### PR TITLE
fix(kiloclaw): handle declined Calendar permission and remove admin gate

### DIFF
--- a/apps/web/src/app/(app)/claw/components/CalendarConnectStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/CalendarConnectStep.tsx
@@ -12,7 +12,6 @@ type CalendarConnectStepViewProps = {
   connectUrl: string;
   isConnected: boolean;
   connectedAccountEmail?: string | null;
-  interactionDisabled?: boolean;
   /**
    * Whether it's safe to start the OAuth round trip. Two prerequisites:
    * (1) the kiloclaw instance row exists — `/api/integrations/google/connect`
@@ -52,7 +51,6 @@ export function CalendarConnectStepView({
   connectUrl,
   isConnected,
   connectedAccountEmail,
-  interactionDisabled = false,
   readyToConnect,
   onSkip,
   onContinue,
@@ -126,13 +124,12 @@ export function CalendarConnectStepView({
           <button
             type="button"
             onClick={() => onSkip()}
-            disabled={interactionDisabled}
-            className="text-muted-foreground hover:text-foreground text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+            className="text-muted-foreground hover:text-foreground text-sm font-medium transition-colors"
           >
             Skip for now
           </button>
           {isConnected ? (
-            <Button variant="primary" onClick={() => onContinue()} disabled={interactionDisabled}>
+            <Button variant="primary" onClick={() => onContinue()}>
               Continue
             </Button>
           ) : readyToConnect ? (

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -332,6 +332,7 @@ function ClawOnboardingFlowInner({
     'oauth_error',
     'missing_code',
     'missing_instance',
+    'missing_permissions',
     'connection_failed',
     'invalid_state',
     'unauthorized',
@@ -371,7 +372,11 @@ function ClawOnboardingFlowInner({
       toast.success('Calendar connected');
     } else if (errorParamRaw) {
       posthog?.capture('claw_setup_calendar_oauth_failed', { reason: errorReason });
-      toast.error('Could not connect calendar. Try again or skip for now.');
+      toast.error(
+        errorReason === 'missing_permissions'
+          ? 'Calendar permission was not granted. Allow Calendar access to connect or skip for now.'
+          : 'Could not connect calendar. Try again or skip for now.'
+      );
     }
     cleanupResumeQueryParams();
   }, [searchParams, botIdentity, posthog, cleanupResumeQueryParams]);

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -11,7 +11,6 @@ import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { controllerVersionOk, gatewayStatusOk } from '@/lib/kiloclaw/types';
 import { useKiloClawGatewayStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawGatewayStatus, useOrgKiloClawMutations } from '@/hooks/useOrgKiloClaw';
-import { useUser } from '@/hooks/useUser';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -119,12 +118,9 @@ function ClawOnboardingFlowInner({
   const personalMutations = useKiloClawMutations();
   const orgMutations = useOrgKiloClawMutations(organizationId ?? '');
   const mutations = organizationId ? orgMutations : personalMutations;
-  const { data: currentUser, isPending: userIsPending } = useUser();
   const searchParams = useSearchParams();
-  const isCalendarResume = searchParams?.get('step') === 'calendar';
-  const calendarEligibilityPending = userIsPending && isCalendarResume;
 
-  const hasCalendarStep = currentUser?.is_admin === true || calendarEligibilityPending;
+  const hasCalendarStep = true;
   // Morning briefing is generally available — the Interests step shows for
   // all users (it still gates on controller version below).
   // Gate on controller version. The plugin route that backs
@@ -527,10 +523,7 @@ function ClawOnboardingFlowInner({
         connectUrl={connectUrl}
         isConnected={isConnected}
         connectedAccountEmail={connectedEmail}
-        interactionDisabled={calendarEligibilityPending}
-        readyToConnect={
-          !calendarEligibilityPending && flowState.instanceStatus !== null && onboardingSaves.ready
-        }
+        readyToConnect={flowState.instanceStatus !== null && onboardingSaves.ready}
         onConnectClick={() => {
           posthog?.capture('claw_setup_calendar_connect_clicked', { skipped: false });
         }}

--- a/apps/web/src/app/api/integrations/google/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/google/callback/route.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, test } from '@jest/globals';
 import { NextRequest, NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user/server';
 import { getInstanceById } from '@/lib/kiloclaw/instance-registry';
-import { exchangeGoogleOAuthCode } from '@/lib/integrations/google-service';
+import {
+  exchangeGoogleOAuthCode,
+  GoogleOAuthCapabilityScopesNotGrantedError,
+} from '@/lib/integrations/google-service';
 import { upsertKiloClawGoogleOAuthConnection } from '@/lib/kiloclaw/google-oauth-connections';
 import { verifyGoogleOAuthState } from '@/lib/integrations/google/oauth-state';
 import { captureException, captureMessage } from '@sentry/nextjs';
@@ -150,6 +153,29 @@ describe('GET /api/integrations/google/callback', () => {
 
     expect(response.status).toBe(307);
     expectRedirectLocation(response, '/claw/new?step=calendar&error=access_denied');
+  });
+
+  test('redirects missing Calendar permission back to onboarding without capturing an exception', async () => {
+    mockedVerifyGoogleOAuthState.mockReturnValue({
+      owner: { type: 'user', id: USER_ID },
+      userId: USER_ID,
+      instanceId: INSTANCE_ID,
+      capabilities: ['calendar_read'],
+      returnTo: '/claw/new?step=calendar',
+    });
+    mockedExchangeGoogleOAuthCode.mockRejectedValue(
+      new GoogleOAuthCapabilityScopesNotGrantedError()
+    );
+
+    const { GET } = await import('./route');
+    const response = await GET(
+      makeRequest('/api/integrations/google/callback?code=abc&state=signed') as never
+    );
+
+    expect(response.status).toBe(307);
+    expectRedirectLocation(response, '/claw/new?step=calendar&error=missing_permissions');
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+    expect(mockedUpsertKiloClawGoogleOAuthConnection).not.toHaveBeenCalled();
   });
 
   test('redirects personal success flow to personal claw settings', async () => {

--- a/apps/web/src/app/api/integrations/google/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/google/callback/route.test.ts
@@ -16,6 +16,15 @@ const mockedEnsureOrganizationAccess = jest.fn();
 jest.mock('@/routers/organizations/utils', () => ({
   ensureOrganizationAccess: mockedEnsureOrganizationAccess,
 }));
+const mockedRequireKiloClawAccess = jest.fn();
+jest.mock('@/lib/kiloclaw/access-gate', () => ({
+  requireKiloClawAccess: mockedRequireKiloClawAccess,
+}));
+const mockedRequireOrganizationKiloClawComputeEntitlement = jest.fn();
+jest.mock('@/lib/organizations/trial-middleware', () => ({
+  requireOrganizationKiloClawComputeEntitlement:
+    mockedRequireOrganizationKiloClawComputeEntitlement,
+}));
 jest.mock('@/lib/kiloclaw/instance-registry');
 jest.mock('@/lib/integrations/google-service');
 jest.mock('@/lib/kiloclaw/google-oauth-connections');
@@ -186,6 +195,8 @@ describe('GET /api/integrations/google/callback', () => {
 
     expect(response.status).toBe(307);
     expectRedirectLocation(response, '/claw/settings?success=google_connected');
+    expect(mockedRequireKiloClawAccess).toHaveBeenCalledWith(USER_ID);
+    expect(mockedRequireOrganizationKiloClawComputeEntitlement).not.toHaveBeenCalled();
     expect(mockedExchangeGoogleOAuthCode).toHaveBeenCalledWith('abc', ['calendar_read']);
     expect(mockedUpsertKiloClawGoogleOAuthConnection).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -202,6 +213,21 @@ describe('GET /api/integrations/google/callback', () => {
       }),
       INSTANCE_ID
     );
+  });
+
+  test('does not persist personal OAuth callback after KiloClaw access expires', async () => {
+    mockedRequireKiloClawAccess.mockRejectedValue(new Error('access denied'));
+
+    const { GET } = await import('./route');
+    const response = await GET(
+      makeRequest('/api/integrations/google/callback?code=abc&state=signed') as never
+    );
+
+    expect(response.status).toBe(307);
+    expectRedirectLocation(response, '/claw/settings?error=connection_failed');
+    expect(mockedExchangeGoogleOAuthCode).not.toHaveBeenCalled();
+    expect(mockedUpsertKiloClawGoogleOAuthConnection).not.toHaveBeenCalled();
+    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error), expect.any(Object));
   });
 
   test('redirects org success flow to org claw settings', async () => {
@@ -229,6 +255,8 @@ describe('GET /api/integrations/google/callback', () => {
       `/organizations/${ORG_ID}/claw/settings?success=google_connected`
     );
     expect(mockedEnsureOrganizationAccess).toHaveBeenCalledWith({ user: { id: USER_ID } }, ORG_ID);
+    expect(mockedRequireOrganizationKiloClawComputeEntitlement).toHaveBeenCalledWith(ORG_ID);
+    expect(mockedRequireKiloClawAccess).not.toHaveBeenCalled();
   });
 
   test('allows different org admin than instance creator to complete callback', async () => {

--- a/apps/web/src/app/api/integrations/google/callback/route.ts
+++ b/apps/web/src/app/api/integrations/google/callback/route.ts
@@ -6,7 +6,10 @@ import { APP_URL } from '@/lib/constants';
 import { getUserFromAuth } from '@/lib/user/server';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { getInstanceById } from '@/lib/kiloclaw/instance-registry';
-import { exchangeGoogleOAuthCode } from '@/lib/integrations/google-service';
+import {
+  exchangeGoogleOAuthCode,
+  GoogleOAuthCapabilityScopesNotGrantedError,
+} from '@/lib/integrations/google-service';
 import {
   type VerifiedGoogleOAuthState,
   verifyGoogleOAuthState,
@@ -204,7 +207,17 @@ export async function GET(request: NextRequest) {
       return NextResponse.redirect(new URL('/claw/settings?error=unauthorized', APP_URL));
     }
 
-    const oauthData = await exchangeGoogleOAuthCode(oauthCode, verifiedState.capabilities);
+    let oauthData;
+    try {
+      oauthData = await exchangeGoogleOAuthCode(oauthCode, verifiedState.capabilities);
+    } catch (error) {
+      if (error instanceof GoogleOAuthCapabilityScopesNotGrantedError) {
+        return NextResponse.redirect(
+          new URL(buildGoogleRedirectPath(verifiedState, 'error=missing_permissions'), APP_URL)
+        );
+      }
+      throw error;
+    }
 
     const persisted = await upsertKiloClawGoogleOAuthConnection({
       instanceId: verifiedState.instanceId,

--- a/apps/web/src/app/api/integrations/google/callback/route.ts
+++ b/apps/web/src/app/api/integrations/google/callback/route.ts
@@ -5,6 +5,8 @@ import { captureException, captureMessage } from '@sentry/nextjs';
 import { APP_URL } from '@/lib/constants';
 import { getUserFromAuth } from '@/lib/user/server';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+import { requireKiloClawAccess } from '@/lib/kiloclaw/access-gate';
+import { requireOrganizationKiloClawComputeEntitlement } from '@/lib/organizations/trial-middleware';
 import { getInstanceById } from '@/lib/kiloclaw/instance-registry';
 import {
   exchangeGoogleOAuthCode,
@@ -205,6 +207,12 @@ export async function GET(request: NextRequest) {
       });
 
       return NextResponse.redirect(new URL('/claw/settings?error=unauthorized', APP_URL));
+    }
+
+    if (verifiedState.owner.type === 'org') {
+      await requireOrganizationKiloClawComputeEntitlement(verifiedState.owner.id);
+    } else {
+      await requireKiloClawAccess(user.id);
     }
 
     let oauthData;

--- a/apps/web/src/app/api/integrations/google/connect/route.test.ts
+++ b/apps/web/src/app/api/integrations/google/connect/route.test.ts
@@ -13,6 +13,10 @@ const mockedEnsureOrganizationAccess = jest.fn();
 jest.mock('@/routers/organizations/utils', () => ({
   ensureOrganizationAccess: mockedEnsureOrganizationAccess,
 }));
+const mockedRequireKiloClawAccess = jest.fn();
+jest.mock('@/lib/kiloclaw/access-gate', () => ({
+  requireKiloClawAccess: mockedRequireKiloClawAccess,
+}));
 const mockedRequireOrganizationKiloClawComputeEntitlement = jest.fn();
 jest.mock('@/lib/organizations/trial-middleware', () => ({
   requireOrganizationKiloClawComputeEntitlement:
@@ -96,9 +100,10 @@ describe('GET /api/integrations/google/connect', () => {
     expect(response.headers.get('location')).toBe(
       'https://accounts.google.com/o/oauth2/v2/auth?x=1'
     );
+    expect(mockedRequireKiloClawAccess).toHaveBeenCalledWith(USER_ID);
     expect(mockedGetActiveInstance).toHaveBeenCalledWith(USER_ID);
     expect(mockedGetActiveOrgInstance).not.toHaveBeenCalled();
-    expect(mockedGetUserFromAuth).toHaveBeenCalledWith({ adminOnly: true });
+    expect(mockedGetUserFromAuth).toHaveBeenCalledWith({ adminOnly: false });
     expect(mockedCreateGoogleOAuthState).toHaveBeenCalledWith(
       {
         owner: { type: 'user', id: USER_ID },
@@ -107,6 +112,19 @@ describe('GET /api/integrations/google/connect', () => {
       },
       USER_ID
     );
+  });
+
+  test('does not initiate personal OAuth without active KiloClaw access', async () => {
+    mockedRequireKiloClawAccess.mockRejectedValue(new Error('access denied'));
+
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest('/api/integrations/google/connect') as never);
+
+    expect(response.status).toBe(307);
+    expectRedirectLocation(response, '/claw/settings?error=oauth_init_failed');
+    expect(mockedGetActiveInstance).not.toHaveBeenCalled();
+    expect(mockedBuildGoogleOAuthUrl).not.toHaveBeenCalled();
+    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error), expect.any(Object));
   });
 
   test('redirects entitled org flow to Google OAuth URL', async () => {
@@ -121,6 +139,7 @@ describe('GET /api/integrations/google/connect', () => {
     );
     expect(mockedEnsureOrganizationAccess).toHaveBeenCalledWith({ user: { id: USER_ID } }, ORG_ID);
     expect(mockedRequireOrganizationKiloClawComputeEntitlement).toHaveBeenCalledWith(ORG_ID);
+    expect(mockedRequireKiloClawAccess).not.toHaveBeenCalled();
     expect(mockedGetActiveOrgInstance).toHaveBeenCalledWith(USER_ID, ORG_ID);
     expect(mockedCreateGoogleOAuthState).toHaveBeenCalledWith(
       {

--- a/apps/web/src/app/api/integrations/google/connect/route.ts
+++ b/apps/web/src/app/api/integrations/google/connect/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { getUserFromAuth } from '@/lib/user/server';
 import { APP_URL } from '@/lib/constants';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+import { requireKiloClawAccess } from '@/lib/kiloclaw/access-gate';
 import { requireOrganizationKiloClawComputeEntitlement } from '@/lib/organizations/trial-middleware';
 import { getActiveInstance, getActiveOrgInstance } from '@/lib/kiloclaw/instance-registry';
 import { buildGoogleOAuthUrl } from '@/lib/integrations/google-service';
@@ -38,7 +39,7 @@ export async function GET(request: NextRequest) {
   let organizationId: string | undefined;
 
   try {
-    const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+    const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
     if (authFailedResponse) {
       return NextResponse.redirect(new URL('/users/sign_in', APP_URL));
     }
@@ -54,6 +55,8 @@ export async function GET(request: NextRequest) {
       organizationId = parsedOrgId.data;
       await ensureOrganizationAccess({ user }, organizationId);
       await requireOrganizationKiloClawComputeEntitlement(organizationId);
+    } else {
+      await requireKiloClawAccess(user.id);
     }
 
     const owner: Owner = organizationId

--- a/apps/web/src/app/api/integrations/google/disconnect/route.test.ts
+++ b/apps/web/src/app/api/integrations/google/disconnect/route.test.ts
@@ -96,7 +96,7 @@ describe('POST /api/integrations/google/disconnect', () => {
 
     expect(response.status).toBe(303);
     expectRedirectLocation(response, '/claw/settings?success=google_disconnected');
-    expect(mockedGetUserFromAuth).toHaveBeenCalledWith({ adminOnly: true });
+    expect(mockedGetUserFromAuth).toHaveBeenCalledWith({ adminOnly: false });
     expect(mockedGetActiveInstance).toHaveBeenCalledWith(USER_ID);
     expect(mockedGetKiloClawGoogleOAuthConnection).toHaveBeenCalledWith(INSTANCE_ID);
     expect(mockedClearKiloClawGoogleOAuthConnection).toHaveBeenCalledWith(INSTANCE_ID);

--- a/apps/web/src/app/api/integrations/google/disconnect/route.ts
+++ b/apps/web/src/app/api/integrations/google/disconnect/route.ts
@@ -41,7 +41,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.redirect(new URL('/claw/settings?error=invalid_origin', APP_URL), 303);
     }
 
-    const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+    // Disconnect revokes stored OAuth credentials, so authenticated owners can perform it after billing access expires.
+    const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
     if (authFailedResponse) {
       return NextResponse.redirect(new URL('/users/sign_in', APP_URL), 303);
     }

--- a/apps/web/src/lib/integrations/google-service.scopes.test.ts
+++ b/apps/web/src/lib/integrations/google-service.scopes.test.ts
@@ -1,0 +1,64 @@
+process.env.NEXTAUTH_SECRET ||= 'test-nextauth-secret';
+process.env.TURNSTILE_SECRET_KEY ||= 'test-turnstile-secret';
+
+import { beforeEach, describe, expect, test, jest } from '@jest/globals';
+import { GOOGLE_CAPABILITY } from '@/lib/integrations/google/capabilities';
+
+const mockedGetToken =
+  jest.fn<() => Promise<{ tokens: { access_token: string; scope: string } }>>();
+
+jest.mock('google-auth-library', () => ({
+  OAuth2Client: jest.fn().mockImplementation(() => ({
+    getToken: mockedGetToken,
+  })),
+}));
+
+describe('Google OAuth granted scope validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.PORT = '3000';
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_ID = 'test-google-workspace-client-id';
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = 'test-google-workspace-client-secret';
+    process.env.GOOGLE_WORKSPACE_OAUTH_REDIRECT_URI =
+      'http://localhost:3000/api/integrations/google/callback';
+  });
+
+  test('classifies a refused Calendar capability as an expected permission outcome', async () => {
+    mockedGetToken.mockResolvedValue({
+      tokens: {
+        access_token: 'access-token',
+        scope: 'openid https://www.googleapis.com/auth/userinfo.email',
+      },
+    });
+
+    const { exchangeGoogleOAuthCode, GoogleOAuthCapabilityScopesNotGrantedError } =
+      await import('@/lib/integrations/google-service');
+
+    await expect(
+      exchangeGoogleOAuthCode('code', [GOOGLE_CAPABILITY.CALENDAR_READ])
+    ).rejects.toBeInstanceOf(GoogleOAuthCapabilityScopesNotGrantedError);
+  });
+
+  test('keeps missing required identity scopes as an unexpected failure', async () => {
+    mockedGetToken.mockResolvedValue({
+      tokens: {
+        access_token: 'access-token',
+        scope: 'https://www.googleapis.com/auth/calendar.readonly',
+      },
+    });
+
+    const { exchangeGoogleOAuthCode, GoogleOAuthCapabilityScopesNotGrantedError } =
+      await import('@/lib/integrations/google-service');
+
+    let error: unknown;
+    try {
+      await exchangeGoogleOAuthCode('code', [GOOGLE_CAPABILITY.CALENDAR_READ]);
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(GoogleOAuthCapabilityScopesNotGrantedError);
+    expect((error as Error).message).toBe('Required Google identity scopes were not granted');
+  });
+});

--- a/apps/web/src/lib/integrations/google-service.ts
+++ b/apps/web/src/lib/integrations/google-service.ts
@@ -9,6 +9,7 @@ import {
 import { APP_URL } from '@/lib/constants';
 import type { GoogleCapability } from '@/lib/integrations/google/capabilities';
 import {
+  GOOGLE_IDENTITY_SCOPES,
   hasRequiredScopesForCapabilities,
   parseGoogleScopeString,
   resolveGoogleScopesForCapabilities,
@@ -31,6 +32,13 @@ type GoogleOAuthExchangeResult = {
   googleEmail: string;
   expiresAt: string | null;
 };
+
+export class GoogleOAuthCapabilityScopesNotGrantedError extends Error {
+  constructor() {
+    super('Required Google capability scopes were not granted');
+    this.name = 'GoogleOAuthCapabilityScopesNotGrantedError';
+  }
+}
 
 export function resolveGoogleOAuthRedirectURI(): string {
   if (!GOOGLE_WORKSPACE_OAUTH_REDIRECT_URI) {
@@ -109,8 +117,13 @@ export async function exchangeGoogleOAuthCode(
       ? grantedScopesFromToken
       : resolveGoogleScopesForCapabilities(requestedCapabilities);
 
+  const grantedScopeSet = new Set(grantedScopes);
+  if (!GOOGLE_IDENTITY_SCOPES.every(scope => grantedScopeSet.has(scope))) {
+    throw new Error('Required Google identity scopes were not granted');
+  }
+
   if (!hasRequiredScopesForCapabilities(grantedScopes, requestedCapabilities)) {
-    throw new Error('Required Google scopes were not granted');
+    throw new GoogleOAuthCapabilityScopesNotGrantedError();
   }
 
   const userInfo = await fetchGoogleUserInfo(tokens.access_token);


### PR DESCRIPTION
## Summary

- Treat a user declining the requested Google Calendar capability during OAuth as an expected outcome instead of an unexpected callback exception.
- Redirect declined Calendar grants back to onboarding as `missing_permissions`, where the UI explains how to connect or skip for now.
- Remove the temporary admin-only Calendar onboarding gate so authenticated users with active KiloClaw access can connect Google Calendar; organization flows retain compute-entitlement enforcement.
- Revalidate entitlement during OAuth callback completion before storing credentials, while keeping disconnect available to authenticated owners for credential revocation after billing access ends.
- Preserve observability for unexpected OAuth failures, including missing mandatory Google identity scopes, by only classifying refused capability scopes as recoverable.

## Verification



## Visual Changes

| Before | After |
|---|---|
| Declining Calendar permission returned to onboarding with a generic connection failure message. | Declining Calendar permission shows: `Calendar permission was not granted. Allow Calendar access to connect or skip for now.` |
| The Calendar OAuth onboarding step was temporarily limited to Kilo admins. | The Calendar OAuth onboarding step is available to eligible authenticated KiloClaw users. |

## Reviewer Notes

- The expected permission-denial path is intentionally narrow: identity-scope failures and infrastructure failures continue through exception capture.
- Connect and callback require current personal/org entitlement; disconnect intentionally requires authentication and ownership checks only because it revokes stored credentials.
- Focus review on scope classification, callback revalidation, organization entitlement enforcement, and the credential-revocation authorization boundary.