### PR TITLE
feat(kiloclaw) orphan volume reaper fixes

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
@@ -335,13 +335,14 @@ function OrphanVolumesSection() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <HardDrive className="h-5 w-5" />
-            Orphan Volume Reaper
+            Leftover Volume Cleanup
           </CardTitle>
           <CardDescription>
-            Scan destroyed KiloClaw instances for Fly volumes that were never cleaned up. A volume
-            is only marked <span className="font-medium">Safe to destroy</span> when it is
-            unattached, no live Durable Object references it, the user has no active subscription,
-            and the instance has been destroyed for more than 7 days.
+            Scan destroyed KiloClaw instances for the Fly volumes they left behind. Only rows marked{' '}
+            <span className="font-medium">Safe to destroy</span> are reapable orphans: unattached,
+            no live Durable Object, no access-granting subscription, and destroyed more than 7 days
+            ago. Other rows are listed for triage and cannot be destroyed here. Volumes Fly is
+            already reaping, and instances still inside the grace period, are omitted.
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
@@ -465,10 +466,12 @@ function OrphanVolumesSection() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Detected Orphan Volumes</CardTitle>
+          <CardTitle>Volumes for Destroyed Instances</CardTitle>
           <CardDescription>
-            Fly volumes still present for destroyed instances. The destroy action is only available
-            for volumes that pass every safety check.
+            Fly volumes still present for destroyed instances. Only{' '}
+            <span className="font-medium">Safe to destroy</span> rows are true orphans with a
+            destroy action; every other row is shown so you can see what is stranded and why it was
+            withheld.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -477,7 +480,9 @@ function OrphanVolumesSection() {
               Choose a date range and run a scan to inspect destroyed instances.
             </p>
           ) : scanResult.volumes.length === 0 ? (
-            <p className="text-muted-foreground text-sm">No orphan volumes found.</p>
+            <p className="text-muted-foreground text-sm">
+              No leftover volumes found for destroyed instances in this window.
+            </p>
           ) : (
             <div className="rounded-lg border">
               <Table>

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
@@ -220,6 +220,11 @@ const VOLUME_CLASSIFICATION_DISPLAY: Record<
     tone: 'warn',
     help: 'User still has an access-granting subscription — data preserved.',
   },
+  destruction_scheduled: {
+    label: 'Destruction scheduled',
+    tone: 'muted',
+    help: 'A billing destruction deadline is still pending — the lifecycle reaper will reap this instance and its volume. Only a true orphan if that reaper fails.',
+  },
   within_grace: {
     label: 'Within 7-day grace',
     tone: 'muted',
@@ -495,6 +500,8 @@ function OrphanVolumesSection() {
                       <TableCell>
                         <Link
                           href={`/admin/users/${encodeURIComponent(volume.user_id)}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
                           className="text-blue-600 hover:underline"
                         >
                           {volume.user_email || volume.user_id}
@@ -822,6 +829,8 @@ export function KiloclawOrphansTab() {
                       <TableCell>
                         <Link
                           href={`/admin/users/${encodeURIComponent(orphan.user_id)}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
                           className="text-blue-600 hover:underline"
                         >
                           {orphan.user_email || orphan.user_id}

--- a/apps/web/src/lib/kiloclaw/orphan-volume.test.ts
+++ b/apps/web/src/lib/kiloclaw/orphan-volume.test.ts
@@ -8,6 +8,7 @@ const SAFE = {
   doStatus: null,
   doStatusError: null,
   hasAccessGrantingSubscription: false,
+  destructionScheduled: false,
   graceElapsed: true,
 } as const;
 
@@ -54,6 +55,12 @@ describe('classifyOrphanVolume', () => {
     );
   });
 
+  it('refuses while a billing destruction deadline is still pending', () => {
+    expect(classifyOrphanVolume({ ...SAFE, destructionScheduled: true })).toBe(
+      'destruction_scheduled'
+    );
+  });
+
   it('refuses while the instance is still inside the grace period', () => {
     expect(classifyOrphanVolume({ ...SAFE, graceElapsed: false })).toBe('within_grace');
   });
@@ -68,6 +75,7 @@ describe('classifyOrphanVolume', () => {
           doStatus: 'running',
           doStatusError: 'unreachable',
           hasAccessGrantingSubscription: true,
+          destructionScheduled: true,
           graceElapsed: false,
         })
       ).toBe('do_check_failed');
@@ -103,14 +111,25 @@ describe('classifyOrphanVolume', () => {
       );
     });
 
-    it('subscription_active outranks within_grace', () => {
+    it('subscription_active outranks destruction_scheduled and within_grace', () => {
       expect(
         classifyOrphanVolume({
           ...SAFE,
           hasAccessGrantingSubscription: true,
+          destructionScheduled: true,
           graceElapsed: false,
         })
       ).toBe('subscription_active');
+    });
+
+    it('destruction_scheduled outranks within_grace', () => {
+      expect(
+        classifyOrphanVolume({
+          ...SAFE,
+          destructionScheduled: true,
+          graceElapsed: false,
+        })
+      ).toBe('destruction_scheduled');
     });
   });
 });

--- a/apps/web/src/lib/kiloclaw/orphan-volume.ts
+++ b/apps/web/src/lib/kiloclaw/orphan-volume.ts
@@ -64,6 +64,7 @@ export type OrphanVolumeClassification =
   | 'do_alive'
   | 'do_check_failed'
   | 'subscription_active'
+  | 'destruction_scheduled'
   | 'within_grace';
 
 /**
@@ -79,6 +80,7 @@ export function classifyOrphanVolume(params: {
   doStatus: string | null;
   doStatusError: string | null;
   hasAccessGrantingSubscription: boolean;
+  destructionScheduled: boolean;
   graceElapsed: boolean;
 }): OrphanVolumeClassification {
   // Cannot confirm DO state → cannot rule out a live reference. Fail closed.
@@ -99,6 +101,10 @@ export function classifyOrphanVolume(params: {
   if (params.doStatus !== null) return 'do_alive';
   // The user still has product access; preserve their data.
   if (params.hasAccessGrantingSubscription) return 'subscription_active';
+  // A billing destruction deadline is still pending — the kiloclaw-billing
+  // lifecycle reaper is already scheduled to destroy this user's instance
+  // and its volume. Not a true orphan yet; only one if that reaper fails.
+  if (params.destructionScheduled) return 'destruction_scheduled';
   // Destroyed too recently — let Fly / the DO sweep self-heal first.
   if (!params.graceElapsed) return 'within_grace';
   return 'safe_destroy';

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -2892,6 +2892,37 @@ describe('admin.kiloclawInstances.destroyOrphanVolume', () => {
     expect(mockDestroyOrphanVolume).not.toHaveBeenCalled();
   });
 
+  it('rejects when a newer destruction of the same sandbox is within grace', async () => {
+    // The submitted row was destroyed long ago, but the sandbox was
+    // reprovisioned and destroyed again recently. Grace runs from the latest
+    // destruction, so the older row must not reap the shared volume early.
+    const sandboxId = `ki_${crypto.randomUUID().replace(/-/g, '')}`;
+    const [oldInstance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        id: crypto.randomUUID(),
+        user_id: regularUser.id,
+        sandbox_id: sandboxId,
+        destroyed_at: daysAgo(30),
+      })
+      .returning({ id: kiloclaw_instances.id });
+    await db.insert(kiloclaw_instances).values({
+      id: crypto.randomUUID(),
+      user_id: regularUser.id,
+      sandbox_id: sandboxId,
+      destroyed_at: daysAgo(2),
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.destroyOrphanVolume({
+        instanceId: oldInstance.id,
+        volumeId: VOLUME_ID,
+      })
+    ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
+    expect(mockDestroyOrphanVolume).not.toHaveBeenCalled();
+  });
+
   it('rejects when the user has an access-granting subscription', async () => {
     const instanceId = await insertDestroyedInstance({
       destroyedAt: daysAgo(30),

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -3835,20 +3835,23 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     const MAX_SCAN = 500;
     const CONCURRENCY = 10;
 
-    // 1. Destroyed instances in the window, deduplicated to one row per
-    //    (user, sandbox).
+    // 1. The latest destroyed row per (user, sandbox), restricted to the
+    //    requested window.
     //
     //    `UQ_kiloclaw_instances_active` is a PARTIAL unique index — it only
     //    covers live rows (`WHERE destroyed_at IS NULL`) — so a sandbox that
     //    has been reprovisioned accumulates many destroyed `kiloclaw_instances`
-    //    rows that all share one `sandbox_id`. Every one of them derives the
-    //    SAME Fly volume name, so scanning each separately would surface the
-    //    same volume once per destroyed row (the duplicate-rows bug).
+    //    rows that all share one `sandbox_id`, hence one Fly volume name.
+    //    Scanning each separately would surface the same volume once per row.
     //
-    //    `selectDistinctOn` keeps only the most recently destroyed row per
-    //    sandbox. That row's `destroyed_at` is also the correct one to
-    //    measure the grace period against: the volume stayed in use until
-    //    the last instance backed by it was destroyed.
+    //    `selectDistinctOn` collapses them to the single most-recent destroyed
+    //    row per sandbox. It runs over ALL destroyed rows, NOT just the window,
+    //    so the row it keeps is the genuine latest destruction — the correct
+    //    `destroyed_at` to measure the grace period against. The window filter
+    //    is then applied to that latest row in the outer query, so a sandbox
+    //    whose latest destruction falls outside the window is omitted entirely
+    //    rather than represented by a stale older row (which would compute the
+    //    grace period from the wrong, earlier timestamp).
     //
     //    leftJoin on subscriptions: a missing subscription row is fine (no
     //    access to preserve); `UQ_kiloclaw_subscriptions_instance` guarantees
@@ -3872,13 +3875,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         kiloclaw_subscriptions,
         eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id)
       )
-      .where(
-        and(
-          isNotNull(kiloclaw_instances.destroyed_at),
-          gte(kiloclaw_instances.destroyed_at, input.destroyedAfter),
-          lte(kiloclaw_instances.destroyed_at, input.destroyedBefore)
-        )
-      )
+      .where(isNotNull(kiloclaw_instances.destroyed_at))
       .orderBy(
         kiloclaw_instances.user_id,
         kiloclaw_instances.sandbox_id,
@@ -3886,11 +3883,19 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       )
       .as('destroyed_instances_by_latest');
 
-    // Wrap the dedup in a subquery so the recency ordering and the scan cap
-    // apply to unique sandboxes, not raw rows.
+    // Apply the requested window to the deduplicated latest row, then order
+    // by recency and cap. Filtering here (not inside the subquery) is what
+    // guarantees the window is matched against each sandbox's genuine latest
+    // destruction.
     const instances = await db
       .select()
       .from(destroyedInstancesByLatest)
+      .where(
+        and(
+          gte(destroyedInstancesByLatest.destroyed_at, input.destroyedAfter),
+          lte(destroyedInstancesByLatest.destroyed_at, input.destroyedBefore)
+        )
+      )
       .orderBy(desc(destroyedInstancesByLatest.destroyed_at))
       .limit(MAX_SCAN + 1);
 
@@ -4068,6 +4073,17 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           sandbox_id: kiloclaw_instances.sandbox_id,
           organization_id: kiloclaw_instances.organization_id,
           destroyed_at: kiloclaw_instances.destroyed_at,
+          // The latest `destroyed_at` across every destroyed row of this
+          // (user, sandbox). A reprovisioned sandbox has several destroyed
+          // rows sharing one Fly volume; the grace period runs from the most
+          // recent destruction, not whichever row the admin selected.
+          latest_sandbox_destroyed_at: sql<string | null>`(
+            select max(latest.destroyed_at)
+            from ${kiloclaw_instances} as latest
+            where latest.user_id = ${kiloclaw_instances.user_id}
+              and latest.sandbox_id = ${kiloclaw_instances.sandbox_id}
+              and latest.destroyed_at is not null
+          )`,
         })
         .from(kiloclaw_instances)
         .where(eq(kiloclaw_instances.id, input.instanceId))
@@ -4086,9 +4102,11 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         });
       }
 
-      // 3. Grace period — give Fly + the DO sweep time to self-heal first.
+      // 3. Grace period, measured from the latest destruction of this
+      //    sandbox — give Fly + the DO sweep time to self-heal first.
       const now = new Date();
-      const destroyedMsAgo = now.getTime() - new Date(row.destroyed_at).getTime();
+      const latestDestroyedAt = row.latest_sandbox_destroyed_at ?? row.destroyed_at;
+      const destroyedMsAgo = now.getTime() - new Date(latestDestroyedAt).getTime();
       if (destroyedMsAgo <= ORPHAN_VOLUME_GRACE_PERIOD_MS) {
         throw new TRPCError({
           code: 'PRECONDITION_FAILED',

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -1,10 +1,6 @@
 import { adminProcedure, createTRPCRouter, UpstreamApiError } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
-import {
-  getAccessGrantingOrphanVolumeContexts,
-  insertKiloClawSubscriptionChangeLog,
-  orphanVolumeSubscriptionContextKey,
-} from '@kilocode/db';
+import { getOrphanVolumeUserProtections, insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import { createHash } from 'crypto';
 import {
   kiloclaw_instances,
@@ -3835,12 +3831,26 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     const MAX_SCAN = 500;
     const CONCURRENCY = 10;
 
-    // 1. Destroyed instances in the window, with user + subscription joins.
+    // 1. Destroyed instances in the window, deduplicated to one row per
+    //    (user, sandbox).
+    //
+    //    `UQ_kiloclaw_instances_active` is a PARTIAL unique index — it only
+    //    covers live rows (`WHERE destroyed_at IS NULL`) — so a sandbox that
+    //    has been reprovisioned accumulates many destroyed `kiloclaw_instances`
+    //    rows that all share one `sandbox_id`. Every one of them derives the
+    //    SAME Fly volume name, so scanning each separately would surface the
+    //    same volume once per destroyed row (the duplicate-rows bug).
+    //
+    //    `selectDistinctOn` keeps only the most recently destroyed row per
+    //    sandbox. That row's `destroyed_at` is also the correct one to
+    //    measure the grace period against: the volume stayed in use until
+    //    the last instance backed by it was destroyed.
+    //
     //    leftJoin on subscriptions: a missing subscription row is fine (no
     //    access to preserve); `UQ_kiloclaw_subscriptions_instance` guarantees
     //    at most one subscription per instance, so the join stays 1:1.
-    const instances = await db
-      .select({
+    const destroyedInstancesByLatest = db
+      .selectDistinctOn([kiloclaw_instances.user_id, kiloclaw_instances.sandbox_id], {
         id: kiloclaw_instances.id,
         user_id: kiloclaw_instances.user_id,
         sandbox_id: kiloclaw_instances.sandbox_id,
@@ -3865,7 +3875,19 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           lte(kiloclaw_instances.destroyed_at, input.destroyedBefore)
         )
       )
-      .orderBy(desc(kiloclaw_instances.destroyed_at))
+      .orderBy(
+        kiloclaw_instances.user_id,
+        kiloclaw_instances.sandbox_id,
+        desc(kiloclaw_instances.destroyed_at)
+      )
+      .as('destroyed_instances_by_latest');
+
+    // Wrap the dedup in a subquery so the recency ordering and the scan cap
+    // apply to unique sandboxes, not raw rows.
+    const instances = await db
+      .select()
+      .from(destroyedInstancesByLatest)
+      .orderBy(desc(destroyedInstancesByLatest.destroyed_at))
       .limit(MAX_SCAN + 1);
 
     const capped = instances.length > MAX_SCAN;
@@ -3909,14 +3931,12 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
 
     const client = new KiloClawInternalClient();
     const now = new Date();
-    const accessGrantingContextKeys = await getAccessGrantingOrphanVolumeContexts(
-      db,
-      toScan.map(instance => ({
-        user_id: instance.user_id,
-        organization_id: instance.organization_id,
-      })),
-      now
-    );
+    const { accessGrantingUserIds, pendingDestructionUserIds } =
+      await getOrphanVolumeUserProtections(
+        db,
+        toScan.map(instance => instance.user_id),
+        now
+      );
     const volumes: VolumeRow[] = [];
     const errors: ScanErrorRow[] = [];
 
@@ -3963,12 +3983,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         const destroyedAt = instance.destroyed_at as string;
         const graceElapsed =
           now.getTime() - new Date(destroyedAt).getTime() > ORPHAN_VOLUME_GRACE_PERIOD_MS;
-        const hasAccess = accessGrantingContextKeys.has(
-          orphanVolumeSubscriptionContextKey({
-            user_id: instance.user_id,
-            organization_id: instance.organization_id,
-          })
-        );
+        const hasAccess = accessGrantingUserIds.has(instance.user_id);
+        const destructionScheduled = pendingDestructionUserIds.has(instance.user_id);
 
         // Only volumes whose name exactly matches THIS instance are ours.
         // A non-matching volume belongs to a different (possibly live)
@@ -4001,6 +4017,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
               doStatus: scan.doStatus,
               doStatusError: scan.doStatusError,
               hasAccessGrantingSubscription: hasAccess,
+              destructionScheduled,
               graceElapsed,
             }),
           });
@@ -4059,27 +4076,26 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         });
       }
 
-      // 4. Subscription guard — never destroy data while this ownership
-      //    context still has access (active / unsuspended past_due / live trial).
-      //    Reprovision transfers cancel the destroyed instance's predecessor
-      //    row and move access to a current successor row, so this lookup must
-      //    evaluate the context rather than only the destroyed instance.
-      const accessGrantingContextKeys = await getAccessGrantingOrphanVolumeContexts(
-        db,
-        [{ user_id: row.user_id, organization_id: row.organization_id }],
-        now
-      );
-      if (
-        accessGrantingContextKeys.has(
-          orphanVolumeSubscriptionContextKey({
-            user_id: row.user_id,
-            organization_id: row.organization_id,
-          })
-        )
-      ) {
+      // 4. Subscription guard — never destroy data while the owning user
+      //    still has access (active / unsuspended past_due / live trial), or
+      //    while the billing lifecycle reaper is still scheduled to destroy
+      //    it (a future `destruction_deadline`). Checked per-user, not
+      //    per-instance: a reprovision transfer moves access to a current
+      //    successor subscription, and a subscription may have no
+      //    `instance_id` link at all.
+      const { accessGrantingUserIds, pendingDestructionUserIds } =
+        await getOrphanVolumeUserProtections(db, [row.user_id], now);
+      if (accessGrantingUserIds.has(row.user_id)) {
         throw new TRPCError({
           code: 'FORBIDDEN',
           message: 'User has an access-granting subscription — volume preserved',
+        });
+      }
+      if (pendingDestructionUserIds.has(row.user_id)) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message:
+            'A billing destruction deadline is still pending — the lifecycle reaper will handle it',
         });
       }
 

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -1,6 +1,10 @@
 import { adminProcedure, createTRPCRouter, UpstreamApiError } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
-import { getOrphanVolumeUserProtections, insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
+import {
+  getOrphanVolumeContextProtections,
+  insertKiloClawSubscriptionChangeLog,
+  orphanVolumeSubscriptionContextKey,
+} from '@kilocode/db';
 import { createHash } from 'crypto';
 import {
   kiloclaw_instances,
@@ -3931,10 +3935,13 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
 
     const client = new KiloClawInternalClient();
     const now = new Date();
-    const { accessGrantingUserIds, pendingDestructionUserIds } =
-      await getOrphanVolumeUserProtections(
+    const { accessGrantingContextKeys, pendingDestructionContextKeys } =
+      await getOrphanVolumeContextProtections(
         db,
-        toScan.map(instance => instance.user_id),
+        toScan.map(instance => ({
+          user_id: instance.user_id,
+          organization_id: instance.organization_id,
+        })),
         now
       );
     const volumes: VolumeRow[] = [];
@@ -3983,8 +3990,12 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         const destroyedAt = instance.destroyed_at as string;
         const graceElapsed =
           now.getTime() - new Date(destroyedAt).getTime() > ORPHAN_VOLUME_GRACE_PERIOD_MS;
-        const hasAccess = accessGrantingUserIds.has(instance.user_id);
-        const destructionScheduled = pendingDestructionUserIds.has(instance.user_id);
+        const contextKey = orphanVolumeSubscriptionContextKey({
+          user_id: instance.user_id,
+          organization_id: instance.organization_id,
+        });
+        const hasAccess = accessGrantingContextKeys.has(contextKey);
+        const destructionScheduled = pendingDestructionContextKeys.has(contextKey);
 
         // Only volumes whose name exactly matches THIS instance are ours.
         // A non-matching volume belongs to a different (possibly live)
@@ -4076,22 +4087,26 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         });
       }
 
-      // 4. Subscription guard — never destroy data while the owning user
-      //    still has access (active / unsuspended past_due / live trial), or
-      //    while the billing lifecycle reaper is still scheduled to destroy
-      //    it (a future `destruction_deadline`). Checked per-user, not
-      //    per-instance: a reprovision transfer moves access to a current
-      //    successor subscription, and a subscription may have no
-      //    `instance_id` link at all.
-      const { accessGrantingUserIds, pendingDestructionUserIds } =
-        await getOrphanVolumeUserProtections(db, [row.user_id], now);
-      if (accessGrantingUserIds.has(row.user_id)) {
+      // 4. Subscription guard — never destroy data while this ownership
+      //    context still has access (active / unsuspended past_due / live trial),
+      //    or while the billing lifecycle reaper is still scheduled to destroy
+      //    it (a future `destruction_deadline`). Reprovision transfers move
+      //    access to a current successor row; a detached current row has no
+      //    resolvable context, so the shared lookup fails closed for the user.
+      const context = {
+        user_id: row.user_id,
+        organization_id: row.organization_id,
+      };
+      const { accessGrantingContextKeys, pendingDestructionContextKeys } =
+        await getOrphanVolumeContextProtections(db, [context], now);
+      const contextKey = orphanVolumeSubscriptionContextKey(context);
+      if (accessGrantingContextKeys.has(contextKey)) {
         throw new TRPCError({
           code: 'FORBIDDEN',
           message: 'User has an access-granting subscription — volume preserved',
         });
       }
-      if (pendingDestructionUserIds.has(row.user_id)) {
+      if (pendingDestructionContextKeys.has(contextKey)) {
         throw new TRPCError({
           code: 'FORBIDDEN',
           message:

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -4004,6 +4004,24 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           if (!v.nameMatchesInstance) continue;
           if (v.state === 'destroyed') continue; // already gone — noise
 
+          const classification = classifyOrphanVolume({
+            volumeState: v.state,
+            attachedMachineId: v.attached_machine_id,
+            trackedByLiveDo: v.trackedByLiveDo,
+            doStatus: scan.doStatus,
+            doStatusError: scan.doStatusError,
+            hasAccessGrantingSubscription: hasAccess,
+            destructionScheduled,
+            graceElapsed,
+          });
+          // Omit transient, self-healing rows: Fly is already reaping the
+          // volume, or the instance is still inside the grace period. Neither
+          // is actionable here and both resolve without admin intervention,
+          // so listing them is just noise.
+          if (classification === 'fly_reaping' || classification === 'within_grace') {
+            continue;
+          }
+
           volumes.push({
             instance_id: instance.id,
             user_id: instance.user_id,
@@ -4021,16 +4039,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             attached_machine_id: v.attached_machine_id,
             volume_created_at: v.created_at,
             do_status: scan.doStatus,
-            classification: classifyOrphanVolume({
-              volumeState: v.state,
-              attachedMachineId: v.attached_machine_id,
-              trackedByLiveDo: v.trackedByLiveDo,
-              doStatus: scan.doStatus,
-              doStatusError: scan.doStatusError,
-              hasAccessGrantingSubscription: hasAccess,
-              destructionScheduled,
-              graceElapsed,
-            }),
+            classification,
           });
         }
       }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -23,9 +23,11 @@ export {
   type DestroyedInstanceRow,
 } from './kiloclaw-personal-subscription-collapse';
 export {
-  getOrphanVolumeUserProtections,
+  getOrphanVolumeContextProtections,
   ORPHAN_VOLUME_GRACE_PERIOD_MS,
-  type OrphanVolumeUserProtections,
+  orphanVolumeSubscriptionContextKey,
+  type OrphanVolumeContextProtections,
+  type OrphanVolumeSubscriptionContext,
 } from './kiloclaw-orphan-volume';
 export { computeDatabaseUrl, getDatabaseClientConfig } from './database-url';
 export {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -23,10 +23,9 @@ export {
   type DestroyedInstanceRow,
 } from './kiloclaw-personal-subscription-collapse';
 export {
-  getAccessGrantingOrphanVolumeContexts,
+  getOrphanVolumeUserProtections,
   ORPHAN_VOLUME_GRACE_PERIOD_MS,
-  orphanVolumeSubscriptionContextKey,
-  type OrphanVolumeSubscriptionContext,
+  type OrphanVolumeUserProtections,
 } from './kiloclaw-orphan-volume';
 export { computeDatabaseUrl, getDatabaseClientConfig } from './database-url';
 export {

--- a/packages/db/src/kiloclaw-orphan-volume.ts
+++ b/packages/db/src/kiloclaw-orphan-volume.ts
@@ -6,11 +6,11 @@
  * definition — both sides enforce these gates, so they must not drift.
  */
 
-import { and, inArray, isNull } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 
 import type { WorkerDb } from './client';
 import { isAccessGrantingSubscription } from './kiloclaw-personal-subscription-collapse';
-import { kiloclaw_subscriptions } from './schema';
+import { kiloclaw_instances, kiloclaw_subscriptions } from './schema';
 
 /**
  * Minimum age, since its owning instance was destroyed, before a leftover
@@ -23,82 +23,114 @@ export const ORPHAN_VOLUME_GRACE_PERIOD_MS = 7 * 24 * 60 * 60 * 1000;
 /** Minimal drizzle executor surface — satisfied by both web and worker DBs. */
 type OrphanVolumeContextExecutor = Pick<WorkerDb, 'select'>;
 
-/**
- * Per-user signals that withhold a leftover volume from the orphan reaper.
- * A volume is reaper-eligible only when its owning user appears in NEITHER
- * set.
- */
-export type OrphanVolumeUserProtections = {
-  /**
-   * Users with a current access-granting subscription — an `active` one, an
-   * unsuspended `past_due` one, or a `trialing` one whose `trial_ends_at`
-   * has not passed. Their data must be preserved.
-   */
-  accessGrantingUserIds: Set<string>;
-  /**
-   * Users with a current subscription whose billing `destruction_deadline`
-   * is still in the future. The kiloclaw-billing lifecycle reaper is already
-   * scheduled to destroy that subscription's instance (and, with it, the
-   * volume) once the deadline passes — so a leftover volume is not a true
-   * orphan yet. It only becomes one if that reaper later fails, i.e. once
-   * the deadline is in the past and the volume is still present.
-   */
-  pendingDestructionUserIds: Set<string>;
+/** The ownership context a leftover volume belongs to. */
+export type OrphanVolumeSubscriptionContext = {
+  user_id: string;
+  organization_id: string | null;
 };
 
+/** Signals that withhold leftover volumes from the orphan reaper. */
+export type OrphanVolumeContextProtections = {
+  accessGrantingContextKeys: Set<string>;
+  pendingDestructionContextKeys: Set<string>;
+};
+
+/** Stable string key for a volume ownership context. */
+export function orphanVolumeSubscriptionContextKey(
+  context: OrphanVolumeSubscriptionContext
+): string {
+  return JSON.stringify([context.user_id, context.organization_id]);
+}
+
 /**
- * For the given users, resolve the per-user signals that withhold their
+ * For the given volume ownership contexts, resolve signals that withhold
  * leftover volumes from the orphan reaper.
  *
  * "Current" means `transferred_to_subscription_id IS NULL` — the head of
- * any reprovision transfer chain.
- *
- * The check is per-user and deliberately ignores which instance a
- * subscription is linked to. `kiloclaw_subscriptions.instance_id` is
- * nullable, so an instance-joined version silently dropped any subscription
- * whose `instance_id` was absent — treating an active or trialing user as
- * having no access and making their leftover volumes look reapable (a
- * data-loss false positive). Keying purely on the user removes that hole.
+ * any reprovision transfer chain. Linked subscriptions protect only their
+ * exact ownership context. A current subscription with no resolvable instance
+ * context is ambiguous, so it fails closed across every requested context for
+ * that user instead of silently making one of their leftover volumes reapable.
  */
-export async function getOrphanVolumeUserProtections(
+export async function getOrphanVolumeContextProtections(
   executor: OrphanVolumeContextExecutor,
-  userIds: string[],
+  contexts: OrphanVolumeSubscriptionContext[],
   now: Date
-): Promise<OrphanVolumeUserProtections> {
-  const uniqueUserIds = [...new Set(userIds)];
-  if (uniqueUserIds.length === 0) {
-    return { accessGrantingUserIds: new Set(), pendingDestructionUserIds: new Set() };
+): Promise<OrphanVolumeContextProtections> {
+  const requestedContextKeys = new Set(contexts.map(orphanVolumeSubscriptionContextKey));
+  const contextKeysByUserId = new Map<string, Set<string>>();
+  for (const context of contexts) {
+    const contextKey = orphanVolumeSubscriptionContextKey(context);
+    const userContextKeys = contextKeysByUserId.get(context.user_id) ?? new Set<string>();
+    userContextKeys.add(contextKey);
+    contextKeysByUserId.set(context.user_id, userContextKeys);
+  }
+
+  const userIds = [...contextKeysByUserId.keys()];
+  if (userIds.length === 0) {
+    return { accessGrantingContextKeys: new Set(), pendingDestructionContextKeys: new Set() };
   }
 
   const currentSubscriptions = await executor
     .select({
       user_id: kiloclaw_subscriptions.user_id,
+      instance_id: kiloclaw_subscriptions.instance_id,
+      instance_user_id: kiloclaw_instances.user_id,
+      organization_id: kiloclaw_instances.organization_id,
       status: kiloclaw_subscriptions.status,
       suspended_at: kiloclaw_subscriptions.suspended_at,
       trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
       destruction_deadline: kiloclaw_subscriptions.destruction_deadline,
     })
     .from(kiloclaw_subscriptions)
+    .leftJoin(
+      kiloclaw_instances,
+      and(
+        eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id),
+        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id)
+      )
+    )
     .where(
       and(
-        inArray(kiloclaw_subscriptions.user_id, uniqueUserIds),
+        inArray(kiloclaw_subscriptions.user_id, userIds),
         isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
       )
     );
 
-  const accessGrantingUserIds = new Set<string>();
-  const pendingDestructionUserIds = new Set<string>();
+  const accessGrantingContextKeys = new Set<string>();
+  const pendingDestructionContextKeys = new Set<string>();
+
+  function addProtectedContexts(
+    subscription: (typeof currentSubscriptions)[number],
+    target: Set<string>
+  ) {
+    if (subscription.instance_id === null || subscription.instance_user_id === null) {
+      for (const contextKey of contextKeysByUserId.get(subscription.user_id) ?? []) {
+        target.add(contextKey);
+      }
+      return;
+    }
+
+    const contextKey = orphanVolumeSubscriptionContextKey({
+      user_id: subscription.user_id,
+      organization_id: subscription.organization_id,
+    });
+    if (requestedContextKeys.has(contextKey)) {
+      target.add(contextKey);
+    }
+  }
+
   for (const subscription of currentSubscriptions) {
     if (isAccessGrantingSubscription(subscription, now)) {
-      accessGrantingUserIds.add(subscription.user_id);
+      addProtectedContexts(subscription, accessGrantingContextKeys);
     }
     if (
       subscription.destruction_deadline !== null &&
       new Date(subscription.destruction_deadline).getTime() > now.getTime()
     ) {
-      pendingDestructionUserIds.add(subscription.user_id);
+      addProtectedContexts(subscription, pendingDestructionContextKeys);
     }
   }
 
-  return { accessGrantingUserIds, pendingDestructionUserIds };
+  return { accessGrantingContextKeys, pendingDestructionContextKeys };
 }

--- a/packages/db/src/kiloclaw-orphan-volume.ts
+++ b/packages/db/src/kiloclaw-orphan-volume.ts
@@ -6,11 +6,11 @@
  * definition — both sides enforce these gates, so they must not drift.
  */
 
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, inArray, isNull } from 'drizzle-orm';
 
 import type { WorkerDb } from './client';
 import { isAccessGrantingSubscription } from './kiloclaw-personal-subscription-collapse';
-import { kiloclaw_instances, kiloclaw_subscriptions } from './schema';
+import { kiloclaw_subscriptions } from './schema';
 
 /**
  * Minimum age, since its owning instance was destroyed, before a leftover
@@ -20,75 +20,85 @@ import { kiloclaw_instances, kiloclaw_subscriptions } from './schema';
  */
 export const ORPHAN_VOLUME_GRACE_PERIOD_MS = 7 * 24 * 60 * 60 * 1000;
 
-/**
- * The ownership context a volume's data belongs to: a user, optionally
- * scoped to an organization. Subscription access is evaluated per context,
- * not per instance — a reprovision transfers the destroyed instance's
- * subscription row to a current successor row.
- */
-export type OrphanVolumeSubscriptionContext = {
-  user_id: string;
-  organization_id: string | null;
-};
-
-/** Stable string key for an ownership context, for Set membership. */
-export function orphanVolumeSubscriptionContextKey(
-  context: OrphanVolumeSubscriptionContext
-): string {
-  return JSON.stringify([context.user_id, context.organization_id]);
-}
-
 /** Minimal drizzle executor surface — satisfied by both web and worker DBs. */
 type OrphanVolumeContextExecutor = Pick<WorkerDb, 'select'>;
 
 /**
- * Of the given ownership contexts, return the keys that still have a
- * **current** access-granting subscription.
+ * Per-user signals that withhold a leftover volume from the orphan reaper.
+ * A volume is reaper-eligible only when its owning user appears in NEITHER
+ * set.
+ */
+export type OrphanVolumeUserProtections = {
+  /**
+   * Users with a current access-granting subscription — an `active` one, an
+   * unsuspended `past_due` one, or a `trialing` one whose `trial_ends_at`
+   * has not passed. Their data must be preserved.
+   */
+  accessGrantingUserIds: Set<string>;
+  /**
+   * Users with a current subscription whose billing `destruction_deadline`
+   * is still in the future. The kiloclaw-billing lifecycle reaper is already
+   * scheduled to destroy that subscription's instance (and, with it, the
+   * volume) once the deadline passes — so a leftover volume is not a true
+   * orphan yet. It only becomes one if that reaper later fails, i.e. once
+   * the deadline is in the past and the volume is still present.
+   */
+  pendingDestructionUserIds: Set<string>;
+};
+
+/**
+ * For the given users, resolve the per-user signals that withhold their
+ * leftover volumes from the orphan reaper.
  *
  * "Current" means `transferred_to_subscription_id IS NULL` — the head of
- * any reprovision transfer chain. This is why the check is context-based
- * rather than per-instance: when an instance is destroyed and reprovisioned,
- * its subscription row is transferred to the successor, so the destroyed
- * instance's own joined row no longer reflects whether the user has access.
- * Reaping a volume requires that the owning context has NO such current
- * access-granting subscription.
+ * any reprovision transfer chain.
+ *
+ * The check is per-user and deliberately ignores which instance a
+ * subscription is linked to. `kiloclaw_subscriptions.instance_id` is
+ * nullable, so an instance-joined version silently dropped any subscription
+ * whose `instance_id` was absent — treating an active or trialing user as
+ * having no access and making their leftover volumes look reapable (a
+ * data-loss false positive). Keying purely on the user removes that hole.
  */
-export async function getAccessGrantingOrphanVolumeContexts(
+export async function getOrphanVolumeUserProtections(
   executor: OrphanVolumeContextExecutor,
-  contexts: OrphanVolumeSubscriptionContext[],
+  userIds: string[],
   now: Date
-): Promise<Set<string>> {
-  const requestedContextKeys = new Set(contexts.map(orphanVolumeSubscriptionContextKey));
-  const userIds = [...new Set(contexts.map(context => context.user_id))];
-  if (userIds.length === 0) {
-    return new Set();
+): Promise<OrphanVolumeUserProtections> {
+  const uniqueUserIds = [...new Set(userIds)];
+  if (uniqueUserIds.length === 0) {
+    return { accessGrantingUserIds: new Set(), pendingDestructionUserIds: new Set() };
   }
 
   const currentSubscriptions = await executor
     .select({
       user_id: kiloclaw_subscriptions.user_id,
-      organization_id: kiloclaw_instances.organization_id,
       status: kiloclaw_subscriptions.status,
       suspended_at: kiloclaw_subscriptions.suspended_at,
       trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
+      destruction_deadline: kiloclaw_subscriptions.destruction_deadline,
     })
     .from(kiloclaw_subscriptions)
-    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
     .where(
       and(
-        inArray(kiloclaw_subscriptions.user_id, userIds),
-        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id),
+        inArray(kiloclaw_subscriptions.user_id, uniqueUserIds),
         isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
       )
     );
 
-  const accessGrantingContextKeys = new Set<string>();
+  const accessGrantingUserIds = new Set<string>();
+  const pendingDestructionUserIds = new Set<string>();
   for (const subscription of currentSubscriptions) {
-    const contextKey = orphanVolumeSubscriptionContextKey(subscription);
-    if (requestedContextKeys.has(contextKey) && isAccessGrantingSubscription(subscription, now)) {
-      accessGrantingContextKeys.add(contextKey);
+    if (isAccessGrantingSubscription(subscription, now)) {
+      accessGrantingUserIds.add(subscription.user_id);
+    }
+    if (
+      subscription.destruction_deadline !== null &&
+      new Date(subscription.destruction_deadline).getTime() > now.getTime()
+    ) {
+      pendingDestructionUserIds.add(subscription.user_id);
     }
   }
 
-  return accessGrantingContextKeys;
+  return { accessGrantingUserIds, pendingDestructionUserIds };
 }

--- a/services/kiloclaw/src/routes/platform-orphan-volume.test.ts
+++ b/services/kiloclaw/src/routes/platform-orphan-volume.test.ts
@@ -64,8 +64,8 @@ const DEFAULT_DESTROY_ROW = {
 /**
  * Build a fake worker DB for the destroy endpoint. It runs two queries on
  * one DB handle — the instance lookup (terminated by `.limit(1)`) and the
- * per-user access-granting subscription lookup inside
- * `getAccessGrantingOrphanVolumeUserIds` (awaited directly, no `.limit`).
+ * ownership-context protection lookup inside
+ * `getOrphanVolumeContextProtections` (awaited directly, no `.limit`).
  * They resolve `instanceRows` and `subscriptionRows` respectively.
  */
 function makeWorkerDb(instanceRows: unknown[], subscriptionRows: unknown[]) {
@@ -88,7 +88,7 @@ function makeWorkerDb(instanceRows: unknown[], subscriptionRows: unknown[]) {
 /**
  * Drive the destroy endpoint's DB queries: `instanceRow` is what the
  * instance lookup resolves; `subscriptions` are the current
- * (non-transferred) subscription rows the per-user access query resolves
+ * (non-transferred) subscription rows the context protection query resolves
  * for the owning user.
  */
 function mockDestroyLookup(
@@ -100,10 +100,13 @@ function mockDestroyLookup(
   );
 }
 
-/** A current, access-granting subscription row for the owning user. */
+/** A current subscription row linked to the destroyed row's ownership context. */
 function accessGrantingSubscriptionRow(status: string): Record<string, unknown> {
   return {
     user_id: USER_ID,
+    instance_id: INSTANCE_ID,
+    instance_user_id: USER_ID,
+    organization_id: null,
     status,
     suspended_at: null,
     trial_ends_at: null,
@@ -546,9 +549,8 @@ describe('POST /admin/orphan-volume-destroy', () => {
 
   it('refuses (409) when the user has a current access-granting subscription', async () => {
     // Models the reprovision case: the destroyed instance's own subscription
-    // was transferred away, but the user still has access via a current
-    // successor subscription. The per-user gate — not the destroyed row's
-    // own subscription — must catch this and block the delete.
+    // was transferred away, but the same ownership context still has access via
+    // a current successor subscription. The context gate must block the delete.
     const { env } = makeEnv();
     mockDestroyLookup(DEFAULT_DESTROY_ROW, [accessGrantingSubscriptionRow('active')]);
 
@@ -562,17 +564,42 @@ describe('POST /admin/orphan-volume-destroy', () => {
     expect(fly.deleteVolume).not.toHaveBeenCalled();
   });
 
+  it('allows destroy when an access-granting subscription belongs to another context', async () => {
+    const { env } = makeEnv();
+    mockDestroyLookup(DEFAULT_DESTROY_ROW, [
+      {
+        ...accessGrantingSubscriptionRow('active'),
+        instance_id: '22222222-2222-4222-8222-222222222222',
+        organization_id: '33333333-3333-4333-8333-333333333333',
+      },
+    ]);
+    vi.mocked(fly.listVolumes).mockResolvedValue([flyVolume()]);
+    vi.mocked(fly.deleteVolume).mockResolvedValue(undefined);
+
+    const response = await platform.request(
+      '/admin/orphan-volume-destroy',
+      destroyInit(validDestroyBody),
+      env
+    );
+    expect(response.status).toBe(200);
+    expect(fly.deleteVolume).toHaveBeenCalledTimes(1);
+  });
+
   it('refuses (409) when the user has a current live trial', async () => {
     // The Odai case: the destroyed instance's own subscription is canceled,
-    // but the user has a separate trialing subscription whose trial has not
-    // ended. A live trial grants access, so the volume must be preserved.
+    // but the user has a detached trialing subscription whose trial has not
+    // ended. The context cannot be resolved safely, so it must fail closed.
     const { env } = makeEnv();
     mockDestroyLookup(DEFAULT_DESTROY_ROW, [
       {
         user_id: USER_ID,
+        instance_id: null,
+        instance_user_id: null,
+        organization_id: null,
         status: 'trialing',
         suspended_at: null,
         trial_ends_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+        destruction_deadline: null,
       },
     ]);
 
@@ -595,6 +622,9 @@ describe('POST /admin/orphan-volume-destroy', () => {
     mockDestroyLookup(DEFAULT_DESTROY_ROW, [
       {
         user_id: USER_ID,
+        instance_id: INSTANCE_ID,
+        instance_user_id: USER_ID,
+        organization_id: null,
         status: 'canceled',
         suspended_at: new Date(Date.now() - 86_400_000).toISOString(),
         trial_ends_at: null,

--- a/services/kiloclaw/src/routes/platform-orphan-volume.test.ts
+++ b/services/kiloclaw/src/routes/platform-orphan-volume.test.ts
@@ -51,7 +51,8 @@ const VOLUME_NAME = volumeNameFromSandboxId(SANDBOX_ID);
 
 /**
  * Instance row for INSTANCE_ID that passes the identity / destroyed /
- * grace gates: identity matches and destroyed long ago.
+ * grace gates: identity matches, destroyed long ago, and the sandbox's
+ * latest destruction (`latestSandboxDestroyedAt`) is also long ago.
  */
 const DEFAULT_DESTROY_ROW = {
   id: INSTANCE_ID,
@@ -59,6 +60,7 @@ const DEFAULT_DESTROY_ROW = {
   sandboxId: SANDBOX_ID,
   organizationId: null,
   destroyedAt: new Date(Date.now() - 30 * 86_400_000).toISOString(),
+  latestSandboxDestroyedAt: new Date(Date.now() - 30 * 86_400_000).toISOString(),
 };
 
 /**
@@ -393,6 +395,7 @@ describe('POST /admin/orphan-volume-destroy', () => {
       sandboxId: legacySandbox,
       organizationId: null,
       destroyedAt: new Date(Date.now() - 30 * 86_400_000).toISOString(),
+      latestSandboxDestroyedAt: new Date(Date.now() - 30 * 86_400_000).toISOString(),
     });
     vi.mocked(fly.listVolumes).mockResolvedValue([
       flyVolume({ id: legacyVolumeId, name: volumeNameFromSandboxId(legacySandbox) }),
@@ -535,6 +538,29 @@ describe('POST /admin/orphan-volume-destroy', () => {
     mockDestroyLookup({
       ...DEFAULT_DESTROY_ROW,
       destroyedAt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+      latestSandboxDestroyedAt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    });
+
+    const response = await platform.request(
+      '/admin/orphan-volume-destroy',
+      destroyInit(validDestroyBody),
+      env
+    );
+    expect(response.status).toBe(409);
+    expect(fly.listVolumes).not.toHaveBeenCalled();
+    expect(fly.deleteVolume).not.toHaveBeenCalled();
+  });
+
+  it('refuses (409) when a newer destruction of the same sandbox is within grace', async () => {
+    // The submitted instance was destroyed long ago, but the sandbox was
+    // reprovisioned and destroyed again recently. The grace period must run
+    // from that latest destruction, so an older submitted row cannot reap
+    // the still-shared volume early.
+    const { env } = makeEnv();
+    mockDestroyLookup({
+      ...DEFAULT_DESTROY_ROW,
+      destroyedAt: new Date(Date.now() - 30 * 86_400_000).toISOString(),
+      latestSandboxDestroyedAt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
     });
 
     const response = await platform.request(

--- a/services/kiloclaw/src/routes/platform-orphan-volume.test.ts
+++ b/services/kiloclaw/src/routes/platform-orphan-volume.test.ts
@@ -64,11 +64,11 @@ const DEFAULT_DESTROY_ROW = {
 /**
  * Build a fake worker DB for the destroy endpoint. It runs two queries on
  * one DB handle — the instance lookup (terminated by `.limit(1)`) and the
- * access-granting-context subscription lookup inside
- * `getAccessGrantingOrphanVolumeContexts` (awaited directly, no `.limit`).
- * They resolve `instanceRows` and `contextRows` respectively.
+ * per-user access-granting subscription lookup inside
+ * `getAccessGrantingOrphanVolumeUserIds` (awaited directly, no `.limit`).
+ * They resolve `instanceRows` and `subscriptionRows` respectively.
  */
-function makeWorkerDb(instanceRows: unknown[], contextRows: unknown[]) {
+function makeWorkerDb(instanceRows: unknown[], subscriptionRows: unknown[]) {
   return {
     select: () => {
       const chain: Record<string, unknown> = {
@@ -78,7 +78,7 @@ function makeWorkerDb(instanceRows: unknown[], contextRows: unknown[]) {
         where: () => chain,
         limit: () => Promise.resolve(instanceRows),
         then: (onFulfilled: (rows: unknown[]) => unknown) =>
-          Promise.resolve(contextRows).then(onFulfilled),
+          Promise.resolve(subscriptionRows).then(onFulfilled),
       };
       return chain;
     },
@@ -87,27 +87,27 @@ function makeWorkerDb(instanceRows: unknown[], contextRows: unknown[]) {
 
 /**
  * Drive the destroy endpoint's DB queries: `instanceRow` is what the
- * instance lookup resolves; `contextSubscriptions` are the current
- * (non-transferred) subscription rows the access-granting-context query
- * resolves for the ownership context.
+ * instance lookup resolves; `subscriptions` are the current
+ * (non-transferred) subscription rows the per-user access query resolves
+ * for the owning user.
  */
 function mockDestroyLookup(
   instanceRow: Record<string, unknown> | null,
-  contextSubscriptions: Record<string, unknown>[] = []
+  subscriptions: Record<string, unknown>[] = []
 ): void {
   vi.mocked(getWorkerDb).mockReturnValue(
-    makeWorkerDb(instanceRow === null ? [] : [instanceRow], contextSubscriptions) as never
+    makeWorkerDb(instanceRow === null ? [] : [instanceRow], subscriptions) as never
   );
 }
 
-/** A current, access-granting subscription row for the default ownership context. */
-function accessGrantingContextRow(status: string): Record<string, unknown> {
+/** A current, access-granting subscription row for the owning user. */
+function accessGrantingSubscriptionRow(status: string): Record<string, unknown> {
   return {
     user_id: USER_ID,
-    organization_id: null,
     status,
     suspended_at: null,
     trial_ends_at: null,
+    destruction_deadline: null,
   };
 }
 
@@ -544,14 +544,13 @@ describe('POST /admin/orphan-volume-destroy', () => {
     expect(fly.deleteVolume).not.toHaveBeenCalled();
   });
 
-  it('refuses (409) when the ownership context has a current access-granting subscription', async () => {
+  it('refuses (409) when the user has a current access-granting subscription', async () => {
     // Models the reprovision case: the destroyed instance's own subscription
     // was transferred away, but the user still has access via a current
-    // successor subscription in the same (user, org) context. The
-    // context-based gate — not the destroyed row's own subscription — must
-    // catch this and block the delete.
+    // successor subscription. The per-user gate — not the destroyed row's
+    // own subscription — must catch this and block the delete.
     const { env } = makeEnv();
-    mockDestroyLookup(DEFAULT_DESTROY_ROW, [accessGrantingContextRow('active')]);
+    mockDestroyLookup(DEFAULT_DESTROY_ROW, [accessGrantingSubscriptionRow('active')]);
 
     const response = await platform.request(
       '/admin/orphan-volume-destroy',
@@ -563,9 +562,59 @@ describe('POST /admin/orphan-volume-destroy', () => {
     expect(fly.deleteVolume).not.toHaveBeenCalled();
   });
 
-  it('allows destroy when the context has only a non-access-granting subscription', async () => {
+  it('refuses (409) when the user has a current live trial', async () => {
+    // The Odai case: the destroyed instance's own subscription is canceled,
+    // but the user has a separate trialing subscription whose trial has not
+    // ended. A live trial grants access, so the volume must be preserved.
     const { env } = makeEnv();
-    mockDestroyLookup(DEFAULT_DESTROY_ROW, [accessGrantingContextRow('canceled')]);
+    mockDestroyLookup(DEFAULT_DESTROY_ROW, [
+      {
+        user_id: USER_ID,
+        status: 'trialing',
+        suspended_at: null,
+        trial_ends_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+      },
+    ]);
+
+    const response = await platform.request(
+      '/admin/orphan-volume-destroy',
+      destroyInit(validDestroyBody),
+      env
+    );
+    expect(response.status).toBe(409);
+    expect(fly.listVolumes).not.toHaveBeenCalled();
+    expect(fly.deleteVolume).not.toHaveBeenCalled();
+  });
+
+  it('refuses (409) when the user has a pending billing destruction deadline', async () => {
+    // The Stefan case: the subscription is canceled and not access-granting,
+    // but its billing destruction_deadline is still in the future — the
+    // kiloclaw-billing lifecycle reaper is already scheduled to destroy the
+    // instance and its volume, so the orphan reaper must not race it.
+    const { env } = makeEnv();
+    mockDestroyLookup(DEFAULT_DESTROY_ROW, [
+      {
+        user_id: USER_ID,
+        status: 'canceled',
+        suspended_at: new Date(Date.now() - 86_400_000).toISOString(),
+        trial_ends_at: null,
+        destruction_deadline: new Date(Date.now() + 2 * 86_400_000).toISOString(),
+      },
+    ]);
+
+    const response = await platform.request(
+      '/admin/orphan-volume-destroy',
+      destroyInit(validDestroyBody),
+      env
+    );
+    expect(response.status).toBe(409);
+    expect(fly.listVolumes).not.toHaveBeenCalled();
+    expect(fly.deleteVolume).not.toHaveBeenCalled();
+  });
+
+  it('allows destroy when the user has only a non-access-granting subscription', async () => {
+    const { env } = makeEnv();
+    mockDestroyLookup(DEFAULT_DESTROY_ROW, [accessGrantingSubscriptionRow('canceled')]);
     vi.mocked(fly.listVolumes).mockResolvedValue([flyVolume()]);
     vi.mocked(fly.deleteVolume).mockResolvedValue(undefined);
 

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -47,11 +47,12 @@ import {
 } from '@kilocode/worker-utils';
 import { readBillingCorrelationHeaders } from '@kilocode/worker-utils/kiloclaw-billing-observability';
 import {
-  getOrphanVolumeUserProtections,
+  getOrphanVolumeContextProtections,
   getKiloClawPricingCatalogEntry,
   isKiloClawPriceVersion,
   markInstanceDestroyedWithPersonalSubscriptionCollapse,
   ORPHAN_VOLUME_GRACE_PERIOD_MS,
+  orphanVolumeSubscriptionContextKey,
   type KiloClawPriceVersion,
   type KiloClawSubscriptionChangeActor,
 } from '@kilocode/db';
@@ -4066,21 +4067,22 @@ platform.post('/admin/orphan-volume-destroy', async c => {
   if (Date.now() - new Date(instance.destroyedAt).getTime() <= ORPHAN_VOLUME_GRACE_PERIOD_MS) {
     return c.json({ error: 'Instance is still within the orphan-volume grace period' }, 409);
   }
-  // Gate C — never destroy data while the owning user still has product
-  // access, or while the billing lifecycle reaper is still scheduled to
-  // destroy it (a future `destruction_deadline`). Checked per-user, not
-  // per-instance: a reprovision transfer moves access to a current
-  // successor subscription, and a subscription may have no `instance_id`
-  // link at all.
-  const { accessGrantingUserIds, pendingDestructionUserIds } = await getOrphanVolumeUserProtections(
-    workerDb,
-    [instance.userId],
-    new Date()
-  );
-  if (accessGrantingUserIds.has(instance.userId)) {
+  // Gate C — never destroy data while this ownership context still has
+  // product access, or while the billing lifecycle reaper is still scheduled
+  // to destroy it (a future `destruction_deadline`). Reprovision transfers
+  // move access to a current successor row; a detached current row has no
+  // resolvable context, so the shared lookup fails closed for the user.
+  const context = {
+    user_id: instance.userId,
+    organization_id: instance.organizationId,
+  };
+  const { accessGrantingContextKeys, pendingDestructionContextKeys } =
+    await getOrphanVolumeContextProtections(workerDb, [context], new Date());
+  const contextKey = orphanVolumeSubscriptionContextKey(context);
+  if (accessGrantingContextKeys.has(contextKey)) {
     return c.json({ error: 'User has an access-granting subscription; volume preserved' }, 409);
   }
-  if (pendingDestructionUserIds.has(instance.userId)) {
+  if (pendingDestructionContextKeys.has(contextKey)) {
     return c.json(
       { error: 'A billing destruction deadline is still pending; volume preserved' },
       409

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -47,12 +47,11 @@ import {
 } from '@kilocode/worker-utils';
 import { readBillingCorrelationHeaders } from '@kilocode/worker-utils/kiloclaw-billing-observability';
 import {
-  getAccessGrantingOrphanVolumeContexts,
+  getOrphanVolumeUserProtections,
   getKiloClawPricingCatalogEntry,
   isKiloClawPriceVersion,
   markInstanceDestroyedWithPersonalSubscriptionCollapse,
   ORPHAN_VOLUME_GRACE_PERIOD_MS,
-  orphanVolumeSubscriptionContextKey,
   type KiloClawPriceVersion,
   type KiloClawSubscriptionChangeActor,
 } from '@kilocode/db';
@@ -4067,22 +4066,25 @@ platform.post('/admin/orphan-volume-destroy', async c => {
   if (Date.now() - new Date(instance.destroyedAt).getTime() <= ORPHAN_VOLUME_GRACE_PERIOD_MS) {
     return c.json({ error: 'Instance is still within the orphan-volume grace period' }, 409);
   }
-  // Gate C — never destroy data while the owning context still has product
-  // access. Evaluated per (user, org) context, not per instance: a
-  // reprovision transfers the destroyed instance's subscription row to a
-  // current successor, so the destroyed row's own subscription no longer
-  // reflects whether the user has access.
-  const ownershipContext = {
-    user_id: instance.userId,
-    organization_id: instance.organizationId,
-  };
-  const accessGrantingContextKeys = await getAccessGrantingOrphanVolumeContexts(
+  // Gate C — never destroy data while the owning user still has product
+  // access, or while the billing lifecycle reaper is still scheduled to
+  // destroy it (a future `destruction_deadline`). Checked per-user, not
+  // per-instance: a reprovision transfer moves access to a current
+  // successor subscription, and a subscription may have no `instance_id`
+  // link at all.
+  const { accessGrantingUserIds, pendingDestructionUserIds } = await getOrphanVolumeUserProtections(
     workerDb,
-    [ownershipContext],
+    [instance.userId],
     new Date()
   );
-  if (accessGrantingContextKeys.has(orphanVolumeSubscriptionContextKey(ownershipContext))) {
+  if (accessGrantingUserIds.has(instance.userId)) {
     return c.json({ error: 'User has an access-granting subscription; volume preserved' }, 409);
+  }
+  if (pendingDestructionUserIds.has(instance.userId)) {
+    return c.json(
+      { error: 'A billing destruction deadline is still pending; volume preserved' },
+      409
+    );
   }
 
   const flyApp = await resolveOrphanVolumeFlyAppName(c.env, {

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -77,7 +77,7 @@ import {
 import type { ProviderId } from '../schemas/instance-config';
 import { doKeyFromActiveInstance, resolveDoKeyForUser } from '../lib/instance-routing';
 import { getInstanceById, getInstanceByIdIncludingDestroyed, getWorkerDb } from '../db';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 import { volumeNameFromSandboxId } from '../durable-objects/machine-config';
 import { fallbackAppNameForRestore } from '../durable-objects/kiloclaw-instance/postgres';
 import { getAppKey } from '../durable-objects/kiloclaw-instance/types';
@@ -4042,6 +4042,17 @@ platform.post('/admin/orphan-volume-destroy', async c => {
       sandboxId: kiloclaw_instances.sandbox_id,
       organizationId: kiloclaw_instances.organization_id,
       destroyedAt: kiloclaw_instances.destroyed_at,
+      // The latest `destroyed_at` across every destroyed row of this
+      // (user, sandbox). A reprovisioned sandbox has several destroyed rows
+      // sharing one Fly volume; the grace period must run from the most
+      // recent destruction, not whichever row the caller happened to submit.
+      latestSandboxDestroyedAt: sql<string | null>`(
+        select max(latest.destroyed_at)
+        from ${kiloclaw_instances} as latest
+        where latest.user_id = ${kiloclaw_instances.user_id}
+          and latest.sandbox_id = ${kiloclaw_instances.sandbox_id}
+          and latest.destroyed_at is not null
+      )`,
     })
     .from(kiloclaw_instances)
     .where(eq(kiloclaw_instances.id, instanceId))
@@ -4063,8 +4074,12 @@ platform.post('/admin/orphan-volume-destroy', async c => {
   if (instance.destroyedAt === null) {
     return c.json({ error: 'Instance is not destroyed; its volume is not an orphan' }, 409);
   }
-  // Gate B — grace period. Give Fly's reaper and the DO sweep time to act.
-  if (Date.now() - new Date(instance.destroyedAt).getTime() <= ORPHAN_VOLUME_GRACE_PERIOD_MS) {
+  // Gate B — grace period, measured from the LATEST destruction of this
+  // sandbox. A reprovisioned sandbox has several destroyed rows sharing one
+  // Fly volume; the volume's cleanup clock runs from the most recent
+  // destruction, so an older submitted row must not shorten the grace.
+  const latestDestroyedAt = instance.latestSandboxDestroyedAt ?? instance.destroyedAt;
+  if (Date.now() - new Date(latestDestroyedAt).getTime() <= ORPHAN_VOLUME_GRACE_PERIOD_MS) {
     return c.json({ error: 'Instance is still within the orphan-volume grace period' }, 409);
   }
   // Gate C — never destroy data while this ownership context still has


### PR DESCRIPTION
## Summary

The admin orphan volume reaper had four correctness gaps. This branch fixes all of them.

**Duplicate rows in the scan.** `UQ_kiloclaw_instances_active` is a partial unique index that only constrains live instance rows (those where `destroyed_at` is null). A sandbox that has been reprovisioned therefore leaves many destroyed `kiloclaw_instances` rows that all share one `sandbox_id`. Because the Fly volume name is derived from `sandbox_id`, every one of those rows surfaced the same volume as its own table row. The scan now keeps only the most recently destroyed row for each `(user, sandbox)` pair with `selectDistinctOn`, which is also the correct row for the grace period clock.

**False positive Safe to destroy.** The subscription safety gate joined `kiloclaw_subscriptions` to `kiloclaw_instances` through the nullable `instance_id` column with an inner join. Any current subscription whose `instance_id` link was absent got dropped, so an active or trialing user looked like they had no access and their leftover volume was classified Safe to destroy. The scan and the destroy guard on both the web and worker sides shared the gap, so a confirm click would actually have deleted the volume. The gate now resolves protections through a left join. A subscription with a resolvable instance context protects that exact ownership context, and a subscription with no resolvable context is treated as ambiguous and protects every ownership context for that user, so it fails closed rather than silently allowing a delete.

**Volume reaped while the billing reaper still owns it.** A leftover volume was eligible for destruction even when the owning subscription still had a future `destruction_deadline`. The billing lifecycle is already scheduled to destroy that instance and its volume once the deadline passes, so the volume is not a true orphan yet. A new `destruction_scheduled` classification withholds the volume until the deadline has passed. If the deadline passes and the volume is still present, the lifecycle reaper has failed and the volume becomes eligible again.

**User links.** The user links in the orphan tables now open in a new tab so an admin can keep the scan results open while checking an account.

## Verification

- [ ] No manual testing in a live environment. The orphan volume reaper is an admin tool whose destroy action deletes real Fly volumes, so it was not exercised against live data. The safety gates and the classification logic are covered by unit and route tests instead: the scan dedup, the classification precedence, the subscription access gate (active and trialing both block, canceled allows), and the destruction deadline gate.

## Visual Changes

The orphan volumes table can now show a new status badge, "Destruction scheduled", for a row whose owner still has a pending billing destruction deadline. The user link change is behavioral (the link target), not visual.

| Before | After |
| ------ | ----- |
| No "Destruction scheduled" status existed | New "Destruction scheduled" badge for volumes the billing reaper still owns |

## Reviewer Notes

- The subscription gate now fails closed on an ambiguous subscription, one with no resolvable instance context. That is a deliberate bias toward preserving data. Confirm it matches intent.
- The destruction deadline gate is keyed to ownership context. A stale future `destruction_deadline` left on a subscription whose instance was destroyed long ago will withhold the volume until that date passes, after which it resolves itself.
- Separate observation, not addressed here: a `destruction_deadline` set in the future on a subscription whose instance was already destroyed looks like stale data that the billing destruction sweep should have cleared.
