### PR TITLE
fix(kiloclaw) morning briefing plugin warmup misclassified

### DIFF
--- a/services/kiloclaw/controller/src/routes/morning-briefing.test.ts
+++ b/services/kiloclaw/controller/src/routes/morning-briefing.test.ts
@@ -95,6 +95,32 @@ describe('morning briefing controller routes', () => {
     });
   });
 
+  it('passes a plugin 404 on a mutation route through verbatim (cloud maps bare 404 to null)', async () => {
+    // Mutation routes must NOT get the plugin_unavailable rewrite: cloud's
+    // mutation wrappers only special-case a bare 404 (→ null), and the typed
+    // 503 code would be stripped crossing the DO RPC boundary and surface as
+    // a generic 500. Keeping the verbatim 404 preserves the existing typed path.
+    const app = new Hono();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ error: 'Not Found' }), { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    registerMorningBriefingRoutes(app, createRunningSupervisor(), 'expected-token');
+
+    const response = await app.request('/_kilo/morning-briefing/enable', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer expected-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ cron: '0 7 * * *', timezone: 'America/Chicago' }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Not Found' });
+  });
+
   it('passes a plugin 404 on a read route through verbatim (semantic "no briefing")', async () => {
     const app = new Hono();
     const fetchMock = vi

--- a/services/kiloclaw/controller/src/routes/morning-briefing.test.ts
+++ b/services/kiloclaw/controller/src/routes/morning-briefing.test.ts
@@ -71,6 +71,49 @@ describe('morning briefing controller routes', () => {
     );
   });
 
+  it('rewrites a plugin 404 on /status to controller-owned plugin_unavailable', async () => {
+    // The controller registered this route, so a 404 from the in-container
+    // plugin means the plugin has not loaded yet — NOT that the image is too
+    // old. Cloud must see a distinct code so it does not show "Upgrade
+    // Required" for a capable image whose plugin is still warming up.
+    const app = new Hono();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ error: 'Not Found' }), { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    registerMorningBriefingRoutes(app, createRunningSupervisor(), 'expected-token');
+
+    const response = await app.request('/_kilo/morning-briefing/status', {
+      headers: { authorization: 'Bearer expected-token' },
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      code: 'morning_briefing_plugin_unavailable',
+      error: 'Morning Briefing plugin is still loading',
+    });
+  });
+
+  it('passes a plugin 404 on a read route through verbatim (semantic "no briefing")', async () => {
+    const app = new Hono();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ error: 'No briefing for today' }), { status: 404 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    registerMorningBriefingRoutes(app, createRunningSupervisor(), 'expected-token');
+
+    const response = await app.request('/_kilo/morning-briefing/read/today', {
+      headers: { authorization: 'Bearer expected-token' },
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'No briefing for today' });
+  });
+
   it('proxies the interests route with the request body', async () => {
     const app = new Hono();
     const fetchMock = vi.fn().mockResolvedValue(

--- a/services/kiloclaw/controller/src/routes/morning-briefing.ts
+++ b/services/kiloclaw/controller/src/routes/morning-briefing.ts
@@ -28,7 +28,15 @@ async function proxyMorningBriefingRoute(params: {
   // the image is too old. Cloud's `isErrorUnknownRoute` treats a bare 404 as
   // "controller too old", so without this rewrite a transient plugin-load
   // gap surfaces to the user as a spurious "Upgrade Required" banner.
-  // Left false for routes whose 404 is semantic (e.g. "no briefing yet").
+  //
+  // Only `/status` opts in. It drives the dashboard card (and is the only
+  // route whose warm-up handling cloud actually consumes). The mutation
+  // routes are intentionally left as a verbatim 404 → cloud's existing
+  // `isErrorUnknownRoute` → null path: cloud's mutation wrappers only
+  // special-case that bare-404 signal, and the typed 503 code would be
+  // stripped crossing the DO RPC boundary and surface as a generic 500.
+  // The read routes are also left verbatim — their 404 is semantic
+  // ("no briefing yet"), not a plugin-load signal.
   notFoundMeansPluginUnavailable?: boolean;
 }): Promise<Response> {
   if (params.supervisor.getState() !== 'running') {
@@ -101,7 +109,6 @@ export function registerMorningBriefingRoutes(
       path: '/enable',
       method: 'POST',
       body,
-      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });
@@ -113,7 +120,6 @@ export function registerMorningBriefingRoutes(
       path: '/disable',
       method: 'POST',
       body: {},
-      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });
@@ -125,7 +131,6 @@ export function registerMorningBriefingRoutes(
       path: '/run',
       method: 'POST',
       body: {},
-      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });
@@ -138,7 +143,6 @@ export function registerMorningBriefingRoutes(
       path: '/onboarding-briefing',
       method: 'POST',
       body,
-      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });
@@ -151,7 +155,6 @@ export function registerMorningBriefingRoutes(
       path: '/interests',
       method: 'POST',
       body,
-      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });
@@ -164,7 +167,6 @@ export function registerMorningBriefingRoutes(
       path: '/user-location',
       method: 'POST',
       body,
-      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });

--- a/services/kiloclaw/controller/src/routes/morning-briefing.ts
+++ b/services/kiloclaw/controller/src/routes/morning-briefing.ts
@@ -19,6 +19,17 @@ async function proxyMorningBriefingRoute(params: {
   path: string;
   method: 'GET' | 'POST';
   body?: unknown;
+  // When true, a 404 from the in-container plugin is rewritten to a
+  // controller-owned `morning_briefing_plugin_unavailable` (503) instead of
+  // being passed through verbatim. Because this controller image registered
+  // the `/_kilo/morning-briefing/*` routes, a 404 from the plugin can only
+  // mean the OpenClaw `kiloclaw-morning-briefing` plugin has not finished
+  // loading yet (common right after a redeploy onto a new image) — NOT that
+  // the image is too old. Cloud's `isErrorUnknownRoute` treats a bare 404 as
+  // "controller too old", so without this rewrite a transient plugin-load
+  // gap surfaces to the user as a spurious "Upgrade Required" banner.
+  // Left false for routes whose 404 is semantic (e.g. "no briefing yet").
+  notFoundMeansPluginUnavailable?: boolean;
 }): Promise<Response> {
   if (params.supervisor.getState() !== 'running') {
     return new Response(JSON.stringify({ error: 'Gateway not running' }), {
@@ -27,8 +38,9 @@ async function proxyMorningBriefingRoute(params: {
     });
   }
 
+  let response: Response;
   try {
-    return await fetch(`http://127.0.0.1:3001${MORNING_BRIEFING_PREFIX}${params.path}`, {
+    response = await fetch(`http://127.0.0.1:3001${MORNING_BRIEFING_PREFIX}${params.path}`, {
       method: params.method,
       headers: {
         authorization: `Bearer ${params.gatewayToken}`,
@@ -43,6 +55,18 @@ async function proxyMorningBriefingRoute(params: {
       headers: { 'content-type': 'application/json' },
     });
   }
+
+  if (params.notFoundMeansPluginUnavailable && response.status === 404) {
+    return new Response(
+      JSON.stringify({
+        code: 'morning_briefing_plugin_unavailable',
+        error: 'Morning Briefing plugin is still loading',
+      }),
+      { status: 503, headers: { 'content-type': 'application/json' } }
+    );
+  }
+
+  return response;
 }
 
 export function registerMorningBriefingRoutes(
@@ -64,6 +88,7 @@ export function registerMorningBriefingRoutes(
       gatewayToken: expectedToken,
       path: '/status',
       method: 'GET',
+      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });
@@ -76,6 +101,7 @@ export function registerMorningBriefingRoutes(
       path: '/enable',
       method: 'POST',
       body,
+      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });
@@ -87,6 +113,7 @@ export function registerMorningBriefingRoutes(
       path: '/disable',
       method: 'POST',
       body: {},
+      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });
@@ -98,6 +125,7 @@ export function registerMorningBriefingRoutes(
       path: '/run',
       method: 'POST',
       body: {},
+      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });
@@ -110,6 +138,7 @@ export function registerMorningBriefingRoutes(
       path: '/onboarding-briefing',
       method: 'POST',
       body,
+      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });
@@ -122,6 +151,7 @@ export function registerMorningBriefingRoutes(
       path: '/interests',
       method: 'POST',
       body,
+      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });
@@ -134,6 +164,7 @@ export function registerMorningBriefingRoutes(
       path: '/user-location',
       method: 'POST',
       body,
+      notFoundMeansPluginUnavailable: true,
     });
     return response;
   });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
@@ -184,7 +184,7 @@ describe('gateway controller routing', () => {
     expect(result).toEqual({
       ok: true,
       reconcileState: 'in_progress',
-      error: 'Gateway warming up, retrying shortly.',
+      error: 'Morning Briefing is starting up, retrying shortly.',
       code: 'gateway_warming_up',
       retryAfterSec: 2,
     });
@@ -339,11 +339,135 @@ describe('gateway controller routing', () => {
     expect(result).toEqual({
       ok: true,
       reconcileState: 'in_progress',
-      error: 'Gateway warming up, retrying shortly.',
+      error: 'Morning Briefing is starting up, retrying shortly.',
       code: 'gateway_warming_up',
       retryAfterSec: 2,
     });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('treats a controller-reported plugin_unavailable as warm-up, not too-old', async () => {
+    // The controller image carries the routes but the in-container plugin has
+    // not finished loading: it replies 503 with `morning_briefing_plugin_unavailable`.
+    // This must surface as warm-up, never the terminal "Upgrade Required".
+    const state = createMutableState();
+    state.provider = 'fly';
+    state.status = 'running';
+    state.sandboxId = 'sandbox-1';
+    state.flyAppName = 'test-app';
+    state.flyMachineId = 'machine-1';
+
+    const fetchMock: FetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          code: 'morning_briefing_plugin_unavailable',
+          error: 'Morning Briefing plugin is still loading',
+        }),
+        { status: 503, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getMorningBriefingStatus(state, {
+      GATEWAY_TOKEN_SECRET: 'gateway-secret',
+      FLY_APP_NAME: 'fallback-app',
+    } as never);
+
+    expect(result).toEqual({
+      ok: true,
+      reconcileState: 'in_progress',
+      error: 'Morning Briefing is starting up, retrying shortly.',
+      code: 'gateway_warming_up',
+      retryAfterSec: 2,
+    });
+    // Only the status route is hit — the capability fallback is unnecessary
+    // because the controller already told us the image is capable.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null (too-old) when the route is missing AND the image lacks the capability', async () => {
+    const state = createMutableState();
+    state.provider = 'fly';
+    state.status = 'running';
+    state.sandboxId = 'sandbox-1';
+    state.flyAppName = 'test-app';
+    state.flyMachineId = 'machine-1';
+
+    // Status route 404s (no code), then the version route reports an image
+    // that does NOT advertise morning-briefing → genuinely too old.
+    const fetchMock: FetchMock = vi.fn().mockImplementation((input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('/_kilo/version')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ version: '2026.1.1.0900', commit: 'abc1234' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: 'Not Found' }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getMorningBriefingStatus(state, {
+      GATEWAY_TOKEN_SECRET: 'gateway-secret',
+      FLY_APP_NAME: 'fallback-app',
+    } as never);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns warm-up (not too-old) when the route is missing but the image is capable', async () => {
+    // A capable image hitting a transient route blip must NOT be told to
+    // upgrade — the capability list is the authoritative "is the feature
+    // present" signal.
+    const state = createMutableState();
+    state.provider = 'fly';
+    state.status = 'running';
+    state.sandboxId = 'sandbox-1';
+    state.flyAppName = 'test-app';
+    state.flyMachineId = 'machine-1';
+
+    const fetchMock: FetchMock = vi.fn().mockImplementation((input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('/_kilo/version')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              version: '2026.5.20.0900',
+              commit: 'def5678',
+              capabilities: ['morning-briefing.status'],
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: 'Not Found' }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getMorningBriefingStatus(state, {
+      GATEWAY_TOKEN_SECRET: 'gateway-secret',
+      FLY_APP_NAME: 'fallback-app',
+    } as never);
+
+    expect(result).toEqual({
+      ok: true,
+      reconcileState: 'in_progress',
+      error: 'Morning Briefing is starting up, retrying shortly.',
+      code: 'gateway_warming_up',
+      retryAfterSec: 2,
+    });
   });
 });
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -772,6 +772,47 @@ export async function importOpenclawWorkspace(
   }
 }
 
+/** Controller-owned code meaning "image has the routes, plugin not loaded yet". */
+function isMorningBriefingPluginUnavailable(error: unknown): boolean {
+  return (
+    error instanceof GatewayControllerError && error.code === 'morning_briefing_plugin_unavailable'
+  );
+}
+
+/**
+ * Transient "plugin/gateway still coming up" status the dashboard renders as
+ * a warmup state (not the terminal "Upgrade Required" banner). The card keys
+ * off `code === 'gateway_warming_up'`; the message is informational only.
+ */
+function morningBriefingWarmingUp(): z.infer<typeof MorningBriefingStatusResponseSchema> {
+  return {
+    ok: true,
+    reconcileState: 'in_progress',
+    error: 'Morning Briefing is starting up, retrying shortly.',
+    code: 'gateway_warming_up',
+    retryAfterSec: 2,
+  };
+}
+
+/**
+ * True when the controller image advertises the morning-briefing capability,
+ * i.e. the image actually carries the bundled plugin routes. Used to tell a
+ * transient route blip on a *capable* image apart from a genuinely too-old
+ * controller. Fails closed (treat as unsupported) when the version route is
+ * itself unreachable — the same conservative default as a missing route.
+ */
+async function controllerSupportsMorningBriefing(
+  state: InstanceMutableState,
+  env: KiloClawEnv
+): Promise<boolean> {
+  try {
+    const version = await getControllerVersion(state, env);
+    return version?.capabilities?.includes('morning-briefing.status') ?? false;
+  } catch {
+    return false;
+  }
+}
+
 export async function getMorningBriefingStatus(
   state: InstanceMutableState,
   env: KiloClawEnv
@@ -787,15 +828,26 @@ export async function getMorningBriefingStatus(
       { timeoutMs: 5_000 }
     );
   } catch (error) {
-    if (isErrorUnknownRoute(error)) return null;
+    // The image carries the routes but the in-container plugin has not
+    // finished loading (common right after a redeploy onto a new :latest
+    // image). Surface a transient warmup state, never "Upgrade Required".
+    if (isMorningBriefingPluginUnavailable(error)) {
+      return morningBriefingWarmingUp();
+    }
     if (isMorningBriefingWarmupControllerError(error)) {
-      return {
-        ok: true,
-        reconcileState: 'in_progress',
-        error: 'Gateway warming up, retrying shortly.',
-        code: 'gateway_warming_up',
-        retryAfterSec: 2,
-      };
+      return morningBriefingWarmingUp();
+    }
+    if (isErrorUnknownRoute(error)) {
+      // The route is missing entirely — an old controller's proxy catch-all
+      // (401 `controller_route_unavailable`) or a bare 404. Only declare the
+      // image "too old" (→ null → controller_route_unavailable → upgrade
+      // banner) when it genuinely does NOT advertise the morning-briefing
+      // capability. A capable image hitting this path is a transient blip,
+      // so we keep the user in a warmup state instead of nagging an upgrade.
+      if (await controllerSupportsMorningBriefing(state, env)) {
+        return morningBriefingWarmingUp();
+      }
+      return null;
     }
     throw error;
   }


### PR DESCRIPTION
## Summary

Stops the Morning Briefing card from showing "Upgrade Required" on instances that already have the feature.

The card's banner is driven by a status route probe. The controller route for that status is a proxy to the in-container OpenClaw `kiloclaw-morning-briefing` plugin. When the gateway is up but the plugin has not finished loading (common right after a redeploy onto a new `:latest` image), the plugin returns a bare 404. Cloud's `isErrorUnknownRoute` treats a bare 404 as "controller too old", so a transient plugin-load gap on a capable image surfaced to the user as a spurious upgrade prompt on every image release.

## Changes

- Controller (`morning-briefing.ts`): on the `/status` route, rewrite a 404 from the plugin to a controller-owned `morning_briefing_plugin_unavailable` (503). Since the controller registered the route, a plugin 404 means the plugin has not loaded yet, not that the image is too old. The rewrite is scoped to `/status` only. Mutation routes (enable, disable, run, onboarding, interests, user-location) and read routes keep passing the 404 through verbatim.
- Worker (`gateway.ts`): in `getMorningBriefingStatus`, map `morning_briefing_plugin_unavailable` to a transient warm-up status (`gateway_warming_up`), which the card already renders as a starting-up state rather than the upgrade banner. In the genuine missing-route path, only return `null` (the "too old" signal) after confirming the controller does not advertise the `morning-briefing.status` capability via `/_kilo/version`. A capable image hitting a transient blip stays in warm-up instead of being told to upgrade.
- Tests: controller tests cover the `/status` 404 rewrite, verbatim 404 pass-through on a mutation route, and verbatim 404 on a read route. Worker tests cover the plugin-unavailable warm-up mapping, the capability-confirmed too-old case returning `null`, and the capable-image transient case returning warm-up.

## Verification

- [ ] No manual app testing. The change is backend request classification, covered by the unit tests above (controller route tests and worker gateway tests). Reproducing the live race would require timing a request into the post-redeploy plugin-load window.

## Visual Changes

N/A

## Reviewer Notes

- The scoping to `/status` only is deliberate. Applying the rewrite to the mutation routes would regress their warm-up handling into a generic 500: the mutation wrappers only special-case a bare 404 (returning `null`), the typed 503 code is stripped crossing the DO RPC boundary, and the route-level warm-up retry matches by error message, not code. `/status` is the only route whose warm-up handling cloud consumes.
- Known limitation (not addressed here): a genuinely broken or disabled plugin on a capable image will sit in the `gateway_warming_up` state indefinitely rather than reaching a terminal failure. This matches the existing unbounded behavior of the warm-up state and avoids reintroducing the misleading upgrade prompt. A bounded terminal state plus plugin-load alerting would be a separate change.
