### PR TITLE
fix(cloud-agent-next): invalidate destroyed wrapper runtime

### DIFF
--- a/services/cloud-agent-next/src/execution/orchestrator.ts
+++ b/services/cloud-agent-next/src/execution/orchestrator.ts
@@ -99,7 +99,11 @@ export class ExecutionOrchestrator {
     options?: {
       onProgress?: (step: string, message: string) => void;
       onWorkspaceReady?: (ready: WorkspaceReady) => Promise<void>;
+      onSandboxDestroying?: (invalidation: PreparationInfrastructureInvalidation) => Promise<void>;
       onSandboxDestroyed?: (invalidation: PreparationInfrastructureInvalidation) => Promise<void>;
+      onSandboxDestructionUncertain?: (
+        invalidation: PreparationInfrastructureInvalidation
+      ) => Promise<void>;
     }
   ): Promise<ExecutionResult> {
     const executionId = 'executionId' in plan ? plan.executionId : undefined;
@@ -146,7 +150,9 @@ export class ExecutionOrchestrator {
         sandboxId,
         sessionId,
         phase: 'executionWorkspacePreparation',
+        onSandboxDestroying: options?.onSandboxDestroying,
         onSandboxDestroyed: options?.onSandboxDestroyed,
+        onSandboxDestructionUncertain: options?.onSandboxDestructionUncertain,
       },
       () => this.executeWithWrapperBootstrap(sandbox, plan, options)
     );

--- a/services/cloud-agent-next/src/execution/orchestrator.ts
+++ b/services/cloud-agent-next/src/execution/orchestrator.ts
@@ -31,6 +31,7 @@ import { withDORetry } from '../utils/do-retry.js';
 import { withTimeout } from '@kilocode/worker-utils';
 import {
   SANDBOX_WORKSPACE_PROBE_TIMEOUT_MESSAGE,
+  type PreparationInfrastructureInvalidation,
   withPreparationInfrastructureRecovery,
 } from '../sandbox-recovery.js';
 import { checkDiskAndCleanBeforeSetup } from '../workspace.js';
@@ -98,6 +99,7 @@ export class ExecutionOrchestrator {
     options?: {
       onProgress?: (step: string, message: string) => void;
       onWorkspaceReady?: (ready: WorkspaceReady) => Promise<void>;
+      onSandboxDestroyed?: (invalidation: PreparationInfrastructureInvalidation) => Promise<void>;
     }
   ): Promise<ExecutionResult> {
     const executionId = 'executionId' in plan ? plan.executionId : undefined;
@@ -144,6 +146,7 @@ export class ExecutionOrchestrator {
         sandboxId,
         sessionId,
         phase: 'executionWorkspacePreparation',
+        onSandboxDestroyed: options?.onSandboxDestroyed,
       },
       () => this.executeWithWrapperBootstrap(sandbox, plan, options)
     );

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -2531,6 +2531,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
           throw new Error(readyResult.error ?? 'Failed to record session readiness');
         }
       },
+      onRuntimeInvalidated: fence => this.getWrapperSupervisor().onRuntimeInvalidated(fence),
       onAccepted: delivery => this.recordRuntimeAcceptedMessage(plan, delivery),
     });
 

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -138,6 +138,15 @@ type TerminalSizeInput = {
 
 type TerminalCreateInput = Partial<TerminalSizeInput>;
 
+type UniqueMessageEventParams = {
+  executionId: EventSourceId;
+  sessionId: string;
+  streamEventType: string;
+  payload: string;
+  timestamp: number;
+  entityId: string;
+};
+
 function validateModeAgainstRuntimeAgents(
   metadata: SessionMetadata,
   mode = metadata.agent?.mode
@@ -520,7 +529,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
         getDeliveryContext: () => this.getPendingMessageDeliveryContext(),
         deliver: plan => this.executeDirectly(plan),
         ensureQueuedMessageEvent: event => {
-          this.ensureQueuedMessageEvent({
+          this.ensureUniqueMessageEvent({
             executionId: '' as EventSourceId,
             ...event,
           });
@@ -774,14 +783,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
     });
   }
 
-  private ensureTerminalMessageEvent(params: {
-    executionId: EventSourceId;
-    sessionId: string;
-    streamEventType: string;
-    payload: string;
-    timestamp: number;
-    entityId: string;
-  }): void {
+  private ensureUniqueMessageEvent(params: UniqueMessageEventParams): void {
     const eventId = this.eventQueries.insertUnique({
       executionId: params.executionId,
       sessionId: params.sessionId,
@@ -801,31 +803,8 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
     });
   }
 
-  private ensureQueuedMessageEvent(params: {
-    executionId: EventSourceId;
-    sessionId: string;
-    streamEventType: string;
-    payload: string;
-    timestamp: number;
-    entityId: string;
-  }): void {
-    const eventId = this.eventQueries.insertUnique({
-      executionId: params.executionId,
-      sessionId: params.sessionId,
-      streamEventType: params.streamEventType,
-      payload: params.payload,
-      timestamp: params.timestamp,
-      entityId: params.entityId,
-    });
-    if (eventId === null) return;
-    this.broadcastEvent({
-      id: eventId,
-      execution_id: params.executionId,
-      session_id: params.sessionId,
-      stream_event_type: params.streamEventType,
-      payload: params.payload,
-      timestamp: params.timestamp,
-    });
+  private ensureTerminalMessageEvent(params: UniqueMessageEventParams): void {
+    this.ensureUniqueMessageEvent(params);
   }
 
   /**

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -2531,6 +2531,8 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
           throw new Error(readyResult.error ?? 'Failed to record session readiness');
         }
       },
+      onRuntimeInvalidationStarted: fence =>
+        this.getWrapperSupervisor().onRuntimeInvalidationStarted(fence),
       onRuntimeInvalidated: fence => this.getWrapperSupervisor().onRuntimeInvalidated(fence),
       onAccepted: delivery => this.recordRuntimeAcceptedMessage(plan, delivery),
     });

--- a/services/cloud-agent-next/src/sandbox-recovery.test.ts
+++ b/services/cloud-agent-next/src/sandbox-recovery.test.ts
@@ -200,8 +200,10 @@ describe('sandbox recovery', () => {
     expect(mockInfo).toHaveBeenCalledWith('Destroyed sandbox after workspace Git probe timeout');
   });
 
-  it('does not report sandbox destruction when destructive recovery fails', async () => {
+  it('invalidates a prepared runtime when sandbox destruction outcome is uncertain', async () => {
     const sandbox = { destroy: vi.fn().mockRejectedValue(new Error('destroy failed')) };
+    const onSandboxDestroying = vi.fn().mockResolvedValue(undefined);
+    const onSandboxDestructionUncertain = vi.fn().mockResolvedValue(undefined);
     const onSandboxDestroyed = vi.fn().mockResolvedValue(undefined);
     const error = new Error(`${SANDBOX_WORKSPACE_PROBE_TIMEOUT_MESSAGE} after 30000ms`);
 
@@ -212,6 +214,8 @@ describe('sandbox recovery', () => {
           sandboxId: 'ses-test',
           sessionId: 'agent_test',
           phase: 'asyncPreparation',
+          onSandboxDestroying,
+          onSandboxDestructionUncertain,
           onSandboxDestroyed,
         },
         async () => {
@@ -220,8 +224,44 @@ describe('sandbox recovery', () => {
       )
     ).rejects.toBe(error);
 
+    expect(onSandboxDestroying).toHaveBeenCalledOnce();
     expect(sandbox.destroy).toHaveBeenCalledOnce();
+    expect(onSandboxDestructionUncertain).toHaveBeenCalledOnce();
     expect(onSandboxDestroyed).not.toHaveBeenCalled();
+  });
+
+  it('does not destroy a sandbox when invalidation intent cannot be recorded', async () => {
+    const sandbox = { destroy: vi.fn().mockResolvedValue(undefined) };
+    const onSandboxDestroying = vi.fn().mockRejectedValue(new Error('storage put failed'));
+    const onSandboxDestroyed = vi.fn().mockResolvedValue(undefined);
+    const error = new Error(`${SANDBOX_WORKSPACE_PROBE_TIMEOUT_MESSAGE} after 30000ms`);
+
+    await expect(
+      withPreparationInfrastructureRecovery(
+        {
+          sandbox,
+          sandboxId: 'ses-test',
+          sessionId: 'agent_test',
+          phase: 'asyncPreparation',
+          onSandboxDestroying,
+          onSandboxDestroyed,
+        },
+        async () => {
+          throw error;
+        }
+      )
+    ).rejects.toBe(error);
+
+    expect(onSandboxDestroying).toHaveBeenCalledOnce();
+    expect(sandbox.destroy).not.toHaveBeenCalled();
+    expect(onSandboxDestroyed).not.toHaveBeenCalled();
+    expect(mockWithFields).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: 'storage put failed',
+        originalError: error.message,
+        logTag: 'preparation_sandbox_destruction_prepare_failed',
+      })
+    );
   });
 
   it('keeps the original error when destroyed-sandbox notification fails', async () => {

--- a/services/cloud-agent-next/src/sandbox-recovery.test.ts
+++ b/services/cloud-agent-next/src/sandbox-recovery.test.ts
@@ -337,7 +337,7 @@ describe('sandbox recovery', () => {
         sessionId: 'agent_test',
         phase: 'asyncPreparation',
       },
-      new Error('Git clone failed')
+      getPreparationInfrastructureFailure(new Error('Git clone failed'))
     );
 
     expect(destroyed).toBe(false);

--- a/services/cloud-agent-next/src/sandbox-recovery.test.ts
+++ b/services/cloud-agent-next/src/sandbox-recovery.test.ts
@@ -169,8 +169,9 @@ describe('sandbox recovery', () => {
     );
   });
 
-  it('destroys sandbox when a workspace Git probe times out before bootstrap', async () => {
+  it('reports sandbox destruction when a workspace Git probe times out before bootstrap', async () => {
     const sandbox = { destroy: vi.fn().mockResolvedValue(undefined) };
+    const onSandboxDestroyed = vi.fn().mockResolvedValue(undefined);
     const error = new Error(`${SANDBOX_WORKSPACE_PROBE_TIMEOUT_MESSAGE} after 30000ms`);
 
     await expect(
@@ -180,6 +181,7 @@ describe('sandbox recovery', () => {
           sandboxId: 'ses-test',
           sessionId: 'agent_test',
           phase: 'asyncPreparation',
+          onSandboxDestroyed,
         },
         async () => {
           throw error;
@@ -188,10 +190,86 @@ describe('sandbox recovery', () => {
     ).rejects.toBe(error);
 
     expect(sandbox.destroy).toHaveBeenCalledOnce();
+    expect(onSandboxDestroyed).toHaveBeenCalledWith({
+      failureType: 'sandbox_workspace_probe_timeout',
+      error,
+    });
     expect(mockError).toHaveBeenCalledWith(
       'Sandbox workspace Git probe timed out; destroying sandbox'
     );
     expect(mockInfo).toHaveBeenCalledWith('Destroyed sandbox after workspace Git probe timeout');
+  });
+
+  it('does not report sandbox destruction when destructive recovery fails', async () => {
+    const sandbox = { destroy: vi.fn().mockRejectedValue(new Error('destroy failed')) };
+    const onSandboxDestroyed = vi.fn().mockResolvedValue(undefined);
+    const error = new Error(`${SANDBOX_WORKSPACE_PROBE_TIMEOUT_MESSAGE} after 30000ms`);
+
+    await expect(
+      withPreparationInfrastructureRecovery(
+        {
+          sandbox,
+          sandboxId: 'ses-test',
+          sessionId: 'agent_test',
+          phase: 'asyncPreparation',
+          onSandboxDestroyed,
+        },
+        async () => {
+          throw error;
+        }
+      )
+    ).rejects.toBe(error);
+
+    expect(sandbox.destroy).toHaveBeenCalledOnce();
+    expect(onSandboxDestroyed).not.toHaveBeenCalled();
+  });
+
+  it('keeps the original error when destroyed-sandbox notification fails', async () => {
+    const sandbox = { destroy: vi.fn().mockResolvedValue(undefined) };
+    const onSandboxDestroyed = vi.fn().mockRejectedValue(new Error('notification failed'));
+    const error = new Error(`${SANDBOX_WORKSPACE_PROBE_TIMEOUT_MESSAGE} after 30000ms`);
+
+    await expect(
+      withPreparationInfrastructureRecovery(
+        {
+          sandbox,
+          sandboxId: 'ses-test',
+          sessionId: 'agent_test',
+          phase: 'asyncPreparation',
+          onSandboxDestroyed,
+        },
+        async () => {
+          throw error;
+        }
+      )
+    ).rejects.toBe(error);
+
+    expect(sandbox.destroy).toHaveBeenCalledOnce();
+    expect(onSandboxDestroyed).toHaveBeenCalledOnce();
+  });
+
+  it('does not report unrelated preparation failures as sandbox destruction', async () => {
+    const sandbox = { destroy: vi.fn().mockResolvedValue(undefined) };
+    const onSandboxDestroyed = vi.fn().mockResolvedValue(undefined);
+    const error = new Error('Git clone failed');
+
+    await expect(
+      withPreparationInfrastructureRecovery(
+        {
+          sandbox,
+          sandboxId: 'ses-test',
+          sessionId: 'agent_test',
+          phase: 'asyncPreparation',
+          onSandboxDestroyed,
+        },
+        async () => {
+          throw error;
+        }
+      )
+    ).rejects.toBe(error);
+
+    expect(sandbox.destroy).not.toHaveBeenCalled();
+    expect(onSandboxDestroyed).not.toHaveBeenCalled();
   });
 
   it('does not destroy sandbox for unrelated errors', async () => {

--- a/services/cloud-agent-next/src/sandbox-recovery.ts
+++ b/services/cloud-agent-next/src/sandbox-recovery.ts
@@ -15,7 +15,11 @@ type RecoveryContext = {
   sandboxId: string;
   sessionId?: string;
   phase: string;
+  onSandboxDestroying?: (invalidation: PreparationInfrastructureInvalidation) => Promise<void>;
   onSandboxDestroyed?: (invalidation: PreparationInfrastructureInvalidation) => Promise<void>;
+  onSandboxDestructionUncertain?: (
+    invalidation: PreparationInfrastructureInvalidation
+  ) => Promise<void>;
 };
 
 export type PreparationInfrastructureFailure =
@@ -354,29 +358,68 @@ export async function withPreparationInfrastructureRecovery<T>(
     return await operation();
   } catch (error) {
     const failure = getPreparationInfrastructureFailure(error);
-    const destroyed = await destroySandboxAfterPreparationInfrastructureFailure(context, error);
-    if (destroyed && failure && context.onSandboxDestroyed) {
-      logger
-        .withFields({
-          sandboxId: context.sandboxId,
-          sessionId: context.sessionId,
-          phase: context.phase,
-          failureType: failure.type,
-          logTag: 'preparation_sandbox_destruction_notified',
-        })
-        .info('Reporting destroyed sandbox after preparation infrastructure failure');
-      try {
-        await context.onSandboxDestroyed({
+    const invalidation = failure
+      ? {
           failureType: failure.type,
           error,
-        });
+        }
+      : undefined;
+
+    if (invalidation && context.onSandboxDestroying) {
+      try {
+        await context.onSandboxDestroying(invalidation);
       } catch (notificationError) {
         logger
           .withFields({
             sandboxId: context.sandboxId,
             sessionId: context.sessionId,
             phase: context.phase,
-            failureType: failure.type,
+            failureType: invalidation.failureType,
+            originalError: getErrorMessage(error),
+            error: getErrorMessage(notificationError),
+            logTag: 'preparation_sandbox_destruction_prepare_failed',
+          })
+          .error('Failed to durably prepare sandbox destruction; preserving sandbox runtime');
+        throw error;
+      }
+    }
+
+    const destroyed = await destroySandboxAfterPreparationInfrastructureFailure(context, error);
+    if (!destroyed && invalidation && context.onSandboxDestructionUncertain) {
+      try {
+        await context.onSandboxDestructionUncertain(invalidation);
+      } catch (notificationError) {
+        logger
+          .withFields({
+            sandboxId: context.sandboxId,
+            sessionId: context.sessionId,
+            phase: context.phase,
+            failureType: invalidation.failureType,
+            error: getErrorMessage(notificationError),
+            logTag: 'preparation_sandbox_destruction_uncertain_notification_failed',
+          })
+          .error('Failed to invalidate runtime after uncertain sandbox destruction outcome');
+      }
+    }
+    if (destroyed && invalidation && context.onSandboxDestroyed) {
+      logger
+        .withFields({
+          sandboxId: context.sandboxId,
+          sessionId: context.sessionId,
+          phase: context.phase,
+          failureType: invalidation.failureType,
+          logTag: 'preparation_sandbox_destruction_notified',
+        })
+        .info('Reporting destroyed sandbox after preparation infrastructure failure');
+      try {
+        await context.onSandboxDestroyed(invalidation);
+      } catch (notificationError) {
+        logger
+          .withFields({
+            sandboxId: context.sandboxId,
+            sessionId: context.sessionId,
+            phase: context.phase,
+            failureType: invalidation.failureType,
             error: getErrorMessage(notificationError),
             logTag: 'preparation_sandbox_destruction_notification_failed',
           })

--- a/services/cloud-agent-next/src/sandbox-recovery.ts
+++ b/services/cloud-agent-next/src/sandbox-recovery.ts
@@ -261,9 +261,8 @@ export async function destroySandboxAfterInternalServerError(
 
 export async function destroySandboxAfterPreparationInfrastructureFailure(
   context: RecoveryContext,
-  error: unknown
+  failure: PreparationInfrastructureFailure | undefined
 ): Promise<boolean> {
-  const failure = getPreparationInfrastructureFailure(error);
   if (!failure) {
     return false;
   }
@@ -384,7 +383,7 @@ export async function withPreparationInfrastructureRecovery<T>(
       }
     }
 
-    const destroyed = await destroySandboxAfterPreparationInfrastructureFailure(context, error);
+    const destroyed = await destroySandboxAfterPreparationInfrastructureFailure(context, failure);
     if (!destroyed && invalidation && context.onSandboxDestructionUncertain) {
       try {
         await context.onSandboxDestructionUncertain(invalidation);

--- a/services/cloud-agent-next/src/sandbox-recovery.ts
+++ b/services/cloud-agent-next/src/sandbox-recovery.ts
@@ -5,14 +5,20 @@ type DestroyableSandbox = {
   destroy(): Promise<void>;
 };
 
+export type PreparationInfrastructureInvalidation = {
+  failureType: PreparationInfrastructureFailure['type'];
+  error: unknown;
+};
+
 type RecoveryContext = {
   sandbox: DestroyableSandbox;
   sandboxId: string;
   sessionId?: string;
   phase: string;
+  onSandboxDestroyed?: (invalidation: PreparationInfrastructureInvalidation) => Promise<void>;
 };
 
-type PreparationInfrastructureFailure =
+export type PreparationInfrastructureFailure =
   | {
       type: 'sandbox_internal_server_error';
       error: unknown;
@@ -347,7 +353,36 @@ export async function withPreparationInfrastructureRecovery<T>(
   try {
     return await operation();
   } catch (error) {
-    await destroySandboxAfterPreparationInfrastructureFailure(context, error);
+    const failure = getPreparationInfrastructureFailure(error);
+    const destroyed = await destroySandboxAfterPreparationInfrastructureFailure(context, error);
+    if (destroyed && failure && context.onSandboxDestroyed) {
+      logger
+        .withFields({
+          sandboxId: context.sandboxId,
+          sessionId: context.sessionId,
+          phase: context.phase,
+          failureType: failure.type,
+          logTag: 'preparation_sandbox_destruction_notified',
+        })
+        .info('Reporting destroyed sandbox after preparation infrastructure failure');
+      try {
+        await context.onSandboxDestroyed({
+          failureType: failure.type,
+          error,
+        });
+      } catch (notificationError) {
+        logger
+          .withFields({
+            sandboxId: context.sandboxId,
+            sessionId: context.sessionId,
+            phase: context.phase,
+            failureType: failure.type,
+            error: getErrorMessage(notificationError),
+            logTag: 'preparation_sandbox_destruction_notification_failed',
+          })
+          .error('Failed to report destroyed sandbox after preparation infrastructure failure');
+      }
+    }
     throw error;
   }
 }

--- a/services/cloud-agent-next/src/session/agent-runtime.test.ts
+++ b/services/cloud-agent-next/src/session/agent-runtime.test.ts
@@ -220,6 +220,7 @@ describe('AgentRuntime', () => {
       ],
     ]);
     const error = new Error('hot follow-up destroyed its sandbox');
+    const invalidationStartedFences: WrapperRunFence[] = [];
     const invalidatedFences: WrapperRunFence[] = [];
     const runtime = createAgentRuntime({
       storage,
@@ -229,15 +230,20 @@ describe('AgentRuntime', () => {
         execute: async (
           _plan: FencedWrapperDispatchRequest,
           options?: {
+            onSandboxDestroying?: (
+              invalidation: PreparationInfrastructureInvalidation
+            ) => Promise<void>;
             onSandboxDestroyed?: (
               invalidation: PreparationInfrastructureInvalidation
             ) => Promise<void>;
           }
         ) => {
-          await options?.onSandboxDestroyed?.({
-            failureType: 'sandbox_workspace_probe_timeout',
+          const invalidation = {
+            failureType: 'sandbox_workspace_probe_timeout' as const,
             error,
-          });
+          };
+          await options?.onSandboxDestroying?.(invalidation);
+          await options?.onSandboxDestroyed?.(invalidation);
           throw error;
         },
       }),
@@ -247,12 +253,22 @@ describe('AgentRuntime', () => {
 
     await expect(
       runtime.send(createPlan(), {
+        onRuntimeInvalidationStarted: async fence => {
+          invalidationStartedFences.push(fence);
+        },
         onRuntimeInvalidated: async fence => {
           invalidatedFences.push(fence);
         },
       })
     ).rejects.toBe(error);
 
+    expect(invalidationStartedFences).toEqual([
+      {
+        wrapperRunId: 'wr_hot',
+        wrapperGeneration: 3,
+        wrapperConnectionId: 'conn_hot',
+      },
+    ]);
     expect(invalidatedFences).toEqual([
       {
         wrapperRunId: 'wr_hot',

--- a/services/cloud-agent-next/src/session/agent-runtime.test.ts
+++ b/services/cloud-agent-next/src/session/agent-runtime.test.ts
@@ -4,7 +4,9 @@ import type {
   FencedWrapperDispatchRequest,
   MessageDeliveryRequest,
   WorkspaceReady,
+  WrapperRunFence,
 } from '../execution/types.js';
+import type { PreparationInfrastructureInvalidation } from '../sandbox-recovery.js';
 import { createAgentRuntime } from './agent-runtime.js';
 import { getWrapperRuntimeState } from './wrapper-runtime-state.js';
 import type { SessionMetadata } from '../persistence/session-metadata.js';
@@ -203,6 +205,61 @@ describe('AgentRuntime', () => {
       pingDeadlineAt: 8_000,
       nextPingAt: 7_000,
     });
+  });
+
+  it('reports the reused wrapper fence when destructive recovery fails a hot delivery', async () => {
+    const storage = createMemoryStorage([
+      [
+        'wrapper_runtime_state',
+        {
+          wrapperGeneration: 3,
+          wrapperConnectionId: 'conn_hot',
+          wrapperRunId: 'wr_hot',
+          noOutputDeadlineAt: 9_000,
+        },
+      ],
+    ]);
+    const error = new Error('hot follow-up destroyed its sandbox');
+    const invalidatedFences: WrapperRunFence[] = [];
+    const runtime = createAgentRuntime({
+      storage,
+      env: {} as Env,
+      getMetadata: async () => createMetadata(),
+      getOrchestratorOverride: () => ({
+        execute: async (
+          _plan: FencedWrapperDispatchRequest,
+          options?: {
+            onSandboxDestroyed?: (
+              invalidation: PreparationInfrastructureInvalidation
+            ) => Promise<void>;
+          }
+        ) => {
+          await options?.onSandboxDestroyed?.({
+            failureType: 'sandbox_workspace_probe_timeout',
+            error,
+          });
+          throw error;
+        },
+      }),
+      getSessionIdForLogs: () => 'agent_runtime',
+      sendToWrapper: () => false,
+    });
+
+    await expect(
+      runtime.send(createPlan(), {
+        onRuntimeInvalidated: async fence => {
+          invalidatedFences.push(fence);
+        },
+      })
+    ).rejects.toBe(error);
+
+    expect(invalidatedFences).toEqual([
+      {
+        wrapperRunId: 'wr_hot',
+        wrapperGeneration: 3,
+        wrapperConnectionId: 'conn_hot',
+      },
+    ]);
   });
 
   it('clears a newly allocated wrapper fence when delivery fails before readiness', async () => {

--- a/services/cloud-agent-next/src/session/agent-runtime.ts
+++ b/services/cloud-agent-next/src/session/agent-runtime.ts
@@ -7,8 +7,10 @@ import type {
   MessageDeliveryRequest,
   MessageDeliveryResult,
   WorkspaceReady,
+  WrapperRunFence,
 } from '../execution/types.js';
 import { logger } from '../logger.js';
+import type { PreparationInfrastructureInvalidation } from '../sandbox-recovery.js';
 import { stopWrapper } from '../kilo/wrapper-manager.js';
 import type { SessionMetadata } from '../persistence/session-metadata.js';
 import { generateSandboxId, getSandboxNamespace } from '../sandbox-id.js';
@@ -42,6 +44,7 @@ export type AgentRuntimeOrchestrator = {
     options?: {
       onProgress?: (step: string, message: string) => void;
       onWorkspaceReady?: (ready: WorkspaceReady) => Promise<void>;
+      onSandboxDestroyed?: (invalidation: PreparationInfrastructureInvalidation) => Promise<void>;
     }
   ): Promise<ExecutionResult>;
 };
@@ -55,6 +58,7 @@ export type AgentRuntimeSendHooks = {
   onProgress?: (step: string, message: string) => void;
   onWorkspaceReady?: (ready: WorkspaceReady) => Promise<void>;
   onAccepted?: (delivery: AgentRuntimeAcceptedDelivery) => Promise<void>;
+  onRuntimeInvalidated?: (fence: WrapperRunFence) => Promise<void>;
 };
 
 export type AgentRuntimeStopReason =
@@ -183,6 +187,13 @@ export function createAgentRuntime(dependencies: AgentRuntimeDependencies): Agen
             })
             .info('AgentRuntime wrapper workspace reported ready');
           await hooks.onWorkspaceReady?.(ready);
+        },
+        onSandboxDestroyed: async () => {
+          await hooks.onRuntimeInvalidated?.({
+            wrapperRunId: wrapperRuntimeState.wrapperRunId,
+            wrapperGeneration: wrapperRuntimeState.wrapperGeneration,
+            wrapperConnectionId: wrapperRuntimeState.wrapperConnectionId,
+          });
         },
       });
 

--- a/services/cloud-agent-next/src/session/agent-runtime.ts
+++ b/services/cloud-agent-next/src/session/agent-runtime.ts
@@ -44,7 +44,11 @@ export type AgentRuntimeOrchestrator = {
     options?: {
       onProgress?: (step: string, message: string) => void;
       onWorkspaceReady?: (ready: WorkspaceReady) => Promise<void>;
+      onSandboxDestroying?: (invalidation: PreparationInfrastructureInvalidation) => Promise<void>;
       onSandboxDestroyed?: (invalidation: PreparationInfrastructureInvalidation) => Promise<void>;
+      onSandboxDestructionUncertain?: (
+        invalidation: PreparationInfrastructureInvalidation
+      ) => Promise<void>;
     }
   ): Promise<ExecutionResult>;
 };
@@ -58,6 +62,7 @@ export type AgentRuntimeSendHooks = {
   onProgress?: (step: string, message: string) => void;
   onWorkspaceReady?: (ready: WorkspaceReady) => Promise<void>;
   onAccepted?: (delivery: AgentRuntimeAcceptedDelivery) => Promise<void>;
+  onRuntimeInvalidationStarted?: (fence: WrapperRunFence) => Promise<void>;
   onRuntimeInvalidated?: (fence: WrapperRunFence) => Promise<void>;
 };
 
@@ -188,7 +193,21 @@ export function createAgentRuntime(dependencies: AgentRuntimeDependencies): Agen
             .info('AgentRuntime wrapper workspace reported ready');
           await hooks.onWorkspaceReady?.(ready);
         },
+        onSandboxDestroying: async () => {
+          await hooks.onRuntimeInvalidationStarted?.({
+            wrapperRunId: wrapperRuntimeState.wrapperRunId,
+            wrapperGeneration: wrapperRuntimeState.wrapperGeneration,
+            wrapperConnectionId: wrapperRuntimeState.wrapperConnectionId,
+          });
+        },
         onSandboxDestroyed: async () => {
+          await hooks.onRuntimeInvalidated?.({
+            wrapperRunId: wrapperRuntimeState.wrapperRunId,
+            wrapperGeneration: wrapperRuntimeState.wrapperGeneration,
+            wrapperConnectionId: wrapperRuntimeState.wrapperConnectionId,
+          });
+        },
+        onSandboxDestructionUncertain: async () => {
           await hooks.onRuntimeInvalidated?.({
             wrapperRunId: wrapperRuntimeState.wrapperRunId,
             wrapperGeneration: wrapperRuntimeState.wrapperGeneration,

--- a/services/cloud-agent-next/src/session/message-settlement-outbox.test.ts
+++ b/services/cloud-agent-next/src/session/message-settlement-outbox.test.ts
@@ -251,6 +251,38 @@ describe('MessageSettlementOutbox', () => {
     expect(harness.callbackJobs[0].target.url).toBe('https://example.com/second');
   });
 
+  it('defers a ready callback while an unrelated callback-free terminal effect is pending', async () => {
+    const harness = createHarness();
+    await putSessionMessageState(
+      harness.storage,
+      acceptedMessageState(firstMessageId, { url: 'https://example.com/ready' })
+    );
+    await putSessionMessageState(harness.storage, {
+      ...acceptedMessageState(secondMessageId),
+      wrapperRunId: 'wr_unrelated',
+    });
+
+    await harness.outbox.terminalizeSessionMessageOnce(firstMessageId, {
+      kind: 'completed',
+      completionSource: 'assistant_message_event',
+    });
+    await harness.outbox.persistTerminalTransition(secondMessageId, {
+      kind: 'failed',
+      reason: 'wrapper_failure',
+      completionSource: 'wrapper_failure',
+    });
+    await harness.outbox.finalizeIdleBatchCallbackIfReady({
+      allowWithoutObservedIdle: true,
+    });
+
+    expect(harness.callbackJobs).toHaveLength(0);
+
+    await harness.outbox.repairTerminalEffects();
+
+    expect(harness.callbackJobs).toHaveLength(1);
+    expect(harness.callbackJobs[0].target.url).toBe('https://example.com/ready');
+  });
+
   it('keeps a repaired gate-waiting terminal callback blocked until gate wait is released', async () => {
     const harness = createHarness({
       metadata: { ...metadata, finalization: { gateThreshold: 'warning' } },

--- a/services/cloud-agent-next/src/session/message-settlement-outbox.ts
+++ b/services/cloud-agent-next/src/session/message-settlement-outbox.ts
@@ -232,6 +232,8 @@ export function createMessageSettlementOutbox(
     const now = Date.now();
     await storage.put(idleBatchCallbackKey(batch.batchId), {
       ...batch,
+      // A released runtime may never report idle after terminal-effect repair resumes later.
+      allowWithoutObservedIdle: true,
       wrapperTerminalWaitReleasedAt: now,
       updatedAt: now,
     } satisfies IdleBatchCallbackState);
@@ -442,6 +444,9 @@ export function createMessageSettlementOutbox(
 
     const acceptedMessages = await listNonTerminalAcceptedMessages(storage);
     if (acceptedMessages.length > 0) return;
+
+    const pendingTerminalEffects = await listTerminalMessagesWithPendingEffects(storage);
+    if (pendingTerminalEffects.length > 0) return;
 
     if (!options?.allowWithoutObservedIdle && !(await hasObservedWrapperIdle())) {
       return;

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
@@ -38,7 +38,10 @@ const NEWER_MESSAGE_ID = 'msg_018f1e2d3c4bNewerMsgAbCdEF';
 
 function createMemoryStorage(
   initialEntries?: Array<[string, unknown]>,
-  options?: { beforeList?: (prefix: string) => Promise<void> }
+  options?: {
+    beforeList?: (prefix: string) => Promise<void>;
+    beforePut?: (key: string, value: unknown) => Promise<void>;
+  }
 ): MemoryStorage {
   const store = new Map(initialEntries ?? []);
   return {
@@ -46,6 +49,7 @@ function createMemoryStorage(
       return store.get(key) as T | undefined;
     },
     async put(key: string, value: unknown): Promise<void> {
+      await options?.beforePut?.(key, value);
       store.set(key, value);
     },
     async delete(keys: string | string[]): Promise<void> {
@@ -94,7 +98,12 @@ function createHarness(
   initialEntries?: Array<[string, unknown]>,
   options?: {
     metadata?: SessionMetadata;
-    storageHooks?: { beforeList?: (prefix: string) => Promise<void> };
+    storageHooks?: {
+      beforeList?: (prefix: string) => Promise<void>;
+      beforePut?: (key: string, value: unknown) => Promise<void>;
+    };
+    terminalEventError?: () => Error | undefined;
+    hasObservedWrapperIdle?: () => Promise<boolean>;
   }
 ) {
   const storage = createMemoryStorage(initialEntries, options?.storageHooks);
@@ -115,9 +124,11 @@ function createHarness(
     }),
     getAssistantMessageForUserMessage: () => null,
     ensureTerminalMessageEvent: event => {
+      const terminalEventError = options?.terminalEventError?.();
+      if (terminalEventError) throw terminalEventError;
       if (!events.some(existing => existing.entityId === event.entityId)) events.push(event);
     },
-    hasObservedWrapperIdle: async () => true,
+    hasObservedWrapperIdle: options?.hasObservedWrapperIdle ?? (async () => true),
     requestAlarmAtOrBefore: async () => {},
     getSessionIdForLogs: () => currentMetadata.identity.sessionId,
   });
@@ -482,6 +493,295 @@ describe('WrapperSupervisor', () => {
       expect(harness.requestPendingDrainIfNeeded).toHaveBeenCalledOnce();
     }
   );
+
+  it('fails accepted work and invalidates its current fence when its sandbox was destroyed', async () => {
+    const harness = createHarness([liveRuntimeState()]);
+    await putSessionMessageState(harness.storage, acceptedMessage());
+
+    await harness.supervisor.onRuntimeInvalidated({
+      wrapperRunId: WRAPPER_RUN_ID,
+      wrapperGeneration: 4,
+      wrapperConnectionId: WRAPPER_CONNECTION_ID,
+    });
+
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      status: 'failed',
+      failureReason: 'wrapper_failure',
+      error: 'Wrapper runtime was destroyed during workspace preparation',
+      completionSource: 'wrapper_failure',
+    });
+    await expect(getWrapperRuntimeState(harness.storage)).resolves.toEqual({
+      wrapperGeneration: 5,
+    });
+    expect(harness.requestPendingDrainIfNeeded).not.toHaveBeenCalled();
+    expect(harness.stops).toEqual([]);
+    expect(harness.events.map(event => event.streamEventType)).toEqual(['cloud.message.failed']);
+  });
+
+  it('invalidates a destroyed fence before fallible terminal effects are repaired', async () => {
+    let terminalEventError: Error | undefined = new Error('terminal event persistence failed');
+    const harness = createHarness([liveRuntimeState()], {
+      terminalEventError: () => terminalEventError,
+    });
+    await putSessionMessageState(harness.storage, acceptedMessage());
+    await putSessionMessageState(harness.storage, acceptedMessage(NEWER_MESSAGE_ID));
+
+    await expect(
+      harness.supervisor.onRuntimeInvalidated({
+        wrapperRunId: WRAPPER_RUN_ID,
+        wrapperGeneration: 4,
+        wrapperConnectionId: WRAPPER_CONNECTION_ID,
+      })
+    ).rejects.toThrow('terminal event persistence failed');
+
+    await expect(getWrapperRuntimeState(harness.storage)).resolves.toEqual({
+      wrapperGeneration: 5,
+    });
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      status: 'failed',
+      failureReason: 'wrapper_failure',
+      completionSource: 'wrapper_failure',
+    });
+    await expect(getSessionMessageState(harness.storage, NEWER_MESSAGE_ID)).resolves.toMatchObject({
+      status: 'failed',
+      failureReason: 'wrapper_failure',
+      completionSource: 'wrapper_failure',
+    });
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 1);
+
+    terminalEventError = undefined;
+    await harness.supervisor.runMaintenance(Date.now());
+    await harness.settlementOutbox.repairTerminalEffects();
+    await harness.supervisor.runMaintenance(Date.now());
+
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 0);
+    expect(harness.events).toHaveLength(2);
+  });
+
+  it('releases callback work after destroyed-runtime terminal effects are repaired', async () => {
+    let terminalEventError: Error | undefined = new Error('terminal event persistence failed');
+    const harness = createHarness([liveRuntimeState()], {
+      terminalEventError: () => terminalEventError,
+      hasObservedWrapperIdle: async () => false,
+    });
+    await putSessionMessageState(harness.storage, {
+      ...acceptedMessage(),
+      callbackRequired: true,
+      callbackTarget: { url: 'https://example.com/destroyed-runtime-repair' },
+    });
+
+    await expect(
+      harness.supervisor.onRuntimeInvalidated({
+        wrapperRunId: WRAPPER_RUN_ID,
+        wrapperGeneration: 4,
+        wrapperConnectionId: WRAPPER_CONNECTION_ID,
+      })
+    ).rejects.toThrow('terminal event persistence failed');
+
+    terminalEventError = undefined;
+    await harness.supervisor.runMaintenance(Date.now());
+    await harness.settlementOutbox.repairTerminalEffects();
+
+    expect(harness.callbackJobs).toHaveLength(0);
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 1);
+
+    await harness.supervisor.runMaintenance(Date.now());
+
+    expect(harness.callbackJobs).toHaveLength(1);
+    expect(harness.callbackJobs[0].payload).toMatchObject({
+      messageId: MESSAGE_ID,
+      status: 'failed',
+    });
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 0);
+  });
+
+  it('does not release a newer wrapper run gate callback while recovering an old destroyed runtime', async () => {
+    const oldWrapperRunId = 'wr_destroyed_old';
+    const newerWrapperRunId = 'wr_newer_after_destroy';
+    const harness = createHarness(
+      [
+        liveRuntimeState({
+          wrapperRunId: newerWrapperRunId,
+          wrapperGeneration: 5,
+          wrapperConnectionId: 'conn_newer_after_destroy',
+        }),
+        [
+          'destroyed_runtime_invalidation:4:conn_destroyed_old',
+          {
+            wrapperRunId: oldWrapperRunId,
+            wrapperGeneration: 4,
+            wrapperConnectionId: 'conn_destroyed_old',
+            invalidatedAt: 1_000,
+          },
+        ],
+      ],
+      {
+        metadata: {
+          ...createMetadata(),
+          finalization: { gateThreshold: 'warning' },
+        },
+      }
+    );
+    await putSessionMessageState(harness.storage, {
+      ...acceptedMessage(NEWER_MESSAGE_ID),
+      wrapperRunId: newerWrapperRunId,
+      callbackRequired: true,
+      callbackTarget: { url: 'https://example.com/newer-after-destroy' },
+    });
+    await harness.settlementOutbox.terminalizeSessionMessageOnce(NEWER_MESSAGE_ID, {
+      kind: 'completed',
+      completionSource: 'assistant_message_event',
+    });
+
+    await harness.supervisor.runMaintenance(11_001);
+
+    expect(harness.callbackJobs).toHaveLength(0);
+    await expect(harness.settlementOutbox.isWaitingForWrapperTerminalGateResult()).resolves.toBe(
+      true
+    );
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 0);
+  });
+
+  it('retries destroyed-runtime settlement after accepted-message discovery fails', async () => {
+    let failAcceptedMessageScan = true;
+    const harness = createHarness([liveRuntimeState()], {
+      storageHooks: {
+        beforeList: async prefix => {
+          if (failAcceptedMessageScan && prefix.startsWith('session_message:')) {
+            failAcceptedMessageScan = false;
+            throw new Error('accepted-message scan failed');
+          }
+        },
+      },
+    });
+    await putSessionMessageState(harness.storage, acceptedMessage());
+
+    await expect(
+      harness.supervisor.onRuntimeInvalidated({
+        wrapperRunId: WRAPPER_RUN_ID,
+        wrapperGeneration: 4,
+        wrapperConnectionId: WRAPPER_CONNECTION_ID,
+      })
+    ).rejects.toThrow('accepted-message scan failed');
+
+    await expect(getWrapperRuntimeState(harness.storage)).resolves.toEqual({
+      wrapperGeneration: 5,
+    });
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 1);
+    await expect(harness.supervisor.nextMaintenanceDeadlines()).resolves.toEqual([
+      expect.any(Number),
+    ]);
+
+    await harness.supervisor.runMaintenance(Date.now());
+
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      status: 'failed',
+      failureReason: 'wrapper_failure',
+      completionSource: 'wrapper_failure',
+    });
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 0);
+  });
+
+  it('retries all destroyed-runtime terminal transitions after one state write fails', async () => {
+    let failTerminalStateWrite = true;
+    const harness = createHarness([liveRuntimeState()], {
+      storageHooks: {
+        beforePut: async (key, value) => {
+          if (
+            failTerminalStateWrite &&
+            key.startsWith('session_message:') &&
+            typeof value === 'object' &&
+            value !== null &&
+            'status' in value &&
+            value.status === 'failed'
+          ) {
+            failTerminalStateWrite = false;
+            throw new Error('terminal state write failed');
+          }
+        },
+      },
+    });
+    await putSessionMessageState(harness.storage, acceptedMessage());
+    await putSessionMessageState(harness.storage, acceptedMessage(NEWER_MESSAGE_ID));
+
+    await expect(
+      harness.supervisor.onRuntimeInvalidated({
+        wrapperRunId: WRAPPER_RUN_ID,
+        wrapperGeneration: 4,
+        wrapperConnectionId: WRAPPER_CONNECTION_ID,
+      })
+    ).rejects.toThrow('terminal state write failed');
+
+    await expect(getWrapperRuntimeState(harness.storage)).resolves.toEqual({
+      wrapperGeneration: 5,
+    });
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 1);
+
+    await harness.supervisor.runMaintenance(Date.now());
+
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      status: 'failed',
+      failureReason: 'wrapper_failure',
+      completionSource: 'wrapper_failure',
+    });
+    await expect(getSessionMessageState(harness.storage, NEWER_MESSAGE_ID)).resolves.toMatchObject({
+      status: 'failed',
+      failureReason: 'wrapper_failure',
+      completionSource: 'wrapper_failure',
+    });
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 0);
+  });
+
+  it('ignores destroyed-runtime invalidation from a stale wrapper fence', async () => {
+    const newerRunId = 'wr_newer_runtime';
+    const harness = createHarness([
+      liveRuntimeState({
+        wrapperRunId: newerRunId,
+        wrapperGeneration: 5,
+        wrapperConnectionId: 'conn_newer_runtime',
+      }),
+    ]);
+    await putSessionMessageState(harness.storage, {
+      ...acceptedMessage(NEWER_MESSAGE_ID),
+      wrapperRunId: newerRunId,
+    });
+
+    await harness.supervisor.onRuntimeInvalidated({
+      wrapperRunId: WRAPPER_RUN_ID,
+      wrapperGeneration: 4,
+      wrapperConnectionId: WRAPPER_CONNECTION_ID,
+    });
+
+    await expect(getSessionMessageState(harness.storage, NEWER_MESSAGE_ID)).resolves.toMatchObject({
+      status: 'accepted',
+      wrapperRunId: newerRunId,
+    });
+    await expect(getWrapperRuntimeState(harness.storage)).resolves.toMatchObject({
+      wrapperRunId: newerRunId,
+      wrapperGeneration: 5,
+      wrapperConnectionId: 'conn_newer_runtime',
+    });
+    expect(harness.events).toHaveLength(0);
+    expect(harness.stops).toEqual([]);
+  });
 
   it('fails accepted current work on liveness expiry without redispatch when no wrapper-local Kilo query remains', async () => {
     const harness = createHarness([

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
@@ -518,6 +518,135 @@ describe('WrapperSupervisor', () => {
     expect(harness.events.map(event => event.streamEventType)).toEqual(['cloud.message.failed']);
   });
 
+  it('persists destruction intent until runtime invalidation settles it', async () => {
+    const harness = createHarness([liveRuntimeState()]);
+    const fence = {
+      wrapperRunId: WRAPPER_RUN_ID,
+      wrapperGeneration: 4,
+      wrapperConnectionId: WRAPPER_CONNECTION_ID,
+    };
+
+    await harness.supervisor.onRuntimeInvalidationStarted(fence);
+
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 1);
+    await expect(getWrapperRuntimeState(harness.storage)).resolves.toMatchObject(fence);
+
+    await harness.supervisor.onRuntimeInvalidated(fence);
+
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 0);
+    await expect(getWrapperRuntimeState(harness.storage)).resolves.toEqual({
+      wrapperGeneration: 5,
+    });
+  });
+
+  it('recovers persisted destruction intent after post-destruction settlement fails', async () => {
+    let terminalEventError: Error | undefined = new Error('terminal event persistence failed');
+    const harness = createHarness([liveRuntimeState()], {
+      terminalEventError: () => terminalEventError,
+    });
+    const fence = {
+      wrapperRunId: WRAPPER_RUN_ID,
+      wrapperGeneration: 4,
+      wrapperConnectionId: WRAPPER_CONNECTION_ID,
+    };
+    await putSessionMessageState(harness.storage, acceptedMessage());
+
+    await harness.supervisor.onRuntimeInvalidationStarted(fence);
+    await expect(harness.supervisor.onRuntimeInvalidated(fence)).rejects.toThrow(
+      'terminal event persistence failed'
+    );
+
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 1);
+    await expect(getWrapperRuntimeState(harness.storage)).resolves.toEqual({
+      wrapperGeneration: 5,
+    });
+
+    terminalEventError = undefined;
+    await harness.supervisor.runMaintenance(Date.now());
+    await harness.settlementOutbox.repairTerminalEffects();
+    await harness.supervisor.runMaintenance(Date.now());
+
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 0);
+    expect(harness.events.map(event => event.streamEventType)).toEqual(['cloud.message.failed']);
+  });
+
+  it('rejects destruction intent for a stale fence', async () => {
+    const harness = createHarness([
+      liveRuntimeState({
+        wrapperRunId: 'wr_replacement',
+        wrapperGeneration: 5,
+        wrapperConnectionId: 'conn_replacement',
+      }),
+    ]);
+
+    await expect(
+      harness.supervisor.onRuntimeInvalidationStarted({
+        wrapperRunId: WRAPPER_RUN_ID,
+        wrapperGeneration: 4,
+        wrapperConnectionId: WRAPPER_CONNECTION_ID,
+      })
+    ).rejects.toThrow('Cannot prepare sandbox destruction for a stale wrapper runtime');
+
+    await expect(
+      harness.storage.list({ prefix: 'destroyed_runtime_invalidation:' })
+    ).resolves.toHaveProperty('size', 0);
+    await expect(getWrapperRuntimeState(harness.storage)).resolves.toMatchObject({
+      wrapperRunId: 'wr_replacement',
+      wrapperGeneration: 5,
+      wrapperConnectionId: 'conn_replacement',
+    });
+  });
+
+  it('does not finalize an earlier callback while destroyed-runtime terminal effects are pending', async () => {
+    let terminalEventError: Error | undefined;
+    const harness = createHarness([liveRuntimeState()], {
+      metadata: {
+        ...createMetadata(),
+        finalization: { gateThreshold: 'warning' },
+      },
+      terminalEventError: () => terminalEventError,
+      hasObservedWrapperIdle: async () => false,
+    });
+    await putSessionMessageState(harness.storage, {
+      ...acceptedMessage(),
+      callbackRequired: true,
+      callbackTarget: { url: 'https://example.com/already-completed' },
+    });
+    await harness.settlementOutbox.terminalizeSessionMessageOnce(MESSAGE_ID, {
+      kind: 'completed',
+      completionSource: 'assistant_message_event',
+    });
+    await putSessionMessageState(harness.storage, {
+      ...acceptedMessage(NEWER_MESSAGE_ID),
+      callbackRequired: true,
+      callbackTarget: { url: 'https://example.com/destroyed-later' },
+    });
+    terminalEventError = new Error('later terminal event persistence failed');
+
+    await expect(
+      harness.supervisor.onRuntimeInvalidated({
+        wrapperRunId: WRAPPER_RUN_ID,
+        wrapperGeneration: 4,
+        wrapperConnectionId: WRAPPER_CONNECTION_ID,
+      })
+    ).rejects.toThrow('later terminal event persistence failed');
+
+    expect(harness.callbackJobs).toHaveLength(0);
+    terminalEventError = undefined;
+    await harness.settlementOutbox.repairTerminalEffects();
+
+    expect(harness.callbackJobs).toHaveLength(1);
+    expect(harness.callbackJobs[0].target.url).toBe('https://example.com/destroyed-later');
+  });
+
   it('invalidates a destroyed fence before fallible terminal effects are repaired', async () => {
     let terminalEventError: Error | undefined = new Error('terminal event persistence failed');
     const harness = createHarness([liveRuntimeState()], {

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { WrapperRunFence } from '../execution/types.js';
 import { logger } from '../logger.js';
 import type { SessionMetadata } from '../persistence/session-metadata.js';
 import type { AgentRuntime } from './agent-runtime.js';
@@ -8,6 +9,8 @@ import { countPendingSessionMessages, type SessionQueueStorage } from './pending
 import type { SessionMessageQueue } from './session-message-queue.js';
 import {
   listNonTerminalAcceptedMessages,
+  listTerminalMessagesWithPendingEffects,
+  type SessionMessageState,
   type SessionMessageStorage,
 } from './session-message-state.js';
 import type { LatestAssistantMessage } from './types.js';
@@ -31,6 +34,16 @@ import {
 const DISCONNECT_GRACE_MS = 10_000;
 const WRAPPER_PING_TIMEOUT_MS = 30_000;
 const DISCONNECT_GRACE_KEY = 'disconnect_grace';
+const DESTROYED_RUNTIME_INVALIDATION_PREFIX = 'destroyed_runtime_invalidation:';
+
+const destroyedRuntimeInvalidationSchema = z.object({
+  wrapperRunId: z.string(),
+  wrapperGeneration: z.number().int().nonnegative(),
+  wrapperConnectionId: z.string(),
+  invalidatedAt: z.number().int().nonnegative(),
+});
+
+type DestroyedRuntimeInvalidation = z.infer<typeof destroyedRuntimeInvalidationSchema>;
 
 const disconnectGraceStateSchema = z.object({
   wrapperRunId: z.string(),
@@ -95,6 +108,7 @@ export type WrapperSupervisor = {
     now: number
   ): Promise<void>;
   onDisconnected(input: WrapperDisconnectedInput): Promise<void>;
+  onRuntimeInvalidated(fence: WrapperRunFence): Promise<void>;
   onTerminalEvent(params: WrapperTerminalEvent): Promise<void>;
   clearDisconnectGrace(): Promise<void>;
   runMaintenance(now: number): Promise<void>;
@@ -238,6 +252,26 @@ export function createWrapperSupervisor(
     });
   }
 
+  function destroyedRuntimeInvalidationKey(invalidated: WrapperRunFence): string {
+    return `${DESTROYED_RUNTIME_INVALIDATION_PREFIX}${invalidated.wrapperGeneration}:${invalidated.wrapperConnectionId}`;
+  }
+
+  async function listDestroyedRuntimeInvalidations(): Promise<
+    Array<{ key: string; invalidation: DestroyedRuntimeInvalidation }>
+  > {
+    const entries = await storage.list<unknown>({ prefix: DESTROYED_RUNTIME_INVALIDATION_PREFIX });
+    const invalidations: Array<{ key: string; invalidation: DestroyedRuntimeInvalidation }> = [];
+    for (const [key, stored] of entries) {
+      const parsed = destroyedRuntimeInvalidationSchema.safeParse(stored);
+      if (!parsed.success) {
+        await storage.delete(key);
+        continue;
+      }
+      invalidations.push({ key, invalidation: parsed.data });
+    }
+    return invalidations;
+  }
+
   async function checkReconnect(input: WrapperReconnectInput): Promise<WrapperReconnectDecision> {
     const runtimeState = await getWrapperRuntimeState(storage);
     if (runtimeState.wrapperRunId !== input.wrapperRunId) {
@@ -359,6 +393,125 @@ export function createWrapperSupervisor(
     await startDisconnectGrace(input);
   }
 
+  async function failAcceptedMessagesForLostRuntime(
+    acceptedMessages: SessionMessageState[],
+    error: string,
+    releaseWrapperRunId?: string
+  ): Promise<void> {
+    const terminalizationErrors: unknown[] = [];
+    for (const message of acceptedMessages) {
+      try {
+        await messageSettlementOutbox.terminalizeSessionMessageOnce(message.messageId, {
+          kind: 'failed',
+          reason: 'wrapper_failure',
+          error,
+          completionSource: 'wrapper_failure',
+        });
+      } catch (terminalizationError) {
+        terminalizationErrors.push(terminalizationError);
+      }
+    }
+    try {
+      if (releaseWrapperRunId) {
+        await releaseWrapperTerminalWaitForIdleBatchForWrapperRun(releaseWrapperRunId);
+      } else {
+        await releaseWrapperTerminalWaitForIdleBatch();
+      }
+    } catch (releaseError) {
+      terminalizationErrors.push(releaseError);
+    }
+
+    if (terminalizationErrors.length > 0) {
+      throw terminalizationErrors[0];
+    }
+  }
+
+  async function settleDestroyedRuntimeInvalidation(
+    key: string,
+    invalidated: DestroyedRuntimeInvalidation
+  ): Promise<void> {
+    const state = await getWrapperRuntimeState(storage);
+    const matchesCurrentRuntime =
+      state.wrapperRunId === invalidated.wrapperRunId &&
+      state.wrapperGeneration === invalidated.wrapperGeneration &&
+      state.wrapperConnectionId === invalidated.wrapperConnectionId;
+    let clearedCurrentRuntime = false;
+    if (matchesCurrentRuntime) {
+      const clearedState = await clearWrapperRuntimeIdentity(
+        storage,
+        {
+          wrapperGeneration: invalidated.wrapperGeneration,
+          wrapperConnectionId: invalidated.wrapperConnectionId,
+        },
+        { incrementGeneration: true }
+      );
+      clearedCurrentRuntime = clearedState !== null;
+    }
+
+    const acceptedMessages = await listNonTerminalAcceptedMessages(
+      storage,
+      invalidated.wrapperRunId
+    );
+    if (clearedCurrentRuntime) {
+      logger
+        .withFields({
+          sessionId: getSessionIdForLogs(),
+          wrapperRunId: invalidated.wrapperRunId,
+          wrapperGeneration: invalidated.wrapperGeneration,
+          wrapperConnectionId: invalidated.wrapperConnectionId,
+          acceptedMessageCount: acceptedMessages.length,
+        })
+        .warn('Invalidated destroyed wrapper runtime');
+    }
+    await failAcceptedMessagesForLostRuntime(
+      acceptedMessages,
+      'Wrapper runtime was destroyed during workspace preparation',
+      invalidated.wrapperRunId
+    );
+    const pendingTerminalEffects = await listTerminalMessagesWithPendingEffects(storage);
+    if (pendingTerminalEffects.some(message => message.wrapperRunId === invalidated.wrapperRunId)) {
+      return;
+    }
+    await storage.delete(key);
+  }
+
+  async function recoverDestroyedRuntimeInvalidations(): Promise<void> {
+    const pendingInvalidations = await listDestroyedRuntimeInvalidations();
+    for (const { key, invalidation } of pendingInvalidations) {
+      await settleDestroyedRuntimeInvalidation(key, invalidation);
+    }
+  }
+
+  async function onRuntimeInvalidated(invalidated: WrapperRunFence): Promise<void> {
+    const state = await getWrapperRuntimeState(storage);
+    const matchesCurrentRuntime =
+      state.wrapperRunId === invalidated.wrapperRunId &&
+      state.wrapperGeneration === invalidated.wrapperGeneration &&
+      state.wrapperConnectionId === invalidated.wrapperConnectionId;
+    if (!matchesCurrentRuntime) {
+      logger
+        .withFields({
+          sessionId: getSessionIdForLogs(),
+          wrapperRunId: invalidated.wrapperRunId,
+          wrapperGeneration: invalidated.wrapperGeneration,
+          wrapperConnectionId: invalidated.wrapperConnectionId,
+          currentWrapperRunId: state.wrapperRunId,
+          currentWrapperGeneration: state.wrapperGeneration,
+          currentWrapperConnectionId: state.wrapperConnectionId,
+        })
+        .info('Ignored stale destroyed wrapper runtime invalidation');
+      return;
+    }
+
+    const pendingInvalidation = destroyedRuntimeInvalidationSchema.parse({
+      ...invalidated,
+      invalidatedAt: Date.now(),
+    });
+    const key = destroyedRuntimeInvalidationKey(pendingInvalidation);
+    await storage.put(key, pendingInvalidation);
+    await settleDestroyedRuntimeInvalidation(key, pendingInvalidation);
+  }
+
   async function handleUnhealthyWrapper(state: WrapperRuntimeState, error: string): Promise<void> {
     logger
       .withFields({
@@ -370,18 +523,7 @@ export function createWrapperSupervisor(
       .warn('Handling unhealthy wrapper runtime');
 
     const acceptedMessages = await listNonTerminalAcceptedMessages(storage, state.wrapperRunId);
-    for (const message of acceptedMessages) {
-      await messageSettlementOutbox.terminalizeSessionMessageOnce(message.messageId, {
-        kind: 'failed',
-        reason: 'wrapper_failure',
-        error,
-        completionSource: 'wrapper_failure',
-      });
-    }
-    await messageSettlementOutbox.releaseWrapperTerminalWaitForIdleBatch();
-    await messageSettlementOutbox.finalizeIdleBatchCallbackIfReady({
-      allowWithoutObservedIdle: true,
-    });
+    await failAcceptedMessagesForLostRuntime(acceptedMessages, error);
 
     if (state.wrapperConnectionId) {
       await clearCurrentWrapperRuntimeFailureState(
@@ -757,6 +899,7 @@ export function createWrapperSupervisor(
   }
 
   async function runMaintenance(now: number): Promise<void> {
+    await recoverDestroyedRuntimeInvalidations();
     await checkDisconnectGrace(now);
     await checkWrapperLiveness(now);
     await checkIdleReconciliation(now);
@@ -765,6 +908,8 @@ export function createWrapperSupervisor(
 
   async function nextMaintenanceDeadlines(): Promise<number[]> {
     const deadlines: number[] = [];
+    const pendingInvalidations = await listDestroyedRuntimeInvalidations();
+    deadlines.push(...pendingInvalidations.map(({ invalidation }) => invalidation.invalidatedAt));
     const livenessDeadline = await getNextWrapperLivenessDeadline();
     if (livenessDeadline !== undefined) {
       deadlines.push(livenessDeadline);
@@ -794,6 +939,7 @@ export function createWrapperSupervisor(
     observeMeaningfulOutput,
     observeRootIdle,
     onDisconnected,
+    onRuntimeInvalidated,
     onTerminalEvent,
     clearDisconnectGrace,
     runMaintenance,

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.ts
@@ -108,6 +108,7 @@ export type WrapperSupervisor = {
     now: number
   ): Promise<void>;
   onDisconnected(input: WrapperDisconnectedInput): Promise<void>;
+  onRuntimeInvalidationStarted(fence: WrapperRunFence): Promise<void>;
   onRuntimeInvalidated(fence: WrapperRunFence): Promise<void>;
   onTerminalEvent(params: WrapperTerminalEvent): Promise<void>;
   clearDisconnectGrace(): Promise<void>;
@@ -253,6 +254,7 @@ export function createWrapperSupervisor(
   }
 
   function destroyedRuntimeInvalidationKey(invalidated: WrapperRunFence): string {
+    // Allocation never reuses a generation/connection pair for another wrapper run in this DO.
     return `${DESTROYED_RUNTIME_INVALIDATION_PREFIX}${invalidated.wrapperGeneration}:${invalidated.wrapperConnectionId}`;
   }
 
@@ -482,7 +484,33 @@ export function createWrapperSupervisor(
     }
   }
 
+  async function onRuntimeInvalidationStarted(invalidated: WrapperRunFence): Promise<void> {
+    const state = await getWrapperRuntimeState(storage);
+    const matchesCurrentRuntime =
+      state.wrapperRunId === invalidated.wrapperRunId &&
+      state.wrapperGeneration === invalidated.wrapperGeneration &&
+      state.wrapperConnectionId === invalidated.wrapperConnectionId;
+    if (!matchesCurrentRuntime) {
+      throw new Error('Cannot prepare sandbox destruction for a stale wrapper runtime');
+    }
+
+    const pendingInvalidation = destroyedRuntimeInvalidationSchema.parse({
+      ...invalidated,
+      invalidatedAt: Date.now(),
+    });
+    await storage.put(destroyedRuntimeInvalidationKey(pendingInvalidation), pendingInvalidation);
+  }
+
   async function onRuntimeInvalidated(invalidated: WrapperRunFence): Promise<void> {
+    const key = destroyedRuntimeInvalidationKey(invalidated);
+    const storedInvalidation = destroyedRuntimeInvalidationSchema.safeParse(
+      await storage.get<unknown>(key)
+    );
+    if (storedInvalidation.success) {
+      await settleDestroyedRuntimeInvalidation(key, storedInvalidation.data);
+      return;
+    }
+
     const state = await getWrapperRuntimeState(storage);
     const matchesCurrentRuntime =
       state.wrapperRunId === invalidated.wrapperRunId &&
@@ -507,7 +535,6 @@ export function createWrapperSupervisor(
       ...invalidated,
       invalidatedAt: Date.now(),
     });
-    const key = destroyedRuntimeInvalidationKey(pendingInvalidation);
     await storage.put(key, pendingInvalidation);
     await settleDestroyedRuntimeInvalidation(key, pendingInvalidation);
   }
@@ -939,6 +966,7 @@ export function createWrapperSupervisor(
     observeMeaningfulOutput,
     observeRootIdle,
     onDisconnected,
+    onRuntimeInvalidationStarted,
     onRuntimeInvalidated,
     onTerminalEvent,
     clearDisconnectGrace,

--- a/services/cloud-agent-next/test/integration/session/execute-directly-failure.test.ts
+++ b/services/cloud-agent-next/test/integration/session/execute-directly-failure.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import type { FencedWrapperDispatchRequest } from '../../../src/execution/types.js';
+import type { PreparationInfrastructureInvalidation } from '../../../src/sandbox-recovery.js';
 import { listPendingSessionMessages } from '../../../src/session/pending-messages.js';
 import {
   getWrapperRuntimeState,
@@ -19,6 +20,7 @@ import {
   recordWrapperAcceptedMessage,
 } from '../../../src/session/wrapper-runtime-state.js';
 import {
+  getSessionMessageState,
   listNonTerminalAcceptedMessages,
   putSessionMessageState,
   type SessionMessageState,
@@ -592,6 +594,151 @@ describe('hot delivery failure preserves existing wrapper identity', () => {
     expect(result.acceptedMessages).toHaveLength(1);
     expect(result.acceptedMessages[0]?.messageId).toBe('msg_018f1e2d3c4bHotFailAccAbCd');
     expect(result.acceptedMessages[0]?.status).toBe('accepted');
+  });
+
+  it('invalidates a destroyed hot wrapper runtime without reclassifying the failed delivery', async () => {
+    const userId = 'user_hot_destroyed_identity';
+    const sessionId = 'agent_hot_destroyed_identity';
+    const priorMessageId = 'msg_018f1e2d3c4bHotDstAccAbCdE';
+    const followUpMessageId = 'msg_018f1e2d3c4bHotDstMsgAbCdE';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const deliveryError = new Error(
+        'Sandbox workspace Git probe timed out before wrapper bootstrap'
+      );
+      (instance as any).orchestrator = {
+        execute: async (
+          _plan: FencedWrapperDispatchRequest,
+          options?: {
+            onSandboxDestroyed?: (
+              invalidation: PreparationInfrastructureInvalidation
+            ) => Promise<void>;
+          }
+        ) => {
+          await options?.onSandboxDestroyed?.({
+            failureType: 'sandbox_workspace_probe_timeout',
+            error: deliveryError,
+          });
+          throw deliveryError;
+        },
+      };
+
+      await registerReadySession(instance, {
+        sessionId,
+        userId,
+        orgId: 'org_hot_destroyed_identity',
+        kiloSessionId: '55555555-6666-4555-8555-555555555555',
+        prompt: 'initial prompt',
+        mode: 'code',
+        model: 'test-model',
+        kilocodeToken: 'token-hot-destroyed-identity',
+        gitUrl: 'https://example.com/repo.git',
+        gitToken: 'git-token',
+      });
+
+      const { state: wrapperState } = await allocateWrapperRuntimeState(instance.ctx.storage);
+      const originalRunId = wrapperState.wrapperRunId;
+      const originalConnectionId = wrapperState.wrapperConnectionId;
+      const originalGeneration = wrapperState.wrapperGeneration;
+      await putSessionMessageState(instance.ctx.storage, {
+        messageId: priorMessageId,
+        status: 'accepted',
+        prompt: 'running task in destroyed runtime',
+        createdAt: 1,
+        acceptedAt: 1,
+        wrapperRunId: originalRunId,
+      });
+      await recordWrapperAcceptedMessage(
+        instance.ctx.storage,
+        wrapperState,
+        Date.now() + 30 * 60_000,
+        Date.now() + 60_000
+      );
+      await instance.ctx.storage.put('wrapper_runtime_state', {
+        ...(await getWrapperRuntimeState(instance.ctx.storage)),
+        lastWrapperMessageAt: Date.now(),
+      });
+
+      await instance.admitSubmittedMessage(
+        queueUserMessageInput({
+          userId,
+          prompt: 'hot follow-up that destroys its sandbox',
+          messageId: followUpMessageId,
+        })
+      );
+      await instance.alarm();
+
+      const destroyedRuntimeState = await getWrapperRuntimeState(instance.ctx.storage);
+      const priorMessageState = await getSessionMessageState(instance.ctx.storage, priorMessageId);
+      const followUpMessageState = await getSessionMessageState(
+        instance.ctx.storage,
+        followUpMessageId
+      );
+      const pendingMessages = await listPendingSessionMessages(instance.ctx.storage);
+      const { state: replacementState } = await allocateWrapperRuntimeState(instance.ctx.storage);
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
+      const allEvents = eventQueries.findByFilters({});
+
+      return {
+        allEvents,
+        destroyedRuntimeState,
+        followUpMessageId,
+        followUpMessageState,
+        originalConnectionId,
+        originalGeneration,
+        originalRunId,
+        pendingMessages,
+        priorMessageState,
+        replacementState,
+      };
+    });
+
+    expect(result.priorMessageState).toMatchObject({
+      status: 'failed',
+      failureReason: 'wrapper_failure',
+      error: 'Wrapper runtime was destroyed during workspace preparation',
+      completionSource: 'wrapper_failure',
+    });
+    expect(result.destroyedRuntimeState.wrapperRunId).toBeUndefined();
+    expect(result.destroyedRuntimeState.wrapperConnectionId).toBeUndefined();
+    expect(result.destroyedRuntimeState.wrapperGeneration).toBeGreaterThan(
+      result.originalGeneration
+    );
+    expect(result.followUpMessageState).toMatchObject({
+      status: 'failed',
+      failureReason: 'exhausted',
+      error: 'Sandbox workspace Git probe timed out before wrapper bootstrap',
+      completionSource: 'delivery_failure',
+    });
+    expect(result.pendingMessages).toHaveLength(0);
+    expect(result.replacementState.wrapperRunId).not.toBe(result.originalRunId);
+    expect(result.replacementState.wrapperConnectionId).not.toBe(result.originalConnectionId);
+    expect(result.replacementState.wrapperGeneration).toBeGreaterThan(
+      result.destroyedRuntimeState.wrapperGeneration
+    );
+    const failedEvents = result.allEvents.filter(
+      event => event.stream_event_type === 'cloud.message.failed'
+    );
+    expect(failedEvents).toHaveLength(2);
+    expect(failedEvents.map(event => JSON.parse(event.payload))).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          messageId: priorMessageId,
+          status: 'failed',
+          error: 'Wrapper runtime was destroyed during workspace preparation',
+          delivery: 'sent',
+          accepted: true,
+        }),
+        expect.objectContaining({
+          messageId: result.followUpMessageId,
+          status: 'failed',
+          error: 'Sandbox workspace Git probe timed out before wrapper bootstrap',
+        }),
+      ])
+    );
   });
 
   it('failed cold delivery clears newly allocated wrapper identity', async () => {

--- a/services/cloud-agent-next/test/integration/session/execute-directly-failure.test.ts
+++ b/services/cloud-agent-next/test/integration/session/execute-directly-failure.test.ts
@@ -612,15 +612,20 @@ describe('hot delivery failure preserves existing wrapper identity', () => {
         execute: async (
           _plan: FencedWrapperDispatchRequest,
           options?: {
+            onSandboxDestroying?: (
+              invalidation: PreparationInfrastructureInvalidation
+            ) => Promise<void>;
             onSandboxDestroyed?: (
               invalidation: PreparationInfrastructureInvalidation
             ) => Promise<void>;
           }
         ) => {
-          await options?.onSandboxDestroyed?.({
-            failureType: 'sandbox_workspace_probe_timeout',
+          const invalidation = {
+            failureType: 'sandbox_workspace_probe_timeout' as const,
             error: deliveryError,
-          });
+          };
+          await options?.onSandboxDestroying?.(invalidation);
+          await options?.onSandboxDestroyed?.(invalidation);
           throw deliveryError;
         },
       };

--- a/services/cloud-agent-next/test/unit/execution/orchestrator.test.ts
+++ b/services/cloud-agent-next/test/unit/execution/orchestrator.test.ts
@@ -446,15 +446,19 @@ describe('ExecutionOrchestrator bootstrap execution', () => {
     expect(sandbox.destroy).toHaveBeenCalledOnce();
   });
 
-  it('reports sandbox destruction when the warm workspace probe stalls', async () => {
+  it('records invalidation intent before destroying a sandbox whose warm probe stalls', async () => {
     vi.useFakeTimers();
     const { sandbox } = createMockSandbox({ workspaceWarm: true });
     sandbox.exec.mockImplementationOnce(() => new Promise(() => {}));
     stubWrapperBootstrap();
     const orchestrator = createOrchestrator(sandbox);
+    const onSandboxDestroying = vi.fn().mockResolvedValue(undefined);
     const onSandboxDestroyed = vi.fn().mockResolvedValue(undefined);
 
-    const execution = orchestrator.execute(createExecutionPlan(), { onSandboxDestroyed });
+    const execution = orchestrator.execute(createExecutionPlan(), {
+      onSandboxDestroying,
+      onSandboxDestroyed,
+    });
     const rejection = expect(execution).rejects.toThrow(
       'Sandbox workspace Git probe timed out before wrapper bootstrap'
     );
@@ -462,10 +466,17 @@ describe('ExecutionOrchestrator bootstrap execution', () => {
 
     await rejection;
     expect(sandbox.destroy).toHaveBeenCalledOnce();
+    expect(onSandboxDestroying).toHaveBeenCalledWith({
+      failureType: 'sandbox_workspace_probe_timeout',
+      error: expect.any(Error),
+    });
     expect(onSandboxDestroyed).toHaveBeenCalledWith({
       failureType: 'sandbox_workspace_probe_timeout',
       error: expect.any(Error),
     });
+    expect(onSandboxDestroying.mock.invocationCallOrder[0]).toBeLessThan(
+      sandbox.destroy.mock.invocationCallOrder[0]
+    );
     expect(sandbox.destroy.mock.invocationCallOrder[0]).toBeLessThan(
       onSandboxDestroyed.mock.invocationCallOrder[0]
     );

--- a/services/cloud-agent-next/test/unit/execution/orchestrator.test.ts
+++ b/services/cloud-agent-next/test/unit/execution/orchestrator.test.ts
@@ -446,14 +446,15 @@ describe('ExecutionOrchestrator bootstrap execution', () => {
     expect(sandbox.destroy).toHaveBeenCalledOnce();
   });
 
-  it('destroys a stale sandbox when the warm workspace probe stalls', async () => {
+  it('reports sandbox destruction when the warm workspace probe stalls', async () => {
     vi.useFakeTimers();
     const { sandbox } = createMockSandbox({ workspaceWarm: true });
     sandbox.exec.mockImplementationOnce(() => new Promise(() => {}));
     stubWrapperBootstrap();
     const orchestrator = createOrchestrator(sandbox);
+    const onSandboxDestroyed = vi.fn().mockResolvedValue(undefined);
 
-    const execution = orchestrator.execute(createExecutionPlan());
+    const execution = orchestrator.execute(createExecutionPlan(), { onSandboxDestroyed });
     const rejection = expect(execution).rejects.toThrow(
       'Sandbox workspace Git probe timed out before wrapper bootstrap'
     );
@@ -461,5 +462,12 @@ describe('ExecutionOrchestrator bootstrap execution', () => {
 
     await rejection;
     expect(sandbox.destroy).toHaveBeenCalledOnce();
+    expect(onSandboxDestroyed).toHaveBeenCalledWith({
+      failureType: 'sandbox_workspace_probe_timeout',
+      error: expect.any(Error),
+    });
+    expect(sandbox.destroy.mock.invocationCallOrder[0]).toBeLessThan(
+      onSandboxDestroyed.mock.invocationCallOrder[0]
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Prevent hot message delivery from continuing against a wrapper runtime whose sandbox was destructively removed during workspace preparation recovery.
- Persist destroyed-runtime invalidation intent before destructive sandbox handling, then recover incomplete settlement from Durable Object maintenance while preserving the triggering delivery failure.
- Preserve idle-batch callback semantics across repair: callback finalization waits for all session terminal effects to be accounted, allowing a later repaired terminal message to become the single callback representative.

## Verification

- No manual verification performed: this is an internal Worker/Durable Object recovery path for sandbox-failure timing and was not exercised through an interactive UI or external runtime in this session.

## Visual Changes

N/A

## Reviewer Notes

- Callback finalization is intentionally session-scoped: pending terminal effects from any message defer idle-batch callback delivery until accounting is repaired.
- Destroyed-runtime invalidation records use generation and connection as their key because allocation does not reuse that pair for another wrapper run in the same Durable Object; the persisted record retains the full wrapper fence.
- Focus review on destruction-intent ordering, runtime identity clearing, and callback release after partial terminal-effect failures.