### PR TITLE
Fix Kimi Code error reasoning_effort does not support none

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/kimi-coding.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/kimi-coding.ts
@@ -17,6 +17,12 @@ export default {
     context.request.body.thinking = {
       type: reasoningDisabled ? 'disabled' : 'enabled',
     };
+    if (
+      context.request.kind === 'chat_completions' &&
+      context.request.body.reasoning_effort === 'none'
+    ) {
+      delete context.request.body.reasoning_effort;
+    }
     context.extraHeaders['user-agent'] = COMPATIBLE_USER_AGENT;
   },
   models: () =>


### PR DESCRIPTION
```
{"error":{"message":"Unsupported value: 'reasoning_effort' does not support 'none' with this model. Supported values are: 'minimal', 'low', 'medium', and 'high'.","type":"invalid_request_error"}}
```