### PR TITLE
fix(kiloclaw): harden destroy collapse planning

### DIFF
--- a/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
+++ b/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
@@ -6,6 +6,7 @@ import {
   collapseOrphanPersonalSubscriptionsOnDestroy,
   FundedRowDemotionRefusedError,
   markInstanceDestroyedWithPersonalSubscriptionCollapse,
+  PersonalSubscriptionCollapseUQConflictError,
   PersonalSubscriptionDestroyConflictError,
 } from '@kilocode/db';
 import {
@@ -66,7 +67,7 @@ async function insertPersonalInstance(params: {
 async function insertPersonalSubscription(params: {
   createdAt: string;
   id: string;
-  instanceId: string;
+  instanceId: string | null;
   plan: PersonalPlan;
   paymentSource?: 'credits' | 'stripe' | null;
   status: PersonalStatus;
@@ -1512,6 +1513,437 @@ describe('personal subscription destroy collapse', () => {
       headPlan: 'trial',
       headStatus: 'canceled',
       headStripeSubscriptionId: null,
+      updateCount: 3,
+    });
+  });
+
+  it('includes detached personal predecessors in collapse planning', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-collapse-detached-predecessor@example.com',
+    });
+
+    const instanceB = crypto.randomUUID();
+    const instanceC = crypto.randomUUID();
+    const subscriptionA = crypto.randomUUID();
+    const subscriptionB = crypto.randomUUID();
+    const subscriptionC = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceB,
+      userId: user.id,
+      createdAt: '2026-04-02T00:00:00.000Z',
+      destroyedAt: '2026-04-03T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceC,
+      userId: user.id,
+      createdAt: '2026-04-04T00:00:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: subscriptionB,
+      userId: user.id,
+      instanceId: instanceB,
+      createdAt: '2026-04-02T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionA,
+      userId: user.id,
+      instanceId: null,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+      transferredToSubscriptionId: subscriptionB,
+    });
+    await insertPersonalSubscription({
+      id: subscriptionC,
+      userId: user.id,
+      instanceId: instanceC,
+      createdAt: '2026-04-04T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: instanceC,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+
+    await expectCurrentHead({ subscriptionId: subscriptionC, userId: user.id });
+
+    const subscriptions = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(subscriptions, {
+      [subscriptionA]: subscriptionB,
+      [subscriptionB]: subscriptionC,
+      [subscriptionC]: null,
+    });
+
+    await expectChangeLogsForSubscriptions([
+      {
+        subscriptionId: subscriptionB,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: subscriptionC,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+    ]);
+
+    expectCollapseStructuredLog({
+      userId: user.id,
+      destroyedInstanceId: instanceC,
+      rowCountTotal: 3,
+      rowCountAlive: 0,
+      headSubscriptionId: subscriptionC,
+      headPlan: 'trial',
+      headStatus: 'canceled',
+      headStripeSubscriptionId: null,
+      updateCount: 1,
+    });
+  });
+
+  it('does not select detached access-granting rows as the collapse head', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-collapse-detached-not-head@example.com',
+    });
+
+    const instanceB = crypto.randomUUID();
+    const instanceC = crypto.randomUUID();
+    const subscriptionA = crypto.randomUUID();
+    const subscriptionB = crypto.randomUUID();
+    const subscriptionC = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceB,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      destroyedAt: '2026-04-02T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceC,
+      userId: user.id,
+      createdAt: '2026-04-02T00:00:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: subscriptionB,
+      userId: user.id,
+      instanceId: instanceB,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionC,
+      userId: user.id,
+      instanceId: instanceC,
+      createdAt: '2026-04-02T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionA,
+      userId: user.id,
+      instanceId: null,
+      createdAt: '2026-04-03T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: instanceC,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+
+    await expectCurrentHead({ subscriptionId: subscriptionC, userId: user.id });
+
+    const subscriptions = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(subscriptions, {
+      [subscriptionB]: subscriptionA,
+      [subscriptionC]: null,
+      [subscriptionA]: subscriptionC,
+    });
+
+    await expectChangeLogsForSubscriptions([
+      {
+        subscriptionId: subscriptionB,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: subscriptionA,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+      {
+        subscriptionId: subscriptionA,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: subscriptionC,
+        beforePlan: 'standard',
+        beforeStatus: 'active',
+      },
+    ]);
+
+    expectCollapseStructuredLog({
+      userId: user.id,
+      destroyedInstanceId: instanceC,
+      rowCountTotal: 3,
+      rowCountAlive: 0,
+      headSubscriptionId: subscriptionC,
+      headPlan: 'trial',
+      headStatus: 'canceled',
+      headStripeSubscriptionId: null,
+      updateCount: 2,
+    });
+  });
+
+  it('throws a typed UQ conflict for invisible target occupants outside the personal planner', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-collapse-uq-conflict@example.com',
+    });
+    const otherUser = await insertTestUser({
+      google_user_email: 'destroy-collapse-uq-conflict-other@example.com',
+    });
+
+    const instanceA = crypto.randomUUID();
+    const instanceB = crypto.randomUUID();
+    const otherUserInstance = crypto.randomUUID();
+    const subscriptionA = crypto.randomUUID();
+    const subscriptionB = crypto.randomUUID();
+    const conflictingSubscription = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceA,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      destroyedAt: '2026-04-02T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceB,
+      userId: user.id,
+      createdAt: '2026-04-03T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: otherUserInstance,
+      userId: otherUser.id,
+      createdAt: '2026-04-04T00:00:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: subscriptionA,
+      userId: user.id,
+      instanceId: instanceA,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionB,
+      userId: user.id,
+      instanceId: instanceB,
+      createdAt: '2026-04-03T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: conflictingSubscription,
+      userId: user.id,
+      instanceId: otherUserInstance,
+      createdAt: '2026-04-04T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+      transferredToSubscriptionId: subscriptionB,
+    });
+
+    const destroyPromise = db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: instanceB,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+
+    await expect(destroyPromise).rejects.toBeInstanceOf(
+      PersonalSubscriptionCollapseUQConflictError
+    );
+    await expect(destroyPromise).rejects.toMatchObject({
+      userId: user.id,
+      selfSubscriptionId: subscriptionA,
+      targetSubscriptionId: subscriptionB,
+      conflictingOccupantId: conflictingSubscription,
+    });
+
+    const [destroyedInstance] = await db
+      .select()
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.id, instanceB));
+    expect(destroyedInstance?.destroyed_at).toBeNull();
+
+    const subscriptions = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(subscriptions, {
+      [subscriptionA]: null,
+      [subscriptionB]: null,
+      [conflictingSubscription]: subscriptionB,
+    });
+
+    await expectNoChangeLogsForSubscriptions([
+      subscriptionA,
+      subscriptionB,
+      conflictingSubscription,
+    ]);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('clears a detached occupant before chaining to the paid head', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-collapse-detached-reporter-shape@example.com',
+    });
+
+    const trialInstance1 = crypto.randomUUID();
+    const paidInstance = crypto.randomUUID();
+    const trialInstance2 = crypto.randomUUID();
+    const trialSubscription1 = crypto.randomUUID();
+    const detachedSubscription = crypto.randomUUID();
+    const paidSubscription = crypto.randomUUID();
+    const trialSubscription2 = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: trialInstance1,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      destroyedAt: '2026-04-02T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: paidInstance,
+      userId: user.id,
+      createdAt: '2026-04-03T00:00:00.000Z',
+      destroyedAt: '2026-04-04T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: trialInstance2,
+      userId: user.id,
+      createdAt: '2026-04-05T00:00:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: trialSubscription1,
+      userId: user.id,
+      instanceId: trialInstance1,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: paidSubscription,
+      userId: user.id,
+      instanceId: paidInstance,
+      createdAt: '2026-04-03T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+      stripeSubscriptionId: 'sub_destroy_collapse_reporter_shape',
+    });
+    await insertPersonalSubscription({
+      id: detachedSubscription,
+      userId: user.id,
+      instanceId: null,
+      createdAt: '2026-04-02T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+      transferredToSubscriptionId: paidSubscription,
+    });
+    await insertPersonalSubscription({
+      id: trialSubscription2,
+      userId: user.id,
+      instanceId: trialInstance2,
+      createdAt: '2026-04-05T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: trialInstance2,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+
+    await expectCurrentHead({ subscriptionId: paidSubscription, userId: user.id });
+
+    const subscriptions = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(subscriptions, {
+      [trialSubscription1]: detachedSubscription,
+      [detachedSubscription]: trialSubscription2,
+      [paidSubscription]: null,
+      [trialSubscription2]: paidSubscription,
+    });
+
+    const paidRow = subscriptions.find(subscription => subscription.id === paidSubscription);
+    expect(paidRow).toEqual(
+      expect.objectContaining({
+        plan: 'standard',
+        status: 'active',
+        transferred_to_subscription_id: null,
+      })
+    );
+
+    await expectChangeLogsForSubscriptions([
+      {
+        subscriptionId: trialSubscription1,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: detachedSubscription,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+      {
+        subscriptionId: detachedSubscription,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: paidSubscription,
+        afterTransferredTo: trialSubscription2,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+      {
+        subscriptionId: trialSubscription2,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: paidSubscription,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+    ]);
+
+    expectCollapseStructuredLog({
+      userId: user.id,
+      destroyedInstanceId: trialInstance2,
+      rowCountTotal: 4,
+      rowCountAlive: 0,
+      headSubscriptionId: paidSubscription,
+      headPlan: 'standard',
+      headStatus: 'active',
+      headStripeSubscriptionId: 'sub_destroy_collapse_reporter_shape',
       updateCount: 3,
     });
   });

--- a/apps/web/src/routers/kiloclaw-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-router.test.ts
@@ -29,7 +29,10 @@ import {
   kiloclaw_subscriptions,
 } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
-import { LEGACY_KILOCLAW_PRICE_VERSION } from '@kilocode/db';
+import {
+  LEGACY_KILOCLAW_PRICE_VERSION,
+  PersonalSubscriptionCollapseUQConflictError,
+} from '@kilocode/db';
 
 (kiloclaw_subscriptions.kiloclaw_price_version as { defaultFn: () => string }).defaultFn = () =>
   LEGACY_KILOCLAW_PRICE_VERSION;
@@ -987,6 +990,88 @@ describe('kiloclawRouter destroy', () => {
         headers: { 'content-type': 'application/json' },
       })
     );
+  });
+
+  it('maps personal subscription collapse UQ conflicts to conflict errors', async () => {
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-destroy-conflict-${Math.random()}@example.com`,
+    });
+    const otherUser = await insertTestUser({
+      google_user_email: `kiloclaw-destroy-conflict-other-${Math.random()}@example.com`,
+    });
+    const instanceA = crypto.randomUUID();
+    const instanceB = crypto.randomUUID();
+    const otherUserInstance = crypto.randomUUID();
+    const subscriptionA = crypto.randomUUID();
+    const subscriptionB = crypto.randomUUID();
+    const conflictingSubscription = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: instanceA,
+        user_id: user.id,
+        sandbox_id: `ki_${instanceA.replace(/-/g, '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+        destroyed_at: '2026-04-02T00:00:00.000Z',
+      },
+      {
+        id: instanceB,
+        user_id: user.id,
+        sandbox_id: `ki_${instanceB.replace(/-/g, '')}`,
+        created_at: '2026-04-03T00:00:00.000Z',
+      },
+      {
+        id: otherUserInstance,
+        user_id: otherUser.id,
+        sandbox_id: `ki_${otherUserInstance.replace(/-/g, '')}`,
+        created_at: '2026-04-04T00:00:00.000Z',
+      },
+    ]);
+    await db.insert(kiloclaw_subscriptions).values([
+      {
+        id: subscriptionA,
+        user_id: user.id,
+        instance_id: instanceA,
+        plan: 'trial',
+        status: 'canceled',
+        created_at: '2026-04-01T00:00:00.000Z',
+        updated_at: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        id: subscriptionB,
+        user_id: user.id,
+        instance_id: instanceB,
+        plan: 'trial',
+        status: 'canceled',
+        created_at: '2026-04-03T00:00:00.000Z',
+        updated_at: '2026-04-03T00:00:00.000Z',
+      },
+      {
+        id: conflictingSubscription,
+        user_id: user.id,
+        instance_id: otherUserInstance,
+        plan: 'trial',
+        status: 'canceled',
+        transferred_to_subscription_id: subscriptionB,
+        created_at: '2026-04-04T00:00:00.000Z',
+        updated_at: '2026-04-04T00:00:00.000Z',
+      },
+    ]);
+
+    await expect(createCaller({ user }).destroy()).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message:
+        'Your subscription state needs support review before this instance can be destroyed.',
+      cause: expect.any(PersonalSubscriptionCollapseUQConflictError),
+    });
+    expect(kiloclawClientMock.__destroyMock).not.toHaveBeenCalled();
+
+    const [instanceAfter] = await db
+      .select()
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.id, instanceB))
+      .limit(1);
+    expect(instanceAfter?.destroyed_at).toBeNull();
   });
 
   it('clears subscription destruction lifecycle and writes changelog', async () => {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -29,6 +29,7 @@ import {
   getKiloClawPlanCostMicrodollars,
   getKiloClawPricingCatalogEntry,
   insertKiloClawSubscriptionChangeLog,
+  PersonalSubscriptionCollapseUQConflictError,
 } from '@kilocode/db';
 import {
   kiloclaw_version_pins,
@@ -3186,7 +3187,26 @@ export const kiloclawRouter = createTRPCRouter({
   }),
 
   destroy: baseProcedure.mutation(async ({ ctx }) => {
-    const destroyedRow = await markActiveInstanceDestroyed(ctx.user.id);
+    let destroyedRow: Awaited<ReturnType<typeof markActiveInstanceDestroyed>>;
+    try {
+      destroyedRow = await markActiveInstanceDestroyed(ctx.user.id);
+    } catch (error) {
+      if (error instanceof PersonalSubscriptionCollapseUQConflictError) {
+        logBillingError('personal subscription collapse UQ conflict', {
+          userId: error.userId,
+          selfSubscriptionId: error.selfSubscriptionId,
+          targetSubscriptionId: error.targetSubscriptionId,
+          conflictingOccupantId: error.conflictingOccupantId,
+        });
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message:
+            'Your subscription state needs support review before this instance can be destroyed.',
+          cause: error,
+        });
+      }
+      throw error;
+    }
     const client = new KiloClawInternalClient();
     let result: Awaited<ReturnType<KiloClawInternalClient['destroy']>>;
     try {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -19,6 +19,7 @@ export {
   FundedRowDemotionRefusedError,
   isAccessGrantingSubscription,
   markInstanceDestroyedWithPersonalSubscriptionCollapse,
+  PersonalSubscriptionCollapseUQConflictError,
   PersonalSubscriptionDestroyConflictError,
   type DestroyedInstanceRow,
 } from './kiloclaw-personal-subscription-collapse';

--- a/packages/db/src/kiloclaw-personal-subscription-collapse.ts
+++ b/packages/db/src/kiloclaw-personal-subscription-collapse.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNotNull, isNull } from 'drizzle-orm';
+import { and, eq, isNull, ne, or } from 'drizzle-orm';
 
 import type { WorkerDb } from './client';
 import {
@@ -14,7 +14,7 @@ type PersonalSubscriptionRow = {
   instance: {
     id: string;
     destroyedAt: string | null;
-  };
+  } | null;
 };
 
 type TransferUpdate = {
@@ -91,6 +91,29 @@ export class FundedRowDemotionRefusedError extends Error {
   }
 }
 
+export class PersonalSubscriptionCollapseUQConflictError extends Error {
+  readonly userId: string;
+  readonly selfSubscriptionId: string;
+  readonly targetSubscriptionId: string;
+  readonly conflictingOccupantId: string;
+
+  constructor(params: {
+    userId: string;
+    selfSubscriptionId: string;
+    targetSubscriptionId: string;
+    conflictingOccupantId: string;
+  }) {
+    super(
+      `Refusing to update personal subscription ${params.selfSubscriptionId} for user ${params.userId}: target ${params.targetSubscriptionId} is already occupied by ${params.conflictingOccupantId} under UQ_kiloclaw_subscriptions_transferred_to`
+    );
+    this.name = 'PersonalSubscriptionCollapseUQConflictError';
+    this.userId = params.userId;
+    this.selfSubscriptionId = params.selfSubscriptionId;
+    this.targetSubscriptionId = params.targetSubscriptionId;
+    this.conflictingOccupantId = params.conflictingOccupantId;
+  }
+}
+
 function compareRowsByCreatedAtAndIdAscending(
   left: PersonalSubscriptionRow,
   right: PersonalSubscriptionRow
@@ -112,7 +135,7 @@ async function listPersonalSubscriptionRows(
   executor: PersonalSubscriptionCollapseWriter,
   userId: string
 ): Promise<PersonalSubscriptionRow[]> {
-  return await executor
+  const rows = await executor
     .select({
       subscription: kiloclaw_subscriptions,
       instance: {
@@ -121,16 +144,31 @@ async function listPersonalSubscriptionRows(
       },
     })
     .from(kiloclaw_subscriptions)
-    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
     .where(
       and(
         eq(kiloclaw_subscriptions.user_id, userId),
-        isNotNull(kiloclaw_subscriptions.instance_id),
-        eq(kiloclaw_instances.user_id, userId),
-        isNull(kiloclaw_instances.organization_id)
+        or(
+          isNull(kiloclaw_subscriptions.instance_id),
+          and(eq(kiloclaw_instances.user_id, userId), isNull(kiloclaw_instances.organization_id))
+        )
       )
     )
     .orderBy(kiloclaw_subscriptions.created_at, kiloclaw_subscriptions.id);
+
+  return rows.map(row => ({
+    subscription: row.subscription,
+    instance: row.instance?.id
+      ? {
+          id: row.instance.id,
+          destroyedAt: row.instance.destroyedAt,
+        }
+      : null,
+  }));
+}
+
+function getAttachedPersonalRows(rows: PersonalSubscriptionRow[]): PersonalSubscriptionRow[] {
+  return rows.filter(row => row.instance !== null);
 }
 
 function getCurrentRows(rows: PersonalSubscriptionRow[]): PersonalSubscriptionRow[] {
@@ -138,7 +176,7 @@ function getCurrentRows(rows: PersonalSubscriptionRow[]): PersonalSubscriptionRo
 }
 
 function getAliveCurrentRows(rows: PersonalSubscriptionRow[]): PersonalSubscriptionRow[] {
-  return getCurrentRows(rows).filter(row => row.instance.destroyedAt === null);
+  return getCurrentRows(rows).filter(row => row.instance?.destroyedAt === null);
 }
 
 /**
@@ -213,8 +251,13 @@ function selectTransferHeadRow(
   return headRow;
 }
 
-function buildDesiredTransferUpdates(rows: PersonalSubscriptionRow[], now: Date): TransferPlan {
-  const headRow = selectTransferHeadRow(rows, now);
+function buildDesiredTransferUpdates(params: {
+  rows: PersonalSubscriptionRow[];
+  headCandidateRows: PersonalSubscriptionRow[];
+  now: Date;
+}): TransferPlan {
+  const { rows, headCandidateRows, now } = params;
+  const headRow = selectTransferHeadRow(headCandidateRows, now);
   const nonHeadRowsDescending = rows
     .filter(row => row.subscription.id !== headRow.subscription.id)
     .sort(compareRowsByCreatedAtAndIdDescending);
@@ -309,12 +352,49 @@ function orderTransferUpdatesForUniqueIndex(
   return orderedUpdates;
 }
 
-function buildTransferPlan(rows: PersonalSubscriptionRow[], now: Date): TransferPlan {
-  const desiredPlan = buildDesiredTransferUpdates(rows, now);
+function buildTransferPlan(params: {
+  rows: PersonalSubscriptionRow[];
+  headCandidateRows: PersonalSubscriptionRow[];
+  now: Date;
+}): TransferPlan {
+  const desiredPlan = buildDesiredTransferUpdates(params);
   return {
     headRow: desiredPlan.headRow,
-    updates: orderTransferUpdatesForUniqueIndex(rows, desiredPlan.updates),
+    updates: orderTransferUpdatesForUniqueIndex(params.rows, desiredPlan.updates),
   };
+}
+
+async function assertTransferTargetSlotAvailable(params: {
+  executor: PersonalSubscriptionCollapseWriter;
+  update: TransferUpdate;
+  userId: string;
+}): Promise<void> {
+  const targetSubscriptionId = params.update.transferredToSubscriptionId;
+  if (targetSubscriptionId === null) {
+    return;
+  }
+
+  const [conflictingOccupant] = await params.executor
+    .select({ id: kiloclaw_subscriptions.id })
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.transferred_to_subscription_id, targetSubscriptionId),
+        ne(kiloclaw_subscriptions.id, params.update.before.id)
+      )
+    )
+    .limit(1);
+
+  if (!conflictingOccupant) {
+    return;
+  }
+
+  throw new PersonalSubscriptionCollapseUQConflictError({
+    userId: params.userId,
+    selfSubscriptionId: params.update.before.id,
+    targetSubscriptionId,
+    conflictingOccupantId: conflictingOccupant.id,
+  });
 }
 
 async function applyTransferUpdates(
@@ -322,11 +402,14 @@ async function applyTransferUpdates(
   updates: TransferUpdate[],
   actor: KiloClawSubscriptionChangeActor,
   reason: string,
-  options: CollapseOptions
+  options: CollapseOptions,
+  userId: string
 ): Promise<string[]> {
   const updatedSubscriptionIds: string[] = [];
 
   for (const update of updates) {
+    await assertTransferTargetSlotAvailable({ executor, update, userId });
+
     const [after] = await executor
       .update(kiloclaw_subscriptions)
       .set({
@@ -393,8 +476,9 @@ export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
   userId: string;
 }): Promise<{ updatedSubscriptionIds: string[] }> {
   const personalRows = await listPersonalSubscriptionRows(params.executor, params.userId);
-  const currentRows = getCurrentRows(personalRows);
-  const aliveCurrentRows = getAliveCurrentRows(personalRows);
+  const attachedPersonalRows = getAttachedPersonalRows(personalRows);
+  const currentRows = getCurrentRows(attachedPersonalRows);
+  const aliveCurrentRows = getAliveCurrentRows(attachedPersonalRows);
 
   if (aliveCurrentRows.length > 1) {
     throw new PersonalSubscriptionDestroyConflictError({
@@ -405,7 +489,7 @@ export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
   }
 
   const aliveRowsAfterDestroy = aliveCurrentRows.filter(
-    row => row.instance.id !== params.destroyedInstanceId
+    row => row.instance?.id !== params.destroyedInstanceId
   );
 
   if (aliveRowsAfterDestroy.length > 0) {
@@ -417,12 +501,20 @@ export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
   }
 
   const now = new Date();
-  const transferPlan = buildTransferPlan(personalRows, now);
+  const transferPlan = buildTransferPlan({
+    rows: personalRows,
+    headCandidateRows: attachedPersonalRows,
+    now,
+  });
   const updates =
     params.buildTransferUpdatesOverride?.({ rows: personalRows, now }) ?? transferPlan.updates;
 
+  const attachedPersonalSubscriptionIds = new Set(
+    attachedPersonalRows.map(row => row.subscription.id)
+  );
   const demotionCandidate = updates.find(
     update =>
+      attachedPersonalSubscriptionIds.has(update.before.id) &&
       update.transferredToSubscriptionId !== null &&
       getHeadSelectionPriority(update.before, now) > 0
   );
@@ -447,14 +539,15 @@ export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
     {
       changeLogFailurePolicy: params.changeLogFailurePolicy,
       onChangeLogFailure: params.onChangeLogFailure,
-    }
+    },
+    params.userId
   );
 
   console.log('personal_subscription_destroy_collapse_applied', {
     userId: params.userId,
     destroyedInstanceId: params.destroyedInstanceId,
     rowCountTotal: personalRows.length,
-    rowCountAlive: personalRows.filter(row => row.instance.destroyedAt === null).length,
+    rowCountAlive: personalRows.filter(row => row.instance?.destroyedAt === null).length,
     headSubscriptionId: transferPlan.headRow.subscription.id,
     headPlan: transferPlan.headRow.subscription.plan,
     headStatus: transferPlan.headRow.subscription.status,

--- a/services/kiloclaw/src/routes/platform-provision-bootstrap.test.ts
+++ b/services/kiloclaw/src/routes/platform-provision-bootstrap.test.ts
@@ -62,6 +62,7 @@ import { BootstrapProvisionFallbackError } from './provision-bootstrap';
 type SelectBuilder<T> = Promise<T[]> & {
   from: ReturnType<typeof vi.fn>;
   innerJoin: ReturnType<typeof vi.fn>;
+  leftJoin: ReturnType<typeof vi.fn>;
   where: ReturnType<typeof vi.fn>;
   orderBy: ReturnType<typeof vi.fn>;
   limit: ReturnType<typeof vi.fn>;
@@ -71,12 +72,14 @@ function createSelectBuilder<T>(rows: T[]): SelectBuilder<T> {
   const builder = Object.assign(Promise.resolve(rows), {
     from: vi.fn(),
     innerJoin: vi.fn(),
+    leftJoin: vi.fn(),
     where: vi.fn(),
     orderBy: vi.fn(),
     limit: vi.fn(),
   }) as SelectBuilder<T>;
   builder.from.mockReturnValue(builder);
   builder.innerJoin.mockReturnValue(builder);
+  builder.leftJoin.mockReturnValue(builder);
   builder.where.mockReturnValue(builder);
   builder.orderBy.mockReturnValue(builder);
   builder.limit.mockReturnValue(builder);


### PR DESCRIPTION
## Summary

Hardens personal KiloClaw destroy subscription collapse against subscription rows that occupy the global transfer unique index but were invisible to the personal collapse planner.

### Why this change is needed

A user hit a blocking 500 while destroying a personal KiloClaw instance because the collapse planner tried to update `transferred_to_subscription_id` to a value already occupied by another row. The conflicting row had the same `user_id` but `instance_id IS NULL`, so it was excluded from the planner’s inner-join view while still participating in the global partial unique index `UQ_kiloclaw_subscriptions_transferred_to`.

That mismatch made the destroy path fail at UPDATE time, roll back the transaction, and leave the user with no self-service recovery path. Detached personal rows can exist from historical chain-rewrite behavior, so the planner needs to account for them without widening into organization-owned subscription chains.

### How this is addressed

- Expands the personal collapse planning view to include same-user detached subscription rows (`instance_id IS NULL`) with a `LEFT JOIN`.
- Keeps live-access and head-selection decisions limited to attached personal rows, so detached rows cannot become the access-granting head.
- Uses the broader row set for transfer ordering, letting the planner see detached rows that occupy `transferred_to_subscription_id` slots and clear or reorder them safely.
- Adds a typed `PersonalSubscriptionCollapseUQConflictError` and a per-target unique-index probe before each transfer update.
- Maps unforeseen invisible occupant conflicts in the destroy router to a structured `CONFLICT` response instead of a raw duplicate-key 500.
- Adds regression coverage for detached predecessors, detached-row head exclusion, unseen UQ occupants, and the reporter-shaped collapse chain.

## Human Verification

<details>
<summary>Tests run locally</summary>

- `pnpm test -- apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts apps/web/src/routers/kiloclaw-router.test.ts`

</details>

## Reviewer Notes

### Human Reviewer Flags

- No schema or migration changes; the partial unique index remains the source of truth.
- Organization-instance rows remain intentionally out of scope for the personal planner and continue to belong to the organization collapse path.
- The new conflict path is intentionally non-mutating for unforeseen invisible-row classes; it surfaces support-review state rather than silently rewriting data outside the planner’s known scope.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Detached rows are represented as `instance: null`; no synthetic live-instance sentinel is used.
- `attachedPersonalRows` drives alive-current checks and head selection.
- The full widened row set drives UQ-aware ordering and change-log-backed transfer updates.
- The router logs `personal subscription collapse UQ conflict` with the relevant subscription IDs before returning `CONFLICT`.

</details>
