### PR TITLE
feat(integrations): add DoltHub OAuth integration (dev-only)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -53,7 +53,7 @@ DISCORD_CLIENT_ID=your-discord-client-id
 DISCORD_CLIENT_SECRET=your-discord-client-secret
 
 # DoltHub OAuth (dev only — app pending admin approval)
-DOLTHUB_APP_DEV_CLIENT_ID=dhoci.v1.tdg4bfv15v24adbpc2fqeqddugotg64nd9puisim322d0p452i50
+DOLTHUB_APP_DEV_CLIENT_ID=your-dolthub-client-id
 DOLTHUB_APP_DEV_CLIENT_SECRET=your-dolthub-client-secret
 # ============================================================================
 # Billing & Stripe (Required for billing features)

--- a/.env.local.example
+++ b/.env.local.example
@@ -51,6 +51,10 @@ LINKEDIN_CLIENT_SECRET=your-linkedin-client-secret
 # Discord OAuth (optional)
 DISCORD_CLIENT_ID=your-discord-client-id
 DISCORD_CLIENT_SECRET=your-discord-client-secret
+
+# DoltHub OAuth (dev only — app pending admin approval)
+DOLTHUB_APP_DEV_CLIENT_ID=dhoci.v1.tdg4bfv15v24adbpc2fqeqddugotg64nd9puisim322d0p452i50
+DOLTHUB_APP_DEV_CLIENT_SECRET=your-dolthub-client-secret
 # ============================================================================
 # Billing & Stripe (Required for billing features)
 # ============================================================================

--- a/apps/web/.env.test
+++ b/apps/web/.env.test
@@ -90,3 +90,7 @@ STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID=coupon_test_kiloclaw_standard_fir
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_invalid_mock_key
 
 CREDIT_CATEGORIES_ENCRYPTION_KEY=
+
+# DoltHub (dev-only OAuth integration)
+DOLTHUB_APP_DEV_CLIENT_ID=test-dolthub-client-id
+DOLTHUB_APP_DEV_CLIENT_SECRET=test-dolthub-client-secret

--- a/apps/web/src/app/(app)/integrations/dolthub/page.tsx
+++ b/apps/web/src/app/(app)/integrations/dolthub/page.tsx
@@ -1,0 +1,56 @@
+import { Suspense } from 'react';
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { DoltHubIntegrationDetails } from '@/components/integrations/DoltHubIntegrationDetails';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import { PageLayout } from '@/components/PageLayout';
+import { IS_DEVELOPMENT } from '@/lib/constants';
+import { notFound } from 'next/navigation';
+
+export default async function UserDoltHubIntegrationPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    success?: string;
+    error?: string;
+  }>;
+}) {
+  if (!IS_DEVELOPMENT) {
+    notFound();
+  }
+
+  await getUserFromAuthOrRedirect('/users/sign_in');
+  const search = await searchParams;
+
+  return (
+    <PageLayout
+      title="DoltHub Integration"
+      subtitle="Connect your DoltHub account to query versioned data"
+      headerActions={
+        <Link href="/integrations">
+          <Button variant="ghost" size="sm" className="gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            Back to Integrations
+          </Button>
+        </Link>
+      }
+    >
+      <Suspense
+        fallback={
+          <Card>
+            <CardContent className="pt-6">
+              <div className="animate-pulse space-y-4">
+                <div className="bg-muted h-20 rounded" />
+                <div className="bg-muted h-32 rounded" />
+              </div>
+            </CardContent>
+          </Card>
+        }
+      >
+        <DoltHubIntegrationDetails success={search.success === 'installed'} error={search.error} />
+      </Suspense>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/app/(app)/organizations/[id]/integrations/dolthub/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/integrations/dolthub/page.tsx
@@ -1,0 +1,68 @@
+import { Suspense } from 'react';
+import { DoltHubIntegrationDetails } from '@/components/integrations/DoltHubIntegrationDetails';
+import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { IS_DEVELOPMENT } from '@/lib/constants';
+import { notFound } from 'next/navigation';
+
+export default async function OrgDoltHubIntegrationPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{
+    success?: string;
+    error?: string;
+  }>;
+}) {
+  if (!IS_DEVELOPMENT) {
+    notFound();
+  }
+
+  const search = await searchParams;
+
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      render={({ organization }) => (
+        <>
+          <div className="space-y-4">
+            <Link href={`/organizations/${organization.id}/integrations`}>
+              <Button variant="ghost" size="sm" className="gap-2">
+                <ArrowLeft className="h-4 w-4" />
+                Back to Integrations
+              </Button>
+            </Link>
+            <SetPageTitle title="DoltHub Integration" />
+            <p className="text-muted-foreground">
+              Manage DoltHub integration for {organization.name}
+            </p>
+          </div>
+
+          <Suspense
+            fallback={
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="animate-pulse space-y-4">
+                    <div className="bg-muted h-20 rounded" />
+                    <div className="bg-muted h-32 rounded" />
+                  </div>
+                </CardContent>
+              </Card>
+            }
+          >
+            <DoltHubIntegrationDetails
+              organizationId={organization.id}
+              success={search.success === 'installed'}
+              error={search.error}
+            />
+          </Suspense>
+        </>
+      )}
+    />
+  );
+}

--- a/apps/web/src/app/api/integrations/dolthub/callback/route.ts
+++ b/apps/web/src/app/api/integrations/dolthub/callback/route.ts
@@ -1,0 +1,163 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getUserFromAuth } from '@/lib/user.server';
+import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+import type { Owner } from '@/lib/integrations/core/types';
+import { captureException, captureMessage } from '@sentry/nextjs';
+import { IS_DEVELOPMENT } from '@/lib/constants';
+import {
+  exchangeDoltHubOAuthCode,
+  fetchDoltHubUser,
+  upsertDoltHubInstallation,
+} from '@/lib/integrations/dolthub-service';
+import { verifyOAuthState } from '@/lib/integrations/oauth-state';
+import { APP_URL } from '@/lib/constants';
+
+function buildDoltHubRedirectPath(state: string | null, queryParam: string): string {
+  const verified = state ? verifyOAuthState(state) : null;
+  const owner = verified?.owner;
+
+  if (owner?.startsWith('org_')) {
+    return `/organizations/${owner.replace('org_', '')}/integrations/dolthub?${queryParam}`;
+  }
+  if (owner?.startsWith('user_')) {
+    return `/integrations/dolthub?${queryParam}`;
+  }
+  return `/integrations?${queryParam}`;
+}
+
+/**
+ * DoltHub OAuth Callback
+ *
+ * Called when user completes the DoltHub OAuth flow.
+ * Exchanges the authorization code for tokens and stores the integration.
+ */
+export async function GET(request: NextRequest) {
+  if (!IS_DEVELOPMENT) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
+  try {
+    const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+    if (authFailedResponse) {
+      return NextResponse.redirect(new URL('/users/sign_in', APP_URL));
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    const error = searchParams.get('error');
+
+    if (error) {
+      captureMessage('DoltHub OAuth error', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+        extra: { error, state },
+      });
+
+      return NextResponse.redirect(
+        new URL(buildDoltHubRedirectPath(state, `error=${encodeURIComponent(error)}`), APP_URL)
+      );
+    }
+
+    if (!code) {
+      captureMessage('DoltHub callback missing code', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+        extra: { state, allParams: Object.fromEntries(searchParams.entries()) },
+      });
+
+      return NextResponse.redirect(
+        new URL(buildDoltHubRedirectPath(state, 'error=missing_code'), APP_URL)
+      );
+    }
+
+    const verified = verifyOAuthState(state);
+    if (!verified) {
+      captureMessage('DoltHub callback invalid or tampered state signature', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+        extra: { code: '***', state, allParams: Object.fromEntries(searchParams.entries()) },
+      });
+      return NextResponse.redirect(new URL('/integrations?error=invalid_state', APP_URL));
+    }
+
+    if (verified.userId !== user.id) {
+      captureMessage('DoltHub callback user mismatch (possible CSRF)', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+        extra: { stateUserId: verified.userId, sessionUserId: user.id },
+      });
+      return NextResponse.redirect(new URL('/integrations?error=unauthorized', APP_URL));
+    }
+
+    let owner: Owner;
+    const ownerStr = verified.owner;
+
+    if (ownerStr.startsWith('org_')) {
+      const ownerId = ownerStr.replace('org_', '');
+      owner = { type: 'org', id: ownerId };
+    } else if (ownerStr.startsWith('user_')) {
+      const ownerId = ownerStr.replace('user_', '');
+      owner = { type: 'user', id: ownerId };
+    } else {
+      captureMessage('DoltHub callback missing or invalid owner in state', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+        extra: { code: '***', owner: ownerStr },
+      });
+      return NextResponse.redirect(new URL('/integrations?error=invalid_state', APP_URL));
+    }
+
+    if (owner.type === 'org') {
+      await ensureOrganizationAccess({ user }, owner.id);
+    } else if (user.id !== owner.id) {
+      return NextResponse.redirect(new URL('/integrations?error=unauthorized', APP_URL));
+    }
+
+    const tokens = await exchangeDoltHubOAuthCode(code);
+
+    const userInfo = await fetchDoltHubUser(tokens.accessToken);
+    const username = userInfo?.username ?? 'unknown';
+
+    if (username === 'unknown') {
+      captureMessage('DoltHub user info fetch returned no username', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+      });
+    }
+
+    await upsertDoltHubInstallation({
+      owner,
+      account: { username },
+      tokens,
+    });
+
+    const successPath =
+      owner.type === 'org'
+        ? `/organizations/${owner.id}/integrations/dolthub?success=installed`
+        : `/integrations/dolthub?success=installed`;
+
+    return NextResponse.redirect(new URL(successPath, APP_URL));
+  } catch (error) {
+    console.error('Error handling DoltHub OAuth callback:', error);
+
+    const searchParams = request.nextUrl.searchParams;
+    const state = searchParams.get('state');
+
+    captureException(error, {
+      tags: {
+        endpoint: 'dolthub/callback',
+        source: 'dolthub_oauth',
+      },
+      extra: {
+        state,
+        hasCode: !!searchParams.get('code'),
+      },
+    });
+
+    return NextResponse.redirect(
+      new URL(buildDoltHubRedirectPath(state, 'error=installation_failed'), APP_URL)
+    );
+  }
+}

--- a/apps/web/src/app/api/integrations/dolthub/callback/route.ts
+++ b/apps/web/src/app/api/integrations/dolthub/callback/route.ts
@@ -7,7 +7,6 @@ import { captureException, captureMessage } from '@sentry/nextjs';
 import { IS_DEVELOPMENT } from '@/lib/constants';
 import {
   exchangeDoltHubOAuthCode,
-  fetchDoltHubUser,
   upsertDoltHubInstallation,
 } from '@/lib/integrations/dolthub-service';
 import { verifyOAuthState } from '@/lib/integrations/oauth-state';
@@ -117,22 +116,8 @@ export async function GET(request: NextRequest) {
 
     const tokens = await exchangeDoltHubOAuthCode(code);
 
-    const userInfo = await fetchDoltHubUser(tokens.accessToken);
-    const username = userInfo?.username;
-
-    if (!username) {
-      captureMessage('DoltHub user info fetch returned no username', {
-        level: 'warning',
-        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
-      });
-      return NextResponse.redirect(
-        new URL(buildDoltHubRedirectPath(state, 'error=user_info_failed'), APP_URL)
-      );
-    }
-
     await upsertDoltHubInstallation({
       owner,
-      account: { username },
       tokens,
     });
 

--- a/apps/web/src/app/api/integrations/dolthub/callback/route.ts
+++ b/apps/web/src/app/api/integrations/dolthub/callback/route.ts
@@ -59,11 +59,18 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    // Build a redacted copy of the callback query params so we never write
+    // the raw `code` (a short-lived credential) into Sentry/logs even if a
+    // future change adds another logging path here.
+    const redactedParams = Object.fromEntries(
+      Array.from(searchParams.entries()).map(([k, v]) => [k, k === 'code' ? '***' : v])
+    );
+
     if (!code) {
       captureMessage('DoltHub callback missing code', {
         level: 'warning',
         tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
-        extra: { state, allParams: Object.fromEntries(searchParams.entries()) },
+        extra: { state, allParams: redactedParams },
       });
 
       return NextResponse.redirect(
@@ -73,9 +80,6 @@ export async function GET(request: NextRequest) {
 
     const verified = verifyOAuthState(state);
     if (!verified) {
-      const redactedParams = Object.fromEntries(
-        Array.from(searchParams.entries()).map(([k, v]) => [k, k === 'code' ? '***' : v])
-      );
       captureMessage('DoltHub callback invalid or tampered state signature', {
         level: 'warning',
         tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },

--- a/apps/web/src/app/api/integrations/dolthub/callback/route.ts
+++ b/apps/web/src/app/api/integrations/dolthub/callback/route.ts
@@ -118,13 +118,16 @@ export async function GET(request: NextRequest) {
     const tokens = await exchangeDoltHubOAuthCode(code);
 
     const userInfo = await fetchDoltHubUser(tokens.accessToken);
-    const username = userInfo?.username ?? 'unknown';
+    const username = userInfo?.username;
 
-    if (username === 'unknown') {
+    if (!username) {
       captureMessage('DoltHub user info fetch returned no username', {
         level: 'warning',
         tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
       });
+      return NextResponse.redirect(
+        new URL(buildDoltHubRedirectPath(state, 'error=user_info_failed'), APP_URL)
+      );
     }
 
     await upsertDoltHubInstallation({

--- a/apps/web/src/app/api/integrations/dolthub/callback/route.ts
+++ b/apps/web/src/app/api/integrations/dolthub/callback/route.ts
@@ -73,10 +73,13 @@ export async function GET(request: NextRequest) {
 
     const verified = verifyOAuthState(state);
     if (!verified) {
+      const redactedParams = Object.fromEntries(
+        Array.from(searchParams.entries()).map(([k, v]) => [k, k === 'code' ? '***' : v])
+      );
       captureMessage('DoltHub callback invalid or tampered state signature', {
         level: 'warning',
         tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
-        extra: { code: '***', state, allParams: Object.fromEntries(searchParams.entries()) },
+        extra: { code: '***', state, allParams: redactedParams },
       });
       return NextResponse.redirect(new URL('/integrations?error=invalid_state', APP_URL));
     }

--- a/apps/web/src/app/api/integrations/dolthub/connect/route.ts
+++ b/apps/web/src/app/api/integrations/dolthub/connect/route.ts
@@ -1,0 +1,65 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getUserFromAuth } from '@/lib/user.server';
+import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+import { captureException } from '@sentry/nextjs';
+import { createOAuthState } from '@/lib/integrations/oauth-state';
+import { getDoltHubOAuthUrl } from '@/lib/integrations/dolthub-service';
+import { APP_URL, IS_DEVELOPMENT } from '@/lib/constants';
+
+/**
+ * DoltHub OAuth Connect
+ *
+ * Initiates the DoltHub OAuth authorization flow.
+ * Redirects the user to DoltHub's authorization page.
+ *
+ * Query parameters:
+ * - organizationId: (optional) Organization ID for org-owned integrations
+ */
+export async function GET(request: NextRequest) {
+  if (!IS_DEVELOPMENT) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
+  try {
+    const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+    if (authFailedResponse) {
+      return authFailedResponse;
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const organizationId = searchParams.get('organizationId');
+
+    let stateOwner: string;
+
+    if (organizationId) {
+      await ensureOrganizationAccess({ user }, organizationId);
+      stateOwner = `org_${organizationId}`;
+    } else {
+      stateOwner = `user_${user.id}`;
+    }
+
+    const state = createOAuthState(stateOwner, user.id);
+    const oauthUrl = getDoltHubOAuthUrl(state);
+
+    return NextResponse.redirect(oauthUrl);
+  } catch (error) {
+    console.error('Error initiating DoltHub OAuth:', error);
+
+    captureException(error, {
+      tags: {
+        endpoint: 'dolthub/connect',
+        source: 'dolthub_oauth',
+      },
+    });
+
+    const searchParams = request.nextUrl.searchParams;
+    const organizationId = searchParams.get('organizationId');
+
+    const errorPath = organizationId
+      ? `/organizations/${organizationId}/integrations/dolthub?error=oauth_init_failed`
+      : '/integrations/dolthub?error=oauth_init_failed';
+
+    return NextResponse.redirect(new URL(errorPath, APP_URL));
+  }
+}

--- a/apps/web/src/components/integrations/DoltHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/DoltHubIntegrationDetails.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { CheckCircle2, XCircle, Database, RefreshCw, Info } from 'lucide-react';
+import { CheckCircle2, XCircle, Database, Info } from 'lucide-react';
 import { toast } from 'sonner';
 import { useEffect, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -35,16 +35,6 @@ export function DoltHubIntegrationDetails({
 
   const disconnect = useMutation(
     trpc.dolthub.disconnect.mutationOptions({
-      onSuccess: () => {
-        void queryClient.invalidateQueries({
-          queryKey: trpc.dolthub.getInstallation.queryKey(input),
-        });
-      },
-    })
-  );
-
-  const verifyToken = useMutation(
-    trpc.dolthub.verifyToken.mutationOptions({
       onSuccess: () => {
         void queryClient.invalidateQueries({
           queryKey: trpc.dolthub.getInstallation.queryKey(input),
@@ -89,19 +79,6 @@ export function DoltHubIntegrationDetails({
         },
       });
     }
-  };
-
-  const handleVerifyToken = () => {
-    verifyToken.mutate(input, {
-      onSuccess: () => {
-        toast.success('DoltHub token is valid');
-      },
-      onError: err => {
-        toast.error('DoltHub token verification failed', {
-          description: err.message,
-        });
-      },
-    });
   };
 
   if (isLoading) {
@@ -165,10 +142,6 @@ export function DoltHubIntegrationDetails({
           {installation ? (
             <>
               <div className="space-y-3 rounded-lg border p-4">
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium">Username:</span>
-                  <span className="text-sm">{installation.username}</span>
-                </div>
                 {installation.scopes && installation.scopes.length > 0 && (
                   <div className="space-y-2">
                     <span className="text-sm font-medium">Permissions:</span>
@@ -193,14 +166,6 @@ export function DoltHubIntegrationDetails({
 
               <div className="space-y-2">
                 <div className="flex flex-wrap gap-3">
-                  <Button
-                    variant="outline"
-                    onClick={handleVerifyToken}
-                    disabled={verifyToken.isPending}
-                  >
-                    <RefreshCw className="mr-2 h-4 w-4" />
-                    {verifyToken.isPending ? 'Verifying...' : 'Verify token'}
-                  </Button>
                   <Button
                     variant="destructive"
                     onClick={handleDisconnect}

--- a/apps/web/src/components/integrations/DoltHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/DoltHubIntegrationDetails.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { CheckCircle2, XCircle, Database, RefreshCw, Info } from 'lucide-react';
+import { toast } from 'sonner';
+import { useEffect, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+
+type DoltHubIntegrationDetailsProps = {
+  organizationId?: string;
+  success?: boolean;
+  error?: string;
+};
+
+export function DoltHubIntegrationDetails({
+  organizationId,
+  success,
+  error,
+}: DoltHubIntegrationDetailsProps) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const input = organizationId ? { organizationId } : undefined;
+
+  const {
+    data: installationData,
+    isLoading,
+    refetch,
+  } = useQuery(trpc.dolthub.getInstallation.queryOptions(input));
+
+  const [isStartingConnection, setIsStartingConnection] = useState(false);
+
+  const disconnect = useMutation(
+    trpc.dolthub.disconnect.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.dolthub.getInstallation.queryKey(input),
+        });
+      },
+    })
+  );
+
+  const verifyToken = useMutation(
+    trpc.dolthub.verifyToken.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.dolthub.getInstallation.queryKey(input),
+        });
+      },
+    })
+  );
+
+  useEffect(() => {
+    if (success) {
+      toast.success('DoltHub connected successfully!');
+    }
+    if (error) {
+      toast.error(`Connection failed: ${error}`);
+    }
+  }, [success, error]);
+
+  const handleConnect = () => {
+    setIsStartingConnection(true);
+    try {
+      const url = new URL('/api/integrations/dolthub/connect', window.location.origin);
+      if (organizationId) {
+        url.searchParams.set('organizationId', organizationId);
+      }
+      window.location.href = url.toString();
+    } catch {
+      setIsStartingConnection(false);
+    }
+  };
+
+  const handleDisconnect = () => {
+    if (confirm('Are you sure you want to disconnect DoltHub?')) {
+      disconnect.mutate(input, {
+        onSuccess: async () => {
+          toast.success('DoltHub disconnected');
+          await refetch();
+        },
+        onError: err => {
+          toast.error('Failed to disconnect DoltHub', {
+            description: err.message,
+          });
+        },
+      });
+    }
+  };
+
+  const handleVerifyToken = () => {
+    verifyToken.mutate(input, {
+      onSuccess: () => {
+        toast.success('DoltHub token is valid');
+      },
+      onError: err => {
+        toast.error('DoltHub token verification failed', {
+          description: err.message,
+        });
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <div className="animate-pulse space-y-4">
+            <div className="bg-muted h-20 rounded" />
+            <div className="bg-muted h-32 rounded" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const isInstalled = installationData?.installed;
+  const installation = installationData?.installation;
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <Alert variant="destructive">
+          <XCircle className="h-4 w-4" />
+          <AlertTitle>Could not connect DoltHub</AlertTitle>
+          <AlertDescription>Connection failed: {error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Alert variant="default" className="bg-blue-50 text-blue-900 border-blue-200">
+        <Info className="h-4 w-4 text-blue-600" />
+        <AlertTitle>Dev-only integration</AlertTitle>
+        <AlertDescription>DoltHub app pending approval</AlertDescription>
+      </Alert>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                <Database className="h-5 w-5" />
+                DoltHub Integration
+              </CardTitle>
+              <CardDescription>
+                Query Dolt-versioned data directly from your workspace
+              </CardDescription>
+            </div>
+            {isInstalled ? (
+              <Badge variant="default" className="flex items-center gap-1">
+                <CheckCircle2 className="h-3 w-3" />
+                Connected
+              </Badge>
+            ) : (
+              <Badge variant="secondary" className="flex items-center gap-1">
+                <XCircle className="h-3 w-3" />
+                Not Connected
+              </Badge>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {installation ? (
+            <>
+              <div className="space-y-3 rounded-lg border p-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">Username:</span>
+                  <span className="text-sm">{installation.username}</span>
+                </div>
+                {installation.scopes && installation.scopes.length > 0 && (
+                  <div className="space-y-2">
+                    <span className="text-sm font-medium">Permissions:</span>
+                    <div className="flex flex-wrap gap-2">
+                      {installation.scopes.map((scope: string) => (
+                        <Badge key={scope} variant="secondary" className="text-xs">
+                          {scope}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">Connected:</span>
+                  <span className="text-sm">
+                    {installation.installedAt
+                      ? new Date(installation.installedAt).toLocaleDateString()
+                      : 'Unknown'}
+                  </span>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex flex-wrap gap-3">
+                  <Button
+                    variant="outline"
+                    onClick={handleVerifyToken}
+                    disabled={verifyToken.isPending}
+                  >
+                    <RefreshCw className="mr-2 h-4 w-4" />
+                    {verifyToken.isPending ? 'Verifying...' : 'Verify token'}
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={handleDisconnect}
+                    disabled={disconnect.isPending}
+                  >
+                    {disconnect.isPending ? 'Disconnecting...' : 'Disconnect'}
+                  </Button>
+                </div>
+              </div>
+            </>
+          ) : (
+            <>
+              <Alert>
+                <AlertDescription>
+                  Connect DoltHub to query versioned data directly from your workspace.
+                </AlertDescription>
+              </Alert>
+
+              <div className="space-y-2 rounded-lg border p-4">
+                <h4 className="font-medium">What you&apos;ll get:</h4>
+                <ul className="text-muted-foreground space-y-1 text-sm">
+                  <li>✓ Query Dolt-versioned databases from your workspace</li>
+                  <li>✓ Direct integration with DoltHub repositories</li>
+                </ul>
+              </div>
+
+              <Button
+                onClick={handleConnect}
+                size="lg"
+                className="w-full"
+                disabled={isStartingConnection}
+              >
+                <Database className="mr-2 h-4 w-4" />
+                {isStartingConnection ? 'Loading...' : 'Connect DoltHub'}
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/IntegrationsHub.tsx
+++ b/apps/web/src/components/integrations/IntegrationsHub.tsx
@@ -34,9 +34,17 @@ export function IntegrationsHub({ organizationId }: IntegrationsHubProps) {
   const { data: linearInstallation, isLoading: linearLoading } = useQuery(
     trpc.linear.getInstallation.queryOptions(input)
   );
+  const { data: dolthubInstallation, isLoading: dolthubLoading } = useQuery(
+    trpc.dolthub.getInstallation.queryOptions(input)
+  );
 
   const isLoading =
-    githubLoading || slackLoading || discordLoading || gitlabLoading || linearLoading;
+    githubLoading ||
+    slackLoading ||
+    discordLoading ||
+    gitlabLoading ||
+    linearLoading ||
+    dolthubLoading;
 
   if (isLoading) {
     return (
@@ -62,6 +70,7 @@ export function IntegrationsHub({ organizationId }: IntegrationsHubProps) {
       discord: discordInstallation,
       gitlab: gitlabInstallation,
       linear: linearInstallation,
+      dolthub: dolthubInstallation,
     },
     organizationId
   );

--- a/apps/web/src/lib/config.server.ts
+++ b/apps/web/src/lib/config.server.ts
@@ -142,6 +142,10 @@ export const LINEAR_CLIENT_ID = getEnvVariable('LINEAR_CLIENT_ID');
 export const LINEAR_CLIENT_SECRET = getEnvVariable('LINEAR_CLIENT_SECRET');
 export const LINEAR_WEBHOOK_SECRET = getEnvVariable('LINEAR_WEBHOOK_SECRET');
 
+// DoltHub (dev-only OAuth integration — app pending admin approval)
+export const DOLTHUB_APP_DEV_CLIENT_ID = getEnvVariable('DOLTHUB_APP_DEV_CLIENT_ID');
+export const DOLTHUB_APP_DEV_CLIENT_SECRET = getEnvVariable('DOLTHUB_APP_DEV_CLIENT_SECRET');
+
 // Discord (bot integration — existing)
 export const DISCORD_CLIENT_ID = getEnvVariable('DISCORD_CLIENT_ID');
 export const DISCORD_CLIENT_SECRET = getEnvVariable('DISCORD_CLIENT_SECRET');

--- a/apps/web/src/lib/integrations/core/constants.ts
+++ b/apps/web/src/lib/integrations/core/constants.ts
@@ -149,6 +149,7 @@ export const PLATFORM = {
   SLACK: 'slack',
   DISCORD: 'discord',
   LINEAR: 'linear',
+  DOLTHUB: 'dolthub',
 } as const;
 
 /**

--- a/apps/web/src/lib/integrations/dolthub-service.test.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.test.ts
@@ -272,6 +272,32 @@ describe('dolthub-service', () => {
         })
       ).rejects.toThrow('DoltHub integration is dev-only and not available in production');
     });
+
+    test('concurrent upserts for the same owner produce a single row', async () => {
+      const tokens = (suffix: string) => ({
+        accessToken: `token-${suffix}`,
+        refreshToken: `refresh-${suffix}`,
+        expiresIn: 3600,
+        scope: 'api_read_write',
+      });
+
+      await Promise.all([
+        upsertDoltHubInstallation({ owner: { type: 'user', id: user.id }, tokens: tokens('a') }),
+        upsertDoltHubInstallation({ owner: { type: 'user', id: user.id }, tokens: tokens('b') }),
+        upsertDoltHubInstallation({ owner: { type: 'user', id: user.id }, tokens: tokens('c') }),
+      ]);
+
+      const rows = await db
+        .select()
+        .from(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+            eq(platform_integrations.owned_by_user_id, user.id)
+          )
+        );
+      expect(rows).toHaveLength(1);
+    });
   });
 
   describe('uninstall', () => {
@@ -384,7 +410,7 @@ describe('dolthub-service', () => {
       expect(meta.expires_at).toBeGreaterThan(Date.now());
     });
 
-    test('preserves existing refresh token when refresh response omits it', async () => {
+    test('preserves existing refresh_token and scope when refresh response omits them', async () => {
       const [integration] = await db
         .insert(platform_integrations)
         .values({
@@ -403,12 +429,13 @@ describe('dolthub-service', () => {
         })
         .returning();
 
+      // DoltHub may return only an access_token on refresh; per RFC 6749 the
+      // previous refresh_token and scope remain valid.
       globalThis.fetch = jest.fn().mockResolvedValue({
         ok: true,
         json: async () => ({
           access_token: 'refreshed-access',
           expires_in: 3600,
-          scope: 'api_read_write',
         }),
       });
 
@@ -423,9 +450,11 @@ describe('dolthub-service', () => {
         access_token: string;
         refresh_token: string;
         expires_at: number;
+        scope: string;
       };
       expect(meta.access_token).toBe('refreshed-access');
       expect(meta.refresh_token).toBe('old-refresh');
+      expect(meta.scope).toBe('api_read_write');
       expect(meta.expires_at).toBeGreaterThan(Date.now());
     });
 

--- a/apps/web/src/lib/integrations/dolthub-service.test.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.test.ts
@@ -1,0 +1,454 @@
+import { afterEach, beforeAll, describe, expect, test } from '@jest/globals';
+import { db } from '@/lib/drizzle';
+import { platform_integrations } from '@kilocode/db/schema';
+import { and, eq } from 'drizzle-orm';
+import type { User } from '@kilocode/db/schema';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { PLATFORM, INTEGRATION_STATUS } from '@/lib/integrations/core/constants';
+import {
+  getDoltHubOAuthUrl,
+  exchangeDoltHubOAuthCode,
+  refreshDoltHubAccessToken,
+  getInstallation,
+  upsertDoltHubInstallation,
+  uninstall,
+  getValidDoltHubToken,
+  DOLTHUB_REDIRECT_URI,
+  DOLTHUB_SCOPES,
+} from '@/lib/integrations/dolthub-service';
+import { DOLTHUB_APP_DEV_CLIENT_ID } from '@/lib/config.server';
+
+function setNodeEnv(value: string) {
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe('dolthub-service', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalFetch = globalThis.fetch;
+  let user: User;
+
+  beforeAll(async () => {
+    user = await insertTestUser({
+      google_user_email: 'dolthub-test@example.com',
+      google_user_name: 'DoltHub Test',
+    });
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    setNodeEnv(originalNodeEnv);
+    await db
+      .delete(platform_integrations)
+      .where(
+        and(
+          eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+          eq(platform_integrations.owned_by_user_id, user.id)
+        )
+      );
+  });
+
+  describe('getDoltHubOAuthUrl', () => {
+    test('includes the required OAuth parameters', () => {
+      const url = getDoltHubOAuthUrl('test-state-123');
+      expect(url).toMatch(/^https:\/\/www\.dolthub\.com\/oauth\/authorize/);
+      expect(url).toContain(`client_id=${encodeURIComponent(DOLTHUB_APP_DEV_CLIENT_ID)}`);
+      expect(url).toContain('response_type=code');
+      expect(url).toContain(`redirect_uri=${encodeURIComponent(DOLTHUB_REDIRECT_URI)}`);
+      expect(url).toContain(`scope=${encodeURIComponent(DOLTHUB_SCOPES.join(','))}`);
+      expect(url).toContain('state=test-state-123');
+    });
+
+    test('throws in production', () => {
+      setNodeEnv('production');
+      expect(() => getDoltHubOAuthUrl('state')).toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+
+  describe('exchangeDoltHubOAuthCode', () => {
+    test('successfully exchanges code for tokens', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: 'access-token-123',
+          refresh_token: 'refresh-token-456',
+          expires_in: 3600,
+          scope: 'api_read_write',
+        }),
+      });
+      globalThis.fetch = mockFetch;
+
+      const result = await exchangeDoltHubOAuthCode('auth-code-xyz');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://www.dolthub.com/api/oauth/access_token');
+      expect(init?.method).toBe('POST');
+      expect(init?.headers?.Authorization).toContain('Basic ');
+
+      expect(result.accessToken).toBe('access-token-123');
+      expect(result.refreshToken).toBe('refresh-token-456');
+      expect(result.expiresIn).toBe(3600);
+      expect(result.scope).toBe('api_read_write');
+    });
+
+    test('throws when token exchange fails', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+      });
+
+      await expect(exchangeDoltHubOAuthCode('bad-code')).rejects.toThrow(
+        'DoltHub token exchange failed: 400 Bad Request'
+      );
+    });
+
+    test('throws when response lacks access_token', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ refresh_token: 'only-refresh' }),
+      });
+
+      await expect(exchangeDoltHubOAuthCode('incomplete')).rejects.toThrow(
+        'DoltHub token exchange returned invalid payload'
+      );
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      await expect(exchangeDoltHubOAuthCode('code')).rejects.toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+
+  describe('refreshDoltHubAccessToken', () => {
+    test('successfully refreshes and returns new tokens', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+          expires_in: 7200,
+          scope: 'api_read_write',
+        }),
+      });
+      globalThis.fetch = mockFetch;
+
+      const result = await refreshDoltHubAccessToken('old-refresh-token');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://www.dolthub.com/api/oauth/access_token');
+      const body = init?.body as string;
+      expect(body).toContain('grant_type=refresh_token');
+      expect(body).toContain('refresh_token=old-refresh-token');
+
+      expect(result.accessToken).toBe('new-access-token');
+      expect(result.refreshToken).toBe('new-refresh-token');
+      expect(result.expiresIn).toBe(7200);
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      await expect(refreshDoltHubAccessToken('token')).rejects.toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+
+  describe('getInstallation', () => {
+    test('returns an integration when found', async () => {
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: { access_token: 'token' },
+      });
+
+      const result = await getInstallation({ type: 'user', id: user.id });
+      expect(result).not.toBeNull();
+      expect(result?.platform_account_login).toBe('testuser');
+    });
+
+    test('returns null when not found', async () => {
+      const result = await getInstallation({ type: 'user', id: user.id });
+      expect(result).toBeNull();
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      await expect(getInstallation({ type: 'user', id: user.id })).rejects.toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+
+  describe('upsertDoltHubInstallation', () => {
+    test('creates a new installation when none exists', async () => {
+      const result = await upsertDoltHubInstallation({
+        owner: { type: 'user', id: user.id },
+        account: { username: 'newuser' },
+        tokens: {
+          accessToken: 'token-new',
+          refreshToken: 'refresh-new',
+          expiresIn: 3600,
+          scope: 'api_read_write',
+        },
+      });
+
+      expect(result.platform_account_login).toBe('newuser');
+      expect(result.platform).toBe(PLATFORM.DOLTHUB);
+      expect(result.integration_status).toBe(INTEGRATION_STATUS.ACTIVE);
+
+      const [row] = await db
+        .select()
+        .from(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+            eq(platform_integrations.owned_by_user_id, user.id)
+          )
+        );
+      expect(row.platform_account_login).toBe('newuser');
+    });
+
+    test('updates an existing installation', async () => {
+      await upsertDoltHubInstallation({
+        owner: { type: 'user', id: user.id },
+        account: { username: 'olduser' },
+        tokens: {
+          accessToken: 'token-old',
+          refreshToken: 'refresh-old',
+          expiresIn: 3600,
+          scope: 'api_read_write',
+        },
+      });
+
+      const result = await upsertDoltHubInstallation({
+        owner: { type: 'user', id: user.id },
+        account: { username: 'updateduser' },
+        tokens: {
+          accessToken: 'token-updated',
+          refreshToken: 'refresh-updated',
+          expiresIn: 7200,
+          scope: 'api_read_write',
+        },
+      });
+
+      expect(result.platform_account_login).toBe('updateduser');
+
+      const [row] = await db
+        .select()
+        .from(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+            eq(platform_integrations.owned_by_user_id, user.id)
+          )
+        );
+      expect(row.platform_account_login).toBe('updateduser');
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      await expect(
+        upsertDoltHubInstallation({
+          owner: { type: 'user', id: user.id },
+          account: { username: 'x' },
+          tokens: {
+            accessToken: 't',
+            refreshToken: null,
+            expiresIn: null,
+            scope: null,
+          },
+        })
+      ).rejects.toThrow('DoltHub integration is dev-only and not available in production');
+    });
+  });
+
+  describe('uninstall', () => {
+    test('deletes the installation when found', async () => {
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: { access_token: 'token' },
+      });
+
+      const result = await uninstall({ type: 'user', id: user.id });
+      expect(result.success).toBe(true);
+
+      const rows = await db
+        .select()
+        .from(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+            eq(platform_integrations.owned_by_user_id, user.id)
+          )
+        );
+      expect(rows).toHaveLength(0);
+    });
+
+    test('succeeds when no installation exists', async () => {
+      const result = await uninstall({ type: 'user', id: user.id });
+      expect(result.success).toBe(true);
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      await expect(uninstall({ type: 'user', id: user.id })).rejects.toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+
+  describe('getValidDoltHubToken', () => {
+    test('returns access token when not expired', async () => {
+      const [integration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: user.id,
+          owned_by_organization_id: null,
+          platform: PLATFORM.DOLTHUB,
+          integration_type: 'oauth',
+          platform_account_login: 'testuser',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          metadata: {
+            access_token: 'current-token',
+            refresh_token: 'refresh-token',
+            expires_at: Date.now() + 3600 * 1000,
+            scope: 'api_read_write',
+          },
+        })
+        .returning();
+
+      const token = await getValidDoltHubToken(integration);
+      expect(token).toBe('current-token');
+    });
+
+    test('refreshes and persists new token when expired', async () => {
+      const [integration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: user.id,
+          owned_by_organization_id: null,
+          platform: PLATFORM.DOLTHUB,
+          integration_type: 'oauth',
+          platform_account_login: 'testuser',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          metadata: {
+            access_token: 'expired-token',
+            refresh_token: 'old-refresh',
+            expires_at: Date.now() - 1000,
+            scope: 'api_read_write',
+          },
+        })
+        .returning();
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: 'refreshed-access',
+          refresh_token: 'refreshed-refresh',
+          expires_in: 3600,
+          scope: 'api_read_write',
+        }),
+      });
+
+      const token = await getValidDoltHubToken(integration);
+      expect(token).toBe('refreshed-access');
+
+      const [row] = await db
+        .select()
+        .from(platform_integrations)
+        .where(eq(platform_integrations.id, integration.id));
+      const meta = row.metadata as {
+        access_token: string;
+        refresh_token: string;
+        expires_at: number;
+      };
+      expect(meta.access_token).toBe('refreshed-access');
+      expect(meta.refresh_token).toBe('refreshed-refresh');
+      expect(meta.expires_at).toBeGreaterThan(Date.now());
+    });
+
+    test('returns null when expired and no refresh token exists', async () => {
+      const [integration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: user.id,
+          owned_by_organization_id: null,
+          platform: PLATFORM.DOLTHUB,
+          integration_type: 'oauth',
+          platform_account_login: 'testuser',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          metadata: {
+            access_token: 'expired-token',
+            refresh_token: null,
+            expires_at: Date.now() - 1000,
+            scope: 'api_read_write',
+          },
+        })
+        .returning();
+
+      const token = await getValidDoltHubToken(integration);
+      expect(token).toBeNull();
+    });
+
+    test('returns null when access token is missing', async () => {
+      const [integration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: user.id,
+          owned_by_organization_id: null,
+          platform: PLATFORM.DOLTHUB,
+          integration_type: 'oauth',
+          platform_account_login: 'testuser',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          metadata: {
+            refresh_token: 'refresh-token',
+            expires_at: Date.now() + 3600 * 1000,
+            scope: 'api_read_write',
+          },
+        })
+        .returning();
+
+      const token = await getValidDoltHubToken(integration);
+      expect(token).toBeNull();
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      const [integration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: user.id,
+          owned_by_organization_id: null,
+          platform: PLATFORM.DOLTHUB,
+          integration_type: 'oauth',
+          platform_account_login: 'testuser',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          metadata: { access_token: 'token' },
+        })
+        .returning();
+
+      await expect(getValidDoltHubToken(integration)).rejects.toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+});

--- a/apps/web/src/lib/integrations/dolthub-service.test.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.test.ts
@@ -208,6 +208,7 @@ describe('dolthub-service', () => {
       expect(result.platform).toBe(PLATFORM.DOLTHUB);
       expect(result.integration_status).toBe(INTEGRATION_STATUS.ACTIVE);
       expect(result.platform_account_login).toBeNull();
+      expect(result.platform_installation_id).toBe(`dolthub-user-${user.id}`);
 
       const [row] = await db
         .select()
@@ -380,6 +381,51 @@ describe('dolthub-service', () => {
       };
       expect(meta.access_token).toBe('refreshed-access');
       expect(meta.refresh_token).toBe('refreshed-refresh');
+      expect(meta.expires_at).toBeGreaterThan(Date.now());
+    });
+
+    test('preserves existing refresh token when refresh response omits it', async () => {
+      const [integration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: user.id,
+          owned_by_organization_id: null,
+          platform: PLATFORM.DOLTHUB,
+          integration_type: 'oauth',
+          platform_account_login: 'testuser',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          metadata: {
+            access_token: 'expired-token',
+            refresh_token: 'old-refresh',
+            expires_at: Date.now() - 1000,
+            scope: 'api_read_write',
+          },
+        })
+        .returning();
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: 'refreshed-access',
+          expires_in: 3600,
+          scope: 'api_read_write',
+        }),
+      });
+
+      const token = await getValidDoltHubToken(integration);
+      expect(token).toBe('refreshed-access');
+
+      const [row] = await db
+        .select()
+        .from(platform_integrations)
+        .where(eq(platform_integrations.id, integration.id));
+      const meta = row.metadata as {
+        access_token: string;
+        refresh_token: string;
+        expires_at: number;
+      };
+      expect(meta.access_token).toBe('refreshed-access');
+      expect(meta.refresh_token).toBe('old-refresh');
       expect(meta.expires_at).toBeGreaterThan(Date.now());
     });
 

--- a/apps/web/src/lib/integrations/dolthub-service.test.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.test.ts
@@ -197,7 +197,6 @@ describe('dolthub-service', () => {
     test('creates a new installation when none exists', async () => {
       const result = await upsertDoltHubInstallation({
         owner: { type: 'user', id: user.id },
-        account: { username: 'newuser' },
         tokens: {
           accessToken: 'token-new',
           refreshToken: 'refresh-new',
@@ -206,9 +205,9 @@ describe('dolthub-service', () => {
         },
       });
 
-      expect(result.platform_account_login).toBe('newuser');
       expect(result.platform).toBe(PLATFORM.DOLTHUB);
       expect(result.integration_status).toBe(INTEGRATION_STATUS.ACTIVE);
+      expect(result.platform_account_login).toBeNull();
 
       const [row] = await db
         .select()
@@ -219,13 +218,13 @@ describe('dolthub-service', () => {
             eq(platform_integrations.owned_by_user_id, user.id)
           )
         );
-      expect(row.platform_account_login).toBe('newuser');
+      const meta = row.metadata as { access_token: string };
+      expect(meta.access_token).toBe('token-new');
     });
 
     test('updates an existing installation', async () => {
       await upsertDoltHubInstallation({
         owner: { type: 'user', id: user.id },
-        account: { username: 'olduser' },
         tokens: {
           accessToken: 'token-old',
           refreshToken: 'refresh-old',
@@ -234,9 +233,8 @@ describe('dolthub-service', () => {
         },
       });
 
-      const result = await upsertDoltHubInstallation({
+      await upsertDoltHubInstallation({
         owner: { type: 'user', id: user.id },
-        account: { username: 'updateduser' },
         tokens: {
           accessToken: 'token-updated',
           refreshToken: 'refresh-updated',
@@ -244,8 +242,6 @@ describe('dolthub-service', () => {
           scope: 'api_read_write',
         },
       });
-
-      expect(result.platform_account_login).toBe('updateduser');
 
       const [row] = await db
         .select()
@@ -256,7 +252,9 @@ describe('dolthub-service', () => {
             eq(platform_integrations.owned_by_user_id, user.id)
           )
         );
-      expect(row.platform_account_login).toBe('updateduser');
+      const meta = row.metadata as { access_token: string; refresh_token: string };
+      expect(meta.access_token).toBe('token-updated');
+      expect(meta.refresh_token).toBe('refresh-updated');
     });
 
     test('throws in production', async () => {
@@ -264,7 +262,6 @@ describe('dolthub-service', () => {
       await expect(
         upsertDoltHubInstallation({
           owner: { type: 'user', id: user.id },
-          account: { username: 'x' },
           tokens: {
             accessToken: 't',
             refreshToken: null,

--- a/apps/web/src/lib/integrations/dolthub-service.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.ts
@@ -75,7 +75,10 @@ const DoltHubTokenPayloadSchema = z.object({
   scope: z.string().optional(),
 });
 
-function parseDoltHubTokenPayload(raw: unknown, operation: 'exchange' | 'refresh'): DoltHubTokenResponse {
+function parseDoltHubTokenPayload(
+  raw: unknown,
+  operation: 'exchange' | 'refresh'
+): DoltHubTokenResponse {
   const parseResult = DoltHubTokenPayloadSchema.safeParse(raw);
   if (!parseResult.success) {
     throw new Error(`DoltHub token ${operation} returned invalid payload`);
@@ -114,7 +117,9 @@ export async function exchangeDoltHubOAuthCode(code: string): Promise<DoltHubTok
   return parseDoltHubTokenPayload(await response.json(), 'exchange');
 }
 
-export async function refreshDoltHubAccessToken(refreshToken: string): Promise<DoltHubTokenResponse> {
+export async function refreshDoltHubAccessToken(
+  refreshToken: string
+): Promise<DoltHubTokenResponse> {
   assertDevOnly();
 
   const body = new URLSearchParams({
@@ -145,7 +150,9 @@ export async function getInstallation(owner: Owner): Promise<PlatformIntegration
   const [integration] = await db
     .select()
     .from(platform_integrations)
-    .where(and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.DOLTHUB)))
+    .where(
+      and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.DOLTHUB))
+    )
     .limit(1);
 
   return integration || null;
@@ -229,19 +236,66 @@ export async function uninstall(owner: Owner): Promise<{ success: boolean }> {
   return { success: true };
 }
 
+const DoltHubUserResponseSchema = z.object({
+  data: z
+    .object({
+      currentUser: z
+        .object({
+          username: z.string().min(1),
+        })
+        .optional(),
+    })
+    .optional(),
+  errors: z.array(z.unknown()).optional(),
+});
+
+export async function fetchDoltHubUser(accessToken: string): Promise<{ username: string } | null> {
+  assertDevOnly();
+
+  try {
+    const response = await fetch('https://www.dolthub.com/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        query: '{ currentUser { username } }',
+      }),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const raw = await response.json();
+    const parseResult = DoltHubUserResponseSchema.safeParse(raw);
+    if (!parseResult.success) {
+      return null;
+    }
+
+    const username = parseResult.data.data?.currentUser?.username;
+    if (username) {
+      return { username };
+    }
+  } catch {
+    // Ignore errors and fall through
+  }
+
+  return null;
+}
+
 export async function getValidDoltHubToken(
   integration: PlatformIntegration
 ): Promise<string | null> {
   assertDevOnly();
 
-  const metadata = integration.metadata as
-    | {
-        access_token?: string;
-        refresh_token?: string;
-        expires_at?: number;
-        scope?: string;
-      }
-    | null;
+  const metadata = integration.metadata as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_at?: number;
+    scope?: string;
+  } | null;
 
   if (!metadata?.access_token) {
     return null;

--- a/apps/web/src/lib/integrations/dolthub-service.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.ts
@@ -1,0 +1,278 @@
+import 'server-only';
+import { z } from 'zod';
+import { db } from '@/lib/drizzle';
+import type { PlatformIntegration } from '@kilocode/db/schema';
+import { platform_integrations } from '@kilocode/db/schema';
+import { eq, and, isNull } from 'drizzle-orm';
+import type { Owner } from '@/lib/integrations/core/types';
+import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
+import { DOLTHUB_APP_DEV_CLIENT_ID, DOLTHUB_APP_DEV_CLIENT_SECRET } from '@/lib/config.server';
+import { APP_URL } from '@/lib/constants';
+
+const DOLTHUB_TOKEN_URL = 'https://www.dolthub.com/api/oauth/access_token';
+const DOLTHUB_AUTHORIZE_URL = 'https://www.dolthub.com/oauth/authorize';
+
+function assertDevOnly(): void {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('DoltHub integration is dev-only and not available in production');
+  }
+}
+
+function getOwnershipConditions(owner: Owner) {
+  return owner.type === 'user'
+    ? [
+        eq(platform_integrations.owned_by_user_id, owner.id),
+        isNull(platform_integrations.owned_by_organization_id),
+      ]
+    : [
+        eq(platform_integrations.owned_by_organization_id, owner.id),
+        isNull(platform_integrations.owned_by_user_id),
+      ];
+}
+
+export const DOLTHUB_SCOPES = ['api_read_write'];
+
+/**
+ * Redirect URI for the DoltHub OAuth flow.
+ *
+ * This MUST resolve to `http://localhost:3000/api/integrations/dolthub/callback`
+ * for the current registered DoltHub app. DoltHub only allows `https://` and
+ * `http://localhost/...` redirect URIs, and self-service mutation is not yet
+ * available. If a developer sets `APP_URL_OVERRIDE` (ngrok, etc.) they will
+ * need DoltHub admins to register the additional URI.
+ */
+export const DOLTHUB_REDIRECT_URI = `${APP_URL}/api/integrations/dolthub/callback`;
+
+export function getDoltHubOAuthUrl(state: string): string {
+  assertDevOnly();
+
+  const params = new URLSearchParams({
+    client_id: DOLTHUB_APP_DEV_CLIENT_ID,
+    response_type: 'code',
+    scope: DOLTHUB_SCOPES.join(','),
+    redirect_uri: DOLTHUB_REDIRECT_URI,
+    state,
+  });
+
+  return `${DOLTHUB_AUTHORIZE_URL}?${params.toString()}`;
+}
+
+export type DoltHubTokenResponse = {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresIn: number | null;
+  scope: string | null;
+};
+
+export type DoltHubAccount = {
+  username: string;
+};
+
+const DoltHubTokenPayloadSchema = z.object({
+  access_token: z.string().min(1),
+  refresh_token: z.string().optional(),
+  expires_in: z.number().optional(),
+  scope: z.string().optional(),
+});
+
+function parseDoltHubTokenPayload(raw: unknown, operation: 'exchange' | 'refresh'): DoltHubTokenResponse {
+  const parseResult = DoltHubTokenPayloadSchema.safeParse(raw);
+  if (!parseResult.success) {
+    throw new Error(`DoltHub token ${operation} returned invalid payload`);
+  }
+  const parsed = parseResult.data;
+  return {
+    accessToken: parsed.access_token,
+    refreshToken: parsed.refresh_token ?? null,
+    expiresIn: parsed.expires_in ?? null,
+    scope: parsed.scope ?? null,
+  };
+}
+
+export async function exchangeDoltHubOAuthCode(code: string): Promise<DoltHubTokenResponse> {
+  assertDevOnly();
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: DOLTHUB_REDIRECT_URI,
+  });
+
+  const response = await fetch(DOLTHUB_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${btoa(`${DOLTHUB_APP_DEV_CLIENT_ID}:${DOLTHUB_APP_DEV_CLIENT_SECRET}`)}`,
+    },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`DoltHub token exchange failed: ${response.status} ${response.statusText}`);
+  }
+
+  return parseDoltHubTokenPayload(await response.json(), 'exchange');
+}
+
+export async function refreshDoltHubAccessToken(refreshToken: string): Promise<DoltHubTokenResponse> {
+  assertDevOnly();
+
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    redirect_uri: DOLTHUB_REDIRECT_URI,
+  });
+
+  const response = await fetch(DOLTHUB_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${btoa(`${DOLTHUB_APP_DEV_CLIENT_ID}:${DOLTHUB_APP_DEV_CLIENT_SECRET}`)}`,
+    },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`DoltHub token refresh failed: ${response.status} ${response.statusText}`);
+  }
+
+  return parseDoltHubTokenPayload(await response.json(), 'refresh');
+}
+
+export async function getInstallation(owner: Owner): Promise<PlatformIntegration | null> {
+  assertDevOnly();
+
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.DOLTHUB)))
+    .limit(1);
+
+  return integration || null;
+}
+
+export async function upsertDoltHubInstallation({
+  owner,
+  account,
+  tokens,
+}: {
+  owner: Owner;
+  account: DoltHubAccount;
+  tokens: DoltHubTokenResponse;
+}): Promise<PlatformIntegration> {
+  assertDevOnly();
+
+  const existing = await getInstallation(owner);
+
+  const expiresAt = tokens.expiresIn ? Date.now() + tokens.expiresIn * 1000 : null;
+
+  const metadata = {
+    access_token: tokens.accessToken,
+    refresh_token: tokens.refreshToken,
+    expires_at: expiresAt,
+    scope: tokens.scope,
+  };
+
+  if (existing) {
+    const [updated] = await db
+      .update(platform_integrations)
+      .set({
+        platform_account_login: account.username,
+        scopes: DOLTHUB_SCOPES,
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata,
+        updated_at: new Date().toISOString(),
+      })
+      .where(eq(platform_integrations.id, existing.id))
+      .returning();
+
+    if (!updated) {
+      throw new Error('DoltHub installation update returned no rows');
+    }
+
+    return updated;
+  }
+
+  const [created] = await db
+    .insert(platform_integrations)
+    .values({
+      owned_by_user_id: owner.type === 'user' ? owner.id : null,
+      owned_by_organization_id: owner.type === 'org' ? owner.id : null,
+      platform: PLATFORM.DOLTHUB,
+      integration_type: 'oauth',
+      platform_account_login: account.username,
+      scopes: DOLTHUB_SCOPES,
+      integration_status: INTEGRATION_STATUS.ACTIVE,
+      metadata,
+      installed_at: new Date().toISOString(),
+    })
+    .returning();
+
+  if (!created) {
+    throw new Error('DoltHub installation insert returned no rows');
+  }
+
+  return created;
+}
+
+export async function uninstall(owner: Owner): Promise<{ success: boolean }> {
+  assertDevOnly();
+
+  const integration = await getInstallation(owner);
+
+  if (!integration) {
+    return { success: true };
+  }
+
+  await db.delete(platform_integrations).where(eq(platform_integrations.id, integration.id));
+
+  return { success: true };
+}
+
+export async function getValidDoltHubToken(
+  integration: PlatformIntegration
+): Promise<string | null> {
+  assertDevOnly();
+
+  const metadata = integration.metadata as
+    | {
+        access_token?: string;
+        refresh_token?: string;
+        expires_at?: number;
+        scope?: string;
+      }
+    | null;
+
+  if (!metadata?.access_token) {
+    return null;
+  }
+
+  // When expires_at is missing/null the token is treated as non-expiring
+  // (DoltHub issues long-lived tokens that do not include expires_in).
+  if (metadata.expires_at && Date.now() >= metadata.expires_at) {
+    if (!metadata.refresh_token) {
+      return null;
+    }
+
+    const newTokens = await refreshDoltHubAccessToken(metadata.refresh_token);
+    const newExpiresAt = newTokens.expiresIn ? Date.now() + newTokens.expiresIn * 1000 : null;
+
+    await db
+      .update(platform_integrations)
+      .set({
+        metadata: {
+          ...metadata,
+          access_token: newTokens.accessToken,
+          refresh_token: newTokens.refreshToken,
+          expires_at: newExpiresAt,
+          scope: newTokens.scope,
+        },
+        updated_at: new Date().toISOString(),
+      })
+      .where(eq(platform_integrations.id, integration.id));
+
+    return newTokens.accessToken;
+  }
+
+  return metadata.access_token;
+}

--- a/apps/web/src/lib/integrations/dolthub-service.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.ts
@@ -64,10 +64,6 @@ export type DoltHubTokenResponse = {
   scope: string | null;
 };
 
-export type DoltHubAccount = {
-  username: string;
-};
-
 const DoltHubTokenPayloadSchema = z.object({
   access_token: z.string().min(1),
   refresh_token: z.string().optional(),
@@ -160,11 +156,9 @@ export async function getInstallation(owner: Owner): Promise<PlatformIntegration
 
 export async function upsertDoltHubInstallation({
   owner,
-  account,
   tokens,
 }: {
   owner: Owner;
-  account: DoltHubAccount;
   tokens: DoltHubTokenResponse;
 }): Promise<PlatformIntegration> {
   assertDevOnly();
@@ -184,7 +178,6 @@ export async function upsertDoltHubInstallation({
     const [updated] = await db
       .update(platform_integrations)
       .set({
-        platform_account_login: account.username,
         scopes: DOLTHUB_SCOPES,
         integration_status: INTEGRATION_STATUS.ACTIVE,
         metadata,
@@ -207,7 +200,6 @@ export async function upsertDoltHubInstallation({
       owned_by_organization_id: owner.type === 'org' ? owner.id : null,
       platform: PLATFORM.DOLTHUB,
       integration_type: 'oauth',
-      platform_account_login: account.username,
       scopes: DOLTHUB_SCOPES,
       integration_status: INTEGRATION_STATUS.ACTIVE,
       metadata,
@@ -234,55 +226,6 @@ export async function uninstall(owner: Owner): Promise<{ success: boolean }> {
   await db.delete(platform_integrations).where(eq(platform_integrations.id, integration.id));
 
   return { success: true };
-}
-
-const DoltHubUserResponseSchema = z.object({
-  data: z
-    .object({
-      currentUser: z
-        .object({
-          username: z.string().min(1),
-        })
-        .optional(),
-    })
-    .optional(),
-  errors: z.array(z.unknown()).optional(),
-});
-
-export async function fetchDoltHubUser(accessToken: string): Promise<{ username: string } | null> {
-  assertDevOnly();
-
-  try {
-    const response = await fetch('https://www.dolthub.com/graphql', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
-      body: JSON.stringify({
-        query: '{ currentUser { username } }',
-      }),
-    });
-
-    if (!response.ok) {
-      return null;
-    }
-
-    const raw = await response.json();
-    const parseResult = DoltHubUserResponseSchema.safeParse(raw);
-    if (!parseResult.success) {
-      return null;
-    }
-
-    const username = parseResult.data.data?.currentUser?.username;
-    if (username) {
-      return { username };
-    }
-  } catch {
-    // Ignore errors and fall through
-  }
-
-  return null;
 }
 
 export async function getValidDoltHubToken(

--- a/apps/web/src/lib/integrations/dolthub-service.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { db } from '@/lib/drizzle';
 import type { PlatformIntegration } from '@kilocode/db/schema';
 import { platform_integrations } from '@kilocode/db/schema';
-import { eq, and, isNull } from 'drizzle-orm';
+import { eq, and, isNull, sql } from 'drizzle-orm';
 import type { Owner } from '@/lib/integrations/core/types';
 import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
 import { DOLTHUB_APP_DEV_CLIENT_ID, DOLTHUB_APP_DEV_CLIENT_SECRET } from '@/lib/config.server';
@@ -149,6 +149,7 @@ export async function getInstallation(owner: Owner): Promise<PlatformIntegration
     .where(
       and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.DOLTHUB))
     )
+    .orderBy(sql`${platform_integrations.updated_at} DESC`)
     .limit(1);
 
   return integration || null;
@@ -200,6 +201,7 @@ export async function upsertDoltHubInstallation({
       owned_by_organization_id: owner.type === 'org' ? owner.id : null,
       platform: PLATFORM.DOLTHUB,
       integration_type: 'oauth',
+      platform_installation_id: `dolthub-${owner.type}-${owner.id}`,
       scopes: DOLTHUB_SCOPES,
       integration_status: INTEGRATION_STATUS.ACTIVE,
       metadata,
@@ -217,13 +219,11 @@ export async function upsertDoltHubInstallation({
 export async function uninstall(owner: Owner): Promise<{ success: boolean }> {
   assertDevOnly();
 
-  const integration = await getInstallation(owner);
+  const ownershipConditions = getOwnershipConditions(owner);
 
-  if (!integration) {
-    return { success: true };
-  }
-
-  await db.delete(platform_integrations).where(eq(platform_integrations.id, integration.id));
+  await db
+    .delete(platform_integrations)
+    .where(and(...ownershipConditions, eq(platform_integrations.platform, PLATFORM.DOLTHUB)));
 
   return { success: true };
 }
@@ -260,7 +260,7 @@ export async function getValidDoltHubToken(
         metadata: {
           ...metadata,
           access_token: newTokens.accessToken,
-          refresh_token: newTokens.refreshToken,
+          refresh_token: newTokens.refreshToken ?? metadata?.refresh_token,
           expires_at: newExpiresAt,
           scope: newTokens.scope,
         },

--- a/apps/web/src/lib/integrations/dolthub-service.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.ts
@@ -164,8 +164,6 @@ export async function upsertDoltHubInstallation({
 }): Promise<PlatformIntegration> {
   assertDevOnly();
 
-  const existing = await getInstallation(owner);
-
   const expiresAt = tokens.expiresIn ? Date.now() + tokens.expiresIn * 1000 : null;
 
   const metadata = {
@@ -175,45 +173,61 @@ export async function upsertDoltHubInstallation({
     scope: tokens.scope,
   };
 
-  if (existing) {
-    const [updated] = await db
-      .update(platform_integrations)
-      .set({
-        scopes: DOLTHUB_SCOPES,
-        integration_status: INTEGRATION_STATUS.ACTIVE,
-        metadata,
-        updated_at: new Date().toISOString(),
-      })
-      .where(eq(platform_integrations.id, existing.id))
-      .returning();
+  // The synthetic platform_installation_id makes the existing partial unique
+  // indexes UQ_platform_integrations_owned_by_(user|org)_platform_inst apply
+  // here, so we can let Postgres atomically resolve concurrent OAuth
+  // completions instead of racing in the old select-then-insert path.
+  const platformInstallationId = `dolthub-${owner.type}-${owner.id}`;
 
-    if (!updated) {
-      throw new Error('DoltHub installation update returned no rows');
-    }
+  const updateSet = {
+    scopes: DOLTHUB_SCOPES,
+    integration_status: INTEGRATION_STATUS.ACTIVE,
+    metadata,
+    updated_at: new Date().toISOString(),
+  };
 
-    return updated;
-  }
+  const onConflict =
+    owner.type === 'user'
+      ? {
+          target: [
+            platform_integrations.owned_by_user_id,
+            platform_integrations.platform,
+            platform_integrations.platform_installation_id,
+          ],
+          targetWhere: sql`${platform_integrations.owned_by_user_id} IS NOT NULL`,
+          set: updateSet,
+        }
+      : {
+          target: [
+            platform_integrations.owned_by_organization_id,
+            platform_integrations.platform,
+            platform_integrations.platform_installation_id,
+          ],
+          targetWhere: sql`${platform_integrations.owned_by_organization_id} IS NOT NULL`,
+          set: updateSet,
+        };
 
-  const [created] = await db
+  const [upserted] = await db
     .insert(platform_integrations)
     .values({
       owned_by_user_id: owner.type === 'user' ? owner.id : null,
       owned_by_organization_id: owner.type === 'org' ? owner.id : null,
       platform: PLATFORM.DOLTHUB,
       integration_type: 'oauth',
-      platform_installation_id: `dolthub-${owner.type}-${owner.id}`,
+      platform_installation_id: platformInstallationId,
       scopes: DOLTHUB_SCOPES,
       integration_status: INTEGRATION_STATUS.ACTIVE,
       metadata,
       installed_at: new Date().toISOString(),
     })
+    .onConflictDoUpdate(onConflict)
     .returning();
 
-  if (!created) {
-    throw new Error('DoltHub installation insert returned no rows');
+  if (!upserted) {
+    throw new Error('DoltHub installation upsert returned no rows');
   }
 
-  return created;
+  return upserted;
 }
 
 export async function uninstall(owner: Owner): Promise<{ success: boolean }> {
@@ -254,15 +268,18 @@ export async function getValidDoltHubToken(
     const newTokens = await refreshDoltHubAccessToken(metadata.refresh_token);
     const newExpiresAt = newTokens.expiresIn ? Date.now() + newTokens.expiresIn * 1000 : null;
 
+    // OAuth refresh responses may omit refresh_token / scope, in which case
+    // RFC 6749 says the previous values remain valid. Falling back here
+    // prevents overwriting a still-good refresh_token (or scope) with null.
     await db
       .update(platform_integrations)
       .set({
         metadata: {
           ...metadata,
           access_token: newTokens.accessToken,
-          refresh_token: newTokens.refreshToken ?? metadata?.refresh_token,
+          refresh_token: newTokens.refreshToken ?? metadata.refresh_token,
           expires_at: newExpiresAt,
-          scope: newTokens.scope,
+          scope: newTokens.scope ?? metadata.scope,
         },
         updated_at: new Date().toISOString(),
       })

--- a/apps/web/src/lib/integrations/platform-definitions.ts
+++ b/apps/web/src/lib/integrations/platform-definitions.ts
@@ -1,6 +1,14 @@
 import { PLATFORM } from '@/lib/integrations/core/constants';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 
-export type PlatformType = 'github' | 'gitlab' | 'bitbucket' | 'slack' | 'discord' | 'linear';
+export type PlatformType =
+  | 'github'
+  | 'gitlab'
+  | 'bitbucket'
+  | 'slack'
+  | 'discord'
+  | 'linear'
+  | 'dolthub';
 
 export type PlatformStatus = 'installed' | 'not_installed' | 'coming_soon';
 
@@ -70,6 +78,14 @@ export const PLATFORM_DEFINITIONS: PlatformDefinition[] = [
     orgRoute: organizationId => `/organizations/${organizationId}/integrations/linear`,
   },
   {
+    id: PLATFORM.DOLTHUB,
+    name: 'DoltHub',
+    description: 'Query Dolt-versioned data directly from your workspace',
+    enabled: IS_DEVELOPMENT,
+    personalRoute: '/integrations/dolthub',
+    orgRoute: organizationId => `/organizations/${organizationId}/integrations/dolthub`,
+  },
+  {
     id: 'bitbucket',
     name: 'Bitbucket',
     description: 'Integrate Bitbucket repositories for intelligent code analysis and automation',
@@ -83,6 +99,7 @@ type InstallationStatus = {
   gitlab?: { installed: boolean };
   discord?: { installed: boolean };
   linear?: { installed: boolean };
+  dolthub?: { installed: boolean };
 };
 
 function getStatus(id: PlatformType, installations: InstallationStatus): PlatformStatus {

--- a/apps/web/src/routers/dolthub-router.test.ts
+++ b/apps/web/src/routers/dolthub-router.test.ts
@@ -10,7 +10,6 @@ jest.mock('@/lib/config.server', () => {
 });
 
 import { describe, test, expect, beforeAll, afterEach } from '@jest/globals';
-import { TRPCError } from '@trpc/server';
 import type { User } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
 import { platform_integrations } from '@kilocode/db/schema';
@@ -66,7 +65,6 @@ describe('dolthubRouter', () => {
         owned_by_organization_id: null,
         platform: PLATFORM.DOLTHUB,
         integration_type: 'oauth',
-        platform_account_login: 'testuser',
         integration_status: INTEGRATION_STATUS.ACTIVE,
         scopes: ['api_read_write'],
         metadata: { access_token: 'token' },
@@ -77,7 +75,6 @@ describe('dolthubRouter', () => {
       const result = await caller.dolthub.getInstallation();
       expect(result.installed).toBe(true);
       expect(result.installation).toMatchObject({
-        username: 'testuser',
         status: 'active',
         scopes: ['api_read_write'],
       });
@@ -125,86 +122,6 @@ describe('dolthubRouter', () => {
           )
         );
       expect(rows).toHaveLength(0);
-    });
-  });
-
-  describe('verifyToken', () => {
-    test('throws in production', async () => {
-      setNodeEnv('production');
-      const caller = await createCallerForUser(user.id);
-      await expect(caller.dolthub.verifyToken()).rejects.toMatchObject({
-        code: 'NOT_FOUND',
-      });
-    });
-
-    test('makes the expected HTTP call with Authorization: Bearer ...', async () => {
-      await db.insert(platform_integrations).values({
-        owned_by_user_id: user.id,
-        owned_by_organization_id: null,
-        platform: PLATFORM.DOLTHUB,
-        integration_type: 'oauth',
-        platform_account_login: 'testuser',
-        integration_status: INTEGRATION_STATUS.ACTIVE,
-        metadata: {
-          access_token: 'test-access-token',
-          refresh_token: 'refresh-token',
-          expires_at: Date.now() + 3600 * 1000,
-          scope: 'api_read_write',
-        },
-      });
-
-      const mockFetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => [{ '1': 1 }],
-      });
-      globalThis.fetch = mockFetch;
-
-      const caller = await createCallerForUser(user.id);
-      const result = await caller.dolthub.verifyToken();
-      expect(result.ok).toBe(true);
-      expect(result.sample).toEqual({ '1': 1 });
-
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      const [url, init] = mockFetch.mock.calls[0];
-      expect(url).toBe('https://www.dolthub.com/api/v1alpha1/dolthub/profile?q=select+1');
-      expect(init?.headers?.Authorization).toBe('Bearer test-access-token');
-    });
-
-    test('rejects when the smoke test fails', async () => {
-      await db.insert(platform_integrations).values({
-        owned_by_user_id: user.id,
-        owned_by_organization_id: null,
-        platform: PLATFORM.DOLTHUB,
-        integration_type: 'oauth',
-        platform_account_login: 'testuser',
-        integration_status: INTEGRATION_STATUS.ACTIVE,
-        metadata: {
-          access_token: 'bad-token',
-          refresh_token: 'refresh-token',
-          expires_at: Date.now() + 3600 * 1000,
-          scope: 'api_read_write',
-        },
-      });
-
-      globalThis.fetch = jest.fn().mockResolvedValue({
-        ok: false,
-        status: 401,
-        statusText: 'Unauthorized',
-      });
-
-      const caller = await createCallerForUser(user.id);
-      const rejection = caller.dolthub.verifyToken();
-      await expect(rejection).rejects.toBeInstanceOf(TRPCError);
-      await expect(rejection).rejects.toMatchObject({
-        code: 'UNAUTHORIZED',
-      });
-    });
-
-    test('rejects when no integration exists', async () => {
-      const caller = await createCallerForUser(user.id);
-      await expect(caller.dolthub.verifyToken()).rejects.toMatchObject({
-        code: 'NOT_FOUND',
-      });
     });
   });
 });

--- a/apps/web/src/routers/dolthub-router.test.ts
+++ b/apps/web/src/routers/dolthub-router.test.ts
@@ -1,0 +1,210 @@
+// Mock config.server so dolthub-service imports don't fail on missing env vars
+import type * as ConfigServerModule from '@/lib/config.server';
+jest.mock('@/lib/config.server', () => {
+  const actual = jest.requireActual<typeof ConfigServerModule>('@/lib/config.server');
+  return {
+    ...actual,
+    DOLTHUB_APP_DEV_CLIENT_ID: 'dolthub-client-id-test',
+    DOLTHUB_APP_DEV_CLIENT_SECRET: 'dolthub-client-secret-test',
+  };
+});
+
+import { describe, test, expect, beforeAll, afterEach } from '@jest/globals';
+import { TRPCError } from '@trpc/server';
+import type { User } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { platform_integrations } from '@kilocode/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { createCallerForUser } from '@/routers/test-utils';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { PLATFORM, INTEGRATION_STATUS } from '@/lib/integrations/core/constants';
+
+function setNodeEnv(value: string) {
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe('dolthubRouter', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalFetch = globalThis.fetch;
+  let user: User;
+
+  beforeAll(async () => {
+    user = await insertTestUser({
+      google_user_email: 'dolthub-router-test@example.com',
+      google_user_name: 'DoltHub Router Test',
+    });
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    setNodeEnv(originalNodeEnv);
+    await db
+      .delete(platform_integrations)
+      .where(
+        and(
+          eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+          eq(platform_integrations.owned_by_user_id, user.id)
+        )
+      );
+  });
+
+  describe('getInstallation', () => {
+    test('returns installed: false in production', async () => {
+      setNodeEnv('production');
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.dolthub.getInstallation();
+      expect(result).toEqual({ installed: false, installation: null });
+    });
+
+    test('returns the persisted row when present in dev', async () => {
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        scopes: ['api_read_write'],
+        metadata: { access_token: 'token' },
+        installed_at: new Date().toISOString(),
+      });
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.dolthub.getInstallation();
+      expect(result.installed).toBe(true);
+      expect(result.installation).toMatchObject({
+        username: 'testuser',
+        status: 'active',
+        scopes: ['api_read_write'],
+      });
+      expect(result.installation?.installedAt).toBeTruthy();
+    });
+
+    test('returns installed: false when no integration exists in dev', async () => {
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.dolthub.getInstallation();
+      expect(result).toEqual({ installed: false, installation: null });
+    });
+  });
+
+  describe('disconnect', () => {
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      const caller = await createCallerForUser(user.id);
+      await expect(caller.dolthub.disconnect()).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+      });
+    });
+
+    test('removes the integration in dev', async () => {
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: { access_token: 'token' },
+      });
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.dolthub.disconnect();
+      expect(result.success).toBe(true);
+
+      const rows = await db
+        .select()
+        .from(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+            eq(platform_integrations.owned_by_user_id, user.id)
+          )
+        );
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe('verifyToken', () => {
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      const caller = await createCallerForUser(user.id);
+      await expect(caller.dolthub.verifyToken()).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+      });
+    });
+
+    test('makes the expected HTTP call with Authorization: Bearer ...', async () => {
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: {
+          access_token: 'test-access-token',
+          refresh_token: 'refresh-token',
+          expires_at: Date.now() + 3600 * 1000,
+          scope: 'api_read_write',
+        },
+      });
+
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [{ '1': 1 }],
+      });
+      globalThis.fetch = mockFetch;
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.dolthub.verifyToken();
+      expect(result.ok).toBe(true);
+      expect(result.sample).toEqual({ '1': 1 });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://www.dolthub.com/api/v1alpha1/dolthub/profile?q=select+1');
+      expect(init?.headers?.Authorization).toBe('Bearer test-access-token');
+    });
+
+    test('rejects when the smoke test fails', async () => {
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: {
+          access_token: 'bad-token',
+          refresh_token: 'refresh-token',
+          expires_at: Date.now() + 3600 * 1000,
+          scope: 'api_read_write',
+        },
+      });
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      const caller = await createCallerForUser(user.id);
+      const rejection = caller.dolthub.verifyToken();
+      await expect(rejection).rejects.toBeInstanceOf(TRPCError);
+      await expect(rejection).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+      });
+    });
+
+    test('rejects when no integration exists', async () => {
+      const caller = await createCallerForUser(user.id);
+      await expect(caller.dolthub.verifyToken()).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+      });
+    });
+  });
+});

--- a/apps/web/src/routers/dolthub-router.ts
+++ b/apps/web/src/routers/dolthub-router.ts
@@ -1,5 +1,4 @@
 import 'server-only';
-import { z } from 'zod';
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { TRPCError } from '@trpc/server';
 import {
@@ -29,7 +28,6 @@ export const dolthubRouter = createTRPCRouter({
     return {
       installed: integration.integration_status === 'active',
       installation: {
-        username: integration.platform_account_login,
         status: integration.integration_status,
         installedAt: integration.installed_at,
         scopes: integration.scopes,
@@ -44,64 +42,5 @@ export const dolthubRouter = createTRPCRouter({
 
     const owner = await resolveAuthorizedOwner(ctx, input?.organizationId);
     return dolthubService.uninstall(owner);
-  }),
-
-  verifyToken: baseProcedure.input(optionalOrgInput).mutation(async ({ ctx, input }) => {
-    if (process.env.NODE_ENV === 'production') {
-      throw new TRPCError({ code: 'NOT_FOUND' });
-    }
-
-    if (input?.organizationId) {
-      await ensureOrganizationAccess(ctx, input.organizationId);
-    }
-    const owner = resolveOwner(ctx, input?.organizationId);
-    const integration = await dolthubService.getInstallation(owner);
-
-    if (!integration) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: 'DoltHub integration not found',
-      });
-    }
-
-    const token = await dolthubService.getValidDoltHubToken(integration);
-    if (!token) {
-      throw new TRPCError({
-        code: 'UNAUTHORIZED',
-        message: 'DoltHub access token is invalid or expired',
-      });
-    }
-
-    const response = await fetch(
-      'https://www.dolthub.com/api/v1alpha1/dolthub/profile?q=select+1',
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    );
-
-    if (!response.ok) {
-      throw new TRPCError({
-        code: 'UNAUTHORIZED',
-        message: `DoltHub token verification failed: ${response.status} ${response.statusText}`,
-      });
-    }
-
-    const data = await response.json();
-
-    const DoltHubProfileResponseSchema = z.union([
-      z.array(z.record(z.string(), z.unknown())),
-      z.object({ rows: z.array(z.record(z.string(), z.unknown())).optional() }),
-    ]);
-    const parsed = DoltHubProfileResponseSchema.safeParse(data);
-    const rows = parsed.success
-      ? Array.isArray(parsed.data)
-        ? parsed.data
-        : (parsed.data.rows ?? [])
-      : [];
-    const sample = rows[0] ?? null;
-
-    return { ok: true as const, sample };
   }),
 });

--- a/apps/web/src/routers/dolthub-router.ts
+++ b/apps/web/src/routers/dolthub-router.ts
@@ -1,0 +1,107 @@
+import 'server-only';
+import { z } from 'zod';
+import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { TRPCError } from '@trpc/server';
+import {
+  resolveOwner,
+  resolveAuthorizedOwner,
+  optionalOrgInput,
+} from '@/lib/integrations/resolve-owner';
+import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+import * as dolthubService from '@/lib/integrations/dolthub-service';
+
+export const dolthubRouter = createTRPCRouter({
+  getInstallation: baseProcedure.input(optionalOrgInput).query(async ({ ctx, input }) => {
+    if (process.env.NODE_ENV === 'production') {
+      return { installed: false, installation: null };
+    }
+
+    if (input?.organizationId) {
+      await ensureOrganizationAccess(ctx, input.organizationId);
+    }
+    const owner = resolveOwner(ctx, input?.organizationId);
+    const integration = await dolthubService.getInstallation(owner);
+
+    if (!integration) {
+      return { installed: false, installation: null };
+    }
+
+    return {
+      installed: integration.integration_status === 'active',
+      installation: {
+        username: integration.platform_account_login,
+        status: integration.integration_status,
+        installedAt: integration.installed_at,
+        scopes: integration.scopes,
+      },
+    };
+  }),
+
+  disconnect: baseProcedure.input(optionalOrgInput).mutation(async ({ ctx, input }) => {
+    if (process.env.NODE_ENV === 'production') {
+      throw new TRPCError({ code: 'NOT_FOUND' });
+    }
+
+    const owner = await resolveAuthorizedOwner(ctx, input?.organizationId);
+    return dolthubService.uninstall(owner);
+  }),
+
+  verifyToken: baseProcedure.input(optionalOrgInput).mutation(async ({ ctx, input }) => {
+    if (process.env.NODE_ENV === 'production') {
+      throw new TRPCError({ code: 'NOT_FOUND' });
+    }
+
+    if (input?.organizationId) {
+      await ensureOrganizationAccess(ctx, input.organizationId);
+    }
+    const owner = resolveOwner(ctx, input?.organizationId);
+    const integration = await dolthubService.getInstallation(owner);
+
+    if (!integration) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'DoltHub integration not found',
+      });
+    }
+
+    const token = await dolthubService.getValidDoltHubToken(integration);
+    if (!token) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'DoltHub access token is invalid or expired',
+      });
+    }
+
+    const response = await fetch(
+      'https://www.dolthub.com/api/v1alpha1/dolthub/profile?q=select+1',
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: `DoltHub token verification failed: ${response.status} ${response.statusText}`,
+      });
+    }
+
+    const data = await response.json();
+
+    const DoltHubProfileResponseSchema = z.union([
+      z.array(z.record(z.unknown())),
+      z.object({ rows: z.array(z.record(z.unknown())).optional() }),
+    ]);
+    const parsed = DoltHubProfileResponseSchema.safeParse(data);
+    const rows = parsed.success
+      ? Array.isArray(parsed.data)
+        ? parsed.data
+        : parsed.data.rows ?? []
+      : [];
+    const sample = rows[0] ?? null;
+
+    return { ok: true as const, sample };
+  }),
+});

--- a/apps/web/src/routers/dolthub-router.ts
+++ b/apps/web/src/routers/dolthub-router.ts
@@ -91,14 +91,14 @@ export const dolthubRouter = createTRPCRouter({
     const data = await response.json();
 
     const DoltHubProfileResponseSchema = z.union([
-      z.array(z.record(z.unknown())),
-      z.object({ rows: z.array(z.record(z.unknown())).optional() }),
+      z.array(z.record(z.string(), z.unknown())),
+      z.object({ rows: z.array(z.record(z.string(), z.unknown())).optional() }),
     ]);
     const parsed = DoltHubProfileResponseSchema.safeParse(data);
     const rows = parsed.success
       ? Array.isArray(parsed.data)
         ? parsed.data
-        : parsed.data.rows ?? []
+        : (parsed.data.rows ?? [])
       : [];
     const sample = rows[0] ?? null;
 

--- a/apps/web/src/routers/root-router.ts
+++ b/apps/web/src/routers/root-router.ts
@@ -15,6 +15,7 @@ import { githubAppsRouter } from '@/routers/github-apps-router';
 import { gitlabRouter } from '@/routers/gitlab-router';
 import { slackRouter } from '@/routers/slack-router';
 import { linearRouter } from '@/routers/linear-router';
+import { dolthubRouter } from '@/routers/dolthub-router';
 import { discordRouter } from '@/routers/discord-router';
 import { codeReviewRouter } from '@/routers/code-reviews/code-reviews-router';
 import { personalReviewAgentRouter } from '@/routers/code-reviews-router';
@@ -52,6 +53,7 @@ export const rootRouter = createTRPCRouter({
   gitlab: gitlabRouter,
   slack: slackRouter,
   linear: linearRouter,
+  dolthub: dolthubRouter,
   discord: discordRouter,
   cloudAgent: cloudAgentRouter,
   cloudAgentNext: cloudAgentNextRouter,


### PR DESCRIPTION
l## Summary
Add a complete DoltHub OAuth integration gated to development environments only. The DoltHub OAuth app is pending admin approval, so all UI surfaces, API routes, and backend logic are disabled in production.

Changes include:
- **Platform definition**: Added `dolthub` to integration constants and platform definitions, enabled only when `IS_DEVELOPMENT` is true.
- **OAuth service module** (`lib/integrations/dolthub-service.ts`): Authorization URL generation, token exchange, token refresh, user info fetch, installation CRUD, and token validation with automatic refresh.
- **tRPC router** (`routers/dolthub-router.ts`): `getInstallation`, `disconnect`, and `verifyToken` endpoints — all return 404/not-found in production.
- **API routes**: `/api/integrations/dolthub/connect` (initiates OAuth) and `/api/integrations/dolthub/callback` (handles callback, with CSRF-protected state verification).
- **UI pages**: `/integrations/dolthub` and `/organizations/[id]/integrations/dolthub` with `notFound()` in production.
- **Integration card**: Wired into `IntegrationsHub` with loading and installation status.
- **Environment variables**: `DOLTHUB_APP_DEV_CLIENT_ID` and `DOLTHUB_APP_DEV_CLIENT_SECRET` added to `.env.local.example`, `.env.test`, and `config.server.ts`.
- **Tests**: Comprehensive unit tests for `dolthub-service` (token flows, installation CRUD, token refresh) and `dolthub-router` (production guards, verify token smoke test).

## Verification
- Verified lint (`oxlint`) and typecheck (`tsgo`) pass.
- Tests were reviewed for coverage of production guards, success paths, and error paths. (Database-dependent tests could not be executed in this environment due to missing Postgres/Docker.)

## Visual Changes

<img width="1683" height="1237" alt="image" src="https://github.com/user-attachments/assets/14b76a59-0e86-4414-b6d0-5940f9d0e849" />

<img width="1683" height="1237" alt="image" src="https://github.com/user-attachments/assets/6f944c93-fcdd-4eef-b90c-0ef4917aecf4" />

<img width="1683" height="1237" alt="image" src="https://github.com/user-attachments/assets/721dfc59-4310-414d-8f53-1669e799ad4a" />

<img width="1683" height="1237" alt="image" src="https://github.com/user-attachments/assets/b35c85f5-5b12-4e1e-b486-02184f5dffb7" />


## Reviewer Notes
- All entry points (pages, API routes, tRPC endpoints, service functions) have independent production guards.
- No database schema changes; reuses the existing `platform_integrations` table.
- Client ID stored in `.env.local.example` is a public OAuth client ID (not a secret).