### PR TITLE
feat(admin/orgs): trial-active filter, sortable entitlements, member-count exclusions, rounded dollar formatting

### DIFF
--- a/apps/web/src/app/admin/api/organizations/hooks.ts
+++ b/apps/web/src/app/admin/api/organizations/hooks.ts
@@ -76,6 +76,7 @@ type UseOrganizationsListParams = {
   plan?: string;
   has_usage?: boolean;
   has_multiple_users?: boolean;
+  trial_ending_in_future?: boolean;
 };
 
 export function useOrganizationsList(params: UseOrganizationsListParams) {
@@ -93,6 +94,7 @@ export function useOrganizationsList(params: UseOrganizationsListParams) {
       plan: params.plan as '' | OrganizationPlan | undefined,
       has_usage: params.has_usage ?? false,
       has_multiple_users: params.has_multiple_users ?? false,
+      trial_ending_in_future: params.trial_ending_in_future ?? false,
     })
   );
 }

--- a/apps/web/src/app/admin/components/OrganizationFilters.tsx
+++ b/apps/web/src/app/admin/components/OrganizationFilters.tsx
@@ -28,6 +28,7 @@ interface OrganizationFiltersProps {
   plan: string;
   hasUsage: boolean;
   hasMultipleUsers: boolean;
+  trialEndingInFuture: boolean;
   showStripeStatus?: boolean;
   showTrialFilters?: boolean;
   onIncludeDeletedChange: (value: boolean) => void;
@@ -35,6 +36,7 @@ interface OrganizationFiltersProps {
   onPlanChange: (value: string) => void;
   onHasUsageChange: (value: boolean) => void;
   onHasMultipleUsersChange: (value: boolean) => void;
+  onTrialEndingInFutureChange: (value: boolean) => void;
   onResetFilters: () => void;
   totalCount?: number;
   filteredCount?: number;
@@ -49,6 +51,7 @@ export function OrganizationFilters({
   plan,
   hasUsage,
   hasMultipleUsers,
+  trialEndingInFuture,
   showStripeStatus = true,
   showTrialFilters = false,
   onIncludeDeletedChange,
@@ -56,6 +59,7 @@ export function OrganizationFilters({
   onPlanChange,
   onHasUsageChange,
   onHasMultipleUsersChange,
+  onTrialEndingInFutureChange,
   onResetFilters,
   totalCount,
   filteredCount,
@@ -64,7 +68,7 @@ export function OrganizationFilters({
     includeDeleted ||
     !!stripeStatus ||
     (!!plan && plan !== 'all') ||
-    (showTrialFilters && (hasUsage || hasMultipleUsers));
+    (showTrialFilters && (hasUsage || hasMultipleUsers || trialEndingInFuture));
 
   const stripeStatusLabel = stripeStatus ? getStripeStatusLabel(stripeStatus) : undefined;
 
@@ -143,6 +147,19 @@ export function OrganizationFilters({
           <>
             <div className="flex items-center gap-2 pb-1">
               <Checkbox
+                id="trial-ending-in-future"
+                checked={trialEndingInFuture}
+                onCheckedChange={checked => onTrialEndingInFutureChange(checked === true)}
+              />
+              <Label
+                htmlFor="trial-ending-in-future"
+                className="cursor-pointer text-sm font-medium"
+              >
+                Trial active
+              </Label>
+            </div>
+            <div className="flex items-center gap-2 pb-1">
+              <Checkbox
                 id="has-usage"
                 checked={hasUsage}
                 onCheckedChange={checked => onHasUsageChange(checked === true)}
@@ -209,6 +226,17 @@ export function OrganizationFilters({
                   Includes deleted
                   <button
                     onClick={() => onIncludeDeletedChange(false)}
+                    className="hover:bg-secondary-foreground/20 ml-1 rounded-full p-0.5"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </Badge>
+              )}
+              {showTrialFilters && trialEndingInFuture && (
+                <Badge variant="secondary" className="text-xs">
+                  Trial active
+                  <button
+                    onClick={() => onTrialEndingInFutureChange(false)}
                     className="hover:bg-secondary-foreground/20 ml-1 rounded-full p-0.5"
                   >
                     <X className="h-3 w-3" />

--- a/apps/web/src/app/admin/components/OrganizationTableBody.tsx
+++ b/apps/web/src/app/admin/components/OrganizationTableBody.tsx
@@ -154,7 +154,7 @@ function EntitlementsRow({
       <TableCell className="min-w-28">
         {organization.subscription_amount_usd ? (
           <span className="font-mono text-sm">
-            ${organization.subscription_amount_usd.toFixed(2)}
+            ${Math.round(organization.subscription_amount_usd).toLocaleString('en-US')}
           </span>
         ) : (
           <span className="text-muted-foreground text-sm">-</span>
@@ -204,13 +204,14 @@ function UsageRow({
       )}
       <TableCell className="min-w-28">
         <span className="font-mono text-sm">
-          {formatMicrodollars(organization.microdollars_used)}
+          {formatMicrodollars(organization.microdollars_used, 0)}
         </span>
       </TableCell>
       <TableCell className="min-w-28">
         <span className="font-mono text-sm">
           {formatMicrodollars(
-            organization.total_microdollars_acquired - organization.microdollars_used
+            organization.total_microdollars_acquired - organization.microdollars_used,
+            0
           )}
         </span>
       </TableCell>

--- a/apps/web/src/app/admin/components/OrganizationTableHeader.tsx
+++ b/apps/web/src/app/admin/components/OrganizationTableHeader.tsx
@@ -37,10 +37,28 @@ export function OrganizationTableHeader({
               Name
             </SortableButton>
           </TableHead>
-          <TableHead>Plan</TableHead>
-          <TableHead>Kilo Pass</TableHead>
-          {showStripeStatus && <TableHead>Stripe Status</TableHead>}
-          <TableHead>Subscription</TableHead>
+          <TableHead>
+            <SortableButton field="plan" sortConfig={sortConfig} onSort={onSort}>
+              Plan
+            </SortableButton>
+          </TableHead>
+          <TableHead>
+            <SortableButton field="kilo_pass_tier" sortConfig={sortConfig} onSort={onSort}>
+              Kilo Pass
+            </SortableButton>
+          </TableHead>
+          {showStripeStatus && (
+            <TableHead>
+              <SortableButton field="latest_stripe_status" sortConfig={sortConfig} onSort={onSort}>
+                Stripe Status
+              </SortableButton>
+            </TableHead>
+          )}
+          <TableHead>
+            <SortableButton field="subscription_amount_usd" sortConfig={sortConfig} onSort={onSort}>
+              Subscription
+            </SortableButton>
+          </TableHead>
           <TableHead>Links</TableHead>
           {showDeleted && <TableHead>Deleted</TableHead>}
         </TableRow>

--- a/apps/web/src/app/admin/components/OrganizationsTable.tsx
+++ b/apps/web/src/app/admin/components/OrganizationsTable.tsx
@@ -94,6 +94,7 @@ export function OrganizationsTable({
   // unchecked". Trial filters do nothing when `showTrialFilters` is false.
   const rawHasUsage = searchParams.get('has_usage');
   const rawHasMultipleUsers = searchParams.get('has_multiple_users');
+  const rawTrialEndingInFuture = searchParams.get('trial_ending_in_future');
   const currentHasUsage = showTrialFilters
     ? rawHasUsage === null
       ? true
@@ -103,6 +104,11 @@ export function OrganizationsTable({
     ? rawHasMultipleUsers === null
       ? true
       : rawHasMultipleUsers === 'true'
+    : false;
+  const currentTrialEndingInFuture = showTrialFilters
+    ? rawTrialEndingInFuture === null
+      ? true
+      : rawTrialEndingInFuture === 'true'
     : false;
 
   const sortConfig: OrganizationSortConfig = useMemo(
@@ -125,6 +131,7 @@ export function OrganizationsTable({
     plan: currentPlan,
     has_usage: currentHasUsage,
     has_multiple_users: currentHasMultipleUsers,
+    trial_ending_in_future: currentTrialEndingInFuture,
   });
 
   const updateUrl = useCallback(
@@ -155,10 +162,12 @@ export function OrganizationsTable({
       stripe_status: rawStripeStatus ?? '',
       plan: currentPlan === 'all' ? '' : currentPlan,
       tab: currentTab,
-      // Preserve whatever's currently in the URL. `has_usage`/`has_multiple_users`
-      // can be absent (= default true on trials), or explicitly 'true' / 'false'.
+      // Preserve whatever's currently in the URL. `has_usage`/`has_multiple_users`/
+      // `trial_ending_in_future` can be absent (= default true on trials), or
+      // explicitly 'true' / 'false'.
       has_usage: rawHasUsage ?? '',
       has_multiple_users: rawHasMultipleUsers ?? '',
+      trial_ending_in_future: rawTrialEndingInFuture ?? '',
     }),
     [
       currentPageSize,
@@ -170,6 +179,7 @@ export function OrganizationsTable({
       currentTab,
       rawHasUsage,
       rawHasMultipleUsers,
+      rawTrialEndingInFuture,
     ]
   );
 
@@ -228,6 +238,18 @@ export function OrganizationsTable({
     [sharedParams, currentSearch, updateUrl]
   );
 
+  const handleTrialEndingInFutureChange = useCallback(
+    (value: boolean) => {
+      updateUrl({
+        ...sharedParams(),
+        trial_ending_in_future: value ? 'true' : 'false',
+        search: currentSearch,
+        page: '1',
+      });
+    },
+    [sharedParams, currentSearch, updateUrl]
+  );
+
   const handlePlanChange = useCallback(
     (value: string) => {
       updateUrl({
@@ -254,6 +276,7 @@ export function OrganizationsTable({
       // trials page (and to inert/false elsewhere).
       has_usage: '',
       has_multiple_users: '',
+      trial_ending_in_future: '',
       tab: currentTab,
     });
   }, [currentSearch, currentPageSize, currentSortBy, currentSortOrder, currentTab, updateUrl]);
@@ -370,6 +393,7 @@ export function OrganizationsTable({
             plan={currentPlan}
             hasUsage={currentHasUsage}
             hasMultipleUsers={currentHasMultipleUsers}
+            trialEndingInFuture={currentTrialEndingInFuture}
             showStripeStatus={showStripeStatus}
             showTrialFilters={showTrialFilters}
             onIncludeDeletedChange={handleIncludeDeletedChange}
@@ -377,6 +401,7 @@ export function OrganizationsTable({
             onPlanChange={handlePlanChange}
             onHasUsageChange={handleHasUsageChange}
             onHasMultipleUsersChange={handleHasMultipleUsersChange}
+            onTrialEndingInFutureChange={handleTrialEndingInFutureChange}
             onResetFilters={handleResetFilters}
             totalCount={data?.pagination.total}
             filteredCount={data?.pagination.total}

--- a/apps/web/src/routers/organizations/organization-admin-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.test.ts
@@ -4,10 +4,13 @@ import {
   organizations,
   credit_transactions,
   organization_seats_purchases,
+  organization_memberships,
+  kilo_pass_subscriptions,
 } from '@kilocode/db/schema';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import { createOrganization } from '@/lib/organizations/organizations';
+import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
+import { KiloPassCadence, KiloPassTier } from '@/lib/kilo-pass/enums';
 import type { User, Organization } from '@kilocode/db/schema';
 
 let adminUser: User;
@@ -594,6 +597,227 @@ describe('organization admin router', () => {
       expect(result.organizations).toBeDefined();
       expect(result.pagination).toBeDefined();
       expect(typeof result.pagination.total).toBe('number');
+    });
+
+    it('does not overcount multi-member orgs when has_multiple_users is off', async () => {
+      const searchName = `Admin Count No Member Join ${crypto.randomUUID()}`;
+      const org = await createOrganization(searchName, adminUser.id);
+      const member = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@count-no-member-join.example.com`,
+      });
+
+      try {
+        await addUserToOrganization(org.id, member.id, 'member');
+
+        const caller = await createCallerForUser(adminUser.id);
+        const result = await caller.organizations.admin.list({
+          page: 1,
+          limit: 25,
+          sortBy: 'name',
+          sortOrder: 'desc',
+          search: searchName,
+          mode: 'all',
+          include_deleted: false,
+          has_multiple_users: false,
+        });
+
+        expect(result.organizations.map(organization => organization.id)).toEqual([org.id]);
+        expect(result.pagination.total).toBe(1);
+      } finally {
+        await db.delete(organizations).where(eq(organizations.id, org.id));
+      }
+    });
+
+    it('counts only non-bot non-billing-manager users for has_multiple_users totals', async () => {
+      const searchName = `Admin Count Excluded Members ${crypto.randomUUID()}`;
+      const org = await createOrganization(searchName, adminUser.id);
+      const billingManager = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@billing-manager.example.com`,
+      });
+      const bot = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@bot.example.com`,
+        is_bot: true,
+      });
+      const member = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@regular-member.example.com`,
+      });
+
+      try {
+        await addUserToOrganization(org.id, billingManager.id, 'billing_manager');
+        await addUserToOrganization(org.id, bot.id, 'member');
+
+        const caller = await createCallerForUser(adminUser.id);
+        const resultBeforeRegularMember = await caller.organizations.admin.list({
+          page: 1,
+          limit: 25,
+          sortBy: 'name',
+          sortOrder: 'desc',
+          search: searchName,
+          mode: 'all',
+          include_deleted: false,
+          has_multiple_users: true,
+        });
+
+        expect(resultBeforeRegularMember.organizations).toEqual([]);
+        expect(resultBeforeRegularMember.pagination.total).toBe(0);
+
+        await addUserToOrganization(org.id, member.id, 'member');
+
+        const resultAfterRegularMember = await caller.organizations.admin.list({
+          page: 1,
+          limit: 25,
+          sortBy: 'name',
+          sortOrder: 'desc',
+          search: searchName,
+          mode: 'all',
+          include_deleted: false,
+          has_multiple_users: true,
+        });
+
+        expect(resultAfterRegularMember.organizations.map(organization => organization.id)).toEqual(
+          [org.id]
+        );
+        expect(resultAfterRegularMember.pagination.total).toBe(1);
+      } finally {
+        await db.delete(organizations).where(eq(organizations.id, org.id));
+      }
+    });
+  });
+
+  describe('list — trial active filter', () => {
+    it('uses effective trial end date and trial_active threshold', async () => {
+      const searchPrefix = `Admin Trial Active ${crypto.randomUUID()}`;
+      const fallbackActiveOrg = await createOrganization(`${searchPrefix} fallback`, adminUser.id);
+      const explicitActiveOrg = await createOrganization(
+        `${searchPrefix} explicit active`,
+        adminUser.id
+      );
+      const endingSoonOrg = await createOrganization(`${searchPrefix} ending soon`, adminUser.id);
+
+      try {
+        await db
+          .update(organizations)
+          .set({
+            free_trial_end_at: null,
+            created_at: new Date().toISOString(),
+          })
+          .where(eq(organizations.id, fallbackActiveOrg.id));
+        await db
+          .update(organizations)
+          .set({
+            free_trial_end_at: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+          })
+          .where(eq(organizations.id, explicitActiveOrg.id));
+        await db
+          .update(organizations)
+          .set({
+            free_trial_end_at: new Date(Date.now() + 6 * 24 * 60 * 60 * 1000).toISOString(),
+          })
+          .where(eq(organizations.id, endingSoonOrg.id));
+
+        const caller = await createCallerForUser(adminUser.id);
+        const result = await caller.organizations.admin.list({
+          page: 1,
+          limit: 25,
+          sortBy: 'name',
+          sortOrder: 'asc',
+          search: searchPrefix,
+          mode: 'trial',
+          include_deleted: false,
+          trial_ending_in_future: true,
+        });
+
+        expect(result.organizations.map(organization => organization.id).sort()).toEqual(
+          [explicitActiveOrg.id, fallbackActiveOrg.id].sort()
+        );
+        expect(result.pagination.total).toBe(2);
+      } finally {
+        await db
+          .delete(organizations)
+          .where(
+            inArray(organizations.id, [
+              fallbackActiveOrg.id,
+              explicitActiveOrg.id,
+              endingSoonOrg.id,
+            ])
+          );
+      }
+    });
+  });
+
+  describe('list — Kilo Pass tier sorting', () => {
+    it('sorts by the joined active Kilo Pass tier selected for display', async () => {
+      const searchPrefix = `Admin Kilo Pass Sort ${crypto.randomUUID()}`;
+      const tier19User = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@tier19.example.com`,
+      });
+      const tier49User = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@tier49.example.com`,
+      });
+      const tier19Org = await createOrganization(`${searchPrefix} tier 19`, tier19User.id);
+      const tier49Org = await createOrganization(`${searchPrefix} tier 49`, tier49User.id);
+      const stripeSubscriptionIds = [
+        `sub_admin_org_tier19_${crypto.randomUUID()}`,
+        `sub_admin_org_tier49_${crypto.randomUUID()}`,
+      ];
+
+      try {
+        const now = new Date().toISOString();
+        await db.insert(kilo_pass_subscriptions).values([
+          {
+            kilo_user_id: tier19User.id,
+            provider_subscription_id: stripeSubscriptionIds[0],
+            stripe_subscription_id: stripeSubscriptionIds[0],
+            tier: KiloPassTier.Tier19,
+            cadence: KiloPassCadence.Monthly,
+            status: 'active',
+            cancel_at_period_end: false,
+            current_streak_months: 1,
+            started_at: now,
+            ended_at: null,
+            next_yearly_issue_at: null,
+          },
+          {
+            kilo_user_id: tier49User.id,
+            provider_subscription_id: stripeSubscriptionIds[1],
+            stripe_subscription_id: stripeSubscriptionIds[1],
+            tier: KiloPassTier.Tier49,
+            cadence: KiloPassCadence.Monthly,
+            status: 'active',
+            cancel_at_period_end: false,
+            current_streak_months: 1,
+            started_at: now,
+            ended_at: null,
+            next_yearly_issue_at: null,
+          },
+        ]);
+
+        const caller = await createCallerForUser(adminUser.id);
+        const result = await caller.organizations.admin.list({
+          page: 1,
+          limit: 1,
+          sortBy: 'kilo_pass_tier',
+          sortOrder: 'asc',
+          search: searchPrefix,
+          mode: 'all',
+          include_deleted: false,
+        });
+
+        expect(result.organizations).toHaveLength(1);
+        expect(result.organizations[0]?.id).toBe(tier19Org.id);
+        expect(result.organizations[0]?.kilo_pass_tier).toBe(KiloPassTier.Tier19);
+        expect(result.pagination.total).toBe(2);
+      } finally {
+        await db
+          .delete(kilo_pass_subscriptions)
+          .where(inArray(kilo_pass_subscriptions.stripe_subscription_id, stripeSubscriptionIds));
+        await db
+          .delete(organization_memberships)
+          .where(inArray(organization_memberships.organization_id, [tier19Org.id, tier49Org.id]));
+        await db
+          .delete(organizations)
+          .where(inArray(organizations.id, [tier19Org.id, tier49Org.id]));
+      }
     });
   });
 });

--- a/apps/web/src/routers/organizations/organization-admin-router.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.ts
@@ -7,8 +7,23 @@ import {
   organization_seats_purchases,
   credit_transactions,
   platform_integrations,
+  kilo_pass_subscriptions,
 } from '@kilocode/db/schema';
-import { ilike, or, asc, desc, count, eq, ne, gt, and, isNull, sql, type SQL } from 'drizzle-orm';
+import {
+  ilike,
+  or,
+  asc,
+  desc,
+  count,
+  eq,
+  ne,
+  gt,
+  and,
+  isNull,
+  inArray,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import * as z from 'zod';
 import { OrganizationsApiGetResponseSchema } from '@/types/admin';
@@ -27,6 +42,10 @@ import { TRPCError } from '@trpc/server';
 import { successResult } from '@/lib/maybe-result';
 import { reportEvents } from '@/lib/ai-gateway/abuse-service';
 import { getMostRecentSeatPurchase } from '@/lib/organizations/organization-seats';
+import {
+  ORGANIZATION_TRIAL_ACTIVE_MIN_DAYS_REMAINING,
+  ORGANIZATION_TRIAL_DURATION_DAYS,
+} from '@kilocode/organization-entitlement';
 
 const OrganizationListInputSchema = z.object({
   page: z.number().int().min(1).default(1),
@@ -58,7 +77,7 @@ const OrganizationListInputSchema = z.object({
   // Trial-tab filters: hide orgs with no recorded usage / a single member.
   has_usage: z.boolean().default(false),
   has_multiple_users: z.boolean().default(false),
-  // When true, only orgs whose free_trial_end_at is non-null and in the future.
+  // When true, only orgs whose effective trial end keeps them trial_active.
   trial_ending_in_future: z.boolean().default(false),
 });
 
@@ -575,6 +594,7 @@ export const organizationAdminRouter = createTRPCRouter({
 
       const searchTerm = search.trim();
       const sortField = sortBy;
+      const sortsByKiloPassTier = sortField === 'kilo_pass_tier';
 
       const conditions = [];
 
@@ -607,11 +627,13 @@ export const organizationAdminRouter = createTRPCRouter({
         conditions.push(gt(organizations.microdollars_used, 0));
       }
 
-      // Trial-tab filter: only orgs whose trial end date is in the future.
-      // Orgs with a null free_trial_end_at are excluded — a trial without an
-      // end date does not "end in the future".
+      // Trial-tab filter: only orgs whose effective trial end maps to the
+      // trial_active entitlement stage. Match the entitlement fallback for orgs
+      // that never had free_trial_end_at persisted.
       if (trial_ending_in_future) {
-        conditions.push(sql`${organizations.free_trial_end_at} > NOW()`);
+        conditions.push(
+          sql`COALESCE(${organizations.free_trial_end_at}, ${organizations.created_at} + ${ORGANIZATION_TRIAL_DURATION_DAYS} * INTERVAL '1 day') >= NOW() + ${ORGANIZATION_TRIAL_ACTIVE_MIN_DAYS_REMAINING} * INTERVAL '1 day'`
+        );
       }
 
       const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
@@ -632,6 +654,22 @@ export const organizationAdminRouter = createTRPCRouter({
         .from(organization_seats_purchases)
         .as('latest_subscriptions');
 
+      const organizationKiloPassTiers = db
+        .select({
+          organization_id: organization_memberships.organization_id,
+          kilo_pass_tier: sql<string | null>`MIN(${kilo_pass_subscriptions.tier})`.as(
+            'kilo_pass_tier'
+          ),
+        })
+        .from(organization_memberships)
+        .innerJoin(
+          kilo_pass_subscriptions,
+          eq(kilo_pass_subscriptions.kilo_user_id, organization_memberships.kilo_user_id)
+        )
+        .where(eq(kilo_pass_subscriptions.status, 'active'))
+        .groupBy(organization_memberships.organization_id)
+        .as('organization_kilo_pass_tiers');
+
       let orderCondition;
       const orderFunction = sortOrder === 'asc' ? asc : desc;
       // For sort keys that come from a derived/aggregate column or a joined
@@ -650,11 +688,7 @@ export const organizationAdminRouter = createTRPCRouter({
       } else if (sortField === 'latest_stripe_status') {
         orderCondition = orderFunction(latestSubscriptions.subscription_status);
       } else if (sortField === 'kilo_pass_tier') {
-        // Sorting by kilo_pass_tier mirrors the displayed-tier subquery so the
-        // order matches what the user sees in the column.
-        orderCondition = orderFunction(
-          sql`(SELECT kps.tier FROM organization_memberships om2 JOIN kilo_pass_subscriptions kps ON kps.kilo_user_id = om2.kilo_user_id WHERE om2.organization_id = ${organizations.id} AND kps.status = 'active' ORDER BY kps.tier LIMIT 1)`
-        );
+        orderCondition = orderFunction(organizationKiloPassTiers.kilo_pass_tier);
       } else {
         // 'name', 'plan', 'microdollars_used' all map to organizations columns.
         orderCondition = orderFunction(organizations[sortField]);
@@ -694,11 +728,9 @@ export const organizationAdminRouter = createTRPCRouter({
           'subscription_amount_usd'
         ),
         latest_stripe_status: latestSubscriptions.subscription_status,
-        kilo_pass_tier: sql<
-          string | null
-        >`(SELECT kps.tier FROM organization_memberships om2 JOIN kilo_pass_subscriptions kps ON kps.kilo_user_id = om2.kilo_user_id WHERE om2.organization_id = ${organizations.id} AND kps.status = 'active' ORDER BY kps.tier LIMIT 1)`.as(
-          'kilo_pass_tier'
-        ),
+        kilo_pass_tier: sortsByKiloPassTier
+          ? organizationKiloPassTiers.kilo_pass_tier
+          : sql<string | null>`NULL`.as('kilo_pass_tier'),
         kiloclaw_count:
           sql<number>`(SELECT COUNT(*) FROM kiloclaw_instances ki WHERE ki.organization_id = ${organizations.id} AND ki.destroyed_at IS NULL)::int`.as(
             'kiloclaw_count'
@@ -731,7 +763,7 @@ export const organizationAdminRouter = createTRPCRouter({
       // is_bot. With LEFT JOINs and a `count(kilocode_users.id)` aggregate,
       // rows that don't match those filters drop out of the count without
       // dropping the org from the result set.
-      const baseQuery = db
+      const baseQueryWithCommonJoins = db
         .select(organizationFields)
         .from(organizations)
         .leftJoin(
@@ -755,6 +787,13 @@ export const organizationAdminRouter = createTRPCRouter({
             eq(latestSubscriptions.row_num, 1)
           )
         );
+
+      const baseQuery = sortsByKiloPassTier
+        ? baseQueryWithCommonJoins.leftJoin(
+            organizationKiloPassTiers,
+            eq(organizations.id, organizationKiloPassTiers.organization_id)
+          )
+        : baseQueryWithCommonJoins;
 
       // Add mode-based and stripe_status conditions
       const statusConditions = whereCondition ? [whereCondition] : [];
@@ -798,62 +837,114 @@ export const organizationAdminRouter = createTRPCRouter({
         .groupBy(
           organizations.id,
           latestSubscriptions.amount_usd,
-          latestSubscriptions.subscription_status
+          latestSubscriptions.subscription_status,
+          ...(sortsByKiloPassTier ? [organizationKiloPassTiers.kilo_pass_tier] : [])
         )
         .having(havingCondition)
         .orderBy(orderCondition)
         .limit(limit)
         .offset((page - 1) * limit);
 
-      // Get total count using the same filtering logic. Only join the
-      // latestSubscriptions windowed subquery when the stripe_status filter is
-      // active — that filter is the only branch where finalWhereCondition
-      // references a column from latestSubscriptions, so unconditional joining
-      // would do avoidable historical-subscription-table work on every list
-      // request.
-      // Mirror the membership + user joins from baseQuery so the
-      // has_multiple_users HAVING clause (which counts kilocode_users.id) and
-      // the billing-manager / bot exclusion stay consistent between the page
-      // result and the total count.
-      const countBase = db
-        .select({ count: count() })
-        .from(organizations)
-        .leftJoin(
-          organization_memberships,
-          and(
-            eq(organizations.id, organization_memberships.organization_id),
-            ne(organization_memberships.role, 'billing_manager')
-          )
-        )
-        .leftJoin(
-          kilocode_users,
-          and(
-            eq(kilocode_users.id, organization_memberships.kilo_user_id),
-            eq(kilocode_users.is_bot, false)
-          )
-        );
+      const organizationsWithKiloPassTiers = sortsByKiloPassTier
+        ? filteredOrganizations
+        : await (async () => {
+            const organizationIds = filteredOrganizations.map(organization => organization.id);
 
-      const countQuery = stripe_status
-        ? countBase
-            .leftJoin(
-              latestSubscriptions,
-              and(
-                eq(organizations.id, latestSubscriptions.organization_id),
-                eq(latestSubscriptions.row_num, 1)
+            if (organizationIds.length === 0) {
+              return filteredOrganizations;
+            }
+
+            const tierRows = await db
+              .select({
+                organization_id: organization_memberships.organization_id,
+                kilo_pass_tier: sql<string | null>`MIN(${kilo_pass_subscriptions.tier})`.as(
+                  'kilo_pass_tier'
+                ),
+              })
+              .from(organization_memberships)
+              .innerJoin(
+                kilo_pass_subscriptions,
+                eq(kilo_pass_subscriptions.kilo_user_id, organization_memberships.kilo_user_id)
               )
-            )
-            .where(finalWhereCondition)
-            .groupBy(organizations.id)
-            .having(havingCondition)
-        : countBase.where(finalWhereCondition).groupBy(organizations.id).having(havingCondition);
+              .where(
+                and(
+                  eq(kilo_pass_subscriptions.status, 'active'),
+                  inArray(organization_memberships.organization_id, organizationIds)
+                )
+              )
+              .groupBy(organization_memberships.organization_id);
 
-      const totalCountResult = await countQuery;
-      const totalOrganizationCount = totalCountResult.length;
+            const kiloPassTierByOrganizationId = new Map(
+              tierRows.map(row => [row.organization_id, row.kilo_pass_tier])
+            );
+
+            return filteredOrganizations.map(organization => ({
+              ...organization,
+              kilo_pass_tier: kiloPassTierByOrganizationId.get(organization.id) ?? null,
+            }));
+          })();
+
+      let totalOrganizationCount: number;
+
+      if (has_multiple_users) {
+        // Mirror the membership + user joins from baseQuery only when the
+        // has_multiple_users HAVING clause needs the excluded member count.
+        const countBase = db
+          .select({ count: count() })
+          .from(organizations)
+          .leftJoin(
+            organization_memberships,
+            and(
+              eq(organizations.id, organization_memberships.organization_id),
+              ne(organization_memberships.role, 'billing_manager')
+            )
+          )
+          .leftJoin(
+            kilocode_users,
+            and(
+              eq(kilocode_users.id, organization_memberships.kilo_user_id),
+              eq(kilocode_users.is_bot, false)
+            )
+          );
+
+        const countQuery = stripe_status
+          ? countBase
+              .leftJoin(
+                latestSubscriptions,
+                and(
+                  eq(organizations.id, latestSubscriptions.organization_id),
+                  eq(latestSubscriptions.row_num, 1)
+                )
+              )
+              .where(finalWhereCondition)
+              .groupBy(organizations.id)
+              .having(havingCondition)
+          : countBase.where(finalWhereCondition).groupBy(organizations.id).having(havingCondition);
+
+        totalOrganizationCount = (await countQuery).length;
+      } else {
+        const countBase = db.select({ count: count() }).from(organizations);
+
+        const countQuery = stripe_status
+          ? countBase
+              .leftJoin(
+                latestSubscriptions,
+                and(
+                  eq(organizations.id, latestSubscriptions.organization_id),
+                  eq(latestSubscriptions.row_num, 1)
+                )
+              )
+              .where(finalWhereCondition)
+          : countBase.where(finalWhereCondition);
+
+        const [countResult] = await countQuery;
+        totalOrganizationCount = countResult?.count ?? 0;
+      }
 
       const totalPages = Math.ceil(totalOrganizationCount / limit);
 
       return {
-        organizations: filteredOrganizations,
+        organizations: organizationsWithKiloPassTiers,
         pagination: {
           page,
           limit,

--- a/apps/web/src/routers/organizations/organization-admin-router.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.ts
@@ -8,7 +8,7 @@ import {
   credit_transactions,
   platform_integrations,
 } from '@kilocode/db/schema';
-import { ilike, or, asc, desc, count, eq, gt, and, isNull, sql, type SQL } from 'drizzle-orm';
+import { ilike, or, asc, desc, count, eq, ne, gt, and, isNull, sql, type SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import * as z from 'zod';
 import { OrganizationsApiGetResponseSchema } from '@/types/admin';
@@ -31,7 +31,18 @@ import { getMostRecentSeatPurchase } from '@/lib/organizations/organization-seat
 const OrganizationListInputSchema = z.object({
   page: z.number().int().min(1).default(1),
   limit: z.number().int().min(1).max(100_000).default(25),
-  sortBy: z.enum(['name', 'microdollars_used', 'balance', 'member_count']).default('name'),
+  sortBy: z
+    .enum([
+      'name',
+      'microdollars_used',
+      'balance',
+      'member_count',
+      'plan',
+      'kilo_pass_tier',
+      'latest_stripe_status',
+      'subscription_amount_usd',
+    ])
+    .default('name'),
   sortOrder: z.enum(['asc', 'desc']).default('desc'),
   search: z.string().optional().default(''),
   // mode controls which broad set of orgs to show (page-level, not user-facing)
@@ -47,6 +58,8 @@ const OrganizationListInputSchema = z.object({
   // Trial-tab filters: hide orgs with no recorded usage / a single member.
   has_usage: z.boolean().default(false),
   has_multiple_users: z.boolean().default(false),
+  // When true, only orgs whose free_trial_end_at is non-null and in the future.
+  trial_ending_in_future: z.boolean().default(false),
 });
 
 const OrganizationSearchInputSchema = z.object({
@@ -557,6 +570,7 @@ export const organizationAdminRouter = createTRPCRouter({
         plan,
         has_usage,
         has_multiple_users,
+        trial_ending_in_future,
       } = input;
 
       const searchTerm = search.trim();
@@ -593,21 +607,18 @@ export const organizationAdminRouter = createTRPCRouter({
         conditions.push(gt(organizations.microdollars_used, 0));
       }
 
-      const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
-
-      let orderCondition;
-      const orderFunction = sortOrder === 'asc' ? asc : desc;
-      if (sortField === 'member_count') {
-        orderCondition = orderFunction(count(organization_memberships.id));
-      } else if (sortField === 'balance') {
-        orderCondition = orderFunction(
-          sql`${organizations.total_microdollars_acquired} - ${organizations.microdollars_used}`
-        );
-      } else {
-        orderCondition = orderFunction(organizations[sortField]);
+      // Trial-tab filter: only orgs whose trial end date is in the future.
+      // Orgs with a null free_trial_end_at are excluded — a trial without an
+      // end date does not "end in the future".
+      if (trial_ending_in_future) {
+        conditions.push(sql`${organizations.free_trial_end_at} > NOW()`);
       }
 
-      // Subquery to get the latest subscription per organization (any status)
+      const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
+
+      // Subquery to get the latest subscription per organization (any status).
+      // Declared before orderCondition so derived sort keys (Stripe status,
+      // Subscription) can reference it.
       const latestSubscriptions = db
         .select({
           organization_id: organization_seats_purchases.organization_id,
@@ -621,6 +632,34 @@ export const organizationAdminRouter = createTRPCRouter({
         .from(organization_seats_purchases)
         .as('latest_subscriptions');
 
+      let orderCondition;
+      const orderFunction = sortOrder === 'asc' ? asc : desc;
+      // For sort keys that come from a derived/aggregate column or a joined
+      // table, build an explicit drizzle expression. Plain organizations columns
+      // fall through to indexing into the table object.
+      if (sortField === 'member_count') {
+        orderCondition = orderFunction(count(kilocode_users.id));
+      } else if (sortField === 'balance') {
+        orderCondition = orderFunction(
+          sql`${organizations.total_microdollars_acquired} - ${organizations.microdollars_used}`
+        );
+      } else if (sortField === 'subscription_amount_usd') {
+        orderCondition = orderFunction(
+          sql`CASE WHEN ${latestSubscriptions.subscription_status} IN ('active','trialing','past_due') THEN ${latestSubscriptions.amount_usd}::float8 ELSE NULL END`
+        );
+      } else if (sortField === 'latest_stripe_status') {
+        orderCondition = orderFunction(latestSubscriptions.subscription_status);
+      } else if (sortField === 'kilo_pass_tier') {
+        // Sorting by kilo_pass_tier mirrors the displayed-tier subquery so the
+        // order matches what the user sees in the column.
+        orderCondition = orderFunction(
+          sql`(SELECT kps.tier FROM organization_memberships om2 JOIN kilo_pass_subscriptions kps ON kps.kilo_user_id = om2.kilo_user_id WHERE om2.organization_id = ${organizations.id} AND kps.status = 'active' ORDER BY kps.tier LIMIT 1)`
+        );
+      } else {
+        // 'name', 'plan', 'microdollars_used' all map to organizations columns.
+        orderCondition = orderFunction(organizations[sortField]);
+      }
+
       const organizationFields = {
         id: organizations.id,
         name: organizations.name,
@@ -632,7 +671,10 @@ export const organizationAdminRouter = createTRPCRouter({
         stripe_customer_id: organizations.stripe_customer_id,
         auto_top_up_enabled: organizations.auto_top_up_enabled,
         settings: organizations.settings,
-        member_count: count(organization_memberships.id).as('member_count'),
+        // Counts kilocode_users.id rather than organization_memberships.id so
+        // billing-manager seats and bot users (filtered out of the user-side
+        // join) are excluded.
+        member_count: count(kilocode_users.id).as('member_count'),
         seat_count: organizations.seat_count,
         require_seats: organizations.require_seats,
         created_by_kilo_user_id: organizations.created_by_kilo_user_id,
@@ -683,13 +725,28 @@ export const organizationAdminRouter = createTRPCRouter({
           ),
       };
 
-      // Build base query without status-specific joins
+      // Build base query without status-specific joins.
+      // The member_count we surface excludes billing-manager seats and bot
+      // users, so the membership join filters role and the user join filters
+      // is_bot. With LEFT JOINs and a `count(kilocode_users.id)` aggregate,
+      // rows that don't match those filters drop out of the count without
+      // dropping the org from the result set.
       const baseQuery = db
         .select(organizationFields)
         .from(organizations)
         .leftJoin(
           organization_memberships,
-          eq(organizations.id, organization_memberships.organization_id)
+          and(
+            eq(organizations.id, organization_memberships.organization_id),
+            ne(organization_memberships.role, 'billing_manager')
+          )
+        )
+        .leftJoin(
+          kilocode_users,
+          and(
+            eq(kilocode_users.id, organization_memberships.kilo_user_id),
+            eq(kilocode_users.is_bot, false)
+          )
         )
         .leftJoin(
           latestSubscriptions,
@@ -730,10 +787,10 @@ export const organizationAdminRouter = createTRPCRouter({
         statusConditions.length > 0 ? and(...statusConditions) : undefined;
 
       // Trial-tab "users > 1" filter is on the aggregate member_count, so it
-      // has to go in HAVING (not WHERE).
-      const havingCondition = has_multiple_users
-        ? gt(count(organization_memberships.id), 1)
-        : undefined;
+      // has to go in HAVING (not WHERE). Same exclusions as the displayed
+      // count: billing-manager seats and bot users do not count toward the
+      // "more than one user" threshold.
+      const havingCondition = has_multiple_users ? gt(count(kilocode_users.id), 1) : undefined;
 
       // Execute main query with pagination
       const filteredOrganizations = await baseQuery
@@ -754,12 +811,26 @@ export const organizationAdminRouter = createTRPCRouter({
       // references a column from latestSubscriptions, so unconditional joining
       // would do avoidable historical-subscription-table work on every list
       // request.
+      // Mirror the membership + user joins from baseQuery so the
+      // has_multiple_users HAVING clause (which counts kilocode_users.id) and
+      // the billing-manager / bot exclusion stay consistent between the page
+      // result and the total count.
       const countBase = db
         .select({ count: count() })
         .from(organizations)
         .leftJoin(
           organization_memberships,
-          eq(organizations.id, organization_memberships.organization_id)
+          and(
+            eq(organizations.id, organization_memberships.organization_id),
+            ne(organization_memberships.role, 'billing_manager')
+          )
+        )
+        .leftJoin(
+          kilocode_users,
+          and(
+            eq(kilocode_users.id, organization_memberships.kilo_user_id),
+            eq(kilocode_users.is_bot, false)
+          )
         );
 
       const countQuery = stripe_status

--- a/apps/web/src/types/admin.ts
+++ b/apps/web/src/types/admin.ts
@@ -101,7 +101,15 @@ export type SortableField = (typeof sortableFields)[number];
 
 export const ascendingFirstFields: SortableField[] = ['google_user_email'];
 
-export type OrganizationSortableField = 'name' | 'microdollars_used' | 'balance' | 'member_count';
+export type OrganizationSortableField =
+  | 'name'
+  | 'microdollars_used'
+  | 'balance'
+  | 'member_count'
+  | 'plan'
+  | 'kilo_pass_tier'
+  | 'latest_stripe_status'
+  | 'subscription_amount_usd';
 
 export type CreditCategorySortableField =
   | 'credit_category'

--- a/packages/organization-entitlement/src/index.ts
+++ b/packages/organization-entitlement/src/index.ts
@@ -1,5 +1,10 @@
 export { classifyOrganizationEntitlement } from './classification';
-export { getDaysRemainingInTrial, getOrgTrialStatusFromDays } from './trial';
+export {
+  getDaysRemainingInTrial,
+  getOrgTrialStatusFromDays,
+  ORGANIZATION_TRIAL_ACTIVE_MIN_DAYS_REMAINING,
+  ORGANIZATION_TRIAL_DURATION_DAYS,
+} from './trial';
 export type {
   OrganizationEntitlementBypassReason,
   OrganizationEntitlementClassification,

--- a/packages/organization-entitlement/src/trial.ts
+++ b/packages/organization-entitlement/src/trial.ts
@@ -1,6 +1,7 @@
 import type { OrganizationTrialStage } from './types';
 
-const ORGANIZATION_TRIAL_DURATION_DAYS = 14;
+export const ORGANIZATION_TRIAL_DURATION_DAYS = 14;
+export const ORGANIZATION_TRIAL_ACTIVE_MIN_DAYS_REMAINING = 8;
 
 export function getDaysRemainingInTrial(
   freeTrialEndAt: string | null,
@@ -17,7 +18,7 @@ export function getDaysRemainingInTrial(
 }
 
 export function getOrgTrialStatusFromDays(daysRemaining: number): OrganizationTrialStage {
-  if (daysRemaining >= 8) {
+  if (daysRemaining >= ORGANIZATION_TRIAL_ACTIVE_MIN_DAYS_REMAINING) {
     return 'trial_active';
   }
   if (daysRemaining > 3) {


### PR DESCRIPTION

<img width="1133" height="421" alt="image" src="https://github.com/user-attachments/assets/f1c42a1b-153b-4b5a-a3ca-6c2186c17be7" />
<img width="1210" height="530" alt="image" src="https://github.com/user-attachments/assets/f0c42fd9-ba11-4893-97e5-f207b6402af7" />


## Summary

- Adds a third trial-tab filter (default ON) — **Trial active** — that filters to orgs whose \`free_trial_end_at\` is in the future. Backend gains a \`trial_ending_in_future\` input; URL/handler/reset/active-badge plumbing matches the existing \`Usage > 0\` and \`Users > 1\` filters.
- Makes every Entitlements-tab column sortable: Plan, Kilo Pass, Stripe Status, Subscription. Schema sortable-fields enum extended; sort expressions wired for derived columns (latest subscription, kilo_pass_tier subquery).
- \`member_count\` (and the \`Users > 1\` HAVING / \`member_count\` sort) now excludes \`role = 'billing_manager'\` memberships and \`is_bot = true\` users via inline JOIN filters and \`count(kilocode_users.id)\`. Both \`baseQuery\` and \`countBase\` get matching joins to keep totals consistent.
- Subscription, Usage, and Balance cells render rounded to the nearest dollar with comma grouping (\`$25,000\` instead of \`$25000.00\` / \`$1234.56\`).

## Verification

- [x] Walked \`/admin/organizations\` and \`/admin/organizations/trials\`. Confirmed Entitlements columns sort. Confirmed Trial active checkbox defaults ON, toggles persist, reset clears all three trial filters.
- [x] Confirmed \`Users / Seats\` count drops billing-manager and bot members (verified via DB after toggling membership rows).
- [x] Confirmed Subscription column shows e.g. \`$25,000\` for an enterprise plan and a small monthly Teams plan rounds to the nearest dollar.

## Visual Changes

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- The membership join's \`role != 'billing_manager'\` filter and the new \`kilocode_users\` LEFT JOIN with \`is_bot = false\` are inlined into the \`ON\` clauses so \`count(kilocode_users.id)\` naturally excludes the unwanted rows. Both the page query and the count query mirror these joins.
- Sort by \`subscription_amount_usd\` reuses the same \`CASE WHEN status IN ('active','trialing','past_due')\` expression that drives the displayed value, so sort order and visible value stay aligned (rows with non-billable statuses sort as NULL).
- \`subscriptionAmountUsd.toFixed(2)\` was replaced with \`Math.round(...).toLocaleString('en-US')\` (Subscription) and \`formatMicrodollars(..., 0)\` (Usage / Balance), both of which add comma grouping via \`Intl.NumberFormat\`.