### PR TITLE
fix(session-ingest): quarantine missing R2 messages in slow queue

### DIFF
--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -219,15 +219,17 @@ describe('queue status notifications', () => {
     } as unknown as ReturnType<typeof getWorkerDb>;
     vi.mocked(getWorkerDb).mockReturnValue(db);
 
+    const r2Get = vi.fn(async () => null);
+    const slowQueueSend = vi.fn(async () => undefined);
     const env = {
       HYPERDRIVE: { connectionString: 'postgres://test' },
       SESSION_INGEST_R2: {
-        get: vi.fn(async () => null),
+        get: r2Get,
         delete: vi.fn(async () => undefined),
         put: vi.fn(async () => undefined),
       },
       SLOW_INGEST_QUEUE: {
-        send: vi.fn(async () => undefined),
+        send: slowQueueSend,
       },
     } as unknown as Env;
     const ack = vi.fn();
@@ -252,8 +254,8 @@ describe('queue status notifications', () => {
 
     await queue(batch, env, { waitUntil: vi.fn() } as unknown as ExecutionContext);
 
-    expect(env.SESSION_INGEST_R2.get).toHaveBeenCalledWith('ingest/missing');
-    expect(env.SLOW_INGEST_QUEUE.send).toHaveBeenCalledWith(
+    expect(r2Get).toHaveBeenCalledWith('ingest/missing');
+    expect(slowQueueSend).toHaveBeenCalledWith(
       { ...body, missingR2SlowAttempt: true },
       { delaySeconds: SLOW_INGEST_DELAY_SECONDS }
     );
@@ -272,6 +274,7 @@ describe('queue status notifications', () => {
     } as unknown as ReturnType<typeof getWorkerDb>;
     vi.mocked(getWorkerDb).mockReturnValue(db);
 
+    const slowQueueSend = vi.fn(async () => undefined);
     const env = {
       HYPERDRIVE: { connectionString: 'postgres://test' },
       SESSION_INGEST_R2: {
@@ -280,7 +283,7 @@ describe('queue status notifications', () => {
         put: vi.fn(async () => undefined),
       },
       SLOW_INGEST_QUEUE: {
-        send: vi.fn(async () => undefined),
+        send: slowQueueSend,
       },
     } as unknown as Env;
     const ack = vi.fn();
@@ -305,7 +308,7 @@ describe('queue status notifications', () => {
 
     await queue(batch, env, { waitUntil: vi.fn() } as unknown as ExecutionContext);
 
-    expect(env.SLOW_INGEST_QUEUE.send).not.toHaveBeenCalled();
+    expect(slowQueueSend).not.toHaveBeenCalled();
     expect(ack).toHaveBeenCalledTimes(1);
     expect(retry).not.toHaveBeenCalled();
   });

--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type * as SessionEvents from './session-events';
+import type { Env } from './env';
 
 // Mock cloudflare:workers before any imports that might pull in DO code
 vi.mock('cloudflare:workers', () => ({
@@ -44,7 +45,12 @@ vi.mock('./util/ingest-limits', () => ({
 import { getWorkerDb } from '@kilocode/db/client';
 import { getSessionIngestDO } from './dos/SessionIngestDO';
 import { notifyUserSessionEvent } from './session-events';
-import { computeSessionMetadataUpdates, createItemExtractor, queue } from './queue-consumer';
+import {
+  SLOW_INGEST_DELAY_SECONDS,
+  computeSessionMetadataUpdates,
+  createItemExtractor,
+  queue,
+} from './queue-consumer';
 
 const encoder = new TextEncoder();
 
@@ -202,6 +208,157 @@ describe('computeSessionMetadataUpdates', () => {
 });
 
 describe('queue status notifications', () => {
+  it('moves messages with missing staging objects from the fast queue to the slow queue', async () => {
+    const select = {
+      from: vi.fn(() => select),
+      where: vi.fn(() => select),
+      limit: vi.fn(async () => [{ session_id: 'ses_12345678901234567890123456' }]),
+    };
+    const db = {
+      select: vi.fn(() => select),
+    } as unknown as ReturnType<typeof getWorkerDb>;
+    vi.mocked(getWorkerDb).mockReturnValue(db);
+
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => null),
+        delete: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+      },
+      SLOW_INGEST_QUEUE: {
+        send: vi.fn(async () => undefined),
+      },
+    } as unknown as Env;
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const body = {
+      r2Key: 'ingest/missing',
+      kiloUserId: 'usr_test',
+      sessionId: 'ses_12345678901234567890123456',
+      ingestVersion: 1,
+      ingestedAt: 1,
+    };
+    const batch = {
+      queue: 'session-ingest-processing',
+      messages: [
+        {
+          body,
+          ack,
+          retry,
+        },
+      ],
+    } as never;
+
+    await queue(batch, env, { waitUntil: vi.fn() } as unknown as ExecutionContext);
+
+    expect(env.SESSION_INGEST_R2.get).toHaveBeenCalledWith('ingest/missing');
+    expect(env.SLOW_INGEST_QUEUE.send).toHaveBeenCalledWith(
+      { ...body, missingR2SlowAttempt: true },
+      { delaySeconds: SLOW_INGEST_DELAY_SECONDS }
+    );
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it('acks stale flagged messages when the staging object is still missing', async () => {
+    const select = {
+      from: vi.fn(() => select),
+      where: vi.fn(() => select),
+      limit: vi.fn(async () => [{ session_id: 'ses_12345678901234567890123456' }]),
+    };
+    const db = {
+      select: vi.fn(() => select),
+    } as unknown as ReturnType<typeof getWorkerDb>;
+    vi.mocked(getWorkerDb).mockReturnValue(db);
+
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => null),
+        delete: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+      },
+      SLOW_INGEST_QUEUE: {
+        send: vi.fn(async () => undefined),
+      },
+    } as unknown as Env;
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const batch = {
+      queue: 'any-queue-name',
+      messages: [
+        {
+          body: {
+            r2Key: 'ingest/missing',
+            kiloUserId: 'usr_test',
+            sessionId: 'ses_12345678901234567890123456',
+            ingestVersion: 1,
+            ingestedAt: 1,
+            missingR2SlowAttempt: true,
+          },
+          ack,
+          retry,
+        },
+      ],
+    } as never;
+
+    await queue(batch, env, { waitUntil: vi.fn() } as unknown as ExecutionContext);
+
+    expect(env.SLOW_INGEST_QUEUE.send).not.toHaveBeenCalled();
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it('retries the original message when slow-queue enqueue fails', async () => {
+    const select = {
+      from: vi.fn(() => select),
+      where: vi.fn(() => select),
+      limit: vi.fn(async () => [{ session_id: 'ses_12345678901234567890123456' }]),
+    };
+    const db = {
+      select: vi.fn(() => select),
+    } as unknown as ReturnType<typeof getWorkerDb>;
+    vi.mocked(getWorkerDb).mockReturnValue(db);
+
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => null),
+        delete: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+      },
+      SLOW_INGEST_QUEUE: {
+        send: vi.fn(async () => {
+          throw new Error('slow queue unavailable');
+        }),
+      },
+    } as unknown as Env;
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const batch = {
+      queue: 'session-ingest-processing',
+      messages: [
+        {
+          body: {
+            r2Key: 'ingest/missing',
+            kiloUserId: 'usr_test',
+            sessionId: 'ses_12345678901234567890123456',
+            ingestVersion: 1,
+            ingestedAt: 1,
+          },
+          ack,
+          retry,
+        },
+      ],
+    } as never;
+
+    await queue(batch, env, { waitUntil: vi.fn() } as unknown as ExecutionContext);
+
+    expect(ack).not.toHaveBeenCalled();
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
   it('emits a status update using the locked pre-update status instead of the intake snapshot', async () => {
     vi.mocked(notifyUserSessionEvent).mockClear();
     const persistedSession = {

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -18,7 +18,10 @@ export interface IngestQueueMessage {
   sessionId: string;
   ingestVersion: number;
   ingestedAt: number;
+  missingR2SlowAttempt?: boolean;
 }
+
+export const SLOW_INGEST_DELAY_SECONDS = 300;
 
 /**
  * Creates a streaming item extractor that uses a low-level Tokenizer to parse
@@ -174,7 +177,24 @@ async function processMessage(
 
   const obj = await env.SESSION_INGEST_R2.get(r2Key);
   if (!obj) {
-    throw new Error(`R2 staging object not found: ${r2Key}`);
+    if (msg.missingR2SlowAttempt) {
+      console.warn('R2 staging object not found on slow queue, dropping stale queue message', {
+        r2Key,
+        sessionId,
+      });
+      return;
+    }
+
+    console.warn('R2 staging object not found, moving queue message to slow ingest queue', {
+      r2Key,
+      sessionId,
+      delaySeconds: SLOW_INGEST_DELAY_SECONDS,
+    });
+    await env.SLOW_INGEST_QUEUE.send(
+      { ...msg, missingR2SlowAttempt: true },
+      { delaySeconds: SLOW_INGEST_DELAY_SECONDS }
+    );
+    return;
   }
 
   const mergedChanges = new Map<string, string | null>();

--- a/services/session-ingest/worker-configuration.d.ts
+++ b/services/session-ingest/worker-configuration.d.ts
@@ -11,6 +11,7 @@ declare namespace Cloudflare {
 		SESSION_INGEST_R2: R2Bucket;
 		HYPERDRIVE: Hyperdrive;
 		INGEST_QUEUE: Queue;
+		SLOW_INGEST_QUEUE: Queue;
 		NEXTAUTH_SECRET_PROD: SecretsStoreSecret;
 		INTERNAL_API_SECRET_PROD: SecretsStoreSecret;
 		SESSION_INGEST_DO: DurableObjectNamespace<import("./src/index").SessionIngestDO>;

--- a/services/session-ingest/wrangler.jsonc
+++ b/services/session-ingest/wrangler.jsonc
@@ -81,10 +81,19 @@
         "binding": "INGEST_QUEUE",
         "queue": "session-ingest-processing",
       },
+      {
+        "binding": "SLOW_INGEST_QUEUE",
+        "queue": "session-ingest-processing-slow",
+      },
     ],
     "consumers": [
       {
         "queue": "session-ingest-processing",
+        "max_retries": 3,
+        "dead_letter_queue": "session-ingest-dlq",
+      },
+      {
+        "queue": "session-ingest-processing-slow",
         "max_retries": 3,
         "dead_letter_queue": "session-ingest-dlq",
       },

--- a/services/session-ingest/wrangler.test.jsonc
+++ b/services/session-ingest/wrangler.test.jsonc
@@ -47,6 +47,10 @@
         "binding": "INGEST_QUEUE",
         "queue": "session-ingest-processing-test",
       },
+      {
+        "binding": "SLOW_INGEST_QUEUE",
+        "queue": "session-ingest-processing-slow-test",
+      },
     ],
   },
 }


### PR DESCRIPTION
## Summary

Missing R2 staging objects were being retried on the main ingest queue, consuming worker capacity and amplifying backlog. 
Workers capacity maxed out due this issue. We're now  routing them through a delayed slow queue once, then drop terminal stale messages so valid ingest work can drain.

Error logs from axiom.
```
{
"Level": "error",
"Message": [
"Queue message processing failed, will retry",
"{\"r2Key\":\"ingest/<USER_ID>/<SESSION_ID>/<OBJECT_ID>\",\"sessionId\":\"<SESSION_ID>\",\"error\":\"R2 staging object not found: ingest/<USER_ID>/<SESSION_ID>/<OBJECT_ID>\"}"
]
}
{
"Level": "warn",
"Message": [
"Session no longer exists, cleaning up staging object",
"{\"r2Key\":\"ingest/<USER_ID>/<SESSION_ID>/<OBJECT_ID>\",\"sessionId\":\"<SESSION_ID>\"}"
]
}
``` 

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [X] pnpm --filter cloudflare-session-ingest exec vitest run src/queue-consumer.test.ts
- [X] Ran a custom script locally to reproduce a scenario closer to the one in cloud workers
 
## Visual Changes

N/A

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
- Set the slow queue to 5 minutes