### PR TITLE
feat(gateway): route Qwen3.7 Max directly through Alibaba

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -1,9 +1,14 @@
 import { describe, test, expect } from '@jest/globals';
-import { autoFreeModels, kiloExclusiveModels, requiresKiloDataCollection } from './models';
+import {
+  autoFreeModels,
+  findKiloExclusiveModel,
+  kiloExclusiveModels,
+  requiresKiloDataCollection,
+} from './models';
 import { isFreeModel } from './is-free-model';
 import { getInferenceProvider } from './providers/kilo-exclusive-model';
 import { claude_opus_4_7_stealth_model } from './providers/anthropic.constants';
-import { qwen36_plus_model } from './providers/qwen';
+import { isAlibabaDirectModel, qwen36_plus_model, qwen37_max_model } from './providers/qwen';
 
 describe('isFreeModel', () => {
   describe('free models', () => {
@@ -59,6 +64,14 @@ describe('isFreeModel', () => {
     test('routes the discounted Claude Opus offering through the stealth provider identity', () => {
       expect(getInferenceProvider(claude_opus_4_7_stealth_model)).toBe('stealth');
       expect(claude_opus_4_7_stealth_model.public_id).toBe('stealth/claude-opus-4.7');
+    });
+
+    test('routes Qwen3.7 Max directly through Alibaba', () => {
+      expect(findKiloExclusiveModel(qwen37_max_model.public_id)).toBe(qwen37_max_model);
+      expect(isAlibabaDirectModel(qwen37_max_model.public_id)).toBe(true);
+      expect(qwen37_max_model.gateway).toBe('alibaba');
+      expect(qwen37_max_model.internal_id).toBe('qwen3.7-max');
+      expect(getInferenceProvider(qwen37_max_model)).toBe('alibaba');
     });
 
     test('requires data collection for paid training-enabled offerings', () => {

--- a/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
@@ -8,6 +8,7 @@ import {
   qwen36_flash_model,
   qwen36_max_preview_model,
   qwen36_plus_model,
+  qwen37_max_model,
 } from '@/lib/ai-gateway/providers/qwen';
 
 const makeUsage = (overrides: Partial<JustTheCostsUsageStats> = {}): JustTheCostsUsageStats => ({
@@ -18,6 +19,26 @@ const makeUsage = (overrides: Partial<JustTheCostsUsageStats> = {}): JustTheCost
   cacheHitTokens: 0,
   is_byok: false,
   ...overrides,
+});
+
+describe('calculatKiloExclusiveCost_mUsd with qwen3.7-max', () => {
+  test('uses direct Alibaba pricing with the Kilo discount', () => {
+    const result = calculateKiloExclusiveCost_mUsd(
+      qwen37_max_model,
+      makeUsage({ inputTokens: 100_000, outputTokens: 10_000 })
+    );
+
+    expect(result).toBe(Math.round(100_000 * 1.625 + 10_000 * 4.875));
+  });
+
+  test('charges explicit cache reads and writes at discounted rates', () => {
+    const result = calculateKiloExclusiveCost_mUsd(
+      qwen37_max_model,
+      makeUsage({ inputTokens: 100_000, cacheHitTokens: 20_000, cacheWriteTokens: 30_000 })
+    );
+
+    expect(result).toBe(Math.round(50_000 * 1.625 + 20_000 * 0.1625 + 30_000 * 2.03125));
+  });
 });
 
 describe('calculatKiloExclusiveCost_mUsd with qwen3.6-plus', () => {

--- a/apps/web/src/lib/ai-gateway/providers/qwen.ts
+++ b/apps/web/src/lib/ai-gateway/providers/qwen.ts
@@ -70,6 +70,27 @@ const TOKENS_128K = 128 * 1024;
 const TOKENS_256K = 256 * 1024;
 const TOKENS_1M = 1024 * 1024;
 
+export const qwen37_max_model: KiloExclusiveModel = {
+  public_id: 'qwen/qwen3.7-max',
+  display_name: 'Qwen: Qwen3.7 Max',
+  description:
+    "Qwen3.7-Max is the flagship model in Alibaba's Qwen3.7 series. It is designed for agent-centric workloads, with particular strengths in coding, office and productivity tasks, and long-horizon autonomous execution.",
+  context_length: 1_000_000,
+  max_completion_tokens: 65_536,
+  status: 'public',
+  flags: ['reasoning'],
+  gateway: 'alibaba',
+  internal_id: 'qwen3.7-max',
+  pricing: makeFlatPricing({
+    prompt_per_million: 2.5,
+    completion_per_million: 7.5,
+    input_cache_read_per_million: 0.25,
+    input_cache_write_per_million: 3.125,
+  }),
+  exclusive_to: [],
+  inference_provider_restriction: [],
+};
+
 export const qwen36_plus_model: KiloExclusiveModel = {
   public_id: 'qwen/qwen3.6-plus',
   display_name: 'Qwen: Qwen3.6 Plus',
@@ -197,6 +218,7 @@ export const qwen36_27b_model: KiloExclusiveModel = {
 };
 
 export const alibabaDirectModels: ReadonlyArray<KiloExclusiveModel> = [
+  qwen37_max_model,
   qwen36_plus_model,
   qwen36_flash_model,
   qwen36_max_preview_model,


### PR DESCRIPTION
## Summary

- Register `qwen/qwen3.7-max` as an Alibaba-direct Kilo model so requests bypass OpenRouter's single-provider route.
- Configure direct model metadata and explicit-cache pricing under the existing Alibaba discount and request-shaping path.
- Add coverage for Alibaba routing registration and Qwen3.7-Max usage/caching cost calculation.

## Verification

- Not manually tested; this is server-side provider-selection and metering logic with no interactive workflow.

## Visual Changes

N/A

## Reviewer Notes

- OpenRouter currently exposes Alibaba as the only endpoint for Qwen3.7-Max; direct routing also uses the existing Alibaba explicit-cache breakpoint handling.