### PR TITLE
fix(kiloclaw): treat missing restart runtime as not found

### DIFF
--- a/apps/web/src/lib/kiloclaw/kiloclaw-user-client.test.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-user-client.test.ts
@@ -1,0 +1,46 @@
+jest.mock('@/lib/config.server', () => ({
+  INTERNAL_API_SECRET: 'internal-test-secret',
+  KILOCLAW_API_URL: 'https://claw.test',
+}));
+
+import { KiloClawApiError } from './kiloclaw-internal-client';
+import { KiloClawUserClient } from './kiloclaw-user-client';
+
+describe('KiloClawUserClient restart failures', () => {
+  let fetchSpy: jest.SpiedFunction<typeof fetch>;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch');
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('preserves the sanitized Worker error body on KiloClawApiError', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response('{"success":false,"error":"No machine exists","unexpected":"do not preserve"}', {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    const client = new KiloClawUserClient('user-token');
+    let thrown: unknown;
+
+    try {
+      await client.restartMachine(undefined, { userId: 'user-1' });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(KiloClawApiError);
+    if (!(thrown instanceof KiloClawApiError)) throw thrown;
+    expect(thrown.statusCode).toBe(404);
+    expect(JSON.parse(thrown.responseBody)).toEqual({
+      success: false,
+      error: 'No machine exists',
+    });
+  });
+});

--- a/apps/web/src/lib/kiloclaw/kiloclaw-user-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-user-client.ts
@@ -6,6 +6,37 @@ import type { UserConfigResponse, PlatformStatusResponse, RestartMachineResponse
 
 type RequestContext = { userId: string; instanceId?: string };
 
+type SanitizedKiloClawErrorBody = {
+  success?: false;
+  error?: string;
+  code?: string;
+};
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function serializeSafeKiloClawErrorResponseBody(responseBody: string): string {
+  try {
+    const parsed: unknown = JSON.parse(responseBody);
+    if (typeof parsed !== 'object' || parsed === null) return '';
+
+    const error = readNonEmptyString('error' in parsed ? parsed.error : undefined);
+    const code = readNonEmptyString('code' in parsed ? parsed.code : undefined);
+
+    if (!error && !code) return '';
+
+    const sanitized: SanitizedKiloClawErrorBody = {};
+    if ('success' in parsed && parsed.success === false) sanitized.success = false;
+    if (error) sanitized.error = error;
+    if (code) sanitized.code = code;
+
+    return JSON.stringify(sanitized);
+  } catch {
+    return '';
+  }
+}
+
 /**
  * KiloClaw worker client for user-facing routes.
  * Uses Bearer JWT auth (forwarding the user's token). Server-only.
@@ -40,13 +71,13 @@ export class KiloClawUserClient {
     });
 
     if (!res.ok) {
-      const body = await res.text();
+      const responseBody = serializeSafeKiloClawErrorResponseBody(await res.text());
       console.error(
         `KiloClaw API error (${res.status}) ${options?.method ?? 'GET'} ${path}:`,
-        body,
+        responseBody,
         ...(ctx ? [`userId=${ctx.userId}`] : [])
       );
-      throw new KiloClawApiError(res.status);
+      throw new KiloClawApiError(res.status, responseBody);
     }
 
     return res.json() as Promise<T>;

--- a/apps/web/src/lib/kiloclaw/kiloclaw-user-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-user-client.ts
@@ -6,7 +6,7 @@ import type { UserConfigResponse, PlatformStatusResponse, RestartMachineResponse
 
 type RequestContext = { userId: string; instanceId?: string };
 
-type SanitizedKiloClawErrorBody = {
+type SerializedKiloClawErrorBody = {
   success?: false;
   error?: string;
   code?: string;
@@ -26,12 +26,12 @@ function serializeSafeKiloClawErrorResponseBody(responseBody: string): string {
 
     if (!error && !code) return '';
 
-    const sanitized: SanitizedKiloClawErrorBody = {};
-    if ('success' in parsed && parsed.success === false) sanitized.success = false;
-    if (error) sanitized.error = error;
-    if (code) sanitized.code = code;
+    const serialized: SerializedKiloClawErrorBody = {};
+    if ('success' in parsed && parsed.success === false) serialized.success = false;
+    if (error) serialized.error = error;
+    if (code) serialized.code = code;
 
-    return JSON.stringify(sanitized);
+    return JSON.stringify(serialized);
   } catch {
     return '';
   }

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -579,6 +579,20 @@ function getKiloClawApiErrorPayload(err: KiloClawApiError): { message?: string; 
   }
 }
 
+function handleRestartMachineError(err: unknown): never {
+  if (err instanceof KiloClawApiError && err.statusCode === 404) {
+    const { message } = getKiloClawApiErrorPayload(err);
+    if (message === 'No machine exists') {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message,
+      });
+    }
+  }
+
+  throw err;
+}
+
 /**
  * True when the user has ever had a paid (non-trial) subscription that is now
  * canceled. Used to gate intro pricing eligibility (spec Credit Enrollment rule 3).
@@ -3681,10 +3695,12 @@ export const kiloclawRouter = createTRPCRouter({
       const client = new KiloClawUserClient(
         generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
       );
-      const result = await client.restartMachine(
-        input?.imageTag ? { imageTag: input.imageTag } : undefined,
-        { userId: ctx.user.id, instanceId: workerInstanceId(instance) }
-      );
+      const result = await client
+        .restartMachine(input?.imageTag ? { imageTag: input.imageTag } : undefined, {
+          userId: ctx.user.id,
+          instanceId: workerInstanceId(instance),
+        })
+        .catch(handleRestartMachineError);
       if (result.success) {
         PostHogClient().capture({
           distinctId: ctx.user.google_user_email,

--- a/apps/web/src/routers/kiloclaw-user-versions-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-user-versions-router.test.ts
@@ -10,6 +10,7 @@ import {
   kiloclaw_subscriptions,
 } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
+import { KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const mockRestartMachine: jest.Mock<any, any> = jest.fn();
@@ -449,6 +450,18 @@ describe('kiloclaw.restartMachine pin consent gate', () => {
       .from(kiloclaw_version_pins)
       .where(eq(kiloclaw_version_pins.instance_id, userAInstanceId));
     expect(pins.length).toBe(1);
+  });
+
+  it('maps a missing Worker runtime to tRPC NOT_FOUND', async () => {
+    mockRestartMachine.mockRejectedValue(
+      new KiloClawApiError(404, '{"success":false,"error":"No machine exists"}')
+    );
+
+    const caller = await createCallerForUser(userA.id);
+    await expect(caller.kiloclaw.restartMachine()).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'No machine exists',
+    });
   });
 
   it('upgrade with no pin succeeds without acknowledgePinRemoval', async () => {

--- a/services/kiloclaw/src/routes/api-restart.test.ts
+++ b/services/kiloclaw/src/routes/api-restart.test.ts
@@ -1,0 +1,82 @@
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+import type { AppEnv } from '../types';
+import { api } from './api';
+
+type RestartFailure = {
+  success: false;
+  error: string;
+};
+
+function createRestartHarness(result: RestartFailure) {
+  const restartMachine = vi.fn().mockResolvedValue(result);
+  const app = new Hono<AppEnv>();
+  app.use('*', async (c, next) => {
+    c.set('userId', 'user-1');
+    await next();
+  });
+  app.route('/api', api);
+
+  return {
+    app,
+    env: {
+      KILOCLAW_INSTANCE: {
+        idFromName: (id: string) => id,
+        get: () => ({ restartMachine }),
+      },
+    } as never,
+    restartMachine,
+  };
+}
+
+async function postRestart(path: string, result: RestartFailure) {
+  const { app, env, restartMachine } = createRestartHarness(result);
+  const response = await app.request(
+    path,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    },
+    env
+  );
+
+  return { response, restartMachine };
+}
+
+describe('admin machine restart route failures', () => {
+  it('returns 404 when no machine runtime exists', async () => {
+    const { response, restartMachine } = await postRestart('/api/admin/machine/restart', {
+      success: false,
+      error: 'No machine exists',
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ success: false, error: 'No machine exists' });
+    expect(restartMachine).toHaveBeenCalledWith(undefined);
+  });
+
+  it('keeps the backward-compatible restart alias on the same 404 contract', async () => {
+    const { response, restartMachine } = await postRestart('/api/admin/gateway/restart', {
+      success: false,
+      error: 'No machine exists',
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ success: false, error: 'No machine exists' });
+    expect(restartMachine).toHaveBeenCalledWith(undefined);
+  });
+
+  it('keeps unexpected restart failures on a 500 response', async () => {
+    const { response } = await postRestart('/api/admin/machine/restart', {
+      success: false,
+      error: 'Fly control plane unavailable',
+    });
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: 'Fly control plane unavailable',
+    });
+  });
+});

--- a/services/kiloclaw/src/routes/api.ts
+++ b/services/kiloclaw/src/routes/api.ts
@@ -65,6 +65,10 @@ async function verifyInstanceOwnership(
   return null;
 }
 
+function restartMachineFailureStatus(error: string | undefined): 404 | 500 {
+  return error === 'No machine exists' ? 404 : 500;
+}
+
 /**
  * Admin API routes -- all operations go through the KiloClawInstance DO.
  */
@@ -111,7 +115,10 @@ adminApi.post('/machine/restart', c =>
           : 'Machine restarting with updated configuration...',
       });
     } else {
-      return c.json({ success: false, error: result.error }, 500);
+      return c.json(
+        { success: false, error: result.error },
+        restartMachineFailureStatus(result.error)
+      );
     }
   })
 );
@@ -144,7 +151,10 @@ adminApi.post('/gateway/restart', c =>
           : 'Machine restarting with updated configuration...',
       });
     } else {
-      return c.json({ success: false, error: result.error }, 500);
+      return c.json(
+        { success: false, error: result.error },
+        restartMachineFailureStatus(result.error)
+      );
     }
   })
 );


### PR DESCRIPTION
## Summary
- Treat restart `No machine exists` as HTTP 404 from Worker restart routes, including backward-compatible alias, so expected resource state stops surfacing as generic infrastructure failure.
- Preserve allowlisted Worker error detail in `KiloClawUserClient` and translate restart missing-runtime failures to tRPC `NOT_FOUND`.
- Add focused route, client, and router regression coverage for HTTP classification, alias parity, safe response-body propagation, and tRPC mapping.

## Verification
N/A - no manual verification performed.

## Visual Changes
N/A

## Reviewer Notes
- Restart classification stays intentionally narrow: only exact `No machine exists` becomes 404; unexpected restart failures keep existing 5xx behavior.
- Worker response retention is allowlisted to `success`, `error`, and `code` before logging or propagation.