### PR TITLE
fix(web): reset PR state when branches are reused

### DIFF
--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.test.ts
@@ -425,6 +425,84 @@ describe('upsertCliSessionPullRequestsFromWebhook', () => {
     expect(rows[0].pr_state).toBe('draft');
   });
 
+  it('starts a new open state when a branch is reused after a merged pull request', async () => {
+    const branch = 'feature/reused-after-merge';
+    await seedSession({ branch, owner: testOwner });
+
+    await upsertCliSessionPullRequestsFromWebhook(
+      makePayload({
+        action: 'closed',
+        prNumber: 208,
+        state: 'closed',
+        merged: true,
+        headRef: branch,
+        headSha: 'sha-208',
+        title: 'Merged old PR',
+      }),
+      testOwner
+    );
+    await upsertCliSessionPullRequestsFromWebhook(
+      makePayload({
+        action: 'opened',
+        prNumber: 209,
+        state: 'open',
+        headRef: branch,
+        headSha: 'sha-209',
+        title: 'Open new PR',
+      }),
+      testOwner
+    );
+
+    const rows = await readUserRow({ userId: testUserId, branch });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      pr_number: 209,
+      pr_url: `https://github.com/${REPO}/pull/209`,
+      pr_title: 'Open new PR',
+      pr_head_sha: 'sha-209',
+      pr_state: 'open',
+    });
+  });
+
+  it('starts a new open state when a branch is reused after a closed pull request', async () => {
+    const branch = 'feature/reused-after-close';
+    await seedSession({ branch, owner: testOwner });
+
+    await upsertCliSessionPullRequestsFromWebhook(
+      makePayload({
+        action: 'closed',
+        prNumber: 210,
+        state: 'closed',
+        merged: false,
+        headRef: branch,
+        headSha: 'sha-210',
+        title: 'Closed old PR',
+      }),
+      testOwner
+    );
+    await upsertCliSessionPullRequestsFromWebhook(
+      makePayload({
+        action: 'opened',
+        prNumber: 211,
+        state: 'open',
+        headRef: branch,
+        headSha: 'sha-211',
+        title: 'Open replacement PR',
+      }),
+      testOwner
+    );
+
+    const rows = await readUserRow({ userId: testUserId, branch });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      pr_number: 211,
+      pr_url: `https://github.com/${REPO}/pull/211`,
+      pr_title: 'Open replacement PR',
+      pr_head_sha: 'sha-211',
+      pr_state: 'open',
+    });
+  });
+
   it('does not demote pr_state=merged back to open on an out-of-order redelivery', async () => {
     const branch = 'feature/monotonic-merged';
     await seedSession({ branch, owner: testOwner });

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.ts
@@ -149,10 +149,12 @@ export async function upsertCliSessionPullRequestsFromWebhook(
       action === GITHUB_ACTION.REOPENED
         ? sql`excluded.pr_state`
         : sql`CASE
-            WHEN ${github_branch_pull_requests.pr_state} = 'merged'
+            WHEN ${github_branch_pull_requests.pr_number} = excluded.pr_number
+              AND ${github_branch_pull_requests.pr_state} = 'merged'
               AND excluded.pr_state IN ('open', 'closed', 'draft')
             THEN ${github_branch_pull_requests.pr_state}
-            WHEN ${github_branch_pull_requests.pr_state} = 'closed'
+            WHEN ${github_branch_pull_requests.pr_number} = excluded.pr_number
+              AND ${github_branch_pull_requests.pr_state} = 'closed'
               AND excluded.pr_state IN ('open', 'draft')
             THEN ${github_branch_pull_requests.pr_state}
             ELSE excluded.pr_state


### PR DESCRIPTION
## Summary

### Why

Cloud Agent caches one pull request per normalized repository, branch, and tenant. When a branch was reused, the webhook upsert replaced the cached PR identity but preserved the previous PR's `merged` or `closed` state, producing a hybrid record that made an open PR appear terminal.

### What was done

- Scope terminal-state protection to webhooks for the same PR number.
- Treat a different PR number on the same branch as a new state machine while retaining same-PR out-of-order delivery protection.
- Cover branch reuse after both merged and closed PRs, including the new PR number, URL, title, head SHA, and open state.

## Verification

- [ ] Not manually verified; this is a backend-only webhook cache transition with no direct UI flow to exercise in isolation.

## Visual Changes

N/A

## Reviewer Notes

- No schema migration or backfill is required; affected cache rows self-heal on a subsequent applicable webhook or successful manual refresh.
- The existing one-row-per-branch model still cannot order very late webhooks across different PR generations. This change intentionally preserves that broader limitation while fixing terminal-state carryover without weakening same-PR monotonicity.