### PR TITLE
refactor(gateway): extract buildDirectProvider used by custom_llm path

### DIFF
--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
@@ -1,0 +1,101 @@
+import {
+  addCacheBreakpoints,
+  injectReasoningIntoContent,
+} from '@/lib/ai-gateway/providers/openrouter/request-helpers';
+import type { CustomLlmProvider, OpenClawApiAdapter } from '@kilocode/db';
+import type { GatewayChatApiKind, Provider } from '@/lib/ai-gateway/providers/types';
+import type { ExperimentUpstream } from '@/lib/ai-gateway/experiments/upstream-schema';
+
+/**
+ * Maps adapter settings to the supported chat APIs for the resulting Provider.
+ * Mirrors the same inference performed for `custom_llm2` rows in
+ * `apps/web/src/lib/ai-gateway/providers/get-provider.ts`.
+ */
+export function inferSupportedChatApis(
+  aiSdkProvider: CustomLlmProvider | undefined,
+  openClawApiAdapter: OpenClawApiAdapter | undefined
+): ReadonlyArray<GatewayChatApiKind> {
+  const result = new Array<GatewayChatApiKind>();
+  if (aiSdkProvider === 'openai' || openClawApiAdapter === 'openai-responses') {
+    result.push('responses');
+  }
+  if (aiSdkProvider === 'anthropic' || openClawApiAdapter === 'anthropic-messages') {
+    result.push('messages');
+  }
+  if (
+    aiSdkProvider === 'openai-compatible' ||
+    aiSdkProvider === 'alibaba' ||
+    aiSdkProvider === 'openrouter' ||
+    openClawApiAdapter === 'openai-completions' ||
+    result.length === 0
+  ) {
+    result.push('chat_completions');
+  }
+  return result;
+}
+
+/**
+ * Plain in-memory shape: an `ExperimentUpstream` (no key) merged with the
+ * decrypted partner-issued api key.
+ *
+ * The cache loader (`getRoutingExperimentForPublicId`) decrypts
+ * `model_experiment_variant_version.encrypted_api_key` once and stores the
+ * resulting plaintext alongside the rest of the upstream blob in this shape
+ * for hot-path use. The plaintext NEVER touches Postgres or any tRPC
+ * response — only this in-memory record and the per-public-id Redis cache.
+ */
+export type ResolvedExperimentUpstream = ExperimentUpstream & { api_key: string };
+
+/**
+ * Input to `buildDirectProvider`. A superset of `ResolvedExperimentUpstream`
+ * that also accepts `extra_headers`, which is used by the custom_llm2
+ * (`kilo-internal/...`) code path but not by experiments. Experiment
+ * upstreams must NOT pass `extra_headers` — see
+ * `ExperimentUpstreamSchema`.
+ */
+export type DirectProviderInput = ResolvedExperimentUpstream & {
+  extra_headers?: Record<string, string>;
+};
+
+/**
+ * Builds a `Provider` that points directly at a partner-issued upstream.
+ *
+ * Used by both the experiment routing path and the existing
+ * `kilo-internal/...` (custom_llm2) path: `id: 'custom'`, `apiUrl` =
+ * upstream `base_url`, `apiKey` = upstream-issued key, supported chat APIs
+ * inferred from adapter settings.
+ *
+ * Direct traffic goes to `apiUrl` — OpenRouter and Vercel are never
+ * contacted. The route layer is responsible for not applying provider
+ * pinning or kilo-exclusive model rewrites on top of this provider.
+ */
+export function buildDirectProvider(upstream: DirectProviderInput): Provider {
+  return {
+    id: 'custom',
+    apiUrl: upstream.base_url,
+    apiKey: upstream.api_key,
+    supportedChatApis: inferSupportedChatApis(
+      upstream.opencode_settings?.ai_sdk_provider,
+      upstream.openclaw_settings?.api_adapter
+    ),
+    transformRequest(context) {
+      if (upstream.remove_from_body) {
+        const body = context.request.body as Record<string, unknown>;
+        for (const key of upstream.remove_from_body) {
+          delete body[key];
+        }
+      }
+      Object.assign(context.request.body, upstream.extra_body ?? {});
+      if (upstream.extra_headers) {
+        Object.assign(context.extraHeaders, upstream.extra_headers);
+      }
+      context.request.body.model = upstream.internal_id;
+      if (upstream.add_cache_breakpoints) {
+        addCacheBreakpoints(context.request);
+      }
+      if (upstream.inject_reasoning_into_content) {
+        injectReasoningIntoContent(context.request);
+      }
+    },
+  };
+}

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -11,41 +11,14 @@ import { db } from '@/lib/drizzle';
 import { eq } from 'drizzle-orm';
 import type { AnonymousUserContext } from '@/lib/anonymous';
 import { isAnonymousContext } from '@/lib/anonymous';
-import type { BYOKResult, GatewayChatApiKind, Provider } from '@/lib/ai-gateway/providers/types';
+import type { BYOKResult, Provider } from '@/lib/ai-gateway/providers/types';
 import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
 import { getDirectByokModel } from '@/lib/ai-gateway/providers/direct-byok';
+import { CustomLlmDefinitionSchema } from '@kilocode/db';
 import {
-  CustomLlmDefinitionSchema,
-  type OpenClawApiAdapter,
-  type CustomLlmProvider,
-} from '@kilocode/db';
-import {
-  addCacheBreakpoints,
-  injectReasoningIntoContent,
-} from '@/lib/ai-gateway/providers/openrouter/request-helpers';
-
-function inferSupportedChatApis(
-  aiSdkProvider: CustomLlmProvider | undefined,
-  openClawApiAdapter: OpenClawApiAdapter | undefined
-): ReadonlyArray<GatewayChatApiKind> {
-  const result = new Array<GatewayChatApiKind>();
-  if (aiSdkProvider === 'openai' || openClawApiAdapter === 'openai-responses') {
-    result.push('responses');
-  }
-  if (aiSdkProvider === 'anthropic' || openClawApiAdapter === 'anthropic-messages') {
-    result.push('messages');
-  }
-  if (
-    aiSdkProvider === 'openai-compatible' ||
-    aiSdkProvider === 'alibaba' ||
-    aiSdkProvider === 'openrouter' ||
-    openClawApiAdapter === 'openai-completions' ||
-    result.length === 0
-  ) {
-    result.push('chat_completions');
-  }
-  return result;
-}
+  buildDirectProvider,
+  inferSupportedChatApis,
+} from '@/lib/ai-gateway/experiments/build-direct-provider';
 
 async function checkDirectBYOK(
   user: User | AnonymousUserContext,
@@ -95,32 +68,22 @@ async function checkCustomLlm(
     return null;
   }
   return {
-    provider: {
-      id: 'custom',
-      apiUrl: customLlm.base_url,
-      apiKey: customLlm.api_key,
-      supportedChatApis: inferSupportedChatApis(
-        customLlm.opencode_settings?.ai_sdk_provider,
-        customLlm.openclaw_settings?.api_adapter
-      ),
-      transformRequest(context) {
-        if (customLlm.remove_from_body) {
-          const body = context.request.body as Record<string, unknown>;
-          for (const key of customLlm.remove_from_body ?? []) {
-            delete body[key];
-          }
-        }
-        Object.assign(context.request.body, customLlm.extra_body ?? {});
-        Object.assign(context.extraHeaders, customLlm.extra_headers ?? {});
-        context.request.body.model = customLlm.internal_id;
-        if (customLlm.add_cache_breakpoints) {
-          addCacheBreakpoints(context.request);
-        }
-        if (customLlm.inject_reasoning_into_content) {
-          injectReasoningIntoContent(context.request);
-        }
-      },
-    },
+    provider: buildDirectProvider({
+      internal_id: customLlm.internal_id,
+      base_url: customLlm.base_url,
+      api_key: customLlm.api_key,
+      opencode_settings: customLlm.opencode_settings
+        ? { ai_sdk_provider: customLlm.opencode_settings.ai_sdk_provider }
+        : undefined,
+      openclaw_settings: customLlm.openclaw_settings
+        ? { api_adapter: customLlm.openclaw_settings.api_adapter }
+        : undefined,
+      extra_body: customLlm.extra_body,
+      extra_headers: customLlm.extra_headers,
+      remove_from_body: customLlm.remove_from_body,
+      add_cache_breakpoints: customLlm.add_cache_breakpoints,
+      inject_reasoning_into_content: customLlm.inject_reasoning_into_content,
+    }),
     userByok: null,
     bypassAccessCheck: true,
   };


### PR DESCRIPTION
## Summary

Extracts the inline `Provider` construction in `checkCustomLlm`
(in `apps/web/src/lib/ai-gateway/providers/get-provider.ts`)
into a shared helper at
`apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts`.

The helper exposes:

- `buildDirectProvider(input)` — produces a `Provider` that points
  directly at a partner-issued upstream
  (`id: 'custom'`, `apiUrl` = upstream `base_url`, `apiKey` =
  upstream-issued key, supported chat APIs inferred from adapter
  settings).
- `inferSupportedChatApis(...)` — adapter-settings → supported
  chat APIs mapping, previously a private helper inside
  `get-provider.ts`.

`checkCustomLlm` now calls `buildDirectProvider(...)` with the
fields from the matching `custom_llm2` row instead of constructing
the `Provider` inline. Behavior is identical for all existing
`kilo-internal/...` traffic.

This is prep for follow-up experiment-routing work that needs to
build the same direct-to-upstream Provider shape from a different
source (`model_experiment_variant_version.upstream`) — sharing the
helper keeps both consumers on one implementation. There is no
behavioral change to the live custom_llm path; the experiment
consumer arrives in a separate PR (#3325).

## Verification

- `pnpm --filter web typecheck` — clean.
- `pnpm --filter web lint` — clean.
- `pnpm --filter web test -- src/lib/ai-gateway/providers` —
  83 tests pass; the existing custom_llm coverage exercises the
  refactored code path.

## Visual Changes

N/A — backend refactor only.

## Reviewer Notes

- The helper input type (`DirectProviderInput`) accepts an optional
  `extra_headers` field, used by the custom_llm2 path. The
  forthcoming experiment consumer deliberately doesn't pass
  `extra_headers` — partner checkpoint routing is constrained to
  `api_key` + `base_url` + `internal_id` + adapter settings.
- File path: `experiments/build-direct-provider.ts`. Custom_llm
  consumes it today; experiments will be the second consumer.
  Either name (`experiments/` or a more neutral
  `providers/build-direct-provider.ts`) is defensible — happy to
  move if preferred before merge.
