### PR TITLE
fix(gastown): restore per-role model combobox width in onboarding

### DIFF
--- a/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
+++ b/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
@@ -283,15 +283,17 @@ function CustomModelPicker({
               {roleRows.map(([label, value, setValue]) => (
                 <div key={label} className="flex items-center gap-2">
                   <span className="w-16 shrink-0 text-xs text-white/40">{label}</span>
-                  <ModelCombobox
-                    label=""
-                    models={modelOptions}
-                    value={value}
-                    onValueChange={setValue}
-                    isLoading={isLoadingModels}
-                    placeholder="Use default"
-                    className="flex-1 border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
-                  />
+                  <div className="min-w-0 flex-1">
+                    <ModelCombobox
+                      label=""
+                      models={modelOptions}
+                      value={value}
+                      onValueChange={setValue}
+                      isLoading={isLoadingModels}
+                      placeholder="Use default"
+                      className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                    />
+                  </div>
                   {value && (
                     <button
                       type="button"


### PR DESCRIPTION
## Summary

In the Gastown onboarding 'Choose your models' step, the per-role override comboboxes (Mayor, Refinery, Polecat) inside the Accordion were far too narrow, too small to read model names or search effectively.

Closes #3684

**Root cause:** Each override row used `flex items-center` and placed `ModelCombobox` directly in the flex. In its `full` variant, `ModelCombobox` wraps its trigger button in a non-flex `<div className="space-y-2">`, so `flex-1`/`w-full` on the button had nowhere to expand. The trigger collapsed to the width of its placeholder text.

**Fix:** Wrap the combobox in a `<div className="min-w-0 flex-1">` so the outer block can grow and the trigger button can fill the row width. The per-role comboboxes now match the Default Model combobox above them.

## Verification

- Opened Gastown onboarding → Choose your models step → selected "Custom" → expanded "Override by role (optional)" → confirmed each combobox now fills the row width and popover search list renders at full width.

## Visual Changes

| Before | After |
|---|---|
| <img width="580" height="706" alt="before_models" src="https://github.com/user-attachments/assets/b1c90c93-2d91-49dc-9427-109d7ef205c4" /> | <img width="579" height="704" alt="after_models" src="https://github.com/user-attachments/assets/6f693cfc-c8eb-4c00-b8c9-f11eb486bdfa" /> |

## Reviewer Notes

N/A