### PR TITLE
feat(gastown): add wasteland delete affordance to overview cards

### DIFF
--- a/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
@@ -15,8 +15,10 @@ import { Plus, Factory, Trash2, Skull } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
 import {
+  DeleteWastelandConfirmDialog,
   WastelandCard,
   WastelandListSkeleton,
+  type WastelandItem,
 } from '@/app/(app)/wasteland/_components/WastelandListComponents';
 import { parseDolthubUpstream } from '@/lib/wasteland/upstream';
 
@@ -68,6 +70,27 @@ export function TownListPageClient() {
       },
       onError: err => {
         toast.error(err.message);
+      },
+    })
+  );
+
+  // Wasteland deletion: track the targeted wasteland in local state so the
+  // confirm dialog can render its name and only act on the user's explicit
+  // confirmation. Keeping it here (rather than per-card) means we have a
+  // single dialog instance for the whole grid and no overlap when the
+  // mutation is in flight.
+  const [pendingWastelandDelete, setPendingWastelandDelete] = useState<WastelandItem | null>(null);
+  const deleteWasteland = useMutation(
+    wastelandTrpc.wasteland.deleteWasteland.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: wastelandTrpc.wasteland.listWastelands.queryKey({}),
+        });
+        toast.success('Wasteland deleted');
+        setPendingWastelandDelete(null);
+      },
+      onError: err => {
+        toast.error(`Failed to delete wasteland: ${err.message}`);
       },
     })
   );
@@ -239,11 +262,22 @@ export function TownListPageClient() {
                 key={wasteland.wasteland_id}
                 wasteland={wasteland}
                 onClick={() => router.push(linkForWasteland(wasteland))}
+                onDelete={() => setPendingWastelandDelete(wasteland)}
               />
             ))}
           </div>
         )}
       </section>
+
+      <DeleteWastelandConfirmDialog
+        wasteland={pendingWastelandDelete}
+        isPending={deleteWasteland.isPending}
+        onCancel={() => setPendingWastelandDelete(null)}
+        onConfirm={() => {
+          if (!pendingWastelandDelete) return;
+          deleteWasteland.mutate({ wastelandId: pendingWastelandDelete.wasteland_id });
+        }}
+      />
     </PageContainer>
   );
 }

--- a/apps/web/src/app/(app)/wasteland/_components/WastelandListComponents.tsx
+++ b/apps/web/src/app/(app)/wasteland/_components/WastelandListComponents.tsx
@@ -1,7 +1,19 @@
+import { useState } from 'react';
 import type { WastelandOutputs } from '@/lib/wasteland/trpc';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ExternalLink } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { ExternalLink, Trash2 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 
 export type WastelandItem = WastelandOutputs['wasteland']['listWastelands'][number];
@@ -9,17 +21,38 @@ export type WastelandItem = WastelandOutputs['wasteland']['listWastelands'][numb
 export function WastelandCard({
   wasteland,
   onClick,
+  onDelete,
 }: {
   wasteland: WastelandItem;
   onClick: () => void;
+  /**
+   * When provided, a trash-icon button is rendered in the card's top-right
+   * corner. The icon click stops propagation so it doesn't fire `onClick`
+   * (which navigates to the wasteland). Pages that don't want the
+   * affordance simply omit this prop.
+   */
+  onDelete?: () => void;
 }) {
   return (
     <Card
-      className="cursor-pointer border-white/10 bg-white/[0.03] transition-[border-color,background-color] hover:border-white/20 hover:bg-white/[0.05]"
+      className="relative cursor-pointer border-white/10 bg-white/[0.03] transition-[border-color,background-color] hover:border-white/20 hover:bg-white/[0.05]"
       onClick={onClick}
     >
+      {onDelete && (
+        <button
+          type="button"
+          onClick={e => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          aria-label={`Delete wasteland ${wasteland.name}`}
+          className="absolute right-2 top-2 rounded p-1.5 text-white/35 transition-colors hover:bg-red-500/10 hover:text-red-300"
+        >
+          <Trash2 className="size-4" />
+        </button>
+      )}
       <CardContent className="flex flex-col gap-3 p-4">
-        <h3 className="truncate text-base font-medium text-white/90">{wasteland.name}</h3>
+        <h3 className="truncate pr-8 text-base font-medium text-white/90">{wasteland.name}</h3>
 
         <div className="flex flex-wrap items-center gap-2">
           {wasteland.dolthub_upstream && <DoltHubLink upstream={wasteland.dolthub_upstream} />}
@@ -32,6 +65,79 @@ export function WastelandCard({
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * Type-the-name confirmation dialog for deleting a wasteland. Mirrors the
+ * one in `/wasteland/[owner]/[repo]/settings/SettingsClient.tsx`'s
+ * `DeleteWastelandDialog` so the UX is consistent across surfaces. The
+ * caller controls visibility (so it can drive both the trigger and the
+ * mutation state); when `wasteland` is `null`, the dialog is closed.
+ */
+export function DeleteWastelandConfirmDialog({
+  wasteland,
+  isPending,
+  onCancel,
+  onConfirm,
+}: {
+  wasteland: WastelandItem | null;
+  isPending: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const [confirmText, setConfirmText] = useState('');
+  const open = wasteland !== null;
+  const confirmed = wasteland !== null && confirmText === wasteland.name;
+
+  // Reset the type-to-confirm field whenever the dialog re-targets a
+  // different wasteland (or closes), so the user starts from an empty
+  // input each time.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setConfirmText('');
+      onCancel();
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent className="border-red-500/20 bg-[oklch(0.13_0_0)] sm:max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-red-400">Delete this wasteland?</AlertDialogTitle>
+          <AlertDialogDescription className="text-white/50">
+            This action cannot be undone. Type{' '}
+            <span className="font-mono font-semibold text-white/80">{wasteland?.name ?? ''}</span>{' '}
+            to confirm.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <Input
+          value={confirmText}
+          onChange={e => setConfirmText(e.target.value)}
+          placeholder={wasteland?.name ?? ''}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          className="border-red-500/20 bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/15"
+        />
+        <AlertDialogFooter>
+          <AlertDialogCancel className="border-white/10 text-white/70 hover:bg-white/5 hover:text-white">
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => {
+              setConfirmText('');
+              onConfirm();
+            }}
+            disabled={!confirmed || isPending}
+            className="bg-red-500/80 text-white hover:bg-red-500 disabled:opacity-40"
+          >
+            {isPending ? 'Deleting...' : 'Yes, delete wasteland'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 


### PR DESCRIPTION
## Summary

- Add a trash-icon button to each wasteland card on the personal gastown overview (`/gastown` \u2192 "Wastelands" section). Clicking it opens a type-the-name confirmation dialog and, on confirm, calls the existing `wasteland.deleteWasteland` mutation. Solves the "user accidentally created a ton of wasteland connections and needs to clean them up" support case without forcing them to navigate into each wasteland's settings page.
- Mirrors the existing `DeleteWastelandDialog` UX from `/wasteland/[owner]/[repo]/settings/SettingsClient.tsx` (type the wasteland's name to enable the confirm button) so the destructive flow stays consistent across surfaces.
- The trash icon is opt-in on `WastelandCard`: pages that don't pass `onDelete` (e.g. `WastelandListPageClient`, `OrgWastelandListPageClient`) render unchanged. No card-level affordance leaks to surfaces we don't want it on.

## Verification

- Loaded `/gastown`, hovered each wasteland card \u2192 trash icon appears top-right, clicking it doesn't navigate (`stopPropagation`).
- Clicked the trash icon \u2192 confirm dialog opens with the wasteland's name shown; the "Yes, delete wasteland" button is disabled until the user types the exact name. Pasting an empty string or a typo leaves the action disabled.
- Confirmed deletion \u2192 `wasteland.deleteWasteland` runs, list invalidates, success toast appears, dialog closes.
- Cancelled the dialog \u2192 input clears so the next attempt starts fresh.
- Loaded `/wasteland` and `/organizations/{id}/wasteland` \u2192 unchanged (no trash icon, since `onDelete` isn't passed).
- `pnpm --filter web typecheck` passes.

## Visual Changes

<img width="1551" height="1237" alt="image" src="https://github.com/user-attachments/assets/ba311092-cba9-4ab3-943a-8b0a6774f29e" />

<img width="1551" height="1237" alt="image" src="https://github.com/user-attachments/assets/ecd8248b-b997-4f03-aca9-bad8ebbbe0af" />


## Reviewer Notes

- The `wasteland.deleteWasteland` server procedure already enforces ownership and admin checks (`services/wasteland/src/trpc/router.ts:580-612`), so this PR doesn't need a backend change. Server soft-deletes via `WastelandDO.updateConfig({ status: 'deleted' })` and removes the registry entry.
- Trash icon is rendered only when `onDelete` is supplied. The card grid pages that should *not* expose this affordance (the personal `/wasteland` list and the org list) intentionally omit the prop. We can flip the affordance on for those later in their own PRs if/when product wants it.
- The reusable `DeleteWastelandConfirmDialog` was added to the shared `_components/WastelandListComponents.tsx` so it can be picked up in the same way later.