### PR TITLE
feat(gastown+web): slingExistingPr + BeadPanel babysit badge (chunks 0+4)

### DIFF
--- a/apps/web/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
+++ b/apps/web/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
@@ -19,13 +19,24 @@ import {
 } from '@/components/ui/alert-dialog';
 import Link from 'next/link';
 import { formatDistanceToNow, format } from 'date-fns';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Eye } from 'lucide-react';
 
 const STATUS_COLORS: Record<string, string> = {
   open: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
   in_progress: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
   closed: 'bg-green-500/10 text-green-400 border-green-500/20',
   failed: 'bg-red-500/10 text-red-400 border-red-500/20',
+};
+
+const EVENT_LABELS: Record<string, string> = {
+  babysit_started: 'Babysit Started',
+  pr_feedback_detected: 'PR Feedback',
+  pr_conflict_detected: 'PR Conflict',
+  pr_auto_merge: 'Auto-merge',
+  pr_status_changed: 'PR Status',
+  pr_created: 'PR Created',
+  pr_creation_failed: 'PR Creation Failed',
+  rework_requested: 'Rework Requested',
 };
 
 type ConfirmActionType = 'close' | 'fail' | 'reset_agent';
@@ -247,10 +258,36 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
                     </dt>
                     <dd className="mt-1 flex flex-wrap gap-1">
                       {bead.labels.map(label => (
-                        <Badge key={label} variant="outline" className="font-mono text-xs">
+                        <Badge
+                          key={label}
+                          variant="outline"
+                          className={`font-mono text-xs ${label === 'gt:babysit' ? 'border-sky-500/30 bg-sky-500/10 text-sky-400' : ''}`}
+                        >
+                          {label === 'gt:babysit' && <Eye className="mr-1 size-3" />}
                           {label}
                         </Badge>
                       ))}
+                    </dd>
+                  </div>
+                )}
+                {bead.labels.includes('gt:babysit') &&
+                  typeof bead.metadata?.head_sha === 'string' && (
+                    <div>
+                      <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                        Head SHA
+                      </dt>
+                      <dd className="font-mono text-xs">
+                        {(bead.metadata.head_sha as string).slice(0, 12)}…
+                      </dd>
+                    </div>
+                  )}
+                {bead.labels.includes('gt:babysit') && (
+                  <div>
+                    <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                      Force-push
+                    </dt>
+                    <dd className="text-xs">
+                      {bead.metadata?.force_push_allowed === true ? 'Allowed' : 'Blocked'}
                     </dd>
                   </div>
                 )}
@@ -353,7 +390,7 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
                     <div className="pb-4">
                       <div className="flex flex-wrap items-center gap-2">
                         <span className="rounded bg-gray-500/10 px-1.5 py-0.5 font-mono text-xs">
-                          {event.event_type}
+                          {EVENT_LABELS[event.event_type] ?? event.event_type}
                         </span>
                         {event.agent_id && (
                           <Link
@@ -431,7 +468,7 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
                       </td>
                       <td className="py-2 pr-4">
                         <span className="rounded bg-gray-500/10 px-1.5 py-0.5 font-mono text-xs">
-                          {event.event_type}
+                          {EVENT_LABELS[event.event_type] ?? event.event_type}
                         </span>
                       </td>
                       <td

--- a/apps/web/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
+++ b/apps/web/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
@@ -276,9 +276,7 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
                       <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                         Head SHA
                       </dt>
-                      <dd className="font-mono text-xs">
-                        {(bead.metadata.head_sha as string).slice(0, 12)}…
-                      </dd>
+                      <dd className="font-mono text-xs">{bead.metadata.head_sha.slice(0, 12)}…</dd>
                     </div>
                   )}
                 {bead.labels.includes('gt:babysit') && (

--- a/apps/web/src/components/gastown/ActivityFeed.tsx
+++ b/apps/web/src/components/gastown/ActivityFeed.tsx
@@ -20,7 +20,6 @@ import {
   MessageCircle,
   GitMergeIcon,
   RefreshCw,
-  Zap,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 

--- a/apps/web/src/components/gastown/ActivityFeed.tsx
+++ b/apps/web/src/components/gastown/ActivityFeed.tsx
@@ -16,6 +16,11 @@ import {
   MessageSquare,
   ChevronRight,
   ShieldCheck,
+  Eye,
+  MessageCircle,
+  GitMergeIcon,
+  RefreshCw,
+  Zap,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 
@@ -31,6 +36,11 @@ const EVENT_ICONS: Record<string, typeof Activity> = {
   mail_sent: Mail,
   agent_status: MessageSquare,
   triage_resolved: ShieldCheck,
+  babysit_started: Eye,
+  pr_feedback_detected: MessageCircle,
+  pr_conflict_detected: AlertTriangle,
+  pr_auto_merge: GitMergeIcon,
+  pr_status_changed: RefreshCw,
 };
 
 const EVENT_COLORS: Record<string, string> = {
@@ -45,6 +55,11 @@ const EVENT_COLORS: Record<string, string> = {
   mail_sent: 'text-sky-500',
   agent_status: 'text-white/50',
   triage_resolved: 'text-amber-500',
+  babysit_started: 'text-sky-500',
+  pr_feedback_detected: 'text-amber-500',
+  pr_conflict_detected: 'text-red-500',
+  pr_auto_merge: 'text-emerald-500',
+  pr_status_changed: 'text-purple-500',
 };
 
 type TownEvent = GastownOutputs['gastown']['getTownEvents'][number];
@@ -103,6 +118,25 @@ function eventDescription(event: {
       // never populated for bead_events rows).
       const prefix = rigName ? `[${rigName}] ` : rigPrefix;
       return agentName ? `${prefix}${agentName}: ${body}` : `${prefix}${body}`;
+    }
+    case 'babysit_started': {
+      const prUrl = event.metadata?.pr_url as string | undefined;
+      const branch = event.metadata?.branch as string | undefined;
+      const desc = `${rigPrefix}Babysit started`;
+      const parts: string[] = [];
+      if (branch) parts.push(branch);
+      if (prUrl) parts.push(prUrl);
+      return parts.length > 0 ? `${desc}: ${parts.join(' → ')}` : desc;
+    }
+    case 'pr_feedback_detected':
+      return `${rigPrefix}PR feedback detected: ${event.new_value ?? 'review comments'}`;
+    case 'pr_conflict_detected':
+      return `${rigPrefix}PR merge conflict detected`;
+    case 'pr_auto_merge':
+      return `${rigPrefix}PR auto-merge triggered`;
+    case 'pr_status_changed': {
+      const newState = event.metadata?.state as string | undefined;
+      return `${rigPrefix}PR status changed: ${newState ?? event.new_value ?? 'unknown'}`;
     }
     default:
       return `${rigPrefix}${event.event_type}`;

--- a/apps/web/src/components/gastown/ActivityFeed.tsx
+++ b/apps/web/src/components/gastown/ActivityFeed.tsx
@@ -65,7 +65,7 @@ const EVENT_COLORS: Record<string, string> = {
 type TownEvent = GastownOutputs['gastown']['getTownEvents'][number];
 type BeadEvent = GastownOutputs['gastown']['getBeadEvents'][number];
 
-function eventDescription(event: {
+export function eventDescription(event: {
   event_type: string;
   old_value: string | null;
   new_value: string | null;

--- a/apps/web/src/components/gastown/ActivityFeed.tsx
+++ b/apps/web/src/components/gastown/ActivityFeed.tsx
@@ -22,6 +22,8 @@ import {
   RefreshCw,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
+export { eventDescription } from './event-description';
+import { eventDescription } from './event-description';
 
 const EVENT_ICONS: Record<string, typeof Activity> = {
   created: PlayCircle,
@@ -63,84 +65,6 @@ const EVENT_COLORS: Record<string, string> = {
 
 type TownEvent = GastownOutputs['gastown']['getTownEvents'][number];
 type BeadEvent = GastownOutputs['gastown']['getBeadEvents'][number];
-
-export function eventDescription(event: {
-  event_type: string;
-  old_value: string | null;
-  new_value: string | null;
-  metadata: Record<string, unknown>;
-  rig_name?: string;
-}): string {
-  const rigPrefix = event.rig_name ? `[${event.rig_name}] ` : '';
-  switch (event.event_type) {
-    case 'created': {
-      const title = event.metadata?.title;
-      return `${rigPrefix}Bead created: ${typeof title === 'string' ? title : (event.new_value ?? 'unknown')}`;
-    }
-    case 'hooked':
-      return `${rigPrefix}Agent hooked to bead`;
-    case 'unhooked':
-      return `${rigPrefix}Agent unhooked from bead`;
-    case 'status_changed': {
-      const desc = `${rigPrefix}Status: ${event.old_value ?? '?'} → ${event.new_value ?? '?'}`;
-      if (event.new_value === 'failed') {
-        const fr = event.metadata?.failure_reason;
-        if (typeof fr === 'object' && fr !== null && 'message' in fr) {
-          const msg = (fr as Record<string, unknown>).message;
-          if (typeof msg === 'string') return `${desc} — ${msg}`;
-        }
-      }
-      return desc;
-    }
-    case 'closed':
-      return `${rigPrefix}Bead closed`;
-    case 'escalated':
-      return `${rigPrefix}Escalation created`;
-    case 'review_submitted':
-      return `${rigPrefix}Submitted for review: ${event.new_value ?? ''}`;
-    case 'review_completed':
-      return `${rigPrefix}Review ${event.new_value ?? 'completed'}`;
-    case 'mail_sent':
-      return `${rigPrefix}Mail sent`;
-    case 'triage_resolved': {
-      const action = event.new_value ?? (event.metadata?.action as string | undefined) ?? 'unknown';
-      const notes = event.metadata?.resolution_notes as string | undefined;
-      const desc = `${rigPrefix}Triage: ${action}`;
-      return notes ? `${desc} — ${notes}` : desc;
-    }
-    case 'agent_status': {
-      const msg = event.new_value ?? (event.metadata?.message as string | undefined);
-      const agentName = event.metadata?.agent_name as string | undefined;
-      const rigName = event.metadata?.rig_name as string | undefined;
-      const body = msg ?? 'Agent status update';
-      // Prefer metadata rig_name over the top-level rig_name (which is
-      // never populated for bead_events rows).
-      const prefix = rigName ? `[${rigName}] ` : rigPrefix;
-      return agentName ? `${prefix}${agentName}: ${body}` : `${prefix}${body}`;
-    }
-    case 'babysit_started': {
-      const prUrl = event.metadata?.pr_url as string | undefined;
-      const branch = event.metadata?.branch as string | undefined;
-      const desc = `${rigPrefix}Babysit started`;
-      const parts: string[] = [];
-      if (branch) parts.push(branch);
-      if (prUrl) parts.push(prUrl);
-      return parts.length > 0 ? `${desc}: ${parts.join(' → ')}` : desc;
-    }
-    case 'pr_feedback_detected':
-      return `${rigPrefix}PR feedback detected: ${event.new_value ?? 'review comments'}`;
-    case 'pr_conflict_detected':
-      return `${rigPrefix}PR merge conflict detected`;
-    case 'pr_auto_merge':
-      return `${rigPrefix}PR auto-merge triggered`;
-    case 'pr_status_changed': {
-      const newState = event.metadata?.state as string | undefined;
-      return `${rigPrefix}PR status changed: ${newState ?? event.new_value ?? 'unknown'}`;
-    }
-    default:
-      return `${rigPrefix}${event.event_type}`;
-  }
-}
 
 function toEventDescriptionInput(event: TownEvent | BeadEvent) {
   return {

--- a/apps/web/src/components/gastown/babysit-ui.test.ts
+++ b/apps/web/src/components/gastown/babysit-ui.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { eventDescription } from '@/components/gastown/ActivityFeed';
+import { eventDescription } from '@/components/gastown/event-description';
 
 describe('eventDescription — babysit event types', () => {
   it('formats babysit_started with branch and pr_url', () => {

--- a/apps/web/src/components/gastown/babysit-ui.test.ts
+++ b/apps/web/src/components/gastown/babysit-ui.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from '@jest/globals';
+import { eventDescription } from '@/components/gastown/ActivityFeed';
+
+describe('eventDescription — babysit event types', () => {
+  it('formats babysit_started with branch and pr_url', () => {
+    const desc = eventDescription({
+      event_type: 'babysit_started',
+      old_value: null,
+      new_value: 'https://github.com/Org/repo/pull/42',
+      metadata: {
+        branch: 'feature/x',
+        pr_url: 'https://github.com/Org/repo/pull/42',
+      },
+    });
+    expect(desc).toContain('Babysit started');
+    expect(desc).toContain('feature/x');
+    expect(desc).toContain('https://github.com/Org/repo/pull/42');
+  });
+
+  it('formats babysit_started without branch or pr_url', () => {
+    const desc = eventDescription({
+      event_type: 'babysit_started',
+      old_value: null,
+      new_value: null,
+      metadata: {},
+    });
+    expect(desc).toContain('Babysit started');
+  });
+
+  it('formats pr_feedback_detected', () => {
+    const desc = eventDescription({
+      event_type: 'pr_feedback_detected',
+      old_value: null,
+      new_value: 'CI failure',
+      metadata: {},
+    });
+    expect(desc).toContain('PR feedback detected');
+    expect(desc).toContain('CI failure');
+  });
+
+  it('formats pr_conflict_detected', () => {
+    const desc = eventDescription({
+      event_type: 'pr_conflict_detected',
+      old_value: null,
+      new_value: null,
+      metadata: {},
+    });
+    expect(desc).toContain('PR merge conflict detected');
+  });
+
+  it('formats pr_auto_merge', () => {
+    const desc = eventDescription({
+      event_type: 'pr_auto_merge',
+      old_value: null,
+      new_value: null,
+      metadata: {},
+    });
+    expect(desc).toContain('PR auto-merge triggered');
+  });
+
+  it('formats pr_status_changed with state from metadata', () => {
+    const desc = eventDescription({
+      event_type: 'pr_status_changed',
+      old_value: null,
+      new_value: null,
+      metadata: { state: 'merged' },
+    });
+    expect(desc).toContain('PR status changed');
+    expect(desc).toContain('merged');
+  });
+
+  it('formats pr_status_changed falling back to new_value', () => {
+    const desc = eventDescription({
+      event_type: 'pr_status_changed',
+      old_value: null,
+      new_value: 'closed',
+      metadata: {},
+    });
+    expect(desc).toContain('PR status changed');
+    expect(desc).toContain('closed');
+  });
+
+  it('includes rig prefix when rig_name is present', () => {
+    const desc = eventDescription({
+      event_type: 'babysit_started',
+      old_value: null,
+      new_value: null,
+      metadata: {},
+      rig_name: 'my-rig',
+    });
+    expect(desc).toContain('[my-rig]');
+    expect(desc).toContain('Babysit started');
+  });
+});

--- a/apps/web/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/apps/web/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -475,7 +475,7 @@ export function BeadPanel({
           />
 
           {isBabysit && typeof bead.metadata?.head_sha === 'string' && (
-            <MetaCell icon={Hash} label="Head SHA" value={bead.metadata.head_sha as string} mono />
+            <MetaCell icon={Hash} label="Head SHA" value={bead.metadata.head_sha} mono />
           )}
           {isBabysit && (
             <MetaCell

--- a/apps/web/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/apps/web/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -37,6 +37,9 @@ import {
   Loader2,
   Play,
   MessageCircle,
+  Lock,
+  Unlock,
+  Eye,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -249,6 +252,7 @@ export function BeadPanel({
 
   // Held bead detection
   const isHeld = bead.labels.includes('gt:held');
+  const isBabysit = bead.labels.includes('gt:babysit');
 
   // Mayor responses: message-type child beads
   const mayorResponses = allBeads.filter(
@@ -335,6 +339,12 @@ export function BeadPanel({
               <Flag className="size-2.5" />
               {bead.priority}
             </span>
+            {isBabysit && (
+              <span className="inline-flex items-center gap-1 rounded-md border border-sky-500/30 bg-sky-500/10 px-2 py-0.5 text-[10px] font-medium text-sky-300">
+                <Eye className="size-2.5" />
+                Babysat external PR
+              </span>
+            )}
             {isHeld && (
               <Button
                 size="sm"
@@ -463,6 +473,17 @@ export function BeadPanel({
             label="Labels"
             value={bead.labels.length ? bead.labels.join(', ') : 'None'}
           />
+
+          {isBabysit && typeof bead.metadata?.head_sha === 'string' && (
+            <MetaCell icon={Hash} label="Head SHA" value={bead.metadata.head_sha as string} mono />
+          )}
+          {isBabysit && (
+            <MetaCell
+              icon={bead.metadata?.force_push_allowed === true ? Unlock : Lock}
+              label="Force-push"
+              value={bead.metadata?.force_push_allowed === true ? 'Allowed' : 'Blocked'}
+            />
+          )}
 
           {/* Parent bead — clickable */}
           {bead.parent_bead_id && (

--- a/apps/web/src/components/gastown/event-description.ts
+++ b/apps/web/src/components/gastown/event-description.ts
@@ -1,0 +1,75 @@
+export function eventDescription(event: {
+  event_type: string;
+  old_value: string | null;
+  new_value: string | null;
+  metadata: Record<string, unknown>;
+  rig_name?: string;
+}): string {
+  const rigPrefix = event.rig_name ? `[${event.rig_name}] ` : '';
+  switch (event.event_type) {
+    case 'created': {
+      const title = event.metadata?.title;
+      return `${rigPrefix}Bead created: ${typeof title === 'string' ? title : (event.new_value ?? 'unknown')}`;
+    }
+    case 'hooked':
+      return `${rigPrefix}Agent hooked to bead`;
+    case 'unhooked':
+      return `${rigPrefix}Agent unhooked from bead`;
+    case 'status_changed': {
+      const desc = `${rigPrefix}Status: ${event.old_value ?? '?'} → ${event.new_value ?? '?'}`;
+      if (event.new_value === 'failed') {
+        const fr = event.metadata?.failure_reason;
+        if (typeof fr === 'object' && fr !== null && 'message' in fr) {
+          const msg = (fr as Record<string, unknown>).message;
+          if (typeof msg === 'string') return `${desc} — ${msg}`;
+        }
+      }
+      return desc;
+    }
+    case 'closed':
+      return `${rigPrefix}Bead closed`;
+    case 'escalated':
+      return `${rigPrefix}Escalation created`;
+    case 'review_submitted':
+      return `${rigPrefix}Submitted for review: ${event.new_value ?? ''}`;
+    case 'review_completed':
+      return `${rigPrefix}Review ${event.new_value ?? 'completed'}`;
+    case 'mail_sent':
+      return `${rigPrefix}Mail sent`;
+    case 'triage_resolved': {
+      const action = event.new_value ?? (event.metadata?.action as string | undefined) ?? 'unknown';
+      const notes = event.metadata?.resolution_notes as string | undefined;
+      const desc = `${rigPrefix}Triage: ${action}`;
+      return notes ? `${desc} — ${notes}` : desc;
+    }
+    case 'agent_status': {
+      const msg = event.new_value ?? (event.metadata?.message as string | undefined);
+      const agentName = event.metadata?.agent_name as string | undefined;
+      const rigName = event.metadata?.rig_name as string | undefined;
+      const body = msg ?? 'Agent status update';
+      const prefix = rigName ? `[${rigName}] ` : rigPrefix;
+      return agentName ? `${prefix}${agentName}: ${body}` : `${prefix}${body}`;
+    }
+    case 'babysit_started': {
+      const prUrl = event.metadata?.pr_url as string | undefined;
+      const branch = event.metadata?.branch as string | undefined;
+      const desc = `${rigPrefix}Babysit started`;
+      const parts: string[] = [];
+      if (branch) parts.push(branch);
+      if (prUrl) parts.push(prUrl);
+      return parts.length > 0 ? `${desc}: ${parts.join(' → ')}` : desc;
+    }
+    case 'pr_feedback_detected':
+      return `${rigPrefix}PR feedback detected: ${event.new_value ?? 'review comments'}`;
+    case 'pr_conflict_detected':
+      return `${rigPrefix}PR merge conflict detected`;
+    case 'pr_auto_merge':
+      return `${rigPrefix}PR auto-merge triggered`;
+    case 'pr_status_changed': {
+      const newState = event.metadata?.state as string | undefined;
+      return `${rigPrefix}PR status changed: ${newState ?? event.new_value ?? 'unknown'}`;
+    }
+    default:
+      return `${rigPrefix}${event.event_type}`;
+  }
+}

--- a/services/gastown/src/db/tables/bead-events.table.ts
+++ b/services/gastown/src/db/tables/bead-events.table.ts
@@ -24,6 +24,7 @@ export const BeadEventType = z.enum([
   'escalation_rate_spike',
   'agent_restart_loop',
   'rework_requested',
+  'babysit_started',
 ]);
 
 export type BeadEventType = z.infer<typeof BeadEventType>;

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -67,6 +67,7 @@ import { generateKiloApiToken } from '../util/kilo-token.util';
 import { resolveSecret } from '../util/secret.util';
 import { writeEvent, type GastownEventData } from '../util/analytics.util';
 import { logger, withLogTags } from '../util/log.util';
+import { parseGitUrl, parsePrUrlForRepoMatch } from '../util/platform-pr.util';
 import { BeadPriority } from '../types';
 import type {
   TownConfig,
@@ -2523,6 +2524,90 @@ export class TownDO extends DurableObject<Env> {
     );
     await this.escalateToActiveCadence();
     return { bead, agent: hookedAgent };
+  }
+
+  async slingExistingPr(args: {
+    rigId: string;
+    prUrl: string;
+    title?: string;
+    body?: string;
+    forcePushAllowed?: boolean;
+    sourceAgentId?: string;
+  }): Promise<{ beadId: string; warning?: string }> {
+    const rig = rigs.getRig(this.sql, args.rigId);
+    if (!rig) {
+      throw new Error(`Rig ${args.rigId} not found`);
+    }
+
+    const rigCoords = parseGitUrl(rig.git_url);
+    if (!rigCoords) {
+      throw new Error(`Cannot parse rig git_url: ${rig.git_url}`);
+    }
+    const prCoords = parsePrUrlForRepoMatch(args.prUrl);
+    if (!prCoords) {
+      throw new Error(`Cannot parse PR URL: ${args.prUrl}`);
+    }
+    if (
+      rigCoords.platform !== prCoords.platform ||
+      rigCoords.owner !== prCoords.owner ||
+      rigCoords.repo !== prCoords.repo
+    ) {
+      throw new Error(
+        'PR URL repo does not match rig repo. Cannot adopt PRs from other repositories.'
+      );
+    }
+
+    const scmCtx = {
+      env: this.env,
+      townId: this.townId,
+      getTownConfig: () => this.getTownConfig(),
+    };
+    const outcome = await scm.checkPRStatus(scmCtx, args.prUrl);
+    if (!outcome.ok) {
+      const err = outcome.error;
+      throw new Error(
+        `Failed to fetch PR status: ${err.kind}${err.kind === 'http_error' ? ` (HTTP ${err.status})` : ''}${err.kind === 'no_token' ? ` — tried: ${err.resolutionChain.join(', ')}` : ''}`
+      );
+    }
+
+    const { result } = outcome;
+    if (result.status === 'merged' || result.status === 'closed') {
+      throw new Error(`Cannot babysit a PR that is already ${result.status}.`);
+    }
+
+    const headBranch = result.head_branch ?? '';
+    const baseBranch = result.base_branch ?? '';
+    const headSha = result.head_sha ?? '';
+    const prTitle = result.title ?? '';
+
+    const resolvedTitle = args.title ?? `Babysit: ${prTitle}`;
+    const resolvedBody =
+      args.body ??
+      `Adopted external PR ${args.prUrl} at SHA ${headSha}. Town will poll and address review feedback, conflicts, and auto-merge.`;
+    const forcePushAllowed = args.forcePushAllowed ?? false;
+    const sourceAgentId = args.sourceAgentId ?? 'mayor';
+
+    const { beadId } = reviewQueue.submitExternalPrToReviewQueue(this.sql, {
+      rigId: args.rigId,
+      prUrl: args.prUrl,
+      branch: headBranch,
+      targetBranch: baseBranch,
+      headSha,
+      title: resolvedTitle,
+      body: resolvedBody,
+      forcePushAllowed,
+      sourceAgentId,
+    });
+
+    await this.escalateToActiveCadence();
+
+    const townConfig = await this.getTownConfig();
+    const codeReview = townConfig.refinery?.code_review;
+    const warning = codeReview
+      ? 'This rig has code_review enabled. Babysat PRs bypass refinery review (wired in chunk 1).'
+      : undefined;
+
+    return { beadId, warning };
   }
 
   /**

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -2575,9 +2575,14 @@ export class TownDO extends DurableObject<Env> {
       throw new Error(`Cannot babysit a PR that is already ${result.status}.`);
     }
 
-    const headBranch = result.head_branch ?? '';
-    const baseBranch = result.base_branch ?? '';
-    const headSha = result.head_sha ?? '';
+    const headBranch = result.head_branch;
+    const baseBranch = result.base_branch;
+    const headSha = result.head_sha;
+    if (!headBranch || !baseBranch || !headSha) {
+      throw new Error(
+        `PR metadata missing required fields: head_branch=${headBranch ?? '(absent)'}, base_branch=${baseBranch ?? '(absent)'}, head_sha=${headSha ?? '(absent)'}. Cannot babysit.`
+      );
+    }
     const prTitle = result.title ?? '';
 
     const resolvedTitle = args.title ?? `Babysit: ${prTitle}`;

--- a/services/gastown/src/dos/town/review-queue.ts
+++ b/services/gastown/src/dos/town/review-queue.ts
@@ -107,41 +107,23 @@ function toReviewQueueEntry(row: MergeRequestBeadRecord): ReviewQueueEntry {
   };
 }
 
-export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): void {
+function createMergeRequestBeadCore(
+  sql: SqlStorage,
+  args: {
+    rigId: string;
+    title: string;
+    body: string | null;
+    metadata: Record<string, unknown>;
+    labels: string[];
+    branch: string;
+    targetBranch: string;
+    prUrl?: string;
+    createdBy: string | null;
+  }
+): { beadId: string } {
   const id = generateId();
   const timestamp = now();
 
-  // Build metadata — include pr_url if the agent already created a PR so
-  // the link is visible via the standard bead list endpoint.
-  const metadata: Record<string, unknown> = {
-    source_bead_id: input.bead_id,
-    source_agent_id: input.agent_id,
-  };
-  if (input.pr_url) {
-    metadata.pr_url = input.pr_url;
-  }
-
-  // Resolve the target branch for this MR:
-  // - For review-then-land convoy beads → convoy's feature branch
-  // - For review-and-merge convoy beads → rig's default branch (land independently)
-  // - For standalone beads → rig's default branch
-  // We pass defaultBranch from the caller so we don't hardcode 'main'.
-  const convoyId = getConvoyForBead(sql, input.bead_id);
-  const convoyFeatureBranch = convoyId ? getConvoyFeatureBranch(sql, convoyId) : null;
-  const convoyMergeMode = convoyId ? getConvoyMergeMode(sql, convoyId) : null;
-  const targetBranch =
-    convoyMergeMode === 'review-then-land' && convoyFeatureBranch
-      ? convoyFeatureBranch
-      : (input.default_branch ?? 'main');
-
-  if (convoyId) {
-    metadata.convoy_id = convoyId;
-    if (convoyFeatureBranch) {
-      metadata.convoy_feature_branch = convoyFeatureBranch;
-    }
-  }
-
-  // Create the merge_request bead
   query(
     sql,
     /* sql */ `
@@ -158,35 +140,21 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
       id,
       'merge_request',
       'open',
-      `Review: ${input.branch}`,
-      input.summary ?? null,
-      input.rig_id,
+      args.title,
+      args.body,
+      args.rigId,
       null,
-      null, // assignee left null — refinery claims it via hookBead
+      null,
       'medium',
-      JSON.stringify(['gt:merge-request']),
-      JSON.stringify(metadata),
-      input.agent_id, // created_by records who submitted
+      JSON.stringify(args.labels),
+      JSON.stringify(args.metadata),
+      args.createdBy,
       timestamp,
       timestamp,
       null,
     ]
   );
 
-  // Link MR bead → source bead via bead_dependencies so the DAG is queryable
-  query(
-    sql,
-    /* sql */ `
-      INSERT INTO ${bead_dependencies} (
-        ${bead_dependencies.columns.bead_id},
-        ${bead_dependencies.columns.depends_on_bead_id},
-        ${bead_dependencies.columns.dependency_type}
-      ) VALUES (?, ?, 'tracks')
-    `,
-    [id, input.bead_id]
-  );
-
-  // Create the review_metadata satellite
   query(
     sql,
     /* sql */ `
@@ -196,7 +164,58 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
         ${review_metadata.columns.pr_url}, ${review_metadata.columns.retry_count}
       ) VALUES (?, ?, ?, ?, ?, ?)
     `,
-    [id, input.branch, targetBranch, null, input.pr_url ?? null, 0]
+    [id, args.branch, args.targetBranch, null, args.prUrl ?? null, 0]
+  );
+
+  return { beadId: id };
+}
+
+export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): void {
+  const metadata: Record<string, unknown> = {
+    source_bead_id: input.bead_id,
+    source_agent_id: input.agent_id,
+  };
+  if (input.pr_url) {
+    metadata.pr_url = input.pr_url;
+  }
+
+  const convoyId = getConvoyForBead(sql, input.bead_id);
+  const convoyFeatureBranch = convoyId ? getConvoyFeatureBranch(sql, convoyId) : null;
+  const convoyMergeMode = convoyId ? getConvoyMergeMode(sql, convoyId) : null;
+  const targetBranch =
+    convoyMergeMode === 'review-then-land' && convoyFeatureBranch
+      ? convoyFeatureBranch
+      : (input.default_branch ?? 'main');
+
+  if (convoyId) {
+    metadata.convoy_id = convoyId;
+    if (convoyFeatureBranch) {
+      metadata.convoy_feature_branch = convoyFeatureBranch;
+    }
+  }
+
+  const { beadId } = createMergeRequestBeadCore(sql, {
+    rigId: input.rig_id,
+    title: `Review: ${input.branch}`,
+    body: input.summary ?? null,
+    metadata,
+    labels: ['gt:merge-request'],
+    branch: input.branch,
+    targetBranch,
+    prUrl: input.pr_url,
+    createdBy: input.agent_id,
+  });
+
+  query(
+    sql,
+    /* sql */ `
+      INSERT INTO ${bead_dependencies} (
+        ${bead_dependencies.columns.bead_id},
+        ${bead_dependencies.columns.depends_on_bead_id},
+        ${bead_dependencies.columns.dependency_type}
+      ) VALUES (?, ?, 'tracks')
+    `,
+    [beadId, input.bead_id]
   );
 
   logBeadEvent(sql, {
@@ -206,6 +225,55 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
     newValue: input.branch,
     metadata: { branch: input.branch, target_branch: targetBranch },
   });
+}
+
+export function submitExternalPrToReviewQueue(
+  sql: SqlStorage,
+  args: {
+    rigId: string;
+    prUrl: string;
+    branch: string;
+    targetBranch: string;
+    headSha: string;
+    title: string;
+    body?: string;
+    forcePushAllowed: boolean;
+    sourceAgentId: string;
+  }
+): { beadId: string } {
+  const metadata: Record<string, unknown> = {
+    source_agent_id: args.sourceAgentId,
+    babysit: true,
+    head_sha: args.headSha,
+    force_push_allowed: args.forcePushAllowed,
+  };
+
+  const { beadId } = createMergeRequestBeadCore(sql, {
+    rigId: args.rigId,
+    title: args.title,
+    body: args.body ?? null,
+    metadata,
+    labels: ['gt:merge-request', 'gt:babysit'],
+    branch: args.branch,
+    targetBranch: args.targetBranch,
+    prUrl: args.prUrl,
+    createdBy: args.sourceAgentId,
+  });
+
+  logBeadEvent(sql, {
+    beadId,
+    agentId: args.sourceAgentId,
+    eventType: 'babysit_started',
+    newValue: args.prUrl,
+    metadata: {
+      branch: args.branch,
+      target_branch: args.targetBranch,
+      head_sha: args.headSha,
+      pr_url: args.prUrl,
+    },
+  });
+
+  return { beadId };
 }
 
 export function completeReview(

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -108,6 +108,10 @@ export async function resolveGitHubTokenString(ctx: SCMContext): Promise<string 
 export type PRStatusResult = {
   status: 'open' | 'merged' | 'closed';
   mergeable_state?: string;
+  head_branch?: string;
+  base_branch?: string;
+  head_sha?: string;
+  title?: string;
 };
 
 export type PRStatusError =
@@ -203,9 +207,39 @@ export async function checkPRStatus(ctx: SCMContext, prUrl: string): Promise<PRS
       };
     }
 
-    if (data.data.merged) return { ok: true, result: { status: 'merged' } };
-    if (data.data.state === 'closed') return { ok: true, result: { status: 'closed' } };
-    return { ok: true, result: { status: 'open', mergeable_state: data.data.mergeable_state } };
+    if (data.data.merged)
+      return {
+        ok: true,
+        result: {
+          status: 'merged',
+          head_branch: data.data.head?.ref,
+          base_branch: data.data.base?.ref,
+          head_sha: data.data.head?.sha,
+          title: data.data.title,
+        },
+      };
+    if (data.data.state === 'closed')
+      return {
+        ok: true,
+        result: {
+          status: 'closed',
+          head_branch: data.data.head?.ref,
+          base_branch: data.data.base?.ref,
+          head_sha: data.data.head?.sha,
+          title: data.data.title,
+        },
+      };
+    return {
+      ok: true,
+      result: {
+        status: 'open',
+        mergeable_state: data.data.mergeable_state,
+        head_branch: data.data.head?.ref,
+        base_branch: data.data.base?.ref,
+        head_sha: data.data.head?.sha,
+        title: data.data.title,
+      },
+    };
   }
 
   // GitLab MR URL format: https://{host}/{path}/-/merge_requests/{iid}
@@ -288,9 +322,38 @@ export async function checkPRStatus(ctx: SCMContext, prUrl: string): Promise<PRS
       };
     }
 
-    if (data.data.state === 'merged') return { ok: true, result: { status: 'merged' } };
-    if (data.data.state === 'closed') return { ok: true, result: { status: 'closed' } };
-    return { ok: true, result: { status: 'open' } };
+    if (data.data.state === 'merged')
+      return {
+        ok: true,
+        result: {
+          status: 'merged',
+          head_branch: data.data.source_branch,
+          base_branch: data.data.target_branch,
+          head_sha: data.data.sha,
+          title: data.data.title,
+        },
+      };
+    if (data.data.state === 'closed')
+      return {
+        ok: true,
+        result: {
+          status: 'closed',
+          head_branch: data.data.source_branch,
+          base_branch: data.data.target_branch,
+          head_sha: data.data.sha,
+          title: data.data.title,
+        },
+      };
+    return {
+      ok: true,
+      result: {
+        status: 'open',
+        head_branch: data.data.source_branch,
+        base_branch: data.data.target_branch,
+        head_sha: data.data.sha,
+        title: data.data.title,
+      },
+    };
   }
 
   console.warn(`${TOWN_LOG} checkPRStatus: unrecognized PR URL format: ${prUrl}`);

--- a/services/gastown/src/util/platform-pr.util.ts
+++ b/services/gastown/src/util/platform-pr.util.ts
@@ -88,12 +88,28 @@ export const GitHubPRStatusSchema = z.object({
   state: z.string(),
   merged: z.boolean().optional(),
   mergeable: z.boolean().nullable().optional(),
-  mergeable_state: z.string().optional(), // 'clean', 'dirty', 'blocked', 'unknown', 'unstable'
+  mergeable_state: z.string().optional(),
+  head: z
+    .object({
+      ref: z.string().optional(),
+      sha: z.string().optional(),
+    })
+    .optional(),
+  base: z
+    .object({
+      ref: z.string().optional(),
+    })
+    .optional(),
+  title: z.string().optional(),
 });
 
 /** Schema for GitLab MR status responses (used by checkPRStatus). */
 export const GitLabMRStatusSchema = z.object({
   state: z.string(),
+  source_branch: z.string().optional(),
+  target_branch: z.string().optional(),
+  sha: z.string().optional(),
+  title: z.string().optional(),
 });
 
 // -- GitHub PR creation --
@@ -270,4 +286,26 @@ export async function createGitLabMR(params: {
   const data: unknown = await response.json();
   const parsed = GitLabMRResponse.parse(data);
   return { mr_url: parsed.web_url, mr_iid: parsed.iid };
+}
+
+export function parsePrUrlForRepoMatch(
+  prUrl: string
+): { platform: 'github' | 'gitlab'; owner: string; repo: string } | null {
+  const ghMatch = prUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/\d+/);
+  if (ghMatch) {
+    return { platform: 'github', owner: ghMatch[1], repo: ghMatch[2] };
+  }
+  const glMatch = prUrl.match(/^https:\/\/([^/]+)\/(.+)\/-\/merge_requests\/\d+/);
+  if (glMatch) {
+    const fullPath = glMatch[2];
+    const lastSlash = fullPath.lastIndexOf('/');
+    if (lastSlash > 0) {
+      return {
+        platform: 'gitlab',
+        owner: fullPath.slice(0, lastSlash),
+        repo: fullPath.slice(lastSlash + 1),
+      };
+    }
+  }
+  return null;
 }

--- a/services/gastown/test/unit/sling-existing-pr.test.ts
+++ b/services/gastown/test/unit/sling-existing-pr.test.ts
@@ -1,20 +1,45 @@
 import { describe, it, expect, vi } from 'vitest';
 import { checkPRStatus, type SCMContext } from '../../src/dos/town/town-scm';
 import { parsePrUrlForRepoMatch, parseGitUrl } from '../../src/util/platform-pr.util';
+import { submitExternalPrToReviewQueue } from '../../src/dos/town/review-queue';
 import type { TownConfig } from '../../src/types';
 
 class MiniSql {
-  exec(_stmt: string): void {}
-  prepare(_stmt: string): {
-    bind(...params: unknown[]): { step(): boolean; getRow(): unknown[]; free(): void };
-  } {
+  private inserts: { table: string; params: unknown[] }[] = [];
+
+  exec(stmt: string, ...params: unknown[]): SqlStoragecursor {
+    this.captureInsert(stmt, params);
     return {
-      bind: (..._params: unknown[]) => ({
-        step: () => false,
-        getRow: () => [],
-        free: () => {},
-      }),
-    };
+      get rows(): unknown[][] { return []; },
+      get columns(): string[] { return []; },
+      cursor: {
+        next(): string | null { return null; },
+        get value(): unknown[] { return []; },
+      },
+    } as unknown as SqlStoragecursor;
+  }
+
+  private captureInsert(stmt: string, params: unknown[]): void {
+    const match = stmt.match(/INSERT\s+INTO\s+(\S+)/i);
+    if (match) {
+      this.inserts.push({ table: match[1], params });
+    }
+  }
+
+  getInserts(): { table: string; params: unknown[] }[] {
+    return this.inserts;
+  }
+
+  findBeadInsert(): { table: string; params: unknown[] } | undefined {
+    return this.inserts.find((i) => /beads$/i.test(i.table));
+  }
+
+  findReviewMetadataInsert(): { table: string; params: unknown[] } | undefined {
+    return this.inserts.find((i) => /review_metadata$/i.test(i.table));
+  }
+
+  findEventInsert(): { table: string; params: unknown[] } | undefined {
+    return this.inserts.find((i) => /bead_events$/i.test(i.table));
   }
 }
 
@@ -269,14 +294,90 @@ describe('slingExistingPr validation logic', () => {
   });
 });
 
-describe('forcePushAllowed default', () => {
-  it('defaults to false when not specified', () => {
-    const forcePushAllowed = undefined ?? false;
-    expect(forcePushAllowed).toBe(false);
+describe('submitExternalPrToReviewQueue force_push_allowed', () => {
+  it('defaults force_push_allowed to false when slingExistingPr omits it', () => {
+    const sql = new MiniSql() as unknown as SqlStorage;
+    const { beadId } = submitExternalPrToReviewQueue(sql, {
+      rigId: 'rig-1',
+      prUrl: 'https://github.com/Org/repo/pull/1',
+      branch: 'feature/x',
+      targetBranch: 'main',
+      headSha: 'abc1234',
+      title: 'Babysit: Test PR',
+      forcePushAllowed: false,
+      sourceAgentId: 'mayor',
+    });
+
+    expect(beadId).toBeTruthy();
+
+    const beadInsert = sql.findBeadInsert();
+    expect(beadInsert).toBeTruthy();
+    const metadata = JSON.parse(beadInsert!.params[10] as string);
+    expect(metadata.force_push_allowed).toBe(false);
+    expect(metadata.babysit).toBe(true);
+    expect(metadata.head_sha).toBe('abc1234');
   });
 
-  it('persists true when explicitly set', () => {
-    const forcePushAllowed = true;
-    expect(forcePushAllowed).toBe(true);
+  it('persists force_push_allowed: true when explicitly set', () => {
+    const sql = new MiniSql() as unknown as SqlStorage;
+    submitExternalPrToReviewQueue(sql, {
+      rigId: 'rig-1',
+      prUrl: 'https://github.com/Org/repo/pull/1',
+      branch: 'feature/x',
+      targetBranch: 'main',
+      headSha: 'def5678',
+      title: 'Babysit: Another PR',
+      forcePushAllowed: true,
+      sourceAgentId: 'system',
+    });
+
+    const beadInsert = sql.findBeadInsert();
+    expect(beadInsert).toBeTruthy();
+    const metadata = JSON.parse(beadInsert!.params[10] as string);
+    expect(metadata.force_push_allowed).toBe(true);
+  });
+
+  it('creates review_metadata row and babysit_started event', () => {
+    const sql = new MiniSql() as unknown as SqlStorage;
+    submitExternalPrToReviewQueue(sql, {
+      rigId: 'rig-1',
+      prUrl: 'https://github.com/Org/repo/pull/1',
+      branch: 'feature/x',
+      targetBranch: 'main',
+      headSha: 'abc1234',
+      title: 'Babysit: Test',
+      forcePushAllowed: false,
+      sourceAgentId: 'mayor',
+    });
+
+    const rmInsert = sql.findReviewMetadataInsert();
+    expect(rmInsert).toBeTruthy();
+    expect(rmInsert!.params[1]).toBe('feature/x');
+    expect(rmInsert!.params[2]).toBe('main');
+    expect(rmInsert!.params[4]).toBe('https://github.com/Org/repo/pull/1');
+
+    const eventInsert = sql.findEventInsert();
+    expect(eventInsert).toBeTruthy();
+    expect(eventInsert!.params[3]).toBe('babysit_started');
+  });
+
+  it('includes gt:babysit label alongside gt:merge-request', () => {
+    const sql = new MiniSql() as unknown as SqlStorage;
+    submitExternalPrToReviewQueue(sql, {
+      rigId: 'rig-1',
+      prUrl: 'https://github.com/Org/repo/pull/1',
+      branch: 'feature/x',
+      targetBranch: 'main',
+      headSha: 'abc1234',
+      title: 'Babysit: Test',
+      forcePushAllowed: false,
+      sourceAgentId: 'mayor',
+    });
+
+    const beadInsert = sql.findBeadInsert();
+    expect(beadInsert).toBeTruthy();
+    const labels = JSON.parse(beadInsert!.params[9] as string);
+    expect(labels).toContain('gt:merge-request');
+    expect(labels).toContain('gt:babysit');
   });
 });

--- a/services/gastown/test/unit/sling-existing-pr.test.ts
+++ b/services/gastown/test/unit/sling-existing-pr.test.ts
@@ -1,13 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { checkPRStatus, type SCMContext, type PRStatusResult } from '../../src/dos/town/town-scm';
+import { describe, it, expect, vi } from 'vitest';
+import { checkPRStatus, type SCMContext } from '../../src/dos/town/town-scm';
 import { parsePrUrlForRepoMatch, parseGitUrl } from '../../src/util/platform-pr.util';
-import { submitExternalPrToReviewQueue } from '../../src/dos/town/review-queue';
-import { initBeadTables } from '../../src/dos/town/beads';
-import { initRigTables } from '../../src/dos/town/rigs';
 import type { TownConfig } from '../../src/types';
 
 class MiniSql {
-  private data: Map<string, unknown[]> = new Map();
   exec(_stmt: string): void {}
   prepare(_stmt: string): {
     bind(...params: unknown[]): { step(): boolean; getRow(): unknown[]; free(): void };

--- a/services/gastown/test/unit/sling-existing-pr.test.ts
+++ b/services/gastown/test/unit/sling-existing-pr.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { checkPRStatus, type SCMContext, type PRStatusResult } from '../../src/dos/town/town-scm';
+import { parsePrUrlForRepoMatch, parseGitUrl } from '../../src/util/platform-pr.util';
+import { submitExternalPrToReviewQueue } from '../../src/dos/town/review-queue';
+import { initBeadTables } from '../../src/dos/town/beads';
+import { initRigTables } from '../../src/dos/town/rigs';
+import type { TownConfig } from '../../src/types';
+
+class MiniSql {
+  private data: Map<string, unknown[]> = new Map();
+  exec(_stmt: string): void {}
+  prepare(_stmt: string): {
+    bind(...params: unknown[]): { step(): boolean; getRow(): unknown[]; free(): void };
+  } {
+    return {
+      bind: (..._params: unknown[]) => ({
+        step: () => false,
+        getRow: () => [],
+        free: () => {},
+      }),
+    };
+  }
+}
+
+function mockSCMContext(overrides: Partial<SCMContext> = {}): SCMContext {
+  return {
+    env: {} as SCMContext['env'],
+    townId: 'test-town',
+    getTownConfig: async () => ({}) as TownConfig,
+    ...overrides,
+  };
+}
+
+function makeSql(): SqlStorage {
+  return new MiniSql() as unknown as SqlStorage;
+}
+
+describe('parsePrUrlForRepoMatch', () => {
+  it('parses GitHub PR URL', () => {
+    const result = parsePrUrlForRepoMatch('https://github.com/Kilo-Org/cloud/pull/42');
+    expect(result).toEqual({ platform: 'github', owner: 'Kilo-Org', repo: 'cloud' });
+  });
+
+  it('parses GitLab MR URL with simple group', () => {
+    const result = parsePrUrlForRepoMatch('https://gitlab.com/group/project/-/merge_requests/7');
+    expect(result).toEqual({ platform: 'gitlab', owner: 'group', repo: 'project' });
+  });
+
+  it('parses GitLab MR URL with subgroup', () => {
+    const result = parsePrUrlForRepoMatch(
+      'https://gitlab.example.com/org/team/project/-/merge_requests/99'
+    );
+    expect(result).toEqual({ platform: 'gitlab', owner: 'org/team', repo: 'project' });
+  });
+
+  it('returns null for unrecognized URLs', () => {
+    expect(parsePrUrlForRepoMatch('https://example.com/pr/1')).toBeNull();
+    expect(parsePrUrlForRepoMatch('not a url')).toBeNull();
+  });
+});
+
+describe('repo mismatch validation', () => {
+  it('detects mismatch between rig git_url and PR URL (different owner)', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    const prCoords = parsePrUrlForRepoMatch('https://github.com/Other-Org/cloud/pull/1');
+    expect(rigCoords).toBeTruthy();
+    expect(prCoords).toBeTruthy();
+    expect(rigCoords!.owner).not.toBe(prCoords!.owner);
+  });
+
+  it('detects mismatch between rig git_url and PR URL (different repo)', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    const prCoords = parsePrUrlForRepoMatch('https://github.com/Kilo-Org/other-repo/pull/1');
+    expect(rigCoords).toBeTruthy();
+    expect(prCoords).toBeTruthy();
+    expect(rigCoords!.repo).not.toBe(prCoords!.repo);
+  });
+
+  it('detects match between rig git_url and PR URL', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    const prCoords = parsePrUrlForRepoMatch('https://github.com/Kilo-Org/cloud/pull/42');
+    expect(rigCoords).toBeTruthy();
+    expect(prCoords).toBeTruthy();
+    expect(rigCoords!.platform).toBe(prCoords!.platform);
+    expect(rigCoords!.owner).toBe(prCoords!.owner);
+    expect(rigCoords!.repo).toBe(prCoords!.repo);
+  });
+
+  it('detects match for GitLab URLs', () => {
+    const rigCoords = parseGitUrl('https://gitlab.com/group/project');
+    const prCoords = parsePrUrlForRepoMatch('https://gitlab.com/group/project/-/merge_requests/7');
+    expect(rigCoords).toBeTruthy();
+    expect(prCoords).toBeTruthy();
+    expect(rigCoords!.platform).toBe(prCoords!.platform);
+    expect(rigCoords!.owner).toBe(prCoords!.owner);
+    expect(rigCoords!.repo).toBe(prCoords!.repo);
+  });
+
+  it('detects cross-platform mismatch (GitHub rig, GitLab PR)', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    const prCoords = parsePrUrlForRepoMatch('https://gitlab.com/Kilo-Org/cloud/-/merge_requests/7');
+    expect(rigCoords).toBeTruthy();
+    expect(prCoords).toBeTruthy();
+    expect(rigCoords!.platform).not.toBe(prCoords!.platform);
+  });
+});
+
+describe('checkPRStatus extended return shape', () => {
+  it('returns head_branch/base_branch/head_sha for GitHub PR', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        state: 'open',
+        merged: false,
+        mergeable_state: 'clean',
+        head: { ref: 'feature-branch', sha: 'abc1234def' },
+        base: { ref: 'main' },
+        title: 'Add new feature',
+      }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
+
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/Kilo-Org/cloud/pull/42');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('open');
+      expect(outcome.result.head_branch).toBe('feature-branch');
+      expect(outcome.result.base_branch).toBe('main');
+      expect(outcome.result.head_sha).toBe('abc1234def');
+      expect(outcome.result.title).toBe('Add new feature');
+    }
+    fetchSpy.mockRestore();
+  });
+
+  it('returns head_branch/base_branch/head_sha for closed GitHub PR', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        state: 'closed',
+        merged: false,
+        head: { ref: 'feature-branch', sha: 'abc123' },
+        base: { ref: 'main' },
+        title: 'Closed PR',
+      }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
+
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/Kilo-Org/cloud/pull/42');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('closed');
+      expect(outcome.result.head_branch).toBe('feature-branch');
+    }
+    fetchSpy.mockRestore();
+  });
+
+  it('returns head_branch/base_branch/head_sha for merged GitHub PR', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        state: 'closed',
+        merged: true,
+        head: { ref: 'feature-branch', sha: 'mergedsha' },
+        base: { ref: 'main' },
+        title: 'Merged PR',
+      }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
+
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/Kilo-Org/cloud/pull/42');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('merged');
+      expect(outcome.result.head_branch).toBe('feature-branch');
+    }
+    fetchSpy.mockRestore();
+  });
+
+  it('returns head_branch/base_branch for GitLab MR', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        state: 'opened',
+        source_branch: 'feature-branch',
+        target_branch: 'main',
+        sha: 'glsha123',
+        title: 'GitLab MR title',
+      }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
+
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({
+          git_auth: { gitlab_token: 'glpat_test', gitlab_instance_url: 'https://gitlab.com' },
+        }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://gitlab.com/group/project/-/merge_requests/7');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('open');
+      expect(outcome.result.head_branch).toBe('feature-branch');
+      expect(outcome.result.base_branch).toBe('main');
+      expect(outcome.result.head_sha).toBe('glsha123');
+      expect(outcome.result.title).toBe('GitLab MR title');
+    }
+    fetchSpy.mockRestore();
+  });
+
+  it('returns ok:false with no_token error when no GitHub token', async () => {
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({}) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/Kilo-Org/cloud/pull/42');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error.kind).toBe('no_token');
+    }
+  });
+
+  it('returns ok:false with http_error on API failure', async () => {
+    const mockResponse = { ok: false, status: 500, statusText: 'Internal Server Error' };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
+
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/Kilo-Org/cloud/pull/42');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error.kind).toBe('http_error');
+      if (outcome.error.kind === 'http_error') {
+        expect(outcome.error.status).toBe(500);
+        expect(outcome.error.transient).toBe(true);
+      }
+    }
+    fetchSpy.mockRestore();
+  });
+});
+
+describe('slingExistingPr validation logic', () => {
+  it('repo mismatch throws with clear message', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    const prCoords = parsePrUrlForRepoMatch('https://github.com/OtherOrg/cloud/pull/1');
+    expect(rigCoords).toBeTruthy();
+    expect(prCoords).toBeTruthy();
+    const mismatch =
+      rigCoords!.platform !== prCoords!.platform ||
+      rigCoords!.owner !== prCoords!.owner ||
+      rigCoords!.repo !== prCoords!.repo;
+    expect(mismatch).toBe(true);
+  });
+
+  it('repo match passes validation', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    const prCoords = parsePrUrlForRepoMatch('https://github.com/Kilo-Org/cloud/pull/42');
+    expect(rigCoords).toBeTruthy();
+    expect(prCoords).toBeTruthy();
+    const match =
+      rigCoords!.platform === prCoords!.platform &&
+      rigCoords!.owner === prCoords!.owner &&
+      rigCoords!.repo === prCoords!.repo;
+    expect(match).toBe(true);
+  });
+});
+
+describe('forcePushAllowed default', () => {
+  it('defaults to false when not specified', () => {
+    const forcePushAllowed = undefined ?? false;
+    expect(forcePushAllowed).toBe(false);
+  });
+
+  it('persists true when explicitly set', () => {
+    const forcePushAllowed = true;
+    expect(forcePushAllowed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

**Chunk 0 — slingExistingPr Town DO method + review-queue refactor:**
- Refactor `submitToReviewQueue` to use private `createMergeRequestBeadCore` helper (public signature unchanged)
- Add `submitExternalPrToReviewQueue` function that creates merge_request bead + review_metadata without `tracks` edge, with `gt:babysit` label and babysit metadata
- Add `slingExistingPr` method to Town.do.ts that validates repo match, checks PR state, fetches branches from SCM, and calls `submitExternalPrToReviewQueue`
- Extend `checkPRStatus` return shape with `head_branch`, `base_branch`, `head_sha`, `title` fields (both GitHub and GitLab paths)
- Add `parsePrUrlForRepoMatch` utility for repo validation
- Add unit tests for parsePrUrlForRepoMatch, repo mismatch validation, checkPRStatus extended return, slingExistingPr validation, and forcePushAllowed defaults

**Chunk 4 — BeadPanel babysit badge + metadata + event formatters:**
- Add "Babysat external PR" badge in BeadPanel header (sky-colored, Eye icon) when `gt:babysit` label is present
- Add `head_sha` and `force_push_allowed` metadata cells in BeadPanel for babysat beads
- Add human-readable event descriptions for `babysit_started`, `pr_feedback_detected`, `pr_conflict_detected`, `pr_auto_merge`, `pr_status_changed` in ActivityFeed
- Add event icons and colors for the new event types in ActivityFeed
- Update BeadInspectorDashboard with colored `gt:babysit` label badge, babysit metadata fields, and human-readable event labels
- Export `eventDescription` from ActivityFeed for testability
- Add unit tests for babysit event descriptions

## Verification

- Chunk 0: `pnpm --filter cloudflare-gastown typecheck && pnpm --filter cloudflare-gastown test`
- Chunk 4: Manual — view a merge_request bead with `gt:babysit` label → badge renders, head_sha and force-push fields visible, activity timeline shows readable descriptions
- Tests: `services/gastown/test/unit/sling-existing-pr.test.ts` and `apps/web/src/components/gastown/babysit-ui.test.ts`

## Visual Changes

- BeadPanel header: new sky-colored "Babysat external PR" badge with Eye icon for babysat beads
- BeadPanel metadata grid: new "Head SHA" (monospace) and "Force-push" (Lock/Unlock icon) cells
- Activity timeline: new icons and readable descriptions for babysit-related events
- BeadInspectorDashboard: colored babysit label badge, head_sha/force-push fields, readable event labels

## Reviewer Notes

- Chunk 0 is the backend foundation; chunk 4 is the UI surface. Both target the same feature branch.
- Source bead section in BeadPanel is already hidden for babysat beads (conditional on `metadata.source_bead_id` which babysit beads don't have).
- The `eventDescription` function was exported from ActivityFeed to enable testing.
- Component-level rendering tests for BeadPanel are not feasible in the current test infrastructure (no React testing library setup).