### PR TITLE
fix(gateway): return usage identity for zero-cost inserts

### DIFF
--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -502,10 +502,8 @@ describe('logMicrodollarUsage', () => {
       where: eq(microdollar_usage.id, metadataRecord!.id),
     });
     expect(usageRecord).toBeTruthy();
-    expect(usageIdentity).toEqual({
-      usageId: usageRecord?.id,
-      createdAt: usageRecord?.created_at,
-    });
+    expect(usageIdentity?.usageId).toBe(usageRecord?.id);
+    expect(usageIdentity?.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     expect(usageRecord?.kilo_user_id).toBe('test-log-user-2');
     expect(usageRecord?.cost).toBe(0);
     expect(metadataRecord?.market_cost).toBe(500);

--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -471,6 +471,7 @@ describe('logMicrodollarUsage', () => {
       messageId: 'test-msg-456',
       hasError: true,
       cost_mUsd: 0, // Zero cost
+      market_cost: 500,
       model: 'openai/gpt-4.1',
     };
 
@@ -486,7 +487,7 @@ describe('logMicrodollarUsage', () => {
       },
     };
 
-    await logMicrodollarUsage(usageStats, usageContext);
+    const usageIdentity = await logMicrodollarUsage(usageStats, usageContext);
 
     // Verify user microdollars were NOT incremented
     const updatedUser = await findUserById('test-log-user-2');
@@ -501,8 +502,13 @@ describe('logMicrodollarUsage', () => {
       where: eq(microdollar_usage.id, metadataRecord!.id),
     });
     expect(usageRecord).toBeTruthy();
+    expect(usageIdentity).toEqual({
+      usageId: usageRecord?.id,
+      createdAt: usageRecord?.created_at,
+    });
     expect(usageRecord?.kilo_user_id).toBe('test-log-user-2');
     expect(usageRecord?.cost).toBe(0);
+    expect(metadataRecord?.market_cost).toBe(500);
     expect(usageRecord?.has_error).toBe(true);
     expect(usageRecord?.model).toBe('openai/gpt-4.1');
     expect(metadataRecord?.has_middle_out_transform).toBe(false);

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -266,7 +266,12 @@ export async function logMicrodollarUsage(
   // `insertUsageRecord` swallows DB errors and returns null; surface that
   // failure to callers so dependent FK writes don't dangle on a row that
   // was never persisted.
-  return inserted ? { usageId: inserted.usageId, createdAt: inserted.createdAt } : null;
+  // Use the JS-side identity values we constructed in toInsertableDbUsageRecord
+  // rather than the DB-returned ones. The DB round-trip for created_at returns a
+  // Postgres timestamp string (e.g. "2026-04-29 01:16:12.945+00") which is not
+  // strict ISO 8601 and will fail downstream datetime validators. core.created_at
+  // is always new Date().toISOString() so the format is guaranteed.
+  return inserted ? { usageId: core.id, createdAt: core.created_at } : null;
 }
 
 async function saveUsageRelatedData(

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -109,6 +109,12 @@ const extractMessageTextContent = (m: Message) =>
 
 export type UsageContextInfo = ReturnType<typeof extractUsageContextInfo>;
 
+export type UsageRecordInsertResult = {
+  usageId: string;
+  createdAt: string;
+  newMicrodollarsUsed: number | null;
+};
+
 export function extractUsageContextInfo(usageContext: MicrodollarUsageContext) {
   return {
     kilo_user_id: usageContext.kiloUserId,
@@ -260,7 +266,7 @@ export async function logMicrodollarUsage(
   // `insertUsageRecord` swallows DB errors and returns null; surface that
   // failure to callers so dependent FK writes don't dangle on a row that
   // was never persisted.
-  return inserted ? { usageId: core.id, createdAt: core.created_at } : null;
+  return inserted ? { usageId: inserted.usageId, createdAt: inserted.createdAt } : null;
 }
 
 async function saveUsageRelatedData(
@@ -268,21 +274,24 @@ async function saveUsageRelatedData(
   metadataFields: UsageMetaData,
   prior_microdollar_usage: number,
   posthog_distinct_id: string | null
-): Promise<BalanceUpdateResult> {
+): Promise<UsageRecordInsertResult | null> {
   const isFirst = await isFirstUsage(coreUsageFields, prior_microdollar_usage);
   if (isFirst && posthog_distinct_id)
     await sendFirstUsageEvent(coreUsageFields, posthog_distinct_id);
-  const balanceUpdateResult = await insertUsageRecord(coreUsageFields, metadataFields);
+  const inserted = await insertUsageRecord(coreUsageFields, metadataFields);
+  if (!inserted) return null;
   if (posthog_distinct_id) {
     await sendFirstMicrodollarUsageEventIfNeeded(
-      balanceUpdateResult,
+      inserted.newMicrodollarsUsed === null
+        ? null
+        : { newMicrodollarsUsed: inserted.newMicrodollarsUsed },
       coreUsageFields,
       posthog_distinct_id,
       isFirst
     );
   }
   await ingestOrganizationTokenUsage(coreUsageFields);
-  return balanceUpdateResult;
+  return inserted;
 }
 
 async function isFirstUsage(
@@ -389,7 +398,7 @@ ${metaDataKindName}_cte AS (
 export async function insertUsageRecord(
   coreUsageFields: MicrodollarUsage,
   metadataFields: UsageMetaData
-): Promise<BalanceUpdateResult> {
+): Promise<UsageRecordInsertResult | null> {
   try {
     const result = await startSpan(
       {
@@ -428,7 +437,7 @@ export async function insertUsageRecord(
 async function insertUsageAndMetadataWithBalanceUpdate(
   coreUsageFields: MicrodollarUsage,
   metadataFields: UsageMetaData
-): Promise<BalanceUpdateResult> {
+): Promise<UsageRecordInsertResult> {
   // Pick the matching partial unique index for the daily-rollup upsert. The
   // microdollar_usage_daily table has two partial unique indexes; the upsert
   // must target the one corresponding to this row's scope.
@@ -440,7 +449,9 @@ async function insertUsageAndMetadataWithBalanceUpdate(
   // Use a single SQL statement with CTEs to insert usage, upsert all lookup values, metadata, and update user balance in one roundtrip
   // This ensures atomicity: microdollar_usage insert and kilocode_users.microdollars_used update happen together
   const result = await db.execute<{
-    new_microdollars_used: number;
+    usage_id: string;
+    usage_created_at: string;
+    new_microdollars_used: number | null;
     kilo_pass_threshold: number | null;
   }>(sql`
           WITH microdollar_usage_ins AS (
@@ -468,6 +479,7 @@ async function insertUsageAndMetadataWithBalanceUpdate(
               ${coreUsageFields.inference_provider},
               ${coreUsageFields.project_id}
             )
+            RETURNING id, created_at
           )
           , ${createUpsertCTE(sql`http_user_agent`, metadataFields.http_user_agent)}
           , ${createUpsertCTE(sql`http_ip`, metadataFields.http_x_forwarded_for)}
@@ -574,55 +586,76 @@ async function insertUsageAndMetadataWithBalanceUpdate(
                 microdollar_usage_daily.total_cost_microdollars + EXCLUDED.total_cost_microdollars,
               updated_at = NOW()
           )
-          UPDATE kilocode_users
-          SET microdollars_used = microdollars_used + ${coreUsageFields.cost}
-          WHERE id = ${coreUsageFields.kilo_user_id}
-            AND ${coreUsageFields.organization_id}::uuid IS NULL
-            AND ${coreUsageFields.cost} > 0
-          RETURNING microdollars_used AS new_microdollars_used, kilo_pass_threshold
+          , balance_update AS (
+            UPDATE kilocode_users
+            SET microdollars_used = microdollars_used + ${coreUsageFields.cost}
+            WHERE id = ${coreUsageFields.kilo_user_id}
+              AND ${coreUsageFields.organization_id}::uuid IS NULL
+              AND ${coreUsageFields.cost} > 0
+            RETURNING microdollars_used AS new_microdollars_used, kilo_pass_threshold
+          )
+          SELECT
+            microdollar_usage_ins.id AS usage_id,
+            microdollar_usage_ins.created_at AS usage_created_at,
+            balance_update.new_microdollars_used,
+            balance_update.kilo_pass_threshold
+          FROM microdollar_usage_ins
+          LEFT JOIN balance_update ON true
         `);
 
-  // No rows returned means either: org usage (no user balance update), zero cost, or missing user
-  if (!result.rows[0]) {
-    // Only log error if we expected an update (non-org, positive cost)
-    if (!coreUsageFields.organization_id && coreUsageFields.cost && coreUsageFields.cost > 0) {
-      captureMessage('impossible: missing user', {
-        level: 'fatal',
-        tags: { source: 'insertUsageAndUpdateBalance' },
-        extra: { coreUsageFields },
-      });
-    }
-    return null;
+  const inserted = result.rows[0];
+  if (!inserted) {
+    throw new Error('microdollar_usage insert returned no identity');
   }
 
-  // Convert BigInt to number (microdollars_used is a bigint column)
-  const newMicrodollarsUsed = Number(result.rows[0].new_microdollars_used);
-
-  const kiloPassThreshold =
-    result.rows[0].kilo_pass_threshold == null ? null : Number(result.rows[0].kilo_pass_threshold);
-
-  const effectiveKiloPassThreshold = getEffectiveKiloPassThreshold(kiloPassThreshold);
-
-  if (effectiveKiloPassThreshold !== null && newMicrodollarsUsed >= effectiveKiloPassThreshold) {
-    // Trigger this async to avoid blocking
-    void maybeIssueKiloPassBonusFromUsageThreshold({
-      kiloUserId: coreUsageFields.kilo_user_id,
-      nowIso: coreUsageFields.created_at,
-    }).catch(async error => {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      await appendKiloPassAuditLog(db, {
-        action: KiloPassAuditLogAction.BonusCreditsIssued,
-        result: KiloPassAuditLogResult.Failed,
-        kiloUserId: coreUsageFields.kilo_user_id,
-        payload: {
-          source: 'usage_threshold',
-          error: errorMessage,
-        },
-      });
+  // Missing balance update is expected for org usage and zero-cost rows, but
+  // suspicious for positive-cost personal usage.
+  if (
+    inserted.new_microdollars_used === null &&
+    !coreUsageFields.organization_id &&
+    coreUsageFields.cost > 0
+  ) {
+    captureMessage('impossible: missing user', {
+      level: 'fatal',
+      tags: { source: 'insertUsageAndUpdateBalance' },
+      extra: { coreUsageFields },
     });
   }
 
-  return { newMicrodollarsUsed };
+  const newMicrodollarsUsed =
+    inserted.new_microdollars_used === null ? null : Number(inserted.new_microdollars_used);
+
+  const kiloPassThreshold =
+    inserted.kilo_pass_threshold == null ? null : Number(inserted.kilo_pass_threshold);
+
+  if (newMicrodollarsUsed !== null) {
+    const effectiveKiloPassThreshold = getEffectiveKiloPassThreshold(kiloPassThreshold);
+
+    if (effectiveKiloPassThreshold !== null && newMicrodollarsUsed >= effectiveKiloPassThreshold) {
+      // Trigger this async to avoid blocking
+      void maybeIssueKiloPassBonusFromUsageThreshold({
+        kiloUserId: coreUsageFields.kilo_user_id,
+        nowIso: coreUsageFields.created_at,
+      }).catch(async error => {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        await appendKiloPassAuditLog(db, {
+          action: KiloPassAuditLogAction.BonusCreditsIssued,
+          result: KiloPassAuditLogResult.Failed,
+          kiloUserId: coreUsageFields.kilo_user_id,
+          payload: {
+            source: 'usage_threshold',
+            error: errorMessage,
+          },
+        });
+      });
+    }
+  }
+
+  return {
+    usageId: inserted.usage_id,
+    createdAt: inserted.usage_created_at,
+    newMicrodollarsUsed,
+  };
 }
 
 export function countAndStoreUsage(


### PR DESCRIPTION
## Summary

- Return the `microdollar_usage` identity independently from user balance updates so zero-cost and org-scoped inserts can still drive dependent attribution rows.
- Preserve existing balance-update behavior for positive-cost personal usage while keeping `newMicrodollarsUsed` nullable for rows that intentionally skip balance mutation.
- Add regression coverage that zero-cost usage still returns an identity and keeps `market_cost` for reporting.

## Verification

Manual verification not run; this is a backend persistence contract change with no user-facing manual path.

## Visual Changes

N/A

## Reviewer Notes

Extracted onto `main` with only the usage persistence fix. This intentionally leaves out experiment-routing code from `mark/experimental-models-gateway`.
