### PR TITLE
fix(kiloclaw): link org settings to org BYOK

### DIFF
--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -2211,6 +2211,7 @@ export function SettingsTab({
     supportsExaSearchUi && kiloExaSearchMode === null ? 'kilo-proxy' : kiloExaSearchMode;
   const braveSearchEnabled = braveSearchConfigured && !exaSearchConfigured;
   const toolEntries = getEntriesByCategory('tool');
+  const byokHref = organizationId ? `/organizations/${organizationId}/byok` : '/byok';
 
   function handleCycleInboundEmailAddress() {
     mutations.cycleInboundEmailAddress.mutate(undefined, {
@@ -2393,7 +2394,7 @@ export function SettingsTab({
               </p>
               <p className="text-muted-foreground mt-2 text-xs">
                 Configure your own model provider keys in{' '}
-                <Link href="/byok" target="_blank" className="underline">
+                <Link href={byokHref} target="_blank" className="underline">
                   Kilo BYOK settings
                 </Link>
                 .


### PR DESCRIPTION
## Summary

KiloClaw organization settings now send users to the organization-scoped BYOK page instead of the personal BYOK page, so org users land on the settings area that applies to their workspace. The change follows the existing settings link pattern while deriving the href from the current `organizationId` when present.

## Verification

## Visual Changes

N/A

## Reviewer Notes

N/A