### PR TITLE
fix(code-review): retry wrapper mismatch

### DIFF
--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -932,6 +932,65 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
       expect(mockTryDispatchPendingReviews).not.toHaveBeenCalled();
     });
 
+    it('retries a wrapper version mismatch infra failure without marking parent terminal', async () => {
+      const errorMessage = 'Wrapper version mismatch after startup: expected 2.0.0, got 1.9.9';
+
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ status: 'running', session_id: 'agent-wrapper-mismatch-old' })
+      );
+      mockUpdateCodeReviewAttemptForCallback.mockResolvedValue(
+        makeAttempt({
+          id: '00000000-0000-0000-0000-000000000203',
+          status: 'failed',
+          session_id: 'agent-wrapper-mismatch-old',
+        })
+      );
+      mockGetLatestCodeReviewAttempt.mockResolvedValue(
+        makeAttempt({
+          id: '00000000-0000-0000-0000-000000000203',
+          status: 'failed',
+          session_id: 'agent-wrapper-mismatch-old',
+        })
+      );
+      mockCreateInfraRetryAttemptIfMissing.mockResolvedValue({
+        outcome: 'created',
+        attempt: makeAttempt({
+          id: '00000000-0000-0000-0000-000000000204',
+          attempt_number: 2,
+          retry_reason: 'infra_failure',
+          retry_of_attempt_id: '00000000-0000-0000-0000-000000000203',
+          status: 'pending',
+        }),
+      });
+
+      const response = await POST(
+        makeRequest({
+          status: 'failed',
+          cloudAgentSessionId: 'agent-wrapper-mismatch-old',
+          errorMessage,
+          terminalReason: 'sandbox_error',
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockCreateInfraRetryAttemptIfMissing).toHaveBeenCalledWith(
+        expect.objectContaining({
+          codeReviewId: REVIEW_ID,
+          retryOfAttemptId: '00000000-0000-0000-0000-000000000203',
+        })
+      );
+      expect(mockRetryReviewFresh).toHaveBeenCalledWith(REVIEW_ID, {
+        sessionId: 'agent-wrapper-mismatch-old',
+        reason: errorMessage,
+        failedAttemptId: '00000000-0000-0000-0000-000000000203',
+        retryAttemptId: '00000000-0000-0000-0000-000000000204',
+      });
+      expect(mockUpdateCodeReviewStatus).not.toHaveBeenCalled();
+      expect(mockUpdateCheckRun).not.toHaveBeenCalled();
+      expect(mockTryDispatchPendingReviews).not.toHaveBeenCalled();
+    });
+
     it('does not retry when the parent review is already superseded', async () => {
       mockGetCodeReviewById.mockResolvedValue(
         makeReview({ status: 'cancelled', terminal_reason: 'superseded' })

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -229,6 +229,8 @@ function getActionRequiredTerminalReason(
   return classifyCodeReviewActionRequiredFailure(errorMessage);
 }
 
+const RETRYABLE_WRAPPER_VERSION_MISMATCH_PHRASE = 'Wrapper version mismatch'.toLowerCase();
+
 function isRetryableInfraFailure(
   status: 'running' | 'completed' | 'failed' | 'cancelled',
   terminalReason?: CodeReviewTerminalReason,
@@ -250,6 +252,7 @@ function isRetryableInfraFailure(
   if (message.includes('user interrupted')) return false;
 
   return (
+    message.includes(RETRYABLE_WRAPPER_VERSION_MISMATCH_PHRASE) ||
     message.includes('container shutdown: sigterm') ||
     message.includes('execution timeout - no heartbeat received') ||
     ((message.includes('sandbox') ||

--- a/services/code-review-infra/src/code-review-orchestrator.ts
+++ b/services/code-review-infra/src/code-review-orchestrator.ts
@@ -143,6 +143,7 @@ type CloudAgentNextFreshRetryFailureCategory =
   | 'non_5xx'
   | 'cancelled'
   | 'sandbox_api_or_storage_failure'
+  | 'wrapper_version_mismatch'
   | 'wrapper_wait_for_port_timeout'
   | 'wrapper_kilo_server_start_timeout'
   | 'configured_session_lookup_failure'
@@ -169,12 +170,15 @@ function cloudAgentNextFreshRetryClassification(
     failureCategory,
     retryClassificationReason,
     retryableWrapperReadinessFailure:
+      failureCategory === 'wrapper_version_mismatch' ||
       failureCategory === 'wrapper_wait_for_port_timeout' ||
       failureCategory === 'wrapper_kilo_server_start_timeout',
     cloudAgentNextProcedure: error?.procedure,
     cloudAgentNextStatus: error?.status,
   };
 }
+
+const RETRYABLE_WRAPPER_VERSION_MISMATCH_PHRASE = 'Wrapper version mismatch'.toLowerCase();
 
 function classifyCloudAgentNextFreshSessionRetry(
   error: unknown
@@ -224,6 +228,15 @@ function classifyCloudAgentNextFreshSessionRetry(
       false,
       'repo_clone_or_checkout_failure',
       'repo_clone_or_checkout_not_retryable'
+    );
+  }
+
+  if (body.includes(RETRYABLE_WRAPPER_VERSION_MISMATCH_PHRASE)) {
+    return cloudAgentNextFreshRetryClassification(
+      error,
+      true,
+      'wrapper_version_mismatch',
+      'wrapper_version_mismatch'
     );
   }
 

--- a/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
+++ b/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
@@ -787,6 +787,52 @@ describe('CodeReviewOrchestrator recovery', () => {
     await expect(storedReview(stub)).resolves.toMatchObject({ sandboxRetryAttempted: true });
   });
 
+  it('retries prepareSession once after wrapper version mismatch', async () => {
+    const stub = getReviewStub();
+    let prepareCalls = 0;
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        prepareCalls += 1;
+        if (prepareCalls === 1) {
+          return trpcError(
+            500,
+            'Wrapper version mismatch after startup: expected 2.0.0, got 1.9.9'
+          );
+        }
+        return trpcSuccess({
+          cloudAgentSessionId: 'agent-wrapper-version-retry',
+          kiloSessionId: 'ses_wrapper_version_retry',
+        });
+      }
+      if (url.includes('/trpc/initiateFromKilocodeSessionV2')) {
+        return trpcSuccess({ executionId: 'exec-wrapper-version-retry', status: 'running' });
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({
+      status: 'running',
+      sessionId: 'agent-wrapper-version-retry',
+      cliSessionId: 'ses_wrapper_version_retry',
+    });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(2);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(1);
+    await expect(storedReview(stub)).resolves.toMatchObject({ sandboxRetryAttempted: true });
+  });
+
   it('fails after a second sandbox 500 without initiating', async () => {
     const stub = getReviewStub();
     const fetchMock = vi.fn(async (request: RequestInfo | URL) => {


### PR DESCRIPTION
## Summary
- Code reviews that hit a wrapper version mismatch now use the existing retry path instead of failing right away.
- The retry check still keeps the existing safeguards for user, billing, model, and cancellation failures.
- The worker retry path now reports this as its own wrapper mismatch case so the retry reason is easier to track.

## Verification
1. Trigger a code review failure whose error includes `Wrapper version mismatch`.
2. Confirm the review starts a fresh retry instead of ending as failed.
3. Confirm normal non-retry failures still end without a fresh retry.

## Visual Changes
N/A

## Reviewer Notes
N/A