### PR TITLE
fix(mobile): sanitize user id in consent SecureStore key

### DIFF
--- a/apps/mobile/src/lib/consent-gate.test.ts
+++ b/apps/mobile/src/lib/consent-gate.test.ts
@@ -28,7 +28,7 @@ describe('consent gate', () => {
   it('returns accepted when the current consent version is stored', async () => {
     const { CURRENT_CONSENT_VERSION } = await import('./consent');
     const { checkConsentGate } = await import('./consent-gate');
-    store.set('consent-accepted-user-1', String(CURRENT_CONSENT_VERSION));
+    store.set('consent-accepted-user1', String(CURRENT_CONSENT_VERSION));
 
     expect(await checkConsentGate('user-1')).toEqual({ status: 'accepted' });
   });

--- a/apps/mobile/src/lib/consent.test.ts
+++ b/apps/mobile/src/lib/consent.test.ts
@@ -33,14 +33,25 @@ describe('consent storage', () => {
       await import('./consent');
 
     await acceptConsent('user-1');
-    expect(store.get('consent-accepted-user-1')).toBe(String(CURRENT_CONSENT_VERSION));
+    expect(store.get('consent-accepted-user1')).toBe(String(CURRENT_CONSENT_VERSION));
     expect(await hasAcceptedConsent('user-1')).toBe(true);
+  });
+
+  it('strips characters that are invalid in SecureStore keys', async () => {
+    const { CURRENT_CONSENT_VERSION, acceptConsent, hasAcceptedConsent } =
+      await import('./consent');
+
+    await acceptConsent('oauth/google:103283381342696699340');
+    expect(store.get('consent-accepted-oauthgoogle103283381342696699340')).toBe(
+      String(CURRENT_CONSENT_VERSION)
+    );
+    expect(await hasAcceptedConsent('oauth/google:103283381342696699340')).toBe(true);
   });
 
   it('returns false when the stored consent version is old', async () => {
     const { hasAcceptedConsent } = await import('./consent');
 
-    store.set('consent-accepted-user-1', '0');
+    store.set('consent-accepted-user1', '0');
 
     expect(await hasAcceptedConsent('user-1')).toBe(false);
   });
@@ -48,7 +59,7 @@ describe('consent storage', () => {
   it('returns false for old unversioned consent records', async () => {
     const { hasAcceptedConsent } = await import('./consent');
 
-    store.set('consent-accepted-user-1', 'true');
+    store.set('consent-accepted-user1', 'true');
 
     expect(await hasAcceptedConsent('user-1')).toBe(false);
   });

--- a/apps/mobile/src/lib/consent.ts
+++ b/apps/mobile/src/lib/consent.ts
@@ -13,8 +13,11 @@ type ConsentChangeListener = (change: ConsentChange) => void;
 
 const listeners = new Set<ConsentChangeListener>();
 
+// SecureStore on iOS only accepts alphanumerics, '.', '-', and '_' in keys.
+// User ids can contain other characters (e.g. "oauth/google:103283..."), so strip
+// everything else before using the id as part of a key.
 function keyFor(userId: string): string {
-  return `${CONSENT_USER_KEY_PREFIX}${userId}`;
+  return `${CONSENT_USER_KEY_PREFIX}${userId.replaceAll(/[^A-Za-z0-9]/g, '')}`;
 }
 
 function notifyConsentChange(change: ConsentChange) {


### PR DESCRIPTION
## Summary
- After sign-out → sign-in, users saw a "Could not load privacy choices" bootstrap error.
- Root cause: `hasAcceptedConsent(userId)` builds a SecureStore key as `consent-accepted-${userId}`. iOS SecureStore rejects keys containing characters outside `[A-Za-z0-9._-]`, and user ids can contain other characters (e.g. `oauth/google:103283381342696699340`), causing `getItemAsync` to throw.
- Strip non-alphanumerics from the user id before composing the key. Added a test covering the realistic problem id.

## Test plan
- [ ] Sign in with a user whose id contains `/` or `:` (e.g. `oauth/google:...`) — consent screen renders normally instead of the error screen.
- [ ] Sign in → accept consent → sign out → sign in again with same account — no consent re-prompt, no error.
- [ ] `pnpm exec vitest run src/lib/consent.test.ts src/lib/consent-gate.test.ts` passes.