### PR TITLE
fix(session-ingest): split duplicate item chunks

### DIFF
--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -247,6 +247,78 @@ describe('queue', () => {
     expect(retry).not.toHaveBeenCalled();
   });
 
+  it('splits duplicate item identities so inline updates do not reuse prior R2 refs', async () => {
+    const ingest = vi.fn(async () => ({ changes: [] }));
+    vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
+    const limit = vi.fn(async () => [{ session_id: 'ses_duplicate' }]);
+    const where = vi.fn(() => ({ limit }));
+    const from = vi.fn(() => ({ where }));
+    vi.mocked(getWorkerDb).mockReturnValue({ select: vi.fn(() => ({ from })) } as never);
+
+    const oversizedData = { id: 'msg_same', content: 'x'.repeat(150) };
+    const inlineData = { id: 'msg_same', content: 'small' };
+    const oversizedItem = { type: 'message', data: oversizedData };
+    const inlineItem = { type: 'message', data: inlineData };
+    const body = JSON.stringify({ data: [oversizedItem, inlineItem] });
+    const put = vi.fn(async () => undefined);
+    const deleteObject = vi.fn(async () => undefined);
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://unused' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => new Response(body)),
+        put,
+        delete: deleteObject,
+      },
+    } as never;
+    const ack = vi.fn();
+    const retry = vi.fn();
+
+    await queue(
+      {
+        messages: [
+          {
+            body: {
+              r2Key: 'staging/duplicate',
+              kiloUserId: 'usr_duplicate',
+              sessionId: 'ses_duplicate',
+              ingestVersion: 1,
+              ingestedAt: 1,
+            },
+            ack,
+            retry,
+          },
+        ],
+      } as never,
+      env,
+      { waitUntil: vi.fn() } as unknown as ExecutionContext
+    );
+
+    const expectedR2Key = 'items/usr_duplicate/ses_duplicate/message/msg_same/1';
+    expect(put).toHaveBeenCalledWith(expectedR2Key, JSON.stringify(oversizedData));
+    expect(ingest).toHaveBeenCalledTimes(2);
+    expect(ingest).toHaveBeenNthCalledWith(
+      1,
+      [oversizedItem],
+      'usr_duplicate',
+      'ses_duplicate',
+      1,
+      1,
+      { 'message/msg_same': expectedR2Key }
+    );
+    expect(ingest).toHaveBeenNthCalledWith(
+      2,
+      [inlineItem],
+      'usr_duplicate',
+      'ses_duplicate',
+      1,
+      1,
+      undefined
+    );
+    expect(deleteObject).toHaveBeenCalledWith('staging/duplicate');
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
   it('batches all items in a message into a single DO ingest call', async () => {
     const ingest = vi.fn(async () => ({ changes: [] }));
     vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -289,6 +289,7 @@ function createIngestChunker(
   const { r2Key, kiloUserId, sessionId, ingestVersion, ingestedAt } = msg;
   const encoder = new TextEncoder();
   const chunk: SessionDataItem[] = [];
+  const chunkItemIds = new Set<string>();
   let chunkR2References: Record<string, string> = {};
   let chunkBytes = 0;
 
@@ -296,6 +297,7 @@ function createIngestChunker(
     if (chunk.length === 0) return;
     const items = chunk.splice(0);
     const r2References = Object.keys(chunkR2References).length > 0 ? chunkR2References : undefined;
+    chunkItemIds.clear();
     chunkR2References = {};
     chunkBytes = 0;
 
@@ -323,10 +325,15 @@ function createIngestChunker(
     const item = parsed.data;
     const { item_id } = getItemIdentity(item);
 
-    // Offload data above the DO SQLite row limit to R2; the DO stores a
-    // reference and an empty inline blob.
     const itemDataJson = JSON.stringify(item.data);
     const itemDataBytes = encoder.encode(itemDataJson).byteLength;
+
+    if (chunkItemIds.has(item_id)) {
+      await flushChunkToSessionDO();
+    }
+
+    // Offload data above the DO SQLite row limit to R2; the DO stores a
+    // reference and an empty inline blob.
     if (itemDataBytes > MAX_INGEST_ITEM_BYTES) {
       const itemR2Key = `items/${kiloUserId}/${sessionId}/${item_id}/${ingestedAt}`;
       await env.SESSION_INGEST_R2.put(itemR2Key, itemDataJson);
@@ -334,6 +341,7 @@ function createIngestChunker(
     }
 
     chunk.push(item);
+    chunkItemIds.add(item_id);
     chunkBytes += itemDataBytes;
     if (chunk.length >= INGEST_CHUNK_MAX_ITEMS || chunkBytes >= INGEST_CHUNK_MAX_BYTES) {
       await flushChunkToSessionDO();


### PR DESCRIPTION
## Summary

This PR addresses the review-report warning: **Duplicate item identity can retain stale oversized data**.

```
WARNING services/session-ingest/src/queue-consumer.ts:333 - Duplicate item identity can retain stale oversized data
Evidence:
+    if (itemDataBytes > MAX_INGEST_ITEM_BYTES) {
+      const itemR2Key = `items/${kiloUserId}/${sessionId}/${item_id}/${ingestedAt}`;
+      await env.SESSION_INGEST_R2.put(itemR2Key, itemDataJson);
+      chunkR2References[item_id] = itemR2Key;
+    }
+
+    chunk.push(item);
Trace:
1. First oversized occurrence stores chunkR2References[item_id].
2. Later inline occurrence with same identity is appended but does not remove existing reference.
3. SessionIngestDO.ingest resolves the shared r2References[item_id] for every occurrence, so later inline update is persisted as {} plus earlier R2 key.
4. Prior one-item calls passed no reference for later inline update, allowing latest value to replace earlier oversized value.
Impact: Latest valid update is lost when one chunk contains oversized-then-inline updates for same session/message/part identity.
```

After #3744, a single queue message can send multiple items to `SessionIngestDO.ingest()` in one batched RPC. The chunk-level `r2References` map is keyed by `item_id`. If the same item identity appears twice in the same chunk and the first occurrence is oversized, the chunk records an R2 reference for that `item_id`. A later inline occurrence with the same identity would be sent in the same RPC while the shared `r2References[item_id]` still points at the earlier oversized payload.

That changes prior semantics. Before batching, each item was sent as its own RPC, so an oversized first update could pass an R2 reference and a later inline update could pass no R2 reference, allowing the later inline payload to replace the earlier oversized value. In one shared chunk, the later inline update can incorrectly inherit the earlier R2 reference.

This fix keeps a set of item identities currently staged in the chunk. Before staging another item with an identity already present in the current chunk, the consumer flushes the existing chunk to the session DO. That preserves ordering while ensuring an R2 reference only applies to the item occurrence it was staged with.

Test coverage added in `services/session-ingest/src/queue-consumer.test.ts`:

- oversized and inline updates with the same message identity split into two ordered DO calls
- first call carries the oversized item with its R2 reference
- second call carries the later inline item without the stale R2 reference

## Verification

Local automated checks run before opening the PR:

- `pnpm exec oxfmt services/session-ingest/src/queue-consumer.ts services/session-ingest/src/queue-consumer.test.ts`
- `pnpm --filter cloudflare-session-ingest test -- src/queue-consumer.test.ts` passed; Vitest executed the full session-ingest test suite (15 files, 279 tests)
- `pnpm --filter cloudflare-session-ingest typecheck` passed

## Visual Changes

N/A

## Reviewer Notes

N/A