### PR TITLE
fix(mobile): stabilize Android agent sessions

### DIFF
--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -1,4 +1,6 @@
 import { Stack } from 'expo-router';
+import { Platform, StatusBar, useWindowDimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { UserWebConnectionProvider } from '@/components/agents/user-web-connection-provider';
 import { KiloChatPresenceMount } from '@/components/kilo-chat/kilo-chat-presence-mount';
@@ -8,6 +10,12 @@ import { StoreKiloPassPurchaseProvider } from '@/lib/kilo-pass/use-store-kilo-pa
 
 export default function AppLayout() {
   const colors = useThemeColors();
+  const { height } = useWindowDimensions();
+  const { top } = useSafeAreaInsets();
+  const androidTopInset = top > 0 ? top : (StatusBar.currentHeight ?? 0);
+  const androidFullSheetDetent =
+    height > 0 ? Math.max(0.5, (height - androidTopInset) / height) : 1;
+  const fullSheetDetent = Platform.OS === 'android' ? androidFullSheetDetent : 1;
 
   return (
     <UserWebConnectionProvider>
@@ -29,7 +37,7 @@ export default function AppLayout() {
                 name="agent-chat/model-picker"
                 options={{
                   presentation: 'formSheet',
-                  sheetAllowedDetents: [0.5, 1],
+                  sheetAllowedDetents: [0.5, fullSheetDetent],
                   sheetGrabberVisible: true,
                   headerShown: false,
                 }}
@@ -38,7 +46,7 @@ export default function AppLayout() {
                 name="agent-chat/repo-picker"
                 options={{
                   presentation: 'formSheet',
-                  sheetAllowedDetents: [0.5, 1],
+                  sheetAllowedDetents: [0.5, fullSheetDetent],
                   sheetGrabberVisible: true,
                   headerShown: false,
                 }}

--- a/apps/mobile/src/app/(app)/agent-chat/model-picker.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/model-picker.tsx
@@ -2,7 +2,8 @@ import * as Haptics from 'expo-haptics';
 import { useFocusEffect, useRouter } from 'expo-router';
 import { BrainCircuit, Check, Search } from 'lucide-react-native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Pressable, ScrollView, TextInput, View } from 'react-native';
+import { FlatList, Pressable, ScrollView, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Text } from '@/components/ui/text';
 import {
@@ -13,11 +14,8 @@ import {
 } from '@/lib/free-model-data-disclosure';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { type ModelOption, thinkingEffortLabel } from '@/lib/hooks/use-available-models';
+import { buildModelPickerRows, type ModelPickerRow } from '@/lib/model-picker-rows';
 import { clearModelPickerBridge, getModelPickerBridge } from '@/lib/picker-bridge';
-
-type ModelPickerRow =
-  | { key: string; title: string; type: 'header' }
-  | { key: string; model: ModelOption; type: 'model' };
 
 function getVariantForModel(model: ModelOption, currentVariant: string) {
   if (currentVariant && model.variants.includes(currentVariant)) {
@@ -29,6 +27,7 @@ function getVariantForModel(model: ModelOption, currentVariant: string) {
 export default function ModelPickerScreen() {
   const router = useRouter();
   const colors = useThemeColors();
+  const { bottom } = useSafeAreaInsets();
   const [search, setSearch] = useState('');
   const [bridge, setBridge] = useState(() => getModelPickerBridge());
 
@@ -93,34 +92,10 @@ export default function ModelPickerScreen() {
     setSelectedVariant(nextVariant);
   }, [currentModelOption]);
 
-  const rows = useMemo<ModelPickerRow[]>(() => {
-    if (!bridge) {
-      return [];
-    }
-
-    const query = search.toLowerCase().trim();
-    const filtered = bridge.options.filter(
-      m => !query || m.name.toLowerCase().includes(query) || m.id.toLowerCase().includes(query)
-    );
-
-    const recommended = filtered.filter(m => m.isPreferred);
-    const all = filtered.filter(m => !m.isPreferred);
-    const result: ModelPickerRow[] = [];
-
-    if (recommended.length > 0) {
-      result.push({ key: 'recommended', title: 'RECOMMENDED', type: 'header' });
-      for (const modelOption of recommended) {
-        result.push({ key: `model:${modelOption.id}`, model: modelOption, type: 'model' });
-      }
-    }
-    if (all.length > 0) {
-      result.push({ key: 'all', title: 'ALL MODELS', type: 'header' });
-      for (const modelOption of all) {
-        result.push({ key: `model:${modelOption.id}`, model: modelOption, type: 'model' });
-      }
-    }
-    return result;
-  }, [bridge, search]);
+  const rows = useMemo<ModelPickerRow[]>(
+    () => buildModelPickerRows({ models: bridge?.options ?? [], search }),
+    [bridge, search]
+  );
 
   const handleSelectVariant = useCallback(
     (variant: string) => {
@@ -169,138 +144,140 @@ export default function ModelPickerScreen() {
   }
 
   return (
-    <ScrollView
+    <FlatList
       className="flex-1 bg-background"
+      data={rows}
+      keyExtractor={item => item.key}
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
-    >
-      <View className="border-b border-border bg-background px-4 pb-3 pt-4">
-        <View className="h-11 flex-row items-center justify-center">
-          <Text className="text-lg font-semibold text-foreground">Select Model</Text>
-          <Pressable
-            onPress={closePicker}
-            hitSlop={8}
-            accessibilityRole="button"
-            accessibilityLabel="Done selecting model"
-            className="absolute right-0 rounded-full bg-secondary px-4 py-2 active:opacity-70 will-change-pressable"
-          >
-            <Text className="text-base font-medium text-foreground">Done</Text>
-          </Pressable>
+      contentContainerStyle={{ paddingBottom: bottom }}
+      ListHeaderComponent={
+        <View className="border-b border-border bg-background px-4 pb-3 pt-4">
+          <View className="h-11 flex-row items-center justify-center">
+            <Text className="text-lg font-semibold text-foreground">Select Model</Text>
+            <Pressable
+              onPress={closePicker}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel="Done selecting model"
+              className="absolute right-0 rounded-full bg-secondary px-4 py-2 active:opacity-70 will-change-pressable"
+            >
+              <Text className="text-base font-medium text-foreground">Done</Text>
+            </Pressable>
+          </View>
+          <View className="mt-2 flex-row items-center gap-2 rounded-full bg-secondary px-3 py-2">
+            <Search size={18} color={colors.mutedForeground} />
+            <TextInput
+              placeholder="Search models..."
+              placeholderTextColor={colors.mutedForeground}
+              autoCapitalize="none"
+              autoCorrect={false}
+              clearButtonMode="while-editing"
+              returnKeyType="search"
+              className="h-8 flex-1 p-0 text-base text-foreground"
+              style={{ color: colors.foreground }}
+              onChangeText={setSearch}
+            />
+          </View>
         </View>
-        <View className="mt-2 flex-row items-center gap-2 rounded-full bg-secondary px-3 py-2">
-          <Search size={18} color={colors.mutedForeground} />
-          <TextInput
-            placeholder="Search models..."
-            placeholderTextColor={colors.mutedForeground}
-            autoCapitalize="none"
-            autoCorrect={false}
-            clearButtonMode="while-editing"
-            returnKeyType="search"
-            className="h-8 flex-1 p-0 text-base text-foreground"
-            style={{ color: colors.foreground }}
-            onChangeText={setSearch}
-          />
-        </View>
-      </View>
-
-      {rows.length === 0 ? (
+      }
+      ListEmptyComponent={
         <View className="items-center justify-center px-6 py-16">
           <Text className="text-center text-sm text-muted-foreground">
             {search.trim() ? 'No models match your search' : 'No models available'}
           </Text>
         </View>
-      ) : (
-        rows.map(item => {
-          if (item.type === 'header') {
-            return (
-              <View key={item.key} className="bg-secondary px-4 py-2">
-                <Text className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                  {item.title}
-                </Text>
-              </View>
-            );
-          }
-
-          const modelOption = item.model;
-          const selected = modelOption.id === selectedModel;
-          const free = isFreeModelOption(modelOption);
-          const collectsData = isFreeModelOption(modelOption);
-          const hasVariants = modelOption.variants.length > 1;
-
+      }
+      renderItem={({ item }) => {
+        if (item.type === 'header') {
           return (
-            <View key={item.key} className="border-b border-border">
-              <Pressable
-                className="flex-row items-center gap-3 px-4 py-3 active:bg-secondary will-change-pressable"
-                onPress={() => {
-                  handleSelectModel(modelOption.id);
-                }}
-                accessibilityRole="button"
-                accessibilityLabel={`${collectsData ? getFreeModelDataAccessibilityLabel(modelOption.name) : modelOption.name}${selected ? ', selected' : ''}`}
-              >
-                <View className="flex-1">
-                  <Text className="text-base text-foreground">{modelOption.name}</Text>
-                  <Text className="text-xs text-muted-foreground">{modelOption.id}</Text>
-                  {free ? (
-                    <View className="mt-1 flex-row items-center gap-1 self-start">
-                      <View
-                        className="rounded-full px-2 py-0.5"
-                        style={{ backgroundColor: colors.good }}
-                      >
-                        <Text className="text-[11px] font-medium text-white" numberOfLines={1}>
-                          {FREE_MODEL_FREE_LABEL}
-                        </Text>
-                      </View>
-                      {collectsData ? (
-                        <BrainCircuit
-                          accessibilityLabel={FREE_MODEL_DATA_LABEL}
-                          size={13}
-                          color={colors.warn}
-                        />
-                      ) : null}
-                    </View>
-                  ) : null}
-                </View>
-                {selected && <Check size={18} color={colors.primary} />}
-              </Pressable>
-
-              {selected && hasVariants ? (
-                <View className="px-4 pb-3">
-                  <Text className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Thinking effort
-                  </Text>
-                  <ScrollView
-                    horizontal
-                    showsHorizontalScrollIndicator={false}
-                    contentContainerClassName="gap-2"
-                    keyboardShouldPersistTaps="handled"
-                  >
-                    {modelOption.variants.map(variant => {
-                      const isActive = variant === selectedVariant;
-                      return (
-                        <Pressable
-                          key={variant}
-                          className={`rounded-full px-3 py-1.5 ${isActive ? 'bg-foreground' : 'bg-secondary'}`}
-                          onPress={() => {
-                            handleSelectVariant(variant);
-                          }}
-                          accessibilityRole="button"
-                          accessibilityLabel={`${thinkingEffortLabel(variant)} thinking effort${isActive ? ', selected' : ''}`}
-                        >
-                          <Text
-                            className={`text-sm font-medium ${isActive ? 'text-background' : 'text-foreground'}`}
-                          >
-                            {thinkingEffortLabel(variant)}
-                          </Text>
-                        </Pressable>
-                      );
-                    })}
-                  </ScrollView>
-                </View>
-              ) : null}
+            <View className="bg-secondary px-4 py-2">
+              <Text className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {item.title}
+              </Text>
             </View>
           );
-        })
-      )}
-    </ScrollView>
+        }
+
+        const modelOption = item.model;
+        const selected = modelOption.id === selectedModel;
+        const free = isFreeModelOption(modelOption);
+        const collectsData = isFreeModelOption(modelOption);
+        const hasVariants = modelOption.variants.length > 1;
+
+        return (
+          <View className="border-b border-border">
+            <Pressable
+              className="flex-row items-center gap-3 px-4 py-3 active:bg-secondary will-change-pressable"
+              onPress={() => {
+                handleSelectModel(modelOption.id);
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={`${collectsData ? getFreeModelDataAccessibilityLabel(modelOption.name) : modelOption.name}${selected ? ', selected' : ''}`}
+            >
+              <View className="flex-1">
+                <Text className="text-base text-foreground">{modelOption.name}</Text>
+                <Text className="text-xs text-muted-foreground">{modelOption.id}</Text>
+                {free ? (
+                  <View className="mt-1 flex-row items-center gap-1 self-start">
+                    <View
+                      className="rounded-full px-2 py-0.5"
+                      style={{ backgroundColor: colors.good }}
+                    >
+                      <Text className="text-[11px] font-medium text-white" numberOfLines={1}>
+                        {FREE_MODEL_FREE_LABEL}
+                      </Text>
+                    </View>
+                    {collectsData ? (
+                      <BrainCircuit
+                        accessibilityLabel={FREE_MODEL_DATA_LABEL}
+                        size={13}
+                        color={colors.warn}
+                      />
+                    ) : null}
+                  </View>
+                ) : null}
+              </View>
+              {selected && <Check size={18} color={colors.primary} />}
+            </Pressable>
+
+            {selected && hasVariants ? (
+              <View className="px-4 pb-3">
+                <Text className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Thinking effort
+                </Text>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerClassName="gap-2"
+                  keyboardShouldPersistTaps="handled"
+                >
+                  {modelOption.variants.map(variant => {
+                    const isActive = variant === selectedVariant;
+                    return (
+                      <Pressable
+                        key={variant}
+                        className={`rounded-full px-3 py-1.5 ${isActive ? 'bg-foreground' : 'bg-secondary'}`}
+                        onPress={() => {
+                          handleSelectVariant(variant);
+                        }}
+                        accessibilityRole="button"
+                        accessibilityLabel={`${thinkingEffortLabel(variant)} thinking effort${isActive ? ', selected' : ''}`}
+                      >
+                        <Text
+                          className={`text-sm font-medium ${isActive ? 'text-background' : 'text-foreground'}`}
+                        >
+                          {thinkingEffortLabel(variant)}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </ScrollView>
+              </View>
+            ) : null}
+          </View>
+        );
+      }}
+    />
   );
 }

--- a/apps/mobile/src/app/(app)/agent-chat/new.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/new.tsx
@@ -9,7 +9,7 @@ import {
   View,
 } from 'react-native';
 import { type Href, useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { generateMessageId } from 'cloud-agent-sdk/message-id';
 import * as Haptics from 'expo-haptics';
 import { toast } from 'sonner-native';
@@ -21,6 +21,7 @@ import { useTextHeight } from '@/components/agents/use-text-height';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { ScreenHeader } from '@/components/screen-header';
+import { invalidateAgentSessionQueries } from '@/lib/agent-session-cache';
 import { useAvailableModels } from '@/lib/hooks/use-available-models';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { trpcClient, useTRPC } from '@/lib/trpc';
@@ -46,6 +47,7 @@ export default function NewSessionScreen() {
   const router = useRouter();
   const navigation = useNavigation();
   const colors = useThemeColors();
+  const queryClient = useQueryClient();
   const { organizationId } = useLocalSearchParams<{ organizationId?: string }>();
 
   // ── Selectors state ──────────────────────────────────────────────
@@ -139,6 +141,7 @@ export default function NewSessionScreen() {
           })
         : await trpcClient.cloudAgentNext.prepareSession.mutate(baseInput);
 
+      await invalidateAgentSessionQueries(queryClient, trpc);
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       const path = organizationId
         ? `/(app)/agent-chat/${result.kiloSessionId}?organizationId=${organizationId}`
@@ -163,7 +166,7 @@ export default function NewSessionScreen() {
     } finally {
       setIsCreating(false);
     }
-  }, [selectedRepo, model, mode, variant, organizationId, router, navigation]);
+  }, [selectedRepo, model, mode, variant, organizationId, queryClient, trpc, router, navigation]);
 
   const canStart = hasPrompt && selectedRepo.length > 0 && model.length > 0 && !isCreating;
 

--- a/apps/mobile/src/app/(app)/agent-chat/new.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/new.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   type LayoutChangeEvent,
+  Platform,
   ScrollView,
   TextInput,
   type TextStyle,
@@ -28,7 +29,8 @@ const PROMPT_INPUT_DEFAULT_LINES = 3;
 const PROMPT_INPUT_MAX_LINES = 6;
 const PROMPT_INPUT_LINE_HEIGHT = 24;
 const PROMPT_INPUT_VERTICAL_PADDING = 32;
-const PROMPT_INPUT_HORIZONTAL_PADDING = 32;
+const PROMPT_INPUT_HORIZONTAL_PADDING = Platform.OS === 'android' ? 48 : 32;
+const PROMPT_INPUT_ANDROID_HORIZONTAL_INSET = 24;
 const PROMPT_INPUT_MIN_HEIGHT =
   PROMPT_INPUT_LINE_HEIGHT * PROMPT_INPUT_DEFAULT_LINES + PROMPT_INPUT_VERTICAL_PADDING;
 const PROMPT_INPUT_MAX_HEIGHT =
@@ -187,7 +189,13 @@ export default function NewSessionScreen() {
             placeholderTextColor={colors.mutedForeground}
             multiline
             className="px-4 py-4 text-base leading-6 text-foreground"
-            style={[promptInputStyle, { height: promptMeasure.height }]}
+            style={[
+              promptInputStyle,
+              { height: promptMeasure.height },
+              Platform.OS === 'android'
+                ? { paddingHorizontal: PROMPT_INPUT_ANDROID_HORIZONTAL_INSET }
+                : undefined,
+            ]}
             onChangeText={text => {
               promptRef.current = text;
               promptMeasure.setText(text);

--- a/apps/mobile/src/app/(app)/agent-chat/repo-picker.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/repo-picker.tsx
@@ -2,15 +2,18 @@ import { useFocusEffect, useRouter } from 'expo-router';
 import * as Haptics from 'expo-haptics';
 import { Check, Lock, Search, Unlock } from 'lucide-react-native';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { Pressable, ScrollView, TextInput, View } from 'react-native';
+import { FlatList, Pressable, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { clearRepoPickerBridge, getRepoPickerBridge } from '@/lib/picker-bridge';
+import { filterRepoPickerOptions } from '@/lib/repo-picker-filter';
 
 export default function RepoPickerScreen() {
   const router = useRouter();
   const colors = useThemeColors();
+  const { bottom } = useSafeAreaInsets();
   const [search, setSearch] = useState('');
   const [bridge, setBridge] = useState(() => getRepoPickerBridge());
 
@@ -34,16 +37,10 @@ export default function RepoPickerScreen() {
     }, [])
   );
 
-  const filtered = useMemo(() => {
-    if (!bridge) {
-      return [];
-    }
-    if (!search) {
-      return bridge.repositories;
-    }
-    const q = search.toLowerCase();
-    return bridge.repositories.filter(r => r.fullName.toLowerCase().includes(q));
-  }, [bridge, search]);
+  const filtered = useMemo(
+    () => filterRepoPickerOptions({ repositories: bridge?.repositories ?? [], search }),
+    [bridge, search]
+  );
 
   const handleSelect = useCallback(
     (repo: string) => {
@@ -65,71 +62,72 @@ export default function RepoPickerScreen() {
   }
 
   return (
-    <ScrollView
+    <FlatList
       className="flex-1 bg-background"
+      data={filtered}
+      keyExtractor={repo => repo.fullName}
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
-    >
-      <View className="border-b border-border bg-background px-4 pb-3 pt-4">
-        <View className="h-11 flex-row items-center justify-center">
-          <Text className="text-lg font-semibold text-foreground">Select Repository</Text>
-          <Pressable
-            onPress={closePicker}
-            hitSlop={8}
-            accessibilityRole="button"
-            accessibilityLabel="Close repository picker"
-            className="absolute right-0 rounded-full bg-secondary px-4 py-2 active:opacity-70 will-change-pressable"
-          >
-            <Text className="text-base font-medium text-foreground">Done</Text>
-          </Pressable>
+      contentContainerStyle={{ paddingBottom: bottom }}
+      ListHeaderComponent={
+        <View className="border-b border-border bg-background px-4 pb-3 pt-4">
+          <View className="h-11 flex-row items-center justify-center">
+            <Text className="text-lg font-semibold text-foreground">Select Repository</Text>
+            <Pressable
+              onPress={closePicker}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel="Close repository picker"
+              className="absolute right-0 rounded-full bg-secondary px-4 py-2 active:opacity-70 will-change-pressable"
+            >
+              <Text className="text-base font-medium text-foreground">Done</Text>
+            </Pressable>
+          </View>
+          <View className="mt-2 flex-row items-center gap-2 rounded-full bg-secondary px-3 py-2">
+            <Search size={18} color={colors.mutedForeground} />
+            <TextInput
+              placeholder="Search repositories..."
+              placeholderTextColor={colors.mutedForeground}
+              autoCapitalize="none"
+              autoCorrect={false}
+              clearButtonMode="while-editing"
+              returnKeyType="search"
+              className="h-8 flex-1 p-0 text-base text-foreground"
+              style={{ color: colors.foreground }}
+              onChangeText={setSearch}
+            />
+          </View>
         </View>
-        <View className="mt-2 flex-row items-center gap-2 rounded-full bg-secondary px-3 py-2">
-          <Search size={18} color={colors.mutedForeground} />
-          <TextInput
-            placeholder="Search repositories..."
-            placeholderTextColor={colors.mutedForeground}
-            autoCapitalize="none"
-            autoCorrect={false}
-            clearButtonMode="while-editing"
-            returnKeyType="search"
-            className="h-8 flex-1 p-0 text-base text-foreground"
-            style={{ color: colors.foreground }}
-            onChangeText={setSearch}
-          />
-        </View>
-      </View>
-
-      {filtered.length === 0 ? (
+      }
+      ListEmptyComponent={
         <View className="items-center justify-center px-6 py-16">
           <Text className="text-center text-sm text-muted-foreground">
             {search.trim() ? 'No repositories match your search' : 'No repositories available'}
           </Text>
         </View>
-      ) : (
-        filtered.map(repo => (
-          <Pressable
-            key={repo.fullName}
-            className="flex-row items-center gap-3 border-b border-border px-4 py-3 active:bg-secondary will-change-pressable"
-            onPress={() => {
-              handleSelect(repo.fullName);
-            }}
-            accessibilityRole="button"
-            accessibilityLabel={repo.fullName}
-          >
-            {repo.isPrivate ? (
-              <Lock size={14} color={colors.mutedForeground} />
-            ) : (
-              <Unlock size={14} color={colors.mutedForeground} />
-            )}
-            <Text className="flex-1 text-base text-foreground" numberOfLines={1}>
-              {repo.fullName}
-            </Text>
-            {bridge.currentValue === repo.fullName ? (
-              <Check size={18} color={colors.primary} />
-            ) : null}
-          </Pressable>
-        ))
+      }
+      renderItem={({ item: repo }) => (
+        <Pressable
+          className="flex-row items-center gap-3 border-b border-border px-4 py-3 active:bg-secondary will-change-pressable"
+          onPress={() => {
+            handleSelect(repo.fullName);
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={repo.fullName}
+        >
+          {repo.isPrivate ? (
+            <Lock size={14} color={colors.mutedForeground} />
+          ) : (
+            <Unlock size={14} color={colors.mutedForeground} />
+          )}
+          <Text className="flex-1 text-base text-foreground" numberOfLines={1}>
+            {repo.fullName}
+          </Text>
+          {bridge.currentValue === repo.fullName ? (
+            <Check size={18} color={colors.primary} />
+          ) : null}
+        </Pressable>
       )}
-    </ScrollView>
+    />
   );
 }

--- a/apps/mobile/src/components/agents/mobile-session-manager.test.ts
+++ b/apps/mobile/src/components/agents/mobile-session-manager.test.ts
@@ -4,6 +4,7 @@ import { type UserWebConnection } from 'cloud-agent-sdk';
 
 const mocks = vi.hoisted(() => ({
   createSessionManager: vi.fn(config => ({ config })),
+  createNativeUserWebConnectionLifecycleHooks: vi.fn(() => ({ marker: 'native-lifecycle-hooks' })),
   getWithRuntimeStateQuery: vi.fn(),
 }));
 
@@ -50,6 +51,10 @@ vi.mock('@/components/agents/mobile-session-diagnostics', () => ({
   ),
 }));
 
+vi.mock('@/lib/user-web-connection-lifecycle', () => ({
+  createNativeUserWebConnectionLifecycleHooks: mocks.createNativeUserWebConnectionLifecycleHooks,
+}));
+
 vi.mock('@/lib/config', () => ({
   API_BASE_URL: 'https://api.example.com',
   CLOUD_AGENT_WS_URL: 'wss://agent.example.com',
@@ -68,6 +73,7 @@ type CapturedSessionManagerConfig = {
   userWebConnection: unknown;
   cliWebsocketUrl?: string;
   getAuthToken?: () => Promise<string>;
+  lifecycleHooks?: unknown;
   fetchSession: (kiloSessionId: string) => Promise<{ associatedPr: unknown }>;
 };
 
@@ -89,6 +95,20 @@ describe('createMobileAgentSessionManager', () => {
     expect(config.userWebConnection).toBe(userWebConnection);
     expect(config.cliWebsocketUrl).toBeUndefined();
     expect(config.getAuthToken).toBeUndefined();
+  });
+
+  it('passes native lifecycle hooks to Cloud Agent stream connections', async () => {
+    const { createMobileAgentSessionManager } =
+      await import('@/components/agents/mobile-session-manager');
+
+    createMobileAgentSessionManager({
+      store: createStore(),
+      userWebConnection,
+    });
+
+    const config = mocks.createSessionManager.mock.calls[0]?.[0] as CapturedSessionManagerConfig;
+    expect(mocks.createNativeUserWebConnectionLifecycleHooks).toHaveBeenCalledTimes(1);
+    expect(config.lifecycleHooks).toEqual({ marker: 'native-lifecycle-hooks' });
   });
 
   it('propagates associatedPr from fetched session data', async () => {

--- a/apps/mobile/src/components/agents/mobile-session-manager.ts
+++ b/apps/mobile/src/components/agents/mobile-session-manager.ts
@@ -21,6 +21,7 @@ import { trpcClient } from '@/lib/trpc';
 import { API_BASE_URL, CLOUD_AGENT_WS_URL, WEB_BASE_URL } from '@/lib/config';
 import { AUTH_TOKEN_KEY } from '@/lib/storage-keys';
 import { type SendMessagePayload } from '@/lib/cloud-agent-next/types';
+import { createNativeUserWebConnectionLifecycleHooks } from '@/lib/user-web-connection-lifecycle';
 
 type CreateMobileAgentSessionManagerOptions = {
   store: JotaiStore;
@@ -63,6 +64,7 @@ export function createMobileAgentSessionManager({
     store,
     websocketBaseUrl: CLOUD_AGENT_WS_URL,
     websocketHeaders: { Origin: WEB_BASE_URL },
+    lifecycleHooks: createNativeUserWebConnectionLifecycleHooks(),
     userWebConnection,
     resolveSession: async (kiloSessionId: KiloSessionId): Promise<ResolvedSession> => {
       try {

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -13,7 +13,10 @@ import { QuestionCard } from '@/components/agents/question-card';
 import { getSessionKeyboardContainerKind } from '@/components/agents/session-keyboard-container-state';
 import { useSessionManager } from '@/components/agents/session-provider';
 import { SessionStatusIndicator } from '@/components/agents/session-status-indicator';
-import { shouldShowAgentWorkingIndicator } from '@/components/agents/session-working-state';
+import {
+  shouldShowAgentWorkingIndicator,
+  shouldShowFooterWorkingIndicator,
+} from '@/components/agents/session-working-state';
 import { AppAwareKeyboardPaddingView } from '@/components/kilo-chat/app-aware-keyboard-padding';
 import { useInteractionHandlers } from '@/components/agents/use-interaction-handlers';
 import { useSessionAutoScroll } from '@/components/agents/use-session-auto-scroll';
@@ -135,6 +138,10 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
   const shouldShowWorkingIndicator = shouldShowAgentWorkingIndicator({
     isStreaming,
     pendingMessageCount: pendingMessages.size,
+  });
+  const shouldShowFooterWorking = shouldShowFooterWorkingIndicator({
+    isAgentWorking: shouldShowWorkingIndicator,
+    hasStatusIndicator: statusIndicator !== null,
   });
 
   const emptyStateText = error ?? (statusIndicator ? null : 'No messages yet');
@@ -301,7 +308,7 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
         scrollEventThrottle={16}
         ListFooterComponent={
           <>
-            <WorkingIndicator messages={messages} isStreaming={shouldShowWorkingIndicator} />
+            <WorkingIndicator messages={messages} isStreaming={shouldShowFooterWorking} />
             {statusIndicator ? <SessionStatusIndicator indicator={statusIndicator} /> : null}
           </>
         }

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -10,9 +10,11 @@ import { ConnectivityBanner } from '@/components/agents/connectivity-banner';
 import { MessageBubble } from '@/components/agents/message-bubble';
 import { PermissionCard } from '@/components/agents/permission-card';
 import { QuestionCard } from '@/components/agents/question-card';
+import { getSessionKeyboardContainerKind } from '@/components/agents/session-keyboard-container-state';
 import { useSessionManager } from '@/components/agents/session-provider';
 import { SessionStatusIndicator } from '@/components/agents/session-status-indicator';
 import { shouldShowAgentWorkingIndicator } from '@/components/agents/session-working-state';
+import { AppAwareKeyboardPaddingView } from '@/components/kilo-chat/app-aware-keyboard-padding';
 import { useInteractionHandlers } from '@/components/agents/use-interaction-handlers';
 import { useSessionAutoScroll } from '@/components/agents/use-session-auto-scroll';
 import { useSessionConfigSync } from '@/components/agents/use-session-config-sync';
@@ -149,6 +151,7 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
     (requiresModel && !currentModel);
   const showInteractionCards = activeQuestion ?? activePermission;
   const composerPlaceholder = getComposerPlaceholder(cloudStatus?.type);
+  const keyboardContainerKind = getSessionKeyboardContainerKind(Platform.OS);
 
   const handleSend = useCallback(
     async (text: string) => {
@@ -186,10 +189,23 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
 
       {!isConnected && <ConnectivityBanner />}
 
-      <KeyboardAvoidingView
-        className="flex-1"
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      >
+      {keyboardContainerKind === 'app-aware-padding' ? (
+        <AppAwareKeyboardPaddingView className="flex-1">
+          {renderKeyboardBody()}
+        </AppAwareKeyboardPaddingView>
+      ) : (
+        <KeyboardAvoidingView className="flex-1" behavior="padding">
+          {renderKeyboardBody()}
+        </KeyboardAvoidingView>
+      )}
+
+      <View style={{ height: bottom }} className="bg-background" />
+    </View>
+  );
+
+  function renderKeyboardBody() {
+    return (
+      <>
         <View className="flex-1">{renderContent()}</View>
 
         {activeQuestion ? (
@@ -242,11 +258,9 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
               }}
             />
           ))}
-      </KeyboardAvoidingView>
-
-      <View style={{ height: bottom }} className="bg-background" />
-    </View>
-  );
+      </>
+    );
+  }
 
   function renderContent() {
     if (shouldBlockMessages) {

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -141,7 +141,8 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
   });
   const shouldShowFooterWorking = shouldShowFooterWorkingIndicator({
     isAgentWorking: shouldShowWorkingIndicator,
-    hasStatusIndicator: statusIndicator !== null,
+    hasStatusIndicator:
+      statusIndicator !== null || (cloudStatus !== null && cloudStatus.type !== 'ready'),
   });
 
   const emptyStateText = error ?? (statusIndicator ? null : 'No messages yet');

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -12,6 +12,7 @@ import { PermissionCard } from '@/components/agents/permission-card';
 import { QuestionCard } from '@/components/agents/question-card';
 import { useSessionManager } from '@/components/agents/session-provider';
 import { SessionStatusIndicator } from '@/components/agents/session-status-indicator';
+import { shouldShowAgentWorkingIndicator } from '@/components/agents/session-working-state';
 import { useInteractionHandlers } from '@/components/agents/use-interaction-handlers';
 import { useSessionAutoScroll } from '@/components/agents/use-session-auto-scroll';
 import { useSessionConfigSync } from '@/components/agents/use-session-config-sync';
@@ -54,6 +55,7 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
   const activePermission = useAtomValue(manager.atoms.activePermission);
   const totalCost = useAtomValue(manager.atoms.totalCost);
   const getChildMessages = useAtomValue(manager.atoms.childMessages);
+  const pendingMessages = useAtomValue(manager.atoms.pendingMessages);
 
   const { isConnected } = useAppLifecycle();
   const { bottom } = useSafeAreaInsets();
@@ -128,6 +130,10 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
     (fetchedData === null && !statusIndicator && !error) ||
     (fetchedData !== null && fetchedData.kiloSessionId !== sessionId);
   const shouldBlockMessages = shouldShowLoading;
+  const shouldShowWorkingIndicator = shouldShowAgentWorkingIndicator({
+    isStreaming,
+    pendingMessageCount: pendingMessages.size,
+  });
 
   const emptyStateText = error ?? (statusIndicator ? null : 'No messages yet');
 
@@ -281,7 +287,7 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
         scrollEventThrottle={16}
         ListFooterComponent={
           <>
-            <WorkingIndicator messages={messages} isStreaming={isStreaming} />
+            <WorkingIndicator messages={messages} isStreaming={shouldShowWorkingIndicator} />
             {statusIndicator ? <SessionStatusIndicator indicator={statusIndicator} /> : null}
           </>
         }

--- a/apps/mobile/src/components/agents/session-keyboard-container-state.test.ts
+++ b/apps/mobile/src/components/agents/session-keyboard-container-state.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSessionKeyboardContainerKind } from '@/components/agents/session-keyboard-container-state';
+
+describe('getSessionKeyboardContainerKind', () => {
+  it('uses app-aware padding on Android', () => {
+    expect(getSessionKeyboardContainerKind('android')).toBe('app-aware-padding');
+  });
+
+  it('keeps keyboard avoiding behavior on iOS', () => {
+    expect(getSessionKeyboardContainerKind('ios')).toBe('keyboard-avoiding');
+  });
+});

--- a/apps/mobile/src/components/agents/session-keyboard-container-state.ts
+++ b/apps/mobile/src/components/agents/session-keyboard-container-state.ts
@@ -1,0 +1,5 @@
+type SessionKeyboardContainerKind = 'app-aware-padding' | 'keyboard-avoiding';
+
+export function getSessionKeyboardContainerKind(platform: string): SessionKeyboardContainerKind {
+  return platform === 'android' ? 'app-aware-padding' : 'keyboard-avoiding';
+}

--- a/apps/mobile/src/components/agents/session-list-content.tsx
+++ b/apps/mobile/src/components/agents/session-list-content.tsx
@@ -17,8 +17,8 @@ import { useSessionMutations } from '@/lib/hooks/use-session-mutations';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { getTabBarOverlayHeight } from '@/lib/tab-bar-layout';
 
-// Height of the hidden-by-default search bar (mt-3 12 + border 1 + py-14 28 + line-20 + border 1 + mb-14 14 = 76).
-const SEARCH_BAR_HEIGHT = 76;
+// Height of the hidden-by-default search bar (mt-3 12 + border 1 + py-1.5 12 + line-20 + border 1 + mb-14 14 = 60).
+const SEARCH_BAR_HEIGHT = 60;
 
 type AgentSessionListContentProps = {
   sections: SessionSection[];
@@ -53,10 +53,10 @@ export function AgentSessionListContent({
 
   const listHeader = useMemo(
     () => (
-      <View className="mx-[22px] mb-[14px] mt-3 flex-row items-center gap-2 rounded-[10px] border border-border bg-card px-4 py-[14px]">
+      <View className="mx-[22px] mb-[14px] mt-3 flex-row items-center gap-2 rounded-[10px] border border-border bg-card px-4 py-1.5">
         <Search size={18} color={colors.mutedForeground} />
         <TextInput
-          className="flex-1 text-[15px] leading-5 text-foreground"
+          className="flex-1 text-[15px] text-foreground"
           placeholder="Search sessions..."
           placeholderTextColor={colors.mutedForeground}
           onChangeText={onSearchChange}

--- a/apps/mobile/src/components/agents/session-working-state.test.ts
+++ b/apps/mobile/src/components/agents/session-working-state.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { shouldShowAgentWorkingIndicator } from '@/components/agents/session-working-state';
+import {
+  shouldShowAgentWorkingIndicator,
+  shouldShowFooterWorkingIndicator,
+} from '@/components/agents/session-working-state';
 
 describe('shouldShowAgentWorkingIndicator', () => {
   it('shows while the agent is streaming', () => {
@@ -26,6 +29,35 @@ describe('shouldShowAgentWorkingIndicator', () => {
       shouldShowAgentWorkingIndicator({
         isStreaming: false,
         pendingMessageCount: 0,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('shouldShowFooterWorkingIndicator', () => {
+  it('shows the working indicator when the agent is working and no status indicator is visible', () => {
+    expect(
+      shouldShowFooterWorkingIndicator({
+        isAgentWorking: true,
+        hasStatusIndicator: false,
+      })
+    ).toBe(true);
+  });
+
+  it('hides the working indicator when a status indicator is already visible', () => {
+    expect(
+      shouldShowFooterWorkingIndicator({
+        isAgentWorking: true,
+        hasStatusIndicator: true,
+      })
+    ).toBe(false);
+  });
+
+  it('hides the working indicator when the agent is idle', () => {
+    expect(
+      shouldShowFooterWorkingIndicator({
+        isAgentWorking: false,
+        hasStatusIndicator: false,
       })
     ).toBe(false);
   });

--- a/apps/mobile/src/components/agents/session-working-state.test.ts
+++ b/apps/mobile/src/components/agents/session-working-state.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldShowAgentWorkingIndicator } from '@/components/agents/session-working-state';
+
+describe('shouldShowAgentWorkingIndicator', () => {
+  it('shows while the agent is streaming', () => {
+    expect(
+      shouldShowAgentWorkingIndicator({
+        isStreaming: true,
+        pendingMessageCount: 0,
+      })
+    ).toBe(true);
+  });
+
+  it('shows while a prompt is queued before streaming starts', () => {
+    expect(
+      shouldShowAgentWorkingIndicator({
+        isStreaming: false,
+        pendingMessageCount: 1,
+      })
+    ).toBe(true);
+  });
+
+  it('hides when there is no stream or queued prompt', () => {
+    expect(
+      shouldShowAgentWorkingIndicator({
+        isStreaming: false,
+        pendingMessageCount: 0,
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/mobile/src/components/agents/session-working-state.ts
+++ b/apps/mobile/src/components/agents/session-working-state.ts
@@ -3,9 +3,21 @@ type AgentWorkingIndicatorInput = {
   pendingMessageCount: number;
 };
 
+type FooterWorkingIndicatorInput = {
+  isAgentWorking: boolean;
+  hasStatusIndicator: boolean;
+};
+
 export function shouldShowAgentWorkingIndicator({
   isStreaming,
   pendingMessageCount,
 }: AgentWorkingIndicatorInput): boolean {
   return isStreaming || pendingMessageCount > 0;
+}
+
+export function shouldShowFooterWorkingIndicator({
+  isAgentWorking,
+  hasStatusIndicator,
+}: FooterWorkingIndicatorInput): boolean {
+  return isAgentWorking && !hasStatusIndicator;
 }

--- a/apps/mobile/src/components/agents/session-working-state.ts
+++ b/apps/mobile/src/components/agents/session-working-state.ts
@@ -1,0 +1,11 @@
+type AgentWorkingIndicatorInput = {
+  isStreaming: boolean;
+  pendingMessageCount: number;
+};
+
+export function shouldShowAgentWorkingIndicator({
+  isStreaming,
+  pendingMessageCount,
+}: AgentWorkingIndicatorInput): boolean {
+  return isStreaming || pendingMessageCount > 0;
+}

--- a/apps/mobile/src/components/app-root-providers.tsx
+++ b/apps/mobile/src/components/app-root-providers.tsx
@@ -8,6 +8,7 @@ import { Toaster } from 'sonner-native';
 import { AuthProvider } from '@/lib/auth/auth-context';
 import { OrganizationProvider } from '@/lib/organization-context';
 import { queryClient } from '@/lib/query-client';
+import { QueryClientNativeLifecycle } from '@/lib/query-client-lifecycle';
 import { trpcClient, TRPCProvider } from '@/lib/trpc';
 
 export function AppRootProviders({ children }: { readonly children: ReactNode }) {
@@ -15,6 +16,7 @@ export function AppRootProviders({ children }: { readonly children: ReactNode })
     <GestureHandlerRootView className="flex-1">
       <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
         <QueryClientProvider client={queryClient}>
+          <QueryClientNativeLifecycle />
           <AuthProvider>
             <OrganizationProvider>
               <ActionSheetProvider>

--- a/apps/mobile/src/lib/agent-session-cache.test.ts
+++ b/apps/mobile/src/lib/agent-session-cache.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { invalidateAgentSessionQueries } from '@/lib/agent-session-cache';
+
+describe('invalidateAgentSessionQueries', () => {
+  it('invalidates session list and recent repository queries', async () => {
+    const listFilter = { queryKey: ['cliSessionsV2', 'list'] };
+    const recentRepositoriesFilter = { queryKey: ['cliSessionsV2', 'recentRepositories'] };
+    const queryClient = {
+      invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    };
+    const trpc = {
+      cliSessionsV2: {
+        list: { pathFilter: () => listFilter },
+        recentRepositories: { pathFilter: () => recentRepositoriesFilter },
+      },
+    };
+
+    await invalidateAgentSessionQueries(queryClient, trpc);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(listFilter);
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(recentRepositoriesFilter);
+  });
+});

--- a/apps/mobile/src/lib/agent-session-cache.ts
+++ b/apps/mobile/src/lib/agent-session-cache.ts
@@ -1,0 +1,22 @@
+import { type QueryClient } from '@tanstack/react-query';
+
+type QueryPathFilter = {
+  pathFilter: () => Parameters<QueryClient['invalidateQueries']>[0];
+};
+
+type AgentSessionTrpcQueries = {
+  cliSessionsV2: {
+    list: QueryPathFilter;
+    recentRepositories: QueryPathFilter;
+  };
+};
+
+export async function invalidateAgentSessionQueries(
+  queryClient: Pick<QueryClient, 'invalidateQueries'>,
+  trpc: AgentSessionTrpcQueries
+): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries(trpc.cliSessionsV2.list.pathFilter()),
+    queryClient.invalidateQueries(trpc.cliSessionsV2.recentRepositories.pathFilter()),
+  ]);
+}

--- a/apps/mobile/src/lib/hooks/use-session-mutations.ts
+++ b/apps/mobile/src/lib/hooks/use-session-mutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner-native';
 
+import { invalidateAgentSessionQueries } from '@/lib/agent-session-cache';
 import { useTRPC } from '@/lib/trpc';
 
 const onError = (error: { message: string }) => {
@@ -12,10 +13,7 @@ export function useSessionMutations() {
   const queryClient = useQueryClient();
 
   const invalidateSessions = async () => {
-    await Promise.all([
-      queryClient.invalidateQueries(trpc.cliSessionsV2.list.pathFilter()),
-      queryClient.invalidateQueries(trpc.cliSessionsV2.recentRepositories.pathFilter()),
-    ]);
+    await invalidateAgentSessionQueries(queryClient, trpc);
   };
 
   const deleteSessionMutation = useMutation(

--- a/apps/mobile/src/lib/model-picker-rows.test.ts
+++ b/apps/mobile/src/lib/model-picker-rows.test.ts
@@ -29,8 +29,15 @@ describe('buildModelPickerRows', () => {
     ]);
   });
 
-  it('filters models by name and id', () => {
-    expect(buildModelPickerRows({ models, search: 'gpt-5' })).toEqual([
+  it('filters models by name', () => {
+    expect(buildModelPickerRows({ models, search: 'Sonnet 4' })).toEqual([
+      { key: 'recommended', title: 'RECOMMENDED', type: 'header' },
+      { key: 'model:anthropic/claude-sonnet-4', model: models[0], type: 'model' },
+    ]);
+  });
+
+  it('filters models by id', () => {
+    expect(buildModelPickerRows({ models, search: 'openai/' })).toEqual([
       { key: 'all', title: 'ALL MODELS', type: 'header' },
       { key: 'model:openai/gpt-5', model: models[1], type: 'model' },
     ]);

--- a/apps/mobile/src/lib/model-picker-rows.test.ts
+++ b/apps/mobile/src/lib/model-picker-rows.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { type ModelOption } from '@/lib/hooks/use-available-models';
+
+import { buildModelPickerRows } from './model-picker-rows';
+
+const models: ModelOption[] = [
+  {
+    id: 'anthropic/claude-sonnet-4',
+    name: 'Claude Sonnet 4',
+    variants: ['low'],
+    isPreferred: true,
+  },
+  {
+    id: 'openai/gpt-5',
+    name: 'GPT-5',
+    variants: ['medium'],
+    isPreferred: false,
+  },
+];
+
+describe('buildModelPickerRows', () => {
+  it('groups preferred models before all other models', () => {
+    expect(buildModelPickerRows({ models, search: '' })).toEqual([
+      { key: 'recommended', title: 'RECOMMENDED', type: 'header' },
+      { key: 'model:anthropic/claude-sonnet-4', model: models[0], type: 'model' },
+      { key: 'all', title: 'ALL MODELS', type: 'header' },
+      { key: 'model:openai/gpt-5', model: models[1], type: 'model' },
+    ]);
+  });
+
+  it('filters models by name and id', () => {
+    expect(buildModelPickerRows({ models, search: 'gpt-5' })).toEqual([
+      { key: 'all', title: 'ALL MODELS', type: 'header' },
+      { key: 'model:openai/gpt-5', model: models[1], type: 'model' },
+    ]);
+  });
+});

--- a/apps/mobile/src/lib/model-picker-rows.ts
+++ b/apps/mobile/src/lib/model-picker-rows.ts
@@ -1,0 +1,36 @@
+import { type ModelOption } from '@/lib/hooks/use-available-models';
+
+export type ModelPickerRow =
+  | { key: string; title: string; type: 'header' }
+  | { key: string; model: ModelOption; type: 'model' };
+
+export function buildModelPickerRows({
+  models,
+  search,
+}: {
+  models: ModelOption[];
+  search: string;
+}): ModelPickerRow[] {
+  const query = search.toLowerCase().trim();
+  const filtered = models.filter(
+    m => !query || m.name.toLowerCase().includes(query) || m.id.toLowerCase().includes(query)
+  );
+
+  const recommended = filtered.filter(m => m.isPreferred);
+  const all = filtered.filter(m => !m.isPreferred);
+  const result: ModelPickerRow[] = [];
+
+  if (recommended.length > 0) {
+    result.push({ key: 'recommended', title: 'RECOMMENDED', type: 'header' });
+    for (const modelOption of recommended) {
+      result.push({ key: `model:${modelOption.id}`, model: modelOption, type: 'model' });
+    }
+  }
+  if (all.length > 0) {
+    result.push({ key: 'all', title: 'ALL MODELS', type: 'header' });
+    for (const modelOption of all) {
+      result.push({ key: `model:${modelOption.id}`, model: modelOption, type: 'model' });
+    }
+  }
+  return result;
+}

--- a/apps/mobile/src/lib/picker-bridge.ts
+++ b/apps/mobile/src/lib/picker-bridge.ts
@@ -13,7 +13,7 @@ type ModePickerBridge = {
   onSelect: (mode: AgentMode) => void;
 };
 
-type RepoOption = {
+export type RepoOption = {
   fullName: string;
   isPrivate: boolean;
 };

--- a/apps/mobile/src/lib/query-client-lifecycle.test.ts
+++ b/apps/mobile/src/lib/query-client-lifecycle.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { installQueryClientNativeLifecycle } from '@/lib/query-client-lifecycle';
+
+vi.mock('react-native', () => ({
+  AppState: { currentState: 'active', addEventListener: vi.fn() },
+}));
+
+vi.mock('@react-native-community/netinfo', () => ({
+  addEventListener: vi.fn(),
+}));
+
+type AppState = 'active' | 'background' | 'inactive';
+type ConnectivityState = { isConnected: boolean | null; isInternetReachable: boolean | null };
+
+function createSources(initialAppState: AppState = 'active') {
+  let appState = initialAppState;
+  let appStateListener: ((state: AppState) => void) | undefined = undefined;
+  let connectivityListener: ((state: ConnectivityState) => void) | undefined = undefined;
+  const removeAppStateListener = vi.fn();
+  const removeConnectivityListener = vi.fn();
+
+  return {
+    sources: {
+      getAppState: () => appState,
+      onAppStateChange: (listener: (state: AppState) => void) => {
+        appStateListener = listener;
+        return removeAppStateListener;
+      },
+      onConnectivityChange: (listener: (state: ConnectivityState) => void) => {
+        connectivityListener = listener;
+        return removeConnectivityListener;
+      },
+    },
+    setAppState(nextState: AppState) {
+      appState = nextState;
+      appStateListener?.(nextState);
+    },
+    setConnectivity(nextState: ConnectivityState) {
+      connectivityListener?.(nextState);
+    },
+    removeAppStateListener,
+    removeConnectivityListener,
+  };
+}
+
+describe('installQueryClientNativeLifecycle', () => {
+  it('mirrors native app focus into React Query focus state', () => {
+    const native = createSources('background');
+    const setFocused = vi.fn();
+
+    const cleanup = installQueryClientNativeLifecycle({
+      sources: native.sources,
+      managers: {
+        focus: { setFocused },
+        online: { setOnline: vi.fn() },
+      },
+    });
+
+    native.setAppState('active');
+    native.setAppState('background');
+    cleanup();
+
+    expect(setFocused).toHaveBeenNthCalledWith(1, false);
+    expect(setFocused).toHaveBeenNthCalledWith(2, true);
+    expect(setFocused).toHaveBeenNthCalledWith(3, false);
+    expect(native.removeAppStateListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('mirrors native connectivity into React Query online state', () => {
+    const native = createSources();
+    const setOnline = vi.fn();
+
+    const cleanup = installQueryClientNativeLifecycle({
+      sources: native.sources,
+      managers: {
+        focus: { setFocused: vi.fn() },
+        online: { setOnline },
+      },
+    });
+
+    native.setConnectivity({ isConnected: false, isInternetReachable: false });
+    native.setConnectivity({ isConnected: true, isInternetReachable: true });
+    cleanup();
+
+    expect(setOnline).toHaveBeenNthCalledWith(1, false);
+    expect(setOnline).toHaveBeenNthCalledWith(2, true);
+    expect(native.removeConnectivityListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/lib/query-client-lifecycle.test.ts
+++ b/apps/mobile/src/lib/query-client-lifecycle.test.ts
@@ -87,4 +87,26 @@ describe('installQueryClientNativeLifecycle', () => {
     expect(setOnline).toHaveBeenNthCalledWith(2, true);
     expect(native.removeConnectivityListener).toHaveBeenCalledTimes(1);
   });
+
+  it('falls back to isConnected when isInternetReachable is null', () => {
+    const native = createSources();
+    const setOnline = vi.fn();
+
+    const cleanup = installQueryClientNativeLifecycle({
+      sources: native.sources,
+      managers: {
+        focus: { setFocused: vi.fn() },
+        online: { setOnline },
+      },
+    });
+
+    native.setConnectivity({ isConnected: false, isInternetReachable: null });
+    native.setConnectivity({ isConnected: true, isInternetReachable: null });
+    native.setConnectivity({ isConnected: null, isInternetReachable: null });
+    cleanup();
+
+    expect(setOnline).toHaveBeenNthCalledWith(1, false);
+    expect(setOnline).toHaveBeenNthCalledWith(2, true);
+    expect(setOnline).toHaveBeenNthCalledWith(3, true);
+  });
 });

--- a/apps/mobile/src/lib/query-client-lifecycle.test.ts
+++ b/apps/mobile/src/lib/query-client-lifecycle.test.ts
@@ -44,16 +44,23 @@ function createSources(initialAppState: AppState = 'active') {
   };
 }
 
+function createBooleanSetterMock() {
+  return vi.fn((value: boolean): void => {
+    void value;
+  });
+}
+
 describe('installQueryClientNativeLifecycle', () => {
   it('mirrors native app focus into React Query focus state', () => {
     const native = createSources('background');
-    const setFocused = vi.fn();
+    const setFocused = createBooleanSetterMock();
+    const setOnline = createBooleanSetterMock();
 
     const cleanup = installQueryClientNativeLifecycle({
       sources: native.sources,
       managers: {
         focus: { setFocused },
-        online: { setOnline: vi.fn() },
+        online: { setOnline },
       },
     });
 
@@ -69,12 +76,13 @@ describe('installQueryClientNativeLifecycle', () => {
 
   it('mirrors native connectivity into React Query online state', () => {
     const native = createSources();
-    const setOnline = vi.fn();
+    const setFocused = createBooleanSetterMock();
+    const setOnline = createBooleanSetterMock();
 
     const cleanup = installQueryClientNativeLifecycle({
       sources: native.sources,
       managers: {
-        focus: { setFocused: vi.fn() },
+        focus: { setFocused },
         online: { setOnline },
       },
     });
@@ -90,12 +98,13 @@ describe('installQueryClientNativeLifecycle', () => {
 
   it('falls back to isConnected when isInternetReachable is null', () => {
     const native = createSources();
-    const setOnline = vi.fn();
+    const setFocused = createBooleanSetterMock();
+    const setOnline = createBooleanSetterMock();
 
     const cleanup = installQueryClientNativeLifecycle({
       sources: native.sources,
       managers: {
-        focus: { setFocused: vi.fn() },
+        focus: { setFocused },
         online: { setOnline },
       },
     });

--- a/apps/mobile/src/lib/query-client-lifecycle.tsx
+++ b/apps/mobile/src/lib/query-client-lifecycle.tsx
@@ -1,0 +1,67 @@
+import { addEventListener, type NetInfoState } from '@react-native-community/netinfo';
+import { focusManager, onlineManager } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+
+type ConnectivityState = Pick<NetInfoState, 'isConnected' | 'isInternetReachable'>;
+
+type QueryClientLifecycleSources = {
+  getAppState: () => AppStateStatus;
+  onAppStateChange: (listener: (state: AppStateStatus) => void) => () => void;
+  onConnectivityChange: (listener: (state: ConnectivityState) => void) => () => void;
+};
+
+type QueryClientLifecycleManagers = {
+  focus: Pick<typeof focusManager, 'setFocused'>;
+  online: Pick<typeof onlineManager, 'setOnline'>;
+};
+
+type QueryClientNativeLifecycleOptions = {
+  sources?: QueryClientLifecycleSources;
+  managers?: QueryClientLifecycleManagers;
+};
+
+const nativeLifecycleSources: QueryClientLifecycleSources = {
+  getAppState: () => AppState.currentState,
+  onAppStateChange: listener => {
+    const subscription = AppState.addEventListener('change', listener);
+    return () => {
+      subscription.remove();
+    };
+  },
+  onConnectivityChange: listener => addEventListener(listener),
+};
+
+const defaultManagers: QueryClientLifecycleManagers = {
+  focus: focusManager,
+  online: onlineManager,
+};
+
+function isOnline(state: ConnectivityState): boolean {
+  return state.isInternetReachable ?? state.isConnected ?? true;
+}
+
+export function installQueryClientNativeLifecycle({
+  sources = nativeLifecycleSources,
+  managers = defaultManagers,
+}: QueryClientNativeLifecycleOptions = {}): () => void {
+  managers.focus.setFocused(sources.getAppState() === 'active');
+
+  const removeAppStateListener = sources.onAppStateChange(nextState => {
+    managers.focus.setFocused(nextState === 'active');
+  });
+  const removeConnectivityListener = sources.onConnectivityChange(nextState => {
+    managers.online.setOnline(isOnline(nextState));
+  });
+
+  return () => {
+    removeAppStateListener();
+    removeConnectivityListener();
+  };
+}
+
+export function QueryClientNativeLifecycle() {
+  useEffect(() => installQueryClientNativeLifecycle(), []);
+
+  return null;
+}

--- a/apps/mobile/src/lib/repo-picker-filter.test.ts
+++ b/apps/mobile/src/lib/repo-picker-filter.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterRepoPickerOptions } from './repo-picker-filter';
+
+const repositories = [
+  { fullName: 'Kilo-Org/cloud', isPrivate: true },
+  { fullName: 'octocat/Hello-World', isPrivate: false },
+];
+
+describe('filterRepoPickerOptions', () => {
+  it('returns all repositories when search is empty', () => {
+    expect(filterRepoPickerOptions({ repositories, search: '' })).toEqual(repositories);
+  });
+
+  it('filters repositories by full name case-insensitively', () => {
+    expect(filterRepoPickerOptions({ repositories, search: 'hello' })).toEqual([repositories[1]]);
+  });
+});

--- a/apps/mobile/src/lib/repo-picker-filter.ts
+++ b/apps/mobile/src/lib/repo-picker-filter.ts
@@ -1,0 +1,15 @@
+import { type RepoOption } from '@/lib/picker-bridge';
+
+export function filterRepoPickerOptions({
+  repositories,
+  search,
+}: {
+  repositories: RepoOption[];
+  search: string;
+}) {
+  const query = search.toLowerCase().trim();
+  if (!query) {
+    return repositories;
+  }
+  return repositories.filter(repo => repo.fullName.toLowerCase().includes(query));
+}

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
@@ -259,7 +259,7 @@ describe('CloudAgentTransport unexpected disconnect', () => {
 
     const stoppedEvents = serviceEvents.filter(e => e.type === 'stopped');
     expect(stoppedEvents).toHaveLength(1);
-    expect(stoppedEvents[0]).toEqual({ type: 'stopped', reason: 'disconnected' });
+    expect(stoppedEvents[0]).toEqual({ type: 'stopped', reason: 'transport-disconnected' });
 
     transport.destroy();
   });

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.ts
@@ -77,7 +77,7 @@ function createCloudAgentTransport(config: CloudAgentTransportConfig): Transport
     ): void {
       if (expectedGeneration !== lifecycleGeneration) return;
 
-      const stoppedEvent: ServiceEvent = { type: 'stopped', reason: 'disconnected' };
+      const stoppedEvent: ServiceEvent = { type: 'stopped', reason: 'transport-disconnected' };
 
       const nextConnection = createConnection({
         websocketUrl: buildWebsocketUrl(),

--- a/apps/web/src/lib/cloud-agent-sdk/normalizer.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/normalizer.ts
@@ -96,7 +96,7 @@ export type ServiceEvent =
   | { type: 'suggestion.dismissed'; requestId: string }
   | {
       type: 'stopped';
-      reason: 'complete' | 'interrupted' | 'disconnected' | 'error';
+      reason: 'complete' | 'interrupted' | 'disconnected' | 'transport-disconnected' | 'error';
       branch?: string;
     }
   | { type: 'warning' }

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
@@ -219,6 +219,19 @@ describe('createServiceState', () => {
       expect(onError).toHaveBeenCalledWith('Connection to agent lost');
     });
 
+    it('ignores wrapper disconnect after a completed idle session', () => {
+      const onError = jest.fn();
+      const state = createServiceState(makeConfig({ onError }));
+      state.setActivity({ type: 'busy' });
+
+      state.process({ type: 'stopped', reason: 'complete' });
+      state.process({ type: 'stopped', reason: 'disconnected' });
+
+      expect(state.getActivity()).toEqual({ type: 'idle' });
+      expect(state.getStatus()).toEqual({ type: 'idle' });
+      expect(onError).not.toHaveBeenCalledWith('Connection to agent lost');
+    });
+
     it('stopped resets cloudStatus to null when it was preparing', () => {
       const state = createServiceState(makeConfig());
       state.process({

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
@@ -673,6 +673,17 @@ describe('createServiceState', () => {
       expect(onError).toHaveBeenCalledWith('New error');
     });
 
+    it('clears disconnected status on reconnect', () => {
+      const state = createServiceState(makeConfig());
+
+      state.process({ type: 'stopped', reason: 'disconnected' });
+      expect(state.getStatus()).toEqual({ type: 'disconnected' });
+
+      state.process({ type: 'connected', sessionStatus: { type: 'idle' } });
+
+      expect(state.getStatus()).toEqual({ type: 'idle' });
+    });
+
     it('sets all fields in one shot', () => {
       const state = createServiceState(makeConfig());
       state.process({

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
@@ -684,6 +684,17 @@ describe('createServiceState', () => {
       expect(state.getStatus()).toEqual({ type: 'idle' });
     });
 
+    it('preserves disconnected status on synthetic viewer reconnect without sessionStatus', () => {
+      const state = createServiceState(makeConfig());
+
+      state.process({ type: 'stopped', reason: 'disconnected' });
+      expect(state.getStatus()).toEqual({ type: 'disconnected' });
+
+      state.process({ type: 'connected' });
+
+      expect(state.getStatus()).toEqual({ type: 'disconnected' });
+    });
+
     it('sets all fields in one shot', () => {
       const state = createServiceState(makeConfig());
       state.process({

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
@@ -695,6 +695,17 @@ describe('createServiceState', () => {
       expect(state.getStatus()).toEqual({ type: 'disconnected' });
     });
 
+    it('clears transport-disconnected status on synthetic viewer reconnect', () => {
+      const state = createServiceState(makeConfig());
+
+      state.process({ type: 'stopped', reason: 'transport-disconnected' });
+      expect(state.getStatus()).toEqual({ type: 'disconnected' });
+
+      state.process({ type: 'connected' });
+
+      expect(state.getStatus()).toEqual({ type: 'idle' });
+    });
+
     it('sets all fields in one shot', () => {
       const state = createServiceState(makeConfig());
       state.process({

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.ts
@@ -95,6 +95,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
   let suggestion: SuggestionState | null = null;
   const pendingMessages = new Map<string, MessageDeliveryState>();
   let disconnectedSource: 'transport' | 'wrapper' | null = null;
+  let completed = false;
 
   // Tracks whether we've received a terminal stopped event (error/interrupted/disconnected).
   // While terminated, session.error events are suppressed as aftershocks.
@@ -126,6 +127,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
         activity = { type: 'busy' };
         status = IDLE_STATUS;
         disconnectedSource = null;
+        completed = false;
         terminated = false;
       }
       // Child session busy → no activity change
@@ -150,21 +152,25 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
 
     switch (event.reason) {
       case 'complete':
+        completed = true;
         // Status stays as-is (idle, or committed if was committing)
         if (event.branch) config.onBranchChanged?.(event.branch);
         break;
       case 'interrupted':
         terminated = true;
         disconnectedSource = null;
+        completed = false;
         status = { type: 'interrupted' };
         break;
       case 'error':
         terminated = true;
         disconnectedSource = null;
+        completed = false;
         status = { type: 'error', message: 'Session terminated' };
         config.onError?.('Session terminated');
         break;
       case 'disconnected':
+        if (completed) break;
         terminated = true;
         disconnectedSource = 'wrapper';
         status = { type: 'disconnected' };
@@ -173,6 +179,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
       case 'transport-disconnected':
         terminated = true;
         disconnectedSource = 'transport';
+        completed = false;
         status = { type: 'disconnected' };
         config.onError?.('Connection to agent lost');
         break;
@@ -547,6 +554,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
       pendingMessages.clear();
       terminated = false;
       disconnectedSource = null;
+      completed = false;
       notify();
     },
   };

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.ts
@@ -94,6 +94,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
   let permission: PermissionState | null = null;
   let suggestion: SuggestionState | null = null;
   const pendingMessages = new Map<string, MessageDeliveryState>();
+  let disconnectedSource: 'transport' | 'wrapper' | null = null;
 
   // Tracks whether we've received a terminal stopped event (error/interrupted/disconnected).
   // While terminated, session.error events are suppressed as aftershocks.
@@ -114,10 +115,17 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
   function processSessionStatus(event: Extract<ServiceEvent, { type: 'session.status' }>): void {
     const { sessionId, status: sessionStatus } = event;
 
+    if (isRootSession(sessionId) && status.type === 'disconnected') {
+      status = IDLE_STATUS;
+      disconnectedSource = null;
+      terminated = false;
+    }
+
     if (sessionStatus.type === 'busy') {
       if (isRootSession(sessionId)) {
         activity = { type: 'busy' };
         status = IDLE_STATUS;
+        disconnectedSource = null;
         terminated = false;
       }
       // Child session busy → no activity change
@@ -147,15 +155,24 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
         break;
       case 'interrupted':
         terminated = true;
+        disconnectedSource = null;
         status = { type: 'interrupted' };
         break;
       case 'error':
         terminated = true;
+        disconnectedSource = null;
         status = { type: 'error', message: 'Session terminated' };
         config.onError?.('Session terminated');
         break;
       case 'disconnected':
         terminated = true;
+        disconnectedSource = 'wrapper';
+        status = { type: 'disconnected' };
+        config.onError?.('Connection to agent lost');
+        break;
+      case 'transport-disconnected':
+        terminated = true;
+        disconnectedSource = 'transport';
         status = { type: 'disconnected' };
         config.onError?.('Connection to agent lost');
         break;
@@ -379,8 +396,12 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
 
     // Clear terminated on connected
     terminated = false;
-    if (sessionStatus !== undefined && status.type === 'disconnected') {
+    if (
+      status.type === 'disconnected' &&
+      (sessionStatus !== undefined || disconnectedSource === 'transport')
+    ) {
       status = IDLE_STATUS;
+      disconnectedSource = null;
     }
 
     // Clear pending-message delivery state — replayed cloud.message.queued
@@ -525,6 +546,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
       suggestion = null;
       pendingMessages.clear();
       terminated = false;
+      disconnectedSource = null;
       notify();
     },
   };

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.ts
@@ -379,7 +379,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
 
     // Clear terminated on connected
     terminated = false;
-    if (status.type === 'disconnected') {
+    if (sessionStatus !== undefined && status.type === 'disconnected') {
       status = IDLE_STATUS;
     }
 

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.ts
@@ -379,6 +379,9 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
 
     // Clear terminated on connected
     terminated = false;
+    if (status.type === 'disconnected') {
+      status = IDLE_STATUS;
+    }
 
     // Clear pending-message delivery state — replayed cloud.message.queued
     // events following the snapshot will repopulate it with the current truth.

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -61,6 +61,7 @@ const mockSessionCallbacks: {
     messageId: string,
     state: Extract<MessageDeliveryState, { status: 'failed' }>
   ) => void;
+  onError?: (message: string) => void;
 } = {};
 
 let latestStorage: JotaiSessionStorage | null = null;
@@ -84,6 +85,7 @@ jest.mock('./session', () => ({
         messageId: string,
         state: Extract<MessageDeliveryState, { status: 'failed' }>
       ) => void;
+      onError?: (message: string) => void;
       transport?: { userWebConnection?: unknown };
     }) => {
       latestStorage = sessionConfig.storage;
@@ -109,6 +111,7 @@ jest.mock('./session', () => ({
       mockSessionCallbacks.onMessageQueued = sessionConfig.onMessageQueued;
       mockSessionCallbacks.onMessageCompleted = sessionConfig.onMessageCompleted;
       mockSessionCallbacks.onMessageFailed = sessionConfig.onMessageFailed;
+      mockSessionCallbacks.onError = sessionConfig.onError;
       return mockSession;
     }
   ),
@@ -276,6 +279,7 @@ describe('createSessionManager', () => {
     mockSessionCallbacks.onMessageQueued = undefined;
     mockSessionCallbacks.onMessageCompleted = undefined;
     mockSessionCallbacks.onMessageFailed = undefined;
+    mockSessionCallbacks.onError = undefined;
   });
 
   // -------------------------------------------------------------------------
@@ -810,6 +814,44 @@ describe('createSessionManager', () => {
           message: 'Agent connection lost',
         })
       );
+    });
+
+    it('clears disconnected error and indicator after the transport reconnects', async () => {
+      let notifyStateChange: (() => void) | undefined;
+      mockSession.state.subscribe.mockImplementation(callback => {
+        notifyStateChange = callback;
+        callback();
+        return () => {};
+      });
+
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      mockSession.state.getStatus.mockReturnValue({ type: 'disconnected' });
+      mockSessionCallbacks.onError?.('Connection to agent lost');
+      notifyStateChange?.();
+
+      expect(atomValue<string | null>(config.store, mgr.atoms.error)).toBe(
+        'Connection to agent lost'
+      );
+      expect(
+        atomValue<{ type: string; message: string } | null>(config.store, mgr.atoms.statusIndicator)
+      ).toEqual(
+        expect.objectContaining({
+          type: 'error',
+          message: 'Agent connection lost',
+        })
+      );
+
+      mockSession.state.getStatus.mockReturnValue({ type: 'idle' });
+      notifyStateChange?.();
+
+      expect(atomValue<string | null>(config.store, mgr.atoms.error)).toBeNull();
+      expect(
+        atomValue<{ type: string; message: string } | null>(config.store, mgr.atoms.statusIndicator)
+      ).toBeNull();
     });
 
     it('passes variant through to session.send', async () => {

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
@@ -548,6 +548,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       const act = session.state.getActivity();
       const st = session.state.getStatus();
       const cs = session.state.getCloudStatus();
+      const previousStatus = store.get(agentStatusAtom);
       store.set(activityAtom, act);
       if (!firstActivityFired && act.type !== 'connecting') {
         firstActivityFired = true;
@@ -572,6 +573,11 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       }
       store.set(canSendAtom, session.canSend && cloudReady);
       store.set(canInterruptAtom, session.canInterrupt);
+
+      if (previousStatus.type === 'disconnected' && st.type !== 'disconnected') {
+        store.set(errorAtom, null);
+        setIndicator(null);
+      }
 
       if (act.type !== prevAct) {
         if (act.type === 'busy') {

--- a/services/cloud-agent-next/scripts/dev-with-docker-proxy.sh
+++ b/services/cloud-agent-next/scripts/dev-with-docker-proxy.sh
@@ -20,6 +20,18 @@ socket="${DOCKER_PROXY_SOCKET:-${TMPDIR:-/tmp}/cloud-agent-dind-${hash}.sock}"
 socket="$(printf '%s' "$socket" | sed 's:/\{1,\}:/:g')"
 export DOCKER_PROXY_SOCKET="$socket"
 
+if [ -z "${MINIFLARE_CONTAINER_EGRESS_IMAGE:-}" ]; then
+  docker_arch="$(docker info --format '{{.Architecture}}' 2>/dev/null || true)"
+  case "$docker_arch" in
+    aarch64 | arm64)
+      # Work around wrangler/miniflare launching the amd64 proxy-everything
+      # image on arm64 Docker engines, which exits with:
+      # "setsockoptint: protocol not available".
+      export MINIFLARE_CONTAINER_EGRESS_IMAGE="cloudflare/proxy-everything:3cb1195@sha256:78c7910f4575a511d928d7824b1cbcaec6b7c4bf4dbb3fafaeeae3104030e73c"
+      ;;
+  esac
+fi
+
 node "$script_dir/docker-privileged-proxy.mjs" &
 proxy=$!
 trap 'kill $proxy 2>/dev/null || true' EXIT INT TERM

--- a/services/cloud-agent-next/scripts/dev-with-docker-proxy.sh
+++ b/services/cloud-agent-next/scripts/dev-with-docker-proxy.sh
@@ -20,8 +20,21 @@ socket="${DOCKER_PROXY_SOCKET:-${TMPDIR:-/tmp}/cloud-agent-dind-${hash}.sock}"
 socket="$(printf '%s' "$socket" | sed 's:/\{1,\}:/:g')"
 export DOCKER_PROXY_SOCKET="$socket"
 
+probe_docker_architecture() {
+  if [ -n "${DOCKER_SOCKET:-}" ]; then
+    case "$DOCKER_SOCKET" in
+      unix://*) probe_docker_host="$DOCKER_SOCKET" ;;
+      *) probe_docker_host="unix://$DOCKER_SOCKET" ;;
+    esac
+    DOCKER_HOST="$probe_docker_host" docker info --format '{{.Architecture}}'
+    return
+  fi
+
+  docker info --format '{{.Architecture}}'
+}
+
 if [ -z "${MINIFLARE_CONTAINER_EGRESS_IMAGE:-}" ]; then
-  docker_arch="$(docker info --format '{{.Architecture}}' 2>/dev/null || true)"
+  docker_arch="$(probe_docker_architecture 2>/dev/null || true)"
   case "$docker_arch" in
     aarch64 | arm64)
       # Work around wrangler/miniflare launching the amd64 proxy-everything

--- a/services/cloud-agent-next/src/dev-with-docker-proxy-script.test.ts
+++ b/services/cloud-agent-next/src/dev-with-docker-proxy-script.test.ts
@@ -1,0 +1,82 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const serviceDir = path.resolve(testDir, '..');
+const repoRoot = path.resolve(serviceDir, '../..');
+const scriptPath = path.join(serviceDir, 'scripts/dev-with-docker-proxy.sh');
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeExecutable(filePath: string, contents: string) {
+  fs.writeFileSync(filePath, contents);
+  fs.chmodSync(filePath, 0o755);
+}
+
+describe('dev-with-docker-proxy.sh', () => {
+  it('probes Docker architecture through DOCKER_SOCKET when provided', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cloud-agent-docker-proxy-test-'));
+    tempDirs.push(tempDir);
+    const binDir = path.join(tempDir, 'bin');
+    fs.mkdirSync(binDir);
+    const dockerSocket = path.join(tempDir, 'upstream.sock');
+    const proxySocket = path.join(tempDir, 'proxy.sock');
+    const wranglerEnvLog = path.join(tempDir, 'wrangler-env.log');
+    const dockerProbeLog = path.join(tempDir, 'docker-probe.log');
+
+    writeExecutable(
+      path.join(binDir, 'docker'),
+      `#!/bin/sh
+printf '%s\\n' "DOCKER_HOST=$DOCKER_HOST DOCKER_SOCKET=$DOCKER_SOCKET $*" >> "${dockerProbeLog}"
+if [ "$1" = "info" ] && [ "$DOCKER_HOST" = "unix://${dockerSocket}" ]; then
+  printf '%s\\n' arm64
+else
+  printf '%s\\n' x86_64
+fi
+`
+    );
+    writeExecutable(
+      path.join(binDir, 'node'),
+      `#!/bin/sh
+exec "${process.execPath}" -e '
+const net = require("node:net");
+const socket = process.env.DOCKER_PROXY_SOCKET;
+const server = net.createServer(() => {});
+server.listen(socket);
+process.on("SIGTERM", () => server.close(() => process.exit(0)));
+setTimeout(() => process.exit(0), 5000);
+' >/dev/null 2>&1
+`
+    );
+    writeExecutable(
+      path.join(binDir, 'wrangler'),
+      `#!/bin/sh
+printf '%s\\n' "MINIFLARE_CONTAINER_EGRESS_IMAGE=$MINIFLARE_CONTAINER_EGRESS_IMAGE" > "${wranglerEnvLog}"
+`
+    );
+
+    execFileSync('sh', [scriptPath, '--env', 'dev'], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        DOCKER_PROXY_SOCKET: proxySocket,
+        DOCKER_SOCKET: dockerSocket,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      },
+    });
+
+    expect(fs.readFileSync(dockerProbeLog, 'utf8')).toContain(`DOCKER_HOST=unix://${dockerSocket}`);
+    expect(fs.readFileSync(wranglerEnvLog, 'utf8')).toContain(
+      'MINIFLARE_CONTAINER_EGRESS_IMAGE=cloudflare/proxy-everything:3cb1195'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Stabilizes Android Cloud Agent sessions and task UI behavior. The branch improves Android picker/task surfaces, reconnects Cloud Agent streams when the app resumes, clears stale disconnect state after reconnect, shows queued prompt activity before streaming starts, keeps the agent composer above the Android keyboard, and refreshes agent session queries on native resume/session creation.

## Verification

- Not manually verified on an Android device in this environment.

## Visual Changes

N/A

## Reviewer Notes

Focus review on Android lifecycle behavior, React Query native focus/online bridging, and the shared Cloud Agent disconnect-state cleanup.
