### PR TITLE
feat(kiloclaw): configure Composio CLI

### DIFF
--- a/.specs/kiloclaw-composio.md
+++ b/.specs/kiloclaw-composio.md
@@ -1,0 +1,251 @@
+# KiloClaw Composio Integration
+
+## Role of This Document
+
+This spec defines the business rules and invariants for integrating
+Composio with KiloClaw. It is the source of truth for what the system
+must guarantee about Composio credential ownership, sandbox injection,
+manual configuration, managed provisioning, organization sharing, and
+connection onboarding.
+
+It deliberately does not prescribe how to implement those guarantees:
+column layouts, endpoint names, controller helper names, and UI component
+structure belong in plan documents and code, not here.
+
+## Status
+
+Draft -- created 2026-05-15.
+
+## Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+"OPTIONAL" in this document are to be interpreted as described in
+BCP 14 [RFC 2119] [RFC 8174] when, and only when, they appear in all
+capitals, as shown here.
+
+## Definitions
+
+- **Composio CLI credentials**: The Composio user API key and
+  organization identifier required to sign the `composio` CLI into a
+  Composio account or organization.
+- **Manual Composio configuration**: User-provided Composio CLI
+  credentials entered through KiloClaw settings and injected into a
+  KiloClaw sandbox.
+- **Managed Composio identity**: A Composio identity provisioned by Kilo
+  on behalf of a Kilo user or organization, with credentials stored by
+  Kilo and reused across KiloClaw instance lifecycles.
+- **Owner scope**: The Kilo ownership boundary for a Composio identity.
+  The supported scopes are a personal Kilo user and a Kilo organization.
+- **Connected account**: A Composio record representing a user's or
+  organization's authorization to an external toolkit such as Google
+  Calendar, Gmail, GitHub, or Slack.
+- **Connect Link**: A Composio-hosted authentication URL used to connect
+  an external toolkit account to a Composio user/context.
+- **Sandbox**: The Fly Machine-backed KiloClaw environment where
+  OpenClaw and the `composio` CLI run.
+- **Kilo central Composio credential**: Any Composio credential owned by
+  Kilo as an operator/developer rather than by a specific Kilo user or
+  Kilo organization owner scope.
+
+## Overview
+
+KiloClaw can expose Composio to sandbox agents in two phases. First,
+users may manually provide Composio CLI credentials in KiloClaw settings;
+KiloClaw injects those credentials into the sandbox and signs the local
+`composio` CLI in during controller bootstrap. This makes Composio
+available without Kilo provisioning or owning a Composio identity.
+
+Later, Kilo may provision managed Composio identities during onboarding.
+Managed personal identities are reused across a user's KiloClaw instance
+recreates. Managed organization identities are shared across eligible
+users in a Kilo organization according to Kilo organization access rules.
+Kilo may create Connect Links during onboarding so external toolkit
+connections can be completed before the sandbox is fully provisioned.
+
+## Rules
+
+### Manual Configuration
+
+1. Manual Composio configuration MUST be opt-in. A sandbox without both
+   a Composio user API key and Composio organization value MUST continue
+   to boot without Composio CLI sign-in.
+2. Manual Composio credentials MUST be treated as user-provided secrets.
+   The Composio user API key MUST be encrypted at rest before it reaches
+   the KiloClaw worker and MUST be delivered to the machine through the
+   existing encrypted environment variable pipeline.
+3. The Composio organization value MAY be less sensitive than the user
+   API key, but when collected with the Composio integration it SHOULD be
+   stored and transported through the same secret path to avoid exposing
+   account metadata unnecessarily.
+4. The controller MUST NOT log Composio user API keys, generated login
+   commands containing those keys, Connect Links containing secret
+   material, OAuth tokens, or raw Composio credentials.
+5. When manual Composio credentials are removed from KiloClaw settings,
+   the next sandbox bootstrap SHOULD leave the CLI unsigned-in or clean
+   up prior Composio CLI auth state so stale credentials are not reused.
+6. Kilo MUST NOT rotate, revoke, claim, or otherwise manage manually
+   entered Composio credentials unless the user explicitly requests that
+   action through a supported product flow.
+
+### Sandbox CLI Sign-In
+
+7. The sandbox MAY contain the Composio CLI even when no Composio
+   credentials are configured.
+8. When valid Composio CLI credentials are available, the controller
+   SHOULD sign the CLI in during bootstrap so `composio` commands work
+   without an interactive browser login.
+9. Composio CLI sign-in MUST be best-effort and MUST NOT prevent the
+   controller from starting OpenClaw unless the user or product has
+   explicitly configured Composio as a required startup dependency.
+10. If sign-in uses a subprocess invocation, the implementation MUST use
+    a direct executable call rather than a shell and MUST suppress logs
+    that would include credentials.
+11. If sign-in writes Composio CLI state files directly, those files MUST
+    be written with owner-only permissions and MUST be placed in the
+    sandbox user's Composio config directory.
+12. Composio credentials injected for CLI sign-in MUST NOT be left in the
+    gateway child process environment when they are no longer needed by
+    the running gateway.
+13. Configuring Composio through KiloClaw settings or managed
+    provisioning is an explicit request for Kilo to manage the sandbox's
+    Composio CLI sign-in. When valid Kilo-provided Composio credentials
+    are available, the controller MAY overwrite existing on-disk
+    Composio CLI configuration during bootstrap.
+14. If a user signs into Composio manually inside the sandbox after
+    configuring Composio through KiloClaw, a later controller bootstrap
+    MAY overwrite that manual sign-in with the Kilo-provided
+    credentials. This is accepted behavior; users who want to preserve a
+    fully custom Composio CLI configuration SHOULD not configure
+    Composio through KiloClaw for that sandbox.
+15. When Composio credentials are removed from Kilo settings or managed
+    provisioning, the controller MAY leave any existing on-disk Composio
+    CLI configuration untouched. Kilo is not required to determine
+    whether that configuration was written by Kilo or by a user.
+
+### Credential Boundary
+
+16. Kilo central Composio credentials MUST NOT be injected into a user or
+    organization sandbox.
+17. A sandbox MUST receive only credentials for its own owner scope: the
+    user's manual credentials, the user's managed personal Composio
+    identity, or the Kilo organization's managed Composio identity.
+18. The system MUST NOT fall back from a missing owner-scoped Composio
+    identity to any shared global Composio identity.
+19. Manual personal Composio credentials MUST NOT be reused for an
+    organization sandbox unless the user explicitly configures those
+    credentials in that organization context.
+20. Managed personal Composio credentials MUST NOT be reused for a Kilo
+    organization context. Managed organization credentials MUST NOT be
+    reused for an unrelated organization or personal context.
+
+### Managed Identity Ownership
+
+21. A managed personal Composio identity MUST be scoped to exactly one
+    Kilo user.
+22. A managed organization Composio identity MUST be scoped to exactly
+    one Kilo organization.
+23. Managed Composio identities MUST survive KiloClaw instance destroy
+    and reprovision operations unless the owner explicitly revokes the
+    identity or account deletion/org deletion policy requires revocation
+    or anonymization.
+24. Kilo SHOULD store managed Composio identities in owner-scoped
+    persistent storage rather than instance-scoped Durable Object state.
+25. Managed Composio identity credentials MUST be encrypted at rest.
+26. The KiloClaw worker MUST NOT be the primary creator of persistent
+    managed Composio identity records. Persistent identity writes SHOULD
+    be owned by the Next.js web app or another explicitly designated
+    control-plane service.
+27. At most one active managed Composio identity SHOULD exist per owner
+    scope unless a future spec explicitly supports multiple active
+    identities.
+
+### Organization Sharing
+
+28. In a Kilo organization context, eligible organization users MAY share
+    the organization's managed Composio identity.
+29. Sharing a managed organization Composio identity means connected
+    accounts associated with that identity MAY be usable by multiple
+    organization users who have access to the relevant organization
+    KiloClaw sandbox.
+30. The system MUST define and enforce which organization roles or
+    permissions can configure, connect, revoke, or use organization-level
+    Composio credentials before enabling managed organization
+    provisioning in production.
+31. When a user loses access to a Kilo organization, the system MUST
+    prevent that user from receiving the organization's managed Composio
+    credentials in any future sandbox config.
+32. Organization member removal SHOULD NOT delete the organization's
+    managed Composio identity or connected accounts unless the removed
+    member was the sole authorized external-account owner and the
+    organization explicitly requests cleanup.
+33. Organization deletion MUST define whether the managed Composio
+    identity is revoked, claimed by an administrator, anonymized, or
+    retained for audit/compliance before deletion support ships.
+
+### Connect Link Onboarding
+
+34. Kilo MAY create Composio Connect Links during onboarding before the
+    sandbox machine exists.
+35. A Connect Link created by Kilo MUST be scoped to the correct managed
+    owner identity and to the intended Composio user/context for that
+    owner.
+36. Connect Link callback handling MUST verify the authenticated Kilo
+    user still has access to the owner scope before recording a
+    connection as active or surfacing it in UI.
+37. Kilo MUST NOT receive or persist raw OAuth access tokens from external
+    toolkits connected through Composio unless a separate spec explicitly
+    permits that behavior.
+38. Connection status displayed in Kilo SHOULD be derived from Composio
+    connected-account state or from a Kilo cache that is refreshed from
+    Composio. Kilo MUST NOT treat creation of a Connect Link as proof
+    that the external account is connected.
+39. For organization-scoped onboarding, Kilo MUST make clear that the
+    connection is for the organization context, not just the individual
+    member completing OAuth.
+
+### Data Protection and Logging
+
+40. Composio user API keys, project API keys, agent keys, OAuth tokens,
+    and any equivalent credential material MUST be treated as secrets.
+41. Logs, analytics, audit records, Sentry events, and user-facing errors
+    MUST NOT include raw Composio credentials or OAuth tokens.
+42. Generated Composio emails or identifiers that can be linked to a Kilo
+    user SHOULD be treated as user-linked data for GDPR/anonymization
+    purposes.
+43. When Kilo stores user-linked managed Composio data in Postgres, the
+    GDPR soft-delete flow MUST anonymize, revoke, or detach that data in
+    a way that complies with the product's account deletion policy.
+
+## Error Handling
+
+1. If manual Composio credentials are missing or incomplete, the
+   controller MUST skip Composio CLI sign-in and continue startup.
+2. If Composio CLI sign-in fails, the controller MUST log a sanitized
+   failure and SHOULD continue startup in a usable state.
+3. If managed Composio identity provisioning fails during onboarding,
+   the onboarding flow MUST surface a retryable error and MUST NOT store
+   a partially usable identity as active.
+4. If a Connect Link callback reports failure or the connected account is
+   not active, Kilo MUST keep the connection status non-active and allow
+   the user to retry.
+5. If an organization user is no longer authorized for an organization
+   before a Connect Link callback completes, Kilo MUST reject the
+   callback result for that user's session.
+
+## Not Yet Implemented
+
+The following rules use SHOULD and reflect intended behavior that is not
+necessarily enforced in the current codebase:
+
+1. The system SHOULD support manual Composio CLI configuration through
+   KiloClaw settings. (Currently not implemented.)
+2. The controller SHOULD sign the Composio CLI in when manual or managed
+   credentials are present. (Currently not implemented.)
+3. Kilo SHOULD provision managed personal Composio identities during
+   onboarding. (Currently not implemented.)
+4. Kilo SHOULD provision or reuse managed organization Composio
+   identities for organization KiloClaw contexts. (Currently not
+   implemented.)
+5. Kilo SHOULD support pre-provision Connect Link onboarding for selected
+   toolkits such as Google Calendar. (Currently not implemented.)

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -2183,7 +2183,7 @@ export function SettingsTab({
       )}
 
       {/* ── Developer Tools ── */}
-      {toolEntries.some(e => e.id === 'github' || e.id === 'linear') && (
+      {toolEntries.some(e => e.id === 'github' || e.id === 'linear' || e.id === 'composio') && (
         <div>
           <h2 className="text-foreground mb-3 text-base font-semibold">Developer Tools</h2>
           <div className="space-y-3">
@@ -2226,6 +2226,19 @@ export function SettingsTab({
               ))}
             {toolEntries
               .filter(e => e.id === 'linear')
+              .map(entry => (
+                <SecretEntrySection
+                  key={entry.id}
+                  entry={entry}
+                  configured={configuredSecrets[entry.id] ?? false}
+                  mutations={mutations}
+                  onSecretsChanged={onSecretsChanged}
+                  isDirty={dirtySecrets.has(entry.id)}
+                  onRedeploy={onRedeploy}
+                />
+              ))}
+            {toolEntries
+              .filter(e => e.id === 'composio')
               .map(entry => (
                 <SecretEntrySection
                   key={entry.id}

--- a/apps/web/src/app/(app)/claw/components/secret-ui-adapter.ts
+++ b/apps/web/src/app/(app)/claw/components/secret-ui-adapter.ts
@@ -1,6 +1,6 @@
 import type React from 'react';
 import type { SecretIconKey } from '@kilocode/kiloclaw-secret-catalog';
-import { Key, Lock } from 'lucide-react';
+import { Key, Lock, Plug } from 'lucide-react';
 import { TelegramIcon } from './icons/TelegramIcon';
 import { DiscordIcon } from './icons/DiscordIcon';
 import { SlackIcon } from './icons/SlackIcon';
@@ -19,6 +19,7 @@ const ICON_MAP: Record<SecretIconKey, React.ComponentType<{ className?: string }
   'credit-card': AgentCardIcon,
   lock: Lock,
   brave: BraveSearchIcon,
+  plug: Plug,
 };
 
 export function getIcon(iconKey: SecretIconKey): React.ComponentType<{ className?: string }> {
@@ -35,6 +36,7 @@ const DESCRIPTION_MAP: Record<string, string> = {
   agentcard: 'Give your bot virtual debit cards for spending',
   onepassword: 'Look up credentials and manage vault items via the op CLI',
   'brave-search': 'Add a Brave Search API key for web search',
+  composio: 'Sign the Composio CLI into this sandbox',
 };
 
 export function getDescription(entryId: string): string {

--- a/packages/kiloclaw-secret-catalog/src/__tests__/catalog.test.ts
+++ b/packages/kiloclaw-secret-catalog/src/__tests__/catalog.test.ts
@@ -52,6 +52,7 @@ describe('Secret Catalog', () => {
         'credit-card',
         'lock',
         'brave',
+        'plug',
       ]);
       for (const entry of SECRET_CATALOG) {
         expect(validIcons.has(entry.icon)).toBe(true);
@@ -128,6 +129,8 @@ describe('Secret Catalog', () => {
         'GITHUB_EMAIL',
         'BRAVE_API_KEY',
         'LINEAR_API_KEY',
+        'COMPOSIO_USER_API_KEY',
+        'COMPOSIO_ORG',
       ]);
 
       const catalogEnvVars = new Set(FIELD_KEY_TO_ENV_VAR.values());
@@ -146,6 +149,8 @@ describe('Secret Catalog', () => {
       expect(FIELD_KEY_TO_ENV_VAR.get('githubUsername')).toBe('GITHUB_USERNAME');
       expect(FIELD_KEY_TO_ENV_VAR.get('githubEmail')).toBe('GITHUB_EMAIL');
       expect(FIELD_KEY_TO_ENV_VAR.get('braveSearchApiKey')).toBe('BRAVE_API_KEY');
+      expect(FIELD_KEY_TO_ENV_VAR.get('composioUserApiKey')).toBe('COMPOSIO_USER_API_KEY');
+      expect(FIELD_KEY_TO_ENV_VAR.get('composioOrg')).toBe('COMPOSIO_ORG');
     });
 
     it('ENV_VAR_TO_FIELD_KEY is the exact reverse of FIELD_KEY_TO_ENV_VAR', () => {
@@ -164,6 +169,8 @@ describe('Secret Catalog', () => {
       expect(ENV_VAR_TO_FIELD_KEY.get('GITHUB_USERNAME')).toBe('githubUsername');
       expect(ENV_VAR_TO_FIELD_KEY.get('GITHUB_EMAIL')).toBe('githubEmail');
       expect(ENV_VAR_TO_FIELD_KEY.get('BRAVE_API_KEY')).toBe('braveSearchApiKey');
+      expect(ENV_VAR_TO_FIELD_KEY.get('COMPOSIO_USER_API_KEY')).toBe('composioUserApiKey');
+      expect(ENV_VAR_TO_FIELD_KEY.get('COMPOSIO_ORG')).toBe('composioOrg');
     });
   });
 
@@ -205,12 +212,13 @@ describe('Secret Catalog', () => {
 
     it('returns all tool entries sorted by order', () => {
       const tools = getEntriesByCategory('tool');
-      expect(tools.length).toBe(5);
+      expect(tools.length).toBe(6);
       expect(tools[0].id).toBe('github');
       expect(tools[1].id).toBe('agentcard');
       expect(tools[2].id).toBe('onepassword');
       expect(tools[3].id).toBe('brave-search');
       expect(tools[4].id).toBe('linear');
+      expect(tools[5].id).toBe('composio');
     });
 
     it('returns empty array for categories with no entries', () => {
@@ -238,7 +246,9 @@ describe('Secret Catalog', () => {
       expect(keys).toContain('agentcardApiKey');
       expect(keys).toContain('onepasswordServiceAccountToken');
       expect(keys).toContain('braveSearchApiKey');
-      expect(keys.size).toBe(7);
+      expect(keys).toContain('composioUserApiKey');
+      expect(keys).toContain('composioOrg');
+      expect(keys.size).toBe(9);
     });
 
     it('returns empty set for categories with no entries', () => {
@@ -390,6 +400,19 @@ describe('Secret Catalog', () => {
       expect(validateFieldValue('bsa' + 'A'.repeat(20), pattern)).toBe(false);
     });
 
+    it('accepts valid Composio user API keys', () => {
+      const pattern = '^uak_[A-Za-z0-9_-]{16,}$';
+      expect(validateFieldValue('uak_FAKE_TEST_KEY_1234567890', pattern)).toBe(true);
+      expect(validateFieldValue('uak_' + 'A'.repeat(16), pattern)).toBe(true);
+    });
+
+    it('rejects invalid Composio user API keys', () => {
+      const pattern = '^uak_[A-Za-z0-9_-]{16,}$';
+      expect(validateFieldValue('invalid', pattern)).toBe(false);
+      expect(validateFieldValue('uak_short', pattern)).toBe(false);
+      expect(validateFieldValue('ak_' + 'A'.repeat(16), pattern)).toBe(false);
+    });
+
     it('rejects empty strings', () => {
       const pattern = '^\\d{8,}:[A-Za-z0-9_-]{30,50}$';
       expect(validateFieldValue('', pattern)).toBe(false);
@@ -442,6 +465,15 @@ describe('Secret Catalog', () => {
         'githubEmail',
         'githubToken',
       ]);
+    });
+
+    it('composio entry requires user API key and organization', () => {
+      const composio = SECRET_CATALOG_MAP.get('composio');
+      expect(composio?.allFieldsRequired).toBe(true);
+      expect(composio?.fields.map(f => f.key)).toEqual(['composioUserApiKey', 'composioOrg']);
+      expect(
+        composio?.fields.find(f => f.key === 'composioOrg')?.validationPattern
+      ).toBeUndefined();
     });
 
     it('telegram and discord do not have allFieldsRequired', () => {

--- a/packages/kiloclaw-secret-catalog/src/catalog.ts
+++ b/packages/kiloclaw-secret-catalog/src/catalog.ts
@@ -246,7 +246,7 @@ const SECRET_CATALOG_RAW = [
       {
         key: 'composioOrg',
         label: 'Organization ID or Name',
-        placeholder: 'syn_workspace',
+        placeholder: 'username_workspace',
         placeholderConfigured: 'Enter new organization ID, name, or slug to replace',
         envVar: 'COMPOSIO_ORG',
         maxLength: 300,

--- a/packages/kiloclaw-secret-catalog/src/catalog.ts
+++ b/packages/kiloclaw-secret-catalog/src/catalog.ts
@@ -225,6 +225,36 @@ const SECRET_CATALOG_RAW = [
     helpText: 'Generate an API key from your Linear account security settings.',
     helpUrl: 'https://linear.app/settings/account/security',
   },
+  {
+    id: 'composio',
+    label: 'Composio',
+    category: 'tool',
+    icon: 'plug',
+    order: 6,
+    allFieldsRequired: true,
+    fields: [
+      {
+        key: 'composioUserApiKey',
+        label: 'User API Key',
+        placeholder: 'uak_...',
+        placeholderConfigured: 'Enter new user API key to replace',
+        envVar: 'COMPOSIO_USER_API_KEY',
+        validationPattern: '^uak_[A-Za-z0-9_-]{16,}$',
+        validationMessage: 'Composio user API keys start with uak_.',
+        maxLength: 300,
+      },
+      {
+        key: 'composioOrg',
+        label: 'Organization ID or Name',
+        placeholder: 'syn_workspace',
+        placeholderConfigured: 'Enter new organization ID, name, or slug to replace',
+        envVar: 'COMPOSIO_ORG',
+        maxLength: 300,
+      },
+    ],
+    helpText: 'Used to sign the Composio CLI into this sandbox.',
+    helpUrl: 'https://docs.composio.dev/docs/cli',
+  },
 ] as const satisfies readonly SecretCatalogEntry[];
 
 // Runtime validation — fails fast at module load if catalog data is malformed

--- a/packages/kiloclaw-secret-catalog/src/types.ts
+++ b/packages/kiloclaw-secret-catalog/src/types.ts
@@ -14,6 +14,7 @@ export const SecretIconKeySchema = z.enum([
   'credit-card',
   'lock',
   'brave',
+  'plug',
 ]);
 
 /**

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -56,11 +56,11 @@ RUN git config --system url."https://github.com/".insteadOf "ssh://git@github.co
 
 # Install global CLI tools in a single invocation, then patch openclaw and clean cache once.
 # Packages: pnpm (package manager), openclaw (pinned for reproducible builds; patched below),
-#   clawhub, mcporter, @steipete/summarize, @kilocode/cli (runtime tooling).
+#   clawhub, mcporter, @steipete/summarize, @kilocode/cli, @composio/cli (runtime tooling).
 # Patch: bump model discovery timeout from 5s to 60s — shared-cpu machines
 # under boot load routinely need 27-35s for the first TLS+fetch to complete.
 # Remove this sed patch once openclaw exposes a configurable timeout.
-RUN npm install -g pnpm openclaw@2026.4.23 clawhub mcporter@0.7.3 @steipete/summarize@0.12.0 @kilocode/cli@7.2.31 \
+RUN npm install -g pnpm openclaw@2026.4.23 clawhub mcporter@0.7.3 @steipete/summarize@0.12.0 @kilocode/cli@7.2.31 @composio/cli@0.2.30 \
     && OC_DIST=/usr/local/lib/node_modules/openclaw/dist \
     && FOUND_FILES=$(find "$OC_DIST" -name 'provider-models-*.js' | wc -l | tr -d ' ') \
     && if [ "$FOUND_FILES" -eq 0 ]; then echo "ERROR: provider-models-*.js not found in openclaw dist" >&2; exit 1; fi \
@@ -78,6 +78,7 @@ RUN npm install -g pnpm openclaw@2026.4.23 clawhub mcporter@0.7.3 @steipete/summ
     && if grep -q 'MESSAGE_ACTION_TARGET_MODE\[action\] !== "none"' "$CT_FILE"; then echo "ERROR: actionRequiresTarget patch failed" >&2; exit 1; fi \
     && echo "OK: patched actionRequiresTarget in $(basename "$CT_FILE")" \
     && openclaw --version \
+    && composio --version \
     && npm cache clean --force
 
 # Bake bundled plugin runtime deps into OpenClaw's external stage dir so first

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -11,7 +11,10 @@ FROM debian:trixie-slim AS runtime
 # Install Node.js 24 (required by OpenClaw)
 ENV NODE_VERSION=24.15.0
 ENV OPENCLAW_PLUGIN_STAGE_DIR=/usr/local/share/openclaw-plugin-runtime-deps
+ENV COMPOSIO_INSTALL_DIR=/usr/local/lib/composio
+ENV PATH="${COMPOSIO_INSTALL_DIR}:${PATH}"
 ARG APT_CACHE_BUST
+ARG COMPOSIO_CLI_VERSION=0.2.28
 RUN echo "apt cache bust: ${APT_CACHE_BUST}" \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -56,11 +59,11 @@ RUN git config --system url."https://github.com/".insteadOf "ssh://git@github.co
 
 # Install global CLI tools in a single invocation, then patch openclaw and clean cache once.
 # Packages: pnpm (package manager), openclaw (pinned for reproducible builds; patched below),
-#   clawhub, mcporter, @steipete/summarize, @kilocode/cli, @composio/cli (runtime tooling).
+#   clawhub, mcporter, @steipete/summarize, @kilocode/cli (runtime tooling).
 # Patch: bump model discovery timeout from 5s to 60s — shared-cpu machines
 # under boot load routinely need 27-35s for the first TLS+fetch to complete.
 # Remove this sed patch once openclaw exposes a configurable timeout.
-RUN npm install -g pnpm openclaw@2026.4.23 clawhub mcporter@0.7.3 @steipete/summarize@0.12.0 @kilocode/cli@7.2.31 @composio/cli@0.2.30 \
+RUN npm install -g pnpm openclaw@2026.4.23 clawhub mcporter@0.7.3 @steipete/summarize@0.12.0 @kilocode/cli@7.2.31 \
     && OC_DIST=/usr/local/lib/node_modules/openclaw/dist \
     && FOUND_FILES=$(find "$OC_DIST" -name 'provider-models-*.js' | wc -l | tr -d ' ') \
     && if [ "$FOUND_FILES" -eq 0 ]; then echo "ERROR: provider-models-*.js not found in openclaw dist" >&2; exit 1; fi \
@@ -78,8 +81,17 @@ RUN npm install -g pnpm openclaw@2026.4.23 clawhub mcporter@0.7.3 @steipete/summ
     && if grep -q 'MESSAGE_ACTION_TARGET_MODE\[action\] !== "none"' "$CT_FILE"; then echo "ERROR: actionRequiresTarget patch failed" >&2; exit 1; fi \
     && echo "OK: patched actionRequiresTarget in $(basename "$CT_FILE")" \
     && openclaw --version \
-    && composio --version \
     && npm cache clean --force
+
+# Composio publishes CLI binaries as GitHub release artifacts rather than as a
+# usable npm package. Pin the tagged install script and stable release so image
+# builds verify the upstream checksum while keeping this install isolated.
+RUN COMPOSIO_INSTALL_TAG="%40composio%2Fcli%40${COMPOSIO_CLI_VERSION}" \
+    && curl -fsSL "https://raw.githubusercontent.com/ComposioHQ/composio/${COMPOSIO_INSTALL_TAG}/install.sh" \
+       -o /tmp/install-composio.sh \
+    && bash /tmp/install-composio.sh "@composio/cli@${COMPOSIO_CLI_VERSION}" \
+    && composio --version \
+    && rm -f /tmp/install-composio.sh
 
 # Bake bundled plugin runtime deps into OpenClaw's external stage dir so first
 # boot is pure startup — no npm install from `openclaw doctor` or gateway plugin

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -24,6 +24,7 @@ import {
   KILO_CLI_SECTION_CONFIG,
   OP_SECTION_CONFIG,
   LINEAR_SECTION_CONFIG,
+  COMPOSIO_SECTION_CONFIG,
   KILOCLAW_MITIGATIONS_SECTION_CONFIG,
   PLUGIN_INSTALL_SECTION_CONFIG,
   PROCESS_MODEL_SECTION_CONFIG,
@@ -1669,6 +1670,7 @@ describe('TOOLS.md section configs', () => {
     KILO_CLI_SECTION_CONFIG,
     OP_SECTION_CONFIG,
     LINEAR_SECTION_CONFIG,
+    COMPOSIO_SECTION_CONFIG,
     KILOCLAW_MITIGATIONS_SECTION_CONFIG,
     PLUGIN_INSTALL_SECTION_CONFIG,
     PROCESS_MODEL_SECTION_CONFIG,
@@ -1756,6 +1758,14 @@ describe('TOOLS.md section configs', () => {
     );
     expect(GOG_SECTION_CONFIG.section).toContain('gog drive ls --account <email> --json');
     expect(GOG_SECTION_CONFIG.section).not.toContain('gog drive files list');
+  });
+
+  it('Composio section references core CLI commands', () => {
+    const section = COMPOSIO_SECTION_CONFIG.section;
+    expect(section).toContain('composio whoami');
+    expect(section).toContain('composio search');
+    expect(section).toContain('composio connections list');
+    expect(section).toContain('composio link <toolkit>');
   });
 });
 

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -1168,6 +1168,24 @@ You can interact with the \`Linear\` MCP server using your \`mcporter\` skill.
   <!-- END:linear -->`,
 };
 
+export const COMPOSIO_SECTION_CONFIG: ToolsMdSectionConfig = {
+  name: 'Composio',
+  beginMarker: '<!-- BEGIN:composio -->',
+  endMarker: '<!-- END:composio -->',
+  section: `
+<!-- BEGIN:composio -->
+## Composio
+
+The \`composio\` CLI is configured for this sandbox. Use it to discover and run Composio tools, or to create connection links for external services.
+
+- Check account: \`composio whoami\`
+- Search tools: \`composio search "send email"\`
+- List connections: \`composio connections list\`
+- Connect a toolkit: \`composio link <toolkit>\`
+- Run \`composio --help\` and \`composio <command> --help\` for all available commands.
+<!-- END:composio -->`,
+};
+
 // Additional KiloClaw-mitigated OpenClaw audit findings beyond the
 // gateway.control_ui.insecure_auth one already documented in the base
 // TOOLS.md. Mirrors the list in apps/web/src/lib/shell-security/
@@ -1324,6 +1342,11 @@ export async function bootstrapNonCritical(
         updateToolsMdSection(googleWorkspaceToolsEnabled, GOG_SECTION_CONFIG, deps);
         updateToolsMdSection(!!env.OP_SERVICE_ACCOUNT_TOKEN, OP_SECTION_CONFIG, deps);
         updateToolsMdSection(!!env.LINEAR_API_KEY, LINEAR_SECTION_CONFIG, deps);
+        updateToolsMdSection(
+          !!env.COMPOSIO_USER_API_KEY && !!env.COMPOSIO_ORG,
+          COMPOSIO_SECTION_CONFIG,
+          deps
+        );
         // Always-on: agent context about KiloClaw-mitigated audit findings
         // and how to keep plugins.allow in sync on plugin installs.
         updateToolsMdSection(true, KILOCLAW_MITIGATIONS_SECTION_CONFIG, deps);

--- a/services/kiloclaw/controller/src/composio-cli-config.test.ts
+++ b/services/kiloclaw/controller/src/composio-cli-config.test.ts
@@ -6,7 +6,11 @@ import {
 } from './composio-cli-config';
 
 function fakeDeps() {
-  const execCalls: { cmd: string; args: string[]; opts: { stdio: 'ignore' } }[] = [];
+  const execCalls: {
+    cmd: string;
+    args: string[];
+    opts: { stdio: 'ignore'; env: NodeJS.ProcessEnv };
+  }[] = [];
   const deps: ComposioCliLoginDeps = {
     execFileSync: vi.fn((cmd, args, opts) => {
       execCalls.push({ cmd, args, opts });
@@ -40,14 +44,13 @@ describe('loginComposioCli', () => {
 
   it('runs composio login when both values are present', () => {
     const { deps, execCalls } = fakeDeps();
+    const env = {
+      COMPOSIO_USER_API_KEY: ' uak_FAKE_TEST_KEY_1234567890 ',
+      COMPOSIO_ORG: ' syn_workspace ',
+      KILOCODE_API_KEY: 'kc_keep',
+    };
 
-    const result = loginComposioCli(
-      {
-        COMPOSIO_USER_API_KEY: ' uak_FAKE_TEST_KEY_1234567890 ',
-        COMPOSIO_ORG: ' syn_workspace ',
-      },
-      deps
-    );
+    const result = loginComposioCli(env, deps);
 
     expect(result).toBe(true);
     expect(execCalls).toHaveLength(1);
@@ -60,6 +63,7 @@ describe('loginComposioCli', () => {
       'syn_workspace',
     ]);
     expect(execCalls[0].opts.stdio).toBe('ignore');
+    expect(execCalls[0].opts.env).toBe(env);
   });
 });
 

--- a/services/kiloclaw/controller/src/composio-cli-config.test.ts
+++ b/services/kiloclaw/controller/src/composio-cli-config.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  clearComposioCliEnv,
+  loginComposioCli,
+  type ComposioCliLoginDeps,
+} from './composio-cli-config';
+
+function fakeDeps() {
+  const execCalls: { cmd: string; args: string[]; opts: { stdio: 'ignore' } }[] = [];
+  const deps: ComposioCliLoginDeps = {
+    execFileSync: vi.fn((cmd, args, opts) => {
+      execCalls.push({ cmd, args, opts });
+    }),
+  };
+
+  return { deps, execCalls };
+}
+
+describe('loginComposioCli', () => {
+  it('returns false when user API key is missing', () => {
+    const { deps, execCalls } = fakeDeps();
+
+    const result = loginComposioCli({ COMPOSIO_ORG: 'syn_workspace' }, deps);
+
+    expect(result).toBe(false);
+    expect(execCalls).toEqual([]);
+  });
+
+  it('returns false when organization is missing', () => {
+    const { deps, execCalls } = fakeDeps();
+
+    const result = loginComposioCli(
+      { COMPOSIO_USER_API_KEY: 'uak_FAKE_TEST_KEY_1234567890' },
+      deps
+    );
+
+    expect(result).toBe(false);
+    expect(execCalls).toEqual([]);
+  });
+
+  it('runs composio login when both values are present', () => {
+    const { deps, execCalls } = fakeDeps();
+
+    const result = loginComposioCli(
+      {
+        COMPOSIO_USER_API_KEY: ' uak_FAKE_TEST_KEY_1234567890 ',
+        COMPOSIO_ORG: ' syn_workspace ',
+      },
+      deps
+    );
+
+    expect(result).toBe(true);
+    expect(execCalls).toHaveLength(1);
+    expect(execCalls[0].cmd).toBe('composio');
+    expect(execCalls[0].args).toEqual([
+      'login',
+      '--user-api-key',
+      'uak_FAKE_TEST_KEY_1234567890',
+      '--org',
+      'syn_workspace',
+    ]);
+    expect(execCalls[0].opts.stdio).toBe('ignore');
+  });
+});
+
+describe('clearComposioCliEnv', () => {
+  it('removes Composio credentials from the provided env', () => {
+    const env = {
+      COMPOSIO_USER_API_KEY: 'uak_FAKE_TEST_KEY_1234567890',
+      COMPOSIO_ORG: 'syn_workspace',
+      KILOCODE_API_KEY: 'kc_keep',
+    };
+
+    clearComposioCliEnv(env);
+
+    expect(env).toEqual({ KILOCODE_API_KEY: 'kc_keep' });
+  });
+});

--- a/services/kiloclaw/controller/src/composio-cli-config.ts
+++ b/services/kiloclaw/controller/src/composio-cli-config.ts
@@ -34,7 +34,7 @@ export function loginComposioCli(
 
   deps.execFileSync('composio', ['login', '--user-api-key', userApiKey, '--org', org], {
     stdio: 'ignore',
-    env: process.env,
+    env: env as NodeJS.ProcessEnv,
   });
   console.log('[composio] CLI login completed');
   return true;

--- a/services/kiloclaw/controller/src/composio-cli-config.ts
+++ b/services/kiloclaw/controller/src/composio-cli-config.ts
@@ -1,0 +1,46 @@
+import { execFileSync as nodeExecFileSync } from 'node:child_process';
+
+type EnvLike = Record<string, string | undefined>;
+
+type ExecFileSync = (
+  cmd: string,
+  args: string[],
+  opts: { stdio: 'ignore'; env: NodeJS.ProcessEnv }
+) => void;
+
+export type ComposioCliLoginDeps = {
+  execFileSync: ExecFileSync;
+};
+
+const defaultDeps: ComposioCliLoginDeps = {
+  execFileSync: (cmd, args, opts) => {
+    nodeExecFileSync(cmd, args, opts);
+  },
+};
+
+function cleanEnvValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function loginComposioCli(
+  env: EnvLike = process.env,
+  deps: ComposioCliLoginDeps = defaultDeps
+): boolean {
+  const userApiKey = cleanEnvValue(env.COMPOSIO_USER_API_KEY);
+  const org = cleanEnvValue(env.COMPOSIO_ORG);
+
+  if (!userApiKey || !org) return false;
+
+  deps.execFileSync('composio', ['login', '--user-api-key', userApiKey, '--org', org], {
+    stdio: 'ignore',
+    env: process.env,
+  });
+  console.log('[composio] CLI login completed');
+  return true;
+}
+
+export function clearComposioCliEnv(env: EnvLike = process.env): void {
+  delete env.COMPOSIO_USER_API_KEY;
+  delete env.COMPOSIO_ORG;
+}

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -518,8 +518,8 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
 
   try {
     loginComposioCli(env as Record<string, string | undefined>);
-  } catch (err) {
-    console.error('[composio] CLI login failed:', err);
+  } catch {
+    console.error('[composio] CLI login failed');
   } finally {
     clearComposioCliEnv(env as Record<string, string | undefined>);
   }

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -45,6 +45,7 @@ import { registerDoctorRoutes } from './routes/doctor';
 import { registerMorningBriefingRoutes } from './routes/morning-briefing';
 import { CONTROLLER_COMMIT, CONTROLLER_VERSION } from './version';
 import { writeKiloCliConfig } from './kilo-cli-config';
+import { clearComposioCliEnv, loginComposioCli } from './composio-cli-config';
 import { writeGogCredentials } from './gog-credentials';
 import { installGogShim } from './gog-shim';
 import { migrateLegacyGoogleCredentialsToBroker } from './legacy-google-migration';
@@ -513,6 +514,14 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     writeKiloCliConfig(env as Record<string, string | undefined>);
   } catch (err) {
     console.error('[kilo-cli] Failed to write config:', err);
+  }
+
+  try {
+    loginComposioCli(env as Record<string, string | undefined>);
+  } catch (err) {
+    console.error('[composio] CLI login failed:', err);
+  } finally {
+    clearComposioCliEnv(env as Record<string, string | undefined>);
   }
 
   try {

--- a/services/kiloclaw/src/routes/kiloclaw.test.ts
+++ b/services/kiloclaw/src/routes/kiloclaw.test.ts
@@ -20,6 +20,7 @@ describe('buildConfiguredSecrets', () => {
       agentcard: false,
       onepassword: false,
       'brave-search': false,
+      composio: false,
     });
   });
 
@@ -116,7 +117,8 @@ describe('buildConfiguredSecrets', () => {
     expect(keys).toContain('linear');
     expect(keys).toContain('onepassword');
     expect(keys).toContain('brave-search');
-    expect(keys).toHaveLength(8);
+    expect(keys).toContain('composio');
+    expect(keys).toHaveLength(9);
   });
 
   it('treats null values as not configured', () => {


### PR DESCRIPTION
## Summary

- Add a Composio KiloClaw integration spec and a manual Composio settings entry for `COMPOSIO_USER_API_KEY` + `COMPOSIO_ORG`.
- Install the Composio CLI in the KiloClaw image and sign it in during best-effort controller pre-gateway setup when credentials are configured.
- Extend sandbox guidance with Composio CLI commands and remove Composio credentials from the gateway environment after login.

## Verification

- No manual sandbox verification was performed because this branch does not have real Composio credentials available in the local environment.
- [ ] Add user-provided manual verification details.

## Visual Changes

<img width="1095" height="312" alt="Screenshot 2026-05-18 at 10 43 50 AM" src="https://github.com/user-attachments/assets/50db741d-f7cd-4a78-9969-867074fc98f2" />

<img width="629" height="201" alt="Screenshot 2026-05-18 at 10 40 25 AM" src="https://github.com/user-attachments/assets/353d0fe8-b323-45ac-bce5-733b88753b68" />

<img width="852" height="259" alt="SCR-20260518-juec" src="https://github.com/user-attachments/assets/dde4f43b-8c64-4ca2-8091-339d86e379ba" />


## Reviewer Notes

- `composio login` intentionally runs with the default skill installation behavior.
- The user API key is passed via CLI argv during login; the credentials are removed from the gateway environment before OpenClaw starts.
- Managed Composio provisioning and onboarding Connect Links are intentionally deferred to a later PR.