### PR TITLE
fix(code-reviews): show superseded cancellations

### DIFF
--- a/apps/web/src/app/(app)/code-reviews/[reviewId]/CodeReviewDetailClient.tsx
+++ b/apps/web/src/app/(app)/code-reviews/[reviewId]/CodeReviewDetailClient.tsx
@@ -143,6 +143,19 @@ export function CodeReviewDetailClient({ reviewId }: CodeReviewDetailClientProps
   const canRetry = ['failed', 'cancelled', 'interrupted'].includes(status);
   const canCancel = ['pending', 'queued', 'running'].includes(status);
   const prLabel = review.platform === 'gitlab' ? 'MR' : 'PR';
+  const isSupersededCancellation =
+    status === 'cancelled' &&
+    (review.terminal_reason === 'superseded' ||
+      review.error_message?.toLowerCase().includes('superseded'));
+  const reviewMessage = review.error_message
+    ? {
+        label: isSupersededCancellation ? 'Cancelled' : 'Error',
+        message: isSupersededCancellation ? 'Superseded by a newer push.' : review.error_message,
+        className: isSupersededCancellation
+          ? 'border-border bg-muted/30 text-muted-foreground'
+          : 'border-destructive/30 bg-destructive/10 text-destructive',
+      }
+    : null;
 
   return (
     <PageContainer>
@@ -266,10 +279,9 @@ export function CodeReviewDetailClient({ reviewId }: CodeReviewDetailClientProps
             )}
           </dl>
 
-          {/* Error message */}
-          {review.error_message && (
-            <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
-              <strong>Error:</strong> {review.error_message}
+          {reviewMessage && (
+            <div className={`mt-4 rounded-md border p-3 text-sm ${reviewMessage.className}`}>
+              <strong>{reviewMessage.label}:</strong> {reviewMessage.message}
             </div>
           )}
 


### PR DESCRIPTION
## Why

A review that was stopped by a newer push looked like a real error. That made it seem like something broke when the review was only canceled.

## What changed

The review page now treats this case as a normal cancellation. It shows a calm message that says the review was superseded by a newer push. Real failed reviews still show error styling, so people can tell the difference.

## How to test

1. Open a canceled review that was superseded by a newer push.
2. Confirm it shows `Cancelled: Superseded by a newer push.` in a neutral message.
3. Open a failed review with a real error.
4. Confirm it still shows an error message with error styling.