### PR TITLE
fix(usage): show personal Snowflake rollups

### DIFF
--- a/apps/web/src/routers/usage-analytics-router.ts
+++ b/apps/web/src/routers/usage-analytics-router.ts
@@ -294,7 +294,9 @@ function buildScopeConditions(
   } else {
     where.addEq('kilo_user_id', ctxUserId);
     if (filters.personalScope === 'personal-only') {
-      where.addIsNull('organization_id');
+      // DBT coalesces personal Snowflake usage rollups to an empty-string sentinel
+      // so incremental merges can match on organization_id.
+      where.addEq('organization_id', '');
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix personal usage analytics queries to match DBT's Snowflake empty-string organization sentinel.
- Restores personal usage data visibility when querying precomputed Snowflake rollups.

## Verification
- Confirmed production PostgreSQL has personal usage for the affected user while Snowflake rows use the non-null personal sentinel.

## Visual Changes
N/A

## Reviewer Notes
- DBT documents `organization_id = ''` for personal usage in `microdollar_usage_daily`; this PR aligns the app-side personal scope filter with that contract.
- Automated checks run locally: `pnpm format:changed`, `pnpm --filter web typecheck`.