### PR TITLE
fix(gitlab): restore glab oauth mode

### DIFF
--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -752,6 +752,42 @@ describe('SessionService.buildWrapperSessionReadyAndPromptRequests', () => {
     portMocks.randomPort.mockReturnValue(4173);
   });
 
+  async function buildPromptWrapperRequests(metadata: CloudAgentSessionState) {
+    const service = new SessionService();
+    const env = createEnv();
+    env.WORKER_URL = 'https://cloud-agent.example.com';
+
+    return service.buildWrapperSessionReadyAndPromptRequests({
+      env,
+      plan: {
+        scope: {
+          sessionId: 'agent_test',
+          userId: 'user_test',
+        },
+        turn: {
+          type: 'prompt',
+          messageId: 'msg_018f1e2d3c4bGitLabEnvAAAA',
+          prompt: 'Do the work',
+        },
+        agent: {
+          mode: 'code',
+          model: 'test-model',
+        },
+        workspace: {
+          sandboxId: 'usr-abcdef',
+          metadata,
+        },
+        wrapper: {
+          fence: {
+            wrapperRunId: 'wr_gitlab_env',
+            wrapperGeneration: 2,
+            wrapperConnectionId: 'conn_gitlab_env',
+          },
+        },
+      } satisfies FencedWrapperDispatchRequest,
+    });
+  }
+
   it('passes persisted devcontainer intent to the active wrapper readiness request', async () => {
     const service = new SessionService();
     const env = createEnv();
@@ -882,6 +918,9 @@ describe('SessionService.buildWrapperSessionReadyAndPromptRequests', () => {
     expect(result.promptRequest).not.toHaveProperty('materialized');
     expect(result.readyRequest.materialized.env.PUBLIC_VALUE).toBe('visible');
     expect(result.readyRequest.materialized.env.KILOCODE_TOKEN).toBe('kilo-token');
+    expect(result.readyRequest.materialized.env.GITLAB_TOKEN).toBe('resolved-gitlab-token');
+    expect(result.readyRequest.materialized.env.GITLAB_HOST).toBe('gitlab.com');
+    expect(result.readyRequest.materialized.env.GLAB_IS_OAUTH2).toBe('true');
     expect(result.readyRequest.session.workerAuthToken).toBe('kilo-token');
     expect(result.readyRequest.session.wrapperRunId).toBe('wr_test');
     expect(result.readyRequest).not.toHaveProperty('message');
@@ -906,6 +945,51 @@ describe('SessionService.buildWrapperSessionReadyAndPromptRequests', () => {
     expect(result.promptRequest).not.toHaveProperty('prompt');
     expect(result.promptRequest).not.toHaveProperty('attachments');
     expect(result.promptRequest.session).toEqual(result.readyRequest.session);
+  });
+
+  it('materializes OAuth bearer mode with a self-managed GitLab host', async () => {
+    const result = await buildPromptWrapperRequests(
+      createMetadata({
+        gitUrl: 'https://gitlab.example.com:8443/acme/repo.git',
+        platform: 'gitlab',
+      })
+    );
+
+    expect(result.ready).toMatchObject({
+      gitToken: 'resolved-gitlab-token',
+      gitlabTokenManaged: true,
+    });
+    expect(result.readyRequest.repo).toMatchObject({
+      kind: 'git',
+      url: 'https://gitlab.example.com:8443/acme/repo.git',
+      token: 'resolved-gitlab-token',
+      platform: 'gitlab',
+    });
+    expect(result.readyRequest.materialized.env.GITLAB_TOKEN).toBe('resolved-gitlab-token');
+    expect(result.readyRequest.materialized.env.GITLAB_HOST).toBe('gitlab.example.com:8443');
+    expect(result.readyRequest.materialized.env.GLAB_IS_OAUTH2).toBe('true');
+  });
+
+  it('preserves an explicit profile GLAB_IS_OAUTH2 value when injecting a managed GitLab token', async () => {
+    const result = await buildPromptWrapperRequests(
+      createMetadata({
+        envVars: {
+          GLAB_IS_OAUTH2: 'false',
+        },
+      })
+    );
+
+    expect(result.ready).toMatchObject({
+      gitToken: 'resolved-gitlab-token',
+      gitlabTokenManaged: true,
+    });
+    expect(result.readyRequest.repo).toMatchObject({
+      token: 'resolved-gitlab-token',
+      platform: 'gitlab',
+    });
+    expect(result.readyRequest.materialized.env.GITLAB_TOKEN).toBe('resolved-gitlab-token');
+    expect(result.readyRequest.materialized.env.GITLAB_HOST).toBe('gitlab.com');
+    expect(result.readyRequest.materialized.env.GLAB_IS_OAUTH2).toBe('false');
   });
 });
 

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -991,6 +991,31 @@ describe('SessionService.buildWrapperSessionReadyAndPromptRequests', () => {
     expect(result.readyRequest.materialized.env.GITLAB_HOST).toBe('gitlab.com');
     expect(result.readyRequest.materialized.env.GLAB_IS_OAUTH2).toBe('false');
   });
+
+  it('does not use OAuth bearer mode for inferred legacy GitLab tokens', async () => {
+    const result = await buildPromptWrapperRequests(
+      createMetadata({
+        gitUrl: 'https://gitlab.com/acme/repo.git',
+        gitToken: 'generic-git-token',
+        platform: undefined,
+        gitlabTokenManaged: undefined,
+      })
+    );
+
+    expect(tokenMocks.resolveManagedGitLabToken).not.toHaveBeenCalled();
+    expect(result.ready).toMatchObject({
+      gitToken: 'generic-git-token',
+      gitlabTokenManaged: undefined,
+    });
+    expect(result.readyRequest.repo).toMatchObject({
+      kind: 'git',
+      url: 'https://gitlab.com/acme/repo.git',
+      token: 'generic-git-token',
+    });
+    expect(result.readyRequest.materialized.env.GITLAB_TOKEN).toBe('generic-git-token');
+    expect(result.readyRequest.materialized.env.GITLAB_HOST).toBe('gitlab.com');
+    expect(result.readyRequest.materialized.env.GLAB_IS_OAUTH2).toBeUndefined();
+  });
 });
 
 describe('fetchSessionMetadata', () => {

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -847,6 +847,7 @@ export class SessionService {
     githubToken?: string;
     gitUrl?: string;
     gitToken?: string;
+    gitlabTokenManaged?: boolean;
     upstreamBranch?: string;
     branchName?: string;
     envVars?: Record<string, string>;
@@ -875,6 +876,7 @@ export class SessionService {
       githubToken: options.githubToken,
       gitUrl: options.gitUrl,
       gitToken: options.gitToken,
+      gitlabTokenManaged: options.gitlabTokenManaged,
       platform: options.platform,
       envVars: options.envVars,
     };
@@ -903,6 +905,7 @@ export class SessionService {
       appendSystemPrompt: opts.appendSystemPrompt,
       gitUrl: context.gitUrl,
       gitToken: context.gitToken,
+      gitlabTokenManaged: context.gitlabTokenManaged,
       platform: context.platform,
       profile: effectiveProfile,
     });
@@ -923,6 +926,7 @@ export class SessionService {
       appendSystemPrompt,
       gitUrl,
       gitToken,
+      gitlabTokenManaged,
       platform,
       profile,
     } = opts;
@@ -1116,7 +1120,7 @@ export class SessionService {
     // Set GITLAB_TOKEN for GitLab repos, respecting user overrides
     if (gitToken && effectivePlatform === 'gitlab' && !baseEnvVars.GITLAB_TOKEN) {
       envVars.GITLAB_TOKEN = gitToken;
-      if (baseEnvVars.GLAB_IS_OAUTH2 === undefined) {
+      if (gitlabTokenManaged === true && baseEnvVars.GLAB_IS_OAUTH2 === undefined) {
         envVars.GLAB_IS_OAUTH2 = 'true';
       }
       if (!baseEnvVars.GITLAB_HOST) {
@@ -1329,6 +1333,7 @@ export class SessionService {
       githubToken: resolvedTokens.githubToken,
       gitUrl: git?.url,
       gitToken: resolvedTokens.gitToken,
+      gitlabTokenManaged: resolvedTokens.gitlabTokenManaged,
       upstreamBranch: metadata.repository?.upstreamBranch,
       branchName,
       envVars: profile.envVars,
@@ -1350,6 +1355,7 @@ export class SessionService {
       appendSystemPrompt: metadata.agent?.appendSystemPrompt,
       gitUrl: git?.url,
       gitToken: resolvedTokens.gitToken,
+      gitlabTokenManaged: resolvedTokens.gitlabTokenManaged,
       platform,
       profile,
     });
@@ -1547,6 +1553,7 @@ export class SessionService {
       githubToken: resolvedTokens.githubToken,
       gitUrl: git?.url,
       gitToken: resolvedTokens.gitToken,
+      gitlabTokenManaged: resolvedTokens.gitlabTokenManaged,
       upstreamBranch: metadata.repository?.upstreamBranch,
       branchName,
       envVars: readProfileBundle(metadata).envVars,
@@ -2409,6 +2416,7 @@ type GetSaferEnvVarsOptions = {
   appendSystemPrompt?: string;
   gitUrl?: string;
   gitToken?: string;
+  gitlabTokenManaged?: boolean;
   platform?: 'github' | 'gitlab';
   profile?: SessionProfileBundle;
 };

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -1116,6 +1116,9 @@ export class SessionService {
     // Set GITLAB_TOKEN for GitLab repos, respecting user overrides
     if (gitToken && effectivePlatform === 'gitlab' && !baseEnvVars.GITLAB_TOKEN) {
       envVars.GITLAB_TOKEN = gitToken;
+      if (baseEnvVars.GLAB_IS_OAUTH2 === undefined) {
+        envVars.GLAB_IS_OAUTH2 = 'true';
+      }
       if (!baseEnvVars.GITLAB_HOST) {
         if (gitUrl) {
           try {
@@ -1132,9 +1135,10 @@ export class SessionService {
         .withFields({
           gitUrl,
           gitlabHost: envVars.GITLAB_HOST,
+          glabOAuthMode: envVars.GLAB_IS_OAUTH2 === 'true',
           gitTokenLength: gitToken.length,
         })
-        .info('[GITLAB] Setting GITLAB_TOKEN and GITLAB_HOST for GitLab session');
+        .info('[GITLAB] Configured GitLab CLI environment for GitLab session');
     }
 
     // Only add KILOCODE_ORG_ID if we have an org (personal accounts don't have one)

--- a/services/cloud-agent-next/src/types.ts
+++ b/services/cloud-agent-next/src/types.ts
@@ -73,6 +73,8 @@ export type SessionContext = {
   gitUrl?: string;
   /** Token for generic git authentication (e.g., GitLab token) */
   gitToken?: string;
+  /** Whether the GitLab token was resolved from a managed OAuth integration */
+  gitlabTokenManaged?: boolean;
   /** Git platform type for correct token/env var handling */
   platform?: 'github' | 'gitlab';
   envVars?: Record<string, string>;


### PR DESCRIPTION
## Summary
- Restore GitLab command-line OAuth mode when the agent gives `glab` a managed GitLab token.
- Keep user-set OAuth mode values unchanged and cover the queued review path that hit the 401.

## Verification
1. After deployment, run a GitLab code review for an OAuth-connected project.
2. Confirm the review note is posted or updated without a 401.
3. Run a follow-up review on the same session and confirm it publishes too.

## Visual Changes
N/A

## Reviewer Notes
This fixes the missing bearer-mode flag only. It does not change the separate project-token author issue or add proof that the note was published.