### PR TITLE
fix(usage): add missing space in overview copy

### DIFF
--- a/apps/web/src/components/usage/UsageWarning.tsx
+++ b/apps/web/src/components/usage/UsageWarning.tsx
@@ -1,7 +1,7 @@
 export function UsageWarning() {
   return (
     <div className="text-muted-foreground mb-4 text-sm">
-      This usage overview includes all of your usage of the Kilo Gateway. It does <b>NOT</b> include
+      This usage overview includes all of your usage of the Kilo Gateway. It does <b>NOT </b>include
       any of the usage made via the Kilo Code extension to other, non-Kilo Code providers. You can
       choose which API provider to use from the extension&apos;s main settings page.
     </div>


### PR DESCRIPTION
## Summary
Fix a typo reported by users on Discord.

## Implementation

JSX collapses whitespace between ordinary text, but the `<b>` boundary changes how that whitespace is represented.

The original code was:

```tsx
It does <b>NOT</b> include
```

The formatter placed the text after `</b>` on a new source line. React’s JSX whitespace handling then omitted that leading whitespace, producing `NOTinclude`.

The fix puts the space inside the bold element:

```tsx
It does <b>NOT </b>include
```

That makes the space explicit and resistant to formatter line wrapping. An alternative is:

```tsx
It does <b>NOT</b>{" "}include
```

However, the formatter wrapped that version in a way that still caused the intended change to disappear. Keeping the trailing space inside `<b>` is the smallest stable fix; visually, the space itself being bold has no observable effect.

## Verification
Confirmed the usage warning now renders a space between “NOT” and “include”.

## Visual Changes
N/A

## Reviewer Notes
N/A