### PR TITLE
fix(billing): normalize renewal queue timestamps

### DIFF
--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -654,6 +654,47 @@ describe('credit renewal fanout queue processing', () => {
     });
   });
 
+  it('normalizes Postgres credit-renewal timestamps before queue fanout', async () => {
+    const first = creditRenewalRow({
+      id: '11111111-1111-4111-8111-111111111111',
+      credit_renewal_at: '2026-04-29 01:16:12.945+00',
+    });
+    const second = creditRenewalRow({
+      id: '33333333-3333-4333-8333-333333333333',
+      credit_renewal_at: '2026-04-30 01:16:12.945+00',
+    });
+    const { db } = createMockDb([[first, second]]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const { env, lifecycleSend } = createEnvWithQueueMocks(vi.fn());
+
+    await processCreditRenewalDiscovery(
+      env,
+      {
+        kind: 'credit_renewal_discovery',
+        runId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        sweep: 'credit_renewal_discovery',
+        cutoffTime: '2026-05-01T00:00:00.000Z',
+        pageBudget: 1,
+      },
+      1
+    );
+
+    expect(lifecycleSend).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        kind: 'credit_renewal_item',
+        renewalBoundary: '2026-04-29T01:16:12.945Z',
+      })
+    );
+    expect(lifecycleSend).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        kind: 'credit_renewal_discovery_continuation',
+        cursorRenewalBoundary: '2026-04-29T01:16:12.945Z',
+      })
+    );
+  });
+
   it('logs discovery cursor, page, and backlog diagnostics without user PII', async () => {
     const first = creditRenewalRow({
       id: '11111111-1111-4111-8111-111111111111',

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1924,6 +1924,14 @@ export async function runCreditRenewalSweep(
 const CREDIT_RENEWAL_DISCOVERY_DEFAULT_PAGE_BUDGET = 50;
 const CREDIT_RENEWAL_DISCOVERY_DEFAULT_WALL_CLOCK_BUDGET_MS = 25_000;
 
+function serializeBillingQueueTimestamp(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Cannot serialize invalid billing queue timestamp');
+  }
+  return date.toISOString();
+}
+
 function creditRenewalEligibilityFilter(nowIso: string) {
   return and(
     eq(kiloclaw_subscriptions.payment_source, 'credits'),
@@ -2075,7 +2083,7 @@ export async function processCreditRenewalDiscovery(
           sweep: 'credit_renewal_item',
           subscriptionId: row.id,
           userId: row.user_id,
-          renewalBoundary: row.credit_renewal_at,
+          renewalBoundary: serializeBillingQueueTimestamp(row.credit_renewal_at),
           discoveredAt,
           diagnostics: {
             instanceId: row.instance_id,
@@ -2088,14 +2096,18 @@ export async function processCreditRenewalDiscovery(
       }
 
       const shouldContinue = rows.length > pageBudget;
-      if (shouldContinue && lastEmitted?.credit_renewal_at) {
+      const nextCursorRenewalBoundary =
+        shouldContinue && lastEmitted?.credit_renewal_at
+          ? serializeBillingQueueTimestamp(lastEmitted.credit_renewal_at)
+          : undefined;
+      if (nextCursorRenewalBoundary && lastEmitted) {
         await env.LIFECYCLE_QUEUE.send({
           kind: 'credit_renewal_discovery_continuation',
           runId: message.runId,
           sweep: 'credit_renewal_discovery',
           cutoffTime,
           cursorSubscriptionId: lastEmitted.id,
-          cursorRenewalBoundary: lastEmitted.credit_renewal_at,
+          cursorRenewalBoundary: nextCursorRenewalBoundary,
           pageBudget: message.pageBudget,
           wallClockBudgetMs: message.wallClockBudgetMs,
         });
@@ -2111,9 +2123,9 @@ export async function processCreditRenewalDiscovery(
         fetchedCount: rows.length,
         enqueuedCount: emitted,
         discoveryBacklogLikely: shouldContinue,
-        continuationEnqueued: shouldContinue && lastEmitted?.credit_renewal_at !== undefined,
+        continuationEnqueued: nextCursorRenewalBoundary !== undefined,
         nextCursorSubscriptionId: lastEmitted?.id,
-        nextCursorRenewalBoundary: lastEmitted?.credit_renewal_at ?? undefined,
+        nextCursorRenewalBoundary,
       });
 
       return summary;


### PR DESCRIPTION
## Summary
- Normalize DB-derived credit-renewal boundaries to strict UTC ISO queue payloads before billing fanout enqueue.
- Prevent production queue schema discards for `renewalBoundary` and `cursorRenewalBoundary` while preserving existing validator, ack, and retry semantics.
- Cover realistic Postgres/Drizzle timestamp text with regression assertions for item and continuation payloads.

## Verification
Confirmed issue by checking Axiom logs.

## Visual Changes
N/A

## Reviewer Notes
- Root cause was queue payload serialization, not downstream-call failure: Drizzle string timestamps arrived as Postgres text such as `2026-04-29 01:16:12.945+00`, while queue schemas require strict ISO datetimes.
- After deployment, positive signal is zero `invalid_message_discarded` logs for `renewalBoundary` and `cursorRenewalBoundary` in next hourly lifecycle run.