### PR TITLE
DeployInfra - Align builder with latest OpenNext

### DIFF
--- a/services/deploy-infra/builder-docker-container/Dockerfile
+++ b/services/deploy-infra/builder-docker-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.6.9
+FROM docker.io/cloudflare/sandbox:0.6.11
 
 # Set command timeout to 10 min
 ENV COMMAND_TIMEOUT_MS=600000
@@ -44,8 +44,8 @@ RUN mise install go@1.25.4
 RUN mise use -g node@24 ruby@3.3 hugo@0.152.2 go@1.25.4
 
 # Build tool versions
-ARG OPENNEXTJS_VERSION=1.14.8
-ARG WRANGLER_VERSION=4.58.0
+ARG OPENNEXTJS_VERSION=1.19.11
+ARG WRANGLER_VERSION=4.90.1
 # Install build tools (opennext, wrangler) to a fixed location that's independent of
 # the active Node.js version. This avoids needing to reinstall when mise switches Node versions.
 ENV BUILD_TOOLS_DIR=/opt/build-tools

--- a/services/deploy-infra/builder-docker-container/container-files/build-nextjs.sh
+++ b/services/deploy-infra/builder-docker-container/container-files/build-nextjs.sh
@@ -22,10 +22,27 @@ error_exit() {
 
 cd "$PROJECT_DIR" || error_exit "Failed to change directory"
 
-# Validate Next.js version
-NEXTJS_VERSION=$(jq -r '.dependencies.next // .devDependencies.next // ""' package.json | sed 's/[^0-9.]//g' | cut -d. -f1)
-[ -z "$NEXTJS_VERSION" ] && error_exit "Next.js not found in package.json"
-[ "$NEXTJS_VERSION" != "14" ] && [ "$NEXTJS_VERSION" != "15" ] && [ "$NEXTJS_VERSION" != "16" ] && error_exit "Unsupported Next.js version: $NEXTJS_VERSION"
+# Validate Next.js version against the OpenNext support range.
+NEXTJS_SPEC=$(jq -r '.dependencies.next // .devDependencies.next // ""' package.json)
+[ -z "$NEXTJS_SPEC" ] && error_exit "Next.js not found in package.json"
+
+NEXTJS_VERSION=$(printf '%s' "$NEXTJS_SPEC" | sed -nE 's/^[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+if [[ "$NEXTJS_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    NEXTJS_MAJOR="${BASH_REMATCH[1]}"
+    NEXTJS_MINOR="${BASH_REMATCH[2]}"
+    NEXTJS_PATCH="${BASH_REMATCH[3]}"
+else
+    error_exit "Unsupported Next.js version spec: $NEXTJS_SPEC. OpenNext requires Next.js >=15.5.18 <16 or >=16.2.6"
+fi
+
+NEXTJS_SUPPORTED=false
+if [ "$NEXTJS_MAJOR" = "15" ]; then
+    [ "$NEXTJS_MINOR" -gt 5 ] || { [ "$NEXTJS_MINOR" -eq 5 ] && [ "$NEXTJS_PATCH" -ge 18 ]; } && NEXTJS_SUPPORTED=true
+elif [ "$NEXTJS_MAJOR" = "16" ]; then
+    [ "$NEXTJS_MINOR" -gt 2 ] || { [ "$NEXTJS_MINOR" -eq 2 ] && [ "$NEXTJS_PATCH" -ge 6 ]; } && NEXTJS_SUPPORTED=true
+fi
+
+[ "$NEXTJS_SUPPORTED" != "true" ] && error_exit "Unsupported Next.js version: $NEXTJS_SPEC. OpenNext requires Next.js >=15.5.18 <16 or >=16.2.6"
 
 echo "Next.js version $NEXTJS_VERSION"
 


### PR DESCRIPTION
## Summary
- Update the deploy builder image to `cloudflare/sandbox:0.6.11`.
- Refresh bundled build tooling to `@opennextjs/cloudflare` 1.19.11 and Wrangler 4.90.1.
- Reject Next.js versions outside OpenNext's supported `>=15.5.18 <16 || >=16.2.6` range before starting a deploy build.

## Verification
- N/A - no manual sandbox deployment was run for this maintenance update.

## Visual Changes
N/A

## Reviewer Notes
- The deploy script now rejects incomplete Next.js specs such as `^16`, rather than allowing them and relying on OpenNext to fail later.
- A full Docker image build was not run in this session.