### PR TITLE
fix(code-reviews): remove unused time setting

### DIFF
--- a/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
@@ -6,7 +6,6 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
 import {
   Settings,
@@ -205,7 +204,6 @@ export function ReviewConfigForm({
   );
   const [focusAreas, setFocusAreas] = useState<string[]>([]);
   const [customInstructions, setCustomInstructions] = useState('');
-  const [maxReviewTime, setMaxReviewTime] = useState([10]);
   const [selectedModel, setSelectedModel] = useState(PRIMARY_DEFAULT_MODEL);
   const [thinkingEffort, setThinkingEffort] = useState<string | null>(null);
   const [gateThreshold, setGateThreshold] = useState<'off' | 'all' | 'warning' | 'critical'>('off');
@@ -305,7 +303,6 @@ export function ReviewConfigForm({
       setReviewStyle(configData.reviewStyle);
       setFocusAreas(configData.focusAreas);
       setCustomInstructions(configData.customInstructions || '');
-      setMaxReviewTime([configData.maxReviewTimeMinutes]);
       setSelectedModel(configData.modelSlug);
       setThinkingEffort(configData.thinkingEffort ?? null);
       setGateThreshold(configData.gateThreshold ?? 'off');
@@ -457,7 +454,6 @@ export function ReviewConfigForm({
         reviewStyle,
         focusAreas,
         customInstructions: customInstructions.trim() || undefined,
-        maxReviewTimeMinutes: maxReviewTime[0],
         modelSlug: selectedModel,
         thinkingEffort,
         gateThreshold,
@@ -474,7 +470,6 @@ export function ReviewConfigForm({
         reviewStyle,
         focusAreas,
         customInstructions: customInstructions.trim() || undefined,
-        maxReviewTimeMinutes: maxReviewTime[0],
         modelSlug: selectedModel,
         thinkingEffort,
         gateThreshold,
@@ -1039,22 +1034,6 @@ export function ReviewConfigForm({
                   </div>
                 ))}
               </div>
-            </div>
-
-            {/* Max Review Time */}
-            <div className="space-y-3">
-              <Label>Maximum Review Time: {maxReviewTime[0]} minutes</Label>
-              <Slider
-                value={maxReviewTime}
-                onValueChange={setMaxReviewTime}
-                min={5}
-                max={30}
-                step={1}
-                className="w-full"
-              />
-              <p className="text-muted-foreground text-sm">
-                Timeout for the code review workflow (5-30 minutes)
-              </p>
             </div>
 
             {/* Custom Instructions */}

--- a/apps/web/src/lib/agent-config/core/types.ts
+++ b/apps/web/src/lib/agent-config/core/types.ts
@@ -38,11 +38,6 @@ export const ReviewConfigSchema = z.object({
     })
   ),
   customInstructions: z.string().nullable(),
-  maxReviewTimeMinutes: z
-    .number()
-    .int()
-    .min(1, 'maxReviewTimeMinutes must be at least 1')
-    .max(120, 'maxReviewTimeMinutes must be at most 120'),
   modelSlug: z
     .string()
     .regex(

--- a/apps/web/src/lib/code-reviews/prompts/generate-prompt.test.ts
+++ b/apps/web/src/lib/code-reviews/prompts/generate-prompt.test.ts
@@ -135,7 +135,6 @@ const baseConfig = {
   focus_areas: [],
   custom_instructions: '',
   model_slug: 'test-model',
-  max_review_time_minutes: 30,
 } satisfies CodeReviewAgentConfig;
 
 describe('generateReviewPrompt', () => {

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
@@ -75,7 +75,6 @@ const baseAgentConfig = {
   focus_areas: [],
   custom_instructions: '',
   model_slug: 'test-model',
-  max_review_time_minutes: 30,
   repository_selection_mode: 'all',
   gate_threshold: 'off',
   disable_review_md: false,

--- a/apps/web/src/routers/code-reviews-router.test.ts
+++ b/apps/web/src/routers/code-reviews-router.test.ts
@@ -320,7 +320,6 @@ describe('review agent config REVIEW.md setting', () => {
       platform: 'github',
       reviewStyle: 'balanced',
       focusAreas: [],
-      maxReviewTimeMinutes: 10,
       modelSlug: 'test-model',
       disableReviewMd: true,
     });
@@ -334,9 +333,11 @@ describe('review agent config REVIEW.md setting', () => {
     });
 
     expect(config?.config).toEqual(expect.objectContaining({ disable_review_md: true }));
+    expect(config?.config).not.toHaveProperty('max_review_time_minutes');
 
     const refetched = await caller.personalReviewAgent.getReviewConfig({ platform: 'github' });
     expect(refetched.disableReviewMd).toBe(true);
+    expect(refetched).not.toHaveProperty('maxReviewTimeMinutes');
   });
 
   it('persists organization disableReviewMd true as disable_review_md true', async () => {
@@ -347,7 +348,6 @@ describe('review agent config REVIEW.md setting', () => {
       platform: 'github',
       reviewStyle: 'balanced',
       focusAreas: [],
-      maxReviewTimeMinutes: 10,
       modelSlug: 'test-model',
       disableReviewMd: true,
     });
@@ -361,12 +361,14 @@ describe('review agent config REVIEW.md setting', () => {
     });
 
     expect(config?.config).toEqual(expect.objectContaining({ disable_review_md: true }));
+    expect(config?.config).not.toHaveProperty('max_review_time_minutes');
 
     const refetched = await caller.organizations.reviewAgent.getReviewConfig({
       organizationId: organization.id,
       platform: 'github',
     });
     expect(refetched.disableReviewMd).toBe(true);
+    expect(refetched).not.toHaveProperty('maxReviewTimeMinutes');
   });
 
   it('persists omitted personal disableReviewMd as true by default', async () => {
@@ -376,7 +378,6 @@ describe('review agent config REVIEW.md setting', () => {
       platform: 'github',
       reviewStyle: 'balanced',
       focusAreas: [],
-      maxReviewTimeMinutes: 10,
       modelSlug: 'test-model',
     });
 
@@ -389,6 +390,7 @@ describe('review agent config REVIEW.md setting', () => {
     });
 
     expect(config?.config).toEqual(expect.objectContaining({ disable_review_md: true }));
+    expect(config?.config).not.toHaveProperty('max_review_time_minutes');
   });
 
   it('persists omitted organization disableReviewMd as true by default', async () => {
@@ -399,7 +401,6 @@ describe('review agent config REVIEW.md setting', () => {
       platform: 'github',
       reviewStyle: 'balanced',
       focusAreas: [],
-      maxReviewTimeMinutes: 10,
       modelSlug: 'test-model',
     });
 
@@ -412,6 +413,7 @@ describe('review agent config REVIEW.md setting', () => {
     });
 
     expect(config?.config).toEqual(expect.objectContaining({ disable_review_md: true }));
+    expect(config?.config).not.toHaveProperty('max_review_time_minutes');
   });
 });
 

--- a/apps/web/src/routers/code-reviews-router.ts
+++ b/apps/web/src/routers/code-reviews-router.ts
@@ -39,7 +39,6 @@ const SaveReviewConfigInputSchema = z.object({
   reviewStyle: z.enum(['strict', 'balanced', 'lenient', 'roast']),
   focusAreas: z.array(z.string()),
   customInstructions: z.string().optional(),
-  maxReviewTimeMinutes: z.number().min(5).max(30),
   modelSlug: z.string(),
   thinkingEffort: z
     .string()
@@ -158,7 +157,6 @@ export const personalReviewAgentRouter = createTRPCRouter({
           reviewStyle: 'balanced' as const,
           focusAreas: [],
           customInstructions: null,
-          maxReviewTimeMinutes: 10,
           modelSlug: PRIMARY_DEFAULT_MODEL,
           thinkingEffort: null satisfies string | null,
           gateThreshold: 'off' as const,
@@ -175,7 +173,6 @@ export const personalReviewAgentRouter = createTRPCRouter({
         reviewStyle: cfg.review_style || 'balanced',
         focusAreas: cfg.focus_areas || [],
         customInstructions: cfg.custom_instructions || null,
-        maxReviewTimeMinutes: cfg.max_review_time_minutes || 10,
         modelSlug: cfg.model_slug || PRIMARY_DEFAULT_MODEL,
         thinkingEffort: cfg.thinking_effort ?? null,
         gateThreshold: cfg.gate_threshold ?? 'off',
@@ -212,7 +209,6 @@ export const personalReviewAgentRouter = createTRPCRouter({
             review_style: input.reviewStyle,
             focus_areas: input.focusAreas,
             custom_instructions: input.customInstructions || null,
-            max_review_time_minutes: input.maxReviewTimeMinutes,
             model_slug: input.modelSlug,
             thinking_effort: input.thinkingEffort ?? null,
             gate_threshold: input.gateThreshold ?? 'off',

--- a/apps/web/src/routers/organizations/organization-code-reviews-router.ts
+++ b/apps/web/src/routers/organizations/organization-code-reviews-router.ts
@@ -46,7 +46,6 @@ const SaveReviewConfigInputSchema = OrganizationIdInputSchema.extend({
   reviewStyle: z.enum(['strict', 'balanced', 'lenient', 'roast']),
   focusAreas: z.array(z.string()),
   customInstructions: z.string().optional(),
-  maxReviewTimeMinutes: z.number().min(5).max(30),
   modelSlug: z.string(),
   thinkingEffort: z
     .string()
@@ -175,7 +174,6 @@ export const organizationReviewAgentRouter = createTRPCRouter({
           reviewStyle: 'balanced' as const,
           focusAreas: [],
           customInstructions: null,
-          maxReviewTimeMinutes: 10,
           modelSlug: PRIMARY_DEFAULT_MODEL,
           thinkingEffort: null satisfies string | null,
           gateThreshold: 'off' as const,
@@ -192,7 +190,6 @@ export const organizationReviewAgentRouter = createTRPCRouter({
         reviewStyle: cfg.review_style || 'balanced',
         focusAreas: cfg.focus_areas || [],
         customInstructions: cfg.custom_instructions || null,
-        maxReviewTimeMinutes: cfg.max_review_time_minutes || 10,
         modelSlug: cfg.model_slug || PRIMARY_DEFAULT_MODEL,
         thinkingEffort: cfg.thinking_effort ?? null,
         gateThreshold: cfg.gate_threshold ?? 'off',
@@ -228,7 +225,6 @@ export const organizationReviewAgentRouter = createTRPCRouter({
             review_style: input.reviewStyle,
             focus_areas: input.focusAreas,
             custom_instructions: input.customInstructions || null,
-            max_review_time_minutes: input.maxReviewTimeMinutes,
             model_slug: input.modelSlug,
             thinking_effort: input.thinkingEffort ?? null,
             gate_threshold: input.gateThreshold ?? 'off',

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -826,7 +826,6 @@ export const CodeReviewAgentConfigSchema = z.object({
   focus_areas: z.array(z.string()),
   auto_approve_minor: z.boolean().optional(),
   custom_instructions: z.string().nullable().optional(),
-  max_review_time_minutes: z.number().int().positive(),
   model_slug: z.string(),
   // Thinking effort variant name (e.g. "high", "max", "thinking") — null means model default
   thinking_effort: z

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2831,7 +2831,6 @@ export const agent_configs = pgTable(
     //   "review_style": "balanced",
     //   "focus_areas": ["security", "performance"],
     //   "model_slug": "anthropic/claude-4.5-sonnet",
-    //   "max_review_time_minutes": 10,
     //   "custom_instructions": "..."
     // }
     config: jsonb().$type<CodeReviewAgentConfig | Record<string, unknown>>().notNull().default({}),


### PR DESCRIPTION
## Summary
The Code Reviewer settings showed a maximum review time control, but that choice did not actually change how reviews ran. This removes the unused setting from the product and from saved settings so people do not think they are changing review behavior when they are not.

New saves no longer write the old setting, and old saved values stay harmless if a user does not edit their settings. The change also keeps personal and organization settings working the same way for GitHub and GitLab.

## Verification
1. Open Code Reviewer settings and confirm the focus areas go straight to custom instructions.
2. Save Code Reviewer settings for a personal account and confirm the save works.
3. Save Code Reviewer settings for an organization and confirm the save works.

## Visual Changes
The Maximum Review Time slider is gone from Code Reviewer settings.

## Reviewer Notes
No database migration is included. Old saved JSON may still contain the old value, but review code does not use it.