### PR TITLE
fix(session-ingest): delay metadata changes until side effects finish

### DIFF
--- a/services/session-ingest/src/dos/SessionIngestDO.test.ts
+++ b/services/session-ingest/src/dos/SessionIngestDO.test.ts
@@ -89,4 +89,132 @@ describe('SessionIngestDO ingest ordering', () => {
       'alarm',
     ]);
   });
+
+  it('does not overwrite newer metadata after orphaned R2 cleanup yields', async () => {
+    const operations: string[] = [];
+    const metaValues = new Map<string, string | null>();
+    const getResults = [
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { ingested_at: 0, item_data_r2_key: 'items/old' },
+      undefined,
+    ];
+    const selectQuery = {
+      from: vi.fn(() => selectQuery),
+      where: vi.fn(() => selectQuery),
+      get: vi.fn(() => getResults.shift()),
+    };
+    const db = {
+      select: vi.fn(() => selectQuery),
+      insert: vi.fn(() => ({
+        values: vi.fn((values: { key?: string; value?: string | null; item_id?: string }) => ({
+          onConflictDoUpdate: vi.fn(() => ({
+            run: vi.fn(() => {
+              if (values.key) {
+                metaValues.set(values.key, values.value ?? null);
+                operations.push(`meta:${values.key}:${values.value}`);
+              }
+            }),
+          })),
+        })),
+      })),
+      delete: vi.fn(() => ({
+        where: vi.fn(() => ({ run: vi.fn() })),
+      })),
+    };
+    drizzleMocks.db = db;
+
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const state = {
+      storage: { setAlarm: vi.fn() },
+      waitUntil: vi.fn((promise: Promise<unknown>) => {
+        operations.push('waitUntil');
+        waitUntilPromises.push(promise);
+      }),
+      blockConcurrencyWhile: vi.fn((fn: () => void) => fn()),
+    } as unknown as DurableObjectState;
+    const deleteObject = vi.fn(async () => {
+      operations.push('r2Delete');
+      // Simulate a newer interleaved ingest updating metadata while stale ingest
+      // would have been awaiting R2 cleanup in the old implementation.
+      metaValues.set('title', 'Newer');
+    });
+    const env = {
+      SESSION_INGEST_R2: {
+        delete: deleteObject,
+      },
+    } as never;
+
+    const durableObject = new SessionIngestDO(state, env);
+    const result = await durableObject.ingest(
+      [{ type: 'session', data: { title: 'Hello' } }],
+      'usr_meta',
+      'ses_meta',
+      1,
+      1,
+      { session: 'items/new' }
+    );
+    await Promise.all(waitUntilPromises);
+
+    expect(result.changes).toEqual([{ name: 'title', value: 'Hello' }]);
+    expect(deleteObject).toHaveBeenCalledWith(['items/old']);
+    expect(operations.indexOf('meta:title:Hello')).toBeLessThan(operations.indexOf('r2Delete'));
+    expect(metaValues.get('title')).toBe('Newer');
+  });
+
+  it('does not report metadata changes when lifecycle side effects fail', async () => {
+    const metaWrites: string[] = [];
+    const selectQuery = {
+      from: vi.fn(() => selectQuery),
+      where: vi.fn(() => selectQuery),
+      get: vi.fn(() => undefined),
+    };
+    const db = {
+      select: vi.fn(() => selectQuery),
+      insert: vi.fn(() => ({
+        values: vi.fn((values: { key?: string; value?: string | null; item_id?: string }) => ({
+          onConflictDoUpdate: vi.fn(() => ({
+            run: vi.fn(() => {
+              if (values.key) {
+                metaWrites.push(`${values.key}:${values.value}`);
+              }
+            }),
+          })),
+        })),
+      })),
+      delete: vi.fn(() => ({
+        where: vi.fn(() => ({ run: vi.fn() })),
+      })),
+    };
+    drizzleMocks.db = db;
+
+    const state = {
+      storage: {
+        setAlarm: vi.fn(async () => {
+          throw new Error('alarm failed');
+        }),
+      },
+      blockConcurrencyWhile: vi.fn((fn: () => void) => fn()),
+    } as unknown as DurableObjectState;
+    const env = { SESSION_INGEST_R2: { delete: vi.fn() } } as never;
+
+    const durableObject = new SessionIngestDO(state, env);
+    await expect(
+      durableObject.ingest(
+        [
+          { type: 'session', data: { title: 'Hello' } },
+          { type: 'session_close', data: { reason: 'completed' } },
+        ],
+        'usr_meta',
+        'ses_meta',
+        1,
+        1
+      )
+    ).rejects.toThrow('alarm failed');
+
+    expect(metaWrites).toContain('closeReason:completed');
+    expect(metaWrites).not.toContain('title:Hello');
+  });
 });

--- a/services/session-ingest/src/dos/SessionIngestDO.ts
+++ b/services/session-ingest/src/dos/SessionIngestDO.ts
@@ -246,25 +246,6 @@ export class SessionIngestDO extends DurableObject<Env> {
       }
     }
 
-    const changes: Changes = [];
-
-    for (const key of Object.keys(incomingByKey) as ExtractableMetaKey[]) {
-      const incoming = incomingByKey[key];
-      if (incoming === undefined) continue;
-      const meta = writeIngestMetaIfChanged(this.db, {
-        key,
-        incomingValue: incoming,
-      });
-      if (meta.changed) {
-        changes.push({ name: key, value: meta.value });
-      }
-    }
-
-    // Clean up orphaned R2 blobs (e.g. replaced or stale oversized items)
-    if (orphanedR2Keys.length > 0) {
-      await this.env.SESSION_INGEST_R2.delete(orphanedR2Keys);
-    }
-
     if (ingestVersion >= 1) {
       // v1 clients send explicit open/close pairs. Only those events drive alarms.
       for (const event of lifecycleEvents) {
@@ -287,6 +268,35 @@ export class SessionIngestDO extends DurableObject<Env> {
     } else {
       // v0 (legacy): no open/close signals, rely on inactivity timeout.
       await this.ctx.storage.setAlarm(Date.now() + INACTIVITY_TIMEOUT_MS);
+    }
+
+    const changes: Changes = [];
+    for (const key of Object.keys(incomingByKey) as ExtractableMetaKey[]) {
+      const incoming = incomingByKey[key];
+      if (incoming === undefined) continue;
+      const meta = writeIngestMetaIfChanged(this.db, {
+        key,
+        incomingValue: incoming,
+      });
+      if (meta.changed) {
+        changes.push({ name: key, value: meta.value });
+      }
+    }
+
+    // Clean up orphaned R2 blobs after metadata is persisted. R2 is external I/O,
+    // so awaiting it before metadata writes can let another DO request interleave
+    // and then be overwritten by stale pre-await metadata from this request.
+    if (orphanedR2Keys.length > 0) {
+      this.ctx.waitUntil(
+        this.env.SESSION_INGEST_R2.delete(orphanedR2Keys).catch(error => {
+          console.error('Failed to delete orphaned session-ingest R2 blobs', {
+            kiloUserId,
+            sessionId,
+            count: orphanedR2Keys.length,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        })
+      );
     }
 
     return {


### PR DESCRIPTION
## Summary

Fixes a metadata consistency race introduced by the queue batching work in #3744, which changed session-ingest from one DO RPC per item to batched `SessionIngestDO.ingest()` calls.

A batched ingest can persist item rows and then perform awaited side effects, like lifecycle alarm scheduling or orphaned R2 blob cleanup. If extractable metadata (`title`, `parentId`, `platform`, `orgId`, `gitUrl`, `gitBranch`, `status`) is written before those side effects finish, a failed RPC can leave the DO metadata updated without returning `changes` to the queue consumer. On retry, the DO sees the same metadata value and does not re-emit it, so Postgres/API consumers can stay stale.

This PR keeps metadata writes aligned with successful side effects:

- lifecycle alarm side effects run before extractable metadata is written, so alarm failure does not mark metadata as already emitted
- `closeReason` stays part of lifecycle handling and is still written before the post-close alarm
- orphaned R2 blob cleanup no longer blocks metadata persistence; it runs in `ctx.waitUntil()` after metadata changes are written/returned
- R2 cleanup failures are logged instead of failing the ingest RPC

The R2 cleanup ordering matters because R2 is external I/O. Awaiting it between timestamp-guarded item writes and metadata persistence can let another request for the same DO interleave, write newer metadata, then get overwritten by stale metadata from the resumed request. Moving cleanup to `waitUntil()` removes that interleaving window.

Test coverage added in `services/session-ingest/src/dos/SessionIngestDO.test.ts`:

- metadata-bearing payload with a failing lifecycle side effect rejects without writing extractable metadata
- `closeReason` is committed before alarm failure, while `title` is not
- orphaned R2 cleanup is scheduled after metadata is written
- stale ingest does not overwrite a simulated newer metadata write during R2 cleanup

## Verification

Local automated checks run after rebasing on `origin/main`:

- `pnpm exec oxfmt services/session-ingest/src/dos/SessionIngestDO.ts services/session-ingest/src/dos/SessionIngestDO.test.ts`
- `pnpm --filter cloudflare-session-ingest test -- src/dos/SessionIngestDO.test.ts` passed; Vitest executed the full session-ingest test suite (15 files, 283 tests)
- `pnpm --filter cloudflare-session-ingest typecheck` passed

## Visual Changes

N/A

## Reviewer Notes

N/A