### PR TITLE
feat(config): add auto_expand_history field

### DIFF
--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -36,6 +36,10 @@ const agentConfig = {
 
 export const kiloExtras = {
   top: {
+    auto_expand_history: {
+      description: 'Automatically expand command history when searching',
+      type: 'boolean',
+    },
     model: {
       description: 'Model to use in the format of provider/model, eg anthropic/claude-2',
       ...nullableModel,

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -32,6 +32,7 @@ describe('kilo config.json schema merge', () => {
   test('adds kilo-only top-level keys', () => {
     expect(props.commit_message).toBeDefined();
     expect(props.remote_control).toBeDefined();
+    expect(props.auto_expand_history).toBeDefined();
   });
 
   test('commit_message has a prompt string property', () => {


### PR DESCRIPTION
## Summary
- Mirror the linked kilocode CLI schema change by allowing the Kilo-only `auto_expand_history` config key in the cloud-hosted JSON schema.
- Add test coverage so the schema merge test verifies the new top-level key is included.
- Replace #3408 from a fork with an in-repo branch so CI can access repository secrets for the Vercel build step.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
Supersedes #3408. The code changes match the fork PR; only the PR source branch changed to avoid missing secrets in CI.