### PR TITLE
fix(redis): require ready client before commands

### DIFF
--- a/apps/web/src/lib/redis.ts
+++ b/apps/web/src/lib/redis.ts
@@ -32,13 +32,17 @@ function getOrCreateClient(): RedisClient | null {
 }
 
 async function ensureConnected(c: RedisClient): Promise<RedisClient> {
-  if (c.isOpen) return c;
+  if (c.isReady) return c;
   if (!connectPromise) {
-    connectPromise = c.connect().catch(err => {
-      captureException(err, { tags: { service: 'redis', operation: 'connect' } });
-      connectPromise = null;
-      throw err;
-    });
+    connectPromise = c
+      .connect()
+      .catch(err => {
+        captureException(err, { tags: { service: 'redis', operation: 'connect' } });
+        throw err;
+      })
+      .finally(() => {
+        connectPromise = null;
+      });
   }
   await connectPromise;
   return c;


### PR DESCRIPTION
## Summary
- Require the Redis client to be fully ready before reusing it for commands, avoiding stale open-but-not-ready sockets on Vercel instances.
- Reset the shared connect promise after connect attempts complete so future disconnected clients can reconnect cleanly.

## Verification
N/A - server helper change; no manual runtime verification performed.

## Visual Changes
N/A

## Reviewer Notes
This is intentionally minimal: it preserves the existing Redis timeout and Sentry behavior while tightening the readiness check.