### PR TITLE
fix(providers): accept endpoints without tags

### DIFF
--- a/packages/db/src/schema-types.test.ts
+++ b/packages/db/src/schema-types.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@jest/globals';
+import { EndpointsSchema } from './schema-types';
+
+describe('EndpointsSchema', () => {
+  it('accepts provider endpoints without tags', () => {
+    const result = EndpointsSchema.parse({
+      data: {
+        endpoints: [
+          {
+            context_length: 128_000,
+            pricing: {
+              prompt: '0.000001',
+              completion: '0.000002',
+            },
+          },
+          {
+            tag: 'openai',
+            context_length: 128_000,
+          },
+        ],
+      },
+    });
+
+    expect(result.data.endpoints[0]?.tag).toBeUndefined();
+    expect(result.data.endpoints[1]?.tag).toBe('openai');
+  });
+});

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1342,7 +1342,7 @@ export const ModelSchema = z.object({
 export const ModelsSchema = z.object({ data: z.array(ModelSchema) });
 
 export const EndpointSchema = z.object({
-  tag: z.string(),
+  tag: z.string().optional().catch(undefined),
   context_length: z.number(),
   pricing: z
     .object({


### PR DESCRIPTION
## Summary
- Accept provider endpoints that omit the optional `tag` field so the sync providers job can process current gateway responses.
- Preserve valid provider tags and add regression coverage for tagged and untagged endpoints.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
The endpoint tag remains available when supplied; untagged endpoints naturally skip provider-specific matching.