### PR TITLE
feat(web): require NEXT_PUBLIC_WASTELAND_URL env var

### DIFF
--- a/apps/web/.env.development.local.example
+++ b/apps/web/.env.development.local.example
@@ -54,7 +54,7 @@ NEXT_PUBLIC_KILO_CHAT_URL=http://localhost:8808
 NEXT_PUBLIC_EVENT_SERVICE_URL=ws://localhost:8809
 
 # @url wasteland
-# NEXT_PUBLIC_WASTELAND_URL=http://localhost:8790
+NEXT_PUBLIC_WASTELAND_URL=http://localhost:8790
 
 # KiloClaw legacy recognized Stripe price IDs (test values)
 # Required so settlement, plan detection, and legacy intro repair continue to recognize pre-rollout subscriptions.

--- a/apps/web/.env.test
+++ b/apps/web/.env.test
@@ -14,6 +14,7 @@ NEXT_PUBLIC_STYTCH_PROJECT_ENV=test
 NEXT_PUBLIC_GASTOWN_URL=https://gastown.test.invalid
 NEXT_PUBLIC_KILO_CHAT_URL=https://kilo-chat.test.invalid
 NEXT_PUBLIC_EVENT_SERVICE_URL=https://event-service.test.invalid
+NEXT_PUBLIC_WASTELAND_URL=https://wasteland.test.invalid
 JEST_SILENT=false
 DEBUG_SHOW_DEV_UI=1
 IS_IN_AUTOMATED_TEST=1

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -76,7 +76,10 @@ export const EVENT_SERVICE_URL = requireEnv(
 // Wasteland worker URL (client-side, inlined at build time)
 // The browser talks directly to the Wasteland Cloudflare Worker for tRPC.
 // Must use NEXT_PUBLIC_ prefix so Next.js exposes it to the browser bundle.
-export const WASTELAND_URL = process.env.NEXT_PUBLIC_WASTELAND_URL ?? '';
+export const WASTELAND_URL = requireEnv(
+  'NEXT_PUBLIC_WASTELAND_URL',
+  process.env.NEXT_PUBLIC_WASTELAND_URL
+);
 
 // Free model rate limits: per-IP for client-side products, per-user for server-side products
 export const FREE_MODEL_RATE_LIMIT_WINDOW_HOURS = 1;


### PR DESCRIPTION
## Summary

- Promote `NEXT_PUBLIC_WASTELAND_URL` from optional (silent fallback to empty string) to required via the existing `requireEnv` helper in `apps/web/src/lib/constants.ts`.
- Brings `WASTELAND_URL` in line with the other required public worker URLs (`GASTOWN_URL`, `KILO_CHAT_URL`, `EVENT_SERVICE_URL`), so misconfiguration fails loudly at startup instead of producing relative URLs against the app origin.

## Verification

- Inspected diff to confirm only the `WASTELAND_URL` declaration changed and the existing `requireEnv` helper is reused.

## Visual Changes

N/A

## Reviewer Notes

- Any environment that was relying on the previous silent empty-string fallback for `NEXT_PUBLIC_WASTELAND_URL` will now throw at build/startup. Confirm the var is set in all deployment targets (Vercel envs, local `.env.local`, CI) before merging.