### PR TITLE
test(ai-gateway): remove free Qwen model coverage

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -16,10 +16,8 @@ import {
   isAlibabaDirectModel,
   qwen36_plus_model,
   qwen37_max_model,
-  qwen37_plus_free_model,
   qwen37_plus_model,
 } from './providers/qwen';
-import { getModelVariants, REASONING_VARIANTS_BINARY } from './providers/model-settings';
 
 describe('isFreeModel', () => {
   describe('free models', () => {
@@ -92,15 +90,6 @@ describe('isFreeModel', () => {
       expect(qwen37_plus_model.gateway).toBe('alibaba');
       expect(qwen37_plus_model.internal_id).toBe('qwen3.7-plus');
       expect(getInferenceProvider(qwen37_plus_model)).toBe('alibaba');
-    });
-
-    test('routes free Qwen3.7 Plus through Vercel with binary thinking variants', () => {
-      expect(findKiloExclusiveModel(qwen37_plus_free_model.public_id)).toBe(qwen37_plus_free_model);
-      expect(isAlibabaDirectModel(qwen37_plus_free_model.public_id)).toBe(false);
-      expect(qwen37_plus_free_model.gateway).toBe('vercel');
-      expect(qwen37_plus_free_model.internal_id).toBe('alibaba/qwen3.7-plus');
-      expect(getInferenceProvider(qwen37_plus_free_model)).toBe(null);
-      expect(getModelVariants(qwen37_plus_free_model.public_id)).toBe(REASONING_VARIANTS_BINARY);
     });
 
     test('requires data collection for paid training-enabled offerings', () => {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -132,10 +132,6 @@ describe('mapModelIdToVercel', () => {
       );
     });
 
-    it('maps a forced Vercel exclusive through the inferred Alibaba model id', () => {
-      expect(mapModelIdToVercel('qwen/qwen3.7-plus:free', false)).toBe('alibaba/qwen3.7-plus');
-    });
-
     it('does not use internal_id for exclusives that are not vercel-routed', () => {
       // claude_sonnet_clawsetup_model has gateway 'openrouter' and no
       // 'vercel-routing' flag, so the mapping must pass the public id through


### PR DESCRIPTION
## Summary
- Remove the Qwen 3.7 Plus free-model tests added in #3712.
- Keep the free-model implementation unchanged while reducing coupling that would complicate its upcoming removal.

## Verification
Not manually tested; this only removes test coverage.

## Visual Changes
N/A

## Reviewer Notes
The removed assertions specifically encode the free Qwen model's registry, routing, and variant behavior.