### PR TITLE
perf(kilo-pass): read average usage from daily rollup

### DIFF
--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -1529,7 +1529,7 @@ describe('kiloPassRouter', () => {
         google_user_email: 'kilo-pass-avg-usage-personal-only@example.com',
       });
 
-      // last 3 months total: $30 personal + $60 org => should average to $10
+      // personal-only total in last 3 months: $30 (org $60 is excluded) => average $10/month
       const now = new Date().toISOString();
       await insertMicrodollarUsageWithDailyRollup([
         {

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -33,7 +33,6 @@ import {
 } from '@/lib/kilo-pass/constants';
 
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import { insertMicrodollarUsageWithDailyRollup } from '@/tests/helpers/microdollar-usage.helper';
 import type { BillingHistoryEntry } from '@/lib/subscriptions/subscription-center';
 import type { ValidatedStoreKiloPassPurchase } from '@/lib/kilo-pass/store-subscription-completion';
 import type Stripe from 'stripe';
@@ -1506,6 +1505,13 @@ describe('kiloPassRouter', () => {
   });
 
   describe('getAverageMonthlyUsageLast3Months', () => {
+    let insertMicrodollarUsageWithDailyRollup: typeof import('@/tests/helpers/microdollar-usage.helper').insertMicrodollarUsageWithDailyRollup;
+
+    beforeAll(async () => {
+      ({ insertMicrodollarUsageWithDailyRollup } =
+        await import('@/tests/helpers/microdollar-usage.helper'));
+    });
+
     beforeEach(async () => {
       // eslint-disable-next-line drizzle/enforce-delete-with-where
       await db.delete(microdollar_usage_daily);

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -33,6 +33,7 @@ import {
 } from '@/lib/kilo-pass/constants';
 
 import { insertTestUser } from '@/tests/helpers/user.helper';
+import type { insertMicrodollarUsageWithDailyRollup as insertMicrodollarUsageWithDailyRollupType } from '@/tests/helpers/microdollar-usage.helper';
 import type { BillingHistoryEntry } from '@/lib/subscriptions/subscription-center';
 import type { ValidatedStoreKiloPassPurchase } from '@/lib/kilo-pass/store-subscription-completion';
 import type Stripe from 'stripe';
@@ -1505,7 +1506,7 @@ describe('kiloPassRouter', () => {
   });
 
   describe('getAverageMonthlyUsageLast3Months', () => {
-    let insertMicrodollarUsageWithDailyRollup: typeof import('@/tests/helpers/microdollar-usage.helper').insertMicrodollarUsageWithDailyRollup;
+    let insertMicrodollarUsageWithDailyRollup: typeof insertMicrodollarUsageWithDailyRollupType;
 
     beforeAll(async () => {
       ({ insertMicrodollarUsageWithDailyRollup } =

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -10,6 +10,7 @@ import {
   kilo_pass_store_purchases,
   kilo_pass_subscriptions,
   microdollar_usage,
+  microdollar_usage_daily,
 } from '@kilocode/db/schema';
 import {
   KiloPassCadence,
@@ -32,6 +33,7 @@ import {
 } from '@/lib/kilo-pass/constants';
 
 import { insertTestUser } from '@/tests/helpers/user.helper';
+import { insertMicrodollarUsageWithDailyRollup } from '@/tests/helpers/microdollar-usage.helper';
 import type { BillingHistoryEntry } from '@/lib/subscriptions/subscription-center';
 import type { ValidatedStoreKiloPassPurchase } from '@/lib/kilo-pass/store-subscription-completion';
 import type Stripe from 'stripe';
@@ -1506,6 +1508,8 @@ describe('kiloPassRouter', () => {
   describe('getAverageMonthlyUsageLast3Months', () => {
     beforeEach(async () => {
       // eslint-disable-next-line drizzle/enforce-delete-with-where
+      await db.delete(microdollar_usage_daily);
+      // eslint-disable-next-line drizzle/enforce-delete-with-where
       await db.delete(microdollar_usage);
     });
 
@@ -1527,26 +1531,28 @@ describe('kiloPassRouter', () => {
 
       // last 3 months total: $30 personal + $60 org => should average to $10
       const now = new Date().toISOString();
-      await db.insert(microdollar_usage).values({
-        kilo_user_id: user.id,
-        organization_id: null,
-        cost: 30_000_000,
-        input_tokens: 0,
-        output_tokens: 0,
-        cache_write_tokens: 0,
-        cache_hit_tokens: 0,
-        created_at: now,
-      });
-      await db.insert(microdollar_usage).values({
-        kilo_user_id: user.id,
-        organization_id: crypto.randomUUID(),
-        cost: 60_000_000,
-        input_tokens: 0,
-        output_tokens: 0,
-        cache_write_tokens: 0,
-        cache_hit_tokens: 0,
-        created_at: now,
-      });
+      await insertMicrodollarUsageWithDailyRollup([
+        {
+          kilo_user_id: user.id,
+          organization_id: null,
+          cost: 30_000_000,
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_write_tokens: 0,
+          cache_hit_tokens: 0,
+          created_at: now,
+        },
+        {
+          kilo_user_id: user.id,
+          organization_id: crypto.randomUUID(),
+          cost: 60_000_000,
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_write_tokens: 0,
+          cache_hit_tokens: 0,
+          created_at: now,
+        },
+      ]);
 
       const caller = await createCallerForUser(user.id);
       const result = await caller.kiloPass.getAverageMonthlyUsageLast3Months();
@@ -1559,16 +1565,18 @@ describe('kiloPassRouter', () => {
         google_user_email: 'kilo-pass-avg-usage-excludes-old@example.com',
       });
 
-      await db.insert(microdollar_usage).values({
-        kilo_user_id: user.id,
-        organization_id: null,
-        cost: 99_000_000,
-        input_tokens: 0,
-        output_tokens: 0,
-        cache_write_tokens: 0,
-        cache_hit_tokens: 0,
-        created_at: new Date(Date.now() - 1000 * 60 * 60 * 24 * 120).toISOString(),
-      });
+      await insertMicrodollarUsageWithDailyRollup([
+        {
+          kilo_user_id: user.id,
+          organization_id: null,
+          cost: 99_000_000,
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_write_tokens: 0,
+          cache_hit_tokens: 0,
+          created_at: new Date(Date.now() - 1000 * 60 * 60 * 24 * 120).toISOString(),
+        },
+      ]);
 
       const caller = await createCallerForUser(user.id);
       const result = await caller.kiloPass.getAverageMonthlyUsageLast3Months();

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -14,6 +14,7 @@ import {
   kilo_pass_store_purchases,
   kilo_pass_subscriptions,
   microdollar_usage,
+  microdollar_usage_daily,
 } from '@kilocode/db/schema';
 import {
   KiloPassCadence,
@@ -787,9 +788,6 @@ export const kiloPassRouter = createTRPCRouter({
   getAverageMonthlyUsageLast3Months: baseProcedure
     .output(GetAverageMonthlyUsageLast3MonthsOutputSchema)
     .query(async ({ ctx }) => {
-      // Use last 3 months from now (rolling window).
-      const startInclusive = sql`(NOW() - INTERVAL '3 months')`;
-
       const result = await timedUsageQuery(
         {
           db: readDb,
@@ -801,14 +799,14 @@ export const kiloPassRouter = createTRPCRouter({
         tx =>
           tx
             .select({
-              totalCost_mUsd: sql<unknown>`COALESCE(${sum(microdollar_usage.cost)}, 0)`,
+              totalCost_mUsd: sql<unknown>`COALESCE(${sum(microdollar_usage_daily.total_cost_microdollars)}, 0)`,
             })
-            .from(microdollar_usage)
+            .from(microdollar_usage_daily)
             .where(
               and(
-                eq(microdollar_usage.kilo_user_id, ctx.user.id),
-                isNull(microdollar_usage.organization_id),
-                sql`${microdollar_usage.created_at} >= ${startInclusive}`
+                eq(microdollar_usage_daily.kilo_user_id, ctx.user.id),
+                isNull(microdollar_usage_daily.organization_id),
+                sql`${microdollar_usage_daily.usage_date} >= (CURRENT_DATE - INTERVAL '3 months')::date`
               )
             )
       );


### PR DESCRIPTION
## Summary
- Switch `getAverageMonthlyUsageLast3Months` from raw `microdollar_usage` scans to the backfilled `microdollar_usage_daily` rollup.
- Preserve the existing endpoint contract and observability label while using the calendar-day rollup window.
- Update focused router fixtures so rollup-backed reads stay covered and isolated in tests.

## Verification
N/A - backend-only read-path change.

## Visual Changes
N/A

## Reviewer Notes
- This assumes the historical `microdollar_usage_daily` backfill has completed, matching the rollout sequencing for the read switch.
- The endpoint intentionally uses the rollup's calendar-date 3-month window rather than the prior raw timestamp boundary.