### PR TITLE
feat(cloud-agent-next): show context window usage

### DIFF
--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -37,6 +37,8 @@ import {
 } from './terminal-tabs';
 import { isMessageStreaming } from './types';
 import { useOrganizationModels } from './hooks/useOrganizationModels';
+import { ContextUsageIndicator } from './ContextUsageIndicator';
+import { resolveContextWindow } from './model-context-lengths';
 import { useSlashCommandSets } from '@/hooks/useSlashCommandSets';
 import { useCelebrationSound } from '@/hooks/useCelebrationSound';
 import type { CloudAgentAttachments } from '@/lib/cloud-agent/constants';
@@ -216,6 +218,7 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const dynamicMessages = useAtomValue(manager.atoms.dynamicMessages);
   const pendingMessages = useAtomValue(manager.atoms.pendingMessages);
   const totalCost = useAtomValue(manager.atoms.totalCost);
+  const contextUsage = useAtomValue(manager.atoms.contextUsage);
   const getChildMessages = useAtomValue(manager.atoms.childMessages);
   const fetchedSessionData = useAtomValue(manager.atoms.fetchedSessionData);
 
@@ -234,7 +237,9 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   }, [sessionId]);
 
   // -- Organization models --------------------------------------------------
-  const { modelOptions, isLoadingModels } = useOrganizationModels(organizationId);
+  const { modelOptions, isLoadingModels, contextLengthByModelId } =
+    useOrganizationModels(organizationId);
+  const contextWindow = resolveContextWindow(contextUsage, contextLengthByModelId);
   const { availableCommands } = useSlashCommandSets();
 
   // -- Sound effects --------------------------------------------------------
@@ -826,17 +831,30 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                                   },
                                 }}
                               />
-                              {sessionConfig?.repository && (
-                                <div className="text-muted-foreground flex items-center gap-1.5 px-[max(1rem,calc(50%_-_27rem))] pb-3 text-xs md:pb-4">
-                                  <GitBranch className="h-3 w-3 shrink-0" />
-                                  <span className="truncate">{sessionConfig.repository}</span>
-                                  {fetchedSessionData?.gitBranch && (
-                                    <>
-                                      <span>·</span>
-                                      <span className="truncate">
-                                        {fetchedSessionData.gitBranch}
-                                      </span>
-                                    </>
+                              {(sessionConfig?.repository ||
+                                (contextUsage !== undefined && contextWindow !== undefined)) && (
+                                <div className="text-muted-foreground flex items-center gap-3 px-[max(1rem,calc(50%_-_27rem))] pb-3 text-xs md:pb-4">
+                                  {sessionConfig?.repository && (
+                                    <div className="flex min-w-0 items-center gap-1.5">
+                                      <GitBranch className="h-3 w-3 shrink-0" />
+                                      <span className="truncate">{sessionConfig.repository}</span>
+                                      {fetchedSessionData?.gitBranch && (
+                                        <>
+                                          <span>·</span>
+                                          <span className="truncate">
+                                            {fetchedSessionData.gitBranch}
+                                          </span>
+                                        </>
+                                      )}
+                                    </div>
+                                  )}
+                                  {contextUsage !== undefined && contextWindow !== undefined && (
+                                    <div className="ml-auto shrink-0">
+                                      <ContextUsageIndicator
+                                        contextTokens={contextUsage.contextTokens}
+                                        contextWindow={contextWindow}
+                                      />
+                                    </div>
                                   )}
                                 </div>
                               )}

--- a/apps/web/src/components/cloud-agent-next/ContextUsageIndicator.tsx
+++ b/apps/web/src/components/cloud-agent-next/ContextUsageIndicator.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React from 'react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { calculateContextUsagePercentage } from '@/lib/cloud-agent-sdk/context-usage';
+
+type ContextUsageIndicatorProps = {
+  contextTokens?: number;
+  contextWindow?: number;
+};
+
+function formatTokenCount(tokens: number): string {
+  return tokens.toLocaleString('en-US');
+}
+
+function formatCompactTokenCount(tokens: number): string {
+  if (tokens < 1_000) return formatTokenCount(tokens);
+  return `${(tokens / 1_000).toFixed(1)}K`;
+}
+
+export function formatContextUsageTooltip(contextTokens: number, contextWindow: number): string {
+  return `${formatTokenCount(contextTokens)} / ${formatTokenCount(contextWindow)} tokens used`;
+}
+
+export function ContextUsageIndicator({
+  contextTokens,
+  contextWindow,
+}: ContextUsageIndicatorProps) {
+  if (contextTokens === undefined || contextWindow === undefined) return null;
+
+  const percentage = calculateContextUsagePercentage(contextTokens, contextWindow);
+  if (percentage === undefined) return null;
+
+  const formattedContextTokens = formatTokenCount(contextTokens);
+  const formattedContextWindow = formatTokenCount(contextWindow);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={`${percentage}% of context used. ${formattedContextTokens} of ${formattedContextWindow} tokens used.`}
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background relative inline-flex h-8 min-w-8 shrink-0 items-center justify-center rounded-sm px-1 font-mono text-xs whitespace-nowrap tabular-nums transition-colors before:absolute before:-inset-1.5 before:content-[''] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        >
+          {formatCompactTokenCount(contextTokens)} ({percentage}%)
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        {formatContextUsageTooltip(contextTokens, contextWindow)}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/cloud-agent-next/context-usage-indicator.test.ts
+++ b/apps/web/src/components/cloud-agent-next/context-usage-indicator.test.ts
@@ -1,0 +1,44 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ContextUsageIndicator, formatContextUsageTooltip } from './ContextUsageIndicator';
+
+function renderIndicator(contextTokens?: number, contextWindow?: number) {
+  return renderToStaticMarkup(
+    React.createElement(ContextUsageIndicator, { contextTokens, contextWindow })
+  );
+}
+
+describe('ContextUsageIndicator', () => {
+  it('renders a visible integer percentage in a named button trigger', () => {
+    const html = renderIndicator(32_418, 80_000);
+
+    expect(html.match(/<button/g)).toHaveLength(1);
+    expect(html).toMatch(/<button[^>]*type="button"[^>]*>32.4K \(41%\)<\/button>/);
+    expect(html).toContain('aria-label="41% of context used. 32,418 of 80,000 tokens used."');
+  });
+
+  it('matches the CLI compact token-count label', () => {
+    expect(renderIndicator(239_100, 1_000_000)).toContain('239.1K (24%)');
+  });
+
+  it('preserves rendered percentages above one hundred', () => {
+    expect(renderIndicator(101, 100)).toContain('101 (101%)');
+  });
+
+  it.each([undefined, 0, -1])('omits markup for invalid context window %s', contextWindow => {
+    expect(renderIndicator(32_418, contextWindow)).toBe('');
+  });
+
+  it('does not announce streaming updates as live status changes', () => {
+    const html = renderIndicator(32_418, 80_000);
+
+    expect(html).not.toContain('aria-live');
+    expect(html).not.toContain('role="status"');
+  });
+});
+
+describe('formatContextUsageTooltip', () => {
+  it('formats exact token counts with stable grouping', () => {
+    expect(formatContextUsageTooltip(32_418, 80_000)).toBe('32,418 / 80,000 tokens used');
+  });
+});

--- a/apps/web/src/components/cloud-agent-next/hooks/useOrganizationModels.ts
+++ b/apps/web/src/components/cloud-agent-next/hooks/useOrganizationModels.ts
@@ -9,12 +9,15 @@ import { useOrganizationDefaults } from '@/app/api/organizations/hooks';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import type { ModelOption } from '@/components/shared/ModelCombobox';
 import { appendCloudAgentNextLocalTestModel } from '@/components/cloud-agent-next/model-preferences';
+import { buildContextLengthByModelId } from '@/components/cloud-agent-next/model-context-lengths';
 
 type UseOrganizationModelsReturn = {
   /** Models formatted for the ModelCombobox component */
   modelOptions: ModelOption[];
   /** Whether models are still loading */
   isLoadingModels: boolean;
+  /** Context windows keyed by exact catalog model ID */
+  contextLengthByModelId: ReadonlyMap<string, number>;
   /** The organization's default model */
   defaultModel: string | undefined;
 };
@@ -44,9 +47,15 @@ export function useOrganizationModels(organizationId?: string): UseOrganizationM
     );
   }, [openRouterModels]);
 
+  const contextLengthByModelId = useMemo(
+    () => buildContextLengthByModelId(openRouterModels?.data ?? []),
+    [openRouterModels]
+  );
+
   return {
     modelOptions,
     isLoadingModels: isLoadingOpenRouter,
+    contextLengthByModelId,
     defaultModel: defaultsData?.defaultModel,
   };
 }

--- a/apps/web/src/components/cloud-agent-next/model-context-lengths.test.ts
+++ b/apps/web/src/components/cloud-agent-next/model-context-lengths.test.ts
@@ -1,0 +1,99 @@
+import type { ContextUsage } from '@/lib/cloud-agent-sdk/context-usage';
+import { buildContextLengthByModelId, resolveContextWindow } from './model-context-lengths';
+
+const contextUsage = {
+  contextTokens: 32_418,
+  providerID: 'kilo',
+  modelID: 'anthropic/claude-sonnet-4',
+} satisfies ContextUsage;
+
+describe('buildContextLengthByModelId', () => {
+  it('maps exact catalog model ids without aliases', () => {
+    const lengths = buildContextLengthByModelId([
+      { id: 'anthropic/claude-sonnet-4', context_length: 200_000 },
+      { id: 'kilo-auto/free', context_length: 114_688 },
+      { id: 'fake-deterministic', context_length: 200_000 },
+      { id: 'kilo/preview-allowed-by-policy', context_length: 80_000 },
+    ]);
+
+    expect(lengths).toEqual(
+      new Map([
+        ['anthropic/claude-sonnet-4', 200_000],
+        ['kilo-auto/free', 114_688],
+        ['fake-deterministic', 200_000],
+        ['kilo/preview-allowed-by-policy', 80_000],
+      ])
+    );
+    expect(lengths.has('preview-allowed-by-policy')).toBe(false);
+  });
+
+  it('omits invalid context lengths', () => {
+    expect(
+      buildContextLengthByModelId([
+        { id: 'zero', context_length: 0 },
+        { id: 'negative', context_length: -1 },
+        { id: 'missing', context_length: undefined },
+        { id: 'nan', context_length: Number.NaN },
+        { id: 'infinity', context_length: Number.POSITIVE_INFINITY },
+      ])
+    ).toEqual(new Map());
+  });
+
+  it('retains agreeing duplicate exact ids', () => {
+    expect(
+      buildContextLengthByModelId([
+        { id: 'anthropic/claude-sonnet-4', context_length: 200_000 },
+        { id: 'anthropic/claude-sonnet-4', context_length: 200_000 },
+      ])
+    ).toEqual(new Map([['anthropic/claude-sonnet-4', 200_000]]));
+  });
+
+  it('permanently omits a conflicting duplicate exact id', () => {
+    expect(
+      buildContextLengthByModelId([
+        { id: 'anthropic/claude-sonnet-4', context_length: 200_000 },
+        { id: 'anthropic/claude-sonnet-4', context_length: 80_000 },
+        { id: 'anthropic/claude-sonnet-4', context_length: 200_000 },
+      ])
+    ).toEqual(new Map());
+  });
+});
+
+describe('resolveContextWindow', () => {
+  it('resolves a known kilo response by exact emitted model id', () => {
+    expect(resolveContextWindow(contextUsage, new Map([[contextUsage.modelID, 200_000]]))).toBe(
+      200_000
+    );
+  });
+
+  it('returns undefined for missing usage or a non-kilo provider', () => {
+    expect(
+      resolveContextWindow(undefined, new Map([[contextUsage.modelID, 200_000]]))
+    ).toBeUndefined();
+    expect(
+      resolveContextWindow(
+        { ...contextUsage, providerID: 'anthropic' },
+        new Map([[contextUsage.modelID, 200_000]])
+      )
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for missing or non-positive capacities', () => {
+    expect(resolveContextWindow(contextUsage, new Map())).toBeUndefined();
+    expect(
+      resolveContextWindow(contextUsage, new Map([[contextUsage.modelID, 0]]))
+    ).toBeUndefined();
+    expect(
+      resolveContextWindow(contextUsage, new Map([[contextUsage.modelID, -1]]))
+    ).toBeUndefined();
+  });
+
+  it('returns undefined rather than guessing a stripped experiment id alias', () => {
+    expect(
+      resolveContextWindow(
+        { ...contextUsage, modelID: 'preview-allowed-by-policy' },
+        new Map([['kilo/preview-allowed-by-policy', 80_000]])
+      )
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/cloud-agent-next/model-context-lengths.ts
+++ b/apps/web/src/components/cloud-agent-next/model-context-lengths.ts
@@ -1,0 +1,47 @@
+import type { ContextUsage } from '@/lib/cloud-agent-sdk/context-usage';
+
+type ModelContextLength = {
+  id: string;
+  context_length?: number | null;
+};
+
+export function buildContextLengthByModelId(
+  models: readonly ModelContextLength[]
+): ReadonlyMap<string, number> {
+  const contextLengthByModelId = new Map<string, number>();
+  const conflictingModelIds = new Set<string>();
+
+  for (const model of models) {
+    const contextLength = model.context_length;
+    if (contextLength === undefined || contextLength === null) continue;
+    if (!Number.isFinite(contextLength) || contextLength <= 0) continue;
+    if (conflictingModelIds.has(model.id)) continue;
+
+    const existingContextLength = contextLengthByModelId.get(model.id);
+    if (existingContextLength === undefined) {
+      contextLengthByModelId.set(model.id, contextLength);
+      continue;
+    }
+
+    if (existingContextLength !== contextLength) {
+      contextLengthByModelId.delete(model.id);
+      conflictingModelIds.add(model.id);
+    }
+  }
+
+  return contextLengthByModelId;
+}
+
+export function resolveContextWindow(
+  contextUsage: ContextUsage | undefined,
+  contextLengthByModelId: ReadonlyMap<string, number>
+): number | undefined {
+  if (contextUsage?.providerID !== 'kilo') return undefined;
+
+  const contextWindow = contextLengthByModelId.get(contextUsage.modelID);
+  if (contextWindow === undefined || !Number.isFinite(contextWindow) || contextWindow <= 0) {
+    return undefined;
+  }
+
+  return contextWindow;
+}

--- a/apps/web/src/lib/cloud-agent-sdk/context-usage.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/context-usage.test.ts
@@ -1,0 +1,182 @@
+import type { AssistantMessage, UserMessage } from '@/types/opencode.gen';
+import { calculateContextUsagePercentage, findLatestContextUsage } from './context-usage';
+
+function assistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+  return {
+    id: 'msg-assistant',
+    sessionID: 'ses-root',
+    role: 'assistant',
+    time: { created: 1 },
+    parentID: 'msg-user',
+    modelID: 'anthropic/claude-sonnet-4',
+    providerID: 'kilo',
+    mode: 'code',
+    agent: 'build',
+    path: { cwd: '/', root: '/' },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 1,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    ...overrides,
+  };
+}
+
+function userMessage(overrides: Partial<UserMessage> = {}): UserMessage {
+  return {
+    id: 'msg-user',
+    sessionID: 'ses-root',
+    role: 'user',
+    time: { created: 1 },
+    agent: 'build',
+    model: {
+      providerID: 'kilo',
+      modelID: 'anthropic/claude-sonnet-4',
+    },
+    ...overrides,
+  };
+}
+
+describe('findLatestContextUsage', () => {
+  it('sums all token buckets from an eligible assistant response', () => {
+    const message = assistantMessage({
+      tokens: {
+        input: 10,
+        output: 20,
+        reasoning: 30,
+        cache: { read: 40, write: 50 },
+      },
+    });
+
+    expect(findLatestContextUsage([{ info: message }])).toEqual({
+      contextTokens: 150,
+      providerID: 'kilo',
+      modelID: 'anthropic/claude-sonnet-4',
+    });
+  });
+
+  it('uses the latest eligible assistant response without summing responses', () => {
+    const first = assistantMessage({
+      id: 'msg-assistant-1',
+      tokens: { input: 10, output: 10, reasoning: 0, cache: { read: 0, write: 0 } },
+    });
+    const second = assistantMessage({
+      id: 'msg-assistant-2',
+      modelID: 'openai/gpt-5',
+      tokens: { input: 20, output: 20, reasoning: 5, cache: { read: 3, write: 2 } },
+    });
+
+    expect(findLatestContextUsage([{ info: first }, { info: second }])).toEqual({
+      contextTokens: 50,
+      providerID: 'kilo',
+      modelID: 'openai/gpt-5',
+    });
+  });
+
+  it('ignores trailing user messages', () => {
+    const assistant = assistantMessage();
+
+    expect(findLatestContextUsage([{ info: assistant }, { info: userMessage() }])).toEqual({
+      contextTokens: 1,
+      providerID: 'kilo',
+      modelID: 'anthropic/claude-sonnet-4',
+    });
+  });
+
+  it('keeps the previous eligible response while the newest assistant has zero output', () => {
+    const previous = assistantMessage({ id: 'msg-assistant-1' });
+    const streaming = assistantMessage({
+      id: 'msg-assistant-2',
+      tokens: { input: 100, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    });
+
+    expect(findLatestContextUsage([{ info: previous }, { info: streaming }])).toEqual({
+      contextTokens: 1,
+      providerID: 'kilo',
+      modelID: 'anthropic/claude-sonnet-4',
+    });
+  });
+
+  it('switches to the newest assistant after its first output token', () => {
+    const previous = assistantMessage({ id: 'msg-assistant-1' });
+    const streaming = assistantMessage({
+      id: 'msg-assistant-2',
+      modelID: 'openai/gpt-5',
+      tokens: { input: 100, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+    });
+
+    expect(findLatestContextUsage([{ info: previous }, { info: streaming }])).toEqual({
+      contextTokens: 101,
+      providerID: 'kilo',
+      modelID: 'openai/gpt-5',
+    });
+  });
+
+  it('returns undefined when no assistant has emitted output', () => {
+    expect(findLatestContextUsage([{ info: userMessage() }])).toBeUndefined();
+    expect(
+      findLatestContextUsage([
+        {
+          info: assistantMessage({
+            tokens: { input: 100, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          }),
+        },
+      ])
+    ).toBeUndefined();
+  });
+
+  it('fails closed when the latest eligible assistant payload is malformed', () => {
+    const valid = assistantMessage();
+    const malformed = {
+      role: 'assistant',
+      providerID: 'kilo',
+      modelID: 'openai/gpt-5',
+      tokens: { input: 100, output: 1, reasoning: 0 },
+    };
+
+    expect(findLatestContextUsage([{ info: valid }, { info: malformed }])).toBeUndefined();
+  });
+
+  it('skips assistant payloads whose finite buckets overflow when summed', () => {
+    const overflowing = assistantMessage({
+      tokens: {
+        input: Number.MAX_VALUE,
+        output: Number.MAX_VALUE,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    });
+
+    expect(findLatestContextUsage([{ info: overflowing }])).toBeUndefined();
+  });
+});
+
+describe('calculateContextUsagePercentage', () => {
+  it('rounds a valid context-window percentage to an integer', () => {
+    expect(calculateContextUsagePercentage(32_418, 80_000)).toBe(41);
+  });
+
+  it.each([undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    'returns undefined for invalid context window %s',
+    contextWindow => {
+      expect(calculateContextUsagePercentage(32_418, contextWindow)).toBeUndefined();
+    }
+  );
+
+  it.each([-1, Number.NaN, Number.POSITIVE_INFINITY])(
+    'returns undefined for invalid context token count %s',
+    contextTokens => {
+      expect(calculateContextUsagePercentage(contextTokens, 80_000)).toBeUndefined();
+    }
+  );
+
+  it('returns undefined when percentage arithmetic overflows', () => {
+    expect(calculateContextUsagePercentage(Number.MAX_VALUE, Number.MIN_VALUE)).toBeUndefined();
+  });
+
+  it('preserves percentages above one hundred', () => {
+    expect(calculateContextUsagePercentage(101, 100)).toBe(101);
+  });
+});

--- a/apps/web/src/lib/cloud-agent-sdk/context-usage.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/context-usage.ts
@@ -51,7 +51,10 @@ export function findLatestContextUsage(
   messages: readonly { info: unknown }[]
 ): ContextUsage | undefined {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const result = getAssistantContextUsage(messages[index].info);
+    const message = messages[index];
+    if (!message) continue;
+
+    const result = getAssistantContextUsage(message.info);
     if (result.status === 'malformed') return undefined;
     if (result.status === 'usage') return result.contextUsage;
   }

--- a/apps/web/src/lib/cloud-agent-sdk/context-usage.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/context-usage.ts
@@ -1,0 +1,73 @@
+export type ContextUsage = {
+  contextTokens: number;
+  providerID: string;
+  modelID: string;
+};
+
+type AssistantContextUsageResult =
+  | { status: 'ineligible' }
+  | { status: 'malformed' }
+  | { status: 'usage'; contextUsage: ContextUsage };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isFiniteNonNegativeNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function getAssistantContextUsage(info: unknown): AssistantContextUsageResult {
+  if (!isRecord(info) || info.role !== 'assistant') return { status: 'ineligible' };
+  if (!isRecord(info.tokens)) return { status: 'malformed' };
+
+  const { input, output, reasoning, cache } = info.tokens;
+  if (!isFiniteNonNegativeNumber(output)) return { status: 'malformed' };
+  if (output === 0) return { status: 'ineligible' };
+  if (typeof info.providerID !== 'string' || typeof info.modelID !== 'string') {
+    return { status: 'malformed' };
+  }
+  if (!isFiniteNonNegativeNumber(input)) return { status: 'malformed' };
+  if (!isFiniteNonNegativeNumber(reasoning)) return { status: 'malformed' };
+  if (!isRecord(cache)) return { status: 'malformed' };
+  if (!isFiniteNonNegativeNumber(cache.read) || !isFiniteNonNegativeNumber(cache.write)) {
+    return { status: 'malformed' };
+  }
+
+  const contextTokens = input + output + reasoning + cache.read + cache.write;
+  if (!Number.isFinite(contextTokens)) return { status: 'malformed' };
+
+  return {
+    status: 'usage',
+    contextUsage: {
+      contextTokens,
+      providerID: info.providerID,
+      modelID: info.modelID,
+    },
+  };
+}
+
+export function findLatestContextUsage(
+  messages: readonly { info: unknown }[]
+): ContextUsage | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const result = getAssistantContextUsage(messages[index].info);
+    if (result.status === 'malformed') return undefined;
+    if (result.status === 'usage') return result.contextUsage;
+  }
+
+  return undefined;
+}
+
+export function calculateContextUsagePercentage(
+  contextTokens: number,
+  contextWindow: number | undefined
+): number | undefined {
+  if (!isFiniteNonNegativeNumber(contextTokens)) return undefined;
+  if (contextWindow === undefined || !Number.isFinite(contextWindow) || contextWindow <= 0) {
+    return undefined;
+  }
+
+  const percentage = Math.round((contextTokens / contextWindow) * 100);
+  return Number.isFinite(percentage) ? percentage : undefined;
+}

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -211,6 +211,36 @@ function createStoredMessage(
   };
 }
 
+function createStoredAssistantMessage(
+  messageId: string,
+  sessionID: string,
+  overrides: Partial<AssistantMessage> = {}
+): StoredMessage {
+  return {
+    info: {
+      id: messageId,
+      sessionID,
+      role: 'assistant',
+      time: { created: 1 },
+      parentID: 'msg-parent',
+      modelID: 'anthropic/claude-sonnet-4',
+      providerID: 'kilo',
+      mode: 'code',
+      agent: 'test-agent',
+      path: { cwd: '/', root: '/' },
+      cost: 1,
+      tokens: {
+        input: 10,
+        output: 1,
+        reasoning: 2,
+        cache: { read: 3, write: 4 },
+      },
+      ...overrides,
+    },
+    parts: [],
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -996,6 +1026,116 @@ describe('createSessionManager', () => {
       );
 
       expect(childMessages('child-1')).toEqual([childOneFirst, childOneSecond]);
+    });
+  });
+
+  describe('context usage', () => {
+    it('exposes token footprint and runtime model identity from the root assistant response', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root'));
+      if (!latestStorage) throw new Error('expected session storage');
+      latestStorage.upsertMessage(createStoredAssistantMessage('msg-001', 'ses-root').info);
+
+      expect(atomValue(config.store, mgr.atoms.contextUsage)).toEqual({
+        contextTokens: 20,
+        providerID: 'kilo',
+        modelID: 'anthropic/claude-sonnet-4',
+      });
+    });
+
+    it('replaces the metric with the latest eligible root assistant response', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root'));
+      if (!latestStorage) throw new Error('expected session storage');
+      latestStorage.upsertMessage(createStoredAssistantMessage('msg-001', 'ses-root').info);
+      latestStorage.upsertMessage(
+        createStoredAssistantMessage('msg-002', 'ses-root', {
+          modelID: 'openai/gpt-5',
+          tokens: { input: 20, output: 5, reasoning: 1, cache: { read: 2, write: 3 } },
+        }).info
+      );
+
+      expect(atomValue(config.store, mgr.atoms.contextUsage)).toEqual({
+        contextTokens: 31,
+        providerID: 'kilo',
+        modelID: 'openai/gpt-5',
+      });
+    });
+
+    it('keeps the previous metric while the latest root assistant response has zero output', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root'));
+      if (!latestStorage) throw new Error('expected session storage');
+      latestStorage.upsertMessage(createStoredAssistantMessage('msg-001', 'ses-root').info);
+      latestStorage.upsertMessage(
+        createStoredAssistantMessage('msg-002', 'ses-root', {
+          modelID: 'openai/gpt-5',
+          tokens: { input: 100, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        }).info
+      );
+
+      expect(atomValue(config.store, mgr.atoms.contextUsage)).toEqual({
+        contextTokens: 20,
+        providerID: 'kilo',
+        modelID: 'anthropic/claude-sonnet-4',
+      });
+    });
+
+    it('ignores later child-session assistant responses', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root'));
+      if (!latestStorage) throw new Error('expected session storage');
+      latestStorage.upsertMessage(createStoredAssistantMessage('msg-001', 'ses-root').info);
+      latestStorage.upsertMessage(
+        createStoredAssistantMessage('msg-002', 'ses-child', {
+          modelID: 'openai/gpt-5',
+          tokens: { input: 200, output: 20, reasoning: 0, cache: { read: 0, write: 0 } },
+        }).info
+      );
+
+      expect(atomValue(config.store, mgr.atoms.contextUsage)).toEqual({
+        contextTokens: 20,
+        providerID: 'kilo',
+        modelID: 'anthropic/claude-sonnet-4',
+      });
+    });
+
+    it('clears and replaces the metric when switching sessions', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root'));
+      if (!latestStorage) throw new Error('expected session storage');
+      latestStorage.upsertMessage(createStoredAssistantMessage('msg-001', 'ses-root').info);
+      expect(atomValue(config.store, mgr.atoms.contextUsage)).toEqual({
+        contextTokens: 20,
+        providerID: 'kilo',
+        modelID: 'anthropic/claude-sonnet-4',
+      });
+
+      await mgr.switchSession(kiloId('ses-next'));
+      if (!latestStorage) throw new Error('expected session storage');
+      expect(atomValue(config.store, mgr.atoms.contextUsage)).toBeUndefined();
+
+      latestStorage.upsertMessage(
+        createStoredAssistantMessage('msg-002', 'ses-next', {
+          modelID: 'openai/gpt-5',
+          tokens: { input: 40, output: 10, reasoning: 0, cache: { read: 0, write: 0 } },
+        }).info
+      );
+      expect(atomValue(config.store, mgr.atoms.contextUsage)).toEqual({
+        contextTokens: 50,
+        providerID: 'kilo',
+        modelID: 'openai/gpt-5',
+      });
     });
   });
 

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
@@ -33,6 +33,8 @@ import type { QuestionInfo } from '@/types/opencode.gen';
 import { splitByContiguousPrefix } from './array-utils';
 import type { UserWebConnection } from './user-web-connection';
 import { generateMessageId } from './message-id';
+import { findLatestContextUsage } from './context-usage';
+import type { ContextUsage } from './context-usage';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -187,6 +189,7 @@ type SessionManagerAtoms = {
   staticMessages: Atom<StoredMessage[]>;
   dynamicMessages: Atom<StoredMessage[]>;
   totalCost: Atom<number>;
+  contextUsage: Atom<ContextUsage | undefined>;
   childMessages: Atom<(childSessionId: string) => StoredMessage[]>;
   childSessionHydrationState: Atom<(childSessionId: string) => ChildSessionHydrationState>;
 };
@@ -368,6 +371,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     for (const m of get(messagesListAtom)) if (m.info.role === 'assistant') t += m.info.cost;
     return t;
   });
+  const contextUsageAtom = atom(get => findLatestContextUsage(get(messagesListAtom)));
   const childMessagesAtom = atom(get => {
     const storage = get(sessionStorageAtom);
     if (!storage) return (): StoredMessage[] => [];
@@ -949,6 +953,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       staticMessages: staticMessagesAtom,
       dynamicMessages: dynamicMessagesAtom,
       totalCost: totalCostAtom,
+      contextUsage: contextUsageAtom,
       childMessages: childMessagesAtom,
       childSessionHydrationState: childSessionHydrationStateAtom,
     },


### PR DESCRIPTION
## Summary

- Show Cloud Agent Next context-window usage below the composer with a CLI-style compact label such as `239.1K (24%)`, while preserving exact token counts in the tooltip and accessible label.
- Derive usage from the latest eligible root-session assistant response using input, output, reasoning, cache-read, and cache-write tokens rather than cumulative session spend.
- Add a Cloud Agent Next-specific exact-model-ID context-length map from the organization catalog and fail closed when provider identity, runtime payloads, or catalog metadata cannot be trusted.
- Architecturally, expose context usage as a derived session-manager atom and keep the context-length projection separate from shared model-picker options.

## Verification

- [x] Verified the changes running locally.

## Visual Changes

<img width="402" height="215" alt="Screenshot 2026-06-01 at 13 06 36" src="https://github.com/user-attachments/assets/5f3039cf-8169-499c-8f51-37f3b71f40d9" />


## Reviewer Notes

- Usage intentionally follows CLI informational semantics and is not a compaction-threshold meter.
- Runtime model IDs are joined to exact catalog IDs only; the UI hides the metric instead of guessing aliases or capacities.