### PR TITLE
fix(kiloclaw) orphan volume grace sql correlation

### DIFF
--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -3288,34 +3288,39 @@ describe('admin.kiloclawInstances.destroyOrphanVolume', () => {
       google_user_email: `unrelated-recent-${Math.random()}@example.com`,
       is_admin: false,
     });
-    await db.insert(kiloclaw_instances).values({
-      id: crypto.randomUUID(),
-      user_id: otherUser.id,
-      sandbox_id: `ki_${crypto.randomUUID().replace(/-/g, '')}`,
-      destroyed_at: daysAgo(1),
-    });
-    const targetInstanceId = await insertDestroyedInstance({ destroyedAt: daysAgo(30) });
-    mockDestroyOrphanVolume.mockResolvedValue({
-      ok: true,
-      flyApp: 'inst-scoped',
-      volumeId: VOLUME_ID,
-      volumeName: 'kiloclaw_scoped',
-      alreadyGone: false,
-    });
-    const caller = await createCallerForUser(adminUser.id);
+    // The outer afterEach only cleans `regularUser` / `adminUser` /
+    // `cliRunUser`, so this unrelated user must be cleaned up explicitly. A
+    // try/finally guarantees the cleanup runs even when an assertion in the
+    // body throws — otherwise a failing run would leave the row in the table
+    // and pollute subsequent tests.
+    try {
+      await db.insert(kiloclaw_instances).values({
+        id: crypto.randomUUID(),
+        user_id: otherUser.id,
+        sandbox_id: `ki_${crypto.randomUUID().replace(/-/g, '')}`,
+        destroyed_at: daysAgo(1),
+      });
+      const targetInstanceId = await insertDestroyedInstance({ destroyedAt: daysAgo(30) });
+      mockDestroyOrphanVolume.mockResolvedValue({
+        ok: true,
+        flyApp: 'inst-scoped',
+        volumeId: VOLUME_ID,
+        volumeName: 'kiloclaw_scoped',
+        alreadyGone: false,
+      });
+      const caller = await createCallerForUser(adminUser.id);
 
-    const result = await caller.admin.kiloclawInstances.destroyOrphanVolume({
-      instanceId: targetInstanceId,
-      volumeId: VOLUME_ID,
-    });
+      const result = await caller.admin.kiloclawInstances.destroyOrphanVolume({
+        instanceId: targetInstanceId,
+        volumeId: VOLUME_ID,
+      });
 
-    expect(result).toMatchObject({ success: true });
-    expect(mockDestroyOrphanVolume).toHaveBeenCalledTimes(1);
-
-    // afterEach cleans by `regularUser` / `adminUser` / `cliRunUser`; this
-    // unrelated user's instance must be cleaned up explicitly.
-    await db.delete(kiloclaw_instances).where(eq(kiloclaw_instances.user_id, otherUser.id));
-    await db.delete(kilocode_users).where(eq(kilocode_users.id, otherUser.id));
+      expect(result).toMatchObject({ success: true });
+      expect(mockDestroyOrphanVolume).toHaveBeenCalledTimes(1);
+    } finally {
+      await db.delete(kiloclaw_instances).where(eq(kiloclaw_instances.user_id, otherUser.id));
+      await db.delete(kilocode_users).where(eq(kilocode_users.id, otherUser.id));
+    }
   });
 
   it('rejects when the user has an access-granting subscription', async () => {

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -3269,6 +3269,55 @@ describe('admin.kiloclawInstances.destroyOrphanVolume', () => {
     expect(mockDestroyOrphanVolume).toHaveBeenCalledTimes(1);
   });
 
+  it('measures grace per (user, sandbox), not across the entire table', async () => {
+    // Regression: an earlier shape of the grace SQL used Drizzle's
+    // `${kiloclaw_instances.user_id}` interpolation inside a `sql` template,
+    // which Drizzle rendered as a BARE `"user_id"` (no table qualifier).
+    // Postgres then resolved that bare reference to the inner aliased table
+    // (most-local scope), collapsing the correlated subquery into a
+    // trivially-true predicate and computing `max(destroyed_at)` over EVERY
+    // destroyed row in the table. In production that maximum is almost
+    // always recent, so the grace gate would fail closed for every destroy
+    // regardless of the target's actual destruction time.
+    //
+    // This test seeds an unrelated user with a destroyed_at inside the last
+    // 7 days alongside a 30-day-old target row. With a properly scoped
+    // correlation the unrelated row is invisible to the target's grace
+    // check; with the bug present, the destroy throws PRECONDITION_FAILED.
+    const otherUser = await insertTestUser({
+      google_user_email: `unrelated-recent-${Math.random()}@example.com`,
+      is_admin: false,
+    });
+    await db.insert(kiloclaw_instances).values({
+      id: crypto.randomUUID(),
+      user_id: otherUser.id,
+      sandbox_id: `ki_${crypto.randomUUID().replace(/-/g, '')}`,
+      destroyed_at: daysAgo(1),
+    });
+    const targetInstanceId = await insertDestroyedInstance({ destroyedAt: daysAgo(30) });
+    mockDestroyOrphanVolume.mockResolvedValue({
+      ok: true,
+      flyApp: 'inst-scoped',
+      volumeId: VOLUME_ID,
+      volumeName: 'kiloclaw_scoped',
+      alreadyGone: false,
+    });
+    const caller = await createCallerForUser(adminUser.id);
+
+    const result = await caller.admin.kiloclawInstances.destroyOrphanVolume({
+      instanceId: targetInstanceId,
+      volumeId: VOLUME_ID,
+    });
+
+    expect(result).toMatchObject({ success: true });
+    expect(mockDestroyOrphanVolume).toHaveBeenCalledTimes(1);
+
+    // afterEach cleans by `regularUser` / `adminUser` / `cliRunUser`; this
+    // unrelated user's instance must be cleaned up explicitly.
+    await db.delete(kiloclaw_instances).where(eq(kiloclaw_instances.user_id, otherUser.id));
+    await db.delete(kilocode_users).where(eq(kilocode_users.id, otherUser.id));
+  });
+
   it('rejects when the user has an access-granting subscription', async () => {
     const instanceId = await insertDestroyedInstance({
       destroyedAt: daysAgo(30),

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -4114,13 +4114,26 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       // 1. Re-fetch the instance. Every DB-side guard is re-evaluated here —
       //    the scan result the admin saw may be stale.
+      // Aliased outer table so the correlated subquery below can refer to
+      // it as `target_inst.*`. Drizzle interpolates `${kiloclaw_instances.X}`
+      // inside a raw `sql` template as a BARE `"X"` column reference (no
+      // table qualifier). Postgres then resolves that bare reference to the
+      // most-local scope — the inner `sandbox_destroys` alias — which
+      // collapses the correlation to a trivially-true
+      // `sandbox_destroys.user_id = sandbox_destroys.user_id` and turns the
+      // subquery into a table-wide `max(destroyed_at)`. With many users in
+      // production that max is always recent, so the grace gate would fail
+      // closed for every destroy regardless of the target. Aliasing the
+      // outer table and writing the correlation columns as literal SQL
+      // keeps every reference explicitly qualified.
+      const targetInstance = alias(kiloclaw_instances, 'target_inst');
       const [row] = await db
         .select({
-          id: kiloclaw_instances.id,
-          user_id: kiloclaw_instances.user_id,
-          sandbox_id: kiloclaw_instances.sandbox_id,
-          organization_id: kiloclaw_instances.organization_id,
-          destroyed_at: kiloclaw_instances.destroyed_at,
+          id: targetInstance.id,
+          user_id: targetInstance.user_id,
+          sandbox_id: targetInstance.sandbox_id,
+          organization_id: targetInstance.organization_id,
+          destroyed_at: targetInstance.destroyed_at,
           // Whether the orphan-volume grace period has elapsed, evaluated
           // entirely in Postgres. Grace runs from the LATEST destruction of
           // this (user, sandbox): a reprovisioned sandbox has several
@@ -4131,15 +4144,15 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           // text differs across the Vercel and Cloudflare runtimes.
           grace_period_elapsed: sql<boolean>`
             extract(epoch from (now() - (
-              select max(latest.destroyed_at)
-              from ${kiloclaw_instances} as latest
-              where latest.user_id = ${kiloclaw_instances.user_id}
-                and latest.sandbox_id = ${kiloclaw_instances.sandbox_id}
-                and latest.destroyed_at is not null
+              select max(sandbox_destroys.destroyed_at)
+              from ${kiloclaw_instances} as sandbox_destroys
+              where sandbox_destroys.user_id = target_inst.user_id
+                and sandbox_destroys.sandbox_id = target_inst.sandbox_id
+                and sandbox_destroys.destroyed_at is not null
             ))) * 1000 > ${ORPHAN_VOLUME_GRACE_PERIOD_MS}`,
         })
-        .from(kiloclaw_instances)
-        .where(eq(kiloclaw_instances.id, input.instanceId))
+        .from(targetInstance)
+        .where(eq(targetInstance.id, input.instanceId))
         .limit(1);
 
       if (!row) {

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -78,6 +78,7 @@ import type { ProviderId } from '../schemas/instance-config';
 import { doKeyFromActiveInstance, resolveDoKeyForUser } from '../lib/instance-routing';
 import { getInstanceById, getInstanceByIdIncludingDestroyed, getWorkerDb } from '../db';
 import { and, eq, isNull, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import { volumeNameFromSandboxId } from '../durable-objects/machine-config';
 import { fallbackAppNameForRestore } from '../durable-objects/kiloclaw-instance/postgres';
 import { getAppKey } from '../durable-objects/kiloclaw-instance/types';
@@ -4036,13 +4037,25 @@ platform.post('/admin/orphan-volume-destroy', async c => {
     return c.json({ error: 'Database connection is not configured' }, 503);
   }
   const workerDb = getWorkerDb(connectionString);
+  // Aliased outer table so the correlated subquery below can refer to it as
+  // `target_inst.*`. Drizzle interpolates `${kiloclaw_instances.X}` inside a
+  // raw `sql` template as a BARE `"X"` column reference (no table qualifier).
+  // Postgres then resolves that bare reference to the most-local scope — the
+  // inner `sandbox_destroys` alias — which collapses the correlation to a
+  // trivially-true `sandbox_destroys.user_id = sandbox_destroys.user_id` and
+  // turns the subquery into a table-wide `max(destroyed_at)`. With many
+  // users in production that max is always recent, so the grace gate would
+  // fail closed for every destroy regardless of the target. Aliasing the
+  // outer table and writing the correlation columns as literal SQL keeps
+  // every reference explicitly qualified.
+  const targetInstance = alias(kiloclaw_instances, 'target_inst');
   const [instance] = await workerDb
     .select({
-      id: kiloclaw_instances.id,
-      userId: kiloclaw_instances.user_id,
-      sandboxId: kiloclaw_instances.sandbox_id,
-      organizationId: kiloclaw_instances.organization_id,
-      destroyedAt: kiloclaw_instances.destroyed_at,
+      id: targetInstance.id,
+      userId: targetInstance.user_id,
+      sandboxId: targetInstance.sandbox_id,
+      organizationId: targetInstance.organization_id,
+      destroyedAt: targetInstance.destroyed_at,
       // Whether the orphan-volume grace period has elapsed, evaluated entirely
       // in Postgres. Grace runs from the LATEST destruction of this
       // (user, sandbox): a reprovisioned sandbox has several destroyed rows
@@ -4053,15 +4066,15 @@ platform.post('/admin/orphan-volume-destroy', async c => {
       // across the Vercel and Cloudflare runtimes.
       gracePeriodElapsed: sql<boolean>`
         extract(epoch from (now() - (
-          select max(latest.destroyed_at)
-          from ${kiloclaw_instances} as latest
-          where latest.user_id = ${kiloclaw_instances.user_id}
-            and latest.sandbox_id = ${kiloclaw_instances.sandbox_id}
-            and latest.destroyed_at is not null
+          select max(sandbox_destroys.destroyed_at)
+          from ${kiloclaw_instances} as sandbox_destroys
+          where sandbox_destroys.user_id = target_inst.user_id
+            and sandbox_destroys.sandbox_id = target_inst.sandbox_id
+            and sandbox_destroys.destroyed_at is not null
         ))) * 1000 > ${ORPHAN_VOLUME_GRACE_PERIOD_MS}`,
     })
-    .from(kiloclaw_instances)
-    .where(eq(kiloclaw_instances.id, instanceId))
+    .from(targetInstance)
+    .where(eq(targetInstance.id, instanceId))
     .limit(1);
 
   if (!instance) {


### PR DESCRIPTION
## Summary

The orphan volume destroy gate was rejecting every destroy with the
message "Instance was destroyed too recently" even when the target was
many weeks past the 7 day grace period. The admin orphan volume cleanup
tool was effectively unusable.

The grace check builds a correlated subquery in Drizzle using a `sql`
template. The template interpolated outer column references via
`${kiloclaw_instances.user_id}` and `${kiloclaw_instances.sandbox_id}`.
Drizzle renders those inside a raw `sql` template as bare unqualified
column references (`"user_id"`, `"sandbox_id"`). Postgres resolves bare
references inside a subquery scope to the most local table, which is
the inner alias. So the intended correlation collapsed into
`sandbox_destroys.user_id = sandbox_destroys.user_id`, a trivially true
predicate. The subquery then computed `max(destroyed_at)` across every
destroyed row in the entire table. Because production always has some
recent destruction, the grace gate failed closed for every call,
regardless of the actual target instance.

The fix aliases the outer table as `target_inst` and writes both sides
of the correlation as literal SQL text in the `sql` template, so every
reference stays explicitly qualified. The same pattern is applied to
the kiloclaw worker route in `services/kiloclaw/src/routes/platform.ts`,
which carried the same bug.

A new regression test seeds an unrelated user with a `destroyed_at`
inside the last 7 days alongside a target row destroyed 30 days ago.
With the previous code that unrelated row inflated the max and the
destroy failed; with the fix the correlation is scoped to the target's
(user, sandbox) and the destroy succeeds. Earlier coverage missed this
because the test database only ever held the test's own destroyed
rows, so the broken table wide max happened to equal the correct per
sandbox max.

## Verification

The bug only manifests when the `kiloclaw_instances` table contains
rows from multiple users with a recent `destroyed_at`. Test
environments with limited seeded data do not exercise the broken
correlation, because the maximum across all destroyed rows happens to
equal the maximum for the target sandbox. Manual verification before
merge is therefore not feasible in a non production database.

After the deploy:

- [ ] Retry destroying an orphan volume from the admin orphan volume
      cleanup tool for an instance destroyed more than 7 days ago and
      confirm it succeeds.

## Visual Changes

N/A. This PR changes server query logic and test coverage only. There
are no UI changes.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

Focus areas:

- The crux is Drizzle interpolating `${kiloclaw_instances.user_id}`
  inside a raw `sql` template as a bare `"user_id"` rather than a
  qualified `"kiloclaw_instances"."user_id"`. Without an outer table
  alias and explicit qualification on both sides of the correlation,
  Postgres binds the bare reference to the inner aliased table and the
  correlation collapses.
- Aliasing the outer table as `target_inst` plus writing both sides of
  the correlation as literal SQL text in the `sql` template is what
  keeps the references explicitly qualified end to end.
- The new regression test seeds two users so the bug would manifest in
  the test environment. The cleanup of the unrelated user is wrapped
  in a try / finally so an assertion failure cannot leave rows behind
  for the next test.
- The kiloclaw worker route received the same fix because it carried
  the same buggy pattern.
