### PR TITLE
feat(admin): add code review date interval

### DIFF
--- a/apps/web/src/app/admin/api/code-reviews/hooks.ts
+++ b/apps/web/src/app/admin/api/code-reviews/hooks.ts
@@ -4,7 +4,9 @@ import { useTRPC } from '@/lib/trpc/utils';
 import { useQuery } from '@tanstack/react-query';
 
 export type FilterParams = {
+  /** Inclusive ISO datetime lower bound for telemetry queries. */
   startDate: string;
+  /** Exclusive ISO datetime upper bound for telemetry queries. */
   endDate: string;
   userId?: string;
   organizationId?: string;

--- a/apps/web/src/app/admin/code-reviews/page.tsx
+++ b/apps/web/src/app/admin/code-reviews/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { format, subDays } from 'date-fns';
 import AdminPage from '@/app/admin/components/AdminPage';
 import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
@@ -169,22 +169,17 @@ export default function CodeReviewsPage() {
   const isIntervalDraftInvalid = rangeType === 'interval' && intervalValidation.interval === null;
   const { activeInterval, intervalDraft } = dateIntervalState;
   const { startDate, endDate } = activeInterval;
+  const hasPendingIntervalDraft =
+    rangeType === 'interval' &&
+    intervalValidation.interval !== null &&
+    (intervalValidation.interval.startDate !== startDate || intervalValidation.interval.endDate !== endDate);
 
-  useEffect(() => {
-    if (rangeType !== 'interval' || !intervalValidation.interval) return;
-
+  const handleApplyInterval = () => {
     const nextInterval = intervalValidation.interval;
-    setDateIntervalState(current => {
-      if (
-        current.activeInterval.startDate === nextInterval.startDate &&
-        current.activeInterval.endDate === nextInterval.endDate
-      ) {
-        return current;
-      }
+    if (!nextInterval) return;
 
-      return { ...current, activeInterval: nextInterval };
-    });
-  }, [intervalValidation.interval, rangeType]);
+    setDateIntervalState(current => ({ ...current, activeInterval: nextInterval }));
+  };
 
   const handleRangeTypeChange = (nextRangeType: RangeType) => {
     setRangeType(nextRangeType);
@@ -420,6 +415,14 @@ export default function CodeReviewsPage() {
                     aria-invalid={isIntervalDraftInvalid}
                   />
                 </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleApplyInterval}
+                  disabled={!hasPendingIntervalDraft}
+                >
+                  Apply interval
+                </Button>
               </div>
               <p
                 id="code-review-date-interval-feedback"
@@ -432,7 +435,9 @@ export default function CodeReviewsPage() {
               >
                 {isIntervalDraftInvalid
                   ? intervalValidation.error
-                  : "Times use this browser's local timezone."}
+                  : hasPendingIntervalDraft
+                    ? "Apply the interval to update telemetry. Times use this browser's local timezone."
+                    : "Times use this browser's local timezone."}
               </p>
             </div>
           )}

--- a/apps/web/src/app/admin/code-reviews/page.tsx
+++ b/apps/web/src/app/admin/code-reviews/page.tsx
@@ -37,7 +37,7 @@ const breadcrumbs = (
   </BreadcrumbItem>
 );
 
-type RangeType = '7d' | '30d' | '90d';
+type RangeType = '7d' | 'interval';
 type OwnershipType = 'all' | 'personal' | 'organization';
 type RetryAccountingModeType = 'final_outcome' | 'all_attempts';
 
@@ -53,10 +53,94 @@ type SelectedOrg = {
   plan: string | null;
 };
 
+type ActiveDateInterval = {
+  startDate: string;
+  endDate: string;
+};
+
+type DateIntervalDraft = {
+  startInput: string;
+  endInput: string;
+};
+
+type DateIntervalState = {
+  activeInterval: ActiveDateInterval;
+  intervalDraft: DateIntervalDraft;
+};
+
+type DateIntervalValidation = {
+  interval: ActiveDateInterval | null;
+  error: string | null;
+};
+
+const dateRangeOptions = [
+  { value: '7d', label: 'Last 7 days' },
+  { value: 'interval', label: 'Date interval' },
+] satisfies { value: RangeType; label: string }[];
+
+function toDatetimeLocalInput(date: Date): string {
+  return format(date, "yyyy-MM-dd'T'HH:mm");
+}
+
+function roundToDatetimeLocalMinute(date: Date): Date {
+  const minuteDate = new Date(date);
+  minuteDate.setSeconds(0, 0);
+  return minuteDate;
+}
+
+function createTrailingSevenDayIntervalState(): DateIntervalState {
+  const end = roundToDatetimeLocalMinute(new Date());
+  const start = subDays(end, 7);
+
+  return {
+    activeInterval: {
+      startDate: start.toISOString(),
+      endDate: end.toISOString(),
+    },
+    intervalDraft: {
+      startInput: toDatetimeLocalInput(start),
+      endInput: toDatetimeLocalInput(end),
+    },
+  };
+}
+
+function parseDatetimeLocal(value: string): Date | null {
+  if (!value) return null;
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function validateDateIntervalDraft(draft: DateIntervalDraft): DateIntervalValidation {
+  const start = parseDatetimeLocal(draft.startInput);
+  const end = parseDatetimeLocal(draft.endInput);
+
+  if (!start || !end) {
+    return { interval: null, error: 'Choose valid start and end times.' };
+  }
+
+  if (start.getTime() >= end.getTime()) {
+    return { interval: null, error: 'Start time must be before end time.' };
+  }
+
+  return {
+    interval: {
+      startDate: start.toISOString(),
+      endDate: end.toISOString(),
+    },
+    error: null,
+  };
+}
+
+function formatDateIntervalLabel(value: string): string {
+  return format(new Date(value), 'yyyy-MM-dd HH:mm');
+}
+
 export default function CodeReviewsPage() {
   const [rangeType, setRangeType] = useState<RangeType>('7d');
-  const [startDate, setStartDate] = useState<string>('');
-  const [endDate, setEndDate] = useState<string>('');
+  const [dateIntervalState, setDateIntervalState] = useState<DateIntervalState>(
+    createTrailingSevenDayIntervalState
+  );
   const [isExporting, setIsExporting] = useState(false);
 
   const trpcClient = useRawTRPCClient();
@@ -78,22 +162,47 @@ export default function CodeReviewsPage() {
   const userSearchResults = useSearchUsers(userSearchQuery, showUserDropdown);
   const orgSearchResults = useSearchOrganizations(orgSearchQuery, showOrgDropdown);
 
-  // Calculate dates based on range type
+  const intervalValidation = useMemo(
+    () => validateDateIntervalDraft(dateIntervalState.intervalDraft),
+    [dateIntervalState.intervalDraft]
+  );
+  const isIntervalDraftInvalid = rangeType === 'interval' && intervalValidation.interval === null;
+  const { activeInterval, intervalDraft } = dateIntervalState;
+  const { startDate, endDate } = activeInterval;
+
   useEffect(() => {
-    const now = new Date();
-    // End date is tomorrow to include today's data
-    const end = format(subDays(now, -1), 'yyyy-MM-dd');
+    if (rangeType !== 'interval' || !intervalValidation.interval) return;
 
-    const daysMap: Record<RangeType, number> = {
-      '7d': 7,
-      '30d': 30,
-      '90d': 90,
-    };
+    const nextInterval = intervalValidation.interval;
+    setDateIntervalState(current => {
+      if (
+        current.activeInterval.startDate === nextInterval.startDate &&
+        current.activeInterval.endDate === nextInterval.endDate
+      ) {
+        return current;
+      }
 
-    const start = format(subDays(now, daysMap[rangeType]), 'yyyy-MM-dd');
-    setStartDate(start);
-    setEndDate(end);
-  }, [rangeType]);
+      return { ...current, activeInterval: nextInterval };
+    });
+  }, [intervalValidation.interval, rangeType]);
+
+  const handleRangeTypeChange = (nextRangeType: RangeType) => {
+    setRangeType(nextRangeType);
+    if (nextRangeType !== '7d') return;
+
+    const nextPresetInterval = createTrailingSevenDayIntervalState().activeInterval;
+    setDateIntervalState(current => ({ ...current, activeInterval: nextPresetInterval }));
+  };
+
+  const handleIntervalDraftChange = (field: keyof DateIntervalDraft, value: string) => {
+    setDateIntervalState(current => ({
+      ...current,
+      intervalDraft: {
+        ...current.intervalDraft,
+        [field]: value,
+      },
+    }));
+  };
 
   // Build filter params
   const filterParams: FilterParams = useMemo(
@@ -118,6 +227,8 @@ export default function CodeReviewsPage() {
   const segmentationQuery = useCodeReviewUserSegmentation(filterParams);
 
   const handleRefresh = useCallback(() => {
+    if (isIntervalDraftInvalid) return;
+
     void overviewQuery.refetch();
     void dailyQuery.refetch();
     void performanceQuery.refetch();
@@ -126,6 +237,7 @@ export default function CodeReviewsPage() {
     void errorQuery.refetch();
     void segmentationQuery.refetch();
   }, [
+    isIntervalDraftInvalid,
     overviewQuery,
     dailyQuery,
     performanceQuery,
@@ -192,7 +304,7 @@ export default function CodeReviewsPage() {
 
   // Handle CSV export
   const handleExport = useCallback(async () => {
-    if (isExporting || !startDate || !endDate) return;
+    if (isExporting || isIntervalDraftInvalid || !startDate || !endDate) return;
 
     setIsExporting(true);
     try {
@@ -205,7 +317,7 @@ export default function CodeReviewsPage() {
     } finally {
       setIsExporting(false);
     }
-  }, [trpcClient, filterParams, startDate, endDate, isExporting]);
+  }, [trpcClient, filterParams, startDate, endDate, isExporting, isIntervalDraftInvalid]);
 
   const isLoading =
     overviewQuery.isLoading ||
@@ -226,11 +338,21 @@ export default function CodeReviewsPage() {
       breadcrumbs={breadcrumbs}
       buttons={
         <div className="flex gap-2">
-          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={isRefreshing}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={isRefreshing || isIntervalDraftInvalid}
+          >
             <RefreshCw className={`mr-2 h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
             Refresh
           </Button>
-          <Button variant="outline" size="sm" onClick={handleExport} disabled={isExporting}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleExport}
+            disabled={isExporting || isIntervalDraftInvalid}
+          >
             <Download className="mr-2 h-4 w-4" />
             {isExporting ? 'Exporting...' : 'Export CSV'}
           </Button>
@@ -251,23 +373,69 @@ export default function CodeReviewsPage() {
           {/* Date Range Row */}
           <div className="flex flex-wrap items-center gap-4">
             <span className="text-sm font-medium">Date Range:</span>
-            {(['7d', '30d', '90d'] as RangeType[]).map(range => (
-              <label key={range} className="flex cursor-pointer items-center gap-2 text-sm">
+            {dateRangeOptions.map(option => (
+              <label key={option.value} className="flex cursor-pointer items-center gap-2 text-sm">
                 <input
                   type="radio"
                   name="rangeType"
-                  value={range}
-                  checked={rangeType === range}
-                  onChange={() => setRangeType(range)}
+                  value={option.value}
+                  checked={rangeType === option.value}
+                  onChange={() => handleRangeTypeChange(option.value)}
                   className="h-4 w-4"
                 />
-                Last {range.replace('d', ' days')}
+                {option.label}
               </label>
             ))}
-            <span className="text-muted-foreground ml-4 text-xs">
-              {startDate} to {endDate}
+            <span className="text-muted-foreground text-xs sm:ml-4">
+              {formatDateIntervalLabel(startDate)} to {formatDateIntervalLabel(endDate)}
             </span>
           </div>
+
+          {rangeType === 'interval' && (
+            <div className="flex flex-col gap-2">
+              <div className="flex flex-wrap items-end gap-4">
+                <div className="flex w-full flex-col gap-2 sm:w-[220px]">
+                  <label htmlFor="code-review-start-time" className="text-sm font-medium">
+                    Start datetime
+                  </label>
+                  <Input
+                    id="code-review-start-time"
+                    type="datetime-local"
+                    value={intervalDraft.startInput}
+                    onChange={event => handleIntervalDraftChange('startInput', event.target.value)}
+                    aria-describedby="code-review-date-interval-feedback"
+                    aria-invalid={isIntervalDraftInvalid}
+                  />
+                </div>
+                <div className="flex w-full flex-col gap-2 sm:w-[220px]">
+                  <label htmlFor="code-review-end-time" className="text-sm font-medium">
+                    End datetime
+                  </label>
+                  <Input
+                    id="code-review-end-time"
+                    type="datetime-local"
+                    value={intervalDraft.endInput}
+                    onChange={event => handleIntervalDraftChange('endInput', event.target.value)}
+                    aria-describedby="code-review-date-interval-feedback"
+                    aria-invalid={isIntervalDraftInvalid}
+                  />
+                </div>
+              </div>
+              <p
+                id="code-review-date-interval-feedback"
+                aria-live="polite"
+                className={
+                  isIntervalDraftInvalid
+                    ? 'text-destructive text-xs'
+                    : 'text-muted-foreground text-xs'
+                }
+              >
+                {isIntervalDraftInvalid
+                  ? intervalValidation.error
+                  : "Times use this browser's local timezone."}
+              </p>
+            </div>
+          )}
 
           {/* Ownership Type Filter */}
           <div className="flex flex-wrap items-center gap-4">

--- a/apps/web/src/app/admin/code-reviews/page.tsx
+++ b/apps/web/src/app/admin/code-reviews/page.tsx
@@ -175,7 +175,8 @@ export default function CodeReviewsPage() {
   const hasPendingIntervalDraft =
     rangeType === 'interval' &&
     intervalValidation.interval !== null &&
-    (intervalValidation.interval.startDate !== startDate || intervalValidation.interval.endDate !== endDate);
+    (intervalValidation.interval.startDate !== startDate ||
+      intervalValidation.interval.endDate !== endDate);
 
   const handleApplyInterval = () => {
     const nextInterval = intervalValidation.interval;

--- a/apps/web/src/app/admin/code-reviews/page.tsx
+++ b/apps/web/src/app/admin/code-reviews/page.tsx
@@ -315,7 +315,7 @@ export default function CodeReviewsPage() {
 
   // Handle CSV export
   const handleExport = useCallback(async () => {
-    if (isExporting || isIntervalDraftInvalid || !startDate || !endDate) return;
+    if (isExporting || isIntervalDraftInvalid) return;
 
     setIsExporting(true);
     try {

--- a/apps/web/src/app/admin/code-reviews/page.tsx
+++ b/apps/web/src/app/admin/code-reviews/page.tsx
@@ -82,14 +82,17 @@ function toDatetimeLocalInput(date: Date): string {
   return format(date, "yyyy-MM-dd'T'HH:mm");
 }
 
-function roundToDatetimeLocalMinute(date: Date): Date {
+function roundUpToDatetimeLocalMinute(date: Date): Date {
   const minuteDate = new Date(date);
+  if (minuteDate.getSeconds() > 0 || minuteDate.getMilliseconds() > 0) {
+    minuteDate.setMinutes(minuteDate.getMinutes() + 1);
+  }
   minuteDate.setSeconds(0, 0);
   return minuteDate;
 }
 
 function createTrailingSevenDayIntervalState(): DateIntervalState {
-  const end = roundToDatetimeLocalMinute(new Date());
+  const end = roundUpToDatetimeLocalMinute(new Date());
   const start = subDays(end, 7);
 
   return {

--- a/apps/web/src/app/admin/code-reviews/page.tsx
+++ b/apps/web/src/app/admin/code-reviews/page.tsx
@@ -185,8 +185,7 @@ export default function CodeReviewsPage() {
     setRangeType(nextRangeType);
     if (nextRangeType !== '7d') return;
 
-    const nextPresetInterval = createTrailingSevenDayIntervalState().activeInterval;
-    setDateIntervalState(current => ({ ...current, activeInterval: nextPresetInterval }));
+    setDateIntervalState(createTrailingSevenDayIntervalState());
   };
 
   const handleIntervalDraftChange = (field: keyof DateIntervalDraft, value: string) => {

--- a/apps/web/src/app/admin/code-reviews/page.tsx
+++ b/apps/web/src/app/admin/code-reviews/page.tsx
@@ -226,6 +226,17 @@ export default function CodeReviewsPage() {
   const handleRefresh = useCallback(() => {
     if (isIntervalDraftInvalid) return;
 
+    if (rangeType === '7d') {
+      const nextPresetState = createTrailingSevenDayIntervalState();
+      if (
+        nextPresetState.activeInterval.startDate !== startDate ||
+        nextPresetState.activeInterval.endDate !== endDate
+      ) {
+        setDateIntervalState(nextPresetState);
+        return;
+      }
+    }
+
     void overviewQuery.refetch();
     void dailyQuery.refetch();
     void performanceQuery.refetch();
@@ -235,6 +246,9 @@ export default function CodeReviewsPage() {
     void segmentationQuery.refetch();
   }, [
     isIntervalDraftInvalid,
+    rangeType,
+    startDate,
+    endDate,
     overviewQuery,
     dailyQuery,
     performanceQuery,

--- a/apps/web/src/app/admin/code-reviews/utils/csvExport.ts
+++ b/apps/web/src/app/admin/code-reviews/utils/csvExport.ts
@@ -60,12 +60,16 @@ function escapeCsvValue(value: string | number | null | undefined): string {
   return str;
 }
 
+function toDownloadFilenameToken(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]+/g, '-');
+}
+
 /**
  * Exports code review data to a CSV file and triggers download.
  *
  * @param data - Array of code review records
- * @param startDate - Start date for filename
- * @param endDate - End date for filename
+ * @param startDate - Start ISO datetime for filename
+ * @param endDate - End ISO datetime for filename
  */
 export function exportCodeReviewsToCSV(
   data: CodeReviewExportRow[],
@@ -149,9 +153,11 @@ export function exportCodeReviewsToCSV(
   const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
   const link = document.createElement('a');
   const url = URL.createObjectURL(blob);
+  const startDateToken = toDownloadFilenameToken(startDate);
+  const endDateToken = toDownloadFilenameToken(endDate);
 
   link.setAttribute('href', url);
-  link.setAttribute('download', `code-reviews-${startDate}-to-${endDate}.csv`);
+  link.setAttribute('download', `code-reviews-${startDateToken}-to-${endDateToken}.csv`);
   link.style.visibility = 'hidden';
   document.body.appendChild(link);
   link.click();

--- a/apps/web/src/routers/admin-code-reviews-router.test.ts
+++ b/apps/web/src/routers/admin-code-reviews-router.test.ts
@@ -11,8 +11,8 @@ import {
 import { eq } from 'drizzle-orm';
 
 const REPO = `test-org/admin-code-review-wait-${Date.now()}`;
-const START_DATE = '2035-01-01';
-const END_DATE = '2035-01-20';
+const START_DATE = '2035-01-01T00:00:00.000Z';
+const END_DATE = '2035-01-20T00:00:00.000Z';
 
 type ReviewOwner = { type: 'user'; id: string } | { type: 'org'; id: string };
 type FilterInput = {
@@ -162,6 +162,35 @@ describe('adminCodeReviewsRouter', () => {
     expect(result.p99WaitSeconds).toBeCloseTo(592.8);
     expect(result.maxWaitSeconds).toBeCloseTo(600);
     expect(result.waitWithinFiveMinuteRate).toBeCloseTo(66.67, 1);
+  });
+
+  it('filters sub-day intervals with an inclusive start and exclusive end', async () => {
+    const personalOwner = { type: 'user', id: adminUser.id } satisfies ReviewOwner;
+
+    await db
+      .insert(cloud_agent_code_reviews)
+      .values([
+        reviewValues({ owner: personalOwner, status: 'pending', createdAt: timestamp(720) }),
+        reviewValues({ owner: personalOwner, status: 'pending', createdAt: timestamp(750) }),
+        reviewValues({ owner: personalOwner, status: 'pending', createdAt: timestamp(780) }),
+      ]);
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.codeReviews.getOverviewStats(
+      filterInput({ startDate: timestamp(720), endDate: timestamp(780) })
+    );
+
+    expect(result.totalReviews).toBe(2);
+  });
+
+  it('rejects empty telemetry date intervals', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.codeReviews.getOverviewStats(
+        filterInput({ startDate: timestamp(780), endDate: timestamp(780) })
+      )
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
   it('counts recovered retries as final outcomes by default and separate attempts in all-attempts mode', async () => {

--- a/apps/web/src/routers/admin-code-reviews-router.test.ts
+++ b/apps/web/src/routers/admin-code-reviews-router.test.ts
@@ -193,6 +193,24 @@ describe('adminCodeReviewsRouter', () => {
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
+  it('rejects telemetry date intervals longer than 90 days', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const longInterval = filterInput({
+      startDate: '2035-01-01T00:00:00.000Z',
+      endDate: '2035-04-02T00:00:00.000Z',
+    });
+
+    await expect(caller.admin.codeReviews.getOverviewStats(longInterval)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+    await expect(
+      caller.admin.codeReviews.getErrorSessions({
+        ...longInterval,
+        errorMessage: 'Container shutdown: SIGTERM',
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
   it('counts recovered retries as final outcomes by default and separate attempts in all-attempts mode', async () => {
     const [review] = await db
       .insert(cloud_agent_code_reviews)

--- a/apps/web/src/routers/admin-code-reviews-router.ts
+++ b/apps/web/src/routers/admin-code-reviews-router.ts
@@ -77,9 +77,9 @@ const attemptErrorCategoryExpr = sql<string>`CASE
   ELSE 'Other'
 END`;
 
-const FilterSchema = z.object({
-  startDate: z.string().date(), // ISO date string YYYY-MM-DD
-  endDate: z.string().date(), // ISO date string YYYY-MM-DD
+const FilterSchemaShape = {
+  startDate: z.string().datetime(), // ISO datetime string
+  endDate: z.string().datetime(), // ISO datetime string
   userId: z.string().min(1).optional(), // Filter by specific user
   organizationId: z.string().uuid().optional(), // Filter by specific organization
   ownershipType: z.enum(['all', 'personal', 'organization']).optional().default('all'),
@@ -87,7 +87,28 @@ const FilterSchema = z.object({
     .enum(['final_outcome', 'all_attempts'])
     .optional()
     .default('final_outcome'),
-});
+};
+
+type DateIntervalInput = {
+  startDate: string;
+  endDate: string;
+};
+
+function hasAscendingDateInterval(input: DateIntervalInput): boolean {
+  return new Date(input.startDate).getTime() < new Date(input.endDate).getTime();
+}
+
+const intervalOrderValidation = {
+  message: 'Start date must be before end date',
+  path: ['endDate'],
+};
+
+const FilterSchema = z
+  .object(FilterSchemaShape)
+  .refine(hasAscendingDateInterval, intervalOrderValidation);
+const ErrorSessionsFilterSchema = z
+  .object({ ...FilterSchemaShape, errorMessage: z.string().min(1) })
+  .refine(hasAscendingDateInterval, intervalOrderValidation);
 
 type FilterInput = z.infer<typeof FilterSchema>;
 
@@ -473,93 +494,91 @@ export const adminCodeReviewsRouter = createTRPCRouter({
   }),
 
   // Get the 20 most recent sessions for a specific error message pattern (drill-down from error table)
-  getErrorSessions: adminProcedure
-    .input(FilterSchema.extend({ errorMessage: z.string().min(1) }))
-    .query(async ({ input }) => {
-      const { errorMessage } = input;
-      const statusTable =
-        input.retryAccountingMode === 'all_attempts'
-          ? cloud_agent_code_review_attempts
-          : cloud_agent_code_reviews;
-      const errorMessageColumn =
-        input.retryAccountingMode === 'all_attempts'
-          ? cloud_agent_code_review_attempts.error_message
-          : cloud_agent_code_reviews.error_message;
-      const excludeBilling =
-        input.retryAccountingMode === 'all_attempts'
-          ? excludeBillingAttemptErrors
-          : excludeBillingErrors;
+  getErrorSessions: adminProcedure.input(ErrorSessionsFilterSchema).query(async ({ input }) => {
+    const { errorMessage } = input;
+    const statusTable =
+      input.retryAccountingMode === 'all_attempts'
+        ? cloud_agent_code_review_attempts
+        : cloud_agent_code_reviews;
+    const errorMessageColumn =
+      input.retryAccountingMode === 'all_attempts'
+        ? cloud_agent_code_review_attempts.error_message
+        : cloud_agent_code_reviews.error_message;
+    const excludeBilling =
+      input.retryAccountingMode === 'all_attempts'
+        ? excludeBillingAttemptErrors
+        : excludeBillingErrors;
 
-      const conditions = [
-        eq(statusTable.status, 'failed'),
-        excludeBilling,
-        eq(
-          sql`COALESCE(SUBSTRING(${errorMessageColumn} FROM 1 FOR 200), 'Unknown Error')`,
-          errorMessage
-        ),
-        ...buildBaseConditions(input),
-      ] as SQL[];
+    const conditions = [
+      eq(statusTable.status, 'failed'),
+      excludeBilling,
+      eq(
+        sql`COALESCE(SUBSTRING(${errorMessageColumn} FROM 1 FOR 200), 'Unknown Error')`,
+        errorMessage
+      ),
+      ...buildBaseConditions(input),
+    ] as SQL[];
 
-      const query = db
-        .select({
-          review_id: cloud_agent_code_reviews.id,
-          session_id:
-            input.retryAccountingMode === 'all_attempts'
-              ? cloud_agent_code_review_attempts.session_id
-              : cloud_agent_code_reviews.session_id,
-          cli_session_id:
-            input.retryAccountingMode === 'all_attempts'
-              ? cloud_agent_code_review_attempts.cli_session_id
-              : cloud_agent_code_reviews.cli_session_id,
-          attempt_id:
-            input.retryAccountingMode === 'all_attempts'
-              ? cloud_agent_code_review_attempts.id
-              : sql<string | null>`NULL`,
-          attempt_number:
-            input.retryAccountingMode === 'all_attempts'
-              ? cloud_agent_code_review_attempts.attempt_number
-              : sql<number | null>`NULL`,
-          user_id: cloud_agent_code_reviews.owned_by_user_id,
-          org_id: cloud_agent_code_reviews.owned_by_organization_id,
-          error_message: errorMessageColumn,
-          created_at:
-            input.retryAccountingMode === 'all_attempts'
-              ? cloud_agent_code_review_attempts.created_at
-              : cloud_agent_code_reviews.created_at,
-          repo_full_name: cloud_agent_code_reviews.repo_full_name,
-          pr_number: cloud_agent_code_reviews.pr_number,
-        })
-        .from(cloud_agent_code_reviews);
+    const query = db
+      .select({
+        review_id: cloud_agent_code_reviews.id,
+        session_id:
+          input.retryAccountingMode === 'all_attempts'
+            ? cloud_agent_code_review_attempts.session_id
+            : cloud_agent_code_reviews.session_id,
+        cli_session_id:
+          input.retryAccountingMode === 'all_attempts'
+            ? cloud_agent_code_review_attempts.cli_session_id
+            : cloud_agent_code_reviews.cli_session_id,
+        attempt_id:
+          input.retryAccountingMode === 'all_attempts'
+            ? cloud_agent_code_review_attempts.id
+            : sql<string | null>`NULL`,
+        attempt_number:
+          input.retryAccountingMode === 'all_attempts'
+            ? cloud_agent_code_review_attempts.attempt_number
+            : sql<number | null>`NULL`,
+        user_id: cloud_agent_code_reviews.owned_by_user_id,
+        org_id: cloud_agent_code_reviews.owned_by_organization_id,
+        error_message: errorMessageColumn,
+        created_at:
+          input.retryAccountingMode === 'all_attempts'
+            ? cloud_agent_code_review_attempts.created_at
+            : cloud_agent_code_reviews.created_at,
+        repo_full_name: cloud_agent_code_reviews.repo_full_name,
+        pr_number: cloud_agent_code_reviews.pr_number,
+      })
+      .from(cloud_agent_code_reviews);
 
-      const rows =
-        input.retryAccountingMode === 'all_attempts'
-          ? await query
-              .innerJoin(
-                cloud_agent_code_review_attempts,
-                eq(cloud_agent_code_review_attempts.code_review_id, cloud_agent_code_reviews.id)
-              )
-              .where(and(...conditions))
-              .orderBy(desc(cloud_agent_code_review_attempts.created_at))
-              .limit(20)
-          : await query
-              .where(and(...conditions))
-              .orderBy(desc(cloud_agent_code_reviews.created_at))
-              .limit(20);
+    const rows =
+      input.retryAccountingMode === 'all_attempts'
+        ? await query
+            .innerJoin(
+              cloud_agent_code_review_attempts,
+              eq(cloud_agent_code_review_attempts.code_review_id, cloud_agent_code_reviews.id)
+            )
+            .where(and(...conditions))
+            .orderBy(desc(cloud_agent_code_review_attempts.created_at))
+            .limit(20)
+        : await query
+            .where(and(...conditions))
+            .orderBy(desc(cloud_agent_code_reviews.created_at))
+            .limit(20);
 
-      return rows.map(row => ({
-        reviewId: row.review_id,
-        sessionId: row.session_id,
-        cliSessionId: row.cli_session_id,
-        attemptId: input.retryAccountingMode === 'all_attempts' ? row.attempt_id : null,
-        attemptNumber: input.retryAccountingMode === 'all_attempts' ? row.attempt_number : null,
-        userId: row.user_id,
-        orgId: row.org_id,
-        errorMessage: row.error_message,
-        createdAt: row.created_at,
-        repoFullName: row.repo_full_name,
-        prNumber: row.pr_number,
-      }));
-    }),
+    return rows.map(row => ({
+      reviewId: row.review_id,
+      sessionId: row.session_id,
+      cliSessionId: row.cli_session_id,
+      attemptId: input.retryAccountingMode === 'all_attempts' ? row.attempt_id : null,
+      attemptNumber: input.retryAccountingMode === 'all_attempts' ? row.attempt_number : null,
+      userId: row.user_id,
+      orgId: row.org_id,
+      errorMessage: row.error_message,
+      createdAt: row.created_at,
+      repoFullName: row.repo_full_name,
+      prNumber: row.pr_number,
+    }));
+  }),
 
   // Get user segmentation (note: this doesn't use filters since it shows top users/orgs for selection)
   getUserSegmentation: adminProcedure.input(FilterSchema).query(async ({ input }) => {

--- a/apps/web/src/routers/admin-code-reviews-router.ts
+++ b/apps/web/src/routers/admin-code-reviews-router.ts
@@ -94,21 +94,36 @@ type DateIntervalInput = {
   endDate: string;
 };
 
+const MAX_TELEMETRY_INTERVAL_MS = 90 * 24 * 60 * 60 * 1000;
+
 function hasAscendingDateInterval(input: DateIntervalInput): boolean {
   return new Date(input.startDate).getTime() < new Date(input.endDate).getTime();
+}
+
+function hasBoundedDateInterval(input: DateIntervalInput): boolean {
+  return (
+    new Date(input.endDate).getTime() - new Date(input.startDate).getTime() <=
+    MAX_TELEMETRY_INTERVAL_MS
+  );
 }
 
 const intervalOrderValidation = {
   message: 'Start date must be before end date',
   path: ['endDate'],
 };
+const intervalLengthValidation = {
+  message: 'Date interval cannot exceed 90 days',
+  path: ['endDate'],
+};
 
 const FilterSchema = z
   .object(FilterSchemaShape)
-  .refine(hasAscendingDateInterval, intervalOrderValidation);
+  .refine(hasAscendingDateInterval, intervalOrderValidation)
+  .refine(hasBoundedDateInterval, intervalLengthValidation);
 const ErrorSessionsFilterSchema = z
   .object({ ...FilterSchemaShape, errorMessage: z.string().min(1) })
-  .refine(hasAscendingDateInterval, intervalOrderValidation);
+  .refine(hasAscendingDateInterval, intervalOrderValidation)
+  .refine(hasBoundedDateInterval, intervalLengthValidation);
 
 type FilterInput = z.infer<typeof FilterSchema>;
 


### PR DESCRIPTION
## Why

Admins could only look at code review data in fixed day ranges. They need a way to check a smaller or exact time period when looking into a problem.

## What changed

The code review dashboard still starts on Last 7 days, and it now has a Date interval option with start and end times. The custom interval starts with the same seven-day window, shows a clear message when the times are missing or out of order, and blocks refresh and export until the range is valid. Code review data requests now accept time-based ranges, keep the end time outside the result set, and reject broken ranges before they run. CSV download names also stay clean when those time values are included.

## How to test

1. Open the admin Code Review Telemetry page and confirm Date Range shows Last 7 days and Date interval.
2. Select Date interval and confirm both time fields are filled with a seven-day window.
3. Set the start time after the end time and confirm the warning appears while Refresh and Export CSV are disabled.
4. Enter a valid time range and confirm the warning clears and the actions become available.
5. Export rows for a range with data and confirm the downloaded CSV name uses safe date and time text.