### PR TITLE
CloudAgentNext - Add child session transcript drawer

### DIFF
--- a/apps/web/src/components/cloud-agent-next/ChildSessionDrawer.tsx
+++ b/apps/web/src/components/cloud-agent-next/ChildSessionDrawer.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useCallback, useEffect, useRef, type ComponentProps } from 'react';
+import { useAtomValue } from 'jotai';
+import { AlertCircle, ArrowLeft, Loader2, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import type { ChildSessionHydrationState, KiloSessionId } from '@/lib/cloud-agent-sdk';
+import { useManager } from './CloudAgentProvider';
+import { MessageBubble } from './MessageBubble';
+import { MessageErrorBoundary } from './MessageErrorBoundary';
+import type { ChildSessionDrawerEntry, OpenChildSession } from './ChildSessionSection';
+
+const IDLE_HYDRATION_STATE: ChildSessionHydrationState = { status: 'idle' };
+
+type ChildSessionDrawerProps = {
+  stack: ChildSessionDrawerEntry[];
+  onBack: () => void;
+  onOpenChange: (open: boolean) => void;
+  onOpenChildSession: OpenChildSession;
+  onCloseAutoFocus?: ComponentProps<typeof SheetContent>['onCloseAutoFocus'];
+  portalContainer?: HTMLElement | null;
+};
+
+function toKiloSessionId(sessionId: string): KiloSessionId {
+  return sessionId as KiloSessionId;
+}
+
+export function ChildSessionDrawer({
+  stack,
+  onBack,
+  onOpenChange,
+  onOpenChildSession,
+  onCloseAutoFocus,
+  portalContainer,
+}: ChildSessionDrawerProps) {
+  const manager = useManager();
+  const getChildMessages = useAtomValue(manager.atoms.childMessages);
+  const getChildSessionHydrationState = useAtomValue(manager.atoms.childSessionHydrationState);
+  const selectedEntry = stack[stack.length - 1];
+  const selectedSessionId = selectedEntry?.sessionId;
+  const messages = selectedSessionId ? getChildMessages(selectedSessionId) : [];
+  const hydrationState = selectedSessionId
+    ? getChildSessionHydrationState(selectedSessionId)
+    : IDLE_HYDRATION_STATE;
+  const previousStackDepthRef = useRef(stack.length);
+  const backButtonRef = useRef<HTMLButtonElement | null>(null);
+  const headingFocusRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!selectedSessionId) return;
+    void manager.hydrateChildSession(toKiloSessionId(selectedSessionId));
+  }, [manager, selectedSessionId]);
+
+  useEffect(() => {
+    const previousStackDepth = previousStackDepthRef.current;
+    previousStackDepthRef.current = stack.length;
+
+    if (stack.length === 0 || previousStackDepth === stack.length) {
+      return;
+    }
+
+    if (stack.length > 1) {
+      backButtonRef.current?.focus();
+      return;
+    }
+
+    headingFocusRef.current?.focus();
+  }, [stack.length]);
+
+  const handleRetry = useCallback(() => {
+    if (!selectedSessionId) return;
+    void manager.hydrateChildSession(toKiloSessionId(selectedSessionId));
+  }, [manager, selectedSessionId]);
+
+  const hasMessages = messages.length > 0;
+
+  return (
+    <Sheet modal={false} open={stack.length > 0} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        portalContainer={portalContainer}
+        overlayClassName="absolute"
+        dismissibleOverlay
+        className="absolute inset-y-0 right-0 h-full w-full gap-0 border-l p-0 sm:max-w-xl lg:max-w-2xl"
+        onCloseAutoFocus={onCloseAutoFocus}
+        onInteractOutside={event => event.preventDefault()}
+      >
+        <SheetHeader className="shrink-0 border-b pr-14">
+          <div className="flex min-w-0 items-start gap-2">
+            {stack.length > 1 && (
+              <Button
+                ref={backButtonRef}
+                variant="ghost"
+                size="sm"
+                onClick={onBack}
+                className="shrink-0 gap-1 px-2"
+              >
+                <ArrowLeft className="size-4" />
+                Back
+              </Button>
+            )}
+            <div
+              ref={headingFocusRef}
+              tabIndex={-1}
+              className="focus-visible:ring-ring/50 min-w-0 space-y-1 rounded-sm focus-visible:ring-[3px] focus-visible:outline-none"
+            >
+              <SheetTitle className="truncate text-base">
+                {selectedEntry?.description || 'Sub-agent transcript'}
+              </SheetTitle>
+              <SheetDescription className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                <span>
+                  {selectedEntry?.agent ? `Agent: ${selectedEntry.agent}` : 'Sub-agent session'}
+                </span>
+                {selectedSessionId && (
+                  <span className="truncate font-mono text-xs">{selectedSessionId}</span>
+                )}
+              </SheetDescription>
+            </div>
+          </div>
+        </SheetHeader>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+          {hydrationState.status === 'loading' && (
+            <div className="border-border bg-muted/20 text-muted-foreground mb-4 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm">
+              <Loader2 className="size-4 shrink-0 animate-spin" />
+              <span>
+                {hasMessages
+                  ? 'Loading earlier sub-agent messages...'
+                  : 'Loading sub-agent messages...'}
+              </span>
+            </div>
+          )}
+
+          {hydrationState.status === 'error' && (
+            <div className="border-destructive/40 bg-destructive/10 mb-4 rounded-lg border px-3 py-3">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="text-destructive mt-0.5 size-4 shrink-0" />
+                <div className="min-w-0 flex-1 space-y-1">
+                  <p className="text-sm font-medium">Could not load sub-agent history.</p>
+                  <p className="text-muted-foreground text-sm">{hydrationState.message}</p>
+                </div>
+              </div>
+              <Button variant="outline" size="sm" onClick={handleRetry} className="mt-3 gap-1.5">
+                <RefreshCw className="size-3.5" />
+                Retry history load
+              </Button>
+            </div>
+          )}
+
+          {hasMessages ? (
+            <div>
+              {messages.map(message => (
+                <MessageErrorBoundary key={message.info.id}>
+                  <MessageBubble
+                    message={message}
+                    getChildMessages={getChildMessages}
+                    onOpenChildSession={onOpenChildSession}
+                  />
+                </MessageErrorBoundary>
+              ))}
+            </div>
+          ) : hydrationState.status === 'loading' || hydrationState.status === 'error' ? null : (
+            <div className="border-border bg-muted/20 text-muted-foreground rounded-lg border px-4 py-6 text-sm">
+              No sub-agent messages yet.
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/components/cloud-agent-next/ChildSessionDrawer.tsx
+++ b/apps/web/src/components/cloud-agent-next/ChildSessionDrawer.tsx
@@ -11,7 +11,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
-import type { ChildSessionHydrationState, KiloSessionId } from '@/lib/cloud-agent-sdk';
+import type { ChildSessionHydrationState } from '@/lib/cloud-agent-sdk';
 import { useManager } from './CloudAgentProvider';
 import { MessageBubble } from './MessageBubble';
 import { MessageErrorBoundary } from './MessageErrorBoundary';
@@ -27,10 +27,6 @@ type ChildSessionDrawerProps = {
   onCloseAutoFocus?: ComponentProps<typeof SheetContent>['onCloseAutoFocus'];
   portalContainer?: HTMLElement | null;
 };
-
-function toKiloSessionId(sessionId: string): KiloSessionId {
-  return sessionId as KiloSessionId;
-}
 
 export function ChildSessionDrawer({
   stack,
@@ -55,7 +51,7 @@ export function ChildSessionDrawer({
 
   useEffect(() => {
     if (!selectedSessionId) return;
-    void manager.hydrateChildSession(toKiloSessionId(selectedSessionId));
+    void manager.hydrateChildSession(selectedSessionId);
   }, [manager, selectedSessionId]);
 
   useEffect(() => {
@@ -76,7 +72,7 @@ export function ChildSessionDrawer({
 
   const handleRetry = useCallback(() => {
     if (!selectedSessionId) return;
-    void manager.hydrateChildSession(toKiloSessionId(selectedSessionId));
+    void manager.hydrateChildSession(selectedSessionId);
   }, [manager, selectedSessionId]);
 
   const hasMessages = messages.length > 0;

--- a/apps/web/src/components/cloud-agent-next/ChildSessionSection.tsx
+++ b/apps/web/src/components/cloud-agent-next/ChildSessionSection.tsx
@@ -4,6 +4,7 @@ import { useState, type ReactNode } from 'react';
 import { ChevronRight, ChevronDown, Bot, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import type { KiloSessionId } from '@/lib/cloud-agent-sdk';
 import type { SubtaskPart, StoredMessage, ToolPart, Part } from './types';
 import { isMessageStreaming, isToolPart } from './types';
 import { MessageErrorBoundary } from './MessageErrorBoundary';
@@ -11,7 +12,7 @@ import { MessageErrorBoundary } from './MessageErrorBoundary';
 const MAX_NESTING_DEPTH = 5;
 
 export type ChildSessionDrawerEntry = {
-  sessionId: string;
+  sessionId: KiloSessionId;
   description?: string;
   agent?: string;
 };
@@ -29,7 +30,7 @@ export type RenderPartFn = (props: {
 type ChildSessionSectionProps = {
   subtaskPart?: SubtaskPart;
   taskToolPart?: ToolPart;
-  sessionId?: string;
+  sessionId?: KiloSessionId;
   childMessages?: StoredMessage[];
   depth?: number;
   getChildMessages?: (sessionId: string) => StoredMessage[];
@@ -254,16 +255,21 @@ function getTaskAgent(toolPart?: ToolPart): string | undefined {
   return getStringProperty(input, 'subagent_type');
 }
 
+function isKiloSessionId(sessionId: string | undefined): sessionId is KiloSessionId {
+  return sessionId !== undefined && sessionId.startsWith('ses_') && sessionId.length === 30;
+}
+
 /**
  * Extract the child session ID from a task tool part.
  * The session ID is stored in state.metadata.sessionId.
  */
-export function getTaskToolSessionId(toolPart: ToolPart): string | undefined {
+export function getTaskToolSessionId(toolPart: ToolPart): KiloSessionId | undefined {
   if (toolPart.tool !== 'task') return undefined;
   const state = toolPart.state;
   if (state.status === 'running' || state.status === 'completed') {
     const metadata = state.metadata;
-    return getStringProperty(metadata, 'sessionId');
+    const sessionId = getStringProperty(metadata, 'sessionId');
+    return isKiloSessionId(sessionId) ? sessionId : undefined;
   }
   return undefined;
 }

--- a/apps/web/src/components/cloud-agent-next/ChildSessionSection.tsx
+++ b/apps/web/src/components/cloud-agent-next/ChildSessionSection.tsx
@@ -1,71 +1,45 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { ChevronRight, ChevronDown, Bot, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import type { ReactNode } from 'react';
 import type { SubtaskPart, StoredMessage, ToolPart, Part } from './types';
 import { isMessageStreaming, isToolPart } from './types';
 import { MessageErrorBoundary } from './MessageErrorBoundary';
 
-const isDev = process.env.NODE_ENV === 'development';
-
-/**
- * Dev-only debug info that shows on hover
- */
-function DevDebugInfo({ messageId, sessionId }: { messageId: string; sessionId: string }) {
-  if (!isDev) return null;
-
-  return (
-    <span className="group relative ml-1 cursor-help">
-      <span className="text-muted-foreground/30 text-[10px]">*</span>
-      <span className="bg-popover text-popover-foreground pointer-events-none absolute top-full left-0 z-50 mt-1 hidden rounded border px-2 py-1 font-mono text-[10px] whitespace-nowrap shadow-md group-hover:block">
-        msg:{messageId}
-        <br />
-        sess:{sessionId}
-      </span>
-    </span>
-  );
-}
-
-/**
- * Maximum nesting depth for child sessions to prevent infinite recursion.
- */
 const MAX_NESTING_DEPTH = 5;
 
-/** Render function for a single part, injected to avoid circular imports */
+export type ChildSessionDrawerEntry = {
+  sessionId: string;
+  description?: string;
+  agent?: string;
+};
+
+export type OpenChildSession = (entry: ChildSessionDrawerEntry) => void;
+
 export type RenderPartFn = (props: {
   part: Part;
   isStreaming?: boolean;
   childSessionMessages?: Map<string, StoredMessage[]>;
   getChildMessages?: (sessionId: string) => StoredMessage[];
+  onOpenChildSession?: OpenChildSession;
 }) => ReactNode;
 
 type ChildSessionSectionProps = {
   subtaskPart?: SubtaskPart;
-  /** For task tool parts, the tool part itself */
   taskToolPart?: ToolPart;
-  /** Child session ID from the task tool's metadata */
   sessionId?: string;
-  /** Messages for this child session */
   childMessages?: StoredMessage[];
-  /** Current nesting depth (for recursive rendering) */
   depth?: number;
-  /** Callback when section is expanded (for lazy loading) */
-  onExpand?: () => void;
-  /** Function to get messages for a child session ID (for nested sessions) */
   getChildMessages?: (sessionId: string) => StoredMessage[];
-  /** Render function for individual parts (injected to avoid circular dependency) */
-  renderPart: RenderPartFn;
+  renderPart?: RenderPartFn;
+  onOpenChildSession?: OpenChildSession;
 };
 
 /**
- * ChildSessionSection - Collapsible component for rendering child sessions (subtasks).
- *
- * Displays subtask/task information with expand/collapse functionality.
- * Renders child session messages inline when expanded.
- * Supports nested child sessions with recursive rendering.
+ * ChildSessionSection - Compact task row that opens Cloud Agent child transcripts in a drawer.
+ * Consumers without a drawer callback retain the existing inline child transcript fallback.
  */
 export function ChildSessionSection({
   subtaskPart,
@@ -73,30 +47,32 @@ export function ChildSessionSection({
   sessionId,
   childMessages = [],
   depth = 0,
-  onExpand,
   getChildMessages,
   renderPart,
+  onOpenChildSession,
 }: ChildSessionSectionProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-
-  const handleToggle = () => {
-    const newExpanded = !isExpanded;
-    setIsExpanded(newExpanded);
-    if (newExpanded && onExpand) {
-      onExpand();
-    }
-  };
-
-  // Determine display info from either subtaskPart or taskToolPart
   const description = subtaskPart?.description || getTaskDescription(taskToolPart);
   const agent = subtaskPart?.agent || getTaskAgent(taskToolPart);
   const taskStatus = taskToolPart?.state?.status;
   const isRunning = taskStatus === 'running' || taskStatus === 'pending';
-
-  // Get current running tool info when task is in progress
   const currentTool = isRunning ? getCurrentRunningTool(childMessages) : undefined;
+  const canOpenDrawer = Boolean(sessionId && onOpenChildSession);
+  const inlineRenderPart = sessionId && !canOpenDrawer ? renderPart : undefined;
+  const canExpandInline = Boolean(inlineRenderPart);
+  const isInteractive = canOpenDrawer || canExpandInline;
 
-  // Border color based on status
+  const handleOpen = () => {
+    if (!sessionId) return;
+    if (onOpenChildSession) {
+      onOpenChildSession({ sessionId, description, agent });
+      return;
+    }
+    if (inlineRenderPart) {
+      setIsExpanded(expanded => !expanded);
+    }
+  };
+
   const borderColor =
     taskStatus === 'error'
       ? 'border-red-500/40'
@@ -104,77 +80,86 @@ export function ChildSessionSection({
         ? 'border-green-500/40'
         : 'border-blue-500/40';
 
-  return (
-    <div className={`bg-muted/20 my-2 rounded-r-md border-l-2 ${borderColor}`}>
-      {/* Header - always visible */}
-      <Button
-        variant="ghost"
-        onClick={handleToggle}
-        className="hover:bg-muted/50 h-auto w-full justify-start gap-2 px-3 py-2"
-      >
-        {/* Expand/Collapse Icon */}
-        {isExpanded ? (
+  const rowContent = (
+    <>
+      {canOpenDrawer ? (
+        <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+      ) : canExpandInline ? (
+        isExpanded ? (
           <ChevronDown className="text-muted-foreground h-4 w-4 shrink-0" />
         ) : (
           <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+        )
+      ) : (
+        <span className="h-4 w-4 shrink-0" aria-hidden />
+      )}
+
+      {isRunning ? (
+        <Loader2 className="h-4 w-4 shrink-0 animate-spin text-blue-500" />
+      ) : (
+        <Bot className="h-4 w-4 shrink-0 text-blue-500" />
+      )}
+
+      <span className="flex-1 truncate text-left text-sm font-medium">
+        {description || 'Subtask'}
+        {currentTool && (
+          <span className="text-muted-foreground ml-2 font-normal">
+            <span className="text-blue-500">{currentTool.tool}</span>
+            {currentTool.context && <span className="ml-1 opacity-70">{currentTool.context}</span>}
+          </span>
         )}
+      </span>
 
-        {/* Agent Icon with loading indicator */}
-        {isRunning ? (
-          <Loader2 className="h-4 w-4 shrink-0 animate-spin text-blue-500" />
-        ) : (
-          <Bot className="h-4 w-4 shrink-0 text-blue-500" />
-        )}
+      {taskStatus && (
+        <Badge
+          variant={
+            taskStatus === 'completed'
+              ? 'default'
+              : taskStatus === 'error'
+                ? 'destructive'
+                : 'outline'
+          }
+          className="shrink-0 text-xs"
+        >
+          {taskStatus}
+        </Badge>
+      )}
 
-        {/* Description and current tool */}
-        <span className="flex-1 truncate text-left text-sm font-medium">
-          {description || 'Subtask'}
-          {currentTool && (
-            <span className="text-muted-foreground ml-2 font-normal">
-              <span className="text-blue-500">{currentTool.tool}</span>
-              {currentTool.context && (
-                <span className="ml-1 opacity-70">{currentTool.context}</span>
-              )}
-            </span>
-          )}
-        </span>
+      {agent && (
+        <Badge variant="outline" className="shrink-0 text-xs">
+          {agent}
+        </Badge>
+      )}
+    </>
+  );
 
-        {/* Status Badge */}
-        {taskStatus && (
-          <Badge
-            variant={
-              taskStatus === 'completed'
-                ? 'default'
-                : taskStatus === 'error'
-                  ? 'destructive'
-                  : 'outline'
-            }
-            className="shrink-0 text-xs"
-          >
-            {taskStatus}
-          </Badge>
-        )}
+  return (
+    <div className={`bg-muted/20 my-2 rounded-r-md border-l-2 ${borderColor}`}>
+      {isInteractive ? (
+        <Button
+          variant="ghost"
+          onClick={handleOpen}
+          className="hover:bg-muted/50 h-auto w-full justify-start gap-2 px-3 py-2 text-left"
+        >
+          {rowContent}
+        </Button>
+      ) : (
+        <div className="flex h-auto w-full items-center justify-start gap-2 px-3 py-2 text-left">
+          {rowContent}
+        </div>
+      )}
 
-        {/* Agent Badge */}
-        {agent && (
-          <Badge variant="outline" className="shrink-0 text-xs">
-            {agent}
-          </Badge>
-        )}
-      </Button>
-
-      {/* Expanded Content - just show child session events */}
-      {isExpanded && (
+      {isExpanded && inlineRenderPart && (
         <div className="space-y-2 px-4 pt-1 pb-3">
           {childMessages.length > 0 ? (
             depth < MAX_NESTING_DEPTH ? (
-              childMessages.map(msg => (
-                <MessageErrorBoundary key={msg.info.id}>
+              childMessages.map(message => (
+                <MessageErrorBoundary key={message.info.id}>
                   <ChildSessionMessage
-                    message={msg}
+                    message={message}
                     depth={depth}
                     getChildMessages={getChildMessages}
-                    renderPart={renderPart}
+                    renderPart={inlineRenderPart}
                   />
                 </MessageErrorBoundary>
               ))
@@ -183,21 +168,17 @@ export function ChildSessionSection({
                 Maximum nesting depth reached. Unable to display nested sessions.
               </div>
             )
-          ) : sessionId ? (
+          ) : (
             <div className="text-muted-foreground text-xs italic">
               {isRunning ? 'Waiting for child session messages...' : 'No messages in child session'}
             </div>
-          ) : null}
+          )}
         </div>
       )}
     </div>
   );
 }
 
-/**
- * Renders a single message from a child session.
- * Handles recursive rendering of nested task tool parts.
- */
 function ChildSessionMessage({
   message,
   depth,
@@ -220,11 +201,9 @@ function ChildSessionMessage({
         {isStreaming && (
           <span className="text-muted-foreground animate-pulse text-xs">streaming...</span>
         )}
-        <DevDebugInfo messageId={message.info.id} sessionId={message.info.sessionID} />
       </div>
       <div className="mt-2 space-y-1">
         {message.parts.map((part, index) => {
-          // Check for nested task tools
           if (isToolPart(part) && part.tool === 'task') {
             const nestedSessionId = getTaskToolSessionId(part);
             const nestedChildMessages = nestedSessionId ? getChildMessages?.(nestedSessionId) : [];
@@ -244,7 +223,7 @@ function ChildSessionMessage({
 
           return (
             <MessageErrorBoundary key={part.id || index}>
-              {renderPart({ part, isStreaming })}
+              {renderPart({ part, isStreaming, getChildMessages })}
             </MessageErrorBoundary>
           );
         })}
@@ -252,9 +231,6 @@ function ChildSessionMessage({
     </div>
   );
 }
-
-// Helper functions to extract info from task tool parts
-// These use runtime type checks instead of unsafe 'as' casts
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -300,12 +276,10 @@ export function getTaskToolSessionId(toolPart: ToolPart): string | undefined {
 export function getCurrentRunningTool(
   childMessages: StoredMessage[]
 ): { tool: string; context?: string } | undefined {
-  // Search messages in reverse order (most recent first)
   for (let i = childMessages.length - 1; i >= 0; i--) {
     const msg = childMessages[i];
     if (msg.info.role !== 'assistant') continue;
 
-    // Search parts in reverse order
     for (let j = msg.parts.length - 1; j >= 0; j--) {
       const part = msg.parts[j];
       if (!isToolPart(part)) continue;
@@ -315,18 +289,15 @@ export function getCurrentRunningTool(
         const tool = part.tool;
         let context: string | undefined;
 
-        // Extract context based on tool type
         const input = part.state.input;
         if (tool === 'read' || tool === 'edit' || tool === 'write') {
           const filePath = getStringProperty(input, 'filePath');
           if (filePath) {
-            // Extract just the filename
             context = filePath.split('/').pop();
           }
         } else if (tool === 'bash') {
           const command = getStringProperty(input, 'command');
           if (command) {
-            // Show first part of command (truncated)
             const firstWord = command.split(/\s+/)[0];
             context = firstWord.length > 20 ? firstWord.slice(0, 20) + '...' : firstWord;
           }
@@ -336,9 +307,10 @@ export function getCurrentRunningTool(
             context = pattern.length > 25 ? pattern.slice(0, 25) + '...' : pattern;
           }
         } else if (tool === 'task') {
-          const description = getStringProperty(input, 'description');
-          if (description) {
-            context = description.length > 30 ? description.slice(0, 30) + '...' : description;
+          const taskDescription = getStringProperty(input, 'description');
+          if (taskDescription) {
+            context =
+              taskDescription.length > 30 ? taskDescription.slice(0, 30) + '...' : taskDescription;
           }
         }
 

--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -15,6 +15,8 @@ import { ChatInput } from './ChatInput';
 import type { ModeOption } from '@/components/shared/ModeCombobox';
 import { MessageErrorBoundary } from './MessageErrorBoundary';
 import { MessageBubble } from './MessageBubble';
+import { ChildSessionDrawer } from './ChildSessionDrawer';
+import type { ChildSessionDrawerEntry, OpenChildSession } from './ChildSessionSection';
 import { SessionStatusIndicator } from './SessionStatusIndicator';
 import { WorkingIndicator } from './WorkingIndicator';
 import { QuestionToolCard } from './QuestionToolCard';
@@ -60,14 +62,20 @@ const StaticMessages = memo(
   ({
     messages,
     getChildMessages,
+    onOpenChildSession,
   }: {
     messages: StoredMessage[];
     getChildMessages?: (sessionId: string) => StoredMessage[];
+    onOpenChildSession?: OpenChildSession;
   }) => (
     <>
       {messages.map(msg => (
         <MessageErrorBoundary key={msg.info.id}>
-          <MessageBubble message={msg} getChildMessages={getChildMessages} />
+          <MessageBubble
+            message={msg}
+            getChildMessages={getChildMessages}
+            onOpenChildSession={onOpenChildSession}
+          />
         </MessageErrorBoundary>
       ))}
     </>
@@ -81,9 +89,11 @@ StaticMessages.displayName = 'StaticMessages';
 function DynamicMessages({
   messages,
   getChildMessages,
+  onOpenChildSession,
 }: {
   messages: StoredMessage[];
   getChildMessages?: (sessionId: string) => StoredMessage[];
+  onOpenChildSession?: OpenChildSession;
 }) {
   return (
     <>
@@ -95,6 +105,7 @@ function DynamicMessages({
               message={msg}
               isStreaming={streaming}
               getChildMessages={getChildMessages}
+              onOpenChildSession={onOpenChildSession}
             />
           </MessageErrorBoundary>
         );
@@ -155,10 +166,17 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const { mutateAsync: orgUploadUrl } = useMutation(
     trpc.organizations.cloudAgentNext.getImageUploadUrl.mutationOptions()
   );
+  const [childSessionStack, setChildSessionStack] = useState<ChildSessionDrawerEntry[]>([]);
+  const [childSessionDrawerContainer, setChildSessionDrawerContainer] =
+    useState<HTMLDivElement | null>(null);
+  const childSessionDrawerFocusTargetRef = useRef<HTMLElement | null>(null);
+
   // URL-driven session switching
   const sessionIdFromParams = searchParams?.get('sessionId');
   useEffect(() => {
     if (sessionIdFromParams) {
+      childSessionDrawerFocusTargetRef.current = null;
+      setChildSessionStack([]);
       void manager.switchSession(sessionIdFromParams as KiloSessionId);
     }
   }, [sessionIdFromParams, manager]);
@@ -460,6 +478,33 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
     [manager]
   );
 
+  const handleOpenTopLevelChildSession = useCallback((entry: ChildSessionDrawerEntry) => {
+    const activeElement = document.activeElement;
+    childSessionDrawerFocusTargetRef.current =
+      activeElement instanceof HTMLElement ? activeElement : null;
+    setChildSessionStack([entry]);
+  }, []);
+
+  const handleOpenNestedChildSession = useCallback((entry: ChildSessionDrawerEntry) => {
+    setChildSessionStack(currentStack => [...currentStack, entry]);
+  }, []);
+
+  const handleChildSessionDrawerBack = useCallback(() => {
+    setChildSessionStack(currentStack => currentStack.slice(0, -1));
+  }, []);
+
+  const handleChildSessionDrawerOpenChange = useCallback((open: boolean) => {
+    if (!open) setChildSessionStack([]);
+  }, []);
+
+  const handleChildSessionDrawerCloseAutoFocus = useCallback((event: Event) => {
+    const focusTarget = childSessionDrawerFocusTargetRef.current;
+    childSessionDrawerFocusTargetRef.current = null;
+    if (!focusTarget?.isConnected) return;
+    event.preventDefault();
+    focusTarget.focus();
+  }, []);
+
   // Expose the session's custom agents to the chat picker. Slug + name only;
   // the full config stays server-side. `GetSessionOutput.runtimeAgents`
   // already filters to enabled & non-hidden at send time, so we just pass
@@ -622,142 +667,162 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                   <div className="shrink-0">{sessionActions}</div>
                 </div>
 
-                <div className="relative min-h-0 flex-1">
-                  {workspaceTabs.activeTabId === CHAT_TAB_ID && (
-                    <>
-                      <div
-                        ref={scrollContainerRef}
-                        className={`absolute inset-0 overflow-y-auto px-[max(1rem,calc(50%_-_27rem))] pb-2 pt-4 transition-opacity duration-150 ${showLoadingIndicator ? 'pointer-events-none opacity-40' : 'opacity-100'}`}
-                        onScroll={handleScroll}
-                      >
-                        <div ref={messagesContentRef}>
-                          <StaticMessages
-                            messages={staticMessages}
-                            getChildMessages={getChildMessages}
-                          />
-                          <DynamicMessages
-                            messages={dynamicMessages}
-                            getChildMessages={getChildMessages}
-                          />
-
-                          <WorkingIndicator messages={dynamicMessages} isStreaming={isStreaming} />
-                          {statusIndicator && (
-                            <SessionStatusIndicator indicator={statusIndicator} />
-                          )}
-
-                          <div ref={messagesEndRef} />
-                        </div>
-                      </div>
-
-                      {showScrollButton && (
-                        <button
-                          type="button"
-                          onClick={scrollToBottom}
-                          className="border-border bg-background absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full border p-2 shadow-md"
-                        >
-                          <ArrowDown className="h-4 w-4" />
-                        </button>
-                      )}
-                    </>
-                  )}
-
+                <div
+                  ref={setChildSessionDrawerContainer}
+                  className="relative flex min-h-0 flex-1 flex-col"
+                >
                   <div
-                    className={
-                      workspaceTabs.activeTabId === CHAT_TAB_ID
-                        ? 'hidden'
-                        : 'h-full min-h-0 px-[max(1rem,calc(50%_-_27rem))] py-2'
-                    }
+                    inert={childSessionStack.length > 0}
+                    className="flex min-h-0 flex-1 flex-col"
                   >
-                    {terminalPaneMap}
-                  </div>
-                </div>
+                    <div className="relative min-h-0 flex-1">
+                      {workspaceTabs.activeTabId === CHAT_TAB_ID && (
+                        <>
+                          <div
+                            ref={scrollContainerRef}
+                            className={`absolute inset-0 overflow-y-auto px-[max(1rem,calc(50%_-_27rem))] pb-2 pt-4 transition-opacity duration-150 ${showLoadingIndicator ? 'pointer-events-none opacity-40' : 'opacity-100'}`}
+                            onScroll={handleScroll}
+                          >
+                            <div ref={messagesContentRef}>
+                              <StaticMessages
+                                messages={staticMessages}
+                                getChildMessages={getChildMessages}
+                                onOpenChildSession={handleOpenTopLevelChildSession}
+                              />
+                              <DynamicMessages
+                                messages={dynamicMessages}
+                                getChildMessages={getChildMessages}
+                                onOpenChildSession={handleOpenTopLevelChildSession}
+                              />
 
-                {workspaceTabs.activeTabId === CHAT_TAB_ID && (
-                  <>
-                    {isReadOnly ? (
-                      !isLoading && sessionIdFromParams && fetchedSessionData ? (
-                        <SessionContinuationPanel sessionId={sessionIdFromParams} />
-                      ) : null
-                    ) : (
+                              <WorkingIndicator
+                                messages={dynamicMessages}
+                                isStreaming={isStreaming}
+                              />
+                              {statusIndicator && (
+                                <SessionStatusIndicator indicator={statusIndicator} />
+                              )}
+
+                              <div ref={messagesEndRef} />
+                            </div>
+                          </div>
+
+                          {showScrollButton && (
+                            <button
+                              type="button"
+                              onClick={scrollToBottom}
+                              className="border-border bg-background absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full border p-2 shadow-md"
+                            >
+                              <ArrowDown className="h-4 w-4" />
+                            </button>
+                          )}
+                        </>
+                      )}
+
+                      <div
+                        className={
+                          workspaceTabs.activeTabId === CHAT_TAB_ID
+                            ? 'hidden'
+                            : 'h-full min-h-0 px-[max(1rem,calc(50%_-_27rem))] py-2'
+                        }
+                      >
+                        {terminalPaneMap}
+                      </div>
+                    </div>
+
+                    {workspaceTabs.activeTabId === CHAT_TAB_ID && (
                       <>
-                        {activeQuestion && (
-                          <div className="border-t px-[max(1rem,calc(50%_-_27rem))] py-4">
-                            <QuestionToolCard
-                              key={activeQuestion.requestId}
-                              questions={activeQuestion.questions}
-                              requestId={activeQuestion.requestId}
-                              status="running"
-                            />
-                          </div>
-                        )}
-                        {activePermission && (
-                          <div className="flex items-center border-t p-4">
-                            <PermissionCard
-                              key={activePermission.requestId}
-                              requestId={activePermission.requestId}
-                              permission={activePermission.permission}
-                              patterns={activePermission.patterns}
-                              metadata={activePermission.metadata}
-                              always={activePermission.always}
-                            />
-                          </div>
-                        )}
-                        <div className={activeQuestion || activePermission ? 'hidden' : ''}>
-                          <ChatInput
-                            onSend={handleSendMessage}
-                            onSendCommand={handleSendSlashCommand}
-                            onStop={handleStopExecution}
-                            disabled={(isStreaming && !activeSuggestion) || !canSend}
-                            isStreaming={isStreaming && !activeSuggestion}
-                            placeholder={placeholder}
-                            slashCommands={availableCommands}
-                            mode={sessionConfig?.mode as AgentMode | undefined}
-                            model={displayModel}
-                            modelOptions={modelOptions}
-                            isLoadingModels={isLoadingModels}
-                            onModeChange={handleModeChange}
-                            onModelChange={handleModelChange}
-                            variant={displayVariant}
-                            onVariantChange={handleVariantChange}
-                            availableVariants={displayAvailableVariants}
-                            showToolbar={Boolean(sessionIdFromParams)}
-                            initialValue={failedPrompt ?? undefined}
-                            customModeOptions={customModeOptions}
-                            modelPickerDisabled={modelPickerLocked}
-                            modelPickerTooltip={lockTooltip}
-                            variantPickerDisabled={modelPickerLocked}
-                            variantPickerTooltip={lockTooltip}
-                            imageUploadOptions={{
-                              messageUuid: imageMessageUuid,
-                              organizationId,
-                              maxImages: CLOUD_AGENT_IMAGE_MAX_COUNT,
-                              maxOriginalFileSizeBytes: CLOUD_AGENT_IMAGE_MAX_ORIGINAL_SIZE_BYTES,
-                              maxFileSizeBytes: CLOUD_AGENT_IMAGE_MAX_SIZE_BYTES,
-                              allowedTypes: CLOUD_AGENT_IMAGE_ALLOWED_TYPES,
-                              resizeImages: { maxDimensionPx: CLOUD_AGENT_IMAGE_MAX_DIMENSION_PX },
-                              getUploadUrl: {
-                                personal: personalUploadUrl,
-                                organization: orgUploadUrl,
-                              },
-                            }}
-                          />
-                          {sessionConfig?.repository && (
-                            <div className="text-muted-foreground flex items-center gap-1.5 px-[max(1rem,calc(50%_-_27rem))] pb-3 text-xs md:pb-4">
-                              <GitBranch className="h-3 w-3 shrink-0" />
-                              <span className="truncate">{sessionConfig.repository}</span>
-                              {fetchedSessionData?.gitBranch && (
-                                <>
-                                  <span>·</span>
-                                  <span className="truncate">{fetchedSessionData.gitBranch}</span>
-                                </>
+                        {isReadOnly ? (
+                          !isLoading && sessionIdFromParams && fetchedSessionData ? (
+                            <SessionContinuationPanel sessionId={sessionIdFromParams} />
+                          ) : null
+                        ) : (
+                          <>
+                            {activeQuestion && (
+                              <div className="border-t px-[max(1rem,calc(50%_-_27rem))] py-4">
+                                <QuestionToolCard
+                                  key={activeQuestion.requestId}
+                                  questions={activeQuestion.questions}
+                                  requestId={activeQuestion.requestId}
+                                  status="running"
+                                />
+                              </div>
+                            )}
+                            {activePermission && (
+                              <div className="flex items-center border-t p-4">
+                                <PermissionCard
+                                  key={activePermission.requestId}
+                                  requestId={activePermission.requestId}
+                                  permission={activePermission.permission}
+                                  patterns={activePermission.patterns}
+                                  metadata={activePermission.metadata}
+                                  always={activePermission.always}
+                                />
+                              </div>
+                            )}
+                            <div className={activeQuestion || activePermission ? 'hidden' : ''}>
+                              <ChatInput
+                                onSend={handleSendMessage}
+                                onSendCommand={handleSendSlashCommand}
+                                onStop={handleStopExecution}
+                                disabled={(isStreaming && !activeSuggestion) || !canSend}
+                                isStreaming={isStreaming && !activeSuggestion}
+                                placeholder={placeholder}
+                                slashCommands={availableCommands}
+                                mode={sessionConfig?.mode as AgentMode | undefined}
+                                model={displayModel}
+                                modelOptions={modelOptions}
+                                isLoadingModels={isLoadingModels}
+                                onModeChange={handleModeChange}
+                                onModelChange={handleModelChange}
+                                variant={displayVariant}
+                                onVariantChange={handleVariantChange}
+                                availableVariants={displayAvailableVariants}
+                                showToolbar={Boolean(sessionIdFromParams)}
+                                initialValue={failedPrompt ?? undefined}
+                                customModeOptions={customModeOptions}
+                                modelPickerDisabled={modelPickerLocked}
+                                modelPickerTooltip={lockTooltip}
+                                variantPickerDisabled={modelPickerLocked}
+                                variantPickerTooltip={lockTooltip}
+                                imageUploadOptions={{
+                                  messageUuid: imageMessageUuid,
+                                  organizationId,
+                                  maxImages: CLOUD_AGENT_IMAGE_MAX_COUNT,
+                                  maxOriginalFileSizeBytes:
+                                    CLOUD_AGENT_IMAGE_MAX_ORIGINAL_SIZE_BYTES,
+                                  maxFileSizeBytes: CLOUD_AGENT_IMAGE_MAX_SIZE_BYTES,
+                                  allowedTypes: CLOUD_AGENT_IMAGE_ALLOWED_TYPES,
+                                  resizeImages: {
+                                    maxDimensionPx: CLOUD_AGENT_IMAGE_MAX_DIMENSION_PX,
+                                  },
+                                  getUploadUrl: {
+                                    personal: personalUploadUrl,
+                                    organization: orgUploadUrl,
+                                  },
+                                }}
+                              />
+                              {sessionConfig?.repository && (
+                                <div className="text-muted-foreground flex items-center gap-1.5 px-[max(1rem,calc(50%_-_27rem))] pb-3 text-xs md:pb-4">
+                                  <GitBranch className="h-3 w-3 shrink-0" />
+                                  <span className="truncate">{sessionConfig.repository}</span>
+                                  {fetchedSessionData?.gitBranch && (
+                                    <>
+                                      <span>·</span>
+                                      <span className="truncate">
+                                        {fetchedSessionData.gitBranch}
+                                      </span>
+                                    </>
+                                  )}
+                                </div>
                               )}
                             </div>
-                          )}
-                        </div>
+                          </>
+                        )}
                       </>
                     )}
-                  </>
-                )}
+                  </div>
+                </div>
               </>
             ) : (
               <div className="text-muted-foreground relative flex h-full flex-col items-center justify-center gap-2">
@@ -766,6 +831,14 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                 <p className="text-xs">Select a session from the sidebar or create a new one</p>
               </div>
             )}
+            <ChildSessionDrawer
+              stack={childSessionStack}
+              onBack={handleChildSessionDrawerBack}
+              onOpenChange={handleChildSessionDrawerOpenChange}
+              onOpenChildSession={handleOpenNestedChildSession}
+              onCloseAutoFocus={handleChildSessionDrawerCloseAutoFocus}
+              portalContainer={childSessionDrawerContainer}
+            />
           </div>
         </SuggestionContextProvider>
       </PermissionContextProvider>

--- a/apps/web/src/components/cloud-agent-next/MessageBubble.tsx
+++ b/apps/web/src/components/cloud-agent-next/MessageBubble.tsx
@@ -15,6 +15,7 @@ import {
 } from './types';
 import type { FilePart } from './types';
 import { PartRenderer } from './PartRenderer';
+import type { OpenChildSession } from './ChildSessionSection';
 import { CopyMessageButton } from '@/components/shared/CopyMessageButton';
 import { stripImageContext } from '@/lib/app-builder/message-utils';
 
@@ -148,6 +149,7 @@ type MessageBubbleProps = {
   isStreaming?: boolean;
   /** Function to get messages for a child session ID */
   getChildMessages?: (sessionId: string) => StoredMessage[];
+  onOpenChildSession?: OpenChildSession;
 };
 
 /**
@@ -160,6 +162,7 @@ export function MessageBubble({
   message,
   isStreaming: isStreamingProp,
   getChildMessages,
+  onOpenChildSession,
 }: MessageBubbleProps) {
   const isStreaming = isStreamingProp ?? isMessageStreaming(message);
   const timestamp = message.info.time.created;
@@ -233,6 +236,7 @@ export function MessageBubble({
               part={part}
               isStreaming={isStreaming}
               getChildMessages={getChildMessages}
+              onOpenChildSession={onOpenChildSession}
             />
           ))}
         </div>

--- a/apps/web/src/components/cloud-agent-next/PartRenderer.tsx
+++ b/apps/web/src/components/cloud-agent-next/PartRenderer.tsx
@@ -18,7 +18,7 @@ import { TodoWriteToolCard } from './TodoWriteToolCard';
 import { QuestionToolStatus } from './QuestionToolStatus';
 import { SuggestToolCard } from './SuggestToolCard';
 import { ChildSessionSection, getTaskToolSessionId } from './ChildSessionSection';
-import type { RenderPartFn } from './ChildSessionSection';
+import type { OpenChildSession, RenderPartFn } from './ChildSessionSection';
 import { useState } from 'react';
 import type { ReactNode } from 'react';
 import { MessageErrorBoundary } from './MessageErrorBoundary';
@@ -39,14 +39,15 @@ import {
 // Types
 // ============================================================================
 
-export interface PartRendererProps {
+export type PartRendererProps = {
   part: Part;
   isStreaming?: boolean;
   /** Messages for child sessions (task tools) - keyed by session ID */
   childSessionMessages?: Map<string, StoredMessage[]>;
   /** Function to get messages for a child session ID (for nested sessions) */
   getChildMessages?: (sessionId: string) => StoredMessage[];
-}
+  onOpenChildSession?: OpenChildSession;
+};
 
 // ============================================================================
 // Shared Components
@@ -140,10 +141,6 @@ function StreamingToolPlaceholder({ toolName }: { toolName: string }) {
   );
 }
 
-/**
- * Adapter that delegates to the exported PartRenderer component,
- * used as a callback prop in ChildSessionSection to break the circular dependency.
- */
 const renderPartFn: RenderPartFn = props => <PartRenderer {...props} />;
 
 /**
@@ -155,10 +152,12 @@ function ToolPartRenderer({
   part,
   childSessionMessages,
   getChildMessages,
+  onOpenChildSession,
 }: {
   part: Extract<Part, { type: 'tool' }>;
   childSessionMessages?: Map<string, StoredMessage[]>;
   getChildMessages?: (sessionId: string) => StoredMessage[];
+  onOpenChildSession?: OpenChildSession;
 }) {
   // plan_enter / plan_exit are internal mode-switching tools with no user-visible output
   if (part.tool === 'plan_exit' || part.tool === 'plan_enter') {
@@ -184,6 +183,7 @@ function ToolPartRenderer({
         childMessages={childMessages}
         getChildMessages={getChildMessages}
         renderPart={renderPartFn}
+        onOpenChildSession={onOpenChildSession}
       />
     );
   }
@@ -431,6 +431,7 @@ export function PartRenderer({
   isStreaming,
   childSessionMessages,
   getChildMessages,
+  onOpenChildSession,
 }: PartRendererProps) {
   // Text parts -> render markdown
   if (isTextPart(part)) {
@@ -449,6 +450,7 @@ export function PartRenderer({
           part={part}
           childSessionMessages={childSessionMessages}
           getChildMessages={getChildMessages}
+          onOpenChildSession={onOpenChildSession}
         />
       </MessageErrorBoundary>
     );

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -42,13 +42,33 @@ function SheetContent({
   className,
   children,
   side = 'right',
+  portalContainer,
+  showOverlay = true,
+  overlayClassName,
+  dismissibleOverlay = false,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: 'top' | 'right' | 'bottom' | 'left';
+  portalContainer?: React.ComponentProps<typeof SheetPrimitive.Portal>['container'];
+  showOverlay?: boolean;
+  overlayClassName?: string;
+  dismissibleOverlay?: boolean;
 }) {
   return (
-    <SheetPortal>
-      <SheetOverlay />
+    <SheetPortal container={portalContainer}>
+      {showOverlay &&
+        (dismissibleOverlay ? (
+          <SheetPrimitive.Close asChild>
+            <button
+              type="button"
+              aria-label="Close sheet"
+              data-slot="sheet-overlay"
+              className={cn('absolute inset-0 z-50 cursor-default bg-black/50', overlayClassName)}
+            />
+          </SheetPrimitive.Close>
+        ) : (
+          <SheetOverlay className={overlayClassName} />
+        ))}
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(

--- a/apps/web/src/lib/cloud-agent-sdk/index.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/index.ts
@@ -8,6 +8,7 @@ export type {
   StandalonePermission,
   StandaloneQuestion,
   StandaloneSuggestion,
+  ChildSessionHydrationState,
   StoredMessage,
   FetchedSessionData,
   AssociatedPrData,

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -9,7 +9,7 @@ import {
 import { createCloudAgentSession } from './session';
 import type { JotaiSessionStorage } from './storage/jotai';
 import type { AssistantMessage, UserMessage } from '@/types/opencode.gen';
-import { kiloId, cloudAgentId, stubUserMessage, stubTextPart } from './test-helpers';
+import { kiloId, cloudAgentId, stubUserMessage, stubTextPart, makeSnapshot } from './test-helpers';
 import type { CloudStatus, ResolvedSession, SessionActivity } from './types';
 
 // ---------------------------------------------------------------------------
@@ -919,6 +919,181 @@ describe('createSessionManager', () => {
       );
 
       expect(childMessages('child-1')).toEqual([childOneFirst, childOneSecond]);
+    });
+  });
+
+  describe('child session hydration', () => {
+    it('hydrates child snapshots while preserving root transcript filtering', async () => {
+      const rootMessage = createStoredMessage('msg-root', 'ses-root', 'assistant');
+      const childMessage = createStoredMessage('msg-child-history', 'child-1', 'assistant');
+      const childPart = stubTextPart({
+        id: 'part-child-history',
+        sessionID: 'child-1',
+        messageID: childMessage.info.id,
+        text: 'Historical child message',
+      });
+      const config = createMockConfig({
+        fetchSnapshot: jest
+          .fn()
+          .mockResolvedValue(
+            makeSnapshot({ id: 'child-1', parentID: 'ses-root' }, [
+              { info: childMessage.info, parts: [childPart] },
+            ])
+          ),
+      });
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root'));
+      if (!latestStorage) throw new Error('expected session storage');
+      latestStorage.upsertMessage(rootMessage.info);
+
+      await mgr.hydrateChildSession(kiloId('child-1'));
+
+      expect(config.fetchSnapshot).toHaveBeenCalledWith(kiloId('child-1'));
+      const childMessages = atomValue<(childSessionId: string) => StoredMessage[]>(
+        config.store,
+        mgr.atoms.childMessages
+      );
+      expect(childMessages('child-1')).toEqual([{ info: childMessage.info, parts: [childPart] }]);
+      expect(atomValue(config.store, mgr.atoms.messagesList)).toEqual([rootMessage]);
+      const childHydrationState = atomValue<(childSessionId: string) => { status: string }>(
+        config.store,
+        mgr.atoms.childSessionHydrationState
+      );
+      expect(childHydrationState('child-1')).toEqual({ status: 'ready' });
+    });
+
+    it('merges fetched history into live child messages without duplicating them', async () => {
+      const childMessage = createStoredMessage('msg-child-live', 'child-live', 'assistant');
+      const livePart = stubTextPart({
+        id: 'part-child-live',
+        sessionID: 'child-live',
+        messageID: childMessage.info.id,
+        text: 'Partial live text',
+      });
+      const historicalPart = stubTextPart({
+        ...livePart,
+        text: 'Complete historical text',
+      });
+      const config = createMockConfig({
+        fetchSnapshot: jest
+          .fn()
+          .mockResolvedValue(
+            makeSnapshot({ id: 'child-live', parentID: 'ses-root' }, [
+              { info: childMessage.info, parts: [historicalPart] },
+            ])
+          ),
+      });
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root'));
+      if (!latestStorage) throw new Error('expected session storage');
+      latestStorage.upsertMessage(childMessage.info);
+      latestStorage.upsertPart(childMessage.info.id, livePart);
+
+      await mgr.hydrateChildSession(kiloId('child-live'));
+
+      const childMessages = atomValue<(childSessionId: string) => StoredMessage[]>(
+        config.store,
+        mgr.atoms.childMessages
+      );
+      expect(childMessages('child-live')).toEqual([
+        { info: childMessage.info, parts: [historicalPart] },
+      ]);
+    });
+
+    it('deduplicates concurrent child snapshot hydration requests', async () => {
+      let resolveSnapshot: ((snapshot: ReturnType<typeof makeSnapshot>) => void) | undefined;
+      const childSnapshot = new Promise<ReturnType<typeof makeSnapshot>>(resolve => {
+        resolveSnapshot = resolve;
+      });
+      const config = createMockConfig({
+        fetchSnapshot: jest.fn().mockReturnValue(childSnapshot),
+      });
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root'));
+
+      const firstHydration = mgr.hydrateChildSession(kiloId('child-deduped'));
+      const secondHydration = mgr.hydrateChildSession(kiloId('child-deduped'));
+
+      expect(config.fetchSnapshot).toHaveBeenCalledTimes(1);
+      const childHydrationState = atomValue<(childSessionId: string) => { status: string }>(
+        config.store,
+        mgr.atoms.childSessionHydrationState
+      );
+      expect(childHydrationState('child-deduped')).toEqual({ status: 'loading' });
+
+      resolveSnapshot?.(makeSnapshot({ id: 'child-deduped', parentID: 'ses-root' }));
+      await Promise.all([firstHydration, secondHydration]);
+
+      const updatedChildHydrationState = atomValue<(childSessionId: string) => { status: string }>(
+        config.store,
+        mgr.atoms.childSessionHydrationState
+      );
+      expect(updatedChildHydrationState('child-deduped')).toEqual({ status: 'ready' });
+    });
+
+    it('ignores stale child snapshots after the active root session changes', async () => {
+      let resolveSnapshot: ((snapshot: ReturnType<typeof makeSnapshot>) => void) | undefined;
+      const childSnapshot = new Promise<ReturnType<typeof makeSnapshot>>(resolve => {
+        resolveSnapshot = resolve;
+      });
+      const staleMessage = createStoredMessage('msg-child-stale', 'child-stale', 'assistant');
+      const config = createMockConfig({
+        fetchSnapshot: jest.fn().mockReturnValue(childSnapshot),
+      });
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root-a'));
+      const staleHydration = mgr.hydrateChildSession(kiloId('child-stale'));
+
+      await mgr.switchSession(kiloId('ses-root-b'));
+      resolveSnapshot?.(
+        makeSnapshot({ id: 'child-stale', parentID: 'ses-root-a' }, [
+          { info: staleMessage.info, parts: [] },
+        ])
+      );
+      await staleHydration;
+
+      const childMessages = atomValue<(childSessionId: string) => StoredMessage[]>(
+        config.store,
+        mgr.atoms.childMessages
+      );
+      expect(childMessages('child-stale')).toEqual([]);
+      const childHydrationState = atomValue<(childSessionId: string) => { status: string }>(
+        config.store,
+        mgr.atoms.childSessionHydrationState
+      );
+      expect(childHydrationState('child-stale')).toEqual({ status: 'idle' });
+    });
+
+    it('allows retrying child history hydration after a snapshot fetch fails', async () => {
+      const config = createMockConfig({
+        fetchSnapshot: jest
+          .fn()
+          .mockRejectedValueOnce(new Error('fetch failed'))
+          .mockResolvedValueOnce(makeSnapshot({ id: 'child-retry', parentID: 'ses-root' })),
+      });
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root'));
+      await mgr.hydrateChildSession(kiloId('child-retry'));
+
+      const childHydrationState = atomValue<
+        (childSessionId: string) => { status: string; message?: string }
+      >(config.store, mgr.atoms.childSessionHydrationState);
+      expect(childHydrationState('child-retry')).toEqual(
+        expect.objectContaining({ status: 'error' })
+      );
+
+      await mgr.hydrateChildSession(kiloId('child-retry'));
+
+      expect(config.fetchSnapshot).toHaveBeenCalledTimes(2);
+      const retriedChildHydrationState = atomValue<
+        (childSessionId: string) => { status: string; message?: string }
+      >(config.store, mgr.atoms.childSessionHydrationState);
+      expect(retriedChildHydrationState('child-retry')).toEqual({ status: 'ready' });
     });
   });
 

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
@@ -5,6 +5,7 @@ import { atom } from 'jotai';
 import type { Atom, WritableAtom } from 'jotai';
 import { createCloudAgentSession } from './session';
 import type { CloudAgentSession } from './session';
+import { createChatProcessor } from './chat-processor';
 import { createJotaiStorage } from './storage/jotai';
 import type { JotaiSessionStorage, JotaiStore } from './storage/jotai';
 import type { CloudAgentApi, CloudAgentStreamTicketResult } from './transport';
@@ -66,6 +67,15 @@ type StandaloneSuggestion = {
   /** Tool call ID that emitted this suggestion, when available. */
   callId?: string;
 };
+type ChildSessionHydrationState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready' }
+  | { status: 'error'; message: string };
+
+const IDLE_CHILD_SESSION_HYDRATION_STATE = {
+  status: 'idle',
+} satisfies ChildSessionHydrationState;
 
 type AssociatedPrData = {
   url: string;
@@ -173,10 +183,12 @@ type SessionManagerAtoms = {
   dynamicMessages: Atom<StoredMessage[]>;
   totalCost: Atom<number>;
   childMessages: Atom<(childSessionId: string) => StoredMessage[]>;
+  childSessionHydrationState: Atom<(childSessionId: string) => ChildSessionHydrationState>;
 };
 
 type SessionManager = {
   switchSession(kiloSessionId: KiloSessionId): Promise<void>;
+  hydrateChildSession(childSessionId: KiloSessionId): Promise<void>;
   send(input: { payload: TransportSendPayload; images?: Images }): Promise<boolean>;
   interrupt(): Promise<void>;
   answerQuestion(requestId: string, answers: string[][]): Promise<void>;
@@ -313,6 +325,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
    * DO) and on every wrapper push. Empty list = wrapper hasn't reported yet.
    */
   const availableCommandsAtom = atom<SlashCommandInfo[]>([]);
+  const childSessionHydrationStatesAtom = atom<Map<string, ChildSessionHydrationState>>(new Map());
 
   // Derived atoms
   const messagesListAtom = atom<StoredMessage[]>(get => {
@@ -359,6 +372,11 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       return out;
     };
   });
+  const childSessionHydrationStateAtom = atom(get => {
+    const states = get(childSessionHydrationStatesAtom);
+    return (childSessionId: string): ChildSessionHydrationState =>
+      states.get(childSessionId) ?? IDLE_CHILD_SESSION_HYDRATION_STATE;
+  });
 
   // Private mutable state
   let activeSessionId: KiloSessionId | null = null;
@@ -366,6 +384,8 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
   let activeSessionType: ActiveSessionType | null = null;
   let stateUnsub: (() => void) | null = null;
   let indicatorTimer: ReturnType<typeof setTimeout> | null = null;
+  let childSessionHydrationGeneration = 0;
+  const childSessionHydrationRequests = new Map<string, Promise<void>>();
 
   function setIndicator(ind: SessionStatusIndicator | null): void {
     if (indicatorTimer !== null) {
@@ -404,6 +424,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     store.set(activeSuggestionAtom, null);
     store.set(failedPromptAtom, null);
     store.set(fetchedSessionDataAtom, null);
+    store.set(childSessionHydrationStatesAtom, new Map());
     store.set(chatUIAtom, { shouldAutoScroll: true });
     store.set(availableCommandsAtom, []);
   }
@@ -431,6 +452,77 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       text: data.prompt,
       synthetic: true,
     } satisfies TextPart);
+  }
+
+  function setChildSessionHydrationState(
+    childSessionId: KiloSessionId,
+    state: ChildSessionHydrationState
+  ): void {
+    const next = new Map(store.get(childSessionHydrationStatesAtom));
+    next.set(childSessionId, state);
+    store.set(childSessionHydrationStatesAtom, next);
+  }
+
+  function isCurrentChildSessionHydration(
+    generation: number,
+    rootSessionId: KiloSessionId,
+    storage: JotaiSessionStorage
+  ): boolean {
+    return (
+      generation === childSessionHydrationGeneration &&
+      activeSessionId === rootSessionId &&
+      store.get(sessionStorageAtom) === storage
+    );
+  }
+
+  async function hydrateChildSession(childSessionId: KiloSessionId): Promise<void> {
+    const existingState = store.get(childSessionHydrationStatesAtom).get(childSessionId);
+    if (existingState?.status === 'ready') return;
+
+    const inFlightRequest = childSessionHydrationRequests.get(childSessionId);
+    if (inFlightRequest) {
+      await inFlightRequest;
+      return;
+    }
+
+    const storage = store.get(sessionStorageAtom);
+    const rootSessionId = activeSessionId;
+    if (!storage || !rootSessionId) return;
+
+    const generation = childSessionHydrationGeneration;
+    setChildSessionHydrationState(childSessionId, { status: 'loading' });
+
+    const request = (async () => {
+      try {
+        const snapshot = await config.fetchSnapshot(childSessionId);
+        if (!isCurrentChildSessionHydration(generation, rootSessionId, storage)) return;
+
+        const chatProcessor = createChatProcessor(storage);
+        for (const message of snapshot.messages) {
+          chatProcessor.process({ type: 'message.updated', info: message.info });
+          for (const part of message.parts) {
+            chatProcessor.process({ type: 'message.part.updated', part });
+          }
+        }
+
+        setChildSessionHydrationState(childSessionId, { status: 'ready' });
+      } catch (err) {
+        if (!isCurrentChildSessionHydration(generation, rootSessionId, storage)) return;
+        setChildSessionHydrationState(childSessionId, {
+          status: 'error',
+          message: formatError(err),
+        });
+      }
+    })();
+
+    childSessionHydrationRequests.set(childSessionId, request);
+    try {
+      await request;
+    } finally {
+      if (childSessionHydrationRequests.get(childSessionId) === request) {
+        childSessionHydrationRequests.delete(childSessionId);
+      }
+    }
   }
 
   function subscribeToServiceState(
@@ -520,6 +612,8 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
   }
 
   async function switchSession(kiloSessionId: KiloSessionId): Promise<void> {
+    childSessionHydrationGeneration += 1;
+    childSessionHydrationRequests.clear();
     activeSessionId = kiloSessionId;
     activeSessionType = null;
     stateUnsub?.();
@@ -809,6 +903,8 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
   }
 
   function destroy(): void {
+    childSessionHydrationGeneration += 1;
+    childSessionHydrationRequests.clear();
     stateUnsub?.();
     stateUnsub = null;
     currentSession?.destroy();
@@ -824,6 +920,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
 
   return {
     switchSession,
+    hydrateChildSession,
     send,
     interrupt,
     answerQuestion,
@@ -866,6 +963,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       dynamicMessages: dynamicMessagesAtom,
       totalCost: totalCostAtom,
       childMessages: childMessagesAtom,
+      childSessionHydrationState: childSessionHydrationStateAtom,
     },
   };
 }
@@ -880,6 +978,7 @@ export type {
   StandalonePermission,
   StandaloneQuestion,
   StandaloneSuggestion,
+  ChildSessionHydrationState,
   StoredMessage,
   FetchedSessionData,
   AssociatedPrData,


### PR DESCRIPTION
## Summary
- Add a chat-local child-session drawer for Cloud Agent Next transcripts, including nested drill-in and focus-safe scoped overlay behavior.
- Hydrate historical child-session snapshots through the session manager while keeping root transcript filtering intact and exposing retry state.
- Extend shared sheet support and regression coverage for child-session transcript rendering and hydration state.

## Verification

<img width="1350" height="1368" alt="Screenshot 2026-05-19 at 14 37 20" src="https://github.com/user-attachments/assets/fdf37f45-1c35-4161-898d-7e2539f3e730" />

## Reviewer Notes
- The drawer intentionally stays scoped to the chat work area rather than taking over the full app shell.
- Historical child transcript loading reuses the existing snapshot fetch path.