### PR TITLE
Fix/kilo chat sandbox id migration tolerance

### DIFF
--- a/services/kilo-chat/src/__tests__/sandbox-ownership.test.ts
+++ b/services/kilo-chat/src/__tests__/sandbox-ownership.test.ts
@@ -1,24 +1,65 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as DrizzleOrm from 'drizzle-orm';
+
+type Row = {
+  id: string;
+  user_id: string;
+  sandbox_id: string;
+  destroyed_at: string | null;
+};
+
+type Predicate = (row: Row) => boolean;
 
 const dbState = vi.hoisted(() => ({
-  rows: [] as { sandbox_id: string; user_id: string }[],
+  rows: [] as Row[],
   queryCount: 0,
 }));
 
 vi.unmock('../services/sandbox-ownership');
 
+// Replace drizzle's expression helpers with predicate factories so the test
+// mock can actually evaluate the WHERE clause against `dbState.rows` instead
+// of silently returning every row regardless of the query.
+vi.mock('drizzle-orm', async () => {
+  const actual = await vi.importActual<typeof DrizzleOrm>('drizzle-orm');
+  type ColRef = { name: string };
+  type MaybePred = Predicate | undefined;
+  return {
+    ...actual,
+    eq:
+      (col: ColRef, val: unknown): Predicate =>
+      row =>
+        (row as unknown as Record<string, unknown>)[col.name] === val,
+    isNull:
+      (col: ColRef): Predicate =>
+      row =>
+        (row as unknown as Record<string, unknown>)[col.name] === null,
+    and:
+      (...preds: MaybePred[]): Predicate =>
+      row =>
+        preds.every(p => !p || p(row)),
+    or:
+      (...preds: MaybePred[]): Predicate =>
+      row =>
+        preds.some(p => !!p && p(row)),
+  };
+});
+
 vi.mock('@kilocode/db', () => ({
   getWorkerDb: () => ({
-    select: (selection: Record<string, unknown>) => ({
+    select: (selection: Record<string, { name: string }>) => ({
       from: () => ({
-        where: () => ({
+        where: (predicate: Predicate | undefined) => ({
           limit: async (limit: number) => {
             dbState.queryCount += 1;
-            const rows =
-              'sandbox_id' in selection
-                ? dbState.rows.map(row => ({ sandbox_id: row.sandbox_id }))
-                : dbState.rows.map(row => ({ user_id: row.user_id }));
-            return rows.slice(0, limit);
+            const matched = predicate ? dbState.rows.filter(row => predicate(row)) : dbState.rows;
+            return matched.slice(0, limit).map(row => {
+              const out: Record<string, unknown> = {};
+              for (const [key, col] of Object.entries(selection)) {
+                out[key] = (row as unknown as Record<string, unknown>)[col.name];
+              }
+              return out;
+            });
           },
         }),
       }),
@@ -30,29 +71,192 @@ const env = {
   HYPERDRIVE: { connectionString: 'postgres://test' },
 } as Env;
 
+const LEGACY_SANDBOX_ID = 'ZTQ0YWM3NGMtZmJkOC00OTc2LTkyZmUtNGQ2NmIzMDg4MDll';
+const INSTANCE_UUID = 'f94cb138-03d6-44a5-a8d8-6514fc947dad';
+const INSTANCE_KEYED_SANDBOX_ID = 'ki_f94cb13803d644a5a8d86514fc947dad';
+
 const { lookupSandboxOwnerUserId, userOwnsSandbox } = await import('../services/sandbox-ownership');
 
 describe('sandbox ownership lookups', () => {
   beforeEach(() => {
-    dbState.rows = [{ sandbox_id: 'sandbox-1', user_id: 'user-1' }];
+    dbState.rows = [];
     dbState.queryCount = 0;
   });
 
-  it('does not reuse a positive ownership result after the instance is destroyed', async () => {
-    await expect(userOwnsSandbox(env, 'user-1', 'sandbox-1')).resolves.toBe(true);
+  describe('userOwnsSandbox', () => {
+    it('accepts exact sandbox_id match', async () => {
+      dbState.rows = [
+        {
+          id: INSTANCE_UUID,
+          user_id: 'user-1',
+          sandbox_id: 'sandbox-1',
+          destroyed_at: null,
+        },
+      ];
+      await expect(userOwnsSandbox(env, 'user-1', 'sandbox-1')).resolves.toBe(true);
+    });
 
-    dbState.rows = [];
+    it('rejects when no row matches', async () => {
+      await expect(userOwnsSandbox(env, 'user-1', 'sandbox-1')).resolves.toBe(false);
+    });
 
-    await expect(userOwnsSandbox(env, 'user-1', 'sandbox-1')).resolves.toBe(false);
-    expect(dbState.queryCount).toBe(2);
+    it('does not reuse a positive ownership result after the instance is destroyed', async () => {
+      dbState.rows = [
+        {
+          id: INSTANCE_UUID,
+          user_id: 'user-1',
+          sandbox_id: 'sandbox-1',
+          destroyed_at: null,
+        },
+      ];
+      await expect(userOwnsSandbox(env, 'user-1', 'sandbox-1')).resolves.toBe(true);
+
+      dbState.rows = [];
+      await expect(userOwnsSandbox(env, 'user-1', 'sandbox-1')).resolves.toBe(false);
+      expect(dbState.queryCount).toBe(2);
+    });
+
+    it('accepts ki_ form via id match when DB row still stores the legacy sandbox_id', async () => {
+      dbState.rows = [
+        {
+          id: INSTANCE_UUID,
+          user_id: 'user-1',
+          sandbox_id: LEGACY_SANDBOX_ID,
+          destroyed_at: null,
+        },
+      ];
+      await expect(userOwnsSandbox(env, 'user-1', INSTANCE_KEYED_SANDBOX_ID)).resolves.toBe(true);
+    });
+
+    it('rejects ki_ form with non-hex content even when a row for the caller exists', async () => {
+      // `isInstanceKeyedSandboxId` only checks prefix + length, so a 35-char
+      // ki_ string of non-hex chars passes that test. `instanceIdFromSandboxId`
+      // then formats it into a UUID-shaped string with non-hex chars, which
+      // `isValidInstanceId` rejects — so the id-match branch must be skipped
+      // and the caller-controlled value must not reach the uuid column.
+      dbState.rows = [
+        {
+          id: INSTANCE_UUID,
+          user_id: 'user-1',
+          sandbox_id: LEGACY_SANDBOX_ID,
+          destroyed_at: null,
+        },
+      ];
+      await expect(
+        userOwnsSandbox(env, 'user-1', 'ki_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz')
+      ).resolves.toBe(false);
+    });
+
+    it('rejects ki_ form referencing a row owned by another user', async () => {
+      const otherInstanceUuid = '11111111-2222-3333-4444-555555555555';
+      const otherKiSandboxId = 'ki_11111111222233334444555555555555';
+      dbState.rows = [
+        {
+          id: otherInstanceUuid,
+          user_id: 'user-2',
+          sandbox_id: 'sandbox-of-user-2',
+          destroyed_at: null,
+        },
+      ];
+      await expect(userOwnsSandbox(env, 'user-1', otherKiSandboxId)).resolves.toBe(false);
+    });
+
+    it('rejects ki_ form when the matching row is destroyed', async () => {
+      dbState.rows = [
+        {
+          id: INSTANCE_UUID,
+          user_id: 'user-1',
+          sandbox_id: LEGACY_SANDBOX_ID,
+          destroyed_at: '2026-01-01T00:00:00Z',
+        },
+      ];
+      await expect(userOwnsSandbox(env, 'user-1', INSTANCE_KEYED_SANDBOX_ID)).resolves.toBe(false);
+    });
+
+    it('rejects legacy sandbox_id belonging to another user', async () => {
+      dbState.rows = [
+        {
+          id: INSTANCE_UUID,
+          user_id: 'user-2',
+          sandbox_id: 'sandbox-of-user-2',
+          destroyed_at: null,
+        },
+      ];
+      await expect(userOwnsSandbox(env, 'user-1', 'sandbox-of-user-2')).resolves.toBe(false);
+    });
   });
 
-  it('does not reuse a positive owner lookup after the instance is destroyed', async () => {
-    await expect(lookupSandboxOwnerUserId(env, 'sandbox-1')).resolves.toBe('user-1');
+  describe('lookupSandboxOwnerUserId', () => {
+    it('returns user_id for exact sandbox_id match', async () => {
+      dbState.rows = [
+        {
+          id: INSTANCE_UUID,
+          user_id: 'user-1',
+          sandbox_id: 'sandbox-1',
+          destroyed_at: null,
+        },
+      ];
+      await expect(lookupSandboxOwnerUserId(env, 'sandbox-1')).resolves.toBe('user-1');
+    });
 
-    dbState.rows = [];
+    it('returns null when no row matches', async () => {
+      await expect(lookupSandboxOwnerUserId(env, 'sandbox-1')).resolves.toBeNull();
+    });
 
-    await expect(lookupSandboxOwnerUserId(env, 'sandbox-1')).resolves.toBeNull();
-    expect(dbState.queryCount).toBe(2);
+    it('does not reuse a positive owner lookup after the instance is destroyed', async () => {
+      dbState.rows = [
+        {
+          id: INSTANCE_UUID,
+          user_id: 'user-1',
+          sandbox_id: 'sandbox-1',
+          destroyed_at: null,
+        },
+      ];
+      await expect(lookupSandboxOwnerUserId(env, 'sandbox-1')).resolves.toBe('user-1');
+
+      dbState.rows = [];
+      await expect(lookupSandboxOwnerUserId(env, 'sandbox-1')).resolves.toBeNull();
+      expect(dbState.queryCount).toBe(2);
+    });
+
+    it('returns user_id for ki_ form via id match when DB row still stores legacy sandbox_id', async () => {
+      dbState.rows = [
+        {
+          id: INSTANCE_UUID,
+          user_id: 'user-1',
+          sandbox_id: LEGACY_SANDBOX_ID,
+          destroyed_at: null,
+        },
+      ];
+      await expect(lookupSandboxOwnerUserId(env, INSTANCE_KEYED_SANDBOX_ID)).resolves.toBe(
+        'user-1'
+      );
+    });
+
+    it('returns null for ki_ form with non-hex content', async () => {
+      dbState.rows = [
+        {
+          id: INSTANCE_UUID,
+          user_id: 'user-1',
+          sandbox_id: LEGACY_SANDBOX_ID,
+          destroyed_at: null,
+        },
+      ];
+      await expect(
+        lookupSandboxOwnerUserId(env, 'ki_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz')
+      ).resolves.toBeNull();
+    });
+
+    it('returns null for ki_ form when the matching row is destroyed', async () => {
+      dbState.rows = [
+        {
+          id: INSTANCE_UUID,
+          user_id: 'user-1',
+          sandbox_id: LEGACY_SANDBOX_ID,
+          destroyed_at: '2026-01-01T00:00:00Z',
+        },
+      ];
+      await expect(lookupSandboxOwnerUserId(env, INSTANCE_KEYED_SANDBOX_ID)).resolves.toBeNull();
+    });
   });
 });

--- a/services/kilo-chat/src/services/sandbox-ownership.ts
+++ b/services/kilo-chat/src/services/sandbox-ownership.ts
@@ -7,29 +7,33 @@ import {
   isValidInstanceId,
 } from '@kilocode/worker-utils/instance-id';
 
+/**
+ * Half-migrated tolerance: a row's `sandbox_id` may still be the legacy
+ * userId-derived value while the kiloclaw DO has already moved to the
+ * ki_<uuid-hex> form (and the browser/bot path sends the latter). Derive
+ * the instance UUID that a ki_-form sandboxId references so callers can
+ * OR it into a `kiloclaw_instances.id` match.
+ *
+ * `isInstanceKeyedSandboxId` only checks prefix + total length, so a value
+ * like `ki_<35 chars of non-hex>` would pass through and format into a
+ * UUID-shaped string with non-hex characters — comparing that to a uuid
+ * column would make Postgres throw `invalid input syntax for type uuid`,
+ * turning a 4xx into a 500 on attacker-controlled input. Re-validate the
+ * derived UUID; if it fails, return null and skip the id-match branch.
+ */
+function candidateInstanceIdFromSandboxId(sandboxId: string): string | null {
+  if (!isInstanceKeyedSandboxId(sandboxId)) return null;
+  const derived = instanceIdFromSandboxId(sandboxId);
+  return isValidInstanceId(derived) ? derived : null;
+}
+
 async function queryOwnsSandbox(
   connectionString: string,
   userId: string,
   sandboxId: string
 ): Promise<boolean> {
   const db = getWorkerDb(connectionString);
-  // Half-migrated tolerance: a row's `sandbox_id` may still be the legacy
-  // userId-derived value while the kiloclaw DO has already moved to the
-  // ki_<uuid-hex> form (and the browser sends the latter). Accept the ki_
-  // form by matching against `id` so ownership keeps working across the
-  // migration window. Ownership is still strictly scoped to the caller's
-  // own active rows (user_id + destroyed_at filters are unchanged).
-  // `isInstanceKeyedSandboxId` only checks prefix + total length, so a value
-  // like `ki_<35 chars of non-hex>` would pass through and then format into
-  // a UUID-shaped string with non-hex characters — comparing that to a uuid
-  // column would make Postgres throw `invalid input syntax for type uuid`,
-  // turning a 403 into a 500 on attacker-controlled input. Re-validate the
-  // derived UUID and skip the id-match branch if it doesn't pass.
-  const derivedInstanceId = isInstanceKeyedSandboxId(sandboxId)
-    ? instanceIdFromSandboxId(sandboxId)
-    : null;
-  const candidateInstanceId =
-    derivedInstanceId && isValidInstanceId(derivedInstanceId) ? derivedInstanceId : null;
+  const candidateInstanceId = candidateInstanceIdFromSandboxId(sandboxId);
   const rows = await db
     .select({ sandbox_id: kiloclaw_instances.sandbox_id })
     .from(kiloclaw_instances)
@@ -54,11 +58,20 @@ async function querySandboxOwner(
   sandboxId: string
 ): Promise<string | null> {
   const db = getWorkerDb(connectionString);
+  const candidateInstanceId = candidateInstanceIdFromSandboxId(sandboxId);
   const rows = await db
     .select({ user_id: kiloclaw_instances.user_id })
     .from(kiloclaw_instances)
     .where(
-      and(eq(kiloclaw_instances.sandbox_id, sandboxId), isNull(kiloclaw_instances.destroyed_at))
+      and(
+        isNull(kiloclaw_instances.destroyed_at),
+        candidateInstanceId
+          ? or(
+              eq(kiloclaw_instances.sandbox_id, sandboxId),
+              eq(kiloclaw_instances.id, candidateInstanceId)
+            )
+          : eq(kiloclaw_instances.sandbox_id, sandboxId)
+      )
     )
     .limit(1);
   return rows[0]?.user_id ?? null;

--- a/services/kilo-chat/src/services/sandbox-ownership.ts
+++ b/services/kilo-chat/src/services/sandbox-ownership.ts
@@ -1,6 +1,10 @@
 import { getWorkerDb } from '@kilocode/db';
 import { kiloclaw_instances } from '@kilocode/db/schema';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, or } from 'drizzle-orm';
+import {
+  instanceIdFromSandboxId,
+  isInstanceKeyedSandboxId,
+} from '@kilocode/worker-utils/instance-id';
 
 async function queryOwnsSandbox(
   connectionString: string,
@@ -8,14 +12,28 @@ async function queryOwnsSandbox(
   sandboxId: string
 ): Promise<boolean> {
   const db = getWorkerDb(connectionString);
+  // Half-migrated tolerance: a row's `sandbox_id` may still be the legacy
+  // userId-derived value while the kiloclaw DO has already moved to the
+  // ki_<uuid-hex> form (and the browser sends the latter). Accept the ki_
+  // form by matching against `id` so ownership keeps working across the
+  // migration window. Ownership is still strictly scoped to the caller's
+  // own active rows (user_id + destroyed_at filters are unchanged).
+  const candidateInstanceId = isInstanceKeyedSandboxId(sandboxId)
+    ? instanceIdFromSandboxId(sandboxId)
+    : null;
   const rows = await db
     .select({ sandbox_id: kiloclaw_instances.sandbox_id })
     .from(kiloclaw_instances)
     .where(
       and(
-        eq(kiloclaw_instances.sandbox_id, sandboxId),
         eq(kiloclaw_instances.user_id, userId),
-        isNull(kiloclaw_instances.destroyed_at)
+        isNull(kiloclaw_instances.destroyed_at),
+        candidateInstanceId
+          ? or(
+              eq(kiloclaw_instances.sandbox_id, sandboxId),
+              eq(kiloclaw_instances.id, candidateInstanceId)
+            )
+          : eq(kiloclaw_instances.sandbox_id, sandboxId)
       )
     )
     .limit(1);

--- a/services/kilo-chat/src/services/sandbox-ownership.ts
+++ b/services/kilo-chat/src/services/sandbox-ownership.ts
@@ -4,6 +4,7 @@ import { and, eq, isNull, or } from 'drizzle-orm';
 import {
   instanceIdFromSandboxId,
   isInstanceKeyedSandboxId,
+  isValidInstanceId,
 } from '@kilocode/worker-utils/instance-id';
 
 async function queryOwnsSandbox(
@@ -18,9 +19,17 @@ async function queryOwnsSandbox(
   // form by matching against `id` so ownership keeps working across the
   // migration window. Ownership is still strictly scoped to the caller's
   // own active rows (user_id + destroyed_at filters are unchanged).
-  const candidateInstanceId = isInstanceKeyedSandboxId(sandboxId)
+  // `isInstanceKeyedSandboxId` only checks prefix + total length, so a value
+  // like `ki_<35 chars of non-hex>` would pass through and then format into
+  // a UUID-shaped string with non-hex characters — comparing that to a uuid
+  // column would make Postgres throw `invalid input syntax for type uuid`,
+  // turning a 403 into a 500 on attacker-controlled input. Re-validate the
+  // derived UUID and skip the id-match branch if it doesn't pass.
+  const derivedInstanceId = isInstanceKeyedSandboxId(sandboxId)
     ? instanceIdFromSandboxId(sandboxId)
     : null;
+  const candidateInstanceId =
+    derivedInstanceId && isValidInstanceId(derivedInstanceId) ? derivedInstanceId : null;
   const rows = await db
     .select({ sandbox_id: kiloclaw_instances.sandbox_id })
     .from(kiloclaw_instances)


### PR DESCRIPTION
## Summary

Loosen sandbox ownership checks in kilo-chat to accept the instance keyed `ki_<uuid hex>` sandboxId form when the database row still stores the legacy userId derived value. Restores chat for users whose kiloclaw Durable Object has moved to the new sandboxId format while their `kiloclaw_instances.sandbox_id` row has not. The same tolerance is applied to the companion owner lookup so bot status pushes and bot conversation creation also work for the same population.

`services/kilo-chat/src/services/sandbox-ownership.ts`:
- New helper `candidateInstanceIdFromSandboxId(sandboxId)` returns the instance UUID a `ki_` form references, or `null`. Revalidates with `isValidInstanceId` before returning so non hex content cannot reach the `uuid` column and produce a Postgres cast error (which would turn a 4xx into a 500 on caller controlled input).
- `queryOwnsSandbox` matches `WHERE user_id = $userId AND destroyed_at IS NULL AND (sandbox_id = $sandboxId OR id = derivedInstanceId)`. The `user_id` and `destroyed_at` filters are unchanged.
- `querySandboxOwner` (behind `lookupSandboxOwnerUserId`) uses the same OR shape against `destroyed_at IS NULL`.

`services/kilo-chat/src/__tests__/sandbox-ownership.test.ts`:
- Replaced the where swallowing mock with a predicate driven one. The new mock imports drizzle helpers via `vi.importActual` and overrides `eq`, `and`, `or`, `isNull` with predicate factories, so the WHERE expression is actually evaluated against `dbState.rows`.
- Added 12 cases covering exact match, `ki_` form via `id`, `ki_` with non hex content, `ki_` referencing another user, `ki_` matching a destroyed row, legacy `sandbox_id` belonging to another user, and the existing `destroyed_at` cache invalidation paths.

## Verification

- [ ] Post deploy: a user whose `kiloclaw_instances.sandbox_id` is in legacy form and whose DO reports a `ki_<hex>` value can load `/claw/chat` and create a conversation without a 403.
- [ ] Post deploy: bot status pushes and bot conversation creation flows continue to work for the same population.

## Visual Changes

N/A

## Reviewer Notes

Ownership scope is intentionally unchanged. The relaxation only adds a second accept form for the same row, derived deterministically from the row's own UUID. `queryOwnsSandbox` still filters by `user_id` from the verified bearer, so a caller cannot use the `ki_` form to reach another user's row. The derived UUID is validated before reaching the `uuid` column, so length 35 strings with non hex content cannot produce a cast error.

The legacy form derived from `userId` is intentionally not accepted as a third form. That would still be ownership scoped, but would let downstream code that uses the caller provided sandboxId as a bot identifier (`bot:kiloclaw:${sandboxId}`) split conversations across two sandbox buckets if some clients send legacy and others send `ki_`.

The predicate driven test mock evaluates drizzle's WHERE expression in JavaScript so the new OR branch and the `isValidInstanceId` guard are actually exercised rather than skipped by the previous mock.