### PR TITLE
fix(kiloclaw): filter trial expiry sweep candidates

### DIFF
--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as DbModule from '@kilocode/db';
 
 const { mockGetWorkerDb, mockGetMissingSnowflakeConfig, mockQueryKiloclawActiveUserIds } =
   vi.hoisted(() => ({
@@ -1633,7 +1634,7 @@ describe('trial expiry sweep', () => {
       throw new Error('expected trial expiry candidate query predicate');
     }
 
-    const actualDbModule = await vi.importActual<typeof import('@kilocode/db')>('@kilocode/db');
+    const actualDbModule = await vi.importActual<typeof DbModule>('@kilocode/db');
     const trialExpirySql = actualDbModule
       .getWorkerDb('postgres://unused:unused@localhost:0/unused')
       .select()

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -1613,6 +1613,45 @@ describe('trial expiry sweep', () => {
     expect(updates).toContainEqual({ inactive_trial_stopped_at: null });
   });
 
+  it('filters detached, missing, destroyed, and organization-managed trial rows in SQL', async () => {
+    const { db, updates, inserts, selectBuilders } = createMockDb([[]]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn();
+
+    const summary = await runSweep(
+      createEnv(fetch),
+      {
+        runId: '23232323-2323-4232-8232-232323232320',
+        sweep: 'trial_expiry',
+      },
+      1
+    );
+
+    const trialExpiryWhere = selectBuilders[0]?.where.mock.calls[0]?.[0];
+    expect(trialExpiryWhere).toBeDefined();
+    if (!trialExpiryWhere) {
+      throw new Error('expected trial expiry candidate query predicate');
+    }
+
+    const actualDbModule = await vi.importActual<typeof import('@kilocode/db')>('@kilocode/db');
+    const trialExpirySql = actualDbModule
+      .getWorkerDb('postgres://unused:unused@localhost:0/unused')
+      .select()
+      .from(actualDbModule.kiloclaw_subscriptions)
+      .where(trialExpiryWhere)
+      .toSQL().sql;
+
+    expect(trialExpirySql).toMatch(/"kiloclaw_subscriptions"\."instance_id"\s+is not null/i);
+    expect(trialExpirySql).toMatch(/"kiloclaw_instances"\."sandbox_id"\s+is not null/i);
+    expect(trialExpirySql).toMatch(/"kiloclaw_instances"\."destroyed_at"\s+is null/i);
+    expect(trialExpirySql).toMatch(/"kiloclaw_instances"\."organization_id"\s+is null/i);
+    expect(summary.sweep1_trial_expiry).toBe(0);
+    expect(summary.errors).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(updates).toEqual([]);
+    expect(inserts).toEqual([]);
+  });
+
   it('does not expire a legacy trial before its recorded trial end timestamp', async () => {
     const instanceId = '22222222-2222-4222-8222-222222222222';
     const { db, updates, inserts } = createMockDb([

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -2386,7 +2386,11 @@ async function runTrialExpirySweep(
         eq(kiloclaw_subscriptions.status, 'trialing'),
         currentSubscriptionRowFilter(),
         lt(kiloclaw_subscriptions.trial_ends_at, now),
-        isNull(kiloclaw_subscriptions.suspended_at)
+        isNull(kiloclaw_subscriptions.suspended_at),
+        isNotNull(kiloclaw_subscriptions.instance_id),
+        isNotNull(kiloclaw_instances.sandbox_id),
+        isNull(kiloclaw_instances.destroyed_at),
+        isNull(kiloclaw_instances.organization_id)
       )
     );
 


### PR DESCRIPTION
## Summary
Filters `trial_expiry` candidate discovery so the worker skips rows already known to be ineligible before JS iteration.

### Why this change is needed
The lifecycle sweep has been loading detached, missing-instance, destroyed, and organization-managed trial rows only to discard them later in JS. Filtering those rows in SQL reduces wasted loop work, skip-log volume, and timeout pressure without changing intended processing for eligible personal trials.

### How this is addressed
- Adds SQL predicates requiring a subscription instance id, joined sandbox id, a non-destroyed instance, and no organization owner.
- Keeps the existing defensive JS skip branches for runtime inconsistencies that still reach the sweep loop.
- Adds regression coverage that inspects the generated trial-expiry predicate shape.

## Human Verification
- Reviewed `.specs/kiloclaw-billing-lifecycle.md`, `.specs/kiloclaw-billing.md`, and `.specs/kiloclaw-datamodel.md` to preserve expected skip semantics.
- `pnpm --filter kiloclaw-billing test -- src/lifecycle.test.ts` — passed; billing package run completed with 118 tests green.
- Scoped local review across security, logic, types, data, resources, style, and React quality reported no actionable findings.

## Reviewer Notes
### Human Reviewer Flags
No notable items for human review beyond what the summary covers.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Defensive skip branches remain intentionally intact; SQL narrows discovery, JS still protects against unexpected row shapes.
- Test coverage targets Drizzle SQL predicate generation rather than duplicating impossible mock-row postconditions after query filtering.

</details>
