### PR TITLE
Enable cancellation for Responses endpoint

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -81,5 +81,10 @@
     "env": {
       "GIT_LFS_SKIP_SMUDGE": "0"
     }
+  },
+  "functions": {
+    "api/openrouter/responses": {
+      "supportsCancellation": true
+    }
   }
 }


### PR DESCRIPTION
this is to be able to log client disconnects: https://github.com/Kilo-Org/cloud/pull/3866#issuecomment-4660377241

this could have unintended side effects, like cost logging becoming less reliable (because the function can be killed after cancellation) so we should revert this if we notice anything strange.