### PR TITLE
fix(ai-gateway): disable free Qwen 3.7 Plus

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/qwen.ts
+++ b/apps/web/src/lib/ai-gateway/providers/qwen.ts
@@ -138,7 +138,7 @@ export const qwen37_plus_free_model: KiloExclusiveModel = {
     "Qwen3.7-Plus is Alibaba's native multimodal agent model for visual-language reasoning, agentic coding, tool use, and productivity workflows. It supports text, image, and video inputs. For this free endpoint, your prompts and completions may be retained and used to train or improve the provider's services.",
   context_length: 1_000_000,
   max_completion_tokens: 65_536,
-  status: 'public',
+  status: 'disabled',
   flags: ['reasoning', 'vision', 'requires-data-collection'],
   gateway: 'vercel',
   internal_id: 'alibaba/qwen3.7-plus',


### PR DESCRIPTION
## Summary
- Disable `qwen/qwen3.7-plus:free`, removing it from the public model registry and preventing direct use.
- Keep the disabled model definition registered so stale clients receive the existing dead-free-model behavior; paid Qwen3.7 Plus remains unchanged.

## Verification
Not manually tested; this is a backend model registry status change.

## Visual Changes
N/A

## Reviewer Notes
Follow-up to #3712. Keeping the model registered with `status: 'disabled'` also suppresses an OpenRouter model with the same public ID.