### PR TITLE
feat(config): add auto_expand_history field

### DIFF
--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -36,6 +36,10 @@ const agentConfig = {
 
 export const kiloExtras = {
   top: {
+    auto_expand_history: {
+      description: 'Automatically expand command history when searching',
+      type: 'boolean',
+    },
     model: {
       description: 'Model to use in the format of provider/model, eg anthropic/claude-2',
       ...nullableModel,

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -32,6 +32,7 @@ describe('kilo config.json schema merge', () => {
   test('adds kilo-only top-level keys', () => {
     expect(props.commit_message).toBeDefined();
     expect(props.remote_control).toBeDefined();
+    expect(props.auto_expand_history).toBeDefined();
   });
 
   test('commit_message has a prompt string property', () => {


### PR DESCRIPTION
## Summary
Add `auto_expand_history` boolean configuration field to mirror the CLI config schema change from the kilocode repo. This field controls whether command history is automatically expanded when searching.

Required for Kilo-Org/kilocode#8759

## Verification
- Added the field to `apps/web/src/app/config.json/extras.ts` in the `top` bucket with appropriate description and boolean type
- Added test assertion in `apps/web/src/tests/cli-config-schema.test.ts` to verify the field is included in the merged schema
- All existing tests pass, confirming the schema merge works correctly

## Visual Changes
N/A

## Reviewer Notes
- This change maintains synchronization between the kilocode CLI schema and the cloud config overlay
- The field follows the same pattern as other top-level boolean configs like `remote_control` and `codebase_search`
- Tests verify the field appears in the merged schema at `https://app.kilo.ai/config.json`