### PR TITLE
feat(collab): show existing integrations in setup

### DIFF
--- a/apps/web/src/app/collab/_components/BotWizard.tsx
+++ b/apps/web/src/app/collab/_components/BotWizard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowLeft, ArrowRight, CheckCircle2, Loader2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -14,8 +15,18 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
+import { useTRPC } from '@/lib/trpc/utils';
 import { ALL_PLATFORMS, CHAT_PLATFORM_IDS, CODE_PLATFORM_IDS, type PlatformId } from './platforms';
 import { PlatformTile } from './PlatformTile';
+import {
+  buildPlatformSetupStatuses,
+  canSelectPlatform,
+  getConnectedPlatformIds,
+  getSelectedServiceIdsToAuthorize,
+  hasAnyConfiguredOrSelectedPlatform,
+  isCheckingPlatformSetup,
+  type PlatformSetupStatusMap,
+} from './setup-status';
 import { WorkspaceSelector, type WorkspaceSelection } from './WorkspaceSelector';
 
 const TOTAL_STEPS = 2;
@@ -23,6 +34,7 @@ type MissingPlatformWarning = 'chat' | 'code';
 
 export function BotWizard() {
   const router = useRouter();
+  const trpc = useTRPC();
   const [stepIndex, setStepIndex] = useState(0);
   const [selected, setSelected] = useState<Set<PlatformId>>(new Set());
   const [workspace, setWorkspace] = useState<WorkspaceSelection | null>(null);
@@ -30,15 +42,76 @@ export function BotWizard() {
     useState<MissingPlatformWarning | null>(null);
 
   const isWorkspaceStep = stepIndex === 0;
-  const hasChatPlatform = Array.from(selected).some(platformId =>
-    CHAT_PLATFORM_IDS.has(platformId)
+  const setupInput = workspace?.type === 'org' ? { organizationId: workspace.id } : undefined;
+  const shouldCheckSetup = workspace !== null && !isWorkspaceStep;
+
+  const githubSetup = useQuery(
+    trpc.githubApps.getInstallation.queryOptions(setupInput, { enabled: shouldCheckSetup })
   );
-  const hasCodePlatform = Array.from(selected).some(platformId =>
-    CODE_PLATFORM_IDS.has(platformId)
+  const gitlabSetup = useQuery(
+    trpc.gitlab.getInstallation.queryOptions(setupInput, { enabled: shouldCheckSetup })
   );
-  const canAdvance = isWorkspaceStep ? workspace !== null : true;
+  const slackSetup = useQuery(
+    trpc.slack.getInstallation.queryOptions(setupInput, { enabled: shouldCheckSetup })
+  );
+  const discordSetup = useQuery(
+    trpc.discord.getInstallation.queryOptions(setupInput, { enabled: shouldCheckSetup })
+  );
+  const linearSetup = useQuery(
+    trpc.linear.getInstallation.queryOptions(setupInput, { enabled: shouldCheckSetup })
+  );
+
+  const setupStatuses = buildPlatformSetupStatuses({
+    github: {
+      data: githubSetup.data,
+      isError: githubSetup.isError,
+      isFetching: githubSetup.isFetching,
+      isLoading: githubSetup.isLoading,
+    },
+    gitlab: {
+      data: gitlabSetup.data,
+      isError: gitlabSetup.isError,
+      isFetching: gitlabSetup.isFetching,
+      isLoading: gitlabSetup.isLoading,
+    },
+    slack: {
+      data: slackSetup.data,
+      isError: slackSetup.isError,
+      isFetching: slackSetup.isFetching,
+      isLoading: slackSetup.isLoading,
+    },
+    discord: {
+      data: discordSetup.data,
+      isError: discordSetup.isError,
+      isFetching: discordSetup.isFetching,
+      isLoading: discordSetup.isLoading,
+    },
+    linear: {
+      data: linearSetup.data,
+      isError: linearSetup.isError,
+      isFetching: linearSetup.isFetching,
+      isLoading: linearSetup.isLoading,
+    },
+  });
+
+  const isCheckingSetup = isCheckingPlatformSetup(setupStatuses);
+  const servicesToAuthorize = getSelectedServiceIdsToAuthorize(selected, setupStatuses);
+  const connectedPlatformIds = getConnectedPlatformIds(setupStatuses);
+  const hasChatPlatform = hasAnyConfiguredOrSelectedPlatform(
+    CHAT_PLATFORM_IDS,
+    selected,
+    setupStatuses
+  );
+  const hasCodePlatform = hasAnyConfiguredOrSelectedPlatform(
+    CODE_PLATFORM_IDS,
+    selected,
+    setupStatuses
+  );
+  const canAdvance = isWorkspaceStep ? workspace !== null : !isCheckingSetup;
 
   const handleToggle = (platformId: PlatformId) => {
+    if (!canSelectPlatform(setupStatuses[platformId])) return;
+
     setSelected(prev => {
       const next = new Set(prev);
       if (next.has(platformId)) {
@@ -52,14 +125,23 @@ export function BotWizard() {
 
   const proceedToAuthorize = () => {
     setMissingPlatformWarning(null);
-    const params = new URLSearchParams({ services: Array.from(selected).join(',') });
+    const params = new URLSearchParams();
+    if (servicesToAuthorize.length > 0) {
+      params.set('services', servicesToAuthorize.join(','));
+    }
+    if (connectedPlatformIds.length > 0) {
+      params.set('connected', connectedPlatformIds.join(','));
+    }
     if (workspace?.type === 'org') {
       params.set('organizationId', workspace.id);
     }
-    router.push(`/collab/authorize?${params.toString()}`);
+    const query = params.toString();
+    router.push(query ? `/collab/authorize?${query}` : '/collab/authorize');
   };
 
   const handleContinueWithoutRecommendedPlatform = () => {
+    if (isCheckingSetup) return;
+
     if (missingPlatformWarning === 'chat' && !hasCodePlatform) {
       setMissingPlatformWarning('code');
       return;
@@ -141,21 +223,24 @@ export function BotWizard() {
                 What services do you want to connect?
               </h1>
               <p className="text-muted-foreground text-sm">
-                Select every service Kilo should use. Each service appears once; you can skip any
-                authorization screen later.
+                Already set up services are marked and count toward setup. Select any remaining
+                services Kilo should use.
               </p>
             </header>
+
+            <ExistingSetupNotice statuses={setupStatuses} />
 
             <div
               className="grid grid-cols-1 gap-3 sm:grid-cols-2"
               role="group"
-              aria-label="Services to connect"
+              aria-label="Integration setup status"
             >
               {ALL_PLATFORMS.map(option => (
                 <PlatformTile
                   key={option.id}
                   option={option}
                   selected={selected.has(option.id)}
+                  setupStatus={setupStatuses[option.id]}
                   onSelect={() => handleToggle(option.id)}
                 />
               ))}
@@ -176,7 +261,7 @@ export function BotWizard() {
         </Button>
 
         <Button onClick={handleNext} disabled={!canAdvance}>
-          Continue
+          {!isWorkspaceStep && isCheckingSetup ? 'Checking setup...' : 'Continue'}
           <ArrowRight className="size-4" />
         </Button>
       </footer>
@@ -201,12 +286,16 @@ export function BotWizard() {
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="gap-2 sm:space-x-0">
-            <Button variant="ghost" onClick={handleContinueWithoutRecommendedPlatform}>
+            <Button
+              variant="ghost"
+              onClick={handleContinueWithoutRecommendedPlatform}
+              disabled={isCheckingSetup}
+            >
               {missingPlatformWarning === 'code'
                 ? 'Continue without code'
                 : 'Continue without chat'}
             </Button>
-            <Button onClick={() => setMissingPlatformWarning(null)}>
+            <Button onClick={() => setMissingPlatformWarning(null)} disabled={isCheckingSetup}>
               {missingPlatformWarning === 'code' ? 'Choose code platform' : 'Choose chat service'}
             </Button>
           </DialogFooter>
@@ -214,6 +303,50 @@ export function BotWizard() {
       </Dialog>
     </div>
   );
+}
+
+function ExistingSetupNotice({ statuses }: { statuses: PlatformSetupStatusMap }) {
+  const connectedPlatformIds = getConnectedPlatformIds(statuses);
+  const isCheckingSetup = isCheckingPlatformSetup(statuses);
+
+  if (isCheckingSetup) {
+    return (
+      <div
+        className="text-muted-foreground flex items-center gap-2 rounded-lg border border-border bg-card/70 px-3 py-2 text-sm"
+        role="status"
+        aria-live="polite"
+      >
+        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        Checking existing integrations...
+      </div>
+    );
+  }
+
+  if (connectedPlatformIds.length === 0) return null;
+
+  const connectedNames = connectedPlatformIds.map(getPlatformName);
+
+  return (
+    <div className="flex gap-3 rounded-lg border border-green-500/20 bg-green-500/10 px-3 py-2 text-sm text-green-100">
+      <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-green-400" aria-hidden="true" />
+      <p className="leading-relaxed">
+        <span className="font-medium text-green-300">
+          Already set up: {formatPlatformList(connectedNames)}.
+        </span>{' '}
+        Select anything else you want to connect now.
+      </p>
+    </div>
+  );
+}
+
+function getPlatformName(platformId: PlatformId): string {
+  return ALL_PLATFORMS.find(platform => platform.id === platformId)?.name ?? platformId;
+}
+
+function formatPlatformList(names: string[]): string {
+  if (names.length <= 1) return names[0] ?? 'None';
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
 }
 
 function StepIndicator({ activeIndex }: { activeIndex: number }) {

--- a/apps/web/src/app/collab/_components/BotWizard.tsx
+++ b/apps/web/src/app/collab/_components/BotWizard.tsx
@@ -45,53 +45,17 @@ export function BotWizard() {
   const setupInput = workspace?.type === 'org' ? { organizationId: workspace.id } : undefined;
   const shouldCheckSetup = workspace !== null && !isWorkspaceStep;
 
-  const githubSetup = useQuery(
-    trpc.githubApps.getInstallation.queryOptions(setupInput, { enabled: shouldCheckSetup })
-  );
-  const gitlabSetup = useQuery(
-    trpc.gitlab.getInstallation.queryOptions(setupInput, { enabled: shouldCheckSetup })
-  );
-  const slackSetup = useQuery(
-    trpc.slack.getInstallation.queryOptions(setupInput, { enabled: shouldCheckSetup })
-  );
-  const discordSetup = useQuery(
-    trpc.discord.getInstallation.queryOptions(setupInput, { enabled: shouldCheckSetup })
-  );
-  const linearSetup = useQuery(
-    trpc.linear.getInstallation.queryOptions(setupInput, { enabled: shouldCheckSetup })
+  const setupQuery = useQuery(
+    trpc.platformIntegrations.listSetupStatus.queryOptions(setupInput, {
+      enabled: shouldCheckSetup,
+    })
   );
 
   const setupStatuses = buildPlatformSetupStatuses({
-    github: {
-      data: githubSetup.data,
-      isError: githubSetup.isError,
-      isFetching: githubSetup.isFetching,
-      isLoading: githubSetup.isLoading,
-    },
-    gitlab: {
-      data: gitlabSetup.data,
-      isError: gitlabSetup.isError,
-      isFetching: gitlabSetup.isFetching,
-      isLoading: gitlabSetup.isLoading,
-    },
-    slack: {
-      data: slackSetup.data,
-      isError: slackSetup.isError,
-      isFetching: slackSetup.isFetching,
-      isLoading: slackSetup.isLoading,
-    },
-    discord: {
-      data: discordSetup.data,
-      isError: discordSetup.isError,
-      isFetching: discordSetup.isFetching,
-      isLoading: discordSetup.isLoading,
-    },
-    linear: {
-      data: linearSetup.data,
-      isError: linearSetup.isError,
-      isFetching: linearSetup.isFetching,
-      isLoading: linearSetup.isLoading,
-    },
+    data: setupQuery.data,
+    isError: setupQuery.isError,
+    isFetching: setupQuery.isFetching,
+    isLoading: setupQuery.isLoading,
   });
 
   const isCheckingSetup = isCheckingPlatformSetup(setupStatuses);

--- a/apps/web/src/app/collab/_components/PlatformTile.tsx
+++ b/apps/web/src/app/collab/_components/PlatformTile.tsx
@@ -1,51 +1,154 @@
 'use client';
 
-import { Check } from 'lucide-react';
+import { AlertCircle, Check, Clock3, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { PlatformOption } from './platforms';
+import { canSelectPlatform, type PlatformSetupStatus } from './setup-status';
 
 type PlatformTileProps = {
   option: PlatformOption;
   selected: boolean;
+  setupStatus: PlatformSetupStatus;
   onSelect: () => void;
 };
 
-export function PlatformTile({ option, selected, onSelect }: PlatformTileProps) {
+export function PlatformTile({ option, selected, setupStatus, onSelect }: PlatformTileProps) {
   const Icon = option.icon;
+  const canSelect = canSelectPlatform(setupStatus);
+  const isConnected = setupStatus.kind === 'connected';
+  const isUnavailable = setupStatus.kind === 'unavailable';
+  const setupDetail = setupStatus.kind === 'connected' ? setupStatus.detail : undefined;
+  const detailId = `${option.id}-setup-detail`;
+  const hasDescription =
+    setupDetail !== undefined || isUnavailable || setupStatus.kind === 'unknown';
+
   return (
     <button
       type="button"
-      onClick={onSelect}
-      aria-pressed={selected}
+      onClick={() => {
+        if (canSelect) onSelect();
+      }}
+      aria-disabled={!canSelect}
+      aria-pressed={canSelect ? selected : undefined}
+      aria-describedby={hasDescription ? detailId : undefined}
       className={cn(
         'group relative flex min-h-40 flex-col items-start gap-4 rounded-xl border bg-card p-4 text-left text-card-foreground',
         'transition-[background-color,border-color,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)]',
-        'hover:bg-accent/40 active:scale-[0.99]',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-        selected
-          ? 'border-primary/70 ring-1 ring-primary/40 bg-primary/5'
-          : 'border-border hover:border-border/80'
+        canSelect && 'hover:bg-accent/40 active:scale-[0.99]',
+        isConnected
+          ? 'border-green-500/30 bg-green-500/10'
+          : isUnavailable
+            ? 'border-border bg-muted/30 text-muted-foreground'
+            : selected
+              ? 'border-primary/70 ring-1 ring-primary/40 bg-primary/5'
+              : 'border-border hover:border-border/80',
+        !canSelect && 'cursor-default',
+        setupStatus.kind === 'checking' && 'border-border bg-card/80'
       )}
     >
       <span className="flex w-full items-start justify-between gap-3">
-        <span className="bg-background/60 border-border grid size-11 place-items-center rounded-lg border">
-          <Icon className="size-6" />
-        </span>
         <span
-          aria-hidden="true"
           className={cn(
-            'grid size-5 place-items-center rounded-full transition-opacity duration-150',
-            selected ? 'bg-primary text-primary-foreground opacity-100' : 'opacity-0'
+            'bg-background/60 border-border grid size-11 place-items-center rounded-lg border',
+            isConnected && 'border-green-500/30 bg-green-500/10',
+            isUnavailable && 'bg-muted/40'
           )}
         >
-          <Check className="size-3" strokeWidth={3} />
+          <Icon className="size-6" />
         </span>
+        <SetupStatusBadge status={setupStatus} selected={selected && canSelect} />
       </span>
-      <span className="flex flex-1 flex-col gap-1.5">
+      <span className="flex min-w-0 flex-1 flex-col gap-1.5">
         <span className="text-muted-foreground text-xs font-medium">{option.connectionType}</span>
         <span className="text-base font-medium">{option.name}</span>
         <span className="text-muted-foreground text-sm leading-relaxed">{option.description}</span>
+        {setupDetail && (
+          <span id={detailId} className="w-full break-words text-xs leading-relaxed text-green-400">
+            Connected to {setupDetail}
+          </span>
+        )}
+        {setupStatus.kind === 'unavailable' && (
+          <span id={detailId} className="text-muted-foreground text-xs leading-relaxed">
+            Setup is not available from this wizard yet.
+          </span>
+        )}
+        {setupStatus.kind === 'unknown' && (
+          <span id={detailId} className="text-muted-foreground text-xs leading-relaxed">
+            Status check failed. You can still try authorization.
+          </span>
+        )}
       </span>
     </button>
+  );
+}
+
+function SetupStatusBadge({
+  status,
+  selected,
+}: {
+  status: PlatformSetupStatus;
+  selected: boolean;
+}) {
+  if (status.kind === 'connected') {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-green-500/30 bg-green-500/10 px-2 py-1 text-xs font-medium text-green-400">
+        <Check className="size-3" strokeWidth={3} aria-hidden="true" />
+        {status.label}
+      </span>
+    );
+  }
+
+  if (status.kind === 'checking') {
+    return (
+      <span
+        className="text-muted-foreground inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/30 px-2 py-1 text-xs font-medium"
+        aria-live="polite"
+      >
+        <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+        {status.label}
+      </span>
+    );
+  }
+
+  if (status.kind === 'unavailable') {
+    return (
+      <span className="text-muted-foreground inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/30 px-2 py-1 text-xs font-medium">
+        <Clock3 className="size-3" aria-hidden="true" />
+        {status.label}
+      </span>
+    );
+  }
+
+  if (status.kind === 'unknown') {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-yellow-500/30 bg-yellow-500/10 px-2 py-1 text-xs font-medium text-yellow-300">
+        <AlertCircle className="size-3" aria-hidden="true" />
+        {status.label}
+      </span>
+    );
+  }
+
+  if (selected) {
+    return (
+      <span
+        aria-hidden="true"
+        className="bg-primary text-primary-foreground grid size-5 place-items-center rounded-full"
+      >
+        <Check className="size-3" strokeWidth={3} />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'grid size-5 place-items-center rounded-full transition-opacity duration-150',
+        selected ? 'bg-primary text-primary-foreground opacity-100' : 'opacity-0'
+      )}
+    >
+      <Check className="size-3" strokeWidth={3} />
+    </span>
   );
 }

--- a/apps/web/src/app/collab/_components/PlatformTile.tsx
+++ b/apps/web/src/app/collab/_components/PlatformTile.tsx
@@ -143,10 +143,7 @@ function SetupStatusBadge({
   return (
     <span
       aria-hidden="true"
-      className={cn(
-        'grid size-5 place-items-center rounded-full transition-opacity duration-150',
-        selected ? 'bg-primary text-primary-foreground opacity-100' : 'opacity-0'
-      )}
+      className="grid size-5 place-items-center rounded-full opacity-0 transition-opacity duration-150"
     >
       <Check className="size-3" strokeWidth={3} />
     </span>

--- a/apps/web/src/app/collab/_components/setup-status.test.ts
+++ b/apps/web/src/app/collab/_components/setup-status.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  buildPlatformSetupStatuses,
+  getConnectedPlatformIds,
+  getSelectedServiceIdsToAuthorize,
+  hasAnyConfiguredOrSelectedPlatform,
+} from './setup-status';
+import { CHAT_PLATFORM_IDS, CODE_PLATFORM_IDS, type PlatformId } from './platforms';
+
+describe('collab setup status', () => {
+  test('marks installed integrations as already set up with account details', () => {
+    const statuses = buildPlatformSetupStatuses({
+      slack: {
+        data: { installed: true, installation: { teamName: 'Kilo Team' } },
+        isError: false,
+        isLoading: false,
+      },
+      github: {
+        data: { installed: true, installation: { accountLogin: 'kilocode' } },
+        isError: false,
+        isLoading: false,
+      },
+      linear: {
+        data: { installed: false, installation: null },
+        isError: false,
+        isLoading: false,
+      },
+    });
+
+    expect(statuses.slack).toEqual({
+      kind: 'connected',
+      label: 'Already set up',
+      detail: 'Kilo Team',
+    });
+    expect(statuses.github).toEqual({
+      kind: 'connected',
+      label: 'Already set up',
+      detail: 'kilocode',
+    });
+    expect(statuses.linear).toEqual({ kind: 'not_connected', label: 'Not set up' });
+  });
+
+  test('keeps services without an authorization path out of selection', () => {
+    const statuses = buildPlatformSetupStatuses({});
+    const selected: PlatformId[] = ['microsoft-teams', 'google-chat', 'slack'];
+
+    expect(statuses['microsoft-teams']).toEqual({
+      kind: 'unavailable',
+      label: 'Not available yet',
+    });
+    expect(statuses['google-chat']).toEqual({
+      kind: 'unavailable',
+      label: 'Not available yet',
+    });
+    expect(getSelectedServiceIdsToAuthorize(selected, statuses)).toEqual(['slack']);
+  });
+
+  test('counts already set up services toward chat and code coverage', () => {
+    const statuses = buildPlatformSetupStatuses({
+      slack: {
+        data: { installed: true, installation: { teamName: 'Kilo Team' } },
+        isError: false,
+        isLoading: false,
+      },
+      gitlab: {
+        data: { installed: true, installation: { accountLogin: 'kilocode' } },
+        isError: false,
+        isLoading: false,
+      },
+    });
+
+    expect(hasAnyConfiguredOrSelectedPlatform(CHAT_PLATFORM_IDS, [], statuses)).toBe(true);
+    expect(hasAnyConfiguredOrSelectedPlatform(CODE_PLATFORM_IDS, [], statuses)).toBe(true);
+  });
+
+  test('filters connected services out of the authorization queue', () => {
+    const statuses = buildPlatformSetupStatuses({
+      slack: {
+        data: { installed: true, installation: { teamName: 'Kilo Team' } },
+        isError: false,
+        isLoading: false,
+      },
+      github: {
+        data: { installed: false, installation: null },
+        isError: false,
+        isLoading: false,
+      },
+    });
+
+    expect(getConnectedPlatformIds(statuses)).toEqual(['slack']);
+    expect(getSelectedServiceIdsToAuthorize(['slack', 'github'], statuses)).toEqual(['github']);
+  });
+
+  test('treats background refetches as checking before using cached setup status', () => {
+    const statuses = buildPlatformSetupStatuses({
+      github: {
+        data: { installed: false, installation: null },
+        isError: false,
+        isFetching: true,
+        isLoading: false,
+      },
+    });
+
+    expect(statuses.github).toEqual({ kind: 'checking', label: 'Checking' });
+  });
+});

--- a/apps/web/src/app/collab/_components/setup-status.test.ts
+++ b/apps/web/src/app/collab/_components/setup-status.test.ts
@@ -10,21 +10,13 @@ import { CHAT_PLATFORM_IDS, CODE_PLATFORM_IDS, type PlatformId } from './platfor
 describe('collab setup status', () => {
   test('marks installed integrations as already set up with account details', () => {
     const statuses = buildPlatformSetupStatuses({
-      slack: {
-        data: { installed: true, installation: { teamName: 'Kilo Team' } },
-        isError: false,
-        isLoading: false,
-      },
-      github: {
-        data: { installed: true, installation: { accountLogin: 'kilocode' } },
-        isError: false,
-        isLoading: false,
-      },
-      linear: {
-        data: { installed: false, installation: null },
-        isError: false,
-        isLoading: false,
-      },
+      data: [
+        { platform: 'slack', installed: true, installation: { teamName: 'Kilo Team' } },
+        { platform: 'github', installed: true, installation: { accountLogin: 'kilocode' } },
+        { platform: 'linear', installed: false, installation: null },
+      ],
+      isError: false,
+      isLoading: false,
     });
 
     expect(statuses.slack).toEqual({
@@ -41,7 +33,11 @@ describe('collab setup status', () => {
   });
 
   test('keeps services without an authorization path out of selection', () => {
-    const statuses = buildPlatformSetupStatuses({});
+    const statuses = buildPlatformSetupStatuses({
+      data: [],
+      isError: false,
+      isLoading: false,
+    });
     const selected: PlatformId[] = ['microsoft-teams', 'google-chat', 'slack'];
 
     expect(statuses['microsoft-teams']).toEqual({
@@ -57,16 +53,12 @@ describe('collab setup status', () => {
 
   test('counts already set up services toward chat and code coverage', () => {
     const statuses = buildPlatformSetupStatuses({
-      slack: {
-        data: { installed: true, installation: { teamName: 'Kilo Team' } },
-        isError: false,
-        isLoading: false,
-      },
-      gitlab: {
-        data: { installed: true, installation: { accountLogin: 'kilocode' } },
-        isError: false,
-        isLoading: false,
-      },
+      data: [
+        { platform: 'slack', installed: true, installation: { teamName: 'Kilo Team' } },
+        { platform: 'gitlab', installed: true, installation: { accountLogin: 'kilocode' } },
+      ],
+      isError: false,
+      isLoading: false,
     });
 
     expect(hasAnyConfiguredOrSelectedPlatform(CHAT_PLATFORM_IDS, [], statuses)).toBe(true);
@@ -75,16 +67,12 @@ describe('collab setup status', () => {
 
   test('filters connected services out of the authorization queue', () => {
     const statuses = buildPlatformSetupStatuses({
-      slack: {
-        data: { installed: true, installation: { teamName: 'Kilo Team' } },
-        isError: false,
-        isLoading: false,
-      },
-      github: {
-        data: { installed: false, installation: null },
-        isError: false,
-        isLoading: false,
-      },
+      data: [
+        { platform: 'slack', installed: true, installation: { teamName: 'Kilo Team' } },
+        { platform: 'github', installed: false, installation: null },
+      ],
+      isError: false,
+      isLoading: false,
     });
 
     expect(getConnectedPlatformIds(statuses)).toEqual(['slack']);
@@ -93,12 +81,10 @@ describe('collab setup status', () => {
 
   test('treats background refetches as checking before using cached setup status', () => {
     const statuses = buildPlatformSetupStatuses({
-      github: {
-        data: { installed: false, installation: null },
-        isError: false,
-        isFetching: true,
-        isLoading: false,
-      },
+      data: [{ platform: 'github', installed: false, installation: null }],
+      isError: false,
+      isFetching: true,
+      isLoading: false,
     });
 
     expect(statuses.github).toEqual({ kind: 'checking', label: 'Checking' });

--- a/apps/web/src/app/collab/_components/setup-status.ts
+++ b/apps/web/src/app/collab/_components/setup-status.ts
@@ -1,6 +1,7 @@
 import type { PlatformId } from './platforms';
 
 export type PlatformInstallation = {
+  platform: Exclude<PlatformId, 'microsoft-teams' | 'google-chat'>;
   installed: boolean;
   installation: {
     accountLogin?: string | null;
@@ -11,7 +12,7 @@ export type PlatformInstallation = {
 };
 
 export type PlatformInstallationQueryState = {
-  data: PlatformInstallation | undefined;
+  data: readonly PlatformInstallation[] | undefined;
   isError: boolean;
   isFetching?: boolean;
   isLoading: boolean;
@@ -25,8 +26,6 @@ export type PlatformSetupStatus =
   | { kind: 'unknown'; label: 'Could not check' };
 
 export type PlatformSetupStatusMap = Record<PlatformId, PlatformSetupStatus>;
-
-type PlatformInstallationQueries = Partial<Record<PlatformId, PlatformInstallationQueryState>>;
 
 const PLATFORM_ORDER: PlatformId[] = [
   'slack',
@@ -56,17 +55,21 @@ function getConnectedAccountLabel(
 
 export function getPlatformSetupStatus(
   platformId: PlatformId,
-  query: PlatformInstallationQueryState | undefined
+  query: PlatformInstallationQueryState
 ): PlatformSetupStatus {
   if (platformId === 'microsoft-teams' || platformId === 'google-chat') {
     return { kind: 'unavailable', label: 'Not available yet' };
   }
 
-  if (query?.isLoading || query?.isFetching) return { kind: 'checking', label: 'Checking' };
-  if (query?.isError) return { kind: 'unknown', label: 'Could not check' };
+  if (query.isLoading || query.isFetching) return { kind: 'checking', label: 'Checking' };
+  if (query.isError) return { kind: 'unknown', label: 'Could not check' };
 
-  if (query?.data?.installed) {
-    const detail = getConnectedAccountLabel(platformId, query.data.installation);
+  const integration = query.data?.find(
+    installedIntegration => installedIntegration.platform === platformId
+  );
+
+  if (integration?.installed) {
+    const detail = getConnectedAccountLabel(platformId, integration.installation);
     return detail
       ? { kind: 'connected', label: 'Already set up', detail }
       : { kind: 'connected', label: 'Already set up' };
@@ -76,16 +79,16 @@ export function getPlatformSetupStatus(
 }
 
 export function buildPlatformSetupStatuses(
-  queries: PlatformInstallationQueries
+  query: PlatformInstallationQueryState
 ): PlatformSetupStatusMap {
   return {
-    slack: getPlatformSetupStatus('slack', queries.slack),
-    discord: getPlatformSetupStatus('discord', queries.discord),
-    'microsoft-teams': getPlatformSetupStatus('microsoft-teams', queries['microsoft-teams']),
-    'google-chat': getPlatformSetupStatus('google-chat', queries['google-chat']),
-    github: getPlatformSetupStatus('github', queries.github),
-    gitlab: getPlatformSetupStatus('gitlab', queries.gitlab),
-    linear: getPlatformSetupStatus('linear', queries.linear),
+    slack: getPlatformSetupStatus('slack', query),
+    discord: getPlatformSetupStatus('discord', query),
+    'microsoft-teams': getPlatformSetupStatus('microsoft-teams', query),
+    'google-chat': getPlatformSetupStatus('google-chat', query),
+    github: getPlatformSetupStatus('github', query),
+    gitlab: getPlatformSetupStatus('gitlab', query),
+    linear: getPlatformSetupStatus('linear', query),
   };
 }
 

--- a/apps/web/src/app/collab/_components/setup-status.ts
+++ b/apps/web/src/app/collab/_components/setup-status.ts
@@ -1,0 +1,120 @@
+import type { PlatformId } from './platforms';
+
+export type PlatformInstallation = {
+  installed: boolean;
+  installation: {
+    accountLogin?: string | null;
+    guildName?: string | null;
+    teamName?: string | null;
+    workspaceName?: string | null;
+  } | null;
+};
+
+export type PlatformInstallationQueryState = {
+  data: PlatformInstallation | undefined;
+  isError: boolean;
+  isFetching?: boolean;
+  isLoading: boolean;
+};
+
+export type PlatformSetupStatus =
+  | { kind: 'connected'; label: 'Already set up'; detail?: string }
+  | { kind: 'not_connected'; label: 'Not set up' }
+  | { kind: 'checking'; label: 'Checking' }
+  | { kind: 'unavailable'; label: 'Not available yet' }
+  | { kind: 'unknown'; label: 'Could not check' };
+
+export type PlatformSetupStatusMap = Record<PlatformId, PlatformSetupStatus>;
+
+type PlatformInstallationQueries = Partial<Record<PlatformId, PlatformInstallationQueryState>>;
+
+const PLATFORM_ORDER: PlatformId[] = [
+  'slack',
+  'discord',
+  'microsoft-teams',
+  'google-chat',
+  'github',
+  'gitlab',
+  'linear',
+];
+
+function getConnectedAccountLabel(
+  platformId: PlatformId,
+  installation: PlatformInstallation['installation']
+): string | undefined {
+  if (!installation) return undefined;
+
+  if (platformId === 'slack') return installation.teamName ?? undefined;
+  if (platformId === 'discord') return installation.guildName ?? undefined;
+  if (platformId === 'linear') return installation.workspaceName ?? undefined;
+  if (platformId === 'github' || platformId === 'gitlab') {
+    return installation.accountLogin ?? undefined;
+  }
+
+  return undefined;
+}
+
+export function getPlatformSetupStatus(
+  platformId: PlatformId,
+  query: PlatformInstallationQueryState | undefined
+): PlatformSetupStatus {
+  if (platformId === 'microsoft-teams' || platformId === 'google-chat') {
+    return { kind: 'unavailable', label: 'Not available yet' };
+  }
+
+  if (query?.isLoading || query?.isFetching) return { kind: 'checking', label: 'Checking' };
+  if (query?.isError) return { kind: 'unknown', label: 'Could not check' };
+
+  if (query?.data?.installed) {
+    const detail = getConnectedAccountLabel(platformId, query.data.installation);
+    return detail
+      ? { kind: 'connected', label: 'Already set up', detail }
+      : { kind: 'connected', label: 'Already set up' };
+  }
+
+  return { kind: 'not_connected', label: 'Not set up' };
+}
+
+export function buildPlatformSetupStatuses(
+  queries: PlatformInstallationQueries
+): PlatformSetupStatusMap {
+  return {
+    slack: getPlatformSetupStatus('slack', queries.slack),
+    discord: getPlatformSetupStatus('discord', queries.discord),
+    'microsoft-teams': getPlatformSetupStatus('microsoft-teams', queries['microsoft-teams']),
+    'google-chat': getPlatformSetupStatus('google-chat', queries['google-chat']),
+    github: getPlatformSetupStatus('github', queries.github),
+    gitlab: getPlatformSetupStatus('gitlab', queries.gitlab),
+    linear: getPlatformSetupStatus('linear', queries.linear),
+  };
+}
+
+export function canSelectPlatform(status: PlatformSetupStatus): boolean {
+  return status.kind === 'not_connected' || status.kind === 'unknown';
+}
+
+export function getConnectedPlatformIds(statuses: PlatformSetupStatusMap): PlatformId[] {
+  return PLATFORM_ORDER.filter(platformId => statuses[platformId].kind === 'connected');
+}
+
+export function getSelectedServiceIdsToAuthorize(
+  selectedIds: Iterable<PlatformId>,
+  statuses: PlatformSetupStatusMap
+): PlatformId[] {
+  return Array.from(selectedIds).filter(platformId => canSelectPlatform(statuses[platformId]));
+}
+
+export function hasAnyConfiguredOrSelectedPlatform(
+  platformIds: ReadonlySet<PlatformId>,
+  selectedIds: Iterable<PlatformId>,
+  statuses: PlatformSetupStatusMap
+): boolean {
+  const selected = new Set(selectedIds);
+  return Array.from(platformIds).some(
+    platformId => selected.has(platformId) || statuses[platformId].kind === 'connected'
+  );
+}
+
+export function isCheckingPlatformSetup(statuses: PlatformSetupStatusMap): boolean {
+  return PLATFORM_ORDER.some(platformId => statuses[platformId].kind === 'checking');
+}

--- a/apps/web/src/app/collab/authorize/_components/AuthorizeFlow.tsx
+++ b/apps/web/src/app/collab/authorize/_components/AuthorizeFlow.tsx
@@ -11,6 +11,7 @@ import KiloLogo from '@/components/KiloLogo';
 import { useTRPC } from '@/lib/trpc/utils';
 import { useUser } from '@/hooks/useUser';
 import { getPlatform, type PlatformId, type PlatformOption } from '../../_components/platforms';
+import { buildReturnToPath } from './authorize-path';
 
 type ProgressListProps = {
   count: number;
@@ -19,13 +20,14 @@ type ProgressListProps = {
 
 type AuthorizeFlowProps = {
   serviceIds: PlatformId[];
+  connectedServiceIds: PlatformId[];
   organizationId?: string;
   initialIndex: number;
   initialError?: string;
 };
 
 export function AuthorizeFlow(props: AuthorizeFlowProps) {
-  const { serviceIds, organizationId, initialIndex, initialError } = props;
+  const { serviceIds, connectedServiceIds, organizationId, initialIndex, initialError } = props;
   const router = useRouter();
   const trpc = useTRPC();
   const { data: user } = useUser();
@@ -36,7 +38,12 @@ export function AuthorizeFlow(props: AuthorizeFlowProps) {
   const services = serviceIds.map(id => getPlatform(id)).filter(p => p !== undefined);
   const current = services[index];
   const isLast = index === services.length - 1;
-  const returnTo = buildReturnToPath({ serviceIds, organizationId, step: index });
+  const returnTo = buildReturnToPath({
+    serviceIds,
+    connectedServiceIds,
+    organizationId,
+    step: index,
+  });
   const oauthInput = {
     ...(organizationId ? { organizationId } : {}),
     returnTo,
@@ -99,7 +106,11 @@ export function AuthorizeFlow(props: AuthorizeFlowProps) {
   if (done || !current) {
     return (
       <div className="flex w-full flex-col items-center gap-12">
-        <Completed hasSelectedServices={services.length > 0} onContinue={() => router.push('/')} />
+        <Completed
+          hasSelectedServices={services.length > 0}
+          connectedServiceIds={connectedServiceIds}
+          onContinue={() => router.push('/')}
+        />
       </div>
     );
   }
@@ -159,20 +170,6 @@ export function AuthorizeFlow(props: AuthorizeFlowProps) {
       </AnimatePresence>
     </div>
   );
-}
-
-function buildReturnToPath({
-  serviceIds,
-  organizationId,
-  step,
-}: {
-  serviceIds: PlatformId[];
-  organizationId?: string;
-  step: number;
-}): string {
-  const params = new URLSearchParams({ services: serviceIds.join(','), step: step.toString() });
-  if (organizationId) params.set('organizationId', organizationId);
-  return `/collab/authorize?${params.toString()}`;
 }
 
 async function getOAuthUrl(
@@ -266,11 +263,15 @@ function ProgressList({ count, activeIndex }: ProgressListProps) {
 
 function Completed({
   hasSelectedServices,
+  connectedServiceIds,
   onContinue,
 }: {
   hasSelectedServices: boolean;
+  connectedServiceIds: PlatformId[];
   onContinue: () => void;
 }) {
+  const connectedServiceNames = connectedServiceIds.map(getPlatformName);
+
   return (
     <motion.section
       initial={{ opacity: 0, y: 8 }}
@@ -284,9 +285,7 @@ function Completed({
       <div className="flex w-full flex-col gap-4 text-center">
         <h1 className="text-2xl font-bold tracking-tight">Kilo is ready</h1>
         <p className="text-muted-foreground text-sm leading-relaxed">
-          {hasSelectedServices
-            ? 'Setup is complete. You can connect more services or fine-tune access from settings later.'
-            : 'No services were connected. You can connect chat, code, and issue tools from settings later.'}
+          {getCompletionDescription({ hasSelectedServices, connectedServiceNames })}
         </p>
       </div>
       <Button onClick={onContinue} size="lg" className="w-full">
@@ -294,4 +293,34 @@ function Completed({
       </Button>
     </motion.section>
   );
+}
+
+function getCompletionDescription({
+  hasSelectedServices,
+  connectedServiceNames,
+}: {
+  hasSelectedServices: boolean;
+  connectedServiceNames: string[];
+}): string {
+  if (hasSelectedServices) {
+    return 'Setup is complete. You can connect more services or fine-tune access from settings later.';
+  }
+
+  if (connectedServiceNames.length > 0) {
+    const serviceList = formatServiceList(connectedServiceNames);
+    const verb = connectedServiceNames.length === 1 ? 'is' : 'are';
+    return `${serviceList} ${verb} already set up. You can connect more services or fine-tune access from settings later.`;
+  }
+
+  return 'No services were connected. You can connect chat, code, and issue tools from settings later.';
+}
+
+function getPlatformName(platformId: PlatformId): string {
+  return getPlatform(platformId)?.name ?? platformId;
+}
+
+function formatServiceList(names: string[]): string {
+  if (names.length <= 1) return names[0] ?? 'Selected services';
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
 }

--- a/apps/web/src/app/collab/authorize/_components/AuthorizeFlow.tsx
+++ b/apps/web/src/app/collab/authorize/_components/AuthorizeFlow.tsx
@@ -100,6 +100,7 @@ export function AuthorizeFlow(props: AuthorizeFlowProps) {
   };
 
   const handleSkip = () => {
+    if (isStartingOAuth) return;
     advance();
   };
 
@@ -161,7 +162,8 @@ export function AuthorizeFlow(props: AuthorizeFlowProps) {
             <button
               type="button"
               onClick={handleSkip}
-              className="text-muted-foreground hover:text-foreground text-sm underline-offset-4 hover:underline"
+              disabled={isStartingOAuth}
+              className="text-muted-foreground hover:text-foreground disabled:text-muted-foreground/60 text-sm underline-offset-4 hover:underline disabled:cursor-not-allowed disabled:no-underline"
             >
               Skip for now
             </button>

--- a/apps/web/src/app/collab/authorize/_components/authorize-path.test.ts
+++ b/apps/web/src/app/collab/authorize/_components/authorize-path.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from '@jest/globals';
+import { buildReturnToPath } from './authorize-path';
+
+describe('collab authorize return path', () => {
+  test('preserves already connected services through OAuth callbacks', () => {
+    const path = buildReturnToPath({
+      serviceIds: ['github', 'linear'],
+      connectedServiceIds: ['slack'],
+      organizationId: '0c06733d-0f2c-42ec-921b-c312fb190427',
+      step: 1,
+    });
+
+    expect(path).toBe(
+      '/collab/authorize?services=github%2Clinear&step=1&connected=slack&organizationId=0c06733d-0f2c-42ec-921b-c312fb190427'
+    );
+  });
+});

--- a/apps/web/src/app/collab/authorize/_components/authorize-path.ts
+++ b/apps/web/src/app/collab/authorize/_components/authorize-path.ts
@@ -1,0 +1,18 @@
+import type { PlatformId } from '../../_components/platforms';
+
+export function buildReturnToPath({
+  serviceIds,
+  connectedServiceIds,
+  organizationId,
+  step,
+}: {
+  serviceIds: PlatformId[];
+  connectedServiceIds: PlatformId[];
+  organizationId?: string;
+  step: number;
+}): string {
+  const params = new URLSearchParams({ services: serviceIds.join(','), step: step.toString() });
+  if (connectedServiceIds.length > 0) params.set('connected', connectedServiceIds.join(','));
+  if (organizationId) params.set('organizationId', organizationId);
+  return `/collab/authorize?${params.toString()}`;
+}

--- a/apps/web/src/app/collab/authorize/page.tsx
+++ b/apps/web/src/app/collab/authorize/page.tsx
@@ -81,6 +81,7 @@ export default async function CollabAuthorizePage({ searchParams }: AppPageProps
 
   const params = await searchParams;
   const services = parseServices(params?.services);
+  const connectedServices = parseServices(params?.connected);
   const organizationId = Array.isArray(params?.organizationId)
     ? params.organizationId[0]
     : params?.organizationId;
@@ -93,6 +94,7 @@ export default async function CollabAuthorizePage({ searchParams }: AppPageProps
     <KiloCardLayout bare className="max-w-xl" contentClassName="">
       <AuthorizeFlow
         serviceIds={services}
+        connectedServiceIds={connectedServices}
         organizationId={organizationId}
         initialIndex={initialIndex}
         initialError={initialError}

--- a/apps/web/src/lib/integrations/platform-integration-setup-status.ts
+++ b/apps/web/src/lib/integrations/platform-integration-setup-status.ts
@@ -1,0 +1,94 @@
+import type { PlatformIntegration } from '@kilocode/db/schema';
+import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
+
+export const SETUP_STATUS_PLATFORMS = [
+  PLATFORM.SLACK,
+  PLATFORM.DISCORD,
+  PLATFORM.GITHUB,
+  PLATFORM.GITLAB,
+  PLATFORM.LINEAR,
+] as const;
+
+export type SetupStatusPlatform = (typeof SETUP_STATUS_PLATFORMS)[number];
+
+export type PlatformIntegrationSetupStatus = {
+  platform: SetupStatusPlatform;
+  installed: boolean;
+  installation: {
+    accountLogin?: string | null;
+    guildName?: string | null;
+    teamName?: string | null;
+    workspaceName?: string | null;
+  } | null;
+};
+
+function isSetupStatusPlatform(platform: string): platform is SetupStatusPlatform {
+  return SETUP_STATUS_PLATFORMS.some(setupPlatform => setupPlatform === platform);
+}
+
+function buildInstallationSummary(
+  integration: PlatformIntegration
+): PlatformIntegrationSetupStatus['installation'] {
+  if (integration.platform === PLATFORM.SLACK) {
+    return { teamName: integration.platform_account_login };
+  }
+  if (integration.platform === PLATFORM.DISCORD) {
+    return { guildName: integration.platform_account_login };
+  }
+  if (integration.platform === PLATFORM.LINEAR) {
+    return { workspaceName: integration.platform_account_login };
+  }
+  if (integration.platform === PLATFORM.GITHUB || integration.platform === PLATFORM.GITLAB) {
+    return { accountLogin: integration.platform_account_login };
+  }
+
+  return null;
+}
+
+function toSetupStatus(integration: PlatformIntegration): PlatformIntegrationSetupStatus | null {
+  if (!isSetupStatusPlatform(integration.platform)) return null;
+
+  return {
+    platform: integration.platform,
+    installed: integration.integration_status === INTEGRATION_STATUS.ACTIVE,
+    installation: buildInstallationSummary(integration),
+  };
+}
+
+function hasDisplayLabel(status: PlatformIntegrationSetupStatus): boolean {
+  return Boolean(
+    status.installation?.accountLogin ||
+    status.installation?.guildName ||
+    status.installation?.teamName ||
+    status.installation?.workspaceName
+  );
+}
+
+function shouldPreferStatus(
+  current: PlatformIntegrationSetupStatus,
+  candidate: PlatformIntegrationSetupStatus
+): boolean {
+  if (candidate.installed !== current.installed) return candidate.installed;
+  return !hasDisplayLabel(current) && hasDisplayLabel(candidate);
+}
+
+export function summarizePlatformIntegrationsForSetupStatus(
+  integrations: PlatformIntegration[]
+): PlatformIntegrationSetupStatus[] {
+  const byPlatform = new Map<SetupStatusPlatform, PlatformIntegrationSetupStatus>();
+
+  for (const integration of integrations) {
+    const status = toSetupStatus(integration);
+    if (!status) continue;
+
+    const current = byPlatform.get(status.platform);
+    if (!current || shouldPreferStatus(current, status)) {
+      byPlatform.set(status.platform, status);
+    }
+  }
+
+  return SETUP_STATUS_PLATFORMS.flatMap(platform => {
+    const status = byPlatform.get(platform);
+    return status ? [status] : [];
+  });
+}

--- a/apps/web/src/routers/platform-integrations-router.test.ts
+++ b/apps/web/src/routers/platform-integrations-router.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, expect, beforeAll, afterEach } from '@jest/globals';
+import { db } from '@/lib/drizzle';
+import { addUserToOrganization } from '@/lib/organizations/organizations';
+import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
+import { createCallerForUser } from '@/routers/test-utils';
+import { createTestOrganization } from '@/tests/helpers/organization.helper';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { platform_integrations, type Organization, type User } from '@kilocode/db/schema';
+import { eq, or } from 'drizzle-orm';
+
+describe('platformIntegrationsRouter', () => {
+  let ownerUser: User;
+  let memberUser: User;
+  let nonMemberUser: User;
+  let organization: Organization;
+
+  beforeAll(async () => {
+    ownerUser = await insertTestUser({
+      google_user_email: 'platform-integrations-owner@example.com',
+      google_user_name: 'Platform Integrations Owner',
+    });
+    memberUser = await insertTestUser({
+      google_user_email: 'platform-integrations-member@example.com',
+      google_user_name: 'Platform Integrations Member',
+    });
+    nonMemberUser = await insertTestUser({
+      google_user_email: 'platform-integrations-non-member@example.com',
+      google_user_name: 'Platform Integrations Non-member',
+    });
+
+    organization = await createTestOrganization('Platform Integrations Test Org', ownerUser.id, 1);
+    await addUserToOrganization(organization.id, memberUser.id, 'member');
+  });
+
+  afterEach(async () => {
+    await db
+      .delete(platform_integrations)
+      .where(
+        or(
+          eq(platform_integrations.owned_by_user_id, ownerUser.id),
+          eq(platform_integrations.owned_by_organization_id, organization.id)
+        )
+      );
+  });
+
+  test('returns sanitized setup statuses for the current user', async () => {
+    await insertPlatformIntegration({
+      userId: ownerUser.id,
+      platform: PLATFORM.SLACK,
+      platformAccountLogin: 'Kilo Team',
+      status: INTEGRATION_STATUS.ACTIVE,
+    });
+    await insertPlatformIntegration({
+      userId: ownerUser.id,
+      platform: PLATFORM.GITHUB,
+      platformAccountLogin: 'kilocode',
+      status: INTEGRATION_STATUS.SUSPENDED,
+    });
+    await insertPlatformIntegration({
+      userId: ownerUser.id,
+      platform: PLATFORM.DOLTHUB,
+      platformAccountLogin: 'kilocode',
+      status: INTEGRATION_STATUS.ACTIVE,
+    });
+
+    const caller = await createCallerForUser(ownerUser.id);
+    const result = await caller.platformIntegrations.listSetupStatus();
+
+    expect(result).toEqual([
+      {
+        platform: PLATFORM.SLACK,
+        installed: true,
+        installation: { teamName: 'Kilo Team' },
+      },
+      {
+        platform: PLATFORM.GITHUB,
+        installed: false,
+        installation: { accountLogin: 'kilocode' },
+      },
+    ]);
+  });
+
+  test('allows organization members to read organization setup status', async () => {
+    await insertPlatformIntegration({
+      organizationId: organization.id,
+      platform: PLATFORM.GITLAB,
+      platformAccountLogin: 'kilocode',
+      status: INTEGRATION_STATUS.ACTIVE,
+    });
+
+    const caller = await createCallerForUser(memberUser.id);
+    const result = await caller.platformIntegrations.listSetupStatus({
+      organizationId: organization.id,
+    });
+
+    expect(result).toEqual([
+      {
+        platform: PLATFORM.GITLAB,
+        installed: true,
+        installation: { accountLogin: 'kilocode' },
+      },
+    ]);
+  });
+
+  test('rejects organization setup status reads for non-members', async () => {
+    const caller = await createCallerForUser(nonMemberUser.id);
+
+    await expect(
+      caller.platformIntegrations.listSetupStatus({ organizationId: organization.id })
+    ).rejects.toThrow('You do not have access to this organization');
+  });
+});
+
+async function insertPlatformIntegration({
+  userId,
+  organizationId,
+  platform,
+  platformAccountLogin,
+  status,
+}: {
+  userId?: string;
+  organizationId?: string;
+  platform: string;
+  platformAccountLogin: string;
+  status: string;
+}) {
+  await db.insert(platform_integrations).values({
+    owned_by_user_id: userId ?? null,
+    owned_by_organization_id: organizationId ?? null,
+    platform,
+    integration_type: 'app',
+    platform_installation_id: `${platform}-${crypto.randomUUID()}`,
+    platform_account_login: platformAccountLogin,
+    repository_access: 'all',
+    integration_status: status,
+    metadata: { access_token: 'secret-token' },
+  });
+}

--- a/apps/web/src/routers/platform-integrations-router.ts
+++ b/apps/web/src/routers/platform-integrations-router.ts
@@ -1,0 +1,18 @@
+import 'server-only';
+import { getAllIntegrationsForOwner } from '@/lib/integrations/db/platform-integrations';
+import { optionalOrgInput, resolveOwner } from '@/lib/integrations/resolve-owner';
+import { summarizePlatformIntegrationsForSetupStatus } from '@/lib/integrations/platform-integration-setup-status';
+import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+
+export const platformIntegrationsRouter = createTRPCRouter({
+  listSetupStatus: baseProcedure.input(optionalOrgInput).query(async ({ ctx, input }) => {
+    if (input?.organizationId) {
+      await ensureOrganizationAccess(ctx, input.organizationId);
+    }
+
+    const owner = resolveOwner(ctx, input?.organizationId);
+    const integrations = await getAllIntegrationsForOwner(owner);
+    return summarizePlatformIntegrationsForSetupStatus(integrations);
+  }),
+});

--- a/apps/web/src/routers/root-router.ts
+++ b/apps/web/src/routers/root-router.ts
@@ -13,6 +13,7 @@ import { cloudAgentRouter } from '@/routers/cloud-agent-router';
 import { cloudAgentNextRouter } from '@/routers/cloud-agent-next-router';
 import { githubAppsRouter } from '@/routers/github-apps-router';
 import { gitlabRouter } from '@/routers/gitlab-router';
+import { platformIntegrationsRouter } from '@/routers/platform-integrations-router';
 import { slackRouter } from '@/routers/slack-router';
 import { linearRouter } from '@/routers/linear-router';
 import { dolthubRouter } from '@/routers/dolthub-router';
@@ -52,6 +53,7 @@ export const rootRouter = createTRPCRouter({
   cliSessionsV2: cliSessionsV2Router,
   githubApps: githubAppsRouter,
   gitlab: gitlabRouter,
+  platformIntegrations: platformIntegrationsRouter,
   slack: slackRouter,
   linear: linearRouter,
   dolthub: dolthubRouter,


### PR DESCRIPTION
## Summary

- Shows already set up integrations in the `/collab` wizard after workspace selection and counts them toward chat/code setup.
- Adds `platformIntegrations.listSetupStatus` so the wizard reads all owner platform integrations through one sanitized endpoint instead of querying each service router.
- Keeps connected and unavailable services out of the authorization queue while preserving connected-service context through authorization callbacks.

## Verification

N/A

## Visual Changes

<img width="1414" height="2634" alt="CleanShot 2026-05-22 at 11 11 07@2x" src="https://github.com/user-attachments/assets/ff319c53-5a25-4222-88f2-6a8180ac8bb8" />

## Reviewer Notes

- Review focus: owner/org access on the consolidated setup-status endpoint, OAuth callback query preservation, background refetch behavior, and connected/unavailable tile accessibility.