### PR TITLE
fix(gastown): surface startup failures

### DIFF
--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -37,6 +37,7 @@ import type {
   StreamTicketResponse,
   MergeResult,
 } from './types';
+import { sanitizeStartupError } from './startup-error';
 
 const MAX_TICKETS = 1000;
 const streamTickets = new Map<string, { agentId: string; expiresAt: number }>();
@@ -359,9 +360,17 @@ app.post('/agents/start', async c => {
     } = agent;
     return c.json(safeAgent, 201);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error(`[control-server] /agents/start: FAILED for ${parsed.data.name}: ${message}`);
-    return c.json({ error: message }, 500);
+    const failure = sanitizeStartupError(err);
+    const details = [
+      `error=${failure.error}`,
+      failure.phase ? `phase=${failure.phase}` : null,
+      failure.status ? `status=${failure.status}` : null,
+      failure.error_type ? `error_type=${failure.error_type}` : null,
+    ].filter(value => value !== null);
+    console.error(
+      `[control-server] /agents/start: FAILED for ${parsed.data.name}: ${details.join(' ')}`
+    );
+    return c.json(failure, 500);
   }
 });
 

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -37,7 +37,7 @@ import type {
   StreamTicketResponse,
   MergeResult,
 } from './types';
-import { sanitizeStartupError } from './startup-error';
+import { classifyStartupError } from './startup-error';
 
 const MAX_TICKETS = 1000;
 const streamTickets = new Map<string, { agentId: string; expiresAt: number }>();
@@ -360,7 +360,7 @@ app.post('/agents/start', async c => {
     } = agent;
     return c.json(safeAgent, 201);
   } catch (err) {
-    const failure = sanitizeStartupError(err);
+    const failure = classifyStartupError(err);
     const details = [
       `error=${failure.error}`,
       failure.phase ? `phase=${failure.phase}` : null,

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -23,7 +23,7 @@ import {
 } from './control-server';
 import { log } from './logger';
 import { refreshTokenIfNearExpiry } from './token-refresh';
-import { AgentStartupError, sanitizeStartupError } from './startup-error';
+import { AgentStartupError, classifyStartupError } from './startup-error';
 
 const MANAGER_LOG = '[process-manager]';
 
@@ -1330,7 +1330,7 @@ async function startAgentImpl(
           },
         });
       } catch (err) {
-        throw new AgentStartupError(sanitizeStartupError(err, 'initial_prompt'));
+        throw new AgentStartupError(classifyStartupError(err, 'initial_prompt'));
       }
 
       // If the event stream errored while we were awaiting the prompt,

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -23,6 +23,7 @@ import {
 } from './control-server';
 import { log } from './logger';
 import { refreshTokenIfNearExpiry } from './token-refresh';
+import { AgentStartupError, sanitizeStartupError } from './startup-error';
 
 const MANAGER_LOG = '[process-manager]';
 
@@ -1319,14 +1320,18 @@ async function startAgentImpl(
     // history is already in kilo.db and re-sending the startup prompt
     // would create a duplicate turn.
     if (!resumed) {
-      await client.session.prompt({
-        path: { id: sessionId },
-        body: {
-          parts: [{ type: 'text', text: request.prompt }],
-          ...(modelParam ? { model: modelParam } : {}),
-          ...(request.systemPrompt ? { system: request.systemPrompt } : {}),
-        },
-      });
+      try {
+        await client.session.prompt({
+          path: { id: sessionId },
+          body: {
+            parts: [{ type: 'text', text: request.prompt }],
+            ...(modelParam ? { model: modelParam } : {}),
+            ...(request.systemPrompt ? { system: request.systemPrompt } : {}),
+          },
+        });
+      } catch (err) {
+        throw new AgentStartupError(sanitizeStartupError(err, 'initial_prompt'));
+      }
 
       // If the event stream errored while we were awaiting the prompt,
       // the stream-error handler already set the agent to 'failed',

--- a/services/gastown/container/src/startup-error.test.ts
+++ b/services/gastown/container/src/startup-error.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { AgentStartupError, sanitizeStartupError } from './startup-error';
+
+describe('sanitizeStartupError', () => {
+  it('classifies initial prompt rate-limit gateway failures', () => {
+    const payload = sanitizeStartupError(
+      {
+        status: 429,
+        body: {
+          error: 'Free model rate limit exceeded',
+          error_type: 'rate_limit_exceeded',
+        },
+      },
+      'initial_prompt'
+    );
+
+    expect(payload).toEqual({
+      error: 'Free model rate limit exceeded',
+      phase: 'initial_prompt',
+      status: 429,
+      error_type: 'rate_limit_exceeded',
+      action: 'Wait and retry, or switch the town/rig to a model with available quota.',
+    });
+  });
+
+  it('extracts gateway details embedded in SDK error messages', () => {
+    const payload = sanitizeStartupError(
+      new Error(
+        'Request failed: {"error":{"message":"quota exhausted"},"error_type":"rate_limit_exceeded"}'
+      ),
+      'initial_prompt'
+    );
+
+    expect(payload).toEqual({
+      error: 'quota exhausted',
+      phase: 'initial_prompt',
+      error_type: 'rate_limit_exceeded',
+    });
+  });
+
+  it('preserves already-sanitized startup payloads', () => {
+    const error = new AgentStartupError({
+      error: 'safe failure',
+      phase: 'initial_prompt',
+      status: 500,
+      error_type: 'server_error',
+    });
+
+    expect(sanitizeStartupError(error)).toEqual({
+      error: 'safe failure',
+      phase: 'initial_prompt',
+      status: 500,
+      error_type: 'server_error',
+    });
+  });
+});

--- a/services/gastown/container/src/startup-error.test.ts
+++ b/services/gastown/container/src/startup-error.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { AgentStartupError, sanitizeStartupError } from './startup-error';
+import { AgentStartupError, classifyStartupError } from './startup-error';
 
-describe('sanitizeStartupError', () => {
+describe('classifyStartupError', () => {
   it('classifies initial prompt rate-limit gateway failures', () => {
-    const payload = sanitizeStartupError(
+    const payload = classifyStartupError(
       {
         status: 429,
         body: {
@@ -24,7 +24,7 @@ describe('sanitizeStartupError', () => {
   });
 
   it('extracts gateway details embedded in SDK error messages', () => {
-    const payload = sanitizeStartupError(
+    const payload = classifyStartupError(
       new Error(
         'Request failed: {"error":{"message":"quota exhausted"},"error_type":"rate_limit_exceeded"}'
       ),
@@ -38,16 +38,16 @@ describe('sanitizeStartupError', () => {
     });
   });
 
-  it('preserves already-sanitized startup payloads', () => {
+  it('preserves already-classified startup payloads', () => {
     const error = new AgentStartupError({
-      error: 'safe failure',
+      error: 'classified failure',
       phase: 'initial_prompt',
       status: 500,
       error_type: 'server_error',
     });
 
-    expect(sanitizeStartupError(error)).toEqual({
-      error: 'safe failure',
+    expect(classifyStartupError(error)).toEqual({
+      error: 'classified failure',
       phase: 'initial_prompt',
       status: 500,
       error_type: 'server_error',

--- a/services/gastown/container/src/startup-error.ts
+++ b/services/gastown/container/src/startup-error.ts
@@ -147,7 +147,7 @@ function messageFromError(err: unknown): string {
   return 'Agent startup failed';
 }
 
-export function sanitizeStartupError(
+export function classifyStartupError(
   err: unknown,
   phase?: AgentStartupPhase
 ): AgentStartupErrorPayload {

--- a/services/gastown/container/src/startup-error.ts
+++ b/services/gastown/container/src/startup-error.ts
@@ -1,0 +1,179 @@
+import { z } from 'zod';
+
+export const AgentStartupPhase = z.enum(['initial_prompt']);
+export type AgentStartupPhase = z.infer<typeof AgentStartupPhase>;
+
+export type AgentStartupErrorPayload = {
+  error: string;
+  phase?: AgentStartupPhase;
+  status?: number;
+  error_type?: string;
+  action?: string;
+};
+
+const StringRecord = z.record(z.string(), z.unknown());
+const GatewayErrorBody = z
+  .object({
+    error: z.unknown().optional(),
+    error_type: z.string().optional(),
+    message: z.string().optional(),
+  })
+  .passthrough();
+const ErrorObject = z
+  .object({
+    message: z.string().optional(),
+    status: z.number().optional(),
+    statusCode: z.number().optional(),
+    code: z.union([z.string(), z.number()]).optional(),
+    body: z.unknown().optional(),
+    data: z.unknown().optional(),
+    response: z
+      .object({
+        status: z.number().optional(),
+        statusCode: z.number().optional(),
+        body: z.unknown().optional(),
+        data: z.unknown().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export class AgentStartupError extends Error {
+  readonly payload: AgentStartupErrorPayload;
+
+  constructor(payload: AgentStartupErrorPayload) {
+    super(payload.error);
+    this.name = 'AgentStartupError';
+    this.payload = payload;
+  }
+}
+
+type JsonParseResult = { success: true; data: unknown } | { success: false };
+
+function parseJsonFromString(value: string): JsonParseResult {
+  const trimmed = value.trim();
+  if (!trimmed) return { success: false };
+
+  try {
+    return { success: true, data: JSON.parse(trimmed) };
+  } catch {
+    const start = trimmed.indexOf('{');
+    const end = trimmed.lastIndexOf('}');
+    if (start === -1 || end <= start) return { success: false };
+    try {
+      return { success: true, data: JSON.parse(trimmed.slice(start, end + 1)) };
+    } catch {
+      return { success: false };
+    }
+  }
+}
+
+function readGatewayBody(value: unknown): z.infer<typeof GatewayErrorBody> | null {
+  if (typeof value === 'string') {
+    const parsed = parseJsonFromString(value);
+    if (!parsed.success) return null;
+    return readGatewayBody(parsed.data);
+  }
+
+  const parsed = GatewayErrorBody.safeParse(value);
+  if (!parsed.success) return null;
+  if (
+    parsed.data.error === undefined &&
+    parsed.data.error_type === undefined &&
+    parsed.data.message === undefined
+  ) {
+    return null;
+  }
+  return parsed.data;
+}
+
+function readBodyMessage(errorValue: unknown): string | undefined {
+  if (typeof errorValue === 'string') return errorValue;
+
+  const record = StringRecord.safeParse(errorValue);
+  if (!record.success) return undefined;
+
+  const message = record.data.message;
+  if (typeof message === 'string') return message;
+
+  const code = record.data.code;
+  if (typeof code === 'string') return code;
+
+  return undefined;
+}
+
+function gatewayBodyFromError(err: unknown): z.infer<typeof GatewayErrorBody> | null {
+  if (err instanceof Error) {
+    const fromMessage = readGatewayBody(err.message);
+    if (fromMessage) return fromMessage;
+  }
+
+  const direct = readGatewayBody(err);
+  if (direct) return direct;
+
+  const parsed = ErrorObject.safeParse(err);
+  if (!parsed.success) return null;
+
+  return (
+    readGatewayBody(parsed.data.body) ??
+    readGatewayBody(parsed.data.data) ??
+    readGatewayBody(parsed.data.response?.body) ??
+    readGatewayBody(parsed.data.response?.data) ??
+    (parsed.data.message ? readGatewayBody(parsed.data.message) : null)
+  );
+}
+
+function statusFromError(err: unknown): number | undefined {
+  const parsed = ErrorObject.safeParse(err);
+  if (!parsed.success) return undefined;
+
+  const status =
+    parsed.data.status ??
+    parsed.data.statusCode ??
+    parsed.data.response?.status ??
+    parsed.data.response?.statusCode;
+  if (status) return status;
+
+  const code = parsed.data.code;
+  if (typeof code === 'number') return code;
+  if (typeof code === 'string' && /^\d{3}$/.test(code)) return Number(code);
+  return undefined;
+}
+
+function messageFromError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return 'Agent startup failed';
+}
+
+export function sanitizeStartupError(
+  err: unknown,
+  phase?: AgentStartupPhase
+): AgentStartupErrorPayload {
+  if (err instanceof AgentStartupError) return err.payload;
+
+  const body = gatewayBodyFromError(err);
+  const status = statusFromError(err);
+  const errorType = body?.error_type;
+  const gatewayMessage = readBodyMessage(body?.error) ?? body?.message;
+
+  if (phase === 'initial_prompt' && status === 429 && errorType === 'rate_limit_exceeded') {
+    return {
+      error:
+        gatewayMessage ??
+        'Kilo gateway rejected the initial prompt because the selected model is rate limited.',
+      phase,
+      status,
+      error_type: errorType,
+      action: 'Wait and retry, or switch the town/rig to a model with available quota.',
+    };
+  }
+
+  return {
+    error: gatewayMessage ?? messageFromError(err),
+    ...(phase ? { phase } : {}),
+    ...(status ? { status } : {}),
+    ...(errorType ? { error_type: errorType } : {}),
+  };
+}

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -3,6 +3,7 @@
  * All container communication goes through the TownContainerDO stub.
  */
 
+import { z } from 'zod';
 import { getTownContainerStub } from '../TownContainer.do';
 import { signAgentJWT, signContainerJWT } from '../../util/jwt.util';
 import { buildPolecatSystemPrompt } from '../../prompts/polecat-system.prompt';
@@ -13,6 +14,14 @@ import { writeEvent } from '../../util/analytics.util';
 import { resolveGitHubTokenString } from './town-scm';
 
 const TOWN_LOG = '[Town.do]';
+
+const ContainerStartError = z.object({
+  error: z.string(),
+  phase: z.string().optional(),
+  status: z.number().optional(),
+  error_type: z.string().optional(),
+  action: z.string().optional(),
+});
 
 // Allowlist of git push flags that are safe to pass from rig config.
 // Flags that bypass hooks (--no-verify), rewrite history (--force,
@@ -58,6 +67,26 @@ function filterGitPushFlags(raw: string): string | undefined {
 let lastStartError: string | null = null;
 export function getLastStartError(): string | null {
   return lastStartError;
+}
+
+function formatContainerStartError(status: number, bodyText: string): string {
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(bodyText);
+  } catch {
+    return `(${status}) ${bodyText.slice(0, 300)}`;
+  }
+  const parsed = ContainerStartError.safeParse(parsedJson);
+  if (!parsed.success) return `(${status}) ${bodyText.slice(0, 300)}`;
+
+  const failure = parsed.data;
+  const details = [
+    failure.phase ? `${failure.phase} failed` : 'container start failed',
+    failure.error_type ?? null,
+    failure.status ? `upstream ${failure.status}` : null,
+  ].filter(value => value !== null);
+  const action = failure.action ? ` Action: ${failure.action}` : '';
+  return `(${status}) ${details.join(': ')}: ${failure.error}${action}`.slice(0, 500);
 }
 
 /**
@@ -553,7 +582,7 @@ export async function startAgentInContainer(
         });
         return { started: true, containerFetchMs: durationMs };
       }
-      const errorMsg = `(${response.status}) ${text.slice(0, 300)}`;
+      const errorMsg = formatContainerStartError(response.status, text);
       console.error(
         `${TOWN_LOG} startAgentInContainer: error response for ` +
           `agent=${params.agentId} role=${params.role}: ${errorMsg}`


### PR DESCRIPTION
## Summary

Gastown startup failures during the initial SDK prompt can currently collapse into a generic container start 500, leaving operators without the cause or recovery action. This adds structured startup error classification around the initial prompt and propagates phase/status/error_type/action details through the container start path so free-model rate limits surface clearly.

## Verification

N/A - backend-only diagnostic handling; no manual UI flow exercised.

## Visual Changes

N/A

## Reviewer Notes

Focus areas: the error parser intentionally accepts several SDK/gateway error shapes. The Town DO formats the container response for user-facing dispatch failure text while preserving the existing 500 handling path.