### PR TITLE
fix(cloud-agent): bound wrapper discovery timeouts

### DIFF
--- a/services/cloud-agent-next/src/kilo/wrapper-manager.test.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-manager.test.ts
@@ -1,4 +1,22 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockTimeoutWithFields, mockWarn, mockLogger } = vi.hoisted(() => {
+  const debug = vi.fn();
+  const warn = vi.fn();
+  const timeoutWithFields = vi.fn(() => ({ warn }));
+  return {
+    mockTimeoutWithFields: timeoutWithFields,
+    mockWarn: warn,
+    mockLogger: {
+      withFields: vi.fn(() => ({ debug })),
+      withTags: vi.fn(() => ({ withFields: timeoutWithFields })),
+    },
+  };
+});
+
+vi.mock('../logger.js', () => ({ logger: mockLogger }));
+
+import { FAST_SANDBOX_COMMAND_TIMEOUT_MS } from '../sandbox-timeout-logging.js';
 import {
   discoverSessionWrappers,
   extractPublishedWrapperPort,
@@ -140,6 +158,43 @@ describe('listWrapperContainers', () => {
 });
 
 describe('discoverSessionWrappers', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('returns inspection failure when direct process discovery times out', async () => {
+    vi.useFakeTimers();
+    const sandbox = {
+      listProcesses: vi.fn(() => new Promise<never>(() => undefined)),
+      exec: vi.fn(),
+    };
+
+    const discovery = discoverSessionWrappers(sandbox as never, 'agent_xyz');
+    let settled = false;
+    const observedResult = discovery.then(result => {
+      settled = true;
+      return result;
+    });
+
+    await vi.advanceTimersByTimeAsync(FAST_SANDBOX_COMMAND_TIMEOUT_MS);
+
+    expect(settled).toBe(true);
+    await expect(observedResult).resolves.toEqual({
+      status: 'inspection-failed',
+      error: `Wrapper process discovery timed out after ${FAST_SANDBOX_COMMAND_TIMEOUT_MS}ms`,
+    });
+    expect(mockLogger.withTags).toHaveBeenCalledWith({ logTag: 'sandbox-operation-timeout' });
+    expect(mockTimeoutWithFields).toHaveBeenCalledWith({
+      operation: 'wrapper.discovery.listProcesses',
+      timeoutMs: FAST_SANDBOX_COMMAND_TIMEOUT_MS,
+      timeoutLayer: 'outer',
+    });
+    expect(mockWarn).toHaveBeenCalledOnce();
+    expect(mockWarn).toHaveBeenCalledWith('Sandbox operation timed out');
+    expect(sandbox.exec).not.toHaveBeenCalled();
+  });
+
   it('returns every direct and devcontainer wrapper process tagged for the session', async () => {
     const sandbox = {
       listProcesses: vi.fn().mockResolvedValue([

--- a/services/cloud-agent-next/src/kilo/wrapper-manager.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-manager.ts
@@ -8,9 +8,14 @@
  * This is similar to server-manager.ts but for the wrapper process.
  */
 
+import { withTimeout } from '@kilocode/worker-utils';
 import type { SandboxInstance } from '../types.js';
 import type { ObservedWrapper, WrapperObservation } from '../agent-sandbox/protocol.js';
 import { logger } from '../logger.js';
+import {
+  FAST_SANDBOX_COMMAND_TIMEOUT_MS,
+  logSandboxOperationTimeout,
+} from '../sandbox-timeout-logging.js';
 import { KILO_AGENT_SESSION_LABEL, KILO_WRAPPER_PORT_LABEL } from './devcontainer.js';
 import { dockerSocketEnv, resolveDockerSocketPath } from './sandbox-runtime.js';
 import { shellQuote } from './utils.js';
@@ -291,7 +296,18 @@ export async function discoverSessionWrappers(
 ): Promise<WrapperObservation> {
   let processes: Process[];
   try {
-    processes = await sandbox.listProcesses();
+    const timeoutMs = FAST_SANDBOX_COMMAND_TIMEOUT_MS;
+    processes = await withTimeout(
+      sandbox.listProcesses(),
+      timeoutMs,
+      `Wrapper process discovery timed out after ${timeoutMs}ms`,
+      () =>
+        logSandboxOperationTimeout({
+          operation: 'wrapper.discovery.listProcesses',
+          timeoutMs,
+          timeoutLayer: 'outer',
+        })
+    );
   } catch (error) {
     return {
       status: 'inspection-failed',

--- a/services/cloud-agent-next/src/session/agent-runtime.test.ts
+++ b/services/cloud-agent-next/src/session/agent-runtime.test.ts
@@ -477,6 +477,7 @@ describe('AgentRuntime', () => {
     async ({ observation, reason }) => {
       const storage = createMemoryStorage();
       const execute = vi.fn();
+      const requestAlarmAtOrBefore = vi.fn();
       const sandbox = {
         discoverSessionWrappers: vi.fn().mockResolvedValue(observation),
       } as unknown as AgentSandbox;
@@ -488,10 +489,19 @@ describe('AgentRuntime', () => {
         getSessionIdForLogs: () => 'agent_runtime',
         sendToWrapper: () => false,
         createAgentSandbox: () => sandbox,
+        requestAlarmAtOrBefore,
       });
 
-      await expect(runtime.send(createPlan())).rejects.toThrow(/cleanup is required/i);
+      const now = 10_000;
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+      try {
+        await expect(runtime.send(createPlan())).rejects.toThrow(/cleanup is required/i);
+      } finally {
+        clock.mockRestore();
+      }
       expect(execute).not.toHaveBeenCalled();
+      expect(requestAlarmAtOrBefore).toHaveBeenCalledOnce();
+      expect(requestAlarmAtOrBefore).toHaveBeenCalledWith(now);
       await expect(getWrapperLease(storage)).resolves.toMatchObject({
         state: 'stop_needed',
         target: { kind: 'session' },

--- a/services/cloud-agent-next/src/session/session-message-queue.test.ts
+++ b/services/cloud-agent-next/src/session/session-message-queue.test.ts
@@ -29,6 +29,7 @@ import {
   putSessionMessageState,
   type TerminalizeParams,
 } from './session-message-state.js';
+import { WrapperCleanupBlockedError } from './wrapper-cleanup-blocked-error.js';
 
 type QueueEvent = {
   sessionId: string;
@@ -546,6 +547,27 @@ describe('SessionMessageQueue', () => {
     expect(drain).toEqual({ retryAt, remainingPendingCount: 1 });
     expect(harness.events).toHaveLength(1);
     expect(harness.deliver).not.toHaveBeenCalled();
+    expect(pending?.flushAttempts).toBeUndefined();
+    expect(pending?.lastFlushError).toBeUndefined();
+  });
+
+  it('retains a queued message without consuming an attempt while wrapper cleanup blocks delivery', async () => {
+    const retryAt = 50_000;
+    const harness = createQueueHarness({
+      deliver: async () => {
+        throw new WrapperCleanupBlockedError(retryAt);
+      },
+    });
+    await harness.queue.admitSubmittedMessage({
+      userId: 'user_test' as UserId,
+      turn: { type: 'prompt', id: FIRST_MESSAGE_ID, prompt: 'wait for wrapper cleanup' },
+    });
+
+    const drain = await harness.queue.drainNextPendingMessage();
+    const [pending] = await listPendingSessionMessages(harness.storage);
+
+    expect(drain).toEqual({ retryAt, remainingPendingCount: 1 });
+    expect(pending?.messageId).toBe(FIRST_MESSAGE_ID);
     expect(pending?.flushAttempts).toBeUndefined();
     expect(pending?.lastFlushError).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- Bound Cloudflare Sandbox wrapper process discovery to 30 seconds so a stalled `listProcesses()` RPC cannot indefinitely block Durable Object alarms or queued-message delivery.
- Preserve timeout as an `inspection-failed` observation, retaining the existing cleanup fence and retry behavior instead of treating an uncertain result as confirmed wrapper absence.
- Keep the existing architecture intact by applying the timeout at the wrapper-discovery boundary, protecting every caller without adding an alarm-wide timeout or changing mutation semantics.
- Add focused coverage for structured timeout telemetry, immediate cleanup scheduling, and queued-message retention without consuming a delivery attempt.

## Verification

- Manual verification was not performed because reproducing a permanently stalled Cloudflare Sandbox RPC requires a provider-side failure condition that is unavailable locally.
- [ ] Add additional manual verification details.

## Visual Changes

N/A

## Reviewer Notes

- The outer timeout releases the caller but cannot cancel the underlying Sandbox SDK promise; retries therefore continue to treat the result as uncertain and block replacement wrapper allocation until absence is confirmed.
- After rollout, monitor `logTag=sandbox-operation-timeout` with `operation=wrapper.discovery.listProcesses` and confirm later alarms retry affected sessions.