### PR TITLE
feat(admin): make Kilo Pass bulk refunds optional

### DIFF
--- a/apps/web/src/app/admin/components/KiloPassBulkCancel.tsx
+++ b/apps/web/src/app/admin/components/KiloPassBulkCancel.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
   AlertDialog,
@@ -35,6 +36,7 @@ const MAX_EMAILS = 500;
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type BulkResultStatus =
+  | 'cancelled'
   | 'cancelled_and_refunded'
   | 'skipped_no_user'
   | 'skipped_no_subscription'
@@ -73,7 +75,8 @@ function parseEmails(raw: string): { valid: string[]; invalid: string[] } {
 }
 
 const statusLabel: Record<BulkResultStatus, string> = {
-  cancelled_and_refunded: 'Cancelled & Refunded',
+  cancelled: 'Cancelled',
+  cancelled_and_refunded: 'Cancelled and refunded',
   skipped_no_user: 'User not found',
   skipped_no_subscription: 'No Kilo Pass',
   skipped_already_canceled: 'Already cancelled',
@@ -82,16 +85,18 @@ const statusLabel: Record<BulkResultStatus, string> = {
 };
 
 const statusBadgeClass: Record<BulkResultStatus, string> = {
-  cancelled_and_refunded: 'bg-green-900/20 text-green-400',
-  skipped_no_user: 'bg-gray-800 text-gray-300',
-  skipped_no_subscription: 'bg-gray-800 text-gray-300',
-  skipped_already_canceled: 'bg-yellow-900/20 text-yellow-400',
-  skipped_store_managed: 'bg-blue-900/20 text-blue-400',
-  error: 'bg-red-900/20 text-red-400',
+  cancelled: 'bg-green-500/20 text-green-400 ring-1 ring-green-500/20',
+  cancelled_and_refunded: 'bg-green-500/20 text-green-400 ring-1 ring-green-500/20',
+  skipped_no_user: 'bg-zinc-500/20 text-zinc-400 ring-1 ring-zinc-500/20',
+  skipped_no_subscription: 'bg-zinc-500/20 text-zinc-400 ring-1 ring-zinc-500/20',
+  skipped_already_canceled: 'bg-yellow-500/20 text-yellow-400 ring-1 ring-yellow-500/20',
+  skipped_store_managed: 'bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/20',
+  error: 'bg-red-500/20 text-red-400 ring-1 ring-red-500/20',
 };
 
 const statusGroupOrder: BulkResultStatus[] = [
   'cancelled_and_refunded',
+  'cancelled',
   'error',
   'skipped_store_managed',
   'skipped_already_canceled',
@@ -107,6 +112,7 @@ export function KiloPassBulkCancel() {
   const trpc = useTRPC();
   const [rawEmails, setRawEmails] = useState('');
   const [reason, setReason] = useState('');
+  const [refundLatestPayment, setRefundLatestPayment] = useState(true);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const { valid: emails, invalid: invalidEmails } = useMemo(
@@ -138,11 +144,15 @@ export function KiloPassBulkCancel() {
 
   function handleConfirm() {
     setConfirmOpen(false);
-    mutation.mutate({ emails, reason: reason.trim() });
+    mutation.mutate({ emails, reason: reason.trim(), refundLatestPayment });
   }
 
   const results = mutation.data?.results;
   const summary = mutation.data?.summary;
+  const actionLabel = refundLatestPayment ? 'Cancel + refund + block' : 'Cancel + block';
+  const alertRefundText = refundLatestPayment
+    ? 'refunds the latest paid invoice,'
+    : 'does not refund Stripe payments,';
 
   const groupedResults = useMemo(() => {
     if (!results) return null;
@@ -193,18 +203,37 @@ export function KiloPassBulkCancel() {
             />
           </div>
 
+          <div className="bg-muted/30 flex items-start gap-3 rounded-md border p-3">
+            <Checkbox
+              id="refund-latest-payment"
+              checked={refundLatestPayment}
+              onCheckedChange={setRefundLatestPayment}
+              disabled={mutation.isPending}
+              className="accent-primary focus:ring-ring"
+            />
+            <div className="space-y-1">
+              <Label htmlFor="refund-latest-payment" className="text-sm font-medium">
+                Refund latest paid invoice
+              </Label>
+              <p className="text-muted-foreground text-sm">
+                Leave checked to refund the latest paid Stripe invoice for each cancelled Kilo Pass.
+                Uncheck to cancel and block without refunding Stripe payments.
+              </p>
+            </div>
+          </div>
+
           <Alert>
             <AlertDescription>
-              For each email: cancels the Stripe subscription immediately, refunds the latest paid
-              invoice, resets balance to $0, blocks the account if not already blocked, and inserts
-              an admin note tagged <code>[bulk]</code>. Each user runs in its own DB transaction;
-              partial failures leave successful users committed.
+              For each email: cancels the Stripe subscription immediately, {alertRefundText} resets
+              balance to $0, blocks the account if not already blocked, and inserts an admin note
+              tagged <code>[bulk]</code>. Each user runs in its own DB transaction; partial failures
+              leave successful users committed.
             </AlertDescription>
           </Alert>
 
           <div className="flex items-center gap-3">
             <Button variant="destructive" disabled={!canSubmit} onClick={handleSubmitClick}>
-              {mutation.isPending ? 'Processing…' : 'Cancel + refund + block'}
+              {mutation.isPending ? 'Processing…' : actionLabel}
             </Button>
             {mutation.isPending && (
               <span className="text-muted-foreground text-sm">
@@ -289,7 +318,9 @@ export function KiloPassBulkCancel() {
                                   Refund must be initiated via the App Store. The customer needs to
                                   contact Apple Support.
                                 </span>
-                              ) : row.status === 'cancelled_and_refunded' && row.alreadyBlocked ? (
+                              ) : (row.status === 'cancelled' ||
+                                  row.status === 'cancelled_and_refunded') &&
+                                row.alreadyBlocked ? (
                                 <span className="text-muted-foreground">
                                   Account was already blocked
                                 </span>
@@ -314,14 +345,16 @@ export function KiloPassBulkCancel() {
           <AlertDialogHeader>
             <AlertDialogTitle>Confirm bulk cancel</AlertDialogTitle>
             <AlertDialogDescription>
-              Cancel + refund Kilo Pass and block {emails.length}{' '}
-              {emails.length === 1 ? 'user' : 'users'}. This is irreversible.
+              {refundLatestPayment
+                ? 'Cancel Kilo Pass, refund the latest paid invoice, and block'
+                : 'Cancel Kilo Pass without refunding Stripe payments and block'}{' '}
+              {emails.length} {emails.length === 1 ? 'user' : 'users'}. This is irreversible.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction variant="destructive" onClick={handleConfirm}>
-              Confirm
+              {actionLabel}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/app/admin/kilo-pass/bulk-cancel/page.tsx
+++ b/apps/web/src/app/admin/kilo-pass/bulk-cancel/page.tsx
@@ -5,7 +5,7 @@ import { KiloPassBulkCancel } from '../../components/KiloPassBulkCancel';
 const breadcrumbs = (
   <>
     <BreadcrumbItem>
-      <BreadcrumbPage>Kilo Pass Bulk Cancel</BreadcrumbPage>
+      <BreadcrumbPage>Kilo Pass bulk cancel</BreadcrumbPage>
     </BreadcrumbItem>
   </>
 );
@@ -15,7 +15,7 @@ export default function KiloPassBulkCancelPage() {
     <AdminPage breadcrumbs={breadcrumbs}>
       <div className="flex w-full flex-col gap-y-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-2xl font-bold">Kilo Pass Bulk Cancel + Refund</h2>
+          <h2 className="text-2xl font-bold">Kilo Pass bulk cancel</h2>
         </div>
         <KiloPassBulkCancel />
       </div>

--- a/apps/web/src/lib/kilo-pass/cancel-and-refund.ts
+++ b/apps/web/src/lib/kilo-pass/cancel-and-refund.ts
@@ -30,7 +30,7 @@ export type CancelAndRefundKiloPassReason =
 
 export type CancelAndRefundKiloPassResult =
   | {
-      status: 'cancelled_and_refunded';
+      status: 'cancelled' | 'cancelled_and_refunded';
       refundedAmountCents: number | null;
       balanceResetAmountUsd: number | null;
       alreadyBlocked: boolean;
@@ -46,12 +46,14 @@ export type CancelAndRefundKiloPassParams = {
   userId: string;
   reason: string;
   adminKiloUserId: string;
+  refundLatestPayment?: boolean;
   noteSuffix?: string;
 };
 
 /**
- * Cancels and refunds a user's Kilo Pass subscription, zeroes their balance,
- * blocks the account if not already blocked, and appends an admin note.
+ * Cancels a user's Kilo Pass subscription, optionally refunds the latest Stripe
+ * payment, zeroes their balance, blocks the account if not already blocked, and
+ * appends an admin note.
  *
  * Each invocation runs its own DB transaction for the local mutations; the
  * Stripe-side calls happen before the transaction to minimize open transaction
@@ -66,6 +68,7 @@ export async function cancelAndRefundKiloPassForUser({
   userId,
   reason,
   adminKiloUserId,
+  refundLatestPayment = true,
   noteSuffix,
 }: CancelAndRefundKiloPassParams): Promise<CancelAndRefundKiloPassResult> {
   const user = await db.query.kilocode_users.findFirst({
@@ -124,33 +127,35 @@ export async function cancelAndRefundKiloPassForUser({
   await stripe.subscriptions.cancel(stripeSubscriptionId);
 
   let refundedAmountCents: number | null = null;
-  const paidInvoices = await stripe.invoices.list({
-    subscription: stripeSubscriptionId,
-    status: 'paid',
-    limit: 1,
-  });
-  const paidInvoice = paidInvoices.data[0];
-  if (paidInvoice) {
-    const payments = await stripe.invoicePayments.list({
-      invoice: paidInvoice.id,
+  if (refundLatestPayment) {
+    const paidInvoices = await stripe.invoices.list({
+      subscription: stripeSubscriptionId,
       status: 'paid',
       limit: 1,
     });
-    const rawPaymentIntent = payments.data[0]?.payment.payment_intent;
-    const paymentIntentId =
-      typeof rawPaymentIntent === 'string' ? rawPaymentIntent : rawPaymentIntent?.id;
-    if (paymentIntentId) {
-      try {
-        const refund = await stripe.refunds.create({
-          payment_intent: paymentIntentId,
-        });
-        refundedAmountCents = refund.amount;
-      } catch (err) {
-        if (
-          !(err instanceof stripe.errors.StripeInvalidRequestError) ||
-          err.code !== 'charge_already_refunded'
-        ) {
-          throw err;
+    const paidInvoice = paidInvoices.data[0];
+    if (paidInvoice) {
+      const payments = await stripe.invoicePayments.list({
+        invoice: paidInvoice.id,
+        status: 'paid',
+        limit: 1,
+      });
+      const rawPaymentIntent = payments.data[0]?.payment.payment_intent;
+      const paymentIntentId =
+        typeof rawPaymentIntent === 'string' ? rawPaymentIntent : rawPaymentIntent?.id;
+      if (paymentIntentId) {
+        try {
+          const refund = await stripe.refunds.create({
+            payment_intent: paymentIntentId,
+          });
+          refundedAmountCents = refund.amount;
+        } catch (err) {
+          if (
+            !(err instanceof stripe.errors.StripeInvalidRequestError) ||
+            err.code !== 'charge_already_refunded'
+          ) {
+            throw err;
+          }
         }
       }
     }
@@ -213,11 +218,15 @@ export async function cancelAndRefundKiloPassForUser({
     }
 
     const noteParts = [
-      `Kilo Pass cancelled and refunded by admin.`,
+      refundLatestPayment
+        ? `Kilo Pass cancelled and refunded by admin.`
+        : `Kilo Pass cancelled by admin.`,
       `Reason: ${reason}`,
-      refundedAmountCents != null
-        ? `Refunded: $${(refundedAmountCents / 100).toFixed(2)}`
-        : 'No invoice to refund.',
+      refundLatestPayment
+        ? refundedAmountCents != null
+          ? `Refunded: $${(refundedAmountCents / 100).toFixed(2)}`
+          : 'No invoice to refund.'
+        : 'Stripe refund skipped.',
       balanceReset != null
         ? `Balance reset: $${balanceReset.toFixed(2)} zeroed.`
         : 'Balance was already $0.',
@@ -251,7 +260,7 @@ export async function cancelAndRefundKiloPassForUser({
   }
 
   return {
-    status: 'cancelled_and_refunded',
+    status: refundLatestPayment ? 'cancelled_and_refunded' : 'cancelled',
     refundedAmountCents,
     balanceResetAmountUsd,
     alreadyBlocked: !!user.blocked_reason,

--- a/apps/web/src/lib/kilo-pass/cancel-and-refund.ts
+++ b/apps/web/src/lib/kilo-pass/cancel-and-refund.ts
@@ -204,7 +204,9 @@ export async function cancelAndRefundKiloPassForUser({
         organization_id: null,
         is_free: true,
         amount_microdollars: -currentBalanceMicrodollars,
-        credit_category: 'admin-cancel-refund-kilo-pass',
+        credit_category: refundLatestPayment
+          ? 'admin-cancel-refund-kilo-pass'
+          : 'admin-cancel-kilo-pass-no-refund',
         description: `Balance zeroed by admin: ${reason}`,
         original_baseline_microdollars_used: freshUser.microdollars_used,
       });

--- a/apps/web/src/lib/promoCreditCategories.ts
+++ b/apps/web/src/lib/promoCreditCategories.ts
@@ -316,6 +316,12 @@ const nonSelfServicePromos: readonly NonSelfServicePromoCreditCategoryConfig[] =
     expect_negative_amount: true,
   },
   {
+    credit_category: 'admin-cancel-kilo-pass-no-refund',
+    description: 'Balance zeroed by admin during Kilo Pass cancellation without refund',
+    is_idempotent: false,
+    expect_negative_amount: true,
+  },
+  {
     credit_category: 'organization_custom',
     description: 'Custom credit grant for organization',
     is_idempotent: false,

--- a/apps/web/src/routers/admin/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/admin/kilo-pass-router.test.ts
@@ -360,6 +360,12 @@ describe('admin.kiloPass.cancelAndRefundKiloPassBulk', () => {
     expect(userRow?.blocked_reason).toBe('policy');
     expect(userRow?.blocked_by_kilo_user_id).toBe(adminUser.id);
 
+    const txnRows = await db.query.credit_transactions.findMany({
+      where: eq(credit_transactions.kilo_user_id, target.id),
+    });
+    expect(txnRows).toHaveLength(1);
+    expect(txnRows[0].credit_category).toBe('admin-cancel-kilo-pass-no-refund');
+
     const noteRows = await db.query.user_admin_notes.findMany({
       where: eq(user_admin_notes.kilo_user_id, target.id),
     });

--- a/apps/web/src/routers/admin/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/admin/kilo-pass-router.test.ts
@@ -317,6 +317,58 @@ describe('admin.kiloPass.cancelAndRefundKiloPassBulk', () => {
     expect(noteRows[0].note_content).toContain('[bulk]');
   });
 
+  it('cancels and blocks without refunding when refundLatestPayment is false', async () => {
+    const stripeMock = getStripeMock();
+    stripeMock.subscriptions.cancel.mockResolvedValue({});
+
+    const target = await insertTestUser({
+      google_user_email: 'bulk-no-refund@example.com',
+      total_microdollars_acquired: 5_000_000,
+      microdollars_used: 1_000_000,
+    });
+    await insertActiveKiloPass(target.id, 'sub_no_refund');
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['bulk-no-refund@example.com'],
+      reason: 'policy',
+      refundLatestPayment: false,
+    });
+
+    expect(result.summary).toEqual({
+      total: 1,
+      cancelled: 1,
+      skipped: 0,
+      errored: 0,
+      totalRefundedCents: 0,
+    });
+    expect(result.results[0].status).toBe('cancelled');
+    expect(result.results[0].refundedAmountCents).toBeNull();
+    expect(stripeMock.subscriptions.cancel).toHaveBeenCalledWith('sub_no_refund');
+    expect(stripeMock.invoices.list).not.toHaveBeenCalled();
+    expect(stripeMock.invoicePayments.list).not.toHaveBeenCalled();
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+
+    const subRow = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, 'sub_no_refund'),
+    });
+    expect(subRow?.status).toBe('canceled');
+
+    const userRow = await db.query.kilocode_users.findFirst({
+      where: eq(kilocode_users.id, target.id),
+    });
+    expect(userRow?.blocked_reason).toBe('policy');
+    expect(userRow?.blocked_by_kilo_user_id).toBe(adminUser.id);
+
+    const noteRows = await db.query.user_admin_notes.findMany({
+      where: eq(user_admin_notes.kilo_user_id, target.id),
+    });
+    expect(noteRows).toHaveLength(1);
+    expect(noteRows[0].note_content).toContain('Kilo Pass cancelled by admin.');
+    expect(noteRows[0].note_content).toContain('Stripe refund skipped.');
+    expect(noteRows[0].note_content).toContain('[bulk]');
+  });
+
   it('handles no-invoice users as cancelled with null refund', async () => {
     const stripeMock = getStripeMock();
     setupNoInvoiceStripe(stripeMock);

--- a/apps/web/src/routers/admin/kilo-pass-router.ts
+++ b/apps/web/src/routers/admin/kilo-pass-router.ts
@@ -13,9 +13,11 @@ import {
 const BulkCancelSchema = z.object({
   emails: z.array(z.string().email()).min(1).max(500),
   reason: z.string().min(1).trim(),
+  refundLatestPayment: z.boolean().default(true),
 });
 
 type BulkResultStatus =
+  | 'cancelled'
   | 'cancelled_and_refunded'
   | 'skipped_no_user'
   | 'skipped_no_subscription'
@@ -51,11 +53,13 @@ export async function runBulkCancelAndRefundKiloPass({
   reason,
   adminKiloUserId,
   stripe,
+  refundLatestPayment,
 }: {
   emails: readonly string[];
   reason: string;
   adminKiloUserId: string;
   stripe: CancelAndRefundKiloPassStripeClient;
+  refundLatestPayment: boolean;
 }): Promise<{
   results: BulkResultRow[];
   summary: {
@@ -115,6 +119,7 @@ export async function runBulkCancelAndRefundKiloPass({
         userId: user.id,
         reason,
         adminKiloUserId,
+        refundLatestPayment,
         noteSuffix: '[bulk]',
       });
 
@@ -141,7 +146,7 @@ export async function runBulkCancelAndRefundKiloPass({
       results.push({
         email,
         userId: user.id,
-        status: 'cancelled_and_refunded',
+        status: result.status,
         refundedAmountCents: result.refundedAmountCents,
         balanceResetAmountUsd: result.balanceResetAmountUsd,
         alreadyBlocked: result.alreadyBlocked,
@@ -167,7 +172,7 @@ export async function runBulkCancelAndRefundKiloPass({
   const summary = results.reduce(
     (acc, row) => {
       acc.total += 1;
-      if (row.status === 'cancelled_and_refunded') {
+      if (row.status === 'cancelled' || row.status === 'cancelled_and_refunded') {
         acc.cancelled += 1;
         acc.totalRefundedCents += row.refundedAmountCents ?? 0;
       } else if (row.status === 'error') {
@@ -192,10 +197,11 @@ export const adminKiloPassRouter = createTRPCRouter({
         reason: input.reason,
         adminKiloUserId: ctx.user.id,
         stripe: stripeClient,
+        refundLatestPayment: input.refundLatestPayment,
       });
 
       console.log(
-        `[admin.kiloPass.cancelAndRefundKiloPassBulk] admin=${ctx.user.id} total=${outcome.summary.total} cancelled=${outcome.summary.cancelled} skipped=${outcome.summary.skipped} errored=${outcome.summary.errored} refundedCents=${outcome.summary.totalRefundedCents}`
+        `[admin.kiloPass.cancelAndRefundKiloPassBulk] admin=${ctx.user.id} total=${outcome.summary.total} cancelled=${outcome.summary.cancelled} skipped=${outcome.summary.skipped} errored=${outcome.summary.errored} refundLatestPayment=${input.refundLatestPayment} refundedCents=${outcome.summary.totalRefundedCents}`
       );
 
       return outcome;


### PR DESCRIPTION
## Summary
- Adds a checked-by-default admin checkbox to decide whether Kilo Pass bulk cancellation refunds the latest paid Stripe invoice.
- Propagates `refundLatestPayment` through the bulk cancel tRPC flow and skips Stripe invoice/payment/refund calls when disabled.
- Distinguishes no-refund cancellation results and admin notes while preserving existing refund-by-default behavior.

## Verification
N/A - local browser verification was skipped at request.

## Visual Changes
N/A - screenshots not captured at request.

## Reviewer Notes
Refunding remains enabled by default for backwards-compatible admin behavior. When unchecked, the flow still cancels the Stripe subscription, blocks the user, zeroes the balance, and writes an admin note, but does not refund Stripe payments.