### PR TITLE
Return REASONING_VARIANTS_LOW_MEDIUM_HIGH for step model

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -11,6 +11,7 @@ import type {
   OpenCodePrompt,
   OpenCodeSettings,
 } from '@kilocode/db/schema-types';
+import { isStepModel } from '@/lib/ai-gateway/providers/stepfun';
 import { ReasoningEffortSchema } from '@kilocode/db/schema-types';
 
 export const REASONING_VARIANTS_BINARY = {

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -94,6 +94,9 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
       high: { reasoning: { enabled: true, effort: 'high' } },
     };
   }
+  if (isStepModel(model)) {
+    return REASONING_VARIANTS_LOW_MEDIUM_HIGH;
+  }
   return undefined;
 }
 


### PR DESCRIPTION
they claim it is supported now: https://openrouter.ai/stepfun/step-3.7-flash