### PR TITLE
fix(code-reviews): update health alerts

### DIFF
--- a/apps/web/src/app/api/code-reviews/up/route.test.ts
+++ b/apps/web/src/app/api/code-reviews/up/route.test.ts
@@ -51,7 +51,8 @@ describe('GET /api/code-reviews/up', () => {
 
   function reviewValues(overrides: Partial<CodeReviewInsert> = {}) {
     const sequence = reviewSequence++;
-    const timestamp = minutesAgo(5);
+    const startedAt = minutesAgo(10);
+    const completedAt = minutesAgo(5);
 
     return {
       owned_by_user_id: testUser.id,
@@ -66,9 +67,10 @@ describe('GET /api/code-reviews/up', () => {
       head_sha: `sha-${sequence}`,
       status: 'completed',
       agent_version: 'v2',
-      created_at: timestamp,
-      updated_at: timestamp,
-      completed_at: timestamp,
+      created_at: startedAt,
+      updated_at: completedAt,
+      started_at: startedAt,
+      completed_at: completedAt,
       ...overrides,
     } satisfies CodeReviewInsert;
   }
@@ -114,8 +116,8 @@ describe('GET /api/code-reviews/up', () => {
       const response = await GET(makeRequest('kilo-code-reviews-health-check'));
 
       expect(response.status).toBe(200);
-      expect(transactionSpy).toHaveBeenCalledTimes(4);
-      expect(txExecuteCalls).toHaveLength(4);
+      expect(transactionSpy).toHaveBeenCalledTimes(2);
+      expect(txExecuteCalls).toHaveLength(2);
       for (const execute of txExecuteCalls) {
         expect(execute).toHaveBeenCalledTimes(2);
       }
@@ -124,14 +126,16 @@ describe('GET /api/code-reviews/up', () => {
     }
   });
 
-  it('returns 503 with failure-rate alert when failure rate trips', async () => {
+  it('returns 503 with slow-review alert when slow-review rate trips', async () => {
     await db
       .insert(cloud_agent_code_reviews)
       .values([
-        ...Array.from({ length: 4 }, () =>
-          reviewValues({ status: 'failed', terminal_reason: 'timeout' })
-        ),
-        ...Array.from({ length: 11 }, () => reviewValues({ status: 'completed' })),
+        reviewValues({
+          started_at: minutesAgo(71),
+          created_at: minutesAgo(71),
+          completed_at: minutesAgo(10),
+        }),
+        ...Array.from({ length: 9 }, () => reviewValues()),
       ]);
 
     const response = await GET(makeRequest('kilo-code-reviews-health-check'));
@@ -142,14 +146,14 @@ describe('GET /api/code-reviews/up', () => {
       healthy: false,
       alerts: [
         {
-          kind: 'failure_rate',
-          label: 'High Failure Rate',
+          kind: 'slow_reviews',
+          label: 'Slow Reviews',
           severity: 'ticket',
-          rate: expect.any(Number),
-          total: 15,
-          failures: 4,
-          topReason: 'timeout',
-          topReasonCount: 4,
+          rate: 0.1,
+          startedCount: 10,
+          slowCount: 1,
+          windowMinutes: 120,
+          durationMinutes: 60,
           adminUrl: expect.stringContaining('/admin/code-reviews'),
           runbookUrl: CODE_REVIEW_RUNBOOK_URL,
         },
@@ -157,14 +161,13 @@ describe('GET /api/code-reviews/up', () => {
     });
   });
 
-  it('returns 503 with stuck-reviews alert when reviews are stuck', async () => {
-    await db.insert(cloud_agent_code_reviews).values([
-      ...Array.from({ length: 5 }, () =>
-        reviewValues({ status: 'queued', created_at: minutesAgo(20), updated_at: minutesAgo(16) })
-      ),
-      // Avoid also tripping no_completions: keep at least one completed review.
-      reviewValues({ status: 'completed' }),
-    ]);
+  it('returns 503 with error-spike alert when error rate trips', async () => {
+    await db
+      .insert(cloud_agent_code_reviews)
+      .values([
+        reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
+        ...Array.from({ length: 19 }, () => reviewValues()),
+      ]);
 
     const response = await GET(makeRequest('kilo-code-reviews-health-check'));
 
@@ -174,27 +177,55 @@ describe('GET /api/code-reviews/up', () => {
       healthy: false,
       alerts: [
         {
-          kind: 'stuck_reviews',
-          label: 'Stuck Reviews',
+          kind: 'error_spike',
+          label: 'Error Spike',
           severity: 'ticket',
-          queuedCount: 5,
-          runningCount: 0,
+          rate: 0.05,
+          startedCount: 20,
+          errorCount: 1,
+          windowMinutes: 30,
+          topReason: 'timeout',
+          topReasonCount: 1,
+          adminUrl: expect.stringContaining('/admin/code-reviews'),
+          runbookUrl: CODE_REVIEW_RUNBOOK_URL,
         },
       ],
     });
+  });
+
+  it('ignores stale queued rows for health', async () => {
+    await db.insert(cloud_agent_code_reviews).values(
+      Array.from({ length: 20 }, () =>
+        reviewValues({
+          status: 'queued',
+          created_at: minutesAgo(60),
+          updated_at: minutesAgo(60),
+          started_at: null,
+          completed_at: null,
+        })
+      )
+    );
+
+    const response = await GET(makeRequest('kilo-code-reviews-health-check'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({ healthy: true, alerts: [] });
   });
 
   it('returns multiple alerts when multiple detectors trip', async () => {
     await db
       .insert(cloud_agent_code_reviews)
       .values([
-        ...Array.from({ length: 4 }, () =>
-          reviewValues({ status: 'failed', terminal_reason: 'timeout' })
+        ...Array.from({ length: 3 }, () =>
+          reviewValues({
+            started_at: minutesAgo(71),
+            created_at: minutesAgo(71),
+            completed_at: minutesAgo(10),
+          })
         ),
-        ...Array.from({ length: 11 }, () => reviewValues({ status: 'completed' })),
-        ...Array.from({ length: 5 }, () =>
-          reviewValues({ status: 'queued', created_at: minutesAgo(20), updated_at: minutesAgo(16) })
-        ),
+        reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
+        ...Array.from({ length: 19 }, () => reviewValues()),
       ]);
 
     const response = await GET(makeRequest('kilo-code-reviews-health-check'));
@@ -203,7 +234,7 @@ describe('GET /api/code-reviews/up', () => {
     const body = await response.json();
     expect(body.healthy).toBe(false);
     const kinds = body.alerts.map((alert: { kind: string }) => alert.kind);
-    expect(kinds).toEqual(expect.arrayContaining(['failure_rate', 'stuck_reviews']));
+    expect(kinds).toEqual(expect.arrayContaining(['slow_reviews', 'error_spike']));
   });
 
   it('fails open and captures every detector error to Sentry when the database is unreachable', async () => {
@@ -217,16 +248,11 @@ describe('GET /api/code-reviews/up', () => {
       expect(response.status).toBe(200);
       const body = await response.json();
       expect(body).toMatchObject({ healthy: true, alerts: [] });
-      expect(mockCaptureException).toHaveBeenCalledTimes(4);
+      expect(mockCaptureException).toHaveBeenCalledTimes(2);
       const detectorTags = mockCaptureException.mock.calls
         .map(call => call[1].tags.detector)
         .sort();
-      expect(detectorTags).toEqual([
-        'error_spike',
-        'failure_rate',
-        'no_completions',
-        'stuck_reviews',
-      ]);
+      expect(detectorTags).toEqual(['error_spike', 'slow_reviews']);
       expect(mockCaptureException.mock.calls[0][1]).toMatchObject({
         tags: { endpoint: 'code-reviews/up', source: 'code_review_health_check' },
       });

--- a/apps/web/src/app/api/code-reviews/up/route.test.ts
+++ b/apps/web/src/app/api/code-reviews/up/route.test.ts
@@ -127,16 +127,14 @@ describe('GET /api/code-reviews/up', () => {
   });
 
   it('returns 503 with slow-review alert when slow-review rate trips', async () => {
-    await db
-      .insert(cloud_agent_code_reviews)
-      .values([
-        reviewValues({
-          started_at: minutesAgo(71),
-          created_at: minutesAgo(71),
-          completed_at: minutesAgo(10),
-        }),
-        ...Array.from({ length: 9 }, () => reviewValues()),
-      ]);
+    await db.insert(cloud_agent_code_reviews).values([
+      reviewValues({
+        started_at: minutesAgo(71),
+        created_at: minutesAgo(71),
+        completed_at: minutesAgo(10),
+      }),
+      ...Array.from({ length: 9 }, () => reviewValues()),
+    ]);
 
     const response = await GET(makeRequest('kilo-code-reviews-health-check'));
 
@@ -214,19 +212,17 @@ describe('GET /api/code-reviews/up', () => {
   });
 
   it('returns multiple alerts when multiple detectors trip', async () => {
-    await db
-      .insert(cloud_agent_code_reviews)
-      .values([
-        ...Array.from({ length: 3 }, () =>
-          reviewValues({
-            started_at: minutesAgo(71),
-            created_at: minutesAgo(71),
-            completed_at: minutesAgo(10),
-          })
-        ),
-        reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
-        ...Array.from({ length: 19 }, () => reviewValues()),
-      ]);
+    await db.insert(cloud_agent_code_reviews).values([
+      ...Array.from({ length: 3 }, () =>
+        reviewValues({
+          started_at: minutesAgo(71),
+          created_at: minutesAgo(71),
+          completed_at: minutesAgo(10),
+        })
+      ),
+      reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
+      ...Array.from({ length: 19 }, () => reviewValues()),
+    ]);
 
     const response = await GET(makeRequest('kilo-code-reviews-health-check'));
 

--- a/apps/web/src/app/api/code-reviews/up/route.ts
+++ b/apps/web/src/app/api/code-reviews/up/route.ts
@@ -3,10 +3,8 @@ import { NextResponse } from 'next/server';
 import { APP_URL } from '@/lib/constants';
 import { db, sql } from '@/lib/drizzle';
 import {
-  evaluateErrorCategorySpike,
-  evaluateFailureRate,
-  evaluateNoCompletions,
-  evaluateStuckReviews,
+  evaluateErrorSpike,
+  evaluateSlowReviews,
   type CodeReviewAlertEvaluation,
 } from '@/lib/code-reviews/alerting/detectors';
 import {
@@ -29,10 +27,8 @@ type Detector = {
 };
 
 const DETECTORS: Detector[] = [
-  { name: 'failure_rate', evaluate: evaluateFailureRate },
-  { name: 'stuck_reviews', evaluate: evaluateStuckReviews },
-  { name: 'no_completions', evaluate: evaluateNoCompletions },
-  { name: 'error_spike', evaluate: evaluateErrorCategorySpike },
+  { name: 'slow_reviews', evaluate: evaluateSlowReviews },
+  { name: 'error_spike', evaluate: evaluateErrorSpike },
 ];
 
 type UnauthorizedResponse = { healthy: false };

--- a/apps/web/src/lib/code-reviews/alerting/detectors.test.ts
+++ b/apps/web/src/lib/code-reviews/alerting/detectors.test.ts
@@ -2,12 +2,7 @@ import { db, sql } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { cloud_agent_code_reviews, kilocode_users, type User } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
-import {
-  evaluateErrorCategorySpike,
-  evaluateFailureRate,
-  evaluateNoCompletions,
-  evaluateStuckReviews,
-} from './detectors';
+import { evaluateErrorSpike, evaluateSlowReviews } from './detectors';
 
 const REPO = `test-org/code-review-alerts-${Date.now()}`;
 type CodeReviewInsert = typeof cloud_agent_code_reviews.$inferInsert;
@@ -38,7 +33,8 @@ describe('code review alert detectors', () => {
 
   function reviewValues(overrides: Partial<CodeReviewInsert> = {}) {
     const sequence = reviewSequence++;
-    const timestamp = minutesAgo(5);
+    const startedAt = minutesAgo(10);
+    const completedAt = minutesAgo(5);
 
     return {
       owned_by_user_id: testUser.id,
@@ -53,9 +49,10 @@ describe('code review alert detectors', () => {
       head_sha: `sha-${sequence}`,
       status: 'completed',
       agent_version: 'v2',
-      created_at: timestamp,
-      updated_at: timestamp,
-      completed_at: timestamp,
+      created_at: startedAt,
+      updated_at: completedAt,
+      started_at: startedAt,
+      completed_at: completedAt,
       ...overrides,
     } satisfies CodeReviewInsert;
   }
@@ -64,212 +61,229 @@ describe('code review alert detectors', () => {
     await db.insert(cloud_agent_code_reviews).values(reviews);
   }
 
-  it('does not trip failure rate at 25% and trips above 25%', async () => {
+  it('trips slow-review alerts at 10% of recently started reviews', async () => {
     await insertReviews([
-      ...Array.from({ length: 2 }, () =>
-        reviewValues({ status: 'failed', terminal_reason: 'timeout' })
-      ),
-      ...Array.from({ length: 6 }, () => reviewValues({ status: 'completed' })),
+      reviewValues({
+        started_at: minutesAgo(71),
+        created_at: minutesAgo(71),
+        completed_at: minutesAgo(10),
+      }),
+      ...Array.from({ length: 9 }, () => reviewValues()),
     ]);
 
-    await expect(evaluateFailureRate(db)).resolves.toEqual({ tripped: false });
-
-    await db.delete(cloud_agent_code_reviews).where(sql`true`);
-    await insertReviews([
-      ...Array.from({ length: 4 }, () =>
-        reviewValues({ status: 'failed', terminal_reason: 'timeout' })
-      ),
-      ...Array.from({ length: 11 }, () => reviewValues({ status: 'completed' })),
-    ]);
-
-    await expect(evaluateFailureRate(db)).resolves.toMatchObject({
+    await expect(evaluateSlowReviews(db)).resolves.toMatchObject({
       tripped: true,
       details: {
-        kind: 'failure_rate',
-        failures: 4,
-        total: 15,
-        topReason: 'timeout',
-        topReasonCount: 4,
+        kind: 'slow_reviews',
+        rate: 0.1,
+        startedCount: 10,
+        slowCount: 1,
+        windowMinutes: 120,
+        durationMinutes: 60,
       },
     });
   });
 
-  it('requires at least eight terminal reviews for failure-rate alerts', async () => {
-    await insertReviews(
-      Array.from({ length: 7 }, () =>
-        reviewValues({ status: 'failed', terminal_reason: 'upstream_error' })
-      )
-    );
+  it('does not trip slow-review alerts when no recent reviews are slow', async () => {
+    await insertReviews(Array.from({ length: 10 }, () => reviewValues()));
 
-    await expect(evaluateFailureRate(db)).resolves.toEqual({ tripped: false });
+    await expect(evaluateSlowReviews(db)).resolves.toEqual({ tripped: false });
   });
 
-  it('excludes benign terminal reasons from system failure counts', async () => {
+  it('excludes reviews started outside the slow-review window', async () => {
+    await insertReviews([
+      reviewValues({
+        started_at: minutesAgo(121),
+        created_at: minutesAgo(121),
+        updated_at: minutesAgo(5),
+        completed_at: null,
+        status: 'running',
+      }),
+      ...Array.from({ length: 9 }, () => reviewValues()),
+    ]);
+
+    await expect(evaluateSlowReviews(db)).resolves.toEqual({ tripped: false });
+  });
+
+  it('counts running reviews over 60 minutes as slow', async () => {
+    await insertReviews([
+      reviewValues({
+        status: 'running',
+        created_at: minutesAgo(61),
+        started_at: minutesAgo(61),
+        updated_at: minutesAgo(5),
+        completed_at: null,
+      }),
+      ...Array.from({ length: 9 }, () => reviewValues()),
+    ]);
+
+    await expect(evaluateSlowReviews(db)).resolves.toMatchObject({
+      tripped: true,
+      details: { kind: 'slow_reviews', startedCount: 10, slowCount: 1 },
+    });
+  });
+
+  it('counts terminal reviews over 60 minutes as slow', async () => {
+    await insertReviews([
+      reviewValues({
+        started_at: minutesAgo(70),
+        created_at: minutesAgo(70),
+        completed_at: minutesAgo(9),
+      }),
+      ...Array.from({ length: 9 }, () => reviewValues()),
+    ]);
+
+    await expect(evaluateSlowReviews(db)).resolves.toMatchObject({
+      tripped: true,
+      details: { kind: 'slow_reviews', startedCount: 10, slowCount: 1 },
+    });
+  });
+
+  it('does not count terminal reviews completed before 60 minutes as slow', async () => {
+    await insertReviews([
+      reviewValues({
+        started_at: minutesAgo(64),
+        created_at: minutesAgo(64),
+        completed_at: minutesAgo(5),
+      }),
+      ...Array.from({ length: 9 }, () => reviewValues()),
+    ]);
+
+    await expect(evaluateSlowReviews(db)).resolves.toEqual({ tripped: false });
+  });
+
+  it('excludes pending and queued reviews from slow-review denominators', async () => {
+    await insertReviews([
+      reviewValues({
+        status: 'queued',
+        created_at: minutesAgo(90),
+        updated_at: minutesAgo(90),
+        started_at: null,
+        completed_at: null,
+      }),
+      reviewValues({
+        status: 'pending',
+        created_at: minutesAgo(90),
+        updated_at: minutesAgo(90),
+        started_at: null,
+        completed_at: null,
+      }),
+    ]);
+
+    await expect(evaluateSlowReviews(db)).resolves.toEqual({ tripped: false });
+  });
+
+  it('trips error-spike alerts at 5% of recently started reviews', async () => {
     await insertReviews([
       reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
+      ...Array.from({ length: 19 }, () => reviewValues()),
+    ]);
+
+    await expect(evaluateErrorSpike(db)).resolves.toMatchObject({
+      tripped: true,
+      details: {
+        kind: 'error_spike',
+        rate: 0.05,
+        startedCount: 20,
+        errorCount: 1,
+        windowMinutes: 30,
+        topReason: 'timeout',
+        topReasonCount: 1,
+      },
+    });
+  });
+
+  it('does not trip error-spike alerts with no recent errors', async () => {
+    await insertReviews(Array.from({ length: 20 }, () => reviewValues()));
+
+    await expect(evaluateErrorSpike(db)).resolves.toEqual({ tripped: false });
+  });
+
+  it('does not trip error-spike alerts below 5%', async () => {
+    await insertReviews([
+      reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
+      ...Array.from({ length: 20 }, () => reviewValues()),
+    ]);
+
+    await expect(evaluateErrorSpike(db)).resolves.toEqual({ tripped: false });
+  });
+
+  it('excludes errors from reviews started outside the error-spike window', async () => {
+    await insertReviews([
+      reviewValues({
+        status: 'failed',
+        terminal_reason: 'timeout',
+        created_at: minutesAgo(31),
+        updated_at: minutesAgo(5),
+        started_at: minutesAgo(31),
+        completed_at: minutesAgo(5),
+      }),
+      ...Array.from({ length: 19 }, () => reviewValues()),
+    ]);
+
+    await expect(evaluateErrorSpike(db)).resolves.toEqual({ tripped: false });
+  });
+
+  it('excludes benign terminal reasons from error-spike counts', async () => {
+    await insertReviews([
       reviewValues({ status: 'failed', terminal_reason: 'billing' }),
       reviewValues({ status: 'cancelled', terminal_reason: 'user_cancelled' }),
       reviewValues({ status: 'cancelled', terminal_reason: 'superseded' }),
-      ...Array.from({ length: 5 }, () => reviewValues({ status: 'completed' })),
+      ...Array.from({ length: 17 }, () => reviewValues()),
     ]);
 
-    await expect(evaluateFailureRate(db)).resolves.toEqual({ tripped: false });
+    await expect(evaluateErrorSpike(db)).resolves.toEqual({ tripped: false });
   });
 
-  it('counts interrupted reviews as system failures', async () => {
+  it('counts interrupted and cancelled interrupted reviews as error spikes', async () => {
     await insertReviews([
-      ...Array.from({ length: 3 }, () =>
-        reviewValues({ status: 'interrupted', terminal_reason: 'interrupted' })
-      ),
-      ...Array.from({ length: 6 }, () => reviewValues({ status: 'completed' })),
+      reviewValues({ status: 'interrupted', terminal_reason: 'interrupted' }),
+      reviewValues({ status: 'cancelled', terminal_reason: 'interrupted' }),
+      ...Array.from({ length: 38 }, () => reviewValues()),
     ]);
 
-    await expect(evaluateFailureRate(db)).resolves.toMatchObject({
+    await expect(evaluateErrorSpike(db)).resolves.toMatchObject({
       tripped: true,
-      details: { kind: 'failure_rate', failures: 3, total: 9 },
+      details: { kind: 'error_spike', startedCount: 40, errorCount: 2, topReason: 'interrupted' },
     });
   });
 
-  it('counts cancelled interrupted reviews as system failures', async () => {
+  it('counts failed reviews with missing terminal reasons as unknown errors', async () => {
     await insertReviews([
-      ...Array.from({ length: 3 }, () =>
-        reviewValues({ status: 'cancelled', terminal_reason: 'interrupted' })
-      ),
-      ...Array.from({ length: 6 }, () => reviewValues({ status: 'completed' })),
+      reviewValues({ status: 'failed', terminal_reason: null }),
+      ...Array.from({ length: 19 }, () => reviewValues()),
     ]);
 
-    await expect(evaluateFailureRate(db)).resolves.toMatchObject({
+    await expect(evaluateErrorSpike(db)).resolves.toMatchObject({
       tripped: true,
-      details: { kind: 'failure_rate', failures: 3, total: 9 },
+      details: {
+        kind: 'error_spike',
+        startedCount: 20,
+        errorCount: 1,
+        topReason: 'unknown',
+        topReasonCount: 1,
+      },
     });
   });
 
-  it('trips stuck-review alerts only at the count threshold', async () => {
-    await insertReviews(
-      Array.from({ length: 4 }, () =>
-        reviewValues({ status: 'queued', created_at: minutesAgo(20), updated_at: minutesAgo(16) })
-      )
-    );
-    await expect(evaluateStuckReviews(db)).resolves.toEqual({ tripped: false });
-
+  it('excludes pending and queued reviews from error-spike denominators', async () => {
     await insertReviews([
-      reviewValues({ status: 'queued', created_at: minutesAgo(20), updated_at: minutesAgo(16) }),
-    ]);
-    await expect(evaluateStuckReviews(db)).resolves.toMatchObject({
-      tripped: true,
-      details: { kind: 'stuck_reviews', queuedCount: 5, runningCount: 0 },
-    });
-  });
-
-  it('detects stuck running reviews after two hours', async () => {
-    await insertReviews(
-      Array.from({ length: 5 }, () =>
-        reviewValues({
-          status: 'running',
-          created_at: minutesAgo(130),
-          updated_at: minutesAgo(10),
-          started_at: minutesAgo(119),
-          completed_at: null,
-        })
-      )
-    );
-    await expect(evaluateStuckReviews(db)).resolves.toEqual({ tripped: false });
-
-    await db.delete(cloud_agent_code_reviews).where(sql`true`);
-    await insertReviews(
-      Array.from({ length: 5 }, () =>
-        reviewValues({
-          status: 'running',
-          created_at: minutesAgo(130),
-          updated_at: minutesAgo(10),
-          started_at: minutesAgo(121),
-          completed_at: null,
-        })
-      )
-    );
-
-    await expect(evaluateStuckReviews(db)).resolves.toMatchObject({
-      tripped: true,
-      details: { kind: 'stuck_reviews', queuedCount: 0, runningCount: 5 },
-    });
-  });
-
-  it('still trips for reviews stuck running for more than six hours', async () => {
-    await insertReviews(
-      Array.from({ length: 5 }, () =>
-        reviewValues({
-          status: 'running',
-          created_at: minutesAgo(60 * 8),
-          updated_at: minutesAgo(60 * 7),
-          started_at: minutesAgo(60 * 7),
-          completed_at: null,
-        })
-      )
-    );
-
-    await expect(evaluateStuckReviews(db)).resolves.toMatchObject({
-      tripped: true,
-      details: { kind: 'stuck_reviews', queuedCount: 0, runningCount: 5 },
-    });
-  });
-
-  it('guards no-completion alerts by minimum created count', async () => {
-    await insertReviews(
-      Array.from({ length: 4 }, () => reviewValues({ status: 'running', completed_at: null }))
-    );
-    await expect(evaluateNoCompletions(db)).resolves.toEqual({ tripped: false });
-
-    await insertReviews([reviewValues({ status: 'running', completed_at: null })]);
-    await expect(evaluateNoCompletions(db)).resolves.toEqual({
-      tripped: true,
-      details: { kind: 'no_completions', createdCount: 5 },
-    });
-
-    await insertReviews([reviewValues({ status: 'completed' })]);
-    await expect(evaluateNoCompletions(db)).resolves.toEqual({ tripped: false });
-  });
-
-  it('detects error category spikes by terminal reason', async () => {
-    await insertReviews(
-      Array.from({ length: 5 }, () =>
-        reviewValues({ status: 'failed', terminal_reason: 'timeout' })
-      )
-    );
-    await expect(evaluateErrorCategorySpike(db)).resolves.toEqual({ tripped: false });
-
-    await insertReviews([reviewValues({ status: 'failed', terminal_reason: 'upstream_error' })]);
-    await expect(evaluateErrorCategorySpike(db)).resolves.toMatchObject({
-      tripped: true,
-      details: { kind: 'error_spike', reason: 'timeout', count: 5, total: 6 },
-    });
-  });
-
-  it('counts cancelled interrupted reviews in error spikes', async () => {
-    await insertReviews(
-      Array.from({ length: 6 }, () =>
-        reviewValues({ status: 'cancelled', terminal_reason: 'interrupted' })
-      )
-    );
-
-    await expect(evaluateErrorCategorySpike(db)).resolves.toMatchObject({
-      tripped: true,
-      details: { kind: 'error_spike', reason: 'interrupted', count: 6, total: 6 },
-    });
-  });
-
-  it('does not trip error category spikes below the share threshold', async () => {
-    await insertReviews([
-      ...Array.from({ length: 2 }, () =>
-        reviewValues({ status: 'failed', terminal_reason: 'timeout' })
-      ),
-      ...Array.from({ length: 2 }, () =>
-        reviewValues({ status: 'failed', terminal_reason: 'upstream_error' })
-      ),
-      ...Array.from({ length: 2 }, () =>
-        reviewValues({ status: 'failed', terminal_reason: 'unknown' })
-      ),
+      reviewValues({
+        status: 'queued',
+        created_at: minutesAgo(5),
+        updated_at: minutesAgo(5),
+        started_at: null,
+        completed_at: null,
+      }),
+      reviewValues({
+        status: 'pending',
+        created_at: minutesAgo(5),
+        updated_at: minutesAgo(5),
+        started_at: null,
+        completed_at: null,
+      }),
     ]);
 
-    await expect(evaluateErrorCategorySpike(db)).resolves.toEqual({ tripped: false });
+    await expect(evaluateErrorSpike(db)).resolves.toEqual({ tripped: false });
   });
 });

--- a/apps/web/src/lib/code-reviews/alerting/detectors.ts
+++ b/apps/web/src/lib/code-reviews/alerting/detectors.ts
@@ -3,81 +3,53 @@ import { sql } from '@/lib/drizzle';
 import { cloud_agent_code_reviews } from '@kilocode/db/schema';
 import { CODE_REVIEW_BENIGN_TERMINAL_REASONS } from '@kilocode/db/schema-types';
 import {
-  CODE_REVIEW_ALERT_WINDOW_MINUTES,
-  ERROR_SPIKE_FRACTION,
-  ERROR_SPIKE_MIN_FAILURES,
-  FAILURE_RATE_MIN_TERMINAL,
-  FAILURE_RATE_THRESHOLD,
-  NO_COMPLETIONS_MIN_CREATED,
-  STUCK_COUNT_THRESHOLD,
-  STUCK_QUEUED_MINUTES,
-  STUCK_RUNNING_MINUTES,
+  ERROR_SPIKE_RATE_THRESHOLD,
+  ERROR_SPIKE_WINDOW_MINUTES,
+  SLOW_REVIEW_DURATION_MINUTES,
+  SLOW_REVIEW_RATE_THRESHOLD,
+  SLOW_REVIEW_WINDOW_MINUTES,
 } from './thresholds';
 
 type AlertingDb = Pick<typeof defaultDb, 'execute'>;
 type CountValue = string | number | bigint | null | undefined;
 
-export type FailureRateAlertDetails = {
-  kind: 'failure_rate';
+export type SlowReviewsAlertDetails = {
+  kind: 'slow_reviews';
   rate: number;
-  total: number;
-  failures: number;
-  topReason?: string;
-  topReasonCount?: number;
-};
-
-export type StuckReviewsAlertDetails = {
-  kind: 'stuck_reviews';
-  queuedCount: number;
-  runningCount: number;
-};
-
-export type NoCompletionsAlertDetails = {
-  kind: 'no_completions';
-  createdCount: number;
+  startedCount: number;
+  slowCount: number;
+  windowMinutes: number;
+  durationMinutes: number;
 };
 
 export type ErrorSpikeAlertDetails = {
   kind: 'error_spike';
-  reason: string;
-  count: number;
-  total: number;
-  share: number;
+  rate: number;
+  startedCount: number;
+  errorCount: number;
+  windowMinutes: number;
+  topReason?: string;
+  topReasonCount?: number;
 };
 
-export type CodeReviewAlertDetails =
-  | FailureRateAlertDetails
-  | StuckReviewsAlertDetails
-  | NoCompletionsAlertDetails
-  | ErrorSpikeAlertDetails;
+export type CodeReviewAlertDetails = SlowReviewsAlertDetails | ErrorSpikeAlertDetails;
 
 export type CodeReviewAlertEvaluation =
   | { tripped: false }
   | { tripped: true; details: CodeReviewAlertDetails };
 
-type FailureRateRow = {
-  terminal_count: CountValue;
-  system_failure_count: CountValue;
+type SlowReviewsRow = {
+  started_count: CountValue;
+  slow_count: CountValue;
+};
+
+type ErrorSpikeRow = {
+  started_count: CountValue;
+  error_count: CountValue;
   top_reason: string | null;
   top_reason_count: CountValue;
 };
 
-type StuckReviewsRow = {
-  stuck_queued_count: CountValue;
-  stuck_running_count: CountValue;
-};
-
-type NoCompletionsRow = {
-  completed_count: CountValue;
-  created_count: CountValue;
-};
-
-type ErrorReasonRow = {
-  reason: string;
-  count: CountValue;
-};
-
-const terminalStatusesSql = sql`('completed', 'failed', 'cancelled', 'interrupted')`;
 const benignTerminalReasonsSql = sql`(${sql.join(
   CODE_REVIEW_BENIGN_TERMINAL_REASONS.map(reason => sql`${reason}`),
   sql.raw(', ')
@@ -86,6 +58,18 @@ const systemFailureSql = sql`(
   status IN ('failed', 'interrupted')
   OR (status = 'cancelled' AND terminal_reason IS NOT NULL)
 )`;
+
+const startedReviewsCteSql = sql`
+  started_reviews AS (
+    SELECT
+      status,
+      terminal_reason,
+      COALESCE(started_at, updated_at, created_at) AS started_at_effective,
+      COALESCE(completed_at, updated_at) AS completed_at_effective
+    FROM ${cloud_agent_code_reviews}
+    WHERE status NOT IN ('pending', 'queued')
+  )
+`;
 
 function toNumber(value: CountValue): number {
   if (value === null || value === undefined) return 0;
@@ -97,14 +81,55 @@ function rate(numerator: number, denominator: number): number {
   return numerator / denominator;
 }
 
-export async function evaluateFailureRate(
+export async function evaluateSlowReviews(
   database: AlertingDb
 ): Promise<CodeReviewAlertEvaluation> {
-  const result = await database.execute<FailureRateRow>(sql`
-    WITH windowed AS (
-      SELECT status, terminal_reason
-      FROM ${cloud_agent_code_reviews}
-      WHERE created_at >= NOW() - (${CODE_REVIEW_ALERT_WINDOW_MINUTES} * INTERVAL '1 minute')
+  const result = await database.execute<SlowReviewsRow>(sql`
+    WITH ${startedReviewsCteSql}, windowed AS (
+      SELECT *
+      FROM started_reviews
+      WHERE started_at_effective >= NOW() - (${SLOW_REVIEW_WINDOW_MINUTES} * INTERVAL '1 minute')
+    )
+    SELECT
+      COUNT(*) AS started_count,
+      COUNT(*) FILTER (
+        WHERE CASE
+          WHEN status = 'running'
+            THEN NOW() - started_at_effective > (${SLOW_REVIEW_DURATION_MINUTES} * INTERVAL '1 minute')
+          ELSE completed_at_effective - started_at_effective > (${SLOW_REVIEW_DURATION_MINUTES} * INTERVAL '1 minute')
+        END
+      ) AS slow_count
+    FROM windowed
+  `);
+
+  const row = result.rows[0];
+  const startedCount = toNumber(row?.started_count);
+  const slowCount = toNumber(row?.slow_count);
+  const currentRate = rate(slowCount, startedCount);
+
+  if (startedCount === 0 || currentRate < SLOW_REVIEW_RATE_THRESHOLD) {
+    return { tripped: false };
+  }
+
+  return {
+    tripped: true,
+    details: {
+      kind: 'slow_reviews',
+      rate: currentRate,
+      startedCount,
+      slowCount,
+      windowMinutes: SLOW_REVIEW_WINDOW_MINUTES,
+      durationMinutes: SLOW_REVIEW_DURATION_MINUTES,
+    },
+  };
+}
+
+export async function evaluateErrorSpike(database: AlertingDb): Promise<CodeReviewAlertEvaluation> {
+  const result = await database.execute<ErrorSpikeRow>(sql`
+    WITH ${startedReviewsCteSql}, windowed AS (
+      SELECT *
+      FROM started_reviews
+      WHERE started_at_effective >= NOW() - (${ERROR_SPIKE_WINDOW_MINUTES} * INTERVAL '1 minute')
     ), top_reason AS (
       SELECT COALESCE(NULLIF(terminal_reason, ''), 'unknown') AS reason, COUNT(*) AS count
       FROM windowed
@@ -115,115 +140,22 @@ export async function evaluateFailureRate(
       LIMIT 1
     )
     SELECT
-      COUNT(*) FILTER (WHERE status IN ${terminalStatusesSql}) AS terminal_count,
+      COUNT(*) AS started_count,
       COUNT(*) FILTER (
         WHERE ${systemFailureSql}
           AND COALESCE(terminal_reason, '') NOT IN ${benignTerminalReasonsSql}
-      ) AS system_failure_count,
+      ) AS error_count,
       (SELECT reason FROM top_reason) AS top_reason,
       (SELECT count FROM top_reason) AS top_reason_count
     FROM windowed
   `);
 
   const row = result.rows[0];
-  const total = toNumber(row?.terminal_count);
-  const failures = toNumber(row?.system_failure_count);
-  const currentRate = rate(failures, total);
+  const startedCount = toNumber(row?.started_count);
+  const errorCount = toNumber(row?.error_count);
+  const currentRate = rate(errorCount, startedCount);
 
-  if (total < FAILURE_RATE_MIN_TERMINAL || currentRate <= FAILURE_RATE_THRESHOLD) {
-    return { tripped: false };
-  }
-
-  return {
-    tripped: true,
-    details: {
-      kind: 'failure_rate',
-      rate: currentRate,
-      total,
-      failures,
-      ...(row?.top_reason ? { topReason: row.top_reason } : {}),
-      ...(toNumber(row?.top_reason_count) > 0
-        ? { topReasonCount: toNumber(row?.top_reason_count) }
-        : {}),
-    },
-  };
-}
-
-export async function evaluateStuckReviews(
-  database: AlertingDb
-): Promise<CodeReviewAlertEvaluation> {
-  const result = await database.execute<StuckReviewsRow>(sql`
-    SELECT
-      COUNT(*) FILTER (
-        WHERE status = 'queued'
-          AND updated_at < NOW() - (${STUCK_QUEUED_MINUTES} * INTERVAL '1 minute')
-      ) AS stuck_queued_count,
-      COUNT(*) FILTER (
-        WHERE status = 'running'
-          AND COALESCE(started_at, updated_at, created_at) < NOW() - (${STUCK_RUNNING_MINUTES} * INTERVAL '1 minute')
-      ) AS stuck_running_count
-    FROM ${cloud_agent_code_reviews}
-    WHERE status IN ('queued', 'running')
-  `);
-
-  const row = result.rows[0];
-  const queuedCount = toNumber(row?.stuck_queued_count);
-  const runningCount = toNumber(row?.stuck_running_count);
-
-  if (queuedCount < STUCK_COUNT_THRESHOLD && runningCount < STUCK_COUNT_THRESHOLD) {
-    return { tripped: false };
-  }
-
-  return { tripped: true, details: { kind: 'stuck_reviews', queuedCount, runningCount } };
-}
-
-export async function evaluateNoCompletions(
-  database: AlertingDb
-): Promise<CodeReviewAlertEvaluation> {
-  const result = await database.execute<NoCompletionsRow>(sql`
-    SELECT
-      COUNT(*) FILTER (WHERE status = 'completed') AS completed_count,
-      COUNT(*) AS created_count
-    FROM ${cloud_agent_code_reviews}
-    WHERE created_at >= NOW() - (${CODE_REVIEW_ALERT_WINDOW_MINUTES} * INTERVAL '1 minute')
-  `);
-
-  const row = result.rows[0];
-  const completedCount = toNumber(row?.completed_count);
-  const createdCount = toNumber(row?.created_count);
-
-  if (createdCount < NO_COMPLETIONS_MIN_CREATED || completedCount > 0) {
-    return { tripped: false };
-  }
-
-  return { tripped: true, details: { kind: 'no_completions', createdCount } };
-}
-
-export async function evaluateErrorCategorySpike(
-  database: AlertingDb
-): Promise<CodeReviewAlertEvaluation> {
-  const result = await database.execute<ErrorReasonRow>(sql`
-    SELECT COALESCE(NULLIF(terminal_reason, ''), 'unknown') AS reason, COUNT(*) AS count
-    FROM ${cloud_agent_code_reviews}
-    WHERE ${systemFailureSql}
-      AND created_at >= NOW() - (${CODE_REVIEW_ALERT_WINDOW_MINUTES} * INTERVAL '1 minute')
-      AND COALESCE(terminal_reason, '') NOT IN ${benignTerminalReasonsSql}
-    GROUP BY 1
-    ORDER BY 2 DESC, 1 ASC
-  `);
-
-  const rows = result.rows;
-  const total = rows.reduce((sum, row) => sum + toNumber(row.count), 0);
-  const topReason = rows[0];
-
-  if (!topReason || total < ERROR_SPIKE_MIN_FAILURES) {
-    return { tripped: false };
-  }
-
-  const count = toNumber(topReason.count);
-  const share = rate(count, total);
-
-  if (share < ERROR_SPIKE_FRACTION) {
+  if (startedCount === 0 || currentRate < ERROR_SPIKE_RATE_THRESHOLD) {
     return { tripped: false };
   }
 
@@ -231,10 +163,14 @@ export async function evaluateErrorCategorySpike(
     tripped: true,
     details: {
       kind: 'error_spike',
-      reason: topReason.reason,
-      count,
-      total,
-      share,
+      rate: currentRate,
+      startedCount,
+      errorCount,
+      windowMinutes: ERROR_SPIKE_WINDOW_MINUTES,
+      ...(row?.top_reason ? { topReason: row.top_reason } : {}),
+      ...(toNumber(row?.top_reason_count) > 0
+        ? { topReasonCount: toNumber(row?.top_reason_count) }
+        : {}),
     },
   };
 }

--- a/apps/web/src/lib/code-reviews/alerting/health-response.ts
+++ b/apps/web/src/lib/code-reviews/alerting/health-response.ts
@@ -7,10 +7,8 @@ export const CODE_REVIEW_RUNBOOK_URL =
 type AlertKindLabel = Record<CodeReviewAlertDetails['kind'], string>;
 
 const ALERT_KIND_LABELS: AlertKindLabel = {
-  failure_rate: 'High Failure Rate',
-  stuck_reviews: 'Stuck Reviews',
-  no_completions: 'No Completions',
-  error_spike: 'Error Category Spike',
+  slow_reviews: 'Slow Reviews',
+  error_spike: 'Error Spike',
 };
 
 type CodeReviewHealthAlertCommon = {

--- a/apps/web/src/lib/code-reviews/alerting/thresholds.ts
+++ b/apps/web/src/lib/code-reviews/alerting/thresholds.ts
@@ -1,16 +1,9 @@
-export const CODE_REVIEW_ALERT_WINDOW_MINUTES = 30;
+export const SLOW_REVIEW_WINDOW_MINUTES = 120;
+export const SLOW_REVIEW_DURATION_MINUTES = 60;
+export const SLOW_REVIEW_RATE_THRESHOLD = 0.1;
 
-export const FAILURE_RATE_THRESHOLD = 0.25;
-export const FAILURE_RATE_MIN_TERMINAL = 8;
-
-export const STUCK_QUEUED_MINUTES = 15;
-export const STUCK_RUNNING_MINUTES = 120;
-export const STUCK_COUNT_THRESHOLD = 5;
-
-export const NO_COMPLETIONS_MIN_CREATED = 5;
-
-export const ERROR_SPIKE_FRACTION = 0.5;
-export const ERROR_SPIKE_MIN_FAILURES = 6;
+export const ERROR_SPIKE_WINDOW_MINUTES = 30;
+export const ERROR_SPIKE_RATE_THRESHOLD = 0.05;
 
 export type CodeReviewAlertSeverity = 'page' | 'ticket';
 export const CODE_REVIEW_ALERT_SEVERITY = 'ticket' satisfies CodeReviewAlertSeverity;


### PR DESCRIPTION
## Why

https://github.com/Kilo-Org/cloud/pull/3136 followup

Old review rows could make the health check look broken long after they stopped mattering. This made alerts noisy and harder to trust.

## What changed

The health check now looks at reviews that started recently instead of old queued or running rows. It marks the system unhealthy when too many recent reviews take more than an hour, or when too many recent started reviews end with system errors. Queued reviews no longer count until they start, and very old running reviews stop affecting health once they are outside the recent window. Billing issues, user cancels, and replaced reviews still do not count as system errors.

## How to test

1. Run `pnpm test -- apps/web/src/lib/code-reviews/alerting/detectors.test.ts apps/web/src/app/api/code-reviews/up/route.test.ts`.
2. Run `scripts/typecheck-all.sh --changes-only`.
3. Run `pnpm format`.