### PR TITLE
perf(admin): add time-window filter and drop unbounded COUNT on heuristic abuse page

### DIFF
--- a/apps/web/src/app/admin/api/users/heuristic-analysis/grouped/route.ts
+++ b/apps/web/src/app/admin/api/users/heuristic-analysis/grouped/route.ts
@@ -5,6 +5,7 @@ import { db } from '@/lib/drizzle';
 import { sql } from 'drizzle-orm';
 import type { GroupByDimension, GroupedData, HeuristicAnalysisResponse } from '../types';
 import { ABUSE_CLASSIFICATION } from '@/types/AbuseClassification';
+import { parseTimeWindow, timeWindowToInterval } from '../timeWindow';
 
 const DIMENSION_MAPPINGS = {
   day: { sql: 'DATE(created_at)', select: (i: number) => `DATE(created_at) as group_${i}` },
@@ -28,6 +29,8 @@ export async function GET(request: NextRequest): Promise<NextResponse<HeuristicA
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get('userId');
     const groupByParam = searchParams.get('groupBy');
+    const timeWindow = parseTimeWindow(searchParams.get('since'));
+    const interval = timeWindowToInterval(timeWindow);
 
     if (!userId) {
       return NextResponse.json({ error: 'userId parameter is required' }, { status: 400 });
@@ -84,6 +87,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<HeuristicA
           END as likely_abuse
       ) computed
       WHERE kilo_user_id = ${userId}
+        ${interval ? sql`AND created_at >= NOW() - ${sql.raw(`INTERVAL '${interval}'`)}` : sql``}
       GROUP BY ${sql.raw(groupByClause)}, computed.likely_abuse
       order by ${sql.raw(orderByClause)}
     `;

--- a/apps/web/src/app/admin/api/users/heuristic-analysis/raw/route.ts
+++ b/apps/web/src/app/admin/api/users/heuristic-analysis/raw/route.ts
@@ -3,9 +3,10 @@ import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { db } from '@/lib/drizzle';
 import { microdollar_usage_view } from '@kilocode/db/schema';
-import { eq, desc, count, and, gt } from 'drizzle-orm';
+import { eq, desc, and, gt, gte, sql } from 'drizzle-orm';
 import type { HeuristicAnalysisResponse } from '../types';
 import { ABUSE_CLASSIFICATION } from '@/types/AbuseClassification';
+import { parseTimeWindow, timeWindowToInterval } from '../timeWindow';
 
 export async function GET(request: NextRequest): Promise<NextResponse<HeuristicAnalysisResponse>> {
   const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
@@ -16,41 +17,45 @@ export async function GET(request: NextRequest): Promise<NextResponse<HeuristicA
   const page = Math.max(1, parseInt(searchParams.get('page') || '1'));
   const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') || '100')));
   const onlyAbuse = searchParams.get('onlyAbuse') === 'true';
+  const timeWindow = parseTimeWindow(searchParams.get('since'));
+  const interval = timeWindowToInterval(timeWindow);
 
   if (!userId) {
     return NextResponse.json({ error: 'userId is required' }, { status: 400 });
   }
 
-  const baseCondition = eq(microdollar_usage_view.kilo_user_id, userId);
-  const whereCondition = onlyAbuse
-    ? and(
-        baseCondition,
-        gt(microdollar_usage_view.abuse_classification, ABUSE_CLASSIFICATION.NOT_CLASSIFIED)
-      )
-    : baseCondition;
+  const conditions = [eq(microdollar_usage_view.kilo_user_id, userId)];
+  if (onlyAbuse) {
+    conditions.push(
+      gt(microdollar_usage_view.abuse_classification, ABUSE_CLASSIFICATION.NOT_CLASSIFIED)
+    );
+  }
+  if (interval) {
+    conditions.push(
+      gte(microdollar_usage_view.created_at, sql`NOW() - ${sql.raw(`INTERVAL '${interval}'`)}`)
+    );
+  }
+  const whereCondition = conditions.length === 1 ? conditions[0] : and(...conditions);
 
-  const totalQuery = db
-    .select({ total: count() })
-    .from(microdollar_usage_view)
-    .where(whereCondition);
-
-  const dataQuery = db
+  // Fetch limit + 1 to detect whether another page exists, avoiding an
+  // unbounded COUNT(*) over the user's full history.
+  const rawData = await db
     .select()
     .from(microdollar_usage_view)
     .where(whereCondition)
     .orderBy(desc(microdollar_usage_view.created_at))
-    .limit(limit)
+    .limit(limit + 1)
     .offset((page - 1) * limit);
 
-  const [[{ total }], rawData] = await Promise.all([totalQuery, dataQuery]);
-  const totalPages = Math.ceil(total / limit);
+  const hasMore = rawData.length > limit;
+  const pageRows = hasMore ? rawData.slice(0, limit) : rawData;
 
   return NextResponse.json({
-    data: rawData.map(o => ({
+    data: pageRows.map(o => ({
       ...o,
       // TODO: Pull this from the abuse classification service
       is_ja4_whitelisted: false,
     })),
-    pagination: { page, limit, total, totalPages },
+    pagination: { page, limit, hasMore },
   });
 }

--- a/apps/web/src/app/admin/api/users/heuristic-analysis/timeWindow.ts
+++ b/apps/web/src/app/admin/api/users/heuristic-analysis/timeWindow.ts
@@ -1,0 +1,21 @@
+import { DEFAULT_TIME_WINDOW, TIME_WINDOW_OPTIONS, type TimeWindow } from './types';
+
+export function parseTimeWindow(value: string | null): TimeWindow {
+  if (value && (TIME_WINDOW_OPTIONS as readonly string[]).includes(value)) {
+    return value as TimeWindow;
+  }
+  return DEFAULT_TIME_WINDOW;
+}
+
+export function timeWindowToInterval(window: TimeWindow): string | null {
+  switch (window) {
+    case '7d':
+      return '7 days';
+    case '30d':
+      return '30 days';
+    case '90d':
+      return '90 days';
+    case 'all':
+      return null;
+  }
+}

--- a/apps/web/src/app/admin/api/users/heuristic-analysis/types.ts
+++ b/apps/web/src/app/admin/api/users/heuristic-analysis/types.ts
@@ -1,5 +1,4 @@
 import type { MicrodollarUsageView } from '@kilocode/db/schema';
-import type { PaginationMetadata } from '@/types/pagination';
 
 export type ApiResponse = GroupedDataResponse | PaginatedRawDataResponse;
 export type UsageForTableDisplay = MicrodollarUsageView & {
@@ -7,6 +6,10 @@ export type UsageForTableDisplay = MicrodollarUsageView & {
 };
 
 export type GroupByDimension = 'day' | 'week' | 'month' | 'userAgent' | 'model';
+
+export const TIME_WINDOW_OPTIONS = ['7d', '30d', '90d', 'all'] as const;
+export type TimeWindow = (typeof TIME_WINDOW_OPTIONS)[number];
+export const DEFAULT_TIME_WINDOW: TimeWindow = '7d';
 
 export type GroupedData = {
   groupKey: string;
@@ -17,9 +20,15 @@ export type GroupedData = {
   likelyAbuse: boolean | null;
 };
 
+export type RawPaginationMetadata = {
+  page: number;
+  limit: number;
+  hasMore: boolean;
+};
+
 export type PaginatedRawDataResponse = {
   data: UsageForTableDisplay[];
-  pagination: PaginationMetadata;
+  pagination: RawPaginationMetadata;
   classificationPerformed?: boolean;
 };
 

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminHeuristicAbuse.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminHeuristicAbuse.tsx
@@ -8,8 +8,10 @@ import type {
   ApiResponse,
   GroupByDimension,
   GroupedData,
+  TimeWindow,
   UsageForTableDisplay,
 } from '../../api/users/heuristic-analysis/types';
+import { DEFAULT_TIME_WINDOW, TIME_WINDOW_OPTIONS } from '../../api/users/heuristic-analysis/types';
 import { CopyJsonButton } from '@/components/admin/CopyJsonButton';
 import {
   DropdownMenu,
@@ -302,6 +304,7 @@ const createMicrodollarUsageColumns = (): TableColumn<UsageForTableDisplay>[] =>
 
 export function UserAdminHeuristicAbuse({ id }: Pick<UserDetailProps, 'id'>) {
   const [timeGrouping, setTimeGrouping] = useState<'day' | 'week' | 'month'>('day');
+  const [timeWindow, setTimeWindow] = useState<TimeWindow>(DEFAULT_TIME_WINDOW);
   const [includeUserAgent, setIncludeUserAgent] = useState(false);
   const [includeModel, setIncludeModel] = useState(false);
   const [showRawData, setShowRawData] = useState(false);
@@ -318,11 +321,19 @@ export function UserAdminHeuristicAbuse({ id }: Pick<UserDetailProps, 'id'>) {
   };
 
   const { data, error, isLoading } = useQuery<ApiResponse>({
-    queryKey: ['admin-user-heuristic-analysis', id, buildGroupBy(), showRawData, onlyAbuse, page],
+    queryKey: [
+      'admin-user-heuristic-analysis',
+      id,
+      buildGroupBy(),
+      showRawData,
+      onlyAbuse,
+      page,
+      timeWindow,
+    ],
     queryFn: async (): Promise<ApiResponse> => {
       const endpoint = showRawData
-        ? `/admin/api/users/heuristic-analysis/raw?userId=${id}&page=${page}&limit=40&onlyAbuse=${onlyAbuse}`
-        : `/admin/api/users/heuristic-analysis/grouped?userId=${id}&groupBy=${buildGroupBy()}`;
+        ? `/admin/api/users/heuristic-analysis/raw?userId=${id}&page=${page}&limit=40&onlyAbuse=${onlyAbuse}&since=${timeWindow}`
+        : `/admin/api/users/heuristic-analysis/grouped?userId=${id}&groupBy=${buildGroupBy()}&since=${timeWindow}`;
 
       const response = await fetch(endpoint);
       if (!response.ok) {
@@ -490,12 +501,33 @@ export function UserAdminHeuristicAbuse({ id }: Pick<UserDetailProps, 'id'>) {
       </label>
     </div>
   );
+  const timeWindowControls = (
+    <label className="flex items-center gap-2">
+      <span className="text-sm font-medium">Time window:</span>
+      <select
+        value={timeWindow}
+        onChange={e => {
+          setTimeWindow(e.target.value as TimeWindow);
+          setPage(1);
+        }}
+        className="rounded border px-2 py-1 text-sm"
+      >
+        {TIME_WINDOW_OPTIONS.map(option => (
+          <option key={option} value={option}>
+            {option === 'all' ? 'All time' : `Last ${option}`}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+
   return (
     <div className="flex flex-col gap-4">
       <h2 className="text-xl font-semibold">
         Analysis of usage patterns for potential abuse detection
       </h2>
-      <div className="flex gap-4">
+      <div className="flex items-center gap-4">
+        {timeWindowControls}
         <Button
           variant={showRawData ? 'default' : 'outline'}
           size="sm"
@@ -608,8 +640,7 @@ export function UserAdminHeuristicAbuse({ id }: Pick<UserDetailProps, 'id'>) {
             {paginatedData && (
               <div className="mt-4 flex">
                 <p className="text-muted-foreground text-sm">
-                  Showing page {paginatedData.pagination.page} of{' '}
-                  {paginatedData.pagination.totalPages}
+                  Page {paginatedData.pagination.page}
                 </p>
                 <div className="flex gap-2">
                   <Button
@@ -624,7 +655,7 @@ export function UserAdminHeuristicAbuse({ id }: Pick<UserDetailProps, 'id'>) {
                     size="sm"
                     variant="outline"
                     onClick={() => setPage(p => p + 1)}
-                    disabled={paginatedData.pagination.page >= paginatedData.pagination.totalPages}
+                    disabled={!paginatedData.pagination.hasMore}
                   >
                     Next
                   </Button>


### PR DESCRIPTION
## Summary

The `/admin/users/<id>/heuristic-abuse` page often failed to load because both endpoints scanned a user's entire `microdollar_usage_view` history with no bound on `created_at`. For heavy users, the grouped query alone could time out, and the raw query's unbounded `COUNT(*)` (used only to compute `totalPages`) frequently dominated request time.

This PR makes two surgical changes:

- **Time window filter** — both routes now accept a `since` query param (`7d` / `30d` / `90d` / `all`), default `7d`. The component exposes a "Time window" selector that applies to both grouped and raw views.
- **Drop the unbounded COUNT in raw mode** — the raw endpoint now fetches `limit + 1` rows to detect whether another page exists, and returns `{ page, limit, hasMore }` instead of `{ page, limit, total, totalPages }`. The UI shows "Page N" with Next disabled when `hasMore` is false.

Net effect: by default the page only fetches the last 7 days of activity, and pagination no longer requires a full-table count.

## Verification

- Opened `/admin/users/<id>/heuristic-abuse` in dev for a heavy user — grouped view loads quickly with the default 7-day window.
- Switched the time-window selector through `7d` / `30d` / `90d` / `all` and confirmed both grouped and raw views requery and re-render.
- Toggled "Show Raw Data" with `Only show abuse` on/off; Next/Previous correctly disable on the last page (no `total` round-trip needed).

## Visual Changes

A `Time window` `<select>` (`7d` / `30d` / `90d` / `All time`) is added to the controls row above the existing `Show Raw Data` button. Raw-mode pagination footer changes from "Showing page N of M" to "Page N".

## Reviewer Notes

- The `since` interval is interpolated via `sql.raw(\`INTERVAL '${interval}'\`)`, but the value is constrained to the `TIME_WINDOW_OPTIONS` enum via `parseTimeWindow`, so it cannot carry user input.
- The raw endpoint's pagination shape changed from `{ total, totalPages }` to `{ hasMore }`. This API is admin-only and only consumed by `UserAdminHeuristicAbuse.tsx`, which has been updated.
- No schema or migration changes.
