### PR TITLE
feat(web): connect collab OAuth flow

### DIFF
--- a/apps/web/src/app/api/integrations/discord/callback/route.ts
+++ b/apps/web/src/app/api/integrations/discord/callback/route.ts
@@ -8,10 +8,17 @@ import { exchangeDiscordCode, upsertDiscordInstallation } from '@/lib/integratio
 import { verifyOAuthState } from '@/lib/integrations/oauth-state';
 import { APP_URL } from '@/lib/constants';
 
+const appendQueryParam = (path: string, queryParam: string): string =>
+  `${path}${path.includes('?') ? '&' : '?'}${queryParam}`;
+
 const buildDiscordRedirectPath = (state: string | null, queryParam: string): string => {
   // Try to extract the owner from a signed state for best-effort redirects on error paths.
   // We use verifyOAuthState so we don't trust unsigned/tampered values for routing.
   const verified = state ? verifyOAuthState(state) : null;
+  if (verified?.returnTo) {
+    return appendQueryParam(verified.returnTo, queryParam);
+  }
+
   const owner = verified?.owner;
 
   if (owner?.startsWith('org_')) {
@@ -125,8 +132,9 @@ export async function GET(request: NextRequest) {
     await upsertDiscordInstallation(owner, oauthData);
 
     // 9. Redirect to success page
-    const successPath =
-      owner.type === 'org'
+    const successPath = verified.returnTo
+      ? appendQueryParam(verified.returnTo, 'success=discord_installed')
+      : owner.type === 'org'
         ? `/organizations/${owner.id}/integrations/discord?success=installed`
         : `/integrations/discord?success=installed`;
 

--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -29,6 +29,9 @@ import { isOrganizationMember } from '@/lib/organizations/organizations';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { botPlatforms } from '@/lib/bot/platforms';
 
+const appendQueryParam = (path: string, queryParam: string): string =>
+  `${path}${path.includes('?') ? '&' : '?'}${queryParam}`;
+
 function htmlPage(title: string, message: string, status = 200): Response {
   return new Response(
     `<!DOCTYPE html>
@@ -176,8 +179,9 @@ export async function GET(request: NextRequest) {
     if (setupAction === 'delete' || setupAction === 'suspend') {
       console.log(`GitHub App ${setupAction} action detected, skipping installation fetch`);
 
-      const redirectPath =
-        owner.type === 'org'
+      const redirectPath = returnTo
+        ? appendQueryParam(returnTo, `github_action=${setupAction}`)
+        : owner.type === 'org'
           ? `/organizations/${owner.id}/integrations/github?action=${setupAction}`
           : `/integrations/github?action=${setupAction}`;
 
@@ -221,8 +225,12 @@ export async function GET(request: NextRequest) {
               githubRequesterId: githubRequester.id,
             });
 
-            const redirectPath =
-              owner.type === 'org'
+            const redirectPath = returnTo
+              ? appendQueryParam(
+                  returnTo,
+                  `error=pending_installation_exists&org=${existingOwnerId}`
+                )
+              : owner.type === 'org'
                 ? `/organizations/${owner.id}/integrations/github?error=pending_installation_exists&org=${existingOwnerId}`
                 : `/integrations/github?error=pending_installation_exists`;
 
@@ -245,8 +253,9 @@ export async function GET(request: NextRequest) {
         });
 
         // Redirect back to integrations page with pending approval status
-        const redirectPath =
-          owner.type === 'org'
+        const redirectPath = returnTo
+          ? appendQueryParam(returnTo, 'github_pending_approval=true')
+          : owner.type === 'org'
             ? `/organizations/${owner.id}/integrations/github?pending_approval=true`
             : `/integrations/github?pending_approval=true`;
 
@@ -255,8 +264,9 @@ export async function GET(request: NextRequest) {
         console.error('Error creating pending installation:', error);
         captureException(error);
 
-        const redirectPath =
-          owner.type === 'org'
+        const redirectPath = returnTo
+          ? appendQueryParam(returnTo, 'error=pending_setup_failed')
+          : owner.type === 'org'
             ? `/organizations/${owner.id}/integrations/github?error=pending_setup_failed`
             : `/integrations/github?error=pending_setup_failed`;
 
@@ -272,8 +282,9 @@ export async function GET(request: NextRequest) {
         extra: { setupAction, rawState, allParams: Object.fromEntries(searchParams.entries()) },
       });
 
-      const redirectPath =
-        owner.type === 'org'
+      const redirectPath = returnTo
+        ? appendQueryParam(returnTo, 'error=missing_installation_id')
+        : owner.type === 'org'
           ? `/organizations/${owner.id}/integrations/github?error=missing_installation_id`
           : `/integrations/github?error=missing_installation_id`;
 
@@ -323,8 +334,9 @@ export async function GET(request: NextRequest) {
 
       // If installation not found, it might have been deleted or belongs to a different app
       if (err.status === 404) {
-        const redirectPath =
-          owner.type === 'org'
+        const redirectPath = returnTo
+          ? appendQueryParam(returnTo, `error=installation_not_found&id=${installationId}`)
+          : owner.type === 'org'
             ? `/organizations/${owner.id}/integrations/github?error=installation_not_found&id=${installationId}`
             : `/integrations/github?error=installation_not_found&id=${installationId}`;
 
@@ -389,7 +401,7 @@ export async function GET(request: NextRequest) {
 
     // 9. Redirect to success page
     const successPath = returnTo
-      ? `${returnTo}${returnTo.includes('?') ? '&' : '?'}github_install=success`
+      ? appendQueryParam(returnTo, 'github_install=success')
       : owner.type === 'org'
         ? `/organizations/${owner.id}/integrations/github?success=installed`
         : `/integrations/github?success=installed`;
@@ -414,14 +426,16 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    const { ownerToken: errorOwnerToken } = parseStateReturn(rawState);
+    const { ownerToken: errorOwnerToken, returnTo } = parseStateReturn(rawState);
 
-    let redirectPath = '/?error=installation_failed';
+    let redirectPath = returnTo
+      ? appendQueryParam(returnTo, 'error=installation_failed')
+      : '/?error=installation_failed';
 
-    if (errorOwnerToken.startsWith('org_')) {
+    if (!returnTo && errorOwnerToken.startsWith('org_')) {
       const orgId = errorOwnerToken.slice(4);
       redirectPath = `/organizations/${orgId}/integrations/github?error=installation_failed`;
-    } else if (errorOwnerToken.startsWith('user_')) {
+    } else if (!returnTo && errorOwnerToken.startsWith('user_')) {
       redirectPath = `/integrations/github?error=installation_failed`;
     }
 

--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -335,11 +335,12 @@ export async function GET(request: NextRequest) {
 
       // If installation not found, it might have been deleted or belongs to a different app
       if (err.status === 404) {
+        const encodedInstallationId = encodeURIComponent(installationId);
         const redirectPath = returnTo
-          ? appendQueryParam(returnTo, `error=installation_not_found&id=${installationId}`)
+          ? appendQueryParam(returnTo, `error=installation_not_found&id=${encodedInstallationId}`)
           : owner.type === 'org'
-            ? `/organizations/${owner.id}/integrations/github?error=installation_not_found&id=${installationId}`
-            : `/integrations/github?error=installation_not_found&id=${installationId}`;
+            ? `/organizations/${owner.id}/integrations/github?error=installation_not_found&id=${encodedInstallationId}`
+            : `/integrations/github?error=installation_not_found&id=${encodedInstallationId}`;
 
         return NextResponse.redirect(new URL(redirectPath, APP_URL));
       }

--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -28,6 +28,7 @@ import { bot } from '@/lib/bot';
 import { isOrganizationMember } from '@/lib/organizations/organizations';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { botPlatforms } from '@/lib/bot/platforms';
+import { APP_URL } from '@/lib/constants';
 
 const appendQueryParam = (path: string, queryParam: string): string =>
   `${path}${path.includes('?') ? '&' : '?'}${queryParam}`;
@@ -122,7 +123,7 @@ export async function GET(request: NextRequest) {
     if (authFailedResponse) {
       // If user is not authenticated (e.g., GitHub admin approving installation),
       // redirect to homepage instead of showing "Unauthorized"
-      return NextResponse.redirect(new URL('/', request.url));
+      return NextResponse.redirect(new URL('/', APP_URL));
     }
 
     // 2. Extract parameters
@@ -158,7 +159,7 @@ export async function GET(request: NextRequest) {
         tags: { endpoint: 'github/callback', source: 'github_app_installation' },
         extra: { installationId, rawState, allParams: Object.fromEntries(searchParams.entries()) },
       });
-      return NextResponse.redirect(new URL('/', request.url));
+      return NextResponse.redirect(new URL('/', APP_URL));
     }
 
     // 4. Verify user has access to the owner
@@ -167,7 +168,7 @@ export async function GET(request: NextRequest) {
     } else {
       // For user-owned integrations, verify it's the same user
       if (user.id !== owner.id) {
-        return NextResponse.redirect(new URL('/', request.url));
+        return NextResponse.redirect(new URL('/', APP_URL));
       }
     }
 
@@ -185,7 +186,7 @@ export async function GET(request: NextRequest) {
           ? `/organizations/${owner.id}/integrations/github?action=${setupAction}`
           : `/integrations/github?action=${setupAction}`;
 
-      return NextResponse.redirect(new URL(redirectPath, request.url));
+      return NextResponse.redirect(new URL(redirectPath, APP_URL));
     }
 
     // Handle pending approval - store requester info for webhook matching
@@ -234,7 +235,7 @@ export async function GET(request: NextRequest) {
                 ? `/organizations/${owner.id}/integrations/github?error=pending_installation_exists&org=${existingOwnerId}`
                 : `/integrations/github?error=pending_installation_exists`;
 
-            return NextResponse.redirect(new URL(redirectPath, request.url));
+            return NextResponse.redirect(new URL(redirectPath, APP_URL));
           }
         }
 
@@ -259,7 +260,7 @@ export async function GET(request: NextRequest) {
             ? `/organizations/${owner.id}/integrations/github?pending_approval=true`
             : `/integrations/github?pending_approval=true`;
 
-        return NextResponse.redirect(new URL(redirectPath, request.url));
+        return NextResponse.redirect(new URL(redirectPath, APP_URL));
       } catch (error) {
         console.error('Error creating pending installation:', error);
         captureException(error);
@@ -270,7 +271,7 @@ export async function GET(request: NextRequest) {
             ? `/organizations/${owner.id}/integrations/github?error=pending_setup_failed`
             : `/integrations/github?error=pending_setup_failed`;
 
-        return NextResponse.redirect(new URL(redirectPath, request.url));
+        return NextResponse.redirect(new URL(redirectPath, APP_URL));
       }
     }
 
@@ -288,7 +289,7 @@ export async function GET(request: NextRequest) {
           ? `/organizations/${owner.id}/integrations/github?error=missing_installation_id`
           : `/integrations/github?error=missing_installation_id`;
 
-      return NextResponse.redirect(new URL(redirectPath, request.url));
+      return NextResponse.redirect(new URL(redirectPath, APP_URL));
     }
 
     // 6. Fetch installation details from GitHub
@@ -340,7 +341,7 @@ export async function GET(request: NextRequest) {
             ? `/organizations/${owner.id}/integrations/github?error=installation_not_found&id=${installationId}`
             : `/integrations/github?error=installation_not_found&id=${installationId}`;
 
-        return NextResponse.redirect(new URL(redirectPath, request.url));
+        return NextResponse.redirect(new URL(redirectPath, APP_URL));
       }
 
       throw error;
@@ -406,7 +407,7 @@ export async function GET(request: NextRequest) {
         ? `/organizations/${owner.id}/integrations/github?success=installed`
         : `/integrations/github?success=installed`;
 
-    return NextResponse.redirect(new URL(successPath, request.url));
+    return NextResponse.redirect(new URL(successPath, APP_URL));
   } catch (error) {
     console.error('Error handling GitHub App callback:', error);
 
@@ -439,6 +440,6 @@ export async function GET(request: NextRequest) {
       redirectPath = `/integrations/github?error=installation_failed`;
     }
 
-    return NextResponse.redirect(new URL(redirectPath, request.url));
+    return NextResponse.redirect(new URL(redirectPath, APP_URL));
   }
 }

--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -172,6 +172,12 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    const integrationPath =
+      owner.type === 'org'
+        ? `/organizations/${owner.id}/integrations/github`
+        : `/integrations/github`;
+    const redirectPath = returnTo || integrationPath;
+
     // 5. Determine which GitHub App to use based on organization settings
     const appType = await getGitHubAppTypeForOrganization(owner.type === 'org' ? owner.id : null);
     const credentials = getGitHubAppCredentials(appType);
@@ -180,13 +186,9 @@ export async function GET(request: NextRequest) {
     if (setupAction === 'delete' || setupAction === 'suspend') {
       console.log(`GitHub App ${setupAction} action detected, skipping installation fetch`);
 
-      const redirectPath = returnTo
-        ? appendQueryParam(returnTo, `github_action=${setupAction}`)
-        : owner.type === 'org'
-          ? `/organizations/${owner.id}/integrations/github?action=${setupAction}`
-          : `/integrations/github?action=${setupAction}`;
-
-      return NextResponse.redirect(new URL(redirectPath, APP_URL));
+      return NextResponse.redirect(
+        new URL(appendQueryParam(redirectPath, `github_action=${setupAction}`), APP_URL)
+      );
     }
 
     // Handle pending approval - store requester info for webhook matching
@@ -226,16 +228,14 @@ export async function GET(request: NextRequest) {
               githubRequesterId: githubRequester.id,
             });
 
-            const redirectPath = returnTo
-              ? appendQueryParam(
-                  returnTo,
-                  `error=pending_installation_exists&org=${existingOwnerId}`
-                )
-              : owner.type === 'org'
-                ? `/organizations/${owner.id}/integrations/github?error=pending_installation_exists&org=${existingOwnerId}`
-                : `/integrations/github?error=pending_installation_exists`;
+            const queryParam =
+              returnTo || owner.type === 'org'
+                ? `error=pending_installation_exists&org=${existingOwnerId}`
+                : 'error=pending_installation_exists';
 
-            return NextResponse.redirect(new URL(redirectPath, APP_URL));
+            return NextResponse.redirect(
+              new URL(appendQueryParam(redirectPath, queryParam), APP_URL)
+            );
           }
         }
 
@@ -254,24 +254,16 @@ export async function GET(request: NextRequest) {
         });
 
         // Redirect back to integrations page with pending approval status
-        const redirectPath = returnTo
-          ? appendQueryParam(returnTo, 'github_pending_approval=true')
-          : owner.type === 'org'
-            ? `/organizations/${owner.id}/integrations/github?pending_approval=true`
-            : `/integrations/github?pending_approval=true`;
+        const queryParam = returnTo ? 'github_pending_approval=true' : 'pending_approval=true';
 
-        return NextResponse.redirect(new URL(redirectPath, APP_URL));
+        return NextResponse.redirect(new URL(appendQueryParam(redirectPath, queryParam), APP_URL));
       } catch (error) {
         console.error('Error creating pending installation:', error);
         captureException(error);
 
-        const redirectPath = returnTo
-          ? appendQueryParam(returnTo, 'error=pending_setup_failed')
-          : owner.type === 'org'
-            ? `/organizations/${owner.id}/integrations/github?error=pending_setup_failed`
-            : `/integrations/github?error=pending_setup_failed`;
-
-        return NextResponse.redirect(new URL(redirectPath, APP_URL));
+        return NextResponse.redirect(
+          new URL(appendQueryParam(redirectPath, 'error=pending_setup_failed'), APP_URL)
+        );
       }
     }
 
@@ -283,13 +275,9 @@ export async function GET(request: NextRequest) {
         extra: { setupAction, rawState, allParams: Object.fromEntries(searchParams.entries()) },
       });
 
-      const redirectPath = returnTo
-        ? appendQueryParam(returnTo, 'error=missing_installation_id')
-        : owner.type === 'org'
-          ? `/organizations/${owner.id}/integrations/github?error=missing_installation_id`
-          : `/integrations/github?error=missing_installation_id`;
-
-      return NextResponse.redirect(new URL(redirectPath, APP_URL));
+      return NextResponse.redirect(
+        new URL(appendQueryParam(redirectPath, 'error=missing_installation_id'), APP_URL)
+      );
     }
 
     // 6. Fetch installation details from GitHub
@@ -336,13 +324,16 @@ export async function GET(request: NextRequest) {
       // If installation not found, it might have been deleted or belongs to a different app
       if (err.status === 404) {
         const encodedInstallationId = encodeURIComponent(installationId);
-        const redirectPath = returnTo
-          ? appendQueryParam(returnTo, `error=installation_not_found&id=${encodedInstallationId}`)
-          : owner.type === 'org'
-            ? `/organizations/${owner.id}/integrations/github?error=installation_not_found&id=${encodedInstallationId}`
-            : `/integrations/github?error=installation_not_found&id=${encodedInstallationId}`;
 
-        return NextResponse.redirect(new URL(redirectPath, APP_URL));
+        return NextResponse.redirect(
+          new URL(
+            appendQueryParam(
+              redirectPath,
+              `error=installation_not_found&id=${encodedInstallationId}`
+            ),
+            APP_URL
+          )
+        );
       }
 
       throw error;
@@ -402,13 +393,11 @@ export async function GET(request: NextRequest) {
     }
 
     // 9. Redirect to success page
-    const successPath = returnTo
-      ? appendQueryParam(returnTo, 'github_install=success')
-      : owner.type === 'org'
-        ? `/organizations/${owner.id}/integrations/github?success=installed`
-        : `/integrations/github?success=installed`;
+    const successQueryParam = returnTo ? 'github_install=success' : 'success=installed';
 
-    return NextResponse.redirect(new URL(successPath, APP_URL));
+    return NextResponse.redirect(
+      new URL(appendQueryParam(redirectPath, successQueryParam), APP_URL)
+    );
   } catch (error) {
     console.error('Error handling GitHub App callback:', error);
 
@@ -430,17 +419,17 @@ export async function GET(request: NextRequest) {
 
     const { ownerToken: errorOwnerToken, returnTo } = parseStateReturn(rawState);
 
-    let redirectPath = returnTo
-      ? appendQueryParam(returnTo, 'error=installation_failed')
-      : '/?error=installation_failed';
+    let redirectPath = returnTo || '/';
 
     if (!returnTo && errorOwnerToken.startsWith('org_')) {
       const orgId = errorOwnerToken.slice(4);
-      redirectPath = `/organizations/${orgId}/integrations/github?error=installation_failed`;
+      redirectPath = `/organizations/${orgId}/integrations/github`;
     } else if (!returnTo && errorOwnerToken.startsWith('user_')) {
-      redirectPath = `/integrations/github?error=installation_failed`;
+      redirectPath = `/integrations/github`;
     }
 
-    return NextResponse.redirect(new URL(redirectPath, APP_URL));
+    return NextResponse.redirect(
+      new URL(appendQueryParam(redirectPath, 'error=installation_failed'), APP_URL)
+    );
   }
 }

--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -229,7 +229,7 @@ export async function GET(request: NextRequest) {
             });
 
             const queryParam =
-              returnTo || owner.type === 'org'
+              owner.type === 'org'
                 ? `error=pending_installation_exists&org=${existingOwnerId}`
                 : 'error=pending_installation_exists';
 

--- a/apps/web/src/app/api/integrations/gitlab/callback/route.ts
+++ b/apps/web/src/app/api/integrations/gitlab/callback/route.ts
@@ -32,9 +32,13 @@ function generateWebhookSecret(): string {
 }
 
 function buildGitLabRedirectPath(
-  state: Pick<VerifiedGitLabOAuthState, 'owner'> | null | undefined,
+  state: Pick<VerifiedGitLabOAuthState, 'owner' | 'returnTo'> | null | undefined,
   queryParams: string
 ): string {
+  if (state?.returnTo) {
+    return `${state.returnTo}${state.returnTo.includes('?') ? '&' : '?'}${queryParams}`;
+  }
+
   if (state?.owner.type === 'org') {
     return `/organizations/${state.owner.id}/integrations/gitlab?${queryParams}`;
   }
@@ -240,8 +244,9 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    const successPath =
-      owner.type === 'org'
+    const successPath = verifiedState.returnTo
+      ? `${verifiedState.returnTo}${verifiedState.returnTo.includes('?') ? '&' : '?'}success=gitlab_connected`
+      : owner.type === 'org'
         ? `/organizations/${owner.id}/integrations/gitlab?success=connected`
         : `/integrations/gitlab?success=connected`;
 

--- a/apps/web/src/app/api/integrations/gitlab/connect/route.ts
+++ b/apps/web/src/app/api/integrations/gitlab/connect/route.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/integrations/platforms/gitlab/oauth-state';
 import type { Owner } from '@/lib/integrations/core/types';
 import { storeGitLabOAuthCredentials } from '@/lib/integrations/platforms/gitlab/oauth-credentials';
+import { validateReturnPath } from '@/lib/integrations/validate-return-path';
 
 /**
  * GitLab OAuth Connect
@@ -35,6 +36,8 @@ export async function GET(request: NextRequest) {
     const instanceUrl = searchParams.get('instanceUrl') || undefined;
     const clientId = searchParams.get('clientId') || undefined;
     const clientSecret = searchParams.get('clientSecret') || undefined;
+    const returnToParam = searchParams.get('returnTo') || undefined;
+    const returnTo = returnToParam ? validateReturnPath(returnToParam) : null;
 
     let owner: Owner;
 
@@ -65,6 +68,7 @@ export async function GET(request: NextRequest) {
         owner,
         ...(usesCustomInstance ? { instanceUrl } : {}),
         ...(customCredentialsRef ? { customCredentialsRef } : {}),
+        ...(returnTo ? { returnTo } : {}),
       },
       user.id
     );

--- a/apps/web/src/app/api/integrations/linear/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/linear/callback/route.test.ts
@@ -263,6 +263,20 @@ describe('verifyOAuthState (self-check, to keep tests honest)', () => {
   test('rejects a tampered signature', () => {
     expect(verifyOAuthState('payload.badsig')).toBeNull();
   });
+
+  test('round-trips a safe return path', () => {
+    const state = createOAuthState(
+      `user_${USER_ID}`,
+      USER_ID,
+      '/collab/authorize?services=linear&step=0'
+    );
+
+    expect(verifyOAuthState(state)).toMatchObject({
+      owner: `user_${USER_ID}`,
+      returnTo: '/collab/authorize?services=linear&step=0',
+      userId: USER_ID,
+    });
+  });
 });
 
 describe('GET /api/integrations/linear/callback bot-link flow', () => {

--- a/apps/web/src/app/api/integrations/linear/callback/route.ts
+++ b/apps/web/src/app/api/integrations/linear/callback/route.ts
@@ -14,7 +14,7 @@ import {
   revokeLinearToken,
   upsertLinearInstallation,
 } from '@/lib/integrations/linear-service';
-import { verifyOAuthState } from '@/lib/integrations/oauth-state';
+import { type VerifiedOAuthState, verifyOAuthState } from '@/lib/integrations/oauth-state';
 import { APP_URL } from '@/lib/constants';
 import { bot } from '@/lib/bot';
 import { linkKiloUser, unlinkTeamKiloUsers } from '@/lib/bot-identity';
@@ -42,7 +42,18 @@ async function deleteChatSdkLinearIdentityCache(organizationId: string): Promise
   await unlinkTeamKiloUsers(bot.getState(), PLATFORM.LINEAR, organizationId);
 }
 
-function buildLinearRedirectPath(ownerStr: string | null, queryParam: string): string {
+const appendQueryParam = (path: string, queryParam: string): string =>
+  `${path}${path.includes('?') ? '&' : '?'}${queryParam}`;
+
+function buildLinearRedirectPath(
+  state: Pick<VerifiedOAuthState, 'owner' | 'returnTo'> | null,
+  queryParam: string
+): string {
+  if (state?.returnTo) {
+    return appendQueryParam(state.returnTo, queryParam);
+  }
+
+  const ownerStr = state?.owner ?? null;
   if (ownerStr?.startsWith('org_')) {
     return `/organizations/${ownerStr.replace('org_', '')}/integrations/linear?${queryParam}`;
   }
@@ -243,7 +254,6 @@ export async function GET(request: NextRequest) {
     // reuse the resulting owner string without re-running HMAC verification
     // on every error branch.
     const verified = state ? verifyOAuthState(state) : null;
-    const verifiedOwner = verified?.owner ?? null;
 
     if (error) {
       captureMessage('Linear OAuth error', {
@@ -252,7 +262,7 @@ export async function GET(request: NextRequest) {
         extra: { error, state },
       });
       return NextResponse.redirect(
-        new URL(buildLinearRedirectPath(verifiedOwner, `error=${error}`), APP_URL)
+        new URL(buildLinearRedirectPath(verified, `error=${encodeURIComponent(error)}`), APP_URL)
       );
     }
 
@@ -263,7 +273,7 @@ export async function GET(request: NextRequest) {
         extra: { state, allParams: Object.fromEntries(searchParams.entries()) },
       });
       return NextResponse.redirect(
-        new URL(buildLinearRedirectPath(verifiedOwner, 'error=missing_code'), APP_URL)
+        new URL(buildLinearRedirectPath(verified, 'error=missing_code'), APP_URL)
       );
     }
 
@@ -342,17 +352,15 @@ export async function GET(request: NextRequest) {
         await linearAdapter.deleteInstallation(organizationId);
         await unlinkTeamKiloUsers(bot.getState(), PLATFORM.LINEAR, organizationId);
         return NextResponse.redirect(
-          new URL(
-            buildLinearRedirectPath(verifiedOwner, 'error=workspace_already_connected'),
-            APP_URL
-          )
+          new URL(buildLinearRedirectPath(verified, 'error=workspace_already_connected'), APP_URL)
         );
       }
       throw error;
     }
 
-    const successPath =
-      owner.type === 'org'
+    const successPath = verified.returnTo
+      ? appendQueryParam(verified.returnTo, 'success=linear_installed')
+      : owner.type === 'org'
         ? `/organizations/${owner.id}/integrations/linear?success=installed`
         : `/integrations/linear?success=installed`;
 
@@ -360,7 +368,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     const searchParams = request.nextUrl.searchParams;
     const state = searchParams.get('state');
-    const verifiedOwner = state ? (verifyOAuthState(state)?.owner ?? null) : null;
+    const verified = state ? verifyOAuthState(state) : null;
 
     captureException(error, {
       tags: {
@@ -374,7 +382,7 @@ export async function GET(request: NextRequest) {
     });
 
     return NextResponse.redirect(
-      new URL(buildLinearRedirectPath(verifiedOwner, 'error=installation_failed'), APP_URL)
+      new URL(buildLinearRedirectPath(verified, 'error=installation_failed'), APP_URL)
     );
   }
 }

--- a/apps/web/src/app/api/integrations/slack/callback/route.ts
+++ b/apps/web/src/app/api/integrations/slack/callback/route.ts
@@ -14,8 +14,15 @@ import { bot } from '@/lib/bot';
 
 const SLACK_REDIRECT_URI = `${APP_URL}/api/integrations/slack/callback`;
 
+const appendQueryParam = (path: string, queryParam: string): string =>
+  `${path}${path.includes('?') ? '&' : '?'}${queryParam}`;
+
 const buildSlackRedirectPath = (state: string | null, queryParam: string): string => {
   const verified = state ? verifyOAuthState(state) : null;
+  if (verified?.returnTo) {
+    return appendQueryParam(verified.returnTo, queryParam);
+  }
+
   const owner = verified?.owner;
 
   if (owner?.startsWith('org_')) {
@@ -55,7 +62,7 @@ export async function GET(request: NextRequest) {
       });
 
       return NextResponse.redirect(
-        new URL(buildSlackRedirectPath(state, `error=${error}`), APP_URL)
+        new URL(buildSlackRedirectPath(state, `error=${encodeURIComponent(error)}`), APP_URL)
       );
     }
 
@@ -144,8 +151,9 @@ export async function GET(request: NextRequest) {
     }
 
     // 9. Redirect to success page
-    const successPath =
-      owner.type === 'org'
+    const successPath = verified.returnTo
+      ? appendQueryParam(verified.returnTo, 'success=slack_installed')
+      : owner.type === 'org'
         ? `/organizations/${owner.id}/integrations/slack?success=installed`
         : `/integrations/slack?success=installed`;
 

--- a/apps/web/src/app/collab/_components/BotWizard.tsx
+++ b/apps/web/src/app/collab/_components/BotWizard.tsx
@@ -52,8 +52,11 @@ export function BotWizard() {
 
   const proceedToAuthorize = () => {
     setMissingPlatformWarning(null);
-    const services = Array.from(selected).join(',');
-    router.push(`/collab/authorize?services=${encodeURIComponent(services)}`);
+    const params = new URLSearchParams({ services: Array.from(selected).join(',') });
+    if (workspace?.type === 'org') {
+      params.set('organizationId', workspace.id);
+    }
+    router.push(`/collab/authorize?${params.toString()}`);
   };
 
   const handleContinueWithoutRecommendedPlatform = () => {

--- a/apps/web/src/app/collab/authorize/_components/AuthorizeFlow.tsx
+++ b/apps/web/src/app/collab/authorize/_components/AuthorizeFlow.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { useState } from 'react';
-import { Check, ChevronRight } from 'lucide-react';
+import { AlertCircle, Check, ChevronRight } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useRouter } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import KiloLogo from '@/components/KiloLogo';
+import { useTRPC } from '@/lib/trpc/utils';
+import { useUser } from '@/hooks/useUser';
 import { getPlatform, type PlatformId, type PlatformOption } from '../../_components/platforms';
 
 type ProgressListProps = {
@@ -16,33 +19,80 @@ type ProgressListProps = {
 
 type AuthorizeFlowProps = {
   serviceIds: PlatformId[];
+  organizationId?: string;
+  initialIndex: number;
 };
 
 export function AuthorizeFlow(props: AuthorizeFlowProps) {
-  const { serviceIds } = props;
+  const { serviceIds, organizationId, initialIndex } = props;
   const router = useRouter();
-  const [index, setIndex] = useState(0);
-  const [done, setDone] = useState(false);
+  const trpc = useTRPC();
+  const { data: user } = useUser();
+  const [index, setIndex] = useState(initialIndex);
+  const [done, setDone] = useState(initialIndex >= serviceIds.length);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
 
   const services = serviceIds.map(id => getPlatform(id)).filter(p => p !== undefined);
   const current = services[index];
   const isLast = index === services.length - 1;
+  const returnTo = buildReturnToPath({ serviceIds, organizationId, step: index });
+  const oauthInput = {
+    ...(organizationId ? { organizationId } : {}),
+    returnTo,
+  };
 
-  const handleAuthorize = () => {
-    // Design-only: simulate a successful OAuth round trip.
-    if (!isLast) {
-      setIndex(i => i + 1);
-    } else {
+  const { refetch: refetchSlackOAuthUrl, isFetching: isFetchingSlackOAuthUrl } = useQuery(
+    trpc.slack.getOAuthUrl.queryOptions(oauthInput, { enabled: false })
+  );
+  const { refetch: refetchDiscordOAuthUrl, isFetching: isFetchingDiscordOAuthUrl } = useQuery(
+    trpc.discord.getOAuthUrl.queryOptions(oauthInput, { enabled: false })
+  );
+  const { refetch: refetchLinearOAuthUrl, isFetching: isFetchingLinearOAuthUrl } = useQuery(
+    trpc.linear.getOAuthUrl.queryOptions(oauthInput, { enabled: false })
+  );
+
+  const isLoadingGitHubUser = current?.id === 'github' && !organizationId && !user;
+  const isStartingOAuth =
+    isFetchingSlackOAuthUrl || isFetchingDiscordOAuthUrl || isFetchingLinearOAuthUrl;
+
+  const advance = () => {
+    setConnectionError(null);
+    if (isLast) {
       setDone(true);
+      return;
+    }
+    setIndex(i => i + 1);
+  };
+
+  const handleAuthorize = async () => {
+    if (!current || isStartingOAuth || isLoadingGitHubUser) return;
+    setConnectionError(null);
+
+    try {
+      const oauthUrl = await getOAuthUrl(current.id, {
+        organizationId,
+        returnTo,
+        userId: user?.id,
+        getSlackOAuthUrl: refetchSlackOAuthUrl,
+        getDiscordOAuthUrl: refetchDiscordOAuthUrl,
+        getLinearOAuthUrl: refetchLinearOAuthUrl,
+      });
+
+      if (!oauthUrl) {
+        setConnectionError(`${current.name} setup is not available from this flow yet.`);
+        return;
+      }
+
+      window.location.href = oauthUrl;
+    } catch (error) {
+      setConnectionError(
+        error instanceof Error ? error.message : `Couldn't start ${current.name}.`
+      );
     }
   };
 
   const handleSkip = () => {
-    if (!isLast) {
-      setIndex(i => i + 1);
-    } else {
-      setDone(true);
-    }
+    advance();
   };
 
   if (done || !current) {
@@ -79,8 +129,21 @@ export function AuthorizeFlow(props: AuthorizeFlowProps) {
           </div>
 
           <div className="flex w-full flex-col items-center gap-4">
-            <Button onClick={handleAuthorize} size="lg" className="w-full">
-              Authorize on {current.name}
+            {connectionError && (
+              <p className="text-destructive flex items-center gap-2 text-sm" role="alert">
+                <AlertCircle className="size-4" />
+                {connectionError}
+              </p>
+            )}
+            <Button
+              onClick={handleAuthorize}
+              size="lg"
+              className="w-full"
+              disabled={isStartingOAuth || isLoadingGitHubUser}
+            >
+              {isStartingOAuth || isLoadingGitHubUser
+                ? 'Starting authorization...'
+                : `Authorize on ${current.name}`}
               <ChevronRight className="size-4" />
             </Button>
             <button
@@ -95,6 +158,59 @@ export function AuthorizeFlow(props: AuthorizeFlowProps) {
       </AnimatePresence>
     </div>
   );
+}
+
+function buildReturnToPath({
+  serviceIds,
+  organizationId,
+  step,
+}: {
+  serviceIds: PlatformId[];
+  organizationId?: string;
+  step: number;
+}): string {
+  const params = new URLSearchParams({ services: serviceIds.join(','), step: step.toString() });
+  if (organizationId) params.set('organizationId', organizationId);
+  return `/collab/authorize?${params.toString()}`;
+}
+
+async function getOAuthUrl(
+  platformId: PlatformId,
+  options: {
+    organizationId?: string;
+    returnTo: string;
+    userId?: string;
+    getSlackOAuthUrl: () => Promise<{ data?: { url: string } }>;
+    getDiscordOAuthUrl: () => Promise<{ data?: { url: string } }>;
+    getLinearOAuthUrl: () => Promise<{ data?: { url: string } }>;
+  }
+): Promise<string | null> {
+  if (platformId === 'slack') {
+    return (await options.getSlackOAuthUrl()).data?.url ?? null;
+  }
+  if (platformId === 'discord') {
+    return (await options.getDiscordOAuthUrl()).data?.url ?? null;
+  }
+  if (platformId === 'linear') {
+    return (await options.getLinearOAuthUrl()).data?.url ?? null;
+  }
+  if (platformId === 'gitlab') {
+    const params = new URLSearchParams({ returnTo: options.returnTo });
+    if (options.organizationId) params.set('organizationId', options.organizationId);
+    return `/api/integrations/gitlab/connect?${params.toString()}`;
+  }
+  if (platformId === 'github') {
+    const ownerToken = options.organizationId
+      ? `org_${options.organizationId}`
+      : options.userId
+        ? `user_${options.userId}`
+        : null;
+    if (!ownerToken) return null;
+    const githubAppName = process.env.NEXT_PUBLIC_GITHUB_APP_NAME || 'KiloConnect';
+    const state = `${ownerToken}|return=${encodeURIComponent(options.returnTo)}`;
+    return `https://github.com/apps/${githubAppName}/installations/new?state=${encodeURIComponent(state)}`;
+  }
+  return null;
 }
 
 function ConnectionBadge({ service }: { service: PlatformOption }) {

--- a/apps/web/src/app/collab/authorize/_components/AuthorizeFlow.tsx
+++ b/apps/web/src/app/collab/authorize/_components/AuthorizeFlow.tsx
@@ -21,16 +21,17 @@ type AuthorizeFlowProps = {
   serviceIds: PlatformId[];
   organizationId?: string;
   initialIndex: number;
+  initialError?: string;
 };
 
 export function AuthorizeFlow(props: AuthorizeFlowProps) {
-  const { serviceIds, organizationId, initialIndex } = props;
+  const { serviceIds, organizationId, initialIndex, initialError } = props;
   const router = useRouter();
   const trpc = useTRPC();
   const { data: user } = useUser();
   const [index, setIndex] = useState(initialIndex);
   const [done, setDone] = useState(initialIndex >= serviceIds.length);
-  const [connectionError, setConnectionError] = useState<string | null>(null);
+  const [connectionError, setConnectionError] = useState<string | null>(initialError ?? null);
 
   const services = serviceIds.map(id => getPlatform(id)).filter(p => p !== undefined);
   const current = services[index];

--- a/apps/web/src/app/collab/authorize/page.tsx
+++ b/apps/web/src/app/collab/authorize/page.tsx
@@ -41,7 +41,14 @@ function hasSuccessfulCallback(params: NextAppSearchParams | undefined): boolean
     ? params.github_pending_approval[0]
     : params?.github_pending_approval;
 
-  return success !== undefined || githubInstall === 'success' || githubPendingApproval === 'true';
+  return (
+    success === 'slack_installed' ||
+    success === 'discord_installed' ||
+    success === 'linear_installed' ||
+    success === 'gitlab_connected' ||
+    githubInstall === 'success' ||
+    githubPendingApproval === 'true'
+  );
 }
 
 export default async function CollabAuthorizePage({ searchParams }: AppPageProps) {

--- a/apps/web/src/app/collab/authorize/page.tsx
+++ b/apps/web/src/app/collab/authorize/page.tsx
@@ -25,16 +25,44 @@ function parseServices(raw: string | string[] | undefined): PlatformId[] {
   return Array.from(seen);
 }
 
+function parseStep(raw: string | string[] | undefined, serviceCount: number): number {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  const parsed = value ? Number.parseInt(value, 10) : 0;
+  if (!Number.isInteger(parsed) || parsed < 0) return 0;
+  return Math.min(parsed, serviceCount);
+}
+
+function hasSuccessfulCallback(params: NextAppSearchParams | undefined): boolean {
+  const success = Array.isArray(params?.success) ? params.success[0] : params?.success;
+  const githubInstall = Array.isArray(params?.github_install)
+    ? params.github_install[0]
+    : params?.github_install;
+  const githubPendingApproval = Array.isArray(params?.github_pending_approval)
+    ? params.github_pending_approval[0]
+    : params?.github_pending_approval;
+
+  return success !== undefined || githubInstall === 'success' || githubPendingApproval === 'true';
+}
+
 export default async function CollabAuthorizePage({ searchParams }: AppPageProps) {
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/collab');
   if (user.is_admin !== true) notFound();
 
   const params = await searchParams;
   const services = parseServices(params?.services);
+  const organizationId = Array.isArray(params?.organizationId)
+    ? params.organizationId[0]
+    : params?.organizationId;
+  const step = parseStep(params?.step, services.length);
+  const initialIndex = hasSuccessfulCallback(params) ? Math.min(step + 1, services.length) : step;
 
   return (
     <KiloCardLayout bare className="max-w-xl" contentClassName="">
-      <AuthorizeFlow serviceIds={services} />
+      <AuthorizeFlow
+        serviceIds={services}
+        organizationId={organizationId}
+        initialIndex={initialIndex}
+      />
     </KiloCardLayout>
   );
 }

--- a/apps/web/src/app/collab/authorize/page.tsx
+++ b/apps/web/src/app/collab/authorize/page.tsx
@@ -51,6 +51,30 @@ function hasSuccessfulCallback(params: NextAppSearchParams | undefined): boolean
   );
 }
 
+function getCallbackError(params: NextAppSearchParams | undefined): string | undefined {
+  const error = Array.isArray(params?.error) ? params.error[0] : params?.error;
+  if (!error) return undefined;
+
+  const messages: Record<string, string> = {
+    access_denied: 'Authorization was canceled. You can try again or skip this service for now.',
+    connection_failed: 'Authorization failed. You can try again or skip this service for now.',
+    installation_failed: 'Installation failed. You can try again or skip this service for now.',
+    invalid_state: 'This authorization session expired. Start authorization again to continue.',
+    missing_code: 'The service did not return an authorization code. Try authorizing again.',
+    missing_installation_id: 'GitHub did not return an installation ID. Try authorizing again.',
+    oauth_init_failed:
+      'Authorization could not be started. Try again or skip this service for now.',
+    pending_installation_exists:
+      'You already have a pending GitHub installation. Complete or cancel it before trying again.',
+    pending_setup_failed: 'The pending GitHub installation could not be saved. Try again.',
+    unauthorized: 'This authorization was started by another user. Start authorization again.',
+    workspace_already_connected:
+      'That workspace is already connected elsewhere. Choose another workspace or skip this service.',
+  };
+
+  return messages[error] ?? 'Authorization failed. You can try again or skip this service for now.';
+}
+
 export default async function CollabAuthorizePage({ searchParams }: AppPageProps) {
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/collab');
   if (user.is_admin !== true) notFound();
@@ -61,7 +85,9 @@ export default async function CollabAuthorizePage({ searchParams }: AppPageProps
     ? params.organizationId[0]
     : params?.organizationId;
   const step = parseStep(params?.step, services.length);
-  const initialIndex = hasSuccessfulCallback(params) ? Math.min(step + 1, services.length) : step;
+  const successfulCallback = hasSuccessfulCallback(params);
+  const initialIndex = successfulCallback ? Math.min(step + 1, services.length) : step;
+  const initialError = successfulCallback ? undefined : getCallbackError(params);
 
   return (
     <KiloCardLayout bare className="max-w-xl" contentClassName="">
@@ -69,6 +95,7 @@ export default async function CollabAuthorizePage({ searchParams }: AppPageProps
         serviceIds={services}
         organizationId={organizationId}
         initialIndex={initialIndex}
+        initialError={initialError}
       />
     </KiloCardLayout>
   );

--- a/apps/web/src/lib/integrations/oauth-state.ts
+++ b/apps/web/src/lib/integrations/oauth-state.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 import crypto from 'node:crypto';
 import { NEXTAUTH_SECRET } from '@/lib/config.server';
+import { validateReturnPath } from '@/lib/integrations/validate-return-path';
 
 /**
  * HMAC-signed OAuth state parameter.
@@ -46,12 +47,19 @@ function sign(data: string): string {
  * @param owner  – owner string, e.g. `user_abc123` or `org_xyz789`
  * @param userId – the ID of the currently-authenticated user initiating the flow
  */
-export function createOAuthState(owner: string, userId: string): string {
+export function createOAuthState(owner: string, userId: string, returnTo?: string): string {
   const iat = Math.floor(Date.now() / 1000);
   const nonce = crypto.randomBytes(NONCE_BYTES).toString('base64url');
-  const payload = Buffer.from(JSON.stringify({ owner, uid: userId, iat, nonce })).toString(
-    'base64url'
-  );
+  const safeReturnTo = returnTo ? validateReturnPath(returnTo) : null;
+  const payload = Buffer.from(
+    JSON.stringify({
+      owner,
+      uid: userId,
+      iat,
+      nonce,
+      ...(safeReturnTo ? { returnTo: safeReturnTo } : {}),
+    })
+  ).toString('base64url');
   const signature = sign(payload);
   return `${payload}.${signature}`;
 }
@@ -61,6 +69,8 @@ export type VerifiedOAuthState = {
   owner: string;
   /** The user ID that initiated the OAuth flow */
   userId: string;
+  /** Optional relative path to return to after the OAuth callback. */
+  returnTo?: string;
 };
 
 /**
@@ -95,6 +105,7 @@ export function verifyOAuthState(state: string | null): VerifiedOAuthState | nul
       uid?: string;
       iat?: number;
       nonce?: string;
+      returnTo?: string;
     };
     if (typeof data.owner !== 'string' || typeof data.uid !== 'string') return null;
 
@@ -106,7 +117,9 @@ export function verifyOAuthState(state: string | null): VerifiedOAuthState | nul
     // Require nonce to be present (guards against old-format tokens)
     if (typeof data.nonce !== 'string' || data.nonce.length === 0) return null;
 
-    return { owner: data.owner, userId: data.uid };
+    const returnTo = typeof data.returnTo === 'string' ? validateReturnPath(data.returnTo) : null;
+
+    return { owner: data.owner, userId: data.uid, ...(returnTo ? { returnTo } : {}) };
   } catch {
     return null;
   }

--- a/apps/web/src/lib/integrations/platforms/gitlab/oauth-state.test.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/oauth-state.test.ts
@@ -38,6 +38,23 @@ describe('gitlab oauth state', () => {
     });
   });
 
+  test('round-trips a safe return path', () => {
+    const state = createGitLabOAuthState(
+      {
+        owner: { type: 'user', id: 'user_123' },
+        returnTo: '/collab/authorize?services=gitlab&step=0',
+      },
+      'user_123'
+    );
+
+    expect(verifyGitLabOAuthState(state)).toEqual({
+      owner: { type: 'user', id: 'user_123' },
+      instanceUrl: DEFAULT_GITLAB_OAUTH_INSTANCE_URL,
+      returnTo: '/collab/authorize?services=gitlab&step=0',
+      userId: 'user_123',
+    });
+  });
+
   test('rejects tampered state', () => {
     const state = createGitLabOAuthState(
       {

--- a/apps/web/src/lib/integrations/platforms/gitlab/oauth-state.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/oauth-state.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { z } from 'zod';
 import { createOAuthState, verifyOAuthState } from '@/lib/integrations/oauth-state';
+import { validateReturnPath } from '@/lib/integrations/validate-return-path';
 
 const GITLAB_OAUTH_STATE_PREFIX = 'gitlab:';
 
@@ -23,6 +24,10 @@ const GitLabOAuthStatePayloadSchema = z.object({
   ]),
   instanceUrl: z.string().url().refine(isHttpInstanceUrl).optional(),
   customCredentialsRef: z.string().min(1).optional(),
+  returnTo: z
+    .string()
+    .refine(value => validateReturnPath(value) !== null)
+    .optional(),
 });
 
 export type GitLabOAuthStatePayload = z.infer<typeof GitLabOAuthStatePayloadSchema>;

--- a/apps/web/src/routers/discord-router.ts
+++ b/apps/web/src/routers/discord-router.ts
@@ -11,6 +11,11 @@ import {
 } from '@/lib/integrations/resolve-owner';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
+import { validateReturnPath } from '@/lib/integrations/validate-return-path';
+
+const oauthUrlInput = z
+  .object({ organizationId: z.string().uuid().optional(), returnTo: z.string().optional() })
+  .optional();
 
 export const discordRouter = createTRPCRouter({
   // Get Discord installation status
@@ -44,14 +49,15 @@ export const discordRouter = createTRPCRouter({
   }),
 
   // Get OAuth URL for initiating Discord OAuth flow
-  getOAuthUrl: baseProcedure.input(optionalOrgInput).query(async ({ ctx, input }) => {
+  getOAuthUrl: baseProcedure.input(oauthUrlInput).query(async ({ ctx, input }) => {
     if (input?.organizationId) {
       await ensureOrganizationAccess(ctx, input.organizationId);
     }
     const statePrefix = input?.organizationId
       ? `org_${input.organizationId}`
       : `user_${ctx.user.id}`;
-    const state = createOAuthState(statePrefix, ctx.user.id);
+    const returnTo = input?.returnTo ? validateReturnPath(input.returnTo) : undefined;
+    const state = createOAuthState(statePrefix, ctx.user.id, returnTo ?? undefined);
     return {
       url: discordService.getDiscordOAuthUrl(state),
     };

--- a/apps/web/src/routers/linear-router.ts
+++ b/apps/web/src/routers/linear-router.ts
@@ -14,6 +14,11 @@ import { requireActiveSubscriptionOrTrial } from '@/lib/organizations/trial-midd
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
 import { unlinkTeamKiloUsers } from '@/lib/bot-identity';
 import { PLATFORM } from '@/lib/integrations/core/constants';
+import { validateReturnPath } from '@/lib/integrations/validate-return-path';
+
+const oauthUrlInput = z
+  .object({ organizationId: z.string().uuid().optional(), returnTo: z.string().optional() })
+  .optional();
 
 // Dynamic import to avoid a circular dependency with @/lib/bot (which imports
 // the bot-platform registry, which imports this router's service layer).
@@ -69,7 +74,7 @@ export const linearRouter = createTRPCRouter({
     };
   }),
 
-  getOAuthUrl: baseProcedure.input(optionalOrgInput).query(async ({ ctx, input }) => {
+  getOAuthUrl: baseProcedure.input(oauthUrlInput).query(async ({ ctx, input }) => {
     if (input?.organizationId) {
       await ensureOrganizationAccess(ctx, input.organizationId, ['owner', 'billing_manager']);
       await requireActiveSubscriptionOrTrial(input.organizationId);
@@ -77,7 +82,8 @@ export const linearRouter = createTRPCRouter({
     const statePrefix = input?.organizationId
       ? `org_${input.organizationId}`
       : `user_${ctx.user.id}`;
-    const state = createOAuthState(statePrefix, ctx.user.id);
+    const returnTo = input?.returnTo ? validateReturnPath(input.returnTo) : undefined;
+    const state = createOAuthState(statePrefix, ctx.user.id, returnTo ?? undefined);
     return { url: linearService.getLinearOAuthUrl(state) };
   }),
 

--- a/apps/web/src/routers/slack-router.ts
+++ b/apps/web/src/routers/slack-router.ts
@@ -13,6 +13,11 @@ import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { requireActiveSubscriptionOrTrial } from '@/lib/organizations/trial-middleware';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
 import { unlinkTeamKiloUsers } from '@/lib/bot-identity';
+import { validateReturnPath } from '@/lib/integrations/validate-return-path';
+
+const oauthUrlInput = z
+  .object({ organizationId: z.string().uuid().optional(), returnTo: z.string().optional() })
+  .optional();
 
 async function getInitializedBot() {
   const { bot } = await import('@/lib/bot');
@@ -66,14 +71,15 @@ export const slackRouter = createTRPCRouter({
   }),
 
   // Get OAuth URL for initiating Slack OAuth flow
-  getOAuthUrl: baseProcedure.input(optionalOrgInput).query(async ({ ctx, input }) => {
+  getOAuthUrl: baseProcedure.input(oauthUrlInput).query(async ({ ctx, input }) => {
     if (input?.organizationId) {
       await ensureOrganizationAccess(ctx, input.organizationId);
     }
     const statePrefix = input?.organizationId
       ? `org_${input.organizationId}`
       : `user_${ctx.user.id}`;
-    const state = createOAuthState(statePrefix, ctx.user.id);
+    const returnTo = input?.returnTo ? validateReturnPath(input.returnTo) : undefined;
+    const state = createOAuthState(statePrefix, ctx.user.id, returnTo ?? undefined);
     return {
       url: slackService.getSlackOAuthUrl(state),
     };


### PR DESCRIPTION
## Summary

- Connect the collab authorization wizard to real OAuth entry points for Slack, Discord, Linear, GitHub, and GitLab.
- Add signed relative return paths so OAuth callbacks can resume the multi-service collab setup flow safely.
- Normalize GitHub callback redirects through the configured app URL so callback host aliases such as 0.0.0.0 do not leak into app redirects.

## Verification

- Not manually verified end-to-end; the GitHub App install callback requires the external GitHub App flow and local app configuration.

## Visual Changes

N/A

## Reviewer Notes

- Review return-path handling across OAuth callbacks, especially error-path query parameters.
- GitHub App install redirects now use APP_URL as the redirect base instead of preserving the incoming callback host.