### PR TITLE
Normalize cloud URL filter in git URL conditions

### DIFF
--- a/apps/web/src/routers/cli-sessions-v2-router.test.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.test.ts
@@ -547,6 +547,31 @@ describe('cli-sessions-v2-router', () => {
       expect(withoutPr?.associatedPr).toBeNull();
     });
 
+    it.each([
+      'git@github.com:Kilo/Repo.git',
+      'ssh://git@github.com/Kilo/Repo.git',
+      'https://token@github.com/Kilo/Repo.git',
+    ])('list normalizes git URL filter %s', async gitUrl => {
+      const caller = await createCallerForUser(regularUser.id);
+      const result = await caller.cliSessionsV2.list({ gitUrl });
+
+      expect(result.cliSessions.map(session => session.session_id)).toEqual(
+        expect.arrayContaining([sessionWithPr, sessionWithoutPr])
+      );
+    });
+
+    it('search normalizes git URL filters', async () => {
+      const caller = await createCallerForUser(regularUser.id);
+      const result = await caller.cliSessionsV2.search({
+        search_string: 'session',
+        gitUrl: 'git@github.com:Kilo/Repo.git',
+      });
+
+      expect(result.results.map(session => session.session_id)).toEqual(
+        expect.arrayContaining([sessionWithPr, sessionWithoutPr])
+      );
+    });
+
     it('list exposes reviewDecision when the cache row has it set', async () => {
       // Update the existing cache row to have an approved review decision.
       await db

--- a/apps/web/src/routers/cli-sessions-v2-router.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.ts
@@ -29,7 +29,7 @@ import {
 } from '@/lib/session-ingest-client';
 import { SESSION_INGEST_WORKER_URL } from '@/lib/config.server';
 import { baseGetSessionNextOutputSchema } from './cloud-agent-next-schemas';
-import { KNOWN_PLATFORMS, sanitizeGitUrl } from '@/routers/cli-sessions-router';
+import { KNOWN_PLATFORMS } from '@/routers/cli-sessions-router';
 import { verifyWebhookTriggerAccess } from '@/lib/webhook-trigger-ownership';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import {
@@ -378,7 +378,7 @@ function addGitUrlConditions(whereConditions: SQL[], gitUrl: string | string[] |
     return;
   }
 
-  const urls = (Array.isArray(gitUrl) ? gitUrl : [gitUrl]).map(sanitizeGitUrl);
+  const urls = (Array.isArray(gitUrl) ? gitUrl : [gitUrl]).map(normalizeGitUrl);
   if (urls.length === 1) {
     const [url] = urls;
     if (url === undefined) {


### PR DESCRIPTION
Fixes https://github.com/Kilo-Org/kilocode/issues/11008

## Why

Cloud session filters compared raw SSH URLs against normalized HTTPS URLs, preventing repository sessions from appearing in extension history.

A local `git@github.com:org/repo.git` remote would not show cloud sessions stored as normalized `https://github.com/org/repo`.

## Implementation

Replace sanitizeGitUrl with normalizeGitUrl in addGitUrlConditions to properly handle various git URL formats (SSH, HTTPS with tokens, SCP syntax) when filtering CLI sessions by repository URL.

## Testing

- Unit tests pass
- typecheck passes