### PR TITLE
fix(kiloclaw): recognize legacy Commit qualification evidence

### DIFF
--- a/packages/db/src/kiloclaw-commit-switch-qualification-repository.test.ts
+++ b/packages/db/src/kiloclaw-commit-switch-qualification-repository.test.ts
@@ -63,6 +63,57 @@ async function insertScheduleChange(input: {
   });
 }
 
+async function insertLifecycleState(input: {
+  subscriptionId: string;
+  createdAt: string;
+  actorId?: string;
+  reason?: string;
+  beforeScheduledPlan?: string | null;
+  afterScheduledPlan?: string | null;
+  beforeScheduledBy?: string | null;
+  afterScheduledBy?: string | null;
+}): Promise<void> {
+  await testDatabase.db.insert(kiloclaw_subscription_change_log).values({
+    subscription_id: input.subscriptionId,
+    created_at: input.createdAt,
+    actor_type: 'system',
+    actor_id: input.actorId ?? 'billing-lifecycle-job',
+    action: 'status_changed',
+    reason: input.reason ?? 'credit_renewal_insufficient_credits',
+    before_state: {
+      scheduled_plan: input.beforeScheduledPlan ?? 'commit',
+      scheduled_by: input.beforeScheduledBy ?? 'user',
+    },
+    after_state: {
+      scheduled_plan: input.afterScheduledPlan ?? 'commit',
+      scheduled_by: input.afterScheduledBy ?? 'user',
+    },
+  });
+}
+
+async function insertAlignmentBaseline(input: {
+  subscriptionId: string;
+  createdAt: string;
+  reason?: string;
+  actorId?: string;
+  scheduledPlan?: string | null;
+  scheduledBy?: string | null;
+}): Promise<void> {
+  await testDatabase.db.insert(kiloclaw_subscription_change_log).values({
+    subscription_id: input.subscriptionId,
+    created_at: input.createdAt,
+    actor_type: 'system',
+    actor_id: input.actorId ?? 'kiloclaw-subscription-alignment',
+    action: 'backfilled',
+    reason: input.reason ?? 'baseline_subscription_snapshot',
+    before_state: null,
+    after_state: {
+      scheduled_plan: input.scheduledPlan ?? 'commit',
+      scheduled_by: input.scheduledBy ?? 'user',
+    },
+  });
+}
+
 afterAll(async () => {
   for (const subscriptionId of testRows) {
     await testDatabase.db
@@ -134,6 +185,116 @@ describe('Commit switch qualification repository', () => {
       qualifiedAt: '2026-06-05T23:59:59.999Z',
       qualificationSource: KiloClawCommitRetirementQualificationSource.SwitchRequestedBeforeCutoff,
     });
+  });
+
+  it.each([
+    'baseline_subscription_snapshot',
+    'baseline_subscription_snapshot_from_earliest_mutation',
+  ])('accepts pre-cutoff alignment evidence from %s', async reason => {
+    const { subscriptionId } = await createSubscription();
+    await insertAlignmentBaseline({
+      subscriptionId,
+      createdAt: '2026-04-17T20:09:06.862Z',
+      reason,
+    });
+
+    await expect(
+      findLatestPreCutoffUserCommitSwitchQualification(testDatabase.db, subscriptionId)
+    ).resolves.toEqual({
+      qualifiedAt: '2026-04-17T20:09:06.862Z',
+      qualificationSource: KiloClawCommitRetirementQualificationSource.SwitchRequestedBeforeCutoff,
+    });
+  });
+
+  it('accepts preserved user-scheduled Commit state from pre-cutoff insufficient-credit renewal', async () => {
+    const { subscriptionId } = await createSubscription();
+    await insertLifecycleState({
+      subscriptionId,
+      createdAt: '2026-05-19T05:02:30.929Z',
+    });
+
+    await expect(
+      findLatestPreCutoffUserCommitSwitchQualification(testDatabase.db, subscriptionId)
+    ).resolves.toEqual({
+      qualifiedAt: '2026-05-19T05:02:30.929Z',
+      qualificationSource: KiloClawCommitRetirementQualificationSource.SwitchRequestedBeforeCutoff,
+    });
+  });
+
+  it.each([
+    { actorId: 'another-system' },
+    { reason: 'another_reason' },
+    { beforeScheduledPlan: 'standard' },
+    { afterScheduledPlan: 'standard' },
+    { beforeScheduledBy: 'system' },
+    { afterScheduledBy: 'system' },
+  ])('excludes non-canonical lifecycle evidence: $actorId$reason', async evidence => {
+    const { subscriptionId } = await createSubscription();
+    await insertLifecycleState({
+      subscriptionId,
+      createdAt: '2026-05-19T05:02:30.929Z',
+      ...evidence,
+    });
+
+    await expect(
+      findLatestPreCutoffUserCommitSwitchQualification(testDatabase.db, subscriptionId)
+    ).resolves.toBeNull();
+  });
+
+  it('excludes lifecycle evidence exactly at cutoff', async () => {
+    const { subscriptionId } = await createSubscription();
+    await insertLifecycleState({
+      subscriptionId,
+      createdAt: KILOCLAW_COMMIT_SALES_CUTOFF,
+    });
+
+    await expect(
+      findLatestPreCutoffUserCommitSwitchQualification(testDatabase.db, subscriptionId)
+    ).resolves.toBeNull();
+  });
+
+  it('excludes alignment baseline exactly at cutoff', async () => {
+    const { subscriptionId } = await createSubscription();
+    await insertAlignmentBaseline({
+      subscriptionId,
+      createdAt: KILOCLAW_COMMIT_SALES_CUTOFF,
+    });
+
+    await expect(
+      findLatestPreCutoffUserCommitSwitchQualification(testDatabase.db, subscriptionId)
+    ).resolves.toBeNull();
+  });
+
+  it.each([
+    { actorId: 'another-system', reason: 'baseline_subscription_snapshot' },
+    { actorId: 'kiloclaw-subscription-alignment', reason: 'another_reason' },
+  ])('excludes non-canonical alignment evidence: $reason', async evidence => {
+    const { subscriptionId } = await createSubscription();
+    await insertAlignmentBaseline({
+      subscriptionId,
+      createdAt: '2026-04-17T20:09:06.862Z',
+      ...evidence,
+    });
+
+    await expect(
+      findLatestPreCutoffUserCommitSwitchQualification(testDatabase.db, subscriptionId)
+    ).resolves.toBeNull();
+  });
+
+  it.each([
+    { scheduledPlan: 'standard', scheduledBy: 'user' },
+    { scheduledPlan: 'commit', scheduledBy: 'system' },
+  ])('excludes alignment baseline without user-scheduled Commit state', async evidence => {
+    const { subscriptionId } = await createSubscription();
+    await insertAlignmentBaseline({
+      subscriptionId,
+      createdAt: '2026-04-17T20:09:06.862Z',
+      ...evidence,
+    });
+
+    await expect(
+      findLatestPreCutoffUserCommitSwitchQualification(testDatabase.db, subscriptionId)
+    ).resolves.toBeNull();
   });
 
   it('excludes transition exactly at cutoff', async () => {

--- a/packages/db/src/kiloclaw-commit-switch-qualification-repository.test.ts
+++ b/packages/db/src/kiloclaw-commit-switch-qualification-repository.test.ts
@@ -66,6 +66,7 @@ async function insertScheduleChange(input: {
 async function insertLifecycleState(input: {
   subscriptionId: string;
   createdAt: string;
+  actorType?: 'user' | 'system';
   actorId?: string;
   reason?: string;
   beforeScheduledPlan?: string | null;
@@ -76,7 +77,7 @@ async function insertLifecycleState(input: {
   await testDatabase.db.insert(kiloclaw_subscription_change_log).values({
     subscription_id: input.subscriptionId,
     created_at: input.createdAt,
-    actor_type: 'system',
+    actor_type: input.actorType ?? 'system',
     actor_id: input.actorId ?? 'billing-lifecycle-job',
     action: 'status_changed',
     reason: input.reason ?? 'credit_renewal_insufficient_credits',
@@ -96,6 +97,7 @@ async function insertAlignmentBaseline(input: {
   createdAt: string;
   reason?: string;
   actorId?: string;
+  beforeState?: Record<string, unknown> | null;
   scheduledPlan?: string | null;
   scheduledBy?: string | null;
 }): Promise<void> {
@@ -106,7 +108,7 @@ async function insertAlignmentBaseline(input: {
     actor_id: input.actorId ?? 'kiloclaw-subscription-alignment',
     action: 'backfilled',
     reason: input.reason ?? 'baseline_subscription_snapshot',
-    before_state: null,
+    before_state: input.beforeState ?? null,
     after_state: {
       scheduled_plan: input.scheduledPlan ?? 'commit',
       scheduled_by: input.scheduledBy ?? 'user',
@@ -222,13 +224,14 @@ describe('Commit switch qualification repository', () => {
   });
 
   it.each([
-    { actorId: 'another-system' },
-    { reason: 'another_reason' },
-    { beforeScheduledPlan: 'standard' },
-    { afterScheduledPlan: 'standard' },
-    { beforeScheduledBy: 'system' },
-    { afterScheduledBy: 'system' },
-  ])('excludes non-canonical lifecycle evidence: $actorId$reason', async evidence => {
+    { description: 'wrong actor type', actorType: 'user' as const },
+    { description: 'wrong actor ID', actorId: 'another-system' },
+    { description: 'wrong reason', reason: 'another_reason' },
+    { description: 'wrong previous plan', beforeScheduledPlan: 'standard' },
+    { description: 'wrong resulting plan', afterScheduledPlan: 'standard' },
+    { description: 'wrong previous scheduler', beforeScheduledBy: 'system' },
+    { description: 'wrong resulting scheduler', afterScheduledBy: 'system' },
+  ])('excludes non-canonical lifecycle evidence: $description', async evidence => {
     const { subscriptionId } = await createSubscription();
     await insertLifecycleState({
       subscriptionId,
@@ -266,9 +269,21 @@ describe('Commit switch qualification repository', () => {
   });
 
   it.each([
-    { actorId: 'another-system', reason: 'baseline_subscription_snapshot' },
-    { actorId: 'kiloclaw-subscription-alignment', reason: 'another_reason' },
-  ])('excludes non-canonical alignment evidence: $reason', async evidence => {
+    {
+      description: 'wrong actor ID',
+      actorId: 'another-system',
+      reason: 'baseline_subscription_snapshot',
+    },
+    {
+      description: 'wrong reason',
+      actorId: 'kiloclaw-subscription-alignment',
+      reason: 'another_reason',
+    },
+    {
+      description: 'non-null before state',
+      beforeState: { scheduled_plan: 'standard' },
+    },
+  ])('excludes non-canonical alignment evidence: $description', async evidence => {
     const { subscriptionId } = await createSubscription();
     await insertAlignmentBaseline({
       subscriptionId,

--- a/packages/db/src/kiloclaw-commit-switch-qualification-repository.ts
+++ b/packages/db/src/kiloclaw-commit-switch-qualification-repository.ts
@@ -41,11 +41,35 @@ export async function findLatestPreCutoffUserCommitSwitchQualification(
     FROM ${kiloclaw_subscription_change_log} change
     INNER JOIN subscription_lineage lineage
       ON change.${sql.identifier(kiloclaw_subscription_change_log.subscription_id.name)} = lineage.${sql.identifier(kiloclaw_subscriptions.id.name)}
-    WHERE change.${sql.identifier(kiloclaw_subscription_change_log.action.name)} = ${KiloClawSubscriptionChangeAction.ScheduleChanged}
-      AND change.${sql.identifier(kiloclaw_subscription_change_log.actor_type.name)} = ${KiloClawSubscriptionChangeActorType.User}
-      AND change.${sql.identifier(kiloclaw_subscription_change_log.created_at.name)} < ${cutoff}
+    WHERE change.${sql.identifier(kiloclaw_subscription_change_log.created_at.name)} < ${cutoff}
       AND change.${sql.identifier(kiloclaw_subscription_change_log.after_state.name)}->>'scheduled_plan' = 'commit'
-      AND COALESCE(change.${sql.identifier(kiloclaw_subscription_change_log.before_state.name)}->>'scheduled_plan', '') <> 'commit'
+      AND (
+        (
+          change.${sql.identifier(kiloclaw_subscription_change_log.action.name)} = ${KiloClawSubscriptionChangeAction.ScheduleChanged}
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.actor_type.name)} = ${KiloClawSubscriptionChangeActorType.User}
+          AND COALESCE(change.${sql.identifier(kiloclaw_subscription_change_log.before_state.name)}->>'scheduled_plan', '') <> 'commit'
+        )
+        OR (
+          change.${sql.identifier(kiloclaw_subscription_change_log.action.name)} = ${KiloClawSubscriptionChangeAction.Backfilled}
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.actor_type.name)} = ${KiloClawSubscriptionChangeActorType.System}
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.actor_id.name)} = 'kiloclaw-subscription-alignment'
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.reason.name)} IN (
+            'baseline_subscription_snapshot',
+            'baseline_subscription_snapshot_from_earliest_mutation'
+          )
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.before_state.name)} IS NULL
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.after_state.name)}->>'scheduled_by' = 'user'
+        )
+        OR (
+          change.${sql.identifier(kiloclaw_subscription_change_log.action.name)} = ${KiloClawSubscriptionChangeAction.StatusChanged}
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.actor_type.name)} = ${KiloClawSubscriptionChangeActorType.System}
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.actor_id.name)} = 'billing-lifecycle-job'
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.reason.name)} = 'credit_renewal_insufficient_credits'
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.before_state.name)}->>'scheduled_plan' = 'commit'
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.before_state.name)}->>'scheduled_by' = 'user'
+          AND change.${sql.identifier(kiloclaw_subscription_change_log.after_state.name)}->>'scheduled_by' = 'user'
+        )
+      )
     ORDER BY
       change.${sql.identifier(kiloclaw_subscription_change_log.created_at.name)} DESC,
       change.${sql.identifier(kiloclaw_subscription_change_log.id.name)} DESC


### PR DESCRIPTION
## Summary
Recognize canonical legacy evidence proving user-scheduled Commit state existed before sales cutoff.

### Why this change is needed
Commit retirement initially accepted only explicit user `schedule_changed` events. Production audit found 11 due subscriptions created before cutoff without that event shape: nine had canonical alignment snapshots, and two had repeated lifecycle renewal records preserving user-scheduled Commit state. These users were incorrectly classified as ambiguous, blocking renewal processing.

### How this is addressed
- Accept canonical pre-cutoff alignment baseline snapshots containing user-scheduled Commit state.
- Accept tightly constrained pre-cutoff insufficient-credit lifecycle records whose before and after snapshots both preserve user-scheduled Commit state.
- Keep existing cutoff, actor, reason, state-transition, and subscription-lineage guards.
- Add acceptance and rejection coverage for each legacy evidence shape.

## Human Verification
- Production read-only audit classified all 19 due pending-Commit subscriptions: 8 explicit user events, 9 alignment baselines, 2 lifecycle observations, 0 unqualified.
- Independent logic review found no issues.

## Reviewer Notes
### Human Reviewer Flags
- Review decision to treat canonical system observations as equivalent proof that user-scheduled Commit state existed before cutoff; no changelog rows are rewritten or synthesized.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Baseline evidence requires canonical alignment actor, approved reason, null before-state, and user-scheduled Commit after-state.
- Lifecycle evidence requires canonical billing actor, insufficient-credit reason, and matching user-scheduled Commit state before and after.
- Exact-cutoff evidence remains excluded.

</details>