### PR TITLE
ci(workers): add manual deploy choices

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -6,9 +6,37 @@ on:
   workflow_dispatch:
     inputs:
       worker:
-        description: 'Worker folder to deploy (e.g. services/app-builder)'
+        description: 'Worker to deploy'
         required: true
-        type: string
+        type: choice
+        options:
+          - services/ai-attribution
+          - services/app-builder
+          - services/auto-fix-infra
+          - services/auto-triage-infra
+          - services/cloud-agent
+          - services/cloud-agent-next
+          - services/code-review-infra
+          - services/db-proxy
+          - services/deploy-infra/builder
+          - services/deploy-infra/dispatcher
+          - services/event-service
+          - services/gastown
+          - services/git-token-service
+          - services/gmail-push
+          - services/images-mcp
+          - services/kilo-chat
+          - services/kilo-ops
+          - services/kiloclaw-billing
+          - services/kiloclaw-inbound-email
+          - services/model-eval-ingest
+          - services/notifications
+          - services/o11y
+          - services/security-auto-analysis
+          - services/security-sync
+          - services/session-ingest
+          - services/wasteland
+          - services/webhook-agent-ingest
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Replace the freeform worker path input in the Cloudflare Workers deploy workflow with a fixed dropdown of standard Wrangler-deployable workers.
- Preserve the existing push-to-main behavior that deploys only changed workers.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
- Manual dispatch now only allows workers listed in the workflow choices; adding a new Wrangler worker will require adding it to this list if manual deploy should be available.