### PR TITLE
fix(session-ingest): extend queue retry delay

### DIFF
--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -44,7 +44,12 @@ vi.mock('./util/ingest-limits', () => ({
 import { getWorkerDb } from '@kilocode/db/client';
 import { getSessionIngestDO } from './dos/SessionIngestDO';
 import { notifyUserSessionEvent } from './session-events';
-import { computeSessionMetadataUpdates, createItemExtractor, queue } from './queue-consumer';
+import {
+  QUEUE_RETRY_DELAY_SECONDS,
+  computeSessionMetadataUpdates,
+  createItemExtractor,
+  queue,
+} from './queue-consumer';
 
 const encoder = new TextEncoder();
 
@@ -176,7 +181,7 @@ describe('queue', () => {
     );
 
     expect(ack).not.toHaveBeenCalled();
-    expect(retry).toHaveBeenCalledWith({ delaySeconds: 60 });
+    expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
   });
 
   it('passes full parsed oversized message data and its R2 reference into ingest', async () => {

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -20,6 +20,8 @@ export interface IngestQueueMessage {
   ingestedAt: number;
 }
 
+export const QUEUE_RETRY_DELAY_SECONDS = 5 * 60;
+
 function elapsedMs(startedAt: number): number {
   return Date.now() - startedAt;
 }
@@ -540,7 +542,7 @@ export async function queue(
         sessionId: msg.body.sessionId,
         error: err instanceof Error ? err.message : String(err),
       });
-      msg.retry({ delaySeconds: 60 });
+      msg.retry({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
     }
   }
 }


### PR DESCRIPTION
## Summary
- Increase failed session-ingest queue retry delay from 60s to 5 minutes.
- Define the retry delay as a named constant and update the queue consumer test.

## Validation
- pnpm --filter cloudflare-session-ingest exec vitest run src/queue-consumer.test.ts
- pnpm run format:check