### PR TITLE
feat(bot): handle pr and mr comment requests

### DIFF
--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -389,6 +389,7 @@ export async function GET(request: NextRequest) {
           ? new Date(installation.created_at).toISOString()
           : new Date().toISOString(),
         githubAppType: appType,
+        metadata: { bot_enabled: true },
       });
     }
 

--- a/apps/web/src/app/api/integrations/gitlab/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/gitlab/callback/route.test.ts
@@ -2,8 +2,24 @@ import { beforeEach, describe, expect, test } from '@jest/globals';
 import { NextRequest } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { createGitLabOAuthState } from '@/lib/integrations/platforms/gitlab/oauth-state';
-import { exchangeGitLabOAuthCode } from '@/lib/integrations/platforms/gitlab/adapter';
+import { createGitLabBotLinkState } from '@/lib/bot/gitlab-link-state';
+import { linkKiloUser } from '@/lib/bot-identity';
+import {
+  canKiloUserAccessPlatformIntegration,
+  getPlatformIntegrationById,
+} from '@/lib/bot/platform-helpers';
+import {
+  exchangeGitLabOAuthCode,
+  fetchGitLabUser,
+} from '@/lib/integrations/platforms/gitlab/adapter';
 import { getGitLabOAuthCredentials } from '@/lib/integrations/platforms/gitlab/oauth-credentials';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import type { StateAdapter } from 'chat';
+
+const mockIsEnabledForBot = jest.fn();
+const mockBotInitialize = jest.fn();
+const mockState = { state: true } as unknown as StateAdapter;
+const mockBotGetState = jest.fn(() => mockState);
 
 jest.mock('@/lib/user.server');
 jest.mock('@/lib/drizzle', () => ({ db: {} }));
@@ -22,6 +38,24 @@ jest.mock('@/lib/integrations/platforms/gitlab/adapter', () => ({
   fetchGitLabProjects: jest.fn(),
   calculateTokenExpiry: jest.fn(),
 }));
+jest.mock('@/lib/bot/platform-helpers', () => ({
+  canKiloUserAccessPlatformIntegration: jest.fn(),
+  getPlatformIntegrationById: jest.fn(),
+}));
+jest.mock('@/lib/bot/platforms', () => ({
+  botPlatforms: {
+    require: jest.fn(() => ({ isEnabledForBot: mockIsEnabledForBot })),
+  },
+}));
+jest.mock('@/lib/bot', () => ({
+  bot: {
+    initialize: (...args: unknown[]) => mockBotInitialize(...args),
+    getState: () => mockBotGetState(),
+  },
+}));
+jest.mock('@/lib/bot-identity', () => ({
+  linkKiloUser: jest.fn(),
+}));
 jest.mock('@/lib/integrations/platforms/gitlab/oauth-credentials', () => ({
   getGitLabOAuthCredentials: jest.fn(),
 }));
@@ -32,7 +66,13 @@ jest.mock('@sentry/nextjs', () => ({
 
 const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
 const mockedExchangeGitLabOAuthCode = jest.mocked(exchangeGitLabOAuthCode);
+const mockedFetchGitLabUser = jest.mocked(fetchGitLabUser);
 const mockedGetGitLabOAuthCredentials = jest.mocked(getGitLabOAuthCredentials);
+const mockedGetPlatformIntegrationById = jest.mocked(getPlatformIntegrationById);
+const mockedCanKiloUserAccessPlatformIntegration = jest.mocked(
+  canKiloUserAccessPlatformIntegration
+);
+const mockedLinkKiloUser = jest.mocked(linkKiloUser);
 
 const USER_ID = '034489e8-19e0-4479-9d69-2edad719e847';
 const OTHER_USER_ID = 'c00b91a1-6959-4b04-9ef8-e8d37b340f4a';
@@ -56,6 +96,21 @@ describe('GET /api/integrations/gitlab/callback', () => {
       authFailedResponse: null,
     } as never);
     mockedGetGitLabOAuthCredentials.mockResolvedValue(null);
+    mockedGetPlatformIntegrationById.mockResolvedValue({
+      id: 'pi_gitlab_1',
+      platform: PLATFORM.GITLAB,
+      metadata: { bot_enabled: true, gitlab_instance_url: 'https://gitlab.example.com' },
+    } as never);
+    mockedCanKiloUserAccessPlatformIntegration.mockResolvedValue(true);
+    mockIsEnabledForBot.mockReturnValue(true);
+    mockedExchangeGitLabOAuthCode.mockResolvedValue({
+      access_token: 'gitlab-oauth-token',
+    } as never);
+    mockedFetchGitLabUser.mockResolvedValue({
+      id: 123,
+      username: 'rso',
+      name: 'RSO',
+    } as never);
   });
 
   test('rejects attacker-controlled raw state before exchanging an OAuth code', async () => {
@@ -158,6 +213,40 @@ describe('GET /api/integrations/gitlab/callback', () => {
         clientId: 'self-hosted-client',
         clientSecret: 'self-hosted-secret',
       }
+    );
+  });
+
+  test('links a GitLab user for bot-link callbacks without running install flow', async () => {
+    const state = createGitLabBotLinkState({
+      userId: USER_ID,
+      platformIntegrationId: 'pi_gitlab_1',
+    });
+    const { GET } = await import('./route');
+    const response = await GET(
+      makeRequest(
+        `/api/integrations/gitlab/callback?code=anything&state=${encodeURIComponent(state)}`
+      )
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain('GitLab account linked');
+    expect(mockedExchangeGitLabOAuthCode).toHaveBeenCalledWith(
+      'anything',
+      'https://gitlab.example.com',
+      undefined
+    );
+    expect(mockedFetchGitLabUser).toHaveBeenCalledWith(
+      'gitlab-oauth-token',
+      'https://gitlab.example.com'
+    );
+    expect(mockedLinkKiloUser).toHaveBeenCalledWith(
+      mockState,
+      {
+        platform: PLATFORM.GITLAB,
+        teamId: 'pi_gitlab_1',
+        userId: '123',
+      },
+      USER_ID
     );
   });
 });

--- a/apps/web/src/app/api/integrations/gitlab/callback/route.ts
+++ b/apps/web/src/app/api/integrations/gitlab/callback/route.ts
@@ -13,7 +13,10 @@ import {
   fetchGitLabProjects,
   calculateTokenExpiry,
 } from '@/lib/integrations/platforms/gitlab/adapter';
-import { normalizeInstanceUrl } from '@/lib/integrations/gitlab-service';
+import {
+  normalizeInstanceUrl,
+  type GitLabIntegrationMetadata,
+} from '@/lib/integrations/gitlab-service';
 import { resetCodeReviewConfigForOwner } from '@/lib/agent-config/db/agent-configs';
 import { APP_URL } from '@/lib/constants';
 import { createHash, randomBytes } from 'crypto';
@@ -23,12 +26,117 @@ import {
   verifyGitLabOAuthState,
 } from '@/lib/integrations/platforms/gitlab/oauth-state';
 import { getGitLabOAuthCredentials } from '@/lib/integrations/platforms/gitlab/oauth-credentials';
+import {
+  type VerifiedGitLabBotLinkState,
+  verifyGitLabBotLinkState,
+} from '@/lib/bot/gitlab-link-state';
+import {
+  canKiloUserAccessPlatformIntegration,
+  getPlatformIntegrationById,
+} from '@/lib/bot/platform-helpers';
+import { botPlatforms } from '@/lib/bot/platforms';
+import { bot } from '@/lib/bot';
+import { linkKiloUser } from '@/lib/bot-identity';
 
 /**
  * Generates a secure random webhook secret for GitLab webhook verification
  */
 function generateWebhookSecret(): string {
   return randomBytes(32).toString('hex');
+}
+
+function htmlPage(title: string, message: string, status = 200): Response {
+  return new Response(
+    `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>${title}</title></head>
+<body style="font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
+<div style="text-align:center">
+  <h1>${title}</h1>
+  <p>${message}</p>
+</div>
+</body></html>`,
+    { status, headers: { 'content-type': 'text/html; charset=utf-8' } }
+  );
+}
+
+async function handleGitLabBotLinkCallback(
+  request: NextRequest,
+  user: { id: string },
+  state: VerifiedGitLabBotLinkState
+): Promise<Response> {
+  const searchParams = request.nextUrl.searchParams;
+  const error = searchParams.get('error');
+  const code = searchParams.get('code');
+
+  if (error) {
+    captureMessage('GitLab bot-link OAuth error', {
+      level: 'warning',
+      tags: { endpoint: 'gitlab/callback', source: 'gitlab_bot_link' },
+      extra: { error },
+    });
+    return htmlPage(
+      'Link Failed',
+      'GitLab returned an OAuth error. Please return to GitLab and try again.',
+      400
+    );
+  }
+
+  if (!code) {
+    return htmlPage(
+      'Link Failed',
+      'GitLab did not return an authorization code. Please try again.',
+      400
+    );
+  }
+
+  if (state.userId !== user.id) {
+    return htmlPage(
+      'Link Failed',
+      'This GitLab link request was started by another Kilo user.',
+      403
+    );
+  }
+
+  const integration = await getPlatformIntegrationById(state.platformIntegrationId).catch(
+    () => null
+  );
+
+  if (!integration || integration.platform !== PLATFORM.GITLAB) {
+    return htmlPage('Link Failed', 'No matching GitLab integration was found.', 404);
+  }
+
+  if (!botPlatforms.require(PLATFORM.GITLAB).isEnabledForBot(integration)) {
+    return htmlPage('Link Unavailable', 'GitLab linking is not enabled for this integration.', 404);
+  }
+
+  if (!(await canKiloUserAccessPlatformIntegration(integration, user.id))) {
+    return htmlPage('Link Failed', 'You do not have access to this GitLab integration.', 403);
+  }
+
+  const metadata = integration.metadata as GitLabIntegrationMetadata | null;
+  const instanceUrl = metadata?.gitlab_instance_url || DEFAULT_GITLAB_OAUTH_INSTANCE_URL;
+  const customCredentials =
+    metadata?.client_id && metadata.client_secret
+      ? { clientId: metadata.client_id, clientSecret: metadata.client_secret }
+      : undefined;
+  const tokens = await exchangeGitLabOAuthCode(code, instanceUrl, customCredentials);
+  const gitlabUser = await fetchGitLabUser(tokens.access_token, instanceUrl);
+
+  await bot.initialize();
+  await linkKiloUser(
+    bot.getState(),
+    {
+      platform: PLATFORM.GITLAB,
+      teamId: integration.id,
+      userId: gitlabUser.id.toString(),
+    },
+    user.id
+  );
+
+  return htmlPage(
+    'GitLab account linked',
+    `GitLab account ${gitlabUser.username} has been linked to your Kilo account.<br>You can return to GitLab and mention Kilo again.`
+  );
 }
 
 function buildGitLabRedirectPath(
@@ -84,6 +192,11 @@ export async function GET(request: NextRequest) {
     const code = searchParams.get('code');
     const state = searchParams.get('state');
     const error = searchParams.get('error');
+
+    const botLinkState = verifyGitLabBotLinkState(state);
+    if (botLinkState) {
+      return await handleGitLabBotLinkCallback(request, user, botLinkState);
+    }
 
     const verifiedState = verifyGitLabOAuthState(state);
     if (!verifiedState) {
@@ -197,6 +310,7 @@ export async function GET(request: NextRequest) {
         instanceUrl !== DEFAULT_GITLAB_OAUTH_INSTANCE_URL ? instanceUrl : undefined,
       webhook_secret: webhookSecret,
       auth_type: 'oauth',
+      bot_enabled: existingMetadata?.bot_enabled === false ? false : true,
       // Only preserve webhooks/tokens if same instance
       configured_webhooks: isInstanceChange ? undefined : existingMetadata?.configured_webhooks,
       project_tokens: isInstanceChange ? undefined : existingMetadata?.project_tokens,

--- a/apps/web/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
+++ b/apps/web/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
@@ -24,8 +24,11 @@ import {
 } from '@/lib/bot/request-logging';
 import { parseBotCallbackStep } from '@/lib/bot/step-budget';
 import { runBotAgent, type BotAgentMessageLike } from '@/lib/bot/agent-runner';
+import { detectPrCreationStrategy } from '@/lib/bot/pr-creation-strategy';
 import { botPlatforms } from '@/lib/bot/platforms';
 import { getPlatformIntegrationById } from '@/lib/bot/platform-helpers';
+import { createGitLabSyntheticThread, parseGitLabThreadId } from '@/lib/bot/platforms/gitlab';
+import { PLATFORM } from '@/lib/integrations/core/constants';
 import { findUserById } from '@/lib/user';
 import type { Thread } from 'chat';
 
@@ -178,6 +181,23 @@ async function startBotThreadTyping(params: {
   });
 }
 
+async function resolveCallbackThread(params: {
+  threadId: string;
+  platformIntegration: PlatformIntegration;
+}): Promise<Thread> {
+  if (params.platformIntegration.platform === PLATFORM.GITLAB) {
+    const context = parseGitLabThreadId(params.threadId);
+    if (!context) throw new Error(`Could not parse GitLab callback thread ${params.threadId}`);
+    return createGitLabSyntheticThread({
+      context,
+      platformIntegration: params.platformIntegration,
+    });
+  }
+
+  await bot.initialize();
+  return bot.thread(params.threadId);
+}
+
 async function continueBotAgentAfterCallback(params: {
   botRequestId: string;
   requestRow: Awaited<ReturnType<typeof getBotRequest>>;
@@ -225,10 +245,12 @@ async function continueBotAgentAfterCallback(params: {
       return await runBotAgent({
         thread: params.thread,
         message: callbackMessage,
+        rawMessage: originalMessage ?? undefined,
         platformIntegration: params.platformIntegration,
         user,
         botRequestId: params.botRequestId,
         prompt: params.continuationPrompt,
+        prCreationStrategy: detectPrCreationStrategy(params.requestRow.user_message),
         completedStepCount: params.completedStepCount,
         initialSteps: params.requestRow.steps ?? [],
       });
@@ -886,8 +908,10 @@ export async function POST(
         const platformIntegration = await getPlatformIntegrationById(
           requestRow.platform_integration_id
         );
-        await bot.initialize();
-        const thread = bot.thread(requestRow.platform_thread_id);
+        const thread = await resolveCallbackThread({
+          threadId: requestRow.platform_thread_id,
+          platformIntegration,
+        });
 
         if (childSessionStatus && trackedCallbackSession) {
           try {

--- a/apps/web/src/app/api/webhooks/gitlab/route.test.ts
+++ b/apps/web/src/app/api/webhooks/gitlab/route.test.ts
@@ -1,0 +1,169 @@
+const mockFindGitLabIntegrationByWebhookToken = jest.fn();
+const mockVerifyGitLabWebhookToken = jest.fn();
+const mockHandleGitLabNoteBotMention = jest.fn();
+const mockHandleMergeRequest = jest.fn();
+const mockLogWebhookEvent = jest.fn();
+const mockUpdateWebhookEvent = jest.fn();
+
+let afterCallbacks: Array<() => Promise<void> | void> = [];
+
+jest.mock('next/server', () => {
+  const actual = jest.requireActual('next/server');
+  return {
+    ...actual,
+    after: (fn: () => Promise<void> | void) => {
+      afterCallbacks.push(fn);
+    },
+  };
+});
+
+jest.mock('@/lib/integrations/platforms/gitlab/adapter', () => ({
+  verifyGitLabWebhookToken: (...args: unknown[]) => mockVerifyGitLabWebhookToken(...args),
+}));
+
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  findGitLabIntegrationByWebhookToken: (...args: unknown[]) =>
+    mockFindGitLabIntegrationByWebhookToken(...args),
+}));
+
+jest.mock('@/lib/integrations/platforms/gitlab/webhook-handlers', () => ({
+  handleGitLabNoteBotMention: (...args: unknown[]) => mockHandleGitLabNoteBotMention(...args),
+  handleMergeRequest: (...args: unknown[]) => mockHandleMergeRequest(...args),
+}));
+
+jest.mock('@/lib/integrations/db/webhook-events', () => ({
+  logWebhookEvent: (...args: unknown[]) => mockLogWebhookEvent(...args),
+  updateWebhookEvent: (...args: unknown[]) => mockUpdateWebhookEvent(...args),
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+import { POST } from './route';
+
+function gitLabRequest(payload: unknown): Request {
+  return new Request('https://app.example.com/api/webhooks/gitlab', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-gitlab-token': 'secret',
+      'x-gitlab-event': 'Note Hook',
+      'x-gitlab-event-uuid': 'event-1',
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+function createIntegration() {
+  return {
+    id: 'pi_gitlab_1',
+    owned_by_user_id: 'user_1',
+    owned_by_organization_id: null,
+    platform: 'gitlab',
+    metadata: { webhook_secret: 'secret', bot_enabled: true },
+    suspended_at: null,
+  };
+}
+
+function createNotePayload(note: string, overrides: Record<string, unknown> = {}) {
+  return {
+    object_kind: 'note',
+    event_type: 'note',
+    user: { id: 123, name: 'RSO', username: 'rso' },
+    project_id: 456,
+    project: {
+      id: 456,
+      name: 'widgets',
+      web_url: 'https://gitlab.example.com/acme/widgets',
+      namespace: 'acme',
+      path_with_namespace: 'acme/widgets',
+      default_branch: 'main',
+    },
+    object_attributes: {
+      id: 789,
+      note,
+      noteable_type: 'MergeRequest',
+      author_id: 123,
+      created_at: '2026-05-05T07:32:52Z',
+      updated_at: '2026-05-05T07:32:52Z',
+      project_id: 456,
+      noteable_id: 999,
+      noteable_iid: 37,
+      system: false,
+      url: 'https://gitlab.example.com/acme/widgets/-/merge_requests/37#note_789',
+      ...overrides,
+    },
+    merge_request: {
+      id: 999,
+      iid: 37,
+      title: 'Update widgets',
+      description: 'MR description',
+      state: 'opened',
+      source_branch: 'feature/widgets',
+      target_branch: 'main',
+      source_project_id: 456,
+      target_project_id: 456,
+      author_id: 123,
+      created_at: '2026-05-05T07:00:00Z',
+      updated_at: '2026-05-05T07:00:00Z',
+      url: 'https://gitlab.example.com/acme/widgets/-/merge_requests/37',
+    },
+  };
+}
+
+async function flushAfterCallbacks(): Promise<void> {
+  const callbacks = afterCallbacks;
+  afterCallbacks = [];
+  await Promise.all(callbacks.map(callback => callback()));
+}
+
+describe('GitLab webhook route', () => {
+  beforeEach(() => {
+    afterCallbacks = [];
+    jest.clearAllMocks();
+    mockFindGitLabIntegrationByWebhookToken.mockResolvedValue(createIntegration());
+    mockVerifyGitLabWebhookToken.mockReturnValue(true);
+    mockLogWebhookEvent.mockResolvedValue({ id: 'webhook_event_1', isDuplicate: false });
+    mockHandleGitLabNoteBotMention.mockResolvedValue(undefined);
+  });
+
+  it('ignores MR notes without a Kilo bot mention', async () => {
+    const response = await POST(gitLabRequest(createNotePayload('please fix this')) as never);
+    await flushAfterCallbacks();
+
+    expect(response.status).toBe(200);
+    expect(mockLogWebhookEvent).not.toHaveBeenCalled();
+    expect(mockHandleGitLabNoteBotMention).not.toHaveBeenCalled();
+  });
+
+  it('schedules bot mention handling for MR notes that mention Kilo', async () => {
+    const payload = createNotePayload('@kilocode-bot open a new MR for this');
+    const integration = createIntegration();
+    mockFindGitLabIntegrationByWebhookToken.mockResolvedValue(integration);
+
+    const response = await POST(gitLabRequest(payload) as never);
+    await flushAfterCallbacks();
+
+    expect(response.status).toBe(200);
+    expect(mockLogWebhookEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ event_action: 'bot_mention' })
+    );
+    expect(mockHandleGitLabNoteBotMention).toHaveBeenCalledWith(payload, integration);
+    expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
+      'webhook_event_1',
+      expect.objectContaining({ processed: true, handlers_triggered: ['bot_mention'] })
+    );
+  });
+
+  it('ignores system notes', async () => {
+    const response = await POST(
+      gitLabRequest(createNotePayload('@kilocode-bot fix this', { system: true })) as never
+    );
+    await flushAfterCallbacks();
+
+    expect(response.status).toBe(200);
+    expect(mockHandleGitLabNoteBotMention).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/webhooks/gitlab/route.ts
+++ b/apps/web/src/app/api/webhooks/gitlab/route.ts
@@ -1,11 +1,18 @@
 import type { NextRequest } from 'next/server';
-import { NextResponse } from 'next/server';
+import { after, NextResponse } from 'next/server';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import { verifyGitLabWebhookToken } from '@/lib/integrations/platforms/gitlab/adapter';
-import { MergeRequestPayloadSchema } from '@/lib/integrations/platforms/gitlab/webhook-schemas';
+import {
+  MergeRequestPayloadSchema,
+  NoteEventPayloadSchema,
+} from '@/lib/integrations/platforms/gitlab/webhook-schemas';
 import { findGitLabIntegrationByWebhookToken } from '@/lib/integrations/db/platform-integrations';
-import { handleMergeRequest } from '@/lib/integrations/platforms/gitlab/webhook-handlers';
+import {
+  handleGitLabNoteBotMention,
+  handleMergeRequest,
+} from '@/lib/integrations/platforms/gitlab/webhook-handlers';
 import { PLATFORM, GITLAB_EVENT, GITLAB_ACTION } from '@/lib/integrations/core/constants';
+import { hasGitLabBotMention } from '@/lib/bot/platforms/gitlab';
 import { logExceptInTest } from '@/lib/utils.server';
 import { logWebhookEvent, updateWebhookEvent } from '@/lib/integrations/db/webhook-events';
 import type { Owner } from '@/lib/integrations/core/types';
@@ -170,7 +177,68 @@ export async function POST(request: NextRequest) {
 
     // Handle Note (comment) events (for future use - e.g., responding to review comments)
     if (eventType === GITLAB_EVENT.NOTE) {
-      logExceptInTest('Note event received, not yet implemented');
+      const parseResult = NoteEventPayloadSchema.safeParse(payload);
+      if (!parseResult.success) {
+        logExceptInTest('Invalid note payload:', parseResult.error);
+        captureMessage('Invalid GitLab note webhook payload structure', {
+          level: 'error',
+          tags: { source: 'gitlab_webhook_validation', event: 'note' },
+          extra: { errors: parseResult.error.issues },
+        });
+        return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+      }
+
+      const notePayload = parseResult.data;
+      if (
+        notePayload.object_attributes.system === true ||
+        notePayload.object_attributes.noteable_type !== 'MergeRequest' ||
+        !notePayload.merge_request ||
+        !hasGitLabBotMention(notePayload.object_attributes.note)
+      ) {
+        return NextResponse.json({ message: 'Event received' }, { status: 200 });
+      }
+
+      const logResult = await logWebhook('bot_mention');
+      if (logResult.isDuplicate) {
+        return NextResponse.json({ message: 'Duplicate event' }, { status: 200 });
+      }
+
+      after(async () => {
+        try {
+          await handleGitLabNoteBotMention(notePayload, integration);
+          if (logResult.webhookEventId) {
+            await updateWebhookEvent(logResult.webhookEventId, {
+              processed: true,
+              processed_at: new Date().toISOString(),
+              handlers_triggered: ['bot_mention'],
+              errors: null,
+            });
+          }
+        } catch (error) {
+          logExceptInTest('Error handling GitLab note bot mention:', error);
+          captureException(error, {
+            tags: { source: 'gitlab_webhook_note_bot_mention' },
+            extra: { integrationId: integration.id, projectId: notePayload.project_id },
+          });
+          if (logResult.webhookEventId) {
+            await updateWebhookEvent(logResult.webhookEventId, {
+              processed: false,
+              processed_at: new Date().toISOString(),
+              handlers_triggered: ['bot_mention'],
+              errors: [
+                {
+                  handler: 'bot_mention',
+                  message: error instanceof Error ? error.message : String(error),
+                  ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+                },
+              ],
+            }).catch(updateError => {
+              logExceptInTest('Error updating failed webhook event:', updateError);
+            });
+          }
+        }
+      });
+
       return NextResponse.json({ message: 'Event received' }, { status: 200 });
     }
 

--- a/apps/web/src/app/gitlab/link/route.test.ts
+++ b/apps/web/src/app/gitlab/link/route.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { NextRequest, NextResponse } from 'next/server';
+import { createGitLabBotLinkState } from '@/lib/bot/gitlab-link-state';
+import { verifyGitLabLinkToken } from '@/lib/bot/gitlab-link-token';
+import {
+  canKiloUserAccessPlatformIntegration,
+  getPlatformIntegrationById,
+} from '@/lib/bot/platform-helpers';
+import { buildGitLabOAuthUrl } from '@/lib/integrations/platforms/gitlab/adapter';
+import { getUserFromAuth } from '@/lib/user.server';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import { failureResult } from '@/lib/maybe-result';
+
+const mockIsEnabledForBot = jest.fn();
+
+jest.mock('@/lib/user.server');
+jest.mock('@/lib/bot/gitlab-link-state');
+jest.mock('@/lib/bot/gitlab-link-token');
+jest.mock('@/lib/bot/platform-helpers');
+jest.mock('@/lib/integrations/platforms/gitlab/adapter', () => ({
+  buildGitLabOAuthUrl: jest.fn(),
+}));
+jest.mock('@/lib/bot/platforms', () => ({
+  botPlatforms: {
+    require: jest.fn(() => ({ isEnabledForBot: mockIsEnabledForBot })),
+  },
+}));
+
+const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
+const mockedCreateGitLabBotLinkState = jest.mocked(createGitLabBotLinkState);
+const mockedVerifyGitLabLinkToken = jest.mocked(verifyGitLabLinkToken);
+const mockedGetPlatformIntegrationById = jest.mocked(getPlatformIntegrationById);
+const mockedCanKiloUserAccessPlatformIntegration = jest.mocked(
+  canKiloUserAccessPlatformIntegration
+);
+const mockedBuildGitLabOAuthUrl = jest.mocked(buildGitLabOAuthUrl);
+
+const USER_ID = '034489e8-19e0-4479-9d69-2edad719e847';
+const PLATFORM_INTEGRATION_ID = 'pi_gitlab_1';
+
+function makeRequest(path: string) {
+  return new NextRequest(`http://localhost:3000${path}`);
+}
+
+describe('GET /gitlab/link', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: { id: USER_ID },
+      authFailedResponse: null,
+    } as never);
+    mockedVerifyGitLabLinkToken.mockReturnValue({
+      platformIntegrationId: PLATFORM_INTEGRATION_ID,
+      integrationId: PLATFORM_INTEGRATION_ID,
+    });
+    mockedCreateGitLabBotLinkState.mockReturnValue('signed-state');
+    mockedGetPlatformIntegrationById.mockResolvedValue({
+      id: PLATFORM_INTEGRATION_ID,
+      platform: PLATFORM.GITLAB,
+      owned_by_organization_id: 'org_1',
+      owned_by_user_id: null,
+      metadata: { bot_enabled: true, gitlab_instance_url: 'https://gitlab.example.com' },
+    } as never);
+    mockedCanKiloUserAccessPlatformIntegration.mockResolvedValue(true);
+    mockIsEnabledForBot.mockReturnValue(true);
+    mockedBuildGitLabOAuthUrl.mockReturnValue(
+      'https://gitlab.example.com/oauth/authorize?scope=read_user&state=signed-state'
+    );
+  });
+
+  test('rejects tampered or expired tokens', async () => {
+    mockedVerifyGitLabLinkToken.mockReturnValue(null);
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('/gitlab/link?token=bogus'));
+
+    expect(response.status).toBe(400);
+    expect(mockedGetUserFromAuth).not.toHaveBeenCalled();
+  });
+
+  test('redirects unauthenticated users to sign-in preserving the signed token', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: null,
+      authFailedResponse: NextResponse.json(failureResult('Unauthorized'), { status: 401 }),
+    } as never);
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('/gitlab/link?token=signed-token'));
+    const location = response.headers.get('location');
+
+    expect(response.status).toBe(307);
+    expect(location).toBeTruthy();
+    const url = new URL(location ?? '');
+    expect(url.pathname).toBe('/users/sign_in');
+    expect(url.searchParams.get('callbackPath')).toBe('/gitlab/link?token=signed-token');
+  });
+
+  test('returns 404 when the integration does not match the signed token', async () => {
+    mockedGetPlatformIntegrationById.mockResolvedValue({
+      id: 'other',
+      platform: PLATFORM.GITLAB,
+      metadata: { bot_enabled: true },
+    } as never);
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('/gitlab/link?token=signed-token'));
+
+    expect(response.status).toBe(404);
+    expect(mockedCreateGitLabBotLinkState).not.toHaveBeenCalled();
+  });
+
+  test('returns 404 when bot linking is disabled', async () => {
+    mockIsEnabledForBot.mockReturnValue(false);
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('/gitlab/link?token=signed-token'));
+
+    expect(response.status).toBe(404);
+    expect(mockedCreateGitLabBotLinkState).not.toHaveBeenCalled();
+  });
+
+  test('returns 403 when the Kilo user cannot access the integration owner', async () => {
+    mockedCanKiloUserAccessPlatformIntegration.mockResolvedValue(false);
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('/gitlab/link?token=signed-token'));
+
+    expect(response.status).toBe(403);
+    expect(mockedCreateGitLabBotLinkState).not.toHaveBeenCalled();
+  });
+
+  test('redirects to GitLab OAuth with read_user scope on the happy path', async () => {
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('/gitlab/link?token=signed-token'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://gitlab.example.com/oauth/authorize?scope=read_user&state=signed-state'
+    );
+    expect(mockedCreateGitLabBotLinkState).toHaveBeenCalledWith({
+      userId: USER_ID,
+      platformIntegrationId: PLATFORM_INTEGRATION_ID,
+    });
+    expect(mockedBuildGitLabOAuthUrl).toHaveBeenCalledWith(
+      'signed-state',
+      'https://gitlab.example.com',
+      undefined,
+      ['read_user']
+    );
+  });
+});

--- a/apps/web/src/app/gitlab/link/route.ts
+++ b/apps/web/src/app/gitlab/link/route.ts
@@ -1,0 +1,88 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { createGitLabBotLinkState } from '@/lib/bot/gitlab-link-state';
+import { verifyGitLabLinkToken } from '@/lib/bot/gitlab-link-token';
+import {
+  canKiloUserAccessPlatformIntegration,
+  getPlatformIntegrationById,
+} from '@/lib/bot/platform-helpers';
+import { botPlatforms } from '@/lib/bot/platforms';
+import { APP_URL } from '@/lib/constants';
+import { getUserFromAuth } from '@/lib/user.server';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import { buildGitLabOAuthUrl } from '@/lib/integrations/platforms/gitlab/adapter';
+import type { GitLabIntegrationMetadata } from '@/lib/integrations/gitlab-service';
+
+function errorPage(title: string, message: string, status: number): Response {
+  return new Response(
+    `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>${title}</title></head>
+<body style="font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
+<div style="text-align:center">
+  <h1>${title}</h1>
+  <p>${message}</p>
+</div>
+</body></html>`,
+    { status, headers: { 'content-type': 'text/html; charset=utf-8' } }
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get('token');
+  const verifiedToken = verifyGitLabLinkToken(token);
+
+  if (!verifiedToken) {
+    return errorPage(
+      'Link Expired',
+      'Invalid or expired GitLab link. Please return to GitLab and mention Kilo again to get a fresh link.',
+      400
+    );
+  }
+
+  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+
+  if (authFailedResponse) {
+    const signInUrl = new URL('/users/sign_in', APP_URL);
+    signInUrl.searchParams.set('callbackPath', `/gitlab/link?token=${token}`);
+    return NextResponse.redirect(signInUrl);
+  }
+
+  const integration = await getPlatformIntegrationById(verifiedToken.platformIntegrationId).catch(
+    () => null
+  );
+
+  if (!integration) {
+    return errorPage('Link Failed', 'No matching GitLab integration was found.', 404);
+  }
+
+  if (integration.platform !== PLATFORM.GITLAB || integration.id !== verifiedToken.integrationId) {
+    return errorPage('Link Failed', 'No matching GitLab integration was found.', 404);
+  }
+
+  if (!botPlatforms.require(PLATFORM.GITLAB).isEnabledForBot(integration)) {
+    return errorPage(
+      'Link Unavailable',
+      'GitLab linking is not enabled for this integration.',
+      404
+    );
+  }
+
+  if (!(await canKiloUserAccessPlatformIntegration(integration, user.id))) {
+    return errorPage('Access Denied', 'You do not have access to this GitLab integration.', 403);
+  }
+
+  const metadata = integration.metadata as GitLabIntegrationMetadata | null;
+  const instanceUrl = metadata?.gitlab_instance_url || 'https://gitlab.com';
+  const customCredentials =
+    metadata?.client_id && metadata.client_secret
+      ? { clientId: metadata.client_id, clientSecret: metadata.client_secret }
+      : undefined;
+  const state = createGitLabBotLinkState({
+    userId: user.id,
+    platformIntegrationId: integration.id,
+  });
+
+  return NextResponse.redirect(
+    buildGitLabOAuthUrl(state, instanceUrl, customCredentials, ['read_user'])
+  );
+}

--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -2,14 +2,7 @@ import { Chat, type Message, type Thread } from 'chat';
 import type { GitHubAdapter } from '@chat-adapter/github';
 import type { LinearAdapter } from '@chat-adapter/linear';
 import type { SlackAdapter } from '@chat-adapter/slack';
-import { captureException } from '@sentry/nextjs';
-import { resolveKiloUserId, unlinkKiloUser } from '@/lib/bot-identity';
-import {
-  canKiloUserAccessPlatformIntegration,
-  getPlatformIntegration,
-} from '@/lib/bot/platform-helpers';
-import { findUserById } from '@/lib/user';
-import { processLinkedMessage } from '@/lib/bot/run';
+import { handleIncomingBotMention } from '@/lib/bot/handle-mention';
 import { createChatState } from '@/lib/bot/state';
 import { githubAdapter } from '@/lib/bot/github-adapter';
 import { linearAdapter } from '@/lib/bot/linear-adapter';
@@ -41,71 +34,7 @@ function createKiloBot(
     thread: Thread,
     message: Message
   ): Promise<void> {
-    const botPlatform = botPlatforms.requireByAdapter(thread.adapter);
-    const identity = await botPlatform.getIdentity({ thread, message });
-    const [platformIntegration, kiloUserId] = await Promise.all([
-      getPlatformIntegration(identity),
-      resolveKiloUserId(chatBot.getState(), identity),
-    ]);
-
-    if (!platformIntegration) {
-      captureException(new Error('No active platform integration found'), {
-        extra: { platform: identity.platform, teamId: identity.teamId },
-      });
-      return;
-    }
-
-    if (!botPlatform.isEnabledForBot(platformIntegration)) {
-      return;
-    }
-
-    if (!(await botPlatform.canHandleMessage({ thread, message, platformIntegration }))) {
-      return;
-    }
-
-    if (!kiloUserId) {
-      await botPlatform.promptLinkAccount({
-        thread,
-        message,
-        identity,
-        platformIntegration,
-        state: chatBot.getState(),
-      });
-      return;
-    }
-
-    const user = await findUserById(kiloUserId);
-
-    if (!user) {
-      await unlinkKiloUser(chatBot.getState(), identity);
-      await botPlatform.promptLinkAccount({
-        thread,
-        message,
-        identity,
-        platformIntegration,
-        state: chatBot.getState(),
-      });
-      return;
-    }
-
-    if (!(await canKiloUserAccessPlatformIntegration(platformIntegration, user.id))) {
-      await unlinkKiloUser(chatBot.getState(), identity);
-      await botPlatform.promptLinkAccount({
-        thread,
-        message,
-        identity,
-        platformIntegration,
-        state: chatBot.getState(),
-      });
-      return;
-    }
-
-    try {
-      await processLinkedMessage({ thread, message, platformIntegration, user });
-    } catch (error) {
-      console.error('[Bot] Unhandled error in message handler:', error);
-      await thread.post({ markdown: 'Sorry, something went wrong while processing your message.' });
-    }
+    await handleIncomingBotMention({ thread, message, state: chatBot.getState() });
   });
 
   chatBot.onAction(async event => {

--- a/apps/web/src/lib/bot/agent-runner.ts
+++ b/apps/web/src/lib/bot/agent-runner.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/bot/constants';
 import { botPlatforms, type BotPlatform } from '@/lib/bot/platforms';
 import { buildPrSignature } from '@/lib/bot/pr-signature';
+import type { PrCreationStrategy } from '@/lib/bot/pr-creation-strategy';
 import {
   linkBotRequestToSession,
   recordBotRequestCloudAgentSession,
@@ -57,6 +58,7 @@ type RunBotAgentParams = {
   user: User;
   botRequestId: string;
   prompt: string;
+  prCreationStrategy?: PrCreationStrategy;
   /** Pre-uploaded image attachments from the user's message (already in R2). */
   images?: Images;
   completedStepCount?: number;
@@ -305,6 +307,7 @@ This tool returns an acknowledgement immediately. The final Cloud Agent result w
             },
             {
               prSignature,
+              prCreationStrategy: params.prCreationStrategy,
               chatPlatform,
               currentStep,
               images: params.images,

--- a/apps/web/src/lib/bot/gitlab-link-state.test.ts
+++ b/apps/web/src/lib/bot/gitlab-link-state.test.ts
@@ -1,0 +1,29 @@
+import { createGitLabBotLinkState, verifyGitLabBotLinkState } from './gitlab-link-state';
+
+describe('GitLab bot link state', () => {
+  it('round-trips a signed bot-link state', () => {
+    const state = createGitLabBotLinkState({
+      userId: 'user_1',
+      platformIntegrationId: 'pi_gitlab_1',
+    });
+
+    expect(verifyGitLabBotLinkState(state)).toEqual({
+      userId: 'user_1',
+      platformIntegrationId: 'pi_gitlab_1',
+      callbackPath: '/gitlab/link',
+    });
+  });
+
+  it('rejects non-GitLab bot-link state shapes', () => {
+    const payload = Buffer.from(
+      JSON.stringify({
+        kind: 'linear-bot-link',
+        userId: 'user_1',
+        iat: Date.now() / 1000,
+        nonce: 'n',
+      })
+    ).toString('base64url');
+
+    expect(verifyGitLabBotLinkState(`${payload}.signature`)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/bot/gitlab-link-state.ts
+++ b/apps/web/src/lib/bot/gitlab-link-state.ts
@@ -1,0 +1,85 @@
+import 'server-only';
+import crypto from 'node:crypto';
+import { z } from 'zod';
+import { NEXTAUTH_SECRET } from '@/lib/config.server';
+
+const HMAC_ALGORITHM = 'sha256';
+const STATE_TTL_SECONDS = 10 * 60;
+const NONCE_BYTES = 16;
+const KIND = 'gitlab-bot-link';
+
+const gitLabBotLinkStatePayloadSchema = z.object({
+  kind: z.literal(KIND),
+  userId: z.string().min(1),
+  platformIntegrationId: z.string().min(1),
+  callbackPath: z.string().startsWith('/'),
+  iat: z.number(),
+  nonce: z.string().min(1),
+});
+
+type GitLabBotLinkStatePayload = z.infer<typeof gitLabBotLinkStatePayloadSchema>;
+
+export type VerifiedGitLabBotLinkState = {
+  userId: string;
+  platformIntegrationId: string;
+  callbackPath: string;
+};
+
+function sign(data: string): string {
+  return crypto.createHmac(HMAC_ALGORITHM, NEXTAUTH_SECRET).update(data).digest('base64url');
+}
+
+export function createGitLabBotLinkState(params: {
+  userId: string;
+  platformIntegrationId: string;
+  callbackPath?: string;
+}): string {
+  const payload: GitLabBotLinkStatePayload = {
+    kind: KIND,
+    userId: params.userId,
+    platformIntegrationId: params.platformIntegrationId,
+    callbackPath: params.callbackPath ?? '/gitlab/link',
+    iat: Math.floor(Date.now() / 1000),
+    nonce: crypto.randomBytes(NONCE_BYTES).toString('base64url'),
+  };
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${encodedPayload}.${sign(encodedPayload)}`;
+}
+
+export function verifyGitLabBotLinkState(state: string | null): VerifiedGitLabBotLinkState | null {
+  if (!state) return null;
+
+  const dotIndex = state.indexOf('.');
+  if (dotIndex === -1) return null;
+
+  const payload = state.slice(0, dotIndex);
+  const providedSig = state.slice(dotIndex + 1);
+  const expectedSig = sign(payload);
+
+  if (
+    providedSig.length !== expectedSig.length ||
+    !crypto.timingSafeEqual(Buffer.from(providedSig), Buffer.from(expectedSig))
+  ) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+
+  const result = gitLabBotLinkStatePayloadSchema.safeParse(parsed);
+  if (!result.success) return null;
+
+  const data = result.data;
+  const ageSeconds = Math.floor(Date.now() / 1000) - data.iat;
+  if (ageSeconds < 0 || ageSeconds > STATE_TTL_SECONDS) return null;
+
+  return {
+    userId: data.userId,
+    platformIntegrationId: data.platformIntegrationId,
+    callbackPath: data.callbackPath,
+  };
+}

--- a/apps/web/src/lib/bot/gitlab-link-token.test.ts
+++ b/apps/web/src/lib/bot/gitlab-link-token.test.ts
@@ -1,0 +1,24 @@
+import { createGitLabLinkToken, verifyGitLabLinkToken } from './gitlab-link-token';
+
+describe('GitLab bot link token', () => {
+  it('round-trips a signed token', () => {
+    const token = createGitLabLinkToken({
+      platformIntegrationId: 'pi_gitlab_1',
+      integrationId: 'pi_gitlab_1',
+    });
+
+    expect(verifyGitLabLinkToken(token)).toEqual({
+      platformIntegrationId: 'pi_gitlab_1',
+      integrationId: 'pi_gitlab_1',
+    });
+  });
+
+  it('rejects tampered tokens', () => {
+    const token = createGitLabLinkToken({
+      platformIntegrationId: 'pi_gitlab_1',
+      integrationId: 'pi_gitlab_1',
+    });
+
+    expect(verifyGitLabLinkToken(`${token}tampered`)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/bot/gitlab-link-token.ts
+++ b/apps/web/src/lib/bot/gitlab-link-token.ts
@@ -1,0 +1,78 @@
+import 'server-only';
+import crypto from 'node:crypto';
+import { NEXTAUTH_SECRET } from '@/lib/config.server';
+
+const HMAC_ALGORITHM = 'sha256';
+const TOKEN_TTL_SECONDS = 30 * 60;
+const NONCE_BYTES = 16;
+
+type GitLabLinkTokenPayload = {
+  platformIntegrationId: string;
+  integrationId: string;
+  iat: number;
+  nonce: string;
+};
+
+export type VerifiedGitLabLinkToken = {
+  platformIntegrationId: string;
+  integrationId: string;
+};
+
+function sign(data: string): string {
+  return crypto.createHmac(HMAC_ALGORITHM, NEXTAUTH_SECRET).update(data).digest('base64url');
+}
+
+export function createGitLabLinkToken(params: {
+  platformIntegrationId: string;
+  integrationId: string;
+}): string {
+  const payload: GitLabLinkTokenPayload = {
+    platformIntegrationId: params.platformIntegrationId,
+    integrationId: params.integrationId,
+    iat: Math.floor(Date.now() / 1000),
+    nonce: crypto.randomBytes(NONCE_BYTES).toString('base64url'),
+  };
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${encodedPayload}.${sign(encodedPayload)}`;
+}
+
+export function verifyGitLabLinkToken(token: string | null): VerifiedGitLabLinkToken | null {
+  if (!token) return null;
+
+  const dotIndex = token.indexOf('.');
+  if (dotIndex === -1) return null;
+
+  const encodedPayload = token.slice(0, dotIndex);
+  const providedSig = token.slice(dotIndex + 1);
+  const expectedSig = sign(encodedPayload);
+
+  if (
+    providedSig.length !== expectedSig.length ||
+    !crypto.timingSafeEqual(Buffer.from(providedSig), Buffer.from(expectedSig))
+  ) {
+    return null;
+  }
+
+  try {
+    const data = JSON.parse(
+      Buffer.from(encodedPayload, 'base64url').toString('utf8')
+    ) as Partial<GitLabLinkTokenPayload>;
+
+    if (typeof data.platformIntegrationId !== 'string' || data.platformIntegrationId.length === 0) {
+      return null;
+    }
+    if (typeof data.integrationId !== 'string' || data.integrationId.length === 0) return null;
+    if (typeof data.iat !== 'number') return null;
+    if (typeof data.nonce !== 'string' || data.nonce.length === 0) return null;
+
+    const ageSeconds = Math.floor(Date.now() / 1000) - data.iat;
+    if (ageSeconds < 0 || ageSeconds > TOKEN_TTL_SECONDS) return null;
+
+    return {
+      platformIntegrationId: data.platformIntegrationId,
+      integrationId: data.integrationId,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/bot/handle-mention.ts
+++ b/apps/web/src/lib/bot/handle-mention.ts
@@ -1,0 +1,91 @@
+import { resolveKiloUserId, unlinkKiloUser, type PlatformIdentity } from '@/lib/bot-identity';
+import {
+  canKiloUserAccessPlatformIntegration,
+  getPlatformIntegration,
+} from '@/lib/bot/platform-helpers';
+import { botPlatforms } from '@/lib/bot/platforms';
+import { processLinkedMessage } from '@/lib/bot/run';
+import { findUserById } from '@/lib/user';
+import { captureException } from '@sentry/nextjs';
+import type { PlatformIntegration } from '@kilocode/db';
+import type { Message, StateAdapter, Thread } from 'chat';
+
+export async function handleIncomingBotMention({
+  thread,
+  message,
+  state,
+  identity: providedIdentity,
+  platformIntegration: providedPlatformIntegration,
+}: {
+  thread: Thread;
+  message: Message;
+  state: StateAdapter;
+  identity?: PlatformIdentity;
+  platformIntegration?: PlatformIntegration;
+}): Promise<void> {
+  const botPlatform = botPlatforms.requireByAdapter(thread.adapter);
+  const identity = providedIdentity ?? (await botPlatform.getIdentity({ thread, message }));
+  const [platformIntegration, kiloUserId] = await Promise.all([
+    providedPlatformIntegration ?? getPlatformIntegration(identity),
+    resolveKiloUserId(state, identity),
+  ]);
+
+  if (!platformIntegration) {
+    captureException(new Error('No active platform integration found'), {
+      extra: { platform: identity.platform, teamId: identity.teamId },
+    });
+    return;
+  }
+
+  if (!botPlatform.isEnabledForBot(platformIntegration)) {
+    return;
+  }
+
+  if (!(await botPlatform.canHandleMessage({ thread, message, platformIntegration }))) {
+    return;
+  }
+
+  if (!kiloUserId) {
+    await botPlatform.promptLinkAccount({
+      thread,
+      message,
+      identity,
+      platformIntegration,
+      state,
+    });
+    return;
+  }
+
+  const user = await findUserById(kiloUserId);
+
+  if (!user) {
+    await unlinkKiloUser(state, identity);
+    await botPlatform.promptLinkAccount({
+      thread,
+      message,
+      identity,
+      platformIntegration,
+      state,
+    });
+    return;
+  }
+
+  if (!(await canKiloUserAccessPlatformIntegration(platformIntegration, user.id))) {
+    await unlinkKiloUser(state, identity);
+    await botPlatform.promptLinkAccount({
+      thread,
+      message,
+      identity,
+      platformIntegration,
+      state,
+    });
+    return;
+  }
+
+  try {
+    await processLinkedMessage({ thread, message, platformIntegration, user });
+  } catch (error) {
+    console.error('[Bot] Unhandled error in message handler:', error);
+    await thread.post({ markdown: 'Sorry, something went wrong while processing your message.' });
+  }
+}

--- a/apps/web/src/lib/bot/platforms/github.test.ts
+++ b/apps/web/src/lib/bot/platforms/github.test.ts
@@ -1,5 +1,6 @@
 const mockIssuesGetFn = jest.fn();
 const mockIssuesListCommentsFn = jest.fn();
+const mockPullsGetFn = jest.fn();
 const mockPullsListReviewCommentsFn = jest.fn();
 const mockGenerateGitHubInstallationTokenFn = jest.fn();
 
@@ -15,6 +16,10 @@ function mockPullsListReviewComments(...args: unknown[]) {
   return mockPullsListReviewCommentsFn(...args);
 }
 
+function mockPullsGet(...args: unknown[]) {
+  return mockPullsGetFn(...args);
+}
+
 function mockGenerateGitHubInstallationToken(...args: unknown[]) {
   return mockGenerateGitHubInstallationTokenFn(...args);
 }
@@ -26,6 +31,7 @@ jest.mock('@octokit/rest', () => ({
       listComments: mockIssuesListComments,
     },
     pulls: {
+      get: mockPullsGet,
       listReviewComments: mockPullsListReviewComments,
     },
   })),
@@ -266,6 +272,14 @@ describe('createGitHubBotPlatform.getConversationContext', () => {
       token: 'ghs_test',
       expires_at: 'never',
     });
+    mockPullsGetFn.mockResolvedValue({
+      data: {
+        base: { ref: 'main', sha: 'base-sha', repo: { full_name: 'Kilo-Org/on-call' } },
+        head: { ref: 'feature/on-call', sha: 'head-sha', repo: { full_name: 'Kilo-Org/on-call' } },
+        html_url: 'https://github.com/Kilo-Org/on-call/pull/37',
+        user: { login: 'RSO' },
+      },
+    });
     mockPullsListReviewCommentsFn.mockResolvedValue({ data: [], headers: {} });
   });
 
@@ -315,6 +329,49 @@ describe('createGitHubBotPlatform.getConversationContext', () => {
     expect(context).not.toContain('<github_comment id="101"');
     expect(context).toContain('Comment that triggered this bot run:');
     expect(context).toContain('@kilocode-dev Please fix this');
+    expect(mockPullsGetFn).not.toHaveBeenCalled();
+  });
+
+  it('includes GitHub pull request base and head branch context', async () => {
+    mockIssuesGetFn.mockResolvedValue({
+      data: {
+        body: 'Pull request description.',
+        html_url: 'https://github.com/Kilo-Org/on-call/pull/37',
+        number: 37,
+        pull_request: {},
+        state: 'open',
+        title: 'Update on-call runbook',
+        user: { login: 'RSO' },
+      },
+    });
+    mockIssuesListCommentsFn.mockResolvedValue({ data: [], headers: {} });
+    mockPullsGetFn.mockResolvedValue({
+      data: {
+        base: { ref: 'main', sha: 'abc1234567890000', repo: { full_name: 'Kilo-Org/on-call' } },
+        head: { ref: 'fix/review', sha: 'def1234567890000', repo: { full_name: 'fork/on-call' } },
+        html_url: 'https://github.com/Kilo-Org/on-call/pull/37',
+        user: { login: 'alice' },
+      },
+    });
+
+    const context = await githubPlatform.getConversationContext({
+      thread: createThread({ id: 'github:Kilo-Org/on-call:37' }),
+      triggerMessage: createMessage({
+        id: '301',
+        text: '@kilocode-dev open a new PR for this',
+      }),
+      platformIntegration: createIntegration(),
+    });
+
+    expect(mockPullsGetFn).toHaveBeenCalledWith({
+      owner: 'Kilo-Org',
+      repo: 'on-call',
+      pull_number: 37,
+    });
+    expect(context).toContain('- Base branch: Kilo-Org/on-call:main (abc123456789)');
+    expect(context).toContain('- Head branch: fork/on-call:fix/review (def123456789)');
+    expect(context).toContain('- Pull request author: alice');
+    expect(context).toContain('create a fresh branch from the PR base branch');
   });
 
   it('fetches only the newest issue comments in a single request', async () => {

--- a/apps/web/src/lib/bot/platforms/github.ts
+++ b/apps/web/src/lib/bot/platforms/github.ts
@@ -89,6 +89,21 @@ type GitHubIssueLike = {
   user?: { login?: string } | null;
 };
 
+type GitHubPullRequestLike = {
+  base?: {
+    ref?: string;
+    sha?: string;
+    repo?: { full_name?: string | null } | null;
+  } | null;
+  head?: {
+    ref?: string;
+    sha?: string;
+    repo?: { full_name?: string | null } | null;
+  } | null;
+  html_url?: string;
+  user?: { login?: string } | null;
+};
+
 type GitHubIssueComment = {
   body?: string | null;
   created_at?: string | null;
@@ -267,6 +282,29 @@ async function fetchReviewThreadContext(
   };
 }
 
+async function fetchPullRequestDetails(
+  octokit: Octokit,
+  coordinates: GitHubThreadCoordinates
+): Promise<GitHubPullRequestLike> {
+  const response = await octokit.pulls.get({
+    owner: coordinates.owner,
+    repo: coordinates.repo,
+    pull_number: coordinates.number,
+  });
+  return response.data;
+}
+
+function formatBranchRef(branch: {
+  ref?: string;
+  sha?: string;
+  repo?: { full_name?: string | null } | null;
+}): string {
+  const repo = branch.repo?.full_name ? `${sanitizeForDelimiters(branch.repo.full_name)}:` : '';
+  const ref = sanitizeForDelimiters(branch.ref ?? 'unknown');
+  const sha = branch.sha ? ` (${branch.sha.slice(0, 12)})` : '';
+  return `${repo}${ref}${sha}`;
+}
+
 function isGitHubBotEnabledForIntegration(integration: PlatformIntegration): boolean {
   const metadata = integration.metadata as { bot_enabled?: boolean } | null;
   return metadata?.bot_enabled === true;
@@ -344,6 +382,9 @@ export function createGitHubBotPlatform(githubAdapter: GitHubInstallationLookup)
       const issue: GitHubIssueLike = issueResponse.data;
       const itemType = issue.pull_request ? 'pull request' : 'issue';
       const itemLabel = issue.pull_request ? 'Pull request' : 'Issue';
+      const pullRequest = issue.pull_request
+        ? await fetchPullRequestDetails(octokit, coordinates)
+        : null;
       const trigger = formatTriggerMessage(triggerMessage, MAX_GITHUB_COMMENT_LENGTH);
       const comments = issueComments
         .filter(comment => comment.id.toString() !== triggerMessage.id)
@@ -360,6 +401,24 @@ export function createGitHubBotPlatform(githubAdapter: GitHubInstallationLookup)
 
       if (coordinates.reviewCommentId !== null) {
         lines.push(`- Review comment thread id: ${coordinates.reviewCommentId}`);
+      }
+
+      if (pullRequest) {
+        if (pullRequest.html_url && pullRequest.html_url !== issue.html_url) {
+          lines.push(`- Pull request URL: ${pullRequest.html_url}`);
+        }
+        if (pullRequest.base) {
+          lines.push(`- Base branch: ${formatBranchRef(pullRequest.base)}`);
+        }
+        if (pullRequest.head) {
+          lines.push(`- Head branch: ${formatBranchRef(pullRequest.head)}`);
+        }
+        if (pullRequest.user?.login) {
+          lines.push(`- Pull request author: ${sanitizeForDelimiters(pullRequest.user.login)}`);
+        }
+        lines.push(
+          '- New PR guidance: if the requester asks for a new or separate PR, create a fresh branch from the PR base branch and avoid pushing to or modifying the current PR head branch unless the requester names a different target.'
+        );
       }
 
       lines.push(

--- a/apps/web/src/lib/bot/platforms/gitlab.ts
+++ b/apps/web/src/lib/bot/platforms/gitlab.ts
@@ -1,0 +1,450 @@
+import { createGitLabLinkToken } from '@/lib/bot/gitlab-link-token';
+import {
+  formatTriggerMessage,
+  formatUserMessage,
+  sanitizeForDelimiters,
+  truncate,
+  type ContextTriggerMessage,
+} from '@/lib/bot/platforms/shared';
+import type { BotPlatform } from '@/lib/bot/platforms/types';
+import { APP_URL } from '@/lib/constants';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import {
+  createMRNote,
+  fetchMergeRequest,
+  fetchMRDiscussion,
+  fetchMRNote,
+  fetchMRNotes,
+  replyToMRDiscussion,
+  type GitLabDiscussion,
+  type GitLabNote,
+} from '@/lib/integrations/platforms/gitlab/adapter';
+import {
+  getOrCreateProjectAccessToken,
+  getValidGitLabToken,
+  type GitLabIntegrationMetadata,
+} from '@/lib/integrations/gitlab-service';
+import type { NoteEventPayload } from '@/lib/integrations/platforms/gitlab/webhook-schemas';
+import type { PlatformIntegration } from '@kilocode/db';
+import type { Author, Message, Thread } from 'chat';
+import { z } from 'zod';
+
+const GITLAB_LINK_PATH = '/gitlab/link';
+const MAX_GITLAB_BODY_LENGTH = 4000;
+const MAX_GITLAB_COMMENT_LENGTH = 1200;
+
+const gitLabThreadContextSchema = z.object({
+  integrationId: z.string().min(1),
+  projectId: z.number(),
+  projectPath: z.string().min(1),
+  mrIid: z.number(),
+  noteId: z.number().optional(),
+  discussionId: z.string().min(1).optional(),
+});
+
+export type GitLabThreadContext = z.infer<typeof gitLabThreadContextSchema>;
+
+type GitLabSyntheticRawMessage = {
+  payload?: NoteEventPayload;
+  note?: GitLabNote;
+  threadContext: GitLabThreadContext;
+};
+
+type PostBody = string | { markdown?: string; text?: string };
+
+export function hasGitLabBotMention(text: string): boolean {
+  return /(^|\s)@(kilocode-bot|kilocode-dev)\b/i.test(text);
+}
+
+export function createGitLabThreadId(context: GitLabThreadContext): string {
+  return `gitlab:${Buffer.from(JSON.stringify(context)).toString('base64url')}`;
+}
+
+export function parseGitLabThreadId(threadId: string): GitLabThreadContext | null {
+  if (!threadId.startsWith('gitlab:')) return null;
+
+  try {
+    return gitLabThreadContextSchema.parse(
+      JSON.parse(Buffer.from(threadId.slice('gitlab:'.length), 'base64url').toString('utf8'))
+    );
+  } catch {
+    return null;
+  }
+}
+
+function getGitLabInstanceUrl(integration: PlatformIntegration): string {
+  const metadata = integration.metadata as GitLabIntegrationMetadata | null;
+  return metadata?.gitlab_instance_url || 'https://gitlab.com';
+}
+
+function isGitLabBotEnabledForIntegration(integration: PlatformIntegration): boolean {
+  const metadata = integration.metadata as { bot_enabled?: boolean } | null;
+  return metadata?.bot_enabled === true;
+}
+
+function isGitLabProjectLinked(
+  integration: PlatformIntegration,
+  context: Pick<GitLabThreadContext, 'projectId' | 'projectPath'>
+): boolean {
+  if (integration.repository_access === 'all') return true;
+  if (integration.repository_access !== 'selected') return false;
+
+  const projectPath = context.projectPath.toLowerCase();
+  return (integration.repositories ?? []).some(repository => {
+    return (
+      repository.id === context.projectId || repository.full_name.toLowerCase() === projectPath
+    );
+  });
+}
+
+function getMarkdownFromPostBody(body: PostBody): string {
+  if (typeof body === 'string') return body;
+  return body.markdown ?? body.text ?? '';
+}
+
+function createAuthor(params: {
+  userId: string;
+  userName: string;
+  fullName: string;
+  isBot?: boolean;
+}): Author {
+  return {
+    userId: params.userId,
+    userName: params.userName,
+    fullName: params.fullName,
+    isBot: params.isBot ?? false,
+    isMe: false,
+  };
+}
+
+function createSyntheticMessage(params: {
+  id: string;
+  threadId: string;
+  text: string;
+  author: Author;
+  dateSent: Date;
+  raw: GitLabSyntheticRawMessage;
+}): Message {
+  return {
+    id: params.id,
+    threadId: params.threadId,
+    text: params.text,
+    formatted: { type: 'root', children: [] },
+    raw: params.raw,
+    author: params.author,
+    metadata: { dateSent: params.dateSent, edited: false },
+    attachments: [],
+    links: [],
+    toJSON: () => {
+      throw new Error('GitLab synthetic messages are not serialized by Chat SDK');
+    },
+  } as Message;
+}
+
+function createMessageFromGitLabNote(
+  note: GitLabNote,
+  threadContext: GitLabThreadContext,
+  threadId: string
+): Message {
+  return createSyntheticMessage({
+    id: note.id.toString(),
+    threadId,
+    text: note.body,
+    author: createAuthor({
+      userId: note.author.id.toString(),
+      userName: note.author.username,
+      fullName: note.author.name,
+    }),
+    dateSent: new Date(note.created_at),
+    raw: { note, threadContext },
+  });
+}
+
+export function createGitLabMessageFromNotePayload(
+  payload: NoteEventPayload,
+  threadContext: GitLabThreadContext
+): Message {
+  const threadId = createGitLabThreadId(threadContext);
+  return createSyntheticMessage({
+    id: payload.object_attributes.id.toString(),
+    threadId,
+    text: payload.object_attributes.note,
+    author: createAuthor({
+      userId: payload.user.id.toString(),
+      userName: payload.user.username,
+      fullName: payload.user.name,
+    }),
+    dateSent: new Date(payload.object_attributes.created_at),
+    raw: { payload, threadContext },
+  });
+}
+
+async function getPostingToken(
+  integration: PlatformIntegration,
+  projectId: number
+): Promise<string> {
+  try {
+    return await getOrCreateProjectAccessToken(integration, projectId);
+  } catch (error) {
+    console.warn('[GitLabBot] Falling back to integration token for MR note posting:', error);
+    return await getValidGitLabToken(integration);
+  }
+}
+
+async function fetchGitLabMessage(
+  integration: PlatformIntegration,
+  threadId: string,
+  messageId: string
+): Promise<Message | null> {
+  const context = parseGitLabThreadId(threadId);
+  const noteId = Number.parseInt(messageId, 10);
+  if (!context || Number.isNaN(noteId)) return null;
+
+  const token = await getValidGitLabToken(integration);
+  const note = await fetchMRNote(
+    token,
+    context.projectId,
+    context.mrIid,
+    noteId,
+    getGitLabInstanceUrl(integration)
+  );
+  return createMessageFromGitLabNote(note, context, threadId);
+}
+
+export function createGitLabSyntheticThread(params: {
+  context: GitLabThreadContext;
+  platformIntegration: PlatformIntegration;
+}): Thread {
+  const threadId = createGitLabThreadId(params.context);
+  const adapter = {
+    name: PLATFORM.GITLAB,
+    fetchMessage: async (id: string, messageId: string) =>
+      await fetchGitLabMessage(params.platformIntegration, id, messageId),
+  };
+
+  const thread = {
+    id: threadId,
+    channelId: `gitlab:${params.context.projectPath}`,
+    isDM: false,
+    adapter,
+    async startTyping() {},
+    async post(body: PostBody) {
+      const markdown = getMarkdownFromPostBody(body);
+      const token = await getPostingToken(params.platformIntegration, params.context.projectId);
+      const instanceUrl = getGitLabInstanceUrl(params.platformIntegration);
+      let note: GitLabNote;
+
+      if (params.context.discussionId) {
+        try {
+          note = await replyToMRDiscussion(
+            token,
+            params.context.projectId,
+            params.context.mrIid,
+            params.context.discussionId,
+            markdown,
+            instanceUrl
+          );
+        } catch (error) {
+          console.warn(
+            '[GitLabBot] Failed to reply to discussion, posting top-level MR note:',
+            error
+          );
+          note = await createMRNote(
+            token,
+            params.context.projectId,
+            params.context.mrIid,
+            markdown,
+            instanceUrl
+          );
+        }
+      } else {
+        note = await createMRNote(
+          token,
+          params.context.projectId,
+          params.context.mrIid,
+          markdown,
+          instanceUrl
+        );
+      }
+
+      return createMessageFromGitLabNote(note, params.context, threadId);
+    },
+    async postEphemeral(author: Author, body: PostBody) {
+      return createSyntheticMessage({
+        id: `gitlab-ephemeral-${Date.now()}`,
+        threadId,
+        text: getMarkdownFromPostBody(body),
+        author,
+        dateSent: new Date(),
+        raw: { threadContext: params.context },
+      });
+    },
+  };
+
+  // Chat SDK has no GitLab adapter. This synthetic thread implements only the
+  // methods Kilo Bot uses for mention processing and callback posting.
+  return thread as unknown as Thread;
+}
+
+function formatGitLabNote(note: GitLabNote): string {
+  const author = sanitizeForDelimiters(note.author.username || note.author.name || 'unknown');
+  const body = sanitizeForDelimiters(
+    truncate(note.body?.trim() || '(empty note)', MAX_GITLAB_COMMENT_LENGTH)
+  );
+  return `<gitlab_note id="${note.id}" author="${author}" time="${note.created_at}">${body}</gitlab_note>`;
+}
+
+function findDiscussionPosition(
+  discussion: GitLabDiscussion | null
+): GitLabNote['position'] | null {
+  if (!discussion) return null;
+  return discussion.notes.find(note => note.position)?.position ?? null;
+}
+
+function getTriggerRawMessage(
+  triggerMessage: ContextTriggerMessage
+): GitLabSyntheticRawMessage | null {
+  const raw = (triggerMessage as ContextTriggerMessage & { raw?: unknown }).raw;
+  const parsed = z
+    .object({ threadContext: gitLabThreadContextSchema })
+    .passthrough()
+    .safeParse(raw);
+  return parsed.success ? (raw as GitLabSyntheticRawMessage) : null;
+}
+
+async function getGitLabConversationContext(params: {
+  thread: Thread;
+  triggerMessage: ContextTriggerMessage;
+  platformIntegration: PlatformIntegration;
+}): Promise<string> {
+  const context = parseGitLabThreadId(params.thread.id);
+  if (!context) return '';
+
+  const token = await getValidGitLabToken(params.platformIntegration);
+  const instanceUrl = getGitLabInstanceUrl(params.platformIntegration);
+  const [mergeRequest, notes, discussion] = await Promise.all([
+    fetchMergeRequest(token, context.projectId, context.mrIid, instanceUrl),
+    fetchMRNotes(token, context.projectId, context.mrIid, instanceUrl),
+    context.discussionId
+      ? fetchMRDiscussion(
+          token,
+          context.projectId,
+          context.mrIid,
+          context.discussionId,
+          instanceUrl
+        ).catch(() => null)
+      : Promise.resolve(null),
+  ]);
+  const triggerRaw = getTriggerRawMessage(params.triggerMessage);
+  const trigger = formatTriggerMessage(params.triggerMessage, MAX_GITLAB_COMMENT_LENGTH);
+  const recentNotes = notes
+    .filter(note => !note.system && note.id.toString() !== params.triggerMessage.id)
+    .map(formatGitLabNote);
+  const position =
+    findDiscussionPosition(discussion) ?? triggerRaw?.payload?.object_attributes.position;
+  const stDiff = triggerRaw?.payload?.object_attributes.st_diff;
+
+  const lines = [
+    'GitLab context:',
+    'You are responding in a GitLab merge request.',
+    `- Project: ${sanitizeForDelimiters(context.projectPath)}`,
+    `- Merge request: !${mergeRequest.iid} ${sanitizeForDelimiters(mergeRequest.title)}`,
+    `- State: ${sanitizeForDelimiters(mergeRequest.state)}`,
+    `- URL: ${mergeRequest.web_url}`,
+    `- Source branch: ${sanitizeForDelimiters(mergeRequest.source_branch)}`,
+    `- Target branch: ${sanitizeForDelimiters(mergeRequest.target_branch)}`,
+    `- Merge request author: ${sanitizeForDelimiters(mergeRequest.author.username)}`,
+    '- New MR guidance: if the requester asks for a new or separate MR, create a fresh branch from the MR target branch and avoid pushing to or modifying the current MR source branch unless the requester names a different target.',
+    '',
+    'Merge request description:',
+    `<gitlab_description author="${sanitizeForDelimiters(mergeRequest.author.username)}">${sanitizeForDelimiters(truncate(mergeRequest.description?.trim() || '(No description provided.)', MAX_GITLAB_BODY_LENGTH))}</gitlab_description>`,
+  ];
+
+  if (recentNotes.length > 0) {
+    lines.push('', 'Recent GitLab MR notes (oldest first):', ...recentNotes);
+  }
+
+  if (discussion) {
+    lines.push(
+      '',
+      'GitLab discussion thread:',
+      `- Discussion id: ${sanitizeForDelimiters(discussion.id)}`
+    );
+    const discussionNotes = discussion.notes
+      .filter(note => note.id.toString() !== params.triggerMessage.id)
+      .map(formatGitLabNote);
+    if (discussionNotes.length > 0) {
+      lines.push('Discussion notes (oldest first):', ...discussionNotes);
+    }
+  }
+
+  if (position) {
+    lines.push('', 'Inline comment position:');
+    const path = position.new_path || position.old_path;
+    if (path) lines.push(`- File: ${sanitizeForDelimiters(path)}`);
+    const line = position.new_line ?? position.old_line;
+    if (line) lines.push(`- Line: ${line}`);
+  }
+
+  if (stDiff?.diff) {
+    lines.push(
+      'Diff hunk:',
+      `<gitlab_diff_hunk>${sanitizeForDelimiters(truncate(stDiff.diff, MAX_GITLAB_COMMENT_LENGTH))}</gitlab_diff_hunk>`
+    );
+  }
+
+  lines.push('', 'Comment that triggered this bot run:', formatUserMessage(trigger));
+
+  return lines.join('\n');
+}
+
+export function createGitLabBotPlatform(): BotPlatform {
+  return {
+    platform: PLATFORM.GITLAB,
+    documentationUrl: 'https://kilo.ai/docs/code-with-ai/platforms/slack',
+    usesGenericLinkAccountRoute: false,
+    async getIdentity({ thread, message }) {
+      const context = parseGitLabThreadId(thread.id);
+      if (!context) throw new Error(`Could not parse GitLab thread id ${thread.id}`);
+      return {
+        platform: PLATFORM.GITLAB,
+        teamId: context.integrationId,
+        userId: message.author.userId,
+      };
+    },
+    isEnabledForBot: isGitLabBotEnabledForIntegration,
+    canHandleMessage({ thread, platformIntegration }) {
+      const context = parseGitLabThreadId(thread.id);
+      return context ? isGitLabProjectLinked(platformIntegration, context) : false;
+    },
+    async promptLinkAccount({ thread, identity, platformIntegration }) {
+      const url = new URL(GITLAB_LINK_PATH, APP_URL);
+      url.searchParams.set(
+        'token',
+        createGitLabLinkToken({
+          platformIntegrationId: platformIntegration.id,
+          integrationId: identity.teamId,
+        })
+      );
+
+      await thread.post({
+        markdown:
+          'To use Kilo from GitLab you first need to link your GitLab account to Kilo. ' +
+          `[Link your Kilo account](${url.toString()}) to continue. ` +
+          'After linking, mention me again in this merge request.',
+      });
+    },
+    async withAuthContext({ fn }) {
+      return await fn();
+    },
+    getConversationContext: getGitLabConversationContext,
+    async getRequesterInfo({ message, displayName }) {
+      const raw = (message as Message<GitLabSyntheticRawMessage>).raw;
+      return {
+        displayName,
+        messageLink: raw.payload?.object_attributes.url,
+        platform: PLATFORM.GITLAB,
+      };
+    },
+  };
+}

--- a/apps/web/src/lib/bot/platforms/registry.ts
+++ b/apps/web/src/lib/bot/platforms/registry.ts
@@ -2,6 +2,7 @@ import type { GitHubAdapter } from '@chat-adapter/github';
 import type { LinearAdapter } from '@chat-adapter/linear';
 import type { SlackAdapter } from '@chat-adapter/slack';
 import { createGitHubBotPlatform } from '@/lib/bot/platforms/github';
+import { createGitLabBotPlatform } from '@/lib/bot/platforms/gitlab';
 import { createLinearBotPlatform } from '@/lib/bot/platforms/linear';
 import { createSlackBotPlatform } from '@/lib/bot/platforms/slack';
 import type { BotPlatform } from '@/lib/bot/platforms/types';
@@ -26,6 +27,7 @@ function createPlatformMap(platforms: BotPlatform[]): Map<string, BotPlatform> {
 export function createBotPlatformRegistry(params: BotPlatformRegistryParams): BotPlatformRegistry {
   const platformMap = createPlatformMap([
     createGitHubBotPlatform(params.githubAdapter),
+    createGitLabBotPlatform(),
     createSlackBotPlatform(params.slackAdapter),
     createLinearBotPlatform(params.linearAdapter),
   ]);

--- a/apps/web/src/lib/bot/pr-creation-strategy.test.ts
+++ b/apps/web/src/lib/bot/pr-creation-strategy.test.ts
@@ -1,0 +1,41 @@
+import { buildForceNewPrInstruction, detectPrCreationStrategy } from './pr-creation-strategy';
+
+describe('detectPrCreationStrategy', () => {
+  it.each([
+    '@kilocode-bot open a new PR to update REVIEW.md',
+    '@kilocode-dev create a new pull request with this fix',
+    'start a new MR for this change',
+    'please put this in a separate merge request',
+    'ship this as a separate PR',
+  ])('forces a new PR/MR for explicit request: %s', text => {
+    expect(detectPrCreationStrategy(text)).toBe('force-new');
+  });
+
+  it.each([
+    '@kilocode-bot fix this',
+    'update the existing PR with this change',
+    'do not create a new PR, just patch this branch',
+    'without opening a new MR, explain the issue',
+    'no new pull request needed',
+  ])('keeps default behavior for non-new or negated request: %s', text => {
+    expect(detectPrCreationStrategy(text)).toBe('default');
+  });
+});
+
+describe('buildForceNewPrInstruction', () => {
+  it('uses GitHub PR branch guidance for GitHub-origin requests', () => {
+    const instruction = buildForceNewPrInstruction('github');
+
+    expect(instruction).toContain('separate new PR');
+    expect(instruction).toContain('original PR base branch');
+    expect(instruction).toContain('avoid pushing to or modifying the original PR head branch');
+  });
+
+  it('uses GitLab MR branch guidance for GitLab-origin requests', () => {
+    const instruction = buildForceNewPrInstruction('gitlab');
+
+    expect(instruction).toContain('separate new MR');
+    expect(instruction).toContain('original MR target branch');
+    expect(instruction).toContain('avoid pushing to or modifying the original MR source branch');
+  });
+});

--- a/apps/web/src/lib/bot/pr-creation-strategy.ts
+++ b/apps/web/src/lib/bot/pr-creation-strategy.ts
@@ -1,0 +1,34 @@
+export type PrCreationStrategy = 'default' | 'force-new';
+
+const NEW_PR_OR_MR_PATTERNS = [
+  /\b(?:open|create|start)\s+(?:a\s+)?new\s+(?:pr|pull\s+request|mr|merge\s+request)\b/i,
+  /\b(?:open|create|start)\s+(?:a\s+)?(?:separate|fresh)\s+(?:pr|pull\s+request|mr|merge\s+request)\b/i,
+  /\bnew\s+(?:pr|pull\s+request|mr|merge\s+request)\b/i,
+  /\b(?:separate|fresh)\s+(?:pr|pull\s+request|mr|merge\s+request)\b/i,
+  /\b(?:pr|pull\s+request|mr|merge\s+request)\s+separately\b/i,
+];
+
+const NEGATED_NEW_PR_OR_MR_PATTERNS = [
+  /\b(?:do\s+not|don't|dont)\s+(?:open|create|start)\s+(?:a\s+)?new\s+(?:pr|pull\s+request|mr|merge\s+request)\b/i,
+  /\bwithout\s+(?:opening|creating|starting)\s+(?:a\s+)?new\s+(?:pr|pull\s+request|mr|merge\s+request)\b/i,
+  /\bno\s+new\s+(?:pr|pull\s+request|mr|merge\s+request)\b/i,
+  /\b(?:update|use|keep)\s+(?:the\s+)?existing\s+(?:pr|pull\s+request|mr|merge\s+request)\b/i,
+];
+
+export function detectPrCreationStrategy(text: string): PrCreationStrategy {
+  if (NEGATED_NEW_PR_OR_MR_PATTERNS.some(pattern => pattern.test(text))) {
+    return 'default';
+  }
+
+  return NEW_PR_OR_MR_PATTERNS.some(pattern => pattern.test(text)) ? 'force-new' : 'default';
+}
+
+export function buildForceNewPrInstruction(chatPlatform: string): string {
+  const platformLabel = chatPlatform === 'gitlab' ? 'MR' : 'PR';
+  const baseBranchGuidance =
+    chatPlatform === 'gitlab'
+      ? 'For GitLab MR-origin comments, base the new MR on the original MR target branch and avoid pushing to or modifying the original MR source branch unless the user explicitly names a different target.'
+      : 'For GitHub PR-origin comments, base the new PR on the original PR base branch and avoid pushing to or modifying the original PR head branch unless the user explicitly names a different target.';
+
+  return `\n\n<Kilo enforced instruction>\nThe original requester explicitly asked for a separate new ${platformLabel}. You must create a fresh branch, open a separate ${platformLabel}, and must not push to or modify the branch of the PR/MR where the comment was made. ${baseBranchGuidance}\n</Kilo enforced instruction>`;
+}

--- a/apps/web/src/lib/bot/run.ts
+++ b/apps/web/src/lib/bot/run.ts
@@ -1,6 +1,7 @@
 import { createBotRequest, updateBotRequest } from '@/lib/bot/request-logging';
 import { runBotAgent } from '@/lib/bot/agent-runner';
 import { extractAndUploadImages } from '@/lib/bot/images';
+import { detectPrCreationStrategy } from '@/lib/bot/pr-creation-strategy';
 import type { PlatformIntegration, User } from '@kilocode/db';
 import type { Message, Thread } from 'chat';
 import { captureException } from '@sentry/nextjs';
@@ -88,6 +89,7 @@ async function processMessage({
       user,
       botRequestId,
       prompt: message.text,
+      prCreationStrategy: detectPrCreationStrategy(message.text),
       images,
     });
 

--- a/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.test.ts
+++ b/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.test.ts
@@ -1,0 +1,142 @@
+const mockPrepareSession = jest.fn();
+const mockInitiateFromPreparedSession = jest.fn();
+const mockGetGitHubTokenForUser = jest.fn();
+const mockResolveBotSessionProfile = jest.fn();
+
+jest.mock('@/lib/cloud-agent-next/cloud-agent-client', () => ({
+  createCloudAgentNextClient: jest.fn(() => ({
+    prepareSession: mockPrepareSession,
+    initiateFromPreparedSession: mockInitiateFromPreparedSession,
+  })),
+}));
+
+jest.mock('@/lib/cloud-agent/github-integration-helpers', () => ({
+  getGitHubTokenForOrganization: jest.fn(),
+  getGitHubTokenForUser: (...args: unknown[]) => mockGetGitHubTokenForUser(...args),
+}));
+
+jest.mock('@/lib/cloud-agent/gitlab-integration-helpers', () => ({
+  getGitLabTokenForOrganization: jest.fn(),
+  getGitLabTokenForUser: jest.fn(),
+  getGitLabInstanceUrlForOrganization: jest.fn(),
+  getGitLabInstanceUrlForUser: jest.fn(),
+  buildGitLabCloneUrl: jest.fn(),
+}));
+
+jest.mock('@/lib/bot/tools/resolve-bot-session-profile', () => ({
+  resolveBotSessionProfile: (...args: unknown[]) => mockResolveBotSessionProfile(...args),
+}));
+
+jest.mock('@kilocode/cloud-agent-profile', () => ({
+  profileMcpServersToClientRecord: jest.fn(() => ({})),
+}));
+
+jest.mock('@/lib/config.server', () => ({
+  CALLBACK_TOKEN_SECRET: 'callback-secret',
+}));
+
+jest.mock('@/lib/constants', () => ({
+  APP_URL: 'https://app.example.com',
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+}));
+
+import type { PlatformIntegration } from '@kilocode/db';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import spawnCloudAgentSession from './spawn-cloud-agent-session';
+
+function createIntegration(): PlatformIntegration {
+  return {
+    id: 'pi_1',
+    owned_by_user_id: 'user_1',
+    owned_by_organization_id: null,
+    created_by_user_id: 'user_1',
+    platform: PLATFORM.GITHUB,
+    integration_type: 'app',
+    platform_installation_id: '98765',
+    platform_account_id: '123',
+    platform_account_login: 'acme',
+    permissions: null,
+    scopes: null,
+    repository_access: 'all',
+    repositories: null,
+    repositories_synced_at: null,
+    metadata: null,
+    kilo_requester_user_id: null,
+    platform_requester_account_id: null,
+    integration_status: 'active',
+    suspended_at: null,
+    suspended_by: null,
+    github_app_type: 'standard',
+    installed_at: '2026-05-05T07:00:00Z',
+    created_at: '2026-05-05T07:00:00Z',
+    updated_at: '2026-05-05T07:00:00Z',
+  };
+}
+
+describe('spawnCloudAgentSession prompt augmentation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetGitHubTokenForUser.mockResolvedValue('gh-token');
+    mockPrepareSession.mockResolvedValue({
+      cloudAgentSessionId: 'cloud-session-1',
+      kiloSessionId: 'kilo-session-1',
+    });
+    mockInitiateFromPreparedSession.mockResolvedValue(undefined);
+    mockResolveBotSessionProfile.mockResolvedValue({
+      envVars: [],
+      encryptedSecrets: [],
+      setupCommands: [],
+      mcpServers: [],
+      skills: [],
+      agents: [],
+    });
+  });
+
+  it('appends enforced new-PR instructions before preparing the session', async () => {
+    await spawnCloudAgentSession(
+      {
+        githubRepo: 'acme/widgets',
+        prompt: 'Update REVIEW.md',
+        mode: 'code',
+      },
+      'openai/gpt-5.5',
+      createIntegration(),
+      'auth-token',
+      'user_1',
+      'bot_request_1',
+      undefined,
+      {
+        chatPlatform: 'github',
+        prCreationStrategy: 'force-new',
+        prSignature: '\n\nRequested by RSO',
+      }
+    );
+
+    const prepareInput = mockPrepareSession.mock.calls[0][0];
+    expect(prepareInput.prompt).toContain('Update REVIEW.md');
+    expect(prepareInput.prompt).toContain('separate new PR');
+    expect(prepareInput.prompt).toContain('original PR base branch');
+    expect(prepareInput.prompt).toContain('Requested by RSO');
+  });
+
+  it('leaves prompts unchanged when no explicit new PR/MR strategy is set', async () => {
+    await spawnCloudAgentSession(
+      {
+        githubRepo: 'acme/widgets',
+        prompt: 'Update REVIEW.md',
+        mode: 'code',
+      },
+      'openai/gpt-5.5',
+      createIntegration(),
+      'auth-token',
+      'user_1',
+      'bot_request_1'
+    );
+
+    const prepareInput = mockPrepareSession.mock.calls[0][0];
+    expect(prepareInput.prompt).toBe('Update REVIEW.md');
+  });
+});

--- a/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
+++ b/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
@@ -19,6 +19,10 @@ import type { Images } from '@/lib/images-schema';
 import { APP_URL } from '@/lib/constants';
 import { CALLBACK_TOKEN_SECRET } from '@/lib/config.server';
 import { parseBotCallbackStep } from '@/lib/bot/step-budget';
+import {
+  buildForceNewPrInstruction,
+  type PrCreationStrategy,
+} from '@/lib/bot/pr-creation-strategy';
 import { resolveBotSessionProfile } from '@/lib/bot/tools/resolve-bot-session-profile';
 import { ownerFromIntegration } from '@/lib/integrations/core/owner';
 import type { Owner } from '@/lib/integrations/core/types';
@@ -98,7 +102,13 @@ export default async function spawnCloudAgentSession(
   ticketUserId: string,
   botRequestId: string,
   onSessionReady?: RunSessionInput['onSessionReady'],
-  options?: { prSignature?: string; chatPlatform?: string; currentStep?: number; images?: Images }
+  options?: {
+    prSignature?: string;
+    prCreationStrategy?: PrCreationStrategy;
+    chatPlatform?: string;
+    currentStep?: number;
+    images?: Images;
+  }
 ): Promise<SpawnCloudAgentResult> {
   console.log('[KiloBot] spawnCloudAgentSession called with args:', JSON.stringify(args, null, 2));
 
@@ -128,6 +138,10 @@ export default async function spawnCloudAgentSession(
   }
 
   let prompt = args.prompt;
+
+  if (options?.prCreationStrategy === 'force-new') {
+    prompt += buildForceNewPrInstruction(chatPlatform);
+  }
 
   // Append PR/MR signature to the prompt if available
   if (options?.prSignature) {

--- a/apps/web/src/lib/integrations/db/platform-integrations.ts
+++ b/apps/web/src/lib/integrations/db/platform-integrations.ts
@@ -13,6 +13,27 @@ import type { IntegrationStatus } from '../core/constants';
 import { PendingInstallationMetadataWrapperSchema } from '../core/schemas';
 import type { GitHubAppType } from '../platforms/github/app-selector';
 
+function mergeIntegrationMetadata(
+  existingMetadata: unknown,
+  metadataUpdates: Record<string, unknown> | undefined
+): Record<string, unknown> | null {
+  const existing =
+    existingMetadata && typeof existingMetadata === 'object' && !Array.isArray(existingMetadata)
+      ? (existingMetadata as Record<string, unknown>)
+      : {};
+
+  if (!metadataUpdates) {
+    return Object.keys(existing).length > 0 ? existing : null;
+  }
+
+  const merged = { ...existing, ...metadataUpdates };
+  if (existing.bot_enabled === false && metadataUpdates.bot_enabled === true) {
+    merged.bot_enabled = false;
+  }
+
+  return merged;
+}
+
 /**
  * Finds a platform integration by installation ID
  */
@@ -273,6 +294,7 @@ export async function createPendingIntegration({
   }
 
   const metadata = {
+    bot_enabled: true,
     pending_approval: {
       requester,
       github_requester: githubRequester,
@@ -396,7 +418,11 @@ export async function autoCompleteInstallation({
   const parseResult = PendingInstallationMetadataWrapperSchema.safeParse(existingMetadata);
   const pendingApproval = parseResult.success ? parseResult.data.pending_approval : undefined;
 
+  const preservedMetadata = { ...(existingMetadata ?? {}) };
+  delete preservedMetadata.pending_approval;
   const completedMetadata = {
+    ...preservedMetadata,
+    bot_enabled: existingMetadata.bot_enabled === false ? false : true,
     completed_installation: {
       requester: pendingApproval?.requester,
       github_requester: pendingApproval?.github_requester,
@@ -544,6 +570,7 @@ export async function upsertPlatformIntegrationForOwner(
     repositories?: PlatformRepository[] | null;
     installedAt?: string;
     githubAppType?: GitHubAppType;
+    metadata?: Record<string, unknown>;
   }
 ) {
   // Build ownership condition based on owner type
@@ -566,6 +593,8 @@ export async function upsertPlatformIntegrationForOwner(
     .limit(1);
 
   if (existing) {
+    const metadata = mergeIntegrationMetadata(existing.metadata, data.metadata);
+
     // Update existing integration
     await db
       .update(platform_integrations)
@@ -578,6 +607,7 @@ export async function upsertPlatformIntegrationForOwner(
         integration_status: INTEGRATION_STATUS.ACTIVE,
         repositories: data.repositories || null,
         github_app_type: data.githubAppType || existing.github_app_type,
+        ...(metadata ? { metadata } : {}),
         updated_at: new Date().toISOString(),
       })
       .where(eq(platform_integrations.id, existing.id));
@@ -598,6 +628,7 @@ export async function upsertPlatformIntegrationForOwner(
       repositories: data.repositories || null,
       installed_at: data.installedAt || new Date().toISOString(),
       github_app_type: data.githubAppType || 'standard',
+      metadata: data.metadata ?? null,
     });
   }
 }

--- a/apps/web/src/lib/integrations/gitlab-service.ts
+++ b/apps/web/src/lib/integrations/gitlab-service.ts
@@ -300,6 +300,7 @@ export async function disconnectGitLabIntegration(owner: Owner) {
     configured_webhooks: existingMetadata.configured_webhooks,
     // PRESERVE project tokens (they're still valid on GitLab)
     project_tokens: existingMetadata.project_tokens,
+    bot_enabled: existingMetadata.bot_enabled,
   };
 
   await db
@@ -419,6 +420,7 @@ export type GitLabIntegrationMetadata = {
   >;
   /** Project Access Tokens per project (keyed by project ID) */
   project_tokens?: Record<string, StoredProjectAccessToken>;
+  bot_enabled?: boolean;
 };
 
 /**
@@ -875,6 +877,7 @@ export async function connectWithPAT(
         : existingMetadata.webhook_secret || randomBytes(32).toString('hex'),
       configured_webhooks: isInstanceChange ? undefined : existingMetadata.configured_webhooks,
       project_tokens: isInstanceChange ? undefined : existingMetadata.project_tokens,
+      bot_enabled: existingMetadata.bot_enabled === false ? false : true,
     };
 
     await db
@@ -936,6 +939,7 @@ export async function connectWithPAT(
     gitlab_instance_url: instanceUrl,
     webhook_secret: webhookSecret,
     auth_type: 'pat',
+    bot_enabled: true,
   };
 
   // 5. Create integration

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
@@ -6,6 +6,8 @@ import {
   searchGitLabProjects,
   normalizeGitLabSearchQuery,
   fetchGitLabRootTextFileAtRef,
+  createProjectWebhook,
+  updateProjectWebhook,
 } from './adapter';
 
 // Mock fetch globally
@@ -102,6 +104,64 @@ describe('GitLab OAuth endpoint safety', () => {
       refreshGitLabOAuthToken('refresh-token', 'https://attacker.example')
     ).rejects.toThrow('Custom GitLab OAuth credentials are required for self-hosted instances');
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('can build reduced-scope authorization URLs for bot account linking', () => {
+    const url = new URL(
+      buildGitLabOAuthUrl(
+        'signed-state',
+        'https://gitlab.com',
+        { clientId: 'client', clientSecret: 'secret' },
+        ['read_user']
+      )
+    );
+
+    expect(url.searchParams.get('scope')).toBe('read_user');
+  });
+});
+
+describe('GitLab project webhooks', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('enables note events when creating project webhooks', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 123, created_at: '2026-05-01T00:00:00Z' }),
+    });
+
+    await createProjectWebhook(
+      'token',
+      123,
+      'https://app.example.com/api/webhooks/gitlab',
+      'secret'
+    );
+
+    const [, init] = mockFetch.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.merge_requests_events).toBe(true);
+    expect(body.note_events).toBe(true);
+  });
+
+  it('enables note events when updating project webhooks', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 456, created_at: '2026-05-01T00:00:00Z' }),
+    });
+
+    await updateProjectWebhook(
+      'token',
+      123,
+      456,
+      'https://app.example.com/api/webhooks/gitlab',
+      'secret'
+    );
+
+    const [, init] = mockFetch.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.merge_requests_events).toBe(true);
+    expect(body.note_events).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
@@ -82,7 +82,8 @@ export type GitLabOAuthCredentials = {
 export function buildGitLabOAuthUrl(
   state: string,
   instanceUrl: string = DEFAULT_GITLAB_URL,
-  customCredentials?: GitLabOAuthCredentials
+  customCredentials?: GitLabOAuthCredentials,
+  scopes: readonly string[] = GITLAB_OAUTH_SCOPES
 ): string {
   if (instanceUrl !== DEFAULT_GITLAB_URL && !customCredentials) {
     throw new Error('Custom GitLab OAuth credentials are required for self-hosted instances');
@@ -99,7 +100,7 @@ export function buildGitLabOAuthUrl(
     redirect_uri: GITLAB_REDIRECT_URI,
     response_type: 'code',
     state,
-    scope: GITLAB_OAUTH_SCOPES.join(' '),
+    scope: scopes.join(' '),
   });
 
   return `${instanceUrl}/oauth/authorize?${params.toString()}`;
@@ -729,7 +730,7 @@ export async function createProjectWebhook(
       issues_events: false,
       confidential_issues_events: false,
       tag_push_events: false,
-      note_events: false,
+      note_events: true,
       confidential_note_events: false,
       job_events: false,
       pipeline_events: false,
@@ -811,7 +812,7 @@ export async function updateProjectWebhook(
         issues_events: false,
         confidential_issues_events: false,
         tag_push_events: false,
-        note_events: false,
+        note_events: true,
         confidential_note_events: false,
         job_events: false,
         pipeline_events: false,
@@ -1216,7 +1217,7 @@ export async function createMRNote(
   mrIid: number,
   body: string,
   instanceUrl: string = DEFAULT_GITLAB_URL
-): Promise<void> {
+): Promise<GitLabNote> {
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
@@ -1237,7 +1238,148 @@ export async function createMRNote(
     throw new Error(`GitLab MR note creation failed: ${response.status} ${error}`);
   }
 
-  logExceptInTest('[createMRNote] Created note', { projectId, mrIid });
+  const note = (await response.json()) as GitLabNote;
+
+  logExceptInTest('[createMRNote] Created note', { projectId, mrIid, noteId: note.id });
+
+  return note;
+}
+
+export async function replyToMRDiscussion(
+  accessToken: string,
+  projectId: string | number,
+  mrIid: number,
+  discussionId: string,
+  body: string,
+  instanceUrl: string = DEFAULT_GITLAB_URL
+): Promise<GitLabNote> {
+  const encodedProjectId =
+    typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
+  const response = await fetch(
+    `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/discussions/${encodeURIComponent(discussionId)}/notes`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ body }),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`GitLab MR discussion reply failed: ${response.status} ${error}`);
+  }
+
+  const note = (await response.json()) as GitLabNote;
+  logExceptInTest('[replyToMRDiscussion] Created discussion reply', {
+    projectId,
+    mrIid,
+    discussionId,
+    noteId: note.id,
+  });
+  return note;
+}
+
+export async function fetchMergeRequest(
+  accessToken: string,
+  projectId: string | number,
+  mrIid: number,
+  instanceUrl: string = DEFAULT_GITLAB_URL
+): Promise<GitLabMergeRequest> {
+  const encodedProjectId =
+    typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
+  const response = await fetch(
+    `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`GitLab MR fetch failed: ${response.status} ${error}`);
+  }
+
+  return (await response.json()) as GitLabMergeRequest;
+}
+
+export async function fetchMRNotes(
+  accessToken: string,
+  projectId: string | number,
+  mrIid: number,
+  instanceUrl: string = DEFAULT_GITLAB_URL,
+  perPage: number = 12
+): Promise<GitLabNote[]> {
+  const encodedProjectId =
+    typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
+  const response = await fetch(
+    `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/notes?sort=desc&order_by=created_at&per_page=${perPage}`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`GitLab MR notes fetch failed: ${response.status} ${error}`);
+  }
+
+  return ((await response.json()) as GitLabNote[]).sort((a, b) => {
+    const aTime = Date.parse(a.created_at);
+    const bTime = Date.parse(b.created_at);
+    if (aTime !== bTime) return aTime - bTime;
+    return a.id - b.id;
+  });
+}
+
+export async function fetchMRNote(
+  accessToken: string,
+  projectId: string | number,
+  mrIid: number,
+  noteId: number,
+  instanceUrl: string = DEFAULT_GITLAB_URL
+): Promise<GitLabNote> {
+  const encodedProjectId =
+    typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
+  const response = await fetch(
+    `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/notes/${noteId}`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`GitLab MR note fetch failed: ${response.status} ${error}`);
+  }
+
+  return (await response.json()) as GitLabNote;
+}
+
+export async function fetchMRDiscussion(
+  accessToken: string,
+  projectId: string | number,
+  mrIid: number,
+  discussionId: string,
+  instanceUrl: string = DEFAULT_GITLAB_URL
+): Promise<GitLabDiscussion> {
+  const encodedProjectId =
+    typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
+  const response = await fetch(
+    `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/discussions/${encodeURIComponent(discussionId)}`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`GitLab MR discussion fetch failed: ${response.status} ${error}`);
+  }
+
+  return (await response.json()) as GitLabDiscussion;
 }
 
 /**

--- a/apps/web/src/lib/integrations/platforms/gitlab/webhook-handlers/bot-note-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/webhook-handlers/bot-note-handler.ts
@@ -1,0 +1,44 @@
+import { handleIncomingBotMention } from '@/lib/bot/handle-mention';
+import { bot } from '@/lib/bot';
+import {
+  createGitLabMessageFromNotePayload,
+  createGitLabSyntheticThread,
+  type GitLabThreadContext,
+} from '@/lib/bot/platforms/gitlab';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import type { NoteEventPayload } from '@/lib/integrations/platforms/gitlab/webhook-schemas';
+import type { PlatformIntegration } from '@kilocode/db';
+
+export async function handleGitLabNoteBotMention(
+  payload: NoteEventPayload,
+  integration: PlatformIntegration
+): Promise<void> {
+  const mergeRequest = payload.merge_request;
+  if (!mergeRequest) return;
+
+  const context: GitLabThreadContext = {
+    integrationId: integration.id,
+    projectId: payload.project_id,
+    projectPath: payload.project.path_with_namespace,
+    mrIid: mergeRequest.iid,
+    noteId: payload.object_attributes.id,
+    ...(payload.object_attributes.discussion_id
+      ? { discussionId: payload.object_attributes.discussion_id }
+      : {}),
+  };
+  const thread = createGitLabSyntheticThread({ context, platformIntegration: integration });
+  const message = createGitLabMessageFromNotePayload(payload, context);
+
+  await bot.initialize();
+  await handleIncomingBotMention({
+    thread,
+    message,
+    state: bot.getState(),
+    identity: {
+      platform: PLATFORM.GITLAB,
+      teamId: integration.id,
+      userId: payload.user.id.toString(),
+    },
+    platformIntegration: integration,
+  });
+}

--- a/apps/web/src/lib/integrations/platforms/gitlab/webhook-handlers/index.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/webhook-handlers/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { handleMergeRequest, handleMergeRequestCodeReview } from './merge-request-handler';
+export { handleGitLabNoteBotMention } from './bot-note-handler';

--- a/apps/web/src/lib/integrations/platforms/gitlab/webhook-schemas.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/webhook-schemas.ts
@@ -247,6 +247,8 @@ export const NoteEventPayloadSchema = z.object({
     line_code: z.string().nullable().optional(),
     commit_id: z.string().nullable().optional(),
     noteable_id: z.number().nullable().optional(),
+    noteable_iid: z.number().nullable().optional(),
+    discussion_id: z.string().nullable().optional(),
     system: z.boolean().optional(),
     st_diff: z
       .object({

--- a/apps/web/src/routers/github-apps-router.ts
+++ b/apps/web/src/routers/github-apps-router.ts
@@ -210,6 +210,7 @@ export const githubAppsRouter = createTRPCRouter({
       scopes: installationDetails.events,
       repositoryAccess: installationDetails.repository_selection,
       installedAt: installationDetails.created_at,
+      metadata: { bot_enabled: true },
     });
 
     const repositories = await fetchGitHubRepositories(installationId, appType);
@@ -266,6 +267,7 @@ export const githubAppsRouter = createTRPCRouter({
         repositoryAccess: installationDetails.repository_selection,
         installedAt: installationDetails.created_at,
         githubAppType: appType,
+        metadata: { bot_enabled: true },
       });
 
       const integration = await getIntegrationForOwner(owner, 'github');


### PR DESCRIPTION
## Summary
- Enable Kilo Bot on GitLab merge request comments so linked users can start Cloud Agent work from GitLab.
- Detect clear requests for a separate PR or MR and guide Cloud Agent to use a fresh branch instead of the current review branch.
- Add branch context for GitHub PRs and GitLab MRs so new PR/MR requests use the right target.

## Verification
1. Mention Kilo on a GitHub PR comment and ask it to open a new PR; confirm the Cloud Agent request says to use a fresh branch from the PR base branch.
2. Mention Kilo on a GitLab MR note from a linked account; confirm the bot starts work and replies back in the MR thread.
3. Use the GitLab link from an MR comment as an unlinked user; confirm OAuth links the GitLab account.

## Visual Changes
N/A

## Reviewer Notes
Existing GitLab project webhooks need to be synced or updated so they send note events.