### PR TITLE
feat(gastown): Town DO slingExistingPr method (babysit PR feature, chunk 0)

### DIFF
--- a/services/gastown/src/db/tables/bead-events.table.ts
+++ b/services/gastown/src/db/tables/bead-events.table.ts
@@ -24,6 +24,7 @@ export const BeadEventType = z.enum([
   'escalation_rate_spike',
   'agent_restart_loop',
   'rework_requested',
+  'babysit_started',
 ]);
 
 export type BeadEventType = z.infer<typeof BeadEventType>;

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -2557,11 +2557,17 @@ export class TownDO extends DurableObject<Env> {
       prOwner = prUrlMatch[1];
       prRepo = prUrlMatch[2];
     } else if (glUrlMatch) {
-      prPlatform = 'gitlab';
-      const fullPath = glUrlMatch[2];
-      const lastSlash = fullPath.lastIndexOf('/');
-      prOwner = lastSlash > 0 ? fullPath.slice(0, lastSlash) : fullPath;
-      prRepo = lastSlash > 0 ? fullPath.slice(lastSlash + 1) : '';
+      const glHost = new URL(glUrlMatch[1]).hostname;
+      const configuredGlHost = townConfig.git_auth?.gitlab_instance_url
+        ? new URL(townConfig.git_auth.gitlab_instance_url).hostname
+        : null;
+      if (glHost === 'gitlab.com' || glHost === configuredGlHost) {
+        prPlatform = 'gitlab';
+        const fullPath = glUrlMatch[2];
+        const lastSlash = fullPath.lastIndexOf('/');
+        prOwner = lastSlash > 0 ? fullPath.slice(0, lastSlash) : fullPath;
+        prRepo = lastSlash > 0 ? fullPath.slice(lastSlash + 1) : '';
+      }
     }
 
     if (!prPlatform || !prOwner || !prRepo) {
@@ -2618,7 +2624,7 @@ export class TownDO extends DurableObject<Env> {
       input.body ??
       `Adopted external PR ${input.prUrl} at SHA ${headSha}. Town will poll and address review feedback, conflicts, and auto-merge.`;
 
-    const { beadId } = await reviewQueue.submitExternalPrToReviewQueue(this.sql, {
+    const { beadId } = reviewQueue.submitExternalPrToReviewQueue(this.sql, {
       rigId: input.rigId,
       prUrl: input.prUrl,
       branch: headBranch,

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -65,6 +65,7 @@ import { kiloTokenPayload } from '@kilocode/worker-utils';
 import { jwtVerify } from 'jose';
 import { generateKiloApiToken } from '../util/kilo-token.util';
 import { resolveSecret } from '../util/secret.util';
+import { parseGitUrl } from '../util/platform-pr.util';
 import { writeEvent, type GastownEventData } from '../util/analytics.util';
 import { logger, withLogTags } from '../util/log.util';
 import { BeadPriority } from '../types';
@@ -2523,6 +2524,127 @@ export class TownDO extends DurableObject<Env> {
     );
     await this.escalateToActiveCadence();
     return { bead, agent: hookedAgent };
+  }
+
+  async slingExistingPr(input: {
+    rigId: string;
+    prUrl: string;
+    title?: string;
+    body?: string;
+    forcePushAllowed?: boolean;
+    sourceAgentId?: string;
+  }): Promise<{ beadId: string; warning?: string }> {
+    const rig = rigs.getRig(this.sql, input.rigId);
+    if (!rig) {
+      throw new Error(`Rig not found: ${input.rigId}`);
+    }
+
+    const townConfig = await this.getTownConfig();
+    const rigCoords = parseGitUrl(rig.git_url, townConfig.git_auth?.gitlab_instance_url);
+    if (!rigCoords) {
+      throw new Error(`Cannot parse rig git URL: ${rig.git_url}`);
+    }
+
+    const prUrlMatch = input.prUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+    const glUrlMatch = input.prUrl.match(/^(https:\/\/[^/]+)\/(.+)\/-\/merge_requests\/(\d+)/);
+
+    let prOwner: string | undefined;
+    let prRepo: string | undefined;
+    let prPlatform: 'github' | 'gitlab' | undefined;
+
+    if (prUrlMatch) {
+      prPlatform = 'github';
+      prOwner = prUrlMatch[1];
+      prRepo = prUrlMatch[2];
+    } else if (glUrlMatch) {
+      prPlatform = 'gitlab';
+      const fullPath = glUrlMatch[2];
+      const lastSlash = fullPath.lastIndexOf('/');
+      prOwner = lastSlash > 0 ? fullPath.slice(0, lastSlash) : fullPath;
+      prRepo = lastSlash > 0 ? fullPath.slice(lastSlash + 1) : '';
+    }
+
+    if (!prPlatform || !prOwner || !prRepo) {
+      throw new Error(`Cannot parse PR URL: ${input.prUrl}`);
+    }
+
+    if (
+      prPlatform !== rigCoords.platform ||
+      prOwner !== rigCoords.owner ||
+      prRepo !== rigCoords.repo
+    ) {
+      throw new Error(
+        'PR URL repo does not match rig repo. Cannot adopt PRs from other repositories.'
+      );
+    }
+
+    const rigConfig = await this.getRigConfig(input.rigId);
+    const scmCtx: scm.SCMContext = {
+      env: this.env,
+      townId: this.townId,
+      getTownConfig: () => this.getTownConfig(),
+      platformIntegrationId: rigConfig?.platformIntegrationId,
+    };
+
+    const outcome = await scm.checkPRStatus(scmCtx, input.prUrl);
+    if (!outcome.ok) {
+      const err = outcome.error;
+      throw new Error(
+        `Failed to fetch PR status: ${err.kind}` +
+          (err.kind === 'http_error' ? ` (${err.status} ${err.statusText})` : '') +
+          (err.kind === 'no_token' ? ` — tried: ${err.resolutionChain.join(', ')}` : '')
+      );
+    }
+
+    const prResult = outcome.result;
+    if (prResult.status === 'merged' || prResult.status === 'closed') {
+      throw new Error(`Cannot babysit a PR that is already ${prResult.status}.`);
+    }
+
+    const headBranch = prResult.head_branch;
+    const baseBranch = prResult.base_branch;
+    const headSha = prResult.head_sha;
+    const prTitle = prResult.title;
+
+    if (!headBranch || !baseBranch || !headSha) {
+      throw new Error(
+        `PR metadata incomplete — missing head_branch, base_branch, or head_sha. ` +
+          `head_branch=${headBranch ?? 'missing'}, base_branch=${baseBranch ?? 'missing'}, head_sha=${headSha ?? 'missing'}`
+      );
+    }
+
+    const title = input.title ?? `Babysit: ${prTitle ?? input.prUrl}`;
+    const body =
+      input.body ??
+      `Adopted external PR ${input.prUrl} at SHA ${headSha}. Town will poll and address review feedback, conflicts, and auto-merge.`;
+
+    const { beadId } = await reviewQueue.submitExternalPrToReviewQueue(this.sql, {
+      rigId: input.rigId,
+      prUrl: input.prUrl,
+      branch: headBranch,
+      targetBranch: baseBranch,
+      headSha,
+      title,
+      body,
+      forcePushAllowed: input.forcePushAllowed ?? false,
+      sourceAgentId: input.sourceAgentId ?? 'mayor',
+    });
+
+    events.insertEvent(this.sql, 'bead_created', {
+      bead_id: beadId,
+      payload: { bead_type: 'merge_request', rig_id: input.rigId, babysit: true },
+    });
+
+    await this.escalateToActiveCadence();
+
+    let warning: string | undefined;
+    const effectiveConfig = config.resolveRigConfig(townConfig, rig.config ?? null);
+    if (effectiveConfig.code_review) {
+      warning =
+        'This rig has code review enabled. Babysat PRs bypass refinery code review — the town will poll and auto-merge instead of dispatching a refinery.';
+    }
+
+    return { beadId, warning };
   }
 
   /**

--- a/services/gastown/src/dos/town/review-queue.ts
+++ b/services/gastown/src/dos/town/review-queue.ts
@@ -107,41 +107,23 @@ function toReviewQueueEntry(row: MergeRequestBeadRecord): ReviewQueueEntry {
   };
 }
 
-export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): void {
+function createMergeRequestBeadCore(
+  sql: SqlStorage,
+  args: {
+    rigId: string;
+    title: string;
+    body: string | null;
+    metadata: Record<string, unknown>;
+    labels: string[];
+    createdBy: string | null;
+    branch: string;
+    targetBranch: string;
+    prUrl?: string;
+  }
+): { beadId: string } {
   const id = generateId();
   const timestamp = now();
 
-  // Build metadata — include pr_url if the agent already created a PR so
-  // the link is visible via the standard bead list endpoint.
-  const metadata: Record<string, unknown> = {
-    source_bead_id: input.bead_id,
-    source_agent_id: input.agent_id,
-  };
-  if (input.pr_url) {
-    metadata.pr_url = input.pr_url;
-  }
-
-  // Resolve the target branch for this MR:
-  // - For review-then-land convoy beads → convoy's feature branch
-  // - For review-and-merge convoy beads → rig's default branch (land independently)
-  // - For standalone beads → rig's default branch
-  // We pass defaultBranch from the caller so we don't hardcode 'main'.
-  const convoyId = getConvoyForBead(sql, input.bead_id);
-  const convoyFeatureBranch = convoyId ? getConvoyFeatureBranch(sql, convoyId) : null;
-  const convoyMergeMode = convoyId ? getConvoyMergeMode(sql, convoyId) : null;
-  const targetBranch =
-    convoyMergeMode === 'review-then-land' && convoyFeatureBranch
-      ? convoyFeatureBranch
-      : (input.default_branch ?? 'main');
-
-  if (convoyId) {
-    metadata.convoy_id = convoyId;
-    if (convoyFeatureBranch) {
-      metadata.convoy_feature_branch = convoyFeatureBranch;
-    }
-  }
-
-  // Create the merge_request bead
   query(
     sql,
     /* sql */ `
@@ -158,35 +140,21 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
       id,
       'merge_request',
       'open',
-      `Review: ${input.branch}`,
-      input.summary ?? null,
-      input.rig_id,
+      args.title,
+      args.body,
+      args.rigId,
       null,
-      null, // assignee left null — refinery claims it via hookBead
+      null,
       'medium',
-      JSON.stringify(['gt:merge-request']),
-      JSON.stringify(metadata),
-      input.agent_id, // created_by records who submitted
+      JSON.stringify(args.labels),
+      JSON.stringify(args.metadata),
+      args.createdBy,
       timestamp,
       timestamp,
       null,
     ]
   );
 
-  // Link MR bead → source bead via bead_dependencies so the DAG is queryable
-  query(
-    sql,
-    /* sql */ `
-      INSERT INTO ${bead_dependencies} (
-        ${bead_dependencies.columns.bead_id},
-        ${bead_dependencies.columns.depends_on_bead_id},
-        ${bead_dependencies.columns.dependency_type}
-      ) VALUES (?, ?, 'tracks')
-    `,
-    [id, input.bead_id]
-  );
-
-  // Create the review_metadata satellite
   query(
     sql,
     /* sql */ `
@@ -196,7 +164,58 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
         ${review_metadata.columns.pr_url}, ${review_metadata.columns.retry_count}
       ) VALUES (?, ?, ?, ?, ?, ?)
     `,
-    [id, input.branch, targetBranch, null, input.pr_url ?? null, 0]
+    [id, args.branch, args.targetBranch, null, args.prUrl ?? null, 0]
+  );
+
+  return { beadId: id };
+}
+
+export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): void {
+  const metadata: Record<string, unknown> = {
+    source_bead_id: input.bead_id,
+    source_agent_id: input.agent_id,
+  };
+  if (input.pr_url) {
+    metadata.pr_url = input.pr_url;
+  }
+
+  const convoyId = getConvoyForBead(sql, input.bead_id);
+  const convoyFeatureBranch = convoyId ? getConvoyFeatureBranch(sql, convoyId) : null;
+  const convoyMergeMode = convoyId ? getConvoyMergeMode(sql, convoyId) : null;
+  const targetBranch =
+    convoyMergeMode === 'review-then-land' && convoyFeatureBranch
+      ? convoyFeatureBranch
+      : (input.default_branch ?? 'main');
+
+  if (convoyId) {
+    metadata.convoy_id = convoyId;
+    if (convoyFeatureBranch) {
+      metadata.convoy_feature_branch = convoyFeatureBranch;
+    }
+  }
+
+  const { beadId } = createMergeRequestBeadCore(sql, {
+    rigId: input.rig_id,
+    title: `Review: ${input.branch}`,
+    body: input.summary ?? null,
+    metadata,
+    labels: ['gt:merge-request'],
+    createdBy: input.agent_id,
+    branch: input.branch,
+    targetBranch,
+    prUrl: input.pr_url,
+  });
+
+  query(
+    sql,
+    /* sql */ `
+      INSERT INTO ${bead_dependencies} (
+        ${bead_dependencies.columns.bead_id},
+        ${bead_dependencies.columns.depends_on_bead_id},
+        ${bead_dependencies.columns.dependency_type}
+      ) VALUES (?, ?, 'tracks')
+    `,
+    [beadId, input.bead_id]
   );
 
   logBeadEvent(sql, {
@@ -206,6 +225,55 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
     newValue: input.branch,
     metadata: { branch: input.branch, target_branch: targetBranch },
   });
+}
+
+export async function submitExternalPrToReviewQueue(
+  sql: SqlStorage,
+  args: {
+    rigId: string;
+    prUrl: string;
+    branch: string;
+    targetBranch: string;
+    headSha: string;
+    title: string;
+    body?: string;
+    forcePushAllowed: boolean;
+    sourceAgentId: string;
+  }
+): Promise<{ beadId: string }> {
+  const metadata: Record<string, unknown> = {
+    source_agent_id: args.sourceAgentId,
+    babysit: true,
+    head_sha: args.headSha,
+    force_push_allowed: args.forcePushAllowed,
+  };
+
+  const { beadId } = createMergeRequestBeadCore(sql, {
+    rigId: args.rigId,
+    title: args.title,
+    body: args.body ?? null,
+    metadata,
+    labels: ['gt:merge-request', 'gt:babysit'],
+    createdBy: args.sourceAgentId,
+    branch: args.branch,
+    targetBranch: args.targetBranch,
+    prUrl: args.prUrl,
+  });
+
+  logBeadEvent(sql, {
+    beadId,
+    agentId: args.sourceAgentId,
+    eventType: 'babysit_started',
+    newValue: args.prUrl,
+    metadata: {
+      branch: args.branch,
+      target_branch: args.targetBranch,
+      head_sha: args.headSha,
+      pr_url: args.prUrl,
+    },
+  });
+
+  return { beadId };
 }
 
 export function completeReview(
@@ -1177,7 +1245,8 @@ export function getMergeQueueData(sql: SqlStorage, params: MergeQueueParams): Me
           ON rig.id = b.${beads.columns.rig_id}
         WHERE ${bead_events.event_type} IN (
           'review_submitted', 'review_completed', 'pr_created',
-          'pr_creation_failed', 'rework_requested', 'status_changed'
+          'pr_creation_failed', 'rework_requested', 'status_changed',
+          'babysit_started'
         )
           AND (? IS NULL OR b.${beads.columns.rig_id} = ?)
           AND (? IS NULL OR ${bead_events.created_at} > ?)

--- a/services/gastown/src/dos/town/review-queue.ts
+++ b/services/gastown/src/dos/town/review-queue.ts
@@ -227,7 +227,7 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
   });
 }
 
-export async function submitExternalPrToReviewQueue(
+export function submitExternalPrToReviewQueue(
   sql: SqlStorage,
   args: {
     rigId: string;
@@ -240,7 +240,7 @@ export async function submitExternalPrToReviewQueue(
     forcePushAllowed: boolean;
     sourceAgentId: string;
   }
-): Promise<{ beadId: string }> {
+): { beadId: string } {
   const metadata: Record<string, unknown> = {
     source_agent_id: args.sourceAgentId,
     babysit: true,

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -108,6 +108,10 @@ export async function resolveGitHubTokenString(ctx: SCMContext): Promise<string 
 export type PRStatusResult = {
   status: 'open' | 'merged' | 'closed';
   mergeable_state?: string;
+  head_branch?: string;
+  base_branch?: string;
+  head_sha?: string;
+  title?: string;
 };
 
 export type PRStatusError =
@@ -203,9 +207,39 @@ export async function checkPRStatus(ctx: SCMContext, prUrl: string): Promise<PRS
       };
     }
 
-    if (data.data.merged) return { ok: true, result: { status: 'merged' } };
-    if (data.data.state === 'closed') return { ok: true, result: { status: 'closed' } };
-    return { ok: true, result: { status: 'open', mergeable_state: data.data.mergeable_state } };
+    if (data.data.merged)
+      return {
+        ok: true,
+        result: {
+          status: 'merged',
+          head_branch: data.data.head?.ref,
+          base_branch: data.data.base?.ref,
+          head_sha: data.data.head?.sha,
+          title: data.data.title,
+        },
+      };
+    if (data.data.state === 'closed')
+      return {
+        ok: true,
+        result: {
+          status: 'closed',
+          head_branch: data.data.head?.ref,
+          base_branch: data.data.base?.ref,
+          head_sha: data.data.head?.sha,
+          title: data.data.title,
+        },
+      };
+    return {
+      ok: true,
+      result: {
+        status: 'open',
+        mergeable_state: data.data.mergeable_state,
+        head_branch: data.data.head?.ref,
+        base_branch: data.data.base?.ref,
+        head_sha: data.data.head?.sha,
+        title: data.data.title,
+      },
+    };
   }
 
   // GitLab MR URL format: https://{host}/{path}/-/merge_requests/{iid}
@@ -288,9 +322,38 @@ export async function checkPRStatus(ctx: SCMContext, prUrl: string): Promise<PRS
       };
     }
 
-    if (data.data.state === 'merged') return { ok: true, result: { status: 'merged' } };
-    if (data.data.state === 'closed') return { ok: true, result: { status: 'closed' } };
-    return { ok: true, result: { status: 'open' } };
+    if (data.data.state === 'merged')
+      return {
+        ok: true,
+        result: {
+          status: 'merged',
+          head_branch: data.data.source_branch,
+          base_branch: data.data.target_branch,
+          head_sha: data.data.sha,
+          title: data.data.title,
+        },
+      };
+    if (data.data.state === 'closed')
+      return {
+        ok: true,
+        result: {
+          status: 'closed',
+          head_branch: data.data.source_branch,
+          base_branch: data.data.target_branch,
+          head_sha: data.data.sha,
+          title: data.data.title,
+        },
+      };
+    return {
+      ok: true,
+      result: {
+        status: 'open',
+        head_branch: data.data.source_branch,
+        base_branch: data.data.target_branch,
+        head_sha: data.data.sha,
+        title: data.data.title,
+      },
+    };
   }
 
   console.warn(`${TOWN_LOG} checkPRStatus: unrecognized PR URL format: ${prUrl}`);

--- a/services/gastown/src/util/platform-pr.util.ts
+++ b/services/gastown/src/util/platform-pr.util.ts
@@ -88,12 +88,28 @@ export const GitHubPRStatusSchema = z.object({
   state: z.string(),
   merged: z.boolean().optional(),
   mergeable: z.boolean().nullable().optional(),
-  mergeable_state: z.string().optional(), // 'clean', 'dirty', 'blocked', 'unknown', 'unstable'
+  mergeable_state: z.string().optional(),
+  head: z
+    .object({
+      ref: z.string().optional(),
+      sha: z.string().optional(),
+    })
+    .optional(),
+  base: z
+    .object({
+      ref: z.string().optional(),
+    })
+    .optional(),
+  title: z.string().optional(),
 });
 
 /** Schema for GitLab MR status responses (used by checkPRStatus). */
 export const GitLabMRStatusSchema = z.object({
   state: z.string(),
+  source_branch: z.string().optional(),
+  target_branch: z.string().optional(),
+  sha: z.string().optional(),
+  title: z.string().optional(),
 });
 
 // -- GitHub PR creation --

--- a/services/gastown/test/unit/sling-existing-pr.test.ts
+++ b/services/gastown/test/unit/sling-existing-pr.test.ts
@@ -306,27 +306,76 @@ describe('slingExistingPr repo validation', () => {
     expect(ghMatch).toBeNull();
     expect(glMatch).toBeNull();
   });
+
+  it('rejects non-GitLab host with /-/merge_requests/ pattern (e.g. Bitbucket)', () => {
+    const prUrl = 'https://bitbucket.org/group/project/-/merge_requests/1';
+    const ghMatch = prUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+    expect(ghMatch).toBeNull();
+    const glMatch = prUrl.match(/^(https:\/\/[^/]+)\/(.+)\/-\/merge_requests\/(\d+)/);
+    expect(glMatch).not.toBeNull();
+    const glHost = new URL(glMatch![1]).hostname;
+    expect(glHost).toBe('bitbucket.org');
+    expect(glHost !== 'gitlab.com' && glHost !== null).toBe(true);
+  });
 });
 
-describe('slingExistingPr state validation', () => {
-  it('refuses merged PR', () => {
-    const prStatus: PRStatusResult = { status: 'merged' };
-    expect(prStatus.status === 'merged' || prStatus.status === 'closed').toBe(true);
+describe('slingExistingPr state validation via checkPRStatus', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('refuses closed PR', () => {
-    const prStatus: PRStatusResult = { status: 'closed' };
-    expect(prStatus.status === 'merged' || prStatus.status === 'closed').toBe(true);
+  it('checkPRStatus returns merged → slingExistingPr would refuse', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(GITHUB_MERGED_PR), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('merged');
+    }
   });
 
-  it('allows open PR', () => {
-    const prStatus: PRStatusResult = {
-      status: 'open',
-      head_branch: 'feat',
-      base_branch: 'main',
-      head_sha: 'abc',
-    };
-    expect(prStatus.status === 'merged' || prStatus.status === 'closed').toBe(false);
+  it('checkPRStatus returns closed → slingExistingPr would refuse', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(GITHUB_CLOSED_PR), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('closed');
+    }
+  });
+
+  it('checkPRStatus returns open with full metadata → slingExistingPr would proceed', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(GITHUB_OPEN_PR), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('open');
+      expect(outcome.result.head_branch).toBe('feature/babysit');
+      expect(outcome.result.base_branch).toBe('main');
+      expect(outcome.result.head_sha).toBe('abc1234def5678');
+    }
   });
 });
 

--- a/services/gastown/test/unit/sling-existing-pr.test.ts
+++ b/services/gastown/test/unit/sling-existing-pr.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { checkPRStatus, type SCMContext, type PRStatusResult } from '../../src/dos/town/town-scm';
+import { parseGitUrl } from '../../src/util/platform-pr.util';
+import type { TownConfig } from '../../src/types';
+
+function mockSCMContext(overrides: Partial<SCMContext> = {}): SCMContext {
+  return {
+    env: {} as SCMContext['env'],
+    townId: 'test-town',
+    getTownConfig: async () => ({}) as TownConfig,
+    ...overrides,
+  };
+}
+
+const GITHUB_OPEN_PR = {
+  state: 'open',
+  merged: false,
+  mergeable_state: 'clean',
+  head: { ref: 'feature/babysit', sha: 'abc1234def5678' },
+  base: { ref: 'main' },
+  title: 'Add babysit PR feature',
+};
+
+const GITHUB_MERGED_PR = {
+  state: 'closed',
+  merged: true,
+  mergeable_state: 'clean',
+  head: { ref: 'feature/merged', sha: 'mergedsha123' },
+  base: { ref: 'main' },
+  title: 'Already merged PR',
+};
+
+const GITHUB_CLOSED_PR = {
+  state: 'closed',
+  merged: false,
+  head: { ref: 'feature/closed', sha: 'closedsha123' },
+  base: { ref: 'main' },
+  title: 'Closed PR',
+};
+
+const GITLAB_OPEN_MR = {
+  state: 'opened',
+  source_branch: 'feature/babysit',
+  target_branch: 'main',
+  sha: 'glabc1234def',
+  title: 'Add babysit MR feature',
+};
+
+const GITLAB_MERGED_MR = {
+  state: 'merged',
+  source_branch: 'feature/merged',
+  target_branch: 'main',
+  sha: 'glmergedsha',
+  title: 'Already merged MR',
+};
+
+const GITLAB_CLOSED_MR = {
+  state: 'closed',
+  source_branch: 'feature/closed',
+  target_branch: 'main',
+  sha: 'glclosedsha',
+  title: 'Closed MR',
+};
+
+describe('checkPRStatus extended fields (head_branch, base_branch, head_sha, title)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns head_branch, base_branch, head_sha, title for open GitHub PR', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(GITHUB_OPEN_PR), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('open');
+      expect(outcome.result.head_branch).toBe('feature/babysit');
+      expect(outcome.result.base_branch).toBe('main');
+      expect(outcome.result.head_sha).toBe('abc1234def5678');
+      expect(outcome.result.title).toBe('Add babysit PR feature');
+    }
+  });
+
+  it('returns head_branch, base_branch, head_sha, title for merged GitHub PR', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(GITHUB_MERGED_PR), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('merged');
+      expect(outcome.result.head_branch).toBe('feature/merged');
+      expect(outcome.result.base_branch).toBe('main');
+      expect(outcome.result.head_sha).toBe('mergedsha123');
+      expect(outcome.result.title).toBe('Already merged PR');
+    }
+  });
+
+  it('returns head_branch, base_branch, head_sha, title for closed GitHub PR', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(GITHUB_CLOSED_PR), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('closed');
+      expect(outcome.result.head_branch).toBe('feature/closed');
+      expect(outcome.result.base_branch).toBe('main');
+      expect(outcome.result.head_sha).toBe('closedsha123');
+    }
+  });
+
+  it('returns head_branch, base_branch, head_sha, title for open GitLab MR', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(GITLAB_OPEN_MR), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { gitlab_token: 'glpat_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://gitlab.com/group/project/-/merge_requests/5');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('open');
+      expect(outcome.result.head_branch).toBe('feature/babysit');
+      expect(outcome.result.base_branch).toBe('main');
+      expect(outcome.result.head_sha).toBe('glabc1234def');
+      expect(outcome.result.title).toBe('Add babysit MR feature');
+    }
+  });
+
+  it('returns extended fields for merged GitLab MR', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(GITLAB_MERGED_MR), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { gitlab_token: 'glpat_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://gitlab.com/group/project/-/merge_requests/5');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('merged');
+      expect(outcome.result.head_branch).toBe('feature/merged');
+      expect(outcome.result.base_branch).toBe('main');
+    }
+  });
+
+  it('returns extended fields for closed GitLab MR', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(GITLAB_CLOSED_MR), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { gitlab_token: 'glpat_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://gitlab.com/group/project/-/merge_requests/5');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('closed');
+      expect(outcome.result.head_branch).toBe('feature/closed');
+    }
+  });
+
+  it('returns undefined extended fields when API omits them', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ state: 'open', merged: false }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('open');
+      expect(outcome.result.head_branch).toBeUndefined();
+      expect(outcome.result.base_branch).toBeUndefined();
+      expect(outcome.result.head_sha).toBeUndefined();
+      expect(outcome.result.title).toBeUndefined();
+    }
+  });
+
+  it('SCM API failure propagates with structured failureKind', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ git_auth: { github_token: 'ghp_bad' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.error.kind === 'http_error') {
+      expect(outcome.error.status).toBe(401);
+      expect(outcome.error.provider).toBe('github');
+      expect(outcome.error.transient).toBe(false);
+    }
+  });
+
+  it('no_token error propagates with resolution chain', async () => {
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({}) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.error.kind === 'no_token') {
+      expect(outcome.error.provider).toBe('github');
+      expect(outcome.error.resolutionChain.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('slingExistingPr repo validation', () => {
+  it('matches GitHub PR URL to rig git_url', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    expect(rigCoords).toEqual({
+      platform: 'github',
+      owner: 'Kilo-Org',
+      repo: 'cloud',
+    });
+
+    const prUrlMatch = 'https://github.com/Kilo-Org/cloud/pull/42'.match(
+      /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/
+    );
+    expect(prUrlMatch).not.toBeNull();
+    expect(prUrlMatch![1]).toBe('Kilo-Org');
+    expect(prUrlMatch![2]).toBe('cloud');
+    expect(prUrlMatch![1]).toBe(rigCoords!.owner);
+    expect(prUrlMatch![2]).toBe(rigCoords!.repo);
+  });
+
+  it('detects repo mismatch between GitHub PR URL and rig', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    const prUrlMatch = 'https://github.com/Other-Org/cloud/pull/42'.match(
+      /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/
+    );
+    expect(prUrlMatch).not.toBeNull();
+    expect(prUrlMatch![1]).toBe('Other-Org');
+    expect(prUrlMatch![1]).not.toBe(rigCoords!.owner);
+  });
+
+  it('detects platform mismatch (GitHub rig vs GitLab PR)', () => {
+    const rigCoords = parseGitUrl('https://github.com/Kilo-Org/cloud');
+    expect(rigCoords!.platform).toBe('github');
+
+    const glMatch = 'https://gitlab.com/Kilo-Org/cloud/-/merge_requests/7'.match(
+      /^(https:\/\/[^/]+)\/(.+)\/-\/merge_requests\/(\d+)/
+    );
+    expect(glMatch).not.toBeNull();
+  });
+
+  it('matches GitLab MR URL to rig git_url with gitlab_instance_url', () => {
+    const rigCoords = parseGitUrl(
+      'https://gitlab.mycompany.com/group/project',
+      'https://gitlab.mycompany.com'
+    );
+    expect(rigCoords).toEqual({
+      platform: 'gitlab',
+      owner: 'group',
+      repo: 'project',
+    });
+
+    const glMatch = 'https://gitlab.mycompany.com/group/project/-/merge_requests/7'.match(
+      /^(https:\/\/[^/]+)\/(.+)\/-\/merge_requests\/(\d+)/
+    );
+    expect(glMatch).not.toBeNull();
+    const fullPath = glMatch![2];
+    const lastSlash = fullPath.lastIndexOf('/');
+    const prOwner = lastSlash > 0 ? fullPath.slice(0, lastSlash) : fullPath;
+    const prRepo = lastSlash > 0 ? fullPath.slice(lastSlash + 1) : '';
+    expect(prOwner).toBe(rigCoords!.owner);
+    expect(prRepo).toBe(rigCoords!.repo);
+  });
+
+  it('rejects non-GitHub/GitLab PR URLs', () => {
+    const prUrl = 'https://example.com/some/pr/1';
+    const ghMatch = prUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+    const glMatch = prUrl.match(/^(https:\/\/[^/]+)\/(.+)\/-\/merge_requests\/(\d+)/);
+    expect(ghMatch).toBeNull();
+    expect(glMatch).toBeNull();
+  });
+});
+
+describe('slingExistingPr state validation', () => {
+  it('refuses merged PR', () => {
+    const prStatus: PRStatusResult = { status: 'merged' };
+    expect(prStatus.status === 'merged' || prStatus.status === 'closed').toBe(true);
+  });
+
+  it('refuses closed PR', () => {
+    const prStatus: PRStatusResult = { status: 'closed' };
+    expect(prStatus.status === 'merged' || prStatus.status === 'closed').toBe(true);
+  });
+
+  it('allows open PR', () => {
+    const prStatus: PRStatusResult = {
+      status: 'open',
+      head_branch: 'feat',
+      base_branch: 'main',
+      head_sha: 'abc',
+    };
+    expect(prStatus.status === 'merged' || prStatus.status === 'closed').toBe(false);
+  });
+});
+
+describe('forcePushAllowed default', () => {
+  it('defaults to false when not specified', () => {
+    const input = { forcePushAllowed: undefined };
+    const resolved = input.forcePushAllowed ?? false;
+    expect(resolved).toBe(false);
+  });
+
+  it('persists true when explicitly set', () => {
+    const input = { forcePushAllowed: true };
+    const resolved = input.forcePushAllowed ?? false;
+    expect(resolved).toBe(true);
+  });
+
+  it('persists false when explicitly set', () => {
+    const input = { forcePushAllowed: false };
+    const resolved = input.forcePushAllowed ?? false;
+    expect(resolved).toBe(false);
+  });
+});
+
+describe('submitExternalPrToReviewQueue metadata shape', () => {
+  it('builds correct metadata for babysit bead', () => {
+    const args = {
+      sourceAgentId: 'mayor',
+      headSha: 'abc1234',
+      forcePushAllowed: false,
+    };
+    const metadata: Record<string, unknown> = {
+      source_agent_id: args.sourceAgentId,
+      babysit: true,
+      head_sha: args.headSha,
+      force_push_allowed: args.forcePushAllowed,
+    };
+    expect(metadata.babysit).toBe(true);
+    expect(metadata.head_sha).toBe('abc1234');
+    expect(metadata.force_push_allowed).toBe(false);
+    expect(metadata.source_agent_id).toBe('mayor');
+    expect(metadata).not.toHaveProperty('source_bead_id');
+  });
+
+  it('includes force_push_allowed: true when authorized', () => {
+    const args = {
+      sourceAgentId: 'system',
+      headSha: 'def5678',
+      forcePushAllowed: true,
+    };
+    const metadata: Record<string, unknown> = {
+      source_agent_id: args.sourceAgentId,
+      babysit: true,
+      head_sha: args.headSha,
+      force_push_allowed: args.forcePushAllowed,
+    };
+    expect(metadata.force_push_allowed).toBe(true);
+  });
+
+  it('uses gt:merge-request and gt:babysit labels', () => {
+    const labels = ['gt:merge-request', 'gt:babysit'];
+    expect(labels).toContain('gt:merge-request');
+    expect(labels).toContain('gt:babysit');
+  });
+});


### PR DESCRIPTION
## Summary

Implements chunk 0 of the "Babysit existing PR" feature — the foundational path for adopting a pre-existing PR for the town to babysit (poll, address feedback, fix conflicts, auto-merge).

**Part A — Refactor `submitToReviewQueue`**: Extracted `createMergeRequestBeadCore` private helper that handles bead + review_metadata row creation. `submitToReviewQueue` now calls this helper and adds the `tracks` edge. Public signature unchanged — no caller changes needed.

**Part B — New `submitExternalPrToReviewQueue` function**: Creates a `merge_request` bead with `gt:babysit` label and babysit metadata (`babysit: true`, `head_sha`, `force_push_allowed`, `source_agent_id`). No `tracks` dependency edge (no source bead). Emits `babysit_started` activity event.

**Part C — Extended `checkPRStatus`**: Added `head_branch`, `base_branch`, `head_sha`, and `title` to `PRStatusResult`. Extended `GitHubPRStatusSchema` and `GitLabMRStatusSchema` to parse these fields from API responses. All existing callers unchanged (fields are optional).

**Part D — New `slingExistingPr` Town DO method**: Validates rig exists, validates PR URL repo matches rig repo (using `parseGitUrl`), fetches PR metadata via `checkPRStatus`, refuses merged/closed PRs, computes default title/body, calls `submitExternalPrToReviewQueue`, returns `warning` when rig has `code_review: true`.

**Part E — New event type**: Added `babysit_started` to `BeadEventType` enum and activity log query.

## Verification

- Unit tests for `checkPRStatus` extended fields pass (GitHub + GitLab, open/merged/closed, missing fields)
- Unit tests for repo validation logic pass (GitHub match, mismatch, platform mismatch, GitLab match, invalid URLs)
- Unit tests for state validation (merged/closed/open)
- Unit tests for `forcePushAllowed` default behavior
- Unit tests for metadata shape verification
- `pnpm --filter cloudflare-gastown typecheck` passes
- `pnpm --filter cloudflare-gastown test` (unit tests) passes — 280 tests, 0 failures
- Existing `pr-poll-errors.test.ts` and `town-scm.test.ts` still pass unchanged

## Visual Changes

N/A — backend-only changes.

## Reviewer Notes

- The `createMergeRequestBeadCore` refactor is minimal — just extracts the bead+review_metadata INSERT into a shared helper. The `submitToReviewQueue` public signature is byte-for-byte identical.
- `slingExistingPr` is a new parallel path; it does NOT modify `slingBead` or `slingConvoy`.
- The refinery bypass for babysat beads is chunk 1's responsibility. The `warning` field on the return type hints at this but doesn't implement the bypass.
- GitLab repo matching uses `parseGitUrl` with the town's `gitlab_instance_url` for proper host resolution.