### PR TITLE
fix(kiloclaw): stop repeated subscription-suspended emails from being triggered

### DIFF
--- a/apps/web/src/lib/kiloclaw/instance-lifecycle.test.ts
+++ b/apps/web/src/lib/kiloclaw/instance-lifecycle.test.ts
@@ -199,13 +199,14 @@ describe('instance lifecycle async resume', () => {
     );
   });
 
-  it('completes async auto-resume for the correct instance and clears retry state', async () => {
+  it('completes async auto-resume for an active subscription and clears retry state', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const sandboxId = 'ki_11111111111141118111111111111111';
     selectResultsQueue.push(
       [{ id: instanceId, sandbox_id: sandboxId }],
       [
         {
+          status: 'active',
           suspended_at: '2026-04-07T20:00:00.000Z',
           auto_resume_requested_at: '2026-04-07T20:05:00.000Z',
           auto_resume_retry_after: '2026-04-07T22:05:00.000Z',
@@ -217,8 +218,8 @@ describe('instance lifecycle async resume', () => {
           id: 'sub-1',
           user_id: 'user-1',
           instance_id: instanceId,
-          plan: 'trial',
-          status: 'canceled',
+          plan: 'standard',
+          status: 'active',
           suspended_at: '2026-04-07T20:00:00.000Z',
           destruction_deadline: '2026-04-14T20:00:00.000Z',
           auto_resume_requested_at: '2026-04-07T20:05:00.000Z',
@@ -251,6 +252,67 @@ describe('instance lifecycle async resume', () => {
     );
   });
 
+  it('does not clear suspension state for a canceled subscription on stale ready callback', async () => {
+    // Regression: a stopped instance suspended by subscription_expiry could be
+    // woken by Fly Proxy if the worker proxied to it. The resulting controller
+    // checkin would fire the instance-ready callback, and previously this
+    // function would treat any non-null suspended_at as a pending auto-resume
+    // and wipe both the suspension state and the once-per-lifecycle email log.
+    // The next billing sweep would then re-stop and re-email.
+    // Per .specs/kiloclaw-billing.md §1132.1, auto-resume completion fires
+    // only on a transition to active status.
+    const instanceId = '11111111-1111-4111-8111-111111111111';
+    const sandboxId = 'ki_11111111111141118111111111111111';
+    selectResultsQueue.push(
+      [{ id: instanceId, sandbox_id: sandboxId }],
+      [
+        {
+          status: 'canceled',
+          suspended_at: '2026-04-07T20:00:00.000Z',
+          auto_resume_requested_at: null,
+          auto_resume_retry_after: null,
+          auto_resume_attempt_count: 0,
+        },
+      ]
+    );
+
+    const result = await completeAutoResumeIfReady('user-1', sandboxId, instanceId);
+
+    expect(result).toEqual({ instanceId, resumeCompleted: false });
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(txUpdateSetCalls).toHaveLength(0);
+    expect(deleteWhereCalls).toHaveLength(0);
+    expect(txInsertValues).toHaveLength(0);
+  });
+
+  it('does not clear suspension state for a past_due subscription on stale ready callback', async () => {
+    // past_due has not transitioned to active yet (the credit-renewal sweep
+    // sets status to active before invoking auto-resume). A ready callback
+    // arriving while still past_due is stale state, not a recovery signal.
+    const instanceId = '11111111-1111-4111-8111-111111111111';
+    const sandboxId = 'ki_11111111111141118111111111111111';
+    selectResultsQueue.push(
+      [{ id: instanceId, sandbox_id: sandboxId }],
+      [
+        {
+          status: 'past_due',
+          suspended_at: '2026-04-07T20:00:00.000Z',
+          auto_resume_requested_at: '2026-04-07T20:05:00.000Z',
+          auto_resume_retry_after: '2026-04-07T22:05:00.000Z',
+          auto_resume_attempt_count: 1,
+        },
+      ]
+    );
+
+    const result = await completeAutoResumeIfReady('user-1', sandboxId, instanceId);
+
+    expect(result).toEqual({ instanceId, resumeCompleted: false });
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(txUpdateSetCalls).toHaveLength(0);
+    expect(deleteWhereCalls).toHaveLength(0);
+    expect(txInsertValues).toHaveLength(0);
+  });
+
   it('clears auto-resume state when readiness arrives after the instance is already gone', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const sandboxId = 'ki_11111111111141118111111111111111';
@@ -280,6 +342,7 @@ describe('instance lifecycle async resume', () => {
       [{ id: instanceId, sandbox_id: sandboxId }],
       [
         {
+          status: 'active',
           suspended_at: null,
           auto_resume_requested_at: null,
           auto_resume_retry_after: null,

--- a/apps/web/src/lib/kiloclaw/instance-lifecycle.test.ts
+++ b/apps/web/src/lib/kiloclaw/instance-lifecycle.test.ts
@@ -27,10 +27,19 @@ const startAsyncMock = jest.fn();
 
 function createSelectResult<T>(rows: T[]) {
   const promise = Promise.resolve(rows);
-  return {
+  const result: {
+    limit: jest.Mock;
+    for: jest.Mock;
+    then: typeof promise.then;
+  } = {
     limit: jest.fn().mockResolvedValue(rows),
+    // Drizzle's `.for('update')` row-locks and returns the same shape as
+    // the parent select. Tests just need the rows; the lock semantics are
+    // exercised by the transaction integration test fixtures.
+    for: jest.fn(() => result),
     then: promise.then.bind(promise),
   };
+  return result;
 }
 
 function createWhereResult<T>(rows: T[]) {
@@ -282,6 +291,46 @@ describe('instance lifecycle async resume', () => {
     expect(mockDb.transaction).not.toHaveBeenCalled();
     expect(txUpdateSetCalls).toHaveLength(0);
     expect(deleteWhereCalls).toHaveLength(0);
+    expect(txInsertValues).toHaveLength(0);
+  });
+
+  it('aborts the transactional clear if the subscription flips out of active before the row lock acquires', async () => {
+    // Regression for the TOCTOU race between the precondition status read
+    // in completeAutoResumeIfReady and the transaction inside
+    // clearAutoResumeState: if the subscription transitions to past_due or
+    // canceled in that window, the in-transaction SELECT FOR UPDATE with
+    // status='active' returns empty rows and the entire mutation is
+    // skipped. Without this guard the email-log dedupe row and
+    // suspended_at would still be wiped on a stale ready callback,
+    // reopening the duplicate-suspension-email loop.
+    const instanceId = '11111111-1111-4111-8111-111111111111';
+    const sandboxId = 'ki_11111111111141118111111111111111';
+    selectResultsQueue.push(
+      [{ id: instanceId, sandbox_id: sandboxId }],
+      // Precondition select: subscription was active with pending markers
+      // when first read.
+      [
+        {
+          status: 'active',
+          suspended_at: '2026-04-07T20:00:00.000Z',
+          auto_resume_requested_at: '2026-04-07T20:05:00.000Z',
+          auto_resume_retry_after: '2026-04-07T22:05:00.000Z',
+          auto_resume_attempt_count: 2,
+        },
+      ],
+      // Transactional SELECT FOR UPDATE with status='active' filter: a
+      // concurrent transition committed before our lock, so no rows match.
+      []
+    );
+
+    const result = await completeAutoResumeIfReady('user-1', sandboxId, instanceId);
+
+    expect(result).toEqual({ instanceId, resumeCompleted: true });
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    // No email_log delete, no row update, no change-log insert when the
+    // active gate fails inside the transaction.
+    expect(deleteWhereCalls).toHaveLength(0);
+    expect(txUpdateSetCalls).toHaveLength(0);
     expect(txInsertValues).toHaveLength(0);
   });
 

--- a/apps/web/src/lib/kiloclaw/instance-lifecycle.test.ts
+++ b/apps/web/src/lib/kiloclaw/instance-lifecycle.test.ts
@@ -325,7 +325,11 @@ describe('instance lifecycle async resume', () => {
 
     const result = await completeAutoResumeIfReady('user-1', sandboxId, instanceId);
 
-    expect(result).toEqual({ instanceId, resumeCompleted: true });
+    // Race-aborted clear must not be reported as a completion: the caller
+    // (instance-ready route) keys its "Completed async auto-resume" log
+    // line on resumeCompleted, and conflating skipped-due-to-race with
+    // genuine completion would mask the race in operator metrics.
+    expect(result).toEqual({ instanceId, resumeCompleted: false });
     expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     // No email_log delete, no row update, no change-log insert when the
     // active gate fails inside the transaction.

--- a/apps/web/src/lib/kiloclaw/instance-lifecycle.ts
+++ b/apps/web/src/lib/kiloclaw/instance-lifecycle.ts
@@ -340,6 +340,7 @@ export async function completeAutoResumeIfReady(
 
   const [subscription] = await db
     .select({
+      status: kiloclaw_subscriptions.status,
       suspended_at: kiloclaw_subscriptions.suspended_at,
       auto_resume_requested_at: kiloclaw_subscriptions.auto_resume_requested_at,
       auto_resume_retry_after: kiloclaw_subscriptions.auto_resume_retry_after,
@@ -355,18 +356,29 @@ export async function completeAutoResumeIfReady(
     )
     .limit(1);
 
-  const hadPendingResume = !!(
+  // Per .specs/kiloclaw-billing.md §1132 (Auto-Resume on Payment Recovery),
+  // auto-resume completion fires when a subscription "transitions to active
+  // while the subscription's instance is suspended". A canceled or past_due
+  // subscription has not transitioned to active and MUST NOT have its
+  // suspension state cleared by a stale instance-ready callback — otherwise
+  // a Fly-Proxy-driven wakeup of a stopped machine would silently delete
+  // the once-per-lifecycle email-log entries (§1118.1) and re-enable the
+  // hourly subscription-expiry sweep to send another suspension email.
+  const hasPendingResumeState = !!(
     subscription?.suspended_at ||
     subscription?.auto_resume_requested_at ||
     subscription?.auto_resume_retry_after ||
     (subscription?.auto_resume_attempt_count ?? 0) > 0
   );
+  const isPendingResume = subscription?.status === 'active' && hasPendingResumeState;
 
-  if (!hadPendingResume) {
+  if (!isPendingResume) {
     logInfo('Instance ready without pending async auto-resume state', {
       user_id: kiloUserId,
       instance_id: targetInstance.id,
       sandbox_id: sandboxId,
+      subscription_status: subscription?.status ?? null,
+      has_suspended_at: subscription?.suspended_at != null,
     });
     return { instanceId: targetInstance.id, resumeCompleted: false };
   }

--- a/apps/web/src/lib/kiloclaw/instance-lifecycle.ts
+++ b/apps/web/src/lib/kiloclaw/instance-lifecycle.ts
@@ -132,12 +132,50 @@ async function clearAutoResumeState(
     logMessage: string;
     changeLogReason: string;
     logFields?: Record<string, unknown>;
+    /**
+     * When set, the transactional clear is gated on the subscription still
+     * being in `status='active'` at lock time. Used by the genuine
+     * auto-resume completion path to close a TOCTOU window: the
+     * subscription status read in `completeAutoResumeIfReady` happens
+     * outside this transaction, and a concurrent transition (credit-renewal
+     * sweep flipping back to past_due, user cancellation, subscription
+     * expiry) between the precondition and this transaction would
+     * otherwise still wipe the email-log dedupe state and suspension
+     * fields. Skipping the entire mutation when no active row is locked
+     * keeps the once-per-lifecycle email-notification guarantee
+     * (.specs/kiloclaw-billing.md §1118.1).
+     */
+    requireActiveSubscription?: boolean;
   }
 ): Promise<void> {
   const subscriptionFilter = subscriptionFilterForUser(kiloUserId, options.instanceId);
+  const activeSubscriptionFilter = and(
+    subscriptionFilter,
+    eq(kiloclaw_subscriptions.status, 'active')
+  );
+  let skippedNoActiveSubscription = false;
 
   await db.transaction(async tx => {
-    const subscriptions = await tx.select().from(kiloclaw_subscriptions).where(subscriptionFilter);
+    // FOR UPDATE row-locks the candidate subscriptions for the duration of
+    // the transaction. When `requireActiveSubscription` is set, any
+    // concurrent writer that flips status away from 'active' has either
+    // already committed (we won't see/lock the row) or will block on our
+    // lock until we commit. Either way the subsequent email-log delete and
+    // subscription update operate on a snapshot we know was 'active' at
+    // lock time.
+    const subscriptions = await tx
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(options.requireActiveSubscription ? activeSubscriptionFilter : subscriptionFilter)
+      .for('update');
+
+    if (options.requireActiveSubscription && subscriptions.length === 0) {
+      // The precondition saw status='active' but a concurrent transition
+      // committed before our lock acquired. Bail without touching any
+      // dedupe state. The next ready callback (or sweep) will re-evaluate.
+      skippedNoActiveSubscription = true;
+      return;
+    }
 
     await tx
       .delete(kiloclaw_email_log)
@@ -154,7 +192,7 @@ async function clearAutoResumeState(
         auto_resume_retry_after: null,
         auto_resume_attempt_count: 0,
       })
-      .where(subscriptionFilter);
+      .where(options.requireActiveSubscription ? activeSubscriptionFilter : subscriptionFilter);
 
     for (const subscription of subscriptions) {
       const clearedSuspension =
@@ -180,6 +218,16 @@ async function clearAutoResumeState(
       });
     }
   });
+
+  if (skippedNoActiveSubscription) {
+    logInfo('Auto-resume completion skipped: subscription not active at lock time', {
+      user_id: kiloUserId,
+      instance_id: options.instanceId ?? null,
+      ...(options.sandboxId ? { sandbox_id: options.sandboxId } : {}),
+      ...(options.logFields ?? {}),
+    });
+    return;
+  }
 
   logInfo(options.logMessage, {
     user_id: kiloUserId,
@@ -388,6 +436,12 @@ export async function completeAutoResumeIfReady(
     sandboxId,
     logMessage: 'Async auto-resume completed',
     changeLogReason: 'auto_resume_completed',
+    // Gate the transactional clear on the subscription still being active
+    // at lock time. The precondition above is racy by itself: a concurrent
+    // transition to past_due/canceled between the read and the transaction
+    // would otherwise still wipe the email-log dedupe row and reopen the
+    // duplicate-suspension-email loop.
+    requireActiveSubscription: true,
   });
   return { instanceId: targetInstance.id, resumeCompleted: true };
 }

--- a/apps/web/src/lib/kiloclaw/instance-lifecycle.ts
+++ b/apps/web/src/lib/kiloclaw/instance-lifecycle.ts
@@ -147,7 +147,7 @@ async function clearAutoResumeState(
      */
     requireActiveSubscription?: boolean;
   }
-): Promise<void> {
+): Promise<{ skippedNoActiveSubscription: boolean }> {
   const subscriptionFilter = subscriptionFilterForUser(kiloUserId, options.instanceId);
   const activeSubscriptionFilter = and(
     subscriptionFilter,
@@ -226,7 +226,7 @@ async function clearAutoResumeState(
       ...(options.sandboxId ? { sandbox_id: options.sandboxId } : {}),
       ...(options.logFields ?? {}),
     });
-    return;
+    return { skippedNoActiveSubscription: true };
   }
 
   logInfo(options.logMessage, {
@@ -235,6 +235,7 @@ async function clearAutoResumeState(
     ...(options.sandboxId ? { sandbox_id: options.sandboxId } : {}),
     ...(options.logFields ?? {}),
   });
+  return { skippedNoActiveSubscription: false };
 }
 
 async function resolveActiveInstance(
@@ -431,7 +432,7 @@ export async function completeAutoResumeIfReady(
     return { instanceId: targetInstance.id, resumeCompleted: false };
   }
 
-  await clearAutoResumeState(kiloUserId, {
+  const { skippedNoActiveSubscription } = await clearAutoResumeState(kiloUserId, {
     instanceId: targetInstance.id,
     sandboxId,
     logMessage: 'Async auto-resume completed',
@@ -443,7 +444,14 @@ export async function completeAutoResumeIfReady(
     // duplicate-suspension-email loop.
     requireActiveSubscription: true,
   });
-  return { instanceId: targetInstance.id, resumeCompleted: true };
+  // When the in-transaction lock found no active subscription, no clear
+  // happened. Surface that to the caller so the instance-ready endpoint's
+  // "Completed async auto-resume" log line doesn't claim a non-completion
+  // and operators get accurate signal on race frequency.
+  return {
+    instanceId: targetInstance.id,
+    resumeCompleted: !skippedNoActiveSubscription,
+  };
 }
 
 async function clearInactiveTrialStopMarkerForPersonalInstance(params: {

--- a/services/kilo-chat/src/__tests__/bot-status-request.test.ts
+++ b/services/kilo-chat/src/__tests__/bot-status-request.test.ts
@@ -9,6 +9,30 @@ describe('isDefiniteUnreachable', () => {
     );
   });
 
+  // Regression: deliverChatWebhook refuses to fetch() against a non-running
+  // instance to prevent Fly Proxy autostart on suspended/stopped machines.
+  // The classifier must treat that throw as definitive so chat dispatchers
+  // immediately publish online: false instead of retrying forever and
+  // showing a stale "online" indicator.
+  it('classifies non-running instance errors as definitive', () => {
+    expect(
+      isDefiniteUnreachable(new Error('Instance for sandbox-foo is not running (status=stopped)'))
+    ).toBe(true);
+    expect(
+      isDefiniteUnreachable(
+        new Error('Instance for instance abc-123 is not running (status=provisioned)')
+      )
+    ).toBe(true);
+    // The match is on the prefix "is not running" so additional status
+    // values introduced later in the worker still classify correctly
+    // without requiring a lock-step update here.
+    expect(
+      isDefiniteUnreachable(
+        new Error('Instance for sandbox-foo is not running (status=some_future_state)')
+      )
+    ).toBe(true);
+  });
+
   it('classifies upstream 4xx as definitive', () => {
     expect(isDefiniteUnreachable(new Error('Webhook forward failed: 401 Unauthorized'))).toBe(true);
     expect(isDefiniteUnreachable(new Error('Webhook forward failed: 404 Not Found'))).toBe(true);

--- a/services/kilo-chat/src/services/bot-status-request.ts
+++ b/services/kilo-chat/src/services/bot-status-request.ts
@@ -93,13 +93,21 @@ async function triggerBotStatusWebhook(env: Env, sandboxId: string): Promise<voi
 
 // Definitive vs transient classification for the upstream RPC error. Strings
 // come from `deliverChatWebhook` in services/kiloclaw/src/index.ts; treat
-// "no routing target" / "no sandboxId" as definitive (the bot is gone), and
-// any 4xx upstream as definitive (the controller actively rejected). Network
-// errors and 5xx/timeouts stay transient.
+// "no routing target" / "no sandboxId" / "is not running" as definitive
+// (the bot is gone or suspended and won't autostart), and any 4xx upstream
+// as definitive (the controller actively rejected). Network errors and
+// 5xx/timeouts stay transient.
 export function isDefiniteUnreachable(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   if (msg.includes('No routing target')) return true;
   if (msg.includes('has no sandboxId')) return true;
+  // `is not running` is thrown by deliverChatWebhook when the target
+  // instance's DO status is anything other than 'running' (stopped,
+  // provisioned, recovering, etc.). Match the prefix only so additional
+  // status values introduced later still classify correctly without
+  // requiring a lock-step update here. The full thrown shape is
+  // "Instance for <label> is not running (status=<value>)".
+  if (msg.includes('is not running')) return true;
   const m = msg.match(/Webhook forward failed: (\d{3})/);
   if (m) {
     const code = Number(m[1]);

--- a/services/kiloclaw/src/index.test.ts
+++ b/services/kiloclaw/src/index.test.ts
@@ -414,6 +414,152 @@ describe('proxy refuses to wake stopped instances', () => {
   });
 });
 
+// `starting` and `restarting` are platform-driven transient states. The
+// previous proxyThroughTarget 502 → 503 retry path was strictly better UX
+// than a flat 409 "Instance not running, start from dashboard" — the user
+// already initiated start, the platform is actively working on it, and the
+// right thing to tell the client is "retry shortly". The `stopped` gate
+// above remains 409 because there it really IS the user's job to start.
+describe('proxy returns 503 retry for transient starting states', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const baseEnv = () => ({
+    NEXTAUTH_SECRET: 'nextauth-secret',
+    GATEWAY_TOKEN_SECRET: 'gateway-secret',
+    KILOCLAW_INSTANCE_HOST_SUFFIX: '.kiloclaw.ai',
+    KILOCLAW_INSTANCE_URL_SCHEME: 'https',
+    FLY_API_TOKEN: 'fly-token',
+    FLY_APP_NAME: 'test-app',
+  });
+
+  const transientStatusBase = {
+    userId: 'user-1',
+    sandboxId: 'ki_550e8400e29b41d4a716446655440000',
+    provider: 'fly' as const,
+    runtimeId: 'machine-1',
+    flyMachineId: 'machine-1',
+    flyAppName: 'test-app',
+    controllerCapabilitiesVersion: 2,
+  };
+
+  for (const transientStatus of ['starting', 'restarting'] as const) {
+    it(`returns 503 with Retry-After for the /i/:instanceId branch when status='${transientStatus}'`, async () => {
+      const instanceStub = {
+        getStatus: vi.fn().mockResolvedValue({
+          ...transientStatusBase,
+          status: transientStatus,
+        }),
+        getRoutingTarget: vi.fn(),
+      };
+      const fetchMock = vi.mocked(fetch) as FetchMock;
+
+      const response = await app.fetch(
+        new Request('https://example.com/i/550e8400-e29b-41d4-a716-446655440000/api/foo'),
+        {
+          ...baseEnv(),
+          KILOCLAW_INSTANCE: {
+            idFromName: vi.fn().mockReturnValue('instance-id'),
+            get: vi.fn().mockReturnValue(instanceStub),
+          },
+        } as never,
+        { waitUntil: vi.fn() } as never
+      );
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get('Retry-After')).toBe('5');
+      await expect(response.json()).resolves.toEqual({
+        error: 'Instance is starting up',
+        hint: 'The instance is starting. Please retry shortly.',
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(instanceStub.getRoutingTarget).not.toHaveBeenCalled();
+    });
+
+    it(`returns 503 with Retry-After for the host-based branch when status='${transientStatus}'`, async () => {
+      const instanceStub = {
+        getStatus: vi.fn().mockResolvedValue({
+          ...transientStatusBase,
+          status: transientStatus,
+        }),
+        getRoutingTarget: vi.fn(),
+      };
+      const fetchMock = vi.mocked(fetch) as FetchMock;
+
+      const response = await app.fetch(
+        new Request('https://i-550e8400e29b41d4a716446655440000.kiloclaw.ai/api/foo'),
+        {
+          ...baseEnv(),
+          KILOCLAW_INSTANCE: {
+            idFromName: vi.fn().mockReturnValue('instance-id'),
+            get: vi.fn().mockReturnValue(instanceStub),
+          },
+        } as never,
+        { waitUntil: vi.fn() } as never
+      );
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get('Retry-After')).toBe('5');
+      await expect(response.json()).resolves.toEqual({
+        error: 'Instance is starting up',
+        hint: 'The instance is starting. Please retry shortly.',
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it(`returns 503 with Retry-After for the default catch-all branch when status='${transientStatus}'`, async () => {
+      const registryStub = {
+        listInstances: vi.fn().mockResolvedValue([
+          {
+            doKey: 'user-1',
+            instanceId: '',
+            assignedUserId: 'user-1',
+            createdAt: new Date().toISOString(),
+            destroyedAt: null,
+          },
+        ]),
+      };
+      const instanceStub = {
+        getStatus: vi.fn().mockResolvedValue({
+          ...transientStatusBase,
+          status: transientStatus,
+        }),
+        getRoutingTarget: vi.fn(),
+      };
+      const fetchMock = vi.mocked(fetch) as FetchMock;
+
+      const response = await app.fetch(
+        new Request('https://example.com/'),
+        {
+          ...baseEnv(),
+          KILOCLAW_REGISTRY: {
+            idFromName: vi.fn().mockReturnValue('registry-id'),
+            get: vi.fn().mockReturnValue(registryStub),
+          },
+          KILOCLAW_INSTANCE: {
+            idFromName: vi.fn().mockReturnValue('instance-id'),
+            get: vi.fn().mockReturnValue(instanceStub),
+          },
+        } as never,
+        { waitUntil: vi.fn() } as never
+      );
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get('Retry-After')).toBe('5');
+      await expect(response.json()).resolves.toEqual({
+        error: 'Instance is starting up',
+        hint: 'Your instance is starting. Please retry shortly.',
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  }
+});
+
 describe('kilo-chat webhook delivery', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());
@@ -426,7 +572,7 @@ describe('kilo-chat webhook delivery', () => {
   it('routes service-binding webhook payloads to the target instance gateway', async () => {
     const sandboxId = 'ki_550e8400e29b41d4a716446655440000';
     const instanceStub = {
-      getStatus: vi.fn().mockResolvedValue({ sandboxId }),
+      getStatus: vi.fn().mockResolvedValue({ sandboxId, status: 'running' }),
       getRoutingTarget: vi.fn().mockResolvedValue({
         origin: 'https://test-app.fly.dev',
         headers: { 'fly-force-instance-id': 'machine-1' },
@@ -519,6 +665,52 @@ describe('kilo-chat webhook delivery', () => {
       expect(registryNamespace.idFromName).not.toHaveBeenCalled();
       expect(instanceNamespace.idFromName).not.toHaveBeenCalled();
     }
+  });
+
+  // Regression: chat dispatchers (Slack/Discord/Telegram) call this RPC for
+  // every inbound message. When the target instance is suspended for billing
+  // or manually stopped, we must NOT issue fetch() against the Fly app —
+  // doing so triggers Fly Proxy's autostart and silently wakes the machine,
+  // creating churn and (before the TOCTOU defense in instance-lifecycle.ts)
+  // feeding the duplicate-suspension-email loop.
+  it('refuses to deliver chat webhooks to a non-running instance', async () => {
+    const sandboxId = 'ki_550e8400e29b41d4a716446655440000';
+    const instanceStub = {
+      getStatus: vi.fn().mockResolvedValue({ sandboxId, status: 'stopped' }),
+      getRoutingTarget: vi.fn(),
+    };
+    const instanceNamespace = {
+      idFromName: vi.fn().mockReturnValue('instance-id'),
+      get: vi.fn().mockReturnValue(instanceStub),
+    };
+    const fetchMock = vi.mocked(fetch) as FetchMock;
+
+    const worker = new WorkerEntrypoint(
+      {
+        KILOCLAW_INSTANCE: instanceNamespace,
+        GATEWAY_TOKEN_SECRET: 'gateway-secret',
+        KILOCLAW_INSTANCE_HOST_SUFFIX: '.kiloclaw.ai',
+        KILOCLAW_INSTANCE_URL_SCHEME: 'https',
+      } as never,
+      {} as never
+    );
+
+    await expect(
+      worker.deliverChatWebhook({
+        type: 'message.created',
+        targetBotId: `bot:kiloclaw:${sandboxId}`,
+        conversationId: '01KP8R0VX4HK4ZSVQR5ZBVKHQH',
+        messageId: '01KP8R0VX4HK4ZSVQR5ZBVKHQJ',
+        from: 'user-1',
+        text: 'Hello',
+        sentAt: '2026-04-21T12:00:00.000Z',
+      })
+    ).rejects.toThrow(/is not running \(status=stopped\)/);
+
+    // Critically: the routing target was never resolved and no fetch was
+    // issued, so Fly Proxy autostart cannot be triggered.
+    expect(instanceStub.getRoutingTarget).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/services/kiloclaw/src/index.test.ts
+++ b/services/kiloclaw/src/index.test.ts
@@ -246,6 +246,174 @@ describe('proxy recovering state', () => {
   });
 });
 
+// Regression: a stopped Fly machine still has flyMachineId/runtimeId set, and
+// proxying to it would trigger Fly Proxy's autostart — silently waking
+// instances we deliberately suspended (subscription_expiry, manual stop, etc.)
+// and feeding the once-per-hour suspension-email loop. Each branch must refuse
+// to forward unless the DO status is strictly 'running'.
+describe('proxy refuses to wake stopped instances', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const baseEnv = () => ({
+    NEXTAUTH_SECRET: 'nextauth-secret',
+    GATEWAY_TOKEN_SECRET: 'gateway-secret',
+    KILOCLAW_INSTANCE_HOST_SUFFIX: '.kiloclaw.ai',
+    KILOCLAW_INSTANCE_URL_SCHEME: 'https',
+    FLY_API_TOKEN: 'fly-token',
+    FLY_APP_NAME: 'test-app',
+  });
+
+  const stoppedStatus = {
+    userId: 'user-1',
+    sandboxId: 'ki_550e8400e29b41d4a716446655440000',
+    status: 'stopped' as const,
+    provider: 'fly' as const,
+    // runtimeId is still set: a stopped Fly machine retains its machine ID;
+    // only the Fly state transitions to "stopped".
+    runtimeId: 'machine-1',
+    flyMachineId: 'machine-1',
+    flyAppName: 'test-app',
+    controllerCapabilitiesVersion: 2,
+  };
+
+  it('returns 409 for the /i/:instanceId branch and never proxies', async () => {
+    const instanceStub = {
+      getStatus: vi.fn().mockResolvedValue(stoppedStatus),
+      getRoutingTarget: vi.fn(),
+    };
+    const fetchMock = vi.mocked(fetch) as FetchMock;
+
+    const response = await app.fetch(
+      new Request('https://example.com/i/550e8400-e29b-41d4-a716-446655440000/api/foo'),
+      {
+        ...baseEnv(),
+        KILOCLAW_INSTANCE: {
+          idFromName: vi.fn().mockReturnValue('instance-id'),
+          get: vi.fn().mockReturnValue(instanceStub),
+        },
+      } as never,
+      { waitUntil: vi.fn() } as never
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Instance not running',
+      hint: 'Start it from the dashboard.',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(instanceStub.getRoutingTarget).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 for the host-based branch and never proxies', async () => {
+    const instanceStub = {
+      getStatus: vi.fn().mockResolvedValue(stoppedStatus),
+      getRoutingTarget: vi.fn(),
+    };
+    const fetchMock = vi.mocked(fetch) as FetchMock;
+
+    const response = await app.fetch(
+      new Request('https://i-550e8400e29b41d4a716446655440000.kiloclaw.ai/api/foo'),
+      {
+        ...baseEnv(),
+        KILOCLAW_INSTANCE: {
+          idFromName: vi.fn().mockReturnValue('instance-id'),
+          get: vi.fn().mockReturnValue(instanceStub),
+        },
+      } as never,
+      { waitUntil: vi.fn() } as never
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Instance not running',
+      hint: 'Start it from the dashboard.',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(instanceStub.getRoutingTarget).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 for the cookie-routed branch and never proxies', async () => {
+    const instanceStub = {
+      getStatus: vi.fn().mockResolvedValue(stoppedStatus),
+      getRoutingTarget: vi.fn(),
+    };
+    const fetchMock = vi.mocked(fetch) as FetchMock;
+
+    const response = await app.fetch(
+      new Request('https://example.com/', {
+        headers: {
+          Cookie: `${KILOCLAW_ACTIVE_INSTANCE_COOKIE}=550e8400-e29b-41d4-a716-446655440000`,
+        },
+      }),
+      {
+        ...baseEnv(),
+        KILOCLAW_INSTANCE: {
+          idFromName: vi.fn().mockReturnValue('instance-id'),
+          get: vi.fn().mockReturnValue(instanceStub),
+        },
+      } as never,
+      { waitUntil: vi.fn() } as never
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Instance not running',
+      hint: 'Start it from the dashboard.',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(instanceStub.getRoutingTarget).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 for the default catch-all branch and never proxies', async () => {
+    const registryStub = {
+      listInstances: vi.fn().mockResolvedValue([
+        {
+          doKey: 'user-1',
+          instanceId: '',
+          assignedUserId: 'user-1',
+          createdAt: new Date().toISOString(),
+          destroyedAt: null,
+        },
+      ]),
+    };
+    const instanceStub = {
+      getStatus: vi.fn().mockResolvedValue(stoppedStatus),
+      getRoutingTarget: vi.fn(),
+    };
+    const fetchMock = vi.mocked(fetch) as FetchMock;
+
+    const response = await app.fetch(
+      new Request('https://example.com/'),
+      {
+        ...baseEnv(),
+        KILOCLAW_REGISTRY: {
+          idFromName: vi.fn().mockReturnValue('registry-id'),
+          get: vi.fn().mockReturnValue(registryStub),
+        },
+        KILOCLAW_INSTANCE: {
+          idFromName: vi.fn().mockReturnValue('instance-id'),
+          get: vi.fn().mockReturnValue(instanceStub),
+        },
+      } as never,
+      { waitUntil: vi.fn() } as never
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Instance not running',
+      hint: 'Start it from the dashboard.',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(instanceStub.getRoutingTarget).not.toHaveBeenCalled();
+  });
+});
+
 describe('kilo-chat webhook delivery', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());

--- a/services/kiloclaw/src/index.ts
+++ b/services/kiloclaw/src/index.ts
@@ -495,6 +495,18 @@ app.all('/i/:instanceId/*', async c => {
   if (status.status === 'recovering') {
     return c.json({ error: 'Instance is recovering from an unexpected stop' }, 409);
   }
+  // Transient lifecycle states the platform is actively driving. Tell the
+  // client to retry rather than surfacing a misleading "start it from the
+  // dashboard" 409 — the instance IS being started.
+  if (status.status === 'starting' || status.status === 'restarting') {
+    return c.json(
+      {
+        error: 'Instance is starting up',
+        hint: 'The instance is starting. Please retry shortly.',
+      },
+      { status: 503, headers: { 'Retry-After': '5' } }
+    );
+  }
   // Refuse to forward to anything that isn't strictly running. A stopped
   // machine still has runtimeId set (Fly machine IDs persist across stop),
   // and proxying to it triggers Fly Proxy's autostart — which would silently
@@ -774,6 +786,17 @@ async function handleHostBasedRoute(c: Context<AppEnv>): Promise<Response | null
   if (status.status === 'recovering') {
     return c.json({ error: 'Instance is recovering from an unexpected stop' }, 409);
   }
+  // Transient lifecycle states: tell the client to retry rather than
+  // returning a misleading "not running" 409.
+  if (status.status === 'starting' || status.status === 'restarting') {
+    return c.json(
+      {
+        error: 'Instance is starting up',
+        hint: 'The instance is starting. Please retry shortly.',
+      },
+      { status: 503, headers: { 'Retry-After': '5' } }
+    );
+  }
   // See comment on the /i/:instanceId branch above: never forward to a non-
   // running instance, otherwise Fly Proxy autostarts machines we deliberately
   // stopped (billing suspension, manual stop, etc.).
@@ -891,6 +914,16 @@ app.all('*', async c => {
             409
           );
         }
+        // Transient lifecycle states: tell the client to retry.
+        if (instanceStatus.status === 'starting' || instanceStatus.status === 'restarting') {
+          return c.json(
+            {
+              error: 'Instance is starting up',
+              hint: 'The instance is starting. Please retry shortly.',
+            },
+            { status: 503, headers: { 'Retry-After': '5' } }
+          );
+        }
         // Never proxy to a non-running instance: forwarding to a stopped
         // machine triggers Fly Proxy autostart and silently restarts
         // instances suspended for billing/lifecycle reasons.
@@ -978,6 +1011,17 @@ app.all('*', async c => {
         hint: 'Your instance is being recovered after an unexpected stop. Please wait.',
       },
       409
+    );
+  }
+  // Transient lifecycle states: tell the client to retry rather than
+  // surfacing a misleading "not running" 409 while we're actively starting.
+  if (status === 'starting' || status === 'restarting') {
+    return c.json(
+      {
+        error: 'Instance is starting up',
+        hint: 'Your instance is starting. Please retry shortly.',
+      },
+      { status: 503, headers: { 'Retry-After': '5' } }
     );
   }
   // Never proxy to a non-running instance: forwarding to a stopped machine
@@ -1154,6 +1198,16 @@ export default class extends WorkerEntrypoint<KiloClawEnv> {
     );
     if (!status.sandboxId) {
       throw new Error(`Instance for ${label} has no sandboxId`);
+    }
+    // Refuse to deliver chat webhooks to a non-running instance. Issuing
+    // fetch() to {flyAppName}.fly.dev with fly-force-instance-id triggers
+    // Fly Proxy's autostart and silently wakes instances we deliberately
+    // suspended for billing/lifecycle reasons. The chat dispatcher should
+    // surface "recipient unavailable" rather than driving a wake-loop.
+    if (status.status !== 'running') {
+      throw new Error(
+        `Instance for ${label} is not running (status=${status.status ?? 'unknown'})`
+      );
     }
 
     const routingTarget = await withDORetry(

--- a/services/kiloclaw/src/index.ts
+++ b/services/kiloclaw/src/index.ts
@@ -170,6 +170,12 @@ function routingTargetUrl(target: ProviderRoutingTarget, pathname: string, searc
  * still booting. Only the default-personal branch surfaces hints today (tests
  * assert the specific strings); branches that prefer the bare error
  * (`{ "error": "Instance not reachable" }`) just omit them.
+ *
+ * IMPORTANT: this function does NOT gate on instance status. Callers MUST
+ * verify the DO `status` is `'running'` before invoking, otherwise a request
+ * to a stopped machine will trigger Fly Proxy's autostart and silently wake
+ * an instance that we deliberately suspended for billing/lifecycle reasons.
+ * See the `status !== 'running'` checks in each proxy branch.
  */
 async function proxyThroughTarget(opts: {
   request: Request;
@@ -489,6 +495,14 @@ app.all('/i/:instanceId/*', async c => {
   if (status.status === 'recovering') {
     return c.json({ error: 'Instance is recovering from an unexpected stop' }, 409);
   }
+  // Refuse to forward to anything that isn't strictly running. A stopped
+  // machine still has runtimeId set (Fly machine IDs persist across stop),
+  // and proxying to it triggers Fly Proxy's autostart — which would silently
+  // restart instances we deliberately suspended for billing/lifecycle reasons.
+  // The only authorized waker of a stopped instance is an explicit start RPC.
+  if (status.status !== 'running') {
+    return c.json({ error: 'Instance not running', hint: 'Start it from the dashboard.' }, 409);
+  }
   if (!status.runtimeId) {
     return c.json({ error: 'Instance not provisioned' }, 404);
   }
@@ -760,6 +774,12 @@ async function handleHostBasedRoute(c: Context<AppEnv>): Promise<Response | null
   if (status.status === 'recovering') {
     return c.json({ error: 'Instance is recovering from an unexpected stop' }, 409);
   }
+  // See comment on the /i/:instanceId branch above: never forward to a non-
+  // running instance, otherwise Fly Proxy autostarts machines we deliberately
+  // stopped (billing suspension, manual stop, etc.).
+  if (status.status !== 'running') {
+    return c.json({ error: 'Instance not running', hint: 'Start it from the dashboard.' }, 409);
+  }
   if (!status.runtimeId) {
     return c.json({ error: 'Instance not provisioned' }, 404);
   }
@@ -871,6 +891,15 @@ app.all('*', async c => {
             409
           );
         }
+        // Never proxy to a non-running instance: forwarding to a stopped
+        // machine triggers Fly Proxy autostart and silently restarts
+        // instances suspended for billing/lifecycle reasons.
+        if (instanceStatus.status !== 'running') {
+          return c.json(
+            { error: 'Instance not running', hint: 'Start it from the dashboard.' },
+            409
+          );
+        }
         if (!instanceStatus.runtimeId) {
           return c.json(
             { error: 'Instance not provisioned', hint: 'The instance has no running machine.' },
@@ -947,6 +976,19 @@ app.all('*', async c => {
       {
         error: 'Instance is recovering',
         hint: 'Your instance is being recovered after an unexpected stop. Please wait.',
+      },
+      409
+    );
+  }
+  // Never proxy to a non-running instance: forwarding to a stopped machine
+  // triggers Fly Proxy autostart and silently restarts instances we
+  // deliberately suspended for billing/lifecycle reasons. The only
+  // authorized waker of a stopped instance is an explicit start RPC.
+  if (status && status !== 'running') {
+    return c.json(
+      {
+        error: 'Instance not running',
+        hint: 'Start it from the dashboard.',
       },
       409
     );

--- a/services/kiloclaw/src/index.ts
+++ b/services/kiloclaw/src/index.ts
@@ -1167,13 +1167,15 @@ export default class extends WorkerEntrypoint<KiloClawEnv> {
    * See resolveChatWebhookDoKey for the two supported sandboxId formats.
    *
    * Load-bearing error strings: the messages thrown below ("has no sandboxId",
-   * "No routing target", "Webhook forward failed: <status>") are pattern-matched
-   * by `isDefiniteUnreachable` in services/kilo-chat/src/services/bot-status-request.ts
-   * to decide whether to flip a bot to offline immediately. Typed errors don't
-   * survive the Workers RPC boundary, so kilo-chat does substring matching on
-   * `err.message`. If you reword these, update the classifier in lock-step —
-   * otherwise the worst case is degrading to "always transient" (UI shows
-   * stale-online until staleness inference catches up, ~poll interval).
+   * "is not running", "No routing target", "Webhook forward failed: <status>")
+   * are pattern-matched by `isDefiniteUnreachable` in
+   * services/kilo-chat/src/services/bot-status-request.ts to decide whether
+   * to flip a bot to offline immediately. Typed errors don't survive the
+   * Workers RPC boundary, so kilo-chat does substring matching on
+   * `err.message`. If you reword these or add a new pre-flight throw, update
+   * the classifier in lock-step — otherwise the worst case is degrading to
+   * "always transient" (UI shows stale-online until staleness inference
+   * catches up, ~poll interval).
    */
   async deliverChatWebhook(payload: ChatWebhookPayload): Promise<void> {
     const { targetBotId, ...rpcPayload } = payload;


### PR DESCRIPTION
## Summary

A user received the "Your KiloClaw Subscription Has Ended" email many times over the course of a few days. Two bugs combined into a self-sustaining loop:

1. **The Worker proxy could still wake stopped instances.** All four legacy proxy branches (`/i/:instanceId/*`, host-based, cookie-routed, default catch-all) gated on `runtimeId` only, never on `status === 'running'`. A stopped Fly machine retains its `flyMachineId`, so the Worker still forwarded to `{flyAppName}.fly.dev` with `fly-force-instance-id`, which triggers Fly Proxy's autostart and silently woke instances we deliberately suspended for billing reasons. The machine would then wake and the controller would perform its ready checkin. 

2. **`deliverChatWebhook` (the WorkerEntrypoint RPC called by our chat dispatcher was a fifth proxy site with the same bypass** — it issued its own `fetch(targetUrl)` rather than going through `proxyThroughTarget`, so an inbound chat message to a suspended instance also triggered Fly autostart.

3. **`completeAutoResumeIfReady` cleared suspension state for canceled subscriptions.** It treated any non-null `suspended_at` as a pending auto-resume and called `clearAutoResumeState`, which deletes the `claw_suspended_subscription` row from `kiloclaw_email_log` and nulls `suspended_at` / `destruction_deadline`. Per `.specs/kiloclaw-billing.md §1132.1`, auto-resume completion fires only when a subscription transitions to `active`. A `canceled`-and-period-ended subscription never satisfies that, but the readiness callback (fired after the proxy-driven Fly wakeup) was wiping the once-per-lifecycle email-log dedupe gate every cycle.

The fixes:

- Add a strict `status === 'running'` gate to all four proxy branches in `services/kiloclaw/src/index.ts` AND to `deliverChatWebhook`. Anything else returns `409 { error: "Instance not running" }` (chat webhook throws). Document the contract on `proxyThroughTarget` so future contributors don't reintroduce the bypass. The chat-webhook throw is a load-bearing error string pattern-matched by `isDefiniteUnreachable` in `services/kilo-chat`, so this PR also extends that classifier in lock-step (with a regression test) — without it, suspended bots would show stale-online in chat platform UIs until staleness inference catches up.
- Require `subscription.status === 'active'` in `completeAutoResumeIfReady` before invoking `clearAutoResumeState`. Stale ready callbacks for `canceled` or `past_due` subscriptions become no-ops.

No schema, migration, or rollout changes. Both fixes are tightenings of existing checks; no happy-path semantics change.

Spec context: `.specs/kiloclaw-billing.md` Email Notifications §1118.1 ("each notification at most once per user per lifecycle event") and Auto-Resume on Payment Recovery §1132.1 ("transitions to active while the subscription's instance is suspended").

## Verification

- [ ] Local Worker test suite exercises the four 409-on-stopped branches plus the `deliverChatWebhook` stopped-throw case and asserts `fetch` is never called against the Fly target.
- [ ] Local web lifecycle test asserts no clear for `status='canceled'` and `status='past_due'`, and asserts the clear still runs for `status='active'` with pending markers.
- [ ] No end-to-end manual run against a real Fly app; the originally-affected instance is already self-destroyed and reproducing the loop in dev would require a 1+ hour billing-sweep cadence. Post-deploy, query AE for `reconcile.sync_status` events with `status='stopped'` over 24h — should drop to ~0 since nothing is waking stopped machines anymore.
- [ ]

## Visual Changes

N/A

## Reviewer Notes

- **Risk**: a user mid-page-load whose subscription has just expired now sees a 409 from the proxy instead of a slow autostart. The response includes `hint: "Start it from the dashboard."` and the dashboard already shows the stopped state. Previous behavior would have charged Fly for the wake then re-stopped the instance ~1 hour later anyway — net better for the user.
- **Where to focus review**: the four `status !== 'running'` gates in `services/kiloclaw/src/index.ts` (search the diff) plus the `deliverChatWebhook` gate. The default-catch-all branch uses `status && status !== 'running'` to avoid false-positives on the `null` status path that the existing `!runtimeId` 404 already handles; the other three branches read directly from `getStatus()` and use the unconditional form.
- **Cross-service change**: this PR also touches `services/kilo-chat/src/services/bot-status-request.ts` to extend the `isDefiniteUnreachable` classifier with the new `is not running` substring match. The `deliverChatWebhook` doc-comment explicitly requires lock-step updates to that classifier; landing them together avoids a window where chat dispatchers misclassify suspended bots as transient.
- **Pre-existing**: `clearAutoResumeState`'s "no active instance found" branch (`apps/web/src/lib/kiloclaw/instance-lifecycle.ts:330-339`) still wipes `suspended_at` regardless of status when readiness fires for a destroyed instance — different code path, rare in practice. The worker-side `clearAutoResumeState` copy in `services/kiloclaw-billing/src/lifecycle.ts:564-614` is currently safe by call-site invariant (only reachable post-renewal where `status='active'`); documented in deviations log for future readers.
- **Test inversion**: the existing `instance-lifecycle.test.ts:202` test was inverted — previously it asserted that a `canceled`+`suspended_at` subscription triggers `clearAutoResumeState`, which encoded the bug. The replacement asserts the active-recovery case, plus two new cases (canceled no-clear, past_due no-clear).
