### PR TITLE
fix(code-reviews): retry transient wrapper startup failures

### DIFF
--- a/services/cloud-agent-next/src/logger.ts
+++ b/services/cloud-agent-next/src/logger.ts
@@ -8,6 +8,7 @@ export type CloudAgentTags = {
   sessionId?: string;
   userId?: string;
   sandboxId?: string;
+  sandboxKind?: 'bot' | 'user';
   orgId?: string;
   executionId?: string;
   botId?: string;

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -215,11 +215,7 @@ function classifyPrepareSessionWorkspaceFailure(
     return 'configured_session_lookup_failure';
   }
 
-  if (
-    message.includes(
-      'failed to start kilo server: timeout waiting for server to start after 30000ms'
-    )
-  ) {
+  if (message.includes('failed to start kilo server: timeout waiting for server to start')) {
     return 'wrapper_kilo_server_start_timeout';
   }
 

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -190,6 +190,75 @@ function setCollectionUpdate<T>(
   updates[key] = isEmpty(value) ? null : value;
 }
 
+type PrepareSessionWorkspaceFailureCategory =
+  | 'sandbox_api_or_storage_failure'
+  | 'wrapper_wait_for_port_timeout'
+  | 'wrapper_kilo_server_start_timeout'
+  | 'configured_session_lookup_failure'
+  | 'repo_clone_or_checkout_failure'
+  | 'other_workspace_preparation_failure';
+
+function prepareSessionErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function classifyPrepareSessionWorkspaceFailure(
+  error: unknown,
+  sandboxInternalServerError: boolean
+): PrepareSessionWorkspaceFailureCategory {
+  const message = prepareSessionErrorMessage(error).toLowerCase();
+
+  if (
+    message.includes('configured session') &&
+    message.includes('not found: session get returned no data')
+  ) {
+    return 'configured_session_lookup_failure';
+  }
+
+  if (
+    message.includes(
+      'failed to start kilo server: timeout waiting for server to start after 30000ms'
+    )
+  ) {
+    return 'wrapper_kilo_server_start_timeout';
+  }
+
+  if (
+    message.includes('wrapper did not become ready on port') &&
+    message.includes('waitforport timed out')
+  ) {
+    return 'wrapper_wait_for_port_timeout';
+  }
+
+  if (
+    message.includes('git clone timed out') ||
+    message.includes('failed to checkout pull ref') ||
+    message.includes('git-lfs filter-process') ||
+    message.includes('object does not exist on the server')
+  ) {
+    return 'repo_clone_or_checkout_failure';
+  }
+
+  if (
+    sandboxInternalServerError ||
+    message.includes('internal error in durable object storage') ||
+    message.includes('durable object storage operation exceeded timeout')
+  ) {
+    return 'sandbox_api_or_storage_failure';
+  }
+
+  return 'other_workspace_preparation_failure';
+}
+
+function isRetryableWrapperReadinessFailure(
+  failureCategory: PrepareSessionWorkspaceFailureCategory
+): boolean {
+  return (
+    failureCategory === 'wrapper_wait_for_port_timeout' ||
+    failureCategory === 'wrapper_kilo_server_start_timeout'
+  );
+}
+
 /**
  * Creates session preparation handlers.
  * These handlers are protected by internal API authentication (backend-to-backend).
@@ -249,6 +318,8 @@ const prepareSessionHandler = internalApiProtectedProcedure
         userId: ctx.userId,
         orgId: input.kilocodeOrganizationId ?? '(personal)',
         sandboxId,
+        botId: ctx.botId,
+        sandboxKind: ctx.botId ? 'bot' : 'user',
       });
       logger.info('Preparing new session with workspace setup');
 
@@ -622,6 +693,20 @@ const prepareSessionHandler = internalApiProtectedProcedure
         preparedWorkspace = await prepareWorkspace();
       } catch (error) {
         const sandboxInternalServerError = isSandboxInternalServerError(error);
+        const failureCategory = classifyPrepareSessionWorkspaceFailure(
+          error,
+          sandboxInternalServerError
+        );
+        logger
+          .withFields({
+            error: prepareSessionErrorMessage(error),
+            failureCategory,
+            retryableSandboxInternalServerError: sandboxInternalServerError,
+            retryableWrapperReadinessFailure: isRetryableWrapperReadinessFailure(failureCategory),
+            sandboxKind: ctx.botId ? 'bot' : 'user',
+            logTag: 'prepare_session_workspace_preparation_failed',
+          })
+          .error('prepareSession workspace preparation failed');
         await destroySandboxAfterInternalServerError(
           {
             sandbox,
@@ -683,7 +768,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
       const doId = ctx.env.CLOUD_AGENT_SESSION.idFromName(`${ctx.userId}:${cloudAgentSessionId}`);
       const stub = ctx.env.CLOUD_AGENT_SESSION.get(doId);
 
-      let prepareResult;
+      let prepareResult: Awaited<ReturnType<typeof stub.prepare>>;
       try {
         prepareResult = await stub.prepare({
           sessionId: cloudAgentSessionId,

--- a/services/code-review-infra/src/code-review-orchestrator.ts
+++ b/services/code-review-infra/src/code-review-orchestrator.ts
@@ -189,6 +189,20 @@ function classifyCloudAgentNextFreshSessionRetry(
     );
   }
 
+  if (
+    body.includes('git clone timed out') ||
+    body.includes('failed to checkout pull ref') ||
+    body.includes('git-lfs filter-process') ||
+    body.includes('object does not exist on the server')
+  ) {
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      false,
+      'repo_clone_or_checkout_failure',
+      'repo_clone_or_checkout_not_retryable'
+    );
+  }
+
   const parsedBody = parseJsonBody(error.body);
   if (hasRetryableSandboxMarker(parsedBody)) {
     return cloudAgentNextFreshRetryClassification(
@@ -199,9 +213,7 @@ function classifyCloudAgentNextFreshSessionRetry(
     );
   }
 
-  if (
-    body.includes('failed to start kilo server: timeout waiting for server to start after 30000ms')
-  ) {
+  if (body.includes('failed to start kilo server: timeout waiting for server to start')) {
     return cloudAgentNextFreshRetryClassification(
       error,
       true,
@@ -241,20 +253,6 @@ function classifyCloudAgentNextFreshSessionRetry(
       true,
       'sandbox_api_or_storage_failure',
       'sandbox_5xx_body_signal'
-    );
-  }
-
-  if (
-    body.includes('git clone timed out') ||
-    body.includes('failed to checkout pull ref') ||
-    body.includes('git-lfs filter-process') ||
-    body.includes('object does not exist on the server')
-  ) {
-    return cloudAgentNextFreshRetryClassification(
-      error,
-      false,
-      'repo_clone_or_checkout_failure',
-      'repo_clone_or_checkout_not_retryable'
     );
   }
 

--- a/services/code-review-infra/src/code-review-orchestrator.ts
+++ b/services/code-review-infra/src/code-review-orchestrator.ts
@@ -113,29 +113,115 @@ function isTerminalStatus(status: CodeReviewStatus): boolean {
   return status === 'completed' || status === 'failed' || status === 'cancelled';
 }
 
-function isCloudAgentNextSandboxInternalServerError(error: unknown): boolean {
+type CloudAgentNextFreshRetryFailureCategory =
+  | 'billing'
+  | 'not_cloud_agent_next_error'
+  | 'non_5xx'
+  | 'cancelled'
+  | 'sandbox_api_or_storage_failure'
+  | 'wrapper_wait_for_port_timeout'
+  | 'wrapper_kilo_server_start_timeout'
+  | 'configured_session_lookup_failure'
+  | 'repo_clone_or_checkout_failure'
+  | 'other_5xx';
+
+type CloudAgentNextFreshRetryClassification = {
+  retryable: boolean;
+  failureCategory: CloudAgentNextFreshRetryFailureCategory;
+  retryClassificationReason: string;
+  retryableWrapperReadinessFailure: boolean;
+  cloudAgentNextProcedure?: string;
+  cloudAgentNextStatus?: number;
+};
+
+function cloudAgentNextFreshRetryClassification(
+  error: CloudAgentNextError | undefined,
+  retryable: boolean,
+  failureCategory: CloudAgentNextFreshRetryFailureCategory,
+  retryClassificationReason: string
+): CloudAgentNextFreshRetryClassification {
+  return {
+    retryable,
+    failureCategory,
+    retryClassificationReason,
+    retryableWrapperReadinessFailure:
+      failureCategory === 'wrapper_wait_for_port_timeout' ||
+      failureCategory === 'wrapper_kilo_server_start_timeout',
+    cloudAgentNextProcedure: error?.procedure,
+    cloudAgentNextStatus: error?.status,
+  };
+}
+
+function classifyCloudAgentNextFreshSessionRetry(
+  error: unknown
+): CloudAgentNextFreshRetryClassification {
   if (error instanceof CloudAgentNextBillingError) {
-    return false;
+    return cloudAgentNextFreshRetryClassification(error, false, 'billing', 'billing_protected');
   }
 
   if (!(error instanceof CloudAgentNextError)) {
-    return false;
+    return cloudAgentNextFreshRetryClassification(
+      undefined,
+      false,
+      'not_cloud_agent_next_error',
+      'not_cloud_agent_next_error'
+    );
   }
 
   if (error.status < 500 || error.status >= 600) {
-    return false;
+    return cloudAgentNextFreshRetryClassification(error, false, 'non_5xx', 'non_5xx');
   }
 
   if (/\b(cancelled|canceled)\b/i.test(error.body)) {
-    return false;
+    return cloudAgentNextFreshRetryClassification(error, false, 'cancelled', 'cancelled_protected');
+  }
+
+  const body = error.body.toLowerCase();
+  if (
+    body.includes('configured session') &&
+    body.includes('not found: session get returned no data')
+  ) {
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      false,
+      'configured_session_lookup_failure',
+      'configured_session_lookup_not_retryable'
+    );
   }
 
   const parsedBody = parseJsonBody(error.body);
   if (hasRetryableSandboxMarker(parsedBody)) {
-    return true;
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      true,
+      'sandbox_api_or_storage_failure',
+      'sandbox_retryable_marker'
+    );
   }
 
-  const body = error.body.toLowerCase();
+  if (
+    body.includes('failed to start kilo server: timeout waiting for server to start after 30000ms')
+  ) {
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      true,
+      'wrapper_kilo_server_start_timeout',
+      'wrapper_kilo_server_start_timeout'
+    );
+  }
+
+  if (
+    body.includes('wrapper did not become ready on port') &&
+    body.includes('waitforport timed out')
+  ) {
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      true,
+      'wrapper_wait_for_port_timeout',
+      'wrapper_wait_for_port_timeout'
+    );
+  }
+
   const hasSandboxSignal =
     body.includes('sandboxerror') ||
     body.includes('sandbox') ||
@@ -149,7 +235,42 @@ function isCloudAgentNextSandboxInternalServerError(error: unknown): boolean {
     /\bhttp\s*500\b/i.test(error.body) ||
     /\b500\b/.test(error.body);
 
-  return hasSandboxSignal && hasInternalServerSignal;
+  if (hasSandboxSignal && hasInternalServerSignal) {
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      true,
+      'sandbox_api_or_storage_failure',
+      'sandbox_5xx_body_signal'
+    );
+  }
+
+  if (
+    body.includes('git clone timed out') ||
+    body.includes('failed to checkout pull ref') ||
+    body.includes('git-lfs filter-process') ||
+    body.includes('object does not exist on the server')
+  ) {
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      false,
+      'repo_clone_or_checkout_failure',
+      'repo_clone_or_checkout_not_retryable'
+    );
+  }
+
+  if (
+    body.includes('internal error in durable object storage') ||
+    body.includes('durable object storage operation exceeded timeout')
+  ) {
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      false,
+      'sandbox_api_or_storage_failure',
+      'storage_failure_not_retryable_by_code_review_classifier'
+    );
+  }
+
+  return cloudAgentNextFreshRetryClassification(error, false, 'other_5xx', 'unclassified_5xx');
 }
 
 /**
@@ -196,15 +317,59 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
     return this.cloudAgentNextClient;
   }
 
+  private logCloudAgentNextFreshSessionRetrySkipped(
+    source: string,
+    error: unknown,
+    classification: CloudAgentNextFreshRetryClassification,
+    retrySkipReason = classification.retryClassificationReason
+  ): void {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    console.info('[CodeReviewOrchestrator] Fresh session retry skipped', {
+      reviewId: this.state.reviewId,
+      source,
+      error: errorMessage,
+      retryOutcome: 'skipped',
+      retrySkipReason,
+      sandboxRetryAttempted: this.state.sandboxRetryAttempted === true,
+      reviewStatus: this.state.status,
+      cancelled: this.cancelled,
+      ...classification,
+    });
+  }
+
   private async tryRetryFreshSessionAfterSandboxError(
     source: string,
-    error: unknown
+    error: unknown,
+    classification: CloudAgentNextFreshRetryClassification
   ): Promise<boolean> {
-    if (
-      this.state.sandboxRetryAttempted === true ||
-      this.cancelled ||
-      isTerminalStatus(this.state.status)
-    ) {
+    if (this.state.sandboxRetryAttempted === true) {
+      this.logCloudAgentNextFreshSessionRetrySkipped(
+        source,
+        error,
+        classification,
+        'retry_already_attempted'
+      );
+      return false;
+    }
+
+    if (this.cancelled) {
+      this.logCloudAgentNextFreshSessionRetrySkipped(
+        source,
+        error,
+        classification,
+        'review_cancelled'
+      );
+      return false;
+    }
+
+    if (isTerminalStatus(this.state.status)) {
+      this.logCloudAgentNextFreshSessionRetrySkipped(
+        source,
+        error,
+        classification,
+        'review_already_terminal'
+      );
       return false;
     }
 
@@ -223,16 +388,21 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
     this.state.updatedAt = new Date().toISOString();
     await this.saveState();
 
-    console.warn('[CodeReviewOrchestrator] Retrying with a fresh session after sandbox 500', {
-      reviewId: this.state.reviewId,
-      source,
-      error: errorMessage,
-      previousCloudAgentSessionId,
-      previousSessionId,
-      previousCliSessionId,
-      previousSandboxId,
-      sandboxRetryAttempted: true,
-    });
+    console.warn(
+      '[CodeReviewOrchestrator] Retrying with a fresh session after retryable cloud-agent-next failure',
+      {
+        reviewId: this.state.reviewId,
+        source,
+        error: errorMessage,
+        previousCloudAgentSessionId,
+        previousSessionId,
+        previousCliSessionId,
+        previousSandboxId,
+        sandboxRetryAttempted: true,
+        retryOutcome: 'attempted',
+        ...classification,
+      }
+    );
 
     await this.runFreshCloudAgentNextFallback(
       previousCloudAgentSessionId ?? previousSessionId ?? 'unknown'
@@ -1011,9 +1181,16 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
       });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const retryClassification = classifyCloudAgentNextFreshSessionRetry(error);
 
-      if (isCloudAgentNextSandboxInternalServerError(error)) {
-        if (await this.tryRetryFreshSessionAfterSandboxError('cloud-agent-next-fresh', error)) {
+      if (retryClassification.retryable) {
+        if (
+          await this.tryRetryFreshSessionAfterSandboxError(
+            'cloud-agent-next-fresh',
+            error,
+            retryClassification
+          )
+        ) {
           return;
         }
 
@@ -1026,12 +1203,20 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
           terminalReason: 'sandbox_error',
         });
 
-        console.error('[CodeReviewOrchestrator] Review failed after sandbox retry:', {
+        console.error('[CodeReviewOrchestrator] Review failed after fresh-session retry:', {
           reviewId: this.state.reviewId,
           error: errorMessage,
+          retryOutcome: 'exhausted',
+          ...retryClassification,
         });
         return;
       }
+
+      this.logCloudAgentNextFreshSessionRetrySkipped(
+        'cloud-agent-next-fresh',
+        error,
+        retryClassification
+      );
 
       const terminalReason = this.getTerminalReason(error);
 
@@ -1040,6 +1225,7 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
       console.error('[CodeReviewOrchestrator] Review failed (cloud-agent-next):', {
         reviewId: this.state.reviewId,
         error: errorMessage,
+        ...retryClassification,
       });
     } finally {
       const totalExecutionTimeMs = Date.now() - runStartTime;
@@ -1197,9 +1383,16 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
       }
 
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const retryClassification = classifyCloudAgentNextFreshSessionRetry(error);
 
-      if (isCloudAgentNextSandboxInternalServerError(error)) {
-        if (await this.tryRetryFreshSessionAfterSandboxError('cloud-agent-next-followup', error)) {
+      if (retryClassification.retryable) {
+        if (
+          await this.tryRetryFreshSessionAfterSandboxError(
+            'cloud-agent-next-followup',
+            error,
+            retryClassification
+          )
+        ) {
           return;
         }
 
@@ -1212,18 +1405,27 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
           terminalReason: 'sandbox_error',
         });
 
-        console.warn('[CodeReviewOrchestrator] sendMessageV2 sandbox failure after retry', {
+        console.warn('[CodeReviewOrchestrator] sendMessageV2 failure after fresh-session retry', {
           reviewId: this.state.reviewId,
           previousCloudAgentSessionId: previousSessionId,
           error: errorMessage,
+          retryOutcome: 'exhausted',
+          ...retryClassification,
         });
         return;
       }
+
+      this.logCloudAgentNextFreshSessionRetrySkipped(
+        'cloud-agent-next-followup',
+        error,
+        retryClassification
+      );
 
       console.warn('[CodeReviewOrchestrator] sendMessageV2 failed, falling back to fresh session', {
         reviewId: this.state.reviewId,
         previousCloudAgentSessionId: previousSessionId,
         error: errorMessage,
+        ...retryClassification,
       });
 
       // Reset status to running (it may have been set to running already, but ensure clean state)

--- a/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
+++ b/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
@@ -592,7 +592,7 @@ describe('CodeReviewOrchestrator recovery', () => {
         if (prepareCalls === 1) {
           return trpcError(
             500,
-            'Wrapper did not become ready on port 5353 within 30000ms: waitForPort timed out | wrapperFileLog: failed to start kilo server: Timeout waiting for server to start after 30000ms'
+            'Wrapper did not become ready on port 5353 within 30000ms: waitForPort timed out | wrapperFileLog: failed to start kilo server: Timeout waiting for server to start after 45000ms'
           );
         }
         return trpcSuccess({
@@ -765,7 +765,10 @@ describe('CodeReviewOrchestrator recovery', () => {
         return Response.json({ success: true });
       }
       if (url.includes('/trpc/prepareSession')) {
-        return trpcError(500, 'Failed to checkout pull ref: Object does not exist on the server');
+        return trpcError(
+          500,
+          'SandboxError: HTTP error! status: 500 during setup | Failed to checkout pull ref: Object does not exist on the server'
+        );
       }
       return new Response('unexpected fetch', { status: 500 });
     });

--- a/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
+++ b/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
@@ -533,6 +533,98 @@ describe('CodeReviewOrchestrator recovery', () => {
     expect(failedStatusUpdates).toHaveLength(0);
   });
 
+  it('retries prepareSession once after wrapper waitForPort readiness timeout', async () => {
+    const stub = getReviewStub();
+    let prepareCalls = 0;
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        prepareCalls += 1;
+        if (prepareCalls === 1) {
+          return trpcError(
+            500,
+            'Wrapper did not become ready on port 5353 within 30000ms: waitForPort timed out'
+          );
+        }
+        return trpcSuccess({
+          cloudAgentSessionId: 'agent-wrapper-timeout-retry',
+          kiloSessionId: 'ses_wrapper_timeout_retry',
+        });
+      }
+      if (url.includes('/trpc/initiateFromKilocodeSessionV2')) {
+        return trpcSuccess({ executionId: 'exec-wrapper-timeout-retry', status: 'running' });
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({
+      status: 'running',
+      sessionId: 'agent-wrapper-timeout-retry',
+      cliSessionId: 'ses_wrapper_timeout_retry',
+    });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(2);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(1);
+    await expect(storedReview(stub)).resolves.toMatchObject({ sandboxRetryAttempted: true });
+  });
+
+  it('retries prepareSession once after wrapper kilo server startup timeout', async () => {
+    const stub = getReviewStub();
+    let prepareCalls = 0;
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        prepareCalls += 1;
+        if (prepareCalls === 1) {
+          return trpcError(
+            500,
+            'Wrapper did not become ready on port 5353 within 30000ms: waitForPort timed out | wrapperFileLog: failed to start kilo server: Timeout waiting for server to start after 30000ms'
+          );
+        }
+        return trpcSuccess({
+          cloudAgentSessionId: 'agent-kilo-startup-retry',
+          kiloSessionId: 'ses_kilo_startup_retry',
+        });
+      }
+      if (url.includes('/trpc/initiateFromKilocodeSessionV2')) {
+        return trpcSuccess({ executionId: 'exec-kilo-startup-retry', status: 'running' });
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({
+      status: 'running',
+      sessionId: 'agent-kilo-startup-retry',
+      cliSessionId: 'ses_kilo_startup_retry',
+    });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(2);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(1);
+    await expect(storedReview(stub)).resolves.toMatchObject({ sandboxRetryAttempted: true });
+  });
+
   it('fails after a second sandbox 500 without initiating', async () => {
     const stub = getReviewStub();
     const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
@@ -611,6 +703,69 @@ describe('CodeReviewOrchestrator recovery', () => {
       }
       if (url.includes('/trpc/prepareSession')) {
         return trpcError(400, 'Branch not found: main', 'BAD_REQUEST');
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({ status: 'failed' });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(1);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(0);
+    const stored = await storedReview(stub);
+    expect(stored).toMatchObject({ status: 'failed' });
+    expect(stored?.sandboxRetryAttempted).toBeUndefined();
+  });
+
+  it('does not retry configured-session lookup failures nested in wrapper readiness output', async () => {
+    const stub = getReviewStub();
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        return trpcError(
+          500,
+          'Wrapper did not become ready on port 5353 within 30000ms: waitForPort timed out | wrapperFileLog: configured session ses_missing not found: Session get returned no data for ses_missing'
+        );
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({ status: 'failed' });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(1);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(0);
+    const stored = await storedReview(stub);
+    expect(stored).toMatchObject({ status: 'failed' });
+    expect(stored?.sandboxRetryAttempted).toBeUndefined();
+  });
+
+  it('does not retry repo-specific checkout failures that surface as prepareSession 500s', async () => {
+    const stub = getReviewStub();
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        return trpcError(500, 'Failed to checkout pull ref: Object does not exist on the server');
       }
       return new Response('unexpected fetch', { status: 500 });
     });


### PR DESCRIPTION
## Summary
- Retry code-review fresh-session fallback for observed transient Cloud Agent wrapper-readiness `prepareSession` 5xx signatures.
- Keep configured-session lookup misses, repo-specific checkout failures, billing failures, and cancelled reviews outside widened retry scope.
- Add structured retry and `prepareSession` failure classification fields so future alerts can split wrapper startup, sandbox/storage, configured-session, repo, retry outcome, and bot/user sandbox behavior.

## Verification
- N/A - no manual verification performed.

## Visual Changes
- N/A

## Reviewer Notes
- Retry widening stays text-targeted to incident-observed wrapper startup failures rather than treating generic 500 responses as retryable.
- `configured session ... not found` remains intentionally non-retryable because wrapper startup treats it as continuity loss, not safe transient infra noise.
- Observability changes add stable category fields and retry outcome states intended for future monitor/query refinement.
