### PR TITLE
feat(kiloclaw) WIP multi agents UI

### DIFF
--- a/apps/web/src/app/(app)/claw/agents/page.tsx
+++ b/apps/web/src/app/(app)/claw/agents/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ClawAgentsPage } from '../components/ClawAgentsPage';
+
+export default function PersonalClawAgentsPage() {
+  return <ClawAgentsPage />;
+}

--- a/apps/web/src/app/(app)/claw/components/AgentCreateDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentCreateDialog.tsx
@@ -18,6 +18,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useClawAgentMutations } from '../hooks/useClawHooks';
 import { useClawModelOptions } from '../hooks/useClawModelOptions';
+import { addKilocodeModelPrefix } from './modelSupport';
 
 // Mirror of the controller's normalizeAgentId (openclaw-agent-config.ts) so the
 // derived workspace is 1:1 with the agent id the controller will assign. Using
@@ -77,7 +78,9 @@ export function AgentCreateDialog({
       await createAgent.mutateAsync({
         name: trimmedName,
         workspace: workspaceFromName(trimmedName),
-        model: trimmedModel || undefined,
+        // The combobox yields a bare catalog id; agent model refs are stored
+        // under the kilocode/ namespace.
+        model: trimmedModel ? addKilocodeModelPrefix(trimmedModel) : undefined,
       });
       toast.success(`Created agent ${trimmedName}`);
       reset();

--- a/apps/web/src/app/(app)/claw/components/AgentCreateDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentCreateDialog.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 
 import { AnimatedDots } from './AnimatedDots';
+import { ModelCombobox } from '@/components/shared/ModelCombobox';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -16,6 +17,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useClawAgentMutations } from '../hooks/useClawHooks';
+import { useClawModelOptions } from '../hooks/useClawModelOptions';
 
 // Mirror of the controller's normalizeAgentId (openclaw-agent-config.ts) so the
 // derived workspace is 1:1 with the agent id the controller will assign. Using
@@ -50,6 +52,7 @@ export function AgentCreateDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const { createAgent } = useClawAgentMutations();
+  const { modelOptions, isLoading: isLoadingModels } = useClawModelOptions();
   const [name, setName] = useState('');
   const [model, setModel] = useState('');
 
@@ -115,13 +118,16 @@ export function AgentCreateDialog({
           </div>
 
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="agent-model">Model (optional)</Label>
-            <Input
-              id="agent-model"
+            <Label>Model (optional)</Label>
+            <ModelCombobox
+              label=""
+              models={modelOptions}
               value={model}
-              maxLength={256}
-              placeholder="Leave blank to use the default model"
-              onChange={e => setModel(e.target.value)}
+              onValueChange={setModel}
+              isLoading={isLoadingModels}
+              placeholder="Use the default model"
+              modal
+              className="w-full"
             />
           </div>
         </div>

--- a/apps/web/src/app/(app)/claw/components/AgentCreateDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentCreateDialog.tsx
@@ -52,7 +52,7 @@ export function AgentCreateDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const { createAgent } = useClawAgentMutations();
-  const { modelOptions, isLoading: isLoadingModels } = useClawModelOptions();
+  const { modelOptions, isLoading: isLoadingModels, error: modelError } = useClawModelOptions();
   const [name, setName] = useState('');
   const [model, setModel] = useState('');
 
@@ -125,6 +125,7 @@ export function AgentCreateDialog({
               value={model}
               onValueChange={setModel}
               isLoading={isLoadingModels}
+              error={modelError}
               placeholder="Use the default model"
               modal
               className="w-full"

--- a/apps/web/src/app/(app)/claw/components/AgentCreateDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentCreateDialog.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { AnimatedDots } from './AnimatedDots';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useClawAgentMutations } from '../hooks/useClawHooks';
+
+// Derive a stable, unix-safe workspace path from the agent name so users never
+// have to type a machine path. Mirrors the controller's id normalization closely
+// enough to give each agent its own workspace directory.
+function workspaceFromName(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `/root/.openclaw/workspace-${slug || 'agent'}`;
+}
+
+export function AgentCreateDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { createAgent } = useClawAgentMutations();
+  const [name, setName] = useState('');
+  const [model, setModel] = useState('');
+
+  const trimmedName = name.trim();
+  const trimmedModel = model.trim();
+  const canSubmit = trimmedName.length > 0 && !createAgent.isPending;
+
+  const reset = () => {
+    setName('');
+    setModel('');
+  };
+
+  const close = (next: boolean) => {
+    if (createAgent.isPending) return;
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const onSubmit = async () => {
+    if (!canSubmit) return;
+    try {
+      await createAgent.mutateAsync({
+        name: trimmedName,
+        workspace: workspaceFromName(trimmedName),
+        model: trimmedModel || undefined,
+      });
+      toast.success(`Created agent ${trimmedName}`);
+      reset();
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to create agent', {
+        duration: 10000,
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>New agent</DialogTitle>
+          <DialogDescription>
+            Stands up a new agent on your machine. You can route channels to it after it is created.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="agent-name">Name</Label>
+            <Input
+              id="agent-name"
+              value={name}
+              maxLength={64}
+              placeholder="research"
+              onChange={e => setName(e.target.value)}
+              autoFocus
+            />
+            {trimmedName.length > 0 && (
+              <p className="text-muted-foreground text-xs">
+                Workspace: {workspaceFromName(trimmedName)}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="agent-model">Model (optional)</Label>
+            <Input
+              id="agent-model"
+              value={model}
+              maxLength={256}
+              placeholder="Leave blank to use the default model"
+              onChange={e => setModel(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => close(false)} disabled={createAgent.isPending}>
+            Cancel
+          </Button>
+          <Button onClick={onSubmit} disabled={!canSubmit}>
+            {createAgent.isPending ? (
+              <>
+                Creating
+                <AnimatedDots />
+              </>
+            ) : (
+              'Create agent'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/AgentCreateDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentCreateDialog.tsx
@@ -17,16 +17,29 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useClawAgentMutations } from '../hooks/useClawHooks';
 
+// Mirror of the controller's normalizeAgentId (openclaw-agent-config.ts) so the
+// derived workspace is 1:1 with the agent id the controller will assign. Using
+// the controller's exact charset (underscores preserved, not collapsed to '-')
+// is what keeps distinct agents like `foo_bar` and `foo-bar` from sharing a
+// workspace directory.
+function normalizeAgentId(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return 'main';
+  const lower = trimmed.toLowerCase();
+  if (/^[a-z0-9][a-z0-9_-]{0,63}$/i.test(trimmed)) return lower;
+  return (
+    lower
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+/, '')
+      .replace(/-+$/, '')
+      .slice(0, 64) || 'main'
+  );
+}
+
 // Derive a stable, unix-safe workspace path from the agent name so users never
-// have to type a machine path. Mirrors the controller's id normalization closely
-// enough to give each agent its own workspace directory.
+// have to type a machine path. Keyed on the normalized agent id for uniqueness.
 function workspaceFromName(name: string): string {
-  const slug = name
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9-]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  return `/root/.openclaw/workspace-${slug || 'agent'}`;
+  return `/root/.openclaw/workspace-${normalizeAgentId(name)}`;
 }
 
 export function AgentCreateDialog({

--- a/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import { AnimatedDots } from './AnimatedDots';
+import { ModelCombobox } from '@/components/shared/ModelCombobox';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -14,7 +15,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
   Select,
@@ -26,6 +26,7 @@ import {
 import type { AgentUpdateInput } from '@/lib/kiloclaw/agent-schemas';
 import type { AgentSummary } from '@/lib/kiloclaw/types';
 import { useClawAgentMutations } from '../hooks/useClawHooks';
+import { useClawModelOptions } from '../hooks/useClawModelOptions';
 
 const INHERIT = 'inherit';
 const THINKING = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'adaptive', 'max'] as const;
@@ -90,6 +91,7 @@ export function AgentEditDialog({
   etag: string;
 }) {
   const { updateAgent } = useClawAgentMutations();
+  const { modelOptions, isLoading: isLoadingModels } = useClawModelOptions();
 
   const initial = useMemo(() => ownModel(agent), [agent]);
   // An agent owns a model when rawModel is set — including a fallback-only model
@@ -220,12 +222,15 @@ export function AgentEditDialog({
             </div>
             {!inheritModel && (
               <>
-                <Input
-                  id="agent-edit-model"
+                <ModelCombobox
+                  label=""
+                  models={modelOptions}
                   value={primary}
-                  maxLength={256}
-                  placeholder="Model id (e.g. kilocode/kilo-auto/balanced)"
-                  onChange={e => setPrimary(e.target.value)}
+                  onValueChange={setPrimary}
+                  isLoading={isLoadingModels}
+                  placeholder="Select a model"
+                  modal
+                  className="w-full"
                 />
                 {initial.fallbacks.length > 0 && (
                   <p className="text-muted-foreground text-xs">

--- a/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 
 import { AnimatedDots } from './AnimatedDots';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -91,6 +92,10 @@ export function AgentEditDialog({
   const { updateAgent } = useClawAgentMutations();
 
   const initial = useMemo(() => ownModel(agent), [agent]);
+  // An agent owns a model when rawModel is set — including a fallback-only model
+  // (no primary). The inherit toggle is the only way to clear such a model.
+  const hadOwnModel = agent.rawModel != null;
+  const [inheritModel, setInheritModel] = useState(!hadOwnModel);
   const [primary, setPrimary] = useState(initial.primary);
   const [thinking, setThinking] = useState<ThinkingOpt>(
     (agent.settings.thinkingDefault as ThinkingOpt | null) ?? INHERIT
@@ -114,14 +119,18 @@ export function AgentEditDialog({
     const set: AgentUpdateInput['set'] = {};
     const unset: AgentUpdateInput['unset'] = [];
 
-    const newPrimary = primary.trim();
-    if (newPrimary !== initial.primary) {
-      if (newPrimary === '') {
-        unset.push('model'); // clearing primary clears the whole model entry
-      } else {
+    if (inheritModel) {
+      // Clear the agent's own model (primary-only OR fallback-only) so it falls
+      // back to the fleet default.
+      if (hadOwnModel) unset.push('model');
+    } else {
+      const newPrimary = primary.trim();
+      const fallbacks = initial.fallbacks; // preserved; not edited here
+      const changed = !hadOwnModel || newPrimary !== initial.primary;
+      if (changed && (newPrimary !== '' || fallbacks.length > 0)) {
         set.model = {
-          primary: newPrimary,
-          ...(initial.fallbacks.length > 0 ? { fallbacks: initial.fallbacks } : {}),
+          ...(newPrimary !== '' ? { primary: newPrimary } : {}),
+          ...(fallbacks.length > 0 ? { fallbacks } : {}),
         };
       }
     }
@@ -152,10 +161,22 @@ export function AgentEditDialog({
     }
 
     return { set, unset };
-  }, [primary, thinking, verbose, reasoning, fastMode, initial, agent.settings]);
+  }, [
+    inheritModel,
+    hadOwnModel,
+    primary,
+    thinking,
+    verbose,
+    reasoning,
+    fastMode,
+    initial,
+    agent.settings,
+  ]);
 
+  // Not inheriting but no primary and no fallbacks = no model to write.
+  const modelInvalid = !inheritModel && primary.trim() === '' && initial.fallbacks.length === 0;
   const hasChanges = Object.keys(patch.set).length > 0 || patch.unset.length > 0;
-  const canSubmit = hasChanges && !updateAgent.isPending;
+  const canSubmit = hasChanges && !modelInvalid && !updateAgent.isPending;
 
   const onSubmit = async () => {
     if (!canSubmit) return;
@@ -182,19 +203,41 @@ export function AgentEditDialog({
         </DialogHeader>
 
         <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="agent-edit-model">Model</Label>
-            <Input
-              id="agent-edit-model"
-              value={primary}
-              maxLength={256}
-              placeholder="Blank to inherit the default model"
-              onChange={e => setPrimary(e.target.value)}
-            />
-            {initial.fallbacks.length > 0 && (
-              <p className="text-muted-foreground text-xs">
-                Fallbacks preserved: {initial.fallbacks.join(', ')}
-              </p>
+          <div className="flex flex-col gap-2">
+            <Label>Model</Label>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="agent-edit-inherit-model"
+                checked={inheritModel}
+                onCheckedChange={checked => setInheritModel(checked === true)}
+              />
+              <Label
+                htmlFor="agent-edit-inherit-model"
+                className="text-muted-foreground font-normal"
+              >
+                Use the default model
+              </Label>
+            </div>
+            {!inheritModel && (
+              <>
+                <Input
+                  id="agent-edit-model"
+                  value={primary}
+                  maxLength={256}
+                  placeholder="Model id (e.g. kilocode/kilo-auto/balanced)"
+                  onChange={e => setPrimary(e.target.value)}
+                />
+                {initial.fallbacks.length > 0 && (
+                  <p className="text-muted-foreground text-xs">
+                    Fallbacks preserved: {initial.fallbacks.join(', ')}
+                  </p>
+                )}
+                {modelInvalid && (
+                  <p className="text-destructive text-xs">
+                    Enter a model id, or use the default model.
+                  </p>
+                )}
+              </>
             )}
           </div>
 

--- a/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+import { AnimatedDots } from './AnimatedDots';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { AgentUpdateInput } from '@/lib/kiloclaw/agent-schemas';
+import type { AgentSummary } from '@/lib/kiloclaw/types';
+import { useClawAgentMutations } from '../hooks/useClawHooks';
+
+const INHERIT = 'inherit';
+const THINKING = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'adaptive', 'max'] as const;
+const VERBOSE = ['off', 'on', 'full'] as const;
+const REASONING = ['on', 'off', 'stream'] as const;
+
+type ThinkingOpt = typeof INHERIT | (typeof THINKING)[number];
+type VerboseOpt = typeof INHERIT | (typeof VERBOSE)[number];
+type ReasoningOpt = typeof INHERIT | (typeof REASONING)[number];
+type FastModeOpt = typeof INHERIT | 'on' | 'off';
+
+// The agent's OWN model (not the inherited/effective one): primary + fallbacks.
+function ownModel(agent: AgentSummary): { primary: string; fallbacks: string[] } {
+  const raw = agent.rawModel;
+  if (typeof raw === 'string') return { primary: raw, fallbacks: [] };
+  if (raw && typeof raw === 'object') {
+    return { primary: raw.primary ?? '', fallbacks: raw.fallbacks ?? [] };
+  }
+  return { primary: '', fallbacks: [] };
+}
+
+function LabeledSelect<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: T;
+  options: readonly T[];
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label>{label}</Label>
+      <Select value={value} onValueChange={v => onChange(v as T)}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={INHERIT}>Inherit default</SelectItem>
+          {options.map(opt => (
+            <SelectItem key={opt} value={opt}>
+              {opt}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+export function AgentEditDialog({
+  open,
+  onOpenChange,
+  agent,
+  etag,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agent: AgentSummary;
+  etag: string;
+}) {
+  const { updateAgent } = useClawAgentMutations();
+
+  const initial = useMemo(() => ownModel(agent), [agent]);
+  const [primary, setPrimary] = useState(initial.primary);
+  const [thinking, setThinking] = useState<ThinkingOpt>(
+    (agent.settings.thinkingDefault as ThinkingOpt | null) ?? INHERIT
+  );
+  const [verbose, setVerbose] = useState<VerboseOpt>(
+    (agent.settings.verboseDefault as VerboseOpt | null) ?? INHERIT
+  );
+  const [reasoning, setReasoning] = useState<ReasoningOpt>(
+    (agent.settings.reasoningDefault as ReasoningOpt | null) ?? INHERIT
+  );
+  const [fastMode, setFastMode] = useState<FastModeOpt>(
+    agent.settings.fastModeDefault === null
+      ? INHERIT
+      : agent.settings.fastModeDefault
+        ? 'on'
+        : 'off'
+  );
+
+  // Diff the form against the agent's current values into a controller patch.
+  const patch = useMemo(() => {
+    const set: AgentUpdateInput['set'] = {};
+    const unset: AgentUpdateInput['unset'] = [];
+
+    const newPrimary = primary.trim();
+    if (newPrimary !== initial.primary) {
+      if (newPrimary === '') {
+        unset.push('model'); // clearing primary clears the whole model entry
+      } else {
+        set.model = {
+          primary: newPrimary,
+          ...(initial.fallbacks.length > 0 ? { fallbacks: initial.fallbacks } : {}),
+        };
+      }
+    }
+
+    if (thinking === INHERIT) {
+      if (agent.settings.thinkingDefault !== null) unset.push('thinkingDefault');
+    } else if (thinking !== agent.settings.thinkingDefault) {
+      set.thinkingDefault = thinking;
+    }
+
+    if (verbose === INHERIT) {
+      if (agent.settings.verboseDefault !== null) unset.push('verboseDefault');
+    } else if (verbose !== agent.settings.verboseDefault) {
+      set.verboseDefault = verbose;
+    }
+
+    if (reasoning === INHERIT) {
+      if (agent.settings.reasoningDefault !== null) unset.push('reasoningDefault');
+    } else if (reasoning !== agent.settings.reasoningDefault) {
+      set.reasoningDefault = reasoning;
+    }
+
+    if (fastMode === INHERIT) {
+      if (agent.settings.fastModeDefault !== null) unset.push('fastModeDefault');
+    } else {
+      const next = fastMode === 'on';
+      if (next !== agent.settings.fastModeDefault) set.fastModeDefault = next;
+    }
+
+    return { set, unset };
+  }, [primary, thinking, verbose, reasoning, fastMode, initial, agent.settings]);
+
+  const hasChanges = Object.keys(patch.set).length > 0 || patch.unset.length > 0;
+  const canSubmit = hasChanges && !updateAgent.isPending;
+
+  const onSubmit = async () => {
+    if (!canSubmit) return;
+    try {
+      await updateAgent.mutateAsync(agent.id, { etag, set: patch.set, unset: patch.unset });
+      toast.success(`Updated ${agent.name ?? agent.id}`);
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update agent', {
+        duration: 10000,
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={updateAgent.isPending ? undefined : onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit {agent.name ?? agent.id}</DialogTitle>
+          <DialogDescription>
+            Model and behavior for this agent. Leave a field on “Inherit default” to use the
+            fleet-wide setting.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="agent-edit-model">Model</Label>
+            <Input
+              id="agent-edit-model"
+              value={primary}
+              maxLength={256}
+              placeholder="Blank to inherit the default model"
+              onChange={e => setPrimary(e.target.value)}
+            />
+            {initial.fallbacks.length > 0 && (
+              <p className="text-muted-foreground text-xs">
+                Fallbacks preserved: {initial.fallbacks.join(', ')}
+              </p>
+            )}
+          </div>
+
+          <LabeledSelect
+            label="Thinking"
+            value={thinking}
+            options={THINKING}
+            onChange={setThinking}
+          />
+          <LabeledSelect label="Verbose" value={verbose} options={VERBOSE} onChange={setVerbose} />
+          <LabeledSelect
+            label="Reasoning"
+            value={reasoning}
+            options={REASONING}
+            onChange={setReasoning}
+          />
+          <LabeledSelect
+            label="Fast mode"
+            value={fastMode}
+            options={['on', 'off'] as const}
+            onChange={setFastMode}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={updateAgent.isPending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={onSubmit} disabled={!canSubmit}>
+            {updateAgent.isPending ? (
+              <>
+                Saving
+                <AnimatedDots />
+              </>
+            ) : (
+              'Save changes'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
@@ -40,6 +40,13 @@ type VerboseOpt = typeof INHERIT | (typeof VERBOSE_OPTIONS)[number];
 type ReasoningOpt = typeof INHERIT | (typeof REASONING_OPTIONS)[number];
 type FastModeOpt = typeof INHERIT | 'on' | 'off';
 
+// Map a controller-reported setting value (string | null) to a select option,
+// matching against the known options rather than casting; anything unrecognized
+// (including null) falls back to INHERIT.
+function toOption<T extends string>(raw: string | null, options: readonly T[]): typeof INHERIT | T {
+  return options.find(opt => opt === raw) ?? INHERIT;
+}
+
 // The agent's OWN model (not the inherited/effective one): primary + fallbacks.
 function ownModel(agent: AgentSummary): { primary: string; fallbacks: string[] } {
   const raw = agent.rawModel;
@@ -61,10 +68,19 @@ function LabeledSelect<T extends string>({
   options: readonly T[];
   onChange: (value: T) => void;
 }) {
+  // Radix's onValueChange hands back a plain string. Narrow it to a known value
+  // (INHERIT, which is always rendered, or one of the options) before calling
+  // onChange instead of casting, so an unexpected value can't reach the patch.
+  const isValue = (v: string): v is T => v === INHERIT || options.some(opt => opt === v);
   return (
     <div className="flex flex-col gap-1.5">
       <Label>{label}</Label>
-      <Select value={value} onValueChange={v => onChange(v as T)}>
+      <Select
+        value={value}
+        onValueChange={v => {
+          if (isValue(v)) onChange(v);
+        }}
+      >
         <SelectTrigger>
           <SelectValue />
         </SelectTrigger>
@@ -102,13 +118,13 @@ export function AgentEditDialog({
   const [inheritModel, setInheritModel] = useState(!hadOwnModel);
   const [primary, setPrimary] = useState(initial.primary);
   const [thinking, setThinking] = useState<ThinkingOpt>(
-    (agent.settings.thinkingDefault as ThinkingOpt | null) ?? INHERIT
+    toOption(agent.settings.thinkingDefault, THINKING_OPTIONS)
   );
   const [verbose, setVerbose] = useState<VerboseOpt>(
-    (agent.settings.verboseDefault as VerboseOpt | null) ?? INHERIT
+    toOption(agent.settings.verboseDefault, VERBOSE_OPTIONS)
   );
   const [reasoning, setReasoning] = useState<ReasoningOpt>(
-    (agent.settings.reasoningDefault as ReasoningOpt | null) ?? INHERIT
+    toOption(agent.settings.reasoningDefault, REASONING_OPTIONS)
   );
   const [fastMode, setFastMode] = useState<FastModeOpt>(
     agent.settings.fastModeDefault === null

--- a/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
@@ -32,6 +32,7 @@ import {
 import type { AgentSummary } from '@/lib/kiloclaw/types';
 import { useClawAgentMutations } from '../hooks/useClawHooks';
 import { useClawModelOptions } from '../hooks/useClawModelOptions';
+import { addKilocodeModelPrefix, stripKilocodeModelPrefix } from './modelSupport';
 
 const INHERIT = 'inherit';
 
@@ -111,30 +112,47 @@ export function AgentEditDialog({
   const { updateAgent } = useClawAgentMutations();
   const { modelOptions, isLoading: isLoadingModels, error: modelError } = useClawModelOptions();
 
-  const initial = useMemo(() => ownModel(agent), [agent]);
+  // Work in bare (un-prefixed) model-id space so the combobox value matches the
+  // catalog options; the kilocode/ prefix is re-added when writing.
+  const initial = useMemo(() => {
+    const own = ownModel(agent);
+    return { primary: stripKilocodeModelPrefix(own.primary), fallbacks: own.fallbacks };
+  }, [agent]);
+  // Initial select values. toOption maps null OR an unknown (forward-compat)
+  // value to INHERIT; we diff against THESE rather than the raw settings so an
+  // unknown value left untouched is never mistaken for an explicit unset and
+  // silently deleted on an unrelated save.
+  const initialSettings = useMemo(
+    (): {
+      thinking: ThinkingOpt;
+      verbose: VerboseOpt;
+      reasoning: ReasoningOpt;
+      fastMode: FastModeOpt;
+    } => ({
+      thinking: toOption(agent.settings.thinkingDefault, THINKING_OPTIONS),
+      verbose: toOption(agent.settings.verboseDefault, VERBOSE_OPTIONS),
+      reasoning: toOption(agent.settings.reasoningDefault, REASONING_OPTIONS),
+      fastMode:
+        agent.settings.fastModeDefault === null
+          ? INHERIT
+          : agent.settings.fastModeDefault
+            ? 'on'
+            : 'off',
+    }),
+    [agent.settings]
+  );
+
   // An agent owns a model when rawModel is set — including a fallback-only model
   // (no primary). The inherit toggle is the only way to clear such a model.
   const hadOwnModel = agent.rawModel != null;
   const [inheritModel, setInheritModel] = useState(!hadOwnModel);
   const [primary, setPrimary] = useState(initial.primary);
-  const [thinking, setThinking] = useState<ThinkingOpt>(
-    toOption(agent.settings.thinkingDefault, THINKING_OPTIONS)
-  );
-  const [verbose, setVerbose] = useState<VerboseOpt>(
-    toOption(agent.settings.verboseDefault, VERBOSE_OPTIONS)
-  );
-  const [reasoning, setReasoning] = useState<ReasoningOpt>(
-    toOption(agent.settings.reasoningDefault, REASONING_OPTIONS)
-  );
-  const [fastMode, setFastMode] = useState<FastModeOpt>(
-    agent.settings.fastModeDefault === null
-      ? INHERIT
-      : agent.settings.fastModeDefault
-        ? 'on'
-        : 'off'
-  );
+  const [thinking, setThinking] = useState<ThinkingOpt>(initialSettings.thinking);
+  const [verbose, setVerbose] = useState<VerboseOpt>(initialSettings.verbose);
+  const [reasoning, setReasoning] = useState<ReasoningOpt>(initialSettings.reasoning);
+  const [fastMode, setFastMode] = useState<FastModeOpt>(initialSettings.fastMode);
 
-  // Diff the form against the agent's current values into a controller patch.
+  // Diff the form against the initial values into a controller patch.
   const patch = useMemo(() => {
     const set: AgentUpdateInput['set'] = {};
     const unset: AgentUpdateInput['unset'] = [];
@@ -149,35 +167,29 @@ export function AgentEditDialog({
       const changed = !hadOwnModel || newPrimary !== initial.primary;
       if (changed && (newPrimary !== '' || fallbacks.length > 0)) {
         set.model = {
-          ...(newPrimary !== '' ? { primary: newPrimary } : {}),
+          ...(newPrimary !== '' ? { primary: addKilocodeModelPrefix(newPrimary) } : {}),
           ...(fallbacks.length > 0 ? { fallbacks } : {}),
         };
       }
     }
 
-    if (thinking === INHERIT) {
-      if (agent.settings.thinkingDefault !== null) unset.push('thinkingDefault');
-    } else if (thinking !== agent.settings.thinkingDefault) {
-      set.thinkingDefault = thinking;
+    // Only emit a setting change when it differs from its initial select value,
+    // so an untouched (incl. unknown) value never produces a spurious unset.
+    if (thinking !== initialSettings.thinking) {
+      if (thinking === INHERIT) unset.push('thinkingDefault');
+      else set.thinkingDefault = thinking;
     }
-
-    if (verbose === INHERIT) {
-      if (agent.settings.verboseDefault !== null) unset.push('verboseDefault');
-    } else if (verbose !== agent.settings.verboseDefault) {
-      set.verboseDefault = verbose;
+    if (verbose !== initialSettings.verbose) {
+      if (verbose === INHERIT) unset.push('verboseDefault');
+      else set.verboseDefault = verbose;
     }
-
-    if (reasoning === INHERIT) {
-      if (agent.settings.reasoningDefault !== null) unset.push('reasoningDefault');
-    } else if (reasoning !== agent.settings.reasoningDefault) {
-      set.reasoningDefault = reasoning;
+    if (reasoning !== initialSettings.reasoning) {
+      if (reasoning === INHERIT) unset.push('reasoningDefault');
+      else set.reasoningDefault = reasoning;
     }
-
-    if (fastMode === INHERIT) {
-      if (agent.settings.fastModeDefault !== null) unset.push('fastModeDefault');
-    } else {
-      const next = fastMode === 'on';
-      if (next !== agent.settings.fastModeDefault) set.fastModeDefault = next;
+    if (fastMode !== initialSettings.fastMode) {
+      if (fastMode === INHERIT) unset.push('fastModeDefault');
+      else set.fastModeDefault = fastMode === 'on';
     }
 
     return { set, unset };
@@ -190,7 +202,7 @@ export function AgentEditDialog({
     reasoning,
     fastMode,
     initial,
-    agent.settings,
+    initialSettings,
   ]);
 
   // Not inheriting but no primary and no fallbacks = no model to write.

--- a/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentEditDialog.tsx
@@ -23,19 +23,21 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import type { AgentUpdateInput } from '@/lib/kiloclaw/agent-schemas';
+import {
+  REASONING_OPTIONS,
+  THINKING_OPTIONS,
+  VERBOSE_OPTIONS,
+  type AgentUpdateInput,
+} from '@/lib/kiloclaw/agent-schemas';
 import type { AgentSummary } from '@/lib/kiloclaw/types';
 import { useClawAgentMutations } from '../hooks/useClawHooks';
 import { useClawModelOptions } from '../hooks/useClawModelOptions';
 
 const INHERIT = 'inherit';
-const THINKING = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'adaptive', 'max'] as const;
-const VERBOSE = ['off', 'on', 'full'] as const;
-const REASONING = ['on', 'off', 'stream'] as const;
 
-type ThinkingOpt = typeof INHERIT | (typeof THINKING)[number];
-type VerboseOpt = typeof INHERIT | (typeof VERBOSE)[number];
-type ReasoningOpt = typeof INHERIT | (typeof REASONING)[number];
+type ThinkingOpt = typeof INHERIT | (typeof THINKING_OPTIONS)[number];
+type VerboseOpt = typeof INHERIT | (typeof VERBOSE_OPTIONS)[number];
+type ReasoningOpt = typeof INHERIT | (typeof REASONING_OPTIONS)[number];
 type FastModeOpt = typeof INHERIT | 'on' | 'off';
 
 // The agent's OWN model (not the inherited/effective one): primary + fallbacks.
@@ -91,7 +93,7 @@ export function AgentEditDialog({
   etag: string;
 }) {
   const { updateAgent } = useClawAgentMutations();
-  const { modelOptions, isLoading: isLoadingModels } = useClawModelOptions();
+  const { modelOptions, isLoading: isLoadingModels, error: modelError } = useClawModelOptions();
 
   const initial = useMemo(() => ownModel(agent), [agent]);
   // An agent owns a model when rawModel is set — including a fallback-only model
@@ -228,6 +230,7 @@ export function AgentEditDialog({
                   value={primary}
                   onValueChange={setPrimary}
                   isLoading={isLoadingModels}
+                  error={modelError}
                   placeholder="Select a model"
                   modal
                   className="w-full"
@@ -249,14 +252,19 @@ export function AgentEditDialog({
           <LabeledSelect
             label="Thinking"
             value={thinking}
-            options={THINKING}
+            options={THINKING_OPTIONS}
             onChange={setThinking}
           />
-          <LabeledSelect label="Verbose" value={verbose} options={VERBOSE} onChange={setVerbose} />
+          <LabeledSelect
+            label="Verbose"
+            value={verbose}
+            options={VERBOSE_OPTIONS}
+            onChange={setVerbose}
+          />
           <LabeledSelect
             label="Reasoning"
             value={reasoning}
-            options={REASONING}
+            options={REASONING_OPTIONS}
             onChange={setReasoning}
           />
           <LabeledSelect

--- a/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
@@ -32,16 +32,20 @@ function settingChips(settings: AgentSettingsSummary): string[] {
 
 function AgentRow({
   agent,
+  canUpdate,
+  canDelete,
   onEdit,
   onDelete,
 }: {
   agent: AgentSummary;
+  canUpdate: boolean;
+  canDelete: boolean;
   onEdit: () => void;
   onDelete: () => void;
 }) {
   const settings = settingChips(agent.settings);
   // `main` is reserved and cannot be deleted (controller rejects it).
-  const canDelete = agent.id !== 'main';
+  const deletable = canDelete && agent.id !== 'main';
 
   return (
     <div className="px-4 py-3">
@@ -55,28 +59,32 @@ function AgentRow({
             </Badge>
           )}
         </div>
-        <div className="flex shrink-0 items-center gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 px-2"
-            onClick={onEdit}
-            aria-label="Edit agent"
-          >
-            <Pencil className="h-3.5 w-3.5" />
-          </Button>
-          {canDelete && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-destructive hover:text-destructive h-7 px-2"
-              onClick={onDelete}
-              aria-label="Delete agent"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
-          )}
-        </div>
+        {(canUpdate || deletable) && (
+          <div className="flex shrink-0 items-center gap-1">
+            {canUpdate && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2"
+                onClick={onEdit}
+                aria-label="Edit agent"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </Button>
+            )}
+            {deletable && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-destructive hover:text-destructive h-7 px-2"
+                onClick={onDelete}
+                aria-label="Delete agent"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="text-muted-foreground mt-1 text-xs">
@@ -139,12 +147,25 @@ function DefaultsRow({ defaults }: { defaults: AgentDefaultsSummary }) {
  * routed to each, with create / edit / delete. Gated by the controller's
  * `config.agents.read` capability and admin status at the call site.
  */
-export function AgentsSection({ enabled }: { enabled: boolean }) {
+export function AgentsSection({
+  enabled,
+  canCreate,
+  canUpdate,
+  canDelete,
+}: {
+  enabled: boolean;
+  canCreate: boolean;
+  canUpdate: boolean;
+  canDelete: boolean;
+}) {
   const { data, isLoading, error } = useClawAgents(enabled);
   const { deleteAgent } = useClawAgentMutations();
 
   const [createOpen, setCreateOpen] = useState(false);
-  const [editTarget, setEditTarget] = useState<AgentSummary | null>(null);
+  // Freeze the agent AND the etag together when opening the editor, so a
+  // background list refetch can't advance the etag under a stale form (which
+  // would let a save bypass the optimistic-concurrency check).
+  const [editTarget, setEditTarget] = useState<{ agent: AgentSummary; etag: string } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<AgentSummary | null>(null);
 
   const onConfirmDelete = async () => {
@@ -162,7 +183,7 @@ export function AgentsSection({ enabled }: { enabled: boolean }) {
 
   return (
     <div>
-      {enabled && data && (
+      {enabled && data && canCreate && (
         <div className="mb-3 flex justify-end">
           <Button size="sm" onClick={() => setCreateOpen(true)}>
             <Plus className="h-4 w-4" />
@@ -191,7 +212,9 @@ export function AgentsSection({ enabled }: { enabled: boolean }) {
               <AgentRow
                 key={agent.id}
                 agent={agent}
-                onEdit={() => setEditTarget(agent)}
+                canUpdate={canUpdate}
+                canDelete={canDelete}
+                onEdit={() => setEditTarget({ agent, etag: data.etag })}
                 onDelete={() => setDeleteTarget(agent)}
               />
             ))}
@@ -206,14 +229,14 @@ export function AgentsSection({ enabled }: { enabled: boolean }) {
 
       <AgentCreateDialog open={createOpen} onOpenChange={setCreateOpen} />
 
-      {data && editTarget && (
+      {editTarget && (
         <AgentEditDialog
           open
           onOpenChange={open => {
             if (!open) setEditTarget(null);
           }}
-          agent={editTarget}
-          etag={data.etag}
+          agent={editTarget.agent}
+          etag={editTarget.etag}
         />
       )}
 

--- a/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import type {
+  AgentDefaultsSummary,
+  AgentSettingsSummary,
+  AgentSummary,
+} from '@/lib/kiloclaw/types';
+
+import { useClawAgents } from '../hooks/useClawHooks';
+
+// Compact, human-readable list of the per-agent behavioral settings that are
+// actually set (null = inherits the default, so we omit it).
+function settingChips(settings: AgentSettingsSummary): string[] {
+  const chips: string[] = [];
+  if (settings.thinkingDefault) chips.push(`thinking: ${settings.thinkingDefault}`);
+  if (settings.verboseDefault) chips.push(`verbose: ${settings.verboseDefault}`);
+  if (settings.reasoningDefault) chips.push(`reasoning: ${settings.reasoningDefault}`);
+  if (settings.fastModeDefault != null) {
+    chips.push(`fast mode: ${settings.fastModeDefault ? 'on' : 'off'}`);
+  }
+  return chips;
+}
+
+function AgentRow({ agent }: { agent: AgentSummary }) {
+  const settings = settingChips(agent.settings);
+
+  return (
+    <div className="px-4 py-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium">{agent.name ?? agent.id}</span>
+        {agent.name && <span className="text-muted-foreground text-xs">{agent.id}</span>}
+        {!agent.configured && (
+          <Badge variant="secondary" className="px-1.5 py-0 text-[10px] leading-4">
+            Default
+          </Badge>
+        )}
+      </div>
+
+      <div className="text-muted-foreground mt-1 text-xs">
+        Model:{' '}
+        {agent.model.primary ? (
+          <span className="text-foreground">
+            {agent.model.primary}
+            {agent.model.source === 'defaults' && (
+              <span className="text-muted-foreground"> (inherited)</span>
+            )}
+          </span>
+        ) : (
+          'uses default'
+        )}
+      </div>
+
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <span className="text-muted-foreground text-xs">Channels:</span>
+        {agent.bindings.length === 0 ? (
+          <span className="text-muted-foreground text-xs">none</span>
+        ) : (
+          agent.bindings.map(binding => (
+            <Badge
+              key={`${binding.channel}:${binding.accountId ?? ''}`}
+              variant="outline"
+              className="px-1.5 py-0 text-[10px] leading-4"
+            >
+              {binding.channel}
+              {binding.accountId ? ` (${binding.accountId})` : ''}
+              {binding.advanced ? ' · advanced' : ''}
+            </Badge>
+          ))
+        )}
+      </div>
+
+      {settings.length > 0 && (
+        <div className="text-muted-foreground mt-2 text-xs">{settings.join(' · ')}</div>
+      )}
+    </div>
+  );
+}
+
+function DefaultsRow({ defaults }: { defaults: AgentDefaultsSummary }) {
+  const settings = settingChips(defaults.settings);
+
+  return (
+    <div className="text-muted-foreground bg-muted/30 px-4 py-3 text-xs">
+      <span className="font-medium">Inherited defaults</span> · Model:{' '}
+      {defaults.model?.primary ?? 'none'}
+      {settings.length > 0 && ` · ${settings.join(' · ')}`}
+    </div>
+  );
+}
+
+/**
+ * Read-only view of the agents running on the user's machine and the channels
+ * routed to each. Gated by the controller's `config.agents.read` capability at
+ * the call site (SettingsTab).
+ */
+export function AgentsSection({ enabled }: { enabled: boolean }) {
+  const { data, isLoading, error } = useClawAgents(enabled);
+
+  return (
+    <div>
+      <div className="rounded-lg border">
+        {!enabled ? (
+          <div className="text-muted-foreground px-4 py-3 text-xs">
+            Start your machine to view its agents.
+          </div>
+        ) : isLoading ? (
+          <div className="text-muted-foreground flex items-center gap-2 px-4 py-3 text-xs">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Loading agents…
+          </div>
+        ) : error ? (
+          <div className="text-destructive px-4 py-3 text-xs">Failed to load agents.</div>
+        ) : !data || data.agents.length === 0 ? (
+          <div className="text-muted-foreground px-4 py-3 text-xs">No agents configured.</div>
+        ) : (
+          <div className="[&>*+*]:border-t">
+            {data.agents.map(agent => (
+              <AgentRow key={agent.id} agent={agent} />
+            ))}
+            <DefaultsRow defaults={data.defaults} />
+          </div>
+        )}
+      </div>
+      <p className="text-muted-foreground mt-2 text-xs">
+        The agents running on your machine and the channels routed to each.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
@@ -65,7 +65,10 @@ function AgentRow({ agent }: { agent: AgentSummary }) {
               className="px-1.5 py-0 text-[10px] leading-4"
             >
               {binding.channel}
-              {binding.accountId ? ` (${binding.accountId})` : ''}
+              {/* accountId is verbatim; null = default-account route. An empty
+                  string is still an account-scoped route, so test against null. */}
+              {binding.accountId !== null &&
+                ` (${binding.accountId === '' ? 'blank account' : binding.accountId})`}
               {binding.advanced ? ' · advanced' : ''}
             </Badge>
           ))

--- a/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
@@ -137,11 +137,17 @@ function AgentRow({
 
 function DefaultsRow({ defaults }: { defaults: AgentDefaultsSummary }) {
   const settings = settingChips(defaults.settings);
+  // Defaults can be fallback-only (primary null, fallbacks set) — don't show "none".
+  const modelLabel = defaults.model
+    ? defaults.model.primary ||
+      (defaults.model.fallbacks.length > 0
+        ? `fallbacks: ${defaults.model.fallbacks.join(', ')}`
+        : 'none')
+    : 'none';
 
   return (
     <div className="text-muted-foreground bg-muted/30 px-4 py-3 text-xs">
-      <span className="font-medium">Inherited defaults</span> · Model:{' '}
-      {defaults.model?.primary ?? 'none'}
+      <span className="font-medium">Inherited defaults</span> · Model: {modelLabel}
       {settings.length > 0 && ` · ${settings.join(' · ')}`}
     </div>
   );
@@ -232,7 +238,9 @@ export function AgentsSection({
         The agents running on your machine and the channels routed to each.
       </p>
 
-      <AgentCreateDialog open={createOpen} onOpenChange={setCreateOpen} />
+      {/* Mounted only while open so its model-catalog/version queries don't run
+          on every page visit (incl. read-only and stopped-machine states). */}
+      {createOpen && <AgentCreateDialog open onOpenChange={setCreateOpen} />}
 
       {editTarget && (
         <AgentEditDialog

--- a/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
@@ -1,15 +1,21 @@
 'use client';
 
-import { Loader2 } from 'lucide-react';
+import { Loader2, Pencil, Plus, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
 
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import type {
   AgentDefaultsSummary,
   AgentSettingsSummary,
   AgentSummary,
 } from '@/lib/kiloclaw/types';
 
-import { useClawAgents } from '../hooks/useClawHooks';
+import { useClawAgentMutations, useClawAgents } from '../hooks/useClawHooks';
+import { AgentCreateDialog } from './AgentCreateDialog';
+import { AgentEditDialog } from './AgentEditDialog';
+import { ConfirmActionDialog } from './ConfirmActionDialog';
 
 // Compact, human-readable list of the per-agent behavioral settings that are
 // actually set (null = inherits the default, so we omit it).
@@ -24,19 +30,53 @@ function settingChips(settings: AgentSettingsSummary): string[] {
   return chips;
 }
 
-function AgentRow({ agent }: { agent: AgentSummary }) {
+function AgentRow({
+  agent,
+  onEdit,
+  onDelete,
+}: {
+  agent: AgentSummary;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
   const settings = settingChips(agent.settings);
+  // `main` is reserved and cannot be deleted (controller rejects it).
+  const canDelete = agent.id !== 'main';
 
   return (
     <div className="px-4 py-3">
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="text-sm font-medium">{agent.name ?? agent.id}</span>
-        {agent.name && <span className="text-muted-foreground text-xs">{agent.id}</span>}
-        {!agent.configured && (
-          <Badge variant="secondary" className="px-1.5 py-0 text-[10px] leading-4">
-            Default
-          </Badge>
-        )}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="text-sm font-medium">{agent.name ?? agent.id}</span>
+          {agent.name && <span className="text-muted-foreground text-xs">{agent.id}</span>}
+          {!agent.configured && (
+            <Badge variant="secondary" className="px-1.5 py-0 text-[10px] leading-4">
+              Default
+            </Badge>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2"
+            onClick={onEdit}
+            aria-label="Edit agent"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          {canDelete && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-destructive hover:text-destructive h-7 px-2"
+              onClick={onDelete}
+              aria-label="Delete agent"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
       </div>
 
       <div className="text-muted-foreground mt-1 text-xs">
@@ -95,15 +135,42 @@ function DefaultsRow({ defaults }: { defaults: AgentDefaultsSummary }) {
 }
 
 /**
- * Read-only view of the agents running on the user's machine and the channels
- * routed to each. Gated by the controller's `config.agents.read` capability at
- * the call site (SettingsTab).
+ * Agents view: lists the fleet running on the user's machine and the channels
+ * routed to each, with create / edit / delete. Gated by the controller's
+ * `config.agents.read` capability and admin status at the call site.
  */
 export function AgentsSection({ enabled }: { enabled: boolean }) {
   const { data, isLoading, error } = useClawAgents(enabled);
+  const { deleteAgent } = useClawAgentMutations();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<AgentSummary | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AgentSummary | null>(null);
+
+  const onConfirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteAgent.mutateAsync(deleteTarget.id);
+      toast.success(`Deleted ${deleteTarget.name ?? deleteTarget.id}`);
+      setDeleteTarget(null);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete agent', {
+        duration: 10000,
+      });
+    }
+  };
 
   return (
     <div>
+      {enabled && data && (
+        <div className="mb-3 flex justify-end">
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4" />
+            New agent
+          </Button>
+        </div>
+      )}
+
       <div className="rounded-lg border">
         {!enabled ? (
           <div className="text-muted-foreground px-4 py-3 text-xs">
@@ -121,15 +188,48 @@ export function AgentsSection({ enabled }: { enabled: boolean }) {
         ) : (
           <div className="[&>*+*]:border-t">
             {data.agents.map(agent => (
-              <AgentRow key={agent.id} agent={agent} />
+              <AgentRow
+                key={agent.id}
+                agent={agent}
+                onEdit={() => setEditTarget(agent)}
+                onDelete={() => setDeleteTarget(agent)}
+              />
             ))}
             <DefaultsRow defaults={data.defaults} />
           </div>
         )}
       </div>
+
       <p className="text-muted-foreground mt-2 text-xs">
         The agents running on your machine and the channels routed to each.
       </p>
+
+      <AgentCreateDialog open={createOpen} onOpenChange={setCreateOpen} />
+
+      {data && editTarget && (
+        <AgentEditDialog
+          open
+          onOpenChange={open => {
+            if (!open) setEditTarget(null);
+          }}
+          agent={editTarget}
+          etag={data.etag}
+        />
+      )}
+
+      <ConfirmActionDialog
+        open={deleteTarget !== null}
+        onOpenChange={open => {
+          if (!open) setDeleteTarget(null);
+        }}
+        title="Delete agent"
+        description={`Delete "${deleteTarget?.name ?? deleteTarget?.id ?? ''}"? This removes the agent and its channel routing. Workspace files on the machine may remain.`}
+        confirmLabel="Delete"
+        isPending={deleteAgent.isPending}
+        pendingLabel="Deleting"
+        onConfirm={onConfirmDelete}
+        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+      />
     </div>
   );
 }

--- a/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
+++ b/apps/web/src/app/(app)/claw/components/AgentsSection.tsx
@@ -30,6 +30,23 @@ function settingChips(settings: AgentSettingsSummary): string[] {
   return chips;
 }
 
+// Render an agent's effective model. A fallback-only agent model (no primary)
+// still has source 'agent', so we must not collapse a null primary to "uses
+// default" — show the fallbacks instead. Only source === null truly inherits.
+function AgentModelLabel({ model }: { model: AgentSummary['model'] }) {
+  const label =
+    model.primary || (model.fallbacks.length > 0 ? `fallbacks: ${model.fallbacks.join(', ')}` : '');
+  if (model.source === null || label === '') {
+    return <>uses default</>;
+  }
+  return (
+    <span className="text-foreground">
+      {label}
+      {model.source === 'defaults' && <span className="text-muted-foreground"> (inherited)</span>}
+    </span>
+  );
+}
+
 function AgentRow({
   agent,
   canUpdate,
@@ -88,17 +105,7 @@ function AgentRow({
       </div>
 
       <div className="text-muted-foreground mt-1 text-xs">
-        Model:{' '}
-        {agent.model.primary ? (
-          <span className="text-foreground">
-            {agent.model.primary}
-            {agent.model.source === 'defaults' && (
-              <span className="text-muted-foreground"> (inherited)</span>
-            )}
-          </span>
-        ) : (
-          'uses default'
-        )}
+        Model: <AgentModelLabel model={agent.model} />
       </div>
 
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
@@ -106,12 +113,10 @@ function AgentRow({
         {agent.bindings.length === 0 ? (
           <span className="text-muted-foreground text-xs">none</span>
         ) : (
-          agent.bindings.map(binding => (
-            <Badge
-              key={`${binding.channel}:${binding.accountId ?? ''}`}
-              variant="outline"
-              className="px-1.5 py-0 text-[10px] leading-4"
-            >
+          // accountId null vs '' are distinct routes and advanced bindings can
+          // repeat channel+account, so the array index is the stable key here.
+          agent.bindings.map((binding, index) => (
+            <Badge key={index} variant="outline" className="px-1.5 py-0 text-[10px] leading-4">
               {binding.channel}
               {/* accountId is verbatim; null = default-account route. An empty
                   string is still an account-scoped route, so test against null. */}

--- a/apps/web/src/app/(app)/claw/components/ClawAgentsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawAgentsPage.tsx
@@ -2,14 +2,16 @@
 
 import { Bot } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 
 import { SetPageTitle } from '@/components/SetPageTitle';
+import { controllerVersionOk } from '@/lib/kiloclaw/types';
 import { Card, CardContent } from '@/components/ui/card';
 import { useKiloClawStatus } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawStatus } from '@/hooks/useOrgKiloClaw';
 import { useUser } from '@/hooks/useUser';
 
+import { useClawControllerVersion } from '../hooks/useClawHooks';
 import { AgentsSection } from './AgentsSection';
 import { BillingWrapper } from './billing/BillingWrapper';
 import { ClawContextProvider } from './ClawContext';
@@ -19,16 +21,28 @@ import { ClawContextProvider } from './ClawContext';
  * rendering the agents view. Mirrors ClawSettingsWithStatus, trimmed to the
  * read-only needs of this page.
  */
+function LoadingCard() {
+  return (
+    <Card>
+      <CardContent className="py-12 text-center">
+        <p className="text-muted-foreground">Loading…</p>
+      </CardContent>
+    </Card>
+  );
+}
+
 function ClawAgentsWithStatus({ organizationId }: { organizationId?: string }) {
   const router = useRouter();
-  const personalStatus = useKiloClawStatus();
+  // Disable the inactive status hook so it doesn't keep polling on the other context.
+  const personalStatus = useKiloClawStatus({ enabled: !organizationId });
   const orgStatus = useOrgKiloClawStatus(organizationId);
   const { data: status, isLoading, error } = organizationId ? orgStatus : personalStatus;
 
-  // Agent management is admin-only. Hide from non-admins and bounce direct hits
-  // back to settings. (The nav item is also gated on is_admin.)
+  // Agent management is admin-only. Fail CLOSED: proceed only on a confirmed
+  // is_admin. A null or errored user query (admin status unknown) bounces to
+  // settings, the same as a non-admin. (The nav item is also gated on is_admin.)
   const { data: user, isLoading: userLoading } = useUser();
-  const notAdmin = !userLoading && !!user && user.is_admin !== true;
+  const notAdmin = !userLoading && user?.is_admin !== true;
   const settingsUrl = organizationId
     ? `/organizations/${organizationId}/claw/settings`
     : '/claw/settings';
@@ -37,6 +51,14 @@ function ClawAgentsWithStatus({ organizationId }: { organizationId?: string }) {
       router.replace(settingsUrl);
     }
   }, [notAdmin, settingsUrl, router]);
+
+  // The agent endpoints ship behind a controller capability; older machine
+  // images don't advertise it and return 501. Gate on it so historical
+  // instances see an upgrade prompt rather than a broken page.
+  const running = status?.status === 'running';
+  const versionQuery = useClawControllerVersion(running);
+  const supportsAgentsRead =
+    controllerVersionOk(versionQuery.data)?.capabilities?.includes('config.agents.read') === true;
 
   const clawUrl = organizationId ? `/organizations/${organizationId}/claw/new` : '/claw/new';
   const shouldRedirect = !isLoading && !error && (!status || status.status === null);
@@ -47,13 +69,7 @@ function ClawAgentsWithStatus({ organizationId }: { organizationId?: string }) {
   }, [shouldRedirect, clawUrl, router]);
 
   if (userLoading || notAdmin || isLoading || shouldRedirect) {
-    return (
-      <Card>
-        <CardContent className="py-12 text-center">
-          <p className="text-muted-foreground">Loading…</p>
-        </CardContent>
-      </Card>
-    );
+    return <LoadingCard />;
   }
 
   if (error) {
@@ -68,9 +84,26 @@ function ClawAgentsWithStatus({ organizationId }: { organizationId?: string }) {
     );
   }
 
-  if (!status || status.status === null) return null;
-
-  const content = <AgentsSection enabled={status.status === 'running'} />;
+  let content: ReactNode;
+  if (!running) {
+    // Machine stopped — AgentsSection renders the "start your machine" hint.
+    content = <AgentsSection enabled={false} />;
+  } else if (versionQuery.isLoading) {
+    content = <LoadingCard />;
+  } else if (!supportsAgentsRead) {
+    content = (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <p className="text-muted-foreground text-sm">
+            Agent management is not available on this machine version. Update your machine to enable
+            it.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  } else {
+    content = <AgentsSection enabled />;
+  }
 
   // Personal context uses BillingWrapper for access-lock dialogs/banners.
   return organizationId ? content : <BillingWrapper>{content}</BillingWrapper>;

--- a/apps/web/src/app/(app)/claw/components/ClawAgentsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawAgentsPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Bot } from 'lucide-react';
+import { AlertTriangle, Bot } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, type ReactNode } from 'react';
 
@@ -130,8 +130,24 @@ function ClawAgentsWithStatus({ organizationId }: { organizationId?: string }) {
     );
   }
 
+  const body = (
+    <div className="flex flex-col gap-4">
+      <div className="rounded-md border border-amber-500/20 bg-amber-500/5 px-3 py-2">
+        <p className="flex items-center gap-1.5 text-xs font-medium text-amber-400">
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          Internal — work in progress
+        </p>
+        <p className="text-muted-foreground mt-1 text-xs">
+          Agent management is admin-only and shipped to production for limited testing. Expect rough
+          edges, and behavior may change.
+        </p>
+      </div>
+      {content}
+    </div>
+  );
+
   // Personal context uses BillingWrapper for access-lock dialogs/banners.
-  return organizationId ? content : <BillingWrapper>{content}</BillingWrapper>;
+  return organizationId ? body : <BillingWrapper>{body}</BillingWrapper>;
 }
 
 export function ClawAgentsPage({ organizationId }: { organizationId?: string }) {

--- a/apps/web/src/app/(app)/claw/components/ClawAgentsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawAgentsPage.tsx
@@ -57,8 +57,12 @@ function ClawAgentsWithStatus({ organizationId }: { organizationId?: string }) {
   // instances see an upgrade prompt rather than a broken page.
   const running = status?.status === 'running';
   const versionQuery = useClawControllerVersion(running);
-  const supportsAgentsRead =
-    controllerVersionOk(versionQuery.data)?.capabilities?.includes('config.agents.read') === true;
+  // Each agent operation advertises its own capability — gate read AND each
+  // mutation control independently so a controller that supports reads but not
+  // a given write never shows a control that can only fail.
+  const capabilities = controllerVersionOk(versionQuery.data)?.capabilities;
+  const has = (cap: string) => capabilities?.includes(cap) === true;
+  const supportsAgentsRead = has('config.agents.read');
 
   const clawUrl = organizationId ? `/organizations/${organizationId}/claw/new` : '/claw/new';
   const shouldRedirect = !isLoading && !error && (!status || status.status === null);
@@ -87,9 +91,23 @@ function ClawAgentsWithStatus({ organizationId }: { organizationId?: string }) {
   let content: ReactNode;
   if (!running) {
     // Machine stopped — AgentsSection renders the "start your machine" hint.
-    content = <AgentsSection enabled={false} />;
+    content = (
+      <AgentsSection enabled={false} canCreate={false} canUpdate={false} canDelete={false} />
+    );
   } else if (versionQuery.isLoading) {
     content = <LoadingCard />;
+  } else if (versionQuery.error) {
+    // Distinguish a transient/operational version-read failure from a genuinely
+    // unsupported machine — don't tell an admin to "upgrade" on a network blip.
+    content = (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <p className="text-destructive text-sm">
+            Couldn’t determine this machine’s capabilities. Try again in a moment.
+          </p>
+        </CardContent>
+      </Card>
+    );
   } else if (!supportsAgentsRead) {
     content = (
       <Card>
@@ -102,7 +120,14 @@ function ClawAgentsWithStatus({ organizationId }: { organizationId?: string }) {
       </Card>
     );
   } else {
-    content = <AgentsSection enabled />;
+    content = (
+      <AgentsSection
+        enabled
+        canCreate={has('config.agents.create.basic.cli')}
+        canUpdate={has('config.agents.update')}
+        canDelete={has('config.agents.delete.cli')}
+      />
+    );
   }
 
   // Personal context uses BillingWrapper for access-lock dialogs/banners.

--- a/apps/web/src/app/(app)/claw/components/ClawAgentsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawAgentsPage.tsx
@@ -8,6 +8,7 @@ import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
 import { useKiloClawStatus } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawStatus } from '@/hooks/useOrgKiloClaw';
+import { useUser } from '@/hooks/useUser';
 
 import { AgentsSection } from './AgentsSection';
 import { BillingWrapper } from './billing/BillingWrapper';
@@ -24,6 +25,19 @@ function ClawAgentsWithStatus({ organizationId }: { organizationId?: string }) {
   const orgStatus = useOrgKiloClawStatus(organizationId);
   const { data: status, isLoading, error } = organizationId ? orgStatus : personalStatus;
 
+  // Agent management is admin-only. Hide from non-admins and bounce direct hits
+  // back to settings. (The nav item is also gated on is_admin.)
+  const { data: user, isLoading: userLoading } = useUser();
+  const notAdmin = !userLoading && !!user && user.is_admin !== true;
+  const settingsUrl = organizationId
+    ? `/organizations/${organizationId}/claw/settings`
+    : '/claw/settings';
+  useEffect(() => {
+    if (notAdmin) {
+      router.replace(settingsUrl);
+    }
+  }, [notAdmin, settingsUrl, router]);
+
   const clawUrl = organizationId ? `/organizations/${organizationId}/claw/new` : '/claw/new';
   const shouldRedirect = !isLoading && !error && (!status || status.status === null);
   useEffect(() => {
@@ -32,7 +46,7 @@ function ClawAgentsWithStatus({ organizationId }: { organizationId?: string }) {
     }
   }, [shouldRedirect, clawUrl, router]);
 
-  if (isLoading || shouldRedirect) {
+  if (userLoading || notAdmin || isLoading || shouldRedirect) {
     return (
       <Card>
         <CardContent className="py-12 text-center">

--- a/apps/web/src/app/(app)/claw/components/ClawAgentsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawAgentsPage.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Bot } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { SetPageTitle } from '@/components/SetPageTitle';
+import { Card, CardContent } from '@/components/ui/card';
+import { useKiloClawStatus } from '@/hooks/useKiloClaw';
+import { useOrgKiloClawStatus } from '@/hooks/useOrgKiloClaw';
+
+import { AgentsSection } from './AgentsSection';
+import { BillingWrapper } from './billing/BillingWrapper';
+import { ClawContextProvider } from './ClawContext';
+
+/**
+ * Polls instance status and handles loading / error / no-instance before
+ * rendering the agents view. Mirrors ClawSettingsWithStatus, trimmed to the
+ * read-only needs of this page.
+ */
+function ClawAgentsWithStatus({ organizationId }: { organizationId?: string }) {
+  const router = useRouter();
+  const personalStatus = useKiloClawStatus();
+  const orgStatus = useOrgKiloClawStatus(organizationId);
+  const { data: status, isLoading, error } = organizationId ? orgStatus : personalStatus;
+
+  const clawUrl = organizationId ? `/organizations/${organizationId}/claw/new` : '/claw/new';
+  const shouldRedirect = !isLoading && !error && (!status || status.status === null);
+  useEffect(() => {
+    if (shouldRedirect) {
+      router.replace(clawUrl);
+    }
+  }, [shouldRedirect, clawUrl, router]);
+
+  if (isLoading || shouldRedirect) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <p className="text-muted-foreground">Loading…</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <p className="text-destructive text-sm">
+            Failed to load status: {error instanceof Error ? error.message : 'Unknown error'}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!status || status.status === null) return null;
+
+  const content = <AgentsSection enabled={status.status === 'running'} />;
+
+  // Personal context uses BillingWrapper for access-lock dialogs/banners.
+  return organizationId ? content : <BillingWrapper>{content}</BillingWrapper>;
+}
+
+export function ClawAgentsPage({ organizationId }: { organizationId?: string }) {
+  return (
+    <ClawContextProvider organizationId={organizationId}>
+      <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
+        <SetPageTitle title="Agents" icon={<Bot className="text-muted-foreground h-4 w-4" />} />
+        <ClawAgentsWithStatus organizationId={organizationId} />
+      </div>
+    </ClawContextProvider>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/modelSupport.ts
+++ b/apps/web/src/app/(app)/claw/components/modelSupport.ts
@@ -21,6 +21,21 @@ export const KILOCODE_CATALOG_IDS = new Set([
 
 export const OPENCLAW_DYNAMIC_MODEL_DISCOVERY_VERSION = '2026.03.08';
 
+// KiloClaw model refs live under the `kilocode/` namespace. Catalog/combobox IDs
+// are bare (e.g. `anthropic/claude-sonnet-4.5`); stored model refs are prefixed
+// (e.g. `kilocode/anthropic/claude-sonnet-4.5`). Mirrors the Settings flow
+// (SettingsTab strips for display and re-adds on save).
+export const KILOCODE_MODEL_PREFIX = 'kilocode/';
+
+export function stripKilocodeModelPrefix(id: string): string {
+  return id.startsWith(KILOCODE_MODEL_PREFIX) ? id.slice(KILOCODE_MODEL_PREFIX.length) : id;
+}
+
+// Idempotent: strips any existing prefix first so we never double-prefix.
+export function addKilocodeModelPrefix(id: string): string {
+  return id ? `${KILOCODE_MODEL_PREFIX}${stripKilocodeModelPrefix(id)}` : id;
+}
+
 export function supportsDynamicGatewayModels(openclawVersion: string | null | undefined): boolean {
   return calverAtLeast(cleanVersion(openclawVersion), OPENCLAW_DYNAMIC_MODEL_DISCOVERY_VERSION);
 }

--- a/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
@@ -94,6 +94,27 @@ export function useClawControllerVersion(enabled: boolean) {
   return organizationId ? org : personal;
 }
 
+// Agents (read-only fleet)
+
+export function useClawAgents(enabled = true) {
+  const trpc = useTRPC();
+  const { organizationId } = useClawContext();
+
+  const personal = useQuery({
+    ...trpc.kiloclaw.listAgents.queryOptions(undefined),
+    enabled: enabled && !organizationId,
+  });
+
+  const org = useQuery({
+    ...trpc.organizations.kiloclaw.listAgents.queryOptions({
+      organizationId: organizationId ?? '',
+    }),
+    enabled: enabled && !!organizationId,
+  });
+
+  return organizationId ? org : personal;
+}
+
 export function useClawMorningBriefingStatus(enabled: boolean) {
   const trpc = useTRPC();
   const { organizationId } = useClawContext();

--- a/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
@@ -9,10 +9,11 @@
  * the actual network request to the correct tRPC route.
  */
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
 import { useTRPC } from '@/lib/trpc/utils';
+import type { AgentCreateInput, AgentUpdateInput } from '@/lib/kiloclaw/agent-schemas';
 import { useClawContext } from '../components/ClawContext';
 
 // Config
@@ -113,6 +114,67 @@ export function useClawAgents(enabled = true) {
   });
 
   return organizationId ? org : personal;
+}
+
+/**
+ * Agent lifecycle mutations (create / update / delete), context-aware. Callers
+ * pass the base input; the org variant injects organizationId. Each mutation
+ * invalidates the active listAgents query on success.
+ */
+export function useClawAgentMutations() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const { organizationId } = useClawContext();
+
+  const invalidateAgents = () =>
+    queryClient.invalidateQueries({
+      queryKey: organizationId
+        ? trpc.organizations.kiloclaw.listAgents.queryKey({ organizationId })
+        : trpc.kiloclaw.listAgents.queryKey(),
+    });
+
+  const personalCreate = useMutation(
+    trpc.kiloclaw.createAgent.mutationOptions({ onSuccess: invalidateAgents })
+  );
+  const orgCreate = useMutation(
+    trpc.organizations.kiloclaw.createAgent.mutationOptions({ onSuccess: invalidateAgents })
+  );
+  const personalUpdate = useMutation(
+    trpc.kiloclaw.updateAgent.mutationOptions({ onSuccess: invalidateAgents })
+  );
+  const orgUpdate = useMutation(
+    trpc.organizations.kiloclaw.updateAgent.mutationOptions({ onSuccess: invalidateAgents })
+  );
+  const personalDelete = useMutation(
+    trpc.kiloclaw.deleteAgent.mutationOptions({ onSuccess: invalidateAgents })
+  );
+  const orgDelete = useMutation(
+    trpc.organizations.kiloclaw.deleteAgent.mutationOptions({ onSuccess: invalidateAgents })
+  );
+
+  return {
+    createAgent: {
+      mutateAsync: (input: AgentCreateInput) =>
+        organizationId
+          ? orgCreate.mutateAsync({ organizationId, agent: input })
+          : personalCreate.mutateAsync(input),
+      isPending: organizationId ? orgCreate.isPending : personalCreate.isPending,
+    },
+    updateAgent: {
+      mutateAsync: (agentId: string, patch: AgentUpdateInput) =>
+        organizationId
+          ? orgUpdate.mutateAsync({ organizationId, agentId, patch })
+          : personalUpdate.mutateAsync({ agentId, patch }),
+      isPending: organizationId ? orgUpdate.isPending : personalUpdate.isPending,
+    },
+    deleteAgent: {
+      mutateAsync: (agentId: string) =>
+        organizationId
+          ? orgDelete.mutateAsync({ organizationId, agentId })
+          : personalDelete.mutateAsync({ agentId }),
+      isPending: organizationId ? orgDelete.isPending : personalDelete.isPending,
+    },
+  };
 }
 
 export function useClawMorningBriefingStatus(enabled: boolean) {

--- a/apps/web/src/app/(app)/claw/hooks/useClawModelOptions.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawModelOptions.ts
@@ -26,19 +26,24 @@ const EMPTY_STATUS = {
 export function useClawModelOptions(): {
   modelOptions: ModelOption[];
   isLoading: boolean;
-  error: boolean;
+  error: string | undefined;
 } {
   const { organizationId } = useClawContext();
   const personalStatus = useKiloClawStatus({ enabled: !organizationId });
   const orgStatus = useOrgKiloClawStatus(organizationId);
   const status = (organizationId ? orgStatus.data : personalStatus.data) ?? EMPTY_STATUS;
 
-  const { data: modelsData, isLoading: isLoadingModels } = useModelSelectorList(organizationId);
+  const {
+    data: modelsData,
+    isLoading: isLoadingModels,
+    error: modelsError,
+  } = useModelSelectorList(organizationId);
+  const isModelsError = modelsError != null;
   const isRunning = status.status === 'running';
   const { trackedVersion, runningVersion, isLoadingControllerVersion, isControllerVersionError } =
     useClawUpdateAvailable(status);
 
-  const hasError = isRunning && isControllerVersionError;
+  const versionError = isRunning && isControllerVersionError;
   const modelOptions = useMemo<ModelOption[]>(
     () =>
       getSettingsModelOptions({
@@ -51,14 +56,24 @@ export function useClawModelOptions(): {
         runningOpenClawVersion: runningVersion,
         isRunning,
         isLoadingRunningVersion: isLoadingControllerVersion,
-        hasRunningVersionError: hasError,
+        hasRunningVersionError: versionError,
       }),
-    [modelsData, trackedVersion, runningVersion, isRunning, isLoadingControllerVersion, hasError]
+    [
+      modelsData,
+      trackedVersion,
+      runningVersion,
+      isRunning,
+      isLoadingControllerVersion,
+      versionError,
+    ]
   );
 
+  // Surface either failure so the combobox shows it instead of a bare "no
+  // models" that hides a transient model-catalog or controller-version error.
+  const hasError = isModelsError || versionError;
   return {
     modelOptions,
     isLoading: isLoadingModels || (isRunning && isLoadingControllerVersion),
-    error: hasError,
+    error: hasError ? 'Could not load models. Try again in a moment.' : undefined,
   };
 }

--- a/apps/web/src/app/(app)/claw/hooks/useClawModelOptions.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawModelOptions.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useModelSelectorList } from '@/app/api/openrouter/hooks';
+import type { ModelOption } from '@/components/shared/ModelCombobox';
+import { useKiloClawStatus } from '@/hooks/useKiloClaw';
+import { useOrgKiloClawStatus } from '@/hooks/useOrgKiloClaw';
+
+import { useClawContext } from '../components/ClawContext';
+import { getSettingsModelOptions } from '../components/modelSupport';
+import { useClawUpdateAvailable } from './useClawUpdateAvailable';
+
+const EMPTY_STATUS = {
+  status: null,
+  openclawVersion: null,
+  imageVariant: null,
+  trackedImageTag: null,
+};
+
+/**
+ * The same version-filtered model list the Settings page shows in its Model
+ * Configuration picker, context-aware (personal vs org). Reuses
+ * useModelSelectorList + getSettingsModelOptions so the two surfaces stay in sync.
+ */
+export function useClawModelOptions(): {
+  modelOptions: ModelOption[];
+  isLoading: boolean;
+  error: boolean;
+} {
+  const { organizationId } = useClawContext();
+  const personalStatus = useKiloClawStatus({ enabled: !organizationId });
+  const orgStatus = useOrgKiloClawStatus(organizationId);
+  const status = (organizationId ? orgStatus.data : personalStatus.data) ?? EMPTY_STATUS;
+
+  const { data: modelsData, isLoading: isLoadingModels } = useModelSelectorList(organizationId);
+  const isRunning = status.status === 'running';
+  const { trackedVersion, runningVersion, isLoadingControllerVersion, isControllerVersionError } =
+    useClawUpdateAvailable(status);
+
+  const hasError = isRunning && isControllerVersionError;
+  const modelOptions = useMemo<ModelOption[]>(
+    () =>
+      getSettingsModelOptions({
+        models: (modelsData?.data || []).map(model => ({
+          id: model.id,
+          name: model.name,
+          isFree: model.isFree,
+        })),
+        trackedOpenClawVersion: trackedVersion,
+        runningOpenClawVersion: runningVersion,
+        isRunning,
+        isLoadingRunningVersion: isLoadingControllerVersion,
+        hasRunningVersionError: hasError,
+      }),
+    [modelsData, trackedVersion, runningVersion, isRunning, isLoadingControllerVersion, hasError]
+  );
+
+  return {
+    modelOptions,
+    isLoading: isLoadingModels || (isRunning && isLoadingControllerVersion),
+    error: hasError,
+  };
+}

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -142,6 +142,11 @@ export default function OrganizationAppSidebar({
       url: `/organizations/${organizationId}/claw/chat`,
     },
     {
+      title: 'Agents',
+      icon: Bot,
+      url: `/organizations/${organizationId}/claw/agents`,
+    },
+    {
       title: 'Settings',
       icon: Settings,
       url: `/organizations/${organizationId}/claw/settings`,

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -141,11 +141,16 @@ export default function OrganizationAppSidebar({
       icon: MessageSquare,
       url: `/organizations/${organizationId}/claw/chat`,
     },
-    {
-      title: 'Agents',
-      icon: Bot,
-      url: `/organizations/${organizationId}/claw/agents`,
-    },
+    // Agent management is admin-only for now.
+    ...(user?.is_admin
+      ? [
+          {
+            title: 'Agents',
+            icon: Bot,
+            url: `/organizations/${organizationId}/claw/agents`,
+          },
+        ]
+      : []),
     {
       title: 'Settings',
       icon: Settings,

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -98,6 +98,11 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
       url: '/claw/subscription',
     },
     {
+      title: 'Agents',
+      icon: Bot,
+      url: '/claw/agents',
+    },
+    {
       title: 'Settings',
       icon: Settings,
       url: '/claw/settings',

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -97,11 +97,16 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
       icon: CreditCard,
       url: '/claw/subscription',
     },
-    {
-      title: 'Agents',
-      icon: Bot,
-      url: '/claw/agents',
-    },
+    // Agent management is admin-only for now.
+    ...(user?.is_admin
+      ? [
+          {
+            title: 'Agents',
+            icon: Bot,
+            url: '/claw/agents',
+          },
+        ]
+      : []),
     {
       title: 'Settings',
       icon: Settings,

--- a/apps/web/src/app/(app)/organizations/[id]/claw/agents/OrgClawAgentsClient.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/agents/OrgClawAgentsClient.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ClawAgentsPage } from '@/app/(app)/claw/components/ClawAgentsPage';
+
+export function OrgClawAgentsClient({ organizationId }: { organizationId: string }) {
+  return <ClawAgentsPage organizationId={organizationId} />;
+}

--- a/apps/web/src/app/(app)/organizations/[id]/claw/agents/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/agents/page.tsx
@@ -1,0 +1,15 @@
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { OrgClawAgentsClient } from './OrgClawAgentsClient';
+
+type OrgClawAgentsPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function OrgClawAgentsPage({ params }: OrgClawAgentsPageProps) {
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      render={org => <OrgClawAgentsClient organizationId={org.organization.id} />}
+    />
+  );
+}

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -3,11 +3,13 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 
-export function useKiloClawStatus() {
+export function useKiloClawStatus(options?: { enabled?: boolean }) {
   const trpc = useTRPC();
+  const enabled = options?.enabled ?? true;
   return useQuery(
     trpc.kiloclaw.getStatus.queryOptions(undefined, {
-      refetchInterval: 10_000,
+      enabled,
+      refetchInterval: enabled ? 10_000 : false,
     })
   );
 }

--- a/apps/web/src/lib/kiloclaw/agent-schemas.ts
+++ b/apps/web/src/lib/kiloclaw/agent-schemas.ts
@@ -14,7 +14,9 @@ import { z } from 'zod';
 // Agent ids normalize to <=64 chars on the controller.
 export const AgentIdSchema = z.string().trim().min(1).max(64);
 
-const ThinkingDefaultSchema = z.enum([
+// Single source of truth for the per-agent setting option values, shared by the
+// Zod enums below and the editor UI (AgentEditDialog) so they can't drift.
+export const THINKING_OPTIONS = [
   'off',
   'minimal',
   'low',
@@ -23,9 +25,13 @@ const ThinkingDefaultSchema = z.enum([
   'xhigh',
   'adaptive',
   'max',
-]);
-const VerboseDefaultSchema = z.enum(['off', 'on', 'full']);
-const ReasoningDefaultSchema = z.enum(['on', 'off', 'stream']);
+] as const;
+export const VERBOSE_OPTIONS = ['off', 'on', 'full'] as const;
+export const REASONING_OPTIONS = ['on', 'off', 'stream'] as const;
+
+const ThinkingDefaultSchema = z.enum(THINKING_OPTIONS);
+const VerboseDefaultSchema = z.enum(VERBOSE_OPTIONS);
+const ReasoningDefaultSchema = z.enum(REASONING_OPTIONS);
 
 // A model value to write: primary and/or fallbacks (at least one).
 const ModelInputSchema = z


### PR DESCRIPTION
## Summary

Adds an admin-only Agents management page to the KiloClaw web app, for both
personal and organization instances. It consumes the already-merged agent
backend (controller CRUD + bindings via DO/Worker/tRPC) to list the agents
running on a machine and create, edit, and delete them. The surface is gated
behind admin status and per-operation controller capabilities. It is a work in
progress shipped for limited testing.

## Changes

Page and navigation:
- New routes: `/claw/agents` (personal) and `/organizations/[id]/claw/agents`
  (org), reusing the `ClawSettingsPage` shell (context provider, status gate,
  billing wrapper).
- "Agents" item added to the personal and org KiloClaw sidebars, shown only to
  admins.
- A work-in-progress / admin-only note at the top of the page.

Gating:
- Admin-only via `useUser().is_admin`, fail-closed: the nav item is hidden and
  the page redirects non-admins (and unknown/errored admin status) to settings.
- Per-capability gating: the view requires `config.agents.read`; New, edit, and
  delete are each gated on `config.agents.create.basic.cli`,
  `config.agents.update`, and `config.agents.delete.cli`. Older controllers that
  don't advertise the read capability get an "update your machine" state, and a
  controller-version fetch failure shows a distinct error rather than an upgrade
  prompt.

Read view (`AgentsSection`):
- Lists each agent's effective model (including fallback-only models), routed
  channels, and behavioral settings, plus the inherited fleet defaults.

Create / edit / delete:
- Create dialog (name + optional model; workspace path derived from the name).
- Edit dialog (model plus thinking/verbose/reasoning/fast-mode), with an
  "inherit default" option per field, diffed into a set/unset patch and guarded
  by the config etag captured at open time.
- Delete via a confirmation dialog with honest "workspace files may remain"
  copy; the reserved `main` agent cannot be deleted.
- `useClawAgentMutations` dispatcher (personal + org) that injects the org id
  and invalidates the agent list on success.

Model selection:
- Create and edit use the shared `ModelCombobox` backed by a new
  `useClawModelOptions` hook, so the agent dialogs offer the same
  version-filtered model list as the Settings Model Configuration picker, and
  surface catalog/version load failures.

Supporting:
- Shared `THINKING`/`VERBOSE`/`REASONING` option tuples exported from
  `agent-schemas.ts` so the Zod enums and the editor selects share one source.
- `useKiloClawStatus` gained an optional `enabled` flag so the personal status
  query doesn't poll on org routes.

## Verification

Exercised in local dev (personal context):
- [x] Agents nav item and page are hidden/redirected for non-admins, shown for admins
- [x] Read-only fleet view renders the agent list and inherited defaults
- [x] Create / edit / delete dialogs open and submit; the list refreshes after each

Full end-to-end validation (including model selection) is being done via the
live limited-testing rollout.

## Visual Changes

New UI: a dedicated Agents page, an admin-only "Agents" sidebar entry, and
create/edit/delete dialogs. Screenshots to be added.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- This is UI only; it is a pure consumer of the already-merged agent backend.
- Gating is client-side (nav visibility, page redirect, per-capability
  controls). The agent tRPC procedures are not admin-gated server-side; whether
  to add that is an open decision.
- The create dialog derives the workspace path by mirroring the controller's
  agent-id normalization. A shared module isn't possible across the
  apps/web ↔ services boundary, so it's re-declared (same pattern as the Zod
  input schemas).
