### PR TITLE
fix(ci): bump pnpm to 11.1.2 to fix sporadic ERR_PNPM_MISSING_TIME

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ permissions:
 
 env:
   VERCEL_VERSION: '53.3.1'
-  # pnpm dlx vercel can hit ERR_PNPM_MISSING_TIME with default resolution mode.
-  PNPM_CONFIG_RESOLUTION_MODE: 'highest'
 
 # Optional repo/org variables for runner migration:
 # - RUNNER_DEFAULT_LABEL=blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,8 +13,6 @@ concurrency:
 
 env:
   VERCEL_VERSION: '53.3.1'
-  # pnpm dlx vercel can hit ERR_PNPM_MISSING_TIME with default resolution mode.
-  PNPM_CONFIG_RESOLUTION_MODE: 'highest'
 
 jobs:
   check-production-db-startup:

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -6,7 +6,7 @@
   "build": {
     "base": {
       "node": "24.15.0",
-      "pnpm": "11.1.1"
+      "pnpm": "11.1.2"
     },
     "development": {
       "extends": "base",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dev:discord-gateway-cron": "tsx dev/discord-gateway-cron.ts",
     "dev:kiloclaw-fly-instances": "tsx services/kiloclaw/scripts/dev-fly-instances.ts"
   },
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.1.2",
   "devDependencies": {
     "@typescript/native-preview": "catalog:",
     "husky": "9.1.7",

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -190,7 +190,7 @@ RUN apt-get update \
     && curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz -o /tmp/node.tar.xz \
     && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
     && rm /tmp/node.tar.xz \
-    && npm install --global pnpm@11.1.1 \
+    && npm install --global pnpm@11.1.2 \
     && curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.13" \
     && rm -rf /var/lib/apt/lists/*
 ENV PATH="/root/.bun/bin:$PATH"


### PR DESCRIPTION
## Summary
Bump pnpm from 11.1.1 to 11.1.2 to eliminate sporadic `ERR_PNPM_MISSING_TIME` failures during `pnpm dlx vercel@…` in CI.

### Why this change is needed
Production deploys and CI jobs intermittently failed on:

```
[ERR_PNPM_MISSING_TIME] The metadata of undici is missing the "time" field
This error happened while installing the dependencies of vercel@53.3.1
  at @vercel/node@5.7.16
```

Setting `PNPM_CONFIG_RESOLUTION_MODE=highest` (already in our workflows) did not help, because the throw happens in pnpm's metadata-fetch fast path *before* version selection mode is consulted.

pnpm 11.1.2 fixes the actual root cause. Per the [11.1.2 release notes](https://github.com/pnpm/pnpm/releases/tag/v11.1.2):

> Fix `minimumReleaseAge` handling for cached abbreviated metadata. The version-spec cache fast path no longer rethrows `ERR_PNPM_MISSING_TIME` under `strictPublishedByCheck`; it now falls through to the registry-fetch path… When the registry returns 304 Not Modified for a package whose cached metadata is abbreviated (no per-version `time`), pnpm now re-fetches with `fullMetadata: true`…

That matches our symptom exactly: a transitive dep (`undici`) hits a stale-but-abbreviated cached packument and the install aborts instead of falling through to a full fetch.

### How this is addressed
- Bump `packageManager` in root `package.json` to `pnpm@11.1.2`. `pnpm/action-setup@v4` reads this field, so all 26 workflow usages pick up the new version automatically.
- Sync the two other places where the version is hard-pinned: `services/kiloclaw/Dockerfile` and `apps/mobile/eas.json`.
- Remove the now-obsolete `PNPM_CONFIG_RESOLUTION_MODE: 'highest'` env var (and its explanatory comment) from `ci.yml` and `deploy-production.yml`. The workaround never actually fixed this failure mode and keeping it invites cargo-cult propagation.

## Human Verification
- Confirmed against pnpm 11.1.2 release notes that the patch targets the exact `ERR_PNPM_MISSING_TIME` path triggered by abbreviated cached metadata for transitive deps.
- Verified all `pnpm@11.1.1` pins across the repo are bumped (no stragglers in `*.json`, `*.yml`, Dockerfiles, etc.).
- Verified `PNPM_CONFIG_RESOLUTION_MODE` is no longer referenced anywhere in the repo after removal.

## Reviewer Notes
### Human Reviewer Flags
- The fix relies on `pnpm/action-setup@v4` resolving the version from `package.json`'s `packageManager` field rather than per-workflow `version:` inputs. This is already how the repo is configured — no workflow currently passes `version:` to the action — but worth a glance to confirm that's still the desired pattern.
- Removing `PNPM_CONFIG_RESOLUTION_MODE=highest` is intentional. If the failure recurs after the bump we want a real signal, not a silent mask. Happy to keep it as a belt-and-braces if you'd prefer; say the word.
