### PR TITLE
fix(web): avoid mcp register route slug conflict

### DIFF
--- a/apps/web/src/app/api/mcp-gateway/oauth/register/[scope]/route.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/register/[scope]/route.ts
@@ -12,11 +12,11 @@ async function authenticatedClient(request: NextRequest) {
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ clientId: string }> }
+  { params }: { params: Promise<{ scope: string }> }
 ) {
   try {
     const auth = await authenticatedClient(request);
-    const { clientId } = await params;
+    const { scope: clientId } = await params;
     if (!auth?.client || auth.client.client_id !== clientId) {
       return NextResponse.json({ error: 'invalid_client' }, { status: 401 });
     }
@@ -36,11 +36,11 @@ export async function GET(
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Promise<{ clientId: string }> }
+  { params }: { params: Promise<{ scope: string }> }
 ) {
   try {
     const auth = await authenticatedClient(request);
-    const { clientId } = await params;
+    const { scope: clientId } = await params;
     if (!auth?.client || auth.client.client_id !== clientId) {
       return NextResponse.json({ error: 'invalid_client' }, { status: 401 });
     }
@@ -63,11 +63,11 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ clientId: string }> }
+  { params }: { params: Promise<{ scope: string }> }
 ) {
   try {
     const auth = await authenticatedClient(request);
-    const { clientId } = await params;
+    const { scope: clientId } = await params;
     if (!auth?.client || auth.client.client_id !== clientId) {
       return NextResponse.json({ error: 'invalid_client' }, { status: 401 });
     }


### PR DESCRIPTION
## Summary

  Renames the MCP gateway dynamic client registration route from `[clientId]` to `[scope]` so it no longer conflicts with the scoped registration route under the same `/
  api/mcp-gateway/oauth/register` path.

  This fixes the Next.js runtime error:

  `You cannot use different slug names for the same dynamic path ('clientId' !== 'scope')`
## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [ ]

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

Next.js requires sibling dynamic route segments at the same path level to use the same parameter name.

  This PR had both:

  /api/mcp-gateway/oauth/register/[clientId]
  /api/mcp-gateway/oauth/register/[scope]/[ownerId]/[configId]/[routeKey]

  At the first dynamic segment under /register, Next sees two route-tree entries for the same URL position:

  /register/:clientId
  /register/:scope/...

  Even though one route is shorter and one has more segments after it, they still share that first dynamic segment position. Next cannot build one route matcher where the
  same segment is sometimes named clientId and sometimes named scope, so it throws:

  You cannot use different slug names for the same dynamic path ('clientId' !== 'scope')

  The fix renames [clientId] to [scope] so the route tree is internally consistent:

  /api/mcp-gateway/oauth/register/[scope]
  /api/mcp-gateway/oauth/register/[scope]/[ownerId]/[configId]/[routeKey]

  The public URL behavior is unchanged. In the one-segment handler, we just treat scope as the old clientId value internally.
