### PR TITLE
fix(auth): rate limit magic link emails

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -104,6 +104,7 @@
     "@types/js-yaml": "4.0.9",
     "@types/mdx": "2.0.13",
     "@upstash/redis": "^1.38.0",
+    "@vercel/firewall": "1.2.1",
     "@vercel/functions": "3.4.6",
     "@vercel/otel": "2.1.2",
     "@workos-inc/node": "catalog:",

--- a/apps/web/src/app/api/auth/magic-link/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/route.test.ts
@@ -6,9 +6,11 @@ import {
 import { sendMagicLinkEmail } from '@/lib/email';
 import { findUserByEmail } from '@/lib/user';
 import { MAGIC_LINK_EMAIL_ERRORS } from '@/lib/schemas/email';
+import { checkRateLimit } from '@vercel/firewall';
 import { NextResponse } from 'next/server';
 import { NextRequest } from 'next/server';
 
+jest.mock('@vercel/firewall');
 jest.mock('@/lib/auth/verify-turnstile-jwt');
 jest.mock('@/lib/auth/magic-link-tokens');
 jest.mock('@/lib/email');
@@ -20,6 +22,7 @@ const mockVerifyTurnstileJWT = jest.mocked(verifyTurnstileJWT);
 const mockCreateMagicLinkToken = jest.mocked(createMagicLinkToken);
 const mockSendMagicLinkEmail = jest.mocked(sendMagicLinkEmail);
 const mockFindUserByEmail = jest.mocked(findUserByEmail);
+const mockCheckRateLimit = jest.mocked(checkRateLimit);
 
 describe('POST /api/auth/magic-link', () => {
   const createRequest = (body: unknown) =>
@@ -58,10 +61,13 @@ describe('POST /api/auth/magic-link', () => {
 
     // Default: User does not exist (new user signup)
     mockFindUserByEmail.mockResolvedValue(undefined);
+
+    mockCheckRateLimit.mockResolvedValue({ rateLimited: false });
   });
 
   it('should send magic link for valid email with valid JWT', async () => {
-    const response = await POST(createRequest({ email: 'user@example.com' }));
+    const request = createRequest({ email: 'user@example.com' });
+    const response = await POST(request);
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -71,8 +77,43 @@ describe('POST /api/auth/magic-link', () => {
     });
 
     expect(mockVerifyTurnstileJWT).toHaveBeenCalledWith('magic-link');
+    expect(mockCheckRateLimit).toHaveBeenCalledWith('magic-link-email', {
+      request,
+      rateLimitKey: expect.stringMatching(/^magic-link-email:[A-Za-z0-9_-]+$/),
+    });
     expect(mockCreateMagicLinkToken).toHaveBeenCalledWith('user@example.com');
     expect(mockSendMagicLinkEmail).toHaveBeenCalledWith(mockMagicLinkToken, undefined);
+  });
+
+  it('should return 429 when the email address is rate limited', async () => {
+    mockCheckRateLimit.mockResolvedValue({ rateLimited: true });
+
+    const response = await POST(createRequest({ email: 'user@example.com' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(data).toEqual({
+      success: false,
+      error: 'Rate limit exceeded. Please try again later.',
+    });
+    expect(mockCreateMagicLinkToken).not.toHaveBeenCalled();
+    expect(mockSendMagicLinkEmail).not.toHaveBeenCalled();
+  });
+
+  it('should use the same rate limit key for different email casing', async () => {
+    mockFindUserByEmail.mockResolvedValue({
+      id: 'existing-user-id',
+      google_user_email: 'user@example.com',
+    } as Awaited<ReturnType<typeof findUserByEmail>>);
+
+    await POST(createRequest({ email: 'User@Example.com' }));
+    await POST(createRequest({ email: 'user@example.com' }));
+
+    expect(mockCheckRateLimit).toHaveBeenCalledTimes(2);
+    const firstKey = mockCheckRateLimit.mock.calls[0]?.[1]?.rateLimitKey;
+    const secondKey = mockCheckRateLimit.mock.calls[1]?.[1]?.rateLimitKey;
+    expect(firstKey).toEqual(expect.stringMatching(/^magic-link-email:[A-Za-z0-9_-]+$/));
+    expect(secondKey).toBe(firstKey);
   });
 
   it('should reject request with invalid Turnstile JWT', async () => {
@@ -91,6 +132,7 @@ describe('POST /api/auth/magic-link', () => {
 
     expect(response.status).toBe(401);
     expect(data).toEqual({ error: 'Security verification required' });
+    expect(mockCheckRateLimit).not.toHaveBeenCalled();
     expect(mockCreateMagicLinkToken).not.toHaveBeenCalled();
     expect(mockSendMagicLinkEmail).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/api/auth/magic-link/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/route.ts
@@ -1,5 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { checkRateLimit } from '@vercel/firewall';
+import { createHmac } from 'node:crypto';
 import { createMagicLinkToken } from '@/lib/auth/magic-link-tokens';
 import { sendMagicLinkEmail } from '@/lib/email';
 import { verifyTurnstileJWT } from '@/lib/auth/verify-turnstile-jwt';
@@ -7,11 +9,21 @@ import * as z from 'zod';
 import { findUserByEmail } from '@/lib/user';
 import { validateMagicLinkSignupEmail } from '@/lib/schemas/email';
 import { isEmailBlacklistedByDomainAsync, isBlockedTLD } from '@/lib/user/server';
+import { NEXTAUTH_SECRET } from '@/lib/config.server';
+
+const MAGIC_LINK_EMAIL_RATE_LIMIT_ID = 'magic-link-email';
 
 const requestSchema = z.object({
   email: z.string().email(),
   callbackUrl: z.string().optional(),
 });
+
+function getMagicLinkEmailRateLimitKey(email: string): string {
+  const emailHash = createHmac('sha256', NEXTAUTH_SECRET)
+    .update(email.trim().toLowerCase())
+    .digest('base64url');
+  return `magic-link-email:${emailHash}`;
+}
 
 /**
  * API route to request a magic link.
@@ -35,6 +47,18 @@ export async function POST(request: NextRequest) {
   const turnstileResult = await verifyTurnstileJWT('magic-link');
   if (!turnstileResult.success) {
     return turnstileResult.response;
+  }
+
+  const { rateLimited } = await checkRateLimit(MAGIC_LINK_EMAIL_RATE_LIMIT_ID, {
+    request,
+    rateLimitKey: getMagicLinkEmailRateLimitKey(email),
+  });
+
+  if (rateLimited) {
+    return NextResponse.json(
+      { success: false, error: 'Rate limit exceeded. Please try again later.' },
+      { status: 429 }
+    );
   }
 
   if (await isEmailBlacklistedByDomainAsync(email)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,6 +715,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.38.0
         version: 1.38.0
+      '@vercel/firewall':
+        specifier: 1.2.1
+        version: 1.2.1
       '@vercel/functions':
         specifier: 3.4.6
         version: 3.4.6(@aws-sdk/credential-provider-web-identity@3.972.43)
@@ -9163,6 +9166,10 @@ packages:
 
   '@upstash/redis@1.38.0':
     resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
+
+  '@vercel/firewall@1.2.1':
+    resolution: {integrity: sha512-WlxjEPpf+GWYMontNNZqZjvLL40ziGwy9swwI9da/L1fB/syAO1S2fMtlBXkp4EGVF6nlXSKmwvkUd6YPWJbbg==}
+    engines: {node: '>= 20'}
 
   '@vercel/functions@3.4.6':
     resolution: {integrity: sha512-ljfB7SceggUOFjagEmw3PBLSAGQK1NmBln4FV/Cg9cewfbdfJZS88LgC7LRfZ9GgG1kWimkwS/8SLHVtx6lhLA==}
@@ -24593,6 +24600,8 @@ snapshots:
   '@upstash/redis@1.38.0':
     dependencies:
       uncrypto: 0.1.3
+
+  '@vercel/firewall@1.2.1': {}
 
   '@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.43)':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `@vercel/firewall` and check the `magic-link-email` rate limit before creating or sending magic-link tokens.
- Use an HMAC of the normalized email address as the custom rate-limit key so raw email addresses are not sent to Vercel.
- Cover allowed, rate-limited, case-normalized, and Turnstile-failure magic-link paths in route tests.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
A Vercel Firewall rate-limit rule with ID `magic-link-email` must be configured for enforcement in production.