### PR TITLE
fix(code-reviews): retry mkdir failures

### DIFF
--- a/services/cloud-agent-next/src/execution/orchestrator.ts
+++ b/services/cloud-agent-next/src/execution/orchestrator.ts
@@ -26,7 +26,7 @@ import { withDORetry } from '../utils/do-retry.js';
 import { normalizeAgentMode } from '../schema.js';
 import { buildImagePromptParts, downloadImagePromptParts } from './image-prompt-parts.js';
 import { withTimeout } from '@kilocode/worker-utils';
-import { withSandboxInternalServerErrorRecovery } from '../sandbox-recovery.js';
+import { withPreparationInfrastructureRecovery } from '../sandbox-recovery.js';
 
 /** Maximum time allowed for workspace preparation (resume, init, fast path). */
 const PREPARE_WORKSPACE_TIMEOUT_MS = 10 * 60 * 1000;
@@ -200,7 +200,7 @@ export class ExecutionOrchestrator {
     };
 
     const { prepared, wrapperClient, kiloSessionId, fileParts } =
-      await withSandboxInternalServerErrorRecovery(
+      await withPreparationInfrastructureRecovery(
         {
           sandbox,
           sandboxId,

--- a/services/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -600,6 +600,36 @@ describe('WrapperClient', () => {
       expect(session.startProcess).toHaveBeenCalledTimes(1);
     });
 
+    it('preserves sandbox waitForPort failures as the not-ready cause', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      const sandboxStartupError = new Error('Process exited before ready');
+      Object.assign(sandboxStartupError, {
+        name: 'ProcessExitedBeforeReadyError',
+        httpStatus: 500,
+      });
+
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-1',
+        waitForPort: vi.fn().mockRejectedValue(sandboxStartupError),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      try {
+        await client.ensureRunning({
+          agentSessionId,
+          userId,
+          maxWaitMs: 100,
+          workspacePath: '/workspace/test',
+        });
+        expect.fail('Expected ensureRunning to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(WrapperNotReadyError);
+        expect(error).toHaveProperty('cause', sandboxStartupError);
+      }
+    });
+
     it('calls getLogs on process when startup fails', async () => {
       const session = createMockSession(createCurlError(7, 'Connection refused'));
 

--- a/services/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -100,16 +100,17 @@ export class WrapperError extends Error {
   constructor(
     message: string,
     public readonly code: string,
-    public readonly statusCode: number
+    public readonly statusCode: number,
+    options?: ErrorOptions
   ) {
-    super(message);
+    super(message, options);
     this.name = 'WrapperError';
   }
 }
 
 export class WrapperNotReadyError extends WrapperError {
-  constructor(message: string) {
-    super(message, 'NOT_READY', 503);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, 'NOT_READY', 503, options);
     this.name = 'WrapperNotReadyError';
   }
 }
@@ -445,7 +446,8 @@ export class WrapperClient {
       });
 
       throw new WrapperNotReadyError(
-        `Wrapper did not become ready on port ${this.port} within ${maxWaitMs}ms: ${diagParts}`
+        `Wrapper did not become ready on port ${this.port} within ${maxWaitMs}ms: ${diagParts}`,
+        { cause: startupError }
       );
     }
   }

--- a/services/cloud-agent-next/src/persistence/async-preparation.ts
+++ b/services/cloud-agent-next/src/persistence/async-preparation.ts
@@ -25,7 +25,7 @@ import { WrapperClient } from '../kilo/wrapper-client.js';
 import type { PreparingStep } from '../shared/protocol.js';
 import type { PreparationInput } from './schemas.js';
 import { readProfileBundle } from '../session-profile.js';
-import { withSandboxInternalServerErrorRecovery } from '../sandbox-recovery.js';
+import { withPreparationInfrastructureRecovery } from '../sandbox-recovery.js';
 import type { Env as WorkerEnv, SandboxId, SessionId as AgentSessionId } from '../types.js';
 
 type EmitProgress = (step: PreparingStep, message: string) => void;
@@ -119,7 +119,7 @@ export async function executePreparationSteps(
   const sandbox = getSandbox(getSandboxNamespace(env, sandboxId), sandboxId, {
     sleepAfter: SANDBOX_SLEEP_AFTER_SECONDS,
   });
-  return withSandboxInternalServerErrorRecovery(
+  return withPreparationInfrastructureRecovery(
     {
       sandbox,
       sandboxId,

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -52,8 +52,8 @@ import {
 import { getPgDb } from '../../db/pg.js';
 import { repoFullNameFromGitUrl } from '@kilocode/worker-utils/git-url';
 import {
-  destroySandboxAfterInternalServerError,
-  isSandboxInternalServerError,
+  destroySandboxAfterPreparationInfrastructureFailure,
+  getPreparationInfrastructureFailure,
 } from '../../sandbox-recovery.js';
 
 type SessionPrepareHandlers = {
@@ -621,8 +621,8 @@ const prepareSessionHandler = internalApiProtectedProcedure
       try {
         preparedWorkspace = await prepareWorkspace();
       } catch (error) {
-        const sandboxInternalServerError = isSandboxInternalServerError(error);
-        await destroySandboxAfterInternalServerError(
+        const preparationFailure = getPreparationInfrastructureFailure(error);
+        await destroySandboxAfterPreparationInfrastructureFailure(
           {
             sandbox,
             sandboxId,
@@ -631,10 +631,10 @@ const prepareSessionHandler = internalApiProtectedProcedure
           },
           error
         );
-        if (sandboxInternalServerError) {
+        if (preparationFailure) {
           throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',
-            message: 'Sandbox returned 500 during workspace preparation',
+            message: preparationFailure.message,
             cause: { error: 'sandbox_internal_server_error', retryable: true },
           });
         }

--- a/services/cloud-agent-next/src/sandbox-recovery.test.ts
+++ b/services/cloud-agent-next/src/sandbox-recovery.test.ts
@@ -14,10 +14,14 @@ vi.mock('./logger.js', () => ({
 }));
 
 import {
+  destroySandboxAfterPreparationInfrastructureFailure,
+  getPreparationInfrastructureFailure,
   destroySandboxAfterInternalServerError,
   isSandboxInternalServerError,
+  withPreparationInfrastructureRecovery,
   withSandboxInternalServerErrorRecovery,
 } from './sandbox-recovery.js';
+import { WorkspaceFilesystemPreparationError } from './workspace-errors.js';
 
 describe('sandbox recovery', () => {
   it('classifies sandbox SDK internal server errors', () => {
@@ -105,9 +109,72 @@ describe('sandbox recovery', () => {
     expect(mockInfo).toHaveBeenCalledWith('Destroyed sandbox after workspace preparation 500');
   });
 
+  it('classifies typed workspace filesystem preparation failures', () => {
+    const cause = new Error('FileSystemError: mkdir operation failed with exit code NaN');
+    const error = new WorkspaceFilesystemPreparationError(
+      'workspace_directory',
+      'Failed to create workspace directory: FileSystemError: mkdir operation failed with exit code NaN',
+      cause
+    );
+
+    expect(getPreparationInfrastructureFailure(error)).toMatchObject({
+      type: 'workspace_filesystem_preparation_error',
+      error,
+      message: error.message,
+    });
+  });
+
+  it('destroys sandbox when preparation hits a workspace filesystem failure', async () => {
+    const sandbox = { destroy: vi.fn().mockResolvedValue(undefined) };
+    const cause = new Error('FileSystemError: mkdir operation failed with exit code NaN');
+    const error = new WorkspaceFilesystemPreparationError(
+      'session_home',
+      'Failed to prepare session home: FileSystemError: mkdir operation failed with exit code NaN',
+      cause
+    );
+
+    await expect(
+      withPreparationInfrastructureRecovery(
+        {
+          sandbox,
+          sandboxId: 'ses-test',
+          sessionId: 'agent_test',
+          phase: 'asyncPreparation',
+        },
+        async () => {
+          throw error;
+        }
+      )
+    ).rejects.toBe(error);
+
+    expect(sandbox.destroy).toHaveBeenCalledOnce();
+    expect(mockError).toHaveBeenCalledWith(
+      'Workspace filesystem preparation failed; destroying sandbox'
+    );
+    expect(mockInfo).toHaveBeenCalledWith(
+      'Destroyed sandbox after workspace filesystem preparation failure'
+    );
+  });
+
   it('does not destroy sandbox for unrelated errors', async () => {
     const sandbox = { destroy: vi.fn().mockResolvedValue(undefined) };
     const destroyed = await destroySandboxAfterInternalServerError(
+      {
+        sandbox,
+        sandboxId: 'ses-test',
+        sessionId: 'agent_test',
+        phase: 'asyncPreparation',
+      },
+      new Error('Git clone failed')
+    );
+
+    expect(destroyed).toBe(false);
+    expect(sandbox.destroy).not.toHaveBeenCalled();
+  });
+
+  it('does not destroy sandbox for unrelated preparation errors', async () => {
+    const sandbox = { destroy: vi.fn().mockResolvedValue(undefined) };
+    const destroyed = await destroySandboxAfterPreparationInfrastructureFailure(
       {
         sandbox,
         sandboxId: 'ses-test',

--- a/services/cloud-agent-next/src/sandbox-recovery.test.ts
+++ b/services/cloud-agent-next/src/sandbox-recovery.test.ts
@@ -19,7 +19,6 @@ import {
   destroySandboxAfterInternalServerError,
   isSandboxInternalServerError,
   withPreparationInfrastructureRecovery,
-  withSandboxInternalServerErrorRecovery,
 } from './sandbox-recovery.js';
 import { WrapperNotReadyError } from './kilo/wrapper-client.js';
 import { WorkspaceFilesystemPreparationError } from './workspace-errors.js';
@@ -102,7 +101,7 @@ describe('sandbox recovery', () => {
     Object.assign(error, { name: 'SandboxError' });
 
     await expect(
-      withSandboxInternalServerErrorRecovery(
+      withPreparationInfrastructureRecovery(
         {
           sandbox,
           sandboxId: 'ses-test',

--- a/services/cloud-agent-next/src/sandbox-recovery.test.ts
+++ b/services/cloud-agent-next/src/sandbox-recovery.test.ts
@@ -21,6 +21,7 @@ import {
   withPreparationInfrastructureRecovery,
   withSandboxInternalServerErrorRecovery,
 } from './sandbox-recovery.js';
+import { WrapperNotReadyError } from './kilo/wrapper-client.js';
 import { WorkspaceFilesystemPreparationError } from './workspace-errors.js';
 
 describe('sandbox recovery', () => {
@@ -47,6 +48,18 @@ describe('sandbox recovery', () => {
       name: 'ExecutionError',
       code: 'WRAPPER_START_FAILED',
     });
+
+    expect(isSandboxInternalServerError(error)).toBe(true);
+  });
+
+  it('classifies wrapper not-ready errors caused by sandbox startup 500s', () => {
+    const cause = new Error('Process exited before ready');
+    Object.assign(cause, {
+      name: 'ProcessExitedBeforeReadyError',
+      httpStatus: 500,
+    });
+
+    const error = new WrapperNotReadyError('Wrapper did not become ready', { cause });
 
     expect(isSandboxInternalServerError(error)).toBe(true);
   });

--- a/services/cloud-agent-next/src/sandbox-recovery.ts
+++ b/services/cloud-agent-next/src/sandbox-recovery.ts
@@ -275,20 +275,6 @@ export async function destroySandboxAfterPreparationInfrastructureFailure(
   }
 }
 
-export async function withSandboxInternalServerErrorRecovery<T>(
-  context: RecoveryContext,
-  operation: () => Promise<T>
-): Promise<T> {
-  try {
-    return await operation();
-  } catch (error) {
-    const cause = getNestedProperty(error, 'cause');
-    const recoveryError = isSandboxInternalServerError(cause) ? cause : error;
-    await destroySandboxAfterInternalServerError(context, recoveryError);
-    throw error;
-  }
-}
-
 export async function withPreparationInfrastructureRecovery<T>(
   context: RecoveryContext,
   operation: () => Promise<T>

--- a/services/cloud-agent-next/src/sandbox-recovery.ts
+++ b/services/cloud-agent-next/src/sandbox-recovery.ts
@@ -1,4 +1,5 @@
 import { logger } from './logger.js';
+import { WorkspaceFilesystemPreparationError } from './workspace-errors.js';
 
 type DestroyableSandbox = {
   destroy(): Promise<void>;
@@ -10,6 +11,18 @@ type RecoveryContext = {
   sessionId?: string;
   phase: string;
 };
+
+type PreparationInfrastructureFailure =
+  | {
+      type: 'sandbox_internal_server_error';
+      error: unknown;
+      message: 'Sandbox returned 500 during workspace preparation';
+    }
+  | {
+      type: 'workspace_filesystem_preparation_error';
+      error: WorkspaceFilesystemPreparationError;
+      message: string;
+    };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -107,6 +120,63 @@ export function isSandboxInternalServerError(error: unknown): boolean {
   return isSandboxInternalServerErrorWithSeen(error, new WeakSet());
 }
 
+function getWorkspaceFilesystemPreparationErrorWithSeen(
+  error: unknown,
+  seen: WeakSet<object>
+): WorkspaceFilesystemPreparationError | undefined {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  if (seen.has(error)) {
+    return undefined;
+  }
+  seen.add(error);
+
+  if (error instanceof WorkspaceFilesystemPreparationError) {
+    return error;
+  }
+
+  const cause = getNestedProperty(error, 'cause');
+  return getWorkspaceFilesystemPreparationErrorWithSeen(cause, seen);
+}
+
+function getWorkspaceFilesystemPreparationError(
+  error: unknown
+): WorkspaceFilesystemPreparationError | undefined {
+  return getWorkspaceFilesystemPreparationErrorWithSeen(error, new WeakSet());
+}
+
+export function getPreparationInfrastructureFailure(
+  error: unknown
+): PreparationInfrastructureFailure | undefined {
+  const cause = getNestedProperty(error, 'cause');
+  const sandboxError = isSandboxInternalServerError(cause)
+    ? cause
+    : isSandboxInternalServerError(error)
+      ? error
+      : undefined;
+
+  if (sandboxError !== undefined) {
+    return {
+      type: 'sandbox_internal_server_error',
+      error: sandboxError,
+      message: 'Sandbox returned 500 during workspace preparation',
+    };
+  }
+
+  const workspaceError = getWorkspaceFilesystemPreparationError(error);
+  if (workspaceError) {
+    return {
+      type: 'workspace_filesystem_preparation_error',
+      error: workspaceError,
+      message: workspaceError.message,
+    };
+  }
+
+  return undefined;
+}
+
 export async function destroySandboxAfterInternalServerError(
   context: RecoveryContext,
   error: unknown
@@ -152,6 +222,59 @@ export async function destroySandboxAfterInternalServerError(
   }
 }
 
+export async function destroySandboxAfterPreparationInfrastructureFailure(
+  context: RecoveryContext,
+  error: unknown
+): Promise<boolean> {
+  const failure = getPreparationInfrastructureFailure(error);
+  if (!failure) {
+    return false;
+  }
+
+  if (failure.type === 'sandbox_internal_server_error') {
+    return destroySandboxAfterInternalServerError(context, failure.error);
+  }
+
+  const errorMessage = getErrorMessage(failure.error);
+  logger
+    .withFields({
+      sandboxId: context.sandboxId,
+      sessionId: context.sessionId,
+      phase: context.phase,
+      target: failure.error.target,
+      error: errorMessage,
+      logTag: 'workspace_filesystem_preparation_failed',
+    })
+    .error('Workspace filesystem preparation failed; destroying sandbox');
+
+  try {
+    await context.sandbox.destroy();
+    logger
+      .withFields({
+        sandboxId: context.sandboxId,
+        sessionId: context.sessionId,
+        phase: context.phase,
+        target: failure.error.target,
+        logTag: 'workspace_filesystem_preparation_destroyed',
+      })
+      .info('Destroyed sandbox after workspace filesystem preparation failure');
+    return true;
+  } catch (destroyError) {
+    logger
+      .withFields({
+        sandboxId: context.sandboxId,
+        sessionId: context.sessionId,
+        phase: context.phase,
+        target: failure.error.target,
+        originalError: errorMessage,
+        destroyError: getErrorMessage(destroyError),
+        logTag: 'workspace_filesystem_preparation_destroy_failed',
+      })
+      .error('Failed to destroy sandbox after workspace filesystem preparation failure');
+    return false;
+  }
+}
+
 export async function withSandboxInternalServerErrorRecovery<T>(
   context: RecoveryContext,
   operation: () => Promise<T>
@@ -162,6 +285,18 @@ export async function withSandboxInternalServerErrorRecovery<T>(
     const cause = getNestedProperty(error, 'cause');
     const recoveryError = isSandboxInternalServerError(cause) ? cause : error;
     await destroySandboxAfterInternalServerError(context, recoveryError);
+    throw error;
+  }
+}
+
+export async function withPreparationInfrastructureRecovery<T>(
+  context: RecoveryContext,
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    await destroySandboxAfterPreparationInfrastructureFailure(context, error);
     throw error;
   }
 }

--- a/services/cloud-agent-next/src/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session-prepare.test.ts
@@ -126,7 +126,9 @@ import {
   GitRepositoryNotFoundError,
   cloneGitHubRepo as mockedCloneGitHubRepo,
   manageBranch as mockedManageBranch,
+  setupWorkspace as mockedSetupWorkspace,
 } from './workspace.js';
+import { WorkspaceFilesystemPreparationError } from './workspace-errors.js';
 import {
   SetupCommandFailedError,
   runSetupCommands as mockedRunSetupCommands,
@@ -521,6 +523,51 @@ describe('prepareSession endpoint', () => {
         const trpcError = error as TRPCError;
         expect(trpcError.code).toBe('INTERNAL_SERVER_ERROR');
         expect(trpcError.message).toBe('Sandbox returned 500 during workspace preparation');
+        expect(trpcError.cause).toMatchObject({
+          error: 'sandbox_internal_server_error',
+          retryable: true,
+        });
+      }
+
+      expect(sandbox.destroy).toHaveBeenCalledOnce();
+      expect(doStub.prepare).not.toHaveBeenCalled();
+    });
+
+    it('marks workspace mkdir preparation failures as retryable', async () => {
+      const sandbox = createMockSandbox();
+      const cause = new Error('FileSystemError: mkdir operation failed with exit code NaN');
+      vi.mocked(mockedSetupWorkspace).mockRejectedValueOnce(
+        new WorkspaceFilesystemPreparationError(
+          'workspace_directory',
+          'Failed to create workspace directory: FileSystemError: mkdir operation failed with exit code NaN',
+          cause
+        )
+      );
+      const { getSandbox } = await import('@cloudflare/sandbox');
+      vi.mocked(getSandbox).mockReturnValueOnce(
+        sandbox as unknown as ReturnType<typeof getSandbox>
+      );
+
+      const doStub = createMockDOStub();
+      const ctx = createInternalApiContext({ doStub });
+      const caller = appRouter.createCaller(ctx);
+
+      try {
+        await caller.prepareSession({
+          prompt: 'Test prompt',
+          mode: 'code',
+          model: 'claude-3',
+          githubRepo: 'acme/repo',
+          githubToken: 'ghp_test_token',
+        });
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(TRPCError);
+        const trpcError = error as TRPCError;
+        expect(trpcError.code).toBe('INTERNAL_SERVER_ERROR');
+        expect(trpcError.message).toBe(
+          'Failed to create workspace directory: FileSystemError: mkdir operation failed with exit code NaN'
+        );
         expect(trpcError.cause).toMatchObject({
           error: 'sandbox_internal_server_error',
           retryable: true,

--- a/services/cloud-agent-next/src/workspace-errors.ts
+++ b/services/cloud-agent-next/src/workspace-errors.ts
@@ -1,0 +1,11 @@
+export type WorkspaceFilesystemPreparationTarget = 'workspace_directory' | 'session_home';
+
+export class WorkspaceFilesystemPreparationError extends Error {
+  target: WorkspaceFilesystemPreparationTarget;
+
+  constructor(target: WorkspaceFilesystemPreparationTarget, message: string, cause: unknown) {
+    super(message, { cause });
+    this.name = 'WorkspaceFilesystemPreparationError';
+    this.target = target;
+  }
+}

--- a/services/cloud-agent-next/src/workspace.test.ts
+++ b/services/cloud-agent-next/src/workspace.test.ts
@@ -47,8 +47,9 @@ import type { ExecutionSession, SandboxInstance } from './types';
 describe('setupWorkspace', () => {
   it('throws a typed preparation error when workspace directory creation fails', async () => {
     const cause = new Error('FileSystemError: mkdir operation failed with exit code NaN');
+    const mkdir = vi.fn().mockRejectedValueOnce(cause);
     const sandbox = {
-      mkdir: vi.fn().mockRejectedValueOnce(cause),
+      mkdir,
     } as unknown as SandboxInstance;
 
     const promise = setupWorkspace(sandbox, 'user-123', undefined, 'agent-session');
@@ -64,8 +65,9 @@ describe('setupWorkspace', () => {
 
   it('throws a typed preparation error when session home creation fails', async () => {
     const cause = new Error('FileSystemError: mkdir operation failed with exit code NaN');
+    const mkdir = vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(cause);
     const sandbox = {
-      mkdir: vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(cause),
+      mkdir,
     } as unknown as SandboxInstance;
 
     const promise = setupWorkspace(sandbox, 'user-123', 'org-123', 'agent-session');
@@ -77,12 +79,10 @@ describe('setupWorkspace', () => {
         'Failed to prepare session home: FileSystemError: mkdir operation failed with exit code NaN',
       cause,
     });
-    expect(sandbox.mkdir).toHaveBeenNthCalledWith(
-      1,
-      '/workspace/org-123/user-123/sessions/agent-session',
-      { recursive: true }
-    );
-    expect(sandbox.mkdir).toHaveBeenNthCalledWith(2, '/home/agent-session', { recursive: true });
+    expect(mkdir).toHaveBeenNthCalledWith(1, '/workspace/org-123/user-123/sessions/agent-session', {
+      recursive: true,
+    });
+    expect(mkdir).toHaveBeenNthCalledWith(2, '/home/agent-session', { recursive: true });
   });
 });
 

--- a/services/cloud-agent-next/src/workspace.test.ts
+++ b/services/cloud-agent-next/src/workspace.test.ts
@@ -37,10 +37,54 @@ import {
   checkDiskAndCleanBeforeSetup,
   cleanupStaleWorkspaces,
   createSandboxUsageEvent,
+  setupWorkspace,
   LOW_DISK_THRESHOLD_MB,
   STALE_DIR_MIN_AGE_SECONDS,
 } from './workspace';
+import { WorkspaceFilesystemPreparationError } from './workspace-errors';
 import type { ExecutionSession, SandboxInstance } from './types';
+
+describe('setupWorkspace', () => {
+  it('throws a typed preparation error when workspace directory creation fails', async () => {
+    const cause = new Error('FileSystemError: mkdir operation failed with exit code NaN');
+    const sandbox = {
+      mkdir: vi.fn().mockRejectedValueOnce(cause),
+    } as unknown as SandboxInstance;
+
+    const promise = setupWorkspace(sandbox, 'user-123', undefined, 'agent-session');
+
+    await expect(promise).rejects.toBeInstanceOf(WorkspaceFilesystemPreparationError);
+    await expect(promise).rejects.toMatchObject({
+      target: 'workspace_directory',
+      message:
+        'Failed to create workspace directory: FileSystemError: mkdir operation failed with exit code NaN',
+      cause,
+    });
+  });
+
+  it('throws a typed preparation error when session home creation fails', async () => {
+    const cause = new Error('FileSystemError: mkdir operation failed with exit code NaN');
+    const sandbox = {
+      mkdir: vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(cause),
+    } as unknown as SandboxInstance;
+
+    const promise = setupWorkspace(sandbox, 'user-123', 'org-123', 'agent-session');
+
+    await expect(promise).rejects.toBeInstanceOf(WorkspaceFilesystemPreparationError);
+    await expect(promise).rejects.toMatchObject({
+      target: 'session_home',
+      message:
+        'Failed to prepare session home: FileSystemError: mkdir operation failed with exit code NaN',
+      cause,
+    });
+    expect(sandbox.mkdir).toHaveBeenNthCalledWith(
+      1,
+      '/workspace/org-123/user-123/sessions/agent-session',
+      { recursive: true }
+    );
+    expect(sandbox.mkdir).toHaveBeenNthCalledWith(2, '/home/agent-session', { recursive: true });
+  });
+});
 
 describe('manageBranch', () => {
   let fakeSession: ExecutionSession;

--- a/services/cloud-agent-next/src/workspace.ts
+++ b/services/cloud-agent-next/src/workspace.ts
@@ -13,6 +13,7 @@ import {
 } from './sandbox-timeout-logging.js';
 import { withTimeout } from '@kilocode/worker-utils';
 import { isSandboxInternalServerError } from './sandbox-recovery.js';
+import { WorkspaceFilesystemPreparationError } from './workspace-errors.js';
 
 /**
  * Minimal interface for running shell commands.
@@ -221,18 +222,20 @@ export async function setupWorkspace(
   try {
     await sandbox.mkdir(sessionWorkspacePath, { recursive: true });
   } catch (error) {
-    throw new Error(
+    throw new WorkspaceFilesystemPreparationError(
+      'workspace_directory',
       `Failed to create workspace directory: ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error }
+      error
     );
   }
 
   try {
     await sandbox.mkdir(sessionHome, { recursive: true });
   } catch (error) {
-    throw new Error(
+    throw new WorkspaceFilesystemPreparationError(
+      'session_home',
       `Failed to prepare session home: ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error }
+      error
     );
   }
 

--- a/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
+++ b/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
@@ -44,7 +44,12 @@ function trpcSuccess(data: unknown): Response {
   return Response.json({ result: { data } });
 }
 
-function trpcError(status: number, message: string, code = 'INTERNAL_SERVER_ERROR'): Response {
+function trpcError(
+  status: number,
+  message: string,
+  code = 'INTERNAL_SERVER_ERROR',
+  data: Record<string, unknown> = {}
+): Response {
   return Response.json(
     {
       error: {
@@ -54,6 +59,7 @@ function trpcError(status: number, message: string, code = 'INTERNAL_SERVER_ERRO
           code,
           httpStatus: status,
           path: 'prepareSession',
+          ...data,
         },
       },
     },
@@ -531,6 +537,108 @@ describe('CodeReviewOrchestrator recovery', () => {
       }
     );
     expect(failedStatusUpdates).toHaveLength(0);
+  });
+
+  it('retries prepareSession from a structured workspace mkdir retry marker', async () => {
+    const stub = getReviewStub();
+    let prepareCalls = 0;
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        prepareCalls += 1;
+        if (prepareCalls === 1) {
+          return trpcError(
+            500,
+            'Failed to create workspace directory: FileSystemError: mkdir operation failed with exit code NaN',
+            'INTERNAL_SERVER_ERROR',
+            { error: 'sandbox_internal_server_error', retryable: true }
+          );
+        }
+        return trpcSuccess({
+          cloudAgentSessionId: 'agent-workspace-retry',
+          kiloSessionId: 'ses_workspace_retry',
+        });
+      }
+      if (url.includes('/trpc/initiateFromKilocodeSessionV2')) {
+        return trpcSuccess({ executionId: 'exec-workspace-retry', status: 'running' });
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    const status = await stub.status();
+    expect(status).toMatchObject({
+      status: 'running',
+      sessionId: 'agent-workspace-retry',
+      cliSessionId: 'ses_workspace_retry',
+    });
+
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(2);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(1);
+
+    await expect(storedReview(stub)).resolves.toMatchObject({
+      sandboxRetryAttempted: true,
+      status: 'running',
+      sessionId: 'agent-workspace-retry',
+      cliSessionId: 'ses_workspace_retry',
+    });
+
+    const failedStatusUpdates = fetchCalls(fetchMock, '/api/internal/code-review-status/').filter(
+      call => {
+        const init = call[1] as RequestInit | undefined;
+        if (typeof init?.body !== 'string') return false;
+        return (JSON.parse(init.body) as { status?: string }).status === 'failed';
+      }
+    );
+    expect(failedStatusUpdates).toHaveLength(0);
+  });
+
+  it('does not retry workspace mkdir prose without a structured retry marker', async () => {
+    const stub = getReviewStub();
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        return trpcError(
+          500,
+          'Failed to create workspace directory: FileSystemError: mkdir operation failed with exit code NaN'
+        );
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({
+      status: 'failed',
+    });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(1);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(0);
+    await expect(storedReview(stub)).resolves.toMatchObject({
+      status: 'failed',
+    });
+    const stored = await storedReview(stub);
+    expect(stored?.sandboxRetryAttempted).toBeUndefined();
   });
 
   it('fails after a second sandbox 500 without initiating', async () => {


### PR DESCRIPTION
## Summary

- Treat Cloud Agent workspace directory setup failures as retryable infrastructure failures and destroy the bad sandbox before callers retry.
- Preserve sandbox startup failures as the `cause` on `WrapperNotReadyError` so existing sandbox-500 recovery can detect `ProcessExitedBeforeReadyError`-style failures.
- Keep code-review retries marker-driven and one-shot; plain prose errors still do not trigger retry behavior.

## Verification

No manual verification performed; this change is backend error propagation and retry classification only.

## Visual Changes

N/A

## Reviewer Notes

- Sandbox recovery is intentionally structural: `httpStatus: 500` causes are classified, while generic HTTP 500 message text alone is not.
- Wrapper startup cause preservation lets the existing prepare-session/code-review retry marker path handle sandbox startup 500s without a new retry policy.