### PR TITLE
Remove ring from auto free

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -40,7 +40,6 @@ export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 export const autoFreeModels = [
   'nvidia/nemotron-3-super-120b-a12b:free',
   'poolside/laguna-m.1:free',
-  'inclusionai/ring-2.6-1t:free',
   stepfun_35_flash_free_model.status === 'public' ? stepfun_35_flash_free_model.public_id : null,
 ].filter(m => m !== null);
 


### PR DESCRIPTION
Ring-2.6-1T is no longer available as a free model

Mirrors #3111 (Removes `ling-2.6-1t:free`).
