### PR TITLE
fix(gastown): route wasteland links by owner/repo instead of id

### DIFF
--- a/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
@@ -32,7 +32,12 @@ import { parseDolthubUpstream } from '@/lib/wasteland/upstream';
 function linkForWasteland(wasteland: { wasteland_id: string; dolthub_upstream: string | null }) {
   const upstream = parseDolthubUpstream(wasteland.dolthub_upstream);
   if (upstream) return `/wasteland/${upstream.owner}/${upstream.repo}`;
-  return `/wasteland/${wasteland.wasteland_id}`;
+  // Fall back to the id-based redirect page when the wasteland has no
+  // parseable upstream — that page resolves the upstream server-side and
+  // forwards to /wasteland/{owner}/{repo} when it can. The bare
+  // `/wasteland/{id}` URL would otherwise hit the [owner]/[repo] route
+  // with the id as the owner segment, which 404s.
+  return `/wasteland/by-id/${wasteland.wasteland_id}`;
 }
 
 export function TownListPageClient() {

--- a/apps/web/src/app/(app)/gastown/[townId]/settings/WastelandSettingsSection.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/settings/WastelandSettingsSection.tsx
@@ -40,6 +40,22 @@ import {
   useUpstreamVerification,
   type UpstreamIntent,
 } from '@/components/wasteland/UpstreamIntent';
+import { parseDolthubUpstream } from '@/lib/wasteland/upstream';
+
+/**
+ * Build the canonical wasteland dashboard URL for a given connection.
+ *
+ * Prefer the `/wasteland/{owner}/{repo}` route when the connection has a
+ * parseable upstream — that's the M2.2 path the rest of the product
+ * navigates to. Fall back to `/wasteland/by-id/{wastelandId}` only when
+ * the upstream is missing or malformed; that page resolves the upstream
+ * server-side and redirects to the owner/repo URL when it can.
+ */
+function wastelandHref(args: { wastelandId: string; upstream: string | null }): string {
+  const parsed = parseDolthubUpstream(args.upstream);
+  if (parsed) return `/wasteland/${parsed.owner}/${parsed.repo}`;
+  return `/wasteland/by-id/${args.wastelandId}`;
+}
 
 /**
  * Derive the default wasteland name when the user hasn't typed one.
@@ -137,7 +153,10 @@ function ConnectedState({
   return (
     <div className="flex items-center justify-between rounded-lg border border-emerald-500/20 bg-emerald-500/5 pr-4">
       <Link
-        href={`/wasteland/${connection.wasteland_id}`}
+        href={wastelandHref({
+          wastelandId: connection.wasteland_id,
+          upstream: connection.upstream,
+        })}
         className="group flex flex-1 items-center gap-3 rounded-l-lg px-4 py-3 transition-colors hover:bg-emerald-500/10"
       >
         <CheckCircle2 className="size-4 shrink-0 text-emerald-400" />
@@ -932,7 +951,10 @@ function ConnectWastelandDialog({
               </Button>
               {connectedWastelandId && (
                 <Link
-                  href={`/wasteland/${connectedWastelandId}`}
+                  href={wastelandHref({
+                    wastelandId: connectedWastelandId,
+                    upstream: connectedUpstream,
+                  })}
                   className="inline-flex items-center gap-1.5 rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
                 >
                   Visit wasteland


### PR DESCRIPTION
## Summary

- Fix the wasteland link on the gastown town settings page (`WastelandSettingsSection.tsx`) so that when a town is connected to a wasteland, the "view connected wasteland" affordance and the post-connect "Visit wasteland" button route to `/wasteland/{owner}/{repo}` (the M2.2 canonical path) instead of `/wasteland/{wastelandId}`.
- Apply the same fix to the wasteland card grid on the gastown overview (`TownListPageClient.tsx`), whose fallback path was building a bare `/wasteland/{wastelandId}` URL that hits the `[owner]/[repo]` route with the id as the owner segment and 404s.
- Both spots now use a small helper that prefers the parsed `dolthub_upstream` and falls back to `/wasteland/by-id/{wastelandId}` (the redirect page that resolves the upstream server-side and forwards to the owner/repo URL when it can) instead of the broken bare-id path.

## Verification

- Connected a town to a wasteland and clicked the "Connected to {upstream}" tile in town settings → routed to `/wasteland/{owner}/{repo}`.
- Completed the in-dialog connect flow and clicked "Visit wasteland" on the success step → routed to `/wasteland/{owner}/{repo}`.
- Confirmed the fallback path renders `/wasteland/by-id/{wastelandId}` only when the parsed upstream is null/malformed, and that the redirect page already forwards to the canonical URL when it can (`apps/web/src/app/(app)/wasteland/by-id/[wastelandId]/page.tsx:19-23`).
- Typecheck passes for the `web` package.

## Visual Changes

No visual changes — only the link target changed.

## Reviewer Notes

- The `connectTownToWasteland` mutation requires `upstream: z.string().min(1)` (`services/gastown/src/trpc/router.ts:1693`), so the connected-state path will essentially always parse cleanly; the `by-id` fallback is defensive for edge cases (e.g. legacy connections).
- `TownListPageClient.tsx` was previously routing to a bare-id URL on the fallback branch — that page would 404 by hitting the `[owner]/[repo]` route. Switching to `/wasteland/by-id/{wastelandId}` recovers the documented redirect path.