### PR TITLE
fix(session-ingest): clean up aborted queue streams

### DIFF
--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -427,6 +427,66 @@ describe('queue', () => {
     expect(deleteObject).not.toHaveBeenCalled();
   });
 
+  it('cancels the unread R2 stream when item processing fails', async () => {
+    const ingest = vi.fn(async () => {
+      throw new Error('Durable Object is overloaded.');
+    });
+    vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
+
+    const limit = vi.fn(async () => [{ session_id: 'ses_cancel' }]);
+    const where = vi.fn(() => ({ limit }));
+    const from = vi.fn(() => ({ where }));
+    vi.mocked(getWorkerDb).mockReturnValue({ select: vi.fn(() => ({ from })) } as never);
+
+    const items = Array.from({ length: 128 }, (_, i) => ({
+      type: 'message',
+      data: { id: `msg_${i}` },
+    }));
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(JSON.stringify({ data: items })));
+      },
+      cancel,
+    });
+    const deleteObject = vi.fn(async () => undefined);
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://unused' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => ({ body })),
+        put: vi.fn(async () => undefined),
+        delete: deleteObject,
+      },
+    } as never;
+    const ack = vi.fn();
+    const retry = vi.fn();
+
+    await queue(
+      {
+        messages: [
+          {
+            body: {
+              r2Key: 'staging/cancel',
+              kiloUserId: 'usr_cancel',
+              sessionId: 'ses_cancel',
+              ingestVersion: 1,
+              ingestedAt: 1,
+            },
+            ack,
+            retry,
+          },
+        ],
+      } as never,
+      env,
+      { waitUntil: vi.fn() } as unknown as ExecutionContext
+    );
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
+    expect(ack).not.toHaveBeenCalled();
+    expect(deleteObject).not.toHaveBeenCalled();
+  });
+
   it('does not flush buffered items when malformed JSON forces a retry', async () => {
     const ingest = vi.fn(async () => ({ changes: [] }));
     vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -260,25 +260,39 @@ async function streamSessionItems(
 ): Promise<Error | null> {
   const { tokenizer, pending, getParseError } = createItemExtractor(r2Key);
   const reader = body.getReader();
+  let completed = false;
 
-  while (true) {
-    const result: ReadableStreamReadResult<Uint8Array> = await reader.read();
-    if (result.done) {
-      tokenizer.end();
-    } else {
-      tokenizer.write(result.value);
+  try {
+    while (true) {
+      const result: ReadableStreamReadResult<Uint8Array> = await reader.read();
+      if (result.done) {
+        tokenizer.end();
+        completed = true;
+      } else {
+        tokenizer.write(result.value);
+      }
+
+      while (pending.length > 0) {
+        const rawItem = pending.shift();
+        if (!rawItem) break;
+        await onItem(rawItem);
+      }
+
+      if (result.done) break;
     }
 
-    while (pending.length > 0) {
-      const rawItem = pending.shift();
-      if (!rawItem) break;
-      await onItem(rawItem);
+    return getParseError();
+  } finally {
+    if (!completed) {
+      await reader.cancel().catch(err => {
+        console.warn('Failed to cancel queue consumer R2 stream', {
+          r2Key,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
     }
-
-    if (result.done) break;
+    reader.releaseLock();
   }
-
-  return getParseError();
 }
 
 function createIngestChunker(


### PR DESCRIPTION
## Summary

This PR addresses the review-report warning: **Propagated ingest failure leaves R2 body unread and locked**.

```
WARNING services/session-ingest/src/queue-consumer.ts:275 - Propagated ingest failure leaves R2 body unread and locked
Evidence:
+  const reader = body.getReader();
...
+      await onItem(rawItem);
Trace:
1. Changed flow propagates stage/DO/R2 errors instead of catching per-item failures.
2. streamSessionItems exits immediately when onItem throws.
3. No finally cancels reader or releases lock; queue loop then continues to later messages.
4. Cloudflare guidance recommends cancelling unused response bodies to release memory and connection resources.
Impact: Repeated hot-DO failures can retain unread R2 streams during queue invocation, adding memory/connection pressure during overload.
```

After #3744, the queue consumer propagates DO/R2 processing errors as message-level failures. That means `streamSessionItems()` can exit before the R2 staging object response body has been fully consumed. This PR adds a `finally` block that cancels and releases the reader when processing aborts early, reducing memory/connection pressure during overload or other repeated failures.

This PR intentionally does **not** delete item R2 blobs on malformed JSON. The review report correctly noted a possible leak for unflushed oversized item blobs, but those item R2 keys are deterministic (`items/.../<item_id>/<ingestedAt>`). In edge cases involving retries or earlier partial chunk commits, deleting a key from the malformed/unflushed path could remove or disturb data that a previously committed DO row already references. Since production logs showed **0 malformed JSON** in the sampled window, this PR keeps the safer behavior: malformed payloads still throw, retry, and eventually DLQ/manual-recovery rather than risking deletion of referenced item data.

Test coverage added in `services/session-ingest/src/queue-consumer.test.ts`:

- aborted item processing cancels the unread R2 stream
- the queue message still retries
- the R2 staging object is not deleted on that failure path

## Verification

Local automated checks run before updating the PR:

- `pnpm exec oxfmt services/session-ingest/src/queue-consumer.ts services/session-ingest/src/queue-consumer.test.ts`
- `pnpm --filter cloudflare-session-ingest test -- src/queue-consumer.test.ts` passed; Vitest executed the full session-ingest test suite (15 files, 279 tests)
- `pnpm --filter cloudflare-session-ingest typecheck` passed

## Visual Changes

N/A

## Reviewer Notes

N/A