### PR TITLE
feat(kiloclaw) clean up the openclaw bump testing steps

### DIFF
--- a/scripts/check-plugin-openclaw-pin.sh
+++ b/scripts/check-plugin-openclaw-pin.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
-# Assert that the kilo-chat plugin's peerDependencies.openclaw matches the
-# version installed in services/kiloclaw/Dockerfile. Drift between the two
-# means the plugin's runtime API shape can silently diverge from the OpenClaw
-# version baked into the Docker image.
+# Assert that every exact openclaw pin in the bundled KiloClaw plugins matches
+# the version installed in services/kiloclaw/Dockerfile. Drift means a plugin's
+# runtime API shape can silently diverge from the OpenClaw version baked into the
+# Docker image.
+#
+# Checks peerDependencies.openclaw and devDependencies.openclaw for both kilo-chat
+# and kiloclaw-morning-briefing. The kiloclaw-customizer plugin intentionally uses
+# a ">=" floor rather than an exact pin, so it is not checked here.
+#
+# No arguments. Exits non-zero on any missing file/field or version mismatch.
 set -euo pipefail
 
 DOCKERFILE="services/kiloclaw/Dockerfile"
-PLUGIN_PKG="services/kiloclaw/plugins/kilo-chat/package.json"
 
-if [ ! -f "$DOCKERFILE" ] || [ ! -f "$PLUGIN_PKG" ]; then
-  echo "check-plugin-openclaw-pin: required files missing" >&2
+if [ ! -f "$DOCKERFILE" ]; then
+  echo "check-plugin-openclaw-pin: required file missing: $DOCKERFILE" >&2
   exit 1
 fi
 
@@ -22,18 +27,43 @@ if [ -z "$DOCKERFILE_VERSION" ]; then
   exit 1
 fi
 
-PEER_VERSION=$(node -e "const p=require('./$PLUGIN_PKG'); process.stdout.write(p.peerDependencies && p.peerDependencies.openclaw || '');")
+# Each entry is "package.json path:dependency field".
+PINS=(
+  "services/kiloclaw/plugins/kilo-chat/package.json:peerDependencies"
+  "services/kiloclaw/plugins/kilo-chat/package.json:devDependencies"
+  "services/kiloclaw/plugins/kiloclaw-morning-briefing/package.json:peerDependencies"
+  "services/kiloclaw/plugins/kiloclaw-morning-briefing/package.json:devDependencies"
+)
 
-if [ -z "$PEER_VERSION" ]; then
-  echo "check-plugin-openclaw-pin: $PLUGIN_PKG peerDependencies.openclaw is missing" >&2
+mismatch=0
+for entry in "${PINS[@]}"; do
+  pkg="${entry%%:*}"
+  field="${entry##*:}"
+
+  if [ ! -f "$pkg" ]; then
+    echo "check-plugin-openclaw-pin: required file missing: $pkg" >&2
+    mismatch=1
+    continue
+  fi
+
+  version=$(node -e "const p=require('./$pkg'); const d=p['$field']||{}; process.stdout.write(d.openclaw||'');")
+
+  if [ -z "$version" ]; then
+    echo "check-plugin-openclaw-pin: $pkg $field.openclaw is missing" >&2
+    mismatch=1
+    continue
+  fi
+
+  if [ "$version" != "$DOCKERFILE_VERSION" ]; then
+    echo "check-plugin-openclaw-pin: version mismatch" >&2
+    echo "  $DOCKERFILE installs openclaw@$DOCKERFILE_VERSION" >&2
+    echo "  $pkg $field.openclaw = $version" >&2
+    mismatch=1
+  fi
+done
+
+if [ "$mismatch" -ne 0 ]; then
   exit 1
 fi
 
-if [ "$DOCKERFILE_VERSION" != "$PEER_VERSION" ]; then
-  echo "check-plugin-openclaw-pin: version mismatch" >&2
-  echo "  $DOCKERFILE installs openclaw@$DOCKERFILE_VERSION" >&2
-  echo "  $PLUGIN_PKG peerDependencies.openclaw = $PEER_VERSION" >&2
-  exit 1
-fi
-
-echo "check-plugin-openclaw-pin: openclaw pinned at $DOCKERFILE_VERSION in both places."
+echo "check-plugin-openclaw-pin: openclaw pinned at $DOCKERFILE_VERSION across all bundled plugin pins."

--- a/scripts/check-plugin-openclaw-pin.sh
+++ b/scripts/check-plugin-openclaw-pin.sh
@@ -1,17 +1,27 @@
 #!/usr/bin/env bash
-# Assert that every exact openclaw pin in the bundled KiloClaw plugins matches
-# the version installed in services/kiloclaw/Dockerfile. Drift means a plugin's
+# Assert that every EXACT openclaw pin in the bundled KiloClaw plugins matches the
+# version installed in services/kiloclaw/Dockerfile. Drift means a plugin's
 # runtime API shape can silently diverge from the OpenClaw version baked into the
 # Docker image.
 #
-# Checks peerDependencies.openclaw and devDependencies.openclaw for both kilo-chat
-# and kiloclaw-morning-briefing. The kiloclaw-customizer plugin intentionally uses
-# a ">=" floor rather than an exact pin, so it is not checked here.
+# Fail-closed on a known required set (kilo-chat and kiloclaw-morning-briefing,
+# peer and dev): each must exist and match. Other bundled plugins are discovered
+# and their exact pins checked as supplemental coverage. Non-exact constraints
+# (for example the kiloclaw-customizer ">=" floor) are intentionally skipped.
 #
-# No arguments. Exits non-zero on any missing file/field or version mismatch.
+# No arguments. Exits non-zero on a missing required pin or any version mismatch.
 set -euo pipefail
 
 DOCKERFILE="services/kiloclaw/Dockerfile"
+PLUGINS_DIR="services/kiloclaw/plugins"
+
+# Required exact pins that must always exist and match (package.json:field).
+REQUIRED=(
+  "$PLUGINS_DIR/kilo-chat/package.json:peerDependencies"
+  "$PLUGINS_DIR/kilo-chat/package.json:devDependencies"
+  "$PLUGINS_DIR/kiloclaw-morning-briefing/package.json:peerDependencies"
+  "$PLUGINS_DIR/kiloclaw-morning-briefing/package.json:devDependencies"
+)
 
 if [ ! -f "$DOCKERFILE" ]; then
   echo "check-plugin-openclaw-pin: required file missing: $DOCKERFILE" >&2
@@ -27,33 +37,37 @@ if [ -z "$DOCKERFILE_VERSION" ]; then
   exit 1
 fi
 
-# Each entry is "package.json path:dependency field".
-PINS=(
-  "services/kiloclaw/plugins/kilo-chat/package.json:peerDependencies"
-  "services/kiloclaw/plugins/kilo-chat/package.json:devDependencies"
-  "services/kiloclaw/plugins/kiloclaw-morning-briefing/package.json:peerDependencies"
-  "services/kiloclaw/plugins/kiloclaw-morning-briefing/package.json:devDependencies"
-)
+read_pin() {
+  node -e "const p=require('./$1'); const d=p['$2']||{}; process.stdout.write(d.openclaw||'');"
+}
 
 mismatch=0
-for entry in "${PINS[@]}"; do
+checked=0
+
+# Required set: must be present and exact and match. Missing or non-exact fails.
+for entry in "${REQUIRED[@]}"; do
   pkg="${entry%%:*}"
   field="${entry##*:}"
-
   if [ ! -f "$pkg" ]; then
     echo "check-plugin-openclaw-pin: required file missing: $pkg" >&2
     mismatch=1
     continue
   fi
-
-  version=$(node -e "const p=require('./$pkg'); const d=p['$field']||{}; process.stdout.write(d.openclaw||'');")
-
+  version="$(read_pin "$pkg" "$field")"
   if [ -z "$version" ]; then
-    echo "check-plugin-openclaw-pin: $pkg $field.openclaw is missing" >&2
+    echo "check-plugin-openclaw-pin: required pin missing: $pkg $field.openclaw" >&2
     mismatch=1
     continue
   fi
-
+  case "$version" in
+    [0-9]*) ;;
+    *)
+      echo "check-plugin-openclaw-pin: required pin is not exact: $pkg $field.openclaw = $version" >&2
+      mismatch=1
+      continue
+      ;;
+  esac
+  checked=$((checked + 1))
   if [ "$version" != "$DOCKERFILE_VERSION" ]; then
     echo "check-plugin-openclaw-pin: version mismatch" >&2
     echo "  $DOCKERFILE installs openclaw@$DOCKERFILE_VERSION" >&2
@@ -62,8 +76,39 @@ for entry in "${PINS[@]}"; do
   fi
 done
 
+# Supplemental: any other bundled plugin's exact pins. The required plugins are
+# already covered above, so skip them here.
+for pkg in "$PLUGINS_DIR"/*/package.json; do
+  [ -f "$pkg" ] || continue
+  case "$pkg" in
+    "$PLUGINS_DIR/kilo-chat/package.json" | "$PLUGINS_DIR/kiloclaw-morning-briefing/package.json") continue ;;
+  esac
+  for field in peerDependencies devDependencies; do
+    version="$(read_pin "$pkg" "$field")"
+    [ -n "$version" ] || continue
+    case "$version" in
+      [0-9]*) ;;
+      *)
+        echo "check-plugin-openclaw-pin: skipping non-exact pin $pkg $field.openclaw = $version" >&2
+        continue
+        ;;
+    esac
+    checked=$((checked + 1))
+    if [ "$version" != "$DOCKERFILE_VERSION" ]; then
+      echo "check-plugin-openclaw-pin: version mismatch" >&2
+      echo "  $DOCKERFILE installs openclaw@$DOCKERFILE_VERSION" >&2
+      echo "  $pkg $field.openclaw = $version" >&2
+      mismatch=1
+    fi
+  done
+done
+
+if [ "$checked" -eq 0 ]; then
+  echo "check-plugin-openclaw-pin: no openclaw pins were checked; expected the required set" >&2
+  exit 1
+fi
 if [ "$mismatch" -ne 0 ]; then
   exit 1
 fi
 
-echo "check-plugin-openclaw-pin: openclaw pinned at $DOCKERFILE_VERSION across all bundled plugin pins."
+echo "check-plugin-openclaw-pin: openclaw pinned at $DOCKERFILE_VERSION across $checked bundled plugin pin(s)."

--- a/services/kiloclaw/scripts/openclaw-bump.sh
+++ b/services/kiloclaw/scripts/openclaw-bump.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deterministic OpenClaw version bump for the KiloClaw image.
+#
+# The GitHub job runs this. Given a target version it edits the pinned
+# touchpoints, regenerates the lockfile, and opens a DRAFT PR.
+#
+# Create-once and terminal: it queries all PR states for the org-owned bump
+# branch. An open PR means nothing to do; a closed PR means the version was
+# already proposed and is not recreated (override with BUMP_FORCE_RECREATE=true).
+# A leftover branch with no PR is not auto-recovered; delete it and re-run.
+# There is no force push. Pin consistency is validated by
+# scripts/check-plugin-openclaw-pin.sh before publishing, and again by CI.
+#
+# Usage:
+#   services/kiloclaw/scripts/openclaw-bump.sh <TARGET_VERSION>
+#   TARGET_VERSION env var is also accepted.
+#
+# Requires: bash, git, gh (authenticated), pnpm, node, sed. Run from a clean
+# checkout of main.
+#
+# Env:
+#   BUMP_ALLOW_DIRTY=true     local edits-only mode: edit + validate, never remote.
+#   BUMP_SIGN_COMMITS=false   disable commit signing (default is to require it).
+#   BUMP_FORCE_RECREATE=true  recreate even if a closed PR exists for the version.
+
+TARGET="${1:-${TARGET_VERSION:-}}"
+REPO="${BUMP_REPO:-Kilo-Org/cloud}"
+OWNER="${REPO%%/*}"
+ASSIGNEES="${BUMP_ASSIGNEES:-St0rmz1,pandemicsyn}"
+GIT_NAME="${BUMP_GIT_NAME:-github-actions[bot]}"
+GIT_EMAIL="${BUMP_GIT_EMAIL:-github-actions[bot]@users.noreply.github.com}"
+# Signing is required on the publish path by default. The workflow provisions the
+# key; set BUMP_SIGN_COMMITS=false only for non-publishing local use.
+BUMP_SIGN="${BUMP_SIGN_COMMITS:-true}"
+ASSESSMENT_PLACEHOLDER="_Automated upgrade assessment pending._"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+DOCKERFILE="services/kiloclaw/Dockerfile"
+KILO_CHAT_PKG="services/kiloclaw/plugins/kilo-chat/package.json"
+MORNING_PKG="services/kiloclaw/plugins/kiloclaw-morning-briefing/package.json"
+E2E_DOC="services/kiloclaw/e2e/docker-image-testing.md"
+CHANGELOG="apps/web/src/app/(app)/claw/components/changelog-data.ts"
+# Single source of truth for the files the bump stages and commits.
+BUMP_PATHS=("$DOCKERFILE" "$KILO_CHAT_PKG" "$MORNING_PKG" "$E2E_DOC" "$CHANGELOG" "pnpm-lock.yaml")
+
+die() { echo "openclaw-bump: $*" >&2; exit 1; }
+
+emit() {
+  echo "$1=$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "$1=$2" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+emit_pr_result() {
+  emit action "$1"
+  emit current "$CURRENT"
+  emit target "$TARGET"
+  emit branch "$BRANCH"
+  emit pr_url "$2"
+}
+
+# Portable in-place replace of every occurrence of the current version with the
+# target. Dots in the search are escaped so they match literally.
+replace_version() {
+  local file="$1" from_esc tmp
+  from_esc="${CURRENT//./\\.}"
+  tmp="$(mktemp)"
+  sed "s/${from_esc}/${TARGET}/g" "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
+apply_edits() {
+  # The version string appears only in openclaw pins and notes in these files,
+  # so a whole-version replace updates every occurrence with nothing to miss.
+  replace_version "$DOCKERFILE"
+  replace_version "$KILO_CHAT_PKG"
+  replace_version "$MORNING_PKG"
+  replace_version "$E2E_DOC"
+
+  # Bump the COPY cache-bust counter so the image layer rebuilds. Only the
+  # bare-integer `RUN echo "N"` line matches, not the apt cache-bust line.
+  local n new tmp
+  n="$(grep -oE 'RUN echo "[0-9]+"' "$DOCKERFILE" | head -n1 | grep -oE '[0-9]+' || true)"
+  [ -n "$n" ] || die "could not find the RUN echo cache-bust counter in $DOCKERFILE"
+  new=$((n + 1))
+  tmp="$(mktemp)"
+  sed "s/RUN echo \"${n}\"/RUN echo \"${new}\"/" "$DOCKERFILE" > "$tmp" && mv "$tmp" "$DOCKERFILE"
+
+  # Insert a changelog entry at the top of the array. Assert the anchor exists
+  # exactly once and that the entry lands, so a changed declaration cannot
+  # silently produce a PR without the changelog update.
+  local anchor='CHANGELOG_ENTRIES: ChangelogEntry\[\] = \['
+  local anchor_count
+  anchor_count="$(grep -cE "$anchor" "$CHANGELOG" || true)"
+  [ "$anchor_count" = "1" ] || die "expected exactly one changelog anchor in $CHANGELOG, found $anchor_count"
+  local entry_file
+  entry_file="$(mktemp)"
+  cat > "$entry_file" <<EOF
+  {
+    date: '$(date +%F)',
+    description: 'Updated OpenClaw to ${TARGET}.',
+    category: 'feature',
+    deployHint: 'upgrade_required',
+  },
+EOF
+  tmp="$(mktemp)"
+  sed "/$anchor/r ${entry_file}" "$CHANGELOG" > "$tmp" && mv "$tmp" "$CHANGELOG"
+  rm -f "$entry_file"
+  grep -qF "Updated OpenClaw to ${TARGET}." "$CHANGELOG" \
+    || die "changelog entry for $TARGET was not inserted into $CHANGELOG"
+}
+
+prepare_bump() {
+  echo "openclaw-bump: editing touchpoints $CURRENT -> $TARGET"
+  apply_edits
+  echo "openclaw-bump: regenerating lockfile"
+  # --no-frozen-lockfile because this is an intentional lockfile update; pnpm
+  # defaults to frozen under CI=true, which would fail after the manifest edits.
+  pnpm install --lockfile-only --no-frozen-lockfile
+  echo "openclaw-bump: validating pin consistency"
+  bash scripts/check-plugin-openclaw-pin.sh
+}
+
+create_pr() {
+  # Prints the PR URL on success; returns non-zero on failure. Failure must be
+  # explicit because command substitution clears errexit.
+  local body_file url
+  body_file="$(mktemp)"
+  cat > "$body_file" <<EOF
+## Summary
+
+Bumps the packaged OpenClaw version in the KiloClaw image from ${CURRENT} to ${TARGET}: the
+Dockerfile pin, the bundled plugin peer and dev deps, the lockfile, the e2e runbook version,
+and a changelog entry. Prepared by automation.
+
+## Verification
+
+Validate per the kiloclaw-openclaw-upgrade skill before marking this PR ready:
+
+- [ ] Run the persisted-root live smoke: \`bash services/kiloclaw/scripts/controller-openclaw-upgrade-smoke-test.sh\`
+- [ ] Run the skill's final submission gates (typecheck, tests, lint) and review plugin diagnostics.
+- [ ] Record the upgrade evidence (before and after versions, smoke result, any diagnostics) in this PR.
+- [ ] Mark this PR ready once the above pass.
+
+## Visual Changes
+
+N/A
+
+## Reviewer Notes
+
+${ASSESSMENT_PLACEHOLDER}
+EOF
+  if ! url="$(gh pr create \
+      --repo "$REPO" \
+      --draft \
+      --head "$BRANCH" \
+      --title "feat(kiloclaw): bump openclaw to version ${TARGET}" \
+      --body-file "$body_file" \
+      --assignee "$ASSIGNEES" 2>&1)"; then
+    rm -f "$body_file"
+    echo "openclaw-bump: gh pr create failed: $url" >&2
+    return 1
+  fi
+  rm -f "$body_file"
+  printf '%s' "$url"
+}
+
+publish() {
+  git checkout -b "$BRANCH"
+  git add "${BUMP_PATHS[@]}"
+  echo "openclaw-bump: staged changes:"
+  git status --short
+
+  # Commit only the touchpoint paths (pathspec), never anything else in the index.
+  local commit_args=(-c "user.name=$GIT_NAME" -c "user.email=$GIT_EMAIL")
+  [ "$BUMP_SIGN" = "true" ] && commit_args+=(-c commit.gpgsign=true)
+  git "${commit_args[@]}" \
+    commit -m "feat(kiloclaw): bump openclaw to version $TARGET" -- "${BUMP_PATHS[@]}"
+
+  # Nothing should remain modified after committing exactly the touchpoints; if a
+  # future touchpoint is edited but missing from BUMP_PATHS, this catches it.
+  if [ -n "$(git status --porcelain)" ]; then
+    die "working tree is not clean after the bump commit; refusing to push:
+$(git status --porcelain)"
+  fi
+
+  # If signing is required, the commit must actually be signed before we push.
+  if [ "$BUMP_SIGN" = "true" ]; then
+    case "$(git log -1 --format='%G?' HEAD)" in
+      G|U) : ;;
+      *) die "commit signing required but the commit is not signed (status $(git log -1 --format='%G?' HEAD)); refusing to push. Provision a signing key, or set BUMP_SIGN_COMMITS=false only for non-publishing use." ;;
+    esac
+  fi
+
+  git push origin "HEAD:$BRANCH"
+
+  local pr_url
+  if ! pr_url="$(create_pr)"; then
+    die "branch $BRANCH was pushed but gh pr create failed. Retry later, or delete the branch (git push origin --delete $BRANCH) and re-run."
+  fi
+  emit_pr_result created "$pr_url"
+  echo "openclaw-bump: opened draft PR $pr_url"
+}
+
+ensure_clean_base() {
+  if [ "${BUMP_ALLOW_DIRTY:-}" = "true" ]; then
+    echo "openclaw-bump: BUMP_ALLOW_DIRTY=true, skipping clean-checkout guard"
+    return
+  fi
+  # The push target (origin) must be the same repo gh queries and opens the PR in.
+  local origin_url
+  origin_url="$(git remote get-url origin 2>/dev/null || true)"
+  case "$origin_url" in
+    *"$REPO"*) : ;;
+    *) die "origin ($origin_url) does not match BUMP_REPO ($REPO); refusing to push to one repo while opening the PR in another." ;;
+  esac
+  # Include untracked files: pnpm install --lockfile-only evaluates every workspace
+  # package, so a stray untracked package could bleed into the lockfile.
+  local dirty
+  dirty="$(git status --porcelain)"
+  if [ -n "$dirty" ]; then
+    die "the checkout is not clean (tracked changes or untracked files); refusing to bump (set BUMP_ALLOW_DIRTY=true to override):
+$dirty"
+  fi
+  git fetch origin main >/dev/null 2>&1 || die "could not fetch origin/main"
+  if [ "$(git rev-parse HEAD)" != "$(git rev-parse FETCH_HEAD)" ]; then
+    die "HEAD is not at origin/main; the bump must branch from main (set BUMP_ALLOW_DIRTY=true to override)."
+  fi
+}
+
+[ -n "$TARGET" ] || die "no target version given (pass as arg 1 or TARGET_VERSION)"
+echo "$TARGET" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' || die "target '$TARGET' is not a clean X.Y.Z version"
+
+# Validate the checkout is clean and at origin/main BEFORE reading the current
+# pin, so the no-op decision is made against main rather than a stale or dirty
+# tree. In BUMP_ALLOW_DIRTY mode this is a no-op and the local pin is used.
+ensure_clean_base
+
+CURRENT="$(grep -oE 'openclaw@[0-9]+\.[0-9]+\.[0-9]+' "$DOCKERFILE" | head -n1 | sed 's/openclaw@//' || true)"
+[ -n "$CURRENT" ] || die "could not read the current openclaw pin from $DOCKERFILE"
+echo "openclaw-bump: current=$CURRENT target=$TARGET"
+
+# No-op guard: only move forward.
+if [ "$CURRENT" = "$TARGET" ]; then
+  emit action noop-same
+  echo "openclaw-bump: Dockerfile already pins $TARGET. Nothing to do."
+  exit 0
+fi
+if [ "$(printf '%s\n%s\n' "$CURRENT" "$TARGET" | sort -V | tail -n1)" != "$TARGET" ]; then
+  emit action noop-newer
+  echo "openclaw-bump: Dockerfile pin $CURRENT is newer than target $TARGET. Nothing to do."
+  exit 0
+fi
+
+BRANCH="feat/bump-openclaw-$TARGET"
+
+# Dirty mode is local edits-only: edit and validate, then stop. It never reaches
+# the create-once query, branch logic, commit, or push.
+if [ "${BUMP_ALLOW_DIRTY:-}" = "true" ]; then
+  prepare_bump
+  emit action edits-only
+  echo "openclaw-bump: BUMP_ALLOW_DIRTY=true; applied edits and lockfile locally, stopping before any remote action."
+  exit 0
+fi
+
+# Create-once across all PR states, scoped to our org-owned exact branch so a fork
+# cannot interfere.
+open_url="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+  --json url,headRefName,headRepositoryOwner \
+  --jq "[.[] | select(.headRepositoryOwner.login == \"$OWNER\" and .headRefName == \"$BRANCH\")][0].url // \"\"")"
+if [ -n "$open_url" ]; then
+  emit action skip-open-pr
+  emit pr_url "$open_url"
+  echo "openclaw-bump: an open PR for $BRANCH already exists: $open_url. Nothing to do."
+  exit 0
+fi
+
+closed_count="$(gh pr list --repo "$REPO" --head "$BRANCH" --state all \
+  --json state,headRefName,headRepositoryOwner \
+  --jq "[.[] | select(.headRepositoryOwner.login == \"$OWNER\" and .headRefName == \"$BRANCH\" and .state != \"OPEN\")] | length")"
+if [ "$closed_count" -gt 0 ] && [ "${BUMP_FORCE_RECREATE:-}" != "true" ]; then
+  emit action skip-closed-pr
+  echo "openclaw-bump: a PR for $BRANCH was already opened and closed; not recreating (set BUMP_FORCE_RECREATE=true to override)."
+  exit 0
+fi
+
+# A leftover branch with no open PR (for example a prior run whose PR creation
+# failed after the push) is not auto-recovered; validating a stray branch is more
+# fragile than regenerating. Delete it and re-run for a clean, complete bump.
+if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+  die "branch $BRANCH exists on origin with no open PR. Delete it and re-run to regenerate a clean bump: git push origin --delete $BRANCH"
+fi
+
+prepare_bump
+publish

--- a/services/kiloclaw/scripts/openclaw-bump.sh
+++ b/services/kiloclaw/scripts/openclaw-bump.sh
@@ -65,6 +65,21 @@ emit_pr_result() {
   emit pr_url "$2"
 }
 
+# True (0) if version $1 is strictly greater than $2. Both are CalVer X.Y.Z with
+# numeric segments, so compare segment by segment and avoid GNU-only `sort -V`
+# (BSD sort on macOS has no -V).
+version_gt() {
+  local -a a b
+  IFS=. read -r -a a <<< "$1"
+  IFS=. read -r -a b <<< "$2"
+  local i
+  for i in 0 1 2; do
+    if [ "${a[i]:-0}" -gt "${b[i]:-0}" ]; then return 0; fi
+    if [ "${a[i]:-0}" -lt "${b[i]:-0}" ]; then return 1; fi
+  done
+  return 1
+}
+
 # Portable in-place replace of every occurrence of the current version with the
 # target. Dots in the search are escaped so they match literally.
 replace_version() {
@@ -90,6 +105,17 @@ apply_edits() {
   new=$((n + 1))
   tmp="$(mktemp)"
   sed "s/RUN echo \"${n}\"/RUN echo \"${new}\"/" "$DOCKERFILE" > "$tmp" && mv "$tmp" "$DOCKERFILE"
+
+  # Refresh the adjacent "# Build cache bust:" comment so its date and vN label do
+  # not drift; AGENTS.md asks for the comment to be updated alongside the counter.
+  # replace_version already updated the openclaw-<version> part of the comment.
+  local cv newcv
+  cv="$(grep -oE 'Build cache bust: [0-9]{4}-[0-9]{2}-[0-9]{2}-v[0-9]+' "$DOCKERFILE" | grep -oE 'v[0-9]+$' | grep -oE '[0-9]+' || true)"
+  if [ -n "$cv" ]; then
+    newcv=$((cv + 1))
+    tmp="$(mktemp)"
+    sed "s/\(Build cache bust: \)[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-v[0-9]\{1,\}/\1$(date +%F)-v${newcv}/" "$DOCKERFILE" > "$tmp" && mv "$tmp" "$DOCKERFILE"
+  fi
 
   # Insert a changelog entry at the top of the array. Assert the anchor exists
   # exactly once and that the entry lands, so a changed declaration cannot
@@ -251,7 +277,7 @@ if [ "$CURRENT" = "$TARGET" ]; then
   echo "openclaw-bump: Dockerfile already pins $TARGET. Nothing to do."
   exit 0
 fi
-if [ "$(printf '%s\n%s\n' "$CURRENT" "$TARGET" | sort -V | tail -n1)" != "$TARGET" ]; then
+if ! version_gt "$TARGET" "$CURRENT"; then
   emit action noop-newer
   echo "openclaw-bump: Dockerfile pin $CURRENT is newer than target $TARGET. Nothing to do."
   exit 0


### PR DESCRIPTION
## Summary

Adds a deterministic OpenClaw version bump script and broadens the bundled plugin pin check.
The script does the mechanical work of an OpenClaw upgrade (update the pinned version across the
touchpoint files, regenerate the lockfile, validate the pins, and open a draft PR) so an upgrade
is prepared consistently for an engineer to review and validate. The pin check now covers every
bundled plugin pin instead of only one.

## Verification

- [x] Ran `bash scripts/check-plugin-openclaw-pin.sh` on the current tree: it passes (four
  plugin pins consistent, the customizer floor skipped), and it exits with an error when a
  plugin pin is drifted or a required pin is removed.
- [x] Exercised the bump script's edit logic against throwaway copies of the touchpoint files:
  every pin and note updates and the old version is fully gone.
- [ ] Did not run the script through to pushing a branch and opening a PR against the live repo;
  that path runs in the automated bump flow.

## Visual Changes

N/A

## Reviewer Notes

- New `services/kiloclaw/scripts/openclaw-bump.sh`. Given a target version it updates the
  OpenClaw pin in the Dockerfile (the install pin, the cache bust comment, and the note that
  mentions the version), the peer and dev pins in the kilo-chat and kiloclaw-morning-briefing
  plugins, the version in the e2e runbook, and adds a changelog entry. It then regenerates
  `pnpm-lock.yaml`, runs the pin check, commits those files, and opens a draft PR. It does
  nothing if the pin is already at or past the target. It opens at most one PR per version: it
  skips when an open PR exists and does not recreate a closed one. It refuses to run from a
  checkout that is dirty or not on main, and it never force pushes.
- Extends `scripts/check-plugin-openclaw-pin.sh`: it now requires the kilo-chat and
  kiloclaw-morning-briefing peer and dev pins to exist and match the Dockerfile version, and
  discovers any other bundled plugin's exact pins as well. Non-exact constraints (the
  kiloclaw-customizer floor) are skipped. Previously it checked only kilo-chat's peer pin.
- The script is meant to be run by the automated bump flow, which opens a draft PR for an
  engineer to review and run the live smoke before merging; it is not a fully automated upgrade.
- Commit signing is optional through `BUMP_SIGN_COMMITS` (off by default to match the bot's
  current commits). `BUMP_ALLOW_DIRTY` is a local mode that only edits and never pushes.
