### PR TITLE
fix(session-ingest): slim oversized item RPC payloads

### DIFF
--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -184,7 +184,7 @@ describe('queue', () => {
     expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
   });
 
-  it('passes full parsed oversized message data and its R2 reference into ingest', async () => {
+  it('passes a slim oversized message and its R2 reference into ingest', async () => {
     const ingest = vi.fn(async () => ({ changes: [] }));
     vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
     const limit = vi.fn(async () => [{ session_id: 'ses_compacted' }]);
@@ -235,7 +235,7 @@ describe('queue', () => {
     const expectedR2Key = 'items/usr_compacted/ses_compacted/message/msg_compacted/456';
     expect(put).toHaveBeenCalledWith(expectedR2Key, JSON.stringify(data));
     expect(ingest).toHaveBeenCalledWith(
-      [{ type: 'message', data }],
+      [{ type: 'message', data: { id: 'msg_compacted' } }],
       'usr_compacted',
       'ses_compacted',
       1,

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -354,6 +354,10 @@ function createIngestChunker(
     // reference and an empty inline blob. Send only identity fields over RPC so
     // a single oversized item cannot exceed Cloudflare's RPC payload limit.
     const itemForRpc = itemDataBytes > MAX_INGEST_ITEM_BYTES ? slimItemForR2Reference(item) : item;
+    const itemForRpcDataBytes =
+      itemDataBytes > MAX_INGEST_ITEM_BYTES
+        ? encoder.encode(JSON.stringify(itemForRpc.data)).byteLength
+        : itemDataBytes;
     if (itemDataBytes > MAX_INGEST_ITEM_BYTES) {
       const itemR2Key = `items/${kiloUserId}/${sessionId}/${item_id}/${ingestedAt}`;
       await env.SESSION_INGEST_R2.put(itemR2Key, itemDataJson);
@@ -361,7 +365,7 @@ function createIngestChunker(
     }
 
     chunk.push(itemForRpc);
-    chunkBytes += itemDataBytes;
+    chunkBytes += itemForRpcDataBytes;
     if (chunk.length >= INGEST_CHUNK_MAX_ITEMS || chunkBytes >= INGEST_CHUNK_MAX_BYTES) {
       await flushChunkToSessionDO();
     }

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -281,6 +281,30 @@ async function streamSessionItems(
   return getParseError();
 }
 
+function slimItemForR2Reference(item: SessionDataItem): SessionDataItem {
+  switch (item.type) {
+    case 'message':
+      return { type: 'message', data: { id: item.data.id } };
+    case 'part':
+      return { type: 'part', data: { id: item.data.id, messageID: item.data.messageID } };
+    case 'session': {
+      const data: Record<string, unknown> = {};
+      if ('title' in item.data) data.title = item.data.title;
+      if ('parentID' in item.data) data.parentID = item.data.parentID;
+      return { type: 'session', data };
+    }
+    case 'session_diff':
+      return { type: 'session_diff', data: [] };
+    case 'model':
+      return { type: 'model', data: [] };
+    case 'session_open':
+    case 'session_close':
+    case 'session_status':
+    case 'kilo_meta':
+      return item;
+  }
+}
+
 function createIngestChunker(
   env: Env,
   msg: IngestQueueMessage,
@@ -323,17 +347,20 @@ function createIngestChunker(
     const item = parsed.data;
     const { item_id } = getItemIdentity(item);
 
-    // Offload data above the DO SQLite row limit to R2; the DO stores a
-    // reference and an empty inline blob.
     const itemDataJson = JSON.stringify(item.data);
     const itemDataBytes = encoder.encode(itemDataJson).byteLength;
+
+    // Offload data above the DO SQLite row limit to R2; the DO stores a
+    // reference and an empty inline blob. Send only identity fields over RPC so
+    // a single oversized item cannot exceed Cloudflare's RPC payload limit.
+    const itemForRpc = itemDataBytes > MAX_INGEST_ITEM_BYTES ? slimItemForR2Reference(item) : item;
     if (itemDataBytes > MAX_INGEST_ITEM_BYTES) {
       const itemR2Key = `items/${kiloUserId}/${sessionId}/${item_id}/${ingestedAt}`;
       await env.SESSION_INGEST_R2.put(itemR2Key, itemDataJson);
       chunkR2References[item_id] = itemR2Key;
     }
 
-    chunk.push(item);
+    chunk.push(itemForRpc);
     chunkBytes += itemDataBytes;
     if (chunk.length >= INGEST_CHUNK_MAX_ITEMS || chunkBytes >= INGEST_CHUNK_MAX_BYTES) {
       await flushChunkToSessionDO();


### PR DESCRIPTION
## Summary

After #3744 batched multiple session-ingest items into one Durable Object RPC, the post-deploy log report showed a concrete retry category for oversized RPC payloads: **RPC >32MiB: 593 retries**. Example error:

`Serialized RPC arguments or return values are limited to 32MiB`

The queue consumer already offloads item data above the DO SQLite row limit to R2 and passes an `r2References` map into `SessionIngestDO.ingest()`. However, it still sent the full parsed item object in the RPC payload. For very large message/part payloads, that meant we paid both costs: the full data was written to R2, but it was also serialized into the DO RPC, where Cloudflare enforces the 32MiB RPC argument/return limit.

This changes the queue consumer so oversized items are still written to R2 unchanged, but the item sent over RPC is slimmed to only the fields the DO needs to identify and route the item. The DO already persists referenced items as an empty inline blob plus `item_data_r2_key`, so the full `item.data` is redundant in the RPC once an R2 reference exists. The chunk byte counter also tracks the slim RPC payload size for offloaded items, rather than the full pre-slim data size, so multiple oversized/R2-backed items do not force unnecessarily tiny chunks.

Specifically:

- `message` keeps only `data.id`
- `part` keeps only `data.id` and `data.messageID`
- `session` keeps metadata fields used by extractors (`title`, `parentID`)
- `session_diff` / `model` keep valid empty payload shapes because full data is available through R2
- metadata/lifecycle-only item types are left unchanged

The existing R2 key generation, DO item identity, queue retry behavior, and R2-backed export/materialization path are unchanged.

Test coverage updated in `services/session-ingest/src/queue-consumer.test.ts`:

- full oversized item data is still written to R2
- the DO RPC receives only the slim item payload
- the DO RPC still receives the correct R2 reference

## Verification

Local automated checks run before updating the PR:

- `pnpm exec oxfmt services/session-ingest/src/queue-consumer.ts services/session-ingest/src/queue-consumer.test.ts`
- `pnpm --filter cloudflare-session-ingest test -- src/queue-consumer.test.ts` passed; Vitest executed the full session-ingest test suite (15 files, 278 tests)
- `pnpm --filter cloudflare-session-ingest typecheck` passed

## Visual Changes

N/A

## Reviewer Notes

N/A