### PR TITLE
ci(deploy): gate production rollout on DB startup

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,9 +15,40 @@ env:
   VERCEL_VERSION: '53.3.1'
 
 jobs:
+  check-production-db-startup:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    environment: production
+
+    steps:
+      - name: Checkout code
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Setup Vercel ENV — link from repo root; Vercel rootDirectory (apps/web) is set on the dashboard
+      - run: pnpm dlx vercel@${{ env.VERCEL_VERSION }} link --project=kilocode-app --token=${{ secrets.VERCEL_TOKEN }} --yes
+      - run: pnpm dlx vercel@${{ env.VERCEL_VERSION }} env pull .env.local --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Check production DB startup path
+        run: NODE_ENV=production pnpm exec tsx scripts/check-production-db-startup.ts
+
   run-migrations:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 15
+    needs: check-production-db-startup
     environment: production
 
     steps:
@@ -148,6 +179,7 @@ jobs:
         run: pnpm dlx vercel@${{ env.VERCEL_VERSION }} deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
   deploy-kiloclaw:
+    needs: check-production-db-startup
     permissions:
       contents: read
       packages: write

--- a/scripts/check-production-db-startup.ts
+++ b/scripts/check-production-db-startup.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env tsx
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+import { computeDatabaseUrl, createDrizzleClient } from '@kilocode/db';
+
+function loadEnvFile(path: string): void {
+  if (!existsSync(path)) return;
+  process.loadEnvFile(path);
+}
+
+async function main(): Promise<void> {
+  loadEnvFile(resolve(process.cwd(), '.env.local'));
+  loadEnvFile(resolve(process.cwd(), '.env'));
+
+  const { pool } = createDrizzleClient({
+    connectionString: computeDatabaseUrl(),
+    poolConfig: {
+      max: 1,
+      connectionTimeoutMillis: 10_000,
+    },
+  });
+
+  try {
+    await pool.query('SELECT 1');
+    console.log('Production database startup smoke check passed.');
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch(error => {
+  console.error('Production database startup smoke check failed.');
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
Production deploy now verifies the application DB startup path before migrations or KiloClaw rollout proceed.

### Why this change is needed
A production database client regression can pass local direct-Postgres integration tests while failing against the production connection path before queries run. Catching that only after deploy leaves migrations and dependent rollouts exposed to protocol-level startup incompatibilities.

### How this is addressed
- Add a dedicated production DB startup job that pulls production Vercel env and runs a real `SELECT 1` through the shared DB client path.
- Make migrations wait for that startup gate.
- Make KiloClaw production deploy wait for that startup gate as well.
- Fail fast with explicit smoke-check output while always closing the temporary pool.

## Human Verification
<details>
<summary>Completed in-session verification</summary>

- Ran the startup smoke script against healthy local Docker Postgres; it passed.
- Ran the startup smoke script against `127.0.0.1:1`; it failed nonzero with connection refusal.
- Validated workflow dependency wiring so both `run-migrations` and `deploy-kiloclaw` depend on the new gate.

</details>

## Reviewer Notes
### Human Reviewer Flags
- This gate covers the production Vercel DB connection path pulled from deploy env.
- It does not validate Cloudflare Worker Hyperdrive bindings; that would require a separate Worker-side canary.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Smoke script uses `createDrizzleClient(...)`, matching the shared `pg.Pool` startup path that caused the incident class.
- Connection timeout is capped at 10 seconds and pool cleanup runs in `finally`.
- Workflow keeps migration env pull separate because GitHub job state does not carry across jobs.

</details>