### PR TITLE
fix(ai-gateway): log upstream transport failures safely

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -178,36 +178,40 @@ export async function upstreamRequest({
       signal: combinedSignal,
     });
   } catch (error) {
-    const cause = error instanceof Error ? error.cause : undefined;
-    const errorName = getErrorName(error);
-    const errorMessage = getErrorMessage(error);
-    const causeCode = getCauseCode(cause);
-    const causeName = getCauseName(cause);
-    const causeMessage = getCauseMessage(cause);
-    const failureFamily = classifyUpstreamFetchFailure({ errorName, causeCode, causeName });
-    const failureMetadata = {
-      providerId: provider.id,
-      targetHost: getProviderTargetHost(provider.apiUrl),
-      path,
-      failureFamily,
-      errorName,
-      errorMessage,
-      ...(causeCode && { causeCode }),
-      ...(causeName && { causeName }),
-      ...(causeMessage && { causeMessage }),
-    };
+    try {
+      const cause = error instanceof Error ? error.cause : undefined;
+      const errorName = getErrorName(error);
+      const errorMessage = getErrorMessage(error);
+      const causeCode = getCauseCode(cause);
+      const causeName = getCauseName(cause);
+      const causeMessage = getCauseMessage(cause);
+      const failureFamily = classifyUpstreamFetchFailure({ errorName, causeCode, causeName });
+      const failureMetadata = {
+        providerId: provider.id,
+        targetHost: getProviderTargetHost(provider.apiUrl),
+        path,
+        failureFamily,
+        errorName,
+        errorMessage,
+        ...(causeCode && { causeCode }),
+        ...(causeName && { causeName }),
+        ...(causeMessage && { causeMessage }),
+      };
 
-    if (!(failureFamily === 'abort' && signal?.aborted)) {
-      errorExceptInTest('AI gateway upstream fetch failed', failureMetadata);
-      captureException(createLoggedFetchFailure(errorName, errorMessage), {
-        level: 'error',
-        tags: {
-          source: 'ai-gateway-upstream-fetch',
-          provider: provider.id,
-          failure_family: failureFamily,
-        },
-        extra: failureMetadata,
-      });
+      if (!(failureFamily === 'abort' && signal?.aborted)) {
+        errorExceptInTest('AI gateway upstream fetch failed', failureMetadata);
+        captureException(createLoggedFetchFailure(errorName, errorMessage), {
+          level: 'error',
+          tags: {
+            source: 'ai-gateway-upstream-fetch',
+            provider: provider.id,
+            failure_family: failureFamily,
+          },
+          extra: failureMetadata,
+        });
+      }
+    } catch {
+      // Fetch failure must remain caller-visible even when diagnostic enrichment fails.
     }
 
     throw error;

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -1,6 +1,7 @@
 import { debugSaveProxyResponseStream } from '../../debugUtils';
 import { fetchWithBackoff } from '../../fetchWithBackoff';
 import { captureException, captureMessage } from '@sentry/nextjs';
+import { errorExceptInTest } from '@/lib/utils.server';
 import type {
   GatewayResponsesRequest,
   OpenRouterChatCompletionRequest,
@@ -9,6 +10,113 @@ import type {
 } from '@/lib/ai-gateway/providers/openrouter/types';
 import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attribution-headers';
 import type { Provider } from '@/lib/ai-gateway/providers/types';
+
+type UpstreamFetchFailureFamily =
+  | 'headers_timeout'
+  | 'connect_timeout'
+  | 'read_timeout'
+  | 'conn_reset'
+  | 'abort'
+  | 'unknown';
+
+function getProviderTargetHost(apiUrl: string): string {
+  try {
+    return new URL(apiUrl).host;
+  } catch {
+    return 'invalid_provider_api_url';
+  }
+}
+
+function getErrorName(error: unknown): string {
+  if (error instanceof Error) return error.name;
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    typeof error.name === 'string'
+  ) {
+    return error.name;
+  }
+  return 'UnknownError';
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return error.message;
+  }
+  return 'Unknown upstream fetch error';
+}
+
+function getCauseCode(cause: unknown): string | undefined {
+  if (
+    typeof cause === 'object' &&
+    cause !== null &&
+    'code' in cause &&
+    (typeof cause.code === 'string' || typeof cause.code === 'number')
+  ) {
+    return String(cause.code);
+  }
+  return undefined;
+}
+
+function getCauseName(cause: unknown): string | undefined {
+  if (cause instanceof Error) return cause.name;
+  if (
+    typeof cause === 'object' &&
+    cause !== null &&
+    'name' in cause &&
+    typeof cause.name === 'string'
+  ) {
+    return cause.name;
+  }
+  return undefined;
+}
+
+function getCauseMessage(cause: unknown): string | undefined {
+  if (cause instanceof Error) return cause.message;
+  if (
+    typeof cause === 'object' &&
+    cause !== null &&
+    'message' in cause &&
+    typeof cause.message === 'string'
+  ) {
+    return cause.message;
+  }
+  return undefined;
+}
+
+function classifyUpstreamFetchFailure({
+  errorName,
+  causeCode,
+  causeName,
+}: {
+  errorName: string;
+  causeCode: string | undefined;
+  causeName: string | undefined;
+}): UpstreamFetchFailureFamily {
+  if (errorName === 'AbortError' || causeName === 'AbortError' || causeCode === 'ABORT_ERR') {
+    return 'abort';
+  }
+
+  switch (causeCode) {
+    case 'UND_ERR_HEADERS_TIMEOUT':
+      return 'headers_timeout';
+    case 'UND_ERR_CONNECT_TIMEOUT':
+      return 'connect_timeout';
+    case 'UND_ERR_BODY_TIMEOUT':
+      return 'read_timeout';
+    case 'ECONNRESET':
+      return 'conn_reset';
+    default:
+      return 'unknown';
+  }
+}
 
 export async function upstreamRequest({
   path,
@@ -44,14 +152,48 @@ export async function upstreamRequest({
   const timeoutSignal = AbortSignal.timeout(TEN_MINUTES_MS);
   const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 
-  return await fetch(targetUrl, {
-    method,
-    headers,
-    body: JSON.stringify(body),
-    // @ts-expect-error see https://github.com/node-fetch/node-fetch/issues/1769
-    duplex: 'half',
-    signal: combinedSignal,
-  });
+  try {
+    return await fetch(targetUrl, {
+      method,
+      headers,
+      body: JSON.stringify(body),
+      // @ts-expect-error see https://github.com/node-fetch/node-fetch/issues/1769
+      duplex: 'half',
+      signal: combinedSignal,
+    });
+  } catch (error) {
+    const cause = error instanceof Error ? error.cause : undefined;
+    const errorName = getErrorName(error);
+    const errorMessage = getErrorMessage(error);
+    const causeCode = getCauseCode(cause);
+    const causeName = getCauseName(cause);
+    const causeMessage = getCauseMessage(cause);
+    const failureFamily = classifyUpstreamFetchFailure({ errorName, causeCode, causeName });
+    const failureMetadata = {
+      providerId: provider.id,
+      targetHost: getProviderTargetHost(provider.apiUrl),
+      path,
+      failureFamily,
+      errorName,
+      errorMessage,
+      ...(causeCode && { causeCode }),
+      ...(causeName && { causeName }),
+      ...(causeMessage && { causeMessage }),
+    };
+
+    errorExceptInTest('AI gateway upstream fetch failed', failureMetadata);
+    captureException(error, {
+      level: 'error',
+      tags: {
+        source: 'ai-gateway-upstream-fetch',
+        provider: provider.id,
+        failure_family: failureFamily,
+      },
+      extra: failureMetadata,
+    });
+
+    throw error;
+  }
 }
 
 export async function fetchGeneration(messageId: string, provider: Provider) {

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -125,6 +125,7 @@ function classifyUpstreamFetchFailure({
     case 'UND_ERR_CONNECT_TIMEOUT':
       return 'connect_timeout';
     case 'UND_ERR_BODY_TIMEOUT':
+    case 'ETIMEDOUT':
       return 'read_timeout';
     case 'ECONNRESET':
       return 'conn_reset';

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -12,6 +12,7 @@ import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attri
 import type { Provider } from '@/lib/ai-gateway/providers/types';
 
 type UpstreamFetchFailureFamily =
+  | 'request_timeout'
   | 'headers_timeout'
   | 'connect_timeout'
   | 'read_timeout'
@@ -40,15 +41,19 @@ function getErrorName(error: unknown): string {
   return 'UnknownError';
 }
 
+function redactUrlsFromErrorMessage(message: string): string {
+  return message.replace(/https?:\/\/[^\s)]+/g, '[redacted-url]');
+}
+
 function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
+  if (error instanceof Error) return redactUrlsFromErrorMessage(error.message);
   if (
     typeof error === 'object' &&
     error !== null &&
     'message' in error &&
     typeof error.message === 'string'
   ) {
-    return error.message;
+    return redactUrlsFromErrorMessage(error.message);
   }
   return 'Unknown upstream fetch error';
 }
@@ -79,16 +84,22 @@ function getCauseName(cause: unknown): string | undefined {
 }
 
 function getCauseMessage(cause: unknown): string | undefined {
-  if (cause instanceof Error) return cause.message;
+  if (cause instanceof Error) return redactUrlsFromErrorMessage(cause.message);
   if (
     typeof cause === 'object' &&
     cause !== null &&
     'message' in cause &&
     typeof cause.message === 'string'
   ) {
-    return cause.message;
+    return redactUrlsFromErrorMessage(cause.message);
   }
   return undefined;
+}
+
+function createLoggedFetchFailure(errorName: string, errorMessage: string): Error {
+  const loggedError = new Error(errorMessage);
+  loggedError.name = errorName;
+  return loggedError;
 }
 
 function classifyUpstreamFetchFailure({
@@ -100,6 +111,10 @@ function classifyUpstreamFetchFailure({
   causeCode: string | undefined;
   causeName: string | undefined;
 }): UpstreamFetchFailureFamily {
+  if (errorName === 'TimeoutError' || causeName === 'TimeoutError') {
+    return 'request_timeout';
+  }
+
   if (errorName === 'AbortError' || causeName === 'AbortError' || causeCode === 'ABORT_ERR') {
     return 'abort';
   }
@@ -181,16 +196,18 @@ export async function upstreamRequest({
       ...(causeMessage && { causeMessage }),
     };
 
-    errorExceptInTest('AI gateway upstream fetch failed', failureMetadata);
-    captureException(error, {
-      level: 'error',
-      tags: {
-        source: 'ai-gateway-upstream-fetch',
-        provider: provider.id,
-        failure_family: failureFamily,
-      },
-      extra: failureMetadata,
-    });
+    if (!(failureFamily === 'abort' && signal?.aborted)) {
+      errorExceptInTest('AI gateway upstream fetch failed', failureMetadata);
+      captureException(createLoggedFetchFailure(errorName, errorMessage), {
+        level: 'error',
+        tags: {
+          source: 'ai-gateway-upstream-fetch',
+          provider: provider.id,
+          failure_family: failureFamily,
+        },
+        extra: failureMetadata,
+      });
+    }
 
     throw error;
   }

--- a/apps/web/src/tests/openrouterApi.timeout.test.ts
+++ b/apps/web/src/tests/openrouterApi.timeout.test.ts
@@ -1,15 +1,27 @@
+import { captureException } from '@sentry/nextjs';
 import { upstreamRequest } from '../lib/ai-gateway/providers/upstream-request';
 import PROVIDERS from '../lib/ai-gateway/providers/provider-definitions';
 
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+const mockCaptureException = jest.mocked(captureException);
+const originalFetch = global.fetch;
+
 describe('upstreamRequest timeout', () => {
+  beforeEach(() => {
+    mockCaptureException.mockReset();
+    global.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
   it('should abort after timeout', async () => {
-    // Use a very short timeout for testing by temporarily modifying the function
-    // For a quick manual test, we can verify the signal is properly combined
-
     const controller = new AbortController();
-
-    // This test verifies that the request respects the abort signal
-    // by immediately aborting and checking the error
     controller.abort();
 
     await expect(
@@ -26,5 +38,63 @@ describe('upstreamRequest timeout', () => {
         signal: controller.signal,
       })
     ).rejects.toThrow();
+  });
+
+  it('rethrows provider fetch failures and captures safe timeout metadata', async () => {
+    const timeoutCause = Object.assign(new Error('Headers Timeout Error'), {
+      code: 'UND_ERR_HEADERS_TIMEOUT',
+      name: 'HeadersTimeoutError',
+    });
+    const fetchError = new TypeError('fetch failed', { cause: timeoutCause });
+    const mockFetch = jest.fn().mockRejectedValue(fetchError);
+    global.fetch = mockFetch;
+
+    await expect(
+      upstreamRequest({
+        path: '/chat/completions',
+        search: '?trace=search-secret',
+        method: 'POST',
+        body: {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'body-secret-content' }],
+        },
+        extraHeaders: { 'x-safe-extra-header': 'extra-header-secret' },
+        provider: {
+          ...PROVIDERS.OPENROUTER,
+          apiUrl: 'https://gateway.example.test/v1?token=url-secret',
+          apiKey: 'provider-api-key-secret',
+        },
+      })
+    ).rejects.toBe(fetchError);
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      fetchError,
+      expect.objectContaining({
+        level: 'error',
+        tags: {
+          source: 'ai-gateway-upstream-fetch',
+          provider: 'openrouter',
+          failure_family: 'headers_timeout',
+        },
+        extra: {
+          providerId: 'openrouter',
+          targetHost: 'gateway.example.test',
+          path: '/chat/completions',
+          failureFamily: 'headers_timeout',
+          errorName: 'TypeError',
+          errorMessage: 'fetch failed',
+          causeCode: 'UND_ERR_HEADERS_TIMEOUT',
+          causeName: 'HeadersTimeoutError',
+          causeMessage: 'Headers Timeout Error',
+        },
+      })
+    );
+
+    const capturedOptions = JSON.stringify(mockCaptureException.mock.calls[0]?.[1]);
+    expect(capturedOptions).not.toContain('provider-api-key-secret');
+    expect(capturedOptions).not.toContain('url-secret');
+    expect(capturedOptions).not.toContain('search-secret');
+    expect(capturedOptions).not.toContain('body-secret-content');
+    expect(capturedOptions).not.toContain('extra-header-secret');
   });
 });

--- a/apps/web/src/tests/openrouterApi.timeout.test.ts
+++ b/apps/web/src/tests/openrouterApi.timeout.test.ts
@@ -131,6 +131,43 @@ describe('upstreamRequest timeout', () => {
     expect(capturedOptions).not.toContain('body-secret-content');
   });
 
+  it('classifies ETIMEDOUT transport failures as read timeouts', async () => {
+    const timeoutCause = Object.assign(new Error('socket read timed out'), {
+      code: 'ETIMEDOUT',
+      name: 'SocketTimeoutError',
+    });
+    const fetchError = new TypeError('fetch failed', { cause: timeoutCause });
+    const mockFetch = jest.fn().mockRejectedValue(fetchError);
+    global.fetch = mockFetch;
+
+    await expect(
+      upstreamRequest({
+        path: '/chat/completions',
+        search: '',
+        method: 'POST',
+        body: {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'test' }],
+        },
+        extraHeaders: {},
+        provider: PROVIDERS.OPENROUTER,
+      })
+    ).rejects.toBe(fetchError);
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'TypeError', message: 'fetch failed' }),
+      expect.objectContaining({
+        tags: expect.objectContaining({ failure_family: 'read_timeout' }),
+        extra: expect.objectContaining({
+          failureFamily: 'read_timeout',
+          causeCode: 'ETIMEDOUT',
+          causeName: 'SocketTimeoutError',
+          causeMessage: 'socket read timed out',
+        }),
+      })
+    );
+  });
+
   it('rethrows provider fetch failures and captures safe timeout metadata', async () => {
     const timeoutCause = Object.assign(new Error('Headers Timeout Error'), {
       code: 'UND_ERR_HEADERS_TIMEOUT',

--- a/apps/web/src/tests/openrouterApi.timeout.test.ts
+++ b/apps/web/src/tests/openrouterApi.timeout.test.ts
@@ -38,6 +38,97 @@ describe('upstreamRequest timeout', () => {
         signal: controller.signal,
       })
     ).rejects.toThrow();
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('classifies request timeout aborts separately', async () => {
+    const timeoutError = new DOMException(
+      'The operation was aborted due to timeout',
+      'TimeoutError'
+    );
+    const mockFetch = jest.fn().mockRejectedValue(timeoutError);
+    global.fetch = mockFetch;
+
+    await expect(
+      upstreamRequest({
+        path: '/chat/completions',
+        search: '',
+        method: 'POST',
+        body: {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'test' }],
+        },
+        extraHeaders: {},
+        provider: PROVIDERS.OPENROUTER,
+      })
+    ).rejects.toBe(timeoutError);
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'TimeoutError',
+        message: 'The operation was aborted due to timeout',
+      }),
+      expect.objectContaining({
+        tags: expect.objectContaining({ failure_family: 'request_timeout' }),
+        extra: expect.objectContaining({ failureFamily: 'request_timeout' }),
+      })
+    );
+  });
+
+  it('redacts URLs from captured fetch and cause messages', async () => {
+    const resetCause = Object.assign(
+      new Error('socket reset at https://gateway.example.test/v1?cause=cause-secret'),
+      {
+        code: 'ECONNRESET',
+        name: 'SocketResetError',
+      }
+    );
+    const fetchError = new TypeError(
+      'fetch failed for https://gateway.example.test/v1?error=error-secret',
+      { cause: resetCause }
+    );
+    const mockFetch = jest.fn().mockRejectedValue(fetchError);
+    global.fetch = mockFetch;
+
+    await expect(
+      upstreamRequest({
+        path: '/chat/completions',
+        search: '?trace=search-secret',
+        method: 'POST',
+        body: {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'body-secret-content' }],
+        },
+        extraHeaders: {},
+        provider: {
+          ...PROVIDERS.OPENROUTER,
+          apiUrl: 'https://gateway.example.test/v1?token=url-secret',
+        },
+      })
+    ).rejects.toBe(fetchError);
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'TypeError',
+        message: 'fetch failed for [redacted-url]',
+      }),
+      expect.objectContaining({
+        tags: expect.objectContaining({ failure_family: 'conn_reset' }),
+        extra: expect.objectContaining({
+          failureFamily: 'conn_reset',
+          errorMessage: 'fetch failed for [redacted-url]',
+          causeMessage: 'socket reset at [redacted-url]',
+        }),
+      })
+    );
+
+    const capturedOptions = JSON.stringify(mockCaptureException.mock.calls[0]?.[1]);
+    expect(capturedOptions).not.toContain('cause-secret');
+    expect(capturedOptions).not.toContain('error-secret');
+    expect(capturedOptions).not.toContain('url-secret');
+    expect(capturedOptions).not.toContain('search-secret');
+    expect(capturedOptions).not.toContain('body-secret-content');
   });
 
   it('rethrows provider fetch failures and captures safe timeout metadata', async () => {
@@ -68,15 +159,15 @@ describe('upstreamRequest timeout', () => {
     ).rejects.toBe(fetchError);
 
     expect(mockCaptureException).toHaveBeenCalledWith(
-      fetchError,
+      expect.objectContaining({ name: 'TypeError', message: 'fetch failed' }),
       expect.objectContaining({
         level: 'error',
-        tags: {
+        tags: expect.objectContaining({
           source: 'ai-gateway-upstream-fetch',
           provider: 'openrouter',
           failure_family: 'headers_timeout',
-        },
-        extra: {
+        }),
+        extra: expect.objectContaining({
           providerId: 'openrouter',
           targetHost: 'gateway.example.test',
           path: '/chat/completions',
@@ -86,7 +177,7 @@ describe('upstreamRequest timeout', () => {
           causeCode: 'UND_ERR_HEADERS_TIMEOUT',
           causeName: 'HeadersTimeoutError',
           causeMessage: 'Headers Timeout Error',
-        },
+        }),
       })
     );
 

--- a/apps/web/src/tests/openrouterApi.timeout.test.ts
+++ b/apps/web/src/tests/openrouterApi.timeout.test.ts
@@ -76,6 +76,33 @@ describe('upstreamRequest timeout', () => {
     );
   });
 
+  it('preserves fetch failures when diagnostic enrichment throws', async () => {
+    const fetchError = new TypeError('fetch failed');
+    Object.defineProperty(fetchError, 'cause', {
+      get() {
+        throw new Error('cause getter failed');
+      },
+    });
+    const mockFetch = jest.fn().mockRejectedValue(fetchError);
+    global.fetch = mockFetch;
+
+    await expect(
+      upstreamRequest({
+        path: '/chat/completions',
+        search: '',
+        method: 'POST',
+        body: {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'test' }],
+        },
+        extraHeaders: {},
+        provider: PROVIDERS.OPENROUTER,
+      })
+    ).rejects.toBe(fetchError);
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
   it('redacts URLs from captured fetch and cause messages', async () => {
     const resetCause = Object.assign(
       new Error('socket reset at https://gateway.example.test/v1?cause=cause-secret'),


### PR DESCRIPTION
## Summary
- Add safe upstream fetch failure instrumentation so transport incidents identify provider, target host, path, and failure family.
- Preserve existing request behavior by rethrowing original fetch errors unchanged.
- Add regression coverage for timeout-shaped failures and confirm secrets/body data stay out of emitted metadata.

## Verification
- Not manually verified.

## Visual Changes
N/A

## Reviewer Notes
- Failure-family mapping intentionally stays narrow and deterministic; unknown runtime shapes fall back to `unknown`.
- Automated check run in workspace: `pnpm test -- apps/web/src/tests/openrouterApi.timeout.test.ts --runInBand`.