### PR TITLE
fix(deploy-infra): expose mise shims in PATH for non-interactive shells

### DIFF
--- a/services/deploy-infra/builder-docker-container/Dockerfile
+++ b/services/deploy-infra/builder-docker-container/Dockerfile
@@ -41,7 +41,10 @@ RUN mise install hugo@0.152.2 hugo@0.120.0
 RUN mise install go@1.25.4
 
 # Set default global versions (can be overridden by .tool-versions)
-RUN mise use -g node@24 ruby@3.3 hugo@0.152.2 go@1.25.4
+RUN mise use -g node@22 ruby@3.3 hugo@0.152.2 go@1.25.4
+
+# Sandbox exec runs non-interactive shells, so expose mise defaults without relying on .bashrc.
+ENV PATH="/root/.local/share/mise/shims:${PATH}"
 
 # Build tool versions
 ARG OPENNEXTJS_VERSION=1.19.11


### PR DESCRIPTION
## Summary

- Adds `ENV PATH` directive to expose mise shims directory in non-interactive shells (sandbox exec doesn't source `.bashrc`, so mise-managed binaries were not on PATH)
- Pins node default to 22 (LTS) instead of 24

## Test plan

- [ ] Build the Docker image and verify `node --version`, `go version` etc. work in a non-interactive exec context

🤖 Generated with [Claude Code](https://claude.com/claude-code)