### PR TITLE
ci(setup): restore local setup smoke workflow

### DIFF
--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -1,0 +1,129 @@
+name: Setup Smoke
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  setup-smoke:
+    runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
+    timeout-minutes: 45
+
+    env:
+      NODE_ENV: development
+      DEBUG_SHOW_DEV_UI: 'true'
+      PORT: '3000'
+      NEXTAUTH_URL: http://localhost:3000
+      POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      POSTGRES_CONNECT_TIMEOUT: '30000'
+      POSTGRES_MAX_QUERY_TIME: '30000'
+      SKIP_STRIPE_API: 'true'
+      NEXT_PUBLIC_POSTHOG_KEY: fake-token
+      PLAYWRIGHT_BASE_URL: http://localhost:3000
+
+    steps:
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.1.2 --activate
+
+      - name: Install tmux
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tmux
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate local environment
+        run: pnpm dev:setup-env --ci
+
+      - name: Sync local service environment
+        run: pnpm dev:env -y
+
+      - name: Start local infrastructure
+        run: docker compose -f dev/docker-compose.yml up -d --wait
+
+      - name: Verify migrations bootstrap cleanly
+        run: pnpm drizzle:verify-bootstrap
+
+      - name: Run database migrations
+        run: pnpm drizzle migrate
+
+      - name: Install Playwright browsers
+        run: pnpm --filter web exec playwright install --with-deps chromium
+
+      - name: Start dev stack
+        run: pnpm dev:start --no-attach
+
+      - name: Wait for web app
+        run: |
+          for i in {1..60}; do
+            if curl -fsSL http://localhost:3000/users/sign_in >/dev/null; then
+              exit 0
+            fi
+
+            pnpm dev:status
+            sleep 5
+          done
+
+          echo "Web app did not become ready in time"
+          exit 1
+
+      - name: Run setup smoke tests
+        run: pnpm test:setup-smoke
+
+      - name: Stop dev stack
+        if: always()
+        run: pnpm dev:stop --force
+
+      - name: Upload setup smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: setup-smoke-artifacts
+          path: |
+            apps/web/playwright-report
+            apps/web/test-results
+            dev/logs
+          retention-days: 7
+
+      - name: Notify setup smoke failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: '3791'
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          cat > /tmp/setup-smoke-failure.md <<EOF
+          @RSO Setup Smoke failed.
+
+          Run: ${RUN_URL}
+          Ref: ${GITHUB_REF_NAME}
+          SHA: ${GITHUB_SHA}
+          Trigger: ${GITHUB_EVENT_NAME}
+          EOF
+
+          gh issue comment "$ISSUE_NUMBER" --body-file /tmp/setup-smoke-failure.md

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -1,9 +1,6 @@
 name: Setup Smoke
 
 on:
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: '17 * * * *'
   workflow_dispatch:

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Expose pnpm to tmux shells
         run: |
-          printf '#!/usr/bin/env bash\nexec "%s/pnpm" "$@"\n' "$PNPM_HOME" | sudo tee /usr/local/bin/pnpm >/dev/null
+          printf '#!/usr/bin/env bash\nexport PATH="%s"\nexec "%s/pnpm" "$@"\n' "$PATH" "$PNPM_HOME" | sudo tee /usr/local/bin/pnpm >/dev/null
           sudo chmod +x /usr/local/bin/pnpm
 
       - name: Install tmux

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -53,7 +53,9 @@ jobs:
           corepack prepare pnpm@11.1.2 --activate
 
       - name: Expose pnpm to tmux shells
-        run: sudo ln -sf "$PNPM_HOME/pnpm" /usr/local/bin/pnpm
+        run: |
+          printf '#!/usr/bin/env bash\nexec "%s/pnpm" "$@"\n' "$PNPM_HOME" | sudo tee /usr/local/bin/pnpm >/dev/null
+          sudo chmod +x /usr/local/bin/pnpm
 
       - name: Install tmux
         run: |

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -1,6 +1,9 @@
 name: Setup Smoke
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: '17 * * * *'
   workflow_dispatch:

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -52,6 +52,9 @@ jobs:
           corepack enable
           corepack prepare pnpm@11.1.2 --activate
 
+      - name: Expose pnpm to tmux shells
+        run: sudo ln -sf "$PNPM_HOME/pnpm" /usr/local/bin/pnpm
+
       - name: Install tmux
         run: |
           sudo apt-get update

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "db:empty-database": "tsx --tsconfig tsconfig.scripts.json src/db/empty-database.ts",
     "knip": "knip",
     "test:e2e": "playwright test",
+    "test:setup-smoke": "playwright test --config=playwright.setup-smoke.config.ts",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
     "promo": "pnpm -s script src/scripts/encrypt-promo-codes.ts"

--- a/apps/web/playwright.setup-smoke.config.ts
+++ b/apps/web/playwright.setup-smoke.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${port}`;
+
+export default defineConfig({
+  testDir: './tests/setup-smoke',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'html' : 'list',
+  outputDir: 'test-results/setup-smoke',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+  ],
+});

--- a/apps/web/src/lib/stripe-client.ts
+++ b/apps/web/src/lib/stripe-client.ts
@@ -7,6 +7,8 @@ const stripeSecretKey = getEnvVariable('STRIPE_SECRET_KEY');
 if (!stripeSecretKey) {
   throw new Error('STRIPE_SECRET_KEY environment variable is not set');
 }
+const skipStripeApi =
+  process.env.NODE_ENV !== 'production' && process.env.SKIP_STRIPE_API === 'true';
 
 export const client: Stripe = new Stripe(stripeSecretKey);
 
@@ -26,11 +28,23 @@ type UserConstrainedMetadata = {
 
 type CreateParams = Omit<Stripe.CustomerCreateParams, 'metadata'> & ConstrainedMetadata;
 
-export async function createStripeCustomer(customer: CreateParams) {
+export async function createStripeCustomer(
+  customer: CreateParams
+): Promise<Pick<Stripe.Customer, 'id'>> {
+  if (skipStripeApi) {
+    const metadataId =
+      'kiloUserId' in customer.metadata
+        ? customer.metadata.kiloUserId
+        : customer.metadata.organizationId;
+    return { id: `cus_local_${metadataId}` };
+  }
+
   return client.customers.create(customer);
 }
 
 export async function deleteStripeCustomer(stripeCustomerId: string) {
+  if (skipStripeApi) return;
+
   await client.customers.del(stripeCustomerId);
 }
 
@@ -56,6 +70,8 @@ export async function hasPaymentMethodInStripe({
 }: {
   stripeCustomerId: string;
 }): Promise<boolean> {
+  if (skipStripeApi) return false;
+
   // This function may become redundant if our in-db administration is accurate.
   const paymentMethods = await client.paymentMethods.list({
     customer: stripeCustomerId,

--- a/apps/web/tests/setup-smoke/profile.spec.ts
+++ b/apps/web/tests/setup-smoke/profile.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+import { createDrizzleClient } from '@kilocode/db/client';
+import { kilocode_users } from '@kilocode/db/schema';
+import { hosted_domain_specials } from '@/lib/auth/constants';
+import { randomUUID } from 'node:crypto';
+
+function isSignedInDestination(url: URL): boolean {
+  return url.pathname === '/profile' || url.pathname.startsWith('/organizations/');
+}
+
+test.describe('local setup smoke', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('signs in with fake auth and renders the profile page', async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const testEmail = `setup-smoke-${uniqueId}+stytchpass@example.com`;
+    const signInUrl = `/users/sign_in?fakeUser=${encodeURIComponent(testEmail)}&callbackPath=${encodeURIComponent('/profile')}`;
+    const postgresUrl = process.env.POSTGRES_URL;
+    if (!postgresUrl) throw new Error('POSTGRES_URL must be set for setup smoke tests');
+
+    const { db, pool } = createDrizzleClient({
+      connectionString: postgresUrl,
+      poolConfig: {
+        connectionTimeoutMillis: Number.parseInt(process.env.POSTGRES_CONNECT_TIMEOUT ?? '30000'),
+        max: 1,
+      },
+    });
+
+    try {
+      await db.insert(kilocode_users).values({
+        id: `setup-smoke-${uniqueId}`,
+        google_user_email: testEmail,
+        google_user_name: `setup-smoke-${uniqueId}`,
+        google_user_image_url: '',
+        hosted_domain: hosted_domain_specials.fake_devonly,
+        stripe_customer_id: `cus_setup_smoke_${uniqueId}`,
+        completed_welcome_form: true,
+        has_validation_stytch: true,
+      });
+    } finally {
+      await pool.end();
+    }
+
+    await page.goto(signInUrl);
+    await page.waitForURL(
+      url => url.pathname === '/customer-source-survey' || isSignedInDestination(url),
+      { timeout: 30_000, waitUntil: 'networkidle' }
+    );
+
+    if (new URL(page.url()).pathname === '/customer-source-survey') {
+      await page.getByRole('button', { name: 'Skip' }).click();
+      await page.waitForURL(url => isSignedInDestination(url), {
+        timeout: 15_000,
+        waitUntil: 'networkidle',
+      });
+    }
+
+    const profileResponse = await page.goto('/profile', { waitUntil: 'domcontentloaded' });
+    expect(profileResponse?.ok()).toBe(true);
+    await expect(page).toHaveURL(/\/profile$/);
+    await expect(page.getByRole('link', { name: 'Your Profile' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Edit profile' })).toBeVisible();
+    await expect(page.getByText(testEmail)).toBeVisible();
+  });
+});

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -199,9 +199,17 @@ async function cmdUp(args: string[], repoRoot: string): Promise<void> {
   // Pass critical runtime env into the session so panes see this worktree's
   // values even when an existing tmux server is shared with sibling worktrees.
   const wranglerRegistryPath = getWranglerRegistryPath(repoRoot);
+  const pnpmHome = process.env.PNPM_HOME;
+  const processPath = process.env.PATH ?? '';
+  const sessionPath =
+    pnpmHome !== undefined &&
+    pnpmHome !== '' &&
+    !processPath.split(path.delimiter).includes(pnpmHome)
+      ? `${pnpmHome}${path.delimiter}${processPath}`
+      : processPath;
   const sessionEnv: Record<string, string> = {
     KILO_PORT_OFFSET: String(portOffset),
-    PATH: process.env.PATH ?? '',
+    PATH: sessionPath,
     WRANGLER_REGISTRY_PATH: wranglerRegistryPath,
   };
   for (const key of ['PNPM_HOME', 'COREPACK_HOME', 'npm_execpath']) {

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -261,7 +261,7 @@ async function cmdUp(args: string[], repoRoot: string): Promise<void> {
     }
 
     for (const name of captureServices) {
-      startServiceInTmux(sessionName, name);
+      startServiceInTmux(sessionName, name, sessionEnv);
       startedServices.push(name);
       await sleep(300);
     }
@@ -369,7 +369,7 @@ async function cmdUp(args: string[], repoRoot: string): Promise<void> {
       continue;
     }
 
-    startServiceInTmux(sessionName, name);
+    startServiceInTmux(sessionName, name, sessionEnv);
     startedServices.push(name);
     await sleep(300);
   }

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -78,7 +78,10 @@ const CAPTURE_TIMEOUT_MS = 30_000;
 // Commands
 // ---------------------------------------------------------------------------
 
-async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
+async function cmdUp(args: string[], repoRoot: string): Promise<void> {
+  const noAttach = args.includes('--no-attach');
+  const targets = args.filter(arg => arg !== '--no-attach');
+
   // --- Preflight checks ---
   if (!isTmuxAvailable()) {
     console.error('tmux is not installed. Install it with: brew install tmux');
@@ -126,8 +129,12 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   // --- Check for existing session ---
   const sessionName = getSessionName();
   if (sessionExists(sessionName)) {
-    console.log(`Session ${sessionName} already running — attaching.`);
-    attachSession(sessionName);
+    console.log(
+      noAttach
+        ? `Session ${sessionName} already running.`
+        : `Session ${sessionName} already running — attaching.`
+    );
+    if (!noAttach) attachSession(sessionName);
     return;
   }
 
@@ -194,10 +201,29 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   const wranglerRegistryPath = getWranglerRegistryPath(repoRoot);
   const sessionEnv: Record<string, string> = {
     KILO_PORT_OFFSET: String(portOffset),
+    PATH: process.env.PATH ?? '',
     WRANGLER_REGISTRY_PATH: wranglerRegistryPath,
   };
+  for (const key of ['PNPM_HOME', 'COREPACK_HOME', 'npm_execpath']) {
+    const value = process.env[key];
+    if (value !== undefined && value !== '') {
+      sessionEnv[key] = value;
+    }
+  }
   if (process.env.PORT !== undefined && process.env.PORT !== '') {
     sessionEnv.PORT = String(getService('nextjs').port);
+  }
+  if (process.env.DEBUG_SHOW_DEV_UI !== undefined && process.env.DEBUG_SHOW_DEV_UI !== '') {
+    sessionEnv.DEBUG_SHOW_DEV_UI = process.env.DEBUG_SHOW_DEV_UI;
+  }
+  if (process.env.SKIP_STRIPE_API !== undefined && process.env.SKIP_STRIPE_API !== '') {
+    sessionEnv.SKIP_STRIPE_API = process.env.SKIP_STRIPE_API;
+  }
+  if (
+    process.env.NEXT_PUBLIC_POSTHOG_KEY !== undefined &&
+    process.env.NEXT_PUBLIC_POSTHOG_KEY !== ''
+  ) {
+    sessionEnv.NEXT_PUBLIC_POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
   }
   createSession(sessionName, sessionEnv);
 
@@ -401,7 +427,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   console.log(
     `${GREEN}Started ${startedServices.length} services in session ${sessionName}${RESET}`
   );
-  attachSession(sessionName);
+  if (!noAttach) attachSession(sessionName);
 }
 
 type ServiceStatus = 'up' | 'down';
@@ -583,7 +609,8 @@ async function cmdEnv(args: string[], repoRoot: string): Promise<void> {
 function printUsage(): void {
   console.log(`
 Usage:
-  dev:start [targets...]  Start services (default: core)
+  dev:start [--no-attach] [targets...]
+                          Start services (default: core)
   dev:stop [--force]      Stop all services (skips shared Docker infra if
                           other kilo-dev sessions are running; --force overrides)
   dev:status [--json]     Show running services and their ports

--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -106,11 +106,15 @@ export function buildStartCommand(serviceName: string): string {
 // Tmux service lifecycle
 // ---------------------------------------------------------------------------
 
-export function startServiceInTmux(sessionName: string, serviceName: string): void {
+export function startServiceInTmux(
+  sessionName: string,
+  serviceName: string,
+  env?: Record<string, string>
+): void {
   const svc = getService(serviceName);
   const startupCommand =
     svc.type === 'infra' ? buildInfraLogCommand(serviceName) : buildStartCommand(serviceName);
-  const winIndex = createWindow(sessionName, serviceName, startupCommand);
+  const winIndex = createWindow(sessionName, serviceName, env, startupCommand);
   const logPath = path.join(findRepoRoot(), 'dev', 'logs', `${serviceName}.log`);
   pipePane(sessionName, winIndex, 0, buildLogPipeCommand(logPath));
 }

--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -92,7 +92,7 @@ export function buildStartCommand(serviceName: string): string {
   // would try to descend into <dir>/<dir> which doesn't exist.
   if (svc.dir !== '.' && svc.command[0] === 'pnpm') {
     const [, ...rest] = svc.command;
-    return `pnpm --filter {./${svc.dir}} ${rest.join(' ')}`;
+    return `${getPnpmCommand()} --filter {./${svc.dir}} ${rest.join(' ')}`;
   }
 
   const parts: string[] = [];
@@ -100,6 +100,21 @@ export function buildStartCommand(serviceName: string): string {
   parts.push(svc.command.join(' '));
 
   return parts.join(' && ');
+}
+
+function getPnpmCommand(): string {
+  const pnpmHome = process.env.PNPM_HOME;
+  if (pnpmHome) {
+    const pnpmPath = path.join(pnpmHome, 'pnpm');
+    if (fs.existsSync(pnpmPath)) return shellQuote(pnpmPath);
+  }
+
+  const npmExecPath = process.env.npm_execpath;
+  if (npmExecPath && npmExecPath.includes('pnpm')) {
+    return `node ${shellQuote(npmExecPath)}`;
+  }
+
+  return 'pnpm';
 }
 
 // ---------------------------------------------------------------------------

--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -92,7 +92,7 @@ export function buildStartCommand(serviceName: string): string {
   // would try to descend into <dir>/<dir> which doesn't exist.
   if (svc.dir !== '.' && svc.command[0] === 'pnpm') {
     const [, ...rest] = svc.command;
-    return `${getPnpmCommand()} --filter {./${svc.dir}} ${rest.join(' ')}`;
+    return `pnpm --filter {./${svc.dir}} ${rest.join(' ')}`;
   }
 
   const parts: string[] = [];
@@ -100,21 +100,6 @@ export function buildStartCommand(serviceName: string): string {
   parts.push(svc.command.join(' '));
 
   return parts.join(' && ');
-}
-
-function getPnpmCommand(): string {
-  const pnpmHome = process.env.PNPM_HOME;
-  if (pnpmHome) {
-    const pnpmPath = path.join(pnpmHome, 'pnpm');
-    if (fs.existsSync(pnpmPath)) return shellQuote(pnpmPath);
-  }
-
-  const npmExecPath = process.env.npm_execpath;
-  if (npmExecPath && npmExecPath.includes('pnpm')) {
-    return `node ${shellQuote(npmExecPath)}`;
-  }
-
-  return 'pnpm';
 }
 
 // ---------------------------------------------------------------------------

--- a/dev/local/setup-env.ts
+++ b/dev/local/setup-env.ts
@@ -40,6 +40,14 @@ const SECRET_KEYS = new Set<string>([
   'BYOK_ENCRYPTION_KEY',
 ]);
 
+const CI_PLACEHOLDER_VALUES: Record<string, string> = {
+  NEXTAUTH_URL: process.env.NEXTAUTH_URL || 'http://localhost:3000',
+  POSTGRES_URL:
+    process.env.POSTGRES_URL || 'postgresql://postgres:postgres@localhost:5432/postgres',
+  STRIPE_SECRET_KEY: 'sk_test_setup_smoke_placeholder',
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk_test_setup_smoke_placeholder',
+};
+
 // ---------------------------------------------------------------------------
 // Repo root detection (reuses `findRepoRoot` convention from dev/local/cli.ts)
 // ---------------------------------------------------------------------------
@@ -155,6 +163,15 @@ function buildDescription(key: string): string | undefined {
   return KEY_DESCRIPTIONS[key];
 }
 
+function isCiMode(): boolean {
+  return process.argv.includes('--ci');
+}
+
+function collectCiValue(key: string, defaultValue: string, isSecret: boolean): string {
+  if (isSecret) return generateSecret();
+  return CI_PLACEHOLDER_VALUES[key] ?? defaultValue;
+}
+
 // ---------------------------------------------------------------------------
 // User interaction
 // ---------------------------------------------------------------------------
@@ -198,6 +215,7 @@ async function promptForValue(
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
+  const ciMode = isCiMode();
   const repoRoot = findRepoRoot();
   const examplePath = path.join(repoRoot, '.env.local.example');
   const envLocalPath = path.join(repoRoot, '.env.local');
@@ -220,6 +238,13 @@ async function main(): Promise<void> {
     if (existingContent.length > 0) {
       envLocalExists = true;
     }
+  }
+
+  if (envLocalExists && ciMode) {
+    console.error(
+      `${RED}.env.local already exists; refusing to overwrite it in --ci mode.${RESET}`
+    );
+    process.exit(1);
   }
 
   if (envLocalExists) {
@@ -250,7 +275,9 @@ async function main(): Promise<void> {
     const description = buildDescription(key);
     const isSecret = SECRET_KEYS.has(key);
 
-    const answer = await promptForValue(key, defaultValue, description, isSecret);
+    const answer = ciMode
+      ? collectCiValue(key, defaultValue, isSecret)
+      : await promptForValue(key, defaultValue, description, isSecret);
 
     if (answer === '') {
       if (isSecret) {

--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -61,8 +61,9 @@ function createSession(sessionName: string, env?: Record<string, string>): void 
   const repoRoot = getWorktreeRoot();
   // When another tmux server is already running (e.g. from a sibling worktree),
   // `tmux new-session` attaches to that existing server and inherits its
-  // environment — NOT our current process.env. Pass critical vars with -e so
-  // panes see this worktree's values (e.g. KILO_PORT_OFFSET).
+  // environment — NOT our current process.env. Pass critical vars with -e and
+  // set them on the session so later windows see values like KILO_PORT_OFFSET
+  // and CI-provided PATH updates.
   const envArgs = env
     ? Object.entries(env)
         .map(([k, v]) => `-e ${escapeForShell(`${k}=${v}`)}`)
@@ -72,6 +73,12 @@ function createSession(sessionName: string, env?: Record<string, string>): void 
   execSync(`tmux new-session -d ${envPrefix}-s ${sessionName} -n dashboard -c ${repoRoot}`, {
     stdio: 'ignore',
   });
+  for (const [key, value] of Object.entries(env ?? {})) {
+    execSync(
+      `tmux set-environment -t ${sessionName} ${escapeForShell(key)} ${escapeForShell(value)}`,
+      { stdio: 'ignore' }
+    );
+  }
   // Destroy the session when no clients are attached (e.g. terminal window closed).
   // The session starts detached (-d) so we must defer the option via a hook;
   // setting it immediately would destroy the session before any client attaches.
@@ -401,7 +408,11 @@ function enablePaneBorders(sessionName: string, windowTarget: string | number): 
     stdio: 'ignore',
   });
   // Prevent shells from overwriting pane titles via OSC escape sequences
-  execSync(`tmux set-window-option -t ${target} allow-set-title off`, { stdio: 'ignore' });
+  try {
+    execSync(`tmux set-window-option -t ${target} allow-set-title off`, { stdio: 'ignore' });
+  } catch {
+    // Older tmux versions do not support this cosmetic option.
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -124,10 +124,16 @@ function attachSession(sessionName: string): void {
 // Window management
 // ---------------------------------------------------------------------------
 
-function createWindow(sessionName: string, windowName: string, startupCommand?: string): number {
+function createWindow(
+  sessionName: string,
+  windowName: string,
+  env?: Record<string, string>,
+  startupCommand?: string
+): number {
   const args = [
     'new-window',
     '-d',
+    ...Object.entries(env ?? {}).flatMap(([key, value]) => ['-e', `${key}=${value}`]),
     '-t',
     sessionName,
     '-n',

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "scripts/typecheck-all.sh",
     "build": "pnpm --filter web build",
     "test": "pnpm --filter web test",
+    "test:setup-smoke": "pnpm --filter web run test:setup-smoke",
     "lint": "scripts/lint-all.sh",
     "format": "oxfmt .",
     "format:check": "oxfmt --list-different .",


### PR DESCRIPTION
## Summary
- Restores the local setup smoke workflow from #3772 after the revert in #3804.
- Adds the setup-smoke Playwright entrypoint and CI env generation path for non-interactive local setup verification.
- Fixes the `pnpm dev:start` regression by moving inherited pnpm/PATH environment into the tmux session instead of prepending long env declarations to pane commands.

## Verification
- Started the dev stack with `KILO_PORT_OFFSET=auto pnpm dev:start --no-attach`; confirmed Stripe webhook secret capture completed and Next.js served on the offset port.
- Checked `KILO_PORT_OFFSET=auto pnpm dev:status --json` and confirmed core services reported up.

## Visual Changes
N/A

## Reviewer Notes
- The main risk area is tmux environment propagation across machines with different tmux/Corepack/pnpm setups.
- This replaces the reverted #3772 change set rather than attempting to update the already-merged original PR.