### PR TITLE
fix(ai-gateway): disable discounted MiniMax M3 (merge EOD 2026-06-07)

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/minimax.ts
+++ b/apps/web/src/lib/ai-gateway/providers/minimax.ts
@@ -13,7 +13,7 @@ export const minimax_m3_discounted_model: KiloExclusiveModel = {
 Trained as a native multimodal model on interleaved data and tuned for multi-turn, production-like collaboration via an interactive user-simulator framework, the model is oriented toward sustained, multi-step tasks rather than single-turn execution.`,
   context_length: 524288,
   max_completion_tokens: 512000,
-  status: 'public',
+  status: 'disabled',
   flags: ['reasoning', 'vercel-routing', 'vision'],
   gateway: 'openrouter',
   internal_id: MINIMAX_CURRENT_MODEL_ID,

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -165,8 +165,12 @@ describe('shouldSuppressOpenRouterModel', () => {
     expect(shouldSuppressOpenRouterModel(seed_20_code_free_model)).toBe(true);
   });
 
-  it('suppresses public and hidden Kilo-exclusive models from OpenRouter', () => {
-    expect(shouldSuppressOpenRouterModel(minimax_m3_discounted_model)).toBe(true);
+  it('does not suppress disabled paid Kilo-exclusive models from OpenRouter', () => {
+    expect(minimax_m3_discounted_model.status).toBe('disabled');
+    expect(shouldSuppressOpenRouterModel(minimax_m3_discounted_model)).toBe(false);
+  });
+
+  it('suppresses hidden Kilo-exclusive models from OpenRouter', () => {
     expect(morph_warp_grep_free_model.status).toBe('hidden');
     expect(shouldSuppressOpenRouterModel(morph_warp_grep_free_model)).toBe(true);
   });


### PR DESCRIPTION
## Summary
- Disable the discounted MiniMax M3 Kilo-exclusive model so it is no longer available through the public model list or discounted routing.

## Verification
- Not manually verified; this is a single status flag change.

## Visual Changes
- N/A

## Reviewer Notes
- The model definition remains in place, but `status: 'disabled'` removes it from active Kilo-exclusive handling.