### PR TITLE
fix(cloud-agent): settle accepted messages on wrapper complete to prevent webhook hang

### DIFF
--- a/services/cloud-agent-next/src/session/wrapper-runtime-state.ts
+++ b/services/cloud-agent-next/src/session/wrapper-runtime-state.ts
@@ -451,6 +451,15 @@ export async function recordRootSessionIdle(
  * this, the deadline would be cleared forever after the first event, and a
  * wrapper whose kilo-server SSE subscription silently stalls would remain
  * live without failing its accepted messages.
+ *
+ * This intentionally does NOT clear the idle-reconciliation fields
+ * (`lastWrapperIdleAt`/`idleReconcileAfter`/`wrapperIdleDeadlineAt`). Those are
+ * only ever armed by `recordRootSessionIdle` once the root session goes idle,
+ * so any wrapper output observed afterwards is post-completion infrastructure
+ * work (autocommit, condense, log upload) — not a new agent turn. Clearing the
+ * idle deadline here would disarm the reconciler that finalizes the in-flight
+ * message, stranding it non-terminal and hanging the callback. A genuinely new
+ * turn clears idle via `recordWrapperAcceptedMessage` instead.
  */
 export async function recordMeaningfulWrapperOutput(
   storage: DurableObjectStorage,
@@ -465,9 +474,6 @@ export async function recordMeaningfulWrapperOutput(
     lastWrapperMessageAt: now,
     noOutputDeadlineAt,
     nextPingAt: current.pingDeadlineAt === undefined ? nextPingAt : undefined,
-    lastWrapperIdleAt: undefined,
-    idleReconcileAfter: undefined,
-    wrapperIdleDeadlineAt: undefined,
   }));
 }
 

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
@@ -16,6 +16,7 @@ import {
   type WrapperSupervisorStorage,
 } from './wrapper-supervisor.js';
 import { getWrapperLease, getWrapperRuntimeState } from './wrapper-runtime-state.js';
+import type { LatestAssistantMessage } from './types.js';
 
 vi.mock('@cloudflare/sandbox', () => ({
   getSandbox: vi.fn(),
@@ -103,8 +104,15 @@ function createHarness(
   options?: {
     metadata?: SessionMetadata;
     storageHooks?: { beforeList?: (prefix: string) => Promise<void> };
+    getAssistantMessageForUserMessage?: (
+      sessionId: string,
+      kiloSessionId: string,
+      parentMessageId: string
+    ) => LatestAssistantMessage | null;
   }
 ) {
+  const getAssistantMessageForUserMessage =
+    options?.getAssistantMessageForUserMessage ?? (() => null);
   const storage = createMemoryStorage(initialEntries, options?.storageHooks);
   const events: MessageEvent[] = [];
   const callbackJobs: CallbackJob[] = [];
@@ -144,7 +152,7 @@ function createHarness(
     messageSettlementOutbox: settlementOutbox,
     sessionMessageQueue: { requestPendingDrainIfNeeded },
     getMetadata: async () => currentMetadata,
-    getAssistantMessageForUserMessage: () => null,
+    getAssistantMessageForUserMessage,
     hasActiveIngestConnection: async () => false,
     clearInterruptRequest: async () => {},
     stopWrappers,
@@ -631,7 +639,7 @@ describe('WrapperSupervisor', () => {
     await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
       status: 'failed',
       failureReason: 'missing_assistant_reply',
-      error: 'No assistant reply found after idle timeout',
+      error: 'No assistant reply found during reconciliation',
       completionSource: 'idle_reconciliation',
       failureStage: 'post_dispatch_no_activity',
       failureCode: 'missing_assistant_reply',
@@ -676,6 +684,66 @@ describe('WrapperSupervisor', () => {
       lastWrapperIdleAt: 2_000,
       idleReconcileAfter: 12_000,
       wrapperIdleDeadlineAt: 60_000,
+    });
+  });
+
+  it('settles a still-accepted message and enqueues its callback when the wrapper completes without a terminal assistant event', async () => {
+    // Reproduces the webhook hang: the final assistant message.updated never
+    // carried time.completed (so assistant_message_event never settled it), and
+    // post-idle autocommit refreshed liveness while clearing the idle-reconcile
+    // deadline (idle fields absent below). The race-free `complete` event must
+    // still terminalize the message and release the gated callback.
+    const assistantMessageId = 'ase_complete_reconcile';
+    const harness = createHarness([liveRuntimeState(), OWNED_WRAPPER_LEASE], {
+      getAssistantMessageForUserMessage: () =>
+        ({
+          info: { id: assistantMessageId, role: 'assistant' },
+          parts: [],
+        }) as unknown as LatestAssistantMessage,
+    });
+    await putSessionMessageState(harness.storage, {
+      ...acceptedMessage(),
+      callbackRequired: true,
+      callbackTarget: { url: 'https://example.com/complete-reconcile' },
+    });
+
+    await harness.supervisor.onTerminalEvent({
+      wrapperRunId: WRAPPER_RUN_ID,
+      status: 'completed',
+    });
+
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      status: 'completed',
+      completionSource: 'idle_reconciliation',
+      assistantMessageId,
+    });
+    expect(harness.callbackJobs).toHaveLength(1);
+    expect(harness.callbackJobs[0].payload).toMatchObject({
+      messageId: MESSAGE_ID,
+      status: 'completed',
+    });
+    expect(harness.requestPendingDrainIfNeeded).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the idle-reconcile deadline armed when post-completion output is observed', async () => {
+    // Layer 2: autocommit/condense events after session.idle must refresh
+    // liveness without disarming the reconciler that finalizes the in-flight
+    // message. Before the fix, observeMeaningfulOutput cleared these fields.
+    const harness = createHarness([
+      liveRuntimeState({
+        lastWrapperIdleAt: 1_000,
+        idleReconcileAfter: 9_000,
+        wrapperIdleDeadlineAt: 50_000,
+      }),
+    ]);
+
+    await harness.supervisor.observeMeaningfulOutput(4, WRAPPER_CONNECTION_ID, 2_000);
+
+    await expect(getWrapperRuntimeState(harness.storage)).resolves.toMatchObject({
+      lastWrapperIdleAt: 1_000,
+      idleReconcileAfter: 9_000,
+      wrapperIdleDeadlineAt: 50_000,
+      lastWrapperMessageAt: 2_000,
     });
   });
 

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.ts
@@ -645,41 +645,37 @@ export function createWrapperSupervisor(
     return false;
   }
 
-  async function checkIdleReconciliation(now: number): Promise<void> {
-    const metadata = await getMetadata();
-    if (!metadata) return;
-
-    const state = await getWrapperRuntimeState(storage);
-    if (!state.wrapperRunId) return;
-
-    const acceptedMessages = await listNonTerminalAcceptedMessages(storage, state.wrapperRunId);
-    if (acceptedMessages.length === 0) {
-      if (
-        state.wrapperConnectionId &&
-        (state.lastWrapperIdleAt !== undefined || state.idleReconcileAfter !== undefined)
-      ) {
-        await clearWrapperIdleState(storage, state.wrapperGeneration, state.wrapperConnectionId);
-      }
-      return;
-    }
-
-    if (state.idleReconcileAfter !== undefined) {
-      if (now < state.idleReconcileAfter) return;
-    } else {
-      const hasRecentOutput =
-        state.lastWrapperMessageAt !== undefined &&
-        now - state.lastWrapperMessageAt < WRAPPER_NO_OUTPUT_TIMEOUT_MS;
-      if (hasRecentOutput) return;
-    }
-
+  /**
+   * Terminalize the wrapper run's still-accepted messages against the latest
+   * assistant reply, mirroring how a finished turn would have settled them.
+   *
+   * Shared by two triggers:
+   *  - `idle`: the idle-reconciliation grace deadline elapsed.
+   *  - `wrapper_complete`: the wrapper emitted its terminal `complete` event,
+   *    which is the race-free "fully done" signal (it fires only after all
+   *    post-completion work). This is the authoritative backstop for the case
+   *    where the assistant `message.updated` arrived without `time.completed`,
+   *    so neither the assistant-event nor the idle path settled the message.
+   *
+   * `terminalizeSessionMessageOnce` is idempotent, so re-running here after a
+   * partial settlement is safe.
+   */
+  async function reconcileAcceptedMessages(
+    now: number,
+    state: WrapperRuntimeState,
+    metadata: SessionMetadata,
+    acceptedMessages: Awaited<ReturnType<typeof listNonTerminalAcceptedMessages>>,
+    trigger: 'idle' | 'wrapper_complete'
+  ): Promise<void> {
     logger
       .withFields({
         sessionId: metadata.identity.sessionId,
         wrapperRunId: state.wrapperRunId,
         acceptedMessageCount: acceptedMessages.length,
         hasKiloSessionId: metadata.auth.kiloSessionId !== undefined,
+        trigger,
       })
-      .info('Idle reconciliation processing accepted messages');
+      .info('Reconciling accepted messages');
 
     let failedTerminalObserved = !metadata.auth.kiloSessionId;
     if (!failedTerminalObserved && metadata.auth.kiloSessionId) {
@@ -704,7 +700,7 @@ export function createWrapperSupervisor(
         await messageSettlementOutbox.terminalizeSessionMessageOnce(message.messageId, {
           kind: 'failed',
           reason: 'missing_assistant_reply',
-          error: 'No assistant reply found after idle timeout',
+          error: 'No assistant reply found during reconciliation',
           completionSource: 'idle_reconciliation',
           failureStage: 'post_dispatch_no_activity',
           failureCode: 'missing_assistant_reply',
@@ -722,7 +718,7 @@ export function createWrapperSupervisor(
         await messageSettlementOutbox.terminalizeSessionMessageOnce(message.messageId, {
           kind: 'failed',
           reason: 'missing_assistant_reply',
-          error: 'No assistant reply found after idle timeout',
+          error: 'No assistant reply found during reconciliation',
           completionSource: 'idle_reconciliation',
           failureStage: 'post_dispatch_no_activity',
           failureCode: 'missing_assistant_reply',
@@ -768,8 +764,39 @@ export function createWrapperSupervisor(
         sessionId: metadata.identity.sessionId,
         wrapperRunId: state.wrapperRunId,
         acceptedMessageCount: acceptedMessages.length,
+        trigger,
       })
-      .info('Idle reconciliation pass completed');
+      .info('Reconciliation pass completed');
+  }
+
+  async function checkIdleReconciliation(now: number): Promise<void> {
+    const metadata = await getMetadata();
+    if (!metadata) return;
+
+    const state = await getWrapperRuntimeState(storage);
+    if (!state.wrapperRunId) return;
+
+    const acceptedMessages = await listNonTerminalAcceptedMessages(storage, state.wrapperRunId);
+    if (acceptedMessages.length === 0) {
+      if (
+        state.wrapperConnectionId &&
+        (state.lastWrapperIdleAt !== undefined || state.idleReconcileAfter !== undefined)
+      ) {
+        await clearWrapperIdleState(storage, state.wrapperGeneration, state.wrapperConnectionId);
+      }
+      return;
+    }
+
+    if (state.idleReconcileAfter !== undefined) {
+      if (now < state.idleReconcileAfter) return;
+    } else {
+      const hasRecentOutput =
+        state.lastWrapperMessageAt !== undefined &&
+        now - state.lastWrapperMessageAt < WRAPPER_NO_OUTPUT_TIMEOUT_MS;
+      if (hasRecentOutput) return;
+    }
+
+    await reconcileAcceptedMessages(now, state, metadata, acceptedMessages, 'idle');
   }
 
   async function checkKeepWarmCleanup(now: number): Promise<void> {
@@ -967,6 +994,28 @@ export function createWrapperSupervisor(
       const acceptedMessages = await listNonTerminalAcceptedMessages(storage, wrapperRunId);
       if (acceptedMessages.length === 0) {
         await retainPhysicalWrapperWarm(Date.now());
+        await clearInterruptRequest();
+      } else {
+        // `complete` is the race-free "fully done" signal: it is emitted only
+        // after all post-completion work. If messages are still accepted here,
+        // the assistant-event and idle-reconcile paths both missed them (e.g.
+        // the final assistant `message.updated` lacked `time.completed`, and
+        // post-idle autocommit refreshed liveness). Settle them now rather than
+        // leaving the callback gated indefinitely.
+        const metadata = await getMetadata();
+        if (metadata) {
+          await reconcileAcceptedMessages(
+            Date.now(),
+            state,
+            metadata,
+            acceptedMessages,
+            'wrapper_complete'
+          );
+        } else {
+          logger
+            .withFields({ sessionId, wrapperRunId, acceptedMessageCount: acceptedMessages.length })
+            .warn('Wrapper complete with accepted messages but no session metadata to reconcile');
+        }
         await clearInterruptRequest();
       }
     } else {

--- a/services/cloud-agent-next/test/integration/session/execute-directly-failure.test.ts
+++ b/services/cloud-agent-next/test/integration/session/execute-directly-failure.test.ts
@@ -20,6 +20,7 @@ import {
   recordWrapperAcceptedMessage,
 } from '../../../src/session/wrapper-runtime-state.js';
 import {
+  getSessionMessageState,
   listNonTerminalAcceptedMessages,
   putSessionMessageState,
   type SessionMessageState,
@@ -294,7 +295,7 @@ describe('handleWrapperTerminalEvent — new-path identity and message preservat
     );
   });
 
-  it('wrapper complete does not clear wrapper runtime identity when accepted messages remain', async () => {
+  it('wrapper complete reconciles still-accepted messages instead of stranding them', async () => {
     const userId = 'user_wrapper_complete_identity';
     const sessionId = 'agent_wrapper_complete_identity';
     const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
@@ -315,9 +316,10 @@ describe('handleWrapperTerminalEvent — new-path identity and message preservat
       const { state: wrapperState } = await allocateWrapperRuntimeState(instance.ctx.storage);
       const { wrapperRunId, wrapperConnectionId } = wrapperState;
 
+      const messageId = 'msg_018f1e2d3c4bWrpCmpAbCdEfGh';
       // Store an accepted (non-terminal) session message state
       const acceptedMessage: SessionMessageState = {
-        messageId: 'msg_018f1e2d3c4bWrpCmpAbCdEfGh',
+        messageId,
         status: 'accepted',
         prompt: 'hello',
         createdAt: Date.now(),
@@ -326,7 +328,11 @@ describe('handleWrapperTerminalEvent — new-path identity and message preservat
       };
       await putSessionMessageState(instance.ctx.storage, acceptedMessage);
 
-      // Fire wrapper complete — with accepted non-terminal messages present
+      // Fire wrapper complete with an accepted non-terminal message present.
+      // `complete` is the race-free terminal signal, so the message must be
+      // settled here rather than left stranded (which would hang the callback).
+      // This session has no kiloSessionId, so no assistant reply can be found
+      // and the message settles as failed (missing_assistant_reply).
       await instance.handleWrapperTerminalEvent({
         wrapperRunId: wrapperRunId!,
         status: 'completed',
@@ -337,20 +343,21 @@ describe('handleWrapperTerminalEvent — new-path identity and message preservat
         instance.ctx.storage,
         wrapperRunId!
       );
+      const settledMessage = await getSessionMessageState(instance.ctx.storage, messageId);
 
-      return { wrapperRuntimeState, wrapperConnectionId, acceptedMessages };
+      return { wrapperRuntimeState, wrapperConnectionId, acceptedMessages, settledMessage };
     });
 
-    // Identity must NOT be cleared while accepted work remains
-    expect(result.wrapperRuntimeState.wrapperConnectionId).toBe(result.wrapperConnectionId);
-    // Accepted message must still be non-terminal
-    expect(result.acceptedMessages).toHaveLength(1);
-    expect(result.acceptedMessages[0]?.status).toBe('accepted');
+    // The message is settled rather than left accepted.
+    expect(result.acceptedMessages).toHaveLength(0);
+    expect(result.settledMessage).toMatchObject({
+      status: 'failed',
+      failureCode: 'missing_assistant_reply',
+      completionSource: 'idle_reconciliation',
+    });
+    // Identity is released once the run has no remaining accepted work.
+    expect(result.wrapperRuntimeState.wrapperConnectionId).toBeUndefined();
   });
-
-  // NOTE: Per Phase 6 (keep-warm cleanup), wrapper `complete` will eventually NOT clear
-  // identity even when no accepted messages remain — keep-warm alarm cleanup owns that.
-  // The current behavior (clearing when idle) is interim and will be superseded by Phase 6.
 });
 
 describe('new-path liveness without executionId', () => {

--- a/services/cloud-agent-next/test/integration/session/idle-reconciliation.test.ts
+++ b/services/cloud-agent-next/test/integration/session/idle-reconciliation.test.ts
@@ -223,7 +223,7 @@ describe('idle reconciliation scheduling', () => {
     expect(JSON.parse(result.failedEvents[0].payload)).toMatchObject({
       messageId: 'msg_018f1e2d3c4b00000000000002',
       status: 'failed',
-      error: 'No assistant reply found after idle timeout',
+      error: 'No assistant reply found during reconciliation',
       delivery: 'sent',
       accepted: true,
       completionSource: 'idle_reconciliation',
@@ -309,7 +309,7 @@ describe('idle reconciliation scheduling', () => {
     expect(result.lease).toMatchObject({ state: 'stop_needed', reason: 'terminal-failed' });
   });
 
-  it('meaningful wrapper output clears idle state', async () => {
+  it('meaningful wrapper output refreshes liveness without clearing idle state', async () => {
     const userId = 'user_idle_output';
     const sessionId = 'agent_idle_output';
     const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
@@ -331,13 +331,16 @@ describe('idle reconciliation scheduling', () => {
       const { wrapperRunId, wrapperConnectionId, wrapperGeneration } = wrapperState;
 
       // Set idle state
+      const idleAt = Date.now();
+      const reconcileAt = idleAt + 15_000;
+      const keepWarmAt = idleAt + 5 * 60 * 1000;
       await instance.ctx.storage.put('wrapper_runtime_state', {
         wrapperGeneration,
         wrapperConnectionId,
         wrapperRunId,
-        lastWrapperIdleAt: Date.now(),
-        idleReconcileAfter: Date.now() + 15_000,
-        wrapperIdleDeadlineAt: Date.now() + 5 * 60 * 1000,
+        lastWrapperIdleAt: idleAt,
+        idleReconcileAfter: reconcileAt,
+        wrapperIdleDeadlineAt: keepWarmAt,
       });
 
       const handler = await (instance as any).getIngestHandler();
@@ -356,7 +359,9 @@ describe('idle reconciliation scheduling', () => {
         send: () => {},
       } as unknown as WebSocket;
 
-      // Simulate a non-fatal error event (meaningful output that clears idle)
+      // Simulate a non-fatal error event. This is post-completion infrastructure
+      // output: it must refresh wrapper liveness but must NOT disarm the idle
+      // reconciler that is about to finalize the in-flight message.
       await handler.handleIngestMessage(
         ws,
         JSON.stringify({
@@ -367,12 +372,15 @@ describe('idle reconciliation scheduling', () => {
       );
 
       const runtimeState = await getWrapperRuntimeState(instance.ctx.storage);
-      return { runtimeState };
+      return { runtimeState, idleAt, reconcileAt, keepWarmAt };
     });
 
-    expect(result.runtimeState.lastWrapperIdleAt).toBeUndefined();
-    expect(result.runtimeState.idleReconcileAfter).toBeUndefined();
-    expect(result.runtimeState.wrapperIdleDeadlineAt).toBeUndefined();
+    // Idle reconciliation fields stay armed so the reconciler still fires.
+    expect(result.runtimeState.lastWrapperIdleAt).toBe(result.idleAt);
+    expect(result.runtimeState.idleReconcileAfter).toBe(result.reconcileAt);
+    expect(result.runtimeState.wrapperIdleDeadlineAt).toBe(result.keepWarmAt);
+    // Liveness is refreshed by the output.
+    expect(result.runtimeState.lastWrapperMessageAt).toBeDefined();
   });
 
   it('root session.idle records wrapperIdleDeadlineAt for keep-warm', async () => {


### PR DESCRIPTION
## Summary

A webhook triggered Cloud Agent session could stay in the `inprogress` state
forever even after the agent finished its work and opened a pull request. The
request kept appearing to spin.

Root cause: when the agent finishes, the wrapper reports `session.idle`, which
arms a short reconciliation deadline that settles the accepted message and
releases the completion callback. The wrapper then runs its finishing tasks
(autocommit and condense) before sending its terminal `complete` event. Those
finishing events were treated as meaningful agent output, which cleared the
reconciliation deadline that had just been armed. With the deadline gone,
nothing settled the accepted message, the callback stayed gated on a message
that was never marked terminal, and the request stayed `inprogress`. This was
reproducible whenever the final assistant `message.updated` arrived without
`time.completed`, so the assistant event path never settled the message either.

The fix has two parts in the wrapper supervisor Durable Object:

1. `recordMeaningfulWrapperOutput` now refreshes wrapper liveness without
   clearing the idle reconciliation fields. Those fields are only armed once the
   root session goes idle, so any output seen afterward is finishing work, not a
   new turn. A genuinely new turn still clears them through
   `recordWrapperAcceptedMessage`, which runs before any output for that turn.

2. The wrapper `complete` event now settles any still accepted messages.
   `complete` is emitted only after all finishing work, so it is a reliable
   point to reconcile a message that the assistant event and idle paths both
   missed. Settlement reuses the existing `idle_reconciliation` completion
   source and the same assistant reply lookup, so it cannot mark a message
   complete unless the assistant reply is itself terminal.

The inline idle settlement logic was extracted into a shared
`reconcileAcceptedMessages` helper used by both the idle path and the new
`complete` path, so behavior stays consistent.

Scope is limited to per session Durable Object lifecycle state. No database
queries, migrations, or backfills. All paths are fenced to the current wrapper
run and act only on messages that are not yet terminal.

## Verification

This is internal Durable Object lifecycle logic that is difficult to exercise
by hand, so it is covered by automated unit and regression tests instead of a
manual run:

- A regression test reproduces the exact sequence (accepted message, assistant
  updates without `time.completed`, idle deadline absent, then `complete`) and
  asserts the message reaches a terminal completed state and the callback is
  enqueued.
- A unit test asserts that observing output after idle keeps the reconciliation
  deadline armed.

- [ ] No manual testing performed (see note above)

## Visual Changes

N/A

## Reviewer Notes

- Confirm that not clearing idle fields on output is safe: a new turn calls
  `recordWrapperAcceptedMessage` first, which clears those fields before any
  output for that turn is observed.
- Confirm the `complete` path cannot settle a message that is still being
  processed: settlement only marks completed when the assistant reply lookup
  returns a reply that is itself terminal, and `complete` fires only after the
  turn finishes.
- `reconcileAcceptedMessages` is the prior idle logic with no behavior change
  beyond an added log field and a neutral error string.


### Why this was not caught earlier

The hang was an emergent gap between two existing behaviors that were each
intentional but never tested together:

- Meaningful wrapper output was deliberately allowed to cancel idle
  reconciliation, so an agent that is still producing output is not reconciled
  prematurely.
- The wrapper `complete` event deliberately deferred message settlement to the
  reconciler instead of settling messages itself (interim scaffolding, noted in
  the prior test).

The gap appears only in the exact sequence `session.idle`, then autocommit
output, then `complete`. The autocommit output cancels the reconciler, and
`complete` then defers to a reconciler that is no longer armed, so the message
is never settled and the callback stays gated. No test covered that full
sequence, so the collision was invisible. This change repoints both behaviors:
output no longer cancels the reconciler, and `complete` settles anything still
outstanding.
