### PR TITLE
fix(ai-gateway): expose disabled paid OpenRouter models

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -1,13 +1,32 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import {
   formatName,
+  getEnhancedOpenRouterModels,
   getOpenRouterTranscriptionModels,
+  shouldSuppressOpenRouterModel,
   undoPricingDiscount,
 } from '@/lib/ai-gateway/providers/openrouter';
 import { createMockResponse, mockOpenRouterModels } from '@/tests/helpers/openrouter-models.helper';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
+import { minimax_m3_discounted_model } from '@/lib/ai-gateway/providers/minimax';
+import { seed_20_code_free_model } from '@/lib/ai-gateway/providers/seed';
+import { morph_warp_grep_free_model } from '@/lib/ai-gateway/providers/morph';
+import { findKiloExclusiveModel, isDeadFreeModel, kiloExclusiveModels } from '@/lib/ai-gateway/models';
+import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
+
+jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
+  getOpenRouterModelsMetadata: jest.fn(() => Promise.resolve({})),
+}));
 
 const originalFetch = global.fetch;
+
+const disabledPaidModel = {
+  ...minimax_m3_discounted_model,
+  public_id: 'vendor/disabled-paid-model',
+  internal_id: 'vendor/disabled-paid-model-internal',
+  display_name: 'Disabled Paid Kilo Model',
+  status: 'disabled',
+} satisfies KiloExclusiveModel;
 
 function buildModel(overrides: Partial<OpenRouterModel> = {}): OpenRouterModel {
   return {
@@ -127,6 +146,52 @@ describe('undoPricingDiscount', () => {
       discount: 1,
     });
     expect(result).toEqual({ prompt: '0.000001', completion: '0.000005' });
+  });
+});
+
+describe('shouldSuppressOpenRouterModel', () => {
+  it('does not suppress disabled paid Kilo-exclusive models returned by OpenRouter', () => {
+    expect(disabledPaidModel.pricing).not.toBeNull();
+    expect(shouldSuppressOpenRouterModel(disabledPaidModel)).toBe(false);
+  });
+
+  it('suppresses disabled free Kilo-exclusive models from OpenRouter', () => {
+    expect(seed_20_code_free_model.status).toBe('disabled');
+    expect(seed_20_code_free_model.pricing).toBeNull();
+    expect(shouldSuppressOpenRouterModel(seed_20_code_free_model)).toBe(true);
+  });
+
+  it('suppresses public and hidden Kilo-exclusive models from OpenRouter', () => {
+    expect(shouldSuppressOpenRouterModel(minimax_m3_discounted_model)).toBe(true);
+    expect(morph_warp_grep_free_model.status).toBe('hidden');
+    expect(shouldSuppressOpenRouterModel(morph_warp_grep_free_model)).toBe(true);
+  });
+});
+
+describe('disabled paid Kilo-exclusive model fallback', () => {
+  beforeEach(() => {
+    kiloExclusiveModels.push(disabledPaidModel);
+    global.fetch = jest.fn(() =>
+      Promise.resolve(
+        createMockResponse({
+          jsonData: { data: [buildModel({ id: disabledPaidModel.public_id })] },
+        })
+      )
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    const modelIndex = kiloExclusiveModels.indexOf(disabledPaidModel);
+    if (modelIndex >= 0) kiloExclusiveModels.splice(modelIndex, 1);
+    global.fetch = originalFetch;
+  });
+
+  it('keeps the OpenRouter model available without Kilo-exclusive blocking or routing', async () => {
+    const models = await getEnhancedOpenRouterModels();
+
+    expect(models.data.some(model => model.id === disabledPaidModel.public_id)).toBe(true);
+    expect(isDeadFreeModel(disabledPaidModel.public_id)).toBe(false);
+    expect(findKiloExclusiveModel(disabledPaidModel.public_id)).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -11,7 +11,11 @@ import type { OpenRouterModel } from '@/lib/organizations/organization-types';
 import { minimax_m3_discounted_model } from '@/lib/ai-gateway/providers/minimax';
 import { seed_20_code_free_model } from '@/lib/ai-gateway/providers/seed';
 import { morph_warp_grep_free_model } from '@/lib/ai-gateway/providers/morph';
-import { findKiloExclusiveModel, isDeadFreeModel, kiloExclusiveModels } from '@/lib/ai-gateway/models';
+import {
+  findKiloExclusiveModel,
+  isDeadFreeModel,
+  kiloExclusiveModels,
+} from '@/lib/ai-gateway/models';
 import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 
 jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -13,7 +13,10 @@ import {
 } from '@/lib/organizations/organization-types';
 import { errorExceptInTest } from '@/lib/utils.server';
 import { captureException, captureMessage } from '@sentry/nextjs';
-import { convertFromKiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
+import {
+  convertFromKiloExclusiveModel,
+  type KiloExclusiveModel,
+} from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 import { isForbiddenFreeModel } from '@/lib/ai-gateway/forbidden-free-models';
 import { getOpenCodeSettings } from '@/lib/ai-gateway/providers/model-settings';
 import { AUTO_MODELS } from '@/lib/ai-gateway/auto-model';
@@ -109,6 +112,10 @@ export function undoPricingDiscount(pricing: EndpointPricing): EndpointPricing {
   return result;
 }
 
+export function shouldSuppressOpenRouterModel(model: KiloExclusiveModel): boolean {
+  return model.status !== 'disabled' || model.pricing === null;
+}
+
 async function enhancedModelList(models: OpenRouterModel[]) {
   const autoModels = buildAutoModels();
   const endpointsMetadata = await getOpenRouterModelsMetadata();
@@ -116,8 +123,9 @@ async function enhancedModelList(models: OpenRouterModel[]) {
     models
       .filter(
         (model: OpenRouterModel) =>
-          !kiloExclusiveModels.some(m => m.public_id === model.id) &&
-          !isForbiddenFreeModel(model.id)
+          !kiloExclusiveModels.some(
+            m => m.public_id === model.id && shouldSuppressOpenRouterModel(m)
+          ) && !isForbiddenFreeModel(model.id)
       )
       .map(model => {
         const preferredProvider = getPreferredProviderOrder(model.id).at(0);


### PR DESCRIPTION
## Summary
- Preserve paid, disabled Kilo-exclusive models in the enhanced model list when OpenRouter returns them.
- Keep public, hidden, and disabled free Kilo-exclusive models suppressed so their existing routing and blocking behavior remains unchanged.
- Add regression coverage for model-list availability and default-gateway fallthrough semantics.

## Verification
N/A — backend-only model catalog filtering change.

## Visual Changes
N/A

## Reviewer Notes
Disabled paid models remain excluded from Kilo-exclusive lookup and dead-free blocking, allowing normal upstream gateway selection.