### PR TITLE
Remove abuse warning for token requests

### DIFF
--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -1011,9 +1011,6 @@ export async function processTokenData(
     usageStats = genStats;
   }
 
-  if (usageStats.inputTokens - usageStats.cacheHitTokens > 100000)
-    console.warn(`Abuse?: Large uncached token request detected:`, usageStats);
-
   if (
     !usageStats.model || // fallback for failure cases
     isKiloStealthModel(usageContext.requested_model) // this can probably be removed once we're sure we only present requested_model to users


### PR DESCRIPTION
I don't think this is indicative of abuse, can easily happen when resuming a task after the cache expired for example.