### PR TITLE
Disallow experiment models for enterprise organizations

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -634,7 +634,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     // `body.provider.only` field, which doesn't reach a direct partner
     // upstream. Refuse the experimented public id rather than routing
     // around the org's allow-list.
-    if (effectiveProviderContext.experiment && providerConfig?.only !== undefined) {
+    if (effectiveProviderContext.experiment && plan === 'enterprise') {
       return modelNotAllowedResponse();
     }
 

--- a/apps/web/src/lib/organizations/organization-models.ts
+++ b/apps/web/src/lib/organizations/organization-models.ts
@@ -26,7 +26,7 @@ export async function getAvailableModelsForOrganization(
   }
 
   const responseData = await getEnhancedOpenRouterModels();
-  const restrictionCandidates = responseData.data;
+  const restrictionCandidates = [...responseData.data];
 
   let filteredModels = restrictionCandidates;
   if (hasActiveModelRestrictions(restrictions)) {

--- a/apps/web/src/lib/organizations/organization-models.ts
+++ b/apps/web/src/lib/organizations/organization-models.ts
@@ -26,8 +26,7 @@ export async function getAvailableModelsForOrganization(
   }
 
   const responseData = await getEnhancedOpenRouterModels();
-  const experimentModels = await listAvailableExperimentModels();
-  const restrictionCandidates = responseData.data.concat(experimentModels);
+  const restrictionCandidates = responseData.data;
 
   let filteredModels = restrictionCandidates;
   if (hasActiveModelRestrictions(restrictions)) {
@@ -39,6 +38,10 @@ export async function getAvailableModelsForOrganization(
       }
     }
     filteredModels = models;
+  }
+
+  if (organization.plan !== 'enterprise' && organization.settings.data_collection !== 'deny') {
+    filteredModels.push(...(await listAvailableExperimentModels()));
   }
 
   filteredModels.push(...(await getDirectByokModelsForOrganization(organizationId)));

--- a/apps/web/src/routers/organizations/organization-settings-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-settings-router.test.ts
@@ -10,9 +10,8 @@ import type {
   OpenRouterModel,
   OpenRouterModelsResponse,
 } from '@/lib/organizations/organization-types';
-import type { User, Organization } from '@kilocode/db/schema';
-import { model_experiment, organizations } from '@kilocode/db/schema';
-import { eq, inArray } from 'drizzle-orm';
+import { type User, type Organization, organizations } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
 import { db } from '@/lib/drizzle';
 
@@ -250,17 +249,6 @@ describe('organizations settings trpc router', () => {
   });
 
   describe('listAvailableModels procedure', () => {
-    const experimentPublicIds = ['kilo/preview-allowed-by-policy', 'kilo/preview-denied-by-policy'];
-
-    async function deleteExperimentModels() {
-      await db
-        .delete(model_experiment)
-        .where(inArray(model_experiment.public_model_id, experimentPublicIds));
-    }
-
-    beforeEach(deleteExperimentModels);
-    afterEach(deleteExperimentModels);
-
     function makeOpenRouterModel(id: string): OpenRouterModel {
       return {
         id,
@@ -293,24 +281,12 @@ describe('organizations settings trpc router', () => {
       } satisfies OpenRouterModelsResponse;
 
       mockedGetEnhancedOpenRouterModels.mockResolvedValue(openRouterModelsResponse);
-      await db.insert(model_experiment).values([
-        {
-          public_model_id: 'kilo/preview-allowed-by-policy',
-          name: 'Allowed experiment',
-          status: 'active',
-        },
-        {
-          public_model_id: 'kilo/preview-denied-by-policy',
-          name: 'Denied experiment',
-          status: 'active',
-        },
-      ]);
 
       const orgWithDenyList = await createTestOrganization(
         'Model Deny List',
         owner.id,
         0,
-        { model_deny_list: ['openai/gpt-4o', 'kilo/preview-denied-by-policy'] },
+        { model_deny_list: ['openai/gpt-4o'] },
         false
       );
       await addUserToOrganization(orgWithDenyList.id, member.id, 'member');
@@ -320,10 +296,7 @@ describe('organizations settings trpc router', () => {
         organizationId: orgWithDenyList.id,
       });
 
-      expect(result.data.map(model => model.id)).toEqual([
-        'anthropic/claude-3-opus',
-        'kilo/preview-allowed-by-policy',
-      ]);
+      expect(result.data.map(model => model.id)).toEqual(['anthropic/claude-3-opus']);
     });
 
     it('should include new models from allowed providers when they are not denied', async () => {


### PR DESCRIPTION
I don't think the current 'allowed when provider list is uninitialized' logic makes sense. There's no way in the UI to observe this state or to go back to it after changing it. I think we would need a new UI if we want to allow experiment models for enterprise orgs.