### PR TITLE
feat(kiloclaw) briefing linear scope and diagnostics

### DIFF
--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1114,9 +1114,15 @@ function MorningBriefingCard({
                   {isReading ? (
                     <p className="text-muted-foreground text-xs">Loading saved briefing...</p>
                   ) : readData?.markdown ? (
-                    <pre className="bg-muted max-h-56 overflow-auto rounded p-3 text-xs whitespace-pre-wrap">
-                      {readData.markdown}
-                    </pre>
+                    <>
+                      <pre className="bg-muted max-h-56 overflow-auto rounded p-3 text-xs whitespace-pre-wrap">
+                        {readData.markdown}
+                      </pre>
+                      <p className="text-muted-foreground mt-2 text-xs italic">
+                        Raw markdown output. Briefings delivered to chat are reformatted for
+                        readability.
+                      </p>
+                    </>
                   ) : (
                     <p className="text-muted-foreground text-xs">
                       No saved briefing for {requestedDay === 'today' ? 'today' : 'yesterday'}.

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
@@ -75,6 +75,20 @@ async function createHarness(options?: {
   preloadedStatus?: Record<string, unknown>;
   githubAuthReady?: boolean;
   githubIssues?: Array<{ title: string; url: string; updatedAt?: string }>;
+  /**
+   * When set, populates `LINEAR_API_KEY` in the process env via
+   * `vi.stubEnv` so `resolveLinearReady` returns configured. Cleared
+   * automatically in `afterEach`.
+   */
+  linearApiKey?: string;
+  /**
+   * Payload returned by the mocked `mcporter call linear list_issues`
+   * invocation. The harness wraps these in the `{issues, hasNextPage}`
+   * envelope that the real Linear MCP server returns.
+   */
+  linearIssues?: Array<Record<string, unknown>>;
+  /** When set, the mocked mcporter call fails with this stderr / non-zero exit. */
+  linearMcpFailure?: { stdout?: string; stderr?: string };
   channelsConfig?: Record<string, unknown>;
   messageSendFailures?: Partial<Record<'telegram' | 'discord' | 'slack', string>>;
   messageSendFailureCounts?: Partial<Record<'telegram' | 'discord' | 'slack', number>>;
@@ -88,6 +102,12 @@ async function createHarness(options?: {
    */
   cronAddBarrier?: Promise<void>;
 }): Promise<TestHarness> {
+  // Linear readiness reads `process.env.LINEAR_API_KEY` directly. Stub it
+  // per-test so `vi.unstubAllEnvs()` in `afterEach` restores the original
+  // and tests that don't opt in run with the env explicitly cleared (no
+  // host-environment leakage into the `resolveLinearReady` path).
+  vi.stubEnv('LINEAR_API_KEY', options?.linearApiKey ?? '');
+
   const { default: morningBriefingPlugin } = await import('./index');
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'morning-briefing-'));
   const pluginDir = path.join(stateDir, 'morning-briefing');
@@ -127,6 +147,29 @@ async function createHarness(options?: {
     if (argv[0] === 'gh' && argv[1] === 'search' && argv[2] === 'issues') {
       return {
         stdout: JSON.stringify(options?.githubIssues ?? []),
+        stderr: '',
+        code: 0,
+      };
+    }
+
+    if (
+      argv[0] === 'mcporter' &&
+      argv[1] === 'call' &&
+      argv[2] === 'linear' &&
+      argv[3] === 'list_issues'
+    ) {
+      if (options?.linearMcpFailure) {
+        return {
+          stdout: options.linearMcpFailure.stdout ?? '',
+          stderr: options.linearMcpFailure.stderr ?? 'mcporter failure',
+          code: 1,
+        };
+      }
+      return {
+        stdout: JSON.stringify({
+          issues: options?.linearIssues ?? [],
+          hasNextPage: false,
+        }),
         stderr: '',
         code: 0,
       };
@@ -351,6 +394,7 @@ async function waitForReconcileState(
 afterEach(async () => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe('morning briefing lifecycle', () => {
@@ -966,6 +1010,179 @@ describe('morning briefing lifecycle', () => {
         )
       )
     ).toBe(true);
+  });
+
+  describe('linear source', () => {
+    async function readGithubAndLinearStatus(
+      stateDir: string
+    ): Promise<Array<{ source: string; summary: string }>> {
+      const status = (await readJson(path.join(stateDir, 'morning-briefing', 'status.json'))) as {
+        sourceSummary?: Array<{ source: string; summary: string }>;
+      };
+      return status.sourceSummary ?? [];
+    }
+
+    const telegramOnly = { telegram: { enabled: true, defaultTo: '-100123456' } };
+
+    it('queries with assignee:me + limit:8 + orderBy:updatedAt and uses the correct workspace cwd', async () => {
+      const harness = await createHarness({
+        linearApiKey: 'lin_api_abc',
+        linearIssues: [],
+        channelsConfig: telegramOnly,
+      });
+
+      const response = new FakeResponse();
+      await harness.runHttpHandler({}, response);
+      expect(response.statusCode).toBe(200);
+
+      const linearCall = harness.runCommandWithTimeout.mock.calls.find(
+        ([argv]) => Array.isArray(argv) && argv[0] === 'mcporter' && argv[3] === 'list_issues'
+      );
+      expect(linearCall).toBeDefined();
+      const [argv, opts] = linearCall as [string[], { cwd?: string }];
+      expect(argv).toContain('assignee:me');
+      expect(argv).toContain('limit:8');
+      expect(argv).toContain('orderBy:updatedAt');
+      expect(argv).toEqual(expect.arrayContaining(['mcporter', 'call', 'linear', 'list_issues']));
+      expect(opts.cwd).toMatch(/workspace$/);
+    });
+
+    it('renders empty-result diagnostic when assignee:me returns no issues', async () => {
+      const harness = await createHarness({
+        linearApiKey: 'lin_api_abc',
+        linearIssues: [],
+        channelsConfig: telegramOnly,
+      });
+
+      const response = new FakeResponse();
+      await harness.runHttpHandler({}, response);
+      expect(response.statusCode).toBe(200);
+
+      const sent = harness.sentMessages[0]?.message ?? '';
+      expect(sent).toContain('No issues assigned to you in Linear');
+      expect(sent).toContain('mcporter call linear list_issues assignee:me');
+
+      const summaries = await readGithubAndLinearStatus(harness.stateDir);
+      const linearSummary = summaries.find(s => s.source === 'linear');
+      expect(linearSummary?.summary).toBe('0 issues assigned to you in Linear');
+    });
+
+    it('renders priority + labels + due date in the issue line, hiding Low when high-signal exists', async () => {
+      const harness = await createHarness({
+        linearApiKey: 'lin_api_abc',
+        linearIssues: [
+          {
+            id: 'KIL-8',
+            title: 'My test issue',
+            status: 'Todo',
+            url: 'https://linear.app/x/issue/KIL-8',
+            updatedAt: '2026-05-14T23:13:00.450Z',
+            priority: { value: 1, name: 'Urgent' },
+            labels: ['Bug'],
+            dueDate: '2026-05-15',
+          },
+          {
+            id: 'KIL-7',
+            title: 'Add Discord button',
+            status: 'Todo',
+            url: 'https://linear.app/x/issue/KIL-7',
+            updatedAt: '2026-05-12',
+            priority: { value: 4, name: 'Low' },
+            labels: [],
+          },
+        ],
+        channelsConfig: telegramOnly,
+      });
+
+      const response = new FakeResponse();
+      await harness.runHttpHandler({}, response);
+      expect(response.statusCode).toBe(200);
+
+      const sent = harness.sentMessages[0]?.message ?? '';
+      // KIL-8 has Urgent + Bug + due date — all surfaced.
+      expect(sent).toContain('KIL-8');
+      expect(sent).toContain('Urgent, Bug');
+      expect(sent).toContain('due 2026-05-15');
+      // KIL-7 has Low priority — hidden because KIL-8 carries high signal.
+      expect(sent).toContain('KIL-7');
+      expect(sent).toContain('Add Discord button');
+      expect(sent).not.toContain('Low');
+
+      const summaries = await readGithubAndLinearStatus(harness.stateDir);
+      const linearSummary = summaries.find(s => s.source === 'linear');
+      expect(linearSummary?.summary).toBe('Fetched 2 Linear issues assigned to you');
+    });
+
+    it('shows Low / None priority badges when nothing in the brief is high-signal', async () => {
+      const harness = await createHarness({
+        linearApiKey: 'lin_api_abc',
+        linearIssues: [
+          {
+            id: 'KIL-1',
+            title: 'Lower priority task',
+            status: 'Todo',
+            url: 'https://linear.app/x/issue/KIL-1',
+            updatedAt: '2026-05-12',
+            priority: { value: 4, name: 'Low' },
+            labels: [],
+          },
+          {
+            id: 'KIL-2',
+            title: 'No priority set',
+            status: 'Todo',
+            url: 'https://linear.app/x/issue/KIL-2',
+            updatedAt: '2026-05-11',
+            priority: { value: 0, name: 'None' },
+            labels: ['Backend'],
+          },
+        ],
+        channelsConfig: telegramOnly,
+      });
+
+      const response = new FakeResponse();
+      await harness.runHttpHandler({}, response);
+      expect(response.statusCode).toBe(200);
+
+      const sent = harness.sentMessages[0]?.message ?? '';
+      // When the whole brief is Low / None, surface those badges so the
+      // reader knows priority is set, not just absent.
+      expect(sent).toContain('Low');
+      expect(sent).toContain('None');
+      expect(sent).toContain('Backend');
+    });
+
+    it('treats mcporter failure as an error source without breaking the brief', async () => {
+      const harness = await createHarness({
+        linearApiKey: 'lin_api_abc',
+        linearMcpFailure: {
+          stdout: JSON.stringify({
+            server: 'linear',
+            tool: 'list_issues',
+            error: 'SSE error: Non-200 status code (401)',
+            issue: { kind: 'auth', statusCode: 401 },
+          }),
+        },
+        githubAuthReady: true,
+        githubIssues: [
+          {
+            title: 'GH issue',
+            url: 'https://github.com/x/y/issues/1',
+            updatedAt: '2026-05-12',
+          },
+        ],
+        channelsConfig: telegramOnly,
+      });
+
+      const response = new FakeResponse();
+      await harness.runHttpHandler({}, response);
+      expect(response.statusCode).toBe(200);
+
+      const summaries = await readGithubAndLinearStatus(harness.stateDir);
+      const linearSummary = summaries.find(s => s.source === 'linear');
+      expect(linearSummary?.summary).toBe(
+        'Linear authentication failed (check LINEAR_API_KEY and redeploy)'
+      );
+    });
   });
 
   describe('interests HTTP route', () => {

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -829,7 +829,7 @@ async function collectLinear(api: {
       sectionLines: [
         'No issues assigned to you in Linear.',
         '',
-        'If you expected results, check `mcporter call linear list_issues assignee:me limit:8` from your container shell. The brief is scoped to issues you own; issues assigned to others will not appear.',
+        'If you expected results, check `mcporter call linear list_issues assignee:me limit:8 orderBy:updatedAt` from your container shell. The brief is scoped to issues you own; issues assigned to others will not appear.',
       ],
     };
   }

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -19,7 +19,12 @@ import {
 } from './cron-utils';
 import { extractBriefingArgsFromText } from './command-fallback-utils';
 import { type EnableInput, isValidTimezone, parseEnableArgs } from './enable-input-utils';
-import { normalizeLinearIssues, summarizeLinearCallFailure } from './linear-utils';
+import {
+  formatLinearIssueLine,
+  hasHighSignalPriority,
+  normalizeLinearIssues,
+  summarizeLinearCallFailure,
+} from './linear-utils';
 import { resolveNextReconcileAction } from './reconcile-queue-utils';
 import { normalizeWebResults } from './web-utils';
 
@@ -779,6 +784,7 @@ async function collectLinear(api: {
       'call',
       'linear',
       'list_issues',
+      'assignee:me',
       'limit:8',
       'orderBy:updatedAt',
       '--output',
@@ -819,20 +825,22 @@ async function collectLinear(api: {
       source: 'linear',
       configured: true,
       ok: true,
-      summary: 'No Linear issues matched the default query',
-      sectionLines: ['- No Linear issues returned.'],
+      summary: '0 issues assigned to you in Linear',
+      sectionLines: [
+        'No issues assigned to you in Linear.',
+        '',
+        'If you expected results, check `mcporter call linear list_issues assignee:me limit:8` from your container shell. The brief is scoped to issues you own; issues assigned to others will not appear.',
+      ],
     };
   }
 
+  const briefHasHighSignal = hasHighSignalPriority(issues);
   return {
     source: 'linear',
     configured: true,
     ok: true,
-    summary: `Fetched ${issues.length} Linear issues`,
-    sectionLines: issues.map(issue => {
-      const updatedSuffix = issue.updatedAt ? ` (updated ${issue.updatedAt})` : '';
-      return `- [${issue.id}](${issue.url}) ${issue.title} - ${issue.status}${updatedSuffix}`;
-    }),
+    summary: `Fetched ${issues.length} Linear issues assigned to you`,
+    sectionLines: issues.map(issue => formatLinearIssueLine(issue, briefHasHighSignal)),
   };
 }
 

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.test.ts
@@ -1,31 +1,205 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeLinearIssues, summarizeLinearCallFailure } from './linear-utils';
+import {
+  formatLinearIssueLine,
+  hasHighSignalPriority,
+  type LinearIssueSummary,
+  normalizeLinearIssues,
+  shouldShowPriorityBadge,
+  summarizeLinearCallFailure,
+} from './linear-utils';
 
-describe('linear-utils', () => {
-  it('normalizes list_issues payload into concise issue summaries', () => {
+function buildIssue(overrides: Partial<LinearIssueSummary> = {}): LinearIssueSummary {
+  const id = overrides.id ?? 'KIL-1';
+  return {
+    id,
+    title: 'Sample',
+    status: 'Todo',
+    url: `https://linear.app/x/issue/${id}`,
+    labels: [],
+    ...overrides,
+  };
+}
+
+describe('normalizeLinearIssues', () => {
+  it('extracts priority, labels, and dueDate when present', () => {
     const issues = normalizeLinearIssues({
       issues: [
         {
-          id: 'TES-1',
-          title: 'Get familiar with Linear',
+          id: 'KIL-8',
+          title: 'My test issue',
           status: 'Todo',
-          url: 'https://linear.app/example/issue/TES-1',
-          updatedAt: '2026-04-23T22:28:59.657Z',
+          url: 'https://linear.app/x/issue/KIL-8',
+          updatedAt: '2026-05-14T23:13:00.450Z',
+          priority: { value: 1, name: 'Urgent' },
+          labels: ['Bug'],
+          dueDate: '2026-05-15',
         },
       ],
     });
 
     expect(issues).toEqual([
       {
-        id: 'TES-1',
-        title: 'Get familiar with Linear',
+        id: 'KIL-8',
+        title: 'My test issue',
         status: 'Todo',
-        url: 'https://linear.app/example/issue/TES-1',
-        updatedAt: '2026-04-23T22:28:59.657Z',
+        url: 'https://linear.app/x/issue/KIL-8',
+        updatedAt: '2026-05-14T23:13:00.450Z',
+        priority: { value: 1, name: 'Urgent' },
+        labels: ['Bug'],
+        dueDate: '2026-05-15',
       },
     ]);
   });
 
+  it('defaults priority to undefined and labels to empty array when missing', () => {
+    const [issue] = normalizeLinearIssues({
+      issues: [
+        {
+          id: 'KIL-1',
+          title: 'Plain',
+          status: 'Todo',
+          url: 'https://linear.app/x/issue/KIL-1',
+        },
+      ],
+    });
+
+    expect(issue.priority).toBeUndefined();
+    expect(issue.labels).toEqual([]);
+    expect(issue.dueDate).toBeUndefined();
+  });
+
+  it('drops malformed labels and priority entries', () => {
+    const [issue] = normalizeLinearIssues({
+      issues: [
+        {
+          id: 'KIL-2',
+          title: 'Mixed',
+          status: 'Todo',
+          url: 'https://linear.app/x/issue/KIL-2',
+          priority: { value: 'not a number', name: 'High' },
+          labels: ['Real', '', 42, '  ', 'AlsoReal'],
+        },
+      ],
+    });
+
+    expect(issue.priority).toBeUndefined();
+    expect(issue.labels).toEqual(['Real', 'AlsoReal']);
+  });
+});
+
+describe('hasHighSignalPriority', () => {
+  it('returns true when at least one issue is Urgent / High / Medium', () => {
+    expect(hasHighSignalPriority([buildIssue({ priority: { value: 3, name: 'Medium' } })])).toBe(
+      true
+    );
+  });
+
+  it('returns false when only Low / None / no-priority issues exist', () => {
+    expect(
+      hasHighSignalPriority([
+        buildIssue({ priority: { value: 4, name: 'Low' } }),
+        buildIssue({ priority: { value: 0, name: 'None' } }),
+        buildIssue(),
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false on an empty list', () => {
+    expect(hasHighSignalPriority([])).toBe(false);
+  });
+});
+
+describe('shouldShowPriorityBadge', () => {
+  it('always shows badge for Urgent / High / Medium', () => {
+    for (const value of [1, 2, 3]) {
+      const issue = buildIssue({ priority: { value, name: 'X' } });
+      expect(shouldShowPriorityBadge(issue, false)).toBe(true);
+      expect(shouldShowPriorityBadge(issue, true)).toBe(true);
+    }
+  });
+
+  it('shows Low / None only when no high signal exists in the brief', () => {
+    for (const value of [4, 0]) {
+      const issue = buildIssue({ priority: { value, name: 'X' } });
+      expect(shouldShowPriorityBadge(issue, false)).toBe(true);
+      expect(shouldShowPriorityBadge(issue, true)).toBe(false);
+    }
+  });
+
+  it('never shows badge when priority is missing', () => {
+    expect(shouldShowPriorityBadge(buildIssue(), false)).toBe(false);
+    expect(shouldShowPriorityBadge(buildIssue(), true)).toBe(false);
+  });
+});
+
+describe('formatLinearIssueLine', () => {
+  it('renders priority and labels in a single bracket when present', () => {
+    const line = formatLinearIssueLine(
+      buildIssue({
+        id: 'KIL-8',
+        title: 'My test issue',
+        url: 'https://linear.app/x/issue/KIL-8',
+        priority: { value: 1, name: 'Urgent' },
+        labels: ['Bug'],
+        dueDate: '2026-05-15',
+        updatedAt: '2026-05-14',
+      }),
+      true
+    );
+
+    expect(line).toBe(
+      '- [KIL-8](https://linear.app/x/issue/KIL-8) [Urgent, Bug] My test issue - Todo (due 2026-05-15, updated 2026-05-14)'
+    );
+  });
+
+  it('omits the bracket when there is no badge content', () => {
+    const line = formatLinearIssueLine(
+      buildIssue({ id: 'KIL-1', title: 'Plain', updatedAt: '2026-05-14' }),
+      true
+    );
+    expect(line).toBe(
+      '- [KIL-1](https://linear.app/x/issue/KIL-1) Plain - Todo (updated 2026-05-14)'
+    );
+  });
+
+  it('hides Low / None priority when brief has high signal', () => {
+    const line = formatLinearIssueLine(
+      buildIssue({ id: 'KIL-2', priority: { value: 4, name: 'Low' }, labels: ['Backend'] }),
+      true
+    );
+    expect(line).toContain('[Backend]');
+    expect(line).not.toContain('Low');
+  });
+
+  it('shows Low / None priority when brief has no high signal', () => {
+    const line = formatLinearIssueLine(
+      buildIssue({ id: 'KIL-2', priority: { value: 4, name: 'Low' }, labels: ['Backend'] }),
+      false
+    );
+    expect(line).toContain('[Low, Backend]');
+  });
+
+  it('renders labels comma-separated', () => {
+    const line = formatLinearIssueLine(
+      buildIssue({ labels: ['Bug', 'Frontend', 'Performance'] }),
+      true
+    );
+    expect(line).toContain('[Bug, Frontend, Performance]');
+  });
+
+  it('drops the parens entirely when due date and updated are both missing', () => {
+    const line = formatLinearIssueLine(buildIssue({ id: 'KIL-3', title: 'Bare' }), true);
+    expect(line).toBe('- [KIL-3](https://linear.app/x/issue/KIL-3) Bare - Todo');
+  });
+
+  it('shows due date alone when updated is missing', () => {
+    const line = formatLinearIssueLine(buildIssue({ dueDate: '2026-05-15' }), true);
+    expect(line).toContain('(due 2026-05-15)');
+    expect(line).not.toContain('updated');
+  });
+});
+
+describe('summarizeLinearCallFailure', () => {
   it('summarizes auth errors from mcporter JSON payloads', () => {
     const summary = summarizeLinearCallFailure(
       JSON.stringify({

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.test.ts
@@ -68,6 +68,36 @@ describe('normalizeLinearIssues', () => {
     expect(issue.dueDate).toBeUndefined();
   });
 
+  it('rejects dueDate values that are not YYYY-MM-DD', () => {
+    const [issue] = normalizeLinearIssues({
+      issues: [
+        {
+          id: 'KIL-9',
+          title: 'Bad date',
+          status: 'Todo',
+          url: 'https://linear.app/x/issue/KIL-9',
+          dueDate: '2026/05/15',
+        },
+      ],
+    });
+    expect(issue.dueDate).toBeUndefined();
+  });
+
+  it('rejects an empty-string dueDate', () => {
+    const [issue] = normalizeLinearIssues({
+      issues: [
+        {
+          id: 'KIL-10',
+          title: 'Empty date',
+          status: 'Todo',
+          url: 'https://linear.app/x/issue/KIL-10',
+          dueDate: '',
+        },
+      ],
+    });
+    expect(issue.dueDate).toBeUndefined();
+  });
+
   it('drops malformed labels and priority entries', () => {
     const [issue] = normalizeLinearIssues({
       issues: [
@@ -196,6 +226,12 @@ describe('formatLinearIssueLine', () => {
     const line = formatLinearIssueLine(buildIssue({ dueDate: '2026-05-15' }), true);
     expect(line).toContain('(due 2026-05-15)');
     expect(line).not.toContain('updated');
+  });
+
+  it('trims a full ISO updatedAt timestamp down to YYYY-MM-DD', () => {
+    const line = formatLinearIssueLine(buildIssue({ updatedAt: '2026-05-14T23:13:00.450Z' }), true);
+    expect(line).toContain('updated 2026-05-14');
+    expect(line).not.toContain('T23:13:00');
   });
 });
 

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.ts
@@ -4,12 +4,38 @@ export type LinearIssueSummary = {
   status: string;
   url: string;
   updatedAt?: string;
+  /**
+   * Priority captured from the Linear `list_issues` response. The MCP
+   * server returns priority as `{value, name}` where value is 0–4 (0=None,
+   * 1=Urgent, 2=High, 3=Medium, 4=Low). We keep both so renderers can
+   * filter on value and display the human name.
+   */
+  priority?: { value: number; name: string };
+  /** Label names attached to the issue. Empty array when none are set. */
+  labels: string[];
+  /** Due date in YYYY-MM-DD form, if any. */
+  dueDate?: string;
 };
 
 function asObject(value: unknown): Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+}
+
+function normalizePriority(raw: unknown): { value: number; name: string } | undefined {
+  const obj = asObject(raw);
+  const value = typeof obj.value === 'number' ? obj.value : null;
+  const name = typeof obj.name === 'string' ? obj.name : null;
+  if (value === null || name === null) return undefined;
+  return { value, name };
+}
+
+function normalizeLabels(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (entry): entry is string => typeof entry === 'string' && entry.trim().length > 0
+  );
 }
 
 export function normalizeLinearIssues(payload: unknown): LinearIssueSummary[] {
@@ -23,8 +49,73 @@ export function normalizeLinearIssues(payload: unknown): LinearIssueSummary[] {
       status: typeof issue.status === 'string' ? issue.status : 'Unknown',
       url: typeof issue.url === 'string' ? issue.url : '',
       updatedAt: typeof issue.updatedAt === 'string' ? issue.updatedAt : undefined,
+      priority: normalizePriority(issue.priority),
+      labels: normalizeLabels(issue.labels),
+      dueDate: typeof issue.dueDate === 'string' ? issue.dueDate : undefined,
     }))
     .filter(issue => issue.id.length > 0);
+}
+
+/**
+ * Priority value semantics from the Linear MCP `list_issues` schema:
+ * 1 Urgent, 2 High, 3 Medium are "high signal" and are always badged.
+ * 4 Low and 0 None are quieter and are only badged when there are no
+ * high-signal items in the same brief, so the user never sees a bare
+ * list with zero priority cues.
+ */
+const HIGH_SIGNAL_PRIORITY_VALUES = new Set([1, 2, 3]);
+
+export function hasHighSignalPriority(issues: readonly LinearIssueSummary[]): boolean {
+  return issues.some(
+    issue => issue.priority !== undefined && HIGH_SIGNAL_PRIORITY_VALUES.has(issue.priority.value)
+  );
+}
+
+/**
+ * Decides whether a given issue's priority should appear in its rendered
+ * line, given the priority distribution of the whole brief.
+ *
+ * - Urgent / High / Medium: always shown.
+ * - Low / None: only shown when no Urgent / High / Medium exists in the brief.
+ * - Missing priority: never shown (nothing to display).
+ */
+export function shouldShowPriorityBadge(
+  issue: LinearIssueSummary,
+  briefHasHighSignal: boolean
+): boolean {
+  if (issue.priority === undefined) return false;
+  if (HIGH_SIGNAL_PRIORITY_VALUES.has(issue.priority.value)) return true;
+  return !briefHasHighSignal;
+}
+
+/**
+ * Render a single Linear issue as a markdown bullet for the brief.
+ * Output shape:
+ *
+ *   - [<id>](<url>) [<badges>] <title> - <status> (due <dueDate>, updated <updatedAt>)
+ *
+ * The bracket combines priority name + label names. Omitted if both are
+ * absent. Due date and updated suffix are space-joined inside the parens
+ * and individually omitted when missing. When all four suffix bits are
+ * absent, the parens drop entirely.
+ */
+export function formatLinearIssueLine(
+  issue: LinearIssueSummary,
+  briefHasHighSignal: boolean
+): string {
+  const badgeParts: string[] = [];
+  if (shouldShowPriorityBadge(issue, briefHasHighSignal) && issue.priority !== undefined) {
+    badgeParts.push(issue.priority.name);
+  }
+  badgeParts.push(...issue.labels);
+  const badge = badgeParts.length > 0 ? ` [${badgeParts.join(', ')}]` : '';
+
+  const suffixParts: string[] = [];
+  if (issue.dueDate) suffixParts.push(`due ${issue.dueDate}`);
+  if (issue.updatedAt) suffixParts.push(`updated ${issue.updatedAt}`);
+  const suffix = suffixParts.length > 0 ? ` (${suffixParts.join(', ')})` : '';
+
+  return `- [${issue.id}](${issue.url})${badge} ${issue.title} - ${issue.status}${suffix}`;
 }
 
 export function summarizeLinearCallFailure(stdout: string, stderr: string): string {

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.ts
@@ -51,7 +51,13 @@ export function normalizeLinearIssues(payload: unknown): LinearIssueSummary[] {
       updatedAt: typeof issue.updatedAt === 'string' ? issue.updatedAt : undefined,
       priority: normalizePriority(issue.priority),
       labels: normalizeLabels(issue.labels),
-      dueDate: typeof issue.dueDate === 'string' ? issue.dueDate : undefined,
+      // dueDate is contracted as YYYY-MM-DD in `LinearIssueSummary`. Enforce
+      // the shape on ingest so malformed values from the API can't leak into
+      // the rendered brief (e.g. "due not-a-date").
+      dueDate:
+        typeof issue.dueDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(issue.dueDate)
+          ? issue.dueDate
+          : undefined,
     }))
     .filter(issue => issue.id.length > 0);
 }
@@ -104,15 +110,25 @@ export function formatLinearIssueLine(
   briefHasHighSignal: boolean
 ): string {
   const badgeParts: string[] = [];
-  if (shouldShowPriorityBadge(issue, briefHasHighSignal) && issue.priority !== undefined) {
-    badgeParts.push(issue.priority.name);
+  // Bind priority into a local so the narrowing flows through `priority.name`
+  // below without a non-null assertion. shouldShowPriorityBadge already
+  // returns false when priority is undefined, but the local + explicit
+  // check keep the formatter readable on its own.
+  const priority = issue.priority;
+  if (priority !== undefined && shouldShowPriorityBadge(issue, briefHasHighSignal)) {
+    badgeParts.push(priority.name);
   }
   badgeParts.push(...issue.labels);
   const badge = badgeParts.length > 0 ? ` [${badgeParts.join(', ')}]` : '';
 
   const suffixParts: string[] = [];
   if (issue.dueDate) suffixParts.push(`due ${issue.dueDate}`);
-  if (issue.updatedAt) suffixParts.push(`updated ${issue.updatedAt}`);
+  if (issue.updatedAt) {
+    // Linear's API returns full ISO timestamps (e.g. 2026-05-14T23:13:00.450Z).
+    // The brief reads more naturally as a date; slice the first 10 chars.
+    // Already-YYYY-MM-DD inputs pass through unchanged.
+    suffixParts.push(`updated ${issue.updatedAt.slice(0, 10)}`);
+  }
   const suffix = suffixParts.length > 0 ? ` (${suffixParts.join(', ')})` : '';
 
   return `- [${issue.id}](${issue.url})${badge} ${issue.title} - ${issue.status}${suffix}`;


### PR DESCRIPTION
## Summary

The morning briefing's Linear source called `mcporter call linear list_issues` with no `assignee` filter, so it returned the eight most recently updated issues from the entire workspace regardless of whether the authenticated user was involved. For a "what is on my plate" briefing this is wrong; on a real workspace it surfaces other people's tickets.

This PR fixes the scoping and adds richer per issue rendering:

* Scopes the query to `assignee:me limit:8 orderBy:updatedAt`. Only issues assigned to the Linear user that owns the `LINEAR_API_KEY` appear in the brief.
* Captures `priority`, `labels`, and `dueDate` from the Linear MCP response. Renders priority plus labels as a single combined bracket (e.g. `[Urgent, Bug]`) and surfaces due dates in the line suffix.
* Hides priority badges for Low and None when the brief contains at least one Urgent, High, or Medium issue, so high signal tickets stand out. When the brief contains only Low or unprioritized issues, those badges show through so the reader can tell priority is set, not just missing.
* Rewrites the empty result diagnostic. Instead of "No Linear issues matched the default query", the brief now reads "No issues assigned to you in Linear" with a hint pointing at the equivalent `mcporter` command for verification.
* Validates `dueDate` as `YYYY-MM-DD` on ingest, trims full ISO `updatedAt` timestamps to the date portion in the rendered line, and drops a redundant priority guard caught in review.
* Adds a small italic footnote under the View Today / View Yesterday preview in Settings noting that the displayed markdown is the raw on disk format and that briefings delivered via chat are reformatted for readability.

Plugin and Settings UI only. No database migration, no new endpoints, no auth flow changes.

## Verification

Built the plugin bundle locally, swapped it onto a running container, restarted the gateway, and triggered a fresh briefing against a real Linear API key.

* Before: the unscoped query returned several workspace issues unrelated to the authenticated user.
* After: the scoped query returned only the issues actually assigned to the authenticated user. Brief rendered the line as `- [KIL-8](...) [Urgent, Bug] My test issue - Todo (due 2026-05-15, updated 2026-05-14T...)`.
* Empty case verified by removing the assignment. Brief read "No issues assigned to you in Linear." plus the self diagnostic hint.
* 91 vitest tests passing in `services/kiloclaw/plugins/kiloclaw-morning-briefing`.

## Visual Changes

The View Today preview in Settings now shows a small italic footnote under the markdown preview:

> Raw markdown output. Briefings delivered to chat are reformatted for readability.

## Reviewer Notes

* `formatLinearIssueLine` is pure and well tested. Priority visibility uses a single boolean argument (`briefHasHighSignal`) computed once per brief by `hasHighSignalPriority`, so per issue rendering stays cheap.
* The Linear MCP server's `list_issues` tool accepts a single `state` value, not an array, so we cannot OR multiple state types in one call. The current approach intentionally relies on `orderBy:updatedAt` to keep closed tickets from drifting into a recent briefing rather than filtering by state. If users complain about closed tickets appearing, a follow up can add either a second query for active states or a client side state filter.
* Linear has only one auth mode (`LINEAR_API_KEY`), so there is no token type classifier here. Auth failures from the MCP server are still surfaced via `summarizeLinearCallFailure`.
* The View Today footnote is a small UX hint, not a feature change. It only renders when there is a saved briefing to display. The empty and loading states are unchanged.