### PR TITLE
fix(session-ingest): batch queue item ingestion

### DIFF
--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -246,6 +246,256 @@ describe('queue', () => {
     expect(ack).toHaveBeenCalledTimes(1);
     expect(retry).not.toHaveBeenCalled();
   });
+
+  it('batches all items in a message into a single DO ingest call', async () => {
+    const ingest = vi.fn(async () => ({ changes: [] }));
+    vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
+    const limit = vi.fn(async () => [{ session_id: 'ses_batch' }]);
+    const where = vi.fn(() => ({ limit }));
+    const from = vi.fn(() => ({ where }));
+    vi.mocked(getWorkerDb).mockReturnValue({ select: vi.fn(() => ({ from })) } as never);
+
+    const items = [
+      { type: 'session', data: { title: 'Hello' } },
+      { type: 'message', data: { id: 'msg_1' } },
+      { type: 'part', data: { id: 'part_1', messageID: 'msg_1' } },
+    ];
+    const body = JSON.stringify({ data: items });
+    const deleteObject = vi.fn(async () => undefined);
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://unused' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => new Response(body)),
+        put: vi.fn(async () => undefined),
+        delete: deleteObject,
+      },
+    } as never;
+    const ack = vi.fn();
+    const retry = vi.fn();
+
+    await queue(
+      {
+        messages: [
+          {
+            body: {
+              r2Key: 'staging/batch',
+              kiloUserId: 'usr_batch',
+              sessionId: 'ses_batch',
+              ingestVersion: 1,
+              ingestedAt: 789,
+            },
+            ack,
+            retry,
+          },
+        ],
+      } as never,
+      env,
+      { waitUntil: vi.fn() } as unknown as ExecutionContext
+    );
+
+    expect(ingest).toHaveBeenCalledTimes(1);
+    expect(ingest).toHaveBeenCalledWith(items, 'usr_batch', 'ses_batch', 1, 789, undefined);
+    expect(deleteObject).toHaveBeenCalledWith('staging/batch');
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it('splits a message past the chunk cap into ordered DO ingest calls', async () => {
+    // 129 items exceed INGEST_CHUNK_MAX_ITEMS (128) -> two chunks: 128 then 1.
+    // Both chunks must commit in order; non-empty changes trigger the final metadata flush.
+    const ingest = vi.fn(async (items: unknown[]) =>
+      items.length === 128
+        ? { changes: [{ name: 'title', value: 'Hello' }] }
+        : { changes: [{ name: 'gitBranch', value: 'main' }] }
+    );
+    vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
+
+    const transaction = vi.fn(async () => null);
+    const limit = vi.fn(async () => [{ session_id: 'ses_split' }]);
+    const where = vi.fn(() => ({ limit }));
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+    vi.mocked(getWorkerDb).mockReturnValue({ select, transaction } as never);
+
+    const items = Array.from({ length: 129 }, (_, i) => ({
+      type: 'message',
+      data: { id: `msg_${i}` },
+    }));
+    const body = JSON.stringify({ data: items });
+    const deleteObject = vi.fn(async () => undefined);
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://unused' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => new Response(body)),
+        put: vi.fn(async () => undefined),
+        delete: deleteObject,
+      },
+    } as never;
+    const ack = vi.fn();
+    const retry = vi.fn();
+
+    await queue(
+      {
+        messages: [
+          {
+            body: {
+              r2Key: 'staging/split',
+              kiloUserId: 'usr_split',
+              sessionId: 'ses_split',
+              ingestVersion: 1,
+              ingestedAt: 1,
+            },
+            ack,
+            retry,
+          },
+        ],
+      } as never,
+      env,
+      { waitUntil: vi.fn() } as unknown as ExecutionContext
+    );
+
+    expect(ingest).toHaveBeenCalledTimes(2);
+    expect(ingest).toHaveBeenNthCalledWith(
+      1,
+      items.slice(0, 128),
+      'usr_split',
+      'ses_split',
+      1,
+      1,
+      undefined
+    );
+    expect(ingest).toHaveBeenNthCalledWith(
+      2,
+      items.slice(128),
+      'usr_split',
+      'ses_split',
+      1,
+      1,
+      undefined
+    );
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(deleteObject).toHaveBeenCalledWith('staging/split');
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it('retries the message when DO ingest fails instead of dropping items', async () => {
+    const ingest = vi.fn(async () => {
+      throw new Error('Durable Object is overloaded.');
+    });
+    vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
+    const limit = vi.fn(async () => [{ session_id: 'ses_overload' }]);
+    const where = vi.fn(() => ({ limit }));
+    const from = vi.fn(() => ({ where }));
+    vi.mocked(getWorkerDb).mockReturnValue({ select: vi.fn(() => ({ from })) } as never);
+
+    const body = JSON.stringify({ data: [{ type: 'message', data: { id: 'msg_1' } }] });
+    const deleteObject = vi.fn(async () => undefined);
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://unused' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => new Response(body)),
+        put: vi.fn(async () => undefined),
+        delete: deleteObject,
+      },
+    } as never;
+    const ack = vi.fn();
+    const retry = vi.fn();
+
+    await queue(
+      {
+        messages: [
+          {
+            body: {
+              r2Key: 'staging/overload',
+              kiloUserId: 'usr_overload',
+              sessionId: 'ses_overload',
+              ingestVersion: 1,
+              ingestedAt: 1,
+            },
+            ack,
+            retry,
+          },
+        ],
+      } as never,
+      env,
+      { waitUntil: vi.fn() } as unknown as ExecutionContext
+    );
+
+    expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
+    expect(ack).not.toHaveBeenCalled();
+    expect(deleteObject).not.toHaveBeenCalled();
+  });
+
+  it('flushes already-committed metadata changes when a later chunk fails', async () => {
+    // First chunk (128 items) commits and reports a metadata change; the second
+    // chunk's ingest fails. The committed change must reach Postgres before the
+    // message is retried — on reprocessing the DO won't re-emit it (its stored
+    // value already matches), so it would otherwise be lost.
+    let ingestCalls = 0;
+    const ingest = vi.fn(async () => {
+      ingestCalls += 1;
+      if (ingestCalls === 1) return { changes: [{ name: 'title', value: 'Hello' }] };
+      throw new Error('Durable Object is overloaded.');
+    });
+    vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
+
+    // db.select powers the session-exists guard; db.transaction is the metadata flush.
+    const transaction = vi.fn(async () => null);
+    const limit = vi.fn(async () => [{ session_id: 'ses_partial' }]);
+    const where = vi.fn(() => ({ limit }));
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+    vi.mocked(getWorkerDb).mockReturnValue({ select, transaction } as never);
+
+    // 129 items -> chunk 1 = 128 items (flush succeeds), chunk 2 = 1 item (flush throws).
+    const items = Array.from({ length: 129 }, (_, i) => ({
+      type: 'message',
+      data: { id: `msg_${i}` },
+    }));
+    const body = JSON.stringify({ data: items });
+    const deleteObject = vi.fn(async () => undefined);
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://unused' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => new Response(body)),
+        put: vi.fn(async () => undefined),
+        delete: deleteObject,
+      },
+    } as never;
+    const ack = vi.fn();
+    const retry = vi.fn();
+
+    await queue(
+      {
+        messages: [
+          {
+            body: {
+              r2Key: 'staging/partial',
+              kiloUserId: 'usr_partial',
+              sessionId: 'ses_partial',
+              ingestVersion: 1,
+              ingestedAt: 1,
+            },
+            ack,
+            retry,
+          },
+        ],
+      } as never,
+      env,
+      { waitUntil: vi.fn() } as unknown as ExecutionContext
+    );
+
+    // First chunk carried the full 128 items and committed.
+    const firstChunkItems = (ingest.mock.calls[0] as unknown[])[0];
+    expect(firstChunkItems).toHaveLength(128);
+    // Its metadata change was flushed to Postgres despite the later failure.
+    expect(transaction).toHaveBeenCalledTimes(1);
+    // The message is retried and the staging object is preserved for reprocessing.
+    expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
+    expect(ack).not.toHaveBeenCalled();
+    expect(deleteObject).not.toHaveBeenCalled();
+  });
 });
 
 describe('computeSessionMetadataUpdates', () => {

--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -427,6 +427,57 @@ describe('queue', () => {
     expect(deleteObject).not.toHaveBeenCalled();
   });
 
+  it('does not flush buffered items when malformed JSON forces a retry', async () => {
+    const ingest = vi.fn(async () => ({ changes: [] }));
+    vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
+
+    const transaction = vi.fn(async () => null);
+    const limit = vi.fn(async () => [{ session_id: 'ses_malformed' }]);
+    const where = vi.fn(() => ({ limit }));
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+    vi.mocked(getWorkerDb).mockReturnValue({ select, transaction } as never);
+
+    const body = '{"data":[{"type":"message","data":{"id":"msg_1"}},broken';
+    const deleteObject = vi.fn(async () => undefined);
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://unused' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => new Response(body)),
+        put: vi.fn(async () => undefined),
+        delete: deleteObject,
+      },
+    } as never;
+    const ack = vi.fn();
+    const retry = vi.fn();
+
+    await queue(
+      {
+        messages: [
+          {
+            body: {
+              r2Key: 'staging/malformed',
+              kiloUserId: 'usr_malformed',
+              sessionId: 'ses_malformed',
+              ingestVersion: 1,
+              ingestedAt: 1,
+            },
+            ack,
+            retry,
+          },
+        ],
+      } as never,
+      env,
+      { waitUntil: vi.fn() } as unknown as ExecutionContext
+    );
+
+    expect(ingest).not.toHaveBeenCalled();
+    expect(transaction).not.toHaveBeenCalled();
+    expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
+    expect(ack).not.toHaveBeenCalled();
+    expect(deleteObject).not.toHaveBeenCalled();
+  });
+
   it('flushes already-committed metadata changes when a later chunk fails', async () => {
     // First chunk (128 items) commits and reports a metadata change; the second
     // chunk's ingest fails. The committed change must reach Postgres before the

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -4,7 +4,7 @@ import { cli_sessions_v2 } from '@kilocode/db/schema';
 import { Tokenizer, TokenParser, TokenType } from '@streamparser/json';
 
 import type { Env } from './env';
-import { SessionItemSchema } from './types/session-sync';
+import { SessionItemSchema, type SessionDataItem } from './types/session-sync';
 import { getItemIdentity } from './util/compaction';
 import { MAX_INGEST_ITEM_BYTES, MAX_SINGLE_ITEM_BYTES } from './util/ingest-limits';
 import { getSessionIngestDO } from './dos/SessionIngestDO';
@@ -21,6 +21,14 @@ export interface IngestQueueMessage {
 }
 
 export const QUEUE_RETRY_DELAY_SECONDS = 5 * 60;
+
+// A queue message is an envelope for one POST's R2 payload for one session.
+// That payload can contain many session items. Batch those items into chunked
+// ingest() RPCs to that session's DO instead of one RPC per item. Prod snapshot
+// (2026-06-03): p99 is ~13 items / ~1.7 MiB, so ~99% fit in one chunk; only
+// ~0.3% (>4 MiB) split. These caps bound memory and RPC size.
+const INGEST_CHUNK_MAX_BYTES = 4 * 1024 * 1024;
+const INGEST_CHUNK_MAX_ITEMS = 128;
 
 /**
  * Creates a streaming item extractor that uses a low-level Tokenizer to parse
@@ -157,7 +165,50 @@ async function processMessage(
   msg: IngestQueueMessage,
   ctx: ExecutionContext
 ): Promise<void> {
-  const { r2Key, kiloUserId, sessionId, ingestVersion, ingestedAt } = msg;
+  if (await deleteStagingObjectIfSessionMissing(env, msg)) return;
+
+  const body = await getStagingObjectBody(env, msg.r2Key);
+  const mergedChanges = new Map<string, string | null>();
+
+  try {
+    await ingestStagedSessionItems(env, msg, body, mergedChanges);
+  } catch (err) {
+    // An earlier chunk may have committed to the DO before a later chunk (or the
+    // JSON parse) failed. The DO reports a metadata change only when its stored
+    // value differs, so on retry those already-persisted values won't be
+    // re-emitted — Postgres would never catch up. Flush what we have now so the
+    // two stores stay in sync. Best-effort: never mask the original error.
+    await flushPartialMetadataChanges(env, msg, mergedChanges, ctx);
+    throw err;
+  }
+
+  await applyMetadataChanges(env, msg.kiloUserId, msg.sessionId, mergedChanges, ctx);
+  await env.SESSION_INGEST_R2.delete(msg.r2Key);
+}
+
+async function flushPartialMetadataChanges(
+  env: Env,
+  msg: IngestQueueMessage,
+  mergedChanges: Map<string, string | null>,
+  ctx: ExecutionContext
+): Promise<void> {
+  if (mergedChanges.size === 0) return;
+  try {
+    await applyMetadataChanges(env, msg.kiloUserId, msg.sessionId, mergedChanges, ctx);
+  } catch (err) {
+    console.error('Failed to flush partial metadata changes after ingest error', {
+      r2Key: msg.r2Key,
+      sessionId: msg.sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+async function deleteStagingObjectIfSessionMissing(
+  env: Env,
+  msg: IngestQueueMessage
+): Promise<boolean> {
+  const { r2Key, kiloUserId, sessionId } = msg;
 
   // Guard: skip processing if the session has been deleted since this message was queued
   const db = getWorkerDb(env.HYPERDRIVE.connectionString);
@@ -168,22 +219,48 @@ async function processMessage(
       and(eq(cli_sessions_v2.session_id, sessionId), eq(cli_sessions_v2.kilo_user_id, kiloUserId))
     )
     .limit(1);
-  if (!sessionRows[0]) {
-    console.warn('Session no longer exists, cleaning up staging object', { r2Key, sessionId });
-    await env.SESSION_INGEST_R2.delete(r2Key);
-    return;
-  }
 
+  if (sessionRows[0]) return false;
+
+  console.warn('Session no longer exists, cleaning up staging object', { r2Key, sessionId });
+  await env.SESSION_INGEST_R2.delete(r2Key);
+  return true;
+}
+
+async function getStagingObjectBody(env: Env, r2Key: string): Promise<ReadableStream<Uint8Array>> {
   const obj = await env.SESSION_INGEST_R2.get(r2Key);
   if (!obj) {
     throw new Error(`R2 staging object not found: ${r2Key}`);
   }
+  // R2 types the body as ReadableStream<any>; staging objects are always byte streams.
+  return obj.body as ReadableStream<Uint8Array>;
+}
 
-  const mergedChanges = new Map<string, string | null>();
+async function ingestStagedSessionItems(
+  env: Env,
+  msg: IngestQueueMessage,
+  body: ReadableStream<Uint8Array>,
+  mergedChanges: Map<string, string | null>
+): Promise<void> {
+  const chunker = createIngestChunker(env, msg, mergedChanges);
+  const parseError = await streamSessionItems(msg.r2Key, body, rawItem => chunker.stage(rawItem));
+
+  // Handle any remaining items not flushed yet.
+  await chunker.flushChunkToSessionDO();
+
+  if (parseError) {
+    throw new Error(`Malformed JSON in staging object ${msg.r2Key}: ${parseError.message}`);
+  }
+}
+
+async function streamSessionItems(
+  r2Key: string,
+  body: ReadableStream<Uint8Array>,
+  onItem: (rawItem: Record<string, unknown>) => Promise<void>
+): Promise<Error | null> {
   const { tokenizer, pending, getParseError } = createItemExtractor(r2Key);
+  const reader = body.getReader();
 
-  // Feed the R2 body chunk by chunk, processing completed items between reads
-  const reader = obj.body.getReader();
   while (true) {
     const result: ReadableStreamReadResult<Uint8Array> = await reader.read();
     if (result.done) {
@@ -192,88 +269,77 @@ async function processMessage(
       tokenizer.write(result.value);
     }
 
-    // Process any items completed during this chunk
     while (pending.length > 0) {
       const rawItem = pending.shift();
       if (!rawItem) break;
-      try {
-        await processItem(
-          env,
-          rawItem,
-          r2Key,
-          kiloUserId,
-          sessionId,
-          ingestVersion,
-          ingestedAt,
-          mergedChanges
-        );
-      } catch (err) {
-        console.error('Error processing single item in queue consumer, continuing', {
-          r2Key,
-          type: rawItem['type'],
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
+      await onItem(rawItem);
     }
 
     if (result.done) break;
   }
 
-  // If the JSON payload was malformed, throw so the queue message is retried/DLQ'd
-  const parseError = getParseError();
-  if (parseError) {
-    throw new Error(`Malformed JSON in staging object ${r2Key}: ${parseError.message}`);
-  }
-
-  // Update Postgres with metadata changes
-  await applyMetadataChanges(env, kiloUserId, sessionId, mergedChanges, ctx);
-
-  // Delete staging R2 object on success
-  await env.SESSION_INGEST_R2.delete(r2Key);
+  return getParseError();
 }
 
-async function processItem(
+function createIngestChunker(
   env: Env,
-  rawItem: Record<string, unknown>,
-  r2Key: string,
-  kiloUserId: string,
-  sessionId: string,
-  ingestVersion: number,
-  ingestedAt: number,
+  msg: IngestQueueMessage,
   mergedChanges: Map<string, string | null>
-): Promise<void> {
-  // Validate against schema
-  const parsed = SessionItemSchema.safeParse(rawItem);
-  if (!parsed.success) {
-    console.warn('Skipping invalid item in queue consumer', {
-      r2Key,
-      type: rawItem['type'],
-      errors: parsed.error.issues.map(i => i.message),
-    });
-    return;
-  }
+) {
+  const { r2Key, kiloUserId, sessionId, ingestVersion, ingestedAt } = msg;
+  const chunk: SessionDataItem[] = [];
+  let chunkR2References: Record<string, string> = {};
+  let chunkBytes = 0;
 
-  const item = parsed.data;
-  const { item_id } = getItemIdentity(item);
+  const flushChunkToSessionDO = async (): Promise<void> => {
+    if (chunk.length === 0) return;
+    const items = chunk.splice(0);
+    const r2References = Object.keys(chunkR2References).length > 0 ? chunkR2References : undefined;
+    chunkR2References = {};
+    chunkBytes = 0;
 
-  // Check if item data exceeds DO SQLite row limit (use byte length for non-ASCII safety)
-  const itemDataJson = JSON.stringify(item.data);
-  let r2References: Record<string, string> | undefined;
-  if (new TextEncoder().encode(itemDataJson).byteLength > MAX_INGEST_ITEM_BYTES) {
-    const itemR2Key = `items/${kiloUserId}/${sessionId}/${item_id}/${ingestedAt}`;
-    await env.SESSION_INGEST_R2.put(itemR2Key, itemDataJson);
-    r2References = { [item_id]: itemR2Key };
-  }
+    const ingestResult = await withDORetry(
+      () => getSessionIngestDO(env, { kiloUserId, sessionId }),
+      stub => stub.ingest(items, kiloUserId, sessionId, ingestVersion, ingestedAt, r2References),
+      'SessionIngestDO.ingest'
+    );
+    for (const change of ingestResult.changes) {
+      mergedChanges.set(change.name, change.value);
+    }
+  };
 
-  const ingestResult = await withDORetry(
-    () => getSessionIngestDO(env, { kiloUserId, sessionId }),
-    stub => stub.ingest([item], kiloUserId, sessionId, ingestVersion, ingestedAt, r2References),
-    'SessionIngestDO.ingest'
-  );
+  const stage = async (rawItem: Record<string, unknown>): Promise<void> => {
+    const parsed = SessionItemSchema.safeParse(rawItem);
+    if (!parsed.success) {
+      console.warn('Skipping invalid item in queue consumer', {
+        r2Key,
+        type: rawItem['type'],
+        errors: parsed.error.issues.map(i => i.message),
+      });
+      return;
+    }
 
-  for (const change of ingestResult.changes) {
-    mergedChanges.set(change.name, change.value);
-  }
+    const item = parsed.data;
+    const { item_id } = getItemIdentity(item);
+
+    // Offload data above the DO SQLite row limit to R2; the DO stores a
+    // reference and an empty inline blob.
+    const itemDataJson = JSON.stringify(item.data);
+    const itemDataBytes = new TextEncoder().encode(itemDataJson).byteLength;
+    if (itemDataBytes > MAX_INGEST_ITEM_BYTES) {
+      const itemR2Key = `items/${kiloUserId}/${sessionId}/${item_id}/${ingestedAt}`;
+      await env.SESSION_INGEST_R2.put(itemR2Key, itemDataJson);
+      chunkR2References[item_id] = itemR2Key;
+    }
+
+    chunk.push(item);
+    chunkBytes += itemDataBytes;
+    if (chunk.length >= INGEST_CHUNK_MAX_ITEMS || chunkBytes >= INGEST_CHUNK_MAX_BYTES) {
+      await flushChunkToSessionDO();
+    }
+  };
+
+  return { stage, flushChunkToSessionDO };
 }
 
 type SessionMetadataUpdates = Partial<

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -245,12 +245,12 @@ async function ingestStagedSessionItems(
   const chunker = createIngestChunker(env, msg, mergedChanges);
   const parseError = await streamSessionItems(msg.r2Key, body, rawItem => chunker.stage(rawItem));
 
-  // Handle any remaining items not flushed yet.
-  await chunker.flushChunkToSessionDO();
-
   if (parseError) {
     throw new Error(`Malformed JSON in staging object ${msg.r2Key}: ${parseError.message}`);
   }
+
+  // Handle any remaining items not flushed yet.
+  await chunker.flushChunkToSessionDO();
 }
 
 async function streamSessionItems(
@@ -287,6 +287,7 @@ function createIngestChunker(
   mergedChanges: Map<string, string | null>
 ) {
   const { r2Key, kiloUserId, sessionId, ingestVersion, ingestedAt } = msg;
+  const encoder = new TextEncoder();
   const chunk: SessionDataItem[] = [];
   let chunkR2References: Record<string, string> = {};
   let chunkBytes = 0;
@@ -325,7 +326,7 @@ function createIngestChunker(
     // Offload data above the DO SQLite row limit to R2; the DO stores a
     // reference and an empty inline blob.
     const itemDataJson = JSON.stringify(item.data);
-    const itemDataBytes = new TextEncoder().encode(itemDataJson).byteLength;
+    const itemDataBytes = encoder.encode(itemDataJson).byteLength;
     if (itemDataBytes > MAX_INGEST_ITEM_BYTES) {
       const itemR2Key = `items/${kiloUserId}/${sessionId}/${item_id}/${ingestedAt}`;
       await env.SESSION_INGEST_R2.put(itemR2Key, itemDataJson);


### PR DESCRIPTION
## Issue

This is related to the incident that happened on 2026-06-03: https://uptime.betterstack.com/team/t335497/incidents/973558695
The retry delay of 5 minutes that was added helped bring the queue down and seems to be preventing it to go beyond 250k but there's still clearly an issue.

## Summary

This fixes the session-ingest queue consumer so one queued staging payload is ingested as ordered batches instead of one Durable Object RPC per individual item. The previous per-item behavior amplified hot-session load, increased the chance of hammering overloaded DOs, and could continue processing later items after an ingest failure, which risked dropping failed items once the queue message was eventually acknowledged.

The new flow keeps the existing streaming JSON parser, but stages validated session items into bounded chunks before calling `SessionIngestDO.ingest`. Chunks flush when they hit either `128` items or roughly `4 MiB` of inline item data, preserving item order while bounding memory/RPC size. Oversized item data still offloads to R2 before ingest, with all references for the current chunk passed in the same DO call.

Failure handling now treats DO ingest failures as message-level failures: the queue message is retried, the staging object is preserved, and the consumer no longer silently skips a failed item while continuing. If an earlier chunk already committed and emitted metadata changes before a later chunk fails, the consumer best-effort flushes those already-committed metadata changes to Postgres before retrying. This avoids losing metadata updates on retry, since the DO will not re-emit unchanged values after the first chunk has already persisted them.

Test coverage added in `services/session-ingest/src/queue-consumer.test.ts`:

- multi-item queue payloads are sent to the DO in a single `ingest` call when below chunk limits
- payloads above the item cap split into ordered chunked DO calls
- DO ingest failure retries the queue message instead of acknowledging and deleting the R2 staging object
- partial success followed by later chunk failure flushes already-committed metadata changes before retrying

## Verification

Local automated checks run before opening the PR:

- pnpm format
- pnpm --filter cloudflare-session-ingest test -- src/queue-consumer.test.ts passed; Vitest executed the full session-ingest test suite (15 files, 277 tests)
- pnpm --filter cloudflare-session-ingest typecheck passed

## Visual Changes

N/A

## Reviewer Notes

- chunk flush boundaries and ordering semantics
- preserving R2 staging objects on retryable message failure
- partial metadata flush behavior when a later chunk fails after an earlier chunk committed
- whether `4 MiB` / `128` item caps are the right production tradeoff for DO RPC size and hot-session pressure (Currently defined after looking historical data in the logs)