### PR TITLE
feat(admin): preview experiment request prompts

### DIFF
--- a/.plans/experimental-models-1.md
+++ b/.plans/experimental-models-1.md
@@ -10,14 +10,14 @@
     [todo]       not started
 -->
 
-| Phase                               | Status      | Current State                                                                                                                                                                                                                      |
-| ----------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Phase 1 — Schema + Migration        | [done]      | Experiment tables exist. `model_experiment_request` is monthly range-partitioned on `created_at`, uses primary key `(usage_id, created_at)`, and stores one full-body prompt hash plus `request_kind`.                             |
-| Phase 2 — Gateway Header Capture    | [done]      | Gateway captures `x-kilo-request`, `x-kilo-session`, and `x-kilocode-machineid`, and passes the client request id, session id, machine id, and client IP into routing/usage context.                                               |
-| Phase 3 — Variant Picker + Routing  | [done]      | Experimented public ids route through the deterministic picker, load routing details from Postgres after Redis membership pre-check, and go directly to the selected partner upstream.                                             |
-| Phase 4 — Usage, Metrics, Reporting | [done-core] | Attribution rows and R2 prompt bodies are written after microdollar usage. Admin request log reads the rows inline. Live aggregate reporting and `model_experiment_request_stats` are deferred until a report consumer needs them. |
-| Phase 5 — Admin tRPC + UI           | [done-core] | Admin CRUD, state transitions, variant version hot-swap, key rotation, UI tab, and request log exist. `getLiveStats` and prompt inflation via `getPromptByHash` are still deferred.                                                |
-| Phase 6 — Specs + Tests             | [partial]   | Router, picker, prompt persistence, and partitioning tests exist. Durable spec file `.specs/model-experiments.md`, AGENTS registration, and soft-delete policy test are still owed.                                                |
+| Phase                               | Status      | Current State                                                                                                                                                                                                                               |
+| ----------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Phase 1 — Schema + Migration        | [done]      | Experiment tables exist. `model_experiment_request` is monthly range-partitioned on `created_at`, uses primary key `(usage_id, created_at)`, and stores one full-body prompt hash plus `request_kind`.                                      |
+| Phase 2 — Gateway Header Capture    | [done]      | Gateway captures `x-kilo-request`, `x-kilo-session`, and `x-kilocode-machineid`, and passes the client request id, session id, machine id, and client IP into routing/usage context.                                                        |
+| Phase 3 — Variant Picker + Routing  | [done]      | Experimented public ids route through the deterministic picker, load routing details from Postgres after Redis membership pre-check, and go directly to the selected partner upstream.                                                      |
+| Phase 4 — Usage, Metrics, Reporting | [done-core] | Attribution rows and R2 prompt bodies are written after microdollar usage. Admin request log reads the rows inline. Live aggregate reporting and `model_experiment_request_stats` are deferred until a report consumer needs them.          |
+| Phase 5 — Admin tRPC + UI           | [done-core] | Admin CRUD, state transitions, variant version hot-swap, key rotation, UI tab, and request log exist. Request log shows existing prompt-prefix metadata; `getLiveStats` and full prompt inflation via `getPromptByHash` are still deferred. |
+| Phase 6 — Specs + Tests             | [partial]   | Router, picker, prompt persistence, and partitioning tests exist. Durable spec file `.specs/model-experiments.md`, AGENTS registration, and soft-delete policy test are still owed.                                                         |
 
 **Current schema:**
 
@@ -72,7 +72,7 @@ Operational consequence: admin mutations that move experiments into or out of ro
 - `apps/web/src/lib/ai-gateway/experiments/upstream-schema.ts` — `ExperimentUpstreamSchema` (strict subset of `CustomLlmDefinitionSchema`, no `api_key`, no `extra_headers`).
 - `apps/web/src/lib/redis-keys.ts` — `EXPERIMENTED_PUBLIC_IDS_REDIS_KEY` helper used by Phase 3 membership checks and admin recomputation on routing-affecting status changes.
 - `apps/web/src/lib/redis.ts` — includes `redisDel(key)` helper.
-- `apps/web/src/routers/admin/model-experiments-router.ts` — full CRUD + state machine (`activate`, `pause`, `complete`, `setArchived`, `delete`-on-draft) + variant ops (`addVariant`, `removeVariant`, `updateVariantLabel`, `swapVariantVersion`, `rotateApiKey`). All routing-affecting mutations invalidate per-public-id cache and recompute the membership set. `encrypted_api_key` is **never** selected by `list`/`get`/`swapVariantVersion`/`rotateApiKey` — admin response shapers explicitly enumerate non-key columns. `BYOK_ENCRYPTION_KEY` missing → `INTERNAL_SERVER_ERROR` on key-touching ops.
+- `apps/web/src/routers/admin/model-experiments-router.ts` — full CRUD + state machine (`activate`, `pause`, `complete`, `setArchived`, `delete`-on-draft) + variant ops (`addVariant`, `removeVariant`, `updateVariantLabel`, `swapVariantVersion`, `rotateApiKey`). All routing-affecting mutations invalidate per-public-id cache and recompute the membership set. Request-log rows include the existing `microdollar_usage_metadata.user_prompt_prefix`, `system_prompt_prefix.system_prompt_prefix`, and `system_prompt_length` fields for compact admin previews. `encrypted_api_key` is **never** selected by `list`/`get`/`swapVariantVersion`/`rotateApiKey` — admin response shapers explicitly enumerate non-key columns. `BYOK_ENCRYPTION_KEY` missing → `INTERNAL_SERVER_ERROR` on key-touching ops.
 - Wired into `apps/web/src/routers/admin-router.ts` as `trpc.admin.modelExperiments.*`.
 - `apps/web/src/app/admin/api/model-experiments/hooks.ts` — react-query hooks for every procedure.
 - `apps/web/src/app/admin/model-experiments/ModelExperimentsContent.tsx` — list + detail (inline) + create dialog + add-variant dialog + Monaco-based hot-swap dialog (validates `ExperimentUpstreamSchema` strict before submit) + rotate-key dialog. Status badges, share = `weight / sum(weights)`, structural-edit lock for non-draft.
@@ -82,7 +82,7 @@ Operational consequence: admin mutations that move experiments into or out of ro
 **Phase 5 — deferred:**
 
 - `getLiveStats(id)` tRPC procedure — still deferred until a real aggregate reporting consumer needs a stable query/result shape.
-- `getPromptByHash(sha)` tRPC procedure and admin prompt inflation — R2 helpers exist, but the admin UI renders hashes/sentinels rather than inflating prompt content.
+- `getPromptByHash(sha)` tRPC procedure and full admin prompt inflation — R2 helpers exist, but the admin UI only renders existing prompt-prefix metadata plus the captured-body download action.
 
 > **Scope: preview/experimental models only.** This system exists to A/B test
 > unreleased model checkpoints in partnership with model providers. It is **not**

--- a/apps/web/src/app/admin/model-experiments/ModelExperimentRequestsContent.tsx
+++ b/apps/web/src/app/admin/model-experiments/ModelExperimentRequestsContent.tsx
@@ -2,7 +2,14 @@
 
 import { useState, type FormEvent } from 'react';
 import Link from 'next/link';
-import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Download } from 'lucide-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  Download,
+  Eye,
+} from 'lucide-react';
 import {
   type ModelExperimentRequestFilters,
   useModelExperiment,
@@ -13,6 +20,7 @@ import { UserAvatarLink } from '@/app/admin/components/UserAvatarLink';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Select,
   SelectContent,
@@ -60,6 +68,10 @@ function formatTokens(value: number): string {
 function formatMicrodollars(value: number | null): string {
   if (value === null) return '—';
   return value.toLocaleString();
+}
+
+function formatPromptLength(value: number | null): string {
+  return value === null ? 'unknown length' : `${value.toLocaleString()} chars`;
 }
 
 function isRequestKind(
@@ -158,6 +170,53 @@ function PromptDownload({
         Download JSON
       </a>
     </Button>
+  );
+}
+
+function PromptPreview({
+  userPromptPrefix,
+  systemPromptPrefix,
+  systemPromptLength,
+}: {
+  userPromptPrefix: string | null;
+  systemPromptPrefix: string | null;
+  systemPromptLength: number | null;
+}) {
+  if (!userPromptPrefix && !systemPromptPrefix) {
+    return <div className="text-muted-foreground text-xs">No prompt preview captured</div>;
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="Preview" title="Preview">
+          <Eye />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="flex w-[min(36rem,calc(100vw-2rem))] flex-col gap-3 text-xs"
+      >
+        {systemPromptPrefix ? (
+          <div>
+            <div className="text-muted-foreground mb-1 font-medium">
+              System prefix · {formatPromptLength(systemPromptLength)}
+            </div>
+            <pre className="bg-muted/40 border-border text-muted-foreground max-h-56 overflow-auto rounded-md border px-2 py-1.5 font-mono whitespace-pre-wrap">
+              {systemPromptPrefix}
+            </pre>
+          </div>
+        ) : null}
+        {userPromptPrefix ? (
+          <div>
+            <div className="text-muted-foreground mb-1 font-medium">User prefix</div>
+            <pre className="bg-muted/40 border-border max-h-56 overflow-auto rounded-md border px-2 py-1.5 font-mono whitespace-pre-wrap">
+              {userPromptPrefix}
+            </pre>
+          </div>
+        ) : null}
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -422,7 +481,7 @@ export function ModelExperimentRequestsContent() {
                   <TableHead>Routing</TableHead>
                   <TableHead>Request</TableHead>
                   <TableHead>Usage</TableHead>
-                  <TableHead>Captured body</TableHead>
+                  <TableHead>Prompt</TableHead>
                   <TableHead>User</TableHead>
                 </TableRow>
               </TableHeader>
@@ -478,10 +537,17 @@ export function ModelExperimentRequestsContent() {
                       {row.hasError ? <Badge variant="destructive">error</Badge> : null}
                     </TableCell>
                     <TableCell className="min-w-48 align-top">
-                      <PromptDownload
-                        usageId={row.usageId}
-                        requestBodySha256={row.requestBodySha256}
-                      />
+                      <div className="flex flex-wrap items-center gap-2">
+                        <PromptPreview
+                          userPromptPrefix={row.userPromptPrefix}
+                          systemPromptPrefix={row.systemPromptPrefix}
+                          systemPromptLength={row.systemPromptLength}
+                        />
+                        <PromptDownload
+                          usageId={row.usageId}
+                          requestBodySha256={row.requestBodySha256}
+                        />
+                      </div>
                     </TableCell>
                     <TableCell className="min-w-48 align-top text-sm">
                       <UserLink

--- a/apps/web/src/routers/admin/model-experiments-router.ts
+++ b/apps/web/src/routers/admin/model-experiments-router.ts
@@ -3,10 +3,12 @@ import { db } from '@/lib/drizzle';
 import {
   kilocode_users,
   microdollar_usage,
+  microdollar_usage_metadata,
   model_experiment,
   model_experiment_request,
   model_experiment_variant,
   model_experiment_variant_version,
+  system_prompt_prefix,
 } from '@kilocode/db/schema';
 import { encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
 import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
@@ -380,9 +382,23 @@ export const adminModelExperimentsRouter = createTRPCRouter({
           costMicrodollars: microdollar_usage.cost,
           cacheDiscountMicrodollars: microdollar_usage.cache_discount,
           hasError: microdollar_usage.has_error,
+          userPromptPrefix: microdollar_usage_metadata.user_prompt_prefix,
+          systemPromptPrefix: system_prompt_prefix.system_prompt_prefix,
+          systemPromptLength: microdollar_usage_metadata.system_prompt_length,
         })
         .from(model_experiment_request)
         .innerJoin(microdollar_usage, eq(model_experiment_request.usage_id, microdollar_usage.id))
+        .leftJoin(
+          microdollar_usage_metadata,
+          eq(model_experiment_request.usage_id, microdollar_usage_metadata.id)
+        )
+        .leftJoin(
+          system_prompt_prefix,
+          eq(
+            microdollar_usage_metadata.system_prompt_prefix_id,
+            system_prompt_prefix.system_prompt_prefix_id
+          )
+        )
         .leftJoin(kilocode_users, eq(microdollar_usage.kilo_user_id, kilocode_users.id))
         .innerJoin(
           model_experiment_variant_version,


### PR DESCRIPTION
## Summary
- Add prompt-prefix metadata to the admin model experiment request log query.
- Show compact system/user prompt previews in a popover, keeping full R2 prompt inflation deferred.
- Update the experimental models plan to reflect request-log prompt previews.

## Verification
- Opened the admin request log locally and confirmed the preview control stays compact while the popover carries long prompt text.

## Visual Changes
- Admin experiment request rows now show an eye icon next to Download JSON for prompt preview popovers.
<img width="854" height="362" alt="CleanShot 2026-05-25 at 14 02 00" src="https://github.com/user-attachments/assets/418226a8-b89a-47c0-b241-db15ec12cb2a" />

## Reviewer Notes
- The PR intentionally uses existing microdollar prompt-prefix metadata rather than fetching full R2 prompt bodies.
