### PR TITLE
fix(mcp-gateway): authorize org browser OAuth flows

### DIFF
--- a/.specs/mcp-gateway-auth.md
+++ b/.specs/mcp-gateway-auth.md
@@ -50,6 +50,9 @@ when they appear in all capitals.
 - **Execution context**: The caller's current Kilo context: personal or one
   specific organization. Authorization, refresh, token issuance, and runtime
   proxying MUST use authoritative execution context, not route inference alone.
+  Browser OAuth entry points that do not carry an organization header may establish
+  org context from an org resource only after authoritative membership and assignment
+  authorization against that exact resolved route.
 - **Connection instance**: A per-user record associated with one config. In v1,
   there is at most one non-terminal instance for each
   `(owner_scope, owner_id, user_id, config_id)` tuple.

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
@@ -6,12 +6,15 @@ const mockGetUserFromAuth =
   jest.fn<
     (params: { adminOnly: boolean }) => Promise<{ user: { id: string }; organizationId?: string }>
   >();
-const mockPreviewAuthorization =
-  jest.fn<
-    (
-      params: unknown
-    ) => Promise<{ clientId: string; clientName: string; resource: string; scopes: string[] }>
-  >();
+const mockPreviewAuthorization = jest.fn<
+  (params: unknown) => Promise<{
+    clientId: string;
+    clientName: string;
+    resource: string;
+    scopes: string[];
+    executionContext: { type: string; organizationId?: string };
+  }>
+>();
 const mockAuthorize =
   jest.fn<(params: unknown) => Promise<{ kind: 'provider_redirect'; authorizationUrl: string }>>();
 const mockRouteAuthorize = jest.fn();
@@ -99,10 +102,10 @@ function approvalRequest(approvalState: string, cookie: string) {
 }
 
 describe('POST /api/mcp-gateway/oauth/authorize', () => {
-  test('uses a see-other redirect for a provider authorization after approval', async () => {
+  test('uses a see-other redirect for a browser org provider authorization after approval', async () => {
     mockGetUserFromAuth.mockResolvedValue({
       user: { id: 'user-1' },
-      organizationId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
+      organizationId: undefined,
     });
     mockPreviewAuthorization.mockResolvedValue({
       clientId: 'mcp:client',
@@ -110,6 +113,10 @@ describe('POST /api/mcp-gateway/oauth/authorize', () => {
       resource:
         'http://localhost:8806/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
       scopes: ['profile'],
+      executionContext: {
+        type: 'organization',
+        organizationId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
+      },
     });
     mockAuthorize.mockResolvedValue({
       kind: 'provider_redirect',
@@ -135,6 +142,22 @@ describe('POST /api/mcp-gateway/oauth/authorize', () => {
     expect(response.headers.get('location')).toBe(
       'https://mcp.linear.app/authorize?state=provider-state'
     );
+    expect(mockPreviewAuthorization).toHaveBeenCalledTimes(2);
+    expect(mockPreviewAuthorization).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        allowBrowserOrgResourceContext: true,
+        executionContext: { type: 'personal' },
+      })
+    );
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowBrowserOrgResourceContext: true,
+        executionContext: {
+          type: 'organization',
+          organizationId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
+        },
+      })
+    );
   });
 });
 
@@ -147,6 +170,10 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
       resource:
         'http://localhost:8806/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
       scopes: ['profile'],
+      executionContext: {
+        type: 'organization',
+        organizationId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
+      },
     });
 
     const response = await loadedRoute().GET(new NextRequest(authorizationUrl()));
@@ -155,10 +182,8 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
     expect(response.status).toBe(200);
     expect(mockPreviewAuthorization).toHaveBeenCalledWith(
       expect.objectContaining({
-        executionContext: {
-          type: 'organization',
-          organizationId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
-        },
+        allowBrowserOrgResourceContext: true,
+        executionContext: { type: 'personal' },
       })
     );
   });
@@ -171,6 +196,10 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
       resource:
         'http://localhost:8806/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
       scopes: ['profile'],
+      executionContext: {
+        type: 'organization',
+        organizationId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
+      },
     });
     const request = new NextRequest(authorizationUrl(), {
       headers: { Authorization: 'Bearer api-token' },

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
@@ -14,6 +14,7 @@ const mockPreviewAuthorization =
   >();
 const mockAuthorize =
   jest.fn<(params: unknown) => Promise<{ kind: 'provider_redirect'; authorizationUrl: string }>>();
+const mockRouteAuthorize = jest.fn();
 
 jest.mock('@/lib/user/server', () => ({
   getUserFromAuth: mockGetUserFromAuth,
@@ -26,7 +27,20 @@ jest.mock('@/lib/mcp-gateway/services', () => ({
       parseResource: () => ({
         ownerScope: 'organization',
         ownerId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
+        rootPath:
+          '/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
       }),
+      resolveResource: async () => ({
+        route: {
+          ownerScope: 'organization',
+          ownerId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
+          rootPath:
+            '/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
+        },
+        resolved: {},
+      }),
+      resolveRouteParams: async () => ({}),
+      authorize: mockRouteAuthorize,
     },
     authorizationService: {
       previewAuthorization: mockPreviewAuthorization,
@@ -125,7 +139,7 @@ describe('POST /api/mcp-gateway/oauth/authorize', () => {
 });
 
 describe('GET /api/mcp-gateway/oauth/authorize', () => {
-  test('passes the authenticated execution context through unchanged', async () => {
+  test('derives org execution context from an authorized browser resource', async () => {
     mockGetUserFromAuth.mockResolvedValue({ user: { id: 'user-1' }, organizationId: undefined });
     mockPreviewAuthorization.mockResolvedValue({
       clientId: 'mcp:client',
@@ -140,8 +154,36 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
 
     expect(response.status).toBe(200);
     expect(mockPreviewAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionContext: {
+          type: 'organization',
+          organizationId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
+        },
+      })
+    );
+  });
+
+  test('keeps explicit API execution context unchanged', async () => {
+    mockGetUserFromAuth.mockResolvedValue({ user: { id: 'user-1' }, organizationId: undefined });
+    mockPreviewAuthorization.mockResolvedValue({
+      clientId: 'mcp:client',
+      clientName: 'Codex',
+      resource:
+        'http://localhost:8806/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
+      scopes: ['profile'],
+    });
+    const request = new NextRequest(authorizationUrl(), {
+      headers: { Authorization: 'Bearer api-token' },
+    });
+
+    const response = await loadedRoute().GET(request);
+    if (!response) throw new Error('Expected authorization response');
+
+    expect(response.status).toBe(200);
+    expect(mockPreviewAuthorization).toHaveBeenCalledWith(
       expect.objectContaining({ executionContext: { type: 'personal' } })
     );
+    expect(mockRouteAuthorize).not.toHaveBeenCalled();
   });
 
   test('rejects duplicate OAuth singleton query parameters', async () => {

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
@@ -1,11 +1,6 @@
 import 'server-only';
 import { NextResponse, type NextRequest } from 'next/server';
-import {
-  createGatewayError,
-  GatewayErrorCode,
-  OAuthAuthorizationQuerySchema,
-  type OAuthAuthorizationQuery,
-} from '@kilocode/mcp-gateway';
+import { OAuthAuthorizationQuerySchema, type OAuthAuthorizationQuery } from '@kilocode/mcp-gateway';
 import { timingSafeEqual } from '@kilocode/encryption';
 import { getUserFromAuth } from '@/lib/user/server';
 import { createGatewayServices } from '@/lib/mcp-gateway/services';
@@ -63,56 +58,12 @@ async function authorizationIdentity() {
   return { user, executionContext: executionContextFromAuth(organizationId) };
 }
 
-async function authorizationExecutionContext(params: {
-  request: NextRequest;
-  query: OAuthAuthorizationQuery;
-  route?: ScopedConnectRoute;
-  userId: string;
-  executionContext: ReturnType<typeof executionContextFromAuth>;
-  services: ReturnType<typeof createGatewayServices>;
-}) {
-  if (params.request.headers.has('Authorization') || params.executionContext.type !== 'personal') {
-    return params.executionContext;
-  }
-  const queryRoute = params.query.resource
-    ? params.services.routeService.parseResource(params.query.resource)
-    : undefined;
-  if (params.route && queryRoute && params.route.rootPath !== queryRoute.rootPath) {
-    throw createGatewayError(GatewayErrorCode.InvalidRequest, 'Resource does not match route', 400);
-  }
-  const candidateRoute = params.route ?? queryRoute;
-  if (!candidateRoute || candidateRoute.ownerScope !== 'organization') {
-    return params.executionContext;
-  }
-  const resolved = params.route
-    ? {
-        route: params.route,
-        resolved: await params.services.routeService.resolveRouteParams(params.route),
-      }
-    : params.query.resource
-      ? await params.services.routeService.resolveResource(params.query.resource)
-      : null;
-  if (!resolved) {
-    return params.executionContext;
-  }
-  const organizationContext = {
-    type: 'organization' as const,
-    organizationId: candidateRoute.ownerId,
-  };
-  await params.services.routeService.authorize({
-    resolved: resolved.resolved,
-    route: resolved.route,
-    userId: params.userId,
-    executionContext: organizationContext,
-  });
-  return organizationContext;
-}
-
 async function authorizeRequest(
   query: OAuthAuthorizationQuery,
   route: ScopedConnectRoute | undefined,
   userId: string,
-  executionContext: ReturnType<typeof executionContextFromAuth>
+  executionContext: ReturnType<typeof executionContextFromAuth>,
+  allowBrowserOrgResourceContext: boolean
 ) {
   const services = createGatewayServices();
   const result = await services.authorizationService.authorize({
@@ -120,6 +71,7 @@ async function authorizeRequest(
     route,
     userId,
     executionContext,
+    allowBrowserOrgResourceContext,
   });
   if (result.kind === 'provider_redirect') {
     return NextResponse.redirect(result.authorizationUrl, 303);
@@ -333,28 +285,23 @@ async function consentResponse(request: NextRequest, route?: ScopedConnectRoute)
     return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
   }
   const services = createGatewayServices();
-  const executionContext = await authorizationExecutionContext({
-    request,
-    query: parsed.data,
-    route,
-    userId: identity.user.id,
-    executionContext: identity.executionContext,
-    services,
-  });
+  const executionContext = identity.executionContext;
   const preview = await services.authorizationService.previewAuthorization({
     query: parsed.data,
     route,
     userId: identity.user.id,
     executionContext,
+    allowBrowserOrgResourceContext: !request.headers.has('Authorization'),
     redirectErrors: true,
   });
+  const resolvedExecutionContext = preview.executionContext;
   const approvalState = randomToken(32);
   const approvalCookie = `${approvalState}.${approvalSignature({
     approvalState,
     clientId: preview.clientId,
     resource: preview.resource,
     scopes: preview.scopes,
-    executionContext,
+    executionContext: resolvedExecutionContext,
     secret: services.config.rateLimitSecret,
   })}`;
   const inputs = Object.entries(parsed.data)
@@ -398,21 +345,16 @@ async function approveRequest(request: NextRequest, route?: ScopedConnectRoute) 
     return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
   }
   const services = createGatewayServices();
-  const executionContext = await authorizationExecutionContext({
-    request,
-    query: parsed.data,
-    route,
-    userId: identity.user.id,
-    executionContext: identity.executionContext,
-    services,
-  });
+  const executionContext = identity.executionContext;
   const preview = await services.authorizationService.previewAuthorization({
     query: parsed.data,
     route,
     userId: identity.user.id,
     executionContext,
+    allowBrowserOrgResourceContext: !request.headers.has('Authorization'),
     redirectErrors: true,
   });
+  const resolvedExecutionContext = preview.executionContext;
   const cookieState = request.cookies.get(consentCookieName)?.value;
   const [cookieApprovalState, cookieSignature] = cookieState?.split('.') ?? [];
   const expectedSignature = approvalSignature({
@@ -420,7 +362,7 @@ async function approveRequest(request: NextRequest, route?: ScopedConnectRoute) 
     clientId: preview.clientId,
     resource: preview.resource,
     scopes: preview.scopes,
-    executionContext,
+    executionContext: resolvedExecutionContext,
     secret: services.config.rateLimitSecret,
   });
   if (
@@ -439,7 +381,13 @@ async function approveRequest(request: NextRequest, route?: ScopedConnectRoute) 
       )
     );
   }
-  const response = await authorizeRequest(parsed.data, route, identity.user.id, executionContext);
+  const response = await authorizeRequest(
+    parsed.data,
+    route,
+    identity.user.id,
+    resolvedExecutionContext,
+    !request.headers.has('Authorization')
+  );
   response.cookies.delete(consentCookieName);
   return response;
 }

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
@@ -1,6 +1,11 @@
 import 'server-only';
 import { NextResponse, type NextRequest } from 'next/server';
-import { OAuthAuthorizationQuerySchema, type OAuthAuthorizationQuery } from '@kilocode/mcp-gateway';
+import {
+  createGatewayError,
+  GatewayErrorCode,
+  OAuthAuthorizationQuerySchema,
+  type OAuthAuthorizationQuery,
+} from '@kilocode/mcp-gateway';
 import { timingSafeEqual } from '@kilocode/encryption';
 import { getUserFromAuth } from '@/lib/user/server';
 import { createGatewayServices } from '@/lib/mcp-gateway/services';
@@ -56,6 +61,51 @@ async function authorizationIdentity() {
   if (authFailedResponse) return { response: authFailedResponse };
   if (!user) return { response: NextResponse.json({ error: 'access_denied' }, { status: 401 }) };
   return { user, executionContext: executionContextFromAuth(organizationId) };
+}
+
+async function authorizationExecutionContext(params: {
+  request: NextRequest;
+  query: OAuthAuthorizationQuery;
+  route?: ScopedConnectRoute;
+  userId: string;
+  executionContext: ReturnType<typeof executionContextFromAuth>;
+  services: ReturnType<typeof createGatewayServices>;
+}) {
+  if (params.request.headers.has('Authorization') || params.executionContext.type !== 'personal') {
+    return params.executionContext;
+  }
+  const queryRoute = params.query.resource
+    ? params.services.routeService.parseResource(params.query.resource)
+    : undefined;
+  if (params.route && queryRoute && params.route.rootPath !== queryRoute.rootPath) {
+    throw createGatewayError(GatewayErrorCode.InvalidRequest, 'Resource does not match route', 400);
+  }
+  const candidateRoute = params.route ?? queryRoute;
+  if (!candidateRoute || candidateRoute.ownerScope !== 'organization') {
+    return params.executionContext;
+  }
+  const resolved = params.route
+    ? {
+        route: params.route,
+        resolved: await params.services.routeService.resolveRouteParams(params.route),
+      }
+    : params.query.resource
+      ? await params.services.routeService.resolveResource(params.query.resource)
+      : null;
+  if (!resolved) {
+    return params.executionContext;
+  }
+  const organizationContext = {
+    type: 'organization' as const,
+    organizationId: candidateRoute.ownerId,
+  };
+  await params.services.routeService.authorize({
+    resolved: resolved.resolved,
+    route: resolved.route,
+    userId: params.userId,
+    executionContext: organizationContext,
+  });
+  return organizationContext;
 }
 
 async function authorizeRequest(
@@ -283,7 +333,14 @@ async function consentResponse(request: NextRequest, route?: ScopedConnectRoute)
     return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
   }
   const services = createGatewayServices();
-  const executionContext = identity.executionContext;
+  const executionContext = await authorizationExecutionContext({
+    request,
+    query: parsed.data,
+    route,
+    userId: identity.user.id,
+    executionContext: identity.executionContext,
+    services,
+  });
   const preview = await services.authorizationService.previewAuthorization({
     query: parsed.data,
     route,
@@ -341,7 +398,14 @@ async function approveRequest(request: NextRequest, route?: ScopedConnectRoute) 
     return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
   }
   const services = createGatewayServices();
-  const executionContext = identity.executionContext;
+  const executionContext = await authorizationExecutionContext({
+    request,
+    query: parsed.data,
+    route,
+    userId: identity.user.id,
+    executionContext: identity.executionContext,
+    services,
+  });
   const preview = await services.authorizationService.previewAuthorization({
     query: parsed.data,
     route,

--- a/apps/web/src/lib/mcp-gateway/authorization-service.ts
+++ b/apps/web/src/lib/mcp-gateway/authorization-service.ts
@@ -267,17 +267,7 @@ export function createAuthorizationService(params: {
         executionContext.type === 'personal' &&
         route.ownerScope === 'organization'
       ) {
-        const organizationContext = {
-          type: 'organization' as const,
-          organizationId: route.ownerId,
-        };
-        await params.routeService.authorize({
-          resolved,
-          route,
-          userId: input.userId,
-          executionContext: organizationContext,
-        });
-        executionContext = organizationContext;
+        executionContext = { type: 'organization', organizationId: route.ownerId };
       }
       if (!executionContextMatchesRoute(executionContext, route)) {
         redirectError(
@@ -334,7 +324,7 @@ export function createAuthorizationService(params: {
     executionContext: GatewayExecutionContext;
     allowBrowserOrgResourceContext?: boolean;
   }) {
-    const { client, route, resolved, scopes } = await prepareAuthorization({
+    const { client, route, resolved, scopes, executionContext } = await prepareAuthorization({
       ...input,
       redirectErrors: true,
     });
@@ -354,7 +344,7 @@ export function createAuthorizationService(params: {
         scopes,
         oauthState: input.query.state,
         codeChallenge: input.query.code_challenge ?? null,
-        executionContext: input.executionContext,
+        executionContext,
         instanceId: instance.instance_id,
       });
       if (

--- a/apps/web/src/lib/mcp-gateway/authorization-service.ts
+++ b/apps/web/src/lib/mcp-gateway/authorization-service.ts
@@ -216,6 +216,7 @@ export function createAuthorizationService(params: {
     route?: ScopedConnectRoute;
     userId: string;
     executionContext: GatewayExecutionContext;
+    allowBrowserOrgResourceContext?: boolean;
     redirectErrors?: boolean;
   }) {
     const client = await params.clientService.findClientById(input.query.client_id);
@@ -253,6 +254,7 @@ export function createAuthorizationService(params: {
     }
     let route: ScopedConnectRoute;
     let resolved: ResolvedGatewayRoute;
+    let executionContext = input.executionContext;
     try {
       const resolvedRoute = await resolveAuthorizationRoute({
         query: input.query,
@@ -260,7 +262,24 @@ export function createAuthorizationService(params: {
       });
       route = resolvedRoute.route;
       resolved = resolvedRoute.resolved;
-      if (!executionContextMatchesRoute(input.executionContext, route)) {
+      if (
+        input.allowBrowserOrgResourceContext &&
+        executionContext.type === 'personal' &&
+        route.ownerScope === 'organization'
+      ) {
+        const organizationContext = {
+          type: 'organization' as const,
+          organizationId: route.ownerId,
+        };
+        await params.routeService.authorize({
+          resolved,
+          route,
+          userId: input.userId,
+          executionContext: organizationContext,
+        });
+        executionContext = organizationContext;
+      }
+      if (!executionContextMatchesRoute(executionContext, route)) {
         redirectError(
           GatewayErrorCode.AccessDenied,
           'Execution context does not match resource owner'
@@ -270,7 +289,7 @@ export function createAuthorizationService(params: {
         resolved,
         route,
         userId: input.userId,
-        executionContext: input.executionContext,
+        executionContext,
       });
     } catch (error) {
       if (input.redirectErrors && error instanceof Error) {
@@ -287,7 +306,7 @@ export function createAuthorizationService(params: {
       }
       throw error;
     }
-    return { client, route, resolved, scopes };
+    return { client, route, resolved, scopes, executionContext };
   }
 
   async function previewAuthorization(input: {
@@ -295,6 +314,7 @@ export function createAuthorizationService(params: {
     route?: ScopedConnectRoute;
     userId: string;
     executionContext: GatewayExecutionContext;
+    allowBrowserOrgResourceContext?: boolean;
     redirectErrors?: boolean;
   }) {
     const prepared = await prepareAuthorization(input);
@@ -303,6 +323,7 @@ export function createAuthorizationService(params: {
       clientName: prepared.client.client_name,
       resource: prepared.resolved.route.canonical_url,
       scopes: prepared.scopes,
+      executionContext: prepared.executionContext,
     };
   }
 
@@ -311,6 +332,7 @@ export function createAuthorizationService(params: {
     route?: ScopedConnectRoute;
     userId: string;
     executionContext: GatewayExecutionContext;
+    allowBrowserOrgResourceContext?: boolean;
   }) {
     const { client, route, resolved, scopes } = await prepareAuthorization({
       ...input,

--- a/apps/web/src/lib/mcp-gateway/oauth-flow.test.ts
+++ b/apps/web/src/lib/mcp-gateway/oauth-flow.test.ts
@@ -1173,23 +1173,29 @@ describe('MCP gateway app OAuth flow', () => {
       },
       headers: new Headers({ 'x-vercel-forwarded-for': '203.0.113.17' }),
     });
-    const preview = await services.authorizationService.previewAuthorization({
-      query: OAuthAuthorizationQuerySchema.parse({
-        client_id: registration.clientId,
-        redirect_uri: 'http://localhost:3000/callback',
-        response_type: 'code',
-        resource: created.route.canonical_url,
-        code_challenge: pkceChallenge(
-          'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~abcdefghijk'
-        ),
-        code_challenge_method: 'S256',
-      }),
+    const query = OAuthAuthorizationQuerySchema.parse({
+      client_id: registration.clientId,
+      redirect_uri: 'http://localhost:3000/callback',
+      response_type: 'code',
+      resource: created.route.canonical_url,
+      code_challenge: pkceChallenge(
+        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~abcdefghijk'
+      ),
+      code_challenge_method: 'S256',
+    });
+    const authorization = await services.authorizationService.authorize({
+      query,
       userId: user.id,
       executionContext: { type: 'personal' },
       allowBrowserOrgResourceContext: true,
     });
+    expect(authorization.kind).toBe('redirect');
+    const [request] = await db
+      .select()
+      .from(mcp_gateway_authorization_requests)
+      .where(eq(mcp_gateway_authorization_requests.config_id, created.config.config_id));
 
-    expect(preview.executionContext).toEqual({ type: 'organization', organizationId });
+    expect(request?.execution_context).toEqual({ type: 'organization', organizationId });
   });
 
   it('rejects an org resource when the authenticated execution context is personal', async () => {

--- a/apps/web/src/lib/mcp-gateway/oauth-flow.test.ts
+++ b/apps/web/src/lib/mcp-gateway/oauth-flow.test.ts
@@ -1143,6 +1143,55 @@ describe('MCP gateway app OAuth flow', () => {
     ).rejects.toThrow();
   });
 
+  it('allows an authorized browser org resource without an explicit org header', async () => {
+    const config = await createTestConfig();
+    const services = createGatewayServices({ config });
+    const user = await insertTestUser({ id: `gateway-user-${crypto.randomUUID()}` });
+    const organizationId = crypto.randomUUID();
+    await db.insert(organizations).values({ id: organizationId, name: 'Gateway Org' });
+    await db.insert(organization_memberships).values({
+      organization_id: organizationId,
+      kilo_user_id: user.id,
+      role: 'owner',
+    });
+    const created = await services.configService.createOrganizationConfig({
+      organizationId,
+      actorUserId: user.id,
+      name: 'Org MCP',
+      remoteUrl: 'https://example.com/mcp',
+      authMode: 'none',
+      sharingMode: 'single_user',
+      initialAssignedUserId: user.id,
+    });
+    const registration = await services.clientService.registerClient({
+      metadata: {
+        redirect_uris: ['http://localhost:3000/callback'],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        scope: 'profile',
+      },
+      headers: new Headers({ 'x-vercel-forwarded-for': '203.0.113.17' }),
+    });
+    const preview = await services.authorizationService.previewAuthorization({
+      query: OAuthAuthorizationQuerySchema.parse({
+        client_id: registration.clientId,
+        redirect_uri: 'http://localhost:3000/callback',
+        response_type: 'code',
+        resource: created.route.canonical_url,
+        code_challenge: pkceChallenge(
+          'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~abcdefghijk'
+        ),
+        code_challenge_method: 'S256',
+      }),
+      userId: user.id,
+      executionContext: { type: 'personal' },
+      allowBrowserOrgResourceContext: true,
+    });
+
+    expect(preview.executionContext).toEqual({ type: 'organization', organizationId });
+  });
+
   it('rejects an org resource when the authenticated execution context is personal', async () => {
     const config = await createTestConfig();
     const services = createGatewayServices({ config });


### PR DESCRIPTION
## Summary

- Allow browser-initiated OAuth approval for org-scoped MCP resources when the signed-in user has valid membership and assignment on that exact org route.
- Keep API/header-authenticated execution context unchanged, while allowing browser sessions without an org header to establish org context only after authoritative route resolution and authorization.
- Update the MCP gateway auth spec to document this browser OAuth exception to the normal execution-context rule.

## Verification

- Manually reproduced the org-scoped Kilo CLI OAuth failure path and verified the failure was caused by the browser session entering the approval route with personal context despite an org resource.
- manually setup linear mcp in org context

## Visual Changes

N/A

## Reviewer Notes

- This is an OAuth authorization-path fix only; it does not change runtime Worker authorization or bypass OAuth.
- The important invariant is that browser-derived org context is only allowed after resolving the exact requested route and confirming membership plus assignment for the current user.