### PR TITLE
fix(kiloclaw): run destruction sweep every 15 minutes

### DIFF
--- a/services/kiloclaw-billing/src/index.test.ts
+++ b/services/kiloclaw-billing/src/index.test.ts
@@ -151,6 +151,39 @@ describe('kiloclaw billing worker handler', () => {
     expect(trialInactivitySend).not.toHaveBeenCalled();
   });
 
+  it('enqueues standalone instance destruction on the quarter-hourly cron', async () => {
+    const { env, lifecycleSend, trialInactivitySend } = createEnv();
+
+    await handler.scheduled?.(
+      { cron: '*/15 * * * *' } as ScheduledController,
+      env,
+      {} as ExecutionContext
+    );
+
+    expect(lifecycleSend).toHaveBeenCalledTimes(1);
+    expect(lifecycleSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'standalone_instance_destruction',
+        sweep: 'instance_destruction',
+      })
+    );
+    expect(trialInactivitySend).not.toHaveBeenCalled();
+
+    const record = findLogRecord('Enqueued standalone instance destruction sweep');
+    expect(record).toMatchObject({
+      event: 'run_started',
+      outcome: 'started',
+      cron: '*/15 * * * *',
+    });
+    expect(record?.tags).toEqual(
+      expect.objectContaining({
+        billingFlow: 'kiloclaw_lifecycle',
+        billingComponent: 'worker',
+        billingSweep: 'instance_destruction',
+      })
+    );
+  });
+
   it('enqueues the daily trial inactivity run on the daily cron when enabled', async () => {
     const { env, lifecycleSend, trialInactivitySend } = createEnv();
     env.TRIAL_INACTIVITY_STOP_ENABLED = 'true';
@@ -193,6 +226,24 @@ describe('kiloclaw billing worker handler', () => {
     });
   });
 
+  it('logs and ignores unknown cron triggers', async () => {
+    const { env, lifecycleSend, trialInactivitySend } = createEnv();
+
+    await handler.scheduled?.(
+      { cron: '5 * * * *' } as ScheduledController,
+      env,
+      {} as ExecutionContext
+    );
+
+    expect(lifecycleSend).not.toHaveBeenCalled();
+    expect(trialInactivitySend).not.toHaveBeenCalled();
+    expect(findLogRecord('Ignoring unknown billing cron trigger')).toMatchObject({
+      event: 'run_skipped',
+      outcome: 'discarded',
+      cron: '5 * * * *',
+    });
+  });
+
   it('acks invalid queue messages', async () => {
     const { env } = createEnv();
     const message = {
@@ -231,6 +282,69 @@ describe('kiloclaw billing worker handler', () => {
       kind: 'lifecycle',
       runId,
       sweep: 'interrupted_auto_resume',
+    });
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  it('runs standalone instance destruction without chaining later lifecycle sweeps', async () => {
+    const { env, lifecycleSend } = createEnv();
+    const runId = '22222222-2222-4222-8222-222222222222';
+    const message = {
+      body: {
+        kind: 'standalone_instance_destruction',
+        runId,
+        sweep: 'instance_destruction',
+      },
+      attempts: 1,
+      ack: vi.fn(),
+      retry: vi.fn(),
+    };
+
+    await handler.queue?.(createBatch(message), env, {} as ExecutionContext);
+
+    expect(runSweep).toHaveBeenCalledWith(env, message.body, 1);
+    expect(lifecycleSend).not.toHaveBeenCalled();
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+
+    const record = findLogRecord('Completed standalone instance destruction run');
+    expect(record).toMatchObject({
+      event: 'run_completed',
+      outcome: 'completed',
+    });
+    expect(record?.tags).toEqual(
+      expect.objectContaining({
+        billingFlow: 'kiloclaw_lifecycle',
+        billingComponent: 'worker',
+        billingRunId: runId,
+        billingSweep: 'instance_destruction',
+        billingAttempt: 1,
+      })
+    );
+  });
+
+  it('continues hourly lifecycle instance destruction into past-due cleanup', async () => {
+    const { env, lifecycleSend } = createEnv();
+    const runId = '33333333-3333-4333-8333-333333333333';
+    const message = {
+      body: {
+        kind: 'lifecycle',
+        runId,
+        sweep: 'instance_destruction',
+      },
+      attempts: 1,
+      ack: vi.fn(),
+      retry: vi.fn(),
+    };
+
+    await handler.queue?.(createBatch(message), env, {} as ExecutionContext);
+
+    expect(runSweep).toHaveBeenCalledWith(env, message.body, 1);
+    expect(lifecycleSend).toHaveBeenCalledWith({
+      kind: 'lifecycle',
+      runId,
+      sweep: 'past_due_cleanup',
     });
     expect(message.ack).toHaveBeenCalledTimes(1);
     expect(message.retry).not.toHaveBeenCalled();

--- a/services/kiloclaw-billing/src/index.test.ts
+++ b/services/kiloclaw-billing/src/index.test.ts
@@ -155,7 +155,7 @@ describe('kiloclaw billing worker handler', () => {
     const { env, lifecycleSend, trialInactivitySend } = createEnv();
 
     await handler.scheduled?.(
-      { cron: '*/15 * * * *' } as ScheduledController,
+      { cron: '5,20,35,50 * * * *' } as ScheduledController,
       env,
       {} as ExecutionContext
     );
@@ -173,7 +173,7 @@ describe('kiloclaw billing worker handler', () => {
     expect(record).toMatchObject({
       event: 'run_started',
       outcome: 'started',
-      cron: '*/15 * * * *',
+      cron: '5,20,35,50 * * * *',
     });
     expect(record?.tags).toEqual(
       expect.objectContaining({

--- a/services/kiloclaw-billing/src/index.ts
+++ b/services/kiloclaw-billing/src/index.ts
@@ -6,6 +6,7 @@ import {
   BILLING_HOURLY_CRON,
   BILLING_QUEUE_MAX_RETRIES,
   BILLING_SWEEP_ORDER,
+  INSTANCE_DESTRUCTION_QUARTER_HOURLY_CRON,
   TRIAL_INACTIVITY_DAILY_CRON,
   TRIAL_INACTIVITY_STOP_CANDIDATE_SWEEP,
   TRIAL_INACTIVITY_SWEEP,
@@ -40,6 +41,12 @@ const LifecycleQueueMessageSchema = z.object({
   kind: z.literal('lifecycle'),
   runId: z.string().uuid(),
   sweep: z.enum(BILLING_SWEEP_ORDER),
+});
+
+const StandaloneInstanceDestructionQueueMessageSchema = z.object({
+  kind: z.literal('standalone_instance_destruction'),
+  runId: z.string().uuid(),
+  sweep: z.literal('instance_destruction'),
 });
 
 const TrialInactivityQueueMessageSchema = z.object({
@@ -109,6 +116,7 @@ const CreditRenewalTerminalFailureQueueMessageSchema = z.object({
 
 const BillingQueueMessageSchema = z.discriminatedUnion('kind', [
   LifecycleQueueMessageSchema,
+  StandaloneInstanceDestructionQueueMessageSchema,
   TrialInactivityQueueMessageSchema,
   TrialInactivityStopCandidateQueueMessageSchema,
   CreditRenewalDiscoveryQueueMessageSchema,
@@ -319,6 +327,36 @@ export const handler: ExportedHandler<BillingWorkerEnv, BillingQueueMessage> = {
       return;
     }
 
+    if (controller.cron === INSTANCE_DESTRUCTION_QUARTER_HOURLY_CRON) {
+      const message = {
+        kind: 'standalone_instance_destruction',
+        runId,
+        sweep: 'instance_destruction',
+      } satisfies BillingQueueMessage;
+
+      await withLogTags(
+        {
+          source: 'scheduled',
+          tags: {
+            billingFlow: BILLING_FLOW,
+            billingComponent: 'worker',
+            billingRunId: runId,
+            billingSweep: message.sweep,
+          },
+        },
+        async () => {
+          await env.LIFECYCLE_QUEUE.send(message);
+
+          log('info', 'Enqueued standalone instance destruction sweep', {
+            event: 'run_started',
+            outcome: 'started',
+            cron: controller.cron,
+          });
+        }
+      );
+      return;
+    }
+
     if (controller.cron !== BILLING_HOURLY_CRON) {
       await withLogTags(
         {
@@ -440,6 +478,12 @@ export const handler: ExportedHandler<BillingWorkerEnv, BillingQueueMessage> = {
                 outcome: 'completed',
                 subscriptionId: parsed.data.subscriptionId,
                 renewalBoundary: parsed.data.renewalBoundary,
+              });
+            } else if (parsed.data.kind === 'standalone_instance_destruction') {
+              await runSweep(env, parsed.data, message.attempts);
+              log('info', 'Completed standalone instance destruction run', {
+                event: 'run_completed',
+                outcome: 'completed',
               });
             } else if (parsed.data.kind === 'lifecycle' && parsed.data.sweep === 'credit_renewal') {
               await env.LIFECYCLE_QUEUE.send({

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -2096,7 +2096,7 @@ describe('instance destruction sweep', () => {
 
   it('keeps DB/email cleanup unchanged when platform destroy succeeds', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
-    const { db, updates, txUpdates, inserts, deletes } = createMockDb([
+    const { db, updates, txUpdates, inserts, deletes, selectBuilders } = createMockDb([
       [
         {
           id: 'sub-1',
@@ -2146,6 +2146,7 @@ describe('instance destruction sweep', () => {
 
     expect(summary.errors).toBe(0);
     expect(summary.sweep3_instance_destruction).toBe(1);
+    expect(selectBuilders[0]?.limit).toHaveBeenCalledWith(50);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     expect(inserts).toEqual(

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -71,6 +71,7 @@ const DESTRUCTION_WARNING_DAYS = 2;
 const EARLYBIRD_WARNING_DAYS = 14;
 const AUTO_RESUME_INITIAL_BACKOFF_MS = 2 * 60 * 60 * 1000;
 const AUTO_RESUME_MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+const INSTANCE_DESTRUCTION_BATCH_SIZE = 50;
 const TRIAL_INACTIVITY_BATCH_SIZE = 50;
 const SOFT_DELETED_EMAIL_SUFFIX = '@deleted.invalid';
 const TRIAL_ENDING_SOON_MIN_DURATION_DAYS = 2;
@@ -2725,7 +2726,9 @@ async function runInstanceDestructionSweep(
         isNotNull(kiloclaw_subscriptions.suspended_at),
         inArray(kiloclaw_subscriptions.status, ['canceled', 'past_due', 'unpaid'])
       )
-    );
+    )
+    .orderBy(asc(kiloclaw_subscriptions.destruction_deadline), asc(kiloclaw_subscriptions.id))
+    .limit(INSTANCE_DESTRUCTION_BATCH_SIZE);
 
   for (const row of destructionCandidates) {
     try {

--- a/services/kiloclaw-billing/src/types.ts
+++ b/services/kiloclaw-billing/src/types.ts
@@ -1,5 +1,5 @@
 export const BILLING_HOURLY_CRON = '0 * * * *';
-export const INSTANCE_DESTRUCTION_QUARTER_HOURLY_CRON = '*/15 * * * *';
+export const INSTANCE_DESTRUCTION_QUARTER_HOURLY_CRON = '5,20,35,50 * * * *';
 export const TRIAL_INACTIVITY_DAILY_CRON = '0 8 * * *';
 export const TRIAL_INACTIVITY_SWEEP = 'trial_inactivity_stop' as const;
 export const TRIAL_INACTIVITY_STOP_CANDIDATE_SWEEP = 'trial_inactivity_stop_candidate' as const;

--- a/services/kiloclaw-billing/src/types.ts
+++ b/services/kiloclaw-billing/src/types.ts
@@ -1,4 +1,5 @@
 export const BILLING_HOURLY_CRON = '0 * * * *';
+export const INSTANCE_DESTRUCTION_QUARTER_HOURLY_CRON = '*/15 * * * *';
 export const TRIAL_INACTIVITY_DAILY_CRON = '0 8 * * *';
 export const TRIAL_INACTIVITY_SWEEP = 'trial_inactivity_stop' as const;
 export const TRIAL_INACTIVITY_STOP_CANDIDATE_SWEEP = 'trial_inactivity_stop_candidate' as const;
@@ -36,6 +37,12 @@ export type LifecycleQueueMessage = {
   kind: 'lifecycle';
   runId: string;
   sweep: BillingSweepKind;
+};
+
+export type StandaloneInstanceDestructionQueueMessage = {
+  kind: 'standalone_instance_destruction';
+  runId: string;
+  sweep: 'instance_destruction';
 };
 
 export type CreditRenewalDiscoveryQueueMessage = {
@@ -92,7 +99,10 @@ export type CreditRenewalQueueMessage =
   | CreditRenewalItemQueueMessage
   | CreditRenewalTerminalFailureQueueMessage;
 
-export type LifecycleProducerQueueMessage = LifecycleQueueMessage | CreditRenewalQueueMessage;
+export type LifecycleProducerQueueMessage =
+  | LifecycleQueueMessage
+  | StandaloneInstanceDestructionQueueMessage
+  | CreditRenewalQueueMessage;
 
 export type TrialInactivityKickoffQueueMessage = {
   kind: 'trial_inactivity_stop';
@@ -115,6 +125,7 @@ export type TrialInactivityQueueMessage =
 
 export type BillingQueueMessage =
   | LifecycleQueueMessage
+  | StandaloneInstanceDestructionQueueMessage
   | CreditRenewalQueueMessage
   | TrialInactivityQueueMessage;
 

--- a/services/kiloclaw-billing/wrangler.jsonc
+++ b/services/kiloclaw-billing/wrangler.jsonc
@@ -20,7 +20,7 @@
     "cpu_ms": 120000,
   },
   "triggers": {
-    "crons": ["0 * * * *", "*/15 * * * *", "0 8 * * *"],
+    "crons": ["0 * * * *", "5,20,35,50 * * * *", "0 8 * * *"],
   },
   "vars": {
     "KILOCODE_BACKEND_BASE_URL": "https://app.kilo.ai",

--- a/services/kiloclaw-billing/wrangler.jsonc
+++ b/services/kiloclaw-billing/wrangler.jsonc
@@ -20,7 +20,7 @@
     "cpu_ms": 120000,
   },
   "triggers": {
-    "crons": ["0 * * * *", "0 8 * * *"],
+    "crons": ["0 * * * *", "*/15 * * * *", "0 8 * * *"],
   },
   "vars": {
     "KILOCODE_BACKEND_BASE_URL": "https://app.kilo.ai",


### PR DESCRIPTION
## Summary

- Reduce deadline-to-destroy lag by scheduling `instance_destruction` every 15 minutes instead of relying only on hourly lifecycle kickoff.
- Keep hourly lifecycle and daily trial inactivity cron behavior unchanged.
- Use standalone queue work that reuses the existing sweep execution path while preventing downstream lifecycle chaining.

## Verification

- N/A - no manual runtime exercise for cron trigger or queue delivery in local environment.

## Visual Changes

N/A

## Reviewer Notes

- `standalone_instance_destruction` intentionally completes after `runSweep(...)`; unlike hourly lifecycle messages, it never calls `nextSweep(...)`.
- Normal hourly `instance_destruction` still advances to `past_due_cleanup`, preserving existing sweep order.