### PR TITLE
fix(billing): normalize side-effect timestamp payloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ permissions:
 
 env:
   VERCEL_VERSION: '53.3.1'
+  # pnpm dlx vercel can hit ERR_PNPM_MISSING_TIME with default resolution mode.
+  PNPM_CONFIG_RESOLUTION_MODE: 'highest'
 
 # Optional repo/org variables for runner migration:
 # - RUNNER_DEFAULT_LABEL=blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,6 +13,8 @@ concurrency:
 
 env:
   VERCEL_VERSION: '53.3.1'
+  # pnpm dlx vercel can hit ERR_PNPM_MISSING_TIME with default resolution mode.
+  PNPM_CONFIG_RESOLUTION_MODE: 'highest'
 
 jobs:
   check-production-db-startup:
@@ -48,7 +50,6 @@ jobs:
   run-migrations:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 15
-    needs: check-production-db-startup
     environment: production
 
     steps:
@@ -79,7 +80,7 @@ jobs:
   deploy-app:
     runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
     timeout-minutes: 30
-    needs: run-migrations
+    needs: [check-production-db-startup, run-migrations]
     environment: production
 
     env:
@@ -130,7 +131,7 @@ jobs:
   deploy-global-app:
     runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
     timeout-minutes: 30
-    needs: run-migrations
+    needs: [check-production-db-startup, run-migrations]
     environment: production
 
     env:
@@ -179,7 +180,7 @@ jobs:
         run: pnpm dlx vercel@${{ env.VERCEL_VERSION }} deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
   deploy-kiloclaw:
-    needs: check-production-db-startup
+    needs: [check-production-db-startup, run-migrations]
     permissions:
       contents: read
       packages: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,12 @@ Before making or reviewing UI changes under `apps/web` — components, routes/pa
 - When the linter flags an unused variable, investigate the root cause — do not blindly prefix with `_`.
 - Use existing dependencies before implementing custom solutions. Check `package.json` for what's available.
 
+## Timestamp Serialization
+
+- Drizzle/Postgres `timestamp({ withTimezone: true, mode: 'string' })` rows may surface timestamp text like `2026-04-29 01:16:12.945+00`, which strict ISO validators such as `z.string().datetime()` reject.
+- Before putting DB-backed timestamp strings into HTTP bodies, queue messages, or other strict JSON contracts, normalize them to UTC ISO with an existing domain serializer or `new Date(value).toISOString()`. Do not forward raw DB timestamp text across contract boundaries.
+- Keep strict validators unless the receiving contract intentionally accepts a broader format. Add regression fixtures using production-shape Postgres timestamp text when fixing or extending these paths.
+
 ## Workers & Durable Objects
 
 - Do not cache database clients, pools, or other transport-owning/request-context-bound SDK objects in module scope for Cloudflare Workers or Durable Objects. Workers reuse isolates across requests, Durable Object classes in the same Worker can share module memory across object instances, and stale module-scope I/O state can cause cross-context runtime failures.

--- a/apps/web/src/app/api/internal/kiloclaw/billing-side-effects/route.test.ts
+++ b/apps/web/src/app/api/internal/kiloclaw/billing-side-effects/route.test.ts
@@ -203,6 +203,73 @@ describe('POST /api/internal/kiloclaw/billing-side-effects', () => {
     );
   });
 
+  it('rejects Postgres timestamp text in paid conversion event dates', async () => {
+    const response = await POST(
+      createRequest({
+        action: 'process_paid_conversion',
+        input: {
+          userId: 'user-123',
+          dedupeKey: 'affiliate:impact:sale:period-123',
+          eventDateIso: '2026-04-29 01:16:12.945+00',
+          orderId: 'period-123',
+          amount: 9,
+          currencyCode: 'usd',
+          itemCategory: 'kiloclaw-standard',
+          itemName: 'KiloClaw Standard Plan',
+          itemSku: 'price_standard',
+        },
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid body' });
+    expect(mockProcessPersonalKiloClawPaidConversion).not.toHaveBeenCalled();
+  });
+
+  it('rejects Postgres timestamp text in auto top-up user update timestamps', async () => {
+    const response = await POST(
+      createRequest({
+        action: 'trigger_user_auto_top_up',
+        input: {
+          user: {
+            id: 'user-123',
+            total_microdollars_acquired: 100,
+            microdollars_used: 50,
+            next_credit_expiration_at: null,
+            updated_at: '2026-04-29 01:16:12.945+00',
+            auto_top_up_enabled: true,
+          },
+        },
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid body' });
+    expect(mockMaybePerformAutoTopUp).not.toHaveBeenCalled();
+  });
+
+  it('rejects Postgres timestamp text in auto top-up credit expiration timestamps', async () => {
+    const response = await POST(
+      createRequest({
+        action: 'trigger_user_auto_top_up',
+        input: {
+          user: {
+            id: 'user-123',
+            total_microdollars_acquired: 100,
+            microdollars_used: 50,
+            next_credit_expiration_at: '2026-04-29 01:16:12.945+00',
+            updated_at: '2026-04-07T00:00:00.000Z',
+            auto_top_up_enabled: true,
+          },
+        },
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid body' });
+    expect(mockMaybePerformAutoTopUp).not.toHaveBeenCalled();
+  });
+
   it('forwards sale affiliate enqueue requests with monetized fields', async () => {
     const response = await POST(
       createRequest({

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -3806,6 +3806,138 @@ describe('credit renewal sweep affiliate tracking', () => {
     expect(typeof autoResumeUpdate?.auto_resume_retry_after).toBe('string');
   });
 
+  it('normalizes Postgres renewal timestamps before paid-conversion side effects', async () => {
+    const postgresRenewalAt = '2026-04-29 01:16:12.945+00';
+    const renewalAtIso = '2026-04-29T01:16:12.945Z';
+    const { db } = createMockDb([
+      [
+        creditRenewalRow({
+          id: 'sub-1',
+          instance_id: 'instance-1',
+          instance_row_id: 'instance-1',
+          credit_renewal_at: postgresRenewalAt,
+          current_period_end: postgresRenewalAt,
+          total_microdollars_acquired: 50_000_000,
+          kilo_pass_threshold: null,
+        }),
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+
+    const fetch = vi.fn(async (_request: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(typeof init?.body === 'string' ? init.body : '{}') as {
+        action: string;
+        input: Record<string, unknown>;
+      };
+
+      switch (body.action) {
+        case 'project_pending_kilo_pass_bonus':
+          return Response.json({ projectedBonusMicrodollars: 0 });
+        case 'issue_kilo_pass_bonus_from_usage_threshold':
+          return Response.json({ ok: true });
+        case 'process_paid_conversion':
+          return Response.json({
+            affiliateSaleEnqueued: false,
+            winningTouchType: 'none',
+            conversionId: null,
+            disqualificationReason: null,
+          });
+        default:
+          throw new Error(`Unexpected side effect action: ${body.action}`);
+      }
+    });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetch);
+
+    const summary = await processCreditRenewalItem(
+      createEnv(vi.fn()),
+      creditRenewalItemMessage({
+        runId: 'acacacac-acac-4cac-8cac-acacacacacac',
+        renewalBoundary: renewalAtIso,
+      }),
+      1
+    );
+
+    expect(summary.credit_renewals).toBe(1);
+    const saleCall = fetch.mock.calls
+      .map(
+        ([, init]) =>
+          JSON.parse(typeof init?.body === 'string' ? init.body : '{}') as {
+            action: string;
+            input: Record<string, unknown>;
+          }
+      )
+      .find(call => call.action === 'process_paid_conversion');
+
+    expect(saleCall?.input.eventDateIso).toBe(renewalAtIso);
+  });
+
+  it('normalizes Postgres user timestamps before auto top-up side effects', async () => {
+    const renewalAt = '2026-04-09T10:00:00.000Z';
+    const beforeRow = creditRenewalRow({
+      id: 'sub-1',
+      credit_renewal_at: renewalAt,
+      current_period_end: renewalAt,
+      total_microdollars_acquired: 1_000_000,
+      microdollars_used: 900_000,
+      auto_top_up_enabled: true,
+      kilo_pass_threshold: null,
+      next_credit_expiration_at: '2026-04-29 01:16:12.945+00',
+      user_updated_at: '2026-04-09 09:00:00+00',
+    });
+    const afterRow = {
+      ...beforeRow,
+      auto_top_up_triggered_for_period: renewalAt,
+    };
+    const { db } = createMockDb([[beforeRow]], {
+      updateReturningRows: [[afterRow]],
+    });
+    mockGetWorkerDb.mockReturnValue(db);
+
+    const fetch = vi.fn(async (_request: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(typeof init?.body === 'string' ? init.body : '{}') as {
+        action: string;
+        input: Record<string, unknown>;
+      };
+
+      switch (body.action) {
+        case 'project_pending_kilo_pass_bonus':
+          return Response.json({ projectedBonusMicrodollars: 0 });
+        case 'trigger_user_auto_top_up':
+          return Response.json({ ok: true });
+        default:
+          throw new Error(`Unexpected side effect action: ${body.action}`);
+      }
+    });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetch);
+
+    const summary = await processCreditRenewalItem(
+      createEnv(vi.fn()),
+      creditRenewalItemMessage({
+        runId: 'bcbcbcbc-bcbc-4cbc-8cbc-bcbcbcbcbcbc',
+        renewalBoundary: renewalAt,
+      }),
+      1
+    );
+
+    expect(summary.credit_renewals_auto_top_up).toBe(1);
+    const autoTopUpCall = fetch.mock.calls
+      .map(
+        ([, init]) =>
+          JSON.parse(typeof init?.body === 'string' ? init.body : '{}') as {
+            action: string;
+            input: { user?: Record<string, unknown> };
+          }
+      )
+      .find(call => call.action === 'trigger_user_auto_top_up');
+
+    expect(autoTopUpCall?.input.user).toEqual(
+      expect.objectContaining({
+        next_credit_expiration_at: '2026-04-29T01:16:12.945Z',
+        updated_at: '2026-04-09T09:00:00.000Z',
+      })
+    );
+  });
+
   it('enqueues a sale affiliate event for pure-credit renewals', async () => {
     const renewalAt = '2026-04-09T10:00:00.000Z';
     const { db, txInserts, txUpdates } = createMockDb([

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1669,7 +1669,7 @@ async function processCreditRenewalRow(
     await processPaidConversionBestEffort(env, context, {
       userId: outcome.userId,
       dedupeKey: `affiliate:impact:sale:${outcome.deductionCategory}`,
-      eventDateIso: outcome.renewalAt,
+      eventDateIso: serializeBillingTimestamp(outcome.renewalAt),
       orderId: outcome.deductionCategory,
       amount: outcome.costMicrodollars / 1_000_000,
       currencyCode: 'usd',
@@ -1734,7 +1734,7 @@ async function processCreditRenewalRow(
     await processPaidConversionBestEffort(env, context, {
       userId: outcome.userId,
       dedupeKey: `affiliate:impact:sale:${outcome.deductionCategory}`,
-      eventDateIso: outcome.renewalAt,
+      eventDateIso: serializeBillingTimestamp(outcome.renewalAt),
       orderId: outcome.deductionCategory,
       amount: outcome.costMicrodollars / 1_000_000,
       currencyCode: 'usd',
@@ -1784,8 +1784,10 @@ async function processCreditRenewalRow(
         total_microdollars_acquired: outcome.row.total_microdollars_acquired,
         microdollars_used: outcome.row.microdollars_used,
         auto_top_up_enabled: outcome.row.auto_top_up_enabled,
-        next_credit_expiration_at: outcome.row.next_credit_expiration_at,
-        updated_at: outcome.row.user_updated_at,
+        next_credit_expiration_at: outcome.row.next_credit_expiration_at
+          ? serializeBillingTimestamp(outcome.row.next_credit_expiration_at)
+          : null,
+        updated_at: serializeBillingTimestamp(outcome.row.user_updated_at),
       });
     } catch (error) {
       log('error', 'Auto top-up trigger failed during credit renewal', {
@@ -1924,10 +1926,10 @@ export async function runCreditRenewalSweep(
 const CREDIT_RENEWAL_DISCOVERY_DEFAULT_PAGE_BUDGET = 50;
 const CREDIT_RENEWAL_DISCOVERY_DEFAULT_WALL_CLOCK_BUDGET_MS = 25_000;
 
-function serializeBillingQueueTimestamp(timestamp: string): string {
+function serializeBillingTimestamp(timestamp: string): string {
   const date = new Date(timestamp);
   if (Number.isNaN(date.getTime())) {
-    throw new Error('Cannot serialize invalid billing queue timestamp');
+    throw new Error('Cannot serialize invalid billing timestamp');
   }
   return date.toISOString();
 }
@@ -2083,7 +2085,7 @@ export async function processCreditRenewalDiscovery(
           sweep: 'credit_renewal_item',
           subscriptionId: row.id,
           userId: row.user_id,
-          renewalBoundary: serializeBillingQueueTimestamp(row.credit_renewal_at),
+          renewalBoundary: serializeBillingTimestamp(row.credit_renewal_at),
           discoveredAt,
           diagnostics: {
             instanceId: row.instance_id,
@@ -2098,7 +2100,7 @@ export async function processCreditRenewalDiscovery(
       const shouldContinue = rows.length > pageBudget;
       const nextCursorRenewalBoundary =
         shouldContinue && lastEmitted?.credit_renewal_at
-          ? serializeBillingQueueTimestamp(lastEmitted.credit_renewal_at)
+          ? serializeBillingTimestamp(lastEmitted.credit_renewal_at)
           : undefined;
       if (nextCursorRenewalBoundary && lastEmitted) {
         await env.LIFECYCLE_QUEUE.send({


### PR DESCRIPTION
## Summary
Normalize KiloClaw billing side-effect timestamps before strict API validation, and harden Vercel workflow setup used by CI/deploy jobs.

### Why this change is needed
Credit-renewal side-effect requests can carry Drizzle/Postgres timestamp text such as `2026-04-29 01:16:12.945+00`. The internal side-effects route intentionally requires strict ISO datetime strings, so those payloads were rejected with HTTP 400 `Invalid body` during paid conversion and auto top-up flows.

The branch also carries workflow hardening for `pnpm dlx vercel` resolution behavior and production deploy ordering already present in local deploy workflow edits.

### How this is addressed
- Normalize DB-backed renewal and user timestamps to UTC ISO before billing side-effects POST bodies are built.
- Keep strict route-side datetime validators unchanged and add production-shape regression coverage for the exact rejected fields.
- Record agent guidance for serializing DB-backed timestamp strings at strict JSON boundaries.
- Apply highest pnpm resolution mode to Vercel CI usage and keep production deploy workflow prerequisites explicit.

## Human Verification
- `pnpm --filter web test -- --runInBand "src/app/api/internal/kiloclaw/billing-side-effects/route.test.ts"`
- `pnpm --filter kiloclaw-billing test -- "src/lifecycle.test.ts"`

## Reviewer Notes
### Human Reviewer Flags
- Side-effects contract remains strict; normalization happens at worker egress rather than widening accepted API input.
- PR includes CI/deploy workflow hardening alongside billing regression fix because both were present in current branch scope.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Route regression tests prove Postgres-shaped timestamps fail strict validation before worker normalization.
- Lifecycle regression tests prove paid-conversion and auto-top-up payloads emit UTC ISO strings after normalization.
- Existing queue timestamp normalization was generalized instead of creating separate one-off serializers.

</details>