### PR TITLE
fix(gitlab): harden instance URL requests

### DIFF
--- a/apps/web/src/app/api/integrations/gitlab/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/gitlab/callback/route.test.ts
@@ -164,6 +164,27 @@ describe('GET /api/integrations/gitlab/callback', () => {
     expect(mockedExchangeGitLabOAuthCode).not.toHaveBeenCalled();
   });
 
+  test('rejects signed state with an unsafe instance URL before exchanging an OAuth code', async () => {
+    const state = createGitLabOAuthState(
+      {
+        owner: { type: 'user', id: USER_ID },
+        instanceUrl: 'http://127.0.0.1:8080',
+        customCredentialsRef: 'cached-credentials-ref',
+      },
+      USER_ID
+    );
+
+    const response = await callGitLabCallback(
+      makeRequest(
+        `/api/integrations/gitlab/callback?code=anything&state=${encodeURIComponent(state)}`
+      )
+    );
+
+    expectRedirectLocation(response, '/integrations/gitlab?error=connection_failed');
+    expect(mockedGetGitLabOAuthCredentials).not.toHaveBeenCalled();
+    expect(mockedExchangeGitLabOAuthCode).not.toHaveBeenCalled();
+  });
+
   test('loads cached custom OAuth credentials before the code exchange', async () => {
     mockedGetGitLabOAuthCredentials.mockResolvedValue({
       clientId: 'self-hosted-client',

--- a/apps/web/src/app/api/integrations/gitlab/connect/route.test.ts
+++ b/apps/web/src/app/api/integrations/gitlab/connect/route.test.ts
@@ -151,7 +151,7 @@ describe('GET /api/integrations/gitlab/connect', () => {
   test('stores self-hosted credentials and binds only their Redis reference into signed state', async () => {
     const response = await callGitLabConnectPost(
       makeJsonRequest('/api/integrations/gitlab/connect', {
-        instanceUrl: 'https://gitlab.example.com',
+        instanceUrl: 'https://GitLab.Example.com/gitlab/',
         clientId: 'client-id',
         clientSecret: 'client-secret',
       })
@@ -165,20 +165,37 @@ describe('GET /api/integrations/gitlab/connect', () => {
     expect(mockedCreateGitLabOAuthState).toHaveBeenCalledWith(
       {
         owner: { type: 'user', id: USER_ID },
-        instanceUrl: 'https://gitlab.example.com',
+        instanceUrl: 'https://gitlab.example.com/gitlab',
         customCredentialsRef: 'cached-credentials-ref',
       },
       USER_ID
     );
     expect(mockedBuildGitLabOAuthUrl).toHaveBeenCalledWith(
       'signed-gitlab-state',
-      'https://gitlab.example.com',
+      'https://gitlab.example.com/gitlab',
       {
         clientId: 'client-id',
         clientSecret: 'client-secret',
       }
     );
     expect(responseBody.url).toBe('https://gitlab.com/oauth/authorize?state=signed');
+  });
+
+  test('does not initialize self-hosted OAuth for unsafe instance URLs', async () => {
+    const response = await callGitLabConnectPost(
+      makeJsonRequest('/api/integrations/gitlab/connect', {
+        instanceUrl: 'http://127.0.0.1:8080',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+      })
+    );
+    const responseBody = (await response.json()) as { error?: string };
+
+    expect(response.status).toBe(500);
+    expect(responseBody.error).toBe('oauth_init_failed');
+    expect(mockedStoreGitLabOAuthCredentials).not.toHaveBeenCalled();
+    expect(mockedCreateGitLabOAuthState).not.toHaveBeenCalled();
+    expect(mockedBuildGitLabOAuthUrl).not.toHaveBeenCalled();
   });
 
   test('supports authenticated legacy GET self-hosted credentials during rollout', async () => {

--- a/apps/web/src/lib/integrations/gitlab-service.test.ts
+++ b/apps/web/src/lib/integrations/gitlab-service.test.ts
@@ -28,6 +28,16 @@ describe('normalizeInstanceUrl', () => {
     expect(normalizeInstanceUrl('http://selfhosted.test:3123')).toBe('http://selfhosted.test:3123');
   });
 
+  it('preserves self-hosted base paths', () => {
+    expect(normalizeInstanceUrl('https://GitLab.Example.com/gitlab/')).toBe(
+      'https://gitlab.example.com/gitlab'
+    );
+  });
+
+  it('rejects unsafe self-hosted URLs', () => {
+    expect(() => normalizeInstanceUrl('http://127.0.0.1:8080')).toThrow('host is not allowed');
+  });
+
   it('detects instance URL changes', () => {
     // same instance (both default to gitlab.com)
     expect(normalizeInstanceUrl(undefined)).toBe(normalizeInstanceUrl('https://gitlab.com'));

--- a/apps/web/src/lib/integrations/gitlab-service.ts
+++ b/apps/web/src/lib/integrations/gitlab-service.ts
@@ -28,8 +28,11 @@ import {
 } from '@/lib/integrations/platforms/gitlab/adapter';
 import { randomBytes } from 'crypto';
 import { logExceptInTest } from '@/lib/utils.server';
-
-const DEFAULT_GITLAB_INSTANCE_URL = 'https://gitlab.com';
+import {
+  DEFAULT_GITLAB_INSTANCE_URL,
+  GitLabInstanceUrlError,
+  normalizeGitLabInstanceUrl,
+} from '@/lib/integrations/platforms/gitlab/instance-url';
 
 /**
  * GitLab Integration Service
@@ -43,8 +46,7 @@ const DEFAULT_GITLAB_INSTANCE_URL = 'https://gitlab.com';
  * Strips trailing slashes, lowercases, and treats undefined/empty as gitlab.com.
  */
 export function normalizeInstanceUrl(url?: string): string {
-  const effectiveUrl = url || DEFAULT_GITLAB_INSTANCE_URL;
-  return effectiveUrl.replace(/\/+$/, '').toLowerCase();
+  return normalizeGitLabInstanceUrl(url || DEFAULT_GITLAB_INSTANCE_URL);
 }
 
 /**
@@ -106,7 +108,7 @@ export async function getValidGitLabToken(integration: PlatformIntegration): Pro
       });
     }
 
-    const instanceUrl = metadata.gitlab_instance_url || 'https://gitlab.com';
+    const instanceUrl = normalizeInstanceUrl(metadata.gitlab_instance_url);
 
     const customCredentials =
       metadata.client_id && metadata.client_secret
@@ -177,7 +179,7 @@ export async function listGitLabRepositories(
   if (forceRefresh || !integration.repositories?.length || !integration.repositories_synced_at) {
     const accessToken = await getValidGitLabToken(integration);
     const metadata = integration.metadata as { gitlab_instance_url?: string } | null;
-    const instanceUrl = metadata?.gitlab_instance_url || 'https://gitlab.com';
+    const instanceUrl = normalizeInstanceUrl(metadata?.gitlab_instance_url);
 
     const repos = await fetchGitLabProjects(accessToken, instanceUrl);
     await updateRepositoriesForIntegration(integrationId, repos);
@@ -230,7 +232,7 @@ export async function listGitLabBranches(
 
   const accessToken = await getValidGitLabToken(integration);
   const metadata = integration.metadata as { gitlab_instance_url?: string } | null;
-  const instanceUrl = metadata?.gitlab_instance_url || 'https://gitlab.com';
+  const instanceUrl = normalizeInstanceUrl(metadata?.gitlab_instance_url);
 
   const branches = await fetchGitLabBranches(accessToken, projectPath, instanceUrl);
 
@@ -452,7 +454,7 @@ export async function getOrCreateProjectAccessToken(
     });
   }
 
-  const instanceUrl = metadata.gitlab_instance_url || 'https://gitlab.com';
+  const instanceUrl = normalizeInstanceUrl(metadata.gitlab_instance_url);
   const projectIdStr = String(projectId);
 
   // Check if we already have a stored token for this project
@@ -681,7 +683,7 @@ export async function removeStoredProjectAccessToken(
   }
 
   const storedToken = metadata.project_tokens[projectIdStr];
-  const instanceUrl = metadata.gitlab_instance_url || 'https://gitlab.com';
+  const instanceUrl = normalizeInstanceUrl(metadata.gitlab_instance_url);
 
   // Try to revoke the token in GitLab
   try {
@@ -768,7 +770,7 @@ export async function importExistingProjectAccessToken(
     });
   }
 
-  const instanceUrl = metadata.gitlab_instance_url || 'https://gitlab.com';
+  const instanceUrl = normalizeInstanceUrl(metadata.gitlab_instance_url);
   const userToken = await getValidGitLabToken(integration);
 
   // Find existing Kilo token on GitLab
@@ -837,8 +839,19 @@ export async function connectWithPAT(
   };
   warnings?: string[];
 }> {
+  let normalizedInstanceUrl: string;
+  try {
+    normalizedInstanceUrl = normalizeInstanceUrl(instanceUrl);
+  } catch (error) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message:
+        error instanceof GitLabInstanceUrlError ? error.message : 'Invalid GitLab instance URL',
+    });
+  }
+
   // 1. Validate the PAT
-  const validation = await validatePersonalAccessToken(token, instanceUrl);
+  const validation = await validatePersonalAccessToken(token, normalizedInstanceUrl);
 
   if (!validation.valid || !validation.user) {
     throw new TRPCError({
@@ -854,19 +867,22 @@ export async function connectWithPAT(
     const existingMetadata = (existingIntegration.metadata || {}) as GitLabIntegrationMetadata;
 
     // Detect if the GitLab instance URL changed (e.g. gitlab.com → self-hosted)
-    const isInstanceChange = instanceUrlChanged(existingMetadata.gitlab_instance_url, instanceUrl);
+    const isInstanceChange = instanceUrlChanged(
+      existingMetadata.gitlab_instance_url,
+      normalizedInstanceUrl
+    );
 
     if (isInstanceChange) {
       logExceptInTest('[connectWithPAT] Instance URL changed — clearing stale config', {
         integrationId: existingIntegration.id,
         oldInstanceUrl: existingMetadata.gitlab_instance_url,
-        newInstanceUrl: instanceUrl,
+        newInstanceUrl: normalizedInstanceUrl,
       });
     }
 
     const updatedMetadata: GitLabIntegrationMetadata = {
       access_token: token,
-      gitlab_instance_url: instanceUrl,
+      gitlab_instance_url: normalizedInstanceUrl,
       auth_type: 'pat',
       // If instance changed: generate fresh webhook secret, clear webhooks & tokens
       // If same instance: preserve existing config for continuity
@@ -901,7 +917,7 @@ export async function connectWithPAT(
       integrationId: existingIntegration.id,
       userId: validation.user.id,
       username: validation.user.username,
-      instanceUrl,
+      instanceUrl: normalizedInstanceUrl,
       authType: 'pat',
       instanceChanged: isInstanceChange,
       preservedWebhookSecret: !isInstanceChange && !!existingMetadata.webhook_secret,
@@ -911,7 +927,7 @@ export async function connectWithPAT(
     });
 
     // Fetch and cache repositories
-    const repos = await fetchGitLabProjects(token, instanceUrl);
+    const repos = await fetchGitLabProjects(token, normalizedInstanceUrl);
     await updateRepositoriesForIntegration(existingIntegration.id, repos);
 
     return {
@@ -920,7 +936,7 @@ export async function connectWithPAT(
         id: existingIntegration.id,
         accountLogin: validation.user.username,
         accountId: String(validation.user.id),
-        instanceUrl,
+        instanceUrl: normalizedInstanceUrl,
       },
       warnings: validation.warnings,
     };
@@ -933,7 +949,7 @@ export async function connectWithPAT(
   const metadata: GitLabIntegrationMetadata = {
     access_token: token,
     // No refresh_token for PAT (PATs don't refresh)
-    gitlab_instance_url: instanceUrl,
+    gitlab_instance_url: normalizedInstanceUrl,
     webhook_secret: webhookSecret,
     auth_type: 'pat',
   };
@@ -962,12 +978,12 @@ export async function connectWithPAT(
     integrationId: integration.id,
     userId: validation.user.id,
     username: validation.user.username,
-    instanceUrl,
+    instanceUrl: normalizedInstanceUrl,
     authType: 'pat',
   });
 
   // 6. Fetch and cache repositories
-  const repos = await fetchGitLabProjects(token, instanceUrl);
+  const repos = await fetchGitLabProjects(token, normalizedInstanceUrl);
   await updateRepositoriesForIntegration(integration.id, repos);
 
   logExceptInTest('[connectWithPAT] Repositories cached', {
@@ -981,7 +997,7 @@ export async function connectWithPAT(
       id: integration.id,
       accountLogin: validation.user.username,
       accountId: String(validation.user.id),
-      instanceUrl,
+      instanceUrl: normalizedInstanceUrl,
     },
     warnings: validation.warnings,
   };

--- a/apps/web/src/lib/integrations/oauth/platforms/gitlab-callback.ts
+++ b/apps/web/src/lib/integrations/oauth/platforms/gitlab-callback.ts
@@ -14,11 +14,14 @@ import {
   calculateTokenExpiry,
 } from '@/lib/integrations/platforms/gitlab/adapter';
 import { normalizeInstanceUrl } from '@/lib/integrations/gitlab-service';
+import {
+  isDefaultGitLabInstanceUrl,
+  normalizeGitLabInstanceUrl,
+} from '@/lib/integrations/platforms/gitlab/instance-url';
 import { resetCodeReviewConfigForOwner } from '@/lib/agent-config/db/agent-configs';
 import { APP_URL } from '@/lib/constants';
 import { createHash, randomBytes } from 'crypto';
 import {
-  DEFAULT_GITLAB_OAUTH_INSTANCE_URL,
   type VerifiedGitLabOAuthState,
   verifyGitLabOAuthState,
 } from '@/lib/integrations/platforms/gitlab/oauth-state';
@@ -106,6 +109,7 @@ export async function handleGitLabOAuthCallback(request: NextRequest) {
     }
 
     const { owner, instanceUrl, customCredentialsRef } = verifiedState;
+    const normalizedInstanceUrl = normalizeGitLabInstanceUrl(instanceUrl);
 
     if (owner.type === 'org') {
       await ensureOrganizationAccess({ user }, owner.id);
@@ -153,13 +157,13 @@ export async function handleGitLabOAuthCallback(request: NextRequest) {
       return NextResponse.redirect(new URL(redirectPath, APP_URL));
     }
 
-    const tokens = await exchangeGitLabOAuthCode(code, instanceUrl, customCredentials);
+    const tokens = await exchangeGitLabOAuthCode(code, normalizedInstanceUrl, customCredentials);
 
-    const gitlabUser = await fetchGitLabUser(tokens.access_token, instanceUrl);
+    const gitlabUser = await fetchGitLabUser(tokens.access_token, normalizedInstanceUrl);
 
     let repositories = null;
     try {
-      repositories = await fetchGitLabProjects(tokens.access_token, instanceUrl);
+      repositories = await fetchGitLabProjects(tokens.access_token, normalizedInstanceUrl);
     } catch (repoError) {
       // Non-fatal - user can refresh later
       console.error('Failed to fetch GitLab projects:', repoError);
@@ -184,7 +188,7 @@ export async function handleGitLabOAuthCallback(request: NextRequest) {
     const isInstanceChange =
       existing !== undefined &&
       normalizeInstanceUrl(existingMetadata?.gitlab_instance_url as string | undefined) !==
-        normalizeInstanceUrl(instanceUrl);
+        normalizeInstanceUrl(normalizedInstanceUrl);
 
     const webhookSecret = isInstanceChange
       ? generateWebhookSecret()
@@ -194,8 +198,9 @@ export async function handleGitLabOAuthCallback(request: NextRequest) {
       access_token: tokens.access_token,
       refresh_token: tokens.refresh_token,
       token_expires_at: tokenExpiresAt,
-      gitlab_instance_url:
-        instanceUrl !== DEFAULT_GITLAB_OAUTH_INSTANCE_URL ? instanceUrl : undefined,
+      gitlab_instance_url: isDefaultGitLabInstanceUrl(normalizedInstanceUrl)
+        ? undefined
+        : normalizedInstanceUrl,
       webhook_secret: webhookSecret,
       auth_type: 'oauth',
       // Only preserve webhooks/tokens if same instance

--- a/apps/web/src/lib/integrations/oauth/platforms/gitlab-connect.ts
+++ b/apps/web/src/lib/integrations/oauth/platforms/gitlab-connect.ts
@@ -5,10 +5,11 @@ import { getUserFromAuth } from '@/lib/user/server';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { captureException } from '@sentry/nextjs';
 import { buildGitLabOAuthUrl } from '@/lib/integrations/platforms/gitlab/adapter';
+import { createGitLabOAuthState } from '@/lib/integrations/platforms/gitlab/oauth-state';
 import {
-  createGitLabOAuthState,
-  DEFAULT_GITLAB_OAUTH_INSTANCE_URL,
-} from '@/lib/integrations/platforms/gitlab/oauth-state';
+  isDefaultGitLabInstanceUrl,
+  normalizeGitLabInstanceUrl,
+} from '@/lib/integrations/platforms/gitlab/instance-url';
 import { storeGitLabOAuthCredentials } from '@/lib/integrations/platforms/gitlab/oauth-credentials';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { validateReturnPath } from '@/lib/integrations/validate-return-path';
@@ -165,7 +166,9 @@ async function buildGitLabConnectOAuthUrl(
 ): Promise<string> {
   const owner = await resolveGitLabOAuthOwner(user, organizationId);
   const customCredentials = clientId && clientSecret ? { clientId, clientSecret } : undefined;
-  const usesCustomInstance = !!instanceUrl && instanceUrl !== DEFAULT_GITLAB_OAUTH_INSTANCE_URL;
+  const normalizedInstanceUrl = instanceUrl ? normalizeGitLabInstanceUrl(instanceUrl) : undefined;
+  const usesCustomInstance =
+    !!normalizedInstanceUrl && !isDefaultGitLabInstanceUrl(normalizedInstanceUrl);
 
   if (usesCustomInstance && !customCredentials) {
     throw new Error('Custom GitLab OAuth credentials are required for self-hosted instances');
@@ -182,14 +185,14 @@ async function buildGitLabConnectOAuthUrl(
   const state = createGitLabOAuthState(
     {
       owner,
-      ...(usesCustomInstance ? { instanceUrl } : {}),
+      ...(usesCustomInstance ? { instanceUrl: normalizedInstanceUrl } : {}),
       ...(customCredentialsRef ? { customCredentialsRef } : {}),
       ...(returnTo ? { returnTo } : {}),
     },
     user.id
   );
 
-  return buildGitLabOAuthUrl(state, instanceUrl, customCredentials);
+  return buildGitLabOAuthUrl(state, normalizedInstanceUrl, customCredentials);
 }
 
 async function resolveGitLabOAuthOwner(

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
@@ -809,6 +809,24 @@ describe('deleteProjectWebhook', () => {
       expect.any(Function)
     );
   });
+
+  it('preserves DELETE methods across 302 redirects', async () => {
+    mockSelfHostedGitLabResponse({
+      status: 302,
+      headers: { location: 'https://gitlab.example.com/api/v4/projects/123/hooks/456' },
+    });
+    mockSelfHostedGitLabResponse({ status: 204, body: '' });
+
+    await expect(
+      deleteProjectWebhook('test-token', 123, 456, 'https://gitlab.example.com')
+    ).resolves.toBeUndefined();
+
+    expect(mockHttpsRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ method: 'DELETE' }),
+      expect.any(Function)
+    );
+  });
 });
 
 describe('createProjectWebhook', () => {

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
@@ -15,6 +15,7 @@ import {
   refreshGitLabOAuthToken,
   validateGitLabInstance,
   validatePersonalAccessToken,
+  createProjectWebhook,
   deleteProjectWebhook,
   searchGitLabProjects,
   normalizeGitLabSearchQuery,
@@ -807,6 +808,31 @@ describe('deleteProjectWebhook', () => {
       }),
       expect.any(Function)
     );
+  });
+});
+
+describe('createProjectWebhook', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('rejects cross-origin 307 redirects before replaying request bodies', async () => {
+    mockSelfHostedGitLabResponse({
+      status: 307,
+      headers: { location: 'https://redirect.example/api/v4/projects/123/hooks' },
+    });
+
+    await expect(
+      createProjectWebhook(
+        'test-token',
+        123,
+        'https://example.com/webhook',
+        'webhook-secret',
+        'https://gitlab.example.com'
+      )
+    ).rejects.toThrow('GitLab request refused cross-origin redirect with request body');
+
+    expect(mockHttpsRequest).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
@@ -56,9 +56,11 @@ function mockSelfHostedGitLabResponse(args: {
       write: jest.Mock;
       end: jest.Mock;
       destroy: jest.Mock;
+      setTimeout: jest.Mock;
     };
     request.write = jest.fn();
     request.destroy = jest.fn();
+    request.setTimeout = jest.fn();
     request.end = jest.fn(() => {
       callback?.(response as never);
       if (args.responseError) {
@@ -78,9 +80,11 @@ function mockSelfHostedGitLabError(error: Error) {
       write: jest.Mock;
       end: jest.Mock;
       destroy: jest.Mock;
+      setTimeout: jest.Mock;
     };
     request.write = jest.fn();
     request.destroy = jest.fn();
+    request.setTimeout = jest.fn();
     request.end = jest.fn(() => {
       request.emit('error', error);
     });
@@ -787,6 +791,14 @@ describe('deleteProjectWebhook', () => {
     await expect(
       deleteProjectWebhook('test-token', 123, 456, 'https://gitlab.example.com')
     ).rejects.toThrow('response interrupted');
+  });
+
+  it('rejects oversized self-hosted responses', async () => {
+    mockSelfHostedGitLabResponse({ status: 200, body: 'x'.repeat(10 * 1024 * 1024 + 1) });
+
+    await expect(
+      deleteProjectWebhook('test-token', 123, 456, 'https://gitlab.example.com')
+    ).rejects.toThrow('GitLab response exceeded size limit');
   });
 
   it('strips authorization headers when redirects change origin', async () => {

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
@@ -1,8 +1,21 @@
+jest.mock('dns/promises', () => ({
+  lookup: jest.fn(),
+}));
+jest.mock('https', () => ({
+  request: jest.fn(),
+}));
+
+import { lookup } from 'dns/promises';
+import { EventEmitter } from 'events';
+import * as https from 'https';
+import { PassThrough } from 'stream';
 import {
   buildGitLabOAuthUrl,
   exchangeGitLabOAuthCode,
   refreshGitLabOAuthToken,
   validateGitLabInstance,
+  validatePersonalAccessToken,
+  deleteProjectWebhook,
   searchGitLabProjects,
   normalizeGitLabSearchQuery,
   fetchGitLabRootTextFileAtRef,
@@ -11,6 +24,64 @@ import {
 // Mock fetch globally
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
+const mockLookup = lookup as jest.Mock;
+const mockHttpsRequest = https.request as jest.Mock;
+
+beforeEach(() => {
+  mockLookup.mockReset();
+  mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+  mockHttpsRequest.mockReset();
+});
+
+function mockSelfHostedGitLabResponse(args: {
+  status: number;
+  body?: string;
+  json?: unknown;
+  statusMessage?: string;
+  headers?: Record<string, string>;
+}) {
+  mockHttpsRequest.mockImplementationOnce((_options, callback) => {
+    const response = new PassThrough() as PassThrough & {
+      statusCode?: number;
+      statusMessage?: string;
+      headers: Record<string, string>;
+    };
+    response.statusCode = args.status;
+    response.statusMessage = args.statusMessage ?? 'OK';
+    response.headers = { 'content-type': 'application/json', ...args.headers };
+
+    const request = new EventEmitter() as EventEmitter & {
+      write: jest.Mock;
+      end: jest.Mock;
+      destroy: jest.Mock;
+    };
+    request.write = jest.fn();
+    request.destroy = jest.fn();
+    request.end = jest.fn(() => {
+      callback?.(response as never);
+      response.end(args.body ?? JSON.stringify(args.json ?? {}));
+    });
+
+    return request as never;
+  });
+}
+
+function mockSelfHostedGitLabError(error: Error) {
+  mockHttpsRequest.mockImplementationOnce(() => {
+    const request = new EventEmitter() as EventEmitter & {
+      write: jest.Mock;
+      end: jest.Mock;
+      destroy: jest.Mock;
+    };
+    request.write = jest.fn();
+    request.destroy = jest.fn();
+    request.end = jest.fn(() => {
+      request.emit('error', error);
+    });
+
+    return request as never;
+  });
+}
 
 describe('normalizeGitLabSearchQuery', () => {
   it('should extract project path from full GitLab URL', () => {
@@ -111,14 +182,14 @@ describe('validateGitLabInstance', () => {
   });
 
   it('should return valid for a valid GitLab instance', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
+    mockSelfHostedGitLabResponse({
+      status: 200,
+      json: {
         version: '16.8.0',
         revision: 'abc123',
         kas: { enabled: true, externalUrl: null, version: null },
         enterprise: false,
-      }),
+      },
     });
 
     const result = await validateGitLabInstance('https://gitlab.example.com');
@@ -128,24 +199,26 @@ describe('validateGitLabInstance', () => {
     expect(result.revision).toBe('abc123');
     expect(result.enterprise).toBe(false);
     expect(result.error).toBeUndefined();
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://gitlab.example.com/api/v4/version',
+    expect(mockHttpsRequest).toHaveBeenCalledWith(
       expect.objectContaining({
+        hostname: 'gitlab.example.com',
+        lookup: expect.any(Function),
         method: 'GET',
-        headers: { Accept: 'application/json' },
-      })
+        headers: { accept: 'application/json' },
+      }),
+      expect.any(Function)
     );
   });
 
   it('should return valid for GitLab Enterprise Edition', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
+    mockSelfHostedGitLabResponse({
+      status: 200,
+      json: {
         version: '16.8.0-ee',
         revision: 'abc123',
         kas: { enabled: true, externalUrl: null, version: null },
         enterprise: true,
-      }),
+      },
     });
 
     const result = await validateGitLabInstance('https://gitlab.example.com');
@@ -156,29 +229,26 @@ describe('validateGitLabInstance', () => {
   });
 
   it('should normalize URL by removing trailing slash', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
+    mockSelfHostedGitLabResponse({
+      status: 200,
+      json: {
         version: '16.8.0',
         revision: 'abc123',
         kas: { enabled: true, externalUrl: null, version: null },
         enterprise: false,
-      }),
+      },
     });
 
     await validateGitLabInstance('https://gitlab.example.com/');
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://gitlab.example.com/api/v4/version',
-      expect.anything()
+    expect(mockHttpsRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/api/v4/version' }),
+      expect.any(Function)
     );
   });
 
   it('should return valid with warning when version endpoint requires auth (401)', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 401,
-    });
+    mockSelfHostedGitLabResponse({ status: 401 });
 
     const result = await validateGitLabInstance('https://gitlab.example.com');
 
@@ -187,10 +257,7 @@ describe('validateGitLabInstance', () => {
   });
 
   it('should return valid with warning when version endpoint requires auth (403)', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 403,
-    });
+    mockSelfHostedGitLabResponse({ status: 403 });
 
     const result = await validateGitLabInstance('https://gitlab.example.com');
 
@@ -199,12 +266,11 @@ describe('validateGitLabInstance', () => {
   });
 
   it('should return invalid for non-GitLab responses', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        // Not a GitLab version response
+    mockSelfHostedGitLabResponse({
+      status: 200,
+      json: {
         name: 'Some other API',
-      }),
+      },
     });
 
     const result = await validateGitLabInstance('https://not-gitlab.example.com');
@@ -214,15 +280,48 @@ describe('validateGitLabInstance', () => {
   });
 
   it('should return invalid for 404 responses', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-    });
+    mockSelfHostedGitLabResponse({ status: 404 });
 
     const result = await validateGitLabInstance('https://not-gitlab.example.com');
 
     expect(result.valid).toBe(false);
     expect(result.error).toContain('returned status 404');
+  });
+
+  it('should follow self-hosted redirects after revalidating each destination', async () => {
+    mockSelfHostedGitLabResponse({
+      status: 302,
+      headers: { location: 'https://gitlab.example.com/gitlab/api/v4/version' },
+    });
+    mockSelfHostedGitLabResponse({
+      status: 200,
+      json: {
+        version: '16.8.0',
+        revision: 'abc123',
+        kas: { enabled: true, externalUrl: null, version: null },
+        enterprise: false,
+      },
+    });
+
+    const result = await validateGitLabInstance('https://gitlab.example.com');
+
+    expect(result.valid).toBe(true);
+    expect(mockHttpsRequest).toHaveBeenCalledTimes(2);
+    expect(mockLookup).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reject redirects to unsafe literal IP addresses before fetching them', async () => {
+    mockSelfHostedGitLabResponse({
+      status: 302,
+      headers: { location: 'https://127.0.0.1/api/v4/version' },
+    });
+
+    const result = await validateGitLabInstance('https://gitlab.example.com');
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('host is not allowed');
+    expect(mockHttpsRequest).toHaveBeenCalledTimes(1);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('should return invalid for invalid URL format', async () => {
@@ -241,8 +340,39 @@ describe('validateGitLabInstance', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it('should return invalid for unsafe hosts before fetching', async () => {
+    const result = await validateGitLabInstance('http://127.0.0.1:8080');
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('host is not allowed');
+    expect(mockLookup).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('should return invalid when hostnames resolve to unsafe addresses before fetching', async () => {
+    mockLookup.mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }]);
+
+    const result = await validateGitLabInstance('https://gitlab.example.com');
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('resolves to an address that is not allowed');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('should return invalid for URLs with credentials before fetching', async () => {
+    const urlWithCredentials = new URL('https://gitlab.example.com');
+    urlWithCredentials.username = 'user';
+    urlWithCredentials.password = 'pass';
+
+    const result = await validateGitLabInstance(urlWithCredentials.toString());
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('must not include credentials');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it('should handle network errors gracefully', async () => {
-    mockFetch.mockRejectedValueOnce(new TypeError('fetch failed'));
+    mockSelfHostedGitLabError(new TypeError('fetch failed'));
 
     const result = await validateGitLabInstance('https://unreachable.example.com');
 
@@ -253,7 +383,7 @@ describe('validateGitLabInstance', () => {
   it('should handle timeout errors', async () => {
     const timeoutError = new Error('Timeout');
     timeoutError.name = 'TimeoutError';
-    mockFetch.mockRejectedValueOnce(timeoutError);
+    mockSelfHostedGitLabError(timeoutError);
 
     const result = await validateGitLabInstance('https://slow.example.com');
 
@@ -320,16 +450,16 @@ describe('searchGitLabProjects', () => {
   });
 
   it('should use custom instance URL', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    });
+    mockSelfHostedGitLabResponse({ status: 200, json: [] });
 
     await searchGitLabProjects('test-token', 'query', 'https://gitlab.example.com');
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://gitlab.example.com/api/v4/projects?membership=true&search=query&per_page=20&archived=false',
-      expect.anything()
+    expect(mockHttpsRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostname: 'gitlab.example.com',
+        path: '/api/v4/projects?membership=true&search=query&per_page=20&archived=false',
+      }),
+      expect.any(Function)
     );
   });
 
@@ -548,10 +678,9 @@ describe('fetchGitLabRootTextFileAtRef', () => {
   });
 
   it('fetches root text file content from the requested ref', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
+    mockSelfHostedGitLabResponse({
       status: 200,
-      text: async () => '# Review policy\n\nFlag only regressions.',
+      body: '# Review policy\n\nFlag only regressions.',
     });
 
     const result = await fetchGitLabRootTextFileAtRef(
@@ -563,13 +692,15 @@ describe('fetchGitLabRootTextFileAtRef', () => {
     );
 
     expect(result).toBe('# Review policy\n\nFlag only regressions.');
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://gitlab.example.com/api/v4/projects/group%2Fsubgroup%2Fproject/repository/files/REVIEW.md/raw?ref=main',
+    expect(mockHttpsRequest).toHaveBeenCalledWith(
       expect.objectContaining({
+        hostname: 'gitlab.example.com',
+        path: '/api/v4/projects/group%2Fsubgroup%2Fproject/repository/files/REVIEW.md/raw?ref=main',
         headers: {
-          Authorization: 'Bearer test-token',
+          authorization: 'Bearer test-token',
         },
-      })
+      }),
+      expect.any(Function)
     );
   });
 
@@ -617,5 +748,76 @@ describe('fetchGitLabRootTextFileAtRef', () => {
     await expect(
       fetchGitLabRootTextFileAtRef('test-token', 'group/project', 'REVIEW.md', 'main')
     ).rejects.toThrow('GitLab repository file fetch failed: 500');
+  });
+});
+
+describe('deleteProjectWebhook', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('handles self-hosted 204 no-content responses', async () => {
+    mockSelfHostedGitLabResponse({ status: 204, body: '' });
+
+    await expect(
+      deleteProjectWebhook('test-token', 123, 456, 'https://gitlab.example.com')
+    ).resolves.toBeUndefined();
+
+    expect(mockHttpsRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'DELETE',
+        path: '/api/v4/projects/123/hooks/456',
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('strips authorization headers when redirects change origin', async () => {
+    mockSelfHostedGitLabResponse({
+      status: 307,
+      headers: { location: 'https://gitlab.example.com:8443/api/v4/projects/123/hooks/456' },
+    });
+    mockSelfHostedGitLabResponse({ status: 204, body: '' });
+
+    await expect(
+      deleteProjectWebhook('test-token', 123, 456, 'https://gitlab.example.com')
+    ).resolves.toBeUndefined();
+
+    expect(mockHttpsRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        headers: expect.not.objectContaining({ authorization: 'Bearer test-token' }),
+        port: '8443',
+      }),
+      expect.any(Function)
+    );
+  });
+});
+
+describe('validatePersonalAccessToken', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('rejects unsafe instance URLs before fetching', async () => {
+    const result = await validatePersonalAccessToken('pat-token', 'http://169.254.169.254');
+
+    expect(result).toEqual({
+      valid: false,
+      error: 'GitLab instance URL host is not allowed.',
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects instance URLs that resolve to unsafe addresses before fetching', async () => {
+    mockLookup.mockResolvedValueOnce([{ address: '10.0.0.1', family: 4 }]);
+
+    const result = await validatePersonalAccessToken('pat-token', 'https://gitlab.example.com');
+
+    expect(result).toEqual({
+      valid: false,
+      error: 'GitLab instance URL host resolves to an address that is not allowed.',
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
@@ -39,6 +39,7 @@ function mockSelfHostedGitLabResponse(args: {
   json?: unknown;
   statusMessage?: string;
   headers?: Record<string, string>;
+  responseError?: Error;
 }) {
   mockHttpsRequest.mockImplementationOnce((_options, callback) => {
     const response = new PassThrough() as PassThrough & {
@@ -59,6 +60,10 @@ function mockSelfHostedGitLabResponse(args: {
     request.destroy = jest.fn();
     request.end = jest.fn(() => {
       callback?.(response as never);
+      if (args.responseError) {
+        response.emit('error', args.responseError);
+        return;
+      }
       response.end(args.body ?? JSON.stringify(args.json ?? {}));
     });
 
@@ -770,6 +775,17 @@ describe('deleteProjectWebhook', () => {
       }),
       expect.any(Function)
     );
+  });
+
+  it('rejects self-hosted response stream errors', async () => {
+    mockSelfHostedGitLabResponse({
+      status: 200,
+      responseError: new Error('response interrupted'),
+    });
+
+    await expect(
+      deleteProjectWebhook('test-token', 123, 456, 'https://gitlab.example.com')
+    ).rejects.toThrow('response interrupted');
   });
 
   it('strips authorization headers when redirects change origin', async () => {

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
@@ -11,12 +11,226 @@ import type { PlatformRepository } from '@/lib/integrations/core/types';
 import { getPlatformOAuthCallbackUrl } from '@/lib/integrations/oauth/urls';
 import { logExceptInTest } from '@/lib/utils.server';
 import crypto from 'crypto';
+import * as http from 'http';
+import * as https from 'https';
+import {
+  buildGitLabUrl,
+  DEFAULT_GITLAB_INSTANCE_URL,
+  type GitLabResolvedUrl,
+  GitLabInstanceUrlError,
+  isDefaultGitLabInstanceUrl,
+  normalizeGitLabInstanceUrl,
+  resolveGitLabUrlSafely,
+} from './instance-url';
 
 const GITLAB_CLIENT_ID = process.env.GITLAB_CLIENT_ID;
 const GITLAB_CLIENT_SECRET = getEnvVariable('GITLAB_CLIENT_SECRET');
 const GITLAB_REDIRECT_URI = getPlatformOAuthCallbackUrl(PLATFORM.GITLAB);
 
-const DEFAULT_GITLAB_URL = 'https://gitlab.com';
+const DEFAULT_GITLAB_URL = DEFAULT_GITLAB_INSTANCE_URL;
+const MAX_GITLAB_REDIRECTS = 5;
+
+async function fetchGitLab(url: string, init?: RequestInit, redirectCount = 0): Promise<Response> {
+  const response = await fetchGitLabOnce(url, init);
+  if (!isGitLabRedirect(response.status)) {
+    return response;
+  }
+
+  const location = response.headers.get('location');
+  if (!location) {
+    return response;
+  }
+
+  if (redirectCount >= MAX_GITLAB_REDIRECTS) {
+    throw new Error('GitLab request exceeded redirect limit');
+  }
+
+  const redirectUrl = new URL(location, url).toString();
+  return fetchGitLab(
+    redirectUrl,
+    buildRedirectRequestInit(init, response.status, url, redirectUrl),
+    redirectCount + 1
+  );
+}
+
+async function fetchGitLabOnce(url: string, init?: RequestInit): Promise<Response> {
+  const resolvedUrl = await resolveGitLabUrlSafely(url);
+  if (!resolvedUrl.address) {
+    return fetch(url, { ...init, redirect: 'manual' });
+  }
+
+  return fetchGitLabBoundToAddress({ ...resolvedUrl, address: resolvedUrl.address }, init);
+}
+
+function isGitLabRedirect(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+function buildRedirectRequestInit(
+  init: RequestInit | undefined,
+  status: number,
+  fromUrl: string,
+  toUrl: string
+): RequestInit | undefined {
+  if (!init) {
+    return undefined;
+  }
+
+  const headers = new Headers(init.headers);
+  const from = new URL(fromUrl);
+  const to = new URL(toUrl);
+  if (from.protocol === 'https:' && to.protocol === 'http:') {
+    throw new Error('GitLab request refused HTTPS-to-HTTP redirect');
+  }
+
+  if (from.origin !== to.origin) {
+    headers.delete('authorization');
+    headers.delete('cookie');
+  }
+
+  const method = init.method?.toUpperCase() ?? 'GET';
+  if (
+    (status === 301 || status === 302 || status === 303) &&
+    method !== 'GET' &&
+    method !== 'HEAD'
+  ) {
+    headers.delete('content-length');
+    headers.delete('content-type');
+    return { ...init, body: undefined, headers, method: 'GET' };
+  }
+
+  return { ...init, headers };
+}
+
+function fetchGitLabBoundToAddress(
+  { url, address, family }: GitLabResolvedUrl & { address: string },
+  init?: RequestInit
+): Promise<Response> {
+  const request = url.protocol === 'https:' ? https.request : http.request;
+  const headers = headersInitToRecord(init?.headers);
+  const body = bodyInitToBuffer(init?.body);
+
+  if (body && !hasHeader(headers, 'content-length')) {
+    headers['content-length'] = String(Buffer.byteLength(body));
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port,
+        path: `${url.pathname}${url.search}`,
+        method: init?.method ?? 'GET',
+        headers,
+        family,
+        lookup: (_hostname, _options, callback) => callback(null, address, family ?? 0),
+        ...(url.protocol === 'https:' ? { servername: url.hostname } : {}),
+      },
+      response => {
+        const chunks: Buffer[] = [];
+        response.on('data', chunk => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        response.on('end', () => {
+          try {
+            const status = response.statusCode ?? 500;
+            const body = responseStatusForbidsBody(status) ? null : Buffer.concat(chunks);
+            resolve(
+              new Response(body, {
+                status,
+                statusText: response.statusMessage,
+                headers: responseHeadersToHeaders(response.headers),
+              })
+            );
+          } catch (error) {
+            reject(error);
+          }
+        });
+      }
+    );
+
+    req.on('error', reject);
+
+    const signal = init?.signal;
+    if (signal) {
+      if (signal.aborted) {
+        req.destroy(signal.reason);
+        reject(signal.reason);
+        return;
+      }
+
+      signal.addEventListener(
+        'abort',
+        () => {
+          req.destroy(signal.reason);
+          reject(signal.reason);
+        },
+        { once: true }
+      );
+    }
+
+    if (body) {
+      req.write(body);
+    }
+    req.end();
+  });
+}
+
+function headersInitToRecord(headers: HeadersInit | undefined): Record<string, string> {
+  const record: Record<string, string> = {};
+  new Headers(headers).forEach((value, key) => {
+    record[key] = value;
+  });
+  return record;
+}
+
+function hasHeader(headers: Record<string, string>, header: string): boolean {
+  const lowerHeader = header.toLowerCase();
+  return Object.keys(headers).some(key => key.toLowerCase() === lowerHeader);
+}
+
+function bodyInitToBuffer(body: BodyInit | null | undefined): Buffer | undefined {
+  if (body == null) {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return Buffer.from(body);
+  }
+
+  if (body instanceof URLSearchParams) {
+    return Buffer.from(body.toString());
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return Buffer.from(body);
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+  }
+
+  throw new Error('Unsupported GitLab request body type');
+}
+
+function responseStatusForbidsBody(status: number): boolean {
+  return status === 204 || status === 205 || status === 304;
+}
+
+function responseHeadersToHeaders(headers: http.IncomingHttpHeaders): Headers {
+  const responseHeaders = new Headers();
+  for (const [key, value] of Object.entries(headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        responseHeaders.append(key, item);
+      }
+    } else if (value !== undefined) {
+      responseHeaders.set(key, value);
+    }
+  }
+  return responseHeaders;
+}
 
 /**
  * GitLab OAuth scopes required for the integration
@@ -85,7 +299,8 @@ export function buildGitLabOAuthUrl(
   instanceUrl: string = DEFAULT_GITLAB_URL,
   customCredentials?: GitLabOAuthCredentials
 ): string {
-  if (instanceUrl !== DEFAULT_GITLAB_URL && !customCredentials) {
+  const normalizedInstanceUrl = normalizeGitLabInstanceUrl(instanceUrl);
+  if (!isDefaultGitLabInstanceUrl(normalizedInstanceUrl) && !customCredentials) {
     throw new Error('Custom GitLab OAuth credentials are required for self-hosted instances');
   }
 
@@ -103,7 +318,7 @@ export function buildGitLabOAuthUrl(
     scope: GITLAB_OAUTH_SCOPES.join(' '),
   });
 
-  return `${instanceUrl}/oauth/authorize?${params.toString()}`;
+  return buildGitLabUrl(normalizedInstanceUrl, '/oauth/authorize', Object.fromEntries(params));
 }
 
 /**
@@ -118,7 +333,8 @@ export async function exchangeGitLabOAuthCode(
   instanceUrl: string = DEFAULT_GITLAB_URL,
   customCredentials?: GitLabOAuthCredentials
 ): Promise<GitLabOAuthTokens> {
-  if (instanceUrl !== DEFAULT_GITLAB_URL && !customCredentials) {
+  const normalizedInstanceUrl = normalizeGitLabInstanceUrl(instanceUrl);
+  if (!isDefaultGitLabInstanceUrl(normalizedInstanceUrl) && !customCredentials) {
     throw new Error('Custom GitLab OAuth credentials are required for self-hosted instances');
   }
 
@@ -129,7 +345,7 @@ export async function exchangeGitLabOAuthCode(
     throw new Error('GitLab OAuth credentials not configured');
   }
 
-  const response = await fetch(`${instanceUrl}/oauth/token`, {
+  const response = await fetchGitLab(buildGitLabUrl(normalizedInstanceUrl, '/oauth/token'), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -173,7 +389,8 @@ export async function refreshGitLabOAuthToken(
   instanceUrl: string = DEFAULT_GITLAB_URL,
   customCredentials?: GitLabOAuthCredentials
 ): Promise<GitLabOAuthTokens> {
-  if (instanceUrl !== DEFAULT_GITLAB_URL && !customCredentials) {
+  const normalizedInstanceUrl = normalizeGitLabInstanceUrl(instanceUrl);
+  if (!isDefaultGitLabInstanceUrl(normalizedInstanceUrl) && !customCredentials) {
     throw new Error('Custom GitLab OAuth credentials are required for self-hosted instances');
   }
 
@@ -184,7 +401,7 @@ export async function refreshGitLabOAuthToken(
     throw new Error('GitLab OAuth credentials not configured');
   }
 
-  const response = await fetch(`${instanceUrl}/oauth/token`, {
+  const response = await fetchGitLab(buildGitLabUrl(normalizedInstanceUrl, '/oauth/token'), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -224,7 +441,7 @@ export async function fetchGitLabUser(
   accessToken: string,
   instanceUrl: string = DEFAULT_GITLAB_URL
 ): Promise<GitLabUser> {
-  const response = await fetch(`${instanceUrl}/api/v4/user`, {
+  const response = await fetchGitLab(buildGitLabUrl(instanceUrl, '/api/v4/user'), {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
@@ -254,8 +471,13 @@ export async function fetchGitLabProjects(
   const perPage = 100;
 
   while (true) {
-    const response = await fetch(
-      `${instanceUrl}/api/v4/projects?membership=true&per_page=${perPage}&page=${page}&archived=false`,
+    const response = await fetchGitLab(
+      buildGitLabUrl(instanceUrl, '/api/v4/projects', {
+        membership: true,
+        per_page: perPage,
+        page,
+        archived: false,
+      }),
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -346,11 +568,14 @@ async function fetchProjectByPath(
 ): Promise<PlatformRepository | null> {
   const encodedPath = encodeURIComponent(projectPath);
 
-  const response = await fetch(`${instanceUrl}/api/v4/projects/${encodedPath}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedPath}`),
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
 
   if (!response.ok) {
     // 404 means project not found or no access - this is expected
@@ -432,8 +657,13 @@ export async function searchGitLabProjects(
     });
   }
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects?membership=true&search=${encodeURIComponent(normalizedQuery)}&per_page=${limit}&archived=false`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, '/api/v4/projects', {
+      membership: true,
+      search: normalizedQuery,
+      per_page: limit,
+      archived: false,
+    }),
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -484,8 +714,11 @@ export async function fetchGitLabBranches(
   const perPage = 100;
 
   while (true) {
-    const response = await fetch(
-      `${instanceUrl}/api/v4/projects/${encodedProjectId}/repository/branches?per_page=${perPage}&page=${page}`,
+    const response = await fetchGitLab(
+      buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/repository/branches`, {
+        per_page: perPage,
+        page,
+      }),
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -526,9 +759,12 @@ export async function fetchGitLabRootTextFileAtRef(
 ): Promise<string | null> {
   const encodedProjectPath = encodeURIComponent(projectPath);
   const encodedFilePath = encodeURIComponent(filePath);
-  const baseUrl = instanceUrl.replace(/\/$/, '');
-  const response = await fetch(
-    `${baseUrl}/api/v4/projects/${encodedProjectPath}/repository/files/${encodedFilePath}/raw?ref=${encodeURIComponent(ref)}`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(
+      instanceUrl,
+      `/api/v4/projects/${encodedProjectPath}/repository/files/${encodedFilePath}/raw`,
+      { ref }
+    ),
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -665,11 +901,14 @@ export async function listProjectWebhooks(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(`${instanceUrl}/api/v4/projects/${encodedProjectId}/hooks`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/hooks`),
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
 
   if (!response.ok) {
     const error = await response.text();
@@ -714,32 +953,35 @@ export async function createProjectWebhook(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(`${instanceUrl}/api/v4/projects/${encodedProjectId}/hooks`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      name: 'Kilo Code Reviews',
-      description: 'Auto-configured webhook for Kilo AI code reviews',
-      url: webhookUrl,
-      token: webhookSecret,
-      merge_requests_events: true,
-      push_events: false,
-      issues_events: false,
-      confidential_issues_events: false,
-      tag_push_events: false,
-      note_events: false,
-      confidential_note_events: false,
-      job_events: false,
-      pipeline_events: false,
-      wiki_page_events: false,
-      deployment_events: false,
-      releases_events: false,
-      enable_ssl_verification: true,
-    }),
-  });
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/hooks`),
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'Kilo Code Reviews',
+        description: 'Auto-configured webhook for Kilo AI code reviews',
+        url: webhookUrl,
+        token: webhookSecret,
+        merge_requests_events: true,
+        push_events: false,
+        issues_events: false,
+        confidential_issues_events: false,
+        tag_push_events: false,
+        note_events: false,
+        confidential_note_events: false,
+        job_events: false,
+        pipeline_events: false,
+        wiki_page_events: false,
+        deployment_events: false,
+        releases_events: false,
+        enable_ssl_verification: true,
+      }),
+    }
+  );
 
   if (!response.ok) {
     const error = await response.text();
@@ -794,8 +1036,8 @@ export async function updateProjectWebhook(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects/${encodedProjectId}/hooks/${hookId}`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/hooks/${hookId}`),
     {
       method: 'PUT',
       headers: {
@@ -873,8 +1115,8 @@ export async function deleteProjectWebhook(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects/${encodedProjectId}/hooks/${hookId}`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/hooks/${hookId}`),
     {
       method: 'DELETE',
       headers: {
@@ -977,8 +1219,11 @@ export async function isMergeCommit(
     const encodedProjectId =
       typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-    const response = await fetch(
-      `${instanceUrl}/api/v4/projects/${encodedProjectId}/repository/commits/${commitSha}`,
+    const response = await fetchGitLab(
+      buildGitLabUrl(
+        instanceUrl,
+        `/api/v4/projects/${encodedProjectId}/repository/commits/${commitSha}`
+      ),
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -1112,8 +1357,12 @@ export async function findKiloReviewNote(
   const perPage = 100;
 
   while (true) {
-    const response = await fetch(
-      `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/notes?per_page=${perPage}&page=${page}`,
+    const response = await fetchGitLab(
+      buildGitLabUrl(
+        instanceUrl,
+        `/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/notes`,
+        { per_page: perPage, page }
+      ),
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -1184,8 +1433,11 @@ export async function updateKiloReviewNote(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/notes/${noteId}`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(
+      instanceUrl,
+      `/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/notes/${noteId}`
+    ),
     {
       method: 'PUT',
       headers: {
@@ -1221,8 +1473,11 @@ export async function createMRNote(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/notes`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(
+      instanceUrl,
+      `/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/notes`
+    ),
     {
       method: 'POST',
       headers: {
@@ -1259,8 +1514,12 @@ export async function hasMRNoteWithMarker(
   const perPage = 100;
 
   while (true) {
-    const response = await fetch(
-      `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/notes?per_page=${perPage}&page=${page}`,
+    const response = await fetchGitLab(
+      buildGitLabUrl(
+        instanceUrl,
+        `/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/notes`,
+        { per_page: perPage, page }
+      ),
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -1319,8 +1578,12 @@ export async function fetchMRInlineComments(
   const perPage = 100;
 
   while (true) {
-    const response = await fetch(
-      `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/discussions?per_page=${perPage}&page=${page}`,
+    const response = await fetchGitLab(
+      buildGitLabUrl(
+        instanceUrl,
+        `/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/discussions`,
+        { per_page: perPage, page }
+      ),
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -1401,8 +1664,8 @@ export async function getMRHeadCommit(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}`),
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -1445,8 +1708,8 @@ export async function getMRDiffRefs(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}`),
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -1497,8 +1760,11 @@ export async function addReactionToMR(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/award_emoji`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(
+      instanceUrl,
+      `/api/v4/projects/${encodedProjectId}/merge_requests/${mrIid}/award_emoji`
+    ),
     {
       method: 'POST',
       headers: {
@@ -1546,11 +1812,14 @@ export async function getGitLabProject(
 ): Promise<GitLabProject> {
   const encodedPath = encodeURIComponent(projectPath);
 
-  const response = await fetch(`${instanceUrl}/api/v4/projects/${encodedPath}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedPath}`),
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
 
   if (!response.ok) {
     const error = await response.text();
@@ -1602,44 +1871,29 @@ export type GitLabInstanceValidationResult = {
 export async function validateGitLabInstance(
   instanceUrl: string
 ): Promise<GitLabInstanceValidationResult> {
-  // Normalize the URL
-  let normalizedUrl = instanceUrl.trim();
-
-  // Remove trailing slash if present
-  if (normalizedUrl.endsWith('/')) {
-    normalizedUrl = normalizedUrl.slice(0, -1);
-  }
-
-  // Validate URL format
+  let normalizedUrl: string;
   try {
-    const url = new URL(normalizedUrl);
-    if (!['http:', 'https:'].includes(url.protocol)) {
-      return {
-        valid: false,
-        error: 'Invalid URL protocol. Must be http or https.',
-      };
-    }
-  } catch {
+    normalizedUrl = normalizeGitLabInstanceUrl(instanceUrl);
+  } catch (error) {
     return {
       valid: false,
-      error: 'Invalid URL format.',
+      error: error instanceof GitLabInstanceUrlError ? error.message : 'Invalid URL format.',
     };
   }
 
   try {
     // The /api/v4/version endpoint is public and doesn't require authentication
-    const response = await fetch(`${normalizedUrl}/api/v4/version`, {
+    const response = await fetchGitLab(buildGitLabUrl(normalizedUrl, '/api/v4/version'), {
       method: 'GET',
       headers: {
         Accept: 'application/json',
       },
+      redirect: 'manual',
       // Set a reasonable timeout for the request
       signal: AbortSignal.timeout(10000),
     });
 
     if (!response.ok) {
-      // 401/403 still indicates a valid GitLab instance (just requires auth for version)
-      // Some self-hosted instances may restrict the version endpoint
       if (response.status === 401 || response.status === 403) {
         logExceptInTest(
           '[validateGitLabInstance] Version endpoint requires auth, but instance is valid',
@@ -1688,6 +1942,13 @@ export async function validateGitLabInstance(
       enterprise: data.enterprise,
     };
   } catch (error) {
+    if (error instanceof GitLabInstanceUrlError) {
+      return {
+        valid: false,
+        error: error.message,
+      };
+    }
+
     // Handle timeout
     if (error instanceof Error && error.name === 'TimeoutError') {
       return {
@@ -1802,19 +2063,22 @@ export async function createProjectAccessToken(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(`${instanceUrl}/api/v4/projects/${encodedProjectId}/access_tokens`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      name: tokenName,
-      scopes,
-      access_level: accessLevel,
-      expires_at: expiresAt,
-    }),
-  });
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/access_tokens`),
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: tokenName,
+        scopes,
+        access_level: accessLevel,
+        expires_at: expiresAt,
+      }),
+    }
+  );
 
   if (!response.ok) {
     const error = await response.text();
@@ -1875,11 +2139,14 @@ export async function listProjectAccessTokens(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(`${instanceUrl}/api/v4/projects/${encodedProjectId}/access_tokens`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/access_tokens`),
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
 
   if (!response.ok) {
     const error = await response.text();
@@ -1929,8 +2196,8 @@ export async function getProjectAccessToken(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects/${encodedProjectId}/access_tokens/${tokenId}`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/access_tokens/${tokenId}`),
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -1985,8 +2252,11 @@ export async function rotateProjectAccessToken(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects/${encodedProjectId}/access_tokens/${tokenId}/rotate`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(
+      instanceUrl,
+      `/api/v4/projects/${encodedProjectId}/access_tokens/${tokenId}/rotate`
+    ),
     {
       method: 'POST',
       headers: {
@@ -2055,8 +2325,8 @@ export async function revokeProjectAccessToken(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects/${encodedProjectId}/access_tokens/${tokenId}`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/access_tokens/${tokenId}`),
     {
       method: 'DELETE',
       headers: {
@@ -2182,7 +2452,7 @@ export async function validateProjectAccessToken(
   try {
     // Use the /user endpoint to validate the token
     // This is a lightweight call that works with any valid token
-    const response = await fetch(`${instanceUrl}/api/v4/user`, {
+    const response = await fetchGitLab(buildGitLabUrl(instanceUrl, '/api/v4/user'), {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -2204,6 +2474,13 @@ export async function validateProjectAccessToken(
     });
     return true;
   } catch (error) {
+    if (error instanceof GitLabInstanceUrlError) {
+      logExceptInTest('[validateProjectAccessToken] Invalid GitLab instance URL', {
+        error: error.message,
+      });
+      return false;
+    }
+
     // Network errors - assume token might still be valid
     logExceptInTest('[validateProjectAccessToken] Error validating token', {
       error: error instanceof Error ? error.message : String(error),
@@ -2282,13 +2559,37 @@ export async function validatePersonalAccessToken(
 ): Promise<GitLabPATValidationResult> {
   const warnings: string[] = [];
 
+  let tokenInfoUrl: string;
+  let userUrl: string;
+  try {
+    tokenInfoUrl = buildGitLabUrl(instanceUrl, '/api/v4/personal_access_tokens/self');
+    userUrl = buildGitLabUrl(instanceUrl, '/api/v4/user');
+  } catch (error) {
+    return {
+      valid: false,
+      error: error instanceof GitLabInstanceUrlError ? error.message : 'Invalid URL format.',
+    };
+  }
+
   // Step 1: Get token info from /api/v4/personal_access_tokens/self
   // This endpoint requires GitLab 14.0+
-  const tokenInfoResponse = await fetch(`${instanceUrl}/api/v4/personal_access_tokens/self`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  let tokenInfoResponse: Response;
+  try {
+    tokenInfoResponse = await fetchGitLab(tokenInfoUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch (error) {
+    if (error instanceof GitLabInstanceUrlError) {
+      return {
+        valid: false,
+        error: error.message,
+      };
+    }
+
+    throw error;
+  }
 
   if (!tokenInfoResponse.ok) {
     if (tokenInfoResponse.status === 401) {
@@ -2377,11 +2678,23 @@ export async function validatePersonalAccessToken(
   }
 
   // Step 4: Fetch user info
-  const userResponse = await fetch(`${instanceUrl}/api/v4/user`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  let userResponse: Response;
+  try {
+    userResponse = await fetchGitLab(userUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch (error) {
+    if (error instanceof GitLabInstanceUrlError) {
+      return {
+        valid: false,
+        error: error.message,
+      };
+    }
+
+    throw error;
+  }
 
   if (!userResponse.ok) {
     const errorText = await userResponse.text();
@@ -2463,8 +2776,8 @@ export async function setCommitStatus(
   const encodedProjectId =
     typeof projectId === 'string' ? encodeURIComponent(projectId) : projectId;
 
-  const response = await fetch(
-    `${instanceUrl}/api/v4/projects/${encodedProjectId}/statuses/${sha}`,
+  const response = await fetchGitLab(
+    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedProjectId}/statuses/${sha}`),
     {
       method: 'POST',
       headers: {

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
@@ -132,6 +132,7 @@ function fetchGitLabBoundToAddress(
         response.on('data', chunk => {
           chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
         });
+        response.on('error', reject);
         response.on('end', () => {
           try {
             const status = response.statusCode ?? 500;

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
@@ -84,6 +84,10 @@ function buildRedirectRequestInit(
   }
 
   if (from.origin !== to.origin) {
+    if ((status === 307 || status === 308) && init.body != null) {
+      throw new Error('GitLab request refused cross-origin redirect with request body');
+    }
+
     headers.delete('authorization');
     headers.delete('cookie');
   }

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
@@ -94,9 +94,8 @@ function buildRedirectRequestInit(
 
   const method = init.method?.toUpperCase() ?? 'GET';
   if (
-    (status === 301 || status === 302 || status === 303) &&
-    method !== 'GET' &&
-    method !== 'HEAD'
+    ((status === 301 || status === 302) && method === 'POST') ||
+    (status === 303 && method !== 'GET' && method !== 'HEAD')
   ) {
     headers.delete('content-length');
     headers.delete('content-type');

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
@@ -29,6 +29,8 @@ const GITLAB_REDIRECT_URI = getPlatformOAuthCallbackUrl(PLATFORM.GITLAB);
 
 const DEFAULT_GITLAB_URL = DEFAULT_GITLAB_INSTANCE_URL;
 const MAX_GITLAB_REDIRECTS = 5;
+const MAX_GITLAB_RESPONSE_BYTES = 10 * 1024 * 1024;
+const GITLAB_REQUEST_TIMEOUT_MS = 30_000;
 
 async function fetchGitLab(url: string, init?: RequestInit, redirectCount = 0): Promise<Response> {
   const response = await fetchGitLabOnce(url, init);
@@ -132,8 +134,19 @@ function fetchGitLabBoundToAddress(
       },
       response => {
         const chunks: Buffer[] = [];
+        let responseBytes = 0;
         response.on('data', chunk => {
-          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          responseBytes += buffer.byteLength;
+          if (responseBytes > MAX_GITLAB_RESPONSE_BYTES) {
+            const error = new Error('GitLab response exceeded size limit');
+            response.destroy(error);
+            req.destroy(error);
+            reject(error);
+            return;
+          }
+
+          chunks.push(buffer);
         });
         response.on('error', reject);
         response.on('end', () => {
@@ -155,6 +168,9 @@ function fetchGitLabBoundToAddress(
     );
 
     req.on('error', reject);
+    req.setTimeout(GITLAB_REQUEST_TIMEOUT_MS, () => {
+      req.destroy(new Error('GitLab request timed out'));
+    });
 
     const signal = init?.signal;
     if (signal) {

--- a/apps/web/src/lib/integrations/platforms/gitlab/instance-url.test.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/instance-url.test.ts
@@ -45,6 +45,7 @@ describe('GitLab instance URL safety', () => {
     ['http://localhost:8080', 'host is not allowed'],
     ['http://127.0.0.1:8080', 'host is not allowed'],
     ['http://[::1]:8080', 'host is not allowed'],
+    ['http://[fec0::1]:8080', 'host is not allowed'],
     ['http://169.254.169.254/latest/meta-data', 'host is not allowed'],
     ['http://10.0.0.1', 'host is not allowed'],
     ['http://172.16.0.1', 'host is not allowed'],
@@ -67,6 +68,14 @@ describe('GitLab instance URL safety', () => {
 
   it('rejects hostnames that resolve to unsafe addresses', async () => {
     mockLookup.mockResolvedValueOnce([{ address: '192.168.1.10', family: 4 }]);
+
+    await expect(
+      assertGitLabUrlResolvesSafely('https://gitlab.example.com/api/v4/user')
+    ).rejects.toThrow('resolves to an address that is not allowed');
+  });
+
+  it('rejects hostnames that resolve to deprecated IPv6 site-local addresses', async () => {
+    mockLookup.mockResolvedValueOnce([{ address: 'fec0::1', family: 6 }]);
 
     await expect(
       assertGitLabUrlResolvesSafely('https://gitlab.example.com/api/v4/user')

--- a/apps/web/src/lib/integrations/platforms/gitlab/instance-url.test.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/instance-url.test.ts
@@ -1,0 +1,91 @@
+jest.mock('dns/promises', () => ({
+  lookup: jest.fn(),
+}));
+
+import { lookup } from 'dns/promises';
+import {
+  assertGitLabUrlResolvesSafely,
+  buildGitLabUrl,
+  isDefaultGitLabInstanceUrl,
+  normalizeGitLabInstanceUrl,
+} from './instance-url';
+
+const mockLookup = lookup as jest.Mock;
+
+beforeEach(() => {
+  mockLookup.mockReset();
+  mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+});
+
+describe('GitLab instance URL safety', () => {
+  it('defaults to gitlab.com', () => {
+    expect(normalizeGitLabInstanceUrl(undefined)).toBe('https://gitlab.com');
+    expect(normalizeGitLabInstanceUrl('')).toBe('https://gitlab.com');
+    expect(isDefaultGitLabInstanceUrl('https://gitlab.com/')).toBe(true);
+  });
+
+  it('canonicalizes hosts and preserves self-hosted base paths', () => {
+    expect(normalizeGitLabInstanceUrl('https://GitLab.Example.COM/gitlab/')).toBe(
+      'https://gitlab.example.com/gitlab'
+    );
+    expect(buildGitLabUrl('https://GitLab.Example.COM/gitlab/', '/api/v4/user')).toBe(
+      'https://gitlab.example.com/gitlab/api/v4/user'
+    );
+  });
+
+  const urlWithCredentials = new URL('https://gitlab.example.com');
+  urlWithCredentials.username = 'user';
+  urlWithCredentials.password = 'pass';
+
+  it.each([
+    ['ftp://gitlab.example.com', 'Invalid URL protocol'],
+    [urlWithCredentials.toString(), 'must not include credentials'],
+    ['https://gitlab.example.com?next=/api', 'must not include query strings'],
+    ['https://gitlab.example.com#fragment', 'must not include query strings'],
+    ['http://localhost:8080', 'host is not allowed'],
+    ['http://127.0.0.1:8080', 'host is not allowed'],
+    ['http://[::1]:8080', 'host is not allowed'],
+    ['http://169.254.169.254/latest/meta-data', 'host is not allowed'],
+    ['http://10.0.0.1', 'host is not allowed'],
+    ['http://172.16.0.1', 'host is not allowed'],
+    ['http://192.168.0.1', 'host is not allowed'],
+    ['https://gitlab.local', 'host is not allowed'],
+  ])('rejects unsafe instance URL %p', (url, message) => {
+    expect(() => normalizeGitLabInstanceUrl(url)).toThrow(message);
+  });
+
+  it('accepts hostnames that resolve to public addresses', async () => {
+    await expect(
+      assertGitLabUrlResolvesSafely('https://gitlab.example.com/api/v4/user')
+    ).resolves.toBeUndefined();
+
+    expect(mockLookup).toHaveBeenCalledWith('gitlab.example.com', {
+      all: true,
+      verbatim: true,
+    });
+  });
+
+  it('rejects hostnames that resolve to unsafe addresses', async () => {
+    mockLookup.mockResolvedValueOnce([{ address: '192.168.1.10', family: 4 }]);
+
+    await expect(
+      assertGitLabUrlResolvesSafely('https://gitlab.example.com/api/v4/user')
+    ).rejects.toThrow('resolves to an address that is not allowed');
+  });
+
+  it('rejects unsafe literal IP URLs during fetch-time validation', async () => {
+    await expect(assertGitLabUrlResolvesSafely('http://127.0.0.1/api/v4/user')).rejects.toThrow(
+      'host is not allowed'
+    );
+
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('does not resolve the default GitLab host', async () => {
+    await expect(
+      assertGitLabUrlResolvesSafely('https://gitlab.com/api/v4/user')
+    ).resolves.toBeUndefined();
+
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/integrations/platforms/gitlab/instance-url.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/instance-url.ts
@@ -178,7 +178,7 @@ async function resolveHostnameSafely(
     return {};
   }
 
-  if (isDefaultGitLabInstanceUrl(origin) || isIP(hostname)) {
+  if (isDefaultGitLabInstanceUrl(origin)) {
     return {};
   }
 

--- a/apps/web/src/lib/integrations/platforms/gitlab/instance-url.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/instance-url.ts
@@ -240,6 +240,10 @@ function isUnsafeIpv6(hostname: string): boolean {
     normalized.startsWith('fe9') ||
     normalized.startsWith('fea') ||
     normalized.startsWith('feb') ||
+    normalized.startsWith('fec') ||
+    normalized.startsWith('fed') ||
+    normalized.startsWith('fee') ||
+    normalized.startsWith('fef') ||
     normalized.startsWith('ff') ||
     normalized.startsWith('2001:db8')
   );

--- a/apps/web/src/lib/integrations/platforms/gitlab/instance-url.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/instance-url.ts
@@ -1,0 +1,246 @@
+import { lookup } from 'dns/promises';
+import { isIP } from 'net';
+
+export const DEFAULT_GITLAB_INSTANCE_URL = 'https://gitlab.com';
+
+export class GitLabInstanceUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GitLabInstanceUrlError';
+  }
+}
+
+export function normalizeGitLabInstanceUrl(instanceUrl?: string): string {
+  const rawUrl = (instanceUrl || DEFAULT_GITLAB_INSTANCE_URL).trim();
+  if (!rawUrl) {
+    return DEFAULT_GITLAB_INSTANCE_URL;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new GitLabInstanceUrlError('Invalid URL format.');
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new GitLabInstanceUrlError('Invalid URL protocol. Must be http or https.');
+  }
+
+  if (url.username || url.password) {
+    throw new GitLabInstanceUrlError('GitLab instance URL must not include credentials.');
+  }
+
+  if (url.search || url.hash) {
+    throw new GitLabInstanceUrlError(
+      'GitLab instance URL must not include query strings or fragments.'
+    );
+  }
+
+  const hostname = stripIpv6Brackets(url.hostname.toLowerCase());
+  if (isUnsafeHostname(hostname)) {
+    throw new GitLabInstanceUrlError('GitLab instance URL host is not allowed.');
+  }
+
+  const path = normalizeBasePath(url.pathname);
+  return `${url.protocol}//${url.host.toLowerCase()}${path}`;
+}
+
+export function isDefaultGitLabInstanceUrl(instanceUrl?: string): boolean {
+  return normalizeGitLabInstanceUrl(instanceUrl) === DEFAULT_GITLAB_INSTANCE_URL;
+}
+
+export function buildGitLabUrl(
+  instanceUrl: string | undefined,
+  path: string,
+  query?: Record<string, string | number | boolean>
+): string {
+  if (!path.startsWith('/')) {
+    throw new Error('GitLab API path must start with a slash');
+  }
+
+  const safeBase = new URL(normalizeGitLabInstanceUrl(instanceUrl));
+  const basePath = safeBase.pathname.replace(/\/+$/, '');
+  safeBase.pathname = `${basePath}${path}`;
+  safeBase.search = '';
+  safeBase.hash = '';
+
+  const queryParams = query
+    ? Object.entries(query).map(
+        ([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
+      )
+    : [];
+
+  if (queryParams.length > 0) {
+    safeBase.search = queryParams.join('&');
+  }
+
+  return safeBase.toString();
+}
+
+export async function assertGitLabUrlResolvesSafely(urlString: string): Promise<void> {
+  await resolveGitLabUrlSafely(urlString);
+}
+
+export type GitLabResolvedUrl = {
+  url: URL;
+  address?: string;
+  family?: number;
+};
+
+export async function resolveGitLabUrlSafely(urlString: string): Promise<GitLabResolvedUrl> {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    throw new GitLabInstanceUrlError('Invalid URL format.');
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new GitLabInstanceUrlError('Invalid URL protocol. Must be http or https.');
+  }
+
+  if (url.username || url.password) {
+    throw new GitLabInstanceUrlError('GitLab URL must not include credentials.');
+  }
+
+  const address = await resolveHostnameSafely(
+    stripIpv6Brackets(url.hostname.toLowerCase()),
+    url.origin
+  );
+  return { url, ...address };
+}
+
+function normalizeBasePath(pathname: string): string {
+  if (pathname === '/' || pathname === '') {
+    return '';
+  }
+
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length === 0) {
+    return '';
+  }
+
+  for (const segment of segments) {
+    let decodedSegment: string;
+    try {
+      decodedSegment = decodeURIComponent(segment);
+    } catch {
+      throw new GitLabInstanceUrlError('GitLab instance URL path is invalid.');
+    }
+
+    if (decodedSegment === '.' || decodedSegment === '..') {
+      throw new GitLabInstanceUrlError('GitLab instance URL path must not contain traversal.');
+    }
+  }
+
+  return `/${segments.join('/')}`;
+}
+
+function stripIpv6Brackets(hostname: string): string {
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return hostname.slice(1, -1);
+  }
+
+  return hostname;
+}
+
+function isUnsafeHostname(hostname: string): boolean {
+  if (
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname.endsWith('.local') ||
+    hostname.includes('%')
+  ) {
+    return true;
+  }
+
+  const ipVersion = isIP(hostname);
+  if (ipVersion === 4) {
+    return isUnsafeIpv4(hostname);
+  }
+
+  if (ipVersion === 6) {
+    return isUnsafeIpv6(hostname);
+  }
+
+  return false;
+}
+
+async function resolveHostnameSafely(
+  hostname: string,
+  origin: string
+): Promise<{ address?: string; family?: number }> {
+  if (isIP(hostname)) {
+    if (isUnsafeHostname(hostname)) {
+      throw new GitLabInstanceUrlError('GitLab instance URL host is not allowed.');
+    }
+    return {};
+  }
+
+  if (isDefaultGitLabInstanceUrl(origin) || isIP(hostname)) {
+    return {};
+  }
+
+  let addresses: Array<{ address: string; family: number }>;
+  try {
+    addresses = await lookup(hostname, { all: true, verbatim: true });
+  } catch {
+    throw new GitLabInstanceUrlError('GitLab instance URL host could not be resolved.');
+  }
+
+  if (addresses.length === 0) {
+    throw new GitLabInstanceUrlError('GitLab instance URL host could not be resolved.');
+  }
+
+  for (const { address } of addresses) {
+    if (isUnsafeHostname(stripIpv6Brackets(address.toLowerCase()))) {
+      throw new GitLabInstanceUrlError(
+        'GitLab instance URL host resolves to an address that is not allowed.'
+      );
+    }
+  }
+
+  return addresses[0];
+}
+
+function isUnsafeIpv4(hostname: string): boolean {
+  const [first, second, third, fourth] = hostname.split('.').map(Number);
+  if ([first, second, third, fourth].some(octet => !Number.isInteger(octet))) {
+    return true;
+  }
+
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    first >= 224 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 192 && second === 0 && third === 0) ||
+    (first === 192 && second === 0 && third === 2) ||
+    (first === 198 && (second === 18 || second === 19)) ||
+    (first === 198 && second === 51 && third === 100) ||
+    (first === 203 && second === 0 && third === 113) ||
+    (first === 255 && second === 255 && third === 255 && fourth === 255)
+  );
+}
+
+function isUnsafeIpv6(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === '::' ||
+    normalized === '::1' ||
+    normalized.startsWith('::ffff:') ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd') ||
+    normalized.startsWith('fe8') ||
+    normalized.startsWith('fe9') ||
+    normalized.startsWith('fea') ||
+    normalized.startsWith('feb') ||
+    normalized.startsWith('ff') ||
+    normalized.startsWith('2001:db8')
+  );
+}

--- a/apps/web/src/lib/integrations/platforms/gitlab/webhook-handlers/merge-request-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/webhook-handlers/merge-request-handler.ts
@@ -26,6 +26,7 @@ import type { Owner } from '@/lib/code-reviews/core';
 import { getBotUserId } from '@/lib/bot-users/bot-user-service';
 import type { CodeReviewAgentConfig } from '@/lib/agent-config/core/types';
 import { addReactionToMR, isMergeCommit, setCommitStatus } from '../adapter';
+import { normalizeGitLabInstanceUrl } from '../instance-url';
 import { resolveMergeRequestCheckoutRef } from './merge-request-checkout-ref';
 import { codeReviewWorkerClient } from '@/lib/code-reviews/client/code-review-worker-client';
 import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
@@ -255,7 +256,7 @@ export async function handleMergeRequestCodeReview(
     const metadata = fullIntegration?.metadata as {
       gitlab_instance_url?: string;
     } | null;
-    const instanceUrl = metadata?.gitlab_instance_url || 'https://gitlab.com';
+    const instanceUrl = normalizeGitLabInstanceUrl(metadata?.gitlab_instance_url);
 
     if (cancelledReviews.length > 0 && fullIntegration) {
       const gitlabCancelledReviews = cancelledReviews.flatMap(review => {
@@ -482,7 +483,7 @@ async function migrateInFlightReviewsToMergeCommitHead(args: {
     const fullIntegration = await getIntegrationById(args.integrationId);
     if (!fullIntegration) return;
     const metadata = fullIntegration.metadata as { gitlab_instance_url?: string } | null;
-    const instanceUrl = metadata?.gitlab_instance_url || 'https://gitlab.com';
+    const instanceUrl = normalizeGitLabInstanceUrl(metadata?.gitlab_instance_url);
 
     // In practice an MR has at most one active review; migrate the first.
     const [reviewId] = activeReviewIds;


### PR DESCRIPTION
## Summary
- Fixes CodeQL `js/request-forgery` alerts in the GitLab integration: [#255](https://github.com/Kilo-Org/cloud/security/code-scanning/255), [#256](https://github.com/Kilo-Org/cloud/security/code-scanning/256), and [#257](https://github.com/Kilo-Org/cloud/security/code-scanning/257).
- Centralizes GitLab instance URL normalization and routes GitLab API/OAuth/PAT/webhook/status calls through safe URL construction.
- Hardens self-hosted GitLab requests with unsafe host rejection, DNS validation/address pinning, redirect revalidation, and credential stripping across origins while preserving restricted version-endpoint support.

## Verification
- Manually reviewed GitLab OAuth, PAT, repository, webhook, commit status, and merge-request handler paths for centralized URL handling.
- Confirmed this is backend/security hardening only.

## Visual Changes
N/A

## Reviewer Notes
- Security-sensitive transport change: self-hosted GitLab requests use a DNS-pinned Node HTTP(S) path so the connected address matches the validated DNS answer.
- Redirects are followed manually with destination revalidation; credentials are stripped across origin changes and HTTPS-to-HTTP redirects are rejected.