### PR TITLE
Improvements to redacting possibly sensitive model ids or error messages

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -784,6 +784,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
   {
     const errorResponse = await makeErrorReadable({
+      providerId: effectiveProviderContext.provider.id,
       requestedModel: effectiveModelIdLowerCased,
       request: requestBodyParsed,
       response,

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
@@ -699,6 +699,7 @@ describe('makeErrorReadable', () => {
   it('returns undefined for non-error responses', async () => {
     const response = new Response('{}', { status: 200 });
     const result = await makeErrorReadable({
+      providerId: 'openrouter',
       requestedModel: 'anything',
       request: { kind: 'chat_completions', body: { model: 'test', messages: [] } },
       response,

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -33,7 +33,7 @@ import { getXKiloCodeVersionNumber } from '@/lib/userAgent';
 import { normalizeModelId } from '@/lib/ai-gateway/providers/openrouter';
 import { createParser, type EventSourceMessage } from 'eventsource-parser';
 import { sentryRootSpan } from '../getRootSpan';
-import { findKiloExclusiveModel, isKiloStealthModel } from '@/lib/ai-gateway/models';
+import { findKiloExclusiveModel, shouldRedactErrorResponse } from '@/lib/ai-gateway/models';
 import type {
   MicrodollarUsageContext,
   MicrodollarUsageStats,
@@ -157,11 +157,11 @@ export function apiKindNotSupportedResponse(
   );
 }
 
-async function stealthModelError(response: Response) {
-  const error = 'Stealth model unable to process request';
+async function redactedErrorResponse(response: Response) {
+  const error = 'The upstream provider was unable to process the request';
   warnExceptInTest(`Responding with ${response.status} ${error}`);
   return NextResponse.json(
-    { error, error_type: ProxyErrorType.stealth_model_error, message: error },
+    { error, error_type: ProxyErrorType.upstream_error, message: error },
     { status: response.status }
   );
 }
@@ -178,11 +178,13 @@ function byokErrorMessage(status: number): string | undefined {
 }
 
 export async function makeErrorReadable({
+  providerId,
   requestedModel,
   request,
   response,
   isUserByok,
 }: {
+  providerId: ProviderId;
   requestedModel: string;
   request: GatewayRequest;
   response: Response;
@@ -210,8 +212,8 @@ export async function makeErrorReadable({
   const overflowResponse = await detectContextOverflow({ requestedModel, request, response });
   if (overflowResponse) return overflowResponse;
 
-  if (isKiloStealthModel(requestedModel)) {
-    return await stealthModelError(response);
+  if (shouldRedactErrorResponse(providerId, requestedModel)) {
+    return await redactedErrorResponse(response);
   }
 
   return undefined;

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -45,6 +45,7 @@ import { isClaudeModel } from '@/lib/ai-gateway/providers/anthropic.constants';
 import { GPT_CURRENT_MODEL_ID, isOpenAiModel } from '@/lib/ai-gateway/providers/openai';
 import { GLM_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/zai';
 import { deepseekDiscountedModels } from '@/lib/ai-gateway/providers/deepseek';
+import { type ProviderId } from '@/lib/ai-gateway/providers/types';
 
 export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 
@@ -116,6 +117,25 @@ export function isKiloExclusiveModelRequiringDataCollection(model: string): bool
 
 export function isKiloStealthModel(model: string): boolean {
   return kiloExclusiveModels.some(m => m.public_id === model && m.flags.includes('stealth'));
+}
+
+export function shouldRedactModelNameInMicrodollarUsage(
+  provider: ProviderId,
+  model: string
+): boolean {
+  return provider === 'custom' || provider === 'experiment' || isKiloStealthModel(model);
+}
+
+export function shouldRedactErrorResponse(provider: ProviderId, model: string): boolean {
+  return provider === 'custom' || provider === 'experiment' || isKiloStealthModel(model);
+}
+
+export function shouldRedactModelNameInResponse(provider: ProviderId, model: string): boolean {
+  // custom is only used internally so we don't have to risk the perf or reliablity impact of rewriting the response
+  return (
+    provider !== 'martian' && // this is a stealth provider, but the models aren't stealth, so we can keep the model name in place
+    (provider === 'experiment' || isKiloStealthModel(model))
+  );
 }
 
 export function isOpenRouterStealthModel(model: string): boolean {

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -21,7 +21,10 @@ import { eq, sql } from 'drizzle-orm';
 import { sentryRootSpan } from '../getRootSpan';
 import { ingestOrganizationTokenUsage } from '@/lib/organizations/organization-usage';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
-import { findKiloExclusiveModel, isKiloStealthModel } from '@/lib/ai-gateway/models';
+import {
+  findKiloExclusiveModel,
+  shouldRedactModelNameInMicrodollarUsage,
+} from '@/lib/ai-gateway/models';
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
 import { sentryLogger } from '@/lib/utils.server';
 import { maybeIssueKiloPassBonusFromUsageThreshold } from '@/lib/kilo-pass/usage-triggered-bonus';
@@ -1015,7 +1018,7 @@ export async function processTokenData(
 
   if (
     !usageStats.model || // fallback for failure cases
-    isKiloStealthModel(usageContext.requested_model) // this can probably be removed once we're sure we only present requested_model to users
+    shouldRedactModelNameInMicrodollarUsage(usageContext.provider, usageContext.requested_model)
   ) {
     usageStats.model = usageContext.requested_model;
   }

--- a/apps/web/src/lib/proxy-error-types.ts
+++ b/apps/web/src/lib/proxy-error-types.ts
@@ -8,7 +8,6 @@ export const proxyErrorTypeSchema = z.enum([
   'usage_limit_exceeded',
   'data_collection_required',
   'api_kind_not_supported',
-  'stealth_model_error',
   'byok_error',
   'context_length_exceeded',
   'model_not_allowed',

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -1,4 +1,4 @@
-import { isKiloExclusiveFreeModel, isKiloStealthModel } from '@/lib/ai-gateway/models';
+import { isKiloExclusiveFreeModel, shouldRedactModelNameInResponse } from '@/lib/ai-gateway/models';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 import { getOutputHeaders } from '@/lib/ai-gateway/llm-proxy-helpers';
@@ -350,9 +350,8 @@ export async function rewriteFreeModelResponse(
 ): Promise<NextResponse | null> {
   const isFreeModelRequiringCostRemoval =
     (providerId === 'openrouter' || providerId === 'vercel') && isKiloExclusiveFreeModel(model);
-  const isStealthModelRequiringNameRemoval = providerId !== 'martian' && isKiloStealthModel(model);
 
-  if (!isFreeModelRequiringCostRemoval && !isStealthModelRequiringNameRemoval) {
+  if (!isFreeModelRequiringCostRemoval && !shouldRedactModelNameInResponse(providerId, model)) {
     return null;
   }
 


### PR DESCRIPTION
based on colleague feedback and the fact that the new usage screen has started using the model column again