### PR TITLE
fix(mobile): ask for system tracking permission on first boot

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -31,6 +31,7 @@ import { subscribeToConsentChanges } from '@/lib/consent';
 import { useAppsFlyerConsentGate } from '@/lib/hooks/use-appsflyer-consent-gate';
 import { useForceUpdate } from '@/lib/hooks/use-force-update';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
+import { useTrackingPermissionPrompt } from '@/lib/hooks/use-tracking-permission-prompt';
 import {
   checkInitialNotification,
   getPendingNotificationLink,
@@ -155,6 +156,7 @@ function RootLayoutNav() {
     return unsubscribe;
   }, [token, userId]);
 
+  useTrackingPermissionPrompt(!isLoading);
   useAppsFlyerConsentGate({ hasToken: token != null, consentChecked, needsConsent });
 
   useEffect(() => {

--- a/apps/mobile/src/lib/hooks/use-appsflyer-consent-gate.ts
+++ b/apps/mobile/src/lib/hooks/use-appsflyer-consent-gate.ts
@@ -1,6 +1,4 @@
-import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
 import { useEffect } from 'react';
-import { Platform } from 'react-native';
 
 import { shouldStartAppsFlyer } from '@/lib/appsflyer-consent';
 import { initAppsFlyer } from '@/lib/appsflyer';
@@ -21,13 +19,6 @@ export function useAppsFlyerConsentGate({
       return;
     }
 
-    async function startAppsFlyer() {
-      if (Platform.OS === 'ios') {
-        await requestTrackingPermissionsAsync();
-      }
-      initAppsFlyer();
-    }
-
-    void startAppsFlyer();
+    initAppsFlyer();
   }, [hasToken, consentChecked, needsConsent]);
 }

--- a/apps/mobile/src/lib/hooks/use-tracking-permission-prompt.ts
+++ b/apps/mobile/src/lib/hooks/use-tracking-permission-prompt.ts
@@ -1,0 +1,22 @@
+import * as Sentry from '@sentry/react-native';
+import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+
+export function useTrackingPermissionPrompt(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled || Platform.OS !== 'ios') {
+      return;
+    }
+
+    async function requestPermission() {
+      try {
+        await requestTrackingPermissionsAsync();
+      } catch (error) {
+        Sentry.captureException(error);
+      }
+    }
+
+    void requestPermission();
+  }, [enabled]);
+}


### PR DESCRIPTION
## Summary

Reorders the consent prompts shown to users on first install:

**Before:** sign-in / onboarding → app-level consent → iOS system tracking prompt (ATT)
**After:** iOS system tracking prompt (ATT) → sign-in / onboarding → app-level consent

The ATT modal now fires once the bootstrap is past (fonts loaded, auth check resolved), before the user interacts with the login screen. iOS handles the "show once per install" behaviour natively, so no extra persistence flag is needed.

AppsFlyer init is unchanged — it still waits for sign-in + app-level consent. By the time it runs ATT has already been resolved, so the consent gate no longer needs to call `requestTrackingPermissionsAsync` itself.

## Test plan

- [ ] Fresh install on iOS: launch → ATT modal appears → dismiss → land on login → sign in → app-level consent screen → accept → app continues, AppsFlyer initializes
- [ ] Relaunch after first boot on iOS: no ATT modal, app resumes normally
- [ ] Android: no ATT modal (no-op), normal flow
- [ ] `cd apps/mobile && pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused`
- [ ] `cd apps/mobile && pnpm vitest run`