### PR TITLE
fix(exa): provision usage partitions for tests

### DIFF
--- a/apps/web/src/app/api/cron/exa-partition-maintenance/route.ts
+++ b/apps/web/src/app/api/cron/exa-partition-maintenance/route.ts
@@ -2,8 +2,7 @@ import { NextResponse } from 'next/server';
 import { captureException } from '@sentry/nextjs';
 import { db } from '@/lib/drizzle';
 import { CRON_SECRET } from '@/lib/config.server';
-import { sql } from 'drizzle-orm';
-import { format } from 'date-fns';
+import { provisionExaUsageLogPartitions } from '@/lib/exa-usage-partitions';
 
 if (!CRON_SECRET) {
   throw new Error('CRON_SECRET is not configured in environment variables');
@@ -22,29 +21,14 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const now = new Date();
-  const created: string[] = [];
+  const { created, errors: partitionErrors } = await provisionExaUsageLogPartitions(db);
   const errors: string[] = [];
 
-  // Create partitions for the current month and the next 2 months
-  for (let offset = 0; offset <= 2; offset++) {
-    const target = new Date(now.getFullYear(), now.getMonth() + offset, 1);
-    const nextMonth = new Date(target.getFullYear(), target.getMonth() + 1, 1);
-    const name = `exa_usage_log_${format(target, 'yyyy_MM')}`;
-
-    try {
-      await db.execute(
-        sql.raw(
-          `CREATE TABLE IF NOT EXISTS "${name}" PARTITION OF "exa_usage_log" FOR VALUES FROM ('${format(target, 'yyyy-MM-dd')}') TO ('${format(nextMonth, 'yyyy-MM-dd')}')`
-        )
-      );
-      created.push(name);
-    } catch (error) {
-      const msg = `Failed to create partition ${name}: ${error instanceof Error ? error.message : String(error)}`;
-      console.error(`[exa-partition-maintenance] ${msg}`);
-      captureException(error, { tags: { source: 'exa-partition-maintenance', partition: name } });
-      errors.push(msg);
-    }
+  for (const { name, error } of partitionErrors) {
+    const msg = `Failed to create partition ${name}: ${error instanceof Error ? error.message : String(error)}`;
+    console.error(`[exa-partition-maintenance] ${msg}`);
+    captureException(error, { tags: { source: 'exa-partition-maintenance', partition: name } });
+    errors.push(msg);
   }
 
   console.log(

--- a/apps/web/src/lib/exa-usage-partitions.ts
+++ b/apps/web/src/lib/exa-usage-partitions.ts
@@ -1,0 +1,43 @@
+import type { db as defaultDb } from '@/lib/drizzle';
+import { sql } from 'drizzle-orm';
+import { format } from 'date-fns';
+
+type ExaPartitionDb = Pick<typeof defaultDb, 'execute'>;
+
+export type ExaUsageLogPartitionProvisioningResult = {
+  created: string[];
+  errors: Array<{ name: string; error: unknown }>;
+};
+
+/**
+ * Creates the current month and next two monthly audit-log partitions.
+ *
+ * The cron endpoint reports all failed partitions, while test setup treats any
+ * failed partition as fatal after calling this best-effort helper.
+ */
+export async function provisionExaUsageLogPartitions(
+  fromDb: ExaPartitionDb,
+  now: Date = new Date()
+): Promise<ExaUsageLogPartitionProvisioningResult> {
+  const created: string[] = [];
+  const errors: Array<{ name: string; error: unknown }> = [];
+
+  for (let offset = 0; offset <= 2; offset++) {
+    const target = new Date(now.getFullYear(), now.getMonth() + offset, 1);
+    const nextMonth = new Date(target.getFullYear(), target.getMonth() + 1, 1);
+    const name = `exa_usage_log_${format(target, 'yyyy_MM')}`;
+
+    try {
+      await fromDb.execute(
+        sql.raw(
+          `CREATE TABLE IF NOT EXISTS "${name}" PARTITION OF "exa_usage_log" FOR VALUES FROM ('${format(target, 'yyyy-MM-dd')}') TO ('${format(nextMonth, 'yyyy-MM-dd')}')`
+        )
+      );
+      created.push(name);
+    } catch (error) {
+      errors.push({ name, error });
+    }
+  }
+
+  return { created, errors };
+}

--- a/apps/web/src/tests/setup/workerSetup.ts
+++ b/apps/web/src/tests/setup/workerSetup.ts
@@ -6,6 +6,7 @@ import { LEGACY_KILOCLAW_PRICE_VERSION } from '@kilocode/db';
 import { kiloclaw_subscriptions } from '@kilocode/db/schema';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
+import { provisionExaUsageLogPartitions } from '@/lib/exa-usage-partitions';
 import { existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { shutdownPosthog } from '@/lib/posthog';
@@ -51,6 +52,17 @@ beforeAll(async () => {
   try {
     const testDb = drizzle(testPool);
     await migrate(testDb, { migrationsFolder: '../../packages/db/src/migrations' });
+
+    // Production keeps this rolling window current via cron. Each Jest worker
+    // starts from the static migration snapshot, so it needs the same window
+    // before tests insert rows whose created_at defaults to now().
+    const { errors: partitionErrors } = await provisionExaUsageLogPartitions(testDb);
+    if (partitionErrors.length > 0) {
+      const [{ name, error }] = partitionErrors;
+      throw new Error(
+        `Failed to create Exa usage log partition ${name}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
   } finally {
     await testPool.end();
   }


### PR DESCRIPTION
## Summary
- Extract Exa usage log partition provisioning into a shared helper used by the cron route.
- Run the same partition provisioning in Jest worker database setup so fresh test databases have the current-month partition before Exa log inserts.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
- Test setup now treats partition provisioning failures as fatal, while the cron endpoint preserves best-effort error reporting.