### PR TITLE
fix(code-reviews): retry transient sandbox prepareSession failures

### DIFF
--- a/services/code-review-infra/src/code-review-orchestrator.ts
+++ b/services/code-review-infra/src/code-review-orchestrator.ts
@@ -123,6 +123,9 @@ type CloudAgentNextFreshRetryFailureCategory =
   | 'wrapper_kilo_server_start_timeout'
   | 'configured_session_lookup_failure'
   | 'repo_clone_or_checkout_failure'
+  | 'sandbox_exec_invalid_exit_code'
+  | 'sandbox_network_connection_lost'
+  | 'sandbox_command_timeout'
   | 'other_5xx';
 
 type CloudAgentNextFreshRetryClassification = {
@@ -231,6 +234,47 @@ function classifyCloudAgentNextFreshSessionRetry(
       true,
       'wrapper_wait_for_port_timeout',
       'wrapper_wait_for_port_timeout'
+    );
+  }
+
+  // Sandbox `exec` returned a non-numeric exit code. Observed in production
+  // as `mkdir operation failed with exit code NaN` and pre-flight `df`
+  // returning `exitCode: null`. The sandbox process never delivered a real
+  // exit code, which is a transient sandbox-side condition (typically a
+  // stuck Cloudflare Sandbox DO). A fresh session creates a new sandbox.
+  if (body.includes('mkdir operation failed with exit code')) {
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      true,
+      'sandbox_exec_invalid_exit_code',
+      'sandbox_exec_invalid_exit_code'
+    );
+  }
+
+  // Cloudflare Durable Object connection drop mid-prepareSession. The
+  // surrounding context (repo cloned, branch checked out) shows the
+  // sandbox itself was healthy a moment earlier, so retrying with a fresh
+  // session is appropriate.
+  if (body.includes('network connection lost')) {
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      true,
+      'sandbox_network_connection_lost',
+      'sandbox_network_connection_lost'
+    );
+  }
+
+  // Generic command timeout inside the sandbox during workspace setup
+  // (e.g. `git checkout` exceeding 30s). Distinct from the deterministic
+  // `repo_clone_or_checkout_failure` cases above (LFS errors, missing
+  // objects, hard checkout failures), which are intentionally not
+  // retried. A timeout is transient and may succeed on a fresh sandbox.
+  if (body.includes('commanderror') && body.includes('command timeout after')) {
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      true,
+      'sandbox_command_timeout',
+      'sandbox_command_timeout'
     );
   }
 

--- a/services/code-review-infra/src/code-review-orchestrator.ts
+++ b/services/code-review-infra/src/code-review-orchestrator.ts
@@ -237,11 +237,6 @@ function classifyCloudAgentNextFreshSessionRetry(
     );
   }
 
-  // Sandbox `exec` returned a non-numeric exit code. Observed in production
-  // as `mkdir operation failed with exit code NaN` and pre-flight `df`
-  // returning `exitCode: null`. The sandbox process never delivered a real
-  // exit code, which is a transient sandbox-side condition (typically a
-  // stuck Cloudflare Sandbox DO). A fresh session creates a new sandbox.
   if (body.includes('mkdir operation failed with exit code')) {
     return cloudAgentNextFreshRetryClassification(
       error,
@@ -251,10 +246,6 @@ function classifyCloudAgentNextFreshSessionRetry(
     );
   }
 
-  // Cloudflare Durable Object connection drop mid-prepareSession. The
-  // surrounding context (repo cloned, branch checked out) shows the
-  // sandbox itself was healthy a moment earlier, so retrying with a fresh
-  // session is appropriate.
   if (body.includes('network connection lost')) {
     return cloudAgentNextFreshRetryClassification(
       error,
@@ -264,11 +255,6 @@ function classifyCloudAgentNextFreshSessionRetry(
     );
   }
 
-  // Generic command timeout inside the sandbox during workspace setup
-  // (e.g. `git checkout` exceeding 30s). Distinct from the deterministic
-  // `repo_clone_or_checkout_failure` cases above (LFS errors, missing
-  // objects, hard checkout failures), which are intentionally not
-  // retried. A timeout is transient and may succeed on a fresh sandbox.
   if (body.includes('commanderror') && body.includes('command timeout after')) {
     return cloudAgentNextFreshRetryClassification(
       error,

--- a/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
+++ b/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
@@ -625,6 +625,141 @@ describe('CodeReviewOrchestrator recovery', () => {
     await expect(storedReview(stub)).resolves.toMatchObject({ sandboxRetryAttempted: true });
   });
 
+  it('retries prepareSession once after sandbox mkdir returns invalid exit code', async () => {
+    const stub = getReviewStub();
+    let prepareCalls = 0;
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        prepareCalls += 1;
+        if (prepareCalls === 1) {
+          return trpcError(
+            500,
+            'Failed to create workspace directory: FileSystemError: mkdir operation failed with exit code NaN'
+          );
+        }
+        return trpcSuccess({
+          cloudAgentSessionId: 'agent-mkdir-retry',
+          kiloSessionId: 'ses_mkdir_retry',
+        });
+      }
+      if (url.includes('/trpc/initiateFromKilocodeSessionV2')) {
+        return trpcSuccess({ executionId: 'exec-mkdir-retry', status: 'running' });
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({
+      status: 'running',
+      sessionId: 'agent-mkdir-retry',
+      cliSessionId: 'ses_mkdir_retry',
+    });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(2);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(1);
+    await expect(storedReview(stub)).resolves.toMatchObject({ sandboxRetryAttempted: true });
+  });
+
+  it('retries prepareSession once after sandbox network connection lost', async () => {
+    const stub = getReviewStub();
+    let prepareCalls = 0;
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        prepareCalls += 1;
+        if (prepareCalls === 1) {
+          return trpcError(500, 'Network connection lost.');
+        }
+        return trpcSuccess({
+          cloudAgentSessionId: 'agent-network-retry',
+          kiloSessionId: 'ses_network_retry',
+        });
+      }
+      if (url.includes('/trpc/initiateFromKilocodeSessionV2')) {
+        return trpcSuccess({ executionId: 'exec-network-retry', status: 'running' });
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({
+      status: 'running',
+      sessionId: 'agent-network-retry',
+      cliSessionId: 'ses_network_retry',
+    });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(2);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(1);
+    await expect(storedReview(stub)).resolves.toMatchObject({ sandboxRetryAttempted: true });
+  });
+
+  it('retries prepareSession once after sandbox command timeout during workspace setup', async () => {
+    const stub = getReviewStub();
+    let prepareCalls = 0;
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        prepareCalls += 1;
+        if (prepareCalls === 1) {
+          return trpcError(
+            500,
+            "CommandError: Failed to execute command 'cd /workspace && git checkout -B refs/pull/3/head FETCH_HEAD' in session session-123: Command timeout after 30000ms"
+          );
+        }
+        return trpcSuccess({
+          cloudAgentSessionId: 'agent-cmd-timeout-retry',
+          kiloSessionId: 'ses_cmd_timeout_retry',
+        });
+      }
+      if (url.includes('/trpc/initiateFromKilocodeSessionV2')) {
+        return trpcSuccess({ executionId: 'exec-cmd-timeout-retry', status: 'running' });
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({
+      status: 'running',
+      sessionId: 'agent-cmd-timeout-retry',
+      cliSessionId: 'ses_cmd_timeout_retry',
+    });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(2);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(1);
+    await expect(storedReview(stub)).resolves.toMatchObject({ sandboxRetryAttempted: true });
+  });
+
   it('fails after a second sandbox 500 without initiating', async () => {
     const stub = getReviewStub();
     const fetchMock = vi.fn(async (request: RequestInfo | URL) => {


### PR DESCRIPTION
## Summary

Extend `classifyCloudAgentNextFreshSessionRetry` so three transient sandbox-side `prepareSession` failure bodies are classified retryable instead of falling through to `other_5xx` / `unclassified_5xx`. Each new branch is opt-in (literal substring match) and lands **after** the existing deterministic not-retryable rules, so behavior for billing, cancelled, configured-session-lookup and hard repo/checkout failures is unchanged.

New retryable categories:

- `sandbox_exec_invalid_exit_code` — matches `mkdir operation failed with exit code` (covers `NaN` and `null`). The sandbox `exec` returned no numeric exit code, typically a stuck Cloudflare Sandbox DO.
- `sandbox_network_connection_lost` — matches `network connection lost`. Cloudflare DO connection drop mid-`prepareSession`.
- `sandbox_command_timeout` — matches `commanderror` + `command timeout after`. Generic in-sandbox command timeout (e.g. `git checkout` 30s). Distinct from `repo_clone_or_checkout_failure`, which stays hard-not-retryable for LFS / missing-object cases.

## Why

Three observed failure bodies post-#3290 classifier:

| Body | Why it landed in `other_5xx` |
|------|------------------------------|
| `mkdir operation failed with exit code NaN` | has `internal_server_error`/`500` but no `sandbox`/`container`/`cloudflare` → fallback `&&` fails |
| `Network connection lost.` | matches no branch |
| `CommandError: ... Command timeout after 30000ms` | `command timeout` not matched; `failed to checkout pull ref` not in body |

In production this means a single stuck bot reviewer sandbox accumulates permanent failures until the user gives up, instead of being recycled by the orchestrator's fresh-session retry. The pre-#3290 `hasSandboxSignal && hasInternalServerSignal` clause retried some of these implicitly; this PR makes the intent explicit per failure mode so it can be measured.

## Safety

- Strictly additive: only new branches added; no existing classifier output changes.
- Each new branch lands **after** `repo_clone_or_checkout_failure`, so hard checkout failures (LFS, missing objects, deterministic checkout errors) stay not-retryable. The `sandbox_command_timeout` branch only triggers on the literal `command timeout after` substring.
- Bounded blast: `sandboxRetryAttempted === true` (orchestrator state) caps retries at one per review (`code-review-orchestrator.ts:382`). Worst case for a genuinely-broken sandbox is one extra retry.
- New categories surface in the existing `Fresh session retry skipped` / `Retrying with a fresh session after sandbox 500` log fields (`failureCategory`, `retryClassificationReason`) for post-deploy measurement per mode.

## Tests

Three new integration tests in `code-review-orchestrator.test.ts`, mirroring the existing `retries prepareSession once after wrapper waitForPort readiness timeout` pattern:

- `retries prepareSession once after sandbox mkdir returns invalid exit code`
- `retries prepareSession once after sandbox network connection lost`
- `retries prepareSession once after sandbox command timeout during workspace setup`

Each asserts a single fresh-session retry and a successful `initiateFromKilocodeSessionV2` call.


## Refs

- Original PR that tightened the classifier: #3290