### PR TITLE
feat(cloud-agent): add Gastown filter

### DIFF
--- a/apps/mobile/src/components/agents/platform-filter-modal.tsx
+++ b/apps/mobile/src/components/agents/platform-filter-modal.tsx
@@ -7,7 +7,7 @@ import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { cn } from '@/lib/utils';
 
-const PLATFORM_FILTERS = ['cloud-agent', 'extension', 'cli', 'slack', 'other'] as const;
+const PLATFORM_FILTERS = ['cloud-agent', 'extension', 'gastown', 'cli', 'slack', 'other'] as const;
 const chipScrollContentStyle = { paddingHorizontal: 22, paddingVertical: 8, gap: 8 };
 
 export type ProjectFilterOption = {
@@ -56,6 +56,9 @@ function platformFilterLabel(p: string): string {
     }
     case 'other': {
       return 'Other';
+    }
+    case 'gastown': {
+      return 'Gastown';
     }
     default: {
       return p;

--- a/apps/web/src/components/cloud-agent-next/ChatSidebar.tsx
+++ b/apps/web/src/components/cloud-agent-next/ChatSidebar.tsx
@@ -270,7 +270,7 @@ function SessionRow({
   );
 }
 
-const PLATFORM_FILTERS = ['cloud-agent', 'extension', 'cli', 'slack', 'other'] as const;
+const PLATFORM_FILTERS = ['cloud-agent', 'extension', 'gastown', 'cli', 'slack', 'other'] as const;
 
 function platformFilterLabel(p: string): string {
   switch (p) {
@@ -284,6 +284,8 @@ function platformFilterLabel(p: string): string {
       return 'Slack';
     case 'other':
       return 'Other';
+    case 'gastown':
+      return 'Gastown';
     default:
       return p;
   }

--- a/apps/web/src/components/cloud-agent-next/CloudSidebarLayout.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudSidebarLayout.tsx
@@ -63,6 +63,7 @@ export function CloudSidebarLayout({ organizationId, children }: CloudSidebarLay
         case 'extension':
           return ['vscode', 'agent-manager'];
         default:
+          // Handles platforms like 'gastown' by passing through unchanged
           return [p];
       }
     });

--- a/services/gastown/container/src/process-manager.test.ts
+++ b/services/gastown/container/src/process-manager.test.ts
@@ -14,18 +14,16 @@ vi.mock('./agent-runner', () => ({
     (kilocodeToken: string, model: string, smallModel: string, organizationId?: string) =>
       JSON.stringify({ kilocodeToken, model, smallModel, organizationId })
   ),
-  buildKiloAuthEnv: vi.fn(
-    (kilocodeToken?: string, organizationId?: string | null) => {
-      const authEnv: Record<string, string> = { KILO_PLATFORM: 'gastown' };
-      if (kilocodeToken) {
-        authEnv.KILO_AUTH_CONTENT = JSON.stringify({ kilo: { type: 'api', key: kilocodeToken } });
-      }
-      if (organizationId) {
-        authEnv.KILO_ORG_ID = organizationId;
-      }
-      return authEnv;
+  buildKiloAuthEnv: vi.fn((kilocodeToken?: string, organizationId?: string | null) => {
+    const authEnv: Record<string, string> = { KILO_PLATFORM: 'gastown' };
+    if (kilocodeToken) {
+      authEnv.KILO_AUTH_CONTENT = JSON.stringify({ kilo: { type: 'api', key: kilocodeToken } });
     }
-  ),
+    if (organizationId) {
+      authEnv.KILO_ORG_ID = organizationId;
+    }
+    return authEnv;
+  }),
   resolveGitCredentials: vi.fn(),
   writeMayorSystemPromptToAgentsMd: vi.fn(),
   ensureMayorWorkspaceForTown: vi.fn(async (_townId: string) => TEST_WORKSPACE),
@@ -288,9 +286,7 @@ describe('awaitHydration', () => {
       });
       expect(env?.KILO_CONFIG_CONTENT).toBeTruthy();
       expect(env?.KILO_PLATFORM).toBe('gastown');
-      expect(env?.KILO_AUTH_CONTENT).toBe(
-        JSON.stringify({ kilo: { type: 'api', key: 'kc-tok' } })
-      );
+      expect(env?.KILO_AUTH_CONTENT).toBe(JSON.stringify({ kilo: { type: 'api', key: 'kc-tok' } }));
       expect(env?.KILO_ORG_ID).toBeUndefined();
     } finally {
       globalThis.fetch = originalFetch;


### PR DESCRIPTION
Adds 'Gastown' option to platform filter dropdowns in web ChatSidebar and mobile platform filter modal. Updates PLATFORM_FILTERS constants and label mappings. Ensures backend filter works via default case. No other behavior changes.