### PR TITLE
feat(stripe): capture early fraud warnings for review

### DIFF
--- a/.specs/stripe-early-fraud-warnings.md
+++ b/.specs/stripe-early-fraud-warnings.md
@@ -38,6 +38,12 @@ BCP 14 [RFC 2119] [RFC 8174] keywords apply only when they appear in all capital
 3. Existing dispute, refund, and fraud-mark handling MUST continue to operate independently, subject to idempotency rules that prevent duplicated EFW side effects.
 4. The persistence-only foundation MAY exist before processing is enabled; until ingestion is deployed, it MUST remain unwritten by EFW automation.
 
+### Observation-Only Rollout Interval
+
+- Before automatic enforcement is deployed and enabled, newly delivered EFWs MUST be persisted as `review_required` cases for operator visibility only, including warnings that resolve to a canonical personal owner.
+- A case captured during the observation-only interval MUST remain manual-review work and MUST NOT later be promoted into automatic enforcement merely because enforcement is enabled for newly arriving warnings.
+- Observation-only ingestion MUST NOT create action-ledger work, block users, disable automatic top-up, refund payments, reverse value, modify subscriptions or compute, reverse payouts or rewards, or send enforcement notices.
+
 ### Ownership Resolution and Review Boundary
 
 5. Automatic enforcement MUST occur only when the warned payment resolves to one canonical personal owner and does not resolve to an organization.

--- a/apps/web/src/app/admin/components/AppSidebar.tsx
+++ b/apps/web/src/app/admin/components/AppSidebar.tsx
@@ -110,6 +110,11 @@ const financialItems: MenuItem[] = [
     icon: () => <Coins />,
   },
   {
+    title: () => 'Early Fraud Warnings',
+    url: '/admin/early-fraud-warnings',
+    icon: () => <Shield />,
+  },
+  {
     title: () => 'Revenue KPI',
     url: '/admin/revenue',
     icon: () => <DollarSign />,

--- a/apps/web/src/app/admin/early-fraud-warnings/EarlyFraudWarningsContent.test.ts
+++ b/apps/web/src/app/admin/early-fraud-warnings/EarlyFraudWarningsContent.test.ts
@@ -1,0 +1,66 @@
+import React from 'react';
+import { describe, expect, it } from '@jest/globals';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { EarlyFraudWarningsTable, type EarlyFraudWarningRow } from './EarlyFraudWarningsContent';
+
+const rows = [
+  {
+    id: '11111111-1111-4111-8111-111111111111',
+    stripeEarlyFraudWarningId: 'issfr_personal',
+    stripeEventId: 'evt_personal',
+    stripeChargeId: 'ch_personal',
+    stripePaymentIntentId: 'pi_personal',
+    stripeCustomerId: 'cus_personal',
+    amountMinorUnits: 1900,
+    currency: 'usd',
+    ownerClassification: 'personal',
+    status: 'review_required',
+    reason: 'Observation only: canonical personal owner matched; manual review required',
+    failureContext: null,
+    warningCreatedAt: '2026-05-28T10:00:00.000Z',
+    reviewRequiredAt: '2026-05-28T10:00:01.000Z',
+    createdAt: '2026-05-28T10:00:01.000Z',
+    user: { id: 'user-personal', email: 'personal@example.com', name: 'Personal User' },
+    organization: null,
+  },
+  {
+    id: '22222222-2222-4222-8222-222222222222',
+    stripeEarlyFraudWarningId: 'issfr_organization',
+    stripeEventId: 'evt_organization',
+    stripeChargeId: null,
+    stripePaymentIntentId: null,
+    stripeCustomerId: 'cus_organization',
+    amountMinorUnits: null,
+    currency: null,
+    ownerClassification: 'organization',
+    status: 'review_required',
+    reason: 'Organization-owned warning; manual review required',
+    failureContext: null,
+    warningCreatedAt: null,
+    reviewRequiredAt: '2026-05-28T10:00:01.000Z',
+    createdAt: '2026-05-28T10:00:01.000Z',
+    user: null,
+    organization: { id: 'organization-id', name: 'Review Organization' },
+  },
+] satisfies EarlyFraudWarningRow[];
+
+describe('EarlyFraudWarningsTable', () => {
+  it('renders stored review cases with operational context and safe account links', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(EarlyFraudWarningsTable, { rows, isLoading: false })
+    );
+
+    expect(html).toContain('Personal observation');
+    expect(html).toContain('Review required');
+    expect(html).toContain('$19.00');
+    expect(html).toContain('personal@example.com');
+    expect(html).toContain('Review Organization');
+    expect(html).toContain('issfr_personal');
+    expect(html).toContain('ch_personal');
+    expect(html).toContain('payments/ch_personal');
+    expect(html).toContain(
+      'Observation only: canonical personal owner matched; manual review required'
+    );
+  });
+});

--- a/apps/web/src/app/admin/early-fraud-warnings/EarlyFraudWarningsContent.tsx
+++ b/apps/web/src/app/admin/early-fraud-warnings/EarlyFraudWarningsContent.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { inferRouterOutputs } from '@trpc/server';
+import { ExternalLink } from 'lucide-react';
+import Link from 'next/link';
+
+import type { RootRouter } from '@/routers/root-router';
+import { useTRPC } from '@/lib/trpc/utils';
+import { formatCents } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+const PAGE_SIZE = 25;
+type RouterOutputs = inferRouterOutputs<RootRouter>;
+export type EarlyFraudWarningRow =
+  RouterOutputs['admin']['earlyFraudWarnings']['list']['rows'][number];
+
+export function EarlyFraudWarningsContent() {
+  const trpc = useTRPC();
+  const [page, setPage] = useState(1);
+  const casesQuery = useQuery(
+    trpc.admin.earlyFraudWarnings.list.queryOptions({ page, limit: PAGE_SIZE })
+  );
+  const rows = casesQuery.data?.rows ?? [];
+  const pagination = casesQuery.data?.pagination;
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-bold">Early Fraud Warnings</h2>
+        <p className="text-muted-foreground max-w-4xl">
+          Review new Stripe warnings captured during the observation rollout. This view is
+          read-only; captured cases do not restrict access, refund payments, or schedule automated
+          actions.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Captured warnings</CardTitle>
+          <CardDescription>
+            One row is stored per newly delivered warning. Personal matches remain manual-review
+            cases during observation.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {casesQuery.isError ? (
+            <p className="text-destructive text-sm" role="alert">
+              Warning cases could not be loaded. Refresh the page to try again.
+            </p>
+          ) : (
+            <>
+              <EarlyFraudWarningsTable rows={rows} isLoading={casesQuery.isLoading} />
+              <div className="flex flex-col items-start justify-between gap-3 text-sm sm:flex-row sm:items-center">
+                <p className="text-muted-foreground">
+                  {pagination
+                    ? `${pagination.total} captured warning${pagination.total === 1 ? '' : 's'}`
+                    : 'Loading warning count...'}
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setPage(current => Math.max(1, current - 1))}
+                    disabled={page <= 1 || casesQuery.isFetching}
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setPage(current => current + 1)}
+                    disabled={!pagination || page >= pagination.totalPages || casesQuery.isFetching}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export function EarlyFraudWarningsTable({
+  rows,
+  isLoading,
+}: {
+  rows: EarlyFraudWarningRow[];
+  isLoading: boolean;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Received</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Owner</TableHead>
+            <TableHead>Amount</TableHead>
+            <TableHead>Linked account</TableHead>
+            <TableHead>Stripe identifiers</TableHead>
+            <TableHead>Review reason</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={7} className="text-muted-foreground h-24 text-center">
+                {isLoading
+                  ? 'Loading captured warnings...'
+                  : 'No early fraud warnings captured yet.'}
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map(row => (
+              <TableRow key={row.id}>
+                <TableCell className="whitespace-nowrap text-sm">
+                  {formatTimestamp(row.warningCreatedAt ?? row.createdAt)}
+                </TableCell>
+                <TableCell>
+                  <Badge variant={row.status === 'failed' ? 'destructive' : 'secondary'}>
+                    {formatStatus(row.status)}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant={row.ownerClassification === 'ambiguous' ? 'destructive' : 'outline'}
+                  >
+                    {formatOwnerClassification(row.ownerClassification)}
+                  </Badge>
+                </TableCell>
+                <TableCell className="whitespace-nowrap font-mono text-sm tabular-nums">
+                  {formatAmount(row.amountMinorUnits, row.currency)}
+                </TableCell>
+                <TableCell className="min-w-48 text-sm">{renderLinkedAccount(row)}</TableCell>
+                <TableCell className="min-w-64 text-xs">
+                  <StripeIdentifiers row={row} />
+                </TableCell>
+                <TableCell className="text-muted-foreground min-w-64 text-sm">
+                  {row.reason ?? 'Manual review required'}
+                  {row.failureContext ? (
+                    <div className="text-destructive mt-1">{row.failureContext}</div>
+                  ) : null}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function StripeIdentifiers({ row }: { row: EarlyFraudWarningRow }) {
+  return (
+    <div className="flex flex-col gap-1 font-mono">
+      <span>{row.stripeEarlyFraudWarningId}</span>
+      {row.stripeChargeId ? (
+        <a
+          href={stripePaymentUrl(row.stripeChargeId)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-400 hover:text-blue-300 inline-flex items-center gap-1"
+        >
+          {row.stripeChargeId}
+          <ExternalLink className="size-3 shrink-0" />
+        </a>
+      ) : null}
+      {row.stripePaymentIntentId ? <span>{row.stripePaymentIntentId}</span> : null}
+      {row.stripeCustomerId ? (
+        <a
+          href={stripeCustomerUrl(row.stripeCustomerId)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-400 hover:text-blue-300 inline-flex items-center gap-1"
+        >
+          {row.stripeCustomerId}
+          <ExternalLink className="size-3 shrink-0" />
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+function renderLinkedAccount(row: EarlyFraudWarningRow) {
+  if (row.user) {
+    return (
+      <Link
+        className="text-blue-400 hover:text-blue-300"
+        href={`/admin/users/${encodeURIComponent(row.user.id)}`}
+      >
+        {row.user.email}
+      </Link>
+    );
+  }
+
+  if (row.organization) {
+    return (
+      <Link
+        className="text-blue-400 hover:text-blue-300"
+        href={`/admin/organizations/${encodeURIComponent(row.organization.id)}`}
+      >
+        {row.organization.name}
+      </Link>
+    );
+  }
+
+  return <span className="text-muted-foreground">No owner linked</span>;
+}
+
+function formatStatus(status: string): string {
+  return status.replaceAll('_', ' ').replace(/^./, value => value.toUpperCase());
+}
+
+function formatOwnerClassification(classification: string): string {
+  return classification === 'personal'
+    ? 'Personal observation'
+    : classification.replace(/^./, value => value.toUpperCase());
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return 'Not available';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'Not available' : date.toLocaleString();
+}
+
+function formatAmount(amountMinorUnits: number | null, currency: string | null): string {
+  if (amountMinorUnits === null || !currency) return 'Not available';
+  return formatCents(amountMinorUnits, currency);
+}
+
+function stripeDashboardPrefix(): string {
+  return process.env.NODE_ENV === 'development' ? 'test/' : '';
+}
+
+function stripePaymentUrl(chargeId: string): string {
+  return `https://dashboard.stripe.com/${stripeDashboardPrefix()}payments/${chargeId}`;
+}
+
+function stripeCustomerUrl(customerId: string): string {
+  return `https://dashboard.stripe.com/${stripeDashboardPrefix()}customers/${customerId}`;
+}

--- a/apps/web/src/app/admin/early-fraud-warnings/page.tsx
+++ b/apps/web/src/app/admin/early-fraud-warnings/page.tsx
@@ -1,0 +1,17 @@
+import AdminPage from '@/app/admin/components/AdminPage';
+import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
+import { EarlyFraudWarningsContent } from './EarlyFraudWarningsContent';
+
+const breadcrumbs = (
+  <BreadcrumbItem>
+    <BreadcrumbPage>Early Fraud Warnings</BreadcrumbPage>
+  </BreadcrumbItem>
+);
+
+export default function EarlyFraudWarningsPage() {
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <EarlyFraudWarningsContent />
+    </AdminPage>
+  );
+}

--- a/apps/web/src/lib/stripe/early-fraud-warning.ts
+++ b/apps/web/src/lib/stripe/early-fraud-warning.ts
@@ -1,0 +1,230 @@
+import 'server-only';
+
+import { captureException } from '@sentry/nextjs';
+import {
+  kilocode_users,
+  organizations,
+  stripe_early_fraud_warning_cases,
+} from '@kilocode/db/schema';
+import {
+  StripeEarlyFraudWarningCaseStatus,
+  StripeEarlyFraudWarningOwnerClassification,
+  type StripeEarlyFraudWarningOwnerClassification as OwnerClassification,
+} from '@kilocode/db/schema-types';
+import { and, eq, isNull } from 'drizzle-orm';
+import type Stripe from 'stripe';
+
+import { db } from '@/lib/drizzle';
+import { client } from '@/lib/stripe-client';
+
+type StripeReference = string | { id: string } | null | undefined;
+
+type EarlyFraudWarningReference = {
+  id: string;
+  charge: StripeReference;
+  payment_intent?: StripeReference;
+  created?: number;
+};
+
+type ObserveEarlyFraudWarningParams = {
+  eventId: string;
+  eventCreated: number;
+  earlyFraudWarning: EarlyFraudWarningReference;
+};
+
+type OwnerResolution = {
+  classification: OwnerClassification;
+  kiloUserId: string | null;
+  organizationId: string | null;
+  reason: string;
+};
+
+type ReviewCaseValues = {
+  eventId: string;
+  earlyFraudWarningId: string;
+  chargeId: string | null;
+  paymentIntentId: string | null;
+  customerId: string | null;
+  amountMinorUnits: number | null;
+  currency: string | null;
+  owner: OwnerResolution;
+  warningCreatedAt: string;
+  failureContext?: string | null;
+};
+
+function stripeReferenceId(reference: StripeReference): string | null {
+  if (typeof reference === 'string') {
+    return reference || null;
+  }
+
+  return reference?.id || null;
+}
+
+async function resolveOwner(customerId: string | null): Promise<OwnerResolution> {
+  if (!customerId) {
+    return {
+      classification: StripeEarlyFraudWarningOwnerClassification.Unmatched,
+      kiloUserId: null,
+      organizationId: null,
+      reason: 'Warned charge has no Stripe customer; manual review required',
+    };
+  }
+
+  const [personalOwners, organizationOwners] = await Promise.all([
+    db
+      .select({ id: kilocode_users.id })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.stripe_customer_id, customerId))
+      .limit(2),
+    db
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(
+        and(eq(organizations.stripe_customer_id, customerId), isNull(organizations.deleted_at))
+      )
+      .limit(2),
+  ]);
+
+  if (personalOwners.length === 1 && organizationOwners.length === 0) {
+    return {
+      classification: StripeEarlyFraudWarningOwnerClassification.Personal,
+      kiloUserId: personalOwners[0].id,
+      organizationId: null,
+      reason: 'Observation only: canonical personal owner matched; manual review required',
+    };
+  }
+
+  if (personalOwners.length === 0 && organizationOwners.length === 1) {
+    return {
+      classification: StripeEarlyFraudWarningOwnerClassification.Organization,
+      kiloUserId: null,
+      organizationId: organizationOwners[0].id,
+      reason: 'Organization-owned warning; manual review required',
+    };
+  }
+
+  if (personalOwners.length === 0 && organizationOwners.length === 0) {
+    return {
+      classification: StripeEarlyFraudWarningOwnerClassification.Unmatched,
+      kiloUserId: null,
+      organizationId: null,
+      reason: 'No canonical customer owner matched; manual review required',
+    };
+  }
+
+  return {
+    classification: StripeEarlyFraudWarningOwnerClassification.Ambiguous,
+    kiloUserId: null,
+    organizationId: null,
+    reason: 'Canonical customer ownership is ambiguous; manual review required',
+  };
+}
+
+async function persistReviewCase(values: ReviewCaseValues): Promise<void> {
+  await db
+    .insert(stripe_early_fraud_warning_cases)
+    .values({
+      stripe_early_fraud_warning_id: values.earlyFraudWarningId,
+      stripe_event_id: values.eventId,
+      stripe_charge_id: values.chargeId,
+      stripe_payment_intent_id: values.paymentIntentId,
+      stripe_customer_id: values.customerId,
+      amount_minor_units: values.amountMinorUnits,
+      currency: values.currency,
+      owner_classification: values.owner.classification,
+      kilo_user_id: values.owner.kiloUserId,
+      organization_id: values.owner.organizationId,
+      status: StripeEarlyFraudWarningCaseStatus.ReviewRequired,
+      reason: values.owner.reason,
+      failure_context: values.failureContext ?? null,
+      warning_created_at: values.warningCreatedAt,
+      review_required_at: new Date().toISOString(),
+    })
+    .onConflictDoNothing({
+      target: [stripe_early_fraud_warning_cases.stripe_early_fraud_warning_id],
+    });
+}
+
+export async function observeStripeEarlyFraudWarningCreated({
+  eventId,
+  eventCreated,
+  earlyFraudWarning,
+}: ObserveEarlyFraudWarningParams): Promise<Stripe.Charge | null> {
+  const chargeId = stripeReferenceId(earlyFraudWarning.charge);
+  const warningCreatedAt = new Date(
+    (earlyFraudWarning.created ?? eventCreated) * 1000
+  ).toISOString();
+  const paymentIntentId = stripeReferenceId(earlyFraudWarning.payment_intent);
+
+  if (!chargeId) {
+    await persistReviewCase({
+      eventId,
+      earlyFraudWarningId: earlyFraudWarning.id,
+      chargeId: null,
+      paymentIntentId,
+      customerId: null,
+      amountMinorUnits: null,
+      currency: null,
+      owner: {
+        classification: StripeEarlyFraudWarningOwnerClassification.Unmatched,
+        kiloUserId: null,
+        organizationId: null,
+        reason: 'Warning does not identify a charge; manual review required',
+      },
+      warningCreatedAt,
+    });
+    return null;
+  }
+
+  let charge: Stripe.Charge;
+  try {
+    charge = await client.charges.retrieve(chargeId);
+  } catch (error) {
+    captureException(error, {
+      tags: { source: 'stripe_early_fraud_warning_observation' },
+      extra: {
+        stripe_event_id: eventId,
+        stripe_early_fraud_warning_id: earlyFraudWarning.id,
+        stripe_charge_id: chargeId,
+      },
+    });
+    await persistReviewCase({
+      eventId,
+      earlyFraudWarningId: earlyFraudWarning.id,
+      chargeId,
+      paymentIntentId,
+      customerId: null,
+      amountMinorUnits: null,
+      currency: null,
+      owner: {
+        classification: StripeEarlyFraudWarningOwnerClassification.Unmatched,
+        kiloUserId: null,
+        organizationId: null,
+        reason: 'Charge context retrieval failed; manual review required',
+      },
+      warningCreatedAt,
+      failureContext: 'Stripe charge retrieval failed during warning observation',
+    });
+    return null;
+  }
+
+  const owner = await resolveOwner(stripeReferenceId(charge.customer));
+  await persistReviewCase({
+    eventId,
+    earlyFraudWarningId: earlyFraudWarning.id,
+    chargeId,
+    paymentIntentId: paymentIntentId ?? stripeReferenceId(charge.payment_intent),
+    customerId: stripeReferenceId(charge.customer),
+    amountMinorUnits: charge.amount,
+    currency: charge.currency,
+    owner: charge.disputed
+      ? {
+          ...owner,
+          reason: 'Warned charge is already disputed; manual review required',
+        }
+      : owner,
+    warningCreatedAt,
+  });
+
+  return charge;
+}

--- a/apps/web/src/lib/stripe/early-fraud-warning.ts
+++ b/apps/web/src/lib/stripe/early-fraud-warning.ts
@@ -11,7 +11,7 @@ import {
   StripeEarlyFraudWarningOwnerClassification,
   type StripeEarlyFraudWarningOwnerClassification as OwnerClassification,
 } from '@kilocode/db/schema-types';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, like, not, or } from 'drizzle-orm';
 import type Stripe from 'stripe';
 
 import { db } from '@/lib/drizzle';
@@ -74,7 +74,15 @@ async function resolveOwner(customerId: string | null): Promise<OwnerResolution>
     db
       .select({ id: kilocode_users.id })
       .from(kilocode_users)
-      .where(eq(kilocode_users.stripe_customer_id, customerId))
+      .where(
+        and(
+          eq(kilocode_users.stripe_customer_id, customerId),
+          or(
+            isNull(kilocode_users.blocked_reason),
+            not(like(kilocode_users.blocked_reason, 'soft-deleted at %'))
+          )
+        )
+      )
       .limit(2),
     db
       .select({ id: organizations.id })

--- a/apps/web/src/lib/stripe/early-fraud-warning.ts
+++ b/apps/web/src/lib/stripe/early-fraud-warning.ts
@@ -14,7 +14,7 @@ import {
 import { and, eq, isNull, like, not, or } from 'drizzle-orm';
 import type Stripe from 'stripe';
 
-import { db } from '@/lib/drizzle';
+import { db, type DrizzleTransaction } from '@/lib/drizzle';
 import { client } from '@/lib/stripe-client';
 
 type StripeReference = string | { id: string } | null | undefined;
@@ -60,7 +60,10 @@ function stripeReferenceId(reference: StripeReference): string | null {
   return reference?.id || null;
 }
 
-async function resolveOwner(customerId: string | null): Promise<OwnerResolution> {
+async function resolveOwner(
+  database: DrizzleTransaction,
+  customerId: string | null
+): Promise<OwnerResolution> {
   if (!customerId) {
     return {
       classification: StripeEarlyFraudWarningOwnerClassification.Unmatched,
@@ -70,28 +73,26 @@ async function resolveOwner(customerId: string | null): Promise<OwnerResolution>
     };
   }
 
-  const [personalOwners, organizationOwners] = await Promise.all([
-    db
-      .select({ id: kilocode_users.id })
-      .from(kilocode_users)
-      .where(
-        and(
-          eq(kilocode_users.stripe_customer_id, customerId),
-          or(
-            isNull(kilocode_users.blocked_reason),
-            not(like(kilocode_users.blocked_reason, 'soft-deleted at %'))
-          )
+  // Keep the case insert ordered with softDeleteUser's link scrubbing for matched user rows.
+  const personalOwners = await database
+    .select({ id: kilocode_users.id })
+    .from(kilocode_users)
+    .where(
+      and(
+        eq(kilocode_users.stripe_customer_id, customerId),
+        or(
+          isNull(kilocode_users.blocked_reason),
+          not(like(kilocode_users.blocked_reason, 'soft-deleted at %'))
         )
       )
-      .limit(2),
-    db
-      .select({ id: organizations.id })
-      .from(organizations)
-      .where(
-        and(eq(organizations.stripe_customer_id, customerId), isNull(organizations.deleted_at))
-      )
-      .limit(2),
-  ]);
+    )
+    .limit(2)
+    .for('update');
+  const organizationOwners = await database
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(and(eq(organizations.stripe_customer_id, customerId), isNull(organizations.deleted_at)))
+    .limit(2);
 
   if (personalOwners.length === 1 && organizationOwners.length === 0) {
     return {
@@ -128,8 +129,11 @@ async function resolveOwner(customerId: string | null): Promise<OwnerResolution>
   };
 }
 
-async function persistReviewCase(values: ReviewCaseValues): Promise<void> {
-  await db
+async function persistReviewCase(
+  database: typeof db | DrizzleTransaction,
+  values: ReviewCaseValues
+): Promise<void> {
+  await database
     .insert(stripe_early_fraud_warning_cases)
     .values({
       stripe_early_fraud_warning_id: values.earlyFraudWarningId,
@@ -165,7 +169,7 @@ export async function observeStripeEarlyFraudWarningCreated({
   const paymentIntentId = stripeReferenceId(earlyFraudWarning.payment_intent);
 
   if (!chargeId) {
-    await persistReviewCase({
+    await persistReviewCase(db, {
       eventId,
       earlyFraudWarningId: earlyFraudWarning.id,
       chargeId: null,
@@ -196,7 +200,7 @@ export async function observeStripeEarlyFraudWarningCreated({
         stripe_charge_id: chargeId,
       },
     });
-    await persistReviewCase({
+    await persistReviewCase(db, {
       eventId,
       earlyFraudWarningId: earlyFraudWarning.id,
       chargeId,
@@ -216,22 +220,24 @@ export async function observeStripeEarlyFraudWarningCreated({
     return null;
   }
 
-  const owner = await resolveOwner(stripeReferenceId(charge.customer));
-  await persistReviewCase({
-    eventId,
-    earlyFraudWarningId: earlyFraudWarning.id,
-    chargeId,
-    paymentIntentId: paymentIntentId ?? stripeReferenceId(charge.payment_intent),
-    customerId: stripeReferenceId(charge.customer),
-    amountMinorUnits: charge.amount,
-    currency: charge.currency,
-    owner: charge.disputed
-      ? {
-          ...owner,
-          reason: 'Warned charge is already disputed; manual review required',
-        }
-      : owner,
-    warningCreatedAt,
+  await db.transaction(async tx => {
+    const owner = await resolveOwner(tx, stripeReferenceId(charge.customer));
+    await persistReviewCase(tx, {
+      eventId,
+      earlyFraudWarningId: earlyFraudWarning.id,
+      chargeId,
+      paymentIntentId: paymentIntentId ?? stripeReferenceId(charge.payment_intent),
+      customerId: stripeReferenceId(charge.customer),
+      amountMinorUnits: charge.amount,
+      currency: charge.currency,
+      owner: charge.disputed
+        ? {
+            ...owner,
+            reason: 'Warned charge is already disputed; manual review required',
+          }
+        : owner,
+      warningCreatedAt,
+    });
   });
 
   return charge;

--- a/apps/web/src/lib/stripe/index.test.ts
+++ b/apps/web/src/lib/stripe/index.test.ts
@@ -74,6 +74,8 @@ import {
   kilocode_users,
   auto_top_up_configs,
   pending_impact_sale_reversals,
+  stripe_early_fraud_warning_actions,
+  stripe_early_fraud_warning_cases,
   user_affiliate_attributions,
   user_affiliate_events,
 } from '@kilocode/db/schema';
@@ -338,6 +340,32 @@ const sampleStripeChargeResponse = (
     ...overrides,
     lastResponse: { headers: {}, requestId: 'req_test', statusCode: 200 },
   }) as Stripe.Response<Stripe.Charge>;
+
+function sampleEarlyFraudWarningEvent(params: {
+  eventId: string;
+  warningId: string;
+  charge: string | null;
+  paymentIntent?: string | null;
+}): Stripe.Event {
+  return {
+    ...baseStripeEvent(),
+    id: params.eventId,
+    data: {
+      object: {
+        id: params.warningId,
+        object: 'radar.early_fraud_warning',
+        actionable: true,
+        charge: params.charge,
+        created: 1234567890,
+        fraud_type: 'stolen_card',
+        livemode: false,
+        payment_intent: params.paymentIntent ?? null,
+      },
+      previous_attributes: {},
+    },
+    type: 'radar.early_fraud_warning.created',
+  } as unknown as Stripe.Event;
+}
 
 async function waitForReportEventsCall() {
   for (let attempt = 0; attempt < 10; attempt++) {
@@ -787,36 +815,52 @@ describe('processStripePaymentEventHook', () => {
     });
   });
 
-  test('radar.early_fraud_warning.created resolves charge customer for abuse service', async () => {
+  test('radar.early_fraud_warning.created persists a personal observation and preserves abuse telemetry', async () => {
+    await cleanupDbForTest();
+    testUser = await insertTestUser();
     const { client } = await import('@/lib/stripe-client');
     const retrieveSpy = jest.spyOn(client.charges, 'retrieve').mockResolvedValue(
       sampleStripeChargeResponse(
         sampleStripeCharge({
           id: 'ch_radar_123',
+          amount: 1900,
+          currency: 'usd',
           customer: testUser.stripe_customer_id,
           payment_intent: 'pi_radar_123',
         })
       )
     );
 
-    const event = {
-      ...baseStripeEvent(),
-      id: 'evt_radar_warning',
-      data: {
-        object: {
-          id: 'issfr_123',
-          object: 'radar.early_fraud_warning',
-          charge: 'ch_radar_123',
-          payment_intent: null,
-        },
-        previous_attributes: {},
-      },
-      type: 'radar.early_fraud_warning.created',
-    } as unknown as Stripe.Event;
-
-    await processStripePaymentEventHook(event);
+    await processStripePaymentEventHook(
+      sampleEarlyFraudWarningEvent({
+        eventId: 'evt_radar_warning',
+        warningId: 'issfr_123',
+        charge: 'ch_radar_123',
+      })
+    );
     await waitForReportEventsCall();
 
+    const [fraudCase] = await db.select().from(stripe_early_fraud_warning_cases);
+    const actions = await db.select().from(stripe_early_fraud_warning_actions);
+    expect(fraudCase).toEqual(
+      expect.objectContaining({
+        stripe_early_fraud_warning_id: 'issfr_123',
+        stripe_event_id: 'evt_radar_warning',
+        stripe_charge_id: 'ch_radar_123',
+        stripe_payment_intent_id: 'pi_radar_123',
+        stripe_customer_id: testUser.stripe_customer_id,
+        amount_minor_units: 1900,
+        currency: 'usd',
+        owner_classification: 'personal',
+        kilo_user_id: testUser.id,
+        organization_id: null,
+        status: 'review_required',
+        reason: 'Observation only: canonical personal owner matched; manual review required',
+      })
+    );
+    expect(fraudCase.review_required_at).not.toBeNull();
+    expect(actions).toHaveLength(0);
+    expect(retrieveSpy).toHaveBeenCalledTimes(1);
     expect(retrieveSpy).toHaveBeenCalledWith('ch_radar_123');
     expect(reportEventsMock).toHaveBeenCalledWith({
       events: [
@@ -830,6 +874,263 @@ describe('processStripePaymentEventHook', () => {
             customer: testUser.stripe_customer_id,
             payment_intent: 'pi_radar_123',
             early_fraud_warning: 'issfr_123',
+          },
+        },
+      ],
+    });
+
+    retrieveSpy.mockRestore();
+  });
+
+  test('radar.early_fraud_warning.created deduplicates repeated delivery without creating actions', async () => {
+    await cleanupDbForTest();
+    testUser = await insertTestUser();
+    const { client } = await import('@/lib/stripe-client');
+    const retrieveSpy = jest
+      .spyOn(client.charges, 'retrieve')
+      .mockResolvedValue(
+        sampleStripeChargeResponse(
+          sampleStripeCharge({ id: 'ch_duplicate', customer: testUser.stripe_customer_id })
+        )
+      );
+
+    await processStripePaymentEventHook(
+      sampleEarlyFraudWarningEvent({
+        eventId: 'evt_duplicate_first',
+        warningId: 'issfr_duplicate',
+        charge: 'ch_duplicate',
+      })
+    );
+    await processStripePaymentEventHook(
+      sampleEarlyFraudWarningEvent({
+        eventId: 'evt_duplicate_second',
+        warningId: 'issfr_duplicate',
+        charge: 'ch_duplicate',
+      })
+    );
+
+    const fraudCases = await db.select().from(stripe_early_fraud_warning_cases);
+    const actions = await db.select().from(stripe_early_fraud_warning_actions);
+    expect(fraudCases).toHaveLength(1);
+    expect(fraudCases[0]).toEqual(
+      expect.objectContaining({
+        stripe_event_id: 'evt_duplicate_first',
+        stripe_early_fraud_warning_id: 'issfr_duplicate',
+        status: 'review_required',
+      })
+    );
+    expect(actions).toHaveLength(0);
+    expect(retrieveSpy).toHaveBeenCalledTimes(2);
+
+    retrieveSpy.mockRestore();
+  });
+
+  test('radar.early_fraud_warning.created classifies organization ownership for review only', async () => {
+    await cleanupDbForTest();
+    const [organization] = await db
+      .insert(organizations)
+      .values({ name: 'Warning Review Organization', stripe_customer_id: 'cus_efw_organization' })
+      .returning();
+    const { client } = await import('@/lib/stripe-client');
+    const retrieveSpy = jest
+      .spyOn(client.charges, 'retrieve')
+      .mockResolvedValue(
+        sampleStripeChargeResponse(
+          sampleStripeCharge({ id: 'ch_organization', customer: 'cus_efw_organization' })
+        )
+      );
+
+    await processStripePaymentEventHook(
+      sampleEarlyFraudWarningEvent({
+        eventId: 'evt_organization',
+        warningId: 'issfr_organization',
+        charge: 'ch_organization',
+      })
+    );
+
+    const [fraudCase] = await db.select().from(stripe_early_fraud_warning_cases);
+    expect(fraudCase).toEqual(
+      expect.objectContaining({
+        owner_classification: 'organization',
+        kilo_user_id: null,
+        organization_id: organization.id,
+        status: 'review_required',
+        reason: 'Organization-owned warning; manual review required',
+      })
+    );
+    expect(await db.select().from(stripe_early_fraud_warning_actions)).toHaveLength(0);
+
+    retrieveSpy.mockRestore();
+  });
+
+  test('radar.early_fraud_warning.created retains ambiguous customer ownership without owner links', async () => {
+    await cleanupDbForTest();
+    testUser = await insertTestUser({ stripe_customer_id: 'cus_efw_shared' });
+    await db
+      .insert(organizations)
+      .values({ name: 'Shared Customer Organization', stripe_customer_id: 'cus_efw_shared' });
+    const { client } = await import('@/lib/stripe-client');
+    const retrieveSpy = jest
+      .spyOn(client.charges, 'retrieve')
+      .mockResolvedValue(
+        sampleStripeChargeResponse(
+          sampleStripeCharge({ id: 'ch_shared', customer: 'cus_efw_shared' })
+        )
+      );
+
+    await processStripePaymentEventHook(
+      sampleEarlyFraudWarningEvent({
+        eventId: 'evt_ambiguous',
+        warningId: 'issfr_ambiguous',
+        charge: 'ch_shared',
+      })
+    );
+
+    const [fraudCase] = await db.select().from(stripe_early_fraud_warning_cases);
+    expect(fraudCase).toEqual(
+      expect.objectContaining({
+        owner_classification: 'ambiguous',
+        kilo_user_id: null,
+        organization_id: null,
+        status: 'review_required',
+        reason: 'Canonical customer ownership is ambiguous; manual review required',
+      })
+    );
+    expect(await db.select().from(stripe_early_fraud_warning_actions)).toHaveLength(0);
+
+    retrieveSpy.mockRestore();
+  });
+
+  test('radar.early_fraud_warning.created retains an already disputed charge for manual review', async () => {
+    await cleanupDbForTest();
+    testUser = await insertTestUser();
+    const { client } = await import('@/lib/stripe-client');
+    const retrieveSpy = jest.spyOn(client.charges, 'retrieve').mockResolvedValue(
+      sampleStripeChargeResponse(
+        sampleStripeCharge({
+          id: 'ch_disputed_warning',
+          customer: testUser.stripe_customer_id,
+          disputed: true,
+        })
+      )
+    );
+
+    await processStripePaymentEventHook(
+      sampleEarlyFraudWarningEvent({
+        eventId: 'evt_disputed_warning',
+        warningId: 'issfr_disputed_warning',
+        charge: 'ch_disputed_warning',
+      })
+    );
+
+    const [fraudCase] = await db.select().from(stripe_early_fraud_warning_cases);
+    expect(fraudCase).toEqual(
+      expect.objectContaining({
+        owner_classification: 'personal',
+        kilo_user_id: testUser.id,
+        status: 'review_required',
+        reason: 'Warned charge is already disputed; manual review required',
+      })
+    );
+    expect(await db.select().from(stripe_early_fraud_warning_actions)).toHaveLength(0);
+
+    retrieveSpy.mockRestore();
+  });
+
+  test('radar.early_fraud_warning.created retains unmatched and malformed warnings for review', async () => {
+    await cleanupDbForTest();
+    const { client } = await import('@/lib/stripe-client');
+    const retrieveSpy = jest
+      .spyOn(client.charges, 'retrieve')
+      .mockResolvedValue(
+        sampleStripeChargeResponse(
+          sampleStripeCharge({ id: 'ch_unmatched', customer: 'cus_unknown' })
+        )
+      );
+
+    await processStripePaymentEventHook(
+      sampleEarlyFraudWarningEvent({
+        eventId: 'evt_unmatched',
+        warningId: 'issfr_unmatched',
+        charge: 'ch_unmatched',
+      })
+    );
+    await processStripePaymentEventHook(
+      sampleEarlyFraudWarningEvent({
+        eventId: 'evt_malformed',
+        warningId: 'issfr_malformed',
+        charge: null,
+      })
+    );
+
+    const fraudCases = await db
+      .select()
+      .from(stripe_early_fraud_warning_cases)
+      .orderBy(stripe_early_fraud_warning_cases.stripe_early_fraud_warning_id);
+    expect(fraudCases).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stripe_early_fraud_warning_id: 'issfr_unmatched',
+          owner_classification: 'unmatched',
+          reason: 'No canonical customer owner matched; manual review required',
+        }),
+        expect.objectContaining({
+          stripe_early_fraud_warning_id: 'issfr_malformed',
+          stripe_charge_id: null,
+          owner_classification: 'unmatched',
+          reason: 'Warning does not identify a charge; manual review required',
+        }),
+      ])
+    );
+    expect(fraudCases.every(fraudCase => fraudCase.status === 'review_required')).toBe(true);
+    expect(await db.select().from(stripe_early_fraud_warning_actions)).toHaveLength(0);
+    expect(retrieveSpy).toHaveBeenCalledTimes(1);
+
+    retrieveSpy.mockRestore();
+  });
+
+  test('radar.early_fraud_warning.created records retrieval failures as safe review cases', async () => {
+    await cleanupDbForTest();
+    const { client } = await import('@/lib/stripe-client');
+    const retrieveSpy = jest
+      .spyOn(client.charges, 'retrieve')
+      .mockRejectedValue(new Error('Temporary Stripe retrieval failure'));
+
+    await processStripePaymentEventHook(
+      sampleEarlyFraudWarningEvent({
+        eventId: 'evt_retrieval_failed',
+        warningId: 'issfr_retrieval_failed',
+        charge: 'ch_retrieval_failed',
+        paymentIntent: 'pi_retrieval_failed',
+      })
+    );
+    await waitForReportEventsCall();
+
+    const [fraudCase] = await db.select().from(stripe_early_fraud_warning_cases);
+    expect(fraudCase).toEqual(
+      expect.objectContaining({
+        stripe_charge_id: 'ch_retrieval_failed',
+        stripe_payment_intent_id: 'pi_retrieval_failed',
+        stripe_customer_id: null,
+        owner_classification: 'unmatched',
+        status: 'review_required',
+        reason: 'Charge context retrieval failed; manual review required',
+        failure_context: 'Stripe charge retrieval failed during warning observation',
+      })
+    );
+    expect(await db.select().from(stripe_early_fraud_warning_actions)).toHaveLength(0);
+    expect(retrieveSpy).toHaveBeenCalledTimes(1);
+    expect(reportEventsMock).toHaveBeenCalledWith({
+      events: [
+        {
+          type: 'stripe.radar.early_fraud_warning.created',
+          occurred_at: 1234567890000,
+          data: {
+            id: 'evt_retrieval_failed',
+            type: 'radar.early_fraud_warning.created',
+            charge: 'ch_retrieval_failed',
+            payment_intent: 'pi_retrieval_failed',
+            early_fraud_warning: 'issfr_retrieval_failed',
           },
         },
       ],

--- a/apps/web/src/lib/stripe/index.test.ts
+++ b/apps/web/src/lib/stripe/index.test.ts
@@ -920,6 +920,54 @@ describe('processStripePaymentEventHook', () => {
     retrieveSpy.mockRestore();
   });
 
+  test('radar.early_fraud_warning.created does not link a case during concurrent soft deletion', async () => {
+    await cleanupDbForTest();
+    testUser = await insertTestUser();
+    const { client } = await import('@/lib/stripe-client');
+    const retrieveSpy = jest.spyOn(client.charges, 'retrieve').mockResolvedValue(
+      sampleStripeChargeResponse(
+        sampleStripeCharge({
+          id: 'ch_deleting_customer',
+          customer: testUser.stripe_customer_id,
+        })
+      )
+    );
+    let observationPromise: Promise<void> | null = null;
+
+    await db.transaction(async tx => {
+      await tx
+        .update(kilocode_users)
+        .set({ blocked_reason: 'soft-deleted at 2026-05-28T12:00:00.000Z' })
+        .where(eq(kilocode_users.id, testUser.id));
+      observationPromise = processStripePaymentEventHook(
+        sampleEarlyFraudWarningEvent({
+          eventId: 'evt_deleting_customer',
+          warningId: 'issfr_deleting_customer',
+          charge: 'ch_deleting_customer',
+        })
+      );
+      await new Promise(resolve => setImmediate(resolve));
+    });
+
+    if (!observationPromise) {
+      throw new Error('Observation did not start during deletion transaction');
+    }
+    await observationPromise;
+
+    const [fraudCase] = await db.select().from(stripe_early_fraud_warning_cases);
+    expect(fraudCase).toEqual(
+      expect.objectContaining({
+        stripe_customer_id: testUser.stripe_customer_id,
+        owner_classification: 'unmatched',
+        kilo_user_id: null,
+        status: 'review_required',
+      })
+    );
+    expect(await db.select().from(stripe_early_fraud_warning_actions)).toHaveLength(0);
+
+    retrieveSpy.mockRestore();
+  });
+
   test('radar.early_fraud_warning.created deduplicates repeated delivery without creating actions', async () => {
     await cleanupDbForTest();
     testUser = await insertTestUser();

--- a/apps/web/src/lib/stripe/index.test.ts
+++ b/apps/web/src/lib/stripe/index.test.ts
@@ -81,6 +81,7 @@ import {
 } from '@kilocode/db/schema';
 import { db, auto_deleted_at } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
+import { softDeleteUser } from '@/lib/user';
 import { createTestPaymentMethod } from '@/tests/helpers/payment-method.helper';
 import { eq, and, count } from 'drizzle-orm';
 import type Stripe from 'stripe';
@@ -878,6 +879,43 @@ describe('processStripePaymentEventHook', () => {
         },
       ],
     });
+
+    retrieveSpy.mockRestore();
+  });
+
+  test('radar.early_fraud_warning.created does not link a new case to a soft-deleted user', async () => {
+    await cleanupDbForTest();
+    testUser = await insertTestUser();
+    await softDeleteUser(testUser.id);
+    const { client } = await import('@/lib/stripe-client');
+    const retrieveSpy = jest.spyOn(client.charges, 'retrieve').mockResolvedValue(
+      sampleStripeChargeResponse(
+        sampleStripeCharge({
+          id: 'ch_deleted_customer',
+          customer: testUser.stripe_customer_id,
+        })
+      )
+    );
+
+    await processStripePaymentEventHook(
+      sampleEarlyFraudWarningEvent({
+        eventId: 'evt_deleted_customer',
+        warningId: 'issfr_deleted_customer',
+        charge: 'ch_deleted_customer',
+      })
+    );
+
+    const [fraudCase] = await db.select().from(stripe_early_fraud_warning_cases);
+    expect(fraudCase).toEqual(
+      expect.objectContaining({
+        stripe_customer_id: testUser.stripe_customer_id,
+        owner_classification: 'unmatched',
+        kilo_user_id: null,
+        status: 'review_required',
+        reason: 'No canonical customer owner matched; manual review required',
+      })
+    );
+    expect(await db.select().from(stripe_early_fraud_warning_actions)).toHaveLength(0);
 
     retrieveSpy.mockRestore();
   });

--- a/apps/web/src/lib/stripe/index.ts
+++ b/apps/web/src/lib/stripe/index.ts
@@ -69,6 +69,7 @@ import {
 import type { OrganizationPlan, BillingCycle } from '@/lib/organizations/organization-types';
 import { isSeatLineItem } from '@/lib/organizations/stripe-seat-line-items';
 import { successResult } from '@/lib/maybe-result';
+import { observeStripeEarlyFraudWarningCreated } from '@/lib/stripe/early-fraud-warning';
 
 type KiloClawChargeContext = {
   chargeId: string;
@@ -165,7 +166,7 @@ async function reportChargeBackedStripeAbuseEvent(params: {
   const chargeId = stripeReferenceId(params.charge);
   let charge: Stripe.Charge | null = params.preFetchedCharge ?? null;
 
-  if (!charge && chargeId) {
+  if (params.preFetchedCharge === undefined && chargeId) {
     try {
       charge = await client.charges.retrieve(chargeId);
     } catch (error) {
@@ -1242,6 +1243,11 @@ export async function processStripePaymentEventHook(event: Stripe.Event) {
 
     case 'radar.early_fraud_warning.created': {
       const earlyFraudWarning = event.data.object;
+      const observedCharge = await observeStripeEarlyFraudWarningCreated({
+        eventId: event.id,
+        eventCreated: event.created,
+        earlyFraudWarning,
+      });
       void reportChargeBackedStripeAbuseEvent({
         abuseEventType: 'stripe.radar.early_fraud_warning.created',
         eventId: event.id,
@@ -1250,6 +1256,7 @@ export async function processStripePaymentEventHook(event: Stripe.Event) {
         charge: earlyFraudWarning.charge,
         paymentIntent: earlyFraudWarning.payment_intent,
         data: { early_fraud_warning: earlyFraudWarning.id },
+        preFetchedCharge: observedCharge,
       });
       break;
     }

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -46,6 +46,7 @@ import { adminBlacklistDomainsRouter } from '@/routers/admin/blacklist-domains-r
 import { adminBulkBlockRouter } from '@/routers/admin/bulk-block-router';
 import { adminKiloPassRouter } from '@/routers/admin/kilo-pass-router';
 import { adminKiloclawReferralsRouter } from '@/routers/admin/kiloclaw-referrals-router';
+import { adminStripeEarlyFraudWarningsRouter } from '@/routers/admin/stripe-early-fraud-warnings-router';
 import { adminShellSecurityContentRouter } from '@/routers/admin/shell-security-content-router';
 import { adminWebhookTriggersRouter } from '@/routers/admin-webhook-triggers-router';
 import { adminAlertingRouter } from '@/routers/admin-alerting-router';
@@ -1891,6 +1892,7 @@ export const adminRouter = createTRPCRouter({
   blacklistDomains: adminBlacklistDomainsRouter,
   bulkBlock: adminBulkBlockRouter,
   kiloPass: adminKiloPassRouter,
+  earlyFraudWarnings: adminStripeEarlyFraudWarningsRouter,
   // Key kept as `securityAdvisorContent` for tRPC client compatibility —
   // admin UI consumers reference `trpc.admin.securityAdvisorContent.*`.
   // Backing router renamed to `adminShellSecurityContentRouter` as part of

--- a/apps/web/src/routers/admin/stripe-early-fraud-warnings-router.test.ts
+++ b/apps/web/src/routers/admin/stripe-early-fraud-warnings-router.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+import { cleanupDbForTest, db } from '@/lib/drizzle';
+import { createCallerForUser } from '@/routers/test-utils';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { organizations, stripe_early_fraud_warning_cases, type User } from '@kilocode/db/schema';
+import {
+  StripeEarlyFraudWarningCaseStatus,
+  StripeEarlyFraudWarningOwnerClassification,
+} from '@kilocode/db/schema-types';
+
+let admin: User;
+let nonAdmin: User;
+let personalOwner: User;
+
+beforeEach(async () => {
+  await cleanupDbForTest();
+  admin = await insertTestUser({
+    google_user_email: `admin-efw-${Math.random()}@admin.example.com`,
+    is_admin: true,
+  });
+  nonAdmin = await insertTestUser({
+    google_user_email: `non-admin-efw-${Math.random()}@example.com`,
+  });
+  personalOwner = await insertTestUser({
+    google_user_email: `personal-efw-${Math.random()}@example.com`,
+  });
+});
+
+describe('admin early fraud warnings list', () => {
+  it('rejects non-admin users', async () => {
+    const caller = await createCallerForUser(nonAdmin.id);
+
+    await expect(
+      caller.admin.earlyFraudWarnings.list({ page: 1, limit: 25 })
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+  });
+
+  it('returns read-only personal and organization warning rows with normalized timestamps', async () => {
+    const [organization] = await db
+      .insert(organizations)
+      .values({ name: 'Manual Review Org', stripe_customer_id: 'cus_review_org' })
+      .returning();
+    await db.insert(stripe_early_fraud_warning_cases).values([
+      {
+        stripe_early_fraud_warning_id: 'issfr_personal_list',
+        stripe_event_id: 'evt_personal_list',
+        stripe_charge_id: 'ch_personal_list',
+        stripe_payment_intent_id: 'pi_personal_list',
+        stripe_customer_id: personalOwner.stripe_customer_id,
+        amount_minor_units: 2900,
+        currency: 'usd',
+        owner_classification: StripeEarlyFraudWarningOwnerClassification.Personal,
+        kilo_user_id: personalOwner.id,
+        status: StripeEarlyFraudWarningCaseStatus.ReviewRequired,
+        reason: 'Observation only: canonical personal owner matched; manual review required',
+        warning_created_at: '2026-05-27 10:11:12.123+00',
+        review_required_at: '2026-05-27 10:11:13.123+00',
+      },
+      {
+        stripe_early_fraud_warning_id: 'issfr_organization_list',
+        stripe_event_id: 'evt_organization_list',
+        stripe_charge_id: 'ch_organization_list',
+        stripe_customer_id: 'cus_review_org',
+        amount_minor_units: 4500,
+        currency: 'eur',
+        owner_classification: StripeEarlyFraudWarningOwnerClassification.Organization,
+        organization_id: organization.id,
+        status: StripeEarlyFraudWarningCaseStatus.ReviewRequired,
+        reason: 'Organization-owned warning; manual review required',
+        warning_created_at: '2026-05-28 11:12:13.456+00',
+        review_required_at: '2026-05-28 11:12:14.456+00',
+      },
+    ]);
+
+    const caller = await createCallerForUser(admin.id);
+    const result = await caller.admin.earlyFraudWarnings.list({ page: 1, limit: 25 });
+
+    expect(result.pagination).toEqual({ page: 1, limit: 25, total: 2, totalPages: 1 });
+    expect(result.rows[0]).toEqual(
+      expect.objectContaining({
+        stripeEarlyFraudWarningId: 'issfr_organization_list',
+        ownerClassification: 'organization',
+        warningCreatedAt: '2026-05-28T11:12:13.456Z',
+        organization: { id: organization.id, name: 'Manual Review Org' },
+        user: null,
+      })
+    );
+    expect(result.rows[1]).toEqual(
+      expect.objectContaining({
+        stripeEarlyFraudWarningId: 'issfr_personal_list',
+        stripeChargeId: 'ch_personal_list',
+        amountMinorUnits: 2900,
+        ownerClassification: 'personal',
+        warningCreatedAt: '2026-05-27T10:11:12.123Z',
+        user: {
+          id: personalOwner.id,
+          email: personalOwner.google_user_email,
+          name: personalOwner.google_user_name,
+        },
+        organization: null,
+      })
+    );
+  });
+
+  it('paginates warning cases deterministically', async () => {
+    await db.insert(stripe_early_fraud_warning_cases).values([
+      {
+        stripe_early_fraud_warning_id: 'issfr_older',
+        stripe_event_id: 'evt_older',
+        owner_classification: StripeEarlyFraudWarningOwnerClassification.Unmatched,
+        status: StripeEarlyFraudWarningCaseStatus.ReviewRequired,
+        reason: 'No canonical customer owner matched; manual review required',
+        warning_created_at: '2026-05-26T00:00:00.000Z',
+      },
+      {
+        stripe_early_fraud_warning_id: 'issfr_newer',
+        stripe_event_id: 'evt_newer',
+        owner_classification: StripeEarlyFraudWarningOwnerClassification.Unmatched,
+        status: StripeEarlyFraudWarningCaseStatus.ReviewRequired,
+        reason: 'No canonical customer owner matched; manual review required',
+        warning_created_at: '2026-05-27T00:00:00.000Z',
+      },
+    ]);
+
+    const caller = await createCallerForUser(admin.id);
+    const firstPage = await caller.admin.earlyFraudWarnings.list({ page: 1, limit: 1 });
+    const secondPage = await caller.admin.earlyFraudWarnings.list({ page: 2, limit: 1 });
+
+    expect(firstPage.pagination).toEqual({ page: 1, limit: 1, total: 2, totalPages: 2 });
+    expect(firstPage.rows[0]?.stripeEarlyFraudWarningId).toBe('issfr_newer');
+    expect(secondPage.rows[0]?.stripeEarlyFraudWarningId).toBe('issfr_older');
+  });
+});

--- a/apps/web/src/routers/admin/stripe-early-fraud-warnings-router.test.ts
+++ b/apps/web/src/routers/admin/stripe-early-fraud-warnings-router.test.ts
@@ -105,7 +105,7 @@ describe('admin early fraud warnings list', () => {
     );
   });
 
-  it('paginates warning cases deterministically', async () => {
+  it('paginates dated warning cases before rows without warning timestamps', async () => {
     await db.insert(stripe_early_fraud_warning_cases).values([
       {
         stripe_early_fraud_warning_id: 'issfr_older',
@@ -123,14 +123,25 @@ describe('admin early fraud warnings list', () => {
         reason: 'No canonical customer owner matched; manual review required',
         warning_created_at: '2026-05-27T00:00:00.000Z',
       },
+      {
+        stripe_early_fraud_warning_id: 'issfr_missing_warning_time',
+        stripe_event_id: 'evt_missing_warning_time',
+        owner_classification: StripeEarlyFraudWarningOwnerClassification.Unmatched,
+        status: StripeEarlyFraudWarningCaseStatus.ReviewRequired,
+        reason: 'Warning timestamp missing; manual review required',
+        warning_created_at: null,
+      },
     ]);
 
     const caller = await createCallerForUser(admin.id);
     const firstPage = await caller.admin.earlyFraudWarnings.list({ page: 1, limit: 1 });
     const secondPage = await caller.admin.earlyFraudWarnings.list({ page: 2, limit: 1 });
+    const thirdPage = await caller.admin.earlyFraudWarnings.list({ page: 3, limit: 1 });
 
-    expect(firstPage.pagination).toEqual({ page: 1, limit: 1, total: 2, totalPages: 2 });
+    expect(firstPage.pagination).toEqual({ page: 1, limit: 1, total: 3, totalPages: 3 });
     expect(firstPage.rows[0]?.stripeEarlyFraudWarningId).toBe('issfr_newer');
     expect(secondPage.rows[0]?.stripeEarlyFraudWarningId).toBe('issfr_older');
+    expect(thirdPage.rows[0]?.stripeEarlyFraudWarningId).toBe('issfr_missing_warning_time');
+    expect(thirdPage.rows[0]?.warningCreatedAt).toBeNull();
   });
 });

--- a/apps/web/src/routers/admin/stripe-early-fraud-warnings-router.ts
+++ b/apps/web/src/routers/admin/stripe-early-fraud-warnings-router.ts
@@ -17,7 +17,7 @@ const EarlyFraudWarningListInputSchema = z.object({
 function normalizeTimestamp(value: string | null): string | null {
   if (!value) return null;
   const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? value : date.toISOString();
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
 export const adminStripeEarlyFraudWarningsRouter = createTRPCRouter({
@@ -57,7 +57,7 @@ export const adminStripeEarlyFraudWarningsRouter = createTRPCRouter({
         eq(organizations.id, stripe_early_fraud_warning_cases.organization_id)
       )
       .orderBy(
-        desc(stripe_early_fraud_warning_cases.warning_created_at),
+        sql`${stripe_early_fraud_warning_cases.warning_created_at} DESC NULLS LAST`,
         desc(stripe_early_fraud_warning_cases.created_at),
         desc(stripe_early_fraud_warning_cases.id)
       )

--- a/apps/web/src/routers/admin/stripe-early-fraud-warnings-router.ts
+++ b/apps/web/src/routers/admin/stripe-early-fraud-warnings-router.ts
@@ -1,0 +1,107 @@
+import { desc, eq, sql } from 'drizzle-orm';
+import * as z from 'zod';
+
+import { db } from '@/lib/drizzle';
+import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import {
+  kilocode_users,
+  organizations,
+  stripe_early_fraud_warning_cases,
+} from '@kilocode/db/schema';
+
+const EarlyFraudWarningListInputSchema = z.object({
+  page: z.number().int().positive().default(1),
+  limit: z.number().int().min(1).max(100).default(25),
+});
+
+function normalizeTimestamp(value: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toISOString();
+}
+
+export const adminStripeEarlyFraudWarningsRouter = createTRPCRouter({
+  list: adminProcedure.input(EarlyFraudWarningListInputSchema).query(async ({ input }) => {
+    const offset = (input.page - 1) * input.limit;
+    const rows = await db
+      .select({
+        id: stripe_early_fraud_warning_cases.id,
+        stripeEarlyFraudWarningId: stripe_early_fraud_warning_cases.stripe_early_fraud_warning_id,
+        stripeEventId: stripe_early_fraud_warning_cases.stripe_event_id,
+        stripeChargeId: stripe_early_fraud_warning_cases.stripe_charge_id,
+        stripePaymentIntentId: stripe_early_fraud_warning_cases.stripe_payment_intent_id,
+        stripeCustomerId: stripe_early_fraud_warning_cases.stripe_customer_id,
+        amountMinorUnits: stripe_early_fraud_warning_cases.amount_minor_units,
+        currency: stripe_early_fraud_warning_cases.currency,
+        ownerClassification: stripe_early_fraud_warning_cases.owner_classification,
+        status: stripe_early_fraud_warning_cases.status,
+        reason: stripe_early_fraud_warning_cases.reason,
+        failureContext: stripe_early_fraud_warning_cases.failure_context,
+        warningCreatedAt: stripe_early_fraud_warning_cases.warning_created_at,
+        reviewRequiredAt: stripe_early_fraud_warning_cases.review_required_at,
+        createdAt: stripe_early_fraud_warning_cases.created_at,
+        userId: kilocode_users.id,
+        userEmail: kilocode_users.google_user_email,
+        userName: kilocode_users.google_user_name,
+        organizationId: organizations.id,
+        organizationName: organizations.name,
+        total: sql<number>`count(*) OVER()::int`.as('total'),
+      })
+      .from(stripe_early_fraud_warning_cases)
+      .leftJoin(
+        kilocode_users,
+        eq(kilocode_users.id, stripe_early_fraud_warning_cases.kilo_user_id)
+      )
+      .leftJoin(
+        organizations,
+        eq(organizations.id, stripe_early_fraud_warning_cases.organization_id)
+      )
+      .orderBy(
+        desc(stripe_early_fraud_warning_cases.warning_created_at),
+        desc(stripe_early_fraud_warning_cases.created_at),
+        desc(stripe_early_fraud_warning_cases.id)
+      )
+      .limit(input.limit)
+      .offset(offset);
+
+    const total = rows[0]?.total ?? 0;
+    return {
+      rows: rows.map(row => ({
+        id: row.id,
+        stripeEarlyFraudWarningId: row.stripeEarlyFraudWarningId,
+        stripeEventId: row.stripeEventId,
+        stripeChargeId: row.stripeChargeId,
+        stripePaymentIntentId: row.stripePaymentIntentId,
+        stripeCustomerId: row.stripeCustomerId,
+        amountMinorUnits: row.amountMinorUnits,
+        currency: row.currency,
+        ownerClassification: row.ownerClassification,
+        status: row.status,
+        reason: row.reason,
+        failureContext: row.failureContext,
+        warningCreatedAt: normalizeTimestamp(row.warningCreatedAt),
+        reviewRequiredAt: normalizeTimestamp(row.reviewRequiredAt),
+        createdAt: normalizeTimestamp(row.createdAt),
+        user: row.userId
+          ? {
+              id: row.userId,
+              email: row.userEmail,
+              name: row.userName,
+            }
+          : null,
+        organization: row.organizationId
+          ? {
+              id: row.organizationId,
+              name: row.organizationName,
+            }
+          : null,
+      })),
+      pagination: {
+        page: input.page,
+        limit: input.limit,
+        total,
+        totalPages: Math.ceil(total / input.limit),
+      },
+    };
+  }),
+});


### PR DESCRIPTION
## Summary
- Capture newly delivered Stripe Early Fraud Warnings as idempotent `review_required` observations, resolving canonical ownership where safe while preserving the no-enforcement rollout boundary.
- Preserve existing abuse telemetry and record malformed, ambiguous, unmatched, already-disputed, or retrieval-failed warnings for financial review without scheduling side effects.
- Add an admin-only, read-only Financial list for captured warnings with stored account links and safe Stripe correlation identifiers.

## Verification
- Not completed: attempted an isolated browser pass for `/admin/early-fraud-warnings`, but Chrome DevTools MCP could not start because its browser profile was locked by another running browser instance.

## Visual Changes
<img width="4388" height="2708" alt="CleanShot 2026-05-28 at 13 26 01@2x" src="https://github.com/user-attachments/assets/fe152d3f-b705-451a-b964-2652ce7504e3" />

## Reviewer Notes
- Originally stacked on #3552; that foundation PR merged while this PR was under review, and GitHub retargeted this PR to `main`.
- Observation-only by design: this PR creates no enforcement actions and performs no blocks, refunds, credit changes, subscription or KiloClaw mutations, payout or reward reversals, or user notices.
- Follow-up review fixes normalize API timestamps, sort timestamp-less observations last, and prevent GDPR-soft-deleted users from being re-linked, including during concurrent deletion.