### PR TITLE
chore(mobile): add preview build profile for ad-hoc distribution

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -18,6 +18,14 @@
       "extends": "base",
       "autoIncrement": true,
       "credentialsSource": "remote"
+    },
+    "preview": {
+      "extends": "base",
+      "distribution": "internal",
+      "credentialsSource": "remote",
+      "ios": {
+        "simulator": false
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
## Summary
- Adds a `preview` EAS build profile with `distribution: "internal"` so we can produce ad-hoc-signed `.ipa` builds that can be sideloaded onto registered devices (Xcode drag-and-drop, install URL, etc.) without going through TestFlight.

## Test plan
- [ ] `eas device:create` to register a test device
- [ ] `eas build --profile preview --platform ios`
- [ ] Verify the resulting `.ipa` installs via the EAS install URL in Safari on the device
- [ ] Verify the `.ipa` also installs via Xcode → Devices and Simulators drag-and-drop