### PR TITLE
fix(kiloclaw): retry Fly secret sync failures

### DIFF
--- a/services/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
@@ -116,6 +116,7 @@ beforeEach(() => {
   (appsClient.getApp as Mock).mockResolvedValue(null);
   (appsClient.createApp as Mock).mockResolvedValue({ id: 'app-id', created_at: 1234567890 });
   (appsClient.allocateIP as Mock).mockResolvedValue({ address: '::1', type: 'v6' });
+  (secretsClient.setAppSecret as Mock).mockResolvedValue({ version: 1 });
 });
 
 describe('ensureApp', () => {
@@ -222,6 +223,22 @@ describe('ensureApp', () => {
     expect(storage._store.get('ipv6Allocated')).toBe(true);
     expect(storage._store.get('ipv4Allocated')).not.toBe(true);
     // Retry alarm armed
+    expect(storage._getAlarm()).not.toBeNull();
+  });
+
+  it('keeps env key setup pending and arms retry alarm when Fly secret sync fails', async () => {
+    (secretsClient.setAppSecret as Mock).mockRejectedValueOnce(
+      new FlyApiError('Fly API setAppSecret failed (520): error code: 520', 520, 'error code: 520')
+    );
+
+    const { appDO, storage } = createAppDO();
+
+    await expect(appDO.ensureApp('user-1')).rejects.toThrow('setAppSecret failed');
+
+    expect(storage._store.get('ipv6Allocated')).toBe(true);
+    expect(storage._store.get('ipv4Allocated')).toBe(true);
+    expect(storage._store.get('envKey')).toBeTruthy();
+    expect(storage._store.get('envKeySet')).toBe(false);
     expect(storage._getAlarm()).not.toBeNull();
   });
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-app.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-app.ts
@@ -246,16 +246,12 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
       } satisfies Partial<AppState>);
     }
 
-    if (!this.envKeySet) {
-      this.envKeySet = true;
-      await this.ctx.storage.put({ envKeySet: true } satisfies Partial<AppState>);
-      console.log(
-        '[AppDO] Persisted env encryption key for:',
-        this.flyAppName ?? `owner ${ownerKey}`
-      );
-    }
-
     if (!this.flyAppName) {
+      if (!this.envKeySet) {
+        this.envKeySet = true;
+        await this.ctx.storage.put({ envKeySet: true } satisfies Partial<AppState>);
+        console.log('[AppDO] Persisted env encryption key for:', `owner ${ownerKey}`);
+      }
       return { key: this.envKey, secretsVersion: 0 };
     }
 
@@ -269,6 +265,12 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
       ENV_KEY_SECRET_NAME,
       this.envKey
     );
+
+    if (!this.envKeySet) {
+      this.envKeySet = true;
+      await this.ctx.storage.put({ envKeySet: true } satisfies Partial<AppState>);
+      console.log('[AppDO] Persisted env encryption key for:', this.flyAppName);
+    }
 
     return { key: this.envKey, secretsVersion };
   }

--- a/services/kiloclaw/src/fly/secrets.test.ts
+++ b/services/kiloclaw/src/fly/secrets.test.ts
@@ -48,6 +48,37 @@ describe('setAppSecret', () => {
     await expect(resultPromise).resolves.toEqual({ version: 4 });
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
+
+  it('retries on network-level fetch rejection before succeeding', async () => {
+    vi.useFakeTimers();
+    mockFetch
+      .mockImplementationOnce(() => {
+        throw new TypeError('Failed to fetch');
+      })
+      .mockResolvedValueOnce(new Response(JSON.stringify({ version: 5 }), { status: 201 }));
+
+    const resultPromise = setAppSecret(config, 'MY_SECRET', 'secret-value');
+    await vi.runAllTimersAsync();
+
+    await expect(resultPromise).resolves.toEqual({ version: 5 });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exhausting retries on network-level fetch rejection', async () => {
+    vi.useFakeTimers();
+    mockFetch.mockImplementation(() => {
+      throw new TypeError('network error');
+    });
+
+    const resultPromise = setAppSecret(config, 'MY_SECRET', 'secret-value');
+    // Attach a handler immediately so Node.js does not report the eventual
+    // rejection as "unhandled" while timers are still running.
+    void resultPromise.catch(() => {});
+    await vi.runAllTimersAsync();
+
+    await expect(resultPromise).rejects.toThrow('network error');
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
 });
 
 describe('deleteAppSecret', () => {

--- a/services/kiloclaw/src/fly/secrets.test.ts
+++ b/services/kiloclaw/src/fly/secrets.test.ts
@@ -7,6 +7,7 @@ vi.stubGlobal('fetch', mockFetch);
 const config = { apiToken: 'test-token', appName: 'test-app' };
 
 beforeEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
@@ -32,6 +33,20 @@ describe('setAppSecret', () => {
     mockFetch.mockResolvedValue(new Response('{"error":"bad"}', { status: 400 }));
 
     await expect(setAppSecret(config, 'BAD', 'val')).rejects.toThrow('setAppSecret failed');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries transient Fly failures before returning version', async () => {
+    vi.useFakeTimers();
+    mockFetch
+      .mockResolvedValueOnce(new Response('error code: 520', { status: 520 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ version: 4 }), { status: 201 }));
+
+    const resultPromise = setAppSecret(config, 'MY_SECRET', 'secret-value');
+    await vi.runAllTimersAsync();
+
+    await expect(resultPromise).resolves.toEqual({ version: 4 });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/services/kiloclaw/src/fly/secrets.ts
+++ b/services/kiloclaw/src/fly/secrets.ts
@@ -21,6 +21,8 @@ type AppSecret = {
   updated_at?: string;
 };
 
+const SET_SECRET_RETRY_DELAYS_MS = [250, 1000];
+
 async function secretsFetch(
   config: FlySecretsConfig,
   path: string,
@@ -44,6 +46,14 @@ async function assertOk(resp: Response, context: string): Promise<void> {
   }
 }
 
+function isRetryableSecretStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 /**
  * Set a single app secret. Returns the secrets version, which should be
  * passed as `min_secrets_version` to createMachine/updateMachine to ensure
@@ -56,13 +66,29 @@ export async function setAppSecret(
   name: string,
   value: string
 ): Promise<{ version: number }> {
-  const resp = await secretsFetch(config, `/secrets/${encodeURIComponent(name)}`, {
-    method: 'POST',
-    body: JSON.stringify({ value }),
-  });
-  await assertOk(resp, 'setAppSecret');
-  const data: { version?: number } = await resp.json();
-  return { version: data.version ?? 0 };
+  const path = `/secrets/${encodeURIComponent(name)}`;
+
+  for (let attempt = 0; attempt <= SET_SECRET_RETRY_DELAYS_MS.length; attempt++) {
+    const resp = await secretsFetch(config, path, {
+      method: 'POST',
+      body: JSON.stringify({ value }),
+    });
+
+    if (resp.ok) {
+      const data: { version?: number } = await resp.json();
+      return { version: data.version ?? 0 };
+    }
+
+    const retryDelayMs = SET_SECRET_RETRY_DELAYS_MS[attempt];
+    if (retryDelayMs === undefined || !isRetryableSecretStatus(resp.status)) {
+      await assertOk(resp, 'setAppSecret');
+      throw new Error('unreachable setAppSecret error state');
+    }
+
+    await sleep(retryDelayMs);
+  }
+
+  throw new Error('unreachable setAppSecret retry state');
 }
 
 /**

--- a/services/kiloclaw/src/fly/secrets.ts
+++ b/services/kiloclaw/src/fly/secrets.ts
@@ -69,17 +69,26 @@ export async function setAppSecret(
   const path = `/secrets/${encodeURIComponent(name)}`;
 
   for (let attempt = 0; attempt <= SET_SECRET_RETRY_DELAYS_MS.length; attempt++) {
-    const resp = await secretsFetch(config, path, {
-      method: 'POST',
-      body: JSON.stringify({ value }),
-    });
+    const retryDelayMs = SET_SECRET_RETRY_DELAYS_MS[attempt];
+
+    let resp: Response;
+    try {
+      resp = await secretsFetch(config, path, {
+        method: 'POST',
+        body: JSON.stringify({ value }),
+      });
+    } catch (err) {
+      // Network-level failure (connection reset, DNS, TLS, etc.)
+      if (retryDelayMs === undefined) throw err;
+      await sleep(retryDelayMs);
+      continue;
+    }
 
     if (resp.ok) {
       const data: { version?: number } = await resp.json();
       return { version: data.version ?? 0 };
     }
 
-    const retryDelayMs = SET_SECRET_RETRY_DELAYS_MS[attempt];
     if (retryDelayMs === undefined || !isRetryableSecretStatus(resp.status)) {
       await assertOk(resp, 'setAppSecret');
       throw new Error('unreachable setAppSecret error state');

--- a/services/kiloclaw/src/fly/secrets.ts
+++ b/services/kiloclaw/src/fly/secrets.ts
@@ -47,7 +47,7 @@ async function assertOk(resp: Response, context: string): Promise<void> {
 }
 
 function isRetryableSecretStatus(status: number): boolean {
-  return status === 408 || status === 429 || status >= 500;
+  return status === 408 || status === 429 || [500, 502, 503, 504, 520].includes(status);
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary
- Retry transient Fly app secret writes so `setAppSecret` 520/5xx/408/429 responses do not immediately fail KiloClaw provisioning.
- Keep AppDO env-key setup marked pending until Fly confirms `KILOCLAW_ENV_KEY` was synced, allowing the retry alarm to self-heal failed secret propagation.
- Add regression coverage for Fly secret retry and AppDO retry-alarm state after secret sync failure.

## Verification
N/A - backend Worker provisioning change; no manual UI verification performed.

## Visual Changes
N/A

## Reviewer Notes
- `setAppSecret` is retried only for transient statuses and remains single-attempt for non-retryable 4xx responses.
- Existing unrelated worktree changes were stashed separately before creating this PR branch.