### PR TITLE
fix(redis): tag timeout phase

### DIFF
--- a/apps/web/src/lib/redis.ts
+++ b/apps/web/src/lib/redis.ts
@@ -3,6 +3,8 @@ import { captureException } from '@sentry/nextjs';
 import type { RedisKey } from '@/lib/redis-keys';
 
 type RedisClient = ReturnType<typeof createClient>;
+type RedisOperation = 'get' | 'getdel' | 'set' | 'del';
+type RedisTimeoutPhase = 'connect' | 'command';
 
 // TCP handshake + TLS negotiation can take a moment on a cold connection.
 // Redis official docs recommend 1-3s for connect (redis.io/docs/latest/develop/clients).
@@ -14,6 +16,38 @@ const COMMAND_TIMEOUT_MS = 200;
 
 let client: RedisClient | null = null;
 let connectPromise: Promise<unknown> | null = null;
+
+class RedisTimeoutError extends Error {
+  constructor(
+    readonly redisTimeoutPhase: RedisTimeoutPhase,
+    readonly redisTimeoutMs: number
+  ) {
+    super(`Redis timeout (${redisTimeoutPhase})`);
+    this.name = 'RedisTimeoutError';
+  }
+}
+
+function captureRedisOperationException(
+  err: unknown,
+  operation: RedisOperation,
+  key: RedisKey,
+  c: RedisClient
+) {
+  const timeoutPhase = err instanceof RedisTimeoutError ? err.redisTimeoutPhase : undefined;
+  captureException(err, {
+    tags: {
+      service: 'redis',
+      operation,
+      ...(timeoutPhase ? { redis_timeout_phase: timeoutPhase } : {}),
+    },
+    extra: {
+      key,
+      client_is_open: c.isOpen,
+      client_is_ready: c.isReady,
+      redis_timeout_ms: err instanceof RedisTimeoutError ? err.redisTimeoutMs : undefined,
+    },
+  });
+}
 
 function getOrCreateClient(): RedisClient | null {
   if (!process.env.REDIS_URL) {
@@ -48,12 +82,16 @@ async function ensureConnected(c: RedisClient): Promise<RedisClient> {
   return c;
 }
 
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  redisTimeoutPhase: RedisTimeoutPhase
+): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
   return Promise.race([
     promise.finally(() => clearTimeout(timer)),
     new Promise<never>((_, reject) => {
-      timer = setTimeout(() => reject(new Error('Redis timeout')), ms);
+      timer = setTimeout(() => reject(new RedisTimeoutError(redisTimeoutPhase, ms)), ms);
     }),
   ]);
 }
@@ -62,10 +100,10 @@ export async function redisGet(key: RedisKey): Promise<string | null> {
   const c = getOrCreateClient();
   if (!c) return null;
   try {
-    await withTimeout(ensureConnected(c), CONNECT_TIMEOUT_MS);
-    return await withTimeout(c.get(key), COMMAND_TIMEOUT_MS);
+    await withTimeout(ensureConnected(c), CONNECT_TIMEOUT_MS, 'connect');
+    return await withTimeout(c.get(key), COMMAND_TIMEOUT_MS, 'command');
   } catch (err) {
-    captureException(err, { tags: { service: 'redis', operation: 'get' }, extra: { key } });
+    captureRedisOperationException(err, 'get', key, c);
     throw err;
   }
 }
@@ -74,10 +112,10 @@ export async function redisGetDel(key: RedisKey): Promise<string | null> {
   const c = getOrCreateClient();
   if (!c) return null;
   try {
-    await withTimeout(ensureConnected(c), CONNECT_TIMEOUT_MS);
-    return await withTimeout(c.getDel(key), COMMAND_TIMEOUT_MS);
+    await withTimeout(ensureConnected(c), CONNECT_TIMEOUT_MS, 'connect');
+    return await withTimeout(c.getDel(key), COMMAND_TIMEOUT_MS, 'command');
   } catch (err) {
-    captureException(err, { tags: { service: 'redis', operation: 'getdel' }, extra: { key } });
+    captureRedisOperationException(err, 'getdel', key, c);
     throw err;
   }
 }
@@ -91,15 +129,15 @@ export async function redisSet(
   const c = getOrCreateClient();
   if (!c) return false;
   try {
-    await withTimeout(ensureConnected(c), CONNECT_TIMEOUT_MS);
+    await withTimeout(ensureConnected(c), CONNECT_TIMEOUT_MS, 'connect');
     if (ttlSeconds) {
-      await withTimeout(c.set(key, value, { EX: ttlSeconds }), COMMAND_TIMEOUT_MS);
+      await withTimeout(c.set(key, value, { EX: ttlSeconds }), COMMAND_TIMEOUT_MS, 'command');
     } else {
-      await withTimeout(c.set(key, value), COMMAND_TIMEOUT_MS);
+      await withTimeout(c.set(key, value), COMMAND_TIMEOUT_MS, 'command');
     }
     return true;
   } catch (err) {
-    captureException(err, { tags: { service: 'redis', operation: 'set' }, extra: { key } });
+    captureRedisOperationException(err, 'set', key, c);
     throw err;
   }
 }
@@ -109,11 +147,11 @@ export async function redisDel(key: RedisKey): Promise<boolean> {
   const c = getOrCreateClient();
   if (!c) return false;
   try {
-    await withTimeout(ensureConnected(c), CONNECT_TIMEOUT_MS);
-    await withTimeout(c.del(key), COMMAND_TIMEOUT_MS);
+    await withTimeout(ensureConnected(c), CONNECT_TIMEOUT_MS, 'connect');
+    await withTimeout(c.del(key), COMMAND_TIMEOUT_MS, 'command');
     return true;
   } catch (err) {
-    captureException(err, { tags: { service: 'redis', operation: 'del' }, extra: { key } });
+    captureRedisOperationException(err, 'del', key, c);
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
- Add phase-aware Redis timeout errors so timeout logs and Sentry events distinguish connection waits from command waits.
- Include Redis client readiness/open state and the timeout budget in Sentry extras for follow-up investigation.

## Verification
N/A - observability-only helper change; no manual runtime verification performed.

## Visual Changes
N/A

## Reviewer Notes
This does not change Redis timeout budgets or connection behavior. It changes timeout error messages from `Redis timeout` to `Redis timeout (connect)` or `Redis timeout (command)` and adds a `redis_timeout_phase` tag in Sentry.