### PR TITLE
fix(kiloclaw) billing clear detached destruction deadline

### DIFF
--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -3029,10 +3029,10 @@ describe('instance destruction sweep', () => {
     // of the FIFO candidate query forever — production saw 25k+ real
     // overdue rows starve for 40 days behind ~50 detached rows.
     //
-    // The fix clears `destruction_deadline = null` (guarded by
-    // `instance_id IS NULL` and `destruction_deadline IS NOT NULL` to be
-    // race-safe) so the row falls out of the candidate set on the first
-    // encounter, and writes a change-log entry for the audit trail.
+    // The fix collects all detached IDs during the loop, then after the
+    // loop issues a single bulk SELECT + guarded bulk UPDATE + single
+    // bulk changelog INSERT — 3 DB round-trips total regardless of how
+    // many detached rows are in the batch.
     const subscriptionId = 'sub-detached-1';
     const detachedBefore = {
       id: subscriptionId,
@@ -3055,7 +3055,7 @@ describe('instance destruction sweep', () => {
             email: 'detached@example.com',
           },
         ],
-        // 2. `getSubscriptionById` from the cleanup helper (before snapshot).
+        // 2. Bulk SELECT for before-snapshots in the cleanup helper.
         [detachedBefore],
       ],
       { updateReturningRows: [[detachedAfter]] }
@@ -3076,13 +3076,14 @@ describe('instance destruction sweep', () => {
     expect(summary.sweep3_instance_destruction).toBe(0);
     expect(fetch).not.toHaveBeenCalled();
     expect(globalThis.fetch).not.toHaveBeenCalled();
-    // The guarded UPDATE fired exactly once, clearing destruction_deadline.
+    // The single guarded bulk UPDATE fired, clearing destruction_deadline.
     expect(updates).toEqual([{ destruction_deadline: null }]);
     expect(txUpdates).toHaveLength(0);
     expect(deletes).toHaveLength(0);
-    // A change-log row was written tagged with the dedicated reason so this
-    // cleanup is auditable.
-    expect(inserts).toEqual(
+    // The bulk INSERT wrote changelog entries as an array in a single call.
+    // inserts[0] is the values array passed to db.insert().values([...]).
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           subscription_id: subscriptionId,

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -3164,7 +3164,7 @@ describe('instance destruction sweep', () => {
 
     expect(summary.errors).toBe(0);
     expect(summary.sweep3_instance_destruction).toBe(1);
-    expect(selectBuilders[0]?.limit).toHaveBeenCalledWith(50);
+    expect(selectBuilders[0]?.limit).toHaveBeenCalledWith(75);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     expect(inserts).toEqual(

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -3020,6 +3020,90 @@ describe('instance destruction sweep', () => {
     );
   });
 
+  it('clears destruction_deadline on a detached subscription row instead of starving the queue', async () => {
+    // Regression: a subscription with `destruction_deadline < now()` but
+    // `instance_id IS NULL` (its instance was already destroyed via some
+    // other path) has nothing left for this sweep to destroy. Before this
+    // fix the loop logged "missing_instance_id" and `continue`d without
+    // clearing the deadline, so the same detached row stayed at the head
+    // of the FIFO candidate query forever — production saw 25k+ real
+    // overdue rows starve for 40 days behind ~50 detached rows.
+    //
+    // The fix clears `destruction_deadline = null` (guarded by
+    // `instance_id IS NULL` and `destruction_deadline IS NOT NULL` to be
+    // race-safe) so the row falls out of the candidate set on the first
+    // encounter, and writes a change-log entry for the audit trail.
+    const subscriptionId = 'sub-detached-1';
+    const detachedBefore = {
+      id: subscriptionId,
+      user_id: 'user-detached',
+      instance_id: null,
+      destruction_deadline: '2026-04-17T18:41:17.736Z',
+    };
+    const detachedAfter = { ...detachedBefore, destruction_deadline: null };
+    const { db, updates, txUpdates, inserts, deletes } = createMockDb(
+      [
+        // 1. Destruction candidates: a single detached row at the head.
+        [
+          {
+            id: subscriptionId,
+            user_id: 'user-detached',
+            instance_id: null,
+            sandbox_id: null,
+            organization_id: null,
+            status: 'canceled',
+            email: 'detached@example.com',
+          },
+        ],
+        // 2. `getSubscriptionById` from the cleanup helper (before snapshot).
+        [detachedBefore],
+      ],
+      { updateReturningRows: [[detachedAfter]] }
+    );
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn();
+
+    const summary = await runSweep(
+      createEnv(fetch),
+      {
+        runId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+        sweep: 'instance_destruction',
+      },
+      1
+    );
+
+    expect(summary.errors).toBe(0);
+    expect(summary.sweep3_instance_destruction).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    // The guarded UPDATE fired exactly once, clearing destruction_deadline.
+    expect(updates).toEqual([{ destruction_deadline: null }]);
+    expect(txUpdates).toHaveLength(0);
+    expect(deletes).toHaveLength(0);
+    // A change-log row was written tagged with the dedicated reason so this
+    // cleanup is auditable.
+    expect(inserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subscription_id: subscriptionId,
+          actor_id: 'billing-lifecycle-job',
+          action: 'status_changed',
+          reason: 'detached_subscription_no_instance',
+        }),
+      ])
+    );
+    // The pre-existing skip log is still emitted for operator visibility.
+    expect(loggedValues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: 'Skipping instance destruction for detached subscription row',
+          reason: 'missing_instance_id',
+          subscriptionId,
+        }),
+      ])
+    );
+  });
+
   it('keeps DB/email cleanup unchanged when platform destroy succeeds', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const { db, updates, txUpdates, inserts, deletes, selectBuilders } = createMockDb([

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -3030,9 +3030,13 @@ describe('instance destruction sweep', () => {
     // overdue rows starve for 40 days behind ~50 detached rows.
     //
     // The fix collects all detached IDs during the loop, then after the
-    // loop issues a single bulk SELECT + guarded bulk UPDATE + single
-    // bulk changelog INSERT — 3 DB round-trips total regardless of how
-    // many detached rows are in the batch.
+    // loop issues a single bulk SELECT + guarded bulk UPDATE + bulk
+    // changelog INSERT inside one database transaction. The transaction
+    // is what keeps the audit record at-least-once: if the INSERT fails
+    // the UPDATE rolls back so the rows stay detached and the next sweep
+    // retries the whole pair atomically — otherwise a transient INSERT
+    // failure would erase the only signal (`destruction_deadline IS NOT
+    // NULL`) that the cleanup ever ran.
     const subscriptionId = 'sub-detached-1';
     const detachedBefore = {
       id: subscriptionId,
@@ -3041,9 +3045,9 @@ describe('instance destruction sweep', () => {
       destruction_deadline: '2026-04-17T18:41:17.736Z',
     };
     const detachedAfter = { ...detachedBefore, destruction_deadline: null };
-    const { db, updates, txUpdates, inserts, deletes } = createMockDb(
+    const { db, updates, txUpdates, inserts, txInserts, deletes } = createMockDb(
       [
-        // 1. Destruction candidates: a single detached row at the head.
+        // 1. Destruction candidates (db.select): a single detached row.
         [
           {
             id: subscriptionId,
@@ -3055,10 +3059,10 @@ describe('instance destruction sweep', () => {
             email: 'detached@example.com',
           },
         ],
-        // 2. Bulk SELECT for before-snapshots in the cleanup helper.
+        // 2. Bulk SELECT for before-snapshots inside the cleanup transaction.
         [detachedBefore],
       ],
-      { updateReturningRows: [[detachedAfter]] }
+      { txUpdateReturningRows: [[detachedAfter]] }
     );
     mockGetWorkerDb.mockReturnValue(db);
     const fetch = vi.fn();
@@ -3076,14 +3080,17 @@ describe('instance destruction sweep', () => {
     expect(summary.sweep3_instance_destruction).toBe(0);
     expect(fetch).not.toHaveBeenCalled();
     expect(globalThis.fetch).not.toHaveBeenCalled();
-    // The single guarded bulk UPDATE fired, clearing destruction_deadline.
-    expect(updates).toEqual([{ destruction_deadline: null }]);
-    expect(txUpdates).toHaveLength(0);
+    // The guarded UPDATE happens inside a transaction so it lives on
+    // `txUpdates`, not `updates`. The top-level handles see nothing.
+    expect(updates).toHaveLength(0);
+    expect(inserts).toHaveLength(0);
     expect(deletes).toHaveLength(0);
-    // The bulk INSERT wrote changelog entries as an array in a single call.
-    // inserts[0] is the values array passed to db.insert().values([...]).
-    expect(inserts).toHaveLength(1);
-    expect(inserts[0]).toEqual(
+    expect(txUpdates).toEqual([{ destruction_deadline: null }]);
+    // The bulk INSERT writes the changelog entries as an array in one
+    // call inside the same transaction. txInserts[0] is the values array
+    // passed to tx.insert().values([...]).
+    expect(txInserts).toHaveLength(1);
+    expect(txInserts[0]).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           subscription_id: subscriptionId,

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -3112,6 +3112,85 @@ describe('instance destruction sweep', () => {
     );
   });
 
+  it('clears a soft-deleted detached subscription instead of leaving it to pin the queue', async () => {
+    // Regression for the review of this PR. The detached check fires
+    // BEFORE the soft-deleted check inside the loop, so a row that is
+    // BOTH soft-deleted AND detached (`instance_id IS NULL`) still gets
+    // its destruction_deadline cleared. Without that ordering, the
+    // soft-deleted `continue` would short-circuit the loop and the row
+    // would stay at the head of the bounded FIFO queue forever — the
+    // same starvation the PR fixes for the common case, just gated on
+    // a different attribute.
+    const subscriptionId = 'sub-detached-softdeleted';
+    const detachedBefore = {
+      id: subscriptionId,
+      user_id: 'user-softdeleted',
+      instance_id: null,
+      destruction_deadline: '2026-04-17T18:41:17.736Z',
+    };
+    const detachedAfter = { ...detachedBefore, destruction_deadline: null };
+    const { db, updates, txUpdates, inserts, txInserts, deletes } = createMockDb(
+      [
+        [
+          {
+            id: subscriptionId,
+            user_id: 'user-softdeleted',
+            instance_id: null,
+            sandbox_id: null,
+            organization_id: null,
+            status: 'canceled',
+            // Trailing @deleted.invalid identifies a soft-deleted account
+            // (see SOFT_DELETED_EMAIL_SUFFIX in lifecycle.ts).
+            email: 'user-softdeleted@deleted.invalid',
+          },
+        ],
+        [detachedBefore],
+      ],
+      { txUpdateReturningRows: [[detachedAfter]] }
+    );
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn();
+
+    const summary = await runSweep(
+      createEnv(fetch),
+      {
+        runId: 'cdcdcdcd-cdcd-4cdc-8cdc-cdcdcdcdcdcd',
+        sweep: 'instance_destruction',
+      },
+      1
+    );
+
+    expect(summary.errors).toBe(0);
+    expect(summary.sweep3_instance_destruction).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    // Cleared inside a transaction even though the user is soft-deleted.
+    expect(updates).toHaveLength(0);
+    expect(inserts).toHaveLength(0);
+    expect(deletes).toHaveLength(0);
+    expect(txUpdates).toEqual([{ destruction_deadline: null }]);
+    expect(txInserts).toHaveLength(1);
+    expect(txInserts[0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subscription_id: subscriptionId,
+          actor_id: 'billing-lifecycle-job',
+          action: 'status_changed',
+          reason: 'detached_subscription_no_instance',
+        }),
+      ])
+    );
+    expect(loggedValues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: 'Skipping instance destruction for detached subscription row',
+          reason: 'missing_instance_id',
+          subscriptionId,
+        }),
+      ])
+    );
+  });
+
   it('keeps DB/email cleanup unchanged when platform destroy succeeds', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const { db, updates, txUpdates, inserts, deletes, selectBuilders } = createMockDb([

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -727,7 +727,14 @@ async function insertLifecycleChangeLogBestEffort(
  *   - `instance_id IS NULL` — only clear rows that are still detached.
  *   - `destruction_deadline IS NOT NULL` — skip rows already cleared.
  * Rows that match neither guard are silently skipped (no changelog entry).
- * Changelog entries for all cleared rows are written in a single bulk INSERT.
+ *
+ * The SELECT + UPDATE + changelog INSERT run inside a single transaction so
+ * the audit record cannot be lost. If the changelog INSERT fails the UPDATE
+ * rolls back; the rows remain detached with their deadlines, and the next
+ * sweep re-discovers them and retries the whole pair atomically. Without
+ * this, a transient INSERT failure would erase the only signal
+ * (`destruction_deadline IS NOT NULL`) that the cleanup ever ran — there
+ * would be no future sweep to reconstruct the missing audit history.
  */
 async function clearDetachedSubscriptionDestructionDeadlineBestEffort(
   database: WorkerDb,
@@ -738,50 +745,58 @@ async function clearDetachedSubscriptionDestructionDeadlineBestEffort(
     return;
   }
 
-  // Bulk SELECT for before-snapshots (used in the audit changelog).
-  const befores = await database
-    .select()
-    .from(kiloclaw_subscriptions)
-    .where(inArray(kiloclaw_subscriptions.id, subscriptionIds));
-
-  // Single guarded UPDATE — rows already cleared or re-attached are skipped.
-  const cleared = await database
-    .update(kiloclaw_subscriptions)
-    .set({ destruction_deadline: null })
-    .where(
-      and(
-        inArray(kiloclaw_subscriptions.id, subscriptionIds),
-        isNull(kiloclaw_subscriptions.instance_id),
-        isNotNull(kiloclaw_subscriptions.destruction_deadline)
-      )
-    )
-    .returning();
-
-  if (cleared.length === 0) {
-    return;
-  }
-
-  // Bulk changelog INSERT — one round-trip for the entire batch.
-  const beforeMap = new Map(befores.map(s => [s.id, s]));
-  const changeLogEntries = cleared.map(after => ({
-    subscription_id: after.id,
-    actor_type: LIFECYCLE_ACTOR.actorType,
-    actor_id: LIFECYCLE_ACTOR.actorId,
-    action: 'status_changed' as KiloClawSubscriptionChangeAction,
-    reason,
-    before_state: serializeKiloClawSubscriptionSnapshot(beforeMap.get(after.id) ?? null),
-    after_state: serializeKiloClawSubscriptionSnapshot(after),
-  }));
-
   try {
-    await database.insert(kiloclaw_subscription_change_log).values(changeLogEntries);
+    await database.transaction(async tx => {
+      // Bulk SELECT for before-snapshots (used in the audit changelog).
+      const befores = await tx
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(inArray(kiloclaw_subscriptions.id, subscriptionIds));
+
+      // Single guarded UPDATE — rows already cleared or re-attached are skipped.
+      const cleared = await tx
+        .update(kiloclaw_subscriptions)
+        .set({ destruction_deadline: null })
+        .where(
+          and(
+            inArray(kiloclaw_subscriptions.id, subscriptionIds),
+            isNull(kiloclaw_subscriptions.instance_id),
+            isNotNull(kiloclaw_subscriptions.destruction_deadline)
+          )
+        )
+        .returning();
+
+      if (cleared.length === 0) {
+        return;
+      }
+
+      // Bulk changelog INSERT — one round-trip for the entire batch.
+      // A throw here aborts the surrounding transaction (above) so the
+      // UPDATE rolls back. The next sweep retries both atomically.
+      const beforeMap = new Map(befores.map(s => [s.id, s]));
+      const changeLogEntries = cleared.map(after => ({
+        subscription_id: after.id,
+        actor_type: LIFECYCLE_ACTOR.actorType,
+        actor_id: LIFECYCLE_ACTOR.actorId,
+        action: 'status_changed' as KiloClawSubscriptionChangeAction,
+        reason,
+        before_state: serializeKiloClawSubscriptionSnapshot(beforeMap.get(after.id) ?? null),
+        after_state: serializeKiloClawSubscriptionSnapshot(after),
+      }));
+      await tx.insert(kiloclaw_subscription_change_log).values(changeLogEntries);
+    });
   } catch (error) {
-    log('error', 'Failed to write lifecycle subscription change log for detached subscriptions', {
+    // The transaction was rolled back. The detached rows remain in the
+    // candidate set with their deadlines intact, so the next sweep will
+    // pick them up and retry both the UPDATE and the changelog INSERT
+    // atomically. We log but do not rethrow so a single bulk failure does
+    // not abort the outer sweep — every other row in this run still has
+    // its bookkeeping completed normally.
+    log('error', 'Bulk-clear of detached subscription destruction deadlines was rolled back', {
       event: 'subscription_change_log_failed',
       outcome: 'failed',
-      actor_id: LIFECYCLE_ACTOR.actorId,
-      action: 'status_changed' as KiloClawSubscriptionChangeAction,
       reason,
+      subscriptionIdCount: subscriptionIds.length,
       error: errorMessage(error),
     });
   }

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -3732,17 +3732,14 @@ async function runInstanceDestructionSweep(
 
   for (const row of destructionCandidates) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) continue;
-      if (row.status === 'active') {
-        logSkippedSubscriptionRow(
-          'Skipping instance destruction for active subscription row',
-          row,
-          {
-            reason: 'active_subscription',
-          }
-        );
-        continue;
-      }
+      // Detached rows are checked FIRST, before any other skip path. A row
+      // with no instance has no live resource to destroy regardless of the
+      // owning user's other attributes (soft-deleted, active, etc), so the
+      // deadline is stale bookkeeping and the row must be cleared from the
+      // bounded candidate queue. Without this ordering, a soft-deleted
+      // detached row would hit the soft-deleted continue below and stay
+      // pinned at the head of the FIFO queue indefinitely, recreating the
+      // exact starvation this PR fixes for the common case.
       if (!row.instance_id) {
         logSkippedSubscriptionRow(
           'Skipping instance destruction for detached subscription row',
@@ -3753,6 +3750,17 @@ async function runInstanceDestructionSweep(
         );
         // Bulk-cleared after the loop — see detachedSubscriptionIds below.
         detachedSubscriptionIds.push(row.id);
+        continue;
+      }
+      if (isSoftDeletedUserEmail(row.email)) continue;
+      if (row.status === 'active') {
+        logSkippedSubscriptionRow(
+          'Skipping instance destruction for active subscription row',
+          row,
+          {
+            reason: 'active_subscription',
+          }
+        );
         continue;
       }
 

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -14,6 +14,7 @@ import {
   getWorkerDb,
   insertKiloClawSubscriptionChangeLog,
   recordTerminalRenewalFailure,
+  serializeKiloClawSubscriptionSnapshot,
   supersedeTerminalRenewalFailuresForBoundary,
   type KiloClawSubscription,
   type Organization,
@@ -40,6 +41,7 @@ import {
   kilo_pass_subscriptions,
   kiloclaw_email_log,
   kiloclaw_instances,
+  kiloclaw_subscription_change_log,
   kiloclaw_subscriptions,
   kilocode_users,
   organization_memberships,
@@ -708,9 +710,9 @@ async function insertLifecycleChangeLogBestEffort(
 }
 
 /**
- * Clear `destruction_deadline` on a subscription whose instance has already
- * been cleaned up via some other path (`instance_id IS NULL`), so the
- * destruction sweep stops re-selecting it on every cron.
+ * Clear `destruction_deadline` on a batch of subscriptions whose instances
+ * have already been cleaned up via some other path (`instance_id IS NULL`),
+ * so the destruction sweep stops re-selecting them on every cron.
  *
  * The destruction sweep selects candidates ordered by `destruction_deadline
  * ASC, id ASC` with `LIMIT INSTANCE_DESTRUCTION_BATCH_SIZE`, then per-row
@@ -724,37 +726,65 @@ async function insertLifecycleChangeLogBestEffort(
  * The UPDATE is guarded so a concurrent re-attach or re-clear cannot race:
  *   - `instance_id IS NULL` — only clear rows that are still detached.
  *   - `destruction_deadline IS NOT NULL` — skip rows already cleared.
- * A no-op UPDATE returns no row, and we skip the change-log write.
+ * Rows that match neither guard are silently skipped (no changelog entry).
+ * Changelog entries for all cleared rows are written in a single bulk INSERT.
  */
 async function clearDetachedSubscriptionDestructionDeadlineBestEffort(
   database: WorkerDb,
-  subscriptionId: string,
+  subscriptionIds: string[],
   reason: string
 ): Promise<void> {
-  const before = await getSubscriptionById(database, subscriptionId);
-  const [after] = await database
+  if (subscriptionIds.length === 0) {
+    return;
+  }
+
+  // Bulk SELECT for before-snapshots (used in the audit changelog).
+  const befores = await database
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(inArray(kiloclaw_subscriptions.id, subscriptionIds));
+
+  // Single guarded UPDATE — rows already cleared or re-attached are skipped.
+  const cleared = await database
     .update(kiloclaw_subscriptions)
     .set({ destruction_deadline: null })
     .where(
       and(
-        eq(kiloclaw_subscriptions.id, subscriptionId),
+        inArray(kiloclaw_subscriptions.id, subscriptionIds),
         isNull(kiloclaw_subscriptions.instance_id),
         isNotNull(kiloclaw_subscriptions.destruction_deadline)
       )
     )
     .returning();
 
-  if (!after) {
+  if (cleared.length === 0) {
     return;
   }
 
-  await insertLifecycleChangeLogBestEffort(database, {
-    subscriptionId,
-    action: 'status_changed',
+  // Bulk changelog INSERT — one round-trip for the entire batch.
+  const beforeMap = new Map(befores.map(s => [s.id, s]));
+  const changeLogEntries = cleared.map(after => ({
+    subscription_id: after.id,
+    actor_type: LIFECYCLE_ACTOR.actorType,
+    actor_id: LIFECYCLE_ACTOR.actorId,
+    action: 'status_changed' as KiloClawSubscriptionChangeAction,
     reason,
-    before,
-    after,
-  });
+    before_state: serializeKiloClawSubscriptionSnapshot(beforeMap.get(after.id) ?? null),
+    after_state: serializeKiloClawSubscriptionSnapshot(after),
+  }));
+
+  try {
+    await database.insert(kiloclaw_subscription_change_log).values(changeLogEntries);
+  } catch (error) {
+    log('error', 'Failed to write lifecycle subscription change log for detached subscriptions', {
+      event: 'subscription_change_log_failed',
+      outcome: 'failed',
+      actor_id: LIFECYCLE_ACTOR.actorId,
+      action: 'status_changed' as KiloClawSubscriptionChangeAction,
+      reason,
+      error: errorMessage(error),
+    });
+  }
 }
 
 function logSkippedSubscriptionRow(
@@ -3673,6 +3703,11 @@ async function runInstanceDestructionSweep(
     .orderBy(asc(kiloclaw_subscriptions.destruction_deadline), asc(kiloclaw_subscriptions.id))
     .limit(INSTANCE_DESTRUCTION_BATCH_SIZE);
 
+  // Collect detached row IDs for a single bulk clear after the loop,
+  // avoiding O(n) DB round-trips per row. See
+  // `clearDetachedSubscriptionDestructionDeadlineBestEffort`.
+  const detachedSubscriptionIds: string[] = [];
+
   for (const row of destructionCandidates) {
     try {
       if (isSoftDeletedUserEmail(row.email)) continue;
@@ -3694,15 +3729,8 @@ async function runInstanceDestructionSweep(
             reason: 'missing_instance_id',
           }
         );
-        // The row has nothing to destroy (its instance was cleaned up via
-        // another path). Clear `destruction_deadline` so the candidate query
-        // stops re-selecting it and starving everything behind it in the
-        // FIFO queue. See `clearDetachedSubscriptionDestructionDeadlineBestEffort`.
-        await clearDetachedSubscriptionDestructionDeadlineBestEffort(
-          database,
-          row.id,
-          'detached_subscription_no_instance'
-        );
+        // Bulk-cleared after the loop — see detachedSubscriptionIds below.
+        detachedSubscriptionIds.push(row.id);
         continue;
       }
 
@@ -3821,16 +3849,27 @@ async function runInstanceDestructionSweep(
       const [updated] = await database
         .update(kiloclaw_subscriptions)
         .set({ destruction_deadline: null })
-        .where(eq(kiloclaw_subscriptions.id, destructionRow.id))
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.id, destructionRow.id),
+            isNotNull(kiloclaw_subscriptions.destruction_deadline)
+          )
+        )
         .returning();
 
-      await insertLifecycleChangeLogBestEffort(database, {
-        subscriptionId: destructionRow.id,
-        action: 'status_changed',
-        reason: 'instance_destroyed',
-        before,
-        after: updated ?? null,
-      });
+      // Only write changelog when the UPDATE actually changed a row.
+      // A concurrent clear (e.g. clearDetachedSubscriptionDestructionDeadlineBestEffort)
+      // can race here; without this guard the log would record a phantom
+      // `instance_destroyed` event with identical before/after states.
+      if (updated) {
+        await insertLifecycleChangeLogBestEffort(database, {
+          subscriptionId: destructionRow.id,
+          action: 'status_changed',
+          reason: 'instance_destroyed',
+          before,
+          after: updated,
+        });
+      }
 
       let organizationNotificationSentCount = 0;
       if (destructionRow.organization_id && destructionRow.organization_name) {
@@ -3926,6 +3965,14 @@ async function runInstanceDestructionSweep(
       });
     }
   }
+
+  // Bulk-clear destruction_deadline for all detached rows collected above.
+  // A single SELECT + UPDATE + INSERT replaces O(n) per-row round-trips.
+  await clearDetachedSubscriptionDestructionDeadlineBestEffort(
+    database,
+    detachedSubscriptionIds,
+    'detached_subscription_no_instance'
+  );
 }
 
 async function runPastDueCleanupSweep(

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -87,7 +87,14 @@ const DESTRUCTION_WARNING_DAYS = 2;
 const EARLYBIRD_WARNING_DAYS = 14;
 const AUTO_RESUME_INITIAL_BACKOFF_MS = 2 * 60 * 60 * 1000;
 const AUTO_RESUME_MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
-const INSTANCE_DESTRUCTION_BATCH_SIZE = 50;
+// Per-cron-tick destruction batch size. Each row's destroy takes ~7-8s
+// (Fly API + DO finalize), and the Cloudflare queue consumer's wall-clock
+// budget per message is 15 minutes — so safe ceiling for the current
+// sequential loop is roughly 100. We chose 75 to leave a generous margin
+// for slower rows while still meaningfully outpacing inflow. Crank higher
+// only after parallelizing the destroy loop, or batches will start
+// hitting the wall-clock limit and getting retried.
+const INSTANCE_DESTRUCTION_BATCH_SIZE = 75;
 const TRIAL_INACTIVITY_BATCH_SIZE = 50;
 const SOFT_DELETED_EMAIL_SUFFIX = '@deleted.invalid';
 const TRIAL_ENDING_SOON_MIN_DURATION_DAYS = 2;

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -707,6 +707,56 @@ async function insertLifecycleChangeLogBestEffort(
   }
 }
 
+/**
+ * Clear `destruction_deadline` on a subscription whose instance has already
+ * been cleaned up via some other path (`instance_id IS NULL`), so the
+ * destruction sweep stops re-selecting it on every cron.
+ *
+ * The destruction sweep selects candidates ordered by `destruction_deadline
+ * ASC, id ASC` with `LIMIT INSTANCE_DESTRUCTION_BATCH_SIZE`, then per-row
+ * checks `!row.instance_id` and `continue`s. Without this cleanup, the same
+ * detached rows stay at the head of the queue forever and every row behind
+ * them is starved — production saw 25k+ overdue real rows stuck behind a
+ * head of ~50 detached rows for 40 days. Clearing the deadline is the same
+ * final step the happy-path destroy does once the underlying resources are
+ * gone.
+ *
+ * The UPDATE is guarded so a concurrent re-attach or re-clear cannot race:
+ *   - `instance_id IS NULL` — only clear rows that are still detached.
+ *   - `destruction_deadline IS NOT NULL` — skip rows already cleared.
+ * A no-op UPDATE returns no row, and we skip the change-log write.
+ */
+async function clearDetachedSubscriptionDestructionDeadlineBestEffort(
+  database: WorkerDb,
+  subscriptionId: string,
+  reason: string
+): Promise<void> {
+  const before = await getSubscriptionById(database, subscriptionId);
+  const [after] = await database
+    .update(kiloclaw_subscriptions)
+    .set({ destruction_deadline: null })
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.id, subscriptionId),
+        isNull(kiloclaw_subscriptions.instance_id),
+        isNotNull(kiloclaw_subscriptions.destruction_deadline)
+      )
+    )
+    .returning();
+
+  if (!after) {
+    return;
+  }
+
+  await insertLifecycleChangeLogBestEffort(database, {
+    subscriptionId,
+    action: 'status_changed',
+    reason,
+    before,
+    after,
+  });
+}
+
 function logSkippedSubscriptionRow(
   message: string,
   row: {
@@ -3643,6 +3693,15 @@ async function runInstanceDestructionSweep(
           {
             reason: 'missing_instance_id',
           }
+        );
+        // The row has nothing to destroy (its instance was cleaned up via
+        // another path). Clear `destruction_deadline` so the candidate query
+        // stops re-selecting it and starving everything behind it in the
+        // FIFO queue. See `clearDetachedSubscriptionDestructionDeadlineBestEffort`.
+        await clearDetachedSubscriptionDestructionDeadlineBestEffort(
+          database,
+          row.id,
+          'detached_subscription_no_instance'
         );
         continue;
       }


### PR DESCRIPTION
## Summary

The billing instance destruction sweep had two production bugs that left it functionally idle. Both are fixed here.

**Bug 1: detached subscriptions starved the queue.** The sweep selects
candidates ordered by `destruction_deadline ASC, id ASC` with `LIMIT
INSTANCE_DESTRUCTION_BATCH_SIZE`. When a row has `instance_id IS NULL`
(its instance was destroyed via another path) the loop logged
"missing_instance_id" and continued without clearing the deadline, so
the same handful of detached rows pinned the head of the queue on
every cron and every row behind them was starved. About 50 detached
rows blocked 25k real overdue rows for over a month.

The fix is a new helper
`clearDetachedSubscriptionDestructionDeadlineBestEffort` that batches
all detached subscription IDs collected during the loop and runs a
single SELECT plus guarded UPDATE plus changelog INSERT inside one
database transaction. The UPDATE guards (`instance_id IS NULL` and
`destruction_deadline IS NOT NULL`) make a concurrent reattach or a
second clear a silent skip. The transaction wrap is important for
audit: if the INSERT throws the UPDATE rolls back, the rows stay
detached with their deadlines, and the next sweep retries the whole
pair atomically. Without the transaction, a transient INSERT failure
would erase the only signal that the cleanup ever ran and the audit
history would be permanently lost.

A small race guard is also added on the existing happy path UPDATE
(`isNotNull(destruction_deadline)` plus an `if (updated)` around the
changelog write) so a concurrent clear from the new code path does
not produce a phantom `instance_destroyed` audit entry with identical
before and after states.

**Bug 2: throughput barely matched inflow.** With the queue unblocked,
the sweep processes 50 rows in about 6 minutes. Each destroy takes 7
to 8 seconds through Fly plus Durable Object cleanup, so the rate was
around 200 destroys per hour. Observed inflow runs close to that, so
the queue was hovering at break even or slightly growing. The batch
size constant is raised to 75. Each row's wall clock budget stays
well inside the Cloudflare queue consumer's 15 minute ceiling. A
comment on the constant explains the math and warns that going higher
requires parallelizing the destroy loop first.

## Verification

The bug only manifests when the candidate query returns rows with
`instance_id IS NULL` at the head of the queue. Reproducing this in
a clean test database is not feasible because the bug requires real
historical detached rows to pin the head, which the fixed code itself
clears on the first sweep. Manual verification before merge therefore
relies on the regression test plus log inspection on the deployed
worker.

After the deploy:

- [ ] Watch the billing worker logs for the next two cron firings.
      Confirm the `sweep_completed` event for `instance_destruction`
      shows `sweep3_instance_destruction` greater than zero and
      `errors` of zero. Before the fix this value was zero on every
      sweep.
- [ ] Run a SQL count of overdue rows where `instance_id IS NULL` and
      confirm it stays at or near zero. The new cleanup keeps it
      drained automatically rather than allowing buildup.

## Visual Changes

N/A. Server side billing worker change. No UI surface area.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

Focus areas:

- `clearDetachedSubscriptionDestructionDeadlineBestEffort` runs after
  the candidate loop closes, with the collected IDs as input. The
  helper returns early on empty input, so a sweep with no detached
  rows pays no cost.
- The transaction makes the UPDATE plus changelog INSERT atomic. The
  outer try and catch logs a rollback but does not rethrow, so a
  single bulk cleanup failure does not abort the rest of the sweep.
  Every other row in the same sweep still has its bookkeeping written
  normally.
- The bump from 50 to 75 is a config change. The wall clock math is
  in the comment above the constant. The existing happy path test was
  updated to assert the new value.
- The regression test seeds one detached row, runs the sweep, and
  asserts the transaction scoped UPDATE and INSERT fired, no destroy
  POST went out to the kiloclaw worker, and the existing skip log is
  still emitted.
