### PR TITLE
fix(code-reviews): raise error spike threshold

### DIFF
--- a/apps/web/src/app/api/code-reviews/up/route.test.ts
+++ b/apps/web/src/app/api/code-reviews/up/route.test.ts
@@ -164,7 +164,8 @@ describe('GET /api/code-reviews/up', () => {
       .insert(cloud_agent_code_reviews)
       .values([
         reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
-        ...Array.from({ length: 19 }, () => reviewValues()),
+        reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
+        ...Array.from({ length: 18 }, () => reviewValues()),
       ]);
 
     const response = await GET(makeRequest('kilo-code-reviews-health-check'));
@@ -178,12 +179,12 @@ describe('GET /api/code-reviews/up', () => {
           kind: 'error_spike',
           label: 'Error Spike',
           severity: 'ticket',
-          rate: 0.05,
+          rate: 0.1,
           startedCount: 20,
-          errorCount: 1,
+          errorCount: 2,
           windowMinutes: 30,
           topReason: 'timeout',
-          topReasonCount: 1,
+          topReasonCount: 2,
           adminUrl: expect.stringContaining('/admin/code-reviews'),
           runbookUrl: CODE_REVIEW_RUNBOOK_URL,
         },
@@ -221,7 +222,9 @@ describe('GET /api/code-reviews/up', () => {
         })
       ),
       reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
-      ...Array.from({ length: 19 }, () => reviewValues()),
+      reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
+      reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
+      ...Array.from({ length: 17 }, () => reviewValues()),
     ]);
 
     const response = await GET(makeRequest('kilo-code-reviews-health-check'));

--- a/apps/web/src/lib/code-reviews/alerting/detectors.test.ts
+++ b/apps/web/src/lib/code-reviews/alerting/detectors.test.ts
@@ -173,22 +173,23 @@ describe('code review alert detectors', () => {
     await expect(evaluateSlowReviews(db)).resolves.toEqual({ tripped: false });
   });
 
-  it('trips error-spike alerts at 5% of recently started reviews', async () => {
+  it('trips error-spike alerts at 10% of recently started reviews', async () => {
     await insertReviews([
       reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
-      ...Array.from({ length: 19 }, () => reviewValues()),
+      reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
+      ...Array.from({ length: 18 }, () => reviewValues()),
     ]);
 
     await expect(evaluateErrorSpike(db)).resolves.toMatchObject({
       tripped: true,
       details: {
         kind: 'error_spike',
-        rate: 0.05,
+        rate: 0.1,
         startedCount: 20,
-        errorCount: 1,
+        errorCount: 2,
         windowMinutes: 30,
         topReason: 'timeout',
-        topReasonCount: 1,
+        topReasonCount: 2,
       },
     });
   });
@@ -199,7 +200,7 @@ describe('code review alert detectors', () => {
     await expect(evaluateErrorSpike(db)).resolves.toEqual({ tripped: false });
   });
 
-  it('does not trip error-spike alerts below 5%', async () => {
+  it('does not trip error-spike alerts below 10%', async () => {
     await insertReviews([
       reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
       ...Array.from({ length: 20 }, () => reviewValues()),
@@ -239,19 +240,22 @@ describe('code review alert detectors', () => {
     await insertReviews([
       reviewValues({ status: 'interrupted', terminal_reason: 'interrupted' }),
       reviewValues({ status: 'cancelled', terminal_reason: 'interrupted' }),
-      ...Array.from({ length: 38 }, () => reviewValues()),
+      reviewValues({ status: 'interrupted', terminal_reason: 'interrupted' }),
+      reviewValues({ status: 'cancelled', terminal_reason: 'interrupted' }),
+      ...Array.from({ length: 36 }, () => reviewValues()),
     ]);
 
     await expect(evaluateErrorSpike(db)).resolves.toMatchObject({
       tripped: true,
-      details: { kind: 'error_spike', startedCount: 40, errorCount: 2, topReason: 'interrupted' },
+      details: { kind: 'error_spike', startedCount: 40, errorCount: 4, topReason: 'interrupted' },
     });
   });
 
   it('counts failed reviews with missing terminal reasons as unknown errors', async () => {
     await insertReviews([
       reviewValues({ status: 'failed', terminal_reason: null }),
-      ...Array.from({ length: 19 }, () => reviewValues()),
+      reviewValues({ status: 'failed', terminal_reason: null }),
+      ...Array.from({ length: 18 }, () => reviewValues()),
     ]);
 
     await expect(evaluateErrorSpike(db)).resolves.toMatchObject({
@@ -259,9 +263,9 @@ describe('code review alert detectors', () => {
       details: {
         kind: 'error_spike',
         startedCount: 20,
-        errorCount: 1,
+        errorCount: 2,
         topReason: 'unknown',
-        topReasonCount: 1,
+        topReasonCount: 2,
       },
     });
   });

--- a/apps/web/src/lib/code-reviews/alerting/thresholds.ts
+++ b/apps/web/src/lib/code-reviews/alerting/thresholds.ts
@@ -3,7 +3,7 @@ export const SLOW_REVIEW_DURATION_MINUTES = 60;
 export const SLOW_REVIEW_RATE_THRESHOLD = 0.1;
 
 export const ERROR_SPIKE_WINDOW_MINUTES = 30;
-export const ERROR_SPIKE_RATE_THRESHOLD = 0.1; // raise from 5% to 10%
+export const ERROR_SPIKE_RATE_THRESHOLD = 0.1;
 
 export type CodeReviewAlertSeverity = 'page' | 'ticket';
 export const CODE_REVIEW_ALERT_SEVERITY = 'ticket' satisfies CodeReviewAlertSeverity;

--- a/apps/web/src/lib/code-reviews/alerting/thresholds.ts
+++ b/apps/web/src/lib/code-reviews/alerting/thresholds.ts
@@ -3,7 +3,7 @@ export const SLOW_REVIEW_DURATION_MINUTES = 60;
 export const SLOW_REVIEW_RATE_THRESHOLD = 0.1;
 
 export const ERROR_SPIKE_WINDOW_MINUTES = 30;
-export const ERROR_SPIKE_RATE_THRESHOLD = 0.05;
+export const ERROR_SPIKE_RATE_THRESHOLD = 0.1; // raise from 5% to 10%
 
 export type CodeReviewAlertSeverity = 'page' | 'ticket';
 export const CODE_REVIEW_ALERT_SEVERITY = 'ticket' satisfies CodeReviewAlertSeverity;


### PR DESCRIPTION
## Summary
- Raise the code review error-spike health threshold from 5% to 10% to reduce noise from partial, ticket-level degradation.
- Update alert detector and health endpoint tests to assert the new 10% trip point.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
- Automated checks run locally: `pnpm format`; `pnpm test -- apps/web/src/lib/code-reviews/alerting/detectors.test.ts apps/web/src/app/api/code-reviews/up/route.test.ts`.
- Push used `--no-verify` with explicit approval because the pre-push hook is blocked by an unrelated existing mobile lint error in `apps/mobile/src/lib/hooks/use-current-user-id.ts`.