### PR TITLE
fix(deps): allow pinned Anthropic SDK releases

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,6 @@ minimumReleaseAgeExclude:
   - '@typescript/native-preview-linux-x64'
   - '@typescript/native-preview-win32-arm64'
   - '@typescript/native-preview-win32-x64'
-  # AI SDK releases are pinned and validated through KiloClaw image builds.
   - '@ai-sdk/anthropic'
   - '@anthropic-ai/sdk'
   # Kilo SDK releases are owned internally and adopted with pinned runtime validation.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,7 @@ minimumReleaseAgeExclude:
   - '@typescript/native-preview-linux-x64'
   - '@typescript/native-preview-win32-arm64'
   - '@typescript/native-preview-win32-x64'
+  # Anthropic adds new parameters regularly and we can't really wait for them to stabilize
   - '@ai-sdk/anthropic'
   - '@anthropic-ai/sdk'
   # Kilo SDK releases are owned internally and adopted with pinned runtime validation.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,9 @@ minimumReleaseAgeExclude:
   - '@typescript/native-preview-linux-x64'
   - '@typescript/native-preview-win32-arm64'
   - '@typescript/native-preview-win32-x64'
+  # AI SDK releases are pinned and validated through KiloClaw image builds.
+  - '@ai-sdk/anthropic'
+  - '@anthropic-ai/sdk'
   # Kilo SDK releases are owned internally and adopted with pinned runtime validation.
   - '@kilocode/sdk'
   # KiloClaw pins and live-smoke-validates OpenClaw image upgrades before rollout.


### PR DESCRIPTION
## Summary

- Exempt `@ai-sdk/anthropic` and `@anthropic-ai/sdk` from the pnpm minimum release age policy.
- Allow the pinned KiloClaw customizer dependencies to install while retaining the policy for other packages.

## Verification

N/A — configuration-only dependency policy change.

## Visual Changes

N/A

## Reviewer Notes

The exceptions are package-scoped rather than version-scoped and are intended for dependencies pinned and validated by KiloClaw image builds.