### PR TITLE
fix(code-reviews): handle retired models

### DIFF
--- a/apps/web/src/app/api/code-reviews/up/route.test.ts
+++ b/apps/web/src/app/api/code-reviews/up/route.test.ts
@@ -192,6 +192,43 @@ describe('GET /api/code-reviews/up', () => {
     });
   });
 
+  it('returns healthy when model-not-found rows reach the error-spike threshold', async () => {
+    await db.insert(cloud_agent_code_reviews).values([
+      reviewValues({ status: 'cancelled', terminal_reason: 'model_not_found' }),
+      reviewValues({
+        status: 'failed',
+        terminal_reason: null,
+        error_message: 'Model not found: kilo/retired-model',
+      }),
+      ...Array.from({ length: 18 }, () => reviewValues()),
+    ]);
+
+    const response = await GET(makeRequest('kilo-code-reviews-health-check'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({ healthy: true, alerts: [] });
+  });
+
+  it('still returns an error-spike alert for non-model not-found failures', async () => {
+    await db
+      .insert(cloud_agent_code_reviews)
+      .values([
+        reviewValues({ status: 'failed', error_message: 'Repository not found' }),
+        reviewValues({ status: 'failed', error_message: 'Session not found' }),
+        ...Array.from({ length: 18 }, () => reviewValues()),
+      ]);
+
+    const response = await GET(makeRequest('kilo-code-reviews-health-check'));
+
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      healthy: false,
+      alerts: [expect.objectContaining({ kind: 'error_spike', errorCount: 2 })],
+    });
+  });
+
   it('ignores stale queued rows for health', async () => {
     await db.insert(cloud_agent_code_reviews).values(
       Array.from({ length: 20 }, () =>

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -1422,6 +1422,30 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
       expect(mockCreatePRComment).not.toHaveBeenCalled();
     });
 
+    it('persists the cancellation if the model-unavailable summary fails to publish', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockFindKiloReviewComment.mockResolvedValue(null);
+      mockCreatePRComment.mockRejectedValue(new Error('GitHub unavailable'));
+
+      const response = await POST(
+        makeRequest({ status: 'failed', errorMessage: 'Model not found: kilo/retired-model' }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockUpdateCodeReviewStatus).toHaveBeenCalledWith(
+        REVIEW_ID,
+        'cancelled',
+        expect.objectContaining({ terminalReason: 'model_not_found' })
+      );
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          tags: { source: 'code-review-status-model-not-found-summary' },
+        })
+      );
+    });
+
     it('creates and updates the canonical GitLab note through the same summary path', async () => {
       mockGetCodeReviewById.mockResolvedValue(
         makeReview({ platform: 'gitlab', platform_project_id: 42, check_run_id: null })

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -151,7 +151,7 @@ jest.mock('@/lib/drizzle', () => ({
   db: {
     transaction: mockDbTransaction,
   },
-  sql: jest.requireActual<typeof import('drizzle-orm')>('drizzle-orm').sql,
+  sql: (jest.requireActual('drizzle-orm') as { sql: unknown }).sql,
 }));
 
 jest.mock('@/lib/integrations/core/constants', () => ({

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -71,6 +71,11 @@ const mockCaptureMessage = jest.fn<any>();
 const mockAppendReviewSummaryFooter = jest.fn<any>();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockRetryReviewFresh = jest.fn<any>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDbExecute = jest.fn<any>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDbTransaction = jest.fn<any>();
+type MockDbTransactionCallback = (tx: { execute: typeof mockDbExecute }) => Promise<unknown>;
 
 // --- Module mocks ---
 
@@ -140,6 +145,13 @@ jest.mock('@/lib/code-reviews/summary/usage-footer', () => ({
 
 jest.mock('@/lib/constants', () => ({
   APP_URL: 'https://test.kilo.ai',
+}));
+
+jest.mock('@/lib/drizzle', () => ({
+  db: {
+    transaction: mockDbTransaction,
+  },
+  sql: jest.requireActual<typeof import('drizzle-orm')>('drizzle-orm').sql,
 }));
 
 jest.mock('@/lib/integrations/core/constants', () => ({
@@ -326,6 +338,10 @@ beforeEach(async () => {
   mockGetSessionUsageFromBilling.mockResolvedValue(null);
   mockUpdateCodeReviewUsage.mockResolvedValue(undefined);
   mockAppendReviewSummaryFooter.mockReturnValue('body with footer');
+  mockDbExecute.mockResolvedValue({ rows: [] });
+  mockDbTransaction.mockImplementation(async (callback: MockDbTransactionCallback) =>
+    callback({ execute: mockDbExecute })
+  );
   ({ POST } = await import('./route'));
 });
 
@@ -490,6 +506,76 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
           errorMessage: 'User cancelled the review',
           terminalReason: 'interrupted',
         })
+      );
+    });
+
+    it('reclassifies failed model-not-found callbacks as cancelled while preserving the error message', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockFindKiloReviewComment.mockResolvedValue(null);
+
+      const response = await POST(
+        makeRequest({
+          status: 'failed',
+          errorMessage: 'Model not found: kilo/retired-model',
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockUpdateCodeReviewAttemptForCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'cancelled',
+          errorMessage: 'Model not found: kilo/retired-model',
+          terminalReason: 'model_not_found',
+        })
+      );
+      expect(mockUpdateCodeReviewStatus).toHaveBeenCalledWith(
+        REVIEW_ID,
+        'cancelled',
+        expect.objectContaining({
+          errorMessage: 'Model not found: kilo/retired-model',
+          terminalReason: 'model_not_found',
+        })
+      );
+      expect(mockCreateInfraRetryAttemptIfMissing).not.toHaveBeenCalled();
+      expect(mockRetryReviewFresh).not.toHaveBeenCalled();
+    });
+
+    it('recognizes model-not-found messages case-insensitively but not generic not-found messages', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+
+      await POST(
+        makeRequest({ status: 'failed', errorMessage: 'MODEL NOT FOUND: kilo/retired-model' }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockUpdateCodeReviewStatus).toHaveBeenLastCalledWith(
+        REVIEW_ID,
+        'cancelled',
+        expect.objectContaining({ terminalReason: 'model_not_found' })
+      );
+
+      jest.clearAllMocks();
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockUpdateCodeReviewAttemptForCallback.mockImplementation(async params =>
+        makeAttempt({
+          status: params.status,
+          error_message: params.errorMessage ?? null,
+          terminal_reason: params.terminalReason ?? null,
+        })
+      );
+      mockGetLatestCodeReviewAttempt.mockResolvedValue(makeAttempt());
+      mockGetIntegrationById.mockResolvedValue(makeIntegration());
+
+      await POST(
+        makeRequest({ status: 'failed', errorMessage: 'Repository not found' }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockUpdateCodeReviewStatus).toHaveBeenLastCalledWith(
+        REVIEW_ID,
+        'failed',
+        expect.objectContaining({ terminalReason: undefined })
       );
     });
 
@@ -1227,6 +1313,183 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         expect.stringContaining('switch to a free model'),
         'standard'
       );
+    });
+  });
+
+  describe('model-not-found provider output', () => {
+    it('updates GitHub check runs with actionable cancelled copy', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockFindKiloReviewComment.mockResolvedValue(null);
+
+      await POST(
+        makeRequest({ status: 'failed', errorMessage: 'Model not found: kilo/retired-model' }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockUpdateCheckRun).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        12345,
+        expect.objectContaining({
+          status: 'completed',
+          conclusion: 'cancelled',
+          output: expect.objectContaining({
+            title: 'Selected model is no longer available',
+            summary: expect.stringContaining('https://app.kilo.ai/code-reviews'),
+          }),
+        }),
+        'standard'
+      );
+    });
+
+    it('updates GitLab commit status with actionable cancelled copy', async () => {
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ platform: 'gitlab', platform_project_id: 42, check_run_id: null })
+      );
+      mockFindKiloReviewNote.mockResolvedValue(null);
+
+      await POST(
+        makeRequest({ status: 'failed', errorMessage: 'Model not found: kilo/retired-model' }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockSetCommitStatus).toHaveBeenCalledWith(
+        'mock-token',
+        42,
+        'abc123',
+        'canceled',
+        expect.objectContaining({
+          description: expect.stringContaining('https://app.kilo.ai/code-reviews'),
+        }),
+        'https://gitlab.com'
+      );
+    });
+
+    it('creates the canonical GitHub summary when absent', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockFindKiloReviewComment.mockResolvedValue(null);
+
+      await POST(
+        makeRequest({ status: 'failed', errorMessage: 'Model not found: kilo/retired-model' }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockDbTransaction).toHaveBeenCalledTimes(1);
+      expect(mockFindKiloReviewComment).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        1,
+        'standard'
+      );
+      expect(mockCreatePRComment).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        1,
+        expect.stringContaining('<!-- kilo-review -->'),
+        'standard'
+      );
+      expect(mockCreatePRComment).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        1,
+        expect.stringContaining('https://app.kilo.ai/code-reviews'),
+        'standard'
+      );
+      expect(mockHasPRCommentWithMarker).not.toHaveBeenCalled();
+    });
+
+    it('updates the canonical GitHub summary when present', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockFindKiloReviewComment.mockResolvedValue({ commentId: 123, body: 'old summary' });
+
+      await POST(
+        makeRequest({ status: 'failed', errorMessage: 'Model not found: kilo/retired-model' }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockUpdateKiloReviewComment).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        123,
+        expect.stringContaining('selected model is no longer available'),
+        'standard'
+      );
+      expect(mockCreatePRComment).not.toHaveBeenCalled();
+    });
+
+    it('creates and updates the canonical GitLab note through the same summary path', async () => {
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ platform: 'gitlab', platform_project_id: 42, check_run_id: null })
+      );
+      mockFindKiloReviewNote.mockResolvedValue(null);
+
+      await POST(
+        makeRequest({ status: 'failed', errorMessage: 'Model not found: kilo/retired-model' }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockCreateMRNote).toHaveBeenCalledWith(
+        'mock-token',
+        'owner/repo',
+        1,
+        expect.stringContaining('<!-- kilo-review -->'),
+        'https://gitlab.com'
+      );
+
+      jest.clearAllMocks();
+      mockDbExecute.mockResolvedValue({ rows: [] });
+      mockDbTransaction.mockImplementation(async (callback: MockDbTransactionCallback) =>
+        callback({ execute: mockDbExecute })
+      );
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ platform: 'gitlab', platform_project_id: 42, check_run_id: null })
+      );
+      mockGetLatestCodeReviewAttempt.mockResolvedValue(makeAttempt());
+      mockGetIntegrationById.mockResolvedValue(makeIntegration());
+      mockFindKiloReviewNote.mockResolvedValue({ noteId: 321, body: 'old summary' });
+
+      await POST(
+        makeRequest({ status: 'failed', errorMessage: 'Model not found: kilo/retired-model' }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockUpdateKiloReviewNote).toHaveBeenCalledWith(
+        'mock-token',
+        'owner/repo',
+        1,
+        321,
+        expect.stringContaining('https://app.kilo.ai/code-reviews'),
+        'https://gitlab.com'
+      );
+      expect(mockCreateMRNote).not.toHaveBeenCalled();
+    });
+
+    it('serializes summary upserts before parent terminal persistence', async () => {
+      const callOrder: string[] = [];
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockFindKiloReviewComment.mockImplementation(async () => {
+        callOrder.push('find-summary');
+        return null;
+      });
+      mockCreatePRComment.mockImplementation(async () => {
+        callOrder.push('create-summary');
+      });
+      mockUpdateCodeReviewStatus.mockImplementation(async () => {
+        callOrder.push('update-parent');
+      });
+
+      await POST(
+        makeRequest({ status: 'failed', errorMessage: 'Model not found: kilo/retired-model' }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockDbExecute).toHaveBeenCalled();
+      expect(callOrder).toEqual(['find-summary', 'create-summary', 'update-parent']);
     });
   });
 

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -17,6 +17,9 @@ const mockGetCodeReviewById = jest.fn() as jest.MockedFunction<
 const mockUpdateCodeReviewStatus = jest.fn() as jest.MockedFunction<
   typeof codeReviewsDbModule.updateCodeReviewStatus
 >;
+const mockUpdateCodeReviewStatusIfNonTerminal = jest.fn() as jest.MockedFunction<
+  typeof codeReviewsDbModule.updateCodeReviewStatusIfNonTerminal
+>;
 const mockUpdateCodeReviewUsage = jest.fn() as jest.MockedFunction<
   typeof codeReviewsDbModule.updateCodeReviewUsage
 >;
@@ -71,11 +74,6 @@ const mockCaptureMessage = jest.fn<any>();
 const mockAppendReviewSummaryFooter = jest.fn<any>();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockRetryReviewFresh = jest.fn<any>();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockDbExecute = jest.fn<any>();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockDbTransaction = jest.fn<any>();
-type MockDbTransactionCallback = (tx: { execute: typeof mockDbExecute }) => Promise<unknown>;
 
 // --- Module mocks ---
 
@@ -86,6 +84,7 @@ jest.mock('@/lib/config.server', () => ({
 jest.mock('@/lib/code-reviews/db/code-reviews', () => ({
   getCodeReviewById: mockGetCodeReviewById,
   updateCodeReviewStatus: mockUpdateCodeReviewStatus,
+  updateCodeReviewStatusIfNonTerminal: mockUpdateCodeReviewStatusIfNonTerminal,
   updateCodeReviewUsage: mockUpdateCodeReviewUsage,
   getSessionUsageFromBilling: mockGetSessionUsageFromBilling,
   updateCodeReviewAttemptForCallback: mockUpdateCodeReviewAttemptForCallback,
@@ -145,13 +144,6 @@ jest.mock('@/lib/code-reviews/summary/usage-footer', () => ({
 
 jest.mock('@/lib/constants', () => ({
   APP_URL: 'https://test.kilo.ai',
-}));
-
-jest.mock('@/lib/drizzle', () => ({
-  db: {
-    transaction: mockDbTransaction,
-  },
-  sql: (jest.requireActual('drizzle-orm') as { sql: unknown }).sql,
 }));
 
 jest.mock('@/lib/integrations/core/constants', () => ({
@@ -337,11 +329,8 @@ beforeEach(async () => {
   mockUpdateKiloReviewNote.mockResolvedValue(undefined);
   mockGetSessionUsageFromBilling.mockResolvedValue(null);
   mockUpdateCodeReviewUsage.mockResolvedValue(undefined);
+  mockUpdateCodeReviewStatusIfNonTerminal.mockResolvedValue(true);
   mockAppendReviewSummaryFooter.mockReturnValue('body with footer');
-  mockDbExecute.mockResolvedValue({ rows: [] });
-  mockDbTransaction.mockImplementation(async (callback: MockDbTransactionCallback) =>
-    callback({ execute: mockDbExecute })
-  );
   ({ POST } = await import('./route'));
 });
 
@@ -529,7 +518,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
           terminalReason: 'model_not_found',
         })
       );
-      expect(mockUpdateCodeReviewStatus).toHaveBeenCalledWith(
+      expect(mockUpdateCodeReviewStatusIfNonTerminal).toHaveBeenCalledWith(
         REVIEW_ID,
         'cancelled',
         expect.objectContaining({
@@ -549,7 +538,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         makeParams(REVIEW_ID)
       );
 
-      expect(mockUpdateCodeReviewStatus).toHaveBeenLastCalledWith(
+      expect(mockUpdateCodeReviewStatusIfNonTerminal).toHaveBeenLastCalledWith(
         REVIEW_ID,
         'cancelled',
         expect.objectContaining({ terminalReason: 'model_not_found' })
@@ -1375,7 +1364,6 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         makeParams(REVIEW_ID)
       );
 
-      expect(mockDbTransaction).toHaveBeenCalledTimes(1);
       expect(mockFindKiloReviewComment).toHaveBeenCalledWith(
         'inst-1',
         'owner',
@@ -1433,7 +1421,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
       );
 
       expect(response.status).toBe(200);
-      expect(mockUpdateCodeReviewStatus).toHaveBeenCalledWith(
+      expect(mockUpdateCodeReviewStatusIfNonTerminal).toHaveBeenCalledWith(
         REVIEW_ID,
         'cancelled',
         expect.objectContaining({ terminalReason: 'model_not_found' })
@@ -1466,10 +1454,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
       );
 
       jest.clearAllMocks();
-      mockDbExecute.mockResolvedValue({ rows: [] });
-      mockDbTransaction.mockImplementation(async (callback: MockDbTransactionCallback) =>
-        callback({ execute: mockDbExecute })
-      );
+      mockUpdateCodeReviewStatusIfNonTerminal.mockResolvedValue(true);
       mockGetCodeReviewById.mockResolvedValue(
         makeReview({ platform: 'gitlab', platform_project_id: 42, check_run_id: null })
       );
@@ -1493,9 +1478,13 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
       expect(mockCreateMRNote).not.toHaveBeenCalled();
     });
 
-    it('serializes summary upserts before parent terminal persistence', async () => {
+    it('claims the terminal update before publishing a model-unavailable summary', async () => {
       const callOrder: string[] = [];
       mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockUpdateCodeReviewStatusIfNonTerminal.mockImplementation(async () => {
+        callOrder.push('update-parent');
+        return true;
+      });
       mockFindKiloReviewComment.mockImplementation(async () => {
         callOrder.push('find-summary');
         return null;
@@ -1503,17 +1492,28 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
       mockCreatePRComment.mockImplementation(async () => {
         callOrder.push('create-summary');
       });
-      mockUpdateCodeReviewStatus.mockImplementation(async () => {
-        callOrder.push('update-parent');
-      });
 
       await POST(
         makeRequest({ status: 'failed', errorMessage: 'Model not found: kilo/retired-model' }),
         makeParams(REVIEW_ID)
       );
 
-      expect(mockDbExecute).toHaveBeenCalled();
-      expect(callOrder).toEqual(['find-summary', 'create-summary', 'update-parent']);
+      expect(callOrder).toEqual(['update-parent', 'find-summary', 'create-summary']);
+    });
+
+    it('does not publish a duplicate summary if another callback claimed cancellation', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockUpdateCodeReviewStatusIfNonTerminal.mockResolvedValue(false);
+
+      const response = await POST(
+        makeRequest({ status: 'failed', errorMessage: 'Model not found: kilo/retired-model' }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockFindKiloReviewComment).not.toHaveBeenCalled();
+      expect(mockCreatePRComment).not.toHaveBeenCalled();
+      expect(mockUpdateCodeReviewStatus).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -918,7 +918,18 @@ export async function POST(
       status === 'cancelled' &&
       isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage)
     ) {
-      await upsertModelNotFoundSummary(review, integration, gitlabAccessToken);
+      try {
+        await upsertModelNotFoundSummary(review, integration, gitlabAccessToken);
+      } catch (summaryError) {
+        logExceptInTest(
+          '[code-review-status] Failed to upsert model unavailable summary:',
+          summaryError
+        );
+        captureException(summaryError, {
+          tags: { source: 'code-review-status-model-not-found-summary' },
+          extra: { reviewId, platform: review.platform || 'github' },
+        });
+      }
     }
 
     // Update review status in database

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -54,6 +54,7 @@ import {
   getValidGitLabToken,
   getStoredProjectAccessToken,
 } from '@/lib/integrations/gitlab-service';
+import { db, sql } from '@/lib/drizzle';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import { CALLBACK_TOKEN_SECRET } from '@/lib/config.server';
 import { verifyCallbackToken } from '@kilocode/worker-utils/callback-token';
@@ -139,6 +140,14 @@ function normalizePayload(raw: StatusUpdatePayload): {
     terminalReason = 'billing';
   }
 
+  if (
+    (raw.status === 'failed' || raw.status === 'interrupted') &&
+    isModelNotFoundCodeReviewTerminalReason(terminalReason, raw.errorMessage)
+  ) {
+    status = 'cancelled';
+    terminalReason = 'model_not_found';
+  }
+
   if (!terminalReason && raw.status === 'interrupted') {
     terminalReason = 'interrupted';
   }
@@ -171,6 +180,17 @@ function isBillingCodeReviewTerminalReason(
   );
 }
 
+function isModelNotFoundCodeReviewTerminalReason(
+  terminalReason?: CodeReviewTerminalReason,
+  errorMessage?: string | null
+): boolean {
+  if (terminalReason === 'model_not_found') {
+    return true;
+  }
+
+  return /\bmodel\s+not\s+found\b/i.test(errorMessage ?? '');
+}
+
 function isRetryableInfraFailure(
   status: 'running' | 'completed' | 'failed' | 'cancelled',
   terminalReason?: CodeReviewTerminalReason,
@@ -178,7 +198,9 @@ function isRetryableInfraFailure(
 ): boolean {
   if (status !== 'failed') return false;
   if (terminalReason === 'billing') return false;
+  if (terminalReason === 'model_not_found') return false;
   if (isBillingCodeReviewTerminalReason(terminalReason, errorMessage)) return false;
+  if (isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage)) return false;
 
   const message = errorMessage?.toLowerCase();
   if (!message) return false;
@@ -206,6 +228,17 @@ function isSupersededReview(review: CloudAgentCodeReview): boolean {
 }
 
 const BILLING_NOTICE_MARKER = '<!-- kilo-billing-notice -->';
+const MODEL_NOT_FOUND_SUMMARY_URL = 'https://app.kilo.ai/code-reviews';
+const MODEL_NOT_FOUND_CHECK_TITLE = 'Selected model is no longer available';
+const MODEL_NOT_FOUND_STATUS_SUMMARY = `The review did not run because the selected model is no longer available. Choose another model in Kilo Code review settings: ${MODEL_NOT_FOUND_SUMMARY_URL}`;
+const MODEL_NOT_FOUND_GITLAB_DESCRIPTION = `Selected model is no longer available. Choose another model: ${MODEL_NOT_FOUND_SUMMARY_URL}`;
+
+const MODEL_NOT_FOUND_SUMMARY_BODY = `<!-- kilo-review -->
+## Code Review Summary
+
+The review did not run because the selected model is no longer available.
+
+Choose another model in Kilo Code review settings: ${MODEL_NOT_FOUND_SUMMARY_URL}`;
 
 const BILLING_NOTICE_BODY = `${BILLING_NOTICE_MARKER}
 **Kilo Code Review could not run — your account is out of credits.**
@@ -308,6 +341,9 @@ function mapStatusToCheckRun(
   const reviewFailed = reviewStatus === 'completed' && gateResult === 'fail';
   const billingFailure =
     reviewStatus === 'failed' && isBillingCodeReviewTerminalReason(terminalReason, errorMessage);
+  const modelNotFoundCancellation =
+    reviewStatus === 'cancelled' &&
+    isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage);
 
   const conclusionMap: Record<string, CheckRunConclusion> = {
     completed: reviewFailed ? 'failure' : 'success',
@@ -319,7 +355,9 @@ function mapStatusToCheckRun(
     running: 'Kilo Code Review in progress',
     completed: reviewFailed ? 'Kilo Code Review found issues' : 'Kilo Code Review completed',
     failed: billingFailure ? 'Insufficient credits to run review' : 'Kilo Code Review failed',
-    cancelled: 'Kilo Code Review cancelled',
+    cancelled: modelNotFoundCancellation
+      ? MODEL_NOT_FOUND_CHECK_TITLE
+      : 'Kilo Code Review cancelled',
   };
 
   const summaryMap: Record<string, string> = {
@@ -332,7 +370,7 @@ function mapStatusToCheckRun(
       : errorMessage
         ? `Review failed: ${errorMessage}`
         : 'Review failed.',
-    cancelled: 'Review was cancelled.',
+    cancelled: modelNotFoundCancellation ? MODEL_NOT_FOUND_STATUS_SUMMARY : 'Review was cancelled.',
   };
 
   return {
@@ -371,6 +409,12 @@ function getGitLabStatusDescription(
     return 'Kilo Code Review found issues that require attention';
   }
   if (reviewStatus === 'completed') return 'Kilo Code Review completed';
+  if (
+    reviewStatus === 'cancelled' &&
+    isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage)
+  ) {
+    return MODEL_NOT_FOUND_GITLAB_DESCRIPTION;
+  }
   if (reviewStatus === 'cancelled') return 'Kilo Code Review cancelled';
   if (
     reviewStatus === 'failed' &&
@@ -384,6 +428,92 @@ function getGitLabStatusDescription(
   }
   if (reviewStatus === 'failed') return 'Kilo Code Review failed';
   return undefined;
+}
+
+async function upsertModelNotFoundSummary(
+  review: CloudAgentCodeReview,
+  integration: PlatformIntegration,
+  gitlabAccessToken?: string
+): Promise<void> {
+  const platform = review.platform || 'github';
+  const lockKey = `code-review-model-not-found-summary:${platform}:${review.repo_full_name}:${review.pr_number}`;
+
+  await db.transaction(async tx => {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`);
+
+    if (platform === 'github' && integration.platform_installation_id) {
+      const [repoOwner, repoName] = review.repo_full_name.split('/');
+      const appType: GitHubAppType = integration.github_app_type || 'standard';
+      const existing = await findKiloReviewComment(
+        integration.platform_installation_id,
+        repoOwner,
+        repoName,
+        review.pr_number,
+        appType
+      );
+
+      if (existing) {
+        await updateKiloReviewComment(
+          integration.platform_installation_id,
+          repoOwner,
+          repoName,
+          existing.commentId,
+          MODEL_NOT_FOUND_SUMMARY_BODY,
+          appType
+        );
+      } else {
+        await createPRComment(
+          integration.platform_installation_id,
+          repoOwner,
+          repoName,
+          review.pr_number,
+          MODEL_NOT_FOUND_SUMMARY_BODY,
+          appType
+        );
+      }
+
+      logExceptInTest(
+        `[code-review-status] Upserted model unavailable summary on ${review.repo_full_name}#${review.pr_number}`
+      );
+      return;
+    }
+
+    if (platform === PLATFORM.GITLAB) {
+      const instanceUrl = getGitLabInstanceUrl(integration);
+      const accessToken =
+        gitlabAccessToken ??
+        (await resolveGitLabAccessToken(integration, review.platform_project_id));
+      const existing = await findKiloReviewNote(
+        accessToken,
+        review.repo_full_name,
+        review.pr_number,
+        instanceUrl
+      );
+
+      if (existing) {
+        await updateKiloReviewNote(
+          accessToken,
+          review.repo_full_name,
+          review.pr_number,
+          existing.noteId,
+          MODEL_NOT_FOUND_SUMMARY_BODY,
+          instanceUrl
+        );
+      } else {
+        await createMRNote(
+          accessToken,
+          review.repo_full_name,
+          review.pr_number,
+          MODEL_NOT_FOUND_SUMMARY_BODY,
+          instanceUrl
+        );
+      }
+
+      logExceptInTest(
+        `[code-review-status] Upserted model unavailable summary on GitLab MR ${review.repo_full_name}!${review.pr_number}`
+      );
+    }
+  });
 }
 
 /**
@@ -781,6 +911,14 @@ export async function POST(
           throw gateCheckError;
         }
       }
+    }
+
+    if (
+      integration &&
+      status === 'cancelled' &&
+      isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage)
+    ) {
+      await upsertModelNotFoundSummary(review, integration, gitlabAccessToken);
     }
 
     // Update review status in database

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -20,6 +20,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import {
   updateCodeReviewStatus,
+  updateCodeReviewStatusIfNonTerminal,
   updateCodeReviewUsage,
   getCodeReviewById,
   getSessionUsageFromBilling,
@@ -54,7 +55,6 @@ import {
   getValidGitLabToken,
   getStoredProjectAccessToken,
 } from '@/lib/integrations/gitlab-service';
-import { db, sql } from '@/lib/drizzle';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import { CALLBACK_TOKEN_SECRET } from '@/lib/config.server';
 import { verifyCallbackToken } from '@kilocode/worker-utils/callback-token';
@@ -436,84 +436,79 @@ async function upsertModelNotFoundSummary(
   gitlabAccessToken?: string
 ): Promise<void> {
   const platform = review.platform || 'github';
-  const lockKey = `code-review-model-not-found-summary:${platform}:${review.repo_full_name}:${review.pr_number}`;
 
-  await db.transaction(async tx => {
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`);
+  if (platform === 'github' && integration.platform_installation_id) {
+    const [repoOwner, repoName] = review.repo_full_name.split('/');
+    const appType: GitHubAppType = integration.github_app_type || 'standard';
+    const existing = await findKiloReviewComment(
+      integration.platform_installation_id,
+      repoOwner,
+      repoName,
+      review.pr_number,
+      appType
+    );
 
-    if (platform === 'github' && integration.platform_installation_id) {
-      const [repoOwner, repoName] = review.repo_full_name.split('/');
-      const appType: GitHubAppType = integration.github_app_type || 'standard';
-      const existing = await findKiloReviewComment(
+    if (existing) {
+      await updateKiloReviewComment(
+        integration.platform_installation_id,
+        repoOwner,
+        repoName,
+        existing.commentId,
+        MODEL_NOT_FOUND_SUMMARY_BODY,
+        appType
+      );
+    } else {
+      await createPRComment(
         integration.platform_installation_id,
         repoOwner,
         repoName,
         review.pr_number,
+        MODEL_NOT_FOUND_SUMMARY_BODY,
         appType
       );
-
-      if (existing) {
-        await updateKiloReviewComment(
-          integration.platform_installation_id,
-          repoOwner,
-          repoName,
-          existing.commentId,
-          MODEL_NOT_FOUND_SUMMARY_BODY,
-          appType
-        );
-      } else {
-        await createPRComment(
-          integration.platform_installation_id,
-          repoOwner,
-          repoName,
-          review.pr_number,
-          MODEL_NOT_FOUND_SUMMARY_BODY,
-          appType
-        );
-      }
-
-      logExceptInTest(
-        `[code-review-status] Upserted model unavailable summary on ${review.repo_full_name}#${review.pr_number}`
-      );
-      return;
     }
 
-    if (platform === PLATFORM.GITLAB) {
-      const instanceUrl = getGitLabInstanceUrl(integration);
-      const accessToken =
-        gitlabAccessToken ??
-        (await resolveGitLabAccessToken(integration, review.platform_project_id));
-      const existing = await findKiloReviewNote(
+    logExceptInTest(
+      `[code-review-status] Upserted model unavailable summary on ${review.repo_full_name}#${review.pr_number}`
+    );
+    return;
+  }
+
+  if (platform === PLATFORM.GITLAB) {
+    const instanceUrl = getGitLabInstanceUrl(integration);
+    const accessToken =
+      gitlabAccessToken ??
+      (await resolveGitLabAccessToken(integration, review.platform_project_id));
+    const existing = await findKiloReviewNote(
+      accessToken,
+      review.repo_full_name,
+      review.pr_number,
+      instanceUrl
+    );
+
+    if (existing) {
+      await updateKiloReviewNote(
         accessToken,
         review.repo_full_name,
         review.pr_number,
+        existing.noteId,
+        MODEL_NOT_FOUND_SUMMARY_BODY,
         instanceUrl
       );
-
-      if (existing) {
-        await updateKiloReviewNote(
-          accessToken,
-          review.repo_full_name,
-          review.pr_number,
-          existing.noteId,
-          MODEL_NOT_FOUND_SUMMARY_BODY,
-          instanceUrl
-        );
-      } else {
-        await createMRNote(
-          accessToken,
-          review.repo_full_name,
-          review.pr_number,
-          MODEL_NOT_FOUND_SUMMARY_BODY,
-          instanceUrl
-        );
-      }
-
-      logExceptInTest(
-        `[code-review-status] Upserted model unavailable summary on GitLab MR ${review.repo_full_name}!${review.pr_number}`
+    } else {
+      await createMRNote(
+        accessToken,
+        review.repo_full_name,
+        review.pr_number,
+        MODEL_NOT_FOUND_SUMMARY_BODY,
+        instanceUrl
       );
     }
-  });
+
+    logExceptInTest(
+      `[code-review-status] Upserted model unavailable summary on GitLab MR ${review.repo_full_name}!${review.pr_number}`
+    );
+  }
 }
 
 /**
@@ -913,27 +908,7 @@ export async function POST(
       }
     }
 
-    if (
-      integration &&
-      status === 'cancelled' &&
-      isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage)
-    ) {
-      try {
-        await upsertModelNotFoundSummary(review, integration, gitlabAccessToken);
-      } catch (summaryError) {
-        logExceptInTest(
-          '[code-review-status] Failed to upsert model unavailable summary:',
-          summaryError
-        );
-        captureException(summaryError, {
-          tags: { source: 'code-review-status-model-not-found-summary' },
-          extra: { reviewId, platform: review.platform || 'github' },
-        });
-      }
-    }
-
-    // Update review status in database
-    await updateCodeReviewStatus(reviewId, status, {
+    const parentStatusUpdates = {
       sessionId,
       cliSessionId,
       errorMessage,
@@ -948,7 +923,44 @@ export async function POST(
         status === 'completed' || status === 'failed' || status === 'cancelled'
           ? new Date()
           : undefined,
-    });
+    };
+
+    if (
+      integration &&
+      status === 'cancelled' &&
+      isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage)
+    ) {
+      const claimedTerminalUpdate = await updateCodeReviewStatusIfNonTerminal(
+        reviewId,
+        status,
+        parentStatusUpdates
+      );
+      if (!claimedTerminalUpdate) {
+        logExceptInTest(
+          '[code-review-status] Model unavailable cancellation was already persisted, skipping summary upsert',
+          { reviewId }
+        );
+        return NextResponse.json({
+          success: true,
+          message: 'Review already in terminal state',
+        });
+      }
+
+      try {
+        await upsertModelNotFoundSummary(review, integration, gitlabAccessToken);
+      } catch (summaryError) {
+        logExceptInTest(
+          '[code-review-status] Failed to upsert model unavailable summary:',
+          summaryError
+        );
+        captureException(summaryError, {
+          tags: { source: 'code-review-status-model-not-found-summary' },
+          extra: { reviewId, platform: review.platform || 'github' },
+        });
+      }
+    } else {
+      await updateCodeReviewStatus(reviewId, status, parentStatusUpdates);
+    }
 
     logExceptInTest('[code-review-status] Updated review status', {
       reviewId,

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -198,7 +198,6 @@ function isRetryableInfraFailure(
 ): boolean {
   if (status !== 'failed') return false;
   if (terminalReason === 'billing') return false;
-  if (terminalReason === 'model_not_found') return false;
   if (isBillingCodeReviewTerminalReason(terminalReason, errorMessage)) return false;
   if (isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage)) return false;
 

--- a/apps/web/src/lib/code-reviews/alerting/detectors.test.ts
+++ b/apps/web/src/lib/code-reviews/alerting/detectors.test.ts
@@ -228,12 +228,54 @@ describe('code review alert detectors', () => {
   it('excludes benign terminal reasons from error-spike counts', async () => {
     await insertReviews([
       reviewValues({ status: 'failed', terminal_reason: 'billing' }),
+      reviewValues({ status: 'cancelled', terminal_reason: 'model_not_found' }),
       reviewValues({ status: 'cancelled', terminal_reason: 'user_cancelled' }),
       reviewValues({ status: 'cancelled', terminal_reason: 'superseded' }),
-      ...Array.from({ length: 17 }, () => reviewValues()),
+      ...Array.from({ length: 16 }, () => reviewValues()),
     ]);
 
     await expect(evaluateErrorSpike(db)).resolves.toEqual({ tripped: false });
+  });
+
+  it('excludes legacy model-not-found failed rows from error-spike counts', async () => {
+    await insertReviews([
+      reviewValues({
+        status: 'failed',
+        terminal_reason: null,
+        error_message: 'Model not found: x',
+      }),
+      reviewValues({
+        status: 'failed',
+        terminal_reason: null,
+        error_message: 'model not found: y',
+      }),
+      ...Array.from({ length: 18 }, () => reviewValues()),
+    ]);
+
+    await expect(evaluateErrorSpike(db)).resolves.toEqual({ tripped: false });
+  });
+
+  it('continues counting non-model not-found failures as errors', async () => {
+    await insertReviews([
+      reviewValues({
+        status: 'failed',
+        terminal_reason: null,
+        error_message: 'Repository not found',
+      }),
+      reviewValues({ status: 'failed', terminal_reason: null, error_message: 'Session not found' }),
+      ...Array.from({ length: 18 }, () => reviewValues()),
+    ]);
+
+    await expect(evaluateErrorSpike(db)).resolves.toMatchObject({
+      tripped: true,
+      details: {
+        kind: 'error_spike',
+        startedCount: 20,
+        errorCount: 2,
+        topReason: 'unknown',
+        topReasonCount: 2,
+      },
+    });
   });
 
   it('counts interrupted and cancelled interrupted reviews as error spikes', async () => {

--- a/apps/web/src/lib/code-reviews/alerting/detectors.ts
+++ b/apps/web/src/lib/code-reviews/alerting/detectors.ts
@@ -58,12 +58,17 @@ const systemFailureSql = sql`(
   status IN ('failed', 'interrupted')
   OR (status = 'cancelled' AND terminal_reason IS NOT NULL)
 )`;
+const modelNotFoundSql = sql`(
+  COALESCE(terminal_reason, '') = 'model_not_found'
+  OR COALESCE(error_message, '') ILIKE '%model not found%'
+)`;
 
 const startedReviewsCteSql = sql`
   started_reviews AS (
     SELECT
       status,
       terminal_reason,
+      error_message,
       COALESCE(started_at, updated_at, created_at) AS started_at_effective,
       COALESCE(completed_at, updated_at) AS completed_at_effective
     FROM ${cloud_agent_code_reviews}
@@ -135,6 +140,7 @@ export async function evaluateErrorSpike(database: AlertingDb): Promise<CodeRevi
       FROM windowed
       WHERE ${systemFailureSql}
         AND COALESCE(terminal_reason, '') NOT IN ${benignTerminalReasonsSql}
+        AND NOT ${modelNotFoundSql}
       GROUP BY 1
       ORDER BY 2 DESC, 1 ASC
       LIMIT 1
@@ -144,6 +150,7 @@ export async function evaluateErrorSpike(database: AlertingDb): Promise<CodeRevi
       COUNT(*) FILTER (
         WHERE ${systemFailureSql}
           AND COALESCE(terminal_reason, '') NOT IN ${benignTerminalReasonsSql}
+          AND NOT ${modelNotFoundSql}
       ) AS error_count,
       (SELECT reason FROM top_reason) AS top_reason,
       (SELECT count FROM top_reason) AS top_reason_count

--- a/apps/web/src/lib/integrations/platforms/github/adapter.find-kilo-review-comment.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.find-kilo-review-comment.test.ts
@@ -8,13 +8,11 @@ process.env.GITHUB_APP_PRIVATE_KEY = 'test-private-key';
 process.env.GITHUB_LITE_APP_ID = 'test-lite-app-id';
 process.env.GITHUB_LITE_APP_PRIVATE_KEY = 'test-lite-private-key';
 
-const mockPaginate = jest.fn();
 const mockListComments = jest.fn();
 
 jest.mock('@octokit/rest', () => ({
   Octokit: jest.fn().mockImplementation(() => ({
     issues: { listComments: mockListComments },
-    paginate: mockPaginate,
   })),
 }));
 
@@ -25,40 +23,68 @@ jest.mock('@octokit/auth-app', () => ({
 import { findKiloReviewComment } from './adapter';
 
 beforeEach(() => {
-  mockPaginate.mockReset();
   mockListComments.mockReset();
 });
 
 describe('findKiloReviewComment', () => {
   it('finds a marked Kilo review comment across paginated issue comments', async () => {
-    mockPaginate.mockResolvedValueOnce([
-      {
-        id: 1,
-        body: 'ordinary discussion',
-        updated_at: '2026-05-01T00:00:00Z',
-      },
-      {
-        id: 2,
-        body: '<!-- kilo-review -->\n## Code Review Summary\nOlder summary',
-        updated_at: '2026-05-02T00:00:00Z',
-      },
-      {
-        id: 3,
-        body: '<!-- kilo-review -->\n## Code Review Summary\nLatest summary',
-        updated_at: '2026-05-03T00:00:00Z',
-      },
-    ]);
+    mockListComments
+      .mockResolvedValueOnce({
+        data: Array.from({ length: 100 }, (_, index) => ({
+          id: index + 1,
+          body: 'ordinary discussion',
+          updated_at: '2026-05-01T00:00:00Z',
+        })),
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 101,
+            body: '<!-- kilo-review -->\n## Code Review Summary\nOlder summary',
+            updated_at: '2026-05-02T00:00:00Z',
+          },
+          {
+            id: 102,
+            body: '<!-- kilo-review -->\n## Code Review Summary\nLatest summary',
+            updated_at: '2026-05-03T00:00:00Z',
+          },
+        ],
+      });
 
     await expect(findKiloReviewComment('42', 'acme', 'widgets', 7)).resolves.toEqual({
-      commentId: 3,
+      commentId: 102,
       body: '<!-- kilo-review -->\n## Code Review Summary\nLatest summary',
     });
 
-    expect(mockPaginate).toHaveBeenCalledWith(mockListComments, {
+    expect(mockListComments).toHaveBeenNthCalledWith(1, {
       owner: 'acme',
       repo: 'widgets',
       issue_number: 7,
       per_page: 100,
+      page: 1,
     });
+    expect(mockListComments).toHaveBeenNthCalledWith(2, {
+      owner: 'acme',
+      repo: 'widgets',
+      issue_number: 7,
+      per_page: 100,
+      page: 2,
+    });
+  });
+
+  it('stops instead of creating a duplicate after the safe scan limit', async () => {
+    mockListComments.mockResolvedValue({
+      data: Array.from({ length: 100 }, (_, index) => ({
+        id: index + 1,
+        body: 'ordinary discussion',
+        updated_at: '2026-05-01T00:00:00Z',
+      })),
+    });
+
+    await expect(findKiloReviewComment('42', 'acme', 'widgets', 7)).rejects.toThrow(
+      'safe issue-comment scan limit'
+    );
+
+    expect(mockListComments).toHaveBeenCalledTimes(5);
   });
 });

--- a/apps/web/src/lib/integrations/platforms/github/adapter.find-kilo-review-comment.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.find-kilo-review-comment.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The GitHub adapter is globally mocked through the `@/` alias in Jest config.
+ * Import the relative module path here so this test exercises the real adapter.
+ */
+
+process.env.GITHUB_APP_ID = 'test-app-id';
+process.env.GITHUB_APP_PRIVATE_KEY = 'test-private-key';
+process.env.GITHUB_LITE_APP_ID = 'test-lite-app-id';
+process.env.GITHUB_LITE_APP_PRIVATE_KEY = 'test-lite-private-key';
+
+const mockPaginate = jest.fn();
+const mockListComments = jest.fn();
+
+jest.mock('@octokit/rest', () => ({
+  Octokit: jest.fn().mockImplementation(() => ({
+    issues: { listComments: mockListComments },
+    paginate: mockPaginate,
+  })),
+}));
+
+jest.mock('@octokit/auth-app', () => ({
+  createAppAuth: jest.fn(() => async () => ({ token: 'mock-token', expiresAt: '2099-01-01' })),
+}));
+
+import { findKiloReviewComment } from './adapter';
+
+beforeEach(() => {
+  mockPaginate.mockReset();
+  mockListComments.mockReset();
+});
+
+describe('findKiloReviewComment', () => {
+  it('finds a marked Kilo review comment across paginated issue comments', async () => {
+    mockPaginate.mockResolvedValueOnce([
+      {
+        id: 1,
+        body: 'ordinary discussion',
+        updated_at: '2026-05-01T00:00:00Z',
+      },
+      {
+        id: 2,
+        body: '<!-- kilo-review -->\n## Code Review Summary\nOlder summary',
+        updated_at: '2026-05-02T00:00:00Z',
+      },
+      {
+        id: 3,
+        body: '<!-- kilo-review -->\n## Code Review Summary\nLatest summary',
+        updated_at: '2026-05-03T00:00:00Z',
+      },
+    ]);
+
+    await expect(findKiloReviewComment('42', 'acme', 'widgets', 7)).resolves.toEqual({
+      commentId: 3,
+      body: '<!-- kilo-review -->\n## Code Review Summary\nLatest summary',
+    });
+
+    expect(mockPaginate).toHaveBeenCalledWith(mockListComments, {
+      owner: 'acme',
+      repo: 'widgets',
+      issue_number: 7,
+      per_page: 100,
+    });
+  });
+});

--- a/apps/web/src/lib/integrations/platforms/github/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.ts
@@ -444,6 +444,9 @@ export async function exchangeGitHubOAuthCode(
   };
 }
 
+const KILO_REVIEW_COMMENTS_PER_PAGE = 100;
+const MAX_KILO_REVIEW_COMMENT_PAGES = 5;
+
 /**
  * Finds an existing Kilo review comment on a PR
  * Looks for the <!-- kilo-review --> marker in issue comments
@@ -461,13 +464,22 @@ export async function findKiloReviewComment(
   const tokenData = await generateGitHubInstallationToken(installationId, appType);
   const octokit = new Octokit({ auth: tokenData.token });
 
-  // Fetch all issue comments (PR comments are issue comments in GitHub API)
-  const comments = await octokit.paginate(octokit.issues.listComments, {
-    owner,
-    repo,
-    issue_number: prNumber,
-    per_page: 100,
-  });
+  const comments: Array<{ id: number; body?: string | null; updated_at: string }> = [];
+  let reachedScanLimit = false;
+
+  for (let page = 1; page <= MAX_KILO_REVIEW_COMMENT_PAGES; page++) {
+    const { data: pageComments } = await octokit.issues.listComments({
+      owner,
+      repo,
+      issue_number: prNumber,
+      per_page: KILO_REVIEW_COMMENTS_PER_PAGE,
+      page,
+    });
+    comments.push(...pageComments);
+
+    if (pageComments.length < KILO_REVIEW_COMMENTS_PER_PAGE) break;
+    reachedScanLimit = page === MAX_KILO_REVIEW_COMMENT_PAGES;
+  }
 
   logExceptInTest('[findKiloReviewComment] Fetched comments', {
     owner,
@@ -493,6 +505,10 @@ export async function findKiloReviewComment(
       detectionMethod: 'marker',
     });
     return { commentId: latestComment.id, body: latestComment.body || '' };
+  }
+
+  if (reachedScanLimit) {
+    throw new Error('Kilo review comment lookup exceeded the safe issue-comment scan limit');
   }
 
   logExceptInTest('[findKiloReviewComment] No existing Kilo review comment found', {

--- a/apps/web/src/lib/integrations/platforms/github/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.ts
@@ -462,7 +462,7 @@ export async function findKiloReviewComment(
   const octokit = new Octokit({ auth: tokenData.token });
 
   // Fetch all issue comments (PR comments are issue comments in GitHub API)
-  const { data: comments } = await octokit.issues.listComments({
+  const comments = await octokit.paginate(octokit.issues.listComments, {
     owner,
     repo,
     issue_number: prNumber,

--- a/apps/web/src/routers/admin-code-reviews-router.test.ts
+++ b/apps/web/src/routers/admin-code-reviews-router.test.ts
@@ -87,6 +87,8 @@ describe('adminCodeReviewsRouter', () => {
     updatedAt = createdAt,
     startedAt = null,
     completedAt = null,
+    errorMessage = null,
+    terminalReason = null,
   }: {
     owner: ReviewOwner;
     status: string;
@@ -94,6 +96,8 @@ describe('adminCodeReviewsRouter', () => {
     updatedAt?: string;
     startedAt?: string | null;
     completedAt?: string | null;
+    errorMessage?: string | null;
+    terminalReason?: string | null;
   }): CodeReviewInsert {
     const sequence = reviewSequence++;
 
@@ -112,6 +116,8 @@ describe('adminCodeReviewsRouter', () => {
       agent_version: 'v2',
       started_at: startedAt,
       completed_at: completedAt,
+      error_message: errorMessage,
+      terminal_reason: terminalReason,
       created_at: createdAt,
       updated_at: updatedAt,
     };
@@ -333,6 +339,148 @@ describe('adminCodeReviewsRouter', () => {
     });
     expect(exportRows[0]).toHaveProperty('attempt_id');
     expect(exportRows[0]).toHaveProperty('attempt_status');
+  });
+
+  it('classifies final model-not-found outcomes as cancellations instead of failures', async () => {
+    const owner = { type: 'user', id: adminUser.id } satisfies ReviewOwner;
+
+    await db.insert(cloud_agent_code_reviews).values([
+      reviewValues({
+        owner,
+        status: 'failed',
+        createdAt: timestamp(700),
+        errorMessage: 'Model not found: kilo/retired-model',
+      }),
+      reviewValues({
+        owner,
+        status: 'cancelled',
+        createdAt: timestamp(710),
+        terminalReason: 'model_not_found',
+        errorMessage: 'Model not found: kilo/retired-model',
+      }),
+      reviewValues({
+        owner,
+        status: 'failed',
+        createdAt: timestamp(720),
+        terminalReason: 'timeout',
+        errorMessage: 'Execution timed out',
+      }),
+      reviewValues({ owner, status: 'completed', createdAt: timestamp(730) }),
+    ]);
+
+    const caller = await createCallerForUser(adminUser.id);
+    const overview = await caller.admin.codeReviews.getOverviewStats(filterInput());
+    const daily = await caller.admin.codeReviews.getDailyStats(filterInput());
+    const cancellations = await caller.admin.codeReviews.getCancellationAnalysis(filterInput());
+    const errors = await caller.admin.codeReviews.getErrorAnalysis(filterInput());
+    const modelSessions = await caller.admin.codeReviews.getErrorSessions({
+      ...filterInput(),
+      errorMessage: 'Model not found: kilo/retired-model',
+    });
+    const segmentation = await caller.admin.codeReviews.getUserSegmentation(filterInput());
+
+    expect(overview).toMatchObject({
+      totalReviews: 4,
+      completedCount: 1,
+      failedCount: 1,
+      cancelledCount: 2,
+    });
+    expect(daily[0]).toMatchObject({ completed: 1, failed: 1, cancelled: 2 });
+    expect(cancellations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ reason: 'Model no longer available', count: 2 }),
+      ])
+    );
+    expect(errors.details).toEqual([
+      expect.objectContaining({ errorType: 'Execution timed out', count: 1 }),
+    ]);
+    expect(modelSessions).toEqual([]);
+    expect(segmentation.ownershipBreakdown[0]).toMatchObject({ failed: 1 });
+  });
+
+  it('classifies all-attempt model-not-found outcomes as cancellations instead of failures', async () => {
+    const [review] = await db
+      .insert(cloud_agent_code_reviews)
+      .values(
+        reviewValues({
+          owner: { type: 'user', id: adminUser.id },
+          status: 'completed',
+          createdAt: timestamp(700),
+          startedAt: timestamp(701),
+          completedAt: timestamp(740),
+        })
+      )
+      .returning({ id: cloud_agent_code_reviews.id });
+
+    await db.insert(cloud_agent_code_review_attempts).values([
+      {
+        code_review_id: review.id,
+        attempt_number: 1,
+        status: 'failed',
+        error_message: 'Model not found: kilo/retired-model',
+        created_at: timestamp(701),
+        started_at: timestamp(702),
+        completed_at: timestamp(703),
+      },
+      {
+        code_review_id: review.id,
+        attempt_number: 2,
+        status: 'cancelled',
+        terminal_reason: 'model_not_found',
+        error_message: 'Model not found: kilo/retired-model',
+        created_at: timestamp(704),
+        started_at: timestamp(705),
+        completed_at: timestamp(706),
+      },
+      {
+        code_review_id: review.id,
+        attempt_number: 3,
+        status: 'failed',
+        terminal_reason: 'timeout',
+        error_message: 'Execution timed out',
+        created_at: timestamp(707),
+        started_at: timestamp(708),
+        completed_at: timestamp(709),
+      },
+      {
+        code_review_id: review.id,
+        attempt_number: 4,
+        status: 'completed',
+        created_at: timestamp(710),
+        started_at: timestamp(711),
+        completed_at: timestamp(740),
+      },
+    ]);
+
+    const input = filterInput({ retryAccountingMode: 'all_attempts' });
+    const caller = await createCallerForUser(adminUser.id);
+    const overview = await caller.admin.codeReviews.getOverviewStats(input);
+    const daily = await caller.admin.codeReviews.getDailyStats(input);
+    const cancellations = await caller.admin.codeReviews.getCancellationAnalysis(input);
+    const errors = await caller.admin.codeReviews.getErrorAnalysis(input);
+    const modelSessions = await caller.admin.codeReviews.getErrorSessions({
+      ...input,
+      errorMessage: 'Model not found: kilo/retired-model',
+    });
+    const segmentation = await caller.admin.codeReviews.getUserSegmentation(input);
+
+    expect(overview).toMatchObject({
+      totalReviews: 4,
+      completedCount: 1,
+      failedCount: 1,
+      cancelledCount: 2,
+    });
+    expect(daily[0]).toMatchObject({ completed: 1, failed: 1, cancelled: 2 });
+    expect(cancellations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ reason: 'Model no longer available', count: 2 }),
+      ])
+    );
+    expect(errors.details).toEqual([
+      expect.objectContaining({ errorType: 'Execution timed out', count: 1 }),
+    ]);
+    expect(modelSessions).toEqual([]);
+    expect(segmentation.ownershipBreakdown[0]).toMatchObject({ failed: 1 });
   });
 
   it('returns ownership wait breakdown and daily trend series', async () => {

--- a/apps/web/src/routers/admin-code-reviews-router.ts
+++ b/apps/web/src/routers/admin-code-reviews-router.ts
@@ -36,6 +36,16 @@ const isBillingAttemptError = sql`(
   OR ${cloud_agent_code_review_attempts.error_message} ILIKE '%Credits Required%'
 )`;
 
+const isModelNotFound = sql`(
+  ${cloud_agent_code_reviews.terminal_reason} = 'model_not_found'
+  OR ${cloud_agent_code_reviews.error_message} ILIKE '%model not found%'
+)`;
+
+const isModelNotFoundAttempt = sql`(
+  ${cloud_agent_code_review_attempts.terminal_reason} = 'model_not_found'
+  OR ${cloud_agent_code_review_attempts.error_message} ILIKE '%model not found%'
+)`;
+
 /**
  * SQL condition to exclude billing errors from failure metrics.
  * Uses COALESCE to handle NULL error_message (NULL NOT LIKE returns NULL, not TRUE).
@@ -51,6 +61,12 @@ const excludeBillingAttemptErrors = sql`COALESCE(${cloud_agent_code_review_attem
   AND COALESCE(${cloud_agent_code_review_attempts.error_message}, '') NOT ILIKE '%paid model%'
   AND COALESCE(${cloud_agent_code_review_attempts.error_message}, '') NOT ILIKE '%add credits%'
   AND COALESCE(${cloud_agent_code_review_attempts.error_message}, '') NOT ILIKE '%Credits Required%'`;
+
+const excludeModelNotFound = sql`COALESCE(${cloud_agent_code_reviews.terminal_reason}, '') <> 'model_not_found'
+  AND COALESCE(${cloud_agent_code_reviews.error_message}, '') NOT ILIKE '%model not found%'`;
+
+const excludeModelNotFoundAttempt = sql`COALESCE(${cloud_agent_code_review_attempts.terminal_reason}, '') <> 'model_not_found'
+  AND COALESCE(${cloud_agent_code_review_attempts.error_message}, '') NOT ILIKE '%model not found%'`;
 
 /**
  * Categorize error messages into high-level buckets via SQL CASE WHEN.
@@ -280,6 +296,12 @@ export const adminCodeReviewsRouter = createTRPCRouter({
       input.retryAccountingMode === 'all_attempts'
         ? excludeBillingAttemptErrors
         : excludeBillingErrors;
+    const excludeModelUnavailable =
+      input.retryAccountingMode === 'all_attempts'
+        ? excludeModelNotFoundAttempt
+        : excludeModelNotFound;
+    const modelUnavailable =
+      input.retryAccountingMode === 'all_attempts' ? isModelNotFoundAttempt : isModelNotFound;
     const durationStartedAt =
       input.retryAccountingMode === 'all_attempts'
         ? cloud_agent_code_review_attempts.started_at
@@ -308,8 +330,8 @@ export const adminCodeReviewsRouter = createTRPCRouter({
         total_reviews: sql<number>`COUNT(*)`,
         completed_count: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'completed')`,
         // Exclude billing errors from system failure count — they get their own KPI
-        failed_count: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'failed' AND ${excludeBilling})`,
-        cancelled_count: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'cancelled')`,
+        failed_count: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'failed' AND ${excludeBilling} AND ${excludeModelUnavailable})`,
+        cancelled_count: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'cancelled' OR (${statusTable.status} = 'failed' AND ${modelUnavailable}))`,
         interrupted_count: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'interrupted')`,
         in_progress_count: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} IN ('pending', 'queued', 'running'))`,
         avg_duration_seconds: sql<number>`AVG(EXTRACT(EPOCH FROM (${durationCompletedAt}::timestamp - ${durationStartedAt}::timestamp))) FILTER (WHERE ${durationCompletedAt} IS NOT NULL AND ${durationStartedAt} IS NOT NULL)`,
@@ -392,6 +414,12 @@ export const adminCodeReviewsRouter = createTRPCRouter({
       input.retryAccountingMode === 'all_attempts'
         ? excludeBillingAttemptErrors
         : excludeBillingErrors;
+    const excludeModelUnavailable =
+      input.retryAccountingMode === 'all_attempts'
+        ? excludeModelNotFoundAttempt
+        : excludeModelNotFound;
+    const modelUnavailable =
+      input.retryAccountingMode === 'all_attempts' ? isModelNotFoundAttempt : isModelNotFound;
 
     const query = db
       .select({
@@ -399,8 +427,8 @@ export const adminCodeReviewsRouter = createTRPCRouter({
         total: sql<number>`COUNT(*)`,
         completed: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'completed')`,
         // Exclude billing errors from system failure count
-        failed: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'failed' AND ${excludeBilling})`,
-        cancelled: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'cancelled')`,
+        failed: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'failed' AND ${excludeBilling} AND ${excludeModelUnavailable})`,
+        cancelled: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'cancelled' OR (${statusTable.status} = 'failed' AND ${modelUnavailable}))`,
         interrupted: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'interrupted')`,
         in_progress: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} IN ('pending', 'queued', 'running'))`,
         billing_errors: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'failed' AND ${billingError})`,
@@ -442,12 +470,16 @@ export const adminCodeReviewsRouter = createTRPCRouter({
         ? cloud_agent_code_review_attempts
         : cloud_agent_code_reviews;
 
+    const modelUnavailable =
+      input.retryAccountingMode === 'all_attempts' ? isModelNotFoundAttempt : isModelNotFound;
+
     const conditions = [
-      eq(statusTable.status, 'cancelled'),
+      sql`(${statusTable.status} = 'cancelled' OR (${statusTable.status} = 'failed' AND ${modelUnavailable}))`,
       ...buildBaseConditions(input),
     ] as SQL[];
 
     const cancellationReasonExpr = sql<string>`CASE
+      WHEN ${statusTable.terminal_reason} = 'model_not_found' OR ${statusTable.error_message} ILIKE '%model not found%' THEN 'Model no longer available'
       WHEN ${statusTable.terminal_reason} = 'superseded' OR ${statusTable.error_message} ILIKE '%superseded%' THEN 'Superseded by new commit'
       WHEN ${statusTable.error_message} ILIKE '%stream timeout%' THEN 'Stream timeout'
       WHEN ${statusTable.terminal_reason} = 'user_cancelled' OR ${statusTable.error_message} ILIKE '%cancelled%' OR ${statusTable.error_message} ILIKE '%canceled%' THEN 'Explicitly cancelled'
@@ -506,10 +538,15 @@ export const adminCodeReviewsRouter = createTRPCRouter({
       input.retryAccountingMode === 'all_attempts'
         ? excludeBillingAttemptErrors
         : excludeBillingErrors;
+    const excludeModelUnavailable =
+      input.retryAccountingMode === 'all_attempts'
+        ? excludeModelNotFoundAttempt
+        : excludeModelNotFound;
 
     const conditions = [
       eq(statusTable.status, 'failed'),
       excludeBilling,
+      excludeModelUnavailable,
       ...buildBaseConditions(input),
     ] as SQL[];
 
@@ -598,10 +635,15 @@ export const adminCodeReviewsRouter = createTRPCRouter({
       input.retryAccountingMode === 'all_attempts'
         ? excludeBillingAttemptErrors
         : excludeBillingErrors;
+    const excludeModelUnavailable =
+      input.retryAccountingMode === 'all_attempts'
+        ? excludeModelNotFoundAttempt
+        : excludeModelNotFound;
 
     const conditions = [
       eq(statusTable.status, 'failed'),
       excludeBilling,
+      excludeModelUnavailable,
       eq(
         sql`COALESCE(SUBSTRING(${errorMessageColumn} FROM 1 FOR 200), 'Unknown Error')`,
         errorMessage
@@ -682,6 +724,10 @@ export const adminCodeReviewsRouter = createTRPCRouter({
       input.retryAccountingMode === 'all_attempts'
         ? excludeBillingAttemptErrors
         : excludeBillingErrors;
+    const excludeModelUnavailable =
+      input.retryAccountingMode === 'all_attempts'
+        ? excludeModelNotFoundAttempt
+        : excludeModelNotFound;
     const waitCondition =
       input.retryAccountingMode === 'all_attempts'
         ? validAttemptStartedWaitCondition
@@ -696,7 +742,7 @@ export const adminCodeReviewsRouter = createTRPCRouter({
         count: sql<number>`COUNT(*)`,
         completed: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'completed')`,
         // Exclude billing errors from failed count
-        failed: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'failed' AND ${excludeBilling})`,
+        failed: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'failed' AND ${excludeBilling} AND ${excludeModelUnavailable})`,
         wait_started_count: sql<number>`COUNT(*) FILTER (WHERE ${waitCondition})`,
         avg_wait_seconds: sql<number>`AVG(${waitSeconds}) FILTER (WHERE ${waitCondition})`,
         p95_wait_seconds: sql<number>`percentile_cont(0.95) WITHIN GROUP (ORDER BY ${waitSeconds}) FILTER (WHERE ${waitCondition})`,

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1221,6 +1221,7 @@ export type StripeSubscriptionStatus =
  */
 export const CODE_REVIEW_TERMINAL_REASONS = [
   'billing',
+  'model_not_found',
   'user_cancelled',
   'superseded',
   'interrupted',
@@ -1243,6 +1244,7 @@ export type CodeReviewTerminalReason = (typeof CODE_REVIEW_TERMINAL_REASONS)[num
  */
 export const CODE_REVIEW_BENIGN_TERMINAL_REASONS = [
   'billing',
+  'model_not_found',
   'user_cancelled',
   'superseded',
 ] as const satisfies readonly CodeReviewTerminalReason[];

--- a/packages/worker-utils/src/cloud-agent-next-client.ts
+++ b/packages/worker-utils/src/cloud-agent-next-client.ts
@@ -118,6 +118,7 @@ export type CloudAgentInterruptOutput = {
  */
 export type CloudAgentTerminalReason =
   | 'billing'
+  | 'model_not_found'
   | 'user_cancelled'
   | 'superseded'
   | 'interrupted'

--- a/services/code-review-infra/src/types.ts
+++ b/services/code-review-infra/src/types.ts
@@ -103,6 +103,7 @@ export const InternalStatusResponseSchema = z.object({
   terminalReason: z
     .enum([
       'billing',
+      'model_not_found',
       'user_cancelled',
       'superseded',
       'interrupted',


### PR DESCRIPTION
## Summary
- Treat reviews that use a retired model as cancelled, not failed.
- Show a clear GitHub or GitLab status and write one review summary that tells the user to choose another model.
- Keep health checks and admin reports from counting these results as system errors, including older saved rows.

## Verification
1. Start a code review with a model that is no longer available and confirm the PR or MR shows a cancelled status.
2. Confirm the review summary says the selected model is no longer available and links to Kilo Code review settings.
3. Confirm the health check stays healthy and admin reports show this under cancellations, not errors.

## Visual Changes
N/A

## Reviewer Notes
The summary is written before the review is saved as terminal so retries can still fix provider posting failures. The summary upsert is locked per PR or MR to avoid duplicate comments.