### PR TITLE
fix(db): verify Supabase SSL hostnames

### DIFF
--- a/packages/db/src/database-url.ts
+++ b/packages/db/src/database-url.ts
@@ -31,7 +31,9 @@ export function getDatabaseClientConfig(postgresUrl: string): ClientConfig {
 
   if (process.env.DATABASE_CA) {
     clientConfig.ssl = {
-      ca: process.env.DATABASE_CA,
+      ca: process.env.DATABASE_CA.replace(/\\n/g, '\n'),
+      rejectUnauthorized: true,
+      servername: databaseUrl.hostname,
     };
   } else {
     clientConfig.ssl = false;


### PR DESCRIPTION
## Summary
- Enforce hostname-verified TLS for Postgres connections whenever `DATABASE_CA` is configured.
- Normalize escaped newline CA values from Vercel env vars so the configured Supabase CA is passed to `pg` as valid PEM content.

## Verification
- Not manually tested against production Supabase; this changes client TLS configuration and was verified locally with targeted package checks.

## Visual Changes
N/A

## Reviewer Notes
- Production DB URLs must use hostnames matching the Supabase certificate; IP-based URLs will fail hostname verification.