### PR TITLE
refactor(gateway): return inserted usage row id and timestamp from logMicrodollarUsage

### DIFF
--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -245,19 +245,22 @@ export function toInsertableDbUsageRecord(
 export async function logMicrodollarUsage(
   usageStats: MicrodollarUsageStats,
   usageContext: MicrodollarUsageContext
-): Promise<{ usageId: string; createdAt: string }> {
+): Promise<{ usageId: string; createdAt: string } | null> {
   usageContext.status_code = usageStats.status_code;
   const contextInfo = extractUsageContextInfo(usageContext);
   const { core, metadata } = toInsertableDbUsageRecord(usageStats, contextInfo);
 
-  await saveUsageRelatedData(
+  const inserted = await saveUsageRelatedData(
     core,
     metadata,
     usageContext.prior_microdollar_usage,
     usageContext.posthog_distinct_id ?? null
   );
 
-  return { usageId: core.id, createdAt: core.created_at };
+  // `insertUsageRecord` swallows DB errors and returns null; surface that
+  // failure to callers so dependent FK writes don't dangle on a row that
+  // was never persisted.
+  return inserted ? { usageId: core.id, createdAt: core.created_at } : null;
 }
 
 async function saveUsageRelatedData(
@@ -265,7 +268,7 @@ async function saveUsageRelatedData(
   metadataFields: UsageMetaData,
   prior_microdollar_usage: number,
   posthog_distinct_id: string | null
-) {
+): Promise<BalanceUpdateResult> {
   const isFirst = await isFirstUsage(coreUsageFields, prior_microdollar_usage);
   if (isFirst && posthog_distinct_id)
     await sendFirstUsageEvent(coreUsageFields, posthog_distinct_id);
@@ -279,6 +282,7 @@ async function saveUsageRelatedData(
     );
   }
   await ingestOrganizationTokenUsage(coreUsageFields);
+  return balanceUpdateResult;
 }
 
 async function isFirstUsage(

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -245,7 +245,7 @@ export function toInsertableDbUsageRecord(
 export async function logMicrodollarUsage(
   usageStats: MicrodollarUsageStats,
   usageContext: MicrodollarUsageContext
-) {
+): Promise<{ usageId: string; createdAt: string }> {
   usageContext.status_code = usageStats.status_code;
   const contextInfo = extractUsageContextInfo(usageContext);
   const { core, metadata } = toInsertableDbUsageRecord(usageStats, contextInfo);
@@ -256,6 +256,8 @@ export async function logMicrodollarUsage(
     usageContext.prior_microdollar_usage,
     usageContext.posthog_distinct_id ?? null
   );
+
+  return { usageId: core.id, createdAt: core.created_at };
 }
 
 async function saveUsageRelatedData(
@@ -909,14 +911,14 @@ export function calculateKiloExclusiveCost_mUsd(
 export async function processTokenData(
   usageStats: MicrodollarUsageStats | null,
   usageContext: MicrodollarUsageContext
-) {
+): Promise<{ usageId: string; createdAt: string } | null> {
   if (!usageStats) {
     captureMessage('SUSPICIOUS: No usage information', {
       level: 'error',
       tags: { source: 'usage_processing' },
       extra: { usageContext },
     });
-    return;
+    return null;
   }
 
   const timer = createTimer();
@@ -987,7 +989,7 @@ export async function processTokenData(
     usageStats.cacheDiscount_mUsd = 0;
   }
 
-  await logMicrodollarUsage(usageStats, usageContext);
+  return logMicrodollarUsage(usageStats, usageContext);
 }
 
 function useAnthropicStyleTokenCounting(requestedModel: string, provider: ProviderId) {


### PR DESCRIPTION
## Summary

Surface the inserted `microdollar_usage` row's `id` and `created_at` from `logMicrodollarUsage` and `processTokenData`. Pure refactor — existing callers ignore the return value, behavior is unchanged.

This is a small prep extracted from #3325 (model-experiments phases 2-4). The model-experiments attribution write needs to key its `model_experiment_request` row onto the same `usage_id` and `created_at` as the underlying microdollar row, and getting them back from the existing insert is the smallest possible change.

## Verification

N/A — pure return-value addition; no caller currently consumes the new value.

## Visual Changes

N/A — backend only.

## Reviewer Notes

`processTokenData` now returns `null` instead of `undefined` on the no-`usageStats` path. Callers using `await` (no return-value consumers exist today) are unaffected.
