### PR TITLE
fix(cloud-agent): suppress expected terminal wrapper-not-running error from Sentry

### DIFF
--- a/services/cloud-agent-next/src/router/handlers/session-terminal.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-terminal.ts
@@ -22,7 +22,8 @@ function throwTerminalError(result: OperationResult<unknown>): never {
       ? 'NOT_FOUND'
       : message.includes('interactive Cloud Agent')
         ? 'FORBIDDEN'
-        : message.includes('workspace is prepared') || message.includes('session wrapper is not running')
+        : message.includes('workspace is prepared') ||
+            message.includes('session wrapper is not running')
           ? 'PRECONDITION_FAILED'
           : 'SERVICE_UNAVAILABLE';
 

--- a/services/cloud-agent-next/src/router/handlers/session-terminal.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-terminal.ts
@@ -22,7 +22,7 @@ function throwTerminalError(result: OperationResult<unknown>): never {
       ? 'NOT_FOUND'
       : message.includes('interactive Cloud Agent')
         ? 'FORBIDDEN'
-        : message.includes('workspace is prepared')
+        : message.includes('workspace is prepared') || message.includes('session wrapper is not running')
           ? 'PRECONDITION_FAILED'
           : 'SERVICE_UNAVAILABLE';
 


### PR DESCRIPTION
## Summary

- The error _"Terminal is unavailable because the session wrapper is not running"_ is a normal transient condition — the Cloud Agent sandbox exists but its wrapper process hasn't started yet. It does not indicate a bug.
- Previously `throwTerminalError` mapped this message to `SERVICE_UNAVAILABLE` (HTTP 503), which is not in the `TRPC_4XX_CODES` exclusion set in `apps/web/sentry.server.config.ts`, causing Sentry to capture it as an unexpected error.
- The fix adds `session wrapper is not running` to the `PRECONDITION_FAILED` branch in `throwTerminalError`, consistent with the existing `workspace is prepared` guard. `PRECONDITION_FAILED` is already in `TRPC_4XX_CODES` and is already handled by `rethrowAsTerminalError` in the web app, so Sentry's `beforeSend` will suppress it with no other code changes needed.

## Verification

- Open a Cloud Agent session and attempt to use the terminal before the wrapper has started — the API should return a 412 response (previously 503) and no Sentry event should be emitted.

## Visual Changes

N/A

## Reviewer Notes

- Only the "not running" case is changed; the "unhealthy" wrapper case stays as `SERVICE_UNAVAILABLE` since that may indicate a real problem worth tracking in Sentry.
- `PRECONDITION_FAILED` is already supported end-to-end: it's in `TerminalTRPCCode`, handled by `readCode` in `terminal-errors.ts`, and covers to the client exactly the same way as "workspace not prepared".

---

Built for [Evgeny Shurakov](https://kilo-code.slack.com/archives/C08TXA9QAGP/p1780943639052739?thread_ts=1780935680.913219&cid=C08TXA9QAGP) by [Kilo for Slack](https://kilo.ai/slack)