### PR TITLE
fix(gastown): bump @kilocode/cli to 7.3.1 + plumb auth env into prewarm

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1721,7 +1721,7 @@ importers:
         version: 7.0.0-dev.20260514.1
       jest:
         specifier: 30.3.0
-        version: 30.3.0(@types/node@24.12.4)(esbuild-register@3.6.0(esbuild@0.27.4))
+        version: 30.3.0(@types/node@25.5.2)(esbuild-register@3.6.0(esbuild@0.27.4))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1851,8 +1851,8 @@ importers:
         specifier: 7.2.52
         version: 7.2.52
       '@kilocode/sdk':
-        specifier: 7.2.14
-        version: 7.2.14
+        specifier: 7.3.1
+        version: 7.3.1
       hono:
         specifier: 4.12.18
         version: 4.12.18
@@ -4838,11 +4838,11 @@ packages:
       '@opentui/solid':
         optional: true
 
-  '@kilocode/sdk@7.2.14':
-    resolution: {integrity: sha512-Naz83lFrsbavuDp6UwxRuglOaSNvRBsZfcRNvb7RpWYAwbuJP0dBdhpXj6uO3ta5qxeQ2JzxKNC9Ffz+LCLLDg==}
-
   '@kilocode/sdk@7.2.52':
     resolution: {integrity: sha512-j8w6ewvo7dyu/qxjJAg0bcjHGUGGvIZ4F2f5tJnpMwLzPTAu26DJoO/08aoxf1BhfuZLzNS9tA2q+ZPdzPT8Jg==}
+
+  '@kilocode/sdk@7.3.1':
+    resolution: {integrity: sha512-UFsCx+Nman7J0jBTr1mZxt6IQkpxkxt3Lqa+gb7/1lSjo0psRgO61H9sUfgLDvAFeaJsQy7k7KMq1eigsbd4rQ==}
 
   '@lexical/clipboard@0.35.0':
     resolution: {integrity: sha512-ko7xSIIiayvDiqjNDX6fgH9RlcM6r9vrrvJYTcfGVBor5httx16lhIi0QJZ4+RNPvGtTjyFv4bwRmsixRRwImg==}
@@ -7128,6 +7128,7 @@ packages:
   '@rocicorp/resolver@1.0.2':
     resolution: {integrity: sha512-TfjMTQp9cNNqNtHFfa+XHEGdA7NnmDRu+ZJH4YF3dso0Xk/b9DMhg/sl+b6CR4ThFZArXXDsG1j8Mwl34wcOZQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    deprecated: Use Promise.withResolvers instead
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -18478,7 +18479,7 @@ snapshots:
       cjs-module-lexer: 1.4.3
       esbuild: 0.27.4
       miniflare: 4.20260508.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler: 4.90.1(@cloudflare/workers-types@4.20260511.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -19955,11 +19956,11 @@ snapshots:
       effect: 4.0.0-beta.57
       zod: 4.1.8
 
-  '@kilocode/sdk@7.2.14':
+  '@kilocode/sdk@7.2.52':
     dependencies:
       cross-spawn: 7.0.6
 
-  '@kilocode/sdk@7.2.52':
+  '@kilocode/sdk@7.3.1':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -28690,6 +28691,25 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@30.3.0(@types/node@25.5.2)(esbuild-register@3.6.0(esbuild@0.27.4)):
+    dependencies:
+      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.3.0(@types/node@25.5.2)(esbuild-register@3.6.0(esbuild@0.27.4))
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   jest-config@29.7.0(@types/node@24.12.4):
     dependencies:
       '@babel/core': 7.29.0
@@ -28777,6 +28797,38 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.12.4
+      esbuild-register: 3.6.0(esbuild@0.27.4)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.3.0(@types/node@25.5.2)(esbuild-register@3.6.0(esbuild@0.27.4)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 13.0.6
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.5.2
       esbuild-register: 3.6.0(esbuild@0.27.4)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -29302,6 +29354,19 @@ snapshots:
       '@jest/types': 30.3.0
       import-local: 3.2.0
       jest-cli: 30.3.0(@types/node@24.12.4)(esbuild-register@3.6.0(esbuild@0.27.4))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@25.5.2)(esbuild-register@3.6.0(esbuild@0.27.4)):
+    dependencies:
+      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@25.5.2)(esbuild-register@3.6.0(esbuild@0.27.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros

--- a/services/gastown/container/Dockerfile
+++ b/services/gastown/container/Dockerfile
@@ -72,7 +72,7 @@ RUN git lfs install --system
 # Install both glibc and musl variants — the CLI's binary resolver may
 # pick either depending on the detected libc.
 # Also install pnpm — many projects use it as their package manager.
-RUN npm install -g @kilocode/cli@7.2.14 @kilocode/cli-linux-x64@7.2.14 @kilocode/cli-linux-x64-musl@7.2.14 @kilocode/plugin@7.2.14 pnpm && \
+RUN npm install -g @kilocode/cli@7.3.1 @kilocode/cli-linux-x64@7.3.1 @kilocode/cli-linux-x64-musl@7.3.1 @kilocode/plugin@7.3.1 pnpm && \
     ln -s "$(which kilo)" /usr/local/bin/opencode
 
 # Create non-root user for defense-in-depth

--- a/services/gastown/container/Dockerfile.dev
+++ b/services/gastown/container/Dockerfile.dev
@@ -71,7 +71,7 @@ RUN git lfs install --system
 # pick either depending on the detected libc. bun:1-slim is Debian (glibc)
 # but the resolver sometimes misdetects; installing both is safe.
 # Also install pnpm — many projects use it as their package manager.
-RUN npm install -g @kilocode/cli@7.2.14 @kilocode/cli-linux-arm64@7.2.14 @kilocode/cli-linux-arm64-musl@7.2.14 @kilocode/plugin@7.2.14 pnpm && \
+RUN npm install -g @kilocode/cli@7.3.1 @kilocode/cli-linux-arm64@7.3.1 @kilocode/cli-linux-arm64-musl@7.3.1 @kilocode/plugin@7.3.1 pnpm && \
     ln -s "$(which kilo)" /usr/local/bin/opencode
 
 # Create non-root user for defense-in-depth

--- a/services/gastown/container/package.json
+++ b/services/gastown/container/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@kilocode/plugin": "7.2.52",
-    "@kilocode/sdk": "7.2.14",
+    "@kilocode/sdk": "7.3.1",
     "hono": "catalog:",
     "zod": "catalog:"
   },

--- a/services/gastown/container/src/agent-runner.test.ts
+++ b/services/gastown/container/src/agent-runner.test.ts
@@ -18,7 +18,7 @@ vi.mock('./logger', () => ({
   log: { info: vi.fn() },
 }));
 
-import { buildAgentEnv, buildKiloConfigContent } from './agent-runner';
+import { buildAgentEnv, buildKiloAuthEnv, buildKiloConfigContent } from './agent-runner';
 import type { StartAgentRequest } from './types';
 
 function baseRequest(overrides: Partial<StartAgentRequest> = {}): StartAgentRequest {
@@ -115,5 +115,46 @@ describe('buildKiloConfigContent', () => {
     );
     const parsed = JSON.parse(json);
     expect(parsed.provider.kilo.options.kilocodeOrganizationId).toBeUndefined();
+  });
+});
+
+describe('buildKiloAuthEnv', () => {
+  it('sets KILO_PLATFORM to gastown', () => {
+    const env = buildKiloAuthEnv(undefined, undefined);
+    expect(env.KILO_PLATFORM).toBe('gastown');
+  });
+
+  it('sets KILO_AUTH_CONTENT when kilocodeToken is provided', () => {
+    const env = buildKiloAuthEnv('tok-abc', undefined);
+    expect(env.KILO_AUTH_CONTENT).toBe(JSON.stringify({ kilo: { type: 'api', key: 'tok-abc' } }));
+  });
+
+  it('omits KILO_AUTH_CONTENT when kilocodeToken is absent', () => {
+    const env = buildKiloAuthEnv(undefined, undefined);
+    expect(env.KILO_AUTH_CONTENT).toBeUndefined();
+  });
+
+  it('sets KILO_ORG_ID when organizationId is provided', () => {
+    const env = buildKiloAuthEnv('tok', 'org-123');
+    expect(env.KILO_ORG_ID).toBe('org-123');
+  });
+
+  it('omits KILO_ORG_ID when organizationId is null', () => {
+    const env = buildKiloAuthEnv('tok', null);
+    expect(env.KILO_ORG_ID).toBeUndefined();
+  });
+
+  it('omits KILO_ORG_ID when organizationId is undefined', () => {
+    const env = buildKiloAuthEnv('tok', undefined);
+    expect(env.KILO_ORG_ID).toBeUndefined();
+  });
+
+  it('sets all three env vars when both inputs are provided', () => {
+    const env = buildKiloAuthEnv('tok-full', 'org-full');
+    expect(env).toEqual({
+      KILO_PLATFORM: 'gastown',
+      KILO_AUTH_CONTENT: JSON.stringify({ kilo: { type: 'api', key: 'tok-full' } }),
+      KILO_ORG_ID: 'org-full',
+    });
   });
 });

--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -85,6 +85,22 @@ export function buildKiloConfigContent(
   } satisfies Config);
 }
 
+export function buildKiloAuthEnv(
+  kilocodeToken: string | undefined,
+  organizationId: string | undefined | null
+): Record<string, string> {
+  const env: Record<string, string> = {
+    KILO_PLATFORM: 'gastown',
+  };
+  if (kilocodeToken) {
+    env.KILO_AUTH_CONTENT = JSON.stringify({ kilo: { type: 'api', key: kilocodeToken } });
+  }
+  if (organizationId) {
+    env.KILO_ORG_ID = organizationId;
+  }
+  return env;
+}
+
 export function buildAgentEnv(request: StartAgentRequest): Record<string, string> {
   // Custom git identity: when GASTOWN_GIT_AUTHOR_NAME is set, the user becomes
   // the primary author and the AI agent name is used for co-authorship trailers.
@@ -173,30 +189,11 @@ GASTOWN_TOWN_ID="${env.GASTOWN_TOWN_ID}"`);
     console.log(
       `[buildAgentEnv] KILO_CONFIG_CONTENT set (model=${request.model}, smallModel=${request.smallModel ?? '(default)'})`
     );
-
-    // Set KILO_AUTH_CONTENT so the kilo CLI's session-ingest path can
-    // authenticate. The CLI's Auth.all() reads this env var before
-    // falling back to the auth.json file. Without it, session deltas
-    // get "session bootstrap skipped: no client" and never reach
-    // cli_sessions_v2.
-    env.KILO_AUTH_CONTENT = JSON.stringify({
-      kilo: { type: 'api', key: kilocodeToken },
-    });
   } else {
     console.warn('[buildAgentEnv] No KILOCODE_TOKEN available — KILO_CONFIG_CONTENT not set');
   }
 
-  // Set KILO_PLATFORM so session-ingest writes created_on_platform =
-  // 'gastown'. The /cloud/sessions page has a "Gastown" filter that
-  // matches this value.
-  env.KILO_PLATFORM = 'gastown';
-
-  // Set KILO_ORG_ID so session-ingest populates organization_id for
-  // org-scoped filtering. Falls back to the auth file's accountId
-  // inside the CLI if not set.
-  if (request.organizationId) {
-    env.KILO_ORG_ID = request.organizationId;
-  }
+  Object.assign(env, buildKiloAuthEnv(kilocodeToken, request.organizationId));
 
   // Authenticate the gh CLI via GH_TOKEN. Prefer the user's GitHub CLI PAT
   // (which makes PRs/issues appear under their identity) over the integration

--- a/services/gastown/container/src/process-manager.test.ts
+++ b/services/gastown/container/src/process-manager.test.ts
@@ -14,6 +14,18 @@ vi.mock('./agent-runner', () => ({
     (kilocodeToken: string, model: string, smallModel: string, organizationId?: string) =>
       JSON.stringify({ kilocodeToken, model, smallModel, organizationId })
   ),
+  buildKiloAuthEnv: vi.fn(
+    (kilocodeToken?: string, organizationId?: string | null) => {
+      const authEnv: Record<string, string> = { KILO_PLATFORM: 'gastown' };
+      if (kilocodeToken) {
+        authEnv.KILO_AUTH_CONTENT = JSON.stringify({ kilo: { type: 'api', key: kilocodeToken } });
+      }
+      if (organizationId) {
+        authEnv.KILO_ORG_ID = organizationId;
+      }
+      return authEnv;
+    }
+  ),
   resolveGitCredentials: vi.fn(),
   writeMayorSystemPromptToAgentsMd: vi.fn(),
   ensureMayorWorkspaceForTown: vi.fn(async (_townId: string) => TEST_WORKSPACE),
@@ -214,10 +226,12 @@ describe('awaitHydration', () => {
       apiUrl: process.env.GASTOWN_API_URL,
       townId: process.env.GASTOWN_TOWN_ID,
       token: process.env.GASTOWN_CONTAINER_TOKEN,
+      kiloOrgId: process.env.KILO_ORG_ID,
     };
     process.env.GASTOWN_API_URL = 'http://test.invalid';
     process.env.GASTOWN_TOWN_ID = 'town-prewarm';
     process.env.GASTOWN_CONTAINER_TOKEN = 'tok-prewarm';
+    delete process.env.KILO_ORG_ID;
 
     let capturedEnv: Record<string, string | undefined> | null = null;
     createKilo.mockImplementationOnce(() => {
@@ -229,6 +243,9 @@ describe('awaitHydration', () => {
         GASTOWN_API_URL: process.env.GASTOWN_API_URL,
         GASTOWN_CONTAINER_TOKEN: process.env.GASTOWN_CONTAINER_TOKEN,
         KILO_CONFIG_CONTENT: process.env.KILO_CONFIG_CONTENT,
+        KILO_AUTH_CONTENT: process.env.KILO_AUTH_CONTENT,
+        KILO_PLATFORM: process.env.KILO_PLATFORM,
+        KILO_ORG_ID: process.env.KILO_ORG_ID,
       };
       return Promise.resolve({
         client: {} as unknown,
@@ -270,6 +287,11 @@ describe('awaitHydration', () => {
         GASTOWN_CONTAINER_TOKEN: 'tok-prewarm',
       });
       expect(env?.KILO_CONFIG_CONTENT).toBeTruthy();
+      expect(env?.KILO_PLATFORM).toBe('gastown');
+      expect(env?.KILO_AUTH_CONTENT).toBe(
+        JSON.stringify({ kilo: { type: 'api', key: 'kc-tok' } })
+      );
+      expect(env?.KILO_ORG_ID).toBeUndefined();
     } finally {
       globalThis.fetch = originalFetch;
       if (prev.apiUrl !== undefined) process.env.GASTOWN_API_URL = prev.apiUrl;
@@ -278,6 +300,8 @@ describe('awaitHydration', () => {
       else delete process.env.GASTOWN_TOWN_ID;
       if (prev.token !== undefined) process.env.GASTOWN_CONTAINER_TOKEN = prev.token;
       else delete process.env.GASTOWN_CONTAINER_TOKEN;
+      if (prev.kiloOrgId !== undefined) process.env.KILO_ORG_ID = prev.kiloOrgId;
+      else delete process.env.KILO_ORG_ID;
     }
   });
 

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -13,6 +13,7 @@ import type { ManagedAgent, StartAgentRequest } from './types';
 import { reportAgentCompleted, reportMayorWaiting } from './completion-reporter';
 import {
   buildKiloConfigContent,
+  buildKiloAuthEnv,
   ensureMayorWorkspaceForTown,
   mayorWorkdirForTown,
 } from './agent-runner';
@@ -2766,6 +2767,8 @@ function buildPrewarmEnv(ctx: MayorPrewarmContext, townId: string): Record<strin
   if (ghToken) {
     env.GH_TOKEN = ghToken;
   }
+
+  Object.assign(env, buildKiloAuthEnv(kilocodeToken, organizationId));
 
   // Without the worker-resolved model, skip prewarm: any guess we make
   // here will almost certainly differ from /agents/start's resolved


### PR DESCRIPTION
## Summary
Fixes the two bugs that prevented PR #3307's session-ingest wiring from working in production.

### Bug 1: kilo CLI version too old (smoking gun)
`@kilocode/cli@7.2.14` doesn't read `process.env.KILO_AUTH_CONTENT`. Every `kilo serve` was hitting `Auth.get("kilo") → undefined → "session bootstrap skipped: no client"` and silently no-op'ing all session deltas.

Bumped to `7.3.1`. Verified `KILO_AUTH_CONTENT` is present in the new binary's strings.

### Bug 2: prewarm path missing auth env
`buildPrewarmEnv` didn't set the three env vars (`KILO_AUTH_CONTENT`, `KILO_PLATFORM`, `KILO_ORG_ID`). Even after the CLI bump, mayor sessions (which go through prewarm) would still be invisible. Now it mirrors `buildAgentEnv` via the extracted `buildKiloAuthEnv` helper.

### Refactor: extracted `buildKiloAuthEnv` helper
The auth-env logic (`KILO_AUTH_CONTENT`, `KILO_PLATFORM`, `KILO_ORG_ID`) was duplicated between `buildAgentEnv` and `buildPrewarmEnv`. Extracted `buildKiloAuthEnv(kilocodeToken, organizationId)` in `agent-runner.ts` and called it from both functions.

## Verification
- `pnpm --filter gastown-container typecheck` passes
- `pnpm --filter gastown-container test` passes (2 pre-existing failures in `plugin/client.test.ts` unrelated to this change)
- Verified `npm view @kilocode/cli@7.3.1 version` returns `7.3.1` for all 6 packages
- Verified `KILO_AUTH_CONTENT` string present in `@kilocode/cli-linux-x64@7.3.1` binary

## Visual Changes
N/A

## Reviewer Notes
- The `buildKiloAuthEnv` helper accepts `organizationId: string | undefined | null` to match the nullable type from `MayorPrewarmContext.organizationId`. Both `null` and `undefined` are falsy and correctly skip setting `KILO_ORG_ID`.
- The `process-manager.test.ts` prewarm test now saves/restores `KILO_ORG_ID` from process.env to avoid interference from the container's own environment.