### PR TITLE
CloudAgent - Gate Dev Container Sessions With Release Toggle

### DIFF
--- a/apps/web/src/app/(app)/cloud/(agent)/page.tsx
+++ b/apps/web/src/app/(app)/cloud/(agent)/page.tsx
@@ -1,5 +1,5 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
-import { isFeatureFlagEnabled, isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { NewSessionPanel } from '@/components/cloud-agent-next/NewSessionPanel';
 import { CloudSessionsPage } from '@/components/cloud-agent/CloudSessionsPage';
 
@@ -8,7 +8,7 @@ export default async function PersonalCloudPage() {
   const isDevelopment = process.env.NODE_ENV === 'development';
   const useNextAgent = isDevelopment || (await isFeatureFlagEnabled('cloud-agent-next', user.id));
   const isDevcontainerAvailable =
-    isDevelopment || (await isReleaseToggleEnabled('cloud-agent-devcontainer', user.id));
+    isDevelopment || (await isFeatureFlagEnabled('cloud-agent-devcontainer', user.id));
 
   if (useNextAgent) {
     return <NewSessionPanel isDevcontainerAvailable={isDevcontainerAvailable} />;

--- a/apps/web/src/app/(app)/cloud/(agent)/page.tsx
+++ b/apps/web/src/app/(app)/cloud/(agent)/page.tsx
@@ -1,5 +1,5 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled, isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
 import { NewSessionPanel } from '@/components/cloud-agent-next/NewSessionPanel';
 import { CloudSessionsPage } from '@/components/cloud-agent/CloudSessionsPage';
 
@@ -7,9 +7,11 @@ export default async function PersonalCloudPage() {
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/cloud');
   const isDevelopment = process.env.NODE_ENV === 'development';
   const useNextAgent = isDevelopment || (await isFeatureFlagEnabled('cloud-agent-next', user.id));
+  const isDevcontainerAvailable =
+    isDevelopment || (await isReleaseToggleEnabled('cloud-agent-devcontainer', user.id));
 
   if (useNextAgent) {
-    return <NewSessionPanel />;
+    return <NewSessionPanel isDevcontainerAvailable={isDevcontainerAvailable} />;
   }
 
   return <CloudSessionsPage />;

--- a/apps/web/src/app/(app)/cloud/(agent)/page.tsx
+++ b/apps/web/src/app/(app)/cloud/(agent)/page.tsx
@@ -1,12 +1,13 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabledOrDevelopment } from '@/lib/posthog-feature-flags';
 import { NewSessionPanel } from '@/components/cloud-agent-next/NewSessionPanel';
 
 export default async function PersonalCloudPage() {
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/cloud');
-  const isDevelopment = process.env.NODE_ENV === 'development';
-  const isDevcontainerAvailable =
-    isDevelopment || (await isFeatureFlagEnabled('cloud-agent-devcontainer', user.id));
+  const isDevcontainerAvailable = await isFeatureFlagEnabledOrDevelopment(
+    'cloud-agent-devcontainer',
+    user.id
+  );
 
   return <NewSessionPanel isDevcontainerAvailable={isDevcontainerAvailable} />;
 }

--- a/apps/web/src/app/(app)/cloud/(agent)/page.tsx
+++ b/apps/web/src/app/(app)/cloud/(agent)/page.tsx
@@ -1,18 +1,12 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { NewSessionPanel } from '@/components/cloud-agent-next/NewSessionPanel';
-import { CloudSessionsPage } from '@/components/cloud-agent/CloudSessionsPage';
 
 export default async function PersonalCloudPage() {
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/cloud');
   const isDevelopment = process.env.NODE_ENV === 'development';
-  const useNextAgent = isDevelopment || (await isFeatureFlagEnabled('cloud-agent-next', user.id));
   const isDevcontainerAvailable =
     isDevelopment || (await isFeatureFlagEnabled('cloud-agent-devcontainer', user.id));
 
-  if (useNextAgent) {
-    return <NewSessionPanel isDevcontainerAvailable={isDevcontainerAvailable} />;
-  }
-
-  return <CloudSessionsPage />;
+  return <NewSessionPanel isDevcontainerAvailable={isDevcontainerAvailable} />;
 }

--- a/apps/web/src/app/(app)/organizations/[id]/cloud/(agent)/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/cloud/(agent)/page.tsx
@@ -1,6 +1,6 @@
 import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
-import { isFeatureFlagEnabled, isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { NewSessionPanel } from '@/components/cloud-agent-next/NewSessionPanel';
 import { CloudSessionsPage } from '@/components/cloud-agent/CloudSessionsPage';
 
@@ -17,7 +17,7 @@ export default async function OrganizationCloudPage({
   const isDevelopment = process.env.NODE_ENV === 'development';
   const useNextAgent = isDevelopment || (await isFeatureFlagEnabled('cloud-agent-next', user.id));
   const isDevcontainerAvailable =
-    isDevelopment || (await isReleaseToggleEnabled('cloud-agent-devcontainer', user.id));
+    isDevelopment || (await isFeatureFlagEnabled('cloud-agent-devcontainer', user.id));
 
   return (
     <OrganizationByPageLayout

--- a/apps/web/src/app/(app)/organizations/[id]/cloud/(agent)/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/cloud/(agent)/page.tsx
@@ -1,6 +1,6 @@
 import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled, isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
 import { NewSessionPanel } from '@/components/cloud-agent-next/NewSessionPanel';
 import { CloudSessionsPage } from '@/components/cloud-agent/CloudSessionsPage';
 
@@ -16,13 +16,18 @@ export default async function OrganizationCloudPage({
   );
   const isDevelopment = process.env.NODE_ENV === 'development';
   const useNextAgent = isDevelopment || (await isFeatureFlagEnabled('cloud-agent-next', user.id));
+  const isDevcontainerAvailable =
+    isDevelopment || (await isReleaseToggleEnabled('cloud-agent-devcontainer', user.id));
 
   return (
     <OrganizationByPageLayout
       params={params}
       render={({ organization }) =>
         useNextAgent ? (
-          <NewSessionPanel organizationId={organization.id} />
+          <NewSessionPanel
+            organizationId={organization.id}
+            isDevcontainerAvailable={isDevcontainerAvailable}
+          />
         ) : (
           <CloudSessionsPage organizationId={organization.id} />
         )

--- a/apps/web/src/app/(app)/organizations/[id]/cloud/(agent)/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/cloud/(agent)/page.tsx
@@ -2,7 +2,6 @@ import { OrganizationByPageLayout } from '@/components/organizations/Organizatio
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { NewSessionPanel } from '@/components/cloud-agent-next/NewSessionPanel';
-import { CloudSessionsPage } from '@/components/cloud-agent/CloudSessionsPage';
 
 export default async function OrganizationCloudPage({
   params,
@@ -15,23 +14,18 @@ export default async function OrganizationCloudPage({
     `/users/sign_in?callbackPath=${encodeURIComponent(`/organizations/${organizationId}/cloud`)}`
   );
   const isDevelopment = process.env.NODE_ENV === 'development';
-  const useNextAgent = isDevelopment || (await isFeatureFlagEnabled('cloud-agent-next', user.id));
   const isDevcontainerAvailable =
     isDevelopment || (await isFeatureFlagEnabled('cloud-agent-devcontainer', user.id));
 
   return (
     <OrganizationByPageLayout
       params={params}
-      render={({ organization }) =>
-        useNextAgent ? (
-          <NewSessionPanel
-            organizationId={organization.id}
-            isDevcontainerAvailable={isDevcontainerAvailable}
-          />
-        ) : (
-          <CloudSessionsPage organizationId={organization.id} />
-        )
-      }
+      render={({ organization }) => (
+        <NewSessionPanel
+          organizationId={organization.id}
+          isDevcontainerAvailable={isDevcontainerAvailable}
+        />
+      )}
     />
   );
 }

--- a/apps/web/src/app/(app)/organizations/[id]/cloud/(agent)/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/cloud/(agent)/page.tsx
@@ -1,6 +1,6 @@
 import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabledOrDevelopment } from '@/lib/posthog-feature-flags';
 import { NewSessionPanel } from '@/components/cloud-agent-next/NewSessionPanel';
 
 export default async function OrganizationCloudPage({
@@ -13,9 +13,10 @@ export default async function OrganizationCloudPage({
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=${encodeURIComponent(`/organizations/${organizationId}/cloud`)}`
   );
-  const isDevelopment = process.env.NODE_ENV === 'development';
-  const isDevcontainerAvailable =
-    isDevelopment || (await isFeatureFlagEnabled('cloud-agent-devcontainer', user.id));
+  const isDevcontainerAvailable = await isFeatureFlagEnabledOrDevelopment(
+    'cloud-agent-devcontainer',
+    user.id
+  );
 
   return (
     <OrganizationByPageLayout

--- a/apps/web/src/app/(app)/organizations/[id]/cloud/(agent)/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/cloud/(agent)/page.tsx
@@ -10,12 +10,12 @@ export default async function OrganizationCloudPage({
 }) {
   const { id } = await params;
   const organizationId = decodeURIComponent(id);
-  const user = await getUserFromAuthOrRedirect(
+  await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=${encodeURIComponent(`/organizations/${organizationId}/cloud`)}`
   );
   const isDevcontainerAvailable = await isFeatureFlagEnabledOrDevelopment(
     'cloud-agent-devcontainer',
-    user.id
+    organizationId
   );
 
   return (

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
 import { useAtom, useSetAtom } from 'jotai';
 import { toast } from 'sonner';
 import {
@@ -49,7 +48,6 @@ import { VariantCombobox } from '@/components/shared/VariantCombobox';
 import { thinkingEffortLabel } from '@/lib/code-reviews/core/model-variants';
 import { InsufficientBalanceBanner } from '@/components/shared/InsufficientBalanceBanner';
 import { ProfilePickerPopover } from '@/components/cloud-agent/ProfilePickerPopover';
-import { Switch } from '@/components/ui/switch';
 import { Popover, PopoverContent, PopoverTrigger, PopoverAnchor } from '@/components/ui/popover';
 import {
   Command as UICommand,
@@ -81,10 +79,12 @@ import {
   CLOUD_AGENT_PROMPT_MAX_LENGTH,
 } from '@/lib/cloud-agent/constants';
 import {
+  getDevcontainerEnabled,
   getLastUsedModel,
   getLastUsedVariant,
   getPreferredInitialModel,
   getPreferredInitialVariant,
+  setDevcontainerEnabled,
   setLastUsedModel,
   setLastUsedVariant,
 } from '@/components/cloud-agent-next/model-preferences';
@@ -98,9 +98,10 @@ type Repository = {
 
 type NewSessionPanelProps = {
   organizationId?: string;
+  isDevcontainerAvailable: boolean;
 };
 
-export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
+export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: NewSessionPanelProps) {
   const router = useRouter();
   const trpc = useTRPC();
   const trpcClient = useRawTRPCClient();
@@ -108,8 +109,6 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const commandListRef = useRef<HTMLDivElement>(null);
-  const { data: session } = useSession();
-  const isAdmin = session?.isAdmin === true;
   const [devcontainer, setDevcontainer] = useState(false);
   const { mutateAsync: personalUploadUrl } = useMutation(
     trpc.cloudAgentNext.getImageUploadUrl.mutationOptions()
@@ -196,6 +195,16 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
     resetSessionForm();
   }, [resetSessionForm]);
 
+  useEffect(() => {
+    setDevcontainer(getDevcontainerEnabled());
+  }, []);
+
+  const handleDevcontainerChange = useCallback((enabled: boolean) => {
+    setDevcontainer(enabled);
+    setDevcontainerEnabled(enabled);
+  }, []);
+
+  const effectiveDevcontainer = isDevcontainerAvailable && devcontainer;
   const availableVariants = modelOptions.find(m => m.id === model)?.variants ?? [];
 
   // ---------------------------------------------------------------------------
@@ -688,7 +697,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
               },
             }
           : {}),
-        ...(devcontainer ? { devcontainer: true } : {}),
+        ...(effectiveDevcontainer ? { devcontainer: true } : {}),
       };
       let result: { kiloSessionId: string; cloudAgentSessionId: string };
 
@@ -748,7 +757,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
       setIsPreparing(false);
     }
   }, [
-    devcontainer,
+    effectiveDevcontainer,
     imageUpload,
     displayModel,
     // `displayVariant` is what we actually submit; raw `variant` is only read
@@ -1233,39 +1242,30 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
             </PopoverContent>
           </Popover>
 
-          {/* Profile chip — bottom right */}
-          <ProfilePickerPopover
-            organizationId={organizationId}
-            selectedOverrideProfileId={selectedProfileId}
-            onOverrideProfileSelect={setSelectedProfileId}
-            repoFullName={selectedRepo || undefined}
-            platform={selectedPlatform}
-          />
-        </div>
-        {isAdmin && (
-          <div className="flex justify-end">
-            <div className={cn('flex items-center gap-2', isPreparing && 'opacity-70')}>
-              <div className="min-w-0 text-right">
-                <label
-                  htmlFor="devcontainer"
-                  className="block cursor-pointer text-xs leading-none font-medium"
-                >
-                  Dev container support
-                </label>
-                <p id="devcontainer-description" className="text-muted-foreground mt-1 text-xs">
-                  Experimental. Turn on for this session.
-                </p>
-              </div>
-              <Switch
-                id="devcontainer"
-                checked={devcontainer}
-                onCheckedChange={setDevcontainer}
-                disabled={isPreparing}
-                aria-describedby="devcontainer-description"
-              />
-            </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {effectiveDevcontainer && (
+              <span className="text-muted-foreground inline-flex shrink-0 items-center rounded-md border border-border/50 bg-muted/30 px-2 py-1 text-xs">
+                Dev container on
+              </span>
+            )}
+            <ProfilePickerPopover
+              organizationId={organizationId}
+              selectedOverrideProfileId={selectedProfileId}
+              onOverrideProfileSelect={setSelectedProfileId}
+              repoFullName={selectedRepo || undefined}
+              platform={selectedPlatform}
+              devcontainerToggle={
+                isDevcontainerAvailable
+                  ? {
+                      checked: effectiveDevcontainer,
+                      disabled: isPreparing,
+                      onCheckedChange: handleDevcontainerChange,
+                    }
+                  : undefined
+              }
+            />
           </div>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/cloud-agent-next/model-preferences.test.ts
+++ b/apps/web/src/components/cloud-agent-next/model-preferences.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
 import {
+  getDevcontainerEnabledStorageKey,
   getLastUsedModelStorageKey,
   getLastUsedVariantsStorageKey,
   getPreferredInitialModel,
   getPreferredInitialVariant,
+  parseDevcontainerEnabled,
 } from './model-preferences';
 import type { ModelOption } from '@/components/shared/ModelCombobox';
 
@@ -69,6 +71,19 @@ describe('getLastUsedVariantsStorageKey', () => {
     expect(getLastUsedVariantsStorageKey('org_123')).toBe(
       'cloud-agent:last-used-variants:organization:org_123'
     );
+  });
+});
+
+describe('devcontainer preference', () => {
+  it('uses one browser-wide storage key', () => {
+    expect(getDevcontainerEnabledStorageKey()).toBe('cloud-agent:devcontainer-enabled');
+  });
+
+  it('enables only the stored boolean true value', () => {
+    expect(parseDevcontainerEnabled('true')).toBe(true);
+    expect(parseDevcontainerEnabled('false')).toBe(false);
+    expect(parseDevcontainerEnabled('1')).toBe(false);
+    expect(parseDevcontainerEnabled(null)).toBe(false);
   });
 });
 

--- a/apps/web/src/components/cloud-agent-next/model-preferences.ts
+++ b/apps/web/src/components/cloud-agent-next/model-preferences.ts
@@ -3,6 +3,7 @@ import type { ModelOption } from '@/components/shared/ModelCombobox';
 
 const MODEL_STORAGE_KEY_PREFIX = 'cloud-agent:last-used-model';
 const VARIANTS_STORAGE_KEY_PREFIX = 'cloud-agent:last-used-variants';
+const DEVCONTAINER_ENABLED_STORAGE_KEY = 'cloud-agent:devcontainer-enabled';
 
 export function getLastUsedModelStorageKey(organizationId?: string) {
   return organizationId
@@ -16,6 +17,22 @@ export function getLastUsedModel(organizationId?: string) {
 
 export function setLastUsedModel(model: string, organizationId?: string) {
   safeLocalStorage.setItem(getLastUsedModelStorageKey(organizationId), model);
+}
+
+export function getDevcontainerEnabledStorageKey() {
+  return DEVCONTAINER_ENABLED_STORAGE_KEY;
+}
+
+export function parseDevcontainerEnabled(rawValue: string | null) {
+  return rawValue === 'true';
+}
+
+export function getDevcontainerEnabled() {
+  return parseDevcontainerEnabled(safeLocalStorage.getItem(DEVCONTAINER_ENABLED_STORAGE_KEY));
+}
+
+export function setDevcontainerEnabled(enabled: boolean) {
+  safeLocalStorage.setItem(DEVCONTAINER_ENABLED_STORAGE_KEY, String(enabled));
 }
 
 export function getPreferredInitialModel({

--- a/apps/web/src/components/cloud-agent/ProfilePickerPopover.tsx
+++ b/apps/web/src/components/cloud-agent/ProfilePickerPopover.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useId } from 'react';
 import { Layers, ChevronDown, Check, Plus, FolderCog, X, ArrowLeft, Zap } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import {
   useProfiles,
@@ -13,12 +14,19 @@ import {
 import { resolveProfileLayers } from '@kilocode/cloud-agent-profile';
 import { ProfilesListDialog } from './ProfilesListDialog';
 
+type DevcontainerToggleControl = {
+  checked: boolean;
+  disabled?: boolean;
+  onCheckedChange: (checked: boolean) => void;
+};
+
 type ProfilePickerPopoverProps = {
   organizationId?: string;
   selectedOverrideProfileId: string | null;
   onOverrideProfileSelect: (id: string | null) => void;
   repoFullName?: string;
   platform?: 'github' | 'gitlab';
+  devcontainerToggle?: DevcontainerToggleControl;
 };
 
 export function ProfilePickerPopover({
@@ -27,7 +35,10 @@ export function ProfilePickerPopover({
   onOverrideProfileSelect,
   repoFullName,
   platform,
+  devcontainerToggle,
 }: ProfilePickerPopoverProps) {
+  const devcontainerToggleId = useId();
+  const devcontainerDescriptionId = `${devcontainerToggleId}-description`;
   const [open, setOpen] = useState(false);
   const [pickingOverride, setPickingOverride] = useState(false);
   const [showManageProfiles, setShowManageProfiles] = useState(false);
@@ -195,6 +206,42 @@ export function ProfilePickerPopover({
                 setOpen(false);
               }}
             />
+          )}
+
+          {devcontainerToggle && (
+            <section
+              className={cn(
+                'bg-accent/10 mt-3 rounded-lg border px-3 py-2.5',
+                devcontainerToggle.disabled && 'opacity-70'
+              )}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-muted-foreground mb-1 text-[10px] font-semibold uppercase tracking-wider">
+                    Experimental runtime
+                  </p>
+                  <label
+                    htmlFor={devcontainerToggleId}
+                    className={cn(
+                      'block text-xs font-medium',
+                      devcontainerToggle.disabled ? 'cursor-not-allowed' : 'cursor-pointer'
+                    )}
+                  >
+                    Dev container support
+                  </label>
+                  <p id={devcontainerDescriptionId} className="text-muted-foreground mt-1 text-xs">
+                    Experimental. Remembered in this browser.
+                  </p>
+                </div>
+                <Switch
+                  id={devcontainerToggleId}
+                  checked={devcontainerToggle.checked}
+                  onCheckedChange={devcontainerToggle.onCheckedChange}
+                  disabled={devcontainerToggle.disabled}
+                  aria-describedby={devcontainerDescriptionId}
+                />
+              </div>
+            </section>
           )}
 
           <div className="my-3 border-t" />

--- a/apps/web/src/lib/posthog-feature-flags.test.ts
+++ b/apps/web/src/lib/posthog-feature-flags.test.ts
@@ -26,7 +26,10 @@ jest.mock('@sentry/nextjs', () => {
   };
 });
 
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import {
+  isFeatureFlagEnabledOrDevelopment,
+  isReleaseToggleEnabled,
+} from '@/lib/posthog-feature-flags';
 
 const posthogMock: {
   mockGetFeatureFlag: jest.Mock;
@@ -38,6 +41,45 @@ const sentryMock: {
 
 const { mockGetFeatureFlag } = posthogMock;
 const { mockCaptureException } = sentryMock;
+
+describe('isFeatureFlagEnabledOrDevelopment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns true without querying PostHog in development', async () => {
+    const replacedEnv = jest.replaceProperty(process, 'env', {
+      ...process.env,
+      NODE_ENV: 'development',
+    });
+
+    try {
+      await expect(
+        isFeatureFlagEnabledOrDevelopment('cloud-agent-devcontainer', 'user-1')
+      ).resolves.toBe(true);
+      expect(mockGetFeatureFlag).not.toHaveBeenCalled();
+    } finally {
+      replacedEnv.restore();
+    }
+  });
+
+  test('queries PostHog outside development', async () => {
+    const replacedEnv = jest.replaceProperty(process, 'env', {
+      ...process.env,
+      NODE_ENV: 'production',
+    });
+    mockGetFeatureFlag.mockResolvedValueOnce(true);
+
+    try {
+      await expect(
+        isFeatureFlagEnabledOrDevelopment('cloud-agent-devcontainer', 'user-2')
+      ).resolves.toBe(true);
+      expect(mockGetFeatureFlag).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-2');
+    } finally {
+      replacedEnv.restore();
+    }
+  });
+});
 
 describe('isReleaseToggleEnabled', () => {
   beforeEach(() => {

--- a/apps/web/src/lib/posthog-feature-flags.ts
+++ b/apps/web/src/lib/posthog-feature-flags.ts
@@ -74,6 +74,15 @@ export async function isFeatureFlagEnabled(
   }
 }
 
+export async function isFeatureFlagEnabledOrDevelopment(
+  flagName: string,
+  distinctId: string = 'server-config-fetch'
+): Promise<boolean> {
+  return (
+    process.env.NODE_ENV === 'development' || (await isFeatureFlagEnabled(flagName, distinctId))
+  );
+}
+
 /**
  * Strict boolean-only release toggle check.
  * Intended for authorization decisions where multivariate feature flag variants must not grant access.

--- a/apps/web/src/routers/cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/cloud-agent-next-router.test.ts
@@ -13,7 +13,7 @@ const mockCreateCloudAgentNextClient = jest.fn(() => ({
   prepareSession: mockPrepareSession,
 }));
 
-const mockIsReleaseToggleEnabled =
+const mockIsFeatureFlagEnabled =
   jest.fn<(flagName: string, distinctId: string) => Promise<boolean>>();
 
 jest.mock('@/lib/tokens', () => ({
@@ -26,7 +26,7 @@ jest.mock('@/lib/cloud-agent-next/cloud-agent-client', () => ({
 }));
 
 jest.mock('@/lib/posthog-feature-flags', () => ({
-  isReleaseToggleEnabled: mockIsReleaseToggleEnabled,
+  isFeatureFlagEnabled: mockIsFeatureFlagEnabled,
 }));
 
 let createCaller: (ctx: { user: User }) => {
@@ -57,8 +57,8 @@ describe('cloudAgentNextRouter.prepareSession', () => {
     });
   });
 
-  it('rejects devcontainer sessions when the release toggle is disabled', async () => {
-    mockIsReleaseToggleEnabled.mockResolvedValue(false);
+  it('rejects devcontainer sessions when the feature flag is disabled', async () => {
+    mockIsFeatureFlagEnabled.mockResolvedValue(false);
     const caller = createCaller({
       user: { id: 'user-1', is_admin: true } as User,
     });
@@ -73,12 +73,12 @@ describe('cloudAgentNextRouter.prepareSession', () => {
         devcontainer: true,
       })
     ).rejects.toThrow('Dev container sessions are not available');
-    expect(mockIsReleaseToggleEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-1');
+    expect(mockIsFeatureFlagEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-1');
     expect(mockCreateCloudAgentNextClient).not.toHaveBeenCalled();
   });
 
-  it('forwards devcontainer sessions when the release toggle is enabled', async () => {
-    mockIsReleaseToggleEnabled.mockResolvedValue(true);
+  it('forwards devcontainer sessions when the feature flag is enabled', async () => {
+    mockIsFeatureFlagEnabled.mockResolvedValue(true);
     const caller = createCaller({
       user: { id: 'user-2', is_admin: false } as User,
     });
@@ -96,7 +96,7 @@ describe('cloudAgentNextRouter.prepareSession', () => {
       cloudAgentSessionId: 'agent_123',
       kiloSessionId: 'ses_12345678901234567890123456',
     });
-    expect(mockIsReleaseToggleEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-2');
+    expect(mockIsFeatureFlagEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-2');
     expect(mockPrepareSession).toHaveBeenCalledWith(
       expect.objectContaining({
         githubRepo: 'acme/repo',

--- a/apps/web/src/routers/cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/cloud-agent-next-router.test.ts
@@ -13,7 +13,7 @@ const mockCreateCloudAgentNextClient = jest.fn(() => ({
   prepareSession: mockPrepareSession,
 }));
 
-const mockIsFeatureFlagEnabled =
+const mockIsFeatureFlagEnabledOrDevelopment =
   jest.fn<(flagName: string, distinctId: string) => Promise<boolean>>();
 
 jest.mock('@/lib/tokens', () => ({
@@ -26,7 +26,7 @@ jest.mock('@/lib/cloud-agent-next/cloud-agent-client', () => ({
 }));
 
 jest.mock('@/lib/posthog-feature-flags', () => ({
-  isFeatureFlagEnabled: mockIsFeatureFlagEnabled,
+  isFeatureFlagEnabledOrDevelopment: mockIsFeatureFlagEnabledOrDevelopment,
 }));
 
 let createCaller: (ctx: { user: User }) => {
@@ -58,7 +58,7 @@ describe('cloudAgentNextRouter.prepareSession', () => {
   });
 
   it('rejects devcontainer sessions when the feature flag is disabled', async () => {
-    mockIsFeatureFlagEnabled.mockResolvedValue(false);
+    mockIsFeatureFlagEnabledOrDevelopment.mockResolvedValue(false);
     const caller = createCaller({
       user: { id: 'user-1', is_admin: true } as User,
     });
@@ -73,12 +73,15 @@ describe('cloudAgentNextRouter.prepareSession', () => {
         devcontainer: true,
       })
     ).rejects.toThrow('Dev container sessions are not available');
-    expect(mockIsFeatureFlagEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-1');
+    expect(mockIsFeatureFlagEnabledOrDevelopment).toHaveBeenCalledWith(
+      'cloud-agent-devcontainer',
+      'user-1'
+    );
     expect(mockCreateCloudAgentNextClient).not.toHaveBeenCalled();
   });
 
   it('forwards devcontainer sessions when the feature flag is enabled', async () => {
-    mockIsFeatureFlagEnabled.mockResolvedValue(true);
+    mockIsFeatureFlagEnabledOrDevelopment.mockResolvedValue(true);
     const caller = createCaller({
       user: { id: 'user-2', is_admin: false } as User,
     });
@@ -96,7 +99,10 @@ describe('cloudAgentNextRouter.prepareSession', () => {
       cloudAgentSessionId: 'agent_123',
       kiloSessionId: 'ses_12345678901234567890123456',
     });
-    expect(mockIsFeatureFlagEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-2');
+    expect(mockIsFeatureFlagEnabledOrDevelopment).toHaveBeenCalledWith(
+      'cloud-agent-devcontainer',
+      'user-2'
+    );
     expect(mockPrepareSession).toHaveBeenCalledWith(
       expect.objectContaining({
         githubRepo: 'acme/repo',

--- a/apps/web/src/routers/cloud-agent-next-router.ts
+++ b/apps/web/src/routers/cloud-agent-next-router.ts
@@ -6,7 +6,7 @@ import {
 } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { rethrowAsTerminalError } from '@/lib/cloud-agent-next/terminal-errors';
 import { generateCloudAgentToken } from '@/lib/tokens';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabledOrDevelopment } from '@/lib/posthog-feature-flags';
 import { fetchGitHubRepositoriesForUser } from '@/lib/cloud-agent/github-integration-helpers';
 import {
   getGitLabInstanceUrlForUser,
@@ -122,8 +122,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       if (
         input.devcontainer &&
-        process.env.NODE_ENV !== 'development' &&
-        !(await isFeatureFlagEnabled('cloud-agent-devcontainer', ctx.user.id))
+        !(await isFeatureFlagEnabledOrDevelopment('cloud-agent-devcontainer', ctx.user.id))
       ) {
         throw new TRPCError({
           code: 'FORBIDDEN',

--- a/apps/web/src/routers/cloud-agent-next-router.ts
+++ b/apps/web/src/routers/cloud-agent-next-router.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { rethrowAsTerminalError } from '@/lib/cloud-agent-next/terminal-errors';
 import { generateCloudAgentToken } from '@/lib/tokens';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
 import { fetchGitHubRepositoriesForUser } from '@/lib/cloud-agent/github-integration-helpers';
 import {
   getGitLabInstanceUrlForUser,
@@ -119,10 +120,14 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(basePrepareSessionNextSchema)
     .output(basePrepareSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      if (input.devcontainer && !ctx.user.is_admin) {
+      if (
+        input.devcontainer &&
+        process.env.NODE_ENV !== 'development' &&
+        !(await isReleaseToggleEnabled('cloud-agent-devcontainer', ctx.user.id))
+      ) {
         throw new TRPCError({
           code: 'FORBIDDEN',
-          message: 'Admin access required for devcontainer sessions',
+          message: 'Dev container sessions are not available',
         });
       }
 

--- a/apps/web/src/routers/cloud-agent-next-router.ts
+++ b/apps/web/src/routers/cloud-agent-next-router.ts
@@ -6,7 +6,7 @@ import {
 } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { rethrowAsTerminalError } from '@/lib/cloud-agent-next/terminal-errors';
 import { generateCloudAgentToken } from '@/lib/tokens';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { fetchGitHubRepositoriesForUser } from '@/lib/cloud-agent/github-integration-helpers';
 import {
   getGitLabInstanceUrlForUser,
@@ -123,7 +123,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
       if (
         input.devcontainer &&
         process.env.NODE_ENV !== 'development' &&
-        !(await isReleaseToggleEnabled('cloud-agent-devcontainer', ctx.user.id))
+        !(await isFeatureFlagEnabled('cloud-agent-devcontainer', ctx.user.id))
       ) {
         throw new TRPCError({
           code: 'FORBIDDEN',

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
@@ -20,7 +20,7 @@ const mockCreateCloudAgentNextClient = jest.fn(() => ({
   prepareSession: mockPrepareSession,
 }));
 
-const mockIsFeatureFlagEnabled =
+const mockIsFeatureFlagEnabledOrDevelopment =
   jest.fn<(flagName: string, distinctId: string) => Promise<boolean>>();
 
 jest.mock('@/lib/tokens', () => ({
@@ -33,7 +33,7 @@ jest.mock('@/lib/cloud-agent-next/cloud-agent-client', () => ({
 }));
 
 jest.mock('@/lib/posthog-feature-flags', () => ({
-  isFeatureFlagEnabled: mockIsFeatureFlagEnabled,
+  isFeatureFlagEnabledOrDevelopment: mockIsFeatureFlagEnabledOrDevelopment,
 }));
 
 jest.mock('@/routers/organizations/utils', () => {
@@ -75,7 +75,7 @@ describe('organizationCloudAgentNextRouter.prepareSession', () => {
   });
 
   it('rejects devcontainer sessions when the feature flag is disabled', async () => {
-    mockIsFeatureFlagEnabled.mockResolvedValue(false);
+    mockIsFeatureFlagEnabledOrDevelopment.mockResolvedValue(false);
     const caller = createCaller({
       user: { id: 'user-1', is_admin: true } as User,
     });
@@ -91,12 +91,15 @@ describe('organizationCloudAgentNextRouter.prepareSession', () => {
         devcontainer: true,
       })
     ).rejects.toThrow('Dev container sessions are not available');
-    expect(mockIsFeatureFlagEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-1');
+    expect(mockIsFeatureFlagEnabledOrDevelopment).toHaveBeenCalledWith(
+      'cloud-agent-devcontainer',
+      'user-1'
+    );
     expect(mockCreateCloudAgentNextClient).not.toHaveBeenCalled();
   });
 
   it('forwards devcontainer sessions when the feature flag is enabled', async () => {
-    mockIsFeatureFlagEnabled.mockResolvedValue(true);
+    mockIsFeatureFlagEnabledOrDevelopment.mockResolvedValue(true);
     const caller = createCaller({
       user: { id: 'user-2', is_admin: false } as User,
     });
@@ -115,7 +118,10 @@ describe('organizationCloudAgentNextRouter.prepareSession', () => {
       cloudAgentSessionId: 'agent_123',
       kiloSessionId: 'ses_12345678901234567890123456',
     });
-    expect(mockIsFeatureFlagEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-2');
+    expect(mockIsFeatureFlagEnabledOrDevelopment).toHaveBeenCalledWith(
+      'cloud-agent-devcontainer',
+      'user-2'
+    );
     expect(mockPrepareSession).toHaveBeenCalledWith(
       expect.objectContaining({
         githubRepo: 'acme/repo',

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
@@ -20,7 +20,7 @@ const mockCreateCloudAgentNextClient = jest.fn(() => ({
   prepareSession: mockPrepareSession,
 }));
 
-const mockIsReleaseToggleEnabled =
+const mockIsFeatureFlagEnabled =
   jest.fn<(flagName: string, distinctId: string) => Promise<boolean>>();
 
 jest.mock('@/lib/tokens', () => ({
@@ -33,7 +33,7 @@ jest.mock('@/lib/cloud-agent-next/cloud-agent-client', () => ({
 }));
 
 jest.mock('@/lib/posthog-feature-flags', () => ({
-  isReleaseToggleEnabled: mockIsReleaseToggleEnabled,
+  isFeatureFlagEnabled: mockIsFeatureFlagEnabled,
 }));
 
 jest.mock('@/routers/organizations/utils', () => {
@@ -74,8 +74,8 @@ describe('organizationCloudAgentNextRouter.prepareSession', () => {
     });
   });
 
-  it('rejects devcontainer sessions when the release toggle is disabled', async () => {
-    mockIsReleaseToggleEnabled.mockResolvedValue(false);
+  it('rejects devcontainer sessions when the feature flag is disabled', async () => {
+    mockIsFeatureFlagEnabled.mockResolvedValue(false);
     const caller = createCaller({
       user: { id: 'user-1', is_admin: true } as User,
     });
@@ -91,12 +91,12 @@ describe('organizationCloudAgentNextRouter.prepareSession', () => {
         devcontainer: true,
       })
     ).rejects.toThrow('Dev container sessions are not available');
-    expect(mockIsReleaseToggleEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-1');
+    expect(mockIsFeatureFlagEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-1');
     expect(mockCreateCloudAgentNextClient).not.toHaveBeenCalled();
   });
 
-  it('forwards devcontainer sessions when the release toggle is enabled', async () => {
-    mockIsReleaseToggleEnabled.mockResolvedValue(true);
+  it('forwards devcontainer sessions when the feature flag is enabled', async () => {
+    mockIsFeatureFlagEnabled.mockResolvedValue(true);
     const caller = createCaller({
       user: { id: 'user-2', is_admin: false } as User,
     });
@@ -115,7 +115,7 @@ describe('organizationCloudAgentNextRouter.prepareSession', () => {
       cloudAgentSessionId: 'agent_123',
       kiloSessionId: 'ses_12345678901234567890123456',
     });
-    expect(mockIsReleaseToggleEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-2');
+    expect(mockIsFeatureFlagEnabled).toHaveBeenCalledWith('cloud-agent-devcontainer', 'user-2');
     expect(mockPrepareSession).toHaveBeenCalledWith(
       expect.objectContaining({
         githubRepo: 'acme/repo',

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, jest, beforeAll, beforeEach } from '@jest/globals';
 import { createCallerFactory } from '@/lib/trpc/init';
+import type * as TrpcInitModule from '@/lib/trpc/init';
 import type { User } from '@kilocode/db/schema';
 
 const ORGANIZATION_ID = '9a283301-b75d-4375-a1ba-e319a02e18b7';
@@ -36,7 +37,7 @@ jest.mock('@/lib/posthog-feature-flags', () => ({
 }));
 
 jest.mock('@/routers/organizations/utils', () => {
-  const trpcInit = jest.requireActual<typeof import('@/lib/trpc/init')>('@/lib/trpc/init');
+  const trpcInit = jest.requireActual<typeof TrpcInitModule>('@/lib/trpc/init');
 
   return {
     organizationMemberProcedure: trpcInit.baseProcedure,

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
@@ -93,7 +93,7 @@ describe('organizationCloudAgentNextRouter.prepareSession', () => {
     ).rejects.toThrow('Dev container sessions are not available');
     expect(mockIsFeatureFlagEnabledOrDevelopment).toHaveBeenCalledWith(
       'cloud-agent-devcontainer',
-      'user-1'
+      ORGANIZATION_ID
     );
     expect(mockCreateCloudAgentNextClient).not.toHaveBeenCalled();
   });
@@ -120,7 +120,7 @@ describe('organizationCloudAgentNextRouter.prepareSession', () => {
     });
     expect(mockIsFeatureFlagEnabledOrDevelopment).toHaveBeenCalledWith(
       'cloud-agent-devcontainer',
-      'user-2'
+      ORGANIZATION_ID
     );
     expect(mockPrepareSession).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it, jest, beforeAll, beforeEach } from '@jest/globals
 import { createCallerFactory } from '@/lib/trpc/init';
 import type { User } from '@kilocode/db/schema';
 
+const ORGANIZATION_ID = '9a283301-b75d-4375-a1ba-e319a02e18b7';
+
 const mockPrepareSession = jest.fn<
-  (input: { githubRepo?: string; devcontainer?: boolean }) => Promise<{
+  (input: {
+    githubRepo?: string;
+    devcontainer?: boolean;
+    kilocodeOrganizationId?: string;
+  }) => Promise<{
     cloudAgentSessionId: string;
     kiloSessionId: string;
   }>
@@ -29,8 +35,18 @@ jest.mock('@/lib/posthog-feature-flags', () => ({
   isReleaseToggleEnabled: mockIsReleaseToggleEnabled,
 }));
 
+jest.mock('@/routers/organizations/utils', () => {
+  const trpcInit = jest.requireActual<typeof import('@/lib/trpc/init')>('@/lib/trpc/init');
+
+  return {
+    organizationMemberProcedure: trpcInit.baseProcedure,
+    organizationMemberMutationProcedure: trpcInit.baseProcedure,
+  };
+});
+
 let createCaller: (ctx: { user: User }) => {
   prepareSession: (input: {
+    organizationId: string;
     prompt: string;
     mode: string;
     model: string;
@@ -44,11 +60,11 @@ let createCaller: (ctx: { user: User }) => {
 };
 
 beforeAll(async () => {
-  const mod = await import('./cloud-agent-next-router');
-  createCaller = createCallerFactory(mod.cloudAgentNextRouter);
+  const mod = await import('./organization-cloud-agent-next-router');
+  createCaller = createCallerFactory(mod.organizationCloudAgentNextRouter);
 });
 
-describe('cloudAgentNextRouter.prepareSession', () => {
+describe('organizationCloudAgentNextRouter.prepareSession', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockPrepareSession.mockResolvedValue({
@@ -65,6 +81,7 @@ describe('cloudAgentNextRouter.prepareSession', () => {
 
     await expect(
       caller.prepareSession({
+        organizationId: ORGANIZATION_ID,
         prompt: 'Test prompt',
         mode: 'code',
         model: 'kilo/test-model',
@@ -85,6 +102,7 @@ describe('cloudAgentNextRouter.prepareSession', () => {
 
     await expect(
       caller.prepareSession({
+        organizationId: ORGANIZATION_ID,
         prompt: 'Test prompt',
         mode: 'code',
         model: 'kilo/test-model',
@@ -101,6 +119,7 @@ describe('cloudAgentNextRouter.prepareSession', () => {
       expect.objectContaining({
         githubRepo: 'acme/repo',
         devcontainer: true,
+        kilocodeOrganizationId: ORGANIZATION_ID,
       })
     );
   });

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -6,7 +6,7 @@ import {
 } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { rethrowAsTerminalError } from '@/lib/cloud-agent-next/terminal-errors';
 import { generateCloudAgentToken } from '@/lib/tokens';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import {
   organizationMemberProcedure,
   organizationMemberMutationProcedure,
@@ -196,7 +196,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       if (
         input.devcontainer &&
         process.env.NODE_ENV !== 'development' &&
-        !(await isReleaseToggleEnabled('cloud-agent-devcontainer', ctx.user.id))
+        !(await isFeatureFlagEnabled('cloud-agent-devcontainer', ctx.user.id))
       ) {
         throw new TRPCError({
           code: 'FORBIDDEN',

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -6,7 +6,7 @@ import {
 } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { rethrowAsTerminalError } from '@/lib/cloud-agent-next/terminal-errors';
 import { generateCloudAgentToken } from '@/lib/tokens';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabledOrDevelopment } from '@/lib/posthog-feature-flags';
 import {
   organizationMemberProcedure,
   organizationMemberMutationProcedure,
@@ -195,8 +195,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       if (
         input.devcontainer &&
-        process.env.NODE_ENV !== 'development' &&
-        !(await isFeatureFlagEnabled('cloud-agent-devcontainer', ctx.user.id))
+        !(await isFeatureFlagEnabledOrDevelopment('cloud-agent-devcontainer', ctx.user.id))
       ) {
         throw new TRPCError({
           code: 'FORBIDDEN',

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { rethrowAsTerminalError } from '@/lib/cloud-agent-next/terminal-errors';
 import { generateCloudAgentToken } from '@/lib/tokens';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
 import {
   organizationMemberProcedure,
   organizationMemberMutationProcedure,
@@ -192,10 +193,14 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(PrepareSessionInput)
     .output(basePrepareSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      if (input.devcontainer && !ctx.user.is_admin) {
+      if (
+        input.devcontainer &&
+        process.env.NODE_ENV !== 'development' &&
+        !(await isReleaseToggleEnabled('cloud-agent-devcontainer', ctx.user.id))
+      ) {
         throw new TRPCError({
           code: 'FORBIDDEN',
-          message: 'Admin access required for devcontainer sessions',
+          message: 'Dev container sessions are not available',
         });
       }
 

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -195,7 +195,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       if (
         input.devcontainer &&
-        !(await isFeatureFlagEnabledOrDevelopment('cloud-agent-devcontainer', ctx.user.id))
+        !(await isFeatureFlagEnabledOrDevelopment('cloud-agent-devcontainer', input.organizationId))
       ) {
         throw new TRPCError({
           code: 'FORBIDDEN',


### PR DESCRIPTION
## Summary
- Gate personal and organization Cloud Agent dev-container sessions with the `cloud-agent-devcontainer` release toggle.
- Move the dev-container control into the profile picker, persist the browser preference, and surface an enabled indicator beside the picker.
- Add router and preference coverage for toggle authorization and browser storage behavior.

## Verification

- [x] Verified manually

## Visual Changes

<img width="409" height="505" alt="Screenshot 2026-05-21 at 09 49 06" src="https://github.com/user-attachments/assets/88b62846-8e4c-4c25-a845-4db4dc17a291" />


## Reviewer Notes
- Development mode keeps the existing local bypass; production requests now require the release toggle instead of admin status.