### PR TITLE
fix(o11y): page queue backlog at escalation intervals

### DIFF
--- a/services/o11y/src/alerting/queue-backlog-evaluate.ts
+++ b/services/o11y/src/alerting/queue-backlog-evaluate.ts
@@ -1,4 +1,4 @@
-import { type QueueBacklogMetrics, QUEUE_BACKLOG_THRESHOLDS } from './queue-backlog';
+import type { QueueBacklogMetrics } from './queue-backlog';
 import {
   readQueueBacklogState,
   transitionQueueBacklogState,
@@ -30,22 +30,17 @@ export async function evaluateQueueBacklogAlert(
   const currentState = await readQueueBacklogState(env.O11Y_ALERT_STATE, metrics.queueId);
   const transition = transitionQueueBacklogState(currentState, metrics.backlogCount);
 
-  if (transition.severityToNotify !== null) {
-    const thresholdCount =
-      transition.severityToNotify === 'page'
-        ? QUEUE_BACKLOG_THRESHOLDS.page
-        : QUEUE_BACKLOG_THRESHOLDS.ticket;
-
+  if (transition.alert !== null) {
     await notifyFn(
       {
         alertType: 'queue_backlog',
-        severity: transition.severityToNotify,
+        severity: transition.alert.severity,
         provider: 'cloudflare',
         model: metrics.queueId,
         clientName: 'queues',
         backlogCount: metrics.backlogCount,
         backlogBytes: metrics.backlogBytes,
-        thresholdCount,
+        thresholdCount: transition.alert.thresholdCount,
         oldestMessageTimestamp: metrics.oldestMessageTimestamp,
       },
       env

--- a/services/o11y/src/alerting/queue-backlog-evaluate.ts
+++ b/services/o11y/src/alerting/queue-backlog-evaluate.ts
@@ -1,5 +1,9 @@
 import { type QueueBacklogMetrics, QUEUE_BACKLOG_THRESHOLDS } from './queue-backlog';
-import { evaluateAndUpdateQueueBacklogState } from './queue-backlog-state';
+import {
+  readQueueBacklogState,
+  transitionQueueBacklogState,
+  writeQueueBacklogState,
+} from './queue-backlog-state';
 import { queryQueueBacklog } from './queue-backlog-query';
 import { sendAlertNotification, type AlertPayload } from './notify';
 
@@ -23,29 +27,32 @@ export async function evaluateQueueBacklogAlert(
   notifyFn: NotifyFn = sendAlertNotification
 ): Promise<void> {
   const metrics = await queryFn(env);
+  const currentState = await readQueueBacklogState(env.O11Y_ALERT_STATE, metrics.queueId);
+  const transition = transitionQueueBacklogState(currentState, metrics.backlogCount);
 
-  const severity = await evaluateAndUpdateQueueBacklogState(
-    env.O11Y_ALERT_STATE,
-    metrics.backlogCount
-  );
+  if (transition.severityToNotify !== null) {
+    const thresholdCount =
+      transition.severityToNotify === 'page'
+        ? QUEUE_BACKLOG_THRESHOLDS.page
+        : QUEUE_BACKLOG_THRESHOLDS.ticket;
 
-  if (severity === null) return;
+    await notifyFn(
+      {
+        alertType: 'queue_backlog',
+        severity: transition.severityToNotify,
+        provider: 'cloudflare',
+        model: metrics.queueId,
+        clientName: 'queues',
+        backlogCount: metrics.backlogCount,
+        backlogBytes: metrics.backlogBytes,
+        thresholdCount,
+        oldestMessageTimestamp: metrics.oldestMessageTimestamp,
+      },
+      env
+    );
+  }
 
-  const thresholdCount =
-    severity === 'page' ? QUEUE_BACKLOG_THRESHOLDS.page : QUEUE_BACKLOG_THRESHOLDS.ticket;
-
-  await notifyFn(
-    {
-      alertType: 'queue_backlog',
-      severity,
-      provider: 'cloudflare',
-      model: metrics.queueId,
-      clientName: 'queues',
-      backlogCount: metrics.backlogCount,
-      backlogBytes: metrics.backlogBytes,
-      thresholdCount,
-      oldestMessageTimestamp: metrics.oldestMessageTimestamp,
-    },
-    env
-  );
+  if (transition.stateChanged) {
+    await writeQueueBacklogState(env.O11Y_ALERT_STATE, metrics.queueId, transition.state);
+  }
 }

--- a/services/o11y/src/alerting/queue-backlog-evaluate.ts
+++ b/services/o11y/src/alerting/queue-backlog-evaluate.ts
@@ -1,6 +1,6 @@
-import { evaluateQueueBacklog, type QueueBacklogMetrics } from './queue-backlog';
+import { type QueueBacklogMetrics, QUEUE_BACKLOG_THRESHOLDS } from './queue-backlog';
+import { evaluateAndUpdateQueueBacklogState } from './queue-backlog-state';
 import { queryQueueBacklog } from './queue-backlog-query';
-import { shouldSuppress, recordAlertFired } from './dedup';
 import { sendAlertNotification, type AlertPayload } from './notify';
 
 type QueueBacklogEnv = {
@@ -22,42 +22,30 @@ export async function evaluateQueueBacklogAlert(
   queryFn: QueryFn = queryQueueBacklog,
   notifyFn: NotifyFn = sendAlertNotification
 ): Promise<void> {
-  const alert = evaluateQueueBacklog(await queryFn(env));
-  if (alert === null) return;
+  const metrics = await queryFn(env);
 
-  const provider = 'cloudflare';
-  const clientName = 'queues';
-  const suppressed = await shouldSuppress(
+  const severity = await evaluateAndUpdateQueueBacklogState(
     env.O11Y_ALERT_STATE,
-    alert.severity,
-    'queue_backlog',
-    provider,
-    alert.queueId,
-    clientName
+    metrics.backlogCount
   );
-  if (suppressed) return;
+
+  if (severity === null) return;
+
+  const thresholdCount =
+    severity === 'page' ? QUEUE_BACKLOG_THRESHOLDS.page : QUEUE_BACKLOG_THRESHOLDS.ticket;
 
   await notifyFn(
     {
       alertType: 'queue_backlog',
-      severity: alert.severity,
-      provider,
-      model: alert.queueId,
-      clientName,
-      backlogCount: alert.backlogCount,
-      backlogBytes: alert.backlogBytes,
-      thresholdCount: alert.thresholdCount,
-      oldestMessageTimestamp: alert.oldestMessageTimestamp,
+      severity,
+      provider: 'cloudflare',
+      model: metrics.queueId,
+      clientName: 'queues',
+      backlogCount: metrics.backlogCount,
+      backlogBytes: metrics.backlogBytes,
+      thresholdCount,
+      oldestMessageTimestamp: metrics.oldestMessageTimestamp,
     },
     env
-  );
-
-  await recordAlertFired(
-    env.O11Y_ALERT_STATE,
-    alert.severity,
-    'queue_backlog',
-    provider,
-    alert.queueId,
-    clientName
   );
 }

--- a/services/o11y/src/alerting/queue-backlog-state.ts
+++ b/services/o11y/src/alerting/queue-backlog-state.ts
@@ -1,34 +1,52 @@
 import { z } from 'zod';
 import type { AlertSeverity } from './slo-config';
-import { QUEUE_BACKLOG_THRESHOLDS } from './queue-backlog';
+import { QUEUE_BACKLOG_PAGE_INTERVAL, QUEUE_BACKLOG_THRESHOLDS } from './queue-backlog';
 
 const CONSECUTIVE_BELOW_TO_RESOLVE = 3;
 
+const InactiveTierStateSchema = z.object({
+  active: z.literal(false),
+  consecutiveBelowCount: z.literal(0),
+});
+
+const ActiveTierStateSchema = z.object({
+  active: z.literal(true),
+  consecutiveBelowCount: z
+    .number()
+    .int()
+    .min(0)
+    .max(CONSECUTIVE_BELOW_TO_RESOLVE - 1),
+});
+
 const TierStateSchema = z.discriminatedUnion('active', [
-  z.object({ active: z.literal(false), consecutiveBelowCount: z.literal(0) }),
-  z.object({
-    active: z.literal(true),
-    consecutiveBelowCount: z
+  InactiveTierStateSchema,
+  ActiveTierStateSchema,
+]);
+
+const PageStateSchema = z.discriminatedUnion('active', [
+  InactiveTierStateSchema,
+  ActiveTierStateSchema.extend({
+    nextThresholdCount: z
       .number()
       .int()
-      .min(0)
-      .max(CONSECUTIVE_BELOW_TO_RESOLVE - 1),
+      .min(QUEUE_BACKLOG_THRESHOLDS.page + QUEUE_BACKLOG_PAGE_INTERVAL),
   }),
 ]);
 
 const QueueBacklogStateSchema = z
   .object({
     ticket: TierStateSchema,
-    page: TierStateSchema,
+    page: PageStateSchema,
   })
   .refine(state => !state.page.active || state.ticket.active);
 
 type TierState = z.infer<typeof TierStateSchema>;
+type PageState = z.infer<typeof PageStateSchema>;
 export type QueueBacklogState = z.infer<typeof QueueBacklogStateSchema>;
 
 type QueueBacklogTransition = {
   state: QueueBacklogState;
-  severityToNotify: AlertSeverity | null;
+  alert: { severity: AlertSeverity; thresholdCount: number } | null;
   stateChanged: boolean;
 };
 
@@ -36,14 +54,18 @@ function inactiveTierState(): TierState {
   return { active: false, consecutiveBelowCount: 0 };
 }
 
+function inactivePageState(): PageState {
+  return { active: false, consecutiveBelowCount: 0 };
+}
+
 function inactiveQueueBacklogState(): QueueBacklogState {
   return {
     ticket: inactiveTierState(),
-    page: inactiveTierState(),
+    page: inactivePageState(),
   };
 }
 
-function transitionTier(
+function transitionTicket(
   state: TierState,
   aboveThreshold: boolean
 ): { state: TierState; crossedThreshold: boolean } {
@@ -78,18 +100,74 @@ function transitionTier(
   };
 }
 
+function pageThresholdAtOrBelow(backlogCount: number): number {
+  const intervalsAbovePage = Math.floor(
+    (backlogCount - QUEUE_BACKLOG_THRESHOLDS.page) / QUEUE_BACKLOG_PAGE_INTERVAL
+  );
+  return QUEUE_BACKLOG_THRESHOLDS.page + intervalsAbovePage * QUEUE_BACKLOG_PAGE_INTERVAL;
+}
+
+function activePageState(backlogCount: number): PageState {
+  return {
+    active: true,
+    consecutiveBelowCount: 0,
+    nextThresholdCount: pageThresholdAtOrBelow(backlogCount) + QUEUE_BACKLOG_PAGE_INTERVAL,
+  };
+}
+
+function transitionPage(
+  state: PageState,
+  backlogCount: number
+): { state: PageState; thresholdCount: number | null } {
+  if (backlogCount >= QUEUE_BACKLOG_THRESHOLDS.page) {
+    if (!state.active || backlogCount >= state.nextThresholdCount) {
+      return {
+        state: activePageState(backlogCount),
+        thresholdCount: pageThresholdAtOrBelow(backlogCount),
+      };
+    }
+
+    if (state.consecutiveBelowCount > 0) {
+      return {
+        state: { ...state, consecutiveBelowCount: 0 },
+        thresholdCount: null,
+      };
+    }
+
+    return { state, thresholdCount: null };
+  }
+
+  if (!state.active) return { state, thresholdCount: null };
+
+  const consecutiveBelowCount = state.consecutiveBelowCount + 1;
+  if (consecutiveBelowCount >= CONSECUTIVE_BELOW_TO_RESOLVE) {
+    return { state: inactivePageState(), thresholdCount: null };
+  }
+
+  return {
+    state: { ...state, consecutiveBelowCount },
+    thresholdCount: null,
+  };
+}
+
 export function transitionQueueBacklogState(
   state: QueueBacklogState,
   backlogCount: number
 ): QueueBacklogTransition {
-  const ticket = transitionTier(state.ticket, backlogCount >= QUEUE_BACKLOG_THRESHOLDS.ticket);
-  const page = transitionTier(state.page, backlogCount >= QUEUE_BACKLOG_THRESHOLDS.page);
+  const ticket = transitionTicket(state.ticket, backlogCount >= QUEUE_BACKLOG_THRESHOLDS.ticket);
+  const page = transitionPage(state.page, backlogCount);
   const stateChanged = ticket.state !== state.ticket || page.state !== state.page;
+  let alert: QueueBacklogTransition['alert'] = null;
+
+  if (page.thresholdCount !== null) {
+    alert = { severity: 'page', thresholdCount: page.thresholdCount };
+  } else if (ticket.crossedThreshold) {
+    alert = { severity: 'ticket', thresholdCount: QUEUE_BACKLOG_THRESHOLDS.ticket };
+  }
 
   return {
     state: stateChanged ? { ticket: ticket.state, page: page.state } : state,
-    // A page covers a direct jump across both thresholds; latching ticket avoids a downgrade alert.
-    severityToNotify: page.crossedThreshold ? 'page' : ticket.crossedThreshold ? 'ticket' : null,
+    alert,
     stateChanged,
   };
 }

--- a/services/o11y/src/alerting/queue-backlog-state.ts
+++ b/services/o11y/src/alerting/queue-backlog-state.ts
@@ -1,121 +1,122 @@
-/**
- * Stateful alert tracking for the queue backlog monitor.
- *
- * Each alert tier (page / ticket) has an independent state machine:
- *
- *   - Fires ONCE when the backlog first crosses the tier threshold.
- *   - Resolves (resets) only after CONSECUTIVE_BELOW_TO_RESOLVE consecutive
- *     calls where the backlog is below the tier threshold.
- *   - While the page tier is active, the ticket tier state is frozen — the
- *     page alert already covers the elevated backlog.
- *
- * State is persisted in the O11Y_ALERT_STATE KV namespace so it survives
- * across cron invocations (runs every minute).
- */
-
+import { z } from 'zod';
 import type { AlertSeverity } from './slo-config';
 import { QUEUE_BACKLOG_THRESHOLDS } from './queue-backlog';
 
-// Number of consecutive below-threshold observations required before an
-// active alert is considered resolved and can fire again.
-export const CONSECUTIVE_BELOW_TO_RESOLVE = 3;
+const CONSECUTIVE_BELOW_TO_RESOLVE = 3;
 
-type TierState = {
-  active: boolean;
-  consecutiveBelowCount: number;
+const TierStateSchema = z.discriminatedUnion('active', [
+  z.object({ active: z.literal(false), consecutiveBelowCount: z.literal(0) }),
+  z.object({
+    active: z.literal(true),
+    consecutiveBelowCount: z
+      .number()
+      .int()
+      .min(0)
+      .max(CONSECUTIVE_BELOW_TO_RESOLVE - 1),
+  }),
+]);
+
+const QueueBacklogStateSchema = z
+  .object({
+    ticket: TierStateSchema,
+    page: TierStateSchema,
+  })
+  .refine(state => !state.page.active || state.ticket.active);
+
+type TierState = z.infer<typeof TierStateSchema>;
+export type QueueBacklogState = z.infer<typeof QueueBacklogStateSchema>;
+
+type QueueBacklogTransition = {
+  state: QueueBacklogState;
+  severityToNotify: AlertSeverity | null;
+  stateChanged: boolean;
 };
 
-function stateKey(severity: AlertSeverity): string {
-  return `o11y:qb:state:${severity}`;
+function inactiveTierState(): TierState {
+  return { active: false, consecutiveBelowCount: 0 };
 }
 
-async function readTierState(kv: KVNamespace, severity: AlertSeverity): Promise<TierState> {
-  const raw = await kv.get(stateKey(severity));
-  if (!raw) return { active: false, consecutiveBelowCount: 0 };
-  try {
-    // KV stores trusted internal JSON we wrote ourselves.
-    return JSON.parse(raw) as TierState;
-  } catch {
-    return { active: false, consecutiveBelowCount: 0 };
-  }
+function inactiveQueueBacklogState(): QueueBacklogState {
+  return {
+    ticket: inactiveTierState(),
+    page: inactiveTierState(),
+  };
 }
 
-function writeTierState(kv: KVNamespace, severity: AlertSeverity, state: TierState): Promise<void> {
-  return kv.put(stateKey(severity), JSON.stringify(state));
-}
-
-/**
- * Pure state-transition function for a single alert tier.
- * Returns whether the alert should fire and the new state to persist.
- */
-function evaluateTier(
+function transitionTier(
   state: TierState,
-  isAboveThreshold: boolean,
-): { shouldFire: boolean; newState: TierState } {
-  if (isAboveThreshold) {
-    if (state.active) {
-      // Already alerted — suppress. Reset any accumulated below-count so a
-      // brief dip that doesn't sustain won't erode the resolve counter.
-      return { shouldFire: false, newState: { active: true, consecutiveBelowCount: 0 } };
+  aboveThreshold: boolean
+): { state: TierState; crossedThreshold: boolean } {
+  if (aboveThreshold) {
+    if (!state.active) {
+      return {
+        state: { active: true, consecutiveBelowCount: 0 },
+        crossedThreshold: true,
+      };
     }
-    // First crossing — fire.
-    return { shouldFire: true, newState: { active: true, consecutiveBelowCount: 0 } };
+
+    if (state.consecutiveBelowCount > 0) {
+      return {
+        state: { active: true, consecutiveBelowCount: 0 },
+        crossedThreshold: false,
+      };
+    }
+
+    return { state, crossedThreshold: false };
   }
 
-  // Below threshold.
-  if (!state.active) {
-    return { shouldFire: false, newState: { active: false, consecutiveBelowCount: 0 } };
+  if (!state.active) return { state, crossedThreshold: false };
+
+  const consecutiveBelowCount = state.consecutiveBelowCount + 1;
+  if (consecutiveBelowCount >= CONSECUTIVE_BELOW_TO_RESOLVE) {
+    return { state: inactiveTierState(), crossedThreshold: false };
   }
 
-  const newCount = state.consecutiveBelowCount + 1;
-  if (newCount >= CONSECUTIVE_BELOW_TO_RESOLVE) {
-    // Sustained recovery — clear the alert so it can fire again next time.
-    return { shouldFire: false, newState: { active: false, consecutiveBelowCount: 0 } };
-  }
-  return { shouldFire: false, newState: { active: true, consecutiveBelowCount: newCount } };
+  return {
+    state: { active: true, consecutiveBelowCount },
+    crossedThreshold: false,
+  };
 }
 
-/**
- * Evaluates both alert tiers against the current backlog count,
- * persists updated state, and returns the severity that should fire (or null).
- *
- * Resolution rules:
- *   - Page tier (≥ 250,000 messages) is evaluated first.
- *   - Ticket tier (≥ 100,000 messages) is only updated when page is not
- *     active — the page alert already signals the elevated backlog.
- *   - When page is active, ticket state is frozen until page resolves.
- */
-export async function evaluateAndUpdateQueueBacklogState(
+export function transitionQueueBacklogState(
+  state: QueueBacklogState,
+  backlogCount: number
+): QueueBacklogTransition {
+  const ticket = transitionTier(state.ticket, backlogCount >= QUEUE_BACKLOG_THRESHOLDS.ticket);
+  const page = transitionTier(state.page, backlogCount >= QUEUE_BACKLOG_THRESHOLDS.page);
+  const stateChanged = ticket.state !== state.ticket || page.state !== state.page;
+
+  return {
+    state: stateChanged ? { ticket: ticket.state, page: page.state } : state,
+    // A page covers a direct jump across both thresholds; latching ticket avoids a downgrade alert.
+    severityToNotify: page.crossedThreshold ? 'page' : ticket.crossedThreshold ? 'ticket' : null,
+    stateChanged,
+  };
+}
+
+function stateKey(queueId: string): string {
+  return `o11y:queue_backlog:${queueId}`;
+}
+
+export async function readQueueBacklogState(
   kv: KVNamespace,
-  backlogCount: number,
-): Promise<AlertSeverity | null> {
-  const [pageState, ticketState] = await Promise.all([
-    readTierState(kv, 'page'),
-    readTierState(kv, 'ticket'),
-  ]);
+  queueId: string
+): Promise<QueueBacklogState> {
+  const raw = await kv.get(stateKey(queueId));
+  if (raw === null) return inactiveQueueBacklogState();
 
-  const abovePage = backlogCount >= QUEUE_BACKLOG_THRESHOLDS.page;
-  const aboveTicket = backlogCount >= QUEUE_BACKLOG_THRESHOLDS.ticket;
-
-  const { shouldFire: pageFire, newState: newPageState } = evaluateTier(pageState, abovePage);
-  const pageNowActive = newPageState.active;
-
-  let ticketFire = false;
-  let newTicketState = ticketState; // frozen by default when page is active
-
-  if (!pageNowActive) {
-    const result = evaluateTier(ticketState, aboveTicket);
-    ticketFire = result.shouldFire;
-    newTicketState = result.newState;
+  try {
+    const parsed = QueueBacklogStateSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : inactiveQueueBacklogState();
+  } catch {
+    return inactiveQueueBacklogState();
   }
+}
 
-  const writes: Promise<void>[] = [writeTierState(kv, 'page', newPageState)];
-  if (!pageNowActive) {
-    writes.push(writeTierState(kv, 'ticket', newTicketState));
-  }
-  await Promise.all(writes);
-
-  if (pageFire) return 'page';
-  if (ticketFire) return 'ticket';
-  return null;
+export async function writeQueueBacklogState(
+  kv: KVNamespace,
+  queueId: string,
+  state: QueueBacklogState
+): Promise<void> {
+  await kv.put(stateKey(queueId), JSON.stringify(state));
 }

--- a/services/o11y/src/alerting/queue-backlog-state.ts
+++ b/services/o11y/src/alerting/queue-backlog-state.ts
@@ -1,0 +1,121 @@
+/**
+ * Stateful alert tracking for the queue backlog monitor.
+ *
+ * Each alert tier (page / ticket) has an independent state machine:
+ *
+ *   - Fires ONCE when the backlog first crosses the tier threshold.
+ *   - Resolves (resets) only after CONSECUTIVE_BELOW_TO_RESOLVE consecutive
+ *     calls where the backlog is below the tier threshold.
+ *   - While the page tier is active, the ticket tier state is frozen — the
+ *     page alert already covers the elevated backlog.
+ *
+ * State is persisted in the O11Y_ALERT_STATE KV namespace so it survives
+ * across cron invocations (runs every minute).
+ */
+
+import type { AlertSeverity } from './slo-config';
+import { QUEUE_BACKLOG_THRESHOLDS } from './queue-backlog';
+
+// Number of consecutive below-threshold observations required before an
+// active alert is considered resolved and can fire again.
+export const CONSECUTIVE_BELOW_TO_RESOLVE = 3;
+
+type TierState = {
+  active: boolean;
+  consecutiveBelowCount: number;
+};
+
+function stateKey(severity: AlertSeverity): string {
+  return `o11y:qb:state:${severity}`;
+}
+
+async function readTierState(kv: KVNamespace, severity: AlertSeverity): Promise<TierState> {
+  const raw = await kv.get(stateKey(severity));
+  if (!raw) return { active: false, consecutiveBelowCount: 0 };
+  try {
+    // KV stores trusted internal JSON we wrote ourselves.
+    return JSON.parse(raw) as TierState;
+  } catch {
+    return { active: false, consecutiveBelowCount: 0 };
+  }
+}
+
+function writeTierState(kv: KVNamespace, severity: AlertSeverity, state: TierState): Promise<void> {
+  return kv.put(stateKey(severity), JSON.stringify(state));
+}
+
+/**
+ * Pure state-transition function for a single alert tier.
+ * Returns whether the alert should fire and the new state to persist.
+ */
+function evaluateTier(
+  state: TierState,
+  isAboveThreshold: boolean,
+): { shouldFire: boolean; newState: TierState } {
+  if (isAboveThreshold) {
+    if (state.active) {
+      // Already alerted — suppress. Reset any accumulated below-count so a
+      // brief dip that doesn't sustain won't erode the resolve counter.
+      return { shouldFire: false, newState: { active: true, consecutiveBelowCount: 0 } };
+    }
+    // First crossing — fire.
+    return { shouldFire: true, newState: { active: true, consecutiveBelowCount: 0 } };
+  }
+
+  // Below threshold.
+  if (!state.active) {
+    return { shouldFire: false, newState: { active: false, consecutiveBelowCount: 0 } };
+  }
+
+  const newCount = state.consecutiveBelowCount + 1;
+  if (newCount >= CONSECUTIVE_BELOW_TO_RESOLVE) {
+    // Sustained recovery — clear the alert so it can fire again next time.
+    return { shouldFire: false, newState: { active: false, consecutiveBelowCount: 0 } };
+  }
+  return { shouldFire: false, newState: { active: true, consecutiveBelowCount: newCount } };
+}
+
+/**
+ * Evaluates both alert tiers against the current backlog count,
+ * persists updated state, and returns the severity that should fire (or null).
+ *
+ * Resolution rules:
+ *   - Page tier (≥ 250,000 messages) is evaluated first.
+ *   - Ticket tier (≥ 100,000 messages) is only updated when page is not
+ *     active — the page alert already signals the elevated backlog.
+ *   - When page is active, ticket state is frozen until page resolves.
+ */
+export async function evaluateAndUpdateQueueBacklogState(
+  kv: KVNamespace,
+  backlogCount: number,
+): Promise<AlertSeverity | null> {
+  const [pageState, ticketState] = await Promise.all([
+    readTierState(kv, 'page'),
+    readTierState(kv, 'ticket'),
+  ]);
+
+  const abovePage = backlogCount >= QUEUE_BACKLOG_THRESHOLDS.page;
+  const aboveTicket = backlogCount >= QUEUE_BACKLOG_THRESHOLDS.ticket;
+
+  const { shouldFire: pageFire, newState: newPageState } = evaluateTier(pageState, abovePage);
+  const pageNowActive = newPageState.active;
+
+  let ticketFire = false;
+  let newTicketState = ticketState; // frozen by default when page is active
+
+  if (!pageNowActive) {
+    const result = evaluateTier(ticketState, aboveTicket);
+    ticketFire = result.shouldFire;
+    newTicketState = result.newState;
+  }
+
+  const writes: Promise<void>[] = [writeTierState(kv, 'page', newPageState)];
+  if (!pageNowActive) {
+    writes.push(writeTierState(kv, 'ticket', newTicketState));
+  }
+  await Promise.all(writes);
+
+  if (pageFire) return 'page';
+  if (ticketFire) return 'ticket';
+  return null;
+}

--- a/services/o11y/src/alerting/queue-backlog.ts
+++ b/services/o11y/src/alerting/queue-backlog.ts
@@ -1,11 +1,9 @@
-import type { AlertSeverity } from './slo-config';
-
 // Queue used for ingest.
 export const MONITORED_QUEUE_ID = '965459cfc1a349c190bb813855a65b02';
 
 export const QUEUE_BACKLOG_THRESHOLDS = {
-  page: 50_000,
-  ticket: 25_000,
+  page: 250_000,
+  ticket: 100_000,
 } as const;
 
 export type QueueBacklogMetrics = {
@@ -14,29 +12,3 @@ export type QueueBacklogMetrics = {
   backlogBytes: number;
   oldestMessageTimestamp?: Date;
 };
-
-export type QueueBacklogAlert = QueueBacklogMetrics & {
-  severity: AlertSeverity;
-  thresholdCount: number;
-};
-
-export function evaluateQueueBacklog(metrics: QueueBacklogMetrics): QueueBacklogAlert | null {
-  let severity: AlertSeverity | null = null;
-  let thresholdCount = 0;
-
-  if (metrics.backlogCount >= QUEUE_BACKLOG_THRESHOLDS.page) {
-    severity = 'page';
-    thresholdCount = QUEUE_BACKLOG_THRESHOLDS.page;
-  } else if (metrics.backlogCount >= QUEUE_BACKLOG_THRESHOLDS.ticket) {
-    severity = 'ticket';
-    thresholdCount = QUEUE_BACKLOG_THRESHOLDS.ticket;
-  }
-
-  if (severity === null) return null;
-
-  return {
-    ...metrics,
-    severity,
-    thresholdCount,
-  };
-}

--- a/services/o11y/src/alerting/queue-backlog.ts
+++ b/services/o11y/src/alerting/queue-backlog.ts
@@ -2,9 +2,11 @@
 export const MONITORED_QUEUE_ID = '965459cfc1a349c190bb813855a65b02';
 
 export const QUEUE_BACKLOG_THRESHOLDS = {
-  page: 250_000,
-  ticket: 100_000,
+  page: 50_000,
+  ticket: 25_000,
 } as const;
+
+export const QUEUE_BACKLOG_PAGE_INTERVAL = 100_000;
 
 export type QueueBacklogMetrics = {
   queueId: string;

--- a/services/o11y/test/queue-backlog-evaluate.spec.ts
+++ b/services/o11y/test/queue-backlog-evaluate.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { evaluateQueueBacklogAlert } from '../src/alerting/queue-backlog-evaluate';
 import {
   MONITORED_QUEUE_ID,
+  QUEUE_BACKLOG_PAGE_INTERVAL,
   QUEUE_BACKLOG_THRESHOLDS,
   type QueueBacklogMetrics,
 } from '../src/alerting/queue-backlog';
@@ -48,6 +49,14 @@ function makeMetrics(backlogCount: number): QueueBacklogMetrics {
   };
 }
 
+async function evaluateAt(
+  kv: KVNamespace,
+  backlogCount: number,
+  notify: (alert: AlertPayload) => Promise<void>
+): Promise<void> {
+  await evaluateQueueBacklogAlert(makeEnv(kv), async () => makeMetrics(backlogCount), notify);
+}
+
 describe('evaluateQueueBacklogAlert', () => {
   it('sends one ticket alert and persists queue-scoped state', async () => {
     const kv = makeKv();
@@ -56,16 +65,8 @@ describe('evaluateQueueBacklogAlert', () => {
       sentAlerts.push(alert);
     };
 
-    await evaluateQueueBacklogAlert(
-      makeEnv(kv),
-      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
-      notify
-    );
-    await evaluateQueueBacklogAlert(
-      makeEnv(kv),
-      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
-      notify
-    );
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.ticket, notify);
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.ticket, notify);
 
     expect(sentAlerts).toEqual([
       {
@@ -92,107 +93,101 @@ describe('evaluateQueueBacklogAlert', () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
 
-    await evaluateQueueBacklogAlert(
-      makeEnv(kv),
-      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket - 1),
-      async alert => {
-        sentAlerts.push(alert);
-      }
-    );
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.ticket - 1, async alert => {
+      sentAlerts.push(alert);
+    });
 
     expect(sentAlerts).toEqual([]);
     expect(kv.store.size).toBe(0);
     expect(kv.putCount).toBe(0);
   });
 
-  it('sends only a page alert on a direct jump across both thresholds', async () => {
-    const kv = makeKv();
-    const sentAlerts: AlertPayload[] = [];
-
-    await evaluateQueueBacklogAlert(
-      makeEnv(kv),
-      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.page),
-      async alert => {
-        sentAlerts.push(alert);
-      }
-    );
-
-    expect(sentAlerts.map(alert => alert.severity)).toEqual(['page']);
-    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
-      ticket: { active: true, consecutiveBelowCount: 0 },
-      page: { active: true, consecutiveBelowCount: 0 },
-    });
-  });
-
-  it('retries an alert when notification delivery fails', async () => {
-    const kv = makeKv();
-    let attempts = 0;
-    const notify = async () => {
-      attempts += 1;
-      if (attempts === 1) throw new Error('Slack unavailable');
-    };
-
-    await expect(
-      evaluateQueueBacklogAlert(
-        makeEnv(kv),
-        async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
-        notify
-      )
-    ).rejects.toThrow('Slack unavailable');
-    expect(kv.store.size).toBe(0);
-
-    await evaluateQueueBacklogAlert(
-      makeEnv(kv),
-      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
-      notify
-    );
-
-    expect(attempts).toBe(2);
-    expect(kv.store.has(STATE_KEY)).toBe(true);
-  });
-
-  it('re-arms only after three consecutive below-threshold checks', async () => {
+  it('pages at 50k and each subsequent 100k escalation interval', async () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
     const notify = async (alert: AlertPayload) => {
       sentAlerts.push(alert);
     };
 
-    await evaluateQueueBacklogAlert(
-      makeEnv(kv),
-      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
-      notify
-    );
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page, notify);
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page + QUEUE_BACKLOG_PAGE_INTERVAL - 1, notify);
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page + QUEUE_BACKLOG_PAGE_INTERVAL, notify);
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page + 2 * QUEUE_BACKLOG_PAGE_INTERVAL, notify);
 
-    for (let check = 0; check < 2; check += 1) {
-      await evaluateQueueBacklogAlert(
-        makeEnv(kv),
-        async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket - 1),
-        notify
-      );
-    }
+    expect(sentAlerts.map(alert => [alert.severity, alert.thresholdCount])).toEqual([
+      ['page', 50_000],
+      ['page', 150_000],
+      ['page', 250_000],
+    ]);
+  });
 
-    await evaluateQueueBacklogAlert(
-      makeEnv(kv),
-      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
-      notify
-    );
+  it('sends one page and advances all intervals on a direct jump', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+    const notify = async (alert: AlertPayload) => {
+      sentAlerts.push(alert);
+    };
+    const backlogCount = QUEUE_BACKLOG_THRESHOLDS.page + 2 * QUEUE_BACKLOG_PAGE_INTERVAL + 10_000;
+
+    await evaluateAt(kv, backlogCount, notify);
+    await evaluateAt(kv, backlogCount, notify);
+
+    expect(sentAlerts.map(alert => [alert.severity, alert.thresholdCount])).toEqual([
+      ['page', 250_000],
+    ]);
+    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
+      ticket: { active: true, consecutiveBelowCount: 0 },
+      page: {
+        active: true,
+        consecutiveBelowCount: 0,
+        nextThresholdCount: 350_000,
+      },
+    });
+  });
+
+  it('retries an escalation page when notification delivery fails', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+    let failNext = false;
+    const notify = async (alert: AlertPayload) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('Slack unavailable');
+      }
+      sentAlerts.push(alert);
+    };
+
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page, notify);
+    failNext = true;
+
+    await expect(
+      evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page + QUEUE_BACKLOG_PAGE_INTERVAL, notify)
+    ).rejects.toThrow('Slack unavailable');
+    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '').page.nextThresholdCount).toBe(150_000);
+
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page + QUEUE_BACKLOG_PAGE_INTERVAL, notify);
+    expect(sentAlerts.map(alert => alert.thresholdCount)).toEqual([50_000, 150_000]);
+  });
+
+  it('re-arms the initial page only after three consecutive checks below 50k', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+    const notify = async (alert: AlertPayload) => {
+      sentAlerts.push(alert);
+    };
+
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page, notify);
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page - 1, notify);
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page - 1, notify);
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page, notify);
     expect(sentAlerts).toHaveLength(1);
 
     for (let check = 0; check < 3; check += 1) {
-      await evaluateQueueBacklogAlert(
-        makeEnv(kv),
-        async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket - 1),
-        notify
-      );
+      await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page - 1, notify);
     }
 
-    await evaluateQueueBacklogAlert(
-      makeEnv(kv),
-      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
-      notify
-    );
-    expect(sentAlerts).toHaveLength(2);
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page, notify);
+    expect(sentAlerts.map(alert => alert.thresholdCount)).toEqual([50_000, 50_000]);
   });
 
   it('recovers safely from invalid persisted state', async () => {
@@ -200,23 +195,17 @@ describe('evaluateQueueBacklogAlert', () => {
     kv.store.set(
       STATE_KEY,
       JSON.stringify({
-        ticket: { active: true, consecutiveBelowCount: 'invalid' },
-        page: { active: false, consecutiveBelowCount: 0 },
+        ticket: { active: true, consecutiveBelowCount: 0 },
+        page: { active: true, consecutiveBelowCount: 0 },
       })
     );
     const sentAlerts: AlertPayload[] = [];
 
-    await evaluateQueueBacklogAlert(
-      makeEnv(kv),
-      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
-      async alert => {
-        sentAlerts.push(alert);
-      }
-    );
-
-    expect(sentAlerts.map(alert => alert.severity)).toEqual(['ticket']);
-    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toMatchObject({
-      ticket: { active: true },
+    await evaluateAt(kv, QUEUE_BACKLOG_THRESHOLDS.page, async alert => {
+      sentAlerts.push(alert);
     });
+
+    expect(sentAlerts.map(alert => alert.severity)).toEqual(['page']);
+    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '').page.nextThresholdCount).toBe(150_000);
   });
 });

--- a/services/o11y/test/queue-backlog-evaluate.spec.ts
+++ b/services/o11y/test/queue-backlog-evaluate.spec.ts
@@ -1,17 +1,28 @@
 import { describe, expect, it } from 'vitest';
 import { evaluateQueueBacklogAlert } from '../src/alerting/queue-backlog-evaluate';
-import { MONITORED_QUEUE_ID, type QueueBacklogMetrics } from '../src/alerting/queue-backlog';
+import {
+  MONITORED_QUEUE_ID,
+  QUEUE_BACKLOG_THRESHOLDS,
+  type QueueBacklogMetrics,
+} from '../src/alerting/queue-backlog';
 import type { AlertPayload } from '../src/alerting/notify';
+
+const STATE_KEY = `o11y:queue_backlog:${MONITORED_QUEUE_ID}`;
 
 function makeKv() {
   const store = new Map<string, string>();
+  let putCount = 0;
   return {
     get: async (key: string) => store.get(key) ?? null,
     put: async (key: string, value: string) => {
+      putCount += 1;
       store.set(key, value);
     },
     store,
-  } as unknown as KVNamespace & { store: Map<string, string> };
+    get putCount() {
+      return putCount;
+    },
+  } as unknown as KVNamespace & { store: Map<string, string>; putCount: number };
 }
 
 function makeSecret(value: string): SecretsStoreSecret {
@@ -38,16 +49,22 @@ function makeMetrics(backlogCount: number): QueueBacklogMetrics {
 }
 
 describe('evaluateQueueBacklogAlert', () => {
-  it('sends a ticket alert and records its dedup marker', async () => {
+  it('sends one ticket alert and persists queue-scoped state', async () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
+    const notify = async (alert: AlertPayload) => {
+      sentAlerts.push(alert);
+    };
 
     await evaluateQueueBacklogAlert(
       makeEnv(kv),
-      async () => makeMetrics(25_000),
-      async alert => {
-        sentAlerts.push(alert);
-      }
+      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
+      notify
+    );
+    await evaluateQueueBacklogAlert(
+      makeEnv(kv),
+      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
+      notify
     );
 
     expect(sentAlerts).toEqual([
@@ -57,24 +74,27 @@ describe('evaluateQueueBacklogAlert', () => {
         provider: 'cloudflare',
         model: MONITORED_QUEUE_ID,
         clientName: 'queues',
-        backlogCount: 25_000,
+        backlogCount: QUEUE_BACKLOG_THRESHOLDS.ticket,
         backlogBytes: 12_345_678,
-        thresholdCount: 25_000,
+        thresholdCount: QUEUE_BACKLOG_THRESHOLDS.ticket,
         oldestMessageTimestamp: new Date('2026-06-04T08:00:00.000Z'),
       },
     ]);
-    expect(
-      kv.store.has(`o11y:alert:ticket:queue_backlog:cloudflare:${MONITORED_QUEUE_ID}:queues`)
-    ).toBe(true);
+    expect(kv.store.size).toBe(1);
+    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
+      ticket: { active: true, consecutiveBelowCount: 0 },
+      page: { active: false, consecutiveBelowCount: 0 },
+    });
+    expect(kv.putCount).toBe(1);
   });
 
-  it('does not send an alert below the ticket threshold', async () => {
+  it('does not write state below the ticket threshold while inactive', async () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
 
     await evaluateQueueBacklogAlert(
       makeEnv(kv),
-      async () => makeMetrics(24_999),
+      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket - 1),
       async alert => {
         sentAlerts.push(alert);
       }
@@ -82,40 +102,121 @@ describe('evaluateQueueBacklogAlert', () => {
 
     expect(sentAlerts).toEqual([]);
     expect(kv.store.size).toBe(0);
+    expect(kv.putCount).toBe(0);
   });
 
-  it('suppresses a ticket while a page cooldown marker is active', async () => {
+  it('sends only a page alert on a direct jump across both thresholds', async () => {
     const kv = makeKv();
-    kv.store.set(
-      `o11y:alert:page:queue_backlog:cloudflare:${MONITORED_QUEUE_ID}:queues`,
-      new Date().toISOString()
-    );
     const sentAlerts: AlertPayload[] = [];
 
     await evaluateQueueBacklogAlert(
       makeEnv(kv),
-      async () => makeMetrics(25_000),
+      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.page),
       async alert => {
         sentAlerts.push(alert);
       }
     );
 
-    expect(sentAlerts).toEqual([]);
+    expect(sentAlerts.map(alert => alert.severity)).toEqual(['page']);
+    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
+      ticket: { active: true, consecutiveBelowCount: 0 },
+      page: { active: true, consecutiveBelowCount: 0 },
+    });
   });
 
-  it('does not record a cooldown marker when notification fails', async () => {
+  it('retries an alert when notification delivery fails', async () => {
     const kv = makeKv();
+    let attempts = 0;
+    const notify = async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('Slack unavailable');
+    };
 
     await expect(
       evaluateQueueBacklogAlert(
         makeEnv(kv),
-        async () => makeMetrics(25_000),
-        async () => {
-          throw new Error('Slack unavailable');
-        }
+        async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
+        notify
       )
     ).rejects.toThrow('Slack unavailable');
-
     expect(kv.store.size).toBe(0);
+
+    await evaluateQueueBacklogAlert(
+      makeEnv(kv),
+      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
+      notify
+    );
+
+    expect(attempts).toBe(2);
+    expect(kv.store.has(STATE_KEY)).toBe(true);
+  });
+
+  it('re-arms only after three consecutive below-threshold checks', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+    const notify = async (alert: AlertPayload) => {
+      sentAlerts.push(alert);
+    };
+
+    await evaluateQueueBacklogAlert(
+      makeEnv(kv),
+      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
+      notify
+    );
+
+    for (let check = 0; check < 2; check += 1) {
+      await evaluateQueueBacklogAlert(
+        makeEnv(kv),
+        async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket - 1),
+        notify
+      );
+    }
+
+    await evaluateQueueBacklogAlert(
+      makeEnv(kv),
+      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
+      notify
+    );
+    expect(sentAlerts).toHaveLength(1);
+
+    for (let check = 0; check < 3; check += 1) {
+      await evaluateQueueBacklogAlert(
+        makeEnv(kv),
+        async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket - 1),
+        notify
+      );
+    }
+
+    await evaluateQueueBacklogAlert(
+      makeEnv(kv),
+      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
+      notify
+    );
+    expect(sentAlerts).toHaveLength(2);
+  });
+
+  it('recovers safely from invalid persisted state', async () => {
+    const kv = makeKv();
+    kv.store.set(
+      STATE_KEY,
+      JSON.stringify({
+        ticket: { active: true, consecutiveBelowCount: 'invalid' },
+        page: { active: false, consecutiveBelowCount: 0 },
+      })
+    );
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateQueueBacklogAlert(
+      makeEnv(kv),
+      async () => makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket),
+      async alert => {
+        sentAlerts.push(alert);
+      }
+    );
+
+    expect(sentAlerts.map(alert => alert.severity)).toEqual(['ticket']);
+    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toMatchObject({
+      ticket: { active: true },
+    });
   });
 });

--- a/services/o11y/test/queue-backlog-integration.spec.ts
+++ b/services/o11y/test/queue-backlog-integration.spec.ts
@@ -43,7 +43,7 @@ describe('evaluateAlerts queue backlog integration', () => {
         return Response.json({
           success: true,
           result: {
-            backlog_count: 50_000,
+            backlog_count: 250_000,
             backlog_bytes: 12_345_678,
             oldest_message_timestamp_ms: 1_780_560_000_000,
           },
@@ -71,8 +71,6 @@ describe('evaluateAlerts queue backlog integration', () => {
 
     expect(slackMessages).toHaveLength(1);
     expect(JSON.stringify(slackMessages[0])).toContain('Queue Backlog Alert');
-    expect(
-      kv.store.has(`o11y:alert:page:queue_backlog:cloudflare:${MONITORED_QUEUE_ID}:queues`)
-    ).toBe(true);
+    expect(kv.store.has(`o11y:queue_backlog:${MONITORED_QUEUE_ID}`)).toBe(true);
   });
 });

--- a/services/o11y/test/queue-backlog-integration.spec.ts
+++ b/services/o11y/test/queue-backlog-integration.spec.ts
@@ -43,7 +43,7 @@ describe('evaluateAlerts queue backlog integration', () => {
         return Response.json({
           success: true,
           result: {
-            backlog_count: 250_000,
+            backlog_count: 50_000,
             backlog_bytes: 12_345_678,
             oldest_message_timestamp_ms: 1_780_560_000_000,
           },

--- a/services/o11y/test/queue-backlog.spec.ts
+++ b/services/o11y/test/queue-backlog.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { QUEUE_BACKLOG_THRESHOLDS } from '../src/alerting/queue-backlog';
+import {
+  QUEUE_BACKLOG_PAGE_INTERVAL,
+  QUEUE_BACKLOG_THRESHOLDS,
+} from '../src/alerting/queue-backlog';
 import {
   type QueueBacklogState,
   transitionQueueBacklogState,
@@ -13,74 +16,127 @@ function inactiveState(): QueueBacklogState {
 }
 
 describe('transitionQueueBacklogState', () => {
-  it('alerts once at each tier while the backlog increases', () => {
+  it('alerts once when the backlog first crosses the ticket threshold', () => {
     const ticket = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.ticket);
-    expect(ticket.severityToNotify).toBe('ticket');
-    expect(ticket.state.ticket.active).toBe(true);
-    expect(ticket.state.page.active).toBe(false);
+    expect(ticket.alert).toEqual({
+      severity: 'ticket',
+      thresholdCount: QUEUE_BACKLOG_THRESHOLDS.ticket,
+    });
 
     const repeatedTicket = transitionQueueBacklogState(
       ticket.state,
       QUEUE_BACKLOG_THRESHOLDS.ticket
     );
-    expect(repeatedTicket.severityToNotify).toBeNull();
+    expect(repeatedTicket.alert).toBeNull();
     expect(repeatedTicket.stateChanged).toBe(false);
-
-    const page = transitionQueueBacklogState(ticket.state, QUEUE_BACKLOG_THRESHOLDS.page);
-    expect(page.severityToNotify).toBe('page');
-    expect(page.state.ticket.active).toBe(true);
-    expect(page.state.page.active).toBe(true);
-
-    const repeatedPage = transitionQueueBacklogState(page.state, QUEUE_BACKLOG_THRESHOLDS.page);
-    expect(repeatedPage.severityToNotify).toBeNull();
-    expect(repeatedPage.stateChanged).toBe(false);
   });
 
-  it('sends only the page alert on a direct jump and does not alert on a downgrade', () => {
+  it('pages at the initial threshold and each 100k escalation interval', () => {
     let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.page);
-    expect(transition.severityToNotify).toBe('page');
+    expect(transition.alert).toEqual({
+      severity: 'page',
+      thresholdCount: QUEUE_BACKLOG_THRESHOLDS.page,
+    });
+
+    transition = transitionQueueBacklogState(
+      transition.state,
+      QUEUE_BACKLOG_THRESHOLDS.page + QUEUE_BACKLOG_PAGE_INTERVAL - 1
+    );
+    expect(transition.alert).toBeNull();
+
+    transition = transitionQueueBacklogState(
+      transition.state,
+      QUEUE_BACKLOG_THRESHOLDS.page + QUEUE_BACKLOG_PAGE_INTERVAL
+    );
+    expect(transition.alert).toEqual({
+      severity: 'page',
+      thresholdCount: QUEUE_BACKLOG_THRESHOLDS.page + QUEUE_BACKLOG_PAGE_INTERVAL,
+    });
+
+    transition = transitionQueueBacklogState(
+      transition.state,
+      QUEUE_BACKLOG_THRESHOLDS.page + 2 * QUEUE_BACKLOG_PAGE_INTERVAL
+    );
+    expect(transition.alert).toEqual({
+      severity: 'page',
+      thresholdCount: QUEUE_BACKLOG_THRESHOLDS.page + 2 * QUEUE_BACKLOG_PAGE_INTERVAL,
+    });
+  });
+
+  it('sends one page for a direct jump and advances beyond every crossed interval', () => {
+    const backlogCount = QUEUE_BACKLOG_THRESHOLDS.page + 2 * QUEUE_BACKLOG_PAGE_INTERVAL + 10_000;
+    const transition = transitionQueueBacklogState(inactiveState(), backlogCount);
+
+    expect(transition.alert).toEqual({
+      severity: 'page',
+      thresholdCount: QUEUE_BACKLOG_THRESHOLDS.page + 2 * QUEUE_BACKLOG_PAGE_INTERVAL,
+    });
     expect(transition.state.ticket.active).toBe(true);
-    expect(transition.state.page.active).toBe(true);
+    expect(transition.state.page).toEqual({
+      active: true,
+      consecutiveBelowCount: 0,
+      nextThresholdCount: QUEUE_BACKLOG_THRESHOLDS.page + 3 * QUEUE_BACKLOG_PAGE_INTERVAL,
+    });
+    expect(transitionQueueBacklogState(transition.state, backlogCount).alert).toBeNull();
+  });
+
+  it('advances every crossed interval during an active page incident', () => {
+    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.page);
+    const backlogCount = QUEUE_BACKLOG_THRESHOLDS.page + 3 * QUEUE_BACKLOG_PAGE_INTERVAL + 10_000;
+
+    transition = transitionQueueBacklogState(transition.state, backlogCount);
+    expect(transition.alert).toEqual({ severity: 'page', thresholdCount: 350_000 });
+    expect(transition.state.page).toMatchObject({ nextThresholdCount: 450_000 });
+    expect(transitionQueueBacklogState(transition.state, backlogCount).alert).toBeNull();
+  });
+
+  it('does not repeat an escalation interval after the backlog drops', () => {
+    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.page);
+    transition = transitionQueueBacklogState(
+      transition.state,
+      QUEUE_BACKLOG_THRESHOLDS.page + QUEUE_BACKLOG_PAGE_INTERVAL
+    );
+    expect(transition.alert?.thresholdCount).toBe(150_000);
+
+    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.page - 1);
+    transition = transitionQueueBacklogState(
+      transition.state,
+      QUEUE_BACKLOG_THRESHOLDS.page + QUEUE_BACKLOG_PAGE_INTERVAL
+    );
+
+    expect(transition.alert).toBeNull();
+  });
+
+  it('re-arms the initial page only after three consecutive checks below 50k', () => {
+    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.page);
+
+    for (let check = 0; check < 2; check += 1) {
+      transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.page - 1);
+    }
+
+    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.page);
+    expect(transition.alert).toBeNull();
 
     for (let check = 0; check < 3; check += 1) {
       transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.page - 1);
-      expect(transition.severityToNotify).toBeNull();
+    }
+
+    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.page);
+    expect(transition.alert).toEqual({
+      severity: 'page',
+      thresholdCount: QUEUE_BACKLOG_THRESHOLDS.page,
+    });
+  });
+
+  it('resolves ticket and page independently after three below-threshold checks', () => {
+    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.page);
+
+    for (let check = 0; check < 3; check += 1) {
+      transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.page - 1);
     }
 
     expect(transition.state.page.active).toBe(false);
     expect(transition.state.ticket.active).toBe(true);
-  });
-
-  it('resolves after three consecutive below-threshold checks', () => {
-    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.ticket);
-
-    for (let check = 1; check <= 3; check += 1) {
-      transition = transitionQueueBacklogState(
-        transition.state,
-        QUEUE_BACKLOG_THRESHOLDS.ticket - 1
-      );
-      expect(transition.severityToNotify).toBeNull();
-      expect(transition.state.ticket.active).toBe(check < 3);
-    }
-
-    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket);
-    expect(transition.severityToNotify).toBe('ticket');
-  });
-
-  it('resets the recovery count when the backlog rises above the threshold again', () => {
-    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.ticket);
-
-    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket - 1);
-    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket - 1);
-    expect(transition.state.ticket.consecutiveBelowCount).toBe(2);
-
-    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket);
-    expect(transition.severityToNotify).toBeNull();
-    expect(transition.state.ticket).toEqual({ active: true, consecutiveBelowCount: 0 });
-  });
-
-  it('resolves both tiers independently after three checks below both thresholds', () => {
-    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.page);
 
     for (let check = 0; check < 3; check += 1) {
       transition = transitionQueueBacklogState(
@@ -90,5 +146,27 @@ describe('transitionQueueBacklogState', () => {
     }
 
     expect(transition.state).toEqual(inactiveState());
+  });
+
+  it('re-arms ticket only after three consecutive checks below 25k', () => {
+    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.ticket);
+
+    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket - 1);
+    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket - 1);
+    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket);
+    expect(transition.alert).toBeNull();
+
+    for (let check = 0; check < 3; check += 1) {
+      transition = transitionQueueBacklogState(
+        transition.state,
+        QUEUE_BACKLOG_THRESHOLDS.ticket - 1
+      );
+    }
+
+    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket);
+    expect(transition.alert).toEqual({
+      severity: 'ticket',
+      thresholdCount: QUEUE_BACKLOG_THRESHOLDS.ticket,
+    });
   });
 });

--- a/services/o11y/test/queue-backlog.spec.ts
+++ b/services/o11y/test/queue-backlog.spec.ts
@@ -1,40 +1,94 @@
 import { describe, expect, it } from 'vitest';
+import { QUEUE_BACKLOG_THRESHOLDS } from '../src/alerting/queue-backlog';
 import {
-  MONITORED_QUEUE_ID,
-  QUEUE_BACKLOG_THRESHOLDS,
-  evaluateQueueBacklog,
-  type QueueBacklogMetrics,
-} from '../src/alerting/queue-backlog';
+  type QueueBacklogState,
+  transitionQueueBacklogState,
+} from '../src/alerting/queue-backlog-state';
 
-function makeMetrics(backlogCount: number): QueueBacklogMetrics {
+function inactiveState(): QueueBacklogState {
   return {
-    queueId: MONITORED_QUEUE_ID,
-    backlogCount,
-    backlogBytes: backlogCount * 100,
-    oldestMessageTimestamp: new Date('2026-06-04T08:00:00.000Z'),
+    ticket: { active: false, consecutiveBelowCount: 0 },
+    page: { active: false, consecutiveBelowCount: 0 },
   };
 }
 
-describe('evaluateQueueBacklog', () => {
-  it('returns no alert below the ticket backlog threshold', () => {
-    expect(evaluateQueueBacklog(makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket - 1))).toBeNull();
+describe('transitionQueueBacklogState', () => {
+  it('alerts once at each tier while the backlog increases', () => {
+    const ticket = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.ticket);
+    expect(ticket.severityToNotify).toBe('ticket');
+    expect(ticket.state.ticket.active).toBe(true);
+    expect(ticket.state.page.active).toBe(false);
+
+    const repeatedTicket = transitionQueueBacklogState(
+      ticket.state,
+      QUEUE_BACKLOG_THRESHOLDS.ticket
+    );
+    expect(repeatedTicket.severityToNotify).toBeNull();
+    expect(repeatedTicket.stateChanged).toBe(false);
+
+    const page = transitionQueueBacklogState(ticket.state, QUEUE_BACKLOG_THRESHOLDS.page);
+    expect(page.severityToNotify).toBe('page');
+    expect(page.state.ticket.active).toBe(true);
+    expect(page.state.page.active).toBe(true);
+
+    const repeatedPage = transitionQueueBacklogState(page.state, QUEUE_BACKLOG_THRESHOLDS.page);
+    expect(repeatedPage.severityToNotify).toBeNull();
+    expect(repeatedPage.stateChanged).toBe(false);
   });
 
-  it('returns a ticket alert at the ticket backlog threshold', () => {
-    expect(evaluateQueueBacklog(makeMetrics(QUEUE_BACKLOG_THRESHOLDS.ticket))).toEqual({
-      severity: 'ticket',
-      queueId: MONITORED_QUEUE_ID,
-      backlogCount: QUEUE_BACKLOG_THRESHOLDS.ticket,
-      backlogBytes: QUEUE_BACKLOG_THRESHOLDS.ticket * 100,
-      thresholdCount: QUEUE_BACKLOG_THRESHOLDS.ticket,
-      oldestMessageTimestamp: new Date('2026-06-04T08:00:00.000Z'),
-    });
+  it('sends only the page alert on a direct jump and does not alert on a downgrade', () => {
+    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.page);
+    expect(transition.severityToNotify).toBe('page');
+    expect(transition.state.ticket.active).toBe(true);
+    expect(transition.state.page.active).toBe(true);
+
+    for (let check = 0; check < 3; check += 1) {
+      transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.page - 1);
+      expect(transition.severityToNotify).toBeNull();
+    }
+
+    expect(transition.state.page.active).toBe(false);
+    expect(transition.state.ticket.active).toBe(true);
   });
 
-  it('returns only a page alert at the page backlog threshold', () => {
-    expect(evaluateQueueBacklog(makeMetrics(QUEUE_BACKLOG_THRESHOLDS.page))).toMatchObject({
-      severity: 'page',
-      thresholdCount: QUEUE_BACKLOG_THRESHOLDS.page,
-    });
+  it('resolves after three consecutive below-threshold checks', () => {
+    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.ticket);
+
+    for (let check = 1; check <= 3; check += 1) {
+      transition = transitionQueueBacklogState(
+        transition.state,
+        QUEUE_BACKLOG_THRESHOLDS.ticket - 1
+      );
+      expect(transition.severityToNotify).toBeNull();
+      expect(transition.state.ticket.active).toBe(check < 3);
+    }
+
+    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket);
+    expect(transition.severityToNotify).toBe('ticket');
+  });
+
+  it('resets the recovery count when the backlog rises above the threshold again', () => {
+    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.ticket);
+
+    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket - 1);
+    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket - 1);
+    expect(transition.state.ticket.consecutiveBelowCount).toBe(2);
+
+    transition = transitionQueueBacklogState(transition.state, QUEUE_BACKLOG_THRESHOLDS.ticket);
+    expect(transition.severityToNotify).toBeNull();
+    expect(transition.state.ticket).toEqual({ active: true, consecutiveBelowCount: 0 });
+  });
+
+  it('resolves both tiers independently after three checks below both thresholds', () => {
+    let transition = transitionQueueBacklogState(inactiveState(), QUEUE_BACKLOG_THRESHOLDS.page);
+
+    for (let check = 0; check < 3; check += 1) {
+      transition = transitionQueueBacklogState(
+        transition.state,
+        QUEUE_BACKLOG_THRESHOLDS.ticket - 1
+      );
+    }
+
+    expect(transition.state).toEqual(inactiveState());
   });
 });

--- a/services/o11y/wrangler.jsonc
+++ b/services/o11y/wrangler.jsonc
@@ -58,7 +58,7 @@
     { "pipeline": "82c1fc4073bb4830a6670e920b9823c2", "binding": "SESSION_METRICS_STREAM" },
   ],
   /**
-   * KV Namespace — stores alert dedup state (TTL-based cooldowns)
+   * KV Namespace — stores alert cooldown and lifecycle state
    */
   "kv_namespaces": [{ "binding": "O11Y_ALERT_STATE", "id": "aef43060c5334b9995450a780eea94fb" }],
   /**


### PR DESCRIPTION
## Summary

- Keeps the existing queue backlog thresholds: ticket at 25,000 messages and initial page at 50,000 messages.
- Replaces repeated 15-minute pages with fixed 100,000-message escalation milestones: page at 50,000, then 150,000, 250,000, 350,000, and so on during the same incident.
- Sends one highest-milestone page for a direct jump and advances beyond all crossed milestones, preventing follow-up spam for thresholds already crossed.
- Re-arms the initial 50,000-message page only after three consecutive checks below 50,000; ticket recovery similarly requires three checks below 25,000.
- Persists notification state only after successful Slack delivery so an alert retries while its milestone remains exceeded.

## Verification

1. Raise backlog through 25,000 and verify one ticket alert.
2. Raise backlog through 50,000, 150,000, and 250,000 and verify one page at each milestone, with no repeated pages between milestones.
3. Jump directly from below 50,000 to above multiple page milestones and verify one page for the highest crossed milestone.
4. Keep backlog below 50,000 for three consecutive checks, then cross 50,000 again and verify the initial page fires again.
5. Briefly dip below 50,000 for fewer than three checks and verify crossing back above 50,000 does not send another page.

## Visual Changes

N/A

## Reviewer Notes

- Lifecycle state is stored under one persistent queue-scoped key: `o11y:queue_backlog:<queueId>`.
- Slack webhooks do not expose a resolve operation; resolving means re-arming internal state after three consecutive recovery datapoints.
- Alert delivery keeps the existing notify-before-state at-least-once tradeoff: a successful Slack call followed by a state-write failure may retry, while a failed Slack call does not suppress the alert.
- Existing TTL deduplication remains unchanged for SLO and container-capacity alerts.

Built for [Evgeny Shurakov](https://kilo-code.slack.com/archives/C090U1NLQUC/p1780599906580189?thread_ts=1780599647.756759&cid=C090U1NLQUC) by [Kilo for Slack](https://kilo.ai/slack)