### PR TITLE
feat(kiloclaw): surface official Google Calendar OAuth in settings, retire Gog on web

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Settings } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { resolveGoogleOAuthFeedback } from './google-oauth-feedback';
 import { TRPCClientError } from '@trpc/client';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawStatus, useKiloClawMutations, useKiloClawMyPin } from '@/hooks/useKiloClaw';
@@ -159,6 +160,9 @@ function ClawSettingsWithStatus({
   organizationName?: string;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const oauthFeedbackHandledRef = useRef(false);
   const personalStatus = useKiloClawStatus();
   const orgStatus = useOrgKiloClawStatus(organizationId);
   const { data: status, isLoading, error } = organizationId ? orgStatus : personalStatus;
@@ -172,6 +176,37 @@ function ClawSettingsWithStatus({
       router.replace(clawUrl);
     }
   }, [shouldRedirect, clawUrl, router]);
+
+  // Surface the one-shot success/error param the Google OAuth routes append
+  // when they redirect back to settings. This lives above the no-instance gate
+  // so feedback (e.g. ?error=missing_instance) still shows even when settings
+  // bounces to onboarding. Wait for status so `shouldRedirect` is meaningful.
+  useEffect(() => {
+    if (oauthFeedbackHandledRef.current || isLoading) return;
+    const feedback = resolveGoogleOAuthFeedback(
+      searchParams.get('success'),
+      searchParams.get('error')
+    );
+    if (!feedback) return;
+    oauthFeedbackHandledRef.current = true;
+
+    if (feedback.kind === 'success') {
+      toast.success(feedback.message);
+    } else {
+      toast.error(feedback.message);
+    }
+
+    // When staying on settings, strip the one-shot param so it can't re-fire.
+    // When redirecting to onboarding, the redirect drops the query string
+    // anyway, so skip the extra replace to avoid racing the redirect.
+    if (!shouldRedirect) {
+      const next = new URLSearchParams(searchParams);
+      next.delete('success');
+      next.delete('error');
+      const query = next.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    }
+  }, [isLoading, shouldRedirect, searchParams, pathname, router]);
 
   if (isLoading || shouldRedirect) {
     return (

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -340,13 +340,16 @@ const GOOGLE_CALENDAR_FEATURES: Array<{ included: boolean; label: string }> = [
 ];
 
 // Friendly messages for the `?error=` codes the Google OAuth connect/callback/
-// disconnect routes append when they redirect back to settings. Only these
-// known codes (plus the two success values) are handled, so unrelated query
-// params on the settings page are left untouched.
+// disconnect routes append when they redirect back to settings. Known codes get
+// tailored copy; any other error value (e.g. a sanitized provider description)
+// falls back to the generic message below so failures are never silent.
+const GOOGLE_OAUTH_GENERIC_ERROR = 'Could not connect Google Calendar. Please try again.';
+
 const GOOGLE_OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  access_denied: 'Google Calendar connection was cancelled.',
   missing_permissions:
     'Calendar access was not granted. Please allow calendar permission and try again.',
-  connection_failed: 'Could not connect Google Calendar. Please try again.',
+  connection_failed: GOOGLE_OAUTH_GENERIC_ERROR,
   oauth_init_failed: 'Could not start the Google connection. Please try again.',
   missing_instance: 'Your KiloClaw instance is still starting. Try again in a moment.',
   missing_code: 'Google did not return an authorization code. Please try again.',
@@ -2119,7 +2122,13 @@ export function SettingsTab({
 
     const success = searchParams.get('success');
     const error = searchParams.get('error');
-    const errorMessage = error ? GOOGLE_OAUTH_ERROR_MESSAGES[error] : undefined;
+    // Any `error=` on this route comes from the Google OAuth routes, so map
+    // known codes to friendly copy and fall back to a generic message for the
+    // rest (e.g. access_denied/cancel, or a sanitized provider description) so
+    // the failure is always surfaced and the param is always cleaned up.
+    const errorMessage = error
+      ? (GOOGLE_OAUTH_ERROR_MESSAGES[error] ?? GOOGLE_OAUTH_GENERIC_ERROR)
+      : undefined;
     const isGoogleSuccess = success === 'google_connected' || success === 'google_disconnected';
 
     if (!isGoogleSuccess && !errorMessage) return;

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -21,7 +21,6 @@ import { OpenclawImportCard } from './OpenclawImportCard';
 
 import { usePostHog } from 'posthog-js/react';
 import Link from 'next/link';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
@@ -339,28 +338,6 @@ const GOOGLE_CALENDAR_FEATURES: Array<{ included: boolean; label: string }> = [
   { included: false, label: 'Create, modify, or delete events (we never request write access)' },
 ];
 
-// Friendly messages for the `?error=` codes the Google OAuth connect/callback/
-// disconnect routes append when they redirect back to settings. Known codes get
-// tailored copy; any other error value (e.g. a sanitized provider description)
-// falls back to the generic message below so failures are never silent.
-const GOOGLE_OAUTH_GENERIC_ERROR = 'Could not connect Google Calendar. Please try again.';
-
-const GOOGLE_OAUTH_ERROR_MESSAGES: Record<string, string> = {
-  access_denied: 'Google Calendar connection was cancelled.',
-  missing_permissions:
-    'Calendar access was not granted. Please allow calendar permission and try again.',
-  connection_failed: GOOGLE_OAUTH_GENERIC_ERROR,
-  oauth_init_failed: 'Could not start the Google connection. Please try again.',
-  missing_instance: 'Your KiloClaw instance is still starting. Try again in a moment.',
-  missing_code: 'Google did not return an authorization code. Please try again.',
-  invalid_state: 'The connection link expired. Please try connecting again.',
-  invalid_origin: 'Could not complete the request. Please try again.',
-  invalid_organization: 'Invalid organization for this connection.',
-  unauthorized: 'You are not authorized to complete this connection.',
-  disconnect_failed: 'Could not disconnect Google Calendar. Please try again.',
-  method_not_allowed: 'That request could not be completed. Please try again.',
-};
-
 /**
  * Settings card for the officially-approved Kilo OAuth client. This is the
  * preferred Google Calendar connection and the successor to the legacy Gog
@@ -528,12 +505,14 @@ function GoogleAccountCard({
   connected,
   gmailNotificationsEnabled,
   inboundEmailAddress,
+  inboundEmailEnabled,
   mutations,
   onRedeploy,
 }: {
   connected: boolean;
   gmailNotificationsEnabled: boolean;
   inboundEmailAddress: string | null;
+  inboundEmailEnabled: boolean;
   mutations: ClawMutations;
   onRedeploy?: () => void;
 }) {
@@ -599,15 +578,20 @@ function GoogleAccountCard({
                   <p className="text-muted-foreground">
                     {"For email functionality, use your bot's automatically provisioned "}
                     <span className="text-foreground font-medium">Inbound Email</span>
-                    {' address below:'}
+                    {' address:'}
                   </p>
-                  {inboundEmailAddress ? (
+                  {/* Only present the alias as usable when delivery is actually
+                      enabled — the backend rejects disabled aliases (410), so
+                      showing a disabled one would send users to a dead path. */}
+                  {inboundEmailAddress && inboundEmailEnabled ? (
                     <code className="bg-muted text-foreground inline-block max-w-full truncate rounded px-2 py-1 text-xs">
                       {inboundEmailAddress}
                     </code>
                   ) : (
                     <span className="text-muted-foreground">
-                      Your Inbound Email address appears in the Inbound Email card below.
+                      {inboundEmailAddress
+                        ? 'Inbound Email is currently disabled for this instance. Enable it in the Inbound Email section on this page before relying on it.'
+                        : 'See the Inbound Email section on this page to set it up.'}
                     </span>
                   )}
                 </div>
@@ -2079,10 +2063,6 @@ export function SettingsTab({
   organizationName?: string;
 }) {
   const posthog = usePostHog();
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const googleOAuthParamHandledRef = useRef(false);
   const { data: config } = useClawConfig();
   const { organizationId } = useClawContext();
   const { data: modelsData, isLoading: isLoadingModels } = useModelSelectorList(organizationId);
@@ -2124,40 +2104,6 @@ export function SettingsTab({
     }
     previousStatusRef.current = status.status;
   }, [status.status]);
-
-  // Surface the one-shot success/error param the Google OAuth routes append
-  // when they redirect back to settings, then strip it so it doesn't re-fire.
-  useEffect(() => {
-    if (googleOAuthParamHandledRef.current) return;
-
-    const success = searchParams.get('success');
-    const error = searchParams.get('error');
-    // Any `error=` on this route comes from the Google OAuth routes, so map
-    // known codes to friendly copy and fall back to a generic message for the
-    // rest (e.g. access_denied/cancel, or a sanitized provider description) so
-    // the failure is always surfaced and the param is always cleaned up.
-    const errorMessage = error
-      ? (GOOGLE_OAUTH_ERROR_MESSAGES[error] ?? GOOGLE_OAUTH_GENERIC_ERROR)
-      : undefined;
-    const isGoogleSuccess = success === 'google_connected' || success === 'google_disconnected';
-
-    if (!isGoogleSuccess && !errorMessage) return;
-    googleOAuthParamHandledRef.current = true;
-
-    if (success === 'google_connected') {
-      toast.success('Google Calendar connected');
-    } else if (success === 'google_disconnected') {
-      toast.success('Google Calendar disconnected');
-    } else if (errorMessage) {
-      toast.error(errorMessage);
-    }
-
-    const next = new URLSearchParams(searchParams);
-    next.delete('success');
-    next.delete('error');
-    const query = next.toString();
-    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
-  }, [searchParams, pathname, router]);
 
   const hasFreshGatewayReady =
     isRunning &&
@@ -2719,6 +2665,7 @@ export function SettingsTab({
               connected={status.googleConnected}
               gmailNotificationsEnabled={status.gmailNotificationsEnabled}
               inboundEmailAddress={status.inboundEmailAddress}
+              inboundEmailEnabled={status.inboundEmailEnabled}
               mutations={mutations}
               onRedeploy={onRedeploy}
             />

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -358,6 +358,7 @@ const GOOGLE_OAUTH_ERROR_MESSAGES: Record<string, string> = {
   invalid_organization: 'Invalid organization for this connection.',
   unauthorized: 'You are not authorized to complete this connection.',
   disconnect_failed: 'Could not disconnect Google Calendar. Please try again.',
+  method_not_allowed: 'That request could not be completed. Please try again.',
 };
 
 /**
@@ -502,8 +503,17 @@ function GoogleCalendarCard({
         isPending={isDisconnecting}
         pendingLabel="Disconnecting..."
         onConfirm={() => {
+          const form = disconnectFormRef.current;
+          if (!form) {
+            toast.error('Could not disconnect Google Calendar. Please try again.');
+            return;
+          }
+          // The disconnect route always 303-redirects, so once we submit the
+          // page navigates away; isDisconnecting intentionally stays true until
+          // then. Only set it after confirming the form exists so a missing ref
+          // can't leave the button permanently disabled.
           setIsDisconnecting(true);
-          disconnectFormRef.current?.submit();
+          form.submit();
         }}
       />
     </>

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -21,6 +21,7 @@ import { OpenclawImportCard } from './OpenclawImportCard';
 
 import { usePostHog } from 'posthog-js/react';
 import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
@@ -31,7 +32,6 @@ import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
 import {
   useClawConfig,
   useClawMyPin,
-  useClawGoogleSetupCommand,
   useClawGatewayReady,
   useClawMorningBriefingStatus,
   useClawReadMorningBriefing,
@@ -328,6 +328,186 @@ function GoogleGIcon({ className }: { className?: string }) {
 }
 
 // ---------------------------------------------------------------------------
+// Google Calendar (official Kilo OAuth client — credential_profile=kilo_owned)
+// ---------------------------------------------------------------------------
+
+// Read-only capability summary, mirrored from the onboarding calendar step
+// (CalendarConnectStep.tsx) so the settings copy stays consistent.
+const GOOGLE_CALENDAR_FEATURES: Array<{ included: boolean; label: string }> = [
+  { included: true, label: 'Read your calendar events (titles, times, attendees, locations)' },
+  { included: true, label: 'Read calendars you own and subscribe to' },
+  { included: false, label: 'Create, modify, or delete events — we never request write access' },
+];
+
+// Friendly messages for the `?error=` codes the Google OAuth connect/callback/
+// disconnect routes append when they redirect back to settings. Only these
+// known codes (plus the two success values) are handled, so unrelated query
+// params on the settings page are left untouched.
+const GOOGLE_OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  missing_permissions:
+    'Calendar access was not granted. Please allow calendar permission and try again.',
+  connection_failed: 'Could not connect Google Calendar. Please try again.',
+  oauth_init_failed: 'Could not start the Google connection. Please try again.',
+  missing_instance: 'Your KiloClaw instance is still starting. Try again in a moment.',
+  missing_code: 'Google did not return an authorization code. Please try again.',
+  invalid_state: 'The connection link expired. Please try connecting again.',
+  invalid_origin: 'Could not complete the request. Please try again.',
+  invalid_organization: 'Invalid organization for this connection.',
+  unauthorized: 'You are not authorized to complete this connection.',
+  disconnect_failed: 'Could not disconnect Google Calendar. Please try again.',
+};
+
+/**
+ * Settings card for the officially-approved Kilo OAuth client. This is the
+ * preferred Google Calendar connection and the successor to the legacy Gog
+ * flow (GoogleAccountCard). Connect/disconnect reuse the existing
+ * /api/integrations/google/{connect,disconnect} routes; disconnect is a native
+ * same-origin form POST so the route's Origin check passes and the 303 redirect
+ * lands back on settings with a success/error param.
+ */
+function GoogleCalendarCard({
+  connected,
+  oauthStatus,
+  accountEmail,
+  organizationId,
+}: {
+  connected: boolean;
+  oauthStatus: 'active' | 'action_required' | 'disconnected';
+  accountEmail: string | null;
+  organizationId: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const [confirmDisconnect, setConfirmDisconnect] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const disconnectFormRef = useRef<HTMLFormElement>(null);
+
+  const settingsPath = organizationId
+    ? `/organizations/${organizationId}/claw/settings`
+    : '/claw/settings';
+  const connectParams = new URLSearchParams({ returnTo: settingsPath });
+  if (organizationId) {
+    connectParams.set('organizationId', organizationId);
+  }
+  const connectUrl = `/api/integrations/google/connect?${connectParams.toString()}`;
+  const disconnectAction = organizationId
+    ? `/api/integrations/google/disconnect?organizationId=${encodeURIComponent(organizationId)}`
+    : '/api/integrations/google/disconnect';
+
+  const needsReconnect = oauthStatus === 'action_required';
+  const isHealthyConnected = connected && !needsReconnect;
+
+  return (
+    <>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <div className="rounded-lg border">
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="hover:bg-muted/50 flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-3 transition-colors"
+            >
+              <GoogleGIcon className="h-5 w-5 shrink-0" />
+              <div className="flex min-w-0 flex-1 flex-col items-start">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">Google Calendar</span>
+                  <Badge
+                    variant={isHealthyConnected ? 'default' : 'secondary'}
+                    className="px-1.5 py-0 text-[10px] leading-4"
+                  >
+                    {connected ? (needsReconnect ? 'Reconnect' : 'Connected') : 'Not connected'}
+                  </Badge>
+                </div>
+                <span className="text-muted-foreground text-xs">
+                  Read-only calendar access · via Kilo OAuth
+                </span>
+              </div>
+              <ChevronDown
+                className={`text-muted-foreground h-4 w-4 shrink-0 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+              />
+            </button>
+          </CollapsibleTrigger>
+
+          <CollapsibleContent>
+            <Separator />
+            <div className="space-y-4 px-4 py-3">
+              {isHealthyConnected ? (
+                <>
+                  <p className="text-muted-foreground text-xs">
+                    {accountEmail ? `Connected as ${accountEmail}` : 'Connected'} · read-only access
+                    to your calendar events.
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={isDisconnecting}
+                    onClick={() => setConfirmDisconnect(true)}
+                  >
+                    <X className="h-4 w-4" />
+                    {isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  {needsReconnect && (
+                    <p className="text-xs text-amber-500">
+                      Your calendar connection needs to be re-authorized. Reconnect to resume
+                      access.
+                    </p>
+                  )}
+                  <ul className="space-y-2">
+                    {GOOGLE_CALENDAR_FEATURES.map(feature => (
+                      <li key={feature.label} className="flex items-start gap-2">
+                        {feature.included ? (
+                          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+                        ) : (
+                          <X className="text-muted-foreground/60 mt-0.5 h-3.5 w-3.5 shrink-0" />
+                        )}
+                        <span
+                          className={
+                            feature.included
+                              ? 'text-muted-foreground text-xs'
+                              : 'text-muted-foreground/70 text-xs'
+                          }
+                        >
+                          {feature.label}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                  <Button asChild size="sm">
+                    <Link href={connectUrl}>
+                      {needsReconnect ? 'Reconnect Google Calendar' : 'Connect Google Calendar'}
+                    </Link>
+                  </Button>
+                </>
+              )}
+            </div>
+          </CollapsibleContent>
+        </div>
+      </Collapsible>
+
+      {/* Native form POST so the disconnect route's same-origin Origin check
+          passes; the 303 redirect navigates back to settings. */}
+      <form ref={disconnectFormRef} method="POST" action={disconnectAction} className="hidden" />
+
+      <ConfirmActionDialog
+        open={confirmDisconnect}
+        onOpenChange={setConfirmDisconnect}
+        title="Disconnect Google Calendar"
+        description="This removes Kilo's read-only access to your Google Calendar. You can reconnect anytime."
+        confirmLabel="Disconnect"
+        confirmIcon={<X className="mr-1 h-4 w-4" />}
+        isPending={isDisconnecting}
+        pendingLabel="Disconnecting..."
+        onConfirm={() => {
+          setIsDisconnecting(true);
+          disconnectFormRef.current?.submit();
+        }}
+      />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Google Account (collapsible card, matches SecretEntrySection card style)
 // ---------------------------------------------------------------------------
 
@@ -342,19 +522,13 @@ function GoogleAccountCard({
   mutations: ClawMutations;
   onRedeploy?: () => void;
 }) {
-  const { data: setupData } = useClawGoogleSetupCommand(!connected);
+  // This card is rendered only for users who already have the legacy Gog
+  // connection (status.googleConnected). The self-service setup-command flow
+  // is intentionally not surfaced — Gog is being retired in favor of the
+  // official Google Calendar OAuth card above, so we only offer disconnect.
   const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
   const isDisconnecting = mutations.disconnectGoogle.isPending;
-  const command = setupData?.command;
-
-  function handleCopy() {
-    if (!command) return;
-    void navigator.clipboard.writeText(command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }
 
   return (
     <>
@@ -375,9 +549,12 @@ function GoogleAccountCard({
                   >
                     {connected ? 'Connected' : 'Not connected'}
                   </Badge>
+                  <Badge variant="outline" className="px-1.5 py-0 text-[10px] leading-4">
+                    Legacy
+                  </Badge>
                 </div>
                 <span className="text-muted-foreground text-xs">
-                  Access Gmail, Calendar, and Docs
+                  Legacy Google connection — being retired
                 </span>
               </div>
               <ChevronDown
@@ -389,86 +566,68 @@ function GoogleAccountCard({
           <CollapsibleContent>
             <Separator />
             <div className="space-y-4 px-4 py-3">
-              {!connected && command && (
-                <div className="space-y-2">
-                  <p className="text-muted-foreground text-xs">
-                    Run this command in a terminal on your local machine to connect your Google
-                    account:
+              <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 p-3">
+                <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                <div className="space-y-1 text-xs">
+                  <p className="text-foreground font-medium">
+                    This connection method is being retired.
                   </p>
-                  <div className="relative">
-                    <pre className="bg-muted overflow-x-auto rounded-md p-3 pr-10 text-xs">
-                      <code>{command}</code>
-                    </pre>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="absolute top-1 right-1 h-7 w-7 p-0"
-                      onClick={handleCopy}
-                    >
-                      {copied ? (
-                        <Check className="h-3.5 w-3.5 text-green-500" />
-                      ) : (
-                        <Copy className="h-3.5 w-3.5" />
-                      )}
-                    </Button>
-                  </div>
+                  <p className="text-muted-foreground">
+                    We recommend disconnecting and using the{' '}
+                    <span className="text-foreground font-medium">Google Calendar</span> card above,
+                    which connects with Kilo&apos;s official OAuth. For email, use your{' '}
+                    <span className="text-foreground font-medium">Inbound Email</span> address below
+                    — it&apos;s set up automatically.
+                  </p>
                 </div>
-              )}
+              </div>
 
-              {connected && (
-                <>
-                  <div className="flex items-center gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={isDisconnecting}
-                      onClick={() => setConfirmDisconnect(true)}
-                    >
-                      <X className="h-4 w-4" />
-                      {isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
-                    </Button>
-                  </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isDisconnecting}
+                  onClick={() => setConfirmDisconnect(true)}
+                >
+                  <X className="h-4 w-4" />
+                  {isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
+                </Button>
+              </div>
 
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <h4 className="text-foreground text-sm font-medium">Gmail Notifications</h4>
-                      <p className="text-muted-foreground text-xs">
-                        Notify your bot when new emails arrive
-                      </p>
-                    </div>
-                    <Button
-                      variant={gmailNotificationsEnabled ? 'default' : 'outline'}
-                      size="sm"
-                      disabled={mutations.setGmailNotifications.isPending}
-                      onClick={() => {
-                        mutations.setGmailNotifications.mutate(
-                          { enabled: !gmailNotificationsEnabled },
-                          {
-                            onSuccess: data => {
-                              toast.success(
-                                data.gmailNotificationsEnabled
-                                  ? 'Gmail notifications enabled'
-                                  : 'Gmail notifications disabled'
-                              );
-                            },
-                            onError: err => toast.error(`Failed: ${err.message}`),
-                          }
-                        );
-                      }}
-                    >
-                      {mutations.setGmailNotifications.isPending
-                        ? 'Saving...'
-                        : gmailNotificationsEnabled
-                          ? 'Enabled'
-                          : 'Disabled'}
-                    </Button>
-                  </div>
-                </>
-              )}
-
-              {!connected && !command && (
-                <p className="text-muted-foreground text-xs">Loading setup command...</p>
-              )}
+              <div className="flex items-center justify-between">
+                <div>
+                  <h4 className="text-foreground text-sm font-medium">Gmail Notifications</h4>
+                  <p className="text-muted-foreground text-xs">
+                    Notify your bot when new emails arrive
+                  </p>
+                </div>
+                <Button
+                  variant={gmailNotificationsEnabled ? 'default' : 'outline'}
+                  size="sm"
+                  disabled={mutations.setGmailNotifications.isPending}
+                  onClick={() => {
+                    mutations.setGmailNotifications.mutate(
+                      { enabled: !gmailNotificationsEnabled },
+                      {
+                        onSuccess: data => {
+                          toast.success(
+                            data.gmailNotificationsEnabled
+                              ? 'Gmail notifications enabled'
+                              : 'Gmail notifications disabled'
+                          );
+                        },
+                        onError: err => toast.error(`Failed: ${err.message}`),
+                      }
+                    );
+                  }}
+                >
+                  {mutations.setGmailNotifications.isPending
+                    ? 'Saving...'
+                    : gmailNotificationsEnabled
+                      ? 'Enabled'
+                      : 'Disabled'}
+                </Button>
+              </div>
             </div>
           </CollapsibleContent>
         </div>
@@ -478,7 +637,7 @@ function GoogleAccountCard({
         open={confirmDisconnect}
         onOpenChange={setConfirmDisconnect}
         title="Disconnect Google Account"
-        description="This will remove your Google credentials. Reconnecting requires re-running the Docker setup flow (gcloud login, project setup, OAuth consent). Redeploy after disconnecting to apply."
+        description="This removes your legacy Google credentials. This connection method is being retired — to keep calendar access, use the Google Calendar (OAuth) card; for email, use your Inbound Email address. Redeploy after disconnecting to apply."
         confirmLabel="Disconnect"
         confirmIcon={<X className="mr-1 h-4 w-4" />}
         isPending={isDisconnecting}
@@ -1889,6 +2048,10 @@ export function SettingsTab({
   organizationName?: string;
 }) {
   const posthog = usePostHog();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const googleOAuthParamHandledRef = useRef(false);
   const { data: config } = useClawConfig();
   const { organizationId } = useClawContext();
   const { data: modelsData, isLoading: isLoadingModels } = useModelSelectorList(organizationId);
@@ -1930,6 +2093,34 @@ export function SettingsTab({
     }
     previousStatusRef.current = status.status;
   }, [status.status]);
+
+  // Surface the one-shot success/error param the Google OAuth routes append
+  // when they redirect back to settings, then strip it so it doesn't re-fire.
+  useEffect(() => {
+    if (googleOAuthParamHandledRef.current) return;
+
+    const success = searchParams.get('success');
+    const error = searchParams.get('error');
+    const errorMessage = error ? GOOGLE_OAUTH_ERROR_MESSAGES[error] : undefined;
+    const isGoogleSuccess = success === 'google_connected' || success === 'google_disconnected';
+
+    if (!isGoogleSuccess && !errorMessage) return;
+    googleOAuthParamHandledRef.current = true;
+
+    if (success === 'google_connected') {
+      toast.success('Google Calendar connected');
+    } else if (success === 'google_disconnected') {
+      toast.success('Google Calendar disconnected');
+    } else if (errorMessage) {
+      toast.error(errorMessage);
+    }
+
+    const next = new URLSearchParams(searchParams);
+    next.delete('success');
+    next.delete('error');
+    const query = next.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }, [searchParams, pathname, router]);
 
   const hasFreshGatewayReady =
     isRunning &&
@@ -2478,12 +2669,22 @@ export function SettingsTab({
       <div>
         <h2 className="text-foreground mb-3 text-base font-semibold">Productivity</h2>
         <div className="space-y-3">
-          <GoogleAccountCard
-            connected={status.googleConnected}
-            gmailNotificationsEnabled={status.gmailNotificationsEnabled}
-            mutations={mutations}
-            onRedeploy={onRedeploy}
+          <GoogleCalendarCard
+            connected={status.googleOAuthConnected}
+            oauthStatus={status.googleOAuthStatus}
+            accountEmail={status.googleOAuthAccountEmail}
+            organizationId={organizationId ?? null}
           />
+          {/* Legacy Gog connection: only surfaced to users who already have it,
+              so new users are never offered the retired setup flow. */}
+          {status.googleConnected && (
+            <GoogleAccountCard
+              connected={status.googleConnected}
+              gmailNotificationsEnabled={status.gmailNotificationsEnabled}
+              mutations={mutations}
+              onRedeploy={onRedeploy}
+            />
+          )}
           <MorningBriefingCard
             mutations={mutations}
             briefingStatus={morningBriefingStatus}

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -328,7 +328,7 @@ function GoogleGIcon({ className }: { className?: string }) {
 }
 
 // ---------------------------------------------------------------------------
-// Google Calendar (official Kilo OAuth client — credential_profile=kilo_owned)
+// Google Calendar (official Kilo OAuth client, credential_profile=kilo_owned)
 // ---------------------------------------------------------------------------
 
 // Read-only capability summary, mirrored from the onboarding calendar step
@@ -336,7 +336,7 @@ function GoogleGIcon({ className }: { className?: string }) {
 const GOOGLE_CALENDAR_FEATURES: Array<{ included: boolean; label: string }> = [
   { included: true, label: 'Read your calendar events (titles, times, attendees, locations)' },
   { included: true, label: 'Read calendars you own and subscribe to' },
-  { included: false, label: 'Create, modify, or delete events — we never request write access' },
+  { included: false, label: 'Create, modify, or delete events (we never request write access)' },
 ];
 
 // Friendly messages for the `?error=` codes the Google OAuth connect/callback/
@@ -514,17 +514,19 @@ function GoogleCalendarCard({
 function GoogleAccountCard({
   connected,
   gmailNotificationsEnabled,
+  inboundEmailAddress,
   mutations,
   onRedeploy,
 }: {
   connected: boolean;
   gmailNotificationsEnabled: boolean;
+  inboundEmailAddress: string | null;
   mutations: ClawMutations;
   onRedeploy?: () => void;
 }) {
   // This card is rendered only for users who already have the legacy Gog
   // connection (status.googleConnected). The self-service setup-command flow
-  // is intentionally not surfaced — Gog is being retired in favor of the
+  // is intentionally not surfaced; Gog is being retired in favor of the
   // official Google Calendar OAuth card above, so we only offer disconnect.
   const [open, setOpen] = useState(false);
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
@@ -554,7 +556,7 @@ function GoogleAccountCard({
                   </Badge>
                 </div>
                 <span className="text-muted-foreground text-xs">
-                  Legacy Google connection — being retired
+                  Legacy Google connection, being retired
                 </span>
               </div>
               <ChevronDown
@@ -568,17 +570,33 @@ function GoogleAccountCard({
             <div className="space-y-4 px-4 py-3">
               <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 p-3">
                 <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
-                <div className="space-y-1 text-xs">
-                  <p className="text-foreground font-medium">
-                    This connection method is being retired.
+                <div className="space-y-2 text-xs">
+                  <p className="text-muted-foreground">
+                    {
+                      "This integration is being retired. We recommend disconnecting your current integration and switching to KiloCode's official Google approved OAuth client."
+                    }
                   </p>
                   <p className="text-muted-foreground">
-                    We recommend disconnecting and using the{' '}
-                    <span className="text-foreground font-medium">Google Calendar</span> card above,
-                    which connects with Kilo&apos;s official OAuth. For email, use your{' '}
-                    <span className="text-foreground font-medium">Inbound Email</span> address below
-                    — it&apos;s set up automatically.
+                    {'To reconnect, use the '}
+                    <span className="text-foreground font-medium">Google Calendar</span>
+                    {
+                      " integration listed above. This integration uses KiloCode's official OAuth application and is fully supported going forward."
+                    }
                   </p>
+                  <p className="text-muted-foreground">
+                    {"For email functionality, use your bot's automatically provisioned "}
+                    <span className="text-foreground font-medium">Inbound Email</span>
+                    {' address below:'}
+                  </p>
+                  {inboundEmailAddress ? (
+                    <code className="bg-muted text-foreground inline-block max-w-full truncate rounded px-2 py-1 text-xs">
+                      {inboundEmailAddress}
+                    </code>
+                  ) : (
+                    <span className="text-muted-foreground">
+                      Your Inbound Email address appears in the Inbound Email card below.
+                    </span>
+                  )}
                 </div>
               </div>
 
@@ -637,7 +655,7 @@ function GoogleAccountCard({
         open={confirmDisconnect}
         onOpenChange={setConfirmDisconnect}
         title="Disconnect Google Account"
-        description="This removes your legacy Google credentials. This connection method is being retired — to keep calendar access, use the Google Calendar (OAuth) card; for email, use your Inbound Email address. Redeploy after disconnecting to apply."
+        description="This removes your legacy Google credentials. This connection method is being retired. To keep calendar access, use the Google Calendar (OAuth) card; for email, use your Inbound Email address. Redeploy after disconnecting to apply."
         confirmLabel="Disconnect"
         confirmIcon={<X className="mr-1 h-4 w-4" />}
         isPending={isDisconnecting}
@@ -2681,6 +2699,7 @@ export function SettingsTab({
             <GoogleAccountCard
               connected={status.googleConnected}
               gmailNotificationsEnabled={status.gmailNotificationsEnabled}
+              inboundEmailAddress={status.inboundEmailAddress}
               mutations={mutations}
               onRedeploy={onRedeploy}
             />

--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-06-03',
+    description:
+      "Google Calendar now connects through KiloCode's official Google approved OAuth client. Connect it from Settings → Productivity → Google Calendar for read-only calendar access. We encourage everyone to use this instead of the legacy Google (Gog) connection. If you already have the legacy connection set up, it keeps working and nothing is removed. New legacy setups are no longer offered, so switch over when convenient.",
+    category: 'feature',
+    deployHint: null,
+  },
+  {
     date: '2026-06-01',
     description: 'Updated OpenClaw to 2026.5.26.',
     category: 'feature',

--- a/apps/web/src/app/(app)/claw/components/google-oauth-feedback.ts
+++ b/apps/web/src/app/(app)/claw/components/google-oauth-feedback.ts
@@ -1,0 +1,54 @@
+// Maps the one-shot `?success=`/`?error=` params the Google OAuth
+// connect/callback/disconnect routes append when they redirect back to the
+// claw settings route into a user-facing toast. This lives in the settings
+// page wrapper (ClawSettingsPage) rather than SettingsTab so the feedback still
+// surfaces in the no-instance race, where settings bounces to onboarding before
+// SettingsTab would ever mount.
+
+// Known error codes get tailored copy; any other error value (e.g. a sanitized
+// provider description) falls back to the generic message so failures are never
+// silent.
+const GOOGLE_OAUTH_GENERIC_ERROR = 'Could not connect Google Calendar. Please try again.';
+
+const GOOGLE_OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  access_denied: 'Google Calendar connection was cancelled.',
+  missing_permissions:
+    'Calendar access was not granted. Please allow calendar permission and try again.',
+  connection_failed: GOOGLE_OAUTH_GENERIC_ERROR,
+  oauth_init_failed: 'Could not start the Google connection. Please try again.',
+  missing_instance: 'Your KiloClaw instance is still starting. Try again in a moment.',
+  missing_code: 'Google did not return an authorization code. Please try again.',
+  invalid_state: 'The connection link expired. Please try connecting again.',
+  invalid_origin: 'Could not complete the request. Please try again.',
+  invalid_organization: 'Invalid organization for this connection.',
+  unauthorized: 'You are not authorized to complete this connection.',
+  disconnect_failed: 'Could not disconnect Google Calendar. Please try again.',
+  method_not_allowed: 'That request could not be completed. Please try again.',
+};
+
+export type GoogleOAuthFeedback = { kind: 'success' | 'error'; message: string };
+
+/**
+ * Resolve the toast to show for the Google OAuth redirect params, or null when
+ * the params aren't ours. Only `google_connected`/`google_disconnected` count
+ * as success; any non-empty `error` is treated as a Google failure (only these
+ * routes append `?error=` to the settings route).
+ */
+export function resolveGoogleOAuthFeedback(
+  success: string | null,
+  error: string | null
+): GoogleOAuthFeedback | null {
+  if (success === 'google_connected') {
+    return { kind: 'success', message: 'Google Calendar connected' };
+  }
+  if (success === 'google_disconnected') {
+    return { kind: 'success', message: 'Google Calendar disconnected' };
+  }
+  if (error) {
+    return {
+      kind: 'error',
+      message: GOOGLE_OAUTH_ERROR_MESSAGES[error] ?? GOOGLE_OAUTH_GENERIC_ERROR,
+    };
+  }
+  return null;
+}

--- a/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
@@ -393,31 +393,6 @@ export function useClawReadFile(path: string | null, enabled: boolean) {
   return organizationId ? org : personal;
 }
 
-// Google integration
-
-export function useClawGoogleSetupCommand(enabled: boolean) {
-  const trpc = useTRPC();
-  const { organizationId } = useClawContext();
-
-  const personal = useQuery({
-    ...trpc.kiloclaw.getGoogleSetupCommand.queryOptions(undefined, {
-      refetchInterval: 50 * 60 * 1000,
-      refetchOnWindowFocus: false,
-    }),
-    enabled: enabled && !organizationId,
-  });
-
-  const org = useQuery({
-    ...trpc.organizations.kiloclaw.getGoogleSetupCommand.queryOptions(
-      { organizationId: organizationId ?? '' },
-      { refetchInterval: 50 * 60 * 1000, refetchOnWindowFocus: false }
-    ),
-    enabled: enabled && !!organizationId,
-  });
-
-  return organizationId ? org : personal;
-}
-
 // Kilo CLI Run
 
 export function useClawKiloCliRunStatus(runId: string | null) {


### PR DESCRIPTION
## Summary

Adds the official, Google-approved KiloCode OAuth client as the way to connect Google Calendar from KiloClaw settings, and begins retiring the legacy self-service "Gog" connection on web.

- **New Google Calendar card** (Settings → Productivity). Connects via KiloCode's official OAuth client (`kilo_owned`, read-only `calendar.readonly`). Connect is a GET redirect to `/api/integrations/google/connect`; disconnect is a same-origin form POST to `/api/integrations/google/disconnect`. Connected state, account email, and a "Reconnect" state are driven by the existing `googleOAuth*` status fields.
- **Legacy Google (Gog) card demoted.** The old "Google Account" card now renders **only** for users who already have it connected (`status.googleConnected`). It shows a retirement notice pointing them to the new card and to their auto-provisioned **Inbound Email** address (shown inline only when delivery is enabled) for email, plus the existing Disconnect and Gmail Notifications controls. The self-service setup-command flow is no longer surfaced, so **new Gog setups are no longer possible on web** while existing connections keep working untouched.
- **OAuth redirect feedback.** A one-shot effect (in the settings page wrapper, so it survives the no-instance bounce to onboarding) reads the `?success=`/`?error=` params the Google routes append on redirect, toasts a message, and strips the param. Known error codes get friendly copy; any other code (e.g. `access_denied`/consent cancelled) falls back to a generic message so failures are never silent.
- **Dead-code cleanup.** Removed the now-unused web `useClawGoogleSetupCommand` hook.
- **Changelog.** Added a `/claw/changelog` entry announcing the official OAuth client and the Gog deprecation.

### Scope / non-goals
- **Web/frontend only.** No DB, migration, or rollout changes.
- The backend `getGoogleSetupCommand` tRPC procedures are **intentionally retained**: the mobile app still uses them as its only Google connection path and has no OAuth flow yet. Retiring Gog on mobile is a separate future effort.

## Verification

- [x] Connected Google Calendar via the new card in a local dev instance — OAuth round-trip succeeded and the card showed the connected account; then disconnected/removed the config.
- [x] Reviewed the legacy Gog card copy and layout (retirement notice, inline Inbound Email address, Disconnect, Gmail Notifications) by temporarily forcing it to render, since the test account had no real Gog connection.

## Visual Changes

| Before | After |
|---|---|
| Settings → Productivity showed only the "Google Account" (Gog terminal-command) card. | New "Google Calendar" OAuth card; legacy "Google Account" card hidden for users without an existing Gog connection. |

## Reviewer Notes

- OAuth redirect feedback is handled in the settings page wrapper (`ClawSettingsPage`), above the no-instance gate, so `?error=missing_instance` still surfaces even when settings bounces the user to onboarding.
- The legacy card only presents the Inbound Email alias as usable when `inboundEmailEnabled` is true (the backend rejects disabled aliases with 410), so a disconnecting user isn't pointed at a dead delivery path.
- Disconnect is a native same-origin form POST so the route's `Origin` check passes; the 303 redirect lands back on settings with a status param. The submit is guarded on the form ref so a missing ref can't permanently disable the button.
- `returnTo` is validated server-side (`isSafeGoogleOAuthReturnTo`) and org IDs are URL-encoded; error copy comes from a static map (no reflected values), so no reflected-XSS surface.
- The retained `getGoogleSetupCommand` endpoints are unreachable from web but still serve mobile — see Scope note.
