### PR TITLE
fix(organizations): enforce invite email on acceptance

### DIFF
--- a/apps/web/src/lib/organizations/organizations.test.ts
+++ b/apps/web/src/lib/organizations/organizations.test.ts
@@ -1478,6 +1478,63 @@ describe('Organizations', () => {
         }
       });
 
+      test('should reject invitation when accepting user email does not match invite email', async () => {
+        const owner = await insertTestUser();
+        const invitee = await insertTestUser();
+        const differentUser = await insertTestUser();
+        const organization = await createOrganization('Test Org', owner.id);
+
+        const invitation = await inviteUserToOrganization(
+          organization.id,
+          owner.id,
+          invitee.google_user_email,
+          'member'
+        );
+
+        const result = await acceptOrganizationInvite(differentUser.id, invitation.token);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error).toBe('Invitation is for a different email address');
+        }
+
+        const storedInvitation = await db.query.organization_invitations.findFirst({
+          where: eq(organization_invitations.token, invitation.token),
+        });
+        expect(storedInvitation?.accepted_at).toBeNull();
+
+        const unexpectedMembership = await db.query.organization_memberships.findFirst({
+          where: and(
+            eq(organization_memberships.organization_id, organization.id),
+            eq(organization_memberships.kilo_user_id, differentUser.id)
+          ),
+        });
+        expect(unexpectedMembership).toBeUndefined();
+      });
+
+      test('should accept invitation when normalized user email matches invite email', async () => {
+        const owner = await insertTestUser();
+        const invitee = await insertTestUser({
+          google_user_email: 'johndoe@gmail.com',
+          normalized_email: 'johndoe@gmail.com',
+        });
+        const organization = await createOrganization('Test Org', owner.id);
+
+        const invitation = await inviteUserToOrganization(
+          organization.id,
+          owner.id,
+          'John.Doe+team@googlemail.com',
+          'member'
+        );
+
+        const result = await acceptOrganizationInvite(invitee.id, invitation.token);
+
+        expect(result.success).toBe(true);
+        const userOrgs = await getUserOrganizationsWithSeats(invitee.id);
+        expect(userOrgs).toHaveLength(1);
+        expect(userOrgs[0].organizationId).toBe(organization.id);
+      });
+
       test('should reject invitation for existing members', async () => {
         const owner = await insertTestUser();
         const invitee = await insertTestUser();

--- a/apps/web/src/lib/organizations/organizations.ts
+++ b/apps/web/src/lib/organizations/organizations.ts
@@ -21,7 +21,7 @@ import { auto_deleted_at, db, sql } from '@/lib/drizzle';
 import { and, eq, isNull, gt } from 'drizzle-orm';
 import { TRIAL_DURATION_DAYS } from '@/lib/constants';
 import { randomUUID } from 'crypto';
-import { fromMicrodollars } from '@/lib/utils';
+import { fromMicrodollars, normalizeEmail } from '@/lib/utils';
 import { logExceptInTest } from '@/lib/utils.server';
 import { APP_URL } from '@/lib/constants';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
@@ -562,6 +562,24 @@ export async function acceptOrganizationInvite(
       // Check if invitation is already accepted
       if (invitation.accepted_at) {
         return failureResult('Invitation has already been accepted');
+      }
+
+      const [acceptingUser] = await tx
+        .select({
+          email: kilocode_users.google_user_email,
+          normalizedEmail: kilocode_users.normalized_email,
+        })
+        .from(kilocode_users)
+        .where(eq(kilocode_users.id, userId))
+        .limit(1);
+
+      if (!acceptingUser) {
+        return failureResult('User not found');
+      }
+
+      const acceptedEmail = acceptingUser.normalizedEmail ?? normalizeEmail(acceptingUser.email);
+      if (acceptedEmail !== normalizeEmail(invitation.email)) {
+        return failureResult('Invitation is for a different email address');
       }
 
       // Fetch the organization to check the require_seats flag


### PR DESCRIPTION
## Summary
- Require the signed-in user's normalized email to match the email stored on an organization invitation before accepting it.
- Leave mismatched invitations pending and avoid creating memberships when an invite code is used by the wrong account.
- Add regression coverage for mismatched users and normalized Gmail/Googlemail invite matching.

## Verification
Ran local verification by inviting `remon@kilocode.ai` to an organization and making sure a user with another email wasn't allowed to accept the invite, but `remon@kilocode.ai` was.

## Reviewer Notes
- The acceptance check uses `normalized_email` when available and falls back to normalizing `google_user_email` for legacy users.