### PR TITLE
chore(ai-gateway): log client disconnects

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -236,7 +236,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   const machineIdHeader = extractHeaderAndLimitLength(request, 'x-kilocode-machineid');
 
   const logClientDisconnect = () => {
-    console.log('AI gateway client disconnected', {
+    console.log('AI gateway client disconnected, requested model: %s', requestedModelLowerCased, {
       path,
       elapsed_ms: Math.round(performance.now() - requestStartedAt),
       client_request_id: clientRequestId,

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -234,6 +234,21 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   // non-kilocode clients). `taskId` still wins when both are present.
   const sessionHeader = extractHeaderAndLimitLength(request, 'x-kilo-session');
   const machineIdHeader = extractHeaderAndLimitLength(request, 'x-kilocode-machineid');
+
+  const logClientDisconnect = () => {
+    console.log('AI gateway client disconnected', {
+      path,
+      elapsed_ms: Math.round(performance.now() - requestStartedAt),
+      client_request_id: clientRequestId,
+      session_id: taskId ?? sessionHeader,
+    });
+  };
+  if (request.signal.aborted) {
+    logClientDisconnect();
+  } else {
+    request.signal.addEventListener('abort', logClientDisconnect, { once: true });
+  }
+
   let autoModel: string | null = null;
   if (isKiloAutoModel(requestedModelLowerCased)) {
     autoModel = requestedModelLowerCased;


### PR DESCRIPTION
## Summary

- Log when an AI gateway client disconnects and aborts its request.
- Include bounded path, elapsed-time, client-request, and session correlation fields without logging request content or credentials.

## Verification

- Manual verification not run because reproducing a client disconnect requires a running gateway stack.

## Visual Changes

N/A

## Reviewer Notes

- The existing request abort signal continues to cancel the upstream provider request; this change only adds an informational log listener.