### PR TITLE
feat(gateway): add discounted Stealth Claude Opus model

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -28,6 +28,7 @@ import {
   isExcludedForFeature,
   isKiloExclusiveFreeModel,
   isKiloStealthModel,
+  requiresKiloDataCollection,
 } from '@/lib/ai-gateway/models';
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
 import {
@@ -498,7 +499,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   });
 
   if (
-    isKiloExclusiveFreeModel(originalModelIdLowerCased) &&
+    requiresKiloDataCollection(originalModelIdLowerCased) &&
     !isFreePromptTrainingAllowed(requestBodyParsed.body.provider)
   ) {
     return dataCollectionRequiredResponse();

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -1,7 +1,9 @@
 import { describe, test, expect } from '@jest/globals';
-import { autoFreeModels, kiloExclusiveModels } from './models';
+import { autoFreeModels, kiloExclusiveModels, requiresKiloDataCollection } from './models';
 import { isFreeModel } from './is-free-model';
 import { getInferenceProvider } from './providers/kilo-exclusive-model';
+import { claude_opus_4_7_stealth_model } from './providers/anthropic.constants';
+import { qwen36_plus_model } from './providers/qwen';
 
 describe('isFreeModel', () => {
   describe('free models', () => {
@@ -52,6 +54,16 @@ describe('isFreeModel', () => {
       for (const model of kiloExclusiveModels) {
         expect(() => getInferenceProvider(model)).not.toThrow();
       }
+    });
+
+    test('routes the discounted Claude Opus offering through the stealth provider identity', () => {
+      expect(getInferenceProvider(claude_opus_4_7_stealth_model)).toBe('stealth');
+      expect(claude_opus_4_7_stealth_model.public_id).toBe('stealth/claude-opus-4.7');
+    });
+
+    test('requires data collection for paid training-enabled offerings', () => {
+      expect(requiresKiloDataCollection(claude_opus_4_7_stealth_model.public_id)).toBe(true);
+      expect(requiresKiloDataCollection(qwen36_plus_model.public_id)).toBe(false);
     });
 
     test('all Kilo exclusive models should have either no pricing or valid pricing', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/ai-gateway/auto-model';
 import {
   CLAUDE_OPUS_CURRENT_MODEL_ID,
+  claude_opus_4_7_stealth_model,
   claude_sonnet_clawsetup_model,
   CLAUDE_SONNET_CURRENT_MODEL_ID,
 } from '@/lib/ai-gateway/providers/anthropic.constants';
@@ -80,8 +81,18 @@ export const kiloExclusiveModels = [
   seed_20_code_free_model,
   ...alibabaDirectModels,
   claude_sonnet_clawsetup_model,
+  claude_opus_4_7_stealth_model,
   stepfun_35_flash_free_model,
 ] as KiloExclusiveModel[];
+
+export function requiresKiloDataCollection(model: string): boolean {
+  return kiloExclusiveModels.some(
+    m =>
+      m.public_id === model &&
+      m.status !== 'disabled' &&
+      (!m.pricing || m.flags.includes('requires-data-collection'))
+  );
+}
 
 export function isKiloStealthModel(model: string): boolean {
   return kiloExclusiveModels.some(m => m.public_id === model && m.flags.includes('stealth'));

--- a/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
@@ -2,6 +2,7 @@ import { test, describe, expect } from '@jest/globals';
 import { calculateKiloExclusiveCost_mUsd } from './processUsage';
 import type { JustTheCostsUsageStats } from './processUsage.types';
 import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
+import { claude_opus_4_7_stealth_model } from '@/lib/ai-gateway/providers/anthropic.constants';
 import {
   qwen36_27b_model,
   qwen36_flash_model,
@@ -398,6 +399,29 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-max-preview', () => {
       makeUsage({ inputTokens: 256 * 1024 })
     );
     expect(result).toBe(Math.round(256 * 1024 * 1.3));
+  });
+});
+
+describe('calculatKiloExclusiveCost_mUsd with stealth Claude Opus 4.7', () => {
+  test('uses the 20% lower flat price for uncached tokens', () => {
+    const result = calculateKiloExclusiveCost_mUsd(
+      claude_opus_4_7_stealth_model,
+      makeUsage({ inputTokens: 100_000, outputTokens: 10_000 })
+    );
+    expect(result).toBe(600_000);
+  });
+
+  test('uses the discounted Anthropic-compatible cache prices', () => {
+    const result = calculateKiloExclusiveCost_mUsd(
+      claude_opus_4_7_stealth_model,
+      makeUsage({
+        inputTokens: 150_000,
+        outputTokens: 10_000,
+        cacheHitTokens: 25_000,
+        cacheWriteTokens: 25_000,
+      })
+    );
+    expect(result).toBe(735_000);
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
+++ b/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
@@ -30,7 +30,7 @@ export const claude_opus_4_7_stealth_model: KiloExclusiveModel = {
   internal_id: 'anthropic/claude-opus-4-7:optimized',
   display_name: 'Stealth: Claude Opus 4.7 (20% off)',
   description:
-    "Trains on your data. This third-party-served variant of Claude Opus 4.7 is offered at 20% lower cost than standard Claude Opus 4.7 pricing and is not served by Anthropic or Kilo Code. Your prompts and completions may be retained and used to train or improve the provider's services.",
+    "Your prompts and completions may be retained and used to train or improve the provider's services. This third-party-served variant of Claude Opus 4.7 is offered at 20% lower cost than standard Claude Opus 4.7 pricing and is not served by Anthropic or Kilo Code.",
   status: 'public',
   context_length: 1_000_000,
   max_completion_tokens: 128_000,

--- a/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
+++ b/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
@@ -1,12 +1,45 @@
-import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
+import type {
+  KiloExclusiveModel,
+  Pricing,
+  Usage,
+} from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 
 export const CLAUDE_SONNET_CURRENT_MODEL_ID = 'anthropic/claude-sonnet-4.6';
 export const CLAUDE_OPUS_CURRENT_MODEL_ID = 'anthropic/claude-opus-4.7';
 export const CLAUDE_HAIKU_CURRENT_MODEL_ID = 'anthropic/claude-haiku-4.5';
+export const CLAUDE_OPUS_STEALTH_MODEL_ID = 'stealth/claude-opus-4.7';
 
 export const CLAUDE_SONNET_CURRENT_VERCEL_MODEL_ID = CLAUDE_SONNET_CURRENT_MODEL_ID;
 export const CLAUDE_OPUS_CURRENT_VERCEL_MODEL_ID = CLAUDE_OPUS_CURRENT_MODEL_ID;
 export const CLAUDE_HAIKU_CURRENT_VERCEL_MODEL_ID = CLAUDE_HAIKU_CURRENT_MODEL_ID;
+
+const CLAUDE_OPUS_STEALTH_PRICING: Pricing = {
+  prompt_per_million: 4,
+  completion_per_million: 20,
+  input_cache_read_per_million: 0.4,
+  input_cache_write_per_million: 5,
+  calculate_mUsd: (usage: Usage) =>
+    usage.uncachedInputTokens * 4 +
+    usage.totalOutputTokens * 20 +
+    usage.cacheHitTokens * 0.4 +
+    usage.cacheWriteTokens * 5,
+};
+
+export const claude_opus_4_7_stealth_model: KiloExclusiveModel = {
+  public_id: CLAUDE_OPUS_STEALTH_MODEL_ID,
+  internal_id: 'anthropic/claude-opus-4-7:optimized',
+  display_name: 'Stealth: Claude Opus 4.7 (20% off)',
+  description:
+    'A third-party-served variant of Claude Opus 4.7 offered at 20% lower cost than standard Claude Opus 4.7 pricing. This model is not served by Anthropic or Kilo Code. The provider may retain your prompts and completions and use them to train or improve its services.',
+  status: 'public',
+  context_length: 1_000_000,
+  max_completion_tokens: 128_000,
+  gateway: 'martian',
+  flags: ['reasoning', 'vision', 'stealth', 'requires-data-collection'],
+  pricing: CLAUDE_OPUS_STEALTH_PRICING,
+  exclusive_to: [],
+  inference_provider_restriction: [],
+};
 
 export const claude_sonnet_clawsetup_model: KiloExclusiveModel = {
   public_id: CLAUDE_SONNET_CURRENT_MODEL_ID + ':clawsetup',

--- a/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
+++ b/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
@@ -30,7 +30,7 @@ export const claude_opus_4_7_stealth_model: KiloExclusiveModel = {
   internal_id: 'anthropic/claude-opus-4-7:optimized',
   display_name: 'Stealth: Claude Opus 4.7 (20% off)',
   description:
-    'A third-party-served variant of Claude Opus 4.7 offered at 20% lower cost than standard Claude Opus 4.7 pricing. This model is not served by Anthropic or Kilo Code. The provider may retain your prompts and completions and use them to train or improve its services.',
+    "Trains on your data. This third-party-served variant of Claude Opus 4.7 is offered at 20% lower cost than standard Claude Opus 4.7 pricing and is not served by Anthropic or Kilo Code. Your prompts and completions may be retained and used to train or improve the provider's services.",
   status: 'public',
   context_length: 1_000_000,
   max_completion_tokens: 128_000,

--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
@@ -6,7 +6,12 @@ import {
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 
-export type KiloExclusiveModelFlag = 'reasoning' | 'vision' | 'stealth' | 'vercel-routing';
+export type KiloExclusiveModelFlag =
+  | 'reasoning'
+  | 'vision'
+  | 'stealth'
+  | 'vercel-routing'
+  | 'requires-data-collection';
 
 export type Usage = {
   uncachedInputTokens: number;

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
@@ -52,7 +52,7 @@ export default {
     id: 'martian',
     apiUrl: 'https://api.withmartian.com/v1',
     apiKey: getEnvVariable('MARTIAN_API_KEY'),
-    supportedChatApis: ['responses'],
+    supportedChatApis: ['responses', 'messages'],
     transformRequest() {},
   },
   MISTRAL: {


### PR DESCRIPTION
## Summary

- Add `Stealth: Claude Opus 4.7 (20% off)` as a paid direct-provider model with a public stealth identity, third-party/training disclosure, and discounted Anthropic-style token pricing.
- Reuse the existing Stealth provider policy metadata while requiring data collection for this paid offering, so requests configured for deny/ZDR are rejected locally.
- Enable Anthropic Messages requests for the Martian gateway to support this Claude-compatible model with minimal temporary routing expansion while the existing Grok offering is retired.

## Verification

- [x] Fetched `GET /api/openrouter/models` from the local Cloud server and confirmed `Stealth: Claude Opus 4.7 (20% off)` appears in the catalog.
- [x] Used the CLI against local Cloud with `KILO_API_URL=http://localhost:3000`, selected the new model, received a completion, and confirmed it reports the public model identity `kilo/stealth/claude-opus-4.7`.

<img width="858" height="419" alt="image" src="https://github.com/user-attachments/assets/7ddb596c-e813-40a2-a139-ccd5e5fa848a" />

## Visual Changes

N/A

## Reviewer Notes

- Current IDE/CLI clients do not render custom promotion or training badges, so `(20% off)` remains in the display name for this release; structured client indicators are follow-up work.
- The existing synthetic Stealth provider policy marks training and prompt retention in organization settings; the new `requires-data-collection` flag extends equivalent deny/ZDR enforcement to this paid training-enabled model.
- Adding `/messages` at the Martian provider level temporarily allows the soon-to-be-removed Grok Martian offering through that API path as an accepted simplification.