### PR TITLE
O11y - Add Queue Backlog Alerts

### DIFF
--- a/services/o11y/src/alerting/evaluate.ts
+++ b/services/o11y/src/alerting/evaluate.ts
@@ -18,6 +18,7 @@ import { sendAlertNotification, type AlertPayload } from './notify';
 import { listAlertingConfigs, type AlertingConfig } from './config-store';
 import { listTtfbAlertingConfigs, type TtfbAlertingConfig } from './ttfb-config-store';
 import { evaluateContainerCapacity } from './container-capacity-evaluate';
+import { evaluateQueueBacklogAlert } from './queue-backlog-evaluate';
 
 /**
  * Compute the burn rate from an observed bad-event fraction and the SLO.
@@ -265,17 +266,25 @@ async function evaluateTtfbWindow(
  * can suppress lower-severity alerts for the same dimension.
  */
 export async function evaluateAlerts(env: Env): Promise<void> {
-  const configs = await listAlertingConfigs(env);
-  const enabledConfigs = configs.filter(config => config.enabled);
-  const configByModel: ConfigByModel = new Map(
-    enabledConfigs.map(config => [config.model, config])
-  );
+  const errors: unknown[] = [];
+  let configByModel: ConfigByModel = new Map();
+  let ttfbConfigByModel: TtfbConfigByModel = new Map();
 
-  const ttfbConfigs = await listTtfbAlertingConfigs(env);
-  const enabledTtfbConfigs = ttfbConfigs.filter(config => config.enabled);
-  const ttfbConfigByModel: TtfbConfigByModel = new Map(
-    enabledTtfbConfigs.map(config => [config.model, config])
-  );
+  try {
+    const configs = await listAlertingConfigs(env);
+    const enabledConfigs = configs.filter(config => config.enabled);
+    configByModel = new Map(enabledConfigs.map(config => [config.model, config]));
+  } catch (err) {
+    errors.push(new Error('error_rate config loading', { cause: err }));
+  }
+
+  try {
+    const ttfbConfigs = await listTtfbAlertingConfigs(env);
+    const enabledTtfbConfigs = ttfbConfigs.filter(config => config.enabled);
+    ttfbConfigByModel = new Map(enabledTtfbConfigs.map(config => [config.model, config]));
+  } catch (err) {
+    errors.push(new Error('ttfb config loading', { cause: err }));
+  }
 
   // Sort windows by severity: pages first, then tickets.
   // Within the same severity, higher burn rate first.
@@ -283,8 +292,6 @@ export async function evaluateAlerts(env: Env): Promise<void> {
     if (a.severity !== b.severity) return a.severity === 'page' ? -1 : 1;
     return b.burnRate - a.burnRate;
   });
-
-  const errors: unknown[] = [];
 
   for (const window of sortedWindows) {
     try {
@@ -300,11 +307,17 @@ export async function evaluateAlerts(env: Env): Promise<void> {
     }
   }
 
-  // Container capacity evaluation runs once per cron tick, independent of burn-rate windows.
+  // Infrastructure evaluations run once per cron tick, independent of burn-rate windows.
   try {
     await evaluateContainerCapacity(env);
   } catch (err) {
     errors.push(new Error('container_capacity evaluation', { cause: err }));
+  }
+
+  try {
+    await evaluateQueueBacklogAlert(env);
+  } catch (err) {
+    errors.push(new Error('queue_backlog evaluation', { cause: err }));
   }
 
   if (errors.length > 0) {

--- a/services/o11y/src/alerting/notify.ts
+++ b/services/o11y/src/alerting/notify.ts
@@ -43,7 +43,22 @@ export type ContainerCapacityAlertPayload = {
   health?: HealthInstances;
 };
 
-export type AlertPayload = SloAlertPayload | ContainerCapacityAlertPayload;
+export type QueueBacklogAlertPayload = {
+  alertType: 'queue_backlog';
+  severity: AlertSeverity;
+  provider: string;
+  model: string;
+  clientName: string;
+  backlogCount: number;
+  backlogBytes: number;
+  thresholdCount: number;
+  oldestMessageTimestamp?: Date;
+};
+
+export type AlertPayload =
+  | SloAlertPayload
+  | ContainerCapacityAlertPayload
+  | QueueBacklogAlertPayload;
 
 // ── Formatting helpers ───────────────────────────────────────────────────────
 
@@ -59,6 +74,8 @@ function formatAlertTypeLabel(alertType: AlertPayload['alertType']): string {
       return 'TTFB Latency';
     case 'container_capacity':
       return 'Container Capacity';
+    case 'queue_backlog':
+      return 'Queue Backlog';
   }
 }
 
@@ -145,17 +162,50 @@ function buildCapacitySlackBlocks(alert: ContainerCapacityAlertPayload): object[
   ];
 }
 
+function buildQueueBacklogSlackBlocks(alert: QueueBacklogAlertPayload): object[] {
+  const severityLabel = alert.severity === 'page' ? ':rotating_light: PAGE' : ':ticket: TICKET';
+  const oldestMessageTimestamp = alert.oldestMessageTimestamp?.toISOString() ?? 'Unknown';
+
+  return [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: `${severityLabel} — Queue Backlog Alert`,
+      },
+    },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `*Queue ID:*\n${alert.model}` },
+        { type: 'mrkdwn', text: `*Backlog:*\n${alert.backlogCount.toLocaleString()} messages` },
+        { type: 'mrkdwn', text: `*Threshold:*\n${alert.thresholdCount.toLocaleString()} messages` },
+        { type: 'mrkdwn', text: `*Backlog bytes:*\n${alert.backlogBytes.toLocaleString()}` },
+      ],
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `Oldest message: ${oldestMessageTimestamp}`,
+      },
+    },
+  ];
+}
+
 /**
  * Builds a Slack Block Kit message body for the given alert.
  * Exported for testing.
  */
 export function buildSlackMessage(alert: AlertPayload): object {
-  const blocks =
-    alert.alertType === 'container_capacity'
-      ? buildCapacitySlackBlocks(alert)
-      : buildSloSlackBlocks(alert);
-
-  return { blocks };
+  switch (alert.alertType) {
+    case 'container_capacity':
+      return { blocks: buildCapacitySlackBlocks(alert) };
+    case 'queue_backlog':
+      return { blocks: buildQueueBacklogSlackBlocks(alert) };
+    default:
+      return { blocks: buildSloSlackBlocks(alert) };
+  }
 }
 
 // ── Notification delivery ───────────────────────────────────────────────────

--- a/services/o11y/src/alerting/queue-backlog-evaluate.ts
+++ b/services/o11y/src/alerting/queue-backlog-evaluate.ts
@@ -1,0 +1,63 @@
+import { evaluateQueueBacklog, type QueueBacklogMetrics } from './queue-backlog';
+import { queryQueueBacklog } from './queue-backlog-query';
+import { shouldSuppress, recordAlertFired } from './dedup';
+import { sendAlertNotification, type AlertPayload } from './notify';
+
+type QueueBacklogEnv = {
+  O11Y_ALERT_STATE: KVNamespace;
+  O11Y_CF_ACCOUNT_ID: string;
+  O11Y_CF_CONTAINERS_API_TOKEN: SecretsStoreSecret;
+  O11Y_SLACK_WEBHOOK_PAGE: SecretsStoreSecret;
+  O11Y_SLACK_WEBHOOK_TICKET: SecretsStoreSecret;
+};
+
+type QueryFn = (
+  env: Pick<QueueBacklogEnv, 'O11Y_CF_ACCOUNT_ID' | 'O11Y_CF_CONTAINERS_API_TOKEN'>
+) => Promise<QueueBacklogMetrics>;
+
+type NotifyFn = (alert: AlertPayload, env: QueueBacklogEnv) => Promise<void>;
+
+export async function evaluateQueueBacklogAlert(
+  env: QueueBacklogEnv,
+  queryFn: QueryFn = queryQueueBacklog,
+  notifyFn: NotifyFn = sendAlertNotification
+): Promise<void> {
+  const alert = evaluateQueueBacklog(await queryFn(env));
+  if (alert === null) return;
+
+  const provider = 'cloudflare';
+  const clientName = 'queues';
+  const suppressed = await shouldSuppress(
+    env.O11Y_ALERT_STATE,
+    alert.severity,
+    'queue_backlog',
+    provider,
+    alert.queueId,
+    clientName
+  );
+  if (suppressed) return;
+
+  await notifyFn(
+    {
+      alertType: 'queue_backlog',
+      severity: alert.severity,
+      provider,
+      model: alert.queueId,
+      clientName,
+      backlogCount: alert.backlogCount,
+      backlogBytes: alert.backlogBytes,
+      thresholdCount: alert.thresholdCount,
+      oldestMessageTimestamp: alert.oldestMessageTimestamp,
+    },
+    env
+  );
+
+  await recordAlertFired(
+    env.O11Y_ALERT_STATE,
+    alert.severity,
+    'queue_backlog',
+    provider,
+    alert.queueId,
+    clientName
+  );
+}

--- a/services/o11y/src/alerting/queue-backlog-query.ts
+++ b/services/o11y/src/alerting/queue-backlog-query.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import { MONITORED_QUEUE_ID, type QueueBacklogMetrics } from './queue-backlog';
+
+type QueryEnv = {
+  O11Y_CF_ACCOUNT_ID: string;
+  O11Y_CF_CONTAINERS_API_TOKEN: SecretsStoreSecret;
+};
+
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+const QueueMetricsResponseSchema = z.object({
+  success: z.literal(true),
+  result: z.object({
+    backlog_count: z.number().nonnegative(),
+    backlog_bytes: z.number().nonnegative(),
+    oldest_message_timestamp_ms: z.number().nonnegative(),
+  }),
+});
+
+const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
+
+export async function queryQueueBacklog(
+  env: QueryEnv,
+  fetchFn: FetchFn = fetch
+): Promise<QueueBacklogMetrics> {
+  const token = await env.O11Y_CF_CONTAINERS_API_TOKEN.get();
+  if (!token) {
+    throw new Error('O11Y_CF_CONTAINERS_API_TOKEN secret is not configured');
+  }
+
+  const response = await fetchFn(
+    `${CF_API_BASE}/accounts/${env.O11Y_CF_ACCOUNT_ID}/queues/${MONITORED_QUEUE_ID}/metrics`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5_000),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Queue metrics request failed (${response.status})`);
+  }
+
+  const parsed = QueueMetricsResponseSchema.parse(await response.json());
+  const oldestMessageTimestamp =
+    parsed.result.oldest_message_timestamp_ms > 0
+      ? new Date(parsed.result.oldest_message_timestamp_ms)
+      : undefined;
+
+  return {
+    queueId: MONITORED_QUEUE_ID,
+    backlogCount: parsed.result.backlog_count,
+    backlogBytes: parsed.result.backlog_bytes,
+    oldestMessageTimestamp,
+  };
+}

--- a/services/o11y/src/alerting/queue-backlog-query.ts
+++ b/services/o11y/src/alerting/queue-backlog-query.ts
@@ -8,14 +8,20 @@ type QueryEnv = {
 
 type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
 
-const QueueMetricsResponseSchema = z.object({
-  success: z.literal(true),
-  result: z.object({
-    backlog_count: z.number().nonnegative(),
-    backlog_bytes: z.number().nonnegative(),
-    oldest_message_timestamp_ms: z.number().nonnegative(),
+const QueueMetricsResponseSchema = z.discriminatedUnion('success', [
+  z.object({
+    success: z.literal(true),
+    result: z.object({
+      backlog_count: z.number().nonnegative(),
+      backlog_bytes: z.number().nonnegative(),
+      oldest_message_timestamp_ms: z.number().nonnegative(),
+    }),
   }),
-});
+  z.object({
+    success: z.literal(false),
+    errors: z.array(z.object({ message: z.string() })).optional(),
+  }),
+]);
 
 const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
 
@@ -41,6 +47,11 @@ export async function queryQueueBacklog(
   }
 
   const parsed = QueueMetricsResponseSchema.parse(await response.json());
+  if (!parsed.success) {
+    const details = parsed.errors?.map(error => error.message).join('; ') || 'unknown error';
+    throw new Error(`Queue metrics request failed: ${details}`);
+  }
+
   const oldestMessageTimestamp =
     parsed.result.oldest_message_timestamp_ms > 0
       ? new Date(parsed.result.oldest_message_timestamp_ms)

--- a/services/o11y/src/alerting/queue-backlog.ts
+++ b/services/o11y/src/alerting/queue-backlog.ts
@@ -1,0 +1,41 @@
+import type { AlertSeverity } from './slo-config';
+
+export const MONITORED_QUEUE_ID = '965459cfc1a349c190bb813855a65b02';
+
+export const QUEUE_BACKLOG_THRESHOLDS = {
+  page: 50_000,
+  ticket: 25_000,
+} as const;
+
+export type QueueBacklogMetrics = {
+  queueId: string;
+  backlogCount: number;
+  backlogBytes: number;
+  oldestMessageTimestamp?: Date;
+};
+
+export type QueueBacklogAlert = QueueBacklogMetrics & {
+  severity: AlertSeverity;
+  thresholdCount: number;
+};
+
+export function evaluateQueueBacklog(metrics: QueueBacklogMetrics): QueueBacklogAlert | null {
+  let severity: AlertSeverity | null = null;
+  let thresholdCount = 0;
+
+  if (metrics.backlogCount >= QUEUE_BACKLOG_THRESHOLDS.page) {
+    severity = 'page';
+    thresholdCount = QUEUE_BACKLOG_THRESHOLDS.page;
+  } else if (metrics.backlogCount >= QUEUE_BACKLOG_THRESHOLDS.ticket) {
+    severity = 'ticket';
+    thresholdCount = QUEUE_BACKLOG_THRESHOLDS.ticket;
+  }
+
+  if (severity === null) return null;
+
+  return {
+    ...metrics,
+    severity,
+    thresholdCount,
+  };
+}

--- a/services/o11y/src/alerting/queue-backlog.ts
+++ b/services/o11y/src/alerting/queue-backlog.ts
@@ -1,5 +1,6 @@
 import type { AlertSeverity } from './slo-config';
 
+// Queue used for ingest.
 export const MONITORED_QUEUE_ID = '965459cfc1a349c190bb813855a65b02';
 
 export const QUEUE_BACKLOG_THRESHOLDS = {

--- a/services/o11y/test/notify.spec.ts
+++ b/services/o11y/test/notify.spec.ts
@@ -3,6 +3,7 @@ import {
   buildSlackMessage,
   type SloAlertPayload,
   type ContainerCapacityAlertPayload,
+  type QueueBacklogAlertPayload,
 } from '../src/alerting/notify';
 
 describe('buildSlackMessage — SLO error_rate alert', () => {
@@ -63,6 +64,35 @@ describe('buildSlackMessage — SLO ttfb alert', () => {
   it('includes TICKET severity label in header', () => {
     const msg = buildSlackMessage(alert) as { blocks: Array<{ text?: { text: string } }> };
     expect(msg.blocks[0].text?.text).toContain('TICKET');
+  });
+});
+
+describe('buildSlackMessage — queue_backlog alert', () => {
+  const alert: QueueBacklogAlertPayload = {
+    alertType: 'queue_backlog',
+    severity: 'page',
+    provider: 'cloudflare',
+    model: '965459cfc1a349c190bb813855a65b02',
+    clientName: 'queues',
+    backlogCount: 50_000,
+    backlogBytes: 12_345_678,
+    thresholdCount: 50_000,
+    oldestMessageTimestamp: new Date('2026-06-04T08:00:00.000Z'),
+  };
+
+  it('includes queue backlog details and oldest-message timestamp', () => {
+    const msg = buildSlackMessage(alert) as {
+      blocks: Array<{ fields?: Array<{ text: string }>; text?: { text: string } }>;
+    };
+    const allText = msg.blocks.flatMap(block => [
+      block.text?.text ?? '',
+      ...(block.fields?.map(field => field.text) ?? []),
+    ]);
+
+    expect(allText.some(text => text.includes('Queue Backlog'))).toBe(true);
+    expect(allText.some(text => text.includes('50,000'))).toBe(true);
+    expect(allText.some(text => text.includes('12,345,678'))).toBe(true);
+    expect(allText.some(text => text.includes('2026-06-04T08:00:00.000Z'))).toBe(true);
   });
 });
 

--- a/services/o11y/test/queue-backlog-evaluate.spec.ts
+++ b/services/o11y/test/queue-backlog-evaluate.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateQueueBacklogAlert } from '../src/alerting/queue-backlog-evaluate';
+import { MONITORED_QUEUE_ID, type QueueBacklogMetrics } from '../src/alerting/queue-backlog';
+import type { AlertPayload } from '../src/alerting/notify';
+
+function makeKv() {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+    store,
+  } as unknown as KVNamespace & { store: Map<string, string> };
+}
+
+function makeSecret(value: string): SecretsStoreSecret {
+  return { get: async () => value } as unknown as SecretsStoreSecret;
+}
+
+function makeEnv(kv: KVNamespace) {
+  return {
+    O11Y_ALERT_STATE: kv,
+    O11Y_CF_ACCOUNT_ID: 'test-account',
+    O11Y_CF_CONTAINERS_API_TOKEN: makeSecret('test-token'),
+    O11Y_SLACK_WEBHOOK_PAGE: makeSecret('https://hooks.slack.com/page'),
+    O11Y_SLACK_WEBHOOK_TICKET: makeSecret('https://hooks.slack.com/ticket'),
+  };
+}
+
+function makeMetrics(backlogCount: number): QueueBacklogMetrics {
+  return {
+    queueId: MONITORED_QUEUE_ID,
+    backlogCount,
+    backlogBytes: 12_345_678,
+    oldestMessageTimestamp: new Date('2026-06-04T08:00:00.000Z'),
+  };
+}
+
+describe('evaluateQueueBacklogAlert', () => {
+  it('sends a ticket alert and records its dedup marker', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateQueueBacklogAlert(
+      makeEnv(kv),
+      async () => makeMetrics(25_000),
+      async alert => {
+        sentAlerts.push(alert);
+      }
+    );
+
+    expect(sentAlerts).toEqual([
+      {
+        alertType: 'queue_backlog',
+        severity: 'ticket',
+        provider: 'cloudflare',
+        model: MONITORED_QUEUE_ID,
+        clientName: 'queues',
+        backlogCount: 25_000,
+        backlogBytes: 12_345_678,
+        thresholdCount: 25_000,
+        oldestMessageTimestamp: new Date('2026-06-04T08:00:00.000Z'),
+      },
+    ]);
+    expect(
+      kv.store.has(`o11y:alert:ticket:queue_backlog:cloudflare:${MONITORED_QUEUE_ID}:queues`)
+    ).toBe(true);
+  });
+
+  it('does not send an alert below the ticket threshold', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateQueueBacklogAlert(
+      makeEnv(kv),
+      async () => makeMetrics(24_999),
+      async alert => {
+        sentAlerts.push(alert);
+      }
+    );
+
+    expect(sentAlerts).toEqual([]);
+    expect(kv.store.size).toBe(0);
+  });
+
+  it('suppresses a ticket while a page cooldown marker is active', async () => {
+    const kv = makeKv();
+    kv.store.set(
+      `o11y:alert:page:queue_backlog:cloudflare:${MONITORED_QUEUE_ID}:queues`,
+      new Date().toISOString()
+    );
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateQueueBacklogAlert(
+      makeEnv(kv),
+      async () => makeMetrics(25_000),
+      async alert => {
+        sentAlerts.push(alert);
+      }
+    );
+
+    expect(sentAlerts).toEqual([]);
+  });
+
+  it('does not record a cooldown marker when notification fails', async () => {
+    const kv = makeKv();
+
+    await expect(
+      evaluateQueueBacklogAlert(
+        makeEnv(kv),
+        async () => makeMetrics(25_000),
+        async () => {
+          throw new Error('Slack unavailable');
+        }
+      )
+    ).rejects.toThrow('Slack unavailable');
+
+    expect(kv.store.size).toBe(0);
+  });
+});

--- a/services/o11y/test/queue-backlog-integration.spec.ts
+++ b/services/o11y/test/queue-backlog-integration.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MONITORED_QUEUE_ID } from '../src/alerting/queue-backlog';
+import { evaluateAlerts } from '../src/alerting/evaluate';
+
+function makeSecret(value: string): SecretsStoreSecret {
+  return { get: async () => value } as unknown as SecretsStoreSecret;
+}
+
+function makeKv() {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+    store,
+  } as unknown as KVNamespace & { store: Map<string, string> };
+}
+
+function makeUnavailableAlertConfigNamespace(): Env['ALERT_CONFIG_DO'] {
+  return {
+    idFromName: () => 'global' as unknown as DurableObjectId,
+    get: () => {
+      throw new Error('alert config unavailable');
+    },
+  } as unknown as Env['ALERT_CONFIG_DO'];
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('evaluateAlerts queue backlog integration', () => {
+  it('sends a page alert even when SLO configuration is unavailable', async () => {
+    const kv = makeKv();
+    const slackMessages: unknown[] = [];
+    const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/containers/dash/applications')) {
+        return Response.json({ success: true, result: [], result_info: { total_pages: 1 } });
+      }
+      if (url.includes(`/queues/${MONITORED_QUEUE_ID}/metrics`)) {
+        return Response.json({
+          success: true,
+          result: {
+            backlog_count: 50_000,
+            backlog_bytes: 12_345_678,
+            oldest_message_timestamp_ms: 1_780_560_000_000,
+          },
+        });
+      }
+      if (url === 'https://hooks.slack.com/page') {
+        slackMessages.push(JSON.parse(String(init?.body)));
+        return new Response(null, { status: 200 });
+      }
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchFn);
+
+    const env = {
+      ALERT_CONFIG_DO: makeUnavailableAlertConfigNamespace(),
+      O11Y_ALERT_STATE: kv,
+      O11Y_CF_ACCOUNT_ID: 'test-account',
+      O11Y_CF_AE_API_TOKEN: makeSecret('ae-token'),
+      O11Y_CF_CONTAINERS_API_TOKEN: makeSecret('read-token'),
+      O11Y_SLACK_WEBHOOK_PAGE: makeSecret('https://hooks.slack.com/page'),
+      O11Y_SLACK_WEBHOOK_TICKET: makeSecret('https://hooks.slack.com/ticket'),
+    } as Env;
+
+    await expect(evaluateAlerts(env)).rejects.toThrow('Alert evaluation failed with 2 error(s)');
+
+    expect(slackMessages).toHaveLength(1);
+    expect(JSON.stringify(slackMessages[0])).toContain('Queue Backlog Alert');
+    expect(
+      kv.store.has(`o11y:alert:page:queue_backlog:cloudflare:${MONITORED_QUEUE_ID}:queues`)
+    ).toBe(true);
+  });
+});

--- a/services/o11y/test/queue-backlog-query.spec.ts
+++ b/services/o11y/test/queue-backlog-query.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { MONITORED_QUEUE_ID } from '../src/alerting/queue-backlog';
+import { queryQueueBacklog } from '../src/alerting/queue-backlog-query';
+
+const ACCOUNT_ID = 'test-account-123';
+const API_TOKEN = 'test-token-abc';
+
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+function makeSecret(value: string | null): SecretsStoreSecret {
+  return { get: async () => value } as unknown as SecretsStoreSecret;
+}
+
+function makeEnv(token: string | null = API_TOKEN) {
+  return {
+    O11Y_CF_ACCOUNT_ID: ACCOUNT_ID,
+    O11Y_CF_CONTAINERS_API_TOKEN: makeSecret(token),
+  };
+}
+
+describe('queryQueueBacklog', () => {
+  it('fetches realtime metrics for the monitored queue', async () => {
+    let calledUrl = '';
+    let calledHeaders: HeadersInit | undefined;
+    const fetchFn: FetchFn = async (url, init) => {
+      calledUrl = url;
+      calledHeaders = init?.headers;
+      return Response.json({
+        success: true,
+        result: {
+          backlog_count: 30_000,
+          backlog_bytes: 4_000_000,
+          oldest_message_timestamp_ms: 1_780_560_000_000,
+        },
+      });
+    };
+
+    await expect(queryQueueBacklog(makeEnv(), fetchFn)).resolves.toEqual({
+      queueId: MONITORED_QUEUE_ID,
+      backlogCount: 30_000,
+      backlogBytes: 4_000_000,
+      oldestMessageTimestamp: new Date(1_780_560_000_000),
+    });
+    expect(calledUrl).toBe(
+      `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/queues/${MONITORED_QUEUE_ID}/metrics`
+    );
+    expect(new Headers(calledHeaders).get('Authorization')).toBe(`Bearer ${API_TOKEN}`);
+  });
+
+  it('omits the oldest timestamp when Cloudflare reports it as unknown', async () => {
+    const fetchFn: FetchFn = async () =>
+      Response.json({
+        success: true,
+        result: {
+          backlog_count: 0,
+          backlog_bytes: 0,
+          oldest_message_timestamp_ms: 0,
+        },
+      });
+
+    await expect(queryQueueBacklog(makeEnv(), fetchFn)).resolves.toEqual({
+      queueId: MONITORED_QUEUE_ID,
+      backlogCount: 0,
+      backlogBytes: 0,
+      oldestMessageTimestamp: undefined,
+    });
+  });
+
+  it('throws when the Queue API rejects the request', async () => {
+    const fetchFn: FetchFn = async () => new Response(null, { status: 403 });
+
+    await expect(queryQueueBacklog(makeEnv(), fetchFn)).rejects.toThrow(
+      'Queue metrics request failed (403)'
+    );
+  });
+
+  it('throws when the API token is not configured', async () => {
+    const fetchFn: FetchFn = async () => Response.json({});
+
+    await expect(queryQueueBacklog(makeEnv(null), fetchFn)).rejects.toThrow(
+      'O11Y_CF_CONTAINERS_API_TOKEN secret is not configured'
+    );
+  });
+});

--- a/services/o11y/test/queue-backlog-query.spec.ts
+++ b/services/o11y/test/queue-backlog-query.spec.ts
@@ -74,6 +74,18 @@ describe('queryQueueBacklog', () => {
     );
   });
 
+  it('includes Cloudflare errors from a successful HTTP response', async () => {
+    const fetchFn: FetchFn = async () =>
+      Response.json({
+        success: false,
+        errors: [{ code: 10000, message: 'Authentication error' }],
+      });
+
+    await expect(queryQueueBacklog(makeEnv(), fetchFn)).rejects.toThrow(
+      'Queue metrics request failed: Authentication error'
+    );
+  });
+
   it('throws when the API token is not configured', async () => {
     const fetchFn: FetchFn = async () => Response.json({});
 

--- a/services/o11y/test/queue-backlog.spec.ts
+++ b/services/o11y/test/queue-backlog.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MONITORED_QUEUE_ID,
+  QUEUE_BACKLOG_THRESHOLDS,
+  evaluateQueueBacklog,
+  type QueueBacklogMetrics,
+} from '../src/alerting/queue-backlog';
+
+function makeMetrics(backlogCount: number): QueueBacklogMetrics {
+  return {
+    queueId: MONITORED_QUEUE_ID,
+    backlogCount,
+    backlogBytes: backlogCount * 100,
+    oldestMessageTimestamp: new Date('2026-06-04T08:00:00.000Z'),
+  };
+}
+
+describe('evaluateQueueBacklog', () => {
+  it('returns no alert below the ticket backlog threshold', () => {
+    expect(evaluateQueueBacklog(makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket - 1))).toBeNull();
+  });
+
+  it('returns a ticket alert at the ticket backlog threshold', () => {
+    expect(evaluateQueueBacklog(makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket))).toEqual({
+      severity: 'ticket',
+      queueId: MONITORED_QUEUE_ID,
+      backlogCount: QUEUE_BACKLOG_THRESHOLDS.ticket,
+      backlogBytes: QUEUE_BACKLOG_THRESHOLDS.ticket * 100,
+      thresholdCount: QUEUE_BACKLOG_THRESHOLDS.ticket,
+      oldestMessageTimestamp: new Date('2026-06-04T08:00:00.000Z'),
+    });
+  });
+
+  it('returns only a page alert at the page backlog threshold', () => {
+    expect(evaluateQueueBacklog(makeMetrics(QUEUE_BACKLOG_THRESHOLDS.page))).toMatchObject({
+      severity: 'page',
+      thresholdCount: QUEUE_BACKLOG_THRESHOLDS.page,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add realtime Cloudflare Queue backlog monitoring with ticket/page thresholds, KV cooldown deduplication, and Slack notifications.
- Keep infrastructure alerts running when SLO configuration loading fails.

## Verification
- N/A - no manual verification performed.

## Visual Changes
N/A

## Reviewer Notes
- `O11Y_CF_CONTAINERS_API_TOKEN` must include Cloudflare `Queues Read` permission before rollout.