### PR TITLE
fix(kiloclaw): hide composio onboarding step

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -289,7 +289,11 @@ function ClawOnboardingFlowInner({
   const mutations = organizationId ? orgMutations : personalMutations;
 
   const { data: currentUser } = useUser();
-  const hasCalendarStep = true;
+  // TEMPORARY: managed Composio onboarding is broken; hide the tools step and
+  // the legacy calendar step until the flow is fixed. Re-enable by flipping
+  // `hasToolsStep` back to true (and restoring `hasCalendarStep` if calendar
+  // is meant to come back too).
+  const hasCalendarStep = false;
   // Morning briefing is generally available — the Interests step shows for
   // all users (it still gates on controller version below).
   // Gate on controller version. The plugin route that backs
@@ -337,7 +341,11 @@ function ClawOnboardingFlowInner({
     composioStatusPolling
   );
   const composioStatus = organizationId ? orgComposioStatus : personalComposioStatus;
-  const hasToolsStep = true;
+  // See `hasCalendarStep` above — managed Composio onboarding is temporarily
+  // hidden. Identity completion now provisions directly and skips to email,
+  // passing `skipIncompleteManagedComposioConnection` so a stale managed
+  // identity from a prior broken attempt can't block provisioning.
+  const hasToolsStep = false;
   const configQuery = useClawConfig(status !== undefined && status.status !== null);
   const composioManualConfigured = composioStatus.data?.sandboxConfigSource === 'manual';
   const composioConfigPending =
@@ -894,10 +902,14 @@ function ClawOnboardingFlowInner({
             }
             setOnboardingStep('tools');
           } else if (hasCalendarStep) {
-            if (!flowState.instanceStatus) provisionInstance(weatherLocation?.location);
+            if (!flowState.instanceStatus) {
+              provisionInstance(weatherLocation?.location, undefined, true);
+            }
             setOnboardingStep('calendar');
           } else {
-            if (!flowState.instanceStatus) provisionInstance(weatherLocation?.location);
+            if (!flowState.instanceStatus) {
+              provisionInstance(weatherLocation?.location, undefined, true);
+            }
             setOnboardingStep('email');
           }
         }}


### PR DESCRIPTION
## Summary

The managed Composio/tools step in the KiloClaw onboarding wizard is broken;
hide it temporarily so new users don't get stuck. Identity completion now
routes straight to the email step and provisioning fires from there, exactly
the way the existing tools-step Skip button already worked.

Changes in `apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx`:

- `hasToolsStep` and `hasCalendarStep` are pinned to `false`. Calendar was
  already replaced by tools (`getRenderStepDecision` maps `calendar → tools`
  when `hasToolsStep` is true), so both flags need to be false to fully hide
  managed Composio onboarding from the wizard.
- The two non-tools branches in `renderIdentityStep` now pass
  `skipIncompleteManagedComposioConnection: true` to `provisionInstance`. This
  is defensive: if a user has a stale `kiloclaw_composio_identities` row
  without a completed `google_calendar_connected_account_id` from a prior
  broken attempt, `buildComposioProvisionSecrets` would otherwise throw
  `CONFLICT` and block provisioning. For users with no prior attempt this
  flag is a no-op.

`ConnectToolsStep`, the Composio mutations, the
`/api/integrations/composio/callback` route, and Settings are intentionally
untouched. Existing managed users keep their config; manual Composio
configuration in Settings remains available. Re-enable the onboarding step
by flipping \`hasToolsStep\` back to \`true\` (and restoring \`hasCalendarStep\`
if the legacy calendar step is meant to come back).

## Verification

- [ ] Manually walked through the onboarding wizard as a new user; identity
      completion advances directly to the email step and provisioning fires
      in the background.
- [ ]

## Visual Changes

| Before                                | After                              |
| ------------------------------------- | ---------------------------------- |
| Identity → Tools (Composio) → Email   | Identity → Email (Tools hidden)    |

## Reviewer Notes

- Two-flag rollback: flip \`hasToolsStep\` back to \`true\` to restore the
  managed Composio onboarding step.
- Settings (\`SettingsTab.tsx\`) is deliberately not gated. Already-provisioned
  managed users keep their existing config and reconnect path; if managed
  Composio is broken end-to-end and we want to suppress reconnects too, that
  is a follow-up.
- The \`?step=tools\` and \`?step=calendar\` URL resume paths and the Composio
  popup callback handler are still wired up. They're not reachable in
  practice once the tools step is hidden — there's no UI that opens the
  popup, and there are no live \`?step=...\` callbacks to come back from once
  the step has been off in production.
- Backend tolerates missing Composio secrets: \`buildComposioProvisionSecrets\`
  returns \`{ secrets: undefined, configToMark: null }\`, the controller
  best-efforts \`loginComposioCli\` and gates it on both env vars present, so
  hiding the step does not break provisioning.