### PR TITLE
fix(kiloclaw): mark OpenClaw update as upgrade required

### DIFF
--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -14,7 +14,7 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     date: '2026-05-28',
     description: 'Updated OpenClaw to 2026.5.22.',
     category: 'feature',
-    deployHint: 'redeploy_suggested',
+    deployHint: 'upgrade_required',
   },
   {
     date: '2026-05-27',


### PR DESCRIPTION
## Summary

- Change the OpenClaw `2026.5.22` changelog entry to display `Upgrade Required` instead of `Redeploy Suggested`.
- This corrects the rollout guidance because receiving the newly packaged OpenClaw image requires users to upgrade their KiloClaw instance, not merely redeploy existing configuration.
- No architectural changes.

## Verification

- [x] Confirmed from the reported KiloClaw changelog view that the OpenClaw `2026.5.22` entry currently displays `Redeploy Suggested`.
- [ ] Confirm the updated changelog entry displays `Upgrade Required` after deployment.
- [ ] Additional manual verification details from reviewer/user.

## Visual Changes

| Before | After |
|---|---|
| OpenClaw `2026.5.22` entry shows `Redeploy Suggested` (reported screenshot) | OpenClaw `2026.5.22` entry shows `Upgrade Required` (screenshot after deployment pending) |

## Reviewer Notes

- The only product behavior change is the user-facing deploy-hint badge for the already-released OpenClaw `2026.5.22` changelog entry.