### PR TITLE
fix(cloud-agent-next): hide callback auth headers

### DIFF
--- a/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -75,6 +75,11 @@ export type CallbackTarget = {
   headers?: Record<string, string>;
 };
 
+/** Callback endpoint surfaced by getSession responses. */
+export type GetSessionCallbackTarget = {
+  url: string;
+};
+
 /**
  * Agent slug selected for a session. Built-in slugs plus `custom` plus any
  * custom slug defined in the session's `runtimeAgents`.
@@ -272,8 +277,8 @@ export type GetSessionOutput = {
   preparedAt?: number;
   initiatedAt?: number;
 
-  // Callback configuration (debug-friendly, URL + headers)
-  callbackTarget?: CallbackTarget;
+  // Callback endpoint only; auth headers remain worker-private.
+  callbackTarget?: GetSessionCallbackTarget;
 
   // Initial message ID for correlation
   initialMessageId?: string;

--- a/apps/web/src/routers/cloud-agent-next-schemas.test.ts
+++ b/apps/web/src/routers/cloud-agent-next-schemas.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
-import { basePrepareSessionNextSchema } from './cloud-agent-next-schemas';
+import {
+  baseGetSessionNextOutputSchema,
+  basePrepareSessionNextSchema,
+} from './cloud-agent-next-schemas';
 
 describe('basePrepareSessionNextSchema', () => {
   it('preserves structured initial slash command payloads', () => {
@@ -18,5 +21,28 @@ describe('basePrepareSessionNextSchema', () => {
     });
 
     expect(result.initialPayload).toEqual(initialPayload);
+  });
+});
+
+describe('baseGetSessionNextOutputSchema', () => {
+  it('removes callback auth headers from browser-facing runtime state', () => {
+    const result = baseGetSessionNextOutputSchema.parse({
+      sessionId: 'agent_12345678-1234-1234-1234-123456789abc',
+      userId: 'user-123',
+      execution: null,
+      callbackTarget: {
+        url: 'https://callback.example.com/complete',
+        headers: {
+          'X-Internal-Secret': 'secret-callback-header',
+        },
+      },
+      timestamp: 123456789,
+      version: 123456789,
+    });
+
+    expect(result.callbackTarget).toEqual({
+      url: 'https://callback.example.com/complete',
+    });
+    expect(result.callbackTarget).not.toHaveProperty('headers');
   });
 });

--- a/apps/web/src/routers/cloud-agent-next-schemas.ts
+++ b/apps/web/src/routers/cloud-agent-next-schemas.ts
@@ -362,10 +362,9 @@ export const executionStatusNextSchema = z
   })
   .nullable();
 
-// Callback target configuration
+// Browser-safe callback target configuration
 export const callbackTargetNextSchema = z.object({
   url: z.string().url(),
-  headers: z.record(z.string(), z.string()).optional(),
 });
 
 // Output schema for getSession (sanitized, no secrets)

--- a/services/cloud-agent-next/src/router.test.ts
+++ b/services/cloud-agent-next/src/router.test.ts
@@ -725,6 +725,12 @@ describe('router sessionId validation', () => {
             mcpServers: {
               puppeteer: { type: 'local', command: ['npx', '-y', '@mcp/puppeteer'] },
             },
+            callbackTarget: {
+              url: 'https://callback.example.com/complete',
+              headers: {
+                'X-Internal-Secret': 'secret-callback-header',
+              },
+            },
             preparedAt: 1700000000000,
             initiatedAt: 1700000001000,
           };
@@ -755,6 +761,10 @@ describe('router sessionId validation', () => {
           expect(result).not.toHaveProperty('envVars');
           expect(result).not.toHaveProperty('setupCommands');
           expect(result).not.toHaveProperty('mcpServers');
+          expect(result.callbackTarget).toEqual({
+            url: 'https://callback.example.com/complete',
+          });
+          expect(result.callbackTarget).not.toHaveProperty('headers');
 
           // Verify DO was accessed with correct key
           expect(cloudAgentSession.idFromName).toHaveBeenCalledWith(`test-user-123:${sessionId}`);

--- a/services/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-management.ts
@@ -462,7 +462,9 @@ export function createSessionManagementHandlers() {
             preparedAt: metadata.preparedAt,
             initiatedAt: metadata.initiatedAt,
 
-            callbackTarget: metadata.callbackTarget,
+            callbackTarget: metadata.callbackTarget
+              ? { url: metadata.callbackTarget.url }
+              : undefined,
 
             initialMessageId: metadata.initialMessageId,
 

--- a/services/cloud-agent-next/src/router/schemas.ts
+++ b/services/cloud-agent-next/src/router/schemas.ts
@@ -567,6 +567,10 @@ export const ExecutionStatusSchema = z
   .nullable()
   .describe('Current execution status (null if no active execution)');
 
+export const GetSessionCallbackTargetSchema = z.object({
+  url: z.string().url(),
+});
+
 export const GetSessionOutput = z.object({
   // Session identifiers
   sessionId: z.string().describe('Cloud-agent session ID'),
@@ -614,9 +618,9 @@ export const GetSessionOutput = z.object({
   preparedAt: z.number().optional().describe('Timestamp when session was prepared'),
   initiatedAt: z.number().optional().describe('Timestamp when session was initiated'),
 
-  // Callback configuration (debug-friendly, URL + headers)
-  callbackTarget: CallbackTargetSchema.optional().describe(
-    'Callback target configuration for execution completion notifications'
+  // Stored callback headers can contain auth material; only expose endpoint location.
+  callbackTarget: GetSessionCallbackTargetSchema.optional().describe(
+    'Callback endpoint for execution completion notifications'
   ),
 
   // Initial message ID for correlation


### PR DESCRIPTION
## Summary
Prevent callback authentication headers stored on Cloud Agent Next sessions from reaching browser-visible session responses.

### Why this change is needed
`callbackTarget.headers` can carry `INTERNAL_API_SECRET` and other callback auth material. Cloud Agent Next persisted those headers for server-side callback delivery, but `getSession` also returned them through web tRPC runtime-state responses, exposing them to browser clients.

### How this is addressed
- Keep callback headers available internally for callback delivery, while projecting public `getSession` callback metadata to URL only.
- Align Cloud Agent Next and web-side output contracts so browser-facing session responses cannot include callback headers.
- Add regression coverage for worker response sanitization and web schema stripping.

## Human Verification
- Confirmed callback delivery still reads stored callback headers server-side; only `getSession` readback shape changed.
- Verified focused worker and web regression tests for header stripping.

## Reviewer Notes
### Human Reviewer Flags
- Secret exposure fix only redacts public session readback; existing callback delivery contracts and internal route auth stay unchanged.
- `INTERNAL_API_SECRET` should be rotated after deploy because prior browser responses may have exposed current value.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `prepareSession` and `updateSession` keep full callback target inputs.
- Durable Object metadata and callback queue delivery retain headers so callback endpoints validating `X-Internal-Secret` continue working.
- Public `GetSessionOutput` now uses a URL-only callback target type in both worker and web contracts.

</details>
