### PR TITLE
feat(usage): add estimated market cost selector

### DIFF
--- a/apps/web/src/components/usage-analytics/FilterGeneratorPopover.tsx
+++ b/apps/web/src/components/usage-analytics/FilterGeneratorPopover.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/select';
 import { Check, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { DIMENSION_LABELS, type Dimension, type FilterDirection } from './types';
+import { DIMENSION_LABELS, type CostSource, type Dimension, type FilterDirection } from './types';
 import { useResolveOrgUsers, type DateRange, type PersonalScope, type UsageFilters } from './hooks';
 import type { Granularity } from './types';
 
@@ -49,6 +49,7 @@ type FilterGeneratorPopoverProps = {
   labelForDimensionValue?: (dim: Dimension, value: string) => string;
   /** Metric used to rank breakdown suggestions (defaults to 'cost'). */
   metric?: 'cost' | 'requests' | 'tokens';
+  costSource: CostSource;
   /** Granularity for the breakdown query (defaults to 'day'). */
   granularity?: Granularity;
 };
@@ -66,6 +67,7 @@ export function FilterGeneratorPopover({
   onAdd,
   labelForDimensionValue,
   metric = 'cost',
+  costSource,
   granularity = 'day',
 }: FilterGeneratorPopoverProps) {
   const [open, setOpen] = useState(false);
@@ -80,6 +82,7 @@ export function FilterGeneratorPopover({
       startDate: dateRange.startDate,
       endDate: dateRange.endDate,
       granularity,
+      costSource,
       organizationId: organizationId ?? undefined,
       personalScope,
       viewAs,

--- a/apps/web/src/components/usage-analytics/PrimaryChart.tsx
+++ b/apps/web/src/components/usage-analytics/PrimaryChart.tsx
@@ -13,7 +13,8 @@ import { isDateOnlyString } from '@/lib/utils';
 import { OTHER_COLOR, colorForIndex as paletteColorForIndex } from './colors';
 import { formatMetric } from './format';
 import {
-  METRIC_LABELS,
+  metricLabelForCostSource,
+  type CostSource,
   type Granularity,
   type MetricKey,
   type PeriodOption,
@@ -25,6 +26,7 @@ const OTHER_KEY = '__other__';
 
 type PrimaryChartProps = {
   metric: MetricKey;
+  costSource: CostSource;
   data: UsageTimeseries | undefined;
   loading: boolean;
   splitByLabel?: string;
@@ -41,6 +43,7 @@ type PrimaryChartProps = {
 
 export function PrimaryChart({
   metric,
+  costSource,
   data,
   loading,
   splitByLabel,
@@ -120,7 +123,7 @@ export function PrimaryChart({
   };
 
   const labelForKey = (key: string) => {
-    if (key === 'value') return METRIC_LABELS[metric];
+    if (key === 'value') return metricLabelForCostSource(metric, costSource);
     if (key === OTHER_KEY) return `Other (${otherCount})`;
     const resolved = seriesLabelFor ? seriesLabelFor(key) : key;
     return resolved || '—';

--- a/apps/web/src/components/usage-analytics/SummarySection.tsx
+++ b/apps/web/src/components/usage-analytics/SummarySection.tsx
@@ -3,11 +3,12 @@ import { Activity, Calculator, DollarSign, Hash, Users } from 'lucide-react';
 import { MetricCard } from './MetricCard';
 import { formatMetric } from './format';
 import { formatLargeNumber } from '@/lib/utils';
-import type { UsageSummary } from './types';
+import type { CostSource, UsageSummary } from './types';
 
 type SummarySectionProps = {
   summary: UsageSummary | undefined;
   loading: boolean;
+  costSource: CostSource;
   /** Show the Active Users card (organization context only). */
   showActiveUsers?: boolean;
 };
@@ -19,7 +20,14 @@ type SummarySectionProps = {
  * (with Active Users). The tokens card shows total tokens with an
  * "{input} in / {output} out" subtext.
  */
-export function SummarySection({ summary, loading, showActiveUsers }: SummarySectionProps) {
+export function SummarySection({
+  summary,
+  loading,
+  costSource,
+  showActiveUsers,
+}: SummarySectionProps) {
+  const costTitle = costSource === 'market' ? 'Est. Market Cost' : 'Cost';
+  const averageCostTitle = costSource === 'market' ? 'Avg Market / Req' : 'Avg Cost / Req';
   const tokensSubtext = summary
     ? `${formatLargeNumber(summary.inputTokens, true)} in / ${formatLargeNumber(summary.outputTokens, true)} out`
     : undefined;
@@ -31,7 +39,7 @@ export function SummarySection({ summary, loading, showActiveUsers }: SummarySec
   return (
     <div className={gridColsClass}>
       <MetricCard
-        title="Cost"
+        title={costTitle}
         value={summary ? formatMetric('cost', summary.costMicrodollars) : '—'}
         icon={DollarSign}
         loading={loading}
@@ -43,7 +51,7 @@ export function SummarySection({ summary, loading, showActiveUsers }: SummarySec
         loading={loading}
       />
       <MetricCard
-        title="Avg Cost / Req"
+        title={averageCostTitle}
         value={summary ? formatMetric('costPerRequest', summary.costPerRequest) : '—'}
         icon={Calculator}
         loading={loading}

--- a/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
@@ -44,6 +44,7 @@ import {
 import { useUsageDashboardState } from './useUsageDashboardState';
 import {
   DIMENSION_LABELS,
+  type CostSource,
   type Dimension,
   type FilterDirection,
   type Granularity,
@@ -109,7 +110,8 @@ export function UsageAnalyticsDashboard({
 }: UsageAnalyticsDashboardProps) {
   const trpc = useTRPC();
   const { state, setState } = useUsageDashboardState();
-  const { period, granularity, chartMetric, filters, groupBy, personalView, viewAs } = state;
+  const { period, granularity, costSource, chartMetric, filters, groupBy, personalView, viewAs } =
+    state;
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   // `organizations.list` is always available to the caller and returns the
@@ -213,11 +215,20 @@ export function UsageAnalyticsDashboard({
       organizationId: effectiveOrgId,
       dateRange,
       granularity,
+      costSource,
       filters,
       personalScope: effectivePersonalScope,
       viewAs: effectiveViewAs,
     }),
-    [effectiveOrgId, dateRange, granularity, filters, effectivePersonalScope, effectiveViewAs]
+    [
+      effectiveOrgId,
+      dateRange,
+      granularity,
+      costSource,
+      filters,
+      effectivePersonalScope,
+      effectiveViewAs,
+    ]
   );
 
   const { data: summary, isLoading: summaryLoading } = useUsageSummary(commonArgs);
@@ -400,7 +411,7 @@ export function UsageAnalyticsDashboard({
       ),
       {
         key: 'costMicrodollars',
-        label: 'Cost',
+        label: costSource === 'market' ? 'Estimated Market Cost' : 'Cost',
         align: 'right',
         render: value => formatDollarsFromMicrodollars(value as number),
         sortAccessor: row => (row.costMicrodollars as number) ?? 0,
@@ -428,7 +439,7 @@ export function UsageAnalyticsDashboard({
       },
     ];
     return cols;
-  }, [granularity, period, tableGroupBy, labelForDimensionValue]);
+  }, [granularity, period, tableGroupBy, labelForDimensionValue, costSource]);
 
   const tableRows = useMemo(() => {
     return (tableData?.rows ?? []).map((row, idx) => ({
@@ -451,9 +462,10 @@ export function UsageAnalyticsDashboard({
       groupBy: tableGroupBy,
       granularity,
       period,
+      costSource,
       labelForDimensionValue,
     });
-  }, [tableData, tableGroupBy, granularity, period, labelForDimensionValue]);
+  }, [tableData, tableGroupBy, granularity, period, costSource, labelForDimensionValue]);
 
   const isOrgContext = context === 'organization';
 
@@ -476,6 +488,8 @@ export function UsageAnalyticsDashboard({
       granularity={granularity}
       onGranularityChange={(v: Granularity) => setState({ granularity: v })}
       granularityOptions={granularityOptions}
+      costSource={costSource}
+      onCostSourceChange={(v: CostSource) => setState({ costSource: v })}
       chartMetric={chartMetric}
       onChartMetricChange={(v: MetricKey) => setState({ chartMetric: v })}
       metricOptions={METRIC_OPTIONS}
@@ -531,6 +545,7 @@ export function UsageAnalyticsDashboard({
             <SummarySection
               summary={summary}
               loading={summaryLoading}
+              costSource={costSource}
               showActiveUsers={isOrgWideView}
             />
 
@@ -574,6 +589,7 @@ export function UsageAnalyticsDashboard({
               <CardContent>
                 <PrimaryChart
                   metric={chartMetric}
+                  costSource={costSource}
                   data={timeseries}
                   loading={timeseriesLoading}
                   splitByLabel={

--- a/apps/web/src/components/usage-analytics/UsageAnalyticsSidebar.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsSidebar.tsx
@@ -12,10 +12,12 @@ import {
 import { X } from 'lucide-react';
 import { FilterGeneratorPopover } from './FilterGeneratorPopover';
 import {
+  COST_SOURCE_LABELS,
   DIMENSION_LABELS,
   GRANULARITY_LABELS,
-  METRIC_LABELS,
   PERIOD_LABELS,
+  metricLabelForCostSource,
+  type CostSource,
   type Dimension,
   type FilterDirection,
   type Granularity,
@@ -90,6 +92,10 @@ type UsageAnalyticsSidebarProps = {
   onGranularityChange: (value: Granularity) => void;
   granularityOptions: Granularity[];
 
+  // Cost source
+  costSource: CostSource;
+  onCostSourceChange: (value: CostSource) => void;
+
   // Trends controls
   chartMetric: MetricKey;
   onChartMetricChange: (value: MetricKey) => void;
@@ -124,6 +130,8 @@ export function UsageAnalyticsSidebar({
   granularity,
   onGranularityChange,
   granularityOptions,
+  costSource,
+  onCostSourceChange,
   chartMetric,
   onChartMetricChange,
   metricOptions,
@@ -230,6 +238,21 @@ export function UsageAnalyticsSidebar({
           </Select>
         </Section>
 
+        <Section title="Cost">
+          <Select value={costSource} onValueChange={v => onCostSourceChange(v as CostSource)}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(COST_SOURCE_LABELS) as CostSource[]).map(source => (
+                <SelectItem key={source} value={source}>
+                  {COST_SOURCE_LABELS[source]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Section>
+
         <Section title="View">
           <div className="flex flex-col gap-2">
             <LabeledRow label="Metric">
@@ -240,7 +263,7 @@ export function UsageAnalyticsSidebar({
                 <SelectContent>
                   {metricOptions.map(o => (
                     <SelectItem key={o} value={o}>
-                      {METRIC_LABELS[o]}
+                      {metricLabelForCostSource(o, costSource)}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -289,6 +312,7 @@ export function UsageAnalyticsSidebar({
               onAdd={onAddFilter}
               labelForDimensionValue={labelForDimensionValue}
               metric="cost"
+              costSource={costSource}
               granularity={granularity}
             />
             {activeFilters.length === 0 ? (

--- a/apps/web/src/components/usage-analytics/csvExport.test.ts
+++ b/apps/web/src/components/usage-analytics/csvExport.test.ts
@@ -1,0 +1,78 @@
+jest.mock('@/lib/admin-csv', () => ({
+  csvField: (value: string) => value,
+  downloadCsv: jest.fn(),
+}));
+
+import { downloadCsv } from '@/lib/admin-csv';
+import { exportUsageTableToCsv } from './csvExport';
+import { metricLabelForCostSource, parseCostSource, type Dimension } from './types';
+
+const rows = [
+  {
+    datetime: '2026-06-04',
+    dimensions: {},
+    costMicrodollars: 1_500_000,
+    requestCount: 2,
+    inputTokens: 3,
+    outputTokens: 4,
+    cacheWriteTokens: 0,
+    cacheHitTokens: 0,
+    errorCount: 0,
+  },
+];
+
+const labelForDimensionValue = (_dimension: Dimension, value: string) => value;
+
+describe('usage analytics cost labels', () => {
+  it('parses URL values with a billable cost fallback', () => {
+    expect(parseCostSource('market')).toBe('market');
+    expect(parseCostSource(null)).toBe('cost');
+    expect(parseCostSource('invalid')).toBe('cost');
+  });
+
+  it('labels selected market cost metrics explicitly', () => {
+    expect(metricLabelForCostSource('cost', 'market')).toBe('Estimated Market Cost');
+    expect(metricLabelForCostSource('costPerRequest', 'market')).toBe(
+      'Estimated Market Cost / Request'
+    );
+    expect(metricLabelForCostSource('tokens', 'market')).toBe('Tokens');
+  });
+});
+
+describe('exportUsageTableToCsv', () => {
+  beforeEach(() => {
+    jest.mocked(downloadCsv).mockClear();
+  });
+
+  it('labels billable cost exports as cost', () => {
+    exportUsageTableToCsv({
+      rows,
+      groupBy: [],
+      granularity: 'day',
+      period: 'today',
+      costSource: 'cost',
+      labelForDimensionValue,
+    });
+
+    expect(downloadCsv).toHaveBeenCalledWith(
+      expect.stringContaining('Cost (USD)'),
+      expect.any(String)
+    );
+  });
+
+  it('labels market cost exports as estimated market cost', () => {
+    exportUsageTableToCsv({
+      rows,
+      groupBy: [],
+      granularity: 'day',
+      period: 'today',
+      costSource: 'market',
+      labelForDimensionValue,
+    });
+
+    expect(downloadCsv).toHaveBeenCalledWith(
+      expect.stringContaining('Estimated Market Cost (USD)'),
+      expect.any(String)
+    );
+  });
+});

--- a/apps/web/src/components/usage-analytics/csvExport.ts
+++ b/apps/web/src/components/usage-analytics/csvExport.ts
@@ -1,6 +1,7 @@
 import { csvField, downloadCsv } from '@/lib/admin-csv';
 import {
   DIMENSION_LABELS,
+  type CostSource,
   type Dimension,
   type Granularity,
   type PeriodOption,
@@ -61,6 +62,7 @@ type ExportArgs = {
   groupBy: Dimension[];
   granularity: Granularity;
   period: PeriodOption;
+  costSource: CostSource;
   labelForDimensionValue: (dim: Dimension, value: string) => string;
 };
 
@@ -76,6 +78,7 @@ export function exportUsageTableToCsv({
   groupBy,
   granularity,
   period,
+  costSource,
   labelForDimensionValue,
 }: ExportArgs): void {
   if (rows.length === 0) return;
@@ -83,7 +86,7 @@ export function exportUsageTableToCsv({
   const headers = [
     datetimeHeaderFor(granularity),
     ...groupBy.map(d => DIMENSION_LABELS[d]),
-    'Cost (USD)',
+    costSource === 'market' ? 'Estimated Market Cost (USD)' : 'Cost (USD)',
     'Requests',
     'Input Tokens',
     'Output Tokens',

--- a/apps/web/src/components/usage-analytics/hooks.ts
+++ b/apps/web/src/components/usage-analytics/hooks.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { skipToken, useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
-import type { Dimension, Granularity, MetricKey, PeriodOption } from './types';
+import type { CostSource, Dimension, Granularity, MetricKey, PeriodOption } from './types';
 
 export type DateRange = {
   startDate: string; // ISO
@@ -121,6 +121,7 @@ type CommonArgs = {
   organizationId: string | null;
   dateRange: DateRange;
   granularity: Granularity;
+  costSource: CostSource;
   filters: UsageFilters;
   /** Personal-context narrowing; ignored when `organizationId` is set. */
   personalScope?: PersonalScope;
@@ -151,6 +152,7 @@ function commonFilters(args: CommonArgs) {
     startDate: args.dateRange.startDate,
     endDate: args.dateRange.endDate,
     granularity: args.granularity,
+    costSource: args.costSource,
     organizationId: args.organizationId ?? undefined,
     personalScope: args.personalScope ?? 'personal-only',
     viewAs: args.viewAs ?? 'self',

--- a/apps/web/src/components/usage-analytics/types.ts
+++ b/apps/web/src/components/usage-analytics/types.ts
@@ -5,6 +5,8 @@ export type PeriodOption = 'today' | 'yesterday' | '7d' | '30d' | '1y';
 
 export type Granularity = 'hour' | 'day' | 'week' | 'month';
 
+export type CostSource = 'cost' | 'market';
+
 export type Dimension = 'feature' | 'model' | 'mode' | 'user' | 'provider' | 'project';
 
 export type MetricKey =
@@ -63,6 +65,18 @@ export const GRANULARITY_LABELS: Record<Granularity, string> = {
   month: 'Month',
 };
 
+export const COST_SOURCE_LABELS: Record<CostSource, string> = {
+  cost: 'Cost',
+  market: 'Estimated Market Cost',
+};
+
+export function parseCostSource(
+  value: string | null | undefined,
+  fallback: CostSource = 'cost'
+): CostSource {
+  return value === 'cost' || value === 'market' ? value : fallback;
+}
+
 export const METRIC_LABELS: Record<MetricKey, string> = {
   cost: 'Cost',
   requests: 'Requests',
@@ -77,3 +91,11 @@ export const METRIC_LABELS: Record<MetricKey, string> = {
   cacheHitRatio: 'Cache Hit Ratio',
   outputInputRatio: 'Output / Input Ratio',
 };
+
+export function metricLabelForCostSource(metric: MetricKey, costSource: CostSource): string {
+  if (costSource === 'market') {
+    if (metric === 'cost') return 'Estimated Market Cost';
+    if (metric === 'costPerRequest') return 'Estimated Market Cost / Request';
+  }
+  return METRIC_LABELS[metric];
+}

--- a/apps/web/src/components/usage-analytics/useUsageDashboardState.ts
+++ b/apps/web/src/components/usage-analytics/useUsageDashboardState.ts
@@ -1,12 +1,20 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import type { PeriodOption, Granularity, MetricKey, Dimension } from './types';
+import {
+  parseCostSource,
+  type CostSource,
+  type PeriodOption,
+  type Granularity,
+  type MetricKey,
+  type Dimension,
+} from './types';
 import type { UsageFilters } from './hooks';
 import { EMPTY_FILTERS } from './hooks';
 
 export type DashboardState = {
   period: PeriodOption;
   granularity: Granularity;
+  costSource: CostSource;
   chartMetric: MetricKey;
   filters: UsageFilters;
   groupBy: Dimension | 'none';
@@ -173,6 +181,8 @@ export function useUsageDashboardState(defaultState?: Partial<DashboardState>): 
       ? (params.get('granularity') as Granularity)
       : (defaultState?.granularity ?? ('hour' as Granularity));
 
+    const costSource = parseCostSource(params.get('costSource'), defaultState?.costSource);
+
     const chartMetric = isValidMetricKey(params.get('metric') ?? '')
       ? (params.get('metric') as MetricKey)
       : (defaultState?.chartMetric ?? ('cost' as MetricKey));
@@ -191,7 +201,7 @@ export function useUsageDashboardState(defaultState?: Partial<DashboardState>): 
 
     const filters = deserializeFiltersFromParams(params);
 
-    return { period, granularity, chartMetric, filters, groupBy, personalView, viewAs };
+    return { period, granularity, costSource, chartMetric, filters, groupBy, personalView, viewAs };
   });
 
   const isInitialized = useRef(false);
@@ -219,6 +229,7 @@ export function useUsageDashboardState(defaultState?: Partial<DashboardState>): 
       const granularity = VALID_GRANULARITIES.includes(params.get('granularity') as Granularity)
         ? (params.get('granularity') as Granularity)
         : state.granularity;
+      const costSource = parseCostSource(params.get('costSource'));
       const chartMetric = isValidMetricKey(params.get('metric') ?? '')
         ? (params.get('metric') as MetricKey)
         : state.chartMetric;
@@ -235,6 +246,7 @@ export function useUsageDashboardState(defaultState?: Partial<DashboardState>): 
       setStateInternal({
         period,
         granularity,
+        costSource,
         chartMetric,
         filters,
         groupBy,
@@ -254,6 +266,7 @@ export function useUsageDashboardState(defaultState?: Partial<DashboardState>): 
   }, [
     state.period,
     state.granularity,
+    state.costSource,
     state.chartMetric,
     state.groupBy,
     state.personalView,
@@ -279,6 +292,12 @@ export function useUsageDashboardState(defaultState?: Partial<DashboardState>): 
     params.set('granularity', state.granularity);
     params.set('metric', state.chartMetric);
     params.set('group', state.groupBy);
+
+    if (state.costSource === 'market') {
+      params.set('costSource', state.costSource);
+    } else {
+      params.delete('costSource');
+    }
 
     if (state.personalView && state.personalView !== 'personal-only') {
       params.set('personalView', state.personalView);

--- a/apps/web/src/routers/usage-analytics-router.test.ts
+++ b/apps/web/src/routers/usage-analytics-router.test.ts
@@ -1,0 +1,36 @@
+jest.mock('@/lib/redis', () => ({ redisClient: {} }));
+
+import {
+  CostSourceSchema,
+  UsageAnalyticsFiltersSchema,
+  costColumnFor,
+  costSumExprSql,
+} from './usage-analytics-router';
+
+const baseFilters = {
+  startDate: '2026-06-04T00:00:00.000Z',
+  endDate: '2026-06-05T00:00:00.000Z',
+  granularity: 'day' as const,
+};
+
+describe('usage analytics cost source', () => {
+  it('defaults to billable cost for existing clients', () => {
+    expect(UsageAnalyticsFiltersSchema.parse(baseFilters).costSource).toBe('cost');
+    expect(costColumnFor('cost')).toBe('total_cost_microdollars');
+    expect(costSumExprSql('cost')).toBe('COALESCE(SUM(total_cost_microdollars), 0)');
+  });
+
+  it('uses the estimated market cost rollup when selected', () => {
+    expect(
+      UsageAnalyticsFiltersSchema.parse({ ...baseFilters, costSource: 'market' }).costSource
+    ).toBe('market');
+    expect(costColumnFor('market')).toBe('total_market_cost_microdollars');
+    expect(costSumExprSql('market')).toBe('COALESCE(SUM(total_market_cost_microdollars), 0)');
+  });
+
+  it('rejects arbitrary cost source values', () => {
+    expect(
+      CostSourceSchema.safeParse('total_cost_microdollars); DROP TABLE usage; --').success
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/routers/usage-analytics-router.ts
+++ b/apps/web/src/routers/usage-analytics-router.ts
@@ -16,6 +16,9 @@ import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 export const GranularitySchema = z.enum(['hour', 'day', 'week', 'month']);
 export type Granularity = z.infer<typeof GranularitySchema>;
 
+export const CostSourceSchema = z.enum(['cost', 'market']);
+export type CostSource = z.infer<typeof CostSourceSchema>;
+
 export const DimensionSchema = z.enum(['feature', 'model', 'mode', 'user', 'provider', 'project']);
 export type Dimension = z.infer<typeof DimensionSchema>;
 
@@ -39,6 +42,7 @@ const FiltersShape = {
   startDate: z.iso.datetime(),
   endDate: z.iso.datetime(),
   granularity: GranularitySchema,
+  costSource: CostSourceSchema.default('cost'),
   organizationId: z.uuid().optional(),
   /**
    * Personal-scope narrowing:
@@ -68,7 +72,7 @@ const FiltersShape = {
   excludedProjects: z.array(z.string()).optional(),
 } as const;
 
-const UsageAnalyticsFiltersSchema = z.object(FiltersShape);
+export const UsageAnalyticsFiltersSchema = z.object(FiltersShape);
 export type UsageAnalyticsFilters = z.infer<typeof UsageAnalyticsFiltersSchema>;
 
 // ---------------------------------------------------------------------------
@@ -341,10 +345,24 @@ function buildWhereClause(
 // Metric SQL expression
 // ---------------------------------------------------------------------------
 
-function metricExprSql(metric: Metric, tier: GranularityTier): string {
+export function costColumnFor(costSource: CostSource): string {
+  switch (costSource) {
+    case 'cost':
+      return 'total_cost_microdollars';
+    case 'market':
+      return 'total_market_cost_microdollars';
+  }
+}
+
+export function costSumExprSql(costSource: CostSource): string {
+  return `COALESCE(SUM(${costColumnFor(costSource)}), 0)`;
+}
+
+function metricExprSql(metric: Metric, tier: GranularityTier, costSource: CostSource): string {
+  const costSumExpr = costSumExprSql(costSource);
   switch (metric) {
     case 'cost':
-      return 'COALESCE(SUM(total_cost_microdollars), 0)';
+      return costSumExpr;
     case 'requests':
       return 'COALESCE(SUM(request_count), 0)';
     case 'inputTokens':
@@ -362,7 +380,7 @@ function metricExprSql(metric: Metric, tier: GranularityTier): string {
       return `CASE WHEN COALESCE(SUM(${countExpr}), 0) = 0 THEN 0 ELSE COALESCE(SUM(total_generation_time_ms), 0)::FLOAT / SUM(${countExpr})::FLOAT END`;
     }
     case 'costPerRequest':
-      return 'CASE WHEN COALESCE(SUM(request_count), 0) = 0 THEN 0 ELSE COALESCE(SUM(total_cost_microdollars), 0)::FLOAT / SUM(request_count)::FLOAT END';
+      return `CASE WHEN COALESCE(SUM(request_count), 0) = 0 THEN 0 ELSE ${costSumExpr}::FLOAT / SUM(request_count)::FLOAT END`;
     case 'tokensPerRequest':
       return 'CASE WHEN COALESCE(SUM(request_count), 0) = 0 THEN 0 ELSE COALESCE(SUM(total_tokens), 0)::FLOAT / SUM(request_count)::FLOAT END';
     case 'cacheHitRatio':
@@ -729,10 +747,11 @@ export const usageAnalyticsRouter = createTRPCRouter({
       const table = getTableName(meta.tier);
       const where = buildWhereClause(meta.tier, input, ctx.user.id, true);
       const generationTimeCountExpr = generationTimeCountExprSql(meta.tier);
+      const costSumExpr = costSumExprSql(input.costSource);
 
       const statement = `
         SELECT
-          COALESCE(SUM(total_cost_microdollars), 0),
+          ${costSumExpr},
           COALESCE(SUM(request_count), 0),
           COALESCE(SUM(total_input_tokens), 0),
           COALESCE(SUM(total_output_tokens), 0),
@@ -831,7 +850,7 @@ export const usageAnalyticsRouter = createTRPCRouter({
       }
       const table = getTableName(meta.tier);
       const bucketExpr = bucketExprSql(meta.effectiveGranularity, meta.tier);
-      const metricExpr = metricExprSql(input.metric, meta.tier);
+      const metricExpr = metricExprSql(input.metric, meta.tier, input.costSource);
       const where = buildWhereClause(meta.tier, input, ctx.user.id, true);
 
       let statement: string;
@@ -901,7 +920,7 @@ export const usageAnalyticsRouter = createTRPCRouter({
       }
       const table = getTableName(meta.tier);
       const dimCol = dimensionColumn(input.dimension);
-      const metricExpr = metricExprSql(input.metric, meta.tier);
+      const metricExpr = metricExprSql(input.metric, meta.tier, input.costSource);
       const where = buildWhereClause(meta.tier, input, ctx.user.id, true);
 
       const statement = `
@@ -969,6 +988,7 @@ export const usageAnalyticsRouter = createTRPCRouter({
       const table = getTableName(meta.tier);
       const bucketExpr = bucketExprSql(meta.effectiveGranularity, meta.tier);
       const where = buildWhereClause(meta.tier, input, ctx.user.id, true);
+      const costSumExpr = costSumExprSql(input.costSource);
 
       const requestedDims = input.groupBy;
 
@@ -996,7 +1016,7 @@ export const usageAnalyticsRouter = createTRPCRouter({
           ${userExpr} AS dim_user,
           ${providerExpr} AS dim_provider,
           ${projectExpr} AS dim_project,
-          COALESCE(SUM(total_cost_microdollars), 0),
+          ${costSumExpr},
           COALESCE(SUM(request_count), 0),
           COALESCE(SUM(total_input_tokens), 0),
           COALESCE(SUM(total_output_tokens), 0),


### PR DESCRIPTION
## Summary
- Add a Cost selector below Granularity on the usage analytics dashboard with billable Cost and Estimated Market Cost options.
- Persist the selected source in the URL and propagate it through summary, trends, breakdowns, filter suggestions, detailed tables, and CSV exports.
- Map the validated selector to the Snowflake rollup columns server-side so market mode reads `total_market_cost_microdollars` without accepting arbitrary SQL column names.

## Verification
- Open `/usage` and confirm Filters & Controls shows Cost directly below Granularity.
- Select Estimated Market Cost and confirm the URL includes `costSource=market`, cost labels update, and dashboard values switch to market-cost totals.
- Download the detailed CSV in both modes and confirm the cost header matches the selected source.

## Visual Changes
N/A - the existing usage sidebar gains one selector using the current control style.