### PR TITLE
fix(cloud-agent-next): recover stalled pending sessions

### DIFF
--- a/services/cloud-agent-next/src/kilo/wrapper-manager.test.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-manager.test.ts
@@ -16,9 +16,9 @@ const { mockTimeoutWithFields, mockWarn, mockLogger } = vi.hoisted(() => {
 
 vi.mock('../logger.js', () => ({ logger: mockLogger }));
 
-import { FAST_SANDBOX_COMMAND_TIMEOUT_MS } from '../sandbox-timeout-logging.js';
 import {
   discoverSessionWrappers,
+  WRAPPER_DISCOVERY_TIMEOUT_MS,
   extractPublishedWrapperPort,
   findWrapperContainerForSession,
   isWrapperLiveInProcessesOrContainers,
@@ -177,17 +177,17 @@ describe('discoverSessionWrappers', () => {
       return result;
     });
 
-    await vi.advanceTimersByTimeAsync(FAST_SANDBOX_COMMAND_TIMEOUT_MS);
+    await vi.advanceTimersByTimeAsync(WRAPPER_DISCOVERY_TIMEOUT_MS);
 
     expect(settled).toBe(true);
     await expect(observedResult).resolves.toEqual({
       status: 'inspection-failed',
-      error: `Wrapper process discovery timed out after ${FAST_SANDBOX_COMMAND_TIMEOUT_MS}ms`,
+      error: `Wrapper process discovery timed out after ${WRAPPER_DISCOVERY_TIMEOUT_MS}ms`,
     });
     expect(mockLogger.withTags).toHaveBeenCalledWith({ logTag: 'sandbox-operation-timeout' });
     expect(mockTimeoutWithFields).toHaveBeenCalledWith({
       operation: 'wrapper.discovery.listProcesses',
-      timeoutMs: FAST_SANDBOX_COMMAND_TIMEOUT_MS,
+      timeoutMs: WRAPPER_DISCOVERY_TIMEOUT_MS,
       timeoutLayer: 'outer',
     });
     expect(mockWarn).toHaveBeenCalledOnce();

--- a/services/cloud-agent-next/src/kilo/wrapper-manager.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-manager.ts
@@ -12,10 +12,7 @@ import { withTimeout } from '@kilocode/worker-utils';
 import type { SandboxInstance } from '../types.js';
 import type { ObservedWrapper, WrapperObservation } from '../agent-sandbox/protocol.js';
 import { logger } from '../logger.js';
-import {
-  FAST_SANDBOX_COMMAND_TIMEOUT_MS,
-  logSandboxOperationTimeout,
-} from '../sandbox-timeout-logging.js';
+import { logSandboxOperationTimeout } from '../sandbox-timeout-logging.js';
 import { KILO_AGENT_SESSION_LABEL, KILO_WRAPPER_PORT_LABEL } from './devcontainer.js';
 import { dockerSocketEnv, resolveDockerSocketPath } from './sandbox-runtime.js';
 import { shellQuote } from './utils.js';
@@ -29,6 +26,7 @@ const KILO_WRAPPER_INSTANCE_FLAG = '--wrapper-instance-id';
 const KILO_WRAPPER_INSTANCE_GENERATION_FLAG = '--wrapper-instance-generation';
 const KILO_WRAPPER_INSTANCE_ENV = 'WRAPPER_INSTANCE_ID=';
 const KILO_WRAPPER_INSTANCE_GENERATION_ENV = 'WRAPPER_INSTANCE_GENERATION=';
+export const WRAPPER_DISCOVERY_TIMEOUT_MS = 10_000;
 
 /**
  * Information about a running wrapper.
@@ -296,7 +294,7 @@ export async function discoverSessionWrappers(
 ): Promise<WrapperObservation> {
   let processes: Process[];
   try {
-    const timeoutMs = FAST_SANDBOX_COMMAND_TIMEOUT_MS;
+    const timeoutMs = WRAPPER_DISCOVERY_TIMEOUT_MS;
     processes = await withTimeout(
       sandbox.listProcesses(),
       timeoutMs,

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -1913,6 +1913,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
    */
   async alarm(): Promise<void> {
     const now = Date.now();
+    await this.scheduleAlarmAtOrBefore(now + PENDING_FLUSH_DEBOUNCE_MS);
     const alarmAtStart = await this.ctx.storage.getAlarm();
 
     let pendingFlushRetryAt: number | undefined;
@@ -2033,7 +2034,21 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       // reaper retries soon rather than sleeping for an hour.
       nextAlarmAt = Date.now() + REAPER_INTERVAL_MS_DEFAULT;
     }
-    await this.ctx.storage.setAlarm(nextAlarmAt);
+    try {
+      await this.ctx.storage.setAlarm(nextAlarmAt);
+    } catch (error) {
+      logger
+        .withFields({
+          doId: this.ctx.id.toString(),
+          sessionId: this.sessionId,
+          nextAlarmAt,
+          alarmWorkFailed,
+          remainingPendingCount,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        .error('Failed to schedule next alarm reaper run');
+      throw error;
+    }
   }
 
   /**
@@ -2041,10 +2056,15 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
    * Called during initialization and when session is first created.
    */
   private async ensureAlarmScheduled(): Promise<void> {
+    if (await this.getSessionMessageQueue().requestPendingDrainIfNeeded()) {
+      logger
+        .withFields({ sessionId: this.sessionId })
+        .info('Rearmed pending session message drain during initialization');
+      return;
+    }
     const alarm = await this.ctx.storage.getAlarm();
     if (alarm === null) {
       await this.ctx.storage.setAlarm(Date.now() + this.getReaperIntervalMs());
-      return;
     }
   }
 

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -1918,6 +1918,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
 
     let pendingFlushRetryAt: number | undefined;
     let remainingPendingCount: number | undefined;
+    let terminalEffectRepairRetryAt: number | undefined;
     let alarmWorkFailed = false;
 
     try {
@@ -1952,6 +1953,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       try {
         await this.getMessageSettlementOutbox().repairTerminalEffects();
       } catch (error) {
+        terminalEffectRepairRetryAt = Date.now() + PENDING_FLUSH_DEBOUNCE_MS;
         logger
           .withFields({
             sessionId: this.sessionId,
@@ -1995,6 +1997,9 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       const deadlines = await this.getNextAlarmDeadlines();
       if (alarmWorkFailed) {
         deadlines.push(currentTime + PENDING_FLUSH_DEBOUNCE_MS);
+      }
+      if (terminalEffectRepairRetryAt !== undefined) {
+        deadlines.push(terminalEffectRepairRetryAt);
       }
       if (pendingFlushRetryAt !== undefined) {
         deadlines.push(pendingFlushRetryAt);

--- a/services/cloud-agent-next/src/session/agent-runtime.test.ts
+++ b/services/cloud-agent-next/src/session/agent-runtime.test.ts
@@ -682,49 +682,80 @@ describe('AgentRuntime', () => {
     });
   });
 
-  it.each([
-    {
-      observation: { status: 'inspection-failed', error: 'provider unavailable' },
-      reason: 'observation-failed',
-    },
-    { observation: { status: 'present', observed: [] }, reason: 'unexpected-wrapper' },
-  ])(
-    'blocks cold launch after unsafe physical preflight ($reason)',
-    async ({ observation, reason }) => {
-      const storage = createMemoryStorage();
-      const execute = vi.fn();
-      const requestAlarmAtOrBefore = vi.fn();
-      const sandbox = {
-        discoverSessionWrappers: vi.fn().mockResolvedValue(observation),
-      } as unknown as AgentSandbox;
-      const runtime = createAgentRuntime({
-        storage,
-        env: {} as Env,
-        getMetadata: async () => createMetadata(),
-        getOrchestratorOverride: () => ({ execute }),
-        getSessionIdForLogs: () => 'agent_runtime',
-        sendToWrapper: () => false,
-        createAgentSandbox: () => sandbox,
-        requestAlarmAtOrBefore,
-      });
+  it('classifies failed cold wrapper inspection as a pre-dispatch sandbox connection failure', async () => {
+    const storage = createMemoryStorage();
+    const execute = vi.fn();
+    const requestAlarmAtOrBefore = vi.fn();
+    const sandbox = {
+      discoverSessionWrappers: vi
+        .fn()
+        .mockResolvedValue({ status: 'inspection-failed', error: 'provider unavailable' }),
+    } as unknown as AgentSandbox;
+    const runtime = createAgentRuntime({
+      storage,
+      env: {} as Env,
+      getMetadata: async () => createMetadata(),
+      getOrchestratorOverride: () => ({ execute }),
+      getSessionIdForLogs: () => 'agent_runtime',
+      sendToWrapper: () => false,
+      createAgentSandbox: () => sandbox,
+      requestAlarmAtOrBefore,
+    });
 
-      const now = 10_000;
-      const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
-      try {
-        await expect(runtime.send(createPlan())).rejects.toThrow(/cleanup is required/i);
-      } finally {
-        clock.mockRestore();
-      }
-      expect(execute).not.toHaveBeenCalled();
-      expect(requestAlarmAtOrBefore).toHaveBeenCalledOnce();
-      expect(requestAlarmAtOrBefore).toHaveBeenCalledWith(now);
-      await expect(getWrapperLease(storage)).resolves.toMatchObject({
-        state: 'stop_needed',
-        target: { kind: 'session' },
-        reason,
+    const now = 10_000;
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      await expect(runtime.send(createPlan())).rejects.toMatchObject({
+        name: 'ExecutionError',
+        code: 'SANDBOX_CONNECT_FAILED',
+        retryable: true,
       });
+    } finally {
+      clock.mockRestore();
     }
-  );
+    expect(execute).not.toHaveBeenCalled();
+    expect(requestAlarmAtOrBefore).toHaveBeenCalledWith(now);
+    await expect(getWrapperLease(storage)).resolves.toMatchObject({
+      state: 'stop_needed',
+      target: { kind: 'session' },
+      reason: 'observation-failed',
+    });
+    await expect(getWrapperRuntimeState(storage)).resolves.not.toHaveProperty('wrapperRunId');
+  });
+
+  it('blocks cold launch when an unexpected physical wrapper is present', async () => {
+    const storage = createMemoryStorage();
+    const execute = vi.fn();
+    const requestAlarmAtOrBefore = vi.fn();
+    const sandbox = {
+      discoverSessionWrappers: vi.fn().mockResolvedValue({ status: 'present', observed: [] }),
+    } as unknown as AgentSandbox;
+    const runtime = createAgentRuntime({
+      storage,
+      env: {} as Env,
+      getMetadata: async () => createMetadata(),
+      getOrchestratorOverride: () => ({ execute }),
+      getSessionIdForLogs: () => 'agent_runtime',
+      sendToWrapper: () => false,
+      createAgentSandbox: () => sandbox,
+      requestAlarmAtOrBefore,
+    });
+
+    const now = 10_000;
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      await expect(runtime.send(createPlan())).rejects.toThrow(/cleanup is required/i);
+    } finally {
+      clock.mockRestore();
+    }
+    expect(execute).not.toHaveBeenCalled();
+    expect(requestAlarmAtOrBefore).toHaveBeenCalledWith(now);
+    await expect(getWrapperLease(storage)).resolves.toMatchObject({
+      state: 'stop_needed',
+      target: { kind: 'session' },
+      reason: 'unexpected-wrapper',
+    });
+  });
 
   it('does not overwrite cleanup requested while physical wrapper observation is in flight', async () => {
     const storage = createMemoryStorage();

--- a/services/cloud-agent-next/src/session/agent-runtime.ts
+++ b/services/cloud-agent-next/src/session/agent-runtime.ts
@@ -1,3 +1,4 @@
+import { ExecutionError } from '../execution/errors.js';
 import { ExecutionOrchestrator } from '../execution/orchestrator.js';
 import { createAgentSandbox } from '../agent-sandbox/factory.js';
 import type {
@@ -219,6 +220,11 @@ export function createAgentRuntime(dependencies: AgentRuntimeDependencies): Agen
         });
         await putWrapperLease(storage, cleanupLease);
         await dependencies.requestAlarmAtOrBefore?.(now);
+        if (observation.status === 'inspection-failed') {
+          throw ExecutionError.sandboxConnectFailed(
+            'Sandbox connection failed during wrapper discovery'
+          );
+        }
         throw cleanupBlockedError(cleanupLease);
       }
     }
@@ -243,6 +249,11 @@ export function createAgentRuntime(dependencies: AgentRuntimeDependencies): Agen
       });
       await putWrapperLease(storage, cleanupLease);
       await dependencies.requestAlarmAtOrBefore?.(now);
+      if (observation.status === 'inspection-failed') {
+        throw ExecutionError.sandboxConnectFailed(
+          'Sandbox connection failed during wrapper discovery'
+        );
+      }
       throw cleanupBlockedError(cleanupLease);
     }
 

--- a/services/cloud-agent-next/src/session/pending-messages.test.ts
+++ b/services/cloud-agent-next/src/session/pending-messages.test.ts
@@ -371,26 +371,44 @@ describe('recordPendingFlushFailure', () => {
     expect(delays).toEqual([2_000, undefined]);
   });
 
-  it('schedules only one cold-init retry', async () => {
+  it('retries a sandbox connection failure once after exactly five seconds', async () => {
     const storage = createMemoryStorage();
-    let message = makeMessage();
+    let message = makeMessage({ createdAt: 100_000 });
     await storePendingSessionMessage(storage, message);
 
-    const delays: (number | undefined)[] = [];
-    const now = 100_000;
+    const firstFailure = await recordPendingFlushFailure(storage, message, 'error', 100_000, {
+      policy: 'cold-init',
+      code: 'SANDBOX_CONNECT_FAILED',
+    });
+    message = firstFailure.message;
+    const secondFailure = await recordPendingFlushFailure(storage, message, 'error', 105_000, {
+      policy: 'cold-init',
+      code: 'SANDBOX_CONNECT_FAILED',
+    });
 
-    for (let i = 0; i < 2; i++) {
-      const result = await recordPendingFlushFailure(storage, message, 'error', now, {
-        policy: 'cold-init',
-        code: 'SANDBOX_CONNECT_FAILED',
-      });
-      delays.push(
-        result.nextFlushAttemptAt !== undefined ? result.nextFlushAttemptAt - now : undefined
-      );
-      message = result.message;
-    }
+    expect(firstFailure.nextFlushAttemptAt).toBe(105_000);
+    expect(firstFailure.exhausted).toBe(false);
+    expect(secondFailure.attempts).toBe(2);
+    expect(secondFailure.nextFlushAttemptAt).toBeUndefined();
+    expect(secondFailure.exhausted).toBe(true);
+  });
 
-    expect(delays).toEqual([2_000, undefined]);
+  it('starts sandbox retry attempts independently from earlier failure categories', async () => {
+    const storage = createMemoryStorage();
+    const message = makeMessage({
+      createdAt: 1,
+      flushAttempts: 2,
+      lastFlushFailureCode: 'WORKSPACE_SETUP_FAILED',
+    });
+    await storePendingSessionMessage(storage, message);
+
+    const result = await recordPendingFlushFailure(storage, message, 'error', 100_000, {
+      policy: 'cold-init',
+      code: 'SANDBOX_CONNECT_FAILED',
+    });
+
+    expect(result.attempts).toBe(1);
+    expect(result.exhausted).toBe(false);
   });
 
   it('exhausts immediately for non-retryable codes', async () => {

--- a/services/cloud-agent-next/src/session/pending-messages.ts
+++ b/services/cloud-agent-next/src/session/pending-messages.ts
@@ -12,7 +12,8 @@ import { MESSAGE_ID_FORMAT_DESCRIPTION, MESSAGE_ID_PATTERN } from './message-id.
 
 export const PENDING_SESSION_MESSAGE_LIMIT = 10;
 export const PENDING_FLUSH_RETRY_BASE_DELAY_MS = 2_000;
-// Pending delivery currently gets one redelivery after its initial failed attempt.
+const SANDBOX_CONNECT_RETRY_DELAYS_MS = [5_000] as const;
+// Other pending delivery failures currently get one redelivery after the initial failed attempt.
 const WARM_FOLLOWUP_RETRY_DELAYS_MS = [PENDING_FLUSH_RETRY_BASE_DELAY_MS] as const;
 const COLD_INIT_RETRY_DELAYS_MS = [PENDING_FLUSH_RETRY_BASE_DELAY_MS] as const;
 
@@ -433,9 +434,32 @@ export async function checkPendingSessionMessageCapacity(
       : `Pending message queue is full (${PENDING_SESSION_MESSAGE_LIMIT})`,
   };
 }
+async function replaceStoredPendingSessionMessage(
+  storage: SessionQueueStorage,
+  previous: PendingSessionMessage,
+  updated: PendingSessionMessage
+): Promise<void> {
+  const entries = (await listPendingMessageEntries(storage)).filter(
+    candidate => candidate.message.messageId === previous.messageId
+  );
+  const matchingEntry = entries.find(candidate => candidate.key === pendingMessageKey(previous));
+  const targetKey = matchingEntry?.key ?? entries[0]?.key ?? pendingMessageKey(previous);
+  await storage.put(targetKey, serializePendingSessionMessage(updated));
+  const duplicateKeys = entries.map(candidate => candidate.key).filter(key => key !== targetKey);
+  if (duplicateKeys.length === 0) return;
+  try {
+    await storage.delete(duplicateKeys);
+  } catch {
+    logger
+      .withFields({ messageId: previous.messageId, duplicateCount: duplicateKeys.length })
+      .warn('Failed to clean duplicate pending-message rows after retry update');
+  }
+}
+
 export function shouldSkipPendingFlush(message: PendingSessionMessage, now: number): boolean {
   return message.nextFlushAttemptAt !== undefined && message.nextFlushAttemptAt > now;
 }
+
 export async function recordPendingFlushFailure(
   storage: SessionQueueStorage,
   message: PendingSessionMessage,
@@ -462,16 +486,25 @@ export async function recordPendingFlushFailure(
       })
       .warn('Pending flush failure with unknown error code; treating as retryable');
   }
-  const attempts = (message.flushAttempts ?? 0) + 1;
-  const retryDelays =
-    options.policy === 'cold-init' ? COLD_INIT_RETRY_DELAYS_MS : WARM_FOLLOWUP_RETRY_DELAYS_MS;
   const flushFailureCode =
     options.code === undefined || options.code === 'INTERNAL'
       ? (message.lastFlushFailureCode ?? options.code ?? 'UNKNOWN')
       : options.code;
-  const retryable = isRetryableFlushCode(options.code);
+  const attempts =
+    flushFailureCode === 'SANDBOX_CONNECT_FAILED' &&
+    message.lastFlushFailureCode !== 'SANDBOX_CONNECT_FAILED'
+      ? 1
+      : (message.flushAttempts ?? 0) + 1;
+  const retryDelays =
+    flushFailureCode === 'SANDBOX_CONNECT_FAILED'
+      ? SANDBOX_CONNECT_RETRY_DELAYS_MS
+      : options.policy === 'cold-init'
+        ? COLD_INIT_RETRY_DELAYS_MS
+        : WARM_FOLLOWUP_RETRY_DELAYS_MS;
+  const retryable = isRetryableFlushCode(flushFailureCode);
   const exhausted = !retryable || attempts > retryDelays.length;
-  const nextFlushAttemptAt = exhausted ? undefined : now + retryDelays[attempts - 1];
+  const retryDelay = retryDelays[attempts - 1];
+  const nextFlushAttemptAt = exhausted || retryDelay === undefined ? undefined : now + retryDelay;
   const updated: PendingSessionMessage = {
     ...message,
     flushAttempts: attempts,
@@ -480,21 +513,13 @@ export async function recordPendingFlushFailure(
     lastFlushFailureCode: flushFailureCode,
     deliveryDisposition: exhausted ? 'terminalization-pending' : undefined,
   };
-  const entries = (await listPendingMessageEntries(storage)).filter(
-    candidate => candidate.message.messageId === message.messageId
-  );
-  const matchingEntry = entries.find(candidate => candidate.key === pendingMessageKey(message));
-  const targetKey = matchingEntry?.key ?? entries[0]?.key ?? pendingMessageKey(message);
-  await storage.put(targetKey, serializePendingSessionMessage(updated));
-  const duplicateKeys = entries.map(candidate => candidate.key).filter(key => key !== targetKey);
-  if (duplicateKeys.length > 0) {
-    try {
-      await storage.delete(duplicateKeys);
-    } catch {
-      logger
-        .withFields({ messageId: message.messageId, duplicateCount: duplicateKeys.length })
-        .warn('Failed to clean duplicate pending-message rows after retry update');
-    }
+  await replaceStoredPendingSessionMessage(storage, message, updated);
+  if (flushFailureCode === 'SANDBOX_CONNECT_FAILED') {
+    logger
+      .withFields({ messageId: message.messageId, attempts, nextFlushAttemptAt })
+      .warn(
+        exhausted ? 'Sandbox connection retry exhausted' : 'Sandbox connection retry scheduled'
+      );
   }
   return { message: updated, attempts, exhausted, nextFlushAttemptAt };
 }

--- a/services/cloud-agent-next/src/session/session-message-queue.test.ts
+++ b/services/cloud-agent-next/src/session/session-message-queue.test.ts
@@ -582,6 +582,76 @@ describe('SessionMessageQueue', () => {
     expect(pending?.lastFlushError).toBeUndefined();
   });
 
+  it('fails the second sandbox attempt when wrapper cleanup remains blocked', async () => {
+    const now = 200_000;
+    const harness = createQueueHarness({
+      getDeliveryBlock: async () => ({ retryAt: now + 300_000 }),
+    });
+    await storePendingSessionMessage(
+      harness.storage,
+      createPendingSessionMessage({
+        messageId: FIRST_MESSAGE_ID,
+        role: 'user',
+        content: 'fail blocked sandbox retry',
+        createdAt: 100_000,
+        flushAttempts: 1,
+        nextFlushAttemptAt: now,
+        lastFlushError: 'Sandbox connection failed during wrapper discovery',
+        lastFlushFailureCode: 'SANDBOX_CONNECT_FAILED',
+      })
+    );
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    let drain;
+    try {
+      drain = await harness.queue.drainNextPendingMessage();
+    } finally {
+      clock.mockRestore();
+    }
+
+    expect(drain).toEqual({ retryAt: undefined, remainingPendingCount: 0 });
+    expect(harness.deliver).not.toHaveBeenCalled();
+    expect(harness.terminalizations).toHaveLength(1);
+    expect(harness.terminalizations[0]?.params).toMatchObject({
+      kind: 'failed',
+      failureStage: 'pre_dispatch',
+      failureCode: 'sandbox_connect_failed',
+    });
+    await expect(listPendingSessionMessages(harness.storage)).resolves.toHaveLength(0);
+  });
+
+  it('keeps the fixed five-second sandbox retry deadline ahead of cleanup backoff', async () => {
+    const now = 200_000;
+    const retryAt = now + 5_000;
+    const harness = createQueueHarness({
+      getDeliveryBlock: async () => ({ retryAt: now + 300_000 }),
+    });
+    await storePendingSessionMessage(
+      harness.storage,
+      createPendingSessionMessage({
+        messageId: FIRST_MESSAGE_ID,
+        role: 'user',
+        content: 'wake for fixed sandbox retry',
+        createdAt: 100_000,
+        flushAttempts: 1,
+        nextFlushAttemptAt: retryAt,
+        lastFlushError: 'Sandbox connection failed during wrapper discovery',
+        lastFlushFailureCode: 'SANDBOX_CONNECT_FAILED',
+      })
+    );
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    let drain;
+    try {
+      drain = await harness.queue.drainNextPendingMessage();
+    } finally {
+      clock.mockRestore();
+    }
+
+    expect(drain).toEqual({ retryAt, remainingPendingCount: 1 });
+    expect(harness.deliver).not.toHaveBeenCalled();
+  });
+
   it('retains a queued message without consuming an attempt while wrapper cleanup blocks delivery', async () => {
     const retryAt = 50_000;
     const harness = createQueueHarness({
@@ -601,6 +671,45 @@ describe('SessionMessageQueue', () => {
     expect(pending?.messageId).toBe(FIRST_MESSAGE_ID);
     expect(pending?.flushAttempts).toBeUndefined();
     expect(pending?.lastFlushError).toBeUndefined();
+  });
+
+  it('fails the second sandbox attempt when delivery discovers blocked cleanup', async () => {
+    const now = 200_000;
+    const harness = createQueueHarness({
+      deliver: async () => {
+        throw new WrapperCleanupBlockedError(now + 300_000);
+      },
+    });
+    await storePendingSessionMessage(
+      harness.storage,
+      createPendingSessionMessage({
+        messageId: FIRST_MESSAGE_ID,
+        role: 'user',
+        content: 'fail sandbox retry blocked during delivery',
+        createdAt: 100_000,
+        flushAttempts: 1,
+        nextFlushAttemptAt: now,
+        lastFlushError: 'Sandbox connection failed during wrapper discovery',
+        lastFlushFailureCode: 'SANDBOX_CONNECT_FAILED',
+      })
+    );
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    let drain;
+    try {
+      drain = await harness.queue.drainNextPendingMessage();
+    } finally {
+      clock.mockRestore();
+    }
+
+    expect(drain).toEqual({ retryAt: undefined, remainingPendingCount: 0 });
+    expect(harness.terminalizations).toHaveLength(1);
+    expect(harness.terminalizations[0]?.params).toMatchObject({
+      kind: 'failed',
+      failureStage: 'pre_dispatch',
+      failureCode: 'sandbox_connect_failed',
+    });
+    await expect(listPendingSessionMessages(harness.storage)).resolves.toHaveLength(0);
   });
 
   it('admits a durable queued message once and replays the original acknowledgement', async () => {
@@ -1269,11 +1378,13 @@ describe('SessionMessageQueue', () => {
       turn: { type: 'prompt', id: FIRST_MESSAGE_ID, prompt: 'terminalize after retry' },
     });
     await harness.queue.drainNextPendingMessage();
-    const pending = await listPendingSessionMessages(harness.storage);
-    if (pending[0]?.nextFlushAttemptAt !== undefined) {
-      vi.spyOn(Date, 'now').mockReturnValueOnce(pending[0].nextFlushAttemptAt);
+    const [pending] = await listPendingSessionMessages(harness.storage);
+    expect(pending?.nextFlushAttemptAt).toBeDefined();
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(pending?.nextFlushAttemptAt ?? 0);
+    try {
       await harness.queue.drainNextPendingMessage();
-      vi.restoreAllMocks();
+    } finally {
+      clock.mockRestore();
     }
 
     expect(harness.terminalizations.at(-1)?.params).toMatchObject({

--- a/services/cloud-agent-next/src/session/session-message-queue.ts
+++ b/services/cloud-agent-next/src/session/session-message-queue.ts
@@ -172,6 +172,12 @@ function toFailureResult(
   };
 }
 
+function isSandboxConnectionRetry(message: PendingSessionMessage): boolean {
+  return (
+    message.lastFlushFailureCode === 'SANDBOX_CONNECT_FAILED' && (message.flushAttempts ?? 0) >= 1
+  );
+}
+
 function classifyDeliveryFailure(code: PendingFlushFailureCode | undefined): {
   failureStage: 'pre_dispatch';
   failureCode: SessionMessageFailureCode;
@@ -393,6 +399,16 @@ export async function flushNextPendingSessionMessage(params: {
 
   const deliveryBlock = await params.getDeliveryBlock?.();
   if (deliveryBlock) {
+    if (isSandboxConnectionRetry(message)) {
+      const failure = await recordPendingFlushFailure(
+        params.storage,
+        message,
+        message.lastFlushError ?? 'Sandbox connection failed',
+        params.now,
+        { policy, code: 'SANDBOX_CONNECT_FAILED' }
+      );
+      return toFailureResult(failure, totalCount);
+    }
     return {
       type: 'skipped',
       nextFlushAttemptAt: deliveryBlock.retryAt,
@@ -429,6 +445,16 @@ export async function flushNextPendingSessionMessage(params: {
       return toFailureResult(error.failure, totalCount);
     }
     if (error instanceof WrapperCleanupBlockedError) {
+      if (isSandboxConnectionRetry(message)) {
+        const failure = await recordPendingFlushFailure(
+          params.storage,
+          message,
+          message.lastFlushError ?? 'Sandbox connection failed',
+          Date.now(),
+          { policy, code: 'SANDBOX_CONNECT_FAILED' }
+        );
+        return toFailureResult(failure, totalCount);
+      }
       return {
         type: 'skipped',
         nextFlushAttemptAt: error.retryAt,

--- a/services/cloud-agent-next/test/integration/session/pending-messages.test.ts
+++ b/services/cloud-agent-next/test/integration/session/pending-messages.test.ts
@@ -13,6 +13,7 @@ import {
   type PendingSessionMessage,
 } from '../../../src/session/pending-messages.js';
 import { createEventQueries } from '../../../src/session/queries/events.js';
+import { PENDING_FLUSH_DEBOUNCE_MS } from '../../../src/session/session-message-queue.js';
 import {
   getSessionMessageState,
   listMessagesWithPendingCallbacks,
@@ -244,6 +245,80 @@ describe('pending session messages', () => {
     expect(result.queueResult).toMatchObject({ success: true, outcome: 'queued' });
     expect(result.staleAlarm).toBeDefined();
     expect(result.refreshedAlarm).toBeGreaterThan(result.staleAlarm ?? result.now);
+  });
+
+  it('pulls a far-future alarm forward when durable pending work already exists', async () => {
+    const userId = 'user_pending_reconstruct_alarm';
+    const sessionId = 'agent_pending_reconstruct_alarm';
+    const stub = env.CLOUD_AGENT_SESSION.get(
+      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+    );
+
+    const result = await runInDurableObject(stub, async instance => {
+      await registerReadySession(instance, {
+        sessionId,
+        userId,
+        prompt: 'prepared prompt',
+        mode: 'code',
+        model: 'test-model',
+        kilocodeToken: 'token-reconstruct-alarm',
+      });
+      await storePendingSessionMessage(
+        instance.ctx.storage,
+        createMessage({
+          messageId: 'msg_018f1e2d3c4bReconAlrmAbCdE',
+          content: 'recover pending drain',
+          createdAt: Date.now(),
+        })
+      );
+      const now = Date.now();
+      const farFutureAlarm = now + 5 * 60 * 1000;
+      await instance.ctx.storage.setAlarm(farFutureAlarm);
+
+      await instance['ensureAlarmScheduled']();
+
+      return { now, farFutureAlarm, repairedAlarm: await instance.ctx.storage.getAlarm() };
+    });
+
+    expect(result.repairedAlarm).toBeGreaterThan(result.now);
+    expect(result.repairedAlarm).toBeLessThan(result.farFutureAlarm);
+    expect(result.repairedAlarm).toBeLessThanOrEqual(result.now + 2_000);
+  });
+
+  it('pre-arms the next wake-up before alarm work can block', async () => {
+    const userId = 'user_pending_alarm_prearm';
+    const sessionId = 'agent_pending_alarm_prearm';
+    const stub = env.CLOUD_AGENT_SESSION.get(
+      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+    );
+
+    const result = await runInDurableObject(stub, async instance => {
+      let releaseFlush: ((result: { remainingPendingCount: number }) => void) | undefined;
+      let markFlushStarted: (() => void) | undefined;
+      const flushStarted = new Promise<void>(resolve => {
+        markFlushStarted = resolve;
+      });
+      const blockedFlush = new Promise<{ remainingPendingCount: number }>(resolve => {
+        releaseFlush = resolve;
+      });
+      (instance as any).flushOnePendingSessionMessage = async () => {
+        markFlushStarted?.();
+        return blockedFlush;
+      };
+      await instance.ctx.storage.deleteAlarm();
+
+      const startedAt = Date.now();
+      const alarmRun = instance.alarm();
+      await flushStarted;
+      const prearmed = await instance.ctx.storage.getAlarm();
+      releaseFlush?.({ remainingPendingCount: 0 });
+      await alarmRun;
+      return { startedAt, prearmed };
+    });
+
+    expect(result.prearmed).not.toBeNull();
+    expect(result.prearmed).toBeGreaterThanOrEqual(result.startedAt);
+    expect(result.prearmed).toBeLessThanOrEqual(result.startedAt + PENDING_FLUSH_DEBOUNCE_MS + 100);
   });
 
   it('flushes one FIFO message on alarm and deletes after orchestrator accepts', async () => {
@@ -532,7 +607,7 @@ describe('pending session messages', () => {
     expect(result.finalLease.state).toBe('owns_wrapper');
   });
 
-  it('does not consume a delivery attempt when wrapper authorization discovers required cleanup', async () => {
+  it('records a retryable sandbox failure when wrapper authorization discovers required cleanup', async () => {
     const userId = 'user_pending_cleanup_discovery';
     const sessionId = 'agent_pending_cleanup_discovery';
     const stub = env.CLOUD_AGENT_SESSION.get(
@@ -566,24 +641,40 @@ describe('pending session messages', () => {
         createMessage({
           messageId: 'msg_018f1e2d3c4bCleanDiscAbCdE',
           content: 'deliver after cleanup discovery',
-          createdAt: 1,
+          createdAt: Date.now(),
         })
       );
 
+      const attemptStartedAt = Date.now();
       await instance.alarm();
+      const attemptFinishedAt = Date.now();
       return {
         authorizationInspections,
         deliveryAttempts,
+        attemptStartedAt,
+        attemptFinishedAt,
         pending: await listPendingSessionMessages(instance.ctx.storage),
         lease: await getWrapperLease(instance.ctx.storage),
+        alarm: await instance.ctx.storage.getAlarm(),
       };
     });
 
     expect(result.authorizationInspections).toBe(1);
     expect(result.deliveryAttempts).toBe(0);
     expect(result.pending).toHaveLength(1);
-    expect(result.pending[0]?.flushAttempts).toBeUndefined();
-    expect(result.pending[0]?.lastFlushError).toBeUndefined();
+    expect(result.pending[0]?.flushAttempts).toBe(1);
+    expect(result.pending[0]?.lastFlushError).toBe(
+      'Sandbox connection failed during wrapper discovery'
+    );
+    expect(result.pending[0]?.lastFlushFailureCode).toBe('SANDBOX_CONNECT_FAILED');
+    expect(result.pending[0]?.nextFlushAttemptAt).toBeGreaterThanOrEqual(
+      result.attemptStartedAt + 5_000
+    );
+    expect(result.pending[0]?.nextFlushAttemptAt).toBeLessThanOrEqual(
+      result.attemptFinishedAt + 5_000
+    );
+    expect(result.alarm).not.toBeNull();
+    expect(result.alarm).toBeLessThanOrEqual(result.pending[0]?.nextFlushAttemptAt ?? 0);
     expect(result.pending[0]?.deliveryDisposition).toBeUndefined();
     expect(result.lease).toMatchObject({
       state: 'stop_needed',


### PR DESCRIPTION
## Summary

### Why

Cloud Agent can durably accept a message and then leave it pending when physical wrapper inspection times out or the Durable Object alarm no longer represents queued work. Because wrapper delivery happens asynchronously after admission, this path needs a bounded failure outcome without weakening the existing fence against launching a second wrapper in ambiguous sandbox state.

### What was done

- Bound the `listProcesses()` phase of wrapper discovery to 10 seconds so the queue can persist failure bookkeeping before the platform timeout.
- Classify failed wrapper inspection as a retryable pre-dispatch `SANDBOX_CONNECT_FAILED` while preserving the `stop_needed` cleanup lease.
- Persist one sandbox-specific retry deadline five seconds after the first failure, then terminalize as `sandbox_connect_failed` if cleanup still blocks delivery or the second attempt fails.
- Pre-arm alarm work and reconstruct a near-term drain from durable pending state during Durable Object initialization.
- Log and rethrow final alarm-scheduling failures so lost wake-ups remain observable.

### High-level architecture

```mermaid
sequenceDiagram
  participant DO as CloudAgentSession DO
  participant Queue as Pending Message Queue
  participant Runtime as AgentRuntime
  participant Sandbox as Sandbox
  participant Store as DO Storage

  DO->>Queue: Drain next durable message
  Queue->>Runtime: Authorize pre-dispatch delivery
  Runtime->>Sandbox: Discover wrapper processes (10s bound)
  alt Wrapper inspection fails
    Runtime->>Store: Persist stop_needed cleanup fence
    Runtime-->>Queue: SANDBOX_CONNECT_FAILED
    Queue->>Store: Persist retry deadline (+5s)
    DO->>Queue: Wake at or after retry deadline
    alt Cleanup completed and authorization succeeds
      Queue->>Runtime: Continue normal delivery
    else Cleanup still blocks or retry fails
      Queue->>Store: Terminalize sandbox_connect_failed
    end
  else Wrapper state is safe
    Runtime-->>Queue: Continue normal delivery
  end
```

### Architecture decision

**Decision:** Treat failed physical wrapper inspection as a bounded pre-dispatch delivery failure owned by the durable queue, while retaining the existing cleanup fence.

**Context:** The Durable Object owns pending intent, retry metadata, alarms, and terminal effects; `AgentRuntime` owns physical wrapper authorization. Previously, an inspection failure became an uncounted cleanup block, so a stale cleanup deadline or alarm could leave admitted work pending indefinitely.

**Rationale:** A typed pre-dispatch error lets the queue apply a deterministic retry and terminalization policy without misclassifying ambiguous post-dispatch failures or allowing an unsafe replacement wrapper.

**Alternatives considered:**

- **Wait for cleanup without consuming an attempt.** This preserves safety but can strand the message behind long cleanup timing.
- **Use the generic two-second delivery retry.** Sandbox connectivity gets a separate five-second deadline so unrelated failure attempts do not suppress its recovery opportunity.

**Consequences:** Pending sandbox failures now reach a visible terminal outcome after at most two authorization attempts. A transient outage that outlasts the retry window can fail the message, and actual Durable Object execution may occur later than the persisted five-second deadline.

## Verification

- [ ] No manual verification performed; this change targets internal Durable Object alarm and sandbox-failure paths without a user-facing manual flow.

## Visual Changes

N/A

## Reviewer Notes

- The 10-second bound applies only to the `listProcesses()` phase, not every operation in wrapper discovery.
- Review the interaction between cleanup fencing, the second-attempt terminalization path, and alarm reconstruction from durable pending state.
- No schema migration, public API change, or UI change is included.