### PR TITLE
feat: Add suport for native agents from marketplace

### DIFF
--- a/apps/web/src/app/api/marketplace/agents/route.test.ts
+++ b/apps/web/src/app/api/marketplace/agents/route.test.ts
@@ -1,0 +1,49 @@
+import type { NextRequest } from 'next/server';
+import { GET } from './route';
+
+const fetchMock = jest.fn();
+const originalFetch = global.fetch;
+
+describe('/api/marketplace/agents', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('passes through generated agents marketplace YAML', async () => {
+    const marketplaceYaml = 'items:\n  - id: architect\n    name: Architect\n';
+
+    fetchMock.mockResolvedValueOnce(new Response(marketplaceYaml, { status: 200 }));
+
+    const response = await GET({} as NextRequest);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/agents/marketplace.yaml'
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/x-yaml');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600, s-maxage=3600');
+    expect(await response.text()).toBe(marketplaceYaml);
+  });
+
+  it('returns empty YAML with the upstream status when GitHub fetch fails', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock.mockResolvedValueOnce(
+      new Response('not found', { status: 404, statusText: 'Not Found' })
+    );
+
+    const response = await GET({} as NextRequest);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('Content-Type')).toBe('application/x-yaml');
+    expect(await response.text()).toBe('items: []\n');
+  });
+});

--- a/apps/web/src/app/api/marketplace/agents/route.ts
+++ b/apps/web/src/app/api/marketplace/agents/route.ts
@@ -1,0 +1,45 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const GITHUB_RAW_URL =
+  'https://raw.githubusercontent.com/Kilo-Org/kilo-marketplace/main/agents/marketplace.yaml';
+
+export const revalidate = 3600; // 1 hour
+
+/**
+ * Agents Marketplace API Route
+ *
+ * Fetches agents.yaml directly from kilo-marketplace GitHub repo.
+ * Uses Next.js ISR with 1 hour revalidation for caching.
+ */
+export async function GET(_request: NextRequest) {
+  try {
+    const response = await fetch(GITHUB_RAW_URL);
+
+    if (!response.ok) {
+      console.error(
+        `Failed to fetch agents from GitHub: ${response.status} ${response.statusText}`
+      );
+      return new NextResponse('items: []\n', {
+        status: response.status,
+        headers: { 'Content-Type': 'application/x-yaml' },
+      });
+    }
+
+    const yamlContent = await response.text();
+
+    return new NextResponse(yamlContent, {
+      headers: {
+        'Content-Type': 'application/x-yaml',
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching agents marketplace data:', error);
+
+    return new NextResponse('items: []\n', {
+      status: 500,
+      headers: { 'Content-Type': 'application/x-yaml' },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Adding passthrough route for marketplace agents

## Verification

- pnpm install
- pnpm --filter web dev
- `curl -i http://127.0.0.1:3000/api/marketplace/agents`

<img width="1768" height="1058" alt="Screenshot 2026-05-27 at 13 42 46" src="https://github.com/user-attachments/assets/cb42bf47-979f-41d9-931a-45f4285e5d71" />



## Visual Changes

N/A

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
