### PR TITLE
fix(ai-gateway): update Qwen discount tiers

### DIFF
--- a/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
@@ -23,13 +23,13 @@ const makeUsage = (overrides: Partial<JustTheCostsUsageStats> = {}): JustTheCost
 });
 
 describe('calculatKiloExclusiveCost_mUsd with qwen3.7-max', () => {
-  test('uses direct Alibaba pricing with the Kilo discount', () => {
+  test('uses direct Alibaba pricing with the 50% discount', () => {
     const result = calculateKiloExclusiveCost_mUsd(
       qwen37_max_model,
       makeUsage({ inputTokens: 100_000, outputTokens: 10_000 })
     );
 
-    expect(result).toBe(Math.round(100_000 * 1.625 + 10_000 * 4.875));
+    expect(result).toBe(Math.round(100_000 * 1.25 + 10_000 * 3.75));
   });
 
   test('charges explicit cache reads and writes at discounted rates', () => {
@@ -38,18 +38,18 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.7-max', () => {
       makeUsage({ inputTokens: 100_000, cacheHitTokens: 20_000, cacheWriteTokens: 30_000 })
     );
 
-    expect(result).toBe(Math.round(50_000 * 1.625 + 20_000 * 0.1625 + 30_000 * 2.03125));
+    expect(result).toBe(Math.round(50_000 * 1.25 + 20_000 * 0.125 + 30_000 * 1.5625));
   });
 });
 
 describe('calculatKiloExclusiveCost_mUsd with qwen3.7-plus', () => {
-  test('uses direct Alibaba pricing with the Kilo discount in the <=256k tier', () => {
+  test('uses direct Alibaba pricing with the 20% discount in the <=256k tier', () => {
     const result = calculateKiloExclusiveCost_mUsd(
       qwen37_plus_model,
       makeUsage({ inputTokens: 100_000, outputTokens: 10_000 })
     );
 
-    expect(result).toBe(Math.round(100_000 * 0.26 + 10_000 * 1.04));
+    expect(result).toBe(Math.round(100_000 * 0.32 + 10_000 * 1.28));
   });
 
   test('charges explicit cache reads and writes at discounted rates', () => {
@@ -58,38 +58,38 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.7-plus', () => {
       makeUsage({ inputTokens: 100_000, cacheHitTokens: 20_000, cacheWriteTokens: 30_000 })
     );
 
-    expect(result).toBe(Math.round(50_000 * 0.26 + 20_000 * 0.026 + 30_000 * 0.325));
+    expect(result).toBe(Math.round(50_000 * 0.32 + 20_000 * 0.032 + 30_000 * 0.4));
   });
 
-  test('uses direct Alibaba pricing with the Kilo discount in the >256k tier', () => {
+  test('uses direct Alibaba pricing with the 20% discount in the >256k tier', () => {
     const result = calculateKiloExclusiveCost_mUsd(
       qwen37_plus_model,
       makeUsage({ inputTokens: 300_000, outputTokens: 10_000 })
     );
 
-    expect(result).toBe(Math.round(300_000 * 0.78 + 10_000 * 3.12));
+    expect(result).toBe(Math.round(300_000 * 0.96 + 10_000 * 3.84));
   });
 
   test('moves to the long-context tier above the 256k boundary', () => {
     expect(
       calculateKiloExclusiveCost_mUsd(qwen37_plus_model, makeUsage({ inputTokens: 262_144 }))
-    ).toBe(Math.round(262_144 * 0.26));
+    ).toBe(Math.round(262_144 * 0.32));
     expect(
       calculateKiloExclusiveCost_mUsd(qwen37_plus_model, makeUsage({ inputTokens: 262_145 }))
-    ).toBe(Math.round(262_145 * 0.78));
+    ).toBe(Math.round(262_145 * 0.96));
   });
 });
 
 describe('calculatKiloExclusiveCost_mUsd with qwen3.6-plus', () => {
-  // Pre-discount prices from Qwen pricing page (35% Kilo discount applied in code):
+  // Qwen pricing page values with no discount applied in code:
   //
   // Input<=256k tier:
-  //   Input: $0.5/1M  → $0.325/1M   CacheWrite: $0.625/1M → $0.40625/1M
-  //   CacheRead: $0.05/1M → $0.0325/1M   Output: $3/1M → $1.95/1M
+  //   Input: $0.5/1M  → $0.5/1M   CacheWrite: $0.625/1M → $0.625/1M
+  //   CacheRead: $0.05/1M → $0.05/1M   Output: $3/1M → $3/1M
   //
   // 256k<Input<=1M tier:
-  //   Input: $2/1M → $1.3/1M   CacheWrite: $2.5/1M → $1.625/1M
-  //   CacheRead: $0.2/1M → $0.13/1M   Output: $6/1M → $3.9/1M
+  //   Input: $2/1M → $2/1M   CacheWrite: $2.5/1M → $2.5/1M
+  //   CacheRead: $0.2/1M → $0.2/1M   Output: $6/1M → $6/1M
 
   test('returns 0 when model has no pricing', () => {
     const model: KiloExclusiveModel = {
@@ -101,51 +101,51 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-plus', () => {
   });
 
   test('input-only cost in <=256k tier', () => {
-    // 100k uncached input tokens at $0.325/1M = 100_000 * 0.325 = 32_500 mUsd
+    // 100k uncached input tokens at $0.5/1M = 100_000 * 0.5 = 50_000 mUsd
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ inputTokens: 100_000 })
     );
-    expect(result).toBe(32_500);
+    expect(result).toBe(50_000);
   });
 
   test('output-only cost in <=256k tier', () => {
-    // 50k output tokens at $1.95/1M = 50_000 * 1.95 = 97_500 mUsd
+    // 50k output tokens at $3/1M = 50_000 * 3 = 150_000 mUsd
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ outputTokens: 50_000 })
     );
-    expect(result).toBe(97_500);
+    expect(result).toBe(150_000);
   });
 
   test('cache read cost in <=256k tier', () => {
     // 200k input tokens, all cache hits → uncached=0, cacheHit=200k
-    // cacheHit: 200_000 * 0.0325 = 6_500 mUsd
+    // cacheHit: 200_000 * 0.05 = 10_000 mUsd
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ inputTokens: 200_000, cacheHitTokens: 200_000 })
     );
-    expect(result).toBe(6_500);
+    expect(result).toBe(10_000);
   });
 
   test('cache write cost in <=256k tier', () => {
     // 200k input tokens, all cache writes → uncached=0, cacheWrite=200k
-    // cacheWrite: 200_000 * 0.40625 = 81_250 mUsd
+    // cacheWrite: 200_000 * 0.625 = 125_000 mUsd
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ inputTokens: 200_000, cacheWriteTokens: 200_000 })
     );
-    expect(result).toBe(81_250);
+    expect(result).toBe(125_000);
   });
 
   test('mixed usage in <=256k tier', () => {
     // 100k input, 20k cache hit, 30k cache write → 50k uncached
     // total input = 50k + 30k + 20k = 100k (<=256k)
-    // uncached: 50_000 * 0.325 = 16_250
-    // output:   10_000 * 1.95  = 19_500
-    // cacheHit: 20_000 * 0.0325 = 650
-    // cacheWrite: 30_000 * 0.40625 = 12_187.5
-    // total = 48_587.5 → 48_588
+    // uncached: 50_000 * 0.5 = 25_000
+    // output:   10_000 * 3  = 30_000
+    // cacheHit: 20_000 * 0.05 = 1_000
+    // cacheWrite: 30_000 * 0.625 = 18_750
+    // total = 74_750
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({
@@ -155,63 +155,63 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-plus', () => {
         cacheWriteTokens: 30_000,
       })
     );
-    expect(result).toBe(48_588);
+    expect(result).toBe(74_750);
   });
 
   test('input-only cost in >256k tier', () => {
     // 300k uncached input tokens, total input = 300k (>256k)
-    // uncached: 300_000 * 1.3 = 390_000 mUsd
+    // uncached: 300_000 * 2 = 600_000 mUsd
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ inputTokens: 300_000 })
     );
-    expect(result).toBe(390_000);
+    expect(result).toBe(600_000);
   });
 
   test('output cost in >256k tier', () => {
     // 300k input + 50k output, total input = 300k (>256k)
-    // uncached: 300_000 * 1.3 = 390_000
-    // output:    50_000 * 3.9 = 195_000
-    // total = 585_000
+    // uncached: 300_000 * 2 = 600_000
+    // output:    50_000 * 6 = 300_000
+    // total = 900_000
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ inputTokens: 300_000, outputTokens: 50_000 })
     );
-    expect(result).toBe(585_000);
+    expect(result).toBe(900_000);
   });
 
   test('cache read cost in >256k tier', () => {
     // 300k input with 100k cache hits → 200k uncached, total input = 300k (>256k)
-    // uncached: 200_000 * 1.3  = 260_000
-    // cacheHit: 100_000 * 0.13 = 13_000
-    // total = 273_000
+    // uncached: 200_000 * 2  = 400_000
+    // cacheHit: 100_000 * 0.2 = 20_000
+    // total = 420_000
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ inputTokens: 300_000, cacheHitTokens: 100_000 })
     );
-    expect(result).toBe(273_000);
+    expect(result).toBe(420_000);
   });
 
   test('cache write cost in >256k tier', () => {
     // 300k input with 100k cache writes → 200k uncached, total input = 300k (>256k)
-    // uncached:    200_000 * 1.3   = 260_000
-    // cacheWrite:  100_000 * 1.625 = 162_500
-    // total = 422_500
+    // uncached:    200_000 * 2   = 400_000
+    // cacheWrite:  100_000 * 2.5 = 250_000
+    // total = 650_000
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ inputTokens: 300_000, cacheWriteTokens: 100_000 })
     );
-    expect(result).toBe(422_500);
+    expect(result).toBe(650_000);
   });
 
   test('mixed usage in >256k tier', () => {
     // 500k input, 50k cache hit, 100k cache write → 350k uncached
     // total input = 350k + 100k + 50k = 500k (>256k)
-    // uncached:    350_000 * 1.3   = 455_000
-    // output:       20_000 * 3.9   =  78_000
-    // cacheHit:     50_000 * 0.13  =   6_500
-    // cacheWrite:  100_000 * 1.625 = 162_500
-    // total = 702_000
+    // uncached:    350_000 * 2   = 700_000
+    // output:       20_000 * 6   = 120_000
+    // cacheHit:     50_000 * 0.2  =  10_000
+    // cacheWrite:  100_000 * 2.5 = 250_000
+    // total = 1_080_000
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({
@@ -221,27 +221,27 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-plus', () => {
         cacheWriteTokens: 100_000,
       })
     );
-    expect(result).toBe(702_000);
+    expect(result).toBe(1_080_000);
   });
 
   test('tier boundary: exactly 256k total input uses <=256k pricing', () => {
     // total input = 256 * 1024 = 262_144 (not > 256k, so <=256k tier)
-    // uncached: 262_144 * 0.325 = 85_196.8 → 85_197
+    // uncached: 262_144 * 0.5 = 85_196.8 → 85_197
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ inputTokens: 262_144 })
     );
-    expect(result).toBe(Math.round(262_144 * 0.325));
+    expect(result).toBe(Math.round(262_144 * 0.5));
   });
 
   test('tier boundary: 256k+1 total input uses >256k pricing', () => {
     // total input = 256 * 1024 + 1 = 262_145 (>256k tier)
-    // uncached: 262_145 * 1.3 = 340_788.5 → 340_789
+    // uncached: 262_145 * 2 = 340_788.5 → 340_789
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ inputTokens: 262_145 })
     );
-    expect(result).toBe(Math.round(262_145 * 1.3));
+    expect(result).toBe(Math.round(262_145 * 2));
   });
 
   test('zero tokens returns 0', () => {
@@ -254,7 +254,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-plus', () => {
     // falls back to using inputTokens=100 as uncachedInputTokens
     // calculate_mUsd receives uncachedInputTokens=100 (fallback), cacheHit=80, cacheWrite=50
     // totalInput in calculate_mUsd = 100 + 50 + 80 = 230 (<=256k)
-    // cost = 100*0.325 + 80*0.0325 + 50*0.40625 = 32.5 + 2.6 + 20.3125 = 55.4125 → 55
+    // cost = 100*0.5 + 80*0.05 + 50*0.625 = 32.5 + 4 + 20.3125 = 55.4125 → 55
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({
@@ -263,51 +263,51 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-plus', () => {
         cacheWriteTokens: 50,
       })
     );
-    expect(result).toBe(Math.round(100 * 0.325 + 80 * 0.0325 + 50 * 0.40625));
+    expect(result).toBe(Math.round(100 * 0.5 + 80 * 0.05 + 50 * 0.625));
   });
 
   test('1M tokens input cost matches post-discount price', () => {
-    // 1M uncached input at >256k tier: 1_000_000 * 1.3 = 1_300_000 mUsd
-    // which is $1.3, the 35%-discounted rate from the pre-discount $2/1M
+    // 1M uncached input at >256k tier: 1_000_000 * 2 = 2_000_000 mUsd
+    // which is the undiscounted $2/1M rate.
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ inputTokens: 1_000_000 })
     );
-    expect(result).toBe(1_300_000);
+    expect(result).toBe(2_000_000);
   });
 
   test('1M tokens output cost matches post-discount price', () => {
     // 1M output at >256k tier (needs >256k input to trigger tier)
     // Use 300k input + 1M output
-    // uncached: 300_000 * 1.3 = 390_000
-    // output: 1_000_000 * 3.9 = 3_900_000
-    // total = 4_290_000
+    // uncached: 300_000 * 2 = 600_000
+    // output: 1_000_000 * 6 = 6_000_000
+    // total = 6_600_000
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_plus_model,
       makeUsage({ inputTokens: 300_000, outputTokens: 1_000_000 })
     );
-    expect(result).toBe(4_290_000);
+    expect(result).toBe(6_600_000);
   });
 });
 
 describe('calculatKiloExclusiveCost_mUsd with qwen3.6-flash', () => {
-  // Pre-discount prices from Qwen pricing page (35% Kilo discount applied in code):
+  // Qwen pricing page values with no discount applied in code:
   //
   // Input<=256k tier:
-  //   Input: $0.25/1M → $0.1625/1M   CacheWrite: $0.3125/1M → $0.203125/1M
-  //   CacheRead: $0.025/1M → $0.01625/1M   Output: $1.5/1M → $0.975/1M
+  //   Input: $0.25/1M → $0.25/1M   CacheWrite: $0.3125/1M → $0.3125/1M
+  //   CacheRead: $0.025/1M → $0.025/1M   Output: $1.5/1M → $1.5/1M
   //
   // 256k<Input<=1M tier:
-  //   Input: $1/1M → $0.65/1M   CacheWrite: $1.25/1M → $0.8125/1M
-  //   CacheRead: $0.1/1M → $0.065/1M   Output: $4/1M → $2.6/1M
+  //   Input: $1/1M → $1/1M   CacheWrite: $1.25/1M → $1.25/1M
+  //   CacheRead: $0.1/1M → $0.1/1M   Output: $4/1M → $4/1M
 
   test('input-only cost in <=256k tier', () => {
-    // 1M tokens * 0.1625 = 162_500 mUsd
+    // 1M tokens * 0.25 = 162_500 mUsd
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_flash_model,
       makeUsage({ inputTokens: 100_000 })
     );
-    expect(result).toBe(Math.round(100_000 * 0.1625));
+    expect(result).toBe(Math.round(100_000 * 0.25));
   });
 
   test('output cost in <=256k tier', () => {
@@ -315,7 +315,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-flash', () => {
       qwen36_flash_model,
       makeUsage({ outputTokens: 50_000 })
     );
-    expect(result).toBe(Math.round(50_000 * 0.975));
+    expect(result).toBe(Math.round(50_000 * 1.5));
   });
 
   test('mixed usage in <=256k tier', () => {
@@ -331,17 +331,17 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-flash', () => {
       })
     );
     expect(result).toBe(
-      Math.round(50_000 * 0.1625 + 10_000 * 0.975 + 20_000 * 0.01625 + 30_000 * 0.203125)
+      Math.round(50_000 * 0.25 + 10_000 * 1.5 + 20_000 * 0.025 + 30_000 * 0.3125)
     );
   });
 
   test('input-only cost in >256k tier', () => {
-    // 300k uncached input tokens > 256k → tier 2: 300_000 * 0.65
+    // 300k uncached input tokens > 256k → tier 2: 300_000 * 1
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_flash_model,
       makeUsage({ inputTokens: 300_000 })
     );
-    expect(result).toBe(Math.round(300_000 * 0.65));
+    expect(result).toBe(Math.round(300_000 * 1));
   });
 
   test('mixed usage in >256k tier', () => {
@@ -357,7 +357,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-flash', () => {
       })
     );
     expect(result).toBe(
-      Math.round(350_000 * 0.65 + 20_000 * 2.6 + 50_000 * 0.065 + 100_000 * 0.8125)
+      Math.round(350_000 * 1 + 20_000 * 4 + 50_000 * 0.1 + 100_000 * 1.25)
     );
   });
 
@@ -366,7 +366,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-flash', () => {
       qwen36_flash_model,
       makeUsage({ inputTokens: 256 * 1024 })
     );
-    expect(result).toBe(Math.round(256 * 1024 * 0.1625));
+    expect(result).toBe(Math.round(256 * 1024 * 0.25));
   });
 
   test('tier boundary: 256k+1 total input uses >256k pricing', () => {
@@ -374,7 +374,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-flash', () => {
       qwen36_flash_model,
       makeUsage({ inputTokens: 256 * 1024 + 1 })
     );
-    expect(result).toBe(Math.round((256 * 1024 + 1) * 0.65));
+    expect(result).toBe(Math.round((256 * 1024 + 1) * 1));
   });
 
   test('1M tokens input cost matches post-discount tier 2 price', () => {
@@ -382,27 +382,27 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-flash', () => {
       qwen36_flash_model,
       makeUsage({ inputTokens: 1_000_000 })
     );
-    expect(result).toBe(1_000_000 * 0.65);
+    expect(result).toBe(1_000_000 * 1);
   });
 });
 
 describe('calculatKiloExclusiveCost_mUsd with qwen3.6-max-preview', () => {
-  // Pre-discount prices from Qwen pricing page (35% Kilo discount applied in code):
+  // Qwen pricing page values with no discount applied in code:
   //
   // Input<=128k tier:
-  //   Input: $1.3/1M → $0.845/1M   CacheWrite: $1.625/1M → $1.05625/1M
-  //   CacheRead: $0.13/1M → $0.0845/1M   Output: $7.8/1M → $5.07/1M
+  //   Input: $1.3/1M → $1.3/1M   CacheWrite: $1.625/1M → $1.625/1M
+  //   CacheRead: $0.13/1M → $0.13/1M   Output: $7.8/1M → $7.8/1M
   //
   // 128k<Input<=256k tier:
-  //   Input: $2/1M → $1.3/1M   CacheWrite: $2.5/1M → $1.625/1M
-  //   CacheRead: $0.2/1M → $0.13/1M   Output: $12/1M → $7.8/1M
+  //   Input: $2/1M → $2/1M   CacheWrite: $2.5/1M → $2.5/1M
+  //   CacheRead: $0.2/1M → $0.2/1M   Output: $12/1M → $12/1M
 
   test('input-only cost in <=128k tier', () => {
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_max_preview_model,
       makeUsage({ inputTokens: 50_000 })
     );
-    expect(result).toBe(Math.round(50_000 * 0.845));
+    expect(result).toBe(Math.round(50_000 * 1.3));
   });
 
   test('output cost in <=128k tier', () => {
@@ -410,7 +410,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-max-preview', () => {
       qwen36_max_preview_model,
       makeUsage({ outputTokens: 10_000 })
     );
-    expect(result).toBe(Math.round(10_000 * 5.07));
+    expect(result).toBe(Math.round(10_000 * 7.8));
   });
 
   test('mixed usage in <=128k tier', () => {
@@ -424,7 +424,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-max-preview', () => {
       })
     );
     expect(result).toBe(
-      Math.round(50_000 * 0.845 + 5_000 * 5.07 + 20_000 * 0.0845 + 30_000 * 1.05625)
+      Math.round(50_000 * 1.3 + 5_000 * 7.8 + 20_000 * 0.2 + 30_000 * 2.5)
     );
   });
 
@@ -434,7 +434,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-max-preview', () => {
       qwen36_max_preview_model,
       makeUsage({ inputTokens: 200_000 })
     );
-    expect(result).toBe(Math.round(200_000 * 1.3));
+    expect(result).toBe(Math.round(200_000 * 2));
   });
 
   test('tier boundary: exactly 128k total input uses <=128k pricing', () => {
@@ -442,7 +442,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-max-preview', () => {
       qwen36_max_preview_model,
       makeUsage({ inputTokens: 128 * 1024 })
     );
-    expect(result).toBe(Math.round(128 * 1024 * 0.845));
+    expect(result).toBe(Math.round(128 * 1024 * 1.3));
   });
 
   test('tier boundary: 128k+1 total input uses >128k pricing', () => {
@@ -450,7 +450,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-max-preview', () => {
       qwen36_max_preview_model,
       makeUsage({ inputTokens: 128 * 1024 + 1 })
     );
-    expect(result).toBe(Math.round((128 * 1024 + 1) * 1.3));
+    expect(result).toBe(Math.round((128 * 1024 + 1) * 2));
   });
 
   test('256k tokens input cost uses >128k tier', () => {
@@ -458,7 +458,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-max-preview', () => {
       qwen36_max_preview_model,
       makeUsage({ inputTokens: 256 * 1024 })
     );
-    expect(result).toBe(Math.round(256 * 1024 * 1.3));
+    expect(result).toBe(Math.round(256 * 1024 * 2));
   });
 });
 
@@ -486,15 +486,15 @@ describe('calculatKiloExclusiveCost_mUsd with stealth Claude Opus 4.7', () => {
 });
 
 describe('calculatKiloExclusiveCost_mUsd with qwen3.6-27b', () => {
-  // Pre-discount prices (35% Kilo discount applied in code):
-  //   Input: $0.5/1M → $0.325/1M   Output: $5/1M → $3.25/1M
+  // Qwen pricing page values with no discount applied in code:
+  //   Input: $0.5/1M → $0.5/1M   Output: $5/1M → $5/1M
 
   test('input-only cost', () => {
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_27b_model,
       makeUsage({ inputTokens: 100_000 })
     );
-    expect(result).toBe(Math.round(100_000 * 0.325));
+    expect(result).toBe(Math.round(100_000 * 0.5));
   });
 
   test('output-only cost', () => {
@@ -502,7 +502,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-27b', () => {
       qwen36_27b_model,
       makeUsage({ outputTokens: 50_000 })
     );
-    expect(result).toBe(Math.round(50_000 * 3.25));
+    expect(result).toBe(Math.round(50_000 * 5));
   });
 
   test('cache hit falls back to prompt price when cache_read is null', () => {
@@ -511,7 +511,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-27b', () => {
       qwen36_27b_model,
       makeUsage({ inputTokens: 100_000, cacheHitTokens: 100_000 })
     );
-    expect(result).toBe(Math.round(100_000 * 0.325));
+    expect(result).toBe(Math.round(100_000 * 0.5));
   });
 
   test('pricing is flat regardless of input size', () => {
@@ -519,6 +519,6 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-27b', () => {
       qwen36_27b_model,
       makeUsage({ inputTokens: 250_000 })
     );
-    expect(result).toBe(Math.round(250_000 * 0.325));
+    expect(result).toBe(Math.round(250_000 * 0.5));
   });
 });

--- a/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
@@ -302,7 +302,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-flash', () => {
   //   CacheRead: $0.1/1M → $0.1/1M   Output: $4/1M → $4/1M
 
   test('input-only cost in <=256k tier', () => {
-    // 1M tokens * 0.25 = 162_500 mUsd
+    // 100k tokens * 0.25 = 25_000 mUsd
     const result = calculateKiloExclusiveCost_mUsd(
       qwen36_flash_model,
       makeUsage({ inputTokens: 100_000 })

--- a/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
@@ -421,7 +421,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-max-preview', () => {
         cacheWriteTokens: 30_000,
       })
     );
-    expect(result).toBe(Math.round(50_000 * 1.3 + 5_000 * 7.8 + 20_000 * 0.2 + 30_000 * 2.5));
+    expect(result).toBe(Math.round(50_000 * 1.3 + 5_000 * 7.8 + 20_000 * 0.13 + 30_000 * 1.625));
   });
 
   test('input-only cost in >128k tier', () => {

--- a/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.calculatKiloExclusiveCost.test.ts
@@ -356,9 +356,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-flash', () => {
         cacheWriteTokens: 100_000,
       })
     );
-    expect(result).toBe(
-      Math.round(350_000 * 1 + 20_000 * 4 + 50_000 * 0.1 + 100_000 * 1.25)
-    );
+    expect(result).toBe(Math.round(350_000 * 1 + 20_000 * 4 + 50_000 * 0.1 + 100_000 * 1.25));
   });
 
   test('tier boundary: exactly 256k total input uses <=256k pricing', () => {
@@ -423,9 +421,7 @@ describe('calculatKiloExclusiveCost_mUsd with qwen3.6-max-preview', () => {
         cacheWriteTokens: 30_000,
       })
     );
-    expect(result).toBe(
-      Math.round(50_000 * 1.3 + 5_000 * 7.8 + 20_000 * 0.2 + 30_000 * 2.5)
-    );
+    expect(result).toBe(Math.round(50_000 * 1.3 + 5_000 * 7.8 + 20_000 * 0.2 + 30_000 * 2.5));
   });
 
   test('input-only cost in >128k tier', () => {

--- a/apps/web/src/lib/ai-gateway/providers/qwen.ts
+++ b/apps/web/src/lib/ai-gateway/providers/qwen.ts
@@ -4,14 +4,16 @@ import type {
   Usage,
 } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 
-const KILO_DISCOUNT_FACTOR = 0.65;
+const DEFAULT_QWEN_DISCOUNT_FACTOR = 1;
+const QWEN37_PLUS_DISCOUNT_FACTOR = 0.8;
+const QWEN37_MAX_DISCOUNT_FACTOR = 0.5;
 const KILO_STEALTH_DISCOUNT_FACTOR = 0.5;
 
 type PricePerMillion = Omit<Pricing, 'calculate_mUsd'>;
 
 function applyKiloDiscount(
   price: PricePerMillion,
-  discountFactor: number = KILO_DISCOUNT_FACTOR
+  discountFactor: number = DEFAULT_QWEN_DISCOUNT_FACTOR
 ): PricePerMillion {
   return {
     prompt_per_million: price.prompt_per_million * discountFactor,
@@ -45,7 +47,7 @@ function costForTier(usage: Usage, tier: PricePerMillion): number {
  */
 function makeTieredPricing(
   tiers: ReadonlyArray<{ maxInputTokens: number; undiscounted: PricePerMillion }>,
-  discountFactor: number = KILO_DISCOUNT_FACTOR
+  discountFactor: number = DEFAULT_QWEN_DISCOUNT_FACTOR
 ): Pricing {
   const discounted = tiers.map(t => ({
     maxInputTokens: t.maxInputTokens,
@@ -63,8 +65,11 @@ function makeTieredPricing(
   };
 }
 
-function makeFlatPricing(undiscounted: PricePerMillion): Pricing {
-  const price = applyKiloDiscount(undiscounted);
+function makeFlatPricing(
+  undiscounted: PricePerMillion,
+  discountFactor: number = DEFAULT_QWEN_DISCOUNT_FACTOR
+): Pricing {
+  const price = applyKiloDiscount(undiscounted, discountFactor);
   return {
     ...price,
     calculate_mUsd: (usage: Usage) => costForTier(usage, price),
@@ -86,12 +91,15 @@ export const qwen37_max_model: KiloExclusiveModel = {
   flags: ['reasoning'],
   gateway: 'alibaba',
   internal_id: 'qwen3.7-max',
-  pricing: makeFlatPricing({
-    prompt_per_million: 2.5,
-    completion_per_million: 7.5,
-    input_cache_read_per_million: 0.25,
-    input_cache_write_per_million: 3.125,
-  }),
+  pricing: makeFlatPricing(
+    {
+      prompt_per_million: 2.5,
+      completion_per_million: 7.5,
+      input_cache_read_per_million: 0.25,
+      input_cache_write_per_million: 3.125,
+    },
+    QWEN37_MAX_DISCOUNT_FACTOR
+  ),
   exclusive_to: [],
   inference_provider_restriction: [],
 };
@@ -107,26 +115,29 @@ export const qwen37_plus_model: KiloExclusiveModel = {
   flags: ['reasoning', 'vision'],
   gateway: 'alibaba',
   internal_id: 'qwen3.7-plus',
-  pricing: makeTieredPricing([
-    {
-      maxInputTokens: TOKENS_256K,
-      undiscounted: {
-        prompt_per_million: 0.4,
-        completion_per_million: 1.6,
-        input_cache_read_per_million: 0.04,
-        input_cache_write_per_million: 0.5,
+  pricing: makeTieredPricing(
+    [
+      {
+        maxInputTokens: TOKENS_256K,
+        undiscounted: {
+          prompt_per_million: 0.4,
+          completion_per_million: 1.6,
+          input_cache_read_per_million: 0.04,
+          input_cache_write_per_million: 0.5,
+        },
       },
-    },
-    {
-      maxInputTokens: TOKENS_1M,
-      undiscounted: {
-        prompt_per_million: 1.2,
-        completion_per_million: 4.8,
-        input_cache_read_per_million: 0.12,
-        input_cache_write_per_million: 1.5,
+      {
+        maxInputTokens: TOKENS_1M,
+        undiscounted: {
+          prompt_per_million: 1.2,
+          completion_per_million: 4.8,
+          input_cache_read_per_million: 0.12,
+          input_cache_write_per_million: 1.5,
+        },
       },
-    },
-  ]),
+    ],
+    QWEN37_PLUS_DISCOUNT_FACTOR
+  ),
   exclusive_to: [],
   inference_provider_restriction: [],
 };


### PR DESCRIPTION
## Summary
- Update direct Qwen pricing so Qwen3.7 Plus uses a 20% discount and Qwen3.7 Max uses a 50% discount.
- Remove the default discount from other custom-priced direct Qwen models while preserving the existing stealth Qwen3.6 Plus discount.
- Update pricing-cost assertions to reflect the new rates.

## Verification
- N/A (no manual verification performed).

## Visual Changes
- N/A.

## Reviewer Notes
- The stealth Qwen3.6 Plus pricing remains on its explicit 50% discount because it is a separate Martian-served offering.