### PR TITLE
feat(gateway): capture x-kilo-request and x-kilo-session headers

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -223,6 +223,13 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
   const modeHeader = extractHeaderAndLimitLength(request, 'x-kilocode-mode');
   const taskId = extractHeaderAndLimitLength(request, 'x-kilocode-taskid') ?? undefined;
+  // Per-message id from the kilocode client. Joinable to PostHog
+  // `Feedback Submitted.parentMessageID`.
+  const clientRequestId = extractHeaderAndLimitLength(request, 'x-kilo-request');
+  // Fallback session id used when `x-kilocode-taskid` is absent (e.g.
+  // non-kilocode clients). `taskId` still wins when both are present.
+  const sessionHeader = extractHeaderAndLimitLength(request, 'x-kilo-session');
+  const machineIdHeader = extractHeaderAndLimitLength(request, 'x-kilocode-machineid');
   let autoModel: string | null = null;
   if (isKiloAutoModel(requestedModelLowerCased)) {
     autoModel = requestedModelLowerCased;
@@ -436,16 +443,17 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     project_id: projectId,
     status_code: null,
     editor_name: extractHeaderAndLimitLength(request, 'x-kilocode-editorname'),
-    machine_id: extractHeaderAndLimitLength(request, 'x-kilocode-machineid'),
+    machine_id: machineIdHeader,
     user_byok: !!userByok,
     has_tools: (requestBodyParsed.body.tools?.length ?? 0) > 0,
     botId,
     tokenSource,
     feature,
-    session_id: taskId ?? null,
+    session_id: taskId ?? sessionHeader ?? null,
     mode: modeHeader,
     auto_model: autoModel,
     ttfb_ms: null,
+    clientRequestId,
   };
 
   setTag('ui.ai_model', requestBodyParsed.body.model);

--- a/apps/web/src/lib/ai-gateway/processUsage.types.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.types.ts
@@ -144,6 +144,13 @@ export type MicrodollarUsageContext = {
   auto_model: string | null;
   /** Time to first byte from the upstream provider, in milliseconds. Set after the upstream request returns. */
   ttfb_ms: number | null;
+  /**
+   * Client-supplied per-message id from the `x-kilo-request` header.
+   * Joinable to PostHog `Feedback Submitted.parentMessageID`. Optional
+   * because pre-existing construction sites (routes, tests, dev helpers)
+   * do not need to know about it.
+   */
+  clientRequestId?: string | null;
 };
 
 export type CoreUsageWithMetaData = {


### PR DESCRIPTION
## Summary

Capture two new request headers in the gateway:

- `x-kilo-request` — the kilocode client's per-message id, joinable to PostHog `Feedback Submitted.parentMessageID`. Stored on `MicrodollarUsageContext.clientRequestId`.
- `x-kilo-session` — fallback session identifier used when `x-kilocode-taskid` is absent (non-kilocode clients). `taskId` still wins when both are present.

Also factors the existing `x-kilocode-machineid` header extraction out into a single `machineIdHeader` constant in `route.ts` (was inlined into the `usageContext` literal).

This is plumbing extracted from #3325 (model-experiments phases 2-4). The `clientRequestId` field has no current consumer in this PR — it lands here so later changes (the experiment attribution write) don't have to touch the dozens of `MicrodollarUsageContext` construction sites in routes, tests, and dev helpers. The field is optional precisely so non-experiment construction sites stay untouched.

`session_id` already feeds existing usage telemetry, so the `x-kilo-session` fallback is immediately useful for non-kilocode clients that supply a session header but not a kilocode task id.

## Verification

Manually sent requests with each header combination against a local instance and confirmed `microdollar_usage_metadata.session_id` reflects the expected precedence (`taskId` > `sessionHeader` > `null`).

## Visual Changes

N/A — backend only.

## Reviewer Notes

`clientRequestId` is `string | null | undefined` (optional `?:` so existing construction sites compile unchanged, then captured as `extractHeaderAndLimitLength`'s `string | null` return).
