### PR TITLE
test(kiloclaw): assert Kilo Chat plugin in smoke tests

### DIFF
--- a/services/kiloclaw/scripts/controller-entrypoint-smoke-test.sh
+++ b/services/kiloclaw/scripts/controller-entrypoint-smoke-test.sh
@@ -9,6 +9,9 @@ IMAGE="${IMAGE:-kiloclaw:controller}"
 TOKEN="${TOKEN:-smoke-token}"
 PORT="${PORT:-18790}"
 KILOCODE_API_KEY="${KILOCODE_API_KEY:-smoke-kilocode-key}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/controller-smoke-helpers.sh"
 
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
   echo "Image '$IMAGE' is not available locally."
@@ -115,6 +118,8 @@ CODE=$(curl -s -o /dev/null -w "%{http_code}" \
   -H "Authorization: Bearer $TOKEN" \
   "http://127.0.0.1:${PORT}/_kilo/gateway/status")
 check "gateway status (bearer auth) -> 200" "200" "$CODE"
+
+assert_kilo_chat_smoke "$CID" "$PORT" "$TOKEN"
 
 echo
 echo "--- proxy token ---"

--- a/services/kiloclaw/scripts/controller-smoke-helpers.sh
+++ b/services/kiloclaw/scripts/controller-smoke-helpers.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# Shared assertions for KiloClaw controller image smoke scripts.
+# Expects the caller to define a `check <label> <expected> <actual>` function.
+
+assert_kilo_chat_config_patched() {
+  local cid="$1"
+  local details
+
+  if details=$(docker exec -i "$cid" python3 - <<'PY' 2>&1
+import json
+from pathlib import Path
+
+config_path = Path('/root/.openclaw/openclaw.json')
+doc = json.loads(config_path.read_text())
+channel = doc.get('channels', {}).get('kilo-chat', {})
+plugins = doc.get('plugins', {})
+entries = plugins.get('entries', {})
+load = plugins.get('load', {})
+paths = load.get('paths', [])
+expected_path = '/usr/local/lib/node_modules/@kiloclaw/kilo-chat'
+
+checks = [
+    ('channels.kilo-chat.enabled', channel.get('enabled') is True),
+    ('channels.kilo-chat._configured', channel.get('_configured') is True),
+    ('plugins.load.paths includes kilo-chat', expected_path in paths),
+    ('plugins.entries.kilo-chat.enabled', entries.get('kilo-chat', {}).get('enabled') is True),
+]
+failed = [name for name, ok in checks if not ok]
+if failed:
+    raise SystemExit('missing/invalid: ' + ', '.join(failed))
+print('ok')
+PY
+  ); then
+    check "kilo-chat config patched" "ok" "$details"
+  else
+    check "kilo-chat config patched" "ok" "failed"
+    echo "  details: $details"
+  fi
+}
+
+assert_kilo_chat_plugin_loaded() {
+  local cid="$1"
+  local plugin_json
+  local details
+
+  if ! plugin_json=$(docker exec "$cid" openclaw plugins inspect kilo-chat --json 2>&1); then
+    check "kilo-chat plugin inspect" "loaded" "failed"
+    echo "  output: $plugin_json"
+    return
+  fi
+
+  if details=$(python3 -c '
+import json
+import sys
+
+doc = json.load(sys.stdin)
+plugin = doc.get("plugin", {})
+status = plugin.get("status")
+error = plugin.get("error")
+route_count = doc.get("httpRouteCount", 0)
+if status != "loaded":
+    raise SystemExit(f"status={status!r}")
+if error:
+    raise SystemExit(f"error={error!r}")
+if not isinstance(route_count, int) or route_count < 1:
+    raise SystemExit(f"httpRouteCount={route_count!r}")
+print("loaded")
+' <<< "$plugin_json" 2>&1); then
+    check "kilo-chat plugin inspect" "loaded" "$details"
+  else
+    check "kilo-chat plugin inspect" "loaded" "failed"
+    echo "  details: $details"
+    echo "  output: $plugin_json"
+  fi
+}
+
+assert_kilo_chat_webhook_route() {
+  local port="$1"
+  local token="$2"
+  local body_file
+  local code
+  local body_check
+
+  body_file=$(mktemp)
+  code=$(curl -sS -o "$body_file" -w "%{http_code}" \
+    -X POST \
+    -H "x-kiloclaw-proxy-token: $token" \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    --data 'not-json' \
+    "http://127.0.0.1:${port}/plugins/kilo-chat/webhook" 2>/dev/null || true)
+
+  check "kilo-chat webhook invalid JSON -> 400" "400" "$code"
+
+  if body_check=$(python3 -c '
+import json
+import sys
+
+doc = json.load(open(sys.argv[1]))
+if doc.get("error") != "Invalid JSON":
+    raise SystemExit(doc)
+print("Invalid JSON")
+' "$body_file" 2>&1); then
+    check "kilo-chat webhook error body" "Invalid JSON" "$body_check"
+  else
+    check "kilo-chat webhook error body" "Invalid JSON" "failed"
+    echo "  details: $body_check"
+    echo "  body: $(cat "$body_file")"
+  fi
+
+  rm -f "$body_file"
+}
+
+assert_kilo_chat_smoke() {
+  local cid="$1"
+  local port="$2"
+  local token="$3"
+
+  echo
+  echo "--- kilo-chat plugin ---"
+  assert_kilo_chat_config_patched "$cid"
+  assert_kilo_chat_plugin_loaded "$cid"
+  assert_kilo_chat_webhook_route "$port" "$token"
+}

--- a/services/kiloclaw/scripts/controller-smoke-helpers.sh
+++ b/services/kiloclaw/scripts/controller-smoke-helpers.sh
@@ -78,18 +78,20 @@ print("loaded")
 assert_kilo_chat_webhook_route() {
   local port="$1"
   local token="$2"
-  local body_file
+  local response
+  local body
   local code
   local body_check
 
-  body_file=$(mktemp)
-  code=$(curl -sS -o "$body_file" -w "%{http_code}" \
+  response=$(curl -sS -w "\n%{http_code}" \
     -X POST \
     -H "x-kiloclaw-proxy-token: $token" \
     -H "Authorization: Bearer $token" \
     -H "Content-Type: application/json" \
     --data '{"type":"smoke.probe"}' \
     "http://127.0.0.1:${port}/plugins/kilo-chat/webhook" 2>/dev/null || true)
+  code="${response##*$'\n'}"
+  body="${response%$'\n'*}"
 
   check "kilo-chat webhook unknown event -> 400" "400" "$code"
 
@@ -97,19 +99,17 @@ assert_kilo_chat_webhook_route() {
 import json
 import sys
 
-doc = json.load(open(sys.argv[1]))
+doc = json.loads(sys.stdin.read())
 if doc.get("error") != "Unknown webhook type":
     raise SystemExit(doc)
 print("Unknown webhook type")
-' "$body_file" 2>&1); then
+' <<< "$body" 2>&1); then
     check "kilo-chat webhook error body" "Unknown webhook type" "$body_check"
   else
     check "kilo-chat webhook error body" "Unknown webhook type" "failed"
     echo "  details: $body_check"
-    echo "  body: $(cat "$body_file")"
+    echo "  body: $body"
   fi
-
-  rm -f "$body_file"
 }
 
 assert_kilo_chat_smoke() {

--- a/services/kiloclaw/scripts/controller-smoke-helpers.sh
+++ b/services/kiloclaw/scripts/controller-smoke-helpers.sh
@@ -88,23 +88,23 @@ assert_kilo_chat_webhook_route() {
     -H "x-kiloclaw-proxy-token: $token" \
     -H "Authorization: Bearer $token" \
     -H "Content-Type: application/json" \
-    --data 'not-json' \
+    --data '{"type":"smoke.probe"}' \
     "http://127.0.0.1:${port}/plugins/kilo-chat/webhook" 2>/dev/null || true)
 
-  check "kilo-chat webhook invalid JSON -> 400" "400" "$code"
+  check "kilo-chat webhook unknown event -> 400" "400" "$code"
 
   if body_check=$(python3 -c '
 import json
 import sys
 
 doc = json.load(open(sys.argv[1]))
-if doc.get("error") != "Invalid JSON":
+if doc.get("error") != "Unknown webhook type":
     raise SystemExit(doc)
-print("Invalid JSON")
+print("Unknown webhook type")
 ' "$body_file" 2>&1); then
-    check "kilo-chat webhook error body" "Invalid JSON" "$body_check"
+    check "kilo-chat webhook error body" "Unknown webhook type" "$body_check"
   else
-    check "kilo-chat webhook error body" "Invalid JSON" "failed"
+    check "kilo-chat webhook error body" "Unknown webhook type" "failed"
     echo "  details: $body_check"
     echo "  body: $(cat "$body_file")"
   fi

--- a/services/kiloclaw/scripts/controller-smoke-test.sh
+++ b/services/kiloclaw/scripts/controller-smoke-test.sh
@@ -10,6 +10,9 @@ set -euo pipefail
 IMAGE="${IMAGE:-kiloclaw:controller}"
 TOKEN="${TOKEN:-smoke-token}"
 PORT="${PORT:-18789}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/controller-smoke-helpers.sh"
 
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
   echo "Image '$IMAGE' is not available locally."
@@ -90,6 +93,8 @@ CODE=$(curl -s -o /dev/null -w "%{http_code}" \
   -H "Authorization: Bearer $TOKEN" \
   "http://127.0.0.1:${PORT}/_kilo/gateway/status")
 check "gateway status (bearer auth) -> 200" "200" "$CODE"
+
+assert_kilo_chat_smoke "$CID" "$PORT" "$TOKEN"
 
 echo
 echo "--- proxy token ---"


### PR DESCRIPTION
## Summary

- Add shared KiloClaw controller smoke helpers that assert the packaged Kilo Chat plugin is configured, loaded by OpenClaw, and exposes its authenticated webhook route through the controller proxy.
- Wire the Kilo Chat assertions into both fresh-start and persisted-root/doctor-path controller smoke scripts so image regressions fail before promotion.
- Architectural change: the smoke scripts now share a helper file for plugin-specific assertions instead of duplicating Docker/OpenClaw/curl checks in each script.

## Verification

- [x] Manually ran a fresh controller smoke test against `kiloclaw:controller`; excerpt from `/tmp/smoketest.log`:
  ```text
  --- kilo-chat plugin ---
  PASS: kilo-chat config patched (got ok)
  PASS: kilo-chat plugin inspect (got loaded)
  PASS: kilo-chat webhook unknown event -> 400 (got 400)
  PASS: kilo-chat webhook error body (got Unknown webhook type)

  === Results: 19 passed, 0 failed ===
  ```
- [x] Manually ran the entrypoint/doctor-path controller smoke test against `kiloclaw:controller`; it completed with `11 passed, 0 failed`.
- [ ] Additional manual verification details from reviewer/user.

## Visual Changes

N/A

## Reviewer Notes

- The webhook probe intentionally sends valid JSON with an unsupported event (`{"type":"smoke.probe"}`) so it verifies semantic route handling without dispatching messages, approvals, or upstream Kilo Chat calls.
- The smoke still requires both controller proxy-token auth and OpenClaw gateway bearer auth to reach the plugin route.