### PR TITLE
chore(o11y): update API metrics pipeline stream ID

### DIFF
--- a/services/o11y/wrangler.jsonc
+++ b/services/o11y/wrangler.jsonc
@@ -54,7 +54,7 @@
    *     o11y_api_metrics_pipeline o11y_api_metrics_sink
    */
   "pipelines": [
-    { "pipeline": "c596ce8db66547598879af3b5d3ef23c", "binding": "API_METRICS_STREAM" },
+    { "pipeline": "70379355c2d741fc8b4527e69b501f52", "binding": "API_METRICS_STREAM" },
     { "pipeline": "82c1fc4073bb4830a6670e920b9823c2", "binding": "SESSION_METRICS_STREAM" },
   ],
   /**


### PR DESCRIPTION
## Summary
- Update the o11y API metrics Pipeline binding to the recreated stream ID.
- Preserve future deploys after PR #3239 added `kilo_user_id` to the immutable Pipeline stream schema.

## Verification
- Recreated `o11y_api_metrics_stream` with the updated schema after PR #3239 merged.
- Confirmed the new stream and pipeline exist in Cloudflare and the deployed Worker uses the new stream ID.

## Visual Changes
N/A

## Reviewer Notes
Old stream `c596ce8db66547598879af3b5d3ef23c` was deleted by the recreation script. New stream ID is `70379355c2d741fc8b4527e69b501f52`.