### PR TITLE
Retire app onboarding chooser safely

### DIFF
--- a/apps/web/src/app/get-started/page.tsx
+++ b/apps/web/src/app/get-started/page.tsx
@@ -1,47 +1,6 @@
-import type { Metadata } from 'next';
-import { getUserFromAuth } from '@/lib/user.server';
+import { buildLandingRedirectUrl } from '@/lib/landing-redirect';
 import { redirect } from 'next/navigation';
-import ProductOptionsContent from './personal/_components/ProductOptionsContent';
-import { PageContainer } from '@/components/layouts/PageContainer';
 
-const title = 'Get started with Kilo Code';
-const description =
-  'Pick a starting point: install Kilo in your editor or CLI, run agents against your repo in Kilo Cloud, or set up KiloClaw for Telegram and Slack.';
-
-export const metadata: Metadata = {
-  title,
-  description,
-  openGraph: {
-    type: 'website',
-    url: '/get-started',
-    title,
-    description,
-    siteName: 'Kilo Code',
-    locale: 'en_US',
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title,
-    description,
-  },
-};
-
-export default async function GetStartedPage() {
-  // Optional: Check if user is authenticated but don't require it
-  const { user } = await getUserFromAuth({ adminOnly: false, DANGEROUS_allowBlockedUsers: true });
-
-  // If authenticated and needs verification, redirect
-  if (user && user.has_validation_stytch === null) {
-    redirect('/account-verification');
-  }
-
-  const isAuthenticated = !!user;
-
-  return (
-    <PageContainer className="min-h-screen max-w-7xl justify-center py-8 md:py-12">
-      <main className="mx-auto w-full max-w-6xl">
-        <ProductOptionsContent isAuthenticated={isAuthenticated} />
-      </main>
-    </PageContainer>
-  );
+export default async function GetStartedPage({ searchParams }: AppPageProps) {
+  redirect(buildLandingRedirectUrl('/install', await searchParams));
 }

--- a/apps/web/src/app/get-started/page.tsx
+++ b/apps/web/src/app/get-started/page.tsx
@@ -1,6 +1,22 @@
 import { buildLandingRedirectUrl } from '@/lib/landing-redirect';
+import { maybeInterceptWithSurvey } from '@/lib/survey-redirect';
+import { getProfileRedirectPath, getUserFromAuth } from '@/lib/user.server';
 import { redirect } from 'next/navigation';
 
 export default async function GetStartedPage({ searchParams }: AppPageProps) {
-  redirect(buildLandingRedirectUrl('/install', await searchParams));
+  const { user } = await getUserFromAuth({ adminOnly: false, DANGEROUS_allowBlockedUsers: true });
+
+  if (!user) {
+    redirect(buildLandingRedirectUrl('/install', await searchParams));
+  }
+
+  if (user.blocked_reason) {
+    redirect('/account-blocked');
+  }
+
+  if (user.has_validation_stytch === null) {
+    redirect('/account-verification');
+  }
+
+  redirect(maybeInterceptWithSurvey(user, await getProfileRedirectPath(user)));
 }

--- a/apps/web/src/app/welcome/page.tsx
+++ b/apps/web/src/app/welcome/page.tsx
@@ -1,46 +1,6 @@
-import { getUserFromAuth } from '@/lib/user.server';
+import { buildLandingRedirectUrl } from '@/lib/landing-redirect';
 import { redirect } from 'next/navigation';
-import { getExtensionUrl } from '@/components/auth/getExtensionUrl';
-import { cookies } from 'next/headers';
-import WelcomeContent from '@/components/WelcomeContent';
-import HeaderLogo from '@/components/HeaderLogo';
-import { PageContainer } from '@/components/layouts/PageContainer';
 
 export default async function WelcomePage({ searchParams }: AppPageProps) {
-  // Optional auth check - page is accessible without authentication
-  const { user } = await getUserFromAuth({ adminOnly: false, DANGEROUS_allowBlockedUsers: true });
-
-  // If authenticated and needs verification, redirect
-  if (user && user.has_validation_stytch === null) {
-    redirect('/account-verification');
-  }
-
-  const params = await searchParams;
-
-  const { ideName, logoSrc, editor } = getExtensionUrl(params, await cookies());
-  const targetParam = params?.target;
-  const installTarget = targetParam === 'cli' ? 'cli' : undefined;
-  // Only check credits if user is authenticated
-  const hasCredits = user ? user.total_microdollars_acquired > 0 : false;
-
-  return (
-    <PageContainer>
-      <div className="flex min-h-screen flex-col items-center justify-between gap-12">
-        <div className="self-start">
-          <HeaderLogo />
-        </div>
-        <WelcomeContent
-          ideName={ideName}
-          logoSrc={logoSrc}
-          hasCredits={hasCredits}
-          editor={editor}
-          isAuthenticated={!!user}
-          installTarget={installTarget}
-        />
-        <div className="text-muted-foreground flex items-center justify-center text-xs">
-          © {new Date().getFullYear()} Kilo Code
-        </div>
-      </div>
-    </PageContainer>
-  );
+  redirect(buildLandingRedirectUrl('/welcome', await searchParams));
 }

--- a/apps/web/src/lib/landing-redirect.ts
+++ b/apps/web/src/lib/landing-redirect.ts
@@ -1,0 +1,18 @@
+import { LANDING_URL } from '@/lib/constants';
+
+export function buildLandingRedirectUrl(path: string, searchParams?: NextAppSearchParams): string {
+  const url = new URL(path, LANDING_URL);
+
+  for (const [key, value] of Object.entries(searchParams ?? {})) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item) url.searchParams.append(key, item);
+      }
+      continue;
+    }
+
+    if (value) url.searchParams.set(key, value);
+  }
+
+  return url.toString();
+}

--- a/apps/web/tests/e2e/auth.setup.ts
+++ b/apps/web/tests/e2e/auth.setup.ts
@@ -17,12 +17,12 @@ setup('authenticate', async ({ page }) => {
   // Navigate to sign in page with fakeUser query param to trigger auto-submit
   await page.goto(`/users/sign_in?fakeUser=${encodeURIComponent(testEmail)}`);
 
-  // Wait for navigation to complete - user will end up on survey, get-started, or profile
+  // Wait for navigation to complete - user will end up on survey, profile, or their org
   await page.waitForURL(
     url =>
       url.pathname === '/customer-source-survey' ||
-      url.pathname === '/get-started' ||
-      url.pathname === '/profile',
+      url.pathname === '/profile' ||
+      url.pathname.startsWith('/organizations/'),
     {
       timeout: 20000,
       waitUntil: 'networkidle',
@@ -32,10 +32,13 @@ setup('authenticate', async ({ page }) => {
   // If we land on the survey page, skip it to complete setup
   if (new URL(page.url()).pathname === '/customer-source-survey') {
     await page.click('button:has-text("Skip")');
-    await page.waitForURL(url => url.pathname === '/get-started' || url.pathname === '/profile', {
-      timeout: 10000,
-      waitUntil: 'networkidle',
-    });
+    await page.waitForURL(
+      url => url.pathname === '/profile' || url.pathname.startsWith('/organizations/'),
+      {
+        timeout: 10000,
+        waitUntil: 'networkidle',
+      }
+    );
   }
 
   // Save the authenticated state (cookies, localStorage, etc.)

--- a/apps/web/tests/e2e/customer-source-survey.spec.ts
+++ b/apps/web/tests/e2e/customer-source-survey.spec.ts
@@ -13,6 +13,17 @@ import { randomUUID } from 'crypto';
  * redirect points (which should be /customer-source-survey once Task 6 is done).
  */
 
+function isSignedInDestination(url: URL) {
+  return url.pathname === '/profile' || url.pathname.startsWith('/organizations/');
+}
+
+async function waitForSignedInDestination(page: import('@playwright/test').Page) {
+  await page.waitForURL(url => isSignedInDestination(url), {
+    timeout: 15000,
+  });
+  expect(isSignedInDestination(new URL(page.url()))).toBe(true);
+}
+
 /**
  * Signs in a brand-new user via fake-login with stytchpass behavior.
  * Returns the final URL after sign-in + verification completes.
@@ -27,13 +38,8 @@ async function signInFreshUser(page: import('@playwright/test').Page): Promise<s
   await page.goto(`/users/sign_in?fakeUser=${encodeURIComponent(testEmail)}`);
 
   // Wait for the full redirect chain to settle.
-  // After Task 6, new users should land on /customer-source-survey.
-  // Before Task 6, they land on /get-started.
   await page.waitForURL(
-    url =>
-      url.pathname === '/customer-source-survey' ||
-      url.pathname === '/get-started' ||
-      url.pathname === '/profile',
+    url => url.pathname === '/customer-source-survey' || isSignedInDestination(url),
     { timeout: 30000, waitUntil: 'networkidle' }
   );
 
@@ -49,7 +55,7 @@ test.describe('Customer Source Survey', () => {
     const finalUrl = await signInFreshUser(page);
 
     // After Task 6 (account-verification redirect change), new users should
-    // land on /customer-source-survey instead of /get-started.
+    // land on /customer-source-survey instead of continuing directly to their app destination.
     expect(new URL(finalUrl).pathname).toBe('/customer-source-survey');
   });
 
@@ -94,7 +100,7 @@ test.describe('Customer Source Survey', () => {
     await expect(submitButton).toBeDisabled();
   });
 
-  test('submitting a response redirects to get-started', async ({ page }) => {
+  test('submitting a response redirects to the signed-in app destination', async ({ page }) => {
     await signInFreshUser(page);
 
     const textarea = page.getByPlaceholder('Example: A YouTube video from Theo');
@@ -103,22 +109,16 @@ test.describe('Customer Source Survey', () => {
     await textarea.fill('Found it on Reddit');
     await submitButton.click();
 
-    await page.waitForURL(url => url.pathname === '/get-started', {
-      timeout: 15000,
-    });
-    expect(new URL(page.url()).pathname).toBe('/get-started');
+    await waitForSignedInDestination(page);
   });
 
-  test('skipping redirects to get-started', async ({ page }) => {
+  test('skipping redirects to the signed-in app destination', async ({ page }) => {
     await signInFreshUser(page);
 
     const skipLink = page.getByRole('button', { name: 'Skip' });
     await skipLink.click();
 
-    await page.waitForURL(url => url.pathname === '/get-started', {
-      timeout: 15000,
-    });
-    expect(new URL(page.url()).pathname).toBe('/get-started');
+    await waitForSignedInDestination(page);
   });
 
   test('already-answered user is redirected past survey', async ({ page }) => {
@@ -131,18 +131,13 @@ test.describe('Customer Source Survey', () => {
     await textarea.fill('Twitter post');
     await submitButton.click();
 
-    await page.waitForURL(url => url.pathname === '/get-started', {
-      timeout: 15000,
-    });
+    await waitForSignedInDestination(page);
 
     // Now navigate directly to the survey page. Since customer_source is set,
     // the server component should redirect past it.
     await page.goto('/customer-source-survey');
 
-    await page.waitForURL(url => url.pathname === '/get-started', {
-      timeout: 15000,
-    });
-    expect(new URL(page.url()).pathname).toBe('/get-started');
+    await waitForSignedInDestination(page);
   });
 
   test('after skipping, revisiting survey should redirect away (H2 sentinel)', async ({ page }) => {
@@ -156,9 +151,7 @@ test.describe('Customer Source Survey', () => {
     const skipLink = page.getByRole('button', { name: 'Skip' });
     await skipLink.click();
 
-    await page.waitForURL(url => url.pathname === '/get-started', {
-      timeout: 15000,
-    });
+    await waitForSignedInDestination(page);
 
     // Navigate back to the survey page directly
     await page.goto('/customer-source-survey');
@@ -166,12 +159,12 @@ test.describe('Customer Source Survey', () => {
     // If H2 is fixed (skip writes a sentinel), user should be redirected away.
     // If H2 is NOT fixed, user will see the survey form again.
     await page.waitForURL(
-      url => url.pathname === '/get-started' || url.pathname === '/customer-source-survey',
+      url => isSignedInDestination(url) || url.pathname === '/customer-source-survey',
       { timeout: 15000 }
     );
 
     // This assertion will FAIL until the H2 skip-persistence bug is fixed
-    expect(new URL(page.url()).pathname).toBe('/get-started');
+    expect(isSignedInDestination(new URL(page.url()))).toBe(true);
   });
 
   test('survey preserves callbackPath through submit', async ({ page }) => {
@@ -186,8 +179,8 @@ test.describe('Customer Source Survey', () => {
     await textarea.fill('Hacker News');
     await submitButton.click();
 
-    // Should redirect to /profile (the callbackPath), not /get-started
-    await page.waitForURL(url => url.pathname === '/profile' || url.pathname === '/get-started', {
+    // Should redirect to /profile (the callbackPath), not the default destination
+    await page.waitForURL(url => url.pathname === '/profile', {
       timeout: 15000,
     });
     expect(new URL(page.url()).pathname).toBe('/profile');
@@ -201,8 +194,8 @@ test.describe('Customer Source Survey', () => {
     const skipLink = page.getByRole('button', { name: 'Skip' });
     await skipLink.click();
 
-    // Should redirect to /profile (the callbackPath), not /get-started
-    await page.waitForURL(url => url.pathname === '/profile' || url.pathname === '/get-started', {
+    // Should redirect to /profile (the callbackPath), not the default destination
+    await page.waitForURL(url => url.pathname === '/profile', {
       timeout: 15000,
     });
     expect(new URL(page.url()).pathname).toBe('/profile');

--- a/apps/web/tests/e2e/get-started-dashboard-link.spec.ts
+++ b/apps/web/tests/e2e/get-started-dashboard-link.spec.ts
@@ -1,44 +1,47 @@
 import { test, expect } from '@chromatic-com/playwright';
 import { randomUUID } from 'crypto';
 
-test.describe('/get-started dashboard escape hatch', () => {
+function isSignedInDestination(url: URL) {
+  return url.pathname === '/profile' || url.pathname.startsWith('/organizations/');
+}
+
+test.describe('/get-started auth-aware router', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
-  test('hides the dashboard link for signed-out users', async ({ page }) => {
-    await page.goto('/get-started');
+  test('redirects signed-out users to the landing install page', async ({ request }) => {
+    const response = await request.get('/get-started', { maxRedirects: 0 });
 
-    const skipLink = page.getByRole('link', { name: /skip to dashboard/i });
-    await expect(skipLink).toHaveCount(0);
+    expect([307, 308]).toContain(response.status());
+    const location = response.headers().location;
+    if (!location) throw new Error('Expected /get-started to return a redirect location');
 
-    const signInLink = page.getByRole('link', { name: /sign in/i });
-    await expect(signInLink).toBeVisible();
-    await expect(signInLink).toHaveAttribute('href', '/users/sign_in?callbackPath=/get-started');
+    expect(new URL(location, 'http://localhost').pathname).toBe('/install');
   });
 
-  test('shows the dashboard link after fake login and survey skip', async ({ page }) => {
+  test('keeps signed-in users in the app', async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const testEmail = `test-get-started-${uniqueId}+stytchpass@example.com`;
 
     await page.goto(`/users/sign_in?fakeUser=${encodeURIComponent(testEmail)}`);
     await page.waitForURL(
-      url =>
-        url.pathname === '/customer-source-survey' ||
-        url.pathname === '/get-started' ||
-        url.pathname === '/profile',
+      url => url.pathname === '/customer-source-survey' || isSignedInDestination(url),
       { timeout: 30000, waitUntil: 'networkidle' }
     );
 
     if (new URL(page.url()).pathname === '/customer-source-survey') {
       await page.getByRole('button', { name: 'Skip' }).click();
-      await page.waitForURL(url => url.pathname === '/get-started' || url.pathname === '/profile', {
+      await page.waitForURL(url => isSignedInDestination(url), {
         timeout: 15000,
         waitUntil: 'networkidle',
       });
     }
 
     await page.goto('/get-started');
-    const skipLink = page.getByRole('link', { name: /skip to dashboard/i });
-    await expect(skipLink).toBeVisible();
-    await expect(skipLink).toHaveAttribute('href', '/profile');
+    await page.waitForURL(url => isSignedInDestination(url), {
+      timeout: 15000,
+      waitUntil: 'networkidle',
+    });
+
+    expect(isSignedInDestination(new URL(page.url()))).toBe(true);
   });
 });

--- a/apps/web/tests/e2e/onboarding-wizard.spec.ts
+++ b/apps/web/tests/e2e/onboarding-wizard.spec.ts
@@ -26,8 +26,8 @@ async function signInFreshUser(
     url =>
       url.pathname === '/gastown/onboarding' ||
       url.pathname === '/customer-source-survey' ||
-      url.pathname === '/get-started' ||
-      url.pathname === '/profile',
+      url.pathname === '/profile' ||
+      url.pathname.startsWith('/organizations/'),
     { timeout: 30000, waitUntil: 'networkidle' }
   );
 
@@ -37,13 +37,13 @@ async function signInFreshUser(
     await page.waitForURL(
       url =>
         url.pathname === '/gastown/onboarding' ||
-        url.pathname === '/get-started' ||
-        url.pathname === '/profile',
+        url.pathname === '/profile' ||
+        url.pathname.startsWith('/organizations/'),
       { timeout: 15000, waitUntil: 'networkidle' }
     );
   }
 
-  // If we're on /get-started rather than /gastown/onboarding, navigate directly
+  // If we're not on /gastown/onboarding, navigate directly
   if (new URL(page.url()).pathname !== '/gastown/onboarding') {
     await page.goto('/gastown/onboarding');
     await page.waitForURL(url => url.pathname === '/gastown/onboarding', {

--- a/apps/web/tests/e2e/pages.visual.spec.ts
+++ b/apps/web/tests/e2e/pages.visual.spec.ts
@@ -27,9 +27,6 @@ test.describe('Top-Level Pages', () => {
     { name: 'Billing', url: '/billing' },
     { name: 'Connected Accounts', url: '/connected-accounts' },
     { name: 'Account Deleted', url: '/account-deleted' },
-    // Onboarding/auth pages
-    { name: 'Get Started', url: '/get-started' },
-    { name: 'Welcome', url: '/welcome' },
     { name: 'Device Auth', url: '/device-auth?code=FOOBAR' },
     { name: 'Sign In To Editor', url: '/sign-in-to-editor' },
   ];


### PR DESCRIPTION
## Summary
- Retire the generic app `/get-started` chooser UI while preserving its auth-aware routing behavior.
- Send signed-out app `/get-started` visitors to landing `/install`, preserving query params.
- Keep signed-in app `/get-started` users inside the app via account verification, survey interception, and profile/org routing.
- Redirect app `/welcome` to landing `/welcome`, preserving query params.
- Keep product-specific app onboarding routes such as `/get-started/slack` and `/get-started/teams` untouched.

## Rollout note
- Deploy landing PR Kilo-Org/kilocode-landing#1517 before this change so `/welcome` resolves on `kilo.ai` and does not bounce back to the app.

## Validation
- `pnpm --filter web typecheck`
- `pnpm lint`
- `pnpm format:changed`