### PR TITLE
fix(web): allow app URL override dev origin

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -28,6 +28,7 @@ const localNetworkDevOrigins = [
   '10.*.*.*',
   '192.168.*.*',
   ...Array.from({ length: 16 }, (_, index) => `172.${16 + index}.*.*`),
+  ...(process.env.APP_URL_OVERRIDE ? [new URL(process.env.APP_URL_OVERRIDE).host] : []),
 ];
 
 /** @type {import('next').NextConfig} */


### PR DESCRIPTION
## Summary
- Add `APP_URL_OVERRIDE` to Next.js `allowedDevOrigins` so dev requests from the configured app host are accepted.
- Keep the PR isolated to the `apps/web/next.config.mjs` configuration change only.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
- `git diff --check` passed.
- Direct config import in the temporary clean worktree was not runnable because dependencies were not installed there (`@sentry/nextjs` missing).