### PR TITLE
fix(session-ingest): persist session attribution metadata at bootstrap

### DIFF
--- a/services/session-ingest/src/dos/SessionIngestDO.ts
+++ b/services/session-ingest/src/dos/SessionIngestDO.ts
@@ -102,6 +102,7 @@ export class SessionIngestDO extends DurableObject<Env> {
     r2References?: Record<string, string>
   ): Promise<{
     changes: Changes;
+    extracted: Changes;
   }> {
     const deletedRow = this.db
       .select({ value: ingestMeta.value })
@@ -116,7 +117,7 @@ export class SessionIngestDO extends DurableObject<Env> {
           await this.env.SESSION_INGEST_R2.delete(keys);
         }
       }
-      return { changes: [] };
+      return { changes: [], extracted: [] };
     }
 
     writeIngestMetaIfChanged(this.db, { key: 'kiloUserId', incomingValue: kiloUserId });
@@ -211,10 +212,12 @@ export class SessionIngestDO extends DurableObject<Env> {
     }
 
     const changes: Changes = [];
+    const extracted: Changes = [];
 
     for (const key of Object.keys(incomingByKey) as ExtractableMetaKey[]) {
       const incoming = incomingByKey[key];
       if (incoming === undefined) continue;
+      extracted.push({ name: key, value: incoming });
       const meta = writeIngestMetaIfChanged(this.db, {
         key,
         incomingValue: incoming,
@@ -251,6 +254,7 @@ export class SessionIngestDO extends DurableObject<Env> {
 
     return {
       changes,
+      extracted,
     };
   }
 

--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { getWorkerDb } from '@kilocode/db/client';
 
 // Mock cloudflare:workers before any imports that might pull in DO code
 vi.mock('cloudflare:workers', () => ({
@@ -33,28 +32,9 @@ vi.mock('./util/ingest-limits', () => ({
   MAX_SINGLE_ITEM_BYTES: 50,
 }));
 
-import {
-  createItemExtractor,
-  computeSessionMetadataUpdates,
-  resolveSafeParentSessionId,
-} from './queue-consumer';
+import { createItemExtractor, computeSessionMetadataUpdates } from './queue-consumer';
 
 const encoder = new TextEncoder();
-type WorkerDb = ReturnType<typeof getWorkerDb>;
-
-function makeParentLookupDb(selectResult: ReturnType<typeof vi.fn>) {
-  const select = {
-    from: vi.fn(() => select),
-    where: vi.fn(() => select),
-    limit: vi.fn(() => select),
-    then: vi.fn((resolve: (v: unknown) => unknown) => resolve(selectResult())),
-  };
-
-  return {
-    db: { select: vi.fn(() => select) },
-    selectResult,
-  };
-}
 
 function feedAll(extractor: ReturnType<typeof createItemExtractor>, json: string) {
   extractor.tokenizer.write(encoder.encode(json));
@@ -206,43 +186,5 @@ describe('computeSessionMetadataUpdates', () => {
   it('ignores a null "platform" change (creation value stays sticky)', () => {
     const updates = computeSessionMetadataUpdates(new Map([['platform', null]]), fixedNow);
     expect('created_on_platform' in updates).toBe(false);
-  });
-});
-
-describe('resolveSafeParentSessionId', () => {
-  it('waits for a shortly delayed same-user parent row', async () => {
-    const selectResult = vi
-      .fn()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ session_id: 'ses_parent12345678901234567890' }]);
-    const { db } = makeParentLookupDb(selectResult);
-
-    await expect(
-      resolveSafeParentSessionId(
-        db as unknown as WorkerDb,
-        'usr_test',
-        'ses_child123456789012345678901',
-        'ses_parent12345678901234567890',
-        { attempts: 2, delayMs: 0 }
-      )
-    ).resolves.toBe('ses_parent12345678901234567890');
-    expect(selectResult).toHaveBeenCalledTimes(2);
-  });
-
-  it('rejects self-parenting without querying Postgres', async () => {
-    const selectResult = vi
-      .fn()
-      .mockResolvedValue([{ session_id: 'ses_12345678901234567890123456' }]);
-    const { db } = makeParentLookupDb(selectResult);
-
-    await expect(
-      resolveSafeParentSessionId(
-        db as unknown as WorkerDb,
-        'usr_test',
-        'ses_12345678901234567890123456',
-        'ses_12345678901234567890123456'
-      )
-    ).resolves.toBeNull();
-    expect(selectResult).not.toHaveBeenCalled();
   });
 });

--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import type { getWorkerDb } from '@kilocode/db/client';
 
 // Mock cloudflare:workers before any imports that might pull in DO code
 vi.mock('cloudflare:workers', () => ({
@@ -32,9 +33,28 @@ vi.mock('./util/ingest-limits', () => ({
   MAX_SINGLE_ITEM_BYTES: 50,
 }));
 
-import { createItemExtractor, computeSessionMetadataUpdates } from './queue-consumer';
+import {
+  createItemExtractor,
+  computeSessionMetadataUpdates,
+  resolveSafeParentSessionId,
+} from './queue-consumer';
 
 const encoder = new TextEncoder();
+type WorkerDb = ReturnType<typeof getWorkerDb>;
+
+function makeParentLookupDb(selectResult: ReturnType<typeof vi.fn>) {
+  const select = {
+    from: vi.fn(() => select),
+    where: vi.fn(() => select),
+    limit: vi.fn(() => select),
+    then: vi.fn((resolve: (v: unknown) => unknown) => resolve(selectResult())),
+  };
+
+  return {
+    db: { select: vi.fn(() => select) },
+    selectResult,
+  };
+}
 
 function feedAll(extractor: ReturnType<typeof createItemExtractor>, json: string) {
   extractor.tokenizer.write(encoder.encode(json));
@@ -186,5 +206,43 @@ describe('computeSessionMetadataUpdates', () => {
   it('ignores a null "platform" change (creation value stays sticky)', () => {
     const updates = computeSessionMetadataUpdates(new Map([['platform', null]]), fixedNow);
     expect('created_on_platform' in updates).toBe(false);
+  });
+});
+
+describe('resolveSafeParentSessionId', () => {
+  it('waits for a shortly delayed same-user parent row', async () => {
+    const selectResult = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ session_id: 'ses_parent12345678901234567890' }]);
+    const { db } = makeParentLookupDb(selectResult);
+
+    await expect(
+      resolveSafeParentSessionId(
+        db as unknown as WorkerDb,
+        'usr_test',
+        'ses_child123456789012345678901',
+        'ses_parent12345678901234567890',
+        { attempts: 2, delayMs: 0 }
+      )
+    ).resolves.toBe('ses_parent12345678901234567890');
+    expect(selectResult).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects self-parenting without querying Postgres', async () => {
+    const selectResult = vi
+      .fn()
+      .mockResolvedValue([{ session_id: 'ses_12345678901234567890123456' }]);
+    const { db } = makeParentLookupDb(selectResult);
+
+    await expect(
+      resolveSafeParentSessionId(
+        db as unknown as WorkerDb,
+        'usr_test',
+        'ses_12345678901234567890123456',
+        'ses_12345678901234567890123456'
+      )
+    ).resolves.toBeNull();
+    expect(selectResult).not.toHaveBeenCalled();
   });
 });

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -9,9 +9,7 @@ import { getItemIdentity } from './util/compaction';
 import { MAX_INGEST_ITEM_BYTES, MAX_SINGLE_ITEM_BYTES } from './util/ingest-limits';
 import { getSessionIngestDO } from './dos/SessionIngestDO';
 import { withDORetry, normalizeGitUrl } from '@kilocode/worker-utils';
-
-const PARENT_SESSION_LOOKUP_ATTEMPTS = 3;
-const PARENT_SESSION_LOOKUP_DELAY_MS = 250;
+import { setSafeParentSessionId } from './services/session-parent';
 
 export type IngestQueueMessage = {
   r2Key: string;
@@ -266,6 +264,12 @@ async function processItem(
     'SessionIngestDO.ingest'
   );
 
+  for (const extracted of ingestResult.extracted) {
+    if (extracted.name === 'parentId') {
+      mergedChanges.set(extracted.name, extracted.value);
+    }
+  }
+
   for (const change of ingestResult.changes) {
     mergedChanges.set(change.name, change.value);
   }
@@ -323,49 +327,6 @@ export function computeSessionMetadataUpdates(
   return updates;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-async function parentSessionExists(
-  db: ReturnType<typeof getWorkerDb>,
-  kiloUserId: string,
-  parentSessionId: string
-): Promise<boolean> {
-  const parentRows = await db
-    .select({ session_id: cli_sessions_v2.session_id })
-    .from(cli_sessions_v2)
-    .where(
-      and(
-        eq(cli_sessions_v2.session_id, parentSessionId),
-        eq(cli_sessions_v2.kilo_user_id, kiloUserId)
-      )
-    )
-    .limit(1);
-
-  return Boolean(parentRows[0]);
-}
-
-export async function resolveSafeParentSessionId(
-  db: ReturnType<typeof getWorkerDb>,
-  kiloUserId: string,
-  sessionId: string,
-  parentSessionId: string,
-  options: { attempts?: number; delayMs?: number } = {}
-): Promise<string | null> {
-  if (parentSessionId === sessionId) return null;
-
-  const attempts = options.attempts ?? PARENT_SESSION_LOOKUP_ATTEMPTS;
-  const delayMs = options.delayMs ?? PARENT_SESSION_LOOKUP_DELAY_MS;
-
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    if (await parentSessionExists(db, kiloUserId, parentSessionId)) return parentSessionId;
-    if (attempt < attempts && delayMs > 0) await sleep(delayMs);
-  }
-
-  return null;
-}
-
 async function applyMetadataChanges(
   env: Env,
   kiloUserId: string,
@@ -391,25 +352,7 @@ async function applyMetadataChanges(
     : undefined;
   if (parentSessionId !== undefined) {
     if (parentSessionId && parentSessionId !== sessionId) {
-      const safeParentSessionId = await resolveSafeParentSessionId(
-        db,
-        kiloUserId,
-        sessionId,
-        parentSessionId
-      );
-
-      if (safeParentSessionId) {
-        await db
-          .update(cli_sessions_v2)
-          .set({ parent_session_id: safeParentSessionId })
-          .where(
-            and(
-              eq(cli_sessions_v2.session_id, sessionId),
-              eq(cli_sessions_v2.kilo_user_id, kiloUserId),
-              sql`${cli_sessions_v2.parent_session_id} IS DISTINCT FROM ${safeParentSessionId}`
-            )
-          );
-      }
+      await setSafeParentSessionId(db, kiloUserId, sessionId, parentSessionId);
     } else if (parentSessionId === null) {
       await db
         .update(cli_sessions_v2)

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -10,13 +10,16 @@ import { MAX_INGEST_ITEM_BYTES, MAX_SINGLE_ITEM_BYTES } from './util/ingest-limi
 import { getSessionIngestDO } from './dos/SessionIngestDO';
 import { withDORetry, normalizeGitUrl } from '@kilocode/worker-utils';
 
-export interface IngestQueueMessage {
+const PARENT_SESSION_LOOKUP_ATTEMPTS = 3;
+const PARENT_SESSION_LOOKUP_DELAY_MS = 250;
+
+export type IngestQueueMessage = {
   r2Key: string;
   kiloUserId: string;
   sessionId: string;
   ingestVersion: number;
   ingestedAt: number;
-}
+};
 
 /**
  * Creates a streaming item extractor that uses a low-level Tokenizer to parse
@@ -320,6 +323,49 @@ export function computeSessionMetadataUpdates(
   return updates;
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function parentSessionExists(
+  db: ReturnType<typeof getWorkerDb>,
+  kiloUserId: string,
+  parentSessionId: string
+): Promise<boolean> {
+  const parentRows = await db
+    .select({ session_id: cli_sessions_v2.session_id })
+    .from(cli_sessions_v2)
+    .where(
+      and(
+        eq(cli_sessions_v2.session_id, parentSessionId),
+        eq(cli_sessions_v2.kilo_user_id, kiloUserId)
+      )
+    )
+    .limit(1);
+
+  return Boolean(parentRows[0]);
+}
+
+export async function resolveSafeParentSessionId(
+  db: ReturnType<typeof getWorkerDb>,
+  kiloUserId: string,
+  sessionId: string,
+  parentSessionId: string,
+  options: { attempts?: number; delayMs?: number } = {}
+): Promise<string | null> {
+  if (parentSessionId === sessionId) return null;
+
+  const attempts = options.attempts ?? PARENT_SESSION_LOOKUP_ATTEMPTS;
+  const delayMs = options.delayMs ?? PARENT_SESSION_LOOKUP_DELAY_MS;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (await parentSessionExists(db, kiloUserId, parentSessionId)) return parentSessionId;
+    if (attempt < attempts && delayMs > 0) await sleep(delayMs);
+  }
+
+  return null;
+}
+
 async function applyMetadataChanges(
   env: Env,
   kiloUserId: string,
@@ -345,26 +391,22 @@ async function applyMetadataChanges(
     : undefined;
   if (parentSessionId !== undefined) {
     if (parentSessionId && parentSessionId !== sessionId) {
-      const parentRows = await db
-        .select({ session_id: cli_sessions_v2.session_id })
-        .from(cli_sessions_v2)
-        .where(
-          and(
-            eq(cli_sessions_v2.session_id, parentSessionId),
-            eq(cli_sessions_v2.kilo_user_id, kiloUserId)
-          )
-        )
-        .limit(1);
+      const safeParentSessionId = await resolveSafeParentSessionId(
+        db,
+        kiloUserId,
+        sessionId,
+        parentSessionId
+      );
 
-      if (parentRows[0]) {
+      if (safeParentSessionId) {
         await db
           .update(cli_sessions_v2)
-          .set({ parent_session_id: parentSessionId })
+          .set({ parent_session_id: safeParentSessionId })
           .where(
             and(
               eq(cli_sessions_v2.session_id, sessionId),
               eq(cli_sessions_v2.kilo_user_id, kiloUserId),
-              sql`${cli_sessions_v2.parent_session_id} IS DISTINCT FROM ${parentSessionId}`
+              sql`${cli_sessions_v2.parent_session_id} IS DISTINCT FROM ${safeParentSessionId}`
             )
           );
       }

--- a/services/session-ingest/src/routes/api.test.ts
+++ b/services/session-ingest/src/routes/api.test.ts
@@ -73,7 +73,7 @@ function makeDbFakes() {
   };
 
   // Drizzle update chain: db.update(table).set({}).where().returning()
-  const updateResult = vi.fn<() => Promise<unknown>>(async () => undefined);
+  const updateResult = vi.fn<() => Promise<unknown>>(async () => []);
   const updateSet = vi.fn(() => update);
   const updateWhere = vi.fn(() => update);
   const updateReturning = vi.fn(() => update);
@@ -118,6 +118,8 @@ function makeDbFakes() {
     fns: {
       insert: insertFn,
       insertValues: insert.values,
+      insertOnConflictDoNothing: insert.onConflictDoNothing,
+      insertOnConflictDoUpdate: insert.onConflictDoUpdate,
       select: selectFn,
       update: updateFn,
       updateSet,
@@ -225,6 +227,7 @@ describe('api routes', () => {
 
     expect(res.status).toBe(200);
     expect(fns.insert).toHaveBeenCalled();
+    expect(fns.insertOnConflictDoNothing).toHaveBeenCalled();
     expect(sessionCache.add).toHaveBeenCalledWith('ses_12345678901234567890123456');
 
     const json = await res.json();
@@ -237,7 +240,7 @@ describe('api routes', () => {
   it('POST /session persists initial attribution metadata when the parent is safe', async () => {
     const { db, fns } = makeDbFakes();
     vi.mocked(getWorkerDb).mockReturnValue(db);
-    fns.selectResult.mockResolvedValueOnce([{ session_id: 'ses_parent12345678901234567890' }]);
+    fns.updateResult.mockResolvedValueOnce([{ session_id: 'ses_child123456789012345678901' }]);
 
     const sessionCache = {
       add: vi.fn(async () => undefined),
@@ -269,6 +272,16 @@ describe('api routes', () => {
       kilo_user_id: 'usr_test',
       title: 'Child run',
       created_on_platform: 'agent-manager',
+    });
+    expect(fns.insertOnConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: {
+          title: 'Child run',
+          created_on_platform: 'agent-manager',
+        },
+      })
+    );
+    expect(fns.updateSet).toHaveBeenCalledWith({
       parent_session_id: 'ses_parent12345678901234567890',
     });
   });
@@ -276,7 +289,6 @@ describe('api routes', () => {
   it('POST /session ignores unsafe parent metadata at bootstrap', async () => {
     const { db, fns } = makeDbFakes();
     vi.mocked(getWorkerDb).mockReturnValue(db);
-    fns.selectResult.mockResolvedValueOnce([]);
 
     const sessionCache = {
       add: vi.fn(async () => undefined),
@@ -307,6 +319,7 @@ describe('api routes', () => {
       kilo_user_id: 'usr_test',
       created_on_platform: 'vscode',
     });
+    expect(fns.updateResult).toHaveBeenCalledTimes(3);
   });
 
   it('POST /session rejects unknown bootstrap metadata fields', async () => {

--- a/services/session-ingest/src/routes/api.test.ts
+++ b/services/session-ingest/src/routes/api.test.ts
@@ -117,6 +117,7 @@ function makeDbFakes() {
     db,
     fns: {
       insert: insertFn,
+      insertValues: insert.values,
       select: selectFn,
       update: updateFn,
       updateSet,
@@ -231,6 +232,101 @@ describe('api routes', () => {
       id: 'ses_12345678901234567890123456',
       ingestPath: '/api/session/ses_12345678901234567890123456/ingest',
     });
+  });
+
+  it('POST /session persists initial attribution metadata when the parent is safe', async () => {
+    const { db, fns } = makeDbFakes();
+    vi.mocked(getWorkerDb).mockReturnValue(db);
+    fns.selectResult.mockResolvedValueOnce([{ session_id: 'ses_parent12345678901234567890' }]);
+
+    const sessionCache = {
+      add: vi.fn(async () => undefined),
+      has: vi.fn(async () => true),
+      remove: vi.fn(async () => undefined),
+    };
+    vi.mocked(getSessionAccessCacheDO).mockReturnValue(
+      sessionCache as unknown as ReturnType<typeof getSessionAccessCacheDO>
+    );
+
+    const app = makeApiApp();
+    const res = await app.fetch(
+      new Request('http://local/session', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          sessionId: 'ses_child123456789012345678901',
+          parentSessionId: 'ses_parent12345678901234567890',
+          createdOnPlatform: 'agent-manager',
+          title: '  Child run  ',
+        }),
+      }),
+      makeTestEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(fns.insertValues).toHaveBeenCalledWith({
+      session_id: 'ses_child123456789012345678901',
+      kilo_user_id: 'usr_test',
+      title: 'Child run',
+      created_on_platform: 'agent-manager',
+      parent_session_id: 'ses_parent12345678901234567890',
+    });
+  });
+
+  it('POST /session ignores unsafe parent metadata at bootstrap', async () => {
+    const { db, fns } = makeDbFakes();
+    vi.mocked(getWorkerDb).mockReturnValue(db);
+    fns.selectResult.mockResolvedValueOnce([]);
+
+    const sessionCache = {
+      add: vi.fn(async () => undefined),
+      has: vi.fn(async () => true),
+      remove: vi.fn(async () => undefined),
+    };
+    vi.mocked(getSessionAccessCacheDO).mockReturnValue(
+      sessionCache as unknown as ReturnType<typeof getSessionAccessCacheDO>
+    );
+
+    const app = makeApiApp();
+    const res = await app.fetch(
+      new Request('http://local/session', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          sessionId: 'ses_child123456789012345678901',
+          parentSessionId: 'ses_parent12345678901234567890',
+          createdOnPlatform: 'vscode',
+        }),
+      }),
+      makeTestEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(fns.insertValues).toHaveBeenCalledWith({
+      session_id: 'ses_child123456789012345678901',
+      kilo_user_id: 'usr_test',
+      created_on_platform: 'vscode',
+    });
+  });
+
+  it('POST /session rejects unknown bootstrap metadata fields', async () => {
+    const { db } = makeDbFakes();
+    vi.mocked(getWorkerDb).mockReturnValue(db);
+
+    const app = makeApiApp();
+    const res = await app.fetch(
+      new Request('http://local/session', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          sessionId: 'ses_12345678901234567890123456',
+          privateField: 'nope',
+        }),
+      }),
+      makeTestEnv()
+    );
+
+    expect(res.status).toBe(400);
   });
 
   it('POST /session/:sessionId/ingest streams to R2 and enqueues on cache hit', async () => {

--- a/services/session-ingest/src/routes/api.ts
+++ b/services/session-ingest/src/routes/api.ts
@@ -10,6 +10,7 @@ import { getSessionIngestDO } from '../dos/SessionIngestDO';
 import { getSessionAccessCacheDO } from '../dos/SessionAccessCacheDO';
 import { getUserConnectionDO } from '../dos/UserConnectionDO';
 import { getSessionExport } from '../services/session-export';
+import { setSafeParentSessionId } from '../services/session-parent';
 import type { IngestQueueMessage } from '../queue-consumer';
 
 export type ApiContext = {
@@ -33,39 +34,6 @@ const createSessionSchema = z
   .strict();
 
 const ingestVersionSchema = z.coerce.number().int().nonnegative().catch(0);
-const PARENT_SESSION_LOOKUP_ATTEMPTS = 3;
-const PARENT_SESSION_LOOKUP_DELAY_MS = 250;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-async function getSafeParentSessionId(
-  db: ReturnType<typeof getWorkerDb>,
-  kiloUserId: string,
-  sessionId: string,
-  parentSessionId: string | undefined
-): Promise<string | undefined> {
-  if (!parentSessionId || parentSessionId === sessionId) return undefined;
-
-  for (let attempt = 1; attempt <= PARENT_SESSION_LOOKUP_ATTEMPTS; attempt++) {
-    const parentRows = await db
-      .select({ session_id: cli_sessions_v2.session_id })
-      .from(cli_sessions_v2)
-      .where(
-        and(
-          eq(cli_sessions_v2.session_id, parentSessionId),
-          eq(cli_sessions_v2.kilo_user_id, kiloUserId)
-        )
-      )
-      .limit(1);
-
-    if (parentRows[0]) return parentSessionId;
-    if (attempt < PARENT_SESSION_LOOKUP_ATTEMPTS) await sleep(PARENT_SESSION_LOOKUP_DELAY_MS);
-  }
-
-  return undefined;
-}
 
 api.post('/session', zodJsonValidator(createSessionSchema), async c => {
   const body = c.req.valid('json');
@@ -73,27 +41,37 @@ api.post('/session', zodJsonValidator(createSessionSchema), async c => {
   // Persist a placeholder session row plus safe attribution metadata supplied at bootstrap.
   const db = getWorkerDb(c.env.HYPERDRIVE.connectionString);
   const kiloUserId = c.get('user_id');
-  const parentSessionId = await getSafeParentSessionId(
-    db,
-    kiloUserId,
-    body.sessionId,
-    body.parentSessionId
-  );
+  const sessionValues: typeof cli_sessions_v2.$inferInsert = {
+    session_id: body.sessionId,
+    kilo_user_id: kiloUserId,
+  };
+  const conflictUpdates: Partial<typeof cli_sessions_v2.$inferInsert> = {};
 
-  await db
-    .insert(cli_sessions_v2)
-    .values({
-      session_id: body.sessionId,
-      kilo_user_id: kiloUserId,
-      ...(body.title !== undefined ? { title: body.title === '' ? null : body.title } : {}),
-      ...(body.createdOnPlatform !== undefined
-        ? { created_on_platform: body.createdOnPlatform }
-        : {}),
-      ...(parentSessionId !== undefined ? { parent_session_id: parentSessionId } : {}),
-    })
-    .onConflictDoNothing({
+  if (body.title !== undefined) {
+    const title = body.title === '' ? null : body.title;
+    sessionValues.title = title;
+    conflictUpdates.title = title;
+  }
+  if (body.createdOnPlatform !== undefined) {
+    sessionValues.created_on_platform = body.createdOnPlatform;
+    conflictUpdates.created_on_platform = body.createdOnPlatform;
+  }
+
+  const insertQuery = db.insert(cli_sessions_v2).values(sessionValues);
+  if (Object.keys(conflictUpdates).length > 0) {
+    await insertQuery.onConflictDoUpdate({
+      target: [cli_sessions_v2.session_id, cli_sessions_v2.kilo_user_id],
+      set: conflictUpdates,
+    });
+  } else {
+    await insertQuery.onConflictDoNothing({
       target: [cli_sessions_v2.session_id, cli_sessions_v2.kilo_user_id],
     });
+  }
+
+  if (body.parentSessionId !== undefined) {
+    await setSafeParentSessionId(db, kiloUserId, body.sessionId, body.parentSessionId);
+  }
 
   // Warm the session cache so the first ingest can skip Postgres.
   await withDORetry(

--- a/services/session-ingest/src/routes/api.ts
+++ b/services/session-ingest/src/routes/api.ts
@@ -21,27 +21,75 @@ export type ApiContext = {
 
 export const api = new Hono<ApiContext>();
 
-const createSessionSchema = z.object({
-  sessionId: z.string().startsWith('ses_').length(30),
-});
-
 const sessionIdSchema = z.string().startsWith('ses_').length(30);
 
+const createSessionSchema = z
+  .object({
+    sessionId: sessionIdSchema,
+    title: z.string().trim().max(512).optional(),
+    parentSessionId: sessionIdSchema.optional(),
+    createdOnPlatform: z.string().trim().min(1).max(128).optional(),
+  })
+  .strict();
+
 const ingestVersionSchema = z.coerce.number().int().nonnegative().catch(0);
+const PARENT_SESSION_LOOKUP_ATTEMPTS = 3;
+const PARENT_SESSION_LOOKUP_DELAY_MS = 250;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function getSafeParentSessionId(
+  db: ReturnType<typeof getWorkerDb>,
+  kiloUserId: string,
+  sessionId: string,
+  parentSessionId: string | undefined
+): Promise<string | undefined> {
+  if (!parentSessionId || parentSessionId === sessionId) return undefined;
+
+  for (let attempt = 1; attempt <= PARENT_SESSION_LOOKUP_ATTEMPTS; attempt++) {
+    const parentRows = await db
+      .select({ session_id: cli_sessions_v2.session_id })
+      .from(cli_sessions_v2)
+      .where(
+        and(
+          eq(cli_sessions_v2.session_id, parentSessionId),
+          eq(cli_sessions_v2.kilo_user_id, kiloUserId)
+        )
+      )
+      .limit(1);
+
+    if (parentRows[0]) return parentSessionId;
+    if (attempt < PARENT_SESSION_LOOKUP_ATTEMPTS) await sleep(PARENT_SESSION_LOOKUP_DELAY_MS);
+  }
+
+  return undefined;
+}
 
 api.post('/session', zodJsonValidator(createSessionSchema), async c => {
   const body = c.req.valid('json');
 
-  // Persist a placeholder session row.
-  // This is intentionally minimal; we only need a working Hyperdrive -> Postgres path.
+  // Persist a placeholder session row plus safe attribution metadata supplied at bootstrap.
   const db = getWorkerDb(c.env.HYPERDRIVE.connectionString);
   const kiloUserId = c.get('user_id');
+  const parentSessionId = await getSafeParentSessionId(
+    db,
+    kiloUserId,
+    body.sessionId,
+    body.parentSessionId
+  );
 
   await db
     .insert(cli_sessions_v2)
     .values({
       session_id: body.sessionId,
       kilo_user_id: kiloUserId,
+      ...(body.title !== undefined ? { title: body.title === '' ? null : body.title } : {}),
+      ...(body.createdOnPlatform !== undefined
+        ? { created_on_platform: body.createdOnPlatform }
+        : {}),
+      ...(parentSessionId !== undefined ? { parent_session_id: parentSessionId } : {}),
     })
     .onConflictDoNothing({
       target: [cli_sessions_v2.session_id, cli_sessions_v2.kilo_user_id],

--- a/services/session-ingest/src/services/session-parent.test.ts
+++ b/services/session-ingest/src/services/session-parent.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { getWorkerDb } from '@kilocode/db/client';
+
+import { setSafeParentSessionId } from './session-parent';
+
+type WorkerDb = ReturnType<typeof getWorkerDb>;
+
+function makeParentDb() {
+  const selectResult = vi.fn<() => Promise<Array<{ parent_session_id: string | null }>>>(
+    async () => []
+  );
+  const select = {
+    from: vi.fn(() => select),
+    where: vi.fn(() => select),
+    limit: vi.fn(() => select),
+    then: vi.fn((resolve: (value: unknown) => unknown, reject?: (reason: unknown) => unknown) =>
+      selectResult().then(resolve, reject)
+    ),
+  };
+
+  const updateResult = vi.fn<() => Promise<Array<{ session_id: string }>>>(async () => []);
+  const update = {
+    set: vi.fn(() => update),
+    where: vi.fn(() => update),
+    returning: vi.fn(() => update),
+    then: vi.fn((resolve: (value: unknown) => unknown, reject?: (reason: unknown) => unknown) =>
+      updateResult().then(resolve, reject)
+    ),
+  };
+
+  return {
+    db: {
+      select: vi.fn(() => select),
+      update: vi.fn(() => update),
+    } as unknown as WorkerDb,
+    fns: {
+      selectResult,
+      updateResult,
+      updateSet: update.set,
+    },
+  };
+}
+
+describe('setSafeParentSessionId', () => {
+  it('retries until a shortly delayed same-user parent row can be linked', async () => {
+    const { db, fns } = makeParentDb();
+    fns.updateResult
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ session_id: 'ses_child123456789012345678901' }]);
+
+    await expect(
+      setSafeParentSessionId(
+        db,
+        'usr_test',
+        'ses_child123456789012345678901',
+        'ses_parent12345678901234567890',
+        { attempts: 2, delayMs: 0 }
+      )
+    ).resolves.toBe(true);
+    expect(fns.updateResult).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns true without updating when the child is already linked', async () => {
+    const { db, fns } = makeParentDb();
+    fns.selectResult.mockResolvedValueOnce([
+      { parent_session_id: 'ses_parent12345678901234567890' },
+    ]);
+
+    await expect(
+      setSafeParentSessionId(
+        db,
+        'usr_test',
+        'ses_child123456789012345678901',
+        'ses_parent12345678901234567890',
+        { attempts: 2, delayMs: 0 }
+      )
+    ).resolves.toBe(true);
+    expect(fns.updateSet).not.toHaveBeenCalled();
+  });
+
+  it('rejects self-parenting without querying Postgres', async () => {
+    const { db, fns } = makeParentDb();
+
+    await expect(
+      setSafeParentSessionId(
+        db,
+        'usr_test',
+        'ses_12345678901234567890123456',
+        'ses_12345678901234567890123456'
+      )
+    ).resolves.toBe(false);
+    expect(fns.selectResult).not.toHaveBeenCalled();
+    expect(fns.updateSet).not.toHaveBeenCalled();
+  });
+
+  it('treats concurrent parent deletion as a retryable miss', async () => {
+    const { db, fns } = makeParentDb();
+    fns.updateResult
+      .mockRejectedValueOnce({ code: '23503' })
+      .mockResolvedValueOnce([{ session_id: 'ses_child123456789012345678901' }]);
+
+    await expect(
+      setSafeParentSessionId(
+        db,
+        'usr_test',
+        'ses_child123456789012345678901',
+        'ses_parent12345678901234567890',
+        { attempts: 2, delayMs: 0 }
+      )
+    ).resolves.toBe(true);
+    expect(fns.updateResult).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not swallow non-FK database errors', async () => {
+    const { db, fns } = makeParentDb();
+    const dbError = new Error('database unavailable');
+    fns.updateResult.mockRejectedValueOnce(dbError);
+
+    await expect(
+      setSafeParentSessionId(
+        db,
+        'usr_test',
+        'ses_child123456789012345678901',
+        'ses_parent12345678901234567890',
+        { attempts: 2, delayMs: 0 }
+      )
+    ).rejects.toBe(dbError);
+  });
+});

--- a/services/session-ingest/src/services/session-parent.ts
+++ b/services/session-ingest/src/services/session-parent.ts
@@ -1,0 +1,90 @@
+import { and, eq, sql } from 'drizzle-orm';
+import type { getWorkerDb } from '@kilocode/db/client';
+import { cli_sessions_v2 } from '@kilocode/db/schema';
+
+const PARENT_SESSION_LINK_ATTEMPTS = 3;
+const PARENT_SESSION_LINK_DELAY_MS = 250;
+
+type WorkerDb = ReturnType<typeof getWorkerDb>;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isForeignKeyViolation(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  if ('code' in err && err.code === '23503') return true;
+  return 'cause' in err && isForeignKeyViolation(err.cause);
+}
+
+async function sessionAlreadyLinkedToParent(
+  db: WorkerDb,
+  kiloUserId: string,
+  sessionId: string,
+  parentSessionId: string
+): Promise<boolean> {
+  const sessionRows = await db
+    .select({ parent_session_id: cli_sessions_v2.parent_session_id })
+    .from(cli_sessions_v2)
+    .where(
+      and(eq(cli_sessions_v2.session_id, sessionId), eq(cli_sessions_v2.kilo_user_id, kiloUserId))
+    )
+    .limit(1);
+
+  return sessionRows[0]?.parent_session_id === parentSessionId;
+}
+
+async function updateParentSessionIdIfParentExists(
+  db: WorkerDb,
+  kiloUserId: string,
+  sessionId: string,
+  parentSessionId: string
+): Promise<boolean> {
+  const updatedRows = await db
+    .update(cli_sessions_v2)
+    .set({ parent_session_id: parentSessionId })
+    .where(
+      and(
+        eq(cli_sessions_v2.session_id, sessionId),
+        eq(cli_sessions_v2.kilo_user_id, kiloUserId),
+        sql`${cli_sessions_v2.parent_session_id} IS DISTINCT FROM ${parentSessionId}`,
+        sql`EXISTS (
+          SELECT 1 FROM ${cli_sessions_v2} parent_session
+          WHERE parent_session.session_id = ${parentSessionId}
+            AND parent_session.kilo_user_id = ${kiloUserId}
+        )`
+      )
+    )
+    .returning({ session_id: cli_sessions_v2.session_id });
+
+  return updatedRows.length > 0;
+}
+
+export async function setSafeParentSessionId(
+  db: WorkerDb,
+  kiloUserId: string,
+  sessionId: string,
+  parentSessionId: string,
+  options: { attempts?: number; delayMs?: number } = {}
+): Promise<boolean> {
+  if (parentSessionId === sessionId) return false;
+
+  const attempts = options.attempts ?? PARENT_SESSION_LINK_ATTEMPTS;
+  const delayMs = options.delayMs ?? PARENT_SESSION_LINK_DELAY_MS;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (await sessionAlreadyLinkedToParent(db, kiloUserId, sessionId, parentSessionId)) return true;
+
+    try {
+      if (await updateParentSessionIdIfParentExists(db, kiloUserId, sessionId, parentSessionId)) {
+        return true;
+      }
+    } catch (err) {
+      if (!isForeignKeyViolation(err)) throw err;
+    }
+
+    if (attempt < attempts && delayMs > 0) await sleep(delayMs);
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- Accept optional bootstrap attribution metadata on `/api/session` (`title`, `parentSessionId`, `createdOnPlatform`) with a strict request schema and persist it on the placeholder session row.
- Keep parent attribution constrained to the same user and non-self parent, with a short lookup retry so child sessions can link when the parent row arrives just after the child.
- Preserve existing ingest metadata behavior while using the same safe parent resolution for queue-applied `parentID`; companion client change follows.

## Reviewer Notes

- No database migration included. The target `cli_sessions_v2` columns and composite parent FK already exist.
- Parent links are only written after finding the parent session for the same user; missing parents are skipped instead of creating unsafe FK writes.