### PR TITLE
chore(model-eval): retrigger ingest worker deploy

### DIFF
--- a/services/model-eval-ingest/wrangler.jsonc
+++ b/services/model-eval-ingest/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  // Touch this Worker config when a deploy-only PR needs to retrigger model-eval-ingest.
   "name": "model-eval-ingest",
   "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

- Touch the model-eval-ingest Worker config with a comment-only change so path-based deploy detection includes this Worker in the next deployment.
- No runtime behavior, bindings, or configuration values changed.

## Verification

- Confirmed the branch only changes `services/model-eval-ingest/wrangler.jsonc` with a comment-only diff.

## Visual Changes

N/A

## Reviewer Notes

- This PR exists to retrigger deployment for the already-merged model-eval-ingest fix because worker deploys are selected from changed paths.