### PR TITLE
fix(web): align tsconfig with Next resolver

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "module": "commonjs",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "lib": ["dom", "dom.iterable", "esnext", "esnext.asynciterable"],
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- Align the web TypeScript config with Next.js 16's modern bundler resolution path.
- Prevent `pnpm dev` from rewriting `apps/web/tsconfig.json` to the removed `moduleResolution: node` setting, which breaks `tsgo` and format cleanliness.

## Verification
- Started the web dev server from `apps/web` on a spare local port and confirmed Next.js no longer rewrites `tsconfig.json` or prints the TypeScript reconfiguration message.
- Confirmed the working tree stays clean after the dev-server startup apart from the committed config change.

## Visual Changes
N/A

## Reviewer Notes
- `noEmit` remains enabled, so Next/SWC still owns actual compilation; this only changes TypeScript's module/resolver model for checking and tooling.