### PR TITLE
feat(gastown): Town DO slingExistingPr method (babysit PR feature, chunk 0)

### DIFF
--- a/services/gastown/src/db/tables/bead-events.table.ts
+++ b/services/gastown/src/db/tables/bead-events.table.ts
@@ -24,6 +24,7 @@ export const BeadEventType = z.enum([
   'escalation_rate_spike',
   'agent_restart_loop',
   'rework_requested',
+  'babysit_started',
 ]);
 
 export type BeadEventType = z.infer<typeof BeadEventType>;

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -58,6 +58,7 @@ import {
   getIndexesAgentNudges,
 } from '../db/tables/agent-nudges.table';
 import { query } from '../util/query.util';
+import { parseGitUrl, parsePrUrl } from '../util/platform-pr.util';
 import { getAgentDOStub } from './Agent.do';
 import { getTownContainerStub } from './TownContainer.do';
 
@@ -2523,6 +2524,100 @@ export class TownDO extends DurableObject<Env> {
     );
     await this.escalateToActiveCadence();
     return { bead, agent: hookedAgent };
+  }
+
+  async slingExistingPr(input: {
+    rigId: string;
+    prUrl: string;
+    title?: string;
+    body?: string;
+    forcePushAllowed?: boolean;
+    sourceAgentId?: string;
+  }): Promise<{ beadId: string; warning?: string }> {
+    const sourceAgentId = input.sourceAgentId ?? 'mayor';
+    const forcePushAllowed = input.forcePushAllowed ?? false;
+
+    const rig = rigs.getRig(this.sql, input.rigId);
+    if (!rig) {
+      throw new Error(`Rig ${input.rigId} not found`);
+    }
+
+    const townConfig = await this.getTownConfig();
+    const rigCoords = parseGitUrl(rig.git_url, townConfig.git_auth?.gitlab_instance_url);
+    const prCoords = parsePrUrl(input.prUrl);
+    if (!rigCoords || !prCoords) {
+      throw new Error(
+        `Cannot parse repo coordinates from rig git_url="${rig.git_url}" or pr_url="${input.prUrl}"`
+      );
+    }
+
+    const effectiveRigHost =
+      rigCoords.platform === 'github'
+        ? 'github.com'
+        : new URL(townConfig.git_auth?.gitlab_instance_url ?? 'https://gitlab.com').hostname;
+
+    if (
+      effectiveRigHost !== prCoords.host ||
+      rigCoords.owner !== prCoords.owner ||
+      rigCoords.repo !== prCoords.repo
+    ) {
+      throw new Error(
+        'PR URL repo does not match rig repo. Cannot adopt PRs from other repositories.'
+      );
+    }
+
+    const scmCtx = {
+      env: this.env,
+      townId: this.townId,
+      getTownConfig: () => this.getTownConfig(),
+    };
+    const outcome = await scm.checkPRStatus(scmCtx, input.prUrl);
+    if (!outcome.ok) {
+      const err = outcome.error;
+      throw new Error(
+        `Failed to fetch PR status: ${err.kind}` +
+          (err.kind === 'http_error' ? ` (HTTP ${err.status})` : '') +
+          (err.kind === 'no_token' ? ` — tried: ${err.resolutionChain.join(', ')}` : '')
+      );
+    }
+
+    const pr = outcome.result;
+    if (pr.status === 'merged' || pr.status === 'closed') {
+      throw new Error(`Cannot babysit a PR that is already ${pr.status}.`);
+    }
+
+    if (!pr.head_branch || !pr.base_branch || !pr.head_sha) {
+      throw new Error(
+        'PR metadata is missing branch or SHA information. ' +
+          `head_branch=${pr.head_branch ?? '(missing)'}, base_branch=${pr.base_branch ?? '(missing)'}, head_sha=${pr.head_sha ?? '(missing)'}`
+      );
+    }
+
+    const title = input.title ?? `Babysit: ${pr.title ?? 'external PR'}`;
+    const body =
+      input.body ??
+      `Adopted external PR ${input.prUrl} at SHA ${pr.head_sha}. Town will poll and address review feedback, conflicts, and auto-merge.`;
+
+    const { beadId } = reviewQueue.submitExternalPrToReviewQueue(this.sql, {
+      rigId: input.rigId,
+      prUrl: input.prUrl,
+      branch: pr.head_branch,
+      targetBranch: pr.base_branch,
+      headSha: pr.head_sha,
+      title,
+      body,
+      forcePushAllowed,
+      sourceAgentId,
+    });
+
+    await this.escalateToActiveCadence();
+
+    const warning =
+      rig.config?.code_review === true
+        ? 'Rig has code_review enabled. Babysat PRs bypass refinery review (wired in chunk 1).'
+        : undefined;
+
+    return { beadId, warning };
   }
 
   /**

--- a/services/gastown/src/dos/town/review-queue.ts
+++ b/services/gastown/src/dos/town/review-queue.ts
@@ -107,41 +107,23 @@ function toReviewQueueEntry(row: MergeRequestBeadRecord): ReviewQueueEntry {
   };
 }
 
-export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): void {
+function createMergeRequestBeadCore(
+  sql: SqlStorage,
+  args: {
+    rigId: string;
+    title: string;
+    body: string | null;
+    metadata: Record<string, unknown>;
+    labels: string[];
+    branch: string;
+    targetBranch: string;
+    prUrl?: string;
+    createdBy: string;
+  }
+): { beadId: string } {
   const id = generateId();
   const timestamp = now();
 
-  // Build metadata — include pr_url if the agent already created a PR so
-  // the link is visible via the standard bead list endpoint.
-  const metadata: Record<string, unknown> = {
-    source_bead_id: input.bead_id,
-    source_agent_id: input.agent_id,
-  };
-  if (input.pr_url) {
-    metadata.pr_url = input.pr_url;
-  }
-
-  // Resolve the target branch for this MR:
-  // - For review-then-land convoy beads → convoy's feature branch
-  // - For review-and-merge convoy beads → rig's default branch (land independently)
-  // - For standalone beads → rig's default branch
-  // We pass defaultBranch from the caller so we don't hardcode 'main'.
-  const convoyId = getConvoyForBead(sql, input.bead_id);
-  const convoyFeatureBranch = convoyId ? getConvoyFeatureBranch(sql, convoyId) : null;
-  const convoyMergeMode = convoyId ? getConvoyMergeMode(sql, convoyId) : null;
-  const targetBranch =
-    convoyMergeMode === 'review-then-land' && convoyFeatureBranch
-      ? convoyFeatureBranch
-      : (input.default_branch ?? 'main');
-
-  if (convoyId) {
-    metadata.convoy_id = convoyId;
-    if (convoyFeatureBranch) {
-      metadata.convoy_feature_branch = convoyFeatureBranch;
-    }
-  }
-
-  // Create the merge_request bead
   query(
     sql,
     /* sql */ `
@@ -158,35 +140,21 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
       id,
       'merge_request',
       'open',
-      `Review: ${input.branch}`,
-      input.summary ?? null,
-      input.rig_id,
+      args.title,
+      args.body,
+      args.rigId,
       null,
-      null, // assignee left null — refinery claims it via hookBead
+      null,
       'medium',
-      JSON.stringify(['gt:merge-request']),
-      JSON.stringify(metadata),
-      input.agent_id, // created_by records who submitted
+      JSON.stringify(args.labels),
+      JSON.stringify(args.metadata),
+      args.createdBy,
       timestamp,
       timestamp,
       null,
     ]
   );
 
-  // Link MR bead → source bead via bead_dependencies so the DAG is queryable
-  query(
-    sql,
-    /* sql */ `
-      INSERT INTO ${bead_dependencies} (
-        ${bead_dependencies.columns.bead_id},
-        ${bead_dependencies.columns.depends_on_bead_id},
-        ${bead_dependencies.columns.dependency_type}
-      ) VALUES (?, ?, 'tracks')
-    `,
-    [id, input.bead_id]
-  );
-
-  // Create the review_metadata satellite
   query(
     sql,
     /* sql */ `
@@ -196,7 +164,58 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
         ${review_metadata.columns.pr_url}, ${review_metadata.columns.retry_count}
       ) VALUES (?, ?, ?, ?, ?, ?)
     `,
-    [id, input.branch, targetBranch, null, input.pr_url ?? null, 0]
+    [id, args.branch, args.targetBranch, null, args.prUrl ?? null, 0]
+  );
+
+  return { beadId: id };
+}
+
+export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): void {
+  const metadata: Record<string, unknown> = {
+    source_bead_id: input.bead_id,
+    source_agent_id: input.agent_id,
+  };
+  if (input.pr_url) {
+    metadata.pr_url = input.pr_url;
+  }
+
+  const convoyId = getConvoyForBead(sql, input.bead_id);
+  const convoyFeatureBranch = convoyId ? getConvoyFeatureBranch(sql, convoyId) : null;
+  const convoyMergeMode = convoyId ? getConvoyMergeMode(sql, convoyId) : null;
+  const targetBranch =
+    convoyMergeMode === 'review-then-land' && convoyFeatureBranch
+      ? convoyFeatureBranch
+      : (input.default_branch ?? 'main');
+
+  if (convoyId) {
+    metadata.convoy_id = convoyId;
+    if (convoyFeatureBranch) {
+      metadata.convoy_feature_branch = convoyFeatureBranch;
+    }
+  }
+
+  const { beadId } = createMergeRequestBeadCore(sql, {
+    rigId: input.rig_id,
+    title: `Review: ${input.branch}`,
+    body: input.summary ?? null,
+    metadata,
+    labels: ['gt:merge-request'],
+    branch: input.branch,
+    targetBranch,
+    prUrl: input.pr_url,
+    createdBy: input.agent_id,
+  });
+
+  query(
+    sql,
+    /* sql */ `
+      INSERT INTO ${bead_dependencies} (
+        ${bead_dependencies.columns.bead_id},
+        ${bead_dependencies.columns.depends_on_bead_id},
+        ${bead_dependencies.columns.dependency_type}
+      ) VALUES (?, ?, 'tracks')
+    `,
+    [beadId, input.bead_id]
   );
 
   logBeadEvent(sql, {
@@ -206,6 +225,53 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
     newValue: input.branch,
     metadata: { branch: input.branch, target_branch: targetBranch },
   });
+}
+
+export function submitExternalPrToReviewQueue(
+  sql: SqlStorage,
+  args: {
+    rigId: string;
+    prUrl: string;
+    branch: string;
+    targetBranch: string;
+    headSha: string;
+    title: string;
+    body?: string;
+    forcePushAllowed: boolean;
+    sourceAgentId: string;
+  }
+): { beadId: string } {
+  const { beadId } = createMergeRequestBeadCore(sql, {
+    rigId: args.rigId,
+    title: args.title,
+    body: args.body ?? null,
+    metadata: {
+      source_agent_id: args.sourceAgentId,
+      babysit: true,
+      head_sha: args.headSha,
+      force_push_allowed: args.forcePushAllowed,
+    },
+    labels: ['gt:merge-request', 'gt:babysit'],
+    branch: args.branch,
+    targetBranch: args.targetBranch,
+    prUrl: args.prUrl,
+    createdBy: args.sourceAgentId,
+  });
+
+  logBeadEvent(sql, {
+    beadId,
+    agentId: args.sourceAgentId,
+    eventType: 'babysit_started',
+    newValue: args.prUrl,
+    metadata: {
+      pr_url: args.prUrl,
+      branch: args.branch,
+      target_branch: args.targetBranch,
+      head_sha: args.headSha,
+    },
+  });
+
+  return { beadId };
 }
 
 export function completeReview(

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -108,6 +108,10 @@ export async function resolveGitHubTokenString(ctx: SCMContext): Promise<string 
 export type PRStatusResult = {
   status: 'open' | 'merged' | 'closed';
   mergeable_state?: string;
+  head_branch?: string;
+  base_branch?: string;
+  head_sha?: string;
+  title?: string;
 };
 
 export type PRStatusError =
@@ -203,9 +207,39 @@ export async function checkPRStatus(ctx: SCMContext, prUrl: string): Promise<PRS
       };
     }
 
-    if (data.data.merged) return { ok: true, result: { status: 'merged' } };
-    if (data.data.state === 'closed') return { ok: true, result: { status: 'closed' } };
-    return { ok: true, result: { status: 'open', mergeable_state: data.data.mergeable_state } };
+    if (data.data.merged)
+      return {
+        ok: true,
+        result: {
+          status: 'merged',
+          head_branch: data.data.head?.ref,
+          base_branch: data.data.base?.ref,
+          head_sha: data.data.head?.sha,
+          title: data.data.title,
+        },
+      };
+    if (data.data.state === 'closed')
+      return {
+        ok: true,
+        result: {
+          status: 'closed',
+          head_branch: data.data.head?.ref,
+          base_branch: data.data.base?.ref,
+          head_sha: data.data.head?.sha,
+          title: data.data.title,
+        },
+      };
+    return {
+      ok: true,
+      result: {
+        status: 'open',
+        mergeable_state: data.data.mergeable_state,
+        head_branch: data.data.head?.ref,
+        base_branch: data.data.base?.ref,
+        head_sha: data.data.head?.sha,
+        title: data.data.title,
+      },
+    };
   }
 
   // GitLab MR URL format: https://{host}/{path}/-/merge_requests/{iid}
@@ -288,9 +322,38 @@ export async function checkPRStatus(ctx: SCMContext, prUrl: string): Promise<PRS
       };
     }
 
-    if (data.data.state === 'merged') return { ok: true, result: { status: 'merged' } };
-    if (data.data.state === 'closed') return { ok: true, result: { status: 'closed' } };
-    return { ok: true, result: { status: 'open' } };
+    if (data.data.state === 'merged')
+      return {
+        ok: true,
+        result: {
+          status: 'merged',
+          head_branch: data.data.source_branch,
+          base_branch: data.data.target_branch,
+          head_sha: data.data.sha,
+          title: data.data.title,
+        },
+      };
+    if (data.data.state === 'closed')
+      return {
+        ok: true,
+        result: {
+          status: 'closed',
+          head_branch: data.data.source_branch,
+          base_branch: data.data.target_branch,
+          head_sha: data.data.sha,
+          title: data.data.title,
+        },
+      };
+    return {
+      ok: true,
+      result: {
+        status: 'open',
+        head_branch: data.data.source_branch,
+        base_branch: data.data.target_branch,
+        head_sha: data.data.sha,
+        title: data.data.title,
+      },
+    };
   }
 
   console.warn(`${TOWN_LOG} checkPRStatus: unrecognized PR URL format: ${prUrl}`);

--- a/services/gastown/src/util/platform-pr.util.ts
+++ b/services/gastown/src/util/platform-pr.util.ts
@@ -25,6 +25,40 @@ function hostnameOf(urlStr: string): string | null {
   }
 }
 
+export type PrUrlCoordinates = {
+  host: string;
+  owner: string;
+  repo: string;
+  prNumber: number;
+};
+
+export function parsePrUrl(prUrl: string): PrUrlCoordinates | null {
+  const ghMatch = prUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  if (ghMatch) {
+    return {
+      host: 'github.com',
+      owner: ghMatch[1],
+      repo: ghMatch[2],
+      prNumber: parseInt(ghMatch[3], 10),
+    };
+  }
+  const glMatch = prUrl.match(/^(https:\/\/([^/]+))\/(.+)\/-\/merge_requests\/(\d+)/);
+  if (glMatch) {
+    const fullPath = glMatch[3];
+    const lastSlash = fullPath.lastIndexOf('/');
+    if (lastSlash > 0) {
+      return {
+        host: glMatch[2],
+        owner: fullPath.slice(0, lastSlash),
+        repo: fullPath.slice(lastSlash + 1),
+        prNumber: parseInt(glMatch[4], 10),
+      };
+    }
+    return null;
+  }
+  return null;
+}
+
 // -- PR body template --
 
 export type QualityGateResult = {
@@ -88,12 +122,28 @@ export const GitHubPRStatusSchema = z.object({
   state: z.string(),
   merged: z.boolean().optional(),
   mergeable: z.boolean().nullable().optional(),
-  mergeable_state: z.string().optional(), // 'clean', 'dirty', 'blocked', 'unknown', 'unstable'
+  mergeable_state: z.string().optional(),
+  title: z.string().optional(),
+  head: z
+    .object({
+      ref: z.string().optional(),
+      sha: z.string().optional(),
+    })
+    .optional(),
+  base: z
+    .object({
+      ref: z.string().optional(),
+    })
+    .optional(),
 });
 
 /** Schema for GitLab MR status responses (used by checkPRStatus). */
 export const GitLabMRStatusSchema = z.object({
   state: z.string(),
+  title: z.string().optional(),
+  source_branch: z.string().optional(),
+  target_branch: z.string().optional(),
+  sha: z.string().optional(),
 });
 
 // -- GitHub PR creation --

--- a/services/gastown/test/unit/sling-existing-pr.test.ts
+++ b/services/gastown/test/unit/sling-existing-pr.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect, vi } from 'vitest';
+import { checkPRStatus, type SCMContext } from '../../src/dos/town/town-scm';
+import { parsePrUrl, parseGitUrl } from '../../src/util/platform-pr.util';
+import { submitExternalPrToReviewQueue } from '../../src/dos/town/review-queue';
+import type { TownConfig } from '../../src/types';
+
+class MiniSql {
+  private inserts: { table: string; params: unknown[] }[] = [];
+  private selectResults: Map<string, Record<string, unknown>[]> = new Map();
+
+  exec(stmt: string, ...params: unknown[]): SqlStoragecursor {
+    this.captureInsert(stmt, params);
+    const selectRows = this.matchSelect(stmt, params);
+    if (selectRows !== undefined) {
+      return this.cursorFromRows(selectRows);
+    }
+    return this.cursorFromRows([]);
+  }
+
+  private captureInsert(stmt: string, params: unknown[]): void {
+    const match = stmt.match(/INSERT\s+INTO\s+(\S+)/i);
+    if (match) {
+      this.inserts.push({ table: match[1], params });
+    }
+  }
+
+  private matchSelect(_stmt: string, _params: unknown[]): Record<string, unknown>[] | undefined {
+    for (const [key, rows] of this.selectResults) {
+      if (_stmt.includes(key)) {
+        return rows;
+      }
+    }
+    return undefined;
+  }
+
+  private cursorFromRows(rows: Record<string, unknown>[]): SqlStoragecursor {
+    return {
+      get rows(): unknown[][] {
+        return rows as unknown as unknown[][];
+      },
+      get columns(): string[] {
+        return rows.length > 0 ? Object.keys(rows[0]) : [];
+      },
+      cursor: {
+        next(): string | null {
+          return null;
+        },
+        get value(): unknown[] {
+          return [];
+        },
+      },
+      [Symbol.iterator]() {
+        return (rows as unknown as unknown[][])[Symbol.iterator]();
+      },
+    } as unknown as SqlStoragecursor;
+  }
+
+  addSelectResult(key: string, rows: Record<string, unknown>[]): void {
+    this.selectResults.set(key, rows);
+  }
+
+  getInserts(): { table: string; params: unknown[] }[] {
+    return this.inserts;
+  }
+
+  findBeadInsert(): { table: string; params: unknown[] } | undefined {
+    return this.inserts.find(i => /beads$/i.test(i.table));
+  }
+
+  findReviewMetadataInsert(): { table: string; params: unknown[] } | undefined {
+    return this.inserts.find(i => /review_metadata$/i.test(i.table));
+  }
+
+  findEventInsert(): { table: string; params: unknown[] } | undefined {
+    return this.inserts.find(i => /bead_events$/i.test(i.table));
+  }
+}
+
+function mockSCMContext(overrides: Partial<SCMContext> = {}): SCMContext {
+  return {
+    env: {} as SCMContext['env'],
+    townId: 'test-town',
+    getTownConfig: async () => ({}) as TownConfig,
+    ...overrides,
+  };
+}
+
+function makeSql(): SqlStorage {
+  return new MiniSql() as unknown as SqlStorage;
+}
+
+describe('parsePrUrl', () => {
+  it('parses GitHub PR URL', () => {
+    const result = parsePrUrl('https://github.com/Kilo-Org/cloud/pull/42');
+    expect(result).toEqual({
+      host: 'github.com',
+      owner: 'Kilo-Org',
+      repo: 'cloud',
+      prNumber: 42,
+    });
+  });
+
+  it('parses GitLab MR URL with simple group', () => {
+    const result = parsePrUrl('https://gitlab.com/group/project/-/merge_requests/7');
+    expect(result).toEqual({
+      host: 'gitlab.com',
+      owner: 'group',
+      repo: 'project',
+      prNumber: 7,
+    });
+  });
+
+  it('parses GitLab MR URL with subgroup', () => {
+    const result = parsePrUrl(
+      'https://gitlab.example.com/org/team/project/-/merge_requests/99'
+    );
+    expect(result).toEqual({
+      host: 'gitlab.example.com',
+      owner: 'org/team',
+      repo: 'project',
+      prNumber: 99,
+    });
+  });
+
+  it('returns null for unrecognized URLs', () => {
+    expect(parsePrUrl('https://example.com/pr/1')).toBeNull();
+    expect(parsePrUrl('not a url')).toBeNull();
+  });
+});
+
+describe('repo mismatch validation (parseGitUrl + parsePrUrl)', () => {
+  it('detects mismatch between rig git_url and PR URL (different owner)', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    const prCoords = parsePrUrl('https://github.com/Other-Org/cloud/pull/1');
+    expect(rigCoords).toBeTruthy();
+    expect(prCoords).toBeTruthy();
+    expect(rigCoords!.owner).not.toBe(prCoords!.owner);
+  });
+
+  it('detects mismatch between rig git_url and PR URL (different repo)', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    const prCoords = parsePrUrl('https://github.com/Kilo-Org/other-repo/pull/1');
+    expect(rigCoords).toBeTruthy();
+    expect(prCoords).toBeTruthy();
+    expect(rigCoords!.repo).not.toBe(prCoords!.repo);
+  });
+
+  it('detects match between rig git_url and PR URL', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    const prCoords = parsePrUrl('https://github.com/Kilo-Org/cloud/pull/42');
+    expect(rigCoords).toBeTruthy();
+    expect(prCoords).toBeTruthy();
+    expect(rigCoords!.owner).toBe(prCoords!.owner);
+    expect(rigCoords!.repo).toBe(prCoords!.repo);
+  });
+
+  it('detects match for GitLab URLs', () => {
+    const rigCoords = parseGitUrl('https://gitlab.com/group/project');
+    const prCoords = parsePrUrl('https://gitlab.com/group/project/-/merge_requests/7');
+    expect(rigCoords).toBeTruthy();
+    expect(prCoords).toBeTruthy();
+    expect(rigCoords!.owner).toBe(prCoords!.owner);
+    expect(rigCoords!.repo).toBe(prCoords!.repo);
+  });
+});
+
+describe('checkPRStatus extended return shape', () => {
+  it('returns head_branch/base_branch/head_sha for GitHub PR', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        state: 'open',
+        merged: false,
+        mergeable_state: 'clean',
+        head: { ref: 'feature-branch', sha: 'abc1234def' },
+        base: { ref: 'main' },
+        title: 'Add new feature',
+      }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse as Response
+    );
+
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(
+      ctx,
+      'https://github.com/Kilo-Org/cloud/pull/42'
+    );
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('open');
+      expect(outcome.result.head_branch).toBe('feature-branch');
+      expect(outcome.result.base_branch).toBe('main');
+      expect(outcome.result.head_sha).toBe('abc1234def');
+      expect(outcome.result.title).toBe('Add new feature');
+    }
+    fetchSpy.mockRestore();
+  });
+
+  it('returns head_branch/base_branch/head_sha for closed GitHub PR', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        state: 'closed',
+        merged: false,
+        head: { ref: 'feature-branch', sha: 'abc123' },
+        base: { ref: 'main' },
+        title: 'Closed PR',
+      }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse as Response
+    );
+
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(
+      ctx,
+      'https://github.com/Kilo-Org/cloud/pull/42'
+    );
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('closed');
+      expect(outcome.result.head_branch).toBe('feature-branch');
+    }
+    fetchSpy.mockRestore();
+  });
+
+  it('returns head_branch/base_branch/head_sha for merged GitHub PR', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        state: 'closed',
+        merged: true,
+        head: { ref: 'feature-branch', sha: 'mergedsha' },
+        base: { ref: 'main' },
+        title: 'Merged PR',
+      }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse as Response
+    );
+
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(
+      ctx,
+      'https://github.com/Kilo-Org/cloud/pull/42'
+    );
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('merged');
+      expect(outcome.result.head_branch).toBe('feature-branch');
+    }
+    fetchSpy.mockRestore();
+  });
+
+  it('returns head_branch/base_branch for GitLab MR', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        state: 'opened',
+        source_branch: 'feature-branch',
+        target_branch: 'main',
+        sha: 'glsha123',
+        title: 'GitLab MR title',
+      }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse as Response
+    );
+
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({
+          git_auth: {
+            gitlab_token: 'glpat_test',
+            gitlab_instance_url: 'https://gitlab.com',
+          },
+        }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(
+      ctx,
+      'https://gitlab.com/group/project/-/merge_requests/7'
+    );
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('open');
+      expect(outcome.result.head_branch).toBe('feature-branch');
+      expect(outcome.result.base_branch).toBe('main');
+      expect(outcome.result.head_sha).toBe('glsha123');
+      expect(outcome.result.title).toBe('GitLab MR title');
+    }
+    fetchSpy.mockRestore();
+  });
+
+  it('returns ok:false with no_token error when no GitHub token', async () => {
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({}) as TownConfig,
+    });
+    const outcome = await checkPRStatus(
+      ctx,
+      'https://github.com/Kilo-Org/cloud/pull/42'
+    );
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error.kind).toBe('no_token');
+    }
+  });
+
+  it('returns ok:false with http_error on API failure', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockResponse as Response
+    );
+
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(
+      ctx,
+      'https://github.com/Kilo-Org/cloud/pull/42'
+    );
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error.kind).toBe('http_error');
+      if (outcome.error.kind === 'http_error') {
+        expect(outcome.error.status).toBe(500);
+        expect(outcome.error.transient).toBe(true);
+      }
+    }
+    fetchSpy.mockRestore();
+  });
+});
+
+describe('submitExternalPrToReviewQueue', () => {
+  it('creates bead with correct metadata when forcePushAllowed=false', () => {
+    const sql = makeSql();
+    const { beadId } = submitExternalPrToReviewQueue(sql, {
+      rigId: 'rig-1',
+      prUrl: 'https://github.com/Org/repo/pull/1',
+      branch: 'feature/x',
+      targetBranch: 'main',
+      headSha: 'abc1234',
+      title: 'Babysit: Test PR',
+      forcePushAllowed: false,
+      sourceAgentId: 'mayor',
+    });
+
+    expect(beadId).toBeTruthy();
+
+    const miniSql = sql as unknown as MiniSql;
+    const beadInsert = miniSql.findBeadInsert();
+    expect(beadInsert).toBeTruthy();
+    const metadata = JSON.parse(beadInsert!.params[10] as string);
+    expect(metadata.force_push_allowed).toBe(false);
+    expect(metadata.babysit).toBe(true);
+    expect(metadata.head_sha).toBe('abc1234');
+    expect(metadata.source_agent_id).toBe('mayor');
+  });
+
+  it('persists force_push_allowed: true when explicitly set', () => {
+    const sql = makeSql();
+    submitExternalPrToReviewQueue(sql, {
+      rigId: 'rig-1',
+      prUrl: 'https://github.com/Org/repo/pull/1',
+      branch: 'feature/x',
+      targetBranch: 'main',
+      headSha: 'def5678',
+      title: 'Babysit: Another PR',
+      forcePushAllowed: true,
+      sourceAgentId: 'system',
+    });
+
+    const miniSql = sql as unknown as MiniSql;
+    const beadInsert = miniSql.findBeadInsert();
+    expect(beadInsert).toBeTruthy();
+    const metadata = JSON.parse(beadInsert!.params[10] as string);
+    expect(metadata.force_push_allowed).toBe(true);
+  });
+
+  it('creates review_metadata row and babysit_started event', () => {
+    const sql = makeSql();
+    submitExternalPrToReviewQueue(sql, {
+      rigId: 'rig-1',
+      prUrl: 'https://github.com/Org/repo/pull/1',
+      branch: 'feature/x',
+      targetBranch: 'main',
+      headSha: 'abc1234',
+      title: 'Babysit: Test',
+      forcePushAllowed: false,
+      sourceAgentId: 'mayor',
+    });
+
+    const miniSql = sql as unknown as MiniSql;
+    const rmInsert = miniSql.findReviewMetadataInsert();
+    expect(rmInsert).toBeTruthy();
+    expect(rmInsert!.params[1]).toBe('feature/x');
+    expect(rmInsert!.params[2]).toBe('main');
+    expect(rmInsert!.params[4]).toBe('https://github.com/Org/repo/pull/1');
+
+    const eventInsert = miniSql.findEventInsert();
+    expect(eventInsert).toBeTruthy();
+    expect(eventInsert!.params[3]).toBe('babysit_started');
+  });
+
+  it('includes gt:babysit label alongside gt:merge-request', () => {
+    const sql = makeSql();
+    submitExternalPrToReviewQueue(sql, {
+      rigId: 'rig-1',
+      prUrl: 'https://github.com/Org/repo/pull/1',
+      branch: 'feature/x',
+      targetBranch: 'main',
+      headSha: 'abc1234',
+      title: 'Babysit: Test',
+      forcePushAllowed: false,
+      sourceAgentId: 'mayor',
+    });
+
+    const miniSql = sql as unknown as MiniSql;
+    const beadInsert = miniSql.findBeadInsert();
+    expect(beadInsert).toBeTruthy();
+    const labels = JSON.parse(beadInsert!.params[9] as string);
+    expect(labels).toContain('gt:merge-request');
+    expect(labels).toContain('gt:babysit');
+  });
+
+  it('does not create a tracks dependency edge', () => {
+    const sql = makeSql();
+    submitExternalPrToReviewQueue(sql, {
+      rigId: 'rig-1',
+      prUrl: 'https://github.com/Org/repo/pull/1',
+      branch: 'feature/x',
+      targetBranch: 'main',
+      headSha: 'abc1234',
+      title: 'Babysit: Test',
+      forcePushAllowed: false,
+      sourceAgentId: 'mayor',
+    });
+
+    const miniSql = sql as unknown as MiniSql;
+    const depInsert = miniSql
+      .getInserts()
+      .find(i => /bead_dependencies/i.test(i.table));
+    expect(depInsert).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Chunk 0 of 6 for the "Babysit existing PR" feature. Opens the path for users to adopt a pre-existing PR for the town to babysit (poll, address feedback, fix conflicts, auto-merge).

Changes:
- **Part A**: Refactored `submitToReviewQueue` to use a private `createMergeRequestBeadCore` helper (bead + review_metadata insert). Public signature unchanged — no callers modified.
- **Part B**: Added `submitExternalPrToReviewQueue` — creates a `merge_request` bead with `gt:babysit` label, `babysit: true` metadata, `force_push_allowed`, `head_sha`, and a `babysit_started` event. No `tracks` dependency edge (no source bead).
- **Part C**: Extended `checkPRStatus` return shape with `head_branch`, `base_branch`, `head_sha`, `title` fields (populated for both GitHub and GitLab paths; existing callers unchanged since fields are optional). Added `parsePrUrl` to `platform-pr.util.ts` for repo validation. Added `slingExistingPr` method to `Town.do.ts` with rig lookup, repo match validation, PR state validation (reject merged/closed), and default title/body computation.

## Verification

- `pnpm --filter cloudflare-gastown typecheck` passes
- `pnpm --filter cloudflare-gastown test` passes (19 new tests + all existing tests)
- Existing `town-scm.test.ts`, `pr-poll-errors.test.ts`, `pr-poll-thresholds.test.ts` tests still pass

## Visual Changes

N/A

## Reviewer Notes

- The `createMergeRequestBeadCore` helper is a minimal extraction — steps 1+2 from `submitToReviewQueue` (bead insert + review_metadata insert). The `tracks` edge and `review_submitted` event remain in `submitToReviewQueue`.
- `slingExistingPr` throws on missing branch metadata (`head_branch`/`base_branch`/`head_sha`) to fail fast if the SCM API doesn't return them, rather than silently creating a broken bead.
- The `babysit_started` event is logged on the new MR bead (not a source bead), mirroring how `review_submitted` is logged on the source bead.