### PR TITLE
chore(experiments): drop plan references from code comments

### DIFF
--- a/apps/web/src/app/admin/model-experiments/ModelExperimentsContent.tsx
+++ b/apps/web/src/app/admin/model-experiments/ModelExperimentsContent.tsx
@@ -165,7 +165,6 @@ function ExperimentList({ onSelect }: { onSelect: (id: string) => void }) {
           public_model_id
         </code>{' '}
         and swaps the upstream checkpoint behind it. Clients keep sending the same public model id.
-        See <code>.plans/experimental-models-1.md</code> for the full design.
       </p>
 
       {isLoading ? (

--- a/apps/web/src/lib/ai-gateway/experiments/upstream-schema.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/upstream-schema.ts
@@ -10,8 +10,8 @@ import {
  *
  * - **Does not include `api_key`.** The encrypted key lives in the sibling
  *   `model_experiment_variant_version.encrypted_api_key` JSONB column so the
- *   never-read invariant is enforceable at the column level. See
- *   `.plans/experimental-models-1.md` §"API Keys".
+ *   never-read invariant is enforceable at the column level — admin tRPC
+ *   responses simply omit the column from their selects.
  * - **Does not include `extra_headers`.** Partner checkpoint routing should
  *   use `api_key` + `base_url` + `internal_id` + adapter settings. If a
  *   non-secret header is required later, add an explicit allowlisted field

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -6084,9 +6084,11 @@ export type NewSecurityAdvisorScan = typeof security_advisor_scans.$inferInsert;
 
 // ---------------------------------------------------------------------------
 // Model experiments (preview/experimental A/B testing)
-// See `.plans/experimental-models-1.md` and (eventually) `.specs/model-experiments.md`.
+//
 // Scope: opt-in dedicated preview public model ids only. Never used for
-// production/general traffic. See plan for full design rationale.
+// production/general traffic. Users only reach this routing path by
+// explicitly selecting a dedicated preview public id (e.g.
+// `kilo/preview-experiment-foo`).
 // ---------------------------------------------------------------------------
 
 export const model_experiment = pgTable(
@@ -6155,11 +6157,10 @@ export type ModelExperimentVariant = typeof model_experiment_variant.$inferSelec
 export type NewModelExperimentVariant = typeof model_experiment_variant.$inferInsert;
 
 // Immutable per-variant version. New RC = new row. Never UPDATEd.
-// `upstream` is validated by ExperimentUpstreamSchema in app code (see
-// experimental-models-1.md Phase 1). The api key is stored separately in
-// `encrypted_api_key` (same shape as byok_api_keys.encrypted_api_key) so the
-// JSONB blob never holds the secret and reporting/admin views can simply omit
-// the column.
+// `upstream` is validated by ExperimentUpstreamSchema in app code. The
+// api key is stored separately in `encrypted_api_key` (same shape as
+// `byok_api_keys.encrypted_api_key`) so the JSONB blob never holds the
+// secret and reporting/admin views can simply omit the column.
 export const model_experiment_variant_version = pgTable(
   'model_experiment_variant_version',
   {
@@ -6185,8 +6186,11 @@ export type ModelExperimentVariantVersion = typeof model_experiment_variant_vers
 export type NewModelExperimentVariantVersion = typeof model_experiment_variant_version.$inferInsert;
 
 // One row per experimented request, keyed on usage_id (1:1 with microdollar_usage).
-// Stores attribution + R2 prompt hashes (or reserved sentinel values).
-// See experimental-models-1.md "Prompt Storage (R2)" for sentinel values.
+// Stores attribution + R2 prompt hashes. The two sha256 columns hold either
+// a 64-char lowercase hex digest pointing at an R2 object, or one of the
+// reserved sentinels: `__absent__` (system only, no leading system message),
+// `__failed__` (R2 storage failed), `__deleted__` (prompt content wiped
+// while retaining attribution).
 export const model_experiment_request = pgTable(
   'model_experiment_request',
   {


### PR DESCRIPTION
## Summary

Drops references to `.plans/experimental-models-1.md` from the
three model-experiments code surfaces that already exist on main:

- `packages/db/src/schema.ts` — three `model_experiment*` table
  header comments now stand on their own.
- `apps/web/src/lib/ai-gateway/experiments/upstream-schema.ts` —
  explains *why* `api_key` lives in a sibling column without
  forwarding to the plan.
- `apps/web/src/app/admin/model-experiments/ModelExperimentsContent.tsx`
  — drops the trailing "See `.plans/...`" sentence from the admin
  page subtitle.

Plans are ephemeral and get removed when the work is done; comments
shouldn't outlive them. The relevant context (sentinel meanings,
why the api key column is separate, scope of preview routing) is
inlined where it matters instead.

## Verification

`pnpm --filter web typecheck` passes locally. No behavioral
changes — pure comment / UI-copy edits.

## Visual Changes

The admin page (`/admin/gateway?tab=model-experiments`) loses one
trailing sentence in its subtitle paragraph. Otherwise unchanged.

## Reviewer Notes

Cherry-picked from a larger branch (PR #3325) so the cleanup can
land independently of the in-progress gateway work. The two
branch-only files in that commit (`persist.ts`, `experiment-prompts.ts`)
were dropped since they don't exist on main yet.
