### PR TITLE
docs(agents): scope kilo-design trigger to apps/web/src path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Target a specific test file: `pnpm test -- <path>`. Run tests for a specific ser
 
 ## apps/web UI Work
 
-When editing files under `apps/web/src/**`, use the `/kilo-design` skill.
+When editing UI files in `apps/web` — React components, pages, layouts, or styles (`.tsx`/`.css`) — use the `/kilo-design` skill.
 
 ## Coding Standards
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Target a specific test file: `pnpm test -- <path>`. Run tests for a specific ser
 
 ## apps/web UI Work
 
-Before making or reviewing UI changes under `apps/web` — components, routes/pages, layouts, styling, Storybook, visual polish, UX copy, interaction states, responsive behavior, theming, or accessibility — read `DESIGN.md` and use `.agents/skills/kilo-design/SKILL.md`. This applies even when the prompt does not explicitly mention design. Skip only for backend-only or non-visual logic changes.
+When editing files under `apps/web/src/**`, use the `/kilo-design` skill.
 
 ## Coding Standards
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -2,4 +2,4 @@
 
 ## UI Work
 
-When editing files under `apps/web/src/**`, use the `/kilo-design` skill.
+When editing UI files in `apps/web` — React components, pages, layouts, or styles (`.tsx`/`.css`) — use the `/kilo-design` skill.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,11 +1,5 @@
 # AGENTS.md
 
-## UI Design Requirements
+## UI Work
 
-When doing UI work in `apps/web` — including React components, routes/pages, layouts, styling, Storybook stories, visual polish, UX copy, interaction states, responsive behavior, theming, or accessibility — you must:
-
-1. Read `../../DESIGN.md` before changing or reviewing UI.
-2. Load and follow the `kilo-design` skill at `../../.agents/skills/kilo-design/SKILL.md`.
-3. Prefer existing Kilo tokens, components, and utilities before adding new visual primitives.
-
-This applies even when the prompt does not explicitly mention design. Skip only for backend-only or non-visual logic changes.
+When editing files under `apps/web/src/**`, use the `/kilo-design` skill.


### PR DESCRIPTION
## Summary

Replaces the keyword-based UI design mandate in `AGENTS.md` and `apps/web/AGENTS.md` with one path-scoped pointer:

> When editing UI files in `apps/web` — React components, pages, layouts, or styles (`.tsx`/`.css`) — use the `/kilo-design` skill.

Naming the UI surfaces (rather than the over-broad `apps/web/src/**`, which also covers ~1800 backend `.ts` files) stops design docs from loading on non-UI work. The `/kilo-design` command and local skill are unchanged.

## Verification

- [ ] No `DESIGN.md` / keyword trigger remains in any `AGENTS.md`.
- [ ]

## Visual Changes

N/A

## Reviewer Notes

Docs-only. Fixes the trigger only; deleting the skill / `DESIGN.md` is a follow-up.