### PR TITLE
fix(web): preserve embedding dimensions in gateway

### DIFF
--- a/apps/web/src/lib/ai-gateway/embeddings/embedding-request.test.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/embedding-request.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from '@jest/globals';
 import { buildUpstreamBody } from './embedding-request';
 
 describe('buildUpstreamBody', () => {
-  it('should forward supported fields and strip client-only, Mistral-specific, and deprecated fields', () => {
+  it('should forward supported fields and strip native Mistral fields', () => {
     const result = buildUpstreamBody({
       model: 'google/text-embedding-004',
       input: ['text1', 'text2'],
@@ -19,13 +19,27 @@ describe('buildUpstreamBody', () => {
       model: 'google/text-embedding-004',
       input: ['text1', 'text2'],
       encoding_format: 'float',
+      dimensions: 768,
       safety_identifier: 'hash-abc',
       provider: { order: ['Google'] },
       input_type: 'search_document',
     });
-    expect(result).not.toHaveProperty('dimensions');
     expect(result).not.toHaveProperty('output_dtype');
     expect(result).not.toHaveProperty('output_dimension');
+  });
+
+  it('should keep Codestral embedding dimensions for the upstream provider', () => {
+    const result = buildUpstreamBody({
+      model: 'mistralai/codestral-embed-2505',
+      input: ['function add(a, b) { return a + b; }'],
+      dimensions: 256,
+    });
+
+    expect(result).toEqual({
+      model: 'mistralai/codestral-embed-2505',
+      input: ['function add(a, b) { return a + b; }'],
+      dimensions: 256,
+    });
   });
 
   it('should strip the deprecated user field', () => {

--- a/apps/web/src/lib/ai-gateway/embeddings/embedding-request.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/embedding-request.ts
@@ -14,17 +14,11 @@ export type EmbeddingProxyRequest = {
 /**
  * Build the upstream request body for the target provider.
  * Strips the deprecated `user` field (replaced by `safety_identifier`) and
- * Mistral-specific fields that upstream providers (OpenRouter, Vercel) don't understand.
+ * native Mistral fields that upstream providers (OpenRouter, Vercel) don't understand.
  */
 export function buildUpstreamBody(
   body: EmbeddingProxyRequest & { user?: string }
 ): Record<string, unknown> {
-  const {
-    dimensions: _,
-    output_dtype: __,
-    output_dimension: ___,
-    user: ____,
-    ...upstreamBody
-  } = body;
+  const { output_dtype: _, output_dimension: __, user: ___, ...upstreamBody } = body;
   return upstreamBody;
 }


### PR DESCRIPTION
Preserve embedding `dimensions` in the embeddings gateway body so Codestral requests keep the hosted catalog's 256-dimensional contract.
Continue removing native Mistral-only fields while covering the Codestral proxy shape in the sanitizer tests.