### PR TITLE
fix(web): require BYOK encryption key

### DIFF
--- a/apps/web/src/lib/config.server.ts
+++ b/apps/web/src/lib/config.server.ts
@@ -1,5 +1,5 @@
 import { APP_URL } from '@/lib/constants';
-import { getEnvVariable } from '@/lib/dotenvx';
+import { getEnvVariable, requireEnv } from '@/lib/dotenvx';
 import 'server-only';
 
 export const IS_IN_AUTOMATED_TEST = !!getEnvVariable('IS_IN_AUTOMATED_TEST');
@@ -103,7 +103,10 @@ export const USER_DEPLOYMENTS_GIT_TOKEN_ENCRYPTION_KEY = getEnvVariable(
  * Must be a base64-encoded 32-byte (256-bit) key.
  * Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
  */
-export const BYOK_ENCRYPTION_KEY = getEnvVariable('BYOK_ENCRYPTION_KEY') || '';
+export const BYOK_ENCRYPTION_KEY = requireEnv(
+  'BYOK_ENCRYPTION_KEY',
+  getEnvVariable('BYOK_ENCRYPTION_KEY')
+);
 
 // Artificial Analysis API
 export const ARTIFICIAL_ANALYSIS_API_KEY = getEnvVariable('ARTIFICIAL_ANALYSIS_API_KEY');

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import { requireEnv } from '@/lib/dotenvx';
+
 export const FIRST_TOPUP_BONUS_AMOUNT: number = 0;
 
 export const REFERRAL_BONUS_AMOUNT = 10;
@@ -42,16 +44,6 @@ export const CLOUD_AGENT_NEXT_WS_URL = process.env.NEXT_PUBLIC_CLOUD_AGENT_NEXT_
 // Session Ingest WebSocket URL (client-side, inlined at build time)
 // Used by the CLI live transport for real-time event streaming
 export const SESSION_INGEST_WS_URL = process.env.NEXT_PUBLIC_SESSION_INGEST_WS_URL ?? '';
-
-// Next.js inlines NEXT_PUBLIC_* at build time. Fail loudly when required
-// public URLs are missing so misconfiguration surfaces at startup instead of
-// producing relative URLs against the app origin.
-function requireEnv(name: string, value: string | undefined): string {
-  if (!value) {
-    throw new Error(`Missing required environment variable ${name}`);
-  }
-  return value;
-}
 
 // Gastown worker URL (client-side, inlined at build time)
 // The browser talks directly to the gastown Cloudflare Worker for tRPC + WS.

--- a/apps/web/src/lib/dotenvx.ts
+++ b/apps/web/src/lib/dotenvx.ts
@@ -6,3 +6,12 @@
 export function getEnvVariable(key: string): string {
   return process.env[key] || '';
 }
+
+// Next.js inlines NEXT_PUBLIC_* at build time. Fail loudly when required
+// environment variables are missing so misconfiguration surfaces at startup.
+export function requireEnv(name: string, value: string | undefined): string {
+  if (!value) {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value;
+}

--- a/apps/web/src/routers/admin/model-experiments-router.ts
+++ b/apps/web/src/routers/admin/model-experiments-router.ts
@@ -38,13 +38,6 @@ const weightSchema = z.number().int().positive();
 
 const apiKeySchema = z.string().min(1);
 
-function ensureEncryptionKey(): string {
-  if (!BYOK_ENCRYPTION_KEY) {
-    trpcThrow('INTERNAL_SERVER_ERROR', 'BYOK encryption is not configured');
-  }
-  return BYOK_ENCRYPTION_KEY;
-}
-
 async function loadExperimentOrThrow(id: string) {
   const row = await db.query.model_experiment.findFirst({
     where: eq(model_experiment.id, id),
@@ -451,7 +444,7 @@ export const adminModelExperimentsRouter = createTRPCRouter({
       // copy and the key is required.
       let encrypted_api_key;
       if (input.apiKey !== undefined) {
-        encrypted_api_key = encryptApiKey(input.apiKey, ensureEncryptionKey());
+        encrypted_api_key = encryptApiKey(input.apiKey, BYOK_ENCRYPTION_KEY);
       } else {
         const previous = await db
           .select({ encrypted_api_key: model_experiment_variant_version.encrypted_api_key })
@@ -482,7 +475,7 @@ export const adminModelExperimentsRouter = createTRPCRouter({
     }),
 
   rotateApiKey: adminProcedure.input(RotateApiKeySchema).mutation(async ({ input, ctx }) => {
-    const key = ensureEncryptionKey();
+    const key = BYOK_ENCRYPTION_KEY;
     const variant = await loadVariantOrThrow(input.variantId);
     const experiment = await loadExperimentOrThrow(variant.experiment_id);
     assertNonTerminal(experiment.status as Status, 'Rotating api key');

--- a/apps/web/src/routers/byok-router.ts
+++ b/apps/web/src/routers/byok-router.ts
@@ -185,13 +185,6 @@ export const byokRouter = createTRPCRouter({
         await ensureOrganizationAccess(ctx, organizationId, ['owner', 'billing_manager']);
       }
 
-      if (!BYOK_ENCRYPTION_KEY) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'BYOK encryption is not configured',
-        });
-      }
-
       // Encrypt the API key
       const encrypted = encryptApiKey(api_key, BYOK_ENCRYPTION_KEY);
 
@@ -241,13 +234,6 @@ export const byokRouter = createTRPCRouter({
       // If organizationId provided, verify owner/billing access
       if (organizationId) {
         await ensureOrganizationAccess(ctx, organizationId, ['owner', 'billing_manager']);
-      }
-
-      if (!BYOK_ENCRYPTION_KEY) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'BYOK encryption is not configured',
-        });
       }
 
       // Verify key exists and belongs to the organization or user


### PR DESCRIPTION
## Summary

- Require `BYOK_ENCRYPTION_KEY` at server config load so BYOK encryption misconfiguration fails during startup/import instead of at key mutation time.
- Move the shared `requireEnv` helper into `dotenvx.ts` and reuse it for both public URL constants and server config.
- Remove now-unreachable BYOK runtime missing-key checks from BYOK and admin model experiment mutations.

## Verification

No manual verification performed; this is a server configuration and router error-path cleanup with no UI flow changes.

## Visual Changes

N/A

## Reviewer Notes

All environments that import `config.server.ts` now need `BYOK_ENCRYPTION_KEY` set. The test env already provides it in `apps/web/.env.test`.
