### PR TITLE
feat(auto-model): route Auto Balanced Opus modes to Qwen3.7 Max

### DIFF
--- a/apps/web/src/lib/ai-gateway/auto-model/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  CLAUDE_OPUS_CURRENT_MODEL_ID,
+  CLAUDE_SONNET_CURRENT_MODEL_ID,
+} from '@/lib/ai-gateway/providers/anthropic.constants';
+import { qwen36_plus_model, qwen37_max_model } from '@/lib/ai-gateway/providers/qwen';
+import {
+  BALANCED_CODE_MODEL,
+  BALANCED_MODE_TO_MODEL,
+  FRONTIER_CODE_MODEL,
+  FRONTIER_MODE_TO_MODEL,
+  modeSchema,
+} from '@/lib/ai-gateway/auto-model';
+
+describe('Auto Balanced model routing', () => {
+  test('uses Qwen3.7 Max in modes where Auto Frontier uses Claude Opus', () => {
+    for (const mode of modeSchema.options) {
+      const frontierModel = FRONTIER_MODE_TO_MODEL[mode].model;
+      const balancedModel = BALANCED_MODE_TO_MODEL[mode].model;
+
+      if (frontierModel === CLAUDE_OPUS_CURRENT_MODEL_ID) {
+        expect(balancedModel).toBe(qwen37_max_model.public_id);
+      } else {
+        expect(frontierModel).toBe(CLAUDE_SONNET_CURRENT_MODEL_ID);
+        expect(balancedModel).toBe(qwen36_plus_model.public_id);
+      }
+    }
+  });
+
+  test('keeps Qwen3.6 Plus for the Sonnet-aligned default route', () => {
+    expect(FRONTIER_CODE_MODEL.model).toBe(CLAUDE_SONNET_CURRENT_MODEL_ID);
+    expect(BALANCED_CODE_MODEL.model).toBe(qwen36_plus_model.public_id);
+  });
+});

--- a/apps/web/src/lib/ai-gateway/auto-model/index.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@/lib/ai-gateway/providers/anthropic.constants';
 import type { OpenRouterReasoningConfig } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { OpenCodeSettings, Verbosity } from '@kilocode/db/schema-types';
-import { qwen36_plus_model } from '@/lib/ai-gateway/providers/qwen';
+import { qwen36_plus_model, qwen37_max_model } from '@/lib/ai-gateway/providers/qwen';
 
 type AutoModel = {
   id: string;
@@ -92,9 +92,29 @@ export const BALANCED_CLAW_SETUP_MODEL: ResolvedAutoModel = {
   verbosity: 'high',
 };
 
-export const BALANCED_QWEN_MODEL: ResolvedAutoModel = {
+const QWEN_MAX_BALANCED: ResolvedAutoModel = {
+  model: qwen37_max_model.public_id,
+  reasoning: { enabled: true },
+};
+
+const QWEN_PLUS_BALANCED: ResolvedAutoModel = {
   model: qwen36_plus_model.public_id,
   reasoning: { enabled: true },
+};
+
+export const BALANCED_CODE_MODEL: ResolvedAutoModel = QWEN_PLUS_BALANCED;
+
+export const BALANCED_MODE_TO_MODEL: Record<Mode, ResolvedAutoModel> = {
+  claw: QWEN_MAX_BALANCED,
+  plan: QWEN_MAX_BALANCED,
+  general: QWEN_MAX_BALANCED,
+  architect: QWEN_MAX_BALANCED,
+  orchestrator: QWEN_MAX_BALANCED,
+  ask: QWEN_MAX_BALANCED,
+  debug: QWEN_MAX_BALANCED,
+  build: QWEN_PLUS_BALANCED,
+  explore: QWEN_PLUS_BALANCED,
+  code: QWEN_PLUS_BALANCED,
 };
 
 export const KILO_AUTO_FRONTIER_MODEL: AutoModel = {

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -15,7 +15,8 @@ import {
   KILO_AUTO_BALANCED_MODEL,
   modeSchema,
   BALANCED_CLAW_SETUP_MODEL,
-  BALANCED_QWEN_MODEL,
+  BALANCED_MODE_TO_MODEL,
+  BALANCED_CODE_MODEL,
   BALANCED_RESPONSES_FALLBACK_MODEL,
   FRONTIER_MODE_TO_MODEL,
   FRONTIER_CODE_MODEL,
@@ -136,7 +137,10 @@ export async function resolveAutoModel(
     } else if (apiKind === 'messages') {
       return { kind: 'ok', resolved: BALANCED_MESSAGES_FALLBACK_MODEL };
     } else {
-      return { kind: 'ok', resolved: BALANCED_QWEN_MODEL };
+      return {
+        kind: 'ok',
+        resolved: (mode !== null ? BALANCED_MODE_TO_MODEL[mode] : null) ?? BALANCED_CODE_MODEL,
+      };
     }
   }
   return {


### PR DESCRIPTION
## Summary

- Align Auto Balanced mode routing with Auto Frontier's quality split: modes routed to Claude Opus in Frontier (`claw`, `plan`, `general`, `architect`, `orchestrator`, `ask`, and `debug`) now use `qwen/qwen3.7-max` in Balanced.
- Keep the Sonnet-aligned Balanced paths (`build`, `explore`, `code`, and the no-mode default) on `qwen/qwen3.6-plus`, with a regression test guarding the tier relationship.

## Verification

- Not manually exercised; this is internal gateway model routing without a user-facing UI path.

## Visual Changes

N/A

## Reviewer Notes

- Existing KiloClaw initial-setup routing and Alibaba-incompatible `responses` / `messages` fallback behavior remain unchanged.