### PR TITLE
fix(web): align embedding dimensions with routed capabilities

### DIFF
--- a/apps/web/src/app/api/gateway/embedding-models/route.test.ts
+++ b/apps/web/src/app/api/gateway/embedding-models/route.test.ts
@@ -21,11 +21,21 @@ describe('GET /api/gateway/embedding-models', () => {
       id: KILO_DEFAULT_EMBEDDING_MODEL,
       dimension: 1024,
       scoreThreshold: 0.35,
+      dimensionMode: 'fixed',
     });
     expect(getKiloEmbeddingModel('codestral-embed-2505')).toMatchObject({
       id: 'mistralai/codestral-embed-2505',
-      dimension: 256,
+      dimension: 1536,
       scoreThreshold: 0.35,
+      dimensionMode: 'fixed',
+    });
+    expect(getKiloEmbeddingModel('openai/text-embedding-3-small')).toMatchObject({
+      dimensionMode: 'selectable',
+      verifiedDimensions: [256, 1536],
+    });
+    expect(getKiloEmbeddingModel('google/gemini-embedding-001')).toMatchObject({
+      dimensionMode: 'selectable',
+      verifiedDimensions: [768, 3072],
     });
     expect(normalizeKiloEmbeddingModelId('text-embedding-3-small')).toBe(
       'openai/text-embedding-3-small'

--- a/apps/web/src/app/api/gateway/embedding-models/route.test.ts
+++ b/apps/web/src/app/api/gateway/embedding-models/route.test.ts
@@ -29,14 +29,6 @@ describe('GET /api/gateway/embedding-models', () => {
       scoreThreshold: 0.35,
       dimensionMode: 'fixed',
     });
-    expect(getKiloEmbeddingModel('openai/text-embedding-3-small')).toMatchObject({
-      dimensionMode: 'selectable',
-      verifiedDimensions: [256, 1536],
-    });
-    expect(getKiloEmbeddingModel('google/gemini-embedding-001')).toMatchObject({
-      dimensionMode: 'selectable',
-      verifiedDimensions: [768, 3072],
-    });
     expect(normalizeKiloEmbeddingModelId('text-embedding-3-small')).toBe(
       'openai/text-embedding-3-small'
     );

--- a/apps/web/src/app/api/openrouter/embeddings/route.ts
+++ b/apps/web/src/app/api/openrouter/embeddings/route.ts
@@ -35,6 +35,7 @@ import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
 import {
   buildUpstreamBody,
   type EmbeddingProxyRequest,
+  validateEmbeddingDimensions,
 } from '@/lib/ai-gateway/embeddings/embedding-request';
 import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelIdToVercel';
 import { getVercelInferenceProviderConfigForUserByok } from '@/lib/ai-gateway/providers/vercel';
@@ -220,6 +221,21 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     performance.now() - requestStartedAt
   );
 
+  const dimensionError = validateEmbeddingDimensions(requestBodyParsed, requestedModelLowerCased);
+  if (dimensionError) {
+    return NextResponse.json(
+      {
+        error: {
+          message: dimensionError,
+          type: 'invalid_request_error',
+          param: 'dimensions',
+          code: null,
+        },
+      },
+      { status: 400 }
+    );
+  }
+
   const embeddingRequestSpan = startInactiveSpan({
     name: 'embedding-request-start',
     op: 'http.client',
@@ -235,7 +251,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     requestBodyParsed.model = mapModelIdToVercel(requestBodyParsed.model, false);
   }
 
-  const upstreamBody = buildUpstreamBody(requestBodyParsed);
+  const upstreamBody = buildUpstreamBody(requestBodyParsed, requestedModelLowerCased);
 
   if (userByok && userByok.length > 0 && provider.id === 'vercel') {
     const byokProviders: Record<string, unknown[]> = {};

--- a/apps/web/src/lib/ai-gateway/embeddings/embedding-request.test.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/embedding-request.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { buildUpstreamBody } from './embedding-request';
+import { buildUpstreamBody, validateEmbeddingDimensions } from './embedding-request';
 
 describe('buildUpstreamBody', () => {
   it('should forward supported fields and strip native Mistral fields', () => {
@@ -28,18 +28,43 @@ describe('buildUpstreamBody', () => {
     expect(result).not.toHaveProperty('output_dimension');
   });
 
-  it('should keep Codestral embedding dimensions for the upstream provider', () => {
+  it.each([
+    ['mistralai/codestral-embed-2505', 1536],
+    ['mistralai/mistral-embed-2312', 1024],
+    ['openai/text-embedding-ada-002', 1536],
+    ['baai/bge-large-en-v1.5', 1024],
+    ['baai/bge-base-en-v1.5', 768],
+  ])('should omit catalog dimensions for fixed model %s', (model, dimensions) => {
     const result = buildUpstreamBody({
-      model: 'mistralai/codestral-embed-2505',
+      model,
       input: ['function add(a, b) { return a + b; }'],
-      dimensions: 256,
+      dimensions,
     });
 
     expect(result).toEqual({
-      model: 'mistralai/codestral-embed-2505',
+      model,
       input: ['function add(a, b) { return a + b; }'],
-      dimensions: 256,
     });
+  });
+
+  it.each([
+    ['openai/text-embedding-3-small', 256],
+    ['google/gemini-embedding-001', 768],
+  ])('should keep selectable dimensions for model %s', (model, dimensions) => {
+    expect(buildUpstreamBody({ model, input: 'hello', dimensions })).toEqual({
+      model,
+      input: 'hello',
+      dimensions,
+    });
+  });
+
+  it('should apply fixed model handling after an upstream model ID rewrite', () => {
+    expect(
+      buildUpstreamBody(
+        { model: 'mistral/codestral-embed', input: 'hello', dimensions: 1536 },
+        'mistralai/codestral-embed-2505'
+      )
+    ).toEqual({ model: 'mistral/codestral-embed', input: 'hello' });
   });
 
   it('should strip the deprecated user field', () => {
@@ -60,6 +85,33 @@ describe('buildUpstreamBody', () => {
     });
 
     expect(result).toEqual({ model: 'openai/text-embedding-3-small', input: 'hello' });
+  });
+
+  it('should reject a non-native dimension for a fixed model before proxying', () => {
+    expect(
+      validateEmbeddingDimensions({
+        model: 'codestral-embed-2505',
+        input: 'hello',
+        dimensions: 256,
+      })
+    ).toContain('fixed 1536-dimensional embeddings');
+    expect(
+      validateEmbeddingDimensions({
+        model: 'mistralai/codestral-embed-2505',
+        input: 'hello',
+        dimensions: 1536,
+      })
+    ).toBeUndefined();
+  });
+
+  it('should not reject configured dimensions for selectable models', () => {
+    expect(
+      validateEmbeddingDimensions({
+        model: 'google/gemini-embedding-001',
+        input: 'hello',
+        dimensions: 768,
+      })
+    ).toBeUndefined();
   });
 
   it('should strip output_dtype and output_dimension even when other optional fields are absent', () => {

--- a/apps/web/src/lib/ai-gateway/embeddings/embedding-request.test.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/embedding-request.test.ts
@@ -48,9 +48,9 @@ describe('buildUpstreamBody', () => {
   });
 
   it.each([
-    ['openai/text-embedding-3-small', 256],
-    ['google/gemini-embedding-001', 768],
-  ])('should keep selectable dimensions for model %s', (model, dimensions) => {
+    ['openai/text-embedding-3-small', 1536],
+    ['google/gemini-embedding-001', 3072],
+  ])('should keep catalog dimensions for model %s without a fixed policy', (model, dimensions) => {
     expect(buildUpstreamBody({ model, input: 'hello', dimensions })).toEqual({
       model,
       input: 'hello',
@@ -104,12 +104,12 @@ describe('buildUpstreamBody', () => {
     ).toBeUndefined();
   });
 
-  it('should not reject configured dimensions for selectable models', () => {
+  it('should not reject a catalog dimension for a model without a fixed policy', () => {
     expect(
       validateEmbeddingDimensions({
         model: 'google/gemini-embedding-001',
         input: 'hello',
-        dimensions: 768,
+        dimensions: 3072,
       })
     ).toBeUndefined();
   });

--- a/apps/web/src/lib/ai-gateway/embeddings/embedding-request.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/embedding-request.ts
@@ -1,3 +1,5 @@
+import { getKiloEmbeddingModel } from './kilo-embedding-models';
+
 export type EmbeddingProxyRequest = {
   model: string;
   input: unknown;
@@ -11,14 +13,28 @@ export type EmbeddingProxyRequest = {
   output_dimension?: number;
 };
 
+export function validateEmbeddingDimensions(
+  body: EmbeddingProxyRequest,
+  requestedModel = body.model
+): string | undefined {
+  const model = getKiloEmbeddingModel(requestedModel);
+  if (model?.dimensionMode !== 'fixed' || body.dimensions == null) return undefined;
+  if (body.dimensions === model.dimension) return undefined;
+  return `${model.name} returns fixed ${model.dimension}-dimensional embeddings through Kilo. Remove the custom dimensions setting and re-index.`;
+}
+
 /**
  * Build the upstream request body for the target provider.
  * Strips the deprecated `user` field (replaced by `safety_identifier`) and
  * native Mistral fields that upstream providers (OpenRouter, Vercel) don't understand.
+ * Catalog dimensions for fixed-width models describe local storage shape only.
  */
 export function buildUpstreamBody(
-  body: EmbeddingProxyRequest & { user?: string }
+  body: EmbeddingProxyRequest & { user?: string },
+  requestedModel = body.model
 ): Record<string, unknown> {
   const { output_dtype: _, output_dimension: __, user: ___, ...upstreamBody } = body;
-  return upstreamBody;
+  if (getKiloEmbeddingModel(requestedModel)?.dimensionMode !== 'fixed') return upstreamBody;
+  const { dimensions: ____, ...fixedBody } = upstreamBody;
+  return fixedBody;
 }

--- a/apps/web/src/lib/ai-gateway/embeddings/kilo-embedding-models.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/kilo-embedding-models.ts
@@ -4,8 +4,7 @@ export type KiloEmbeddingModel = {
   dimension: number;
   scoreThreshold: number;
   note?: string;
-  dimensionMode?: 'fixed' | 'selectable';
-  verifiedDimensions?: number[];
+  dimensionMode?: 'fixed';
 };
 
 export type KiloEmbeddingModelCatalog = {
@@ -37,8 +36,6 @@ export const KILO_EMBEDDING_MODELS = [
     name: 'OpenAI Text Embedding 3 Small',
     dimension: 1536,
     scoreThreshold: 0.4,
-    dimensionMode: 'selectable',
-    verifiedDimensions: [256, 1536],
   },
   {
     id: 'openai/text-embedding-3-large',
@@ -58,8 +55,6 @@ export const KILO_EMBEDDING_MODELS = [
     name: 'Gemini Embedding 001',
     dimension: 3072,
     scoreThreshold: 0.35,
-    dimensionMode: 'selectable',
-    verifiedDimensions: [768, 3072],
   },
   {
     id: 'qwen/qwen3-embedding-8b',

--- a/apps/web/src/lib/ai-gateway/embeddings/kilo-embedding-models.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/kilo-embedding-models.ts
@@ -4,6 +4,8 @@ export type KiloEmbeddingModel = {
   dimension: number;
   scoreThreshold: number;
   note?: string;
+  dimensionMode?: 'fixed' | 'selectable';
+  verifiedDimensions?: number[];
 };
 
 export type KiloEmbeddingModelCatalog = {
@@ -18,21 +20,25 @@ export const KILO_EMBEDDING_MODELS = [
   {
     id: 'mistralai/codestral-embed-2505',
     name: 'Codestral Embed 2505',
-    dimension: 256,
+    dimension: 1536,
     scoreThreshold: 0.35,
     note: 'code',
+    dimensionMode: 'fixed',
   },
   {
     id: KILO_DEFAULT_EMBEDDING_MODEL,
     name: 'Mistral Embed 2312',
     dimension: 1024,
     scoreThreshold: 0.35,
+    dimensionMode: 'fixed',
   },
   {
     id: 'openai/text-embedding-3-small',
     name: 'OpenAI Text Embedding 3 Small',
     dimension: 1536,
     scoreThreshold: 0.4,
+    dimensionMode: 'selectable',
+    verifiedDimensions: [256, 1536],
   },
   {
     id: 'openai/text-embedding-3-large',
@@ -45,12 +51,15 @@ export const KILO_EMBEDDING_MODELS = [
     name: 'OpenAI Text Embedding Ada 002',
     dimension: 1536,
     scoreThreshold: 0.4,
+    dimensionMode: 'fixed',
   },
   {
     id: 'google/gemini-embedding-001',
     name: 'Gemini Embedding 001',
     dimension: 3072,
     scoreThreshold: 0.35,
+    dimensionMode: 'selectable',
+    verifiedDimensions: [768, 3072],
   },
   {
     id: 'qwen/qwen3-embedding-8b',
@@ -82,12 +91,14 @@ export const KILO_EMBEDDING_MODELS = [
     name: 'BAAI bge-large-en-v1.5',
     dimension: 1024,
     scoreThreshold: 0.35,
+    dimensionMode: 'fixed',
   },
   {
     id: 'baai/bge-base-en-v1.5',
     name: 'BAAI bge-base-en-v1.5',
     dimension: 768,
     scoreThreshold: 0.35,
+    dimensionMode: 'fixed',
   },
   { id: 'thenlper/gte-large', name: 'GTE Large', dimension: 1024, scoreThreshold: 0.35 },
   { id: 'thenlper/gte-base', name: 'GTE Base', dimension: 768, scoreThreshold: 0.35 },


### PR DESCRIPTION
## Summary
Correct Kilo-hosted embedding handling so fixed-width models do not forward an unsupported `dimensions` parameter, while verified selectable dimension paths continue to forward it.
Publish Codestral's routed native width as `1536` and reject stale fixed-width overrides before proxying to prevent index shape mismatches.

## Verification
- In Indexing settings, select Codestral Embed 2505 and initialize or rebuild an index. Initialization should complete at `1536d` without an upstream `dimensions` rejection.
- Select Mistral Embed 2312 and initialize an index. It should complete without the prior dimension-field error.

## Visual Changes
N/A

## Reviewer Notes
Codestral users with a saved explicit `256d` override must clear it and re-index. Released clients using catalog defaults are repaired server-side.