### PR TITLE
fix(kiloclaw): renew credits after instance destruction

### DIFF
--- a/.specs/kiloclaw-billing-lifecycle.md
+++ b/.specs/kiloclaw-billing-lifecycle.md
@@ -139,7 +139,9 @@ downstream enforcement can proceed.
    the item MUST be skipped without billing mutation.
 5. If the associated instance or ownership context makes the row
    ineligible for personal credit renewal, the item MUST be skipped
-   without billing mutation.
+   without billing mutation. Instance destruction alone MUST NOT make a
+   current personal pure-credit subscription ineligible; renewal remains
+   governed by subscription state and cancellation intent.
 6. If the user has been soft-deleted, the item MUST NOT create
    user-facing side effects.
 7. Expected stale, superseded, or ineligible-row outcomes MUST NOT be
@@ -187,9 +189,11 @@ downstream enforcement can proceed.
    expected outcome.
 6. Reconciling a duplicate idempotency key as an already-finalized
    boundary is an expected outcome.
-7. Skipping a stale, superseded, transferred, destroyed, detached,
+7. Skipping a stale, superseded, transferred, detached,
    organization-managed, Stripe-funded, hybrid, or otherwise ineligible
-   row is an expected outcome.
+   row is an expected outcome. A destroyed instance row is not skipped
+   when its current personal pure-credit subscription otherwise remains
+   renewable.
 8. Expected outcomes MUST NOT create terminal renewal failures.
 9. Expected outcomes MUST NOT block unrelated downstream enforcement.
 

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -4860,10 +4860,14 @@ describe('credit renewal sweep affiliate tracking', () => {
         }),
       ])
     );
-    expect(JSON.stringify(loggedValues)).not.toContain(
-      'Skipping credit renewal for destroyed instance row'
+    expect(loggedValues).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: 'subscription_row_skipped',
+          reason: 'instance_destroyed',
+        }),
+      ])
     );
-    expect(JSON.stringify(loggedValues)).not.toContain('instance_destroyed');
   });
 
   it('renews destroyed suspended past-due rows without requesting platform auto-resume', async () => {

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -3603,7 +3603,7 @@ describe('credit renewal sweep affiliate tracking', () => {
     }
   });
 
-  it('cancels pending pure-credit rows without charging, advancing, or rewriting price version', async () => {
+  it('cancels destroyed pending pure-credit rows without charging, advancing, or rewriting price version', async () => {
     const renewalAt = '2026-04-09T10:00:00.000Z';
     const { db, inserts, updates, txInserts, txUpdates } = createMockDb(
       [
@@ -3615,7 +3615,7 @@ describe('credit renewal sweep affiliate tracking', () => {
             id: 'cancel-sub',
             instance_row_id: 'cancel-instance',
             organization_id: null,
-            instance_destroyed_at: null,
+            instance_destroyed_at: '2026-04-08T10:00:00.000Z',
             plan: 'standard',
             status: 'active',
             kiloclaw_price_version: '2026-05-10',
@@ -4778,6 +4778,242 @@ describe('credit renewal sweep affiliate tracking', () => {
     );
 
     expect(sideEffectCalls).toEqual([]);
+  });
+
+  it('renews active pure-credit rows whose linked instance is destroyed', async () => {
+    const renewalAt = '2026-04-09T10:00:00.000Z';
+    const { db, txInserts, txUpdates } = createMockDb([
+      [
+        creditRenewalRow({
+          id: 'destroyed-renew-sub',
+          user_id: 'destroyed-renew-user',
+          email: 'destroyed-renew-user@example.com',
+          instance_id: 'destroyed-renew-instance',
+          instance_row_id: 'destroyed-renew-instance',
+          instance_destroyed_at: '2026-04-08T10:00:00.000Z',
+          kiloclaw_price_version: '2026-05-10',
+          credit_renewal_at: renewalAt,
+          current_period_end: renewalAt,
+          total_microdollars_acquired: 100_000_000,
+        }),
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      vi.fn(async (_request: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(typeof init?.body === 'string' ? init.body : '{}') as {
+          action: string;
+        };
+
+        switch (body.action) {
+          case 'project_pending_kilo_pass_bonus':
+            return Response.json({ projectedBonusMicrodollars: 0 });
+          case 'issue_kilo_pass_bonus_from_usage_threshold':
+            return Response.json({ ok: true });
+          case 'process_paid_conversion':
+            return Response.json({
+              affiliateSaleEnqueued: true,
+              winningTouchType: 'affiliate',
+              conversionId: null,
+              disqualificationReason: null,
+            });
+          default:
+            throw new Error(`Unexpected side effect action: ${body.action}`);
+        }
+      })
+    );
+
+    const summary = await processCreditRenewalItem(
+      createEnv(vi.fn()),
+      creditRenewalItemMessage({
+        subscriptionId: 'destroyed-renew-sub',
+        userId: 'destroyed-renew-user',
+        renewalBoundary: renewalAt,
+      }),
+      1
+    );
+
+    expect(summary.credit_renewals).toBe(1);
+    expect(summary.errors).toBe(0);
+    expect(txInserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kilo_user_id: 'destroyed-renew-user',
+          amount_microdollars: -55_000_000,
+          credit_category: 'kiloclaw-subscription:destroyed-renew-instance:2026-04',
+        }),
+        expect.objectContaining({
+          subscription_id: 'destroyed-renew-sub',
+          action: 'period_advanced',
+          reason: 'credit_renewal',
+        }),
+      ])
+    );
+    expect(txUpdates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ microdollars_used: expect.anything() }),
+        expect.objectContaining({
+          current_period_start: renewalAt,
+          current_period_end: '2026-05-09T10:00:00.000Z',
+          credit_renewal_at: '2026-05-09T10:00:00.000Z',
+        }),
+      ])
+    );
+    expect(JSON.stringify(loggedValues)).not.toContain(
+      'Skipping credit renewal for destroyed instance row'
+    );
+    expect(JSON.stringify(loggedValues)).not.toContain('instance_destroyed');
+  });
+
+  it('renews destroyed suspended past-due rows without requesting platform auto-resume', async () => {
+    const renewalAt = '2026-04-09T10:00:00.000Z';
+    const { db, txUpdates } = createMockDb(
+      [
+        [
+          creditRenewalRow({
+            id: 'destroyed-suspended-sub',
+            user_id: 'destroyed-suspended-user',
+            email: 'destroyed-suspended-user@example.com',
+            instance_id: 'destroyed-suspended-instance',
+            instance_row_id: 'destroyed-suspended-instance',
+            instance_destroyed_at: '2026-04-08T10:00:00.000Z',
+            status: 'past_due',
+            kiloclaw_price_version: '2026-05-10',
+            credit_renewal_at: renewalAt,
+            current_period_end: renewalAt,
+            past_due_since: '2026-04-01T10:00:00.000Z',
+            suspended_at: '2026-04-08T10:00:00.000Z',
+            auto_resume_attempt_count: 2,
+            total_microdollars_acquired: 100_000_000,
+          }),
+        ],
+        [],
+      ],
+      { txFallbackFromDbSelect: true }
+    );
+    mockGetWorkerDb.mockReturnValue(db);
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      vi.fn(async (_request: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(typeof init?.body === 'string' ? init.body : '{}') as {
+          action: string;
+        };
+
+        switch (body.action) {
+          case 'project_pending_kilo_pass_bonus':
+            return Response.json({ projectedBonusMicrodollars: 0 });
+          case 'issue_kilo_pass_bonus_from_usage_threshold':
+            return Response.json({ ok: true });
+          case 'process_paid_conversion':
+            return Response.json({
+              affiliateSaleEnqueued: true,
+              winningTouchType: 'affiliate',
+              conversionId: null,
+              disqualificationReason: null,
+            });
+          default:
+            throw new Error(`Unexpected side effect action: ${body.action}`);
+        }
+      })
+    );
+    const kiloclawFetch = vi.fn();
+
+    const summary = await processCreditRenewalItem(
+      createEnv(kiloclawFetch),
+      creditRenewalItemMessage({
+        subscriptionId: 'destroyed-suspended-sub',
+        userId: 'destroyed-suspended-user',
+        renewalBoundary: renewalAt,
+      }),
+      1
+    );
+
+    expect(summary.credit_renewals).toBe(1);
+    expect(summary.errors).toBe(0);
+    expect(kiloclawFetch).not.toHaveBeenCalled();
+    expect(txUpdates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: 'active',
+          past_due_since: null,
+          credit_renewal_at: '2026-05-09T10:00:00.000Z',
+        }),
+        expect.objectContaining({
+          suspended_at: null,
+          destruction_deadline: null,
+          auto_resume_requested_at: null,
+          auto_resume_retry_after: null,
+          auto_resume_attempt_count: 0,
+        }),
+      ])
+    );
+  });
+
+  it('skips detached rows in personal credit renewal item processing', async () => {
+    const renewalAt = '2026-04-09T10:00:00.000Z';
+    const { db, txInserts, txUpdates } = createMockDb([
+      [
+        creditRenewalRow({
+          id: 'detached-renew-sub',
+          instance_id: null,
+          credit_renewal_at: renewalAt,
+          current_period_end: renewalAt,
+        }),
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetch);
+
+    const summary = await processCreditRenewalItem(
+      createEnv(vi.fn()),
+      creditRenewalItemMessage({
+        subscriptionId: 'detached-renew-sub',
+        renewalBoundary: renewalAt,
+      }),
+      1
+    );
+
+    expect(summary.credit_renewals).toBe(0);
+    expect(summary.credit_renewals_skipped_duplicate).toBe(0);
+    expect(summary.errors).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(txInserts).toHaveLength(0);
+    expect(txUpdates).toHaveLength(0);
+  });
+
+  it('skips rows whose linked instance record is missing in credit renewal item processing', async () => {
+    const renewalAt = '2026-04-09T10:00:00.000Z';
+    const { db, txInserts, txUpdates } = createMockDb([
+      [
+        creditRenewalRow({
+          id: 'missing-instance-renew-sub',
+          instance_row_id: null,
+          credit_renewal_at: renewalAt,
+          current_period_end: renewalAt,
+        }),
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetch);
+
+    const summary = await processCreditRenewalItem(
+      createEnv(vi.fn()),
+      creditRenewalItemMessage({
+        subscriptionId: 'missing-instance-renew-sub',
+        renewalBoundary: renewalAt,
+      }),
+      1
+    );
+
+    expect(summary.credit_renewals).toBe(0);
+    expect(summary.credit_renewals_skipped_duplicate).toBe(0);
+    expect(summary.errors).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(txInserts).toHaveLength(0);
+    expect(txUpdates).toHaveLength(0);
   });
 
   it('skips organization-managed rows in personal credit renewal item processing', async () => {

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1460,13 +1460,6 @@ async function processCreditRenewalRow(
       return { kind: 'skipped' } satisfies CreditRenewalTransactionOutcome;
     }
 
-    if (current.instance_destroyed_at) {
-      logSkippedSubscriptionRow('Skipping credit renewal for destroyed instance row', current, {
-        reason: 'instance_destroyed',
-      });
-      return { kind: 'skipped' } satisfies CreditRenewalTransactionOutcome;
-    }
-
     const userId = current.user_id;
     if (current.cancel_at_period_end) {
       const before = await getSubscriptionById(tx, current.id);


### PR DESCRIPTION
## Summary
Keep pure-credit KiloClaw subscriptions renewing after linked instance destruction when subscription remains current and uncanceled.

### Why this change is needed
Production renewal items kept rediscovering active credit-funded rows tied to destroyed instances, then skipping them instead of charging and advancing billing periods. That conflicted with KiloClaw destroy/reprovision semantics: instance destruction preserves subscription entitlement until explicit cancellation.

### How this is addressed
- Align lifecycle spec text so destroyed instance markers alone do not make otherwise renewable personal credit subscriptions ineligible.
- Remove destroyed-instance skip from credit renewal row processing while preserving detached, missing-instance, organization-managed, Stripe-funded, and hybrid guards.
- Cover destroyed active renewal, destroyed `cancel_at_period_end`, destroyed suspended past-due renewal without platform restart, and retained malformed-row skips.

## Human Verification
- Confirmed governing KiloClaw billing, lifecycle, and data model specs align destruction with preserved subscription entitlement.
- Verified focused billing lifecycle behavior with `pnpm --filter kiloclaw-billing test -- src/lifecycle.test.ts`.

## Reviewer Notes
### Human Reviewer Flags
- Supplemental lifecycle spec changes reconcile prior generic “destroyed row” skip language with existing KiloClaw billing/reprovision contract.
- Auto-resume remains live-instance-gated; renewal succeeds for destroyed suspended rows without issuing platform restart calls.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Core code change is removal of destroyed-instance early return inside `processCreditRenewalRow(...)`; subscription cancellation still runs before any deduction.
- Detached and missing-instance rows stay fail-closed because they lack trustworthy billing anchors; tests keep those skip paths explicit.
- Validation also included `pnpm --filter kiloclaw-billing typecheck` and `pnpm --filter kiloclaw-billing lint` locally.

</details>
