### PR TITLE
Undo OpenRouter discounts in listed prices

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals
 import {
   formatName,
   getOpenRouterTranscriptionModels,
+  undoPricingDiscount,
 } from '@/lib/ai-gateway/providers/openrouter';
 import { createMockResponse, mockOpenRouterModels } from '@/tests/helpers/openrouter-models.helper';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
@@ -87,6 +88,45 @@ describe('formatName', () => {
   it('returns the name unchanged when no markers apply', () => {
     const model = buildModel({ created: 0 });
     expect(formatName(model, NOT_PREFERRED)).toBe('Test Model');
+  });
+});
+
+describe('undoPricingDiscount', () => {
+  it('reverses the discount and drops the field without exponential output', () => {
+    const result = undoPricingDiscount({
+      prompt: '0.00000006',
+      completion: '0.0000006',
+      input_cache_read: '0.000000015',
+      discount: 0.7,
+    });
+    expect(result).toEqual({
+      prompt: '0.0000002',
+      completion: '0.000002',
+      input_cache_read: '0.00000005',
+    });
+    expect('discount' in result).toBe(false);
+    for (const value of Object.values(result)) {
+      expect(value).not.toMatch(/e/i);
+    }
+  });
+
+  it('leaves pricing untouched when there is no discount', () => {
+    const pricing = { prompt: '0.000001', completion: '0.000005' };
+    expect(undoPricingDiscount(pricing)).toBe(pricing);
+  });
+
+  it('leaves pricing untouched when the discount is zero', () => {
+    const pricing = { prompt: '0.000001', completion: '0.000005', discount: 0 };
+    expect(undoPricingDiscount(pricing)).toBe(pricing);
+  });
+
+  it('drops the field when the discount cannot be reversed', () => {
+    const result = undoPricingDiscount({
+      prompt: '0.000001',
+      completion: '0.000005',
+      discount: 1,
+    });
+    expect(result).toEqual({ prompt: '0.000001', completion: '0.000005' });
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -100,9 +100,9 @@ describe('undoPricingDiscount', () => {
       discount: 0.7,
     });
     expect(result).toEqual({
-      prompt: '0.0000002',
-      completion: '0.000002',
-      input_cache_read: '0.00000005',
+      prompt: '0.000000200000',
+      completion: '0.000002000000',
+      input_cache_read: '0.000000050000',
     });
     expect('discount' in result).toBe(false);
     for (const value of Object.values(result)) {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@/lib/ai-gateway/models';
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
 import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import type { StoredModel } from '@kilocode/db';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
 import {
   OpenRouterModelsResponseSchema,
@@ -90,6 +91,23 @@ export function formatName(model: OpenRouterModel, preferredIndex: number) {
   return model.name;
 }
 
+type EndpointPricing = NonNullable<StoredModel['endpoints'][number]['pricing']>;
+
+export function undoPricingDiscount(pricing: EndpointPricing): EndpointPricing {
+  const { discount, ...prices } = pricing;
+  if (discount === undefined || discount <= 0) return pricing;
+  const factor = 1 - discount;
+  if (factor <= 0) return prices;
+  const result = { ...prices };
+  for (const key of Object.keys(prices) as (keyof typeof prices)[]) {
+    const value = prices[key];
+    if (value !== undefined) {
+      result[key] = (Number.parseFloat(value) / factor).toFixed(12);
+    }
+  }
+  return result;
+}
+
 async function enhancedModelList(models: OpenRouterModel[]) {
   const autoModels = buildAutoModels();
   const endpointsMetadata = await getOpenRouterModelsMetadata();
@@ -103,14 +121,15 @@ async function enhancedModelList(models: OpenRouterModel[]) {
       .map(model => {
         const preferredProvider = getPreferredProviderOrder(model.id).at(0);
         const endpoints = endpointsMetadata[model.id]?.endpoints ?? [];
-        const pricing = preferredProvider
-          ? (endpoints.find(e => e.tag === preferredProvider)?.pricing ??
+        const rawPricing = !preferredProvider
+          ? endpoints[0]?.pricing
+          : (endpoints.find(e => e.tag === preferredProvider)?.pricing ??
             endpoints.find(
               e =>
                 normalizeInferenceProviderId(e.tag) ===
                 normalizeInferenceProviderId(preferredProvider)
-            )?.pricing)
-          : undefined;
+            )?.pricing);
+        const pricing = rawPricing ? undoPricingDiscount(rawPricing) : rawPricing;
         return pricing ? { ...model, pricing } : model;
       })
       .concat(

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1281,6 +1281,7 @@ export const EndpointSchema = z.object({
       input_cache_write: z.string().optional(),
       web_search: z.string().optional(),
       internal_reasoning: z.string().optional(),
+      discount: z.number().optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
currently, we blindly take prices from OpenRouter, even if they are discounted.

because of how OpenRouter routing works there's no guarantee we actually get these discounts and we do normally charge users standard rates.

this PR removes the discounts from our metadata. if we accidentally do get the discount because no BYOK was used on the OpenRouter side that's not as bad as the other way around.