### PR TITLE
feat(integrations): make DoltHub generally available

### DIFF
--- a/apps/web/src/lib/integrations/platform-definitions.ts
+++ b/apps/web/src/lib/integrations/platform-definitions.ts
@@ -1,5 +1,4 @@
 import { PLATFORM } from '@/lib/integrations/core/constants';
-import { IS_DEVELOPMENT } from '@/lib/constants';
 
 export type PlatformType =
   | 'github'
@@ -81,7 +80,7 @@ export const PLATFORM_DEFINITIONS: PlatformDefinition[] = [
     id: PLATFORM.DOLTHUB,
     name: 'DoltHub',
     description: 'Query Dolt-versioned data directly from your workspace',
-    enabled: IS_DEVELOPMENT,
+    enabled: true,
     personalRoute: '/integrations/dolthub',
     orgRoute: organizationId => `/organizations/${organizationId}/integrations/dolthub`,
   },


### PR DESCRIPTION
## Summary

- Flip the DoltHub integration's `enabled` flag from `IS_DEVELOPMENT` to `true` in `apps/web/src/lib/integrations/platform-definitions.ts` so the integrations card no longer renders the "Coming Soon" badge or the disabled "This integration will be available soon" footer in production.
- Drop the now-unused `IS_DEVELOPMENT` import from the same file.

The card itself (`PlatformCard.tsx`) is data-driven off `enabled` / `status`, so no component changes were needed. With `enabled: true`, `getStatus` resolves to `installed` or `not_installed` based on the user/org's actual installation state, and the card renders the standard "Configure" / "Manage Integration" CTA.

## Verification

- Inspected the diff: only the DoltHub `enabled` field and the obsolete import changed; all other platform definitions are untouched.
- Confirmed `PlatformCard.tsx` consumes `platform.enabled` and `platform.status` directly, so no UI-side guard needed updating.

## Visual Changes

Before: DoltHub card showed a "Coming Soon" badge with a disabled, low-opacity card and the footer "This integration will be available soon".

<img width="1551" height="1237" alt="image" src="https://github.com/user-attachments/assets/1299a80d-0254-4c8c-ba91-4c0cf975a49b" />

## Reviewer Notes

- The DoltHub OAuth flow, tRPC routers, and `/integrations/dolthub` route already exist and were previously gated only by this card's `enabled` flag. Verify in production that the Vercel env has the DoltHub OAuth client ID/secret set for the production environment before rolling out, or the "Configure" flow will fail at the OAuth step rather than gracefully.