### PR TITLE
fix(cloud-agent-next): persist actionable failure diagnostics

### DIFF
--- a/packages/worker-utils/src/cloud-agent-queue-report.ts
+++ b/packages/worker-utils/src/cloud-agent-queue-report.ts
@@ -32,7 +32,7 @@ export const CloudAgentRunFailureClassifications = [
 
 const MAX_OPERATIONAL_IDENTIFIER_LENGTH = 128;
 const MAX_DIAGNOSTIC_MESSAGE_LENGTH = 4096;
-const DIAGNOSTIC_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+export const DIAGNOSTIC_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 const IsoTimestampSchema = z.string().datetime({ offset: true });
 const OperationalIdentifierSchema = z.string().min(1).max(MAX_OPERATIONAL_IDENTIFIER_LENGTH);

--- a/packages/worker-utils/src/index.ts
+++ b/packages/worker-utils/src/index.ts
@@ -99,6 +99,7 @@ export {
   CloudAgentQueueReportSchema,
   CloudAgentRunStatuses,
   CloudAgentRunFailureClassifications,
+  DIAGNOSTIC_RETENTION_MS,
 } from './cloud-agent-queue-report.js';
 export type {
   CloudAgentQueueReport,

--- a/services/cloud-agent-next/src/session/pending-messages.ts
+++ b/services/cloud-agent-next/src/session/pending-messages.ts
@@ -448,10 +448,11 @@ export async function recordPendingFlushFailure(
       | 'BAD_REQUEST'
       | 'INTERNAL'
       | 'PENDING_QUEUE_FULL'
-      | 'MODEL_MISSING';
+      | 'MODEL_MISSING'
+      | 'UNKNOWN';
   }
 ): Promise<PendingFlushFailureResult> {
-  if (options.code === undefined) {
+  if (options.code === undefined || options.code === 'UNKNOWN') {
     logger
       .withFields({
         messageId: message.messageId,
@@ -504,10 +505,12 @@ function isRetryableFlushCode(
     | 'INTERNAL'
     | 'PENDING_QUEUE_FULL'
     | 'MODEL_MISSING'
+    | 'UNKNOWN'
     | undefined
-): code is RetryableResultCode {
+): boolean {
   return (
     code === undefined ||
+    code === 'UNKNOWN' ||
     code === 'SANDBOX_CONNECT_FAILED' ||
     code === 'WORKSPACE_SETUP_FAILED' ||
     code === 'KILO_SERVER_FAILED' ||

--- a/services/cloud-agent-next/src/session/session-message-queue.test.ts
+++ b/services/cloud-agent-next/src/session/session-message-queue.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { ExecutionError } from '../execution/errors.js';
 import type {
   ExecutionDeliveryContext,
   MessageDeliveryRequest,
@@ -1120,6 +1121,96 @@ describe('SessionMessageQueue', () => {
       kind: 'failed',
       failureStage: 'pre_dispatch',
       failureCode,
+    });
+  });
+
+  it('preserves a thrown workspace setup failure through retry exhaustion', async () => {
+    const error = 'Git clone failed: No space left on device';
+    const harness = createQueueHarness({
+      deliver: async () => Promise.reject(ExecutionError.workspaceSetupFailed(error)),
+    });
+    await harness.queue.admitSubmittedMessage({
+      userId: 'user_test' as UserId,
+      turn: { type: 'prompt', id: FIRST_MESSAGE_ID, prompt: 'clone a workspace' },
+    });
+
+    await harness.queue.drainNextPendingMessage();
+    const [pending] = await listPendingSessionMessages(harness.storage);
+    expect(pending?.lastFlushFailureCode).toBe('WORKSPACE_SETUP_FAILED');
+    expect(pending?.lastFlushError).toBe(error);
+    if (pending?.nextFlushAttemptAt === undefined) {
+      throw new Error('Expected workspace setup failure to be retried before terminalization');
+    }
+
+    vi.spyOn(Date, 'now').mockReturnValueOnce(pending.nextFlushAttemptAt);
+    await harness.queue.drainNextPendingMessage();
+    vi.restoreAllMocks();
+
+    expect(harness.terminalizations.at(-1)?.params).toMatchObject({
+      kind: 'failed',
+      error,
+      failureStage: 'pre_dispatch',
+      failureCode: 'workspace_setup_failed',
+    });
+  });
+
+  it('does not classify an ambiguous thrown wrapper execution failure as startup', async () => {
+    const harness = createQueueHarness({
+      deliver: async () =>
+        Promise.reject(
+          ExecutionError.wrapperStartFailed('Failed to execute wrapper bootstrap: dispatch unknown')
+        ),
+    });
+    await harness.queue.admitSubmittedMessage({
+      userId: 'user_test' as UserId,
+      turn: { type: 'prompt', id: FIRST_MESSAGE_ID, prompt: 'deliver ambiguously' },
+    });
+
+    await harness.queue.drainNextPendingMessage();
+    const [pending] = await listPendingSessionMessages(harness.storage);
+    if (pending?.nextFlushAttemptAt === undefined) {
+      throw new Error('Expected ambiguous delivery failure to be retried before terminalization');
+    }
+    vi.spyOn(Date, 'now').mockReturnValueOnce(pending.nextFlushAttemptAt);
+    await harness.queue.drainNextPendingMessage();
+    vi.restoreAllMocks();
+
+    expect(harness.terminalizations.at(-1)?.params).toMatchObject({
+      kind: 'failed',
+      failureStage: 'pre_dispatch',
+      failureCode: 'delivery_failure_unknown',
+    });
+  });
+
+  it('clears an earlier typed cause when exhaustion becomes ambiguous', async () => {
+    const deliver = vi
+      .fn<(_plan: MessageDeliveryRequest) => Promise<MessageDeliveryResult>>()
+      .mockRejectedValueOnce(
+        ExecutionError.workspaceSetupFailed('workspace temporarily unavailable')
+      )
+      .mockRejectedValueOnce(
+        ExecutionError.wrapperStartFailed('Failed to execute wrapper bootstrap: dispatch unknown')
+      );
+    const harness = createQueueHarness({ deliver });
+    await harness.queue.admitSubmittedMessage({
+      userId: 'user_test' as UserId,
+      turn: { type: 'prompt', id: FIRST_MESSAGE_ID, prompt: 'retry then dispatch ambiguously' },
+    });
+
+    await harness.queue.drainNextPendingMessage();
+    const [pending] = await listPendingSessionMessages(harness.storage);
+    expect(pending?.lastFlushFailureCode).toBe('WORKSPACE_SETUP_FAILED');
+    if (pending?.nextFlushAttemptAt === undefined) {
+      throw new Error('Expected workspace setup failure to be retried before terminalization');
+    }
+    vi.spyOn(Date, 'now').mockReturnValueOnce(pending.nextFlushAttemptAt);
+    await harness.queue.drainNextPendingMessage();
+    vi.restoreAllMocks();
+
+    expect(harness.terminalizations.at(-1)?.params).toMatchObject({
+      kind: 'failed',
+      failureStage: 'pre_dispatch',
+      failureCode: 'delivery_failure_unknown',
     });
   });
 

--- a/services/cloud-agent-next/src/session/session-message-queue.ts
+++ b/services/cloud-agent-next/src/session/session-message-queue.ts
@@ -4,6 +4,7 @@ import type {
   AdmitAcceptedSessionMessageRequest,
   MessageDeliveryRequest,
   MessageDeliveryResult,
+  RetryableResultCode,
   SessionMessageAdmissionResult,
   SessionMessageIntent,
   SubmittedSessionMessageRequest,
@@ -183,6 +184,21 @@ function classifyDeliveryFailure(code: PendingFlushFailureCode | undefined): {
     case 'UNKNOWN':
     case undefined:
       return { failureStage: 'pre_dispatch', failureCode: 'delivery_failure_unknown' };
+  }
+}
+
+function knownPreDispatchExecutionFailureCode(error: unknown): RetryableResultCode | undefined {
+  if (!isExecutionError(error) || !error.retryable) return undefined;
+  switch (error.code) {
+    case 'SANDBOX_CONNECT_FAILED':
+    case 'WORKSPACE_SETUP_FAILED':
+    case 'KILO_SERVER_FAILED':
+      return error.code;
+    case 'WRAPPER_START_FAILED':
+      // Orchestration also uses this code when prompt dispatch fails after wrapper readiness.
+      return undefined;
+    default:
+      return undefined;
   }
 }
 
@@ -383,13 +399,13 @@ export async function flushNextPendingSessionMessage(params: {
         ? error.code
         : isSandboxWorkspaceProbeTimeoutError(error)
           ? 'INTERNAL'
-          : undefined;
+          : knownPreDispatchExecutionFailureCode(error);
     const failure = await recordPendingFlushFailure(
       params.storage,
       message,
       error instanceof Error ? error.message : String(error),
       params.now,
-      code === undefined ? { policy } : { policy, code }
+      { policy, code: code ?? 'UNKNOWN' }
     );
     return toFailureResult(failure, totalCount);
   }

--- a/services/cloud-agent-next/src/telemetry/queue-reports.test.ts
+++ b/services/cloud-agent-next/src/telemetry/queue-reports.test.ts
@@ -27,7 +27,7 @@ const state: SessionMessageState = {
 };
 
 describe('Cloud Agent report emitter', () => {
-  it('sends only persisted observed run facts without state content', async () => {
+  it('sends safe persisted observed run facts without raw state content', async () => {
     const reports: CloudAgentQueueReport[] = [];
     await emitRunStateReport({
       queue: { send: async report => void reports.push(report) },
@@ -52,11 +52,148 @@ describe('Cloud Agent report emitter', () => {
           terminalAt: new Date(5).toISOString(),
           failureStage: 'agent_activity',
           failureCode: 'wrapper_error_after_activity',
+          diagnostic: {
+            errorMessageRedacted: 'Wrapper failed after agent activity',
+            errorExpiresAt: new Date(5 + 30 * 24 * 60 * 60 * 1000).toISOString(),
+          },
         },
       },
     ]);
     expect(JSON.stringify(reports)).not.toContain('never report');
     expect(JSON.stringify(reports)).not.toContain('model/test');
+  });
+
+  it('emits a safe disk-full diagnostic for a workspace setup failure', async () => {
+    const reports: CloudAgentQueueReport[] = [];
+    await emitRunStateReport({
+      queue: { send: async report => void reports.push(report) },
+      cloudAgentSessionId: 'agent_report',
+      state: {
+        ...state,
+        acceptedAt: undefined,
+        dispatchAcceptanceKind: undefined,
+        agentActivityObservedAt: undefined,
+        wrapperRunId: undefined,
+        failureStage: 'pre_dispatch',
+        failureCode: 'workspace_setup_failed',
+        error: 'Git clone failed: No space left on device while checking out secret-repository',
+      },
+    });
+
+    expect(reports[0]?.run.diagnostic).toEqual({
+      errorMessageRedacted: 'Workspace setup failed: sandbox storage full',
+      errorExpiresAt: new Date(5 + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+    expect(JSON.stringify(reports)).not.toContain('secret-repository');
+    expect(JSON.stringify(reports)).not.toContain('No space left on device');
+  });
+
+  it('emits a safe insufficient-credit diagnostic for the wrapper terminal text', async () => {
+    const reports: CloudAgentQueueReport[] = [];
+    await emitRunStateReport({
+      queue: { send: async report => void reports.push(report) },
+      cloudAgentSessionId: 'agent_report',
+      state: { ...state, error: 'Insufficient credits' },
+    });
+
+    expect(reports[0]?.run.diagnostic).toEqual({
+      errorMessageRedacted: 'Model request failed: insufficient credits',
+      errorExpiresAt: new Date(5 + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+    expect(JSON.stringify(reports)).not.toContain('Insufficient credits');
+  });
+
+  it.each(['Payment Required', 'pAyMeNt ReQuIrEd'])(
+    'emits an insufficient-credit diagnostic before activity for known terminal text %s',
+    async error => {
+      const reports: CloudAgentQueueReport[] = [];
+      await emitRunStateReport({
+        queue: { send: async report => void reports.push(report) },
+        cloudAgentSessionId: 'agent_report',
+        state: {
+          ...state,
+          agentActivityObservedAt: undefined,
+          failureStage: 'post_dispatch_no_activity',
+          failureCode: 'wrapper_error_before_activity',
+          error,
+        },
+      });
+
+      expect(reports[0]?.run.diagnostic?.errorMessageRedacted).toBe(
+        'Model request failed: insufficient credits'
+      );
+      expect(JSON.stringify(reports)).not.toContain(error);
+    }
+  );
+
+  it('emits an insufficient-credit diagnostic for a recognized assistant failure', async () => {
+    const reports: CloudAgentQueueReport[] = [];
+    await emitRunStateReport({
+      queue: { send: async report => void reports.push(report) },
+      cloudAgentSessionId: 'agent_report',
+      state: { ...state, failureCode: 'assistant_error', error: 'usage_limit_exceeded' },
+    });
+
+    expect(reports[0]?.run.diagnostic?.errorMessageRedacted).toBe(
+      'Model request failed: insufficient credits'
+    );
+    expect(JSON.stringify(reports)).not.toContain('usage_limit_exceeded');
+  });
+
+  it('uses a phase-neutral diagnostic for unknown delivery outcomes', async () => {
+    const reports: CloudAgentQueueReport[] = [];
+    await emitRunStateReport({
+      queue: { send: async report => void reports.push(report) },
+      cloudAgentSessionId: 'agent_report',
+      state: {
+        ...state,
+        acceptedAt: undefined,
+        dispatchAcceptanceKind: undefined,
+        agentActivityObservedAt: undefined,
+        wrapperRunId: undefined,
+        failureStage: 'pre_dispatch',
+        failureCode: 'delivery_failure_unknown',
+        error: 'Failed to execute wrapper bootstrap: dispatch outcome is secret and unknown',
+      },
+    });
+
+    expect(reports[0]?.run.diagnostic?.errorMessageRedacted).toBe(
+      'Message delivery outcome is unknown'
+    );
+    expect(JSON.stringify(reports)).not.toContain('dispatch outcome is secret');
+    expect(JSON.stringify(reports)).not.toContain('before dispatch');
+  });
+
+  it('does not infer insufficient credits from arbitrary payment-like error content', async () => {
+    const reports: CloudAgentQueueReport[] = [];
+    await emitRunStateReport({
+      queue: { send: async report => void reports.push(report) },
+      cloudAgentSessionId: 'agent_report',
+      state: { ...state, error: 'Low Credit Warning: balance=private-balance-value' },
+    });
+
+    expect(reports[0]?.run.diagnostic?.errorMessageRedacted).toBe(
+      'Wrapper failed after agent activity'
+    );
+    expect(JSON.stringify(reports)).not.toContain('private-balance-value');
+  });
+
+  it('does not emit diagnostics for completed reports', async () => {
+    const reports: CloudAgentQueueReport[] = [];
+    await emitRunStateReport({
+      queue: { send: async report => void reports.push(report) },
+      cloudAgentSessionId: 'agent_report',
+      state: {
+        ...state,
+        status: 'completed',
+        completionSource: 'assistant_message_event',
+        failureStage: undefined,
+        failureCode: undefined,
+        error: 'Insufficient credits',
+      },
+    });
+
+    expect(reports[0]?.run).not.toHaveProperty('diagnostic');
   });
 
   it('omits dispatch timestamps that were inferred internally', async () => {

--- a/services/cloud-agent-next/src/telemetry/queue-reports.ts
+++ b/services/cloud-agent-next/src/telemetry/queue-reports.ts
@@ -1,5 +1,6 @@
 import {
   CloudAgentQueueReportSchema,
+  DIAGNOSTIC_RETENTION_MS,
   type CloudAgentQueueReport,
   type CloudAgentRunStateReport,
 } from '@kilocode/worker-utils/cloud-agent-queue-report';
@@ -16,8 +17,71 @@ type ReportLogContext = {
   status: string;
 };
 
+const INSUFFICIENT_CREDIT_TERMINAL_ERRORS = new Set([
+  'insufficient credits',
+  'insufficient credits: payment_required',
+  'insufficient credits: insufficient_funds',
+  'payment required',
+  'usage_limit_exceeded',
+]);
+const FAILED_RUN_DIAGNOSTIC_MESSAGES: Partial<
+  Record<NonNullable<SessionMessageState['failureCode']>, string>
+> = {
+  sandbox_connect_failed: 'Sandbox connection failed',
+  workspace_setup_failed: 'Workspace setup failed',
+  kilo_server_failed: 'Kilo server failed to start',
+  wrapper_start_failed: 'Wrapper failed to start',
+  invalid_delivery_request: 'Queued message could not be dispatched',
+  session_metadata_missing: 'Session metadata is unavailable',
+  model_missing: 'No model is available for this run',
+  delivery_failure_unknown: 'Message delivery outcome is unknown',
+  wrapper_disconnected: 'Wrapper disconnected before completion',
+  wrapper_no_output: 'Wrapper produced no output before timeout',
+  wrapper_ping_timeout: 'Wrapper health check timed out',
+  wrapper_error_before_activity: 'Wrapper failed before agent activity',
+  assistant_error: 'Assistant request failed',
+  wrapper_error_after_activity: 'Wrapper failed after agent activity',
+  missing_assistant_reply: 'No assistant reply was produced',
+  unclassified: 'Run failed without a classified cause',
+};
+
 function timestamp(value: number): string {
   return new Date(value).toISOString();
+}
+
+function isKnownInsufficientCreditFailure(state: SessionMessageState): boolean {
+  if (
+    state.failureCode !== 'assistant_error' &&
+    state.failureCode !== 'wrapper_error_before_activity' &&
+    state.failureCode !== 'wrapper_error_after_activity'
+  ) {
+    return false;
+  }
+  if (state.error === undefined) return false;
+  return INSUFFICIENT_CREDIT_TERMINAL_ERRORS.has(state.error.trim().toLowerCase());
+}
+
+function diagnosticForFailedRun(
+  state: SessionMessageState
+): CloudAgentRunStateReport['run']['diagnostic'] | undefined {
+  if (state.status !== 'failed' || state.terminalAt === undefined) return undefined;
+
+  let errorMessageRedacted =
+    state.failureCode === undefined ? undefined : FAILED_RUN_DIAGNOSTIC_MESSAGES[state.failureCode];
+  if (
+    state.failureCode === 'workspace_setup_failed' &&
+    state.error?.toLowerCase().includes('no space left on device')
+  ) {
+    errorMessageRedacted = 'Workspace setup failed: sandbox storage full';
+  } else if (isKnownInsufficientCreditFailure(state)) {
+    errorMessageRedacted = 'Model request failed: insufficient credits';
+  }
+  if (errorMessageRedacted === undefined) return undefined;
+
+  return {
+    errorMessageRedacted,
+    errorExpiresAt: timestamp(state.terminalAt + DIAGNOSTIC_RETENTION_MS),
+  };
 }
 
 function logReportFailure(context: ReportLogContext, phase: 'validation' | 'send'): void {
@@ -59,6 +123,7 @@ export async function emitRunStateReport(params: {
   const { state } = params;
   const observedDispatchAcceptedAt =
     state.dispatchAcceptanceKind === 'observed' ? state.acceptedAt : undefined;
+  const diagnostic = diagnosticForFailedRun(state);
   const report: CloudAgentRunStateReport = {
     version: 1,
     type: 'run.state',
@@ -78,6 +143,7 @@ export async function emitRunStateReport(params: {
       ...(state.terminalAt === undefined ? {} : { terminalAt: timestamp(state.terminalAt) }),
       ...(state.failureStage === undefined ? {} : { failureStage: state.failureStage }),
       ...(state.failureCode === undefined ? {} : { failureCode: state.failureCode }),
+      ...(diagnostic === undefined ? {} : { diagnostic }),
     },
   };
   await trySendReport(params.queue, report, {

--- a/services/cloud-agent-next/test/integration/session/message-terminalization.test.ts
+++ b/services/cloud-agent-next/test/integration/session/message-terminalization.test.ts
@@ -258,6 +258,72 @@ describe('message terminalization and stream events', () => {
     });
   });
 
+  it('reports a safe insufficient-credit diagnostic for a wrapper failure after activity', async () => {
+    const userId = 'user_term_credit_report';
+    const sessionId = 'agent_term_credit_report';
+    const stub = env.CLOUD_AGENT_SESSION.get(
+      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+    );
+    const reports: CloudAgentQueueReport[] = [];
+
+    const message = await runInDurableObject(stub, async instance => {
+      injectReportQueue(instance, reports);
+      await registerReadySession(instance, {
+        sessionId,
+        userId,
+        kiloSessionId,
+        prompt: 'send a model request',
+        mode: 'code',
+        model: 'test-model',
+        kilocodeToken: 'token-term-credit-report',
+      });
+      const { state: runtimeState } = await allocateWrapperRuntimeState(instance.ctx.storage);
+      const messageId = 'msg_018f1e2d3c4bTermCreditAbCd';
+      await putSessionMessageState(instance.ctx.storage, {
+        messageId,
+        status: 'accepted',
+        prompt: 'send a model request',
+        createdAt: Date.now(),
+        acceptedAt: Date.now(),
+        dispatchAcceptanceKind: 'observed',
+        wrapperRunId: runtimeState.wrapperRunId,
+        callbackRequired: false,
+      });
+      await instance['recordCorrelatedAgentActivity'](messageId);
+      await instance.handleWrapperTerminalEvent({
+        wrapperRunId: runtimeState.wrapperRunId,
+        status: 'failed',
+        error: 'Insufficient credits',
+      });
+      return getSessionMessageState(instance.ctx.storage, messageId);
+    });
+
+    expect(message).toMatchObject({
+      status: 'failed',
+      failureStage: 'agent_activity',
+      failureCode: 'wrapper_error_after_activity',
+      error: 'Insufficient credits',
+    });
+    const failedReport = reports.find(report => report.run.status === 'failed');
+    expect(failedReport).toMatchObject({
+      type: 'run.state',
+      run: {
+        status: 'failed',
+        failureStage: 'agent_activity',
+        failureCode: 'wrapper_error_after_activity',
+        diagnostic: { errorMessageRedacted: 'Model request failed: insufficient credits' },
+      },
+    });
+    if (!failedReport?.run.terminalAt || !failedReport.run.diagnostic) {
+      throw new Error('Expected failed report to contain terminal diagnostics');
+    }
+    expect(
+      Date.parse(failedReport.run.diagnostic.errorExpiresAt) -
+        Date.parse(failedReport.run.terminalAt)
+    ).toBe(30 * 24 * 60 * 60 * 1000);
+    expect(JSON.stringify(failedReport)).not.toContain('Insufficient credits');
+  });
+
   it('ignores terminal acceptance reconstruction for a non-current wrapper run', async () => {
     const userId = 'user_term_stale_accept';
     const sessionId = 'agent_term_stale_accept';


### PR DESCRIPTION
## Summary

Improve cloud agent session reporting. 

- Persist safe, normalized failure diagnostics in existing Cloud Agent run telemetry so database inspection distinguishes actionable causes such as sandbox storage exhaustion and insufficient model credits without storing raw error payloads.
- Preserve phase-safe typed delivery failures through retry exhaustion, while resetting later ambiguous delivery outcomes to an unknown classification so stale bootstrap causes are not persisted as terminal truth.
- Reuse the existing `run.diagnostic` queue-report and database storage contract with 30-day expiry; this introduces no schema, migration, admin API, or admin UI changes.

