### PR TITLE
chore(models): remove expired MiniMax M3 discount

### DIFF
--- a/apps/web/src/lib/ai-gateway/context-overflow.test.ts
+++ b/apps/web/src/lib/ai-gateway/context-overflow.test.ts
@@ -4,7 +4,7 @@ import type {
   GatewayRequest,
   OpenRouterChatCompletionRequest,
 } from '@/lib/ai-gateway/providers/openrouter/types';
-import { minimax_m3_discounted_model } from '@/lib/ai-gateway/providers/minimax';
+import { gemma_4_26b_a4b_it_free_model } from '@/lib/ai-gateway/providers/google';
 import { ProxyErrorType } from '@/lib/proxy-error-types';
 
 function chatRequest(body: OpenRouterChatCompletionRequest): GatewayRequest {
@@ -158,16 +158,16 @@ describe('detectContextOverflow', () => {
   });
 
   it('triggers on a generic 500 when our estimate exceeds the window', async () => {
-    // MiniMax M3 has context_length 524_288 and max_completion_tokens 512_000.
-    // This request estimates to more than 612_000 tokens, exceeding the context window.
+    // Gemma 4 has context_length 262_144 and max_completion_tokens 32_768.
+    // This request estimates to more than 282_000 tokens, exceeding the context window.
     const hugeRequest = chatRequest({
-      model: minimax_m3_discounted_model.public_id,
-      messages: [{ role: 'user', content: 'x'.repeat(400_000) }],
-      max_tokens: 512_000,
+      model: gemma_4_26b_a4b_it_free_model.public_id,
+      messages: [{ role: 'user', content: 'x'.repeat(1_000_000) }],
+      max_tokens: 32_768,
     });
 
     const result = await detectContextOverflow({
-      requestedModel: minimax_m3_discounted_model.public_id,
+      requestedModel: gemma_4_26b_a4b_it_free_model.public_id,
       request: hugeRequest,
       response: new Response('Internal Server Error', { status: 500 }),
     });
@@ -180,12 +180,12 @@ describe('detectContextOverflow', () => {
 
   it('does not trigger on a 500 when the estimate fits the window', async () => {
     const smallRequest = chatRequest({
-      model: minimax_m3_discounted_model.public_id,
+      model: gemma_4_26b_a4b_it_free_model.public_id,
       messages: [{ role: 'user', content: 'hi' }],
     });
 
     const result = await detectContextOverflow({
-      requestedModel: minimax_m3_discounted_model.public_id,
+      requestedModel: gemma_4_26b_a4b_it_free_model.public_id,
       request: smallRequest,
       response: new Response('Internal Server Error', { status: 500 }),
     });

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -23,10 +23,7 @@ import {
 } from '@/lib/ai-gateway/providers/anthropic.constants';
 import { seed_20_code_free_model } from '@/lib/ai-gateway/providers/seed';
 import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
-import {
-  MINIMAX_CURRENT_MODEL_ID,
-  minimax_m3_discounted_model,
-} from '@/lib/ai-gateway/providers/minimax';
+import { MINIMAX_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/minimax';
 import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 import { morph_warp_grep_free_model } from '@/lib/ai-gateway/providers/morph';
 import {
@@ -89,7 +86,6 @@ export function isKiloExclusiveModel(model: string): boolean {
 
 export const kiloExclusiveModels = [
   gemma_4_26b_a4b_it_free_model,
-  minimax_m3_discounted_model,
   morph_warp_grep_free_model,
   seed_20_code_free_model,
   ...alibabaDirectModels,

--- a/apps/web/src/lib/ai-gateway/providers/minimax.ts
+++ b/apps/web/src/lib/ai-gateway/providers/minimax.ts
@@ -1,32 +1,4 @@
-import {
-  calculateSimpleCost_mUsd,
-  type KiloExclusiveModel,
-} from '@/lib/ai-gateway/providers/kilo-exclusive-model';
-
 export const MINIMAX_CURRENT_MODEL_ID = 'minimax/minimax-m3';
-
-export const minimax_m3_discounted_model: KiloExclusiveModel = {
-  public_id: MINIMAX_CURRENT_MODEL_ID + ':discounted',
-  display_name: 'MiniMax: MiniMax M3 (50% off through 2026-06-07)',
-  description: `MiniMax-M3 is a multimodal foundation model from MiniMax. It supports text, image, and video inputs with text output, a 1M-token context window, and is suited for long-horizon agentic work, coding, and tool use. It is built on MiniMax Sparse Attention (MSA), which replaces full attention with KV-block selection to cut per-token compute at long context — roughly 1/20 the cost of the previous generation at 1M tokens, with substantially faster prefill and decode while retaining quality across most tasks.
-
-Trained as a native multimodal model on interleaved data and tuned for multi-turn, production-like collaboration via an interactive user-simulator framework, the model is oriented toward sustained, multi-step tasks rather than single-turn execution.`,
-  context_length: 524288,
-  max_completion_tokens: 512000,
-  status: 'disabled',
-  flags: ['reasoning', 'vercel-routing', 'vision'],
-  gateway: 'openrouter',
-  internal_id: MINIMAX_CURRENT_MODEL_ID,
-  pricing: {
-    prompt_per_million: 0.3,
-    completion_per_million: 1.2,
-    input_cache_read_per_million: 0.06,
-    input_cache_write_per_million: null,
-    calculate_mUsd: calculateSimpleCost_mUsd,
-  },
-  exclusive_to: [],
-  inference_provider_restriction: [],
-};
 
 export function isMinimaxModel(model: string) {
   return model.includes('minimax');

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@/lib/ai-gateway/providers/openrouter';
 import { createMockResponse, mockOpenRouterModels } from '@/tests/helpers/openrouter-models.helper';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
-import { minimax_m3_discounted_model } from '@/lib/ai-gateway/providers/minimax';
+import { qwen36_plus_stealth_model } from '@/lib/ai-gateway/providers/qwen';
 import { seed_20_code_free_model } from '@/lib/ai-gateway/providers/seed';
 import { morph_warp_grep_free_model } from '@/lib/ai-gateway/providers/morph';
 import {
@@ -25,7 +25,7 @@ jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
 const originalFetch = global.fetch;
 
 const disabledPaidModel = {
-  ...minimax_m3_discounted_model,
+  ...qwen36_plus_stealth_model,
   public_id: 'vendor/disabled-paid-model',
   internal_id: 'vendor/disabled-paid-model-internal',
   display_name: 'Disabled Paid Kilo Model',
@@ -163,11 +163,6 @@ describe('shouldSuppressOpenRouterModel', () => {
     expect(seed_20_code_free_model.status).toBe('disabled');
     expect(seed_20_code_free_model.pricing).toBeNull();
     expect(shouldSuppressOpenRouterModel(seed_20_code_free_model)).toBe(true);
-  });
-
-  it('does not suppress disabled paid Kilo-exclusive models from OpenRouter', () => {
-    expect(minimax_m3_discounted_model.status).toBe('disabled');
-    expect(shouldSuppressOpenRouterModel(minimax_m3_discounted_model)).toBe(false);
   });
 
   it('suppresses hidden Kilo-exclusive models from OpenRouter', () => {


### PR DESCRIPTION
## Summary

- Remove the expired `minimax_m3_discounted_model` definition and registry entry.
- Keep context-overflow and disabled paid-model coverage using active model fixtures.

## Verification

- [ ] Manual testing not run; this removes a disabled model definition with no visual behavior.

## Visual Changes

N/A

## Reviewer Notes

The standard pre-commit and pre-push checks were skipped as requested; deferred automated verification follows the initial push.