### PR TITLE
fix(gastown): guard eviction resets with heartbeat

### DIFF
--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -45,6 +45,7 @@ import {
   isAlreadyReported,
   type ReporterBead,
 } from './wasteland-reporter';
+import { HEARTBEAT_STALE_MS, staleMs } from './staleness';
 
 const LOG = '[reconciler]';
 
@@ -130,13 +131,6 @@ const STALE_IN_PROGRESS_TIMEOUT_MS = 5 * 60_000; // 5 min
  * running/unknown, the stalled row persists indefinitely. This time-based
  * cleanup closes the loop. */
 const STALLED_AUTO_IDLE_MS = 2.5 * 60 * 60_000; // 2h 30min
-
-// ── Helper: staleness check ─────────────────────────────────────────
-
-function staleMs(timestamp: string | null, thresholdMs: number): boolean {
-  if (!timestamp) return true;
-  return Date.now() - new Date(timestamp).getTime() > thresholdMs;
-}
 
 /**
  * Compute the dispatch cooldown for a bead based on its attempt count.
@@ -728,7 +722,7 @@ export function reconcileAgents(sql: SqlStorage, opts?: { draining?: boolean }):
         to: 'idle',
         reason: 'no heartbeat received since dispatch',
       });
-    } else if (staleMs(agent.last_activity_at, 90_000)) {
+    } else if (staleMs(agent.last_activity_at, HEARTBEAT_STALE_MS)) {
       actions.push({
         type: 'transition_agent',
         agent_id: agent.bead_id,
@@ -907,7 +901,7 @@ export function reconcileAgents(sql: SqlStorage, opts?: { draining?: boolean }):
       // alive and leave the hook in place. The 90s window matches
       // reconcileAgents' stale-heartbeat threshold, so a truly dead
       // agent still gets reaped by the heartbeat path on a later tick.
-      if (!staleMs(agent.last_activity_at, 90_000)) continue;
+      if (!staleMs(agent.last_activity_at, HEARTBEAT_STALE_MS)) continue;
 
       actions.push({
         type: 'unhook_agent',

--- a/services/gastown/src/dos/town/review-queue.ts
+++ b/services/gastown/src/dos/town/review-queue.ts
@@ -28,6 +28,7 @@ import {
 import { getAgent, unhookBead, updateAgentStatus } from './agents';
 import { getRig } from './rigs';
 import type { ReviewQueueInput, ReviewQueueEntry, AgentDoneInput, Molecule } from '../../types';
+import { heartbeatStale } from './staleness';
 
 function generateId(): string {
   return crypto.randomUUID();
@@ -735,23 +736,30 @@ export function agentCompleted(
         });
       } else if (hookedBead && hookedBead.status === 'in_progress') {
         if (input.reason === 'container eviction') {
-          // Container eviction: WIP was force-pushed and eviction context
-          // was written on the bead body. Reset to open and clear the
-          // stale assignee so the reconciler can re-dispatch immediately.
-          console.log(
-            `[review-queue] agentCompleted: polecat ${agentId} evicted — ` +
-              `resetting bead ${agent.current_hook_bead_id} to open`
-          );
-          updateBeadStatus(sql, agent.current_hook_bead_id, 'open', agentId);
-          query(
-            sql,
-            /* sql */ `
-              UPDATE ${beads}
-              SET ${beads.columns.assignee_agent_bead_id} = NULL
-              WHERE ${beads.bead_id} = ?
-            `,
-            [agent.current_hook_bead_id]
-          );
+          if (!heartbeatStale(agent.last_activity_at)) {
+            console.log(
+              `[review-queue] agentCompleted: polecat ${agentId} eviction event ignored — ` +
+                `heartbeat fresh; bead ${agent.current_hook_bead_id} stays in_progress`
+            );
+          } else {
+            // Container eviction with a stale heartbeat: WIP was force-pushed and eviction
+            // context was written on the bead body. Reset to open and clear the stale
+            // assignee so the reconciler can re-dispatch immediately.
+            console.log(
+              `[review-queue] agentCompleted: polecat ${agentId} evicted (heartbeat stale) — ` +
+                `resetting bead ${agent.current_hook_bead_id} to open`
+            );
+            updateBeadStatus(sql, agent.current_hook_bead_id, 'open', agentId);
+            query(
+              sql,
+              /* sql */ `
+                UPDATE ${beads}
+                SET ${beads.columns.assignee_agent_bead_id} = NULL
+                WHERE ${beads.bead_id} = ?
+              `,
+              [agent.current_hook_bead_id]
+            );
+          }
         } else {
           // Agent exited 'completed' but bead is still in_progress — gt_done was never called.
           // Don't close the bead. Rule 3 will handle rework.

--- a/services/gastown/src/dos/town/staleness.test.ts
+++ b/services/gastown/src/dos/town/staleness.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HEARTBEAT_STALE_MS, heartbeatStale } from './staleness';
+
+describe('heartbeatStale', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('treats a fresh heartbeat as live', () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-05-28T12:00:00.000Z');
+    vi.setSystemTime(now);
+
+    expect(heartbeatStale(new Date(now.getTime() - 1_000).toISOString())).toBe(false);
+  });
+
+  it('treats a heartbeat past the threshold as stale', () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-05-28T12:00:00.000Z');
+    vi.setSystemTime(now);
+
+    expect(heartbeatStale(new Date(now.getTime() - HEARTBEAT_STALE_MS - 1).toISOString())).toBe(
+      true
+    );
+  });
+
+  it('treats a missing heartbeat as stale', () => {
+    expect(heartbeatStale(null)).toBe(true);
+  });
+});

--- a/services/gastown/src/dos/town/staleness.ts
+++ b/services/gastown/src/dos/town/staleness.ts
@@ -1,0 +1,10 @@
+export const HEARTBEAT_STALE_MS = 90_000;
+
+export function staleMs(timestamp: string | null, thresholdMs: number): boolean {
+  if (!timestamp) return true;
+  return Date.now() - new Date(timestamp).getTime() > thresholdMs;
+}
+
+export function heartbeatStale(timestamp: string | null): boolean {
+  return staleMs(timestamp, HEARTBEAT_STALE_MS);
+}

--- a/services/gastown/test/integration/reconciler.test.ts
+++ b/services/gastown/test/integration/reconciler.test.ts
@@ -237,6 +237,38 @@ describe('Reconciler', () => {
     });
   });
 
+  describe('event-driven agentCompleted container eviction', () => {
+    it('keeps an in-progress bead assigned when the agent heartbeat is fresh', async () => {
+      const agent = await town.registerAgent({
+        role: 'polecat',
+        name: 'P1',
+        identity: `eviction-fresh-${townName}`,
+        rig_id: 'rig-1',
+      });
+      const bead = await town.createBead({
+        type: 'issue',
+        title: 'Fresh eviction bead',
+        rig_id: 'rig-1',
+      });
+
+      await town.hookBead(agent.id, bead.bead_id);
+      await town.updateBeadStatus(bead.bead_id, 'in_progress', agent.id);
+      await town.updateAgentStatus(agent.id, 'working');
+      await town.touchAgentHeartbeat(agent.id);
+
+      await town.agentCompleted(agent.id, { status: 'completed', reason: 'container eviction' });
+      await runDurableObjectAlarm(town);
+
+      const beadAfter = await town.getBeadAsync(bead.bead_id);
+      expect(beadAfter?.status).toBe('in_progress');
+      expect(beadAfter?.assignee_agent_bead_id).toBe(agent.id);
+
+      const agentAfter = await town.getAgentAsync(agent.id);
+      expect(agentAfter?.status).toBe('idle');
+      expect(agentAfter?.current_hook_bead_id).toBeNull();
+    });
+  });
+
   // ── reconcileReviewQueue Rule 5: Refinery dispatch ──────────────────
 
   describe('reconcileReviewQueue Rule 5: refinery dispatch', () => {


### PR DESCRIPTION
## Summary

- Guard `agentCompleted` container-eviction bead resets with the same 90s heartbeat freshness window used by the reconciler.
- Share the heartbeat staleness constant/helper so live polecats keep their in-progress bead assignment while still unhooking the exited agent process.
- Add regression coverage for fresh, stale, and missing heartbeats plus the Town DO fresh-heartbeat eviction path.

## Verification

Not manually tested; non-visual Durable Object state-machine change.

## Visual Changes

N/A

## Reviewer Notes

Local automated checks were attempted after PR creation per issue instructions, but this shell has no `pnpm`, Node, Corepack, or Nix available on `PATH`, so `pnpm format`, `pnpm typecheck`, `pnpm lint`, and `pnpm test` could not start. The branch was pushed with `--no-verify` as requested.

Fixes #3538