### PR TITLE
feat(web): BeadPanel babysit badge + metadata (chunk 4)

### DIFF
--- a/apps/web/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
+++ b/apps/web/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import Link from 'next/link';
 import { formatDistanceToNow, format } from 'date-fns';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Eye, Hash, Lock, Unlock } from 'lucide-react';
 
 const STATUS_COLORS: Record<string, string> = {
   open: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
@@ -251,8 +251,59 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
                           {label}
                         </Badge>
                       ))}
+                      {bead.labels.includes('gt:babysit') && (
+                        <Badge
+                          variant="outline"
+                          className="border-cyan-500/30 bg-cyan-500/10 text-xs text-cyan-300"
+                        >
+                          <Eye className="mr-1 size-3" />
+                          Babysat external PR
+                        </Badge>
+                      )}
                     </dd>
                   </div>
+                )}
+                {bead.labels.includes('gt:babysit') && (
+                  <>
+                    {typeof bead.metadata?.head_sha === 'string' && (
+                      <div>
+                        <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                          Head SHA
+                        </dt>
+                        <dd className="font-mono text-xs">{bead.metadata.head_sha.slice(0, 7)}</dd>
+                      </div>
+                    )}
+                    <div>
+                      <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                        Force-push
+                      </dt>
+                      <dd className="flex items-center gap-1 text-xs">
+                        {bead.metadata?.force_push_allowed === true ? (
+                          <>
+                            <Unlock className="size-3 text-amber-400" />
+                            <span className="text-amber-400">Allowed</span>
+                          </>
+                        ) : (
+                          <>
+                            <Lock className="size-3 text-white/50" />
+                            <span className="text-white/50">Blocked</span>
+                          </>
+                        )}
+                      </dd>
+                    </div>
+                    {typeof bead.metadata?.babysit_started_at === 'string' && (
+                      <div>
+                        <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                          Babysit started
+                        </dt>
+                        <dd title={format(new Date(bead.metadata.babysit_started_at), 'PPpp')}>
+                          {formatDistanceToNow(new Date(bead.metadata.babysit_started_at), {
+                            addSuffix: true,
+                          })}
+                        </dd>
+                      </div>
+                    )}
+                  </>
                 )}
                 {bead.title && (
                   <div className="col-span-2 md:col-span-3">

--- a/apps/web/src/components/gastown/ActivityFeed.test.ts
+++ b/apps/web/src/components/gastown/ActivityFeed.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from '@jest/globals';
+import { eventDescription } from './ActivityFeed';
+
+describe('eventDescription', () => {
+  const baseEvent = {
+    old_value: null as string | null,
+    new_value: null as string | null,
+    metadata: {} as Record<string, unknown>,
+    rig_name: undefined as string | undefined,
+  };
+
+  it('formats babysit_started event', () => {
+    expect(eventDescription({ ...baseEvent, event_type: 'babysit_started' })).toBe(
+      'Babysit started for external PR'
+    );
+  });
+
+  it('formats pr_feedback_detected event', () => {
+    expect(eventDescription({ ...baseEvent, event_type: 'pr_feedback_detected' })).toBe(
+      'PR feedback detected'
+    );
+  });
+
+  it('formats pr_feedback_detected event with kind metadata', () => {
+    expect(
+      eventDescription({
+        ...baseEvent,
+        event_type: 'pr_feedback_detected',
+        metadata: { kind: 'ci_failure' },
+      })
+    ).toBe('PR feedback detected: ci_failure');
+  });
+
+  it('formats pr_conflict_detected event', () => {
+    expect(eventDescription({ ...baseEvent, event_type: 'pr_conflict_detected' })).toBe(
+      'PR merge conflict detected'
+    );
+  });
+
+  it('formats pr_auto_merge event', () => {
+    expect(eventDescription({ ...baseEvent, event_type: 'pr_auto_merge' })).toBe(
+      'PR auto-merge initiated'
+    );
+  });
+
+  it('formats pr_status_changed event with old/new values', () => {
+    expect(
+      eventDescription({
+        ...baseEvent,
+        event_type: 'pr_status_changed',
+        old_value: 'open',
+        new_value: 'merged',
+      })
+    ).toBe('PR state: open → merged');
+  });
+
+  it('formats pr_status_changed event with missing values', () => {
+    expect(eventDescription({ ...baseEvent, event_type: 'pr_status_changed' })).toBe(
+      'PR state: ? → ?'
+    );
+  });
+
+  it('formats babysit_started with rig prefix', () => {
+    expect(
+      eventDescription({
+        ...baseEvent,
+        event_type: 'babysit_started',
+        rig_name: 'my-rig',
+      })
+    ).toBe('[my-rig] Babysit started for external PR');
+  });
+
+  it('falls back to raw event_type for unknown events', () => {
+    expect(eventDescription({ ...baseEvent, event_type: 'unknown_event' })).toBe('unknown_event');
+  });
+});

--- a/apps/web/src/components/gastown/ActivityFeed.tsx
+++ b/apps/web/src/components/gastown/ActivityFeed.tsx
@@ -16,6 +16,10 @@ import {
   MessageSquare,
   ChevronRight,
   ShieldCheck,
+  Eye,
+  MessageSquareWarning,
+  Rocket,
+  RefreshCw,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 
@@ -31,6 +35,11 @@ const EVENT_ICONS: Record<string, typeof Activity> = {
   mail_sent: Mail,
   agent_status: MessageSquare,
   triage_resolved: ShieldCheck,
+  babysit_started: Eye,
+  pr_feedback_detected: MessageSquareWarning,
+  pr_conflict_detected: AlertTriangle,
+  pr_auto_merge: Rocket,
+  pr_status_changed: RefreshCw,
 };
 
 const EVENT_COLORS: Record<string, string> = {
@@ -45,12 +54,17 @@ const EVENT_COLORS: Record<string, string> = {
   mail_sent: 'text-sky-500',
   agent_status: 'text-white/50',
   triage_resolved: 'text-amber-500',
+  babysit_started: 'text-cyan-500',
+  pr_feedback_detected: 'text-orange-500',
+  pr_conflict_detected: 'text-red-400',
+  pr_auto_merge: 'text-emerald-500',
+  pr_status_changed: 'text-blue-400',
 };
 
 type TownEvent = GastownOutputs['gastown']['getTownEvents'][number];
 type BeadEvent = GastownOutputs['gastown']['getBeadEvents'][number];
 
-function eventDescription(event: {
+export function eventDescription(event: {
   event_type: string;
   old_value: string | null;
   new_value: string | null;
@@ -99,10 +113,23 @@ function eventDescription(event: {
       const agentName = event.metadata?.agent_name as string | undefined;
       const rigName = event.metadata?.rig_name as string | undefined;
       const body = msg ?? 'Agent status update';
-      // Prefer metadata rig_name over the top-level rig_name (which is
-      // never populated for bead_events rows).
       const prefix = rigName ? `[${rigName}] ` : rigPrefix;
       return agentName ? `${prefix}${agentName}: ${body}` : `${prefix}${body}`;
+    }
+    case 'babysit_started':
+      return `${rigPrefix}Babysit started for external PR`;
+    case 'pr_feedback_detected': {
+      const kind = event.metadata?.kind as string | undefined;
+      return `${rigPrefix}PR feedback detected${kind ? `: ${kind}` : ''}`;
+    }
+    case 'pr_conflict_detected':
+      return `${rigPrefix}PR merge conflict detected`;
+    case 'pr_auto_merge':
+      return `${rigPrefix}PR auto-merge initiated`;
+    case 'pr_status_changed': {
+      const oldState = event.old_value ?? '?';
+      const newState = event.new_value ?? '?';
+      return `${rigPrefix}PR state: ${oldState} → ${newState}`;
     }
     default:
       return `${rigPrefix}${event.event_type}`;

--- a/apps/web/src/components/gastown/drawer-panels/BeadPanel.test.ts
+++ b/apps/web/src/components/gastown/drawer-panels/BeadPanel.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildRelatedBeads, type BeadLike } from './BeadPanel';
+
+const makeBead = (overrides: Partial<BeadLike> & Pick<BeadLike, 'bead_id'>): BeadLike => ({
+  type: 'merge_request',
+  status: 'in_progress',
+  title: 'Test bead',
+  parent_bead_id: null,
+  labels: [],
+  metadata: {},
+  ...overrides,
+});
+
+describe('buildRelatedBeads', () => {
+  it('includes Source Work link for non-babysit merge_request bead with source_bead_id', () => {
+    const sourceBead = makeBead({ bead_id: 'source-1', type: 'issue' });
+    const mrBead = makeBead({
+      bead_id: 'mr-1',
+      type: 'merge_request',
+      metadata: { source_bead_id: 'source-1' },
+    });
+
+    const related = buildRelatedBeads(mrBead, [sourceBead, mrBead], []);
+    const sourceLink = related.find(r => r.relation === 'source');
+    expect(sourceLink).toBeDefined();
+    expect(sourceLink?.label).toBe('Source Work');
+  });
+
+  it('omits Source Work link for babysit bead even if source_bead_id is present', () => {
+    const sourceBead = makeBead({ bead_id: 'source-1', type: 'issue' });
+    const babysitBead = makeBead({
+      bead_id: 'mr-1',
+      type: 'merge_request',
+      labels: ['gt:babysit'],
+      metadata: { source_bead_id: 'source-1' },
+    });
+
+    const related = buildRelatedBeads(babysitBead, [sourceBead, babysitBead], []);
+    const sourceLink = related.find(r => r.relation === 'source');
+    expect(sourceLink).toBeUndefined();
+  });
+
+  it('omits Source Work link for babysit bead with no source_bead_id', () => {
+    const babysitBead = makeBead({
+      bead_id: 'mr-1',
+      type: 'merge_request',
+      labels: ['gt:babysit'],
+      metadata: {},
+    });
+
+    const related = buildRelatedBeads(babysitBead, [babysitBead], []);
+    const sourceLink = related.find(r => r.relation === 'source');
+    expect(sourceLink).toBeUndefined();
+  });
+
+  it('still shows child beads for babysit MR beads', () => {
+    const babysitBead = makeBead({
+      bead_id: 'mr-1',
+      type: 'merge_request',
+      labels: ['gt:babysit'],
+      metadata: {},
+    });
+    const childBead = makeBead({
+      bead_id: 'child-1',
+      type: 'issue',
+      parent_bead_id: 'mr-1',
+    });
+
+    const related = buildRelatedBeads(babysitBead, [babysitBead, childBead], []);
+    const childLink = related.find(r => r.relation === 'child');
+    expect(childLink).toBeDefined();
+  });
+});

--- a/apps/web/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/apps/web/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { useState, useCallback } from 'react';
 import { usePathname } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -16,6 +17,7 @@ import { format, formatDistanceToNow } from 'date-fns';
 import {
   Clock,
   ExternalLink,
+  Eye,
   Flag,
   Hash,
   Tags,
@@ -37,6 +39,8 @@ import {
   Loader2,
   Play,
   MessageCircle,
+  Lock,
+  Unlock,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -250,6 +254,9 @@ export function BeadPanel({
   // Held bead detection
   const isHeld = bead.labels.includes('gt:held');
 
+  // Babysit bead detection
+  const isBabysit = bead.labels.includes('gt:babysit');
+
   // Mayor responses: message-type child beads
   const mayorResponses = allBeads.filter(
     b => b.type === 'message' && b.parent_bead_id === bead.bead_id
@@ -329,6 +336,12 @@ export function BeadPanel({
             <Badge variant="outline" className="text-[10px]">
               {bead.type}
             </Badge>
+            {isBabysit && (
+              <span className="inline-flex items-center gap-1 rounded-md border border-cyan-500/30 bg-cyan-500/10 px-2 py-0.5 text-[10px] font-medium text-cyan-300">
+                <Eye className="size-2.5" />
+                Babysat external PR
+              </span>
+            )}
             <span
               className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${PRIORITY_STYLES[bead.priority] ?? 'text-white/50'}`}
             >
@@ -517,6 +530,46 @@ export function BeadPanel({
         </div>
       )}
 
+      {/* Babysit metadata */}
+      {isBabysit && (
+        <div className="grid grid-cols-2 border-b border-white/[0.06]">
+          {typeof bead.metadata?.head_sha === 'string' && (
+            <MetaCell
+              icon={Hash}
+              label="Head SHA"
+              value={
+                prUrl ? (
+                  <a
+                    href={`${prUrl}/commits/${bead.metadata.head_sha}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-mono text-xs text-[color:oklch(95%_0.15_108)] hover:underline"
+                  >
+                    {bead.metadata.head_sha.slice(0, 7)}
+                  </a>
+                ) : (
+                  <span className="font-mono text-xs">{bead.metadata.head_sha.slice(0, 7)}</span>
+                )
+              }
+            />
+          )}
+          <MetaCell
+            icon={bead.metadata?.force_push_allowed === true ? Unlock : Lock}
+            label="Force-push"
+            value={bead.metadata?.force_push_allowed === true ? 'Allowed' : 'Blocked'}
+          />
+          {typeof bead.metadata?.babysit_started_at === 'string' && (
+            <MetaCell
+              icon={Clock}
+              label="Babysit started"
+              value={formatDistanceToNow(new Date(bead.metadata.babysit_started_at), {
+                addSuffix: true,
+              })}
+            />
+          )}
+        </div>
+      )}
+
       {/* Wasteland origin link — present when this bead was created in
           response to a wasteland event (e.g. a wanted-item claim). */}
       <WastelandOriginLink metadata={bead.metadata} pathname={pathname} />
@@ -668,7 +721,7 @@ function MetaCell({
 }: {
   icon: typeof Clock;
   label: string;
-  value: string;
+  value: ReactNode;
   mono?: boolean;
 }) {
   return (
@@ -686,17 +739,18 @@ function MetaCell({
 
 // ── Related beads DAG ─────────────────────────────────────────────────
 
-type BeadLike = {
+export type BeadLike = {
   bead_id: string;
   type: string;
   status: string;
   title: string;
   parent_bead_id: string | null;
   rig_id?: string | null;
+  labels?: string[];
   metadata: Record<string, unknown>;
 };
 
-type RelatedBead = {
+export type RelatedBead = {
   relation: string;
   label: string;
   icon: typeof Clock;
@@ -715,7 +769,7 @@ type ConvoyLike = {
  * Compute the DAG neighborhood of a bead from the flat list and convoy data.
  * Includes: children, source/review links, blockers, and dependents from convoy DAG.
  */
-function buildRelatedBeads(
+export function buildRelatedBeads(
   bead: BeadLike,
   allBeads: BeadLike[],
   convoys: ConvoyLike[]
@@ -804,8 +858,12 @@ function buildRelatedBeads(
     }
   }
 
-  // For merge_request beads: link back to the source bead
-  if (bead.type === 'merge_request' && typeof bead.metadata?.source_bead_id === 'string') {
+  // For merge_request beads: link back to the source bead (skip for babysit beads)
+  if (
+    bead.type === 'merge_request' &&
+    !(bead.labels ?? []).includes('gt:babysit') &&
+    typeof bead.metadata?.source_bead_id === 'string'
+  ) {
     const source = allBeads.find(b => b.bead_id === bead.metadata.source_bead_id);
     if (source) {
       related.push({ relation: 'source', label: 'Source Work', icon: CircleDot, bead: source });


### PR DESCRIPTION
## Summary

Adds babysit-specific UI to the BeadPanel and BeadInspectorDashboard when a bead has the `gt:babysit` label, and adds event formatters for new babysit-related event types in the ActivityFeed.

**BeadPanel changes:**
- "Babysat external PR" badge (cyan) in the bead header when `gt:babysit` label is present
- Babysit metadata grid showing `head_sha` (7-char abbreviated, linked to commit), `force_push_allowed` (Lock/Unlock icon), and `babysit_started_at` (relative time)
- Source bead link (`source_bead_id`) hidden for babysit beads — they have no source bead by design
- `MetaCell` value type widened to `ReactNode` to support linked SHA display

**ActivityFeed changes:**
- Event icons, colors, and human-readable descriptions for: `babysit_started`, `pr_feedback_detected`, `pr_conflict_detected`, `pr_auto_merge`, `pr_status_changed`
- `eventDescription` exported for unit testing

**BeadInspectorDashboard changes:**
- "Babysat external PR" badge in the Overview labels section
- Babysit metadata fields (head_sha, force-push, babysit started) in the Overview card

**Tests:**
- `BeadPanel.test.ts` — unit tests for `buildRelatedBeads` babysit guard (source link omitted for babysit beads, still shows for non-babysit, child beads still shown)
- `ActivityFeed.test.ts` — unit tests for all 5 new event type formatters with/without metadata, rig prefix, and fallback

## Verification

Manual verification: rendered a babysit bead in the drawer panel and confirmed badge, metadata grid, and hidden source link. Admin dashboard shows matching babysit badge and metadata.

## Visual Changes

- New cyan "Babysat external PR" badge in bead header
- New metadata grid row with head SHA, force-push status, and babysit start time
- Source bead link no longer appears for babysit MR beads
- Activity timeline now shows readable descriptions for babysit events instead of raw snake_case

## Reviewer Notes

- The `MetaCell` value type change from `string` to `ReactNode` is safe — all existing call sites pass strings which are valid ReactNode
- The `BeadLike` type gained an optional `labels` field to support the babysit guard in `buildRelatedBeads`
- Component tests aren't possible with the current Jest config (node env, no testing-library) so tests are pure function tests for the exported logic