### PR TITLE
fix(kiloclaw): paginate trial expiry lifecycle

### DIFF
--- a/services/kiloclaw-billing/src/index.test.ts
+++ b/services/kiloclaw-billing/src/index.test.ts
@@ -16,6 +16,7 @@ vi.mock('./lifecycle.js', () => ({
   processTrialInactivityStopCandidate: vi.fn(),
   processCreditRenewalDiscovery: vi.fn(),
   processCreditRenewalItem: vi.fn(),
+  processTrialExpiryPage: vi.fn(),
   recordCreditRenewalTerminalFailure: vi.fn(),
 }));
 
@@ -28,6 +29,7 @@ import { bootstrapProvisionSubscription } from './bootstrap.js';
 import {
   processCreditRenewalDiscovery,
   processCreditRenewalItem,
+  processTrialExpiryPage,
   processTrialInactivityStopCandidate,
   recordCreditRenewalTerminalFailure,
   runSweep,
@@ -132,6 +134,10 @@ describe('kiloclaw billing worker handler', () => {
     vi.mocked(processTrialInactivityStopCandidate).mockResolvedValue(emptySummary);
     vi.mocked(processCreditRenewalDiscovery).mockResolvedValue(emptySummary);
     vi.mocked(processCreditRenewalItem).mockResolvedValue(emptySummary);
+    vi.mocked(processTrialExpiryPage).mockResolvedValue({
+      summary: emptySummary,
+      continuationEnqueued: false,
+    });
     vi.mocked(recordCreditRenewalTerminalFailure).mockResolvedValue(undefined);
   });
 
@@ -324,6 +330,111 @@ describe('kiloclaw billing worker handler', () => {
     );
   });
 
+  it('starts paginated trial-expiry processing without advancing to subscription expiry', async () => {
+    const { env, lifecycleSend } = createEnv();
+    const runId = '21212121-2121-4212-8212-212121212121';
+    const message = {
+      body: { kind: 'lifecycle', runId, sweep: 'trial_expiry' },
+      attempts: 1,
+      ack: vi.fn(),
+      retry: vi.fn(),
+    };
+
+    await handler.queue?.(createBatch(message), env, {} as ExecutionContext);
+
+    expect(runSweep).not.toHaveBeenCalled();
+    expect(processTrialExpiryPage).not.toHaveBeenCalled();
+    expect(lifecycleSend).toHaveBeenCalledTimes(1);
+    expect(lifecycleSend).toHaveBeenCalledWith({
+      kind: 'trial_expiry_page',
+      runId,
+      sweep: 'trial_expiry',
+    });
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  it('enqueues subscription expiry only after a final trial-expiry page completes', async () => {
+    const { env, lifecycleSend } = createEnv();
+    const runId = '31313131-3131-4313-8313-313131313131';
+    const message = {
+      body: {
+        kind: 'trial_expiry_continuation',
+        runId,
+        sweep: 'trial_expiry',
+        cutoffTime: '2026-04-20T00:00:00.000Z',
+        cursorSubscriptionId: '11111111-1111-4111-8111-111111111111',
+        cursorTrialEndsAt: '2026-04-17T00:00:00.000Z',
+      },
+      attempts: 1,
+      ack: vi.fn(),
+      retry: vi.fn(),
+    };
+
+    await handler.queue?.(createBatch(message), env, {} as ExecutionContext);
+
+    expect(processTrialExpiryPage).toHaveBeenCalledWith(env, message.body, 1);
+    expect(lifecycleSend).toHaveBeenCalledTimes(1);
+    expect(lifecycleSend).toHaveBeenCalledWith({
+      kind: 'lifecycle',
+      runId,
+      sweep: 'subscription_expiry',
+    });
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  it('does not enqueue subscription expiry while trial-expiry continuation remains', async () => {
+    const { env, lifecycleSend } = createEnv();
+    vi.mocked(processTrialExpiryPage).mockResolvedValueOnce({
+      summary: {
+        credit_renewals: 0,
+        credit_renewals_canceled: 0,
+        credit_renewals_past_due: 0,
+        credit_renewals_auto_top_up: 0,
+        credit_renewals_skipped_duplicate: 0,
+        interrupted_auto_resume_requests: 0,
+        trial_inactivity_candidates: 0,
+        trial_inactivity_batches: 0,
+        trial_inactivity_batch_fallbacks: 0,
+        trial_inactivity_stop_messages_enqueued: 0,
+        trial_inactivity_stops: 0,
+        trial_inactivity_dry_run_candidates: 0,
+        trial_warnings: 0,
+        earlybird_warnings: 0,
+        sweep1_trial_expiry: 0,
+        sweep2_subscription_expiry: 0,
+        destruction_warnings: 0,
+        sweep3_instance_destruction: 0,
+        sweep4_past_due_cleanup: 0,
+        sweep5_intro_schedules_repaired: 0,
+        complementary_inference_ended_emails: 0,
+        emails_sent: 0,
+        emails_skipped: 0,
+        errors: 0,
+      },
+      continuationEnqueued: true,
+    });
+    const message = {
+      body: {
+        kind: 'trial_expiry_page',
+        runId: '41414141-4141-4414-8414-414141414141',
+        sweep: 'trial_expiry',
+        pageBudget: 1,
+      },
+      attempts: 1,
+      ack: vi.fn(),
+      retry: vi.fn(),
+    };
+
+    await handler.queue?.(createBatch(message), env, {} as ExecutionContext);
+
+    expect(processTrialExpiryPage).toHaveBeenCalledWith(env, message.body, 1);
+    expect(lifecycleSend).not.toHaveBeenCalled();
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+  });
+
   it('continues hourly lifecycle instance destruction into past-due cleanup', async () => {
     const { env, lifecycleSend } = createEnv();
     const runId = '33333333-3333-4333-8333-333333333333';
@@ -349,7 +460,6 @@ describe('kiloclaw billing worker handler', () => {
     expect(message.ack).toHaveBeenCalledTimes(1);
     expect(message.retry).not.toHaveBeenCalled();
   });
-
   it('retries queue messages when sweep execution throws', async () => {
     const { env } = createEnv();
     vi.mocked(runSweep).mockRejectedValueOnce(new Error('boom'));

--- a/services/kiloclaw-billing/src/index.ts
+++ b/services/kiloclaw-billing/src/index.ts
@@ -18,6 +18,7 @@ import {
 import {
   processCreditRenewalDiscovery,
   processCreditRenewalItem,
+  processTrialExpiryPage,
   processTrialInactivityStopCandidate,
   recordCreditRenewalTerminalFailure,
   runSweep,
@@ -86,6 +87,28 @@ const CreditRenewalDiscoveryContinuationQueueMessageSchema = z.object({
   wallClockBudgetMs: z.number().int().min(1).max(110_000).optional(),
 });
 
+const TrialExpiryPageQueueMessageSchema = z.object({
+  kind: z.literal('trial_expiry_page'),
+  runId: z.string().uuid(),
+  sweep: z.literal('trial_expiry'),
+  cutoffTime: z.string().datetime().optional(),
+  cursorSubscriptionId: z.string().uuid().optional(),
+  cursorTrialEndsAt: z.string().datetime().optional(),
+  pageBudget: z.number().int().min(1).max(1000).optional(),
+  wallClockBudgetMs: z.number().int().min(1).max(110_000).optional(),
+});
+
+const TrialExpiryContinuationQueueMessageSchema = z.object({
+  kind: z.literal('trial_expiry_continuation'),
+  runId: z.string().uuid(),
+  sweep: z.literal('trial_expiry'),
+  cutoffTime: z.string().datetime(),
+  cursorSubscriptionId: z.string().uuid(),
+  cursorTrialEndsAt: z.string().datetime(),
+  pageBudget: z.number().int().min(1).max(1000).optional(),
+  wallClockBudgetMs: z.number().int().min(1).max(110_000).optional(),
+});
+
 const CreditRenewalItemQueueMessageSchema = z.object({
   kind: z.literal('credit_renewal_item'),
   runId: z.string().uuid(),
@@ -121,6 +144,8 @@ const BillingQueueMessageSchema = z.discriminatedUnion('kind', [
   TrialInactivityStopCandidateQueueMessageSchema,
   CreditRenewalDiscoveryQueueMessageSchema,
   CreditRenewalDiscoveryContinuationQueueMessageSchema,
+  TrialExpiryPageQueueMessageSchema,
+  TrialExpiryContinuationQueueMessageSchema,
   CreditRenewalItemQueueMessageSchema,
   CreditRenewalTerminalFailureQueueMessageSchema,
 ]);
@@ -463,6 +488,26 @@ export const handler: ExportedHandler<BillingWorkerEnv, BillingQueueMessage> = {
                 event: 'run_completed',
                 outcome: 'completed',
               });
+            } else if (
+              parsed.data.kind === 'trial_expiry_page' ||
+              parsed.data.kind === 'trial_expiry_continuation'
+            ) {
+              const result = await processTrialExpiryPage(env, parsed.data, message.attempts);
+              if (!result.continuationEnqueued) {
+                const next = nextSweep('trial_expiry');
+                if (next) {
+                  await env.LIFECYCLE_QUEUE.send({
+                    kind: 'lifecycle',
+                    runId: parsed.data.runId,
+                    sweep: next,
+                  });
+                }
+              }
+              log('info', 'Completed trial-expiry page message', {
+                event: 'run_completed',
+                outcome: 'completed',
+                continuationEnqueued: result.continuationEnqueued,
+              });
             } else if (parsed.data.kind === 'credit_renewal_item') {
               await processCreditRenewalItem(env, parsed.data, message.attempts);
               log('info', 'Completed credit-renewal item message', {
@@ -500,6 +545,16 @@ export const handler: ExportedHandler<BillingWorkerEnv, BillingQueueMessage> = {
                 });
               }
               log('info', 'Started credit-renewal fanout discovery', {
+                event: 'run_started',
+                outcome: 'started',
+              });
+            } else if (parsed.data.kind === 'lifecycle' && parsed.data.sweep === 'trial_expiry') {
+              await env.LIFECYCLE_QUEUE.send({
+                kind: 'trial_expiry_page',
+                runId: parsed.data.runId,
+                sweep: 'trial_expiry',
+              });
+              log('info', 'Started trial-expiry paginated processing', {
                 event: 'run_started',
                 outcome: 'started',
               });

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -24,6 +24,7 @@ vi.mock('./snowflake.js', () => ({
 import {
   processCreditRenewalDiscovery,
   processCreditRenewalItem,
+  processTrialExpiryPage,
   processTrialInactivityStopCandidate,
   recordCreditRenewalTerminalFailure,
   runCreditRenewalSweep,
@@ -313,6 +314,20 @@ function creditRenewalRow(overrides: Partial<Record<string, unknown>> = {}) {
     kilo_pass_threshold: 1_000_000_000,
     next_credit_expiration_at: null,
     user_updated_at: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function trialExpiryRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    user_id: 'user-1',
+    instance_id: '22222222-2222-4222-8222-222222222222',
+    sandbox_id: 'ki_22222222222242228222222222222222',
+    instance_destroyed_at: null,
+    organization_id: null,
+    email: 'user-1@example.com',
+    trial_ends_at: '2026-04-17T00:00:00.000Z',
     ...overrides,
   };
 }
@@ -1525,7 +1540,10 @@ describe('trial expiry sweep', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetWorkerDb.mockReset();
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    loggedValues = [];
+    vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      loggedValues.push(value);
+    });
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     vi.spyOn(globalThis, 'fetch').mockImplementation(
       async () =>
@@ -1583,17 +1601,20 @@ describe('trial expiry sweep', () => {
       );
     });
 
-    const summary = await runSweep(
-      createEnv(fetch),
+    const { env } = createEnvWithQueueMocks(fetch);
+    const result = await processTrialExpiryPage(
+      env,
       {
+        kind: 'trial_expiry_page',
         runId: '21212121-2121-4212-8212-212121212120',
         sweep: 'trial_expiry',
       },
       1
     );
 
-    expect(summary.sweep1_trial_expiry).toBe(1);
-    expect(summary.errors).toBe(0);
+    expect(result.summary.sweep1_trial_expiry).toBe(1);
+    expect(result.summary.errors).toBe(0);
+    expect(result.continuationEnqueued).toBe(false);
     expect(fetch).toHaveBeenCalledTimes(1);
     const stopRequest = fetch.mock.calls[0]?.[0];
     expect(stopRequest).toBeInstanceOf(Request);
@@ -1619,9 +1640,11 @@ describe('trial expiry sweep', () => {
     mockGetWorkerDb.mockReturnValue(db);
     const fetch = vi.fn();
 
-    const summary = await runSweep(
-      createEnv(fetch),
+    const { env } = createEnvWithQueueMocks(fetch);
+    const result = await processTrialExpiryPage(
+      env,
       {
+        kind: 'trial_expiry_page',
         runId: '23232323-2323-4232-8232-232323232320',
         sweep: 'trial_expiry',
       },
@@ -1646,8 +1669,9 @@ describe('trial expiry sweep', () => {
     expect(trialExpirySql).toMatch(/"kiloclaw_instances"\."sandbox_id"\s+is not null/i);
     expect(trialExpirySql).toMatch(/"kiloclaw_instances"\."destroyed_at"\s+is null/i);
     expect(trialExpirySql).toMatch(/"kiloclaw_instances"\."organization_id"\s+is null/i);
-    expect(summary.sweep1_trial_expiry).toBe(0);
-    expect(summary.errors).toBe(0);
+    expect(result.summary.sweep1_trial_expiry).toBe(0);
+    expect(result.summary.errors).toBe(0);
+    expect(result.continuationEnqueued).toBe(false);
     expect(fetch).not.toHaveBeenCalled();
     expect(updates).toEqual([]);
     expect(inserts).toEqual([]);
@@ -1672,20 +1696,183 @@ describe('trial expiry sweep', () => {
     mockGetWorkerDb.mockReturnValue(db);
     const fetch = vi.fn();
 
-    const summary = await runSweep(
-      createEnv(fetch),
+    const { env } = createEnvWithQueueMocks(fetch);
+    const result = await processTrialExpiryPage(
+      env,
       {
+        kind: 'trial_expiry_page',
         runId: '22222222-2222-4222-8222-222222222220',
         sweep: 'trial_expiry',
       },
       1
     );
 
-    expect(summary.sweep1_trial_expiry).toBe(0);
-    expect(summary.errors).toBe(0);
+    expect(result.summary.sweep1_trial_expiry).toBe(0);
+    expect(result.summary.errors).toBe(0);
+    expect(result.continuationEnqueued).toBe(false);
     expect(fetch).not.toHaveBeenCalled();
     expect(updates).toEqual([]);
     expect(inserts).toEqual([]);
+  });
+
+  it('processes only the trial-expiry page budget and enqueues a continuation', async () => {
+    const first = trialExpiryRow({
+      id: '11111111-1111-4111-8111-111111111111',
+      trial_ends_at: '2026-04-17T00:00:00.000Z',
+    });
+    const second = trialExpiryRow({
+      id: '33333333-3333-4333-8333-333333333333',
+      instance_id: '44444444-4444-4444-8444-444444444444',
+      trial_ends_at: '2026-04-18T00:00:00.000Z',
+    });
+    const { db } = createMockDb([[first, second], [first]]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            stopped: true,
+            previousStatus: 'running',
+            currentStatus: 'stopped',
+            stoppedAt: Date.parse('2026-04-22T00:00:00.000Z'),
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+    );
+    const { env, lifecycleSend } = createEnvWithQueueMocks(fetch);
+
+    const result = await processTrialExpiryPage(env, {
+      kind: 'trial_expiry_page',
+      runId: '44444444-4444-4444-8444-444444444440',
+      sweep: 'trial_expiry',
+      cutoffTime: '2026-04-20T00:00:00.000Z',
+      pageBudget: 1,
+    });
+
+    expect(result.summary.sweep1_trial_expiry).toBe(1);
+    expect(result.continuationEnqueued).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(lifecycleSend).toHaveBeenCalledWith({
+      kind: 'trial_expiry_continuation',
+      runId: '44444444-4444-4444-8444-444444444440',
+      sweep: 'trial_expiry',
+      cutoffTime: '2026-04-20T00:00:00.000Z',
+      cursorSubscriptionId: '11111111-1111-4111-8111-111111111111',
+      cursorTrialEndsAt: '2026-04-17T00:00:00.000Z',
+      pageBudget: 1,
+      wallClockBudgetMs: undefined,
+    });
+  });
+
+  it('does not enqueue another trial-expiry continuation after the final page', async () => {
+    const { db } = createMockDb([
+      [
+        trialExpiryRow({
+          email: 'deleted-user@deleted.invalid',
+        }),
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const { env, lifecycleSend } = createEnvWithQueueMocks(vi.fn());
+
+    const result = await processTrialExpiryPage(env, {
+      kind: 'trial_expiry_continuation',
+      runId: '55555555-5555-4555-8555-555555555550',
+      sweep: 'trial_expiry',
+      cutoffTime: '2026-04-20T00:00:00.000Z',
+      cursorSubscriptionId: '00000000-0000-4000-8000-000000000000',
+      cursorTrialEndsAt: '2026-04-16T00:00:00.000Z',
+      pageBudget: 1,
+    });
+
+    expect(result.summary.sweep1_trial_expiry).toBe(0);
+    expect(result.continuationEnqueued).toBe(false);
+    expect(lifecycleSend).not.toHaveBeenCalled();
+  });
+
+  it('keeps trial-expiry cursors ordered by subscription id at the same trial end', async () => {
+    const sharedTrialEnd = '2026-04-17T00:00:00.000Z';
+    const { db } = createMockDb([
+      [
+        trialExpiryRow({
+          id: '11111111-1111-4111-8111-111111111111',
+          email: 'deleted-first@deleted.invalid',
+          trial_ends_at: sharedTrialEnd,
+        }),
+        trialExpiryRow({
+          id: '33333333-3333-4333-8333-333333333333',
+          email: 'deleted-second@deleted.invalid',
+          trial_ends_at: sharedTrialEnd,
+        }),
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const { env, lifecycleSend } = createEnvWithQueueMocks(vi.fn());
+
+    await processTrialExpiryPage(env, {
+      kind: 'trial_expiry_page',
+      runId: '66666666-6666-4666-8666-666666666660',
+      sweep: 'trial_expiry',
+      cutoffTime: '2026-04-20T00:00:00.000Z',
+      pageBudget: 1,
+    });
+
+    expect(lifecycleSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'trial_expiry_continuation',
+        cursorSubscriptionId: '11111111-1111-4111-8111-111111111111',
+        cursorTrialEndsAt: sharedTrialEnd,
+      })
+    );
+  });
+
+  it('logs trial-expiry page backlog and cursor diagnostics without user PII', async () => {
+    const { db } = createMockDb([
+      [
+        trialExpiryRow({
+          id: '11111111-1111-4111-8111-111111111111',
+          email: 'private-first@deleted.invalid',
+        }),
+        trialExpiryRow({
+          id: '33333333-3333-4333-8333-333333333333',
+          email: 'private-second@deleted.invalid',
+          trial_ends_at: '2026-04-18T00:00:00.000Z',
+        }),
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const { env } = createEnvWithQueueMocks(vi.fn());
+
+    await processTrialExpiryPage(env, {
+      kind: 'trial_expiry_continuation',
+      runId: '77777777-7777-4777-8777-777777777770',
+      sweep: 'trial_expiry',
+      cutoffTime: '2026-04-20T00:00:00.000Z',
+      cursorSubscriptionId: '00000000-0000-4000-8000-000000000000',
+      cursorTrialEndsAt: '2026-04-16T00:00:00.000Z',
+      pageBudget: 1,
+    });
+
+    expect(findLogRecord('Processed trial-expiry page')).toMatchObject({
+      event: 'trial_expiry_page',
+      outcome: 'completed',
+      cutoffTime: '2026-04-20T00:00:00.000Z',
+      cursorSubscriptionId: '00000000-0000-4000-8000-000000000000',
+      cursorTrialEndsAt: '2026-04-16T00:00:00.000Z',
+      pageBudget: 1,
+      fetchedCount: 2,
+      processedCount: 1,
+      trialExpiryBacklogLikely: true,
+      continuationEnqueued: true,
+      nextCursorSubscriptionId: '11111111-1111-4111-8111-111111111111',
+      nextCursorTrialEndsAt: '2026-04-17T00:00:00.000Z',
+    });
+    expect(JSON.stringify(loggedValues)).not.toContain('private-first@deleted.invalid');
+    expect(JSON.stringify(loggedValues)).not.toContain('private-second@deleted.invalid');
   });
 });
 

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -58,6 +58,8 @@ import type {
   CreditRenewalDiscoveryQueueMessage,
   CreditRenewalItemQueueMessage,
   CreditRenewalTerminalFailureQueueMessage,
+  TrialExpiryContinuationQueueMessage,
+  TrialExpiryPageQueueMessage,
   TrialInactivityStopCandidateQueueMessage,
 } from './types.js';
 import { logger, withLogTags, type BillingLogFields } from './logger.js';
@@ -158,6 +160,17 @@ type CreditRenewalRow = {
   kilo_pass_threshold: number | null;
   next_credit_expiration_at: string | null;
   user_updated_at: string;
+};
+
+type TrialExpiryRow = {
+  id: string;
+  user_id: string;
+  instance_id: string | null;
+  sandbox_id: string | null;
+  instance_destroyed_at: string | null;
+  organization_id: string | null;
+  email: string;
+  trial_ends_at: string | null;
 };
 
 type KiloPassProjectionSubscriptionRow = KiloPassBonusProjectionSubscription &
@@ -1926,6 +1939,8 @@ export async function runCreditRenewalSweep(
 
 const CREDIT_RENEWAL_DISCOVERY_DEFAULT_PAGE_BUDGET = 50;
 const CREDIT_RENEWAL_DISCOVERY_DEFAULT_WALL_CLOCK_BUDGET_MS = 25_000;
+const TRIAL_EXPIRY_DEFAULT_PAGE_BUDGET = 50;
+const TRIAL_EXPIRY_DEFAULT_WALL_CLOCK_BUDGET_MS = 25_000;
 
 function serializeBillingTimestamp(timestamp: string): string {
   const date = new Date(timestamp);
@@ -2359,151 +2374,264 @@ async function destroyInstanceForEnforcement(
   }
 }
 
-async function runTrialExpirySweep(
-  database: WorkerDb,
-  env: BillingWorkerEnv,
-  context: SweepExecutionContext,
-  summary: BillingSummary
-): Promise<void> {
-  const now = new Date().toISOString();
-  const clawUrl = buildClawUrl(env);
+function trialExpiryEligibilityFilter(cutoffTime: string) {
+  return and(
+    eq(kiloclaw_subscriptions.status, 'trialing'),
+    currentSubscriptionRowFilter(),
+    lt(kiloclaw_subscriptions.trial_ends_at, cutoffTime),
+    isNull(kiloclaw_subscriptions.suspended_at),
+    isNotNull(kiloclaw_subscriptions.instance_id),
+    isNotNull(kiloclaw_instances.sandbox_id),
+    isNull(kiloclaw_instances.destroyed_at),
+    isNull(kiloclaw_instances.organization_id)
+  );
+}
 
-  const expiredTrials = await database
-    .select({
-      id: kiloclaw_subscriptions.id,
-      user_id: kiloclaw_subscriptions.user_id,
-      instance_id: kiloclaw_subscriptions.instance_id,
-      sandbox_id: kiloclaw_instances.sandbox_id,
-      instance_destroyed_at: kiloclaw_instances.destroyed_at,
-      organization_id: kiloclaw_instances.organization_id,
-      email: kilocode_users.google_user_email,
-      trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
-    })
+function trialExpiryCursorFilter(
+  cursorSubscriptionId: string | undefined,
+  cursorTrialEndsAt: string | undefined
+) {
+  if (!cursorSubscriptionId || !cursorTrialEndsAt) {
+    return undefined;
+  }
+
+  return or(
+    gt(kiloclaw_subscriptions.trial_ends_at, cursorTrialEndsAt),
+    and(
+      eq(kiloclaw_subscriptions.trial_ends_at, cursorTrialEndsAt),
+      gt(kiloclaw_subscriptions.id, cursorSubscriptionId)
+    )
+  );
+}
+
+function selectTrialExpiryRowFields() {
+  return {
+    id: kiloclaw_subscriptions.id,
+    user_id: kiloclaw_subscriptions.user_id,
+    instance_id: kiloclaw_subscriptions.instance_id,
+    sandbox_id: kiloclaw_instances.sandbox_id,
+    instance_destroyed_at: kiloclaw_instances.destroyed_at,
+    organization_id: kiloclaw_instances.organization_id,
+    email: kilocode_users.google_user_email,
+    trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
+  };
+}
+
+async function fetchTrialExpiryRows(
+  database: WorkerDb,
+  cutoffTime: string,
+  message: TrialExpiryPageQueueMessage | TrialExpiryContinuationQueueMessage,
+  limit: number
+): Promise<TrialExpiryRow[]> {
+  const cursorFilter = trialExpiryCursorFilter(
+    message.cursorSubscriptionId,
+    message.cursorTrialEndsAt
+  );
+
+  return await database
+    .select(selectTrialExpiryRowFields())
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
     .leftJoin(kiloclaw_instances, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
-    .where(
-      and(
-        eq(kiloclaw_subscriptions.status, 'trialing'),
-        currentSubscriptionRowFilter(),
-        lt(kiloclaw_subscriptions.trial_ends_at, now),
-        isNull(kiloclaw_subscriptions.suspended_at),
-        isNotNull(kiloclaw_subscriptions.instance_id),
-        isNotNull(kiloclaw_instances.sandbox_id),
-        isNull(kiloclaw_instances.destroyed_at),
-        isNull(kiloclaw_instances.organization_id)
-      )
-    );
+    .where(and(trialExpiryEligibilityFilter(cutoffTime), cursorFilter))
+    .orderBy(asc(kiloclaw_subscriptions.trial_ends_at), asc(kiloclaw_subscriptions.id))
+    .limit(limit);
+}
 
-  for (const row of expiredTrials) {
-    try {
-      if (isSoftDeletedUserEmail(row.email)) continue;
-      if (!row.trial_ends_at || new Date(row.trial_ends_at).getTime() >= Date.now()) {
-        logSkippedSubscriptionRow('Skipping trial expiry for active recorded trial end', row, {
-          reason: 'trial_end_not_elapsed',
-        });
-        continue;
-      }
-
-      if (!row.instance_id) {
-        logSkippedSubscriptionRow('Skipping trial expiry for detached subscription row', row, {
-          reason: 'missing_instance_id',
-        });
-        continue;
-      }
-
-      if (!row.sandbox_id) {
-        logSkippedSubscriptionRow(
-          'Skipping trial expiry for subscription without instance row',
-          row,
-          {
-            reason: 'missing_instance_row',
-          }
-        );
-        continue;
-      }
-
-      if (row.instance_destroyed_at) {
-        logSkippedSubscriptionRow('Skipping trial expiry for destroyed instance', row, {
-          reason: 'instance_destroyed',
-        });
-        continue;
-      }
-
-      if (row.organization_id) {
-        logSkippedSubscriptionRow('Skipping trial expiry for organization-managed row', row, {
-          reason: 'organization_managed',
-          organizationId: row.organization_id,
-        });
-        continue;
-      }
-
-      await stopInstanceForEnforcement(env, context, row, 'trial_expiry');
-
-      const destructionDeadline = new Date(Date.now() + DESTRUCTION_GRACE_DAYS * MS_PER_DAY);
-      const before = await getSubscriptionById(database, row.id);
-      const [updated] = await database
-        .update(kiloclaw_subscriptions)
-        .set({
-          status: 'canceled',
-          suspended_at: now,
-          destruction_deadline: destructionDeadline.toISOString(),
-        })
-        .where(eq(kiloclaw_subscriptions.id, row.id))
-        .returning();
-
-      if (row.instance_id) {
-        await setInactiveTrialStoppedAt(database, row.instance_id, null);
-      }
-
-      await insertLifecycleChangeLogBestEffort(database, {
-        subscriptionId: row.id,
-        action: 'suspended',
-        reason: 'trial_expired',
-        before,
-        after: updated ?? null,
-      });
-
-      await enqueueAffiliateEvent(env, context, {
-        userId: row.user_id,
-        provider: 'impact',
-        eventType: 'trial_end',
-        dedupeKey: `affiliate:impact:trial_end:${row.id}`,
-        eventDateIso: now,
-        orderId: 'IR_AN_64_TS',
-      }).catch(error => {
-        log('warn', 'Affiliate trial end enqueue failed during sweep', {
-          userId: row.user_id,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
-
-      await trySendEmail(
-        database,
-        env,
-        context,
-        row.user_id,
-        row.email,
-        'claw_suspended_trial',
-        'clawSuspendedTrial',
-        {
-          destruction_date: formatDateForEmail(destructionDeadline),
-          claw_url: clawUrl,
-        },
-        summary,
-        undefined,
-        { instanceId: row.instance_id }
-      );
-
-      summary.sweep1_trial_expiry++;
-    } catch (error) {
-      summary.errors++;
-      log('error', 'Trial expiry sweep failed for user', {
-        userId: row.user_id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+async function processTrialExpiryRow(
+  database: WorkerDb,
+  env: BillingWorkerEnv,
+  context: SweepExecutionContext,
+  summary: BillingSummary,
+  row: TrialExpiryRow,
+  clawUrl: string,
+  now: string
+): Promise<void> {
+  if (isSoftDeletedUserEmail(row.email)) return;
+  if (!row.trial_ends_at || new Date(row.trial_ends_at).getTime() >= Date.now()) {
+    logSkippedSubscriptionRow('Skipping trial expiry for active recorded trial end', row, {
+      reason: 'trial_end_not_elapsed',
+    });
+    return;
   }
+
+  if (!row.instance_id) {
+    logSkippedSubscriptionRow('Skipping trial expiry for detached subscription row', row, {
+      reason: 'missing_instance_id',
+    });
+    return;
+  }
+
+  if (!row.sandbox_id) {
+    logSkippedSubscriptionRow('Skipping trial expiry for subscription without instance row', row, {
+      reason: 'missing_instance_row',
+    });
+    return;
+  }
+
+  if (row.instance_destroyed_at) {
+    logSkippedSubscriptionRow('Skipping trial expiry for destroyed instance', row, {
+      reason: 'instance_destroyed',
+    });
+    return;
+  }
+
+  if (row.organization_id) {
+    logSkippedSubscriptionRow('Skipping trial expiry for organization-managed row', row, {
+      reason: 'organization_managed',
+      organizationId: row.organization_id,
+    });
+    return;
+  }
+
+  await stopInstanceForEnforcement(env, context, row, 'trial_expiry');
+
+  const destructionDeadline = new Date(Date.now() + DESTRUCTION_GRACE_DAYS * MS_PER_DAY);
+  const before = await getSubscriptionById(database, row.id);
+  const [updated] = await database
+    .update(kiloclaw_subscriptions)
+    .set({
+      status: 'canceled',
+      suspended_at: now,
+      destruction_deadline: destructionDeadline.toISOString(),
+    })
+    .where(eq(kiloclaw_subscriptions.id, row.id))
+    .returning();
+
+  await setInactiveTrialStoppedAt(database, row.instance_id, null);
+
+  await insertLifecycleChangeLogBestEffort(database, {
+    subscriptionId: row.id,
+    action: 'suspended',
+    reason: 'trial_expired',
+    before,
+    after: updated ?? null,
+  });
+
+  await enqueueAffiliateEvent(env, context, {
+    userId: row.user_id,
+    provider: 'impact',
+    eventType: 'trial_end',
+    dedupeKey: `affiliate:impact:trial_end:${row.id}`,
+    eventDateIso: now,
+    orderId: 'IR_AN_64_TS',
+  }).catch(error => {
+    log('warn', 'Affiliate trial end enqueue failed during sweep', {
+      userId: row.user_id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+
+  await trySendEmail(
+    database,
+    env,
+    context,
+    row.user_id,
+    row.email,
+    'claw_suspended_trial',
+    'clawSuspendedTrial',
+    {
+      destruction_date: formatDateForEmail(destructionDeadline),
+      claw_url: clawUrl,
+    },
+    summary,
+    undefined,
+    { instanceId: row.instance_id }
+  );
+
+  summary.sweep1_trial_expiry++;
+}
+
+export async function processTrialExpiryPage(
+  env: BillingWorkerEnv,
+  message: TrialExpiryPageQueueMessage | TrialExpiryContinuationQueueMessage,
+  attempt = 1
+): Promise<{ summary: BillingSummary; continuationEnqueued: boolean }> {
+  const context = createSweepContext(message, attempt);
+
+  return await withLogTags(
+    {
+      source: 'processTrialExpiryPage',
+      tags: {
+        ...context,
+        billingComponent: 'worker',
+      },
+    },
+    async () => {
+      const database = getDb(env);
+      const summary = createSummary();
+      const startedAt = Date.now();
+      const pageBudget = message.pageBudget ?? TRIAL_EXPIRY_DEFAULT_PAGE_BUDGET;
+      const wallClockBudgetMs =
+        message.wallClockBudgetMs ?? TRIAL_EXPIRY_DEFAULT_WALL_CLOCK_BUDGET_MS;
+      const cutoffTime = message.cutoffTime ?? new Date().toISOString();
+      const rows = await fetchTrialExpiryRows(database, cutoffTime, message, pageBudget + 1);
+      const clawUrl = buildClawUrl(env);
+      const processedAt = new Date().toISOString();
+      let processedCount = 0;
+      let lastProcessed: TrialExpiryRow | null = null;
+
+      for (const row of rows.slice(0, pageBudget)) {
+        if (Date.now() - startedAt >= wallClockBudgetMs && processedCount > 0) {
+          break;
+        }
+
+        try {
+          await processTrialExpiryRow(database, env, context, summary, row, clawUrl, processedAt);
+        } catch (error) {
+          summary.errors++;
+          log('error', 'Trial expiry sweep failed for user', {
+            userId: row.user_id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+
+        processedCount++;
+        lastProcessed = row;
+      }
+
+      const shouldContinue = rows.length > processedCount;
+      const nextCursorTrialEndsAt =
+        shouldContinue && lastProcessed?.trial_ends_at
+          ? serializeBillingTimestamp(lastProcessed.trial_ends_at)
+          : undefined;
+
+      if (shouldContinue && (!lastProcessed || !nextCursorTrialEndsAt)) {
+        throw new Error('Cannot continue trial expiry page without a complete cursor');
+      }
+
+      if (nextCursorTrialEndsAt && lastProcessed) {
+        await env.LIFECYCLE_QUEUE.send({
+          kind: 'trial_expiry_continuation',
+          runId: message.runId,
+          sweep: 'trial_expiry',
+          cutoffTime,
+          cursorSubscriptionId: lastProcessed.id,
+          cursorTrialEndsAt: nextCursorTrialEndsAt,
+          pageBudget: message.pageBudget,
+          wallClockBudgetMs: message.wallClockBudgetMs,
+        });
+      }
+
+      const continuationEnqueued = nextCursorTrialEndsAt !== undefined;
+      log('info', 'Processed trial-expiry page', {
+        event: 'trial_expiry_page',
+        outcome: 'completed',
+        cutoffTime,
+        cursorSubscriptionId: message.cursorSubscriptionId,
+        cursorTrialEndsAt: message.cursorTrialEndsAt,
+        pageBudget,
+        fetchedCount: rows.length,
+        processedCount,
+        trialExpiryBacklogLikely: shouldContinue,
+        continuationEnqueued,
+        nextCursorSubscriptionId: lastProcessed?.id,
+        nextCursorTrialEndsAt,
+      });
+
+      return { summary, continuationEnqueued };
+    }
+  );
 }
 
 async function hasUnresolvedTerminalRenewalFailureForBoundary(
@@ -3899,7 +4027,11 @@ export async function runSweep(
             await runInterruptedAutoResumeSweep(database, env, context, summary);
             break;
           case 'trial_expiry':
-            await runTrialExpirySweep(database, env, context, summary);
+            await env.LIFECYCLE_QUEUE.send({
+              kind: 'trial_expiry_page',
+              runId: message.runId,
+              sweep: 'trial_expiry',
+            });
             break;
           case 'subscription_expiry':
             await runSubscriptionExpirySweep(database, env, context, summary);

--- a/services/kiloclaw-billing/src/types.ts
+++ b/services/kiloclaw-billing/src/types.ts
@@ -99,10 +99,37 @@ export type CreditRenewalQueueMessage =
   | CreditRenewalItemQueueMessage
   | CreditRenewalTerminalFailureQueueMessage;
 
+export type TrialExpiryPageQueueMessage = {
+  kind: 'trial_expiry_page';
+  runId: string;
+  sweep: 'trial_expiry';
+  cutoffTime?: string;
+  cursorSubscriptionId?: string;
+  cursorTrialEndsAt?: string;
+  pageBudget?: number;
+  wallClockBudgetMs?: number;
+};
+
+export type TrialExpiryContinuationQueueMessage = {
+  kind: 'trial_expiry_continuation';
+  runId: string;
+  sweep: 'trial_expiry';
+  cutoffTime: string;
+  cursorSubscriptionId: string;
+  cursorTrialEndsAt: string;
+  pageBudget?: number;
+  wallClockBudgetMs?: number;
+};
+
+export type TrialExpiryQueueMessage =
+  | TrialExpiryPageQueueMessage
+  | TrialExpiryContinuationQueueMessage;
+
 export type LifecycleProducerQueueMessage =
   | LifecycleQueueMessage
   | StandaloneInstanceDestructionQueueMessage
-  | CreditRenewalQueueMessage;
+  | CreditRenewalQueueMessage
+  | TrialExpiryQueueMessage;
 
 export type TrialInactivityKickoffQueueMessage = {
   kind: 'trial_inactivity_stop';
@@ -127,6 +154,7 @@ export type BillingQueueMessage =
   | LifecycleQueueMessage
   | StandaloneInstanceDestructionQueueMessage
   | CreditRenewalQueueMessage
+  | TrialExpiryQueueMessage
   | TrialInactivityQueueMessage;
 
 export type ServiceFetcher = {


### PR DESCRIPTION
## Summary
Bound trial-expiry enforcement so large expired-trial cohorts drain across resumable queue pages without starving later lifecycle sweeps.

### Why this change is needed
Recent lifecycle queue runs showed large `trial_expiry` cohorts can monopolize one queue message, increase timeout risk, and delay later sweeps such as instance destruction. Credit-renewal discovery already uses safer continuation-style work slicing, so trial expiry needs equivalent bounded orchestration without changing billing semantics.

### How this is addressed
- Route the initial `trial_expiry` lifecycle sweep into paginated queue work plus continuation messages.
- Page deterministically by `trial_ends_at ASC, subscription id ASC` with cursor continuation and bounded work budgets.
- Advance to `subscription_expiry` only after final trial-expiry page drains.
- Preserve existing stop/cancel/email/affiliate side effects and row-level validation behavior.
- Emit structured trial-expiry progress telemetry for backlog and cursor diagnosis.

## Human Verification
- Confirmed KiloClaw billing lifecycle and billing specs remain aligned with existing trial-expiry enforcement semantics.
- Ran focused billing worker tests covering lifecycle queue routing and trial-expiry pagination:
  `pnpm --filter kiloclaw-billing test -- src/lifecycle.test.ts src/index.test.ts`

## Reviewer Notes
### Human Reviewer Flags
- Lifecycle orchestration changes from one inline sweep message to resumable page/continuation messages.
- Later sweep ordering is intentionally gated on full trial-expiry page drain.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- New queue contracts: `trial_expiry_page` and `trial_expiry_continuation`.
- Pagination mirrors credit-renewal discovery shape: stable cursor, `pageBudget + 1`, optional wall-clock budget, structured progress telemetry.
- Existing trial-expiry business side effects remain inside row processor; queue changes bound orchestration only.
- Focused verification also passed locally before PR creation:
  - `pnpm --filter kiloclaw-billing typecheck`
  - `pnpm --filter kiloclaw-billing lint`

</details>
