### PR TITLE
fix(kiloclaw) admin feature to release stuck provision reservation

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -2767,12 +2767,12 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                       provisioning provider:
                       <ol className="mt-1 list-decimal space-y-0.5 pl-5 text-xs">
                         <li>
-                          Fly: run orphan-volume-scan for this instanceId and confirm the app
-                          (<code>inst-…</code>) has no machines or volumes, or is deleted.
+                          Fly: run orphan-volume-scan for this instanceId and confirm the app (
+                          <code>inst-…</code>) has no machines or volumes, or is deleted.
                         </li>
                         <li>
-                          Northflank: confirm the project (<code>kc-ki-…</code>) and its services and
-                          volumes no longer exist in the Northflank console.
+                          Northflank: confirm the project (<code>kc-ki-…</code>) and its services
+                          and volumes no longer exist in the Northflank console.
                         </li>
                       </ol>
                     </li>

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1407,6 +1407,20 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     })
   );
 
+  const { mutateAsync: releaseReservation, isPending: isReleasingReservation } = useMutation(
+    trpc.admin.kiloclawInstances.releaseReservation.mutationOptions({
+      onSuccess: result => {
+        toast.success(`Reservation released (was ${result.previousStatus})`);
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawInstances.registryEntries.queryKey(),
+        });
+      },
+      onError: err => {
+        toast.error(`Failed to release reservation: ${err.message}`);
+      },
+    })
+  );
+
   const { mutateAsync: restoreSnapshot, isPending: isRestoring } = useMutation(
     trpc.admin.kiloclawInstances.restoreVolumeSnapshot.mutationOptions({
       onSuccess: () => {
@@ -2639,6 +2653,79 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                       })}
                     </tbody>
                   </table>
+                </div>
+              )}
+
+              {registry.reservations.length > 0 && (
+                <div className="mt-6">
+                  <h4 className="mb-2 text-sm font-medium">Provision Reservations</h4>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b text-left text-muted-foreground">
+                          <th className="pb-2 pr-4">Instance ID</th>
+                          <th className="pb-2 pr-4">Status</th>
+                          <th className="pb-2 pr-4">Failure</th>
+                          <th className="pb-2 pr-4">Started</th>
+                          <th className="pb-2">Action</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {registry.reservations.map(reservation => {
+                          const isStuck =
+                            reservation.status === 'in_progress' ||
+                            reservation.status === 'failed_requires_reconciliation';
+                          const reservationOrgId = registry.registryKey.startsWith('org:')
+                            ? registry.registryKey.slice('org:'.length)
+                            : undefined;
+                          return (
+                            <tr key={reservation.instanceId} className="border-b">
+                              <td className="py-2 pr-4">
+                                <code className="text-xs">
+                                  {reservation.instanceId.slice(0, 8)}...
+                                </code>
+                              </td>
+                              <td className="py-2 pr-4">
+                                <Badge variant={isStuck ? 'destructive' : 'secondary'}>
+                                  {reservation.status}
+                                </Badge>
+                              </td>
+                              <td className="py-2 pr-4 text-xs text-muted-foreground">
+                                {reservation.failureCode ?? '—'}
+                              </td>
+                              <td className="py-2 pr-4 text-xs text-muted-foreground">
+                                {new Date(reservation.startedAt).toLocaleString()}
+                              </td>
+                              <td className="py-2">
+                                {isStuck ? (
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={isReleasingReservation}
+                                    title="Release this stuck reservation (no provider/Postgres changes) so the user can provision again"
+                                    onClick={() =>
+                                      void releaseReservation({
+                                        userId: reservation.assignedUserId,
+                                        instanceId: reservation.instanceId,
+                                        orgId: reservationOrgId,
+                                      })
+                                    }
+                                  >
+                                    {isReleasingReservation ? (
+                                      <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                                    ) : null}
+                                    Release
+                                  </Button>
+                                ) : (
+                                  <span className="text-xs text-muted-foreground">—</span>
+                                )}
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               )}
             </CardContent>

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1331,6 +1331,12 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
   const [restoreReason, setRestoreReason] = useState('');
   const [cleanupRecoveryVolumeDialogOpen, setCleanupRecoveryVolumeDialogOpen] = useState(false);
   const [inboundEmailCycleDialogOpen, setInboundEmailCycleDialogOpen] = useState(false);
+  const [releaseReservationTarget, setReleaseReservationTarget] = useState<{
+    instanceId: string;
+    userId: string;
+    orgId?: string;
+    status: string;
+  } | null>(null);
   const [awaitingRestoreCompletion, setAwaitingRestoreCompletion] = useState(false);
   const [sizeOverrideDialogOpen, setSizeOverrideDialogOpen] = useState(false);
   const [sizeOverrideMode, setSizeOverrideMode] = useState<'set' | 'clear'>('set');
@@ -2702,18 +2708,16 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                                     variant="outline"
                                     size="sm"
                                     disabled={isReleasingReservation}
-                                    title="Release this stuck reservation (no provider/Postgres changes) so the user can provision again"
+                                    title="Operator override — opens a confirmation with required pre-flight checks before releasing the admission lock"
                                     onClick={() =>
-                                      void releaseReservation({
+                                      setReleaseReservationTarget({
                                         userId: reservation.assignedUserId,
                                         instanceId: reservation.instanceId,
                                         orgId: reservationOrgId,
+                                        status: reservation.status,
                                       })
                                     }
                                   >
-                                    {isReleasingReservation ? (
-                                      <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-                                    ) : null}
                                     Release
                                   </Button>
                                 ) : (
@@ -2731,6 +2735,86 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
             </CardContent>
           </Card>
         ))}
+
+        {/* Break-glass confirm dialog for releasing a stuck provision reservation. */}
+        <Dialog
+          open={releaseReservationTarget !== null}
+          onOpenChange={open => {
+            if (!open) setReleaseReservationTarget(null);
+          }}
+        >
+          <DialogContent className="sm:max-w-[560px]">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <ShieldAlert className="h-5 w-5" />
+                Release stuck provision reservation
+              </DialogTitle>
+              <DialogDescription asChild>
+                <div className="max-h-[60vh] space-y-3 overflow-y-auto pr-1 text-sm">
+                  <p>
+                    This is a break-glass operator action. It clears the admission lock so the user
+                    can provision again. It does <strong>not</strong> delete any provider resources
+                    and does not touch Postgres.
+                  </p>
+                  <p className="font-medium text-foreground">
+                    Confirm ALL of the following before releasing:
+                  </p>
+                  <ul className="list-disc space-y-1 pl-5">
+                    <li>The provisioning attempt is dead (not still running).</li>
+                    <li>No active instance exists for this user/context.</li>
+                    <li>
+                      Provider resources from the failed attempt are destroyed — verify per the
+                      provisioning provider:
+                      <ol className="mt-1 list-decimal space-y-0.5 pl-5 text-xs">
+                        <li>
+                          Fly: run orphan-volume-scan for this instanceId and confirm the app
+                          (<code>inst-…</code>) has no machines or volumes, or is deleted.
+                        </li>
+                        <li>
+                          Northflank: confirm the project (<code>kc-ki-…</code>) and its services and
+                          volumes no longer exist in the Northflank console.
+                        </li>
+                      </ol>
+                    </li>
+                    <li>
+                      You understand that releasing while orphaned resources still exist can leave
+                      infrastructure that may hold the user&apos;s secrets.
+                    </li>
+                  </ul>
+                  {releaseReservationTarget && (
+                    <p className="text-xs text-muted-foreground">
+                      Reservation <code>{releaseReservationTarget.instanceId}</code> · status{' '}
+                      <code>{releaseReservationTarget.status}</code>
+                    </p>
+                  )}
+                </div>
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="gap-2 sm:gap-0">
+              <DialogClose asChild>
+                <Button variant="outline">Cancel</Button>
+              </DialogClose>
+              <Button
+                variant="destructive"
+                disabled={isReleasingReservation}
+                onClick={() => {
+                  if (!releaseReservationTarget) return;
+                  void releaseReservation({
+                    userId: releaseReservationTarget.userId,
+                    instanceId: releaseReservationTarget.instanceId,
+                    orgId: releaseReservationTarget.orgId,
+                    acknowledgeCleanupVerified: true,
+                  })
+                    .then(() => setReleaseReservationTarget(null))
+                    .catch(() => undefined);
+                }}
+              >
+                {isReleasingReservation ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
+                I&apos;ve verified — release
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
         <Card>
           <CardHeader>

--- a/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -318,6 +318,21 @@ export class KiloClawInternalClient {
     );
   }
 
+  async releaseProvisionReservation(
+    userId: string,
+    instanceId: string,
+    orgId?: string
+  ): Promise<{ ok: true; previousStatus: string }> {
+    return this.request(
+      '/api/platform/provision/release-reservation',
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId, instanceId, orgId }),
+      },
+      { userId }
+    );
+  }
+
   async start(
     userId: string,
     instanceId?: string,

--- a/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -321,13 +321,16 @@ export class KiloClawInternalClient {
   async releaseProvisionReservation(
     userId: string,
     instanceId: string,
-    orgId?: string
+    orgId: string | undefined,
+    acknowledgeCleanupVerified: true
   ): Promise<{ ok: true; previousStatus: string }> {
     return this.request(
       '/api/platform/provision/release-reservation',
       {
         method: 'POST',
-        body: JSON.stringify({ userId, instanceId, orgId }),
+        // The acknowledgement is threaded from the admin UI's break-glass
+        // confirmation through tRPC; the worker requires it to be exactly `true`.
+        body: JSON.stringify({ userId, instanceId, orgId, acknowledgeCleanupVerified }),
       },
       { userId }
     );

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -929,16 +929,22 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       return client.getRegistryEntries(input.userId, input.orgId ?? undefined);
     }),
 
-  // Release a STUCK provision reservation (status in_progress /
-  // failed_requires_reconciliation) so the user can provision again. The worker
-  // endpoint is guarded: it refuses reservations backing an active instance or
-  // already completed/released, and performs no provider/Postgres mutations.
+  // Admin break-glass: release a STUCK provision reservation (status
+  // in_progress / failed_requires_reconciliation) so the user can provision
+  // again. This is an operator action — the admin asserts (via the UI confirm
+  // dialog) that they have verified the attempt is dead and any provider
+  // resources are cleaned up. The worker mutates only the registry bookkeeping
+  // row (no provider/Postgres changes) and refuses reservations backing an
+  // active instance or in a non-releasable state.
   releaseReservation: adminProcedure
     .input(
       z.object({
         userId: z.string().min(1),
         instanceId: z.string().uuid(),
         orgId: z.string().uuid().optional(),
+        // Caller (the break-glass confirmation dialog) must supply this; enforced
+        // at the API boundary, not auto-inserted by the client.
+        acknowledgeCleanupVerified: z.literal(true),
       })
     )
     .mutation(async ({ input, ctx }) => {
@@ -946,7 +952,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       const result = await client.releaseProvisionReservation(
         input.userId,
         input.instanceId,
-        input.orgId
+        input.orgId,
+        input.acknowledgeCleanupVerified
       );
       await createKiloClawAdminAuditLog({
         action: 'kiloclaw.provision_reservation.release',
@@ -954,11 +961,14 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         actor_email: ctx.user.google_user_email,
         actor_name: ctx.user.google_user_name,
         target_user_id: input.userId,
-        message: `Released stuck provision reservation ${input.instanceId} (was ${result.previousStatus})`,
+        message:
+          `Break-glass released stuck provision reservation ${input.instanceId} ` +
+          `(was ${result.previousStatus}); operator asserted provider cleanup verified`,
         metadata: {
           instanceId: input.instanceId,
           orgId: input.orgId ?? null,
           previousStatus: result.previousStatus,
+          acknowledgeCleanupVerified: true,
         },
       });
       return result;

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -929,6 +929,41 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       return client.getRegistryEntries(input.userId, input.orgId ?? undefined);
     }),
 
+  // Release a STUCK provision reservation (status in_progress /
+  // failed_requires_reconciliation) so the user can provision again. The worker
+  // endpoint is guarded: it refuses reservations backing an active instance or
+  // already completed/released, and performs no provider/Postgres mutations.
+  releaseReservation: adminProcedure
+    .input(
+      z.object({
+        userId: z.string().min(1),
+        instanceId: z.string().uuid(),
+        orgId: z.string().uuid().optional(),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      const client = new KiloClawInternalClient();
+      const result = await client.releaseProvisionReservation(
+        input.userId,
+        input.instanceId,
+        input.orgId
+      );
+      await createKiloClawAdminAuditLog({
+        action: 'kiloclaw.provision_reservation.release',
+        actor_id: ctx.user.id,
+        actor_email: ctx.user.google_user_email,
+        actor_name: ctx.user.google_user_name,
+        target_user_id: input.userId,
+        message: `Released stuck provision reservation ${input.instanceId} (was ${result.previousStatus})`,
+        metadata: {
+          instanceId: input.instanceId,
+          orgId: input.orgId ?? null,
+          previousStatus: result.previousStatus,
+        },
+      });
+      return result;
+    }),
+
   list: adminProcedure.input(ListInstancesSchema).query(async ({ input }) => {
     const { offset, limit, sortBy, sortOrder, search, status, imageTag, hasSizeOverride } = input;
     const searchTerm = search?.trim() || '';

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -554,6 +554,7 @@ export const KiloClawAdminAuditAction = z.enum([
   'kiloclaw.scheduled_action.created',
   'kiloclaw.fleet_upgrade.created',
   'kiloclaw.scheduled_action.cancelled',
+  'kiloclaw.provision_reservation.release',
 ]);
 
 export type KiloClawAdminAuditAction = z.infer<typeof KiloClawAdminAuditAction>;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-registry.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-registry.test.ts
@@ -328,8 +328,6 @@ describe('KiloClawRegistry fresh provision reservations', () => {
 });
 
 describe('KiloClawRegistry.adminReleaseStuckReservation', () => {
-  const STALE_MS = 15 * 60 * 1000;
-
   beforeEach(() => {
     databaseRows.instances.length = 0;
     databaseRows.reservations.length = 0;
@@ -348,8 +346,8 @@ describe('KiloClawRegistry.adminReleaseStuckReservation', () => {
       'user:user-1',
       'user-1',
       'instance-1',
-      'manual_admin_release',
-      STALE_MS
+      'failed_requires_reconciliation',
+      'manual_admin_release'
     );
     expect(result).toEqual({
       outcome: 'released',
@@ -361,53 +359,40 @@ describe('KiloClawRegistry.adminReleaseStuckReservation', () => {
     expect(retry.outcome).toBe('admitted');
   });
 
-  it('releases an in_progress reservation only once it is stale', async () => {
+  it('releases an in_progress reservation matching the expected status', async () => {
     const registry = new KiloClawRegistry(createState() as never, {} as never);
     await registry.beginFreshProvision('user:user-1', 'user-1', 'instance-1', 'do-1');
-    // Age the reservation past the staleness threshold.
-    databaseRows.reservations[0].updated_at = new Date(Date.now() - 20 * 60 * 1000).toISOString();
 
     const result = await registry.adminReleaseStuckReservation(
       'user:user-1',
       'user-1',
       'instance-1',
-      'manual_admin_release',
-      STALE_MS
+      'in_progress',
+      'manual_admin_release'
     );
     expect(result).toEqual({ outcome: 'released', previousStatus: 'in_progress' });
   });
 
-  it('refuses to release a fresh in_progress reservation (executor may still be running)', async () => {
+  it('reports status_changed when the row no longer matches the expected status', async () => {
     const registry = new KiloClawRegistry(createState() as never, {} as never);
     await registry.beginFreshProvision('user:user-1', 'user-1', 'instance-1', 'do-1');
-
-    const result = await registry.adminReleaseStuckReservation(
-      'user:user-1',
-      'user-1',
-      'instance-1',
-      'manual_admin_release',
-      STALE_MS
-    );
-    expect(result.outcome).toBe('in_progress_too_fresh');
-
-    // Still blocks a duplicate provision.
-    const blocked = await registry.beginFreshProvision('user:user-1', 'user-1', 'instance-2', 'do-2');
-    expect(blocked.outcome).toBe('conflict');
-  });
-
-  it('refuses to release a completed reservation', async () => {
-    const registry = new KiloClawRegistry(createState() as never, {} as never);
-    await registry.beginFreshProvision('user:user-1', 'user-1', 'instance-1', 'do-1');
+    // Caller validated in_progress, but it completed before the release landed.
     await registry.completeFreshProvision('user:user-1', 'user-1', 'instance-1', 'do-1');
 
     const result = await registry.adminReleaseStuckReservation(
       'user:user-1',
       'user-1',
       'instance-1',
-      'manual_admin_release',
-      STALE_MS
+      'in_progress',
+      'manual_admin_release'
     );
-    expect(result).toEqual({ outcome: 'not_releasable', status: 'completed' });
+    expect(result).toEqual({ outcome: 'status_changed', status: 'completed' });
+
+    // The completed reservation is untouched.
+    const all = await registry.listAllInstances('user:user-1');
+    expect(all.reservations).toEqual([
+      expect.objectContaining({ instanceId: 'instance-1', status: 'completed' }),
+    ]);
   });
 
   it('returns not_found when no reservation exists for the instance', async () => {
@@ -417,8 +402,8 @@ describe('KiloClawRegistry.adminReleaseStuckReservation', () => {
       'user:user-1',
       'user-1',
       'missing-instance',
-      'manual_admin_release',
-      STALE_MS
+      'failed_requires_reconciliation',
+      'manual_admin_release'
     );
     expect(result).toEqual({ outcome: 'not_found' });
   });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-registry.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-registry.test.ts
@@ -326,3 +326,100 @@ describe('KiloClawRegistry fresh provision reservations', () => {
     expect(await registry.listInstances('user:user-1')).toEqual([]);
   });
 });
+
+describe('KiloClawRegistry.adminReleaseStuckReservation', () => {
+  const STALE_MS = 15 * 60 * 1000;
+
+  beforeEach(() => {
+    databaseRows.instances.length = 0;
+    databaseRows.reservations.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('releases a failed_requires_reconciliation reservation and unblocks new provisions', async () => {
+    const registry = new KiloClawRegistry(createState() as never, {} as never);
+    await registry.beginFreshProvision('user:user-1', 'user-1', 'instance-1', 'do-1');
+    await registry.failFreshProvision('user:user-1', 'user-1', 'instance-1', 'provider_failed');
+
+    const result = await registry.adminReleaseStuckReservation(
+      'user:user-1',
+      'user-1',
+      'instance-1',
+      'manual_admin_release',
+      STALE_MS
+    );
+    expect(result).toEqual({
+      outcome: 'released',
+      previousStatus: 'failed_requires_reconciliation',
+    });
+
+    // Admission lock is gone — a fresh provision is admitted again.
+    const retry = await registry.beginFreshProvision('user:user-1', 'user-1', 'instance-2', 'do-2');
+    expect(retry.outcome).toBe('admitted');
+  });
+
+  it('releases an in_progress reservation only once it is stale', async () => {
+    const registry = new KiloClawRegistry(createState() as never, {} as never);
+    await registry.beginFreshProvision('user:user-1', 'user-1', 'instance-1', 'do-1');
+    // Age the reservation past the staleness threshold.
+    databaseRows.reservations[0].updated_at = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+
+    const result = await registry.adminReleaseStuckReservation(
+      'user:user-1',
+      'user-1',
+      'instance-1',
+      'manual_admin_release',
+      STALE_MS
+    );
+    expect(result).toEqual({ outcome: 'released', previousStatus: 'in_progress' });
+  });
+
+  it('refuses to release a fresh in_progress reservation (executor may still be running)', async () => {
+    const registry = new KiloClawRegistry(createState() as never, {} as never);
+    await registry.beginFreshProvision('user:user-1', 'user-1', 'instance-1', 'do-1');
+
+    const result = await registry.adminReleaseStuckReservation(
+      'user:user-1',
+      'user-1',
+      'instance-1',
+      'manual_admin_release',
+      STALE_MS
+    );
+    expect(result.outcome).toBe('in_progress_too_fresh');
+
+    // Still blocks a duplicate provision.
+    const blocked = await registry.beginFreshProvision('user:user-1', 'user-1', 'instance-2', 'do-2');
+    expect(blocked.outcome).toBe('conflict');
+  });
+
+  it('refuses to release a completed reservation', async () => {
+    const registry = new KiloClawRegistry(createState() as never, {} as never);
+    await registry.beginFreshProvision('user:user-1', 'user-1', 'instance-1', 'do-1');
+    await registry.completeFreshProvision('user:user-1', 'user-1', 'instance-1', 'do-1');
+
+    const result = await registry.adminReleaseStuckReservation(
+      'user:user-1',
+      'user-1',
+      'instance-1',
+      'manual_admin_release',
+      STALE_MS
+    );
+    expect(result).toEqual({ outcome: 'not_releasable', status: 'completed' });
+  });
+
+  it('returns not_found when no reservation exists for the instance', async () => {
+    const registry = new KiloClawRegistry(createState() as never, {} as never);
+
+    const result = await registry.adminReleaseStuckReservation(
+      'user:user-1',
+      'user-1',
+      'missing-instance',
+      'manual_admin_release',
+      STALE_MS
+    );
+    expect(result).toEqual({ outcome: 'not_found' });
+  });
+});

--- a/services/kiloclaw/src/durable-objects/kiloclaw-registry.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-registry.ts
@@ -39,6 +39,12 @@ export type BeginFreshProvisionResult =
   | { outcome: 'admitted'; reservation: ProvisionReservationEntry }
   | { outcome: 'conflict'; reservation: ProvisionReservationEntry };
 
+export type AdminReleaseReservationResult =
+  | { outcome: 'released'; previousStatus: 'in_progress' | 'failed_requires_reconciliation' }
+  | { outcome: 'not_found' }
+  | { outcome: 'not_releasable'; status: ProvisionReservationStatus }
+  | { outcome: 'in_progress_too_fresh'; updatedAt: string };
+
 function rowToEntry(row: typeof registryInstances.$inferSelect): RegistryEntry {
   return {
     instanceId: row.instance_id,
@@ -277,6 +283,66 @@ export class KiloClawRegistry extends DurableObject<KiloClawEnv> {
         )
       )
       .run();
+  }
+
+  /**
+   * Atomically release a STUCK reservation for an admin/operator. Unlike
+   * `releaseFreshProvision`, this validates and transitions in a single
+   * `transactionSync` so it cannot race a concurrent
+   * `completeFreshProvision`/`finalizeDestroyedInstance` (the read+write are
+   * not split across RPCs), and it refuses to touch `completed`/`released`.
+   *
+   * `in_progress` is only releasable once it is provably stale (older than
+   * `inProgressMaxAgeMs`) — a live in-flight provision must keep its admission
+   * lock. `failed_requires_reconciliation` is releasable here; the route layer
+   * is responsible for confirming no provider resources remain first.
+   */
+  async adminReleaseStuckReservation(
+    ownerKey: string,
+    assignedUserId: string,
+    instanceId: string,
+    reason: string,
+    inProgressMaxAgeMs: number
+  ): Promise<AdminReleaseReservationResult> {
+    await this.ensureOwnerKey(ownerKey);
+    const now = new Date();
+    return this.ctx.storage.transactionSync(() => {
+      const row = this.db
+        .select()
+        .from(registryProvisionReservations)
+        .where(
+          and(
+            eq(registryProvisionReservations.instance_id, instanceId),
+            eq(registryProvisionReservations.assigned_user_id, assignedUserId)
+          )
+        )
+        .get();
+      if (!row) return { outcome: 'not_found' };
+      const previousStatus = row.status;
+      if (previousStatus !== 'in_progress' && previousStatus !== 'failed_requires_reconciliation') {
+        return { outcome: 'not_releasable', status: previousStatus };
+      }
+      if (previousStatus === 'in_progress') {
+        const ageMs = now.getTime() - new Date(row.updated_at).getTime();
+        if (ageMs < inProgressMaxAgeMs) {
+          return { outcome: 'in_progress_too_fresh', updatedAt: row.updated_at };
+        }
+      }
+      // Compare-and-set on the exact observed status. Redundant with the
+      // surrounding transaction but makes the intended invariant explicit.
+      this.db
+        .update(registryProvisionReservations)
+        .set({ status: 'released', updated_at: now.toISOString(), resolution_reason: reason })
+        .where(
+          and(
+            eq(registryProvisionReservations.instance_id, instanceId),
+            eq(registryProvisionReservations.assigned_user_id, assignedUserId),
+            eq(registryProvisionReservations.status, previousStatus)
+          )
+        )
+        .run();
+      return { outcome: 'released', previousStatus };
+    });
   }
 
   async listProvisionReservations(ownerKey: string): Promise<ProvisionReservationEntry[]> {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-registry.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-registry.ts
@@ -39,11 +39,12 @@ export type BeginFreshProvisionResult =
   | { outcome: 'admitted'; reservation: ProvisionReservationEntry }
   | { outcome: 'conflict'; reservation: ProvisionReservationEntry };
 
+export type ReleasableReservationStatus = 'in_progress' | 'failed_requires_reconciliation';
+
 export type AdminReleaseReservationResult =
-  | { outcome: 'released'; previousStatus: 'in_progress' | 'failed_requires_reconciliation' }
+  | { outcome: 'released'; previousStatus: ReleasableReservationStatus }
   | { outcome: 'not_found' }
-  | { outcome: 'not_releasable'; status: ProvisionReservationStatus }
-  | { outcome: 'in_progress_too_fresh'; updatedAt: string };
+  | { outcome: 'status_changed'; status: ProvisionReservationStatus };
 
 function rowToEntry(row: typeof registryInstances.$inferSelect): RegistryEntry {
   return {
@@ -286,26 +287,27 @@ export class KiloClawRegistry extends DurableObject<KiloClawEnv> {
   }
 
   /**
-   * Atomically release a STUCK reservation for an admin/operator. Unlike
-   * `releaseFreshProvision`, this validates and transitions in a single
-   * `transactionSync` so it cannot race a concurrent
-   * `completeFreshProvision`/`finalizeDestroyedInstance` (the read+write are
-   * not split across RPCs), and it refuses to touch `completed`/`released`.
+   * Atomically release a stuck reservation as an explicit admin/operator
+   * break-glass action. This is NOT an autonomous safety decision: the caller
+   * (an authenticated admin) is asserting they have already confirmed the
+   * attempt is dead and any provider resources are cleaned up. The audit log on
+   * the route records that assertion.
    *
-   * `in_progress` is only releasable once it is provably stale (older than
-   * `inProgressMaxAgeMs`) — a live in-flight provision must keep its admission
-   * lock. `failed_requires_reconciliation` is releasable here; the route layer
-   * is responsible for confirming no provider resources remain first.
+   * Validation + transition happen in a single `transactionSync` so the read
+   * and write cannot be split across RPCs. The release is a compare-and-set on
+   * `expectedStatus` — the exact status the caller validated — so a reservation
+   * that changed underneath (e.g. a concurrent `completeFreshProvision`) is
+   * reported as `status_changed` rather than silently released.
    */
   async adminReleaseStuckReservation(
     ownerKey: string,
     assignedUserId: string,
     instanceId: string,
-    reason: string,
-    inProgressMaxAgeMs: number
+    expectedStatus: ReleasableReservationStatus,
+    reason: string
   ): Promise<AdminReleaseReservationResult> {
     await this.ensureOwnerKey(ownerKey);
-    const now = new Date();
+    const now = new Date().toISOString();
     return this.ctx.storage.transactionSync(() => {
       const row = this.db
         .select()
@@ -318,30 +320,21 @@ export class KiloClawRegistry extends DurableObject<KiloClawEnv> {
         )
         .get();
       if (!row) return { outcome: 'not_found' };
-      const previousStatus = row.status;
-      if (previousStatus !== 'in_progress' && previousStatus !== 'failed_requires_reconciliation') {
-        return { outcome: 'not_releasable', status: previousStatus };
+      if (row.status !== expectedStatus) {
+        return { outcome: 'status_changed', status: row.status };
       }
-      if (previousStatus === 'in_progress') {
-        const ageMs = now.getTime() - new Date(row.updated_at).getTime();
-        if (ageMs < inProgressMaxAgeMs) {
-          return { outcome: 'in_progress_too_fresh', updatedAt: row.updated_at };
-        }
-      }
-      // Compare-and-set on the exact observed status. Redundant with the
-      // surrounding transaction but makes the intended invariant explicit.
       this.db
         .update(registryProvisionReservations)
-        .set({ status: 'released', updated_at: now.toISOString(), resolution_reason: reason })
+        .set({ status: 'released', updated_at: now, resolution_reason: reason })
         .where(
           and(
             eq(registryProvisionReservations.instance_id, instanceId),
             eq(registryProvisionReservations.assigned_user_id, assignedUserId),
-            eq(registryProvisionReservations.status, previousStatus)
+            eq(registryProvisionReservations.status, expectedStatus)
           )
         )
         .run();
-      return { outcome: 'released', previousStatus };
+      return { outcome: 'released', previousStatus: expectedStatus };
     });
   }
 

--- a/services/kiloclaw/src/routes/platform-release-reservation.test.ts
+++ b/services/kiloclaw/src/routes/platform-release-reservation.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { platform } from './platform';
-import { getActivePersonalInstance } from '../db';
+import { getActivePersonalInstance, getActiveOrganizationInstance } from '../db';
 import type * as DbModule from '../db';
 
 vi.mock('cloudflare:workers', () => ({
@@ -14,11 +14,13 @@ vi.mock('../db', async () => {
     ...actual,
     getWorkerDb: vi.fn(() => ({})),
     getActivePersonalInstance: vi.fn(),
+    getActiveOrganizationInstance: vi.fn(),
   };
 });
 
 const USER_ID = 'user-1';
 const INSTANCE_ID = '0ef67a15-64d5-450e-a128-df0f22969ac9';
+const ORG_ID = '11111111-2222-4333-8444-555555555555';
 
 type Reservation = { instanceId: string; status: string };
 
@@ -57,6 +59,7 @@ function releaseInit(body?: Record<string, unknown>) {
 
 beforeEach(() => {
   vi.mocked(getActivePersonalInstance).mockReset().mockResolvedValue(null);
+  vi.mocked(getActiveOrganizationInstance).mockReset().mockResolvedValue(null);
   vi.spyOn(console, 'error').mockImplementation(() => undefined);
 });
 
@@ -98,6 +101,55 @@ describe('POST /provision/release-reservation', () => {
     expect(res.status).toBe(409);
     expect(((await res.json()) as { code?: string }).code).toBe('reservation_active');
     expect(adminReleaseStuckReservation).not.toHaveBeenCalled();
+  });
+
+  it('refuses an org-context reservation backing a live active org instance', async () => {
+    vi.mocked(getActiveOrganizationInstance).mockResolvedValue({ id: INSTANCE_ID } as never);
+    const { env, adminReleaseStuckReservation } = makeEnv();
+
+    const res = await platform.request(
+      '/provision/release-reservation',
+      releaseInit({
+        userId: USER_ID,
+        instanceId: INSTANCE_ID,
+        orgId: ORG_ID,
+        acknowledgeCleanupVerified: true,
+      }),
+      env
+    );
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { code?: string }).code).toBe('reservation_active');
+    // The org path must use the org lookup, not the personal one.
+    expect(getActiveOrganizationInstance).toHaveBeenCalled();
+    expect(getActivePersonalInstance).not.toHaveBeenCalled();
+    expect(adminReleaseStuckReservation).not.toHaveBeenCalled();
+  });
+
+  it('releases an org-context reservation', async () => {
+    const { env, adminReleaseStuckReservation } = makeEnv({
+      reservations: [{ instanceId: INSTANCE_ID, status: 'failed_requires_reconciliation' }],
+      releaseResult: { outcome: 'released', previousStatus: 'failed_requires_reconciliation' },
+    });
+
+    const res = await platform.request(
+      '/provision/release-reservation',
+      releaseInit({
+        userId: USER_ID,
+        instanceId: INSTANCE_ID,
+        orgId: ORG_ID,
+        acknowledgeCleanupVerified: true,
+      }),
+      env
+    );
+    expect(res.status).toBe(200);
+    expect(getActiveOrganizationInstance).toHaveBeenCalled();
+    expect(adminReleaseStuckReservation).toHaveBeenCalledWith(
+      expect.any(String),
+      USER_ID,
+      INSTANCE_ID,
+      'failed_requires_reconciliation',
+      'manual_admin_release'
+    );
   });
 
   it('returns 404 when no reservation exists for the instance', async () => {

--- a/services/kiloclaw/src/routes/platform-release-reservation.test.ts
+++ b/services/kiloclaw/src/routes/platform-release-reservation.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { platform } from './platform';
-import * as fly from '../fly/client';
-import type * as FlyClient from '../fly/client';
-import * as flyApps from '../fly/apps';
-import type * as FlyApps from '../fly/apps';
 import { getActivePersonalInstance } from '../db';
 import type * as DbModule from '../db';
 
@@ -11,20 +7,6 @@ vi.mock('cloudflare:workers', () => ({
   DurableObject: class {},
   waitUntil: (promise: Promise<unknown>) => promise,
 }));
-
-vi.mock('../fly/client', async () => {
-  const actual = await vi.importActual<typeof FlyClient>('../fly/client');
-  return { ...actual, listMachines: vi.fn(), listVolumes: vi.fn() };
-});
-
-vi.mock('../fly/apps', async () => {
-  const actual = await vi.importActual<typeof FlyApps>('../fly/apps');
-  return {
-    ...actual,
-    getApp: vi.fn(),
-    appNameFromInstanceId: vi.fn().mockResolvedValue('inst-testapp'),
-  };
-});
 
 vi.mock('../db', async () => {
   const actual = await vi.importActual<typeof DbModule>('../db');
@@ -40,21 +22,18 @@ const INSTANCE_ID = '0ef67a15-64d5-450e-a128-df0f22969ac9';
 
 type Reservation = { instanceId: string; status: string };
 
-function makeEnv(opts?: {
-  flyApiToken?: string | null;
-  reservations?: Reservation[];
-  releaseResult?: unknown;
-}) {
+function makeEnv(opts?: { reservations?: Reservation[]; releaseResult?: unknown }) {
   const listAllInstances = vi
     .fn()
     .mockResolvedValue({ entries: [], reservations: opts?.reservations ?? [], migrated: true });
-  const adminReleaseStuckReservation = vi
-    .fn()
-    .mockResolvedValue(opts?.releaseResult ?? { outcome: 'released', previousStatus: 'in_progress' });
-  const flyApiToken = opts?.flyApiToken === undefined ? 'test-token' : opts.flyApiToken;
+  const adminReleaseStuckReservation = vi.fn().mockResolvedValue(
+    opts?.releaseResult ?? {
+      outcome: 'released',
+      previousStatus: 'failed_requires_reconciliation',
+    }
+  );
   return {
     env: {
-      FLY_API_TOKEN: flyApiToken ?? undefined,
       HYPERDRIVE: { connectionString: 'postgres://test' },
       KILOCLAW_REGISTRY: {
         idFromName: (id: string) => id,
@@ -66,19 +45,18 @@ function makeEnv(opts?: {
   };
 }
 
-function releaseInit() {
+function releaseInit(body?: Record<string, unknown>) {
   return {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ userId: USER_ID, instanceId: INSTANCE_ID }),
+    body: JSON.stringify(
+      body ?? { userId: USER_ID, instanceId: INSTANCE_ID, acknowledgeCleanupVerified: true }
+    ),
   };
 }
 
 beforeEach(() => {
   vi.mocked(getActivePersonalInstance).mockReset().mockResolvedValue(null);
-  vi.mocked(fly.listMachines).mockReset().mockResolvedValue([]);
-  vi.mocked(fly.listVolumes).mockReset().mockResolvedValue([]);
-  vi.mocked(flyApps.getApp).mockReset().mockResolvedValue(null);
   vi.spyOn(console, 'error').mockImplementation(() => undefined);
 });
 
@@ -87,6 +65,31 @@ afterEach(() => {
 });
 
 describe('POST /provision/release-reservation', () => {
+  it('rejects a request missing the cleanup acknowledgement', async () => {
+    const { env, adminReleaseStuckReservation } = makeEnv({
+      reservations: [{ instanceId: INSTANCE_ID, status: 'failed_requires_reconciliation' }],
+    });
+    const res = await platform.request(
+      '/provision/release-reservation',
+      releaseInit({ userId: USER_ID, instanceId: INSTANCE_ID }),
+      env
+    );
+    expect(res.status).toBe(400);
+    expect(adminReleaseStuckReservation).not.toHaveBeenCalled();
+  });
+
+  it('rejects a falsey cleanup acknowledgement', async () => {
+    const { env } = makeEnv({
+      reservations: [{ instanceId: INSTANCE_ID, status: 'failed_requires_reconciliation' }],
+    });
+    const res = await platform.request(
+      '/provision/release-reservation',
+      releaseInit({ userId: USER_ID, instanceId: INSTANCE_ID, acknowledgeCleanupVerified: false }),
+      env
+    );
+    expect(res.status).toBe(400);
+  });
+
   it('refuses when the reservation backs a live active instance', async () => {
     vi.mocked(getActivePersonalInstance).mockResolvedValue({ id: INSTANCE_ID } as never);
     const { env, adminReleaseStuckReservation } = makeEnv();
@@ -114,21 +117,7 @@ describe('POST /provision/release-reservation', () => {
     expect(adminReleaseStuckReservation).not.toHaveBeenCalled();
   });
 
-  it('refuses failed_requires_reconciliation when provider resources still exist', async () => {
-    vi.mocked(flyApps.getApp).mockResolvedValue({ id: 'app', created_at: 1 } as never);
-    vi.mocked(fly.listMachines).mockResolvedValue([{ id: 'm1' } as never]);
-    const { env, adminReleaseStuckReservation } = makeEnv({
-      reservations: [{ instanceId: INSTANCE_ID, status: 'failed_requires_reconciliation' }],
-    });
-
-    const res = await platform.request('/provision/release-reservation', releaseInit(), env);
-    expect(res.status).toBe(409);
-    expect(((await res.json()) as { code?: string }).code).toBe('provider_resources_present');
-    expect(adminReleaseStuckReservation).not.toHaveBeenCalled();
-  });
-
-  it('releases failed_requires_reconciliation when no Fly app remains', async () => {
-    vi.mocked(flyApps.getApp).mockResolvedValue(null);
+  it('releases a failed_requires_reconciliation reservation with the validated status', async () => {
     const { env, adminReleaseStuckReservation } = makeEnv({
       reservations: [{ instanceId: INSTANCE_ID, status: 'failed_requires_reconciliation' }],
       releaseResult: { outcome: 'released', previousStatus: 'failed_requires_reconciliation' },
@@ -140,31 +129,24 @@ describe('POST /provision/release-reservation', () => {
       ok: true,
       previousStatus: 'failed_requires_reconciliation',
     });
-    expect(adminReleaseStuckReservation).toHaveBeenCalledOnce();
+    expect(adminReleaseStuckReservation).toHaveBeenCalledWith(
+      expect.any(String),
+      USER_ID,
+      INSTANCE_ID,
+      'failed_requires_reconciliation',
+      'manual_admin_release'
+    );
   });
 
-  it('returns 503 when FLY_API_TOKEN is missing for a reconciliation release', async () => {
-    const { env, adminReleaseStuckReservation } = makeEnv({
-      flyApiToken: null,
-      reservations: [{ instanceId: INSTANCE_ID, status: 'failed_requires_reconciliation' }],
-    });
-
-    const res = await platform.request('/provision/release-reservation', releaseInit(), env);
-    expect(res.status).toBe(503);
-    expect(((await res.json()) as { code?: string }).code).toBe('provider_check_unavailable');
-    expect(adminReleaseStuckReservation).not.toHaveBeenCalled();
-  });
-
-  it('maps a still-fresh in_progress reservation to 409 (no Fly check needed)', async () => {
+  it('maps a concurrent status change to 409', async () => {
     const { env } = makeEnv({
       reservations: [{ instanceId: INSTANCE_ID, status: 'in_progress' }],
-      releaseResult: { outcome: 'in_progress_too_fresh', updatedAt: '2026-06-04T13:54:51.966Z' },
+      releaseResult: { outcome: 'status_changed', status: 'completed' },
     });
 
     const res = await platform.request('/provision/release-reservation', releaseInit(), env);
     expect(res.status).toBe(409);
-    expect(((await res.json()) as { code?: string }).code).toBe('reservation_in_progress_active');
-    expect(flyApps.getApp).not.toHaveBeenCalled();
+    expect(((await res.json()) as { code?: string }).code).toBe('reservation_status_changed');
   });
 
   it('releases a stale in_progress reservation', async () => {

--- a/services/kiloclaw/src/routes/platform-release-reservation.test.ts
+++ b/services/kiloclaw/src/routes/platform-release-reservation.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { platform } from './platform';
+import * as fly from '../fly/client';
+import type * as FlyClient from '../fly/client';
+import * as flyApps from '../fly/apps';
+import type * as FlyApps from '../fly/apps';
+import { getActivePersonalInstance } from '../db';
+import type * as DbModule from '../db';
+
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class {},
+  waitUntil: (promise: Promise<unknown>) => promise,
+}));
+
+vi.mock('../fly/client', async () => {
+  const actual = await vi.importActual<typeof FlyClient>('../fly/client');
+  return { ...actual, listMachines: vi.fn(), listVolumes: vi.fn() };
+});
+
+vi.mock('../fly/apps', async () => {
+  const actual = await vi.importActual<typeof FlyApps>('../fly/apps');
+  return {
+    ...actual,
+    getApp: vi.fn(),
+    appNameFromInstanceId: vi.fn().mockResolvedValue('inst-testapp'),
+  };
+});
+
+vi.mock('../db', async () => {
+  const actual = await vi.importActual<typeof DbModule>('../db');
+  return {
+    ...actual,
+    getWorkerDb: vi.fn(() => ({})),
+    getActivePersonalInstance: vi.fn(),
+  };
+});
+
+const USER_ID = 'user-1';
+const INSTANCE_ID = '0ef67a15-64d5-450e-a128-df0f22969ac9';
+
+type Reservation = { instanceId: string; status: string };
+
+function makeEnv(opts?: {
+  flyApiToken?: string | null;
+  reservations?: Reservation[];
+  releaseResult?: unknown;
+}) {
+  const listAllInstances = vi
+    .fn()
+    .mockResolvedValue({ entries: [], reservations: opts?.reservations ?? [], migrated: true });
+  const adminReleaseStuckReservation = vi
+    .fn()
+    .mockResolvedValue(opts?.releaseResult ?? { outcome: 'released', previousStatus: 'in_progress' });
+  const flyApiToken = opts?.flyApiToken === undefined ? 'test-token' : opts.flyApiToken;
+  return {
+    env: {
+      FLY_API_TOKEN: flyApiToken ?? undefined,
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+      KILOCLAW_REGISTRY: {
+        idFromName: (id: string) => id,
+        get: () => ({ listAllInstances, adminReleaseStuckReservation }),
+      },
+    } as never,
+    listAllInstances,
+    adminReleaseStuckReservation,
+  };
+}
+
+function releaseInit() {
+  return {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ userId: USER_ID, instanceId: INSTANCE_ID }),
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(getActivePersonalInstance).mockReset().mockResolvedValue(null);
+  vi.mocked(fly.listMachines).mockReset().mockResolvedValue([]);
+  vi.mocked(fly.listVolumes).mockReset().mockResolvedValue([]);
+  vi.mocked(flyApps.getApp).mockReset().mockResolvedValue(null);
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('POST /provision/release-reservation', () => {
+  it('refuses when the reservation backs a live active instance', async () => {
+    vi.mocked(getActivePersonalInstance).mockResolvedValue({ id: INSTANCE_ID } as never);
+    const { env, adminReleaseStuckReservation } = makeEnv();
+
+    const res = await platform.request('/provision/release-reservation', releaseInit(), env);
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { code?: string }).code).toBe('reservation_active');
+    expect(adminReleaseStuckReservation).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when no reservation exists for the instance', async () => {
+    const { env } = makeEnv({ reservations: [] });
+    const res = await platform.request('/provision/release-reservation', releaseInit(), env);
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { code?: string }).code).toBe('reservation_not_found');
+  });
+
+  it('refuses a non-releasable (completed) reservation', async () => {
+    const { env, adminReleaseStuckReservation } = makeEnv({
+      reservations: [{ instanceId: INSTANCE_ID, status: 'completed' }],
+    });
+    const res = await platform.request('/provision/release-reservation', releaseInit(), env);
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { code?: string }).code).toBe('reservation_not_releasable');
+    expect(adminReleaseStuckReservation).not.toHaveBeenCalled();
+  });
+
+  it('refuses failed_requires_reconciliation when provider resources still exist', async () => {
+    vi.mocked(flyApps.getApp).mockResolvedValue({ id: 'app', created_at: 1 } as never);
+    vi.mocked(fly.listMachines).mockResolvedValue([{ id: 'm1' } as never]);
+    const { env, adminReleaseStuckReservation } = makeEnv({
+      reservations: [{ instanceId: INSTANCE_ID, status: 'failed_requires_reconciliation' }],
+    });
+
+    const res = await platform.request('/provision/release-reservation', releaseInit(), env);
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { code?: string }).code).toBe('provider_resources_present');
+    expect(adminReleaseStuckReservation).not.toHaveBeenCalled();
+  });
+
+  it('releases failed_requires_reconciliation when no Fly app remains', async () => {
+    vi.mocked(flyApps.getApp).mockResolvedValue(null);
+    const { env, adminReleaseStuckReservation } = makeEnv({
+      reservations: [{ instanceId: INSTANCE_ID, status: 'failed_requires_reconciliation' }],
+      releaseResult: { outcome: 'released', previousStatus: 'failed_requires_reconciliation' },
+    });
+
+    const res = await platform.request('/provision/release-reservation', releaseInit(), env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      previousStatus: 'failed_requires_reconciliation',
+    });
+    expect(adminReleaseStuckReservation).toHaveBeenCalledOnce();
+  });
+
+  it('returns 503 when FLY_API_TOKEN is missing for a reconciliation release', async () => {
+    const { env, adminReleaseStuckReservation } = makeEnv({
+      flyApiToken: null,
+      reservations: [{ instanceId: INSTANCE_ID, status: 'failed_requires_reconciliation' }],
+    });
+
+    const res = await platform.request('/provision/release-reservation', releaseInit(), env);
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { code?: string }).code).toBe('provider_check_unavailable');
+    expect(adminReleaseStuckReservation).not.toHaveBeenCalled();
+  });
+
+  it('maps a still-fresh in_progress reservation to 409 (no Fly check needed)', async () => {
+    const { env } = makeEnv({
+      reservations: [{ instanceId: INSTANCE_ID, status: 'in_progress' }],
+      releaseResult: { outcome: 'in_progress_too_fresh', updatedAt: '2026-06-04T13:54:51.966Z' },
+    });
+
+    const res = await platform.request('/provision/release-reservation', releaseInit(), env);
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { code?: string }).code).toBe('reservation_in_progress_active');
+    expect(flyApps.getApp).not.toHaveBeenCalled();
+  });
+
+  it('releases a stale in_progress reservation', async () => {
+    const { env } = makeEnv({
+      reservations: [{ instanceId: INSTANCE_ID, status: 'in_progress' }],
+      releaseResult: { outcome: 'released', previousStatus: 'in_progress' },
+    });
+
+    const res = await platform.request('/provision/release-reservation', releaseInit(), env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, previousStatus: 'in_progress' });
+  });
+});

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1866,6 +1866,71 @@ platform.post('/provision/repair-reservation', async c => {
   }
 });
 
+// POST /api/platform/provision/release-reservation
+// Surgically resolves a STUCK provision reservation (status `in_progress` or
+// `failed_requires_reconciliation`) so the user can provision again. A failed
+// fresh provision can leave such a row behind (e.g. `provider_provision_failed`
+// during a provider outage); the partial unique index then rejects every new
+// provision with `provision_in_progress` ("An instance is already being
+// created"), and nothing auto-heals it because no instance/DO exists to finalize
+// a destroy.
+//
+// Unlike `/destroy`, this issues NO provider (Fly) calls and mutates NO Postgres
+// state -- it flips a single registry bookkeeping row to `released`. It is
+// guarded to refuse releasing a reservation that backs a live active instance or
+// that is already `completed`/`released`.
+platform.post('/provision/release-reservation', async c => {
+  const result = await parseBody(c, ProvisionReservationRepairSchema);
+  if ('error' in result) return result.error;
+  const { userId, instanceId, orgId } = result.data;
+
+  try {
+    // Defense in depth: never release a reservation that belongs to a
+    // currently-active instance.
+    const activeInstance = await getActiveProvisionContextInstance(c.env, userId, orgId);
+    if (activeInstance?.id === instanceId) {
+      return jsonError(
+        'Reservation belongs to an active instance; refusing to release',
+        409,
+        'reservation_active'
+      );
+    }
+
+    const { registryKey, stub } = getProvisionRegistryStub(c.env, userId, orgId);
+    const { reservations } = await stub.listAllInstances(registryKey);
+    const reservation = reservations.find(r => r.instanceId === instanceId);
+    if (!reservation) {
+      return jsonError('No provision reservation found for instance', 404, 'reservation_not_found');
+    }
+    if (
+      reservation.status !== 'in_progress' &&
+      reservation.status !== 'failed_requires_reconciliation'
+    ) {
+      return jsonError(
+        `Reservation is not in a releasable state (status=${reservation.status})`,
+        409,
+        'reservation_not_releasable'
+      );
+    }
+
+    await stub.releaseFreshProvision(registryKey, userId, instanceId, 'manual_admin_release');
+
+    writeEvent(c.env, {
+      event: 'instance.provision_reservation_released',
+      delivery: 'http',
+      route: '/api/platform/provision/release-reservation',
+      userId,
+      instanceId,
+      orgId: orgId ?? undefined,
+      label: reservation.status,
+    });
+    return c.json({ ok: true, previousStatus: reservation.status });
+  } catch (error) {
+    const { message, status } = sanitizeError(error, 'provision reservation release');
+    return jsonError(message, status);
+  }
+});
+
 // PATCH /api/platform/kilocode-config
 
 platform.patch('/kilocode-config', async c => {

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -8,6 +8,7 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import * as fly from '../fly/client';
+import { appNameFromInstanceId, getApp } from '../fly/apps';
 import type { InstanceStatus } from '../durable-objects/kiloclaw-instance/types';
 import type { FileWriteResponse } from '../durable-objects/gateway-controller-types';
 import type { AppEnv } from '../types';
@@ -1866,8 +1867,14 @@ platform.post('/provision/repair-reservation', async c => {
   }
 });
 
+// An `in_progress` reservation is only releasable once it is provably stale: a
+// Cloudflare Worker provision request is bounded to a few minutes, so a
+// reservation untouched for longer than this means the creating executor is
+// gone and cannot still be allocating provider resources.
+const RELEASE_IN_PROGRESS_STALE_MS = 15 * 60 * 1000;
+
 // POST /api/platform/provision/release-reservation
-// Surgically resolves a STUCK provision reservation (status `in_progress` or
+// Resolves a STUCK provision reservation (`in_progress` or
 // `failed_requires_reconciliation`) so the user can provision again. A failed
 // fresh provision can leave such a row behind (e.g. `provider_provision_failed`
 // during a provider outage); the partial unique index then rejects every new
@@ -1875,10 +1882,16 @@ platform.post('/provision/repair-reservation', async c => {
 // created"), and nothing auto-heals it because no instance/DO exists to finalize
 // a destroy.
 //
-// Unlike `/destroy`, this issues NO provider (Fly) calls and mutates NO Postgres
-// state -- it flips a single registry bookkeeping row to `released`. It is
-// guarded to refuse releasing a reservation that backs a live active instance or
-// that is already `completed`/`released`.
+// This is FAIL-CLOSED. It does NOT destroy anything; it only flips the bookkeeping
+// row to `released`, and only once it can prove the release is safe:
+//   - refuses if the reservation backs a live active instance;
+//   - refuses `in_progress` unless it is stale (executor provably dead);
+//   - for `failed_requires_reconciliation` (provider side effects MAY exist),
+//     confirms via Fly that no app / machines / volumes remain for this
+//     instanceId before releasing — otherwise it refuses so the orphaned
+//     resources are reaped first (orphan-volume reaper / DO destroy);
+//   - performs the validate+transition atomically in one DO RPC so it cannot
+//     race a concurrent provision completion.
 platform.post('/provision/release-reservation', async c => {
   const result = await parseBody(c, ProvisionReservationRepairSchema);
   if ('error' in result) return result.error;
@@ -1913,18 +1926,81 @@ platform.post('/provision/release-reservation', async c => {
       );
     }
 
-    await stub.releaseFreshProvision(registryKey, userId, instanceId, 'manual_admin_release');
+    // `failed_requires_reconciliation` is fail-closed by design: provider side
+    // effects may exist. Releasing the admission lock while a Fly app / machine /
+    // volume for this instanceId is still around would orphan infrastructure that
+    // may hold the user's encrypted env/secrets. Confirm there is nothing to
+    // reconcile (read-only) before releasing; if we can't confirm, refuse.
+    if (reservation.status === 'failed_requires_reconciliation') {
+      const apiToken = c.env.FLY_API_TOKEN;
+      if (!apiToken) {
+        return jsonError(
+          'FLY_API_TOKEN is not configured; cannot confirm provider cleanup before release',
+          503,
+          'provider_check_unavailable'
+        );
+      }
+      const prefix = c.env.WORKER_ENV === 'development' ? 'dev' : undefined;
+      const appName = await appNameFromInstanceId(instanceId, prefix);
+      const app = await getApp({ apiToken }, appName);
+      if (app) {
+        const flyConfig = { apiToken, appName };
+        const [machines, volumes] = await Promise.all([
+          fly.listMachines(flyConfig),
+          fly.listVolumes(flyConfig),
+        ]);
+        if (machines.length > 0 || volumes.length > 0) {
+          return jsonError(
+            `Provider resources still exist for this instance (app=${appName}, ` +
+              `machines=${machines.length}, volumes=${volumes.length}). Reap them ` +
+              `before releasing the reservation.`,
+            409,
+            'provider_resources_present'
+          );
+        }
+      }
+    }
 
-    writeEvent(c.env, {
-      event: 'instance.provision_reservation_released',
-      delivery: 'http',
-      route: '/api/platform/provision/release-reservation',
+    // Atomic validate + transition (no read/write split, no completed->released).
+    const release = await stub.adminReleaseStuckReservation(
+      registryKey,
       userId,
       instanceId,
-      orgId: orgId ?? undefined,
-      label: reservation.status,
-    });
-    return c.json({ ok: true, previousStatus: reservation.status });
+      'manual_admin_release',
+      RELEASE_IN_PROGRESS_STALE_MS
+    );
+    switch (release.outcome) {
+      case 'not_found':
+        return jsonError(
+          'No provision reservation found for instance',
+          404,
+          'reservation_not_found'
+        );
+      case 'not_releasable':
+        return jsonError(
+          `Reservation is not in a releasable state (status=${release.status})`,
+          409,
+          'reservation_not_releasable'
+        );
+      case 'in_progress_too_fresh':
+        return jsonError(
+          'Reservation is still in progress and not yet stale; the provision may ' +
+            'still be running. Try again later.',
+          409,
+          'reservation_in_progress_active'
+        );
+      case 'released':
+        writeEvent(c.env, {
+          event: 'instance.provision_reservation_released',
+          delivery: 'http',
+          route: '/api/platform/provision/release-reservation',
+          userId,
+          instanceId,
+          orgId: orgId ?? undefined,
+          label: release.previousStatus,
+        });
+        return c.json({ ok: true, previousStatus: release.previousStatus });
+    }
   } catch (error) {
     const { message, status } = sanitizeError(error, 'provision reservation release');
     return jsonError(message, status);

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -8,7 +8,6 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import * as fly from '../fly/client';
-import { appNameFromInstanceId, getApp } from '../fly/apps';
 import type { InstanceStatus } from '../durable-objects/kiloclaw-instance/types';
 import type { FileWriteResponse } from '../durable-objects/gateway-controller-types';
 import type { AppEnv } from '../types';
@@ -132,6 +131,16 @@ const ProvisionReservationRepairSchema = z.object({
   userId: z.string().min(1),
   instanceId: z.uuid(),
   orgId: z.uuid().nullable().optional(),
+});
+
+const ProvisionReservationReleaseSchema = z.object({
+  userId: z.string().min(1),
+  instanceId: z.uuid(),
+  orgId: z.uuid().nullable().optional(),
+  // Break-glass: the operator must explicitly assert they have confirmed the
+  // attempt is dead and any provider resources are cleaned up. `z.literal(true)`
+  // makes the request fail validation unless the flag is present and true.
+  acknowledgeCleanupVerified: z.literal(true),
 });
 
 const KILOCLAW_WORKER_DESTROY_ACTOR = {
@@ -1867,14 +1876,8 @@ platform.post('/provision/repair-reservation', async c => {
   }
 });
 
-// An `in_progress` reservation is only releasable once it is provably stale: a
-// Cloudflare Worker provision request is bounded to a few minutes, so a
-// reservation untouched for longer than this means the creating executor is
-// gone and cannot still be allocating provider resources.
-const RELEASE_IN_PROGRESS_STALE_MS = 15 * 60 * 1000;
-
 // POST /api/platform/provision/release-reservation
-// Resolves a STUCK provision reservation (`in_progress` or
+// Admin break-glass: release a stuck provision reservation (`in_progress` or
 // `failed_requires_reconciliation`) so the user can provision again. A failed
 // fresh provision can leave such a row behind (e.g. `provider_provision_failed`
 // during a provider outage); the partial unique index then rejects every new
@@ -1882,24 +1885,21 @@ const RELEASE_IN_PROGRESS_STALE_MS = 15 * 60 * 1000;
 // created"), and nothing auto-heals it because no instance/DO exists to finalize
 // a destroy.
 //
-// This is FAIL-CLOSED. It does NOT destroy anything; it only flips the bookkeeping
-// row to `released`, and only once it can prove the release is safe:
-//   - refuses if the reservation backs a live active instance;
-//   - refuses `in_progress` unless it is stale (executor provably dead);
-//   - for `failed_requires_reconciliation` (provider side effects MAY exist),
-//     confirms via Fly that no app / machines / volumes remain for this
-//     instanceId before releasing — otherwise it refuses so the orphaned
-//     resources are reaped first (orphan-volume reaper / DO destroy);
-//   - performs the validate+transition atomically in one DO RPC so it cannot
-//     race a concurrent provision completion.
+// This is an OPERATOR action, not an autonomous safety decision. The admin must
+// have already confirmed the attempt is dead and any provider resources are
+// cleaned up; `acknowledgeCleanupVerified: true` records that assertion (and the
+// admin identity is captured in the tRPC audit log upstream). It mutates only
+// the registry bookkeeping row — no provider (Fly/Northflank) or Postgres
+// changes. Guards: refuses a reservation backing a live active instance, refuses
+// non-releasable statuses, and releases atomically via a compare-and-set on the
+// validated status so a concurrent completion is reported, not clobbered.
 platform.post('/provision/release-reservation', async c => {
-  const result = await parseBody(c, ProvisionReservationRepairSchema);
+  const result = await parseBody(c, ProvisionReservationReleaseSchema);
   if ('error' in result) return result.error;
   const { userId, instanceId, orgId } = result.data;
 
   try {
-    // Defense in depth: never release a reservation that belongs to a
-    // currently-active instance.
+    // Never release a reservation that belongs to a currently-active instance.
     const activeInstance = await getActiveProvisionContextInstance(c.env, userId, orgId);
     if (activeInstance?.id === instanceId) {
       return jsonError(
@@ -1926,48 +1926,13 @@ platform.post('/provision/release-reservation', async c => {
       );
     }
 
-    // `failed_requires_reconciliation` is fail-closed by design: provider side
-    // effects may exist. Releasing the admission lock while a Fly app / machine /
-    // volume for this instanceId is still around would orphan infrastructure that
-    // may hold the user's encrypted env/secrets. Confirm there is nothing to
-    // reconcile (read-only) before releasing; if we can't confirm, refuse.
-    if (reservation.status === 'failed_requires_reconciliation') {
-      const apiToken = c.env.FLY_API_TOKEN;
-      if (!apiToken) {
-        return jsonError(
-          'FLY_API_TOKEN is not configured; cannot confirm provider cleanup before release',
-          503,
-          'provider_check_unavailable'
-        );
-      }
-      const prefix = c.env.WORKER_ENV === 'development' ? 'dev' : undefined;
-      const appName = await appNameFromInstanceId(instanceId, prefix);
-      const app = await getApp({ apiToken }, appName);
-      if (app) {
-        const flyConfig = { apiToken, appName };
-        const [machines, volumes] = await Promise.all([
-          fly.listMachines(flyConfig),
-          fly.listVolumes(flyConfig),
-        ]);
-        if (machines.length > 0 || volumes.length > 0) {
-          return jsonError(
-            `Provider resources still exist for this instance (app=${appName}, ` +
-              `machines=${machines.length}, volumes=${volumes.length}). Reap them ` +
-              `before releasing the reservation.`,
-            409,
-            'provider_resources_present'
-          );
-        }
-      }
-    }
-
-    // Atomic validate + transition (no read/write split, no completed->released).
+    // Atomic compare-and-set on the exact status we validated.
     const release = await stub.adminReleaseStuckReservation(
       registryKey,
       userId,
       instanceId,
-      'manual_admin_release',
-      RELEASE_IN_PROGRESS_STALE_MS
+      reservation.status,
+      'manual_admin_release'
     );
     switch (release.outcome) {
       case 'not_found':
@@ -1976,18 +1941,11 @@ platform.post('/provision/release-reservation', async c => {
           404,
           'reservation_not_found'
         );
-      case 'not_releasable':
+      case 'status_changed':
         return jsonError(
-          `Reservation is not in a releasable state (status=${release.status})`,
+          `Reservation status changed to ${release.status} during release; re-check and retry`,
           409,
-          'reservation_not_releasable'
-        );
-      case 'in_progress_too_fresh':
-        return jsonError(
-          'Reservation is still in progress and not yet stale; the provision may ' +
-            'still be running. Try again later.',
-          409,
-          'reservation_in_progress_active'
+          'reservation_status_changed'
         );
       case 'released':
         writeEvent(c.env, {


### PR DESCRIPTION
## Summary

Adds an admin path to release a stuck KiloClaw provision reservation. A failed
fresh provision can leave a reservation in `failed_requires_reconciliation` (or
`in_progress`) with no instance or Durable Object to finalize a destroy. The
partial unique index then rejects every new provision for that user with
`provision_in_progress`, so the user is stuck on "An instance is already being
created" and nothing clears it automatically. This adds an internal worker
endpoint, a tRPC admin mutation, and an admin UI control to clear that
reservation as an explicit, audited operator action.

### Worker (`services/kiloclaw`)

- New internal endpoint `POST /api/platform/provision/release-reservation`
  (x-internal-api-key). It validates the reservation, refuses one that backs a
  live active instance, refuses non-releasable statuses, and releases via the
  registry Durable Object.
- New `KiloClawRegistry.adminReleaseStuckReservation` method. It validates and
  transitions in a single `transactionSync` and uses a compare-and-set on the
  caller's validated status, so a reservation that changed underneath (for
  example a concurrent completion) returns `status_changed` instead of being
  released.
- The request requires `acknowledgeCleanupVerified: true`. This is an operator
  override, not an automated safety check: the worker makes no provider
  (Fly/Northflank) or Postgres changes, and the admin asserts they have already
  confirmed cleanup.

### Web (`apps/web`)

- New `releaseReservation` admin tRPC mutation. It also requires
  `acknowledgeCleanupVerified: true` at the API boundary and writes a
  `kiloclaw.provision_reservation.release` admin audit log entry.
- New `releaseProvisionReservation` method on the internal client.
- The admin instance detail page now renders a "Provision Reservations" table in
  the Registry Status card (reservations were already fetched but never shown).
  Stuck reservations get a Release button that opens a confirmation dialog with a
  pre-flight checklist the operator must confirm: the attempt is dead, no active
  instance exists, Fly and Northflank resources from the failed attempt are
  destroyed (with concrete steps), and a warning that releasing while orphans
  remain can leave infrastructure holding the user's secrets.

### Schema/types (`packages/db`)

- Adds `kiloclaw.provision_reservation.release` to the `KiloClawAdminAuditAction`
  enum. The audit `action` column is text, so no migration is required.

### Tests

- Durable Object tests for `adminReleaseStuckReservation` (release, status
  mismatch, not found).
- New route test file `platform-release-reservation.test.ts` covering the request
  guards (missing acknowledgement, active instance, not found, non-releasable)
  and the status mapping.

## Verification

<!-- Only list manually tested paths, not automated tests. -->

- [ ] No manual browser testing was performed for this change. The admin UI path
      was not exercised in a running environment, so the release dialog and the
      end-to-end release flow should be checked manually before relying on them.

## Visual Changes

UI changed: a new "Provision Reservations" table in the admin KiloClaw instance
detail (Registry Status card) and a release confirmation dialog. Screenshots to
be added.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- The release is intentionally a break-glass operator action. It does not
  auto-discover or reconcile provider resources; the operator confirms cleanup
  via the dialog checklist and that assertion is recorded in the audit log.
- `acknowledgeCleanupVerified` is enforced at three layers (UI dialog, tRPC
  input, worker).
- The route test imports the worker app, which depends on workspace packages
  that are built in CI, so it runs in CI rather than a bare local checkout.
