### PR TITLE
feat(kiloclaw): polish onboarding previews with shared chat shell

### DIFF
--- a/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
@@ -339,7 +339,8 @@ export function BotIdentityStep({
 
       <div className="flex justify-end">
         <Button
-          className="bg-brand-primary hover:bg-brand-primary/90 text-black"
+          variant="default"
+          className="bg-brand-primary hover:bg-brand-primary/90"
           disabled={isContinuing}
           onClick={() => void handleContinue()}
         >

--- a/apps/web/src/app/(app)/claw/components/BriefingChatPreview.tsx
+++ b/apps/web/src/app/(app)/claw/components/BriefingChatPreview.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import type { BotIdentity } from './claw.types';
+
+type BriefingChatPreviewProps = {
+  /** Bot identity (name, emoji, nature) — pulled from earlier wizard step. */
+  bot: BotIdentity;
+  /** Optional greeting line that opens the message. */
+  greeting?: string;
+  /** Body items shown as bulleted lines inside the message bubble. */
+  items: string[];
+  /** Soft sign-off italicized at the bottom of the message. */
+  closer?: string;
+  /**
+   * Copy shown when `items` is empty. Lets parents distinguish between
+   * "I have nothing yet" and "look at this rich preview" without each
+   * screen owning the empty state styling.
+   */
+  emptyMessage?: string;
+  /**
+   * Time stamp shown in the date separator. Static "7:30 AM" by default
+   * — this is a preview, not a live stream.
+   */
+  time?: string;
+  /**
+   * Day label shown in the date separator. Defaults to "Tomorrow" since
+   * every onboarding step previews the next morning's briefing.
+   */
+  dayLabel?: string;
+  className?: string;
+};
+
+/**
+ * Chat-message shell that previews tomorrow's morning briefing as if it
+ * arrived in a messaging surface. Used as the left column of multi-column
+ * onboarding steps so the user sees what they're configuring.
+ *
+ * Visual register borrows from real chat apps (iMessage / Slack / Discord)
+ * rather than form chrome:
+ *
+ * - Content top-anchors so the chat preview reads as a paired column
+ *   with the form on the right (both fill from the top, so when the
+ *   grid stretches one to match the other, empty space lands at the
+ *   bottom of both — never in opposite halves).
+ * - Centered date separator with hairlines, the way every chat client
+ *   marks a day boundary.
+ * - Bubble uses the `bg-secondary` token so it sits brighter than the
+ *   `bg-muted/20` shell — pops by being lighter, the way iMessage and
+ *   WhatsApp dark do it. No pure-black shell needed.
+ * - `rounded-tl-sm` corner gives a subtle "tail" pointing back at the
+ *   avatar without resorting to a literal triangle pseudo-element.
+ * - Mono timestamps for chat-app realism (numbers in dense data lean
+ *   mono per `design.md` typography).
+ *
+ * Stays away from over-branding: no "via Kilo" footer, no presence
+ * indicator on the avatar (the bot isn't online yet — this is a future
+ * preview), no decorative glow.
+ */
+export function BriefingChatPreview({
+  bot,
+  greeting,
+  items,
+  closer,
+  emptyMessage,
+  time = '7:30 AM',
+  dayLabel = 'Tomorrow',
+  className,
+}: BriefingChatPreviewProps) {
+  const showEmptyMessage = items.length === 0 && emptyMessage !== undefined;
+
+  return (
+    <div
+      className={cn(
+        'border-border bg-muted/20 flex h-full flex-col overflow-hidden rounded-lg border',
+        className
+      )}
+    >
+      <div className="flex flex-1 flex-col gap-4 px-5 py-6">
+        <div className="flex items-center gap-3">
+          <div className="bg-border h-px flex-1" aria-hidden />
+          <span className="text-muted-foreground flex items-baseline gap-1.5 text-xs">
+            <span>{dayLabel}</span>
+            <span className="text-muted-foreground/60" aria-hidden>
+              ·
+            </span>
+            <span className="font-mono">{time}</span>
+          </span>
+          <div className="bg-border h-px flex-1" aria-hidden />
+        </div>
+
+        <div className="flex items-start gap-3">
+          <div
+            aria-hidden
+            className="border-border bg-secondary flex h-10 w-10 shrink-0 items-center justify-center rounded-full border text-xl leading-none"
+          >
+            {bot.botEmoji}
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <span className="text-foreground text-sm font-semibold tracking-tight">
+              {bot.botName || 'Your bot'}
+            </span>
+
+            <div className="bg-secondary flex flex-col gap-2.5 rounded-lg rounded-tl-sm px-4 py-3">
+              {greeting && <p className="text-foreground text-sm leading-relaxed">{greeting}</p>}
+
+              {showEmptyMessage ? (
+                <p className="text-muted-foreground text-sm leading-relaxed italic">
+                  {emptyMessage}
+                </p>
+              ) : (
+                <ul className="flex flex-col gap-1.5">
+                  {items.map((item, index) => (
+                    <li
+                      key={index}
+                      className="text-foreground/95 flex items-start gap-2.5 text-sm leading-relaxed"
+                    >
+                      <span
+                        className="text-muted-foreground mt-1.5 shrink-0 leading-none select-none"
+                        aria-hidden
+                      >
+                        •
+                      </span>
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {closer && (
+                <p className="text-muted-foreground text-xs leading-relaxed italic">{closer}</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/CalendarConnectStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/CalendarConnectStep.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import Link from 'next/link';
-import { Calendar, Check, X } from 'lucide-react';
+import { Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
+import { GoogleLogo } from '@/components/auth/GoogleLogo';
 import { OnboardingStepView } from './OnboardingStepView';
+import { BriefingChatPreview } from './BriefingChatPreview';
+import type { BotIdentity } from './claw.types';
 
 type CalendarConnectStepViewProps = {
   currentStep: number;
   totalSteps: number;
+  bot: BotIdentity;
   connectUrl: string;
   isConnected: boolean;
   connectedAccountEmail?: string | null;
@@ -27,27 +30,28 @@ type CalendarConnectStepViewProps = {
   onConnectClick?: () => void;
 };
 
-const FEATURES: Array<{ included: boolean; title: string; detail: string }> = [
+const FEATURES: Array<{ title: string; detail: string }> = [
   {
-    included: true,
-    title: 'Read your calendar events',
+    title: 'Calendar events',
     detail: 'Titles, attendees, locations, descriptions for the next 14 days.',
   },
   {
-    included: true,
-    title: 'Read calendars you own and subscribe to',
+    title: 'Calendars you own and follow',
     detail: 'Including team calendars shared with you.',
   },
-  {
-    included: false,
-    title: 'Create, modify, or delete events',
-    detail: "We don't request write access.",
-  },
+];
+
+const PREVIEW_ITEMS = [
+  '3 meetings on your calendar today',
+  'Standup at 10:00 with the platform team',
+  'Lunch with Reese, 12:30',
+  '1:1 with Devon at 3:00',
 ];
 
 export function CalendarConnectStepView({
   currentStep,
   totalSteps,
+  bot,
   connectUrl,
   isConnected,
   connectedAccountEmail,
@@ -56,6 +60,10 @@ export function CalendarConnectStepView({
   onContinue,
   onConnectClick,
 }: CalendarConnectStepViewProps) {
+  const greetingName =
+    isConnected && connectedAccountEmail ? connectedAccountEmail.split('@')[0] : null;
+  const greeting = greetingName ? `Good morning, ${greetingName}.` : 'Good morning.';
+
   return (
     <OnboardingStepView
       currentStep={currentStep}
@@ -64,86 +72,94 @@ export function CalendarConnectStepView({
       title="Connect a calendar."
       description="This is what day one of your briefing is built from. Read access only, no writes."
       showProvisioningBanner
+      contentClassName="gap-6"
     >
-      <div className="border-border bg-card flex flex-col gap-5 rounded-lg border p-5 sm:p-6">
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex items-start gap-3">
-            <div className="border-border flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border">
-              <Calendar className="h-5 w-5" />
+      <div className="grid gap-6 md:grid-cols-[1fr_2fr] md:gap-8">
+        <BriefingChatPreview
+          bot={bot}
+          greeting={greeting}
+          items={PREVIEW_ITEMS}
+          closer="Light afternoon. Coffee at 2 if you can."
+        />
+
+        <div className="flex flex-col gap-6">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <div className="bg-muted/40 border-border flex h-10 w-10 shrink-0 items-center justify-center rounded-md border">
+                <GoogleLogo />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-foreground text-base font-semibold">Google Calendar</span>
+                <span className="text-muted-foreground text-xs">
+                  {isConnected && connectedAccountEmail
+                    ? `Connected as ${connectedAccountEmail}`
+                    : 'OAuth · Read-only'}
+                </span>
+              </div>
             </div>
-            <div className="flex flex-col gap-0.5">
-              <h3 className="text-foreground text-base font-semibold">Google Calendar</h3>
-              <p className="text-muted-foreground text-xs">
-                {isConnected && connectedAccountEmail
-                  ? `Connected as ${connectedAccountEmail}`
-                  : 'via OAuth · read-only'}
-              </p>
-            </div>
-          </div>
-          <span
-            className={cn(
-              'rounded-full border px-2.5 py-0.5 text-[10px] font-semibold tracking-wider uppercase',
-              isConnected
-                ? 'border-emerald-500/40 text-emerald-500'
-                : 'border-amber-500/40 text-amber-500'
+            {isConnected && (
+              <span className="bg-emerald-500/10 text-emerald-400 ring-emerald-500/20 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-medium ring-1">
+                <Check className="size-4" />
+                Connected
+              </span>
             )}
-          >
-            {isConnected ? 'Connected' : 'Recommended'}
-          </span>
-        </div>
+          </div>
 
-        <div className="flex flex-col gap-3">
-          {FEATURES.map(feature => (
-            <div key={feature.title} className="flex items-start gap-3">
-              <div
-                className={cn(
-                  'flex h-5 w-5 shrink-0 items-center justify-center rounded-md border',
-                  feature.included
-                    ? 'border-emerald-500/60 bg-emerald-500/10 text-emerald-500'
-                    : 'border-border text-muted-foreground/60'
-                )}
-              >
-                {feature.included ? <Check className="h-3 w-3" /> : <X className="h-3 w-3" />}
-              </div>
-              <div className="flex flex-col gap-0.5">
-                <p
-                  className={cn(
-                    'text-sm font-medium',
-                    feature.included ? 'text-foreground' : 'text-muted-foreground/70'
-                  )}
-                >
-                  {feature.title}
-                </p>
-                <p className="text-muted-foreground text-xs">{feature.detail}</p>
-              </div>
+          <section className="flex flex-col gap-3">
+            <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+              What we'll read
+            </h3>
+            <div className="flex flex-col gap-3">
+              {FEATURES.map(feature => (
+                <div key={feature.title} className="flex items-start gap-3">
+                  <div className="bg-emerald-500/10 text-emerald-400 ring-emerald-500/20 mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md ring-1">
+                    <Check className="h-3.5 w-3.5" />
+                  </div>
+                  <div className="flex flex-col gap-0.5">
+                    <p className="text-foreground text-sm font-semibold">{feature.title}</p>
+                    <p className="text-muted-foreground text-sm leading-snug">{feature.detail}</p>
+                  </div>
+                </div>
+              ))}
             </div>
-          ))}
+          </section>
         </div>
+      </div>
 
-        <div className="flex items-center justify-end gap-3 pt-2">
-          <button
-            type="button"
-            onClick={() => onSkip()}
-            className="text-muted-foreground hover:text-foreground text-sm font-medium transition-colors"
+      <div className="flex items-center justify-end gap-3 pt-2">
+        <Button variant="ghost" size="lg" onClick={() => onSkip()}>
+          Skip for now
+        </Button>
+        {isConnected ? (
+          <Button
+            variant="default"
+            size="lg"
+            className="bg-brand-primary hover:bg-brand-primary/90"
+            onClick={() => onContinue()}
           >
-            Skip for now
-          </button>
-          {isConnected ? (
-            <Button variant="primary" onClick={() => onContinue()}>
-              Continue
-            </Button>
-          ) : readyToConnect ? (
-            <Button asChild variant="primary">
-              <Link href={connectUrl} onClick={() => onConnectClick?.()}>
-                Connect Google Calendar
-              </Link>
-            </Button>
-          ) : (
-            <Button variant="primary" disabled>
-              Setting up your instance…
-            </Button>
-          )}
-        </div>
+            Continue
+          </Button>
+        ) : readyToConnect ? (
+          <Button
+            asChild
+            variant="default"
+            size="lg"
+            className="bg-brand-primary hover:bg-brand-primary/90"
+          >
+            <Link href={connectUrl} onClick={() => onConnectClick?.()}>
+              Connect Google Calendar
+            </Link>
+          </Button>
+        ) : (
+          <Button
+            variant="default"
+            size="lg"
+            className="bg-brand-primary hover:bg-brand-primary/90"
+            disabled
+          >
+            Setting up your instance…
+          </Button>
+        )}
       </div>
     </OnboardingStepView>
   );

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
@@ -20,6 +20,17 @@ import { InboundEmailStepView } from './InboundEmailStep';
 import { InterestsStepView } from './InterestsStep';
 import { ClawSetupCompleteStep, ClawSetupErrorStep } from './ClawOnboardingFlow';
 import { ProvisioningStepView } from './ProvisioningStep';
+import type { BotIdentity } from './claw.types';
+
+// Realistic-looking identity so the chat preview reads convincingly when
+// the fake walkthrough is loaded directly into a step that bypasses the
+// Identity screen.
+const FAKE_BOT_IDENTITY: BotIdentity = {
+  botName: 'Aria',
+  botNature: 'Operator',
+  botVibe: 'Focused, capable, effective',
+  botEmoji: '🤖',
+};
 
 const FAKE_STEP_LABELS: Record<ClawOnboardingRenderStep, string> = {
   identity: 'Identity',
@@ -197,6 +208,7 @@ function renderFakeStep({ step, setStep, stepProgress, basePath }: RenderFakeSte
       return (
         <CalendarConnectStepView
           {...stepProgress}
+          bot={FAKE_BOT_IDENTITY}
           connectUrl="#"
           isConnected={false}
           connectedAccountEmail={null}
@@ -211,6 +223,7 @@ function renderFakeStep({ step, setStep, stepProgress, basePath }: RenderFakeSte
       return (
         <InboundEmailStepView
           {...stepProgress}
+          bot={FAKE_BOT_IDENTITY}
           address="operator@inbound.example.com"
           enabled={true}
           loading={false}
@@ -222,6 +235,7 @@ function renderFakeStep({ step, setStep, stepProgress, basePath }: RenderFakeSte
       return (
         <InterestsStepView
           {...stepProgress}
+          bot={FAKE_BOT_IDENTITY}
           saving={false}
           onContinue={() => setStep('provisioning')}
           onSkip={() => setStep('provisioning')}

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -531,6 +531,7 @@ function ClawOnboardingFlowInner({
       <CalendarConnectStepView
         currentStep={flowState.currentStep}
         totalSteps={flowState.totalSteps}
+        bot={botIdentity ?? DEFAULT_BOT_IDENTITY}
         connectUrl={connectUrl}
         isConnected={isConnected}
         connectedAccountEmail={connectedEmail}
@@ -564,6 +565,7 @@ function ClawOnboardingFlowInner({
       <InboundEmailStepView
         currentStep={flowState.currentStep}
         totalSteps={flowState.totalSteps}
+        bot={botIdentity ?? DEFAULT_BOT_IDENTITY}
         address={inboundEmailAddress}
         enabled={inboundEmailEnabled}
         loading={loading}
@@ -592,6 +594,7 @@ function ClawOnboardingFlowInner({
       <InterestsStepView
         currentStep={flowState.currentStep}
         totalSteps={flowState.totalSteps}
+        bot={botIdentity ?? DEFAULT_BOT_IDENTITY}
         // Save is deferred to ProvisioningStep.onComplete; the step itself
         // never roundtrips. No "saving" state needed.
         saving={false}
@@ -775,7 +778,11 @@ export function ClawSetupErrorStep({ basePath }: { basePath: string }) {
         </div>
 
         <div className="flex w-full flex-col gap-3">
-          <Button asChild variant="primary" className="w-full min-w-[180px] py-6 text-base">
+          <Button
+            asChild
+            variant="default"
+            className="bg-brand-primary hover:bg-brand-primary/90 w-full min-w-[180px] py-6 text-base"
+          >
             <a href="https://kilo.ai/support" target="_blank" rel="noopener noreferrer">
               Contact Support
             </a>

--- a/apps/web/src/app/(app)/claw/components/InboundEmailStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/InboundEmailStep.tsx
@@ -5,10 +5,13 @@ import { Check, Copy, Mail } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { OnboardingStepView } from './OnboardingStepView';
+import { BriefingChatPreview } from './BriefingChatPreview';
+import type { BotIdentity } from './claw.types';
 
 type InboundEmailStepViewProps = {
   currentStep: number;
   totalSteps: number;
+  bot: BotIdentity;
   /** Inbound alias from `KiloClawDashboardStatus.inboundEmailAddress`. */
   address: string | null;
   /** `KiloClawDashboardStatus.inboundEmailEnabled`. */
@@ -24,9 +27,31 @@ type InboundEmailStepViewProps = {
   onCopyClick?: () => void;
 };
 
+const PREVIEW_ITEMS = [
+  'From investor-newsletter — 2 fundraising signals to skim',
+  'From product@your-vendor — release notes summary',
+  'From you (forwarded) — flagged thread context',
+];
+
+const TIPS: Array<{ title: string; detail: string }> = [
+  {
+    title: 'Forward emails to this address',
+    detail: 'Newsletters, threads, briefings — anything you want surfaced.',
+  },
+  {
+    title: 'Subject becomes the topic',
+    detail: 'Whatever you write in the subject line is what the bot calls it.',
+  },
+  {
+    title: 'Shows up the next morning',
+    detail: 'Forwarded items become context in your next briefing.',
+  },
+];
+
 export function InboundEmailStepView({
   currentStep,
   totalSteps,
+  bot,
   address,
   enabled,
   loading,
@@ -82,21 +107,26 @@ export function InboundEmailStepView({
       title="Your bot has an inbox."
       description="Forward anything useful to this address and it can show up as context in future briefings."
       showProvisioningBanner
+      contentClassName="gap-6"
     >
-      <div className="border-border bg-card flex flex-col gap-4 rounded-lg border p-5 sm:p-6">
-        <div className="flex flex-col gap-2">
-          <span className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase">
-            Inbound Address
-          </span>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="bg-muted/50 border-border flex min-w-0 items-center gap-2 rounded-md border px-3 py-2">
+      <div className="grid gap-6 md:grid-cols-[1fr_2fr] md:gap-8">
+        <BriefingChatPreview
+          bot={bot}
+          greeting="What you forwarded yesterday:"
+          items={PREVIEW_ITEMS}
+          closer="I'll surface anything time-sensitive in your morning briefing."
+        />
+
+        <div className="flex flex-col gap-6">
+          <div className="bg-muted/40 border-border flex items-stretch overflow-hidden rounded-md border">
+            <div className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2">
               <Mail className="text-muted-foreground h-4 w-4 shrink-0" />
               {ready ? (
                 <code className="text-foreground min-w-0 truncate font-mono text-sm">
                   {address}
                 </code>
               ) : (
-                <span className="text-muted-foreground text-sm">
+                <span className="text-muted-foreground truncate text-sm">
                   {loading
                     ? 'Setting up your inbox…'
                     : enabled
@@ -105,33 +135,54 @@ export function InboundEmailStepView({
                 </span>
               )}
             </div>
-            <Button
+            <button
               type="button"
-              variant="outline"
               onClick={handleCopy}
               disabled={!ready}
-              className="shrink-0"
+              aria-label={copied ? 'Address copied' : 'Copy inbound address'}
+              className="border-border text-muted-foreground hover:bg-muted/60 hover:text-foreground focus-visible:ring-ring flex shrink-0 cursor-pointer items-center gap-1.5 self-stretch border-l px-3 text-sm font-medium transition-colors focus-visible:ring-1 focus-visible:outline-none focus-visible:ring-inset disabled:cursor-not-allowed disabled:opacity-50"
             >
               {copied ? (
-                <Check className="h-4 w-4 text-emerald-500" />
+                <Check className="h-4 w-4 text-emerald-400" />
               ) : (
                 <Copy className="h-4 w-4" />
               )}
-              {copied ? 'Copied' : 'Copy address'}
-            </Button>
+              {copied ? 'Copied' : 'Copy'}
+            </button>
           </div>
-        </div>
 
-        <div className="flex items-center justify-end gap-3 pt-2">
-          <Button
-            type="button"
-            variant="primary"
-            onClick={() => onContinue()}
-            disabled={!canContinue}
-          >
-            {loading ? 'Setting up your instance…' : 'Continue →'}
-          </Button>
+          <section className="flex flex-col gap-3">
+            <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+              How it works
+            </h3>
+            <ol className="flex flex-col gap-3">
+              {TIPS.map((tip, index) => (
+                <li key={tip.title} className="flex items-start gap-3">
+                  <div className="bg-muted/40 border-border text-muted-foreground mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md border font-mono text-xs font-semibold">
+                    {index + 1}
+                  </div>
+                  <div className="flex flex-col gap-0.5">
+                    <p className="text-foreground text-sm font-semibold">{tip.title}</p>
+                    <p className="text-muted-foreground text-sm leading-snug">{tip.detail}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </section>
         </div>
+      </div>
+
+      <div className="flex items-center justify-end gap-3 pt-2">
+        <Button
+          type="button"
+          variant="default"
+          size="lg"
+          className="bg-brand-primary hover:bg-brand-primary/90"
+          onClick={() => onContinue()}
+          disabled={!canContinue}
+        >
+          {loading ? 'Setting up your instance…' : 'Continue'}
+        </Button>
       </div>
     </OnboardingStepView>
   );

--- a/apps/web/src/app/(app)/claw/components/InterestsStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/InterestsStep.tsx
@@ -2,18 +2,45 @@
 
 import { useMemo, useState, type KeyboardEvent } from 'react';
 import { Plus, X } from 'lucide-react';
+import { motion } from 'motion/react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { OnboardingStepView } from './OnboardingStepView';
+import { BriefingChatPreview } from './BriefingChatPreview';
+import type { BotIdentity } from './claw.types';
+import { cn } from '@/lib/utils';
 import {
   INTEREST_TOPIC_PRESETS,
   MORNING_BRIEFING_INTERESTS_MAX_TOPICS as MAX_TOPICS,
   MORNING_BRIEFING_INTERESTS_MAX_TOPIC_LENGTH as MAX_TOPIC_LENGTH,
 } from '@/lib/kiloclaw/morning-briefing-interests';
 
+const EASE_OUT_QUART = [0.22, 1, 0.36, 1] as const;
+const TAP_EASE = { duration: 0.12, ease: EASE_OUT_QUART } as const;
+
+/**
+ * Static realistic preview lines per preset topic, used in the
+ * morning-briefing preview card so users can see what each topic
+ * means before committing. Custom topics fall back to a generic
+ * line composed at render time.
+ */
+const TOPIC_PREVIEW_SAMPLES: Record<string, string> = {
+  Tech: 'Tech: 3 stories on developer tools and AI',
+  AI: 'AI: GPT-5 evaluations, new Claude API updates',
+  Finance: 'Finance: SPY 0.4%, NVDA 1.8%, Bitcoin steady',
+  Health: 'Health: New CDC guidance on flu season',
+  Startups: 'Startups: 4 funding rounds in fintech and devtools',
+  Markets: 'Markets: Pre-market movers and overnight earnings',
+  Science: 'Science: 2 climate papers, 1 fusion update',
+  Design: 'Design: Linear release notes, Figma plugin updates',
+  'Local News': 'Local: 6 mi rain expected, light traffic',
+  Sports: 'Sports: NBA scores from last night, MLB on tap',
+};
+
 type InterestsStepViewProps = {
   currentStep: number;
   totalSteps: number;
+  bot: BotIdentity;
   /** Existing topics from Postgres, if any (e.g. resume after refresh). */
   initialTopics?: string[];
   /** True when the save mutation is in flight. */
@@ -32,9 +59,14 @@ function isPresetSelected(topic: string, selected: string[]): boolean {
   return selected.some(value => value.toLowerCase() === topic.toLowerCase());
 }
 
+function previewLineForTopic(topic: string): string {
+  return TOPIC_PREVIEW_SAMPLES[topic] ?? `${topic}: relevant news from your sources`;
+}
+
 export function InterestsStepView({
   currentStep,
   totalSteps,
+  bot,
   initialTopics = [],
   saving,
   onContinue,
@@ -54,16 +86,20 @@ export function InterestsStepView({
     [selected]
   );
 
-  const previewText = useMemo(() => {
-    if (selected.length === 0) {
-      return 'Pick topics to scope tomorrow’s briefing.';
+  const previewItems = useMemo(() => {
+    const calendarLine = '2 calendar events on your day';
+    const topicLines = selected.map(previewLineForTopic);
+    // Cap visible topics so the preview shell stays a predictable height
+    // even when the user picks many topics. Past the cap we collapse the
+    // remainder into a single "+ N more topics" line so the magnitude is
+    // still honest without unbounded vertical growth.
+    const TOPIC_CAP = 6;
+    if (topicLines.length <= TOPIC_CAP) {
+      return [calendarLine, ...topicLines];
     }
-    if (selected.length === 1) {
-      return `Tomorrow’s briefing will cover ${selected[0]}.`;
-    }
-    const head = selected.slice(0, selected.length - 1).join(', ');
-    const tail = selected[selected.length - 1];
-    return `Tomorrow’s briefing will cover ${head} and ${tail}.`;
+    const visible = topicLines.slice(0, TOPIC_CAP);
+    const hidden = topicLines.length - TOPIC_CAP;
+    return [calendarLine, ...visible, `+ ${hidden} more topic${hidden === 1 ? '' : 's'}`];
   }, [selected]);
 
   function togglePreset(topic: string) {
@@ -106,111 +142,131 @@ export function InterestsStepView({
       totalSteps={totalSteps}
       stepLabel={`Step ${currentStep} of ${totalSteps} · Interests`}
       title="What should your bot watch?"
-      description="Pick topics your morning briefing should cover. Choosing topics turns on your daily briefing — you can add your own, adjust the schedule, or turn it off later from settings."
+      description="Pick topics to turn on your daily briefing. Adjust later in settings."
       showProvisioningBanner
+      contentClassName="gap-6"
     >
-      <div className="border-border bg-card flex flex-col gap-5 rounded-lg border p-5 sm:p-6">
-        <div className="flex flex-col gap-2">
-          <span className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase">
-            Topics
-          </span>
-          <div className="flex flex-wrap gap-2">
-            {INTEREST_TOPIC_PRESETS.map(preset => {
-              const active = isPresetSelected(preset, selected);
-              return (
-                <button
-                  key={preset}
-                  type="button"
-                  onClick={() => togglePreset(preset)}
-                  disabled={!active && atCap}
-                  className={`focus-visible:ring-ring rounded-full border px-3 py-1 text-sm transition focus-visible:ring-2 focus-visible:outline-none ${
-                    active
-                      ? 'border-primary bg-primary text-primary-foreground'
-                      : 'border-border bg-background text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
-                  }`}
-                  aria-pressed={active}
-                >
-                  {preset}
-                </button>
-              );
-            })}
-          </div>
-        </div>
+      <div className="grid gap-6 md:grid-cols-[1fr_2fr] md:gap-8">
+        <BriefingChatPreview
+          bot={bot}
+          greeting={selected.length === 0 ? 'Good morning.' : 'Good morning. Here\u2019s your day.'}
+          items={selected.length === 0 ? [] : previewItems}
+          emptyMessage="Pick a topic to see your briefing take shape."
+          closer={selected.length > 0 ? 'Have a good one.' : undefined}
+        />
 
-        <div className="flex flex-col gap-2">
-          <label
-            htmlFor="claw-interests-custom"
-            className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase"
-          >
-            Add your own
-          </label>
-          <div className="flex gap-2">
-            <Input
-              id="claw-interests-custom"
-              value={customInput}
-              onChange={event => setCustomInput(event.target.value)}
-              onKeyDown={handleCustomKeyDown}
-              maxLength={MAX_TOPIC_LENGTH}
-              placeholder="e.g. Biotech, NBA, Real estate"
-              disabled={atCap}
-            />
-            <Button
-              type="button"
-              variant="outline"
-              onClick={addCustom}
-              disabled={!customInput.trim() || atCap}
-            >
-              <Plus className="h-4 w-4" />
-              Add
-            </Button>
-          </div>
-          {customTopics.length > 0 && (
-            <div className="flex flex-wrap gap-2 pt-1">
-              {customTopics.map(topic => (
-                <span
-                  key={topic}
-                  className="border-border bg-muted text-foreground inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
-                >
-                  {topic}
-                  <button
-                    type="button"
-                    onClick={() => removeTopic(topic)}
-                    aria-label={`Remove ${topic}`}
-                    className="hover:text-destructive"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                </span>
-              ))}
+        <div className="flex flex-col gap-8">
+          <section className="flex flex-col gap-3">
+            <div className="flex items-baseline gap-2">
+              <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+                Topics
+              </h3>
+              <span className="text-muted-foreground/80 text-xs">
+                Pick what your briefing covers
+              </span>
             </div>
-          )}
-          {atCap && (
-            <span className="text-muted-foreground text-xs">
-              Maximum of {MAX_TOPICS} topics. Remove one to add another.
-            </span>
-          )}
-        </div>
+            <div className="flex flex-wrap gap-2">
+              {INTEREST_TOPIC_PRESETS.map(preset => {
+                const active = isPresetSelected(preset, selected);
+                return (
+                  <motion.button
+                    key={preset}
+                    type="button"
+                    aria-pressed={active}
+                    disabled={!active && atCap}
+                    whileHover={{ scale: 1.03 }}
+                    whileTap={{ scale: 0.97 }}
+                    transition={TAP_EASE}
+                    onClick={() => togglePreset(preset)}
+                    className={cn(
+                      'focus-visible:ring-brand-primary/60 cursor-pointer rounded-full border px-3 py-1.5 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+                      active
+                        ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
+                        : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+                    )}
+                  >
+                    {preset}
+                  </motion.button>
+                );
+              })}
+            </div>
+          </section>
 
-        <div className="bg-muted/40 border-border rounded-md border p-3">
-          <span className="text-muted-foreground block text-[10px] font-semibold tracking-wider uppercase">
-            Morning workflow
-          </span>
-          <p className="text-foreground mt-1 text-sm">{previewText}</p>
+          <section className="flex flex-col gap-3">
+            <div className="flex items-baseline gap-2">
+              <label
+                htmlFor="claw-interests-custom"
+                className="text-muted-foreground text-xs font-semibold tracking-wider uppercase"
+              >
+                Add your own
+              </label>
+              <span className="text-muted-foreground/80 text-xs">
+                Anything specific you want covered
+              </span>
+            </div>
+            <div className="flex gap-2">
+              <Input
+                id="claw-interests-custom"
+                value={customInput}
+                onChange={event => setCustomInput(event.target.value)}
+                onKeyDown={handleCustomKeyDown}
+                maxLength={MAX_TOPIC_LENGTH}
+                placeholder="e.g. Biotech, NBA, Real estate"
+                disabled={atCap}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={addCustom}
+                disabled={!customInput.trim() || atCap}
+              >
+                <Plus className="h-4 w-4" />
+                Add
+              </Button>
+            </div>
+            {customTopics.length > 0 && (
+              <div className="flex flex-wrap gap-2 pt-1">
+                {customTopics.map(topic => (
+                  <span
+                    key={topic}
+                    className="border-brand-primary/40 bg-brand-primary/10 text-brand-primary inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm"
+                  >
+                    {topic}
+                    <button
+                      type="button"
+                      onClick={() => removeTopic(topic)}
+                      aria-label={`Remove ${topic}`}
+                      className="hover:text-foreground transition-colors"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+            {atCap && (
+              <span className="text-muted-foreground text-xs">
+                Maximum of {MAX_TOPICS} topics. Remove one to add another.
+              </span>
+            )}
+          </section>
         </div>
+      </div>
 
-        <div className="flex items-center justify-end gap-3 pt-1">
-          <Button type="button" variant="ghost" onClick={onSkip} disabled={saving}>
-            Skip for now
-          </Button>
-          <Button
-            type="button"
-            variant="primary"
-            onClick={() => onContinue(selected)}
-            disabled={saving}
-          >
-            {saving ? 'Saving…' : 'Continue →'}
-          </Button>
-        </div>
+      <div className="flex items-center justify-end gap-3 pt-2">
+        <Button type="button" variant="ghost" size="lg" onClick={onSkip} disabled={saving}>
+          Skip for now
+        </Button>
+        <Button
+          type="button"
+          variant="default"
+          size="lg"
+          className="bg-brand-primary hover:bg-brand-primary/90"
+          onClick={() => onContinue(selected)}
+          disabled={saving}
+        >
+          {saving ? 'Saving…' : 'Continue'}
+        </Button>
       </div>
     </OnboardingStepView>
   );


### PR DESCRIPTION
## Summary

- Adds a reusable `BriefingChatPreview` component (`apps/web/src/app/(app)/claw/components/BriefingChatPreview.tsx`) that renders the user's bot identity sending a sample tomorrow-morning message — used as the left column of the Calendar / Inbound Email / Interests steps so the Identity step's personalization (name + emoji) carries through the rest of the wizard.
- Tightens each step's right column: drops redundant single-row eyebrows (`ACCESS`, `INBOUND ADDRESS`), right-sizes integration tiles (56px → 40px) to match the chat avatar, swaps the generic Lucide `Calendar` icon for the multi-color Google "G" mark from the existing `GoogleLogo`, and replaces three brand-yellow-on-every-row `Forward` tip tiles with a neutral mono numbered list (`1`, `2`, `3`) — three yellow tiles violated the brand's "yellow scarce" rule.
- Merges the inbound email address display + Copy button into a single bordered field with an inline `border-l` divider action, matching the field-with-action pattern used elsewhere in the codebase.
- Migrates the wizard's primary CTAs from the legacy blue (`variant="primary"` = hardcoded `#2B6AD2`) to brand yellow-green by overriding with `bg-brand-primary` className on `variant="default"`. Follows existing precedent (`KiloClawCheckoutSuccessClient`, `SidebarMenuBadge`); does not introduce a new Button variant.
- Trims verbose UX copy: Interests description 33 → 13 words; feature titles drop redundant `Read` prefix (`Read your calendar events` → `Calendar events`); Calendar subtitle simplified (`via OAuth · read-only` → `OAuth · Read-only`).
- Fixes a "card-in-card" anti-pattern by removing `border + bg-card` wrappers around inner content blocks on Calendar and Interests steps.
- Caps the Interests preview at 6 visible topics + a `+ N more topics` overflow line so the preview shell stays predictably sized when users select many topics, while still being honest about the magnitude.

## Verification

- Walked all four onboarding steps locally via the existing `?fakeOnboardingStep=` non-prod route (`identity`, `calendar`, `email`, `interests`, plus `complete` and `error` terminal states). Chat preview renders the fake identity (`Aria 🤖`) consistently across the three middle steps.
- Toggled topics on the Interests step: preview updates live, empty-state message renders inside the bubble when no topics, overflow line appears at 7+ topics, cap holds at 6 visible.
- Connected/disconnected states on Calendar render the correct subtitle (`Connected as <email>` vs `OAuth · Read-only`) and the emerald `Connected` pill only when connected.
- Copy button on the merged Inbound Email field shows the transient "Copied" state with the emerald check; `aria-label` updates accordingly.
- All four primary CTAs render in brand yellow-green; ghost `Skip for now` buttons render with the `bg-accent` hover and focus-visible ring.
- Two-column layout (`md:grid-cols-[1fr_2fr]`) collapses cleanly to a single column below the `md` breakpoint.

## Visual Changes

Before/after screenshots can be captured by running locally — I don't have a way to attach images from a coding session.

To preview locally:
1. From a worktree with `.env.local`: `KILO_PORT_OFFSET=auto pnpm dev:start`
2. Read the assigned port from `.dev-port`
3. Sign in with `?fakeUser=...&callbackPath=%2Fclaw%2Fnew%3FfakeOnboardingStep%3D<step>`
4. Walk through `identity`, `calendar`, `email`, `interests`

## Reviewer Notes

- **`--primary` token mismatch left intentionally.** `apps/web/src/app/globals.css:138` has `--primary: oklch(0.922 0 0)` (near-white), contradicting `design.md` and `kilo-brand.md` which say it should equal the brand yellow-green (`oklch(95% 0.15 108)`). Flipping the token would turn ~89 unrelated consumers yellow — chat bubbles, message input send button, selected-state cards, payment success buttons, sidebar menu badges, reaction pills. That's a coordinated design-system task. The CTA migration here uses `bg-brand-primary` className override instead, matching the existing precedent in `KiloClawCheckoutSuccessClient.tsx`.
- **Sibling CTAs left blue.** `SettingsTab`, `OpenClawButton`, `BillingBanner`, `WelcomePage`, `PlanSelectionDialog`, `AccessLockedDialog`, and `SubscriptionTab` all still use `variant="primary"` (legacy blue). They're outside the wizard flow so deliberately out of scope for this PR — easy follow-up: `grep -rn 'variant="primary"' apps/web/src` returns the rest.
- **Email step's copy button is a raw `<button>`** rather than the `Button` primitive. The merged field needed precise control over `self-stretch`, `border-l` divider, `rounded-none` corners, and `hover:bg-muted/60` to integrate cleanly. It still carries focus-visible ring and disabled-state styling consistent with the Button primitive. If a second screen needs the same merged-field affordance, that's the moment to promote it to a Button variant.
- **`botIdentity` may be `null` briefly** during OAuth resume on the Calendar step. `ClawOnboardingFlow.tsx`'s hydration effect catches this from `instanceStatus`, but until it fires, the chat preview falls back to `DEFAULT_BOT_IDENTITY` (`KiloClaw 🦾`). Sub-second flash, acceptable.
- **`ClawOnboardingFakeWalkthrough` got a `FAKE_BOT_IDENTITY` constant** (`Aria 🤖 / Operator`) so the preview reads convincingly when designers/reviewers load steps directly via the fake route without going through Identity first.
- **No DB schema changes, no PII additions, no new dependencies.** Pure UI/UX changes against existing components.
- **Error-step CTA also migrated.** `ClawSetupErrorStep`'s "Contact Support" button moved from `variant="primary"` to `variant="default"` + `bg-brand-primary` so the brand action color is consistent across all wizard exit states.