### PR TITLE
fix(code-review): cancel superseded reviews

### DIFF
--- a/apps/web/src/lib/code-reviews/db/code-reviews.test.ts
+++ b/apps/web/src/lib/code-reviews/db/code-reviews.test.ts
@@ -4,12 +4,167 @@ import { eq } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';
 import {
+  cancelSupersededReviewsForPR,
   createCodeReview,
-  updateCodeReviewStatus,
   findPreviousCompletedReview,
+  updateCodeReviewStatus,
 } from './code-reviews';
 
 const REPO = `test-org/session-continuation-${Date.now()}`;
+
+describe('cancelSupersededReviewsForPR', () => {
+  let testUser: User;
+  const createdReviewIds: string[] = [];
+  const repo = `${REPO}-superseded`;
+
+  beforeAll(async () => {
+    testUser = await insertTestUser();
+  });
+
+  afterAll(async () => {
+    for (const id of createdReviewIds) {
+      await db.delete(cloud_agent_code_reviews).where(eq(cloud_agent_code_reviews.id, id));
+    }
+    await db.delete(kilocode_users).where(eq(kilocode_users.id, testUser.id));
+  });
+
+  async function createReview({
+    headSha,
+    prNumber = 42,
+    repoFullName = repo,
+    platform = 'github' as const,
+    platformProjectId,
+  }: {
+    headSha: string;
+    prNumber?: number;
+    repoFullName?: string;
+    platform?: 'github' | 'gitlab';
+    platformProjectId?: number;
+  }) {
+    const id = await createCodeReview({
+      owner: { type: 'user', id: testUser.id, userId: testUser.id },
+      repoFullName,
+      prNumber,
+      prUrl: `https://github.com/${repoFullName}/pull/${prNumber}`,
+      prTitle: 'test PR',
+      prAuthor: 'octocat',
+      baseRef: 'main',
+      headRef: `feature/${headSha}`,
+      headSha,
+      platform,
+      platformProjectId,
+    });
+    createdReviewIds.push(id);
+    return id;
+  }
+
+  it('cancels pending, queued, and running rows and returns accurate prev_status values', async () => {
+    const pendingId = await createReview({ headSha: 'sha-pending' });
+    const queuedId = await createReview({ headSha: 'sha-queued' });
+    const runningId = await createReview({ headSha: 'sha-running' });
+
+    await updateCodeReviewStatus(queuedId, 'queued');
+    await updateCodeReviewStatus(runningId, 'running', { sessionId: 'session-running' });
+
+    const cancelled = await cancelSupersededReviewsForPR(repo, 42, 'sha-latest');
+
+    expect(cancelled).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: pendingId, prevStatus: 'pending', headSha: 'sha-pending' }),
+        expect.objectContaining({ id: queuedId, prevStatus: 'queued', headSha: 'sha-queued' }),
+        expect.objectContaining({
+          id: runningId,
+          prevStatus: 'running',
+          headSha: 'sha-running',
+          sessionId: 'session-running',
+        }),
+      ])
+    );
+
+    const rows = await db
+      .select({
+        id: cloud_agent_code_reviews.id,
+        status: cloud_agent_code_reviews.status,
+        terminalReason: cloud_agent_code_reviews.terminal_reason,
+        errorMessage: cloud_agent_code_reviews.error_message,
+        completedAt: cloud_agent_code_reviews.completed_at,
+        startedAt: cloud_agent_code_reviews.started_at,
+        sessionId: cloud_agent_code_reviews.session_id,
+      })
+      .from(cloud_agent_code_reviews)
+      .where(eq(cloud_agent_code_reviews.repo_full_name, repo));
+
+    for (const row of rows.filter(row => [pendingId, queuedId, runningId].includes(row.id))) {
+      expect(row.status).toBe('cancelled');
+      expect(row.terminalReason).toBe('superseded');
+      expect(row.errorMessage).toBe('Superseded by new push');
+      expect(row.completedAt).not.toBeNull();
+    }
+
+    expect(rows.find(row => row.id === pendingId)?.startedAt).toBeNull();
+    expect(rows.find(row => row.id === pendingId)?.sessionId).toBeNull();
+    expect(rows.find(row => row.id === runningId)?.sessionId).toBe('session-running');
+  });
+
+  it('ignores same-sha, different repo or pr, and already-terminal rows; second call is idempotent', async () => {
+    const sameShaId = await createReview({ headSha: 'sha-keep' });
+    const otherPrId = await createReview({ headSha: 'sha-other-pr', prNumber: 43 });
+    const otherRepoId = await createReview({
+      headSha: 'sha-other-repo',
+      repoFullName: `${repo}-other`,
+    });
+    const terminalCompletedId = await createReview({ headSha: 'sha-completed' });
+    const terminalFailedId = await createReview({ headSha: 'sha-failed' });
+    const targetId = await createReview({
+      headSha: 'sha-gitlab',
+      platform: 'gitlab',
+      platformProjectId: 999,
+    });
+
+    await updateCodeReviewStatus(terminalCompletedId, 'completed');
+    await updateCodeReviewStatus(terminalFailedId, 'failed', {
+      errorMessage: 'failed before cancel',
+    });
+
+    const cancelled = await cancelSupersededReviewsForPR(repo, 42, 'sha-keep');
+    expect(cancelled).toHaveLength(1);
+    expect(cancelled[0]).toEqual(
+      expect.objectContaining({
+        id: targetId,
+        prevStatus: 'pending',
+        headSha: 'sha-gitlab',
+        platform: 'gitlab',
+        platformProjectId: 999,
+        platformIntegrationId: null,
+      })
+    );
+
+    const cancelledAgain = await cancelSupersededReviewsForPR(repo, 42, 'sha-keep');
+    expect(cancelledAgain).toEqual([]);
+
+    const rows = await db
+      .select({
+        id: cloud_agent_code_reviews.id,
+        status: cloud_agent_code_reviews.status,
+        terminalReason: cloud_agent_code_reviews.terminal_reason,
+      })
+      .from(cloud_agent_code_reviews)
+      .where(eq(cloud_agent_code_reviews.repo_full_name, repo));
+
+    expect(rows.find(row => row.id === sameShaId)?.status).toBe('pending');
+    expect(rows.find(row => row.id === targetId)?.status).toBe('cancelled');
+    expect(rows.find(row => row.id === otherPrId)?.status).toBe('pending');
+    expect(rows.find(row => row.id === terminalCompletedId)?.status).toBe('completed');
+    expect(rows.find(row => row.id === terminalFailedId)?.status).toBe('failed');
+
+    const [otherRepoRow] = await db
+      .select({ status: cloud_agent_code_reviews.status })
+      .from(cloud_agent_code_reviews)
+      .where(eq(cloud_agent_code_reviews.id, otherRepoId))
+      .limit(1);
+    expect(otherRepoRow?.status).toBe('pending');
+  });
+});
 
 describe('findPreviousCompletedReview', () => {
   let testUser: User;

--- a/apps/web/src/lib/code-reviews/db/code-reviews.ts
+++ b/apps/web/src/lib/code-reviews/db/code-reviews.ts
@@ -17,6 +17,17 @@ import type { CreateReviewParams, CodeReviewStatus, ListReviewsParams, Owner } f
 import type { CloudAgentCodeReview } from '@kilocode/db/schema';
 import type { CodeReviewTerminalReason } from '@kilocode/db/schema-types';
 
+export type CancelledReviewRow = {
+  id: string;
+  prevStatus: 'pending' | 'queued' | 'running';
+  sessionId: string | null;
+  checkRunId: number | null;
+  headSha: string;
+  platform: 'github' | 'gitlab';
+  platformProjectId: number | null;
+  platformIntegrationId: string | null;
+};
+
 /**
  * Creates a new code review record
  * Returns the created review ID
@@ -519,6 +530,77 @@ export async function findActiveReviewsForPR(
   } catch (error) {
     captureException(error, {
       tags: { operation: 'findActiveReviewsForPR' },
+      extra: { repoFullName, prNumber, excludeSha },
+    });
+    throw error;
+  }
+}
+
+export async function cancelSupersededReviewsForPR(
+  repoFullName: string,
+  prNumber: number,
+  excludeSha: string
+): Promise<CancelledReviewRow[]> {
+  try {
+    const result = await db.execute<{
+      id: string;
+      prev_status: 'pending' | 'queued' | 'running';
+      session_id: string | null;
+      check_run_id: number | null;
+      head_sha: string;
+      platform: 'github' | 'gitlab';
+      platform_project_id: number | null;
+      platform_integration_id: string | null;
+    }>(sql`
+      WITH targets AS (
+        SELECT
+          id,
+          status AS prev_status,
+          session_id,
+          check_run_id,
+          head_sha,
+          platform,
+          platform_project_id,
+          platform_integration_id
+        FROM ${cloud_agent_code_reviews}
+        WHERE ${cloud_agent_code_reviews.repo_full_name} = ${repoFullName}
+          AND ${cloud_agent_code_reviews.pr_number} = ${prNumber}
+          AND ${cloud_agent_code_reviews.head_sha} != ${excludeSha}
+          AND ${cloud_agent_code_reviews.status} IN ('pending', 'queued', 'running')
+      )
+      UPDATE ${cloud_agent_code_reviews} AS reviews
+      SET
+        status = 'cancelled',
+        terminal_reason = 'superseded',
+        error_message = 'Superseded by new push',
+        completed_at = now(),
+        updated_at = now()
+      FROM targets
+      WHERE reviews.id = targets.id
+      RETURNING
+        reviews.id,
+        targets.prev_status,
+        targets.session_id,
+        targets.check_run_id,
+        targets.head_sha,
+        targets.platform,
+        targets.platform_project_id,
+        targets.platform_integration_id
+    `);
+
+    return result.rows.map(row => ({
+      id: row.id,
+      prevStatus: row.prev_status,
+      sessionId: row.session_id,
+      checkRunId: row.check_run_id,
+      headSha: row.head_sha,
+      platform: row.platform,
+      platformProjectId: row.platform_project_id,
+      platformIntegrationId: row.platform_integration_id,
+    }));
+  } catch (error) {
+    captureException(error, {
+      tags: { operation: 'cancelSupersededReviewsForPR' },
       extra: { repoFullName, prNumber, excludeSha },
     });
     throw error;

--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
@@ -32,6 +32,7 @@ import {
 } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import { tryDispatchPendingReviews } from './dispatch-pending-reviews';
+import { cancelSupersededReviewsForPR } from '../db/code-reviews';
 
 const REPO = `test-org/dispatch-pending-${Date.now()}`;
 const FUNDED_BALANCE_MICRODOLLARS = 5_000_001;
@@ -374,6 +375,49 @@ describe('tryDispatchPendingReviews', () => {
       activeCount: 20,
     });
     expect(mockDispatchReview).not.toHaveBeenCalled();
+  });
+
+  it('does not claim a review that was cancelled as superseded before dispatch', async () => {
+    const recentTimestamp = minutesAgo(1);
+    const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
+
+    await db.insert(cloud_agent_code_reviews).values({
+      ...reviewValues({
+        owner,
+        status: 'pending',
+        createdAt: recentTimestamp,
+        updatedAt: recentTimestamp,
+      }),
+      pr_number: 99,
+      head_sha: 'sha-old',
+    });
+
+    await cancelSupersededReviewsForPR(REPO, 99, 'sha-new');
+
+    const result = await tryDispatchPendingReviews({
+      type: 'user',
+      id: testUser.id,
+      userId: testUser.id,
+    });
+
+    expect(result).toEqual({
+      dispatched: 0,
+      pending: 0,
+      activeCount: 0,
+    });
+    expect(mockDispatchReview).not.toHaveBeenCalled();
+
+    const [review] = await db
+      .select({
+        status: cloud_agent_code_reviews.status,
+        terminalReason: cloud_agent_code_reviews.terminal_reason,
+      })
+      .from(cloud_agent_code_reviews)
+      .where(eq(cloud_agent_code_reviews.pr_number, 99))
+      .limit(1);
+
+    expect(review?.status).toBe('cancelled');
+    expect(review?.terminalReason).toBe('superseded');
   });
 
   it('does not count stale queued reviews against owner capacity', async () => {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
@@ -4,6 +4,7 @@ const mockCreateCheckRun = jest.fn();
 const mockUpdateCheckRun = jest.fn();
 const mockUpdateCheckRunId = jest.fn();
 const mockCreateCodeReview = jest.fn();
+const mockCancelSupersededReviewsForPR = jest.fn();
 const mockFindExistingReview = jest.fn();
 const mockFindActiveReviewsForPR = jest.fn();
 const mockUpdateReviewHeadShaAndCheckRun = jest.fn();
@@ -24,6 +25,7 @@ jest.mock('@/lib/agent-config/db/agent-configs', () => ({
 
 jest.mock('@/lib/code-reviews/db/code-reviews', () => ({
   createCodeReview: (...args: unknown[]) => mockCreateCodeReview(...args),
+  cancelSupersededReviewsForPR: (...args: unknown[]) => mockCancelSupersededReviewsForPR(...args),
   findExistingReview: (...args: unknown[]) => mockFindExistingReview(...args),
   findActiveReviewsForPR: (...args: unknown[]) => mockFindActiveReviewsForPR(...args),
   updateReviewHeadShaAndCheckRun: (...args: unknown[]) =>
@@ -100,6 +102,7 @@ beforeEach(() => {
   mockUpdateCheckRun.mockResolvedValue(undefined);
   mockUpdateCheckRunId.mockResolvedValue(undefined);
   mockCreateCodeReview.mockResolvedValue('review-1');
+  mockCancelSupersededReviewsForPR.mockResolvedValue([]);
   mockFindExistingReview.mockResolvedValue(null);
   mockFindActiveReviewsForPR.mockResolvedValue([]);
   mockUpdateReviewHeadShaAndCheckRun.mockResolvedValue(undefined);
@@ -269,6 +272,103 @@ describe('handlePullRequest', () => {
       { status: 'completed', conclusion: 'cancelled' },
       'standard'
     );
+  });
+
+  it('cancels superseded DB rows, interrupts queued/running only, and creates the new review', async () => {
+    mockGetBotUserId.mockResolvedValue('bot-user-1');
+    mockGetAgentConfigForOwner.mockResolvedValue({
+      is_enabled: true,
+      config: {},
+    });
+    mockCancelSupersededReviewsForPR.mockResolvedValue([
+      {
+        id: 'pending-review',
+        prevStatus: 'pending',
+        sessionId: null,
+        checkRunId: 101,
+        headSha: 'old-pending-sha',
+        platform: 'github',
+        platformProjectId: null,
+        platformIntegrationId: 'integration-1',
+      },
+      {
+        id: 'queued-review',
+        prevStatus: 'queued',
+        sessionId: 'session-queued',
+        checkRunId: 102,
+        headSha: 'old-queued-sha',
+        platform: 'github',
+        platformProjectId: null,
+        platformIntegrationId: 'integration-1',
+      },
+      {
+        id: 'running-review',
+        prevStatus: 'running',
+        sessionId: 'session-running',
+        checkRunId: null,
+        headSha: 'old-running-sha',
+        platform: 'github',
+        platformProjectId: null,
+        platformIntegrationId: 'integration-1',
+      },
+    ]);
+
+    const response = await handlePullRequest(pullRequestPayload(), platformIntegration());
+
+    expect(response.status).toBe(202);
+    expect(mockCancelSupersededReviewsForPR).toHaveBeenCalledWith('acme/widgets', 42, 'abc123');
+    expect(mockCancelReview).toHaveBeenCalledTimes(2);
+    expect(mockCancelReview).toHaveBeenNthCalledWith(1, 'queued-review', 'Superseded by new push');
+    expect(mockCancelReview).toHaveBeenNthCalledWith(2, 'running-review', 'Superseded by new push');
+    expect(mockUpdateCheckRun).toHaveBeenCalledWith(
+      '98765',
+      'acme',
+      'widgets',
+      101,
+      {
+        status: 'completed',
+        conclusion: 'cancelled',
+        output: {
+          title: 'Kilo Code Review superseded',
+          summary: 'A newer commit was pushed; this review was cancelled.',
+        },
+      },
+      'standard'
+    );
+    expect(mockUpdateCheckRun).toHaveBeenCalledWith(
+      '98765',
+      'acme',
+      'widgets',
+      102,
+      {
+        status: 'completed',
+        conclusion: 'cancelled',
+        output: {
+          title: 'Kilo Code Review superseded',
+          summary: 'A newer commit was pushed; this review was cancelled.',
+        },
+      },
+      'standard'
+    );
+    expect(mockCreateCodeReview).toHaveBeenCalledTimes(1);
+    expect(mockTryDispatchPendingReviews).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips supersession cancel on merge-commit synchronize events', async () => {
+    mockGetBotUserId.mockResolvedValue('bot-user-1');
+    mockGetAgentConfigForOwner.mockResolvedValue({
+      is_enabled: true,
+      config: {},
+    });
+    mockFindActiveReviewsForPR.mockResolvedValue(['review-1']);
+    mockIsMergeCommit.mockResolvedValue(true);
+
+    const response = await handlePullRequest(pullRequestPayload(), platformIntegration());
+
+    expect(response.status).toBe(200);
+    expect(mockCancelSupersededReviewsForPR).not.toHaveBeenCalled();
+    expect(mockCancelReview).not.toHaveBeenCalled();
+    expect(mockCreateCodeReview).not.toHaveBeenCalled();
   });
 
   it('passes the integration GitHub app type when cancelling an orphaned merge-commit check run', async () => {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
-import { captureException } from '@sentry/nextjs';
+import { addBreadcrumb, captureException } from '@sentry/nextjs';
 import type { PullRequestPayload } from '../webhook-schemas';
 import { GITHUB_ACTION } from '@/lib/integrations/core/constants';
 import { logExceptInTest } from '@/lib/utils.server';
 import {
   createCodeReview,
+  cancelSupersededReviewsForPR,
   findExistingReview,
   findActiveReviewsForPR,
   updateReviewHeadShaAndCheckRun,
@@ -198,25 +199,78 @@ export async function handlePullRequestCodeReview(
 
     // 5. Cancel any existing reviews for this PR (different SHA)
     // This prevents spam when user pushes multiple commits quickly
-    const oldReviewIds = await findActiveReviewsForPR(
+    const cancelledReviews = await cancelSupersededReviewsForPR(
       repository.full_name,
       pull_request.number,
       pull_request.head.sha
     );
 
-    if (oldReviewIds.length > 0) {
+    if (cancelledReviews.length > 0) {
+      const cancellationCounts = {
+        pending: cancelledReviews.filter(review => review.prevStatus === 'pending').length,
+        queued: cancelledReviews.filter(review => review.prevStatus === 'queued').length,
+        running: cancelledReviews.filter(review => review.prevStatus === 'running').length,
+      };
+
       logExceptInTest(
-        `Cancelling ${oldReviewIds.length} old review(s) for ${repository.full_name}#${pull_request.number}`
+        `Cancelled ${cancelledReviews.length} superseded review(s) for ${repository.full_name}#${pull_request.number}`,
+        cancellationCounts
       );
 
-      // Cancel each review via the orchestrator (fire-and-forget, don't block new review)
       await Promise.allSettled(
-        oldReviewIds.map(reviewId =>
-          codeReviewWorkerClient.cancelReview(reviewId, 'Superseded by new push').catch(err => {
-            logExceptInTest(`Failed to cancel review ${reviewId}:`, err);
-            return { success: false, reviewId };
+        cancelledReviews
+          .filter(review => review.prevStatus !== 'pending')
+          .map(async review => {
+            try {
+              const response = await codeReviewWorkerClient.cancelReview(
+                review.id,
+                'Superseded by new push'
+              );
+
+              if (!response.success) {
+                addBreadcrumb({
+                  category: 'code-review.cancel',
+                  level: 'info',
+                  message: 'Worker cancel returned success=false for superseded review',
+                  data: {
+                    reviewId: review.id,
+                    prevStatus: review.prevStatus,
+                    repo: repository.full_name,
+                    prNumber: pull_request.number,
+                  },
+                });
+              }
+            } catch (error) {
+              logExceptInTest(`Failed to interrupt review ${review.id}:`, error);
+            }
           })
-        )
+      );
+
+      const [repoOwner, repoName] = repository.full_name.split('/');
+      await Promise.allSettled(
+        cancelledReviews
+          .filter(review => review.checkRunId != null && review.platform === 'github')
+          .map(async review => {
+            try {
+              await updateCheckRun(
+                integration.platform_installation_id as string,
+                repoOwner,
+                repoName,
+                review.checkRunId as number,
+                {
+                  status: 'completed',
+                  conclusion: 'cancelled',
+                  output: {
+                    title: 'Kilo Code Review superseded',
+                    summary: 'A newer commit was pushed; this review was cancelled.',
+                  },
+                },
+                appType
+              );
+            } catch (error) {
+              logExceptInTest(`Failed to cancel old check run ${review.checkRunId}:`, error);
+            }
+          })
       );
     }
 

--- a/apps/web/src/lib/integrations/platforms/gitlab/webhook-handlers/merge-request-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/webhook-handlers/merge-request-handler.test.ts
@@ -1,4 +1,142 @@
-import { shouldSkipUpdateForMergeCommit } from '@/lib/integrations/platforms/gitlab/webhook-handlers/merge-request-handler';
+const mockGetBotUserId = jest.fn();
+const mockGetAgentConfigForOwner = jest.fn();
+const mockCreateCodeReview = jest.fn();
+const mockCancelSupersededReviewsForPR = jest.fn();
+const mockFindExistingReview = jest.fn();
+const mockFindActiveReviewsForPR = jest.fn();
+const mockUpdateReviewHeadShaAndCheckRun = jest.fn();
+const mockTryDispatchPendingReviews = jest.fn();
+const mockCancelReview = jest.fn();
+const mockAddReactionToMR = jest.fn();
+const mockSetCommitStatus = jest.fn();
+const mockIsMergeCommit = jest.fn();
+const mockGetIntegrationById = jest.fn();
+const mockGetOrCreateProjectAccessToken = jest.fn();
+const mockGetValidGitLabToken = jest.fn();
+
+jest.mock('@/lib/bot-users/bot-user-service', () => ({
+  getBotUserId: (...args: unknown[]) => mockGetBotUserId(...args),
+}));
+
+jest.mock('@/lib/agent-config/db/agent-configs', () => ({
+  getAgentConfigForOwner: (...args: unknown[]) => mockGetAgentConfigForOwner(...args),
+}));
+
+jest.mock('@/lib/code-reviews/db/code-reviews', () => ({
+  createCodeReview: (...args: unknown[]) => mockCreateCodeReview(...args),
+  cancelSupersededReviewsForPR: (...args: unknown[]) => mockCancelSupersededReviewsForPR(...args),
+  findExistingReview: (...args: unknown[]) => mockFindExistingReview(...args),
+  findActiveReviewsForPR: (...args: unknown[]) => mockFindActiveReviewsForPR(...args),
+  updateReviewHeadShaAndCheckRun: (...args: unknown[]) =>
+    mockUpdateReviewHeadShaAndCheckRun(...args),
+}));
+
+jest.mock('@/lib/code-reviews/dispatch/dispatch-pending-reviews', () => ({
+  tryDispatchPendingReviews: (...args: unknown[]) => mockTryDispatchPendingReviews(...args),
+}));
+
+jest.mock('@/lib/code-reviews/client/code-review-worker-client', () => ({
+  codeReviewWorkerClient: {
+    cancelReview: (...args: unknown[]) => mockCancelReview(...args),
+  },
+}));
+
+jest.mock('@/lib/integrations/platforms/gitlab/adapter', () => ({
+  addReactionToMR: (...args: unknown[]) => mockAddReactionToMR(...args),
+  isMergeCommit: (...args: unknown[]) => mockIsMergeCommit(...args),
+  setCommitStatus: (...args: unknown[]) => mockSetCommitStatus(...args),
+}));
+
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  getIntegrationById: (...args: unknown[]) => mockGetIntegrationById(...args),
+}));
+
+jest.mock('@/lib/integrations/gitlab-service', () => ({
+  getOrCreateProjectAccessToken: (...args: unknown[]) => mockGetOrCreateProjectAccessToken(...args),
+  getValidGitLabToken: (...args: unknown[]) => mockGetValidGitLabToken(...args),
+}));
+
+import {
+  handleMergeRequestCodeReview,
+  shouldSkipUpdateForMergeCommit,
+} from '@/lib/integrations/platforms/gitlab/webhook-handlers/merge-request-handler';
+import type { MergeRequestPayload } from '@/lib/integrations/platforms/gitlab/webhook-schemas';
+import type { PlatformIntegration } from '@kilocode/db/schema';
+
+function mergeRequestPayload(overrides: Partial<MergeRequestPayload> = {}): MergeRequestPayload {
+  return {
+    object_kind: 'merge_request',
+    user: { id: 1, username: 'alice', name: 'Alice' },
+    project: {
+      id: 123,
+      path_with_namespace: 'acme/widgets',
+      web_url: 'https://gitlab.com/acme/widgets',
+      default_branch: 'main',
+      namespace: 'acme',
+      path: 'widgets',
+      name: 'widgets',
+      description: null,
+      avatar_url: null,
+      git_ssh_url: 'git@gitlab.com:acme/widgets.git',
+      git_http_url: 'https://gitlab.com/acme/widgets.git',
+      visibility_level: 20,
+      homepage: 'https://gitlab.com/acme/widgets',
+      url: 'git@gitlab.com:acme/widgets.git',
+      ssh_url: 'git@gitlab.com:acme/widgets.git',
+      http_url: 'https://gitlab.com/acme/widgets.git',
+    },
+    object_attributes: {
+      id: 456,
+      iid: 42,
+      title: 'Add widgets',
+      action: 'update',
+      url: 'https://gitlab.com/acme/widgets/-/merge_requests/42',
+      source_branch: 'feature/widgets',
+      target_branch: 'main',
+      source_project_id: 123,
+      target_project_id: 123,
+      state: 'opened',
+      draft: false,
+      work_in_progress: false,
+      last_commit: { id: 'abc123', message: 'Add widgets' },
+    },
+    ...overrides,
+  } as MergeRequestPayload;
+}
+
+function platformIntegration(overrides: Partial<PlatformIntegration> = {}): PlatformIntegration {
+  return {
+    id: '8b2ff443-8396-4b07-99ae-7015789da7dd',
+    owned_by_organization_id: 'f2aa36d7-9c1b-4db9-ae4a-a4492618796d',
+    owned_by_user_id: null,
+    kilo_requester_user_id: null,
+    platform_installation_id: '98765',
+    metadata: { gitlab_instance_url: 'https://gitlab.example.com' },
+    ...overrides,
+  } as PlatformIntegration;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetBotUserId.mockResolvedValue(null);
+  mockGetAgentConfigForOwner.mockResolvedValue(null);
+  mockCreateCodeReview.mockResolvedValue('review-1');
+  mockCancelSupersededReviewsForPR.mockResolvedValue([]);
+  mockFindExistingReview.mockResolvedValue(null);
+  mockFindActiveReviewsForPR.mockResolvedValue([]);
+  mockUpdateReviewHeadShaAndCheckRun.mockResolvedValue(undefined);
+  mockTryDispatchPendingReviews.mockResolvedValue({ dispatched: 0, pending: 1, activeCount: 0 });
+  mockCancelReview.mockResolvedValue({ success: true, reviewId: 'old-review' });
+  mockAddReactionToMR.mockResolvedValue(undefined);
+  mockSetCommitStatus.mockResolvedValue(undefined);
+  mockIsMergeCommit.mockResolvedValue(false);
+  mockGetIntegrationById.mockResolvedValue({
+    id: '8b2ff443-8396-4b07-99ae-7015789da7dd',
+    metadata: { gitlab_instance_url: 'https://gitlab.example.com' },
+  });
+  mockGetOrCreateProjectAccessToken.mockResolvedValue('prat-token');
+  mockGetValidGitLabToken.mockResolvedValue('gitlab-token');
+});
 
 describe('shouldSkipUpdateForMergeCommit', () => {
   it('returns false for non-update actions without calling the check', async () => {
@@ -45,5 +183,104 @@ describe('shouldSkipUpdateForMergeCommit', () => {
     });
 
     expect(result).toBe(false);
+  });
+});
+
+describe('handleMergeRequestCodeReview', () => {
+  it('cancels superseded DB rows, interrupts queued/running only, and creates the new review', async () => {
+    mockGetBotUserId.mockResolvedValue('bot-user-1');
+    mockGetAgentConfigForOwner.mockResolvedValue({
+      is_enabled: true,
+      config: {},
+    });
+    mockCancelSupersededReviewsForPR.mockResolvedValue([
+      {
+        id: 'pending-review',
+        prevStatus: 'pending',
+        sessionId: null,
+        checkRunId: null,
+        headSha: 'old-pending-sha',
+        platform: 'gitlab',
+        platformProjectId: 123,
+        platformIntegrationId: 'integration-1',
+      },
+      {
+        id: 'queued-review',
+        prevStatus: 'queued',
+        sessionId: 'session-queued',
+        checkRunId: null,
+        headSha: 'old-queued-sha',
+        platform: 'gitlab',
+        platformProjectId: 123,
+        platformIntegrationId: 'integration-1',
+      },
+      {
+        id: 'running-review',
+        prevStatus: 'running',
+        sessionId: 'session-running',
+        checkRunId: null,
+        headSha: 'old-running-sha',
+        platform: 'gitlab',
+        platformProjectId: 123,
+        platformIntegrationId: 'integration-1',
+      },
+    ]);
+
+    const response = await handleMergeRequestCodeReview(
+      mergeRequestPayload(),
+      platformIntegration()
+    );
+
+    expect(response.status).toBe(202);
+    expect(mockCancelSupersededReviewsForPR).toHaveBeenCalledWith('acme/widgets', 42, 'abc123');
+    expect(mockCancelReview).toHaveBeenCalledTimes(2);
+    expect(mockCancelReview).toHaveBeenNthCalledWith(1, 'queued-review', 'Superseded by new push');
+    expect(mockCancelReview).toHaveBeenNthCalledWith(2, 'running-review', 'Superseded by new push');
+    expect(mockSetCommitStatus).toHaveBeenCalledWith(
+      'prat-token',
+      123,
+      'old-pending-sha',
+      'canceled',
+      { description: 'Superseded by new push' },
+      'https://gitlab.example.com'
+    );
+    expect(mockSetCommitStatus).toHaveBeenCalledWith(
+      'prat-token',
+      123,
+      'old-queued-sha',
+      'canceled',
+      { description: 'Superseded by new push' },
+      'https://gitlab.example.com'
+    );
+    expect(mockSetCommitStatus).toHaveBeenCalledWith(
+      'prat-token',
+      123,
+      'old-running-sha',
+      'canceled',
+      { description: 'Superseded by new push' },
+      'https://gitlab.example.com'
+    );
+    expect(mockCreateCodeReview).toHaveBeenCalledTimes(1);
+    expect(mockTryDispatchPendingReviews).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips supersession cancel on merge-commit update events', async () => {
+    mockGetBotUserId.mockResolvedValue('bot-user-1');
+    mockGetAgentConfigForOwner.mockResolvedValue({
+      is_enabled: true,
+      config: {},
+    });
+    mockFindActiveReviewsForPR.mockResolvedValue(['review-1']);
+    mockIsMergeCommit.mockResolvedValue(true);
+
+    const response = await handleMergeRequestCodeReview(
+      mergeRequestPayload(),
+      platformIntegration()
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockCancelSupersededReviewsForPR).not.toHaveBeenCalled();
+    expect(mockCancelReview).not.toHaveBeenCalled();
+    expect(mockCreateCodeReview).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/integrations/platforms/gitlab/webhook-handlers/merge-request-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/webhook-handlers/merge-request-handler.ts
@@ -8,12 +8,13 @@
  */
 
 import { NextResponse } from 'next/server';
-import { captureException } from '@sentry/nextjs';
+import { addBreadcrumb, captureException } from '@sentry/nextjs';
 import type { MergeRequestPayload } from '../webhook-schemas';
 import { GITLAB_ACTION, PLATFORM } from '@/lib/integrations/core/constants';
 import { logExceptInTest } from '@/lib/utils.server';
 import {
   createCodeReview,
+  cancelSupersededReviewsForPR,
   findExistingReview,
   findActiveReviewsForPR,
   updateReviewHeadShaAndCheckRun,
@@ -198,25 +199,97 @@ export async function handleMergeRequestCodeReview(
 
     // 5. Cancel any existing reviews for this MR (different SHA)
     // This prevents spam when user pushes multiple commits quickly
-    const oldReviewIds = await findActiveReviewsForPR(project.path_with_namespace, mr.iid, headSha);
+    const cancelledReviews = await cancelSupersededReviewsForPR(
+      project.path_with_namespace,
+      mr.iid,
+      headSha
+    );
 
-    if (oldReviewIds.length > 0) {
+    if (cancelledReviews.length > 0) {
+      const cancellationCounts = {
+        pending: cancelledReviews.filter(review => review.prevStatus === 'pending').length,
+        queued: cancelledReviews.filter(review => review.prevStatus === 'queued').length,
+        running: cancelledReviews.filter(review => review.prevStatus === 'running').length,
+      };
+
       logExceptInTest(
-        `Cancelling ${oldReviewIds.length} old review(s) for ${project.path_with_namespace}!${mr.iid}`
+        `Cancelled ${cancelledReviews.length} superseded review(s) for ${project.path_with_namespace}!${mr.iid}`,
+        cancellationCounts
       );
 
-      // Cancel each review via the orchestrator (fire-and-forget, don't block new review)
       await Promise.allSettled(
-        oldReviewIds.map(reviewId =>
-          codeReviewWorkerClient.cancelReview(reviewId, 'Superseded by new push').catch(err => {
-            logExceptInTest(`Failed to cancel review ${reviewId}:`, err);
-            return { success: false, reviewId };
+        cancelledReviews
+          .filter(review => review.prevStatus !== 'pending')
+          .map(async review => {
+            try {
+              const response = await codeReviewWorkerClient.cancelReview(
+                review.id,
+                'Superseded by new push'
+              );
+
+              if (!response.success) {
+                addBreadcrumb({
+                  category: 'code-review.cancel',
+                  level: 'info',
+                  message: 'Worker cancel returned success=false for superseded review',
+                  data: {
+                    reviewId: review.id,
+                    prevStatus: review.prevStatus,
+                    repo: project.path_with_namespace,
+                    prNumber: mr.iid,
+                  },
+                });
+              }
+            } catch (error) {
+              logExceptInTest(`Failed to interrupt review ${review.id}:`, error);
+            }
           })
-        )
       );
     }
 
-    // 6. Check for duplicate review (same project, MR, SHA)
+    // 6. Get integration details needed for best-effort GitLab status cleanup.
+    // This must run before duplicate-review return so redeliveries still clean up
+    // stale statuses on superseded SHAs even when the new review already exists.
+    const fullIntegration = await getIntegrationById(integration.id);
+    const metadata = fullIntegration?.metadata as {
+      gitlab_instance_url?: string;
+    } | null;
+    const instanceUrl = metadata?.gitlab_instance_url || 'https://gitlab.com';
+
+    if (cancelledReviews.length > 0 && fullIntegration) {
+      await Promise.allSettled(
+        cancelledReviews
+          .filter(
+            review =>
+              review.platform === 'gitlab' &&
+              review.platformProjectId != null &&
+              review.headSha.length > 0
+          )
+          .map(async review => {
+            try {
+              const pratToken = await getOrCreateProjectAccessToken(
+                fullIntegration,
+                review.platformProjectId as number
+              );
+              await setCommitStatus(
+                pratToken,
+                review.platformProjectId as number,
+                review.headSha,
+                'canceled',
+                { description: 'Superseded by new push' },
+                instanceUrl
+              );
+            } catch (error) {
+              logExceptInTest(
+                `Failed to cancel old commit status for ${review.headSha} on project ${review.platformProjectId}:`,
+                error
+              );
+            }
+          })
+      );
+    }
+
+    // 7. Check for duplicate review (same project, MR, SHA)
     const existingReview = await findExistingReview(project.path_with_namespace, mr.iid, headSha);
 
     if (existingReview) {
@@ -233,10 +306,10 @@ export async function handleMergeRequestCodeReview(
       );
     }
 
-    // 7. Resolve checkout ref (fork MRs use refs/merge-requests/<iid>/head)
+    // 8. Resolve checkout ref (fork MRs use refs/merge-requests/<iid>/head)
     const { checkoutRef } = resolveMergeRequestCheckoutRef(payload);
 
-    // 8. Create review record (session_id will be updated async)
+    // 9. Create review record (session_id will be updated async)
     const reviewId = await createCodeReview({
       owner,
       platformIntegrationId: integration.id,
@@ -253,14 +326,6 @@ export async function handleMergeRequestCodeReview(
     });
 
     logExceptInTest(`Created code review ${reviewId} for ${project.path_with_namespace}!${mr.iid}`);
-
-    // 9. Get or create Project Access Token (PrAT) for bot identity
-    // This is also used later in prepare-review-payload.ts for the actual review
-    const fullIntegration = await getIntegrationById(integration.id);
-    const metadata = fullIntegration?.metadata as {
-      gitlab_instance_url?: string;
-    } | null;
-    const instanceUrl = metadata?.gitlab_instance_url || 'https://gitlab.com';
 
     // 10. Post 👀 reaction and set commit status (using PrAT for bot identity)
     if (fullIntegration) {


### PR DESCRIPTION
## Summary

- cancel superseded code reviews in the database before worker cleanup so pending reviews cannot run after a newer commit lands
- keep best-effort worker interruption and old GitHub and GitLab gate cleanup for queued or running superseded reviews
- add regression coverage for DB cancellation, webhook handling, merge-commit preservation, and the dispatch race

## Verification

- Ran `pnpm --filter web test -- src/lib/code-reviews/db/code-reviews.test.ts src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts src/lib/integrations/platforms/gitlab/webhook-handlers/merge-request-handler.test.ts`
- Ran `pnpm --filter web typecheck`
- Ran `pnpm format`

## Visual Changes

- N/A

## Reviewer Notes

- GitLab superseded status cleanup now runs before duplicate-review early return so webhook redeliveries still clear stale statuses on old SHAs