### PR TITLE
fix(ci): invoke eas without global pnpm install

### DIFF
--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -71,14 +71,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install EAS CLI
-        run: pnpm install --global eas-cli@latest
-
       - name: Build and submit
         working-directory: apps/mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: eas build --profile production --platform all --submit --non-interactive
+        run: pnpx eas-cli@latest build --profile production --platform all --submit --non-interactive
 
       - name: Tag release
         run: |


### PR DESCRIPTION
## Summary

- Fixes the scheduled kilo-app release workflow after the pnpm 11 bump by removing the failing global `eas-cli` install step.
- Invokes EAS through `pnpx eas-cli@latest` from `apps/mobile`, matching the existing mobile release scripts and avoiding pnpm global-bin PATH setup.

## Verification

N/A - workflow-only change; I did not manually dispatch a production app release.

## Visual Changes

N/A

## Reviewer Notes

Recent scheduled runs are still triggering daily, but `build-and-submit` has failed since May 15 at `pnpm install --global eas-cli@latest` with pnpm's global bin directory missing from `PATH`.
