### PR TITLE
chore(cloud-agent-next): bump sandbox runtime packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1489,8 +1489,8 @@ importers:
   services/cloud-agent-next:
     dependencies:
       '@cloudflare/sandbox':
-        specifier: 0.10.1
-        version: 0.10.1(@xterm/xterm@6.0.0)
+        specifier: 0.10.3
+        version: 0.10.3(@xterm/xterm@6.0.0)
       '@hono/trpc-server':
         specifier: 0.4.2
         version: 0.4.2(@trpc/server@11.17.0(typescript@5.9.3))(hono@4.12.18)
@@ -1535,8 +1535,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@cloudflare/containers':
-        specifier: 0.3.4
-        version: 0.3.4
+        specifier: 0.3.5
+        version: 0.3.5
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
         version: 0.16.4(@cloudflare/workers-types@4.20260511.1)(@vitest/runner@4.1.6)(@vitest/snapshot@4.1.6)(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vitest@4.1.6)
@@ -1577,8 +1577,8 @@ importers:
   services/cloud-agent-next/wrapper:
     dependencies:
       '@kilocode/sdk':
-        specifier: 7.2.52
-        version: 7.2.52
+        specifier: 7.3.12
+        version: 7.3.12
     devDependencies:
       '@types/bun':
         specifier: 1.3.14
@@ -3758,6 +3758,9 @@ packages:
   '@cloudflare/containers@0.3.4':
     resolution: {integrity: sha512-6kWodmgBSug/rr9fjcWrZcKhxmWTEc1BTKC6nVv7yvYaRRvV3rZPZjq9R17eN0l9cl2LNc03wp/Z6OV+0uDwXA==}
 
+  '@cloudflare/containers@0.3.5':
+    resolution: {integrity: sha512-P6jYEDkw1Q9qWRr9iFBxe1fozI5HfGMY6XrNg/jROPGZykcYrrzOluUqXv+q4N8gIoRXPCqJJ1FGALbTqnYTkg==}
+
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
     engines: {node: '>=18.0.0'}
@@ -3766,8 +3769,8 @@ packages:
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
     engines: {node: '>=22.0.0'}
 
-  '@cloudflare/sandbox@0.10.1':
-    resolution: {integrity: sha512-l5QH0zemshvsYGvF5K/Lee1WydL93Oc1jZlVC2gRQkRwsNxNvHpfNn59B4/u68lax6iLGemWGd/TdJHzoq6MiQ==}
+  '@cloudflare/sandbox@0.10.3':
+    resolution: {integrity: sha512-UHAbkYpS5iB7WwOIN/+x3JC+mP0NPFcpgCXKoxCycwwfyp46Gq5eX4KffTp7WWFa4ghM04ZDkqmn9r4/959IbA==}
     peerDependencies:
       '@openai/agents': ^0.3.3
       '@opencode-ai/sdk': ^1.1.40
@@ -4916,6 +4919,9 @@ packages:
 
   '@kilocode/sdk@7.2.52':
     resolution: {integrity: sha512-j8w6ewvo7dyu/qxjJAg0bcjHGUGGvIZ4F2f5tJnpMwLzPTAu26DJoO/08aoxf1BhfuZLzNS9tA2q+ZPdzPT8Jg==}
+
+  '@kilocode/sdk@7.3.12':
+    resolution: {integrity: sha512-wnodVXM7ThX1nvPMao2fMBUXykoVxzMTP0fKe0FIr+R3xWlK9kXGnqnj8614+e9xgIGHhNAPJ8XQtMpoMJBXNw==}
 
   '@lexical/clipboard@0.35.0':
     resolution: {integrity: sha512-ko7xSIIiayvDiqjNDX6fgH9RlcM6r9vrrvJYTcfGVBor5httx16lhIi0QJZ4+RNPvGtTjyFv4bwRmsixRRwImg==}
@@ -9907,8 +9913,8 @@ packages:
   caniuse-lite@1.0.30001779:
     resolution: {integrity: sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==}
 
-  capnweb@0.6.1:
-    resolution: {integrity: sha512-fmhV26QPd1ewf5R74h55oVZnGwIcSaRMzbfLQUy8+zOBjuTmT3KXoT8wxHvnp1m9Ht9BoUUS5ZwNLoVLfQTyBg==}
+  capnweb@0.8.0:
+    resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
 
   case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
@@ -18316,15 +18322,17 @@ snapshots:
 
   '@cloudflare/containers@0.3.4': {}
 
+  '@cloudflare/containers@0.3.5': {}
+
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/sandbox@0.10.1(@xterm/xterm@6.0.0)':
+  '@cloudflare/sandbox@0.10.3(@xterm/xterm@6.0.0)':
     dependencies:
       '@cloudflare/containers': 0.3.4
       aws4fetch: 1.0.20
-      capnweb: 0.6.1
+      capnweb: 0.8.0
       hono: 4.12.18
     optionalDependencies:
       '@xterm/xterm': 6.0.0
@@ -19949,6 +19957,10 @@ snapshots:
       cross-spawn: 7.0.6
 
   '@kilocode/sdk@7.2.52':
+    dependencies:
+      cross-spawn: 7.0.6
+
+  '@kilocode/sdk@7.3.12':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -25795,7 +25807,7 @@ snapshots:
 
   caniuse-lite@1.0.30001779: {}
 
-  capnweb@0.6.1: {}
+  capnweb@0.8.0: {}
 
   case-sensitive-paths-webpack-plugin@2.4.0: {}
 

--- a/services/cloud-agent-next/Dockerfile
+++ b/services/cloud-agent-next/Dockerfile
@@ -1,9 +1,9 @@
-FROM docker.io/cloudflare/sandbox:0.10.1
+FROM docker.io/cloudflare/sandbox:0.10.3
 
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.2.52"
+ARG KILOCODE_CLI_VERSION="7.3.12"
 
 # Install latest stable git + git-lfs from the git-core PPA, GitHub CLI, and supporting tools.
 # The default Ubuntu git (2.34.1 on 22.04) is outdated; the git-core PPA ships the latest

--- a/services/cloud-agent-next/Dockerfile.dev
+++ b/services/cloud-agent-next/Dockerfile.dev
@@ -1,9 +1,9 @@
-FROM docker.io/cloudflare/sandbox:0.10.1
+FROM docker.io/cloudflare/sandbox:0.10.3
 
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.2.52"
+ARG KILOCODE_CLI_VERSION="7.3.12"
 
 # Build the kilo binary:
 #   cd ~/projects/kilocode-backend/cloud-agent

--- a/services/cloud-agent-next/Dockerfile.dind
+++ b/services/cloud-agent-next/Dockerfile.dind
@@ -1,4 +1,4 @@
-ARG SANDBOX_VERSION="0.10.1"
+ARG SANDBOX_VERSION="0.10.3"
 
 FROM docker.io/cloudflare/sandbox:${SANDBOX_VERSION}-musl AS cloudflare-sandbox
 
@@ -9,7 +9,7 @@ USER root
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.2.52"
+ARG KILOCODE_CLI_VERSION="7.3.12"
 
 # Cloudflare Containers run without root privileges, so Docker must run in
 # rootless mode. The Sandbox SDK server is copied into this image so the

--- a/services/cloud-agent-next/README.md
+++ b/services/cloud-agent-next/README.md
@@ -36,7 +36,7 @@ By default, the script looks for kilo-cli at `$HOME/projects/kilo-cli`. Override
 
 **What's in Dockerfile.dev:**
 
-- Base image: `cloudflare/sandbox:0.10.1`
+- Base image: `cloudflare/sandbox:0.10.3`
 - Pre-built `kilo` binary (from `cloud-agent-build.sh`)
 - GitHub CLI (`gh`) and GitLab CLI (`glab`)
 - Wrapper bundle built inside the container

--- a/services/cloud-agent-next/package.json
+++ b/services/cloud-agent-next/package.json
@@ -30,7 +30,7 @@
     "update-default-slash-commands": "node scripts/update-default-slash-commands.mjs"
   },
   "dependencies": {
-    "@cloudflare/sandbox": "0.10.1",
+    "@cloudflare/sandbox": "0.10.3",
     "@hono/trpc-server": "0.4.2",
     "@kilocode/cloud-agent-profile": "workspace:*",
     "@kilocode/db": "workspace:*",
@@ -47,7 +47,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@cloudflare/containers": "0.3.4",
+    "@cloudflare/containers": "0.3.5",
     "@cloudflare/vitest-pool-workers": "catalog:",
     "@types/jsonwebtoken": "catalog:",
     "@types/node": "catalog:",

--- a/services/cloud-agent-next/scripts/update-default-slash-commands.mjs
+++ b/services/cloud-agent-next/scripts/update-default-slash-commands.mjs
@@ -199,7 +199,15 @@ async function main() {
     const sourceLine = `kilo@${version}`;
     const json = JSON.stringify(commands, null, 2);
 
-    const file = `import type { SlashCommandInfo } from './slash-commands.js';
+    const file = `export type SlashCommandInfo = {
+  name: string;
+  description?: string;
+  agent?: string;
+  model?: string;
+  source?: 'command' | 'mcp' | 'skill';
+  hints: string[];
+  subtask?: boolean;
+};
 
 /**
  * Source Kilo version / ref used to generate this catalog.

--- a/services/cloud-agent-next/src/kilo/devcontainer.ts
+++ b/services/cloud-agent-next/src/kilo/devcontainer.ts
@@ -121,7 +121,7 @@ export const KILO_WRAPPER_PORT_LABEL = 'kilo.wrapperPort';
  * `wrangler.jsonc#image_vars` so the kilo running in the dev container
  * matches the one we use on the outer sandbox.
  */
-export const KILO_CLI_VERSION = '7.2.52';
+export const KILO_CLI_VERSION = '7.3.12';
 
 const DEVCONTAINER_RUNTIME_BUN_VERSION = '1.3.14';
 const DEVCONTAINER_RUNTIME_BOOTSTRAP_TIMEOUT_MS = 10 * 60 * 1000;

--- a/services/cloud-agent-next/src/shared/default-slash-commands.generated.ts
+++ b/services/cloud-agent-next/src/shared/default-slash-commands.generated.ts
@@ -17,7 +17,7 @@ export type SlashCommandInfo = {
  *
  * Regenerate with `pnpm --filter cloud-agent-next update-default-slash-commands`.
  */
-export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.2.49';
+export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.3.12';
 
 /**
  * Default slash command catalog used when no live wrapper-reported catalog is
@@ -25,26 +25,34 @@ export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.2.49';
  */
 export const DEFAULT_SLASH_COMMANDS = [
   {
-    name: 'init',
-    description: 'guided AGENTS.md setup',
-    source: 'command',
-    hints: ['$ARGUMENTS'],
+    name: "init",
+    description: "guided AGENTS.md setup",
+    source: "command",
+    hints: [
+      "$ARGUMENTS"
+    ]
   },
   {
-    name: 'local-review',
-    description: 'local review (current branch)',
-    hints: [],
+    name: "local-review",
+    description: "local review (current branch, optional base or instructions)",
+    hints: [
+      "$ARGUMENTS"
+    ]
   },
   {
-    name: 'local-review-uncommitted',
-    description: 'local review (uncommitted changes)',
-    hints: [],
+    name: "local-review-uncommitted",
+    description: "local review (uncommitted changes)",
+    hints: [
+      "$ARGUMENTS"
+    ]
   },
   {
-    name: 'review',
-    description: 'review changes [commit|branch|pr], defaults to uncommitted',
-    source: 'command',
+    name: "review",
+    description: "review changes [commit|branch|pr], defaults to uncommitted",
+    source: "command",
     subtask: true,
-    hints: ['$ARGUMENTS'],
-  },
+    hints: [
+      "$ARGUMENTS"
+    ]
+  }
 ] satisfies SlashCommandInfo[];

--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -146,7 +146,7 @@
       "image": "./Dockerfile",
       "instance_type": "standard-4",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.2.52",
+        "KILOCODE_CLI_VERSION": "7.3.12",
       },
       "max_instances": 250,
       "rollout_active_grace_period": 1800,
@@ -156,7 +156,7 @@
       "image": "./Dockerfile",
       "instance_type": "standard-2",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.2.52",
+        "KILOCODE_CLI_VERSION": "7.3.12",
       },
       "max_instances": 400,
       "rollout_active_grace_period": 1800,
@@ -166,7 +166,7 @@
       "image": "./Dockerfile.dind",
       "instance_type": "standard-3",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.2.52",
+        "KILOCODE_CLI_VERSION": "7.3.12",
       },
       "max_instances": 20,
       "rollout_active_grace_period": 1800,
@@ -319,7 +319,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.2.52",
+            "KILOCODE_CLI_VERSION": "7.3.12",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,
@@ -329,7 +329,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-2",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.2.52",
+            "KILOCODE_CLI_VERSION": "7.3.12",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -339,7 +339,7 @@
           "image": "./Dockerfile.dind",
           "instance_type": "standard-3",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.2.52",
+            "KILOCODE_CLI_VERSION": "7.3.12",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,

--- a/services/cloud-agent-next/wrapper/package.json
+++ b/services/cloud-agent-next/wrapper/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@kilocode/sdk": "7.2.52"
+    "@kilocode/sdk": "7.3.12"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",


### PR DESCRIPTION
## Summary
- Bump Cloud Agent Next Kilo CLI/SDK pins to the newest release allowed by the repository release-age policy.
- Bump Cloudflare sandbox/container SDK pins and Docker sandbox image tags while keeping package, image, and lockfile references synchronized.
- Regenerate the fallback slash-command catalog and fix its generated type ownership to avoid a circular type import.
