### PR TITLE
fix(ai-gateway): preserve valid Terminal Bench stats

### DIFF
--- a/apps/web/src/lib/model-stats/terminal-bench.test.ts
+++ b/apps/web/src/lib/model-stats/terminal-bench.test.ts
@@ -46,9 +46,14 @@ function row(overrides: Partial<Parameters<typeof summarizeTerminalBench>[0][num
 describe('summarizeTerminalBench', () => {
   it('publishes only eligible non-internal summaries', () => {
     const stealth = { ...row({ openrouterId: 'stealth/model' }), isStealth: true };
+    const nullable = {
+      ...benchmarks(),
+      artificialAnalysis: { liveCodeBench: null },
+    };
     const summaries = summarizeTerminalBench([
       row(),
       stealth,
+      row({ openrouterId: 'nullable/model', benchmarks: nullable }),
       row({ openrouterId: 'kilo-internal/custom', benchmarks: benchmarks() }),
       row({ isActive: false }),
       row({ benchmarks: benchmarks({ nAttempts: 4 }) }),
@@ -61,6 +66,7 @@ describe('summarizeTerminalBench', () => {
       new Map([
         ['openai/model', summary],
         ['stealth/model', summary],
+        ['nullable/model', summary],
       ])
     );
   });

--- a/apps/web/src/lib/model-stats/terminal-bench.ts
+++ b/apps/web/src/lib/model-stats/terminal-bench.ts
@@ -1,26 +1,13 @@
 import { CUSTOM_LLM_PREFIX } from '@/lib/ai-gateway/model-utils';
 import { createCachedFetch } from '@/lib/cached-fetch';
 import { readDb } from '@/lib/drizzle';
-import { modelStats } from '@kilocode/db/schema';
+import { ModelStatsBenchmarksSchema, modelStats } from '@kilocode/db/schema';
 import { unprefixKiloGatewayModelId } from '@kilocode/worker-utils/kilo-model-id';
 import { and, eq, notLike } from 'drizzle-orm';
-import { z } from 'zod';
 
-const TerminalBenchSchema = z.object({
-  kiloBench: z
-    .object({
-      evals: z.object({
-        'terminal-bench': z
-          .object({
-            overallScore: z.number(),
-            nAttempts: z.number().nullable().optional(),
-            avgAttemptCostUsd: z.number().nullable().optional(),
-          })
-          .optional(),
-      }),
-    })
-    .optional(),
-});
+const TerminalBenchSchema = ModelStatsBenchmarksSchema.unwrap()
+  .pick({ kiloBench: true })
+  .optional();
 
 const TTL = process.env.NODE_ENV === 'test' ? 0 : 5 * 60 * 1000;
 

--- a/apps/web/src/lib/model-stats/terminal-bench.ts
+++ b/apps/web/src/lib/model-stats/terminal-bench.ts
@@ -1,9 +1,26 @@
 import { CUSTOM_LLM_PREFIX } from '@/lib/ai-gateway/model-utils';
 import { createCachedFetch } from '@/lib/cached-fetch';
 import { readDb } from '@/lib/drizzle';
-import { ModelStatsBenchmarksSchema, modelStats } from '@kilocode/db/schema';
+import { modelStats } from '@kilocode/db/schema';
 import { unprefixKiloGatewayModelId } from '@kilocode/worker-utils/kilo-model-id';
 import { and, eq, notLike } from 'drizzle-orm';
+import { z } from 'zod';
+
+const TerminalBenchSchema = z.object({
+  kiloBench: z
+    .object({
+      evals: z.object({
+        'terminal-bench': z
+          .object({
+            overallScore: z.number(),
+            nAttempts: z.number().nullable().optional(),
+            avgAttemptCostUsd: z.number().nullable().optional(),
+          })
+          .optional(),
+      }),
+    })
+    .optional(),
+});
 
 const TTL = process.env.NODE_ENV === 'test' ? 0 : 5 * 60 * 1000;
 
@@ -25,7 +42,7 @@ export function summarizeTerminalBench(rows: readonly Row[]): TerminalBenchSumma
 
   for (const row of rows) {
     if (!row.isActive || row.openrouterId.startsWith(CUSTOM_LLM_PREFIX)) continue;
-    const result = ModelStatsBenchmarksSchema.safeParse(row.benchmarks);
+    const result = TerminalBenchSchema.safeParse(row.benchmarks);
     if (!result.success) continue;
     const bench = result.data?.kiloBench?.evals['terminal-bench'];
     if (


### PR DESCRIPTION
## Summary

- Validate only the Terminal Bench subtree when enriching the model catalog.
- Preserve valid Terminal Bench results when unrelated benchmark providers contain nullable or otherwise incompatible fields.
- Cover the production-shaped `artificialAnalysis.liveCodeBench: null` regression.

## Verification

- Verified locally that GPT-5.5 appears in the Kilo Gateway catalog with its Terminal Bench score and attempt cost while retaining no Artificial Analysis data.

## Visual Changes

N/A

## Reviewer Notes

This keeps Terminal Bench publication isolated from schema drift in unrelated benchmark providers. Existing eligibility requirements remain unchanged.