### PR TITLE
fix(cloud-agent-next): refresh generic git credentials

### DIFF
--- a/services/cloud-agent-next/src/execution/types.ts
+++ b/services/cloud-agent-next/src/execution/types.ts
@@ -196,10 +196,16 @@ export type QueueExecutionTurnCommand = {
   finalization?: TurnFinalization;
 };
 
+/** Transient repository credential mutation applied during message admission. */
+export type RepositoryCredentialUpdate = {
+  genericGitToken: string;
+};
+
 /** Current-path submitted message before durable admission resolves identity/defaults. */
 export type SubmittedSessionMessageRequest = {
   userId: UserId;
   botId?: string;
+  repositoryCredentialUpdate?: RepositoryCredentialUpdate;
 } & QueueExecutionTurnCommand;
 
 /** Already-canonical current message intent admitted without recreating its turn identity. */

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -72,6 +72,7 @@ import type {
   MessageDeliveryRequest,
   AdmitAcceptedSessionMessageRequest,
   LegacyRegisteredInitialAdmissionRequest,
+  RepositoryCredentialUpdate,
   MessageDeliveryResult,
   SessionMessageAdmissionResult,
   SubmittedSessionMessageRequest,
@@ -155,6 +156,8 @@ const EVENT_RETENTION_MS = Limits.SESSION_TTL_MS;
 
 /** Storage key for tracking last activity timestamp */
 const LAST_ACTIVITY_KEY = 'last_activity';
+const REPOSITORY_CREDENTIAL_MESSAGE_ID_KEY = 'repository_credential_message_id';
+const REPOSITORY_CREDENTIAL_UPDATE_PREFIX = 'repository_credential_update:';
 const EXPLICIT_DELETION_PENDING_KEY = 'explicit_deletion_pending';
 
 /** Kilo server idle timeout: 15 minutes */
@@ -597,6 +600,10 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       this.sessionMessageQueue = createSessionMessageQueue({
         storage: this.ctx.storage,
         getMetadata: () => this.getMetadata(),
+        applyRepositoryCredentialUpdate: (messageId, update, replay) =>
+          this.applyRepositoryCredentialUpdate(messageId, update, replay),
+        finalizeRepositoryCredentialUpdate: messageId =>
+          this.finalizeRepositoryCredentialUpdate(messageId),
         requireSessionId: () => this.requireSessionId(),
         validateModeAgainstRuntimeAgents,
         getDeliveryContext: () => this.getPendingMessageDeliveryContext(),
@@ -1116,6 +1123,55 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
 
     // Track activity for session TTL
     await this.updateLastActivity();
+  }
+
+  private async applyRepositoryCredentialUpdate(
+    messageId: string,
+    update: RepositoryCredentialUpdate,
+    replay: boolean
+  ): Promise<void> {
+    const credentialUpdateKey = `${REPOSITORY_CREDENTIAL_UPDATE_PREFIX}${messageId}`;
+    const stored = await this.ctx.storage.get([
+      'metadata',
+      REPOSITORY_CREDENTIAL_MESSAGE_ID_KEY,
+      credentialUpdateKey,
+    ]);
+    const storedMetadata = stored.get('metadata');
+    const metadata = storedMetadata ? parseSessionMetadata(storedMetadata) : null;
+    if (metadata?.repository?.type !== 'git') return;
+
+    const currentCredentialMessageId = stored.get(REPOSITORY_CREDENTIAL_MESSAGE_ID_KEY);
+    const credentialUpdateWasApplied = stored.get(credentialUpdateKey) === true;
+    if (
+      currentCredentialMessageId !== undefined &&
+      currentCredentialMessageId !== messageId &&
+      (replay || credentialUpdateWasApplied)
+    ) {
+      return;
+    }
+
+    const now = Date.now();
+    const serialized = serializeSessionMetadata({
+      ...metadata,
+      repository: {
+        ...metadata.repository,
+        token: update.genericGitToken,
+      },
+      lifecycle: {
+        ...metadata.lifecycle,
+        version: now,
+      },
+    });
+    await this.ctx.storage.put({
+      metadata: serialized,
+      [REPOSITORY_CREDENTIAL_MESSAGE_ID_KEY]: messageId,
+      [credentialUpdateKey]: true,
+      [LAST_ACTIVITY_KEY]: now,
+    });
+  }
+
+  private async finalizeRepositoryCredentialUpdate(messageId: string): Promise<void> {
+    await this.ctx.storage.delete(`${REPOSITORY_CREDENTIAL_UPDATE_PREFIX}${messageId}`);
   }
 
   /**

--- a/services/cloud-agent-next/src/router.test.ts
+++ b/services/cloud-agent-next/src/router.test.ts
@@ -1975,7 +1975,7 @@ describe('legacy V2 execution response compatibility', () => {
     );
   });
 
-  it('sendMessageV2 accepts deprecated token fields without queueing token overrides', async () => {
+  it('sendMessageV2 forwards only the generic git credential update', async () => {
     const { caller, admitSubmittedMessage } = createLegacyExecutionCaller();
 
     await caller.sendMessageV2({
@@ -1984,7 +1984,7 @@ describe('legacy V2 execution response compatibility', () => {
       mode: 'code',
       model: 'test-model',
       githubToken: 'deprecated-github-token',
-      gitToken: 'deprecated-git-token',
+      gitToken: 'fresh-generic-git-token',
     });
 
     const request = admitSubmittedMessage.mock.calls[0]?.[0];
@@ -1995,8 +1995,28 @@ describe('legacy V2 execution response compatibility', () => {
         prompt: 'follow up',
         attachments: undefined,
       },
+      repositoryCredentialUpdate: {
+        genericGitToken: 'fresh-generic-git-token',
+      },
     });
+    expect(request).not.toHaveProperty('githubToken');
     expect(request).not.toHaveProperty('tokenOverrides');
+  });
+
+  it('sendMessageV2 ignores an empty generic git credential update', async () => {
+    const { caller, admitSubmittedMessage } = createLegacyExecutionCaller();
+
+    await caller.sendMessageV2({
+      cloudAgentSessionId: validSessionId,
+      prompt: 'follow up',
+      mode: 'code',
+      model: 'test-model',
+      gitToken: '   ',
+    });
+
+    expect(admitSubmittedMessage.mock.calls[0]?.[0]).not.toHaveProperty(
+      'repositoryCredentialUpdate'
+    );
   });
 
   it('sendMessageV2 queues structured commands without flattening them into prompt text', async () => {

--- a/services/cloud-agent-next/src/router/handlers/session-execution.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-execution.ts
@@ -126,6 +126,10 @@ export function createSessionExecutionV2Handlers() {
               autoCommit: input.autoCommit,
               condenseOnComplete: input.condenseOnComplete,
             } satisfies TurnFinalization,
+            repositoryCredentialUpdate:
+              input.gitToken !== undefined && input.gitToken.trim().length > 0
+                ? { genericGitToken: input.gitToken }
+                : undefined,
           };
           const admissionContext = { env: ctx.env, userId: ctx.userId, botId: ctx.botId };
           const ack =

--- a/services/cloud-agent-next/src/router/schemas.ts
+++ b/services/cloud-agent-next/src/router/schemas.ts
@@ -240,7 +240,7 @@ const SendMessageV2Options = z.object({
     .string()
     .optional()
     .describe(
-      'Deprecated compatibility field. Accepted for older clients but ignored; provider credentials are managed by the server.'
+      'Compatibility field whose non-empty values rotate credentials for generic git repositories. Managed provider credentials remain server-resolved.'
     ),
   ...AttachmentFieldsSchema,
   messageId: MessageIdSchema.nullish().describe('Optional message ID for correlating the request'),

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -677,12 +677,12 @@ describe('SessionService.prepareWorkspace', () => {
     );
   });
 
-  it('uses stored generic git tokens without managed provider lookup', async () => {
+  it('uses the refreshed stored generic git token for a cold clone', async () => {
     const session = createSession(false);
     const sandbox = createSandbox(session);
     const metadata = createMetadata({
       gitUrl: 'https://git.example.com/acme/repo.git',
-      gitToken: 'generic-git-token',
+      gitToken: 'fresh-generic-git-token',
       platform: undefined,
       gitlabTokenManaged: undefined,
     });
@@ -701,9 +701,45 @@ describe('SessionService.prepareWorkspace', () => {
       session,
       '/workspace/user/sessions/agent_test',
       'https://git.example.com/acme/repo.git',
-      'generic-git-token',
+      'fresh-generic-git-token',
       undefined,
       { platform: undefined }
+    );
+    expect(tokenMocks.resolveManagedGitLabToken).not.toHaveBeenCalled();
+    expect(tokenMocks.resolveCloudAgentGitHubAuthForRepo).not.toHaveBeenCalled();
+  });
+
+  it('refreshes a warm generic git remote with the stored token', async () => {
+    const session = createSession(true);
+    const sandbox = createSandbox(session, true);
+    const metadata = createMetadata({
+      gitUrl: 'https://git.example.com/acme/repo.git',
+      gitToken: 'fresh-generic-git-token',
+      platform: undefined,
+      gitlabTokenManaged: undefined,
+      workspacePath: '/workspace/user/sessions/agent_test',
+      sessionHome: '/home/agent_test',
+      branchName: 'session/agent_test',
+      sandboxId: 'usr-abcdef',
+    });
+
+    await new SessionService().prepareWorkspace({
+      sandbox,
+      sandboxId: 'usr-abcdef',
+      userId: 'user_test',
+      sessionId: 'agent_test' as SessionId,
+      env: createEnv(),
+      metadata,
+      kilocodeModel: 'test-model',
+    });
+
+    expect(workspaceMocks.cloneGitRepo).not.toHaveBeenCalled();
+    expect(workspaceMocks.updateGitRemoteToken).toHaveBeenCalledWith(
+      session,
+      '/workspace/user/sessions/agent_test',
+      'https://git.example.com/acme/repo.git',
+      'fresh-generic-git-token',
+      undefined
     );
     expect(tokenMocks.resolveManagedGitLabToken).not.toHaveBeenCalled();
     expect(tokenMocks.resolveCloudAgentGitHubAuthForRepo).not.toHaveBeenCalled();
@@ -1442,6 +1478,26 @@ describe('SessionService.buildWrapperSessionReadyAndPromptRequests', () => {
     );
 
     expect(result.readyRequest.materialized.env.GH_TOKEN).toBe('explicit-profile-token');
+  });
+
+  it('requests warm remote refresh for generic git credentials', async () => {
+    const result = await buildPromptWrapperRequests(
+      createMetadata({
+        gitUrl: 'https://git.example.com/acme/repo.git',
+        gitToken: 'fresh-generic-git-token',
+        platform: undefined,
+        gitlabTokenManaged: undefined,
+      })
+    );
+
+    expect(result.readyRequest.repo).toMatchObject({
+      kind: 'git',
+      url: 'https://git.example.com/acme/repo.git',
+      token: 'fresh-generic-git-token',
+      refreshRemote: true,
+    });
+    expect(tokenMocks.resolveManagedGitLabToken).not.toHaveBeenCalled();
+    expect(tokenMocks.resolveCloudAgentGitHubAuthForRepo).not.toHaveBeenCalled();
   });
 
   it('materializes OAuth bearer mode with a self-managed GitLab host', async () => {

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -1592,7 +1592,9 @@ export class SessionService {
         ...(repositoryShallow(metadata) !== undefined
           ? { shallow: repositoryShallow(metadata) }
           : {}),
-        refreshRemote: tokens.gitlabTokenManaged === true,
+        refreshRemote:
+          tokens.gitToken !== undefined &&
+          (git.type === 'git' || tokens.gitlabTokenManaged === true),
       };
     }
 
@@ -1988,12 +1990,12 @@ export class SessionService {
    * Refresh the embedded credentials in the workspace's git remote URL on the
    * warm fast path.
    *
-   * GitHub App installation tokens expire after ~1h, and server-resolved GitLab
-   * credentials can rotate independently of a warm workspace. The URL-embedded
-   * credentials from the original clone go stale quickly. `GH_TOKEN` /
-   * `GITLAB_TOKEN` env vars don't rescue `git` itself (they only affect the
-   * provider CLIs / GitLab HTTP integrations), so we rewrite `origin` whenever
-   * the token is resolved by us.
+   * GitHub App installation tokens, server-resolved GitLab credentials, and
+   * caller-managed generic git credentials can all rotate independently of a
+   * warm workspace. The URL-embedded credentials from the original clone go
+   * stale quickly. `GH_TOKEN` / `GITLAB_TOKEN` env vars don't rescue `git`
+   * itself (they only affect the provider CLIs / GitLab HTTP integrations), so
+   * we rewrite `origin` whenever current credentials are available.
    */
   private async refreshGitRemoteToken(
     session: ExecutionSession,
@@ -2018,7 +2020,10 @@ export class SessionService {
 
     const git = gitRepository(metadata);
     if (git) {
-      if (tokens.gitToken !== undefined && tokens.gitlabTokenManaged === true) {
+      if (
+        tokens.gitToken !== undefined &&
+        (git.type === 'git' || tokens.gitlabTokenManaged === true)
+      ) {
         await updateGitRemoteToken(
           session,
           context.workspacePath,

--- a/services/cloud-agent-next/src/session/queue-message.ts
+++ b/services/cloud-agent-next/src/session/queue-message.ts
@@ -10,6 +10,7 @@ import { TRPCError } from '@trpc/server';
 
 import type {
   QueueExecutionTurnCommand,
+  RepositoryCredentialUpdate,
   SessionMessageAdmissionResult,
   SubmittedSessionMessageRequest,
   RetryableResultCode,
@@ -70,6 +71,7 @@ export function throwAdmissionError(
 
 export type QueueMessageInput = {
   cloudAgentSessionId: string;
+  repositoryCredentialUpdate?: RepositoryCredentialUpdate;
 } & QueueExecutionTurnCommand;
 
 export type QueueMessageContext = {
@@ -153,6 +155,9 @@ export async function queueMessage(
     },
     agent: input.agent,
     finalization: input.finalization,
+    ...(input.repositoryCredentialUpdate
+      ? { repositoryCredentialUpdate: input.repositoryCredentialUpdate }
+      : {}),
   };
 
   const result = await withDORetry<

--- a/services/cloud-agent-next/src/session/session-message-queue.ts
+++ b/services/cloud-agent-next/src/session/session-message-queue.ts
@@ -4,6 +4,7 @@ import type {
   AdmitAcceptedSessionMessageRequest,
   MessageDeliveryRequest,
   MessageDeliveryResult,
+  RepositoryCredentialUpdate,
   RetryableResultCode,
   SessionMessageAdmissionResult,
   SessionMessageIntent,
@@ -131,6 +132,12 @@ export type SessionMessageQueue = {
 export type SessionMessageQueueDependencies = {
   storage: SessionMessageQueueStorage;
   getMetadata: () => Promise<SessionMetadata | null>;
+  applyRepositoryCredentialUpdate?: (
+    messageId: string,
+    update: RepositoryCredentialUpdate,
+    replay: boolean
+  ) => Promise<void>;
+  finalizeRepositoryCredentialUpdate?: (messageId: string) => Promise<void>;
   requireSessionId: () => Promise<string>;
   validateModeAgainstRuntimeAgents: (metadata: SessionMetadata, mode: string) => string | null;
   getDeliveryContext: () => Promise<ExecutionDeliveryContext | null>;
@@ -490,6 +497,8 @@ export function createSessionMessageQueue(
   const {
     storage,
     getMetadata,
+    applyRepositoryCredentialUpdate,
+    finalizeRepositoryCredentialUpdate,
     requireSessionId,
     validateModeAgainstRuntimeAgents,
     getDeliveryContext,
@@ -581,7 +590,8 @@ export function createSessionMessageQueue(
 
   async function getExistingAdmissionAckForMessageId(
     messageId: string,
-    requestedIntent?: SessionMessageIntent
+    requestedIntent?: SessionMessageIntent,
+    beforeSuccessfulReplay?: () => Promise<void>
   ): Promise<SessionMessageAdmissionResult | undefined> {
     const pendingMessage = await getQueuedMessageByMessageId(storage, messageId);
     const metadata = pendingMessage ? await getMetadata() : undefined;
@@ -623,16 +633,19 @@ export function createSessionMessageQueue(
 
     if (messageState) {
       if (messageState.status === 'queued') {
+        await beforeSuccessfulReplay?.();
         const repairIntent = persistedIntent ?? requestedIntent;
         if (repairIntent) await completeQueuedAdmissionEffects(repairIntent);
         return buildAdmissionAck(messageId);
       }
       if (messageState.status === 'accepted') {
+        await beforeSuccessfulReplay?.();
         return buildAdmissionAck(messageId, 'sent');
       }
     }
 
     if (pendingMessage) {
+      await beforeSuccessfulReplay?.();
       await repairMissingQueuedStateFromPendingMessage(pendingMessage);
       const repairIntent = persistedIntent ?? requestedIntent;
       if (repairIntent) await completeQueuedAdmissionEffects(repairIntent);
@@ -706,9 +719,24 @@ export function createSessionMessageQueue(
     await putSessionMessageState(storage, repairedState);
   }
 
-  async function admitIntent(intent: SessionMessageIntent): Promise<SessionMessageAdmissionResult> {
+  async function admitIntent(
+    intent: SessionMessageIntent,
+    beforeAdmissionEffects?: (replay: boolean) => Promise<void>,
+    afterAdmissionPersistence?: () => Promise<void>
+  ): Promise<SessionMessageAdmissionResult> {
     const { turn } = intent;
-    const idempotentResult = await getExistingAdmissionAckForMessageId(turn.messageId, intent);
+    const beforeSuccessfulReplay =
+      beforeAdmissionEffects || afterAdmissionPersistence
+        ? async () => {
+            await beforeAdmissionEffects?.(true);
+            await afterAdmissionPersistence?.();
+          }
+        : undefined;
+    const idempotentResult = await getExistingAdmissionAckForMessageId(
+      turn.messageId,
+      intent,
+      beforeSuccessfulReplay
+    );
     if (idempotentResult) return idempotentResult;
 
     const capacityError = await checkPendingQueueCapacity();
@@ -720,9 +748,12 @@ export function createSessionMessageQueue(
       ? { required: true, target: callbackTarget }
       : undefined;
 
+    // Rotate session credentials before pending work can become visible to an existing drain alarm.
+    await beforeAdmissionEffects?.(false);
     await enqueuePendingSessionMessageIntent(storage, intent, Date.now(), callbackSnapshot);
     const messageState = createQueuedSessionMessageState(intent, callbackSnapshot);
     await putSessionMessageState(storage, messageState);
+    await afterAdmissionPersistence?.();
     await completeQueuedAdmissionEffects(intent);
     return buildAdmissionAck(turn.messageId);
   }
@@ -839,11 +870,17 @@ export function createSessionMessageQueue(
             requestedFinalization?.condenseOnComplete ?? metadata.finalization?.condenseOnComplete,
         },
       };
-      const existingAdmission = await getExistingAdmissionAckForMessageId(messageId, intent);
-      if (existingAdmission) return existingAdmission;
-      const capacityError = await checkPendingQueueCapacity();
-      if (capacityError) return capacityError;
-      return await admitIntent(intent);
+      const credentialUpdate = request.repositoryCredentialUpdate;
+      const applyCredentialUpdate =
+        credentialUpdate && applyRepositoryCredentialUpdate
+          ? (replay: boolean) =>
+              applyRepositoryCredentialUpdate(messageId, credentialUpdate, replay)
+          : undefined;
+      const finalizeCredentialUpdate =
+        credentialUpdate && finalizeRepositoryCredentialUpdate
+          ? () => finalizeRepositoryCredentialUpdate(messageId)
+          : undefined;
+      return await admitIntent(intent, applyCredentialUpdate, finalizeCredentialUpdate);
     } catch (error) {
       if (isExecutionError(error)) {
         if (error.retryable) {

--- a/services/cloud-agent-next/src/workspace.test.ts
+++ b/services/cloud-agent-next/src/workspace.test.ts
@@ -42,6 +42,7 @@ import {
   LOW_DISK_THRESHOLD_MB,
   STALE_DIR_MIN_AGE_SECONDS,
 } from './workspace';
+import { shellQuote } from './kilo/utils.js';
 import {
   SandboxCapacityInspectionError,
   WorkspaceCapacityAdmissionRejectedError,
@@ -780,6 +781,22 @@ describe('disk space checking', () => {
 
       expect(mockExec).toHaveBeenCalledWith(
         expect.stringContaining('x-access-token:new-token'),
+        expect.any(Object)
+      );
+    });
+
+    it('shell-quotes caller-controlled generic git tokens', async () => {
+      mockExec.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+      const workspacePath = "/workspace/user's-repo";
+      const token = "'$(touch /tmp/pwn)'";
+      const authenticatedUrl = new URL('https://example.com/repo.git');
+      authenticatedUrl.username = 'x-access-token';
+      authenticatedUrl.password = token;
+
+      await updateGitRemoteToken(fakeSession, workspacePath, 'https://example.com/repo.git', token);
+
+      expect(mockExec).toHaveBeenCalledWith(
+        `cd ${shellQuote(workspacePath)} && git remote set-url origin ${shellQuote(authenticatedUrl.toString())}`,
         expect.any(Object)
       );
     });

--- a/services/cloud-agent-next/src/workspace.ts
+++ b/services/cloud-agent-next/src/workspace.ts
@@ -882,7 +882,7 @@ export async function updateGitRemoteToken(
 
   const result = await timedExec(
     session,
-    `cd '${workspacePath}' && git remote set-url origin '${newUrl.toString()}'`,
+    `cd ${shellQuote(workspacePath)} && git remote set-url origin ${shellQuote(newUrl.toString())}`,
     'git.updateRemoteToken'
   );
 

--- a/services/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
+++ b/services/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
@@ -397,16 +397,34 @@ describe('CloudAgentSession message admission', () => {
         gitToken: 'old-token',
       });
 
-      const request = queueUserMessageInput({
-        userId,
-        prompt: 'followup prompt',
-        messageId: 'msg_018f1e2d3c4bAbCdEfGhIjKlMn',
-      });
+      const request = {
+        ...queueUserMessageInput({
+          userId,
+          prompt: 'followup prompt',
+          messageId: 'msg_018f1e2d3c4bAbCdEfGhIjKlMn',
+        }),
+        repositoryCredentialUpdate: {
+          genericGitToken: 'fresh-token',
+        },
+      };
 
       const startResult = await instance.admitSubmittedMessage(request);
       const metadata = await instance.getMetadata();
+      const credentialMarker = await instance.ctx.storage.get(
+        'repository_credential_update:msg_018f1e2d3c4bAbCdEfGhIjKlMn'
+      );
+      const credentialMessageId = await instance.ctx.storage.get(
+        'repository_credential_message_id'
+      );
       const pending = await listPendingSessionMessages(instance.ctx.storage);
-      return { startResult, metadata, plan: capturedPlan, pending };
+      return {
+        startResult,
+        metadata,
+        credentialMarker,
+        credentialMessageId,
+        plan: capturedPlan,
+        pending,
+      };
     });
 
     expect(result.startResult.success).toBe(true);
@@ -414,12 +432,73 @@ describe('CloudAgentSession message admission', () => {
 
     expect(result.startResult.messageId).toBe('msg_018f1e2d3c4bAbCdEfGhIjKlMn');
     expect(result.startResult.outcome).toBe('queued');
-    expect(result.metadata?.repository?.token).toBe('old-token');
+    expect(result.metadata?.repository?.token).toBe('fresh-token');
+    expect(result.metadata?.repository).not.toHaveProperty('credentialMessageId');
+    expect(result.credentialMarker).toBeUndefined();
+    expect(result.credentialMessageId).toBe('msg_018f1e2d3c4bAbCdEfGhIjKlMn');
     expect(result.plan).toBeNull();
     expect(result.pending).toHaveLength(1);
     expect(result.pending[0]?.messageId).toBe('msg_018f1e2d3c4bAbCdEfGhIjKlMn');
     expect(result.pending[0]?.content).toBe('followup prompt');
     expect(result.pending[0]?.executionId).toBe(result.startResult.executionId);
+  });
+
+  it.each([
+    {
+      provider: 'GitHub',
+      userId: 'user_exec_github_credentials',
+      sessionId: 'agent_exec_github_credentials',
+      githubRepo: 'acme/repo',
+      githubToken: 'stored-github-token',
+      gitUrl: undefined,
+      platform: 'github' as const,
+    },
+    {
+      provider: 'managed GitLab',
+      userId: 'user_exec_gitlab_credentials',
+      sessionId: 'agent_exec_gitlab_credentials',
+      githubRepo: undefined,
+      githubToken: undefined,
+      gitUrl: 'https://gitlab.com/acme/repo.git',
+      platform: 'gitlab' as const,
+    },
+  ])('ignores generic credential updates for $provider repositories', async fixture => {
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${fixture.userId}:${fixture.sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async instance => {
+      await registerReadySession(instance, {
+        sessionId: fixture.sessionId,
+        userId: fixture.userId,
+        prompt: 'prepared prompt',
+        mode: 'code',
+        model: 'test-model',
+        kilocodeToken: 'token-followup',
+        githubRepo: fixture.githubRepo,
+        githubToken: fixture.githubToken,
+        gitUrl: fixture.gitUrl,
+        platform: fixture.platform,
+      });
+      const before = await instance.getMetadata();
+      const admission = await instance.admitSubmittedMessage({
+        ...queueUserMessageInput({
+          userId: fixture.userId,
+          prompt: 'followup prompt',
+          messageId:
+            fixture.platform === 'github'
+              ? 'msg_018f1e2d3c4bAbCdEfGhIjKlM1'
+              : 'msg_018f1e2d3c4bAbCdEfGhIjKlM2',
+        }),
+        repositoryCredentialUpdate: {
+          genericGitToken: 'caller-generic-token',
+        },
+      });
+      const after = await instance.getMetadata();
+      return { admission, before, after };
+    });
+
+    expect(result.admission.success).toBe(true);
+    expect(result.after?.repository).toEqual(result.before?.repository);
   });
 
   it('flushes queued follow-up using the originally queued execution options', async () => {
@@ -928,26 +1007,125 @@ describe('CloudAgentSession message admission', () => {
         })
       );
       await instance.alarm();
-      const retryResult = await instance.admitSubmittedMessage(
-        queueUserMessageInput({
+      const retryResult = await instance.admitSubmittedMessage({
+        ...queueUserMessageInput({
           userId,
           prompt: 'accept once',
           messageId: 'msg_018f1e2d3c4bActRetAbCdEfGh',
-        })
-      );
+        }),
+        repositoryCredentialUpdate: {
+          genericGitToken: 'retry-token',
+        },
+      });
+      const metadata = await instance.getMetadata();
       const pending = await listPendingSessionMessages(instance.ctx.storage);
-      return { retryResult, pending, callCount };
+      return { retryResult, metadata, pending, callCount };
     });
 
     expect(result.retryResult.success).toBe(true);
     if (!result.retryResult.success) return;
     expect(result.retryResult.outcome).toBe('queued');
     expect(result.retryResult.compatibilityDelivery).toBe('sent');
+    expect(result.metadata?.repository?.token).toBe('retry-token');
     expect(result.pending).toHaveLength(0);
     expect(result.callCount).toBe(1);
   });
 
-  it('does not persist token overrides when model validation fails', async () => {
+  it('does not let an older credential retry without queue state roll back a newer token', async () => {
+    const userId = 'user_exec_credential_order' as const;
+    const sessionId = 'agent_exec_credential_order' as const;
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async instance => {
+      await registerReadySession(instance, {
+        sessionId,
+        userId,
+        prompt: 'prepared prompt',
+        mode: 'code',
+        model: 'test-model',
+        kilocodeToken: 'token-followup',
+        gitUrl: 'https://example.com/repo.git',
+        gitToken: 'old-token',
+      });
+      const firstMessageId = 'msg_018f1e2d3c4bAbCdEfGhIjKlN1';
+      const firstRequest = {
+        ...queueUserMessageInput({
+          userId,
+          prompt: 'first followup',
+          messageId: firstMessageId,
+        }),
+        repositoryCredentialUpdate: {
+          genericGitToken: 'first-token',
+        },
+      };
+      await (instance as any).applyRepositoryCredentialUpdate(
+        firstMessageId,
+        firstRequest.repositoryCredentialUpdate
+      );
+      await instance.admitSubmittedMessage({
+        ...queueUserMessageInput({
+          userId,
+          prompt: 'second followup',
+          messageId: 'msg_018f1e2d3c4bAbCdEfGhIjKlN2',
+        }),
+        repositoryCredentialUpdate: {
+          genericGitToken: 'second-token',
+        },
+      });
+      const replay = await instance.admitSubmittedMessage({
+        ...firstRequest,
+        repositoryCredentialUpdate: {
+          genericGitToken: 'replayed-first-token',
+        },
+      });
+      const metadata = await instance.getMetadata();
+      return { replay, metadata };
+    });
+
+    expect(result.replay.success).toBe(true);
+    expect(result.metadata?.repository?.token).toBe('second-token');
+  });
+
+  it('does not rotate generic credentials for a mismatched message replay', async () => {
+    const userId = 'user_exec_credential_mismatch' as const;
+    const sessionId = 'agent_exec_credential_mismatch' as const;
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async instance => {
+      await registerReadySession(instance, {
+        sessionId,
+        userId,
+        prompt: 'prepared prompt',
+        mode: 'code',
+        model: 'test-model',
+        kilocodeToken: 'token-followup',
+        gitUrl: 'https://example.com/repo.git',
+        gitToken: 'old-token',
+      });
+      const messageId = 'msg_018f1e2d3c4bAbCdEfGhIjKlN3';
+      await instance.admitSubmittedMessage({
+        ...queueUserMessageInput({ userId, prompt: 'original', messageId }),
+        repositoryCredentialUpdate: {
+          genericGitToken: 'accepted-token',
+        },
+      });
+      const replay = await instance.admitSubmittedMessage({
+        ...queueUserMessageInput({ userId, prompt: 'changed', messageId }),
+        repositoryCredentialUpdate: {
+          genericGitToken: 'rejected-token',
+        },
+      });
+      const metadata = await instance.getMetadata();
+      return { replay, metadata };
+    });
+
+    expect(result.replay).toMatchObject({ success: false, code: 'BAD_REQUEST' });
+    expect(result.metadata?.repository?.token).toBe('accepted-token');
+  });
+
+  it('does not rotate generic credentials when model validation fails', async () => {
     const userId = 'user_exec_invalid_model' as const;
     const sessionId = 'agent_exec_invalid_model' as const;
     const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
@@ -966,14 +1144,17 @@ describe('CloudAgentSession message admission', () => {
         gitToken: 'old-token',
       });
 
-      const startResult = await instance.admitSubmittedMessage(
-        queueUserMessageInput({
+      const startResult = await instance.admitSubmittedMessage({
+        ...queueUserMessageInput({
           userId,
           prompt: 'bad model',
           model: '',
           messageId: 'msg_018f1e2d3c4bInvModAbCdEfGh',
-        })
-      );
+        }),
+        repositoryCredentialUpdate: {
+          genericGitToken: 'rejected-token',
+        },
+      });
       const metadata = await instance.getMetadata();
       const pending = await listPendingSessionMessages(instance.ctx.storage);
       return { startResult, metadata, pending };

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -362,6 +362,47 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     );
   });
 
+  it('refreshes a warm generic git remote with the current credential', async () => {
+    const repositoryUrl = 'https://git.example.com/acme/repo.git';
+    const token = 'fresh-generic-token';
+    const request = makeRequest(tmpDir, {
+      workspace: {
+        workspacePath: path.join(tmpDir, 'workspace'),
+        sessionHome: path.join(tmpDir, 'home'),
+        branchName: 'main',
+        preferSnapshot: true,
+      },
+      repo: {
+        kind: 'git',
+        url: repositoryUrl,
+        token,
+        refreshRemote: true,
+      },
+    });
+    await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
+    const gitCalls: string[][] = [];
+
+    const result = await prepareWrapperBootstrapWorkspace(request, undefined, {
+      git: async args => {
+        gitCalls.push(args);
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+      runProcess: async () => {
+        throw new Error('setup commands should not run on warm path');
+      },
+      restoreSession: async () => {
+        throw new Error('session restore should not run on warm path');
+      },
+    });
+
+    const authenticatedRemote = new URL(repositoryUrl);
+    authenticatedRemote.username = 'x-access-token';
+    authenticatedRemote.password = token;
+
+    expect(result.workspaceWasWarm).toBe(true);
+    expect(gitCalls).toEqual([['remote', 'set-url', 'origin', authenticatedRemote.toString()]]);
+  });
+
   it('refreshes a warm GitHub remote, author, and selected CLI credential', async () => {
     const request = makeRequest(tmpDir, {
       workspace: {


### PR DESCRIPTION
## Summary

### Why

Generic Git repositories such as App Builder use short-lived credentials that can rotate between follow-up messages. `sendMessageV2` accepted the refreshed `gitToken` but discarded it, so the Durable Object and workspace could keep using an expired credential and fail later clones or Git operations. Refreshing the credential at durable message admission gives queued work a consistent token without changing the server-managed GitHub and GitLab credential paths.

### What was done

- Adapt non-empty legacy V2 `gitToken` values into a transient generic repository credential update while continuing to ignore caller-provided GitHub credentials.
- Apply generic Git credential changes after message validation and capacity checks but before queued work becomes visible, with durable message ordering that prevents stale retries from restoring older credentials.
- Keep credentials out of immutable message intents, pending rows, events, callbacks, and logs; temporary non-secret admission markers are removed after queue persistence.
- Use the refreshed credential for cold clones and rewrite `origin` for warm direct and wrapper-bootstrap workspaces.
- Shell-quote direct workspace paths and authenticated remote URLs before invoking Git.

### High-level architecture

```mermaid
sequenceDiagram
  participant Client as App Builder / legacy client
  participant API as sendMessageV2
  participant DO as CloudAgentSession DO
  participant Store as Durable Object storage
  participant Runtime as Workspace runtime

  Client->>API: Follow-up message + fresh gitToken
  API->>DO: Submitted turn + transient credential update
  DO->>DO: Validate turn, model, and queue capacity
  alt Generic Git repository
    DO->>Store: Update repository metadata, message pointer, and temporary marker
  end
  DO->>Store: Persist message intent and admission state without credential
  DO->>Store: Remove temporary credential marker
  DO-->>API: Admission acknowledgement
  API-->>Client: Queued or sent result

  rect rgb(245, 245, 245)
    Note over DO,Runtime: When queued work prepares its workspace
    DO->>Runtime: Prepare execution from current session metadata
    alt Cold workspace
      Runtime->>Runtime: Clone with current credential
    else Warm workspace
      Runtime->>Runtime: Refresh origin with current credential
    end
  end
```

### Architecture decision

**Decision:** Treat generic Git credential rotation as a transient, validated session-metadata mutation at durable message admission rather than as part of the immutable queued message intent.

**Context:** Cloud Agent can resolve managed GitHub and GitLab credentials through the shared token service, but it cannot independently refresh credentials for arbitrary Git providers. Admission retries and existing drain alarms also require the metadata update to be ordered with queue visibility.

**Rationale:** The Durable Object already owns session metadata and queue coordination, so it can apply the latest generic credential before work is observable while keeping the secret out of message persistence and delivery contracts. A durable current-message pointer plus temporary non-secret markers preserves ordering across partial failures and retries.

**Alternatives considered:**

- **Continue ignoring caller credentials.** This preserves a server-only policy but cannot support arbitrary providers and leaves short-lived generic credentials stale.
- **Persist the token in the queued message intent.** This simplifies handoff but would spread a secret into immutable pending-message, replay, event, or callback surfaces.
- **Add an App Builder-specific refresh path.** This would address one caller while duplicating provider policy outside the durable session boundary and leaving other generic Git clients exposed.

**Consequences:** Generic Git follow-ups can safely rotate credentials for both cold and warm workspaces, while GitHub and managed GitLab remain server-resolved. The trade-off is additional Durable Object admission bookkeeping and an intentionally narrow compatibility contract where only non-empty `gitToken` values affect generic Git repositories.

## Verification

- [ ] Manual verification was not performed; this path requires a live generic Git repository with rotating credentials, and no manual environment was exercised.

## Visual Changes

N/A

## Reviewer Notes

- Focus review on credential ordering when metadata persistence succeeds but queue persistence is retried, especially stale message replays.
- Generic Git is intentionally the only caller-managed path; GitHub and managed GitLab credential behavior is unchanged.
- No UI or database migration is included.