### PR TITLE
fix(github): repair renamed installation login metadata

### DIFF
--- a/apps/web/src/lib/integrations/core/constants.ts
+++ b/apps/web/src/lib/integrations/core/constants.ts
@@ -62,6 +62,7 @@ export const GITHUB_ACTION = {
   DELETED: 'deleted',
   SUSPEND: 'suspend',
   UNSUSPEND: 'unsuspend',
+  RENAMED: 'renamed',
 
   // Repository actions
   ADDED: 'added',

--- a/apps/web/src/lib/integrations/db/platform-integrations.ts
+++ b/apps/web/src/lib/integrations/db/platform-integrations.ts
@@ -178,6 +178,21 @@ export async function updateRepositoriesForIntegration(
     .where(eq(platform_integrations.id, integrationId));
 }
 
+export async function updateIntegrationAccountIdentity(
+  integrationId: string,
+  platformAccountId: string,
+  platformAccountLogin: string
+) {
+  await db
+    .update(platform_integrations)
+    .set({
+      platform_account_id: platformAccountId,
+      platform_account_login: platformAccountLogin,
+      updated_at: new Date().toISOString(),
+    })
+    .where(eq(platform_integrations.id, integrationId));
+}
+
 /**
  * Suspends a platform integration
  */

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -8,6 +8,7 @@ const mockLogWebhookEvent = jest.fn();
 const mockUpdateWebhookEvent = jest.fn();
 const mockHandlePullRequest = jest.fn();
 const mockHandlePRReviewComment = jest.fn();
+const mockHandleInstallationTargetRenamed = jest.fn();
 
 jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
   verifyGitHubWebhookSignature: (payload: string, signature: string, appType: string) =>
@@ -31,6 +32,8 @@ jest.mock('@/lib/integrations/platforms/github/webhook-handlers', () => ({
   handleInstallationRepositories: jest.fn(),
   handleInstallationSuspend: jest.fn(),
   handleInstallationUnsuspend: jest.fn(),
+  handleInstallationTargetRenamed: (payload: unknown, integrationId: string, appType: string) =>
+    mockHandleInstallationTargetRenamed(payload, integrationId, appType),
   handleIssue: jest.fn(),
   handlePRReviewComment: (payload: unknown, platformIntegration: unknown) =>
     mockHandlePRReviewComment(payload, platformIntegration),
@@ -165,6 +168,80 @@ describe('handleGitHubWebhook', () => {
     mockUpdateWebhookEvent.mockResolvedValue(undefined);
     mockHandlePullRequest.mockResolvedValue(Response.json({ message: 'review queued' }));
     mockHandlePRReviewComment.mockResolvedValue(undefined);
+    mockHandleInstallationTargetRenamed.mockResolvedValue(
+      Response.json({ message: 'Installation target updated' })
+    );
+  });
+
+  it('routes installation_target renamed events through authoritative login synchronization', async () => {
+    const payload = {
+      action: 'renamed',
+      installation: { id: 98765 },
+      account: { id: 123, login: 'renamed-owner' },
+      changes: { login: { from: 'old-owner' } },
+      target_type: 'User',
+    };
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('installation_target', payload),
+      'lite'
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockHandleInstallationTargetRenamed).toHaveBeenCalledWith(
+      expect.objectContaining(payload),
+      integration.id,
+      'lite'
+    );
+    expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
+      'we_1',
+      expect.objectContaining({ handlers_triggered: ['installation_target_renamed'] })
+    );
+  });
+
+  it('retries installation_target synchronization after a transient handler failure', async () => {
+    const payload = {
+      action: 'renamed',
+      installation: { id: 98765 },
+      account: { id: 123, login: 'renamed-owner' },
+      changes: { login: { from: 'old-owner' } },
+      target_type: 'User',
+    };
+    mockHandleInstallationTargetRenamed
+      .mockRejectedValueOnce(new Error('temporary GitHub failure'))
+      .mockResolvedValueOnce(Response.json({ message: 'Installation target updated' }));
+
+    const firstResponse = await handleGitHubWebhook(
+      signedGitHubRequest('installation_target', payload),
+      'standard'
+    );
+    const retriedResponse = await handleGitHubWebhook(
+      signedGitHubRequest('installation_target', payload),
+      'standard'
+    );
+
+    expect(firstResponse.status).toBe(500);
+    expect(retriedResponse.status).toBe(200);
+    expect(mockHandleInstallationTargetRenamed).toHaveBeenCalledTimes(2);
+    expect(mockLogWebhookEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('safely revalidates identity before acknowledging duplicate rename deliveries', async () => {
+    mockLogWebhookEvent.mockResolvedValue({ isDuplicate: true });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('installation_target', {
+        action: 'renamed',
+        installation: { id: 98765 },
+        account: { id: 123, login: 'renamed-owner' },
+        changes: { login: { from: 'old-owner' } },
+        target_type: 'User',
+      }),
+      'standard'
+    );
+
+    expect(await response.json()).toEqual({ message: 'Duplicate event' });
+    expect(mockHandleInstallationTargetRenamed).toHaveBeenCalledTimes(1);
   });
 
   it('keeps pull_request webhooks on the code review path', async () => {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
@@ -7,6 +7,7 @@ import {
   InstallationDeletedPayloadSchema,
   InstallationSuspendPayloadSchema,
   InstallationUnsuspendPayloadSchema,
+  InstallationTargetRenamedPayloadSchema,
   InstallationRepositoriesPayloadSchema,
   PushEventPayloadSchema,
   PullRequestPayloadSchema,
@@ -20,6 +21,7 @@ import {
   handleInstallationDeleted,
   handleInstallationSuspend,
   handleInstallationUnsuspend,
+  handleInstallationTargetRenamed,
   handleInstallationRepositories,
   handlePushEvent,
   handlePullRequest,
@@ -286,6 +288,65 @@ export async function handleGitHubWebhook(
       }
 
       return NextResponse.json({ message: 'Event received' }, { status: 200 });
+    }
+
+    if (eventType === GITHUB_EVENT.INSTALLATION_TARGET) {
+      const action = (payload as { action?: string }).action || '';
+      if (action !== GITHUB_ACTION.RENAMED) {
+        return NextResponse.json({ message: 'Event received' }, { status: 200 });
+      }
+
+      const parseResult = InstallationTargetRenamedPayloadSchema.safeParse(payload);
+      if (!parseResult.success) {
+        logExceptInTest(
+          `Invalid installation_target.renamed payload${logSuffix}:`,
+          parseResult.error
+        );
+        captureMessage('Invalid GitHub webhook payload structure', {
+          level: 'error',
+          tags: {
+            source: `${sentryPrefix}webhook_validation`,
+            event: 'installation_target.renamed',
+          },
+          extra: { errors: parseResult.error.issues },
+        });
+        return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+      }
+
+      const installationId = parseResult.data.installation.id.toString();
+      const integration = await findIntegrationByInstallationId(PLATFORM.GITHUB, installationId);
+      if (!integration) {
+        console.warn(`Integration not found${logSuffix}:`, installationId);
+        return NextResponse.json({ message: 'Integration not found' }, { status: 404 });
+      }
+
+      // Identity synchronization is idempotent and must finish before delivery deduplication;
+      // otherwise GitHub redelivery after a transient API or database failure cannot repair metadata.
+      const result = await handleInstallationTargetRenamed(
+        parseResult.data,
+        integration.id,
+        appType
+      );
+
+      const logResult = await logWebhook(integration, action);
+      if (logResult.isDuplicate) {
+        return NextResponse.json({ message: 'Duplicate event' }, { status: 200 });
+      }
+
+      if (logResult.webhookEventId) {
+        try {
+          await updateWebhookEvent(logResult.webhookEventId, {
+            processed: true,
+            processed_at: new Date().toISOString(),
+            handlers_triggered: ['installation_target_renamed'],
+            errors: null,
+          });
+        } catch (error) {
+          logExceptInTest(`Error updating webhook event${logSuffix}:`, error);
+        }
+      }
+
+      return result;
     }
 
     // Handle installation_repositories events

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/index.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/index.ts
@@ -9,6 +9,7 @@ export {
   handleInstallationSuspend,
   handleInstallationUnsuspend,
 } from './installation-handler';
+export { handleInstallationTargetRenamed } from './installation-target-handler';
 export { handleInstallationRepositories } from './installation-repositories-handler';
 export { handlePushEvent } from './push-handler';
 export { handlePullRequest } from './pull-request-handler';

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/installation-target-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/installation-target-handler.test.ts
@@ -1,0 +1,97 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { GitHubAppType } from '../app-selector';
+import type { InstallationTargetRenamedPayload } from '../webhook-schemas';
+
+type InstallationAccountDetails = {
+  account: { id: number; login: string };
+};
+
+const mockFetchGitHubInstallationDetails =
+  jest.fn<
+    (installationId: string, appType: GitHubAppType) => Promise<InstallationAccountDetails>
+  >();
+const mockUpdateIntegrationAccountIdentity =
+  jest.fn<
+    (
+      integrationId: string,
+      platformAccountId: string,
+      platformAccountLogin: string
+    ) => Promise<void>
+  >();
+
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  fetchGitHubInstallationDetails: (installationId: string, appType: GitHubAppType) =>
+    mockFetchGitHubInstallationDetails(installationId, appType),
+}));
+
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  updateIntegrationAccountIdentity: (
+    integrationId: string,
+    platformAccountId: string,
+    platformAccountLogin: string
+  ) => mockUpdateIntegrationAccountIdentity(integrationId, platformAccountId, platformAccountLogin),
+}));
+
+let handleInstallationTargetRenamed: (
+  payload: InstallationTargetRenamedPayload,
+  integrationId: string,
+  appType: GitHubAppType
+) => Promise<Response>;
+
+beforeAll(async () => {
+  ({ handleInstallationTargetRenamed } = await import('./installation-target-handler'));
+});
+
+describe('handleInstallationTargetRenamed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchGitHubInstallationDetails.mockResolvedValue({
+      account: { id: 123, login: 'authoritative-current-owner' },
+    });
+    mockUpdateIntegrationAccountIdentity.mockResolvedValue(undefined);
+  });
+
+  it('persists the current installation identity fetched from GitHub', async () => {
+    const response = await handleInstallationTargetRenamed(
+      {
+        action: 'renamed',
+        installation: { id: 98765 },
+        account: { id: 123, login: 'possibly-stale-webhook-owner' },
+        changes: { login: { from: 'old-owner' } },
+        target_type: 'User',
+      },
+      'integration-1',
+      'lite'
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockFetchGitHubInstallationDetails).toHaveBeenCalledWith('98765', 'lite');
+    expect(mockUpdateIntegrationAccountIdentity).toHaveBeenCalledWith(
+      'integration-1',
+      '123',
+      'authoritative-current-owner'
+    );
+  });
+
+  it('does not overwrite stored identity when GitHub returns no current login', async () => {
+    mockFetchGitHubInstallationDetails.mockResolvedValue({
+      account: { id: 123, login: '' },
+    });
+
+    await expect(
+      handleInstallationTargetRenamed(
+        {
+          action: 'renamed',
+          installation: { id: 98765 },
+          account: {},
+          changes: {},
+          target_type: 'Organization',
+        },
+        'integration-1',
+        'standard'
+      )
+    ).rejects.toThrow('GitHub installation account identity missing after rename event');
+
+    expect(mockUpdateIntegrationAccountIdentity).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/installation-target-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/installation-target-handler.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { updateIntegrationAccountIdentity } from '@/lib/integrations/db/platform-integrations';
+import type { GitHubAppType } from '../app-selector';
+import { fetchGitHubInstallationDetails } from '@/lib/integrations/platforms/github/adapter';
+import type { InstallationTargetRenamedPayload } from '../webhook-schemas';
+import { logExceptInTest } from '@/lib/utils.server';
+
+export async function handleInstallationTargetRenamed(
+  payload: InstallationTargetRenamedPayload,
+  integrationId: string,
+  appType: GitHubAppType
+) {
+  const installationId = payload.installation.id.toString();
+  const details = await fetchGitHubInstallationDetails(installationId, appType);
+
+  if (!details.account.id || !details.account.login) {
+    throw new Error('GitHub installation account identity missing after rename event');
+  }
+
+  await updateIntegrationAccountIdentity(
+    integrationId,
+    details.account.id.toString(),
+    details.account.login
+  );
+
+  logExceptInTest('GitHub App installation target renamed:', {
+    installation_id: installationId,
+    integration_id: integrationId,
+    target_type: payload.target_type,
+  });
+
+  return NextResponse.json({ message: 'Installation target updated' }, { status: 200 });
+}

--- a/apps/web/src/lib/integrations/platforms/github/webhook-schemas.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-schemas.ts
@@ -65,6 +65,17 @@ export const InstallationUnsuspendPayloadSchema = z.object({
   sender: GitHubSenderSchema.optional(),
 });
 
+// installation_target.renamed webhook payload
+export const InstallationTargetRenamedPayloadSchema = z.object({
+  action: z.literal('renamed'),
+  installation: z.object({
+    id: z.number(),
+  }),
+  account: z.object({}).passthrough(),
+  changes: z.object({}).passthrough(),
+  target_type: z.string(),
+});
+
 // installation_repositories webhook payload
 export const InstallationRepositoriesPayloadSchema = z.object({
   action: z.enum(['added', 'removed']),
@@ -281,6 +292,9 @@ export type InstallationCreatedPayload = z.infer<typeof InstallationCreatedPaylo
 export type InstallationDeletedPayload = z.infer<typeof InstallationDeletedPayloadSchema>;
 export type InstallationSuspendPayload = z.infer<typeof InstallationSuspendPayloadSchema>;
 export type InstallationUnsuspendPayload = z.infer<typeof InstallationUnsuspendPayloadSchema>;
+export type InstallationTargetRenamedPayload = z.infer<
+  typeof InstallationTargetRenamedPayloadSchema
+>;
 export type InstallationRepositoriesPayload = z.infer<typeof InstallationRepositoriesPayloadSchema>;
 export type PushEventPayload = z.infer<typeof PushEventPayloadSchema>;
 export type PullRequestPayload = z.infer<typeof PullRequestPayloadSchema>;

--- a/apps/web/src/routers/github-apps-router.test.ts
+++ b/apps/web/src/routers/github-apps-router.test.ts
@@ -1,0 +1,91 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { createCallerFactory } from '@/lib/trpc/init';
+import type { User } from '@kilocode/db/schema';
+import type { Owner } from '@/lib/integrations/core/types';
+import type { GitHubAppType } from '@/lib/integrations/platforms/github/app-selector';
+
+type TestIntegration = {
+  id: string;
+  platform_installation_id: string;
+  platform_account_login: string;
+  github_app_type: GitHubAppType;
+};
+
+type InstallationDetails = {
+  account: { id: number; login: string };
+  permissions: Record<string, string>;
+  events: string[];
+  repository_selection: string;
+  created_at: string;
+};
+
+const mockGetIntegrationForOwner =
+  jest.fn<(owner: Owner, platform: string) => Promise<TestIntegration | null>>();
+const mockUpsertPlatformIntegrationForOwner =
+  jest.fn<(owner: Owner, details: Record<string, unknown>) => Promise<void>>();
+const mockUpdateRepositoriesForIntegration =
+  jest.fn<(integrationId: string, repositories: unknown[]) => Promise<void>>();
+const mockFetchGitHubInstallationDetails =
+  jest.fn<(installationId: string, appType: GitHubAppType) => Promise<InstallationDetails>>();
+const mockFetchGitHubRepositories =
+  jest.fn<(installationId: string, appType: GitHubAppType) => Promise<unknown[]>>();
+
+jest.mock('@/lib/integrations/github-apps-service', () => ({}));
+
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  getIntegrationForOwner: (owner: Owner, platform: string) =>
+    mockGetIntegrationForOwner(owner, platform),
+  upsertPlatformIntegrationForOwner: (owner: Owner, details: Record<string, unknown>) =>
+    mockUpsertPlatformIntegrationForOwner(owner, details),
+  updateRepositoriesForIntegration: (integrationId: string, repositories: unknown[]) =>
+    mockUpdateRepositoriesForIntegration(integrationId, repositories),
+}));
+
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  fetchGitHubInstallationDetails: (installationId: string, appType: GitHubAppType) =>
+    mockFetchGitHubInstallationDetails(installationId, appType),
+  fetchGitHubRepositories: (installationId: string, appType: GitHubAppType) =>
+    mockFetchGitHubRepositories(installationId, appType),
+}));
+
+let createCaller: (ctx: { user: User }) => {
+  refreshInstallation: (input?: { organizationId?: string }) => Promise<{ success: boolean }>;
+};
+
+beforeAll(async () => {
+  const mod = await import('./github-apps-router');
+  createCaller = createCallerFactory(mod.githubAppsRouter);
+});
+
+describe('githubAppsRouter.refreshInstallation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetIntegrationForOwner.mockResolvedValue({
+      id: 'integration-1',
+      platform_installation_id: '98765',
+      platform_account_login: 'old-owner',
+      github_app_type: 'standard',
+    });
+    mockFetchGitHubInstallationDetails.mockResolvedValue({
+      account: { id: 123, login: 'renamed-owner' },
+      permissions: {},
+      events: [],
+      repository_selection: 'all',
+      created_at: '2026-01-01T00:00:00.000Z',
+    });
+    mockFetchGitHubRepositories.mockResolvedValue([]);
+    mockUpsertPlatformIntegrationForOwner.mockResolvedValue(undefined);
+    mockUpdateRepositoriesForIntegration.mockResolvedValue(undefined);
+  });
+
+  it('persists the current account login returned by GitHub', async () => {
+    const caller = createCaller({ user: { id: 'user-1' } as User });
+
+    await caller.refreshInstallation();
+
+    expect(mockUpsertPlatformIntegrationForOwner).toHaveBeenCalledWith(
+      { type: 'user', id: 'user-1' },
+      expect.objectContaining({ platformAccountLogin: 'renamed-owner' })
+    );
+  });
+});

--- a/apps/web/src/routers/github-apps-router.test.ts
+++ b/apps/web/src/routers/github-apps-router.test.ts
@@ -88,4 +88,23 @@ describe('githubAppsRouter.refreshInstallation', () => {
       expect.objectContaining({ platformAccountLogin: 'renamed-owner' })
     );
   });
+
+  it('does not clear stored identity when GitHub returns no current account login', async () => {
+    mockFetchGitHubInstallationDetails.mockResolvedValue({
+      account: { id: 0, login: '' },
+      permissions: {},
+      events: [],
+      repository_selection: 'all',
+      created_at: '2026-01-01T00:00:00.000Z',
+    });
+    const caller = createCaller({ user: { id: 'user-1' } as User });
+
+    await expect(caller.refreshInstallation()).rejects.toThrow(
+      'GitHub installation account identity unavailable'
+    );
+
+    expect(mockUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
+    expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
+    expect(mockUpdateRepositoriesForIntegration).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/routers/github-apps-router.ts
+++ b/apps/web/src/routers/github-apps-router.ts
@@ -205,7 +205,7 @@ export const githubAppsRouter = createTRPCRouter({
       integrationType: 'app',
       platformInstallationId: installationId,
       platformAccountId: installationDetails.account.id.toString(),
-      platformAccountLogin: integration.platform_account_login ?? undefined,
+      platformAccountLogin: installationDetails.account.login,
       permissions: installationDetails.permissions,
       scopes: installationDetails.events,
       repositoryAccess: installationDetails.repository_selection,

--- a/apps/web/src/routers/github-apps-router.ts
+++ b/apps/web/src/routers/github-apps-router.ts
@@ -199,6 +199,12 @@ export const githubAppsRouter = createTRPCRouter({
     const appType = integration.github_app_type || 'standard';
 
     const installationDetails = await fetchGitHubInstallationDetails(installationId, appType);
+    if (!installationDetails.account.id || !installationDetails.account.login) {
+      throw new TRPCError({
+        code: 'BAD_GATEWAY',
+        message: 'GitHub installation account identity unavailable',
+      });
+    }
 
     await upsertPlatformIntegrationForOwner(owner, {
       platform: 'github',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1933,6 +1933,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
         version: 4.90.1(@cloudflare/workers-types@4.20260511.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1920,6 +1920,9 @@ importers:
       '@octokit/auth-app':
         specifier: 'catalog:'
         version: 8.2.0
+      '@octokit/rest':
+        specifier: 22.0.1
+        version: 22.0.1
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260511.1)(@opentelemetry/api@1.9.1)(@types/pg@8.18.0)(bun-types@1.3.14)(pg@8.20.0)

--- a/services/git-token-service/package.json
+++ b/services/git-token-service/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@kilocode/db": "workspace:*",
     "@octokit/auth-app": "catalog:",
+    "@octokit/rest": "22.0.1",
     "drizzle-orm": "catalog:",
     "zod": "catalog:"
   },

--- a/services/git-token-service/package.json
+++ b/services/git-token-service/package.json
@@ -6,6 +6,7 @@
     "dev": "wrangler dev --env dev",
     "dev:test": "wrangler dev --config wrangler.test.jsonc",
     "deploy": "wrangler deploy",
+    "test": "vitest run",
     "typecheck": "tsgo --noEmit",
     "lint": "pnpm -w exec oxlint --config .oxlintrc.json services/git-token-service/src",
     "types": "wrangler types --env-interface CloudflareEnv worker-configuration.d.ts"
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@typescript/native-preview": "catalog:",
     "typescript": "catalog:",
+    "vitest": "catalog:",
     "wrangler": "catalog:"
   }
 }

--- a/services/git-token-service/src/github-token-service.test.ts
+++ b/services/git-token-service/src/github-token-service.test.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAppAuth } from '@octokit/auth-app';
+import { Octokit } from '@octokit/rest';
 import { GitHubTokenService } from './github-token-service.js';
 
 vi.mock('@octokit/auth-app', () => ({
   createAppAuth: vi.fn(),
 }));
+vi.mock('@octokit/rest', () => ({
+  Octokit: vi.fn(),
+}));
+
+const mockGetInstallation = vi.fn();
 
 type RefreshableGitHubTokenService = {
   refreshInstallationAccountLoginIfDue(
@@ -24,6 +30,11 @@ describe('GitHubTokenService', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.mocked(createAppAuth).mockReset();
+    vi.mocked(Octokit).mockReset();
+    mockGetInstallation.mockReset();
+    vi.mocked(Octokit).mockImplementation(function MockOctokit() {
+      return { apps: { getInstallation: mockGetInstallation } } as unknown as Octokit;
+    });
   });
 
   it('refreshes installation account login and stores a fifteen minute cooldown marker', async () => {
@@ -31,11 +42,7 @@ describe('GitHubTokenService', () => {
     vi.mocked(createAppAuth).mockReturnValue(
       vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
     );
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(
-        new Response(JSON.stringify({ account: { login: 'renamed-owner' } }), { status: 200 })
-      );
+    mockGetInstallation.mockResolvedValue({ data: { account: { login: 'renamed-owner' } } });
     const service = new GitHubTokenService({
       GITHUB_APP_ID: 'app-id',
       GITHUB_APP_PRIVATE_KEY: 'private-key',
@@ -50,15 +57,12 @@ describe('GitHubTokenService', () => {
       expect.any(String),
       { expirationTtl: 15 * 60 }
     );
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'https://api.github.com/app/installations/123',
-      expect.objectContaining({ method: 'GET' })
-    );
+    expect(Octokit).toHaveBeenCalledWith({ auth: 'app-jwt' });
+    expect(mockGetInstallation).toHaveBeenCalledWith({ installation_id: 123 });
   });
 
   it('suppresses installation login refresh during the cooldown window', async () => {
     const tokenCache = createTokenCache('attempted');
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
     const service = new GitHubTokenService({
       GITHUB_APP_ID: 'app-id',
       GITHUB_APP_PRIVATE_KEY: 'private-key',
@@ -69,7 +73,7 @@ describe('GitHubTokenService', () => {
 
     expect(result).toBeNull();
     expect(tokenCache.put).not.toHaveBeenCalled();
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(Octokit).not.toHaveBeenCalled();
     expect(createAppAuth).not.toHaveBeenCalled();
   });
 
@@ -84,7 +88,7 @@ describe('GitHubTokenService', () => {
     vi.mocked(createAppAuth).mockReturnValue(
       vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
     );
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('unavailable'));
+    mockGetInstallation.mockRejectedValue(new Error('unavailable'));
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const service = new GitHubTokenService({
       GITHUB_APP_ID: 'app-id',
@@ -96,7 +100,7 @@ describe('GitHubTokenService', () => {
     expect(await service.refreshInstallationAccountLoginIfDue('123')).toBeNull();
 
     expect(tokenCache.put).toHaveBeenCalledTimes(1);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(mockGetInstallation).toHaveBeenCalledTimes(1);
   });
 
   it('does not log authenticated response data when installation login refresh fails', async () => {
@@ -106,7 +110,7 @@ describe('GitHubTokenService', () => {
     vi.mocked(createAppAuth).mockReturnValue(
       vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
     );
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(upstreamError);
+    mockGetInstallation.mockRejectedValue(upstreamError);
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const service = new GitHubTokenService({
       GITHUB_APP_ID: 'app-id',

--- a/services/git-token-service/src/github-token-service.test.ts
+++ b/services/git-token-service/src/github-token-service.test.ts
@@ -26,7 +26,7 @@ describe('GitHubTokenService', () => {
     vi.mocked(createAppAuth).mockReset();
   });
 
-  it('refreshes installation account login and stores a ten minute cooldown marker', async () => {
+  it('refreshes installation account login and stores a fifteen minute cooldown marker', async () => {
     const tokenCache = createTokenCache();
     vi.mocked(createAppAuth).mockReturnValue(
       vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
@@ -48,7 +48,7 @@ describe('GitHubTokenService', () => {
     expect(tokenCache.put).toHaveBeenCalledWith(
       'gh-installation-login-refresh:v1:standard:123',
       expect.any(String),
-      { expirationTtl: 10 * 60 }
+      { expirationTtl: 15 * 60 }
     );
     expect(fetchSpy).toHaveBeenCalledWith(
       'https://api.github.com/app/installations/123',

--- a/services/git-token-service/src/github-token-service.test.ts
+++ b/services/git-token-service/src/github-token-service.test.ts
@@ -73,6 +73,32 @@ describe('GitHubTokenService', () => {
     expect(createAppAuth).not.toHaveBeenCalled();
   });
 
+  it('cools down failed login refresh attempts to avoid repeated upstream requests', async () => {
+    let cooldownValue: string | null = null;
+    const tokenCache = {
+      get: vi.fn(async () => cooldownValue),
+      put: vi.fn(async (_key: string, value: string) => {
+        cooldownValue = value;
+      }),
+    };
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
+    );
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('unavailable'));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const service = new GitHubTokenService({
+      GITHUB_APP_ID: 'app-id',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+      TOKEN_CACHE: tokenCache,
+    } as unknown as CloudflareEnv) as unknown as RefreshableGitHubTokenService;
+
+    expect(await service.refreshInstallationAccountLoginIfDue('123')).toBeNull();
+    expect(await service.refreshInstallationAccountLoginIfDue('123')).toBeNull();
+
+    expect(tokenCache.put).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('does not log authenticated response data when installation login refresh fails', async () => {
     const upstreamError = Object.assign(new Error('metadata lookup unavailable'), {
       response: { data: { token: 'sensitive-metadata-response' } },

--- a/services/git-token-service/src/github-token-service.test.ts
+++ b/services/git-token-service/src/github-token-service.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAppAuth } from '@octokit/auth-app';
+import { GitHubTokenService } from './github-token-service.js';
+
+vi.mock('@octokit/auth-app', () => ({
+  createAppAuth: vi.fn(),
+}));
+
+type RefreshableGitHubTokenService = {
+  refreshInstallationAccountLoginIfDue(
+    installationId: string,
+    appType?: 'standard' | 'lite'
+  ): Promise<string | null>;
+};
+
+function createTokenCache(cooldownValue: string | null = null) {
+  return {
+    get: vi.fn(async () => cooldownValue),
+    put: vi.fn(async () => undefined),
+  };
+}
+
+describe('GitHubTokenService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(createAppAuth).mockReset();
+  });
+
+  it('refreshes installation account login and stores a ten minute cooldown marker', async () => {
+    const tokenCache = createTokenCache();
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ account: { login: 'renamed-owner' } }), { status: 200 })
+      );
+    const service = new GitHubTokenService({
+      GITHUB_APP_ID: 'app-id',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+      TOKEN_CACHE: tokenCache,
+    } as unknown as CloudflareEnv) as unknown as RefreshableGitHubTokenService;
+
+    const result = await service.refreshInstallationAccountLoginIfDue('123');
+
+    expect(result).toBe('renamed-owner');
+    expect(tokenCache.put).toHaveBeenCalledWith(
+      'gh-installation-login-refresh:v1:standard:123',
+      expect.any(String),
+      { expirationTtl: 10 * 60 }
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.github.com/app/installations/123',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('suppresses installation login refresh during the cooldown window', async () => {
+    const tokenCache = createTokenCache('attempted');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const service = new GitHubTokenService({
+      GITHUB_APP_ID: 'app-id',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+      TOKEN_CACHE: tokenCache,
+    } as unknown as CloudflareEnv) as unknown as RefreshableGitHubTokenService;
+
+    const result = await service.refreshInstallationAccountLoginIfDue('123', 'lite');
+
+    expect(result).toBeNull();
+    expect(tokenCache.put).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(createAppAuth).not.toHaveBeenCalled();
+  });
+
+  it('does not log authenticated response data when installation login refresh fails', async () => {
+    const upstreamError = Object.assign(new Error('metadata lookup unavailable'), {
+      response: { data: { token: 'sensitive-metadata-response' } },
+    });
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
+    );
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(upstreamError);
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const service = new GitHubTokenService({
+      GITHUB_APP_ID: 'app-id',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+    } as CloudflareEnv) as unknown as RefreshableGitHubTokenService;
+
+    const result = await service.refreshInstallationAccountLoginIfDue('123');
+
+    expect(result).toBeNull();
+    expect(JSON.stringify(consoleWarn.mock.calls)).not.toContain('sensitive-metadata-response');
+  });
+
+  it('does not log authenticated upstream response data when scoped token minting fails', async () => {
+    const upstreamError = Object.assign(new Error('repository unavailable'), {
+      response: { data: { token: 'sensitive-upstream-data' } },
+    });
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockRejectedValue(upstreamError) as unknown as ReturnType<typeof createAppAuth>
+    );
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const service = new GitHubTokenService({
+      GITHUB_APP_ID: 'app-id',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+    } as CloudflareEnv);
+
+    await expect(service.getTokenForRepo('123', 'repository')).rejects.toThrow(
+      'Failed to generate GitHub installation token: repository unavailable'
+    );
+
+    expect(consoleError).toHaveBeenCalledWith(
+      JSON.stringify({
+        message: 'Failed to generate GitHub installation token',
+        errorType: 'Error',
+      })
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain('sensitive-upstream-data');
+  });
+});

--- a/services/git-token-service/src/github-token-service.ts
+++ b/services/git-token-service/src/github-token-service.ts
@@ -79,6 +79,7 @@ export class GitHubTokenService {
       if (cooldownMarker !== null) {
         return null;
       }
+      // Cool down failed attempts too, so repeated lookup misses cannot hammer GitHub.
       await this.env.TOKEN_CACHE.put(cooldownKey, new Date().toISOString(), {
         expirationTtl: INSTALLATION_LOGIN_REFRESH_TTL_SECONDS,
       });

--- a/services/git-token-service/src/github-token-service.ts
+++ b/services/git-token-service/src/github-token-service.ts
@@ -24,7 +24,7 @@ const CACHE_KEY_PREFIX = 'gh-token:';
 const MIN_TTL_SECONDS = 60;
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 const INSTALLATION_LOGIN_REFRESH_CACHE_KEY_PREFIX = 'gh-installation-login-refresh:v1:';
-const INSTALLATION_LOGIN_REFRESH_TTL_SECONDS = 10 * 60;
+const INSTALLATION_LOGIN_REFRESH_TTL_SECONDS = 15 * 60;
 
 const GitHubInstallationAccountSchema = z.object({
   account: z.object({

--- a/services/git-token-service/src/github-token-service.ts
+++ b/services/git-token-service/src/github-token-service.ts
@@ -1,4 +1,5 @@
 import { createAppAuth } from '@octokit/auth-app';
+import { Octokit } from '@octokit/rest';
 import * as z from 'zod';
 
 type Token = z.infer<typeof Token>;
@@ -93,28 +94,9 @@ export class GitHubTokenService {
         privateKey: credentials.privateKey,
       });
       const { token } = await auth({ type: 'app' });
-      const response = await fetch(`https://api.github.com/app/installations/${numericId}`, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/vnd.github+json',
-          Authorization: `Bearer ${token}`,
-          'User-Agent': 'Kilo-Git-Token-Service',
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-      });
-
-      if (!response.ok) {
-        console.warn(
-          JSON.stringify({
-            message: 'Failed to refresh GitHub installation account login',
-            status: response.status,
-            appType,
-          })
-        );
-        return null;
-      }
-
-      const parsed = GitHubInstallationAccountSchema.safeParse(await response.json());
+      const octokit = new Octokit({ auth: token });
+      const { data } = await octokit.apps.getInstallation({ installation_id: numericId });
+      const parsed = GitHubInstallationAccountSchema.safeParse(data);
       if (!parsed.success) {
         console.warn(
           JSON.stringify({

--- a/services/git-token-service/src/github-token-service.ts
+++ b/services/git-token-service/src/github-token-service.ts
@@ -23,6 +23,14 @@ const CACHE_TTL_MS = 30 * 60 * 1000;
 const CACHE_KEY_PREFIX = 'gh-token:';
 const MIN_TTL_SECONDS = 60;
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+const INSTALLATION_LOGIN_REFRESH_CACHE_KEY_PREFIX = 'gh-installation-login-refresh:v1:';
+const INSTALLATION_LOGIN_REFRESH_TTL_SECONDS = 10 * 60;
+
+const GitHubInstallationAccountSchema = z.object({
+  account: z.object({
+    login: z.string().min(1),
+  }),
+});
 
 export class GitHubTokenService {
   constructor(private env: CloudflareEnv) {}
@@ -59,6 +67,74 @@ export class GitHubTokenService {
     await this.cacheToken(cacheKey, token, expiresAt);
 
     return token;
+  }
+
+  async refreshInstallationAccountLoginIfDue(
+    installationId: string,
+    appType: GitHubAppType = 'standard'
+  ): Promise<string | null> {
+    const cooldownKey = `${INSTALLATION_LOGIN_REFRESH_CACHE_KEY_PREFIX}${appType}:${installationId}`;
+    if (this.env.TOKEN_CACHE) {
+      const cooldownMarker = await this.env.TOKEN_CACHE.get(cooldownKey);
+      if (cooldownMarker !== null) {
+        return null;
+      }
+      await this.env.TOKEN_CACHE.put(cooldownKey, new Date().toISOString(), {
+        expirationTtl: INSTALLATION_LOGIN_REFRESH_TTL_SECONDS,
+      });
+    }
+
+    try {
+      const numericId = this.validateInstallationId(installationId);
+      const credentials = this.getCredentials(appType);
+      const auth = createAppAuth({
+        appId: credentials.appId,
+        privateKey: credentials.privateKey,
+      });
+      const { token } = await auth({ type: 'app' });
+      const response = await fetch(`https://api.github.com/app/installations/${numericId}`, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'User-Agent': 'Kilo-Git-Token-Service',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+
+      if (!response.ok) {
+        console.warn(
+          JSON.stringify({
+            message: 'Failed to refresh GitHub installation account login',
+            status: response.status,
+            appType,
+          })
+        );
+        return null;
+      }
+
+      const parsed = GitHubInstallationAccountSchema.safeParse(await response.json());
+      if (!parsed.success) {
+        console.warn(
+          JSON.stringify({
+            message: 'Invalid GitHub installation account metadata response',
+            appType,
+          })
+        );
+        return null;
+      }
+
+      return parsed.data.account.login;
+    } catch (error) {
+      console.warn(
+        JSON.stringify({
+          message: 'Failed to refresh GitHub installation account login',
+          errorType: error instanceof Error ? error.name : 'UnknownError',
+          appType,
+        })
+      );
+      return null;
+    }
   }
 
   /**
@@ -156,7 +232,12 @@ export class GitHubTokenService {
         expiresAt: new Date(result.expiresAt).getTime(),
       };
     } catch (error) {
-      console.error('Failed to generate GitHub token:', error);
+      console.error(
+        JSON.stringify({
+          message: 'Failed to generate GitHub installation token',
+          errorType: error instanceof Error ? error.name : 'UnknownError',
+        })
+      );
       const message = error instanceof Error ? error.message : 'Unknown error';
       throw new Error(`Failed to generate GitHub installation token: ${message}`);
     }

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('cloudflare:workers', () => ({
+  WorkerEntrypoint: class WorkerEntrypoint {
+    constructor(_ctx: unknown, _env: unknown) {}
+  },
+}));
+
+import { GitHubTokenService } from './github-token-service.js';
+import { GitTokenRPCEntrypoint } from './index.js';
+import { InstallationLookupService } from './installation-lookup-service.js';
+
+describe('GitTokenRPCEntrypoint', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('mints repository-scoped tokens after resolving an authorized installation', async () => {
+    vi.spyOn(InstallationLookupService.prototype, 'findInstallationId').mockResolvedValue({
+      success: true,
+      installationId: '123',
+      accountLogin: 'old-owner',
+      githubAppType: 'lite',
+    });
+    const getTokenForRepo = vi
+      .spyOn(GitHubTokenService.prototype, 'getTokenForRepo')
+      .mockResolvedValue('scoped-token');
+    const getToken = vi
+      .spyOn(GitHubTokenService.prototype, 'getToken')
+      .mockResolvedValue('installation-wide-token');
+    const rpc = new GitTokenRPCEntrypoint({} as ExecutionContext, {} as CloudflareEnv);
+
+    const result = await rpc.getTokenForRepo({
+      githubRepo: 'renamed-owner/repository',
+      userId: 'user-1',
+    });
+
+    expect(result).toEqual({
+      success: true,
+      token: 'scoped-token',
+      installationId: '123',
+      accountLogin: 'old-owner',
+      appType: 'lite',
+    });
+    expect(getTokenForRepo).toHaveBeenCalledWith('123', 'repository', 'lite');
+    expect(getToken).not.toHaveBeenCalled();
+  });
+
+  it('repairs stale login metadata after a lookup miss before minting a token', async () => {
+    const findInstallationId = vi
+      .spyOn(InstallationLookupService.prototype, 'findInstallationId')
+      .mockResolvedValueOnce({ success: false, reason: 'no_installation_found' })
+      .mockResolvedValueOnce({
+        success: true,
+        installationId: '123',
+        accountLogin: 'renamed-owner',
+        githubAppType: 'standard',
+      });
+    vi.spyOn(InstallationLookupService.prototype, 'findRefreshCandidates').mockResolvedValue({
+      success: true,
+      candidates: [
+        {
+          integrationId: 'integration-1',
+          installationId: '123',
+          accountLogin: 'old-owner',
+          githubAppType: 'standard',
+        },
+      ],
+    });
+    const updateAccountLogin = vi
+      .spyOn(InstallationLookupService.prototype, 'updateAccountLogin')
+      .mockResolvedValue();
+    vi.spyOn(
+      GitHubTokenService.prototype,
+      'refreshInstallationAccountLoginIfDue'
+    ).mockResolvedValue('renamed-owner');
+    const getTokenForRepo = vi
+      .spyOn(GitHubTokenService.prototype, 'getTokenForRepo')
+      .mockResolvedValue('scoped-token');
+    const rpc = new GitTokenRPCEntrypoint({} as ExecutionContext, {} as CloudflareEnv);
+
+    const result = await rpc.getTokenForRepo({
+      githubRepo: 'renamed-owner/repository',
+      userId: 'user-1',
+    });
+
+    expect(result).toMatchObject({ success: true, token: 'scoped-token' });
+    expect(updateAccountLogin).toHaveBeenCalledWith('integration-1', 'renamed-owner');
+    expect(findInstallationId).toHaveBeenCalledTimes(2);
+    expect(getTokenForRepo).toHaveBeenCalledWith('123', 'repository', 'standard');
+  });
+
+  it('does not mint when refreshed metadata identifies a different repository owner', async () => {
+    vi.spyOn(InstallationLookupService.prototype, 'findInstallationId').mockResolvedValue({
+      success: false,
+      reason: 'no_installation_found',
+    });
+    vi.spyOn(InstallationLookupService.prototype, 'findRefreshCandidates').mockResolvedValue({
+      success: true,
+      candidates: [
+        {
+          integrationId: 'integration-1',
+          installationId: '123',
+          accountLogin: 'old-owner',
+          githubAppType: 'standard',
+        },
+      ],
+    });
+    const updateAccountLogin = vi
+      .spyOn(InstallationLookupService.prototype, 'updateAccountLogin')
+      .mockResolvedValue();
+    vi.spyOn(
+      GitHubTokenService.prototype,
+      'refreshInstallationAccountLoginIfDue'
+    ).mockResolvedValue('different-owner');
+    const getTokenForRepo = vi.spyOn(GitHubTokenService.prototype, 'getTokenForRepo');
+    const rpc = new GitTokenRPCEntrypoint({} as ExecutionContext, {} as CloudflareEnv);
+
+    const result = await rpc.getTokenForRepo({
+      githubRepo: 'requested-owner/repository',
+      userId: 'user-1',
+    });
+
+    expect(result).toEqual({ success: false, reason: 'no_installation_found' });
+    expect(updateAccountLogin).toHaveBeenCalledWith('integration-1', 'different-owner');
+    expect(getTokenForRepo).not.toHaveBeenCalled();
+  });
+
+  it('fails closed without metadata repair when exact owner selection is ambiguous', async () => {
+    vi.spyOn(InstallationLookupService.prototype, 'findInstallationId').mockResolvedValue({
+      success: false,
+      reason: 'ambiguous_installation',
+    });
+    const findRefreshCandidates = vi.spyOn(
+      InstallationLookupService.prototype,
+      'findRefreshCandidates'
+    );
+    const getTokenForRepo = vi.spyOn(GitHubTokenService.prototype, 'getTokenForRepo');
+    const rpc = new GitTokenRPCEntrypoint({} as ExecutionContext, {} as CloudflareEnv);
+
+    const result = await rpc.getTokenForRepo({
+      githubRepo: 'requested-owner/repository',
+      userId: 'user-1',
+    });
+
+    expect(result).toEqual({ success: false, reason: 'no_installation_found' });
+    expect(findRefreshCandidates).not.toHaveBeenCalled();
+    expect(getTokenForRepo).not.toHaveBeenCalled();
+  });
+
+  it('does not mint a token for an invalid repository path', async () => {
+    const getTokenForRepo = vi.spyOn(GitHubTokenService.prototype, 'getTokenForRepo');
+    const rpc = new GitTokenRPCEntrypoint(
+      {} as ExecutionContext,
+      {
+        HYPERDRIVE: { connectionString: 'postgres://test' },
+      } as CloudflareEnv
+    );
+
+    const result = await rpc.getTokenForRepo({
+      githubRepo: 'owner/repository/extra',
+      userId: 'user-1',
+    });
+
+    expect(result).toEqual({ success: false, reason: 'invalid_repo_format' });
+    expect(getTokenForRepo).not.toHaveBeenCalled();
+  });
+
+  it('does not fall back to an installation-wide token when scoped minting fails', async () => {
+    vi.spyOn(InstallationLookupService.prototype, 'findInstallationId').mockResolvedValue({
+      success: true,
+      installationId: '123',
+      accountLogin: 'old-owner',
+      githubAppType: 'standard',
+    });
+    vi.spyOn(GitHubTokenService.prototype, 'getTokenForRepo').mockRejectedValue(
+      new Error('repository not accessible')
+    );
+    const getToken = vi.spyOn(GitHubTokenService.prototype, 'getToken');
+    const rpc = new GitTokenRPCEntrypoint({} as ExecutionContext, {} as CloudflareEnv);
+
+    await expect(
+      rpc.getTokenForRepo({ githubRepo: 'renamed-owner/repository', userId: 'user-1' })
+    ).rejects.toThrow('repository not accessible');
+    expect(getToken).not.toHaveBeenCalled();
+  });
+});

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -69,7 +69,7 @@ describe('GitTokenRPCEntrypoint', () => {
     });
     const updateAccountLogin = vi
       .spyOn(InstallationLookupService.prototype, 'updateAccountLogin')
-      .mockResolvedValue();
+      .mockResolvedValue(true);
     const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(
       GitHubTokenService.prototype,
@@ -101,6 +101,50 @@ describe('GitTokenRPCEntrypoint', () => {
     expect(getTokenForRepo).toHaveBeenCalledWith('123', 'repository', 'standard');
   });
 
+  it('warns instead of reporting success when a repaired integration no longer exists', async () => {
+    vi.spyOn(InstallationLookupService.prototype, 'findInstallationId').mockResolvedValue({
+      success: false,
+      reason: 'no_installation_found',
+    });
+    vi.spyOn(InstallationLookupService.prototype, 'findRefreshCandidates').mockResolvedValue({
+      success: true,
+      candidates: [
+        {
+          integrationId: 'integration-1',
+          installationId: '123',
+          accountLogin: 'old-owner',
+          githubAppType: 'standard',
+        },
+      ],
+    });
+    vi.spyOn(InstallationLookupService.prototype, 'updateAccountLogin').mockResolvedValue(false);
+    vi.spyOn(
+      GitHubTokenService.prototype,
+      'refreshInstallationAccountLoginIfDue'
+    ).mockResolvedValue('renamed-owner');
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rpc = new GitTokenRPCEntrypoint({} as ExecutionContext, {} as CloudflareEnv);
+
+    const result = await rpc.getTokenForRepo({
+      githubRepo: 'renamed-owner/repository',
+      userId: 'user-1',
+    });
+
+    expect(result).toEqual({ success: false, reason: 'no_installation_found' });
+    expect(consoleLog).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      JSON.stringify({
+        message: 'GitHub installation login repair found no integration row to update',
+        integrationId: 'integration-1',
+        installationId: '123',
+        appType: 'standard',
+      })
+    );
+    expect(JSON.stringify(consoleWarn.mock.calls)).not.toContain('old-owner');
+    expect(JSON.stringify(consoleWarn.mock.calls)).not.toContain('renamed-owner');
+  });
+
   it('does not mint when refreshed metadata identifies a different repository owner', async () => {
     vi.spyOn(InstallationLookupService.prototype, 'findInstallationId').mockResolvedValue({
       success: false,
@@ -119,7 +163,7 @@ describe('GitTokenRPCEntrypoint', () => {
     });
     const updateAccountLogin = vi
       .spyOn(InstallationLookupService.prototype, 'updateAccountLogin')
-      .mockResolvedValue();
+      .mockResolvedValue(true);
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(
       GitHubTokenService.prototype,

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -70,6 +70,7 @@ describe('GitTokenRPCEntrypoint', () => {
     const updateAccountLogin = vi
       .spyOn(InstallationLookupService.prototype, 'updateAccountLogin')
       .mockResolvedValue();
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(
       GitHubTokenService.prototype,
       'refreshInstallationAccountLoginIfDue'
@@ -86,6 +87,16 @@ describe('GitTokenRPCEntrypoint', () => {
 
     expect(result).toMatchObject({ success: true, token: 'scoped-token' });
     expect(updateAccountLogin).toHaveBeenCalledWith('integration-1', 'renamed-owner');
+    expect(consoleLog).toHaveBeenCalledWith(
+      JSON.stringify({
+        message: 'Repaired GitHub installation account login after token lookup miss',
+        integrationId: 'integration-1',
+        installationId: '123',
+        appType: 'standard',
+      })
+    );
+    expect(JSON.stringify(consoleLog.mock.calls)).not.toContain('old-owner');
+    expect(JSON.stringify(consoleLog.mock.calls)).not.toContain('renamed-owner');
     expect(findInstallationId).toHaveBeenCalledTimes(2);
     expect(getTokenForRepo).toHaveBeenCalledWith('123', 'repository', 'standard');
   });
@@ -109,6 +120,7 @@ describe('GitTokenRPCEntrypoint', () => {
     const updateAccountLogin = vi
       .spyOn(InstallationLookupService.prototype, 'updateAccountLogin')
       .mockResolvedValue();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(
       GitHubTokenService.prototype,
       'refreshInstallationAccountLoginIfDue'

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -67,27 +67,68 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     this.gitlabTokenService = new GitLabTokenService(env);
   }
 
+  private async refreshGitHubInstallationLogins(params: GetTokenForRepoParams): Promise<void> {
+    const candidates = await this.installationLookupService.findRefreshCandidates(params);
+    if (!candidates.success) {
+      return;
+    }
+
+    for (const candidate of candidates.candidates) {
+      const refreshedAccountLogin = await this.githubService.refreshInstallationAccountLoginIfDue(
+        candidate.installationId,
+        candidate.githubAppType
+      );
+      if (
+        !refreshedAccountLogin ||
+        refreshedAccountLogin.toLowerCase() === candidate.accountLogin?.toLowerCase()
+      ) {
+        continue;
+      }
+
+      await this.installationLookupService.updateAccountLogin(
+        candidate.integrationId,
+        refreshedAccountLogin
+      );
+    }
+  }
+
   /**
    * Get a GitHub token for a repository.
    *
    * This is the main entry point - it handles the full flow:
    * 1. Looks up the GitHub App installation for this repo/user
    * 2. Validates the user has access (via org membership if applicable)
-   * 3. Generates an installation access token
+   * 3. Generates an installation access token restricted to this repository
    *
    * @param params - The repo and user context
    * @returns Token and installation details, or a failure reason
    */
   async getTokenForRepo(params: GetTokenForRepoParams): Promise<GetTokenForRepoResult> {
-    // 1. Look up installation
-    const installation = await this.installationLookupService.findInstallationId(params);
+    let installation = await this.installationLookupService.findInstallationId(params);
+    if (!installation.success && installation.reason === 'no_installation_found') {
+      await this.refreshGitHubInstallationLogins(params);
+      installation = await this.installationLookupService.findInstallationId(params);
+    }
     if (!installation.success) {
-      return installation;
+      switch (installation.reason) {
+        case 'ambiguous_installation':
+          return { success: false, reason: 'no_installation_found' };
+        case 'database_not_configured':
+        case 'invalid_repo_format':
+        case 'no_installation_found':
+        case 'invalid_org_id':
+          return { success: false, reason: installation.reason };
+      }
     }
 
-    // 2. Generate token for the installation (not scoped to specific repo)
-    const token = await this.githubService.getToken(
+    const [, repoName] = params.githubRepo.split('/');
+    if (!repoName) {
+      return { success: false, reason: 'invalid_repo_format' };
+    }
+
+    const token = await this.githubService.getTokenForRepo(
       installation.installationId,
+      repoName,
       installation.githubAppType
     );
 

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -89,6 +89,14 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
         candidate.integrationId,
         refreshedAccountLogin
       );
+      console.log(
+        JSON.stringify({
+          message: 'Repaired GitHub installation account login after token lookup miss',
+          integrationId: candidate.integrationId,
+          installationId: candidate.installationId,
+          appType: candidate.githubAppType,
+        })
+      );
     }
   }
 

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -85,10 +85,22 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
         continue;
       }
 
-      await this.installationLookupService.updateAccountLogin(
+      const wasUpdated = await this.installationLookupService.updateAccountLogin(
         candidate.integrationId,
         refreshedAccountLogin
       );
+      if (!wasUpdated) {
+        console.warn(
+          JSON.stringify({
+            message: 'GitHub installation login repair found no integration row to update',
+            integrationId: candidate.integrationId,
+            installationId: candidate.installationId,
+            appType: candidate.githubAppType,
+          })
+        );
+        continue;
+      }
+
       console.log(
         JSON.stringify({
           message: 'Repaired GitHub installation account login after token lookup miss',

--- a/services/git-token-service/src/installation-lookup-service.behavior.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.behavior.test.ts
@@ -14,7 +14,7 @@ type InstallationRow = {
   owned_by_organization_id: string | null;
 };
 
-function createDb(rows: InstallationRow[]) {
+function createDb(rows: InstallationRow[], updatedRows = [{ id: 'integration-1' }]) {
   const query = {
     from: vi.fn(() => query),
     leftJoin: vi.fn(() => query),
@@ -26,7 +26,8 @@ function createDb(rows: InstallationRow[]) {
   };
   const updateQuery = {
     set: vi.fn(() => updateQuery),
-    where: vi.fn(async () => undefined),
+    where: vi.fn(() => updateQuery),
+    returning: vi.fn(async () => updatedRows),
   };
 
   return {
@@ -104,21 +105,33 @@ describe('InstallationLookupService', () => {
     });
   });
 
-  it('persists refreshed account login metadata', async () => {
+  it('reports when refreshed account login metadata is persisted', async () => {
     const db = createDb([]);
     vi.mocked(getWorkerDb).mockReturnValue(db as never);
     const service = new InstallationLookupService({
       HYPERDRIVE: { connectionString: 'postgres://test' },
-    } as CloudflareEnv) as unknown as {
-      updateAccountLogin(integrationId: string, accountLogin: string): Promise<void>;
-    };
+    } as CloudflareEnv);
 
-    await service.updateAccountLogin('integration-1', 'renamed-owner');
+    const wasUpdated = await service.updateAccountLogin('integration-1', 'renamed-owner');
 
+    expect(wasUpdated).toBe(true);
     expect(db.updateQuery.set).toHaveBeenCalledWith(
       expect.objectContaining({ platform_account_login: 'renamed-owner' })
     );
     expect(db.updateQuery.where).toHaveBeenCalled();
+  });
+
+  it('reports when refreshed account login metadata no longer has a target row', async () => {
+    const db = createDb([], []);
+    vi.mocked(getWorkerDb).mockReturnValue(db as never);
+    const service = new InstallationLookupService({
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+    } as CloudflareEnv);
+
+    const wasUpdated = await service.updateAccountLogin('integration-1', 'renamed-owner');
+
+    expect(wasUpdated).toBe(false);
+    expect(db.updateQuery.returning).toHaveBeenCalled();
   });
 
   it('resolves an exact-login integration using the legacy standard app type', async () => {

--- a/services/git-token-service/src/installation-lookup-service.behavior.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.behavior.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getWorkerDb } from '@kilocode/db/client';
+import { InstallationLookupService } from './installation-lookup-service.js';
+
+vi.mock('@kilocode/db/client', () => ({
+  getWorkerDb: vi.fn(),
+}));
+
+type InstallationRow = {
+  id?: string;
+  platform_installation_id: string;
+  platform_account_login: string | null;
+  github_app_type: 'standard' | 'lite' | null;
+  owned_by_organization_id: string | null;
+};
+
+function createDb(rows: InstallationRow[]) {
+  const query = {
+    from: vi.fn(() => query),
+    leftJoin: vi.fn(() => query),
+    innerJoin: vi.fn(() => query),
+    where: vi.fn(() => query),
+    orderBy: vi.fn(() => query),
+    limit: vi.fn((limit: number) => Promise.resolve(rows.slice(0, limit))),
+    then: vi.fn((resolve: (value: InstallationRow[]) => unknown) => resolve(rows)),
+  };
+  const updateQuery = {
+    set: vi.fn(() => updateQuery),
+    where: vi.fn(async () => undefined),
+  };
+
+  return {
+    select: vi.fn(() => query),
+    update: vi.fn(() => updateQuery),
+    updateQuery,
+  };
+}
+
+function createService(rows: InstallationRow[]) {
+  vi.mocked(getWorkerDb).mockReturnValue(createDb(rows) as never);
+  return new InstallationLookupService({
+    HYPERDRIVE: { connectionString: 'postgres://test' },
+  } as CloudflareEnv);
+}
+
+describe('InstallationLookupService', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('fails closed when multiple active personal installations match the requested owner', async () => {
+    const service = createService([
+      {
+        platform_installation_id: '100',
+        platform_account_login: 'old-owner',
+        github_app_type: 'standard',
+        owned_by_organization_id: null,
+      },
+      {
+        platform_installation_id: '200',
+        platform_account_login: 'other-owner',
+        github_app_type: 'lite',
+        owned_by_organization_id: null,
+      },
+    ]);
+
+    const result = await service.findInstallationId({
+      githubRepo: 'renamed-owner/repository',
+      userId: 'user-1',
+    });
+
+    expect(result).toEqual({ success: false, reason: 'ambiguous_installation' });
+  });
+
+  it('returns stale authorized installations as login refresh candidates', async () => {
+    const service = createService([
+      {
+        id: 'integration-1',
+        platform_installation_id: '100',
+        platform_account_login: 'pre-rename-owner',
+        github_app_type: null,
+        owned_by_organization_id: null,
+      },
+    ]) as unknown as {
+      findRefreshCandidates(params: { githubRepo: string; userId: string }): Promise<unknown>;
+    };
+
+    const result = await service.findRefreshCandidates({
+      githubRepo: 'renamed-owner/repository',
+      userId: 'user-1',
+    });
+
+    expect(result).toEqual({
+      success: true,
+      candidates: [
+        {
+          integrationId: 'integration-1',
+          installationId: '100',
+          accountLogin: 'pre-rename-owner',
+          githubAppType: 'standard',
+        },
+      ],
+    });
+  });
+
+  it('persists refreshed account login metadata', async () => {
+    const db = createDb([]);
+    vi.mocked(getWorkerDb).mockReturnValue(db as never);
+    const service = new InstallationLookupService({
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+    } as CloudflareEnv) as unknown as {
+      updateAccountLogin(integrationId: string, accountLogin: string): Promise<void>;
+    };
+
+    await service.updateAccountLogin('integration-1', 'renamed-owner');
+
+    expect(db.updateQuery.set).toHaveBeenCalledWith(
+      expect.objectContaining({ platform_account_login: 'renamed-owner' })
+    );
+    expect(db.updateQuery.where).toHaveBeenCalled();
+  });
+
+  it('resolves an exact-login integration using the legacy standard app type', async () => {
+    const service = createService([
+      {
+        platform_installation_id: '100',
+        platform_account_login: 'renamed-owner',
+        github_app_type: null,
+        owned_by_organization_id: null,
+      },
+    ]);
+
+    const result = await service.findInstallationId({
+      githubRepo: 'renamed-owner/repository',
+      userId: 'user-1',
+    });
+
+    expect(result).toEqual({
+      success: true,
+      installationId: '100',
+      accountLogin: 'renamed-owner',
+      githubAppType: 'standard',
+    });
+  });
+
+  it('fails closed when organization and personal installations both match the requested owner', async () => {
+    const service = createService([
+      {
+        platform_installation_id: 'org-installation',
+        platform_account_login: 'organization-owner',
+        github_app_type: 'standard',
+        owned_by_organization_id: '00000000-0000-4000-8000-000000000001',
+      },
+      {
+        platform_installation_id: 'personal-installation',
+        platform_account_login: 'personal-owner',
+        github_app_type: 'lite',
+        owned_by_organization_id: null,
+      },
+    ]);
+
+    const result = await service.findInstallationId({
+      githubRepo: 'renamed-owner/repository',
+      userId: 'user-1',
+      orgId: '00000000-0000-4000-8000-000000000001',
+    });
+
+    expect(result).toEqual({ success: false, reason: 'ambiguous_installation' });
+  });
+
+  it('fails closed when multiple active organization installations match the requested owner', async () => {
+    const service = createService([
+      {
+        platform_installation_id: 'org-installation-1',
+        platform_account_login: 'organization-owner',
+        github_app_type: 'standard',
+        owned_by_organization_id: '00000000-0000-4000-8000-000000000001',
+      },
+      {
+        platform_installation_id: 'org-installation-2',
+        platform_account_login: 'organization-owner',
+        github_app_type: 'standard',
+        owned_by_organization_id: '00000000-0000-4000-8000-000000000001',
+      },
+    ]);
+
+    const result = await service.findInstallationId({
+      githubRepo: 'renamed-owner/repository',
+      userId: 'user-1',
+      orgId: '00000000-0000-4000-8000-000000000001',
+    });
+
+    expect(result).toEqual({ success: false, reason: 'ambiguous_installation' });
+  });
+
+  it.each(['owner/repository/extra', 'owner/', '/repository', 'owner//repository', 'owner'])(
+    'rejects invalid repository path %s before querying integrations',
+    async githubRepo => {
+      const service = createService([]);
+
+      const result = await service.findInstallationId({ githubRepo, userId: 'user-1' });
+
+      expect(result).toEqual({ success: false, reason: 'invalid_repo_format' });
+      expect(getWorkerDb).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/services/git-token-service/src/installation-lookup-service.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { getWorkerDb } from '@kilocode/db/client';
+import {
+  buildInstallationLookupQuery,
+  buildInstallationRefreshCandidatesQuery,
+} from './installation-lookup-service.js';
+
+const params = {
+  githubRepo: 'renamed-owner/repository',
+  userId: 'user-1',
+  orgId: '00000000-0000-4000-8000-000000000001',
+};
+
+function buildQuery() {
+  const db = getWorkerDb('postgres://unused:unused@localhost:0/unused');
+  return buildInstallationLookupQuery(db, params).toSQL();
+}
+
+describe('buildInstallationLookupQuery', () => {
+  it('requires the current repository owner to match installation account metadata', () => {
+    const query = buildQuery();
+
+    expect(query.sql).toContain('lower("platform_integrations"."platform_account_login") =');
+    expect(query.params).toContain('renamed-owner');
+  });
+
+  it('retains tenant authorization and fail-closed query guards', () => {
+    const query = buildQuery();
+
+    expect(query.sql).toContain('"platform_integrations"."platform_installation_id" is not null');
+    expect(query.sql).toContain('"kilocode_users"."blocked_reason" is null');
+    expect(query.sql).toContain('"organization_memberships"."kilo_user_id" =');
+    expect(query.sql).toContain('"organization_memberships"."id" is not null');
+    expect(query.sql).toContain('"platform_integrations"."owned_by_organization_id" =');
+    expect(query.sql).toContain('"platform_integrations"."owned_by_user_id" =');
+    expect(query.params.filter(param => param === 'user-1')).toHaveLength(3);
+    expect(query.params).toContain('00000000-0000-4000-8000-000000000001');
+    expect(query.params).toContain(2);
+  });
+
+  it('loads authorized repair candidates without relying on stale account login metadata', () => {
+    const db = getWorkerDb('postgres://unused:unused@localhost:0/unused');
+    const query = buildInstallationRefreshCandidatesQuery(db, params).toSQL();
+
+    expect(query.params).not.toContain('renamed-owner');
+    expect(query.sql).toContain('"kilocode_users"."blocked_reason" is null');
+    expect(query.sql).toContain('"organization_memberships"."id" is not null');
+  });
+});

--- a/services/git-token-service/src/installation-lookup-service.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.test.ts
@@ -38,12 +38,13 @@ describe('buildInstallationLookupQuery', () => {
     expect(query.params).toContain(2);
   });
 
-  it('loads authorized repair candidates without relying on stale account login metadata', () => {
+  it('loads up to ten authorized repair candidates without relying on stale account login metadata', () => {
     const db = getWorkerDb('postgres://unused:unused@localhost:0/unused');
     const query = buildInstallationRefreshCandidatesQuery(db, params).toSQL();
 
     expect(query.params).not.toContain('renamed-owner');
     expect(query.sql).toContain('"kilocode_users"."blocked_reason" is null');
     expect(query.sql).toContain('"organization_memberships"."id" is not null');
+    expect(query.params).toContain(10);
   });
 });

--- a/services/git-token-service/src/installation-lookup-service.ts
+++ b/services/git-token-service/src/installation-lookup-service.ts
@@ -15,8 +15,13 @@ export type FindInstallationParams = {
 
 const InstallationLookupResultSchema = z.object({
   platform_installation_id: z.string(),
-  platform_account_login: z.string(),
+  platform_account_login: z.string().nullable(),
   github_app_type: z.enum(['standard', 'lite']).nullable().optional(),
+  owned_by_organization_id: z.string().nullable(),
+});
+
+const InstallationRefreshCandidateSchema = InstallationLookupResultSchema.extend({
+  id: z.string(),
 });
 
 export type InstallationLookupSuccess = {
@@ -32,10 +37,92 @@ export type InstallationLookupFailure = {
     | 'database_not_configured'
     | 'invalid_repo_format'
     | 'no_installation_found'
+    | 'ambiguous_installation'
     | 'invalid_org_id';
 };
 
 export type InstallationLookupResult = InstallationLookupSuccess | InstallationLookupFailure;
+
+export type InstallationRefreshCandidate = {
+  integrationId: string;
+  installationId: string;
+  accountLogin: string | null;
+  githubAppType: 'standard' | 'lite';
+};
+
+export type InstallationRefreshCandidatesResult =
+  | { success: true; candidates: InstallationRefreshCandidate[] }
+  | InstallationLookupFailure;
+
+function buildAuthorizedInstallationsQuery(
+  db: WorkerDb,
+  params: FindInstallationParams,
+  repoOwner?: string
+) {
+  const accountLoginFilter =
+    repoOwner === undefined
+      ? undefined
+      : sql`lower(${platform_integrations.platform_account_login}) = lower(${repoOwner})`;
+
+  return db
+    .select({
+      id: platform_integrations.id,
+      platform_installation_id: platform_integrations.platform_installation_id,
+      platform_account_login: platform_integrations.platform_account_login,
+      github_app_type: platform_integrations.github_app_type,
+      owned_by_organization_id: platform_integrations.owned_by_organization_id,
+    })
+    .from(platform_integrations)
+    .leftJoin(
+      organization_memberships,
+      and(
+        eq(
+          platform_integrations.owned_by_organization_id,
+          organization_memberships.organization_id
+        ),
+        eq(organization_memberships.kilo_user_id, params.userId)
+      )
+    )
+    .innerJoin(
+      kilocode_users,
+      and(eq(kilocode_users.id, params.userId), isNull(kilocode_users.blocked_reason))
+    )
+    .where(
+      and(
+        eq(platform_integrations.platform, 'github'),
+        eq(platform_integrations.integration_type, 'app'),
+        eq(platform_integrations.integration_status, 'active'),
+        accountLoginFilter,
+        isNotNull(platform_integrations.platform_installation_id),
+        or(
+          and(
+            isNotNull(platform_integrations.owned_by_organization_id),
+            eq(platform_integrations.owned_by_organization_id, sql`${params.orgId ?? null}::uuid`),
+            isNotNull(organization_memberships.id)
+          ),
+          and(
+            isNotNull(platform_integrations.owned_by_user_id),
+            eq(platform_integrations.owned_by_user_id, params.userId)
+          )
+        )
+      )
+    )
+    .orderBy(
+      sql`CASE WHEN ${platform_integrations.owned_by_organization_id} IS NOT NULL THEN 0 ELSE 1 END`
+    );
+}
+
+export function buildInstallationLookupQuery(db: WorkerDb, params: FindInstallationParams) {
+  const [repoOwner = ''] = params.githubRepo.split('/');
+  return buildAuthorizedInstallationsQuery(db, params, repoOwner).limit(2);
+}
+
+export function buildInstallationRefreshCandidatesQuery(
+  db: WorkerDb,
+  params: FindInstallationParams
+) {
+  return buildAuthorizedInstallationsQuery(db, params);
+}
 
 export class InstallationLookupService {
   private db: WorkerDb | null = null;
@@ -56,8 +143,25 @@ export class InstallationLookupService {
     return this.db;
   }
 
+  private validateParams(params: FindInstallationParams): InstallationLookupFailure | null {
+    if (!this.isConfigured()) {
+      return { success: false, reason: 'database_not_configured' };
+    }
+
+    if (params.orgId !== undefined && !z.string().uuid().safeParse(params.orgId).success) {
+      return { success: false, reason: 'invalid_org_id' };
+    }
+
+    const repoParts = params.githubRepo.split('/');
+    if (repoParts.length !== 2 || repoParts.some(part => part.length === 0)) {
+      return { success: false, reason: 'invalid_repo_format' };
+    }
+
+    return null;
+  }
+
   /**
-   * Find a GitHub App installation ID for a given repo owner and user/org context.
+   * Find a GitHub App installation ID for a requested repository and user/org context.
    *
    * SECURITY: When looking up org installations, we JOIN with organization_memberships
    * to verify the user is actually a member of the organization. This prevents users
@@ -66,89 +170,70 @@ export class InstallationLookupService {
    * Prioritizes org installations over user installations.
    */
   async findInstallationId(params: FindInstallationParams): Promise<InstallationLookupResult> {
-    if (!this.isConfigured()) {
-      return { success: false, reason: 'database_not_configured' };
-    }
-
-    // Validate orgId is a valid UUID if provided, to prevent database errors
-    if (params.orgId !== undefined && !z.string().uuid().safeParse(params.orgId).success) {
-      return { success: false, reason: 'invalid_org_id' };
-    }
-
-    // Validate githubRepo format (expected: "owner/repo")
-    if (!params.githubRepo || !params.githubRepo.includes('/')) {
-      return { success: false, reason: 'invalid_repo_format' };
-    }
-
-    const [repoOwner] = params.githubRepo.split('/');
-    if (!repoOwner) {
-      return { success: false, reason: 'invalid_repo_format' };
+    const validationFailure = this.validateParams(params);
+    if (validationFailure) {
+      return validationFailure;
     }
 
     const db = this.getDb();
-
-    const rows = await db
-      .select({
-        platform_installation_id: platform_integrations.platform_installation_id,
-        platform_account_login: platform_integrations.platform_account_login,
-        github_app_type: platform_integrations.github_app_type,
-      })
-      .from(platform_integrations)
-      // For org installations, verify user is a member of the org
-      .leftJoin(
-        organization_memberships,
-        and(
-          eq(
-            platform_integrations.owned_by_organization_id,
-            organization_memberships.organization_id
-          ),
-          eq(organization_memberships.kilo_user_id, params.userId)
-        )
-      )
-      // Verify user is not blocked
-      .innerJoin(
-        kilocode_users,
-        and(eq(kilocode_users.id, params.userId), isNull(kilocode_users.blocked_reason))
-      )
-      .where(
-        and(
-          eq(platform_integrations.platform, 'github'),
-          eq(platform_integrations.integration_type, 'app'),
-          eq(platform_integrations.integration_status, 'active'),
-          eq(platform_integrations.platform_account_login, repoOwner),
-          or(
-            // Org installation: must match org ID AND user must be a member
-            and(
-              isNotNull(platform_integrations.owned_by_organization_id),
-              eq(
-                platform_integrations.owned_by_organization_id,
-                sql`${params.orgId ?? null}::uuid`
-              ),
-              isNotNull(organization_memberships.id)
-            ),
-            // User installation: must match user ID directly
-            and(
-              isNotNull(platform_integrations.owned_by_user_id),
-              eq(platform_integrations.owned_by_user_id, params.userId)
-            )
-          )
-        )
-      )
-      .orderBy(
-        sql`CASE WHEN ${platform_integrations.owned_by_organization_id} IS NOT NULL THEN 0 ELSE 1 END`
-      )
-      .limit(1);
+    const rows = await buildInstallationLookupQuery(db, params);
 
     if (rows.length === 0) {
       return { success: false, reason: 'no_installation_found' };
     }
 
-    const parsed = InstallationLookupResultSchema.parse(rows[0]);
+    const [selected, other] = rows.map(row => InstallationLookupResultSchema.parse(row));
+    if (!selected) {
+      return { success: false, reason: 'no_installation_found' };
+    }
+
+    if (other) {
+      console.warn(
+        JSON.stringify({
+          message: 'Multiple exact GitHub App integrations found during token resolution',
+        })
+      );
+      return { success: false, reason: 'ambiguous_installation' };
+    }
+
     return {
       success: true,
-      installationId: parsed.platform_installation_id,
-      accountLogin: parsed.platform_account_login,
-      githubAppType: parsed.github_app_type ?? 'standard',
+      installationId: selected.platform_installation_id,
+      accountLogin: selected.platform_account_login ?? '',
+      githubAppType: selected.github_app_type ?? 'standard',
     };
+  }
+
+  async findRefreshCandidates(
+    params: FindInstallationParams
+  ): Promise<InstallationRefreshCandidatesResult> {
+    const validationFailure = this.validateParams(params);
+    if (validationFailure) {
+      return validationFailure;
+    }
+
+    const rows = await buildInstallationRefreshCandidatesQuery(this.getDb(), params);
+    return {
+      success: true,
+      candidates: rows.map(row => {
+        const parsed = InstallationRefreshCandidateSchema.parse(row);
+        return {
+          integrationId: parsed.id,
+          installationId: parsed.platform_installation_id,
+          accountLogin: parsed.platform_account_login,
+          githubAppType: parsed.github_app_type ?? 'standard',
+        };
+      }),
+    };
+  }
+
+  async updateAccountLogin(integrationId: string, accountLogin: string): Promise<void> {
+    await this.getDb()
+      .update(platform_integrations)
+      .set({
+        platform_account_login: accountLogin,
+        updated_at: new Date().toISOString(),
+      })
+      .where(eq(platform_integrations.id, integrationId));
   }
 }

--- a/services/git-token-service/src/installation-lookup-service.ts
+++ b/services/git-token-service/src/installation-lookup-service.ts
@@ -231,13 +231,16 @@ export class InstallationLookupService {
     };
   }
 
-  async updateAccountLogin(integrationId: string, accountLogin: string): Promise<void> {
-    await this.getDb()
+  async updateAccountLogin(integrationId: string, accountLogin: string): Promise<boolean> {
+    const updatedRows = await this.getDb()
       .update(platform_integrations)
       .set({
         platform_account_login: accountLogin,
         updated_at: new Date().toISOString(),
       })
-      .where(eq(platform_integrations.id, integrationId));
+      .where(eq(platform_integrations.id, integrationId))
+      .returning({ id: platform_integrations.id });
+
+    return updatedRows.length > 0;
   }
 }

--- a/services/git-token-service/src/installation-lookup-service.ts
+++ b/services/git-token-service/src/installation-lookup-service.ts
@@ -24,6 +24,8 @@ const InstallationRefreshCandidateSchema = InstallationLookupResultSchema.extend
   id: z.string(),
 });
 
+const MAX_INSTALLATION_LOGIN_REFRESH_CANDIDATES = 10;
+
 export type InstallationLookupSuccess = {
   success: true;
   installationId: string;
@@ -121,7 +123,9 @@ export function buildInstallationRefreshCandidatesQuery(
   db: WorkerDb,
   params: FindInstallationParams
 ) {
-  return buildAuthorizedInstallationsQuery(db, params);
+  return buildAuthorizedInstallationsQuery(db, params).limit(
+    MAX_INSTALLATION_LOGIN_REFRESH_CANDIDATES
+  );
 }
 
 export class InstallationLookupService {

--- a/services/git-token-service/vitest.config.ts
+++ b/services/git-token-service/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- Keep GitHub App integrations usable after account renames by synchronizing current installation identity from rename webhooks and manual refreshes.
- Repair stale login metadata during git-token lookup misses with throttling and fail-closed ambiguity handling, then mint repository-scoped tokens.
- Architecturally, the web integration path performs proactive reconciliation while the token service provides defensive repair for existing stale records.

## Verification

- [x] Verified locally

## Visual Changes

N/A

## Reviewer Notes

- Review authorization/ambiguity handling, webhook retry ordering, and the 10-minute repair cooldown.