### PR TITLE
fix(collab): preserve setup step in browser history

### DIFF
--- a/apps/web/src/app/collab/_components/BotWizard.tsx
+++ b/apps/web/src/app/collab/_components/BotWizard.tsx
@@ -38,14 +38,11 @@ export function BotWizard() {
   const searchParams = useSearchParams();
   const setupSearch = searchParams.toString();
   const trpc = useTRPC();
-  const initialSetupState = getInitialSetupState(searchParams);
-  const [stepIndex, setStepIndex] = useState(initialSetupState.stepIndex);
+  const [setupState, setSetupState] = useState(() => getInitialSetupState(searchParams));
   const [selected, setSelected] = useState<Set<PlatformId>>(new Set());
-  const [workspace, setWorkspace] = useState<WorkspaceSelection | null>(
-    initialSetupState.workspace
-  );
   const [missingPlatformWarning, setMissingPlatformWarning] =
     useState<MissingPlatformWarning | null>(null);
+  const { stepIndex, workspace } = setupState;
 
   const isWorkspaceStep = stepIndex === 0;
   const setupInput = workspace?.type === 'org' ? { organizationId: workspace.id } : undefined;
@@ -82,8 +79,7 @@ export function BotWizard() {
   useEffect(() => {
     const params = new URLSearchParams(setupSearch);
     const nextSetupState = getInitialSetupState(params);
-    setStepIndex(nextSetupState.stepIndex);
-    setWorkspace(nextSetupState.workspace);
+    setSetupState(nextSetupState);
     setMissingPlatformWarning(null);
 
     if (params.has('step') && nextSetupState.stepIndex === 0) {
@@ -92,10 +88,10 @@ export function BotWizard() {
   }, [router, setupSearch]);
 
   const navigateToStep = (nextStepIndex: number, nextWorkspace: WorkspaceSelection | null) => {
+    const nextSetupState = { stepIndex: nextStepIndex, workspace: nextWorkspace };
     setMissingPlatformWarning(null);
-    setWorkspace(nextWorkspace);
-    setStepIndex(nextStepIndex);
-    router.push(buildSetupPath({ stepIndex: nextStepIndex, workspace: nextWorkspace }), {
+    setSetupState(nextSetupState);
+    router.push(buildSetupPath(nextSetupState), {
       scroll: false,
     });
   };

--- a/apps/web/src/app/collab/_components/BotWizard.tsx
+++ b/apps/web/src/app/collab/_components/BotWizard.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, ArrowRight, CheckCircle2, Loader2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -27,6 +27,7 @@ import {
   isCheckingPlatformSetup,
   type PlatformSetupStatusMap,
 } from './setup-status';
+import { buildSetupPath, getInitialSetupState } from './setup-path';
 import { WorkspaceSelector, type WorkspaceSelection } from './WorkspaceSelector';
 
 const TOTAL_STEPS = 2;
@@ -34,10 +35,15 @@ type MissingPlatformWarning = 'chat' | 'code';
 
 export function BotWizard() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const setupSearch = searchParams.toString();
   const trpc = useTRPC();
-  const [stepIndex, setStepIndex] = useState(0);
+  const initialSetupState = getInitialSetupState(searchParams);
+  const [stepIndex, setStepIndex] = useState(initialSetupState.stepIndex);
   const [selected, setSelected] = useState<Set<PlatformId>>(new Set());
-  const [workspace, setWorkspace] = useState<WorkspaceSelection | null>(null);
+  const [workspace, setWorkspace] = useState<WorkspaceSelection | null>(
+    initialSetupState.workspace
+  );
   const [missingPlatformWarning, setMissingPlatformWarning] =
     useState<MissingPlatformWarning | null>(null);
 
@@ -71,7 +77,28 @@ export function BotWizard() {
     selected,
     setupStatuses
   );
-  const canAdvance = isWorkspaceStep ? workspace !== null : !isCheckingSetup;
+  const canAdvance = isWorkspaceStep ? workspace !== null : workspace !== null && !isCheckingSetup;
+
+  useEffect(() => {
+    const params = new URLSearchParams(setupSearch);
+    const nextSetupState = getInitialSetupState(params);
+    setStepIndex(nextSetupState.stepIndex);
+    setWorkspace(nextSetupState.workspace);
+    setMissingPlatformWarning(null);
+
+    if (params.has('step') && nextSetupState.stepIndex === 0) {
+      router.replace(buildSetupPath(nextSetupState), { scroll: false });
+    }
+  }, [router, setupSearch]);
+
+  const navigateToStep = (nextStepIndex: number, nextWorkspace: WorkspaceSelection | null) => {
+    setMissingPlatformWarning(null);
+    setWorkspace(nextWorkspace);
+    setStepIndex(nextStepIndex);
+    router.push(buildSetupPath({ stepIndex: nextStepIndex, workspace: nextWorkspace }), {
+      scroll: false,
+    });
+  };
 
   const handleToggle = (platformId: PlatformId) => {
     if (!canSelectPlatform(setupStatuses[platformId])) return;
@@ -88,6 +115,7 @@ export function BotWizard() {
   };
 
   const proceedToAuthorize = () => {
+    if (workspace === null) return;
     setMissingPlatformWarning(null);
     const params = new URLSearchParams();
     if (servicesToAuthorize.length > 0) {
@@ -104,7 +132,7 @@ export function BotWizard() {
   };
 
   const handleContinueWithoutRecommendedPlatform = () => {
-    if (isCheckingSetup) return;
+    if (isCheckingSetup || workspace === null) return;
 
     if (missingPlatformWarning === 'chat' && !hasCodePlatform) {
       setMissingPlatformWarning('code');
@@ -116,7 +144,8 @@ export function BotWizard() {
   const handleNext = () => {
     if (!canAdvance) return;
     if (isWorkspaceStep) {
-      setStepIndex(1);
+      if (workspace === null) return;
+      navigateToStep(1, workspace);
       return;
     }
     if (!hasChatPlatform) {
@@ -131,12 +160,11 @@ export function BotWizard() {
   };
 
   const handleWorkspaceSelect = (selection: WorkspaceSelection) => {
-    setWorkspace(selection);
-    setStepIndex(1);
+    navigateToStep(1, selection);
   };
 
   const handleBack = () => {
-    if (stepIndex > 0) setStepIndex(i => i - 1);
+    if (stepIndex > 0) navigateToStep(stepIndex - 1, workspace);
   };
 
   return (

--- a/apps/web/src/app/collab/_components/WorkspaceSelector.tsx
+++ b/apps/web/src/app/collab/_components/WorkspaceSelector.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 
-export type WorkspaceSelection = { type: 'org'; id: string; name: string } | { type: 'personal' };
+export type WorkspaceSelection = { type: 'org'; id: string } | { type: 'personal' };
 
 type WorkspaceSelectorProps = {
   value: WorkspaceSelection | null;
@@ -58,7 +58,6 @@ export function WorkspaceSelector({ value, onSelect }: WorkspaceSelectorProps) {
       onSelect({
         type: 'org',
         id: result.organization.id,
-        name: result.organization.name,
       });
     } catch (error) {
       setCreateError(
@@ -87,9 +86,7 @@ export function WorkspaceSelector({ value, onSelect }: WorkspaceSelectorProps) {
           <WorkspaceRow
             key={org.organizationId}
             selected={isSelected}
-            onClick={() =>
-              onSelect({ type: 'org', id: org.organizationId, name: org.organizationName })
-            }
+            onClick={() => onSelect({ type: 'org', id: org.organizationId })}
           >
             <div className="bg-primary/10 flex size-10 items-center justify-center rounded-full">
               <Building2 className="text-primary size-5" />

--- a/apps/web/src/app/collab/_components/setup-path.test.ts
+++ b/apps/web/src/app/collab/_components/setup-path.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from '@jest/globals';
+import { buildSetupPath, getInitialSetupState } from './setup-path';
+
+describe('collab setup path', () => {
+  test('pushes step two with personal workspace state', () => {
+    expect(buildSetupPath({ stepIndex: 1, workspace: { type: 'personal' } })).toBe(
+      '/collab?step=1'
+    );
+  });
+
+  test('pushes step two with organization workspace state', () => {
+    expect(
+      buildSetupPath({
+        stepIndex: 1,
+        workspace: {
+          type: 'org',
+          id: '0c06733d-0f2c-42ec-921b-c312fb190427',
+          name: 'Kilo Team',
+        },
+      })
+    ).toBe('/collab?step=1&organizationId=0c06733d-0f2c-42ec-921b-c312fb190427');
+  });
+
+  test('defaults step two to personal workspace when organization is not set', () => {
+    const params = new URLSearchParams({ step: '1' });
+
+    expect(getInitialSetupState(params)).toEqual({
+      stepIndex: 1,
+      workspace: { type: 'personal' },
+    });
+  });
+});

--- a/apps/web/src/app/collab/_components/setup-path.test.ts
+++ b/apps/web/src/app/collab/_components/setup-path.test.ts
@@ -15,7 +15,6 @@ describe('collab setup path', () => {
         workspace: {
           type: 'org',
           id: '0c06733d-0f2c-42ec-921b-c312fb190427',
-          name: 'Kilo Team',
         },
       })
     ).toBe('/collab?step=1&organizationId=0c06733d-0f2c-42ec-921b-c312fb190427');
@@ -27,6 +26,18 @@ describe('collab setup path', () => {
     expect(getInitialSetupState(params)).toEqual({
       stepIndex: 1,
       workspace: { type: 'personal' },
+    });
+  });
+
+  test('restores organization workspace state from URL', () => {
+    const params = new URLSearchParams({
+      step: '1',
+      organizationId: '0c06733d-0f2c-42ec-921b-c312fb190427',
+    });
+
+    expect(getInitialSetupState(params)).toEqual({
+      stepIndex: 1,
+      workspace: { type: 'org', id: '0c06733d-0f2c-42ec-921b-c312fb190427' },
     });
   });
 });

--- a/apps/web/src/app/collab/_components/setup-path.ts
+++ b/apps/web/src/app/collab/_components/setup-path.ts
@@ -1,0 +1,45 @@
+import type { WorkspaceSelection } from './WorkspaceSelector';
+
+type SearchParamReader = {
+  get(name: string): string | null;
+};
+
+export function getSetupStepIndex(searchParams: SearchParamReader): number {
+  return searchParams.get('step') === '1' ? 1 : 0;
+}
+
+export function getSetupWorkspace(searchParams: SearchParamReader): WorkspaceSelection | null {
+  const organizationId = searchParams.get('organizationId');
+  if (organizationId) return { type: 'org', id: organizationId, name: '' };
+  if (getSetupStepIndex(searchParams) === 1) return { type: 'personal' };
+  return null;
+}
+
+export function getInitialSetupState(searchParams: SearchParamReader): {
+  stepIndex: number;
+  workspace: WorkspaceSelection | null;
+} {
+  const workspace = getSetupWorkspace(searchParams);
+  const requestedStepIndex = getSetupStepIndex(searchParams);
+
+  return {
+    stepIndex: requestedStepIndex === 1 && workspace === null ? 0 : requestedStepIndex,
+    workspace,
+  };
+}
+
+export function buildSetupPath({
+  stepIndex,
+  workspace,
+}: {
+  stepIndex: number;
+  workspace: WorkspaceSelection | null;
+}): string {
+  const params = new URLSearchParams();
+
+  if (stepIndex > 0) params.set('step', '1');
+  if (workspace?.type === 'org') params.set('organizationId', workspace.id);
+
+  const query = params.toString();
+  return query ? `/collab?${query}` : '/collab';
+}

--- a/apps/web/src/app/collab/_components/setup-path.ts
+++ b/apps/web/src/app/collab/_components/setup-path.ts
@@ -10,7 +10,7 @@ export function getSetupStepIndex(searchParams: SearchParamReader): number {
 
 export function getSetupWorkspace(searchParams: SearchParamReader): WorkspaceSelection | null {
   const organizationId = searchParams.get('organizationId');
-  if (organizationId) return { type: 'org', id: organizationId, name: '' };
+  if (organizationId) return { type: 'org', id: organizationId };
   if (getSetupStepIndex(searchParams) === 1) return { type: 'personal' };
   return null;
 }

--- a/apps/web/src/app/collab/authorize/_components/AuthorizeFlow.tsx
+++ b/apps/web/src/app/collab/authorize/_components/AuthorizeFlow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AlertCircle, Check, ChevronRight } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useRouter } from 'next/navigation';
@@ -37,13 +37,14 @@ export function AuthorizeFlow(props: AuthorizeFlowProps) {
 
   const services = serviceIds.map(id => getPlatform(id)).filter(p => p !== undefined);
   const current = services[index];
-  const isLast = index === services.length - 1;
-  const returnTo = buildReturnToPath({
-    serviceIds,
-    connectedServiceIds,
-    organizationId,
-    step: index,
-  });
+  const getAuthorizePath = (step: number) =>
+    buildReturnToPath({
+      serviceIds,
+      connectedServiceIds,
+      organizationId,
+      step,
+    });
+  const returnTo = getAuthorizePath(index);
   const oauthInput = {
     ...(organizationId ? { organizationId } : {}),
     returnTo,
@@ -63,13 +64,18 @@ export function AuthorizeFlow(props: AuthorizeFlowProps) {
   const isStartingOAuth =
     isFetchingSlackOAuthUrl || isFetchingDiscordOAuthUrl || isFetchingLinearOAuthUrl;
 
+  useEffect(() => {
+    setIndex(initialIndex);
+    setDone(initialIndex >= serviceIds.length);
+    setConnectionError(initialError ?? null);
+  }, [initialError, initialIndex, serviceIds.length]);
+
   const advance = () => {
+    const nextIndex = index + 1;
     setConnectionError(null);
-    if (isLast) {
-      setDone(true);
-      return;
-    }
-    setIndex(i => i + 1);
+    setIndex(nextIndex);
+    setDone(nextIndex >= services.length);
+    router.push(getAuthorizePath(nextIndex), { scroll: false });
   };
 
   const handleAuthorize = async () => {


### PR DESCRIPTION
## Summary

- Preserve `/collab` setup and authorize steps in the URL so browser back/forward returns to the previous step instead of leaving the flow.
- Add shared setup path parsing/building for personal and organization setup URLs, with personal represented by `step=1` and no `organizationId`.

## Verification

- [x] Manually went back-and-forth through the `/collab` flow in my dev server.

## Visual Changes

N/A

## Reviewer Notes

- Personal setup step two uses `/collab?step=1`; organization setup step two adds `organizationId`.
