### PR TITLE
fix(model-stats): monitor Qwen3.7 Max

### DIFF
--- a/apps/web/src/lib/ai-gateway/monitored-models.ts
+++ b/apps/web/src/lib/ai-gateway/monitored-models.ts
@@ -2,6 +2,7 @@ import { AUTO_MODELS, isKiloAutoModel, KILO_AUTO_FREE_MODEL } from '@/lib/ai-gat
 import type { FeatureValue } from '@/lib/feature-detection';
 import { resolveAutoModel } from '@/lib/ai-gateway/auto-model/resolution';
 import { preferredModels } from '@/lib/ai-gateway/models';
+import { qwen37_max_model } from '@/lib/ai-gateway/providers/qwen';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 
 type AutoModelVariation = {
@@ -66,6 +67,9 @@ export async function getMonitoredModels() {
       set.add(model);
     }
   }
+
+  // Track stats for Qwen3.7 Max without elevating it in preferred UI placement.
+  set.add(qwen37_max_model.public_id);
 
   return [...set];
 }


### PR DESCRIPTION
## Summary

- Add `qwen/qwen3.7-max` to model-stats monitoring so the stats sync creates and populates its `model_stats` row from the OpenRouter entry.
- Keep the model out of `preferredModels`, avoiding unrelated changes to preferred picker ordering and other preferred-model consumers.
- Enable the existing benchmark repull path to attach the promoted Terminal Bench result once stats sync has created the target row.

## Verification

- [x] Confirmed `qwen/qwen3.7-max` exists in `https://openrouter.ai/api/v1/models` with the expected exact ID.
- [x] Ran `pnpm --filter web typecheck`.
- [x] Ran `pnpm --filter web lint`.
- [x] Ran a local integration flow against an isolated Postgres database: `getMonitoredModels()` plus `syncOpenRouterModels()` inserted an active `model_stats` row for `qwen/qwen3.7-max` with slug `qwen-qwen3-7-max`.
- [x] Ran local `kilo-bench-dashboard#Dashboard` -> `model-eval-ingest` service-binding ingestion for a promoted Qwen Terminal Bench fixture; the ingestion row attached to `model_stats_id` and wrote `benchmarks.kiloBench.evals['terminal-bench']` with `nTotalTrials: 5`, `nAttempts: 5`, `avgAttemptCostUsd: 100`, and `overallScore: 0.9`.

## Visual Changes

N/A

## Reviewer Notes

- After deployment, run the existing model-stats sync, then use the Model Eval Ingestion `Repull` action for the Qwen3.7 Max promoted Terminal Bench record.
- This intentionally monitors the model for stats without changing its preferred-product ordering.