### PR TITLE
fix(security-agent): retry queued manual analysis

### DIFF
--- a/apps/web/src/components/security-agent/FindingDetailDialog.tsx
+++ b/apps/web/src/components/security-agent/FindingDetailDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -33,6 +34,9 @@ import { toast } from 'sonner';
 import { manualAnalysisAdmissionCopy } from './manual-analysis-admission-copy';
 
 type Severity = 'critical' | 'high' | 'medium' | 'low';
+
+const ACCEPTED_QUEUE_POLL_INTERVAL_MS = 3000;
+const ACCEPTED_QUEUE_POLL_TIMEOUT_MS = 18_000;
 
 function isSeverity(value: string): value is Severity {
   return ['critical', 'high', 'medium', 'low'].includes(value);
@@ -79,12 +83,16 @@ export function FindingDetailDialog({
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const isOrg = !!organizationId;
+  const [queuedFindingId, setQueuedFindingId] = useState<string | null>(null);
+  const isAwaitingAnalysisStart = queuedFindingId === finding?.id;
 
-  // Poll for analysis status when running.
+  // Poll while queued admission is crossing the Worker boundary or analysis is active.
   // Two separate queries for org/personal to avoid type-union issues with useQuery.
   const pollWhileActive = (query: { state: { data?: { status?: string | null } } }) => {
     const status = query.state.data?.status;
-    if (status === 'pending' || status === 'running') return 3000;
+    if (isAwaitingAnalysisStart || status === 'pending' || status === 'running') {
+      return ACCEPTED_QUEUE_POLL_INTERVAL_MS;
+    }
     return false as const;
   };
   const orgAnalysisQuery = useQuery({
@@ -104,12 +112,30 @@ export function FindingDetailDialog({
   });
   const analysisData = isOrg ? orgAnalysisQuery.data : personalAnalysisQuery.data;
 
+  useEffect(() => {
+    if (!queuedFindingId) return;
+    const intervalId = window.setInterval(() => {
+      void queryClient.invalidateQueries();
+    }, ACCEPTED_QUEUE_POLL_INTERVAL_MS);
+    const timeoutId = window.setTimeout(() => {
+      setQueuedFindingId(current => (current === queuedFindingId ? null : current));
+    }, ACCEPTED_QUEUE_POLL_TIMEOUT_MS);
+    return () => {
+      window.clearInterval(intervalId);
+      window.clearTimeout(timeoutId);
+    };
+  }, [queryClient, queuedFindingId]);
+
   // Start analysis mutation (organization)
   const startOrgAnalysisMutation = useMutation(
     trpc.organizations.securityAgent.startAnalysis.mutationOptions({
       onSuccess: async () => {
         toast.success(manualAnalysisAdmissionCopy.successTitle);
         await queryClient.invalidateQueries();
+      },
+      onError: (error, variables) => {
+        toast.error(manualAnalysisAdmissionCopy.failureTitle, { description: error.message });
+        setQueuedFindingId(current => (current === variables.findingId ? null : current));
       },
     })
   );
@@ -120,6 +146,10 @@ export function FindingDetailDialog({
       onSuccess: async () => {
         toast.success(manualAnalysisAdmissionCopy.successTitle);
         await queryClient.invalidateQueries();
+      },
+      onError: (error, variables) => {
+        toast.error(manualAnalysisAdmissionCopy.failureTitle, { description: error.message });
+        setQueuedFindingId(current => (current === variables.findingId ? null : current));
       },
     })
   );
@@ -135,9 +165,13 @@ export function FindingDetailDialog({
   const cliSessionId = analysisData?.cliSessionId ?? finding.cli_session_id;
 
   const isAnalyzing =
-    startAnalysisMutation.isPending || analysisStatus === 'pending' || analysisStatus === 'running';
+    isAwaitingAnalysisStart ||
+    startAnalysisMutation.isPending ||
+    analysisStatus === 'pending' ||
+    analysisStatus === 'running';
 
   const handleStartAnalysis = ({ retrySandboxOnly }: { retrySandboxOnly?: boolean } = {}) => {
+    setQueuedFindingId(finding.id);
     if (isOrg) {
       if (!organizationId) return;
       startOrgAnalysisMutation.mutate({
@@ -335,12 +369,16 @@ export function FindingDetailDialog({
                   />
                 )}
               </div>
-            ) : analysisStatus === 'running' || analysisStatus === 'pending' ? (
+            ) : isAwaitingAnalysisStart ||
+              analysisStatus === 'running' ||
+              analysisStatus === 'pending' ? (
               <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3">
                 <div className="flex items-center gap-2">
                   <Loader2 className="h-4 w-4 animate-spin text-yellow-400" />
                   <p className="text-sm text-yellow-400">
-                    {analysisStatus === 'pending' ? 'Queued...' : 'Triage in progress...'}
+                    {isAwaitingAnalysisStart || analysisStatus === 'pending'
+                      ? `${manualAnalysisAdmissionCopy.pendingLabel}...`
+                      : 'Triage in progress...'}
                   </p>
                 </div>
               </div>
@@ -463,13 +501,15 @@ export function FindingDetailDialog({
               <div className="space-y-4">
                 <MarkdownProse markdown={analysis.rawMarkdown} className="text-muted-foreground" />
               </div>
-            ) : analysisStatus === 'running' || analysisStatus === 'pending' ? (
+            ) : isAwaitingAnalysisStart ||
+              analysisStatus === 'running' ||
+              analysisStatus === 'pending' ? (
               <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3">
                 <div className="flex items-center gap-2">
                   <Loader2 className="h-4 w-4 animate-spin text-yellow-400" />
                   <p className="text-sm text-yellow-400">
-                    {analysisStatus === 'pending'
-                      ? 'Queued...'
+                    {isAwaitingAnalysisStart || analysisStatus === 'pending'
+                      ? `${manualAnalysisAdmissionCopy.pendingLabel}...`
                       : 'Codebase analysis in progress...'}
                   </p>
                 </div>

--- a/services/security-auto-analysis/src/db/queries.integration.test.ts
+++ b/services/security-auto-analysis/src/db/queries.integration.test.ts
@@ -137,6 +137,57 @@ describe('security analysis durable database invariants', () => {
     ]);
   });
 
+  it('lets manual retry supersede an unclaimed scheduled retry', async () => {
+    const findingId = await insertFinding('manual-supersedes-scheduled-retry', 'failed');
+    const finding = await getSecurityFindingById(client.db as never, findingId);
+    expect(finding).not.toBeNull();
+    if (!finding) return;
+
+    await client.db.insert(security_analysis_queue).values({
+      finding_id: findingId,
+      owned_by_user_id: testUserId,
+      queue_status: 'queued',
+      severity_rank: 1,
+      queued_at: '2026-05-18T08:00:00.000Z',
+      attempt_count: 2,
+      next_retry_at: '2026-05-18T09:00:00.000Z',
+      failure_code: 'NETWORK_TIMEOUT',
+      last_error_redacted: 'prior scheduled failure',
+    });
+
+    await expect(
+      ensureManualAnalysisQueueRow(client.db as never, {
+        finding,
+        claimToken: 'manual-claim-token',
+        jobId: 'manual-job',
+      })
+    ).resolves.toBe(true);
+
+    const queueRows = await client.db
+      .select({
+        queueStatus: security_analysis_queue.queue_status,
+        claimToken: security_analysis_queue.claim_token,
+        claimedByJobId: security_analysis_queue.claimed_by_job_id,
+        failureCode: security_analysis_queue.failure_code,
+        lastErrorRedacted: security_analysis_queue.last_error_redacted,
+        attemptCount: security_analysis_queue.attempt_count,
+        nextRetryAt: security_analysis_queue.next_retry_at,
+      })
+      .from(security_analysis_queue)
+      .where(eq(security_analysis_queue.finding_id, findingId));
+    expect(queueRows).toEqual([
+      {
+        queueStatus: 'pending',
+        claimToken: 'manual-claim-token',
+        claimedByJobId: 'manual-job',
+        failureCode: null,
+        lastErrorRedacted: null,
+        attemptCount: 0,
+        nextRetryAt: null,
+      },
+    ]);
+  });
+
   it('requeues stale pending rows and terminalizes stale running rows in real SQL', async () => {
     const pendingFindingId = await insertFinding('stale-pending');
     const runningFindingId = await insertFinding('stale-running', 'running');

--- a/services/security-auto-analysis/src/db/queries.ts
+++ b/services/security-auto-analysis/src/db/queries.ts
@@ -377,10 +377,9 @@ export async function ensureManualAnalysisQueueRow(
         : params.finding.severity === 'medium'
           ? 2
           : 3;
-  // Insert a fresh manual-analysis claim, or revive a prior row that is in a
-  // terminal state (completed/failed) so users can rerun analysis after a
-  // previous attempt finished. Active rows (queued/pending/running) are left
-  // alone and the caller treats this as a duplicate.
+  // Insert a fresh manual-analysis claim, revive a terminal row, or let an
+  // explicit user retry supersede an unclaimed scheduled retry. Pending and
+  // running rows remain untouched because another launch already owns them.
   const rows = await db
     .insert(security_analysis_queue)
     .values({
@@ -410,10 +409,7 @@ export async function ensureManualAnalysisQueueRow(
         last_error_redacted: null,
         updated_at: sql`now()`,
       },
-      setWhere: or(
-        eq(security_analysis_queue.queue_status, 'completed'),
-        eq(security_analysis_queue.queue_status, 'failed')
-      ),
+      setWhere: inArray(security_analysis_queue.queue_status, ['queued', 'completed', 'failed']),
     })
     .returning({ id: security_analysis_queue.id });
   return rows.length > 0;

--- a/services/security-auto-analysis/src/manual-analysis.test.ts
+++ b/services/security-auto-analysis/src/manual-analysis.test.ts
@@ -467,9 +467,9 @@ describe('ensureManualAnalysisQueueRow', () => {
       claim_token: 'claim-token',
       claimed_by_job_id: 'manual-job',
     });
-    // Reviving terminal rows requires a setWhere clause that scopes the
-    // ON CONFLICT update to completed/failed rows. Active rows (queued/
-    // pending/running) must remain untouched and surface as duplicates.
+    // Manual starts may revive terminal rows or supersede unclaimed queued
+    // work. Active pending/running rows remain untouched and surface as
+    // duplicates.
     expect(updateConfigs[0]).toMatchObject({
       set: expect.objectContaining({
         queue_status: 'pending',

--- a/services/security-auto-analysis/vitest.integration.config.ts
+++ b/services/security-auto-analysis/vitest.integration.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    fileParallelism: false,
     include: ['src/**/*.integration.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary
Restore manual Security Agent retries after scheduled launch failures and keep retry progress visible while Worker queue admission settles.

### Why this change is needed
A scheduled analysis launch failure leaves finding state as `failed` while its scheduler row returns to `queued` for backoff retry. Manual Retry Analysis requests entered the Worker command queue successfully, but consumer treated that existing `queued` row as a duplicate and acknowledged command without launching a new analysis.

Finding dialog also refreshed once immediately after admission, before Worker consumer persisted new state. User could keep seeing stale failure panel with no queued or running indication.

### How this is addressed
- Let explicit user retries supersede unclaimed scheduled `queued` rows.
- Keep duplicate protection for active `pending` and `running` rows.
- Reset scheduler backoff metadata when user explicitly requests retry.
- Show `Queueing...` immediately in finding dialog and poll through queue-admission bridge.
- Add Postgres regression coverage for manual retry superseding scheduled backoff.
- Serialize Security Auto Analysis integration files because they share database state and reconciliation intentionally scans global queue rows.

## Human Verification
<img width="2064" height="928" alt="Helium 2026-06-03 13 22 44" src="https://github.com/user-attachments/assets/15c6aff1-600c-47af-911f-1bdb786b0b5f" />
<img width="1890" height="810" alt="Helium 2026-06-03 13 22 45" src="https://github.com/user-attachments/assets/fa70f1f5-2881-481d-bfbb-7bfbbb7ac9fd" />
<img width="1884" height="646" alt="Helium 2026-06-03 13 23 56" src="https://github.com/user-attachments/assets/2117af54-83e6-4d83-8c43-a8d76fea4484" />


## Reviewer Notes
### Human Reviewer Flags
- Explicit user retry intentionally bypasses scheduled backoff for unclaimed `queued` work.
- Active `pending` and `running` work remains protected against duplicate launches.
- Integration files run serially because shared-database reconciliation tests inspect global queue state.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Conflict update now permits `queued`, `completed`, and `failed` scheduler rows to become fresh manual `pending` claims.
- Finding dialog keeps local queueing state for up to 18 seconds and clears interval and timeout handles on cleanup.
- Integration config disables file-level parallelism to prevent one suite's stale-row fixtures from changing another suite's global reconciliation counts.

</details>