### PR TITLE
security(kiloclaw) set internal chat URL as server side variable 

### DIFF
--- a/apps/web/.env.development.local.example
+++ b/apps/web/.env.development.local.example
@@ -59,6 +59,12 @@ NEXT_PUBLIC_GASTOWN_URL=http://localhost:8803
 # @url kilo-chat
 NEXT_PUBLIC_KILO_CHAT_URL=http://localhost:8808
 
+# Server-only destination for the cloud → kilo-chat internal call (carries the
+# internal API key + prompt). Kept separate from the NEXT_PUBLIC_ var so the
+# destination is never browser-exposed. Locally points at the same kilo-chat.
+# @url kilo-chat
+KILO_CHAT_INTERNAL_URL=http://localhost:8808
+
 # @url event-service
 NEXT_PUBLIC_EVENT_SERVICE_URL=ws://localhost:8809
 

--- a/apps/web/src/lib/kiloclaw/kilo-chat-internal-client.test.ts
+++ b/apps/web/src/lib/kiloclaw/kilo-chat-internal-client.test.ts
@@ -1,5 +1,8 @@
 // Env must be set BEFORE importing the module under test so its constants
-// resolve to the test values.
+// resolve to the test values. KILO_CHAT_INTERNAL_URL is the preferred
+// server-only destination; NEXT_PUBLIC_KILO_CHAT_URL is the migration-safe
+// fallback.
+process.env.KILO_CHAT_INTERNAL_URL = 'https://chat.kiloapps.io';
 process.env.NEXT_PUBLIC_KILO_CHAT_URL = 'https://chat.kiloapps.io';
 
 jest.mock('@/lib/config.server', () => ({
@@ -113,21 +116,73 @@ describe('postMessageAsUser (cloud → kilo-chat internal HTTP)', () => {
     await expect(postMessageAsUser(VALID_PARAMS)).rejects.toThrow(/unexpected payload/);
   });
 
-  it('throws when NEXT_PUBLIC_KILO_CHAT_URL is missing', async () => {
-    const saved = process.env.NEXT_PUBLIC_KILO_CHAT_URL;
+  it('prefers KILO_CHAT_INTERNAL_URL over NEXT_PUBLIC_KILO_CHAT_URL', async () => {
+    const savedInternal = process.env.KILO_CHAT_INTERNAL_URL;
+    const savedPublic = process.env.NEXT_PUBLIC_KILO_CHAT_URL;
+    // Point the public var somewhere off-allowlist: if it were used, the call
+    // would be refused. The internal var must win and the fetch must go to it.
+    process.env.KILO_CHAT_INTERNAL_URL = 'https://chat.kiloapps.io';
+    process.env.NEXT_PUBLIC_KILO_CHAT_URL = 'https://evil.example.com';
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      jsonResponse({
+        ok: true,
+        conversationId: 'conv-1',
+        messageId: 'msg-1',
+        conversationCreated: false,
+      })
+    );
+    try {
+      await postMessageAsUser(VALID_PARAMS);
+      const [url] = fetchSpy.mock.calls[0]!;
+      expect(url).toBe('https://chat.kiloapps.io/internal/v1/post-message-as-user');
+    } finally {
+      process.env.KILO_CHAT_INTERNAL_URL = savedInternal;
+      process.env.NEXT_PUBLIC_KILO_CHAT_URL = savedPublic;
+    }
+  });
+
+  it('falls back to NEXT_PUBLIC_KILO_CHAT_URL with a warning when the internal var is unset', async () => {
+    const savedInternal = process.env.KILO_CHAT_INTERNAL_URL;
+    delete process.env.KILO_CHAT_INTERNAL_URL;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      jsonResponse({
+        ok: true,
+        conversationId: 'conv-1',
+        messageId: 'msg-1',
+        conversationCreated: false,
+      })
+    );
+    try {
+      await postMessageAsUser(VALID_PARAMS);
+      const [url] = fetchSpy.mock.calls[0]!;
+      expect(url).toBe('https://chat.kiloapps.io/internal/v1/post-message-as-user');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/KILO_CHAT_INTERNAL_URL is not set/)
+      );
+    } finally {
+      process.env.KILO_CHAT_INTERNAL_URL = savedInternal;
+    }
+  });
+
+  it('throws when neither destination var is configured', async () => {
+    const savedInternal = process.env.KILO_CHAT_INTERNAL_URL;
+    const savedPublic = process.env.NEXT_PUBLIC_KILO_CHAT_URL;
+    delete process.env.KILO_CHAT_INTERNAL_URL;
     delete process.env.NEXT_PUBLIC_KILO_CHAT_URL;
     try {
       await expect(postMessageAsUser(VALID_PARAMS)).rejects.toThrow(
-        /NEXT_PUBLIC_KILO_CHAT_URL is not configured/
+        /Neither KILO_CHAT_INTERNAL_URL nor NEXT_PUBLIC_KILO_CHAT_URL is configured/
       );
     } finally {
-      process.env.NEXT_PUBLIC_KILO_CHAT_URL = saved;
+      process.env.KILO_CHAT_INTERNAL_URL = savedInternal;
+      process.env.NEXT_PUBLIC_KILO_CHAT_URL = savedPublic;
     }
   });
 
   it('refuses to send the key to an off-allowlist origin (never fetches)', async () => {
-    const saved = process.env.NEXT_PUBLIC_KILO_CHAT_URL;
-    process.env.NEXT_PUBLIC_KILO_CHAT_URL = 'https://evil.example.com';
+    const saved = process.env.KILO_CHAT_INTERNAL_URL;
+    process.env.KILO_CHAT_INTERNAL_URL = 'https://evil.example.com';
     const fetchSpy = jest.spyOn(global, 'fetch');
     try {
       await expect(postMessageAsUser(VALID_PARAMS)).rejects.toThrow(
@@ -135,7 +190,7 @@ describe('postMessageAsUser (cloud → kilo-chat internal HTTP)', () => {
       );
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
-      process.env.NEXT_PUBLIC_KILO_CHAT_URL = saved;
+      process.env.KILO_CHAT_INTERNAL_URL = saved;
     }
   });
 

--- a/apps/web/src/lib/kiloclaw/kilo-chat-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kilo-chat-internal-client.ts
@@ -21,17 +21,21 @@ const POST_MESSAGE_AS_USER_TIMEOUT_MS = 5_000;
  * `x-internal-api-key` header that kilo-chat's `internalApiMiddleware`
  * timing-safe compares against `INTERNAL_API_SECRET`.
  *
- * Both env vars are required at runtime:
- * - `NEXT_PUBLIC_KILO_CHAT_URL` — already used by the existing public
- *   client-side kilo-chat token flow; we reuse it for the internal path.
+ * Two env vars are required at runtime:
+ * - `KILO_CHAT_INTERNAL_URL` — server-only destination for the internal
+ *   call. Preferred so the key + prompt destination is never sourced from a
+ *   browser-exposed `NEXT_PUBLIC_*` var. Falls back to
+ *   `NEXT_PUBLIC_KILO_CHAT_URL` (with a warning) until the new var is
+ *   provisioned on every project; a follow-up drops the fallback.
  * - `INTERNAL_API_SECRET` — shared secret with kilo-chat's Secrets Store
  *   binding. Already used by other cloud → service integrations.
  */
 
 // Origins the internal API key may be sent to. The destination comes from
-// NEXT_PUBLIC_KILO_CHAT_URL (deploy config), so this is defense in depth: a
-// misconfigured or tampered value must not be able to forward the key (and the
-// prompt) to an unexpected host. `chat.kiloapps.io` is the single deployed
+// deploy config (KILO_CHAT_INTERNAL_URL, or the NEXT_PUBLIC_KILO_CHAT_URL
+// fallback), so this is defense in depth: a misconfigured or tampered value
+// must not be able to forward the key (and the prompt) to an unexpected host.
+// `chat.kiloapps.io` is the single deployed
 // kilo-chat origin (services/kilo-chat/wrangler.jsonc). Loopback covers local
 // dev on any port (KILO_PORT_OFFSET can shift it). Add new deployed origins
 // here if kilo-chat ever gains a staging domain.
@@ -42,21 +46,36 @@ function isAllowedKiloChatOrigin(url: URL): boolean {
 }
 
 function getKiloChatBaseUrl(): string {
-  // Read process.env directly rather than importing KILO_CHAT_URL from
-  // `@/lib/constants`: that constant is marked required at import time, which
-  // crashes test setups if the var is unset. This server-only client should
-  // fail loudly only when it is actually called.
-  const raw = process.env.NEXT_PUBLIC_KILO_CHAT_URL;
+  // Prefer the server-only KILO_CHAT_INTERNAL_URL so the internal-call
+  // destination is never sourced from a browser-exposed NEXT_PUBLIC_* var.
+  // Migration-safe fallback to NEXT_PUBLIC_KILO_CHAT_URL (with a warning) so an
+  // environment that has not provisioned the new var yet keeps working rather
+  // than repeating a wrong-config outage; a follow-up removes the fallback once
+  // KILO_CHAT_INTERNAL_URL is confirmed on every project. Read process.env
+  // directly rather than importing from `@/lib/constants`: those constants are
+  // marked required at import time, which crashes test setups if a var is
+  // unset. This server-only client should fail loudly only when actually called.
+  let raw = process.env.KILO_CHAT_INTERNAL_URL;
+  let source = 'KILO_CHAT_INTERNAL_URL';
+  if (!raw) {
+    raw = process.env.NEXT_PUBLIC_KILO_CHAT_URL;
+    source = 'NEXT_PUBLIC_KILO_CHAT_URL';
+    if (raw) {
+      console.warn(
+        'KILO_CHAT_INTERNAL_URL is not set; falling back to NEXT_PUBLIC_KILO_CHAT_URL for the kilo-chat internal call. Set KILO_CHAT_INTERNAL_URL to remove this fallback.'
+      );
+    }
+  }
   if (!raw) {
     throw new Error(
-      'NEXT_PUBLIC_KILO_CHAT_URL is not configured, cannot reach kilo-chat internal routes'
+      'Neither KILO_CHAT_INTERNAL_URL nor NEXT_PUBLIC_KILO_CHAT_URL is configured, cannot reach kilo-chat internal routes'
     );
   }
   let parsed: URL;
   try {
     parsed = new URL(raw);
   } catch {
-    throw new Error(`NEXT_PUBLIC_KILO_CHAT_URL is not a valid URL: ${raw}`);
+    throw new Error(`${source} is not a valid URL: ${raw}`);
   }
   if (!isAllowedKiloChatOrigin(parsed)) {
     throw new Error(


### PR DESCRIPTION
## Summary

The cloud Next.js app reaches kilo-chat over HTTPS for the install dispatch (`postMessageAsUser`). The destination base URL was sourced from `NEXT_PUBLIC_KILO_CHAT_URL`, a browser exposed value. This change reads the destination from a new server only variable, `KILO_CHAT_INTERNAL_URL`, so the internal call resolves its target from server config rather than a public variable.

`getKiloChatBaseUrl()` now prefers `KILO_CHAT_INTERNAL_URL`. If it is unset, it falls back to `NEXT_PUBLIC_KILO_CHAT_URL` and logs a one line warning, so installs keep working until the new variable is provisioned on every project. A later cleanup removes the fallback once the variable is confirmed everywhere.

The existing guards are unchanged and still apply to whatever URL resolves: the `isAllowedKiloChatOrigin` allowlist (only `chat.kiloapps.io` plus loopback) and `redirect: 'error'`. This builds on top of those.

## Verification

- [ ] No manual run yet. The change is covered by unit tests in `kilo-chat-internal-client.test.ts`: precedence of `KILO_CHAT_INTERNAL_URL` over the public variable, the fallback with warning when it is unset, a throw when neither is set, and the existing off allowlist refusal (now driving the new variable). The full kiloclaw suite passes locally. Manual install dispatch will be confirmed after the variable is provisioned and the web app is redeployed.

## Visual Changes

N/A
