### PR TITLE
feat(cloud-agent-next): add manual compact command

### DIFF
--- a/services/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -568,6 +568,7 @@ describe('WrapperClient', () => {
         command: 'compact',
         args: '--aggressive',
         messageId: 'msg_018f1e2d3c4bCommandWireAAA',
+        agent: { model: { modelID: 'anthropic/claude-sonnet-4-20250514' } },
         autoCommit: true,
         condenseOnComplete: false,
         session: {
@@ -581,6 +582,7 @@ describe('WrapperClient', () => {
 
       const execCall = (session.exec as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(execCall).toContain('"messageId":"msg_018f1e2d3c4bCommandWireAAA"');
+      expect(execCall).toContain('"modelID":"anthropic/claude-sonnet-4-20250514"');
       expect(execCall).toContain('"autoCommit":true');
       expect(execCall).toContain('"condenseOnComplete":false');
       expect(execCall).toContain('"workerAuthToken":"tok_command"');

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -604,12 +604,12 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
         terminalizeSessionMessageOnce: async (messageId, params, wrapperRunId) => {
           await this.ensureAcceptedMessageBeforeTerminal(messageId, wrapperRunId);
           await this.recordCorrelatedAgentActivity(messageId);
-          await this.terminalizeSessionMessageOnce(messageId, {
-            ...params,
-            ...(params.kind === 'failed'
-              ? { failureStage: 'agent_activity', failureCode: 'assistant_error' }
-              : {}),
-          } as TerminalizeParams);
+          await this.terminalizeSessionMessageOnce(
+            messageId,
+            params.kind === 'failed'
+              ? { ...params, failureStage: 'agent_activity', failureCode: 'assistant_error' }
+              : params
+          );
         },
       };
 

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -1482,6 +1482,11 @@ export class SessionService {
         command: turn.command,
         ...(turn.arguments.length > 0 ? { args: turn.arguments } : {}),
         messageId: turn.messageId,
+        agent: {
+          mode: promptAgent,
+          model: { modelID: agent.model },
+          ...(agent.variant ? { variant: agent.variant } : {}),
+        },
         ...(finalization?.autoCommit !== undefined ? { autoCommit: finalization.autoCommit } : {}),
         ...(finalization?.condenseOnComplete !== undefined
           ? { condenseOnComplete: finalization.condenseOnComplete }

--- a/services/cloud-agent-next/src/session/ingest-handlers/commands-available.test.ts
+++ b/services/cloud-agent-next/src/session/ingest-handlers/commands-available.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { handleCommandsAvailable } from './commands-available.js';
-import { DEFAULT_SLASH_COMMANDS } from '../../shared/default-slash-commands.generated';
+import { commandsOrDefault } from '../../shared/slash-commands.js';
 
 const silentLogger = { info: () => {}, warn: () => {} };
 
@@ -18,10 +18,13 @@ describe('handleCommandsAvailable', () => {
     );
 
     expect(setAvailableCommands).toHaveBeenCalledTimes(1);
-    expect(setAvailableCommands).toHaveBeenCalledWith([
-      { name: 'review', description: 'Review', hints: [] },
-      { name: 'init', hints: ['$ARGUMENTS'], source: 'command' },
-    ]);
+    expect(setAvailableCommands).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'review', description: 'Review', hints: [] }),
+        expect.objectContaining({ name: 'init', hints: ['$ARGUMENTS'], source: 'command' }),
+        { name: 'compact', description: 'compact the current session context', hints: [] },
+      ])
+    );
   });
 
   it('drops items missing a name without rejecting the whole event', async () => {
@@ -31,7 +34,12 @@ describe('handleCommandsAvailable', () => {
       { setAvailableCommands, logger: silentLogger }
     );
 
-    expect(setAvailableCommands).toHaveBeenCalledWith([{ name: 'ok', hints: [] }]);
+    expect(setAvailableCommands).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'ok', hints: [] }),
+        { name: 'compact', description: 'compact the current session context', hints: [] },
+      ])
+    );
   });
 
   it('warns and skips when commands array is missing', async () => {
@@ -60,7 +68,7 @@ describe('handleCommandsAvailable', () => {
     await handleCommandsAvailable({ commands: [] }, { setAvailableCommands, logger: silentLogger });
 
     expect(setAvailableCommands).toHaveBeenCalledTimes(1);
-    expect(setAvailableCommands).toHaveBeenCalledWith(DEFAULT_SLASH_COMMANDS);
+    expect(setAvailableCommands).toHaveBeenCalledWith(commandsOrDefault(undefined));
   });
 
   it('persists defaults when all items fail validation', async () => {
@@ -71,6 +79,6 @@ describe('handleCommandsAvailable', () => {
     );
 
     expect(setAvailableCommands).toHaveBeenCalledTimes(1);
-    expect(setAvailableCommands).toHaveBeenCalledWith(DEFAULT_SLASH_COMMANDS);
+    expect(setAvailableCommands).toHaveBeenCalledWith(commandsOrDefault(undefined));
   });
 });

--- a/services/cloud-agent-next/src/session/message-settlement-outbox.test.ts
+++ b/services/cloud-agent-next/src/session/message-settlement-outbox.test.ts
@@ -198,6 +198,28 @@ describe('MessageSettlementOutbox', () => {
     });
   });
 
+  it('persists manual compact terminalization and emits one completion event', async () => {
+    const harness = createHarness();
+    await putSessionMessageState(harness.storage, acceptedMessageState(firstMessageId));
+
+    const result = await harness.outbox.terminalizeSessionMessageOnce(firstMessageId, {
+      kind: 'completed',
+      completionSource: 'manual_compact_summarize',
+    });
+
+    expect(result.changed).toBe(true);
+    expect(await getSessionMessageState(harness.storage, firstMessageId)).toMatchObject({
+      status: 'completed',
+      completionSource: 'manual_compact_summarize',
+    });
+    expect(harness.events).toHaveLength(1);
+    expect(JSON.parse(harness.events[0].payload)).toMatchObject({
+      messageId: firstMessageId,
+      status: 'completed',
+      completionSource: 'manual_compact_summarize',
+    });
+  });
+
   it('dispatches one web-session push using message identity and assistant text', async () => {
     const harness = createHarness({
       metadata: pushMetadata,

--- a/services/cloud-agent-next/src/session/session-message-state.ts
+++ b/services/cloud-agent-next/src/session/session-message-state.ts
@@ -12,6 +12,7 @@ export type SessionMessageStatus = 'queued' | 'accepted' | 'completed' | 'failed
 
 export type SessionMessageCompletionSource =
   | 'assistant_message_event'
+  | 'manual_compact_summarize'
   | 'idle_reconciliation'
   | 'wrapper_failure'
   | 'interrupt'
@@ -167,6 +168,7 @@ export const SessionMessageStateSchema = z
     completionSource: z
       .enum([
         'assistant_message_event',
+        'manual_compact_summarize',
         'idle_reconciliation',
         'wrapper_failure',
         'interrupt',

--- a/services/cloud-agent-next/src/shared/protocol.ts
+++ b/services/cloud-agent-next/src/shared/protocol.ts
@@ -5,7 +5,7 @@ import type { SlashCommandInfo } from './slash-commands.js';
  *
  * From wrapper -> DO:
  *   started, kilocode, output, status, heartbeat, pong, error, interrupted, complete, wrapper_resumed,
- *   autocommit_started, autocommit_completed
+ *   autocommit_started, autocommit_completed, cloud.message.completed
  *
  * From DO -> /stream clients:
  *   All of the above, plus wrapper_disconnected, wrapper_reconnected, preparing,

--- a/services/cloud-agent-next/src/shared/slash-commands.test.ts
+++ b/services/cloud-agent-next/src/shared/slash-commands.test.ts
@@ -94,21 +94,34 @@ describe('toSlashCommandInfo', () => {
 });
 
 describe('commandsOrDefault', () => {
-  it('returns the provided list when non-empty', () => {
+  it('returns live commands with session actions when non-empty', () => {
     const live = [{ name: 'live', hints: [] }];
+    expect(commandsOrDefault(live)).toEqual([
+      { name: 'live', hints: [] },
+      { name: 'compact', description: 'compact the current session context', hints: [] },
+    ]);
+  });
+
+  it('does not duplicate live session actions', () => {
+    const live = [{ name: 'compact', description: 'live compact', hints: [] }];
     expect(commandsOrDefault(live)).toBe(live);
   });
 
   it('returns defaults for undefined', () => {
-    expect(commandsOrDefault(undefined)).toEqual(DEFAULT_SLASH_COMMANDS);
+    expect(commandsOrDefault(undefined)).toEqual(
+      expect.arrayContaining([
+        ...DEFAULT_SLASH_COMMANDS,
+        { name: 'compact', description: 'compact the current session context', hints: [] },
+      ])
+    );
   });
 
   it('returns defaults for null', () => {
-    expect(commandsOrDefault(null)).toEqual(DEFAULT_SLASH_COMMANDS);
+    expect(commandsOrDefault(null)).toEqual(commandsOrDefault(undefined));
   });
 
   it('returns defaults for empty array', () => {
-    expect(commandsOrDefault([])).toEqual(DEFAULT_SLASH_COMMANDS);
+    expect(commandsOrDefault([])).toEqual(commandsOrDefault(undefined));
   });
 
   it('default commands are non-empty and validate', () => {

--- a/services/cloud-agent-next/src/shared/slash-commands.ts
+++ b/services/cloud-agent-next/src/shared/slash-commands.ts
@@ -6,6 +6,14 @@ import {
 
 export { DEFAULT_SLASH_COMMANDS, DEFAULT_SLASH_COMMANDS_SOURCE, type SlashCommandInfo };
 
+const SESSION_SLASH_COMMANDS = [
+  {
+    name: 'compact',
+    description: 'compact the current session context',
+    hints: [],
+  },
+] satisfies SlashCommandInfo[];
+
 /** Parsed result of "/name rest of the line" from the chat composer. */
 export type SlashCommandInvocation = {
   command: string;
@@ -55,10 +63,19 @@ export function toSlashCommandInfo(raw: unknown): SlashCommandInfo | null {
  * Return the provided command list when it is non-empty, otherwise fall back
  * to the hardcoded default catalog. Used both server-side (DO storage) and
  * client-side (hook) so empty always means "defaults" rather than "none yet".
+ * Session actions such as compaction are local Kilo actions rather than
+ * registered prompt commands, so append them when the live catalog omits them.
  */
 export function commandsOrDefault(
   commands: SlashCommandInfo[] | null | undefined
 ): SlashCommandInfo[] {
-  if (commands && commands.length > 0) return commands;
-  return DEFAULT_SLASH_COMMANDS;
+  return withSessionSlashCommands(
+    commands && commands.length > 0 ? commands : DEFAULT_SLASH_COMMANDS
+  );
+}
+
+function withSessionSlashCommands(commands: SlashCommandInfo[]): SlashCommandInfo[] {
+  const names = new Set(commands.map(command => command.name));
+  const missing = SESSION_SLASH_COMMANDS.filter(command => !names.has(command.name));
+  return missing.length > 0 ? [...commands, ...missing] : commands;
 }

--- a/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
+++ b/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
@@ -100,6 +100,7 @@ export type WrapperCommandRequest = {
   command: string;
   args?: string;
   messageId: string;
+  agent?: WrapperPromptAgent;
   autoCommit?: boolean;
   condenseOnComplete?: boolean;
   session: WrapperSessionBinding;

--- a/services/cloud-agent-next/src/websocket/ingest.test.ts
+++ b/services/cloud-agent-next/src/websocket/ingest.test.ts
@@ -41,6 +41,7 @@ function createFakeDOContext(): IngestDOContext {
     updateKiloSessionId: vi.fn().mockResolvedValue(undefined),
     updateUpstreamBranch: vi.fn().mockResolvedValue(undefined),
     setAvailableCommands: vi.fn().mockResolvedValue(undefined),
+    terminalizeSessionMessageOnce: vi.fn().mockResolvedValue(undefined),
     wrapperSupervisor: {
       checkReconnect: vi.fn().mockResolvedValue({ accepted: true }),
       recordReconnectAccepted: vi.fn().mockResolvedValue(undefined),
@@ -964,6 +965,35 @@ describe('createIngestHandler', () => {
       expect(eventQueries.insert).not.toHaveBeenCalled();
       expect(eventQueries.upsert).not.toHaveBeenCalled();
       expect(broadcast).not.toHaveBeenCalled();
+    });
+
+    it('rejects unsupported wrapper cloud.message.completed sources', async () => {
+      const state = createFakeState();
+      const doContext = createNewPathDOContext();
+      const eventQueries = createFakeEventQueries();
+      const broadcast = vi.fn();
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const handler = createIngestHandler(state, eventQueries, SESSION_ID, broadcast, doContext);
+
+      const ws = createFakeWebSocket(makeNewPathAttachment());
+
+      const message = JSON.stringify({
+        streamEventType: 'cloud.message.completed',
+        data: {
+          messageId: 'msg_compact',
+          completionSource: 'unsupported_source',
+        },
+        timestamp: new Date().toISOString(),
+      });
+
+      await handler.handleIngestMessage(ws, message);
+
+      expect(doContext.terminalizeSessionMessageOnce).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        'Invalid cloud.message.completed event payload',
+        expect.anything()
+      );
+      warn.mockRestore();
     });
 
     it('terminalizes as failed on assistant message.updated with error', async () => {

--- a/services/cloud-agent-next/src/websocket/ingest.test.ts
+++ b/services/cloud-agent-next/src/websocket/ingest.test.ts
@@ -932,6 +932,40 @@ describe('createIngestHandler', () => {
       );
     });
 
+    it('terminalizes on wrapper cloud.message.completed control event', async () => {
+      const state = createFakeState();
+      const doContext = createNewPathDOContext();
+      const eventQueries = createFakeEventQueries();
+      const broadcast = vi.fn();
+      const handler = createIngestHandler(state, eventQueries, SESSION_ID, broadcast, doContext);
+
+      const ws = createFakeWebSocket(makeNewPathAttachment());
+
+      const message = JSON.stringify({
+        streamEventType: 'cloud.message.completed',
+        data: {
+          messageId: 'msg_compact',
+          completionSource: 'manual_compact_summarize',
+        },
+        timestamp: new Date().toISOString(),
+      });
+
+      await handler.handleIngestMessage(ws, message);
+
+      expect(doContext.terminalizeSessionMessageOnce).toHaveBeenCalledWith(
+        'msg_compact',
+        {
+          kind: 'completed',
+          assistantMessageId: undefined,
+          completionSource: 'manual_compact_summarize',
+        },
+        WRAPPER_RUN_ID
+      );
+      expect(eventQueries.insert).not.toHaveBeenCalled();
+      expect(eventQueries.upsert).not.toHaveBeenCalled();
+      expect(broadcast).not.toHaveBeenCalled();
+    });
+
     it('terminalizes as failed on assistant message.updated with error', async () => {
       const state = createFakeState();
       const doContext = createNewPathDOContext();

--- a/services/cloud-agent-next/src/websocket/ingest.ts
+++ b/services/cloud-agent-next/src/websocket/ingest.ts
@@ -60,6 +60,12 @@ const errorEventSchema = z.object({
   message: z.string().optional(),
 });
 
+const cloudMessageCompletedEventSchema = z.object({
+  messageId: z.string(),
+  assistantMessageId: z.string().optional(),
+  completionSource: z.string().optional(),
+});
+
 const wrapperGenerationParamSchema = z.coerce.number().int().nonnegative();
 
 function getAssistantErrorMessage(error: unknown): string | undefined {
@@ -478,6 +484,31 @@ export function createIngestHandler(
               now
             );
           }
+        }
+
+        if (eventType === 'cloud.message.completed') {
+          const parsedCloudMessageCompleted = cloudMessageCompletedEventSchema.safeParse(
+            ingestEvent.data
+          );
+          if (!parsedCloudMessageCompleted.success) {
+            console.warn(
+              'Invalid cloud.message.completed event payload',
+              parsedCloudMessageCompleted.error
+            );
+            return;
+          }
+
+          await doContext.terminalizeSessionMessageOnce?.(
+            parsedCloudMessageCompleted.data.messageId,
+            {
+              kind: 'completed',
+              assistantMessageId: parsedCloudMessageCompleted.data.assistantMessageId,
+              completionSource:
+                parsedCloudMessageCompleted.data.completionSource ?? 'wrapper_completion_event',
+            },
+            wrapperRunId
+          );
+          return;
         }
 
         let eventId: number;

--- a/services/cloud-agent-next/src/websocket/ingest.ts
+++ b/services/cloud-agent-next/src/websocket/ingest.ts
@@ -28,6 +28,7 @@ import type { CompleteEventData, KilocodeEventData, CloudStatusData } from '../s
 import type { SlashCommandInfo } from '../shared/slash-commands.js';
 import { logger } from '../logger.js';
 import type { WrapperSupervisor } from '../session/wrapper-supervisor.js';
+import type { TerminalizeParams } from '../session/session-message-state.js';
 
 // ---------------------------------------------------------------------------
 // Ingest Attachment
@@ -63,7 +64,7 @@ const errorEventSchema = z.object({
 const cloudMessageCompletedEventSchema = z.object({
   messageId: z.string(),
   assistantMessageId: z.string().optional(),
-  completionSource: z.string().optional(),
+  completionSource: z.literal('manual_compact_summarize'),
 });
 
 const wrapperGenerationParamSchema = z.coerce.number().int().nonnegative();
@@ -151,15 +152,9 @@ export type IngestDOContext = {
   >;
   keepContainerAlive?: () => void;
   observeCorrelatedAgentActivity?: (messageId: string) => Promise<void>;
-  terminalizeSessionMessageOnce?: (
+  terminalizeSessionMessageOnce: (
     messageId: string,
-    params: {
-      kind: 'completed' | 'failed' | 'interrupted';
-      assistantMessageId?: string;
-      completionSource: string;
-      reason?: string;
-      error?: string;
-    },
+    params: TerminalizeParams & { assistantMessageId?: string },
     wrapperRunId: string
   ) => Promise<void>;
   /** Persist the slash-command catalog so connecting clients can be hydrated. */
@@ -498,13 +493,12 @@ export function createIngestHandler(
             return;
           }
 
-          await doContext.terminalizeSessionMessageOnce?.(
+          await doContext.terminalizeSessionMessageOnce(
             parsedCloudMessageCompleted.data.messageId,
             {
               kind: 'completed',
               assistantMessageId: parsedCloudMessageCompleted.data.assistantMessageId,
-              completionSource:
-                parsedCloudMessageCompleted.data.completionSource ?? 'wrapper_completion_event',
+              completionSource: parsedCloudMessageCompleted.data.completionSource,
             },
             wrapperRunId
           );
@@ -648,15 +642,21 @@ export function createIngestHandler(
             if (parentMessageId !== undefined) {
               await doContext.observeCorrelatedAgentActivity?.(parentMessageId);
               if (isTerminal) {
-                await doContext.terminalizeSessionMessageOnce?.(
+                await doContext.terminalizeSessionMessageOnce(
                   parentMessageId,
-                  {
-                    kind: hasError ? 'failed' : 'completed',
-                    assistantMessageId: typeof info?.id === 'string' ? info.id : undefined,
-                    completionSource: 'assistant_message_event',
-                    reason: hasError ? 'assistant_error' : undefined,
-                    error: assistantError,
-                  },
+                  hasError
+                    ? {
+                        kind: 'failed',
+                        assistantMessageId: typeof info?.id === 'string' ? info.id : undefined,
+                        reason: 'assistant_error',
+                        error: assistantError,
+                        completionSource: 'assistant_message_event',
+                      }
+                    : {
+                        kind: 'completed',
+                        assistantMessageId: typeof info?.id === 'string' ? info.id : undefined,
+                        completionSource: 'assistant_message_event',
+                      },
                   wrapperRunId
                 );
               }

--- a/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
@@ -42,6 +42,7 @@ const createMockKiloClient = (): WrapperKiloClient => ({
   getSession: vi.fn(),
   sendPromptAsync: vi.fn(),
   abortSession: vi.fn(),
+  summarizeSession: vi.fn(),
   sendCommand: vi.fn(),
   answerPermission: vi.fn(),
   answerQuestion: vi.fn(),

--- a/services/cloud-agent-next/test/unit/wrapper/condense-on-complete.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/condense-on-complete.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { runCondenseOnComplete } from '../../../wrapper/src/condense-on-complete.js';
+import type { WrapperKiloClient } from '../../../wrapper/src/kilo-api.js';
+
+describe('runCondenseOnComplete', () => {
+  it('uses the dedicated summarize endpoint with the active model', async () => {
+    const kiloClient = {
+      summarizeSession: vi.fn().mockResolvedValue(true),
+      abortSession: vi.fn().mockResolvedValue(true),
+    } as unknown as WrapperKiloClient;
+    const onEvent = vi.fn();
+    const expectCompletion = vi.fn();
+    const waitForCompletion = vi.fn().mockResolvedValue(undefined);
+    const wasAborted = vi.fn().mockReturnValue(false);
+
+    const result = await runCondenseOnComplete({
+      workspacePath: '/workspace',
+      kiloSessionId: 'kilo_sess',
+      model: 'anthropic/claude-sonnet-4-20250514',
+      onEvent,
+      kiloClient,
+      expectCompletion,
+      waitForCompletion,
+      wasAborted,
+      timeoutMs: 100,
+    });
+
+    expect(result).toEqual({ wasAborted: false, success: true });
+    expect(expectCompletion).toHaveBeenCalledOnce();
+    expect(kiloClient.summarizeSession).toHaveBeenCalledWith({
+      sessionId: 'kilo_sess',
+      model: { modelID: 'anthropic/claude-sonnet-4-20250514' },
+      auto: true,
+    });
+  });
+});

--- a/services/cloud-agent-next/test/unit/wrapper/kilo-api.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/kilo-api.test.ts
@@ -33,6 +33,32 @@ describe('createWrapperKiloClient prompt handoff', () => {
     ).rejects.toThrow('Command for session kilo_sess failed: command rejected');
   });
 
+  it('summarizes sessions through the dedicated Kilo endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(true), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const client = createWrapperKiloClient(createSdkClient(), 'http://127.0.0.1:0', workspacePath);
+
+    const result = await client.summarizeSession({
+      sessionId: 'kilo_sess',
+      model: { modelID: 'anthropic/claude-sonnet-4-20250514' },
+    });
+
+    expect(result).toBe(true);
+    const request = fetchMock.mock.calls[0]?.[0];
+    expect(request).toBeInstanceOf(Request);
+    const url = new URL((request as Request).url);
+    expect(url.pathname).toBe('/session/kilo_sess/summarize');
+    await expect((request as Request).clone().json()).resolves.toEqual({
+      providerID: 'kilo',
+      modelID: 'anthropic/claude-sonnet-4-20250514',
+    });
+  });
+
   it('throws when the SDK async prompt response contains an error', async () => {
     vi.stubGlobal(
       'fetch',

--- a/services/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
@@ -44,6 +44,7 @@ const createMockKiloClient = (): WrapperKiloClient => ({
   getSession: vi.fn().mockResolvedValue({ id: 'kilo_sess' }),
   sendPromptAsync: vi.fn().mockResolvedValue(undefined),
   abortSession: vi.fn().mockResolvedValue(true),
+  summarizeSession: vi.fn().mockResolvedValue(true),
   sendCommand: vi.fn().mockResolvedValue(undefined),
   answerPermission: vi.fn().mockResolvedValue(true),
   answerQuestion: vi.fn().mockResolvedValue(true),

--- a/services/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
@@ -186,6 +186,22 @@ describe('createLifecycleManager', () => {
       expect(connectionFns.closeConnections).toHaveBeenCalled();
     });
 
+    it('defers drain while ingest reconnects and resumes it when connectivity is restored', async () => {
+      const mgr = createManager();
+      (connectionFns.isConnected as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      state.bindSession(createSessionContext());
+      state.acceptMessage('msg_1', { autoCommit: false, condenseOnComplete: false });
+      mgr.onMessageComplete('msg_1');
+      mgr.onSessionIdle();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(connectionFns.closeConnections).not.toHaveBeenCalled();
+
+      (connectionFns.isConnected as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      mgr.onConnectionRestored();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(connectionFns.closeConnections).toHaveBeenCalled();
+    });
+
     it('does not trigger drain when pending messages remain', async () => {
       const mgr = createManager();
       (connectionFns.isConnected as ReturnType<typeof vi.fn>).mockReturnValue(true);

--- a/services/cloud-agent-next/test/unit/wrapper/network-resume.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/network-resume.test.ts
@@ -147,6 +147,7 @@ function createMockKiloClient(overrides?: Partial<WrapperKiloClient>): WrapperKi
     getSession: vi.fn().mockResolvedValue({ id: 'kilo_sess' }),
     sendPromptAsync: vi.fn().mockResolvedValue(undefined),
     abortSession: vi.fn().mockResolvedValue(true),
+    summarizeSession: vi.fn().mockResolvedValue(true),
     sendCommand: vi.fn().mockResolvedValue(undefined),
     answerPermission: vi.fn().mockResolvedValue(true),
     answerQuestion: vi.fn().mockResolvedValue(true),

--- a/services/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
@@ -157,6 +157,7 @@ const createMockKiloClient = (overrides: Partial<WrapperKiloClient> = {}): Wrapp
   getSession: vi.fn().mockResolvedValue({ id: 'kilo_sess' }),
   sendPromptAsync: vi.fn().mockResolvedValue(undefined),
   abortSession: vi.fn().mockResolvedValue(true),
+  summarizeSession: vi.fn().mockResolvedValue(true),
   sendCommand: vi.fn().mockResolvedValue(undefined),
   answerPermission: vi.fn().mockResolvedValue(true),
   answerQuestion: vi.fn().mockResolvedValue(true),

--- a/services/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
@@ -651,8 +651,14 @@ describe('ingest WS reconnection', () => {
       timestamp: new Date().toISOString(),
       data: { text: 'some output' },
     };
+    const event3: IngestEvent = {
+      streamEventType: 'cloud.message.completed',
+      timestamp: new Date().toISOString(),
+      data: { messageId: 'msg_compact', completionSource: 'manual_compact_summarize' },
+    };
     state.sendToIngest(event1);
     state.sendToIngest(event2);
+    state.sendToIngest(event3);
 
     // Events should NOT have been sent to the old WS
     // (old WS is closed, so nothing is sent — events are buffered internally).
@@ -665,6 +671,12 @@ describe('ingest WS reconnection', () => {
         return true;
       }
       if (parsed.streamEventType === 'kilocode' && parsed.data?.event === 'test_event_1') {
+        return true;
+      }
+      if (
+        parsed.streamEventType === 'cloud.message.completed' &&
+        parsed.data?.messageId === 'msg_compact'
+      ) {
         return true;
       }
       return false;
@@ -685,7 +697,7 @@ describe('ingest WS reconnection', () => {
     });
     expect(resumeMsg).toBeDefined();
     const parsedResume = JSON.parse(resumeMsg!);
-    expect(parsedResume.data.bufferedEvents).toBe(2);
+    expect(parsedResume.data.bufferedEvents).toBe(3);
     expect(parsedResume.data.eventsLost).toBe(false);
 
     // Verify buffered events were flushed to new WS. Filter to the specific
@@ -693,14 +705,29 @@ describe('ingest WS reconnection', () => {
     // session.status kilocode event, which we ignore.
     const flushedEvents = newWs.sent
       .map(msg => JSON.parse(msg))
-      .filter((e: { streamEventType: string; data?: { event?: string; text?: string } }) => {
-        if (e.streamEventType === 'kilocode' && e.data?.event === 'test_event_1') return true;
-        if (e.streamEventType === 'output' && e.data?.text === 'some output') return true;
-        return false;
-      });
-    expect(flushedEvents).toHaveLength(2);
+      .filter(
+        (e: {
+          streamEventType: string;
+          data?: { event?: string; text?: string; messageId?: string };
+        }) => {
+          if (e.streamEventType === 'kilocode' && e.data?.event === 'test_event_1') return true;
+          if (e.streamEventType === 'output' && e.data?.text === 'some output') return true;
+          if (
+            e.streamEventType === 'cloud.message.completed' &&
+            e.data?.messageId === 'msg_compact'
+          ) {
+            return true;
+          }
+          return false;
+        }
+      );
+    expect(flushedEvents).toHaveLength(3);
     expect(flushedEvents[0].data.event).toBe('test_event_1');
     expect(flushedEvents[1].data.text).toBe('some output');
+    expect(flushedEvents[2]).toMatchObject({
+      streamEventType: 'cloud.message.completed',
+      data: { messageId: 'msg_compact', completionSource: 'manual_compact_summarize' },
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/services/cloud-agent-next/test/unit/wrapper/server.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/server.test.ts
@@ -13,6 +13,7 @@ import {
   createRejectQuestionHandler,
   createAbortHandler,
   createPromptHandler,
+  createCommandHandler,
   createSessionReadyHandler,
   bindSessionContext,
   type ServerConfig,
@@ -30,6 +31,7 @@ function createMockKiloClient(): WrapperKiloClient {
     getSession: vi.fn().mockResolvedValue({ id: 'kilo_sess' }),
     sendPromptAsync: vi.fn().mockResolvedValue(undefined),
     abortSession: vi.fn().mockResolvedValue(true),
+    summarizeSession: vi.fn().mockResolvedValue(true),
     sendCommand: vi.fn().mockResolvedValue(undefined),
     answerPermission: vi.fn().mockResolvedValue(true),
     answerQuestion: vi.fn().mockResolvedValue(true),
@@ -51,6 +53,7 @@ function createMockDeps(state: WrapperState) {
     closeConnection: vi.fn().mockResolvedValue(undefined),
     setAborted: vi.fn(),
     resetLifecycle: vi.fn(),
+    onMessageComplete: vi.fn(),
     readySession: vi.fn(),
     materializePromptAttachments: vi.fn(async prompt => prompt),
   };
@@ -550,6 +553,107 @@ describe('createPromptHandler', () => {
 
     expect(response.status).toBe(400);
     expect(state.hasSession).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Command Handler
+// ---------------------------------------------------------------------------
+
+describe('createCommandHandler', () => {
+  it('routes compact through session summarize with the selected model', async () => {
+    const state = new WrapperState();
+    const sendToIngest = vi.fn();
+    state.setSendToIngestFn(sendToIngest);
+    const deps = createMockDeps(state);
+    const handler = createCommandHandler(defaultServerConfig, deps);
+
+    const response = await handler(
+      jsonRequest({
+        command: 'compact',
+        messageId: 'msg_compact',
+        agent: {
+          model: { providerID: 'kilo', modelID: 'anthropic/claude-sonnet-4-20250514' },
+        },
+        session: completeBinding,
+      })
+    );
+    const data = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ status: 'sent', result: true });
+    expect(deps.openConnection).toHaveBeenCalledOnce();
+    expect(deps.kiloClient.summarizeSession).toHaveBeenCalledWith({
+      sessionId: 'kilo_sess_1',
+      model: { providerID: 'kilo', modelID: 'anthropic/claude-sonnet-4-20250514' },
+    });
+    expect(deps.kiloClient.sendCommand).not.toHaveBeenCalled();
+    expect(sendToIngest).toHaveBeenCalledWith({
+      streamEventType: 'cloud.message.completed',
+      data: {
+        messageId: 'msg_compact',
+        completionSource: 'manual_compact_summarize',
+      },
+      timestamp: expect.any(String),
+    });
+    expect(deps.onMessageComplete).toHaveBeenCalledWith('msg_compact');
+    expect(state.getMessageConfig('msg_compact')).toEqual({
+      autoCommit: false,
+      condenseOnComplete: false,
+      model: 'anthropic/claude-sonnet-4-20250514',
+      upstreamBranch: undefined,
+    });
+  });
+
+  it('rejects compact without a model', async () => {
+    const state = new WrapperState();
+    const deps = createMockDeps(state);
+    const handler = createCommandHandler(defaultServerConfig, deps);
+
+    const response = await handler(
+      jsonRequest({
+        command: 'compact',
+        messageId: 'msg_compact',
+        session: completeBinding,
+      })
+    );
+    const data = await readJson(response);
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: 'INVALID_REQUEST', message: 'model is required for compact' });
+    expect(deps.openConnection).not.toHaveBeenCalled();
+    expect(deps.kiloClient.summarizeSession).not.toHaveBeenCalled();
+    expect(deps.kiloClient.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('does not complete compact message when summarize fails', async () => {
+    const state = new WrapperState();
+    const sendToIngest = vi.fn();
+    state.setSendToIngestFn(sendToIngest);
+    const deps = createMockDeps(state);
+    deps.kiloClient.summarizeSession = vi.fn().mockRejectedValue(new Error('summarize failed'));
+    const handler = createCommandHandler(defaultServerConfig, deps);
+
+    const response = await handler(
+      jsonRequest({
+        command: 'compact',
+        messageId: 'msg_compact',
+        agent: {
+          model: { providerID: 'kilo', modelID: 'anthropic/claude-sonnet-4-20250514' },
+        },
+        session: completeBinding,
+      })
+    );
+    const data = await readJson(response);
+
+    expect(response.status).toBe(500);
+    expect(data).toEqual({
+      error: 'COMMAND_ERROR',
+      message: 'Failed to send command: summarize failed',
+    });
+    expect(sendToIngest).not.toHaveBeenCalled();
+    expect(deps.onMessageComplete).not.toHaveBeenCalled();
+    expect(state.getMessageConfig('msg_compact')).toBeNull();
   });
 });
 

--- a/services/cloud-agent-next/test/unit/wrapper/snapshot.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/snapshot.test.ts
@@ -130,6 +130,7 @@ function createMockKiloClient(overrides?: Partial<WrapperKiloClient>): WrapperKi
     getSession: vi.fn().mockResolvedValue({ id: 'kilo_sess' }),
     sendPromptAsync: vi.fn().mockResolvedValue(undefined),
     abortSession: vi.fn().mockResolvedValue(true),
+    summarizeSession: vi.fn().mockResolvedValue(true),
     sendCommand: vi.fn().mockResolvedValue(undefined),
     answerPermission: vi.fn().mockResolvedValue(true),
     answerQuestion: vi.fn().mockResolvedValue(true),

--- a/services/cloud-agent-next/wrapper/src/condense-on-complete.ts
+++ b/services/cloud-agent-next/wrapper/src/condense-on-complete.ts
@@ -50,14 +50,18 @@ export async function runCondenseOnComplete(
   try {
     sendStatus('Condensing context...');
 
+    if (!opts.model) {
+      throw new Error('No model specified for condense');
+    }
+
     // Arm the completion waiter BEFORE sending the prompt
     opts.expectCompletion();
 
-    // Send /compact command via server API
-    logToFile(`condense: sending /compact command to session ${opts.kiloSessionId}`);
-    await opts.kiloClient.sendCommand({
+    logToFile(`condense: summarizing session ${opts.kiloSessionId}`);
+    await opts.kiloClient.summarizeSession({
       sessionId: opts.kiloSessionId,
-      command: 'compact',
+      model: { modelID: opts.model },
+      auto: true,
     });
 
     // Wait for completion with timeout

--- a/services/cloud-agent-next/wrapper/src/kilo-api.ts
+++ b/services/cloud-agent-next/wrapper/src/kilo-api.ts
@@ -115,6 +115,11 @@ export type WrapperKiloClient = {
     tools?: Record<string, boolean>;
   }) => Promise<void>;
   abortSession: (opts: { sessionId: string }) => Promise<boolean>;
+  summarizeSession: (opts: {
+    sessionId: string;
+    model: { providerID?: string; modelID: string };
+    auto?: boolean;
+  }) => Promise<boolean>;
   sendCommand: (opts: {
     sessionId: string;
     command: string;
@@ -254,6 +259,21 @@ export function createWrapperKiloClient(
     abortSession: async opts => {
       await sdkClient.session.abort({ path: { id: opts.sessionId } });
       return true;
+    },
+
+    summarizeSession: async opts => {
+      const result = await v2Client.session.summarize({
+        sessionID: opts.sessionId,
+        providerID: opts.model.providerID ?? 'kilo',
+        modelID: opts.model.modelID,
+        ...(opts.auto !== undefined ? { auto: opts.auto } : {}),
+      });
+      if (result.error !== undefined) {
+        throw new Error(
+          `Session summarize for ${opts.sessionId} failed: ${formatSdkError(result.error)}`
+        );
+      }
+      return result.data ?? true;
     },
 
     sendCommand: async opts => {

--- a/services/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/services/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -69,6 +69,8 @@ export type LifecycleManager = {
   onSessionIdle: () => void;
   /** Called when the root Kilo session emits activity after idle. */
   onRootSessionActivity: () => void;
+  /** Called when ingest connectivity is restored after a reconnect. */
+  onConnectionRestored: () => void;
   /** Called to trigger drain and close sequence */
   triggerDrainAndClose: () => void;
   /** Signal completion for post-processing waiters (called by connection on completion events) */
@@ -342,6 +344,10 @@ export function createLifecycleManager(
     rootSessionIdleBarrierPresent = false;
   }
 
+  function onConnectionRestored(): void {
+    maybeFinalizeIdleBatch();
+  }
+
   return {
     start: () => {
       logToFile('lifecycle started (transport timer is event-driven)');
@@ -361,6 +367,7 @@ export function createLifecycleManager(
     onMessageComplete,
     onSessionIdle,
     onRootSessionActivity,
+    onConnectionRestored,
     triggerDrainAndClose,
     signalCompletion,
 

--- a/services/cloud-agent-next/wrapper/src/main.ts
+++ b/services/cloud-agent-next/wrapper/src/main.ts
@@ -191,6 +191,7 @@ async function main() {
     closeConnection: () => connectionManager?.close() ?? Promise.resolve(),
     setAborted: () => lifecycleManager?.setAborted(),
     resetLifecycle: () => lifecycleManager?.reset(),
+    onMessageComplete: (messageId: string) => lifecycleManager?.onMessageComplete(messageId),
     readySession: readySession,
     materializePromptAttachments,
   };

--- a/services/cloud-agent-next/wrapper/src/main.ts
+++ b/services/cloud-agent-next/wrapper/src/main.ts
@@ -373,6 +373,7 @@ async function main() {
         },
         onReconnected: () => {
           logToFile('ingest WS reconnected');
+          lifecycleManager?.onConnectionRestored();
           const lastError = state.getLastError();
           if (lastError?.code === 'DISCONNECT') {
             state.clearLastError();

--- a/services/cloud-agent-next/wrapper/src/server.ts
+++ b/services/cloud-agent-next/wrapper/src/server.ts
@@ -21,6 +21,7 @@ import { logToFile } from './utils.js';
 import { materializePromptAttachments as defaultMaterializePromptAttachments } from './session-bootstrap.js';
 import {
   isWrapperSessionReadyRequest,
+  type WrapperPromptAgent,
   type WrapperPromptRequest,
   type WrapperSessionReadyRequest,
   type WrapperSessionReadyResponse,
@@ -54,6 +55,8 @@ export type ServerDependencies = {
   setAborted: () => void;
   /** Reset lifecycle state for a new execution */
   resetLifecycle: () => void;
+  /** Mark a submitted message complete when the wrapper handles a synchronous session action. */
+  onMessageComplete?: (messageId: string) => void;
   /** Compatibility hook for callers that still construct wrapper server test deps. */
   setPerTurnConfig?: (config: PerTurnConfig) => void;
   /** Workspace/Kilo readiness path */
@@ -78,6 +81,7 @@ type CommandBody = {
   command: string;
   args?: string;
   messageId?: string;
+  agent?: WrapperPromptAgent;
   autoCommit?: boolean;
   condenseOnComplete?: boolean;
   session?: SessionBinding;
@@ -396,7 +400,7 @@ export function createPromptHandler(config: ServerConfig, deps: ServerDependenci
   };
 }
 
-function createCommandHandler(config: ServerConfig, deps: ServerDependencies) {
+export function createCommandHandler(config: ServerConfig, deps: ServerDependencies) {
   return async (req: Request): Promise<Response> => {
     const { state, kiloClient, openConnection } = deps;
 
@@ -418,6 +422,10 @@ function createCommandHandler(config: ServerConfig, deps: ServerDependencies) {
     if (!body.command) {
       return errorResponse('INVALID_REQUEST', 'command is required', 400);
     }
+    const compactModel = body.command === 'compact' ? body.agent?.model : undefined;
+    if (body.command === 'compact' && !compactModel?.modelID) {
+      return errorResponse('INVALID_REQUEST', 'model is required for compact', 400);
+    }
 
     const binding = body.session ?? body.execution;
     const messageId = body.messageId;
@@ -425,6 +433,7 @@ function createCommandHandler(config: ServerConfig, deps: ServerDependencies) {
       state.acceptMessage(messageId, {
         autoCommit: body.autoCommit ?? false,
         condenseOnComplete: body.condenseOnComplete ?? false,
+        model: body.agent?.model?.modelID,
         upstreamBranch: binding?.upstreamBranch,
       });
     }
@@ -442,12 +451,31 @@ function createCommandHandler(config: ServerConfig, deps: ServerDependencies) {
     }
 
     try {
-      const result = await kiloClient.sendCommand({
-        sessionId: session.kiloSessionId,
-        command: body.command,
-        args: body.args,
-        messageId,
-      });
+      let result: unknown;
+      if (compactModel) {
+        result = await kiloClient.summarizeSession({
+          sessionId: session.kiloSessionId,
+          model: compactModel,
+        });
+        if (messageId) {
+          state.sendToIngest({
+            streamEventType: 'cloud.message.completed',
+            data: {
+              messageId,
+              completionSource: 'manual_compact_summarize',
+            },
+            timestamp: new Date().toISOString(),
+          });
+          deps.onMessageComplete?.(messageId);
+        }
+      } else {
+        result = await kiloClient.sendCommand({
+          sessionId: session.kiloSessionId,
+          command: body.command,
+          args: body.args,
+          messageId,
+        });
+      }
       state.updateActivity();
       logToFile(`job/command: sent command=${body.command}`);
       return jsonResponse({ status: 'sent', result });


### PR DESCRIPTION
## Summary

- Add a synthetic `/compact` slash command to Cloud Agent Next sessions so users can manually compact session context even though compaction is a local Kilo session action rather than a registered prompt command.
- Route `/compact` through Kilo's dedicated session summarize API using the selected session model, and pass command agent metadata through the wrapper handoff so summarize has the required model context.
- Add a wrapper-to-DO `cloud.message.completed` control event that terminalizes the durable command message after synchronous manual compaction succeeds, without persisting or broadcasting an extra stream event.

## Verification

- [x] Verified locally

## Visual Changes

<img width="1005" height="733" alt="Screenshot 2026-06-01 at 12 36 19" src="https://github.com/user-attachments/assets/cf3c09ed-5b95-4d6c-a261-d131adf58f2f" />

