### PR TITLE
fix(ci): exempt tsx metadata gap for Vercel

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,7 @@ catalog:
 
 minimumReleaseAge: 6842
 minimumReleaseAgeExclude:
-  - tsx@4.21.0
+  - tsx
 overrides:
   '@sentry/cli': 3.4.2
   mdast-util-to-hast: 13.2.1


### PR DESCRIPTION
## Summary
- Keep Vercel CLI dependency resolution working under pnpm `minimumReleaseAge` enforcement after #3259.
- Broaden the existing `tsx` release-age exception from one exact version to the package name because pnpm still requires missing registry `time` metadata before exact-version matching can unblock this `dlx` path.
- Preserve release-age protection for every other dependency resolved by `pnpm dlx vercel@53.3.1`.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
- GitHub Actions reproduced `ERR_PNPM_MISSING_TIME` for `tsx` while resolving `vercel@53.3.1` through `@vercel/backends@0.4.0`; this config change targets that registry metadata failure.
- Package-level `tsx` exclusion is intentionally broader than `tsx@4.21.0`, but still far narrower than restoring `--config.minimum-release-age=0` for the full Vercel dependency tree.