### PR TITLE
feat(SBOM) release pipeline

### DIFF
--- a/.github/workflows/deploy-kiloclaw.yml
+++ b/.github/workflows/deploy-kiloclaw.yml
@@ -25,7 +25,12 @@ jobs:
       image-tag: ${{ steps.image-hash.outputs.tag }}
       image-hash: ${{ steps.image-hash.outputs.hash }}
       image-digest: ${{ steps.image-digest.outputs.digest }}
-      image-built: ${{ steps.check-image.outputs.exists != 'true' }}
+      # True only when the build step actually ran and succeeded (it is skipped
+      # when the content-hash tag already exists). Keyed off the step outcome
+      # rather than the pre-build registry check so a failed build never reports
+      # as "built". `outcome` (not `conclusion`) stays correct if a future
+      # continue-on-error is added to the build step.
+      image-built: ${{ steps.docker-build.outcome == 'success' }}
       openclaw-version: ${{ steps.openclaw-version.outputs.version }}
 
     steps:

--- a/.github/workflows/deploy-kiloclaw.yml
+++ b/.github/workflows/deploy-kiloclaw.yml
@@ -7,6 +7,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write # required by actions/attest-sbom for OIDC signing
+  attestations: write # required by actions/attest-sbom to write the attestation
 
 jobs:
   deploy:
@@ -203,6 +205,31 @@ jobs:
           else
             echo "digest=" >> "$GITHUB_OUTPUT"
           fi
+
+      # ── Generate + attest image SBOM ────────────────────────────
+      # Runs only when a NEW image was built. The content-hash skip path
+      # leaves the prior attestation in place (identical content → identical
+      # digest), so we avoid pulling a large unchanged image on no-op deploys.
+      # syft scans the GHCR image by digest (runner is already logged in);
+      # attest-sbom binds a signed SBOM to that digest, stored in GHCR.
+      - name: Generate image SBOM
+        if: steps.check-image.outputs.exists != 'true'
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/kilo-org/kiloclaw@${{ steps.image-digest.outputs.digest }}
+          format: cyclonedx-json
+          output-file: kiloclaw-sbom.cyclonedx.json
+          upload-artifact: true
+          artifact-name: kiloclaw-sbom-${{ steps.image-hash.outputs.tag }}
+
+      - name: Attest image SBOM
+        if: steps.check-image.outputs.exists != 'true'
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/kilo-org/kiloclaw
+          subject-digest: ${{ steps.image-digest.outputs.digest }}
+          sbom-path: kiloclaw-sbom.cyclonedx.json
+          push-to-registry: true
 
       # ── Extract OpenClaw version ────────────────────────────────
       - name: Extract OpenClaw version

--- a/.github/workflows/deploy-kiloclaw.yml
+++ b/.github/workflows/deploy-kiloclaw.yml
@@ -4,21 +4,28 @@ on:
   workflow_dispatch:
   workflow_call:
 
+# Least-privilege default for the whole workflow. Each job opts into only the
+# scopes it needs via its own `permissions:` block below.
 permissions:
   contents: read
-  packages: write
-  id-token: write # required by actions/attest-sbom for OIDC signing
-  attestations: write # required by actions/attest-sbom to write the attestation
 
 jobs:
   deploy:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 30
     name: Deploy KiloClaw
+    # Builds/pushes the image and deploys the worker. Deliberately has NO
+    # id-token/attestations scopes — signing is isolated in the attest-sbom job
+    # so a compromised install step or action here cannot mint a trusted OIDC
+    # identity.
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image-tag: ${{ steps.image-hash.outputs.tag }}
       image-hash: ${{ steps.image-hash.outputs.hash }}
       image-digest: ${{ steps.image-digest.outputs.digest }}
+      image-built: ${{ steps.check-image.outputs.exists != 'true' }}
       openclaw-version: ${{ steps.openclaw-version.outputs.version }}
 
     steps:
@@ -206,31 +213,6 @@ jobs:
             echo "digest=" >> "$GITHUB_OUTPUT"
           fi
 
-      # ── Generate + attest image SBOM ────────────────────────────
-      # Runs only when a NEW image was built. The content-hash skip path
-      # leaves the prior attestation in place (identical content → identical
-      # digest), so we avoid pulling a large unchanged image on no-op deploys.
-      # syft scans the GHCR image by digest (runner is already logged in);
-      # attest-sbom binds a signed SBOM to that digest, stored in GHCR.
-      - name: Generate image SBOM
-        if: steps.check-image.outputs.exists != 'true'
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          image: ghcr.io/kilo-org/kiloclaw@${{ steps.image-digest.outputs.digest }}
-          format: cyclonedx-json
-          output-file: kiloclaw-sbom.cyclonedx.json
-          upload-artifact: true
-          artifact-name: kiloclaw-sbom-${{ steps.image-hash.outputs.tag }}
-
-      - name: Attest image SBOM
-        if: steps.check-image.outputs.exists != 'true'
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
-        with:
-          subject-name: ghcr.io/kilo-org/kiloclaw
-          subject-digest: ${{ steps.image-digest.outputs.digest }}
-          sbom-path: kiloclaw-sbom.cyclonedx.json
-          push-to-registry: true
-
       # ── Extract OpenClaw version ────────────────────────────────
       - name: Extract OpenClaw version
         id: openclaw-version
@@ -256,6 +238,48 @@ jobs:
             --var OPENCLAW_VERSION:${{ steps.openclaw-version.outputs.version }}
             --var FLY_IMAGE_DIGEST:${{ steps.image-digest.outputs.digest }}
 
+  # ── Generate + attest the image SBOM (isolated, minimal scopes) ──
+  # Separated from `deploy` so that ONLY this job can mint an OIDC identity or
+  # write attestations — no install steps or third-party build actions run here.
+  # Runs after `deploy` (image already pushed; digest comes from its output).
+  # Gated to the build path: an unchanged image keeps the attestation produced
+  # when its content was last built, so we don't pull a large unchanged image.
+  attest-sbom:
+    needs: deploy
+    if: needs.deploy.outputs.image-built == 'true' && needs.deploy.outputs.image-digest != ''
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    name: Attest image SBOM
+    permissions:
+      contents: read
+      packages: write # pull the GHCR image + push the attestation referrer
+      id-token: write # OIDC signing for actions/attest-sbom
+      attestations: write # write the attestation
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/kilo-org/kiloclaw@${{ needs.deploy.outputs.image-digest }}
+          format: cyclonedx-json
+          output-file: kiloclaw-sbom.cyclonedx.json
+          upload-artifact: true
+          artifact-name: kiloclaw-sbom-${{ needs.deploy.outputs.image-tag }}
+
+      - name: Attest image SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/kilo-org/kiloclaw
+          subject-digest: ${{ needs.deploy.outputs.image-digest }}
+          sbom-path: kiloclaw-sbom.cyclonedx.json
+          push-to-registry: true
+
   # ── Push prod image to dev registry ───────────────────────────
   # Runs after the production deploy completes. Copies the prod image
   # to the dev Fly registry so dev stays in sync automatically.
@@ -266,6 +290,9 @@ jobs:
     timeout-minutes: 10
     name: Push Dev Image
     continue-on-error: true
+    # Uses Fly registry tokens via docker login, not GITHUB_TOKEN — no
+    # GITHUB_TOKEN scopes are required.
+    permissions: {}
 
     steps:
       - name: Setup Docker Buildx

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -179,8 +179,13 @@ jobs:
 
   deploy-kiloclaw:
     needs: [check-production-db-startup, run-migrations]
+    # Ceiling for the reusable workflow's GITHUB_TOKEN (a called workflow cannot
+    # exceed the caller). The reusable workflow restricts further per job — only
+    # its isolated attest-sbom job actually uses id-token/attestations.
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/deploy-kiloclaw.yml
     secrets: inherit

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,38 @@
+name: SBOM
+
+# Generates a repo-wide CycloneDX SBOM of the resolved pnpm dependency tree.
+# syft reads pnpm-lock.yaml directly, so no `pnpm install` is needed — a fresh
+# checkout has no node_modules and therefore no filesystem-duplicate noise.
+# The SBOM is uploaded as a retained workflow artifact (never committed).
+#
+# Container-image SBOMs are handled separately in deploy-kiloclaw.yml, where
+# they are attested against the image digest in GHCR.
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly (Mondays 04:00 UTC) — regenerate against the unchanged lockfile.
+    # Sets up future vulnerability re-scans against newly disclosed CVEs.
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  source-sbom:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    name: Source dependency SBOM
+    steps:
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+
+      - name: Generate source SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: cloud-sbom.cyclonedx.json
+          upload-artifact: true
+          artifact-name: cloud-sbom-${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,13 @@ supabase/.temp
 # beads task workspace (per-agent local state)
 .beads/
 
+# generated SBOMs (produced in CI / locally, never committed)
+*sbom*.json
+*sbom*.json.gz
+*.cyclonedx.json
+*.cyclonedx.json.gz
+*.spdx.json
+
 # misc
 TMP_CI_commit_msg.txt
 *.csv

--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,15 @@
+# syft configuration — keeps local `syft scan dir:.` runs consistent with CI.
+# In CI (a fresh checkout) node_modules/.next/dist don't exist, so these
+# excludes are no-ops there; they matter when generating an SBOM locally where
+# an installed tree would otherwise add filesystem-duplicate noise.
+#
+# Source SBOMs are built from pnpm-lock.yaml (the resolved dependency tree),
+# not from a walk of node_modules.
+exclude:
+  - ./node_modules/**
+  - ./**/node_modules/**
+  - ./.next/**
+  - ./**/.next/**
+  - ./**/dist/**
+  - ./.wrangler/**
+  - ./**/.wrangler/**

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -1,0 +1,56 @@
+# Software Bill of Materials (SBOM)
+
+We generate SBOMs automatically as part of the release flow so every shipped artifact has a
+traceable, verifiable inventory of its components. This complements CodeQL, Dependabot, and
+Trufflehog — none of which emit an SBOM.
+
+All SBOMs are **CycloneDX JSON**, generated with [syft](https://github.com/anchore/syft) via the
+official `anchore/sbom-action`. SBOMs are **never committed** to the repo.
+
+## What we generate, where it lives, and when
+
+| Target | Tooling | When | Stored as |
+| --- | --- | --- | --- |
+| **Source dependency tree** (repo-wide pnpm graph) | `.github/workflows/sbom.yml` | push to `main`, weekly cron, manual dispatch | Retained CI **workflow artifact** (`cloud-sbom-<sha>`) |
+| **KiloClaw container image** (OS packages + Go + Node + OpenClaw + npm) | `.github/workflows/deploy-kiloclaw.yml` | at image **build time** (only when content changes) | Signed **attestation in GHCR**, bound to the image digest |
+
+The image SBOM uses the richest source available — the built image — so it captures the OS-package
+and multi-ecosystem footprint that a lockfile-only SBOM misses. The image step is gated to the
+build path: the content-hash skip logic means an unchanged image keeps the attestation produced when
+its content was last built, so we never pull a large unchanged image on a no-op deploy.
+
+## Verifying an image SBOM attestation
+
+```sh
+gh attestation verify oci://ghcr.io/kilo-org/kiloclaw@<digest> --owner kilo-org
+```
+
+## Reproducing the source SBOM locally
+
+syft reads `pnpm-lock.yaml` directly (no `pnpm install` needed) and picks up the repo's
+`.syft.yaml` exclusions automatically:
+
+```sh
+syft scan dir:. -o cyclonedx-json=cloud-sbom.cyclonedx.json
+```
+
+## Other repos (kilocode, abuse) — bun caveat
+
+syft cannot parse `bun.lock` (its lock cataloger only handles `package-lock.json`, `yarn.lock`, and
+`pnpm-lock.yaml`). For bun repos you must scan an **installed** tree and explicitly enable the
+package cataloger (it is tagged `image,installed` and is off by default for directory scans):
+
+```sh
+bun install --frozen-lockfile
+syft scan dir:. \
+  --select-catalogers '+javascript-package-cataloger' \
+  --exclude './.git/**' --exclude './**/.turbo/**' --exclude './**/dist/**' \
+  -o cyclonedx-json=sbom.cyclonedx.json
+```
+
+## Follow-ups (not yet implemented)
+
+- **Vulnerability scanning** — pair each SBOM with Grype and upload SARIF to the GitHub Security tab,
+  surfacing OS-package and shipped-image CVEs that Dependabot/CodeQL don't see.
+- **Additional container images** — extend the `deploy-kiloclaw.yml` attestation pattern to gastown,
+  cloud-agent, and other images once each has a registry-push path to attest against.

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -10,7 +10,7 @@ official `anchore/sbom-action`. SBOMs are **never committed** to the repo.
 ## What we generate, where it lives, and when
 
 | Target | Tooling | When | Stored as |
-| --- | --- | --- | --- |
+|---|---|---|---|
 | **Source dependency tree** (repo-wide pnpm graph) | `.github/workflows/sbom.yml` | push to `main`, weekly cron, manual dispatch | Retained CI **workflow artifact** (`cloud-sbom-<sha>`) |
 | **KiloClaw container image** (OS packages + Go + Node + OpenClaw + npm) | `.github/workflows/deploy-kiloclaw.yml` | at image **build time** (only when content changes) | Signed **attestation in GHCR**, bound to the image digest |
 


### PR DESCRIPTION
## Summary

Adds automated SBOM generation to the release flow so shipped artifacts have a
traceable inventory of their components. Two SBOMs are produced: a repo-wide
dependency SBOM from the pnpm lockfile, and an SBOM of the KiloClaw container
image that is attested to the image digest in GHCR. This sits alongside the
existing CodeQL, Dependabot, and Trufflehog checks, none of which produce an
SBOM.

The image attestation is built as a separate, least-privilege job so the
high-privilege build-and-push job never carries OIDC or attestation scopes.

## Changes

- New `sbom.yml` workflow: generates a CycloneDX SBOM of the resolved pnpm
  dependency tree on push to main, weekly, and manual dispatch. syft reads
  `pnpm-lock.yaml` directly (no install needed) and the SBOM is uploaded as a
  retained workflow artifact.
- `deploy-kiloclaw.yml`: adds an isolated `attest-sbom` job that runs after
  `deploy`, generates the image SBOM with syft (scanning the GHCR image by
  digest), and attests it to that digest with `actions/attest-sbom`. Gated to
  the build path via a new `image-built` output so unchanged images are not
  re-pulled.
- Permission scoping in `deploy-kiloclaw.yml`: workflow default dropped to
  `contents: read`; the `deploy` job keeps only `contents: read` +
  `packages: write`; `id-token`/`attestations` live only on the new
  `attest-sbom` job; `push-dev-image` set to `permissions: {}`.
- `deploy-production.yml`: raises the `deploy-kiloclaw` caller job's permissions
  to include `id-token: write` and `attestations: write`. A reusable workflow
  cannot exceed its caller, so without this the attestation step would fail on
  production runs.
- `.syft.yaml`: exclusions so local SBOM runs match CI.
- `docs/sbom.md`: what is generated, where it is stored, how to verify an image
  attestation, and how to reproduce locally.
- `.gitignore`: ignore generated SBOM files.

Action pins: `anchore/sbom-action@v0.24.0` and `actions/attest-sbom@v4.1.0`,
both pinned by commit SHA.

## Verification

These workflows do not run on pull requests (`deploy-production` is
push-to-main only, `deploy-kiloclaw` is `workflow_call`/`workflow_dispatch`
only, and `sbom.yml` triggers on push to main, schedule, and dispatch), so PR
CI does not exercise them. First real execution is on merge to main.

- [x] All three workflow YAML files parse cleanly (validated locally).
- [x] `pnpm run format:check` passes.
- [ ] `sbom.yml` can be smoke-tested before merge via `workflow_dispatch` on
      this branch (read-only; produces the source SBOM artifact). Not yet run.
- [ ] The image-attestation path cannot be safely dry-run, since dispatching
      `deploy-kiloclaw` performs a real worker deploy. It will first run on the
      next production deploy that rebuilds the KiloClaw image.

## Visual Changes

N/A

## Reviewer Notes

- The caller-permission change in `deploy-production.yml` is required for
  correctness, not just hygiene: reusable workflows are capped by the caller, so
  the added `id-token`/`attestations` scopes would otherwise be stripped on
  production runs and the attest step would fail before the worker deploys.
- Attestation is isolated so a compromised scanner or install step cannot reach
  image production. The `attest-sbom` job has no Fly credentials and runs
  against the already-pushed image digest, so it can write an attestation but
  cannot alter image content or push to Fly.
- The attest job is gated to the build path (`image-built == 'true'`). An image
  whose content is unchanged keeps the attestation from when it was last built.
  Known gap: if the attest step fails transiently, a later fresh run skips it
  because the image already exists; re-running the failed job immediately is the
  current workaround.
- `docs/sbom.md` records follow-ups intentionally out of scope here:
  vulnerability scanning (Grype + SARIF) and extending attestation to other
  container images.
