### PR TITLE
ci(codeql): report high security alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,4 @@
-name: Critical-only CodeQL config
+name: High-and-critical CodeQL config
 
 query-filters:
   - include:
@@ -8,4 +8,4 @@ query-filters:
         - alert
         - path-alert
       tags contain: security
-      security-severity: /^(9(\.[0-9])?|10(\.0)?)$/
+      security-severity: /^(7(\.[0-9])?|8(\.[0-9])?|9(\.[0-9])?|10(\.0)?)$/


### PR DESCRIPTION
## Summary
- Expand CodeQL security filtering to include high-severity findings in addition to critical findings.
- Rename the CodeQL config to reflect the broader high-and-critical threshold.

## Verification
N/A - configuration-only change.

## Visual Changes
N/A

## Reviewer Notes
CodeQL `security-severity` now matches `7.x` through `10.0`, covering GitHub high and critical alert thresholds.