### PR TITLE
feat(mobile): add data-sharing consent gate

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -12,7 +12,7 @@ if (missing.length > 0) {
 }
 
 const config: ExpoConfig = {
-  name: 'KiloClaw',
+  name: 'Kilo',
   owner: 'kilocode',
   slug: 'kilo-app',
   version: '1.0.0',

--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -73,6 +73,20 @@ export default function AppLayout() {
                 gestureEnabled: false,
               }}
             />
+            <Stack.Screen
+              name="consent"
+              options={{
+                presentation: 'modal',
+                headerShown: false,
+                gestureEnabled: false,
+              }}
+            />
+            <Stack.Screen
+              name="consent-details"
+              options={{
+                headerShown: false,
+              }}
+            />
           </Stack>
         </StoreKiloPassPurchaseProvider>
       </KiloChatPresenceMount>

--- a/apps/mobile/src/app/(app)/consent-details.tsx
+++ b/apps/mobile/src/app/(app)/consent-details.tsx
@@ -1,0 +1,5 @@
+import { ConsentDetails } from '@/components/consent/consent-details';
+
+export default function ConsentDetailsScreen() {
+  return <ConsentDetails />;
+}

--- a/apps/mobile/src/app/(app)/consent.tsx
+++ b/apps/mobile/src/app/(app)/consent.tsx
@@ -1,5 +1,10 @@
+import { useLocalSearchParams } from 'expo-router';
+
 import { ConsentCard } from '@/components/consent/consent-card';
+import { consentModeForSearchParam } from '@/components/consent/consent-mode';
 
 export default function ConsentScreen() {
-  return <ConsentCard />;
+  const { mode } = useLocalSearchParams<{ mode?: string }>();
+
+  return <ConsentCard mode={consentModeForSearchParam(mode)} />;
 }

--- a/apps/mobile/src/app/(app)/consent.tsx
+++ b/apps/mobile/src/app/(app)/consent.tsx
@@ -1,0 +1,5 @@
+import { ConsentCard } from '@/components/consent/consent-card';
+
+export default function ConsentScreen() {
+  return <ConsentCard />;
+}

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -31,6 +31,7 @@ import { Toaster } from 'sonner-native';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { AuthProvider, useAuth } from '@/lib/auth/auth-context';
+import { shouldStartAppsFlyer } from '@/lib/appsflyer-consent';
 import { initAppsFlyer } from '@/lib/appsflyer';
 import { consentModeForSearchParam } from '@/components/consent/consent-mode';
 import { hasAcceptedConsent, subscribeToConsentChanges } from '@/lib/consent';
@@ -161,6 +162,27 @@ function RootLayoutNav() {
 
     return unsubscribe;
   }, [token, userId]);
+
+  useEffect(() => {
+    if (
+      !shouldStartAppsFlyer({
+        hasToken: token != null,
+        consentChecked,
+        needsConsent,
+      })
+    ) {
+      return;
+    }
+
+    async function startAppsFlyer() {
+      if (Platform.OS === 'ios') {
+        await requestTrackingPermissionsAsync();
+      }
+      initAppsFlyer();
+    }
+
+    void startAppsFlyer();
+  }, [token, consentChecked, needsConsent]);
 
   useEffect(() => {
     if (isLoading) {
@@ -302,16 +324,6 @@ function RootLayout() {
       navigationIntegration.registerNavigationContainer(ref);
     }
   }, [ref]);
-
-  useEffect(() => {
-    async function startAppsFlyer() {
-      if (Platform.OS === 'ios') {
-        await requestTrackingPermissionsAsync();
-      }
-      initAppsFlyer();
-    }
-    void startAppsFlyer();
-  }, []);
 
   useEffect(() => {
     const subscription = setupNotificationResponseHandler();

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -28,6 +28,8 @@ import { Platform, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Toaster } from 'sonner-native';
 
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
 import { AuthProvider, useAuth } from '@/lib/auth/auth-context';
 import { initAppsFlyer } from '@/lib/appsflyer';
 import { consentModeForSearchParam } from '@/components/consent/consent-mode';
@@ -82,7 +84,7 @@ setupNotificationHandler();
 checkInitialNotification();
 
 function RootLayoutNav() {
-  const { token, isLoading: authLoading } = useAuth();
+  const { token, isLoading: authLoading, signOut } = useAuth();
   const { updateRequired, isChecking: updateChecking } = useForceUpdate();
   const [fontsLoaded, fontsError] = useFonts({
     JetBrainsMono_500Medium,
@@ -92,7 +94,12 @@ function RootLayoutNav() {
   const pathname = usePathname();
   const { mode } = useGlobalSearchParams<{ mode?: string }>();
   const router = useRouter();
-  const { userId, isLoading: userIdLoading } = useCurrentUserId({ enabled: token != null });
+  const {
+    userId,
+    isLoading: userIdLoading,
+    isError: userIdError,
+    refetch: refetchUserId,
+  } = useCurrentUserId({ enabled: token != null });
   const [consentChecked, setConsentChecked] = useState(false);
   const [needsConsent, setNeedsConsent] = useState(false);
 
@@ -182,6 +189,11 @@ function RootLayoutNav() {
         router.replace('/(auth)/login');
       }
     } else {
+      if (userIdError) {
+        void SplashScreen.hideAsync();
+        return;
+      }
+
       if (userIdLoading || !consentChecked) {
         return;
       }
@@ -215,6 +227,7 @@ function RootLayoutNav() {
     inForceUpdate,
     router,
     userIdLoading,
+    userIdError,
     consentChecked,
     needsConsent,
     onConsentRoute,
@@ -225,6 +238,7 @@ function RootLayoutNav() {
   const showingForceUpdate = updateRequired && inForceUpdate;
   const needsAuth = !token && !inAuthGroup;
   const needsAppRedirect = token != null && inAuthGroup;
+  const hasUserBootstrapError = token != null && userIdError;
   const consentLoading =
     token != null && !consentChecked && !inAuthGroup && !inForceUpdate && !onConsentRoute;
   const needsConsentRedirect = consentChecked && needsConsent && !onConsentRoute;
@@ -238,7 +252,37 @@ function RootLayoutNav() {
   // initialised — returning null unmounts it and breaks router.replace.
   // The native splash screen covers everything during initial load, and
   // opacity 0 hides the wrong screen during redirects.
-  const hidden = isLoading || needsRedirect || consentLoading;
+  const hidden = !hasUserBootstrapError && (isLoading || needsRedirect || consentLoading);
+
+  if (hasUserBootstrapError) {
+    return (
+      <View className="flex-1 items-center justify-center gap-4 bg-background px-6">
+        <View className="gap-2">
+          <Text className="text-center text-lg font-semibold text-foreground">
+            Could not load your account
+          </Text>
+          <Text className="text-center text-sm text-muted-foreground">
+            Check your connection and try again.
+          </Text>
+        </View>
+        <View className="w-full gap-3">
+          <Button size="lg" onPress={refetchUserId} accessibilityLabel="Retry loading account">
+            <Text>Retry</Text>
+          </Button>
+          <Button
+            variant="outline"
+            size="lg"
+            onPress={() => {
+              void signOut();
+            }}
+            accessibilityLabel="Sign out"
+          >
+            <Text>Sign out</Text>
+          </Button>
+        </View>
+      </View>
+    );
+  }
 
   return (
     <View

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,14 +1,11 @@
 import '../global.css';
 import '@/lib/cloud-agent-runtime';
 
-import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import {
   JetBrainsMono_500Medium,
   JetBrainsMono_600SemiBold,
 } from '@expo-google-fonts/jetbrains-mono';
-import { PortalHost } from '@rn-primitives/portal';
 import * as Sentry from '@sentry/react-native';
-import { QueryClientProvider } from '@tanstack/react-query';
 import { isRunningInExpoGo } from 'expo';
 import { useFonts } from 'expo-font';
 import {
@@ -22,19 +19,16 @@ import {
 } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
-import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
 import { useEffect, useState } from 'react';
-import { Platform, View } from 'react-native';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { Toaster } from 'sonner-native';
+import { View } from 'react-native';
 
-import { Button } from '@/components/ui/button';
-import { Text } from '@/components/ui/text';
-import { AuthProvider, useAuth } from '@/lib/auth/auth-context';
-import { shouldStartAppsFlyer } from '@/lib/appsflyer-consent';
-import { initAppsFlyer } from '@/lib/appsflyer';
+import { AppRootProviders } from '@/components/app-root-providers';
+import { BootstrapErrorScreen } from '@/components/bootstrap-error-screen';
+import { useAuth } from '@/lib/auth/auth-context';
 import { consentModeForSearchParam } from '@/components/consent/consent-mode';
-import { hasAcceptedConsent, subscribeToConsentChanges } from '@/lib/consent';
+import { checkConsentGate } from '@/lib/consent-gate';
+import { subscribeToConsentChanges } from '@/lib/consent';
+import { useAppsFlyerConsentGate } from '@/lib/hooks/use-appsflyer-consent-gate';
 import { useForceUpdate } from '@/lib/hooks/use-force-update';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
 import {
@@ -43,10 +37,7 @@ import {
   setupNotificationHandler,
   setupNotificationResponseHandler,
 } from '@/lib/notifications';
-import { OrganizationProvider } from '@/lib/organization-context';
 import { resolvePendingNotificationNavigation } from '@/lib/pending-notification-navigation';
-import { queryClient } from '@/lib/query-client';
-import { trpcClient, TRPCProvider } from '@/lib/trpc';
 
 const navigationIntegration = Sentry.reactNavigationIntegration({
   enableTimeToInitialDisplay: !isRunningInExpoGo(),
@@ -59,24 +50,16 @@ Sentry.init({
 
   sendDefaultPii: false,
 
-  // Enable Logs
   enableLogs: true,
-
-  // Tracing is fully disabled.
   tracesSampleRate: 0,
-
-  // Configure Session Replay
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1,
-
-  // Capture a screenshot and view hierarchy on every error
   attachScreenshot: true,
   attachViewHierarchy: true,
 
   integrations: [Sentry.mobileReplayIntegration(), navigationIntegration],
   enableNativeFramesTracking: false,
 
-  // uncomment the line below to enable Spotlight (https://spotlightjs.com)
   spotlight: __DEV__,
 });
 
@@ -103,6 +86,8 @@ function RootLayoutNav() {
   } = useCurrentUserId({ enabled: token != null });
   const [consentChecked, setConsentChecked] = useState(false);
   const [needsConsent, setNeedsConsent] = useState(false);
+  const [consentCheckError, setConsentCheckError] = useState<unknown>(null);
+  const [consentCheckRetryKey, setConsentCheckRetryKey] = useState(0);
 
   useEffect(() => {
     if (fontsError) {
@@ -110,10 +95,6 @@ function RootLayoutNav() {
     }
   }, [fontsError]);
 
-  // Treat font load errors as terminal: fall back to system fonts rather
-  // than holding the app at opacity 0 forever. `useFonts` sets `error` and
-  // leaves `loaded` false on failure, so gating only on `!fontsLoaded` would
-  // keep the splash screen up indefinitely.
   const fontsReady = fontsLoaded || fontsError !== null;
   const isLoading = authLoading || updateChecking || !fontsReady;
   const inAuthGroup = segments[0] === '(auth)';
@@ -128,14 +109,25 @@ function RootLayoutNav() {
       if (!token || !userId) {
         setConsentChecked(false);
         setNeedsConsent(false);
+        setConsentCheckError(null);
         return;
       }
 
-      const accepted = await hasAcceptedConsent(userId);
+      const result = await checkConsentGate(userId);
       if (cancelled) {
         return;
       }
-      setNeedsConsent(!accepted);
+
+      if (result.status === 'error') {
+        Sentry.captureException(result.error);
+        setNeedsConsent(false);
+        setConsentChecked(false);
+        setConsentCheckError(result.error);
+        return;
+      }
+
+      setConsentCheckError(null);
+      setNeedsConsent(result.status === 'needs-consent');
       setConsentChecked(true);
     }
 
@@ -144,7 +136,7 @@ function RootLayoutNav() {
     return () => {
       cancelled = true;
     };
-  }, [token, userId]);
+  }, [token, userId, consentCheckRetryKey]);
 
   useEffect(() => {
     if (!token || !userId) {
@@ -163,26 +155,7 @@ function RootLayoutNav() {
     return unsubscribe;
   }, [token, userId]);
 
-  useEffect(() => {
-    if (
-      !shouldStartAppsFlyer({
-        hasToken: token != null,
-        consentChecked,
-        needsConsent,
-      })
-    ) {
-      return;
-    }
-
-    async function startAppsFlyer() {
-      if (Platform.OS === 'ios') {
-        await requestTrackingPermissionsAsync();
-      }
-      initAppsFlyer();
-    }
-
-    void startAppsFlyer();
-  }, [token, consentChecked, needsConsent]);
+  useAppsFlyerConsentGate({ hasToken: token != null, consentChecked, needsConsent });
 
   useEffect(() => {
     if (isLoading) {
@@ -199,7 +172,6 @@ function RootLayoutNav() {
     }
 
     if (inForceUpdate) {
-      // Version is now acceptable, leave the force-update screen
       router.replace('/(app)');
       return;
     }
@@ -212,6 +184,11 @@ function RootLayoutNav() {
       }
     } else {
       if (userIdError) {
+        void SplashScreen.hideAsync();
+        return;
+      }
+
+      if (consentCheckError) {
         void SplashScreen.hideAsync();
         return;
       }
@@ -250,6 +227,7 @@ function RootLayoutNav() {
     router,
     userIdLoading,
     userIdError,
+    consentCheckError,
     consentChecked,
     needsConsent,
     onConsentRoute,
@@ -261,6 +239,7 @@ function RootLayoutNav() {
   const needsAuth = !token && !inAuthGroup;
   const needsAppRedirect = token != null && inAuthGroup;
   const hasUserBootstrapError = token != null && userIdError;
+  const hasConsentBootstrapError = token != null && consentCheckError !== null;
   const consentLoading =
     token != null && !consentChecked && !inAuthGroup && !inForceUpdate && !onConsentRoute;
   const needsConsentRedirect = consentChecked && needsConsent && !onConsentRoute;
@@ -274,35 +253,45 @@ function RootLayoutNav() {
   // initialised — returning null unmounts it and breaks router.replace.
   // The native splash screen covers everything during initial load, and
   // opacity 0 hides the wrong screen during redirects.
-  const hidden = !hasUserBootstrapError && (isLoading || needsRedirect || consentLoading);
+  const hidden =
+    !hasUserBootstrapError &&
+    !hasConsentBootstrapError &&
+    (isLoading || needsRedirect || consentLoading);
 
   if (hasUserBootstrapError) {
     return (
-      <View className="flex-1 items-center justify-center gap-4 bg-background px-6">
-        <View className="gap-2">
-          <Text className="text-center text-lg font-semibold text-foreground">
-            Could not load your account
-          </Text>
-          <Text className="text-center text-sm text-muted-foreground">
-            Check your connection and try again.
-          </Text>
-        </View>
-        <View className="w-full gap-3">
-          <Button size="lg" onPress={refetchUserId} accessibilityLabel="Retry loading account">
-            <Text>Retry</Text>
-          </Button>
-          <Button
-            variant="outline"
-            size="lg"
-            onPress={() => {
-              void signOut();
-            }}
-            accessibilityLabel="Sign out"
-          >
-            <Text>Sign out</Text>
-          </Button>
-        </View>
-      </View>
+      <BootstrapErrorScreen
+        title="Could not load your account"
+        description="Check your connection and try again."
+        primaryLabel="Retry"
+        primaryAccessibilityLabel="Retry loading account"
+        onPrimaryPress={refetchUserId}
+        secondaryLabel="Sign out"
+        secondaryAccessibilityLabel="Sign out"
+        onSecondaryPress={() => {
+          void signOut();
+        }}
+      />
+    );
+  }
+
+  if (hasConsentBootstrapError) {
+    return (
+      <BootstrapErrorScreen
+        title="Could not load privacy choices"
+        description="Check your device security settings and try again."
+        primaryLabel="Retry"
+        primaryAccessibilityLabel="Retry loading privacy choices"
+        onPrimaryPress={() => {
+          setConsentCheckError(null);
+          setConsentCheckRetryKey(key => key + 1);
+        }}
+        secondaryLabel="Sign out"
+        secondaryAccessibilityLabel="Sign out"
+        onSecondaryPress={() => {
+          void signOut();
+        }}
+      />
     );
   }
 
@@ -333,24 +322,10 @@ function RootLayout() {
   }, []);
 
   return (
-    <GestureHandlerRootView className="flex-1">
+    <AppRootProviders>
       <StatusBar style="auto" />
-      <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
-        <QueryClientProvider client={queryClient}>
-          <AuthProvider>
-            <OrganizationProvider>
-              <ActionSheetProvider>
-                <>
-                  <RootLayoutNav />
-                  <Toaster />
-                  <PortalHost />
-                </>
-              </ActionSheetProvider>
-            </OrganizationProvider>
-          </AuthProvider>
-        </QueryClientProvider>
-      </TRPCProvider>
-    </GestureHandlerRootView>
+      <RootLayoutNav />
+    </AppRootProviders>
   );
 }
 

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -14,6 +14,7 @@ import { useFonts } from 'expo-font';
 import {
   type Href,
   Slot,
+  useGlobalSearchParams,
   useNavigationContainerRef,
   usePathname,
   useRouter,
@@ -29,6 +30,7 @@ import { Toaster } from 'sonner-native';
 
 import { AuthProvider, useAuth } from '@/lib/auth/auth-context';
 import { initAppsFlyer } from '@/lib/appsflyer';
+import { consentModeForSearchParam } from '@/components/consent/consent-mode';
 import { hasAcceptedConsent, subscribeToConsentChanges } from '@/lib/consent';
 import { useForceUpdate } from '@/lib/hooks/use-force-update';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
@@ -88,6 +90,7 @@ function RootLayoutNav() {
   });
   const segments = useSegments();
   const pathname = usePathname();
+  const { mode } = useGlobalSearchParams<{ mode?: string }>();
   const router = useRouter();
   const { userId, isLoading: userIdLoading } = useCurrentUserId({ enabled: token != null });
   const [consentChecked, setConsentChecked] = useState(false);
@@ -108,6 +111,7 @@ function RootLayoutNav() {
   const inAuthGroup = segments[0] === '(auth)';
   const inForceUpdate = segments[0] === 'force-update';
   const onConsentRoute = pathname === '/consent' || pathname === '/consent-details';
+  const onConsentReviewRoute = onConsentRoute && consentModeForSearchParam(mode) === 'review';
 
   useEffect(() => {
     let cancelled = false;
@@ -191,7 +195,7 @@ function RootLayoutNav() {
         return;
       }
 
-      if (onConsentRoute || inAuthGroup) {
+      if ((onConsentRoute && !onConsentReviewRoute) || inAuthGroup) {
         router.replace('/(app)');
         return;
       }
@@ -214,6 +218,7 @@ function RootLayoutNav() {
     consentChecked,
     needsConsent,
     onConsentRoute,
+    onConsentReviewRoute,
   ]);
 
   const needsForceUpdate = updateRequired && !inForceUpdate;

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -29,7 +29,7 @@ import { Toaster } from 'sonner-native';
 
 import { AuthProvider, useAuth } from '@/lib/auth/auth-context';
 import { initAppsFlyer } from '@/lib/appsflyer';
-import { hasAcceptedConsent } from '@/lib/consent';
+import { hasAcceptedConsent, subscribeToConsentChanges } from '@/lib/consent';
 import { useForceUpdate } from '@/lib/hooks/use-force-update';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
 import {
@@ -132,6 +132,23 @@ function RootLayoutNav() {
     return () => {
       cancelled = true;
     };
+  }, [token, userId]);
+
+  useEffect(() => {
+    if (!token || !userId) {
+      return undefined;
+    }
+
+    const unsubscribe = subscribeToConsentChanges(change => {
+      if (change.userId !== userId) {
+        return;
+      }
+
+      setNeedsConsent(!change.hasAccepted);
+      setConsentChecked(true);
+    });
+
+    return unsubscribe;
   }, [token, userId]);
 
   useEffect(() => {

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -11,26 +11,35 @@ import * as Sentry from '@sentry/react-native';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { isRunningInExpoGo } from 'expo';
 import { useFonts } from 'expo-font';
-import { type Href, Slot, useNavigationContainerRef, useRouter, useSegments } from 'expo-router';
+import {
+  type Href,
+  Slot,
+  useNavigationContainerRef,
+  usePathname,
+  useRouter,
+  useSegments,
+} from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Platform, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Toaster } from 'sonner-native';
 
 import { AuthProvider, useAuth } from '@/lib/auth/auth-context';
-import { OrganizationProvider } from '@/lib/organization-context';
 import { initAppsFlyer } from '@/lib/appsflyer';
+import { hasAcceptedConsent } from '@/lib/consent';
+import { useForceUpdate } from '@/lib/hooks/use-force-update';
+import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
 import {
   checkInitialNotification,
   getPendingNotificationLink,
   setupNotificationHandler,
   setupNotificationResponseHandler,
 } from '@/lib/notifications';
+import { OrganizationProvider } from '@/lib/organization-context';
 import { resolvePendingNotificationNavigation } from '@/lib/pending-notification-navigation';
-import { useForceUpdate } from '@/lib/hooks/use-force-update';
 import { queryClient } from '@/lib/query-client';
 import { trpcClient, TRPCProvider } from '@/lib/trpc';
 
@@ -78,7 +87,11 @@ function RootLayoutNav() {
     JetBrainsMono_600SemiBold,
   });
   const segments = useSegments();
+  const pathname = usePathname();
   const router = useRouter();
+  const { userId, isLoading: userIdLoading } = useCurrentUserId({ enabled: token != null });
+  const [consentChecked, setConsentChecked] = useState(false);
+  const [needsConsent, setNeedsConsent] = useState(false);
 
   useEffect(() => {
     if (fontsError) {
@@ -94,6 +107,32 @@ function RootLayoutNav() {
   const isLoading = authLoading || updateChecking || !fontsReady;
   const inAuthGroup = segments[0] === '(auth)';
   const inForceUpdate = segments[0] === 'force-update';
+  const onConsentRoute = pathname === '/consent' || pathname === '/consent-details';
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkConsent() {
+      if (!token || !userId) {
+        setConsentChecked(false);
+        setNeedsConsent(false);
+        return;
+      }
+
+      const accepted = await hasAcceptedConsent(userId);
+      if (cancelled) {
+        return;
+      }
+      setNeedsConsent(!accepted);
+      setConsentChecked(true);
+    }
+
+    void checkConsent();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, userId]);
 
   useEffect(() => {
     if (isLoading) {
@@ -121,9 +160,25 @@ function RootLayoutNav() {
       } else {
         router.replace('/(auth)/login');
       }
-    } else if (inAuthGroup) {
-      router.replace('/(app)');
     } else {
+      if (userIdLoading || !consentChecked) {
+        return;
+      }
+
+      if (needsConsent) {
+        if (onConsentRoute) {
+          void SplashScreen.hideAsync();
+        } else {
+          router.replace('/(app)/consent' as Href);
+        }
+        return;
+      }
+
+      if (onConsentRoute || inAuthGroup) {
+        router.replace('/(app)');
+        return;
+      }
+
       void SplashScreen.hideAsync();
       // Navigate to pending notification deep link (cold start / background tap)
       const pendingNavigation = resolvePendingNotificationNavigation(getPendingNotificationLink());
@@ -131,21 +186,37 @@ function RootLayoutNav() {
         router.replace(pendingNavigation.href as Href);
       }
     }
-  }, [token, isLoading, updateRequired, inAuthGroup, inForceUpdate, router]);
+  }, [
+    token,
+    isLoading,
+    updateRequired,
+    inAuthGroup,
+    inForceUpdate,
+    router,
+    userIdLoading,
+    consentChecked,
+    needsConsent,
+    onConsentRoute,
+  ]);
 
   const needsForceUpdate = updateRequired && !inForceUpdate;
   const showingForceUpdate = updateRequired && inForceUpdate;
   const needsAuth = !token && !inAuthGroup;
   const needsAppRedirect = token != null && inAuthGroup;
+  const consentLoading =
+    token != null && !consentChecked && !inAuthGroup && !inForceUpdate && !onConsentRoute;
+  const needsConsentRedirect = consentChecked && needsConsent && !onConsentRoute;
 
   const needsRedirect =
-    !isLoading && (needsForceUpdate || (!showingForceUpdate && (needsAuth || needsAppRedirect)));
+    !isLoading &&
+    (needsForceUpdate ||
+      (!showingForceUpdate && (needsAuth || needsAppRedirect || needsConsentRedirect)));
 
   // Always keep Slot mounted so Expo Router's navigation tree stays
   // initialised — returning null unmounts it and breaks router.replace.
   // The native splash screen covers everything during initial load, and
   // opacity 0 hides the wrong screen during redirects.
-  const hidden = isLoading || needsRedirect;
+  const hidden = isLoading || needsRedirect || consentLoading;
 
   return (
     <View

--- a/apps/mobile/src/components/app-root-providers.tsx
+++ b/apps/mobile/src/components/app-root-providers.tsx
@@ -1,0 +1,33 @@
+import { ActionSheetProvider } from '@expo/react-native-action-sheet';
+import { PortalHost } from '@rn-primitives/portal';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { type ReactNode } from 'react';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { Toaster } from 'sonner-native';
+
+import { AuthProvider } from '@/lib/auth/auth-context';
+import { OrganizationProvider } from '@/lib/organization-context';
+import { queryClient } from '@/lib/query-client';
+import { trpcClient, TRPCProvider } from '@/lib/trpc';
+
+export function AppRootProviders({ children }: { readonly children: ReactNode }) {
+  return (
+    <GestureHandlerRootView className="flex-1">
+      <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
+            <OrganizationProvider>
+              <ActionSheetProvider>
+                <>
+                  {children}
+                  <Toaster />
+                  <PortalHost />
+                </>
+              </ActionSheetProvider>
+            </OrganizationProvider>
+          </AuthProvider>
+        </QueryClientProvider>
+      </TRPCProvider>
+    </GestureHandlerRootView>
+  );
+}

--- a/apps/mobile/src/components/bootstrap-error-screen.tsx
+++ b/apps/mobile/src/components/bootstrap-error-screen.tsx
@@ -1,0 +1,48 @@
+import { View } from 'react-native';
+
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+
+type BootstrapErrorScreenProps = {
+  readonly title: string;
+  readonly description: string;
+  readonly primaryLabel: string;
+  readonly primaryAccessibilityLabel: string;
+  readonly onPrimaryPress: () => void;
+  readonly secondaryLabel: string;
+  readonly secondaryAccessibilityLabel: string;
+  readonly onSecondaryPress: () => void;
+};
+
+export function BootstrapErrorScreen({
+  title,
+  description,
+  primaryLabel,
+  primaryAccessibilityLabel,
+  onPrimaryPress,
+  secondaryLabel,
+  secondaryAccessibilityLabel,
+  onSecondaryPress,
+}: BootstrapErrorScreenProps) {
+  return (
+    <View className="flex-1 items-center justify-center gap-4 bg-background px-6">
+      <View className="gap-2">
+        <Text className="text-center text-lg font-semibold text-foreground">{title}</Text>
+        <Text className="text-center text-sm text-muted-foreground">{description}</Text>
+      </View>
+      <View className="w-full gap-3">
+        <Button size="lg" onPress={onPrimaryPress} accessibilityLabel={primaryAccessibilityLabel}>
+          <Text>{primaryLabel}</Text>
+        </Button>
+        <Button
+          variant="outline"
+          size="lg"
+          onPress={onSecondaryPress}
+          accessibilityLabel={secondaryAccessibilityLabel}
+        >
+          <Text>{secondaryLabel}</Text>
+        </Button>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/consent/consent-card.tsx
+++ b/apps/mobile/src/components/consent/consent-card.tsx
@@ -1,0 +1,141 @@
+import * as WebBrowser from 'expo-web-browser';
+import { type Href, useRouter } from 'expo-router';
+import { ChevronRight, MessageSquare, Shield, Smartphone, User } from 'lucide-react-native';
+import { Alert, Platform, Pressable, ScrollView, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { toast } from 'sonner-native';
+
+import { ConsentRow } from '@/components/consent/consent-row';
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { useAuth } from '@/lib/auth/auth-context';
+import { acceptConsent } from '@/lib/consent';
+import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+
+const PRIVACY_URL = 'https://kilo.ai/privacy';
+
+export function ConsentCard() {
+  const router = useRouter();
+  const colors = useThemeColors();
+  const { bottom, top } = useSafeAreaInsets();
+  const { signOut } = useAuth();
+  const { userId } = useCurrentUserId();
+  const rootStyle = { paddingTop: top };
+  const contentContainerStyle = {
+    paddingTop: 24,
+    paddingBottom: Math.max(bottom, 16) + (Platform.OS === 'android' ? 8 : 0),
+  };
+
+  const handleAccept = async () => {
+    if (!userId) {
+      toast.error('Could not load your account. Please try again.');
+      return;
+    }
+
+    await acceptConsent(userId);
+    router.replace('/(app)/(tabs)' as Href);
+  };
+
+  const handleDecline = () => {
+    Alert.alert(
+      'Decline data sharing?',
+      'Kilo Code needs to share data with AI providers to work. If you decline, you will be signed out.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Decline and sign out',
+          style: 'destructive',
+          onPress: () => {
+            void signOut();
+          },
+        },
+      ]
+    );
+  };
+
+  const handleOpenPrivacy = () => {
+    void WebBrowser.openBrowserAsync(PRIVACY_URL);
+  };
+
+  return (
+    <View className="flex-1 bg-background" style={rootStyle}>
+      <ScrollView
+        className="flex-1 px-6"
+        contentContainerStyle={contentContainerStyle}
+        showsVerticalScrollIndicator={false}
+      >
+        <View className="flex-row items-center gap-3">
+          <View className="h-10 w-10 items-center justify-center rounded-lg bg-secondary">
+            <Shield size={20} color={colors.foreground} />
+          </View>
+          <Text className="text-base font-semibold text-foreground">Kilo Code</Text>
+        </View>
+
+        <Text className="mt-6 text-2xl font-bold text-foreground">Before we get started</Text>
+        <Text className="mt-3 text-base text-muted-foreground">
+          Kilo Code sends your messages to AI providers to generate responses. Here&apos;s
+          what&apos;s shared and with whom.
+        </Text>
+
+        <View className="mt-6 gap-5">
+          <ConsentRow
+            icon={MessageSquare}
+            title="Your prompts and conversations"
+            description="Sent to AI model providers (Anthropic, OpenAI, Google, and others) to generate replies."
+          />
+          <ConsentRow
+            icon={User}
+            title="Account & usage data"
+            description="Your Kilo account ID and request metadata, used to authenticate you and meter usage."
+          />
+          <ConsentRow
+            icon={Smartphone}
+            title="App diagnostics"
+            description="Anonymous performance and crash data, used to keep the app stable."
+          />
+        </View>
+
+        <Pressable
+          onPress={() => {
+            router.push('/(app)/consent-details' as Href);
+          }}
+          hitSlop={8}
+          accessibilityLabel="See full details"
+          className="mt-6 flex-row items-center gap-1 active:opacity-70"
+        >
+          <Text className="text-sm font-semibold text-primary">See full details</Text>
+          <ChevronRight size={16} color={colors.primary} />
+        </Pressable>
+
+        <Text className="mt-6 text-xs text-muted-foreground">
+          Your data is handled per the{' '}
+          <Text className="text-xs text-primary underline" onPress={handleOpenPrivacy}>
+            Kilo privacy policy
+          </Text>
+          .
+        </Text>
+
+        <View className="mt-8 gap-3">
+          <Button
+            onPress={() => {
+              void handleAccept();
+            }}
+            size="lg"
+            accessibilityLabel="Accept and continue"
+          >
+            <Text>Accept and continue</Text>
+          </Button>
+          <Button
+            variant="outline"
+            size="lg"
+            onPress={handleDecline}
+            accessibilityLabel="Decline"
+          >
+            <Text>Decline</Text>
+          </Button>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/consent/consent-card.tsx
+++ b/apps/mobile/src/components/consent/consent-card.tsx
@@ -24,8 +24,8 @@ export function ConsentCard({ mode = 'onboarding' }: ConsentCardProps) {
   const router = useRouter();
   const colors = useThemeColors();
   const { bottom, top } = useSafeAreaInsets();
-  const { signOut } = useAuth();
-  const { userId } = useCurrentUserId();
+  const { signOut, token } = useAuth();
+  const { userId } = useCurrentUserId({ enabled: token != null });
   const actions = getConsentActions(mode);
   const rootStyle = { paddingTop: top };
   const contentContainerStyle = {

--- a/apps/mobile/src/components/consent/consent-card.tsx
+++ b/apps/mobile/src/components/consent/consent-card.tsx
@@ -6,28 +6,39 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { toast } from 'sonner-native';
 
 import { ConsentRow } from '@/components/consent/consent-row';
+import { type ConsentMode, getConsentActions } from '@/components/consent/consent-mode';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { useAuth } from '@/lib/auth/auth-context';
-import { acceptConsent } from '@/lib/consent';
+import { acceptConsent, revokeConsent } from '@/lib/consent';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 
 const PRIVACY_URL = 'https://kilo.ai/privacy';
 
-export function ConsentCard() {
+type ConsentCardProps = {
+  readonly mode?: ConsentMode;
+};
+
+export function ConsentCard({ mode = 'onboarding' }: ConsentCardProps) {
   const router = useRouter();
   const colors = useThemeColors();
   const { bottom, top } = useSafeAreaInsets();
   const { signOut } = useAuth();
   const { userId } = useCurrentUserId();
+  const actions = getConsentActions(mode);
   const rootStyle = { paddingTop: top };
   const contentContainerStyle = {
     paddingTop: 24,
     paddingBottom: Math.max(bottom, 16) + (Platform.OS === 'android' ? 8 : 0),
   };
 
-  const handleAccept = async () => {
+  const handlePrimaryAction = async () => {
+    if (mode === 'review') {
+      router.back();
+      return;
+    }
+
     if (!userId) {
       toast.error('Could not load your account. Please try again.');
       return;
@@ -37,21 +48,33 @@ export function ConsentCard() {
     router.replace('/(app)/(tabs)' as Href);
   };
 
-  const handleDecline = () => {
-    Alert.alert(
-      'Decline data sharing?',
-      'Kilo Code needs to share data with AI providers to work. If you decline, you will be signed out.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Decline and sign out',
-          style: 'destructive',
-          onPress: () => {
-            void signOut();
-          },
+  const handleSecondaryAction = () => {
+    const message =
+      mode === 'review'
+        ? 'Kilo Code needs this consent to function. Revoking will sign you out. You can accept again on next sign-in.'
+        : 'Kilo Code needs to share data with AI providers to work. If you decline, you will be signed out.';
+
+    Alert.alert(actions.destructiveTitle, message, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: actions.destructiveLabel,
+        style: 'destructive',
+        onPress: () => {
+          void (async () => {
+            if (mode === 'review') {
+              if (!userId) {
+                toast.error('Could not load your account. Please try again.');
+                return;
+              }
+
+              await revokeConsent(userId);
+            }
+
+            await signOut();
+          })();
         },
-      ]
-    );
+      },
+    ]);
   };
 
   const handleOpenPrivacy = () => {
@@ -98,7 +121,11 @@ export function ConsentCard() {
 
         <Pressable
           onPress={() => {
-            router.push('/(app)/consent-details' as Href);
+            router.push(
+              mode === 'review'
+                ? ('/(app)/consent-details?mode=review' as Href)
+                : ('/(app)/consent-details' as Href)
+            );
           }}
           hitSlop={8}
           accessibilityLabel="See full details"
@@ -119,15 +146,20 @@ export function ConsentCard() {
         <View className="mt-8 gap-3">
           <Button
             onPress={() => {
-              void handleAccept();
+              void handlePrimaryAction();
             }}
             size="lg"
-            accessibilityLabel="Accept and continue"
+            accessibilityLabel={actions.primaryLabel}
           >
-            <Text>Accept and continue</Text>
+            <Text>{actions.primaryLabel}</Text>
           </Button>
-          <Button variant="outline" size="lg" onPress={handleDecline} accessibilityLabel="Decline">
-            <Text>Decline</Text>
+          <Button
+            variant={mode === 'review' ? 'destructive' : 'outline'}
+            size="lg"
+            onPress={handleSecondaryAction}
+            accessibilityLabel={actions.secondaryLabel}
+          >
+            <Text>{actions.secondaryLabel}</Text>
           </Button>
         </View>
       </ScrollView>

--- a/apps/mobile/src/components/consent/consent-card.tsx
+++ b/apps/mobile/src/components/consent/consent-card.tsx
@@ -126,12 +126,7 @@ export function ConsentCard() {
           >
             <Text>Accept and continue</Text>
           </Button>
-          <Button
-            variant="outline"
-            size="lg"
-            onPress={handleDecline}
-            accessibilityLabel="Decline"
-          >
+          <Button variant="outline" size="lg" onPress={handleDecline} accessibilityLabel="Decline">
             <Text>Decline</Text>
           </Button>
         </View>

--- a/apps/mobile/src/components/consent/consent-details.tsx
+++ b/apps/mobile/src/components/consent/consent-details.tsx
@@ -1,0 +1,81 @@
+import * as WebBrowser from 'expo-web-browser';
+import { useRouter } from 'expo-router';
+import { Platform, ScrollView, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Section } from '@/components/consent/section';
+import { ScreenHeader } from '@/components/screen-header';
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+
+const PRIVACY_URL = 'https://kilo.ai/privacy';
+
+export function ConsentDetails() {
+  const router = useRouter();
+  const { bottom } = useSafeAreaInsets();
+  const contentContainerStyle = {
+    paddingTop: 8,
+    paddingBottom: Math.max(bottom, 16) + (Platform.OS === 'android' ? 8 : 0),
+  };
+
+  const handleOpenPrivacy = () => {
+    void WebBrowser.openBrowserAsync(PRIVACY_URL);
+  };
+
+  return (
+    <View className="flex-1 bg-background">
+      <ScreenHeader title="Data we share with third parties" />
+      <ScrollView
+        className="flex-1 px-6"
+        contentContainerStyle={contentContainerStyle}
+        showsVerticalScrollIndicator={false}
+      >
+        <Section
+          title="AI model providers"
+          what="Your prompts, conversation history, and any files you attach."
+          why="To generate AI responses."
+          who="Anthropic, OpenAI, Google, and other providers you select per request."
+        />
+        <Section
+          title="Kilo Gateway (our backend)"
+          what="Account ID, request metadata, token usage."
+          why="Authentication, routing requests, billing reconciliation."
+          who="Kilo (kilo.ai)."
+        />
+        <Section
+          title="Analytics & attribution"
+          what="App events (opens, screens viewed, feature use), device type, app version, install source."
+          why="Measure app performance and understand which channels bring new users."
+          who="[MMP vendor - TBD]."
+          footer={
+            <View className="mt-3 rounded-md bg-amber-50 p-3 dark:bg-amber-950">
+              <Text className="text-xs text-amber-900 dark:text-amber-100">
+                No prompt or conversation content is sent to analytics.
+              </Text>
+            </View>
+          }
+        />
+
+        <Text className="mt-6 text-xs text-muted-foreground">
+          Full retention periods, your rights, and contact information are in the{' '}
+          <Text className="text-xs text-primary underline" onPress={handleOpenPrivacy}>
+            Kilo privacy policy
+          </Text>
+          .
+        </Text>
+
+        <View className="mt-8">
+          <Button
+            size="lg"
+            onPress={() => {
+              router.back();
+            }}
+            accessibilityLabel="Back to consent"
+          >
+            <Text>Back to consent</Text>
+          </Button>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/consent/consent-details.tsx
+++ b/apps/mobile/src/components/consent/consent-details.tsx
@@ -46,7 +46,7 @@ export function ConsentDetails() {
           title="Analytics & attribution"
           what="App events (opens, screens viewed, feature use), device type, app version, install source."
           why="Measure app performance and understand which channels bring new users."
-          who="[MMP vendor - TBD]."
+          who="The analytics provider named in our privacy policy."
           footer={
             <View className="mt-3 rounded-md bg-amber-50 p-3 dark:bg-amber-950">
               <Text className="text-xs text-amber-900 dark:text-amber-100">

--- a/apps/mobile/src/components/consent/consent-mode.test.ts
+++ b/apps/mobile/src/components/consent/consent-mode.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { consentModeForSearchParam, getConsentActions } from './consent-mode';
+
+describe('consent mode', () => {
+  it('uses accept and decline actions for first-time consent', () => {
+    expect(getConsentActions('onboarding')).toEqual({
+      primaryLabel: 'Accept and continue',
+      secondaryLabel: 'Decline',
+      destructiveLabel: 'Decline and sign out',
+      destructiveTitle: 'Decline data sharing?',
+    });
+  });
+
+  it('uses back and revoke actions when reviewing accepted consent', () => {
+    expect(getConsentActions('review')).toEqual({
+      primaryLabel: 'Back',
+      secondaryLabel: 'Revoke consent',
+      destructiveLabel: 'Revoke consent',
+      destructiveTitle: 'Revoke data sharing consent?',
+    });
+  });
+
+  it('maps only the review search param to review mode', () => {
+    expect(consentModeForSearchParam('review')).toBe('review');
+    expect(consentModeForSearchParam('anything-else')).toBe('onboarding');
+    expect(consentModeForSearchParam(undefined)).toBe('onboarding');
+  });
+});

--- a/apps/mobile/src/components/consent/consent-mode.ts
+++ b/apps/mobile/src/components/consent/consent-mode.ts
@@ -1,0 +1,30 @@
+export type ConsentMode = 'onboarding' | 'review';
+
+type ConsentActions = {
+  readonly primaryLabel: string;
+  readonly secondaryLabel: string;
+  readonly destructiveLabel: string;
+  readonly destructiveTitle: string;
+};
+
+export function consentModeForSearchParam(mode: string | string[] | undefined): ConsentMode {
+  return mode === 'review' ? 'review' : 'onboarding';
+}
+
+export function getConsentActions(mode: ConsentMode): ConsentActions {
+  if (mode === 'review') {
+    return {
+      primaryLabel: 'Back',
+      secondaryLabel: 'Revoke consent',
+      destructiveLabel: 'Revoke consent',
+      destructiveTitle: 'Revoke data sharing consent?',
+    };
+  }
+
+  return {
+    primaryLabel: 'Accept and continue',
+    secondaryLabel: 'Decline',
+    destructiveLabel: 'Decline and sign out',
+    destructiveTitle: 'Decline data sharing?',
+  };
+}

--- a/apps/mobile/src/components/consent/consent-row.tsx
+++ b/apps/mobile/src/components/consent/consent-row.tsx
@@ -1,4 +1,4 @@
-import type { LucideIcon } from 'lucide-react-native';
+import { type LucideIcon } from 'lucide-react-native';
 import { View } from 'react-native';
 
 import { Text } from '@/components/ui/text';

--- a/apps/mobile/src/components/consent/consent-row.tsx
+++ b/apps/mobile/src/components/consent/consent-row.tsx
@@ -1,0 +1,27 @@
+import type { LucideIcon } from 'lucide-react-native';
+import { View } from 'react-native';
+
+import { Text } from '@/components/ui/text';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+
+type ConsentRowProps = {
+  readonly icon: LucideIcon;
+  readonly title: string;
+  readonly description: string;
+};
+
+export function ConsentRow({ icon: Icon, title, description }: ConsentRowProps) {
+  const colors = useThemeColors();
+
+  return (
+    <View className="flex-row gap-3">
+      <View className="mt-1 w-6 items-center">
+        <Icon size={18} color={colors.mutedForeground} />
+      </View>
+      <View className="flex-1">
+        <Text className="text-base font-semibold text-foreground">{title}</Text>
+        <Text className="mt-0.5 text-sm text-muted-foreground">{description}</Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/consent/section.tsx
+++ b/apps/mobile/src/components/consent/section.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { View } from 'react-native';
 
 import { Text } from '@/components/ui/text';

--- a/apps/mobile/src/components/consent/section.tsx
+++ b/apps/mobile/src/components/consent/section.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react';
+import { View } from 'react-native';
+
+import { Text } from '@/components/ui/text';
+
+type SectionProps = {
+  readonly title: string;
+  readonly what: string;
+  readonly why: string;
+  readonly who: string;
+  readonly footer?: ReactNode;
+};
+
+type FieldProps = {
+  readonly label: string;
+  readonly value: string;
+};
+
+function Field({ label, value }: FieldProps) {
+  return (
+    <Text className="mt-1 text-sm text-muted-foreground">
+      <Text className="text-sm font-semibold text-foreground">{label}: </Text>
+      {value}
+    </Text>
+  );
+}
+
+export function Section({ title, what, why, who, footer }: SectionProps) {
+  return (
+    <View className="border-t border-border py-4">
+      <Text className="text-base font-semibold text-foreground">{title}</Text>
+      <Field label="What" value={what} />
+      <Field label="Why" value={why} />
+      <Field label="Who" value={who} />
+      {footer}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/notifications-card.tsx
+++ b/apps/mobile/src/components/notifications-card.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner-native';
 
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
+import { useAuth } from '@/lib/auth/auth-context';
 import { useAppLifecycle } from '@/lib/hooks/use-app-lifecycle';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import * as Notifications from 'expo-notifications';
@@ -25,6 +26,8 @@ export function NotificationsCard() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const colors = useThemeColors();
+  const { token: authToken } = useAuth();
+  const isAuthenticated = authToken != null;
 
   const { data: permissionGranted = false, isLoading: permissionLoading } = useQuery({
     queryKey: permissionQueryKey,
@@ -40,9 +43,10 @@ export function NotificationsCard() {
     enabled: permissionGranted,
   });
 
-  const { data: pushTokens, isLoading: tokensLoading } = useQuery(
-    trpc.user.getMyPushTokens.queryOptions()
-  );
+  const { data: pushTokens, isLoading: tokensLoading } = useQuery({
+    ...trpc.user.getMyPushTokens.queryOptions(),
+    enabled: isAuthenticated,
+  });
 
   const pushTokensQueryKey = trpc.user.getMyPushTokens.queryOptions().queryKey;
   const serverRegistered =

--- a/apps/mobile/src/components/profile-credits-card.tsx
+++ b/apps/mobile/src/components/profile-credits-card.tsx
@@ -14,10 +14,11 @@ import { useTRPC } from '@/lib/trpc';
 import { parseTimestamp } from '@/lib/utils';
 
 type CreditsCardProps = {
+  readonly enabled: boolean;
   orgs: { organizationId: string; organizationName: string }[] | undefined;
 };
 
-export function CreditsCard({ orgs }: Readonly<CreditsCardProps>) {
+export function CreditsCard({ enabled, orgs }: Readonly<CreditsCardProps>) {
   const trpc = useTRPC();
   const colors = useThemeColors();
   const { showActionSheetWithOptions } = useActionSheet();
@@ -33,17 +34,18 @@ export function CreditsCard({ orgs }: Readonly<CreditsCardProps>) {
     refetch: refetchBalance,
   } = useQuery({
     ...trpc.user.getContextBalance.queryOptions({ organizationId: selectedOrgId }),
+    enabled,
     placeholderData: keepPreviousData,
   });
 
   const { data: personalCreditData, isLoading: personalCreditsLoading } = useQuery({
     ...trpc.user.getCreditBlocks.queryOptions({}),
-    enabled: !selectedOrgId,
+    enabled: enabled && !selectedOrgId,
   });
 
   const { data: orgCreditData, isLoading: orgCreditsLoading } = useQuery({
     ...trpc.organizations.getCreditBlocks.queryOptions({ organizationId: selectedOrgId ?? '' }),
-    enabled: Boolean(selectedOrgId),
+    enabled: enabled && Boolean(selectedOrgId),
     placeholderData: keepPreviousData,
   });
 
@@ -147,7 +149,7 @@ export function CreditsCard({ orgs }: Readonly<CreditsCardProps>) {
           {balanceFetching && <ActivityIndicator size="small" color={colors.mutedForeground} />}
         </View>
       )}
-      {!selectedOrgId && <KiloPassSubscriptionCard />}
+      {enabled && !selectedOrgId && <KiloPassSubscriptionCard />}
     </View>
   );
 }

--- a/apps/mobile/src/components/profile-screen.tsx
+++ b/apps/mobile/src/components/profile-screen.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import * as Application from 'expo-application';
-import { KeyRound, LogOut, Trash2 } from 'lucide-react-native';
+import { KeyRound, Lock, LogOut, Trash2 } from 'lucide-react-native';
 import { Alert, Platform, Pressable, ScrollView, View } from 'react-native';
 import { toast } from 'sonner-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -13,6 +13,8 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { useAuth } from '@/lib/auth/auth-context';
+import { revokeConsent } from '@/lib/consent';
+import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { useTRPC } from '@/lib/trpc';
 
@@ -22,6 +24,7 @@ function providerIcon(_provider: string) {
 
 export function ProfileScreen() {
   const { signOut } = useAuth();
+  const { userId } = useCurrentUserId();
   const trpc = useTRPC();
   const colors = useThemeColors();
   const {
@@ -73,6 +76,28 @@ export function ProfileScreen() {
         },
       },
     ]);
+  };
+
+  const confirmRevokeConsent = () => {
+    Alert.alert(
+      'Revoke data sharing consent?',
+      'Kilo Code needs this consent to function. Revoking will sign you out. You can accept again on next sign-in.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Revoke and sign out',
+          style: 'destructive',
+          onPress: () => {
+            void (async () => {
+              if (userId) {
+                await revokeConsent(userId);
+              }
+              await signOut();
+            })();
+          },
+        },
+      ]
+    );
   };
 
   return (
@@ -141,6 +166,16 @@ export function ProfileScreen() {
 
         {/* Actions */}
         <View className="mt-6 gap-3">
+          <Button
+            variant="ghost"
+            className="flex-row gap-2"
+            onPress={confirmRevokeConsent}
+            accessibilityLabel="Revoke data sharing consent"
+          >
+            <Lock size={16} color={colors.mutedForeground} />
+            <Text className="text-muted-foreground">Privacy choices</Text>
+          </Button>
+
           <Button
             variant="ghost"
             className="flex-row gap-2"

--- a/apps/mobile/src/components/profile-screen.tsx
+++ b/apps/mobile/src/components/profile-screen.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import * as Application from 'expo-application';
+import { type Href, useRouter } from 'expo-router';
 import { KeyRound, Lock, LogOut, Trash2 } from 'lucide-react-native';
 import { Alert, Platform, Pressable, ScrollView, View } from 'react-native';
 import { toast } from 'sonner-native';
@@ -13,8 +14,6 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { useAuth } from '@/lib/auth/auth-context';
-import { revokeConsent } from '@/lib/consent';
-import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { useTRPC } from '@/lib/trpc';
 
@@ -24,7 +23,7 @@ function providerIcon(_provider: string) {
 
 export function ProfileScreen() {
   const { signOut } = useAuth();
-  const { userId } = useCurrentUserId();
+  const router = useRouter();
   const trpc = useTRPC();
   const colors = useThemeColors();
   const {
@@ -78,28 +77,8 @@ export function ProfileScreen() {
     ]);
   };
 
-  const confirmRevokeConsent = () => {
-    if (!userId) {
-      toast.error('Could not load your account. Please try again.');
-      return;
-    }
-    Alert.alert(
-      'Revoke data sharing consent?',
-      'Kilo Code needs this consent to function. Revoking will sign you out. You can accept again on next sign-in.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Revoke and sign out',
-          style: 'destructive',
-          onPress: () => {
-            void (async () => {
-              await revokeConsent(userId);
-              await signOut();
-            })();
-          },
-        },
-      ]
-    );
+  const showPrivacyChoices = () => {
+    router.push('/(app)/consent?mode=review' as Href);
   };
 
   return (
@@ -171,8 +150,8 @@ export function ProfileScreen() {
           <Button
             variant="ghost"
             className="flex-row gap-2"
-            onPress={confirmRevokeConsent}
-            accessibilityLabel="Revoke data sharing consent"
+            onPress={showPrivacyChoices}
+            accessibilityLabel="Privacy choices"
           >
             <Lock size={16} color={colors.mutedForeground} />
             <Text className="text-muted-foreground">Privacy choices</Text>

--- a/apps/mobile/src/components/profile-screen.tsx
+++ b/apps/mobile/src/components/profile-screen.tsx
@@ -22,17 +22,24 @@ function providerIcon(_provider: string) {
 }
 
 export function ProfileScreen() {
-  const { signOut } = useAuth();
+  const { signOut, token } = useAuth();
   const router = useRouter();
   const trpc = useTRPC();
   const colors = useThemeColors();
+  const isAuthenticated = token != null;
   const {
     data,
     isLoading,
     isError: providersError,
     refetch: refetchProviders,
-  } = useQuery(trpc.user.getAuthProviders.queryOptions());
-  const { data: orgs } = useQuery(trpc.organizations.list.queryOptions());
+  } = useQuery({
+    ...trpc.user.getAuthProviders.queryOptions(),
+    enabled: isAuthenticated,
+  });
+  const { data: orgs } = useQuery({
+    ...trpc.organizations.list.queryOptions(),
+    enabled: isAuthenticated,
+  });
 
   const { bottom } = useSafeAreaInsets();
 
@@ -93,7 +100,7 @@ export function ProfileScreen() {
         showsVerticalScrollIndicator={false}
       >
         {/* Credits */}
-        <CreditsCard orgs={orgs} />
+        <CreditsCard orgs={orgs} enabled={isAuthenticated} />
 
         {/* Linked accounts */}
         <Animated.View className="mt-6 gap-3" layout={LinearTransition}>

--- a/apps/mobile/src/components/profile-screen.tsx
+++ b/apps/mobile/src/components/profile-screen.tsx
@@ -79,6 +79,10 @@ export function ProfileScreen() {
   };
 
   const confirmRevokeConsent = () => {
+    if (!userId) {
+      toast.error('Could not load your account. Please try again.');
+      return;
+    }
     Alert.alert(
       'Revoke data sharing consent?',
       'Kilo Code needs this consent to function. Revoking will sign you out. You can accept again on next sign-in.',
@@ -89,9 +93,7 @@ export function ProfileScreen() {
           style: 'destructive',
           onPress: () => {
             void (async () => {
-              if (userId) {
-                await revokeConsent(userId);
-              }
+              await revokeConsent(userId);
               await signOut();
             })();
           },

--- a/apps/mobile/src/lib/appsflyer-consent.test.ts
+++ b/apps/mobile/src/lib/appsflyer-consent.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldStartAppsFlyer } from './appsflyer-consent';
+
+describe('AppsFlyer consent gate', () => {
+  it('does not start before consent is checked and accepted', () => {
+    expect(
+      shouldStartAppsFlyer({
+        hasToken: true,
+        consentChecked: false,
+        needsConsent: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldStartAppsFlyer({
+        hasToken: true,
+        consentChecked: true,
+        needsConsent: true,
+      })
+    ).toBe(false);
+  });
+
+  it('starts only for signed-in users with accepted consent', () => {
+    expect(
+      shouldStartAppsFlyer({
+        hasToken: false,
+        consentChecked: true,
+        needsConsent: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldStartAppsFlyer({
+        hasToken: true,
+        consentChecked: true,
+        needsConsent: false,
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/mobile/src/lib/appsflyer-consent.ts
+++ b/apps/mobile/src/lib/appsflyer-consent.ts
@@ -1,0 +1,13 @@
+type AppsFlyerConsentState = {
+  readonly hasToken: boolean;
+  readonly consentChecked: boolean;
+  readonly needsConsent: boolean;
+};
+
+export function shouldStartAppsFlyer({
+  hasToken,
+  consentChecked,
+  needsConsent,
+}: AppsFlyerConsentState): boolean {
+  return hasToken && consentChecked && !needsConsent;
+}

--- a/apps/mobile/src/lib/consent-gate.test.ts
+++ b/apps/mobile/src/lib/consent-gate.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const store = vi.hoisted(() => new Map<string, string>());
+const shouldReject = vi.hoisted(() => ({ value: false }));
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn(async (key: string) => {
+    await Promise.resolve();
+    if (shouldReject.value) {
+      throw new Error('secure store unavailable');
+    }
+    return store.get(key) ?? null;
+  }),
+}));
+
+describe('consent gate', () => {
+  beforeEach(() => {
+    store.clear();
+    shouldReject.value = false;
+  });
+
+  it('returns needs-consent when consent has not been accepted', async () => {
+    const { checkConsentGate } = await import('./consent-gate');
+
+    expect(await checkConsentGate('user-1')).toEqual({ status: 'needs-consent' });
+  });
+
+  it('returns accepted when the current consent version is stored', async () => {
+    const { CURRENT_CONSENT_VERSION } = await import('./consent');
+    const { checkConsentGate } = await import('./consent-gate');
+    store.set('consent-accepted-user-1', String(CURRENT_CONSENT_VERSION));
+
+    expect(await checkConsentGate('user-1')).toEqual({ status: 'accepted' });
+  });
+
+  it('returns an error result when consent storage cannot be read', async () => {
+    const { checkConsentGate } = await import('./consent-gate');
+    shouldReject.value = true;
+
+    const result = await checkConsentGate('user-1');
+
+    expect(result.status).toBe('error');
+  });
+});

--- a/apps/mobile/src/lib/consent-gate.ts
+++ b/apps/mobile/src/lib/consent-gate.ts
@@ -1,0 +1,15 @@
+import { hasAcceptedConsent } from '@/lib/consent';
+
+type ConsentGateResult =
+  | { readonly status: 'accepted' }
+  | { readonly status: 'needs-consent' }
+  | { readonly status: 'error'; readonly error: unknown };
+
+export async function checkConsentGate(userId: string): Promise<ConsentGateResult> {
+  try {
+    const accepted = await hasAcceptedConsent(userId);
+    return accepted ? { status: 'accepted' } : { status: 'needs-consent' };
+  } catch (error) {
+    return { status: 'error', error };
+  }
+}

--- a/apps/mobile/src/lib/consent.test.ts
+++ b/apps/mobile/src/lib/consent.test.ts
@@ -1,18 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const store = new Map<string, string>();
+const store = vi.hoisted(() => new Map<string, string>());
 
 vi.mock('expo-secure-store', () => ({
-  getItemAsync: vi.fn(async (key: string) => store.get(key) ?? null),
+  getItemAsync: vi.fn(async (key: string) => {
+    await Promise.resolve();
+    return store.get(key) ?? null;
+  }),
   setItemAsync: vi.fn(async (key: string, value: string) => {
+    await Promise.resolve();
     store.set(key, value);
   }),
   deleteItemAsync: vi.fn(async (key: string) => {
+    await Promise.resolve();
     store.delete(key);
   }),
 }));
-
-import { acceptConsent, hasAcceptedConsent, revokeConsent } from './consent';
 
 describe('consent storage', () => {
   beforeEach(() => {
@@ -20,20 +23,46 @@ describe('consent storage', () => {
   });
 
   it('returns false when nothing is stored for the user', async () => {
+    const { hasAcceptedConsent } = await import('./consent');
+
     expect(await hasAcceptedConsent('user-1')).toBe(false);
   });
 
   it('returns true after acceptConsent for the same user', async () => {
+    const { CURRENT_CONSENT_VERSION, acceptConsent, hasAcceptedConsent } =
+      await import('./consent');
+
     await acceptConsent('user-1');
+    expect(store.get('consent-accepted:user-1')).toBe(String(CURRENT_CONSENT_VERSION));
     expect(await hasAcceptedConsent('user-1')).toBe(true);
   });
 
+  it('returns false when the stored consent version is old', async () => {
+    const { hasAcceptedConsent } = await import('./consent');
+
+    store.set('consent-accepted:user-1', '0');
+
+    expect(await hasAcceptedConsent('user-1')).toBe(false);
+  });
+
+  it('returns false for old unversioned consent records', async () => {
+    const { hasAcceptedConsent } = await import('./consent');
+
+    store.set('consent-accepted:user-1', 'true');
+
+    expect(await hasAcceptedConsent('user-1')).toBe(false);
+  });
+
   it('isolates acceptance per user id', async () => {
+    const { acceptConsent, hasAcceptedConsent } = await import('./consent');
+
     await acceptConsent('user-1');
     expect(await hasAcceptedConsent('user-2')).toBe(false);
   });
 
   it('revokes acceptance for the user', async () => {
+    const { acceptConsent, hasAcceptedConsent, revokeConsent } = await import('./consent');
+
     await acceptConsent('user-1');
     await revokeConsent('user-1');
     expect(await hasAcceptedConsent('user-1')).toBe(false);

--- a/apps/mobile/src/lib/consent.test.ts
+++ b/apps/mobile/src/lib/consent.test.ts
@@ -72,12 +72,13 @@ describe('consent storage', () => {
     const { acceptConsent, revokeConsent, subscribeToConsentChanges } = await import('./consent');
     const changes: string[] = [];
 
-    subscribeToConsentChanges(change => {
+    const unsubscribe = subscribeToConsentChanges(change => {
       changes.push(`${change.userId}:${change.hasAccepted ? 'accepted' : 'revoked'}`);
     });
 
     await acceptConsent('user-1');
     await revokeConsent('user-1');
+    unsubscribe();
 
     expect(changes).toEqual(['user-1:accepted', 'user-1:revoked']);
   });

--- a/apps/mobile/src/lib/consent.test.ts
+++ b/apps/mobile/src/lib/consent.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const store = new Map<string, string>();
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn(async (key: string) => store.get(key) ?? null),
+  setItemAsync: vi.fn(async (key: string, value: string) => {
+    store.set(key, value);
+  }),
+  deleteItemAsync: vi.fn(async (key: string) => {
+    store.delete(key);
+  }),
+}));
+
+import { acceptConsent, hasAcceptedConsent, revokeConsent } from './consent';
+
+describe('consent storage', () => {
+  beforeEach(() => {
+    store.clear();
+  });
+
+  it('returns false when nothing is stored for the user', async () => {
+    expect(await hasAcceptedConsent('user-1')).toBe(false);
+  });
+
+  it('returns true after acceptConsent for the same user', async () => {
+    await acceptConsent('user-1');
+    expect(await hasAcceptedConsent('user-1')).toBe(true);
+  });
+
+  it('isolates acceptance per user id', async () => {
+    await acceptConsent('user-1');
+    expect(await hasAcceptedConsent('user-2')).toBe(false);
+  });
+
+  it('revokes acceptance for the user', async () => {
+    await acceptConsent('user-1');
+    await revokeConsent('user-1');
+    expect(await hasAcceptedConsent('user-1')).toBe(false);
+  });
+});

--- a/apps/mobile/src/lib/consent.test.ts
+++ b/apps/mobile/src/lib/consent.test.ts
@@ -33,14 +33,14 @@ describe('consent storage', () => {
       await import('./consent');
 
     await acceptConsent('user-1');
-    expect(store.get('consent-accepted:user-1')).toBe(String(CURRENT_CONSENT_VERSION));
+    expect(store.get('consent-accepted-user-1')).toBe(String(CURRENT_CONSENT_VERSION));
     expect(await hasAcceptedConsent('user-1')).toBe(true);
   });
 
   it('returns false when the stored consent version is old', async () => {
     const { hasAcceptedConsent } = await import('./consent');
 
-    store.set('consent-accepted:user-1', '0');
+    store.set('consent-accepted-user-1', '0');
 
     expect(await hasAcceptedConsent('user-1')).toBe(false);
   });
@@ -48,7 +48,7 @@ describe('consent storage', () => {
   it('returns false for old unversioned consent records', async () => {
     const { hasAcceptedConsent } = await import('./consent');
 
-    store.set('consent-accepted:user-1', 'true');
+    store.set('consent-accepted-user-1', 'true');
 
     expect(await hasAcceptedConsent('user-1')).toBe(false);
   });
@@ -66,5 +66,33 @@ describe('consent storage', () => {
     await acceptConsent('user-1');
     await revokeConsent('user-1');
     expect(await hasAcceptedConsent('user-1')).toBe(false);
+  });
+
+  it('notifies listeners when consent changes for a user', async () => {
+    const { acceptConsent, revokeConsent, subscribeToConsentChanges } = await import('./consent');
+    const changes: string[] = [];
+
+    subscribeToConsentChanges(change => {
+      changes.push(`${change.userId}:${change.hasAccepted ? 'accepted' : 'revoked'}`);
+    });
+
+    await acceptConsent('user-1');
+    await revokeConsent('user-1');
+
+    expect(changes).toEqual(['user-1:accepted', 'user-1:revoked']);
+  });
+
+  it('stops notifying unsubscribed consent listeners', async () => {
+    const { acceptConsent, subscribeToConsentChanges } = await import('./consent');
+    const changes: string[] = [];
+
+    const unsubscribe = subscribeToConsentChanges(change => {
+      changes.push(change.userId);
+    });
+
+    unsubscribe();
+    await acceptConsent('user-1');
+
+    expect(changes).toEqual([]);
   });
 });

--- a/apps/mobile/src/lib/consent.ts
+++ b/apps/mobile/src/lib/consent.ts
@@ -4,8 +4,31 @@ import { CONSENT_USER_KEY_PREFIX } from '@/lib/storage-keys';
 
 export const CURRENT_CONSENT_VERSION = 1;
 
+export type ConsentChange = {
+  readonly userId: string;
+  readonly hasAccepted: boolean;
+};
+
+type ConsentChangeListener = (change: ConsentChange) => void;
+
+const listeners = new Set<ConsentChangeListener>();
+
 function keyFor(userId: string): string {
   return `${CONSENT_USER_KEY_PREFIX}${userId}`;
+}
+
+function notifyConsentChange(change: ConsentChange) {
+  for (const listener of listeners) {
+    listener(change);
+  }
+}
+
+export function subscribeToConsentChanges(listener: ConsentChangeListener): () => void {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
 }
 
 export async function hasAcceptedConsent(userId: string): Promise<boolean> {
@@ -19,8 +42,10 @@ export async function hasAcceptedConsent(userId: string): Promise<boolean> {
 
 export async function acceptConsent(userId: string): Promise<void> {
   await SecureStore.setItemAsync(keyFor(userId), String(CURRENT_CONSENT_VERSION));
+  notifyConsentChange({ userId, hasAccepted: true });
 }
 
 export async function revokeConsent(userId: string): Promise<void> {
   await SecureStore.deleteItemAsync(keyFor(userId));
+  notifyConsentChange({ userId, hasAccepted: false });
 }

--- a/apps/mobile/src/lib/consent.ts
+++ b/apps/mobile/src/lib/consent.ts
@@ -2,17 +2,23 @@ import * as SecureStore from 'expo-secure-store';
 
 import { CONSENT_USER_KEY_PREFIX } from '@/lib/storage-keys';
 
+export const CURRENT_CONSENT_VERSION = 1;
+
 function keyFor(userId: string): string {
   return `${CONSENT_USER_KEY_PREFIX}${userId}`;
 }
 
 export async function hasAcceptedConsent(userId: string): Promise<boolean> {
   const value = await SecureStore.getItemAsync(keyFor(userId));
-  return value === 'true';
+  if (!value) {
+    return false;
+  }
+
+  return Number(value) === CURRENT_CONSENT_VERSION;
 }
 
 export async function acceptConsent(userId: string): Promise<void> {
-  await SecureStore.setItemAsync(keyFor(userId), 'true');
+  await SecureStore.setItemAsync(keyFor(userId), String(CURRENT_CONSENT_VERSION));
 }
 
 export async function revokeConsent(userId: string): Promise<void> {

--- a/apps/mobile/src/lib/consent.ts
+++ b/apps/mobile/src/lib/consent.ts
@@ -1,0 +1,20 @@
+import * as SecureStore from 'expo-secure-store';
+
+import { CONSENT_USER_KEY_PREFIX } from '@/lib/storage-keys';
+
+function keyFor(userId: string): string {
+  return `${CONSENT_USER_KEY_PREFIX}${userId}`;
+}
+
+export async function hasAcceptedConsent(userId: string): Promise<boolean> {
+  const value = await SecureStore.getItemAsync(keyFor(userId));
+  return value === 'true';
+}
+
+export async function acceptConsent(userId: string): Promise<void> {
+  await SecureStore.setItemAsync(keyFor(userId), 'true');
+}
+
+export async function revokeConsent(userId: string): Promise<void> {
+  await SecureStore.deleteItemAsync(keyFor(userId));
+}

--- a/apps/mobile/src/lib/consent.ts
+++ b/apps/mobile/src/lib/consent.ts
@@ -4,7 +4,7 @@ import { CONSENT_USER_KEY_PREFIX } from '@/lib/storage-keys';
 
 export const CURRENT_CONSENT_VERSION = 1;
 
-export type ConsentChange = {
+type ConsentChange = {
   readonly userId: string;
   readonly hasAccepted: boolean;
 };

--- a/apps/mobile/src/lib/hooks/use-appsflyer-consent-gate.ts
+++ b/apps/mobile/src/lib/hooks/use-appsflyer-consent-gate.ts
@@ -1,0 +1,33 @@
+import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+
+import { shouldStartAppsFlyer } from '@/lib/appsflyer-consent';
+import { initAppsFlyer } from '@/lib/appsflyer';
+
+type AppsFlyerConsentGateState = {
+  readonly hasToken: boolean;
+  readonly consentChecked: boolean;
+  readonly needsConsent: boolean;
+};
+
+export function useAppsFlyerConsentGate({
+  hasToken,
+  consentChecked,
+  needsConsent,
+}: AppsFlyerConsentGateState): void {
+  useEffect(() => {
+    if (!shouldStartAppsFlyer({ hasToken, consentChecked, needsConsent })) {
+      return;
+    }
+
+    async function startAppsFlyer() {
+      if (Platform.OS === 'ios') {
+        await requestTrackingPermissionsAsync();
+      }
+      initAppsFlyer();
+    }
+
+    void startAppsFlyer();
+  }, [hasToken, consentChecked, needsConsent]);
+}

--- a/apps/mobile/src/lib/hooks/use-current-user-id.ts
+++ b/apps/mobile/src/lib/hooks/use-current-user-id.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useTRPC } from '@/lib/trpc';
+
+export function useCurrentUserId(): {
+  userId: string | undefined;
+  isLoading: boolean;
+  isError: boolean;
+} {
+  const trpc = useTRPC();
+  const { data, isLoading, isError } = useQuery(trpc.user.getMe.queryOptions());
+
+  return {
+    userId: data?.id,
+    isLoading,
+    isError,
+  };
+}

--- a/apps/mobile/src/lib/hooks/use-current-user-id.ts
+++ b/apps/mobile/src/lib/hooks/use-current-user-id.ts
@@ -10,9 +10,10 @@ export function useCurrentUserId(options: UseCurrentUserIdOptions = {}): {
   userId: string | undefined;
   isLoading: boolean;
   isError: boolean;
+  refetch: () => void;
 } {
   const trpc = useTRPC();
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError, refetch } = useQuery({
     ...trpc.user.getMe.queryOptions(),
     enabled: options.enabled ?? true,
   });
@@ -21,5 +22,8 @@ export function useCurrentUserId(options: UseCurrentUserIdOptions = {}): {
     userId: data?.id,
     isLoading,
     isError,
+    refetch: () => {
+      void refetch();
+    },
   };
 }

--- a/apps/mobile/src/lib/hooks/use-current-user-id.ts
+++ b/apps/mobile/src/lib/hooks/use-current-user-id.ts
@@ -2,13 +2,20 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useTRPC } from '@/lib/trpc';
 
-export function useCurrentUserId(): {
+type UseCurrentUserIdOptions = {
+  readonly enabled?: boolean;
+};
+
+export function useCurrentUserId(options: UseCurrentUserIdOptions = {}): {
   userId: string | undefined;
   isLoading: boolean;
   isError: boolean;
 } {
   const trpc = useTRPC();
-  const { data, isLoading, isError } = useQuery(trpc.user.getMe.queryOptions());
+  const { data, isLoading, isError } = useQuery({
+    ...trpc.user.getMe.queryOptions(),
+    enabled: options.enabled ?? true,
+  });
 
   return {
     userId: data?.id,

--- a/apps/mobile/src/lib/storage-keys.ts
+++ b/apps/mobile/src/lib/storage-keys.ts
@@ -10,3 +10,4 @@ export const ORGANIZATION_STORAGE_KEY = 'selected-organization';
 export const SESSION_FILTERS_KEY = 'agent-session-filters';
 export const NOTIFICATION_PROMPT_SEEN_KEY = 'notification-prompt-seen';
 export const LAST_ACTIVE_INSTANCE_KEY = 'last-active-chat-instance';
+export const CONSENT_USER_KEY_PREFIX = 'consent-accepted:';

--- a/apps/mobile/src/lib/storage-keys.ts
+++ b/apps/mobile/src/lib/storage-keys.ts
@@ -3,6 +3,7 @@
  *
  * All keys used with expo-secure-store should be defined here so they stay
  * consistent across reads, writes, and sign-out cleanup.
+ * Keys must not be empty and contain only alphanumeric characters, ".", "-", and "_".
  */
 
 export const AUTH_TOKEN_KEY = 'auth-token';
@@ -10,4 +11,4 @@ export const ORGANIZATION_STORAGE_KEY = 'selected-organization';
 export const SESSION_FILTERS_KEY = 'agent-session-filters';
 export const NOTIFICATION_PROMPT_SEEN_KEY = 'notification-prompt-seen';
 export const LAST_ACTIVE_INSTANCE_KEY = 'last-active-chat-instance';
-export const CONSENT_USER_KEY_PREFIX = 'consent-accepted:';
+export const CONSENT_USER_KEY_PREFIX = 'consent-accepted-';

--- a/apps/web/src/routers/user-router.ts
+++ b/apps/web/src/routers/user-router.ts
@@ -256,6 +256,10 @@ async function enrichDeductionsWithInstanceNames(
 
 export const userRouter = createTRPCRouter({
   // Account linking routes
+  getMe: baseProcedure.query(async ({ ctx }) => {
+    return successResult({ id: ctx.user.id });
+  }),
+
   getAuthProviders: baseProcedure.query(async ({ ctx }) => {
     const providers = await getUserAuthProviders(ctx.user.id);
 

--- a/dev/local/mobile-env.test.ts
+++ b/dev/local/mobile-env.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { applyEnvValues, buildMobileEnvValues, isUsableIpv4, upsertRootEnv } from './mobile-env';
+
+test('builds LAN URLs for every mobile-facing local service', () => {
+  const values = buildMobileEnvValues('192.168.1.10');
+
+  assert.equal(values.get('API_BASE_URL'), 'http://192.168.1.10:3000');
+  assert.equal(values.get('WEB_BASE_URL'), 'http://192.168.1.10:3000');
+  assert.equal(values.get('CLOUD_AGENT_WS_URL'), 'ws://192.168.1.10:8794');
+  assert.equal(values.get('SESSION_INGEST_WS_URL'), 'ws://192.168.1.10:8800');
+  assert.equal(values.get('KILO_CHAT_URL'), 'http://192.168.1.10:8808');
+  assert.equal(values.get('EVENT_SERVICE_URL'), 'ws://192.168.1.10:8809');
+  assert.equal(values.get('NOTIFICATIONS_URL'), 'http://192.168.1.10:8804');
+});
+
+test('rewrites only requested env keys while preserving comments and other values', () => {
+  const content = [
+    '# comment',
+    'API_BASE_URL=http://localhost:3000',
+    'APPSFLYER_APP_ID=6761193135',
+    '',
+  ].join('\n');
+
+  const result = applyEnvValues(
+    content,
+    new Map([
+      ['API_BASE_URL', 'http://192.168.1.10:3000'],
+      ['WEB_BASE_URL', 'http://192.168.1.10:3000'],
+    ])
+  );
+
+  assert.equal(
+    result,
+    [
+      '# comment',
+      'API_BASE_URL=http://192.168.1.10:3000',
+      'APPSFLYER_APP_ID=6761193135',
+      '',
+      'WEB_BASE_URL=http://192.168.1.10:3000',
+      '',
+    ].join('\n')
+  );
+});
+
+test('upserts quoted web app URL values in root env', () => {
+  const result = upsertRootEnv(
+    ['NEXTAUTH_URL="http://localhost:3000"', 'OTHER=value', ''].join('\n'),
+    new Map([
+      ['APP_URL_OVERRIDE', 'http://192.168.1.10:3000'],
+      ['NEXTAUTH_URL', 'http://192.168.1.10:3000'],
+    ])
+  );
+
+  assert.equal(
+    result,
+    [
+      'NEXTAUTH_URL="http://192.168.1.10:3000"',
+      'OTHER=value',
+      '',
+      'APP_URL_OVERRIDE="http://192.168.1.10:3000"',
+      '',
+    ].join('\n')
+  );
+});
+
+test('validates IPv4-looking host values', () => {
+  assert.equal(isUsableIpv4('192.168.1.10'), true);
+  assert.equal(isUsableIpv4('localhost'), false);
+  assert.equal(isUsableIpv4(undefined), false);
+});

--- a/dev/local/mobile-env.test.ts
+++ b/dev/local/mobile-env.test.ts
@@ -66,6 +66,7 @@ test('upserts quoted web app URL values in root env', () => {
 
 test('validates IPv4-looking host values', () => {
   assert.equal(isUsableIpv4('192.168.1.10'), true);
+  assert.equal(isUsableIpv4('999.999.999.999'), false);
   assert.equal(isUsableIpv4('localhost'), false);
   assert.equal(isUsableIpv4(undefined), false);
 });

--- a/dev/local/mobile-env.ts
+++ b/dev/local/mobile-env.ts
@@ -1,0 +1,205 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { services } from './services';
+
+const MOBILE_ENV_REL_PATH = 'apps/mobile/.env.local';
+const MOBILE_ENV_EXAMPLE_REL_PATH = 'apps/mobile/.env.local.example';
+const ROOT_ENV_REL_PATH = '.env.local';
+
+const URL_KEY_TO_SERVICE = new Map<string, { service: string; protocol: 'http' | 'ws' }>([
+  ['API_BASE_URL', { service: 'nextjs', protocol: 'http' }],
+  ['WEB_BASE_URL', { service: 'nextjs', protocol: 'http' }],
+  ['CLOUD_AGENT_WS_URL', { service: 'cloud-agent-next', protocol: 'ws' }],
+  ['SESSION_INGEST_WS_URL', { service: 'cloudflare-session-ingest', protocol: 'ws' }],
+  ['KILO_CHAT_URL', { service: 'kilo-chat', protocol: 'http' }],
+  ['EVENT_SERVICE_URL', { service: 'event-service', protocol: 'ws' }],
+  ['NOTIFICATIONS_URL', { service: 'notifications', protocol: 'http' }],
+]);
+
+type MobileEnvValues = ReadonlyMap<string, string>;
+
+function parseArgs(args: string[]): { host: string | undefined } {
+  let host = process.env.MOBILE_DEV_HOST;
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--host') {
+      host = args[index + 1];
+      index++;
+    } else if (arg?.startsWith('--host=')) {
+      host = arg.slice('--host='.length);
+    } else if (arg === '--help' || arg === '-h') {
+      console.log('Usage: pnpm dev:env:mobile [--host <lan-ip>]');
+      process.exit(0);
+    }
+  }
+  return { host };
+}
+
+function isUsableIpv4(value: string | undefined): value is string {
+  return typeof value === 'string' && /^\d{1,3}(?:\.\d{1,3}){3}$/.test(value);
+}
+
+function detectLanIp(): string | undefined {
+  try {
+    const routeOutput = execFileSync('route', ['-n', 'get', 'default'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const iface = routeOutput.match(/interface:\s*(\S+)/)?.[1];
+    if (iface) {
+      const ip = execFileSync('ipconfig', ['getifaddr', iface], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      if (isUsableIpv4(ip)) {
+        return ip;
+      }
+    }
+  } catch {
+    // Fall through to Node's cross-platform interface scan.
+  }
+
+  for (const addresses of Object.values(os.networkInterfaces())) {
+    for (const address of addresses ?? []) {
+      if (address.family === 'IPv4' && !address.internal && isUsableIpv4(address.address)) {
+        return address.address;
+      }
+    }
+  }
+  return undefined;
+}
+
+function serviceUrl(host: string, serviceName: string, protocol: 'http' | 'ws'): string {
+  const service = services.get(serviceName);
+  if (!service) {
+    throw new Error(`Unknown service: ${serviceName}`);
+  }
+  return `${protocol}://${host}:${service.port}`;
+}
+
+function buildMobileEnvValues(host: string): MobileEnvValues {
+  const values = new Map<string, string>();
+  for (const [key, target] of URL_KEY_TO_SERVICE) {
+    values.set(key, serviceUrl(host, target.service, target.protocol));
+  }
+  return values;
+}
+
+function applyEnvValues(content: string, values: MobileEnvValues): string {
+  const seen = new Set<string>();
+  const lines = content.split('\n').map(line => {
+    const match = line.match(/^([A-Z0-9_]+)=/);
+    if (!match) {
+      return line;
+    }
+    const key = match[1];
+    const value = values.get(key);
+    if (value === undefined) {
+      return line;
+    }
+    seen.add(key);
+    return `${key}=${value}`;
+  });
+
+  for (const [key, value] of values) {
+    if (!seen.has(key)) {
+      lines.push(`${key}=${value}`);
+    }
+  }
+
+  return `${lines.join('\n').replace(/\n*$/, '')}\n`;
+}
+
+function quoteEnvValue(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function upsertRootEnv(content: string, values: MobileEnvValues): string {
+  const quotedValues = new Map(
+    [...values.entries()].map(([key, value]) => [key, quoteEnvValue(value)] as const)
+  );
+  return applyEnvValues(content, quotedValues);
+}
+
+function writeMobileEnv(repoRoot: string, host: string): void {
+  const examplePath = path.join(repoRoot, MOBILE_ENV_EXAMPLE_REL_PATH);
+  const envPath = path.join(repoRoot, MOBILE_ENV_REL_PATH);
+  if (!fs.existsSync(examplePath)) {
+    throw new Error(`Missing ${MOBILE_ENV_EXAMPLE_REL_PATH}`);
+  }
+
+  const content = fs.readFileSync(examplePath, 'utf-8');
+  fs.writeFileSync(envPath, applyEnvValues(content, buildMobileEnvValues(host)), 'utf-8');
+}
+
+function writeRootEnv(repoRoot: string, host: string): void {
+  const envPath = path.join(repoRoot, ROOT_ENV_REL_PATH);
+  if (!fs.existsSync(envPath)) {
+    throw new Error(`Missing ${ROOT_ENV_REL_PATH}. Run: vercel env pull .env.local`);
+  }
+
+  const appUrl = serviceUrl(host, 'nextjs', 'http');
+  const values = new Map([
+    ['APP_URL_OVERRIDE', appUrl],
+    ['NEXTAUTH_URL', appUrl],
+  ]);
+  const content = fs.readFileSync(envPath, 'utf-8');
+  fs.writeFileSync(envPath, upsertRootEnv(content, values), 'utf-8');
+}
+
+function findRepoRoot(): string {
+  let dir = import.meta.dirname;
+  for (let i = 0; i < 20; i++) {
+    const pkgPath = path.join(dir, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { name?: string };
+      if (pkg.name === 'kilocode-monorepo') {
+        return dir;
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  throw new Error("Could not find repo root (package.json with name 'kilocode-monorepo')");
+}
+
+function main(): void {
+  const { host: hostArg } = parseArgs(process.argv.slice(2));
+  const host = hostArg ?? detectLanIp();
+  if (!isUsableIpv4(host)) {
+    throw new Error(
+      'Could not detect LAN IP. Pass one explicitly: pnpm dev:env:mobile -- --host 192.168.x.x'
+    );
+  }
+
+  const repoRoot = findRepoRoot();
+  writeMobileEnv(repoRoot, host);
+  writeRootEnv(repoRoot, host);
+
+  const appUrl = serviceUrl(host, 'nextjs', 'http');
+  console.log(`Wrote ${MOBILE_ENV_REL_PATH}`);
+  console.log(`Updated ${ROOT_ENV_REL_PATH} APP_URL_OVERRIDE and NEXTAUTH_URL`);
+  console.log(`Mobile web/API base URL: ${appUrl}`);
+  console.log('Restart Next.js after changing this while dev is running: pnpm dev:restart nextjs');
+  console.log('Reload or restart the mobile dev build so Expo reads apps/mobile/.env.local.');
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(import.meta.dirname, 'mobile-env.ts');
+
+if (isMain) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}
+
+export { applyEnvValues, buildMobileEnvValues, detectLanIp, isUsableIpv4, upsertRootEnv };

--- a/dev/local/mobile-env.ts
+++ b/dev/local/mobile-env.ts
@@ -38,7 +38,11 @@ function parseArgs(args: string[]): { host: string | undefined } {
 }
 
 function isUsableIpv4(value: string | undefined): value is string {
-  return typeof value === 'string' && /^\d{1,3}(?:\.\d{1,3}){3}$/.test(value);
+  if (typeof value !== 'string' || !/^\d{1,3}(?:\.\d{1,3}){3}$/.test(value)) {
+    return false;
+  }
+
+  return value.split('.').every(part => Number(part) <= 255);
 }
 
 function detectLanIp(): string | undefined {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dev:status": "tsx dev/local/cli.ts status",
     "dev:restart": "tsx dev/local/cli.ts restart",
     "dev:env": "tsx dev/local/cli.ts env",
+    "dev:env:mobile": "tsx dev/local/mobile-env.ts",
     "dev:seed": "tsx dev/seed/index.ts",
     "dev:discord-gateway-cron": "tsx dev/discord-gateway-cron.ts",
     "dev:kiloclaw-fly-instances": "tsx services/kiloclaw/scripts/dev-fly-instances.ts"


### PR DESCRIPTION
## Summary

- Add `user.getMe` plus a mobile current-user hook so the app can key consent by account.
- Add versioned device-local consent storage and boot gating that re-prompts when `CURRENT_CONSENT_VERSION` is bumped.
- Add the consent/details screens and a Profile "Privacy choices" revoke action that signs the user out.

## Verification

- [ ] Not run: manual mobile flows require a dev build/device session that is not available from this environment.

## Visual Changes

Not captured; the new consent and details screens need device/simulator screenshots during manual verification.

## Reviewer Notes

- Consent versioning lives in `apps/mobile/src/lib/consent.ts`; increment `CURRENT_CONSENT_VERSION` to re-prompt accepted users on their next boot.
- Please focus manual review on cold start while already signed in, per-account isolation, and the revoke/sign-out path.