### PR TITLE
fix(cloud-agent-next): provision devcontainer runtime tools

### DIFF
--- a/services/cloud-agent-next/src/kilo/devcontainer.test.ts
+++ b/services/cloud-agent-next/src/kilo/devcontainer.test.ts
@@ -115,7 +115,113 @@ describe('parseUpOutcome', () => {
 });
 
 describe('bringUpDevContainer', () => {
-  it('tears down the container when the tool preflight fails after devcontainer up', async () => {
+  it('bootstraps runtime tools after devcontainer up when the preflight reports them missing', async () => {
+    let preflightCount = 0;
+    const onProgress = vi.fn();
+    const session = mockSessionExec(cmd => {
+      if (cmd.includes('if [ -S /var/run/docker.sock ]')) {
+        return { exitCode: 0, stdout: '/var/run/docker.sock' };
+      }
+      if (cmd === 'docker version --format {{.Server.Version}}') {
+        return { exitCode: 0, stdout: '27.0.0' };
+      }
+      if (cmd.includes('__KILO_READ_DEVCONTAINER_EOF__')) {
+        return { exitCode: 0, stdout: '{"image":"debian:bookworm"}' };
+      }
+      if (cmd.startsWith('devcontainer up ')) {
+        return {
+          exitCode: 0,
+          stdout:
+            '{"outcome":"success","containerId":"deadbeef","remoteWorkspaceFolder":"/workspaces/repo"}',
+        };
+      }
+      if (cmd.includes('command -v bun')) {
+        preflightCount += 1;
+        return preflightCount === 1 ? { exitCode: 0, stdout: 'MISSING' } : { exitCode: 0 };
+      }
+      return { exitCode: 0, stdout: '' };
+    });
+
+    const handle = await bringUpDevContainer(session, {
+      workspacePath: '/workspace/repo',
+      sessionHome: '/home/agent_xyz',
+      agentSessionId: 'agent_xyz',
+      wrapperPort: 5050,
+      kiloCliVersion: '7.2.52',
+      configPath: '.devcontainer/devcontainer.json',
+      onProgress,
+    });
+
+    expect(handle.containerId).toBe('deadbeef');
+    expect(onProgress.mock.calls.map(([message]) => message)).toEqual([
+      'Preparing dev container configuration…',
+      'Building dev container…',
+      'Checking dev container runtime…',
+      'Installing runtime tools in dev container…',
+      'Checking dev container runtime…',
+    ]);
+    const commands = (
+      session.exec as unknown as { mock: { calls: Array<[string]> } }
+    ).mock.calls.map(([cmd]) => cmd);
+    expect(preflightCount).toBe(2);
+    expect(commands.some(cmd => cmd.includes('bun --version'))).toBe(true);
+    expect(commands.some(cmd => cmd.includes('nvm install --lts'))).toBe(true);
+    expect(commands.some(cmd => cmd.includes('nvm use --lts'))).toBe(false);
+    expect(commands.some(cmd => cmd.includes('curl -fsSL https://bun.sh/install | bash'))).toBe(
+      true
+    );
+    expect(commands.some(cmd => cmd.includes('@kilocode/cli@7.2.52'))).toBe(true);
+    expect(commands.some(cmd => cmd.includes('set -euo pipefail'))).toBe(true);
+    expect(commands.some(cmd => cmd.includes('/usr/local/bin/bun'))).toBe(true);
+    expect(commands.some(cmd => cmd.includes('/usr/local/bin/kilo'))).toBe(true);
+    expect(commands.some(cmd => cmd.startsWith('devcontainer down '))).toBe(false);
+  });
+
+  it('tears down the container when runtime bootstrap fails', async () => {
+    const session = mockSessionExec(cmd => {
+      if (cmd.includes('if [ -S /var/run/docker.sock ]')) {
+        return { exitCode: 0, stdout: '/var/run/docker.sock' };
+      }
+      if (cmd === 'docker version --format {{.Server.Version}}') {
+        return { exitCode: 0, stdout: '27.0.0' };
+      }
+      if (cmd.includes('__KILO_READ_DEVCONTAINER_EOF__')) {
+        return { exitCode: 0, stdout: '{"image":"debian:bookworm"}' };
+      }
+      if (cmd.startsWith('devcontainer up ')) {
+        return {
+          exitCode: 0,
+          stdout:
+            '{"outcome":"success","containerId":"deadbeef","remoteWorkspaceFolder":"/workspaces/repo"}',
+        };
+      }
+      if (cmd.includes('command -v bun')) {
+        return { exitCode: 0, stdout: 'MISSING' };
+      }
+      if (cmd.includes('nvm install --lts')) {
+        return { exitCode: 1, stdout: '', stderr: 'curl failed' };
+      }
+      return { exitCode: 0, stdout: '' };
+    });
+
+    await expect(
+      bringUpDevContainer(session, {
+        workspacePath: '/workspace/repo',
+        sessionHome: '/home/agent_xyz',
+        agentSessionId: 'agent_xyz',
+        wrapperPort: 5050,
+        kiloCliVersion: '7.2.52',
+        configPath: '.devcontainer/devcontainer.json',
+      })
+    ).rejects.toThrow('Failed to bootstrap dev container runtime tools');
+
+    const commands = (
+      session.exec as unknown as { mock: { calls: Array<[string]> } }
+    ).mock.calls.map(([cmd]) => cmd);
+    expect(commands.some(cmd => cmd.startsWith('devcontainer down '))).toBe(true);
+  });
+
+  it('tears down the container when bootstrap finishes without making runtime tools available', async () => {
     const session = mockSessionExec(cmd => {
       if (cmd.includes('if [ -S /var/run/docker.sock ]')) {
         return { exitCode: 0, stdout: '/var/run/docker.sock' };
@@ -148,7 +254,7 @@ describe('bringUpDevContainer', () => {
         kiloCliVersion: '7.2.52',
         configPath: '.devcontainer/devcontainer.json',
       })
-    ).rejects.toThrow('Dev container is missing required tools');
+    ).rejects.toThrow('Dev container runtime bootstrap completed');
 
     const commands = (
       session.exec as unknown as { mock: { calls: Array<[string]> } }

--- a/services/cloud-agent-next/src/kilo/devcontainer.test.ts
+++ b/services/cloud-agent-next/src/kilo/devcontainer.test.ts
@@ -160,20 +160,32 @@ describe('bringUpDevContainer', () => {
       'Installing runtime tools in dev container…',
       'Checking dev container runtime…',
     ]);
-    const commands = (
-      session.exec as unknown as { mock: { calls: Array<[string]> } }
-    ).mock.calls.map(([cmd]) => cmd);
+    const execCalls = (
+      session.exec as unknown as {
+        mock: {
+          calls: Array<[string, { env?: Record<string, string>; timeout?: number } | undefined]>;
+        };
+      }
+    ).mock.calls;
+    const commands = execCalls.map(([cmd]) => cmd);
+    const bootstrapCall = execCalls.find(([cmd]) => cmd.includes('nvm install --lts'));
     expect(preflightCount).toBe(2);
     expect(commands.some(cmd => cmd.includes('bun --version'))).toBe(true);
     expect(commands.some(cmd => cmd.includes('nvm install --lts'))).toBe(true);
     expect(commands.some(cmd => cmd.includes('nvm use --lts'))).toBe(false);
-    expect(commands.some(cmd => cmd.includes('curl -fsSL https://bun.sh/install | bash'))).toBe(
-      true
-    );
+    expect(
+      commands.some(cmd =>
+        cmd.includes('curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"')
+      )
+    ).toBe(true);
     expect(commands.some(cmd => cmd.includes('@kilocode/cli@7.2.52'))).toBe(true);
     expect(commands.some(cmd => cmd.includes('set -euo pipefail'))).toBe(true);
     expect(commands.some(cmd => cmd.includes('/usr/local/bin/bun'))).toBe(true);
     expect(commands.some(cmd => cmd.includes('/usr/local/bin/kilo'))).toBe(true);
+    expect(bootstrapCall?.[1]).toEqual({
+      env: { DOCKER_HOST: 'unix:///var/run/docker.sock' },
+      timeout: 10 * 60 * 1000,
+    });
     expect(commands.some(cmd => cmd.startsWith('devcontainer down '))).toBe(false);
   });
 

--- a/services/cloud-agent-next/src/kilo/devcontainer.ts
+++ b/services/cloud-agent-next/src/kilo/devcontainer.ts
@@ -67,6 +67,8 @@ export type BringUpOptions = {
   wrapperPort: number;
   /** Pinned `@kilocode/cli` version installed inside the dev container. */
   kiloCliVersion: string;
+  /** Optional milestone callback surfaced to preparation status streams. */
+  onProgress?: (message: string) => void;
   /**
    * Path (relative to workspace root) of the detected devcontainer config,
    * as returned by `detectDevContainer`. Passed through so `readDevContainerConfig`
@@ -211,6 +213,83 @@ export async function detectDevContainer(
 // Bring up
 // ---------------------------------------------------------------------------
 
+type DevContainerRuntimeCommandOptions = {
+  workspacePath: string;
+  overridePath: string;
+  agentSessionId: string;
+};
+
+type BootstrapDevContainerRuntimeOptions = DevContainerRuntimeCommandOptions & {
+  kiloCliVersion: string;
+};
+
+function buildDevContainerRuntimeExecCommand(
+  opts: DevContainerRuntimeCommandOptions,
+  shellCommand: string,
+  shell: 'sh -c' | 'bash -lc'
+): string {
+  return [
+    'devcontainer exec',
+    `--workspace-folder ${shellQuote(opts.workspacePath)}`,
+    `--config ${shellQuote(opts.overridePath)}`,
+    `--id-label ${shellQuote(`${KILO_AGENT_SESSION_LABEL}=${opts.agentSessionId}`)}`,
+    '--',
+    shell,
+    shellQuote(shellCommand),
+  ].join(' ');
+}
+
+async function runDevContainerRuntimePreflight(
+  session: ExecutionSession,
+  opts: DevContainerRuntimeCommandOptions,
+  dockerEnv: Record<string, string>
+) {
+  const command = buildDevContainerRuntimeExecCommand(
+    opts,
+    'command -v bun >/dev/null && bun --version >/dev/null 2>&1 && command -v kilo >/dev/null || echo MISSING',
+    'sh -c'
+  );
+  return session.exec(command, { env: dockerEnv });
+}
+
+function devContainerRuntimeToolsMissing(
+  result: Awaited<ReturnType<ExecutionSession['exec']>>
+): boolean {
+  return (result.stdout ?? '').includes('MISSING') || result.exitCode !== 0;
+}
+
+async function bootstrapDevContainerRuntimeTools(
+  session: ExecutionSession,
+  opts: BootstrapDevContainerRuntimeOptions,
+  dockerEnv: Record<string, string>
+): Promise<void> {
+  const installCommand = [
+    'set -euo pipefail',
+    'export NVM_DIR=/usr/local/share/nvm',
+    'mkdir -p "$NVM_DIR" /usr/local/bin',
+    'if [ ! -s "$NVM_DIR/nvm.sh" ]; then curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | PROFILE=/dev/null NVM_DIR="$NVM_DIR" bash; fi',
+    '. "$NVM_DIR/nvm.sh"',
+    'nvm install --lts',
+    "nvm alias default 'lts/*'",
+    'ln -sf "$(command -v node)" /usr/local/bin/node',
+    'ln -sf "$(command -v npm)" /usr/local/bin/npm',
+    'ln -sf "$(command -v npx)" /usr/local/bin/npx',
+    'curl -fsSL https://bun.sh/install | bash',
+    'ln -sf "$HOME/.bun/bin/bun" /usr/local/bin/bun',
+    `npm install -g ${shellQuote(`@kilocode/cli@${opts.kiloCliVersion}`)}`,
+    'ln -sf "$(command -v kilo)" /usr/local/bin/kilo',
+  ].join(' && ');
+  const command = buildDevContainerRuntimeExecCommand(opts, installCommand, 'bash -lc');
+  const result = await session.exec(command, { env: dockerEnv });
+  if (result.exitCode !== 0) {
+    throw new DevContainerUpError(
+      `Failed to bootstrap dev container runtime tools (exit ${result.exitCode})`,
+      result.stdout ?? '',
+      result.stderr ?? ''
+    );
+  }
+}
+
 /**
  * Run `devcontainer up` for the cloned workspace and install kilo inside.
  *
@@ -222,8 +301,15 @@ export async function bringUpDevContainer(
   session: ExecutionSession,
   opts: BringUpOptions
 ): Promise<DevContainerHandle> {
-  const { workspacePath, sessionHome, agentSessionId, wrapperPort, kiloCliVersion, configPath } =
-    opts;
+  const {
+    workspacePath,
+    sessionHome,
+    agentSessionId,
+    wrapperPort,
+    kiloCliVersion,
+    configPath,
+    onProgress,
+  } = opts;
 
   // devcontainer/docker CLIs need DOCKER_HOST pointing at the sandbox dockerd
   // socket, which may differ between local smoke images and Cloudflare runtime.
@@ -245,6 +331,8 @@ export async function bringUpDevContainer(
     `mkdir -p "${sessionHome}/.cache" "${sessionHome}/.local/share/kilo" "${sessionHome}/tmp"`,
     { timeout: 10_000 }
   );
+
+  onProgress?.('Preparing dev container configuration…');
 
   // 1. Build merged config. `@devcontainers/cli` treats an override file as the
   // complete config unless the base config is passed explicitly via `--config`.
@@ -278,6 +366,7 @@ export async function bringUpDevContainer(
   // `.devcontainer/devcontainer.json` and resets `remoteUser` to whatever
   // the user declared (typically `vscode`), breaking writes into the
   // bind-mounted sessionHome. See `getDevContainerOverridePath`.
+  onProgress?.('Building dev container…');
   logger.withFields({ agentSessionId, workspacePath }).info('Running devcontainer up');
   const upCmd = [
     'devcontainer up',
@@ -326,29 +415,26 @@ export async function bringUpDevContainer(
     // `.devcontainer/devcontainer.json`. Cleanup happens in
     // `teardownDevContainer`.
 
-    // Verify the dev container has bun and kilo. Fail early with a clear
-    // message so users know what to add to their devcontainer.json.
-    const preflightCmd = [
-      'devcontainer exec',
-      `--workspace-folder ${shellQuote(workspacePath)}`,
-      `--config ${shellQuote(overridePath)}`,
-      `--id-label ${shellQuote(`${KILO_AGENT_SESSION_LABEL}=${agentSessionId}`)}`,
-      `--`,
-      `sh -c ${shellQuote('command -v bun >/dev/null && command -v kilo >/dev/null || echo MISSING')}`,
-    ].join(' ');
-    const preflight = await session.exec(preflightCmd, { env: dockerEnv });
-    const missing = (preflight.stdout ?? '').includes('MISSING') || preflight.exitCode !== 0;
-    if (missing) {
+    const preflightOptions = {
+      workspacePath,
+      overridePath,
+      agentSessionId,
+    };
+    onProgress?.('Checking dev container runtime…');
+    let preflight = await runDevContainerRuntimePreflight(session, preflightOptions, dockerEnv);
+    if (devContainerRuntimeToolsMissing(preflight)) {
+      onProgress?.('Installing runtime tools in dev container…');
+      await bootstrapDevContainerRuntimeTools(
+        session,
+        { ...preflightOptions, kiloCliVersion },
+        dockerEnv
+      );
+      onProgress?.('Checking dev container runtime…');
+      preflight = await runDevContainerRuntimePreflight(session, preflightOptions, dockerEnv);
+    }
+    if (devContainerRuntimeToolsMissing(preflight)) {
       throw new DevContainerUpError(
-        'Dev container is missing required tools (bun and/or kilo). Add to your devcontainer.json:\n\n' +
-          '  "features": {\n' +
-          '    "ghcr.io/devcontainers/features/node:1": {}\n' +
-          '  },\n' +
-          '  "postCreateCommand": "curl -fsSL https://bun.sh/install | bash && ' +
-          'npm install -g @kilocode/cli@' +
-          kiloCliVersion +
-          '"\n\n' +
-          'Or install bun and kilo manually so both are on PATH.',
+        'Dev container runtime bootstrap completed, but bun and/or kilo are still missing.',
         preflight.stdout ?? '',
         preflight.stderr ?? ''
       );

--- a/services/cloud-agent-next/src/kilo/devcontainer.ts
+++ b/services/cloud-agent-next/src/kilo/devcontainer.ts
@@ -123,6 +123,9 @@ export const KILO_WRAPPER_PORT_LABEL = 'kilo.wrapperPort';
  */
 export const KILO_CLI_VERSION = '7.2.52';
 
+const DEVCONTAINER_RUNTIME_BUN_VERSION = '1.3.14';
+const DEVCONTAINER_RUNTIME_BOOTSTRAP_TIMEOUT_MS = 10 * 60 * 1000;
+
 /** `devcontainer up` prints multiple JSON lines on stdout — we look for this final line. */
 const UP_OUTCOME_SUCCESS = 'success';
 
@@ -274,13 +277,16 @@ async function bootstrapDevContainerRuntimeTools(
     'ln -sf "$(command -v node)" /usr/local/bin/node',
     'ln -sf "$(command -v npm)" /usr/local/bin/npm',
     'ln -sf "$(command -v npx)" /usr/local/bin/npx',
-    'curl -fsSL https://bun.sh/install | bash',
+    `curl -fsSL https://bun.sh/install | bash -s "bun-v${DEVCONTAINER_RUNTIME_BUN_VERSION}"`,
     'ln -sf "$HOME/.bun/bin/bun" /usr/local/bin/bun',
     `npm install -g ${shellQuote(`@kilocode/cli@${opts.kiloCliVersion}`)}`,
     'ln -sf "$(command -v kilo)" /usr/local/bin/kilo',
   ].join(' && ');
   const command = buildDevContainerRuntimeExecCommand(opts, installCommand, 'bash -lc');
-  const result = await session.exec(command, { env: dockerEnv });
+  const result = await session.exec(command, {
+    env: dockerEnv,
+    timeout: DEVCONTAINER_RUNTIME_BOOTSTRAP_TIMEOUT_MS,
+  } satisfies ExecOptions);
   if (result.exitCode !== 0) {
     throw new DevContainerUpError(
       `Failed to bootstrap dev container runtime tools (exit ${result.exitCode})`,

--- a/services/cloud-agent-next/src/persistence/async-preparation.test.ts
+++ b/services/cloud-agent-next/src/persistence/async-preparation.test.ts
@@ -330,7 +330,11 @@ describe('executePreparationSteps', () => {
     detectDevContainerMock.mockResolvedValueOnce({
       configPath: '.devcontainer/devcontainer.json',
     });
-    bringUpDevContainerMock.mockResolvedValueOnce(devcontainer);
+    bringUpDevContainerMock.mockImplementationOnce(async (_session, options) => {
+      options.onProgress?.('Building dev container…');
+      options.onProgress?.('Checking dev container runtime…');
+      return devcontainer;
+    });
     const input = {
       sessionId: 'agent_test',
       userId: 'test-user',
@@ -363,6 +367,11 @@ describe('executePreparationSteps', () => {
           KILO_SESSION_INGEST_URL: 'https://ingest.example',
         },
       }
+    );
+    expect(emitProgress).toHaveBeenCalledWith('devcontainer_setup', 'Building dev container…');
+    expect(emitProgress).toHaveBeenCalledWith(
+      'devcontainer_setup',
+      'Checking dev container runtime…'
     );
     expect(emitProgress).toHaveBeenCalledWith('setup_commands', 'Running setup commands…');
   });

--- a/services/cloud-agent-next/src/persistence/async-preparation.ts
+++ b/services/cloud-agent-next/src/persistence/async-preparation.ts
@@ -237,7 +237,6 @@ export async function executePreparationSteps(
 
           detected = await detectDevContainer(session, workspacePath);
           if (detected) {
-            emitProgress('devcontainer_setup', `Building dev container (${detected.configPath})…`);
             const existingContainer = await findWrapperContainerForSession(
               sandbox,
               input.sessionId
@@ -251,6 +250,7 @@ export async function executePreparationSteps(
                 wrapperPort,
                 kiloCliVersion: KILO_CLI_VERSION,
                 configPath: detected.configPath,
+                onProgress: message => emitProgress('devcontainer_setup', message),
               });
             } catch (error) {
               const message = error instanceof Error ? error.message : String(error);
@@ -321,8 +321,9 @@ export async function executePreparationSteps(
           });
           if (restoreResult.exitCode !== 0) {
             const stdout = restoreResult.stdout?.trim() ?? '';
+            const stderr = restoreResult.stderr?.trim() ?? '';
             logger
-              .withFields({ exitCode: restoreResult.exitCode, stdout })
+              .withFields({ exitCode: restoreResult.exitCode, stdout, stderr })
               .error('Session import failed');
             emitProgress('failed', `Session import failed (exit ${restoreResult.exitCode})`);
             return undefined;

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -682,8 +682,9 @@ const prepareSessionHandler = internalApiProtectedProcedure
         );
         if (restoreResult.exitCode !== 0) {
           const stdout = restoreResult.stdout?.trim() ?? '';
+          const stderr = restoreResult.stderr?.trim() ?? '';
           logger
-            .withFields({ exitCode: restoreResult.exitCode, stdout })
+            .withFields({ exitCode: restoreResult.exitCode, stdout, stderr })
             .error('Pre-import of kilo session failed');
           throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -1866,10 +1866,6 @@ export class SessionService {
 
       let dockerEnv: Record<string, string> | undefined;
       if (metadata.devcontainer) {
-        onProgress?.(
-          'devcontainer_setup',
-          `Building dev container (${metadata.devcontainer.configPath})…`
-        );
         dockerEnv = dockerSocketEnv(await resolveDockerSocketPath(session));
         devContainerHandle = await bringUpDevContainer(session, {
           workspacePath: metadata.devcontainer.workspacePath,
@@ -1878,6 +1874,7 @@ export class SessionService {
           wrapperPort: metadata.devcontainer.wrapperPort,
           kiloCliVersion: KILO_CLI_VERSION,
           configPath: metadata.devcontainer.configPath,
+          onProgress: message => onProgress?.('devcontainer_setup', message),
         });
       }
 


### PR DESCRIPTION
## Summary

- Provision missing Node/Bun/Kilo runtime tools for devcontainer sessions.
- Surface clearer devcontainer setup milestones and preserve stderr on import failures.

## Verification

- [x] Manually verified locally.