### PR TITLE
fix(cloud-agent): tolerate unknown stored metadata

### DIFF
--- a/services/cloud-agent-next/src/persistence/session-metadata.test.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.test.ts
@@ -229,10 +229,11 @@ describe('session metadata boundary', () => {
     });
   });
 
-  it('rejects current grouped metadata containing legacy images', () => {
-    expect(() =>
+  it('ignores unknown fields in current grouped metadata', () => {
+    expect(
       parseSessionMetadata({
         metadataSchemaVersion: 2,
+        unknownRootField: 'from-newer-writer',
         identity: { sessionId: 'agent_grouped_legacy', userId: 'user_123' },
         auth: {},
         initialMessage: {
@@ -242,10 +243,28 @@ describe('session metadata boundary', () => {
             path: '123e4567-e89b-12d3-a456-426614174000',
             files: ['123e4567-e89b-12d3-a456-426614174001.png'],
           },
+          turn: {
+            type: 'prompt',
+            prompt: 'old image turn',
+            images: {
+              path: '123e4567-e89b-12d3-a456-426614174000',
+              files: ['123e4567-e89b-12d3-a456-426614174001.png'],
+            },
+          },
         },
         lifecycle: { version: 1, timestamp: 1 },
       })
-    ).toThrow('Invalid current session metadata');
+    ).toEqual({
+      metadataSchemaVersion: 2,
+      identity: { sessionId: 'agent_grouped_legacy', userId: 'user_123' },
+      auth: {},
+      initialMessage: {
+        id: 'msg_018f1e2d3c4bAbCdEfGhIjKlMn',
+        prompt: 'old image turn',
+        turn: { type: 'prompt', prompt: 'old image turn' },
+      },
+      lifecycle: { version: 1, timestamp: 1 },
+    });
   });
 
   it('maps legacy DIND devcontainer metadata into grouped current metadata', () => {

--- a/services/cloud-agent-next/src/persistence/session-metadata.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.ts
@@ -28,14 +28,14 @@ const MetadataIdentitySchema = z
     botId: z.string().optional(),
     createdOnPlatform: z.string().max(100).optional(),
   })
-  .strict();
+  .strip();
 
 const MetadataAuthSchema = z
   .object({
     kiloSessionId: z.string().optional(),
     kilocodeToken: z.string().optional(),
   })
-  .strict();
+  .strip();
 
 const RepositoryCommonSchema = {
   token: z.string().optional(),
@@ -52,7 +52,7 @@ const MetadataRepositorySchema = z.discriminatedUnion('type', [
       githubAppType: z.enum(['standard', 'lite']).optional(),
       ...RepositoryCommonSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal('gitlab'),
@@ -61,7 +61,7 @@ const MetadataRepositorySchema = z.discriminatedUnion('type', [
       gitlabTokenManaged: z.boolean().optional(),
       ...RepositoryCommonSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal('git'),
@@ -69,7 +69,7 @@ const MetadataRepositorySchema = z.discriminatedUnion('type', [
       platform: z.enum(['github', 'gitlab']).optional(),
       ...RepositoryCommonSchema,
     })
-    .strict(),
+    .strip(),
 ]);
 
 const CurrentMetadataInitialTurnSchema = z.discriminatedUnion('type', [
@@ -79,14 +79,14 @@ const CurrentMetadataInitialTurnSchema = z.discriminatedUnion('type', [
       prompt: z.string(),
       attachments: AttachmentsSchema.optional(),
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal('command'),
       command: z.string().min(1),
       arguments: z.string(),
     })
-    .strict(),
+    .strip(),
 ]);
 
 const CurrentMetadataInitialMessageSchema = z
@@ -96,7 +96,7 @@ const CurrentMetadataInitialMessageSchema = z
     attachments: AttachmentsSchema.optional(),
     turn: CurrentMetadataInitialTurnSchema.optional(),
   })
-  .strict();
+  .strip();
 
 const MetadataAgentSchema = z
   .object({
@@ -109,7 +109,7 @@ const MetadataAgentSchema = z
       .optional(),
     appendSystemPrompt: z.string().max(10000).optional(),
   })
-  .strict();
+  .strip();
 
 const MetadataFinalizationSchema = z
   .object({
@@ -117,13 +117,13 @@ const MetadataFinalizationSchema = z
     condenseOnComplete: z.boolean().optional(),
     gateThreshold: z.enum(['off', 'all', 'warning', 'critical']).optional(),
   })
-  .strict();
+  .strip();
 
 const MetadataCallbackSchema = z
   .object({
     target: CallbackTargetSchema.optional(),
   })
-  .strict();
+  .strip();
 
 const MetadataWorkspaceSchema = z
   .object({
@@ -134,7 +134,7 @@ const MetadataWorkspaceSchema = z
     shallow: z.boolean().optional(),
     devcontainerRequested: z.boolean().optional(),
   })
-  .strict();
+  .strip();
 
 const MetadataDevContainerSchema = z
   .object({
@@ -143,7 +143,7 @@ const MetadataDevContainerSchema = z
     wrapperPort: z.number().int().min(1).max(65535),
     configPath: z.string(),
   })
-  .strict();
+  .strip();
 
 const MetadataLifecycleSchema = z
   .object({
@@ -153,7 +153,7 @@ const MetadataLifecycleSchema = z
     initiatedAt: z.number().optional(),
     kiloServerLastActivity: z.number().optional(),
   })
-  .strict();
+  .strip();
 
 export const CurrentSessionMetadataSchema = z
   .object({
@@ -170,7 +170,7 @@ export const CurrentSessionMetadataSchema = z
     devcontainer: MetadataDevContainerSchema.optional(),
     lifecycle: MetadataLifecycleSchema,
   })
-  .strict();
+  .strip();
 
 export type SessionMetadata = z.infer<typeof CurrentSessionMetadataSchema>;
 


### PR DESCRIPTION
## Summary

- Make grouped v2 session metadata parsing discard additive unknown fields instead of failing existing sessions.
- Restore readability and stream setup for sessions containing older persisted fields such as `initialMessage.images`.
- Add regression coverage for unknown fields at both root and nested initial-message boundaries.

## Verification

- [x] Inspected production logs and confirmed session reads/streams fail on persisted `images` fields.

## Visual Changes

N/A

## Reviewer Notes

- Unknown fields are intentionally stripped only at the persisted grouped metadata schemas; known fields remain validated.
- The affected session's unsupported legacy image metadata is ignored on read, matching the desired forward-compatible behavior.