### PR TITLE
fix(kiloclaw): mount morning-briefing plugin HTTP routes via activati…

### DIFF
--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/openclaw.plugin.json
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/openclaw.plugin.json
@@ -2,6 +2,9 @@
   "id": "kiloclaw-morning-briefing",
   "name": "KiloClawMorningBriefing",
   "description": "Daily Morning Briefing plugin for KiloClaw-hosted OpenClaw",
+  "activation": {
+    "onStartup": true
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,


### PR DESCRIPTION
## Summary

The Morning Briefing plugin's HTTP control routes (`/status`, `/interests`, `/enable`, etc.) were returning 404 on running instances. In the UI this showed up as "Failed to save interests (404)" and a Morning Briefing card stuck on "Instance Warming Up".

OpenClaw 2026.5.26 activates plugins lazily, and a plugin's HTTP routes only mount on the gateway if the plugin is activated at gateway startup. The morning-briefing manifest declared no activation trigger, so the plugin activated lazily (its cron and tools still ran) but its HTTP routes were never mounted, so every request to them 404'd.

This adds `activation.onStartup: true` to the plugin manifest so the gateway imports the plugin during startup and mounts its routes.

## Verification

Validated on a running Fly instance by applying this manifest change in the container and restarting the gateway:

- [x] Gateway startup log went from mounting 10 plugins to 11, now including `kiloclaw-morning-briefing`.
- [x] `GET /api/plugins/kiloclaw-morning-briefing/status` (gateway auth): 404 before, 200 after, returning the real briefing status payload.
- [x] `POST /api/plugins/kiloclaw-morning-briefing/interests`: 404 before, 400 after (the plugin's input validation handler runs instead of route-not-found).

## Visual Changes

N/A

## Reviewer Notes

- The plugin is baked into the kiloclaw image, so this takes effect only after a kiloclaw image rebuild and instance redeploy. The running-container patch used for verification is ephemeral.
- The same lazy-activation behavior does not affect `kiloclaw-customizer` (it registers no HTTP routes) or `kilo-chat` (it owns a channel, so it already activates at startup).
