### PR TITLE
fix(kiloclaw): surface oversized file tree errors

### DIFF
--- a/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
+++ b/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
@@ -221,6 +221,26 @@ describe('sanitizeError: Instance-not-* status correction', () => {
   });
 });
 
+describe('sanitizeOpenclawConfigError: file tree RPC limit', () => {
+  it('returns a stable code and bounded message for oversized file trees', async () => {
+    const err = new Error(
+      'Serialized RPC arguments or return values are limited to 32MiB, but the size of this value was: 37110765 bytes.'
+    );
+    const env = envWithDOError(err);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const resp = await platform.request('/files/tree?userId=user-1', {}, env);
+
+    expect(resp.status).toBe(413);
+    await expect(jsonBody(resp)).resolves.toEqual({
+      code: 'file_tree_too_large',
+      error:
+        'File tree is too large to load through the Cloudflare RPC limit (32 MiB; returned 37110765 bytes).',
+    });
+    expect(consoleSpy).toHaveBeenCalledWith('[platform] files/tree failed:', err.message);
+  });
+});
+
 describe('kilo-cli-run/start: conflict response handling', () => {
   function envWithStartRun(startRun: () => Promise<unknown>) {
     return {

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1066,6 +1066,27 @@ const OPENCLAW_CONFIG_ERROR_CODES = new Set([
   'invalid_request_body',
 ]);
 
+const FILE_TREE_RPC_LIMIT_ERROR_PREFIX =
+  'Serialized RPC arguments or return values are limited to 32MiB';
+
+function sanitizeFileTreeRpcLimitError(message: string): {
+  message: string;
+  status: number;
+  code: string;
+} | null {
+  if (!message.startsWith(FILE_TREE_RPC_LIMIT_ERROR_PREFIX)) return null;
+
+  const sizeMatch = message.match(/size of this value was: (\d+) bytes/);
+  const returnedSize = sizeMatch?.[1];
+  const returnedSizeSegment = returnedSize ? `; returned ${returnedSize} bytes` : '';
+
+  return {
+    message: `File tree is too large to load through the Cloudflare RPC limit (32 MiB${returnedSizeSegment}).`,
+    status: 413,
+    code: 'file_tree_too_large',
+  };
+}
+
 function isSafeOpenclawConfigCode(code: string): boolean {
   return OPENCLAW_CONFIG_ERROR_CODES.has(code) || code.startsWith('openclaw_import_');
 }
@@ -1080,6 +1101,11 @@ function sanitizeOpenclawConfigError(
   const code = getErrorCode(err);
 
   console.error(`[platform] ${operation} failed:`, raw);
+
+  if (operation === 'files/tree') {
+    const fileTreeRpcLimitError = sanitizeFileTreeRpcLimitError(normalized);
+    if (fileTreeRpcLimitError) return fileTreeRpcLimitError;
+  }
 
   if (code && isSafeOpenclawConfigCode(code)) {
     return { message: normalized, status, code };


### PR DESCRIPTION
## Summary
- Surface KiloClaw admin file-tree failures caused by Cloudflare's 32 MiB Durable Object RPC serialization limit with a stable `file_tree_too_large` code and bounded message.
- Keep raw error passthrough narrowly scoped to the exact `/files/tree` RPC-size failure instead of broadening global sanitizer behavior.
- Add regression coverage for the observed oversized file-tree error shape.

## Verification
N/A - no manual verification was performed for this worker-side error-handling change.

## Visual Changes
N/A

## Reviewer Notes
The new safe error response is intentionally limited to `files/tree` errors whose normalized message starts with Cloudflare's RPC serialization-limit prefix.