### PR TITLE
docs: improve contributing and environment documentation

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -12,6 +12,11 @@ NEXTAUTH_URL=http://localhost:3000
 POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/postgres
 POSTGRES_CONNECT_TIMEOUT=10000
 POSTGRES_MAX_QUERY_TIME=20000
+# Callback token secret (generate: openssl rand -base64 32)
+CALLBACK_TOKEN_SECRET=changeme
+# BYOK encryption key (generate: openssl rand -base64 32)
+# Used for Bring-Your-Own-Key encryption of sensitive app data.
+BYOK_ENCRYPTION_KEY=
 # ============================================================================
 # REQUIRED - Security & Turnstile
 # ============================================================================
@@ -131,7 +136,6 @@ SENTRY_ORG=
 SENTRY_PROJECT=
 NEXT_PUBLIC_SENTRY_DSN=
 # Encryption keys (generate if needed)
-BYOK_ENCRYPTION_KEY=
 CREDIT_CATEGORIES_ENCRYPTION_KEY=
 # Connected GitHub user token envelope encryption (dedicated RSA public key only in Web)
 USER_GITHUB_APP_TOKEN_ACTIVE_KEY_ID=

--- a/.env.local.example
+++ b/.env.local.example
@@ -13,7 +13,7 @@ POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/postgres
 POSTGRES_CONNECT_TIMEOUT=10000
 POSTGRES_MAX_QUERY_TIME=20000
 # Callback token secret (generate: openssl rand -base64 32)
-CALLBACK_TOKEN_SECRET=changeme
+CALLBACK_TOKEN_SECRET=
 # BYOK encryption key (generate: openssl rand -base64 32)
 # Used for Bring-Your-Own-Key encryption of sensitive app data.
 BYOK_ENCRYPTION_KEY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,34 @@ pnpm install
 
 ### 2. Set up environment variables
 
-If you do not have Vercel access, copy `.env.local.example` to `.env.local` and set at least:
+Copy `.env.local.example` to `.env.local` and adjust URLs as needed:
 
-- `NEXTAUTH_SECRET`: `openssl rand -base64 32`
-- `INTERNAL_API_SECRET`: `openssl rand -base64 32`
+- `NEXTAUTH_URL` — auth redirect URL (defaults to `http://localhost:3000`)
+- `POSTGRES_URL` — database connection (defaults to `postgres://postgres:postgres@localhost:5432/postgres`)
+
+Then generate secrets and add Stripe test keys:
+
+```bash
+openssl rand -base64 32   # NEXTAUTH_SECRET
+openssl rand -base64 32   # INTERNAL_API_SECRET
+openssl rand -base64 32   # CALLBACK_TOKEN_SECRET
+openssl rand -base64 32   # BYOK_ENCRYPTION_KEY
+```
+
+Get Stripe test keys from https://dashboard.stripe.com/test/apikeys.
+
+Required in `.env.local`:
+
+- `NEXTAUTH_SECRET`
+- `INTERNAL_API_SECRET`
+- `CALLBACK_TOKEN_SECRET`
+- `BYOK_ENCRYPTION_KEY`
+- `STRIPE_SECRET_KEY`
+- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
 
 Then run `pnpm dev:env` to derive worker `.dev.vars` files from `.env.local`.
+
+For the full list of environment variables, see [ENVIRONMENT.md](./ENVIRONMENT.md).
 
 ### 3. Start the database
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,210 @@
+# Contributing to Kilo Code Cloud
+
+See [the Documentation for details on contributing](https://kilo.ai/docs/contributing).
+
+## TL;DR
+
+There are lots of ways to contribute to the project:
+
+- **Code Contributions:** Implement new features or fix bugs
+- **Documentation:** Improve existing docs or create new guides
+- **Bug Reports:** Report issues you encounter
+- **Feature Requests:** Suggest new features or improvements
+- **Community Support:** Help other users in the community
+
+The Kilo Community is [on Discord](https://kilo.ai/discord).
+
+## Prerequisites
+
+- **Node.js 24** (`.nvmrc` pins `24.14.1`) — required for all packages.
+- **pnpm 11.1.2** — use Corepack so the active version matches `package.json` `packageManager`:
+  ```bash
+  corepack enable
+  corepack prepare pnpm@11.1.2 --activate
+  ```
+- **Docker / Docker Compose** — required to run the local PostgreSQL database.
+
+## Developing Kilo Code Cloud
+
+### 1. Install dependencies
+
+```bash
+nvm install && nvm use
+pnpm install
+```
+
+### 2. Set up environment variables
+
+If you do not have Vercel access, copy `.env.local.example` to `.env.local` and set at least:
+
+- `NEXTAUTH_SECRET`: `openssl rand -base64 32`
+- `INTERNAL_API_SECRET`: `openssl rand -base64 32`
+
+Then run `pnpm dev:env` to derive worker `.dev.vars` files from `.env.local`.
+
+### 3. Start the database
+
+```bash
+docker compose -f dev/docker-compose.yml up -d
+```
+
+This starts PostgreSQL on `localhost:5432` with user `postgres` / password `postgres`.
+
+### 4. Run database migrations
+
+```bash
+pnpm drizzle migrate
+```
+
+Re-run this after pulling new migrations. To fully reset:
+
+```bash
+pnpm dev:db:reset
+pnpm drizzle migrate
+```
+
+To smoke-test migrations from a fresh database:
+
+```bash
+pnpm drizzle:verify-bootstrap
+```
+
+### 5. Start the development server
+
+```bash
+pnpm dev:start
+```
+
+This launches a tmux dashboard with the Next.js app and local infrastructure. The web app is available at http://localhost:3000.
+
+To stop all services:
+
+```bash
+pnpm dev:stop
+```
+
+## Verifying Your Setup
+
+```bash
+pnpm test
+```
+
+All tests should pass against the local PostgreSQL database.
+
+## Repo Layout
+
+Key locations:
+
+- `apps/web/` — Next.js web application and main UI code
+- `apps/mobile/` — React Native mobile app
+- `services/` — Cloudflare Worker services (KiloClaw, cloud agent, etc.)
+- `packages/` — shared libraries (`@kilocode/db`, `@kilocode/trpc`, `@kilocode/worker-utils`)
+- `dev/` — local dev tooling (docker-compose, tmux scripts, env sync, seed data)
+- `scripts/` — CI and one-off scripts
+- `packages/db/src/schema.ts` — database schema; migrations in `packages/db/src/migrations/`
+- `apps/web/src/routers/` — tRPC routers
+
+## Mock / seed data
+
+The repo includes a seed runner for creating local fixtures via `pnpm dev:seed`. Run it with no args to see all available topics.
+
+### App
+
+- `pnpm dev:seed app:create-user <name> <email>` — creates a `kilocode_users` row with a real Stripe test customer, pre-bypassing onboarding gates so you can use the app immediately.
+- `pnpm dev:seed app:add-credits <user-id> <usd>` — grants credits to an existing user, updating the `total_microdollars_acquired` balance and creating a `credit_transactions` row. Supports `--paid`/`--free`, `--category`, `--expires-in-days`, etc. Useful for testing billing and credit flows without manual DB edits.
+
+### KiloClaw
+
+- `pnpm dev:seed kiloclaw:fake-instance <user-id> [options]` — creates a fake personal KiloClaw instance + subscription in the database only (no real container or Worker). Before creating, it retires any prior fake personal instances for that user. Supports `--plan=trial|standard|commit` and `--days=<n>`. For paid plans, it also grants enough credits to cover the plan cost and then deducts the subscription cost.
+- `pnpm dev:seed kiloclaw:fake-org-instance <user-id> <org-id> [options]` — same as above, but creates an instance belonging to an organization rather than a personal account.
+- `pnpm dev:seed kiloclaw:referrals-<scenario>` — seeds KiloClaw referral fixtures. Topics include `referrals-happy-path`, `referrals-pending-referrer`, `referrals-cap-boundary`, and `referrals-support-override`.
+- `pnpm dev:seed kiloclaw-billing:inactive-trials` — seeds inactive-trial billing fixtures. One user is provisioned through the real KiloClaw worker endpoint (`/api/platform/provision`), while others are DB-only rows representing users in recently-started, support-marked, or eligible inactive-trial states.
+
+## Common Development Commands
+
+| Command | Description |
+|---|---|
+| `pnpm dev:start` | Start all local services in a tmux dashboard |
+| `pnpm dev:stop` | Stop the tmux session and all services |
+| `pnpm dev:status` | Live status of running services |
+| `pnpm dev:restart` | Restart a running service |
+| `pnpm dev:env` | Sync `.dev.vars` files from `.env.local` |
+| `pnpm test` | Run the Jest test suite |
+| `pnpm test:e2e` | Run Playwright end-to-end tests |
+| `pnpm typecheck` | Run TypeScript type checking |
+| `pnpm lint` | Lint all source files |
+| `pnpm format` | Auto-format all supported files with oxfmt |
+| `pnpm validate` | Run typecheck, lint, and tests together |
+| `pnpm drizzle migrate` | Apply pending database migrations |
+| `pnpm drizzle generate` | Generate a new migration after schema changes |
+
+## Tests for a specific package
+
+```bash
+pnpm --filter <package> test
+```
+
+## Cloudflare Workers
+
+Workers are started individually as needed:
+
+```bash
+cd services/<worker-name>
+pnpm dev        # or: wrangler dev
+```
+
+Use `pnpm dev:start <group>` to run groups of related services via the tmux dashboard. The easiest way to manage workers during development is through the dev dashboard.
+
+## Fake Login (Local Auth)
+
+Sign in without real OAuth:
+
+```
+http://localhost:3000/users/sign_in?fakeUser=<email>
+```
+
+Use an `@admin.example.com` email for fake admin access:
+
+```
+http://localhost:3000/users/sign_in?fakeUser=<email>@admin.example.com
+```
+
+Append `callbackPath` to redirect after login:
+
+```
+http://localhost:3000/users/sign_in?fakeUser=<email>&callbackPath=/profile
+```
+
+## Git Workflow
+
+- Direct commits to `main` are blocked. Always work on a feature branch.
+- The pre-push hook runs `pnpm format:check`, `pnpm lint`, and `pnpm typecheck --changes-only`.
+
+## Pull Requests
+
+### PR Titles
+
+Use conventional commit style PR titles:
+
+- `feat: add MCP settings tab`
+- `fix: correct Windows path handling`
+- `docs: clarify issue template requirements`
+- `chore: bump TypeScript version`
+- `refactor: extract diff renderer into a hook`
+- `test: cover ServerManager orphan cleanup`
+
+### Contribution Ownership and AI Assistance
+
+AI and coding agents are allowed, but contributors own the work they submit. Before requesting review, make sure you personally understand the change, have tested it appropriately, can explain the diff, and understand how it interacts with the affected packages and the rest of the repo.
+
+Maintainers may close PRs that appear to be submitted without credible contributor ownership or understanding, including AI-assisted work that the contributor cannot explain or has not meaningfully reviewed.
+
+### Tracker Use and Automation
+
+Do not submit batches of agent-generated, untested, or weakly reviewed PRs.
+
+Please keep concurrent PRs focused and limited. As a rule, open no more than three PRs at a time, especially if you are a new contributor. Prioritize high-impact or high-priority issues first instead of opening many speculative fixes. If a contributor opens a large batch of low-value or duplicative PRs, maintainers may close the batch and ask the contributor to choose one PR to reopen, focus, and bring up to the documented review bar before submitting more.
+
+For issues, do not mass-create tickets through automation or agents. Search existing issues first, open issues only when you have enough context for someone to act, and prioritize the most important reports instead of filing every possible finding. Maintainers may close duplicate, low-signal, automated, or weakly reviewed issues without action.
+
+Repeated disregard of this contribution guide, or high-volume automated or agent-generated tracker spam across issues or PRs, may result in maintainers blocking the responsible account.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,32 +35,19 @@ pnpm install
 
 ### 2. Set up environment variables
 
-Copy `.env.local.example` to `.env.local` and adjust URLs as needed:
-
-- `NEXTAUTH_URL` — auth redirect URL (defaults to `http://localhost:3000`)
-- `POSTGRES_URL` — database connection (defaults to `postgres://postgres:postgres@localhost:5432/postgres`)
-
-Then generate secrets and add Stripe test keys:
+Run the interactive setup CLI to bootstrap `.env.local` from the example:
 
 ```bash
-openssl rand -base64 32   # NEXTAUTH_SECRET
-openssl rand -base64 32   # INTERNAL_API_SECRET
-openssl rand -base64 32   # CALLBACK_TOKEN_SECRET
-openssl rand -base64 32   # BYOK_ENCRYPTION_KEY
+pnpm dev:setup-env
 ```
 
-Get Stripe test keys from https://dashboard.stripe.com/test/apikeys.
+This prompts for the 8 required env vars only, generates secrets automatically where appropriate, then writes `.env.local`. If you already have a `.env.local` (e.g., from Vercel pull or a previous setup), the CLI warns you before overwriting anything.
 
-Required in `.env.local`:
+After it completes, run:
 
-- `NEXTAUTH_SECRET`
-- `INTERNAL_API_SECRET`
-- `CALLBACK_TOKEN_SECRET`
-- `BYOK_ENCRYPTION_KEY`
-- `STRIPE_SECRET_KEY`
-- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
-
-Then run `pnpm dev:env` to derive worker `.dev.vars` files from `.env.local`.
+```bash
+pnpm dev:env
+```
 
 For the full list of environment variables, see [ENVIRONMENT.md](./ENVIRONMENT.md).
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -132,15 +132,21 @@ Both are already present in Vercel and pulled by `vercel env pull`. If either is
 
 #### b. Set up manually
 
-If you do not have Vercel access (typical for non-Kilo-employees), you will need to set up the `.env.local` file manually.
+If you do not have Vercel access (typical for non-Kilo-employees), run the interactive setup CLI to bootstrap `.env.local`:
 
-Copy `.env.local.example` to `.env.local`, then update the following variables in `.env.local`:
+```bash
+pnpm dev:setup-env
+```
 
-- `NEXTAUTH_SECRET`: Generate a random secret with `openssl rand -base64 32`
-- `INTERNAL_API_SECRET`: Generate a random secret with `openssl rand -base64 32`
-- `STRIPE_SECRET_KEY` and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`: These must be set to create a fake account. You can use an existing Stripe account or create a new one, and use the keys from Sandbox Mode (formerly Test Mode) here.
+This prompts for the 8 required env vars only, generates secrets automatically, and writes `.env.local`. It warns if `.env.local` already exists before making changes.
 
-Then run `pnpm dev:env`. It derives `apps/web/.env.development.local` and Worker `.dev.vars` files from `.env.local` plus each `.example` template. Re-run it after pulling changes that add local service URLs or Worker env vars.
+After it completes, run:
+
+```bash
+pnpm dev:env
+```
+
+The setup covers: `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `POSTGRES_URL`, `CALLBACK_TOKEN_SECRET`, `BYOK_ENCRYPTION_KEY`, `INTERNAL_API_SECRET`, `STRIPE_SECRET_KEY`, and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`.
 
 These changes will allow you to do local testing with a fake account.
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -1,0 +1,380 @@
+# Environment Variables
+
+This document lists all environment variables used in the Kilo Code cloud monorepo.
+
+## Core / System
+
+- `NODE_ENV` - Node environment (`development`, `production`, `test`); used by virtually every package. [SERVER]
+- `CI` - Set to `true` in CI environments; detected by Next.js, Playwright, Vitest, and various tooling to alter behavior (non-interactive, skip prompts, etc.). [SERVER]
+- `PORT` - Port for local dev servers. Next.js defaults to 3000; used by `apps/web/src/lib/constants.ts` and various test servers. [SERVER]
+- `HOME` - User home directory; used by child processes spawned by services (OpenClaw resolves `~/.openclaw`, Expo devcert for mkcert certs). [SYSTEM]
+- `PATH` - System executable search path; modified by tooling (OpenClaw, tsx, etc.) to locate CLIs. [SYSTEM]
+- `TMUX` - Set when running inside a tmux session; used by `dev/local/tmux.ts` to detect tmux environment. [SYSTEM]
+- `GITHUB_ACTIONS` - Set to `true` by GitHub Actions CI; detected by tooling (Rye log groups, Playwright, Vitest) to enable GitHub Actions-specific output/reporting. [SERVER]
+- `NEXT_RUNTIME` - Set by Next.js to `'node'`, `'edge'`, or `'browser'`; used in `apps/web/src/instrumentation.ts` to select appropriate Sentry instrumentation. [SERVER]
+- `DOTENV_CONFIG_QUIET` - Set by dotenv to suppress load output; set to `'true'` in `dev/seed/lib/preflight.ts:9` during seeding. [SERVER]
+
+## App (apps/web)
+
+### Configuration & Constant URLs
+
+- `APP_URL_OVERRIDE` - Override for the base application URL; used in `apps/web/src/lib/constants.ts` and `next.config.mjs`. [SERVER]
+- `KILOCLAW_INSTANCE_URL_TEMPLATE` - URL template for KiloClaw instances; used in `apps/web/src/lib/config.server.ts`. [SERVER]
+- `NEXTAUTH_URL` - Base URL for NextAuth.js; used across many auth-related files. [SERVER]
+- `NEXTAUTH_SECRET` - Secret key for NextAuth.js session encryption; used across many auth-related files. `[SECRET]`
+- `DEBUG_SHOW_DEV_UI` - Enables dev-only UI elements (debug panels, admin buttons); checked in `apps/web/src/lib/constants.ts` and `apps/web/src/app/(app)/profile/page.tsx`. [SERVER]
+- `TRPC_TIMING_LOGGING` - Enables tRPC timing logs in development; checked in `apps/web/src/lib/trpc/init.ts`. [SERVER]
+- `JEST_MAX_WORKERS` - Limits max worker threads for Jest; read in `apps/web/jest.config.ts`. [SERVER]
+- `JEST_SILENT` - When `false`, shows verbose Jest output; read in `apps/web/jest.config.ts` and `apps/web/.env.test`. [SERVER]
+- `JEST_WORKER_ID` - Set by Jest to identify the current worker thread; used by db connection pooling and libraries to handle worker-specific state. [SERVER]
+- `IS_SCRIPT` - Set to `'true'` by `apps/web/src/scripts/index.ts` to indicate a script-mode run (bypasses web server logic). Used by Drizzle in `packages/db/src/database-url.ts`. [SERVER]
+
+### Analytics & Monitoring
+
+- `NEXT_PUBLIC_POSTHOG_KEY` - PostHog public API key for client-side analytics; used in `apps/web/src/components/PostHogProvider.tsx`. [PUBLIC]
+- `NEXT_PUBLIC_POSTHOG_DEBUG` - Enables PostHog debug logging; checked in `apps/web/src/components/PostHogProvider.tsx` and `apps/web/src/lib/stytch.ts`. [PUBLIC]
+- `SENTRY_ORG` - Sentry organization slug for source map uploads; used in `apps/web/next.config.mjs`. `[SECRET]`
+- `SENTRY_PROJECT` - Sentry project slug for source map uploads; used in `apps/web/next.config.mjs`. `[SECRET]`
+- `SENTRY_AUTH_TOKEN` - Sentry auth token for source map uploads; used in `apps/web/next.config.mjs`. `[SECRET]`
+- `NEXT_PUBLIC_SENTRY_DSN` - Sentry DSN for client-side error reporting; used in `apps/web/instrumentation-client.ts`, `sentry.edge.config.ts`, `sentry.server.config.ts`. `[PUBLIC]`
+
+### Marketing Tags
+
+- `NEXT_PUBLIC_GTM_ID` - Google Tag Manager container ID; rendered in `apps/web/src/app/layout.tsx` and exposed via `apps/web/src/app/api/marketing-tags/gtm/route.ts`. [PUBLIC]
+- `NEXT_PUBLIC_IMPACT_UTT_ID` - Impact.com UTT (Universal Tracking Token) ID; rendered in `apps/web/src/app/layout.tsx` and exposed via `apps/web/src/app/api/marketing-tags/impact/route.ts`. [PUBLIC]
+
+### Vercel & Build Info
+
+- `VERCEL_ENV` - Vercel environment (`development`, `preview`, `production`); used in `apps/web/next.config.mjs`, `apps/web/src/lib/constants.ts`, and `apps/web/.env.test`. [SERVER]
+- `VERCEL_URL` - Auto-injected by Vercel; current deployment URL. Used in `apps/web/src/lib/buildInfo.ts`. [SERVER]
+- `VERCEL_GIT_COMMIT_SHA` - Auto-injected by Vercel; Git commit SHA of the current deployment. Used in `apps/web/src/lib/buildInfo.ts`. [SERVER]
+- `NEXT_PUBLIC_VERCEL_URL` - Client-exposed Vercel deployment URL from build info. [PUBLIC]
+- `NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF` - Client-exposed Git branch/ref from build info. [PUBLIC]
+- `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` - Client-exposed Git commit SHA from build info. [PUBLIC]
+- `NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER` - Client-exposed Git repo owner from build info. [PUBLIC]
+- `NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG` - Client-exposed Git repo slug from build info. [PUBLIC]
+- `GITHUB_SHA` - GitHub Actions commit SHA; used in `apps/web/src/lib/buildInfo.ts` during CI builds. [SERVER]
+
+### Security & Auth
+
+- `NEXT_PUBLIC_TURNSTILE_SITE_KEY` - Cloudflare Turnstile public site key; used in `apps/web/src/components/auth/sign-in/TurnstileView.tsx`. [PUBLIC]
+- `TURNSTILE_SECRET_KEY` - Cloudflare Turnstile secret key; used in test files. `[SECRET]`
+- `NEXT_PUBLIC_STYTCH_PROJECT_ENV` - Stytch public project environment identifier; used in `apps/web/src/components/auth/StytchClient.tsx`. [PUBLIC]
+- `NEXT_PUBLIC_STYTCH_PUBLIC_TOKEN` - Stytch public token for client SDKs; used in `apps/web/src/components/auth/StytchClient.tsx`. [PUBLIC]
+- `STYTCH_PROJECT_ID` - Stytch project ID for secret-side SDK calls. `[SECRET]`
+- `STYTCH_PROJECT_SECRET` - Stytch project secret. `[SECRET]`
+- `STYTCH_PUBLIC_TOKEN` - Stytch legacy public token alias used in some test fixtures. [PUBLIC]
+- `INTERNAL_API_SECRET` - Shared secret for internal API calls between services; used in `apps/web/src/lib/kiloclaw/cli-runs.test.ts`, `kiloclaw-router.test.ts`, dev seed scripts, and other service routers. `[SECRET]`
+- `INTERNAL_SECRET` - Alias/fallback for `INTERNAL_API_SECRET`; used in KiloClaw E2E scripts (`services/kiloclaw/e2e/`). `[SECRET]`
+
+### Social OAuth Clients
+
+- `GITHUB_CLIENT_ID` - GitHub OAuth app client ID. `[PUBLIC]`
+- `GITHUB_CLIENT_SECRET` - GitHub OAuth app client secret. `[SECRET]`
+- `GITHUB_APP_ID` - GitHub App ID; used in integration adapter and tests. `[SECRET]`
+- `GITHUB_APP_PRIVATE_KEY` - GitHub App private key (PEM); used in integration adapter and tests. `[SECRET]`
+- `GITHUB_APP_CLIENT_ID` - GitHub OAuth Client ID for the app install/login flow; used in `apps/web/src/lib/integrations/platforms/github/app-selector.ts`. [PUBLIC]
+- `GITHUB_LITE_APP_ID` - Lighter/secondary GitHub App ID for select integrations. `[SECRET]`
+- `GITHUB_LITE_APP_PRIVATE_KEY` - Private key for the lite GitHub App. `[SECRET]`
+- `GITHUB_LITE_APP_CLIENT_ID` - OAuth Client ID for the lite GitHub App install/login flow. [PUBLIC]
+- `GITHUB_ADMIN_STATS_TOKEN` - Token for admin GitHub API stats lookups; used in `apps/web/src/scripts/backfill-pr-author-github-ids.ts`. `[SECRET]`
+- `GITHUB_CLI_PAT` - GitHub personal access token for `gh` CLI operations inside contractors; used in `services/gastown/container/src/process-manager.ts`. `[SECRET]`
+- `GITHUB_TOKEN` - Generic GitHub token for API calls used as fallback when `GIT_TOKEN` or `GITHUB_CLI_PAT` is absent; used in `services/gastown/container/src/process-manager.ts`. `[SECRET]`
+- `GH_TOKEN` - Short alias for GitHub token; used in `services/gastown/container/plugin/mayor-tools.ts`. `[SECRET]`
+- `GIT_TOKEN` - Dynamic git credential token (often a GitHub App installation token) scoped for git clone/push; propagated from Town DO to containers in `services/gastown/src/dos/town/container-dispatch.ts` and `services/gastown/container/src/agent-runner.ts`. `[SECRET]`
+- `GOOGLE_WORKSPACE_OAUTH_CLIENT_ID` - Google Workspace OAuth client ID; used in tests and integration code. [PUBLIC]
+- `GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET` - Google Workspace OAuth client secret. `[SECRET]`
+- `GOOGLE_WORKSPACE_OAUTH_REDIRECT_URI` - Redirect URI for Google Workspace OAuth flow. [SERVER]
+- `GOOGLE_CLIENT_ID` - Primary Google OAuth client ID. `[PUBLIC]`
+- `GOOGLE_CLIENT_SECRET` - Primary Google OAuth client secret. `[SECRET]`
+- `GOOGLE_SERVICE_ACCOUNT_EMAIL` - Google service account email. `[SECRET]`
+- `GOOGLE_WEB_RISK_API_KEY` - API key for Google Web Risk API. `[SECRET]`
+- `GOOGLE_SHEETS_SPREADSHEET_ID` - ID of the Google Sheet used for specific app integrations. [SERVER]
+- `GITLAB_CLIENT_ID` - GitLab OAuth app client ID. `[PUBLIC]`
+- `GITLAB_CLIENT_SECRET` - GitLab OAuth app client secret. `[SECRET]`
+- `LINKEDIN_CLIENT_ID` - LinkedIn OAuth app client ID. `[PUBLIC]`
+- `LINKEDIN_CLIENT_SECRET` - LinkedIn OAuth app client secret. `[SECRET]`
+- `DISCORD_CLIENT_ID` - Discord OAuth app client ID. `[PUBLIC]`
+- `DISCORD_CLIENT_SECRET` - Discord OAuth app client secret. `[SECRET]`
+- `DISCORD_BOT_TOKEN` - Discord bot token. `[SECRET]`
+- `DISCORD_PUBLIC_KEY` - Discord app public key (for interactions). [PUBLIC]
+- `DISCORD_OAUTH_CLIENT_ID` - Discord OAuth client ID for the bot/app. [PUBLIC]
+- `DISCORD_OAUTH_CLIENT_SECRET` - Discord OAuth client secret for the bot/app. `[SECRET]`
+- `DISCORD_OAUTH_BOT_TOKEN` - Discord bot OAuth token (separate from standard bot token). `[SECRET]`
+- `DISCORD_SERVER_ID` - ID of the primary Discord guild/server. [SERVER]
+- `DOLTHUB_APP_CLIENT_ID` - DoltHub OAuth app client ID. `[PUBLIC]`
+- `DOLTHUB_APP_CLIENT_SECRET` - DoltHub OAuth app client secret. `[SECRET]`
+- `DOLTHUB_APP_DEV_CLIENT_ID` - Dev-only DoltHub OAuth client ID; used in `apps/web/.env.test`. `[PUBLIC]`
+- `DOLTHUB_APP_DEV_CLIENT_SECRET` - Dev-only DoltHub OAuth client secret; used in `apps/web/.env.test`. `[SECRET]`
+- `DOLTHUB_TOKEN` - DoltHub personal access token; used by the `wl-sdk` package for Dolt operations. `[SECRET]`
+
+### Billing & Stripe
+
+- `STRIPE_SECRET_KEY` - Stripe secret API key (`sk_*`). `[SECRET]`
+- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` - Stripe publishable key for client-side 3DS and payment Element initialization. `[PUBLIC]`
+- `STRIPE_TEAMS_SUBSCRIPTION_PRODUCT_ID` - Stripe product ID for Teams subscription. [SERVER]
+- `STRIPE_ENTERPRISE_SUBSCRIPTION_PRODUCT_ID` - Stripe product ID for Enterprise subscription. [SERVER]
+- `STRIPE_TEAMS_MONTHLY_PRICE_ID` - Stripe price ID for Teams monthly plan (test). [SERVER]
+- `STRIPE_TEAMS_ANNUAL_PRICE_ID` - Stripe price ID for Teams annual plan (test). [SERVER]
+- `STRIPE_ENTERPRISE_MONTHLY_PRICE_ID` - Stripe price ID for Enterprise monthly plan (test). [SERVER]
+- `STRIPE_ENTERPRISE_ANNUAL_PRICE_ID` - Stripe price ID for Enterprise annual plan (test). [SERVER]
+- `STRIPE_TOP_UP_PRICE_ID` - Stripe price ID for credit top-up purchases. [SERVER]
+- `STRIPE_KILO_PASS_TIER_19_MONTHLY_PRICE_ID` - Stripe price ID for Kilo Pass $19/mo tier. [SERVER]
+- `STRIPE_KILO_PASS_TIER_19_YEARLY_PRICE_ID` - Stripe price ID for Kilo Pass $19/yr tier. [SERVER]
+- `STRIPE_KILO_PASS_TIER_49_MONTHLY_PRICE_ID` - Stripe price ID for Kilo Pass $49/mo tier. [SERVER]
+- `STRIPE_KILO_PASS_TIER_49_YEARLY_PRICE_ID` - Stripe price ID for Kilo Pass $49/yr tier. [SERVER]
+- `STRIPE_KILO_PASS_TIER_199_MONTHLY_PRICE_ID` - Stripe price ID for Kilo Pass $199/mo tier. [SERVER]
+- `STRIPE_KILO_PASS_TIER_199_YEARLY_PRICE_ID` - Stripe price ID for Kilo Pass $199/yr tier. [SERVER]
+- `STRIPE_KILOCLAW_2026_03_19_STANDARD_INTRO_PRICE_ID` - Legacy KiloClaw Standard intro price ID (pre-rollout). [SERVER]
+- `STRIPE_KILOCLAW_2026_03_19_STANDARD_PRICE_ID` - Legacy KiloClaw Standard recurring price ID (pre-rollout). [SERVER]
+- `STRIPE_KILOCLAW_2026_03_19_COMMIT_PRICE_ID` - Legacy KiloClaw Commit price ID (pre-rollout). [SERVER]
+- `STRIPE_KILOCLAW_2026_05_10_STANDARD_PRICE_ID` - Current KiloClaw Standard recurring price ID. [SERVER]
+- `STRIPE_KILOCLAW_2026_05_10_COMMIT_PRICE_ID` - Current KiloClaw Commit price ID. [SERVER]
+- `STRIPE_KILOCLAW_EARLYBIRD_PRICE_ID` - KiloClaw early-bird price ID (test-only). [SERVER]
+- `STRIPE_KILOCLAW_EARLYBIRD_COUPON_ID` - Coupon ID for KiloClaw early-bird pricing. [SERVER]
+- `CHURNKEY_API_SECRET` - Secret for Churnkey (cancellation flows). `[SECRET]`
+- `NEXT_PUBLIC_CHURNKEY_APP_ID` - Public app ID for Churnkey widget. [PUBLIC]
+
+### Apple / In-App Purchases
+
+- `APPLE_APP_APPLE_ID` - Apple App ID for IAP verification. `[SECRET]`
+- `APPLE_IAP_ENVIRONMENT` - Apple IAP environment (`Sandbox` or `Production`). [SERVER]
+- `APPLE_IAP_KEY_ID` - Apple IAP key identifier. `[SECRET]`
+- `APPLE_IAP_ISSUER_ID` - Apple IAP issuer (team) ID. `[SECRET]`
+- `APPLE_IAP_PRIVATE_KEY` - Apple IAP private key (PEM/ES256) for receipt validation. `[SECRET]`
+- `APPLE_ROOT_CERTIFICATES_PEM` - Apple root CA certs (PEM) for validating IAP receipts. [SERVER]
+
+### Ablation / Experimentation
+
+- `NEXT_PUBLIC_CLOUD_AGENT_NEXT_ENABLE_LOCAL_FAKE_MODEL` - Feature flag for local fake model routing in the Cloud Agent Next UI. [PUBLIC]
+- `GLOBAL_KILO_BACKEND` - Override to select the global backend region/endpoint; used in `next.config.mjs`. [SERVER]
+- `ANALYZE` - Next.js bundle analyzer switch; enables `@next/bundle-analyzer` in `next.config.mjs`. [SERVER]
+
+### Database
+
+- `POSTGRES_URL` - Primary Postgres connection string. `[SECRET]`
+- `POSTGRES_SCRIPT_URL` - Alternate Postgres URL used by one-off scripts/backfills in `src/scripts/` and tests. `[SECRET]`
+- `POSTGRES_URL_PRODUCTION` - Production Postgres connection string override; used by `packages/db/src/database-url.ts`. `[SECRET]`
+- `POSTGRES_CONNECT_TIMEOUT` - Postgres connect timeout in ms (default/typical: 10000). [SERVER]
+- `POSTGRES_MAX_QUERY_TIME` - Max allowed query time in ms. [SERVER]
+- `USE_PRODUCTION_DB` - Forces use of the production DB URL in non-production contexts; used by `packages/db/src/database-url.ts`. [SERVER]
+- `DATABASE_CA` - CA certificate content (PEM) for TLS connections to Postgres; used by `packages/db/src/database-url.ts` in tests and scripts. [SERVER]
+- `DATABASE_URL` - Generic/alternate Postgres URL used by E2E tests and some services (`cloud-agent`, `kiloclaw`). `[SECRET]`
+
+### Redis & Queue
+
+- `REDIS_URL` - Redis connection URL; used by `apps/web/src/lib/redis.ts` and bot state. `[SECRET]`
+
+### Encryption & Secrets
+
+- `BYOK_ENCRYPTION_KEY` - Base64 encryption key for Bring-Your-Own-Key encryption of sensitive app data. `[SECRET]`
+- `CREDIT_CATEGORIES_ENCRYPTION_KEY` - Encryption key for credit category labels/values. `[SECRET]`
+- `AGENT_ENV_VARS_PUBLIC_KEY` - RSA public key (base64) used to encrypt agent environment variables. [SERVER]
+- `AGENT_ENV_VARS_PRIVATE_KEY` - Legacy alias for the above — the actual private key used to decrypt agent env vars (kept server-side). `[SECRET]`
+
+### Internal Services
+
+- `WEBHOOK_AGENT_URL` - URL for the webhook agent worker. [SERVER]
+- `MODEL_EVAL_INGEST_URL` - URL for model evaluation ingest worker. [SERVER]
+- `SESSION_INGEST_WORKER_URL` - URL for the session ingest worker. [SERVER]
+- `NEXT_PUBLIC_SESSION_INGEST_WS_URL` - WebSocket URL for session ingest from the browser. [PUBLIC]
+- `CODE_REVIEW_WORKER_URL` - URL for the code review worker. [SERVER]
+- `CODE_REVIEW_WORKER_AUTH_TOKEN` - Auth token for the code review worker. `[SECRET]`
+- `AUTO_TRIAGE_URL` - URL for the auto-triage worker. [SERVER]
+- `AUTO_TRIAGE_AUTH_TOKEN` - Auth token for the auto-triage worker. `[SECRET]`
+- `AUTO_FIX_URL` - URL for the auto-fix worker. [SERVER]
+- `AUTO_FIX_AUTH_TOKEN` - Auth token for the auto-fix worker. `[SECRET]`
+- `APP_BUILDER_URL` - URL for the App Builder worker. [SERVER]
+- `APP_BUILDER_AUTH_TOKEN` - Auth token for the App Builder worker. `[SECRET]`
+- `KILOCLAW_API_URL` - Base URL for KiloClaw API; used heavily by `apps/web/src/routers/kiloclaw-router.ts` and tests. [SERVER]
+- `USER_DEPLOYMENTS_API_BASE_URL` - Base URL for user deployments dispatcher. [SERVER]
+- `USER_DEPLOYMENTS_API_AUTH_KEY` - Auth key for user deployments API. `[SECRET]`
+- `USER_DEPLOYMENTS_DISPATCHER_URL` - URL for the deployments dispatcher (local dev). [SERVER]
+- `USER_DEPLOYMENTS_ENV_VARS_PUBLIC_KEY` - Public key for encrypting user deployment env vars. [SERVER]
+- `USER_DEPLOYMENTS_ENV_VARS_PRIVATE_KEY` - Private key counterpart for decrypting user deployment env vars. `[SECRET]`
+- `CLOUD_AGENT_API_URL` - URL for Cloud Agent Next API; used by App Builder chat and other clients. [SERVER]
+- `CLOUD_AGENT_NEXT_API_URL` - Alias for `CLOUD_AGENT_API_URL` in local dev overrides. [SERVER]
+- `NEXT_PUBLIC_CLOUD_AGENT_WS_URL` - WebSocket URL for Cloud Agent (legacy) from browser. [PUBLIC]
+- `NEXT_PUBLIC_CLOUD_AGENT_NEXT_WS_URL` - WebSocket URL for Cloud Agent Next from browser. [PUBLIC]
+- `CLOUD_AGENT_R2_ATTACHMENTS_BUCKET_NAME` - R2 bucket for cloud agent file attachments. [SERVER]
+- `GASTOWN_SERVICE_URL` - URL for the Gastown service. [SERVER]
+- `NEXT_PUBLIC_GASTOWN_URL` - Client-side base URL for Gastown. [PUBLIC]
+- `O11Y_SERVICE_URL` - URL for the observability (O11Y) service. [SERVER]
+- `O11Y_KILO_GATEWAY_CLIENT_SECRET` - Client secret for the O11Y Kilo Gateway. `[SECRET]`
+- `ABUSE_SERVICE_URL` - URL for the abuse detection service. [SERVER]
+- `ABUSE_SERVICE_CF_ACCESS_CLIENT_ID` - Cloudflare Access client ID for abuse service. [PUBLIC]
+- `ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET` - Cloudflare Access client secret for abuse service. `[SECRET]`
+- `CRON_SECRET` - Shared secret for authenticated cron endpoints; used in `dev/discord-gateway-cron.ts` and `.env.test`. `[SECRET]`
+- `WORKOS_API_KEY` - WorkOS API key for enterprise SSO. `[SECRET]`
+- `WORKOS_CLIENT_ID` - WorkOS client ID for enterprise SSO. [PUBLIC]
+
+### AI Providers
+
+- `OPENROUTER_API_KEY` - Primary OpenRouter API key for model inference through the AI gateway; provider definition in `apps/web/src/lib/ai-gateway/providers/provider-definitions.ts` pointing to `https://openrouter.ai/api/v1`. `[SECRET]`
+- `OPENAI_API_KEY` - OpenAI API key; used in `apps/web/src/lib/ai-gateway/embeddings/embedding-providers.ts` for the `text-embedding-3-small` embedding model, and as a provider config in `apps/web/src/lib/config.server.ts`. `[SECRET]`
+- `MISTRAL_API_KEY` - Mistral API key; used in `apps/web/src/lib/ai-gateway/embeddings/embedding-providers.ts` for `codestral-embed-2505` and `mistral-embed` embeddings, in the FIM completions proxy at `apps/web/src/app/api/fim/completions/route.ts` (routes Mistral Codestral vs. La Plateforme keys), and as a provider config in `apps/web/src/lib/config.server.ts`. `[SECRET]`
+- `XAI_API_KEY` - xAI / Grok API key; referenced in `.env.local.example` as "your-xai-grok-key" and in Grok model naming (`x-ai/grok-*`). No direct `process.env.XAI_API_KEY` call was found outside `.env` files, so actual runtime wiring is likely via `OPENROUTER_API_KEY` routing through OpenRouter to Grok models. `[SECRET]`
+- `INCEPTION_API_KEY` - Inception Labs API key; used in `apps/web/src/app/api/fim/completions/route.ts` and `apps/web/src/app/api/edit/completions/route.ts` as a fill-in-the-middle (FIM) provider, with endpoint `https://api.inceptionlabs.ai/v1/fim/completions`. Defined in `apps/web/src/lib/config.server.ts`. `[SECRET]`
+- `AI_ATTRIBUTION_ADMIN_SECRET` - Admin secret for the AI Attribution service (`apps/web/src/lib/ai-attribution-service.ts`); sent as `X-Admin-Secret` header. `[SECRET]`
+- `ARTIFICIAL_ANALYSIS_API_KEY` - API key for Artificial Analysis (`apps/web/src/lib/model-stats/sync-artificial-analysis.ts`); sent as `x-api-key` header for model benchmarking data sync. `[SECRET]`
+- `GIGAPOTATO_API_KEY` - Only appears in `.env.local.example` and `apps/web/.env.test`; no production usage found. Presumed API key for the Gigapotato API provider. `[SECRET]`
+- `GIGAPOTATO_API_URL` - Only appears in `.env.local.example` and `apps/web/.env.test`; no production usage found. Presumed base URL for the Gigapotato provider. [SERVER]
+- `GENLABS_API_KEY` - Only appears in `.env.local.example` and `apps/web/.env.test`; no production usage found. Presumed API key for the GenLabs provider. `[SECRET]`
+- `FAKE_LLM_URL` - URL for a fake/local LLM server used in `services/cloud-agent-next` E2E tests (`test/e2e/client.ts`, `test/e2e/fake-llm-server.ts`, `test/e2e/README.md`); defaults to `http://localhost:8811`. [SERVER]
+
+### Vector DBs
+
+- `QDRANT_HOST` - Qdrant vector DB host. [SERVER]
+- `QDRANT_API_KEY` - Qdrant API key. `[SECRET]`
+- `MILVUS_ADDRESS` - Milvus vector DB address. [SERVER]
+- `MILVUS_TOKEN` - Milvus auth token. `[SECRET]`
+
+### Email & Notifications
+
+- `MAILGUN_API_KEY` - Mailgun API key for transactional email. `[SECRET]`
+- `MAILGUN_DOMAIN` - Mailgun sending domain. [SERVER]
+- `NEVERBOUNCE_API_KEY` - NeverBounce API key for email verification. `[SECRET]`
+
+### Slack
+
+- `SLACK_CLIENT_ID` - Slack OAuth app client ID. [PUBLIC]
+- `SLACK_CLIENT_SECRET` - Slack OAuth app client secret. `[SECRET]`
+- `SLACK_SIGNING_SECRET` - Slack request signing secret for webhooks. `[SECRET]`
+- `SLACK_USER_FEEDBACK_WEBHOOK_URL` - Slack incoming webhook for user feedback. [SERVER]
+- `SLACK_DEPLOY_THREAT_WEBHOOK_URL` - Slack incoming webhook for deploy threat alerts. [SERVER]
+
+### Feature Flags
+
+- `KILOCLAW_BILLING_ENFORCEMENT` - Feature flag controlling KiloClaw billing enforcement. [SERVER]
+- `BRIEFING_DEBUG` - Enables verbose debug logging for the KiloClaw morning briefing plugin; checked in `services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts`. [SERVER]
+- `KILOCLAW_DISABLE_AI_COAUTHOR` - Disables AI co-author features in Gastown; checked in `services/gastown/container/src/control-server.ts`. [SERVER]
+- `KILOCLAW_GOOGLE_LEGACY_MIGRATION_FAILED` - Set when the legacy Google migration flow fails in the KiloClaw controller. [SERVER]
+- `KILOCLAW_GOOGLE_LEGACY_MIGRATION_REASON` - Human-readable reason for legacy Google migration failure in the KiloClaw controller. [SERVER]
+- `IMPACT_ADVOCATE_DEBUG_LOGGING` - Enables verbose Impact Advocate debug logs. [SERVER]
+- `IMPACT_REFERRAL_DEBUG` - Enables verbose Impact referral debug logs. [SERVER]
+
+### Impact.com Affiliate/Advocate
+
+- `IMPACT_ACCOUNT_SID` - Impact.com account SID for API auth. `[SECRET]`
+- `IMPACT_AUTH_TOKEN` - Impact.com API auth token for affiliate/click events. `[SECRET]`
+- `IMPACT_ADVOCATE_ACCOUNT_SID` - Impact.com account SID for Advocate (referral) API. `[SECRET]`
+- `IMPACT_ADVOCATE_AUTH_TOKEN` - Impact.com Advocate API auth token. `[SECRET]`
+- `IMPACT_ADVOCATE_PROGRAM_ID` - Impact.com Advocate program ID. [SERVER]
+- `IMPACT_ADVOCATE_TENANT_ALIAS` - Impact.com Advocate tenant alias. [SERVER]
+- `IMPACT_ADVOCATE_WIDGET_ID` - Impact.com Advocate widget ID. [SERVER]
+- `IMPACT_CAMPAIGN_ID` - Impact.com campaign ID for event tracking. [SERVER]
+
+### R2 / Object Storage
+
+- `R2_ACCOUNT_ID` - Cloudflare R2 account ID for CLI session storage. [SERVER]
+- `R2_ACCESS_KEY_ID` - R2 access key ID for CLI session storage. `[SECRET]`
+- `R2_SECRET_ACCESS_KEY` - R2 secret access key for CLI session storage. `[SECRET]`
+- `R2_CLI_SESSIONS_BUCKET_NAME` - R2 bucket name for CLI session blobs. [SERVER]
+
+## Services
+
+### KiloClaw Controller
+
+- `KILOCODE_API_KEY` - API key used by the KiloClaw controller for internal gateway identity. `[SECRET]`
+- `FLY_MACHINE_ID` - Fly.io machine ID; auto-injected by the Fly runtime, used in `services/kiloclaw/controller/src/checkin.ts` for machine identity. [SERVER]
+- `KILOCLAW_MACHINE_CPU_KIND` - CPU architecture label used in KiloClaw gateway health checks/tests. [SERVER]
+- `KILOCLAW_RUNTIME_PROVIDER` - Runtime provider identifier used in KiloClaw gateway tests (e.g. `fly`). [SERVER]
+- `OPENCLAW_OAUTH_DIR` - Directory path for OpenClaw OAuth credentials; managed by OpenClaw runtime. [SERVER]
+- `OPENCLAW_STATE_DIR` - Directory path for OpenClaw persistent state; managed by OpenClaw runtime. [SERVER]
+- `GOG_KEYRING_PASSWORD` - Password for the legacy Google keyring migration in KiloClaw controller. `[SECRET]`
+- `KILOCLAW_PROVISION_LOCK_POOL_MAX` - Max concurrency for KiloClaw provision locks; used in `apps/web/src/lib/kiloclaw/provision-lock.ts`. [SERVER]
+- `OPENCLAW_GATEWAY_TOKEN` - Token for authenticating with the OpenClaw gateway. Used by `kiloclaw` plugins (kilo-chat, morning-briefing) and OpenClaw internals. `[SECRET]`
+- `KILOCLAW_KILO_CLI` - Set by the KiloClaw controller route when the Kilo CLI is invoking a run; gates CLI-specific code paths in `services/kiloclaw/controller/src/routes/kilo-cli-run.ts`. [SERVER]
+- `KILO_API_KEY` - API key for the Kilo API; used by CLI run route and customizer plugin tests. `[SECRET]`
+
+### KiloClaw Plugins
+
+- `KILOCLAW_CONTROLLER_URL` - Base URL for the KiloClaw controller service; used across plugins (kilo-chat, morning-briefing) and tests. [SERVER]
+- `KILOCLAW_SANDBOX_ID` - Sandbox identifier for isolated KiloClaw execution environments; used by morning-briefing plugin. [SERVER]
+- `KILOCLAW_USER_LOCATION` - User location string used by the morning briefing plugin for timezone-aware scheduling. [SERVER]
+- `KILOCLAW_USER_TIMEZONE` - User timezone string used by the morning briefing plugin. [SERVER]
+- `LINEAR_API_KEY` - Linear API key for issue integration in the morning briefing plugin. `[SECRET]`
+- `KILOCHAT_BASE_URL` - Base URL for the KiloChat service. [SERVER]
+- `KILO_API_URL` - Kilo API base URL used by the customizer Exa web search plugin. [SERVER]
+- `KILOCODE_API_BASE_URL` - KiloCode API base URL for the customizer plugin. [SERVER]
+- `KILOCODE_ORGANIZATION_ID` - Organization ID for KiloCode API calls. [SERVER]
+- `OPENCODE_CONFIG_CONTENT` - JSON/Toml/YAML string containing OpenCode configuration injected into agent environments at runtime (used as an alternative to `KILO_CONFIG_CONTENT`). [SERVER]
+- `KILO_CONFIG_CONTENT` - JSON/Toml/YAML string containing Kilo configuration injected into agent environments at runtime (session config, skills, etc.); read by `@kilocode/sdk` and Gastown process manager. [SERVER]
+
+### Cloud Agent Services
+
+- `KILOCODE_TOKEN` - Auth token for KiloCode/Session service identity; used by `cloud-agent-next` wrapper and Gastown containers. `[SECRET]`
+- `KILOCODE_TOKEN_FILE` - Path to a file containing the KiloCode token (alternative to the env var). [SERVER]
+- `KILO_SESSION_ID` - Legacy/session-wrapper session identifier. [SERVER]
+- `KILO_SESSION_INGEST_URL` - URL for ingesting session data from the cloud agent wrapper. [SERVER]
+- `INGEST_URL` - URL for telemetry/event ingest from `cloud-agent/wrapper`. [SERVER]
+- `KILO_PLATFORM` - Target platform identifier for the cloud-agent wrapper (`darwin`, `linux`, etc.). [SERVER]
+- `CLI_LOG_PATH` - File path for the cloud-agent wrapper's local CLI log output. [SERVER]
+- `WRAPPER_LOG_PATH` - File path for the cloud-agent-next wrapper's log output. [SERVER]
+- `KILO_BIN_PATH` - Path or name of the `kilo` CLI binary; used by `services/cloud-agent-next/scripts/update-default-slash-commands.mjs`. [SERVER]
+- `UPSTREAM_BRANCH` - Default upstream branch name for the cloud-agent wrapper workspace. [SERVER]
+- `WORKSPACE_PATH` - Filesystem path of the agent workspace. [SERVER]
+- `SESSION_ID` - Reserved session identifier for the `cloud-agent-next` runtime; reserved in `RESERVED_ENV_VARS`. [SERVER]
+- `HOME` - Reserved in `RESERVED_ENV_VARS` for cloud-agent-next session home management. [SYSTEM]
+
+### Gastown
+
+- `GASTOWN_TOWN_ID` - Unique identifier for a Gastown town (isolated environment/agent pool). [SERVER]
+- `GASTOWN_RIG_ID` - Rig (hardware profile) identifier for Gastown scheduling. [SERVER]
+- `GASTOWN_AGENT_ID` - Unique identifier for an individual Gastown agent instance. [SERVER]
+- `GASTOWN_AGENT_ROLE` - Role assigned to a Gastown agent (e.g. `coder`, `reviewer`). [SERVER]
+- `GASTOWN_API_URL` - Base URL for the Gastown control API. [SERVER]
+- `GASTOWN_CONTAINER_TOKEN` - Auth token for Gastown container authentication; refreshed via `token-refresh.ts`. `[SECRET]`
+- `GASTOWN_SESSION_TOKEN` - Per-session auth token for Gastown. `[SECRET]`
+- `GASTOWN_ORGANIZATION_ID` - Organization ID associated with the Gastown town. [SERVER]
+- `GASTOWN_GIT_AUTHOR_NAME` - Git author name used by agents in Gastown for commits. [SERVER]
+- `GASTOWN_GIT_AUTHOR_EMAIL` - Git author email used by agents in Gastown for commits. [SERVER]
+- `AGENT_IDLE_TIMEOUT_MS` - Timeout in ms before an idle Gastown agent is terminated; used in `services/gastown/container/src/process-manager.ts`. [SERVER]
+- `REFINERY_IDLE_TIMEOUT_MS` - Timeout in ms before an idle Refinery sub-process is killed; used in `services/gastown/container/src/process-manager.ts`. [SERVER]
+
+### Deploy Infra (Dispatcher)
+
+- `LOCAL_AUTH_TOKEN` - Auth token for the local deployment dispatcher env. `[SECRET]`
+- `STAGING_AUTH_TOKEN` - Auth token for the staging deployment dispatcher env. `[SECRET]`
+- `PROD_AUTH_TOKEN` - Auth token for the production deployment dispatcher env. `[SECRET]`
+
+### Other Services
+
+- `DOCKER_SOCKET` - Path or URL for the Docker daemon socket; used by `services/cloud-agent-next/scripts/docker-privileged-proxy.mjs`. [SERVER]
+- `DOCKER_PROXY_SOCKET` - Path to the Docker privileged proxy socket. [SERVER]
+- `CALLBACK_TOKEN_SECRET` - Secret for signing callback tokens. `[SECRET]`
+- `SECRET` - Generic secret env var used in `services/kiloclaw/src/auth/sandbox-id-adversarial.test.ts` for sandbox auth tests. `[SECRET]`
+
+## Mobile
+
+- `API_BASE_URL` - Base HTTPS URL for the mobile app's API (e.g. `https://api.kilo.ai`). Bundled into the binary. [PUBLIC]
+- `WEB_BASE_URL` - Base HTTPS URL for the mobile in-app web views (e.g. `https://app.kilo.ai`). Bundled into the binary. [PUBLIC]
+- `CLOUD_AGENT_WS_URL` - WebSocket URL for cloud-agent streaming in the mobile app. Bundled into the binary. [PUBLIC]
+- `SESSION_INGEST_WS_URL` - WebSocket URL for session ingest from the mobile app. Bundled into the binary. [PUBLIC]
+- `APPSFLYER_DEV_KEY` - AppsFlyer development key for mobile attribution. Bundled into the binary (not secret — it's a device-level SDK key). [PUBLIC]
+- `APPSFLYER_APP_ID` - AppsFlyer app ID for mobile attribution tracking. [PUBLIC]
+- `KILO_CHAT_URL` - Base URL for Kilo Chat in the mobile app. Bundled into the binary. [PUBLIC]
+- `EVENT_SERVICE_URL` - WebSocket URL for the event service from mobile. Bundled into the binary. [PUBLIC]
+- `NOTIFICATIONS_URL` - HTTP URL for the push-notifications backend from mobile. [PUBLIC]
+- `MOBILE_DEV_HOST` - LAN host override for mobile dev (replaces `localhost` on physical devices); read in `dev/local/mobile-env.ts`. [SERVER]
+
+## Tests / Dev
+
+- `IS_IN_AUTOMATED_TEST` - Set to `1` to put the app in automated-test mode (e.g. skip Turnstile challenges). [SERVER]
+- `AUTH_TOKEN` - Generic auth token used in `services/app-builder/src/_integration_tests/git-test-helpers.ts` to authenticate integration tests against local services. `[SECRET]`
+- `CANDIDATE_TAG` - Tag string used by `scripts/test-rollout-bucket.mjs` to test rollout bucket assignment. [SERVER]
+- `PERCENT` - Percentage value (0-100) used by `scripts/test-rollout-bucket.mjs` when testing rollout bucket logic. [SERVER]
+- `SNOWFLAKE_MAX_POLL_ATTEMPTS` - Max poll attempts for Snowflake job completion in `services/kiloclaw-billing/src/snowflake.ts`. [SERVER]
+- `CF_AE_TOKEN` - Cloudflare Account/Enterprise API token for the local dev CLI (`dev/local/cli.ts`). `[SECRET]`
+- `KILO_PORT_OFFSET` - Port offset for the local dev tmux dashboard; applied by `dev/local/cli.ts` and `dev/local/services.ts` to prevent port conflicts. [SERVER]
+
+## E2E
+
+- `DATABASE_URL` - Postgres URL for E2E test runs across `cloud-agent-next` and `kiloclaw` E2E suites. `[SECRET]`
+- `WORKER_URL` - Base URL of the worker under test (Kiloclaw E2E). [SERVER]
+- `E2E_GIT_URL` - Git server URL for E2E tests (clones repos during runs). [SERVER]
+- `E2E_MODEL` - Model identifier string for E2E inference tests (e.g. a fake/small model name). [SERVER]
+- `KILOCLAW_USER_LOCATION` - User location parameter for lifecycle tests of the morning briefing plugin. [SERVER]
+- `KILOCLAW_USER_TIMEZONE` - User timezone parameter for lifecycle tests of the morning briefing plugin. [SERVER]
+
+

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -65,6 +65,7 @@ This document lists all environment variables used in the Kilo Code cloud monore
 - `STYTCH_PROJECT_SECRET` - Stytch project secret. `[SECRET]`
 - `STYTCH_PUBLIC_TOKEN` - Stytch legacy public token alias used in some test fixtures. [PUBLIC]
 - `INTERNAL_API_SECRET` - Shared secret for internal API calls between services; used in `apps/web/src/lib/kiloclaw/cli-runs.test.ts`, `kiloclaw-router.test.ts`, dev seed scripts, and other service routers. `[SECRET]`
+- `CALLBACK_TOKEN_SECRET` - Secret for signing callback tokens. Required for local development. `[SECRET]`
 - `INTERNAL_SECRET` - Alias/fallback for `INTERNAL_API_SECRET`; used in KiloClaw E2E scripts (`services/kiloclaw/e2e/`). `[SECRET]`
 
 ### Social OAuth Clients
@@ -342,7 +343,6 @@ This document lists all environment variables used in the Kilo Code cloud monore
 
 - `DOCKER_SOCKET` - Path or URL for the Docker daemon socket; used by `services/cloud-agent-next/scripts/docker-privileged-proxy.mjs`. [SERVER]
 - `DOCKER_PROXY_SOCKET` - Path to the Docker privileged proxy socket. [SERVER]
-- `CALLBACK_TOKEN_SECRET` - Secret for signing callback tokens. `[SECRET]`
 - `SECRET` - Generic secret env var used in `services/kiloclaw/src/auth/sandbox-id-adversarial.test.ts` for sandbox auth tests. `[SECRET]`
 
 ## Mobile
@@ -376,5 +376,3 @@ This document lists all environment variables used in the Kilo Code cloud monore
 - `E2E_MODEL` - Model identifier string for E2E inference tests (e.g. a fake/small model name). [SERVER]
 - `KILOCLAW_USER_LOCATION` - User location parameter for lifecycle tests of the morning briefing plugin. [SERVER]
 - `KILOCLAW_USER_TIMEZONE` - User timezone parameter for lifecycle tests of the morning briefing plugin. [SERVER]
-
-

--- a/dev/local/setup-env.ts
+++ b/dev/local/setup-env.ts
@@ -1,0 +1,321 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as readline from 'node:readline';
+import { spawnSync } from 'node:child_process';
+
+// ---------------------------------------------------------------------------
+// ANSI color constants
+// ---------------------------------------------------------------------------
+
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const RED = '\x1b[31m';
+const CYAN = '\x1b[36m';
+const WHITE = '\x1b[37m';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT_MARKER = 'kilocode-monorepo';
+
+const REQUIRED_KEYS: readonly string[] = [
+  'NEXTAUTH_SECRET',
+  'NEXTAUTH_URL',
+  'POSTGRES_URL',
+  'CALLBACK_TOKEN_SECRET',
+  'BYOK_ENCRYPTION_KEY',
+  'INTERNAL_API_SECRET',
+  'STRIPE_SECRET_KEY',
+  'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+];
+
+const SECRET_KEYS = new Set<string>([
+  'NEXTAUTH_SECRET',
+  'INTERNAL_API_SECRET',
+  'CALLBACK_TOKEN_SECRET',
+  'BYOK_ENCRYPTION_KEY',
+]);
+
+// ---------------------------------------------------------------------------
+// Repo root detection (reuses `findRepoRoot` convention from dev/local/cli.ts)
+// ---------------------------------------------------------------------------
+
+function findRepoRoot(): string {
+  let dir = import.meta.dirname;
+  for (let i = 0; i < 20; i++) {
+    const pkgPath = path.join(dir, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+        if (pkg.name === REPO_ROOT_MARKER) return dir;
+      } catch {
+        // Not valid JSON, keep walking
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`Could not find repo root (package.json with name '${REPO_ROOT_MARKER}')`);
+}
+
+// ---------------------------------------------------------------------------
+// .env.local.example parsing
+// ---------------------------------------------------------------------------
+
+function parseExampleFile(content: string): Map<string, string> {
+  const values = new Map<string, string>();
+
+  for (const rawLine of content.split('\n')) {
+    const trimmed = rawLine.trim();
+
+    if (trimmed === '' || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, eqIdx).trim();
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    values.set(key, value);
+  }
+
+  return values;
+}
+
+// ---------------------------------------------------------------------------
+// Env value formatting (mirrors dev/local/env-sync/parse.ts)
+// ---------------------------------------------------------------------------
+
+function needsQuoting(value: string): boolean {
+  return (
+    value.includes('\n') ||
+    value.includes('"') ||
+    value.includes("'") ||
+    value.includes(' ') ||
+    value.includes('#')
+  );
+}
+
+function formatValue(value: string): string {
+  if (!value) return value;
+  if (!needsQuoting(value)) return value;
+  const escaped = value.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+// ---------------------------------------------------------------------------
+// Secret generation
+// ---------------------------------------------------------------------------
+
+function generateSecret(): string {
+  const result = spawnSync('openssl', ['rand', '-base64', '32'], {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  if (result.status !== 0 || !result.stdout) {
+    throw new Error(`openssl rand failed: ${result.stderr?.trim() ?? 'unknown error'}`);
+  }
+  return result.stdout.trim();
+}
+
+const KEY_DESCRIPTIONS: Record<string, string> = {
+  NEXTAUTH_SECRET: 'Used to encrypt NextAuth session tokens',
+  NEXTAUTH_URL: 'The URL the app is served from',
+  POSTGRES_URL:
+    'Should match your local dev/docker-compose.yaml setup unless you are using a remote database',
+  CALLBACK_TOKEN_SECRET: 'Secret used to sign webhook/callback tokens',
+  BYOK_ENCRYPTION_KEY: 'Used for Bring-Your-Own-Key encryption of sensitive app data',
+  INTERNAL_API_SECRET: 'Internal API authentication secret',
+  STRIPE_SECRET_KEY:
+    'Stripe secret key — get test keys at https://dashboard.stripe.com/test/apikeys',
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
+    'Stripe publishable key — get test keys at https://dashboard.stripe.com/test/apikeys',
+};
+
+// ---------------------------------------------------------------------------
+// Key-specific descriptions
+// ---------------------------------------------------------------------------
+
+function buildDescription(key: string): string | undefined {
+  return KEY_DESCRIPTIONS[key];
+}
+
+// ---------------------------------------------------------------------------
+// User interaction
+// ---------------------------------------------------------------------------
+
+function confirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => {
+    rl.question(question, answer => {
+      rl.close();
+      resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+    });
+  });
+}
+
+async function promptForValue(
+  key: string,
+  defaultValue: string,
+  description: string | undefined,
+  isSecret: boolean
+): Promise<string> {
+  const bracketDefault = isSecret ? '' : defaultValue ? ` [${defaultValue}]` : '';
+  const secretHint = isSecret ? ' (leave blank to generate)' : '';
+
+  const prompt = `${CYAN}${key}${RESET}${bracketDefault}${YELLOW}${secretHint}${RESET} > `;
+
+  if (description) {
+    console.log(`\n${WHITE}${description}${RESET}`);
+  }
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise<string>(resolve => {
+    rl.question(prompt, answer => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const repoRoot = findRepoRoot();
+  const examplePath = path.join(repoRoot, '.env.local.example');
+  const envLocalPath = path.join(repoRoot, '.env.local');
+
+  if (!fs.existsSync(examplePath)) {
+    console.error(`${RED}Missing ${examplePath}${RESET}`);
+    process.exit(1);
+  }
+
+  const exampleContent = fs.readFileSync(examplePath, 'utf-8');
+  const exampleValues = parseExampleFile(exampleContent);
+
+  // -----------------------------------------------------------------------
+  // Step 1: Check for existing .env.local
+  // -----------------------------------------------------------------------
+
+  let envLocalExists = false;
+  if (fs.existsSync(envLocalPath)) {
+    const existingContent = fs.readFileSync(envLocalPath, 'utf-8').trim();
+    if (existingContent.length > 0) {
+      envLocalExists = true;
+    }
+  }
+
+  if (envLocalExists) {
+    console.log();
+    console.log(
+      `${RED}${BOLD}WARNING${RESET}${RED}: .env.local already exists and is non-empty.${RESET}`
+    );
+    console.log(
+      `${YELLOW}Running this setup may overwrite existing values, including secrets.${RESET}`
+    );
+    console.log(`${YELLOW}Recommend backing up .env.local before continuing.${RESET}`);
+    console.log();
+    const shouldContinue = await confirm(`  Do you want to continue anyway? [y/N] `);
+    if (!shouldContinue) {
+      console.log('Aborted.');
+      process.exit(0);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Step 2 & 3: Collect values, then write once
+  // -----------------------------------------------------------------------
+
+  const collected = new Map<string, string>();
+
+  for (const key of REQUIRED_KEYS) {
+    const defaultValue = exampleValues.get(key) ?? '';
+    const description = buildDescription(key);
+    const isSecret = SECRET_KEYS.has(key);
+
+    const answer = await promptForValue(key, defaultValue, description, isSecret);
+
+    if (answer === '') {
+      if (isSecret) {
+        console.log(`  ${DIM}Generating random secret...${RESET}`);
+        const generated = generateSecret();
+        console.log(`  ${GREEN}✓ Generated${RESET}`);
+        collected.set(key, generated);
+      } else {
+        collected.set(key, defaultValue);
+      }
+    } else {
+      collected.set(key, answer);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Step 6: Build final content and write atomically once
+  // -----------------------------------------------------------------------
+
+  let finalContent = exampleContent;
+  for (const [key, value] of collected) {
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`^(${escapedKey}=).*$`, 'm');
+    const replacement = `$1${formatValue(value)}`;
+    if (regex.test(finalContent)) {
+      finalContent = finalContent.replace(regex, replacement);
+    } else {
+      finalContent = finalContent.trimEnd() + `\n${key}=${formatValue(value)}\n`;
+    }
+  }
+
+  const tmpPath = path.join(repoRoot, '.env.local.tmp');
+  try {
+    fs.writeFileSync(tmpPath, finalContent, 'utf-8');
+    fs.renameSync(tmpPath, envLocalPath);
+  } catch (err) {
+    try {
+      if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
+    } catch {
+      // ignore cleanup failure
+    }
+    throw err;
+  }
+
+  // -----------------------------------------------------------------------
+  // Post-setup guidance
+  // -----------------------------------------------------------------------
+
+  console.log();
+  console.log(`${GREEN}${BOLD}✓ Wrote .env.local${RESET}`);
+  console.log();
+  console.log(`${DIM}Next steps:${RESET}`);
+  console.log(
+    `  1. Run ${CYAN}pnpm dev:env${RESET} to sync worker \`.dev.vars\` and \`.env.development.local\``
+  );
+  console.log(`  2. Run ${CYAN}pnpm dev:start${RESET} to launch all services`);
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(import.meta.dirname, 'setup-env.ts');
+
+if (isMain) {
+  main().catch((err: unknown) => {
+    console.error(`${RED}Error:${RESET}`, err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev:restart": "tsx dev/local/cli.ts restart",
     "dev:env": "tsx dev/local/cli.ts env",
     "dev:env:mobile": "tsx dev/local/mobile-env.ts",
+    "dev:setup-env": "tsx dev/local/setup-env.ts",
     "dev:seed": "tsx dev/seed/index.ts",
     "dev:discord-gateway-cron": "tsx dev/discord-gateway-cron.ts",
     "dev:kiloclaw-fly-instances": "tsx services/kiloclaw/scripts/dev-fly-instances.ts"


### PR DESCRIPTION
## Summary

Added two documentation files to lower the barrier for community contributors:

- `CONTRIBUTING.md` — a practical onboarding guide covering prerequisites, local development setup, database seeding with `pnpm dev:seed`, and common development commands. Addresses the gap where the previous guide was macOS-focused and lacked concrete local testing tooling references.
- `ENVIRONMENT.md` — a comprehensive reference of all environment variables used across the monorepo, organized by domain (App, KiloClaw, Cloud Agent, etc.) with descriptions of what each variable activates. Provides the transparency needed for non-employees to understand which keys are required for specific product surfaces without access to `vercel env pull`.

These changes directly address the onboarding and environment documentation gaps raised in #3510, making it easier for external contributors to set up their environment and understand what each configuration variable does.

Closes #3510

## Verification

I've manually verified my changes. Read my comment below.

## Visual Changes

N/A

## Reviewer Notes

N/A