### PR TITLE
fix(usage): resolve table user labels

### DIFF
--- a/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
@@ -271,8 +271,13 @@ export function UsageAnalyticsDashboard({
     if (!effectiveOrgId) return [];
     const fromBreakdown = userBreakdown?.breakdown.map(b => b.key) ?? [];
     const fromFilters = [...filters.userIds, ...filters.excludedUserIds];
-    return Array.from(new Set([...fromBreakdown, ...fromFilters]));
-  }, [userBreakdown, effectiveOrgId, filters.userIds, filters.excludedUserIds]);
+    const fromTable =
+      tableData?.rows.flatMap(row => {
+        const userId = row.dimensions.user;
+        return userId ? [userId] : [];
+      }) ?? [];
+    return Array.from(new Set([...fromBreakdown, ...fromFilters, ...fromTable]));
+  }, [userBreakdown, effectiveOrgId, filters.userIds, filters.excludedUserIds, tableData]);
   const { data: userResolution } = useResolveOrgUsers(effectiveOrgId, userIds);
   const userLabelFor = useCallback(
     (value: string) => {

--- a/apps/web/src/routers/usage-analytics-router.ts
+++ b/apps/web/src/routers/usage-analytics-router.ts
@@ -637,9 +637,11 @@ const TableOutputSchema = z.object({
 // User list (for org context)
 // ---------------------------------------------------------------------------
 
+const MAX_USER_LABEL_LOOKUP_IDS = 1_000;
+
 const UserListInputSchema = z.object({
   organizationId: z.uuid(),
-  userIds: z.array(z.string()).max(200),
+  userIds: z.array(z.string()).max(MAX_USER_LABEL_LOOKUP_IDS),
 });
 
 const UserListOutputSchema = z.object({
@@ -1061,7 +1063,7 @@ export const usageAnalyticsRouter = createTRPCRouter({
 
   /**
    * Look up user names and emails for a set of user IDs that belong to an org.
-   * Used by the UI to decorate per-user breakdowns.
+   * Used by the UI to decorate per-user breakdowns, filters, and table rows.
    *
    * Only returns users that are active or invited members of `organizationId`
    * to prevent callers from enumerating arbitrary kilocode_users PII.


### PR DESCRIPTION
## Summary
- Resolve user IDs present only in the Detailed Breakdown table before rendering the User column, so org owners see email/name labels instead of raw IDs.
- Increase the org-user resolver batch cap to handle table-sized label lookups while preserving existing org-membership and role guards.

## Verification
N/A (not manually verified).

## Visual Changes
N/A

## Reviewer Notes
Unresolvable IDs still fall back to the raw usage key. The resolver continues to return only organization members, with non-owner/non-billing-manager callers limited to their own user ID.