### PR TITLE
feat(cloud-agent): add workspace terminal support

### DIFF
--- a/apps/web/src/components/cloud-agent-next/CloudAgentTerminalDock.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudAgentTerminalDock.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect } from 'react';
+import { StatusSpinner } from '@/components/shared/StatusSpinner';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useCloudAgentTerminal } from './useCloudAgentTerminal';
+import type { TerminalStatus } from './useCloudAgentTerminal';
+
+export function CloudAgentTerminalPane({
+  cloudAgentSessionId,
+  organizationId,
+  active,
+  onStatusChange,
+}: {
+  cloudAgentSessionId: string;
+  organizationId?: string;
+  active: boolean;
+  onStatusChange?: (status: { status: TerminalStatus; statusText: string }) => void;
+}) {
+  const terminal = useCloudAgentTerminal({
+    cloudAgentSessionId,
+    organizationId,
+    enabled: true,
+    active,
+  });
+
+  useEffect(() => {
+    onStatusChange?.({ status: terminal.status, statusText: terminal.statusText });
+  }, [onStatusChange, terminal.status, terminal.statusText]);
+
+  const waitingForTerminal = terminal.status === 'connecting' || terminal.status === 'reconnecting';
+  const terminalNeedsReconnect = terminal.status === 'error' || terminal.status === 'exited';
+
+  return (
+    <section
+      className="bg-background flex h-full min-h-0 flex-col overflow-hidden"
+      aria-label="Workspace terminal"
+    >
+      <div className="relative min-h-0 flex-1 bg-[#0a0a0a] p-2">
+        {(waitingForTerminal || terminalNeedsReconnect) && (
+          <div
+            className={cn(
+              'absolute inset-0 z-10 flex justify-center px-4',
+              waitingForTerminal ? 'items-start pt-6' : 'items-center'
+            )}
+          >
+            <div
+              role={waitingForTerminal ? 'status' : undefined}
+              aria-live={waitingForTerminal ? 'polite' : undefined}
+              className={cn(
+                'border-border bg-background/95 text-muted-foreground flex max-w-md items-center rounded-md border px-3 py-3 text-center text-sm',
+                waitingForTerminal ? 'gap-2' : 'flex-col gap-3'
+              )}
+            >
+              {waitingForTerminal && <StatusSpinner className="h-3 w-3 shrink-0" />}
+              <span>{terminal.statusText}</span>
+              {terminalNeedsReconnect && (
+                <Button size="sm" variant="secondary" className="h-8" onClick={terminal.reconnect}>
+                  Reconnect
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+        <div ref={terminal.terminalRef} className="h-full w-full overflow-hidden" />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/cloud-agent-next/CloudAgentWorkspaceTabs.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudAgentWorkspaceTabs.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { MessageSquare, Plus, Terminal, X } from 'lucide-react';
+import { CHAT_TAB_ID, terminalTabId } from './terminal-tabs';
+import type { TerminalWorkspaceTab, WorkspaceTabId } from './terminal-tabs';
+
+type TerminalStatusSummary = {
+  status: 'connecting' | 'connected' | 'reconnecting' | 'disconnected' | 'exited' | 'error';
+  statusText: string;
+};
+
+function statusDotClass(status: TerminalStatusSummary['status'] | 'chat-active'): string {
+  if (status === 'connected') return 'bg-emerald-500';
+  if (status === 'error' || status === 'exited') return 'bg-destructive';
+  if (status === 'chat-active') return 'bg-primary';
+  return 'bg-amber-500';
+}
+
+export function CloudAgentWorkspaceTabs({
+  activeTabId,
+  terminals,
+  terminalStatuses,
+  chatNeedsAttention,
+  canCreateTerminal,
+  onSelectTab,
+  onCreateTerminal,
+  onCloseTerminal,
+  className,
+}: {
+  activeTabId: WorkspaceTabId;
+  terminals: TerminalWorkspaceTab[];
+  terminalStatuses: Record<string, TerminalStatusSummary | undefined>;
+  chatNeedsAttention: boolean;
+  canCreateTerminal: boolean;
+  onSelectTab: (tabId: WorkspaceTabId) => void;
+  onCreateTerminal: () => void;
+  onCloseTerminal: (terminalId: string) => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Cloud Agent workspace"
+      className={cn('flex min-w-0 items-center gap-1 overflow-x-auto', className)}
+    >
+      <Button
+        type="button"
+        size="sm"
+        variant={activeTabId === CHAT_TAB_ID ? 'secondary' : 'ghost'}
+        className="h-8 shrink-0 gap-2"
+        role="tab"
+        aria-selected={activeTabId === CHAT_TAB_ID}
+        onClick={() => onSelectTab(CHAT_TAB_ID)}
+      >
+        <MessageSquare className="h-4 w-4" />
+        <span>Chat</span>
+        {chatNeedsAttention && (
+          <span className={cn('h-2 w-2 rounded-full', statusDotClass('chat-active'))} />
+        )}
+      </Button>
+
+      {terminals.map(tab => {
+        const tabId = terminalTabId(tab.id);
+        const active = activeTabId === tabId;
+        const status = terminalStatuses[tab.id]?.status ?? 'connecting';
+
+        return (
+          <div
+            key={tab.id}
+            className={cn(
+              'border-border flex h-8 shrink-0 items-center rounded-md border',
+              active ? 'bg-secondary text-secondary-foreground' : 'text-muted-foreground'
+            )}
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={active}
+              className="flex h-full min-w-0 items-center gap-2 rounded-l-md px-2 text-sm font-medium"
+              onClick={() => onSelectTab(tabId)}
+            >
+              <Terminal className="h-4 w-4 shrink-0" />
+              <span className="max-w-32 truncate">{tab.title}</span>
+              <span className={cn('h-2 w-2 shrink-0 rounded-full', statusDotClass(status))} />
+            </button>
+            <button
+              type="button"
+              aria-label={`Close ${tab.title}`}
+              className="hover:bg-muted flex h-full w-7 shrink-0 items-center justify-center rounded-r-md"
+              onClick={() => onCloseTerminal(tab.id)}
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        );
+      })}
+
+      {canCreateTerminal && (
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-8 w-8 shrink-0"
+          aria-label="New terminal"
+          onClick={onCreateTerminal}
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -22,6 +22,17 @@ import { QuestionContextProvider } from './QuestionContext';
 import { PermissionCard, PermissionContextProvider } from './PermissionCard';
 import { SuggestionContextProvider } from './SuggestionCard';
 import { SessionContinuationPanel } from './SessionContinuationPanel';
+import { CloudAgentTerminalPane } from './CloudAgentTerminalDock';
+import { CloudAgentWorkspaceTabs } from './CloudAgentWorkspaceTabs';
+import {
+  CHAT_TAB_ID,
+  addTerminalTab,
+  closeTerminalTab,
+  createWorkspaceTabsState,
+  resetWorkspaceTabs,
+  selectWorkspaceTab,
+  terminalTabId,
+} from './terminal-tabs';
 import { isMessageStreaming } from './types';
 import { useOrganizationModels } from './hooks/useOrganizationModels';
 import { useSlashCommandSets } from '@/hooks/useSlashCommandSets';
@@ -39,6 +50,8 @@ import { formatShortModelDisplayName } from '@/lib/format-model-name';
 import type { AgentMode } from './types';
 import type { StoredMessage } from '@/lib/cloud-agent-sdk';
 import type { Images } from '@/lib/images-schema';
+import type { WorkspaceTabId } from './terminal-tabs';
+import type { TerminalStatus } from './useCloudAgentTerminal';
 
 // ---------------------------------------------------------------------------
 // Static messages — memoized, never re-renders during streaming
@@ -97,6 +110,40 @@ const emptyQuestionRequestIds = new Map<string, string>();
 
 type CloudChatPageProps = { organizationId?: string };
 
+type TerminalStatusSummary = { status: TerminalStatus; statusText: string };
+
+function TerminalPaneSlot({
+  terminalId,
+  active,
+  sessionId,
+  organizationId,
+  onStatusChange,
+}: {
+  terminalId: string;
+  active: boolean;
+  sessionId: string | null | undefined;
+  organizationId?: string;
+  onStatusChange: (terminalId: string, status: TerminalStatusSummary) => void;
+}) {
+  const handleStatusChange = useCallback(
+    (status: TerminalStatusSummary) => onStatusChange(terminalId, status),
+    [onStatusChange, terminalId]
+  );
+
+  return (
+    <div className={active ? 'h-full min-h-0' : 'hidden'} aria-hidden={!active}>
+      {sessionId && (
+        <CloudAgentTerminalPane
+          cloudAgentSessionId={sessionId}
+          organizationId={organizationId}
+          active={active}
+          onStatusChange={handleStatusChange}
+        />
+      )}
+    </div>
+  );
+}
+
 export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const manager = useManager();
   const searchParams = useSearchParams();
@@ -139,6 +186,15 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const setSessionConfig = useSetAtom(manager.atoms.sessionConfig);
 
   const [imageMessageUuid, setImageMessageUuid] = useState(() => crypto.randomUUID());
+  const [workspaceTabs, setWorkspaceTabs] = useState(createWorkspaceTabsState);
+  const [terminalStatuses, setTerminalStatuses] = useState<
+    Record<string, TerminalStatusSummary | undefined>
+  >({});
+
+  useEffect(() => {
+    setWorkspaceTabs(resetWorkspaceTabs);
+    setTerminalStatuses({});
+  }, [sessionId]);
 
   // -- Organization models --------------------------------------------------
   const { modelOptions, isLoadingModels } = useOrganizationModels(organizationId);
@@ -337,6 +393,47 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
     setSoundEnabled(prev => !prev);
   }, [setSoundEnabled]);
 
+  const handleCreateTerminalTab = useCallback(() => {
+    const terminalId = crypto.randomUUID();
+    setWorkspaceTabs(state => addTerminalTab(state, terminalId));
+  }, []);
+
+  const handleSelectWorkspaceTab = useCallback((tabId: WorkspaceTabId) => {
+    setWorkspaceTabs(state => selectWorkspaceTab(state, tabId));
+  }, []);
+
+  const handleCloseTerminalTab = useCallback((terminalId: string) => {
+    setWorkspaceTabs(state => closeTerminalTab(state, terminalId));
+    setTerminalStatuses(current => {
+      const next = { ...current };
+      delete next[terminalId];
+      return next;
+    });
+  }, []);
+
+  const handleTerminalStatusChange = useCallback(
+    (terminalId: string, status: TerminalStatusSummary) => {
+      setTerminalStatuses(current => ({ ...current, [terminalId]: status }));
+    },
+    []
+  );
+
+  const chatNeedsAttention = Boolean(activeQuestion || activePermission || statusIndicator);
+
+  const terminalPaneMap = workspaceTabs.terminals.map(tab => {
+    const active = terminalTabId(tab.id) === workspaceTabs.activeTabId;
+    return (
+      <TerminalPaneSlot
+        key={tab.id}
+        terminalId={tab.id}
+        active={active}
+        sessionId={sessionId}
+        organizationId={organizationId}
+        onStatusChange={handleTerminalStatusChange}
+      />
+    );
+  });
+
   const handleAnswerQuestion = useCallback(
     (requestId: string, answers: string[][]) => manager.answerQuestion(requestId, answers),
     [manager]
@@ -456,6 +553,8 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
         ? 'Wrapping up…'
         : 'Ask anything…';
 
+  const canOpenTerminal = Boolean(sessionId) && !isReadOnly;
+
   const sessionActions = (
     <ChatHeader
       cloudAgentSessionId={sessionId ?? 'Starting session…'}
@@ -502,129 +601,161 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
               <>
                 {showLoadingIndicator && <div className="bg-primary h-0.5 w-full animate-pulse" />}
 
-                <div className="flex shrink-0 items-center justify-between border-b px-3 py-2 lg:hidden">
+                <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
                   <MobileSidebarToggle variant="inline" label="Sessions" />
-                  {sessionActions}
+                  <div className="min-w-0 flex-1">
+                    {canOpenTerminal && (
+                      <CloudAgentWorkspaceTabs
+                        activeTabId={workspaceTabs.activeTabId}
+                        terminals={workspaceTabs.terminals}
+                        terminalStatuses={terminalStatuses}
+                        chatNeedsAttention={
+                          chatNeedsAttention && workspaceTabs.activeTabId !== CHAT_TAB_ID
+                        }
+                        canCreateTerminal={canOpenTerminal}
+                        onSelectTab={handleSelectWorkspaceTab}
+                        onCreateTerminal={handleCreateTerminalTab}
+                        onCloseTerminal={handleCloseTerminalTab}
+                      />
+                    )}
+                  </div>
+                  <div className="shrink-0">{sessionActions}</div>
                 </div>
 
                 <div className="relative min-h-0 flex-1">
-                  <div className="absolute right-3 top-2 z-10 hidden lg:block">
-                    {sessionActions}
-                  </div>
+                  {workspaceTabs.activeTabId === CHAT_TAB_ID && (
+                    <>
+                      <div
+                        ref={scrollContainerRef}
+                        className={`absolute inset-0 overflow-y-auto px-[max(1rem,calc(50%_-_27rem))] pb-2 pt-4 transition-opacity duration-150 ${showLoadingIndicator ? 'pointer-events-none opacity-40' : 'opacity-100'}`}
+                        onScroll={handleScroll}
+                      >
+                        <div ref={messagesContentRef}>
+                          <StaticMessages
+                            messages={staticMessages}
+                            getChildMessages={getChildMessages}
+                          />
+                          <DynamicMessages
+                            messages={dynamicMessages}
+                            getChildMessages={getChildMessages}
+                          />
+
+                          <WorkingIndicator messages={dynamicMessages} isStreaming={isStreaming} />
+                          {statusIndicator && (
+                            <SessionStatusIndicator indicator={statusIndicator} />
+                          )}
+
+                          <div ref={messagesEndRef} />
+                        </div>
+                      </div>
+
+                      {showScrollButton && (
+                        <button
+                          type="button"
+                          onClick={scrollToBottom}
+                          className="border-border bg-background absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full border p-2 shadow-md"
+                        >
+                          <ArrowDown className="h-4 w-4" />
+                        </button>
+                      )}
+                    </>
+                  )}
 
                   <div
-                    ref={scrollContainerRef}
-                    className={`absolute inset-0 overflow-y-auto px-[max(1rem,calc(50%_-_27rem))] pb-2 pt-4 transition-opacity duration-150 lg:pt-12 ${showLoadingIndicator ? 'pointer-events-none opacity-40' : 'opacity-100'}`}
-                    onScroll={handleScroll}
+                    className={
+                      workspaceTabs.activeTabId === CHAT_TAB_ID
+                        ? 'hidden'
+                        : 'h-full min-h-0 px-[max(1rem,calc(50%_-_27rem))] py-2'
+                    }
                   >
-                    <div ref={messagesContentRef}>
-                      <StaticMessages
-                        messages={staticMessages}
-                        getChildMessages={getChildMessages}
-                      />
-                      <DynamicMessages
-                        messages={dynamicMessages}
-                        getChildMessages={getChildMessages}
-                      />
-
-                      <WorkingIndicator messages={dynamicMessages} isStreaming={isStreaming} />
-                      {statusIndicator && <SessionStatusIndicator indicator={statusIndicator} />}
-
-                      <div ref={messagesEndRef} />
-                    </div>
+                    {terminalPaneMap}
                   </div>
-
-                  {showScrollButton && (
-                    <button
-                      type="button"
-                      onClick={scrollToBottom}
-                      className="border-border bg-background absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full border p-2 shadow-md"
-                    >
-                      <ArrowDown className="h-4 w-4" />
-                    </button>
-                  )}
                 </div>
 
-                {isReadOnly ? (
-                  !isLoading && sessionIdFromParams && fetchedSessionData ? (
-                    <SessionContinuationPanel sessionId={sessionIdFromParams} />
-                  ) : null
-                ) : (
+                {workspaceTabs.activeTabId === CHAT_TAB_ID && (
                   <>
-                    {activeQuestion && (
-                      <div className="border-t px-[max(1rem,calc(50%_-_27rem))] py-4">
-                        <QuestionToolCard
-                          key={activeQuestion.requestId}
-                          questions={activeQuestion.questions}
-                          requestId={activeQuestion.requestId}
-                          status="running"
-                        />
-                      </div>
-                    )}
-                    {activePermission && (
-                      <div className="flex items-center border-t p-4">
-                        <PermissionCard
-                          key={activePermission.requestId}
-                          requestId={activePermission.requestId}
-                          permission={activePermission.permission}
-                          patterns={activePermission.patterns}
-                          metadata={activePermission.metadata}
-                          always={activePermission.always}
-                        />
-                      </div>
-                    )}
-                    <div className={activeQuestion || activePermission ? 'hidden' : ''}>
-                      <ChatInput
-                        onSend={handleSendMessage}
-                        onSendCommand={handleSendSlashCommand}
-                        onStop={handleStopExecution}
-                        disabled={(isStreaming && !activeSuggestion) || !canSend}
-                        isStreaming={isStreaming && !activeSuggestion}
-                        placeholder={placeholder}
-                        slashCommands={availableCommands}
-                        mode={sessionConfig?.mode as AgentMode | undefined}
-                        model={displayModel}
-                        modelOptions={modelOptions}
-                        isLoadingModels={isLoadingModels}
-                        onModeChange={handleModeChange}
-                        onModelChange={handleModelChange}
-                        variant={displayVariant}
-                        onVariantChange={handleVariantChange}
-                        availableVariants={displayAvailableVariants}
-                        showToolbar={Boolean(sessionIdFromParams)}
-                        initialValue={failedPrompt ?? undefined}
-                        customModeOptions={customModeOptions}
-                        modelPickerDisabled={modelPickerLocked}
-                        modelPickerTooltip={lockTooltip}
-                        variantPickerDisabled={modelPickerLocked}
-                        variantPickerTooltip={lockTooltip}
-                        imageUploadOptions={{
-                          messageUuid: imageMessageUuid,
-                          organizationId,
-                          maxImages: CLOUD_AGENT_IMAGE_MAX_COUNT,
-                          maxOriginalFileSizeBytes: CLOUD_AGENT_IMAGE_MAX_ORIGINAL_SIZE_BYTES,
-                          maxFileSizeBytes: CLOUD_AGENT_IMAGE_MAX_SIZE_BYTES,
-                          allowedTypes: CLOUD_AGENT_IMAGE_ALLOWED_TYPES,
-                          resizeImages: { maxDimensionPx: CLOUD_AGENT_IMAGE_MAX_DIMENSION_PX },
-                          getUploadUrl: {
-                            personal: personalUploadUrl,
-                            organization: orgUploadUrl,
-                          },
-                        }}
-                      />
-                      {sessionConfig?.repository && (
-                        <div className="text-muted-foreground flex items-center gap-1.5 px-[max(1rem,calc(50%_-_27rem))] pb-3 text-xs md:pb-4">
-                          <GitBranch className="h-3 w-3 shrink-0" />
-                          <span className="truncate">{sessionConfig.repository}</span>
-                          {fetchedSessionData?.gitBranch && (
-                            <>
-                              <span>·</span>
-                              <span className="truncate">{fetchedSessionData.gitBranch}</span>
-                            </>
+                    {isReadOnly ? (
+                      !isLoading && sessionIdFromParams && fetchedSessionData ? (
+                        <SessionContinuationPanel sessionId={sessionIdFromParams} />
+                      ) : null
+                    ) : (
+                      <>
+                        {activeQuestion && (
+                          <div className="border-t px-[max(1rem,calc(50%_-_27rem))] py-4">
+                            <QuestionToolCard
+                              key={activeQuestion.requestId}
+                              questions={activeQuestion.questions}
+                              requestId={activeQuestion.requestId}
+                              status="running"
+                            />
+                          </div>
+                        )}
+                        {activePermission && (
+                          <div className="flex items-center border-t p-4">
+                            <PermissionCard
+                              key={activePermission.requestId}
+                              requestId={activePermission.requestId}
+                              permission={activePermission.permission}
+                              patterns={activePermission.patterns}
+                              metadata={activePermission.metadata}
+                              always={activePermission.always}
+                            />
+                          </div>
+                        )}
+                        <div className={activeQuestion || activePermission ? 'hidden' : ''}>
+                          <ChatInput
+                            onSend={handleSendMessage}
+                            onSendCommand={handleSendSlashCommand}
+                            onStop={handleStopExecution}
+                            disabled={(isStreaming && !activeSuggestion) || !canSend}
+                            isStreaming={isStreaming && !activeSuggestion}
+                            placeholder={placeholder}
+                            slashCommands={availableCommands}
+                            mode={sessionConfig?.mode as AgentMode | undefined}
+                            model={displayModel}
+                            modelOptions={modelOptions}
+                            isLoadingModels={isLoadingModels}
+                            onModeChange={handleModeChange}
+                            onModelChange={handleModelChange}
+                            variant={displayVariant}
+                            onVariantChange={handleVariantChange}
+                            availableVariants={displayAvailableVariants}
+                            showToolbar={Boolean(sessionIdFromParams)}
+                            initialValue={failedPrompt ?? undefined}
+                            customModeOptions={customModeOptions}
+                            modelPickerDisabled={modelPickerLocked}
+                            modelPickerTooltip={lockTooltip}
+                            variantPickerDisabled={modelPickerLocked}
+                            variantPickerTooltip={lockTooltip}
+                            imageUploadOptions={{
+                              messageUuid: imageMessageUuid,
+                              organizationId,
+                              maxImages: CLOUD_AGENT_IMAGE_MAX_COUNT,
+                              maxOriginalFileSizeBytes: CLOUD_AGENT_IMAGE_MAX_ORIGINAL_SIZE_BYTES,
+                              maxFileSizeBytes: CLOUD_AGENT_IMAGE_MAX_SIZE_BYTES,
+                              allowedTypes: CLOUD_AGENT_IMAGE_ALLOWED_TYPES,
+                              resizeImages: { maxDimensionPx: CLOUD_AGENT_IMAGE_MAX_DIMENSION_PX },
+                              getUploadUrl: {
+                                personal: personalUploadUrl,
+                                organization: orgUploadUrl,
+                              },
+                            }}
+                          />
+                          {sessionConfig?.repository && (
+                            <div className="text-muted-foreground flex items-center gap-1.5 px-[max(1rem,calc(50%_-_27rem))] pb-3 text-xs md:pb-4">
+                              <GitBranch className="h-3 w-3 shrink-0" />
+                              <span className="truncate">{sessionConfig.repository}</span>
+                              {fetchedSessionData?.gitBranch && (
+                                <>
+                                  <span>·</span>
+                                  <span className="truncate">{fetchedSessionData.gitBranch}</span>
+                                </>
+                              )}
+                            </div>
                           )}
                         </div>
-                      )}
-                    </div>
+                      </>
+                    )}
                   </>
                 )}
               </>

--- a/apps/web/src/components/cloud-agent-next/terminal-tabs.test.ts
+++ b/apps/web/src/components/cloud-agent-next/terminal-tabs.test.ts
@@ -1,0 +1,73 @@
+import {
+  CHAT_TAB_ID,
+  addTerminalTab,
+  closeTerminalTab,
+  createWorkspaceTabsState,
+  resetWorkspaceTabs,
+  selectWorkspaceTab,
+  terminalTabId,
+} from './terminal-tabs';
+
+describe('cloud agent workspace terminal tabs', () => {
+  it('starts on the chat tab without terminals', () => {
+    expect(createWorkspaceTabsState()).toEqual({
+      activeTabId: CHAT_TAB_ID,
+      terminals: [],
+      nextTerminalNumber: 1,
+    });
+  });
+
+  it('adds terminal tabs with stable ids and human labels', () => {
+    const first = addTerminalTab(createWorkspaceTabsState(), 'tab-a');
+    const second = addTerminalTab(first, 'tab-b');
+
+    expect(second).toEqual({
+      activeTabId: terminalTabId('tab-b'),
+      nextTerminalNumber: 3,
+      terminals: [
+        { id: 'tab-a', title: 'Terminal 1' },
+        { id: 'tab-b', title: 'Terminal 2' },
+      ],
+    });
+  });
+
+  it('selects chat and existing terminal tabs only', () => {
+    const state = addTerminalTab(createWorkspaceTabsState(), 'tab-a');
+
+    expect(selectWorkspaceTab(state, CHAT_TAB_ID).activeTabId).toBe(CHAT_TAB_ID);
+    expect(selectWorkspaceTab(state, terminalTabId('tab-a')).activeTabId).toBe(
+      terminalTabId('tab-a')
+    );
+    expect(selectWorkspaceTab(state, terminalTabId('missing'))).toBe(state);
+  });
+
+  it('keeps the current tab when a background terminal closes', () => {
+    const state = selectWorkspaceTab(
+      addTerminalTab(addTerminalTab(createWorkspaceTabsState(), 'tab-a'), 'tab-b'),
+      terminalTabId('tab-a')
+    );
+
+    expect(closeTerminalTab(state, 'tab-b')).toEqual({
+      activeTabId: terminalTabId('tab-a'),
+      nextTerminalNumber: 3,
+      terminals: [{ id: 'tab-a', title: 'Terminal 1' }],
+    });
+  });
+
+  it('activates the left neighbor when the active terminal closes', () => {
+    const state = addTerminalTab(addTerminalTab(createWorkspaceTabsState(), 'tab-a'), 'tab-b');
+
+    expect(closeTerminalTab(state, 'tab-b')).toEqual({
+      activeTabId: terminalTabId('tab-a'),
+      nextTerminalNumber: 3,
+      terminals: [{ id: 'tab-a', title: 'Terminal 1' }],
+    });
+  });
+
+  it('returns to chat when the last terminal closes or the session resets', () => {
+    const state = addTerminalTab(createWorkspaceTabsState(), 'tab-a');
+
+    expect(closeTerminalTab(state, 'tab-a')).toEqual(createWorkspaceTabsState());
+    expect(resetWorkspaceTabs(state)).toEqual(createWorkspaceTabsState());
+  });
+});

--- a/apps/web/src/components/cloud-agent-next/terminal-tabs.ts
+++ b/apps/web/src/components/cloud-agent-next/terminal-tabs.ts
@@ -1,0 +1,85 @@
+export const CHAT_TAB_ID = 'chat' as const;
+
+export type TerminalTabId = `terminal:${string}`;
+export type WorkspaceTabId = typeof CHAT_TAB_ID | TerminalTabId;
+
+export type TerminalWorkspaceTab = {
+  id: string;
+  title: string;
+};
+
+export type WorkspaceTabsState = {
+  activeTabId: WorkspaceTabId;
+  terminals: TerminalWorkspaceTab[];
+  nextTerminalNumber: number;
+};
+
+export function terminalTabId(terminalId: string): TerminalTabId {
+  return `terminal:${terminalId}`;
+}
+
+export function terminalIdFromTabId(tabId: WorkspaceTabId): string | null {
+  if (tabId === CHAT_TAB_ID) return null;
+  return tabId.slice('terminal:'.length);
+}
+
+export function createWorkspaceTabsState(): WorkspaceTabsState {
+  return {
+    activeTabId: CHAT_TAB_ID,
+    terminals: [],
+    nextTerminalNumber: 1,
+  };
+}
+
+export function resetWorkspaceTabs(_state: WorkspaceTabsState): WorkspaceTabsState {
+  return createWorkspaceTabsState();
+}
+
+export function addTerminalTab(state: WorkspaceTabsState, terminalId: string): WorkspaceTabsState {
+  const title = `Terminal ${state.nextTerminalNumber}`;
+
+  return {
+    activeTabId: terminalTabId(terminalId),
+    terminals: [...state.terminals, { id: terminalId, title }],
+    nextTerminalNumber: state.nextTerminalNumber + 1,
+  };
+}
+
+export function selectWorkspaceTab(
+  state: WorkspaceTabsState,
+  activeTabId: WorkspaceTabId
+): WorkspaceTabsState {
+  if (activeTabId === CHAT_TAB_ID) {
+    return { ...state, activeTabId };
+  }
+
+  const terminalId = terminalIdFromTabId(activeTabId);
+  if (!terminalId || !state.terminals.some(tab => tab.id === terminalId)) {
+    return state;
+  }
+
+  return { ...state, activeTabId };
+}
+
+export function closeTerminalTab(
+  state: WorkspaceTabsState,
+  terminalId: string
+): WorkspaceTabsState {
+  const closedIndex = state.terminals.findIndex(tab => tab.id === terminalId);
+  if (closedIndex === -1) return state;
+
+  const terminals = state.terminals.filter(tab => tab.id !== terminalId);
+  const closedActiveTab = state.activeTabId === terminalTabId(terminalId);
+
+  if (!closedActiveTab) {
+    return { ...state, terminals };
+  }
+
+  const fallback = terminals[Math.max(0, closedIndex - 1)] ?? null;
+
+  return {
+    activeTabId: fallback ? terminalTabId(fallback.id) : CHAT_TAB_ID,
+    terminals,
+    nextTerminalNumber: terminals.length === 0 ? 1 : state.nextTerminalNumber,
+  };
+}

--- a/apps/web/src/components/cloud-agent-next/terminal-utils.test.ts
+++ b/apps/web/src/components/cloud-agent-next/terminal-utils.test.ts
@@ -1,0 +1,111 @@
+import {
+  classifyTerminalCreateError,
+  classifyTerminalSocketClose,
+  getTerminalReconnectDelayMs,
+  isPtyControlFrame,
+  resolveCloudAgentTerminalWsUrl,
+} from './terminal-utils';
+
+describe('resolveCloudAgentTerminalWsUrl', () => {
+  it('resolves relative terminal paths against the WebSocket base URL', () => {
+    expect(
+      resolveCloudAgentTerminalWsUrl(
+        '/terminal?cloudAgentSessionId=agent_1&ptyId=pty_1',
+        'https://cloud-agent.example.com'
+      )
+    ).toBe('wss://cloud-agent.example.com/terminal?cloudAgentSessionId=agent_1&ptyId=pty_1');
+  });
+
+  it('upgrades absolute HTTP URLs to WebSocket URLs', () => {
+    expect(resolveCloudAgentTerminalWsUrl('http://worker.example.com/terminal', '')).toBe(
+      'ws://worker.example.com/terminal'
+    );
+  });
+});
+
+describe('isPtyControlFrame', () => {
+  it('filters NUL-prefixed binary control frames', () => {
+    expect(isPtyControlFrame(new Uint8Array([0x00, 0x7b, 0x7d]).buffer)).toBe(true);
+  });
+
+  it('filters JSON cursor control frames', () => {
+    expect(isPtyControlFrame('{"cursor":12}')).toBe(true);
+  });
+
+  it('keeps normal terminal output', () => {
+    expect(isPtyControlFrame('echo {"ok":true}')).toBe(false);
+    expect(isPtyControlFrame('{"ok":true}')).toBe(false);
+    expect(isPtyControlFrame('{"scripts":{"test":"jest"}}\r\n')).toBe(false);
+  });
+});
+
+describe('getTerminalReconnectDelayMs', () => {
+  it('backs off and caps retries so the terminal can keep waiting for the wrapper', () => {
+    expect(getTerminalReconnectDelayMs(0)).toBe(1_000);
+    expect(getTerminalReconnectDelayMs(1)).toBe(2_000);
+    expect(getTerminalReconnectDelayMs(2)).toBe(4_000);
+    expect(getTerminalReconnectDelayMs(3)).toBe(5_000);
+    expect(getTerminalReconnectDelayMs(20)).toBe(5_000);
+  });
+});
+
+describe('classifyTerminalCreateError', () => {
+  it('retries wrapper and workspace availability failures', () => {
+    expect(
+      classifyTerminalCreateError({
+        data: { code: 'SERVICE_UNAVAILABLE' },
+        message: 'Terminal is unavailable because the session wrapper is not healthy',
+      })
+    ).toEqual({ kind: 'retry', statusText: 'Waiting for terminal' });
+
+    expect(
+      classifyTerminalCreateError({
+        data: { code: 'PRECONDITION_FAILED' },
+        message: 'Terminal is only available after the workspace is prepared',
+      })
+    ).toEqual({ kind: 'retry', statusText: 'Waiting for workspace' });
+  });
+
+  it('stops retrying for permanent access and session errors', () => {
+    expect(
+      classifyTerminalCreateError({
+        data: { code: 'FORBIDDEN' },
+        message: 'Terminal is only available for interactive Cloud Agent sessions',
+      })
+    ).toEqual({
+      kind: 'final-error',
+      statusText: 'Terminal is only available for interactive Cloud Agent sessions',
+    });
+
+    expect(
+      classifyTerminalCreateError({
+        data: { code: 'NOT_FOUND' },
+        message: 'Session not found',
+      })
+    ).toEqual({
+      kind: 'final-error',
+      statusText: 'Terminal session was not found',
+    });
+  });
+});
+
+describe('classifyTerminalSocketClose', () => {
+  it('treats normal PTY completion as shell exit', () => {
+    expect(classifyTerminalSocketClose({ code: 1000, reason: 'PTY session ended' })).toEqual({
+      kind: 'exited',
+      statusText: 'Terminal exited',
+    });
+  });
+
+  it('retries abnormal network and upstream failures', () => {
+    expect(classifyTerminalSocketClose({ code: 1006, reason: '' })).toEqual({
+      kind: 'retry',
+      statusText: 'Reconnecting',
+    });
+
+    expect(classifyTerminalSocketClose({ code: 1011, reason: 'PTY upstream error' })).toEqual({
+      kind: 'retry',
+      statusText: 'Reconnecting',
+    });
+  });
+});

--- a/apps/web/src/components/cloud-agent-next/terminal-utils.ts
+++ b/apps/web/src/components/cloud-agent-next/terminal-utils.ts
@@ -1,0 +1,107 @@
+export function resolveCloudAgentTerminalWsUrl(wsUrl: string, baseUrl: string): string {
+  if (!wsUrl) {
+    throw new Error('Terminal WebSocket URL is missing');
+  }
+
+  const url = /^(wss?|https?):\/\//i.test(wsUrl) ? new URL(wsUrl) : new URL(wsUrl, baseUrl);
+
+  if (url.protocol === 'http:') url.protocol = 'ws:';
+  else if (url.protocol === 'https:') url.protocol = 'wss:';
+
+  return url.toString();
+}
+
+function isPtyCursorControlPayload(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  if (keys.length !== 1 || keys[0] !== 'cursor') return false;
+  const cursor = (value as { cursor: unknown }).cursor;
+  return typeof cursor === 'number' || typeof cursor === 'string';
+}
+
+export function isPtyControlFrame(data: string | ArrayBuffer): boolean {
+  if (data instanceof ArrayBuffer) {
+    const bytes = new Uint8Array(data);
+    return bytes.length > 0 && bytes[0] === 0x00;
+  }
+
+  if (data.length > 0 && data.charCodeAt(0) === 0) return true;
+  if (!data.startsWith('{')) return false;
+
+  try {
+    return isPtyCursorControlPayload(JSON.parse(data));
+  } catch {
+    return false;
+  }
+}
+
+export function getTerminalReconnectDelayMs(
+  attempt: number,
+  options: { baseDelayMs?: number; maxDelayMs?: number } = {}
+): number {
+  const baseDelayMs = options.baseDelayMs ?? 1_000;
+  const maxDelayMs = options.maxDelayMs ?? 5_000;
+  const normalizedAttempt = Math.max(0, Math.floor(attempt));
+  return Math.min(baseDelayMs * Math.pow(2, normalizedAttempt), maxDelayMs);
+}
+
+export type TerminalConnectionDecision =
+  | { kind: 'retry'; statusText: string }
+  | { kind: 'final-error'; statusText: string }
+  | { kind: 'exited'; statusText: string };
+
+function readErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const data = 'data' in error ? (error as { data?: unknown }).data : undefined;
+  if (data && typeof data === 'object' && 'code' in data) {
+    const code = (data as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  }
+  return undefined;
+}
+
+function readErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    return typeof message === 'string' ? message : '';
+  }
+  return '';
+}
+
+export function classifyTerminalCreateError(error: unknown): TerminalConnectionDecision {
+  const code = readErrorCode(error);
+  const message = readErrorMessage(error);
+
+  if (code === 'NOT_FOUND' || message === 'Session not found') {
+    return { kind: 'final-error', statusText: 'Terminal session was not found' };
+  }
+
+  if (code === 'FORBIDDEN' || message.includes('interactive Cloud Agent')) {
+    return {
+      kind: 'final-error',
+      statusText: message || 'Terminal is not available for this session',
+    };
+  }
+
+  if (code === 'PRECONDITION_FAILED' || message.includes('workspace is prepared')) {
+    return { kind: 'retry', statusText: 'Waiting for workspace' };
+  }
+
+  return { kind: 'retry', statusText: 'Waiting for terminal' };
+}
+
+export function classifyTerminalSocketClose(event: {
+  code: number;
+  reason: string;
+}): TerminalConnectionDecision {
+  if (event.code === 1000 && event.reason.includes('PTY session ended')) {
+    return { kind: 'exited', statusText: 'Terminal exited' };
+  }
+
+  if (event.code === 1000) {
+    return { kind: 'final-error', statusText: 'Terminal disconnected' };
+  }
+
+  return { kind: 'retry', statusText: 'Reconnecting' };
+}

--- a/apps/web/src/components/cloud-agent-next/useCloudAgentTerminal.ts
+++ b/apps/web/src/components/cloud-agent-next/useCloudAgentTerminal.ts
@@ -1,0 +1,415 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import type { Terminal } from '@xterm/xterm';
+import type { FitAddon } from '@xterm/addon-fit';
+import { CLOUD_AGENT_NEXT_WS_URL } from '@/lib/constants';
+import { useTRPC } from '@/lib/trpc/utils';
+import {
+  classifyTerminalCreateError,
+  classifyTerminalSocketClose,
+  getTerminalReconnectDelayMs,
+  isPtyControlFrame,
+  resolveCloudAgentTerminalWsUrl,
+} from './terminal-utils';
+
+export type TerminalStatus =
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'disconnected'
+  | 'exited'
+  | 'error';
+
+type CloudAgentTerminalResult = {
+  terminalRef: RefObject<HTMLDivElement | null>;
+  status: TerminalStatus;
+  statusText: string;
+  connected: boolean;
+  reconnect: () => void;
+};
+
+const RESIZE_DEBOUNCE_MS = 150;
+
+export function useCloudAgentTerminal({
+  cloudAgentSessionId,
+  organizationId,
+  enabled,
+  active,
+}: {
+  cloudAgentSessionId: string | null | undefined;
+  organizationId?: string;
+  enabled: boolean;
+  active: boolean;
+}): CloudAgentTerminalResult {
+  const trpc = useTRPC();
+  const [status, setStatus] = useState<TerminalStatus>('disconnected');
+  const [statusText, setStatusText] = useState('Disconnected');
+  const terminalRef = useRef<HTMLDivElement>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const xtermRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const intentionalCloseRef = useRef(false);
+  const ptyIdRef = useRef<string | null>(null);
+  const activeRef = useRef(active);
+  const reconnectNowRef = useRef<() => void>(() => {});
+
+  activeRef.current = active;
+
+  const personalCreate = useMutation(trpc.cloudAgentNext.createTerminal.mutationOptions());
+  const orgCreate = useMutation(trpc.organizations.cloudAgentNext.createTerminal.mutationOptions());
+  const personalRefreshTicket = useMutation(
+    trpc.cloudAgentNext.refreshTerminalTicket.mutationOptions()
+  );
+  const orgRefreshTicket = useMutation(
+    trpc.organizations.cloudAgentNext.refreshTerminalTicket.mutationOptions()
+  );
+  const personalResize = useMutation(trpc.cloudAgentNext.resizeTerminal.mutationOptions());
+  const orgResize = useMutation(trpc.organizations.cloudAgentNext.resizeTerminal.mutationOptions());
+  const personalClose = useMutation(trpc.cloudAgentNext.closeTerminal.mutationOptions());
+  const orgClose = useMutation(trpc.organizations.cloudAgentNext.closeTerminal.mutationOptions());
+
+  const personalCreateRef = useRef(personalCreate.mutateAsync);
+  const orgCreateRef = useRef(orgCreate.mutateAsync);
+  const personalRefreshTicketRef = useRef(personalRefreshTicket.mutateAsync);
+  const orgRefreshTicketRef = useRef(orgRefreshTicket.mutateAsync);
+  const personalResizeRef = useRef(personalResize.mutate);
+  const orgResizeRef = useRef(orgResize.mutate);
+  const personalCloseRef = useRef(personalClose.mutate);
+  const orgCloseRef = useRef(orgClose.mutate);
+
+  personalCreateRef.current = personalCreate.mutateAsync;
+  orgCreateRef.current = orgCreate.mutateAsync;
+  personalRefreshTicketRef.current = personalRefreshTicket.mutateAsync;
+  orgRefreshTicketRef.current = orgRefreshTicket.mutateAsync;
+  personalResizeRef.current = personalResize.mutate;
+  orgResizeRef.current = orgResize.mutate;
+  personalCloseRef.current = personalClose.mutate;
+  orgCloseRef.current = orgClose.mutate;
+
+  const createTerminal = useCallback(
+    (input: { cloudAgentSessionId: string; cols?: number; rows?: number }) => {
+      if (organizationId) {
+        return orgCreateRef.current({ ...input, organizationId });
+      }
+      return personalCreateRef.current(input);
+    },
+    [organizationId]
+  );
+
+  const refreshTerminalTicket = useCallback(
+    (input: { cloudAgentSessionId: string; ptyId: string }) => {
+      if (organizationId) {
+        return orgRefreshTicketRef.current({ ...input, organizationId });
+      }
+      return personalRefreshTicketRef.current(input);
+    },
+    [organizationId]
+  );
+
+  const resizeTerminal = useCallback(
+    (input: { cloudAgentSessionId: string; ptyId: string; cols: number; rows: number }) => {
+      if (organizationId) {
+        orgResizeRef.current({ ...input, organizationId });
+        return;
+      }
+      personalResizeRef.current(input);
+    },
+    [organizationId]
+  );
+
+  const closeTerminal = useCallback(
+    (input: { cloudAgentSessionId: string; ptyId: string }) => {
+      if (organizationId) {
+        orgCloseRef.current({ ...input, organizationId });
+        return;
+      }
+      personalCloseRef.current(input);
+    },
+    [organizationId]
+  );
+
+  const reconnect = useCallback(() => {
+    reconnectNowRef.current();
+  }, []);
+
+  useEffect(() => {
+    if (!active || !cloudAgentSessionId) return;
+
+    const frame = requestAnimationFrame(() => {
+      fitAddonRef.current?.fit();
+      const dims = fitAddonRef.current?.proposeDimensions();
+      const ptyId = ptyIdRef.current;
+      if (dims && ptyId) {
+        resizeTerminal({
+          cloudAgentSessionId,
+          ptyId,
+          cols: dims.cols,
+          rows: dims.rows,
+        });
+      }
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [active, cloudAgentSessionId, resizeTerminal]);
+
+  useEffect(() => {
+    if (!enabled || !cloudAgentSessionId) return;
+
+    let disposed = false;
+    const capturedSessionId = cloudAgentSessionId;
+    intentionalCloseRef.current = false;
+
+    function updateStatus(next: TerminalStatus, text: string) {
+      if (disposed) return;
+      setStatus(next);
+      setStatusText(text);
+    }
+
+    updateStatus('connecting', 'Connecting terminal');
+
+    function sendResize(cols: number, rows: number) {
+      const ptyId = ptyIdRef.current;
+      if (!ptyId) return;
+      resizeTerminal({ cloudAgentSessionId: capturedSessionId, ptyId, cols, rows });
+    }
+
+    function scheduleResizeFit() {
+      if (!activeRef.current) return;
+      if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+      resizeTimerRef.current = setTimeout(() => {
+        resizeTimerRef.current = null;
+        if (disposed || !activeRef.current) return;
+        fitAddonRef.current?.fit();
+      }, RESIZE_DEBOUNCE_MS);
+    }
+
+    function scheduleReconnect(term: Terminal, fitAddon: FitAddon, text: string) {
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+
+      const attempt = reconnectAttemptsRef.current;
+      const delay = getTerminalReconnectDelayMs(attempt);
+      reconnectAttemptsRef.current = attempt + 1;
+      updateStatus('reconnecting', text);
+      reconnectTimerRef.current = setTimeout(() => {
+        reconnectTimerRef.current = null;
+        if (!disposed) void reconnectTerminal(term, fitAddon);
+      }, delay);
+    }
+
+    function connectWs(term: Terminal, fitAddon: FitAddon, wsUrl: string) {
+      const ws = new WebSocket(resolveCloudAgentTerminalWsUrl(wsUrl, CLOUD_AGENT_NEXT_WS_URL));
+      ws.binaryType = 'arraybuffer';
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        if (disposed) return;
+        reconnectAttemptsRef.current = 0;
+        updateStatus('connected', 'Connected');
+        const dims = fitAddon.proposeDimensions();
+        if (dims) sendResize(dims.cols, dims.rows);
+      };
+
+      ws.onmessage = event => {
+        if (disposed || isPtyControlFrame(event.data)) return;
+        if (event.data instanceof ArrayBuffer) {
+          term.write(new Uint8Array(event.data));
+          return;
+        }
+        term.write(event.data);
+      };
+
+      ws.onclose = event => {
+        if (disposed) return;
+        if (wsRef.current === ws) wsRef.current = null;
+        if (intentionalCloseRef.current) {
+          updateStatus('disconnected', 'Disconnected');
+          return;
+        }
+
+        const decision = classifyTerminalSocketClose({
+          code: event.code,
+          reason: event.reason,
+        });
+
+        if (decision.kind === 'retry') {
+          scheduleReconnect(term, fitAddon, decision.statusText);
+          return;
+        }
+
+        const previousPtyId = ptyIdRef.current;
+        ptyIdRef.current = null;
+        if (previousPtyId) {
+          closeTerminal({ cloudAgentSessionId: capturedSessionId, ptyId: previousPtyId });
+        }
+
+        updateStatus(decision.kind === 'exited' ? 'exited' : 'error', decision.statusText);
+      };
+
+      ws.onerror = () => {
+        if (!disposed) updateStatus('reconnecting', 'Connection issue');
+      };
+    }
+
+    async function reconnectTerminal(term: Terminal, fitAddon: FitAddon) {
+      const ptyId = ptyIdRef.current;
+      if (!ptyId) {
+        await createAndConnect(term, fitAddon);
+        return;
+      }
+
+      if (reconnectAttemptsRef.current === 0) {
+        updateStatus('reconnecting', 'Retrying terminal');
+      }
+      try {
+        const result = await refreshTerminalTicket({
+          cloudAgentSessionId: capturedSessionId,
+          ptyId,
+        });
+        if (!disposed) connectWs(term, fitAddon, result.wsUrl);
+      } catch (error) {
+        if (disposed) return;
+        const decision = classifyTerminalCreateError(error);
+        if (decision.kind === 'retry') {
+          scheduleReconnect(term, fitAddon, decision.statusText);
+          return;
+        }
+        updateStatus('error', decision.statusText);
+      }
+    }
+
+    async function createAndConnect(term: Terminal, fitAddon: FitAddon) {
+      if (reconnectAttemptsRef.current === 0) {
+        updateStatus('connecting', 'Connecting terminal');
+      }
+      const dims = fitAddon.proposeDimensions();
+      try {
+        const result = await createTerminal({
+          cloudAgentSessionId: capturedSessionId,
+          cols: dims?.cols,
+          rows: dims?.rows,
+        });
+        if (disposed) {
+          closeTerminal({ cloudAgentSessionId: capturedSessionId, ptyId: result.ptyId });
+          return;
+        }
+
+        ptyIdRef.current = result.ptyId;
+        connectWs(term, fitAddon, result.wsUrl);
+      } catch (error) {
+        if (disposed) return;
+        const decision = classifyTerminalCreateError(error);
+        if (decision.kind === 'retry') {
+          scheduleReconnect(term, fitAddon, decision.statusText);
+          return;
+        }
+        updateStatus('error', decision.statusText);
+      }
+    }
+
+    async function init() {
+      const container = terminalRef.current;
+      if (!container) return;
+
+      const [{ Terminal }, { FitAddon }, { WebLinksAddon }, { ClipboardAddon }] = await Promise.all(
+        [
+          import('@xterm/xterm'),
+          import('@xterm/addon-fit'),
+          import('@xterm/addon-web-links'),
+          import('@xterm/addon-clipboard'),
+        ]
+      );
+
+      if (disposed) return;
+
+      const fitAddon = new FitAddon();
+      const term = new Terminal({
+        cursorBlink: true,
+        fontSize: 13,
+        lineHeight: 1.25,
+        fontFamily:
+          '"JetBrains Mono", "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+        theme: {
+          background: '#0a0a0a',
+          foreground: '#e5e5e5',
+          cursor: '#fafafa',
+          selectionBackground: '#404040',
+        },
+        allowProposedApi: true,
+        scrollback: 5000,
+      });
+
+      term.loadAddon(fitAddon);
+      term.loadAddon(new WebLinksAddon());
+      term.loadAddon(new ClipboardAddon());
+      term.open(container);
+      fitAddon.fit();
+
+      xtermRef.current = term;
+      fitAddonRef.current = fitAddon;
+      reconnectNowRef.current = () => {
+        if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+        reconnectAttemptsRef.current = 0;
+        intentionalCloseRef.current = false;
+        void reconnectTerminal(term, fitAddon);
+      };
+
+      term.onResize(({ cols, rows }) => sendResize(cols, rows));
+      term.onData(data => {
+        const ws = wsRef.current;
+        if (ws?.readyState === WebSocket.OPEN) ws.send(data);
+      });
+
+      const observer = new ResizeObserver(scheduleResizeFit);
+      observer.observe(container);
+      resizeObserverRef.current = observer;
+
+      await createAndConnect(term, fitAddon);
+    }
+
+    void init();
+
+    return () => {
+      disposed = true;
+      intentionalCloseRef.current = true;
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+      if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+      resizeObserverRef.current?.disconnect();
+      wsRef.current?.close(1000, 'Terminal closed');
+      const ptyId = ptyIdRef.current;
+      if (ptyId) {
+        closeTerminal({ cloudAgentSessionId: capturedSessionId, ptyId });
+      }
+      wsRef.current = null;
+      ptyIdRef.current = null;
+      xtermRef.current?.dispose();
+      xtermRef.current = null;
+      fitAddonRef.current = null;
+      resizeObserverRef.current = null;
+      reconnectNowRef.current = () => {};
+      updateStatus('disconnected', 'Disconnected');
+    };
+  }, [
+    cloudAgentSessionId,
+    closeTerminal,
+    createTerminal,
+    enabled,
+    refreshTerminalTicket,
+    resizeTerminal,
+  ]);
+
+  return {
+    terminalRef,
+    status,
+    statusText,
+    connected: status === 'connected',
+    reconnect,
+  };
+}

--- a/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -168,6 +168,46 @@ export type SendMessageInput = {
   messageId?: string;
 };
 
+export type TerminalPty = {
+  id: string;
+  title: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  status: 'running' | 'exited';
+  pid: number;
+};
+
+export type CreateTerminalInput = {
+  cloudAgentSessionId: string;
+  cols?: number;
+  rows?: number;
+};
+
+export type CreateTerminalOutput = {
+  pty: TerminalPty;
+};
+
+export type ResizeTerminalInput = {
+  cloudAgentSessionId: string;
+  ptyId: string;
+  cols: number;
+  rows: number;
+};
+
+export type ResizeTerminalOutput = {
+  pty: TerminalPty;
+};
+
+export type CloseTerminalInput = {
+  cloudAgentSessionId: string;
+  ptyId: string;
+};
+
+export type CloseTerminalOutput = {
+  success: boolean;
+};
+
 /** Output from V2 mutation procedures (WebSocket-based) */
 export type InitiateSessionOutput = {
   cloudAgentSessionId: string;
@@ -394,6 +434,15 @@ type CloudAgentNextTRPCClient = {
   };
   sendMessageV2: {
     mutate: (input: SendMessageInput) => Promise<InitiateSessionOutput>;
+  };
+  createTerminal: {
+    mutate: (input: CreateTerminalInput) => Promise<CreateTerminalOutput>;
+  };
+  resizeTerminal: {
+    mutate: (input: ResizeTerminalInput) => Promise<ResizeTerminalOutput>;
+  };
+  closeTerminal: {
+    mutate: (input: CloseTerminalInput) => Promise<CloseTerminalOutput>;
   };
   answerQuestion: {
     mutate: (input: AnswerQuestionInput) => Promise<{ success: boolean }>;
@@ -634,6 +683,42 @@ export class CloudAgentNextClient {
         extra: { input },
       });
       throw normalizedError;
+    }
+  }
+
+  async createTerminal(input: CreateTerminalInput): Promise<CreateTerminalOutput> {
+    try {
+      return await this.client.createTerminal.mutate(input);
+    } catch (error) {
+      captureException(error, {
+        tags: { source: 'cloud-agent-next-client', endpoint: 'createTerminal' },
+        extra: { cloudAgentSessionId: input.cloudAgentSessionId },
+      });
+      throw error;
+    }
+  }
+
+  async resizeTerminal(input: ResizeTerminalInput): Promise<ResizeTerminalOutput> {
+    try {
+      return await this.client.resizeTerminal.mutate(input);
+    } catch (error) {
+      captureException(error, {
+        tags: { source: 'cloud-agent-next-client', endpoint: 'resizeTerminal' },
+        extra: { cloudAgentSessionId: input.cloudAgentSessionId, ptyId: input.ptyId },
+      });
+      throw error;
+    }
+  }
+
+  async closeTerminal(input: CloseTerminalInput): Promise<CloseTerminalOutput> {
+    try {
+      return await this.client.closeTerminal.mutate(input);
+    } catch (error) {
+      captureException(error, {
+        tags: { source: 'cloud-agent-next-client', endpoint: 'closeTerminal' },
+        extra: { cloudAgentSessionId: input.cloudAgentSessionId, ptyId: input.ptyId },
+      });
+      throw error;
     }
   }
 

--- a/apps/web/src/lib/cloud-agent-next/terminal-errors.ts
+++ b/apps/web/src/lib/cloud-agent-next/terminal-errors.ts
@@ -1,0 +1,53 @@
+import 'server-only';
+import { TRPCClientError } from '@trpc/client';
+import { TRPCError } from '@trpc/server';
+
+type TerminalTRPCCode = 'NOT_FOUND' | 'FORBIDDEN' | 'PRECONDITION_FAILED' | 'SERVICE_UNAVAILABLE';
+type TerminalClientErrorShape = {
+  data?: unknown;
+  shape?: { data?: unknown } | null;
+};
+
+const HTTP_STATUS_TO_CODE = new Map<number, TerminalTRPCCode>([
+  [403, 'FORBIDDEN'],
+  [404, 'NOT_FOUND'],
+  [412, 'PRECONDITION_FAILED'],
+  [503, 'SERVICE_UNAVAILABLE'],
+]);
+
+function readHttpStatus(error: TerminalClientErrorShape): number | undefined {
+  const data = error.data as { httpStatus?: unknown } | undefined;
+  if (typeof data?.httpStatus === 'number') return data.httpStatus;
+
+  const shapeData = error.shape?.data as { httpStatus?: unknown } | undefined;
+  if (typeof shapeData?.httpStatus === 'number') return shapeData.httpStatus;
+
+  return undefined;
+}
+
+function readCode(error: TerminalClientErrorShape): TerminalTRPCCode | undefined {
+  const data = error.data as { code?: unknown } | undefined;
+  const code = data?.code;
+  if (
+    code === 'NOT_FOUND' ||
+    code === 'FORBIDDEN' ||
+    code === 'PRECONDITION_FAILED' ||
+    code === 'SERVICE_UNAVAILABLE'
+  ) {
+    return code;
+  }
+
+  const httpStatus = readHttpStatus(error);
+  return httpStatus === undefined ? undefined : HTTP_STATUS_TO_CODE.get(httpStatus);
+}
+
+export function rethrowAsTerminalError(error: unknown): never {
+  if (error instanceof TRPCClientError) {
+    const code = readCode(error);
+    if (code) {
+      throw new TRPCError({ code, message: error.message });
+    }
+  }
+
+  throw error;
+}

--- a/apps/web/src/lib/cloud-agent/stream-ticket.ts
+++ b/apps/web/src/lib/cloud-agent/stream-ticket.ts
@@ -3,10 +3,12 @@ import crypto from 'node:crypto';
 import { NEXTAUTH_SECRET } from '@/lib/config.server';
 
 export type StreamTicketPayload = {
+  purpose?: 'stream' | 'terminal';
   userId: string;
   kiloSessionId?: string;
   cloudAgentSessionId: string;
   organizationId?: string;
+  ptyId?: string;
 };
 
 export function signStreamTicket(

--- a/apps/web/src/routers/cloud-agent-next-router.ts
+++ b/apps/web/src/routers/cloud-agent-next-router.ts
@@ -4,6 +4,7 @@ import {
   createCloudAgentNextClient,
   rethrowAsPaymentRequired,
 } from '@/lib/cloud-agent-next/cloud-agent-client';
+import { rethrowAsTerminalError } from '@/lib/cloud-agent-next/terminal-errors';
 import { generateCloudAgentToken } from '@/lib/tokens';
 import { fetchGitHubRepositoriesForUser } from '@/lib/cloud-agent/github-integration-helpers';
 import {
@@ -23,12 +24,77 @@ import {
   baseAnswerQuestionNextSchema,
   baseRejectQuestionNextSchema,
   baseAnswerPermissionNextSchema,
+  baseCreateTerminalNextSchema,
+  baseCreateTerminalNextOutputSchema,
+  baseRefreshTerminalTicketNextSchema,
+  baseRefreshTerminalTicketNextOutputSchema,
+  baseResizeTerminalNextSchema,
+  baseResizeTerminalNextOutputSchema,
+  baseCloseTerminalNextSchema,
+  baseCloseTerminalNextOutputSchema,
   cloudAgentGetImageUploadUrlSchema,
 } from './cloud-agent-next-schemas';
 import { generateImageUploadUrl } from '@/lib/r2/cloud-agent-attachments';
 import * as z from 'zod';
 import { PLATFORM } from '@/lib/integrations/core/constants';
+import { signStreamTicket } from '@/lib/cloud-agent/stream-ticket';
+import { db } from '@/lib/drizzle';
+import { verifyUserOwnsSessionV2ByCloudAgentId } from '@/lib/cloud-agent/session-ownership';
 import { TRPCError } from '@trpc/server';
+
+function buildTerminalUrl(params: {
+  cloudAgentSessionId: string;
+  ptyId: string;
+  ticket: string;
+}): string {
+  const search = new URLSearchParams({
+    cloudAgentSessionId: params.cloudAgentSessionId,
+    ptyId: params.ptyId,
+    ticket: params.ticket,
+  });
+  return `/terminal?${search.toString()}`;
+}
+
+function createTerminalTicket(params: {
+  userId: string;
+  cloudAgentSessionId: string;
+  ptyId: string;
+}) {
+  const signed = signStreamTicket({
+    purpose: 'terminal',
+    userId: params.userId,
+    cloudAgentSessionId: params.cloudAgentSessionId,
+    ptyId: params.ptyId,
+  });
+
+  return {
+    wsUrl: buildTerminalUrl({
+      cloudAgentSessionId: params.cloudAgentSessionId,
+      ptyId: params.ptyId,
+      ticket: signed.ticket,
+    }),
+    ticket: signed.ticket,
+    expiresAt: signed.expiresAt,
+  };
+}
+
+async function assertUserOwnsTerminalSession(
+  userId: string,
+  cloudAgentSessionId: string
+): Promise<void> {
+  const sessionOwnership = await verifyUserOwnsSessionV2ByCloudAgentId(
+    db,
+    userId,
+    cloudAgentSessionId
+  );
+
+  if (!sessionOwnership) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Session not found or access denied',
+    });
+  }
+}
 
 /**
  * Cloud Agent Next Router (Personal Context)
@@ -142,6 +208,75 @@ export const cloudAgentNextRouter = createTRPCRouter({
       } catch (error) {
         rethrowAsPaymentRequired(error);
         throw error;
+      }
+    }),
+
+  createTerminal: baseProcedure
+    .input(baseCreateTerminalNextSchema)
+    .output(baseCreateTerminalNextOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertUserOwnsTerminalSession(ctx.user.id, input.cloudAgentSessionId);
+
+      try {
+        const authToken = generateCloudAgentToken(ctx.user);
+        const client = createCloudAgentNextClient(authToken);
+        const result = await client.createTerminal(input);
+        const terminalTicket = createTerminalTicket({
+          userId: ctx.user.id,
+          cloudAgentSessionId: input.cloudAgentSessionId,
+          ptyId: result.pty.id,
+        });
+
+        return {
+          pty: result.pty,
+          ptyId: result.pty.id,
+          ...terminalTicket,
+        };
+      } catch (error) {
+        rethrowAsTerminalError(error);
+      }
+    }),
+
+  refreshTerminalTicket: baseProcedure
+    .input(baseRefreshTerminalTicketNextSchema)
+    .output(baseRefreshTerminalTicketNextOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertUserOwnsTerminalSession(ctx.user.id, input.cloudAgentSessionId);
+
+      return createTerminalTicket({
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.cloudAgentSessionId,
+        ptyId: input.ptyId,
+      });
+    }),
+
+  resizeTerminal: baseProcedure
+    .input(baseResizeTerminalNextSchema)
+    .output(baseResizeTerminalNextOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertUserOwnsTerminalSession(ctx.user.id, input.cloudAgentSessionId);
+
+      try {
+        const authToken = generateCloudAgentToken(ctx.user);
+        const client = createCloudAgentNextClient(authToken);
+        return await client.resizeTerminal(input);
+      } catch (error) {
+        rethrowAsTerminalError(error);
+      }
+    }),
+
+  closeTerminal: baseProcedure
+    .input(baseCloseTerminalNextSchema)
+    .output(baseCloseTerminalNextOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertUserOwnsTerminalSession(ctx.user.id, input.cloudAgentSessionId);
+
+      try {
+        const authToken = generateCloudAgentToken(ctx.user);
+        const client = createCloudAgentNextClient(authToken);
+        return await client.closeTerminal(input);
+      } catch (error) {
+        rethrowAsTerminalError(error);
       }
     }),
 

--- a/apps/web/src/routers/cloud-agent-next-schemas.ts
+++ b/apps/web/src/routers/cloud-agent-next-schemas.ts
@@ -279,6 +279,75 @@ export const baseGetSessionNextSchema = z.object({
   cloudAgentSessionId: z.string(),
 });
 
+export const cloudAgentTerminalSizeSchema = z.object({
+  cols: z.number().int().min(2).max(500),
+  rows: z.number().int().min(2).max(200),
+});
+
+export const cloudAgentTerminalPtyIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-zA-Z0-9_-]+$/);
+
+export const cloudAgentTerminalPtySchema = z.object({
+  id: cloudAgentTerminalPtyIdSchema,
+  title: z.string(),
+  command: z.string(),
+  args: z.array(z.string()),
+  cwd: z.string(),
+  status: z.enum(['running', 'exited']),
+  pid: z.number().int(),
+});
+
+export const baseCreateTerminalNextSchema = z
+  .object({
+    cloudAgentSessionId: z.string(),
+  })
+  .extend(cloudAgentTerminalSizeSchema.partial().shape)
+  .refine(data => (data.cols === undefined) === (data.rows === undefined), {
+    message: 'cols and rows must be provided together',
+  });
+
+export const baseResizeTerminalNextSchema = z
+  .object({
+    cloudAgentSessionId: z.string(),
+    ptyId: cloudAgentTerminalPtyIdSchema,
+  })
+  .extend(cloudAgentTerminalSizeSchema.shape);
+
+export const baseCloseTerminalNextSchema = z.object({
+  cloudAgentSessionId: z.string(),
+  ptyId: cloudAgentTerminalPtyIdSchema,
+});
+
+export const baseCreateTerminalNextOutputSchema = z.object({
+  pty: cloudAgentTerminalPtySchema,
+  ptyId: cloudAgentTerminalPtyIdSchema,
+  wsUrl: z.string().min(1),
+  ticket: z.string().min(1),
+  expiresAt: z.number().int().positive(),
+});
+
+export const baseRefreshTerminalTicketNextSchema = z.object({
+  cloudAgentSessionId: z.string(),
+  ptyId: cloudAgentTerminalPtyIdSchema,
+});
+
+export const baseRefreshTerminalTicketNextOutputSchema = z.object({
+  wsUrl: z.string().min(1),
+  ticket: z.string().min(1),
+  expiresAt: z.number().int().positive(),
+});
+
+export const baseResizeTerminalNextOutputSchema = z.object({
+  pty: cloudAgentTerminalPtySchema,
+});
+
+export const baseCloseTerminalNextOutputSchema = z.object({
+  success: z.boolean(),
+});
+
 // Execution status schema for getSession response
 export const executionStatusNextSchema = z
   .object({

--- a/apps/web/src/routers/cloud-agent-router.test.ts
+++ b/apps/web/src/routers/cloud-agent-router.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, jest, beforeEach, beforeAll } from '@jest/globals';
 import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import type { User } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { cli_sessions_v2, type User } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
 import * as cloudAgentModule from '@/lib/cloud-agent/cloud-agent-client';
 
 describe('cloudAgentRouter.deleteSession', () => {
@@ -72,5 +74,104 @@ describe('cloudAgentRouter.deleteSession', () => {
     const result = await caller.cloudAgent.deleteSession({ sessionId });
 
     expect(result).toEqual({ success: false });
+  });
+});
+
+describe('cloudAgentNextRouter.refreshTerminalTicket', () => {
+  const ownedSessionId = 'ses_terminal_ticket_personal_owned';
+  const otherSessionId = 'ses_terminal_ticket_personal_other';
+  const ownedCloudAgentSessionId = 'agent_terminal_ticket_personal_owned';
+  const otherCloudAgentSessionId = 'agent_terminal_ticket_personal_other';
+  let testUser: User;
+  let otherUser: User;
+
+  beforeAll(async () => {
+    testUser = await insertTestUser({
+      google_user_email: 'terminal-ticket-personal-owner@example.com',
+      google_user_name: 'Terminal Ticket Personal Owner',
+      is_admin: false,
+    });
+    otherUser = await insertTestUser({
+      google_user_email: 'terminal-ticket-personal-other@example.com',
+      google_user_name: 'Terminal Ticket Personal Other',
+      is_admin: false,
+    });
+
+    await db.insert(cli_sessions_v2).values([
+      {
+        session_id: ownedSessionId,
+        kilo_user_id: testUser.id,
+        cloud_agent_session_id: ownedCloudAgentSessionId,
+        created_on_platform: 'cloud-agent-web',
+      },
+      {
+        session_id: otherSessionId,
+        kilo_user_id: otherUser.id,
+        cloud_agent_session_id: otherCloudAgentSessionId,
+        created_on_platform: 'cloud-agent-web',
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, ownedSessionId));
+    await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, otherSessionId));
+  });
+
+  it('issues a terminal ticket for a session owned by the caller', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    const result = await caller.cloudAgentNext.refreshTerminalTicket({
+      cloudAgentSessionId: ownedCloudAgentSessionId,
+      ptyId: 'pty_personal_owned',
+    });
+
+    expect(result.ticket).toEqual(expect.any(String));
+    expect(result.wsUrl).toContain(`cloudAgentSessionId=${ownedCloudAgentSessionId}`);
+  });
+
+  it('rejects terminal ticket refresh for a session owned by another user', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    await expect(
+      caller.cloudAgentNext.refreshTerminalTicket({
+        cloudAgentSessionId: otherCloudAgentSessionId,
+        ptyId: 'pty_personal_other',
+      })
+    ).rejects.toThrow('Session not found or access denied');
+  });
+
+  it('rejects terminal creation for a session owned by another user', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    await expect(
+      caller.cloudAgentNext.createTerminal({
+        cloudAgentSessionId: otherCloudAgentSessionId,
+      })
+    ).rejects.toThrow('Session not found or access denied');
+  });
+
+  it('rejects terminal resizing for a session owned by another user', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    await expect(
+      caller.cloudAgentNext.resizeTerminal({
+        cloudAgentSessionId: otherCloudAgentSessionId,
+        ptyId: 'pty_personal_other',
+        cols: 120,
+        rows: 32,
+      })
+    ).rejects.toThrow('Session not found or access denied');
+  });
+
+  it('rejects terminal closure for a session owned by another user', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    await expect(
+      caller.cloudAgentNext.closeTerminal({
+        cloudAgentSessionId: otherCloudAgentSessionId,
+        ptyId: 'pty_personal_other',
+      })
+    ).rejects.toThrow('Session not found or access denied');
   });
 });

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -4,6 +4,7 @@ import {
   createCloudAgentNextClient,
   rethrowAsPaymentRequired,
 } from '@/lib/cloud-agent-next/cloud-agent-client';
+import { rethrowAsTerminalError } from '@/lib/cloud-agent-next/terminal-errors';
 import { generateCloudAgentToken } from '@/lib/tokens';
 import {
   organizationMemberProcedure,
@@ -27,12 +28,81 @@ import {
   baseAnswerQuestionNextSchema,
   baseRejectQuestionNextSchema,
   baseAnswerPermissionNextSchema,
+  baseCreateTerminalNextSchema,
+  baseCreateTerminalNextOutputSchema,
+  baseRefreshTerminalTicketNextSchema,
+  baseRefreshTerminalTicketNextOutputSchema,
+  baseResizeTerminalNextSchema,
+  baseResizeTerminalNextOutputSchema,
+  baseCloseTerminalNextSchema,
+  baseCloseTerminalNextOutputSchema,
   cloudAgentGetImageUploadUrlSchema,
 } from '../cloud-agent-next-schemas';
 import { generateImageUploadUrl } from '@/lib/r2/cloud-agent-attachments';
 import * as z from 'zod';
 import { PLATFORM } from '@/lib/integrations/core/constants';
+import { signStreamTicket } from '@/lib/cloud-agent/stream-ticket';
+import { db } from '@/lib/drizzle';
+import { verifyOrgOwnsSessionV2ByCloudAgentId } from '@/lib/cloud-agent/session-ownership';
 import { TRPCError } from '@trpc/server';
+
+function buildTerminalUrl(params: {
+  cloudAgentSessionId: string;
+  ptyId: string;
+  ticket: string;
+}): string {
+  const search = new URLSearchParams({
+    cloudAgentSessionId: params.cloudAgentSessionId,
+    ptyId: params.ptyId,
+    ticket: params.ticket,
+  });
+  return `/terminal?${search.toString()}`;
+}
+
+function createTerminalTicket(params: {
+  userId: string;
+  organizationId: string;
+  cloudAgentSessionId: string;
+  ptyId: string;
+}) {
+  const signed = signStreamTicket({
+    purpose: 'terminal',
+    userId: params.userId,
+    cloudAgentSessionId: params.cloudAgentSessionId,
+    organizationId: params.organizationId,
+    ptyId: params.ptyId,
+  });
+
+  return {
+    wsUrl: buildTerminalUrl({
+      cloudAgentSessionId: params.cloudAgentSessionId,
+      ptyId: params.ptyId,
+      ticket: signed.ticket,
+    }),
+    ticket: signed.ticket,
+    expiresAt: signed.expiresAt,
+  };
+}
+
+async function assertOrganizationOwnsTerminalSession(params: {
+  organizationId: string;
+  userId: string;
+  cloudAgentSessionId: string;
+}): Promise<void> {
+  const sessionOwnership = await verifyOrgOwnsSessionV2ByCloudAgentId(
+    db,
+    params.organizationId,
+    params.userId,
+    params.cloudAgentSessionId
+  );
+
+  if (!sessionOwnership) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Organization does not own this session',
+    });
+  }
+}
 
 // Extend base schemas with organizationId for organization context
 const PrepareSessionInput = basePrepareSessionNextSchema.and(
@@ -58,6 +128,22 @@ const ImageUploadUrlInput = cloudAgentGetImageUploadUrlSchema.extend({
 });
 
 const GetSessionInput = baseGetSessionNextSchema.extend({
+  organizationId: z.uuid(),
+});
+
+const CreateTerminalInput = baseCreateTerminalNextSchema.extend({
+  organizationId: z.uuid(),
+});
+
+const RefreshTerminalTicketInput = baseRefreshTerminalTicketNextSchema.extend({
+  organizationId: z.uuid(),
+});
+
+const ResizeTerminalInput = baseResizeTerminalNextSchema.extend({
+  organizationId: z.uuid(),
+});
+
+const CloseTerminalInput = baseCloseTerminalNextSchema.extend({
   organizationId: z.uuid(),
 });
 
@@ -202,6 +288,105 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       } catch (error) {
         rethrowAsPaymentRequired(error);
         throw error;
+      }
+    }),
+
+  createTerminal: organizationMemberMutationProcedure
+    .input(CreateTerminalInput)
+    .output(baseCreateTerminalNextOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertOrganizationOwnsTerminalSession({
+        organizationId: input.organizationId,
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.cloudAgentSessionId,
+      });
+
+      try {
+        const authToken = generateCloudAgentToken(ctx.user);
+        const client = createCloudAgentNextClient(authToken);
+        const result = await client.createTerminal({
+          cloudAgentSessionId: input.cloudAgentSessionId,
+          cols: input.cols,
+          rows: input.rows,
+        });
+        const terminalTicket = createTerminalTicket({
+          userId: ctx.user.id,
+          organizationId: input.organizationId,
+          cloudAgentSessionId: input.cloudAgentSessionId,
+          ptyId: result.pty.id,
+        });
+
+        return {
+          pty: result.pty,
+          ptyId: result.pty.id,
+          ...terminalTicket,
+        };
+      } catch (error) {
+        rethrowAsTerminalError(error);
+      }
+    }),
+
+  refreshTerminalTicket: organizationMemberMutationProcedure
+    .input(RefreshTerminalTicketInput)
+    .output(baseRefreshTerminalTicketNextOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertOrganizationOwnsTerminalSession({
+        organizationId: input.organizationId,
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.cloudAgentSessionId,
+      });
+
+      return createTerminalTicket({
+        userId: ctx.user.id,
+        organizationId: input.organizationId,
+        cloudAgentSessionId: input.cloudAgentSessionId,
+        ptyId: input.ptyId,
+      });
+    }),
+
+  resizeTerminal: organizationMemberMutationProcedure
+    .input(ResizeTerminalInput)
+    .output(baseResizeTerminalNextOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertOrganizationOwnsTerminalSession({
+        organizationId: input.organizationId,
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.cloudAgentSessionId,
+      });
+
+      try {
+        const authToken = generateCloudAgentToken(ctx.user);
+        const client = createCloudAgentNextClient(authToken);
+        return await client.resizeTerminal({
+          cloudAgentSessionId: input.cloudAgentSessionId,
+          ptyId: input.ptyId,
+          cols: input.cols,
+          rows: input.rows,
+        });
+      } catch (error) {
+        rethrowAsTerminalError(error);
+      }
+    }),
+
+  closeTerminal: organizationMemberMutationProcedure
+    .input(CloseTerminalInput)
+    .output(baseCloseTerminalNextOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await assertOrganizationOwnsTerminalSession({
+        organizationId: input.organizationId,
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.cloudAgentSessionId,
+      });
+
+      try {
+        const authToken = generateCloudAgentToken(ctx.user);
+        const client = createCloudAgentNextClient(authToken);
+        return await client.closeTerminal({
+          cloudAgentSessionId: input.cloudAgentSessionId,
+          ptyId: input.ptyId,
+        });
+      } catch (error) {
+        rethrowAsTerminalError(error);
       }
     }),
 

--- a/apps/web/src/routers/organizations/organization-cloud-agent-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-router.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, jest, beforeEach, beforeAll } from '@jest/globals';
 import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import type { User, Organization } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { cli_sessions_v2, type User, type Organization } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
 import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
 import * as cloudAgentModule from '@/lib/cloud-agent/cloud-agent-client';
 
@@ -138,5 +140,106 @@ describe('organizationCloudAgentRouter.deleteSession', () => {
     });
 
     expect(result).toEqual({ success: false });
+  });
+});
+
+describe('organizationCloudAgentNextRouter.refreshTerminalTicket', () => {
+  const organizationSessionId = 'ses_terminal_ticket_org_owned';
+  const personalSessionId = 'ses_terminal_ticket_org_personal';
+  const organizationCloudAgentSessionId = 'agent_terminal_ticket_org_owned';
+  const personalCloudAgentSessionId = 'agent_terminal_ticket_org_personal';
+  let testUser: User;
+  let testOrganization: Organization;
+
+  beforeAll(async () => {
+    testUser = await insertTestUser({
+      google_user_email: 'terminal-ticket-org-owner@example.com',
+      google_user_name: 'Terminal Ticket Org Owner',
+      is_admin: false,
+    });
+    testOrganization = await createOrganization('Terminal Ticket Organization', testUser.id);
+
+    await db.insert(cli_sessions_v2).values([
+      {
+        session_id: organizationSessionId,
+        kilo_user_id: testUser.id,
+        organization_id: testOrganization.id,
+        cloud_agent_session_id: organizationCloudAgentSessionId,
+        created_on_platform: 'cloud-agent-web',
+      },
+      {
+        session_id: personalSessionId,
+        kilo_user_id: testUser.id,
+        cloud_agent_session_id: personalCloudAgentSessionId,
+        created_on_platform: 'cloud-agent-web',
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, organizationSessionId));
+    await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, personalSessionId));
+  });
+
+  it('issues a terminal ticket for a session owned by the organization', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    const result = await caller.organizations.cloudAgentNext.refreshTerminalTicket({
+      organizationId: testOrganization.id,
+      cloudAgentSessionId: organizationCloudAgentSessionId,
+      ptyId: 'pty_org_owned',
+    });
+
+    expect(result.ticket).toEqual(expect.any(String));
+    expect(result.wsUrl).toContain(`cloudAgentSessionId=${organizationCloudAgentSessionId}`);
+  });
+
+  it('rejects terminal ticket refresh for a session outside the organization', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    await expect(
+      caller.organizations.cloudAgentNext.refreshTerminalTicket({
+        organizationId: testOrganization.id,
+        cloudAgentSessionId: personalCloudAgentSessionId,
+        ptyId: 'pty_org_other',
+      })
+    ).rejects.toThrow('Organization does not own this session');
+  });
+
+  it('rejects terminal creation for a session outside the organization', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    await expect(
+      caller.organizations.cloudAgentNext.createTerminal({
+        organizationId: testOrganization.id,
+        cloudAgentSessionId: personalCloudAgentSessionId,
+      })
+    ).rejects.toThrow('Organization does not own this session');
+  });
+
+  it('rejects terminal resizing for a session outside the organization', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    await expect(
+      caller.organizations.cloudAgentNext.resizeTerminal({
+        organizationId: testOrganization.id,
+        cloudAgentSessionId: personalCloudAgentSessionId,
+        ptyId: 'pty_org_other',
+        cols: 120,
+        rows: 32,
+      })
+    ).rejects.toThrow('Organization does not own this session');
+  });
+
+  it('rejects terminal closure for a session outside the organization', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    await expect(
+      caller.organizations.cloudAgentNext.closeTerminal({
+        organizationId: testOrganization.id,
+        cloudAgentSessionId: personalCloudAgentSessionId,
+        ptyId: 'pty_org_other',
+      })
+    ).rejects.toThrow('Organization does not own this session');
   });
 });

--- a/services/cloud-agent-next/src/auth.ts
+++ b/services/cloud-agent-next/src/auth.ts
@@ -3,11 +3,13 @@ import { verifyKiloToken, extractBearerToken } from '@kilocode/worker-utils';
 
 type StreamTicketPayload = {
   type: 'stream_ticket';
+  purpose?: 'stream' | 'terminal';
   userId?: string;
   kiloSessionId?: string;
   cloudAgentSessionId?: string;
   sessionId?: string;
   organizationId?: string;
+  ptyId?: string;
   nonce?: string;
 };
 

--- a/services/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -10,6 +10,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   WrapperClient,
+  WrapperContainerClient,
   WrapperError,
   WrapperNotReadyError,
   WrapperNoJobError,
@@ -1521,5 +1522,65 @@ describe('WrapperClient', () => {
       expect(new WrapperNoJobError('test')).toBeInstanceOf(WrapperError);
       expect(new WrapperJobConflictError('test')).toBeInstanceOf(WrapperError);
     });
+  });
+});
+
+describe('WrapperContainerClient', () => {
+  it('creates terminal PTYs through sandbox containerFetch', async () => {
+    const containerFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'pty_123',
+          title: 'Workspace terminal',
+          command: '',
+          args: [],
+          cwd: '/workspace/repo',
+          status: 'running',
+          pid: 42,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    const sandbox = { containerFetch } as unknown as SandboxInstance;
+    const client = new WrapperContainerClient({ sandbox, port: 5000 });
+
+    const pty = await client.createTerminal({ cols: 100, rows: 30 });
+
+    expect(pty.id).toBe('pty_123');
+    expect(containerFetch).toHaveBeenCalledWith(
+      'http://container/pty',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ cols: 100, rows: 30 }),
+      }),
+      5000
+    );
+  });
+
+  it('connects terminal PTYs through the websocket-capable sandbox path', async () => {
+    const terminalResponse = new Response('proxied', { status: 200 });
+    const containerFetch = vi.fn();
+    const wsConnect = vi.fn().mockResolvedValueOnce(terminalResponse);
+    const sandbox = { containerFetch, wsConnect } as unknown as SandboxInstance;
+    const client = new WrapperContainerClient({ sandbox, port: 5000 });
+    const request = new Request('http://worker.test/terminal?cloudAgentSessionId=session-1', {
+      headers: {
+        Connection: 'Upgrade',
+        Upgrade: 'websocket',
+        'X-Test': 'preserved',
+      },
+    });
+
+    const response = await client.connectTerminal('pty_123', request);
+
+    expect(response).toBe(terminalResponse);
+    expect(containerFetch).not.toHaveBeenCalled();
+    expect(wsConnect).toHaveBeenCalledTimes(1);
+    const connectRequest = wsConnect.mock.calls[0]?.[0];
+    expect(connectRequest).toBeInstanceOf(Request);
+    expect(new URL((connectRequest as Request).url).pathname).toBe('/pty/pty_123/connect');
+    expect((connectRequest as Request).headers.get('Upgrade')).toBe('websocket');
+    expect((connectRequest as Request).headers.get('X-Test')).toBe('preserved');
+    expect(wsConnect.mock.calls[0]?.[1]).toBe(5000);
   });
 });

--- a/services/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -112,6 +112,16 @@ export type WrapperHealthResponse = {
   sessionId: string;
 };
 
+export type WrapperPty = {
+  id: string;
+  title: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  status: 'running' | 'exited';
+  pid: number;
+};
+
 export type JobStatus = {
   state: 'idle' | 'active';
   executionId?: string;
@@ -125,6 +135,11 @@ export type JobStatus = {
 };
 
 export type WrapperSessionCommandResponse = unknown;
+
+export type WrapperContainerClientOptions = {
+  sandbox: SandboxInstance;
+  port: number;
+};
 
 // ---------------------------------------------------------------------------
 // Error Classes
@@ -811,5 +826,80 @@ export class WrapperClient {
    */
   async status(): Promise<JobStatus> {
     return this.request<JobStatus>('GET', '/job/status');
+  }
+}
+
+/**
+ * Wrapper client that talks to the already-running wrapper over containerFetch.
+ * Used for terminal support so WebSocket/HTTP proxying goes through the wrapper
+ * without starting a new wrapper process or using sandbox terminal primitives.
+ */
+export class WrapperContainerClient {
+  private readonly sandbox: SandboxInstance;
+  private readonly port: number;
+
+  constructor(options: WrapperContainerClientOptions) {
+    this.sandbox = options.sandbox;
+    this.port = options.port;
+  }
+
+  private async request<T extends object>(
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+    path: string,
+    body?: unknown
+  ): Promise<T> {
+    const response = await this.sandbox.containerFetch(
+      `http://container${path}`,
+      {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      },
+      this.port
+    );
+
+    const text = await response.text();
+    const data = text ? (JSON.parse(text) as T & { error?: string; message?: string }) : ({} as T);
+
+    const errorPayload = data as { error?: string; message?: string };
+    if (!response.ok || errorPayload.error) {
+      const errorCode = errorPayload.error ?? 'REQUEST_FAILED';
+      const message =
+        typeof errorPayload.message === 'string'
+          ? errorPayload.message
+          : `Wrapper request failed with status ${response.status}`;
+      throw new WrapperError(message, errorCode, response.status);
+    }
+
+    return data;
+  }
+
+  async health(): Promise<WrapperHealthResponse> {
+    return this.request<WrapperHealthResponse>('GET', '/health');
+  }
+
+  async createTerminal(size?: { cols: number; rows: number }): Promise<WrapperPty> {
+    return this.request<WrapperPty>('POST', '/pty', size);
+  }
+
+  async resizeTerminal(
+    ptyId: string,
+    size: {
+      cols: number;
+      rows: number;
+    }
+  ): Promise<WrapperPty> {
+    return this.request<WrapperPty>('PUT', `/pty/${encodeURIComponent(ptyId)}`, size);
+  }
+
+  async closeTerminal(ptyId: string): Promise<{ success: boolean }> {
+    return this.request<{ success: boolean }>('DELETE', `/pty/${encodeURIComponent(ptyId)}`);
+  }
+
+  async connectTerminal(ptyId: string, request: Request): Promise<Response> {
+    return this.sandbox.wsConnect(
+      new Request(`http://container/pty/${encodeURIComponent(ptyId)}/connect`, request),
+      this.port
+    );
   }
 }

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -91,6 +91,8 @@ import { stopWrapper } from '../kilo/wrapper-manager.js';
 import { SessionService } from '../session-service.js';
 import { executePreparationSteps } from './async-preparation.js';
 import { resolveManagedGitLabToken } from '../services/git-token-service-client.js';
+import { resolveTerminalWrapperClient, type TerminalWrapperClient } from '../terminal/access.js';
+import type { WrapperPty } from '../kilo/wrapper-client.js';
 
 // ---------------------------------------------------------------------------
 // Alarm Constants
@@ -136,6 +138,13 @@ type DisconnectGraceState = {
   wsCloseCode: number;
   wsCloseReason: string;
 };
+
+type TerminalSizeInput = {
+  cols: number;
+  rows: number;
+};
+
+type TerminalCreateInput = Partial<TerminalSizeInput>;
 
 function validateModeAgainstRuntimeAgents(metadata: CloudAgentSessionState): string | null {
   const mode = metadata.mode;
@@ -376,6 +385,16 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
     return this.ingestHandler;
   }
 
+  private isAllowedWebSocketOrigin(origin: string | null): boolean {
+    const allowedOrigins = (this.env.WS_ALLOWED_ORIGINS || '')
+      .split(',')
+      .map(value => value.trim())
+      .filter(Boolean);
+
+    const isRealOrigin = origin !== null && origin !== 'null';
+    return allowedOrigins.length === 0 || !isRealOrigin || allowedOrigins.includes(origin);
+  }
+
   // ---------------------------------------------------------------------------
   // HTTP/WebSocket Routing
   // ---------------------------------------------------------------------------
@@ -393,20 +412,9 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       const ticket = url.searchParams.get('ticket');
       const origin = request.headers.get('Origin');
 
-      const allowedOrigins = (this.env.WS_ALLOWED_ORIGINS || '')
-        .split(',')
-        .map(value => value.trim())
-        .filter(Boolean);
-
-      // Only enforce the Origin allowlist when the client sends a real browser
-      // Origin. Native clients (iOS/Android) either omit the header entirely or
-      // send the literal string "null" — both cases are allowed through because
-      // the Worker already authenticated the request via the JWT ticket before
-      // forwarding here.
-      const isRealOrigin = origin !== null && origin !== 'null';
-      if (allowedOrigins.length > 0 && isRealOrigin && !allowedOrigins.includes(origin)) {
+      if (!this.isAllowedWebSocketOrigin(origin)) {
         logger
-          .withFields({ origin, allowedOrigins, sessionId: sessionIdParam })
+          .withFields({ origin, sessionId: sessionIdParam })
           .warn('DO /stream: Origin not allowed');
         return new Response('Origin not allowed', { status: 403 });
       }
@@ -875,6 +883,97 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
     this.sendToWrapper(activeExecutionId, { type: 'kill', signal: 'SIGTERM' });
 
     return { success: true };
+  }
+
+  private async getTerminalClient(): Promise<OperationResult<{ client: TerminalWrapperClient }>> {
+    const sessionId = await this.requireSessionId();
+    const terminal = await resolveTerminalWrapperClient({
+      env: this.env,
+      metadata: await this.getMetadata(),
+      sessionId,
+    });
+
+    if (!terminal.success || !terminal.data) {
+      return { success: false, error: terminal.error };
+    }
+
+    return { success: true, data: { client: terminal.data.client } };
+  }
+
+  async createTerminal(input: TerminalCreateInput): Promise<OperationResult<{ pty: WrapperPty }>> {
+    const terminal = await this.getTerminalClient();
+    if (!terminal.success || !terminal.data) {
+      return { success: false, error: terminal.error };
+    }
+
+    try {
+      const pty = await terminal.data.client.createTerminal(
+        input.cols !== undefined && input.rows !== undefined
+          ? { cols: input.cols, rows: input.rows }
+          : undefined
+      );
+      await this.updateLastActivity();
+      return { success: true, data: { pty } };
+    } catch (error) {
+      logger
+        .withFields({
+          sessionId: this.sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        .warn('Failed to create terminal');
+      return { success: false, error: 'Terminal is unavailable' };
+    }
+  }
+
+  async resizeTerminal(input: {
+    ptyId: string;
+    cols: number;
+    rows: number;
+  }): Promise<OperationResult<{ pty: WrapperPty }>> {
+    const terminal = await this.getTerminalClient();
+    if (!terminal.success || !terminal.data) {
+      return { success: false, error: terminal.error };
+    }
+
+    try {
+      const pty = await terminal.data.client.resizeTerminal(input.ptyId, {
+        cols: input.cols,
+        rows: input.rows,
+      });
+      await this.updateLastActivity();
+      return { success: true, data: { pty } };
+    } catch (error) {
+      logger
+        .withFields({
+          sessionId: this.sessionId,
+          ptyId: input.ptyId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        .warn('Failed to resize terminal');
+      return { success: false, error: 'Terminal is unavailable' };
+    }
+  }
+
+  async closeTerminal(input: { ptyId: string }): Promise<OperationResult<{ success: boolean }>> {
+    const terminal = await this.getTerminalClient();
+    if (!terminal.success || !terminal.data) {
+      return { success: false, error: terminal.error };
+    }
+
+    try {
+      const result = await terminal.data.client.closeTerminal(input.ptyId);
+      await this.updateLastActivity();
+      return { success: true, data: result };
+    } catch (error) {
+      logger
+        .withFields({
+          sessionId: this.sessionId,
+          ptyId: input.ptyId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        .warn('Failed to close terminal');
+      return { success: false, error: 'Terminal is unavailable' };
+    }
   }
 
   /**

--- a/services/cloud-agent-next/src/router.test.ts
+++ b/services/cloud-agent-next/src/router.test.ts
@@ -61,6 +61,9 @@ type MockSessionStub = {
   getActiveExecutionId?: ReturnType<typeof vi.fn>;
   getExecution?: ReturnType<typeof vi.fn>;
   getLatestAssistantMessage?: ReturnType<typeof vi.fn>;
+  createTerminal?: ReturnType<typeof vi.fn>;
+  resizeTerminal?: ReturnType<typeof vi.fn>;
+  closeTerminal?: ReturnType<typeof vi.fn>;
 };
 
 type MockCAS = {
@@ -1195,5 +1198,59 @@ describe('router sessionId validation', () => {
         ).rejects.toThrow('Authentication required');
       });
     });
+  });
+});
+
+describe('router terminal procedures', () => {
+  it('creates a terminal through the session Durable Object', async () => {
+    const createTerminal = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        pty: {
+          id: 'pty_123',
+          title: 'Workspace terminal',
+          command: '/bin/sh',
+          args: [],
+          cwd: '/workspace/repo',
+          status: 'running',
+          pid: 123,
+        },
+      },
+    });
+    const cloudAgentSession: MockCAS = {
+      idFromName: vi.fn().mockReturnValue('do-id'),
+      get: vi.fn().mockReturnValue({ createTerminal }),
+    };
+    const context = {
+      userId: 'test-user-123',
+      authToken: 'token',
+      botId: undefined,
+      request: new Request('http://test.local'),
+      env: {
+        CLOUD_AGENT_SESSION: cloudAgentSession,
+      },
+    } as unknown as TRPCContext;
+    const caller = appRouter.createCaller(context);
+    const sessionId = 'agent_12345678-1234-1234-1234-123456789abc' as SessionId;
+
+    const result = await caller.createTerminal({
+      cloudAgentSessionId: sessionId,
+      cols: 120,
+      rows: 32,
+    });
+
+    expect(result).toEqual({
+      pty: {
+        id: 'pty_123',
+        title: 'Workspace terminal',
+        command: '/bin/sh',
+        args: [],
+        cwd: '/workspace/repo',
+        status: 'running',
+        pid: 123,
+      },
+    });
+    expect(cloudAgentSession.idFromName).toHaveBeenCalledWith(`test-user-123:${sessionId}`);
+    expect(createTerminal).toHaveBeenCalledWith({ cols: 120, rows: 32 });
   });
 });

--- a/services/cloud-agent-next/src/router.ts
+++ b/services/cloud-agent-next/src/router.ts
@@ -9,12 +9,14 @@ import { createSessionManagementHandlers } from './router/handlers/session-manag
 import { createSessionPrepareHandlers } from './router/handlers/session-prepare.js';
 import { createSessionExecutionV2Handlers } from './router/handlers/session-execution.js';
 import { createSessionQuestionHandlers } from './router/handlers/session-questions.js';
+import { createSessionTerminalHandlers } from './router/handlers/session-terminal.js';
 
 export const appRouter = router({
   ...createSessionManagementHandlers(),
   ...createSessionPrepareHandlers(),
   ...createSessionExecutionV2Handlers(),
   ...createSessionQuestionHandlers(),
+  ...createSessionTerminalHandlers(),
 });
 
 export type AppRouter = typeof appRouter;

--- a/services/cloud-agent-next/src/router/handlers/session-terminal.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-terminal.ts
@@ -1,0 +1,127 @@
+import { TRPCError } from '@trpc/server';
+import { logger, withLogTags } from '../../logger.js';
+import type { OperationResult } from '../../persistence/types.js';
+import type { CloudAgentSession } from '../../persistence/CloudAgentSession.js';
+import type { WrapperPty } from '../../kilo/wrapper-client.js';
+import type { SessionId } from '../../types/ids.js';
+import { withDORetry } from '../../utils/do-retry.js';
+import { protectedProcedure } from '../auth.js';
+import {
+  CloseTerminalInput,
+  CloseTerminalOutput,
+  CreateTerminalInput,
+  CreateTerminalOutput,
+  ResizeTerminalInput,
+  ResizeTerminalOutput,
+} from '../schemas.js';
+
+function throwTerminalError(result: OperationResult<unknown>): never {
+  const message = result.error ?? 'Terminal is unavailable';
+  const code =
+    message === 'Session not found'
+      ? 'NOT_FOUND'
+      : message.includes('interactive Cloud Agent')
+        ? 'FORBIDDEN'
+        : message.includes('workspace is prepared')
+          ? 'PRECONDITION_FAILED'
+          : 'SERVICE_UNAVAILABLE';
+
+  throw new TRPCError({ code, message });
+}
+
+function getSessionStub(
+  env: { CLOUD_AGENT_SESSION: DurableObjectNamespace<CloudAgentSession> },
+  userId: string,
+  sessionId: SessionId
+): DurableObjectStub<CloudAgentSession> {
+  const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+  return env.CLOUD_AGENT_SESSION.get(doId);
+}
+
+export function createSessionTerminalHandlers() {
+  return {
+    createTerminal: protectedProcedure
+      .input(CreateTerminalInput)
+      .output(CreateTerminalOutput)
+      .mutation(async ({ input, ctx }) => {
+        return withLogTags({ source: 'createTerminal' }, async () => {
+          const sessionId = input.cloudAgentSessionId as SessionId;
+          logger.setTags({ userId: ctx.userId, sessionId });
+
+          const result = await withDORetry<
+            DurableObjectStub<CloudAgentSession>,
+            OperationResult<{ pty: WrapperPty }>
+          >(
+            () => getSessionStub(ctx.env, ctx.userId, sessionId),
+            stub =>
+              stub.createTerminal({
+                cols: input.cols,
+                rows: input.rows,
+              }),
+            'createTerminal'
+          );
+
+          if (!result.success || !result.data) {
+            throwTerminalError(result);
+          }
+
+          return { pty: result.data.pty };
+        });
+      }),
+
+    resizeTerminal: protectedProcedure
+      .input(ResizeTerminalInput)
+      .output(ResizeTerminalOutput)
+      .mutation(async ({ input, ctx }) => {
+        return withLogTags({ source: 'resizeTerminal' }, async () => {
+          const sessionId = input.cloudAgentSessionId as SessionId;
+          logger.setTags({ userId: ctx.userId, sessionId, ptyId: input.ptyId });
+
+          const result = await withDORetry<
+            DurableObjectStub<CloudAgentSession>,
+            OperationResult<{ pty: WrapperPty }>
+          >(
+            () => getSessionStub(ctx.env, ctx.userId, sessionId),
+            stub =>
+              stub.resizeTerminal({
+                ptyId: input.ptyId,
+                cols: input.cols,
+                rows: input.rows,
+              }),
+            'resizeTerminal'
+          );
+
+          if (!result.success || !result.data) {
+            throwTerminalError(result);
+          }
+
+          return { pty: result.data.pty };
+        });
+      }),
+
+    closeTerminal: protectedProcedure
+      .input(CloseTerminalInput)
+      .output(CloseTerminalOutput)
+      .mutation(async ({ input, ctx }) => {
+        return withLogTags({ source: 'closeTerminal' }, async () => {
+          const sessionId = input.cloudAgentSessionId as SessionId;
+          logger.setTags({ userId: ctx.userId, sessionId, ptyId: input.ptyId });
+
+          const result = await withDORetry<
+            DurableObjectStub<CloudAgentSession>,
+            OperationResult<{ success: boolean }>
+          >(
+            () => getSessionStub(ctx.env, ctx.userId, sessionId),
+            stub => stub.closeTerminal({ ptyId: input.ptyId }),
+            'closeTerminal'
+          );
+
+          if (!result.success || !result.data) {
+            throwTerminalError(result);
+          }
+
+          return { success: result.data.success };
+        });
+      }),
+  };
+}

--- a/services/cloud-agent-next/src/router/schemas.ts
+++ b/services/cloud-agent-next/src/router/schemas.ts
@@ -183,6 +183,62 @@ export const SendMessageV2Input = z
 
 export type SendMessageV2InputPayload = z.infer<typeof SendMessageV2Payload>;
 
+export const PtyIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-zA-Z0-9_-]+$/, 'Invalid PTY ID format');
+
+export const TerminalSizeSchema = z.object({
+  cols: z.number().int().min(2).max(500),
+  rows: z.number().int().min(2).max(200),
+});
+
+export const TerminalPtySchema = z.object({
+  id: PtyIdSchema,
+  title: z.string(),
+  command: z.string(),
+  args: z.array(z.string()),
+  cwd: z.string(),
+  status: z.enum(['running', 'exited']),
+  pid: z.number().int(),
+});
+
+export const CreateTerminalInput = z
+  .object({
+    cloudAgentSessionId: sessionIdSchema.describe('Cloud-agent session ID to open a terminal for'),
+  })
+  .extend(TerminalSizeSchema.partial().shape)
+  .refine(data => (data.cols === undefined) === (data.rows === undefined), {
+    message: 'cols and rows must be provided together',
+  });
+
+export const CreateTerminalOutput = z.object({
+  pty: TerminalPtySchema,
+});
+
+export const ResizeTerminalInput = z
+  .object({
+    cloudAgentSessionId: sessionIdSchema.describe(
+      'Cloud-agent session ID to resize a terminal for'
+    ),
+    ptyId: PtyIdSchema,
+  })
+  .extend(TerminalSizeSchema.shape);
+
+export const ResizeTerminalOutput = z.object({
+  pty: TerminalPtySchema,
+});
+
+export const CloseTerminalInput = z.object({
+  cloudAgentSessionId: sessionIdSchema.describe('Cloud-agent session ID to close a terminal for'),
+  ptyId: PtyIdSchema,
+});
+
+export const CloseTerminalOutput = z.object({
+  success: z.boolean(),
+});
+
 /**
  * Input schema for prepareSession endpoint.
  * Creates a session in "prepared" state for later initiation.

--- a/services/cloud-agent-next/src/server.test.ts
+++ b/services/cloud-agent-next/src/server.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import jwt from 'jsonwebtoken';
+import type { Env } from './types.js';
+import { WRAPPER_VERSION } from './shared/wrapper-version.js';
+
+const { getSandboxMock, findWrapperForSessionMock } = vi.hoisted(() => ({
+  getSandboxMock: vi.fn(),
+  findWrapperForSessionMock: vi.fn(),
+}));
 
 vi.mock('./logger.js', () => {
   const logger = {
@@ -19,6 +26,11 @@ vi.mock('./logger.js', () => {
 
 vi.mock('@cloudflare/sandbox', () => ({
   Sandbox: class Sandbox {},
+  getSandbox: getSandboxMock,
+}));
+
+vi.mock('./kilo/wrapper-manager.js', () => ({
+  findWrapperForSession: findWrapperForSessionMock,
 }));
 
 vi.mock('./router.js', () => ({
@@ -47,6 +59,9 @@ const secret = 'test-secret';
 
 type MockEnv = {
   NEXTAUTH_SECRET: string;
+  Sandbox: unknown;
+  SandboxSmall: unknown;
+  WS_ALLOWED_ORIGINS?: string;
   CLOUD_AGENT_SESSION: {
     idFromName: ReturnType<typeof vi.fn>;
     get: ReturnType<typeof vi.fn>;
@@ -56,12 +71,23 @@ type MockEnv = {
 function createEnv(): MockEnv {
   return {
     NEXTAUTH_SECRET: secret,
+    Sandbox: {},
+    SandboxSmall: {},
     CLOUD_AGENT_SESSION: {
       idFromName: vi.fn(),
       get: vi.fn(),
     },
   };
 }
+
+function fetchWorker(request: Request, env: MockEnv): Promise<Response> | Response {
+  return worker.fetch(request, env as unknown as Env, {} as ExecutionContext);
+}
+
+beforeEach(() => {
+  getSandboxMock.mockReset();
+  findWrapperForSessionMock.mockReset();
+});
 
 describe('server /stream', () => {
   it('returns Ticket expired before Durable Object lookup for expired tickets', async () => {
@@ -82,11 +108,166 @@ describe('server /stream', () => {
       }
     );
 
-    const response = await worker.fetch(request, env);
+    const response = await fetchWorker(request, env);
 
     expect(response.status).toBe(401);
     await expect(response.text()).resolves.toBe('Ticket expired');
     expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
     expect(env.CLOUD_AGENT_SESSION.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('server /terminal', () => {
+  it('proxies valid terminal tickets directly to the wrapper container', async () => {
+    const ticket = jwt.sign(
+      {
+        type: 'stream_ticket',
+        purpose: 'terminal',
+        userId: 'user-1',
+        cloudAgentSessionId: 'session-1',
+        ptyId: 'pty_123',
+      },
+      secret,
+      { algorithm: 'HS256', expiresIn: 60 }
+    );
+    const env = createEnv();
+    const sandboxId = `usr-${'a'.repeat(48)}`;
+    const metadata = {
+      version: 1,
+      sessionId: 'session-1',
+      userId: 'user-1',
+      sandboxId,
+      createdOnPlatform: 'cloud-agent-web',
+      preparedAt: Date.now(),
+      workspacePath: '/workspace/user/repo',
+    };
+    const terminalResponse = new Response('proxied', { status: 200 });
+    const wsConnect = vi.fn().mockResolvedValueOnce(terminalResponse);
+    const containerFetch = vi.fn().mockResolvedValueOnce(
+      Response.json({
+        healthy: true,
+        state: 'idle',
+        version: WRAPPER_VERSION,
+        sessionId: 'session-1',
+      })
+    );
+    const sandbox = { containerFetch, wsConnect };
+    getSandboxMock.mockReturnValue(sandbox);
+    findWrapperForSessionMock.mockResolvedValue({ port: 59954 });
+    const getMetadata = vi.fn().mockResolvedValue(metadata);
+    const fetch = vi.fn();
+    env.CLOUD_AGENT_SESSION.idFromName.mockReturnValue('do-id');
+    env.CLOUD_AGENT_SESSION.get.mockReturnValue({ fetch, getMetadata });
+
+    const request = new Request(
+      `http://worker.test/terminal?cloudAgentSessionId=session-1&ptyId=pty_123&ticket=${encodeURIComponent(ticket)}`,
+      {
+        headers: { Upgrade: 'websocket' },
+      }
+    );
+
+    const response = await fetchWorker(request, env);
+
+    expect(response).toBe(terminalResponse);
+    expect(env.CLOUD_AGENT_SESSION.idFromName).toHaveBeenCalledWith('user-1:session-1');
+    expect(getMetadata).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(getSandboxMock).toHaveBeenCalledWith(env.Sandbox, sandboxId, expect.any(Object));
+    expect(findWrapperForSessionMock).toHaveBeenCalledWith(sandbox, 'session-1');
+    expect(containerFetch).toHaveBeenCalledTimes(1);
+    expect(containerFetch.mock.calls[0]).toEqual([
+      'http://container/health',
+      { method: 'GET', headers: { 'Content-Type': 'application/json' } },
+      59954,
+    ]);
+    expect(wsConnect).toHaveBeenCalledTimes(1);
+    const connectRequest = wsConnect.mock.calls[0]?.[0];
+    expect(connectRequest).toBeInstanceOf(Request);
+    expect(new URL((connectRequest as Request).url).pathname).toBe('/pty/pty_123/connect');
+    expect(wsConnect.mock.calls[0]?.[1]).toBe(59954);
+  });
+
+  it('rejects stream-purpose tickets', async () => {
+    const ticket = jwt.sign(
+      {
+        type: 'stream_ticket',
+        purpose: 'stream',
+        userId: 'user-1',
+        cloudAgentSessionId: 'session-1',
+      },
+      secret,
+      { algorithm: 'HS256', expiresIn: 60 }
+    );
+    const env = createEnv();
+    const request = new Request(
+      `http://worker.test/terminal?cloudAgentSessionId=session-1&ptyId=pty_123&ticket=${encodeURIComponent(ticket)}`,
+      {
+        headers: { Upgrade: 'websocket' },
+      }
+    );
+
+    const response = await fetchWorker(request, env);
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe('Invalid ticket purpose');
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+  });
+
+  it('rejects terminal tickets scoped to a different PTY', async () => {
+    const ticket = jwt.sign(
+      {
+        type: 'stream_ticket',
+        purpose: 'terminal',
+        userId: 'user-1',
+        cloudAgentSessionId: 'session-1',
+        ptyId: 'pty_other',
+      },
+      secret,
+      { algorithm: 'HS256', expiresIn: 60 }
+    );
+    const env = createEnv();
+    const request = new Request(
+      `http://worker.test/terminal?cloudAgentSessionId=session-1&ptyId=pty_123&ticket=${encodeURIComponent(ticket)}`,
+      {
+        headers: { Upgrade: 'websocket' },
+      }
+    );
+
+    const response = await fetchWorker(request, env);
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe('PTY mismatch');
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+  });
+
+  it('rejects disallowed WebSocket origins before looking up the session', async () => {
+    const ticket = jwt.sign(
+      {
+        type: 'stream_ticket',
+        purpose: 'terminal',
+        userId: 'user-1',
+        cloudAgentSessionId: 'session-1',
+        ptyId: 'pty_123',
+      },
+      secret,
+      { algorithm: 'HS256', expiresIn: 60 }
+    );
+    const env = createEnv();
+    env.WS_ALLOWED_ORIGINS = 'https://app.example.com';
+    const request = new Request(
+      `http://worker.test/terminal?cloudAgentSessionId=session-1&ptyId=pty_123&ticket=${encodeURIComponent(ticket)}`,
+      {
+        headers: {
+          Upgrade: 'websocket',
+          Origin: 'https://evil.example.com',
+        },
+      }
+    );
+
+    const response = await fetchWorker(request, env);
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe('Origin not allowed');
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
   });
 });

--- a/services/cloud-agent-next/src/server.ts
+++ b/services/cloud-agent-next/src/server.ts
@@ -11,8 +11,98 @@ import { createCallbackQueueConsumer } from './callbacks/index.js';
 import type { CallbackJob } from './callbacks/index.js';
 import { authMiddleware } from './middleware/auth.js';
 import { balanceMiddleware } from './middleware/balance.js';
+import { resolveTerminalWrapperClient } from './terminal/access.js';
 
 const app = new Hono<HonoContext>();
+
+function isAllowedWebSocketOrigin(env: Env, origin: string | undefined): boolean {
+  const allowedOrigins = (env.WS_ALLOWED_ORIGINS || '')
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean);
+  const isRealOrigin = origin !== undefined && origin !== 'null';
+  return allowedOrigins.length === 0 || !isRealOrigin || allowedOrigins.includes(origin);
+}
+
+async function handleTerminalWebSocket(request: Request, env: Env): Promise<Response> {
+  const upgradeHeader = request.headers.get('Upgrade');
+  if (upgradeHeader?.toLowerCase() !== 'websocket') {
+    return new Response('Expected WebSocket upgrade', { status: 426 });
+  }
+
+  const url = new URL(request.url);
+  const cloudAgentSessionId = url.searchParams.get('cloudAgentSessionId');
+  if (!cloudAgentSessionId) {
+    logger.warn('/terminal: Missing cloudAgentSessionId parameter');
+    return new Response('Missing cloudAgentSessionId parameter', { status: 400 });
+  }
+
+  const ptyId = url.searchParams.get('ptyId');
+  if (!ptyId) {
+    logger.withFields({ cloudAgentSessionId }).warn('/terminal: Missing ptyId parameter');
+    return new Response('Missing ptyId parameter', { status: 400 });
+  }
+
+  if (!isAllowedWebSocketOrigin(env, request.headers.get('Origin') ?? undefined)) {
+    logger.withFields({ cloudAgentSessionId, ptyId }).warn('/terminal: Origin not allowed');
+    return new Response('Origin not allowed', { status: 403 });
+  }
+
+  const ticket = url.searchParams.get('ticket');
+  if (!ticket) {
+    logger.withFields({ cloudAgentSessionId }).warn('/terminal: Missing ticket');
+    return new Response('Missing ticket', { status: 401 });
+  }
+
+  const ticketResult = validateStreamTicket(ticket, env.NEXTAUTH_SECRET);
+  if (!ticketResult.success) {
+    logger
+      .withFields({ cloudAgentSessionId, error: ticketResult.error })
+      .warn('/terminal: Ticket validation failed');
+    return new Response(ticketResult.error, { status: 401 });
+  }
+
+  const userId = ticketResult.payload.userId;
+  if (!userId) {
+    logger.withFields({ cloudAgentSessionId }).warn('/terminal: Invalid ticket - missing userId');
+    return new Response('Invalid ticket: missing userId', { status: 401 });
+  }
+
+  if (ticketResult.payload.purpose !== 'terminal') {
+    logger.withFields({ cloudAgentSessionId, userId }).warn('/terminal: Invalid ticket purpose');
+    return new Response('Invalid ticket purpose', { status: 403 });
+  }
+
+  const ticketCloudAgentSessionId =
+    ticketResult.payload.cloudAgentSessionId ?? ticketResult.payload.sessionId;
+  if (ticketCloudAgentSessionId !== cloudAgentSessionId) {
+    logger
+      .withFields({ cloudAgentSessionId, ticketCloudAgentSessionId })
+      .warn('/terminal: Session mismatch between URL and ticket');
+    return new Response('Session mismatch', { status: 403 });
+  }
+
+  if (ticketResult.payload.ptyId !== ptyId) {
+    logger.withFields({ cloudAgentSessionId, userId, ptyId }).warn('/terminal: PTY mismatch');
+    return new Response('PTY mismatch', { status: 403 });
+  }
+
+  logger.withFields({ cloudAgentSessionId, userId, ptyId }).info('/terminal: WebSocket authorized');
+
+  const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${cloudAgentSessionId}`);
+  const stub = env.CLOUD_AGENT_SESSION.get(doId);
+  const metadata = await stub.getMetadata();
+  const terminal = await resolveTerminalWrapperClient({
+    env,
+    metadata,
+    sessionId: cloudAgentSessionId,
+  });
+  if (!terminal.success || !terminal.data) {
+    return new Response(terminal.error ?? 'Terminal unavailable', { status: 503 });
+  }
+
+  return terminal.data.client.connectTerminal(ptyId, request);
+}
 
 app.use('*', async (c: Context<HonoContext>, next: Next) => {
   await withLogTags({ source: 'worker-entry' }, async () => {
@@ -63,6 +153,11 @@ app.get('/stream', async (c: Context<HonoContext>) => {
     return c.text('Invalid ticket: missing userId', 401);
   }
 
+  if (ticketResult.payload.purpose && ticketResult.payload.purpose !== 'stream') {
+    logger.withFields({ cloudAgentSessionId, userId }).warn('/stream: Invalid ticket purpose');
+    return c.text('Invalid ticket purpose', 403);
+  }
+
   const ticketCloudAgentSessionId =
     ticketResult.payload.cloudAgentSessionId ?? ticketResult.payload.sessionId;
   if (ticketCloudAgentSessionId !== cloudAgentSessionId) {
@@ -77,6 +172,10 @@ app.get('/stream', async (c: Context<HonoContext>) => {
   const doId = c.env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${cloudAgentSessionId}`);
   const stub = c.env.CLOUD_AGENT_SESSION.get(doId);
   return stub.fetch(c.req.raw);
+});
+
+app.get('/terminal', async (c: Context<HonoContext>) => {
+  return handleTerminalWebSocket(c.req.raw, c.env);
 });
 
 app.all('/sessions/:userId/:sessionId/ingest', async (c: Context<HonoContext>) => {
@@ -215,7 +314,17 @@ app.notFound(createNotFoundHandler());
 app.onError(createErrorHandler(logger, { includeMessage: false }));
 
 export default {
-  fetch: app.fetch,
+  fetch(request: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response> {
+    const url = new URL(request.url);
+    if (
+      url.pathname === '/terminal' &&
+      request.headers.get('Upgrade')?.toLowerCase() === 'websocket'
+    ) {
+      return handleTerminalWebSocket(request, env);
+    }
+
+    return app.fetch(request, env, ctx);
+  },
   async queue(batch: MessageBatch<unknown>, _env: Env): Promise<void> {
     if (batch.queue.startsWith('cloud-agent-next-callback-queue')) {
       const consumer = createCallbackQueueConsumer();

--- a/services/cloud-agent-next/src/terminal/access.test.ts
+++ b/services/cloud-agent-next/src/terminal/access.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CloudAgentSessionState } from '../persistence/types.js';
+import { WRAPPER_VERSION } from '../shared/wrapper-version.js';
+import type { Env, SandboxInstance } from '../types.js';
+import { resolveTerminalWrapperClient, validateTerminalMetadata } from './access.js';
+
+vi.mock('@cloudflare/sandbox', () => ({
+  getSandbox: vi.fn(),
+}));
+
+const baseMetadata: CloudAgentSessionState = {
+  version: 1,
+  sessionId: 'agent_12345678-1234-1234-1234-123456789abc',
+  userId: 'user-1',
+  timestamp: 1,
+  preparedAt: 1,
+  workspacePath: '/workspace/repo',
+  createdOnPlatform: 'cloud-agent-web',
+};
+
+describe('validateTerminalMetadata', () => {
+  it('allows prepared interactive cloud-agent sessions', () => {
+    const result = validateTerminalMetadata(baseMetadata, baseMetadata.sessionId);
+
+    expect(result).toEqual({ success: true, data: { metadata: baseMetadata } });
+  });
+
+  it('rejects sessions created by non-interactive platforms', () => {
+    const result = validateTerminalMetadata(
+      { ...baseMetadata, createdOnPlatform: 'code-review' },
+      baseMetadata.sessionId
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Terminal is only available for interactive Cloud Agent sessions',
+    });
+  });
+
+  it('rejects unprepared sessions', () => {
+    const result = validateTerminalMetadata(
+      { ...baseMetadata, preparedAt: undefined },
+      baseMetadata.sessionId
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Terminal is only available after the workspace is prepared',
+    });
+  });
+
+  it('treats minimal async-preparation metadata as unprepared', () => {
+    const result = validateTerminalMetadata(
+      {
+        ...baseMetadata,
+        preparedAt: undefined,
+        workspacePath: undefined,
+        createdOnPlatform: undefined,
+      },
+      baseMetadata.sessionId
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Terminal is only available after the workspace is prepared',
+    });
+  });
+});
+
+describe('resolveTerminalWrapperClient', () => {
+  it('returns a healthy existing wrapper client', async () => {
+    const sandbox = {} as SandboxInstance;
+    const client = {
+      health: vi.fn().mockResolvedValue({
+        healthy: true,
+        state: 'idle',
+        version: WRAPPER_VERSION,
+        sessionId: 'kilo-session-1',
+      }),
+      createTerminal: vi.fn(),
+      resizeTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      connectTerminal: vi.fn(),
+    };
+
+    const result = await resolveTerminalWrapperClient(
+      {
+        env: { PER_SESSION_SANDBOX_ORG_IDS: '' } as Env,
+        metadata: baseMetadata,
+        sessionId: baseMetadata.sessionId,
+      },
+      {
+        getSandboxInstance: vi.fn().mockReturnValue(sandbox),
+        findWrapperForSession: vi.fn().mockResolvedValue({ port: 5050 }),
+        createClient: vi.fn().mockReturnValue(client),
+      }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      client,
+      sandbox,
+      port: 5050,
+    });
+    expect(client.health).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns unavailable when no existing wrapper process is running', async () => {
+    const findWrapperForSession = vi.fn().mockResolvedValue(null);
+    const health = vi.fn();
+
+    const result = await resolveTerminalWrapperClient(
+      {
+        env: { PER_SESSION_SANDBOX_ORG_IDS: '' } as Env,
+        metadata: baseMetadata,
+        sessionId: baseMetadata.sessionId,
+      },
+      {
+        getSandboxInstance: vi.fn().mockReturnValue({} as SandboxInstance),
+        findWrapperForSession,
+        createClient: vi.fn().mockReturnValue({ health }),
+      }
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Terminal is unavailable because the session wrapper is not running',
+    });
+    expect(findWrapperForSession).toHaveBeenCalledTimes(1);
+    expect(health).not.toHaveBeenCalled();
+  });
+});

--- a/services/cloud-agent-next/src/terminal/access.ts
+++ b/services/cloud-agent-next/src/terminal/access.ts
@@ -1,0 +1,140 @@
+import type { CloudAgentSessionState, OperationResult } from '../persistence/types.js';
+import { getSandbox } from '@cloudflare/sandbox';
+import { SANDBOX_SLEEP_AFTER_SECONDS } from '../core/lease.js';
+import {
+  WrapperContainerClient,
+  type WrapperHealthResponse,
+  type WrapperPty,
+} from '../kilo/wrapper-client.js';
+import { findWrapperForSession } from '../kilo/wrapper-manager.js';
+import { generateSandboxId, getSandboxNamespace } from '../sandbox-id.js';
+import { WRAPPER_VERSION } from '../shared/wrapper-version.js';
+import type { Env, SandboxId, SandboxInstance } from '../types.js';
+
+const TERMINAL_SESSION_PLATFORMS = new Set(['cloud-agent', 'cloud-agent-web']);
+
+export function isTerminalSessionPlatform(platform: string | undefined): boolean {
+  return platform !== undefined && TERMINAL_SESSION_PLATFORMS.has(platform);
+}
+
+export function validateTerminalMetadata(
+  metadata: CloudAgentSessionState | null,
+  sessionId: string
+): OperationResult<{ metadata: CloudAgentSessionState }> {
+  if (!metadata) {
+    return { success: false, error: 'Session not found' };
+  }
+
+  if (metadata.sessionId !== sessionId) {
+    return { success: false, error: 'Invalid terminal session' };
+  }
+
+  if (!metadata.preparedAt || !metadata.workspacePath) {
+    return {
+      success: false,
+      error: 'Terminal is only available after the workspace is prepared',
+    };
+  }
+
+  if (!isTerminalSessionPlatform(metadata.createdOnPlatform)) {
+    return {
+      success: false,
+      error: 'Terminal is only available for interactive Cloud Agent sessions',
+    };
+  }
+
+  return { success: true, data: { metadata } };
+}
+
+export type TerminalWrapperClient = {
+  health(): Promise<WrapperHealthResponse>;
+  createTerminal(size?: { cols: number; rows: number }): Promise<WrapperPty>;
+  resizeTerminal(ptyId: string, size: { cols: number; rows: number }): Promise<WrapperPty>;
+  closeTerminal(ptyId: string): Promise<{ success: boolean }>;
+  connectTerminal(ptyId: string, request: Request): Promise<Response>;
+};
+
+type ResolveTerminalWrapperDeps = {
+  getSandboxInstance(params: { env: Env; sandboxId: SandboxId }): SandboxInstance;
+  findWrapperForSession(
+    sandbox: SandboxInstance,
+    sessionId: string
+  ): Promise<{ port: number } | null>;
+  createClient(params: { sandbox: SandboxInstance; port: number }): TerminalWrapperClient;
+};
+
+const defaultDeps: ResolveTerminalWrapperDeps = {
+  getSandboxInstance: ({ env, sandboxId }) =>
+    getSandbox(getSandboxNamespace(env, sandboxId), sandboxId, {
+      sleepAfter: SANDBOX_SLEEP_AFTER_SECONDS,
+    }),
+  findWrapperForSession,
+  createClient: ({ sandbox, port }) => new WrapperContainerClient({ sandbox, port }),
+};
+
+export async function resolveTerminalWrapperClient(
+  params: {
+    env: Env;
+    metadata: CloudAgentSessionState | null;
+    sessionId: string;
+  },
+  deps: ResolveTerminalWrapperDeps = defaultDeps
+): Promise<
+  OperationResult<{
+    client: TerminalWrapperClient;
+    sandbox: SandboxInstance;
+    sandboxId: SandboxId;
+    port: number;
+  }>
+> {
+  const metadataResult = validateTerminalMetadata(params.metadata, params.sessionId);
+  if (!metadataResult.success || !metadataResult.data) {
+    return { success: false, error: metadataResult.error };
+  }
+
+  const { metadata } = metadataResult.data;
+  const sandboxId =
+    metadata.sandboxId ??
+    (await generateSandboxId(
+      params.env.PER_SESSION_SANDBOX_ORG_IDS,
+      metadata.orgId,
+      metadata.userId,
+      metadata.sessionId,
+      metadata.botId
+    ));
+  const sandbox = deps.getSandboxInstance({ env: params.env, sandboxId });
+  const wrapper = await deps.findWrapperForSession(sandbox, metadata.sessionId);
+
+  if (!wrapper) {
+    return {
+      success: false,
+      error: 'Terminal is unavailable because the session wrapper is not running',
+    };
+  }
+
+  const client = deps.createClient({ sandbox, port: wrapper.port });
+  try {
+    const health = await client.health();
+    if (!health.healthy || health.version !== WRAPPER_VERSION) {
+      return {
+        success: false,
+        error: 'Terminal is unavailable because the session wrapper is not healthy',
+      };
+    }
+  } catch {
+    return {
+      success: false,
+      error: 'Terminal is unavailable because the session wrapper is not healthy',
+    };
+  }
+
+  return {
+    success: true,
+    data: {
+      client,
+      sandbox,
+      sandboxId,
+      port: wrapper.port,
+    },
+  };
+}

--- a/services/cloud-agent-next/test/unit/wrapper/kilo-api.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/kilo-api.test.ts
@@ -9,6 +9,8 @@ function createSdkClient(): SDKClient {
   } as SDKClient;
 }
 
+const workspacePath = '/workspace/project';
+
 describe('createWrapperKiloClient network endpoints', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -29,7 +31,7 @@ describe('createWrapperKiloClient network endpoints', () => {
       )
     );
 
-    const client = createWrapperKiloClient(createSdkClient(), 'http://127.0.0.1:0');
+    const client = createWrapperKiloClient(createSdkClient(), 'http://127.0.0.1:0', workspacePath);
 
     await expect(client.getNetworkWaits()).resolves.toEqual([]);
   });
@@ -45,10 +47,76 @@ describe('createWrapperKiloClient network endpoints', () => {
       )
     );
 
-    const client = createWrapperKiloClient(createSdkClient(), 'http://127.0.0.1:0');
+    const client = createWrapperKiloClient(createSdkClient(), 'http://127.0.0.1:0', workspacePath);
 
     await expect(client.resumeNetworkWait('net_req_missing')).rejects.toThrow(
       'Network reply net_req_missing failed: missing network wait'
     );
+  });
+});
+
+describe('createWrapperKiloClient PTY endpoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('resizes PTYs within the configured workspace directory', async () => {
+    const requestedUrls: URL[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(input => {
+        const requestUrl = input instanceof Request ? input.url : String(input);
+        requestedUrls.push(new URL(requestUrl));
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: 'pty_resize',
+              title: 'Workspace terminal',
+              command: '/bin/bash',
+              args: [],
+              cwd: workspacePath,
+              status: 'running',
+              pid: 42,
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+        );
+      })
+    );
+
+    const client = createWrapperKiloClient(createSdkClient(), 'http://127.0.0.1:0', workspacePath);
+
+    await client.resizePty('pty_resize', { cols: 120, rows: 40 });
+
+    expect(requestedUrls).toHaveLength(1);
+    expect(requestedUrls[0]?.searchParams.get('directory')).toBe(workspacePath);
+  });
+
+  it('deletes PTYs within the configured workspace directory', async () => {
+    const requestedUrls: URL[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(input => {
+        const requestUrl = input instanceof Request ? input.url : String(input);
+        requestedUrls.push(new URL(requestUrl));
+        return Promise.resolve(
+          new Response(JSON.stringify(true), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      })
+    );
+
+    const client = createWrapperKiloClient(createSdkClient(), 'http://127.0.0.1:0', workspacePath);
+
+    await client.deletePty('pty_delete');
+
+    expect(requestedUrls).toHaveLength(1);
+    expect(requestedUrls[0]?.searchParams.get('directory')).toBe(workspacePath);
   });
 });

--- a/services/cloud-agent-next/wrapper/src/kilo-api.ts
+++ b/services/cloud-agent-next/wrapper/src/kilo-api.ts
@@ -64,6 +64,21 @@ export type NetworkWait = {
   restored: boolean;
 };
 
+export type WrapperPty = {
+  id: string;
+  title: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  status: 'running' | 'exited';
+  pid: number;
+};
+
+export type WrapperPtySize = {
+  cols: number;
+  rows: number;
+};
+
 /**
  * The wrapper's unified kilo client interface.
  * All wrapper modules depend on this type rather than the raw SDK client.
@@ -119,6 +134,13 @@ export type WrapperKiloClient = {
   getNetworkWaits: () => Promise<NetworkWait[]>;
   resumeNetworkWait: (requestID: string) => Promise<boolean>;
   generateCommitMessage: (opts: { path: string }) => Promise<{ message: string }>;
+  createPty: (opts: {
+    cwd: string;
+    title: string;
+    env: Record<string, string>;
+  }) => Promise<WrapperPty>;
+  resizePty: (ptyId: string, size: WrapperPtySize) => Promise<WrapperPty>;
+  deletePty: (ptyId: string) => Promise<boolean>;
 
   /** The underlying SDK client — used directly by connection.ts for event subscription */
   readonly sdkClient: SDKClient;
@@ -138,7 +160,8 @@ export type WrapperKiloClient = {
  */
 export function createWrapperKiloClient(
   sdkClient: SDKClient,
-  serverUrl: string
+  serverUrl: string,
+  workspacePath: string
 ): WrapperKiloClient {
   logToFile(`creating wrapper kilo client for ${serverUrl}`);
   const v2Client = createV2Client({ baseUrl: serverUrl });
@@ -283,6 +306,39 @@ export function createWrapperKiloClient(
     generateCommitMessage: async opts => {
       const result = await v2Client.commitMessage.generate({ path: opts.path });
       return result.data ?? { message: '' };
+    },
+
+    createPty: async opts => {
+      const result = await v2Client.pty.create({
+        directory: opts.cwd,
+        cwd: opts.cwd,
+        title: opts.title,
+        env: opts.env,
+      });
+      if (!result.data) {
+        throw new Error('PTY create returned no data');
+      }
+      return result.data as WrapperPty;
+    },
+
+    resizePty: async (ptyId, size) => {
+      const result = await v2Client.pty.update({
+        ptyID: ptyId,
+        directory: workspacePath,
+        size,
+      });
+      if (!result.data) {
+        throw new Error(`PTY update returned no data for ${ptyId}`);
+      }
+      return result.data as WrapperPty;
+    },
+
+    deletePty: async ptyId => {
+      const result = await v2Client.pty.remove({
+        ptyID: ptyId,
+        directory: workspacePath,
+      });
+      return Boolean(result.data);
     },
   };
 }

--- a/services/cloud-agent-next/wrapper/src/main.ts
+++ b/services/cloud-agent-next/wrapper/src/main.ts
@@ -182,7 +182,7 @@ async function main() {
   }
 
   // Create wrapper kilo client (adapter over SDK client + raw fetch)
-  const kiloClient = createWrapperKiloClient(sdkClient, kiloServer.url);
+  const kiloClient = createWrapperKiloClient(sdkClient, kiloServer.url, workspacePath);
 
   // ---------------------------------------------------------------------------
   // Create or verify kilo session

--- a/services/cloud-agent-next/wrapper/src/server.test.ts
+++ b/services/cloud-agent-next/wrapper/src/server.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { createServer as createNetServer } from 'node:net';
+import { WrapperState } from './state';
+import {
+  createFetchHandler,
+  createServer,
+  resolvePtyClientClose,
+  type WrapperServer,
+} from './server';
+import type { WrapperKiloClient, WrapperPty, WrapperPtySize } from './kilo-api';
+
+type PtyCall = {
+  cwd: string;
+  title: string;
+  env: Record<string, string>;
+};
+
+const servers: WrapperServer[] = [];
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createNetServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      server.close(() => {
+        if (address && typeof address === 'object') {
+          resolve(address.port);
+          return;
+        }
+        reject(new Error('Failed to allocate test port'));
+      });
+    });
+  });
+}
+
+function createTestFetch(overrides?: {
+  ptyCalls?: PtyCall[];
+  resizeCalls?: Array<{ ptyId: string; cols: number; rows: number }>;
+  deleteCalls?: string[];
+  resizeError?: Error;
+}) {
+  const ptyCalls = overrides?.ptyCalls ?? [];
+  const resizeCalls = overrides?.resizeCalls ?? [];
+  const deleteCalls = overrides?.deleteCalls ?? [];
+
+  const pty: WrapperPty = {
+    id: 'pty_123',
+    title: 'Workspace terminal',
+    command: '',
+    args: [],
+    cwd: '/workspace/repo',
+    status: 'running',
+    pid: 123,
+  };
+
+  const kiloClient = {
+    createPty: async (input: { cwd: string; title: string; env: Record<string, string> }) => {
+      ptyCalls.push({ cwd: input.cwd, title: input.title, env: input.env });
+      return { ...pty, cwd: input.cwd, title: input.title };
+    },
+    resizePty: async (ptyId: string, size: WrapperPtySize) => {
+      resizeCalls.push({ ptyId, cols: size.cols, rows: size.rows });
+      if (overrides?.resizeError) throw overrides.resizeError;
+      return pty;
+    },
+    deletePty: async (ptyId: string) => {
+      deleteCalls.push(ptyId);
+      return true;
+    },
+  } as unknown as WrapperKiloClient;
+
+  const fetchHandler = createFetchHandler(
+    {
+      port: 5000,
+      workspacePath: '/workspace/repo',
+      version: 'test',
+      sessionId: 'kilo_sess_test',
+      agentSessionId: 'agent_00000000-0000-0000-0000-000000000000',
+      userId: 'user_test',
+    },
+    {
+      state: new WrapperState(),
+      kiloClient,
+      openConnection: async () => {},
+      closeConnection: async () => {},
+      setAborted: () => {},
+      resetLifecycle: () => {},
+      setPerTurnConfig: () => {},
+    },
+    () => {}
+  );
+  return { fetchHandler, ptyCalls, resizeCalls, deleteCalls };
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(server => server.stop()));
+});
+
+describe('wrapper PTY routes', () => {
+  it('creates a workspace PTY and applies the requested size', async () => {
+    const { fetchHandler, ptyCalls, resizeCalls } = createTestFetch();
+
+    const response = await fetchHandler(
+      new Request('http://wrapper.test/pty', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cols: 120, rows: 32 }),
+      })
+    );
+
+    expect(response).toBeDefined();
+    if (!response) throw new Error('Expected PTY create response');
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      id: 'pty_123',
+      cwd: '/workspace/repo',
+      title: 'Workspace terminal',
+    });
+    expect(ptyCalls).toEqual([
+      {
+        cwd: '/workspace/repo',
+        title: 'Workspace terminal',
+        env: {
+          PROMPT_COMMAND: "PS1='\\n\\W\\n\\$ '",
+          PS1: '\\n\\W\\n\\$ ',
+        },
+      },
+    ]);
+    expect(resizeCalls).toEqual([{ ptyId: 'pty_123', cols: 120, rows: 32 }]);
+  });
+
+  it('deletes the PTY when applying the initial size fails', async () => {
+    const { fetchHandler, deleteCalls, resizeCalls } = createTestFetch({
+      resizeError: new Error('resize failed'),
+    });
+
+    const response = await fetchHandler(
+      new Request('http://wrapper.test/pty', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cols: 120, rows: 32 }),
+      })
+    );
+
+    expect(response).toBeDefined();
+    if (!response) throw new Error('Expected PTY create response');
+    expect(response.status).toBe(500);
+    expect(resizeCalls).toEqual([{ ptyId: 'pty_123', cols: 120, rows: 32 }]);
+    expect(deleteCalls).toEqual(['pty_123']);
+  });
+
+  it('upgrades PTY websocket connections and proxies to the SDK PTY endpoint', async () => {
+    const upstreamPort = await getFreePort();
+    const wrapperPort = await getFreePort();
+    let upstreamPath: string | undefined;
+    const upstream = Bun.serve<{ pty: true }>({
+      port: upstreamPort,
+      fetch(req, server) {
+        upstreamPath = new URL(req.url).pathname + new URL(req.url).search;
+        if (server.upgrade(req, { data: { pty: true } })) return undefined;
+        return new Response('upgrade failed', { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          ws.send('ready');
+        },
+        message(ws, message) {
+          ws.send(message);
+        },
+      },
+    });
+
+    const kiloClient = {
+      serverUrl: `http://127.0.0.1:${upstreamPort}`,
+    } as unknown as WrapperKiloClient;
+
+    const wrapper = createServer(
+      {
+        port: wrapperPort,
+        workspacePath: '/workspace/repo',
+        version: 'test',
+        sessionId: 'kilo_sess_test',
+        agentSessionId: 'agent_00000000-0000-0000-0000-000000000000',
+        userId: 'user_test',
+      },
+      {
+        state: new WrapperState(),
+        kiloClient,
+        openConnection: async () => {},
+        closeConnection: async () => {},
+        setAborted: () => {},
+        resetLifecycle: () => {},
+        setPerTurnConfig: () => {},
+      },
+      () => {}
+    );
+
+    try {
+      const message = await new Promise<string>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('wrapper websocket timed out')), 1_000);
+        const ws = new WebSocket(`ws://127.0.0.1:${wrapperPort}/pty/pty_123/connect`);
+        ws.addEventListener('message', event => {
+          clearTimeout(timeout);
+          ws.close();
+          resolve(String(event.data));
+        });
+        ws.addEventListener('error', () => {
+          clearTimeout(timeout);
+          reject(new Error('wrapper websocket failed'));
+        });
+      });
+
+      expect(message).toBe('ready');
+      expect(upstreamPath).toBe('/pty/pty_123/connect?directory=%2Fworkspace%2Frepo');
+    } finally {
+      await wrapper.server.stop(true);
+      await upstream.stop(true);
+    }
+  });
+
+  it('preserves abnormal upstream PTY websocket close codes', () => {
+    expect(resolvePtyClientClose({ code: 1011, reason: 'container restarting' })).toEqual({
+      code: 1011,
+      reason: 'container restarting',
+    });
+    expect(resolvePtyClientClose({ code: 1006, reason: '' })).toEqual({
+      code: 1011,
+      reason: 'PTY upstream closed',
+    });
+    expect(resolvePtyClientClose({ code: 1000, reason: '' })).toEqual({
+      code: 1000,
+      reason: 'PTY session ended',
+    });
+  });
+});

--- a/services/cloud-agent-next/wrapper/src/server.ts
+++ b/services/cloud-agent-next/wrapper/src/server.ts
@@ -13,7 +13,7 @@
  */
 
 import type { WrapperState, JobContext } from './state.js';
-import type { WrapperKiloClient } from './kilo-api.js';
+import type { WrapperKiloClient, WrapperPtySize } from './kilo-api.js';
 import type { PerTurnConfig } from './lifecycle.js';
 import { createLogUploader } from './log-uploader.js';
 import { logToFile } from './utils.js';
@@ -106,9 +106,34 @@ type RejectQuestionBody = {
   questionId: string;
 };
 
+type PtyCreateBody = {
+  cols?: number;
+  rows?: number;
+};
+
+type PtyResizeBody = {
+  cols?: number;
+  rows?: number;
+  size?: {
+    cols?: number;
+    rows?: number;
+  };
+};
+
 // ---------------------------------------------------------------------------
 // Helper Functions
 // ---------------------------------------------------------------------------
+
+const PTY_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const MIN_PTY_COLS = 2;
+const MAX_PTY_COLS = 500;
+const MIN_PTY_ROWS = 2;
+const MAX_PTY_ROWS = 200;
+const WORKSPACE_TERMINAL_ENV = {
+  // Shell startup files may replace inherited PS1, so reapply it before each prompt.
+  PROMPT_COMMAND: "PS1='\\n\\W\\n\\$ '",
+  PS1: '\\n\\W\\n\\$ ',
+} satisfies Record<string, string>;
 
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -119,6 +144,54 @@ function jsonResponse(data: unknown, status = 200): Response {
 
 function errorResponse(error: string, message: string, status: number): Response {
   return jsonResponse({ error, message }, status);
+}
+
+async function readJsonBody<T>(req: Request, defaultValue: T): Promise<T> {
+  const text = await req.text();
+  if (!text.trim()) return defaultValue;
+  return JSON.parse(text) as T;
+}
+
+function validatePtyId(ptyId: string | undefined): string | null {
+  if (!ptyId || !PTY_ID_RE.test(ptyId)) return null;
+  return ptyId;
+}
+
+function parsePtySize(input: PtyCreateBody | PtyResizeBody): WrapperPtySize | null {
+  const rows = 'size' in input && input.size ? input.size.rows : input.rows;
+  const cols = 'size' in input && input.size ? input.size.cols : input.cols;
+
+  if (rows === undefined && cols === undefined) return null;
+
+  if (
+    typeof rows !== 'number' ||
+    typeof cols !== 'number' ||
+    !Number.isInteger(rows) ||
+    !Number.isInteger(cols) ||
+    rows < MIN_PTY_ROWS ||
+    rows > MAX_PTY_ROWS ||
+    cols < MIN_PTY_COLS ||
+    cols > MAX_PTY_COLS
+  ) {
+    throw new Error(
+      `PTY size must include integer cols ${MIN_PTY_COLS}-${MAX_PTY_COLS} and rows ${MIN_PTY_ROWS}-${MAX_PTY_ROWS}`
+    );
+  }
+
+  return { cols, rows };
+}
+
+function parsePtyPath(path: string): { ptyId: string; action?: 'connect' } | null {
+  const match = path.match(/^\/pty\/([^/]+)(?:\/(connect))?$/);
+  if (!match) return null;
+
+  const ptyId = validatePtyId(match[1]);
+  if (!ptyId) return null;
+
+  return {
+    ptyId,
+    action: match[2] === 'connect' ? 'connect' : undefined,
+  };
 }
 
 /**
@@ -529,6 +602,215 @@ function createAbortHandler(deps: ServerDependencies, triggerDrainAndClose: () =
   };
 }
 
+function createPtyCreateHandler(config: ServerConfig, deps: ServerDependencies) {
+  return async (req: Request): Promise<Response> => {
+    let body: PtyCreateBody;
+    try {
+      body = await readJsonBody<PtyCreateBody>(req, {});
+    } catch {
+      return errorResponse('INVALID_REQUEST', 'Invalid JSON body', 400);
+    }
+
+    let size: WrapperPtySize | null;
+    try {
+      size = parsePtySize(body);
+    } catch (error) {
+      return errorResponse(
+        'INVALID_REQUEST',
+        error instanceof Error ? error.message : String(error),
+        400
+      );
+    }
+
+    let createdPtyId: string | null = null;
+    try {
+      const pty = await deps.kiloClient.createPty({
+        cwd: config.workspacePath,
+        title: 'Workspace terminal',
+        env: WORKSPACE_TERMINAL_ENV,
+      });
+      createdPtyId = pty.id;
+      const sizedPty = size ? await deps.kiloClient.resizePty(pty.id, size) : pty;
+      logToFile(`pty/create: ptyId=${pty.id}`);
+      return jsonResponse(sizedPty);
+    } catch (error) {
+      if (createdPtyId) {
+        try {
+          await deps.kiloClient.deletePty(createdPtyId);
+          logToFile(`pty/create: cleaned up ptyId=${createdPtyId}`);
+        } catch (cleanupError) {
+          const cleanupMessage =
+            cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+          logToFile(`pty/create: cleanup failed ptyId=${createdPtyId}: ${cleanupMessage}`);
+        }
+      }
+
+      const msg = error instanceof Error ? error.message : String(error);
+      logToFile(`pty/create: failed: ${msg}`);
+      return errorResponse('PTY_ERROR', `Failed to create PTY: ${msg}`, 500);
+    }
+  };
+}
+
+function createPtyResizeHandler(deps: ServerDependencies, ptyId: string) {
+  return async (req: Request): Promise<Response> => {
+    let body: PtyResizeBody;
+    try {
+      body = await readJsonBody<PtyResizeBody>(req, {});
+    } catch {
+      return errorResponse('INVALID_REQUEST', 'Invalid JSON body', 400);
+    }
+
+    let size: WrapperPtySize | null;
+    try {
+      size = parsePtySize(body);
+    } catch (error) {
+      return errorResponse(
+        'INVALID_REQUEST',
+        error instanceof Error ? error.message : String(error),
+        400
+      );
+    }
+
+    if (!size) {
+      return errorResponse('INVALID_REQUEST', 'PTY size is required', 400);
+    }
+
+    try {
+      const pty = await deps.kiloClient.resizePty(ptyId, size);
+      logToFile(`pty/resize: ptyId=${ptyId} cols=${size.cols} rows=${size.rows}`);
+      return jsonResponse(pty);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logToFile(`pty/resize: failed ptyId=${ptyId}: ${msg}`);
+      return errorResponse('PTY_ERROR', `Failed to resize PTY: ${msg}`, 500);
+    }
+  };
+}
+
+function createPtyDeleteHandler(deps: ServerDependencies, ptyId: string) {
+  return async (_req: Request): Promise<Response> => {
+    try {
+      const success = await deps.kiloClient.deletePty(ptyId);
+      logToFile(`pty/delete: ptyId=${ptyId}`);
+      return jsonResponse({ success });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logToFile(`pty/delete: failed ptyId=${ptyId}: ${msg}`);
+      return errorResponse('PTY_ERROR', `Failed to delete PTY: ${msg}`, 500);
+    }
+  };
+}
+
+function buildPtyUpstreamUrl(
+  config: ServerConfig,
+  deps: ServerDependencies,
+  ptyId: string
+): string {
+  const upstream = new URL(`/pty/${encodeURIComponent(ptyId)}/connect`, deps.kiloClient.serverUrl);
+  upstream.protocol = upstream.protocol === 'https:' ? 'wss:' : 'ws:';
+  upstream.searchParams.set('directory', config.workspacePath);
+  return upstream.toString();
+}
+
+type WrapperWebSocketData = {
+  ptyId?: string;
+};
+
+type PtyClientClose = {
+  code: number;
+  reason: string;
+};
+
+function isForwardableCloseCode(code: number): boolean {
+  return (
+    Number.isInteger(code) && code >= 1000 && code <= 4999 && ![1005, 1006, 1015].includes(code)
+  );
+}
+
+export function resolvePtyClientClose(event: { code: number; reason: string }): PtyClientClose {
+  if (event.code === 1000) {
+    return { code: 1000, reason: 'PTY session ended' };
+  }
+
+  if (isForwardableCloseCode(event.code)) {
+    return { code: event.code, reason: event.reason || 'PTY upstream closed' };
+  }
+
+  return { code: 1011, reason: event.reason || 'PTY upstream closed' };
+}
+
+type BunUpgradeServer = {
+  upgrade: (req: Request, options: { data: WrapperWebSocketData }) => boolean;
+};
+
+function createWebSocketHandlers(config: ServerConfig, deps: ServerDependencies) {
+  const ptyUpstreams = new WeakMap<object, WebSocket>();
+
+  return {
+    open(ws: Bun.ServerWebSocket<WrapperWebSocketData>) {
+      const ptyId = ws.data.ptyId;
+      if (!ptyId) {
+        ws.close(1011, 'Missing PTY');
+        return;
+      }
+
+      const upstream = new WebSocket(buildPtyUpstreamUrl(config, deps, ptyId));
+      upstream.binaryType = 'arraybuffer';
+      ptyUpstreams.set(ws, upstream);
+
+      upstream.onmessage = event => {
+        try {
+          ws.send(event.data instanceof ArrayBuffer ? event.data : String(event.data));
+        } catch {
+          // Client disconnected.
+        }
+      };
+      upstream.onclose = event => {
+        const close = resolvePtyClientClose({ code: event.code, reason: event.reason });
+        try {
+          ws.close(close.code, close.reason);
+        } catch {
+          // Already closed.
+        }
+      };
+      upstream.onerror = () => {
+        try {
+          ws.close(1011, 'PTY upstream error');
+        } catch {
+          // Already closed.
+        }
+      };
+    },
+    message(
+      ws: Bun.ServerWebSocket<WrapperWebSocketData>,
+      message: string | ArrayBuffer | Uint8Array
+    ) {
+      const upstream = ptyUpstreams.get(ws);
+      if (upstream?.readyState === WebSocket.OPEN) {
+        if (typeof message === 'string' || message instanceof ArrayBuffer) {
+          upstream.send(message);
+          return;
+        }
+        const copy = new Uint8Array(message.byteLength);
+        copy.set(message);
+        upstream.send(copy.buffer);
+      }
+    },
+    close(ws: Bun.ServerWebSocket<WrapperWebSocketData>) {
+      const upstream = ptyUpstreams.get(ws);
+      if (upstream) {
+        try {
+          upstream.close();
+        } catch {
+          // Already closed.
+        }
+        ptyUpstreams.delete(ws);
+      }
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Server Creation
 // ---------------------------------------------------------------------------
@@ -538,11 +820,11 @@ export type WrapperServer = {
   stop: () => Promise<void>;
 };
 
-export function createServer(
+export function createFetchHandler(
   config: ServerConfig,
   deps: ServerDependencies,
   triggerDrainAndClose: () => void
-): WrapperServer {
+): (req: Request, server?: BunUpgradeServer) => Response | Promise<Response> | undefined {
   const { state } = deps;
 
   // Create route handlers
@@ -554,6 +836,7 @@ export function createServer(
   const answerQuestionHandler = createAnswerQuestionHandler(deps);
   const rejectQuestionHandler = createRejectQuestionHandler(deps);
   const abortHandler = createAbortHandler(deps, triggerDrainAndClose);
+  const ptyCreateHandler = createPtyCreateHandler(config, deps);
 
   // Route table
   type RouteHandler = (req: Request) => Response | Promise<Response>;
@@ -569,37 +852,79 @@ export function createServer(
       '/job/answer-question': answerQuestionHandler,
       '/job/reject-question': rejectQuestionHandler,
       '/job/abort': abortHandler,
+      '/pty': ptyCreateHandler,
     },
   };
 
-  const server = Bun.serve({
-    port: config.port,
-    fetch: async (req: Request): Promise<Response> => {
-      const url = new URL(req.url);
-      const method = req.method;
-      const path = url.pathname;
+  return (req: Request, server?: BunUpgradeServer): Response | Promise<Response> | undefined => {
+    const url = new URL(req.url);
+    const method = req.method;
+    const path = url.pathname;
 
-      logToFile(`HTTP ${method} ${path}`);
+    logToFile(`HTTP ${method} ${path}`);
 
-      // Look up route
-      const methodRoutes = routes[method];
-      if (!methodRoutes) {
-        return errorResponse('METHOD_NOT_ALLOWED', `Method ${method} not allowed`, 405);
+    const ptyPath = parsePtyPath(path);
+    if (ptyPath) {
+      if (ptyPath.action === 'connect') {
+        if (method !== 'GET') {
+          return errorResponse('METHOD_NOT_ALLOWED', `Method ${method} not allowed`, 405);
+        }
+        if (req.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
+          return errorResponse('UPGRADE_REQUIRED', 'Expected WebSocket upgrade', 426);
+        }
+        if (!server) {
+          return errorResponse('INTERNAL_ERROR', 'WebSocket server unavailable', 500);
+        }
+        const upgraded = server.upgrade(req, { data: { ptyId: ptyPath.ptyId } });
+        if (upgraded) return undefined;
+        return errorResponse('UPGRADE_FAILED', 'WebSocket upgrade failed', 400);
       }
 
-      const handler = methodRoutes[path];
-      if (!handler) {
-        return errorResponse('NOT_FOUND', `Path ${path} not found`, 404);
+      if (method === 'PUT') {
+        return createPtyResizeHandler(deps, ptyPath.ptyId)(req);
       }
+      if (method === 'DELETE') {
+        return createPtyDeleteHandler(deps, ptyPath.ptyId)(req);
+      }
+    }
 
-      try {
-        return await handler(req);
-      } catch (error) {
+    // Look up route
+    const methodRoutes = routes[method];
+    if (!methodRoutes) {
+      return errorResponse('METHOD_NOT_ALLOWED', `Method ${method} not allowed`, 405);
+    }
+
+    const handler = methodRoutes[path];
+    if (!handler) {
+      return errorResponse('NOT_FOUND', `Path ${path} not found`, 404);
+    }
+
+    try {
+      return Promise.resolve(handler(req)).catch(error => {
         const msg = error instanceof Error ? error.message : String(error);
         logToFile(`HTTP handler error: ${msg}`);
         return errorResponse('INTERNAL_ERROR', msg, 500);
-      }
-    },
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logToFile(`HTTP handler error: ${msg}`);
+      return errorResponse('INTERNAL_ERROR', msg, 500);
+    }
+  };
+}
+
+export function createServer(
+  config: ServerConfig,
+  deps: ServerDependencies,
+  triggerDrainAndClose: () => void
+): WrapperServer {
+  const fetchHandler = createFetchHandler(config, deps, triggerDrainAndClose);
+  const websocket = createWebSocketHandlers(config, deps);
+
+  const server = Bun.serve<WrapperWebSocketData>({
+    port: config.port,
+    fetch: fetchHandler,
+    websocket,
   });
 
   logToFile(`HTTP server listening on port ${config.port}`);


### PR DESCRIPTION
## Summary

- Adds workspace terminal tabs and a terminal dock to cloud-agent chat sessions.
- Adds web, tRPC, cloud-agent service, and wrapper routes for creating and proxying PTY terminal sessions.
- Adds access checks, terminal error handling, and regression coverage for wrapper/client/session behavior.

## Verification

- Manual verification

## Visual Changes

<img width="988" height="496" alt="Screenshot 2026-05-18 at 16 02 03" src="https://github.com/user-attachments/assets/5aee9b12-a4cf-463a-8a5e-95130fe4c6d5" />


## Reviewer Notes

- Main review areas: WebSocket close/retry behavior, session access checks, and wrapper PTY proxying.
- The branch is ready for review.