### PR TITLE
fix(web): enable OpenRouter request cancellation

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -81,5 +81,10 @@
     "env": {
       "GIT_LFS_SKIP_SMUDGE": "0"
     }
+  },
+  "functions": {
+    "src/app/api/openrouter/[...path]/route.ts": {
+      "supportsCancellation": true
+    }
   }
 }


### PR DESCRIPTION
## Summary

Enable Vercel request cancellation for the OpenRouter catch-all serverless function using its App Router source path, allowing `/api/openrouter/responses` requests to stop when clients disconnect without triggering Vercel's unmatched-function validation error.

## Verification

- [ ] Not manually tested; this is a deployment configuration-only change.

## Visual Changes

N/A

## Reviewer Notes

The function pattern intentionally targets `src/app/api/openrouter/[...path]/route.ts`, which owns the Responses endpoint.