### PR TITLE
feat(ai-gateway): add free Qwen 3.7 Plus

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -16,8 +16,10 @@ import {
   isAlibabaDirectModel,
   qwen36_plus_model,
   qwen37_max_model,
+  qwen37_plus_free_model,
   qwen37_plus_model,
 } from './providers/qwen';
+import { getModelVariants, REASONING_VARIANTS_BINARY } from './providers/model-settings';
 
 describe('isFreeModel', () => {
   describe('free models', () => {
@@ -90,6 +92,15 @@ describe('isFreeModel', () => {
       expect(qwen37_plus_model.gateway).toBe('alibaba');
       expect(qwen37_plus_model.internal_id).toBe('qwen3.7-plus');
       expect(getInferenceProvider(qwen37_plus_model)).toBe('alibaba');
+    });
+
+    test('routes free Qwen3.7 Plus through Vercel with binary thinking variants', () => {
+      expect(findKiloExclusiveModel(qwen37_plus_free_model.public_id)).toBe(qwen37_plus_free_model);
+      expect(isAlibabaDirectModel(qwen37_plus_free_model.public_id)).toBe(false);
+      expect(qwen37_plus_free_model.gateway).toBe('vercel');
+      expect(qwen37_plus_free_model.internal_id).toBe('qwen/qwen3.7-plus');
+      expect(getInferenceProvider(qwen37_plus_free_model)).toBe(null);
+      expect(getModelVariants(qwen37_plus_free_model.public_id)).toBe(REASONING_VARIANTS_BINARY);
     });
 
     test('requires data collection for paid training-enabled offerings', () => {

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -98,7 +98,7 @@ describe('isFreeModel', () => {
       expect(findKiloExclusiveModel(qwen37_plus_free_model.public_id)).toBe(qwen37_plus_free_model);
       expect(isAlibabaDirectModel(qwen37_plus_free_model.public_id)).toBe(false);
       expect(qwen37_plus_free_model.gateway).toBe('vercel');
-      expect(qwen37_plus_free_model.internal_id).toBe('qwen/qwen3.7-plus');
+      expect(qwen37_plus_free_model.internal_id).toBe('alibaba/qwen3.7-plus');
       expect(getInferenceProvider(qwen37_plus_free_model)).toBe(null);
       expect(getModelVariants(qwen37_plus_free_model.public_id)).toBe(REASONING_VARIANTS_BINARY);
     });

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -37,6 +37,7 @@ import {
   alibabaDirectModels,
   qwen36_plus_model,
   qwen36_plus_stealth_model,
+  qwen37_plus_free_model,
 } from '@/lib/ai-gateway/providers/qwen';
 import { stepfun_37_flash_free_model } from '@/lib/ai-gateway/providers/stepfun';
 import { isGrokModel } from '@/lib/ai-gateway/providers/xai';
@@ -95,6 +96,7 @@ export const kiloExclusiveModels = [
   ...alibabaDirectModels,
   ...deepseekDiscountedModels,
   qwen36_plus_stealth_model,
+  qwen37_plus_free_model,
   claude_sonnet_clawsetup_model,
   claude_opus_4_8_stealth_model,
   claude_opus_4_7_stealth_model,

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -2,7 +2,11 @@ import { isClaudeModel, isOpusModel } from '@/lib/ai-gateway/providers/anthropic
 import { isGemini3Model, isGemmaModel } from '@/lib/ai-gateway/providers/google';
 import { isKimiModel } from '@/lib/ai-gateway/providers/moonshotai';
 import { isOpenAiModel } from '@/lib/ai-gateway/providers/openai';
-import { isAlibabaDirectModel, qwen36_plus_stealth_model } from '@/lib/ai-gateway/providers/qwen';
+import {
+  isAlibabaDirectModel,
+  qwen36_plus_stealth_model,
+  qwen37_plus_free_model,
+} from '@/lib/ai-gateway/providers/qwen';
 import { seed_20_code_free_model } from '@/lib/ai-gateway/providers/seed';
 import { isGrokModel, isGrokToggleableReasoningModel } from '@/lib/ai-gateway/providers/xai';
 import { isGlmModel } from '@/lib/ai-gateway/providers/zai';
@@ -93,6 +97,7 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
     isGrokToggleableReasoningModel(model) ||
     isAlibabaDirectModel(model) ||
     model === qwen36_plus_stealth_model.public_id ||
+    model === qwen37_plus_free_model.public_id ||
     isGemmaModel(model)
   ) {
     return REASONING_VARIANTS_BINARY;

--- a/apps/web/src/lib/ai-gateway/providers/qwen.ts
+++ b/apps/web/src/lib/ai-gateway/providers/qwen.ts
@@ -131,6 +131,22 @@ export const qwen37_plus_model: KiloExclusiveModel = {
   inference_provider_restriction: [],
 };
 
+export const qwen37_plus_free_model: KiloExclusiveModel = {
+  public_id: 'qwen/qwen3.7-plus:free',
+  display_name: 'Qwen: Qwen3.7 Plus (free)',
+  description:
+    "Qwen3.7-Plus is Alibaba's native multimodal agent model for visual-language reasoning, agentic coding, tool use, and productivity workflows. It supports text, image, and video inputs. For this free endpoint, your prompts and completions may be retained and used to train or improve the provider's services.",
+  context_length: 1_000_000,
+  max_completion_tokens: 65_536,
+  status: 'public',
+  flags: ['reasoning', 'vision', 'requires-data-collection'],
+  gateway: 'vercel',
+  internal_id: 'qwen/qwen3.7-plus',
+  pricing: null,
+  exclusive_to: [],
+  inference_provider_restriction: ['alibaba'],
+};
+
 export const qwen36_plus_model: KiloExclusiveModel = {
   public_id: 'qwen/qwen3.6-plus',
   display_name: 'Qwen: Qwen3.6 Plus',

--- a/apps/web/src/lib/ai-gateway/providers/qwen.ts
+++ b/apps/web/src/lib/ai-gateway/providers/qwen.ts
@@ -141,10 +141,10 @@ export const qwen37_plus_free_model: KiloExclusiveModel = {
   status: 'public',
   flags: ['reasoning', 'vision', 'requires-data-collection'],
   gateway: 'vercel',
-  internal_id: 'qwen/qwen3.7-plus',
+  internal_id: 'alibaba/qwen3.7-plus',
   pricing: null,
   exclusive_to: [],
-  inference_provider_restriction: ['alibaba'],
+  inference_provider_restriction: [],
 };
 
 export const qwen36_plus_model: KiloExclusiveModel = {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -132,6 +132,10 @@ describe('mapModelIdToVercel', () => {
       );
     });
 
+    it('maps a forced Vercel exclusive through the inferred Alibaba model id', () => {
+      expect(mapModelIdToVercel('qwen/qwen3.7-plus:free', false)).toBe('alibaba/qwen3.7-plus');
+    });
+
     it('does not use internal_id for exclusives that are not vercel-routed', () => {
       // claude_sonnet_clawsetup_model has gateway 'openrouter' and no
       // 'vercel-routing' flag, so the mapping must pass the public id through


### PR DESCRIPTION
## Summary
- Add a public `qwen/qwen3.7-plus:free` Kilo-exclusive model that is forced through Vercel and pinned to Alibaba upstream routing.
- Preserve Qwen 3.7 Plus reasoning behavior for the free endpoint by exposing the binary `instant`/`thinking` variants.
- Cover the registry and Vercel model-id rewrite behavior with focused AI gateway tests.

## Verification
- Not manually tested; this was a backend registry/routing change and the sandbox could not complete the local prepare step needed to run tests.

## Visual Changes
N/A

## Reviewer Notes
- The free endpoint intentionally stays separate from `alibabaDirectModels` so it remains Vercel-transported while still receiving Qwen binary thinking variants.