### PR TITLE
feat(kiloclaw): ungate Composion/calendar in onboarding

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
@@ -177,11 +177,10 @@ describe('ClawOnboardingFlow state machine', () => {
     ).toBe('complete');
   });
 
-  test('the active wizard has five steps when all admin-gated steps are visible', () => {
-    // Channels and pairing were removed from the active wizard. The
-    // counter is 5 with all admin-gated steps visible: identity,
-    // calendar, email, interests, provisioning. Non-admins skip the
-    // calendar and interests steps (see the describe block below).
+  test('the active wizard has five steps when all optional steps are visible', () => {
+    // Channels and pairing were removed from the active wizard. The counter
+    // is 5 with all optional steps visible: identity, calendar, email,
+    // interests, provisioning.
     const defaultState = getClawOnboardingFlowState(createInput());
     expect(defaultState.totalSteps).toBe(5);
     expect(defaultState.currentStep).toBe(1);
@@ -331,11 +330,9 @@ describe('ClawOnboardingFlow state machine', () => {
     ).toBe('provisioning');
   });
 
-  describe('when admin-gated steps are hidden (non-admin user)', () => {
-    // A real non-admin has BOTH calendar and interests hidden (they share
-    // the same admin gate). Each test passes both flags as `false` so the
-    // total step count reflects the actual non-admin wizard: identity,
-    // email, provisioning = 3 steps.
+  describe('when optional calendar and interests steps are hidden', () => {
+    // Each test passes both flags as `false` so the total step count reflects
+    // the shortened wizard: identity, email, provisioning = 3 steps.
     test('drops calendar and interests from total step count', () => {
       const nonAdmin = getClawOnboardingFlowState(
         createInput({ hasCalendarStep: false, hasInterestsStep: false })
@@ -376,9 +373,9 @@ describe('ClawOnboardingFlow state machine', () => {
     });
 
     test('reports email as step 2 of 3 even when stored onboardingStep is calendar', () => {
-      // A non-admin briefly sitting on onboardingStep='calendar' (e.g. via a
-      // stale URL) gets normalized for both the rendered step and the
-      // progress indicator so the header doesn't read "Step 0 of 3".
+      // A user briefly sitting on onboardingStep='calendar' (e.g. via a stale
+      // URL) gets normalized for both the rendered step and the progress
+      // indicator so the header doesn't read "Step 0 of 3".
       const state = getClawOnboardingFlowState(
         createInput({
           createSetupStarted: true,

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
@@ -81,11 +81,9 @@ export type ClawOnboardingFlowStateInput = {
   hasBotIdentity: boolean;
   gatewayState?: GatewayProcessStatusOkResponse['state'] | null;
   /**
-   * Whether the calendar step is available in the wizard. Calendar OAuth is
-   * gated to Kilo Code admins (the `/api/integrations/google/connect` and
-   * `/disconnect` routes both require `adminOnly: true`), so non-admins skip
-   * the step entirely. When false, the wizard advances identity → email
-   * and `'calendar'` is mapped to `'email'` in the render decision.
+   * Whether the calendar step is available in the wizard. When false, the
+   * wizard advances identity -> email and `'calendar'` is mapped to `'email'`
+   * in the render decision.
    */
   hasCalendarStep?: boolean;
   hasToolsStep?: boolean;
@@ -159,10 +157,9 @@ export function getClawOnboardingStepProgress(
     return { currentStep: totalSteps, totalSteps };
   }
 
-  // A non-admin sitting briefly on `onboardingStep === 'calendar'` (e.g. via
-  // a stale `?step=calendar` URL) gets normalized to email for progress
-  // display, matching the renderStep redirect in getRenderStepDecision.
-  // Same treatment for `'interests'` → `'provisioning'`.
+  // A user sitting briefly on an unavailable step (e.g. via a stale URL) gets
+  // normalized to the next available step for progress display, matching the
+  // renderStep redirect in getRenderStepDecision.
   let lookupStep: OnboardingStep = step;
   if (lookupStep === 'tools' && !hasToolsStep) lookupStep = hasCalendarStep ? 'calendar' : 'email';
   if (lookupStep === 'calendar' && hasToolsStep) lookupStep = 'tools';
@@ -347,8 +344,7 @@ function getRenderStepDecision({
       if (!hasCalendarStep) {
         return {
           renderStep: 'email',
-          reason:
-            'calendar step is admin-only and the current user is not an admin; advance to email',
+          reason: 'calendar step is unavailable; advance to email',
         };
       }
       return {
@@ -366,8 +362,7 @@ function getRenderStepDecision({
       if (!hasInterestsStep) {
         return {
           renderStep: 'provisioning',
-          reason:
-            'interests step is admin-only and the current user is not an admin; advance to provisioning',
+          reason: 'interests step is unavailable; advance to provisioning',
         };
       }
       return {
@@ -443,8 +438,7 @@ function getRenderStepDecision({
     if (!hasCalendarStep) {
       return {
         renderStep: 'email',
-        reason:
-          'calendar step is admin-only and the current user is not an admin; advance to email',
+        reason: 'calendar step is unavailable; advance to email',
       };
     }
     return {
@@ -464,8 +458,7 @@ function getRenderStepDecision({
     if (!hasInterestsStep) {
       return {
         renderStep: 'provisioning',
-        reason:
-          'interests step is admin-only and the current user is not an admin; advance to provisioning',
+        reason: 'interests step is unavailable; advance to provisioning',
       };
     }
     return {

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -288,20 +288,8 @@ function ClawOnboardingFlowInner({
   const orgMutations = useOrgKiloClawMutations(organizationId ?? '');
   const mutations = organizationId ? orgMutations : personalMutations;
 
-  const { data: currentUser, isPending: isUserPending } = useUser();
-  // Calendar OAuth is admin-only — both `/api/integrations/google/connect` and
-  // `/disconnect` require `adminOnly: true`. Hide the calendar step from
-  // non-admins so the wizard advances identity → email directly.
-  //
-  // While `useUser` is loading we default to `true` (admin assumption). This
-  // matters most for admins returning from the OAuth round-trip on a full
-  // page reload: defaulting to `false` would briefly flip the wizard into
-  // the 3-step non-admin layout and — if they race-clicked Continue before
-  // the query resolved — silently skip the calendar step entirely. The
-  // theoretical inverse (a non-admin race-clicking Continue and seeing one
-  // frame of the calendar UI before the state machine redirects to email)
-  // is harmless: the connect endpoint enforces admin too.
-  const hasCalendarStep = isUserPending ? true : currentUser?.is_admin === true;
+  const { data: currentUser } = useUser();
+  const hasCalendarStep = true;
   // Morning briefing is generally available — the Interests step shows for
   // all users (it still gates on controller version below).
   // Gate on controller version. The plugin route that backs
@@ -349,7 +337,7 @@ function ClawOnboardingFlowInner({
     composioStatusPolling
   );
   const composioStatus = organizationId ? orgComposioStatus : personalComposioStatus;
-  const hasToolsStep = hasCalendarStep && composioStatus.data?.enabled !== false;
+  const hasToolsStep = true;
   const configQuery = useClawConfig(status !== undefined && status.status !== null);
   const composioManualConfigured = composioStatus.data?.sandboxConfigSource === 'manual';
   const composioConfigPending =
@@ -741,23 +729,6 @@ function ClawOnboardingFlowInner({
     if (hasResumedFromQuery.current) return;
     const stepParam = searchParams?.get('step');
     if (stepParam !== 'calendar' && stepParam !== 'tools') return;
-    // The OAuth round-trip is a full-page reload, so `useUser` starts fresh
-    // and the query is in-flight on the first render(s). Gate on `isPending`
-    // (not `currentUser === undefined`) so that a `/api/user` fetch that
-    // settles in error after retries — `data` stays undefined, `isPending`
-    // flips to false — still falls through to the cleanup branch below
-    // instead of stranding the URL params forever.
-    if (isUserPending) return;
-    // Calendar is admin-only; a non-admin (or any user we couldn't classify
-    // as admin, e.g. /api/user errored after retries) landing here shouldn't
-    // trigger calendar-specific toasts or set onboardingStep to 'calendar'.
-    // Strip the params and move on. An admin who just completed OAuth but
-    // had /api/user error can re-verify the connection in settings.
-    if (stepParam === 'calendar' && !hasCalendarStep) {
-      hasResumedFromQuery.current = true;
-      cleanupResumeQueryParams();
-      return;
-    }
     if (botIdentity === null) return;
     const successParam = searchParams?.get('success');
     const errorParamRaw = searchParams?.get('error');
@@ -791,14 +762,7 @@ function ClawOnboardingFlowInner({
       toast.error('Could not connect calendar. Try again or skip for now.');
     }
     cleanupResumeQueryParams();
-  }, [
-    searchParams,
-    botIdentity,
-    posthog,
-    cleanupResumeQueryParams,
-    hasCalendarStep,
-    isUserPending,
-  ]);
+  }, [searchParams, botIdentity, posthog, cleanupResumeQueryParams]);
 
   // Watchdog: if `?step=calendar` is in the URL but botIdentity hydration
   // never completes (e.g. patchBotIdentity hadn't propagated to the DB

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -696,12 +696,9 @@ function ClawOnboardingFlowInner({
   }, [flowState.instanceStatus, botIdentity]);
 
   // Resume the wizard at a specific step when returning from a flow that
-  // leaves the page (e.g. the Google OAuth round-trip on the calendar step
-  // posts the user back to /claw/new?step=calendar). The effect only acts
-  // when stepParam === 'calendar' — otherwise stale `?error=` or `?success=`
-  // params from elsewhere would fire calendar-specific toasts on the wrong
-  // screen. Also waits until botIdentity has been hydrated before consuming
-  // `step`, otherwise the state machine would override us with identity.
+  // leaves the page. The current Composio flow uses `?step=tools`; legacy
+  // `?step=calendar` callbacks are cleanup-only so stale OAuth URLs do not
+  // emit misleading calendar toasts or analytics.
   const hasResumedFromQuery = useRef(false);
 
   // Allowlist of known OAuth error codes that the callback route can emit.
@@ -729,6 +726,11 @@ function ClawOnboardingFlowInner({
     if (hasResumedFromQuery.current) return;
     const stepParam = searchParams?.get('step');
     if (stepParam !== 'calendar' && stepParam !== 'tools') return;
+    if (stepParam === 'calendar') {
+      hasResumedFromQuery.current = true;
+      cleanupResumeQueryParams();
+      return;
+    }
     if (botIdentity === null) return;
     const successParam = searchParams?.get('success');
     const errorParamRaw = searchParams?.get('error');
@@ -764,15 +766,14 @@ function ClawOnboardingFlowInner({
     cleanupResumeQueryParams();
   }, [searchParams, botIdentity, posthog, cleanupResumeQueryParams]);
 
-  // Watchdog: if `?step=calendar` is in the URL but botIdentity hydration
-  // never completes (e.g. patchBotIdentity hadn't propagated to the DB
-  // before the OAuth round-trip), don't silently strand the user on the
-  // identity step with stale params lingering in the URL. After a short
-  // grace period, clean the URL and surface a soft warning.
+  // Watchdog: if a Composio callback has `?step=tools` but botIdentity
+  // hydration never completes, don't silently strand the user on the identity
+  // step with stale params lingering in the URL. After a short grace period,
+  // clean the URL and surface a soft warning.
   useEffect(() => {
     if (hasResumedFromQuery.current) return;
     const stepParam = searchParams?.get('step');
-    if (stepParam !== 'calendar' && stepParam !== 'tools') return;
+    if (stepParam !== 'tools') return;
     const timeoutId = window.setTimeout(() => {
       if (hasResumedFromQuery.current) return;
       if (botIdentity !== null) return;

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -22,7 +22,6 @@ import { OpenclawImportCard } from './OpenclawImportCard';
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
-import { useUser } from '@/hooks/useUser';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import type { KiloClawDashboardStatus, MorningBriefingStatusLite } from '@/lib/kiloclaw/types';
 import { morningBriefingStatusOk } from '@/lib/kiloclaw/types';
@@ -1890,7 +1889,6 @@ export function SettingsTab({
   organizationName?: string;
 }) {
   const posthog = usePostHog();
-  const { data: user } = useUser();
   const { data: config } = useClawConfig();
   const { data: composioOnboardingStatus } = useClawComposioOnboardingStatus();
   const { organizationId } = useClawContext();
@@ -2042,26 +2040,6 @@ export function SettingsTab({
     supportsExaSearchUi && kiloExaSearchMode === null ? 'kilo-proxy' : kiloExaSearchMode;
   const braveSearchEnabled = braveSearchConfigured && !exaSearchConfigured;
   const toolEntries = getEntriesByCategory('tool');
-  const googleCalendarConnectHref = useMemo(() => {
-    const params = new URLSearchParams({ capabilities: 'calendar_read' });
-    if (organizationId) {
-      params.set('organizationId', organizationId);
-    }
-
-    return `/api/integrations/google/connect?${params.toString()}`;
-  }, [organizationId]);
-  const googleCalendarDisconnectHref = useMemo(() => {
-    const params = new URLSearchParams();
-    if (organizationId) {
-      params.set('organizationId', organizationId);
-    }
-
-    const qs = params.toString();
-    return qs.length > 0
-      ? `/api/integrations/google/disconnect?${qs}`
-      : '/api/integrations/google/disconnect';
-  }, [organizationId]);
-  const canSeeGoogleCalendar = !!user?.is_admin;
 
   function handleCycleInboundEmailAddress() {
     mutations.cycleInboundEmailAddress.mutate(undefined, {
@@ -2286,35 +2264,6 @@ export function SettingsTab({
 
       {/* ── Webhook Integration ── */}
       <WebhookIntegrationSection />
-
-      {canSeeGoogleCalendar && (
-        <div className="rounded-lg border px-4 py-3">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-3">
-              <GoogleGIcon className="h-5 w-5 shrink-0" />
-              <div>
-                <p className="text-sm font-medium">Google Calendar</p>
-                <div className="text-muted-foreground text-xs">
-                  {status.googleOAuthConnected
-                    ? `Connected${status.googleOAuthAccountEmail ? ` as ${status.googleOAuthAccountEmail}` : ''}`
-                    : 'Not connected'}
-                </div>
-              </div>
-            </div>
-            {status.googleOAuthConnected ? (
-              <form action={googleCalendarDisconnectHref} method="POST">
-                <Button type="submit" variant="outline" size="sm">
-                  Disconnect
-                </Button>
-              </form>
-            ) : (
-              <Button asChild variant="outline" size="sm">
-                <a href={googleCalendarConnectHref}>Connect</a>
-              </Button>
-            )}
-          </div>
-        </div>
-      )}
 
       {/* ── Messaging Channels ── */}
       <div>


### PR DESCRIPTION
## Summary

- Default KiloClaw onboarding to the managed Composio tools step for all users instead of deriving calendar/tools availability from admin status.
- Remove the legacy admin-only Google Calendar card from Settings so new settings surfaces no longer expose the old OAuth connect/disconnect path.
- No backend or database architecture changes are included; legacy Google OAuth routes remain in place for a follow-up removal PR.

## Verification

- [ ] No manual browser verification was performed in this session; changes were limited to onboarding/settings rendering and state-machine gating.
- [ ] Add user-provided manual verification details.

## Visual Changes

| Before | After |
| ------ | ----- |
| Settings showed an admin-only “Google Calendar” legacy OAuth card. | Settings no longer shows the legacy Google Calendar card. |
| Some non-admin onboarding paths skipped calendar/tools setup. | Onboarding always routes through the Composio-powered tools step. |

## Reviewer Notes

- Focus review on the onboarding state transition from identity to tools and the Settings tab removal of the legacy Google Calendar card.
- The Composio settings/manual credentials card remains unchanged; this does not remove legacy Google OAuth backend code.
- There will be no migration path for legacy calendar Oauth users because it was never exposed to non-Kilo admins. 
- All the legacy google calendar oauth code will be removed in a follow up.