### PR TITLE
fix(gitlab): reject OAuth secrets in GET connect

### DIFF
--- a/apps/web/src/app/api/integrations/gitlab/connect/route.test.ts
+++ b/apps/web/src/app/api/integrations/gitlab/connect/route.test.ts
@@ -198,36 +198,17 @@ describe('GET /api/integrations/gitlab/connect', () => {
     expect(mockedBuildGitLabOAuthUrl).not.toHaveBeenCalled();
   });
 
-  test('supports authenticated legacy GET self-hosted credentials during rollout', async () => {
+  test('does not accept self-hosted credentials through authenticated GET query parameters', async () => {
     const response = await callGitLabConnect(
       makeRequest(
         '/api/integrations/gitlab/connect?instanceUrl=https%3A%2F%2Fgitlab.example.com&clientId=client-id&clientSecret=client-secret'
       )
     );
 
-    expect(response.headers.get('location')).toBe(
-      'https://gitlab.com/oauth/authorize?state=signed'
-    );
-    expect(mockedStoreGitLabOAuthCredentials).toHaveBeenCalledWith({
-      clientId: 'client-id',
-      clientSecret: 'client-secret',
-    });
-    expect(mockedCreateGitLabOAuthState).toHaveBeenCalledWith(
-      {
-        owner: { type: 'user', id: USER_ID },
-        instanceUrl: 'https://gitlab.example.com',
-        customCredentialsRef: 'cached-credentials-ref',
-      },
-      USER_ID
-    );
-    expect(mockedBuildGitLabOAuthUrl).toHaveBeenCalledWith(
-      'signed-gitlab-state',
-      'https://gitlab.example.com',
-      {
-        clientId: 'client-id',
-        clientSecret: 'client-secret',
-      }
-    );
+    expectRedirectLocation(response, '/integrations/gitlab?error=oauth_init_failed');
+    expect(mockedStoreGitLabOAuthCredentials).not.toHaveBeenCalled();
+    expect(mockedCreateGitLabOAuthState).not.toHaveBeenCalled();
+    expect(mockedBuildGitLabOAuthUrl).not.toHaveBeenCalled();
   });
 
   test('preserves a valid returnTo in signed OAuth state', async () => {

--- a/apps/web/src/lib/integrations/oauth/platforms/gitlab-connect.ts
+++ b/apps/web/src/lib/integrations/oauth/platforms/gitlab-connect.ts
@@ -46,7 +46,6 @@ type GitLabOAuthConnectOptions = {
  * Query parameters:
  * - organizationId: (optional) Organization ID for org-owned integrations
  * - instanceUrl: (optional) Self-hosted GitLab instance URL
- * - clientId/clientSecret: (temporary, authenticated GET compatibility) Self-hosted OAuth credentials
  * - returnTo: (optional) Relative path to return to after OAuth
  */
 export async function handleGitLabOAuthConnect(request: NextRequest) {
@@ -66,19 +65,12 @@ export async function handleGitLabOAuthConnect(request: NextRequest) {
     }
 
     const instanceUrl = searchParams.get('instanceUrl') || undefined;
-    const clientId = searchParams.get('clientId') || undefined;
-    const clientSecret = searchParams.get('clientSecret') || undefined;
     const returnToParam = searchParams.get('returnTo') || undefined;
     const returnTo = returnToParam ? validateReturnPath(returnToParam) : null;
-    const legacyQueryCredentials =
-      clientId && clientSecret ? { clientId, clientSecret } : undefined;
 
     const oauthUrl = await buildGitLabConnectOAuthUrl(user, {
       organizationId,
       instanceUrl,
-      // Temporary rollout compatibility for old client bundles that sent
-      // self-hosted GitLab credentials through an authenticated GET.
-      ...legacyQueryCredentials,
       returnTo,
     });
 


### PR DESCRIPTION
## Summary
- Remove the temporary authenticated GET compatibility path that accepted self-hosted GitLab OAuth client secrets in query parameters.
- Keep self-hosted GitLab OAuth credentials on the POST initiation path so secrets are sent in the request body and cached server-side before signed state generation.
- Update the GitLab connect route regression test to ensure GET query credentials are rejected and never cached or propagated.

## Verification
N/A - backend route hardening with no manual UI flow changes.

## Visual Changes
N/A

## Reviewer Notes
- Current web UI already uses POST for self-hosted GitLab OAuth credentials.
- Old clients that still send self-hosted GitLab credentials through GET will now fail initialization instead of preserving secrets in URLs.