### PR TITLE
feat(kiloclaw): advertise controller capabilities

### DIFF
--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -588,9 +588,27 @@ The response fields are:
 | `commit`          | string         | Yes      | Controller build commit hash                                                       |
 | `openclawVersion` | string \| null | Yes      | Installed openclaw version                                                         |
 | `openclawCommit`  | string \| null | Yes      | Installed openclaw commit hash                                                     |
+| `apiVersion`      | number         | No       | Controller response/protocol envelope shape version                                |
+| `capabilities`    | string[]       | No       | Sorted capability hints for controller routes/behaviors registered in this build   |
 | `gateway`         | object \| null | Yes      | Supervisor stats (same as `/_kilo/gateway/status`), null if supervisor not created |
 | `controllerState` | object         | No       | Current controller lifecycle state, present when state ref is wired                |
 | `kiloChatHealth`  | object         | No       | Kilo Chat health probe summary, present when Kilo Chat probing is active           |
+
+Version capability hint rules:
+
+1. `apiVersion`, when present, describes the version response/protocol
+   envelope shape only. It MUST NOT be used as the sole proof that a
+   specific endpoint exists when a named capability is available.
+2. `capabilities`, when present, MUST be a sorted, duplicate-free array
+   of stable lowercase dot/kebab strings.
+3. A capability MUST only be advertised when the corresponding route or
+   behavior is registered in the running controller build.
+4. Capability hints are advisory. Clients MUST keep normal mutation-time
+   handling for old routes, auth failures, validation failures,
+   conflicts, and runtime errors.
+5. Missing `capabilities` on a controller with a non-null version means
+   capability support is unknown and SHOULD fail closed for newly
+   capability-gated features.
 
 #### Gateway (bearer token)
 
@@ -690,6 +708,7 @@ running. When forwarding, it MUST authenticate to gog with
 | POST   | `/_kilo/morning-briefing/disable`        | Disable the morning briefing schedule |
 | POST   | `/_kilo/morning-briefing/run`            | Run briefing generation immediately   |
 | POST   | `/_kilo/morning-briefing/interests`      | Update briefing interest topics       |
+| POST   | `/_kilo/morning-briefing/user-location`  | Update briefing user location         |
 | GET    | `/_kilo/morning-briefing/read/today`     | Read today's briefing markdown        |
 | GET    | `/_kilo/morning-briefing/read/yesterday` | Read yesterday's briefing markdown    |
 
@@ -718,6 +737,8 @@ per-sandbox gateway token.
 | GET    | `/_kilo/kilo-chat/conversations/:conversationId/members`                             | List conversation members       |
 | POST   | `/_kilo/kilo-chat/conversations/:conversationId/messages/:messageId/delivery-failed` | Report message delivery failure |
 | POST   | `/_kilo/kilo-chat/conversations/:conversationId/actions/:groupId/delivery-failed`    | Report action delivery failure  |
+| POST   | `/_kilo/kilo-chat/attachments/init`                                                  | Initialize an attachment upload |
+| GET    | `/_kilo/kilo-chat/attachments/:attachmentId/url`                                     | Resolve an attachment URL       |
 
 #### Catch-All Proxy (proxy token)
 

--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -599,8 +599,10 @@ Version capability hint rules:
 1. `apiVersion`, when present, describes the version response/protocol
    envelope shape only. It MUST NOT be used as the sole proof that a
    specific endpoint exists when a named capability is available.
-2. `capabilities`, when present, MUST be a sorted, duplicate-free array
-   of stable lowercase dot/kebab strings.
+2. `capabilities`, when present, MUST be sorted in ascending ASCII
+   lexicographic order by stable lowercase dot/kebab capability string
+   and MUST be duplicate-free. Clients MUST treat the array as a set;
+   ordering is canonicalization only and carries no feature semantics.
 3. Capability names MUST be derived from the controller behavior they
    expose, not from UI labels or release names. Names MUST use dots to
    separate stable resource/behavior hierarchy and kebab-case inside a

--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -601,12 +601,33 @@ Version capability hint rules:
    specific endpoint exists when a named capability is available.
 2. `capabilities`, when present, MUST be a sorted, duplicate-free array
    of stable lowercase dot/kebab strings.
-3. A capability MUST only be advertised when the corresponding route or
+3. Capability names MUST be derived from the controller behavior they
+   expose, not from UI labels or release names. Names MUST use dots to
+   separate stable resource/behavior hierarchy and kebab-case inside a
+   segment when a concept is multiple words. For route-backed
+   capabilities, derive the leading segments from the `/_kilo/` route
+   namespace and the final segment from the operation or behavior. For
+   example: `/_kilo/config/read` -> `config.read`,
+   `/_kilo/config/tools-md/google-workspace` ->
+   `config.tools-md.google-workspace`,
+   `/_kilo/morning-briefing/interests` ->
+   `morning-briefing.interests`, and the Kilo Chat attachment routes ->
+   `kilo-chat.attachments`.
+4. A capability MAY cover multiple routes only when those routes are one
+   inseparable behavior for clients, such as start/status/cancel for one
+   async operation or init/url routes for one attachment flow. It MUST NOT
+   combine independent read, update, create, repair, or delete behaviors
+   under one broad name when clients may need to gate those behaviors
+   separately.
+5. Capability names MUST be additive and stable. Renaming or removing a
+   capability is a breaking behavior change; add a new capability instead
+   when a new implementation has meaningfully different semantics.
+6. A capability MUST only be advertised when the corresponding route or
    behavior is registered in the running controller build.
-4. Capability hints are advisory. Clients MUST keep normal mutation-time
+7. Capability hints are advisory. Clients MUST keep normal mutation-time
    handling for old routes, auth failures, validation failures,
    conflicts, and runtime errors.
-5. Missing `capabilities` on a controller with a non-null version means
+8. Missing `capabilities` on a controller with a non-null version means
    capability support is unknown and SHOULD fail closed for newly
    capability-gated features.
 

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -514,6 +514,8 @@ export type ControllerVersionResponse =
       commit: string | null;
       openclawVersion?: string | null;
       openclawCommit?: string | null;
+      apiVersion?: number;
+      capabilities?: string[];
     }
   | InstanceNotRunningSentinel;
 

--- a/services/kiloclaw/controller/src/endpoint-capabilities.test.ts
+++ b/services/kiloclaw/controller/src/endpoint-capabilities.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONTROLLER_ENDPOINT_CAPABILITIES,
+  KILO_CHAT_ENDPOINT_CAPABILITIES,
+  getControllerEndpointCapabilities,
+} from './endpoint-capabilities';
+
+describe('getControllerEndpointCapabilities', () => {
+  it('returns sorted unique capabilities', () => {
+    const capabilities = getControllerEndpointCapabilities();
+
+    expect(capabilities).toEqual([...capabilities].sort());
+    expect(capabilities).toHaveLength(new Set(capabilities).size);
+    expect(capabilities).toEqual([...new Set(CONTROLLER_ENDPOINT_CAPABILITIES)].sort());
+  });
+
+  it('includes conditional Kilo Chat capabilities only when requested', () => {
+    const defaultCapabilities = getControllerEndpointCapabilities();
+    const kiloChatCapabilities = getControllerEndpointCapabilities({
+      includeKiloChatCapabilities: true,
+    });
+
+    expect(defaultCapabilities).not.toContain('kilo-chat.attachments');
+    for (const capability of KILO_CHAT_ENDPOINT_CAPABILITIES) {
+      expect(kiloChatCapabilities).toContain(capability);
+    }
+    expect(kiloChatCapabilities).toEqual([...kiloChatCapabilities].sort());
+    expect(kiloChatCapabilities).toHaveLength(new Set(kiloChatCapabilities).size);
+  });
+});

--- a/services/kiloclaw/controller/src/endpoint-capabilities.test.ts
+++ b/services/kiloclaw/controller/src/endpoint-capabilities.test.ts
@@ -5,6 +5,8 @@ import {
   getControllerEndpointCapabilities,
 } from './endpoint-capabilities';
 
+const CAPABILITY_NAME_PATTERN = /^[a-z][a-z0-9]*(?:[.-][a-z][a-z0-9]*)*$/;
+
 describe('getControllerEndpointCapabilities', () => {
   it('returns sorted unique capabilities', () => {
     const capabilities = getControllerEndpointCapabilities();
@@ -26,5 +28,14 @@ describe('getControllerEndpointCapabilities', () => {
     }
     expect(kiloChatCapabilities).toEqual([...kiloChatCapabilities].sort());
     expect(kiloChatCapabilities).toHaveLength(new Set(kiloChatCapabilities).size);
+  });
+
+  it('only contains names accepted by the Worker schema', () => {
+    for (const capability of [
+      ...CONTROLLER_ENDPOINT_CAPABILITIES,
+      ...KILO_CHAT_ENDPOINT_CAPABILITIES,
+    ]) {
+      expect(capability).toMatch(CAPABILITY_NAME_PATTERN);
+    }
   });
 });

--- a/services/kiloclaw/controller/src/endpoint-capabilities.ts
+++ b/services/kiloclaw/controller/src/endpoint-capabilities.ts
@@ -1,0 +1,60 @@
+export const CONTROLLER_API_VERSION = 1;
+
+export const CONTROLLER_ENDPOINT_CAPABILITIES = [
+  'config.read',
+  'config.restore',
+  'config.replace',
+  'config.patch',
+  'config.tools-md.google-workspace',
+  'env.patch',
+  'doctor.run',
+  'kilo-cli.run',
+  'files.tree',
+  'files.read',
+  'files.write',
+  'files.import-openclaw-workspace',
+  'profile.bot-identity',
+  'profile.user-profile',
+  'gateway.lifecycle',
+  'gateway.ready',
+  'morning-briefing.status',
+  'morning-briefing.actions',
+  'morning-briefing.interests',
+  'morning-briefing.user-location',
+  'morning-briefing.read',
+  'pairing.channels',
+  'pairing.devices',
+  'google-oauth.token',
+  'google-oauth.status',
+  'gmail.pubsub',
+  'hooks.email',
+] as const;
+
+export const KILO_CHAT_ENDPOINT_CAPABILITIES = [
+  'kilo-chat.messages.send',
+  'kilo-chat.messages.update',
+  'kilo-chat.messages.delete',
+  'kilo-chat.messages.reactions',
+  'kilo-chat.typing',
+  'kilo-chat.conversations.read',
+  'kilo-chat.conversations.create',
+  'kilo-chat.conversations.update',
+  'kilo-chat.conversations.members.read',
+  'kilo-chat.bot-status.update',
+  'kilo-chat.conversation-status.update',
+  'kilo-chat.delivery-failed',
+  'kilo-chat.attachments',
+] as const;
+
+export type ControllerEndpointCapability =
+  | (typeof CONTROLLER_ENDPOINT_CAPABILITIES)[number]
+  | (typeof KILO_CHAT_ENDPOINT_CAPABILITIES)[number];
+
+export function getControllerEndpointCapabilities(options?: {
+  includeKiloChatCapabilities?: boolean;
+}): string[] {
+  const capabilities = options?.includeKiloChatCapabilities
+    ? [...CONTROLLER_ENDPOINT_CAPABILITIES, ...KILO_CHAT_ENDPOINT_CAPABILITIES]
+    : CONTROLLER_ENDPOINT_CAPABILITIES;
+  return [...new Set(capabilities)].sort();
+}

--- a/services/kiloclaw/controller/src/endpoint-capabilities.ts
+++ b/services/kiloclaw/controller/src/endpoint-capabilities.ts
@@ -52,9 +52,9 @@ export type ControllerEndpointCapability =
 
 export function getControllerEndpointCapabilities(options?: {
   includeKiloChatCapabilities?: boolean;
-}): string[] {
+}): ControllerEndpointCapability[] {
   const capabilities = options?.includeKiloChatCapabilities
     ? [...CONTROLLER_ENDPOINT_CAPABILITIES, ...KILO_CHAT_ENDPOINT_CAPABILITIES]
     : CONTROLLER_ENDPOINT_CAPABILITIES;
-  return [...new Set(capabilities)].sort();
+  return [...new Set<ControllerEndpointCapability>(capabilities)].sort();
 }

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -422,8 +422,10 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
   // kilo-chat channel: the controller forwards its own per-sandbox gateway
   // token directly to the kilo-chat Worker. No kiloclaw Worker middleman.
   let kiloChatHealthProbe: KiloChatHealthProbe | undefined;
+  let includeKiloChatCapabilities = false;
   const kiloChatBaseUrl = env.KILOCHAT_BASE_URL || undefined;
   if (env.KILOCLAW_SANDBOX_ID && kiloChatBaseUrl) {
+    includeKiloChatCapabilities = true;
     kiloChatHealthProbe = startKiloChatHealthProbe({ kiloChatBaseUrl });
     const kiloChatOpts = {
       expectedToken: config.expectedToken,
@@ -459,7 +461,8 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     supervisor,
     config.expectedToken,
     controllerState,
-    kiloChatHealthProbe
+    kiloChatHealthProbe,
+    { includeKiloChatCapabilities }
   );
   registerGatewayRoutes(honoApp, supervisor, config.expectedToken);
   registerMorningBriefingRoutes(honoApp, supervisor, config.expectedToken);

--- a/services/kiloclaw/controller/src/routes/health.test.ts
+++ b/services/kiloclaw/controller/src/routes/health.test.ts
@@ -208,6 +208,7 @@ describe('GET /_kilo/version', () => {
     expect(body.commit).toBe('unknown');
     expect(body.apiVersion).toBe(CONTROLLER_API_VERSION);
     expect(body.capabilities).toEqual(getControllerEndpointCapabilities());
+    expect(body.capabilities).not.toContain('kilo-chat.attachments');
     expect(body.gateway).toEqual(MOCK_STATS);
     expect(body.controllerState).toEqual({ state: 'ready' });
   });

--- a/services/kiloclaw/controller/src/routes/health.test.ts
+++ b/services/kiloclaw/controller/src/routes/health.test.ts
@@ -4,6 +4,10 @@ import { registerHealthRoute, parseOpenclawVersion, startKiloChatHealthProbe } f
 import type { KiloChatHealthProbe } from './health';
 import type { Supervisor } from '../supervisor';
 import type { ControllerStateRef } from '../bootstrap';
+import {
+  CONTROLLER_API_VERSION,
+  getControllerEndpointCapabilities,
+} from '../endpoint-capabilities';
 
 const MOCK_STATS = {
   state: 'running' as const,
@@ -195,11 +199,15 @@ describe('GET /_kilo/version', () => {
     const body = (await resp.json()) as {
       version: string;
       commit: string;
+      apiVersion: number;
+      capabilities: string[];
       gateway: typeof MOCK_STATS;
       controllerState: { state: string };
     };
     expect(body.version).toBe('dev');
     expect(body.commit).toBe('unknown');
+    expect(body.apiVersion).toBe(CONTROLLER_API_VERSION);
+    expect(body.capabilities).toEqual(getControllerEndpointCapabilities());
     expect(body.gateway).toEqual(MOCK_STATS);
     expect(body.controllerState).toEqual({ state: 'ready' });
   });
@@ -256,6 +264,19 @@ describe('GET /_kilo/version', () => {
 
     const body = (await resp.json()) as { gateway: null };
     expect(body.gateway).toBeNull();
+  });
+
+  it('includes Kilo Chat capabilities only when the route set is registered', async () => {
+    const app = new Hono();
+    registerHealthRoute(app, null, undefined, undefined, undefined, {
+      includeKiloChatCapabilities: true,
+    });
+
+    const resp = await app.request('/_kilo/version');
+    expect(resp.status).toBe(200);
+
+    const body = (await resp.json()) as { capabilities: string[] };
+    expect(body.capabilities).toContain('kilo-chat.attachments');
   });
 });
 

--- a/services/kiloclaw/controller/src/routes/health.ts
+++ b/services/kiloclaw/controller/src/routes/health.ts
@@ -5,6 +5,10 @@ import type { ControllerStateRef } from '../bootstrap';
 import { CONTROLLER_COMMIT, CONTROLLER_VERSION } from '../version';
 import { getBearerToken } from './gateway';
 import { getOpenclawVersion } from '../openclaw-version';
+import {
+  CONTROLLER_API_VERSION,
+  getControllerEndpointCapabilities,
+} from '../endpoint-capabilities';
 
 export { parseOpenclawVersion } from '../openclaw-version';
 
@@ -73,7 +77,8 @@ export function registerHealthRoute(
   supervisor: Supervisor | null,
   expectedToken?: string,
   stateRef?: ControllerStateRef,
-  kiloChatHealth?: KiloChatHealthProbe
+  kiloChatHealth?: KiloChatHealthProbe,
+  options?: { includeKiloChatCapabilities?: boolean }
 ): void {
   // Eagerly resolve so the first /_kilo/version request doesn't wait on the subprocess.
   void getOpenclawVersion();
@@ -112,6 +117,8 @@ export function registerHealthRoute(
     return c.json({
       version: CONTROLLER_VERSION,
       commit: CONTROLLER_COMMIT,
+      apiVersion: CONTROLLER_API_VERSION,
+      capabilities: getControllerEndpointCapabilities(options),
       openclawVersion: openclaw.version,
       openclawCommit: openclaw.commit,
       gateway: supervisor?.getStats() ?? null,

--- a/services/kiloclaw/src/durable-objects/gateway-controller-types.test.ts
+++ b/services/kiloclaw/src/durable-objects/gateway-controller-types.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { ControllerVersionResponseSchema } from './gateway-controller-types';
+
+describe('ControllerVersionResponseSchema', () => {
+  it('accepts legacy version responses without capability hints', () => {
+    expect(
+      ControllerVersionResponseSchema.parse({
+        version: '2026.5.20.1200',
+        commit: 'abc123',
+        openclawVersion: null,
+        openclawCommit: null,
+      })
+    ).toEqual({
+      version: '2026.5.20.1200',
+      commit: 'abc123',
+      openclawVersion: null,
+      openclawCommit: null,
+    });
+  });
+
+  it('accepts version responses with api version and capability hints', () => {
+    expect(
+      ControllerVersionResponseSchema.parse({
+        version: '2026.5.20.1200',
+        commit: 'abc123',
+        apiVersion: 1,
+        capabilities: ['config.read', 'files.import-openclaw-workspace', 'kilo-cli.run'],
+      })
+    ).toEqual({
+      version: '2026.5.20.1200',
+      commit: 'abc123',
+      apiVersion: 1,
+      capabilities: ['config.read', 'files.import-openclaw-workspace', 'kilo-cli.run'],
+    });
+  });
+
+  it('rejects malformed capability names', () => {
+    const result = ControllerVersionResponseSchema.safeParse({
+      version: '2026.5.20.1200',
+      commit: 'abc123',
+      capabilities: ['Config.Read'],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unsorted capability names', () => {
+    const result = ControllerVersionResponseSchema.safeParse({
+      version: '2026.5.20.1200',
+      commit: 'abc123',
+      capabilities: ['kilo-cli.run', 'config.read'],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects duplicate capability names', () => {
+    const result = ControllerVersionResponseSchema.safeParse({
+      version: '2026.5.20.1200',
+      commit: 'abc123',
+      capabilities: ['config.read', 'config.read'],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
+++ b/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
@@ -58,6 +58,18 @@ export const ControllerVersionResponseSchema = z.object({
   // optional() for backward compat with older controllers that don't include these fields
   openclawVersion: z.string().nullable().optional(),
   openclawCommit: z.string().nullable().optional(),
+  apiVersion: z.number().int().positive().optional(),
+  capabilities: z
+    .array(z.string().regex(/^[a-z][a-z0-9]*(?:[.-][a-z][a-z0-9]*)*$/))
+    .refine(
+      capabilities =>
+        capabilities.every((capability, index) => {
+          if (index === 0) return true;
+          return capabilities[index - 1] < capability;
+        }),
+      { message: 'Capabilities must be sorted and unique' }
+    )
+    .optional(),
 });
 
 export type ControllerHealthResponse = {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -300,6 +300,9 @@ export async function getControllerVersion(
   version: string;
   commit: string;
   openclawVersion?: string | null;
+  openclawCommit?: string | null;
+  apiVersion?: number;
+  capabilities?: string[];
 } | null> {
   try {
     return await callGatewayController(

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -3712,6 +3712,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     version: string;
     commit: string;
     openclawVersion?: string | null;
+    openclawCommit?: string | null;
+    apiVersion?: number;
+    capabilities?: string[];
   } | null> {
     await this.loadState();
     return gateway.getControllerVersion(this.s, this.env);


### PR DESCRIPTION
## Summary

- Add an explicit controller capability contract to `GET /_kilo/version` with `apiVersion` and sorted `capabilities`.
- Thread the optional capability fields through the Worker schema, Instance DO return types, platform response, and web API type.
- Add a controller endpoint capability registry, including conditional Kilo Chat capabilities only when Kilo Chat routes are registered.
- Update the KiloClaw controller spec so capability hints are documented as advisory route/behavior support, not mutation-time guarantees.

## Verification

- Manual verification was not performed; this is a controller/API contract and schema-threading change with no UI behavior changes.
- [ ] Add any additional manual verification details before merge.

## Visual Changes

N/A

## Reviewer Notes

- Existing CalVer-gated UI behavior is intentionally unchanged.
- Old controllers remain compatible because `apiVersion` and `capabilities` are optional.
- Worker validation now rejects malformed, duplicate, or unsorted capability arrays.
- Capability hints are advisory; future mutation paths still need old-controller and runtime fallback handling.