### PR TITLE
refactor(gateway): convert getProvider to discriminated GetProviderResult union

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -372,13 +372,20 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
   // Use new shared helper for fraud & project headers
   const { fraudHeaders, projectId } = extractFraudAndProjectHeaders(request);
-  const { provider, userByok, bypassAccessCheck } = await getProvider(
-    originalModelIdLowerCased,
-    requestBodyParsed,
+  const providerResult = await getProvider({
+    requestedModel: originalModelIdLowerCased,
+    request: requestBodyParsed,
     user,
     organizationId,
-    taskId
-  );
+    taskId,
+  });
+  if (providerResult.kind === 'not-found') {
+    return modelDoesNotExistResponse();
+  }
+  if (providerResult.kind === 'unavailable') {
+    return temporarilyUnavailableResponse();
+  }
+  const { provider, userByok, bypassAccessCheck } = providerResult;
   if (!provider.supportedChatApis.includes(requestBodyParsed.kind)) {
     return apiKindNotSupportedResponse(
       requestBodyParsed.kind,

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -20,11 +20,34 @@ import {
   inferSupportedChatApis,
 } from '@/lib/ai-gateway/experiments/build-direct-provider';
 
+export type GetProviderProviderResult = {
+  kind: 'provider';
+  provider: Provider;
+  userByok: BYOKResult[] | null;
+  /** Skip balance, paid-auth, and organization policy checks entirely. Used
+   *  by direct-byok and custom_llm2 because both already require explicit
+   *  admin opt-in. */
+  bypassAccessCheck: boolean;
+};
+
+/**
+ * Discriminated routing result. `not-found` maps to the local
+ * model-unavailable response; `unavailable` maps to a 503
+ * temporarily-unavailable response. Today only the `provider` shape is
+ * produced; the other kinds are scaffolding for upcoming model-experiment
+ * routing (PR #3325) where paused/unreachable experiments need to
+ * short-circuit without falling through to default routing.
+ */
+export type GetProviderResult =
+  | GetProviderProviderResult
+  | { kind: 'not-found' }
+  | { kind: 'unavailable' };
+
 async function checkDirectBYOK(
   user: User | AnonymousUserContext,
   requestedModel: string,
   organizationId: string | undefined
-) {
+): Promise<GetProviderProviderResult | null> {
   const { provider: directByok, model: directByokModel } = await getDirectByokModel(requestedModel);
   if (!directByok || !directByokModel) {
     return null;
@@ -36,6 +59,7 @@ async function checkDirectBYOK(
     return null;
   }
   return {
+    kind: 'provider',
     provider: {
       id: 'direct-byok',
       apiUrl: directByok.base_url,
@@ -54,7 +78,7 @@ async function checkDirectBYOK(
 async function checkCustomLlm(
   requestedModel: string,
   organizationId: string
-): Promise<{ provider: Provider; userByok: null; bypassAccessCheck: true } | null> {
+): Promise<GetProviderProviderResult | null> {
   const [row] = await db
     .select()
     .from(custom_llm2)
@@ -68,6 +92,7 @@ async function checkCustomLlm(
     return null;
   }
   return {
+    kind: 'provider',
     provider: buildDirectProvider({
       internal_id: customLlm.internal_id,
       base_url: customLlm.base_url,
@@ -109,13 +134,17 @@ async function checkVercelBYOK(
     : getBYOKforUser(db, user.id, modelProviders);
 }
 
-export async function getProvider(
-  requestedModel: string,
-  request: GatewayRequest,
-  user: User | AnonymousUserContext,
-  organizationId: string | undefined,
-  taskId: string | undefined
-): Promise<{ provider: Provider; userByok: BYOKResult[] | null; bypassAccessCheck: boolean }> {
+export type GetProviderInput = {
+  requestedModel: string;
+  request: GatewayRequest;
+  user: User | AnonymousUserContext;
+  organizationId: string | undefined;
+  taskId: string | undefined;
+};
+
+export async function getProvider(input: GetProviderInput): Promise<GetProviderResult> {
+  const { requestedModel, request, user, organizationId, taskId } = input;
+
   const directByokByok = await checkDirectBYOK(user, requestedModel, organizationId);
   if (directByokByok) {
     return directByokByok;
@@ -124,6 +153,7 @@ export async function getProvider(
   const vercelByok = await checkVercelBYOK(user, requestedModel, organizationId);
   if (vercelByok) {
     return {
+      kind: 'provider',
       provider: PROVIDERS.VERCEL_AI_GATEWAY,
       userByok: vercelByok,
       bypassAccessCheck: false,
@@ -145,10 +175,16 @@ export async function getProvider(
     eligibleForVercelRouting &&
     (await shouldRouteToVercel(requestedModel, request, taskId || user.id))
   ) {
-    return { provider: PROVIDERS.VERCEL_AI_GATEWAY, userByok: null, bypassAccessCheck: false };
+    return {
+      kind: 'provider',
+      provider: PROVIDERS.VERCEL_AI_GATEWAY,
+      userByok: null,
+      bypassAccessCheck: false,
+    };
   }
 
   return {
+    kind: 'provider',
     provider:
       Object.values(PROVIDERS).find(p => p.id === kiloExclusiveModel?.gateway) ??
       PROVIDERS.OPENROUTER,


### PR DESCRIPTION
## Summary

Two coordinated shape changes to `getProvider`, extracted from #3325 (model-experiments phases 2-4) so reviewers can vet "did existing branches preserve behavior?" without also evaluating the new experiment logic:

1. **Inputs**: positional args → `GetProviderInput` object. Keeps the call site readable as we add more inputs in the upcoming model-experiments work.
2. **Output**: `{ provider, userByok, bypassAccessCheck }` → discriminated `GetProviderResult` with kinds `'provider'` / `'not-found'` / `'unavailable'`.

Today only the `'provider'` kind is produced. `'not-found'` and `'unavailable'` are scaffolding for the upcoming model-experiment routing branch (#3325) where paused/unreachable experiments need to short-circuit without falling through to default routing. The route handler dispatches the new kinds via the existing `modelDoesNotExistResponse` / `temporarilyUnavailableResponse` helpers.

Behavior is unchanged: every call path that previously returned a provider now returns `{ kind: 'provider', ... }`, and the call site destructures the provider shape after the kind guard.

## Verification

Manually exercised existing routing branches (Vercel BYOK, direct BYOK, kilo-internal/custom_llm, kilo-exclusive default, OpenRouter default) against a local instance and confirmed each returns `kind: 'provider'` with the same field values as before. The two new kinds are unreachable today; the response helpers they map to are already used elsewhere in the same handler.

## Visual Changes

N/A — backend only.

## Reviewer Notes

- The `'not-found'` / `'unavailable'` cases are intentionally added in this PR (rather than with the experiment branch) so the type-shape change is the only thing to evaluate here. Reviewers should focus on whether the `'provider'`-shape returns are byte-identical to the previous return shapes.
- `checkDirectBYOK` and `checkCustomLlm` previously had ad-hoc inferred / inline return types; both now share the explicit `Promise<GetProviderProviderResult | null>` annotation.
