### PR TITLE
fix(bot): add GitHub processing reactions

### DIFF
--- a/apps/web/src/app/api/chat/link-account/route.ts
+++ b/apps/web/src/app/api/chat/link-account/route.ts
@@ -144,13 +144,16 @@ async function reprocessLinkedMessage(
     const platformIntegration = await getPlatformIntegration(identity);
     if (!platformIntegration) return;
 
-    await botPlatforms.require(platformIntegration.platform).withAuthContext({
+    const botPlatform = botPlatforms.require(platformIntegration.platform);
+
+    await botPlatform.withAuthContext({
       platformIntegration,
       fn: async () => {
         await processLinkedMessage({
           thread,
           message,
           platformIntegration,
+          botPlatform,
           user,
         });
       },

--- a/apps/web/src/lib/bot.test.ts
+++ b/apps/web/src/lib/bot.test.ts
@@ -258,6 +258,7 @@ describe('bot mention authorization', () => {
       thread,
       message,
       platformIntegration: integration,
+      botPlatform: mockSlackBotPlatform,
       user,
     });
   });

--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -101,7 +101,7 @@ function createKiloBot(
     }
 
     try {
-      await processLinkedMessage({ thread, message, platformIntegration, user });
+      await processLinkedMessage({ thread, message, platformIntegration, botPlatform, user });
     } catch (error) {
       console.error('[Bot] Unhandled error in message handler:', error);
       await thread.post({ markdown: 'Sorry, something went wrong while processing your message.' });

--- a/apps/web/src/lib/bot/platforms/github.test.ts
+++ b/apps/web/src/lib/bot/platforms/github.test.ts
@@ -35,6 +35,17 @@ jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
   generateGitHubInstallationToken: mockGenerateGitHubInstallationToken,
 }));
 
+jest.mock(
+  'chat',
+  () => ({
+    emoji: {
+      check: { name: 'check' },
+      eyes: { name: 'eyes' },
+    },
+  }),
+  { virtual: true }
+);
+
 import type { Message, Thread } from 'chat';
 import type { PlatformIntegration } from '@kilocode/db';
 import { PLATFORM } from '@/lib/integrations/core/constants';
@@ -78,10 +89,14 @@ async function* messages(items: Message[]): AsyncIterable<Message> {
   for (const item of items) yield item;
 }
 
-function createThread(params: { id: string; threadMessages?: Message[] }): Thread {
+function createThread(params: {
+  id: string;
+  threadMessages?: Message[];
+  addReaction?: jest.Mock;
+}): Thread {
   return {
     id: params.id,
-    adapter: { name: 'github' },
+    adapter: { name: 'github', addReaction: params.addReaction ?? jest.fn() },
     isDM: false,
     channel: {
       fetchMetadata: async () => ({
@@ -97,7 +112,7 @@ function createThread(params: { id: string; threadMessages?: Message[] }): Threa
     get messages() {
       return messages(params.threadMessages ?? []);
     },
-  } as Thread;
+  } as unknown as Thread;
 }
 
 function createIntegration(overrides: Partial<PlatformIntegration> = {}): PlatformIntegration {
@@ -449,5 +464,61 @@ describe('createGitHubBotPlatform.getConversationContext', () => {
     expect(context).toContain('This conditional is wrong.');
     expect(context).not.toContain('<github_review_comment id="301"');
     expect(context).toContain('Comment that triggered this bot run:');
+  });
+});
+
+describe('createGitHubBotPlatform.startTyping', () => {
+  it('uses chat-sdk reactions for GitHub processing start and completion', async () => {
+    const addReaction = jest.fn(async () => undefined);
+    const thread = createThread({
+      id: 'github:Kilo-Org/on-call:issue:37',
+      addReaction,
+    });
+    const message = createMessage({ id: '101', text: '@kilocode-dev Please fix this' });
+
+    const indicator = await githubPlatform.startTyping?.({
+      thread,
+      message,
+      platformIntegration: createIntegration(),
+      text: 'Thinking...',
+    });
+    await indicator?.done();
+
+    expect(addReaction).toHaveBeenNthCalledWith(
+      1,
+      thread.id,
+      message.id,
+      expect.objectContaining({ name: 'eyes' })
+    );
+    expect(addReaction).toHaveBeenNthCalledWith(
+      2,
+      thread.id,
+      message.id,
+      expect.objectContaining({ name: 'check' })
+    );
+  });
+
+  it('does not let GitHub reaction failures block processing', async () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const addReaction = jest.fn(async () => {
+      throw new Error('reaction failed');
+    });
+    const thread = createThread({
+      id: 'github:Kilo-Org/on-call:issue:37',
+      addReaction,
+    });
+    const message = createMessage({ id: '101', text: '@kilocode-dev Please fix this' });
+
+    const indicator = await githubPlatform.startTyping?.({
+      thread,
+      message,
+      platformIntegration: createIntegration(),
+      text: 'Thinking...',
+    });
+    await indicator?.done();
+
+    expect(addReaction).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/apps/web/src/lib/bot/platforms/github.ts
+++ b/apps/web/src/lib/bot/platforms/github.ts
@@ -13,7 +13,7 @@ import { PLATFORM } from '@/lib/integrations/core/constants';
 import type { GitHubAdapter, GitHubRawMessage } from '@chat-adapter/github';
 import { Octokit } from '@octokit/rest';
 import type { PlatformIntegration } from '@kilocode/db';
-import type { Message, Thread } from 'chat';
+import { emoji, type Message, type Thread } from 'chat';
 
 type GitHubInstallationLookup = Pick<GitHubAdapter, 'getInstallationId'>;
 
@@ -272,6 +272,23 @@ function isGitHubBotEnabledForIntegration(integration: PlatformIntegration): boo
   return metadata?.bot_enabled === true;
 }
 
+async function addGitHubReactionBestEffort(
+  thread: Thread,
+  message: Message,
+  reaction: typeof emoji.eyes | typeof emoji.check
+): Promise<void> {
+  try {
+    await thread.adapter.addReaction(thread.id, message.id, reaction);
+  } catch (error) {
+    console.warn('[bot] Failed to add GitHub bot reaction', {
+      threadId: thread.id,
+      messageId: message.id,
+      reaction: reaction.name,
+      error,
+    });
+  }
+}
+
 export function createGitHubBotPlatform(githubAdapter: GitHubInstallationLookup): BotPlatform {
   return {
     platform: PLATFORM.GITHUB,
@@ -408,6 +425,15 @@ export function createGitHubBotPlatform(githubAdapter: GitHubInstallationLookup)
       lines.push('', 'Comment that triggered this bot run:', formatUserMessage(trigger));
 
       return lines.join('\n');
+    },
+    async startTyping({ thread, message }) {
+      await addGitHubReactionBestEffort(thread, message, emoji.eyes);
+
+      return {
+        async done() {
+          await addGitHubReactionBestEffort(thread, message, emoji.check);
+        },
+      };
     },
     async getRequesterInfo({ displayName }) {
       return { displayName, platform: PLATFORM.GITHUB };

--- a/apps/web/src/lib/bot/platforms/types.ts
+++ b/apps/web/src/lib/bot/platforms/types.ts
@@ -18,6 +18,10 @@ export type RequesterInfo = {
   platform: Platform;
 };
 
+export type BotTypingIndicator = {
+  done(): Promise<void>;
+};
+
 export type BotPlatform = {
   platform: Platform;
   documentationUrl: string;
@@ -50,6 +54,12 @@ export type BotPlatform = {
     triggerMessage: ContextTriggerMessage;
     platformIntegration: PlatformIntegration;
   }): Promise<string>;
+  startTyping?(params: {
+    thread: Thread;
+    message: Message;
+    platformIntegration: PlatformIntegration;
+    text: string;
+  }): Promise<BotTypingIndicator | void>;
   getRequesterInfo(params: {
     message: Message;
     platformIntegration: PlatformIntegration;

--- a/apps/web/src/lib/bot/run.ts
+++ b/apps/web/src/lib/bot/run.ts
@@ -4,6 +4,7 @@ import { extractAndUploadAttachments } from '@/lib/bot/attachments';
 import type { PlatformIntegration, User } from '@kilocode/db';
 import type { Message, Thread } from 'chat';
 import { captureException } from '@sentry/nextjs';
+import { startTyping } from '@/lib/bot/typing';
 
 export async function processLinkedMessage({
   thread,
@@ -16,39 +17,43 @@ export async function processLinkedMessage({
   platformIntegration: PlatformIntegration;
   user: User;
 }) {
-  await thread.startTyping('Thinking...');
+  const typingIndicator = await startTyping({ thread, message, platformIntegration });
 
-  let botRequestId: string;
   try {
-    botRequestId = await createBotRequest({
-      createdBy: user.id,
-      organizationId: platformIntegration.owned_by_organization_id ?? null,
-      platformIntegrationId: platformIntegration.id,
-      platform: thread.adapter.name,
-      platformThreadId: thread.id,
-      platformMessageId: message.id,
-      userMessage: message.text,
-      modelUsed: undefined,
-    });
-  } catch (error) {
-    captureException(error, {
-      tags: { component: 'kilo-bot', op: 'create-bot-request' },
-      extra: {
-        platform: thread.adapter.name,
+    let botRequestId: string;
+    try {
+      botRequestId = await createBotRequest({
+        createdBy: user.id,
+        organizationId: platformIntegration.owned_by_organization_id ?? null,
         platformIntegrationId: platformIntegration.id,
-        userId: user.id,
-        threadId: thread.id,
-        messageId: message.id,
-      },
-    });
-    await thread.post({
-      markdown:
-        'Sorry, I could not start processing your message because of an internal error. Please try again in a moment.',
-    });
-    return;
-  }
+        platform: thread.adapter.name,
+        platformThreadId: thread.id,
+        platformMessageId: message.id,
+        userMessage: message.text,
+        modelUsed: undefined,
+      });
+    } catch (error) {
+      captureException(error, {
+        tags: { component: 'kilo-bot', op: 'create-bot-request' },
+        extra: {
+          platform: thread.adapter.name,
+          platformIntegrationId: platformIntegration.id,
+          userId: user.id,
+          threadId: thread.id,
+          messageId: message.id,
+        },
+      });
+      await thread.post({
+        markdown:
+          'Sorry, I could not start processing your message because of an internal error. Please try again in a moment.',
+      });
+      return;
+    }
 
-  await processMessage({ thread, message, platformIntegration, user, botRequestId });
+    await processMessage({ thread, message, platformIntegration, user, botRequestId });
+  } finally {
+    await typingIndicator.done();
+  }
 }
 
 async function processMessage({

--- a/apps/web/src/lib/bot/run.ts
+++ b/apps/web/src/lib/bot/run.ts
@@ -5,19 +5,22 @@ import type { PlatformIntegration, User } from '@kilocode/db';
 import type { Message, Thread } from 'chat';
 import { captureException } from '@sentry/nextjs';
 import { startTyping } from '@/lib/bot/typing';
+import type { BotPlatform } from '@/lib/bot/platforms/types';
 
 export async function processLinkedMessage({
   thread,
   message,
   platformIntegration,
+  botPlatform,
   user,
 }: {
   thread: Thread;
   message: Message;
   platformIntegration: PlatformIntegration;
+  botPlatform: BotPlatform;
   user: User;
 }) {
-  const typingIndicator = await startTyping({ thread, message, platformIntegration });
+  const typingIndicator = await startTyping({ botPlatform, thread, message, platformIntegration });
 
   try {
     let botRequestId: string;

--- a/apps/web/src/lib/bot/typing.test.ts
+++ b/apps/web/src/lib/bot/typing.test.ts
@@ -1,150 +1,45 @@
-const mockAddReactionToIssueCommentFn = jest.fn();
-const mockAddReactionToPRFn = jest.fn();
-const mockAddReactionToPRReviewCommentFn = jest.fn();
-
-jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
-  addReactionToIssueComment: (...args: unknown[]) => mockAddReactionToIssueCommentFn(...args),
-  addReactionToPR: (...args: unknown[]) => mockAddReactionToPRFn(...args),
-  addReactionToPRReviewComment: (...args: unknown[]) => mockAddReactionToPRReviewCommentFn(...args),
-}));
-
+import type { BotPlatform } from '@/lib/bot/platforms/types';
 import type { PlatformIntegration } from '@kilocode/db';
 import type { Message, Thread } from 'chat';
-import { PLATFORM } from '@/lib/integrations/core/constants';
 import { startTyping } from './typing';
 
-function createIntegration(overrides: Partial<PlatformIntegration> = {}): PlatformIntegration {
+function createThread(): Thread {
   return {
-    platform_installation_id: '98765',
-    github_app_type: 'standard',
-    ...overrides,
-  } as PlatformIntegration;
-}
-
-function createThread(params: { adapterName: string; id: string }): Thread {
-  return {
-    adapter: { name: params.adapterName },
-    id: params.id,
     startTyping: jest.fn(async () => undefined),
   } as unknown as Thread;
 }
 
-function createMessage(params: { id: string; raw?: unknown } = { id: '123' }): Message {
-  return {
-    id: params.id,
-    raw: params.raw ?? {},
-  } as Message;
-}
+const message = {} as Message;
+const platformIntegration = {} as PlatformIntegration;
 
 describe('startTyping', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+  it('defaults to chat-sdk thread typing when the platform has no override', async () => {
+    const botPlatform = {} as BotPlatform;
+    const thread = createThread();
 
-  it('uses the chat-sdk typing indicator outside GitHub', async () => {
-    const thread = createThread({ adapterName: PLATFORM.SLACK, id: 'thread-1' });
-
-    const indicator = await startTyping({
-      thread,
-      message: createMessage(),
-      platformIntegration: createIntegration(),
-    });
+    const indicator = await startTyping({ botPlatform, thread, message, platformIntegration });
     await indicator.done();
 
     expect(thread.startTyping).toHaveBeenCalledWith('Thinking...');
-    expect(mockAddReactionToIssueCommentFn).not.toHaveBeenCalled();
-    expect(mockAddReactionToPRFn).not.toHaveBeenCalled();
-    expect(mockAddReactionToPRReviewCommentFn).not.toHaveBeenCalled();
   });
 
-  it('adds eyes and completion reactions to GitHub issue comments', async () => {
-    const thread = createThread({
-      adapterName: PLATFORM.GITHUB,
-      id: 'github:Kilo-Org/on-call:issue:37',
-    });
-    const message = createMessage({ id: '101', raw: { comment: { id: 101 } } });
+  it('uses the platform typing override when provided', async () => {
+    const done = jest.fn(async () => undefined);
+    const botPlatform = {
+      startTyping: jest.fn(async () => ({ done })),
+    } as unknown as BotPlatform;
+    const thread = createThread();
 
-    const indicator = await startTyping({
+    const indicator = await startTyping({ botPlatform, thread, message, platformIntegration });
+    await indicator.done();
+
+    expect(botPlatform.startTyping).toHaveBeenCalledWith({
       thread,
       message,
-      platformIntegration: createIntegration(),
+      platformIntegration,
+      text: 'Thinking...',
     });
-    await indicator.done();
-
     expect(thread.startTyping).not.toHaveBeenCalled();
-    expect(mockAddReactionToIssueCommentFn).toHaveBeenNthCalledWith(
-      1,
-      '98765',
-      'Kilo-Org',
-      'on-call',
-      101,
-      'eyes',
-      'standard'
-    );
-    expect(mockAddReactionToIssueCommentFn).toHaveBeenNthCalledWith(
-      2,
-      '98765',
-      'Kilo-Org',
-      'on-call',
-      101,
-      '+1',
-      'standard'
-    );
-  });
-
-  it('adds eyes and completion reactions to GitHub review comments', async () => {
-    const thread = createThread({
-      adapterName: PLATFORM.GITHUB,
-      id: 'github:Kilo-Org/on-call:37:rc:202',
-    });
-
-    const indicator = await startTyping({
-      thread,
-      message: createMessage({ id: '203' }),
-      platformIntegration: createIntegration({ github_app_type: 'lite' }),
-    });
-    await indicator.done();
-
-    expect(mockAddReactionToPRReviewCommentFn).toHaveBeenNthCalledWith(
-      1,
-      '98765',
-      'Kilo-Org',
-      'on-call',
-      203,
-      'eyes',
-      'lite'
-    );
-    expect(mockAddReactionToPRReviewCommentFn).toHaveBeenNthCalledWith(
-      2,
-      '98765',
-      'Kilo-Org',
-      'on-call',
-      203,
-      '+1',
-      'lite'
-    );
-  });
-
-  it('does not let GitHub reaction failures block message processing', async () => {
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-    mockAddReactionToIssueCommentFn.mockRejectedValueOnce(new Error('rate limited'));
-    const thread = createThread({
-      adapterName: PLATFORM.GITHUB,
-      id: 'github:Kilo-Org/on-call:issue:37',
-    });
-
-    const indicator = await startTyping({
-      thread,
-      message: createMessage({ id: '101' }),
-      platformIntegration: createIntegration(),
-    });
-    await indicator.done();
-
-    expect(mockAddReactionToIssueCommentFn).toHaveBeenCalledTimes(2);
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      '[Bot] Failed to add GitHub bot reaction:',
-      expect.any(Error)
-    );
-    consoleWarnSpy.mockRestore();
+    expect(done).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/bot/typing.test.ts
+++ b/apps/web/src/lib/bot/typing.test.ts
@@ -1,0 +1,150 @@
+const mockAddReactionToIssueCommentFn = jest.fn();
+const mockAddReactionToPRFn = jest.fn();
+const mockAddReactionToPRReviewCommentFn = jest.fn();
+
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  addReactionToIssueComment: (...args: unknown[]) => mockAddReactionToIssueCommentFn(...args),
+  addReactionToPR: (...args: unknown[]) => mockAddReactionToPRFn(...args),
+  addReactionToPRReviewComment: (...args: unknown[]) => mockAddReactionToPRReviewCommentFn(...args),
+}));
+
+import type { PlatformIntegration } from '@kilocode/db';
+import type { Message, Thread } from 'chat';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import { startTyping } from './typing';
+
+function createIntegration(overrides: Partial<PlatformIntegration> = {}): PlatformIntegration {
+  return {
+    platform_installation_id: '98765',
+    github_app_type: 'standard',
+    ...overrides,
+  } as PlatformIntegration;
+}
+
+function createThread(params: { adapterName: string; id: string }): Thread {
+  return {
+    adapter: { name: params.adapterName },
+    id: params.id,
+    startTyping: jest.fn(async () => undefined),
+  } as unknown as Thread;
+}
+
+function createMessage(params: { id: string; raw?: unknown } = { id: '123' }): Message {
+  return {
+    id: params.id,
+    raw: params.raw ?? {},
+  } as Message;
+}
+
+describe('startTyping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the chat-sdk typing indicator outside GitHub', async () => {
+    const thread = createThread({ adapterName: PLATFORM.SLACK, id: 'thread-1' });
+
+    const indicator = await startTyping({
+      thread,
+      message: createMessage(),
+      platformIntegration: createIntegration(),
+    });
+    await indicator.done();
+
+    expect(thread.startTyping).toHaveBeenCalledWith('Thinking...');
+    expect(mockAddReactionToIssueCommentFn).not.toHaveBeenCalled();
+    expect(mockAddReactionToPRFn).not.toHaveBeenCalled();
+    expect(mockAddReactionToPRReviewCommentFn).not.toHaveBeenCalled();
+  });
+
+  it('adds eyes and completion reactions to GitHub issue comments', async () => {
+    const thread = createThread({
+      adapterName: PLATFORM.GITHUB,
+      id: 'github:Kilo-Org/on-call:issue:37',
+    });
+    const message = createMessage({ id: '101', raw: { comment: { id: 101 } } });
+
+    const indicator = await startTyping({
+      thread,
+      message,
+      platformIntegration: createIntegration(),
+    });
+    await indicator.done();
+
+    expect(thread.startTyping).not.toHaveBeenCalled();
+    expect(mockAddReactionToIssueCommentFn).toHaveBeenNthCalledWith(
+      1,
+      '98765',
+      'Kilo-Org',
+      'on-call',
+      101,
+      'eyes',
+      'standard'
+    );
+    expect(mockAddReactionToIssueCommentFn).toHaveBeenNthCalledWith(
+      2,
+      '98765',
+      'Kilo-Org',
+      'on-call',
+      101,
+      '+1',
+      'standard'
+    );
+  });
+
+  it('adds eyes and completion reactions to GitHub review comments', async () => {
+    const thread = createThread({
+      adapterName: PLATFORM.GITHUB,
+      id: 'github:Kilo-Org/on-call:37:rc:202',
+    });
+
+    const indicator = await startTyping({
+      thread,
+      message: createMessage({ id: '203' }),
+      platformIntegration: createIntegration({ github_app_type: 'lite' }),
+    });
+    await indicator.done();
+
+    expect(mockAddReactionToPRReviewCommentFn).toHaveBeenNthCalledWith(
+      1,
+      '98765',
+      'Kilo-Org',
+      'on-call',
+      203,
+      'eyes',
+      'lite'
+    );
+    expect(mockAddReactionToPRReviewCommentFn).toHaveBeenNthCalledWith(
+      2,
+      '98765',
+      'Kilo-Org',
+      'on-call',
+      203,
+      '+1',
+      'lite'
+    );
+  });
+
+  it('does not let GitHub reaction failures block message processing', async () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockAddReactionToIssueCommentFn.mockRejectedValueOnce(new Error('rate limited'));
+    const thread = createThread({
+      adapterName: PLATFORM.GITHUB,
+      id: 'github:Kilo-Org/on-call:issue:37',
+    });
+
+    const indicator = await startTyping({
+      thread,
+      message: createMessage({ id: '101' }),
+      platformIntegration: createIntegration(),
+    });
+    await indicator.done();
+
+    expect(mockAddReactionToIssueCommentFn).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[Bot] Failed to add GitHub bot reaction:',
+      expect.any(Error)
+    );
+    consoleWarnSpy.mockRestore();
+  });
+});

--- a/apps/web/src/lib/bot/typing.ts
+++ b/apps/web/src/lib/bot/typing.ts
@@ -1,208 +1,28 @@
+import type { BotPlatform, BotTypingIndicator } from '@/lib/bot/platforms/types';
 import type { PlatformIntegration } from '@kilocode/db';
 import type { Message, Thread } from 'chat';
-import { PLATFORM } from '@/lib/integrations/core/constants';
-import {
-  addReactionToIssueComment,
-  addReactionToPR,
-  addReactionToPRReviewComment,
-  type GitHubReaction,
-} from '@/lib/integrations/platforms/github/adapter';
 
-type TypingIndicator = {
-  done(): Promise<void>;
-};
-
-type GitHubThreadCoordinates = {
-  owner: string;
-  repo: string;
-  number: number;
-  reviewCommentId: number | null;
-};
-
-type GitHubReactionTarget =
-  | {
-      kind: 'issue';
-      number: number;
-    }
-  | {
-      kind: 'issueComment';
-      commentId: number;
-    }
-  | {
-      kind: 'reviewComment';
-      commentId: number;
-    };
-
-const noopTypingIndicator: TypingIndicator = {
+export const noopTypingIndicator: BotTypingIndicator = {
   async done() {},
 };
 
-function parseGitHubThreadId(threadId: string): GitHubThreadCoordinates | null {
-  if (!threadId.startsWith('github:')) return null;
-
-  const withoutPrefix = threadId.slice('github:'.length);
-  const reviewCommentMatch = withoutPrefix.match(/^([^/]+)\/([^:]+):(\d+):rc:(\d+)$/);
-  if (reviewCommentMatch) {
-    const owner = reviewCommentMatch[1];
-    const repo = reviewCommentMatch[2];
-    const number = Number.parseInt(reviewCommentMatch[3], 10);
-    const reviewCommentId = Number.parseInt(reviewCommentMatch[4], 10);
-    if (!owner || !repo || Number.isNaN(number) || Number.isNaN(reviewCommentId)) return null;
-
-    return { owner, repo, number, reviewCommentId };
-  }
-
-  const issueMatch = withoutPrefix.match(/^([^/]+)\/([^:]+):issue:(\d+)$/);
-  if (issueMatch) {
-    const owner = issueMatch[1];
-    const repo = issueMatch[2];
-    const number = Number.parseInt(issueMatch[3], 10);
-    if (!owner || !repo || Number.isNaN(number)) return null;
-
-    return { owner, repo, number, reviewCommentId: null };
-  }
-
-  const pullRequestMatch = withoutPrefix.match(/^([^/]+)\/([^:]+):(\d+)$/);
-  if (pullRequestMatch) {
-    const owner = pullRequestMatch[1];
-    const repo = pullRequestMatch[2];
-    const number = Number.parseInt(pullRequestMatch[3], 10);
-    if (!owner || !repo || Number.isNaN(number)) return null;
-
-    return { owner, repo, number, reviewCommentId: null };
-  }
-
-  return null;
-}
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function getNumericId(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isInteger(value)) return value;
-  if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
-
-  const id = Number.parseInt(value, 10);
-  return Number.isSafeInteger(id) ? id : null;
-}
-
-function getGitHubCommentId(message: Message): number | null {
-  const raw = message.raw;
-  if (isObject(raw)) {
-    const comment = raw.comment;
-    if (isObject(comment)) {
-      const commentId = getNumericId(comment.id);
-      if (commentId !== null) return commentId;
-    }
-  }
-
-  return getNumericId(message.id);
-}
-
-function getGitHubReactionTarget(
-  coordinates: GitHubThreadCoordinates,
-  message: Message
-): GitHubReactionTarget {
-  const commentId = getGitHubCommentId(message);
-
-  if (coordinates.reviewCommentId !== null) {
-    return {
-      kind: 'reviewComment',
-      commentId: commentId ?? coordinates.reviewCommentId,
-    };
-  }
-
-  if (commentId !== null) return { kind: 'issueComment', commentId };
-
-  return { kind: 'issue', number: coordinates.number };
-}
-
-async function addGitHubReaction(params: {
-  platformIntegration: PlatformIntegration;
-  coordinates: GitHubThreadCoordinates;
-  target: GitHubReactionTarget;
-  reaction: GitHubReaction;
-}): Promise<void> {
-  const installationId = params.platformIntegration.platform_installation_id;
-  if (!installationId) return;
-
-  const appType = params.platformIntegration.github_app_type ?? 'standard';
-  const { owner, repo } = params.coordinates;
-
-  switch (params.target.kind) {
-    case 'reviewComment':
-      await addReactionToPRReviewComment(
-        installationId,
-        owner,
-        repo,
-        params.target.commentId,
-        params.reaction,
-        appType
-      );
-      return;
-    case 'issueComment':
-      await addReactionToIssueComment(
-        installationId,
-        owner,
-        repo,
-        params.target.commentId,
-        params.reaction,
-        appType
-      );
-      return;
-    case 'issue':
-      await addReactionToPR(
-        installationId,
-        owner,
-        repo,
-        params.target.number,
-        params.reaction,
-        appType
-      );
-      return;
-  }
-}
-
-async function addGitHubReactionBestEffort(params: Parameters<typeof addGitHubReaction>[0]) {
-  try {
-    await addGitHubReaction(params);
-  } catch (error) {
-    console.warn('[Bot] Failed to add GitHub bot reaction:', error);
-  }
-}
-
 export async function startTyping(params: {
+  botPlatform: BotPlatform;
   thread: Thread;
   message: Message;
   platformIntegration: PlatformIntegration;
   text?: string;
-}): Promise<TypingIndicator> {
-  if (params.thread.adapter.name !== PLATFORM.GITHUB) {
-    await params.thread.startTyping(params.text ?? 'Thinking...');
-    return noopTypingIndicator;
-  }
-
-  const coordinates = parseGitHubThreadId(params.thread.id);
-  if (!coordinates) return noopTypingIndicator;
-
-  const target = getGitHubReactionTarget(coordinates, params.message);
-
-  await addGitHubReactionBestEffort({
+}): Promise<BotTypingIndicator> {
+  const text = params.text ?? 'Thinking...';
+  const platformIndicator = await params.botPlatform.startTyping?.({
+    thread: params.thread,
+    message: params.message,
     platformIntegration: params.platformIntegration,
-    coordinates,
-    target,
-    reaction: 'eyes',
+    text,
   });
 
-  return {
-    async done() {
-      await addGitHubReactionBestEffort({
-        platformIntegration: params.platformIntegration,
-        coordinates,
-        target,
-        reaction: '+1',
-      });
-    },
-  };
+  if (platformIndicator) return platformIndicator;
+
+  await params.thread.startTyping(text);
+  return noopTypingIndicator;
 }

--- a/apps/web/src/lib/bot/typing.ts
+++ b/apps/web/src/lib/bot/typing.ts
@@ -1,0 +1,208 @@
+import type { PlatformIntegration } from '@kilocode/db';
+import type { Message, Thread } from 'chat';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import {
+  addReactionToIssueComment,
+  addReactionToPR,
+  addReactionToPRReviewComment,
+  type GitHubReaction,
+} from '@/lib/integrations/platforms/github/adapter';
+
+type TypingIndicator = {
+  done(): Promise<void>;
+};
+
+type GitHubThreadCoordinates = {
+  owner: string;
+  repo: string;
+  number: number;
+  reviewCommentId: number | null;
+};
+
+type GitHubReactionTarget =
+  | {
+      kind: 'issue';
+      number: number;
+    }
+  | {
+      kind: 'issueComment';
+      commentId: number;
+    }
+  | {
+      kind: 'reviewComment';
+      commentId: number;
+    };
+
+const noopTypingIndicator: TypingIndicator = {
+  async done() {},
+};
+
+function parseGitHubThreadId(threadId: string): GitHubThreadCoordinates | null {
+  if (!threadId.startsWith('github:')) return null;
+
+  const withoutPrefix = threadId.slice('github:'.length);
+  const reviewCommentMatch = withoutPrefix.match(/^([^/]+)\/([^:]+):(\d+):rc:(\d+)$/);
+  if (reviewCommentMatch) {
+    const owner = reviewCommentMatch[1];
+    const repo = reviewCommentMatch[2];
+    const number = Number.parseInt(reviewCommentMatch[3], 10);
+    const reviewCommentId = Number.parseInt(reviewCommentMatch[4], 10);
+    if (!owner || !repo || Number.isNaN(number) || Number.isNaN(reviewCommentId)) return null;
+
+    return { owner, repo, number, reviewCommentId };
+  }
+
+  const issueMatch = withoutPrefix.match(/^([^/]+)\/([^:]+):issue:(\d+)$/);
+  if (issueMatch) {
+    const owner = issueMatch[1];
+    const repo = issueMatch[2];
+    const number = Number.parseInt(issueMatch[3], 10);
+    if (!owner || !repo || Number.isNaN(number)) return null;
+
+    return { owner, repo, number, reviewCommentId: null };
+  }
+
+  const pullRequestMatch = withoutPrefix.match(/^([^/]+)\/([^:]+):(\d+)$/);
+  if (pullRequestMatch) {
+    const owner = pullRequestMatch[1];
+    const repo = pullRequestMatch[2];
+    const number = Number.parseInt(pullRequestMatch[3], 10);
+    if (!owner || !repo || Number.isNaN(number)) return null;
+
+    return { owner, repo, number, reviewCommentId: null };
+  }
+
+  return null;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getNumericId(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value)) return value;
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
+
+  const id = Number.parseInt(value, 10);
+  return Number.isSafeInteger(id) ? id : null;
+}
+
+function getGitHubCommentId(message: Message): number | null {
+  const raw = message.raw;
+  if (isObject(raw)) {
+    const comment = raw.comment;
+    if (isObject(comment)) {
+      const commentId = getNumericId(comment.id);
+      if (commentId !== null) return commentId;
+    }
+  }
+
+  return getNumericId(message.id);
+}
+
+function getGitHubReactionTarget(
+  coordinates: GitHubThreadCoordinates,
+  message: Message
+): GitHubReactionTarget {
+  const commentId = getGitHubCommentId(message);
+
+  if (coordinates.reviewCommentId !== null) {
+    return {
+      kind: 'reviewComment',
+      commentId: commentId ?? coordinates.reviewCommentId,
+    };
+  }
+
+  if (commentId !== null) return { kind: 'issueComment', commentId };
+
+  return { kind: 'issue', number: coordinates.number };
+}
+
+async function addGitHubReaction(params: {
+  platformIntegration: PlatformIntegration;
+  coordinates: GitHubThreadCoordinates;
+  target: GitHubReactionTarget;
+  reaction: GitHubReaction;
+}): Promise<void> {
+  const installationId = params.platformIntegration.platform_installation_id;
+  if (!installationId) return;
+
+  const appType = params.platformIntegration.github_app_type ?? 'standard';
+  const { owner, repo } = params.coordinates;
+
+  switch (params.target.kind) {
+    case 'reviewComment':
+      await addReactionToPRReviewComment(
+        installationId,
+        owner,
+        repo,
+        params.target.commentId,
+        params.reaction,
+        appType
+      );
+      return;
+    case 'issueComment':
+      await addReactionToIssueComment(
+        installationId,
+        owner,
+        repo,
+        params.target.commentId,
+        params.reaction,
+        appType
+      );
+      return;
+    case 'issue':
+      await addReactionToPR(
+        installationId,
+        owner,
+        repo,
+        params.target.number,
+        params.reaction,
+        appType
+      );
+      return;
+  }
+}
+
+async function addGitHubReactionBestEffort(params: Parameters<typeof addGitHubReaction>[0]) {
+  try {
+    await addGitHubReaction(params);
+  } catch (error) {
+    console.warn('[Bot] Failed to add GitHub bot reaction:', error);
+  }
+}
+
+export async function startTyping(params: {
+  thread: Thread;
+  message: Message;
+  platformIntegration: PlatformIntegration;
+  text?: string;
+}): Promise<TypingIndicator> {
+  if (params.thread.adapter.name !== PLATFORM.GITHUB) {
+    await params.thread.startTyping(params.text ?? 'Thinking...');
+    return noopTypingIndicator;
+  }
+
+  const coordinates = parseGitHubThreadId(params.thread.id);
+  if (!coordinates) return noopTypingIndicator;
+
+  const target = getGitHubReactionTarget(coordinates, params.message);
+
+  await addGitHubReactionBestEffort({
+    platformIntegration: params.platformIntegration,
+    coordinates,
+    target,
+    reaction: 'eyes',
+  });
+
+  return {
+    async done() {
+      await addGitHubReactionBestEffort({
+        platformIntegration: params.platformIntegration,
+        coordinates,
+        target,
+        reaction: '+1',
+      });
+    },
+  };
+}

--- a/apps/web/src/lib/integrations/platforms/github/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.ts
@@ -247,22 +247,12 @@ export async function fetchGitHubInstallationDetails(
  * Used to show that Kilo is reviewing a PR (e.g., 👀 eyes reaction)
  * @param appType - The type of GitHub App to use (defaults to 'standard')
  */
-export type GitHubReaction =
-  | 'eyes'
-  | '+1'
-  | '-1'
-  | 'laugh'
-  | 'confused'
-  | 'heart'
-  | 'hooray'
-  | 'rocket';
-
 export async function addReactionToPR(
   installationId: string,
   owner: string,
   repo: string,
   prNumber: number,
-  reaction: GitHubReaction,
+  reaction: 'eyes' | '+1' | '-1' | 'laugh' | 'confused' | 'heart' | 'hooray' | 'rocket',
   appType: GitHubAppType = 'standard'
 ): Promise<void> {
   const tokenData = await generateGitHubInstallationToken(installationId, appType);
@@ -334,32 +324,13 @@ export async function addReactionToPRReviewComment(
   owner: string,
   repo: string,
   commentId: number,
-  reaction: GitHubReaction,
+  reaction: 'eyes' | '+1' | '-1' | 'laugh' | 'confused' | 'heart' | 'hooray' | 'rocket',
   appType: GitHubAppType = 'standard'
 ): Promise<void> {
   const tokenData = await generateGitHubInstallationToken(installationId, appType);
   const octokit = new Octokit({ auth: tokenData.token });
 
   await octokit.reactions.createForPullRequestReviewComment({
-    owner,
-    repo,
-    comment_id: commentId,
-    content: reaction,
-  });
-}
-
-export async function addReactionToIssueComment(
-  installationId: string,
-  owner: string,
-  repo: string,
-  commentId: number,
-  reaction: GitHubReaction,
-  appType: GitHubAppType = 'standard'
-): Promise<void> {
-  const tokenData = await generateGitHubInstallationToken(installationId, appType);
-  const octokit = new Octokit({ auth: tokenData.token });
-
-  await octokit.reactions.createForIssueComment({
     owner,
     repo,
     comment_id: commentId,

--- a/apps/web/src/lib/integrations/platforms/github/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.ts
@@ -247,12 +247,22 @@ export async function fetchGitHubInstallationDetails(
  * Used to show that Kilo is reviewing a PR (e.g., 👀 eyes reaction)
  * @param appType - The type of GitHub App to use (defaults to 'standard')
  */
+export type GitHubReaction =
+  | 'eyes'
+  | '+1'
+  | '-1'
+  | 'laugh'
+  | 'confused'
+  | 'heart'
+  | 'hooray'
+  | 'rocket';
+
 export async function addReactionToPR(
   installationId: string,
   owner: string,
   repo: string,
   prNumber: number,
-  reaction: 'eyes' | '+1' | '-1' | 'laugh' | 'confused' | 'heart' | 'hooray' | 'rocket',
+  reaction: GitHubReaction,
   appType: GitHubAppType = 'standard'
 ): Promise<void> {
   const tokenData = await generateGitHubInstallationToken(installationId, appType);
@@ -324,13 +334,32 @@ export async function addReactionToPRReviewComment(
   owner: string,
   repo: string,
   commentId: number,
-  reaction: 'eyes' | '+1' | '-1' | 'laugh' | 'confused' | 'heart' | 'hooray' | 'rocket',
+  reaction: GitHubReaction,
   appType: GitHubAppType = 'standard'
 ): Promise<void> {
   const tokenData = await generateGitHubInstallationToken(installationId, appType);
   const octokit = new Octokit({ auth: tokenData.token });
 
   await octokit.reactions.createForPullRequestReviewComment({
+    owner,
+    repo,
+    comment_id: commentId,
+    content: reaction,
+  });
+}
+
+export async function addReactionToIssueComment(
+  installationId: string,
+  owner: string,
+  repo: string,
+  commentId: number,
+  reaction: GitHubReaction,
+  appType: GitHubAppType = 'standard'
+): Promise<void> {
+  const tokenData = await generateGitHubInstallationToken(installationId, appType);
+  const octokit = new Octokit({ auth: tokenData.token });
+
+  await octokit.reactions.createForIssueComment({
     owner,
     repo,
     comment_id: commentId,


### PR DESCRIPTION
## Summary
- Adds a generic bot typing helper that delegates to a platform hook when one exists, otherwise falls back to chat-sdk `thread.startTyping` for Slack/Linear-style indicators.
- Implements GitHub processing indicators inside the GitHub platform file using chat-sdk `thread.adapter.addReaction(...)` on the triggering comment.
- Keeps GitHub reaction failures best-effort so they do not block bot processing.

## Verification
N/A (backend-only behavior change).

## Visual Changes
N/A.

## Reviewer Notes
GitHub-specific behavior is contained in the GitHub platform implementation. The Chat SDK exposes `emoji.check`, but `@chat-adapter/github` maps unsupported GitHub reactions to the closest GitHub-supported reaction because GitHub issue/comment reactions do not support a green checkmark.