### PR TITLE
fix(security-agent): return 4xx for non-eligible startAnalysis findings

### DIFF
--- a/apps/web/src/lib/security-agent/core/error-classification.test.ts
+++ b/apps/web/src/lib/security-agent/core/error-classification.test.ts
@@ -135,6 +135,8 @@ describe('isUserActionableError', () => {
     ['CLONE_FAILED', true],
     ['AUTH_FAILED', true],
     ['REPO_NOT_FOUND', true],
+    ['FINDING_NOT_ELIGIBLE', true],
+    ['ANALYSIS_IN_PROGRESS', true],
     ['SANDBOX_FAILED', false],
     ['UNKNOWN', false],
   ])('%s → isUserActionable = %s', (code, expected) => {
@@ -147,6 +149,8 @@ describe('trpcCodeForAnalysisError', () => {
     ['CLONE_FAILED', 'BAD_REQUEST'],
     ['AUTH_FAILED', 'PRECONDITION_FAILED'],
     ['REPO_NOT_FOUND', 'NOT_FOUND'],
+    ['FINDING_NOT_ELIGIBLE', 'CONFLICT'],
+    ['ANALYSIS_IN_PROGRESS', 'CONFLICT'],
     ['SANDBOX_FAILED', 'INTERNAL_SERVER_ERROR'],
     ['UNKNOWN', 'INTERNAL_SERVER_ERROR'],
     [undefined, 'INTERNAL_SERVER_ERROR'],

--- a/apps/web/src/lib/security-agent/core/error-classification.ts
+++ b/apps/web/src/lib/security-agent/core/error-classification.ts
@@ -5,6 +5,8 @@ export type AnalysisErrorCode =
   | 'AUTH_FAILED'
   | 'REPO_NOT_FOUND'
   | 'SANDBOX_FAILED'
+  | 'FINDING_NOT_ELIGIBLE'
+  | 'ANALYSIS_IN_PROGRESS'
   | 'UNKNOWN';
 
 type ClassifiedError = {
@@ -90,6 +92,8 @@ export function isUserActionableError(code: AnalysisErrorCode): boolean {
     case 'CLONE_FAILED':
     case 'AUTH_FAILED':
     case 'REPO_NOT_FOUND':
+    case 'FINDING_NOT_ELIGIBLE':
+    case 'ANALYSIS_IN_PROGRESS':
       return true;
     case 'SANDBOX_FAILED':
     case 'UNKNOWN':
@@ -105,6 +109,9 @@ export function trpcCodeForAnalysisError(code: AnalysisErrorCode | undefined): T
       return 'PRECONDITION_FAILED';
     case 'REPO_NOT_FOUND':
       return 'NOT_FOUND';
+    case 'FINDING_NOT_ELIGIBLE':
+    case 'ANALYSIS_IN_PROGRESS':
+      return 'CONFLICT';
     case 'SANDBOX_FAILED':
     case 'UNKNOWN':
     default:

--- a/apps/web/src/lib/security-agent/services/analysis-service.test.ts
+++ b/apps/web/src/lib/security-agent/services/analysis-service.test.ts
@@ -128,6 +128,33 @@ describe('analysis-service', () => {
     expect(result).toEqual({
       started: false,
       error: "Finding status is 'fixed', analysis requires 'open' status",
+      errorCode: 'FINDING_NOT_ELIGIBLE',
+    });
+    expect(mockUpdateAnalysisStatus).not.toHaveBeenCalledWith(findingId, 'pending');
+  });
+
+  it('reports analysis in progress when lease is held for an open finding', async () => {
+    const findingId = 'finding-lease-busy';
+    const user = { id: 'user-1', google_user_email: 'test@example.com' } as User;
+
+    mockGetSecurityFindingById.mockResolvedValue({
+      id: findingId,
+      status: 'open',
+      analysis_status: 'running',
+    } as Awaited<ReturnType<typeof mockGetSecurityFindingById>>);
+    mockTryAcquireAnalysisStartLease.mockResolvedValue(false);
+
+    const result = await startSecurityAnalysis({
+      findingId,
+      user,
+      githubRepo: 'acme/repo',
+      githubToken: 'gh-token',
+    });
+
+    expect(result).toEqual({
+      started: false,
+      error: 'Analysis already in progress',
+      errorCode: 'ANALYSIS_IN_PROGRESS',
     });
     expect(mockUpdateAnalysisStatus).not.toHaveBeenCalledWith(findingId, 'pending');
   });

--- a/apps/web/src/lib/security-agent/services/analysis-service.ts
+++ b/apps/web/src/lib/security-agent/services/analysis-service.ts
@@ -258,9 +258,14 @@ export async function startSecurityAnalysis(params: {
       return {
         started: false,
         error: `Finding status is '${finding.status}', analysis requires 'open' status`,
+        errorCode: 'FINDING_NOT_ELIGIBLE',
       };
     }
-    return { started: false, error: 'Analysis already in progress' };
+    return {
+      started: false,
+      error: 'Analysis already in progress',
+      errorCode: 'ANALYSIS_IN_PROGRESS',
+    };
   }
 
   const existingTriage = retrySandboxOnly ? finding.analysis?.triage : undefined;


### PR DESCRIPTION
## Summary
Map `securityAgent.startAnalysis` refusals for non-eligible findings to 4xx tRPC errors instead of HTTP 500s.

### Why this change is needed
- Production Sentry issue KILOCODE-WEB-25S9: retrying analysis on a finding the user had marked `ignored` returned an unhandled HTTP 500 with a captured Sentry exception (`mechanism: auto.rpc.trpc.middleware`, `handled: no`).
- The backend correctly declines, but a non-`open` finding is an expected, user-actionable condition — not a pipeline defect — so it should not page as a 500.
- The auto-analysis queue consumer already treats this exact condition as benign (`SKIPPED_NO_LONGER_ELIGIBLE`); only the interactive tRPC path 500s.

### How this is addressed
- Added `FINDING_NOT_ELIGIBLE` and `ANALYSIS_IN_PROGRESS` to the `AnalysisErrorCode` union.
- Both map to `CONFLICT` in `trpcCodeForAnalysisError`, so they no longer fall through to `INTERNAL_SERVER_ERROR`.
- Both are marked user-actionable in `isUserActionableError`, so the in-service paths never capture them as Sentry exceptions.
- `startSecurityAnalysis` now tags the non-open return with `FINDING_NOT_ELIGIBLE` and the lease-held return with `ANALYSIS_IN_PROGRESS`; the human-readable error message strings are unchanged so the worker's substring/equality matches still hold.

## Human Verification
<details>
<summary>Verified in this session</summary>

- Ran the security-agent unit suites: `pnpm --filter web test src/lib/security-agent/core/error-classification.test.ts src/lib/security-agent/services/analysis-service.test.ts` — 68 passed.
- Confirmed the error strings consumed by `services/security-auto-analysis/src/consumer.ts` (exact `'Analysis already in progress'` at line 119, substring `"analysis requires 'open' status"` at line 122) are unchanged.

</details>

## Reviewer Notes
### Human Reviewer Flags
- Error-code-to-HTTP mapping decision: both new conditions map to `CONFLICT` (409). `FINDING_NOT_ELIGIBLE` could alternatively be `BAD_REQUEST` if the team prefers — flagged for confirmation.
- The `ANALYSIS_IN_PROGRESS` mapping is a sibling fix for the same root cause (also previously 500d); included intentionally.
