### PR TITLE
feat(kiloclaw): add Google Calendar source to morning briefing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2245,6 +2245,9 @@ importers:
       esbuild:
         specifier: '>=0.25.0'
         version: 0.27.4
+      openclaw:
+        specifier: 2026.4.23
+        version: 2026.4.23(@napi-rs/canvas@0.1.100)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       vitest:
         specifier: 'catalog:'
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/package.json
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/package.json
@@ -18,14 +18,16 @@
     "prepack": "npm run build",
     "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node22 --external:openclaw --external:openclaw/* --outfile=dist/index.js",
     "clean": "rm -rf dist",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsgo --noEmit"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.3.24-beta.2"
+    "openclaw": "2026.4.23"
   },
   "devDependencies": {
     "@sinclair/typebox": "0.34.41",
     "esbuild": "0.25.12",
+    "openclaw": "2026.4.23",
     "vitest": "catalog:"
   }
 }

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
 export type BriefingSourceStatus = {
-  source: 'github' | 'linear' | 'local-news' | 'web';
+  source: 'calendar' | 'github' | 'linear' | 'local-news' | 'web';
   configured: boolean;
   ok: boolean;
   summary: string;

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-client.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-client.test.ts
@@ -30,6 +30,7 @@ describe('resolveCalendarReady', () => {
   it('returns connected=false when the broker reports no connection', async () => {
     const fetchImpl = mockFetch(async () => jsonResponse({ connected: false, accounts: [] }, 200));
     const result = await resolveCalendarReady({ fetchImpl });
+    expect(result.statusOk).toBe(true);
     expect(result.connected).toBe(false);
     expect(result.accountEmail).toBeNull();
     expect(result.hasCalendarCapability).toBe(false);
@@ -58,6 +59,7 @@ describe('resolveCalendarReady', () => {
       )
     );
     const result = await resolveCalendarReady({ fetchImpl });
+    expect(result.statusOk).toBe(true);
     expect(result.connected).toBe(true);
     expect(result.accountEmail).toBe('astorms@kilocode.ai');
     expect(result.hasCalendarCapability).toBe(true);
@@ -118,6 +120,7 @@ describe('resolveCalendarReady', () => {
   it('returns a failure reason when the broker returns 5xx', async () => {
     const fetchImpl = mockFetch(async () => jsonResponse({ error: 'boom' }, 503));
     const result = await resolveCalendarReady({ fetchImpl });
+    expect(result.statusOk).toBe(false);
     expect(result.connected).toBe(false);
     expect(result.reason).toContain('(503)');
     expect(result.reason).toContain('boom');

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-client.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-client.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchCalendarAccessToken,
+  fetchCalendarEvents,
+  resolveCalendarReady,
+} from './calendar-client';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV, OPENCLAW_GATEWAY_TOKEN: 'test-token' };
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+function mockFetch(impl: typeof fetch): typeof fetch {
+  return vi.fn(impl) as unknown as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('resolveCalendarReady', () => {
+  it('returns connected=false when the broker reports no connection', async () => {
+    const fetchImpl = mockFetch(async () => jsonResponse({ connected: false, accounts: [] }, 200));
+    const result = await resolveCalendarReady({ fetchImpl });
+    expect(result.connected).toBe(false);
+    expect(result.accountEmail).toBeNull();
+    expect(result.hasCalendarCapability).toBe(false);
+    expect(result.reason).toBe('Google account not connected');
+  });
+
+  it('returns connected=true with hasCalendarCapability=true when services includes calendar_read', async () => {
+    const fetchImpl = mockFetch(async () =>
+      jsonResponse(
+        {
+          connected: true,
+          accounts: [
+            {
+              email: 'astorms@kilocode.ai',
+              client: 'kilo-oauth',
+              services: ['calendar_read'],
+              scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+              created_at: '2026-05-01T00:00:00Z',
+              auth: 'oauth',
+              profile: 'kilo_owned',
+              status: 'active',
+            },
+          ],
+        },
+        200
+      )
+    );
+    const result = await resolveCalendarReady({ fetchImpl });
+    expect(result.connected).toBe(true);
+    expect(result.accountEmail).toBe('astorms@kilocode.ai');
+    expect(result.hasCalendarCapability).toBe(true);
+  });
+
+  it('detects calendar scope when capability flag is absent', async () => {
+    const fetchImpl = mockFetch(async () =>
+      jsonResponse(
+        {
+          connected: true,
+          accounts: [
+            {
+              email: 'astorms@kilocode.ai',
+              client: 'kilo-legacy',
+              services: ['gmail_read'],
+              scopes: ['https://www.googleapis.com/auth/calendar.events.readonly'],
+              created_at: '2026-05-01T00:00:00Z',
+              auth: 'oauth-legacy',
+              profile: 'legacy',
+              status: 'active',
+            },
+          ],
+        },
+        200
+      )
+    );
+    const result = await resolveCalendarReady({ fetchImpl });
+    expect(result.hasCalendarCapability).toBe(true);
+  });
+
+  it('returns hasCalendarCapability=false when neither services nor scopes mention calendar', async () => {
+    const fetchImpl = mockFetch(async () =>
+      jsonResponse(
+        {
+          connected: true,
+          accounts: [
+            {
+              email: 'astorms@kilocode.ai',
+              client: 'kilo-oauth',
+              services: ['gmail_read'],
+              scopes: ['https://www.googleapis.com/auth/gmail.readonly'],
+              created_at: '2026-05-01T00:00:00Z',
+              auth: 'oauth',
+              profile: 'kilo_owned',
+              status: 'active',
+            },
+          ],
+        },
+        200
+      )
+    );
+    const result = await resolveCalendarReady({ fetchImpl });
+    expect(result.connected).toBe(true);
+    expect(result.hasCalendarCapability).toBe(false);
+    expect(result.reason).toContain('missing calendar scope');
+  });
+
+  it('returns a failure reason when the broker returns 5xx', async () => {
+    const fetchImpl = mockFetch(async () => jsonResponse({ error: 'boom' }, 503));
+    const result = await resolveCalendarReady({ fetchImpl });
+    expect(result.connected).toBe(false);
+    expect(result.reason).toContain('(503)');
+    expect(result.reason).toContain('boom');
+  });
+});
+
+describe('fetchCalendarAccessToken', () => {
+  it('returns accessToken + accountEmail on broker success', async () => {
+    const fetchImpl = mockFetch(async () =>
+      jsonResponse(
+        {
+          accessToken: 'ya29.fake',
+          expiresAt: '2026-05-19T16:00:00Z',
+          accountEmail: 'astorms@kilocode.ai',
+          scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+        },
+        200
+      )
+    );
+    const token = await fetchCalendarAccessToken({ fetchImpl });
+    expect(token.accessToken).toBe('ya29.fake');
+    expect(token.accountEmail).toBe('astorms@kilocode.ai');
+  });
+
+  it('throws a stable error code when the broker returns 5xx', async () => {
+    const fetchImpl = mockFetch(async () => jsonResponse({ error: 'broker_down' }, 502));
+    await expect(fetchCalendarAccessToken({ fetchImpl })).rejects.toThrow(
+      /google_oauth_token_fetch_failed:502/
+    );
+  });
+});
+
+describe('fetchCalendarEvents', () => {
+  it('parses events from the Google API response', async () => {
+    const fetchImpl = mockFetch(async () =>
+      jsonResponse(
+        {
+          items: [
+            {
+              id: 'evt-1',
+              summary: 'Standup',
+              start: { dateTime: '2026-05-19T16:00:00Z' },
+              end: { dateTime: '2026-05-19T16:30:00Z' },
+            },
+            {
+              id: 'evt-2',
+              summary: 'Offsite',
+              start: { date: '2026-05-19' },
+              end: { date: '2026-05-20' },
+            },
+          ],
+        },
+        200
+      )
+    );
+    const events = await fetchCalendarEvents(
+      'ya29.fake',
+      '2026-05-19T00:00:00Z',
+      '2026-05-20T12:00:00Z',
+      { fetchImpl }
+    );
+    expect(events).toHaveLength(2);
+    expect(events[0].id).toBe('evt-1');
+    expect(events[1].id).toBe('evt-2');
+  });
+
+  it('returns an empty array when items is missing', async () => {
+    const fetchImpl = mockFetch(async () => jsonResponse({}, 200));
+    const events = await fetchCalendarEvents('ya29.fake', 'a', 'b', { fetchImpl });
+    expect(events).toEqual([]);
+  });
+
+  it('throws with the Google error message on 401', async () => {
+    const fetchImpl = mockFetch(async () =>
+      jsonResponse({ error: { message: 'Invalid Credentials' } }, 401)
+    );
+    await expect(fetchCalendarEvents('ya29.fake', 'a', 'b', { fetchImpl })).rejects.toThrow(
+      /google_calendar_fetch_failed:401:Invalid Credentials/
+    );
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-client.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-client.ts
@@ -28,6 +28,7 @@ export interface CalendarClientDeps {
 }
 
 export interface CalendarReadiness {
+  statusOk: boolean;
   connected: boolean;
   accountEmail: string | null;
   hasCalendarCapability: boolean;
@@ -117,6 +118,7 @@ export async function resolveCalendarReady(
   const result = await brokerPost<BrokerStatusResponse>('/_kilo/google-oauth/status', {}, deps);
   if (!result.ok) {
     return {
+      statusOk: false,
       connected: false,
       accountEmail: null,
       hasCalendarCapability: false,
@@ -125,6 +127,7 @@ export async function resolveCalendarReady(
   }
   if (!result.data.connected || result.data.accounts.length === 0) {
     return {
+      statusOk: true,
       connected: false,
       accountEmail: null,
       hasCalendarCapability: false,
@@ -136,6 +139,7 @@ export async function resolveCalendarReady(
     account.services.includes(CALENDAR_CAPABILITY) ||
     account.scopes.some(scope => scope.includes('calendar'));
   return {
+    statusOk: true,
     connected: true,
     accountEmail: account.email,
     hasCalendarCapability,

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-client.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-client.ts
@@ -1,0 +1,207 @@
+/**
+ * HTTP wrappers for the controller's Google OAuth broker
+ * (`/_kilo/google-oauth/{status,token}`) and Google Calendar's
+ * `events.list` REST endpoint.
+ *
+ * The broker handles both connection paths in Settings transparently:
+ *   - "Calendar Connect" (simple OAuth, credential_profile=kilo_owned)
+ *   - "Full Google Account" (gog migrated to db, credential_profile=legacy)
+ * Both materialize as a single per-instance row, so this client only
+ * needs to ask the broker for status + tokens and doesn't branch on
+ * which UI path was used.
+ *
+ * All HTTP failures surface as thrown Errors with stable string codes
+ * so `collectCalendar` can map them to `SourceCollectionResult.ok=false`
+ * summaries.
+ */
+
+import type { CalendarEvent } from './calendar-utils';
+
+const DEFAULT_CONTROLLER_URL = 'http://127.0.0.1:18789';
+const CALENDAR_API_BASE = 'https://www.googleapis.com/calendar/v3';
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export interface CalendarClientDeps {
+  controllerUrl?: string;
+  gatewayToken?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface CalendarReadiness {
+  connected: boolean;
+  accountEmail: string | null;
+  hasCalendarCapability: boolean;
+  reason: string;
+}
+
+export interface CalendarToken {
+  accessToken: string;
+  accountEmail: string;
+  scopes: string[];
+}
+
+interface BrokerStatusAccount {
+  email: string;
+  client: string;
+  services: string[];
+  scopes: string[];
+  auth: string;
+  profile: string;
+  status: string;
+}
+
+interface BrokerStatusResponse {
+  connected: boolean;
+  accounts: BrokerStatusAccount[];
+}
+
+function resolveControllerUrl(deps: CalendarClientDeps): string {
+  return deps.controllerUrl ?? process.env.KILOCLAW_CONTROLLER_URL ?? DEFAULT_CONTROLLER_URL;
+}
+
+function resolveGatewayToken(deps: CalendarClientDeps): string {
+  const token = deps.gatewayToken ?? process.env.OPENCLAW_GATEWAY_TOKEN;
+  if (!token) {
+    throw new Error('OPENCLAW_GATEWAY_TOKEN is not set');
+  }
+  return token;
+}
+
+function resolveFetch(deps: CalendarClientDeps): typeof fetch {
+  return deps.fetchImpl ?? fetch;
+}
+
+async function brokerPost<T>(
+  path: string,
+  body: unknown,
+  deps: CalendarClientDeps
+): Promise<{ ok: true; data: T } | { ok: false; status: number; message: string }> {
+  const url = `${resolveControllerUrl(deps).replace(/\/$/, '')}${path}`;
+  const fetchImpl = resolveFetch(deps);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${resolveGatewayToken(deps)}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+    if (!response.ok) {
+      const message =
+        typeof payload.error === 'string' ? payload.error : `broker_${response.status}`;
+      return { ok: false, status: response.status, message };
+    }
+    return { ok: true, data: payload as T };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, status: 0, message };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Capability flag the broker uses for calendar.events.list scope.
+ * Mirrors `GOOGLE_CAPABILITY_SCOPES` in the worker controller.
+ */
+const CALENDAR_CAPABILITY = 'calendar_read';
+
+export async function resolveCalendarReady(
+  deps: CalendarClientDeps = {}
+): Promise<CalendarReadiness> {
+  const result = await brokerPost<BrokerStatusResponse>('/_kilo/google-oauth/status', {}, deps);
+  if (!result.ok) {
+    return {
+      connected: false,
+      accountEmail: null,
+      hasCalendarCapability: false,
+      reason: `Google OAuth status check failed (${result.status}): ${result.message}`,
+    };
+  }
+  if (!result.data.connected || result.data.accounts.length === 0) {
+    return {
+      connected: false,
+      accountEmail: null,
+      hasCalendarCapability: false,
+      reason: 'Google account not connected',
+    };
+  }
+  const account = result.data.accounts[0];
+  const hasCalendarCapability =
+    account.services.includes(CALENDAR_CAPABILITY) ||
+    account.scopes.some(scope => scope.includes('calendar'));
+  return {
+    connected: true,
+    accountEmail: account.email,
+    hasCalendarCapability,
+    reason: hasCalendarCapability
+      ? 'connected'
+      : 'Google account connected but missing calendar scope',
+  };
+}
+
+export async function fetchCalendarAccessToken(
+  deps: CalendarClientDeps = {}
+): Promise<CalendarToken> {
+  const result = await brokerPost<{
+    accessToken: string;
+    accountEmail: string;
+    scopes: string[];
+  }>('/_kilo/google-oauth/token', { capabilities: [CALENDAR_CAPABILITY] }, deps);
+  if (!result.ok) {
+    throw new Error(`google_oauth_token_fetch_failed:${result.status}:${result.message}`);
+  }
+  return {
+    accessToken: result.data.accessToken,
+    accountEmail: result.data.accountEmail,
+    scopes: result.data.scopes,
+  };
+}
+
+export async function fetchCalendarEvents(
+  accessToken: string,
+  timeMin: string,
+  timeMax: string,
+  deps: CalendarClientDeps = {}
+): Promise<CalendarEvent[]> {
+  const fetchImpl = resolveFetch(deps);
+  const params = new URLSearchParams({
+    timeMin,
+    timeMax,
+    singleEvents: 'true',
+    orderBy: 'startTime',
+    maxResults: '25',
+  });
+  const url = `${CALENDAR_API_BASE}/calendars/primary/events?${params.toString()}`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(url, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const errorPayload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+      const message =
+        (errorPayload.error as Record<string, unknown>)?.message ?? `google_api_${response.status}`;
+      throw new Error(`google_calendar_fetch_failed:${response.status}:${String(message)}`);
+    }
+    const payload = (await response.json()) as { items?: unknown };
+    if (!Array.isArray(payload.items)) return [];
+    return payload.items.filter(isCalendarEvent);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function isCalendarEvent(value: unknown): value is CalendarEvent {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.id === 'string' && typeof v.start === 'object' && typeof v.end === 'object';
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCalendarNoConnectionLines,
+  buildCalendarSectionLines,
+  buildCalendarSectionTitle,
+  buildCalendarTimeWindow,
+  formatAllDayEventLine,
+  formatEventTitle,
+  formatTimedEventLine,
+  isAllDayEvent,
+  partitionEventsByDay,
+  type CalendarEvent,
+} from './calendar-utils';
+
+function event(overrides: Partial<CalendarEvent> & { id: string }): CalendarEvent {
+  return {
+    id: overrides.id,
+    summary: overrides.summary ?? null,
+    start: overrides.start ?? {},
+    end: overrides.end ?? {},
+  };
+}
+
+describe('buildCalendarTimeWindow', () => {
+  it('returns timeMin at start of today and timeMax at noon tomorrow', () => {
+    // 2026-05-19T15:00:00Z — afternoon in PDT (08:00 PDT)
+    const now = new Date('2026-05-19T15:00:00Z');
+    const window = buildCalendarTimeWindow(now, 'America/Los_Angeles');
+    expect(window.timeMin).toBe('2026-05-19T00:00:00-07:00');
+    expect(window.timeMax).toBe('2026-05-20T12:00:00-07:00');
+  });
+
+  it('handles UTC timezone with Z offset', () => {
+    const now = new Date('2026-05-19T15:00:00Z');
+    const window = buildCalendarTimeWindow(now, 'UTC');
+    expect(window.timeMin).toBe('2026-05-19T00:00:00Z');
+    expect(window.timeMax).toBe('2026-05-20T12:00:00Z');
+  });
+
+  it('rolls over correctly when the UTC instant lands on the next local day', () => {
+    // 2026-05-19T23:00:00Z is 2026-05-20T07:00 in Asia/Tokyo (+09:00)
+    const now = new Date('2026-05-19T23:00:00Z');
+    const window = buildCalendarTimeWindow(now, 'Asia/Tokyo');
+    expect(window.timeMin).toBe('2026-05-20T00:00:00+09:00');
+    expect(window.timeMax).toBe('2026-05-21T12:00:00+09:00');
+  });
+
+  it('falls back to UTC when timezone is empty', () => {
+    const now = new Date('2026-05-19T15:00:00Z');
+    const window = buildCalendarTimeWindow(now, '');
+    expect(window.timeMin).toBe('2026-05-19T00:00:00Z');
+  });
+});
+
+describe('formatEventTitle', () => {
+  it('returns the trimmed summary when provided', () => {
+    expect(formatEventTitle(event({ id: '1', summary: '  Standup  ' }))).toBe('Standup');
+  });
+
+  it('falls back to "(no title)" when summary is null or empty', () => {
+    expect(formatEventTitle(event({ id: '1', summary: null }))).toBe('(no title)');
+    expect(formatEventTitle(event({ id: '2', summary: '   ' }))).toBe('(no title)');
+  });
+});
+
+describe('isAllDayEvent', () => {
+  it('returns true for events with a date but no dateTime', () => {
+    expect(
+      isAllDayEvent(event({ id: '1', start: { date: '2026-05-19' }, end: { date: '2026-05-20' } }))
+    ).toBe(true);
+  });
+
+  it('returns false for events with a dateTime', () => {
+    expect(
+      isAllDayEvent(
+        event({
+          id: '1',
+          start: { dateTime: '2026-05-19T09:00:00-07:00' },
+          end: { dateTime: '2026-05-19T10:00:00-07:00' },
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+describe('formatTimedEventLine', () => {
+  it('formats HH:MM-HH:MM title in the user timezone', () => {
+    const e = event({
+      id: '1',
+      summary: '1:1 with Sarah',
+      start: { dateTime: '2026-05-19T16:00:00Z' },
+      end: { dateTime: '2026-05-19T17:00:00Z' },
+    });
+    expect(formatTimedEventLine(e, 'America/Los_Angeles')).toBe('- 09:00-10:00 1:1 with Sarah');
+  });
+
+  it('falls back to title-only when dateTime is missing', () => {
+    const e = event({ id: '1', summary: 'Weird event' });
+    expect(formatTimedEventLine(e, 'UTC')).toBe('- Weird event');
+  });
+});
+
+describe('formatAllDayEventLine', () => {
+  it('prefixes with "All day:"', () => {
+    expect(
+      formatAllDayEventLine(
+        event({ id: '1', summary: 'Team offsite', start: { date: '2026-05-19' } })
+      )
+    ).toBe('- All day: Team offsite');
+  });
+});
+
+describe('partitionEventsByDay', () => {
+  const now = new Date('2026-05-19T15:00:00Z'); // 2026-05-19 in LA
+  const tz = 'America/Los_Angeles';
+
+  it('groups events into today vs tomorrow, timed vs all-day', () => {
+    const events: CalendarEvent[] = [
+      event({
+        id: 'a',
+        summary: 'Today timed B',
+        start: { dateTime: '2026-05-19T21:00:00Z' }, // 14:00 LA
+        end: { dateTime: '2026-05-19T22:00:00Z' },
+      }),
+      event({
+        id: 'b',
+        summary: 'Today timed A',
+        start: { dateTime: '2026-05-19T17:00:00Z' }, // 10:00 LA
+        end: { dateTime: '2026-05-19T18:00:00Z' },
+      }),
+      event({ id: 'c', summary: 'Today all-day', start: { date: '2026-05-19' } }),
+      event({
+        id: 'd',
+        summary: 'Tomorrow timed',
+        start: { dateTime: '2026-05-20T15:00:00Z' }, // 08:00 LA next day
+        end: { dateTime: '2026-05-20T16:00:00Z' },
+      }),
+      event({ id: 'e', summary: 'Tomorrow all-day', start: { date: '2026-05-20' } }),
+      event({
+        id: 'f',
+        summary: 'Stray two days out',
+        start: { dateTime: '2026-05-21T15:00:00Z' },
+        end: { dateTime: '2026-05-21T16:00:00Z' },
+      }),
+    ];
+
+    const partitioned = partitionEventsByDay(events, now, tz);
+    expect(partitioned.todayTimed.map(e => e.id)).toEqual(['b', 'a']); // sorted by start
+    expect(partitioned.todayAllDay.map(e => e.id)).toEqual(['c']);
+    expect(partitioned.tomorrowTimed.map(e => e.id)).toEqual(['d']);
+    expect(partitioned.tomorrowAllDay.map(e => e.id)).toEqual(['e']);
+    // 'f' is two days out — dropped.
+  });
+});
+
+describe('buildCalendarSectionLines', () => {
+  const now = new Date('2026-05-19T15:00:00Z');
+  const tz = 'America/Los_Angeles';
+
+  it('renders today + tomorrow morning sections', () => {
+    const events: CalendarEvent[] = [
+      event({
+        id: 'a',
+        summary: 'Standup',
+        start: { dateTime: '2026-05-19T16:00:00Z' }, // 09:00 LA
+        end: { dateTime: '2026-05-19T16:30:00Z' },
+      }),
+      event({
+        id: 'b',
+        summary: 'Coffee with Alex',
+        start: { dateTime: '2026-05-20T15:00:00Z' }, // 08:00 LA next day
+        end: { dateTime: '2026-05-20T16:00:00Z' },
+      }),
+      event({ id: 'c', summary: 'Team offsite', start: { date: '2026-05-19' } }),
+    ];
+
+    const lines = buildCalendarSectionLines(events, now, tz);
+    expect(lines).toEqual([
+      '- 09:00-09:30 Standup',
+      '- All day: Team offsite',
+      '',
+      'Tomorrow morning',
+      '- 08:00-09:00 Coffee with Alex',
+    ]);
+  });
+
+  it('emits a single "no events" line when calendar is empty', () => {
+    expect(buildCalendarSectionLines([], now, tz)).toEqual([
+      'No events on your calendar for today or tomorrow morning.',
+    ]);
+  });
+
+  it('shows "No events today." when only tomorrow has events', () => {
+    const events: CalendarEvent[] = [
+      event({
+        id: 'b',
+        summary: 'Coffee',
+        start: { dateTime: '2026-05-20T15:00:00Z' },
+        end: { dateTime: '2026-05-20T16:00:00Z' },
+      }),
+    ];
+    expect(buildCalendarSectionLines(events, now, tz)).toEqual([
+      'No events today.',
+      '',
+      'Tomorrow morning',
+      '- 08:00-09:00 Coffee',
+    ]);
+  });
+
+  it('omits the "Tomorrow morning" subsection when tomorrow is empty', () => {
+    const events: CalendarEvent[] = [
+      event({
+        id: 'a',
+        summary: 'Standup',
+        start: { dateTime: '2026-05-19T16:00:00Z' },
+        end: { dateTime: '2026-05-19T16:30:00Z' },
+      }),
+    ];
+    expect(buildCalendarSectionLines(events, now, tz)).toEqual(['- 09:00-09:30 Standup']);
+  });
+});
+
+describe('buildCalendarSectionTitle', () => {
+  it('formats "{email} daily calendar"', () => {
+    expect(buildCalendarSectionTitle('storms@kilocode.ai')).toBe(
+      'storms@kilocode.ai daily calendar'
+    );
+  });
+});
+
+describe('buildCalendarNoConnectionLines', () => {
+  it('emits the connect-your-google nudge', () => {
+    expect(buildCalendarNoConnectionLines()).toEqual([
+      "Connect your Google account in Settings to see today's events.",
+    ]);
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildCalendarMissingScopeLines,
   buildCalendarNoConnectionLines,
   buildCalendarSectionLines,
   buildCalendarSectionTitle,
@@ -289,6 +290,14 @@ describe('buildCalendarNoConnectionLines', () => {
   it('emits the connect-your-google nudge', () => {
     expect(buildCalendarNoConnectionLines()).toEqual([
       "Connect your Google account in Settings to see today's events.",
+    ]);
+  });
+});
+
+describe('buildCalendarMissingScopeLines', () => {
+  it('emits the reconnect-with-calendar-scope nudge', () => {
+    expect(buildCalendarMissingScopeLines()).toEqual([
+      "Your Google account is connected, but it's missing calendar permission. Reconnect from Settings and include calendar access to see today's events.",
     ]);
   });
 });

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.test.ts
@@ -50,6 +50,22 @@ describe('buildCalendarTimeWindow', () => {
     const window = buildCalendarTimeWindow(now, '');
     expect(window.timeMin).toBe('2026-05-19T00:00:00Z');
   });
+
+  it('uses the correct offset for each boundary across DST start', () => {
+    // 2026-03-08 starts in PST (-08:00), then switches to PDT (-07:00).
+    const now = new Date('2026-03-08T15:00:00Z');
+    const window = buildCalendarTimeWindow(now, 'America/Los_Angeles');
+    expect(window.timeMin).toBe('2026-03-08T00:00:00-08:00');
+    expect(window.timeMax).toBe('2026-03-09T12:00:00-07:00');
+  });
+
+  it('uses the correct offset for each boundary across DST end', () => {
+    // 2026-11-01 starts in PDT (-07:00), then switches to PST (-08:00).
+    const now = new Date('2026-11-01T15:00:00Z');
+    const window = buildCalendarTimeWindow(now, 'America/Los_Angeles');
+    expect(window.timeMin).toBe('2026-11-01T00:00:00-07:00');
+    expect(window.timeMax).toBe('2026-11-02T12:00:00-08:00');
+  });
 });
 
 describe('formatEventTitle', () => {
@@ -150,6 +166,47 @@ describe('partitionEventsByDay', () => {
     expect(partitioned.tomorrowTimed.map(e => e.id)).toEqual(['d']);
     expect(partitioned.tomorrowAllDay.map(e => e.id)).toEqual(['e']);
     // 'f' is two days out — dropped.
+  });
+
+  it('includes all-day events that overlap today or tomorrow even when they started earlier', () => {
+    const events: CalendarEvent[] = [
+      event({
+        id: 'a',
+        summary: 'Conference',
+        start: { date: '2026-05-18' },
+        end: { date: '2026-05-21' },
+      }),
+      event({
+        id: 'b',
+        summary: 'Ended yesterday',
+        start: { date: '2026-05-18' },
+        end: { date: '2026-05-19' },
+      }),
+    ];
+
+    const partitioned = partitionEventsByDay(events, now, tz);
+    expect(partitioned.todayAllDay.map(e => e.id)).toEqual(['a']);
+    expect(partitioned.tomorrowAllDay.map(e => e.id)).toEqual(['a']);
+  });
+
+  it('sorts timed events by instant when dateTime offsets differ', () => {
+    const events: CalendarEvent[] = [
+      event({
+        id: 'a',
+        summary: 'LA breakfast',
+        start: { dateTime: '2026-05-19T07:00:00-07:00' },
+        end: { dateTime: '2026-05-19T07:30:00-07:00' },
+      }),
+      event({
+        id: 'b',
+        summary: 'NY check-in',
+        start: { dateTime: '2026-05-19T09:00:00-04:00' },
+        end: { dateTime: '2026-05-19T09:30:00-04:00' },
+      }),
+    ];
+
+    const partitioned = partitionEventsByDay(events, now, tz);
+    expect(partitioned.todayTimed.map(e => e.id)).toEqual(['b', 'a']);
   });
 });
 

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.ts
@@ -41,9 +41,13 @@ function getTimezoneOffset(date: Date, timezone: string): string {
     const parts = formatter.formatToParts(date);
     const offsetPart = parts.find(part => part.type === 'timeZoneName');
     if (!offsetPart) return 'Z';
-    // longOffset renders as "GMT-07:00" or just "GMT" for UTC.
+    // longOffset normally renders as "GMT-07:00". For UTC, some ICU
+    // implementations emit bare "GMT" (macOS), others emit "GMT+00:00"
+    // (Linux). Normalize both to the bare "Z" suffix so the produced
+    // ISO string round-trips identically across platforms.
     const match = offsetPart.value.match(/GMT([+-]\d{2}:\d{2})/);
-    return match ? match[1] : 'Z';
+    if (!match) return 'Z';
+    return match[1] === '+00:00' || match[1] === '-00:00' ? 'Z' : match[1];
   } catch {
     return 'Z';
   }

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.ts
@@ -1,0 +1,231 @@
+/**
+ * Pure helpers for the Google Calendar source.
+ *
+ * Kept side-effect free so the unit tests cover the date arithmetic,
+ * formatting, and grouping logic without mocking fetch or the broker.
+ * `calendar-client.ts` owns the HTTP layer; `index.ts` glues them
+ * together inside `collectCalendar`.
+ *
+ * Time window semantics:
+ *   - timeMin: start of today in the user's timezone.
+ *   - timeMax: noon of tomorrow in the user's timezone.
+ *   We deliberately cut at noon tomorrow so a 7am brief warns about an
+ *   8am tomorrow meeting without dumping the whole next day.
+ */
+
+const DEFAULT_TIMEZONE = 'UTC';
+
+export interface CalendarEvent {
+  id: string;
+  summary: string | null;
+  start: { dateTime?: string | null; date?: string | null; timeZone?: string | null };
+  end: { dateTime?: string | null; date?: string | null; timeZone?: string | null };
+}
+
+export interface CalendarTimeWindow {
+  timeMin: string;
+  timeMax: string;
+}
+
+/**
+ * Pulls the ISO offset (e.g. `-07:00`) for a given UTC instant in the
+ * named IANA zone. Used to construct ISO strings that the Google
+ * Calendar API will accept as wall-clock-anchored.
+ */
+function getTimezoneOffset(date: Date, timezone: string): string {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      timeZoneName: 'longOffset',
+    });
+    const parts = formatter.formatToParts(date);
+    const offsetPart = parts.find(part => part.type === 'timeZoneName');
+    if (!offsetPart) return 'Z';
+    // longOffset renders as "GMT-07:00" or just "GMT" for UTC.
+    const match = offsetPart.value.match(/GMT([+-]\d{2}:\d{2})/);
+    return match ? match[1] : 'Z';
+  } catch {
+    return 'Z';
+  }
+}
+
+/**
+ * Returns the `YYYY-MM-DD` for the calendar day containing `date` in
+ * `timezone`. Mirrors `formatDateKey` in briefing-utils, kept inline
+ * to keep this module free of cross-module pulls.
+ */
+function dateKeyInZone(date: Date, timezone: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+  const year = parts.find(p => p.type === 'year')?.value ?? '1970';
+  const month = parts.find(p => p.type === 'month')?.value ?? '01';
+  const day = parts.find(p => p.type === 'day')?.value ?? '01';
+  return `${year}-${month}-${day}`;
+}
+
+function addDays(dateKey: string, days: number): string {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  const utc = new Date(Date.UTC(year, month - 1, day));
+  utc.setUTCDate(utc.getUTCDate() + days);
+  const offsetYear = utc.getUTCFullYear();
+  const offsetMonth = String(utc.getUTCMonth() + 1).padStart(2, '0');
+  const offsetDay = String(utc.getUTCDate()).padStart(2, '0');
+  return `${offsetYear}-${offsetMonth}-${offsetDay}`;
+}
+
+export function buildCalendarTimeWindow(now: Date, userTimezone: string): CalendarTimeWindow {
+  const tz = userTimezone || DEFAULT_TIMEZONE;
+  const todayKey = dateKeyInZone(now, tz);
+  const tomorrowKey = addDays(todayKey, 1);
+  const offset = getTimezoneOffset(now, tz);
+  return {
+    timeMin: `${todayKey}T00:00:00${offset}`,
+    timeMax: `${tomorrowKey}T12:00:00${offset}`,
+  };
+}
+
+function formatTime(isoDateTime: string, timezone: string): string {
+  const date = new Date(isoDateTime);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone || DEFAULT_TIMEZONE,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+}
+
+function eventDayKey(event: CalendarEvent, timezone: string): string {
+  if (event.start.date) return event.start.date;
+  if (event.start.dateTime) {
+    return dateKeyInZone(new Date(event.start.dateTime), timezone || DEFAULT_TIMEZONE);
+  }
+  return '';
+}
+
+export function isAllDayEvent(event: CalendarEvent): boolean {
+  return Boolean(event.start.date && !event.start.dateTime);
+}
+
+export function formatEventTitle(event: CalendarEvent): string {
+  const summary = event.summary?.trim();
+  return summary && summary.length > 0 ? summary : '(no title)';
+}
+
+export function formatTimedEventLine(event: CalendarEvent, timezone: string): string {
+  if (!event.start.dateTime || !event.end.dateTime) {
+    return `- ${formatEventTitle(event)}`;
+  }
+  const start = formatTime(event.start.dateTime, timezone);
+  const end = formatTime(event.end.dateTime, timezone);
+  return `- ${start}-${end} ${formatEventTitle(event)}`;
+}
+
+export function formatAllDayEventLine(event: CalendarEvent): string {
+  return `- All day: ${formatEventTitle(event)}`;
+}
+
+interface PartitionedEvents {
+  todayTimed: CalendarEvent[];
+  todayAllDay: CalendarEvent[];
+  tomorrowTimed: CalendarEvent[];
+  tomorrowAllDay: CalendarEvent[];
+}
+
+export function partitionEventsByDay(
+  events: CalendarEvent[],
+  now: Date,
+  timezone: string
+): PartitionedEvents {
+  const tz = timezone || DEFAULT_TIMEZONE;
+  const todayKey = dateKeyInZone(now, tz);
+  const tomorrowKey = addDays(todayKey, 1);
+
+  const todayTimed: CalendarEvent[] = [];
+  const todayAllDay: CalendarEvent[] = [];
+  const tomorrowTimed: CalendarEvent[] = [];
+  const tomorrowAllDay: CalendarEvent[] = [];
+
+  for (const event of events) {
+    const dayKey = eventDayKey(event, tz);
+    const isAllDay = isAllDayEvent(event);
+    if (dayKey === todayKey) {
+      if (isAllDay) {
+        todayAllDay.push(event);
+      } else {
+        todayTimed.push(event);
+      }
+    } else if (dayKey === tomorrowKey) {
+      if (isAllDay) {
+        tomorrowAllDay.push(event);
+      } else {
+        tomorrowTimed.push(event);
+      }
+    }
+    // Events outside today/tomorrow are dropped — the time window
+    // limits API results, this is belt-and-suspenders for stragglers.
+  }
+
+  todayTimed.sort(timedEventComparator);
+  tomorrowTimed.sort(timedEventComparator);
+
+  return { todayTimed, todayAllDay, tomorrowTimed, tomorrowAllDay };
+}
+
+function timedEventComparator(a: CalendarEvent, b: CalendarEvent): number {
+  const aStart = a.start.dateTime ?? '';
+  const bStart = b.start.dateTime ?? '';
+  return aStart.localeCompare(bStart);
+}
+
+export function buildCalendarSectionTitle(accountEmail: string): string {
+  return `${accountEmail} daily calendar`;
+}
+
+export function buildCalendarSectionLines(
+  events: CalendarEvent[],
+  now: Date,
+  timezone: string
+): string[] {
+  const { todayTimed, todayAllDay, tomorrowTimed, tomorrowAllDay } = partitionEventsByDay(
+    events,
+    now,
+    timezone
+  );
+
+  const todayLines: string[] = [
+    ...todayTimed.map(event => formatTimedEventLine(event, timezone)),
+    ...todayAllDay.map(formatAllDayEventLine),
+  ];
+  const tomorrowLines: string[] = [
+    ...tomorrowTimed.map(event => formatTimedEventLine(event, timezone)),
+    ...tomorrowAllDay.map(formatAllDayEventLine),
+  ];
+
+  if (todayLines.length === 0 && tomorrowLines.length === 0) {
+    return ['No events on your calendar for today or tomorrow morning.'];
+  }
+
+  const lines: string[] = [];
+  if (todayLines.length > 0) {
+    lines.push(...todayLines);
+  } else {
+    lines.push('No events today.');
+  }
+
+  if (tomorrowLines.length > 0) {
+    lines.push('');
+    lines.push('Tomorrow morning');
+    lines.push(...tomorrowLines);
+  }
+
+  return lines;
+}
+
+export function buildCalendarNoConnectionLines(): string[] {
+  return ["Connect your Google account in Settings to see today's events."];
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.ts
@@ -248,3 +248,9 @@ export function buildCalendarSectionLines(
 export function buildCalendarNoConnectionLines(): string[] {
   return ["Connect your Google account in Settings to see today's events."];
 }
+
+export function buildCalendarMissingScopeLines(): string[] {
+  return [
+    "Your Google account is connected, but it's missing calendar permission. Reconnect from Settings and include calendar access to see today's events.",
+  ];
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/calendar-utils.ts
@@ -81,11 +81,14 @@ export function buildCalendarTimeWindow(now: Date, userTimezone: string): Calend
   const tz = userTimezone || DEFAULT_TIMEZONE;
   const todayKey = dateKeyInZone(now, tz);
   const tomorrowKey = addDays(todayKey, 1);
-  const offset = getTimezoneOffset(now, tz);
   return {
-    timeMin: `${todayKey}T00:00:00${offset}`,
-    timeMax: `${tomorrowKey}T12:00:00${offset}`,
+    timeMin: `${todayKey}T00:00:00${getTimezoneOffsetForWallTime(todayKey, '00:00:00', tz)}`,
+    timeMax: `${tomorrowKey}T12:00:00${getTimezoneOffsetForWallTime(tomorrowKey, '12:00:00', tz)}`,
   };
+}
+
+function getTimezoneOffsetForWallTime(dateKey: string, time: string, timezone: string): string {
+  return getTimezoneOffset(new Date(`${dateKey}T${time}Z`), timezone);
 }
 
 function formatTime(isoDateTime: string, timezone: string): string {
@@ -109,6 +112,13 @@ function eventDayKey(event: CalendarEvent, timezone: string): string {
 
 export function isAllDayEvent(event: CalendarEvent): boolean {
   return Boolean(event.start.date && !event.start.dateTime);
+}
+
+function allDayEventOverlapsDate(event: CalendarEvent, dateKey: string): boolean {
+  const startKey = event.start.date;
+  if (!startKey) return false;
+  const endKey = event.end.date ?? addDays(startKey, 1);
+  return startKey <= dateKey && dateKey < endKey;
 }
 
 export function formatEventTitle(event: CalendarEvent): string {
@@ -151,20 +161,22 @@ export function partitionEventsByDay(
   const tomorrowAllDay: CalendarEvent[] = [];
 
   for (const event of events) {
-    const dayKey = eventDayKey(event, tz);
     const isAllDay = isAllDayEvent(event);
-    if (dayKey === todayKey) {
-      if (isAllDay) {
+    if (isAllDay) {
+      if (allDayEventOverlapsDate(event, todayKey)) {
         todayAllDay.push(event);
-      } else {
-        todayTimed.push(event);
       }
-    } else if (dayKey === tomorrowKey) {
-      if (isAllDay) {
+      if (allDayEventOverlapsDate(event, tomorrowKey)) {
         tomorrowAllDay.push(event);
-      } else {
-        tomorrowTimed.push(event);
       }
+      continue;
+    }
+
+    const dayKey = eventDayKey(event, tz);
+    if (dayKey === todayKey) {
+      todayTimed.push(event);
+    } else if (dayKey === tomorrowKey) {
+      tomorrowTimed.push(event);
     }
     // Events outside today/tomorrow are dropped — the time window
     // limits API results, this is belt-and-suspenders for stragglers.
@@ -177,9 +189,16 @@ export function partitionEventsByDay(
 }
 
 function timedEventComparator(a: CalendarEvent, b: CalendarEvent): number {
-  const aStart = a.start.dateTime ?? '';
-  const bStart = b.start.dateTime ?? '';
-  return aStart.localeCompare(bStart);
+  const aStart = a.start.dateTime;
+  const bStart = b.start.dateTime;
+  const aTime = aStart ? Date.parse(aStart) : Number.POSITIVE_INFINITY;
+  const bTime = bStart ? Date.parse(bStart) : Number.POSITIVE_INFINITY;
+
+  if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
+    return aTime - bTime;
+  }
+
+  return (aStart ?? '').localeCompare(bStart ?? '');
 }
 
 export function buildCalendarSectionTitle(accountEmail: string): string {

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/delivery-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/delivery-utils.ts
@@ -239,7 +239,7 @@ export function parseStoredDelivery(entries: unknown): BriefingDeliveryResult[] 
 
   return entries
     .map(entry => asObject(entry))
-    .map(entry => {
+    .map((entry): BriefingDeliveryResult | null => {
       const channel =
         entry.channel === 'telegram' || entry.channel === 'discord' || entry.channel === 'slack'
           ? entry.channel
@@ -267,7 +267,7 @@ export function parseStoredDelivery(entries: unknown): BriefingDeliveryResult[] 
         accountId: typeof entry.accountId === 'string' ? entry.accountId : undefined,
         reason,
         error: typeof entry.error === 'string' ? entry.error : undefined,
-      } satisfies BriefingDeliveryResult;
+      };
     })
     .filter((entry): entry is BriefingDeliveryResult => entry !== null);
 }

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
@@ -289,19 +289,17 @@ async function createHarness(options?: {
       if (channel && target && message) {
         sentMessages.push({ channel, target, accountId, message });
       }
-      const configuredFailure =
-        channel === 'telegram' || channel === 'discord' || channel === 'slack'
-          ? options?.messageSendFailures?.[channel]
-          : undefined;
-      const configuredFailureCount =
-        channel === 'telegram' || channel === 'discord' || channel === 'slack'
-          ? options?.messageSendFailureCounts?.[channel]
-          : undefined;
-      if (configuredFailure && configuredFailureCount && configuredFailureCount > 0) {
+      const channelKey: 'telegram' | 'discord' | 'slack' | null =
+        channel === 'telegram' || channel === 'discord' || channel === 'slack' ? channel : null;
+      const configuredFailure = channelKey ? options?.messageSendFailures?.[channelKey] : undefined;
+      const configuredFailureCount = channelKey
+        ? options?.messageSendFailureCounts?.[channelKey]
+        : undefined;
+      if (channelKey && configuredFailure && configuredFailureCount && configuredFailureCount > 0) {
         if (!options?.messageSendFailureCounts) {
           return { stdout: '', stderr: configuredFailure, code: 1 };
         }
-        options.messageSendFailureCounts[channel] = configuredFailureCount - 1;
+        options.messageSendFailureCounts[channelKey] = configuredFailureCount - 1;
         return { stdout: '', stderr: configuredFailure, code: 1 };
       }
       if (configuredFailure && configuredFailureCount === undefined) {

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -59,6 +59,7 @@ import {
 import { resolveNextReconcileAction } from './reconcile-queue-utils';
 import { normalizeWebResults } from './web-utils';
 import {
+  buildCalendarMissingScopeLines,
   buildCalendarNoConnectionLines,
   buildCalendarSectionLines,
   buildCalendarSectionTitle,
@@ -1272,13 +1273,23 @@ async function collectCalendar(now: Date, userTimezone: string): Promise<SourceC
     };
   }
 
-  if (!readiness.connected || !readiness.hasCalendarCapability) {
+  if (!readiness.connected) {
     return {
       source: 'calendar',
       configured: false,
       ok: true,
       summary: readiness.reason,
       sectionLines: buildCalendarNoConnectionLines(),
+    };
+  }
+
+  if (!readiness.hasCalendarCapability) {
+    return {
+      source: 'calendar',
+      configured: false,
+      ok: true,
+      summary: readiness.reason,
+      sectionLines: buildCalendarMissingScopeLines(),
     };
   }
 

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -50,6 +50,17 @@ import {
 } from './local-news-utils';
 import { resolveNextReconcileAction } from './reconcile-queue-utils';
 import { normalizeWebResults } from './web-utils';
+import {
+  buildCalendarNoConnectionLines,
+  buildCalendarSectionLines,
+  buildCalendarSectionTitle,
+  buildCalendarTimeWindow,
+} from './calendar-utils';
+import {
+  fetchCalendarAccessToken,
+  fetchCalendarEvents,
+  resolveCalendarReady,
+} from './calendar-client';
 
 const PLUGIN_ID = 'kiloclaw-morning-briefing';
 const CRON_JOB_NAME = 'KiloClaw Morning Briefing';
@@ -119,7 +130,7 @@ type StoredStatus = {
 };
 
 type SourceCollectionResult = {
-  source: 'github' | 'linear' | 'local-news' | 'web';
+  source: 'calendar' | 'github' | 'linear' | 'local-news' | 'web';
   configured: boolean;
   ok: boolean;
   summary: string;
@@ -127,9 +138,10 @@ type SourceCollectionResult = {
   /**
    * Optional per-source section title override. Most sources use a
    * fixed title (`GitHub`, `Linear`, `Web Search`), but `local-news`
-   * adds the resolved user location in parens when one is set. Bare
-   * `Local News` heading when no location is configured. Set by
-   * `collectLocalNews`; unset for sources with a static title.
+   * adds the resolved user location in parens when one is set, and
+   * `calendar` uses the connected Google account's email (e.g.
+   * `astorms@kilocode.ai daily calendar`). Set by the collector;
+   * unset for sources with a static title.
    */
   sectionTitle?: string;
 };
@@ -1225,6 +1237,70 @@ async function collectLinear(api: {
   };
 }
 
+/**
+ * Pulls today + tomorrow-morning events from the user's primary Google
+ * calendar via the controller's OAuth broker. Both Settings UI cards
+ * (simple "Calendar Connect" and the full Google Account flow) write
+ * to the same per-instance connection row, so this collector is path-
+ * agnostic: ask the broker for status, then for a token, then hit
+ * Google.
+ *
+ * Returns:
+ *   - `ok:true, configured:false` + nudge body when no Google
+ *     connection or no calendar capability is present
+ *   - `ok:true, configured:true` + rendered section when calendar
+ *     fetch succeeds (including the empty-calendar case)
+ *   - `ok:false, configured:true` when the broker has a connection
+ *     but the token fetch or Google API call fails — the source
+ *     surfaces in the `## Failures` list and the source-status footer
+ */
+async function collectCalendar(now: Date, userTimezone: string): Promise<SourceCollectionResult> {
+  const readiness = await resolveCalendarReady();
+  if (!readiness.connected || !readiness.hasCalendarCapability) {
+    return {
+      source: 'calendar',
+      configured: false,
+      ok: true,
+      summary: readiness.reason,
+      sectionLines: buildCalendarNoConnectionLines(),
+    };
+  }
+
+  let token: Awaited<ReturnType<typeof fetchCalendarAccessToken>>;
+  try {
+    token = await fetchCalendarAccessToken();
+  } catch (error) {
+    return {
+      source: 'calendar',
+      configured: true,
+      ok: false,
+      summary: `Could not retrieve Google access token: ${error instanceof Error ? error.message : String(error)}`,
+      sectionLines: [],
+    };
+  }
+
+  const { timeMin, timeMax } = buildCalendarTimeWindow(now, userTimezone);
+  try {
+    const events = await fetchCalendarEvents(token.accessToken, timeMin, timeMax);
+    return {
+      source: 'calendar',
+      configured: true,
+      ok: true,
+      summary: `Fetched ${events.length} events for ${token.accountEmail}`,
+      sectionLines: buildCalendarSectionLines(events, now, userTimezone),
+      sectionTitle: buildCalendarSectionTitle(token.accountEmail),
+    };
+  } catch (error) {
+    return {
+      source: 'calendar',
+      configured: true,
+      ok: false,
+      summary: `Google Calendar fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+      sectionLines: [],
+    };
+  }
+}
+
 async function generateBriefing(
   api: {
     runtime: {
@@ -1243,7 +1319,9 @@ async function generateBriefing(
         }>;
       };
     };
-    config: unknown;
+    config: {
+      agents?: { defaults?: { userTimezone?: string } };
+    };
     logger: { info?: (message: string) => void; warn?: (message: string) => void };
   },
   dateKey: string
@@ -1258,12 +1336,11 @@ async function generateBriefing(
   const paths = getStatePaths(api);
   await ensureStorage(paths);
 
-  // Read interest topics + userLocation directly from config.json — we
-  // only need these two narrow fields here, and the surrounding `api`
-  // shape doesn't have the `pluginConfig` / `agents.defaults.userTimezone`
-  // context that `readStoredConfig` uses to default cron/timezone.
-  // Missing or malformed file => empty topics + null location (env-var
-  // fallback path in resolveLocationContextWithOverride).
+  // Read interest topics + userLocation directly from config.json. The
+  // `api.config.agents.defaults.userTimezone` field above gives us the
+  // brief's effective timezone for the Calendar source's time window.
+  // Missing or malformed config.json => empty topics + null location
+  // (env-var fallback path in resolveLocationContextWithOverride).
   const storedConfig = await readJsonFile<StoredConfig>(paths.configPath);
   const interestTopics = Array.isArray(storedConfig?.interestTopics)
     ? storedConfig.interestTopics.filter((value): value is string => typeof value === 'string')
@@ -1286,12 +1363,22 @@ async function generateBriefing(
   const webSearchTopics = interestTopics.filter(
     topic => topic.trim().toLowerCase() !== localNewsLabelLower
   );
+  // Calendar uses the user's IANA timezone for time window + formatting.
+  // Falls back to UTC when not configured (the brief plugin already
+  // accepts that fallback elsewhere via `resolveEffectiveTimezone`).
+  const briefingTimezone =
+    api.config.agents?.defaults?.userTimezone &&
+    isValidTimezone(api.config.agents.defaults.userTimezone)
+      ? api.config.agents.defaults.userTimezone
+      : DEFAULT_TIMEZONE;
+
   const corePromises = [
+    collectCalendar(new Date(), briefingTimezone),
     collectGithub(api),
     collectLinear(api),
     collectWebSearch(api, webSearchTopics),
   ];
-  const [github, linear, web] = await Promise.all(corePromises);
+  const [calendar, github, linear, web] = await Promise.all(corePromises);
   // Local News slots between Linear and Web Search — interest-gated so
   // users who haven't opted in pay no search cost and see no
   // local-news entry in the source-status footer.
@@ -1300,6 +1387,7 @@ async function generateBriefing(
     : null;
 
   const sources: SourceCollectionResult[] = [
+    calendar,
     github,
     linear,
     ...(localNews ? [localNews] : []),
@@ -1309,7 +1397,7 @@ async function generateBriefing(
 
   if (successes.length === 0) {
     throw new Error(
-      'No usable briefing sources are available. Configure at least one of GitHub, Linear, Local News, or web search.'
+      'No usable briefing sources are available. Configure at least one of Calendar, GitHub, Linear, Local News, or web search.'
     );
   }
 
@@ -1320,6 +1408,7 @@ async function generateBriefing(
   // `SourceCollectionResult.sectionTitle` (used by Local News to surface
   // the resolved location in the parens).
   const DEFAULT_SECTION_TITLE: Record<SourceCollectionResult['source'], string> = {
+    calendar: 'Calendar',
     github: 'GitHub',
     linear: 'Linear',
     'local-news': 'Local News',

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -1262,6 +1262,16 @@ async function collectLinear(api: {
  */
 async function collectCalendar(now: Date, userTimezone: string): Promise<SourceCollectionResult> {
   const readiness = await resolveCalendarReady();
+  if (!readiness.statusOk) {
+    return {
+      source: 'calendar',
+      configured: true,
+      ok: false,
+      summary: readiness.reason,
+      sectionLines: [],
+    };
+  }
+
   if (!readiness.connected || !readiness.hasCalendarCapability) {
     return {
       source: 'calendar',

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -1,7 +1,15 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Type } from '@sinclair/typebox';
+import type { OpenClawConfig, OpenClawPluginApi } from 'openclaw/plugin-sdk';
 import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry';
+
+// Reused inside the narrow function-parameter shapes below so the local
+// type stays a strict subset of the real plugin API. Without this the
+// hand-written `listProviders: (params?: { config?: unknown }) => ...`
+// signature is actually broader than the SDK's typed `ListWebSearchProvidersParams`,
+// and passing the real api into a narrow-typed function fails.
+type SdkWebSearchRuntime = OpenClawPluginApi['runtime']['webSearch'];
 import { buildBriefingMarkdown, offsetDateKey, resolveBriefingPath } from './briefing-utils';
 import {
   type BriefingDeliveryResult,
@@ -615,11 +623,9 @@ async function resolveGithubReady(api: {
 
 async function resolveWebSearchReady(api: {
   runtime: {
-    webSearch: {
-      listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
-    };
+    webSearch: Pick<SdkWebSearchRuntime, 'listProviders'>;
   };
-  config: unknown;
+  config: OpenClawConfig;
 }): Promise<{ configured: boolean; summary: string }> {
   const providers = api.runtime.webSearch.listProviders({ config: api.config });
   if (!Array.isArray(providers) || providers.length === 0) {
@@ -769,8 +775,14 @@ async function gatherGithubEmptyResultContext(
   // fine-grained context we never confirmed.
   const authFailedClassicOrFineGrained =
     (tokenType === 'classic' || tokenType === 'fine-grained') && login === null;
+  // After the earlier early-returns + the degrade-on-auth-failure above, the
+  // tokenType reaching this return is always one of the third union variant's
+  // literals. TS can't narrow GithubTokenType down to that subset on its own.
+  const narrowedTokenType: 'app' | 'oauth' | 'unknown' = authFailedClassicOrFineGrained
+    ? 'unknown'
+    : (tokenType as 'app' | 'oauth' | 'unknown');
   return {
-    tokenType: authFailedClassicOrFineGrained ? 'unknown' : tokenType,
+    tokenType: narrowedTokenType,
     login,
   };
 }
@@ -989,15 +1001,9 @@ async function collectWebSearch(
 
 type WebSearchRuntime = {
   runtime: {
-    webSearch: {
-      listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
-      search: (params: { args: Record<string, unknown>; config?: unknown }) => Promise<{
-        provider: string;
-        result: Record<string, unknown>;
-      }>;
-    };
+    webSearch: SdkWebSearchRuntime;
   };
-  config: unknown;
+  config: OpenClawConfig;
   logger: { info?: (message: string) => void; warn?: (message: string) => void };
 };
 
@@ -1311,13 +1317,7 @@ async function generateBriefing(
           options: { timeoutMs: number; cwd?: string }
         ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
       };
-      webSearch: {
-        listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
-        search: (params: { args: Record<string, unknown>; config?: unknown }) => Promise<{
-          provider: string;
-          result: Record<string, unknown>;
-        }>;
-      };
+      webSearch: SdkWebSearchRuntime;
     };
     config: {
       agents?: { defaults?: { userTimezone?: string } };
@@ -1531,9 +1531,7 @@ async function getStatusSnapshot(api: {
         options: { timeoutMs: number; cwd?: string }
       ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
     };
-    webSearch: {
-      listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
-    };
+    webSearch: Pick<SdkWebSearchRuntime, 'listProviders'>;
   };
   config: {
     agents?: {
@@ -1622,7 +1620,7 @@ export default definePluginEntry({
         // between our read and our final write (the `ensureCronJob` call
         // below is slow). `patchStoredStatus` uses a separate queue, so
         // no deadlock from nesting.
-        return await queueConfigWrite(paths.configPath, async () => {
+        return await queueConfigWrite<'succeeded' | 'failed'>(paths.configPath, async () => {
           const config = await readStoredConfig(api, paths);
 
           if (config.enabled) {
@@ -1931,6 +1929,7 @@ export default definePluginEntry({
 
     api.registerTool({
       name: 'morning_briefing_handle_command',
+      label: 'Morning briefing /briefing command',
       description:
         'Deterministically handles /briefing commands from raw inbound text when slash routing fails.',
       parameters: Type.Object(
@@ -1944,7 +1943,8 @@ export default definePluginEntry({
         { additionalProperties: false }
       ),
       async execute(_toolCallId, params) {
-        const commandArgs = extractBriefingArgsFromText(params.message);
+        const { message } = params as { message: string };
+        const commandArgs = extractBriefingArgsFromText(message);
         if (commandArgs === null) {
           return {
             content: [
@@ -1953,6 +1953,7 @@ export default definePluginEntry({
                 text: 'No /briefing command found in the provided message.',
               },
             ],
+            details: undefined,
           };
         }
 
@@ -1964,12 +1965,14 @@ export default definePluginEntry({
               text: resultText,
             },
           ],
+          details: undefined,
         };
       },
     });
 
     api.registerTool({
       name: 'morning_briefing_generate',
+      label: 'Generate morning briefing',
       description:
         "Generate today's morning briefing from configured sources and persist it as Markdown.",
       parameters: Type.Object(
@@ -1984,7 +1987,8 @@ export default definePluginEntry({
         { additionalProperties: false }
       ),
       async execute(_toolCallId, params) {
-        const dateValue = typeof params.date === 'string' ? params.date : undefined;
+        const typed = params as { date?: string };
+        const dateValue = typeof typed.date === 'string' ? typed.date : undefined;
         const targetDateKey = dateValue ?? (await resolveDateKeyForOffset(api, 0));
         const result = await generateBriefing(api, targetDateKey);
         return {
@@ -1999,12 +2003,14 @@ export default definePluginEntry({
               ].join('\n'),
             },
           ],
+          details: undefined,
         };
       },
     });
 
     api.registerTool({
       name: 'morning_briefing_read',
+      label: 'Read morning briefing',
       description: 'Read a saved morning briefing Markdown file for a specific date.',
       parameters: Type.Object(
         {
@@ -2019,7 +2025,8 @@ export default definePluginEntry({
         { additionalProperties: false }
       ),
       async execute(_toolCallId, params) {
-        const rawDay = typeof params.day === 'string' ? params.day : 'today';
+        const typed = params as { day?: string };
+        const rawDay = typeof typed.day === 'string' ? typed.day : 'today';
         const dateKey =
           rawDay === 'yesterday'
             ? await resolveDateKeyForOffset(api, -1)
@@ -2035,6 +2042,7 @@ export default definePluginEntry({
                 text: `No briefing exists for ${briefing.dateKey}.`,
               },
             ],
+            details: undefined,
           };
         }
         return {
@@ -2044,6 +2052,7 @@ export default definePluginEntry({
               text: briefing.markdown,
             },
           ],
+          details: undefined,
         };
       },
     });

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -1366,10 +1366,14 @@ async function generateBriefing(
   // Calendar uses the user's IANA timezone for time window + formatting.
   // Falls back to UTC when not configured (the brief plugin already
   // accepts that fallback elsewhere via `resolveEffectiveTimezone`).
+  const storedTimezone =
+    typeof storedConfig?.timezone === 'string' && storedConfig.timezone.trim().length > 0
+      ? storedConfig.timezone.trim()
+      : null;
+  const configuredTimezone = storedTimezone ?? api.config.agents?.defaults?.userTimezone;
   const briefingTimezone =
-    api.config.agents?.defaults?.userTimezone &&
-    isValidTimezone(api.config.agents.defaults.userTimezone)
-      ? api.config.agents.defaults.userTimezone
+    configuredTimezone && isValidTimezone(configuredTimezone)
+      ? configuredTimezone
       : DEFAULT_TIMEZONE;
 
   const corePromises = [

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/tsconfig.json
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["@types/node"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a Google Calendar source to the morning briefing plugin so the daily brief opens with today's events and a preview of tomorrow morning.

Both Settings UI cards (the simple Calendar Connect card and the full Google Account card) write to the same per instance connection row, so the new collector is path agnostic. It asks the controller broker for connection status, then for a calendar scoped access token, then hits `calendars/primary/events` directly. Section header uses the connected account's email, e.g. `## you@gmail.com daily calendar`.

Empty calendar renders a short "No events" line. A user who has not connected Google sees a nudge body inviting them to connect from Settings, matching the pattern other opt in sources use. Time window covers today from 00:00 in the user timezone through 12:00 of tomorrow, so an early morning brief can warn about an early meeting the next day without dumping the whole following day.

Also cleans up a pre existing gap on the plugin's build pipeline:

* The plugin had no `typecheck` script, so plugin only diffs tripped pre push because pnpm could not find any package with a typecheck script under the filter. Prior plugin PRs slipped through only because they also touched parent kiloclaw files with their own typecheck. Added a plugin scoped `tsconfig.json` plus a `typecheck` script.
* Pinned `openclaw` to `2026.4.23` on both `peerDependencies` and `devDependencies`, matching the container's Dockerfile install. The previous peer dep range allowed local installs to float to a newer version while the container kept running 2026.4.23, which is a version skew bug.
* Fixed 30 pre existing typecheck errors that surfaced once openclaw types resolved cleanly. Most disappeared automatically. The remaining batch covered: replacing hand rolled `webSearch.listProviders` signatures with indexed access from the SDK (the local signatures were unintentionally broader in a contravariant position); narrowing `config: unknown` to `OpenClawConfig` where it gets passed into typed SDK calls; adding the required `label` field and `details` field on tool registrations; casting tool execute params to typed shapes at access sites; narrowing the GitHub fallback `tokenType` to the third union variant; pinning `queueConfigWrite` return type so a literal return does not widen to `string`; and a small fix in `delivery-utils.parseStoredDelivery` and one lifecycle test.

No runtime behavior change for anything other than the new Calendar source.

## Verification

* [x] Booted a fresh local image, ran a brief, confirmed `## storms@kilocode.ai daily calendar` rendered with today's events and a "Tomorrow morning" subsection populated from the next morning preview window.
* [x] Tested an empty calendar window and confirmed the "No events on your calendar for today or tomorrow morning." copy.
* [x] Tested with Google disconnected and confirmed the nudge body renders.
* [x] All 188 plugin tests pass, full typecheck clean, lint clean, format clean.
* [ ] Production verification will happen after deploy, alongside the normal image rollout.

## Visual Changes

N/A. Brief output is markdown delivered to chat or a saved file.

## Reviewer Notes

* The broker only ever exposes one connected Google account per instance, regardless of which Settings card was used to connect it. The collector therefore renders one Calendar section, not one per UI card. The `credential_profile` field on the row distinguishes the two paths internally; the plugin does not branch on it.
* Time window cuts at noon of tomorrow on purpose. Earlier drafts considered a rolling 24 hour window, but anchoring to local day boundaries plus a half day peek keeps "today" semantics clean across timezones.
* `openclaw` version is a deliberate pin, not a free range. If a future workspace bump moves openclaw up, this plugin needs a matching bump alongside kilo-chat and the Dockerfile.