### PR TITLE
chore(cloud-agent): resize SandboxSmall fleet

### DIFF
--- a/services/cloud-agent-next/src/types.ts
+++ b/services/cloud-agent-next/src/types.ts
@@ -187,7 +187,7 @@ export type GitTokenService = {
 
 export type Env = {
   Sandbox: DurableObjectNamespace<Sandbox>;
-  /** Durable Object namespace for per-session sandbox containers (standard-2) */
+  /** Durable Object namespace for per-session sandbox containers (standard-3) */
   SandboxSmall: DurableObjectNamespace<Sandbox>;
   /** Durable Object namespace for Docker-in-Docker per-session sandbox containers (standard-3) */
   SandboxDIND: DurableObjectNamespace<Sandbox>;

--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -154,11 +154,11 @@
     {
       "class_name": "SandboxSmall",
       "image": "./Dockerfile",
-      "instance_type": "standard-2",
+      "instance_type": "standard-3",
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.21",
       },
-      "max_instances": 400,
+      "max_instances": 200,
       "rollout_active_grace_period": 1800,
     },
     {
@@ -335,7 +335,7 @@
         {
           "class_name": "SandboxSmall",
           "image": "./Dockerfile.dev",
-          "instance_type": "standard-2",
+          "instance_type": "standard-3",
           "image_vars": {
             "KILOCODE_CLI_VERSION": "7.3.21",
           },


### PR DESCRIPTION
## Summary

- Upgrade Cloud Agent Next `SandboxSmall` containers from `standard-2` to `standard-3`, increasing each sandbox from 1 vCPU to 2 vCPU.
- Reduce the production `SandboxSmall` capacity from 400 to 200 instances while keeping the development capacity unchanged.

## Verification

- Not manually tested; this change only updates Cloudflare container sizing configuration and its corresponding type documentation.

## Visual Changes

N/A

## Reviewer Notes

`standard-3` provides 2 vCPU, 8 GiB memory, and 16 GB disk per instance. The production capacity reduction offsets the larger per-instance allocation.