### PR TITLE
feat(web): add Claude Fable model support

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
+++ b/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
@@ -6,6 +6,7 @@ import type {
 export const CLAUDE_SONNET_CURRENT_MODEL_ID = 'anthropic/claude-sonnet-4.6';
 export const CLAUDE_OPUS_CURRENT_MODEL_ID = 'anthropic/claude-opus-4.8';
 export const CLAUDE_HAIKU_CURRENT_MODEL_ID = 'anthropic/claude-haiku-4.5';
+export const CLAUDE_FABLE_CURRENT_MODEL_ID = 'anthropic/claude-fable-5';
 export const CLAUDE_OPUS_4_8_STEALTH_MODEL_ID = 'stealth/claude-opus-4.8';
 export const CLAUDE_OPUS_STEALTH_MODEL_ID = 'stealth/claude-opus-4.7';
 export const CLAUDE_SONNET_STEALTH_MODEL_ID = 'stealth/claude-sonnet-4.6';
@@ -14,6 +15,7 @@ export const CLAUDE_OPUS_4_6_STEALTH_MODEL_ID = 'stealth/claude-opus-4.6';
 export const CLAUDE_SONNET_CURRENT_VERCEL_MODEL_ID = CLAUDE_SONNET_CURRENT_MODEL_ID;
 export const CLAUDE_OPUS_CURRENT_VERCEL_MODEL_ID = CLAUDE_OPUS_CURRENT_MODEL_ID;
 export const CLAUDE_HAIKU_CURRENT_VERCEL_MODEL_ID = CLAUDE_HAIKU_CURRENT_MODEL_ID;
+export const CLAUDE_FABLE_CURRENT_VERCEL_MODEL_ID = CLAUDE_FABLE_CURRENT_MODEL_ID;
 
 const CLAUDE_OPUS_STEALTH_PRICING: PricingTiers = [
   {
@@ -128,4 +130,8 @@ export function isHaikuModel(requestedModel: string) {
 
 export function isOpusModel(requestedModel: string) {
   return requestedModel.includes('opus');
+}
+
+export function isFableModel(requestedModel: string) {
+  return requestedModel.includes('fable');
 }

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -1,4 +1,8 @@
-import { isClaudeModel, isOpusModel } from '@/lib/ai-gateway/providers/anthropic.constants';
+import {
+  isClaudeModel,
+  isFableModel,
+  isOpusModel,
+} from '@/lib/ai-gateway/providers/anthropic.constants';
 import { isGemini3Model, isGemmaModel } from '@/lib/ai-gateway/providers/google';
 import { isKimiModel } from '@/lib/ai-gateway/providers/moonshotai';
 import { isOpenAiModel } from '@/lib/ai-gateway/providers/openai';
@@ -72,7 +76,7 @@ export const REASONING_VARIANTS_INSTANT_LOW_MEDIUM_HIGH = {
 } as const;
 
 export function getModelVariants(model: string): OpenCodeSettings['variants'] {
-  if (isOpusModel(model) && (model.includes('4.7') || model.includes('4.8'))) {
+  if (isOpusModel(model) || isFableModel(model)) {
     return REASONING_VARIANTS_OPUS;
   }
   if (isClaudeModel(model)) {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import {
+  CLAUDE_FABLE_CURRENT_VERCEL_MODEL_ID,
   CLAUDE_HAIKU_CURRENT_VERCEL_MODEL_ID,
   CLAUDE_OPUS_CURRENT_VERCEL_MODEL_ID,
   CLAUDE_SONNET_CURRENT_VERCEL_MODEL_ID,
@@ -18,6 +19,7 @@ import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelId
 describe('mapModelIdToVercel', () => {
   describe('tilde-prefixed latest aliases', () => {
     it.each([
+      ['~anthropic/claude-fable-latest', CLAUDE_FABLE_CURRENT_VERCEL_MODEL_ID],
       ['~anthropic/claude-opus-latest', CLAUDE_OPUS_CURRENT_VERCEL_MODEL_ID],
       ['~anthropic/claude-sonnet-latest', CLAUDE_SONNET_CURRENT_VERCEL_MODEL_ID],
       ['~anthropic/claude-haiku-latest', CLAUDE_HAIKU_CURRENT_VERCEL_MODEL_ID],

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
@@ -1,5 +1,6 @@
 import { kiloExclusiveModels } from '@/lib/ai-gateway/models';
 import {
+  CLAUDE_FABLE_CURRENT_VERCEL_MODEL_ID,
   CLAUDE_HAIKU_CURRENT_VERCEL_MODEL_ID,
   CLAUDE_OPUS_CURRENT_VERCEL_MODEL_ID,
   CLAUDE_SONNET_CURRENT_VERCEL_MODEL_ID,
@@ -16,6 +17,7 @@ import {
 import { inferVercelFirstPartyInferenceProviderForModel } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 
 const vercelModelIdMapping: Record<string, string | undefined> = {
+  '~anthropic/claude-fable-latest': CLAUDE_FABLE_CURRENT_VERCEL_MODEL_ID,
   '~anthropic/claude-opus-latest': CLAUDE_OPUS_CURRENT_VERCEL_MODEL_ID,
   '~anthropic/claude-sonnet-latest': CLAUDE_SONNET_CURRENT_VERCEL_MODEL_ID,
   '~anthropic/claude-haiku-latest': CLAUDE_HAIKU_CURRENT_VERCEL_MODEL_ID,


### PR DESCRIPTION
## Summary

- Add Claude Fable 5 as the current Fable model and support the `~anthropic/claude-fable-latest` Vercel alias.
- Give all Opus models and Fable models the extended Claude reasoning variants without version-specific checks.

## Verification

- Not manually tested before PR creation, per request to defer long-running tasks until after push and PR creation.

## Visual Changes

N/A

## Reviewer Notes

The Fable latest alias resolves to `anthropic/claude-fable-5`.