### PR TITLE
feat(admin): make experiment requests browsable

### DIFF
--- a/apps/web/src/app/admin/api/model-experiments/download/route.ts
+++ b/apps/web/src/app/admin/api/model-experiments/download/route.ts
@@ -1,0 +1,62 @@
+import { connection, type NextRequest } from 'next/server';
+import { eq } from 'drizzle-orm';
+import * as z from 'zod';
+import { model_experiment_request } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { getPromptByHash } from '@/lib/r2/experiment-prompts';
+import { getUserFromAuth } from '@/lib/user/server';
+
+const UsageIdSchema = z.string().uuid();
+const STORED_BODY_HASH = /^[0-9a-f]{64}$/;
+
+function jsonError(error: string, status: number) {
+  return Response.json({ error }, { status });
+}
+
+export async function GET(request: NextRequest) {
+  await connection();
+
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) {
+    return authFailedResponse;
+  }
+
+  const parsedUsageId = UsageIdSchema.safeParse(request.nextUrl.searchParams.get('usageId'));
+  if (!parsedUsageId.success) {
+    return jsonError('A valid usageId is required', 400);
+  }
+
+  const row = await db.query.model_experiment_request.findFirst({
+    columns: {
+      request_body_sha256: true,
+      was_truncated: true,
+    },
+    where: eq(model_experiment_request.usage_id, parsedUsageId.data),
+  });
+  if (!row) {
+    return jsonError('Experiment request not found', 404);
+  }
+  if (row.request_body_sha256 === '__deleted__') {
+    return jsonError('Captured request body was deleted', 410);
+  }
+  if (row.request_body_sha256 === '__failed__' || !STORED_BODY_HASH.test(row.request_body_sha256)) {
+    return jsonError('Captured request body is not available', 404);
+  }
+
+  const body = await getPromptByHash(row.request_body_sha256);
+  if (body === null) {
+    return jsonError('Captured request body was not found in storage', 404);
+  }
+
+  const extension = row.was_truncated ? 'json.part' : 'json';
+  return new Response(body, {
+    headers: {
+      'Cache-Control': 'private, no-store',
+      'Content-Disposition': `attachment; filename="experiment-request-${parsedUsageId.data}.${extension}"`,
+      'Content-Type': row.was_truncated
+        ? 'text/plain; charset=utf-8'
+        : 'application/json; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}

--- a/apps/web/src/app/admin/api/model-experiments/hooks.ts
+++ b/apps/web/src/app/admin/api/model-experiments/hooks.ts
@@ -2,6 +2,18 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
+import type { PageSize } from '@/types/pagination';
+
+export type ModelExperimentRequestFilters = {
+  page: number;
+  limit: PageSize;
+  experimentId?: string;
+  variantId?: string;
+  clientRequestId?: string;
+  requestKind?: 'chat_completions' | 'messages' | 'responses';
+  outcome: 'all' | 'success' | 'error';
+  bodyState: 'all' | 'available' | 'truncated' | 'failed' | 'deleted';
+};
 
 export function useModelExperiments(includeArchived = false) {
   const trpc = useTRPC();
@@ -16,9 +28,9 @@ export function useModelExperiment(id: string | null) {
   });
 }
 
-export function useModelExperimentRequests() {
+export function useModelExperimentRequests(filters: ModelExperimentRequestFilters) {
   const trpc = useTRPC();
-  return useQuery(trpc.admin.modelExperiments.listRequests.queryOptions());
+  return useQuery(trpc.admin.modelExperiments.listRequests.queryOptions(filters));
 }
 
 function useInvalidate() {

--- a/apps/web/src/app/admin/model-experiments/ModelExperimentRequestsContent.tsx
+++ b/apps/web/src/app/admin/model-experiments/ModelExperimentRequestsContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, type FormEvent } from 'react';
+import Link from 'next/link';
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Download } from 'lucide-react';
 import {
   type ModelExperimentRequestFilters,
@@ -8,6 +9,7 @@ import {
   useModelExperimentRequests,
   useModelExperiments,
 } from '@/app/admin/api/model-experiments/hooks';
+import { UserAvatarLink } from '@/app/admin/components/UserAvatarLink';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -35,6 +37,7 @@ import {
 
 const ALL = '__all__';
 const DEFAULT_PAGE_SIZE: PageSize = 25;
+const MODEL_EXPERIMENTS_TAB = '/admin/gateway?tab=model-experiments';
 const INITIAL_FILTERS: ModelExperimentRequestFilters = {
   page: 1,
   limit: DEFAULT_PAGE_SIZE,
@@ -79,12 +82,55 @@ function isBodyState(value: string): value is ModelExperimentRequestFilters['bod
   );
 }
 
-function HashCell({ value }: { value: string }) {
-  const display = value.length > 18 ? `${value.slice(0, 18)}…` : value;
+function experimentHref(experimentId: string): string {
+  return `${MODEL_EXPERIMENTS_TAB}&experimentId=${encodeURIComponent(experimentId)}`;
+}
+
+function isAnonymousUserId(userId: string): boolean {
+  return userId.startsWith('anon:');
+}
+
+function UserLink({
+  userId,
+  userName,
+  userEmail,
+  userImageUrl,
+}: {
+  userId: string;
+  userName: string | null;
+  userEmail: string | null;
+  userImageUrl: string | null;
+}) {
+  if (isAnonymousUserId(userId)) {
+    return <span className="font-mono text-xs">{userId}</span>;
+  }
+
+  if (userName && userEmail && userImageUrl) {
+    return (
+      <UserAvatarLink
+        user={{
+          id: userId,
+          google_user_name: userName,
+          google_user_email: userEmail,
+          google_user_image_url: userImageUrl,
+        }}
+        className="flex items-center gap-2"
+        avatarClassName="h-6 w-6 shrink-0"
+        nameClassName="truncate"
+        displayFormat="name"
+      />
+    );
+  }
+
+  const label = userName ?? userEmail ?? userId;
   return (
-    <span className="font-mono text-xs" title={value}>
-      {display}
-    </span>
+    <Link
+      href={`/admin/users/${encodeURIComponent(userId)}`}
+      className="hover:text-foreground font-medium underline-offset-4 hover:underline"
+      title={userEmail ?? userId}
+    >
+      {label}
+    </Link>
   );
 }
 
@@ -341,8 +387,8 @@ export function ModelExperimentRequestsContent() {
             className="max-w-md font-mono"
             value={clientRequestId}
             onChange={event => setClientRequestId(event.target.value)}
-            placeholder="Exact client request ID"
-            aria-label="Filter by client request ID"
+            placeholder="Exact Kilo request ID"
+            aria-label="Filter by Kilo request ID"
           />
           <Button type="submit">Apply</Button>
           <Button type="button" variant="outline" onClick={resetFilters}>
@@ -373,10 +419,11 @@ export function ModelExperimentRequestsContent() {
                   <TableHead>Created</TableHead>
                   <TableHead>Experiment</TableHead>
                   <TableHead>Variant</TableHead>
+                  <TableHead>Routing</TableHead>
                   <TableHead>Request</TableHead>
                   <TableHead>Usage</TableHead>
                   <TableHead>Captured body</TableHead>
-                  <TableHead>User / org</TableHead>
+                  <TableHead>User</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -386,18 +433,23 @@ export function ModelExperimentRequestsContent() {
                       {formatDate(row.createdAt)}
                     </TableCell>
                     <TableCell className="min-w-56 align-top">
-                      <div className="font-medium">{row.experimentName}</div>
+                      <Link
+                        href={experimentHref(row.experimentId)}
+                        className="hover:text-foreground font-medium underline-offset-4 hover:underline"
+                      >
+                        {row.experimentName}
+                      </Link>
                       <div className="text-muted-foreground font-mono text-xs">
                         {row.publicModelId}
-                      </div>
-                      <div className="text-muted-foreground mt-1 font-mono text-xs">
-                        {row.experimentId}
                       </div>
                     </TableCell>
                     <TableCell className="min-w-48 align-top">
                       <div className="font-medium">{row.variantLabel}</div>
-                      <div className="text-muted-foreground font-mono text-xs">
-                        {row.variantVersionId}
+                    </TableCell>
+                    <TableCell className="min-w-56 align-top text-xs">
+                      <div>Provider: {formatNullable(row.inferenceProvider ?? row.provider)}</div>
+                      <div className="text-muted-foreground font-mono">
+                        {formatNullable(row.requestedModel)} → {formatNullable(row.upstreamModel)}
                       </div>
                     </TableCell>
                     <TableCell className="min-w-48 align-top">
@@ -407,9 +459,8 @@ export function ModelExperimentRequestsContent() {
                         {row.wasTruncated ? <Badge variant="destructive">truncated</Badge> : null}
                       </div>
                       <div className="text-muted-foreground mt-1 text-xs">
-                        Client: {formatNullable(row.clientRequestId)}
+                        Kilo request: {formatNullable(row.clientRequestId)}
                       </div>
-                      <div className="text-muted-foreground font-mono text-xs">{row.usageId}</div>
                     </TableCell>
                     <TableCell className="min-w-48 align-top text-sm tabular-nums">
                       <div>
@@ -427,25 +478,18 @@ export function ModelExperimentRequestsContent() {
                       {row.hasError ? <Badge variant="destructive">error</Badge> : null}
                     </TableCell>
                     <TableCell className="min-w-48 align-top">
-                      <div className="mb-2">
-                        <HashCell value={row.requestBodySha256} />
-                      </div>
                       <PromptDownload
                         usageId={row.usageId}
                         requestBodySha256={row.requestBodySha256}
                       />
                     </TableCell>
-                    <TableCell className="min-w-56 align-top text-xs">
-                      <div className="font-mono">{row.userId}</div>
-                      <div className="text-muted-foreground font-mono">
-                        {formatNullable(row.organizationId)}
-                      </div>
-                      <div className="text-muted-foreground mt-1">
-                        {formatNullable(row.provider)} / {formatNullable(row.inferenceProvider)}
-                      </div>
-                      <div className="text-muted-foreground font-mono">
-                        {formatNullable(row.requestedModel)} → {formatNullable(row.upstreamModel)}
-                      </div>
+                    <TableCell className="min-w-48 align-top text-sm">
+                      <UserLink
+                        userId={row.userId}
+                        userName={row.userName}
+                        userEmail={row.userEmail}
+                        userImageUrl={row.userImageUrl}
+                      />
                     </TableCell>
                   </TableRow>
                 ))}

--- a/apps/web/src/app/admin/model-experiments/ModelExperimentRequestsContent.tsx
+++ b/apps/web/src/app/admin/model-experiments/ModelExperimentRequestsContent.tsx
@@ -1,6 +1,23 @@
 'use client';
 
+import { useState, type FormEvent } from 'react';
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Download } from 'lucide-react';
+import {
+  type ModelExperimentRequestFilters,
+  useModelExperiment,
+  useModelExperimentRequests,
+  useModelExperiments,
+} from '@/app/admin/api/model-experiments/hooks';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import {
   Table,
   TableBody,
@@ -9,7 +26,21 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { useModelExperimentRequests } from '@/app/admin/api/model-experiments/hooks';
+import {
+  getPaginationHelpers,
+  PAGE_SIZE_OPTIONS,
+  type PageSize,
+  type PaginationMetadata,
+} from '@/types/pagination';
+
+const ALL = '__all__';
+const DEFAULT_PAGE_SIZE: PageSize = 25;
+const INITIAL_FILTERS: ModelExperimentRequestFilters = {
+  page: 1,
+  limit: DEFAULT_PAGE_SIZE,
+  outcome: 'all',
+  bodyState: 'all',
+};
 
 function formatDate(value: string): string {
   return new Date(value).toLocaleString();
@@ -28,6 +59,26 @@ function formatMicrodollars(value: number | null): string {
   return value.toLocaleString();
 }
 
+function isRequestKind(
+  value: string
+): value is NonNullable<ModelExperimentRequestFilters['requestKind']> {
+  return value === 'chat_completions' || value === 'messages' || value === 'responses';
+}
+
+function isOutcome(value: string): value is ModelExperimentRequestFilters['outcome'] {
+  return value === 'all' || value === 'success' || value === 'error';
+}
+
+function isBodyState(value: string): value is ModelExperimentRequestFilters['bodyState'] {
+  return (
+    value === 'all' ||
+    value === 'available' ||
+    value === 'truncated' ||
+    value === 'failed' ||
+    value === 'deleted'
+  );
+}
+
 function HashCell({ value }: { value: string }) {
   const display = value.length > 18 ? `${value.slice(0, 18)}…` : value;
   return (
@@ -37,106 +88,375 @@ function HashCell({ value }: { value: string }) {
   );
 }
 
+function PromptDownload({
+  usageId,
+  requestBodySha256,
+}: {
+  usageId: string;
+  requestBodySha256: string;
+}) {
+  if (requestBodySha256 === '__failed__') {
+    return <span className="text-muted-foreground text-xs">Capture failed</span>;
+  }
+  if (requestBodySha256 === '__deleted__') {
+    return <span className="text-muted-foreground text-xs">Deleted</span>;
+  }
+
+  return (
+    <Button variant="outline" size="sm" asChild>
+      <a
+        href={`/admin/api/model-experiments/download?usageId=${encodeURIComponent(usageId)}`}
+        download
+      >
+        <Download />
+        Download JSON
+      </a>
+    </Button>
+  );
+}
+
+function RequestsPagination({
+  pagination,
+  onPageChange,
+  onLimitChange,
+}: {
+  pagination: PaginationMetadata;
+  onPageChange: (page: number) => void;
+  onLimitChange: (limit: PageSize) => void;
+}) {
+  const { hasNext, hasPrev } = getPaginationHelpers(pagination);
+
+  return (
+    <div className="flex flex-col gap-3 border-t p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="text-muted-foreground text-sm tabular-nums">
+        Showing {Math.min((pagination.page - 1) * pagination.limit + 1, pagination.total)}–
+        {Math.min(pagination.page * pagination.limit, pagination.total)} of{' '}
+        {pagination.total.toLocaleString()}
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground text-sm">Rows</span>
+          <Select
+            value={String(pagination.limit)}
+            onValueChange={value => {
+              const parsed = Number.parseInt(value, 10);
+              const limit =
+                PAGE_SIZE_OPTIONS.find(option => option === parsed) ?? DEFAULT_PAGE_SIZE;
+              onLimitChange(limit);
+            }}
+          >
+            <SelectTrigger size="sm" className="w-20">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PAGE_SIZE_OPTIONS.map(size => (
+                <SelectItem key={size} value={String(size)}>
+                  {size}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="icon"
+            disabled={!hasPrev}
+            aria-label="First page"
+            onClick={() => onPageChange(1)}
+          >
+            <ChevronsLeft />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            disabled={!hasPrev}
+            aria-label="Previous page"
+            onClick={() => onPageChange(pagination.page - 1)}
+          >
+            <ChevronLeft />
+          </Button>
+          <span className="text-muted-foreground px-2 text-sm tabular-nums">
+            Page {pagination.page} of {pagination.totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="icon"
+            disabled={!hasNext}
+            aria-label="Next page"
+            onClick={() => onPageChange(pagination.page + 1)}
+          >
+            <ChevronRight />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            disabled={!hasNext}
+            aria-label="Last page"
+            onClick={() => onPageChange(pagination.totalPages)}
+          >
+            <ChevronsRight />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ModelExperimentRequestsContent() {
-  const { data, isLoading } = useModelExperimentRequests();
+  const [filters, setFilters] = useState<ModelExperimentRequestFilters>(INITIAL_FILTERS);
+  const [clientRequestId, setClientRequestId] = useState('');
+  const { data: experiments } = useModelExperiments(true);
+  const { data: experimentDetails } = useModelExperiment(filters.experimentId ?? null);
+  const { data, isLoading, isFetching, error } = useModelExperimentRequests(filters);
   const rows = data?.items ?? [];
+  const pagination = data?.pagination ?? {
+    page: filters.page,
+    limit: filters.limit,
+    total: 0,
+    totalPages: 0,
+  };
+
+  function setFilter(patch: Partial<ModelExperimentRequestFilters>) {
+    setFilters(current => ({ ...current, ...patch, page: 1 }));
+  }
+
+  function applyRequestIdFilter(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const value = clientRequestId.trim();
+    setFilter({ clientRequestId: value.length > 0 ? value : undefined });
+  }
+
+  function resetFilters() {
+    setClientRequestId('');
+    setFilters(INITIAL_FILTERS);
+  }
 
   return (
     <div className="flex w-full flex-col gap-y-4">
       <div className="flex flex-col gap-1">
         <h2 className="text-2xl font-bold">Experiment Requests</h2>
         <p className="text-muted-foreground text-sm">
-          Last 100 requests attributed to model experiments. Prompt bodies stay in R2; this table
-          shows attribution, routing, and usage metadata only.
+          Inspect attributed traffic by experiment and download captured upstream request bodies
+          from R2.
         </p>
       </div>
 
-      {isLoading ? (
+      <form
+        onSubmit={applyRequestIdFilter}
+        className="border-border bg-card grid gap-3 rounded-xl border p-4 md:grid-cols-2 xl:grid-cols-6"
+      >
+        <Select
+          value={filters.experimentId ?? ALL}
+          onValueChange={value =>
+            setFilter({ experimentId: value === ALL ? undefined : value, variantId: undefined })
+          }
+        >
+          <SelectTrigger className="w-full" aria-label="Filter by experiment">
+            <SelectValue placeholder="All experiments" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All experiments</SelectItem>
+            {(experiments?.items ?? []).map(experiment => (
+              <SelectItem key={experiment.id} value={experiment.id}>
+                {experiment.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          disabled={!filters.experimentId}
+          value={filters.variantId ?? ALL}
+          onValueChange={value => setFilter({ variantId: value === ALL ? undefined : value })}
+        >
+          <SelectTrigger className="w-full" aria-label="Filter by variant">
+            <SelectValue placeholder="All variants" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All variants</SelectItem>
+            {(experimentDetails?.variants ?? []).map(variant => (
+              <SelectItem key={variant.id} value={variant.id}>
+                {variant.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filters.requestKind ?? ALL}
+          onValueChange={value => {
+            if (value === ALL || isRequestKind(value)) {
+              setFilter({ requestKind: value === ALL ? undefined : value });
+            }
+          }}
+        >
+          <SelectTrigger className="w-full" aria-label="Filter by request type">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All request types</SelectItem>
+            <SelectItem value="chat_completions">Chat completions</SelectItem>
+            <SelectItem value="messages">Messages</SelectItem>
+            <SelectItem value="responses">Responses</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filters.outcome}
+          onValueChange={value => {
+            if (isOutcome(value)) setFilter({ outcome: value });
+          }}
+        >
+          <SelectTrigger className="w-full" aria-label="Filter by outcome">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All outcomes</SelectItem>
+            <SelectItem value="success">Successful</SelectItem>
+            <SelectItem value="error">Errors</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filters.bodyState}
+          onValueChange={value => {
+            if (isBodyState(value)) setFilter({ bodyState: value });
+          }}
+        >
+          <SelectTrigger className="w-full" aria-label="Filter by body state">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All captures</SelectItem>
+            <SelectItem value="available">Downloadable</SelectItem>
+            <SelectItem value="truncated">Truncated</SelectItem>
+            <SelectItem value="failed">Capture failed</SelectItem>
+            <SelectItem value="deleted">Deleted</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <div className="flex gap-2 md:col-span-2 xl:col-span-6">
+          <Input
+            className="max-w-md font-mono"
+            value={clientRequestId}
+            onChange={event => setClientRequestId(event.target.value)}
+            placeholder="Exact client request ID"
+            aria-label="Filter by client request ID"
+          />
+          <Button type="submit">Apply</Button>
+          <Button type="button" variant="outline" onClick={resetFilters}>
+            Reset
+          </Button>
+          {isFetching && !isLoading ? (
+            <span className="text-muted-foreground self-center text-sm">Updating…</span>
+          ) : null}
+        </div>
+      </form>
+
+      {error ? (
+        <div className="border-destructive text-destructive rounded-lg border p-4 text-sm">
+          Could not load experiment requests: {error.message}
+        </div>
+      ) : isLoading ? (
         <div className="text-muted-foreground text-sm">Loading…</div>
       ) : rows.length === 0 ? (
         <div className="border-border bg-card text-muted-foreground rounded-lg border p-6 text-sm">
-          No experiment requests recorded yet.
+          No experiment requests match these filters.
         </div>
       ) : (
-        <div className="border-border overflow-x-auto rounded-lg border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Created</TableHead>
-                <TableHead>Experiment</TableHead>
-                <TableHead>Variant</TableHead>
-                <TableHead>Request</TableHead>
-                <TableHead>Usage</TableHead>
-                <TableHead>Prompt hash</TableHead>
-                <TableHead>User / org</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rows.map(row => (
-                <TableRow key={row.usageId}>
-                  <TableCell className="whitespace-nowrap align-top text-sm">
-                    {formatDate(row.createdAt)}
-                  </TableCell>
-                  <TableCell className="min-w-56 align-top">
-                    <div className="font-medium">{row.experimentName}</div>
-                    <div className="text-muted-foreground font-mono text-xs">
-                      {row.publicModelId}
-                    </div>
-                    <div className="text-muted-foreground mt-1 font-mono text-xs">
-                      {row.experimentId}
-                    </div>
-                  </TableCell>
-                  <TableCell className="min-w-48 align-top">
-                    <div className="font-medium">{row.variantLabel}</div>
-                    <div className="text-muted-foreground font-mono text-xs">
-                      {row.variantVersionId}
-                    </div>
-                  </TableCell>
-                  <TableCell className="min-w-48 align-top">
-                    <div className="flex flex-wrap items-center gap-1">
-                      <Badge variant="outline">{row.requestKind}</Badge>
-                      <Badge variant="secondary">{row.allocationSubject}</Badge>
-                      {row.wasTruncated && <Badge variant="destructive">truncated</Badge>}
-                    </div>
-                    <div className="text-muted-foreground mt-1 text-xs">
-                      Client: {formatNullable(row.clientRequestId)}
-                    </div>
-                    <div className="text-muted-foreground font-mono text-xs">{row.usageId}</div>
-                  </TableCell>
-                  <TableCell className="min-w-48 align-top text-sm">
-                    <div>
-                      Tokens: {formatTokens(row.inputTokens)} in / {formatTokens(row.outputTokens)}{' '}
-                      out
-                    </div>
-                    <div className="text-muted-foreground text-xs">
-                      Cache: {formatTokens(row.cacheWriteTokens)} write /{' '}
-                      {formatTokens(row.cacheHitTokens)} hit
-                    </div>
-                    <div className="text-muted-foreground text-xs">
-                      Cost: {formatMicrodollars(row.costMicrodollars)} µ$ · discount:{' '}
-                      {formatMicrodollars(row.cacheDiscountMicrodollars)} µ$
-                    </div>
-                    {row.hasError && <Badge variant="destructive">error</Badge>}
-                  </TableCell>
-                  <TableCell className="min-w-44 align-top">
-                    <HashCell value={row.requestBodySha256} />
-                  </TableCell>
-                  <TableCell className="min-w-56 align-top text-xs">
-                    <div className="font-mono">{row.userId}</div>
-                    <div className="text-muted-foreground font-mono">
-                      {formatNullable(row.organizationId)}
-                    </div>
-                    <div className="text-muted-foreground mt-1">
-                      {formatNullable(row.provider)} / {formatNullable(row.inferenceProvider)}
-                    </div>
-                    <div className="text-muted-foreground font-mono">
-                      {formatNullable(row.requestedModel)} → {formatNullable(row.upstreamModel)}
-                    </div>
-                  </TableCell>
+        <div className="border-border overflow-hidden rounded-lg border">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Experiment</TableHead>
+                  <TableHead>Variant</TableHead>
+                  <TableHead>Request</TableHead>
+                  <TableHead>Usage</TableHead>
+                  <TableHead>Captured body</TableHead>
+                  <TableHead>User / org</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {rows.map(row => (
+                  <TableRow key={row.usageId}>
+                    <TableCell className="whitespace-nowrap align-top text-sm">
+                      {formatDate(row.createdAt)}
+                    </TableCell>
+                    <TableCell className="min-w-56 align-top">
+                      <div className="font-medium">{row.experimentName}</div>
+                      <div className="text-muted-foreground font-mono text-xs">
+                        {row.publicModelId}
+                      </div>
+                      <div className="text-muted-foreground mt-1 font-mono text-xs">
+                        {row.experimentId}
+                      </div>
+                    </TableCell>
+                    <TableCell className="min-w-48 align-top">
+                      <div className="font-medium">{row.variantLabel}</div>
+                      <div className="text-muted-foreground font-mono text-xs">
+                        {row.variantVersionId}
+                      </div>
+                    </TableCell>
+                    <TableCell className="min-w-48 align-top">
+                      <div className="flex flex-wrap items-center gap-1">
+                        <Badge variant="outline">{row.requestKind}</Badge>
+                        <Badge variant="secondary">{row.allocationSubject}</Badge>
+                        {row.wasTruncated ? <Badge variant="destructive">truncated</Badge> : null}
+                      </div>
+                      <div className="text-muted-foreground mt-1 text-xs">
+                        Client: {formatNullable(row.clientRequestId)}
+                      </div>
+                      <div className="text-muted-foreground font-mono text-xs">{row.usageId}</div>
+                    </TableCell>
+                    <TableCell className="min-w-48 align-top text-sm tabular-nums">
+                      <div>
+                        Tokens: {formatTokens(row.inputTokens)} in /{' '}
+                        {formatTokens(row.outputTokens)} out
+                      </div>
+                      <div className="text-muted-foreground text-xs">
+                        Cache: {formatTokens(row.cacheWriteTokens)} write /{' '}
+                        {formatTokens(row.cacheHitTokens)} hit
+                      </div>
+                      <div className="text-muted-foreground text-xs">
+                        Cost: {formatMicrodollars(row.costMicrodollars)} µ$ · discount:{' '}
+                        {formatMicrodollars(row.cacheDiscountMicrodollars)} µ$
+                      </div>
+                      {row.hasError ? <Badge variant="destructive">error</Badge> : null}
+                    </TableCell>
+                    <TableCell className="min-w-48 align-top">
+                      <div className="mb-2">
+                        <HashCell value={row.requestBodySha256} />
+                      </div>
+                      <PromptDownload
+                        usageId={row.usageId}
+                        requestBodySha256={row.requestBodySha256}
+                      />
+                    </TableCell>
+                    <TableCell className="min-w-56 align-top text-xs">
+                      <div className="font-mono">{row.userId}</div>
+                      <div className="text-muted-foreground font-mono">
+                        {formatNullable(row.organizationId)}
+                      </div>
+                      <div className="text-muted-foreground mt-1">
+                        {formatNullable(row.provider)} / {formatNullable(row.inferenceProvider)}
+                      </div>
+                      <div className="text-muted-foreground font-mono">
+                        {formatNullable(row.requestedModel)} → {formatNullable(row.upstreamModel)}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+          <RequestsPagination
+            pagination={pagination}
+            onPageChange={page => setFilters(current => ({ ...current, page }))}
+            onLimitChange={limit => setFilters(current => ({ ...current, page: 1, limit }))}
+          />
         </div>
       )}
     </div>

--- a/apps/web/src/routers/admin/model-experiments-router.test.ts
+++ b/apps/web/src/routers/admin/model-experiments-router.test.ts
@@ -134,6 +134,7 @@ describe('admin.modelExperiments — basic CRUD', () => {
 
     const requests = await caller.admin.modelExperiments.listRequests();
 
+    expect(requests.pagination).toEqual({ page: 1, limit: 25, total: 1, totalPages: 1 });
     expect(requests.items[0]).toEqual(
       expect.objectContaining({
         usageId,
@@ -155,6 +156,118 @@ describe('admin.modelExperiments — basic CRUD', () => {
         outputTokens: 45,
       })
     );
+  });
+
+  it('paginates and filters request attribution rows for investigation', async () => {
+    const first = await makeDraftWithTwoVariants('kilo/preview-filter-first');
+    const second = await makeDraftWithTwoVariants('kilo/preview-filter-second');
+    const [firstVersion] = await db
+      .select({ id: model_experiment_variant_version.id })
+      .from(model_experiment_variant_version)
+      .where(eq(model_experiment_variant_version.variant_id, first.variantA.id))
+      .limit(1);
+    const [secondVersion] = await db
+      .select({ id: model_experiment_variant_version.id })
+      .from(model_experiment_variant_version)
+      .where(eq(model_experiment_variant_version.variant_id, second.variantA.id))
+      .limit(1);
+    expect(firstVersion).toBeDefined();
+    expect(secondVersion).toBeDefined();
+
+    const firstUsageId = randomUUID();
+    const secondUsageId = randomUUID();
+    await db.insert(microdollar_usage).values([
+      {
+        id: firstUsageId,
+        kilo_user_id: 'filter-user-one',
+        cost: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_write_tokens: 0,
+        cache_hit_tokens: 0,
+        has_error: false,
+      },
+      {
+        id: secondUsageId,
+        kilo_user_id: 'filter-user-two',
+        cost: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_write_tokens: 0,
+        cache_hit_tokens: 0,
+        has_error: true,
+      },
+    ]);
+    await db.insert(model_experiment_request).values([
+      {
+        usage_id: firstUsageId,
+        variant_version_id: firstVersion.id,
+        allocation_subject: 'user',
+        client_request_id: 'client-success',
+        request_kind: 'responses',
+        request_body_sha256: 'a'.repeat(64),
+        was_truncated: false,
+      },
+      {
+        usage_id: secondUsageId,
+        variant_version_id: secondVersion.id,
+        allocation_subject: 'user',
+        client_request_id: 'client-error',
+        request_kind: 'messages',
+        request_body_sha256: '__failed__',
+        was_truncated: false,
+      },
+    ]);
+
+    const additionalUsageIds = Array.from({ length: 9 }, () => randomUUID());
+    await db.insert(microdollar_usage).values(
+      additionalUsageIds.map(id => ({
+        id,
+        kilo_user_id: 'filter-user-one',
+        cost: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_write_tokens: 0,
+        cache_hit_tokens: 0,
+        has_error: false,
+      }))
+    );
+    await db.insert(model_experiment_request).values(
+      additionalUsageIds.map(id => ({
+        usage_id: id,
+        variant_version_id: firstVersion.id,
+        allocation_subject: 'user' as const,
+        client_request_id: 'client-success',
+        request_kind: 'responses' as const,
+        request_body_sha256: 'a'.repeat(64),
+        was_truncated: false,
+      }))
+    );
+
+    const firstPage = await first.caller.admin.modelExperiments.listRequests({
+      page: 1,
+      limit: 10,
+    });
+    const secondPage = await first.caller.admin.modelExperiments.listRequests({
+      page: 2,
+      limit: 10,
+    });
+    expect(firstPage.items).toHaveLength(10);
+    expect(secondPage.items).toHaveLength(1);
+    expect(firstPage.pagination).toEqual({ page: 1, limit: 10, total: 11, totalPages: 2 });
+    expect(firstPage.items.map(item => item.usageId)).not.toContain(secondPage.items[0].usageId);
+
+    const filtered = await first.caller.admin.modelExperiments.listRequests({
+      page: 1,
+      limit: 25,
+      experimentId: second.experimentId,
+      clientRequestId: 'client-error',
+      requestKind: 'messages',
+      outcome: 'error',
+      bodyState: 'failed',
+    });
+    expect(filtered.items.map(item => item.usageId)).toEqual([secondUsageId]);
+    expect(filtered.pagination.total).toBe(1);
   });
 
   it('rejects delete unless status is draft', async () => {

--- a/apps/web/src/routers/admin/model-experiments-router.ts
+++ b/apps/web/src/routers/admin/model-experiments-router.ts
@@ -13,7 +13,7 @@ import { ExperimentUpstreamSchema } from '@/lib/ai-gateway/experiments/upstream-
 import { EXPERIMENTED_PUBLIC_IDS_REDIS_KEY } from '@/lib/redis-keys';
 import { redisSet } from '@/lib/redis';
 import { TRPCError } from '@trpc/server';
-import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import * as z from 'zod';
 
 type TrpcErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
@@ -267,6 +267,19 @@ const SetArchivedSchema = idSchema.extend({
   archived: z.boolean(),
 });
 
+const ListRequestsSchema = z
+  .object({
+    page: z.number().int().min(1).default(1),
+    limit: z.union([z.literal(10), z.literal(25), z.literal(50), z.literal(100)]).default(25),
+    experimentId: z.string().uuid().optional(),
+    variantId: z.string().uuid().optional(),
+    clientRequestId: z.string().trim().min(1).max(200).optional(),
+    requestKind: z.enum(['chat_completions', 'messages', 'responses']).optional(),
+    outcome: z.enum(['all', 'success', 'error']).default('all'),
+    bodyState: z.enum(['all', 'available', 'truncated', 'failed', 'deleted']).default('all'),
+  })
+  .optional();
+
 export const adminModelExperimentsRouter = createTRPCRouter({
   // ---- Experiment-level ------------------------------------------------
 
@@ -282,51 +295,119 @@ export const adminModelExperimentsRouter = createTRPCRouter({
       return { items: rows };
     }),
 
-  listRequests: adminProcedure.query(async () => {
-    const rows = await db
-      .select({
-        usageId: model_experiment_request.usage_id,
-        createdAt: model_experiment_request.created_at,
-        experimentId: model_experiment.id,
-        experimentName: model_experiment.name,
-        publicModelId: model_experiment.public_model_id,
-        variantId: model_experiment_variant.id,
-        variantLabel: model_experiment_variant.label,
-        variantVersionId: model_experiment_variant_version.id,
-        allocationSubject: model_experiment_request.allocation_subject,
-        clientRequestId: model_experiment_request.client_request_id,
-        requestKind: model_experiment_request.request_kind,
-        requestBodySha256: model_experiment_request.request_body_sha256,
-        wasTruncated: model_experiment_request.was_truncated,
-        userId: microdollar_usage.kilo_user_id,
-        organizationId: microdollar_usage.organization_id,
-        requestedModel: microdollar_usage.requested_model,
-        upstreamModel: microdollar_usage.model,
-        provider: microdollar_usage.provider,
-        inferenceProvider: microdollar_usage.inference_provider,
-        inputTokens: microdollar_usage.input_tokens,
-        outputTokens: microdollar_usage.output_tokens,
-        cacheWriteTokens: microdollar_usage.cache_write_tokens,
-        cacheHitTokens: microdollar_usage.cache_hit_tokens,
-        costMicrodollars: microdollar_usage.cost,
-        cacheDiscountMicrodollars: microdollar_usage.cache_discount,
-        hasError: microdollar_usage.has_error,
-      })
-      .from(model_experiment_request)
-      .innerJoin(microdollar_usage, eq(model_experiment_request.usage_id, microdollar_usage.id))
-      .innerJoin(
-        model_experiment_variant_version,
-        eq(model_experiment_request.variant_version_id, model_experiment_variant_version.id)
-      )
-      .innerJoin(
-        model_experiment_variant,
-        eq(model_experiment_variant_version.variant_id, model_experiment_variant.id)
-      )
-      .innerJoin(model_experiment, eq(model_experiment_variant.experiment_id, model_experiment.id))
-      .orderBy(desc(model_experiment_request.created_at))
-      .limit(100);
+  listRequests: adminProcedure.input(ListRequestsSchema).query(async ({ input }) => {
+    const page = input?.page ?? 1;
+    const limit = input?.limit ?? 25;
+    const offset = (page - 1) * limit;
+    const conditions = [sql`true`];
 
-    return { items: rows };
+    if (input?.experimentId) {
+      conditions.push(eq(model_experiment.id, input.experimentId));
+    }
+    if (input?.variantId) {
+      conditions.push(eq(model_experiment_variant.id, input.variantId));
+    }
+    if (input?.clientRequestId) {
+      conditions.push(eq(model_experiment_request.client_request_id, input.clientRequestId));
+    }
+    if (input?.requestKind) {
+      conditions.push(eq(model_experiment_request.request_kind, input.requestKind));
+    }
+    if (input?.outcome === 'success') {
+      conditions.push(eq(microdollar_usage.has_error, false));
+    } else if (input?.outcome === 'error') {
+      conditions.push(eq(microdollar_usage.has_error, true));
+    }
+    if (input?.bodyState === 'available') {
+      conditions.push(
+        sql`${model_experiment_request.request_body_sha256} NOT IN ('__failed__', '__deleted__')`
+      );
+    } else if (input?.bodyState === 'truncated') {
+      conditions.push(eq(model_experiment_request.was_truncated, true));
+    } else if (input?.bodyState === 'failed') {
+      conditions.push(eq(model_experiment_request.request_body_sha256, '__failed__'));
+    } else if (input?.bodyState === 'deleted') {
+      conditions.push(eq(model_experiment_request.request_body_sha256, '__deleted__'));
+    }
+
+    const filter = and(...conditions);
+    const [totals, rows] = await Promise.all([
+      db
+        .select({ total: count() })
+        .from(model_experiment_request)
+        .innerJoin(microdollar_usage, eq(model_experiment_request.usage_id, microdollar_usage.id))
+        .innerJoin(
+          model_experiment_variant_version,
+          eq(model_experiment_request.variant_version_id, model_experiment_variant_version.id)
+        )
+        .innerJoin(
+          model_experiment_variant,
+          eq(model_experiment_variant_version.variant_id, model_experiment_variant.id)
+        )
+        .innerJoin(
+          model_experiment,
+          eq(model_experiment_variant.experiment_id, model_experiment.id)
+        )
+        .where(filter),
+      db
+        .select({
+          usageId: model_experiment_request.usage_id,
+          createdAt: model_experiment_request.created_at,
+          experimentId: model_experiment.id,
+          experimentName: model_experiment.name,
+          publicModelId: model_experiment.public_model_id,
+          variantId: model_experiment_variant.id,
+          variantLabel: model_experiment_variant.label,
+          variantVersionId: model_experiment_variant_version.id,
+          allocationSubject: model_experiment_request.allocation_subject,
+          clientRequestId: model_experiment_request.client_request_id,
+          requestKind: model_experiment_request.request_kind,
+          requestBodySha256: model_experiment_request.request_body_sha256,
+          wasTruncated: model_experiment_request.was_truncated,
+          userId: microdollar_usage.kilo_user_id,
+          organizationId: microdollar_usage.organization_id,
+          requestedModel: microdollar_usage.requested_model,
+          upstreamModel: microdollar_usage.model,
+          provider: microdollar_usage.provider,
+          inferenceProvider: microdollar_usage.inference_provider,
+          inputTokens: microdollar_usage.input_tokens,
+          outputTokens: microdollar_usage.output_tokens,
+          cacheWriteTokens: microdollar_usage.cache_write_tokens,
+          cacheHitTokens: microdollar_usage.cache_hit_tokens,
+          costMicrodollars: microdollar_usage.cost,
+          cacheDiscountMicrodollars: microdollar_usage.cache_discount,
+          hasError: microdollar_usage.has_error,
+        })
+        .from(model_experiment_request)
+        .innerJoin(microdollar_usage, eq(model_experiment_request.usage_id, microdollar_usage.id))
+        .innerJoin(
+          model_experiment_variant_version,
+          eq(model_experiment_request.variant_version_id, model_experiment_variant_version.id)
+        )
+        .innerJoin(
+          model_experiment_variant,
+          eq(model_experiment_variant_version.variant_id, model_experiment_variant.id)
+        )
+        .innerJoin(
+          model_experiment,
+          eq(model_experiment_variant.experiment_id, model_experiment.id)
+        )
+        .where(filter)
+        .orderBy(desc(model_experiment_request.created_at), desc(model_experiment_request.usage_id))
+        .limit(limit)
+        .offset(offset),
+    ]);
+
+    const total = totals[0]?.total ?? 0;
+    return {
+      items: rows,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
   }),
 
   get: adminProcedure.input(idSchema).query(async ({ input }) => {

--- a/apps/web/src/routers/admin/model-experiments-router.ts
+++ b/apps/web/src/routers/admin/model-experiments-router.ts
@@ -1,6 +1,7 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
 import {
+  kilocode_users,
   microdollar_usage,
   model_experiment,
   model_experiment_request,
@@ -365,7 +366,9 @@ export const adminModelExperimentsRouter = createTRPCRouter({
           requestBodySha256: model_experiment_request.request_body_sha256,
           wasTruncated: model_experiment_request.was_truncated,
           userId: microdollar_usage.kilo_user_id,
-          organizationId: microdollar_usage.organization_id,
+          userName: kilocode_users.google_user_name,
+          userEmail: kilocode_users.google_user_email,
+          userImageUrl: kilocode_users.google_user_image_url,
           requestedModel: microdollar_usage.requested_model,
           upstreamModel: microdollar_usage.model,
           provider: microdollar_usage.provider,
@@ -380,6 +383,7 @@ export const adminModelExperimentsRouter = createTRPCRouter({
         })
         .from(model_experiment_request)
         .innerJoin(microdollar_usage, eq(model_experiment_request.usage_id, microdollar_usage.id))
+        .leftJoin(kilocode_users, eq(microdollar_usage.kilo_user_id, kilocode_users.id))
         .innerJoin(
           model_experiment_variant_version,
           eq(model_experiment_request.variant_version_id, model_experiment_variant_version.id)


### PR DESCRIPTION
## Summary

- Makes the Experiment Requests admin tab usable for investigations by adding server-backed pagination and filters for experiment, variant, request kind, outcome, capture status, and exact client request ID.
- Adds per-row request-body downloads through an admin-authenticated endpoint that resolves the attributed R2 object on demand instead of exposing bucket access or eagerly loading prompt bodies in the table.
- Presents capture failure/deletion states directly in the table and returns truncated bodies as `.json.part` downloads so partial JSON is not mistaken for a valid document.
- Extends router coverage for pagination and combined investigation filters.

## Verification

- [x] Manual browser verification not performed in this CLI session; exercising downloads requires locally captured experiment traffic and an R2 experiment-prompts bucket/object.

## Visual Changes

### Before:

<img width="2259" height="505" alt="CleanShot 2026-05-25 at 10 40 05" src="https://github.com/user-attachments/assets/05963a87-4cda-4d44-92fa-216bfcb2c949" />


### After:
<img width="2251" height="669" alt="CleanShot 2026-05-25 at 10 35 31" src="https://github.com/user-attachments/assets/83cede2e-b9af-44c5-a7e2-edf322496769" />

## Reviewer Notes

- The download endpoint only accepts an attributed `usageId`, applies the existing admin auth gate, and looks up the server-owned SHA before reading R2; arbitrary object-key downloads are not exposed.
- Captures marked `__failed__` or `__deleted__` never trigger an R2 read, and truncated request bodies are served as text with a `.json.part` filename.
