### PR TITLE
fix(cloud-agent-next): preserve retries during wrapper cleanup

### DIFF
--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -98,6 +98,7 @@ import {
   clearWrapperRuntimeIdentity,
   getWrapperLease,
   getWrapperRuntimeState,
+  nextWrapperCleanupDeadline,
   nextWrapperLeaseDeadline,
 } from '../session/wrapper-runtime-state.js';
 import {
@@ -598,6 +599,10 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
         requireSessionId: () => this.requireSessionId(),
         validateModeAgainstRuntimeAgents,
         getDeliveryContext: () => this.getPendingMessageDeliveryContext(),
+        getDeliveryBlock: async () => {
+          const retryAt = nextWrapperCleanupDeadline(await getWrapperLease(this.ctx.storage));
+          return retryAt === undefined ? null : { retryAt };
+        },
         deliver: plan => this.executeDirectly(plan),
         ensureQueuedMessageEvent: event => {
           this.ensureQueuedMessageEvent({

--- a/services/cloud-agent-next/src/session/agent-runtime.test.ts
+++ b/services/cloud-agent-next/src/session/agent-runtime.test.ts
@@ -500,6 +500,98 @@ describe('AgentRuntime', () => {
     }
   );
 
+  it('does not overwrite cleanup requested while physical wrapper observation is in flight', async () => {
+    const storage = createMemoryStorage();
+    const execute = vi.fn();
+    const sandbox = {
+      discoverSessionWrappers: vi.fn().mockImplementation(async () => {
+        await storage.put('wrapper_lease', {
+          state: 'stop_needed',
+          nextInstanceGeneration: 1,
+          target: { kind: 'session' },
+          reason: 'user-interrupt',
+          requestedAt: 10_000,
+          nextAttemptAt: 10_000,
+          attempts: 0,
+        });
+        return { status: 'absent' };
+      }),
+    } as unknown as AgentSandbox;
+    const runtime = createAgentRuntime({
+      storage,
+      env: {} as Env,
+      getMetadata: async () => createMetadata(),
+      getOrchestratorOverride: () => ({ execute }),
+      getSessionIdForLogs: () => 'agent_runtime',
+      sendToWrapper: () => false,
+      createAgentSandbox: () => sandbox,
+    });
+
+    await expect(runtime.send(createPlan())).rejects.toThrow(/cleanup is required/i);
+    expect(execute).not.toHaveBeenCalled();
+    await expect(getWrapperLease(storage)).resolves.toMatchObject({
+      state: 'stop_needed',
+      reason: 'user-interrupt',
+    });
+  });
+
+  it('reauthorizes when cleanup completes during physical wrapper observation', async () => {
+    const storage = createMemoryStorage([
+      [
+        'wrapper_lease',
+        {
+          state: 'owns_wrapper',
+          nextInstanceGeneration: 2,
+          instance: { instanceId: 'instance_stale', instanceGeneration: 1 },
+        },
+      ],
+    ]);
+    const leasedInstances: Array<{ instanceId: string; instanceGeneration: number } | undefined> =
+      [];
+    const discoverSessionWrappers = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await storage.put('wrapper_lease', { state: 'none', nextInstanceGeneration: 2 });
+        return {
+          status: 'present',
+          observed: [
+            {
+              representation: 'process',
+              id: 'stale-wrapper',
+              port: 5_000,
+              instanceId: 'instance_stale',
+              instanceGeneration: 1,
+            },
+          ],
+        };
+      })
+      .mockResolvedValueOnce({ status: 'absent' });
+    const sandbox = { discoverSessionWrappers } as unknown as AgentSandbox;
+
+    const runtime = createAgentRuntime({
+      storage,
+      env: {} as Env,
+      getMetadata: async () => createMetadata(),
+      getOrchestratorOverride: () => ({
+        execute: async (_plan, options) => {
+          leasedInstances.push(options?.leasedInstance);
+          return { kiloSessionId: 'kilo_runtime' };
+        },
+      }),
+      getSessionIdForLogs: () => 'agent_runtime',
+      sendToWrapper: () => false,
+      createAgentSandbox: () => sandbox,
+    });
+
+    await expect(runtime.send(createPlan())).resolves.toMatchObject({ success: true });
+    expect(discoverSessionWrappers).toHaveBeenCalledTimes(2);
+    expect(leasedInstances).toEqual([expect.objectContaining({ instanceGeneration: 2 })]);
+    await expect(getWrapperLease(storage)).resolves.toMatchObject({
+      state: 'owns_wrapper',
+      instance: { instanceGeneration: 2 },
+    });
+  });
+
   it('blocks migrated run-fence state when no durable physical owner authorizes the visible wrapper', async () => {
     const storage = createMemoryStorage([
       [

--- a/services/cloud-agent-next/src/session/agent-runtime.ts
+++ b/services/cloud-agent-next/src/session/agent-runtime.ts
@@ -16,17 +16,20 @@ import { logger } from '../logger.js';
 import type { SessionMetadata } from '../persistence/session-metadata.js';
 import type { WrapperCommand } from '../shared/protocol.js';
 import type { Env as WorkerEnv } from '../types.js';
+import { WrapperCleanupBlockedError } from './wrapper-cleanup-blocked-error.js';
 import {
   allocateWrapperRuntimeState,
   clearAllocatedWrapperRuntimeState,
   clearWrapperRuntimeIdentity,
   getWrapperLease,
   getWrapperRuntimeState,
+  nextWrapperCleanupDeadline,
   putWrapperLease,
   READY_ONLY_IDLE_MS,
   recordWrapperAcceptedMessage,
   recordWrapperReadyLease,
   reduceWrapperLease,
+  type WrapperLease,
 } from './wrapper-runtime-state.js';
 
 export const WRAPPER_NO_OUTPUT_TIMEOUT_MS = 5 * 60 * 1000;
@@ -79,6 +82,28 @@ export type AgentRuntimeDependencies = {
   requestAlarmAtOrBefore?: (deadline: number) => Promise<void>;
 };
 
+function cleanupBlockedError(lease: WrapperLease): WrapperCleanupBlockedError {
+  const retryAt = nextWrapperCleanupDeadline(lease);
+  if (retryAt === undefined) {
+    throw new Error('Wrapper cleanup state is missing its retry deadline');
+  }
+  return new WrapperCleanupBlockedError(retryAt);
+}
+
+function hasSamePhysicalAuthorization(expected: WrapperLease, latest: WrapperLease): boolean {
+  if (expected.state === 'none') {
+    return (
+      latest.state === 'none' && latest.nextInstanceGeneration === expected.nextInstanceGeneration
+    );
+  }
+  if (expected.state !== 'owns_wrapper' || latest.state !== 'owns_wrapper') return false;
+  return (
+    latest.nextInstanceGeneration === expected.nextInstanceGeneration &&
+    latest.instance.instanceId === expected.instance.instanceId &&
+    latest.instance.instanceGeneration === expected.instance.instanceGeneration
+  );
+}
+
 function buildRuntimeAcceptanceResult(
   messageId: string,
   wrapperRunId: string
@@ -130,7 +155,7 @@ export function createAgentRuntime(dependencies: AgentRuntimeDependencies): Agen
   }> {
     const current = await getWrapperLease(storage);
     if (current.state === 'stop_needed' || current.state === 'stopping') {
-      throw new Error('Wrapper cleanup is required before delivery can launch');
+      throw cleanupBlockedError(current);
     }
 
     const observeWrappers = () =>
@@ -140,6 +165,9 @@ export function createAgentRuntime(dependencies: AgentRuntimeDependencies): Agen
     let allocatable = current;
     if (current.state === 'owns_wrapper') {
       const observation = await observeWrappers();
+      if (!hasSamePhysicalAuthorization(current, await getWrapperLease(storage))) {
+        return authorizePhysicalWrapper(plan);
+      }
       const matchingObserved =
         observation.status === 'present' &&
         observation.observed.length === 1 &&
@@ -178,37 +206,43 @@ export function createAgentRuntime(dependencies: AgentRuntimeDependencies): Agen
         const reason =
           observation.status === 'inspection-failed' ? 'observation-failed' : 'unexpected-wrapper';
         const now = Date.now();
-        await putWrapperLease(
-          storage,
-          reduceWrapperLease(current, {
-            type: 'request_stop',
-            target: { kind: 'session' },
-            reason,
-            now,
-          })
-        );
+        const cleanupLease = reduceWrapperLease(current, {
+          type: 'request_stop',
+          target: { kind: 'session' },
+          reason,
+          now,
+        });
+        await putWrapperLease(storage, cleanupLease);
         await dependencies.requestAlarmAtOrBefore?.(now);
-        throw new Error('Wrapper cleanup is required before delivery can launch');
+        throw cleanupBlockedError(cleanupLease);
       }
     }
 
     const observation =
       allocatable === current ? await observeWrappers() : { status: 'absent' as const };
+    if (
+      allocatable === current &&
+      !hasSamePhysicalAuthorization(current, await getWrapperLease(storage))
+    ) {
+      return authorizePhysicalWrapper(plan);
+    }
     if (observation.status !== 'absent') {
       const reason =
         observation.status === 'inspection-failed' ? 'observation-failed' : 'unexpected-wrapper';
       const now = Date.now();
-      await putWrapperLease(
-        storage,
-        reduceWrapperLease(allocatable, {
-          type: 'request_stop',
-          target: { kind: 'session' },
-          reason,
-          now,
-        })
-      );
+      const cleanupLease = reduceWrapperLease(allocatable, {
+        type: 'request_stop',
+        target: { kind: 'session' },
+        reason,
+        now,
+      });
+      await putWrapperLease(storage, cleanupLease);
       await dependencies.requestAlarmAtOrBefore?.(now);
-      throw new Error('Wrapper cleanup is required before delivery can launch');
+      throw cleanupBlockedError(cleanupLease);
+    }
+
+    if (!hasSamePhysicalAuthorization(allocatable, await getWrapperLease(storage))) {
+      return authorizePhysicalWrapper(plan);
     }
 
     const leasedInstance = {

--- a/services/cloud-agent-next/src/session/session-message-queue.test.ts
+++ b/services/cloud-agent-next/src/session/session-message-queue.test.ts
@@ -17,6 +17,7 @@ import {
   createPendingSessionMessage,
   createPendingSessionMessageFromIntent,
   listPendingSessionMessages,
+  PENDING_FLUSH_RETRY_BASE_DELAY_MS,
   PENDING_SESSION_MESSAGE_LIMIT,
   recordPendingFlushFailure,
   storePendingSessionMessage,
@@ -121,6 +122,7 @@ function createQueueHarness(options?: {
   failAlarmOnce?: boolean;
   failTerminalizationOnce?: boolean;
   ensureAcceptedMessageEffects?: (messageId: string) => Promise<void>;
+  getDeliveryBlock?: () => Promise<{ retryAt: number } | null>;
 }) {
   const storage = options?.storage ?? createMemoryStorage();
   const events: QueueEvent[] = [];
@@ -155,6 +157,7 @@ function createQueueHarness(options?: {
       requireSessionId: async () => metadata?.identity.sessionId ?? 'agent_test',
       validateModeAgainstRuntimeAgents: () => null,
       getDeliveryContext: async () => (metadata ? createContext(metadata) : null),
+      getDeliveryBlock: options?.getDeliveryBlock ?? (async () => null),
       deliver,
       ensureQueuedMessageEvent: event => {
         if (failQueuedEvent) {
@@ -336,6 +339,84 @@ describe('flushNextPendingSessionMessage', () => {
     expect((await storage.list({ prefix: 'pending_message:' })).size).toBe(0);
   });
 
+  it('schedules a retry from the time a delivery failure is observed', async () => {
+    const storage = createMemoryStorage();
+    await storePendingSessionMessage(
+      storage,
+      createPendingSessionMessage({
+        messageId: FIRST_MESSAGE_ID,
+        role: 'user',
+        content: 'slow failed delivery',
+        createdAt: 1,
+      })
+    );
+    const attemptStartedAt = 100_000;
+    const failedAt = 160_000;
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(attemptStartedAt);
+    const deliver = vi.fn(async () => {
+      clock.mockReturnValue(failedAt);
+      throw ExecutionError.workspaceSetupFailed('workspace failed late');
+    });
+
+    const result = await (async () => {
+      try {
+        return await flushNextPendingSessionMessage({
+          storage,
+          now: attemptStartedAt,
+          getDeliveryContext: async () => createContext(),
+          validateModeAgainstRuntimeAgents: () => null,
+          deliver,
+        });
+      } finally {
+        clock.mockRestore();
+      }
+    })();
+
+    expect(result).toMatchObject({
+      type: 'failure',
+      nextFlushAttemptAt: failedAt + PENDING_FLUSH_RETRY_BASE_DELAY_MS,
+    });
+  });
+
+  it('schedules an unsuccessful delivery result retry from the time it is observed', async () => {
+    const storage = createMemoryStorage();
+    await storePendingSessionMessage(
+      storage,
+      createPendingSessionMessage({
+        messageId: FIRST_MESSAGE_ID,
+        role: 'user',
+        content: 'slow unsuccessful delivery',
+        createdAt: 1,
+      })
+    );
+    const attemptStartedAt = 100_000;
+    const failedAt = 160_000;
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(attemptStartedAt);
+    const deliver = vi.fn(async (): Promise<MessageDeliveryResult> => {
+      clock.mockReturnValue(failedAt);
+      return { success: false, code: 'WORKSPACE_SETUP_FAILED', error: 'workspace failed late' };
+    });
+
+    const result = await (async () => {
+      try {
+        return await flushNextPendingSessionMessage({
+          storage,
+          now: attemptStartedAt,
+          getDeliveryContext: async () => createContext(),
+          validateModeAgainstRuntimeAgents: () => null,
+          deliver,
+        });
+      } finally {
+        clock.mockRestore();
+      }
+    })();
+
+    expect(result).toMatchObject({
+      type: 'failure',
+      nextFlushAttemptAt: failedAt + PENDING_FLUSH_RETRY_BASE_DELAY_MS,
+    });
+  });
+
   it('delivers the next current message without execution-runtime blocking', async () => {
     const storage = createMemoryStorage();
     await storePendingSessionMessage(
@@ -442,6 +523,31 @@ describe('SessionMessageQueue', () => {
     });
 
     await expect(harness.queue.hasMessageAdmission(FIRST_MESSAGE_ID)).resolves.toBe(true);
+  });
+
+  it('repairs queued effects without consuming delivery attempts while delivery is blocked', async () => {
+    const retryAt = 50_000;
+    const harness = createQueueHarness({
+      getDeliveryBlock: async () => ({ retryAt }),
+    });
+    await storePendingSessionMessage(
+      harness.storage,
+      createPendingSessionMessage({
+        messageId: FIRST_MESSAGE_ID,
+        role: 'user',
+        content: 'repair before blocked delivery',
+        createdAt: 1,
+      })
+    );
+
+    const drain = await harness.queue.drainNextPendingMessage();
+    const [pending] = await listPendingSessionMessages(harness.storage);
+
+    expect(drain).toEqual({ retryAt, remainingPendingCount: 1 });
+    expect(harness.events).toHaveLength(1);
+    expect(harness.deliver).not.toHaveBeenCalled();
+    expect(pending?.flushAttempts).toBeUndefined();
+    expect(pending?.lastFlushError).toBeUndefined();
   });
 
   it('admits a durable queued message once and replays the original acknowledgement', async () => {

--- a/services/cloud-agent-next/src/session/session-message-queue.ts
+++ b/services/cloud-agent-next/src/session/session-message-queue.ts
@@ -15,6 +15,7 @@ import { logger } from '../logger.js';
 import { dispatchedKilocodeModelId } from '../persistence/model-utils.js';
 import type { SessionMetadata } from '../persistence/session-metadata.js';
 import { isSandboxWorkspaceProbeTimeoutError } from '../sandbox-recovery.js';
+import { WrapperCleanupBlockedError } from './wrapper-cleanup-blocked-error.js';
 import {
   MESSAGE_ID_FORMAT_DESCRIPTION,
   createMessageId,
@@ -124,6 +125,7 @@ export type SessionMessageQueueDependencies = {
   requireSessionId: () => Promise<string>;
   validateModeAgainstRuntimeAgents: (metadata: SessionMetadata, mode: string) => string | null;
   getDeliveryContext: () => Promise<ExecutionDeliveryContext | null>;
+  getDeliveryBlock: () => Promise<{ retryAt: number } | null>;
   deliver: (plan: MessageDeliveryRequest) => Promise<MessageDeliveryResult>;
   ensureQueuedMessageEvent: (event: PersistedQueuedMessageEvent & { entityId: string }) => void;
   reportQueuedState?: (state: SessionMessageState) => void;
@@ -269,9 +271,11 @@ export async function flushNextPendingSessionMessage(params: {
   storage: SessionMessageQueueStorage;
   now: number;
   getDeliveryContext: () => Promise<ExecutionDeliveryContext | null>;
+  getDeliveryBlock?: SessionMessageQueueDependencies['getDeliveryBlock'];
   validateModeAgainstRuntimeAgents: SessionMessageQueueDependencies['validateModeAgainstRuntimeAgents'];
   deliver: (plan: MessageDeliveryRequest) => Promise<MessageDeliveryResult>;
   repairQueuedMessageEffects?: (intent: SessionMessageIntent) => Promise<void>;
+  prepareQueuedMessageDelivery?: (intent: SessionMessageIntent) => Promise<void>;
   ensureAcceptedMessageEffects?: (messageId: string) => Promise<void>;
 }): Promise<PendingFlushResult> {
   const context = await params.getDeliveryContext();
@@ -369,7 +373,19 @@ export async function flushNextPendingSessionMessage(params: {
       createQueuedSessionMessageState(intent, callbackSnapshot, message.createdAt)
     );
   }
+
   await params.repairQueuedMessageEffects?.(intent);
+
+  const deliveryBlock = await params.getDeliveryBlock?.();
+  if (deliveryBlock) {
+    return {
+      type: 'skipped',
+      nextFlushAttemptAt: deliveryBlock.retryAt,
+      remainingCount: totalCount,
+    };
+  }
+
+  await params.prepareQueuedMessageDelivery?.(intent);
 
   try {
     const plan = buildMessageDeliveryRequest(
@@ -383,7 +399,7 @@ export async function flushNextPendingSessionMessage(params: {
         params.storage,
         message,
         startResult.error,
-        params.now,
+        Date.now(),
         { policy, code: startResult.code }
       );
       throw new PendingFlushRecordedError(failure);
@@ -393,6 +409,13 @@ export async function flushNextPendingSessionMessage(params: {
   } catch (error) {
     if (error instanceof PendingFlushRecordedError) {
       return toFailureResult(error.failure, totalCount);
+    }
+    if (error instanceof WrapperCleanupBlockedError) {
+      return {
+        type: 'skipped',
+        nextFlushAttemptAt: error.retryAt,
+        remainingCount: totalCount,
+      };
     }
     const code =
       error instanceof MessageDeliveryRequestValidationError
@@ -404,7 +427,7 @@ export async function flushNextPendingSessionMessage(params: {
       params.storage,
       message,
       error instanceof Error ? error.message : String(error),
-      params.now,
+      Date.now(),
       { policy, code: code ?? 'UNKNOWN' }
     );
     return toFailureResult(failure, totalCount);
@@ -452,6 +475,7 @@ export function createSessionMessageQueue(
     requireSessionId,
     validateModeAgainstRuntimeAgents,
     getDeliveryContext,
+    getDeliveryBlock,
     deliver,
     ensureQueuedMessageEvent,
     reportQueuedState,
@@ -501,7 +525,7 @@ export function createSessionMessageQueue(
     return true;
   }
 
-  async function completeQueuedAdmissionEffects(intent: SessionMessageIntent): Promise<void> {
+  async function repairQueuedAdmissionEffects(intent: SessionMessageIntent): Promise<void> {
     const sessionId = await requireSessionId();
     ensureQueuedMessageEvent({
       entityId: `queued-message/${intent.turn.messageId}`,
@@ -516,10 +540,18 @@ export function createSessionMessageQueue(
     });
     const queuedState = await getSessionMessageState(storage, intent.turn.messageId);
     if (queuedState?.status === 'queued') reportQueuedState?.(queuedState);
+  }
+
+  async function prepareQueuedMessageDelivery(intent: SessionMessageIntent): Promise<void> {
     await requestPendingDrain();
     logger
-      .withFields({ sessionId, messageId: intent.turn.messageId })
+      .withFields({ sessionId: getSessionIdForLogs(), messageId: intent.turn.messageId })
       .info('Queued message event persisted and pending flush scheduled');
+  }
+
+  async function completeQueuedAdmissionEffects(intent: SessionMessageIntent): Promise<void> {
+    await repairQueuedAdmissionEffects(intent);
+    await prepareQueuedMessageDelivery(intent);
   }
 
   async function hasMessageAdmission(messageId: string): Promise<boolean> {
@@ -819,9 +851,11 @@ export function createSessionMessageQueue(
       storage,
       now,
       getDeliveryContext,
+      getDeliveryBlock,
       validateModeAgainstRuntimeAgents,
       deliver,
-      repairQueuedMessageEffects: completeQueuedAdmissionEffects,
+      repairQueuedMessageEffects: repairQueuedAdmissionEffects,
+      prepareQueuedMessageDelivery,
       ensureAcceptedMessageEffects,
     });
 

--- a/services/cloud-agent-next/src/session/wrapper-cleanup-blocked-error.ts
+++ b/services/cloud-agent-next/src/session/wrapper-cleanup-blocked-error.ts
@@ -1,0 +1,6 @@
+export class WrapperCleanupBlockedError extends Error {
+  constructor(readonly retryAt: number) {
+    super('Wrapper cleanup is required before delivery can launch');
+    this.name = 'WrapperCleanupBlockedError';
+  }
+}

--- a/services/cloud-agent-next/src/session/wrapper-runtime-state.test.ts
+++ b/services/cloud-agent-next/src/session/wrapper-runtime-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   emptyWrapperLease,
   getWrapperLease,
+  nextWrapperCleanupDeadline,
   nextWrapperLeaseDeadline,
   putWrapperLease,
   reduceWrapperLease,
@@ -80,6 +81,7 @@ describe('WrapperLease', () => {
       startupDeadlineAt: undefined,
       keepWarmUntil: 20_000,
     });
+    expect(nextWrapperCleanupDeadline(warm)).toBeUndefined();
     expect(nextWrapperLeaseDeadline(warm)).toBe(20_000);
 
     const reusing = reduceWrapperLease(warm, {
@@ -191,6 +193,7 @@ describe('WrapperLease', () => {
       nextAttemptAt: 5_200,
       lastError: 'inspection failed',
     });
+    expect(nextWrapperCleanupDeadline(retrying)).toBe(5_200);
     expect(nextWrapperLeaseDeadline(retrying)).toBe(5_200);
   });
 

--- a/services/cloud-agent-next/src/session/wrapper-runtime-state.ts
+++ b/services/cloud-agent-next/src/session/wrapper-runtime-state.ts
@@ -183,9 +183,15 @@ export function reduceWrapperLease(state: WrapperLease, event: WrapperLeaseEvent
   }
 }
 
-export function nextWrapperLeaseDeadline(lease: WrapperLease): number | undefined {
+export function nextWrapperCleanupDeadline(lease: WrapperLease): number | undefined {
   if (lease.state === 'stop_needed') return lease.nextAttemptAt;
   if (lease.state === 'stopping') return lease.attemptDeadlineAt;
+  return undefined;
+}
+
+export function nextWrapperLeaseDeadline(lease: WrapperLease): number | undefined {
+  const cleanupDeadline = nextWrapperCleanupDeadline(lease);
+  if (cleanupDeadline !== undefined) return cleanupDeadline;
   if (lease.state !== 'owns_wrapper') return undefined;
   return lease.startupDeadlineAt ?? lease.keepWarmUntil;
 }

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
@@ -908,6 +908,42 @@ describe('WrapperSupervisor', () => {
     });
   });
 
+  it('schedules an unconfirmed cleanup retry from the time its result is observed', async () => {
+    const harness = createHarness([
+      [
+        'wrapper_lease',
+        {
+          state: 'stop_needed',
+          nextInstanceGeneration: 2,
+          target: { kind: 'session' },
+          reason: 'unexpected-wrapper',
+          requestedAt: 1_000,
+          nextAttemptAt: 1_000,
+          attempts: 0,
+        },
+      ],
+    ]);
+    const attemptStartedAt = 1_000;
+    const failedAt = 20_000;
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(attemptStartedAt);
+    harness.stopWrappers.mockImplementationOnce(async () => {
+      clock.mockReturnValue(failedAt);
+      return { status: 'still-present', observed: [] };
+    });
+
+    try {
+      await harness.supervisor.runMaintenance(attemptStartedAt);
+    } finally {
+      clock.mockRestore();
+    }
+
+    await expect(getWrapperLease(harness.storage)).resolves.toMatchObject({
+      state: 'stop_needed',
+      attempts: 1,
+      nextAttemptAt: failedAt + 5_000,
+    });
+  });
+
   it('backs off unconfirmed physical cleanup retries through the saturated delay tail', async () => {
     const harness = createHarness([
       [
@@ -926,16 +962,22 @@ describe('WrapperSupervisor', () => {
     harness.stopWrappers.mockResolvedValue({ status: 'still-present', observed: [] });
     const expectedDelays = [5_000, 30_000, 120_000, 300_000, 300_000];
     let now = 1_001;
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
 
-    for (const [index, expectedDelay] of expectedDelays.entries()) {
-      await harness.supervisor.runMaintenance(now);
-      const lease = await getWrapperLease(harness.storage);
-      if (lease.state !== 'stop_needed') {
-        throw new Error(`Expected a retryable cleanup lease after attempt ${index + 1}`);
+    try {
+      for (const [index, expectedDelay] of expectedDelays.entries()) {
+        clock.mockReturnValue(now);
+        await harness.supervisor.runMaintenance(now);
+        const lease = await getWrapperLease(harness.storage);
+        if (lease.state !== 'stop_needed') {
+          throw new Error(`Expected a retryable cleanup lease after attempt ${index + 1}`);
+        }
+        expect(lease.attempts).toBe(index + 1);
+        expect(lease.nextAttemptAt - now).toBe(expectedDelay);
+        now = lease.nextAttemptAt;
       }
-      expect(lease.attempts).toBe(index + 1);
-      expect(lease.nextAttemptAt - now).toBe(expectedDelay);
-      now = lease.nextAttemptAt;
+    } finally {
+      clock.mockRestore();
     }
   });
 

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.ts
@@ -927,7 +927,7 @@ export function createWrapperSupervisor(
       reduceWrapperLease(latest, {
         type: 'stop_not_confirmed',
         attemptId,
-        retryAt: stopRetryAt(now, stopping.attempts),
+        retryAt: stopRetryAt(Date.now(), stopping.attempts),
         error,
       })
     );

--- a/services/cloud-agent-next/test/integration/session/pending-messages.test.ts
+++ b/services/cloud-agent-next/test/integration/session/pending-messages.test.ts
@@ -450,6 +450,149 @@ describe('pending session messages', () => {
     expect(result.alarm).toBeGreaterThan(Date.now());
   });
 
+  it('does not consume a delivery attempt while physical wrapper cleanup is still in progress', async () => {
+    const userId = 'user_pending_cleanup_gate';
+    const sessionId = 'agent_pending_cleanup_gate';
+    const stub = env.CLOUD_AGENT_SESSION.get(
+      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+    );
+
+    const result = await runInDurableObject(stub, async instance => {
+      let deliveryAttempts = 0;
+      (instance as any).orchestrator = {
+        execute: async (plan: any) => {
+          deliveryAttempts += 1;
+          return { messageId: plan.turn.messageId, kiloSessionId: 'kilo_test' };
+        },
+      };
+      await registerReadySession(instance, {
+        sessionId,
+        userId,
+        kiloSessionId: '46464646-4646-4646-8646-464646464646',
+        prompt: 'prepared prompt',
+        mode: 'code',
+        model: 'test-model',
+        kilocodeToken: 'token-cleanup-gate',
+      });
+      const cleanupDeadline = Date.now() + 60_000;
+      await instance.ctx.storage.put('wrapper_lease', {
+        state: 'stopping',
+        nextInstanceGeneration: 2,
+        target: { kind: 'session' },
+        reason: 'unexpected-wrapper',
+        requestedAt: Date.now() - 1_000,
+        attemptId: 'attempt_cleanup_gate',
+        attemptStartedAt: Date.now() - 500,
+        attemptDeadlineAt: cleanupDeadline,
+        attempts: 1,
+      });
+      await storePendingSessionMessage(
+        instance.ctx.storage,
+        createMessage({
+          messageId: 'msg_018f1e2d3c4bCleanGateAbCdE',
+          content: 'deliver after cleanup',
+          createdAt: 1,
+        })
+      );
+
+      await instance.alarm();
+      const blockedPending = await listPendingSessionMessages(instance.ctx.storage);
+      const blockedLease = await getWrapperLease(instance.ctx.storage);
+      const blockedAlarm = await instance.ctx.storage.getAlarm();
+
+      await instance.ctx.storage.put('wrapper_lease', {
+        state: 'stop_needed',
+        nextInstanceGeneration: 2,
+        target: { kind: 'session' },
+        reason: 'unexpected-wrapper',
+        requestedAt: Date.now() - 1_000,
+        nextAttemptAt: Date.now(),
+        attempts: 1,
+      });
+      await instance.alarm();
+      return {
+        deliveryAttempts,
+        cleanupDeadline,
+        blockedPending,
+        blockedLease,
+        blockedAlarm,
+        finalPending: await listPendingSessionMessages(instance.ctx.storage),
+        finalLease: await getWrapperLease(instance.ctx.storage),
+      };
+    });
+
+    expect(result.blockedPending).toHaveLength(1);
+    expect(result.blockedPending[0]?.flushAttempts).toBeUndefined();
+    expect(result.blockedPending[0]?.lastFlushError).toBeUndefined();
+    expect(result.blockedPending[0]?.deliveryDisposition).toBeUndefined();
+    expect(result.blockedLease.state).toBe('stopping');
+    expect(result.blockedAlarm).toBe(result.cleanupDeadline);
+    expect(result.deliveryAttempts).toBe(1);
+    expect(result.finalPending).toHaveLength(0);
+    expect(result.finalLease.state).toBe('owns_wrapper');
+  });
+
+  it('does not consume a delivery attempt when wrapper authorization discovers required cleanup', async () => {
+    const userId = 'user_pending_cleanup_discovery';
+    const sessionId = 'agent_pending_cleanup_discovery';
+    const stub = env.CLOUD_AGENT_SESSION.get(
+      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+    );
+
+    const result = await runInDurableObject(stub, async instance => {
+      let deliveryAttempts = 0;
+      let authorizationInspections = 0;
+      (instance as any).orchestrator = {
+        execute: async () => {
+          deliveryAttempts += 1;
+          throw new Error('delivery must wait for cleanup');
+        },
+      };
+      instance['physicalWrapperObserver'] = async () => {
+        authorizationInspections += 1;
+        return { status: 'inspection-failed', error: 'provider unavailable' };
+      };
+      await registerReadySession(instance, {
+        sessionId,
+        userId,
+        kiloSessionId: '47474747-4747-4747-8747-474747474747',
+        prompt: 'prepared prompt',
+        mode: 'code',
+        model: 'test-model',
+        kilocodeToken: 'token-cleanup-discovery',
+      });
+      await storePendingSessionMessage(
+        instance.ctx.storage,
+        createMessage({
+          messageId: 'msg_018f1e2d3c4bCleanDiscAbCdE',
+          content: 'deliver after cleanup discovery',
+          createdAt: 1,
+        })
+      );
+
+      await instance.alarm();
+      return {
+        authorizationInspections,
+        deliveryAttempts,
+        pending: await listPendingSessionMessages(instance.ctx.storage),
+        lease: await getWrapperLease(instance.ctx.storage),
+      };
+    });
+
+    expect(result.authorizationInspections).toBe(1);
+    expect(result.deliveryAttempts).toBe(0);
+    expect(result.pending).toHaveLength(1);
+    expect(result.pending[0]?.flushAttempts).toBeUndefined();
+    expect(result.pending[0]?.lastFlushError).toBeUndefined();
+    expect(result.pending[0]?.deliveryDisposition).toBeUndefined();
+    expect(result.lease).toMatchObject({
+      state: 'stop_needed',
+      target: { kind: 'session' },
+      reason: 'observation-failed',
+      attempts: 0,
+    });
+  });
+
   it('exhausts failed flush retries, emits cloud.message.failed, and removes the pending message', async () => {
     const userId = 'user_pending_flush_exhaust';
     const sessionId = 'agent_pending_flush_exhaust';
@@ -1711,6 +1854,7 @@ describe('pending session messages', () => {
           throw new Error('wrapper unavailable');
         },
       };
+
       await registerReadySession(instance, {
         sessionId,
         userId,


### PR DESCRIPTION
## Summary
- defer pending-message delivery while durable physical-wrapper cleanup is required, preserving the message retry budget
- reauthorize wrapper leases after asynchronous observation and schedule cleanup/delivery retries from completion time
