### PR TITLE
perf(gastown): shorten mayor cold start path

### DIFF
--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -528,7 +528,7 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
 
     // On fresh containers the browse worktrees won't exist yet. Refresh
     // them in the background so mayor readiness does not wait on clone/fetch
-    // work across every rig. AGENTS.md is rewritten when setup completes.
+    // work across every rig.
     if (request.rigs?.length) {
       void setupMayorBrowseWorktrees(request).catch(err => {
         console.error('[runAgent] background mayor browse worktree setup failed:', err);

--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -661,15 +661,4 @@ async function setupMayorBrowseWorktrees(
     rigCount: request.rigs.length,
     failureCount: failures.length,
   });
-
-  if (request.systemPrompt) {
-    const writeAgentsStart = Date.now();
-    await writeMayorSystemPromptToAgentsMd(workdir, request.systemPrompt);
-    log.info('mayor.write_agents_md_ms', {
-      agentId: request.agentId,
-      townId: request.townId,
-      durationMs: Date.now() - writeAgentsStart,
-      label: 'after_browse_setup',
-    });
-  }
 }

--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -530,7 +530,7 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
     // them in the background so mayor readiness does not wait on clone/fetch
     // work across every rig. AGENTS.md is rewritten when setup completes.
     if (request.rigs?.length) {
-      void setupMayorBrowseWorktrees(request, workdir).catch(err => {
+      void setupMayorBrowseWorktrees(request).catch(err => {
         console.error('[runAgent] background mayor browse worktree setup failed:', err);
       });
     }
@@ -602,10 +602,7 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
   return startAgent(startRequest, workdir, env);
 }
 
-async function setupMayorBrowseWorktrees(
-  request: StartAgentRequest,
-  workdir: string
-): Promise<void> {
+async function setupMayorBrowseWorktrees(request: StartAgentRequest): Promise<void> {
   if (!request.rigs?.length) return;
 
   const setupStart = Date.now();

--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -518,58 +518,21 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
     workdir = await createLightweightWorkspace('triage', request.rigId);
   } else if (request.role === 'mayor') {
     // Mayor doesn't need a repo clone — just a git-initialized directory
+    const workspaceStart = Date.now();
     workdir = await createMayorWorkspace(request.rigId);
+    log.info('mayor.workspace_created_ms', {
+      agentId: request.agentId,
+      townId: request.townId,
+      durationMs: Date.now() - workspaceStart,
+    });
 
-    // On fresh containers the browse worktrees won't exist yet. Set them
-    // up for all known rigs before writing AGENTS.md so the mayor (and its
-    // sub-agents) can immediately browse codebases.
+    // On fresh containers the browse worktrees won't exist yet. Refresh
+    // them in the background so mayor readiness does not wait on clone/fetch
+    // work across every rig. AGENTS.md is rewritten when setup completes.
     if (request.rigs?.length) {
-      // Resolve credentials per-rig since each may use a different
-      // GitHub App installation (platformIntegrationId).
-      const baseEnvVars = request.envVars ?? {};
-      const rigSetupResults = await Promise.allSettled(
-        request.rigs.map(async rig => {
-          const envVars = await resolveGitCredentials({
-            envVars: baseEnvVars,
-            platformIntegrationId: rig.platformIntegrationId,
-          });
-          const hasGitToken = !!(envVars.GIT_TOKEN || envVars.GITHUB_TOKEN || envVars.GITLAB_TOKEN);
-          console.log(
-            `[runAgent] setting up browse worktree: rig=${rig.rigId} gitUrl=${rig.gitUrl} hasGitToken=${hasGitToken}`
-          );
-          await setupRigBrowseWorktree({
-            rigId: rig.rigId,
-            gitUrl: rig.gitUrl,
-            defaultBranch: rig.defaultBranch,
-            envVars,
-          });
-          return rig.rigId;
-        })
-      );
-
-      const failures: Array<{ rigId: string; error: unknown }> = [];
-      for (let i = 0; i < rigSetupResults.length; i++) {
-        const r = rigSetupResults[i];
-        if (r.status === 'rejected') {
-          const reason: unknown = r.reason;
-          failures.push({ rigId: request.rigs[i].rigId, error: reason });
-        }
-      }
-
-      if (failures.length > 0) {
-        for (const f of failures) {
-          const msg = f.error instanceof Error ? f.error.message : String(f.error);
-          const stack = f.error instanceof Error ? f.error.stack : undefined;
-          console.error(
-            `[runAgent] browse worktree setup FAILED for rig=${f.rigId}: ${msg}`,
-            stack ? `\n${stack}` : ''
-          );
-        }
-        console.error(
-          `[runAgent] mayor rig setup: ${failures.length}/${request.rigs.length} rigs failed. ` +
-            `Mayor will start but may not be able to browse these codebases.`
-        );
-      }
+      void setupMayorBrowseWorktrees(request, workdir).catch(err => {
+        console.error('[runAgent] background mayor browse worktree setup failed:', err);
+      });
     }
 
     // Write the system prompt to AGENTS.md so the mayor AND its built-in
@@ -577,7 +540,13 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
     // The system prompt is NOT passed via the session.prompt API — AGENTS.md
     // is the sole source of truth for the mayor's instructions.
     if (request.systemPrompt) {
+      const writeAgentsStart = Date.now();
       await writeMayorSystemPromptToAgentsMd(workdir, request.systemPrompt);
+      log.info('mayor.write_agents_md_ms', {
+        agentId: request.agentId,
+        townId: request.townId,
+        durationMs: Date.now() - writeAgentsStart,
+      });
     }
   } else {
     // Resolve git credentials if missing. When the town config doesn't have
@@ -631,4 +600,76 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
   const startRequest = request.role === 'mayor' ? { ...request, systemPrompt: undefined } : request;
 
   return startAgent(startRequest, workdir, env);
+}
+
+async function setupMayorBrowseWorktrees(
+  request: StartAgentRequest,
+  workdir: string
+): Promise<void> {
+  if (!request.rigs?.length) return;
+
+  const setupStart = Date.now();
+  const baseEnvVars = request.envVars ?? {};
+  const rigSetupResults = await Promise.allSettled(
+    request.rigs.map(async rig => {
+      const envVars = await resolveGitCredentials({
+        envVars: baseEnvVars,
+        platformIntegrationId: rig.platformIntegrationId,
+      });
+      const hasGitToken = !!(envVars.GIT_TOKEN || envVars.GITHUB_TOKEN || envVars.GITLAB_TOKEN);
+      console.log(
+        `[runAgent] setting up browse worktree: rig=${rig.rigId} gitUrl=${rig.gitUrl} hasGitToken=${hasGitToken}`
+      );
+      await setupRigBrowseWorktree({
+        rigId: rig.rigId,
+        gitUrl: rig.gitUrl,
+        defaultBranch: rig.defaultBranch,
+        envVars,
+      });
+      return rig.rigId;
+    })
+  );
+
+  const failures: Array<{ rigId: string; error: unknown }> = [];
+  for (let i = 0; i < rigSetupResults.length; i++) {
+    const result = rigSetupResults[i];
+    if (result.status === 'rejected') {
+      failures.push({ rigId: request.rigs[i].rigId, error: result.reason });
+    }
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      const msg = failure.error instanceof Error ? failure.error.message : String(failure.error);
+      const stack = failure.error instanceof Error ? failure.error.stack : undefined;
+      console.error(
+        `[runAgent] browse worktree setup FAILED for rig=${failure.rigId}: ${msg}`,
+        stack ? `\n${stack}` : ''
+      );
+    }
+    console.error(
+      `[runAgent] mayor rig setup: ${failures.length}/${request.rigs.length} rigs failed. ` +
+        `Mayor will start but may not be able to browse these codebases.`
+    );
+  }
+
+  const setupDurationMs = Date.now() - setupStart;
+  log.info('mayor.browse_worktree_setup_ms', {
+    agentId: request.agentId,
+    townId: request.townId,
+    durationMs: setupDurationMs,
+    rigCount: request.rigs.length,
+    failureCount: failures.length,
+  });
+
+  if (request.systemPrompt) {
+    const writeAgentsStart = Date.now();
+    await writeMayorSystemPromptToAgentsMd(workdir, request.systemPrompt);
+    log.info('mayor.write_agents_md_ms', {
+      agentId: request.agentId,
+      townId: request.townId,
+      durationMs: Date.now() - writeAgentsStart,
+      label: 'after_browse_setup',
+    });
+  }
 }

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -9,7 +9,7 @@
 import { createKilo, type KiloClient } from '@kilocode/sdk';
 import { z } from 'zod';
 import * as fs from 'node:fs/promises';
-import type { ManagedAgent, StartAgentRequest } from './types';
+import { type ManagedAgent, StartAgentRequest } from './types';
 import { reportAgentCompleted, reportMayorWaiting } from './completion-reporter';
 import {
   buildKiloConfigContent,
@@ -29,6 +29,15 @@ const MANAGER_LOG = '[process-manager]';
 // Validates the shape returned by client.session.create() so we fail fast
 // if the SDK changes its return type.
 const SessionResponse = z.object({ id: z.string().min(1) }).passthrough();
+
+const ContainerRegistryResponse = z.object({ data: z.unknown() }).passthrough();
+const ContainerRegistryEntry = z.object({
+  agentId: z.string().min(1),
+  request: StartAgentRequest,
+  workdir: z.string().min(1),
+  env: z.record(z.string(), z.string()),
+});
+type ContainerRegistryEntry = z.infer<typeof ContainerRegistryEntry>;
 
 type SDKInstance = {
   client: KiloClient;
@@ -2918,8 +2927,7 @@ async function bootHydrationImpl(LOG: string): Promise<void> {
       console.warn(`${LOG} Failed to fetch registry: ${resp.status}`);
       return;
     }
-    const json = (await resp.json()) as { data: unknown };
-    registry = json.data;
+    registry = ContainerRegistryResponse.parse(await resp.json()).data;
   } catch (err) {
     const registryFetchMs = Date.now() - registryFetchStart;
     log.warn('bootHydration.registry_fetch_ms', {
@@ -2935,21 +2943,14 @@ async function bootHydrationImpl(LOG: string): Promise<void> {
     return;
   }
 
-  const registryEntries = Array.isArray(registry) ? registry : [];
+  const registryEntries = parseRegistryEntries(LOG, registry);
   if (registryEntries.length === 0) {
     console.log(`${LOG} No agents in registry — nothing to hydrate`);
   } else {
     console.log(`${LOG} Resuming ${registryEntries.length} agent(s) from registry`);
   }
 
-  const mayorEntries = registryEntries.filter(
-    (e: unknown) =>
-      typeof e === 'object' &&
-      e !== null &&
-      'request' in e &&
-      typeof (e as { request?: { role?: string } }).request?.role === 'string' &&
-      (e as { request: { role: string } }).request.role === 'mayor'
-  );
+  const mayorEntries = registryEntries.filter(entry => entry.request.role === 'mayor');
   const nonMayorEntries = registryEntries.filter(entry => !mayorEntries.includes(entry));
 
   if (mayorEntries.length > 0) {
@@ -2993,38 +2994,37 @@ async function bootHydrationImpl(LOG: string): Promise<void> {
 
 async function resumeRegistryEntries(
   LOG: string,
-  entries: unknown[],
+  entries: ContainerRegistryEntry[],
   token: string
 ): Promise<void> {
   for (const entry of entries) {
-    if (typeof entry !== 'object' || entry === null) {
-      console.warn(`${LOG} Skipping malformed registry entry:`, entry);
-      continue;
-    }
-
-    const record = entry as Record<string, unknown>;
-    const agentId = typeof record.agentId === 'string' ? record.agentId : undefined;
-    const agentRequest = record.request as StartAgentRequest | undefined;
-    const workdir = typeof record.workdir === 'string' ? record.workdir : undefined;
-    const env = record.env as Record<string, string> | undefined;
-
-    if (!agentId || !agentRequest || !workdir || !env) {
-      console.warn(`${LOG} Skipping malformed registry entry:`, entry);
-      continue;
-    }
-
     // Registry entries were written with the token snapshot at dispatch
     // time. If we just refreshed, overlay the fresh value so the hydrated
     // kilo serve child inherits the current token.
-    const hydratedEnv = { ...env, GASTOWN_CONTAINER_TOKEN: token };
+    const hydratedEnv = { ...entry.env, GASTOWN_CONTAINER_TOKEN: token };
 
-    console.log(`${LOG} Resuming agent ${agentId} in ${workdir}`);
+    console.log(`${LOG} Resuming agent ${entry.agentId} in ${entry.workdir}`);
     try {
-      await startAgent(agentRequest, workdir, hydratedEnv);
-      console.log(`${LOG} Agent ${agentId} resumed`);
+      await startAgent(entry.request, entry.workdir, hydratedEnv);
+      console.log(`${LOG} Agent ${entry.agentId} resumed`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`${LOG} Failed to resume agent ${agentId}:`, msg);
+      console.error(`${LOG} Failed to resume agent ${entry.agentId}:`, msg);
     }
   }
+}
+
+function parseRegistryEntries(LOG: string, registry: unknown): ContainerRegistryEntry[] {
+  if (!Array.isArray(registry)) return [];
+
+  const entries: ContainerRegistryEntry[] = [];
+  for (const entry of registry) {
+    const parsed = ContainerRegistryEntry.safeParse(entry);
+    if (!parsed.success) {
+      console.warn(`${LOG} Skipping malformed registry entry:`, parsed.error.issues);
+      continue;
+    }
+    entries.push(parsed.data);
+  }
+  return entries;
 }

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -2901,11 +2901,19 @@ async function bootHydrationImpl(LOG: string): Promise<void> {
 
   console.log(`${LOG} Fetching container registry for town=${townId}`);
   let registry: unknown;
+  const registryFetchStart = Date.now();
   try {
     const resp = await fetch(`${apiUrl}/api/towns/${townId}/container-registry`, {
       headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(10_000),
     });
+    const registryFetchMs = Date.now() - registryFetchStart;
+    log.info('bootHydration.registry_fetch_ms', {
+      townId,
+      durationMs: registryFetchMs,
+      statusCode: resp.status,
+    });
+    postEventToWorker('bootHydration.registry_fetch_ms', { durationMs: registryFetchMs });
     if (!resp.ok) {
       console.warn(`${LOG} Failed to fetch registry: ${resp.status}`);
       return;
@@ -2913,43 +2921,28 @@ async function bootHydrationImpl(LOG: string): Promise<void> {
     const json = (await resp.json()) as { data: unknown };
     registry = json.data;
   } catch (err) {
+    const registryFetchMs = Date.now() - registryFetchStart;
+    log.warn('bootHydration.registry_fetch_ms', {
+      townId,
+      durationMs: registryFetchMs,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    postEventToWorker('bootHydration.registry_fetch_ms', {
+      durationMs: registryFetchMs,
+      error: err instanceof Error ? err.message : String(err),
+    });
     console.warn(`${LOG} Registry fetch failed:`, err);
     return;
   }
 
-  if (!Array.isArray(registry) || registry.length === 0) {
+  const registryEntries = Array.isArray(registry) ? registry : [];
+  if (registryEntries.length === 0) {
     console.log(`${LOG} No agents in registry — nothing to hydrate`);
   } else {
-    console.log(`${LOG} Resuming ${registry.length} agent(s) from registry`);
-
-    for (const entry of registry as Record<string, unknown>[]) {
-      const agentId = entry.agentId as string | undefined;
-      const agentRequest = entry.request as StartAgentRequest | undefined;
-      const workdir = entry.workdir as string | undefined;
-      const env = entry.env as Record<string, string> | undefined;
-
-      if (!agentId || !agentRequest || !workdir || !env) {
-        console.warn(`${LOG} Skipping malformed registry entry:`, entry);
-        continue;
-      }
-
-      // Registry entries were written with the token snapshot at dispatch
-      // time. If we just refreshed, overlay the fresh value so the hydrated
-      // kilo serve child inherits the current token.
-      const hydratedEnv = { ...env, GASTOWN_CONTAINER_TOKEN: token };
-
-      console.log(`${LOG} Resuming agent ${agentId} in ${workdir}`);
-      try {
-        await startAgent(agentRequest, workdir, hydratedEnv);
-        console.log(`${LOG} Agent ${agentId} resumed`);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error(`${LOG} Failed to resume agent ${agentId}:`, msg);
-      }
-    }
+    console.log(`${LOG} Resuming ${registryEntries.length} agent(s) from registry`);
   }
 
-  const mayorAlreadyResumed = (Array.isArray(registry) ? registry : []).some(
+  const mayorEntries = registryEntries.filter(
     (e: unknown) =>
       typeof e === 'object' &&
       e !== null &&
@@ -2957,11 +2950,81 @@ async function bootHydrationImpl(LOG: string): Promise<void> {
       typeof (e as { request?: { role?: string } }).request?.role === 'string' &&
       (e as { request: { role: string } }).request.role === 'mayor'
   );
-  if (!mayorAlreadyResumed) {
+  const nonMayorEntries = registryEntries.filter(entry => !mayorEntries.includes(entry));
+
+  if (mayorEntries.length > 0) {
+    const mayorResumeStart = Date.now();
+    await resumeRegistryEntries(LOG, mayorEntries, token);
+    const mayorResumeMs = Date.now() - mayorResumeStart;
+    log.info('bootHydration.mayor_resume_ms', { townId, durationMs: mayorResumeMs });
+    postEventToWorker('bootHydration.mayor_resume_ms', { durationMs: mayorResumeMs });
+  } else {
+    const mayorPrewarmStart = Date.now();
     try {
       await prewarmMayorSDK(townId, apiUrl, token);
     } catch (err) {
       console.warn(`${LOG} Mayor SDK prewarm failed:`, err);
+    } finally {
+      const mayorPrewarmMs = Date.now() - mayorPrewarmStart;
+      log.info('bootHydration.mayor_prewarm_ms', { townId, durationMs: mayorPrewarmMs });
+      postEventToWorker('bootHydration.mayor_prewarm_ms', { durationMs: mayorPrewarmMs });
+    }
+  }
+
+  if (nonMayorEntries.length > 0) {
+    setTimeout(() => {
+      void (async () => {
+        const nonMayorResumeStart = Date.now();
+        await resumeRegistryEntries(LOG, nonMayorEntries, token);
+        const nonMayorResumeMs = Date.now() - nonMayorResumeStart;
+        log.info('bootHydration.non_mayor_resume_ms', {
+          townId,
+          durationMs: nonMayorResumeMs,
+          count: nonMayorEntries.length,
+        });
+        postEventToWorker('bootHydration.non_mayor_resume_ms', {
+          durationMs: nonMayorResumeMs,
+          count: nonMayorEntries.length,
+        });
+      })();
+    }, 0);
+  }
+}
+
+async function resumeRegistryEntries(
+  LOG: string,
+  entries: unknown[],
+  token: string
+): Promise<void> {
+  for (const entry of entries) {
+    if (typeof entry !== 'object' || entry === null) {
+      console.warn(`${LOG} Skipping malformed registry entry:`, entry);
+      continue;
+    }
+
+    const record = entry as Record<string, unknown>;
+    const agentId = typeof record.agentId === 'string' ? record.agentId : undefined;
+    const agentRequest = record.request as StartAgentRequest | undefined;
+    const workdir = typeof record.workdir === 'string' ? record.workdir : undefined;
+    const env = record.env as Record<string, string> | undefined;
+
+    if (!agentId || !agentRequest || !workdir || !env) {
+      console.warn(`${LOG} Skipping malformed registry entry:`, entry);
+      continue;
+    }
+
+    // Registry entries were written with the token snapshot at dispatch
+    // time. If we just refreshed, overlay the fresh value so the hydrated
+    // kilo serve child inherits the current token.
+    const hydratedEnv = { ...env, GASTOWN_CONTAINER_TOKEN: token };
+
+    console.log(`${LOG} Resuming agent ${agentId} in ${workdir}`);
+    try {
+      await startAgent(agentRequest, workdir, hydratedEnv);
+      console.log(`${LOG} Agent ${agentId} resumed`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`${LOG} Failed to resume agent ${agentId}:`, msg);
     }
   }
 }

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -398,7 +398,11 @@ export async function startAgentInContainer(
   try {
     // Mint a container-scoped JWT (8h expiry, refreshed by TownDO alarm).
     // One token per container — shared by all agents in the town.
-    // Carries { townId, userId, scope: 'container' }.
+    // Carries { townId, userId, scope: 'container' }. Fresh dispatches
+    // pass the token in /agents/start instead of first pushing
+    // /refresh-token, keeping cold starts off the extra live request path.
+    // Already-running agents receive token rotation from the alarm or
+    // explicit refresh paths rather than this user-visible startup path.
     const tokenMintStart = Date.now();
     const containerToken = await mintContainerToken(env, {
       townId: params.townId,
@@ -472,6 +476,9 @@ export async function startAgentInContainer(
     }
 
     // Container token is preferred (shared by all agents, refreshed by alarm).
+    // This freshly minted token is for the agent being started; it is not
+    // pushed to existing SDK children here so mayor cold starts avoid a
+    // pre-start /refresh-token request.
     // Legacy per-agent JWT kept as fallback during rollout.
     if (containerToken) envVars.GASTOWN_CONTAINER_TOKEN = containerToken;
     if (agentToken) envVars.GASTOWN_SESSION_TOKEN = agentToken;

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -138,7 +138,14 @@ export async function ensureContainerToken(
   townId: string,
   userId: string
 ): Promise<string | null> {
+  const mintStart = Date.now();
   const token = await mintContainerToken(env, { townId, userId });
+  writeEvent(env, {
+    event: 'startAgentInContainer.token_mint_ms',
+    townId,
+    userId,
+    durationMs: Date.now() - mintStart,
+  });
   if (!token) {
     return null;
   }
@@ -147,6 +154,7 @@ export async function ensureContainerToken(
 
   // Push to running process so existing agents pick up the fresh token.
   // Throw on non-2xx so the alarm's throttle doesn't advance on failure.
+  const refreshStart = Date.now();
   try {
     const resp = await container.fetch('http://container/refresh-token', {
       method: 'POST',
@@ -157,12 +165,27 @@ export async function ensureContainerToken(
     if (!resp.ok) {
       throw new Error(`container returned ${resp.status}`);
     }
+    writeEvent(env, {
+      event: 'startAgentInContainer.refresh_token_ms',
+      townId,
+      userId,
+      durationMs: Date.now() - refreshStart,
+      statusCode: resp.status,
+    });
   } catch (err) {
     // If the container isn't running yet, the next dispatch will include
     // the token in request env. But if it IS running and rejected the
     // refresh, propagate the error so the alarm retries on the next tick.
     const isContainerDown =
       err instanceof TypeError || (err instanceof Error && err.message.includes('fetch'));
+    writeEvent(env, {
+      event: 'startAgentInContainer.refresh_token_ms',
+      townId,
+      userId,
+      durationMs: Date.now() - refreshStart,
+      error: err instanceof Error ? err.message : String(err),
+      label: isContainerDown ? 'container_down' : 'failed',
+    });
     if (!isContainerDown) throw err;
   }
 
@@ -376,7 +399,19 @@ export async function startAgentInContainer(
     // Mint a container-scoped JWT (8h expiry, refreshed by TownDO alarm).
     // One token per container — shared by all agents in the town.
     // Carries { townId, userId, scope: 'container' }.
-    const containerToken = await ensureContainerToken(env, params.townId, params.userId);
+    const tokenMintStart = Date.now();
+    const containerToken = await mintContainerToken(env, {
+      townId: params.townId,
+      userId: params.userId,
+    });
+    writeEvent(env, {
+      event: 'startAgentInContainer.token_mint_ms',
+      townId: params.townId,
+      userId: params.userId,
+      agentId: params.agentId,
+      role: params.role,
+      durationMs: Date.now() - tokenMintStart,
+    });
 
     // Also mint a per-agent JWT as fallback during rollout.
     const agentToken = await mintAgentToken(env, {

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -16,6 +16,7 @@ import { getGastownOrgStub } from '../dos/GastownOrg.do';
 import type { JwtOrgMembership } from '../middleware/auth.middleware';
 import { generateKiloApiToken } from '../util/kilo-token.util';
 import { resolveSecret } from '../util/secret.util';
+import { writeEvent } from '../util/analytics.util';
 import { TownConfigSchema, TownConfigUpdateSchema, RigOverrideConfigSchema } from '../types';
 import { resolveModel } from '../dos/town/config';
 import type { UserRigRecord } from '../db/tables/user-rigs.table';
@@ -74,6 +75,46 @@ async function refreshGitCredentials(
       platform_integration_id: result.installationId,
     },
   });
+}
+
+async function refreshFirstGithubRigCredentials(params: {
+  env: Env;
+  townId: string;
+  ownerStub: RigOwnerStub;
+  credentialUserId: string;
+  organizationId?: string;
+}): Promise<void> {
+  const start = Date.now();
+  try {
+    const rigList = await params.ownerStub.listRigs(params.townId);
+    for (const rig of rigList) {
+      if (extractGithubRepo(rig.git_url)) {
+        await refreshGitCredentials(
+          params.env,
+          params.townId,
+          rig.git_url,
+          params.credentialUserId,
+          params.organizationId
+        );
+        break;
+      }
+    }
+    writeEvent(params.env, {
+      event: 'ensureMayor.git_credential_refresh_ms',
+      townId: params.townId,
+      userId: params.credentialUserId,
+      durationMs: Date.now() - start,
+    });
+  } catch (err) {
+    writeEvent(params.env, {
+      event: 'ensureMayor.git_credential_refresh_ms',
+      townId: params.townId,
+      userId: params.credentialUserId,
+      durationMs: Date.now() - start,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    console.warn('[gastown-trpc] ensureMayor: git credential refresh failed', err);
+  }
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -1004,23 +1045,15 @@ export const gastownRouter = router({
       // Best-effort: refresh git credentials using the town owner's identity
       const townConfig = await getTownDOStub(ctx.env, input.townId).getTownConfig();
       const credentialUserId = townConfig.owner_user_id ?? ctx.userId;
-      try {
-        const rigList = await ownerStub.listRigs(input.townId);
-        for (const rig of rigList) {
-          if (extractGithubRepo(rig.git_url)) {
-            await refreshGitCredentials(
-              ctx.env,
-              input.townId,
-              rig.git_url,
-              credentialUserId,
-              townConfig.organization_id
-            );
-            break;
-          }
-        }
-      } catch (err) {
-        console.warn('[gastown-trpc] ensureMayor: git credential refresh failed', err);
-      }
+      ctx.executionCtx.waitUntil(
+        refreshFirstGithubRigCredentials({
+          env: ctx.env,
+          townId: input.townId,
+          ownerStub,
+          credentialUserId,
+          organizationId: townConfig.organization_id,
+        })
+      );
 
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.ensureMayor();


### PR DESCRIPTION
## Summary

- Shortens the cold path to mayor readiness by minting the container JWT for `/agents/start` without first issuing a live `/refresh-token` request.
- Moves best-effort `ensureMayor` git credential refresh off the user-visible request path.
- Prioritizes mayor boot hydration/prewarm, backgrounds non-mayor registry resume, defers mayor browse worktree setup, and adds phase timing telemetry for the new critical-path segments.

## Verification

Not manually tested; this targets cold container startup behavior that needs a deployed Gastown environment to measure accurately.

## Visual Changes

N/A

## Reviewer Notes

Review the deferred/background work carefully: non-mayor registry hydration now runs after the boot hydration gate releases, and mayor browse worktrees are refreshed after the mayor can start with the currently discovered worktrees.