### PR TITLE
fix(kilo-pass): reconcile subscription webhooks with Stripe

### DIFF
--- a/.specs/kilo-pass.md
+++ b/.specs/kilo-pass.md
@@ -335,9 +335,10 @@ Rules 51-55 protect against rapid cross-account reuse of a recently first-used c
     append a failed audit entry and rethrow.
 74. Store-expiry reconciliation MUST append success audit after persisted cancellation. App Store expiry notifications
     also append success audit after persisting ended state.
-75. Duplicate-card cancellation or refund failures MUST remain operational error reports only. A successful
-    duplicate-card audit MUST remain authoritative blocked-replay evidence even when provider enforcement fails. It MUST
-    identify the matched first fingerprint claim and fingerprint digest without recording the raw fingerprint.
+75. Duplicate-card blocking MUST commit before provider enforcement and remain authoritative replay evidence. The block
+    audit MUST identify the matched first fingerprint claim and fingerprint digest without recording the raw fingerprint.
+    Cancellation and refund outcomes MUST be recorded separately in audit payloads. Cancellation failure MUST throw for
+    webhook retry; refund failure MUST remain observable without reversing the block or granting credits.
 76. Repeated base or bonus issuance handled by normal issuance helpers MUST append skipped-idempotent audit entries.
     Store-transaction replay and usage-triggered prechecks that find an existing bonus-like item return without an
     equivalent skipped-idempotent audit entry.
@@ -357,8 +358,8 @@ Rules 51-55 protect against rapid cross-account reuse of a recently first-used c
 4. Threshold-trigger handling MUST clear threshold and return without issuing when selected subscription is absent or
    non-active, current issuance is absent, base item is absent, or bonus-like item already exists.
 5. Duplicate-card provider cancellation and refund failures, and a missing refundable settlement identifier, MUST NOT
-   abort the database-side block and MUST NOT permit credits. Such failures MUST be reported operationally and do not
-   create persisted reconciliation records.
+   reverse the database-side block or permit credits. Cancellation failure MUST abort webhook acknowledgement so Stripe
+   retries. Cancellation and refund outcomes MUST be persisted in existing audit records; refund failure remains nonfatal.
 6. Missing or unsupported duplicate-card evidence and missing first-claimant attribution MUST fail open as described in
    Rules 52-54. Provider lookup failures, multiple paid settlements, and missing first-claimant attribution MUST be
    reported operationally but MUST NOT abort normal invoice processing. Matching blocked-audit or committed-issuance
@@ -376,7 +377,8 @@ The following behavior or stronger guarantees are not implemented by current cod
 2. Effective-subscription reselection after late-derived pause or store expiration.
 3. Exposed verified Google Play purchase completion and provider notification handling.
 4. Mobile-store yearly products and store-yearly monthly issuance lifecycle.
-5. Persisted reconciliation state for duplicate-card cancellation or refund partial failures.
+5. Dedicated durable workflow state for duplicate-card cancellation or refund partial failures beyond existing audits and
+   Stripe idempotency keys.
 6. One canonical projection path that matches issuance eligibility, existing bonus-like item checks, scheduled-change
    target behavior, and stored Stripe promo reason across every consumer.
 7. Unbounded or explicitly durable streak accounting beyond the 36-month scan cap.

--- a/apps/web/src/lib/kilo-pass/card-fingerprint-gate.test.ts
+++ b/apps/web/src/lib/kilo-pass/card-fingerprint-gate.test.ts
@@ -584,20 +584,41 @@ describe('duplicate-card provider enforcement and email', () => {
     );
   });
 
-  test('provider failures and missing refund target do not throw', async () => {
+  test('cancellation failure throws before refund so webhook delivery can retry', async () => {
     const providerError = new Error('provider unavailable');
+    const createRefund = jest.fn();
     await expect(
       attemptDuplicateCardProviderEnforcement({
         stripe: {
           subscriptions: { cancel: jest.fn(async () => Promise.reject(providerError)) },
-          refunds: { create: jest.fn(async () => Promise.reject(providerError)) },
+          refunds: { create: createRefund },
         } as unknown as Stripe,
         stripeInvoiceId: 'in_provider_failure',
         stripeSubscriptionId: 'sub_provider_failure',
         kiloUserId: 'user_provider_failure',
         gateResult: { ...gateResult, refundableTarget: null },
       })
-    ).resolves.toBeUndefined();
+    ).rejects.toThrow('provider unavailable');
+    expect(createRefund).not.toHaveBeenCalled();
+  });
+
+  test('refund failure is returned separately after successful cancellation', async () => {
+    const providerError = new Error('refund unavailable');
+    const result = await attemptDuplicateCardProviderEnforcement({
+      stripe: {
+        subscriptions: { cancel: jest.fn(async () => ({ id: 'sub_refund_failure' })) },
+        refunds: { create: jest.fn(async () => Promise.reject(providerError)) },
+      } as unknown as Stripe,
+      stripeInvoiceId: 'in_refund_failure',
+      stripeSubscriptionId: 'sub_refund_failure',
+      kiloUserId: 'user_refund_failure',
+      gateResult,
+    });
+
+    expect(result).toEqual({
+      cancellation: { subscriptionId: 'sub_refund_failure' },
+      refund: { status: 'failed', error: providerError },
+    });
   });
 
   test('clears email marker when provider is unavailable so replay can retry', async () => {

--- a/apps/web/src/lib/kilo-pass/card-fingerprint-gate.test.ts
+++ b/apps/web/src/lib/kilo-pass/card-fingerprint-gate.test.ts
@@ -602,6 +602,36 @@ describe('duplicate-card provider enforcement and email', () => {
     expect(createRefund).not.toHaveBeenCalled();
   });
 
+  test('already canceled subscription still proceeds to refund on replay', async () => {
+    const createRefund = jest.fn(async (...args: unknown[]) => {
+      void args;
+      return { id: 're_replay' };
+    });
+    const result = await attemptDuplicateCardProviderEnforcement({
+      stripe: {
+        subscriptions: {
+          cancel: jest.fn(async () =>
+            Promise.reject(new Error('Subscription sub_replay is already canceled'))
+          ),
+        },
+        refunds: { create: createRefund },
+      } as unknown as Stripe,
+      stripeInvoiceId: 'in_replay',
+      stripeSubscriptionId: 'sub_replay',
+      kiloUserId: 'user_replay',
+      gateResult,
+    });
+
+    expect(result).toEqual({
+      cancellation: { subscriptionId: 'sub_replay' },
+      refund: { status: 'succeeded', refundId: 're_replay' },
+    });
+    expect(createRefund).toHaveBeenCalledWith(
+      expect.objectContaining({ charge: 'ch_exact', reason: 'duplicate' }),
+      { idempotencyKey: 'kilo-pass-duplicate-card-refund:in_replay' }
+    );
+  });
+
   test('refund failure is returned separately after successful cancellation', async () => {
     const providerError = new Error('refund unavailable');
     const result = await attemptDuplicateCardProviderEnforcement({

--- a/apps/web/src/lib/kilo-pass/card-fingerprint-gate.test.ts
+++ b/apps/web/src/lib/kilo-pass/card-fingerprint-gate.test.ts
@@ -613,6 +613,7 @@ describe('duplicate-card provider enforcement and email', () => {
           cancel: jest.fn(async () =>
             Promise.reject(new Error('Subscription sub_replay is already canceled'))
           ),
+          retrieve: jest.fn(async () => ({ id: 'sub_replay', status: 'canceled' })),
         },
         refunds: { create: createRefund },
       } as unknown as Stripe,
@@ -630,6 +631,28 @@ describe('duplicate-card provider enforcement and email', () => {
       expect.objectContaining({ charge: 'ch_exact', reason: 'duplicate' }),
       { idempotencyKey: 'kilo-pass-duplicate-card-refund:in_replay' }
     );
+  });
+
+  test('already canceled message still throws when Stripe status is active', async () => {
+    const createRefund = jest.fn();
+    await expect(
+      attemptDuplicateCardProviderEnforcement({
+        stripe: {
+          subscriptions: {
+            cancel: jest.fn(async () =>
+              Promise.reject(new Error('Subscription sub_active is already canceled'))
+            ),
+            retrieve: jest.fn(async () => ({ id: 'sub_active', status: 'active' })),
+          },
+          refunds: { create: createRefund },
+        } as unknown as Stripe,
+        stripeInvoiceId: 'in_active',
+        stripeSubscriptionId: 'sub_active',
+        kiloUserId: 'user_active',
+        gateResult,
+      })
+    ).rejects.toThrow('already canceled');
+    expect(createRefund).not.toHaveBeenCalled();
   });
 
   test('refund failure is returned separately after successful cancellation', async () => {

--- a/apps/web/src/lib/kilo-pass/card-fingerprint-gate.ts
+++ b/apps/web/src/lib/kilo-pass/card-fingerprint-gate.ts
@@ -443,15 +443,9 @@ export async function attemptDuplicateCardProviderEnforcement(params: {
       );
     } catch (error) {
       if (mayIndicateAlreadyCanceledStripeSubscriptionError(error)) {
+        let subscription: Stripe.Subscription;
         try {
-          const subscription = await params.stripe.subscriptions.retrieve(
-            params.stripeSubscriptionId
-          );
-          if (isStripeSubscriptionEnded(subscription.status)) {
-            canceledSubscription = { id: subscription.id };
-          } else {
-            throw error;
-          }
+          subscription = await params.stripe.subscriptions.retrieve(params.stripeSubscriptionId);
         } catch (confirmationError) {
           captureException(confirmationError, {
             tags: {
@@ -460,6 +454,11 @@ export async function attemptDuplicateCardProviderEnforcement(params: {
             },
             extra: operationalContext,
           });
+          throw error;
+        }
+        if (isStripeSubscriptionEnded(subscription.status)) {
+          canceledSubscription = { id: subscription.id };
+        } else {
           throw error;
         }
       } else {

--- a/apps/web/src/lib/kilo-pass/card-fingerprint-gate.ts
+++ b/apps/web/src/lib/kilo-pass/card-fingerprint-gate.ts
@@ -30,6 +30,16 @@ import { createHash } from 'node:crypto';
 
 const KILO_PASS_DUPLICATE_CARD_EMAIL_TYPE = 'kilo_pass_duplicate_card_canceled';
 
+function isAlreadyCanceledStripeSubscriptionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalizedMessage = message.toLowerCase();
+  return (
+    (normalizedMessage.includes('already') && normalizedMessage.includes('cancel')) ||
+    normalizedMessage.includes('has been canceled') ||
+    normalizedMessage.includes('is canceled')
+  );
+}
+
 export type PaymentFingerprintClaimResult = {
   welcomePromoReason: KiloPassWelcomePromoEligibilityReason;
   cardClaim: {
@@ -418,7 +428,7 @@ export async function attemptDuplicateCardProviderEnforcement(params: {
     matchedKiloUserId: params.gateResult.matchedKiloUserId,
   };
 
-  let canceledSubscription: Stripe.Subscription;
+  let canceledSubscription: { id: string };
   try {
     canceledSubscription = await params.stripe.subscriptions.cancel(
       params.stripeSubscriptionId,
@@ -426,11 +436,15 @@ export async function attemptDuplicateCardProviderEnforcement(params: {
       { idempotencyKey: `kilo-pass-duplicate-card-cancel:${params.stripeInvoiceId}` }
     );
   } catch (error) {
-    captureException(error, {
-      tags: { source: 'kilo_pass_duplicate_card_gate', stage: 'subscription_cancel' },
-      extra: operationalContext,
-    });
-    throw error;
+    if (isAlreadyCanceledStripeSubscriptionError(error)) {
+      canceledSubscription = { id: params.stripeSubscriptionId };
+    } else {
+      captureException(error, {
+        tags: { source: 'kilo_pass_duplicate_card_gate', stage: 'subscription_cancel' },
+        extra: operationalContext,
+      });
+      throw error;
+    }
   }
 
   const refundableTarget = params.gateResult.refundableTarget;

--- a/apps/web/src/lib/kilo-pass/card-fingerprint-gate.ts
+++ b/apps/web/src/lib/kilo-pass/card-fingerprint-gate.ts
@@ -227,7 +227,16 @@ export async function loadDuplicateCardReplayAuthority(params: {
     .where(
       and(
         eq(kilo_pass_audit_log.action, KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled),
-        eq(kilo_pass_audit_log.result, KiloPassAuditLogResult.Success),
+        or(
+          and(
+            eq(kilo_pass_audit_log.result, KiloPassAuditLogResult.SkippedIdempotent),
+            sql`${kilo_pass_audit_log.payload_json}->>'outcome' = 'duplicate_card_blocked'`
+          ),
+          and(
+            eq(kilo_pass_audit_log.result, KiloPassAuditLogResult.Success),
+            sql`${kilo_pass_audit_log.payload_json}->>'outcome' IS NULL`
+          )
+        ),
         or(
           eq(kilo_pass_audit_log.stripe_invoice_id, params.stripeInvoiceId),
           eq(kilo_pass_audit_log.stripe_subscription_id, params.stripeSubscriptionId)
@@ -265,7 +274,7 @@ export async function loadDuplicateCardReplayAuthority(params: {
   }
 
   const blockAudit = blockAudits[0];
-  const blockedAuthority: DuplicateCardReplayAuthority | null = blockAudit
+  const existingBlockedAuthority: DuplicateCardReplayAuthority | null = blockAudit
     ? {
         kind: 'blocked',
         gateResult: {
@@ -287,7 +296,7 @@ export async function loadDuplicateCardReplayAuthority(params: {
     : null;
   const issuanceRecord = issuanceRecords[0];
   if (issuanceRecord) {
-    return blockedAuthority ?? { kind: 'allowed', issuanceId: issuanceRecord.issuanceId };
+    return existingBlockedAuthority ?? { kind: 'allowed', issuanceId: issuanceRecord.issuanceId };
   }
 
   const conflictingSubscriptionIssuance = (
@@ -319,7 +328,7 @@ export async function loadDuplicateCardReplayAuthority(params: {
     });
   }
 
-  return blockedAuthority ?? { kind: 'none' };
+  return existingBlockedAuthority ?? { kind: 'none' };
 }
 
 export async function checkDuplicateCardFingerprintGate(params: {
@@ -383,13 +392,21 @@ export async function checkDuplicateCardFingerprintGate(params: {
   };
 }
 
+export type DuplicateCardProviderEnforcementResult = {
+  cancellation: { subscriptionId: string };
+  refund:
+    | { status: 'succeeded'; refundId: string }
+    | { status: 'failed'; error: unknown }
+    | { status: 'skipped'; reason: 'missing_refund_target' };
+};
+
 export async function attemptDuplicateCardProviderEnforcement(params: {
   stripe: Stripe;
   stripeInvoiceId: string;
   stripeSubscriptionId: string;
   kiloUserId: string;
   gateResult: Extract<DuplicateCardGateResult, { blocked: true }>;
-}): Promise<void> {
+}): Promise<DuplicateCardProviderEnforcementResult> {
   const operationalContext = {
     stripeInvoiceId: params.stripeInvoiceId,
     stripeSubscriptionId: params.stripeSubscriptionId,
@@ -401,8 +418,9 @@ export async function attemptDuplicateCardProviderEnforcement(params: {
     matchedKiloUserId: params.gateResult.matchedKiloUserId,
   };
 
+  let canceledSubscription: Stripe.Subscription;
   try {
-    await params.stripe.subscriptions.cancel(
+    canceledSubscription = await params.stripe.subscriptions.cancel(
       params.stripeSubscriptionId,
       { invoice_now: false, prorate: false },
       { idempotencyKey: `kilo-pass-duplicate-card-cancel:${params.stripeInvoiceId}` }
@@ -412,6 +430,7 @@ export async function attemptDuplicateCardProviderEnforcement(params: {
       tags: { source: 'kilo_pass_duplicate_card_gate', stage: 'subscription_cancel' },
       extra: operationalContext,
     });
+    throw error;
   }
 
   const refundableTarget = params.gateResult.refundableTarget;
@@ -423,11 +442,14 @@ export async function attemptDuplicateCardProviderEnforcement(params: {
         extra: operationalContext,
       }
     );
-    return;
+    return {
+      cancellation: { subscriptionId: canceledSubscription.id },
+      refund: { status: 'skipped', reason: 'missing_refund_target' },
+    };
   }
 
   try {
-    await params.stripe.refunds.create(
+    const refund = await params.stripe.refunds.create(
       {
         ...(refundableTarget.kind === 'payment_intent'
           ? { payment_intent: refundableTarget.id }
@@ -441,6 +463,10 @@ export async function attemptDuplicateCardProviderEnforcement(params: {
       },
       { idempotencyKey: `kilo-pass-duplicate-card-refund:${params.stripeInvoiceId}` }
     );
+    return {
+      cancellation: { subscriptionId: canceledSubscription.id },
+      refund: { status: 'succeeded', refundId: refund.id },
+    };
   } catch (error) {
     captureException(error, {
       tags: { source: 'kilo_pass_duplicate_card_gate', stage: 'refund' },
@@ -450,6 +476,10 @@ export async function attemptDuplicateCardProviderEnforcement(params: {
         refundableTargetId: refundableTarget.id,
       },
     });
+    return {
+      cancellation: { subscriptionId: canceledSubscription.id },
+      refund: { status: 'failed', error },
+    };
   }
 }
 

--- a/apps/web/src/lib/kilo-pass/card-fingerprint-gate.ts
+++ b/apps/web/src/lib/kilo-pass/card-fingerprint-gate.ts
@@ -27,10 +27,11 @@ import type Stripe from 'stripe';
 import { captureException } from '@sentry/nextjs';
 import { sendKiloPassDuplicateCardCanceledEmail } from '@/lib/email';
 import { createHash } from 'node:crypto';
+import { isStripeSubscriptionEnded } from '@/lib/kilo-pass/stripe-subscription-status';
 
 const KILO_PASS_DUPLICATE_CARD_EMAIL_TYPE = 'kilo_pass_duplicate_card_canceled';
 
-function isAlreadyCanceledStripeSubscriptionError(error: unknown): boolean {
+function mayIndicateAlreadyCanceledStripeSubscriptionError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   const normalizedMessage = message.toLowerCase();
   return (
@@ -407,7 +408,7 @@ export type DuplicateCardProviderEnforcementResult = {
   refund:
     | { status: 'succeeded'; refundId: string }
     | { status: 'failed'; error: unknown }
-    | { status: 'skipped'; reason: 'missing_refund_target' };
+    | { status: 'skipped'; reason: 'missing_refund_target' | 'already_recorded' };
 };
 
 export async function attemptDuplicateCardProviderEnforcement(params: {
@@ -416,6 +417,8 @@ export async function attemptDuplicateCardProviderEnforcement(params: {
   stripeSubscriptionId: string;
   kiloUserId: string;
   gateResult: Extract<DuplicateCardGateResult, { blocked: true }>;
+  skipSubscriptionCancellation?: boolean;
+  skipRefund?: boolean;
 }): Promise<DuplicateCardProviderEnforcementResult> {
   const operationalContext = {
     stripeInvoiceId: params.stripeInvoiceId,
@@ -429,22 +432,51 @@ export async function attemptDuplicateCardProviderEnforcement(params: {
   };
 
   let canceledSubscription: { id: string };
-  try {
-    canceledSubscription = await params.stripe.subscriptions.cancel(
-      params.stripeSubscriptionId,
-      { invoice_now: false, prorate: false },
-      { idempotencyKey: `kilo-pass-duplicate-card-cancel:${params.stripeInvoiceId}` }
-    );
-  } catch (error) {
-    if (isAlreadyCanceledStripeSubscriptionError(error)) {
-      canceledSubscription = { id: params.stripeSubscriptionId };
-    } else {
-      captureException(error, {
-        tags: { source: 'kilo_pass_duplicate_card_gate', stage: 'subscription_cancel' },
-        extra: operationalContext,
-      });
-      throw error;
+  if (params.skipSubscriptionCancellation) {
+    canceledSubscription = { id: params.stripeSubscriptionId };
+  } else {
+    try {
+      canceledSubscription = await params.stripe.subscriptions.cancel(
+        params.stripeSubscriptionId,
+        { invoice_now: false, prorate: false },
+        { idempotencyKey: `kilo-pass-duplicate-card-cancel:${params.stripeInvoiceId}` }
+      );
+    } catch (error) {
+      if (mayIndicateAlreadyCanceledStripeSubscriptionError(error)) {
+        try {
+          const subscription = await params.stripe.subscriptions.retrieve(
+            params.stripeSubscriptionId
+          );
+          if (isStripeSubscriptionEnded(subscription.status)) {
+            canceledSubscription = { id: subscription.id };
+          } else {
+            throw error;
+          }
+        } catch (confirmationError) {
+          captureException(confirmationError, {
+            tags: {
+              source: 'kilo_pass_duplicate_card_gate',
+              stage: 'subscription_cancel_confirmation',
+            },
+            extra: operationalContext,
+          });
+          throw error;
+        }
+      } else {
+        captureException(error, {
+          tags: { source: 'kilo_pass_duplicate_card_gate', stage: 'subscription_cancel' },
+          extra: operationalContext,
+        });
+        throw error;
+      }
     }
+  }
+
+  if (params.skipRefund) {
+    return {
+      cancellation: { subscriptionId: canceledSubscription.id },
+      refund: { status: 'skipped', reason: 'already_recorded' },
+    };
   }
 
   const refundableTarget = params.gateResult.refundableTarget;

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.test.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.test.ts
@@ -15,6 +15,7 @@ import {
   user_affiliate_events,
 } from '@kilocode/db/schema';
 import { KiloPassAuditLogAction } from './enums';
+import { KiloPassAuditLogResult } from './enums';
 import { KiloPassIssuanceItemKind } from './enums';
 import { KiloPassIssuanceSource } from './enums';
 import { KiloPassCadence } from './enums';
@@ -587,6 +588,107 @@ describe('handleKiloPassInvoicePaid', () => {
       expect(JSON.stringify(audit?.payload_json)).not.toContain(fingerprint);
     }
   );
+
+  test('duplicate-card replay retries refund when cancellation audit exists without refund audit', async () => {
+    const { handleKiloPassInvoicePaid } =
+      await import('@/lib/kilo-pass/stripe-handlers-invoice-paid');
+    const user = await insertTestUser({ total_microdollars_acquired: 0, microdollars_used: 0 });
+    const stripeSubscriptionId = `sub_refund_retry_${Math.random()}`;
+    const stripeInvoiceId = `in_refund_retry_${Math.random()}`;
+    const metadata = kiloPassMetadata({
+      kiloUserId: user.id,
+      tier: KiloPassTier.Tier19,
+      cadence: KiloPassCadence.Monthly,
+    });
+    await db.insert(kilo_pass_audit_log).values([
+      {
+        action: KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled,
+        result: KiloPassAuditLogResult.SkippedIdempotent,
+        kilo_user_id: user.id,
+        stripe_event_id: 'evt_existing_block',
+        stripe_invoice_id: stripeInvoiceId,
+        stripe_subscription_id: stripeSubscriptionId,
+        payload_json: {
+          outcome: 'duplicate_card_blocked',
+          fingerprintDigest: 'd'.repeat(64),
+          firstClaimSourceStripeInvoiceId: 'in_existing_winner',
+          firstClaimedAt: '2026-06-05T12:00:00.000Z',
+          matchedKiloUserId: 'first_claimant',
+          matchedStripeSubscriptionId: 'sub_existing_winner',
+        },
+      },
+      {
+        action: KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled,
+        result: KiloPassAuditLogResult.Success,
+        kilo_user_id: user.id,
+        stripe_event_id: 'evt_existing_cancel',
+        stripe_invoice_id: stripeInvoiceId,
+        stripe_subscription_id: stripeSubscriptionId,
+        payload_json: {
+          outcome: 'subscription_cancellation',
+          canceledStripeSubscriptionId: stripeSubscriptionId,
+        },
+      },
+    ]);
+    const cancel = jest.fn();
+    const refund = jest.fn(async (...args: unknown[]) => {
+      void args;
+      return { id: 're_refund_retry' };
+    });
+    const priceId = await getKiloPassPriceId({
+      tier: KiloPassTier.Tier19,
+      cadence: KiloPassCadence.Monthly,
+    });
+
+    await handleKiloPassInvoicePaid({
+      eventId: 'evt_refund_retry',
+      invoice: makeStripeInvoice({
+        id: stripeInvoiceId,
+        amount_paid_cents: 1900,
+        created_seconds: 1_780_272_000,
+        paid_seconds: 1_780_272_000,
+        priceId,
+        subscriptionIdOrExpanded: stripeSubscriptionId,
+        metadata,
+        invoicePaymentId: 'inpay_refund_retry',
+        invoicePayment: {
+          type: 'charge',
+          charge: makeFingerprintCharge('ch_refund_retry', 'card', 'fp_refund_retry'),
+        },
+        billingReason: 'subscription_create',
+      }),
+      stripe: {
+        subscriptions: {
+          retrieve: jest.fn(async () =>
+            makeStripeSubscription({
+              id: stripeSubscriptionId,
+              start_date_seconds: 1_780_272_000,
+              metadata,
+            })
+          ),
+          cancel,
+        },
+        refunds: { create: refund },
+      } as unknown as Stripe,
+    });
+
+    expect(cancel).not.toHaveBeenCalled();
+    expect(refund).toHaveBeenCalledWith(
+      expect.objectContaining({ charge: 'ch_refund_retry', reason: 'duplicate' }),
+      expect.objectContaining({
+        idempotencyKey: `kilo-pass-duplicate-card-refund:${stripeInvoiceId}`,
+      })
+    );
+    const auditRows = await db
+      .select({ payload: kilo_pass_audit_log.payload_json })
+      .from(kilo_pass_audit_log)
+      .where(eq(kilo_pass_audit_log.stripe_invoice_id, stripeInvoiceId));
+    expect(
+      auditRows.some(
+        row => row.payload.outcome === 'refund' && row.payload.stripeRefundId === 're_refund_retry'
+      )
+    ).toBe(true);
+  });
 
   test('committed fail-open initial purchase cannot be retroactively reclassified on replay', async () => {
     const { handleKiloPassInvoicePaid } =

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import {
   credit_transactions,
+  kilo_pass_audit_log,
   kilo_pass_issuances,
   kilo_pass_scheduled_changes,
   kilo_pass_subscriptions,
@@ -10,7 +11,7 @@ import {
 
 import type { DrizzleTransaction } from '@/lib/drizzle';
 import { db } from '@/lib/drizzle';
-import { and, asc, eq, isNull } from 'drizzle-orm';
+import { and, asc, eq, isNull, sql } from 'drizzle-orm';
 
 import { KILO_PASS_TIER_CONFIG } from '@/lib/kilo-pass/constants';
 import { KiloPassError } from '@/lib/kilo-pass/errors';
@@ -69,6 +70,108 @@ import {
   type KiloPassAffiliateSaleContext,
 } from '@/lib/kilo-pass/affiliate-sale';
 import { processPersonalKiloPassStripePaidConversion } from '@/lib/impact/kilo-pass-referrals';
+type DuplicateCardEnforcement = {
+  kiloUserId: string;
+  stripeInvoiceId: string;
+  stripeSubscriptionId: string;
+  kiloPassSubscriptionId: string;
+  gateResult: Extract<DuplicateCardGateResult, { blocked: true }>;
+};
+
+function getRefundAuditResult(
+  status: Awaited<ReturnType<typeof attemptDuplicateCardProviderEnforcement>>['refund']['status']
+): KiloPassAuditLogResult {
+  switch (status) {
+    case 'succeeded':
+      return KiloPassAuditLogResult.Success;
+    case 'failed':
+      return KiloPassAuditLogResult.Failed;
+    case 'skipped':
+      return KiloPassAuditLogResult.SkippedIdempotent;
+  }
+}
+
+async function enforceDuplicateCardBlock(params: {
+  enforcement: DuplicateCardEnforcement;
+  eventId: string;
+  stripe: Stripe;
+}): Promise<void> {
+  const { enforcement, eventId, stripe } = params;
+  const existingCancellationSuccess = await db.query.kilo_pass_audit_log.findFirst({
+    columns: { id: true },
+    where: and(
+      eq(kilo_pass_audit_log.action, KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled),
+      eq(kilo_pass_audit_log.result, KiloPassAuditLogResult.Success),
+      eq(kilo_pass_audit_log.stripe_invoice_id, enforcement.stripeInvoiceId),
+      sql`${kilo_pass_audit_log.payload_json}->>'outcome' = 'subscription_cancellation'`
+    ),
+  });
+  if (existingCancellationSuccess) return;
+
+  let enforcementResult: Awaited<ReturnType<typeof attemptDuplicateCardProviderEnforcement>>;
+  try {
+    enforcementResult = await attemptDuplicateCardProviderEnforcement({
+      stripe,
+      stripeInvoiceId: enforcement.stripeInvoiceId,
+      stripeSubscriptionId: enforcement.stripeSubscriptionId,
+      kiloUserId: enforcement.kiloUserId,
+      gateResult: enforcement.gateResult,
+    });
+  } catch (error) {
+    await appendKiloPassAuditLog(db, {
+      action: KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled,
+      result: KiloPassAuditLogResult.Failed,
+      kiloUserId: enforcement.kiloUserId,
+      kiloPassSubscriptionId: enforcement.kiloPassSubscriptionId,
+      stripeEventId: eventId,
+      stripeInvoiceId: enforcement.stripeInvoiceId,
+      stripeSubscriptionId: enforcement.stripeSubscriptionId,
+      payload: {
+        outcome: 'subscription_cancellation',
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    throw error;
+  }
+
+  await appendKiloPassAuditLog(db, {
+    action: KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled,
+    result: KiloPassAuditLogResult.Success,
+    kiloUserId: enforcement.kiloUserId,
+    kiloPassSubscriptionId: enforcement.kiloPassSubscriptionId,
+    stripeEventId: eventId,
+    stripeInvoiceId: enforcement.stripeInvoiceId,
+    stripeSubscriptionId: enforcement.stripeSubscriptionId,
+    payload: {
+      outcome: 'subscription_cancellation',
+      canceledStripeSubscriptionId: enforcementResult.cancellation.subscriptionId,
+    },
+  });
+  await appendKiloPassAuditLog(db, {
+    action: KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled,
+    result: getRefundAuditResult(enforcementResult.refund.status),
+    kiloUserId: enforcement.kiloUserId,
+    kiloPassSubscriptionId: enforcement.kiloPassSubscriptionId,
+    stripeEventId: eventId,
+    stripeInvoiceId: enforcement.stripeInvoiceId,
+    stripeSubscriptionId: enforcement.stripeSubscriptionId,
+    payload: {
+      outcome: 'refund',
+      refundStatus: enforcementResult.refund.status,
+      ...(enforcementResult.refund.status === 'succeeded'
+        ? { stripeRefundId: enforcementResult.refund.refundId }
+        : enforcementResult.refund.status === 'skipped'
+          ? { reason: enforcementResult.refund.reason }
+          : {
+              error:
+                enforcementResult.refund.error instanceof Error
+                  ? enforcementResult.refund.error.message
+                  : String(enforcementResult.refund.error),
+            }),
+    },
+  });
+}
+
 async function getOrCreateInitialMonthlyWelcomePromoReason(params: {
   tx: DrizzleTransaction;
   subscriptionId: string;
@@ -315,10 +418,10 @@ export async function handleKiloPassInvoicePaid(params: {
   let kiloUserIdForAudit: string | null = null;
   let stripeSubscriptionIdForAudit: string | null = null;
 
-  let blockedEmailParams: { kiloUserId: string; stripeInvoiceId: string } | null = null;
+  let duplicateCardEnforcement: DuplicateCardEnforcement | null = null;
 
   try {
-    blockedEmailParams = await db.transaction(async tx => {
+    duplicateCardEnforcement = await db.transaction(async tx => {
       const subscription = await getInvoiceSubscription({ invoice, stripe });
       if (!subscription) {
         throw new KiloPassError('Kilo Pass invoice has no subscription reference', {
@@ -482,13 +585,14 @@ export async function handleKiloPassInvoicePaid(params: {
       if (gateResult.blocked) {
         await appendKiloPassAuditLog(tx, {
           action: KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled,
-          result: KiloPassAuditLogResult.Success,
+          result: KiloPassAuditLogResult.SkippedIdempotent,
           kiloUserId,
           kiloPassSubscriptionId,
           stripeEventId: eventId,
           stripeInvoiceId: invoice.id,
           stripeSubscriptionId: subscription.id,
           payload: {
+            outcome: 'duplicate_card_blocked',
             fingerprintDigest: gateResult.fingerprintDigest,
             firstClaimSourceStripeInvoiceId: gateResult.firstClaimSourceStripeInvoiceId,
             firstClaimedAt: gateResult.firstClaimedAt,
@@ -510,17 +614,15 @@ export async function handleKiloPassInvoicePaid(params: {
           })
           .where(and(eq(kilocode_users.id, kiloUserId), isNull(kilocode_users.blocked_reason)));
 
-        await attemptDuplicateCardProviderEnforcement({
-          stripe,
-          stripeInvoiceId: invoice.id,
-          stripeSubscriptionId: subscription.id,
-          kiloUserId,
-          gateResult,
-        });
-
         affiliateSaleState.context = null;
         kiloUserIdForCache = null;
-        return { kiloUserId, stripeInvoiceId: invoice.id };
+        return {
+          kiloUserId,
+          stripeInvoiceId: invoice.id,
+          stripeSubscriptionId: subscription.id,
+          kiloPassSubscriptionId,
+          gateResult,
+        };
       }
 
       if (metadata.kiloPassScheduledChangeId) {
@@ -683,6 +785,14 @@ export async function handleKiloPassInvoicePaid(params: {
 
       return null;
     });
+
+    if (duplicateCardEnforcement) {
+      await enforceDuplicateCardBlock({
+        enforcement: duplicateCardEnforcement,
+        eventId,
+        stripe,
+      });
+    }
   } catch (error) {
     // Write failure audit log outside the transaction (non-transactional)
     // so it persists even when the transaction rolls back. Omit
@@ -754,10 +864,10 @@ export async function handleKiloPassInvoicePaid(params: {
     });
   }
 
-  if (blockedEmailParams) {
+  if (duplicateCardEnforcement) {
     await maybeSendDuplicateCardCanceledEmail({
-      kiloUserId: blockedEmailParams.kiloUserId,
-      stripeInvoiceId: blockedEmailParams.stripeInvoiceId,
+      kiloUserId: duplicateCardEnforcement.kiloUserId,
+      stripeInvoiceId: duplicateCardEnforcement.stripeInvoiceId,
     });
   }
 

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.ts
@@ -785,14 +785,6 @@ export async function handleKiloPassInvoicePaid(params: {
 
       return null;
     });
-
-    if (duplicateCardEnforcement) {
-      await enforceDuplicateCardBlock({
-        enforcement: duplicateCardEnforcement,
-        eventId,
-        stripe,
-      });
-    }
   } catch (error) {
     // Write failure audit log outside the transaction (non-transactional)
     // so it persists even when the transaction rolls back. Omit
@@ -817,6 +809,14 @@ export async function handleKiloPassInvoicePaid(params: {
     }
 
     throw error;
+  }
+
+  if (duplicateCardEnforcement) {
+    await enforceDuplicateCardBlock({
+      enforcement: duplicateCardEnforcement,
+      eventId,
+      stripe,
+    });
   }
 
   if (

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.ts
@@ -106,7 +106,15 @@ async function enforceDuplicateCardBlock(params: {
       sql`${kilo_pass_audit_log.payload_json}->>'outcome' = 'subscription_cancellation'`
     ),
   });
-  if (existingCancellationSuccess) return;
+  const existingRefundOutcome = await db.query.kilo_pass_audit_log.findFirst({
+    columns: { id: true },
+    where: and(
+      eq(kilo_pass_audit_log.action, KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled),
+      eq(kilo_pass_audit_log.stripe_invoice_id, enforcement.stripeInvoiceId),
+      sql`${kilo_pass_audit_log.payload_json}->>'outcome' = 'refund'`
+    ),
+  });
+  if (existingCancellationSuccess && existingRefundOutcome) return;
 
   let enforcementResult: Awaited<ReturnType<typeof attemptDuplicateCardProviderEnforcement>>;
   try {
@@ -116,11 +124,32 @@ async function enforceDuplicateCardBlock(params: {
       stripeSubscriptionId: enforcement.stripeSubscriptionId,
       kiloUserId: enforcement.kiloUserId,
       gateResult: enforcement.gateResult,
+      skipSubscriptionCancellation: existingCancellationSuccess !== undefined,
+      skipRefund: existingRefundOutcome !== undefined,
     });
   } catch (error) {
+    if (!existingCancellationSuccess) {
+      await appendKiloPassAuditLog(db, {
+        action: KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled,
+        result: KiloPassAuditLogResult.Failed,
+        kiloUserId: enforcement.kiloUserId,
+        kiloPassSubscriptionId: enforcement.kiloPassSubscriptionId,
+        stripeEventId: eventId,
+        stripeInvoiceId: enforcement.stripeInvoiceId,
+        stripeSubscriptionId: enforcement.stripeSubscriptionId,
+        payload: {
+          outcome: 'subscription_cancellation',
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+    throw error;
+  }
+
+  if (!existingCancellationSuccess) {
     await appendKiloPassAuditLog(db, {
       action: KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled,
-      result: KiloPassAuditLogResult.Failed,
+      result: KiloPassAuditLogResult.Success,
       kiloUserId: enforcement.kiloUserId,
       kiloPassSubscriptionId: enforcement.kiloPassSubscriptionId,
       stripeEventId: eventId,
@@ -128,48 +157,35 @@ async function enforceDuplicateCardBlock(params: {
       stripeSubscriptionId: enforcement.stripeSubscriptionId,
       payload: {
         outcome: 'subscription_cancellation',
-        error: error instanceof Error ? error.message : String(error),
+        canceledStripeSubscriptionId: enforcementResult.cancellation.subscriptionId,
       },
     });
-    throw error;
   }
-
-  await appendKiloPassAuditLog(db, {
-    action: KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled,
-    result: KiloPassAuditLogResult.Success,
-    kiloUserId: enforcement.kiloUserId,
-    kiloPassSubscriptionId: enforcement.kiloPassSubscriptionId,
-    stripeEventId: eventId,
-    stripeInvoiceId: enforcement.stripeInvoiceId,
-    stripeSubscriptionId: enforcement.stripeSubscriptionId,
-    payload: {
-      outcome: 'subscription_cancellation',
-      canceledStripeSubscriptionId: enforcementResult.cancellation.subscriptionId,
-    },
-  });
-  await appendKiloPassAuditLog(db, {
-    action: KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled,
-    result: getRefundAuditResult(enforcementResult.refund.status),
-    kiloUserId: enforcement.kiloUserId,
-    kiloPassSubscriptionId: enforcement.kiloPassSubscriptionId,
-    stripeEventId: eventId,
-    stripeInvoiceId: enforcement.stripeInvoiceId,
-    stripeSubscriptionId: enforcement.stripeSubscriptionId,
-    payload: {
-      outcome: 'refund',
-      refundStatus: enforcementResult.refund.status,
-      ...(enforcementResult.refund.status === 'succeeded'
-        ? { stripeRefundId: enforcementResult.refund.refundId }
-        : enforcementResult.refund.status === 'skipped'
-          ? { reason: enforcementResult.refund.reason }
-          : {
-              error:
-                enforcementResult.refund.error instanceof Error
-                  ? enforcementResult.refund.error.message
-                  : String(enforcementResult.refund.error),
-            }),
-    },
-  });
+  if (!existingRefundOutcome) {
+    await appendKiloPassAuditLog(db, {
+      action: KiloPassAuditLogAction.DuplicateCardSubscriptionCanceled,
+      result: getRefundAuditResult(enforcementResult.refund.status),
+      kiloUserId: enforcement.kiloUserId,
+      kiloPassSubscriptionId: enforcement.kiloPassSubscriptionId,
+      stripeEventId: eventId,
+      stripeInvoiceId: enforcement.stripeInvoiceId,
+      stripeSubscriptionId: enforcement.stripeSubscriptionId,
+      payload: {
+        outcome: 'refund',
+        refundStatus: enforcementResult.refund.status,
+        ...(enforcementResult.refund.status === 'succeeded'
+          ? { stripeRefundId: enforcementResult.refund.refundId }
+          : enforcementResult.refund.status === 'skipped'
+            ? { reason: enforcementResult.refund.reason }
+            : {
+                error:
+                  enforcementResult.refund.error instanceof Error
+                    ? enforcementResult.refund.error.message
+                    : String(enforcementResult.refund.error),
+              }),
+      },
+    });
+  }
 }
 
 async function getOrCreateInitialMonthlyWelcomePromoReason(params: {

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.test.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.test.ts
@@ -16,6 +16,9 @@ import type Stripe from 'stripe';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockStripeSubscriptionsRetrieve = jest.fn<any>();
+const mockReportEvents = jest.fn(async (...args: unknown[]) => {
+  void args;
+});
 
 jest.mock('@/lib/stripe-client', () => ({
   client: {
@@ -23,6 +26,10 @@ jest.mock('@/lib/stripe-client', () => ({
       retrieve: (...args: unknown[]) => mockStripeSubscriptionsRetrieve(...args),
     },
   },
+}));
+
+jest.mock('@/lib/ai-gateway/abuse-service', () => ({
+  reportEvents: (...args: unknown[]) => mockReportEvents(...args),
 }));
 
 function ensureKiloPassStripePriceIdEnv(): void {
@@ -84,6 +91,7 @@ beforeEach(async () => {
   await cleanupDbForTest();
   // Default: no pause_collection
   mockStripeSubscriptionsRetrieve.mockResolvedValue({ pause_collection: null });
+  mockReportEvents.mockClear();
 });
 
 afterEach(() => {
@@ -510,6 +518,62 @@ describe('handleKiloPassSubscriptionEvent', () => {
       eventStatus: 'active',
       appliedStatus: 'canceled',
       staleDelivery: true,
+    });
+  });
+
+  test('stale delivery reports reconciled current Stripe metadata', async () => {
+    const { handleKiloPassSubscriptionEvent } =
+      await import('@/lib/kilo-pass/stripe-handlers-subscription-events');
+    const staleUser = await insertTestUser();
+    const currentUser = await insertTestUser();
+    const stripeSubId = `sub_stale_metadata_${Math.random()}`;
+    const staleMetadata = kiloPassMetadata({
+      kiloUserId: staleUser.id,
+      tier: KiloPassTier.Tier19,
+      cadence: KiloPassCadence.Monthly,
+    });
+    const currentMetadata = kiloPassMetadata({
+      kiloUserId: currentUser.id,
+      tier: KiloPassTier.Tier49,
+      cadence: KiloPassCadence.Monthly,
+    });
+    mockStripeSubscriptionsRetrieve.mockResolvedValue(
+      makeStripeSubscription({
+        id: stripeSubId,
+        start_date_seconds: 1_767_225_600,
+        status: 'active',
+        metadata: currentMetadata,
+      })
+    );
+
+    await handleKiloPassSubscriptionEvent({
+      eventId: 'evt_stale_metadata',
+      eventType: 'customer.subscription.updated',
+      subscription: makeStripeSubscription({
+        id: stripeSubId,
+        start_date_seconds: 1_767_225_600,
+        status: 'past_due',
+        metadata: staleMetadata,
+      }),
+    });
+
+    const row = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, stripeSubId),
+    });
+    expect(row?.kilo_user_id).toBe(currentUser.id);
+    expect(row?.tier).toBe(KiloPassTier.Tier49);
+    expect(mockReportEvents).toHaveBeenCalledWith({
+      events: [
+        {
+          type: 'billing.kilo_pass_changed',
+          data: {
+            kilo_user_id: currentUser.id,
+            tier: KiloPassTier.Tier49,
+            status: 'active',
+            streak_months: 0,
+          },
+        },
+      ],
     });
   });
 

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.test.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.test.ts
@@ -584,6 +584,45 @@ describe('handleKiloPassSubscriptionEvent', () => {
     expect(row?.status).toBe('canceled');
   });
 
+  test('Stripe resource_missing preserves existing ended_at when event has no terminal timestamp', async () => {
+    const { handleKiloPassSubscriptionEvent } =
+      await import('@/lib/kilo-pass/stripe-handlers-subscription-events');
+    const user = await insertTestUser();
+    const stripeSubId = `sub_missing_preserve_${Math.random()}`;
+    const endedAt = '2026-01-02T03:04:05.000Z';
+    await db.insert(kilo_pass_subscriptions).values({
+      kilo_user_id: user.id,
+      provider_subscription_id: stripeSubId,
+      stripe_subscription_id: stripeSubId,
+      tier: KiloPassTier.Tier19,
+      cadence: KiloPassCadence.Monthly,
+      status: 'canceled',
+      ended_at: endedAt,
+    });
+    mockStripeSubscriptionsRetrieve.mockRejectedValue({ code: 'resource_missing' });
+
+    await handleKiloPassSubscriptionEvent({
+      eventId: 'evt_resource_missing_preserve',
+      eventType: 'customer.subscription.updated',
+      subscription: makeStripeSubscription({
+        id: stripeSubId,
+        start_date_seconds: 1_767_225_600,
+        status: 'active',
+        metadata: kiloPassMetadata({
+          kiloUserId: user.id,
+          tier: KiloPassTier.Tier19,
+          cadence: KiloPassCadence.Monthly,
+        }),
+      }),
+    });
+
+    const row = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, stripeSubId),
+    });
+    expect(row?.status).toBe('canceled');
+    expect(toIso(row?.ended_at)).toBe(endedAt);
+  });
+
   test('closes pause event when pause_collection is cleared', async () => {
     const { handleKiloPassSubscriptionEvent } =
       await import('@/lib/kilo-pass/stripe-handlers-subscription-events');

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.test.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.test.ts
@@ -164,7 +164,14 @@ describe('handleKiloPassSubscriptionEvent', () => {
     expect(auditRow?.result).toBe(KiloPassAuditLogResult.Success);
     expect(auditRow?.kilo_user_id).toBe(user.id);
     expect(auditRow?.stripe_subscription_id).toBe(stripeSubId);
-    expect(auditRow?.payload_json).toEqual({ type: eventType });
+    expect(auditRow?.payload_json).toMatchObject({
+      type: eventType,
+      reconciliation: 'stripe_current_state',
+      eventStatus: 'active',
+      appliedStatus: 'active',
+      resourceMissing: false,
+      staleDelivery: false,
+    });
   });
 
   test('active subscription with cancel_at_period_end=true stores cancel_at_period_end flag', async () => {
@@ -458,6 +465,123 @@ describe('handleKiloPassSubscriptionEvent', () => {
       .where(eq(kilo_pass_pause_events.kilo_pass_subscription_id, subRow!.id));
     expect(pauseEvents).toHaveLength(1);
     expect(pauseEvents[0]!.resumed_at).toBeNull();
+  });
+
+  test('stale active delivery persists current canceled Stripe state', async () => {
+    const { handleKiloPassSubscriptionEvent } =
+      await import('@/lib/kilo-pass/stripe-handlers-subscription-events');
+    const user = await insertTestUser();
+    const stripeSubId = `sub_stale_${Math.random()}`;
+    const metadata = kiloPassMetadata({
+      kiloUserId: user.id,
+      tier: KiloPassTier.Tier49,
+      cadence: KiloPassCadence.Monthly,
+    });
+    const staleActive = makeStripeSubscription({
+      id: stripeSubId,
+      start_date_seconds: 1_767_225_600,
+      status: 'active',
+      metadata,
+    });
+    mockStripeSubscriptionsRetrieve.mockResolvedValue(
+      makeStripeSubscription({
+        id: stripeSubId,
+        start_date_seconds: 1_767_225_600,
+        status: 'canceled',
+        canceled_at_seconds: 1_767_311_000,
+        metadata,
+      })
+    );
+
+    await handleKiloPassSubscriptionEvent({
+      eventId: 'evt_stale_created',
+      eventType: 'customer.subscription.created',
+      subscription: staleActive,
+    });
+
+    const row = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, stripeSubId),
+    });
+    expect(row?.status).toBe('canceled');
+    const audit = await db.query.kilo_pass_audit_log.findFirst({
+      where: eq(kilo_pass_audit_log.stripe_event_id, 'evt_stale_created'),
+    });
+    expect(audit?.payload_json).toMatchObject({
+      eventStatus: 'active',
+      appliedStatus: 'canceled',
+      staleDelivery: true,
+    });
+  });
+
+  test('temporary Stripe retrieval failure leaves local state unchanged and throws', async () => {
+    const { handleKiloPassSubscriptionEvent } =
+      await import('@/lib/kilo-pass/stripe-handlers-subscription-events');
+    const user = await insertTestUser();
+    const stripeSubId = `sub_retrieve_failure_${Math.random()}`;
+    await db.insert(kilo_pass_subscriptions).values({
+      kilo_user_id: user.id,
+      provider_subscription_id: stripeSubId,
+      stripe_subscription_id: stripeSubId,
+      tier: KiloPassTier.Tier19,
+      cadence: KiloPassCadence.Monthly,
+      status: 'canceled',
+    });
+    mockStripeSubscriptionsRetrieve.mockRejectedValue(new Error('Stripe unavailable'));
+
+    await expect(
+      handleKiloPassSubscriptionEvent({
+        eventId: 'evt_retrieve_failure',
+        eventType: 'customer.subscription.updated',
+        subscription: makeStripeSubscription({
+          id: stripeSubId,
+          start_date_seconds: 1_767_225_600,
+          status: 'active',
+          metadata: kiloPassMetadata({
+            kiloUserId: user.id,
+            tier: KiloPassTier.Tier19,
+            cadence: KiloPassCadence.Monthly,
+          }),
+        }),
+      })
+    ).rejects.toThrow('Stripe unavailable');
+
+    const row = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, stripeSubId),
+    });
+    expect(row?.status).toBe('canceled');
+    expect(
+      await db.query.kilo_pass_audit_log.findFirst({
+        where: eq(kilo_pass_audit_log.stripe_event_id, 'evt_retrieve_failure'),
+      })
+    ).toBeUndefined();
+  });
+
+  test('Stripe resource_missing persists terminal canceled state', async () => {
+    const { handleKiloPassSubscriptionEvent } =
+      await import('@/lib/kilo-pass/stripe-handlers-subscription-events');
+    const user = await insertTestUser();
+    const stripeSubId = `sub_missing_${Math.random()}`;
+    mockStripeSubscriptionsRetrieve.mockRejectedValue({ code: 'resource_missing' });
+
+    await handleKiloPassSubscriptionEvent({
+      eventId: 'evt_resource_missing',
+      eventType: 'customer.subscription.updated',
+      subscription: makeStripeSubscription({
+        id: stripeSubId,
+        start_date_seconds: 1_767_225_600,
+        status: 'active',
+        metadata: kiloPassMetadata({
+          kiloUserId: user.id,
+          tier: KiloPassTier.Tier19,
+          cadence: KiloPassCadence.Monthly,
+        }),
+      }),
+    });
+
+    const row = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, stripeSubId),
+    });
+    expect(row?.status).toBe('canceled');
   });
 
   test('closes pause event when pause_collection is cleared', async () => {

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.ts
@@ -1,10 +1,11 @@
 import 'server-only';
 
-import { kilo_pass_subscriptions } from '@kilocode/db/schema';
+import { kilo_pass_audit_log, kilo_pass_subscriptions } from '@kilocode/db/schema';
 
 import { db } from '@/lib/drizzle';
-import { eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { reportEvents } from '@/lib/ai-gateway/abuse-service';
+import { captureException } from '@sentry/nextjs';
 
 import { KiloPassError } from '@/lib/kilo-pass/errors';
 import { appendKiloPassAuditLog } from '@/lib/kilo-pass/issuance';
@@ -21,130 +22,178 @@ import {
 import { isStripeSubscriptionEnded } from '@/lib/kilo-pass/stripe-subscription-status';
 import { dayjs } from '@/lib/kilo-pass/dayjs';
 
+function isStripeResourceMissing(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'resource_missing'
+  );
+}
+
 export async function handleKiloPassSubscriptionEvent(params: {
   eventId: string;
   eventType: string;
   subscription: Stripe.Subscription;
 }): Promise<void> {
-  const { eventId, eventType, subscription } = params;
-  const metadata = getKiloPassSubscriptionMetadata(subscription);
-  if (!metadata) {
+  const { eventId, eventType, subscription: eventSubscription } = params;
+  const eventMetadata = getKiloPassSubscriptionMetadata(eventSubscription);
+  if (!eventMetadata) {
     throw new KiloPassError(
       `Kilo Pass subscription event missing required metadata fields (event_type=${eventType})`,
       {
         stripe_event_id: eventId,
-        stripe_subscription_id: subscription.id,
+        stripe_subscription_id: eventSubscription.id,
       }
     );
   }
 
-  const { kiloUserId, tier, cadence } = metadata;
-
   let finalStatus: string | undefined;
   let finalStreakMonths: number | undefined;
+  let wasDuplicateDelivery = false;
 
-  await db.transaction(async tx => {
-    await appendKiloPassAuditLog(tx, {
-      action: KiloPassAuditLogAction.StripeWebhookReceived,
-      result: KiloPassAuditLogResult.Success,
-      kiloUserId,
-      stripeEventId: eventId,
-      stripeSubscriptionId: subscription.id,
-      payload: { type: eventType },
-    });
+  try {
+    await db.transaction(async tx => {
+      const lockKey = `kilo-pass:subscription:${eventSubscription.id}`;
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`);
 
-    const stripeStatus = subscription.status;
-    const cancelAtPeriodEnd = subscription.cancel_at_period_end;
+      let currentSubscription: Stripe.Subscription;
+      let resourceMissing = false;
+      try {
+        const retrievedSubscription = await stripe.subscriptions.retrieve(eventSubscription.id);
+        currentSubscription = { ...eventSubscription, ...retrievedSubscription };
+      } catch (error) {
+        if (!isStripeResourceMissing(error)) throw error;
+        currentSubscription = {
+          ...eventSubscription,
+          status: 'canceled',
+          cancel_at_period_end: false,
+          ended_at: eventSubscription.ended_at ?? eventSubscription.canceled_at,
+          pause_collection: null,
+        };
+        resourceMissing = true;
+      }
 
-    const existing = await tx.query.kilo_pass_subscriptions.findFirst({
-      where: eq(kilo_pass_subscriptions.stripe_subscription_id, subscription.id),
-    });
-
-    const wasEnded = existing ? isStripeSubscriptionEnded(existing.status) : false;
-    const isNowEnded = isStripeSubscriptionEnded(stripeStatus) || subscription.ended_at != null;
-    const transitionedToEnded = !wasEnded && isNowEnded;
-
-    const endedAt = isNowEnded ? getStripeEndedAtIso(subscription) : null;
-
-    const baseValues = {
-      kilo_user_id: kiloUserId,
-      tier,
-      cadence,
-      status: stripeStatus,
-      cancel_at_period_end: cancelAtPeriodEnd,
-    } satisfies Partial<typeof kilo_pass_subscriptions.$inferInsert>;
-
-    const updateSet = {
-      ...baseValues,
-      ended_at: endedAt,
-      ...(transitionedToEnded ? { current_streak_months: 0 } : {}),
-    } satisfies Partial<typeof kilo_pass_subscriptions.$inferInsert>;
-
-    const upserted = await tx
-      .insert(kilo_pass_subscriptions)
-      .values({
-        ...baseValues,
-        payment_provider: KiloPassPaymentProvider.Stripe,
-        provider_subscription_id: subscription.id,
-        stripe_subscription_id: subscription.id,
-        started_at: dayjs.unix(subscription.start_date).utc().toISOString(),
-        ended_at: endedAt,
-        current_streak_months: 0,
-      })
-      .onConflictDoUpdate({
-        target: kilo_pass_subscriptions.stripe_subscription_id,
-        set: {
-          ...updateSet,
-          payment_provider: KiloPassPaymentProvider.Stripe,
-          provider_subscription_id: subscription.id,
-        },
-      })
-      .returning({
-        id: kilo_pass_subscriptions.id,
-        current_streak_months: kilo_pass_subscriptions.current_streak_months,
+      const metadata = getKiloPassSubscriptionMetadata(currentSubscription) ?? eventMetadata;
+      const { kiloUserId, tier, cadence } = metadata;
+      const stripeStatus = currentSubscription.status;
+      const existing = await tx.query.kilo_pass_subscriptions.findFirst({
+        where: eq(kilo_pass_subscriptions.stripe_subscription_id, eventSubscription.id),
       });
+      const priorAudit = await tx.query.kilo_pass_audit_log.findFirst({
+        columns: { id: true },
+        where: and(
+          eq(kilo_pass_audit_log.action, KiloPassAuditLogAction.StripeWebhookReceived),
+          eq(kilo_pass_audit_log.stripe_event_id, eventId)
+        ),
+      });
+      wasDuplicateDelivery = priorAudit !== undefined;
 
-    finalStatus = stripeStatus;
-    finalStreakMonths = upserted[0]?.current_streak_months ?? 0;
+      const wasEnded = existing ? isStripeSubscriptionEnded(existing.status) : false;
+      const isNowEnded =
+        isStripeSubscriptionEnded(stripeStatus) || currentSubscription.ended_at != null;
+      const transitionedToEnded = !wasEnded && isNowEnded;
+      const endedAt = isNowEnded ? getStripeEndedAtIso(currentSubscription) : null;
+      const baseValues = {
+        kilo_user_id: kiloUserId,
+        tier,
+        cadence,
+        status: stripeStatus,
+        cancel_at_period_end: currentSubscription.cancel_at_period_end,
+      } satisfies Partial<typeof kilo_pass_subscriptions.$inferInsert>;
 
-    const kiloPassSubscriptionId = upserted[0]?.id;
+      const upserted = await tx
+        .insert(kilo_pass_subscriptions)
+        .values({
+          ...baseValues,
+          payment_provider: KiloPassPaymentProvider.Stripe,
+          provider_subscription_id: eventSubscription.id,
+          stripe_subscription_id: eventSubscription.id,
+          started_at: dayjs.unix(currentSubscription.start_date).utc().toISOString(),
+          ended_at: endedAt,
+          current_streak_months: 0,
+        })
+        .onConflictDoUpdate({
+          target: kilo_pass_subscriptions.stripe_subscription_id,
+          set: {
+            ...baseValues,
+            ended_at: endedAt,
+            ...(transitionedToEnded ? { current_streak_months: 0 } : {}),
+            payment_provider: KiloPassPaymentProvider.Stripe,
+            provider_subscription_id: eventSubscription.id,
+          },
+        })
+        .returning({
+          id: kilo_pass_subscriptions.id,
+          current_streak_months: kilo_pass_subscriptions.current_streak_months,
+        });
 
-    if (kiloPassSubscriptionId) {
-      // Fetch pause_collection from the Stripe API (not included in the webhook type)
-      const freshSubscription = await stripe.subscriptions.retrieve(subscription.id);
-      const pauseCollection = freshSubscription.pause_collection;
+      const row = upserted[0];
+      if (!row)
+        throw new Error(`Failed to reconcile Kilo Pass subscription ${eventSubscription.id}`);
 
-      if (pauseCollection && pauseCollection.behavior) {
-        // Subscription has an active pause — open a pause event
-        const resumesAtIso = pauseCollection.resumes_at
-          ? dayjs.unix(pauseCollection.resumes_at).utc().toISOString()
-          : null;
+      finalStatus = stripeStatus;
+      finalStreakMonths = row.current_streak_months;
+
+      const pauseCollection = currentSubscription.pause_collection;
+      if (pauseCollection?.behavior) {
         await openPauseEvent(tx, {
-          kiloPassSubscriptionId,
+          kiloPassSubscriptionId: row.id,
           pausedAt: dayjs().utc().toISOString(),
-          resumesAt: resumesAtIso,
+          resumesAt: pauseCollection.resumes_at
+            ? dayjs.unix(pauseCollection.resumes_at).utc().toISOString()
+            : null,
         });
       } else {
-        // No pause_collection — close any open pause event
         await closePauseEvent(tx, {
-          kiloPassSubscriptionId,
+          kiloPassSubscriptionId: row.id,
           resumedAt: dayjs().utc().toISOString(),
         });
       }
-    }
-  });
+
+      await appendKiloPassAuditLog(tx, {
+        action: KiloPassAuditLogAction.StripeWebhookReceived,
+        result: wasDuplicateDelivery
+          ? KiloPassAuditLogResult.SkippedIdempotent
+          : KiloPassAuditLogResult.Success,
+        kiloUserId,
+        stripeEventId: eventId,
+        stripeSubscriptionId: eventSubscription.id,
+        payload: {
+          type: eventType,
+          reconciliation: 'stripe_current_state',
+          eventStatus: eventSubscription.status,
+          appliedStatus: stripeStatus,
+          resourceMissing,
+          staleDelivery: eventSubscription.status !== stripeStatus,
+        },
+      });
+    });
+  } catch (error) {
+    captureException(error, {
+      tags: { source: 'kilo_pass_subscription_reconciliation', stage: 'stripe_retrieve' },
+      extra: {
+        stripeEventId: eventId,
+        stripeEventType: eventType,
+        stripeSubscriptionId: eventSubscription.id,
+      },
+    });
+    throw error;
+  }
+
+  if (wasDuplicateDelivery) return;
 
   void reportEvents({
     events: [
       {
         type: 'billing.kilo_pass_changed',
         data: {
-          kilo_user_id: kiloUserId,
-          tier,
+          kilo_user_id: eventMetadata.kiloUserId,
+          tier: eventMetadata.tier,
           status: finalStatus ?? null,
           streak_months: finalStreakMonths,
         },
       },
     ],
-  });
+  }).catch(captureException);
 }

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.ts
@@ -171,7 +171,10 @@ export async function handleKiloPassSubscriptionEvent(params: {
     });
   } catch (error) {
     captureException(error, {
-      tags: { source: 'kilo_pass_subscription_reconciliation', stage: 'stripe_retrieve' },
+      tags: {
+        source: 'kilo_pass_subscription_reconciliation',
+        stage: 'subscription_reconciliation',
+      },
       extra: {
         stripeEventId: eventId,
         stripeEventType: eventType,

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.ts
@@ -50,6 +50,8 @@ export async function handleKiloPassSubscriptionEvent(params: {
 
   let finalStatus: string | undefined;
   let finalStreakMonths: number | undefined;
+  let finalKiloUserId: string | undefined;
+  let finalTier: string | undefined;
   let wasDuplicateDelivery = false;
 
   try {
@@ -142,6 +144,8 @@ export async function handleKiloPassSubscriptionEvent(params: {
 
       finalStatus = stripeStatus;
       finalStreakMonths = row.current_streak_months;
+      finalKiloUserId = kiloUserId;
+      finalTier = tier;
 
       const pauseCollection = currentSubscription.pause_collection;
       if (pauseCollection?.behavior) {
@@ -199,8 +203,8 @@ export async function handleKiloPassSubscriptionEvent(params: {
       {
         type: 'billing.kilo_pass_changed',
         data: {
-          kilo_user_id: eventMetadata.kiloUserId,
-          tier: eventMetadata.tier,
+          kilo_user_id: finalKiloUserId ?? eventMetadata.kiloUserId,
+          tier: finalTier ?? eventMetadata.tier,
           status: finalStatus ?? null,
           streak_months: finalStreakMonths,
         },

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-subscription-events.ts
@@ -93,7 +93,15 @@ export async function handleKiloPassSubscriptionEvent(params: {
       const isNowEnded =
         isStripeSubscriptionEnded(stripeStatus) || currentSubscription.ended_at != null;
       const transitionedToEnded = !wasEnded && isNowEnded;
-      const endedAt = isNowEnded ? getStripeEndedAtIso(currentSubscription) : null;
+      const hasProviderEndedAt =
+        currentSubscription.ended_at != null || currentSubscription.canceled_at != null;
+      let endedAt: string | null = null;
+      if (isNowEnded) {
+        endedAt =
+          resourceMissing && !hasProviderEndedAt && existing?.ended_at
+            ? existing.ended_at
+            : getStripeEndedAtIso(currentSubscription);
+      }
       const baseValues = {
         kilo_user_id: kiloUserId,
         tier,


### PR DESCRIPTION
## Summary
Prevent stale or concurrent Stripe webhook deliveries from resurrecting canceled Kilo Pass subscriptions, while hardening the duplicate-card path that produced the incident.

### Why this change is needed
Out-of-order subscription events allowed an older `customer.subscription.created` payload to overwrite a newer canceled state. This left Stripe canceled and refunded while local checkout logic still treated the subscription as active.

The webhook reconciliation change fixes that root cause: local state previously followed delivery order instead of Stripe's current state. The duplicate-card changes harden the incident-producing path: cancellation and refund outcomes are now accurate, observable, and safely retryable. Duplicate-card enforcement is not the ordering fix itself, but it prevents partial provider failures from leaving misleading audit state or unsafe retry behavior.

### How this is addressed
- Fix the root cause by reconciling each subscription event against current Stripe state under a per-subscription advisory lock.
- Treat Stripe `resource_missing` as canceled and propagate temporary retrieval failures for webhook retry.
- Record stale, duplicate, applied, and failed reconciliation outcomes in existing audit facilities.
- Harden the incident-producing duplicate-card path by committing the block before provider calls, moving cancellation and refund outside the database transaction, and recording their outcomes separately.
- Preserve retry safety through webhook failure propagation and deterministic Stripe idempotency keys without granting credits or reversing the block.
- Keep existing schema unchanged; no webhook ledger, workflow table, or migration is introduced.

## Human Verification
- Focused Kilo Pass subscription, invoice, and duplicate-card webhook tests passed.
- Stripe dispatcher tests passed.
- Seven-focus code review completed; React Code Quality analyzer passed with 100/100 and no applicable React files.

## Reviewer Notes
### Human Reviewer Flags
- Current Stripe retrieval is the primary ordering mechanism; subscription-row event metadata was intentionally not added.
- Stripe retrieval occurs while holding the transaction-scoped advisory lock so concurrent handlers cannot persist state out of order.
- Duplicate-card hardening addresses the incident-producing path, while current-state reconciliation is the root-cause fix.
- Kilo Pass spec now requires duplicate-card cancellation failures to trigger webhook retry while refund failures remain observable and nonfatal.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `resource_missing` maps to terminal canceled state; other Stripe retrieval failures roll back local mutation and propagate.
- Duplicate-card provider calls run after the database transaction commits.
- Existing audit action values are reused with structured outcome payloads, avoiding a schema migration.
- Store-managed subscriptions are unaffected because routing changes apply only to Stripe Kilo Pass subscription events.

</details>
