### PR TITLE
fix(gateway): strip Martian messages provider options

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from '@jest/globals';
+import { EmptyFraudDetectionHeaders } from '@/lib/utils';
+import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+
+function transformMartianRequest(request: GatewayRequest, model: string) {
+  PROVIDERS.MARTIAN.transformRequest({
+    model,
+    request,
+    originalHeaders: EmptyFraudDetectionHeaders,
+    extraHeaders: {},
+    userByok: null,
+  });
+}
+
+describe('Martian provider', () => {
+  it('does not forward OpenRouter provider options through the Messages API', () => {
+    const request: GatewayRequest = {
+      kind: 'messages',
+      body: {
+        model: 'anthropic/claude-opus-4-7:optimized',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: 'Hello' }],
+        provider: { data_collection: 'allow', only: ['stealth'] },
+      },
+    };
+
+    transformMartianRequest(request, 'stealth/claude-opus-4.7');
+
+    expect(request.body.provider).toBeUndefined();
+  });
+
+  it('leaves provider options intact through the existing Responses API path', () => {
+    const request: GatewayRequest = {
+      kind: 'responses',
+      body: {
+        model: 'x-ai/grok-code-fast-1:optimized',
+        input: 'Hello',
+        provider: { data_collection: 'allow', only: ['stealth'] },
+      },
+    };
+
+    transformMartianRequest(request, 'x-ai/grok-code-fast-1:optimized:free');
+
+    expect(request.body.provider).toEqual({ data_collection: 'allow', only: ['stealth'] });
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
@@ -53,7 +53,11 @@ export default {
     apiUrl: 'https://api.withmartian.com/v1',
     apiKey: getEnvVariable('MARTIAN_API_KEY'),
     supportedChatApis: ['responses', 'messages'],
-    transformRequest() {},
+    transformRequest(context) {
+      if (context.request.kind === 'messages') {
+        delete context.request.body.provider;
+      }
+    },
   },
   MISTRAL: {
     id: 'mistral',


### PR DESCRIPTION
## Summary

- Fix organization-backed Stealth Claude Opus requests failing with `400 Invalid request parameters` from Martian's Anthropic Messages endpoint.
- Strip the OpenRouter-only `provider` request field immediately before forwarding Martian `/messages` requests, after Kilo has already evaluated organization data-collection policy.
- Preserve existing Martian Responses behavior for Grok and add regression coverage for both API paths.

## Verification

- [x] Inspected production logs for `stealth/claude-opus-4.7` and confirmed Martian rejected organization-backed `/messages` requests with `400 Invalid request parameters`.
- [x] Sent direct Martian Messages probes: requests succeed without `provider` and reproduce the `400` when organization-style `provider.data_collection` or `provider.only` fields are included.
- [x] Sent direct Martian Responses probes for the existing Grok route and confirmed requests continue to succeed with the same provider fields present.
- [x] Validated with local build that organization requests now succeed, and if you enable ZDR they are correctly blocked.

## Visual Changes

N/A

## Reviewer Notes

- Personal-account use succeeded because it does not inject organization provider-policy metadata; organization requests may inject `provider.data_collection` or `provider.only`.
- Deny/ZDR protection is unaffected: Kilo rejects training-disallowed requests before `MARTIAN.transformRequest()` removes unsupported upstream metadata.