### PR TITLE
feat(web): make usage breakdowns metric-aware

### DIFF
--- a/apps/web/src/components/usage-analytics/BreakdownBarChart.tsx
+++ b/apps/web/src/components/usage-analytics/BreakdownBarChart.tsx
@@ -12,16 +12,15 @@ import {
   YAxis,
 } from 'recharts';
 import { colorForIndex } from './colors';
-import { formatDollarsFromMicrodollars, formatMetric } from './format';
-import { formatLargeNumber } from '@/lib/utils';
-import type { Dimension, UsageBreakdown } from './types';
+import { formatMetric } from './format';
+import { isAdditiveMetric, type Dimension, type MetricKey, type UsageBreakdown } from './types';
 
 type BreakdownBarChartProps = {
   title: string;
   dimension: Dimension;
   data: UsageBreakdown | undefined;
   loading: boolean;
-  metric: 'cost' | 'requests' | 'tokens';
+  metric: MetricKey;
   labelFor?: (value: string) => string;
 };
 
@@ -43,12 +42,6 @@ const LABEL_MIN_WIDTH = 120;
 const LABEL_MAX_WIDTH = 280;
 const LABEL_RIGHT_PADDING = 16;
 
-function formatBarValue(metric: 'cost' | 'requests' | 'tokens', value: number): string {
-  if (metric === 'cost') return formatDollarsFromMicrodollars(value);
-  if (metric === 'requests') return formatLargeNumber(value);
-  return formatMetric('tokens', value);
-}
-
 export function BreakdownBarChart({
   title,
   data,
@@ -69,6 +62,7 @@ export function BreakdownBarChart({
   }, [data, labelFor]);
 
   const chartHeight = Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, items.length * ROW_HEIGHT + 24));
+  const showPercentage = isAdditiveMetric(metric);
 
   /** Size the Y-axis to fit the longest label so names aren't truncated. */
   const yAxisWidth = useMemo(() => {
@@ -107,7 +101,7 @@ export function BreakdownBarChart({
                   type="number"
                   stroke="currentColor"
                   fontSize={11}
-                  tickFormatter={v => formatBarValue(metric, Number(v))}
+                  tickFormatter={v => formatMetric(metric, Number(v))}
                 />
                 <YAxis
                   dataKey="label"
@@ -131,8 +125,10 @@ export function BreakdownBarChart({
                   cursor={{ fill: 'rgba(255, 255, 255, 0.04)' }}
                   formatter={(value, _name, item) => {
                     const raw = Number(value);
+                    const formatted = formatMetric(metric, raw);
+                    if (!showPercentage) return [formatted];
                     const pct = (item?.payload as BarDatum | undefined)?.percentage ?? 0;
-                    return [`${formatBarValue(metric, raw)} (${pct.toFixed(1)}%)`];
+                    return [`${formatted} (${pct.toFixed(1)}%)`];
                   }}
                 />
                 <Bar dataKey="value" radius={[0, 4, 4, 0]} isAnimationActive={false}>

--- a/apps/web/src/components/usage-analytics/BreakdownPieChart.tsx
+++ b/apps/web/src/components/usage-analytics/BreakdownPieChart.tsx
@@ -28,7 +28,13 @@ type Slice = {
   sourceKeys?: string[];
 };
 
-export function BreakdownPieChart({ title, data, loading, metric, labelFor }: BreakdownPieChartProps) {
+export function BreakdownPieChart({
+  title,
+  data,
+  loading,
+  metric,
+  labelFor,
+}: BreakdownPieChartProps) {
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
 
   const slices = useMemo<Slice[]>(() => {
@@ -149,9 +155,7 @@ export function BreakdownPieChart({ title, data, loading, metric, labelFor }: Br
                   <span className="text-muted-foreground shrink-0">
                     {slice.percentage.toFixed(1)}%
                   </span>
-                  <span className="shrink-0 font-mono">
-                    {formatMetric(metric, slice.value)}
-                  </span>
+                  <span className="shrink-0 font-mono">{formatMetric(metric, slice.value)}</span>
                 </li>
               ))}
             </ul>

--- a/apps/web/src/components/usage-analytics/BreakdownPieChart.tsx
+++ b/apps/web/src/components/usage-analytics/BreakdownPieChart.tsx
@@ -4,8 +4,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts';
 import { cn } from '@/lib/utils';
 import { OTHER_COLOR, PALETTE } from './colors';
-import { formatDollarsFromMicrodollars } from './format';
-import type { Dimension, UsageBreakdown } from './types';
+import { formatMetric } from './format';
+import type { AdditiveMetricKey, Dimension, UsageBreakdown } from './types';
 
 const TOP_N = 8;
 
@@ -14,6 +14,7 @@ type BreakdownPieChartProps = {
   dimension: Dimension;
   data: UsageBreakdown | undefined;
   loading: boolean;
+  metric: AdditiveMetricKey;
   labelFor?: (value: string) => string;
 };
 
@@ -27,7 +28,7 @@ type Slice = {
   sourceKeys?: string[];
 };
 
-export function BreakdownPieChart({ title, data, loading, labelFor }: BreakdownPieChartProps) {
+export function BreakdownPieChart({ title, data, loading, metric, labelFor }: BreakdownPieChartProps) {
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
 
   const slices = useMemo<Slice[]>(() => {
@@ -120,7 +121,7 @@ export function BreakdownPieChart({ title, data, loading, labelFor }: BreakdownP
                         const raw = Number(value);
                         const pct = (item?.payload as Slice | undefined)?.percentage ?? 0;
                         return [
-                          `${formatDollarsFromMicrodollars(raw)} (${pct.toFixed(1)}%)`,
+                          `${formatMetric(metric, raw)} (${pct.toFixed(1)}%)`,
                           (item?.payload as Slice | undefined)?.label ?? '',
                         ];
                       }}
@@ -149,7 +150,7 @@ export function BreakdownPieChart({ title, data, loading, labelFor }: BreakdownP
                     {slice.percentage.toFixed(1)}%
                   </span>
                   <span className="shrink-0 font-mono">
-                    {formatDollarsFromMicrodollars(slice.value)}
+                    {formatMetric(metric, slice.value)}
                   </span>
                 </li>
               ))}

--- a/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
@@ -44,6 +44,8 @@ import {
 import { useUsageDashboardState } from './useUsageDashboardState';
 import {
   DIMENSION_LABELS,
+  METRIC_LABELS,
+  isAdditiveMetric,
   type Dimension,
   type FilterDirection,
   type Granularity,
@@ -229,28 +231,29 @@ export function UsageAnalyticsDashboard({
     splitBy: splitByDimension,
   });
 
+  const featureBreakdownMetric = isAdditiveMetric(chartMetric) ? chartMetric : 'cost';
   const { data: featureBreakdown, isLoading: featureBreakdownLoading } = useUsageBreakdown({
     ...commonArgs,
     dimension: 'feature',
-    metric: 'cost',
+    metric: featureBreakdownMetric,
     limit: 20,
   });
   const { data: modelBreakdown, isLoading: modelBreakdownLoading } = useUsageBreakdown({
     ...commonArgs,
     dimension: 'model',
-    metric: 'cost',
+    metric: chartMetric,
     limit: 10,
   });
   const { data: projectBreakdown, isLoading: projectBreakdownLoading } = useUsageBreakdown({
     ...commonArgs,
     dimension: 'project',
-    metric: 'cost',
+    metric: chartMetric,
     limit: 10,
   });
   const { data: userBreakdown, isLoading: userBreakdownLoading } = useUsageBreakdown({
     ...commonArgs,
     dimension: 'user',
-    metric: 'cost',
+    metric: chartMetric,
     limit: 10,
     enabled: isOrgWideView,
   });
@@ -535,34 +538,35 @@ export function UsageAnalyticsDashboard({
             />
 
             <BreakdownPieChart
-              title="Features"
+              title={`Features by ${METRIC_LABELS[featureBreakdownMetric]}`}
               dimension="feature"
               data={featureBreakdown}
               loading={featureBreakdownLoading}
+              metric={featureBreakdownMetric}
               labelFor={featureLabelFor}
             />
             <BreakdownBarChart
-              title="Models"
+              title={`Models by ${METRIC_LABELS[chartMetric]}`}
               dimension="model"
               data={modelBreakdown}
               loading={modelBreakdownLoading}
-              metric="cost"
+              metric={chartMetric}
             />
             <BreakdownBarChart
-              title="Top Projects"
+              title={`Top Projects by ${METRIC_LABELS[chartMetric]}`}
               dimension="project"
               data={projectBreakdown}
               loading={projectBreakdownLoading}
-              metric="cost"
+              metric={chartMetric}
               labelFor={projectLabelFor}
             />
             {isOrgWideView && (
               <BreakdownBarChart
-                title="Users"
+                title={`Users by ${METRIC_LABELS[chartMetric]}`}
                 dimension="user"
                 data={userBreakdown}
                 loading={userBreakdownLoading}
-                metric="cost"
+                metric={chartMetric}
                 labelFor={userLabelFor}
               />
             )}

--- a/apps/web/src/components/usage-analytics/hooks.ts
+++ b/apps/web/src/components/usage-analytics/hooks.ts
@@ -182,7 +182,7 @@ export function useUsageTimeseries(
 export function useUsageBreakdown(
   args: CommonArgs & {
     dimension: Dimension;
-    metric: 'cost' | 'requests' | 'tokens';
+    metric: MetricKey;
     limit?: number;
     enabled?: boolean;
   }

--- a/apps/web/src/components/usage-analytics/types.test.ts
+++ b/apps/web/src/components/usage-analytics/types.test.ts
@@ -1,0 +1,22 @@
+import { isAdditiveMetric, type MetricKey } from './types';
+
+describe('isAdditiveMetric', () => {
+  it.each<MetricKey>(['cost', 'requests', 'tokens', 'inputTokens', 'outputTokens'])(
+    'recognizes %s as additive',
+    metric => {
+      expect(isAdditiveMetric(metric)).toBe(true);
+    }
+  );
+
+  it.each<MetricKey>([
+    'errorRate',
+    'avgLatencyMs',
+    'avgGenerationTimeMs',
+    'costPerRequest',
+    'tokensPerRequest',
+    'cacheHitRatio',
+    'outputInputRatio',
+  ])('recognizes %s as non-additive', metric => {
+    expect(isAdditiveMetric(metric)).toBe(false);
+  });
+});

--- a/apps/web/src/components/usage-analytics/types.ts
+++ b/apps/web/src/components/usage-analytics/types.ts
@@ -21,6 +21,23 @@ export type MetricKey =
   | 'cacheHitRatio'
   | 'outputInputRatio';
 
+export type AdditiveMetricKey = Extract<
+  MetricKey,
+  'cost' | 'requests' | 'tokens' | 'inputTokens' | 'outputTokens'
+>;
+
+const ADDITIVE_METRICS = new Set<MetricKey>([
+  'cost',
+  'requests',
+  'tokens',
+  'inputTokens',
+  'outputTokens',
+]);
+
+export function isAdditiveMetric(metric: MetricKey): metric is AdditiveMetricKey {
+  return ADDITIVE_METRICS.has(metric);
+}
+
 export type FilterDirection = 'include' | 'exclude';
 
 export type DimensionFilter = {

--- a/apps/web/src/routers/usage-analytics-router.ts
+++ b/apps/web/src/routers/usage-analytics-router.ts
@@ -19,6 +19,8 @@ export type Granularity = z.infer<typeof GranularitySchema>;
 export const DimensionSchema = z.enum(['feature', 'model', 'mode', 'user', 'provider', 'project']);
 export type Dimension = z.infer<typeof DimensionSchema>;
 
+const AdditiveMetricSchema = z.enum(['cost', 'requests', 'tokens', 'inputTokens', 'outputTokens']);
+
 export const MetricSchema = z.enum([
   'cost',
   'requests',
@@ -311,12 +313,12 @@ function buildDimensionConditions(where: WhereBuilder, filters: UsageAnalyticsFi
   };
 
   addInIfNonEmpty('feature', filters.features);
-  addInIfNonEmpty('model', filters.models);
+  addInIfNonEmpty('requested_model', filters.models);
   addInIfNonEmpty('mode', filters.modes);
   addInIfNonEmpty('provider', filters.providers);
   addInIfNonEmpty('project_id', filters.projects);
   addNotInIfNonEmpty('feature', filters.excludedFeatures);
-  addNotInIfNonEmpty('model', filters.excludedModels);
+  addNotInIfNonEmpty('requested_model', filters.excludedModels);
   addNotInIfNonEmpty('mode', filters.excludedModes);
   addNotInIfNonEmpty('provider', filters.excludedProviders);
   addNotInIfNonEmpty('project_id', filters.excludedProjects);
@@ -421,7 +423,7 @@ function dimensionColumn(dimension: Dimension): string {
     case 'feature':
       return 'feature';
     case 'model':
-      return 'model';
+      return 'requested_model';
     case 'mode':
       return 'mode';
     case 'user':
@@ -590,7 +592,7 @@ const TimeseriesOutputSchema = z.object({
 
 const BreakdownInputSchema = UsageAnalyticsFiltersSchema.extend({
   dimension: DimensionSchema,
-  metric: z.enum(['cost', 'requests', 'tokens']),
+  metric: MetricSchema,
   limit: z.number().int().min(1).max(100).default(15),
 });
 
@@ -939,9 +941,10 @@ export const usageAnalyticsRouter = createTRPCRouter({
       );
 
       const values = rows.map(row => ({ key: row[0] ?? '', value: toSafeNumber(row[1]) }));
+      const isAdditive = AdditiveMetricSchema.safeParse(input.metric).success;
       // Percentages are relative to the *returned* rows (limited by input.limit).
       // They will not reflect the true share when the result set is capped.
-      const totalValue = values.reduce((s, r) => s + r.value, 0);
+      const totalValue = isAdditive ? values.reduce((s, r) => s + r.value, 0) : 0;
 
       return {
         breakdown: values.map(r => ({
@@ -975,7 +978,7 @@ export const usageAnalyticsRouter = createTRPCRouter({
       // For dimensions not in groupBy, emit an empty string constant so the
       // row shape stays stable regardless of which dimensions were requested.
       const featExpr = requestedDims.includes('feature') ? 'feature' : "''";
-      const modelExpr = requestedDims.includes('model') ? 'model' : "''";
+      const modelExpr = requestedDims.includes('model') ? 'requested_model' : "''";
       const modeExpr = requestedDims.includes('mode') ? 'mode' : "''";
       const userExpr = requestedDims.includes('user') ? 'kilo_user_id' : "''";
       const providerExpr = requestedDims.includes('provider') ? 'provider' : "''";

--- a/apps/web/src/scripts/usage/lib/mock-dimensions.ts
+++ b/apps/web/src/scripts/usage/lib/mock-dimensions.ts
@@ -1,7 +1,7 @@
 /**
  * Pools of dimension values used by the mock usage generator.
  *
- * Snowflake groups by `model`, `feature`, `mode`, `provider`, `project_id`,
+ * Snowflake groups by `requested_model`, `feature`, `mode`, `provider`, `project_id`,
  * plus the user and org scope. We generate records with enough variety across
  * those dimensions that every breakdown chart has multiple slices.
  */


### PR DESCRIPTION
## Summary

- Make model, project, and user bar charts follow the selected usage metric, with metric-aware labels and formatting.
- Let the feature pie chart follow additive metrics while retaining cost for rates and averages that cannot be represented as shares.
- Use `requested_model` instead of the inconsistent internal `model` value across usage analytics filters, groupings, and table output.

## Verification

- [ ] Not manually verified; local web services were not started in this environment.

## Visual Changes

N/A — chart titles and displayed metrics change with the existing Metric control; no screenshots captured.

## Reviewer Notes

- Confirm the Snowflake hourly and daily rollups expose `requested_model` as part of their grouping grain.
- Non-additive breakdown metrics intentionally return no percentage share, while additive metrics retain percentage tooltips.