### PR TITLE
fix(ai-gateway): redact custom model errors

### DIFF
--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
@@ -706,4 +706,21 @@ describe('makeErrorReadable', () => {
     });
     expect(result).toBeUndefined();
   });
+
+  it('redacts custom LLM error responses', async () => {
+    const response = new Response('sensitive upstream error', { status: 500 });
+    const result = await makeErrorReadable({
+      requestedModel: 'kilo-internal/custom-model',
+      request: { kind: 'chat_completions', body: { model: 'test', messages: [] } },
+      response,
+      isUserByok: false,
+    });
+
+    expect(result?.status).toBe(500);
+    await expect(result?.json()).resolves.toEqual({
+      error: 'Stealth model unable to process request',
+      error_type: 'stealth_model_error',
+      message: 'Stealth model unable to process request',
+    });
+  });
 });

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -34,6 +34,7 @@ import { normalizeModelId } from '@/lib/ai-gateway/providers/openrouter';
 import { createParser, type EventSourceMessage } from 'eventsource-parser';
 import { sentryRootSpan } from '../getRootSpan';
 import { findKiloExclusiveModel, isKiloStealthModel } from '@/lib/ai-gateway/models';
+import { CUSTOM_LLM_PREFIX } from '@/lib/ai-gateway/model-utils';
 import type {
   MicrodollarUsageContext,
   MicrodollarUsageStats,
@@ -210,7 +211,7 @@ export async function makeErrorReadable({
   const overflowResponse = await detectContextOverflow({ requestedModel, request, response });
   if (overflowResponse) return overflowResponse;
 
-  if (isKiloStealthModel(requestedModel)) {
+  if (isKiloStealthModel(requestedModel) || requestedModel.startsWith(CUSTOM_LLM_PREFIX)) {
     return await stealthModelError(response);
   }
 


### PR DESCRIPTION
## Summary

- Redact upstream errors from `custom_llm2` models under the reserved `kilo-internal/` namespace using the existing stealth-model error response.
- Add regression coverage confirming the upstream status is preserved while sensitive error content is replaced.

## Verification

- Not manually tested; this is a backend-only error-response change.

## Visual Changes

N/A

## Reviewer Notes

Context-overflow responses continue to take precedence over generic redaction.