### PR TITLE
fix(mobile): add subscription legal links

### DIFF
--- a/apps/mobile/src/components/kilo-pass/kilo-pass-subscription-screen.tsx
+++ b/apps/mobile/src/components/kilo-pass/kilo-pass-subscription-screen.tsx
@@ -1,4 +1,5 @@
 import * as Haptics from 'expo-haptics';
+import * as WebBrowser from 'expo-web-browser';
 import { useRouter } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -7,7 +8,9 @@ import { ScreenHeader } from '@/components/screen-header';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
+import { WEB_BASE_URL } from '@/lib/config';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { getKiloPassLegalLinks, KILO_PASS_LEGAL_DISCLOSURE } from '@/lib/kilo-pass/legal-links';
 import { ensureProfileAfterKiloPassPurchase } from '@/lib/kilo-pass/navigation';
 import { type AppStoreKiloPassProduct } from '@/lib/kilo-pass/store-products';
 import { useStoreKiloPassProducts } from '@/lib/kilo-pass/use-store-kilo-pass-products';
@@ -28,6 +31,7 @@ export function KiloPassSubscriptionScreen() {
   const productsQuery = useStoreKiloPassProducts();
   const purchase = useStoreKiloPassPurchase();
   const isRetryDisabled = purchase.isPending || productsQuery.isRefetching;
+  const [privacyPolicyLink, termsOfUseLink] = getKiloPassLegalLinks(WEB_BASE_URL);
   const handleProductPress = (product: AppStoreKiloPassProduct) => {
     void Haptics.selectionAsync();
     void purchase.purchase(product, {
@@ -102,6 +106,31 @@ export function KiloPassSubscriptionScreen() {
                 </View>
               </Pressable>
             ))}
+
+          <Text className="px-1 pt-1 text-xs leading-5 text-muted-foreground">
+            {KILO_PASS_LEGAL_DISCLOSURE}
+            {' By subscribing, you agree to the '}
+            <Text
+              accessibilityRole="link"
+              className="text-xs text-primary underline"
+              onPress={() => {
+                void WebBrowser.openBrowserAsync(termsOfUseLink.url);
+              }}
+            >
+              {termsOfUseLink.label}
+            </Text>
+            {' and acknowledge the '}
+            <Text
+              accessibilityRole="link"
+              className="text-xs text-primary underline"
+              onPress={() => {
+                void WebBrowser.openBrowserAsync(privacyPolicyLink.url);
+              }}
+            >
+              {privacyPolicyLink.label}
+            </Text>
+            .
+          </Text>
         </ScrollView>
 
         {purchase.isPending && (

--- a/apps/mobile/src/lib/kilo-pass/legal-links.test.ts
+++ b/apps/mobile/src/lib/kilo-pass/legal-links.test.ts
@@ -16,9 +16,9 @@ describe('Kilo Pass legal disclosure links', () => {
     ]);
   });
 
-  it('uses App Store subscription disclosure copy', () => {
+  it('uses platform-neutral subscription disclosure copy', () => {
     expect(KILO_PASS_LEGAL_DISCLOSURE).toBe(
-      'Subscriptions renew monthly until canceled. Manage or cancel anytime in your App Store account settings.'
+      'Subscriptions renew monthly until canceled. Manage or cancel anytime through your app store account settings.'
     );
   });
 });

--- a/apps/mobile/src/lib/kilo-pass/legal-links.test.ts
+++ b/apps/mobile/src/lib/kilo-pass/legal-links.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getKiloPassLegalLinks, KILO_PASS_LEGAL_DISCLOSURE } from './legal-links';
+
+describe('Kilo Pass legal disclosure links', () => {
+  it('includes functional privacy policy and Terms of Use links for the purchase flow', () => {
+    expect(getKiloPassLegalLinks('https://app.example.com')).toEqual([
+      {
+        label: 'Privacy Policy',
+        url: 'https://app.example.com/privacy-app',
+      },
+      {
+        label: 'Terms of Use (EULA)',
+        url: 'https://app.example.com/terms-app',
+      },
+    ]);
+  });
+
+  it('uses App Store subscription disclosure copy', () => {
+    expect(KILO_PASS_LEGAL_DISCLOSURE).toBe(
+      'Subscriptions renew monthly until canceled. Manage or cancel anytime in your App Store account settings.'
+    );
+  });
+});

--- a/apps/mobile/src/lib/kilo-pass/legal-links.ts
+++ b/apps/mobile/src/lib/kilo-pass/legal-links.ts
@@ -1,0 +1,24 @@
+export const KILO_PASS_LEGAL_DISCLOSURE =
+  'Subscriptions renew monthly until canceled. Manage or cancel anytime in your App Store account settings.';
+
+type KiloPassLegalLink = {
+  label: 'Privacy Policy' | 'Terms of Use (EULA)';
+  url: string;
+};
+
+export function getKiloPassLegalLinks(
+  webBaseUrl: string
+): readonly [KiloPassLegalLink, KiloPassLegalLink] {
+  const baseUrl = webBaseUrl.replace(/\/+$/, '');
+
+  return [
+    {
+      label: 'Privacy Policy',
+      url: `${baseUrl}/privacy-app`,
+    },
+    {
+      label: 'Terms of Use (EULA)',
+      url: `${baseUrl}/terms-app`,
+    },
+  ];
+}

--- a/apps/mobile/src/lib/kilo-pass/legal-links.ts
+++ b/apps/mobile/src/lib/kilo-pass/legal-links.ts
@@ -1,5 +1,5 @@
 export const KILO_PASS_LEGAL_DISCLOSURE =
-  'Subscriptions renew monthly until canceled. Manage or cancel anytime in your App Store account settings.';
+  'Subscriptions renew monthly until canceled. Manage or cancel anytime through your app store account settings.';
 
 type KiloPassLegalLink = {
   label: 'Privacy Policy' | 'Terms of Use (EULA)';

--- a/apps/web/src/app/legal-page-source.ts
+++ b/apps/web/src/app/legal-page-source.ts
@@ -1,0 +1,32 @@
+type ExtractLegalMainHtmlOptions = {
+  html: string;
+  sourceUrl: string;
+  missingMessage: string;
+};
+
+function absolutizeKiloLinks(html: string, sourceUrl: string): string {
+  return html.replaceAll(/(href|src)="\/(?!\/)/g, `$1="${new URL('/', sourceUrl)}`);
+}
+
+function removeActiveContent(html: string): string {
+  return html
+    .replaceAll(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replaceAll(/<iframe\b[^>]*>[\s\S]*?<\/iframe>/gi, '')
+    .replaceAll(/\son[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+}
+
+function removeSourceAttributes(html: string): string {
+  return removeActiveContent(html)
+    .replaceAll(/\sclass="[^"]*"/g, '')
+    .replaceAll(/\sdata-sentry-[a-z-]+="[^"]*"/g, '')
+    .replaceAll(/\sstyle="[^"]*"/g, '');
+}
+
+export function extractLegalMainHtml(options: ExtractLegalMainHtmlOptions): string {
+  const match = options.html.match(/<main\b[^>]*>([\s\S]*)<\/main>/i);
+  if (!match?.[1]) {
+    throw new Error(options.missingMessage);
+  }
+
+  return removeSourceAttributes(absolutizeKiloLinks(match[1], options.sourceUrl)).trim();
+}

--- a/apps/web/src/app/privacy-app/privacy-policy-source.test.ts
+++ b/apps/web/src/app/privacy-app/privacy-policy-source.test.ts
@@ -32,6 +32,40 @@ describe('extractPrivacyPolicyMainHtml', () => {
     expect(result).not.toContain('Pricing');
     expect(result).not.toContain('Terms');
   });
+
+  test('strips active content from the extracted privacy policy HTML', () => {
+    const html = `
+      <main>
+        <h1 onclick="alert('xss')">Privacy Policy</h1>
+        <img src="/logo.png" onerror="alert('xss')" />
+        <script>alert('xss')</script>
+        <iframe src="https://example.com"></iframe>
+      </main>
+    `;
+
+    const result = extractPrivacyPolicyMainHtml(html);
+
+    expect(result).toContain('Privacy Policy');
+    expect(result).toContain('src="https://kilo.ai/logo.png"');
+    expect(result).not.toContain('onclick');
+    expect(result).not.toContain('onerror');
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('<iframe');
+  });
+
+  test('keeps content after an inner closing main marker', () => {
+    const html = `
+      <main>
+        <h1>Privacy Policy</h1>
+        <template></main></template>
+        <p>Final privacy section</p>
+      </main>
+    `;
+
+    const result = extractPrivacyPolicyMainHtml(html);
+
+    expect(result).toContain('Final privacy section');
+  });
 });
 
 describe('fetchPrivacyPolicyMainHtml', () => {

--- a/apps/web/src/app/privacy-app/privacy-policy-source.ts
+++ b/apps/web/src/app/privacy-app/privacy-policy-source.ts
@@ -1,3 +1,5 @@
+import { extractLegalMainHtml } from '@/app/legal-page-source';
+
 export const PRIVACY_POLICY_SOURCE_URL = 'https://kilo.ai/privacy';
 
 const PRIVACY_CONTACT_EMAIL = ['support', 'kilo.ai'].join('@');
@@ -8,24 +10,12 @@ export const PRIVACY_POLICY_FALLBACK_HTML = `
 <p>For privacy questions or requests, contact <a href="mailto:${PRIVACY_CONTACT_EMAIL}">${PRIVACY_CONTACT_EMAIL}</a>.</p>
 `.trim();
 
-function absolutizeKiloLinks(html: string): string {
-  return html.replaceAll(/(href|src)="\/(?!\/)/g, `$1="${new URL('/', PRIVACY_POLICY_SOURCE_URL)}`);
-}
-
-function removeSourceAttributes(html: string): string {
-  return html
-    .replaceAll(/\sclass="[^"]*"/g, '')
-    .replaceAll(/\sdata-sentry-[a-z-]+="[^"]*"/g, '')
-    .replaceAll(/\sstyle="[^"]*"/g, '');
-}
-
 export function extractPrivacyPolicyMainHtml(html: string): string {
-  const match = html.match(/<main\b[^>]*>([\s\S]*?)<\/main>/i);
-  if (!match?.[1]) {
-    throw new Error('Could not find privacy policy content.');
-  }
-
-  return removeSourceAttributes(absolutizeKiloLinks(match[1])).trim();
+  return extractLegalMainHtml({
+    html,
+    sourceUrl: PRIVACY_POLICY_SOURCE_URL,
+    missingMessage: 'Could not find privacy policy content.',
+  });
 }
 
 export async function fetchPrivacyPolicyMainHtml(): Promise<string> {

--- a/apps/web/src/app/terms-app/page.tsx
+++ b/apps/web/src/app/terms-app/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+
+import { fetchTermsMainHtml } from './terms-source';
+
+export const metadata: Metadata = {
+  title: 'Terms of Use',
+  description: 'Terms of Use for Kilo Code',
+  robots: {
+    index: false,
+    follow: true,
+  },
+};
+
+export const revalidate = 3600;
+
+export default async function TermsAppPage() {
+  const termsHtml = await fetchTermsMainHtml();
+
+  return (
+    <main className="bg-background min-h-screen px-4 py-6 sm:px-6">
+      <div
+        className="prose prose-invert prose-headings:text-foreground prose-p:text-muted-foreground prose-li:text-muted-foreground prose-a:text-primary mx-auto max-w-3xl"
+        dangerouslySetInnerHTML={{ __html: termsHtml }}
+      />
+    </main>
+  );
+}

--- a/apps/web/src/app/terms-app/terms-source.test.ts
+++ b/apps/web/src/app/terms-app/terms-source.test.ts
@@ -28,6 +28,40 @@ describe('extractTermsMainHtml', () => {
     expect(result).not.toContain('Pricing');
     expect(result).not.toContain('Privacy');
   });
+
+  test('strips active content from the extracted terms HTML', () => {
+    const html = `
+      <main>
+        <h1 onclick="alert('xss')">Terms of Service</h1>
+        <img src="/logo.png" onerror="alert('xss')" />
+        <script>alert('xss')</script>
+        <iframe src="https://example.com"></iframe>
+      </main>
+    `;
+
+    const result = extractTermsMainHtml(html);
+
+    expect(result).toContain('Terms of Service');
+    expect(result).toContain('src="https://kilo.ai/logo.png"');
+    expect(result).not.toContain('onclick');
+    expect(result).not.toContain('onerror');
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('<iframe');
+  });
+
+  test('keeps content after an inner closing main marker', () => {
+    const html = `
+      <main>
+        <h1>Terms of Service</h1>
+        <template></main></template>
+        <p>Final terms section</p>
+      </main>
+    `;
+
+    const result = extractTermsMainHtml(html);
+
+    expect(result).toContain('Final terms section');
+  });
 });
 
 describe('fetchTermsMainHtml', () => {

--- a/apps/web/src/app/terms-app/terms-source.test.ts
+++ b/apps/web/src/app/terms-app/terms-source.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+
+import { extractTermsMainHtml, fetchTermsMainHtml, TERMS_FALLBACK_HTML } from './terms-source';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe('extractTermsMainHtml', () => {
+  test('keeps the terms content without source navigation or footer', () => {
+    const html = `
+      <header><a href="/pricing">Pricing</a></header>
+      <main id="main">
+        <h1>Terms of Service</h1>
+        <p>Terms body</p>
+        <a href="/support">Support</a>
+      </main>
+      <footer><a href="/privacy">Privacy</a></footer>
+    `;
+
+    const result = extractTermsMainHtml(html);
+
+    expect(result).toContain('Terms of Service');
+    expect(result).toContain('Terms body');
+    expect(result).toContain('href="https://kilo.ai/support"');
+    expect(result).not.toContain('Pricing');
+    expect(result).not.toContain('Privacy');
+  });
+});
+
+describe('fetchTermsMainHtml', () => {
+  test('returns fallback content when the source request fails', async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error('network unavailable');
+    });
+
+    await expect(fetchTermsMainHtml()).resolves.toBe(TERMS_FALLBACK_HTML);
+  });
+
+  test('returns fallback content when the source returns an error status', async () => {
+    global.fetch = jest.fn(async () => ({ ok: false, status: 503 }) as Response);
+
+    await expect(fetchTermsMainHtml()).resolves.toBe(TERMS_FALLBACK_HTML);
+  });
+
+  test('returns fallback content when the source content cannot be parsed', async () => {
+    global.fetch = jest.fn(
+      async () =>
+        ({
+          ok: true,
+          text: async () => '<html><body>No terms content</body></html>',
+        }) as Response
+    );
+
+    await expect(fetchTermsMainHtml()).resolves.toBe(TERMS_FALLBACK_HTML);
+  });
+});

--- a/apps/web/src/app/terms-app/terms-source.ts
+++ b/apps/web/src/app/terms-app/terms-source.ts
@@ -1,0 +1,45 @@
+export const TERMS_SOURCE_URL = 'https://kilo.ai/terms';
+
+const TERMS_CONTACT_EMAIL = ['support', 'kilo.ai'].join('@');
+
+export const TERMS_FALLBACK_HTML = `
+<h1>Terms of Use</h1>
+<p>The full Kilo terms are temporarily unavailable. Please try again shortly.</p>
+<p>For terms questions, contact <a href="mailto:${TERMS_CONTACT_EMAIL}">${TERMS_CONTACT_EMAIL}</a>.</p>
+`.trim();
+
+function absolutizeKiloLinks(html: string): string {
+  return html.replaceAll(/(href|src)="\/(?!\/)/g, `$1="${new URL('/', TERMS_SOURCE_URL)}`);
+}
+
+function removeSourceAttributes(html: string): string {
+  return html
+    .replaceAll(/\sclass="[^"]*"/g, '')
+    .replaceAll(/\sdata-sentry-[a-z-]+="[^"]*"/g, '')
+    .replaceAll(/\sstyle="[^"]*"/g, '');
+}
+
+export function extractTermsMainHtml(html: string): string {
+  const match = html.match(/<main\b[^>]*>([\s\S]*?)<\/main>/i);
+  if (!match?.[1]) {
+    throw new Error('Could not find terms content.');
+  }
+
+  return removeSourceAttributes(absolutizeKiloLinks(match[1])).trim();
+}
+
+export async function fetchTermsMainHtml(): Promise<string> {
+  try {
+    const response = await fetch(TERMS_SOURCE_URL, {
+      next: { revalidate: 3600 },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch terms: ${response.status}`);
+    }
+
+    return extractTermsMainHtml(await response.text());
+  } catch {
+    return TERMS_FALLBACK_HTML;
+  }
+}

--- a/apps/web/src/app/terms-app/terms-source.ts
+++ b/apps/web/src/app/terms-app/terms-source.ts
@@ -1,3 +1,5 @@
+import { extractLegalMainHtml } from '@/app/legal-page-source';
+
 export const TERMS_SOURCE_URL = 'https://kilo.ai/terms';
 
 const TERMS_CONTACT_EMAIL = ['support', 'kilo.ai'].join('@');
@@ -8,24 +10,12 @@ export const TERMS_FALLBACK_HTML = `
 <p>For terms questions, contact <a href="mailto:${TERMS_CONTACT_EMAIL}">${TERMS_CONTACT_EMAIL}</a>.</p>
 `.trim();
 
-function absolutizeKiloLinks(html: string): string {
-  return html.replaceAll(/(href|src)="\/(?!\/)/g, `$1="${new URL('/', TERMS_SOURCE_URL)}`);
-}
-
-function removeSourceAttributes(html: string): string {
-  return html
-    .replaceAll(/\sclass="[^"]*"/g, '')
-    .replaceAll(/\sdata-sentry-[a-z-]+="[^"]*"/g, '')
-    .replaceAll(/\sstyle="[^"]*"/g, '');
-}
-
 export function extractTermsMainHtml(html: string): string {
-  const match = html.match(/<main\b[^>]*>([\s\S]*?)<\/main>/i);
-  if (!match?.[1]) {
-    throw new Error('Could not find terms content.');
-  }
-
-  return removeSourceAttributes(absolutizeKiloLinks(match[1])).trim();
+  return extractLegalMainHtml({
+    html,
+    sourceUrl: TERMS_SOURCE_URL,
+    missingMessage: 'Could not find terms content.',
+  });
 }
 
 export async function fetchTermsMainHtml(): Promise<string> {


### PR DESCRIPTION
## Summary

- Adds an app-hosted `/terms-app` route that mirrors the existing `/privacy-app` pattern by extracting the Kilo terms page content and falling back to support copy if the source is unavailable.
- Adds the required Kilo Pass subscription disclosure links in the mobile purchase flow for Privacy Policy and Terms of Use (EULA).
- Covers the app-hosted terms extractor and mobile legal-link targets with focused regression tests.

## Verification

- Confirmed `https://kilo.ai/terms` returns HTTP 200 and includes the expected terms page content for extraction.

## Visual Changes

N/A - no screenshots captured for the legal-copy/link addition.

## Reviewer Notes

- The Terms of Use link now resolves through `${WEB_BASE_URL}/terms-app`, matching the existing app-hosted privacy policy route pattern.
