### PR TITLE
fix(cloud-agent-next): restore slash commands after reload

### DIFF
--- a/apps/web/src/lib/cloud-agent-next/event-types.ts
+++ b/apps/web/src/lib/cloud-agent-next/event-types.ts
@@ -10,7 +10,7 @@
  */
 export type CloudAgentEvent = {
   eventId: number;
-  executionId: string;
+  executionId: string | null;
   sessionId: string;
   streamEventType: string;
   timestamp: string;
@@ -58,7 +58,7 @@ export function isValidCloudAgentEvent(event: unknown): event is CloudAgentEvent
     'eventId' in event &&
     typeof event.eventId === 'number' &&
     'executionId' in event &&
-    typeof event.executionId === 'string' &&
+    (event.executionId === null || typeof event.executionId === 'string') &&
     'sessionId' in event &&
     typeof event.sessionId === 'string' &&
     'streamEventType' in event &&

--- a/apps/web/src/lib/cloud-agent-next/websocket-manager.ts
+++ b/apps/web/src/lib/cloud-agent-next/websocket-manager.ts
@@ -8,7 +8,7 @@ import {
 export type ConnectionState =
   | { status: 'disconnected' }
   | { status: 'connecting' }
-  | { status: 'connected'; executionId: string }
+  | { status: 'connected'; executionId: string | null }
   | { status: 'reconnecting'; lastEventId: number; attempt: number }
   | { status: 'refreshing_ticket' }
   | { status: 'error'; error: string; retryable: boolean };

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
@@ -143,6 +143,33 @@ describe('CloudAgentTransport event routing', () => {
     transport.destroy();
   });
 
+  it('routes cached command catalogs emitted without an execution ID', async () => {
+    const { transport, serviceEvents } = createTransportWithSinks();
+    const commands = [
+      {
+        name: 'deploy-prod',
+        description: 'Deploy production',
+        hints: ['$ARGUMENTS'],
+        source: 'command',
+      },
+    ];
+
+    transport.connect();
+    await flushPromises();
+    sendRaw({
+      eventId: 0,
+      executionId: null,
+      sessionId: 'ses-1',
+      streamEventType: 'commands.available',
+      timestamp: new Date().toISOString(),
+      data: { commands },
+    });
+
+    expect(serviceEvents).toContainEqual({ type: 'commands.available', commands });
+
+    transport.destroy();
+  });
+
   it('routes mixed events to correct sinks', async () => {
     const { transport, chatEvents, serviceEvents } = createTransportWithSinks();
 


### PR DESCRIPTION
## Summary

- Restore Cloud Agent Next session reload hydration so cached custom slash-command catalogs reach the browser again.
- Align the web stream event contract with session-level synthetic WebSocket events that intentionally omit an execution ID.
- Add regression coverage for `commands.available` events with `eventId: 0` and `executionId: null`, which are emitted when reconnecting to an existing session.

## Verification

- Manual browser verification was not performed in this session; the fix is scoped to the stream parsing and reconnect hydration boundary.
- [ ] Add any extra user-provided manual verification details.

## Visual Changes

N/A

## Reviewer Notes

- The worker already persists and resends cached command catalogs on `/stream` connect; this change fixes the browser-side contract mismatch that dropped those events.
- The nullable execution ID also applies to the synthetic `connected` event emitted on stream establishment, not to persisted execution events.