### PR TITLE
fix(gateway): rate limit Gastown free models by user

### DIFF
--- a/apps/web/src/lib/feature-detection.test.ts
+++ b/apps/web/src/lib/feature-detection.test.ts
@@ -25,6 +25,7 @@ describe('isUserRateLimitedFeature', () => {
     expect(isUserRateLimitedFeature('cloud-agent')).toBe(true);
     expect(isUserRateLimitedFeature('code-review')).toBe(true);
     expect(isUserRateLimitedFeature('app-builder')).toBe(true);
+    expect(isUserRateLimitedFeature('gastown')).toBe(true);
   });
 
   test('returns false for client-side products', () => {

--- a/apps/web/src/lib/feature-detection.ts
+++ b/apps/web/src/lib/feature-detection.ts
@@ -57,6 +57,7 @@ const USER_RATE_LIMITED_FEATURES: ReadonlySet<FeatureValue> = new Set([
   'cloud-agent',
   'code-review',
   'app-builder',
+  'gastown',
 ]);
 
 export function isUserRateLimitedFeature(feature: FeatureValue | null): boolean {


### PR DESCRIPTION
## Summary

Gastown free-model usage should not be throttled by a shared infrastructure IP, because one active user can otherwise exhaust the bucket for unrelated users. This change adds Gastown to the existing set of server-side features that use per-user free-model rate limiting, following the same pattern as cloud-agent, code-review, and app-builder.

## Verification

No manual UI verification; this is a non-visual gateway attribution change.

## Visual Changes

N/A

## Reviewer Notes