### PR TITLE
feat(gastown): simplify town overview header cards

### DIFF
--- a/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
@@ -82,12 +82,12 @@ export function TownListPageClient() {
             transparency: every object is clickable; every outcome is attributable.
           </p>
 
-          <div className="flex items-end gap-3">
+          <div className="flex flex-wrap items-end gap-3">
             <div className="min-w-[120px] rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
               <div className="text-[11px] tracking-wider text-white/40 uppercase">Towns</div>
               <div className="mt-1 text-2xl font-semibold text-white/90">
                 {townsQuery.isLoading ? (
-                  <span className="inline-block h-5 w-6 animate-pulse rounded bg-white/20" />
+                  <Skeleton className="h-8 w-6 bg-white/20" />
                 ) : (
                   (townsQuery.data ?? []).length
                 )}

--- a/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
@@ -75,48 +75,35 @@ export function TownListPageClient() {
   return (
     <PageContainer>
       <GastownBackdrop contentClassName="p-5 md:p-7">
-        <div className="flex flex-col gap-3">
-          <div className="flex items-start justify-between gap-3">
-            <div>
-              <SetPageTitle title="Gas Town" />
-              <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/60">
-                A chat-first orchestration console for towns, rigs, beads, and agents. Built for
-                radical transparency: every object is clickable; every outcome is attributable.
-              </p>
-            </div>
+        <div className="flex flex-col gap-4">
+          <SetPageTitle title="Gas Town" />
+          <p className="max-w-2xl text-sm leading-relaxed text-white/60">
+            A chat-first orchestration console for towns, rigs, beads, and agents. Built for radical
+            transparency: every object is clickable; every outcome is attributable.
+          </p>
 
-            <Button
-              variant="primary"
-              size="md"
-              onClick={() => router.push('/gastown/onboarding')}
-              className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
-            >
-              <Plus className="size-5" />
-              New Town
-            </Button>
-          </div>
-
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+          <div className="flex items-end gap-3">
+            <div className="min-w-[120px] rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
               <div className="text-[11px] tracking-wider text-white/40 uppercase">Towns</div>
-              <div className="mt-0.5 text-lg font-semibold text-white/85">
-                {townsQuery.isLoading ? '…' : (townsQuery.data ?? []).length}
+              <div className="mt-1 text-2xl font-semibold text-white/90">
+                {townsQuery.isLoading ? (
+                  <span className="inline-block h-5 w-6 animate-pulse rounded bg-white/20" />
+                ) : (
+                  (townsQuery.data ?? []).length
+                )}
               </div>
             </div>
-            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
-              <div className="text-[11px] tracking-wider text-white/40 uppercase">Mode</div>
-              <div className="mt-1 inline-flex items-center gap-2 text-sm text-white/70">
-                <span className="size-2 rounded-full bg-emerald-400" />
-                Live
-              </div>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
-              <div className="text-[11px] tracking-wider text-white/40 uppercase">Core</div>
-              <div className="mt-1 text-sm text-white/70">MEOW · GUPP · NDI</div>
-            </div>
-            <div className="hidden rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 sm:block">
-              <div className="text-[11px] tracking-wider text-white/40 uppercase">Promise</div>
-              <div className="mt-1 text-sm text-white/70">Discover, don’t track</div>
+
+            <div className="ml-auto">
+              <Button
+                variant="primary"
+                size="md"
+                onClick={() => router.push('/gastown/onboarding')}
+                className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+              >
+                <Plus className="size-5" />
+                New Town
+              </Button>
             </div>
           </div>
         </div>

--- a/apps/web/src/app/(app)/organizations/[id]/gastown/OrgTownListPageClient.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/gastown/OrgTownListPageClient.tsx
@@ -44,48 +44,35 @@ export function OrgTownListPageClient({ organizationId, role }: OrgTownListPageC
   return (
     <PageContainer>
       <GastownBackdrop contentClassName="p-5 md:p-7">
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-4">
           <SetPageTitle title="Gas Town" />
-          <div className="flex items-start justify-between gap-3">
-            <div>
-              <p className="max-w-2xl text-sm leading-relaxed text-white/60">
-                A chat-first orchestration console for towns, rigs, beads, and agents. Built for
-                radical transparency: every object is clickable; every outcome is attributable.
-              </p>
-            </div>
+          <p className="max-w-2xl text-sm leading-relaxed text-white/60">
+            A chat-first orchestration console for towns, rigs, beads, and agents. Built for radical
+            transparency: every object is clickable; every outcome is attributable.
+          </p>
 
-            <Button
-              variant="primary"
-              size="md"
-              onClick={() => router.push(onboardingUrl)}
-              className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
-            >
-              <Plus className="size-5" />
-              New Town
-            </Button>
-          </div>
-
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="min-w-[120px] rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
               <div className="text-[11px] tracking-wider text-white/40 uppercase">Towns</div>
-              <div className="mt-0.5 text-lg font-semibold text-white/85">
-                {townsQuery.isLoading ? '…' : (townsQuery.data ?? []).length}
+              <div className="mt-1 text-2xl font-semibold text-white/90">
+                {townsQuery.isLoading ? (
+                  <Skeleton className="h-8 w-6 bg-white/20" />
+                ) : (
+                  (townsQuery.data ?? []).length
+                )}
               </div>
             </div>
-            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
-              <div className="text-[11px] tracking-wider text-white/40 uppercase">Mode</div>
-              <div className="mt-1 inline-flex items-center gap-2 text-sm text-white/70">
-                <span className="size-2 rounded-full bg-emerald-400" />
-                Live
-              </div>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
-              <div className="text-[11px] tracking-wider text-white/40 uppercase">Core</div>
-              <div className="mt-1 text-sm text-white/70">MEOW · GUPP · NDI</div>
-            </div>
-            <div className="hidden rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 sm:block">
-              <div className="text-[11px] tracking-wider text-white/40 uppercase">Promise</div>
-              <div className="mt-1 text-sm text-white/70">Discover, don't track</div>
+
+            <div className="ml-auto">
+              <Button
+                variant="primary"
+                size="md"
+                onClick={() => router.push(onboardingUrl)}
+                className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+              >
+                <Plus className="size-5" />
+                New Town
+              </Button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Updated `apps/web/src/app/(app)/gastown/TownListPageClient.tsx` to clean up the top stat card row on the Gas Town overview. Removed the `Mode`, `Core`, and `Promise` cards, which provided misleading or non-actionable information. Kept only the `Towns` count, moved the **New Town** button to sit alongside it on the right, and improved the loading state for the count.

Closes #3678

## Verification

- Visually verified `/gastown` in the dev build and confirmed the header reads correctly with the single `Towns` card and aligned CTA.

## Visual Changes

### Before

<img width="1919" height="873" alt="before_1" src="https://github.com/user-attachments/assets/b93b24c3-73f5-4d42-ab65-a811dea3c358" />
<img width="1133" height="227" alt="before_2" src="https://github.com/user-attachments/assets/7e210482-8fd2-49fe-930b-74137fc1ebb7" />

### After

<img width="1920" height="866" alt="after_1" src="https://github.com/user-attachments/assets/8bf9556d-004a-4cce-9e29-f3c496a6abbb" />
<img width="1145" height="309" alt="after_2" src="https://github.com/user-attachments/assets/74271614-494a-4fb9-a6ae-46c6ead4542d" />

## Reviewer Notes

No functional or backend changes. This is a UI-only cleanup. The removed cards had no connected state or behavior.