### PR TITLE
fix(db): avoid cached Worker DB clients

### DIFF
--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('pg', () => {
+  class Pool {}
+
+  return {
+    __esModule: true,
+    default: {
+      Pool,
+      types: {
+        builtins: { INT8: 20 },
+        setTypeParser: jest.fn(),
+      },
+    },
+    types: {
+      builtins: { INT8: 20 },
+      setTypeParser: jest.fn(),
+    },
+  };
+});
+
+jest.mock('drizzle-orm/node-postgres', () => ({
+  drizzle: jest.fn((pool: unknown) => ({ pool })),
+}));
+
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { getWorkerDb } from './client';
+
+describe('getWorkerDb', () => {
+  it('returns a fresh Worker database object for every call', () => {
+    const firstDb = getWorkerDb('postgres://worker.example/db');
+    const secondDb = getWorkerDb('postgres://worker.example/db');
+
+    expect(firstDb).not.toBe(secondDb);
+    expect(drizzle).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('pg', () => {
-  class Pool {}
+  const Pool = jest.fn(function Pool(this: object) {
+    return this;
+  });
 
   return {
     __esModule: true,
@@ -20,18 +22,23 @@ jest.mock('pg', () => {
 });
 
 jest.mock('drizzle-orm/node-postgres', () => ({
-  drizzle: jest.fn((pool: unknown) => ({ pool })),
+  drizzle: jest.fn((pool: object) => ({ pool })),
 }));
 
 import { drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
 import { getWorkerDb } from './client';
 
 describe('getWorkerDb', () => {
-  it('returns a fresh Worker database object for every call', () => {
-    const firstDb = getWorkerDb('postgres://worker.example/db');
-    const secondDb = getWorkerDb('postgres://worker.example/db');
+  it('creates separate Worker DB transports for identical inputs', () => {
+    const connectionString = 'postgres://worker.example/db';
+    const firstDb = getWorkerDb(connectionString);
+    const secondDb = getWorkerDb(connectionString);
+    const drizzleMock = jest.mocked(drizzle);
 
+    expect(pg.Pool).toHaveBeenNthCalledWith(1, { connectionString, max: 1 });
+    expect(pg.Pool).toHaveBeenNthCalledWith(2, { connectionString, max: 1 });
+    expect(drizzleMock.mock.calls[0]?.[0]).not.toBe(drizzleMock.mock.calls[1]?.[0]);
     expect(firstDb).not.toBe(secondDb);
-    expect(drizzle).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -36,8 +36,6 @@ export function createDrizzleClient(options: CreateDrizzleClientOptions) {
 
 export type GetWorkerDbOptions = Omit<pg.PoolConfig, 'connectionString' | 'max'>;
 
-const workerDbCache = new Map<string, ReturnType<typeof drizzle>>();
-
 /**
  * Convenience wrapper for Cloudflare Workers using Hyperdrive.
  * Hyperdrive handles connection pooling at the infrastructure level,
@@ -45,14 +43,8 @@ const workerDbCache = new Map<string, ReturnType<typeof drizzle>>();
  * Return a fresh wrapper per call so request/DO-bound I/O state never crosses contexts.
  */
 export function getWorkerDb(connectionString: string, options: GetWorkerDbOptions = {}) {
-  const cacheKey = JSON.stringify({ connectionString, options });
-  const cached = workerDbCache.get(cacheKey);
-  if (cached) return cached;
-
   const pool = new pg.Pool({ connectionString, max: 1, ...options });
-  const db = drizzle(pool, { schema });
-  workerDbCache.set(cacheKey, db);
-  return db;
+  return drizzle(pool, { schema });
 }
 
 export type WorkerDb = ReturnType<typeof getWorkerDb>;

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -42,6 +42,7 @@ const workerDbCache = new Map<string, ReturnType<typeof drizzle>>();
  * Convenience wrapper for Cloudflare Workers using Hyperdrive.
  * Hyperdrive handles connection pooling at the infrastructure level,
  * so we use max: 1 here. Pass env.HYPERDRIVE.connectionString directly.
+ * Return a fresh wrapper per call so request/DO-bound I/O state never crosses contexts.
  */
 export function getWorkerDb(connectionString: string, options: GetWorkerDbOptions = {}) {
   const cacheKey = JSON.stringify({ connectionString, options });


### PR DESCRIPTION
## Summary
Prevent Cloudflare Worker and Durable Object database helpers from reusing request-bound I/O state across execution contexts.

### Why this change is needed
PR #3233 introduced a module-global cache for `getWorkerDb()`. In Cloudflare Workers and Durable Objects, the cached Drizzle/Pool wrapper can retain I/O-backed transport state from an earlier request or Durable Object context. Production then emitted cross-context I/O errors and KiloClaw hangs.

### How this is addressed
- Restore fresh `getWorkerDb()` wrapper creation per call instead of reusing module-global Worker DB clients.
- Keep Hyperdrive's infrastructure-level pooling model intact while avoiding unsafe request/DO state retention.
- Add regression coverage that asserts repeated `getWorkerDb()` calls do not return the same Worker DB object.

## Human Verification
- Reviewed PR #3233 diff and KiloClaw Durable Object call sites that exercise `getWorkerDb()`.
- Ran local change review, including React Code Quality analyzer; no blocking findings remained.

## Reviewer Notes
### Human Reviewer Flags
- Intentional tradeoff: per-call wrapper creation restores pre-PR safety semantics; Hyperdrive still owns connection pooling, but wrapper allocation cost returns.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Root cause tied to module-scope cache in Worker/DO runtime, not KiloClaw pricing logic.
- Focus review found one unrelated `.gitignore` style issue; it was removed from the final diff.
- Package validation completed with DB typecheck and lint.

</details>