### PR TITLE
Disable step 3.5 flash: free

### DIFF
--- a/apps/web/src/lib/ai-gateway/forbidden-free-models.ts
+++ b/apps/web/src/lib/ai-gateway/forbidden-free-models.ts
@@ -43,6 +43,7 @@ const forbiddenFreeModelIds: ReadonlySet<string> = new Set([
   'xiaomi/mimo-v2-pro:free',
   'z-ai/glm-4.5-air:free',
   'z-ai/glm-4.7:free',
+  'stepfun/step-3.5-flash:free',
   'z-ai/glm-5:free',
   claude_sonnet_clawsetup_model.public_id, // only usable through kilo-auto
 ]);

--- a/apps/web/src/lib/ai-gateway/providers/stepfun.ts
+++ b/apps/web/src/lib/ai-gateway/providers/stepfun.ts
@@ -11,7 +11,7 @@ export const stepfun_35_flash_free_model: KiloExclusiveModel = {
     "Step 3.5 Flash is StepFun's most capable open-source foundation model. Built on a sparse Mixture of Experts (MoE) architecture, it selectively activates only 11B of its 196B parameters per token. It is a reasoning model that is incredibly speed efficient even at long contexts.",
   context_length: 262_144,
   max_completion_tokens: 262_144,
-  status: 'public',
+  status: 'disabled',
   flags: ['reasoning'],
   gateway: 'openrouter',
   internal_id: 'stepfun/step-3.5-flash',


### PR DESCRIPTION
Remove the free endpoint as provider is having capacity issues. Should be removed from model list and no longer Recommended.


