### PR TITLE
fix(cloud-agent-next): retry transient model validation failures

### DIFF
--- a/services/cloud-agent-next/src/model-validation.test.ts
+++ b/services/cloud-agent-next/src/model-validation.test.ts
@@ -26,6 +26,7 @@ describe('model validation', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     global.fetch = originalFetch;
   });
 
@@ -68,29 +69,88 @@ describe('model validation', () => {
       code: 'BAD_REQUEST',
       message: 'Selected model is not available for this cloud agent session',
     });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('fails closed with a retryable service error for malformed validation responses', async () => {
+  it('retries transient validation failures twice with exponential backoff', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockRejectedValueOnce(new Error('catalog unavailable'))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(Response.json({ valid: true }));
+
+    const validation = assertKiloModelAvailable({
+      env: officialEnv,
+      submittedModel: 'available/model',
+      originalToken: 'stored-token',
+      procedure: 'send',
+    });
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(199);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(validation).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails closed after exhausting retries for malformed validation responses', async () => {
+    vi.useFakeTimers();
     fetchMock.mockResolvedValue(Response.json({ unexpected: true }));
 
-    try {
-      await assertKiloModelAvailable({
+    const errorPromise = assertKiloModelAvailable({
+      env: officialEnv,
+      submittedModel: 'available/model',
+      originalToken: 'stored-token',
+      procedure: 'send',
+    }).catch((error: unknown) => error);
+    await vi.runAllTimersAsync();
+    const error: unknown = await errorPromise;
+
+    expect(error).toBeInstanceOf(TRPCError);
+    expect(error).toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
+    if (error instanceof TRPCError) {
+      expect(error.cause).toMatchObject({
+        error: 'MODEL_VALIDATION_UNAVAILABLE',
+        retryable: true,
+      });
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries a rate-limited validation response', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 429 }))
+      .mockResolvedValueOnce(Response.json({ valid: true }));
+
+    const validation = assertKiloModelAvailable({
+      env: officialEnv,
+      submittedModel: 'available/model',
+      procedure: 'send',
+    });
+    await vi.runAllTimersAsync();
+
+    await expect(validation).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a definitive client error', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 400 }));
+
+    await expect(
+      assertKiloModelAvailable({
         env: officialEnv,
         submittedModel: 'available/model',
-        originalToken: 'stored-token',
         procedure: 'send',
-      });
-      throw new Error('Expected validation failure');
-    } catch (error) {
-      expect(error).toBeInstanceOf(TRPCError);
-      expect(error).toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
-      if (error instanceof TRPCError) {
-        expect(error.cause).toMatchObject({
-          error: 'MODEL_VALIDATION_UNAVAILABLE',
-          retryable: true,
-        });
-      }
-    }
+      })
+    ).rejects.toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('skips personal official validation when the validation route is not deployed yet', async () => {

--- a/services/cloud-agent-next/src/model-validation.test.ts
+++ b/services/cloud-agent-next/src/model-validation.test.ts
@@ -261,15 +261,17 @@ describe('model validation', () => {
   });
 
   it('fails closed when an override validation endpoint returns a malformed response', async () => {
+    vi.useFakeTimers();
     fetchMock.mockResolvedValue(Response.json({ unexpected: true }));
 
-    await expect(
-      assertKiloModelAvailable({
-        env: { KILO_OPENROUTER_BASE: 'http://localhost:8811/api' } as Env,
-        submittedModel: 'available/model',
-        procedure: 'start',
-      })
-    ).rejects.toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
+    const validation = assertKiloModelAvailable({
+      env: { KILO_OPENROUTER_BASE: 'http://localhost:8811/api' } as Env,
+      submittedModel: 'available/model',
+      procedure: 'start',
+    }).catch((error: unknown) => error);
+    await vi.runAllTimersAsync();
+
+    await expect(validation).resolves.toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
   });
 
   it('calls the organization-scoped override validation endpoint', async () => {

--- a/services/cloud-agent-next/src/model-validation.ts
+++ b/services/cloud-agent-next/src/model-validation.ts
@@ -6,6 +6,8 @@ import { dispatchedKilocodeModelId } from './persistence/model-utils.js';
 import type { PersistenceEnv } from './persistence/types.js';
 
 const MODEL_VALIDATION_TIMEOUT_MS = 5_000;
+const MODEL_VALIDATION_MAX_ATTEMPTS = 3;
+const MODEL_VALIDATION_RETRY_BASE_DELAY_MS = 100;
 const MODEL_UNAVAILABLE_MESSAGE = 'Selected model is not available for this cloud agent session';
 const MODEL_VALIDATION_UNAVAILABLE_MESSAGE = 'Model availability could not be verified';
 
@@ -44,6 +46,11 @@ const officialValidationResponseSchema = z.union([
   z.object({ valid: z.literal(false), reason: z.literal('unavailable') }),
 ]);
 
+type EndpointValidationResult =
+  | { type: 'validated'; valid: boolean }
+  | { type: 'http-error'; status: number }
+  | { type: 'unavailable' };
+
 function effectiveCatalogContext(input: AssertKiloModelAvailableInput): EffectiveCatalogContext {
   return {
     token: input.env.KILOCODE_TOKEN_OVERRIDE ?? input.originalToken,
@@ -74,6 +81,57 @@ async function fetchWithTimeout(url: string, init: RequestInit): Promise<Respons
   }
 }
 
+function isTransientValidationStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status <= 599);
+}
+
+async function waitBeforeValidationRetry(attempt: number): Promise<void> {
+  const delayMs = MODEL_VALIDATION_RETRY_BASE_DELAY_MS * 2 ** attempt;
+  await new Promise(resolve => setTimeout(resolve, delayMs));
+}
+
+async function validateEndpoint(url: string, init: RequestInit): Promise<EndpointValidationResult> {
+  for (let attempt = 0; attempt < MODEL_VALIDATION_MAX_ATTEMPTS; attempt += 1) {
+    const response = await fetchWithTimeout(url, init);
+    if (!response) {
+      if (attempt < MODEL_VALIDATION_MAX_ATTEMPTS - 1) {
+        await waitBeforeValidationRetry(attempt);
+      }
+      continue;
+    }
+
+    if (!response.ok) {
+      if (!isTransientValidationStatus(response.status)) {
+        return { type: 'http-error', status: response.status };
+      }
+      if (attempt < MODEL_VALIDATION_MAX_ATTEMPTS - 1) {
+        await waitBeforeValidationRetry(attempt);
+      }
+      continue;
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      if (attempt < MODEL_VALIDATION_MAX_ATTEMPTS - 1) {
+        await waitBeforeValidationRetry(attempt);
+      }
+      continue;
+    }
+
+    const parsed = officialValidationResponseSchema.safeParse(body);
+    if (parsed.success) {
+      return { type: 'validated', valid: parsed.data.valid };
+    }
+    if (attempt < MODEL_VALIDATION_MAX_ATTEMPTS - 1) {
+      await waitBeforeValidationRetry(attempt);
+    }
+  }
+
+  return { type: 'unavailable' };
+}
+
 function anonymousCatalogContext(feature: string): EffectiveCatalogContext {
   return { feature };
 }
@@ -93,28 +151,23 @@ async function validateFromOfficialSource(
   modelId: string,
   context: EffectiveCatalogContext
 ): Promise<ModelValidationResult> {
-  const response = await fetchWithTimeout(officialValidationUrl(env, context.organizationId), {
+  const result = await validateEndpoint(officialValidationUrl(env, context.organizationId), {
     method: 'POST',
     headers: requestHeaders(context),
     body: JSON.stringify({ modelId }),
   });
-  if (!response) return { type: 'validation-unavailable', source: 'official' };
-  if (response.status === 404) return { type: 'skipped', source: 'official' };
-  if (response.status === 401 && (context.token || context.organizationId)) {
-    return validateFromOfficialSource(env, modelId, anonymousCatalogContext(context.feature));
-  }
-  if (response.status === 403) return { type: 'access-denied', source: 'official' };
-  if (!response.ok) return { type: 'validation-unavailable', source: 'official' };
-
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch {
+  if (result.type === 'unavailable') {
     return { type: 'validation-unavailable', source: 'official' };
   }
-  const parsed = officialValidationResponseSchema.safeParse(body);
-  if (!parsed.success) return { type: 'validation-unavailable', source: 'official' };
-  return parsed.data.valid
+  if (result.type === 'http-error') {
+    if (result.status === 404) return { type: 'skipped', source: 'official' };
+    if (result.status === 401 && (context.token || context.organizationId)) {
+      return validateFromOfficialSource(env, modelId, anonymousCatalogContext(context.feature));
+    }
+    if (result.status === 403) return { type: 'access-denied', source: 'official' };
+    return { type: 'validation-unavailable', source: 'official' };
+  }
+  return result.valid
     ? { type: 'valid', source: 'official' }
     : { type: 'unavailable-model', source: 'official' };
 }
@@ -163,27 +216,22 @@ async function validateFromOverrideSource(
   const validationUrl = tokenSelectedSource
     ? `${baseURL}/models/validate`
     : buildKiloOverrideValidationUrl(baseURL, context.organizationId);
-  const response = await fetchWithTimeout(validationUrl, {
+  const result = await validateEndpoint(validationUrl, {
     method: 'POST',
     headers: requestHeaders(context),
     body: JSON.stringify({ modelId }),
   });
-  if (!response) return { type: 'validation-unavailable', source: 'override' };
-  if (response.status === 401 && (context.token || context.organizationId)) {
-    return validateFromOfficialSource(env, modelId, anonymousCatalogContext(context.feature));
-  }
-  if (response.status === 403) return { type: 'access-denied', source: 'override' };
-  if (!response.ok) return { type: 'validation-unavailable', source: 'override' };
-
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch {
+  if (result.type === 'unavailable') {
     return { type: 'validation-unavailable', source: 'override' };
   }
-  const parsed = officialValidationResponseSchema.safeParse(body);
-  if (!parsed.success) return { type: 'validation-unavailable', source: 'override' };
-  return parsed.data.valid
+  if (result.type === 'http-error') {
+    if (result.status === 401 && (context.token || context.organizationId)) {
+      return validateFromOfficialSource(env, modelId, anonymousCatalogContext(context.feature));
+    }
+    if (result.status === 403) return { type: 'access-denied', source: 'override' };
+    return { type: 'validation-unavailable', source: 'override' };
+  }
+  return result.valid
     ? { type: 'valid', source: 'override' }
     : { type: 'unavailable-model', source: 'override' };
 }


### PR DESCRIPTION
## Summary
- Retry model catalog validation twice for transient network, timeout, rate-limit, server, and malformed-response failures.
- Keep definitive model availability, authentication, and client-error responses fail-fast.
- Add focused coverage for retry timing, exhaustion, and non-retryable outcomes.

## Verification
N/A — backend-only retry behavior.

## Visual Changes
N/A

## Reviewer Notes
A fully unavailable catalog can extend validation latency to roughly 15.3 seconds because each of the three attempts retains the existing five-second timeout.