### PR TITLE
fix(kiloclaw): stage bundled plugin deps in image

### DIFF
--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -275,6 +275,10 @@ tag (16 bytes)`.
      supervisor.
    - `GOG_KEYRING_PASSWORD=kiloclaw` — required for the gog keyring
      backend (not a secret; see gog-credentials.ts).
+   - `OPENCLAW_PLUGIN_STAGE_DIR=/usr/local/share/openclaw-plugin-runtime-deps`
+     when unset — keep bundled OpenClaw plugin runtime dependencies in
+     the image-baked stage directory instead of mutating `/root` or each
+     bundled plugin directory during doctor/gateway startup.
 
 ### Feature Flags
 

--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -13,6 +13,13 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-05-13',
     description:
+      'Baked bundled OpenClaw plugin runtime dependencies into the KiloClaw image so doctor and gateway startup no longer need to install them one plugin at a time. This reduces cold-start delays on shared-CPU instances and only affects bundled OpenClaw plugins; custom user-installed plugins keep their normal install behavior.',
+    category: 'feature',
+    deployHint: 'redeploy_suggested',
+  },
+  {
+    date: '2026-05-13',
+    description:
       'Optimized the KiloClaw image and startup path by cleaning npm and Bun package caches. Build-time cleanup reduces deployed image size, and runtime npm cache cleanup now runs after bootstrap finishes so it reduces persistent storage growth without delaying readiness.',
     category: 'feature',
     deployHint: 'redeploy_suggested',

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -10,6 +10,7 @@ FROM debian:trixie-slim AS runtime
 
 # Install Node.js 24 (required by OpenClaw)
 ENV NODE_VERSION=24.15.0
+ENV OPENCLAW_PLUGIN_STAGE_DIR=/usr/local/share/openclaw-plugin-runtime-deps
 ARG APT_CACHE_BUST
 RUN echo "apt cache bust: ${APT_CACHE_BUST}" \
     && apt-get update \
@@ -79,17 +80,22 @@ RUN npm install -g pnpm openclaw@2026.4.23 clawhub mcporter@0.7.3 @steipete/summ
     && openclaw --version \
     && npm cache clean --force
 
-# Bake bundled plugin runtime deps into the image so first boot is pure
-# startup — no npm install from `openclaw doctor` on shared-cpu Fly machines.
-# Each step writes to a temp file and is chained with && so failures break
-# the build (Debian's /bin/sh is dash, no pipefail). jq does the workspace:
-# filter so no pipe is needed between jq and sort.
+# Bake bundled plugin runtime deps into OpenClaw's external stage dir so first
+# boot is pure startup — no npm install from `openclaw doctor` or gateway plugin
+# load on shared-cpu Fly machines. The stage-root naming mirrors OpenClaw
+# 2026.4.23's resolveExternalBundledRuntimeDepsInstallRoot().
 RUN cd /usr/local/lib/node_modules/openclaw \
+    && OPENCLAW_PACKAGE_ROOT="$(pwd -P)" \
+    && OPENCLAW_PACKAGE_VERSION="$(node -p "require('./package.json').version")" \
+    && OPENCLAW_PACKAGE_HASH="$(node -e "process.stdout.write(require('node:crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 12))" "$OPENCLAW_PACKAGE_ROOT")" \
+    && OPENCLAW_BUNDLED_RUNTIME_ROOT="${OPENCLAW_PLUGIN_STAGE_DIR}/openclaw-${OPENCLAW_PACKAGE_VERSION}-${OPENCLAW_PACKAGE_HASH}" \
+    && mkdir -p "$OPENCLAW_BUNDLED_RUNTIME_ROOT" \
     && jq -r '((.dependencies // {}) + (.optionalDependencies // {})) | to_entries[] | select(.value | startswith("workspace:") | not) | "\(.key)@\(.value)"' \
          dist/extensions/*/package.json > /tmp/bundled-plugin-specs.raw \
     && sort -u /tmp/bundled-plugin-specs.raw > /tmp/bundled-plugin-specs.txt \
     && test -s /tmp/bundled-plugin-specs.txt \
     && xargs -a /tmp/bundled-plugin-specs.txt npm install \
+           --prefix "$OPENCLAW_BUNDLED_RUNTIME_ROOT" \
            --omit=dev --no-save --package-lock=false \
            --ignore-scripts --legacy-peer-deps \
            --no-fund --no-audit \

--- a/services/kiloclaw/Dockerfile.local
+++ b/services/kiloclaw/Dockerfile.local
@@ -2,6 +2,7 @@ FROM debian:trixie-slim AS runtime
 
 # Install Node.js 24 (required by OpenClaw)
 ENV NODE_VERSION=24.15.0
+ENV OPENCLAW_PLUGIN_STAGE_DIR=/usr/local/share/openclaw-plugin-runtime-deps
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        ca-certificates curl gnupg git xz-utils unzip jq ripgrep rsync zstd \
@@ -45,6 +46,27 @@ RUN npm install -g pnpm /tmp/openclaw.tgz clawhub mcporter@0.7.3 @steipete/summa
     && rm /tmp/openclaw.tgz \
     && openclaw --version \
     && npm cache clean --force
+
+# Bake bundled plugin runtime deps into OpenClaw's external stage dir so local
+# images match production startup behavior. The stage-root naming mirrors
+# OpenClaw's resolveExternalBundledRuntimeDepsInstallRoot().
+RUN cd /usr/local/lib/node_modules/openclaw \
+    && OPENCLAW_PACKAGE_ROOT="$(pwd -P)" \
+    && OPENCLAW_PACKAGE_VERSION="$(node -p "require('./package.json').version")" \
+    && OPENCLAW_PACKAGE_HASH="$(node -e "process.stdout.write(require('node:crypto').createHash('sha256').update(process.argv[1]).digest('hex').slice(0, 12))" "$OPENCLAW_PACKAGE_ROOT")" \
+    && OPENCLAW_BUNDLED_RUNTIME_ROOT="${OPENCLAW_PLUGIN_STAGE_DIR}/openclaw-${OPENCLAW_PACKAGE_VERSION}-${OPENCLAW_PACKAGE_HASH}" \
+    && mkdir -p "$OPENCLAW_BUNDLED_RUNTIME_ROOT" \
+    && jq -r '((.dependencies // {}) + (.optionalDependencies // {})) | to_entries[] | select(.value | startswith("workspace:") | not) | "\(.key)@\(.value)"' \
+         dist/extensions/*/package.json > /tmp/bundled-plugin-specs.raw \
+    && sort -u /tmp/bundled-plugin-specs.raw > /tmp/bundled-plugin-specs.txt \
+    && test -s /tmp/bundled-plugin-specs.txt \
+    && xargs -a /tmp/bundled-plugin-specs.txt npm install \
+           --prefix "$OPENCLAW_BUNDLED_RUNTIME_ROOT" \
+           --omit=dev --no-save --package-lock=false \
+           --ignore-scripts --legacy-peer-deps \
+           --no-fund --no-audit \
+    && rm -f /tmp/bundled-plugin-specs.raw /tmp/bundled-plugin-specs.txt \
+    && rm -rf /root/.npm
 
 # Install Go (available at runtime for users to `go install` additional tools)
 ENV GO_VERSION=1.26.2

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -297,6 +297,18 @@ describe('setupDirectories', () => {
     expect(env.NODE_COMPILE_CACHE).toBe('/var/tmp/openclaw-compile-cache');
     expect(env.INVOCATION_ID).toBe('1');
     expect(env.GOG_KEYRING_PASSWORD).toBe('kiloclaw');
+    expect(env.OPENCLAW_PLUGIN_STAGE_DIR).toBe('/usr/local/share/openclaw-plugin-runtime-deps');
+  });
+
+  it('preserves an explicit OpenClaw plugin stage dir', () => {
+    const { deps } = fakeDeps();
+    const env: Record<string, string | undefined> = {
+      OPENCLAW_PLUGIN_STAGE_DIR: '/custom/plugin-runtime-deps',
+    };
+
+    setupDirectories(env, deps);
+
+    expect(env.OPENCLAW_PLUGIN_STAGE_DIR).toBe('/custom/plugin-runtime-deps');
   });
 
   it('derives KILO_API_URL from KILOCODE_API_BASE_URL origin', () => {

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -32,6 +32,7 @@ const DEVICE_PAIRED_PATH = '/root/.openclaw/devices/paired.json';
 const DEVICE_PENDING_PATH = '/root/.openclaw/devices/pending.json';
 const WORKSPACE_DIR = '/root/clawd';
 const COMPILE_CACHE_DIR = '/var/tmp/openclaw-compile-cache';
+const OPENCLAW_PLUGIN_STAGE_DIR = '/usr/local/share/openclaw-plugin-runtime-deps';
 const TOOLS_MD_SOURCE = '/usr/local/share/kiloclaw/TOOLS.md';
 const TOOLS_MD_DEST = '/root/.openclaw/workspace/TOOLS.md';
 const WEATHER_SKILL_SOURCE = '/usr/local/share/kiloclaw/skills/weather/SKILL.md';
@@ -272,6 +273,13 @@ export function setupDirectories(env: EnvLike, deps: BootstrapDeps = defaultDeps
 
   // GOG_KEYRING_PASSWORD is NOT a secret — see gog-credentials.ts for context.
   env.GOG_KEYRING_PASSWORD = 'kiloclaw';
+
+  // Keep bundled OpenClaw plugin runtime deps in the image-baked stage dir
+  // instead of mutating each bundled plugin directory or the persistent /root
+  // volume during doctor/gateway startup.
+  if (!env.OPENCLAW_PLUGIN_STAGE_DIR?.trim()) {
+    env.OPENCLAW_PLUGIN_STAGE_DIR = OPENCLAW_PLUGIN_STAGE_DIR;
+  }
 
   // Derive the API origin for the Kilo CLI from the full base URL.
   if (env.KILOCODE_API_BASE_URL) {


### PR DESCRIPTION
## Summary

- Stage OpenClaw bundled plugin runtime dependencies in an image-baked `OPENCLAW_PLUGIN_STAGE_DIR` so doctor and gateway startup do not repair default bundled plugins one-by-one at boot.
- Mirror the staged dependency prewarm in the local KiloClaw Dockerfile and default the controller env var while preserving explicit overrides.
- Document the controller env var in the KiloClaw controller spec and add a new KiloClaw changelog entry for the bundled-plugin startup optimization.

## Verification

- Built a fresh local KiloClaw image tagged `kiloclaw:plugin-stage-dir`.
- Inspected the built image and confirmed `OPENCLAW_PLUGIN_STAGE_DIR=/usr/local/share/openclaw-plugin-runtime-deps` plus a populated OpenClaw 2026.4.23 staged dependency root containing representative bundled plugin dependencies.
- Ran `services/kiloclaw/scripts/controller-entrypoint-smoke-test.sh` against the fresh image: 7 passed, 0 failed.
- Ran `services/kiloclaw/scripts/controller-proxy-auth-smoke-test.sh` against the fresh image.
- Ran `services/kiloclaw/scripts/controller-smoke-test.sh` against the fresh image: 15 passed, 0 failed.

## Visual Changes

N/A

## Reviewer Notes

This only changes bundled OpenClaw plugin runtime dependency staging. User-installed npm, ClawHub, marketplace, or local plugins are not bundled plugin candidates and keep their normal install behavior.

The staged root is intentionally outside `/root` because Fly mounts the persistent instance volume at `/root`; placing image-baked deps there would be shadowed at runtime and could reintroduce persistent package growth. The controller sets the same default env var only when unset, so explicit image/operator overrides still win.