### PR TITLE
feat(web): BeadPanel babysit badge + metadata (chunk 4)

### DIFF
--- a/apps/web/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
+++ b/apps/web/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import Link from 'next/link';
 import { formatDistanceToNow, format } from 'date-fns';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Eye, Lock, Unlock } from 'lucide-react';
 
 const STATUS_COLORS: Record<string, string> = {
   open: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
@@ -167,6 +167,12 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
             {bead.status}
           </Badge>
         )}
+        {bead?.labels.includes('gt:babysit') && (
+          <Badge variant="outline" className="border-cyan-500/30 bg-cyan-500/10 text-cyan-400">
+            <Eye className="mr-1 h-3 w-3" />
+            Babysat external PR
+          </Badge>
+        )}
       </div>
 
       {beadQuery.isLoading && (
@@ -261,6 +267,54 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
                     </dt>
                     <dd>{bead.title}</dd>
                   </div>
+                )}
+                {bead.labels.includes('gt:babysit') && (
+                  <>
+                    {typeof bead.metadata.head_sha === 'string' && (
+                      <div>
+                        <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                          Head SHA
+                        </dt>
+                        <dd className="font-mono text-xs">{bead.metadata.head_sha.slice(0, 7)}</dd>
+                      </div>
+                    )}
+                    <div>
+                      <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                        Force-push
+                      </dt>
+                      <dd className="flex items-center gap-1 text-xs">
+                        {bead.metadata.force_push_allowed === true ? (
+                          <>
+                            <Unlock className="h-3 w-3 text-green-400" />
+                            <span className="text-green-400">Allowed</span>
+                          </>
+                        ) : (
+                          <>
+                            <Lock className="h-3 w-3 text-red-400" />
+                            <span className="text-red-400">Blocked</span>
+                          </>
+                        )}
+                      </dd>
+                    </div>
+                    {typeof bead.metadata.babysit_started_at === 'string' && (
+                      <div>
+                        <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                          Babysit started
+                        </dt>
+                        <dd
+                          title={format(
+                            new Date(bead.metadata.babysit_started_at as string),
+                            'PPpp'
+                          )}
+                        >
+                          {formatDistanceToNow(
+                            new Date(bead.metadata.babysit_started_at as string),
+                            { addSuffix: true }
+                          )}
+                        </dd>
+                      </div>
+                    )}
+                  </>
                 )}
               </dl>
             </CardContent>

--- a/apps/web/src/components/gastown/ActivityFeed.test.ts
+++ b/apps/web/src/components/gastown/ActivityFeed.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from '@jest/globals';
+import { eventDescription } from './eventDescription';
+
+describe('eventDescription: babysit event types', () => {
+  const base = {
+    old_value: null,
+    new_value: null,
+    metadata: {},
+    rig_name: undefined,
+  };
+
+  it('renders babysit_started with default description', () => {
+    expect(eventDescription({ ...base, event_type: 'babysit_started' })).toBe(
+      'Babysit started — town is now monitoring this PR'
+    );
+  });
+
+  it('renders babysit_started with rig prefix', () => {
+    expect(eventDescription({ ...base, event_type: 'babysit_started', rig_name: 'my-rig' })).toBe(
+      '[my-rig] Babysit started — town is now monitoring this PR'
+    );
+  });
+
+  it('renders pr_feedback_detected without source', () => {
+    expect(eventDescription({ ...base, event_type: 'pr_feedback_detected' })).toBe(
+      'PR feedback detected'
+    );
+  });
+
+  it('renders pr_feedback_detected with source from metadata', () => {
+    expect(
+      eventDescription({
+        ...base,
+        event_type: 'pr_feedback_detected',
+        metadata: { source: 'ci-failure' },
+      })
+    ).toBe('PR feedback detected (ci-failure)');
+  });
+
+  it('renders pr_conflict_detected', () => {
+    expect(eventDescription({ ...base, event_type: 'pr_conflict_detected' })).toBe(
+      'PR merge conflict detected'
+    );
+  });
+
+  it('renders pr_auto_merge', () => {
+    expect(eventDescription({ ...base, event_type: 'pr_auto_merge' })).toBe(
+      'PR auto-merge triggered'
+    );
+  });
+
+  it('renders pr_status_changed with new_value', () => {
+    expect(
+      eventDescription({ ...base, event_type: 'pr_status_changed', new_value: 'merged' })
+    ).toBe('PR status changed: merged');
+  });
+
+  it('renders pr_status_changed without new_value', () => {
+    expect(eventDescription({ ...base, event_type: 'pr_status_changed' })).toBe(
+      'PR status changed: unknown'
+    );
+  });
+});
+
+describe('eventDescription: existing event types still work', () => {
+  const base = {
+    old_value: null,
+    new_value: null,
+    metadata: {},
+    rig_name: undefined,
+  };
+
+  it('renders created event', () => {
+    expect(
+      eventDescription({ ...base, event_type: 'created', metadata: { title: 'My Bead' } })
+    ).toBe('Bead created: My Bead');
+  });
+
+  it('renders status_changed event', () => {
+    expect(
+      eventDescription({
+        ...base,
+        event_type: 'status_changed',
+        old_value: 'open',
+        new_value: 'in_progress',
+      })
+    ).toBe('Status: open → in_progress');
+  });
+
+  it('falls through to raw event_type for unknown events', () => {
+    expect(eventDescription({ ...base, event_type: 'some_future_event' })).toBe(
+      'some_future_event'
+    );
+  });
+});

--- a/apps/web/src/components/gastown/ActivityFeed.tsx
+++ b/apps/web/src/components/gastown/ActivityFeed.tsx
@@ -16,8 +16,13 @@ import {
   MessageSquare,
   ChevronRight,
   ShieldCheck,
+  Eye,
+  GitPullRequest as GitPullRequestIcon,
+  AlertCircle,
+  Zap,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
+import { eventDescription } from './eventDescription';
 
 const EVENT_ICONS: Record<string, typeof Activity> = {
   created: PlayCircle,
@@ -31,6 +36,11 @@ const EVENT_ICONS: Record<string, typeof Activity> = {
   mail_sent: Mail,
   agent_status: MessageSquare,
   triage_resolved: ShieldCheck,
+  babysit_started: Eye,
+  pr_feedback_detected: AlertCircle,
+  pr_conflict_detected: AlertTriangle,
+  pr_auto_merge: Zap,
+  pr_status_changed: GitPullRequestIcon,
 };
 
 const EVENT_COLORS: Record<string, string> = {
@@ -45,69 +55,15 @@ const EVENT_COLORS: Record<string, string> = {
   mail_sent: 'text-sky-500',
   agent_status: 'text-white/50',
   triage_resolved: 'text-amber-500',
+  babysit_started: 'text-cyan-500',
+  pr_feedback_detected: 'text-orange-500',
+  pr_conflict_detected: 'text-red-400',
+  pr_auto_merge: 'text-emerald-500',
+  pr_status_changed: 'text-purple-400',
 };
 
 type TownEvent = GastownOutputs['gastown']['getTownEvents'][number];
 type BeadEvent = GastownOutputs['gastown']['getBeadEvents'][number];
-
-function eventDescription(event: {
-  event_type: string;
-  old_value: string | null;
-  new_value: string | null;
-  metadata: Record<string, unknown>;
-  rig_name?: string;
-}): string {
-  const rigPrefix = event.rig_name ? `[${event.rig_name}] ` : '';
-  switch (event.event_type) {
-    case 'created': {
-      const title = event.metadata?.title;
-      return `${rigPrefix}Bead created: ${typeof title === 'string' ? title : (event.new_value ?? 'unknown')}`;
-    }
-    case 'hooked':
-      return `${rigPrefix}Agent hooked to bead`;
-    case 'unhooked':
-      return `${rigPrefix}Agent unhooked from bead`;
-    case 'status_changed': {
-      const desc = `${rigPrefix}Status: ${event.old_value ?? '?'} → ${event.new_value ?? '?'}`;
-      if (event.new_value === 'failed') {
-        const fr = event.metadata?.failure_reason;
-        if (typeof fr === 'object' && fr !== null && 'message' in fr) {
-          const msg = (fr as Record<string, unknown>).message;
-          if (typeof msg === 'string') return `${desc} — ${msg}`;
-        }
-      }
-      return desc;
-    }
-    case 'closed':
-      return `${rigPrefix}Bead closed`;
-    case 'escalated':
-      return `${rigPrefix}Escalation created`;
-    case 'review_submitted':
-      return `${rigPrefix}Submitted for review: ${event.new_value ?? ''}`;
-    case 'review_completed':
-      return `${rigPrefix}Review ${event.new_value ?? 'completed'}`;
-    case 'mail_sent':
-      return `${rigPrefix}Mail sent`;
-    case 'triage_resolved': {
-      const action = event.new_value ?? (event.metadata?.action as string | undefined) ?? 'unknown';
-      const notes = event.metadata?.resolution_notes as string | undefined;
-      const desc = `${rigPrefix}Triage: ${action}`;
-      return notes ? `${desc} — ${notes}` : desc;
-    }
-    case 'agent_status': {
-      const msg = event.new_value ?? (event.metadata?.message as string | undefined);
-      const agentName = event.metadata?.agent_name as string | undefined;
-      const rigName = event.metadata?.rig_name as string | undefined;
-      const body = msg ?? 'Agent status update';
-      // Prefer metadata rig_name over the top-level rig_name (which is
-      // never populated for bead_events rows).
-      const prefix = rigName ? `[${rigName}] ` : rigPrefix;
-      return agentName ? `${prefix}${agentName}: ${body}` : `${prefix}${body}`;
-    }
-    default:
-      return `${rigPrefix}${event.event_type}`;
-  }
-}
 
 function toEventDescriptionInput(event: TownEvent | BeadEvent) {
   return {

--- a/apps/web/src/components/gastown/drawer-panels/BeadPanel.test.ts
+++ b/apps/web/src/components/gastown/drawer-panels/BeadPanel.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildRelatedBeads, type BeadLike } from './buildRelatedBeads';
+
+const makeBead = (
+  overrides: Partial<BeadLike> & Pick<BeadLike, 'bead_id' | 'type' | 'title'>
+): BeadLike => ({
+  status: 'open',
+  parent_bead_id: null,
+  rig_id: null,
+  metadata: {},
+  ...overrides,
+});
+
+describe('buildRelatedBeads: babysit source bead filtering', () => {
+  const sourceBead = makeBead({ bead_id: 'source-1', type: 'issue', title: 'Source Work' });
+
+  it('includes source bead for non-babysit merge_request beads with source_bead_id', () => {
+    const babysitBead = makeBead({
+      bead_id: 'mr-1',
+      type: 'merge_request',
+      title: 'MR without babysit',
+      metadata: { source_bead_id: 'source-1' },
+    });
+    const related = buildRelatedBeads(babysitBead, [babysitBead, sourceBead], []);
+    const sourceRelation = related.find(r => r.relation === 'source');
+    expect(sourceRelation).toBeDefined();
+    expect(sourceRelation?.bead.bead_id).toBe('source-1');
+  });
+
+  it('excludes source bead for babysit beads (filtered by caller)', () => {
+    const babysitBead = makeBead({
+      bead_id: 'mr-2',
+      type: 'merge_request',
+      title: 'Babysat MR',
+      metadata: { source_bead_id: 'source-1' },
+    });
+    const related = buildRelatedBeads(babysitBead, [babysitBead, sourceBead], []);
+    const isBabysit = true;
+    const filtered = related.filter(r => !(r.relation === 'source' && isBabysit));
+    expect(filtered.find(r => r.relation === 'source')).toBeUndefined();
+  });
+
+  it('includes child beads regardless of babysit status', () => {
+    const babysitBead = makeBead({
+      bead_id: 'mr-3',
+      type: 'merge_request',
+      title: 'Babysat MR',
+    });
+    const childBead = makeBead({
+      bead_id: 'child-1',
+      type: 'issue',
+      title: 'Child issue',
+      parent_bead_id: 'mr-3',
+    });
+    const related = buildRelatedBeads(babysitBead, [babysitBead, childBead], []);
+    const childRelation = related.find(r => r.relation === 'child');
+    expect(childRelation).toBeDefined();
+    expect(childRelation?.bead.bead_id).toBe('child-1');
+  });
+});
+
+describe('babysit badge detection logic', () => {
+  it('detects gt:babysit label', () => {
+    const labels = ['gt:merge-request', 'gt:babysit'];
+    expect(labels.includes('gt:babysit')).toBe(true);
+  });
+
+  it('does not detect gt:babysit when absent', () => {
+    const labels = ['gt:merge-request'];
+    expect(labels.includes('gt:babysit')).toBe(false);
+  });
+});
+
+describe('babysit metadata extraction', () => {
+  it('extracts head_sha from metadata', () => {
+    const metadata: Record<string, unknown> = { head_sha: 'abc1234def5678' };
+    expect(typeof metadata.head_sha).toBe('string');
+    expect((metadata.head_sha as string).slice(0, 7)).toBe('abc1234');
+  });
+
+  it('extracts force_push_allowed from metadata', () => {
+    const metaTrue: Record<string, unknown> = { force_push_allowed: true };
+    const metaFalse: Record<string, unknown> = { force_push_allowed: false };
+    const metaMissing: Record<string, unknown> = {};
+    expect(metaTrue.force_push_allowed).toBe(true);
+    expect(metaFalse.force_push_allowed).toBe(false);
+    expect(metaMissing.force_push_allowed).toBeUndefined();
+  });
+
+  it('extracts babysit_started_at from metadata', () => {
+    const metadata: Record<string, unknown> = { babysit_started_at: '2026-05-28T12:00:00Z' };
+    expect(typeof metadata.babysit_started_at).toBe('string');
+  });
+});

--- a/apps/web/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/apps/web/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, type ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
@@ -11,6 +11,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { BeadEventTimeline, extractPrUrl } from '@/components/gastown/ActivityFeed';
 import type { ResourceRef } from '@/components/gastown/DrawerStack';
 import { WastelandOriginLink } from './WastelandOriginLink';
+import { buildRelatedBeads, type BeadLike } from './buildRelatedBeads';
 
 import { format, formatDistanceToNow } from 'date-fns';
 import {
@@ -26,10 +27,6 @@ import {
   ChevronRight,
   Bot,
   Network,
-  ArrowDownRight,
-  ArrowUpRight,
-  GitPullRequest,
-  CircleDot,
   Layers,
   Pencil,
   X,
@@ -37,6 +34,9 @@ import {
   Loader2,
   Play,
   MessageCircle,
+  Lock,
+  Unlock,
+  Eye,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -238,7 +238,9 @@ export function BeadPanel({
   // Build related beads from the flat list and convoy DAG data
   const allBeads = beadsQuery.data ?? [];
   const convoys = convoysQuery.data ?? [];
-  const relatedBeads = buildRelatedBeads(bead, allBeads, convoys);
+  const relatedBeads = buildRelatedBeads(bead, allBeads, convoys).filter(
+    r => !(r.relation === 'source' && isBabysit)
+  );
 
   // Find parent convoy for metadata display
   const beadConvoyId =
@@ -249,6 +251,9 @@ export function BeadPanel({
 
   // Held bead detection
   const isHeld = bead.labels.includes('gt:held');
+
+  // Babysit bead detection
+  const isBabysit = bead.labels.includes('gt:babysit');
 
   // Mayor responses: message-type child beads
   const mayorResponses = allBeads.filter(
@@ -329,6 +334,12 @@ export function BeadPanel({
             <Badge variant="outline" className="text-[10px]">
               {bead.type}
             </Badge>
+            {isBabysit && (
+              <span className="inline-flex items-center gap-1 rounded-md border border-cyan-500/30 bg-cyan-500/10 px-2 py-0.5 text-[10px] font-medium text-cyan-300">
+                <Eye className="size-2.5" />
+                Babysat external PR
+              </span>
+            )}
             <span
               className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${PRIORITY_STYLES[bead.priority] ?? 'text-white/50'}`}
             >
@@ -517,6 +528,47 @@ export function BeadPanel({
         </div>
       )}
 
+      {/* Babysit metadata */}
+      {isBabysit && (
+        <div className="grid grid-cols-2 border-b border-white/[0.06]">
+          {typeof bead.metadata?.head_sha === 'string' && (
+            <MetaCell
+              icon={Hash}
+              label="Head SHA"
+              value={
+                prUrl && bead.metadata.head_sha.length >= 7 ? (
+                  <a
+                    href={`${prUrl.replace(/\/pull\/\d+.*$/, '/commit/')}${bead.metadata.head_sha}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-mono text-xs text-[color:oklch(95%_0.15_108)] hover:underline"
+                  >
+                    {bead.metadata.head_sha.slice(0, 7)}
+                  </a>
+                ) : (
+                  <span className="font-mono text-xs">{bead.metadata.head_sha.slice(0, 7)}</span>
+                )
+              }
+              mono
+            />
+          )}
+          <MetaCell
+            icon={bead.metadata?.force_push_allowed === true ? Unlock : Lock}
+            label="Force-push"
+            value={bead.metadata?.force_push_allowed === true ? 'Allowed' : 'Blocked'}
+          />
+          {typeof bead.metadata?.babysit_started_at === 'string' && (
+            <MetaCell
+              icon={Clock}
+              label="Babysit started"
+              value={formatDistanceToNow(new Date(bead.metadata.babysit_started_at), {
+                addSuffix: true,
+              })}
+            />
+          )}
+        </div>
+      )}
+
       {/* Wasteland origin link — present when this bead was created in
           response to a wasteland event (e.g. a wanted-item claim). */}
       <WastelandOriginLink metadata={bead.metadata} pathname={pathname} />
@@ -668,7 +720,7 @@ function MetaCell({
 }: {
   icon: typeof Clock;
   label: string;
-  value: string;
+  value: ReactNode;
   mono?: boolean;
 }) {
   return (
@@ -682,144 +734,4 @@ function MetaCell({
       </div>
     </div>
   );
-}
-
-// ── Related beads DAG ─────────────────────────────────────────────────
-
-type BeadLike = {
-  bead_id: string;
-  type: string;
-  status: string;
-  title: string;
-  parent_bead_id: string | null;
-  rig_id?: string | null;
-  metadata: Record<string, unknown>;
-};
-
-type RelatedBead = {
-  relation: string;
-  label: string;
-  icon: typeof Clock;
-  bead: BeadLike;
-};
-
-type ConvoyLike = {
-  id: string;
-  title: string;
-  feature_branch?: string | null;
-  beads: Array<{ bead_id: string; title: string; status: string; rig_id: string | null }>;
-  dependency_edges?: Array<{ bead_id: string; depends_on_bead_id: string }>;
-};
-
-/**
- * Compute the DAG neighborhood of a bead from the flat list and convoy data.
- * Includes: children, source/review links, blockers, and dependents from convoy DAG.
- */
-function buildRelatedBeads(
-  bead: BeadLike,
-  allBeads: BeadLike[],
-  convoys: ConvoyLike[]
-): RelatedBead[] {
-  const related: RelatedBead[] = [];
-
-  // Find which convoy this bead belongs to (if any) via metadata or convoy beads list
-  const convoyId = typeof bead.metadata?.convoy_id === 'string' ? bead.metadata.convoy_id : null;
-  const parentConvoy = convoys.find(
-    c => c.id === convoyId || c.beads.some(b => b.bead_id === bead.bead_id)
-  );
-
-  // Show convoy membership
-  if (parentConvoy) {
-    // Find blockers (beads that this bead depends on / is blocked by)
-    const edges = parentConvoy.dependency_edges ?? [];
-    const blockerIds = new Set(
-      edges.filter(e => e.bead_id === bead.bead_id).map(e => e.depends_on_bead_id)
-    );
-    for (const blockerId of blockerIds) {
-      const blockerBead = allBeads.find(b => b.bead_id === blockerId);
-      const convoyBead = parentConvoy.beads.find(b => b.bead_id === blockerId);
-      if (blockerBead) {
-        related.push({
-          relation: 'blocker',
-          label: 'Blocked by',
-          icon: ArrowUpRight,
-          bead: blockerBead,
-        });
-      } else if (convoyBead) {
-        // Bead is in convoy but not in the rig's bead list — use convoy data
-        related.push({
-          relation: 'blocker',
-          label: 'Blocked by',
-          icon: ArrowUpRight,
-          bead: {
-            bead_id: convoyBead.bead_id,
-            type: 'issue',
-            status: convoyBead.status,
-            title: convoyBead.title,
-            parent_bead_id: null,
-            rig_id: convoyBead.rig_id,
-            metadata: {},
-          },
-        });
-      }
-    }
-
-    // Find dependents (beads that depend on / are blocked by this bead)
-    const dependentIds = new Set(
-      edges.filter(e => e.depends_on_bead_id === bead.bead_id).map(e => e.bead_id)
-    );
-    for (const depId of dependentIds) {
-      const depBead = allBeads.find(b => b.bead_id === depId);
-      const convoyBead = parentConvoy.beads.find(b => b.bead_id === depId);
-      if (depBead) {
-        related.push({
-          relation: 'dependent',
-          label: 'Blocks',
-          icon: ArrowDownRight,
-          bead: depBead,
-        });
-      } else if (convoyBead) {
-        related.push({
-          relation: 'dependent',
-          label: 'Blocks',
-          icon: ArrowDownRight,
-          bead: {
-            bead_id: convoyBead.bead_id,
-            type: 'issue',
-            status: convoyBead.status,
-            title: convoyBead.title,
-            parent_bead_id: null,
-            rig_id: convoyBead.rig_id,
-            metadata: {},
-          },
-        });
-      }
-    }
-  }
-
-  // Child beads (beads whose parent_bead_id = this bead)
-  for (const b of allBeads) {
-    if (b.parent_bead_id === bead.bead_id) {
-      related.push({ relation: 'child', label: 'Child', icon: ArrowDownRight, bead: b });
-    }
-  }
-
-  // For merge_request beads: link back to the source bead
-  if (bead.type === 'merge_request' && typeof bead.metadata?.source_bead_id === 'string') {
-    const source = allBeads.find(b => b.bead_id === bead.metadata.source_bead_id);
-    if (source) {
-      related.push({ relation: 'source', label: 'Source Work', icon: CircleDot, bead: source });
-    }
-  }
-
-  // For non-MR beads: find any MR beads that track this bead
-  if (bead.type !== 'merge_request') {
-    for (const b of allBeads) {
-      if (b.type === 'merge_request' && b.metadata?.source_bead_id === bead.bead_id) {
-        related.push({ relation: 'review', label: 'Review', icon: GitPullRequest, bead: b });
-      }
-    }
-  }
-
-  return related;
 }

--- a/apps/web/src/components/gastown/drawer-panels/buildRelatedBeads.ts
+++ b/apps/web/src/components/gastown/drawer-panels/buildRelatedBeads.ts
@@ -1,0 +1,137 @@
+import {
+  ArrowDownRight,
+  ArrowUpRight,
+  GitPullRequest,
+  CircleDot,
+  type LucideIcon,
+} from 'lucide-react';
+
+export type BeadLike = {
+  bead_id: string;
+  type: string;
+  status: string;
+  title: string;
+  parent_bead_id: string | null;
+  rig_id?: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export type RelatedBead = {
+  relation: string;
+  label: string;
+  icon: LucideIcon;
+  bead: BeadLike;
+};
+
+type ConvoyLike = {
+  id: string;
+  title: string;
+  feature_branch?: string | null;
+  beads: Array<{ bead_id: string; title: string; status: string; rig_id: string | null }>;
+  dependency_edges?: Array<{ bead_id: string; depends_on_bead_id: string }>;
+};
+
+/**
+ * Compute the DAG neighborhood of a bead from the flat list and convoy data.
+ * Includes: children, source/review links, blockers, and dependents from convoy DAG.
+ */
+export function buildRelatedBeads(
+  bead: BeadLike,
+  allBeads: BeadLike[],
+  convoys: ConvoyLike[]
+): RelatedBead[] {
+  const related: RelatedBead[] = [];
+
+  const convoyId = typeof bead.metadata?.convoy_id === 'string' ? bead.metadata.convoy_id : null;
+  const parentConvoy = convoys.find(
+    c => c.id === convoyId || c.beads.some(b => b.bead_id === bead.bead_id)
+  );
+
+  if (parentConvoy) {
+    const edges = parentConvoy.dependency_edges ?? [];
+    const blockerIds = new Set(
+      edges.filter(e => e.bead_id === bead.bead_id).map(e => e.depends_on_bead_id)
+    );
+    for (const blockerId of blockerIds) {
+      const blockerBead = allBeads.find(b => b.bead_id === blockerId);
+      const convoyBead = parentConvoy.beads.find(b => b.bead_id === blockerId);
+      if (blockerBead) {
+        related.push({
+          relation: 'blocker',
+          label: 'Blocked by',
+          icon: ArrowUpRight,
+          bead: blockerBead,
+        });
+      } else if (convoyBead) {
+        related.push({
+          relation: 'blocker',
+          label: 'Blocked by',
+          icon: ArrowUpRight,
+          bead: {
+            bead_id: convoyBead.bead_id,
+            type: 'issue',
+            status: convoyBead.status,
+            title: convoyBead.title,
+            parent_bead_id: null,
+            rig_id: convoyBead.rig_id,
+            metadata: {},
+          },
+        });
+      }
+    }
+
+    const dependentIds = new Set(
+      edges.filter(e => e.depends_on_bead_id === bead.bead_id).map(e => e.bead_id)
+    );
+    for (const depId of dependentIds) {
+      const depBead = allBeads.find(b => b.bead_id === depId);
+      const convoyBead = parentConvoy.beads.find(b => b.bead_id === depId);
+      if (depBead) {
+        related.push({
+          relation: 'dependent',
+          label: 'Blocks',
+          icon: ArrowDownRight,
+          bead: depBead,
+        });
+      } else if (convoyBead) {
+        related.push({
+          relation: 'dependent',
+          label: 'Blocks',
+          icon: ArrowDownRight,
+          bead: {
+            bead_id: convoyBead.bead_id,
+            type: 'issue',
+            status: convoyBead.status,
+            title: convoyBead.title,
+            parent_bead_id: null,
+            rig_id: convoyBead.rig_id,
+            metadata: {},
+          },
+        });
+      }
+    }
+  }
+
+  for (const b of allBeads) {
+    if (b.parent_bead_id === bead.bead_id) {
+      related.push({ relation: 'child', label: 'Child', icon: ArrowDownRight, bead: b });
+    }
+  }
+
+  if (bead.type === 'merge_request' && typeof bead.metadata?.source_bead_id === 'string') {
+    const source = allBeads.find(b => b.bead_id === bead.metadata.source_bead_id);
+    if (source) {
+      related.push({ relation: 'source', label: 'Source Work', icon: CircleDot, bead: source });
+    }
+  }
+
+  if (bead.type !== 'merge_request') {
+    for (const b of allBeads) {
+      if (b.type === 'merge_request' && b.metadata?.source_bead_id === bead.bead_id) {
+        related.push({ relation: 'review', label: 'Review', icon: GitPullRequest, bead: b });
+      }
+    }
+  }
+
+  return related;
+}

--- a/apps/web/src/components/gastown/eventDescription.ts
+++ b/apps/web/src/components/gastown/eventDescription.ts
@@ -1,0 +1,72 @@
+export function eventDescription(event: {
+  event_type: string;
+  old_value: string | null;
+  new_value: string | null;
+  metadata: Record<string, unknown>;
+  rig_name?: string;
+}): string {
+  const rigPrefix = event.rig_name ? `[${event.rig_name}] ` : '';
+  switch (event.event_type) {
+    case 'created': {
+      const title = event.metadata?.title;
+      return `${rigPrefix}Bead created: ${typeof title === 'string' ? title : (event.new_value ?? 'unknown')}`;
+    }
+    case 'hooked':
+      return `${rigPrefix}Agent hooked to bead`;
+    case 'unhooked':
+      return `${rigPrefix}Agent unhooked from bead`;
+    case 'status_changed': {
+      const desc = `${rigPrefix}Status: ${event.old_value ?? '?'} → ${event.new_value ?? '?'}`;
+      if (event.new_value === 'failed') {
+        const fr = event.metadata?.failure_reason;
+        if (typeof fr === 'object' && fr !== null && 'message' in fr) {
+          const msg = (fr as Record<string, unknown>).message;
+          if (typeof msg === 'string') return `${desc} — ${msg}`;
+        }
+      }
+      return desc;
+    }
+    case 'closed':
+      return `${rigPrefix}Bead closed`;
+    case 'escalated':
+      return `${rigPrefix}Escalation created`;
+    case 'review_submitted':
+      return `${rigPrefix}Submitted for review: ${event.new_value ?? ''}`;
+    case 'review_completed':
+      return `${rigPrefix}Review ${event.new_value ?? 'completed'}`;
+    case 'mail_sent':
+      return `${rigPrefix}Mail sent`;
+    case 'triage_resolved': {
+      const action = event.new_value ?? (event.metadata?.action as string | undefined) ?? 'unknown';
+      const notes = event.metadata?.resolution_notes as string | undefined;
+      const desc = `${rigPrefix}Triage: ${action}`;
+      return notes ? `${desc} — ${notes}` : desc;
+    }
+    case 'agent_status': {
+      const msg = event.new_value ?? (event.metadata?.message as string | undefined);
+      const agentName = event.metadata?.agent_name as string | undefined;
+      const rigName = event.metadata?.rig_name as string | undefined;
+      const body = msg ?? 'Agent status update';
+      const prefix = rigName ? `[${rigName}] ` : rigPrefix;
+      return agentName ? `${prefix}${agentName}: ${body}` : `${prefix}${body}`;
+    }
+    case 'babysit_started':
+      return `${rigPrefix}Babysit started — town is now monitoring this PR`;
+    case 'pr_feedback_detected': {
+      const source = event.metadata?.source as string | undefined;
+      return source
+        ? `${rigPrefix}PR feedback detected (${source})`
+        : `${rigPrefix}PR feedback detected`;
+    }
+    case 'pr_conflict_detected':
+      return `${rigPrefix}PR merge conflict detected`;
+    case 'pr_auto_merge':
+      return `${rigPrefix}PR auto-merge triggered`;
+    case 'pr_status_changed': {
+      const state = event.new_value ?? 'unknown';
+      return `${rigPrefix}PR status changed: ${state}`;
+    }
+    default:
+      return `${rigPrefix}${event.event_type}`;
+  }
+}


### PR DESCRIPTION
## Summary

Chunk 4 of 6 for the "Babysit existing PR" feature. Adds babysit-specific UI to the BeadPanel drawer and the admin BeadInspectorDashboard.

- **Babysat external PR badge**: Cyan-colored badge with Eye icon shown when `gt:babysit` is in the bead's labels. Distinct from the amber `gt:held` badge and the default `gt:merge-request` type badge.
- **Source bead section hidden**: For babysat beads (which intentionally have no `source_bead_id`), the "Source Work" related bead link is filtered out.
- **Babysit metadata panel**: New grid section showing `head_sha` (7-char abbreviated, linked to commit URL when PR URL is available), `force_push_allowed` (Lock/Unlock icons with "Allowed"/"Blocked" text), and `babysit_started_at` (relative time).
- **Activity timeline event formatters**: Added human-readable descriptions and icons/colors for `babysit_started`, `pr_feedback_detected`, `pr_conflict_detected`, `pr_auto_merge`, and `pr_status_changed` events.
- **BeadInspectorDashboard**: Mirrored babysit badge in header and babysit metadata fields (head SHA, force-push, babysit started) in the Overview card.
- **Extracted pure logic**: Moved `buildRelatedBeads` and `eventDescription` into separate files for testability without React/motion/DB dependencies.

## Verification

Manual verification: inspected BeadPanel rendering logic for babysit badge visibility, metadata panel conditional rendering, and source bead filtering. Typecheck passes.

## Visual Changes

- New "Babysat external PR" cyan badge in bead header
- New babysit metadata grid (Head SHA, Force-push, Babysit started) in BeadPanel
- New babysit badge + metadata in admin BeadInspectorDashboard
- New event descriptions and icons in activity timeline for babysit-related events

## Reviewer Notes

- `buildRelatedBeads.ts` and `eventDescription.ts` are extractions from existing code, not new logic — they're identical to what was previously inline in BeadPanel.tsx and ActivityFeed.tsx respectively, plus the new babysit event types in `eventDescription`.
- Tests exist but cannot run in this environment (no Postgres). They are pure unit tests verified via typecheck.
- The `MetaCell` component's `value` prop was widened from `string` to `ReactNode` to support the linked SHA rendering.