### PR TITLE
fix(mobile): satisfy attachment picker lint

### DIFF
--- a/apps/mobile/src/components/kilo-chat/message-attachment-picker.test.ts
+++ b/apps/mobile/src/components/kilo-chat/message-attachment-picker.test.ts
@@ -59,10 +59,10 @@ describe('message attachment picker permissions', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // eslint-disable-next-line require-await, typescript-eslint/require-await -- canonical fetch stub: async signature with sync body
-    globalThis.fetch = vi.fn(
-      async () => new Response(new Blob(['x'], { type: 'image/jpeg' }))
-    ) as typeof globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => {
+      await Promise.resolve();
+      return new Response(new Blob(['x'], { type: 'image/jpeg' }));
+    }) as typeof globalThis.fetch;
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Removes the stale lint suppression on the mobile attachment picker fetch stub and makes the async mock include an explicit awaited boundary so the `require-await` lint rules pass on main.

## Verification

N/A - test-harness-only change; no manual UI path to exercise.

## Visual Changes

N/A

## Reviewer Notes

Fixes the `lint` failure from GitHub Actions run 26240894138 / job 77226702971.