### PR TITLE
fix(kiloclaw): prevent provision advisory lock deadlocks

### DIFF
--- a/apps/web/src/lib/kiloclaw/provision-lock.test.ts
+++ b/apps/web/src/lib/kiloclaw/provision-lock.test.ts
@@ -1,0 +1,200 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { withKiloclawProvisionContextLock as WithKiloclawProvisionContextLock } from './provision-lock';
+
+jest.mock('@vercel/functions', () => ({
+  attachDatabasePool: jest.fn(),
+}));
+
+jest.mock('@kilocode/db', () => ({
+  computeDatabaseUrl: jest.fn(() => 'postgres://provision-lock-test'),
+}));
+
+jest.mock('@kilocode/db/client', () => {
+  const connectMock = jest.fn();
+  const onMock = jest.fn();
+
+  return {
+    createDrizzleClient: jest.fn(() => ({
+      pool: {
+        connect: connectMock,
+        on: onMock,
+      },
+    })),
+    __connectMock: connectMock,
+  };
+});
+
+type AsyncMock = jest.Mock<(...args: unknown[]) => Promise<unknown>>;
+type ReleaseMock = jest.Mock<(...args: unknown[]) => void>;
+type ProvisionLockClientMock = {
+  query: AsyncMock;
+  release: ReleaseMock;
+};
+type DrizzleClientModuleMock = {
+  __connectMock: AsyncMock;
+};
+
+const { __connectMock: connectMock } =
+  jest.requireMock<DrizzleClientModuleMock>('@kilocode/db/client');
+
+let withKiloclawProvisionContextLock: typeof WithKiloclawProvisionContextLock;
+
+beforeAll(async () => {
+  const provisionLockModule = await import('./provision-lock');
+  withKiloclawProvisionContextLock = provisionLockModule.withKiloclawProvisionContextLock;
+});
+
+function createProvisionLockClient(): ProvisionLockClientMock {
+  return {
+    query: jest.fn<(...args: unknown[]) => Promise<unknown>>(),
+    release: jest.fn<(...args: unknown[]) => void>(),
+  };
+}
+
+function queueProvisionLockClient(client: ProvisionLockClientMock): void {
+  connectMock.mockResolvedValueOnce(client);
+}
+
+function prepareSuccessfulLockLifecycle(client: ProvisionLockClientMock): void {
+  client.query
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [{ unlocked: true }] });
+}
+
+describe('withKiloclawProvisionContextLock', () => {
+  beforeEach(() => {
+    connectMock.mockReset();
+  });
+
+  it('acquires the context lock, runs work, unlocks, and returns a reusable client', async () => {
+    const client = createProvisionLockClient();
+    const work = jest.fn(async () => 'provisioned');
+    prepareSuccessfulLockLifecycle(client);
+    queueProvisionLockClient(client);
+
+    await expect(withKiloclawProvisionContextLock('normal-key', work)).resolves.toBe('provisioned');
+
+    expect(work).toHaveBeenCalledTimes(1);
+    expect(client.query).toHaveBeenNthCalledWith(1, 'SELECT pg_advisory_lock(hashtext($1))', [
+      'normal-key',
+    ]);
+    expect(client.query).toHaveBeenNthCalledWith(
+      2,
+      'SELECT pg_advisory_unlock(hashtext($1)) AS unlocked',
+      ['normal-key']
+    );
+    expect(client.release.mock.calls).toEqual([[]]);
+  });
+
+  it('unlocks and returns a reusable client when work throws', async () => {
+    const client = createProvisionLockClient();
+    prepareSuccessfulLockLifecycle(client);
+    queueProvisionLockClient(client);
+
+    await expect(
+      withKiloclawProvisionContextLock('work-failure-key', async () => {
+        throw new Error('provision work failed');
+      })
+    ).rejects.toThrow('provision work failed');
+
+    expect(client.query).toHaveBeenNthCalledWith(
+      2,
+      'SELECT pg_advisory_unlock(hashtext($1)) AS unlocked',
+      ['work-failure-key']
+    );
+    expect(client.release.mock.calls).toEqual([[]]);
+  });
+
+  it('discards the client while preserving the work result when unlock throws', async () => {
+    const client = createProvisionLockClient();
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    client.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(new Error('unlock transport failed'));
+    queueProvisionLockClient(client);
+
+    await expect(
+      withKiloclawProvisionContextLock('unlock-throw-key', async () => 'completed')
+    ).resolves.toBe('completed');
+
+    expect(client.release).toHaveBeenCalledWith(true);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[kiloclaw] Failed to release provision context lock',
+      {
+        lockKey: 'unlock-throw-key',
+        error: 'unlock transport failed',
+      }
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('discards the client when PostgreSQL does not confirm unlock cleanup', async () => {
+    const client = createProvisionLockClient();
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    client.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ unlocked: false }] });
+    queueProvisionLockClient(client);
+
+    await expect(
+      withKiloclawProvisionContextLock('unlock-false-key', async () => 'completed')
+    ).resolves.toBe('completed');
+
+    expect(client.release).toHaveBeenCalledWith(true);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[kiloclaw] Failed to release provision context lock',
+      {
+        lockKey: 'unlock-false-key',
+        error: 'PostgreSQL did not confirm provision context lock release',
+      }
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('discards the client and skips work when lock acquisition times out', async () => {
+    const client = createProvisionLockClient();
+    const work = jest.fn(async () => 'must not run');
+    client.query.mockRejectedValueOnce(new Error('canceling statement due to statement timeout'));
+    queueProvisionLockClient(client);
+
+    await expect(withKiloclawProvisionContextLock('acquire-timeout-key', work)).rejects.toThrow(
+      'canceling statement due to statement timeout'
+    );
+
+    expect(work).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(client.release).toHaveBeenCalledWith(true);
+  });
+
+  it('prevents later checkouts from reusing a client whose unlock state is uncertain', async () => {
+    const contaminatedClient = createProvisionLockClient();
+    const cleanClient = createProvisionLockClient();
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    let contaminatedClientDiscarded = false;
+
+    contaminatedClient.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(new Error('unlock cancelled'));
+    contaminatedClient.release.mockImplementation(discard => {
+      contaminatedClientDiscarded = discard === true;
+    });
+    prepareSuccessfulLockLifecycle(cleanClient);
+    connectMock.mockImplementation(async () =>
+      contaminatedClientDiscarded ? cleanClient : contaminatedClient
+    );
+
+    await expect(
+      withKiloclawProvisionContextLock('contaminated-key', async () => 'first')
+    ).resolves.toBe('first');
+    await expect(withKiloclawProvisionContextLock('clean-key', async () => 'second')).resolves.toBe(
+      'second'
+    );
+
+    expect(contaminatedClient.release).toHaveBeenCalledWith(true);
+    expect(cleanClient.query).toHaveBeenNthCalledWith(1, 'SELECT pg_advisory_lock(hashtext($1))', [
+      'clean-key',
+    ]);
+    expect(cleanClient.release.mock.calls).toEqual([[]]);
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/web/src/lib/kiloclaw/provision-lock.ts
+++ b/apps/web/src/lib/kiloclaw/provision-lock.ts
@@ -46,22 +46,45 @@ export async function withKiloclawProvisionContextLock<T>(
 ): Promise<T> {
   const client = await provisionLockClient.pool.connect();
   let lockAcquired = false;
+  let discardClient = false;
 
   try {
-    await client.query('SELECT pg_advisory_lock(hashtext($1))', [lockKey]);
-    lockAcquired = true;
+    try {
+      await client.query('SELECT pg_advisory_lock(hashtext($1))', [lockKey]);
+      lockAcquired = true;
+    } catch (error) {
+      discardClient = true;
+      throw error;
+    }
+
     return await work();
   } finally {
     if (lockAcquired) {
       try {
-        await client.query('SELECT pg_advisory_unlock(hashtext($1))', [lockKey]);
+        const unlockResult = await client.query<{ unlocked: boolean }>(
+          'SELECT pg_advisory_unlock(hashtext($1)) AS unlocked',
+          [lockKey]
+        );
+        if (unlockResult.rows[0]?.unlocked !== true) {
+          discardClient = true;
+          console.error('[kiloclaw] Failed to release provision context lock', {
+            lockKey,
+            error: 'PostgreSQL did not confirm provision context lock release',
+          });
+        }
       } catch (error) {
+        discardClient = true;
         console.error('[kiloclaw] Failed to release provision context lock', {
           lockKey,
           error: error instanceof Error ? error.message : String(error),
         });
       }
     }
-    client.release();
+
+    if (discardClient) {
+      client.release(true);
+    } else {
+      client.release();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Prevent KiloClaw provision advisory-lock pool contamination after ambiguous lock acquire or unlock failures.
- Discard tainted lock clients instead of returning uncertain session-level advisory lock state to reusable PostgreSQL pool.
- Add deterministic lifecycle coverage for normal cleanup, work failures, lock acquisition failures, unlock failures, and post-failure client reuse safety.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
- Core safety choice: `release(true)` destroys provision-lock pool clients whenever advisory-lock cleanup is uncertain, letting PostgreSQL session teardown release any lingering session lock.
- Normal success and work-error flows still preserve same personal/org context serialization behavior and reuse clean clients.