### PR TITLE
fix(ai-gateway): use binary reasoning for mistral medium

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -16,7 +16,7 @@ import { ReasoningEffortSchema } from '@kilocode/db/schema-types';
 
 export const REASONING_VARIANTS_BINARY = {
   instant: { reasoning: { enabled: false, effort: 'none' } },
-  thinking: { reasoning: { enabled: true, effort: 'medium' } },
+  thinking: { reasoning: { enabled: true, effort: 'high' } },
 } as const;
 
 export const REASONING_VARIANTS_LOW_MEDIUM_HIGH = {
@@ -83,6 +83,9 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
         .filter(e => e !== 'minimal')
         .map(effort => [effort, { reasoning: { enabled: effort !== 'none', effort } }])
     );
+  }
+  if (model.includes('mistral-medium-3-5')) {
+    return REASONING_VARIANTS_BINARY;
   }
   if (
     isKimiModel(model) ||


### PR DESCRIPTION
## Summary
- Return `REASONING_VARIANTS_BINARY` for `mistral-medium-3-5` models so they expose instant and thinking modes.
- Increase the shared binary `thinking` effort to `high` for models that use that variant set.

## Verification
- Not run (per request).

## Visual Changes
- N/A

## Reviewer Notes
- The `thinking` effort change applies to every model using `REASONING_VARIANTS_BINARY`.