### PR TITLE
fix(mobile): route empty-state CTA to native onboarding flow

### DIFF
--- a/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
@@ -48,7 +48,11 @@ export default function KiloClawTab() {
     })();
   }, [refetchInstances]);
 
-  if (instancesQuery.isError) {
+  const onboardingQueryEnabled = entryDecision.kind === 'empty';
+  const hasQueryError =
+    instancesQuery.isError || (onboardingQueryEnabled && onboardingQuery.isError);
+
+  if (hasQueryError) {
     return (
       <View className="flex-1 bg-background">
         <ScreenHeader
@@ -63,7 +67,12 @@ export default function KiloClawTab() {
             className="flex-1"
             message="Could not load KiloClaw instances"
             onRetry={() => {
-              void instancesQuery.refetch();
+              if (instancesQuery.isError) {
+                void instancesQuery.refetch();
+              }
+              if (onboardingQueryEnabled && onboardingQuery.isError) {
+                void onboardingQuery.refetch();
+              }
             }}
           />
         </Animated.View>
@@ -101,7 +110,7 @@ export default function KiloClawTab() {
         headerRight={<ProfileAvatarButton />}
       />
       <Animated.View layout={LinearTransition} className="flex-1 px-4">
-        {showInstanceSkeleton ? (
+        {showInstanceSkeleton || onboardingQuery.data === undefined ? (
           <Animated.View exiting={FadeOut.duration(150)} className="w-full gap-3 px-4 pt-5">
             <Skeleton className="h-16 w-full rounded-xl" />
             <Skeleton className="h-16 w-full rounded-xl" />

--- a/apps/mobile/src/components/kiloclaw/empty-state-content.tsx
+++ b/apps/mobile/src/components/kiloclaw/empty-state-content.tsx
@@ -10,7 +10,7 @@ import { Text } from '@/components/ui/text';
 import { type MobileOnboardingState } from '@/lib/derive-mobile-onboarding-state';
 
 type EmptyStateContentProps = {
-  state: MobileOnboardingState | undefined;
+  state: MobileOnboardingState;
   foregroundColor: string;
   onCreate: () => void;
 };
@@ -39,7 +39,7 @@ export function EmptyStateContent({
   foregroundColor,
   onCreate,
 }: Readonly<EmptyStateContentProps>) {
-  if (state?.state === 'pending_settlement') {
+  if (state.state === 'pending_settlement') {
     return (
       <EmptyState
         icon={Server}
@@ -49,7 +49,7 @@ export function EmptyStateContent({
     );
   }
 
-  const accessRequiredSubcase = state ? resolveAccessRequiredSubcase(state) : null;
+  const accessRequiredSubcase = resolveAccessRequiredSubcase(state);
   if (accessRequiredSubcase) {
     return <AccessRequiredScreen subcase={accessRequiredSubcase} />;
   }

--- a/apps/mobile/src/components/kiloclaw/empty-state-content.tsx
+++ b/apps/mobile/src/components/kiloclaw/empty-state-content.tsx
@@ -1,5 +1,4 @@
-import { ExternalLink, Plus, Server } from 'lucide-react-native';
-import { Linking } from 'react-native';
+import { Plus, Server } from 'lucide-react-native';
 
 import { EmptyState } from '@/components/empty-state';
 import {
@@ -8,7 +7,6 @@ import {
 } from '@/components/kiloclaw/access-required-screen';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
-import { WEB_BASE_URL } from '@/lib/config';
 import { type MobileOnboardingState } from '@/lib/derive-mobile-onboarding-state';
 
 type EmptyStateContentProps = {
@@ -41,27 +39,7 @@ export function EmptyStateContent({
   foregroundColor,
   onCreate,
 }: Readonly<EmptyStateContentProps>) {
-  if (state === undefined) {
-    return (
-      <EmptyState
-        icon={Server}
-        title="No KiloClaw instances"
-        description="You don't have any KiloClaw instances yet. Continue on kilo.ai to get started."
-        action={
-          <Button
-            variant="outline"
-            onPress={() => void Linking.openURL(`${WEB_BASE_URL}/claw`)}
-            accessibilityRole="link"
-          >
-            <Text>Continue on kilo.ai</Text>
-            <ExternalLink size={16} color={foregroundColor} />
-          </Button>
-        }
-      />
-    );
-  }
-
-  if (state.state === 'pending_settlement') {
+  if (state?.state === 'pending_settlement') {
     return (
       <EmptyState
         icon={Server}
@@ -71,7 +49,7 @@ export function EmptyStateContent({
     );
   }
 
-  const accessRequiredSubcase = resolveAccessRequiredSubcase(state);
+  const accessRequiredSubcase = state ? resolveAccessRequiredSubcase(state) : null;
   if (accessRequiredSubcase) {
     return <AccessRequiredScreen subcase={accessRequiredSubcase} />;
   }


### PR DESCRIPTION
## Summary
- The KiloClaw tab's empty-state fallback (shown when the onboarding-state query has no data) linked out to `kilo.ai/claw`. That CTA predates the native onboarding flow at `/(app)/onboarding`.
- Drop the special-case branch so the existing "Get started" empty state renders for the undefined case too — pressing it opens the in-app onboarding modal, which already handles account-state edge cases internally.
- Subscription/billing and account-remediation CTAs in `access-required-screen.tsx` are intentionally left pointing to the web (Apple IAP rules + states the native flow can't resolve).

## Test plan
- [ ] Launch the app with no instances and verify the KiloClaw tab shows "Get started" instead of "Continue on kilo.ai".
- [ ] Tap "Get started" → onboarding modal opens.
- [ ] Verify `pending_settlement`, `access_required`, `quarantined`, `multiple_current_conflict`, and `non_canonical_earlybird` states still render their respective screens.