### PR TITLE
feat(kiloclaw): add BYOK setup link to settings page

### DIFF
--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -2236,14 +2236,13 @@ export function SettingsTab({
               </p>
               <p className="text-muted-foreground mt-2 text-xs">
                 Configure your own model provider keys in{' '}
-                <Link href="/byok" className="underline">
+                <Link href="/byok" target="_blank" className="underline">
                   Kilo BYOK settings
                 </Link>
                 .{' '}
                 <a
                   href="https://kilo.ai/docs/getting-started/byok"
                   target="_blank"
-                  rel="noopener noreferrer"
                   className="underline"
                 >
                   View the BYOK setup guide

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -2243,6 +2243,7 @@ export function SettingsTab({
                 <a
                   href="https://kilo.ai/docs/getting-started/byok"
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="underline"
                 >
                   View the BYOK setup guide

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -20,6 +20,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { OpenclawImportCard } from './OpenclawImportCard';
 
 import { usePostHog } from 'posthog-js/react';
+import Link from 'next/link';
 import { toast } from 'sonner';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import { useUser } from '@/hooks/useUser';
@@ -2232,6 +2233,22 @@ export function SettingsTab({
               <p className="text-sm font-medium">Default Model</p>
               <p className="text-muted-foreground text-xs">
                 Used for new conversations. Can be changed per-conversation.
+              </p>
+              <p className="text-muted-foreground mt-2 text-xs">
+                Configure your own model provider keys in{' '}
+                <Link href="/byok" className="underline">
+                  Kilo BYOK settings
+                </Link>
+                .{' '}
+                <a
+                  href="https://kilo.ai/docs/getting-started/byok"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  View the BYOK setup guide
+                </a>
+                .
               </p>
             </div>
             <div className="flex items-center gap-2">

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -2239,15 +2239,6 @@ export function SettingsTab({
                 <Link href="/byok" target="_blank" className="underline">
                   Kilo BYOK settings
                 </Link>
-                .{' '}
-                <a
-                  href="https://kilo.ai/docs/getting-started/byok"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline"
-                >
-                  View the BYOK setup guide
-                </a>
                 .
               </p>
             </div>

--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -21,7 +21,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
@@ -88,6 +88,19 @@ function BYOKDescription() {
       Supply your own key provider API keys. Your Kilo balance will not be used when using these
       providers: you will be billed by the provider directly.
     </p>
+  );
+}
+
+function BYOKSetupGuideLink() {
+  return (
+    <a
+      href="https://kilo.ai/docs/getting-started/byok"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-muted-foreground hover:text-foreground text-sm underline underline-offset-4 transition-colors"
+    >
+      View the BYOK setup guide
+    </a>
   );
 }
 
@@ -293,11 +306,16 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
         <BYOKDescription />
         <Card>
           <CardHeader>
-            <CardTitle>BYOK API Keys</CardTitle>
+            <div className="flex flex-col gap-2">
+              <CardTitle>BYOK API Keys</CardTitle>
+            </div>
           </CardHeader>
           <CardContent>
             <div className="text-muted-foreground">Loading...</div>
           </CardContent>
+          <CardFooter>
+            <BYOKSetupGuideLink />
+          </CardFooter>
         </Card>
       </div>
     );
@@ -317,8 +335,10 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
     <div className="space-y-4">
       <BYOKDescription />
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
-          <CardTitle>BYOK API Keys</CardTitle>
+        <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0 pb-4">
+          <div className="flex flex-col gap-2">
+            <CardTitle>BYOK API Keys</CardTitle>
+          </div>
           <Button onClick={() => setIsDialogOpen(true)} size="sm">
             <Plus className="mr-2 h-4 w-4" />
             Add Key
@@ -622,6 +642,9 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
             </DialogFooter>
           </DialogContent>
         </Dialog>
+        <CardFooter>
+          <BYOKSetupGuideLink />
+        </CardFooter>
       </Card>
     </div>
   );


### PR DESCRIPTION
## Summary

Users configuring default models in KiloClaw settings had no easy way to discover or navigate to BYOK (Bring Your Own Key) setup, and the support team frequently receives questions related to BYOK in KiloClaw. This adds a link to the Kilo BYOK settings page directly below the default model selector, guiding users to configure their own model provider keys. It additionally adds the link to BYOK docs in the /byok page itself.

## Verification

- [x] Link to `/byok` navigates to Kilo BYOK settings page in a new tab
- [x] Link to BYOK setup guide opens docs in new tab

## Visual Changes

### KiloClaw Settings

<img width="1240" height="180" alt="image" src="https://github.com/user-attachments/assets/ab6fbddf-97b1-48ed-b4c4-d3322feca9e0" />

### BYOK page

<img width="2004" height="549" alt="image" src="https://github.com/user-attachments/assets/ed131bb9-a27e-4a7f-9bb2-dcab23d563c2" />



## Reviewer Notes

N/A