### PR TITLE
fix(cloud-agent): make stale workspace cleanup runtime-aware

### DIFF
--- a/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.test.ts
@@ -146,6 +146,78 @@ describe('CloudflareAgentSandbox', () => {
     ensureBootstrapWrapper.mockRestore();
   });
 
+  it('reclaims stale bootstrap workspaces without inspecting Docker', async () => {
+    const bootstrapSession = {};
+    const createSession = vi.fn().mockResolvedValue(bootstrapSession);
+    const ensureBootstrapWrapper = vi
+      .spyOn(WrapperClient, 'ensureBootstrapWrapper')
+      .mockResolvedValueOnce({ client: {} as WrapperClient });
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '536870912  10485760000\n', stderr: '' })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: 'agent_stale-aaaa\nagent_cloudflare\n',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '0\n', stderr: '' })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '3145728000  10485760000\n', stderr: '' });
+    const sandbox = new CloudflareAgentSandbox({} as Env, metadata(), {
+      resolveSandbox: () =>
+        ({
+          exec,
+          listProcesses: vi.fn().mockResolvedValue([]),
+          createSession,
+        }) as unknown as SandboxInstance,
+    });
+
+    await expect(sandbox.ensureWrapper(ensureRequest())).resolves.toMatchObject({
+      status: 'wrapper-running',
+    });
+    expect(exec.mock.calls.every(call => !call[0].includes('docker'))).toBe(true);
+    expect(createSession).toHaveBeenCalled();
+    ensureBootstrapWrapper.mockRestore();
+  });
+
+  it('keeps unresolved DIND bootstrap cleanup fail-closed', async () => {
+    const unresolvedDindMetadata = {
+      ...metadata(),
+      workspace: { sandboxId: 'dind-unresolved' },
+    } satisfies SessionMetadata;
+    const request = ensureRequest();
+    request.plan.workspace = { sandboxId: 'dind-unresolved', metadata: unresolvedDindMetadata };
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '536870912  10485760000\n', stderr: '' })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: 'agent_stale-aaaa\n', stderr: '' })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: '/run/user/1000/docker.sock',
+        stderr: '',
+      })
+      .mockRejectedValueOnce(new Error('docker inspection unavailable'))
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '536870912  10485760000\n', stderr: '' });
+    const sandbox = new CloudflareAgentSandbox({} as Env, unresolvedDindMetadata, {
+      resolveSandbox: () =>
+        ({
+          exec,
+          listProcesses: vi.fn().mockResolvedValue([]),
+          createSession: vi.fn(),
+        }) as unknown as SandboxInstance,
+    });
+
+    await expect(sandbox.ensureWrapper(request)).rejects.toBeInstanceOf(
+      WorkspaceCapacityAdmissionRejectedError
+    );
+    expect(exec.mock.calls[4][0]).toContain('docker ps');
+    expect(exec.mock.calls.every(call => !call[0].includes('stat'))).toBe(true);
+    expect(exec.mock.calls.every(call => !call[0].includes('rm -rf'))).toBe(true);
+  });
+
   it('passes a leased physical identity into bootstrap startup', async () => {
     const bootstrapSession = {};
     const ensureBootstrapWrapper = vi

--- a/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.ts
@@ -230,7 +230,9 @@ export class CloudflareAgentSandbox implements AgentSandbox {
     const workspaceWarm = await this.workspaceHasGit(sandbox, prepared.context.workspacePath);
     if (!workspaceWarm) {
       request.onProgress?.('disk_check', 'Checking disk space...');
-      await checkDiskAndCleanBeforeSetup(sandbox, orgId, userId, sessionId);
+      await checkDiskAndCleanBeforeSetup(sandbox, orgId, userId, sessionId, {
+        inspectContainers: sandboxId.startsWith('dind-'),
+      });
     }
     request.onProgress?.('kilo_server', 'Starting Kilo...');
     const bootstrapSession = await sandbox.createSession({

--- a/services/cloud-agent-next/src/kilo/wrapper-manager.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-manager.ts
@@ -164,7 +164,7 @@ export async function findWrapperForSession(
  * `kilo.agentSession=<id>`. The published port we want is buried in the
  * `Ports` column (`0.0.0.0:5xxx->5xxx/tcp` or `127.0.0.1:5xxx->5xxx/tcp`).
  */
-type LabeledWrapperRow = {
+export type LabeledWrapperRow = {
   containerId: string;
   agentSessionId: string;
   port?: number;

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -286,6 +286,13 @@ describe('SessionService.prepareWorkspace', () => {
       onProgress: progress,
     });
 
+    expect(workspaceMocks.checkDiskAndCleanBeforeSetup).toHaveBeenCalledWith(
+      sandbox,
+      undefined,
+      'user_test',
+      'agent_test',
+      { inspectContainers: false }
+    );
     expect(workspaceMocks.cloneGitRepo).toHaveBeenCalledWith(
       session,
       '/workspace/user/sessions/agent_test',
@@ -375,9 +382,55 @@ describe('SessionService.prepareWorkspace', () => {
       })
     ).rejects.toBe(rejection);
 
+    expect(workspaceMocks.checkDiskAndCleanBeforeSetup).toHaveBeenCalledWith(
+      sandbox,
+      undefined,
+      'user_test',
+      'agent_test',
+      { inspectContainers: true }
+    );
     expect(workspaceMocks.setupWorkspace).not.toHaveBeenCalled();
     expect(sandbox.createSessionMock).not.toHaveBeenCalled();
     expect(devcontainerMocks.bringUpDevContainer).not.toHaveBeenCalled();
+  });
+
+  it('keeps requested devcontainer cleanup fail-closed when the sandbox ID is not DIND', async () => {
+    const session = createSession(false);
+    const sandbox = createSandbox(session);
+    const metadata = {
+      ...createMetadata(),
+      workspace: {
+        sandboxId: 'usr-abcdef' as const,
+        devcontainerRequested: true,
+      },
+    } satisfies CloudAgentSessionState;
+    const rejection = new WorkspaceCapacityAdmissionRejectedError({
+      availableMB: 512,
+      thresholdMB: 2048,
+      cleaned: 0,
+      skipped: 1,
+    });
+    workspaceMocks.checkDiskAndCleanBeforeSetup.mockRejectedValueOnce(rejection);
+
+    await expect(
+      new SessionService().prepareWorkspace({
+        sandbox,
+        sandboxId: 'usr-abcdef',
+        userId: 'user_test',
+        sessionId: 'agent_test' as SessionId,
+        env: createEnv(),
+        metadata,
+        kilocodeModel: 'test-model',
+      })
+    ).rejects.toBe(rejection);
+
+    expect(workspaceMocks.checkDiskAndCleanBeforeSetup).toHaveBeenCalledWith(
+      sandbox,
+      undefined,
+      'user_test',
+      'agent_test',
+      { inspectContainers: true }
+    );
   });
 
   it('hydrates requested devcontainer metadata while preparing a cold DIND workspace', async () => {

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -1703,7 +1703,12 @@ export class SessionService {
     }
 
     onProgress?.('disk_check', 'Checking disk space…');
-    await checkDiskAndCleanBeforeSetup(sandbox, orgId, userId, sessionId);
+    await checkDiskAndCleanBeforeSetup(sandbox, orgId, userId, sessionId, {
+      inspectContainers:
+        sandboxId.startsWith('dind-') ||
+        metadata.workspace?.devcontainerRequested === true ||
+        metadata.devcontainer !== undefined,
+    });
 
     onProgress?.('workspace_setup', 'Setting up workspace…');
     await setupWorkspace(sandbox, userId, orgId, sessionId);

--- a/services/cloud-agent-next/src/workspace.test.ts
+++ b/services/cloud-agent-next/src/workspace.test.ts
@@ -772,18 +772,11 @@ describe('disk space checking', () => {
     let mockSandboxExec: ReturnType<typeof vi.fn>;
     let mockListProcesses: ReturnType<typeof vi.fn>;
 
-    /**
-     * `cleanupStaleWorkspaces` resolves DOCKER_HOST and then issues a single
-     * `docker ps` (via `listWrapperContainers`) right after `ls -1 sessions/`.
-     * Tests that enumerate exec calls in order need to inject these responses
-     * before any stat/rm results.
-     */
     const dockerSocketPath = {
       exitCode: 0,
       stdout: '/run/user/1000/docker.sock',
       stderr: '',
     };
-    const dockerPsEmpty = { exitCode: 0, stdout: '', stderr: '' };
 
     beforeEach(() => {
       mockSandboxExec = vi.fn();
@@ -794,7 +787,7 @@ describe('disk space checking', () => {
       } as unknown as SandboxInstance;
     });
 
-    it('cleans up sessions with no running wrapper and reports reclamation', async () => {
+    it('cleans up sessions with no running wrapper without inspecting Docker', async () => {
       const oldMtime = String(Math.floor(Date.now() / 1000) - STALE_DIR_MIN_AGE_SECONDS - 60);
       mockSandboxExec
         .mockResolvedValueOnce({
@@ -802,8 +795,6 @@ describe('disk space checking', () => {
           stdout: 'agent_stale-1111\nagent_current-aaaa\n',
           stderr: '',
         }) // ls sessions/
-        .mockResolvedValueOnce(dockerSocketPath) // resolve Docker socket
-        .mockResolvedValueOnce(dockerPsEmpty) // docker ps (listWrapperContainers)
         .mockResolvedValueOnce({ exitCode: 0, stdout: `${oldMtime}\n`, stderr: '' }) // stat agent_stale-1111
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // rm -rf workspace for stale session
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // rm -rf home for stale session
@@ -811,35 +802,34 @@ describe('disk space checking', () => {
       mockListProcesses.mockResolvedValue([]);
 
       await expect(
-        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa')
+        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).resolves.toEqual({ cleaned: 1, skipped: 1 });
 
       expect(mockListProcesses).toHaveBeenCalledTimes(1);
 
       const execCalls = mockSandboxExec.mock.calls.map((c: string[]) => c[0]);
-      expect(execCalls[1]).toContain('/run/user/1000/docker.sock');
-      expect(execCalls[2]).toContain('docker ps');
-      expect(execCalls[3]).toContain('stat');
-      expect(execCalls[4]).toContain("rm -rf '/workspace/org/user/sessions/agent_stale-1111'");
-      expect(execCalls[5]).toContain("rm -rf '/home/agent_stale-1111'");
+      expect(execCalls.every((command: string) => !command.includes('docker'))).toBe(true);
+      expect(execCalls[1]).toContain('stat');
+      expect(execCalls[2]).toContain("rm -rf '/workspace/org/user/sessions/agent_stale-1111'");
+      expect(execCalls[3]).toContain("rm -rf '/home/agent_stale-1111'");
     });
 
     it('skips the current session directory', async () => {
-      mockSandboxExec
-        .mockResolvedValueOnce({
-          exitCode: 0,
-          stdout: 'agent_current-aaaa\n',
-          stderr: '',
-        }) // ls sessions/
-        .mockResolvedValueOnce(dockerSocketPath) // resolve Docker socket
-        .mockResolvedValueOnce(dockerPsEmpty); // docker ps
+      mockSandboxExec.mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: 'agent_current-aaaa\n',
+        stderr: '',
+      });
 
       mockListProcesses.mockResolvedValue([]);
 
-      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa');
+      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+        inspectContainers: false,
+      });
 
-      // ls + docker socket resolution + docker ps — no rm calls
-      expect(mockSandboxExec).toHaveBeenCalledTimes(3);
+      expect(mockSandboxExec).toHaveBeenCalledTimes(1);
     });
 
     it('skips sessions that have a running wrapper', async () => {
@@ -850,8 +840,6 @@ describe('disk space checking', () => {
           stdout: 'agent_active-bbbb\n',
           stderr: '',
         }) // ls sessions/
-        .mockResolvedValueOnce(dockerSocketPath) // resolve Docker socket
-        .mockResolvedValueOnce(dockerPsEmpty) // docker ps
         .mockResolvedValueOnce({ exitCode: 0, stdout: `${oldMtime}\n`, stderr: '' }); // stat agent_active-bbbb
 
       mockListProcesses.mockResolvedValue([
@@ -862,10 +850,36 @@ describe('disk space checking', () => {
         },
       ]);
 
-      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa');
+      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+        inspectContainers: false,
+      });
 
-      // ls + docker socket resolution + docker ps + stat — no rm calls
-      expect(mockSandboxExec).toHaveBeenCalledTimes(4);
+      expect(mockSandboxExec).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips sessions that have a starting wrapper', async () => {
+      const oldMtime = String(Math.floor(Date.now() / 1000) - STALE_DIR_MIN_AGE_SECONDS - 60);
+      mockSandboxExec
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: 'agent_starting-bbbb\n',
+          stderr: '',
+        })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: `${oldMtime}\n`, stderr: '' });
+
+      mockListProcesses.mockResolvedValue([
+        {
+          id: 1,
+          command: 'kilocode-wrapper --agent-session agent_starting-bbbb WRAPPER_PORT=5001',
+          status: 'starting',
+        },
+      ]);
+
+      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+        inspectContainers: false,
+      });
+
+      expect(mockSandboxExec).toHaveBeenCalledTimes(2);
     });
 
     it('returns early when sessions directory does not exist', async () => {
@@ -875,7 +889,9 @@ describe('disk space checking', () => {
         stderr: 'No such file or directory',
       });
 
-      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa');
+      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+        inspectContainers: false,
+      });
 
       expect(mockSandboxExec).toHaveBeenCalledTimes(1);
       expect(mockListProcesses).not.toHaveBeenCalled();
@@ -884,7 +900,9 @@ describe('disk space checking', () => {
     it('returns early when sessions directory is empty', async () => {
       mockSandboxExec.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
 
-      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa');
+      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+        inspectContainers: false,
+      });
 
       expect(mockSandboxExec).toHaveBeenCalledTimes(1);
       expect(mockListProcesses).not.toHaveBeenCalled();
@@ -894,15 +912,15 @@ describe('disk space checking', () => {
       const oldMtime = String(Math.floor(Date.now() / 1000) - STALE_DIR_MIN_AGE_SECONDS - 60);
       mockSandboxExec
         .mockResolvedValueOnce({ exitCode: 0, stdout: 'agent_stale-aaaa\n', stderr: '' })
-        .mockResolvedValueOnce(dockerSocketPath)
-        .mockResolvedValueOnce(dockerPsEmpty)
         .mockResolvedValueOnce({ exitCode: 0, stdout: `${oldMtime}\n`, stderr: '' })
         .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'rm failed' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
       mockListProcesses.mockResolvedValue([]);
 
       await expect(
-        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa')
+        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).resolves.toEqual({ cleaned: 0, skipped: 1 });
     });
 
@@ -914,8 +932,6 @@ describe('disk space checking', () => {
           stdout: 'agent_stale-aaaa\nagent_stale-bbbb\n',
           stderr: '',
         }) // ls
-        .mockResolvedValueOnce(dockerSocketPath) // resolve Docker socket
-        .mockResolvedValueOnce(dockerPsEmpty) // docker ps
         .mockRejectedValueOnce(new Error('exec threw during agent_stale-aaaa stat')) // stat throws for first session
         .mockResolvedValueOnce({ exitCode: 0, stdout: `${oldMtime}\n`, stderr: '' }) // stat agent_stale-bbbb
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // rm workspace agent_stale-bbbb
@@ -924,7 +940,9 @@ describe('disk space checking', () => {
       mockListProcesses.mockResolvedValue([]);
 
       await expect(
-        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa')
+        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).resolves.toEqual({ cleaned: 1, skipped: 1 });
 
       // listProcesses is called exactly once (not per session)
@@ -944,7 +962,9 @@ describe('disk space checking', () => {
       mockListProcesses.mockRejectedValue(new Error('sandbox unavailable'));
 
       await expect(
-        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa')
+        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).resolves.toEqual({ cleaned: 0, skipped: 1 });
 
       // Only the ls call — no rm calls since listProcesses failed
@@ -955,7 +975,9 @@ describe('disk space checking', () => {
       mockSandboxExec.mockRejectedValueOnce(new Error('exec error'));
 
       await expect(
-        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa')
+        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).resolves.toEqual({ cleaned: 0, skipped: 0 });
     });
 
@@ -967,15 +989,15 @@ describe('disk space checking', () => {
           stdout: 'unexpected-dir\n.hidden\nlost+found\nagent_valid-1234\n',
           stderr: '',
         }) // ls
-        .mockResolvedValueOnce(dockerSocketPath) // resolve Docker socket
-        .mockResolvedValueOnce(dockerPsEmpty) // docker ps
         .mockResolvedValueOnce({ exitCode: 0, stdout: `${oldMtime}\n`, stderr: '' }) // stat agent_valid-1234
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // rm workspace agent_valid-1234
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // rm home agent_valid-1234
 
       mockListProcesses.mockResolvedValue([]);
 
-      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa');
+      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+        inspectContainers: false,
+      });
 
       const execCalls = mockSandboxExec.mock.calls.map((c: string[]) => c[0]);
       // Non-matching entries never appear in any exec call after the ls
@@ -994,16 +1016,16 @@ describe('disk space checking', () => {
           stdout: 'agent_recent-1111\n',
           stderr: '',
         }) // ls sessions/
-        .mockResolvedValueOnce(dockerSocketPath) // resolve Docker socket
-        .mockResolvedValueOnce(dockerPsEmpty) // docker ps
         .mockResolvedValueOnce({ exitCode: 0, stdout: `${recentMtime}\n`, stderr: '' }); // stat
 
       mockListProcesses.mockResolvedValue([]);
 
-      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa');
+      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+        inspectContainers: false,
+      });
 
-      // ls + docker socket resolution + docker ps + stat only — no rm calls
-      expect(mockSandboxExec).toHaveBeenCalledTimes(4);
+      // ls + stat only — no rm calls
+      expect(mockSandboxExec).toHaveBeenCalledTimes(2);
     });
 
     it('cleans old directories but skips recent ones in the same run', async () => {
@@ -1015,8 +1037,6 @@ describe('disk space checking', () => {
           stdout: 'agent_old-1111\nagent_recent-2222\n',
           stderr: '',
         }) // ls
-        .mockResolvedValueOnce(dockerSocketPath) // resolve Docker socket
-        .mockResolvedValueOnce(dockerPsEmpty) // docker ps
         .mockResolvedValueOnce({ exitCode: 0, stdout: `${oldMtime}\n`, stderr: '' }) // stat agent_old-1111
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // rm workspace agent_old-1111
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // rm home agent_old-1111
@@ -1024,7 +1044,9 @@ describe('disk space checking', () => {
 
       mockListProcesses.mockResolvedValue([]);
 
-      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa');
+      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+        inspectContainers: false,
+      });
 
       const execCalls = mockSandboxExec.mock.calls.map((c: string[]) => c[0]);
       // Old session was cleaned
@@ -1046,16 +1068,16 @@ describe('disk space checking', () => {
           stdout: 'agent_stale-1111\n',
           stderr: '',
         }) // ls
-        .mockResolvedValueOnce(dockerSocketPath) // resolve Docker socket
-        .mockResolvedValueOnce(dockerPsEmpty) // docker ps
         .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'stat: cannot stat' }); // stat fails
 
       mockListProcesses.mockResolvedValue([]);
 
-      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa');
+      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+        inspectContainers: false,
+      });
 
-      // ls + docker socket resolution + docker ps + stat only — no rm calls (directory was skipped)
-      expect(mockSandboxExec).toHaveBeenCalledTimes(4);
+      // ls + stat only — no rm calls (directory was skipped)
+      expect(mockSandboxExec).toHaveBeenCalledTimes(2);
     });
 
     it('skips cleanup when stat returns unparseable output', async () => {
@@ -1065,16 +1087,16 @@ describe('disk space checking', () => {
           stdout: 'agent_stale-1111\n',
           stderr: '',
         }) // ls
-        .mockResolvedValueOnce(dockerSocketPath) // resolve Docker socket
-        .mockResolvedValueOnce(dockerPsEmpty) // docker ps
         .mockResolvedValueOnce({ exitCode: 0, stdout: 'not-a-number\n', stderr: '' }); // stat returns garbage
 
       mockListProcesses.mockResolvedValue([]);
 
-      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa');
+      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+        inspectContainers: false,
+      });
 
-      // ls + docker socket resolution + docker ps + stat only — no rm calls (directory was skipped)
-      expect(mockSandboxExec).toHaveBeenCalledTimes(4);
+      // ls + stat only — no rm calls (directory was skipped)
+      expect(mockSandboxExec).toHaveBeenCalledTimes(2);
     });
 
     it('skips all cleanup when devcontainer wrapper inspection fails', async () => {
@@ -1085,9 +1107,15 @@ describe('disk space checking', () => {
       mockListProcesses.mockResolvedValue([]);
 
       await expect(
-        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa')
+        cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+          inspectContainers: true,
+        })
       ).resolves.toEqual({ cleaned: 0, skipped: 1 });
-      expect(mockSandboxExec.mock.calls.every(call => !call[0].includes('rm -rf'))).toBe(true);
+      const execCalls = mockSandboxExec.mock.calls.map((call: string[]) => call[0]);
+      expect(execCalls[1]).toContain('/run/user/1000/docker.sock');
+      expect(execCalls[2]).toContain('docker ps');
+      expect(execCalls.every((command: string) => !command.includes('stat'))).toBe(true);
+      expect(execCalls.every((command: string) => !command.includes('rm -rf'))).toBe(true);
     });
 
     it('skips sessions with a wrapper running inside a dev container', async () => {
@@ -1110,7 +1138,9 @@ describe('disk space checking', () => {
 
       mockListProcesses.mockResolvedValue([]);
 
-      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa');
+      await cleanupStaleWorkspaces(fakeSandbox, '/workspace/org/user', 'agent_current-aaaa', {
+        inspectContainers: true,
+      });
 
       // ls + docker socket resolution + docker ps + stat only — no rm calls (live devcontainer wrapper)
       expect(mockSandboxExec).toHaveBeenCalledTimes(4);
@@ -1139,7 +1169,9 @@ describe('disk space checking', () => {
       });
 
       await expect(
-        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa')
+        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).resolves.toEqual({
         availableMB: 5000,
         thresholdMB: LOW_DISK_THRESHOLD_MB,
@@ -1163,8 +1195,6 @@ describe('disk space checking', () => {
           stdout: 'agent_stale-1111\nagent_current-aaaa\n',
           stderr: '',
         })
-        .mockResolvedValueOnce({ exitCode: 0, stdout: '/run/user/1000/docker.sock', stderr: '' })
-        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: `${oldMtime}\n`, stderr: '' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
@@ -1176,14 +1206,18 @@ describe('disk space checking', () => {
       mockListProcesses.mockResolvedValue([]);
 
       await expect(
-        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa')
+        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).resolves.toEqual({
         availableMB: 3000,
         thresholdMB: LOW_DISK_THRESHOLD_MB,
         cleanup: { cleaned: 1, skipped: 1 },
       });
 
-      expect(mockSandboxExec.mock.calls[7][0]).toContain('df -B1');
+      const execCalls = mockSandboxExec.mock.calls.map((call: string[]) => call[0]);
+      expect(execCalls[5]).toContain('df -B1');
+      expect(execCalls.every((command: string) => !command.includes('docker'))).toBe(true);
     });
 
     it('types ENOSPC during stale cleanup as sandbox unusable instead of rechecking capacity', async () => {
@@ -1196,7 +1230,9 @@ describe('disk space checking', () => {
         .mockRejectedValueOnce(new Error('ENOSPC: no space left on device'));
 
       await expect(
-        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa')
+        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).rejects.toBeInstanceOf(SandboxCapacityInspectionError);
       expect(mockSandboxExec).toHaveBeenCalledTimes(2);
     });
@@ -1206,15 +1242,15 @@ describe('disk space checking', () => {
       mockSandboxExec
         .mockResolvedValueOnce({ exitCode: 0, stdout: '1073741824  10485760000\n', stderr: '' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: 'agent_stale-aaaa\n', stderr: '' })
-        .mockResolvedValueOnce({ exitCode: 0, stdout: '/run/user/1000/docker.sock', stderr: '' })
-        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: `${oldMtime}\n`, stderr: '' })
         .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'No space left on device' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
       mockListProcesses.mockResolvedValue([]);
 
       await expect(
-        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa')
+        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).rejects.toBeInstanceOf(SandboxCapacityInspectionError);
     });
 
@@ -1233,7 +1269,9 @@ describe('disk space checking', () => {
         });
 
       await expect(
-        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa')
+        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).resolves.toEqual({
         availableMB: 3000,
         thresholdMB: LOW_DISK_THRESHOLD_MB,
@@ -1259,7 +1297,8 @@ describe('disk space checking', () => {
         fakeSandbox,
         'org-1',
         'user-1',
-        'agent_current-aaaa'
+        'agent_current-aaaa',
+        { inspectContainers: false }
       );
 
       await expect(result).rejects.toBeInstanceOf(WorkspaceCapacityAdmissionRejectedError);
@@ -1276,8 +1315,6 @@ describe('disk space checking', () => {
       mockSandboxExec
         .mockResolvedValueOnce({ exitCode: 0, stdout: '1073741824  10485760000\n', stderr: '' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: 'agent_active-bbbb\n', stderr: '' })
-        .mockResolvedValueOnce({ exitCode: 0, stdout: '/run/user/1000/docker.sock', stderr: '' })
-        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: `${oldMtime}\n`, stderr: '' })
         .mockResolvedValueOnce({ exitCode: 0, stdout: '1073741824  10485760000\n', stderr: '' });
       mockListProcesses.mockResolvedValue([
@@ -1289,7 +1326,9 @@ describe('disk space checking', () => {
       ]);
 
       await expect(
-        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa')
+        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).rejects.toMatchObject({ skipped: 1 });
       expect(mockSandboxExec.mock.calls.every(call => !call[0].includes('rm -rf'))).toBe(true);
     });
@@ -1302,7 +1341,9 @@ describe('disk space checking', () => {
       });
 
       await expect(
-        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa')
+        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).rejects.toBeInstanceOf(SandboxCapacityInspectionError);
     });
 
@@ -1314,7 +1355,9 @@ describe('disk space checking', () => {
       });
 
       await expect(
-        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa')
+        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).rejects.toBeInstanceOf(WorkspaceCapacityInspectionUnavailableError);
     });
 
@@ -1322,7 +1365,9 @@ describe('disk space checking', () => {
       mockSandboxExec.mockRejectedValueOnce(new Error('execution session unavailable'));
 
       await expect(
-        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa')
+        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).rejects.toBeInstanceOf(WorkspaceCapacityInspectionUnavailableError);
     });
 
@@ -1330,7 +1375,9 @@ describe('disk space checking', () => {
       mockSandboxExec.mockRejectedValueOnce(new Error('ENOSPC: no space left on device'));
 
       await expect(
-        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa')
+        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).rejects.toBeInstanceOf(SandboxCapacityInspectionError);
     });
 
@@ -1342,7 +1389,9 @@ describe('disk space checking', () => {
       });
 
       await expect(
-        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa')
+        checkDiskAndCleanBeforeSetup(fakeSandbox, 'org-1', 'user-1', 'agent_current-aaaa', {
+          inspectContainers: false,
+        })
       ).rejects.toBeInstanceOf(WorkspaceCapacityInspectionUnavailableError);
     });
   });

--- a/services/cloud-agent-next/src/workspace.ts
+++ b/services/cloud-agent-next/src/workspace.ts
@@ -4,6 +4,7 @@ import { logger } from './logger.js';
 import {
   inspectWrapperContainers,
   isWrapperLiveInProcessesOrContainers,
+  type LabeledWrapperRow,
 } from './kilo/wrapper-manager.js';
 import {
   DISK_CHECK_TIMEOUT_MS,
@@ -190,6 +191,10 @@ export type StaleWorkspaceCleanupResult = {
   skipped: number;
 };
 
+export type StaleWorkspaceCleanupOptions = {
+  inspectContainers: boolean;
+};
+
 export type WorkspaceAdmissionResult = {
   availableMB: number;
   thresholdMB: number;
@@ -212,7 +217,8 @@ export async function checkDiskAndCleanBeforeSetup(
   sandbox: SandboxInstance,
   orgId: string | undefined,
   userId: string,
-  sessionId: string
+  sessionId: string,
+  options: StaleWorkspaceCleanupOptions
 ): Promise<WorkspaceAdmissionResult> {
   try {
     const initialCapacity = await checkDiskSpace(sandbox);
@@ -229,7 +235,8 @@ export async function checkDiskAndCleanBeforeSetup(
     const cleanup = await cleanupStaleWorkspaces(
       sandbox,
       getBaseWorkspacePath(orgId, userId),
-      sessionId
+      sessionId,
+      options
     );
     const recheckedCapacity = await checkDiskSpace(sandbox);
     if (recheckedCapacity.isLow) {
@@ -406,7 +413,8 @@ async function cleanupWorkspaceBestEffort(
 export async function cleanupStaleWorkspaces(
   sandbox: SandboxInstance,
   baseWorkspacePath: string,
-  currentSessionId: string
+  currentSessionId: string,
+  options: StaleWorkspaceCleanupOptions
 ): Promise<StaleWorkspaceCleanupResult> {
   logger
     .withFields({ baseWorkspacePath, currentSessionId })
@@ -460,22 +468,25 @@ export async function cleanupStaleWorkspaces(
     return { cleaned: 0, skipped: sessionDirs.length };
   }
 
-  const wrapperContainerInspection = await inspectWrapperContainers(sandbox);
-  if (wrapperContainerInspection.status === 'inspection-failed') {
-    throwIfSandboxFilesystemUnusable(
-      'Stale devcontainer wrapper inspection',
-      wrapperContainerInspection.error
-    );
-    logger
-      .withFields({
-        error: wrapperContainerInspection.error,
-        cleaned: 0,
-        skipped: sessionDirs.length,
-      })
-      .warn('Failed to inspect devcontainer wrappers, skipping cleanup');
-    return { cleaned: 0, skipped: sessionDirs.length };
+  let wrapperContainers: LabeledWrapperRow[] = [];
+  if (options.inspectContainers) {
+    const wrapperContainerInspection = await inspectWrapperContainers(sandbox);
+    if (wrapperContainerInspection.status === 'inspection-failed') {
+      throwIfSandboxFilesystemUnusable(
+        'Stale devcontainer wrapper inspection',
+        wrapperContainerInspection.error
+      );
+      logger
+        .withFields({
+          error: wrapperContainerInspection.error,
+          cleaned: 0,
+          skipped: sessionDirs.length,
+        })
+        .warn('Failed to inspect devcontainer wrappers, skipping cleanup');
+      return { cleaned: 0, skipped: sessionDirs.length };
+    }
+    wrapperContainers = wrapperContainerInspection.containers;
   }
-  const wrapperContainers = wrapperContainerInspection.containers;
 
   // Get current epoch once so we can age-check directories without re-shelling per candidate
   const nowSeconds = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
## Summary

- Allow standard Cloud Agent sandboxes to reclaim stale session workspaces without requiring Docker, restoring low-disk cold-workspace admission on images that intentionally omit Docker.
- Preserve fail-closed cleanup for DIND and devcontainer-signaled runtimes: direct wrapper processes are always inspected, and Docker inspection failures still skip deletion conservatively.
- Make cleanup runtime intent explicit by threading a required `inspectContainers` option through workspace admission and stale cleanup. Add regression coverage for standard reclamation, direct running/starting wrapper protection, devcontainer inspection failures, and unresolved DIND bootstrap paths.
