### PR TITLE
fix(kiloclaw): align billing recovery with funding

### DIFF
--- a/apps/web/src/app/(app)/claw/components/billing/BillingBanner.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/BillingBanner.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import React from 'react';
+import Link from 'next/link';
 import {
   AlertCircle,
   AlertTriangle,
@@ -148,6 +150,19 @@ function getBannerContent(state: ClawBannerState, billing: ClawBillingStatus) {
         action: 'reactivate' as const,
       };
     case 'subscription_past_due':
+      if (
+        billing.subscription &&
+        !billing.subscription.hasStripeFunding &&
+        billing.subscription.paymentSource === 'credits'
+      ) {
+        return {
+          title: 'Payment failed — action required',
+          message:
+            'Your credit balance is insufficient for the next renewal. Add credits to avoid service interruption.',
+          cta: 'Add Credits',
+          action: 'add_credits' as const,
+        };
+      }
       return {
         title: 'Payment failed — action required',
         message:
@@ -211,23 +226,28 @@ export function BillingBanner({
         <p className="text-muted-foreground text-sm">{content.message}</p>
       </div>
 
-      {content.cta && (
-        <Button
-          onClick={handleCta}
-          variant="primary"
-          className="shrink-0"
-          disabled={content.action === 'reactivate' && isReactivating}
-        >
-          {content.action === 'reactivate' && isReactivating ? (
-            <>
-              <Loader2 className="animate-spin" />
-              Reactivating...
-            </>
-          ) : (
-            content.cta
-          )}
-        </Button>
-      )}
+      {content.cta &&
+        (content.action === 'add_credits' ? (
+          <Button variant="primary" className="shrink-0" asChild>
+            <Link href="/credits">{content.cta}</Link>
+          </Button>
+        ) : (
+          <Button
+            onClick={handleCta}
+            variant="primary"
+            className="shrink-0"
+            disabled={content.action === 'reactivate' && isReactivating}
+          >
+            {content.action === 'reactivate' && isReactivating ? (
+              <>
+                <Loader2 className="animate-spin" />
+                Reactivating...
+              </>
+            ) : (
+              content.cta
+            )}
+          </Button>
+        ))}
     </div>
   );
 }

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
@@ -187,6 +187,28 @@ describe('BillingBanner credit renewal recovery', () => {
     expect(html).toContain('href="/credits"');
     expect(html).not.toContain('Update Payment');
   });
+
+  it('keeps Stripe-funded hybrid past-due subscriptions on payment recovery', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(BillingBanner, {
+        billing: createBillingStatus({
+          subscription: {
+            status: 'past_due',
+            hasStripeFunding: true,
+            paymentSource: 'credits',
+          },
+        }),
+        onSubscribeClick: () => undefined,
+        onReactivateClick: () => undefined,
+        onUpdatePaymentClick: () => undefined,
+      })
+    );
+
+    expect(html).toContain('Your subscription payment failed.');
+    expect(html).toContain('Update Payment');
+    expect(html).not.toContain('href="/credits"');
+    expect(html).not.toContain('Add Credits');
+  });
 });
 
 describe('billing-types pending settlement compatibility', () => {

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import {
   createKiloClawSignupDisplay,
   deriveBannerState,
@@ -6,6 +8,7 @@ import {
   type ClawBillingStatus,
   type KiloPassUpsellActivationPreview,
 } from './billing-types';
+import { BillingBanner } from './BillingBanner';
 
 const emptyUpsellPreview: KiloPassUpsellActivationPreview = {
   eligible: false,
@@ -159,6 +162,30 @@ describe('KiloClaw billing display helpers', () => {
     expect(formatKiloClawPlanPrice({ plan: 'commit', priceVersion: '2026-05-10' })).toBe(
       '$306/6-month commit'
     );
+  });
+});
+
+describe('BillingBanner credit renewal recovery', () => {
+  it('routes pure-credit past-due subscriptions to credit top-up', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(BillingBanner, {
+        billing: createBillingStatus({
+          subscription: {
+            status: 'past_due',
+            hasStripeFunding: false,
+            paymentSource: 'credits',
+          },
+        }),
+        onSubscribeClick: () => undefined,
+        onReactivateClick: () => undefined,
+        onUpdatePaymentClick: () => undefined,
+      })
+    );
+
+    expect(html).toContain('Your credit balance is insufficient for the next renewal.');
+    expect(html).toContain('Add Credits');
+    expect(html).toContain('href="/credits"');
+    expect(html).not.toContain('Update Payment');
   });
 });
 

--- a/apps/web/src/components/subscriptions/helpers.test.ts
+++ b/apps/web/src/components/subscriptions/helpers.test.ts
@@ -1,5 +1,6 @@
 import {
   formatKiloclawPrice,
+  formatPaymentSummary,
   getKiloclawDisplayStatus,
   getKiloclawStatusNote,
   isKiloclawPendingSettlement,
@@ -15,6 +16,27 @@ describe('KiloClaw subscription helpers', () => {
     expect(formatKiloclawPrice({ plan: 'commit', priceVersion: '2026-05-10' })).toBe(
       '$306/6-month commit'
     );
+  });
+
+  it('labels Stripe-funded hybrid subscriptions as Stripe', () => {
+    expect(
+      formatPaymentSummary({
+        paymentSource: 'stripe',
+        hasStripeFunding: true,
+      })
+    ).toBe('Stripe');
+    expect(
+      formatPaymentSummary({
+        paymentSource: 'credits',
+        hasStripeFunding: true,
+      })
+    ).toBe('Stripe');
+    expect(
+      formatPaymentSummary({
+        paymentSource: 'credits',
+        hasStripeFunding: false,
+      })
+    ).toBe('Credits');
   });
 
   it('marks pending settlement rows explicitly for display', () => {

--- a/apps/web/src/components/subscriptions/helpers.ts
+++ b/apps/web/src/components/subscriptions/helpers.ts
@@ -95,11 +95,11 @@ export function formatPaymentSummary(params: {
   paymentSource: string | null;
   hasStripeFunding?: boolean;
 }): string {
-  if (params.paymentSource === 'credits') {
-    return 'Credits';
-  }
   if (params.hasStripeFunding) {
     return 'Stripe';
+  }
+  if (params.paymentSource === 'credits') {
+    return 'Credits';
   }
   return '—';
 }


### PR DESCRIPTION
## Summary
Credit-funded KiloClaw recovery now routes users to credits, while Stripe-backed subscriptions keep Stripe-facing payment labels.

### Why this change is needed
Pure-credit renewal failures were shown with an Update Payment action that tried to open Stripe billing, even though those subscriptions have no Stripe funding path. Hybrid KiloClaw rows also store `payment_source = credits` while Stripe still owns payment collection, which made subscription summaries look credit-funded when users are still paying through Stripe.

### How this is addressed
- Route pure-credit past-due banner recovery to `/credits` with credit-specific copy and an Add Credits CTA.
- Keep Stripe portal recovery behavior for Stripe-funded and hybrid subscriptions.
- Prefer Stripe-funding presence over raw payment source when rendering customer-facing payment summaries.
- Add regression coverage for both failed credit-renewal recovery and hybrid payment-source labeling.

## Human Verification
- `NODE_ENV=test pnpm --filter web exec jest --runTestsByPath "src/components/subscriptions/helpers.test.ts" "src/app/(app)/claw/components/billing/billing-types.test.ts"`

## Reviewer Notes
### Human Reviewer Flags
- Hybrid subscriptions intentionally render as `Stripe` when a Stripe subscription ID exists, even if local `payment_source` is `credits`; this reflects who collects payment from user.
