### PR TITLE
fix(mobile): pin Node and pnpm versions in eas.json

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -4,12 +4,18 @@
     "appVersionSource": "remote"
   },
   "build": {
+    "base": {
+      "node": "24.15.0",
+      "pnpm": "11.1.2"
+    },
     "development": {
+      "extends": "base",
       "developmentClient": true,
       "distribution": "internal",
       "credentialsSource": "remote"
     },
     "production": {
+      "extends": "base",
       "autoIncrement": true,
       "credentialsSource": "remote"
     }


### PR DESCRIPTION
## Summary
- EAS Build was defaulting to Node 20.19.4, but pnpm 11.x uses the `node:sqlite` builtin and requires Node >= 22.13, causing `pnpm install --frozen-lockfile` to fail with `ERR_UNKNOWN_BUILTIN_MODULE`.
- Pin `node: 24.15.0` and `pnpm: 11.1.2` via a shared `base` build profile that `development` and `production` extend.

## Test plan
- [ ] Trigger an EAS development build and confirm `pnpm install --frozen-lockfile` succeeds.
- [ ] Trigger an EAS production build and confirm install + build succeed.