### PR TITLE
fix(gastown): write kilo auth so sessions sync to /cloud/sessions

### DIFF
--- a/services/gastown/container/src/agent-runner.test.ts
+++ b/services/gastown/container/src/agent-runner.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(),
+}));
+vi.mock('./git-manager', () => ({
+  cloneRepo: vi.fn(),
+  createWorktree: vi.fn(),
+  setupRigBrowseWorktree: vi.fn(),
+}));
+vi.mock('./process-manager', () => ({
+  startAgent: vi.fn(),
+}));
+vi.mock('./control-server', () => ({
+  getCurrentTownConfig: vi.fn(() => ({})),
+}));
+vi.mock('./logger', () => ({
+  log: { info: vi.fn() },
+}));
+
+import { buildAgentEnv, buildKiloConfigContent } from './agent-runner';
+import type { StartAgentRequest } from './types';
+
+function baseRequest(overrides: Partial<StartAgentRequest> = {}): StartAgentRequest {
+  return {
+    agentId: 'agent-1',
+    rigId: 'rig-1',
+    townId: 'town-1',
+    role: 'polecat',
+    name: 'TestAgent',
+    identity: 'TestAgent-polecat-1',
+    prompt: 'test prompt',
+    model: 'anthropic/claude-sonnet-4.6',
+    gitUrl: 'https://github.com/test/repo.git',
+    branch: 'gt/test',
+    defaultBranch: 'main',
+    ...overrides,
+  };
+}
+
+describe('buildAgentEnv', () => {
+  it('sets KILO_AUTH_CONTENT with valid JSON auth for the kilo provider when KILOCODE_TOKEN is present', () => {
+    const env = buildAgentEnv(
+      baseRequest({
+        envVars: { KILOCODE_TOKEN: 'tok-123' },
+      })
+    );
+
+    expect(env.KILO_AUTH_CONTENT).toBeDefined();
+    const parsed = JSON.parse(env.KILO_AUTH_CONTENT);
+    expect(parsed).toEqual({ kilo: { type: 'api', key: 'tok-123' } });
+  });
+
+  it('does not set KILO_AUTH_CONTENT when KILOCODE_TOKEN is absent', () => {
+    const prev = process.env.KILOCODE_TOKEN;
+    delete process.env.KILOCODE_TOKEN;
+    try {
+      const env = buildAgentEnv(baseRequest());
+      expect(env.KILO_AUTH_CONTENT).toBeUndefined();
+    } finally {
+      if (prev !== undefined) process.env.KILOCODE_TOKEN = prev;
+    }
+  });
+
+  it('sets KILO_PLATFORM to agent-manager', () => {
+    const prev = process.env.KILOCODE_TOKEN;
+    delete process.env.KILOCODE_TOKEN;
+    try {
+      const env = buildAgentEnv(baseRequest());
+      expect(env.KILO_PLATFORM).toBe('agent-manager');
+    } finally {
+      if (prev !== undefined) process.env.KILOCODE_TOKEN = prev;
+    }
+  });
+
+  it('sets KILO_ORG_ID when organizationId is provided', () => {
+    const env = buildAgentEnv(
+      baseRequest({
+        organizationId: 'org-abc',
+        envVars: { KILOCODE_TOKEN: 'tok-123' },
+      })
+    );
+    expect(env.KILO_ORG_ID).toBe('org-abc');
+  });
+
+  it('does not set KILO_ORG_ID when organizationId is absent', () => {
+    const prev = process.env.KILOCODE_TOKEN;
+    delete process.env.KILOCODE_TOKEN;
+    try {
+      const env = buildAgentEnv(baseRequest());
+      expect(env.KILO_ORG_ID).toBeUndefined();
+    } finally {
+      if (prev !== undefined) process.env.KILOCODE_TOKEN = prev;
+    }
+  });
+});
+
+describe('buildKiloConfigContent', () => {
+  it('includes kilocodeOrganizationId when organizationId is provided', () => {
+    const json = buildKiloConfigContent('tok', 'anthropic/claude-sonnet-4.6', 'anthropic/claude-haiku-4.5', 'org-xyz');
+    const parsed = JSON.parse(json);
+    expect(parsed.provider.kilo.options.kilocodeOrganizationId).toBe('org-xyz');
+  });
+
+  it('omits kilocodeOrganizationId when organizationId is absent', () => {
+    const json = buildKiloConfigContent('tok', 'anthropic/claude-sonnet-4.6', 'anthropic/claude-haiku-4.5');
+    const parsed = JSON.parse(json);
+    expect(parsed.provider.kilo.options.kilocodeOrganizationId).toBeUndefined();
+  });
+});

--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -85,7 +85,7 @@ export function buildKiloConfigContent(
   } satisfies Config);
 }
 
-function buildAgentEnv(request: StartAgentRequest): Record<string, string> {
+export function buildAgentEnv(request: StartAgentRequest): Record<string, string> {
   // Custom git identity: when GASTOWN_GIT_AUTHOR_NAME is set, the user becomes
   // the primary author and the AI agent name is used for co-authorship trailers.
   const customAuthorName = resolveEnv(request, 'GASTOWN_GIT_AUTHOR_NAME');
@@ -173,8 +173,29 @@ GASTOWN_TOWN_ID="${env.GASTOWN_TOWN_ID}"`);
     console.log(
       `[buildAgentEnv] KILO_CONFIG_CONTENT set (model=${request.model}, smallModel=${request.smallModel ?? '(default)'})`
     );
+
+    // Set KILO_AUTH_CONTENT so the kilo CLI's session-ingest path can
+    // authenticate. The CLI's Auth.all() reads this env var before
+    // falling back to the auth.json file. Without it, session deltas
+    // get "session bootstrap skipped: no client" and never reach
+    // cli_sessions_v2.
+    env.KILO_AUTH_CONTENT = JSON.stringify({
+      kilo: { type: 'api', key: kilocodeToken },
+    });
   } else {
     console.warn('[buildAgentEnv] No KILOCODE_TOKEN available — KILO_CONFIG_CONTENT not set');
+  }
+
+  // Set KILO_PLATFORM so session-ingest writes created_on_platform =
+  // 'agent-manager'. The /cloud/sessions page already has an "Agent
+  // Manager" filter that matches this value.
+  env.KILO_PLATFORM = 'agent-manager';
+
+  // Set KILO_ORG_ID so session-ingest populates organization_id for
+  // org-scoped filtering. Falls back to the auth file's accountId
+  // inside the CLI if not set.
+  if (request.organizationId) {
+    env.KILO_ORG_ID = request.organizationId;
   }
 
   // Authenticate the gh CLI via GH_TOKEN. Prefer the user's GitHub CLI PAT

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -608,6 +608,12 @@ export async function startMergeInContainer(
 ): Promise<boolean> {
   try {
     const userId = params.townConfig.owner_user_id ?? params.townId;
+    if (!params.townConfig.owner_user_id) {
+      console.warn(
+        `${TOWN_LOG} startMergeInContainer: owner_user_id missing from town config for town ${params.townId}. ` +
+          'Falling back to townId — this breaks session-ingest authorization and should not happen for properly provisioned towns.'
+      );
+    }
     const containerToken = await ensureContainerToken(env, params.townId, userId);
     const agentToken = await mintAgentToken(env, {
       agentId: params.agentId,


### PR DESCRIPTION
## Summary

Gastown polecat/mayor/refinery sessions never appeared on `/cloud/sessions` because the kilo CLI's session-ingest path requires `Auth.get("kilo")`, which reads from `auth.json` or `KILO_AUTH_CONTENT` — neither of which was set by gastown's container. This PR sets the necessary env vars in `buildAgentEnv` so session deltas flow through to `cli_sessions_v2` and become visible on the dashboard.

Changes:
- **`agent-runner.ts`**: Set `KILO_AUTH_CONTENT` (JSON with `{kilo: {type: 'api', key: token}}`) when `KILOCODE_TOKEN` is available, enabling the kilo CLI's session-ingest authentication.
- **`agent-runner.ts`**: Set `KILO_PLATFORM=agent-manager` so sessions are tagged with `created_on_platform = 'agent-manager'`, matching the existing "Agent Manager" filter on `/cloud/sessions`.
- **`agent-runner.ts`**: Set `KILO_ORG_ID` from `organizationId` when available, enabling org-scoped session filtering.
- **`container-dispatch.ts`**: Added `console.warn` when `owner_user_id` is missing from town config in `startMergeInContainer`, making the fallback to `townId` visible instead of silent.
- **`agent-runner.test.ts`**: Unit tests for `KILO_AUTH_CONTENT`, `KILO_PLATFORM`, and `KILO_ORG_ID` env var construction.

## Verification

- All 7 new unit tests in `agent-runner.test.ts` pass.
- Pre-existing test failures in `plugin/client.test.ts` (JWT header assertions) are unrelated to this change.

## Visual Changes

N/A

## Reviewer Notes

- The `KILO_AUTH_CONTENT` approach (env var) mirrors what `cloud-agent-next` does and is preferred over file-write because it survives ephemeral container resets and avoids filesystem path computation.
- The `owner_user_id` fallback uses `console.warn` rather than throwing to avoid breaking existing test fixtures/local dev setups that may not have `owner_user_id` configured. The warning makes the issue visible for investigation.