### PR TITLE
fix(web): batch API request log cleanup

### DIFF
--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
@@ -1,0 +1,102 @@
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/config.server', () => ({
+  CRON_SECRET: 'cron-secret',
+}));
+
+import { api_request_log } from '@kilocode/db/schema';
+import { db, sql } from '@/lib/drizzle';
+import { GET } from './route';
+
+const BATCH_SIZE = 1_000;
+
+function daysAgo(days: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString();
+}
+
+function makeRequest(headers?: Record<string, string>) {
+  return new NextRequest('http://localhost:3000/api/cron/cleanup-api-request-log', {
+    method: 'GET',
+    headers,
+  });
+}
+
+async function insertApiRequestLogRecord(created_at: string, provider = 'test-provider') {
+  const [row] = await db.insert(api_request_log).values({ created_at, provider }).returning();
+  return row;
+}
+
+async function insertApiRequestLogRecords(count: number, created_at: string) {
+  await db.insert(api_request_log).values(
+    Array.from({ length: count }, (_, index) => ({
+      created_at,
+      provider: `test-provider-${index}`,
+    }))
+  );
+}
+
+describe('GET /api/cron/cleanup-api-request-log', () => {
+  beforeEach(async () => {
+    await db.delete(api_request_log).where(sql`true`);
+  });
+
+  it('rejects requests without authorization header', async () => {
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns zero deleted when table is empty', async () => {
+    const response = await GET(makeRequest({ authorization: 'Bearer cron-secret' }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.deletedCount).toBe(0);
+    expect(body.batchSize).toBe(BATCH_SIZE);
+    expect(body.hasMore).toBe(false);
+    expect(body.cutoffDate).toEqual(expect.any(String));
+    expect(body.timestamp).toEqual(expect.any(String));
+  });
+
+  it('deletes expired records and preserves recent records', async () => {
+    await insertApiRequestLogRecord(daysAgo(45));
+    await insertApiRequestLogRecord(daysAgo(31));
+    const recent = await insertApiRequestLogRecord(daysAgo(1));
+
+    const response = await GET(makeRequest({ authorization: 'Bearer cron-secret' }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.deletedCount).toBe(2);
+    expect(body.hasMore).toBe(false);
+
+    const remaining = await db.select().from(api_request_log);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(recent.id);
+  });
+
+  it('deletes at most one batch per request', async () => {
+    await insertApiRequestLogRecords(BATCH_SIZE + 5, daysAgo(45));
+    const recent1 = await insertApiRequestLogRecord(daysAgo(1), 'recent-1');
+    const recent2 = await insertApiRequestLogRecord(new Date().toISOString(), 'recent-2');
+
+    const response = await GET(makeRequest({ authorization: 'Bearer cron-secret' }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.deletedCount).toBe(BATCH_SIZE);
+    expect(body.batchSize).toBe(BATCH_SIZE);
+    expect(body.hasMore).toBe(true);
+
+    const remaining = await db.select().from(api_request_log);
+    expect(remaining).toHaveLength(7);
+
+    const remainingIds = remaining.map(row => row.id.toString()).sort();
+    expect(remainingIds).toEqual(
+      expect.arrayContaining([recent1.id.toString(), recent2.id.toString()])
+    );
+  });
+});

--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/drizzle';
 import { api_request_log } from '@kilocode/db/schema';
-import { lt } from 'drizzle-orm';
+import { asc, inArray, lt } from 'drizzle-orm';
 import { CRON_SECRET } from '@/lib/config.server';
+
+const RETENTION_DAYS = 30;
+const BATCH_SIZE = 1_000;
 
 function getDaysAgo(days: number) {
   const date = new Date();
@@ -15,11 +18,24 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const cutoffDate = getDaysAgo(30).toISOString();
-  const result = await db.delete(api_request_log).where(lt(api_request_log.created_at, cutoffDate));
+  const cutoffDate = getDaysAgo(RETENTION_DAYS).toISOString();
+  const expiredRows = await db
+    .select({ id: api_request_log.id })
+    .from(api_request_log)
+    .where(lt(api_request_log.created_at, cutoffDate))
+    .orderBy(asc(api_request_log.created_at))
+    .limit(BATCH_SIZE + 1);
+
+  const batchIds = expiredRows.slice(0, BATCH_SIZE).map(row => row.id);
+  const result =
+    batchIds.length > 0
+      ? await db.delete(api_request_log).where(inArray(api_request_log.id, batchIds))
+      : null;
 
   return NextResponse.json({
-    deletedCount: result.rowCount ?? 0,
+    deletedCount: result?.rowCount ?? 0,
+    batchSize: BATCH_SIZE,
+    hasMore: expiredRows.length > BATCH_SIZE,
     cutoffDate,
     timestamp: new Date().toISOString(),
   });

--- a/apps/web/src/lib/integrations/platforms/github/batch-review-decisions.ts
+++ b/apps/web/src/lib/integrations/platforms/github/batch-review-decisions.ts
@@ -321,5 +321,5 @@ export function triggerBatchReviewDecisionFetchIfNeeded(
   owner: TenantOwner
 ): void {
   if (!hasPendingRows) return;
-  void executeBatchReviewDecisionFetch(owner).catch(captureException);
+  executeBatchReviewDecisionFetch(owner).catch(captureException);
 }

--- a/apps/web/src/lib/integrations/platforms/github/batch-review-decisions.ts
+++ b/apps/web/src/lib/integrations/platforms/github/batch-review-decisions.ts
@@ -321,5 +321,5 @@ export function triggerBatchReviewDecisionFetchIfNeeded(
   owner: TenantOwner
 ): void {
   if (!hasPendingRows) return;
-  executeBatchReviewDecisionFetch(owner).catch(captureException);
+  void executeBatchReviewDecisionFetch(owner).catch(captureException);
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "/api/cron/cleanup-api-request-log",
-      "schedule": "0 12 * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/cron/kilo-pass-yearly-monthly-base",


### PR DESCRIPTION
## Summary
- Batch `api_request_log` cleanup to delete up to 1,000 expired rows per cron invocation, reducing WAL bursts that can disrupt Snowflake replication.
- Increase the cleanup cron cadence to every 5 minutes so expired rows drain gradually while preserving 30-day retention.
- Add route tests covering authorization, empty cleanup, retention behavior, and the one-batch limit.
- Mark an existing detached GitHub review-decision fetch promise as intentionally ignored so the repository pre-push lint hook passes.

## Verification
- N/A. Backend cron route change only; no manual user flow to exercise.

## Visual Changes
N/A

## Reviewer Notes
- The route intentionally processes one batch per invocation; `hasMore` reports backlog without looping through all expired rows in a single request.
- The oldest-expired-row query uses the existing `idx_api_request_log_created_at` index.
- The GitHub review-decision promise change is a mechanical lint fix surfaced by the pre-push hook and is unrelated to cleanup behavior.