### PR TITLE
fix(cloud-agent): pre-import kilo session in sync prepare path to fix ingest race

### DIFF
--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -562,17 +562,56 @@ const prepareSessionHandler = internalApiProtectedProcedure
         await writeAuthFile(sandbox, sessionHome, ctx.authToken);
         await writeGlobalRules(sandbox, sessionHome, cloudAgentSessionId);
 
-        // 11. Start wrapper (which starts kilo server in-process and creates session)
-        logger.info('Starting wrapper');
-        const { client: _wrapperClient, sessionId: kiloSessionId } =
-          await WrapperClient.ensureWrapper(sandbox, session, {
-            agentSessionId: cloudAgentSessionId,
-            userId: ctx.userId,
-            workspacePath,
-          });
-
+        // 11. Pre-import a minimal session so the wrapper starts with --session-id.
+        // This avoids the race condition where Session.Event.Created fires before
+        // KiloSessions.init() has registered its Bus.subscribe handler.
+        const kiloSessionId = generateKiloSessionId();
         logger.setTags({ kiloSessionId });
-        logger.info('Wrapper started, kilo session created');
+        logger.info('Pre-importing kilo session');
+        const now = Date.now();
+        const minimalSessionJson = JSON.stringify({
+          info: {
+            id: kiloSessionId,
+            slug: '',
+            projectID: '',
+            directory: '',
+            title: 'New session - ' + new Date(now).toISOString(),
+            version: '2',
+            time: { created: now, updated: now },
+          },
+          messages: [],
+        });
+        const importFilePath = `/tmp/kilo-empty-session-${kiloSessionId}.json`;
+        await sandbox.writeFile(importFilePath, minimalSessionJson);
+        const escapedFile = importFilePath.replaceAll("'", "'\\''");
+        const escapedId = kiloSessionId.replaceAll("'", "'\\''");
+        const escapedWorkspace = workspacePath.replaceAll("'", "'\\''");
+        const restoreResult = await session.exec(
+          `bun /usr/local/bin/kilo-restore-session.js --file '${escapedFile}' '${escapedId}' '${escapedWorkspace}'`,
+          { cwd: workspacePath }
+        );
+        if (restoreResult.exitCode !== 0) {
+          const stdout = restoreResult.stdout?.trim() ?? '';
+          logger
+            .withFields({ exitCode: restoreResult.exitCode, stdout })
+            .error('Pre-import of kilo session failed');
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Failed to pre-import kilo session (exit ${restoreResult.exitCode})`,
+          });
+        }
+        logger.info('Kilo session pre-imported');
+
+        // 12. Start wrapper with --session-id so no new session is created (no race)
+        logger.info('Starting wrapper');
+        const { client: _wrapperClient } = await WrapperClient.ensureWrapper(sandbox, session, {
+          agentSessionId: cloudAgentSessionId,
+          userId: ctx.userId,
+          workspacePath,
+          sessionId: kiloSessionId,
+        });
+
+        logger.info('Wrapper started');
 
         return { workspacePath, sessionHome, branchName, kiloSessionId };
       };

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -1,3 +1,4 @@
+import { dirname } from 'node:path';
 import { TRPCError } from '@trpc/server';
 import type * as z from 'zod';
 import { getSandbox } from '@cloudflare/sandbox';
@@ -588,7 +589,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
         const escapedWorkspace = workspacePath.replaceAll("'", "'\\''");
         const restoreResult = await session.exec(
           `bun /usr/local/bin/kilo-restore-session.js --file '${escapedFile}' '${escapedId}' '${escapedWorkspace}'`,
-          { cwd: workspacePath }
+          { cwd: dirname(workspacePath) }
         );
         if (restoreResult.exitCode !== 0) {
           const stdout = restoreResult.stdout?.trim() ?? '';

--- a/services/cloud-agent-next/src/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session-prepare.test.ts
@@ -29,6 +29,7 @@ const createMockSandbox = () => {
     createSession: vi.fn().mockResolvedValue(mockSession),
     listProcesses: vi.fn().mockResolvedValue([]),
     mkdir: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
     destroy: vi.fn().mockResolvedValue(undefined),
   };
 };
@@ -55,6 +56,10 @@ vi.mock('./workspace.js', async importOriginal => {
   };
 });
 
+vi.mock('./utils/kilo-session-id.js', () => ({
+  generateKiloSessionId: () => generateKiloSessionIdMock(),
+}));
+
 // Mock WrapperClient.ensureWrapper (wrapper now starts kilo server in-process)
 vi.mock('./kilo/wrapper-client.js', () => ({
   WrapperClient: {
@@ -69,10 +74,12 @@ vi.mock('./kilo/wrapper-client.js', () => ({
 // vi.hoisted() ensures these are available when the mock factory runs
 const {
   generateSessionIdMock,
+  generateKiloSessionIdMock,
   createCliSessionViaSessionIngestMock,
   deleteCliSessionViaSessionIngestMock,
 } = vi.hoisted(() => ({
   generateSessionIdMock: vi.fn(() => 'agent_12345678-1234-1234-1234-123456789abc'),
+  generateKiloSessionIdMock: vi.fn(() => 'ses_mock-kilo-session-id'),
   createCliSessionViaSessionIngestMock: vi.fn().mockResolvedValue(undefined),
   deleteCliSessionViaSessionIngestMock: vi.fn().mockResolvedValue(undefined),
 }));
@@ -317,12 +324,12 @@ describe('prepareSession endpoint', () => {
       });
 
       expect(result.cloudAgentSessionId).toMatch(/^agent_[0-9a-f-]+$/);
-      expect(result.kiloSessionId).toBe('cli-session-abc123');
+      expect(result.kiloSessionId).toBe('ses_mock-kilo-session-id');
       expect(doStub.prepare).toHaveBeenCalledWith(
         expect.objectContaining({
           sessionId: expect.stringMatching(/^agent_/) as unknown,
           userId: 'test-user-123',
-          kiloSessionId: 'cli-session-abc123',
+          kiloSessionId: 'ses_mock-kilo-session-id',
           prompt: 'Test prompt',
           mode: 'code',
           model: 'claude-3',
@@ -348,7 +355,7 @@ describe('prepareSession endpoint', () => {
       });
 
       expect(result.cloudAgentSessionId).toBeDefined();
-      expect(result.kiloSessionId).toBe('cli-session-abc123');
+      expect(result.kiloSessionId).toBe('ses_mock-kilo-session-id');
       expect(doStub.prepare).toHaveBeenCalledWith(
         expect.objectContaining({
           gitUrl: 'https://gitlab.com/org/repo.git',


### PR DESCRIPTION
## Summary

- Slack bot sessions (`autoInitiate=false`) were producing empty sessions in the dashboard because no data ever reached the session-ingest worker.
- Root cause: race condition between `Session.Event.Created` (~7ms) and `KiloSessions.init()` completing its `Bus.subscribe` registration (~35ms). The wrapper started without `--session-id`, so the CLI created a fresh session live — firing the event into the race window. With no handler registered, `bootstrap()` was never called, `session_share` was never written, and all `IngestQueue.flush()` calls failed silently.
- Fix: in the sync prepare path, pre-generate a `kiloSessionId`, write a minimal session JSON, run `kilo-restore-session.js --file` to import it into the CLI's SQLite, then pass `--session-id` to `ensureWrapper`. The wrapper calls `Session.get()` instead of `Session.create()`, so `Session.Event.Created` never fires — identical to how the `autoInitiate=true` (web UI) path already works.

## Verification

1. Trigger a Slack bot session via `pnpm --filter web script:run bot replay-slack-spawn <session-id>`
2. Check container logs — `ingest flush: no session_share found` should not appear
3. Confirm session data appears in the Kilo dashboard

## Visual Changes

N/A

## Reviewer Notes

The fix reuses `generateKiloSessionId()` (already imported) and the exact `kilo-restore-session.js --file` pattern from `async-preparation.ts` steps 8–9, which has been running in production for the `autoInitiate=true` web UI path. No new code paths introduced.