### PR TITLE
fix(webhook-agent-ingest): stop the internal-key gate from blocking token-authed callbacks

### DIFF
--- a/services/webhook-agent-ingest/src/util/auth.test.ts
+++ b/services/webhook-agent-ingest/src/util/auth.test.ts
@@ -1,7 +1,33 @@
 import { describe, it, expect } from 'vitest';
-import { validateInternalApiKey } from './auth';
+import { Hono } from 'hono';
+import type { HonoContext } from '../index';
+import { INTERNAL_API_KEY_HEADER, internalApiMiddleware, validateInternalApiKey } from './auth';
 
 const TEST_SECRET = 'test-internal-api-secret';
+
+/**
+ * Build an app that mirrors index.ts's mounting: the internal-key middleware is
+ * applied to the `/api` router (which also mounts `/api/callbacks`). This is the
+ * exact shape that previously 401'd completion callbacks before they reached the
+ * token-validating handler.
+ */
+function buildMountedApp(secret: string | undefined = TEST_SECRET) {
+  const api = new Hono<HonoContext>();
+  api.use('*', internalApiMiddleware);
+  api.post('/triggers/user/:userId/:triggerId', c => c.json({ reached: 'trigger' }));
+
+  const callbacksStub = new Hono<HonoContext>().post('/execution', c =>
+    c.json({ reached: 'callbacks' })
+  );
+
+  const app = new Hono<HonoContext>();
+  // Order matches index.ts: `/api` is registered before `/api/callbacks`.
+  app.route('/api', api);
+  app.route('/api/callbacks', callbacksStub);
+
+  const env = { INTERNAL_API_SECRET: { get: async () => secret } } as unknown as Env;
+  return { app, env };
+}
 
 describe('validateInternalApiKey', () => {
   describe('header validation', () => {
@@ -39,5 +65,37 @@ describe('validateInternalApiKey', () => {
         expect(result.error).toBe('Invalid internal API key');
       }
     });
+  });
+});
+
+describe('internalApiMiddleware (mounted like index.ts)', () => {
+  it('exempts the /api/callbacks subtree — callbacks reach the handler without the internal key', async () => {
+    const { app, env } = buildMountedApp();
+
+    const response = await app.request('/api/callbacks/execution', { method: 'POST' }, env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ reached: 'callbacks' });
+  });
+
+  it('still requires the internal key for non-callback /api routes', async () => {
+    const { app, env } = buildMountedApp();
+
+    const response = await app.request('/api/triggers/user/u/t', { method: 'POST' }, env);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('allows non-callback /api routes with a valid internal key', async () => {
+    const { app, env } = buildMountedApp();
+
+    const response = await app.request(
+      '/api/triggers/user/u/t',
+      { method: 'POST', headers: { [INTERNAL_API_KEY_HEADER]: TEST_SECRET } },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ reached: 'trigger' });
   });
 });

--- a/services/webhook-agent-ingest/src/util/auth.ts
+++ b/services/webhook-agent-ingest/src/util/auth.ts
@@ -39,6 +39,17 @@ export function validateInternalApiKey(
  * Does NOT set user context - routes extract userId/orgId from URL path.
  */
 export const internalApiMiddleware = createMiddleware<HonoContext>(async (c, next) => {
+  // The /api/callbacks subtree authenticates with a scoped X-Callback-Token
+  // (see routes/callbacks.ts via verifyCallbackToken), NOT the internal API key.
+  // It is mounted under /api, so the `/api/*` matcher for this middleware would
+  // otherwise 401 completion callbacks before they reach the token-validating
+  // handler — orphaning the webhook request in `inprogress`. Exempt the subtree
+  // here; every route under it self-authenticates. (c.req.path is the full
+  // request path under Hono's app.route() mounting, verified for hono@4.12.18.)
+  if (c.req.path.startsWith('/api/callbacks/')) {
+    return next();
+  }
+
   const apiKeyHeader = c.req.header(INTERNAL_API_KEY_HEADER);
   const secret = await c.env.INTERNAL_API_SECRET.get();
 

--- a/services/webhook-agent-ingest/test/integration/routes.test.ts
+++ b/services/webhook-agent-ingest/test/integration/routes.test.ts
@@ -248,4 +248,26 @@ describe('Hono Routes', () => {
       expect(body.data.message).toBe('Webhook captured successfully');
     });
   });
+
+  describe('Completion callback auth boundary', () => {
+    it('routes /api/callbacks past the internal-key middleware to the callback handler', async () => {
+      // Regression for the webhook-stuck-`inprogress` bug: completion callbacks
+      // authenticate with X-Callback-Token, not the internal API key. Because
+      // `/api/callbacks` is mounted under `/api`, the internal-key middleware
+      // previously 401'd them before the handler ran. With no internal key and
+      // no webhook identity headers, the request must now reach the handler,
+      // whose own 400 (missing webhook headers) proves it was not blocked by the
+      // internal-key middleware.
+      const response = await SELF.fetch('http://localhost/api/callbacks/execution', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Missing webhook identification headers');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Webhook triggered Cloud Agent sessions finished their work, but the webhook request stayed `inprogress` in the UI forever.

Root cause: completion callbacks authenticate with a scoped `X-Callback-Token` that the callbacks route validates. They are not meant to present the internal API key. But the callbacks route is mounted under `/api`, and the `/api` router runs an internal API key middleware on every path beneath it. That middleware returned `401` for the callback before it reached the route that validates the token the callback already carried. Cloud Agent delivery treats a `401` as permanent and does not retry, so the request was never moved out of `inprogress`.

The fix lets the `/api/callbacks` subtree skip the internal API key check so its own token validation runs. The route stays authenticated, by the token it already carries rather than the internal key. The callback URL is unchanged, so URLs already stored in running sessions keep resolving, with no transition window.

Architecture note for an unfamiliar reviewer: inbound webhooks already work because they are mounted at `/inbound`, outside `/api`. The callbacks route was the only token validated route trapped behind the internal API key gate.

The functional change is a single guard in `internalApiMiddleware`; the rest of the diff is a comment and tests.

## Verification

This is auth and routing logic. The failure it fixes only reproduces with a live webhook trigger and a full session, so manual testing focused on confirming the root cause rather than a deployed run:

- [x] Confirmed in production logs that the stuck request was caused by a `401` on callback delivery (delivery happened, the endpoint returned `401`, and it was classified permanent).
- [x] Probed the live callback endpoint directly: an unauthenticated request returns the worker's own `401` body, proving the request is rejected by the internal API key middleware before the callbacks handler runs.
- [ ] Post deploy smoke (fire one trigger, confirm the request flips to success): pending deploy.

Automated unit and integration tests are included in the diff and not listed here per the template.

## Visual Changes

N/A

## Reviewer Notes

- The only functional change is an early `return next()` for the `/api/callbacks/` prefix at the top of `internalApiMiddleware`.
- Security scope: the only route under `/api/callbacks` is the callback handler, which always validates the scoped token (missing headers return `400`, bad token returns `401`, session mismatch returns `403`). No unauthenticated route is exposed.
- Path match: under Hono `app.route()` mounting, `c.req.path` is the full request path (verified for hono 4.12.18), so the prefix check matches. The trailing slash avoids matching an unrelated path such as `/api/callbacksX`.
- Blast radius: the `/api` router otherwise contains only trigger CRUD routes, which still require the internal API key. The new unit tests assert both that callbacks pass without the key and that trigger routes still reject without it.
- Why this was not caught before: the prior callbacks test exercised the router in isolation, never mounted under `/api`, so the middleware interaction was untested. The new tests mount the routers the way the worker does.
