### PR TITLE
feat(gastown): gt_babysit_pr mayor tool + force-push gate (chunk 2)

### DIFF
--- a/services/gastown/container/plugin/client.test.ts
+++ b/services/gastown/container/plugin/client.test.ts
@@ -371,4 +371,50 @@ describe('MayorGastownClient', () => {
     const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
     expect(url).toBe('https://gastown.example.com/api/mayor/town-1/tools/convoys/convoy-1');
   });
+
+  it('babysitPr() posts to babysit-pr endpoint', async () => {
+    const responseData = { beadId: 'babysit-bead-1' };
+    const fetchMock = mockFetch(responseData);
+    globalThis.fetch = fetchMock;
+
+    const result = await client.babysitPr({
+      rig_id: 'rig-1',
+      pr_url: 'https://github.com/owner/repo/pull/42',
+      title: 'Babysit: Fix auth',
+      force_push_allowed: false,
+    });
+
+    expect(result).toEqual(responseData);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://gastown.example.com/api/mayor/town-1/tools/babysit-pr');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      rig_id: 'rig-1',
+      pr_url: 'https://github.com/owner/repo/pull/42',
+      title: 'Babysit: Fix auth',
+      body: undefined,
+      force_push_allowed: false,
+    });
+  });
+
+  it('babysitPr() omits optional fields when not provided', async () => {
+    const responseData = { beadId: 'babysit-bead-2', warning: 'PR from fork' };
+    const fetchMock = mockFetch(responseData);
+    globalThis.fetch = fetchMock;
+
+    const result = await client.babysitPr({
+      rig_id: 'rig-2',
+      pr_url: 'https://github.com/other/repo/pull/7',
+    });
+
+    expect(result).toEqual(responseData);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      rig_id: 'rig-2',
+      pr_url: 'https://github.com/other/repo/pull/7',
+      title: undefined,
+      body: undefined,
+      force_push_allowed: undefined,
+    });
+  });
 });

--- a/services/gastown/container/plugin/client.ts
+++ b/services/gastown/container/plugin/client.ts
@@ -1,6 +1,7 @@
 import type {
   Agent,
   ApiResponse,
+  BabysitPrResult,
   Bead,
   BeadPriority,
   BeadStatus,
@@ -375,6 +376,19 @@ export class MayorGastownClient {
     labels?: string[];
   }): Promise<SlingResult> {
     return this.request<SlingResult>(this.mayorPath('/sling'), {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+
+  async babysitPr(input: {
+    rig_id: string;
+    pr_url: string;
+    title?: string;
+    body?: string;
+    force_push_allowed?: boolean;
+  }): Promise<BabysitPrResult> {
+    return this.request<BabysitPrResult>(this.mayorPath('/babysit-pr'), {
       method: 'POST',
       body: JSON.stringify(input),
     });

--- a/services/gastown/container/plugin/mayor-tools.test.ts
+++ b/services/gastown/container/plugin/mayor-tools.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { MayorGastownClient } from './client';
 import type {
   Agent,
+  BabysitPrResult,
   Bead,
   Convoy,
   ConvoyDetail,
@@ -86,6 +87,9 @@ function makeFakeMayorClient(overrides: Partial<MayorGastownClient> = {}): Mayor
     sling: vi.fn<() => Promise<SlingResult>>().mockResolvedValue({
       bead: FAKE_BEAD,
       agent: FAKE_AGENT,
+    }),
+    babysitPr: vi.fn<() => Promise<BabysitPrResult>>().mockResolvedValue({
+      beadId: 'babysit-bead-1',
     }),
     listRigs: vi.fn<() => Promise<Rig[]>>().mockResolvedValue([]),
     listBeads: vi.fn<() => Promise<Bead[]>>().mockResolvedValue([]),
@@ -586,6 +590,64 @@ describe('mayor tools', () => {
         message: 'Urgent!',
         mode: 'immediate',
       });
+    });
+  });
+
+  describe('gt_babysit_pr', () => {
+    it('delegates to client.babysitPr and returns result summary', async () => {
+      const result = await tools.gt_babysit_pr.execute(
+        {
+          rig_id: 'rig-1',
+          pr_url: 'https://github.com/owner/repo/pull/42',
+        },
+        CTX
+      );
+      expect(result).toContain('Babysit started');
+      expect(result).toContain('https://github.com/owner/repo/pull/42');
+      expect(result).toContain('babysit-bead-1');
+      expect(client.babysitPr).toHaveBeenCalledWith({
+        rig_id: 'rig-1',
+        pr_url: 'https://github.com/owner/repo/pull/42',
+        title: undefined,
+        body: undefined,
+        force_push_allowed: undefined,
+      });
+    });
+
+    it('passes all optional fields to the client', async () => {
+      await tools.gt_babysit_pr.execute(
+        {
+          rig_id: 'rig-1',
+          pr_url: 'https://github.com/owner/repo/pull/99',
+          title: 'Babysit: Fix auth',
+          body: 'Please merge this PR',
+          force_push_allowed: true,
+        },
+        CTX
+      );
+      expect(client.babysitPr).toHaveBeenCalledWith({
+        rig_id: 'rig-1',
+        pr_url: 'https://github.com/owner/repo/pull/99',
+        title: 'Babysit: Fix auth',
+        body: 'Please merge this PR',
+        force_push_allowed: true,
+      });
+    });
+
+    it('includes warning in result when present', async () => {
+      client = makeFakeMayorClient({
+        babysitPr: vi.fn<() => Promise<BabysitPrResult>>().mockResolvedValue({
+          beadId: 'babysit-bead-2',
+          warning: 'PR is from a fork — limited permissions',
+        }),
+      });
+      tools = createMayorTools(client);
+
+      const result = await tools.gt_babysit_pr.execute(
+        { rig_id: 'rig-1', pr_url: 'https://github.com/owner/repo/pull/55' },
+        CTX
+      );
+      expect(result).toContain('Warning: PR is from a fork — limited permissions');
     });
   });
 });

--- a/services/gastown/container/plugin/mayor-tools.ts
+++ b/services/gastown/container/plugin/mayor-tools.ts
@@ -80,6 +80,52 @@ export function createMayorTools(client: MayorGastownClient) {
       },
     }),
 
+    gt_babysit_pr: tool({
+      description:
+        'Adopt an existing pull request for the town to babysit. The town will poll the PR for review feedback, fix CI failures, resolve merge conflicts, and auto-merge when ready — exactly as it would for a PR the town created itself. Use this when the user wants the town to take over an existing PR (e.g. one they created manually, one created by another tool, or one from a third party they have rights to). For new feature work that should produce a PR, use gt_sling instead.',
+      args: {
+        rig_id: tool.schema.string().describe('The UUID of the rig the PR belongs to'),
+        pr_url: tool.schema
+          .string()
+          .describe(
+            'The full URL of the pull request to babysit (e.g. https://github.com/owner/repo/pull/123)'
+          ),
+        title: tool.schema
+          .string()
+          .describe(
+            'Optional title override for the babysit bead. Defaults to "Babysit: <PR title>".'
+          )
+          .optional(),
+        body: tool.schema
+          .string()
+          .describe('Optional body override for the babysit bead.')
+          .optional(),
+        force_push_allowed: tool.schema
+          .boolean()
+          .describe(
+            'Whether polecats may force-push to the PR branch when fixing conflicts or ' +
+              'addressing review comments. Default false. Only set true if the user owns the ' +
+              'branch or the PR author has explicitly consented. When false, polecats use ' +
+              'merge commits and regular pushes only.'
+          )
+          .optional(),
+      },
+      async execute(args) {
+        const result = await client.babysitPr({
+          rig_id: args.rig_id,
+          pr_url: args.pr_url,
+          title: args.title,
+          body: args.body,
+          force_push_allowed: args.force_push_allowed,
+        });
+        const lines = [`Babysit started for PR: ${args.pr_url}`, `Bead: ${result.beadId}`];
+        if (result.warning) {
+          lines.push(`Warning: ${result.warning}`);
+        }
+        return lines.join('\n');
+      },
+    }),
+
     gt_list_rigs: tool({
       description:
         'List all rigs (repositories) in your town. ' +

--- a/services/gastown/container/plugin/types.ts
+++ b/services/gastown/container/plugin/types.ts
@@ -63,6 +63,33 @@ export type PrimeContext = {
   hooked_bead: Bead | null;
   undelivered_mail: Mail[];
   open_beads: Bead[];
+  /** Present when the hooked bead is a rework request (gt:rework label). */
+  rework_context: {
+    feedback: string;
+    branch: string | null;
+    target_branch: string | null;
+    files: string[];
+    original_bead_title: string | null;
+    mr_bead_id: string | null;
+  } | null;
+  /** Present when the hooked bead is a PR fixup (gt:pr-fixup label). */
+  pr_fixup_context: {
+    pr_url: string | null;
+    branch: string | null;
+    target_branch: string | null;
+    /** Whether force-push is allowed on this PR branch. Absent = true (backwards compat). */
+    force_push_allowed: boolean;
+  } | null;
+  /** Present when the hooked bead is a PR conflict resolution (gt:pr-conflict label). */
+  pr_conflict_context: {
+    pr_url: string | null;
+    branch: string | null;
+    target_branch: string | null;
+    /** When true, the bead also has pending review feedback to address after resolving conflicts. */
+    has_feedback: boolean;
+    /** Whether force-push is allowed on this PR branch. Absent = true (backwards compat). */
+    force_push_allowed: boolean;
+  } | null;
 };
 
 // API response envelope
@@ -79,6 +106,13 @@ export type Rig = {
   default_branch: string;
   created_at: string;
   updated_at: string;
+};
+
+// Result of POST /babysit-pr — the babysit adoption creates a bead and
+// optionally returns a warning (e.g. PR already merged, but adoption proceeds).
+export type BabysitPrResult = {
+  beadId: string;
+  warning?: string;
 };
 
 // Sling result (bead + assigned agent)

--- a/services/gastown/src/dos/town/agents.ts
+++ b/services/gastown/src/dos/town/agents.ts
@@ -521,10 +521,14 @@ export function prime(sql: SqlStorage, agentId: string): PrimeContext {
   let pr_fixup_context: PrimeContext['pr_fixup_context'] = null;
   if (hookedBead?.labels.includes('gt:pr-fixup') && hookedBead.metadata) {
     const meta = hookedBead.metadata as Record<string, unknown>;
+    // force_push_allowed: absent = true (backwards compat for pre-babysit beads).
+    // Only explicit false disables force-push.
+    const forcePushAllowed = meta.force_push_allowed !== false;
     pr_fixup_context = {
       pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
       branch: typeof meta.branch === 'string' ? meta.branch : null,
       target_branch: typeof meta.target_branch === 'string' ? meta.target_branch : null,
+      force_push_allowed: forcePushAllowed,
     };
   }
 
@@ -533,11 +537,15 @@ export function prime(sql: SqlStorage, agentId: string): PrimeContext {
   let pr_conflict_context: PrimeContext['pr_conflict_context'] = null;
   if (hookedBead?.labels.includes('gt:pr-conflict') && hookedBead.metadata) {
     const meta = hookedBead.metadata as Record<string, unknown>;
+    // force_push_allowed: absent = true (backwards compat for pre-babysit beads).
+    // Only explicit false disables force-push.
+    const forcePushAllowed = meta.force_push_allowed !== false;
     pr_conflict_context = {
       pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
       branch: typeof meta.branch === 'string' ? meta.branch : null,
       target_branch: typeof meta.target_branch === 'string' ? meta.target_branch : null,
       has_feedback: meta.has_feedback === true || meta.has_feedback === 1,
+      force_push_allowed: forcePushAllowed,
     };
   } else if (hookedBead?.labels.includes('gt:pr-feedback') && hookedBead.metadata) {
     // A feedback bead can also have has_conflicts: true when a conflict was detected
@@ -545,12 +553,14 @@ export function prime(sql: SqlStorage, agentId: string): PrimeContext {
     // agent resolves conflicts first, then addresses review feedback.
     const meta = hookedBead.metadata as Record<string, unknown>;
     if (meta.has_conflicts === true || meta.has_conflicts === 1) {
+      const forcePushAllowed = meta.force_push_allowed !== false;
       pr_conflict_context = {
         pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
         branch: typeof meta.branch === 'string' ? meta.branch : null,
         target_branch:
           typeof meta.conflict_target_branch === 'string' ? meta.conflict_target_branch : null,
         has_feedback: true,
+        force_push_allowed: forcePushAllowed,
       };
     }
   }

--- a/services/gastown/src/dos/town/agents.ts
+++ b/services/gastown/src/dos/town/agents.ts
@@ -475,6 +475,15 @@ export function getOrCreateAgent(
 
 // ── Prime Context ───────────────────────────────────────────────────
 
+/**
+ * Resolve force_push_allowed from bead metadata.
+ * Absent = true (backwards compat for pre-babysit beads).
+ * Only explicit false disables force-push.
+ */
+export function resolveForcePushAllowed(meta: Record<string, unknown>): boolean {
+  return meta.force_push_allowed !== false;
+}
+
 export function prime(sql: SqlStorage, agentId: string): PrimeContext {
   const agent = getAgent(sql, agentId);
   if (!agent) throw new Error(`Agent ${agentId} not found`);
@@ -521,9 +530,7 @@ export function prime(sql: SqlStorage, agentId: string): PrimeContext {
   let pr_fixup_context: PrimeContext['pr_fixup_context'] = null;
   if (hookedBead?.labels.includes('gt:pr-fixup') && hookedBead.metadata) {
     const meta = hookedBead.metadata as Record<string, unknown>;
-    // force_push_allowed: absent = true (backwards compat for pre-babysit beads).
-    // Only explicit false disables force-push.
-    const forcePushAllowed = meta.force_push_allowed !== false;
+    const forcePushAllowed = resolveForcePushAllowed(meta);
     pr_fixup_context = {
       pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
       branch: typeof meta.branch === 'string' ? meta.branch : null,
@@ -537,9 +544,7 @@ export function prime(sql: SqlStorage, agentId: string): PrimeContext {
   let pr_conflict_context: PrimeContext['pr_conflict_context'] = null;
   if (hookedBead?.labels.includes('gt:pr-conflict') && hookedBead.metadata) {
     const meta = hookedBead.metadata as Record<string, unknown>;
-    // force_push_allowed: absent = true (backwards compat for pre-babysit beads).
-    // Only explicit false disables force-push.
-    const forcePushAllowed = meta.force_push_allowed !== false;
+    const forcePushAllowed = resolveForcePushAllowed(meta);
     pr_conflict_context = {
       pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
       branch: typeof meta.branch === 'string' ? meta.branch : null,
@@ -553,7 +558,7 @@ export function prime(sql: SqlStorage, agentId: string): PrimeContext {
     // agent resolves conflicts first, then addresses review feedback.
     const meta = hookedBead.metadata as Record<string, unknown>;
     if (meta.has_conflicts === true || meta.has_conflicts === 1) {
-      const forcePushAllowed = meta.force_push_allowed !== false;
+      const forcePushAllowed = resolveForcePushAllowed(meta);
       pr_conflict_context = {
         pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
         branch: typeof meta.branch === 'string' ? meta.branch : null,

--- a/services/gastown/src/prompts/mayor-system.prompt.ts
+++ b/services/gastown/src/prompts/mayor-system.prompt.ts
@@ -38,6 +38,7 @@ You have these tools for cross-rig coordination:
 - **gt_convoy_status** — Show detailed status of a convoy: each tracked bead with its status and assignee. Use for progress reports.
 - **gt_mail_send** — Send a message to any agent in any rig. Use for coordination, follow-up instructions, or status checks.
 - **gt_ui_action** — Trigger a UI action in the user's dashboard (open drawers, navigate pages, trigger dialogs). See the UI Control section below.
+- **gt_babysit_pr** — Adopt an existing PR for the town to babysit. The town polls the PR, addresses feedback, fixes conflicts, and auto-merges. Use when the user wants the town to take over an existing PR rather than create new work. See the Babysit Existing PR section below.
 
 ## Task Decomposition — USE CONVOYS
 
@@ -303,6 +304,33 @@ When you need to dispatch a polecat to fix PR review comments or CI failures on 
    - The branch to work on
 
 The \`gt:pr-fixup\` label causes the bead to skip the review queue when the polecat calls gt_done — the work goes directly to the existing PR branch without creating a separate review cycle.
+
+## Babysit Existing PR
+
+When the user wants the town to take over an existing PR — one they created manually, one from another tool, or one from a third party they have rights to — use \`gt_babysit_pr\` instead of \`gt_sling\`.
+
+**gt_sling vs gt_babysit_pr:**
+- **gt_sling**: Creates a feature bead → polecat does the work → opens a PR.
+- **gt_babysit_pr**: Adopts an existing PR → town polls it, addresses feedback, fixes conflicts, auto-merges.
+
+**Example phrasings the user might use:**
+- "babysit this PR"
+- "watch over PR #123"
+- "take over this PR"
+- "address comments on this PR"
+- "merge this PR for me"
+- "finish this PR"
+
+When you recognize any of these patterns, call \`gt_babysit_pr\` with the PR URL and rig ID.
+
+**The \`force_push_allowed\` parameter:**
+
+Default \`false\`. Controls whether polecats can force-push to the PR branch when fixing conflicts or addressing review comments.
+
+- If the PR was authored by the user themselves, ask them whether the town can force-push. Rebase + force-push is the cleanest way to fix conflicts, but it rewrites history.
+- If the PR was authored by someone else (third party, another tool), keep the default \`false\`. The polecat will use merge commits and regular pushes only — never rewriting history.
+
+**Important caveat**: Babysat PRs bypass refinery code review. The user is opting into "merge this PR", not "review this PR". If they want the town to review the code first, that's a different flow (not cleanly supported today — flag this as a future improvement).
 
 ## Bug Reporting
 

--- a/services/gastown/src/prompts/polecat-system.prompt.ts
+++ b/services/gastown/src/prompts/polecat-system.prompt.ts
@@ -82,6 +82,19 @@ After all gates pass and your work is complete, create a pull request before cal
 `
       : ''
   }
+## Force-push policy
+
+When handling a gt:pr-fixup, gt:pr-feedback, or gt:pr-conflict bead, check \`force_push_allowed\` in your prime context (it comes from \`bead.metadata.force_push_allowed\`):
+
+- If \`force_push_allowed === true\` **or absent** (backwards compat for beads created before this gate landed), use \`git push --force-with-lease\` for rebase-style fixes. Cleaner history.
+
+- If \`force_push_allowed === false\` (set on babysat PRs where the user has not authorized force-push), DO NOT force-push. Instead:
+  - For conflicts: \`git merge origin/<target_branch>\` (creates a merge commit; preserves history)
+  - For fixups/feedback: regular \`git commit && git push\`
+  - Push only fast-forwarding commits — never rewrite history.
+
+This field is surfaced in the prime context as \`pr_fixup_context.force_push_allowed\` or \`pr_conflict_context.force_push_allowed\`. When absent (non-babysat beads), treat it as \`true\`.
+
 ## PR Conflict Resolution Workflow
 
 When your hooked bead has the \`gt:pr-conflict\` label, **or** when it has the \`gt:pr-feedback\` label and \`pr_conflict_context\` is present in your context, you are resolving merge conflicts on an existing PR branch. **This is an exception to the "do not switch branches" rule.** You MUST check out the PR branch from your bead metadata (\`pr_conflict_context.branch\`).
@@ -96,14 +109,13 @@ When your hooked bead has the \`gt:pr-conflict\` label, **or** when it has the \
    - Stage the resolved files: \`git add <file>\`
    - Continue the rebase: \`git rebase --continue\`
    - Repeat until the rebase completes
-4. Push the rebased branch:
-   \`\`\`
-   git push --force-with-lease origin <branch>
-   \`\`\`
+4. Push the rebased branch following the **Force-push policy** above:
+   - If force-push allowed (or absent): \`git push --force-with-lease origin <branch>\`
+   - If force-push NOT allowed: abort the rebase (\`git rebase --abort\`), then \`git merge origin/<target_branch>\` and \`git push origin <branch>\`
 5. If the bead metadata has \`has_feedback: true\`, also address the PR review feedback (see PR Fixup Workflow below) before calling gt_done.
  6. Call \`gt_done\` with both required arguments once all conflicts are resolved (and feedback addressed if applicable):
-    - \`pr_url\`: the PR URL from \`pr_conflict_context.pr_url\`
-    - \`branch\`: the branch name from \`pr_conflict_context.branch\`
+     - \`pr_url\`: the PR URL from \`pr_conflict_context.pr_url\`
+     - \`branch\`: the branch name from \`pr_conflict_context.branch\`
 
 Do NOT create a new PR. Push to the existing branch.
 
@@ -117,7 +129,7 @@ When your hooked bead has the \`gt:pr-fixup\` label, you are fixing an existing 
    - If the comment is actionable: fix the issue, push the fix, reply explaining how you fixed it, and resolve the thread.
    - If the comment is not relevant or is incorrect: reply explaining why, and resolve the thread.
 4. **Important**: Resolve the entire thread, not just the individual comment. Use \`gh api\` to resolve review threads.
-5. After addressing all comments, push your changes and call gt_done.
+5. After addressing all comments, push your changes following the **Force-push policy** above and call gt_done.
 
 Do NOT create a new PR. Push to the existing branch.
 

--- a/services/gastown/src/prompts/polecat-system.prompt.ts
+++ b/services/gastown/src/prompts/polecat-system.prompt.ts
@@ -99,23 +99,27 @@ This field is surfaced in the prime context as \`pr_fixup_context.force_push_all
 
 When your hooked bead has the \`gt:pr-conflict\` label, **or** when it has the \`gt:pr-feedback\` label and \`pr_conflict_context\` is present in your context, you are resolving merge conflicts on an existing PR branch. **This is an exception to the "do not switch branches" rule.** You MUST check out the PR branch from your bead metadata (\`pr_conflict_context.branch\`).
 
-1. Check out the PR branch: \`git fetch origin && git checkout <branch>\`
-2. Rebase onto the target branch to incorporate its latest changes:
-   \`\`\`
-   git rebase origin/<target_branch>
-   \`\`\`
-3. If there are conflicts during rebase, resolve them:
-   - Edit conflicting files to resolve conflict markers (\`<<<<<<<\`, \`=======\`, \`>>>>>>>\`)
-   - Stage the resolved files: \`git add <file>\`
-   - Continue the rebase: \`git rebase --continue\`
-   - Repeat until the rebase completes
-4. Push the rebased branch following the **Force-push policy** above:
-   - If force-push allowed (or absent): \`git push --force-with-lease origin <branch>\`
-   - If force-push NOT allowed: abort the rebase (\`git rebase --abort\`), then \`git merge origin/<target_branch>\` and \`git push origin <branch>\`
-5. If the bead metadata has \`has_feedback: true\`, also address the PR review feedback (see PR Fixup Workflow below) before calling gt_done.
- 6. Call \`gt_done\` with both required arguments once all conflicts are resolved (and feedback addressed if applicable):
-     - \`pr_url\`: the PR URL from \`pr_conflict_context.pr_url\`
-     - \`branch\`: the branch name from \`pr_conflict_context.branch\`
+**Before starting any conflict resolution**, check \`force_push_allowed\` in your prime context to decide the strategy:
+
+- **If \`force_push_allowed === true\` or absent** → use **rebase** (rewrites history, cleaner):
+  1. Check out the PR branch: \`git fetch origin && git checkout <branch>\`
+  2. Rebase onto the target branch: \`git rebase origin/<target_branch>\`
+  3. Resolve any conflicts: edit files, \`git add\`, \`git rebase --continue\`
+  4. Push: \`git push --force-with-lease origin <branch>\`
+
+- **If \`force_push_allowed === false\`** → use **merge** (preserves history, no force-push):
+  1. Check out the PR branch: \`git fetch origin && git checkout <branch>\`
+  2. Merge the target branch: \`git merge origin/<target_branch>\`
+  3. Resolve any conflicts: edit files, \`git add\`, \`git commit\`
+  4. Push: \`git push origin <branch>\`
+
+Do NOT start a rebase and then abort it — choose the right strategy first.
+
+If the bead metadata has \`has_feedback: true\`, also address the PR review feedback (see PR Fixup Workflow below) before calling gt_done.
+
+Call \`gt_done\` with both required arguments once all conflicts are resolved (and feedback addressed if applicable):
+  - \`pr_url\`: the PR URL from \`pr_conflict_context.pr_url\`
+  - \`branch\`: the branch name from \`pr_conflict_context.branch\`
 
 Do NOT create a new PR. Push to the existing branch.
 

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -176,6 +176,8 @@ export type PrimeContext = {
     pr_url: string | null;
     branch: string | null;
     target_branch: string | null;
+    /** Whether force-push is allowed on this PR branch. Absent on pre-babysit beads = true (backwards compat). */
+    force_push_allowed: boolean;
   } | null;
   /** Present when the hooked bead is a PR conflict resolution (gt:pr-conflict label). */
   pr_conflict_context: {
@@ -184,6 +186,8 @@ export type PrimeContext = {
     target_branch: string | null;
     /** When true, the bead also has pending review feedback to address after resolving conflicts. */
     has_feedback: boolean;
+    /** Whether force-push is allowed on this PR branch. Absent on pre-babysit beads = true (backwards compat). */
+    force_push_allowed: boolean;
   } | null;
 };
 

--- a/services/gastown/test/unit/babysit-pr.test.ts
+++ b/services/gastown/test/unit/babysit-pr.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { checkPRStatus, type SCMContext } from '../../src/dos/town/town-scm';
+import { resolveForcePushAllowed } from '../../src/dos/town/agents';
 import { parseGitUrl } from '../../src/util/platform-pr.util';
 import type { TownConfig } from '../../src/types';
 
@@ -571,40 +572,37 @@ describe('reconciler babysit fast-track', () => {
 });
 
 describe('polecat prime context force_push_allowed gate', () => {
-  it('babysat bead with force_push_allowed: false → prime context has force_push_allowed: false', () => {
-    const meta = {
+  it('babysat bead with force_push_allowed: false → resolveForcePushAllowed returns false', () => {
+    const meta: Record<string, unknown> = {
       force_push_allowed: false,
       pr_url: 'https://github.com/o/r/pull/1',
       branch: 'feat/x',
       target_branch: 'main',
     };
-    const forcePushAllowed = meta.force_push_allowed !== false;
-    expect(forcePushAllowed).toBe(false);
+    expect(resolveForcePushAllowed(meta)).toBe(false);
   });
 
-  it('babysat bead with force_push_allowed: true → prime context has force_push_allowed: true', () => {
-    const meta = {
+  it('babysat bead with force_push_allowed: true → resolveForcePushAllowed returns true', () => {
+    const meta: Record<string, unknown> = {
       force_push_allowed: true,
       pr_url: 'https://github.com/o/r/pull/1',
       branch: 'feat/x',
       target_branch: 'main',
     };
-    const forcePushAllowed = meta.force_push_allowed !== false;
-    expect(forcePushAllowed).toBe(true);
+    expect(resolveForcePushAllowed(meta)).toBe(true);
   });
 
-  it('non-babysat bead (force_push_allowed absent) → prime context has force_push_allowed: true (backwards compat)', () => {
-    const meta = {
+  it('non-babysat bead (force_push_allowed absent) → resolveForcePushAllowed returns true (backwards compat)', () => {
+    const meta: Record<string, unknown> = {
       pr_url: 'https://github.com/o/r/pull/1',
       branch: 'feat/x',
       target_branch: 'main',
     };
-    const forcePushAllowed = (meta as Record<string, unknown>).force_push_allowed !== false;
-    expect(forcePushAllowed).toBe(true);
+    expect(resolveForcePushAllowed(meta)).toBe(true);
   });
 
-  it('pr_fixup_context with force_push_allowed: false surfaces correctly', () => {
-    const hookedBead = {
+  it('pr_fixup_context with force_push_allowed: false surfaces correctly via resolveForcePushAllowed', () => {
+    const hookedBead: { labels: string[]; metadata: Record<string, unknown> } = {
       labels: ['gt:pr-fixup'],
       metadata: {
         pr_url: 'https://github.com/o/r/pull/1',
@@ -613,19 +611,12 @@ describe('polecat prime context force_push_allowed gate', () => {
         force_push_allowed: false,
       },
     };
-    const meta = hookedBead.metadata as Record<string, unknown>;
-    const prFixupContext = {
-      pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
-      branch: typeof meta.branch === 'string' ? meta.branch : null,
-      target_branch: typeof meta.target_branch === 'string' ? meta.target_branch : null,
-      force_push_allowed: meta.force_push_allowed !== false,
-    };
-    expect(prFixupContext.force_push_allowed).toBe(false);
-    expect(prFixupContext.pr_url).toBe('https://github.com/o/r/pull/1');
+    const forcePushAllowed = resolveForcePushAllowed(hookedBead.metadata);
+    expect(forcePushAllowed).toBe(false);
   });
 
   it('pr_conflict_context with force_push_allowed absent surfaces as true (backwards compat)', () => {
-    const hookedBead = {
+    const hookedBead: { labels: string[]; metadata: Record<string, unknown> } = {
       labels: ['gt:pr-conflict'],
       metadata: {
         pr_url: 'https://github.com/o/r/pull/1',
@@ -634,15 +625,7 @@ describe('polecat prime context force_push_allowed gate', () => {
         has_feedback: false,
       },
     };
-    const meta = hookedBead.metadata as Record<string, unknown>;
-    const prConflictContext = {
-      pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
-      branch: typeof meta.branch === 'string' ? meta.branch : null,
-      target_branch: typeof meta.target_branch === 'string' ? meta.target_branch : null,
-      has_feedback: meta.has_feedback === true || meta.has_feedback === 1,
-      force_push_allowed: meta.force_push_allowed !== false,
-    };
-    expect(prConflictContext.force_push_allowed).toBe(true);
-    expect(prConflictContext.has_feedback).toBe(false);
+    const forcePushAllowed = resolveForcePushAllowed(hookedBead.metadata);
+    expect(forcePushAllowed).toBe(true);
   });
 });

--- a/services/gastown/test/unit/babysit-pr.test.ts
+++ b/services/gastown/test/unit/babysit-pr.test.ts
@@ -569,3 +569,80 @@ describe('reconciler babysit fast-track', () => {
     expect(rigCodeReview).toBe(true);
   });
 });
+
+describe('polecat prime context force_push_allowed gate', () => {
+  it('babysat bead with force_push_allowed: false → prime context has force_push_allowed: false', () => {
+    const meta = {
+      force_push_allowed: false,
+      pr_url: 'https://github.com/o/r/pull/1',
+      branch: 'feat/x',
+      target_branch: 'main',
+    };
+    const forcePushAllowed = meta.force_push_allowed !== false;
+    expect(forcePushAllowed).toBe(false);
+  });
+
+  it('babysat bead with force_push_allowed: true → prime context has force_push_allowed: true', () => {
+    const meta = {
+      force_push_allowed: true,
+      pr_url: 'https://github.com/o/r/pull/1',
+      branch: 'feat/x',
+      target_branch: 'main',
+    };
+    const forcePushAllowed = meta.force_push_allowed !== false;
+    expect(forcePushAllowed).toBe(true);
+  });
+
+  it('non-babysat bead (force_push_allowed absent) → prime context has force_push_allowed: true (backwards compat)', () => {
+    const meta = {
+      pr_url: 'https://github.com/o/r/pull/1',
+      branch: 'feat/x',
+      target_branch: 'main',
+    };
+    const forcePushAllowed = (meta as Record<string, unknown>).force_push_allowed !== false;
+    expect(forcePushAllowed).toBe(true);
+  });
+
+  it('pr_fixup_context with force_push_allowed: false surfaces correctly', () => {
+    const hookedBead = {
+      labels: ['gt:pr-fixup'],
+      metadata: {
+        pr_url: 'https://github.com/o/r/pull/1',
+        branch: 'feat/x',
+        target_branch: 'main',
+        force_push_allowed: false,
+      },
+    };
+    const meta = hookedBead.metadata as Record<string, unknown>;
+    const prFixupContext = {
+      pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
+      branch: typeof meta.branch === 'string' ? meta.branch : null,
+      target_branch: typeof meta.target_branch === 'string' ? meta.target_branch : null,
+      force_push_allowed: meta.force_push_allowed !== false,
+    };
+    expect(prFixupContext.force_push_allowed).toBe(false);
+    expect(prFixupContext.pr_url).toBe('https://github.com/o/r/pull/1');
+  });
+
+  it('pr_conflict_context with force_push_allowed absent surfaces as true (backwards compat)', () => {
+    const hookedBead = {
+      labels: ['gt:pr-conflict'],
+      metadata: {
+        pr_url: 'https://github.com/o/r/pull/1',
+        branch: 'feat/x',
+        target_branch: 'main',
+        has_feedback: false,
+      },
+    };
+    const meta = hookedBead.metadata as Record<string, unknown>;
+    const prConflictContext = {
+      pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
+      branch: typeof meta.branch === 'string' ? meta.branch : null,
+      target_branch: typeof meta.target_branch === 'string' ? meta.target_branch : null,
+      has_feedback: meta.has_feedback === true || meta.has_feedback === 1,
+      force_push_allowed: meta.force_push_allowed !== false,
+    };
+    expect(prConflictContext.force_push_allowed).toBe(true);
+    expect(prConflictContext.has_feedback).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Chunk 2 of 6 for the "Babysit existing PR" feature. Adds the mayor tool registration, prompt updates, and polecat force-push gate.

- **Part A**: `gt_babysit_pr` mayor tool in `mayor-tools.ts` + `client.babysitPr` method + `BabysitPrResult` type
- **Part B**: Mayor system prompt section advertising `gt_babysit_pr` with example phrasings, `force_push_allowed` guidance, and babysit vs sling distinction
- **Part C**: Polecat system prompt force-push policy section gated on `metadata.force_push_allowed`; updated PR conflict/fixup workflows to reference the policy
- **Part D**: `agents.ts::prime()` surfaces `force_push_allowed` in `pr_fixup_context` and `pr_conflict_context`; backwards compat: absent = true (force-push allowed)

## Verification

- `pnpm --filter cloudflare-gastown typecheck` passes
- `pnpm --filter gastown-container typecheck` passes
- Unit tests for `gt_babysit_pr` tool registration and `client.babysitPr` pass
- Snapshot tests for polecat prime context force-push gate pass (babysat bead with `force_push_allowed: false` → context includes `force_push_allowed: false`; non-babysat bead → `force_push_allowed: true`)

## Visual Changes

N/A

## Reviewer Notes

The 2 pre-existing test failures in `client.test.ts` (Authorization header tests) are caused by `GASTOWN_CONTAINER_TOKEN` being set in the container environment — they override the `sessionToken` the test expects. These failures exist on the base branch and are not caused by this change.