### PR TITLE
fix(cloud-agent-next): rotate shared sandbox IDs

### DIFF
--- a/services/cloud-agent-next/src/sandbox-id.test.ts
+++ b/services/cloud-agent-next/src/sandbox-id.test.ts
@@ -53,6 +53,45 @@ describe('generateSandboxId', () => {
       const id2 = await generateSandboxId(undefined, 'org-id', 'user-id', 'session-b');
       expect(id1).toBe(id2);
     });
+
+    it.each([
+      [
+        'org',
+        'org-id',
+        undefined,
+        'org-7d891a9e4905bb0d5ff8dffcb99ba76973039c70340665b0',
+        'org-aa6ba1f356e062c430f121b97b5fd9cfd64c51487e5f28c5',
+      ],
+      [
+        'usr',
+        undefined,
+        undefined,
+        'usr-e4da69a737a38f1fc3283e8159b965e9d88f13d84c23cab1',
+        'usr-3c060fe2d53dd0b6e7a7e03084b290b64c8e0f67a8988161',
+      ],
+      [
+        'bot',
+        'org-id',
+        'reviewer',
+        'bot-b7b5ae452e738ff4c3e88238a0bd903edb1039b22314e3dc',
+        'bot-4415e0ae1dcbda7236e3bf04b66f13344682f349eac4500d',
+      ],
+      [
+        'ubt',
+        undefined,
+        'reviewer',
+        'ubt-5714320d8e828e8d428046c7f8601c126755f3e04d55b0d6',
+        'ubt-fb0f08bd868516e812f84fc34ddc327364046281c8e4c978',
+      ],
+    ])(
+      'should use the second shared sandbox ID generation for %s IDs',
+      async (_prefix, orgId, botId, expectedId, legacyId) => {
+        const id = await generateSandboxId(undefined, orgId, 'user-id', 'session', botId);
+
+        expect(id).toBe(expectedId);
+        expect(id).not.toBe(legacyId);
+      }
+    );
   });
 
   describe('prefix correctness', () => {
@@ -134,9 +173,9 @@ describe('generateSandboxId', () => {
   });
 
   describe('per-session sandbox', () => {
-    it('should produce a ses- prefixed ID for a per-session org', async () => {
+    it('should preserve the existing per-session ID generation', async () => {
       const id = await generateSandboxId('my-org', 'my-org', 'user-id', 'agent_abc123');
-      expect(id).toMatch(/^ses-[0-9a-f]{48}$/);
+      expect(id).toBe('ses-51256c9fcd04ef0144d0afcdfb9ffb2abc280ff2e0bae370');
     });
 
     it('should be exactly 52 characters', async () => {
@@ -199,7 +238,7 @@ describe('generateSandboxId', () => {
   });
 
   describe('devcontainer sandbox', () => {
-    it('should produce a dind- prefixed ID when devcontainer is true', async () => {
+    it('should preserve the existing devcontainer ID generation', async () => {
       const id = await generateSandboxId(
         undefined,
         'org-id',
@@ -208,7 +247,7 @@ describe('generateSandboxId', () => {
         undefined,
         true
       );
-      expect(id).toMatch(/^dind-[0-9a-f]{48}$/);
+      expect(id).toBe('dind-51256c9fcd04ef0144d0afcdfb9ffb2abc280ff2e0bae370');
     });
 
     it('should be exactly 53 characters', async () => {

--- a/services/cloud-agent-next/src/sandbox-id.ts
+++ b/services/cloud-agent-next/src/sandbox-id.ts
@@ -1,6 +1,8 @@
 import type { SandboxId, Env } from './types.js';
 import type { Sandbox } from '@cloudflare/sandbox';
 
+const SHARED_SANDBOX_ID_VERSION = 'shared-v2';
+
 /**
  * Parses a comma-separated org ID list into a set.
  * Returns an empty set when the value is falsy or blank.
@@ -79,5 +81,5 @@ export async function generateSandboxId(
     prefix = orgId ? 'org' : 'usr';
   }
 
-  return hashToSandboxId(originalFormat, prefix);
+  return hashToSandboxId(`${SHARED_SANDBOX_ID_VERSION}:${originalFormat}`, prefix);
 }


### PR DESCRIPTION
## Summary

- Rotate shared `org-*`, `usr-*`, `bot-*`, and `ubt-*` sandbox IDs with a versioned hash input so new sessions avoid Durable Objects carrying stale outbound-proxy state.
- Preserve existing `ses-*` per-session and `dind-*` devcontainer ID derivation exactly.
- Add regression fixtures covering every shared ID variant and the unchanged specialized ID variants.

## Verification

- Confirmed shared IDs retain their existing prefixes and deterministic behavior while producing a new hash generation.
- Confirmed per-session and devcontainer IDs match their prior exact values.

## Visual Changes

N/A

## Reviewer Notes

Existing sessions continue using their persisted sandbox IDs. This only changes ID generation for newly assigned shared sandboxes and intentionally does not add `ContainerProxy` or alter Worker compatibility configuration.