### PR TITLE
fix(referrals): redeem Impact month rewards

### DIFF
--- a/apps/web/src/lib/impact/advocate.test.ts
+++ b/apps/web/src/lib/impact/advocate.test.ts
@@ -190,7 +190,7 @@ describe('impact advocate', () => {
     const result = await sendImpactAdvocateRewardRedemptionPayload({
       rewardId: 'reward-123',
       amount: 1,
-      unit: 'free-months',
+      unit: 'MONTH',
     });
 
     expect(result).toEqual({ ok: true, statusCode: 200, responseBody: '{"ok":true}' });
@@ -205,7 +205,7 @@ describe('impact advocate', () => {
         Accept: 'application/json',
         'Content-Type': 'application/json',
       }),
-      body: '{"amount":1,"unit":"free-months"}',
+      body: '{"amount":1,"unit":"MONTH"}',
     });
   });
 

--- a/apps/web/src/lib/impact/kiloclaw-referrals.test.ts
+++ b/apps/web/src/lib/impact/kiloclaw-referrals.test.ts
@@ -270,7 +270,7 @@ describe('kiloclaw referrals', () => {
             userId: user.google_user_email,
             rewardTypeFilter: 'CREDIT',
           },
-          redemption: { amount: 1, unit: 'free-months' },
+          redemption: { amount: 1, unit: 'MONTH' },
         },
       });
       mockSendImpactAdvocateRewardRedemptionPayload.mockResolvedValueOnce({
@@ -311,7 +311,7 @@ describe('kiloclaw referrals', () => {
             userId: user.google_user_email,
             rewardTypeFilter: 'CREDIT',
           },
-          redemption: { amount: 1, unit: 'free-months' },
+          redemption: { amount: 1, unit: 'MONTH' },
         },
       });
       mockSendImpactAdvocateRewardRedemptionPayload.mockResolvedValueOnce({
@@ -331,6 +331,66 @@ describe('kiloclaw referrals', () => {
           impact_reward_id: 'impact-reward-123',
           response_status_code: 400,
           redeem_response_payload: expect.objectContaining({ alreadyRedeemed: true }),
+        })
+      );
+    });
+
+    it('redeems month credits returned by Impact', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'month-credit@example.com',
+        normalized_email: 'month-credit@example.com',
+      });
+      const rewardId = await insertAppliedReferralRewardForUser(user.id);
+      await db.insert(impact_advocate_reward_redemptions).values({
+        reward_id: rewardId,
+        dedupe_key: `month-credit:${rewardId}`,
+        beneficiary_user_id: user.id,
+        state: 'queued',
+        request_payload: {
+          lookup: {
+            accountId: user.google_user_email,
+            userId: user.google_user_email,
+            rewardTypeFilter: 'CREDIT',
+          },
+          redemption: { amount: 1, unit: 'MONTH' },
+        },
+      });
+      mockSendImpactAdvocateRewardLookupPayload.mockResolvedValueOnce({
+        ok: true,
+        statusCode: 200,
+        responseBody: JSON.stringify([
+          {
+            id: 'impact-month-reward',
+            type: 'CREDIT',
+            unit: 'MONTH',
+            assignedCredit: 1,
+            redeemedCredit: 0,
+          },
+        ]),
+        rewards: [
+          {
+            id: 'impact-month-reward',
+            type: 'CREDIT',
+            unit: 'MONTH',
+            assignedCredit: 1,
+            redeemedCredit: 0,
+          },
+        ],
+      });
+
+      const summary = await dispatchQueuedImpactAdvocateRewardRedemptions();
+
+      expect(summary).toEqual({ claimed: 1, redeemed: 1, retried: 0, failed: 0 });
+      expect(mockSendImpactAdvocateRewardRedemptionPayload).toHaveBeenCalledWith({
+        rewardId: 'impact-month-reward',
+        amount: 1,
+        unit: 'MONTH',
+      });
+      const [redemption] = await db.select().from(impact_advocate_reward_redemptions);
+      expect(redemption).toEqual(
+        expect.objectContaining({
+          state: 'redeemed',
+          impact_reward_id: 'impact-month-reward',
         })
       );
     });
@@ -1439,7 +1499,7 @@ describe('kiloclaw referrals', () => {
       expect(mockSendImpactAdvocateRewardRedemptionPayload).toHaveBeenCalledWith({
         rewardId: 'impact-reward-123',
         amount: 1,
-        unit: 'free-months',
+        unit: 'MONTH',
       });
 
       const redeemedRedemptions = await db.select().from(impact_advocate_reward_redemptions);

--- a/apps/web/src/lib/impact/kiloclaw-referrals.ts
+++ b/apps/web/src/lib/impact/kiloclaw-referrals.ts
@@ -126,7 +126,7 @@ const REFERRAL_REWARD_ACTOR = {
 } as const;
 
 const SIGNUP_REFERRAL_TOUCH_CAPTURE_GRACE_MS = 10 * 60 * 1000;
-const IMPACT_ADVOCATE_REWARD_UNIT = 'free-months';
+const IMPACT_ADVOCATE_REWARD_UNIT = 'MONTH';
 
 function getDatabaseClient(database?: DatabaseClient): DatabaseClient {
   return database ?? db;

--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -729,7 +729,7 @@ describe('User', () => {
             userId: user.google_user_email,
             rewardTypeFilter: 'CREDIT',
           },
-          redemption: { amount: 1, unit: 'free-months' },
+          redemption: { amount: 1, unit: 'MONTH' },
         },
       });
       await db.insert(impact_conversion_reports).values({


### PR DESCRIPTION
## Summary
Impact Advocate KiloClaw reward redemptions now use the provider's `MONTH` credit unit so valid rewards can be selected and redeemed.

### Why this change is needed
Impact returns earned free-month credits with `unit: "MONTH"`, while redemption requests used `unit: "free-months"`. Exact unit matching rejected returned credits as `impact_reward_not_found`, leaving redemption attempts retrying without reaching the redemption endpoint.

### How this is addressed
- Send and match Impact Advocate redemption credits using the provider unit `MONTH`.
- Cover the returned `MONTH` reward shape and redemption request contract with regression tests.
- Keep GDPR cleanup fixture data aligned with the supported redemption payload shape.

## Human Verification
- Verified Impact Advocate redemption and GDPR cleanup regression tests cover the corrected payload behavior.
- Checked behavior against Impact referral redemption requirements in `.specs/impact-referrals.md`.

## Reviewer Notes
### Human Reviewer Flags
- This change establishes `MONTH` as the supported Impact reward unit; existing retry rows persisted with `free-months` require the operational SQL update before they can match returned rewards.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Impact's successful lookup response contained a redeemable `CREDIT` reward with `unit: "MONTH"`; the previous local constant used `free-months`.
- Change is intentionally contract-aligned without a runtime legacy-unit fallback.
- Focused logic and API/type review passes reported no actionable issues.

</details>