### PR TITLE
feat(kiloclaw): friendly 404 page byte installs

### DIFF
--- a/apps/web/src/app/(app)/claw/install/[source]/[slug]/not-found.tsx
+++ b/apps/web/src/app/(app)/claw/install/[source]/[slug]/not-found.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card';
+
+/**
+ * Friendly not-found for the install route. Rendered when the install page
+ * calls notFound(): unknown source, a byte missing or removed upstream, a
+ * failed signature verification, or a slug mismatch. Replaces the bare default
+ * 404 with a clear message and a way back into the app.
+ */
+export default function InstallNotFound() {
+  return (
+    <div className="mx-auto flex min-h-[60vh] w-full max-w-lg items-center px-6 py-12">
+      <Card className="w-full text-left">
+        <CardHeader>
+          <CardTitle className="text-xl break-words">This install link isn’t available</CardTitle>
+          <CardDescription className="leading-relaxed">
+            This ClawByte could not be found, or it is no longer available. It may have been
+            removed, or the link may be incorrect. You can browse the catalog on kilo.ai, or head
+            back to your chat.
+          </CardDescription>
+        </CardHeader>
+        <CardFooter className="justify-end">
+          <Button asChild>
+            <Link href="/claw/chat">Back to chat</Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a friendly not found page for the ClawByte install route. When the install page returns a not found result (an unknown source, a byte that is missing or was removed upstream, a failed signature check, or a slug that does not match), the user now sees a clear card with a way back to chat instead of the bare default 404.

It still returns a 404 status; only the rendered content changes, and it renders inside the existing claw layout (sidebar and auth gate still apply).

## Verification

- [x] Not run manually yet. This is a static server component that Next renders whenever the install route hits its not found path. To verify in a browser, open an install URL with an unknown slug (for example `/claw/install/byte/does-not-exist`) and confirm the new card renders in place of the default 404.

## Visual Changes

| Before | After |
|---|---|
| Bare default 404: "This page could not be found." | Card titled "This install link isn't available" with a short explanation and a Back to chat button |

## Reviewer Notes

- Scoped to the install route via `not-found.tsx`; other routes are unaffected.
- Returns a 404 status, so clients and crawlers still see 404; only the page content is friendlier.
- Renders within the `(app)/claw` layout.
