### PR TITLE
feat(kiloclaw): lazy-load file tree directories

### DIFF
--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -726,11 +726,19 @@ running. When forwarding, it MUST authenticate to gog with
 |---|---|---|
 | POST | `/_kilo/bot-identity` | Write bot identity metadata |
 | POST | `/_kilo/user-profile` | Write user profile metadata |
-| GET | `/_kilo/files/tree` | List the safe file tree under controller root |
+| GET | `/_kilo/files/tree` | List immediate safe file-tree children under controller root, or under `?path=<directory>` when `files.tree.path` is advertised |
 | GET | `/_kilo/files/read` | Read a safe file path |
 | POST | `/_kilo/files/import-openclaw-workspace` | Import OpenClaw workspace files |
 | POST | `/_kilo/files/write` | Write a safe file path |
 | POST | `/_kilo/files/write-openclaw-config` | Validate and write `openclaw.json`, with explicit invalid override support |
+
+##### File tree listing
+
+1. `GET /_kilo/files/tree` MUST return only the immediate children of the requested directory; it MUST NOT recursively serialize the full descendant tree in a single response.
+2. Without `?path=...`, the endpoint MUST list immediate children under the controller root.
+3. When the controller advertises `files.tree.path`, clients MAY pass `?path=<directory>` to list immediate children under that safe relative directory.
+4. Requested directory paths MUST use the same safe-path protections as file reads and writes: reject absolute paths, root escapes, symlinks, non-directory paths, and controller-owned internal validation artifacts.
+5. Directory nodes MAY omit `children`; clients MUST treat omitted `children` as not loaded yet, not as proof that the directory is empty.
 
 ##### Validation-aware `openclaw.json` file writes
 

--- a/apps/web/src/app/(app)/claw/components/FileEditorShell.tsx
+++ b/apps/web/src/app/(app)/claw/components/FileEditorShell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef, type ReactNode } from 'react';
+import { useState, useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { Loader2, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -18,11 +18,46 @@ import { useResizableSidebar } from '@/hooks/useResizableSidebar';
 import type { FileNode } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { FileTree } from './FileTree';
 
+function replaceDirectoryChildren(
+  nodes: FileNode[],
+  path: string,
+  children: FileNode[]
+): FileNode[] {
+  return nodes.map(node => {
+    if (node.path === path && node.type === 'directory') {
+      return { ...node, children };
+    }
+    if (node.children) {
+      return { ...node, children: replaceDirectoryChildren(node.children, path, children) };
+    }
+    return node;
+  });
+}
+
+function stripNestedChildren(nodes: FileNode[]): FileNode[] {
+  return nodes.map(node => {
+    if (node.type === 'directory') {
+      return { name: node.name, path: node.path, type: node.type };
+    }
+    return node;
+  });
+}
+
+function validatePathScopedChildren(path: string, children: FileNode[]): void {
+  const prefix = `${path}/`;
+  if (children.every(child => child.path.startsWith(prefix))) return;
+
+  throw new Error(
+    'Controller returned a recursive file tree. Restart this instance with the latest image.'
+  );
+}
+
 export function FileEditorShell({
   tree,
   isLoading,
   error,
   refetch,
+  loadChildren,
   renderPane,
   onClose,
   height,
@@ -31,6 +66,7 @@ export function FileEditorShell({
   isLoading: boolean;
   error: { message: string } | null;
   refetch: () => void;
+  loadChildren?: (path: string) => Promise<FileNode[]>;
   renderPane: (selectedPath: string, onDirtyChange: (dirty: boolean) => void) => ReactNode;
   onClose?: () => void;
   height?: string;
@@ -39,8 +75,19 @@ export function FileEditorShell({
   const [pendingAction, setPendingAction] = useState<
     { type: 'switch'; path: string } | { type: 'close' } | null
   >(null);
+  const [mergedTree, setMergedTree] = useState<FileNode[] | undefined>(tree);
+  const [loadedPaths, setLoadedPaths] = useState<Set<string>>(new Set());
+  const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
+  const [loadErrors, setLoadErrors] = useState<Map<string, string>>(new Map());
   const hasUnsavedChangesRef = useRef(false);
   const { width: sidebarWidth, startDrag } = useResizableSidebar();
+
+  useEffect(() => {
+    setMergedTree(tree ? stripNestedChildren(tree) : tree);
+    setLoadedPaths(new Set());
+    setLoadingPaths(new Set());
+    setLoadErrors(new Map());
+  }, [tree]);
 
   const handleDirtyChange = useCallback((dirty: boolean) => {
     hasUnsavedChangesRef.current = dirty;
@@ -67,6 +114,39 @@ export function FileEditorShell({
     onClose();
   }, [onClose]);
 
+  const handleLoadChildren = useCallback(
+    async (path: string) => {
+      if (!loadChildren || loadingPaths.has(path) || loadedPaths.has(path)) return;
+
+      setLoadingPaths(prev => new Set(prev).add(path));
+      setLoadErrors(prev => {
+        const next = new Map(prev);
+        next.delete(path);
+        return next;
+      });
+
+      try {
+        const children = await loadChildren(path);
+        validatePathScopedChildren(path, children);
+        const shallowChildren = stripNestedChildren(children);
+        setMergedTree(prev =>
+          prev ? replaceDirectoryChildren(prev, path, shallowChildren) : prev
+        );
+        setLoadedPaths(prev => new Set(prev).add(path));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to load folder';
+        setLoadErrors(prev => new Map(prev).set(path, message));
+      } finally {
+        setLoadingPaths(prev => {
+          const next = new Set(prev);
+          next.delete(path);
+          return next;
+        });
+      }
+    },
+    [loadChildren, loadedPaths, loadingPaths]
+  );
+
   if (isLoading) {
     return (
       <div className="flex items-center gap-2 py-4">
@@ -84,7 +164,9 @@ export function FileEditorShell({
     );
   }
 
-  if (!tree) return null;
+  const visibleTree = mergedTree ?? tree;
+
+  if (!visibleTree) return null;
 
   return (
     <div className="space-y-2">
@@ -104,7 +186,15 @@ export function FileEditorShell({
         style={height ? { height } : undefined}
       >
         <div className="shrink-0 overflow-y-auto" style={{ width: `${sidebarWidth}px` }}>
-          <FileTree tree={tree} selectedPath={selectedPath} onSelect={handleSelect} />
+          <FileTree
+            tree={visibleTree}
+            selectedPath={selectedPath}
+            loadedPaths={loadedPaths}
+            loadingPaths={loadingPaths}
+            loadErrors={loadErrors}
+            onSelect={handleSelect}
+            onLoadChildren={loadChildren ? path => void handleLoadChildren(path) : undefined}
+          />
         </div>
         <div
           className="before:bg-border hover:before:bg-border relative w-3 shrink-0 cursor-col-resize before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:content-['']"

--- a/apps/web/src/app/(app)/claw/components/FileEditorShell.tsx
+++ b/apps/web/src/app/(app)/claw/components/FileEditorShell.tsx
@@ -43,6 +43,26 @@ function stripNestedChildren(nodes: FileNode[]): FileNode[] {
   });
 }
 
+function indexNodesByPath(nodes: FileNode[], index = new Map<string, FileNode>()) {
+  for (const node of nodes) {
+    index.set(node.path, node);
+    if (node.children) indexNodesByPath(node.children, index);
+  }
+  return index;
+}
+
+function preserveLoadedDirectoryChildren(nodes: FileNode[], existingNodes: FileNode[]): FileNode[] {
+  const existingByPath = indexNodesByPath(existingNodes);
+  return nodes.map(node => {
+    if (node.type !== 'directory') return node;
+
+    const existing = existingByPath.get(node.path);
+    if (!existing?.children) return node;
+
+    return { ...node, children: existing.children };
+  });
+}
+
 function validatePathScopedChildren(path: string, children: FileNode[]): void {
   const prefix = `${path}/`;
   if (children.every(child => child.path.startsWith(prefix))) return;
@@ -76,16 +96,33 @@ export function FileEditorShell({
     { type: 'switch'; path: string } | { type: 'close' } | null
   >(null);
   const [mergedTree, setMergedTree] = useState<FileNode[] | undefined>(tree);
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
   const [loadedPaths, setLoadedPaths] = useState<Set<string>>(new Set());
   const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
   const [loadErrors, setLoadErrors] = useState<Map<string, string>>(new Map());
+  const expandedPathsRef = useRef(new Set<string>());
+  const loadedPathsRef = useRef(new Set<string>());
+  const loadingPathsRef = useRef(new Set<string>());
   const hasUnsavedChangesRef = useRef(false);
   const { width: sidebarWidth, startDrag } = useResizableSidebar();
 
   useEffect(() => {
-    setMergedTree(tree ? stripNestedChildren(tree) : tree);
-    setLoadedPaths(new Set());
-    setLoadingPaths(new Set());
+    if (!tree) {
+      setMergedTree(tree);
+      expandedPathsRef.current = new Set();
+      loadedPathsRef.current = new Set();
+      loadingPathsRef.current = new Set();
+      setExpandedPaths(expandedPathsRef.current);
+      setLoadedPaths(loadedPathsRef.current);
+      setLoadingPaths(loadingPathsRef.current);
+      setLoadErrors(new Map());
+      return;
+    }
+
+    const shallowTree = stripNestedChildren(tree);
+    setMergedTree(prev =>
+      prev ? preserveLoadedDirectoryChildren(shallowTree, prev) : shallowTree
+    );
     setLoadErrors(new Map());
   }, [tree]);
 
@@ -116,9 +153,13 @@ export function FileEditorShell({
 
   const handleLoadChildren = useCallback(
     async (path: string) => {
-      if (!loadChildren || loadingPaths.has(path) || loadedPaths.has(path)) return;
+      if (!loadChildren || loadingPathsRef.current.has(path) || loadedPathsRef.current.has(path)) {
+        return;
+      }
 
-      setLoadingPaths(prev => new Set(prev).add(path));
+      const nextLoadingPaths = new Set(loadingPathsRef.current).add(path);
+      loadingPathsRef.current = nextLoadingPaths;
+      setLoadingPaths(nextLoadingPaths);
       setLoadErrors(prev => {
         const next = new Map(prev);
         next.delete(path);
@@ -132,19 +173,39 @@ export function FileEditorShell({
         setMergedTree(prev =>
           prev ? replaceDirectoryChildren(prev, path, shallowChildren) : prev
         );
-        setLoadedPaths(prev => new Set(prev).add(path));
+        const nextLoadedPaths = new Set(loadedPathsRef.current).add(path);
+        loadedPathsRef.current = nextLoadedPaths;
+        setLoadedPaths(nextLoadedPaths);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to load folder';
         setLoadErrors(prev => new Map(prev).set(path, message));
       } finally {
-        setLoadingPaths(prev => {
-          const next = new Set(prev);
-          next.delete(path);
-          return next;
-        });
+        const nextLoadingPaths = new Set(loadingPathsRef.current);
+        nextLoadingPaths.delete(path);
+        loadingPathsRef.current = nextLoadingPaths;
+        setLoadingPaths(nextLoadingPaths);
       }
     },
-    [loadChildren, loadedPaths, loadingPaths]
+    [loadChildren]
+  );
+
+  const handleToggleDirectory = useCallback(
+    (node: FileNode) => {
+      if (node.type !== 'directory') return;
+
+      const isExpanded = expandedPathsRef.current.has(node.path);
+      const nextExpandedPaths = new Set(expandedPathsRef.current);
+      if (isExpanded) {
+        nextExpandedPaths.delete(node.path);
+      } else {
+        nextExpandedPaths.add(node.path);
+      }
+      expandedPathsRef.current = nextExpandedPaths;
+      setExpandedPaths(nextExpandedPaths);
+
+      if (!isExpanded) void handleLoadChildren(node.path);
+    },
+    [handleLoadChildren]
   );
 
   if (isLoading) {
@@ -189,11 +250,13 @@ export function FileEditorShell({
           <FileTree
             tree={visibleTree}
             selectedPath={selectedPath}
+            expandedPaths={expandedPaths}
             loadedPaths={loadedPaths}
             loadingPaths={loadingPaths}
             loadErrors={loadErrors}
             onSelect={handleSelect}
             onLoadChildren={loadChildren ? path => void handleLoadChildren(path) : undefined}
+            onToggleDirectory={handleToggleDirectory}
           />
         </div>
         <div

--- a/apps/web/src/app/(app)/claw/components/FileTree.tsx
+++ b/apps/web/src/app/(app)/claw/components/FileTree.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { ChevronRight, ChevronDown, File, Folder } from 'lucide-react';
+import { ChevronRight, ChevronDown, File, Folder, Loader2 } from 'lucide-react';
 import type { FileNode } from '@/lib/kiloclaw/kiloclaw-internal-client';
 
 function sortNodes(nodes: FileNode[]): FileNode[] {
@@ -16,19 +16,29 @@ function FileTreeNode({
   depth,
   selectedPath,
   expanded,
+  loadedPaths,
+  loadingPaths,
+  loadErrors,
   onSelect,
   onToggle,
+  onLoadChildren,
 }: {
   node: FileNode;
   depth: number;
   selectedPath: string | null;
   expanded: Set<string>;
+  loadedPaths: ReadonlySet<string>;
+  loadingPaths: ReadonlySet<string>;
+  loadErrors: ReadonlyMap<string, string>;
   onSelect: (path: string) => void;
-  onToggle: (path: string) => void;
+  onToggle: (node: FileNode) => void;
+  onLoadChildren?: (path: string) => void;
 }) {
   const isDir = node.type === 'directory';
   const isExpanded = expanded.has(node.path);
   const isSelected = node.path === selectedPath;
+  const isLoading = loadingPaths.has(node.path);
+  const loadError = loadErrors.get(node.path);
 
   return (
     <>
@@ -40,7 +50,7 @@ function FileTreeNode({
         style={{ paddingLeft: `${depth * 16 + 8}px` }}
         onClick={() => {
           if (isDir) {
-            onToggle(node.path);
+            onToggle(node);
           } else {
             onSelect(node.path);
           }
@@ -60,16 +70,39 @@ function FileTreeNode({
       </button>
       {isDir &&
         isExpanded &&
-        sortNodes(node.children ?? []).map(child => (
-          <FileTreeNode
-            key={child.path}
-            node={child}
-            depth={depth + 1}
-            selectedPath={selectedPath}
-            expanded={expanded}
-            onSelect={onSelect}
-            onToggle={onToggle}
-          />
+        (isLoading ? (
+          <div
+            className="text-muted-foreground flex items-center gap-1 px-2 py-1 text-xs"
+            style={{ paddingLeft: `${(depth + 1) * 16 + 8}px` }}
+          >
+            <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+            <span className="truncate">Loading...</span>
+          </div>
+        ) : loadError ? (
+          <button
+            type="button"
+            className="text-destructive hover:bg-accent/50 flex w-full items-center gap-1 px-2 py-1 text-left text-xs"
+            style={{ paddingLeft: `${(depth + 1) * 16 + 8}px` }}
+            onClick={() => onLoadChildren?.(node.path)}
+          >
+            <span className="truncate">{loadError}. Retry</span>
+          </button>
+        ) : (
+          sortNodes(node.children ?? []).map(child => (
+            <FileTreeNode
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              selectedPath={selectedPath}
+              expanded={expanded}
+              loadedPaths={loadedPaths}
+              loadingPaths={loadingPaths}
+              loadErrors={loadErrors}
+              onSelect={onSelect}
+              onToggle={onToggle}
+              onLoadChildren={onLoadChildren}
+            />
+          ))
         ))}
     </>
   );
@@ -78,25 +111,40 @@ function FileTreeNode({
 export function FileTree({
   tree,
   selectedPath,
+  loadedPaths = new Set(),
+  loadingPaths = new Set(),
+  loadErrors = new Map(),
   onSelect,
+  onLoadChildren,
 }: {
   tree: FileNode[];
   selectedPath: string | null;
+  loadedPaths?: ReadonlySet<string>;
+  loadingPaths?: ReadonlySet<string>;
+  loadErrors?: ReadonlyMap<string, string>;
   onSelect: (path: string) => void;
+  onLoadChildren?: (path: string) => void;
 }) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
-  const handleToggle = useCallback((path: string) => {
-    setExpanded(prev => {
-      const next = new Set(prev);
-      if (next.has(path)) {
-        next.delete(path);
-      } else {
-        next.add(path);
+  const handleToggle = useCallback(
+    (node: FileNode) => {
+      const shouldExpand = !expanded.has(node.path);
+      setExpanded(prev => {
+        const next = new Set(prev);
+        if (next.has(node.path)) {
+          next.delete(node.path);
+        } else {
+          next.add(node.path);
+        }
+        return next;
+      });
+      if (shouldExpand && node.type === 'directory' && !loadedPaths.has(node.path)) {
+        onLoadChildren?.(node.path);
       }
-      return next;
-    });
-  }, []);
+    },
+    [expanded, loadedPaths, onLoadChildren]
+  );
 
   return (
     <div className="flex flex-col overflow-y-auto">
@@ -110,8 +158,12 @@ export function FileTree({
           depth={0}
           selectedPath={selectedPath}
           expanded={expanded}
+          loadedPaths={loadedPaths}
+          loadingPaths={loadingPaths}
+          loadErrors={loadErrors}
           onSelect={onSelect}
           onToggle={handleToggle}
+          onLoadChildren={onLoadChildren}
         />
       ))}
     </div>

--- a/apps/web/src/app/(app)/claw/components/FileTree.tsx
+++ b/apps/web/src/app/(app)/claw/components/FileTree.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState, useCallback } from 'react';
 import { ChevronRight, ChevronDown, File, Folder, Loader2 } from 'lucide-react';
 import type { FileNode } from '@/lib/kiloclaw/kiloclaw-internal-client';
 
@@ -26,7 +25,7 @@ function FileTreeNode({
   node: FileNode;
   depth: number;
   selectedPath: string | null;
-  expanded: Set<string>;
+  expanded: ReadonlySet<string>;
   loadedPaths: ReadonlySet<string>;
   loadingPaths: ReadonlySet<string>;
   loadErrors: ReadonlyMap<string, string>;
@@ -111,41 +110,24 @@ function FileTreeNode({
 export function FileTree({
   tree,
   selectedPath,
+  expandedPaths,
   loadedPaths = new Set(),
   loadingPaths = new Set(),
   loadErrors = new Map(),
   onSelect,
   onLoadChildren,
+  onToggleDirectory,
 }: {
   tree: FileNode[];
   selectedPath: string | null;
+  expandedPaths: ReadonlySet<string>;
   loadedPaths?: ReadonlySet<string>;
   loadingPaths?: ReadonlySet<string>;
   loadErrors?: ReadonlyMap<string, string>;
   onSelect: (path: string) => void;
   onLoadChildren?: (path: string) => void;
+  onToggleDirectory: (node: FileNode) => void;
 }) {
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-
-  const handleToggle = useCallback(
-    (node: FileNode) => {
-      const shouldExpand = !expanded.has(node.path);
-      setExpanded(prev => {
-        const next = new Set(prev);
-        if (next.has(node.path)) {
-          next.delete(node.path);
-        } else {
-          next.add(node.path);
-        }
-        return next;
-      });
-      if (shouldExpand && node.type === 'directory' && !loadedPaths.has(node.path)) {
-        onLoadChildren?.(node.path);
-      }
-    },
-    [expanded, loadedPaths, onLoadChildren]
-  );
-
   return (
     <div className="flex flex-col overflow-y-auto">
       <div className="text-muted-foreground px-3 py-2 text-[10px] font-medium tracking-wider uppercase">
@@ -157,12 +139,12 @@ export function FileTree({
           node={node}
           depth={0}
           selectedPath={selectedPath}
-          expanded={expanded}
+          expanded={expandedPaths}
           loadedPaths={loadedPaths}
           loadingPaths={loadingPaths}
           loadErrors={loadErrors}
           onSelect={onSelect}
-          onToggle={handleToggle}
+          onToggle={onToggleDirectory}
           onLoadChildren={onLoadChildren}
         />
       ))}

--- a/apps/web/src/app/(app)/claw/components/WorkspaceFileEditor.tsx
+++ b/apps/web/src/app/(app)/claw/components/WorkspaceFileEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
-import { useClawFileTree, useClawReadFile } from '../hooks/useClawHooks';
+import { useClawFileTree, useClawFileTreeLoader, useClawReadFile } from '../hooks/useClawHooks';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
 import type {
   FileWriteResponse,
@@ -75,6 +75,7 @@ export function WorkspaceFileEditor({
   enableOpenclawValidation: boolean;
 }) {
   const { data: tree, isLoading, error, refetch } = useClawFileTree(enabled);
+  const loadChildren = useClawFileTreeLoader(enabled);
 
   return (
     <FileEditorShell
@@ -82,6 +83,7 @@ export function WorkspaceFileEditor({
       isLoading={isLoading}
       error={error}
       refetch={refetch}
+      loadChildren={loadChildren}
       onClose={() => onOpenChange(false)}
       renderPane={(selectedPath, onDirtyChange) => (
         <UserFileEditorPane

--- a/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
@@ -10,6 +10,7 @@
  */
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
 
 import { useTRPC } from '@/lib/trpc/utils';
 import { useClawContext } from '../components/ClawContext';
@@ -348,24 +349,52 @@ export function useClawGatewayReady(enabled: boolean) {
 
 // File operations
 
-export function useClawFileTree(enabled: boolean) {
+export function useClawFileTree(enabled: boolean, path?: string) {
   const trpc = useTRPC();
   const { organizationId } = useClawContext();
 
   const personal = useQuery({
-    ...trpc.kiloclaw.fileTree.queryOptions(undefined, { refetchOnWindowFocus: false }),
+    ...trpc.kiloclaw.fileTree.queryOptions(path === undefined ? undefined : { path }, {
+      refetchOnWindowFocus: false,
+    }),
     enabled: enabled && !organizationId,
   });
 
   const org = useQuery({
     ...trpc.organizations.kiloclaw.fileTree.queryOptions(
-      { organizationId: organizationId ?? '' },
+      { organizationId: organizationId ?? '', ...(path === undefined ? {} : { path }) },
       { refetchOnWindowFocus: false }
     ),
     enabled: enabled && !!organizationId,
   });
 
   return organizationId ? org : personal;
+}
+
+export function useClawFileTreeLoader(enabled: boolean) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const { organizationId } = useClawContext();
+
+  return useCallback(
+    async (path: string) => {
+      if (!enabled) return [];
+
+      if (organizationId) {
+        return await queryClient.fetchQuery(
+          trpc.organizations.kiloclaw.fileTree.queryOptions(
+            { organizationId, path },
+            { refetchOnWindowFocus: false }
+          )
+        );
+      }
+
+      return await queryClient.fetchQuery(
+        trpc.kiloclaw.fileTree.queryOptions({ path }, { refetchOnWindowFocus: false })
+      );
+    },
+    [enabled, organizationId, queryClient, trpc]
+  );
 }
 
 export function useClawReadFile(path: string | null, enabled: boolean) {

--- a/apps/web/src/app/admin/components/KiloclawInstances/AdminFileEditor.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/AdminFileEditor.tsx
@@ -112,7 +112,7 @@ export function AdminFileEditor({
       onSuccess: async result => {
         if ('outcome' in result) return;
         await queryClient.invalidateQueries({
-          queryKey: trpc.admin.kiloclawInstances.fileTree.queryKey({ userId, instanceId }),
+          queryKey: trpc.admin.kiloclawInstances.fileTree.queryKey(),
         });
         await queryClient.invalidateQueries({
           queryKey: trpc.admin.kiloclawInstances.readFile.queryKey({ userId, instanceId }),
@@ -137,6 +137,14 @@ export function AdminFileEditor({
       error={error}
       refetch={refetch}
       height="600px"
+      loadChildren={path =>
+        queryClient.fetchQuery(
+          trpc.admin.kiloclawInstances.fileTree.queryOptions(
+            { userId, instanceId, path },
+            { refetchOnWindowFocus: false }
+          )
+        )
+      }
       renderPane={(selectedPath, onDirtyChange) => (
         <AdminFileEditorPaneInner
           key={selectedPath}

--- a/apps/web/src/app/admin/components/KiloclawInstances/AdminFileEditor.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/AdminFileEditor.tsx
@@ -112,7 +112,7 @@ export function AdminFileEditor({
       onSuccess: async result => {
         if ('outcome' in result) return;
         await queryClient.invalidateQueries({
-          queryKey: trpc.admin.kiloclawInstances.fileTree.queryKey(),
+          queryKey: trpc.admin.kiloclawInstances.fileTree.queryKey({ userId, instanceId }),
         });
         await queryClient.invalidateQueries({
           queryKey: trpc.admin.kiloclawInstances.readFile.queryKey({ userId, instanceId }),

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -474,10 +474,10 @@ export function useKiloClawLatestVersion() {
   );
 }
 
-export function useFileTree(enabled: boolean) {
+export function useFileTree(enabled: boolean, path?: string) {
   const trpc = useTRPC();
   return useQuery(
-    trpc.kiloclaw.fileTree.queryOptions(undefined, {
+    trpc.kiloclaw.fileTree.queryOptions(path === undefined ? undefined : { path }, {
       enabled,
       refetchOnWindowFocus: false,
     })

--- a/apps/web/src/hooks/useOrgKiloClaw.ts
+++ b/apps/web/src/hooks/useOrgKiloClaw.ts
@@ -168,11 +168,11 @@ export function useOrgKiloClawMyPin(organizationId: string, opts: { enabled?: bo
   );
 }
 
-export function useOrgFileTree(organizationId: string, enabled: boolean) {
+export function useOrgFileTree(organizationId: string, enabled: boolean, path?: string) {
   const trpc = useTRPC();
   return useQuery(
     trpc.organizations.kiloclaw.fileTree.queryOptions(
-      { organizationId },
+      { organizationId, ...(path === undefined ? {} : { path }) },
       { enabled, refetchOnWindowFocus: false }
     )
   );

--- a/apps/web/src/lib/kiloclaw/file-path-schema.ts
+++ b/apps/web/src/lib/kiloclaw/file-path-schema.ts
@@ -1,0 +1,5 @@
+import * as z from 'zod';
+
+export const KILOCLAW_FILE_PATH_MAX_LENGTH = 4096;
+
+export const kiloclawFilePathSchema = z.string().min(1).max(KILOCLAW_FILE_PATH_MAX_LENGTH);

--- a/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -69,12 +69,12 @@ import type {
 import type { InstanceTierKey } from '@kilocode/kiloclaw-instance-tiers';
 
 /** Keep in sync with: kiloclaw/controller/src/routes/files.ts, kiloclaw/src/.../gateway.ts (Zod) */
-export interface FileNode {
+export type FileNode = {
   name: string;
   path: string;
   type: 'file' | 'directory';
   children?: FileNode[];
-}
+};
 
 export type OpenclawFileWriteValidation = 'warn-before-write' | 'allow-invalid';
 
@@ -913,9 +913,13 @@ export class KiloClawInternalClient {
     );
   }
 
-  async getFileTree(userId: string, instanceId?: string): Promise<{ tree: FileNode[] }> {
+  async getFileTree(
+    userId: string,
+    opts: { instanceId?: string; path?: string } = {}
+  ): Promise<{ tree: FileNode[] }> {
     const params = new URLSearchParams({ userId });
-    if (instanceId) params.set('instanceId', instanceId);
+    if (opts.instanceId) params.set('instanceId', opts.instanceId);
+    if (opts.path !== undefined) params.set('path', opts.path);
     return this.request(`/api/platform/files/tree?${params.toString()}`);
   }
 

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -23,6 +23,7 @@ import { UpstreamApiError } from '@/lib/trpc/init';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const mockGetDebugStatus: jest.Mock<any, any> = jest.fn();
+const mockGetFileTree: jest.Mock<any, any> = jest.fn();
 const mockDestroyFlyMachine: jest.Mock<any, any> = jest.fn();
 const mockDestroyOrphanVolume: jest.Mock<any, any> = jest.fn();
 const mockScanOrphanVolumes: jest.Mock<any, any> = jest.fn();
@@ -44,6 +45,7 @@ function mockKiloClawInternalClient() {
   const { KiloClawInternalClient } = jest.requireMock('@/lib/kiloclaw/kiloclaw-internal-client');
   KiloClawInternalClient.mockImplementation(() => ({
     getDebugStatus: mockGetDebugStatus,
+    getFileTree: mockGetFileTree,
     destroyFlyMachine: mockDestroyFlyMachine,
     destroyOrphanVolume: mockDestroyOrphanVolume,
     scanOrphanVolumes: mockScanOrphanVolumes,
@@ -58,6 +60,7 @@ function mockKiloClawInternalClient() {
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
   KiloClawInternalClient: jest.fn().mockImplementation(() => ({
     getDebugStatus: mockGetDebugStatus,
+    getFileTree: mockGetFileTree,
     destroyFlyMachine: mockDestroyFlyMachine,
     destroyOrphanVolume: mockDestroyOrphanVolume,
     scanOrphanVolumes: mockScanOrphanVolumes,
@@ -161,6 +164,7 @@ beforeEach(async () => {
 
   cliRunId = run.id;
   mockGetDebugStatus.mockReset();
+  mockGetFileTree.mockReset();
   mockDestroyFlyMachine.mockReset();
   mockDestroyOrphanVolume.mockReset();
   mockScanOrphanVolumes.mockReset();
@@ -327,6 +331,30 @@ describe('admin.kiloclawInstances.list and stats', () => {
     expect(stats.overview.inactiveTrialStoppedInstances).toBe(
       baselineStats.overview.inactiveTrialStoppedInstances + 1
     );
+  });
+});
+
+describe('admin.kiloclawInstances.fileTree', () => {
+  it('forwards path-scoped tree requests to the resolved instance', async () => {
+    mockGetFileTree.mockResolvedValue({ tree: [] });
+    const instanceId = crypto.randomUUID();
+    await db.insert(kiloclaw_instances).values({
+      id: instanceId,
+      user_id: regularUser.id,
+      sandbox_id: `ki_${instanceId.replace(/-/g, '')}`,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await caller.admin.kiloclawInstances.fileTree({
+      userId: regularUser.id,
+      instanceId,
+      path: 'workspace/nested',
+    });
+
+    expect(mockGetFileTree).toHaveBeenCalledWith(regularUser.id, {
+      instanceId,
+      path: 'workspace/nested',
+    });
   });
 });
 

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -26,6 +26,7 @@ import {
   getInboundEmailAddressForInstance,
 } from '@/lib/kiloclaw/inbound-email-alias';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { kiloclawFilePathSchema } from '@/lib/kiloclaw/file-path-schema';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import { pushPinToWorker } from '@/lib/kiloclaw/pin-sync';
 import {
@@ -1598,7 +1599,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       z.object({
         userId: z.string().min(1),
         instanceId: z.string().uuid().optional(),
-        path: z.string().min(1).optional(),
+        path: kiloclawFilePathSchema.optional(),
       })
     )
     .query(async ({ input }) => {
@@ -1620,7 +1621,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       z.object({
         userId: z.string().min(1),
         instanceId: z.string().uuid().optional(),
-        path: z.string().min(1),
+        path: kiloclawFilePathSchema,
       })
     )
     .query(async ({ input }) => {
@@ -1638,7 +1639,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       z.object({
         userId: z.string().min(1),
         instanceId: z.string().uuid().optional(),
-        path: z.string().min(1),
+        path: kiloclawFilePathSchema,
         content: z.string(),
         etag: z.string().optional(),
         openclawValidation: z.enum(['warn-before-write', 'allow-invalid']).optional(),

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -1594,12 +1594,21 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
   }),
 
   fileTree: adminProcedure
-    .input(z.object({ userId: z.string().min(1), instanceId: z.string().uuid().optional() }))
+    .input(
+      z.object({
+        userId: z.string().min(1),
+        instanceId: z.string().uuid().optional(),
+        path: z.string().min(1).optional(),
+      })
+    )
     .query(async ({ input }) => {
       try {
         const instance = await resolveInstance(input.userId, input.instanceId);
         const client = new KiloClawInternalClient();
-        const result = await client.getFileTree(input.userId, workerInstanceId(instance));
+        const result = await client.getFileTree(input.userId, {
+          instanceId: workerInstanceId(instance),
+          path: input.path,
+        });
         return result.tree;
       } catch (err) {
         throwKiloclawAdminError(err, 'Failed to fetch file tree');

--- a/apps/web/src/routers/kiloclaw-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-router.test.ts
@@ -45,6 +45,7 @@ type KiloClawClientMock = {
   __getStatusMock: AnyMock;
   __getLatestVersionMock: AnyMock;
   __getLatestVersionForInstanceMock: AnyMock;
+  __getFileTreeMock: AnyMock;
   __destroyMock: AnyMock;
   __startMock: AnyMock;
 };
@@ -113,6 +114,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const getStatusMock = jest.fn();
   const getLatestVersionMock = jest.fn();
   const getLatestVersionForInstanceMock = jest.fn();
+  const getFileTreeMock = jest.fn();
   const destroyMock = jest.fn();
   const startMock = jest.fn();
   return {
@@ -120,6 +122,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
       getStatus: getStatusMock,
       getLatestVersion: getLatestVersionMock,
       getLatestVersionForInstance: getLatestVersionForInstanceMock,
+      getFileTree: getFileTreeMock,
       start: startMock,
       destroy: destroyMock,
     })),
@@ -135,6 +138,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
     __getStatusMock: getStatusMock,
     __getLatestVersionMock: getLatestVersionMock,
     __getLatestVersionForInstanceMock: getLatestVersionForInstanceMock,
+    __getFileTreeMock: getFileTreeMock,
     __destroyMock: destroyMock,
     __startMock: startMock,
   };
@@ -151,6 +155,7 @@ jest.mock('@/lib/kiloclaw/install-dispatch', () => {
 let createCaller: (ctx: { user: Awaited<ReturnType<typeof insertTestUser>> }) => {
   getStatus: () => Promise<unknown>;
   latestVersion: (input?: { currentImageTag?: string }) => Promise<unknown>;
+  fileTree: (input?: { path?: string }) => Promise<unknown>;
   getNavState: () => Promise<{ hasActiveInstance: boolean }>;
   validateWeatherLocation: (input: { location: string }) => Promise<{
     location: string;
@@ -239,6 +244,16 @@ beforeAll(async () => {
   const mod = await import('@/routers/kiloclaw-router');
   createCaller = createCallerFactory(mod.kiloclawRouter);
 });
+
+async function createActivePersonalInstance(userId: string): Promise<string> {
+  const instanceId = crypto.randomUUID();
+  await db.insert(kiloclaw_instances).values({
+    id: instanceId,
+    user_id: userId,
+    sandbox_id: `ki_${instanceId.replace(/-/g, '')}`,
+  });
+  return instanceId;
+}
 
 function wttrFormat3Response(text: string, status = 200): Response {
   return new Response(text, { status, headers: { 'Content-Type': 'text/plain' } });
@@ -564,6 +579,36 @@ describe('kiloclawRouter latestVersion', () => {
     expect(result).toEqual({ imageTag: 'anonymous-tag' });
     expect(kiloclawClientMock.__getLatestVersionMock).toHaveBeenCalledWith();
     expect(kiloclawClientMock.__getLatestVersionForInstanceMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('kiloclawRouter fileTree', () => {
+  beforeEach(async () => {
+    await cleanupDbForTest();
+    kiloclawClientMock.__getFileTreeMock.mockReset();
+  });
+
+  it('forwards path-scoped tree requests to the active instance', async () => {
+    kiloclawClientMock.__getFileTreeMock.mockResolvedValue({ tree: [] });
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-file-tree-${crypto.randomUUID()}@example.com`,
+    });
+    const instanceId = await createActivePersonalInstance(user.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instanceId,
+      plan: 'trial',
+      status: 'trialing',
+      trial_ends_at: '2026-07-01T00:00:00.000Z',
+    });
+
+    const caller = createCaller({ user });
+    await caller.fileTree({ path: 'workspace/nested' });
+
+    expect(kiloclawClientMock.__getFileTreeMock).toHaveBeenCalledWith(user.id, {
+      instanceId,
+      path: 'workspace/nested',
+    });
   });
 });
 

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -4179,16 +4179,21 @@ export const kiloclawRouter = createTRPCRouter({
     return { success: true, deleted: !!deleted, worker_sync: workerSync };
   }),
 
-  fileTree: clawAccessProcedure.query(async ({ ctx }) => {
-    try {
-      const instance = await getActiveInstance(ctx.user.id);
-      const client = new KiloClawInternalClient();
-      const result = await client.getFileTree(ctx.user.id, workerInstanceId(instance));
-      return result.tree;
-    } catch (err) {
-      handleFileOperationError(err, 'fetch file tree');
-    }
-  }),
+  fileTree: clawAccessProcedure
+    .input(z.object({ path: z.string().min(1).optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const instance = await getActiveInstance(ctx.user.id);
+        const client = new KiloClawInternalClient();
+        const result = await client.getFileTree(ctx.user.id, {
+          instanceId: workerInstanceId(instance),
+          path: input?.path,
+        });
+        return result.tree;
+      } catch (err) {
+        handleFileOperationError(err, 'fetch file tree');
+      }
+    }),
 
   readFile: clawAccessProcedure
     .input(z.object({ path: z.string().min(1) }))

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -5,6 +5,7 @@ import { TRPCError } from '@trpc/server';
 import { baseProcedure, createTRPCRouter, UpstreamApiError } from '@/lib/trpc/init';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { kiloclawFilePathSchema } from '@/lib/kiloclaw/file-path-schema';
 import { pushPinToWorker } from '@/lib/kiloclaw/pin-sync';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import { encryptKiloClawSecret } from '@/lib/kiloclaw/encryption';
@@ -4180,7 +4181,7 @@ export const kiloclawRouter = createTRPCRouter({
   }),
 
   fileTree: clawAccessProcedure
-    .input(z.object({ path: z.string().min(1).optional() }).optional())
+    .input(z.object({ path: kiloclawFilePathSchema.optional() }).optional())
     .query(async ({ ctx, input }) => {
       try {
         const instance = await getActiveInstance(ctx.user.id);
@@ -4196,7 +4197,7 @@ export const kiloclawRouter = createTRPCRouter({
     }),
 
   readFile: clawAccessProcedure
-    .input(z.object({ path: z.string().min(1) }))
+    .input(z.object({ path: kiloclawFilePathSchema }))
     .query(async ({ ctx, input }) => {
       try {
         const instance = await getActiveInstance(ctx.user.id);
@@ -4210,7 +4211,7 @@ export const kiloclawRouter = createTRPCRouter({
   writeFile: clawAccessProcedure
     .input(
       z.object({
-        path: z.string().min(1),
+        path: kiloclawFilePathSchema,
         content: z.string(),
         etag: z.string().min(1),
         openclawValidation: z.enum(['warn-before-write', 'allow-invalid']).optional(),
@@ -4274,7 +4275,7 @@ export const kiloclawRouter = createTRPCRouter({
         files: z
           .array(
             z.object({
-              path: z.string().min(1),
+              path: kiloclawFilePathSchema,
               content: z.string(),
             })
           )

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
@@ -26,6 +26,7 @@ type AnyMock = jest.Mock<(...args: any[]) => any>;
 
 type KiloClawClientMock = {
   __destroyMock: AnyMock;
+  __getFileTreeMock: AnyMock;
   __getLatestVersionMock: AnyMock;
   __getLatestVersionForInstanceMock: AnyMock;
   __patchWebSearchConfigMock: AnyMock;
@@ -76,6 +77,7 @@ jest.mock('@/lib/config.server', () => {
 
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const destroyMock = jest.fn();
+  const getFileTreeMock = jest.fn();
   const getLatestVersionMock = jest.fn();
   const getLatestVersionForInstanceMock = jest.fn();
   const patchWebSearchConfigMock = jest.fn();
@@ -88,6 +90,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   return {
     KiloClawInternalClient: jest.fn().mockImplementation(() => ({
       destroy: destroyMock,
+      getFileTree: getFileTreeMock,
       getLatestVersion: getLatestVersionMock,
       getLatestVersionForInstance: getLatestVersionForInstanceMock,
       patchWebSearchConfig: patchWebSearchConfigMock,
@@ -108,6 +111,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
       }
     },
     __destroyMock: destroyMock,
+    __getFileTreeMock: getFileTreeMock,
     __getLatestVersionMock: getLatestVersionMock,
     __getLatestVersionForInstanceMock: getLatestVersionForInstanceMock,
     __patchWebSearchConfigMock: patchWebSearchConfigMock,
@@ -788,6 +792,33 @@ describe('organizations.kiloclaw.writeFile validation mode', () => {
       instanceId,
       'warn-before-write'
     );
+  });
+});
+
+describe('organizations.kiloclaw.fileTree', () => {
+  beforeEach(async () => {
+    await cleanupDbForTest();
+    kiloclawClientMock.__getFileTreeMock.mockReset();
+  });
+
+  it('forwards path-scoped tree requests to the active org instance', async () => {
+    kiloclawClientMock.__getFileTreeMock.mockResolvedValue({ tree: [] });
+    const user = await insertTestUser({
+      google_user_email: `org-kiloclaw-file-tree-${crypto.randomUUID()}@example.com`,
+    });
+    const organization = await createOrganization('Org KiloClaw File Tree Test', user.id);
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+
+    const caller = await createCallerForUser(user.id);
+    await caller.organizations.kiloclaw.fileTree({
+      organizationId: organization.id,
+      path: 'workspace/nested',
+    });
+
+    expect(kiloclawClientMock.__getFileTreeMock).toHaveBeenCalledWith(user.id, {
+      instanceId,
+      path: 'workspace/nested',
+    });
   });
 });
 

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1461,16 +1461,21 @@ export const organizationKiloclawRouter = createTRPCRouter({
 
   // ── File operations ───────────────────────────────────────────
 
-  fileTree: organizationMemberProcedure.query(async ({ ctx, input }) => {
-    try {
-      const instance = await getActiveOrgInstance(ctx.user.id, input.organizationId);
-      const client = new KiloClawInternalClient();
-      const result = await client.getFileTree(ctx.user.id, workerInstanceId(instance));
-      return result.tree;
-    } catch (err) {
-      handleFileOperationError(err, 'fetch file tree');
-    }
-  }),
+  fileTree: organizationMemberProcedure
+    .input(z.object({ organizationId: z.uuid(), path: z.string().min(1).optional() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const instance = await getActiveOrgInstance(ctx.user.id, input.organizationId);
+        const client = new KiloClawInternalClient();
+        const result = await client.getFileTree(ctx.user.id, {
+          instanceId: workerInstanceId(instance),
+          path: input.path,
+        });
+        return result.tree;
+      } catch (err) {
+        handleFileOperationError(err, 'fetch file tree');
+      }
+    }),
 
   readFile: organizationMemberProcedure
     .input(z.object({ organizationId: z.uuid(), path: z.string().min(1) }))

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -5,6 +5,7 @@ import { TRPCError } from '@trpc/server';
 import { createTRPCRouter, UpstreamApiError } from '@/lib/trpc/init';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { kiloclawFilePathSchema } from '@/lib/kiloclaw/file-path-schema';
 import { pushPinToWorker } from '@/lib/kiloclaw/pin-sync';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import { encryptKiloClawSecret } from '@/lib/kiloclaw/encryption';
@@ -1462,7 +1463,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
   // ── File operations ───────────────────────────────────────────
 
   fileTree: organizationMemberProcedure
-    .input(z.object({ organizationId: z.uuid(), path: z.string().min(1).optional() }))
+    .input(z.object({ organizationId: z.uuid(), path: kiloclawFilePathSchema.optional() }))
     .query(async ({ ctx, input }) => {
       try {
         const instance = await getActiveOrgInstance(ctx.user.id, input.organizationId);
@@ -1478,7 +1479,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
     }),
 
   readFile: organizationMemberProcedure
-    .input(z.object({ organizationId: z.uuid(), path: z.string().min(1) }))
+    .input(z.object({ organizationId: z.uuid(), path: kiloclawFilePathSchema }))
     .query(async ({ ctx, input }) => {
       try {
         const instance = await getActiveOrgInstance(ctx.user.id, input.organizationId);
@@ -1493,7 +1494,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
     .input(
       z.object({
         organizationId: z.uuid(),
-        path: z.string().min(1),
+        path: kiloclawFilePathSchema,
         content: z.string(),
         etag: z.string().min(1),
         openclawValidation: z.enum(['warn-before-write', 'allow-invalid']).optional(),
@@ -1558,7 +1559,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
         files: z
           .array(
             z.object({
-              path: z.string().min(1),
+              path: kiloclawFilePathSchema,
               content: z.string(),
             })
           )

--- a/services/kiloclaw/controller/src/endpoint-capabilities.test.ts
+++ b/services/kiloclaw/controller/src/endpoint-capabilities.test.ts
@@ -32,6 +32,10 @@ describe('getControllerEndpointCapabilities', () => {
     expect(getControllerEndpointCapabilities()).toContain('files.write-openclaw-config');
   });
 
+  it('advertises path-scoped file tree listing', () => {
+    expect(getControllerEndpointCapabilities()).toContain('files.tree.path');
+  });
+
   it('includes conditional Kilo Chat capabilities only when requested', () => {
     const defaultCapabilities = getControllerEndpointCapabilities();
     const kiloChatCapabilities = getControllerEndpointCapabilities({

--- a/services/kiloclaw/controller/src/endpoint-capabilities.ts
+++ b/services/kiloclaw/controller/src/endpoint-capabilities.ts
@@ -15,6 +15,7 @@ export const CONTROLLER_ENDPOINT_CAPABILITIES = [
   'doctor.run',
   'kilo-cli.run',
   'files.tree',
+  'files.tree.path',
   'files.read',
   'files.write',
   'files.write-openclaw-config',

--- a/services/kiloclaw/controller/src/routes/files.test.ts
+++ b/services/kiloclaw/controller/src/routes/files.test.ts
@@ -154,7 +154,7 @@ describe('file routes', () => {
   });
 
   describe('GET /_kilo/files/tree', () => {
-    it('returns recursive directory listing including credentials', async () => {
+    it('returns a shallow root directory listing including credentials', async () => {
       vi.mocked(fs.readdirSync).mockImplementation((dir: any) => {
         if (dir === ROOT) {
           return [
@@ -179,16 +179,68 @@ describe('file routes', () => {
       expect(res.status).toBe(200);
 
       const body = (await res.json()) as any;
-      const names = body.tree.flatMap(function flatNames(n: any): string[] {
-        return [n.name, ...(n.children ? n.children.flatMap(flatNames) : [])];
-      });
+      const names = body.tree.map((node: any) => node.name);
       expect(names).toContain('openclaw.json');
       expect(names).toContain('SOUL.md.bak.2026-03-01');
       expect(names).toContain('debug.log');
-      expect(names).toContain('SOUL.md');
       expect(names).toContain('credentials');
-      expect(names).toContain('token.txt');
+      expect(names).not.toContain('SOUL.md');
+      expect(names).not.toContain('token.txt');
       expect(names).not.toContain('.openclaw.kiloclaw-validation-candidate.json');
+      expect(vi.mocked(fs.readdirSync)).not.toHaveBeenCalledWith(`${ROOT}/workspace`, {
+        withFileTypes: true,
+      });
+    });
+
+    it('returns a shallow listing for a requested directory path', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        isSymbolicLink: () => false,
+        isDirectory: () => true,
+      } as any);
+      vi.mocked(fs.readdirSync).mockImplementation((dir: any) => {
+        if (dir === `${ROOT}/workspace`) {
+          return [mockDirent('SOUL.md', false), mockDirent('nested', true)] as any;
+        }
+        if (dir === `${ROOT}/workspace/nested`) {
+          return [mockDirent('ignored.md', false)] as any;
+        }
+        return [];
+      });
+
+      const res = await app.request('/_kilo/files/tree?path=workspace', { headers: authHeaders() });
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as any;
+      expect(body.tree).toEqual([
+        { name: 'SOUL.md', path: 'workspace/SOUL.md', type: 'file' },
+        { name: 'nested', path: 'workspace/nested', type: 'directory' },
+      ]);
+      expect(vi.mocked(fs.readdirSync)).not.toHaveBeenCalledWith(`${ROOT}/workspace/nested`, {
+        withFileTypes: true,
+      });
+    });
+
+    it('rejects a requested file path', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        isSymbolicLink: () => false,
+        isDirectory: () => false,
+      } as any);
+
+      const res = await app.request('/_kilo/files/tree?path=openclaw.json', {
+        headers: authHeaders(),
+      });
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toMatchObject({ error: 'Not a directory' });
+    });
+
+    it('rejects requested directory paths that escape root', async () => {
+      const res = await app.request('/_kilo/files/tree?path=../secret', { headers: authHeaders() });
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toMatchObject({ error: 'Path escapes root directory' });
     });
 
     it('skips symlinks', async () => {

--- a/services/kiloclaw/controller/src/routes/files.ts
+++ b/services/kiloclaw/controller/src/routes/files.ts
@@ -324,14 +324,14 @@ function computeEtag(content: string): string {
 }
 
 /** Keep in sync with: kiloclaw/src/.../gateway.ts (Zod), src/lib/kiloclaw/kiloclaw-internal-client.ts */
-interface FileNode {
+type FileNode = {
   name: string;
   path: string;
   type: 'file' | 'directory';
   children?: FileNode[];
-}
+};
 
-function buildTree(dir: string, rootDir: string): FileNode[] {
+function buildDirectoryChildren(dir: string, rootDir: string): FileNode[] {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -351,7 +351,6 @@ function buildTree(dir: string, rootDir: string): FileNode[] {
         name: entry.name,
         path: relativePath,
         type: 'directory',
-        children: buildTree(path.join(dir, entry.name), rootDir),
       });
     } else {
       nodes.push({
@@ -366,6 +365,53 @@ function buildTree(dir: string, rootDir: string): FileNode[] {
 }
 
 type FileValidationError = { error: string; code?: string; status: 400 | 404 };
+
+function resolveAndValidateDirectory(
+  relativePath: string,
+  rootDir: string
+): string | FileValidationError {
+  let resolved: string;
+  try {
+    resolved = resolveSafePath(relativePath, rootDir);
+  } catch (e) {
+    if (e instanceof SafePathError) {
+      return { error: e.message, status: 400 };
+    }
+    throw e;
+  }
+
+  if (isOpenclawValidationArtifactPath(path.relative(rootDir, resolved))) {
+    return { code: 'file_not_found', error: 'Directory does not exist', status: 404 };
+  }
+
+  if (!fs.existsSync(resolved)) {
+    return { code: 'file_not_found', error: 'Directory does not exist', status: 404 };
+  }
+
+  let canonicalPath: string;
+  try {
+    canonicalPath = fs.realpathSync(resolved);
+    verifyCanonicalized(canonicalPath, rootDir);
+  } catch (e) {
+    if (e instanceof SafePathError) {
+      return { error: e.message, status: 400 };
+    }
+    throw e;
+  }
+  if (isOpenclawValidationArtifactPath(path.relative(rootDir, canonicalPath))) {
+    return { code: 'file_not_found', error: 'Directory does not exist', status: 404 };
+  }
+
+  const stat = fs.lstatSync(resolved);
+  if (stat.isSymbolicLink()) {
+    return { error: 'Symlinks are not allowed', status: 400 };
+  }
+  if (!stat.isDirectory()) {
+    return { error: 'Not a directory', status: 400 };
+  }
+
+  return resolved;
+}
 
 /**
  * Resolve a relative file path within the root directory and validate it:
@@ -581,7 +627,21 @@ export function registerFileRoutes(app: Hono, expectedToken: string, rootDir: st
   });
 
   app.get('/_kilo/files/tree', c => {
-    const tree = buildTree(rootDir, rootDir);
+    const relativePath = c.req.query('path');
+    let directory = rootDir;
+
+    if (relativePath !== undefined) {
+      const result = resolveAndValidateDirectory(relativePath, rootDir);
+      if (typeof result !== 'string') {
+        return c.json(
+          { error: result.error, ...(result.code && { code: result.code }) },
+          result.status
+        );
+      }
+      directory = result;
+    }
+
+    const tree = buildDirectoryChildren(directory, rootDir);
     return c.json({ tree });
   });
 

--- a/services/kiloclaw/scripts/push-dev.sh
+++ b/services/kiloclaw/scripts/push-dev.sh
@@ -18,6 +18,7 @@ fly auth docker
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 KILOCLAW_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(cd "$KILOCLAW_DIR/../.." && pwd)"
 
 # shellcheck source=services/kiloclaw/scripts/dev-image-mode.sh
 . "$SCRIPT_DIR/dev-image-mode.sh"
@@ -78,6 +79,7 @@ docker buildx build \
   -f "$DOCKERFILE" \
   --build-arg "CONTROLLER_COMMIT=$GIT_SHA" \
   --build-arg "CONTROLLER_CACHE_BUST=$(date +%s)" \
+  --build-context "workspace=$REPO_ROOT" \
   -t "$IMAGE" \
   --push \
   --metadata-file "$METADATA_FILE" \

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { deriveGatewayToken } from '../../auth/gateway-token';
 import { createMutableState } from './state';
 import {
+  getFileTree,
   getGatewayProcessStatus,
   getMorningBriefingStatus,
   runMorningBriefing,
@@ -79,6 +80,36 @@ describe('gateway controller routing', () => {
       Accept: 'application/json',
       'fly-force-instance-id': 'machine-1',
     });
+  });
+
+  it('encodes file tree directory paths in controller requests', async () => {
+    const state = createMutableState();
+    state.provider = 'fly';
+    state.status = 'running';
+    state.sandboxId = 'sandbox-1';
+    state.flyAppName = 'test-app';
+    state.flyMachineId = 'machine-1';
+
+    const fetchMock: FetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ tree: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await getFileTree(
+      state,
+      {
+        GATEWAY_TOKEN_SECRET: 'gateway-secret',
+        FLY_APP_NAME: 'fallback-app',
+      } as never,
+      'workspace/nested config'
+    );
+
+    const { input, init } = getFetchCall(fetchMock);
+    expect(input).toBe('https://test-app.fly.dev/_kilo/files/tree?path=workspace%2Fnested+config');
+    expect(init?.method).toBe('GET');
   });
 
   it('uses provider routing for health probes', async () => {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -416,16 +416,15 @@ const FileTreeResponseSchema = z.object({
 
 export async function getFileTree(
   state: InstanceMutableState,
-  env: KiloClawEnv
+  env: KiloClawEnv,
+  filePath?: string
 ): Promise<{ tree: unknown[] } | null> {
+  const params = new URLSearchParams();
+  if (filePath !== undefined) params.set('path', filePath);
+  const path = `/_kilo/files/tree${params.toString() ? `?${params.toString()}` : ''}`;
+
   try {
-    return await callGatewayController(
-      state,
-      env,
-      '/_kilo/files/tree',
-      'GET',
-      FileTreeResponseSchema
-    );
+    return await callGatewayController(state, env, path, 'GET', FileTreeResponseSchema);
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;
     throw error;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -3870,9 +3870,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     return gateway.replaceConfigOnMachine(this.s, this.env, config, etag);
   }
 
-  async getFileTree() {
+  async getFileTree(filePath?: string) {
     await this.loadState();
-    return gateway.getFileTree(this.s, this.env);
+    return gateway.getFileTree(this.s, this.env, filePath);
   }
 
   async readFile(filePath: string) {

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -3049,9 +3049,10 @@ platform.get('/morning-briefing/read/:day', async c => {
   }
 });
 
-// GET /api/platform/files/tree?userId=...
+// GET /api/platform/files/tree?userId=...[&path=...]
 platform.get('/files/tree', async c => {
   const userId = setValidatedQueryUserId(c);
+  const filePath = c.req.query('path');
   if (!userId) {
     return c.json({ error: 'userId query parameter is required' }, 400);
   }
@@ -3064,7 +3065,7 @@ platform.get('/files/tree', async c => {
       c.env,
       userId,
       iidResult.instanceId,
-      stub => stub.getFileTree(),
+      stub => stub.getFileTree(filePath),
       'getFileTree'
     );
     if (!result) {


### PR DESCRIPTION
## Summary
- Add path-scoped, shallow KiloClaw controller file-tree listing and advertise the `files.tree.path` capability.
- Thread optional file-tree paths through Worker, platform, tRPC, and personal/org/admin file editors so folders lazy-load on expansion.
- Fix the KiloClaw dev image push script to pass the monorepo `workspace` build context required by plugin builder stages.

## Verification
- Local debug confirmed stale docker-local instances surfaced the recursive-tree guard before the local image was rebuilt.
- Rebuilt `kiloclaw:local` for docker-local follow-up validation; the running instance was not recreated before handoff.

## Visual Changes

https://github.com/user-attachments/assets/c8fed5a4-1570-4f61-b105-02708dccebbc

## Reviewer Notes
- Existing KiloClaw instances need a restart or recreation with the updated controller image before path-scoped tree loading works.
- The UI strips nested directory children defensively so stale recursive-controller responses produce an actionable error instead of suppressing lazy loads.