### PR TITLE
chore(notifications): remove Grok Code discontinued notice

### DIFF
--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -115,7 +115,6 @@ export async function generateUserNotifications(user: User): Promise<KiloNotific
     generateAutoTopUpNotification,
     generateAutoTopUpOrgsNotification,
     generateByokProvidersNotification,
-    generateGrokCodeFast1OptimizedDiscontinuedNotification,
     generateKiloPassNotification,
     generateKiloPassPromoMay29Notification,
   ];
@@ -357,46 +356,6 @@ async function generateByokProvidersNotification(
     ];
   } catch (e) {
     console.error('[generateByokProvidersNotification]', e);
-    return [];
-  }
-}
-
-const getGrokCodeFast1OptimizedDiscontinuedUsers = cachedPosthogQuery(
-  z.array(z.tuple([z.string()]).transform(([userId]) => userId))
-);
-
-async function generateGrokCodeFast1OptimizedDiscontinuedNotification(
-  user: User,
-  _ctx: NotificationContext
-): Promise<KiloNotification[]> {
-  try {
-    const users = await getGrokCodeFast1OptimizedDiscontinuedUsers(
-      'grok-code-fast-1-optimized-discontinued-users',
-      'select kilo_user_id from notification_grok_code_may_15 limit 5e5'
-    );
-
-    if (!users.includes(user.id)) {
-      console.debug(
-        '[generateGrokCodeFast1OptimizedDiscontinuedNotification] not showing notification for user'
-      );
-      return [];
-    }
-
-    console.debug(
-      '[generateGrokCodeFast1OptimizedDiscontinuedNotification] showing notification for user'
-    );
-    return [
-      {
-        id: 'grok-code-fast-1-optimized-discontinued-may-15',
-        title: 'Grok Code Fast 1 Optimized is discontinued',
-        message:
-          'Grok Code Fast 1 Optimized has been discontinued. Give Grok Build 0.1 a try as a replacement.',
-        suggestModelId: 'x-ai/grok-build-0.1',
-        showIn: ['cli', 'extension'],
-      },
-    ];
-  } catch (e) {
-    console.error('[generateGrokCodeFast1OptimizedDiscontinuedNotification]', e);
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- Remove the targeted Grok Code Fast 1 Optimized discontinued notification from the user notification pipeline.
- Remove the now-unused PostHog query helper and generator so affected users no longer receive the stale notice.

## Verification
- Not manually verified; this removes a conditional notification generator and no local app session was started.

## Visual Changes
N/A

## Reviewer Notes
N/A