### PR TITLE
fix(code-reviews): gracefully handle blocked models

### DIFF
--- a/apps/web/src/app/api/code-reviews/up/route.test.ts
+++ b/apps/web/src/app/api/code-reviews/up/route.test.ts
@@ -14,6 +14,7 @@ import { eq } from 'drizzle-orm';
 import { GET } from './route';
 
 const REPO = `test-org/code-review-up-${Date.now()}`;
+const MODEL_NOT_ALLOWED_ERROR = 'Not Found: The requested model is not allowed for your team.';
 type CodeReviewInsert = typeof cloud_agent_code_reviews.$inferInsert;
 
 function minutesAgo(minutes: number): string {
@@ -192,15 +193,21 @@ describe('GET /api/code-reviews/up', () => {
     });
   });
 
-  it('returns healthy when model-not-found rows reach the error-spike threshold', async () => {
+  it('returns healthy when model-unavailable rows reach the error-spike threshold', async () => {
     await db.insert(cloud_agent_code_reviews).values([
       reviewValues({ status: 'cancelled', terminal_reason: 'model_not_found' }),
+      reviewValues({ status: 'cancelled', terminal_reason: 'model_not_allowed' }),
       reviewValues({
         status: 'failed',
         terminal_reason: null,
         error_message: 'Model not found: kilo/retired-model',
       }),
-      ...Array.from({ length: 18 }, () => reviewValues()),
+      reviewValues({
+        status: 'failed',
+        terminal_reason: null,
+        error_message: MODEL_NOT_ALLOWED_ERROR,
+      }),
+      ...Array.from({ length: 16 }, () => reviewValues()),
     ]);
 
     const response = await GET(makeRequest('kilo-code-reviews-health-check'));

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -154,6 +154,7 @@ jest.mock('@/lib/integrations/core/constants', () => ({
 
 const CALLBACK_SECRET = 'test-callback-token-secret';
 const REVIEW_ID = '00000000-0000-0000-0000-000000000001';
+const MODEL_NOT_ALLOWED_ERROR = 'Not Found: The requested model is not allowed for your team.';
 let defaultCallbackToken: string;
 
 function makeRequest(
@@ -526,6 +527,38 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         expect.objectContaining({
           errorMessage: 'Model not found: kilo/retired-model',
           terminalReason: 'model_not_found',
+        })
+      );
+      expect(mockCreateInfraRetryAttemptIfMissing).not.toHaveBeenCalled();
+      expect(mockRetryReviewFresh).not.toHaveBeenCalled();
+    });
+
+    it('reclassifies failed model-not-allowed callbacks as cancelled while preserving the error message', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockFindKiloReviewComment.mockResolvedValue(null);
+
+      const response = await POST(
+        makeRequest({
+          status: 'failed',
+          errorMessage: MODEL_NOT_ALLOWED_ERROR,
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockUpdateCodeReviewAttemptForCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'cancelled',
+          errorMessage: MODEL_NOT_ALLOWED_ERROR,
+          terminalReason: 'model_not_allowed',
+        })
+      );
+      expect(mockUpdateCodeReviewStatusIfNonTerminal).toHaveBeenCalledWith(
+        REVIEW_ID,
+        'cancelled',
+        expect.objectContaining({
+          errorMessage: MODEL_NOT_ALLOWED_ERROR,
+          terminalReason: 'model_not_allowed',
         })
       );
       expect(mockCreateInfraRetryAttemptIfMissing).not.toHaveBeenCalled();
@@ -1307,7 +1340,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
     });
   });
 
-  describe('model-not-found provider output', () => {
+  describe('model-unavailable provider output', () => {
     it('updates GitHub check runs with actionable cancelled copy', async () => {
       mockGetCodeReviewById.mockResolvedValue(makeReview());
       mockFindKiloReviewComment.mockResolvedValue(null);
@@ -1353,6 +1386,70 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         expect.objectContaining({
           description: expect.stringContaining('https://app.kilo.ai/code-reviews'),
         }),
+        'https://gitlab.com'
+      );
+    });
+
+    it('updates GitHub check runs and summary with model-not-allowed copy', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockFindKiloReviewComment.mockResolvedValue(null);
+
+      await POST(
+        makeRequest({ status: 'failed', errorMessage: MODEL_NOT_ALLOWED_ERROR }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockUpdateCheckRun).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        12345,
+        expect.objectContaining({
+          status: 'completed',
+          conclusion: 'cancelled',
+          output: expect.objectContaining({
+            title: 'Selected model is not allowed for your team',
+            summary: expect.stringContaining('Choose an allowed model'),
+          }),
+        }),
+        'standard'
+      );
+      expect(mockCreatePRComment).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        1,
+        expect.stringContaining('selected model is not allowed for your team'),
+        'standard'
+      );
+    });
+
+    it('updates GitLab commit status and summary with model-not-allowed copy', async () => {
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ platform: 'gitlab', platform_project_id: 42, check_run_id: null })
+      );
+      mockFindKiloReviewNote.mockResolvedValue(null);
+
+      await POST(
+        makeRequest({ status: 'failed', errorMessage: MODEL_NOT_ALLOWED_ERROR }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockSetCommitStatus).toHaveBeenCalledWith(
+        'mock-token',
+        42,
+        'abc123',
+        'canceled',
+        expect.objectContaining({
+          description: expect.stringContaining('Selected model is not allowed for your team'),
+        }),
+        'https://gitlab.com'
+      );
+      expect(mockCreateMRNote).toHaveBeenCalledWith(
+        'mock-token',
+        'owner/repo',
+        1,
+        expect.stringContaining('selected model is not allowed for your team'),
         'https://gitlab.com'
       );
     });

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -97,6 +97,11 @@ type CloudAgentNextCallbackPayload = {
 
 type StatusUpdatePayload = OrchestratorPayload | CloudAgentNextCallbackPayload;
 
+type ModelUnavailableTerminalReason = Extract<
+  CodeReviewTerminalReason,
+  'model_not_found' | 'model_not_allowed'
+>;
+
 /**
  * Normalize a payload from either the orchestrator or cloud-agent-next callback
  * into the common format expected by the update logic.
@@ -140,12 +145,13 @@ function normalizePayload(raw: StatusUpdatePayload): {
     terminalReason = 'billing';
   }
 
-  if (
-    (raw.status === 'failed' || raw.status === 'interrupted') &&
-    isModelNotFoundCodeReviewTerminalReason(terminalReason, raw.errorMessage)
-  ) {
+  const modelUnavailableTerminalReason = getModelUnavailableCodeReviewTerminalReason(
+    terminalReason,
+    raw.errorMessage
+  );
+  if ((raw.status === 'failed' || raw.status === 'interrupted') && modelUnavailableTerminalReason) {
     status = 'cancelled';
-    terminalReason = 'model_not_found';
+    terminalReason = modelUnavailableTerminalReason;
   }
 
   if (!terminalReason && raw.status === 'interrupted') {
@@ -180,15 +186,26 @@ function isBillingCodeReviewTerminalReason(
   );
 }
 
-function isModelNotFoundCodeReviewTerminalReason(
+function getModelUnavailableCodeReviewTerminalReason(
   terminalReason?: CodeReviewTerminalReason,
   errorMessage?: string | null
-): boolean {
-  if (terminalReason === 'model_not_found') {
-    return true;
+): ModelUnavailableTerminalReason | undefined {
+  if (terminalReason === 'model_not_found' || terminalReason === 'model_not_allowed') {
+    return terminalReason;
   }
 
-  return /\bmodel\s+not\s+found\b/i.test(errorMessage ?? '');
+  const message = errorMessage ?? '';
+  if (/\bmodel\s+not\s+found\b/i.test(message)) {
+    return 'model_not_found';
+  }
+  if (
+    /\brequested\s+model\s+is\s+not\s+allowed\s+for\s+your\s+team\b/i.test(message) ||
+    /\bmodel\s+not\s+allowed\s+for\s+your\s+team\b/i.test(message)
+  ) {
+    return 'model_not_allowed';
+  }
+
+  return undefined;
 }
 
 function isRetryableInfraFailure(
@@ -199,7 +216,7 @@ function isRetryableInfraFailure(
   if (status !== 'failed') return false;
   if (terminalReason === 'billing') return false;
   if (isBillingCodeReviewTerminalReason(terminalReason, errorMessage)) return false;
-  if (isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage)) return false;
+  if (getModelUnavailableCodeReviewTerminalReason(terminalReason, errorMessage)) return false;
 
   const message = errorMessage?.toLowerCase();
   if (!message) return false;
@@ -227,17 +244,40 @@ function isSupersededReview(review: CloudAgentCodeReview): boolean {
 }
 
 const BILLING_NOTICE_MARKER = '<!-- kilo-billing-notice -->';
-const MODEL_NOT_FOUND_SUMMARY_URL = 'https://app.kilo.ai/code-reviews';
-const MODEL_NOT_FOUND_CHECK_TITLE = 'Selected model is no longer available';
-const MODEL_NOT_FOUND_STATUS_SUMMARY = `The review did not run because the selected model is no longer available. Choose another model in Kilo Code review settings: ${MODEL_NOT_FOUND_SUMMARY_URL}`;
-const MODEL_NOT_FOUND_GITLAB_DESCRIPTION = `Selected model is no longer available. Choose another model: ${MODEL_NOT_FOUND_SUMMARY_URL}`;
+const MODEL_UNAVAILABLE_SUMMARY_URL = 'https://app.kilo.ai/code-reviews';
 
-const MODEL_NOT_FOUND_SUMMARY_BODY = `<!-- kilo-review -->
+const MODEL_UNAVAILABLE_COPY = {
+  model_not_found: {
+    checkTitle: 'Selected model is no longer available',
+    statusSummary: `The review did not run because the selected model is no longer available. Choose another model in Kilo Code review settings: ${MODEL_UNAVAILABLE_SUMMARY_URL}`,
+    gitlabDescription: `Selected model is no longer available. Choose another model: ${MODEL_UNAVAILABLE_SUMMARY_URL}`,
+    summaryBody: `<!-- kilo-review -->
 ## Code Review Summary
 
 The review did not run because the selected model is no longer available.
 
-Choose another model in Kilo Code review settings: ${MODEL_NOT_FOUND_SUMMARY_URL}`;
+Choose another model in Kilo Code review settings: ${MODEL_UNAVAILABLE_SUMMARY_URL}`,
+  },
+  model_not_allowed: {
+    checkTitle: 'Selected model is not allowed for your team',
+    statusSummary: `The review did not run because the selected model is not allowed for your team. Choose an allowed model in Kilo Code review settings: ${MODEL_UNAVAILABLE_SUMMARY_URL}`,
+    gitlabDescription: `Selected model is not allowed for your team. Choose an allowed model: ${MODEL_UNAVAILABLE_SUMMARY_URL}`,
+    summaryBody: `<!-- kilo-review -->
+## Code Review Summary
+
+The review did not run because the selected model is not allowed for your team.
+
+Choose an allowed model in Kilo Code review settings: ${MODEL_UNAVAILABLE_SUMMARY_URL}`,
+  },
+} satisfies Record<
+  ModelUnavailableTerminalReason,
+  {
+    checkTitle: string;
+    statusSummary: string;
+    gitlabDescription: string;
+    summaryBody: string;
+  }
+>;
 
 const BILLING_NOTICE_BODY = `${BILLING_NOTICE_MARKER}
 **Kilo Code Review could not run — your account is out of credits.**
@@ -340,9 +380,10 @@ function mapStatusToCheckRun(
   const reviewFailed = reviewStatus === 'completed' && gateResult === 'fail';
   const billingFailure =
     reviewStatus === 'failed' && isBillingCodeReviewTerminalReason(terminalReason, errorMessage);
-  const modelNotFoundCancellation =
-    reviewStatus === 'cancelled' &&
-    isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage);
+  const modelUnavailableReason =
+    reviewStatus === 'cancelled'
+      ? getModelUnavailableCodeReviewTerminalReason(terminalReason, errorMessage)
+      : undefined;
 
   const conclusionMap: Record<string, CheckRunConclusion> = {
     completed: reviewFailed ? 'failure' : 'success',
@@ -354,8 +395,8 @@ function mapStatusToCheckRun(
     running: 'Kilo Code Review in progress',
     completed: reviewFailed ? 'Kilo Code Review found issues' : 'Kilo Code Review completed',
     failed: billingFailure ? 'Insufficient credits to run review' : 'Kilo Code Review failed',
-    cancelled: modelNotFoundCancellation
-      ? MODEL_NOT_FOUND_CHECK_TITLE
+    cancelled: modelUnavailableReason
+      ? MODEL_UNAVAILABLE_COPY[modelUnavailableReason].checkTitle
       : 'Kilo Code Review cancelled',
   };
 
@@ -369,7 +410,9 @@ function mapStatusToCheckRun(
       : errorMessage
         ? `Review failed: ${errorMessage}`
         : 'Review failed.',
-    cancelled: modelNotFoundCancellation ? MODEL_NOT_FOUND_STATUS_SUMMARY : 'Review was cancelled.',
+    cancelled: modelUnavailableReason
+      ? MODEL_UNAVAILABLE_COPY[modelUnavailableReason].statusSummary
+      : 'Review was cancelled.',
   };
 
   return {
@@ -408,11 +451,14 @@ function getGitLabStatusDescription(
     return 'Kilo Code Review found issues that require attention';
   }
   if (reviewStatus === 'completed') return 'Kilo Code Review completed';
-  if (
-    reviewStatus === 'cancelled' &&
-    isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage)
-  ) {
-    return MODEL_NOT_FOUND_GITLAB_DESCRIPTION;
+  if (reviewStatus === 'cancelled') {
+    const modelUnavailableReason = getModelUnavailableCodeReviewTerminalReason(
+      terminalReason,
+      errorMessage
+    );
+    if (modelUnavailableReason) {
+      return MODEL_UNAVAILABLE_COPY[modelUnavailableReason].gitlabDescription;
+    }
   }
   if (reviewStatus === 'cancelled') return 'Kilo Code Review cancelled';
   if (
@@ -429,12 +475,14 @@ function getGitLabStatusDescription(
   return undefined;
 }
 
-async function upsertModelNotFoundSummary(
+async function upsertModelUnavailableSummary(
   review: CloudAgentCodeReview,
   integration: PlatformIntegration,
+  terminalReason: ModelUnavailableTerminalReason,
   gitlabAccessToken?: string
 ): Promise<void> {
   const platform = review.platform || 'github';
+  const summaryBody = MODEL_UNAVAILABLE_COPY[terminalReason].summaryBody;
 
   if (platform === 'github' && integration.platform_installation_id) {
     const [repoOwner, repoName] = review.repo_full_name.split('/');
@@ -453,7 +501,7 @@ async function upsertModelNotFoundSummary(
         repoOwner,
         repoName,
         existing.commentId,
-        MODEL_NOT_FOUND_SUMMARY_BODY,
+        summaryBody,
         appType
       );
     } else {
@@ -462,7 +510,7 @@ async function upsertModelNotFoundSummary(
         repoOwner,
         repoName,
         review.pr_number,
-        MODEL_NOT_FOUND_SUMMARY_BODY,
+        summaryBody,
         appType
       );
     }
@@ -491,7 +539,7 @@ async function upsertModelNotFoundSummary(
         review.repo_full_name,
         review.pr_number,
         existing.noteId,
-        MODEL_NOT_FOUND_SUMMARY_BODY,
+        summaryBody,
         instanceUrl
       );
     } else {
@@ -499,7 +547,7 @@ async function upsertModelNotFoundSummary(
         accessToken,
         review.repo_full_name,
         review.pr_number,
-        MODEL_NOT_FOUND_SUMMARY_BODY,
+        summaryBody,
         instanceUrl
       );
     }
@@ -924,11 +972,11 @@ export async function POST(
           : undefined,
     };
 
-    if (
-      integration &&
-      status === 'cancelled' &&
-      isModelNotFoundCodeReviewTerminalReason(terminalReason, errorMessage)
-    ) {
+    const modelUnavailableReason =
+      status === 'cancelled'
+        ? getModelUnavailableCodeReviewTerminalReason(terminalReason, errorMessage)
+        : undefined;
+    if (integration && modelUnavailableReason) {
       const claimedTerminalUpdate = await updateCodeReviewStatusIfNonTerminal(
         reviewId,
         status,
@@ -946,7 +994,12 @@ export async function POST(
       }
 
       try {
-        await upsertModelNotFoundSummary(review, integration, gitlabAccessToken);
+        await upsertModelUnavailableSummary(
+          review,
+          integration,
+          modelUnavailableReason,
+          gitlabAccessToken
+        );
       } catch (summaryError) {
         logExceptInTest(
           '[code-review-status] Failed to upsert model unavailable summary:',

--- a/apps/web/src/lib/code-reviews/alerting/detectors.test.ts
+++ b/apps/web/src/lib/code-reviews/alerting/detectors.test.ts
@@ -5,6 +5,7 @@ import { eq } from 'drizzle-orm';
 import { evaluateErrorSpike, evaluateSlowReviews } from './detectors';
 
 const REPO = `test-org/code-review-alerts-${Date.now()}`;
+const MODEL_NOT_ALLOWED_ERROR = 'Not Found: The requested model is not allowed for your team.';
 type CodeReviewInsert = typeof cloud_agent_code_reviews.$inferInsert;
 
 function minutesAgo(minutes: number): string {
@@ -229,15 +230,16 @@ describe('code review alert detectors', () => {
     await insertReviews([
       reviewValues({ status: 'failed', terminal_reason: 'billing' }),
       reviewValues({ status: 'cancelled', terminal_reason: 'model_not_found' }),
+      reviewValues({ status: 'cancelled', terminal_reason: 'model_not_allowed' }),
       reviewValues({ status: 'cancelled', terminal_reason: 'user_cancelled' }),
       reviewValues({ status: 'cancelled', terminal_reason: 'superseded' }),
-      ...Array.from({ length: 16 }, () => reviewValues()),
+      ...Array.from({ length: 15 }, () => reviewValues()),
     ]);
 
     await expect(evaluateErrorSpike(db)).resolves.toEqual({ tripped: false });
   });
 
-  it('excludes legacy model-not-found failed rows from error-spike counts', async () => {
+  it('excludes legacy model-unavailable failed rows from error-spike counts', async () => {
     await insertReviews([
       reviewValues({
         status: 'failed',
@@ -249,7 +251,17 @@ describe('code review alert detectors', () => {
         terminal_reason: null,
         error_message: 'model not found: y',
       }),
-      ...Array.from({ length: 18 }, () => reviewValues()),
+      reviewValues({
+        status: 'failed',
+        terminal_reason: null,
+        error_message: MODEL_NOT_ALLOWED_ERROR,
+      }),
+      reviewValues({
+        status: 'failed',
+        terminal_reason: null,
+        error_message: 'Model not allowed for your team.',
+      }),
+      ...Array.from({ length: 16 }, () => reviewValues()),
     ]);
 
     await expect(evaluateErrorSpike(db)).resolves.toEqual({ tripped: false });

--- a/apps/web/src/lib/code-reviews/alerting/detectors.ts
+++ b/apps/web/src/lib/code-reviews/alerting/detectors.ts
@@ -58,9 +58,12 @@ const systemFailureSql = sql`(
   status IN ('failed', 'interrupted')
   OR (status = 'cancelled' AND terminal_reason IS NOT NULL)
 )`;
-const modelNotFoundSql = sql`(
+const modelUnavailableSql = sql`(
   COALESCE(terminal_reason, '') = 'model_not_found'
+  OR COALESCE(terminal_reason, '') = 'model_not_allowed'
   OR COALESCE(error_message, '') ILIKE '%model not found%'
+  OR COALESCE(error_message, '') ILIKE '%requested model is not allowed for your team%'
+  OR COALESCE(error_message, '') ILIKE '%model not allowed for your team%'
 )`;
 
 const startedReviewsCteSql = sql`
@@ -140,7 +143,7 @@ export async function evaluateErrorSpike(database: AlertingDb): Promise<CodeRevi
       FROM windowed
       WHERE ${systemFailureSql}
         AND COALESCE(terminal_reason, '') NOT IN ${benignTerminalReasonsSql}
-        AND NOT ${modelNotFoundSql}
+        AND NOT ${modelUnavailableSql}
       GROUP BY 1
       ORDER BY 2 DESC, 1 ASC
       LIMIT 1
@@ -150,7 +153,7 @@ export async function evaluateErrorSpike(database: AlertingDb): Promise<CodeRevi
       COUNT(*) FILTER (
         WHERE ${systemFailureSql}
           AND COALESCE(terminal_reason, '') NOT IN ${benignTerminalReasonsSql}
-          AND NOT ${modelNotFoundSql}
+          AND NOT ${modelUnavailableSql}
       ) AS error_count,
       (SELECT reason FROM top_reason) AS top_reason,
       (SELECT count FROM top_reason) AS top_reason_count

--- a/apps/web/src/routers/admin-code-reviews-router.test.ts
+++ b/apps/web/src/routers/admin-code-reviews-router.test.ts
@@ -13,6 +13,7 @@ import { eq } from 'drizzle-orm';
 const REPO = `test-org/admin-code-review-wait-${Date.now()}`;
 const START_DATE = '2035-01-01T00:00:00.000Z';
 const END_DATE = '2035-01-20T00:00:00.000Z';
+const MODEL_NOT_ALLOWED_ERROR = 'Not Found: The requested model is not allowed for your team.';
 
 type ReviewOwner = { type: 'user'; id: string } | { type: 'org'; id: string };
 type FilterInput = {
@@ -361,6 +362,19 @@ describe('adminCodeReviewsRouter', () => {
       reviewValues({
         owner,
         status: 'failed',
+        createdAt: timestamp(715),
+        errorMessage: MODEL_NOT_ALLOWED_ERROR,
+      }),
+      reviewValues({
+        owner,
+        status: 'cancelled',
+        createdAt: timestamp(718),
+        terminalReason: 'model_not_allowed',
+        errorMessage: MODEL_NOT_ALLOWED_ERROR,
+      }),
+      reviewValues({
+        owner,
+        status: 'failed',
         createdAt: timestamp(720),
         terminalReason: 'timeout',
         errorMessage: 'Execution timed out',
@@ -377,24 +391,30 @@ describe('adminCodeReviewsRouter', () => {
       ...filterInput(),
       errorMessage: 'Model not found: kilo/retired-model',
     });
+    const modelAllowedSessions = await caller.admin.codeReviews.getErrorSessions({
+      ...filterInput(),
+      errorMessage: MODEL_NOT_ALLOWED_ERROR,
+    });
     const segmentation = await caller.admin.codeReviews.getUserSegmentation(filterInput());
 
     expect(overview).toMatchObject({
-      totalReviews: 4,
+      totalReviews: 6,
       completedCount: 1,
       failedCount: 1,
-      cancelledCount: 2,
+      cancelledCount: 4,
     });
-    expect(daily[0]).toMatchObject({ completed: 1, failed: 1, cancelled: 2 });
+    expect(daily[0]).toMatchObject({ completed: 1, failed: 1, cancelled: 4 });
     expect(cancellations).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ reason: 'Model no longer available', count: 2 }),
+        expect.objectContaining({ reason: 'Model not allowed for team', count: 2 }),
       ])
     );
     expect(errors.details).toEqual([
       expect.objectContaining({ errorType: 'Execution timed out', count: 1 }),
     ]);
     expect(modelSessions).toEqual([]);
+    expect(modelAllowedSessions).toEqual([]);
     expect(segmentation.ownershipBreakdown[0]).toMatchObject({ failed: 1 });
   });
 
@@ -436,6 +456,25 @@ describe('adminCodeReviewsRouter', () => {
         code_review_id: review.id,
         attempt_number: 3,
         status: 'failed',
+        error_message: MODEL_NOT_ALLOWED_ERROR,
+        created_at: timestamp(706),
+        started_at: timestamp(706),
+        completed_at: timestamp(706),
+      },
+      {
+        code_review_id: review.id,
+        attempt_number: 4,
+        status: 'cancelled',
+        terminal_reason: 'model_not_allowed',
+        error_message: MODEL_NOT_ALLOWED_ERROR,
+        created_at: timestamp(706),
+        started_at: timestamp(706),
+        completed_at: timestamp(706),
+      },
+      {
+        code_review_id: review.id,
+        attempt_number: 5,
+        status: 'failed',
         terminal_reason: 'timeout',
         error_message: 'Execution timed out',
         created_at: timestamp(707),
@@ -444,7 +483,7 @@ describe('adminCodeReviewsRouter', () => {
       },
       {
         code_review_id: review.id,
-        attempt_number: 4,
+        attempt_number: 6,
         status: 'completed',
         created_at: timestamp(710),
         started_at: timestamp(711),
@@ -462,24 +501,30 @@ describe('adminCodeReviewsRouter', () => {
       ...input,
       errorMessage: 'Model not found: kilo/retired-model',
     });
+    const modelAllowedSessions = await caller.admin.codeReviews.getErrorSessions({
+      ...input,
+      errorMessage: MODEL_NOT_ALLOWED_ERROR,
+    });
     const segmentation = await caller.admin.codeReviews.getUserSegmentation(input);
 
     expect(overview).toMatchObject({
-      totalReviews: 4,
+      totalReviews: 6,
       completedCount: 1,
       failedCount: 1,
-      cancelledCount: 2,
+      cancelledCount: 4,
     });
-    expect(daily[0]).toMatchObject({ completed: 1, failed: 1, cancelled: 2 });
+    expect(daily[0]).toMatchObject({ completed: 1, failed: 1, cancelled: 4 });
     expect(cancellations).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ reason: 'Model no longer available', count: 2 }),
+        expect.objectContaining({ reason: 'Model not allowed for team', count: 2 }),
       ])
     );
     expect(errors.details).toEqual([
       expect.objectContaining({ errorType: 'Execution timed out', count: 1 }),
     ]);
     expect(modelSessions).toEqual([]);
+    expect(modelAllowedSessions).toEqual([]);
     expect(segmentation.ownershipBreakdown[0]).toMatchObject({ failed: 1 });
   });
 

--- a/apps/web/src/routers/admin-code-reviews-router.ts
+++ b/apps/web/src/routers/admin-code-reviews-router.ts
@@ -46,6 +46,21 @@ const isModelNotFoundAttempt = sql`(
   OR ${cloud_agent_code_review_attempts.error_message} ILIKE '%model not found%'
 )`;
 
+const isModelNotAllowed = sql`(
+  ${cloud_agent_code_reviews.terminal_reason} = 'model_not_allowed'
+  OR ${cloud_agent_code_reviews.error_message} ILIKE '%requested model is not allowed for your team%'
+  OR ${cloud_agent_code_reviews.error_message} ILIKE '%model not allowed for your team%'
+)`;
+
+const isModelNotAllowedAttempt = sql`(
+  ${cloud_agent_code_review_attempts.terminal_reason} = 'model_not_allowed'
+  OR ${cloud_agent_code_review_attempts.error_message} ILIKE '%requested model is not allowed for your team%'
+  OR ${cloud_agent_code_review_attempts.error_message} ILIKE '%model not allowed for your team%'
+)`;
+
+const isModelUnavailable = sql`(${isModelNotFound} OR ${isModelNotAllowed})`;
+const isModelUnavailableAttempt = sql`(${isModelNotFoundAttempt} OR ${isModelNotAllowedAttempt})`;
+
 /**
  * SQL condition to exclude billing errors from failure metrics.
  * Uses COALESCE to handle NULL error_message (NULL NOT LIKE returns NULL, not TRUE).
@@ -62,11 +77,17 @@ const excludeBillingAttemptErrors = sql`COALESCE(${cloud_agent_code_review_attem
   AND COALESCE(${cloud_agent_code_review_attempts.error_message}, '') NOT ILIKE '%add credits%'
   AND COALESCE(${cloud_agent_code_review_attempts.error_message}, '') NOT ILIKE '%Credits Required%'`;
 
-const excludeModelNotFound = sql`COALESCE(${cloud_agent_code_reviews.terminal_reason}, '') <> 'model_not_found'
-  AND COALESCE(${cloud_agent_code_reviews.error_message}, '') NOT ILIKE '%model not found%'`;
+const excludeModelUnavailableReview = sql`COALESCE(${cloud_agent_code_reviews.terminal_reason}, '') <> 'model_not_found'
+  AND COALESCE(${cloud_agent_code_reviews.terminal_reason}, '') <> 'model_not_allowed'
+  AND COALESCE(${cloud_agent_code_reviews.error_message}, '') NOT ILIKE '%model not found%'
+  AND COALESCE(${cloud_agent_code_reviews.error_message}, '') NOT ILIKE '%requested model is not allowed for your team%'
+  AND COALESCE(${cloud_agent_code_reviews.error_message}, '') NOT ILIKE '%model not allowed for your team%'`;
 
-const excludeModelNotFoundAttempt = sql`COALESCE(${cloud_agent_code_review_attempts.terminal_reason}, '') <> 'model_not_found'
-  AND COALESCE(${cloud_agent_code_review_attempts.error_message}, '') NOT ILIKE '%model not found%'`;
+const excludeModelUnavailableAttempt = sql`COALESCE(${cloud_agent_code_review_attempts.terminal_reason}, '') <> 'model_not_found'
+  AND COALESCE(${cloud_agent_code_review_attempts.terminal_reason}, '') <> 'model_not_allowed'
+  AND COALESCE(${cloud_agent_code_review_attempts.error_message}, '') NOT ILIKE '%model not found%'
+  AND COALESCE(${cloud_agent_code_review_attempts.error_message}, '') NOT ILIKE '%requested model is not allowed for your team%'
+  AND COALESCE(${cloud_agent_code_review_attempts.error_message}, '') NOT ILIKE '%model not allowed for your team%'`;
 
 /**
  * Categorize error messages into high-level buckets via SQL CASE WHEN.
@@ -298,10 +319,10 @@ export const adminCodeReviewsRouter = createTRPCRouter({
         : excludeBillingErrors;
     const excludeModelUnavailable =
       input.retryAccountingMode === 'all_attempts'
-        ? excludeModelNotFoundAttempt
-        : excludeModelNotFound;
+        ? excludeModelUnavailableAttempt
+        : excludeModelUnavailableReview;
     const modelUnavailable =
-      input.retryAccountingMode === 'all_attempts' ? isModelNotFoundAttempt : isModelNotFound;
+      input.retryAccountingMode === 'all_attempts' ? isModelUnavailableAttempt : isModelUnavailable;
     const durationStartedAt =
       input.retryAccountingMode === 'all_attempts'
         ? cloud_agent_code_review_attempts.started_at
@@ -416,10 +437,10 @@ export const adminCodeReviewsRouter = createTRPCRouter({
         : excludeBillingErrors;
     const excludeModelUnavailable =
       input.retryAccountingMode === 'all_attempts'
-        ? excludeModelNotFoundAttempt
-        : excludeModelNotFound;
+        ? excludeModelUnavailableAttempt
+        : excludeModelUnavailableReview;
     const modelUnavailable =
-      input.retryAccountingMode === 'all_attempts' ? isModelNotFoundAttempt : isModelNotFound;
+      input.retryAccountingMode === 'all_attempts' ? isModelUnavailableAttempt : isModelUnavailable;
 
     const query = db
       .select({
@@ -471,7 +492,7 @@ export const adminCodeReviewsRouter = createTRPCRouter({
         : cloud_agent_code_reviews;
 
     const modelUnavailable =
-      input.retryAccountingMode === 'all_attempts' ? isModelNotFoundAttempt : isModelNotFound;
+      input.retryAccountingMode === 'all_attempts' ? isModelUnavailableAttempt : isModelUnavailable;
 
     const conditions = [
       sql`(${statusTable.status} = 'cancelled' OR (${statusTable.status} = 'failed' AND ${modelUnavailable}))`,
@@ -479,6 +500,7 @@ export const adminCodeReviewsRouter = createTRPCRouter({
     ] as SQL[];
 
     const cancellationReasonExpr = sql<string>`CASE
+      WHEN ${statusTable.terminal_reason} = 'model_not_allowed' OR ${statusTable.error_message} ILIKE '%requested model is not allowed for your team%' OR ${statusTable.error_message} ILIKE '%model not allowed for your team%' THEN 'Model not allowed for team'
       WHEN ${statusTable.terminal_reason} = 'model_not_found' OR ${statusTable.error_message} ILIKE '%model not found%' THEN 'Model no longer available'
       WHEN ${statusTable.terminal_reason} = 'superseded' OR ${statusTable.error_message} ILIKE '%superseded%' THEN 'Superseded by new commit'
       WHEN ${statusTable.error_message} ILIKE '%stream timeout%' THEN 'Stream timeout'
@@ -540,8 +562,8 @@ export const adminCodeReviewsRouter = createTRPCRouter({
         : excludeBillingErrors;
     const excludeModelUnavailable =
       input.retryAccountingMode === 'all_attempts'
-        ? excludeModelNotFoundAttempt
-        : excludeModelNotFound;
+        ? excludeModelUnavailableAttempt
+        : excludeModelUnavailableReview;
 
     const conditions = [
       eq(statusTable.status, 'failed'),
@@ -637,8 +659,8 @@ export const adminCodeReviewsRouter = createTRPCRouter({
         : excludeBillingErrors;
     const excludeModelUnavailable =
       input.retryAccountingMode === 'all_attempts'
-        ? excludeModelNotFoundAttempt
-        : excludeModelNotFound;
+        ? excludeModelUnavailableAttempt
+        : excludeModelUnavailableReview;
 
     const conditions = [
       eq(statusTable.status, 'failed'),
@@ -726,8 +748,8 @@ export const adminCodeReviewsRouter = createTRPCRouter({
         : excludeBillingErrors;
     const excludeModelUnavailable =
       input.retryAccountingMode === 'all_attempts'
-        ? excludeModelNotFoundAttempt
-        : excludeModelNotFound;
+        ? excludeModelUnavailableAttempt
+        : excludeModelUnavailableReview;
     const waitCondition =
       input.retryAccountingMode === 'all_attempts'
         ? validAttemptStartedWaitCondition

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1222,6 +1222,7 @@ export type StripeSubscriptionStatus =
 export const CODE_REVIEW_TERMINAL_REASONS = [
   'billing',
   'model_not_found',
+  'model_not_allowed',
   'user_cancelled',
   'superseded',
   'interrupted',
@@ -1245,6 +1246,7 @@ export type CodeReviewTerminalReason = (typeof CODE_REVIEW_TERMINAL_REASONS)[num
 export const CODE_REVIEW_BENIGN_TERMINAL_REASONS = [
   'billing',
   'model_not_found',
+  'model_not_allowed',
   'user_cancelled',
   'superseded',
 ] as const satisfies readonly CodeReviewTerminalReason[];

--- a/packages/worker-utils/src/cloud-agent-next-client.ts
+++ b/packages/worker-utils/src/cloud-agent-next-client.ts
@@ -119,6 +119,7 @@ export type CloudAgentInterruptOutput = {
 export type CloudAgentTerminalReason =
   | 'billing'
   | 'model_not_found'
+  | 'model_not_allowed'
   | 'user_cancelled'
   | 'superseded'
   | 'interrupted'

--- a/services/code-review-infra/src/types.ts
+++ b/services/code-review-infra/src/types.ts
@@ -104,6 +104,7 @@ export const InternalStatusResponseSchema = z.object({
     .enum([
       'billing',
       'model_not_found',
+      'model_not_allowed',
       'user_cancelled',
       'superseded',
       'interrupted',


### PR DESCRIPTION
## Why

Some code reviews failed when a team blocked the selected model. The review should stop cleanly and tell the user to choose a model their team allows.

## What changed

Code reviews now treat blocked models as cancelled instead of failed. GitHub and GitLab show a clear message that the selected model is not allowed for the team. Health checks and admin reports count these runs as cancellations, not system errors. Old saved failures with the same message are handled the same way.

## How to test

1. Start a code review with a model that is not allowed for the team.
2. Confirm the PR or MR status is cancelled.
3. Confirm the summary says the selected model is not allowed for the team and points to code review settings.
4. Confirm admin reporting and health checks do not count it as a system failure.