### PR TITLE
docs(kiloclaw): refresh controller spec

### DIFF
--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -438,7 +438,8 @@ patches to `openclaw.json`. The patches MUST include:
     Web search MUST auto-enable the `kilo-exa` provider when
     `KILO_EXA_SEARCH_MODE=kilo-proxy`, or when the mode is unset and the
     user has not explicitly configured search; it MUST disable or defer to
-    user/Brave configuration when `KILO_EXA_SEARCH_MODE=disabled`.
+    user/Brave configuration when `KILO_EXA_SEARCH_MODE=disabled` or any
+    unrecognised value (unknown values MUST be logged and treated as `disabled`).
 16. KiloClaw morning briefing plugin: load path and entry MUST be
     present; when `plugins.allow` exists, it MUST include
     `kiloclaw-morning-briefing`.

--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Draft — generated from branch `florian/chore/controller-is-the-one-true-path`
-on 2026-03-17.
+Maintained — audited against `services/kiloclaw/controller/src` on
+2026-05-14.
 
 ## Conventions
 
@@ -15,18 +15,23 @@ capitals, as shown here.
 
 ## Overview
 
-The KiloClaw controller is the single process running inside each
-Fly.io machine. It is the Dockerfile CMD entrypoint (`node
+The KiloClaw controller is the machine entrypoint process running inside
+each Fly.io machine. It is the Dockerfile CMD entrypoint (`node
 kiloclaw-controller.js`) and is responsible for:
 
 1. Bootstrapping the machine environment (env decryption, openclaw
-   onboarding/doctor, config patching, feature flags).
+   onboarding/doctor, config patching, feature flags, integration
+   metadata).
 2. Serving an HTTP API on port 18789 for health probes, diagnostics,
    configuration management, and gateway lifecycle control.
-3. Supervising the openclaw gateway process (automatic respawn on
-   crash with exponential backoff).
+3. Supervising the openclaw gateway process and auxiliary local
+   processes such as Gmail watch delivery (automatic respawn on crash
+   with exponential backoff).
 4. Reverse-proxying HTTP and WebSocket traffic from the CF worker to
    the openclaw gateway on port 3001.
+5. Bridging controller-mediated platform integrations: Kilo Chat,
+   Google OAuth/Gmail, inbound email hooks, file import/write, doctor
+   runs, Kilo CLI repair runs, and morning briefing control.
 
 The controller owns the machine's entire lifecycle from boot to
 shutdown. The CF worker communicates with it exclusively through the
@@ -45,8 +50,8 @@ one succeeding, except where noted.
    takes seconds or fails entirely.
 
 2. **Critical bootstrap.** The controller MUST run the critical
-   bootstrap steps (decryption, directories, feature flags, gateway
-   args) after the HTTP server is listening. Each major step updates
+   bootstrap steps (decryption, directories, feature flags, hooks token,
+   gateway args) after the HTTP server is listening. Each major step updates
    the controller state so `/_kilo/health` reflects progress. If any
    critical step fails, the controller MUST enter degraded mode (see
    Degraded Mode) and MUST NOT proceed to subsequent phases.
@@ -66,21 +71,26 @@ one succeeding, except where noted.
    the gateway itself fails.
 
 5. **Non-critical bootstrap.** The controller MUST then run the
-   non-critical bootstrap steps (GitHub config, Linear config,
-   onboard/doctor with config patching, TOOLS.md updates, mcporter
-   config). If one of these steps fails, the controller MUST enter
-   degraded mode but MUST keep the Hono app active so authenticated
-   recovery endpoints remain available. The controller MUST NOT
-   proceed to gateway start after a non-critical bootstrap failure.
+   non-critical bootstrap steps in order: GitHub config, Linear config,
+   gateway-client device scope remediation, onboard/doctor with config
+   patching, bounded `TOOLS.md` section updates, and mcporter config. If
+   one of these steps fails, the controller MUST enter degraded mode but
+   MUST keep the Hono app active so authenticated recovery endpoints
+   remain available. The controller MUST NOT proceed to gateway start
+   after a non-critical bootstrap failure.
 
 6. **Pre-gateway setup.** The controller SHOULD attempt best-effort
-   setup tasks (Kilo CLI config, gog credentials). Failures in this
-   phase MUST be logged but MUST NOT prevent startup from continuing.
+   setup tasks (npm cache cleanup, Kilo CLI config, gog credentials,
+   legacy Google credential migration, gog shim installation). Failures
+   in this phase MUST be logged but MUST NOT prevent startup from
+   continuing.
 
-7. **Gateway start.** The controller MUST start the gateway
-   supervisor as the final phase. If the gateway fails to start, the
-   controller MUST enter degraded mode but MUST NOT tear down the
-   Hono app — all `/_kilo/*` routes MUST remain functional.
+7. **Gateway start.** The controller MUST start the gateway supervisor
+   as the final phase. It MUST then start the pairing cache, Gmail watch
+   supervisor when configured, Gmail watch renewal, controller check-in,
+   and delayed background Kilo CLI upgrade when enabled. If the gateway
+   fails to start, the controller MUST enter degraded mode but MUST NOT
+   tear down the Hono app — all `/_kilo/*` routes MUST remain functional.
 
 ### Event Loop Yields
 
@@ -143,9 +153,12 @@ The `phase` field during `bootstrapping` progresses through:
 | `directories`                  | Creating config/workspace dirs, setting env vars  |
 | `feature-flags`                | Applying instance feature flags                   |
 | `github`                       | Configuring GitHub access (best-effort)           |
+| `linear`                       | Configuring Linear MCP availability               |
 | `gateway-client-device-scopes` | Remediating gateway-client device approval scopes |
 | `onboard`                      | Running `openclaw onboard` (first boot)           |
 | `doctor`                       | Running `openclaw doctor --fix` (subsequent boot) |
+| `tools-md`                     | Synchronizing managed `TOOLS.md` sections         |
+| `mcporter`                     | Writing managed MCP server config                 |
 
 ### Endpoint Availability by Phase
 
@@ -279,6 +292,8 @@ tag (16 bytes)`.
      when unset — keep bundled OpenClaw plugin runtime dependencies in
      the image-baked stage directory instead of mutating `/root` or each
      bundled plugin directory during doctor/gateway startup.
+   - `KILO_API_URL` to the origin of `KILOCODE_API_BASE_URL` when the
+     API base URL override is set.
 
 ### Feature Flags
 
@@ -303,32 +318,85 @@ tag (16 bytes)`.
 
 1. GitHub configuration is best-effort. Failures MUST be logged but
    MUST NOT abort bootstrap.
-2. When `GITHUB_TOKEN` is set, the controller SHOULD run `gh auth
-login --with-token` and `gh auth setup-git`.
-3. When `GITHUB_USERNAME` is set, the controller SHOULD run `git
-config --global user.name`. When `GITHUB_EMAIL` is set, the
+2. When `GITHUB_TOKEN` is set, the controller SHOULD run
+   `gh auth login --with-token` and `gh auth setup-git`.
+3. When `GITHUB_USERNAME` is set, the controller SHOULD run
+   `git config --global user.name`. When `GITHUB_EMAIL` is set, the
    controller SHOULD run `git config --global user.email`. Failures
    MUST be logged but MUST NOT abort bootstrap.
 4. When `GITHUB_TOKEN` is not set, the controller SHOULD clean up
-   any previously stored credentials (`gh auth logout`, `git config
---global --unset user.name/email`). Cleanup failures MUST be
-   silently ignored.
+   any previously stored credentials (`gh auth logout`,
+   `git config --global --unset user.name/email`). Cleanup failures
+   MUST be silently ignored.
+
+### Linear and MCPorter Configuration
+
+1. Linear configuration is managed through mcporter, not by writing
+   OpenClaw MCP config directly.
+2. When `LINEAR_API_KEY` is present, the controller MUST preserve it for
+   the gateway environment and MUST configure the `linear` MCP server in
+   `/root/.openclaw/workspace/config/mcporter.json` with URL
+   `https://mcp.linear.app/mcp` and authorization header
+   `Bearer ${LINEAR_API_KEY}`.
+3. When `LINEAR_API_KEY` is absent, the controller MUST remove any
+   managed `linear` entry from mcporter config and MUST remove any
+   managed Linear section from `TOOLS.md`.
+4. When `AGENTCARD_API_KEY` is present, the controller MUST configure
+   the `agentcard` MCP server in mcporter with URL
+   `https://mcp.agentcard.sh/mcp` and bearer authorization.
+5. When `AGENTCARD_API_KEY` is absent, the controller MUST remove any
+   managed `agentcard` entry from mcporter config.
+6. mcporter config writes MUST preserve user-added server entries whose
+   keys are not managed by the controller.
 
 ### Onboard vs Doctor
 
 1. If `/root/.openclaw/openclaw.json` does not exist (first boot),
-   the controller MUST run `openclaw onboard --non-interactive` with
-   the flags: `--accept-risk`, `--mode local`, `--gateway-port 3001`,
-   `--gateway-bind loopback`, `--skip-channels`, `--skip-skills`,
-   `--skip-health`, and `--kilocode-api-key`.
-2. If the config file exists (subsequent boot), the controller MUST
+   the controller MUST generate a base config by running
+   `openclaw onboard --non-interactive` against a temporary
+   `OPENCLAW_CONFIG_PATH`, patching the temp config, chmodding it to
+   `0600`, and atomically renaming it into place.
+2. The onboard invocation MUST include the flags: `--accept-risk`,
+   `--mode local`, `--gateway-port 3001`, `--gateway-bind loopback`,
+   `--skip-channels`, `--skip-skills`, `--skip-health`,
+   `--secret-input-mode ref`, and `--kilocode-api-key`.
+3. If the config file exists (subsequent boot), the controller MUST
    run `openclaw doctor --fix --non-interactive`.
-3. On first boot, the controller MUST seed
+4. On first boot, the controller MUST seed
    `/root/.openclaw/workspace/TOOLS.md` from the image-baked copy at
    `/usr/local/share/kiloclaw/TOOLS.md`.
-4. When `KILOCLAW_USER_TIMEZONE` is set, the controller MUST create or
-   update `/root/.openclaw/workspace/USER.md` so its `Timezone` field is
-   set to that IANA timezone.
+5. After onboard or doctor, the controller MUST seed
+   `/root/.openclaw/exec-approvals.json` defaults to match the configured
+   exec policy.
+6. After onboard or doctor, the controller MUST migrate legacy plaintext
+   KiloCode auth profile keys to env-backed key references.
+7. The controller MUST seed `/root/.openclaw/workspace/IDENTITY.md` if
+   it does not already exist, using `KILOCLAW_BOT_NAME`,
+   `KILOCLAW_BOT_NATURE`, `KILOCLAW_BOT_VIBE`, and
+   `KILOCLAW_BOT_EMOJI` when present and defaults otherwise. It MUST
+   remove legacy `/root/.openclaw/workspace/BOOTSTRAP.md`.
+8. When `KILOCLAW_USER_TIMEZONE` or `KILOCLAW_USER_LOCATION` is set,
+   the controller MUST create or update `/root/.openclaw/workspace/USER.md`
+   so the corresponding `Timezone` or `Location` field is present.
+9. When `KILOCLAW_USER_LOCATION` is set, the controller SHOULD install
+   the image-baked weather skill into `/root/clawd/skills/weather/SKILL.md`.
+
+### TOOLS.md Sections
+
+1. The controller MUST manage bounded sections in
+   `/root/.openclaw/workspace/TOOLS.md` using begin/end markers so edits
+   outside managed sections are preserved.
+2. The controller MUST always enable the Kilo CLI, KiloClaw mitigations,
+   plugin install guidance, and process model sections.
+3. The controller MUST enable the Google Workspace section when
+   `KILOCLAW_GOOGLE_WORKSPACE_ENABLED=true` or
+   `KILOCLAW_GOG_CONFIG_TARBALL` is present; otherwise it MUST remove the
+   managed section.
+4. The controller MUST enable the 1Password section when
+   `OP_SERVICE_ACCOUNT_TOKEN` is present; otherwise it MUST remove the
+   managed section.
+5. The controller MUST enable the Linear section when `LINEAR_API_KEY` is
+   present; otherwise it MUST remove the managed section.
 
 ### Config Patching
 
@@ -360,16 +428,44 @@ patches to `openclaw.json`. The patches MUST include:
     models).
 11. `tools.profile`: MUST be set to `full` on fresh install or config
     restore. MUST be preserved on subsequent boots.
-12. Exec policy: host `gateway`, security `allowlist`, ask `on-miss`.
-13. Browser: enabled, headless, noSandbox.
-14. KiloClaw customizer plugin: load path and entry MUST be present;
+12. Exec policy: host `gateway`, security from `KILOCLAW_EXEC_SECURITY`
+    or default `allowlist`, ask from `KILOCLAW_EXEC_ASK` or default
+    `on-miss`.
+13. Update checks disabled (`update.checkOnStart=false`).
+14. Browser: enabled, headless, noSandbox.
+15. KiloClaw customizer plugin: load path and entry MUST be present;
     when `plugins.allow` exists, it MUST include `kiloclaw-customizer`.
-15. Channel configuration from `TELEGRAM_BOT_TOKEN`,
+    Web search MUST auto-enable the `kilo-exa` provider when
+    `KILO_EXA_SEARCH_MODE=kilo-proxy`, or when the mode is unset and the
+    user has not explicitly configured search; it MUST disable or defer to
+    user/Brave configuration when `KILO_EXA_SEARCH_MODE=disabled`.
+16. KiloClaw morning briefing plugin: load path and entry MUST be
+    present; when `plugins.allow` exists, it MUST include
+    `kiloclaw-morning-briefing`.
+17. Channel configuration from `TELEGRAM_BOT_TOKEN`,
     `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN`, with
     corresponding plugin enablement.
-16. Hooks configuration from `KILOCLAW_HOOKS_TOKEN`: enabled,
-    token, inbound email mapping. When Gmail credentials are present, the
-    gmail preset MUST also be enabled.
+18. Session default DM scope MUST be `per-channel-peer` when unset.
+19. Kilo Chat channel and plugin MUST be enabled. The channel MUST include
+    `_configured=true` so OpenClaw treats it as meaningful configuration.
+20. Hooks configuration from `KILOCLAW_HOOKS_TOKEN`: enabled, token,
+    `/hooks` path, inbound email mapping, and allowed session key prefixes
+    for `hook:` and `inbound-email:`. When Gmail credentials are present,
+    the gmail preset MUST also be enabled. Legacy inbound-email `wake`
+    mappings MUST be migrated to the current `agent` mapping form.
+21. Vector memory: when `KILOCLAW_VECTOR_MEMORY_ENABLED=true`, configure
+    `agents.defaults.memorySearch` to use the Kilo Gateway embeddings
+    endpoint. When disabled and stale memory search config exists, mark it
+    disabled and remove stale remote/provider/model fields.
+22. Dreaming: when `KILOCLAW_DREAMING_ENABLED=true`, enable
+    `plugins.entries.memory-core.config.dreaming`. When disabled and stale
+    dreaming config exists, mark it disabled.
+23. Custom secret path patching from `KILOCLAW_SECRET_CONFIG_PATHS`: for
+    each env-var-to-config-path mapping, set the decrypted env value at the
+    requested JSON dot-notation path unless the path contains a banned
+    prototype-pollution segment.
+24. Legacy Stream Chat channel/plugin config MUST be removed before the
+    patched config is written.
 
 ### Hooks Token
 
@@ -380,6 +476,29 @@ patches to `openclaw.json`. The patches MUST include:
    authenticate to controller endpoints with the gateway token, and the
    controller forwards to local OpenClaw hook endpoints with the hooks
    token.
+
+### Google Workspace and Gmail
+
+1. Google Workspace is configured from `KILOCLAW_GOG_CONFIG_TARBALL` and
+   related metadata. The controller SHOULD extract credentials into the
+   gog config directory, set `GOG_KEYRING_BACKEND=file`, set
+   `GOG_KEYRING_PASSWORD=kiloclaw`, and set `GOG_ACCOUNT` when the
+   Google account email is known.
+2. When `KILOCLAW_GMAIL_LAST_HISTORY_ID` is present, the controller
+   SHOULD patch the gog Gmail watch state so watch delivery resumes from
+   the latest worker-observed history ID.
+3. When Google credentials, account email, and hooks token are available,
+   the controller SHOULD start a gog Gmail watch supervisor using
+   `/usr/local/bin/gog.real gmail watch serve` bound to `127.0.0.1:3002`
+   with path `/gmail-pubsub`, gateway-token authentication, hook URL
+   `http://127.0.0.1:3001/hooks/gmail`, hook-token authentication, body
+   inclusion, and bounded body bytes.
+4. The controller SHOULD renew the Gmail watch periodically while the
+   watch supervisor is running.
+5. The controller SHOULD install the gog shim so normal `gog` invocations
+   can use brokered OAuth tokens and legacy fallback behavior.
+6. Legacy Google credential migration to the Kilo broker is best-effort.
+   Migration failures MUST be logged and MUST NOT prevent gateway startup.
 
 ### Gateway Args
 
@@ -460,16 +579,17 @@ The controller uses three authentication mechanisms:
 | ------ | ---------------- | ----------------------------------------------------------------------------- |
 | GET    | `/_kilo/version` | Controller version, commit, openclaw version, gateway stats, controller state |
 
-The response MUST include:
+The response fields are:
 
-| Field             | Type           | Description                                                                        |
-| ----------------- | -------------- | ---------------------------------------------------------------------------------- |
-| `version`         | string         | Controller version (calver)                                                        |
-| `commit`          | string         | Controller build commit hash                                                       |
-| `openclawVersion` | string \| null | Installed openclaw version                                                         |
-| `openclawCommit`  | string \| null | Installed openclaw commit hash                                                     |
-| `gateway`         | object \| null | Supervisor stats (same as `/_kilo/gateway/status`), null if supervisor not created |
-| `controllerState` | object         | Current controller lifecycle state (present when state ref is wired)               |
+| Field             | Type           | Required | Description                                                                        |
+| ----------------- | -------------- | -------- | ---------------------------------------------------------------------------------- |
+| `version`         | string         | Yes      | Controller version (calver)                                                        |
+| `commit`          | string         | Yes      | Controller build commit hash                                                       |
+| `openclawVersion` | string \| null | Yes      | Installed openclaw version                                                         |
+| `openclawCommit`  | string \| null | Yes      | Installed openclaw commit hash                                                     |
+| `gateway`         | object \| null | Yes      | Supervisor stats (same as `/_kilo/gateway/status`), null if supervisor not created |
+| `controllerState` | object         | No       | Current controller lifecycle state, present when state ref is wired                |
+| `kiloChatHealth`  | object         | No       | Kilo Chat health probe summary, present when Kilo Chat probing is active           |
 
 #### Gateway (bearer token)
 
@@ -478,16 +598,18 @@ The response MUST include:
 | GET    | `/_kilo/gateway/status`  | Gateway supervisor state and stats         |
 | POST   | `/_kilo/gateway/start`   | Start the gateway (409 if running)         |
 | POST   | `/_kilo/gateway/stop`    | Stop the gateway gracefully                |
+| GET    | `/_kilo/gateway/ready`   | Proxy the gateway readiness endpoint       |
 | POST   | `/_kilo/gateway/restart` | Restart the gateway (409 if shutting down) |
 
 #### Config (bearer token)
 
-| Method | Path                         | Description                                            |
-| ------ | ---------------------------- | ------------------------------------------------------ |
-| GET    | `/_kilo/config/read`         | Read openclaw.json with MD5 etag                       |
-| POST   | `/_kilo/config/restore/base` | Regenerate config from env vars, signal gateway reload |
-| POST   | `/_kilo/config/replace`      | Atomically replace openclaw.json (etag concurrency)    |
-| POST   | `/_kilo/config/patch`        | Deep-merge a JSON patch into openclaw.json             |
+| Method | Path                                      | Description                                                |
+| ------ | ----------------------------------------- | ---------------------------------------------------------- |
+| GET    | `/_kilo/config/read`                      | Read openclaw.json with MD5 etag                           |
+| POST   | `/_kilo/config/restore/base`              | Regenerate config from env vars, signal gateway reload     |
+| POST   | `/_kilo/config/replace`                   | Atomically replace openclaw.json (etag concurrency)        |
+| POST   | `/_kilo/config/patch`                     | Deep-merge a JSON patch into openclaw.json                 |
+| POST   | `/_kilo/config/tools-md/google-workspace` | Enable/disable managed Google Workspace `TOOLS.md` section |
 
 The restore endpoint only accepts `base` as the version parameter.
 Other values MUST return 400.
@@ -497,6 +619,13 @@ Other values MUST return 400.
 | Method | Path               | Description                                          |
 | ------ | ------------------ | ---------------------------------------------------- |
 | POST   | `/_kilo/env/patch` | Hot-patch allowed env vars and signal gateway reload |
+
+#### Google OAuth (bearer token)
+
+| Method | Path                         | Description                                      |
+| ------ | ---------------------------- | ------------------------------------------------ |
+| POST   | `/_kilo/google-oauth/token`  | Resolve a brokered Google OAuth access token     |
+| POST   | `/_kilo/google-oauth/status` | Report broker/legacy Google credential readiness |
 
 #### Pairing (bearer token)
 
@@ -509,9 +638,85 @@ Other values MUST return 400.
 
 #### Gmail Push (bearer token)
 
-| Method | Path                  | Description                                     |
-| ------ | --------------------- | ----------------------------------------------- |
-| POST   | `/_kilo/gmail-pubsub` | Forward Google Pub/Sub push to gog on port 3002 |
+| Method | Path                  | Description                                           |
+| ------ | --------------------- | ----------------------------------------------------- |
+| POST   | `/_kilo/gmail-pubsub` | Forward Google Pub/Sub push to gog watch on port 3002 |
+
+The Gmail push endpoint MUST return 404 when Gmail watch is not
+configured and 503 when the watch supervisor is configured but not
+running. When forwarding, it MUST authenticate to gog with
+`x-gog-token: <gateway token>`.
+
+#### Inbound Hooks (bearer token)
+
+| Method | Path                 | Description                                      |
+| ------ | -------------------- | ------------------------------------------------ |
+| POST   | `/_kilo/hooks/email` | Forward inbound email payloads to OpenClaw hooks |
+
+#### Files and Profiles (bearer token)
+
+| Method | Path                                     | Description                                   |
+| ------ | ---------------------------------------- | --------------------------------------------- |
+| POST   | `/_kilo/bot-identity`                    | Write bot identity metadata                   |
+| POST   | `/_kilo/user-profile`                    | Write user profile metadata                   |
+| GET    | `/_kilo/files/tree`                      | List the safe file tree under controller root |
+| GET    | `/_kilo/files/read`                      | Read a safe file path                         |
+| POST   | `/_kilo/files/import-openclaw-workspace` | Import OpenClaw workspace files               |
+| POST   | `/_kilo/files/write`                     | Write a safe file path                        |
+
+#### Doctor (bearer token)
+
+| Method | Path                   | Description                          |
+| ------ | ---------------------- | ------------------------------------ |
+| POST   | `/_kilo/doctor/start`  | Start an async `openclaw doctor` run |
+| GET    | `/_kilo/doctor/status` | Inspect current doctor run status    |
+| POST   | `/_kilo/doctor/cancel` | Cancel the active doctor run         |
+
+#### Kilo CLI Run (bearer token)
+
+| Method | Path                    | Description                 |
+| ------ | ----------------------- | --------------------------- |
+| POST   | `/_kilo/cli-run/start`  | Start an async Kilo CLI run |
+| GET    | `/_kilo/cli-run/status` | Inspect current run status  |
+| POST   | `/_kilo/cli-run/cancel` | Cancel the active Kilo run  |
+
+#### Morning Briefing (bearer token)
+
+| Method | Path                                     | Description                           |
+| ------ | ---------------------------------------- | ------------------------------------- |
+| GET    | `/_kilo/morning-briefing/status`         | Proxy morning briefing plugin status  |
+| POST   | `/_kilo/morning-briefing/enable`         | Enable the morning briefing schedule  |
+| POST   | `/_kilo/morning-briefing/disable`        | Disable the morning briefing schedule |
+| POST   | `/_kilo/morning-briefing/run`            | Run briefing generation immediately   |
+| POST   | `/_kilo/morning-briefing/interests`      | Update briefing interest topics       |
+| GET    | `/_kilo/morning-briefing/read/today`     | Read today's briefing markdown        |
+| GET    | `/_kilo/morning-briefing/read/yesterday` | Read yesterday's briefing markdown    |
+
+#### Kilo Chat (bearer token)
+
+Kilo Chat routes are registered only when both `KILOCLAW_SANDBOX_ID` and
+`KILOCHAT_BASE_URL` are set. When registered, the controller MUST relay
+to `${KILOCHAT_BASE_URL}/bot/v1/sandboxes/:sandboxId` using the
+per-sandbox gateway token.
+
+| Method | Path                                                                                 | Description                     |
+| ------ | ------------------------------------------------------------------------------------ | ------------------------------- |
+| POST   | `/_kilo/kilo-chat/send`                                                              | Send a Kilo Chat message        |
+| PATCH  | `/_kilo/kilo-chat/messages/:messageId`                                               | Edit a Kilo Chat message        |
+| DELETE | `/_kilo/kilo-chat/messages/:messageId`                                               | Delete a Kilo Chat message      |
+| POST   | `/_kilo/kilo-chat/messages/:messageId/reactions`                                     | Add a message reaction          |
+| DELETE | `/_kilo/kilo-chat/messages/:messageId/reactions`                                     | Delete a message reaction       |
+| POST   | `/_kilo/kilo-chat/typing`                                                            | Start typing indicator          |
+| POST   | `/_kilo/kilo-chat/typing/stop`                                                       | Stop typing indicator           |
+| GET    | `/_kilo/kilo-chat/conversations/:conversationId/messages`                            | List conversation messages      |
+| PATCH  | `/_kilo/kilo-chat/conversations/:conversationId`                                     | Rename a conversation           |
+| POST   | `/_kilo/kilo-chat/bot-status`                                                        | Set bot status                  |
+| POST   | `/_kilo/kilo-chat/conversations/:conversationId/conversation-status`                 | Set conversation status         |
+| POST   | `/_kilo/kilo-chat/conversations`                                                     | Create a conversation           |
+| GET    | `/_kilo/kilo-chat/conversations`                                                     | List conversations              |
+| GET    | `/_kilo/kilo-chat/conversations/:conversationId/members`                             | List conversation members       |
+| POST   | `/_kilo/kilo-chat/conversations/:conversationId/messages/:messageId/delivery-failed` | Report message delivery failure |
+| POST   | `/_kilo/kilo-chat/conversations/:conversationId/actions/:groupId/delivery-failed`    | Report action delivery failure  |
 
 #### Catch-All Proxy (proxy token)
 
@@ -599,13 +804,14 @@ Other values MUST return 400.
    MAY include operational error details in responses since the
    caller has already proven identity via bearer token.
 3. The full error MUST always be logged to stdout.
-4. Best-effort steps (Kilo CLI config, gog credentials, GitHub
-   configuration) MUST log failures but MUST NOT abort startup or
-   enter degraded mode.
+4. Best-effort steps (npm cache cleanup, Kilo CLI config, gog
+   credentials, legacy Google credential migration, gog shim
+   installation, GitHub configuration) MUST log failures but MUST NOT
+   abort startup or enter degraded mode.
 5. Feature flag directory creation failures MUST log a warning and
    skip the corresponding env var setup, matching the documented
    behavior of each flag.
-6. The `writeBaseConfig` function MUST internally set
-   `KILOCLAW_FRESH_INSTALL=true` before calling `generateBaseConfig`
-   so that `tools.profile` is forced to `full` on both fresh
-   installs and config restores.
+6. The first-boot path MUST set `KILOCLAW_FRESH_INSTALL=true` before
+   calling `writeBaseConfig` so `generateBaseConfig` forces
+   `tools.profile=full`; config restore MUST also force
+   `tools.profile=full` before atomically replacing `openclaw.json`.


### PR DESCRIPTION
## Summary

- Refreshes the KiloClaw controller spec against the current controller implementation so it documents the machine entrypoint process, supervised child processes, bootstrap phases, config patching, and controller-mediated integrations accurately.
- Adds missing coverage for Linear/AgentCard via mcporter, managed `TOOLS.md` sections, Google Workspace/Gmail watch, Kilo Chat, morning briefing, file/profile routes, doctor routes, Kilo CLI run routes, and Google OAuth endpoints.
- Clarifies the `/_kilo/version` response contract by distinguishing required fields from optional diagnostics such as `controllerState` and `kiloChatHealth`.
- No runtime architecture changes; this is a documentation/spec alignment update.

## Verification

- No manual runtime verification performed; this is a docs-only spec update and does not change application behavior.
- [ ] Add any additional manual verification details before merge.

## Visual Changes

N/A

## Reviewer Notes

- Review focus: confirm the updated spec matches `services/kiloclaw/controller/src`, especially bootstrap sequencing, config patching, and the expanded controller endpoint catalog.
- Push used `--no-verify` with approval because unrelated pre-push lint/typecheck failures exist in mobile/web Kilo Pass files and missing App Store Server Library types.