### PR TITLE
fix(admin): relax userId validation in gastown router for legacy oauth/* IDs

### DIFF
--- a/apps/web/src/routers/admin/gastown-router.ts
+++ b/apps/web/src/routers/admin/gastown-router.ts
@@ -392,7 +392,7 @@ export const adminGastownRouter = createTRPCRouter({
    * Calls: GET /api/users/:userId/towns (kiloAuthMiddleware, no ownership check)
    */
   getUserTowns: adminProcedure
-    .input(z.object({ userId: z.string().uuid() }))
+    .input(z.object({ userId: z.string().min(1) }))
     .output(z.array(UserTownRecord))
     .query(({ input, ctx }) => {
       return gastownGet(ctx.user, `/api/users/${input.userId}/towns`, z.array(UserTownRecord));
@@ -403,7 +403,7 @@ export const adminGastownRouter = createTRPCRouter({
    * Calls: GET /api/users/:userId/towns/:townId/rigs for each town.
    */
   getUserRigs: adminProcedure
-    .input(z.object({ userId: z.string().uuid() }))
+    .input(z.object({ userId: z.string().min(1) }))
     .output(z.array(UserRigRecord))
     .query(async ({ input, ctx }) => {
       const towns = await gastownGet(


### PR DESCRIPTION
## Summary

Relax `userId` input validation in `admin.gastown.getUserTowns` and `admin.gastown.getUserRigs` from `z.string().uuid()` to `z.string().min(1)`, allowing legacy `oauth/...` user IDs to pass validation. The downstream gastown service already accepts arbitrary string IDs — the Zod UUID constraint was the only thing rejecting them.

## Verification

Loaded the admin Gas Town tab for a user with an `oauth/google/...` ID and confirmed it renders without a BAD_REQUEST error.

## Visual Changes

N/A

## Reviewer Notes

Single-file change, two identical validator relaxations. No other admin router constrains userId to UUID.