### PR TITLE
fix(kiloclaw): avoid sidebar status polling

### DIFF
--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -34,7 +34,7 @@ import OrganizationSwitcher from './OrganizationSwitcher';
 import { useRoleTesting } from '@/contexts/RoleTestingContext';
 import HeaderLogo from '@/components/HeaderLogo';
 import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
-import { useOrgKiloClawStatus } from '@/hooks/useOrgKiloClaw';
+import { useOrgKiloClawNavState } from '@/hooks/useOrgKiloClaw';
 import SidebarMenuList from './SidebarMenuList';
 import SidebarUserFooter from './SidebarUserFooter';
 import { ENABLE_DEPLOY_FEATURE } from '@/lib/constants';
@@ -53,7 +53,7 @@ export default function OrganizationAppSidebar({
   const { assumedRole, setAssumedRole, setOriginalRole } = useRoleTesting();
   // Fetch full organization data to access settings
   const { data: organizationData } = useOrganizationWithMembers(organizationId);
-  const kiloClawStatusQuery = useOrgKiloClawStatus(organizationId);
+  const kiloClawNavStateQuery = useOrgKiloClawNavState(organizationId);
 
   // Feature flags
   const isAutoTriageFeatureEnabled = useFeatureFlagEnabled('auto-triage-feature');
@@ -299,10 +299,10 @@ export default function OrganizationAppSidebar({
   ];
 
   const kiloClawBaseUrl = `/organizations/${organizationId}/claw`;
-  const kiloClawInstanceState = kiloClawStatusQuery.isSuccess
-    ? kiloClawStatusQuery.data.status === null
-      ? 'absent'
-      : 'present'
+  const kiloClawInstanceState = kiloClawNavStateQuery.isSuccess
+    ? kiloClawNavStateQuery.data.hasActiveInstance
+      ? 'present'
+      : 'absent'
     : 'unknown';
   const hasKiloClawInstance = kiloClawInstanceState === 'present';
   const isKiloClawPath = pathname === kiloClawBaseUrl || pathname.startsWith(kiloClawBaseUrl + '/');

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { Sidebar, SidebarContent, SidebarHeader } from '@/components/ui/sidebar';
 import { useUser } from '@/hooks/useUser';
-import { useKiloClawStatus } from '@/hooks/useKiloClaw';
+import { useKiloClawNavState } from '@/hooks/useKiloClaw';
 import { useEffect, useMemo, useState } from 'react';
 import {
   Code,
@@ -45,7 +45,7 @@ import { usePathname } from 'next/navigation';
 
 export default function PersonalAppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const { data: user, isLoading } = useUser();
-  const kiloClawStatusQuery = useKiloClawStatus();
+  const kiloClawNavStateQuery = useKiloClawNavState();
   const pathname = usePathname();
 
   // Feature flags
@@ -255,10 +255,10 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
   ];
 
   const kiloClawBaseUrl = '/claw';
-  const kiloClawInstanceState = kiloClawStatusQuery.isSuccess
-    ? kiloClawStatusQuery.data.status === null
-      ? 'absent'
-      : 'present'
+  const kiloClawInstanceState = kiloClawNavStateQuery.isSuccess
+    ? kiloClawNavStateQuery.data.hasActiveInstance
+      ? 'present'
+      : 'absent'
     : 'unknown';
   const hasKiloClawInstance = kiloClawInstanceState === 'present';
   const isKiloClawPath = pathname === kiloClawBaseUrl || pathname.startsWith(kiloClawBaseUrl + '/');

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -12,6 +12,15 @@ export function useKiloClawStatus() {
   );
 }
 
+export function useKiloClawNavState() {
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.kiloclaw.getNavState.queryOptions(undefined, {
+      staleTime: 60_000,
+    })
+  );
+}
+
 export function useKiloClawConfig() {
   const trpc = useTRPC();
   return useQuery(trpc.kiloclaw.getConfig.queryOptions());
@@ -129,10 +138,13 @@ export function useKiloClawMutations() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const invalidateStatus = async () => {
-    await queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getStatus.queryKey() });
-    await queryClient.invalidateQueries({
-      queryKey: trpc.kiloclaw.controllerVersion.queryKey(),
-    });
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getStatus.queryKey() }),
+      queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getNavState.queryKey() }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.controllerVersion.queryKey(),
+      }),
+    ]);
   };
 
   const invalidateStatusAndBilling = async () => {

--- a/apps/web/src/hooks/useOrgKiloClaw.ts
+++ b/apps/web/src/hooks/useOrgKiloClaw.ts
@@ -17,6 +17,17 @@ export function useOrgKiloClawStatus(organizationId?: string) {
   );
 }
 
+export function useOrgKiloClawNavState(organizationId?: string) {
+  const trpc = useTRPC();
+  const resolvedOrganizationId = organizationId ?? NIL_UUID;
+  return useQuery(
+    trpc.organizations.kiloclaw.getNavState.queryOptions(
+      { organizationId: resolvedOrganizationId },
+      { enabled: !!organizationId, staleTime: 60_000 }
+    )
+  );
+}
+
 export function useOrgKiloClawConfig(organizationId: string) {
   const trpc = useTRPC();
   return useQuery(trpc.organizations.kiloclaw.getConfig.queryOptions({ organizationId }));
@@ -198,12 +209,17 @@ export function useOrgKiloClawMutations(
   const queryClient = useQueryClient();
 
   const invalidateStatus = async () => {
-    await queryClient.invalidateQueries({
-      queryKey: trpc.organizations.kiloclaw.getStatus.queryKey({ organizationId }),
-    });
-    await queryClient.invalidateQueries({
-      queryKey: trpc.organizations.kiloclaw.controllerVersion.queryKey({ organizationId }),
-    });
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: trpc.organizations.kiloclaw.getStatus.queryKey({ organizationId }),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.organizations.kiloclaw.getNavState.queryKey({ organizationId }),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.organizations.kiloclaw.controllerVersion.queryKey({ organizationId }),
+      }),
+    ]);
   };
 
   const resetAllInstanceState = async () => {

--- a/apps/web/src/routers/kiloclaw-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-router.test.ts
@@ -134,7 +134,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
 
 let createCaller: (ctx: { user: Awaited<ReturnType<typeof insertTestUser>> }) => {
   getStatus: () => Promise<unknown>;
-  getNavState: () => Promise<{ hasActiveInstance: boolean; instanceId: string | null }>;
+  getNavState: () => Promise<{ hasActiveInstance: boolean }>;
   validateWeatherLocation: (input: { location: string }) => Promise<{
     location: string;
     currentWeatherText: string;
@@ -505,12 +505,12 @@ describe('kiloclawRouter getNavState', () => {
 
     const result = await caller.getNavState();
 
-    expect(result).toEqual({ hasActiveInstance: false, instanceId: null });
+    expect(result).toEqual({ hasActiveInstance: false });
     expect(kiloclawClientMock.KiloClawInternalClient).not.toHaveBeenCalled();
     expect(kiloclawClientMock.__getStatusMock).not.toHaveBeenCalled();
   });
 
-  it('returns the active personal instance id without requiring subscription access', async () => {
+  it('returns active personal instance presence without requiring subscription access', async () => {
     const user = await insertTestUser({
       google_user_email: `kiloclaw-nav-present-${Math.random()}@example.com`,
     });
@@ -524,7 +524,7 @@ describe('kiloclawRouter getNavState', () => {
 
     const result = await caller.getNavState();
 
-    expect(result).toEqual({ hasActiveInstance: true, instanceId });
+    expect(result).toEqual({ hasActiveInstance: true });
     expect(kiloclawClientMock.KiloClawInternalClient).not.toHaveBeenCalled();
     expect(kiloclawClientMock.__getStatusMock).not.toHaveBeenCalled();
   });
@@ -544,7 +544,7 @@ describe('kiloclawRouter getNavState', () => {
 
     const result = await caller.getNavState();
 
-    expect(result).toEqual({ hasActiveInstance: false, instanceId: null });
+    expect(result).toEqual({ hasActiveInstance: false });
   });
 });
 

--- a/apps/web/src/routers/kiloclaw-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-router.test.ts
@@ -134,6 +134,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
 
 let createCaller: (ctx: { user: Awaited<ReturnType<typeof insertTestUser>> }) => {
   getStatus: () => Promise<unknown>;
+  getNavState: () => Promise<{ hasActiveInstance: boolean; instanceId: string | null }>;
   validateWeatherLocation: (input: { location: string }) => Promise<{
     location: string;
     currentWeatherText: string;
@@ -486,6 +487,64 @@ describe('kiloclawRouter getStatus', () => {
       .where(eq(kiloclaw_inbound_email_aliases.instance_id, instanceId));
     expect(rows.find(row => row.alias === alias)?.retired_at).not.toBeNull();
     expect(rows.filter(row => row.retired_at === null)).toHaveLength(1);
+  });
+});
+
+describe('kiloclawRouter getNavState', () => {
+  beforeEach(async () => {
+    await cleanupDbForTest();
+    kiloclawClientMock.KiloClawInternalClient.mockClear();
+    kiloclawClientMock.__getStatusMock.mockReset();
+  });
+
+  it('returns absent without querying the KiloClaw worker', async () => {
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-nav-absent-${Math.random()}@example.com`,
+    });
+    const caller = createCaller({ user });
+
+    const result = await caller.getNavState();
+
+    expect(result).toEqual({ hasActiveInstance: false, instanceId: null });
+    expect(kiloclawClientMock.KiloClawInternalClient).not.toHaveBeenCalled();
+    expect(kiloclawClientMock.__getStatusMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the active personal instance id without requiring subscription access', async () => {
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-nav-present-${Math.random()}@example.com`,
+    });
+    const instanceId = crypto.randomUUID();
+    await db.insert(kiloclaw_instances).values({
+      id: instanceId,
+      user_id: user.id,
+      sandbox_id: `ki_${instanceId.replace(/-/g, '')}`,
+    });
+    const caller = createCaller({ user });
+
+    const result = await caller.getNavState();
+
+    expect(result).toEqual({ hasActiveInstance: true, instanceId });
+    expect(kiloclawClientMock.KiloClawInternalClient).not.toHaveBeenCalled();
+    expect(kiloclawClientMock.__getStatusMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores destroyed personal instances', async () => {
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-nav-destroyed-${Math.random()}@example.com`,
+    });
+    const instanceId = crypto.randomUUID();
+    await db.insert(kiloclaw_instances).values({
+      id: instanceId,
+      user_id: user.id,
+      sandbox_id: `ki_${instanceId.replace(/-/g, '')}`,
+      destroyed_at: '2026-05-29T00:00:00.000Z',
+    });
+    const caller = createCaller({ user });
+
+    const result = await caller.getNavState();
+
+    expect(result).toEqual({ hasActiveInstance: false, instanceId: null });
   });
 });
 

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2989,7 +2989,6 @@ export const kiloclawRouter = createTRPCRouter({
     const instance = await getActiveInstance(ctx.user.id);
     return {
       hasActiveInstance: instance !== null,
-      instanceId: instance?.id ?? null,
     };
   }),
 

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2985,6 +2985,14 @@ export const kiloclawRouter = createTRPCRouter({
     } satisfies KiloClawDashboardStatus;
   }),
 
+  getNavState: baseProcedure.query(async ({ ctx }) => {
+    const instance = await getActiveInstance(ctx.user.id);
+    return {
+      hasActiveInstance: instance !== null,
+      instanceId: instance?.id ?? null,
+    };
+  }),
+
   getDiskUsage: baseProcedure.query(async ({ ctx }) => {
     const instance = await getActiveInstance(ctx.user.id);
     if (!instance) {

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
@@ -255,22 +255,22 @@ describe('organizations.kiloclaw.getNavState', () => {
       organizationId: organization.id,
     });
 
-    expect(result).toEqual({ hasActiveInstance: false, instanceId: null });
+    expect(result).toEqual({ hasActiveInstance: false });
   });
 
-  it('returns the active organization instance id', async () => {
+  it('returns active organization instance presence', async () => {
     const user = await insertTestUser({
       google_user_email: `org-kiloclaw-nav-present-${Math.random()}@example.com`,
     });
     const organization = await createOrganization('Org KiloClaw Nav Present Test', user.id);
-    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+    await createActiveOrgInstance(user.id, organization.id);
     const caller = await createCallerForUser(user.id);
 
     const result = await caller.organizations.kiloclaw.getNavState({
       organizationId: organization.id,
     });
 
-    expect(result).toEqual({ hasActiveInstance: true, instanceId });
+    expect(result).toEqual({ hasActiveInstance: true });
   });
 
   it('does not leak a personal instance into organization nav state', async () => {
@@ -290,7 +290,7 @@ describe('organizations.kiloclaw.getNavState', () => {
       organizationId: organization.id,
     });
 
-    expect(result).toEqual({ hasActiveInstance: false, instanceId: null });
+    expect(result).toEqual({ hasActiveInstance: false });
   });
 
   it('ignores destroyed organization instances', async () => {
@@ -309,7 +309,7 @@ describe('organizations.kiloclaw.getNavState', () => {
       organizationId: organization.id,
     });
 
-    expect(result).toEqual({ hasActiveInstance: false, instanceId: null });
+    expect(result).toEqual({ hasActiveInstance: false });
   });
 });
 

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
@@ -239,6 +239,80 @@ describe('organizations.kiloclaw.listActiveInstances', () => {
   });
 });
 
+describe('organizations.kiloclaw.getNavState', () => {
+  beforeEach(async () => {
+    await cleanupDbForTest();
+  });
+
+  it('returns absent when the organization has no KiloClaw instance', async () => {
+    const user = await insertTestUser({
+      google_user_email: `org-kiloclaw-nav-absent-${Math.random()}@example.com`,
+    });
+    const organization = await createOrganization('Org KiloClaw Nav Absent Test', user.id);
+    const caller = await createCallerForUser(user.id);
+
+    const result = await caller.organizations.kiloclaw.getNavState({
+      organizationId: organization.id,
+    });
+
+    expect(result).toEqual({ hasActiveInstance: false, instanceId: null });
+  });
+
+  it('returns the active organization instance id', async () => {
+    const user = await insertTestUser({
+      google_user_email: `org-kiloclaw-nav-present-${Math.random()}@example.com`,
+    });
+    const organization = await createOrganization('Org KiloClaw Nav Present Test', user.id);
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+    const caller = await createCallerForUser(user.id);
+
+    const result = await caller.organizations.kiloclaw.getNavState({
+      organizationId: organization.id,
+    });
+
+    expect(result).toEqual({ hasActiveInstance: true, instanceId });
+  });
+
+  it('does not leak a personal instance into organization nav state', async () => {
+    const user = await insertTestUser({
+      google_user_email: `org-kiloclaw-nav-personal-${Math.random()}@example.com`,
+    });
+    const organization = await createOrganization('Org KiloClaw Nav Personal Test', user.id);
+    const personalInstanceId = crypto.randomUUID();
+    await db.insert(kiloclaw_instances).values({
+      id: personalInstanceId,
+      user_id: user.id,
+      sandbox_id: `ki_${personalInstanceId.replace(/-/g, '')}`,
+    });
+    const caller = await createCallerForUser(user.id);
+
+    const result = await caller.organizations.kiloclaw.getNavState({
+      organizationId: organization.id,
+    });
+
+    expect(result).toEqual({ hasActiveInstance: false, instanceId: null });
+  });
+
+  it('ignores destroyed organization instances', async () => {
+    const user = await insertTestUser({
+      google_user_email: `org-kiloclaw-nav-destroyed-${Math.random()}@example.com`,
+    });
+    const organization = await createOrganization('Org KiloClaw Nav Destroyed Test', user.id);
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+    await db
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: '2026-05-29T00:00:00.000Z' })
+      .where(eq(kiloclaw_instances.id, instanceId));
+    const caller = await createCallerForUser(user.id);
+
+    const result = await caller.organizations.kiloclaw.getNavState({
+      organizationId: organization.id,
+    });
+
+    expect(result).toEqual({ hasActiveInstance: false, instanceId: null });
+  });
+});
+
 describe('organization kiloclaw destroy', () => {
   beforeEach(async () => {
     await cleanupDbForTest();

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -404,6 +404,14 @@ export const organizationKiloclawRouter = createTRPCRouter({
     } satisfies KiloClawDashboardStatus;
   }),
 
+  getNavState: organizationMemberProcedure.query(async ({ ctx, input }) => {
+    const instance = await getActiveOrgInstance(ctx.user.id, input.organizationId);
+    return {
+      hasActiveInstance: instance !== null,
+      instanceId: instance?.id ?? null,
+    };
+  }),
+
   getDiskUsage: organizationMemberProcedure.query(async ({ ctx, input }) => {
     const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
     try {

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -408,7 +408,6 @@ export const organizationKiloclawRouter = createTRPCRouter({
     const instance = await getActiveOrgInstance(ctx.user.id, input.organizationId);
     return {
       hasActiveInstance: instance !== null,
-      instanceId: instance?.id ?? null,
     };
   }),
 


### PR DESCRIPTION
## Summary
KiloClaw sidebars now use a lightweight database-backed nav-state query instead of the polling status query.

### Why this change is needed
The sidebar only needs to know whether an active KiloClaw instance exists. Using the full status query for that state caused unnecessary 10-second polling and could call the KiloClaw worker from global navigation.

### How this is addressed
- Add personal and organization `getNavState` tRPC queries that read active instance state from the database.
- Switch personal and organization app sidebars to use nav state instead of KiloClaw status.
- Invalidate nav-state caches when KiloClaw mutations can change instance presence.
- Add regression coverage for absent, active, destroyed, and scope-isolated nav-state behavior.

## Human Verification
Verified polling stops and nav-state works as expected in local dev env.

## Reviewer Notes
### Human Reviewer Flags
- Adds a dedicated lightweight nav-state endpoint instead of reusing the richer status endpoint, trading a small API addition for lower sidebar polling cost.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Personal nav-state tests assert the KiloClaw worker client is not constructed or queried.
- Organization nav-state tests cover org scoping and ensure personal instances do not leak into organization navigation.
- Destroyed instances are ignored in both personal and organization nav-state paths.

</details>
