### PR TITLE
fix(session-ingest): preserve lifecycle marker order

### DIFF
--- a/services/session-ingest/src/dos/SessionIngestDO.test.ts
+++ b/services/session-ingest/src/dos/SessionIngestDO.test.ts
@@ -1,16 +1,92 @@
 import { describe, expect, it, vi } from 'vitest';
 
+const drizzleMocks = vi.hoisted(() => ({
+  db: undefined as unknown,
+  migrate: vi.fn(),
+}));
+
 vi.mock('cloudflare:workers', () => ({
   DurableObject: class DurableObject {
-    constructor(_state: unknown, _env: unknown) {}
+    ctx: unknown;
+    env: unknown;
+    constructor(state: unknown, env: unknown) {
+      this.ctx = state;
+      this.env = env;
+    }
   },
 }));
 
-import { ingestOrderCursor } from './SessionIngestDO';
+vi.mock('drizzle-orm/durable-sqlite', () => ({
+  drizzle: vi.fn(() => drizzleMocks.db),
+}));
+
+vi.mock('drizzle-orm/durable-sqlite/migrator', () => ({
+  migrate: drizzleMocks.migrate,
+}));
+
+import { SessionIngestDO, ingestOrderCursor } from './SessionIngestDO';
 
 describe('SessionIngestDO ingest ordering', () => {
   it('uses ingested_at with id only as a tie-breaker for cursor progression', () => {
     expect(ingestOrderCursor({ ingested_at: 100, id: 7 })).toEqual({ ingestedAt: 100, id: 7 });
     expect(ingestOrderCursor({ ingested_at: null, id: 3 })).toEqual({ ingestedAt: null, id: 3 });
+  });
+
+  it('applies same-batch lifecycle markers in payload order', async () => {
+    const operations: string[] = [];
+    const selectQuery = {
+      from: vi.fn(() => selectQuery),
+      where: vi.fn(() => selectQuery),
+      get: vi.fn(() => undefined),
+    };
+    const db = {
+      select: vi.fn(() => selectQuery),
+      insert: vi.fn(() => ({
+        values: vi.fn((values: { key?: string; value?: string | null; item_id?: string }) => ({
+          onConflictDoUpdate: vi.fn(() => ({
+            run: vi.fn(() => {
+              if (values.key === 'closeReason') {
+                operations.push(`meta:${values.key}:${values.value}`);
+              }
+            }),
+          })),
+        })),
+      })),
+      delete: vi.fn(() => ({
+        where: vi.fn(() => ({
+          run: vi.fn(() => operations.push('delete:closeReason')),
+        })),
+      })),
+    };
+    drizzleMocks.db = db;
+
+    const state = {
+      storage: {
+        setAlarm: vi.fn(async () => {
+          operations.push('alarm');
+        }),
+      },
+      blockConcurrencyWhile: vi.fn((fn: () => void) => fn()),
+    } as unknown as DurableObjectState;
+    const env = { SESSION_INGEST_R2: { delete: vi.fn() } } as never;
+
+    const durableObject = new SessionIngestDO(state, env);
+    await durableObject.ingest(
+      [
+        { type: 'session_close', data: { reason: 'completed' } },
+        { type: 'session_open', data: {} },
+      ],
+      'usr_order',
+      'ses_order',
+      1,
+      1
+    );
+
+    expect(operations).toEqual([
+      'meta:closeReason:completed',
+      'alarm',
+      'delete:closeReason',
+      'alarm',
+    ]);
   });
 });

--- a/services/session-ingest/src/dos/SessionIngestDO.ts
+++ b/services/session-ingest/src/dos/SessionIngestDO.ts
@@ -86,6 +86,13 @@ const INGEST_META_EXTRACTORS: Array<{
 
 type Changes = Array<{ name: ExtractableMetaKey; value: string | null }>;
 
+type IngestLifecycleEvent =
+  | { type: 'session_open' }
+  | {
+      type: 'session_close';
+      reason: Extract<SessionDataItem, { type: 'session_close' }>['data']['reason'];
+    };
+
 export type IngestOrderCursor = { ingestedAt: number | null; id: number };
 
 export function afterIngestOrderCursor(cursor: IngestOrderCursor) {
@@ -164,8 +171,7 @@ export class SessionIngestDO extends DurableObject<Env> {
       status: undefined,
     };
 
-    let hasSessionOpen = false;
-    let closeReason: string | undefined;
+    const lifecycleEvents: IngestLifecycleEvent[] = [];
     const orphanedR2Keys: string[] = [];
 
     for (const item of payload) {
@@ -231,10 +237,12 @@ export class SessionIngestDO extends DurableObject<Env> {
         }
       }
 
-      if (item.type === 'session_open') {
-        hasSessionOpen = true;
-      } else if (item.type === 'session_close') {
-        closeReason = item.data.reason;
+      if (ingestVersion >= 1) {
+        if (item.type === 'session_open') {
+          lifecycleEvents.push({ type: 'session_open' });
+        } else if (item.type === 'session_close') {
+          lifecycleEvents.push({ type: 'session_close', reason: item.data.reason });
+        }
       }
     }
 
@@ -259,17 +267,21 @@ export class SessionIngestDO extends DurableObject<Env> {
 
     if (ingestVersion >= 1) {
       // v1 clients send explicit open/close pairs. Only those events drive alarms.
-      if (hasSessionOpen) {
-        // New turn starting — clear prior emission so metrics are re-computed.
-        this.db
-          .delete(ingestMeta)
-          .where(inArray(ingestMeta.key, ['metricsEmitted', 'closeReason']))
-          .run();
-        await this.ctx.storage.setAlarm(Date.now() + INACTIVITY_TIMEOUT_MS);
-      }
-      if (closeReason) {
-        writeIngestMetaIfChanged(this.db, { key: 'closeReason', incomingValue: closeReason });
-        await this.ctx.storage.setAlarm(Date.now() + POST_CLOSE_DRAIN_MS);
+      for (const event of lifecycleEvents) {
+        if (event.type === 'session_open') {
+          // New turn starting — clear prior emission so metrics are re-computed.
+          this.db
+            .delete(ingestMeta)
+            .where(inArray(ingestMeta.key, ['metricsEmitted', 'closeReason']))
+            .run();
+          await this.ctx.storage.setAlarm(Date.now() + INACTIVITY_TIMEOUT_MS);
+        } else {
+          writeIngestMetaIfChanged(this.db, {
+            key: 'closeReason',
+            incomingValue: event.reason,
+          });
+          await this.ctx.storage.setAlarm(Date.now() + POST_CLOSE_DRAIN_MS);
+        }
       }
       // Events without open/close (stragglers) don't touch the alarm.
     } else {


### PR DESCRIPTION
## Summary

This PR addresses the review-report warning: **Same-chunk lifecycle markers no longer preserve order**.

```
WARNING services/session-ingest/src/queue-consumer.ts:304 - Same-chunk lifecycle markers no longer preserve order
Evidence:
+    const items = chunk.splice(0);
...
+      stub => stub.ingest(items, kiloUserId, sessionId, ingestVersion, ingestedAt, r2References),
Trace:
1. Changed code sends multiple ordered items through one SessionIngestDO.ingest call instead of one RPC per item.
2. SessionIngestDO.ingest was checked: it records hasSessionOpen and closeReason while iterating, then always applies open side effects before close side effects.
3. For valid input [session_close, session_open], prior one-item calls ended with cleared close reason and inactivity alarm; batched call restores close reason and replaces alarm with five-second post-close alarm.
Impact: New turn can be finalized as closed and emit metrics prematurely with stale termination reason.
```

After #3744, multiple ordered session-ingest items can be sent through one `SessionIngestDO.ingest()` call. The DO previously collapsed lifecycle markers while iterating: it recorded whether any `session_open` was present and the latest `session_close` reason, then applied open side effects before close side effects. That was equivalent enough when every item arrived in its own RPC, but it is wrong when both markers appear in one batched payload.

For example, with `[session_close, session_open]` in the same payload:

- prior one-item RPC behavior ended with the session opened again
- batched behavior could apply open first and close second, ending with a close reason and post-close alarm

This fix records lifecycle events in payload order and applies the side effects in that same order. That preserves the old per-item ordering semantics while keeping the batched RPC path.

Test coverage added in `services/session-ingest/src/dos/SessionIngestDO.test.ts`:

- a same-batch `[session_close, session_open]` payload applies close side effects first and open side effects second
- the final side effect order matches the prior one-item-RPC semantics

## Verification

Local automated checks run before opening the PR:

- `pnpm exec oxfmt services/session-ingest/src/dos/SessionIngestDO.ts services/session-ingest/src/dos/SessionIngestDO.test.ts`
- `pnpm --filter cloudflare-session-ingest test -- src/dos/SessionIngestDO.test.ts` passed; Vitest executed the full session-ingest test suite (15 files, 279 tests)
- `pnpm --filter cloudflare-session-ingest typecheck` passed

## Visual Changes

N/A

## Reviewer Notes

N/A