### PR TITLE
fix(cloud-agent-next): bound callback queue payloads

### DIFF
--- a/services/cloud-agent-next/src/callbacks/queue-payload.test.ts
+++ b/services/cloud-agent-next/src/callbacks/queue-payload.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CallbackJob } from './types.js';
+import {
+  CALLBACK_QUEUE_MAX_SERIALIZED_BYTES,
+  fitCallbackJobToQueueLimit,
+  serializedCallbackJobByteLength,
+} from './queue-payload.js';
+
+function callbackJob(lastAssistantMessageText: string): CallbackJob {
+  return {
+    target: { url: 'https://example.com/callback' },
+    payload: {
+      sessionId: 'agent_callback_size',
+      cloudAgentSessionId: 'agent_callback_size',
+      messageId: 'msg_callback_size',
+      status: 'completed',
+      lastAssistantMessageText,
+    },
+  };
+}
+
+function actualSerializedCallbackJobByteLength(job: CallbackJob): number {
+  return new TextEncoder().encode(JSON.stringify(job)).byteLength;
+}
+
+describe('fitCallbackJobToQueueLimit', () => {
+  it('leaves callback jobs within the queue limit unchanged', () => {
+    const job = callbackJob('Done');
+
+    const result = fitCallbackJobToQueueLimit(job);
+
+    expect(result).toEqual({
+      status: 'ready',
+      job,
+      serializedByteLength: serializedCallbackJobByteLength(job),
+    });
+    expect(result.status === 'ready' && result.job).toBe(job);
+    expect(job.payload.lastAssistantMessageTextTruncation).toBeUndefined();
+  });
+
+  it('omits oversized assistant text so consumers cannot treat a prefix as complete', () => {
+    const assistantText = 'a'.repeat(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES * 2);
+
+    const result = fitCallbackJobToQueueLimit(callbackJob(assistantText));
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') return;
+
+    expect(actualSerializedCallbackJobByteLength(result.job)).toBe(result.serializedByteLength);
+    expect(result.serializedByteLength).toBeLessThanOrEqual(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES);
+    expect(result.job.payload.lastAssistantMessageText).toBeUndefined();
+    expect(result.job.payload.lastAssistantMessageTextTruncation).toEqual({
+      originalUtf8ByteLength: assistantText.length,
+      retainedUtf8ByteLength: 0,
+    });
+  });
+
+  it('measures and fits oversized callback jobs without materializing serialized JSON', () => {
+    const job = callbackJob('😀"\\\n\ud800'.repeat(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES));
+    job.target.headers = { 'x-callback-context': 'line 1\nline 2' };
+    const expectedByteLength = new TextEncoder().encode(JSON.stringify(job)).byteLength;
+    const stringify = vi.spyOn(JSON, 'stringify');
+
+    expect(serializedCallbackJobByteLength(job)).toBe(expectedByteLength);
+    const result = fitCallbackJobToQueueLimit(job);
+
+    expect(result.status).toBe('ready');
+    expect(stringify).not.toHaveBeenCalled();
+    stringify.mockRestore();
+  });
+
+  it('does not split a multi-byte Unicode character in a truncated error', () => {
+    const errorMessage = '😀'.repeat(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES);
+    const job = callbackJob('');
+    job.payload.status = 'failed';
+    delete job.payload.lastAssistantMessageText;
+    job.payload.errorMessage = errorMessage;
+
+    const result = fitCallbackJobToQueueLimit(job);
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') return;
+
+    const retainedText = result.job.payload.errorMessage ?? '';
+    expect(retainedText.endsWith('😀')).toBe(true);
+    expect(result.job.payload.errorMessageTruncation).toEqual({
+      originalUtf8ByteLength: new TextEncoder().encode(errorMessage).byteLength,
+      retainedUtf8ByteLength: new TextEncoder().encode(retainedText).byteLength,
+    });
+    expect(actualSerializedCallbackJobByteLength(result.job)).toBe(result.serializedByteLength);
+    expect(result.serializedByteLength).toBeLessThanOrEqual(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES);
+  });
+
+  it('accounts for JSON escaping, callback headers, and error messages', () => {
+    const escapedText = '"\\\n'.repeat(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES);
+    const job = callbackJob(escapedText);
+    job.target.headers = { 'x-callback-context': '"\\\n'.repeat(5_000) };
+    job.payload.errorMessage = '"\\\n'.repeat(5_000);
+
+    const result = fitCallbackJobToQueueLimit(job);
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') return;
+
+    expect(result.job.target.headers).toEqual(job.target.headers);
+    expect(result.job.payload.errorMessage).toBe(job.payload.errorMessage);
+    expect(result.job.payload.lastAssistantMessageText).toBeUndefined();
+    expect(result.job.payload.lastAssistantMessageTextTruncation).toEqual({
+      originalUtf8ByteLength: new TextEncoder().encode(escapedText).byteLength,
+      retainedUtf8ByteLength: 0,
+    });
+    expect(actualSerializedCallbackJobByteLength(result.job)).toBe(result.serializedByteLength);
+    expect(result.serializedByteLength).toBeLessThanOrEqual(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES);
+  });
+
+  it('truncates oversized failure errors so the terminal callback is still delivered', () => {
+    const errorMessage = 'provider failure: '.repeat(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES);
+    const job = callbackJob('');
+    job.payload.status = 'failed';
+    delete job.payload.lastAssistantMessageText;
+    job.payload.errorMessage = errorMessage;
+
+    const result = fitCallbackJobToQueueLimit(job);
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') return;
+
+    expect(result.job.payload.errorMessage?.length).toBeLessThan(errorMessage.length);
+    expect(result.job.payload.errorMessageTruncation).toEqual({
+      originalUtf8ByteLength: new TextEncoder().encode(errorMessage).byteLength,
+      retainedUtf8ByteLength: new TextEncoder().encode(result.job.payload.errorMessage).byteLength,
+    });
+    expect(actualSerializedCallbackJobByteLength(result.job)).toBe(result.serializedByteLength);
+    expect(result.serializedByteLength).toBeLessThanOrEqual(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES);
+  });
+
+  it('rejects a callback whose fixed fields exceed the queue limit', () => {
+    const job = callbackJob('assistant output');
+    job.target.headers = {
+      'x-callback-context': 'x'.repeat(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES * 2),
+    };
+
+    const result = fitCallbackJobToQueueLimit(job);
+
+    expect(result).toMatchObject({
+      status: 'too-large',
+      maximumByteLength: CALLBACK_QUEUE_MAX_SERIALIZED_BYTES,
+    });
+  });
+});

--- a/services/cloud-agent-next/src/callbacks/queue-payload.ts
+++ b/services/cloud-agent-next/src/callbacks/queue-payload.ts
@@ -1,0 +1,261 @@
+import type { CallbackJob } from './types.js';
+
+// Queues allow 128,000 bytes including roughly 100 bytes of internal metadata.
+export const CALLBACK_QUEUE_MAX_SERIALIZED_BYTES = 127_000;
+
+export type CallbackJobQueueFitResult =
+  | {
+      status: 'ready';
+      job: CallbackJob;
+      serializedByteLength: number;
+    }
+  | {
+      status: 'too-large';
+      serializedByteLength: number;
+      maximumByteLength: number;
+    };
+
+function jsonStringUtf8ByteLength(value: string): number {
+  let byteLength = 2;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit === 0x22 || codeUnit === 0x5c || codeUnit === 0x08 || codeUnit === 0x09) {
+      byteLength += 2;
+    } else if (codeUnit === 0x0a || codeUnit === 0x0c || codeUnit === 0x0d) {
+      byteLength += 2;
+    } else if (codeUnit <= 0x1f) {
+      byteLength += 6;
+    } else if (codeUnit <= 0x7f) {
+      byteLength += 1;
+    } else if (codeUnit <= 0x7ff) {
+      byteLength += 2;
+    } else if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const nextCodeUnit = value.charCodeAt(index + 1);
+      if (nextCodeUnit >= 0xdc00 && nextCodeUnit <= 0xdfff) {
+        byteLength += 4;
+        index += 1;
+      } else {
+        byteLength += 6;
+      }
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      byteLength += 6;
+    } else {
+      byteLength += 3;
+    }
+  }
+
+  return byteLength;
+}
+
+function serializedJsonByteLength(value: unknown, arrayEntry = false): number | undefined {
+  if (value === null) return 4;
+
+  switch (typeof value) {
+    case 'string':
+      return jsonStringUtf8ByteLength(value);
+    case 'number':
+      return Number.isFinite(value) ? String(value).length : 4;
+    case 'boolean':
+      return value ? 4 : 5;
+    case 'undefined':
+    case 'function':
+    case 'symbol':
+      return arrayEntry ? 4 : undefined;
+    case 'bigint':
+      throw new TypeError('Cannot serialize BigInt in callback job');
+    case 'object': {
+      if (Array.isArray(value)) {
+        let byteLength = 2;
+        for (let index = 0; index < value.length; index += 1) {
+          if (index > 0) byteLength += 1;
+          byteLength += serializedJsonByteLength(value[index], true) ?? 4;
+        }
+        return byteLength;
+      }
+
+      let byteLength = 2;
+      let serializedEntries = 0;
+      for (const [key, entryValue] of Object.entries(value)) {
+        const entryByteLength = serializedJsonByteLength(entryValue);
+        if (entryByteLength === undefined) continue;
+        if (serializedEntries > 0) byteLength += 1;
+        byteLength += jsonStringUtf8ByteLength(key) + 1 + entryByteLength;
+        serializedEntries += 1;
+      }
+      return byteLength;
+    }
+  }
+}
+
+export function serializedCallbackJobByteLength(job: CallbackJob): number {
+  const byteLength = serializedJsonByteLength(job);
+  if (byteLength === undefined) {
+    throw new TypeError('Callback job cannot be serialized as JSON');
+  }
+  return byteLength;
+}
+
+function utf8ByteLength(value: string): number {
+  let byteLength = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit <= 0x7f) {
+      byteLength += 1;
+    } else if (codeUnit <= 0x7ff) {
+      byteLength += 2;
+    } else if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const nextCodeUnit = value.charCodeAt(index + 1);
+      if (nextCodeUnit >= 0xdc00 && nextCodeUnit <= 0xdfff) {
+        byteLength += 4;
+        index += 1;
+      } else {
+        byteLength += 3;
+      }
+    } else {
+      byteLength += 3;
+    }
+  }
+
+  return byteLength;
+}
+
+function sliceAtUnicodeBoundary(value: string, end: number): string {
+  let boundary = end;
+  if (boundary > 0 && boundary < value.length) {
+    const previousCodeUnit = value.charCodeAt(boundary - 1);
+    if (previousCodeUnit >= 0xd800 && previousCodeUnit <= 0xdbff) {
+      boundary -= 1;
+    }
+  }
+  return value.slice(0, boundary);
+}
+
+type TruncateCallbackText = (
+  job: CallbackJob,
+  text: string,
+  originalUtf8ByteLength: number
+) => CallbackJob;
+
+type CallbackTextFitResult =
+  | {
+      status: 'ready';
+      job: CallbackJob;
+      serializedByteLength: number;
+    }
+  | {
+      status: 'too-large';
+      minimizedJob: CallbackJob;
+      serializedByteLength: number;
+    };
+
+function omittedAssistantTextJob(job: CallbackJob, originalUtf8ByteLength: number): CallbackJob {
+  const payload = { ...job.payload };
+  delete payload.lastAssistantMessageText;
+  return {
+    ...job,
+    payload: {
+      ...payload,
+      lastAssistantMessageTextTruncation: {
+        originalUtf8ByteLength,
+        retainedUtf8ByteLength: 0,
+      },
+    },
+  };
+}
+
+function truncatedErrorMessageJob(
+  job: CallbackJob,
+  text: string,
+  originalUtf8ByteLength: number
+): CallbackJob {
+  return {
+    ...job,
+    payload: {
+      ...job.payload,
+      errorMessage: text,
+      errorMessageTruncation: {
+        originalUtf8ByteLength,
+        retainedUtf8ByteLength: utf8ByteLength(text),
+      },
+    },
+  };
+}
+
+function fitCallbackTextToQueueLimit(
+  job: CallbackJob,
+  text: string,
+  truncate: TruncateCallbackText
+): CallbackTextFitResult {
+  const originalUtf8ByteLength = utf8ByteLength(text);
+  const emptyTextJob = truncate(job, '', originalUtf8ByteLength);
+  const emptyTextJobByteLength = serializedCallbackJobByteLength(emptyTextJob);
+  if (emptyTextJobByteLength > CALLBACK_QUEUE_MAX_SERIALIZED_BYTES) {
+    return {
+      status: 'too-large',
+      minimizedJob: emptyTextJob,
+      serializedByteLength: emptyTextJobByteLength,
+    };
+  }
+
+  let lowerBound = 0;
+  let upperBound = Math.min(text.length, CALLBACK_QUEUE_MAX_SERIALIZED_BYTES);
+  let fittedJob = emptyTextJob;
+  let fittedByteLength = emptyTextJobByteLength;
+
+  while (lowerBound <= upperBound) {
+    const midpoint = Math.floor((lowerBound + upperBound) / 2);
+    const candidateText = sliceAtUnicodeBoundary(text, midpoint);
+    const candidateJob = truncate(job, candidateText, originalUtf8ByteLength);
+    const candidateByteLength = serializedCallbackJobByteLength(candidateJob);
+
+    if (candidateByteLength <= CALLBACK_QUEUE_MAX_SERIALIZED_BYTES) {
+      fittedJob = candidateJob;
+      fittedByteLength = candidateByteLength;
+      lowerBound = midpoint + 1;
+    } else {
+      upperBound = midpoint - 1;
+    }
+  }
+
+  return {
+    status: 'ready',
+    job: fittedJob,
+    serializedByteLength: fittedByteLength,
+  };
+}
+
+export function fitCallbackJobToQueueLimit(job: CallbackJob): CallbackJobQueueFitResult {
+  let candidateJob = job;
+  let serializedByteLength = serializedCallbackJobByteLength(candidateJob);
+  if (serializedByteLength <= CALLBACK_QUEUE_MAX_SERIALIZED_BYTES) {
+    return { status: 'ready', job: candidateJob, serializedByteLength };
+  }
+
+  const assistantText = candidateJob.payload.lastAssistantMessageText;
+  if (assistantText !== undefined) {
+    candidateJob = omittedAssistantTextJob(candidateJob, utf8ByteLength(assistantText));
+    serializedByteLength = serializedCallbackJobByteLength(candidateJob);
+    if (serializedByteLength <= CALLBACK_QUEUE_MAX_SERIALIZED_BYTES) {
+      return { status: 'ready', job: candidateJob, serializedByteLength };
+    }
+  }
+
+  const errorMessage = candidateJob.payload.errorMessage;
+  if (errorMessage !== undefined) {
+    const errorResult = fitCallbackTextToQueueLimit(
+      candidateJob,
+      errorMessage,
+      truncatedErrorMessageJob
+    );
+    if (errorResult.status === 'ready') return errorResult;
+    serializedByteLength = errorResult.serializedByteLength;
+  }
+
+  return {
+    status: 'too-large',
+    serializedByteLength,
+    maximumByteLength: CALLBACK_QUEUE_MAX_SERIALIZED_BYTES,
+  };
+}

--- a/services/cloud-agent-next/src/callbacks/types.ts
+++ b/services/cloud-agent-next/src/callbacks/types.ts
@@ -3,6 +3,11 @@ export type CallbackTarget = {
   headers?: Record<string, string>;
 };
 
+export type CallbackTextTruncation = {
+  originalUtf8ByteLength: number;
+  retainedUtf8ByteLength: number;
+};
+
 export type ExecutionCallbackPayload = {
   sessionId: string;
   cloudAgentSessionId: string;
@@ -12,6 +17,8 @@ export type ExecutionCallbackPayload = {
   messageId?: string;
   status: 'completed' | 'failed' | 'interrupted';
   errorMessage?: string;
+  /** Present when errorMessage was shortened to fit the callback queue. */
+  errorMessageTruncation?: CallbackTextTruncation;
   lastSeenBranch?: string;
   kiloSessionId?: string;
   /** Gate result reported by the agent when gate_threshold is active */
@@ -21,6 +28,8 @@ export type ExecutionCallbackPayload = {
    * Undefined when no assistant message has been recorded yet.
    */
   lastAssistantMessageText?: string;
+  /** Present when lastAssistantMessageText was omitted to fit the callback queue. */
+  lastAssistantMessageTextTruncation?: CallbackTextTruncation;
   /**
    * Deterministic idempotency key based on messageId.
    * Receivers can use this to safely deduplicate retried callbacks after a

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -13,6 +13,7 @@ import {
   type SessionMetadata,
 } from './session-metadata.js';
 import { readProfileBundle, type SessionProfileBundle } from '../session-profile.js';
+import { fitCallbackJobToQueueLimit } from '../callbacks/queue-payload.js';
 import type { CallbackJob, CallbackTarget } from '../callbacks/index.js';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { logger } from '../logger.js';
@@ -355,9 +356,21 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       target: callbackTarget,
       payload,
     };
+    const fittedCallbackJob = fitCallbackJobToQueueLimit(callbackJob);
+    if (fittedCallbackJob.status === 'too-large') {
+      logger
+        .withFields({
+          sessionId,
+          messageId,
+          serializedByteLength: fittedCallbackJob.serializedByteLength,
+          maximumByteLength: fittedCallbackJob.maximumByteLength,
+        })
+        .error('Skipped legacy callback job that cannot fit queue size limit');
+      return;
+    }
 
     try {
-      await callbackQueue.send(callbackJob);
+      await callbackQueue.send(fittedCallbackJob.job);
       logger
         .withFields({
           sessionId,

--- a/services/cloud-agent-next/src/session/message-settlement-outbox.test.ts
+++ b/services/cloud-agent-next/src/session/message-settlement-outbox.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import {
+  CALLBACK_QUEUE_MAX_SERIALIZED_BYTES,
+  serializedCallbackJobByteLength,
+} from '../callbacks/queue-payload.js';
 import type { CallbackJob } from '../callbacks/types.js';
 import type {
   SendCloudAgentSessionNotificationParams,
@@ -601,6 +605,47 @@ describe('MessageSettlementOutbox', () => {
     });
   });
 
+  it('omits oversized assistant output before enqueueing the callback job', async () => {
+    const assistantText = '😀"\\\n'.repeat(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES);
+    const harness = createHarness({
+      assistantMessage: {
+        eventId: 1 as LatestAssistantMessage['eventId'],
+        timestamp: 1,
+        info: { id: 'assistant_large', role: 'assistant' },
+        parts: [
+          {
+            id: 'part_large',
+            messageID: 'assistant_large',
+            type: 'text',
+            text: assistantText,
+          },
+        ],
+      },
+    });
+    await putSessionMessageState(
+      harness.storage,
+      acceptedMessageState(firstMessageId, { url: 'https://example.com/large-callback' })
+    );
+
+    await harness.outbox.terminalizeSessionMessageOnce(firstMessageId, {
+      kind: 'completed',
+      completionSource: 'assistant_message_event',
+    });
+
+    expect(harness.callbackJobs).toHaveLength(1);
+    expect(serializedCallbackJobByteLength(harness.callbackJobs[0])).toBeLessThanOrEqual(
+      CALLBACK_QUEUE_MAX_SERIALIZED_BYTES
+    );
+    expect(harness.callbackJobs[0].payload.lastAssistantMessageText).toBeUndefined();
+    expect(harness.callbackJobs[0].payload.lastAssistantMessageTextTruncation).toEqual({
+      originalUtf8ByteLength: new TextEncoder().encode(assistantText.trim()).byteLength,
+      retainedUtf8ByteLength: 0,
+    });
+    const persisted = await getSessionMessageState(harness.storage, firstMessageId);
+    expect(persisted?.callbackEnqueuedAt).toBeDefined();
+    expect(persisted?.callbackRetryAt).toBeUndefined();
+  });
+
   it('reports a late wrapper gate result once without allowing replay to replace it', async () => {
     const harness = createHarness({
       metadata: { ...metadata, finalization: { gateThreshold: 'warning' } },
@@ -663,6 +708,44 @@ describe('MessageSettlementOutbox', () => {
       status: 'completed',
     });
     expect(harness.callbackJobs[0].payload.gateResult).toBeUndefined();
+  });
+
+  it('abandons a callback whose fixed fields cannot fit instead of retrying forever', async () => {
+    const harness = createHarness();
+    await putSessionMessageState(
+      harness.storage,
+      acceptedMessageState(firstMessageId, {
+        url: 'https://example.com/oversized-fixed-fields',
+        headers: {
+          'x-callback-context': 'x'.repeat(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES * 2),
+        },
+      })
+    );
+
+    await harness.outbox.terminalizeSessionMessageOnce(firstMessageId, {
+      kind: 'completed',
+      completionSource: 'assistant_message_event',
+    });
+
+    const persisted = await getSessionMessageState(harness.storage, firstMessageId);
+    expect(harness.callbackJobs).toHaveLength(0);
+    expect(persisted).toMatchObject({
+      callbackAttempts: 1,
+      callbackAbandonedAt: expect.any(Number),
+      callbackEnqueuedAt: expect.any(Number),
+    });
+    expect(persisted?.callbackEnqueuedAt).toBe(persisted?.callbackAbandonedAt);
+    expect(persisted?.callbackLastError).toContain('maximum is');
+    expect(persisted?.callbackRetryAt).toBeUndefined();
+    await expect(harness.outbox.nextCallbackDeadline()).resolves.toBeUndefined();
+
+    await harness.outbox.repairTerminalMessageEffects(firstMessageId);
+    await harness.outbox.repairTerminalEffects();
+    await harness.outbox.retryPendingCallbacks(Date.now() + 60_000);
+
+    const afterRetry = await getSessionMessageState(harness.storage, firstMessageId);
+    expect(afterRetry).toMatchObject({ callbackAttempts: 1 });
+    expect(harness.callbackJobs).toHaveLength(0);
   });
 
   it('persists enqueue retry state and exposes the next callback deadline', async () => {

--- a/services/cloud-agent-next/src/session/message-settlement-outbox.ts
+++ b/services/cloud-agent-next/src/session/message-settlement-outbox.ts
@@ -1,3 +1,4 @@
+import { fitCallbackJobToQueueLimit } from '../callbacks/queue-payload.js';
 import type { CallbackJob } from '../callbacks/types.js';
 import { logger } from '../logger.js';
 import type {
@@ -240,6 +241,7 @@ export function createMessageSettlementOutbox(
       if (
         representative?.callbackRequired &&
         !representative.callbackEnqueuedAt &&
+        !representative.callbackAbandonedAt &&
         representative.gateResult === undefined
       ) {
         const updated = { ...representative, gateResult };
@@ -420,8 +422,30 @@ export function createMessageSettlementOutbox(
       payload,
     };
 
+    const fittedCallbackJob = fitCallbackJobToQueueLimit(callbackJob);
+    if (fittedCallbackJob.status === 'too-large') {
+      const error = `Callback job is ${fittedCallbackJob.serializedByteLength} bytes after minimizing callback text; maximum is ${fittedCallbackJob.maximumByteLength} bytes`;
+      const abandonedAt = Date.now();
+      state.callbackAbandonedAt = abandonedAt;
+      // Rolled-back workers only recognize callbackEnqueuedAt as a terminal callback marker.
+      state.callbackEnqueuedAt = abandonedAt;
+      state.callbackLastError = error;
+      state.callbackAttempts = (state.callbackAttempts ?? 0) + 1;
+      delete state.callbackRetryAt;
+      await putSessionMessageState(storage, state);
+      logger
+        .withFields({
+          sessionId,
+          messageId: state.messageId,
+          serializedByteLength: fittedCallbackJob.serializedByteLength,
+          maximumByteLength: fittedCallbackJob.maximumByteLength,
+        })
+        .error('Abandoned callback job that cannot fit queue size limit');
+      return;
+    }
+
     try {
-      await callbackQueue.send(callbackJob);
+      await callbackQueue.send(fittedCallbackJob.job);
       state.callbackEnqueuedAt = Date.now();
       await putSessionMessageState(storage, state);
       logger
@@ -571,7 +595,13 @@ export function createMessageSettlementOutbox(
 
     if (!finalized.representativeMessageId) return;
     const representative = await getSessionMessageState(storage, finalized.representativeMessageId);
-    if (!representative?.callbackRequired || representative.callbackEnqueuedAt) return;
+    if (
+      !representative?.callbackRequired ||
+      representative.callbackEnqueuedAt ||
+      representative.callbackAbandonedAt
+    ) {
+      return;
+    }
     await enqueueMessageCallbackNotification(representative);
   }
 
@@ -624,7 +654,8 @@ export function createMessageSettlementOutbox(
     for (const batch of batches.values()) {
       if (batch.finalizedAt === undefined || !batch.representativeMessageId) continue;
       const state = await getSessionMessageState(storage, batch.representativeMessageId);
-      if (!state?.callbackRequired || state.callbackEnqueuedAt) continue;
+      if (!state?.callbackRequired || state.callbackEnqueuedAt || state.callbackAbandonedAt)
+        continue;
       states.push(state);
     }
     return states;

--- a/services/cloud-agent-next/src/session/session-message-state.ts
+++ b/services/cloud-agent-next/src/session/session-message-state.ts
@@ -123,6 +123,7 @@ export type SessionMessageState = {
   callbackRequired?: boolean;
   callbackTarget?: CallbackTarget;
   callbackEnqueuedAt?: number;
+  callbackAbandonedAt?: number;
   callbackLastError?: string;
   callbackAttempts?: number;
   callbackRetryAt?: number;
@@ -230,6 +231,7 @@ export const SessionMessageStateSchema = z
       })
       .optional(),
     callbackEnqueuedAt: z.number().optional(),
+    callbackAbandonedAt: z.number().optional(),
     callbackLastError: z.string().optional(),
     callbackAttempts: z.number().int().nonnegative().optional(),
     callbackRetryAt: z.number().optional(),
@@ -646,7 +648,11 @@ export async function listMessagesWithPendingCallbacks(
 ): Promise<SessionMessageState[]> {
   const entries = await listSessionMessageStates(storage);
   return entries.filter(
-    state => isTerminalStatus(state.status) && state.callbackRequired && !state.callbackEnqueuedAt
+    state =>
+      isTerminalStatus(state.status) &&
+      state.callbackRequired &&
+      !state.callbackEnqueuedAt &&
+      !state.callbackAbandonedAt
   );
 }
 
@@ -658,7 +664,10 @@ export async function listTerminalMessagesWithPendingEffects(
     .flatMap(state => {
       if (!isTerminalStatus(state.status)) return [];
       const normalized =
-        state.terminalEffects || !state.callbackRequired || state.callbackEnqueuedAt
+        state.terminalEffects ||
+        !state.callbackRequired ||
+        state.callbackEnqueuedAt ||
+        state.callbackAbandonedAt
           ? state
           : {
               ...state,

--- a/services/cloud-agent-next/test/integration/session/callback-notification.test.ts
+++ b/services/cloud-agent-next/test/integration/session/callback-notification.test.ts
@@ -14,6 +14,10 @@ import { describe, it, expect } from 'vitest';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import type { CloudAgentSession } from '../../../src/persistence/CloudAgentSession.js';
+import {
+  CALLBACK_QUEUE_MAX_SERIALIZED_BYTES,
+  serializedCallbackJobByteLength,
+} from '../../../src/callbacks/queue-payload.js';
 import type { CallbackJob } from '../../../src/callbacks/types.js';
 import type { ExecutionId } from '../../../src/types/ids.js';
 import { groupedRegisterSessionInput } from '../../helpers/session-setup.js';
@@ -84,7 +88,8 @@ async function seedAssistantMessage(
 async function prepareSessionWithCallback(
   instance: CloudAgentSession,
   sessionId: string,
-  userId: string
+  userId: string,
+  callbackTarget: CallbackJob['target'] = { url: 'https://example.com/callback' }
 ): Promise<void> {
   const prepareResult = await instance.registerSession(
     groupedRegisterSessionInput({
@@ -97,7 +102,7 @@ async function prepareSessionWithCallback(
       kilocodeToken: 'token',
       gitUrl: 'https://example.com/repo.git',
       gitToken: 'git-token',
-      callbackTarget: { url: 'https://example.com/callback' },
+      callbackTarget,
     })
   );
   expect(prepareResult.success).toBe(true);
@@ -141,6 +146,77 @@ describe('Callback notification with latest assistant message', () => {
     expect(job.payload.status).toBe('completed');
     expect(job.payload.lastAssistantMessageText).toBe('Hello world');
     expect(job.target.url).toBe('https://example.com/callback');
+  });
+
+  it('omits oversized assistant output from legacy completed callbacks', async () => {
+    const userId = 'user_cb_oversized';
+    const sessionId = 'agent_cb_oversized';
+    const executionId = 'exec_cb_oversized' as ExecutionId;
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const assistantText = '😀"\\\n'.repeat(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES);
+    const queue = createCapturedQueue();
+
+    await runInDurableObject(stub, async (instance: CloudAgentSession, state) => {
+      injectCallbackQueue(instance, queue);
+      await prepareSessionWithCallback(instance, sessionId, userId);
+      await seedAssistantMessage(state, sessionId, {
+        messageId: 'msg_00000000000000000000000011',
+        parts: [{ id: 'part_00000000000000000000000011', type: 'text', text: assistantText }],
+      });
+      const addResult = await instance.addExecution({
+        executionId,
+        mode: 'followup',
+        streamingMode: 'websocket',
+      });
+      expect(addResult.ok).toBe(true);
+
+      await instance.updateExecutionStatus({ executionId, status: 'running' });
+      await instance.updateExecutionStatus({ executionId, status: 'completed' });
+    });
+
+    expect(queue.captured).toHaveLength(1);
+    const [job] = queue.captured;
+    expect(serializedCallbackJobByteLength(job)).toBeLessThanOrEqual(
+      CALLBACK_QUEUE_MAX_SERIALIZED_BYTES
+    );
+    expect(job.payload.lastAssistantMessageText).toBeUndefined();
+    expect(job.payload.lastAssistantMessageTextTruncation).toEqual({
+      originalUtf8ByteLength: new TextEncoder().encode(assistantText.trim()).byteLength,
+      retainedUtf8ByteLength: 0,
+    });
+  });
+
+  it('skips a legacy callback whose fixed fields cannot fit the queue', async () => {
+    const userId = 'user_cb_oversized_fixed';
+    const sessionId = 'agent_cb_oversized_fixed';
+    const executionId = 'exec_cb_oversized_fixed' as ExecutionId;
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const queue = createCapturedQueue();
+
+    await runInDurableObject(stub, async (instance: CloudAgentSession) => {
+      injectCallbackQueue(instance, queue);
+      await prepareSessionWithCallback(instance, sessionId, userId, {
+        url: 'https://example.com/callback',
+        headers: {
+          'x-callback-context': 'x'.repeat(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES * 2),
+        },
+      });
+      const addResult = await instance.addExecution({
+        executionId,
+        mode: 'followup',
+        streamingMode: 'websocket',
+      });
+      expect(addResult.ok).toBe(true);
+
+      await instance.updateExecutionStatus({ executionId, status: 'running' });
+      await expect(
+        instance.updateExecutionStatus({ executionId, status: 'completed' })
+      ).resolves.toMatchObject({ ok: true });
+    });
+
+    expect(queue.captured).toHaveLength(0);
   });
 
   it('surfaces callback queue enqueue failures to terminal status updates', async () => {


### PR DESCRIPTION
## Summary

### Why

Completed cloud-agent callbacks can exceed Cloudflare Queues' 128 KB message limit when assistant output or terminal errors are large. The queue rejects those jobs deterministically, but the settlement outbox previously treated the rejection as transient and kept rebuilding and retrying the same oversized payload.

### What was done

- Fit the complete callback queue job to a conservative 127,000-byte serialized JSON limit before either the current or rollout-only legacy producer sends it.
- Preserve callbacks that already fit; otherwise omit assistant output completely or retain the longest Unicode-safe error prefix, with optional metadata describing original and retained UTF-8 byte lengths.
- Persist oversized fixed-field callbacks as abandoned so alarms and repair passes do not retry them indefinitely.
- Write `callbackEnqueuedAt` alongside `callbackAbandonedAt` as a rollback sentinel, preventing older workers from resuming deterministic retries.
- Measure serialized size without materializing the full JSON string or byte buffer for unbounded text.

### High-level architecture

```mermaid
sequenceDiagram
  participant Runtime as Agent runtime
  participant DO as Session Durable Object
  participant Outbox as Settlement outbox
  participant Fitter as Queue payload fitter
  participant Queue as Callback queue

  Runtime->>DO: Report terminal message state
  DO->>Outbox: Persist and settle callback effect
  Outbox->>Fitter: Fit target and payload to queue limit
  alt Job fits after optional text reduction
    Fitter-->>Outbox: Deliverable callback job
    Outbox->>Queue: Enqueue fitted job
    Outbox->>DO: Persist callbackEnqueuedAt
  else Fixed fields cannot fit
    Fitter-->>Outbox: Permanently too large
    Outbox->>DO: Persist abandonment and rollback sentinel
  end
```

### Architecture decision

**Decision:** Enforce one producer-side fitting policy for the complete callback job, prioritizing terminal delivery over optional text while making irreducible oversize failures non-retryable.

**Context:** Queue rejection occurs before the consumer can apply fallback behavior, and deterministic oversize failures cannot recover through the outbox's transient retry loop. Current message-native callbacks and old in-flight legacy executions can coexist during rollout.

**Rationale:** A shared boundary keeps both producers within the queue contract. Omitting assistant output avoids presenting a prefix as a complete answer, while truncating errors preserves useful failure context and terminal status. Persisted abandonment gives the durable coordinator an explicit terminal state.

**Alternatives considered:**

- **Rely on queue rejection and retries.** This repeats an identical payload indefinitely and cannot recover.
- **Retain an assistant-output prefix.** Consumers could misinterpret partial output as the complete result.
- **Trim callback headers or other fixed fields.** Those fields are part of the callback target contract, so the implementation preserves them and abandons jobs that remain oversized.

**Consequences:** Deliverable callbacks stay within the application limit and deterministic oversize failures stop consuming retry work. Receivers may observe optional truncation metadata or absent assistant text, and `callbackEnqueuedAt` must be interpreted with `callbackAbandonedAt` because it also serves as a rollback compatibility marker.

## Verification

No manual verification was performed; this change is an internal queue-boundary and Durable Object settlement path without a practical UI flow.

## Visual Changes

N/A

## Reviewer Notes

- Review the JSON UTF-8 byte counter and Unicode boundary handling in the shared fitter.
- Fixed-field overflow intentionally abandons the current outbox callback and only logs/skips the rollout-only legacy callback; no fallback transport or DLQ is introduced.
- Transient queue failures, unavailable bindings, and missing callback targets retain their existing retry behavior.