### PR TITLE
test(kilo-pass): freeze App Store notification clock

### DIFF
--- a/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
+++ b/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import {
   DeliveryStatus,
   NotificationTypeV2,
@@ -31,6 +31,8 @@ import { processAppStoreKiloPassNotification } from './apple-store-notifications
 import type { AppleStoreDecodedNotification } from './apple-store-notifications';
 import type { AppleStoreDecodedTransaction } from './apple-store-verifier';
 import { toMicrodollars } from '@/lib/utils';
+
+const APP_STORE_NOTIFICATION_TEST_NOW_MS = Date.parse('2026-05-15T00:00:00.000Z');
 
 function notification(
   overrides: Partial<AppleStoreDecodedNotification> = {}
@@ -95,6 +97,16 @@ async function insertProviderScopedSubscriptionRows(providerSubscriptionId: stri
 }
 
 describe('processAppStoreKiloPassNotification', () => {
+  let dateNowSpy: jest.SpiedFunction<typeof Date.now>;
+
+  beforeAll(() => {
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(APP_STORE_NOTIFICATION_TEST_NOW_MS);
+  });
+
+  afterAll(() => {
+    dateNowSpy.mockRestore();
+  });
+
   it('records a renewal notification and completes the subscription once', async () => {
     const user = await insertTestUser();
     const decodedNotification = notification();


### PR DESCRIPTION
## Summary
- Freeze the App Store notification test clock at May 15, 2026 so date-based transaction fixtures remain valid.
- Restore the `Date.now()` spy after the suite to keep the override scoped to these tests.

## Verification
- Confirmed the failing CI job was caused by the shared App Store notification fixture expiring after May 31, 2026.
- No browser verification needed for this test-only change.

## Visual Changes
N/A

## Reviewer Notes
- Uses a `Date.now()` spy instead of fake timers to avoid interfering with async duplicate-delivery timing coverage.