### PR TITLE
fix(wasteland): wasteland routing fixes, restore /wasteland/new create-upstream flow, drop gastown beta label

### DIFF
--- a/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
@@ -7,7 +7,6 @@ import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { useWastelandTRPC } from '@/lib/wasteland/trpc';
 import { PageContainer } from '@/components/layouts/PageContainer';
 import { Button } from '@/components/Button';
-import { Badge } from '@/components/ui/badge';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -79,9 +78,7 @@ export function TownListPageClient() {
         <div className="flex flex-col gap-3">
           <div className="flex items-start justify-between gap-3">
             <div>
-              <SetPageTitle title="Gas Town">
-                <Badge variant="beta">beta</Badge>
-              </SetPageTitle>
+              <SetPageTitle title="Gas Town" />
               <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/60">
                 A chat-first orchestration console for towns, rigs, beads, and agents. Built for
                 radical transparency: every object is clickable; every outcome is attributable.

--- a/apps/web/src/app/(app)/organizations/[id]/gastown/OrgTownListPageClient.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/gastown/OrgTownListPageClient.tsx
@@ -5,7 +5,6 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { PageContainer } from '@/components/layouts/PageContainer';
 import { Button } from '@/components/Button';
-import { Badge } from '@/components/ui/badge';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -46,9 +45,7 @@ export function OrgTownListPageClient({ organizationId, role }: OrgTownListPageC
     <PageContainer>
       <GastownBackdrop contentClassName="p-5 md:p-7">
         <div className="flex flex-col gap-3">
-          <SetPageTitle title="Gas Town">
-            <Badge variant="beta">beta</Badge>
-          </SetPageTitle>
+          <SetPageTitle title="Gas Town" />
           <div className="flex items-start justify-between gap-3">
             <div>
               <p className="max-w-2xl text-sm leading-relaxed text-white/60">

--- a/apps/web/src/app/(app)/wasteland/new/NewWastelandWizardClient.tsx
+++ b/apps/web/src/app/(app)/wasteland/new/NewWastelandWizardClient.tsx
@@ -46,6 +46,33 @@ import {
   useUpstreamVerification,
   type UpstreamIntent,
 } from '@/components/wasteland/UpstreamIntent';
+import { parseDolthubUpstream } from '@/lib/wasteland/upstream';
+
+/**
+ * Build the canonical post-create URL for a wasteland.
+ *
+ * Personal-scope wastelands route to `/wasteland/{owner}/{repo}` (the
+ * M2.2 path the rest of the product uses). The bare `/wasteland/{id}`
+ * URL would otherwise hit the `[owner]/[repo]` route with the id as the
+ * owner segment and 404. When the upstream string can't be parsed we
+ * fall back to `/wasteland/by-id/{wastelandId}`, the redirect page that
+ * resolves the upstream server-side.
+ *
+ * Org-scope wastelands keep their existing `/organizations/{orgId}/...`
+ * URL — the org wasteland routes have their own id-based pages.
+ */
+function postCreateWastelandPath(args: {
+  wastelandId: string;
+  upstream: string;
+  lockedOrgId: string | null | undefined;
+}): string {
+  if (args.lockedOrgId) {
+    return `/organizations/${args.lockedOrgId}/wasteland/${args.wastelandId}`;
+  }
+  const parsed = parseDolthubUpstream(args.upstream);
+  if (parsed) return `/wasteland/${parsed.owner}/${parsed.repo}`;
+  return `/wasteland/by-id/${args.wastelandId}`;
+}
 
 const NAME_MAX_LENGTH = 128;
 
@@ -333,9 +360,11 @@ function NewWastelandWizardForm({ lockedOrgId }: NewWastelandWizardFormProps) {
         wastelandId = created.wasteland_id;
         setPendingWastelandId(wastelandId);
       }
-      const wastelandPath = lockedOrgId
-        ? `/organizations/${lockedOrgId}/wasteland/${wastelandId}`
-        : `/wasteland/${wastelandId}`;
+      const wastelandPath = postCreateWastelandPath({
+        wastelandId,
+        upstream,
+        lockedOrgId,
+      });
 
       if (!needsJoinCeremony) {
         // create intent — the user still has to wire DoltHub on the

--- a/apps/web/src/app/(app)/wasteland/new/NewWastelandWizardClient.tsx
+++ b/apps/web/src/app/(app)/wasteland/new/NewWastelandWizardClient.tsx
@@ -13,7 +13,6 @@ import {
   ChevronDown,
   GitFork,
   Globe,
-  Info,
   Loader2,
   Sparkles,
 } from 'lucide-react';
@@ -171,7 +170,7 @@ function NewWastelandWizardForm({ lockedOrgId }: NewWastelandWizardFormProps) {
   const [step, setStep] = useState<Step>('intent');
   const [error, setError] = useState<string | null>(null);
   const [successState, setSuccessState] = useState<SuccessState | null>(null);
-  // Track the wasteland created in `runProvisionAndJoin` so a retry
+  // Track the wasteland created in `runProvision` so a retry
   // after a credential-store / join failure reuses the existing record
   // instead of creating a duplicate. Cleared if the user navigates
   // back to a step that could change the create payload.
@@ -287,32 +286,26 @@ function NewWastelandWizardForm({ lockedOrgId }: NewWastelandWizardFormProps) {
   const rigHandleError = getRigHandleError(rigHandle);
   const rigStepValid = rigHandleError === null;
 
-  // Whether this intent runs the join ceremony (commons + connect).
-  // `create` skips join entirely (the createUpstream path already
-  // bootstraps + registers); `reuse` is N/A here (the standalone
-  // wizard never shows the reuse card).
-  const needsJoinCeremony = intent.kind === 'commons' || intent.kind === 'connect';
+  // Whether this intent runs the upstream-bootstrap path (`createUpstream`)
+  // versus the explicit fork-and-register ceremony (`joinWasteland`). Both
+  // paths now go through the same stepper — credentials and rig handle are
+  // required for either flow because both call into a DoltHub-authenticated
+  // mutation. `reuse` is N/A here (the standalone wizard never shows the
+  // reuse card).
+  const isCreateIntent = intent.kind === 'create';
 
-  // The set of steps shown in the stepper, gated by intent.
+  // The set of steps shown in the stepper, gated by intent. The work
+  // step's label changes based on the action; everything else is shared.
   const visibleSteps = useMemo<{ key: Step; label: string }[]>(() => {
-    if (needsJoinCeremony) {
-      return [
-        { key: 'intent', label: 'Wasteland' },
-        { key: 'credentials', label: 'DoltHub' },
-        { key: 'rig', label: 'Rig handle' },
-        { key: 'preview', label: 'Confirm' },
-        { key: 'work', label: 'Joining' },
-        { key: 'success', label: 'Done' },
-      ];
-    }
-    // create path: name → credentials are deferred to settings page,
-    // so we go intent → work → success.
     return [
       { key: 'intent', label: 'Wasteland' },
-      { key: 'work', label: 'Creating' },
+      { key: 'credentials', label: 'DoltHub' },
+      { key: 'rig', label: 'Rig handle' },
+      { key: 'preview', label: 'Confirm' },
+      { key: 'work', label: isCreateIntent ? 'Creating' : 'Joining' },
       { key: 'success', label: 'Done' },
     ];
-  }, [needsJoinCeremony]);
+  }, [isCreateIntent]);
 
   const stepIndex = visibleSteps.findIndex(s => s.key === step);
 
@@ -334,12 +327,14 @@ function NewWastelandWizardForm({ lockedOrgId }: NewWastelandWizardFormProps) {
   };
 
   /**
-   * Run the full provision-and-join flow. Called from the preview step
-   * (commons/connect) or directly from the intent step (create).
-   * Wraps in a separate function so the "Retry" button on a failure
-   * can re-invoke without reopening earlier steps.
+   * Run the full provision flow. Both branches start with `createWasteland`
+   * + `storeCredential`; the join branch (commons/connect) finishes with
+   * `joinWasteland`, while the create branch finishes with `createUpstream`
+   * (which bootstraps a brand-new DoltHub repo and registers the caller as
+   * the first rig). Wraps in a separate function so the "Retry" button on
+   * a failure can re-invoke without reopening earlier steps.
    */
-  const runProvisionAndJoin = async () => {
+  const runProvision = async () => {
     setStep('work');
     setError(null);
 
@@ -366,27 +361,24 @@ function NewWastelandWizardForm({ lockedOrgId }: NewWastelandWizardFormProps) {
         lockedOrgId,
       });
 
-      if (!needsJoinCeremony) {
-        // create intent — the user still has to wire DoltHub on the
-        // settings page, but the wasteland record is in place.
-        toast.message(
-          'Wasteland created. Connect DoltHub on the settings page to bootstrap the upstream.',
-          { duration: 8000 }
-        );
-        setSuccessState({ wastelandId, wastelandPath, upstream, join: null });
-        setStep('success');
-        return;
-      }
-
-      // 2. Persist DoltHub credentials so the join (and every
-      //    subsequent op) can resolve them deterministically.
+      // 2. Persist DoltHub credentials so the downstream mutation
+      //    (joinWasteland or createUpstream) can resolve them
+      //    deterministically. For the create branch the caller is
+      //    the upstream admin by definition; for commons/connect we
+      //    honour the toggle on the corresponding picker card.
       const tokenToStore = resolveDolthubToken();
       if (!tokenToStore) {
         throw new Error('Connect your DoltHub account or paste an API token to continue.');
       }
-      // intent is commons or connect here (needsJoinCeremony narrowed it).
-      // Both carry an `isUpstreamAdmin` flag from the picker.
-      const isUpstreamAdmin = intent.isUpstreamAdmin;
+      // The standalone wizard's picker never surfaces the `reuse` card,
+      // so `intent.kind` is always `commons | connect | create` here. Pull
+      // the admin flag explicitly per branch so TS narrows correctly.
+      const isUpstreamAdmin =
+        intent.kind === 'create'
+          ? true
+          : intent.kind === 'commons' || intent.kind === 'connect'
+            ? intent.isUpstreamAdmin
+            : false;
       await wastelandClient.wasteland.storeCredential.mutate({
         wastelandId,
         dolthubToken: tokenToStore,
@@ -395,11 +387,21 @@ function NewWastelandWizardForm({ lockedOrgId }: NewWastelandWizardFormProps) {
         isUpstreamAdmin,
       });
 
-      // 3. Run the explicit fork-and-register ceremony.
-      const join = await wastelandClient.wasteland.joinWasteland.mutate({
-        wastelandId,
-        rigHandle: rigHandle.trim(),
-      });
+      // 3. Bootstrap the DoltHub repo (create) OR run the explicit
+      //    fork-and-register ceremony (commons/connect).
+      let join: JoinResult | null = null;
+      if (isCreateIntent) {
+        await wastelandClient.wasteland.createUpstream.mutate({
+          wastelandId,
+          upstream,
+          rigHandle: rigHandle.trim(),
+        });
+      } else {
+        join = await wastelandClient.wasteland.joinWasteland.mutate({
+          wastelandId,
+          rigHandle: rigHandle.trim(),
+        });
+      }
 
       void queryClient.invalidateQueries({
         queryKey: trpc.wasteland.listWastelands.queryKey({}),
@@ -420,25 +422,19 @@ function NewWastelandWizardForm({ lockedOrgId }: NewWastelandWizardFormProps) {
 
   /**
    * Retry handler from the failure-state preview step.
-   * `runProvisionAndJoin` reuses `pendingWastelandId` when set, so a
-   * retry after a credential-store / join failure does not create a
-   * duplicate wasteland record. `storeCredential` and `joinWasteland`
-   * are themselves idempotent.
+   * `runProvision` reuses `pendingWastelandId` when set, so a retry
+   * after a credential-store / join / create-upstream failure does not
+   * create a duplicate wasteland record. `storeCredential`, `joinWasteland`,
+   * and `createUpstream` are themselves idempotent.
    */
   const handleRetry = () => {
-    void runProvisionAndJoin();
+    void runProvision();
   };
 
   // ── Step transitions ──────────────────────────────────────────────
 
   const goToCredentials = () => {
     if (!intentStepValid) return;
-    if (!needsJoinCeremony) {
-      // Skip straight to provisioning — the create path doesn't
-      // collect credentials in this wizard.
-      void runProvisionAndJoin();
-      return;
-    }
     setStep('credentials');
   };
 
@@ -485,7 +481,7 @@ function NewWastelandWizardForm({ lockedOrgId }: NewWastelandWizardFormProps) {
           setIntent={setIntent}
           dolthubUsername={cachedDolthubUsername}
           canContinue={intentStepValid}
-          continueLabel={needsJoinCeremony ? 'Next' : 'Create wasteland'}
+          continueLabel="Next"
           onContinue={goToCredentials}
           isPending={createMutation.isPending}
           commonsDisabled={hasCommonsConnection}
@@ -539,7 +535,7 @@ function NewWastelandWizardForm({ lockedOrgId }: NewWastelandWizardFormProps) {
             setError(null);
             setStep('rig');
           }}
-          onJoin={() => void runProvisionAndJoin()}
+          onJoin={() => void runProvision()}
           onRetry={handleRetry}
         />
       )}
@@ -745,15 +741,6 @@ function IntentStep({
           disabled={isPending}
           commonsDisabled={commonsDisabled}
         />
-        {intent.kind === 'create' && (
-          <div className="flex items-start gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-            <Info className="mt-0.5 size-3 shrink-0" />
-            <span>
-              We&apos;ll save this intent on your wasteland. Connect DoltHub on the settings page to
-              bootstrap the upstream.
-            </span>
-          </div>
-        )}
       </div>
 
       <div className="flex justify-end gap-2 pt-2">
@@ -1021,41 +1008,72 @@ function PreviewStep({
   onJoin: () => void;
   onRetry: () => void;
 }) {
-  if (intent.kind === 'reuse' || intent.kind === 'create') {
-    // Defensive: this step should never render for these intents.
+  if (intent.kind === 'reuse') {
+    // Defensive: the standalone wizard never offers the reuse card.
     return null;
   }
   const upstream = resolveUpstreamFromIntent(intent);
   const slash = upstream.indexOf('/');
   const repo = slash > 0 ? upstream.slice(slash + 1) : upstream;
   const fork = `${dolthubOrg}/${repo}`;
+  const isCreate = intent.kind === 'create';
+
+  const heading = isCreate ? 'Confirm new upstream' : 'Confirm fork target';
+  const introText = isCreate ? (
+    <>
+      Bootstrapping <span className="font-mono text-foreground">{upstream}</span> on DoltHub will:
+    </>
+  ) : (
+    <>
+      Connecting to <span className="font-mono text-foreground">{upstream}</span> will:
+    </>
+  );
+  const primaryActionLabel = isCreate ? 'Create wasteland' : 'Join wasteland';
 
   return (
     <div className="space-y-6">
       <div className="space-y-1">
-        <h2 className="text-lg font-medium text-foreground">Confirm fork target</h2>
+        <h2 className="text-lg font-medium text-foreground">{heading}</h2>
         <p className="text-sm text-muted-foreground">
           Here&apos;s what we&apos;re about to do. Nothing has been written yet.
         </p>
       </div>
 
       <div className="space-y-4 rounded-lg border border-border bg-card px-5 py-4 text-sm">
-        <p className="text-foreground">
-          Connecting to <span className="font-mono text-foreground">{upstream}</span> will:
-        </p>
+        <p className="text-foreground">{introText}</p>
         <ol className="space-y-3 text-muted-foreground">
-          <li className="flex items-start gap-3">
-            <GitFork className="mt-0.5 size-4 shrink-0 text-primary/80" />
-            <span>
-              Fork the upstream to <span className="font-mono text-foreground">{fork}</span> on your
-              DoltHub account.
-            </span>
-          </li>
+          {isCreate ? (
+            <li className="flex items-start gap-3">
+              <GitFork className="mt-0.5 size-4 shrink-0 text-primary/80" />
+              <span>
+                Create the DoltHub repo{' '}
+                <span className="font-mono text-foreground">{upstream}</span> with the wasteland
+                schema applied.
+              </span>
+            </li>
+          ) : (
+            <li className="flex items-start gap-3">
+              <GitFork className="mt-0.5 size-4 shrink-0 text-primary/80" />
+              <span>
+                Fork the upstream to <span className="font-mono text-foreground">{fork}</span> on
+                your DoltHub account.
+              </span>
+            </li>
+          )}
           <li className="flex items-start gap-3">
             <Sparkles className="mt-0.5 size-4 shrink-0 text-primary/80" />
             <span>
-              Register your rig <span className="font-mono text-foreground">{rigHandle}</span> in
-              the upstream via a pull request.
+              {isCreate ? (
+                <>
+                  Register your rig <span className="font-mono text-foreground">{rigHandle}</span>{' '}
+                  as the first upstream contributor.
+                </>
+              ) : (
+                <>
+                  Register your rig <span className="font-mono text-foreground">{rigHandle}</span>{' '}
+                  in the upstream via a pull request.
+                </>
+              )}
             </span>
           </li>
           <li className="flex items-start gap-3">
@@ -1067,8 +1085,9 @@ function PreviewStep({
           </li>
         </ol>
         <p className="border-t border-border pt-3 text-xs text-muted-foreground">
-          Your fork is yours — work you do here stays on your fork until you explicitly publish a
-          PR.
+          {isCreate
+            ? 'You\u2019re the upstream admin from day one. You can invite contributors from wasteland settings.'
+            : 'Your fork is yours \u2014 work you do here stays on your fork until you explicitly publish a PR.'}
         </p>
       </div>
 
@@ -1079,14 +1098,14 @@ function PreviewStep({
           <p className="text-xs text-muted-foreground">
             {/(^|\s)(401|403)(\s|:|$)/.test(error) || /unauthor|forbidden/i.test(error) ? (
               <>
-                If DoltHub rejected the fork, try{' '}
+                If DoltHub rejected the request, try{' '}
                 <a
                   href={`https://dolthub.com/repositories/${upstream}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-primary underline-offset-4 hover:underline"
                 >
-                  forking it manually
+                  {isCreate ? 'creating it manually' : 'forking it manually'}
                 </a>{' '}
                 first, then click Retry.
               </>
@@ -1109,7 +1128,7 @@ function PreviewStep({
           </Button>
         ) : (
           <Button onClick={onJoin} variant="primary">
-            Join wasteland
+            {primaryActionLabel}
             <ArrowRight className="size-4" />
           </Button>
         )}
@@ -1135,11 +1154,15 @@ function WorkStep({
     <div className="flex flex-col items-center gap-3 py-12 text-center">
       <Loader2 className="size-8 animate-spin text-muted-foreground" />
       <p className="text-sm text-foreground">
-        {isCreate ? 'Creating wasteland…' : 'Joining the wasteland…'}
+        {isCreate ? 'Creating the upstream…' : 'Joining the wasteland…'}
       </p>
       <p className="max-w-md text-xs text-muted-foreground">
         {isCreate ? (
-          <>Setting up the wasteland record. You&apos;ll connect DoltHub on the settings page.</>
+          <>
+            Bootstrapping <span className="font-mono text-foreground">{upstream}</span> on DoltHub
+            and registering rig <span className="font-mono text-foreground">{rigHandle}</span>. This
+            usually takes under a minute.
+          </>
         ) : (
           <>
             Forking <span className="font-mono text-foreground">{upstream}</span> to{' '}
@@ -1165,7 +1188,11 @@ function SuccessStep({
   onDone: () => void;
 }) {
   const { join } = state;
+  const isCreate = intent.kind === 'create';
   const upstreamPath = state.upstream ? `/wasteland/${state.upstream}` : state.wastelandPath;
+  const dolthubRepoUrl = state.upstream
+    ? `https://www.dolthub.com/repositories/${state.upstream}`
+    : null;
 
   return (
     <div className="space-y-6">
@@ -1177,12 +1204,16 @@ function SuccessStep({
               ? join.alreadyJoined
                 ? 'Already joined'
                 : 'Joined the wasteland'
-              : 'Wasteland created'}
+              : isCreate
+                ? 'Wasteland created'
+                : 'Wasteland created'}
           </h2>
           <p className="mt-1 text-sm text-muted-foreground">
             {join
               ? 'Your fork is live and your rig is registered upstream.'
-              : 'Connect DoltHub on the settings page to bootstrap the upstream.'}
+              : isCreate
+                ? 'Your DoltHub repo is live and your rig is registered as the first contributor.'
+                : 'Wasteland record is in place.'}
           </p>
         </div>
       </div>
@@ -1230,8 +1261,27 @@ function SuccessStep({
         </dl>
       )}
 
+      {!join && isCreate && dolthubRepoUrl && (
+        <dl className="space-y-3 rounded-lg border border-border bg-card px-5 py-4 text-sm">
+          <div className="flex items-start justify-between gap-3">
+            <dt className="text-muted-foreground">DoltHub repo</dt>
+            <dd className="text-right">
+              <a
+                href={dolthubRepoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 font-mono text-foreground underline-offset-4 hover:underline"
+              >
+                {state.upstream}
+                <ArrowUpRight className="size-3" />
+              </a>
+            </dd>
+          </div>
+        </dl>
+      )}
+
       <div className="flex flex-wrap items-center justify-end gap-2 pt-2">
-        {intent.kind !== 'create' && state.upstream && (
+        {state.upstream && (
           <Link
             href={upstreamPath}
             className="inline-flex h-9 items-center gap-1.5 rounded-md border border-border px-3 text-sm text-foreground hover:bg-muted/40"

--- a/apps/web/src/components/gastown/wasteland-bead-origin.test.ts
+++ b/apps/web/src/components/gastown/wasteland-bead-origin.test.ts
@@ -28,9 +28,9 @@ describe('readWastelandBeadOrigin', () => {
 describe('buildWastelandItemHref', () => {
   const origin = { wasteland_id: 'w-abc', item_id: 'item 7/x' };
 
-  it('builds a personal-scope href when pathname is not org-scoped', () => {
+  it('builds a personal-scope href via the by-id redirect when pathname is not org-scoped', () => {
     expect(buildWastelandItemHref(origin, '/gastown/town-1')).toBe(
-      '/wasteland/w-abc/wanted?itemId=item%207%2Fx'
+      '/wasteland/by-id/w-abc/wanted?itemId=item%207%2Fx'
     );
   });
 
@@ -40,9 +40,9 @@ describe('buildWastelandItemHref', () => {
     );
   });
 
-  it('falls back to personal scope when pathname is null', () => {
+  it('falls back to the personal by-id redirect when pathname is null', () => {
     expect(buildWastelandItemHref(origin, null)).toBe(
-      '/wasteland/w-abc/wanted?itemId=item%207%2Fx'
+      '/wasteland/by-id/w-abc/wanted?itemId=item%207%2Fx'
     );
   });
 });

--- a/apps/web/src/components/gastown/wasteland-bead-origin.ts
+++ b/apps/web/src/components/gastown/wasteland-bead-origin.ts
@@ -39,6 +39,14 @@ export function readWastelandBeadOrigin(
  * When `pathname` includes an org-scoped segment, the link is routed
  * through the matching `/organizations/[id]/wasteland/...` tree so the
  * user stays inside the org's app shell.
+ *
+ * The personal-scope link goes through `/wasteland/by-id/{wastelandId}/wanted`,
+ * the redirect page that resolves the wasteland's upstream server-side
+ * and forwards to the canonical `/wasteland/{owner}/{repo}` URL,
+ * preserving the `?itemId=` query. The bare `/wasteland/{wastelandId}/wanted`
+ * URL would otherwise hit the `[owner]/[repo]` route with the id as the
+ * owner segment and 404 — the bead origin metadata only carries the
+ * wasteland UUID, not the upstream slug.
  */
 export function buildWastelandItemHref(
   origin: Pick<WastelandBeadOrigin, 'wasteland_id' | 'item_id'>,
@@ -47,6 +55,6 @@ export function buildWastelandItemHref(
   const orgMatch = pathname?.match(/^\/organizations\/([^/]+)\//);
   const base = orgMatch
     ? `/organizations/${orgMatch[1]}/wasteland/${origin.wasteland_id}/wanted`
-    : `/wasteland/${origin.wasteland_id}/wanted`;
+    : `/wasteland/by-id/${origin.wasteland_id}/wanted`;
   return `${base}?itemId=${encodeURIComponent(origin.item_id)}`;
 }


### PR DESCRIPTION
## Summary

- **Restore the create-upstream bootstrap on `/wasteland/new`.** The standalone wizard's `create` branch was deliberately reduced in `0e3270c50` ("explicit fork-and-register connect ceremony"): for `intent.kind === 'create'` it ran `createWasteland` only, then toasted "Connect DoltHub on the settings page to bootstrap the upstream" and skipped to success — never calling `wasteland.createUpstream`, so no DoltHub repo was ever created. The wizard now runs the full `createWasteland` \u2192 `storeCredential` (with `is_upstream_admin: true`) \u2192 `createUpstream` chain end-to-end, mirroring the gastown wasteland-connect dialog. The stepper for the create branch is now `intent \u2192 credentials \u2192 rig \u2192 preview \u2192 work \u2192 success` (previously `intent \u2192 work \u2192 success`). Preview, Work, and Success copy was updated to reflect the create branch's actual outcome (a brand-new DoltHub repo with the caller registered as the first rig). The "Connect DoltHub on the settings page to bootstrap the upstream" punt-banner under the create card was dropped.
- **Fix `/wasteland/new` redirect.** The post-create redirect on `/wasteland/new` now routes personal-scope wastelands to the canonical `/wasteland/{owner}/{repo}` URL instead of the legacy `/wasteland/{wastelandId}` URL. The bare-id URL would otherwise hit the `[owner]/[repo]` route with the wasteland id as the owner segment and 404. Org-scope keeps its existing `/organizations/{orgId}/wasteland/{wastelandId}` URL. Logic is centralized in a `postCreateWastelandPath` helper inside `NewWastelandWizardClient.tsx` so both the "Done" button (`router.push`) and the success-step preview link build the same path.
- **Fix bead-drawer wasteland-origin link.** `buildWastelandItemHref` (used by `WastelandOriginLink` in the BeadPanel) now points the personal-scope link at `/wasteland/by-id/{wastelandId}/wanted` instead of `/wasteland/{wastelandId}/wanted`. The bead origin metadata only carries the wasteland UUID \u2014 not the upstream slug \u2014 so we can't build the canonical URL inline. The `by-id/.../wanted` redirect page resolves the upstream server-side and forwards to `/wasteland/{owner}/{repo}` while preserving `?itemId=`. Org-scope path is unchanged. Tests updated to match.
- **Drop "beta" label from Gas Town.** Remove the `<Badge variant="beta">beta</Badge>` next to the "Gas Town" page title on both the personal (`TownListPageClient.tsx`) and org (`OrgTownListPageClient.tsx`) town list pages, plus remove the now-unused `Badge` import from each.

## Verification

- Walked through the new-wasteland wizard with the `commons` intent \u2192 "Done" routed to `/wasteland/Kilo-Org/wl-commons`.
- Walked through with the `create` intent and a fresh `owner/my-wl` upstream \u2192 wizard ran credentials \u2192 rig \u2192 preview \u2192 work, the DoltHub repo was created, and "Done" routed to `/wasteland/{owner}/my-wl`. Confirmed via DoltHub UI that the new repo exists with the wasteland schema applied and the rig registration row present.
- Walked through with the `connect` intent against an existing repo \u2192 join ceremony still runs as before.
- Walked through with the org scope locked \u2192 "Done" still routes to `/organizations/{orgId}/wasteland/{wastelandId}`, matching previous behavior.
- Opened a bead in the gastown drawer that carries a `metadata.wasteland` origin tag \u2192 wasteland item link routes to `/wasteland/by-id/{id}/wanted?itemId=...`, which redirects to `/wasteland/{owner}/{repo}?itemId=...` and auto-opens the wanted-item drawer.
- Loaded `/gastown` and `/organizations/{orgId}/gastown` \u2192 "Gas Town" page heading no longer shows the `beta` badge.
- `pnpm --filter web test -- src/components/gastown/wasteland-bead-origin.test.ts` passes (5/5).
- `pnpm --filter web typecheck` passes.

## Visual Changes

- **/wasteland/new create flow:** The stepper now shows the same six steps (`Wasteland \u2192 DoltHub \u2192 Rig handle \u2192 Confirm \u2192 Creating \u2192 Done`) for the create branch as for join. Preview/Work/Success copy adapted per branch (e.g. "Bootstrapping owner/repo on DoltHub..." instead of forking copy). The success step's outcome panel now shows a DoltHub repo link for the create branch and a "Browse the upstream" CTA. The punt-to-settings info banner under the create card on the intent step is gone.
- **/wasteland/new join flow:** No visual changes \u2014 only the link target on "Done" / the inline upstream-path link changed.
- **Gastown bead drawer:** No visual changes \u2014 only the link target on the "Wasteland Item" tile changed.
- **Gas Town heading:** The small `beta` pill next to "Gas Town" in the page title no longer renders. Heading rhythm is unchanged otherwise.

## Reviewer Notes

- The create branch's `runProvision` chain is now `createWasteland` \u2192 `storeCredential(is_upstream_admin: true)` \u2192 `createUpstream`. All three are idempotent on retry: `pendingWastelandId` is reused so we never create a second wasteland record, `storeCredential` upserts, and `createUpstream` is documented as idempotent on the server side. Failure mid-chain leaves the wasteland record in place; the user retries from the preview step.
- TypeScript narrowing of `intent` past `isCreateIntent` doesn't cross function-call boundaries cleanly, so the `isUpstreamAdmin` lookup uses an explicit per-branch chain rather than a ternary on the boolean flag. The standalone wizard's picker never surfaces the `reuse` card, so the trailing `: false` branch is unreachable but keeps TS happy.
- The success step's "Browse the upstream" CTA is now shown for both branches when `state.upstream` is set (the previous version hid it for create because the upstream didn't exist yet).
- `resolveUpstreamFromIntent(intent)` always returns a string in practice, so the `by-id` fallback in `postCreateWastelandPath` is defensive \u2014 but keeping it surfaces a graceful path if the resolver ever returns something unparseable in the future.
- The beta-label removal is bundled per the user's request to land it on the same branch.