### PR TITLE
feat(wasteland): debounce wanted board search input

### DIFF
--- a/apps/web/src/app/(app)/wasteland/by-id/[wastelandId]/wanted/WantedBoardClient.tsx
+++ b/apps/web/src/app/(app)/wasteland/by-id/[wastelandId]/wanted/WantedBoardClient.tsx
@@ -155,6 +155,21 @@ export function WantedBoardClient({
   const search = searchParams?.get('q') ?? '';
   const sortField = parseSortField(searchParams?.get('sort'));
 
+  const [localSearch, setLocalSearch] = useState(search);
+  const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setLocalSearch(search);
+  }, [search]);
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const updateFilterParams = useCallback(
     (updates: { status?: StatusFilter | 'all'; q?: string; sort?: SortField }) => {
       const next = new URLSearchParams(searchParams?.toString());
@@ -176,6 +191,25 @@ export function WantedBoardClient({
       router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
     },
     [pathname, router, searchParams]
+  );
+
+  const handleSearchChange = useCallback(
+    (val: string) => {
+      setLocalSearch(val);
+
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+
+      if (val === '') {
+        updateFilterParams({ q: '' });
+      } else {
+        debounceTimeoutRef.current = setTimeout(() => {
+          updateFilterParams({ q: val });
+        }, 250);
+      }
+    },
+    [updateFilterParams]
   );
 
   // Dialog state
@@ -410,8 +444,8 @@ export function WantedBoardClient({
             <input
               type="text"
               placeholder="Search wanted items..."
-              value={search}
-              onChange={e => updateFilterParams({ q: e.target.value })}
+              value={localSearch}
+              onChange={e => handleSearchChange(e.target.value)}
               className="w-48 bg-transparent text-xs text-white/80 outline-none placeholder:text-white/25"
             />
           </div>


### PR DESCRIPTION
## Summary

- Syncs the fork PR that debounces wanted board search input updates before writing `q` to the URL.
- Keeps local search input responsive while avoiding high-frequency router updates during typing.
- Clears the URL search parameter immediately when the input is emptied.

## Verification

- Manually verified in fork PR: search inputs and clear state behavior under latency.

## Visual Changes

N/A

## Reviewer Notes

- Source fork PR: https://github.com/jrf0110/cloud/pull/1
- `scripts/typecheck-all.sh --changes-only` skipped because no matching workspace packages were detected for the changed file.
- `pnpm format` could not complete due to a pnpm `EEXIST` symlink collision in `node_modules`; the worktree remained clean.