### PR TITLE
fix(kiloclaw): connect Composio before provision

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
@@ -205,6 +205,7 @@ function renderFakeStep({ step, setStep, stepProgress, basePath }: RenderFakeSte
           connecting={false}
           savingManual={false}
           readyToConnect={true}
+          readyToSaveManualCredentials={true}
           manualConfigured={false}
           organizationContext={false}
           onConnect={() => setStep('email')}

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
@@ -101,6 +101,20 @@ describe('ClawOnboardingFlow state machine', () => {
     expect(state.instanceStatus).toBeNull();
   });
 
+  test('allows managed tools before initial provisioning starts', () => {
+    const state = getClawOnboardingFlowState(
+      createInput({
+        onboardingStep: 'tools',
+        hasBotIdentity: true,
+        hasToolsStep: true,
+      })
+    );
+
+    expect(state.renderStep).toBe('tools');
+    expect(state.createSetupActive).toBe(false);
+    expect(state.instanceStatus).toBeNull();
+  });
+
   test('keeps create setup active once an instance status exists', () => {
     const state = getClawOnboardingFlowState(
       createInput({

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
@@ -392,7 +392,11 @@ function getRenderStepDecision({
     };
   }
 
-  if (instanceStatus === null && !createSetupStarted) {
+  if (
+    instanceStatus === null &&
+    !createSetupStarted &&
+    (onboardingStep === 'identity' || !hasBotIdentity)
+  ) {
     return {
       renderStep: 'identity',
       reason: 'create-first mode starts with bot identity before setup is requested',

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -172,6 +172,68 @@ function createComposioConnectAttemptId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
+const ONBOARDING_DRAFT_STORAGE_PREFIX = 'kiloclaw:onboarding-draft:';
+
+type OnboardingDraft = {
+  userId: string;
+  botIdentity: BotIdentity;
+  userLocation: string | null;
+};
+
+function onboardingDraftStorageKey(organizationId?: string): string {
+  return `${ONBOARDING_DRAFT_STORAGE_PREFIX}${organizationId ?? 'personal'}`;
+}
+
+function readOnboardingDraft(
+  organizationId: string | undefined,
+  userId: string
+): OnboardingDraft | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(onboardingDraftStorageKey(organizationId));
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    const record = parsed as Record<string, unknown>;
+    if (record.userId !== userId) return null;
+    const botIdentity = record.botIdentity;
+    if (typeof botIdentity !== 'object' || botIdentity === null) return null;
+    const identity = botIdentity as Record<string, unknown>;
+    if (
+      typeof identity.botName !== 'string' ||
+      typeof identity.botNature !== 'string' ||
+      typeof identity.botVibe !== 'string' ||
+      typeof identity.botEmoji !== 'string'
+    ) {
+      return null;
+    }
+    const userLocation = record.userLocation;
+    if (userLocation !== null && typeof userLocation !== 'string') return null;
+    return {
+      userId,
+      botIdentity: {
+        botName: identity.botName,
+        botNature: identity.botNature,
+        botVibe: identity.botVibe,
+        botEmoji: identity.botEmoji,
+      },
+      userLocation,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeOnboardingDraft(organizationId: string | undefined, draft: OnboardingDraft): void {
+  if (typeof window === 'undefined') return;
+  window.sessionStorage.setItem(onboardingDraftStorageKey(organizationId), JSON.stringify(draft));
+}
+
+function clearOnboardingDraft(organizationId?: string): void {
+  if (typeof window === 'undefined') return;
+  window.sessionStorage.removeItem(onboardingDraftStorageKey(organizationId));
+}
+
 export type { ClawOnboardingMode };
 
 export function ClawOnboardingFlow({
@@ -287,14 +349,16 @@ function ClawOnboardingFlowInner({
   );
   const composioStatus = organizationId ? orgComposioStatus : personalComposioStatus;
   const hasToolsStep = hasCalendarStep && composioStatus.data?.enabled !== false;
-  const configQuery = useClawConfig();
+  const configQuery = useClawConfig(status !== undefined && status.status !== null);
   const composioManualConfigured = composioStatus.data?.sandboxConfigSource === 'manual';
-  const composioConfigPending = configQuery.isPending;
+  const composioConfigPending =
+    status !== undefined && status.status !== null && configQuery.isPending;
 
   const gatewayUrl = useGatewayUrl(status);
 
   const selectedPreset: ExecPreset = DEFAULT_ONBOARDING_EXEC_PRESET;
   const [botIdentity, setBotIdentity] = useState<BotIdentity | null>(null);
+  const [pendingUserLocation, setPendingUserLocation] = useState<string | null>(null);
   // Interest topics chosen on the Interests step are deferred until the
   // provisioning step completes — the plugin endpoint that backs
   // `updateBriefingInterests` isn't reachable until the instance gateway
@@ -313,8 +377,20 @@ function ClawOnboardingFlowInner({
   const composioPopupRef = useRef<Window | null>(null);
   const composioPopupPendingRef = useRef(false);
   const composioPopupResultHandledRef = useRef(false);
+  const composioPopupAwaitingConfirmationRef = useRef(false);
   const composioPopupAttemptIdRef = useRef<string | null>(null);
   const createSetupStarted = createFlowStarted || localCreateSetupStarted;
+
+  useEffect(() => {
+    if (!currentUser?.id || botIdentity !== null) return;
+    const draft = readOnboardingDraft(organizationId, currentUser.id);
+    if (!draft) {
+      clearOnboardingDraft(organizationId);
+      return;
+    }
+    setBotIdentity(draft.botIdentity);
+    setPendingUserLocation(draft.userLocation);
+  }, [botIdentity, currentUser?.id, organizationId]);
 
   const stateInput = {
     status,
@@ -374,7 +450,10 @@ function ClawOnboardingFlowInner({
 
   const setComposioPopupPendingState = useCallback((pending: boolean) => {
     composioPopupPendingRef.current = pending;
-    if (pending) composioPopupResultHandledRef.current = false;
+    if (pending) {
+      composioPopupResultHandledRef.current = false;
+      composioPopupAwaitingConfirmationRef.current = false;
+    }
     setComposioPopupPending(pending);
   }, []);
 
@@ -386,16 +465,15 @@ function ClawOnboardingFlowInner({
       composioPopupRef.current?.close();
       composioPopupRef.current = null;
       composioPopupAttemptIdRef.current = null;
-      setComposioPopupPendingState(false);
       setOnboardingStep('tools');
       void composioStatus.refetch();
 
       if (message.result === 'success') {
-        posthog?.capture('claw_setup_tools_composio_completed');
-        toast.success('Google Calendar connected');
+        composioPopupAwaitingConfirmationRef.current = true;
         return;
       }
 
+      setComposioPopupPendingState(false);
       posthog?.capture('claw_setup_tools_connect_failed', {
         toolkit: 'googlecalendar',
       });
@@ -444,9 +522,19 @@ function ClawOnboardingFlowInner({
   useEffect(() => {
     if (!composioPopupPending) return;
 
+    let closedChecks = 0;
     const intervalId = window.setInterval(() => {
       const popup = composioPopupRef.current;
-      if (!popup || !popup.closed) return;
+      if (!popup?.closed || composioPopupAwaitingConfirmationRef.current) {
+        closedChecks = 0;
+        return;
+      }
+
+      // Cross-origin popup navigation can transiently look closed during the
+      // handoff from our pre-opened window to Composio. Require consecutive
+      // closed observations before treating it as a user dismissal.
+      closedChecks += 1;
+      if (closedChecks < 3) return;
 
       composioPopupRef.current = null;
       composioPopupAttemptIdRef.current = null;
@@ -456,7 +544,6 @@ function ClawOnboardingFlowInner({
         toolkit: 'googlecalendar',
         reason: 'popup_closed',
       });
-      toast.message('Connection window closed. Checking Google Calendar status.');
     }, 700);
 
     return () => window.clearInterval(intervalId);
@@ -468,6 +555,7 @@ function ClawOnboardingFlowInner({
     composioPopupRef.current?.close();
     composioPopupRef.current = null;
     composioPopupAttemptIdRef.current = null;
+    composioPopupAwaitingConfirmationRef.current = false;
     setComposioPopupPendingState(false);
     posthog?.capture('claw_setup_tools_composio_completed', { source: 'status_refetch' });
     toast.success('Google Calendar connected');
@@ -540,14 +628,15 @@ function ClawOnboardingFlowInner({
   const resetWizardSelections = useCallback(() => {
     setOnboardingStep('identity');
     setBotIdentity(null);
-  }, []);
+    setPendingUserLocation(null);
+    clearOnboardingDraft(organizationId);
+  }, [organizationId]);
 
   const handleCreateFlowStarted = useCallback(() => {
     setLocalCreateSetupStarted(true);
     setOnboardingSaveSession(value => value + 1);
-    resetWizardSelections();
     onCreateFlowStarted?.();
-  }, [onCreateFlowStarted, resetWizardSelections]);
+  }, [onCreateFlowStarted]);
 
   const handleCreateFlowFailed = useCallback(() => {
     setLocalCreateSetupStarted(false);
@@ -709,14 +798,23 @@ function ClawOnboardingFlowInner({
     router.push(`${basePath}/chat`);
   }, [flowState.renderStep, flowState.gatewayReady, basePath, router, posthog]);
 
-  function provisionInstance(userLocation?: string) {
+  function provisionInstance(
+    userLocation?: string,
+    composioManualCredentials?: { composioUserApiKey: string; composioOrg: string },
+    skipIncompleteManagedComposioConnection?: boolean
+  ) {
     handleCreateFlowStarted();
+    clearOnboardingDraft(organizationId);
 
     mutations.provision.mutate(
       {
         kilocodeDefaultModel: `kilocode/${KILO_AUTO_BALANCED_MODEL.id}`,
         userTimezone: getBrowserTimeZone(),
         ...(userLocation ? { userLocation } : undefined),
+        ...(composioManualCredentials ? { secrets: composioManualCredentials } : undefined),
+        ...(skipIncompleteManagedComposioConnection
+          ? { skipIncompleteManagedComposioConnection: true }
+          : undefined),
       },
       {
         onError: err => {
@@ -728,6 +826,21 @@ function ClawOnboardingFlowInner({
           toast.error(`Failed to create: ${err.message}`);
         },
       }
+    );
+  }
+
+  function startProvisionForCreateFlow(
+    composioManualCredentials?: { composioUserApiKey: string; composioOrg: string },
+    skipIncompleteManagedComposioConnection?: boolean
+  ) {
+    if (mode !== 'create-first' || flowState.instanceStatus !== null || createSetupStarted) return;
+    posthog?.capture('claw_create_instance_clicked', {
+      selected_model: KILO_AUTO_BALANCED_MODEL.id,
+    });
+    provisionInstance(
+      pendingUserLocation ?? undefined,
+      composioManualCredentials,
+      skipIncompleteManagedComposioConnection
     );
   }
 
@@ -756,21 +869,27 @@ function ClawOnboardingFlowInner({
               );
             }
           } else {
-            posthog?.capture('claw_create_instance_clicked', {
-              selected_model: KILO_AUTO_BALANCED_MODEL.id,
-            });
-            provisionInstance(weatherLocation?.location);
+            setPendingUserLocation(weatherLocation?.location ?? null);
           }
           posthog?.capture('claw_setup_permissions_completed', {
             preset: DEFAULT_ONBOARDING_EXEC_PRESET,
             defaulted: true,
           });
           setBotIdentity(identity);
+          if (!flowState.instanceStatus && currentUser?.id) {
+            writeOnboardingDraft(organizationId, {
+              userId: currentUser.id,
+              botIdentity: identity,
+              userLocation: weatherLocation?.location ?? null,
+            });
+          }
           if (hasToolsStep) {
             setOnboardingStep('tools');
           } else if (hasCalendarStep) {
+            if (!flowState.instanceStatus) provisionInstance(weatherLocation?.location);
             setOnboardingStep('calendar');
           } else {
+            if (!flowState.instanceStatus) provisionInstance(weatherLocation?.location);
             setOnboardingStep('email');
           }
         }}
@@ -789,6 +908,7 @@ function ClawOnboardingFlowInner({
     const connectedEmail = flowState.instanceStatus?.googleOAuthAccountEmail ?? null;
 
     function advanceToEmail() {
+      startProvisionForCreateFlow();
       setOnboardingStep('email');
     }
 
@@ -816,7 +936,14 @@ function ClawOnboardingFlowInner({
   }
 
   function renderToolsStep() {
-    function advanceToEmail() {
+    function advanceToEmail(
+      composioManualCredentials?: { composioUserApiKey: string; composioOrg: string },
+      skipIncompleteManagedComposioConnection?: boolean
+    ) {
+      startProvisionForCreateFlow(
+        composioManualCredentials,
+        skipIncompleteManagedComposioConnection
+      );
       setOnboardingStep('email');
     }
 
@@ -828,8 +955,9 @@ function ClawOnboardingFlowInner({
         loading={composioStatus.isPending || composioConfigPending}
         connecting={mutations.createComposioGoogleCalendarLink.isPending || composioPopupPending}
         savingManual={mutations.patchSecrets.isPending}
-        readyToConnect={
-          flowState.instanceStatus !== null && onboardingSaves.ready && !composioConfigPending
+        readyToConnect={botIdentity !== null && !composioConfigPending}
+        readyToSaveManualCredentials={
+          botIdentity !== null && (flowState.instanceStatus === null || onboardingSaves.ready)
         }
         manualConfigured={composioManualConfigured}
         organizationContext={!!organizationId}
@@ -873,7 +1001,7 @@ function ClawOnboardingFlowInner({
         }}
         onSkip={() => {
           posthog?.capture('claw_setup_tools_completed', { connected: false, skipped: true });
-          advanceToEmail();
+          advanceToEmail(undefined, true);
         }}
         onContinue={() => {
           posthog?.capture('claw_setup_tools_completed', { connected: true, skipped: false });
@@ -881,6 +1009,13 @@ function ClawOnboardingFlowInner({
         }}
         onSaveManualCredentials={credentials => {
           posthog?.capture('claw_setup_tools_manual_credentials_save_clicked');
+          if (flowState.instanceStatus === null) {
+            posthog?.capture('claw_setup_tools_manual_credentials_saved', {
+              provision_input: true,
+            });
+            advanceToEmail(credentials);
+            return;
+          }
           mutations.patchSecrets.mutate(
             { secrets: credentials },
             {

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -845,6 +845,9 @@ function ClawOnboardingFlowInner({
     composioManualCredentials?: { composioUserApiKey: string; composioOrg: string },
     skipIncompleteManagedComposioConnection?: boolean
   ) {
+    posthog?.capture('claw_create_instance_clicked', {
+      selected_model: KILO_AUTO_BALANCED_MODEL.id,
+    });
     handleCreateFlowStarted();
 
     mutations.provision.mutate(
@@ -876,9 +879,6 @@ function ClawOnboardingFlowInner({
     skipIncompleteManagedComposioConnection?: boolean
   ) {
     if (mode !== 'create-first' || flowState.instanceStatus !== null || createSetupStarted) return;
-    posthog?.capture('claw_create_instance_clicked', {
-      selected_model: KILO_AUTO_BALANCED_MODEL.id,
-    });
     provisionInstance(
       pendingUserLocation ?? undefined,
       composioManualCredentials,

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -378,6 +378,7 @@ function ClawOnboardingFlowInner({
   const composioPopupPendingRef = useRef(false);
   const composioPopupResultHandledRef = useRef(false);
   const composioPopupAwaitingConfirmationRef = useRef(false);
+  const composioPopupConfirmationTimeoutRef = useRef<number | null>(null);
   const composioPopupAttemptIdRef = useRef<string | null>(null);
   const createSetupStarted = createFlowStarted || localCreateSetupStarted;
 
@@ -448,14 +449,28 @@ function ClawOnboardingFlowInner({
     mutations,
   });
 
-  const setComposioPopupPendingState = useCallback((pending: boolean) => {
-    composioPopupPendingRef.current = pending;
-    if (pending) {
-      composioPopupResultHandledRef.current = false;
-      composioPopupAwaitingConfirmationRef.current = false;
-    }
-    setComposioPopupPending(pending);
+  const clearComposioPopupConfirmationTimeout = useCallback(() => {
+    if (composioPopupConfirmationTimeoutRef.current === null) return;
+    window.clearTimeout(composioPopupConfirmationTimeoutRef.current);
+    composioPopupConfirmationTimeoutRef.current = null;
   }, []);
+
+  const setComposioPopupPendingState = useCallback(
+    (pending: boolean) => {
+      composioPopupPendingRef.current = pending;
+      if (pending) {
+        composioPopupResultHandledRef.current = false;
+        composioPopupAwaitingConfirmationRef.current = false;
+        clearComposioPopupConfirmationTimeout();
+      }
+      setComposioPopupPending(pending);
+    },
+    [clearComposioPopupConfirmationTimeout]
+  );
+
+  useEffect(() => {
+    return () => clearComposioPopupConfirmationTimeout();
+  }, [clearComposioPopupConfirmationTimeout]);
 
   const handleComposioPopupResult = useCallback(
     (message: { result: 'success' | 'failed' | 'unknown'; attemptId: string }) => {
@@ -470,16 +485,29 @@ function ClawOnboardingFlowInner({
 
       if (message.result === 'success') {
         composioPopupAwaitingConfirmationRef.current = true;
+        clearComposioPopupConfirmationTimeout();
+        composioPopupConfirmationTimeoutRef.current = window.setTimeout(() => {
+          if (!composioPopupAwaitingConfirmationRef.current) return;
+          composioPopupAwaitingConfirmationRef.current = false;
+          composioPopupConfirmationTimeoutRef.current = null;
+          setComposioPopupPendingState(false);
+          posthog?.capture('claw_setup_tools_connect_failed', {
+            toolkit: 'googlecalendar',
+            reason: 'status_confirmation_timeout',
+          });
+          toast.error('Could not confirm Google Calendar. Try again or skip for now.');
+        }, 45_000);
         return;
       }
 
+      clearComposioPopupConfirmationTimeout();
       setComposioPopupPendingState(false);
       posthog?.capture('claw_setup_tools_connect_failed', {
         toolkit: 'googlecalendar',
       });
       toast.error('Could not connect Google Calendar. Try again or skip for now.');
     },
-    [composioStatus, posthog, setComposioPopupPendingState]
+    [clearComposioPopupConfirmationTimeout, composioStatus, posthog, setComposioPopupPendingState]
   );
 
   useEffect(() => {
@@ -538,6 +566,7 @@ function ClawOnboardingFlowInner({
 
       composioPopupRef.current = null;
       composioPopupAttemptIdRef.current = null;
+      clearComposioPopupConfirmationTimeout();
       setComposioPopupPendingState(false);
       void composioStatus.refetch();
       posthog?.capture('claw_setup_tools_connect_failed', {
@@ -547,7 +576,13 @@ function ClawOnboardingFlowInner({
     }, 700);
 
     return () => window.clearInterval(intervalId);
-  }, [composioPopupPending, composioStatus, posthog, setComposioPopupPendingState]);
+  }, [
+    clearComposioPopupConfirmationTimeout,
+    composioPopupPending,
+    composioStatus,
+    posthog,
+    setComposioPopupPendingState,
+  ]);
 
   useEffect(() => {
     if (!composioPopupPending || composioStatus.data?.status !== 'connected') return;
@@ -556,10 +591,17 @@ function ClawOnboardingFlowInner({
     composioPopupRef.current = null;
     composioPopupAttemptIdRef.current = null;
     composioPopupAwaitingConfirmationRef.current = false;
+    clearComposioPopupConfirmationTimeout();
     setComposioPopupPendingState(false);
     posthog?.capture('claw_setup_tools_composio_completed', { source: 'status_refetch' });
     toast.success('Google Calendar connected');
-  }, [composioPopupPending, composioStatus.data?.status, posthog, setComposioPopupPendingState]);
+  }, [
+    clearComposioPopupConfirmationTimeout,
+    composioPopupPending,
+    composioStatus.data?.status,
+    posthog,
+    setComposioPopupPendingState,
+  ]);
 
   useEffect(() => {
     if (!composioPopupPending) return;

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -846,7 +846,6 @@ function ClawOnboardingFlowInner({
     skipIncompleteManagedComposioConnection?: boolean
   ) {
     handleCreateFlowStarted();
-    clearOnboardingDraft(organizationId);
 
     mutations.provision.mutate(
       {
@@ -859,6 +858,7 @@ function ClawOnboardingFlowInner({
           : undefined),
       },
       {
+        onSuccess: () => clearOnboardingDraft(organizationId),
         onError: err => {
           posthog?.capture('claw_setup_provision_failed', {
             selected_model: KILO_AUTO_BALANCED_MODEL.id,
@@ -918,14 +918,14 @@ function ClawOnboardingFlowInner({
             defaulted: true,
           });
           setBotIdentity(identity);
-          if (!flowState.instanceStatus && currentUser?.id) {
-            writeOnboardingDraft(organizationId, {
-              userId: currentUser.id,
-              botIdentity: identity,
-              userLocation: weatherLocation?.location ?? null,
-            });
-          }
           if (hasToolsStep) {
+            if (!flowState.instanceStatus && currentUser?.id) {
+              writeOnboardingDraft(organizationId, {
+                userId: currentUser.id,
+                botIdentity: identity,
+                userLocation: weatherLocation?.location ?? null,
+              });
+            }
             setOnboardingStep('tools');
           } else if (hasCalendarStep) {
             if (!flowState.instanceStatus) provisionInstance(weatherLocation?.location);

--- a/apps/web/src/app/(app)/claw/components/ConnectToolsStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/ConnectToolsStep.tsx
@@ -17,6 +17,7 @@ type ConnectToolsStepViewProps = {
   connecting: boolean;
   savingManual: boolean;
   readyToConnect: boolean;
+  readyToSaveManualCredentials: boolean;
   manualConfigured: boolean;
   organizationContext: boolean;
   onConnect: () => void;
@@ -49,6 +50,7 @@ export function ConnectToolsStepView({
   connecting,
   savingManual,
   readyToConnect,
+  readyToSaveManualCredentials,
   manualConfigured,
   organizationContext,
   onConnect,
@@ -268,7 +270,7 @@ export function ConnectToolsStepView({
               </label>
             </div>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              {!readyToConnect ? (
+              {!readyToSaveManualCredentials ? (
                 <p className="text-muted-foreground text-xs">
                   Wait for instance setup before saving credentials.
                 </p>
@@ -277,7 +279,7 @@ export function ConnectToolsStepView({
               )}
               <Button
                 variant="outline"
-                disabled={!manualReady || !readyToConnect || savingManual}
+                disabled={!manualReady || !readyToSaveManualCredentials || savingManual}
                 onClick={() =>
                   onSaveManualCredentials({
                     composioUserApiKey: userApiKey.trim(),
@@ -287,7 +289,7 @@ export function ConnectToolsStepView({
               >
                 {savingManual
                   ? 'Saving…'
-                  : readyToConnect
+                  : readyToSaveManualCredentials
                     ? 'Save Composio credentials'
                     : 'Waiting for instance setup'}
               </Button>

--- a/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
@@ -16,18 +16,18 @@ import { useClawContext } from '../components/ClawContext';
 
 // Config
 
-export function useClawConfig() {
+export function useClawConfig(enabled = true) {
   const trpc = useTRPC();
   const { organizationId } = useClawContext();
 
   const personal = useQuery({
     ...trpc.kiloclaw.getConfig.queryOptions(),
-    enabled: !organizationId,
+    enabled: enabled && !organizationId,
   });
 
   const org = useQuery({
     ...trpc.organizations.kiloclaw.getConfig.queryOptions({ organizationId: organizationId ?? '' }),
-    enabled: !!organizationId,
+    enabled: enabled && !!organizationId,
   });
 
   return organizationId ? org : personal;

--- a/apps/web/src/app/api/integrations/composio/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/composio/callback/route.test.ts
@@ -3,11 +3,21 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { getActiveInstance, getActiveOrgInstance } from '@/lib/kiloclaw/instance-registry';
 import { completeManagedComposioGoogleCalendarConnection } from '@/lib/kiloclaw/composio-onboarding';
+import { withKiloclawProvisionContextLock } from '@/lib/kiloclaw/provision-lock';
 import { failureResult } from '@/lib/maybe-result';
 
 jest.mock('@/lib/user.server');
 jest.mock('@/lib/kiloclaw/instance-registry');
 jest.mock('@/lib/kiloclaw/composio-onboarding');
+jest.mock('@/lib/kiloclaw/provision-lock', () => ({
+  getPersonalProvisionLockKey: jest.fn((userId: string) => `personal:${userId}`),
+  getOrganizationProvisionLockKey: jest.fn(
+    (userId: string, organizationId: string) => `org:${userId}:${organizationId}`
+  ),
+  withKiloclawProvisionContextLock: jest.fn(async (_key: string, work: () => Promise<unknown>) => {
+    return await work();
+  }),
+}));
 const mockedEnsureOrganizationAccess = jest.fn();
 jest.mock('@/routers/organizations/utils', () => ({
   ensureOrganizationAccess: mockedEnsureOrganizationAccess,
@@ -19,6 +29,7 @@ const mockedGetActiveOrgInstance = jest.mocked(getActiveOrgInstance);
 const mockedCompleteManagedComposioGoogleCalendarConnection = jest.mocked(
   completeManagedComposioGoogleCalendarConnection
 );
+const mockedWithKiloclawProvisionContextLock = jest.mocked(withKiloclawProvisionContextLock);
 
 const USER_ID = '034489e8-19e0-4479-9d69-2edad719e847';
 const ORG_ID = 'a32ba169-8d90-43f6-98ee-95e509a1b06b';
@@ -59,6 +70,9 @@ describe('GET /api/integrations/composio/callback', () => {
     mockedGetActiveInstance.mockResolvedValue(fakeInstance as never);
     mockedGetActiveOrgInstance.mockResolvedValue(fakeInstance as never);
     mockedCompleteManagedComposioGoogleCalendarConnection.mockResolvedValue(true);
+    mockedWithKiloclawProvisionContextLock.mockImplementation(async (_key, work) => {
+      return await work();
+    });
   });
 
   test('redirects to sign-in when auth fails', async () => {
@@ -148,6 +162,25 @@ describe('GET /api/integrations/composio/callback', () => {
       userId: USER_ID,
       instance: fakeInstance,
       scope: { ownerType: 'organization_user', userId: USER_ID, organizationId: ORG_ID },
+      connectedAccountId: 'ca_123',
+    });
+  });
+
+  test('records managed connection before an instance exists', async () => {
+    mockedGetActiveInstance.mockResolvedValue(null as never);
+
+    const { GET } = await import('./route');
+    const response = await GET(
+      makeRequest(
+        '/api/integrations/composio/callback?returnTo=%2Fclaw%2Fnew%3Fstep%3Dtools&status=success&connected_account_id=ca_123'
+      ) as never
+    );
+
+    expect(redirectPath(response)).toBe('/claw/new?step=tools&success=composio_connected');
+    expect(mockedCompleteManagedComposioGoogleCalendarConnection).toHaveBeenCalledWith({
+      userId: USER_ID,
+      instance: null,
+      scope: { ownerType: 'user', userId: USER_ID },
       connectedAccountId: 'ca_123',
     });
   });

--- a/apps/web/src/app/api/integrations/composio/callback/route.ts
+++ b/apps/web/src/app/api/integrations/composio/callback/route.ts
@@ -7,6 +7,11 @@ import { getUserFromAuth } from '@/lib/user.server';
 import { isSafeGoogleOAuthReturnTo } from '@/lib/integrations/google/oauth-state';
 import { completeManagedComposioGoogleCalendarConnection } from '@/lib/kiloclaw/composio-onboarding';
 import { getActiveInstance, getActiveOrgInstance } from '@/lib/kiloclaw/instance-registry';
+import {
+  getOrganizationProvisionLockKey,
+  getPersonalProvisionLockKey,
+  withKiloclawProvisionContextLock,
+} from '@/lib/kiloclaw/provision-lock';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 
 const OrganizationIdSchema = z.string().uuid();
@@ -183,22 +188,24 @@ export async function GET(request: NextRequest) {
       return NextResponse.redirect(new URL(appendResult(returnTo, 'unknown'), APP_URL));
     }
 
-    const instance = organizationId
-      ? await getActiveOrgInstance(user.id, organizationId)
-      : await getActiveInstance(user.id);
-    if (!instance) {
-      if (popup) return popupResultResponse('failed', 'missing_instance', attemptId);
-      return NextResponse.redirect(new URL(appendError(returnTo, 'missing_instance'), APP_URL));
-    }
-
-    const verified = await completeManagedComposioGoogleCalendarConnection({
-      userId: user.id,
-      instance,
-      scope: organizationId
-        ? { ownerType: 'organization_user', userId: user.id, organizationId }
-        : { ownerType: 'user', userId: user.id },
-      connectedAccountId,
-    });
+    const verified = await withKiloclawProvisionContextLock(
+      organizationId
+        ? getOrganizationProvisionLockKey(user.id, organizationId)
+        : getPersonalProvisionLockKey(user.id),
+      async () => {
+        const instance = organizationId
+          ? await getActiveOrgInstance(user.id, organizationId)
+          : await getActiveInstance(user.id);
+        return await completeManagedComposioGoogleCalendarConnection({
+          userId: user.id,
+          instance,
+          scope: organizationId
+            ? { ownerType: 'organization_user', userId: user.id, organizationId }
+            : { ownerType: 'user', userId: user.id },
+          connectedAccountId,
+        });
+      }
+    );
 
     if (popup) return popupResultResponse(verified ? 'success' : 'failed', undefined, attemptId);
     return NextResponse.redirect(

--- a/apps/web/src/lib/kiloclaw/composio-onboarding.test.ts
+++ b/apps/web/src/lib/kiloclaw/composio-onboarding.test.ts
@@ -267,7 +267,7 @@ describe('buildComposioProvisionSecrets', () => {
     const result = await buildComposioProvisionSecrets({
       scope,
       secrets: {
-        composioUserApiKey: 'uak_manual',
+        composioUserApiKey: 'uak_manual_credential_123',
         composioOrg: 'manual-org',
         otherSecret: 'kept',
       },
@@ -275,13 +275,25 @@ describe('buildComposioProvisionSecrets', () => {
 
     expect(result).toEqual({
       secrets: {
-        composioUserApiKey: 'uak_manual',
+        composioUserApiKey: 'uak_manual_credential_123',
         composioOrg: 'manual-org',
         otherSecret: 'kept',
       },
       configToMark: { source: 'manual' },
     });
     expect(mockedGetActiveManagedComposioIdentity).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid pre-provision manual Composio credentials', async () => {
+    await expect(
+      buildComposioProvisionSecrets({
+        scope,
+        secrets: {
+          composioUserApiKey: 'uak_short',
+          composioOrg: 'manual-org',
+        },
+      })
+    ).rejects.toThrow('Composio user API keys start with uak_');
   });
 
   it('rehydrates previously applied managed credentials for a recreated sandbox', async () => {

--- a/apps/web/src/lib/kiloclaw/composio-onboarding.test.ts
+++ b/apps/web/src/lib/kiloclaw/composio-onboarding.test.ts
@@ -21,6 +21,7 @@ jest.mock('@/lib/kiloclaw/encryption', () => ({
 }));
 
 const selectedRows: unknown[][] = [];
+const updateSets: unknown[] = [];
 
 jest.mock('@/lib/drizzle', () => ({
   db: {
@@ -39,9 +40,12 @@ jest.mock('@/lib/drizzle', () => ({
       })),
     })),
     update: jest.fn(() => ({
-      set: jest.fn(() => ({
-        where: jest.fn(async () => undefined),
-      })),
+      set: jest.fn((values: unknown) => {
+        updateSets.push(values);
+        return {
+          where: jest.fn(async () => undefined),
+        };
+      }),
     })),
     delete: jest.fn(),
   },
@@ -90,6 +94,7 @@ function mockManagedIdentity() {
 beforeEach(() => {
   jest.clearAllMocks();
   selectedRows.length = 0;
+  updateSets.length = 0;
   mockManagedIdentity();
   mockedListComposioConnectedAccounts.mockResolvedValue([
     { id: 'ca_123', status: 'ACTIVE' },
@@ -128,6 +133,49 @@ describe('getManagedComposioGoogleCalendarStatus', () => {
       status: 'connected',
       connectedAccountId: 'ca_123',
       sandboxConfigSource: 'managed',
+    });
+  });
+
+  it('reports connected before provision when the owner identity has an active account', async () => {
+    const status = await getManagedComposioGoogleCalendarStatus({
+      scope,
+      instance: null,
+      sandboxHasComposioSecrets: false,
+    });
+
+    expect(status).toEqual({
+      enabled: true,
+      status: 'connected',
+      connectedAccountId: 'ca_123',
+      sandboxConfigSource: null,
+    });
+  });
+
+  it('does not report pre-provision connected until the callback stores the durable account marker', async () => {
+    mockedGetActiveManagedComposioIdentity.mockResolvedValue({
+      row: {
+        id: 'identity-1',
+        composio_project_id: 'project-1',
+        google_calendar_connected_account_id: null,
+      },
+      agentKey: 'agent-key',
+      userApiKey: 'uak_123',
+      apiKey: 'api-key',
+      org: 'org-1',
+      consumerUserId: 'consumer-user-1',
+    } as never);
+
+    const status = await getManagedComposioGoogleCalendarStatus({
+      scope,
+      instance: null,
+      sandboxHasComposioSecrets: false,
+    });
+
+    expect(status).toEqual({
+      enabled: true,
+      status: 'disconnected',
+      connectedAccountId: null,
+      sandboxConfigSource: null,
     });
   });
 
@@ -185,6 +233,26 @@ describe('completeManagedComposioGoogleCalendarConnection', () => {
       undefined
     );
   });
+
+  it('records the connected account without patching secrets before an instance exists', async () => {
+    const patchSecrets = jest.fn(async () => ({}));
+    mockedKiloClawInternalClient.mockImplementation(
+      () => ({ patchSecrets }) as unknown as KiloClawInternalClient
+    );
+
+    const result = await completeManagedComposioGoogleCalendarConnection({
+      userId: 'user-1',
+      instance: null,
+      scope,
+      connectedAccountId: 'ca_123',
+    });
+
+    expect(result).toBe(true);
+    expect(patchSecrets).not.toHaveBeenCalled();
+    expect(updateSets[0]).toMatchObject({
+      google_calendar_connected_account_id: 'ca_123',
+    });
+  });
 });
 
 describe('composioSecretsPatchSource', () => {
@@ -232,6 +300,44 @@ describe('buildComposioProvisionSecrets', () => {
       },
       configToMark: { source: 'managed' },
     });
+  });
+
+  it('blocks first provision while a managed Composio connect attempt has no durable marker', async () => {
+    mockedGetActiveManagedComposioIdentity.mockResolvedValue({
+      row: {
+        id: 'identity-1',
+        composio_project_id: 'project-1',
+        google_calendar_connected_account_id: null,
+      },
+      agentKey: 'agent-key',
+      userApiKey: 'uak_123',
+      apiKey: 'api-key',
+      org: 'org-1',
+      consumerUserId: 'consumer-user-1',
+    } as never);
+
+    await expect(buildComposioProvisionSecrets({ scope })).rejects.toThrow(
+      'Managed Composio connection is still completing'
+    );
+  });
+
+  it('allows an explicit Tools skip to provision while a managed connect attempt is incomplete', async () => {
+    mockedGetActiveManagedComposioIdentity.mockResolvedValue({
+      row: {
+        id: 'identity-1',
+        composio_project_id: 'project-1',
+        google_calendar_connected_account_id: null,
+      },
+      agentKey: 'agent-key',
+      userApiKey: 'uak_123',
+      apiKey: 'api-key',
+      org: 'org-1',
+      consumerUserId: 'consumer-user-1',
+    } as never);
+
+    await expect(
+      buildComposioProvisionSecrets({ scope, skipIncompleteManagedConnection: true })
+    ).resolves.toEqual({ secrets: undefined, configToMark: null });
   });
 
   it('does not inject managed credentials into a current manual sandbox', async () => {

--- a/apps/web/src/lib/kiloclaw/composio-onboarding.ts
+++ b/apps/web/src/lib/kiloclaw/composio-onboarding.ts
@@ -119,12 +119,23 @@ export async function buildComposioProvisionSecrets(params: {
   scope: ComposioOwnerScope;
   instanceId?: string | null;
   secrets?: Record<string, string>;
+  skipIncompleteManagedConnection?: boolean;
 }): Promise<{
   secrets?: Record<string, string>;
   configToMark: ProvisionComposioConfigToMark;
 }> {
   if (hasComposioProvisionSecrets(params.secrets)) {
     return { secrets: params.secrets, configToMark: { source: 'manual' } };
+  }
+
+  if (!params.instanceId) {
+    const pendingIdentity = await getActiveManagedComposioIdentity(params.scope);
+    if (pendingIdentity && !pendingIdentity.row.google_calendar_connected_account_id) {
+      if (params.skipIncompleteManagedConnection) {
+        return { secrets: params.secrets, configToMark: null };
+      }
+      throw new Error('Managed Composio connection is still completing');
+    }
   }
 
   const identity = await getReusableManagedComposioIdentityForProvision({
@@ -145,7 +156,7 @@ export async function buildComposioProvisionSecrets(params: {
 
 export async function completeManagedComposioGoogleCalendarConnection(params: {
   userId: string;
-  instance: ActiveKiloClawInstance;
+  instance: ActiveKiloClawInstance | null;
   scope: ComposioOwnerScope;
   connectedAccountId: string;
 }): Promise<boolean> {
@@ -162,6 +173,14 @@ export async function completeManagedComposioGoogleCalendarConnection(params: {
     account => account.id === params.connectedAccountId && account.status === 'ACTIVE'
   );
   if (!connected) return false;
+
+  if (!params.instance) {
+    await db
+      .update(kiloclaw_composio_identities)
+      .set({ google_calendar_connected_account_id: params.connectedAccountId })
+      .where(eq(kiloclaw_composio_identities.id, identity.row.id));
+    return true;
+  }
 
   // Blocks callbacks after manual mode is recorded. The worker secret write
   // below is cross-service, so a manual save starting concurrently still races
@@ -193,7 +212,6 @@ export async function completeManagedComposioGoogleCalendarConnection(params: {
 
 export async function createManagedComposioGoogleCalendarLink(params: {
   userId: string;
-  instance: ActiveKiloClawInstance;
   scope: ComposioOwnerScope;
   organizationId?: string;
   returnTo: string;
@@ -251,7 +269,11 @@ export async function getManagedComposioGoogleCalendarStatus(params: {
         account.status === 'ACTIVE' &&
         (!knownConnectedAccountId || account.id === knownConnectedAccountId)
     );
-    if (active && params.sandboxHasComposioSecrets && sandboxConfigSource === 'managed') {
+    if (
+      active &&
+      ((!params.instance && knownConnectedAccountId !== null) ||
+        (params.instance && params.sandboxHasComposioSecrets && sandboxConfigSource === 'managed'))
+    ) {
       return {
         enabled: true,
         status: 'connected',

--- a/apps/web/src/lib/kiloclaw/composio-onboarding.ts
+++ b/apps/web/src/lib/kiloclaw/composio-onboarding.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
+import { FIELD_KEY_TO_ENTRY, validateFieldValue } from '@kilocode/kiloclaw-secret-catalog';
 import { APP_URL } from '@/lib/constants';
 import { encryptKiloClawSecret } from '@/lib/kiloclaw/encryption';
 import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
@@ -100,6 +101,27 @@ function hasComposioProvisionSecrets(secrets: Record<string, string> | undefined
   return secrets?.composioUserApiKey !== undefined || secrets?.composioOrg !== undefined;
 }
 
+function validateManualComposioProvisionSecrets(secrets: Record<string, string>): void {
+  for (const key of ['composioUserApiKey', 'composioOrg']) {
+    const value = secrets[key];
+    if (value === undefined) continue;
+    const entry = FIELD_KEY_TO_ENTRY.get(key);
+    const field = entry?.fields.find(candidate => candidate.key === key);
+    if (field?.maxLength != null && value.length > field.maxLength) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `${field.label} exceeds maximum length of ${field.maxLength} characters`,
+      });
+    }
+    if (!validateFieldValue(value, field?.validationPattern)) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: field?.validationMessage ?? `Invalid value for ${key}`,
+      });
+    }
+  }
+}
+
 async function getReusableManagedComposioIdentityForProvision(params: {
   scope: ComposioOwnerScope;
   instanceId?: string | null;
@@ -126,6 +148,7 @@ export async function buildComposioProvisionSecrets(params: {
   configToMark: ProvisionComposioConfigToMark;
 }> {
   if (hasComposioProvisionSecrets(params.secrets)) {
+    validateManualComposioProvisionSecrets(params.secrets ?? {});
     return { secrets: params.secrets, configToMark: { source: 'manual' } };
   }
 

--- a/apps/web/src/lib/kiloclaw/composio-onboarding.ts
+++ b/apps/web/src/lib/kiloclaw/composio-onboarding.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
 import { APP_URL } from '@/lib/constants';
 import { encryptKiloClawSecret } from '@/lib/kiloclaw/encryption';
@@ -134,7 +135,10 @@ export async function buildComposioProvisionSecrets(params: {
       if (params.skipIncompleteManagedConnection) {
         return { secrets: params.secrets, configToMark: null };
       }
-      throw new Error('Managed Composio connection is still completing');
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'Managed Composio connection is still completing',
+      });
     }
   }
 

--- a/apps/web/src/lib/kiloclaw/provision-secrets.test.ts
+++ b/apps/web/src/lib/kiloclaw/provision-secrets.test.ts
@@ -1,0 +1,21 @@
+jest.mock('@/lib/kiloclaw/encryption', () => ({
+  encryptKiloClawSecret: jest.fn((value: string) => `encrypted:${value}`),
+}));
+
+import { encryptProvisionSecretsForWorker } from './provision-secrets';
+
+describe('encryptProvisionSecretsForWorker', () => {
+  it('maps catalog field keys to worker env var names before encrypting', () => {
+    expect(
+      encryptProvisionSecretsForWorker({
+        composioUserApiKey: 'uak_123',
+        composioOrg: 'org-1',
+        CUSTOM_SECRET: 'kept',
+      })
+    ).toEqual({
+      COMPOSIO_USER_API_KEY: 'encrypted:uak_123',
+      COMPOSIO_ORG: 'encrypted:org-1',
+      CUSTOM_SECRET: 'encrypted:kept',
+    });
+  });
+});

--- a/apps/web/src/lib/kiloclaw/provision-secrets.ts
+++ b/apps/web/src/lib/kiloclaw/provision-secrets.ts
@@ -1,0 +1,14 @@
+import { FIELD_KEY_TO_ENV_VAR } from '@kilocode/kiloclaw-secret-catalog';
+import { encryptKiloClawSecret } from '@/lib/kiloclaw/encryption';
+
+export function encryptProvisionSecretsForWorker(
+  secrets: Record<string, string> | undefined
+): Record<string, ReturnType<typeof encryptKiloClawSecret>> | undefined {
+  if (!secrets) return undefined;
+  return Object.fromEntries(
+    Object.entries(secrets).map(([key, value]) => [
+      FIELD_KEY_TO_ENV_VAR.get(key) ?? key,
+      encryptKiloClawSecret(value),
+    ])
+  );
+}

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -827,7 +827,7 @@ const channelsSchema = z
 
 const updateConfigSchema = z.object({
   envVars: z.record(z.string(), z.string()).optional(),
-  secrets: z.record(z.string(), z.string()).optional(),
+  secrets: z.record(z.string(), z.string().max(MAX_CUSTOM_SECRET_VALUE_LENGTH)).optional(),
   channels: channelsSchema,
   kilocodeDefaultModel: kilocodeDefaultModelSchema.nullable().optional(),
   userTimezone: userTimezoneSchema.nullable().optional(),

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -74,6 +74,7 @@ import {
   getPersonalProvisionLockKey,
   withKiloclawProvisionContextLock,
 } from '@/lib/kiloclaw/provision-lock';
+import { encryptProvisionSecretsForWorker } from '@/lib/kiloclaw/provision-secrets';
 import {
   buildComposioProvisionSecrets,
   composioSecretsPatchSource,
@@ -831,6 +832,7 @@ const updateConfigSchema = z.object({
   kilocodeDefaultModel: kilocodeDefaultModelSchema.nullable().optional(),
   userTimezone: userTimezoneSchema.nullable().optional(),
   userLocation: userLocationSchema.nullable().optional(),
+  skipIncompleteManagedComposioConnection: z.boolean().optional(),
 });
 
 const updateKiloCodeConfigSchema = z.object({
@@ -1098,13 +1100,10 @@ async function provisionInstance(
     scope: { ownerType: 'user', userId: user.id },
     instanceId: params.instanceId,
     secrets: input.secrets,
+    skipIncompleteManagedConnection: input.skipIncompleteManagedComposioConnection,
   });
 
-  const encryptedSecrets = composioProvision.secrets
-    ? Object.fromEntries(
-        Object.entries(composioProvision.secrets).map(([k, v]) => [k, encryptKiloClawSecret(v)])
-      )
-    : undefined;
+  const encryptedSecrets = encryptProvisionSecretsForWorker(composioProvision.secrets);
 
   const expiresInSeconds = TOKEN_EXPIRY.thirtyDays;
   const kilocodeApiKey = generateApiToken(user, undefined, {
@@ -3504,30 +3503,30 @@ export const kiloclawRouter = createTRPCRouter({
   createComposioGoogleCalendarLink: baseProcedure
     .input(composioConnectLinkSchema)
     .mutation(async ({ ctx, input }) => {
-      const instance = await getActiveInstance(ctx.user.id);
-      if (!instance) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'No active KiloClaw instance found',
-        });
-      }
+      return await withKiloclawProvisionContextLock(
+        getPersonalProvisionLockKey(ctx.user.id),
+        async () => {
+          await ensureProvisionAccess(ctx.user.id, ctx.user.google_user_email);
+          const instance = await getActiveInstance(ctx.user.id);
+          const sandboxConfigSource = instance
+            ? await getComposioInstanceConfigSource(instance.id)
+            : null;
+          if (sandboxConfigSource === 'manual') {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: 'This sandbox already uses your own Composio credentials.',
+            });
+          }
 
-      const sandboxConfigSource = await getComposioInstanceConfigSource(instance.id);
-      if (sandboxConfigSource === 'manual') {
-        throw new TRPCError({
-          code: 'CONFLICT',
-          message: 'This sandbox already uses your own Composio credentials.',
-        });
-      }
-
-      return await createManagedComposioGoogleCalendarLink({
-        userId: ctx.user.id,
-        instance,
-        scope: { ownerType: 'user', userId: ctx.user.id },
-        returnTo: input.returnTo,
-        popup: input.popup,
-        attemptId: input.attemptId,
-      });
+          return await createManagedComposioGoogleCalendarLink({
+            userId: ctx.user.id,
+            scope: { ownerType: 'user', userId: ctx.user.id },
+            returnTo: input.returnTo,
+            popup: input.popup,
+            attemptId: input.attemptId,
+          });
+        }
+      );
     }),
 
   getChannelCatalog: baseProcedure.query(async ({ ctx }) => {

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -188,7 +188,7 @@ const channelsSchema = z
 const updateConfigSchema = z.object({
   organizationId: z.uuid(),
   envVars: z.record(z.string(), z.string()).optional(),
-  secrets: z.record(z.string(), z.string()).optional(),
+  secrets: z.record(z.string(), z.string().max(MAX_CUSTOM_SECRET_VALUE_LENGTH)).optional(),
   channels: channelsSchema,
   kilocodeDefaultModel: kilocodeDefaultModelSchema.nullable().optional(),
   userTimezone: userTimezoneSchema.nullable().optional(),

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -50,6 +50,7 @@ import {
   getOrganizationProvisionLockKey,
   withKiloclawProvisionContextLock,
 } from '@/lib/kiloclaw/provision-lock';
+import { encryptProvisionSecretsForWorker } from '@/lib/kiloclaw/provision-secrets';
 import {
   buildComposioProvisionSecrets,
   composioSecretsPatchSource,
@@ -192,6 +193,7 @@ const updateConfigSchema = z.object({
   kilocodeDefaultModel: kilocodeDefaultModelSchema.nullable().optional(),
   userTimezone: userTimezoneSchema.nullable().optional(),
   userLocation: userLocationSchema.nullable().optional(),
+  skipIncompleteManagedComposioConnection: z.boolean().optional(),
 });
 
 const updateKiloCodeConfigSchema = z.object({
@@ -483,16 +485,10 @@ export const organizationKiloclawRouter = createTRPCRouter({
               organizationId: input.organizationId,
             },
             secrets: input.secrets,
+            skipIncompleteManagedConnection: input.skipIncompleteManagedComposioConnection,
           });
 
-          const encryptedSecrets = composioProvision.secrets
-            ? Object.fromEntries(
-                Object.entries(composioProvision.secrets).map(([k, v]) => [
-                  k,
-                  encryptKiloClawSecret(v),
-                ])
-              )
-            : undefined;
+          const encryptedSecrets = encryptProvisionSecretsForWorker(composioProvision.secrets);
 
           const expiresInSeconds = TOKEN_EXPIRY.thirtyDays;
           const kilocodeApiKey = generateApiToken(ctx.user, undefined, {
@@ -556,13 +552,10 @@ export const organizationKiloclawRouter = createTRPCRouter({
         },
         instanceId: instance.id,
         secrets: input.secrets,
+        skipIncompleteManagedConnection: input.skipIncompleteManagedComposioConnection,
       });
 
-      const encryptedSecrets = composioProvision.secrets
-        ? Object.fromEntries(
-            Object.entries(composioProvision.secrets).map(([k, v]) => [k, encryptKiloClawSecret(v)])
-          )
-        : undefined;
+      const encryptedSecrets = encryptProvisionSecretsForWorker(composioProvision.secrets);
 
       const expiresInSeconds = TOKEN_EXPIRY.thirtyDays;
       const kilocodeApiKey = generateApiToken(ctx.user, undefined, {
@@ -865,28 +858,34 @@ export const organizationKiloclawRouter = createTRPCRouter({
   createComposioGoogleCalendarLink: organizationMemberMutationProcedure
     .input(composioConnectLinkSchema)
     .mutation(async ({ ctx, input }) => {
-      const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
-      const sandboxConfigSource = await getComposioInstanceConfigSource(instance.id);
-      if (sandboxConfigSource === 'manual') {
-        throw new TRPCError({
-          code: 'CONFLICT',
-          message: 'This sandbox already uses your own Composio credentials.',
-        });
-      }
+      return await withKiloclawProvisionContextLock(
+        getOrganizationProvisionLockKey(ctx.user.id, input.organizationId),
+        async () => {
+          const instance = await getActiveOrgInstance(ctx.user.id, input.organizationId);
+          const sandboxConfigSource = instance
+            ? await getComposioInstanceConfigSource(instance.id)
+            : null;
+          if (sandboxConfigSource === 'manual') {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: 'This sandbox already uses your own Composio credentials.',
+            });
+          }
 
-      return await createManagedComposioGoogleCalendarLink({
-        userId: ctx.user.id,
-        instance,
-        scope: {
-          ownerType: 'organization_user',
-          userId: ctx.user.id,
-          organizationId: input.organizationId,
-        },
-        organizationId: input.organizationId,
-        returnTo: input.returnTo,
-        popup: input.popup,
-        attemptId: input.attemptId,
-      });
+          return await createManagedComposioGoogleCalendarLink({
+            userId: ctx.user.id,
+            scope: {
+              ownerType: 'organization_user',
+              userId: ctx.user.id,
+              organizationId: input.organizationId,
+            },
+            organizationId: input.organizationId,
+            returnTo: input.returnTo,
+            popup: input.popup,
+            attemptId: input.attemptId,
+          });
+        }
+      );
     }),
 
   getChannelCatalog: organizationMemberProcedure.query(async ({ ctx, input }) => {


### PR DESCRIPTION
## Summary

- KiloClaw already delays first provision until the user has selected or skipped location, this pushes that to cover composio. Managed or manual Composio setup now completes before initial provision instead of racing after the machine is already booting. Without this - the instance is provisioned BEFORE composio creds are added and so the instance requires another boot to pick up fly env changes.

## Verification


## Visual Changes

| Before | After |
| ------ | ----- |
| Tools step could connect Composio after provisioning had already started, which could require a later restart before CLI login took effect. | Tools step completes managed/manual Composio setup before initial provision so first boot can consume the chosen credentials. |
| Popup success could surface before the durable connected-account status was confirmed. | Popup flow remains pending until status refetch confirms the managed connection is durably connected. |

## Reviewer Notes

- Provisioning now starts after Tools connect/save/skip, before Email; legacy non-Composio Calendar retains its existing active-instance sequencing.
- Manual Composio credentials remain a real pre-provision path and are passed directly into the initial provision request.
- Managed Connect Link creation, callback completion, and provision now coordinate through the same personal/org provision locks to avoid first-boot races.
- `skipIncompleteManagedComposioConnection` is only used by the explicit Tools skip path so users can proceed without waiting on an abandoned managed-connect attempt.