### PR TITLE
fix(gastown): use 'gastown' platform value for session-ingest

### DIFF
--- a/apps/web/src/app/(app)/cloud/sessions/SessionsPageContent.tsx
+++ b/apps/web/src/app/(app)/cloud/sessions/SessionsPageContent.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Search, Cloud, Terminal, Puzzle, Bot } from 'lucide-react';
+import { Search, Cloud, Terminal, Puzzle, Bot, Workflow } from 'lucide-react';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import type { SessionsListItem } from '@/components/cloud-agent/SessionsList';
 import { SessionsList } from '@/components/cloud-agent/SessionsList';
@@ -40,10 +40,11 @@ const PLATFORM_OPTIONS: readonly {
   { value: 'cloud-agent', label: 'Cloud', icon: Cloud },
   { value: 'cli', label: 'CLI', icon: Terminal },
   { value: 'agent-manager', label: 'Agent Manager', icon: Bot },
+  { value: 'gastown', label: 'Gastown', icon: Workflow },
   { value: 'other', label: 'Other', icon: Puzzle },
 ];
 
-type PlatformFilterValue = 'all' | 'cloud-agent' | 'cli' | 'agent-manager' | 'other';
+type PlatformFilterValue = 'all' | 'cloud-agent' | 'cli' | 'agent-manager' | 'gastown' | 'other';
 
 export function SessionsPageContent() {
   const trpc = useTRPC();

--- a/apps/web/src/routers/cli-sessions-router.ts
+++ b/apps/web/src/routers/cli-sessions-router.ts
@@ -49,6 +49,7 @@ export const KNOWN_PLATFORMS = [
   'agent-manager',
   'app-builder',
   'slack',
+  'gastown',
 ] as const;
 
 const PAGE_SIZE = 10;

--- a/services/gastown/container/src/agent-runner.test.ts
+++ b/services/gastown/container/src/agent-runner.test.ts
@@ -62,12 +62,12 @@ describe('buildAgentEnv', () => {
     }
   });
 
-  it('sets KILO_PLATFORM to agent-manager', () => {
+  it('sets KILO_PLATFORM to gastown', () => {
     const prev = process.env.KILOCODE_TOKEN;
     delete process.env.KILOCODE_TOKEN;
     try {
       const env = buildAgentEnv(baseRequest());
-      expect(env.KILO_PLATFORM).toBe('agent-manager');
+      expect(env.KILO_PLATFORM).toBe('gastown');
     } finally {
       if (prev !== undefined) process.env.KILOCODE_TOKEN = prev;
     }

--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -187,9 +187,9 @@ GASTOWN_TOWN_ID="${env.GASTOWN_TOWN_ID}"`);
   }
 
   // Set KILO_PLATFORM so session-ingest writes created_on_platform =
-  // 'agent-manager'. The /cloud/sessions page already has an "Agent
-  // Manager" filter that matches this value.
-  env.KILO_PLATFORM = 'agent-manager';
+  // 'gastown'. The /cloud/sessions page has a "Gastown" filter that
+  // matches this value.
+  env.KILO_PLATFORM = 'gastown';
 
   // Set KILO_ORG_ID so session-ingest populates organization_id for
   // org-scoped filtering. Falls back to the auth file's accountId


### PR DESCRIPTION
## Summary

Changes the platform value Gastown emits from `'agent-manager'` to `'gastown'`, adds `'gastown'` as a known platform on the dashboard side, and adds a "Gastown" filter button. This ensures Gastown sessions appear under their own filter rather than "Agent Manager" or falling into "Other".

Cherry-picked from orphaned commit `f5960fec0` on `gt/toast/5b3b7da4` (the original fix that was lost due to a mislabeled `gt:pr-fixup` bead).

**Changes:**
- `services/gastown/container/src/agent-runner.ts`: Set `KILO_PLATFORM = 'gastown'` (was `'agent-manager'`)
- `services/gastown/container/src/agent-runner.test.ts`: Update assertion to expect `'gastown'`
- `apps/web/src/routers/cli-sessions-router.ts`: Add `'gastown'` to `KNOWN_PLATFORMS` array
- `apps/web/src/app/(app)/cloud/sessions/SessionsPageContent.tsx`: Add Gastown filter button with Workflow icon, update `PlatformFilterValue` type

## Verification

Manually inspected the cherry-picked diff to confirm all 4 edits are correct. Grep confirmed no remaining `'agent-manager'` references in `services/gastown/`.

## Visual Changes

Sessions dashboard now has a "Gastown" filter button alongside Cloud, CLI, Agent Manager, and Other.

## Reviewer Notes

This is a re-sling of the original fix (bead `5b3b7da4`) which was incorrectly labeled `gt:pr-fixup`, causing the commit to be orphaned. The cherry-pick was clean against current `gastown-staging`. `'agent-manager'` remains in `KNOWN_PLATFORMS` since it's still valid for cloud-agent-next's Agent Manager feature.