### PR TITLE
Cloud Agent - add dispatch health monitor

### DIFF
--- a/apps/web/src/app/api/cloud-agent/dispatch-health/route.test.ts
+++ b/apps/web/src/app/api/cloud-agent/dispatch-health/route.test.ts
@@ -1,0 +1,237 @@
+import { NextRequest } from 'next/server';
+
+const mockCaptureException = jest.fn();
+const mockEvaluateDispatchHealth = jest.fn();
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
+jest.mock('@/lib/cloud-agent/dispatch-health/detector', () => {
+  const actual = jest.requireActual('@/lib/cloud-agent/dispatch-health/detector');
+  return {
+    ...actual,
+    evaluateDispatchHealth: (...args: unknown[]) => mockEvaluateDispatchHealth(...args),
+  };
+});
+
+import { db, sql } from '@/lib/drizzle';
+import { CLOUD_AGENT_DISPATCH_RUNBOOK_URL } from '@/lib/cloud-agent/dispatch-health/health-response';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { GET } from './route';
+
+const HEALTH_CHECK_KEY = 'kilo-cloud-agent-dispatch-health-check';
+
+function makeRequest(key: string | null): NextRequest {
+  const url =
+    key === null
+      ? 'http://localhost:3000/api/cloud-agent/dispatch-health'
+      : `http://localhost:3000/api/cloud-agent/dispatch-health?key=${key}`;
+  return new NextRequest(url, { method: 'GET' });
+}
+
+describe('GET /api/cloud-agent/dispatch-health', () => {
+  beforeEach(() => {
+    mockCaptureException.mockReset();
+    mockEvaluateDispatchHealth.mockReset();
+  });
+
+  it('rejects requests with no key without querying the database', async () => {
+    const transactionSpy = jest.spyOn(db, 'transaction');
+
+    try {
+      const response = await GET(makeRequest(null));
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ healthy: false });
+      expect(transactionSpy).not.toHaveBeenCalled();
+    } finally {
+      transactionSpy.mockRestore();
+    }
+  });
+
+  it('rejects requests with the wrong key without querying the database', async () => {
+    const transactionSpy = jest.spyOn(db, 'transaction');
+
+    try {
+      const response = await GET(makeRequest('wrong-key'));
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ healthy: false });
+      expect(transactionSpy).not.toHaveBeenCalled();
+    } finally {
+      transactionSpy.mockRestore();
+    }
+  });
+
+  it('returns a completed healthy response when the detector is healthy', async () => {
+    mockEvaluateDispatchHealth.mockResolvedValue({ tripped: false });
+    const transactionSpy = jest.spyOn(db, 'transaction').mockImplementation(async callback => {
+      const execute = jest.fn().mockResolvedValue({ rows: [] });
+      return callback({ execute } as never);
+    });
+
+    try {
+      const response = await GET(makeRequest(HEALTH_CHECK_KEY));
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        healthy: true,
+        alerts: [],
+        metadata: {
+          timestamp: expect.any(String),
+          runbookUrl: CLOUD_AGENT_DISPATCH_RUNBOOK_URL,
+          evaluationStatus: 'completed',
+          detector: {
+            cohortWindowMinutes: 15,
+            dispatchGraceMinutes: 5,
+            stuckRateThreshold: 0.1,
+            minimumAffectedSessions: 3,
+          },
+        },
+      });
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(mockEvaluateDispatchHealth).toHaveBeenCalledTimes(1);
+    } finally {
+      transactionSpy.mockRestore();
+    }
+  });
+
+  it('sets the 10-second statement timeout before detector SQL', async () => {
+    const events: string[] = [];
+    const execute = jest.fn().mockImplementation(async () => {
+      events.push('execute');
+      return { rows: [] };
+    });
+    mockEvaluateDispatchHealth.mockImplementation(
+      async (database: { execute: (query: unknown) => Promise<unknown> }) => {
+        events.push('detector');
+        await database.execute(sql`SELECT 1`);
+        return { tripped: false };
+      }
+    );
+    const transactionSpy = jest
+      .spyOn(db, 'transaction')
+      .mockImplementation(async callback => callback({ execute } as never));
+
+    try {
+      const response = await GET(makeRequest(HEALTH_CHECK_KEY));
+
+      expect(response.status).toBe(200);
+      expect(events).toEqual(['execute', 'detector', 'execute']);
+      expect(execute).toHaveBeenCalledTimes(2);
+      const timeoutQuery = new PgDialect().sqlToQuery(execute.mock.calls[0][0]).sql;
+      expect(timeoutQuery).toBe("SET LOCAL statement_timeout = '10000'");
+    } finally {
+      transactionSpy.mockRestore();
+    }
+  });
+
+  it('captures transaction failures and fails open without exposing the error', async () => {
+    const errorMessage = 'database credentials leaked in error';
+    const transactionSpy = jest.spyOn(db, 'transaction').mockRejectedValue(new Error(errorMessage));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      const response = await GET(makeRequest(HEALTH_CHECK_KEY));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({
+        healthy: true,
+        alerts: [],
+        metadata: {
+          timestamp: expect.any(String),
+          runbookUrl: CLOUD_AGENT_DISPATCH_RUNBOOK_URL,
+          evaluationStatus: 'failed_open',
+          detector: {
+            cohortWindowMinutes: 15,
+            dispatchGraceMinutes: 5,
+            stuckRateThreshold: 0.1,
+            minimumAffectedSessions: 3,
+          },
+        },
+      });
+      expect(JSON.stringify(body)).not.toContain(errorMessage);
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+      expect(mockCaptureException.mock.calls[0][1]).toEqual({
+        tags: {
+          endpoint: 'cloud-agent/dispatch-health',
+          source: 'cloud_agent_dispatch_health_check',
+          detector: 'stuck_dispatch_rate',
+        },
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      transactionSpy.mockRestore();
+    }
+  });
+
+  it('returns one ticket alert when the detector trips', async () => {
+    mockEvaluateDispatchHealth.mockResolvedValue({
+      tripped: true,
+      details: {
+        eligibleRunCount: 30,
+        stuckRunCount: 3,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+        oldestStuckQueuedAt: '2040-06-10T11:46:00.000Z',
+      },
+    });
+    const transactionSpy = jest.spyOn(db, 'transaction').mockImplementation(async callback => {
+      const execute = jest.fn().mockResolvedValue({ rows: [] });
+      return callback({ execute } as never);
+    });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    try {
+      const response = await GET(makeRequest(HEALTH_CHECK_KEY));
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        healthy: false,
+        alerts: [
+          {
+            kind: 'stuck_dispatch_rate',
+            label: 'Stuck Dispatch Rate',
+            severity: 'ticket',
+            eligibleRunCount: 30,
+            stuckRunCount: 3,
+            affectedSessionCount: 3,
+            stuckRate: 0.1,
+            oldestStuckQueuedAt: '2040-06-10T11:46:00.000Z',
+            runbookUrl: CLOUD_AGENT_DISPATCH_RUNBOOK_URL,
+          },
+        ],
+        metadata: {
+          timestamp: expect.any(String),
+          runbookUrl: CLOUD_AGENT_DISPATCH_RUNBOOK_URL,
+          evaluationStatus: 'completed',
+          detector: {
+            cohortWindowMinutes: 15,
+            dispatchGraceMinutes: 5,
+            stuckRateThreshold: 0.1,
+            minimumAffectedSessions: 3,
+          },
+        },
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[cloud-agent/dispatch-health] returning 503: detector tripped',
+        {
+          eligibleRunCount: 30,
+          stuckRunCount: 3,
+          affectedSessionCount: 3,
+          stuckRate: 0.1,
+          oldestStuckQueuedAt: '2040-06-10T11:46:00.000Z',
+        }
+      );
+    } finally {
+      warnSpy.mockRestore();
+      transactionSpy.mockRestore();
+    }
+  });
+});

--- a/apps/web/src/app/api/cloud-agent/dispatch-health/route.ts
+++ b/apps/web/src/app/api/cloud-agent/dispatch-health/route.ts
@@ -1,0 +1,56 @@
+import { captureException } from '@sentry/nextjs';
+import { NextResponse } from 'next/server';
+import { db, sql } from '@/lib/drizzle';
+import { evaluateDispatchHealth } from '@/lib/cloud-agent/dispatch-health/detector';
+import {
+  buildCompletedHealthyResponse,
+  buildCompletedUnhealthyResponse,
+  buildFailedOpenHealthyResponse,
+  type DispatchHealthResponse,
+} from '@/lib/cloud-agent/dispatch-health/health-response';
+
+const HEALTH_CHECK_KEY = 'kilo-cloud-agent-dispatch-health-check';
+const DETECTOR_STATEMENT_TIMEOUT_MS = 10_000;
+
+type UnauthorizedResponse = { healthy: false };
+
+export async function GET(
+  request: Request
+): Promise<NextResponse<DispatchHealthResponse | UnauthorizedResponse>> {
+  const { searchParams } = new URL(request.url);
+
+  if (searchParams.get('key') !== HEALTH_CHECK_KEY) {
+    return NextResponse.json({ healthy: false }, { status: 401 });
+  }
+
+  try {
+    const evaluation = await db.transaction(async tx => {
+      await tx.execute(sql.raw(`SET LOCAL statement_timeout = '${DETECTOR_STATEMENT_TIMEOUT_MS}'`));
+      return evaluateDispatchHealth(tx);
+    });
+
+    if (!evaluation.tripped) {
+      return NextResponse.json(buildCompletedHealthyResponse(), { status: 200 });
+    }
+
+    console.warn('[cloud-agent/dispatch-health] returning 503: detector tripped', {
+      eligibleRunCount: evaluation.details.eligibleRunCount,
+      stuckRunCount: evaluation.details.stuckRunCount,
+      affectedSessionCount: evaluation.details.affectedSessionCount,
+      stuckRate: evaluation.details.stuckRate,
+      oldestStuckQueuedAt: evaluation.details.oldestStuckQueuedAt,
+    });
+    return NextResponse.json(buildCompletedUnhealthyResponse(evaluation.details), {
+      status: 503,
+    });
+  } catch (error) {
+    captureException(error, {
+      tags: {
+        endpoint: 'cloud-agent/dispatch-health',
+        source: 'cloud_agent_dispatch_health_check',
+        detector: 'stuck_dispatch_rate',
+      },
+    });
+    return NextResponse.json(buildFailedOpenHealthyResponse(), { status: 200 });
+  }
+}

--- a/apps/web/src/lib/cloud-agent/dispatch-health/detector.test.ts
+++ b/apps/web/src/lib/cloud-agent/dispatch-health/detector.test.ts
@@ -1,0 +1,376 @@
+import { db } from '@/lib/drizzle';
+import { cloud_agent_session_runs, cloud_agent_sessions } from '@kilocode/db/schema';
+import { inArray } from 'drizzle-orm';
+import { evaluateDispatchHealth } from './detector';
+
+const TEST_PREFIX = `dispatch-health-${Date.now()}`;
+const REFERENCE_TIME = new Date('2040-06-10T12:00:00.000Z');
+type SessionInsert = typeof cloud_agent_sessions.$inferInsert;
+type RunInsert = typeof cloud_agent_session_runs.$inferInsert;
+
+function minutesBeforeReference(minutes: number): string {
+  return new Date(REFERENCE_TIME.getTime() - minutes * 60 * 1000).toISOString();
+}
+
+describe('dispatch health detector', () => {
+  const insertedSessionIds: string[] = [];
+  let sessionSequence = 0;
+  let runSequence = 0;
+
+  function sessionValues(overrides: Partial<SessionInsert> = {}): SessionInsert {
+    const sequence = sessionSequence++;
+
+    return {
+      cloud_agent_session_id: `${TEST_PREFIX}-cloud-session-${sequence}`,
+      kilo_session_id: `${TEST_PREFIX}-kilo-session-${sequence}`,
+      initial_message_id: `${TEST_PREFIX}-initial-message-${sequence}`,
+      created_at: minutesBeforeReference(20),
+      ...overrides,
+    } satisfies SessionInsert;
+  }
+
+  function runValues(session: SessionInsert, overrides: Partial<RunInsert> = {}): RunInsert {
+    const sequence = runSequence++;
+    const queuedAt = minutesBeforeReference(10);
+
+    return {
+      cloud_agent_session_id: session.cloud_agent_session_id,
+      message_id: `${TEST_PREFIX}-message-${sequence}`,
+      status: 'completed',
+      queued_at: queuedAt,
+      terminal_at: queuedAt,
+      ...overrides,
+    } satisfies RunInsert;
+  }
+
+  async function insertFixtures(sessions: SessionInsert[], runs: RunInsert[]): Promise<void> {
+    await db.insert(cloud_agent_sessions).values(sessions);
+    insertedSessionIds.push(...sessions.map(session => session.cloud_agent_session_id));
+    await db.insert(cloud_agent_session_runs).values(runs);
+  }
+
+  async function insertThresholdCohort(
+    stuckMinutesBeforeReference: number[] = [14, 12, 10]
+  ): Promise<void> {
+    const sessions = Array.from({ length: 30 }, () => sessionValues());
+    const runs = sessions.map((session, index) =>
+      index < stuckMinutesBeforeReference.length
+        ? runValues(session, {
+            status: 'queued',
+            queued_at: minutesBeforeReference(stuckMinutesBeforeReference[index]),
+            terminal_at: null,
+          })
+        : runValues(session)
+    );
+    await insertFixtures(sessions, runs);
+  }
+
+  afterEach(async () => {
+    if (insertedSessionIds.length === 0) return;
+
+    await db
+      .delete(cloud_agent_sessions)
+      .where(inArray(cloud_agent_sessions.cloud_agent_session_id, insertedSessionIds));
+    insertedSessionIds.length = 0;
+  });
+
+  it('returns healthy for an empty eligible cohort', async () => {
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toEqual({
+      tripped: false,
+    });
+  });
+
+  it('trips at a 10% stuck rate across three affected sessions', async () => {
+    await insertThresholdCohort();
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toEqual({
+      tripped: true,
+      details: {
+        eligibleRunCount: 30,
+        stuckRunCount: 3,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+        oldestStuckQueuedAt: '2040-06-10T11:46:00.000Z',
+      },
+    });
+  });
+
+  it('excludes runs younger than the dispatch grace from the cohort', async () => {
+    await insertThresholdCohort();
+    const session = sessionValues();
+    await insertFixtures(
+      [session],
+      [
+        runValues(session, {
+          status: 'queued',
+          queued_at: minutesBeforeReference(4),
+          terminal_at: null,
+        }),
+      ]
+    );
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toMatchObject({
+      tripped: true,
+      details: {
+        eligibleRunCount: 30,
+        stuckRunCount: 3,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+      },
+    });
+  });
+
+  it('excludes runs older than the cohort window', async () => {
+    await insertThresholdCohort();
+    const session = sessionValues();
+    await insertFixtures(
+      [session],
+      [
+        runValues(session, {
+          status: 'queued',
+          queued_at: minutesBeforeReference(16),
+          terminal_at: null,
+        }),
+      ]
+    );
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toMatchObject({
+      tripped: true,
+      details: {
+        eligibleRunCount: 30,
+        stuckRunCount: 3,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+      },
+    });
+  });
+
+  it('includes the cohort lower bound and excludes the grace boundary', async () => {
+    await insertThresholdCohort([15, 12, 10]);
+    const session = sessionValues();
+    await insertFixtures(
+      [session],
+      [
+        runValues(session, {
+          status: 'queued',
+          queued_at: minutesBeforeReference(5),
+          terminal_at: null,
+        }),
+      ]
+    );
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toEqual({
+      tripped: true,
+      details: {
+        eligibleRunCount: 30,
+        stuckRunCount: 3,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+        oldestStuckQueuedAt: '2040-06-10T11:45:00.000Z',
+      },
+    });
+  });
+
+  it('excludes runs whose parent session has a classified setup failure', async () => {
+    await insertThresholdCohort();
+    const session = sessionValues({
+      failure_at: minutesBeforeReference(11),
+      failure_stage: 'initial_admission',
+      failure_code: 'initial_admission_rejected',
+    });
+    await insertFixtures(
+      [session],
+      [
+        runValues(session, {
+          status: 'queued',
+          terminal_at: null,
+        }),
+      ]
+    );
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toMatchObject({
+      tripped: true,
+      details: {
+        eligibleRunCount: 30,
+        stuckRunCount: 3,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+      },
+    });
+  });
+
+  it('includes initial and follow-up message runs', async () => {
+    const sessions = Array.from({ length: 39 }, () => sessionValues());
+    const firstSession = sessions[0];
+    const runs = [
+      runValues(firstSession, {
+        message_id: firstSession.initial_message_id,
+        status: 'queued',
+        terminal_at: null,
+      }),
+      runValues(firstSession, { status: 'queued', terminal_at: null }),
+      runValues(sessions[1], { status: 'queued', terminal_at: null }),
+      runValues(sessions[2], { status: 'queued', terminal_at: null }),
+      ...sessions.slice(3).map(session => runValues(session)),
+    ];
+    await insertFixtures(sessions, runs);
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toMatchObject({
+      tripped: true,
+      details: {
+        eligibleRunCount: 40,
+        stuckRunCount: 4,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+      },
+    });
+  });
+
+  it('keeps non-queued lifecycle statuses in the denominator only', async () => {
+    const sessions = Array.from({ length: 30 }, () => sessionValues());
+    const milestoneAt = minutesBeforeReference(9);
+    const runs = sessions.map((session, index) => {
+      if (index < 3) return runValues(session, { status: 'queued', terminal_at: null });
+      if (index === 3) {
+        return runValues(session, {
+          status: 'accepted',
+          dispatch_accepted_at: milestoneAt,
+          terminal_at: null,
+        });
+      }
+      if (index === 4) return runValues(session, { status: 'completed' });
+      if (index === 5) return runValues(session, { status: 'failed' });
+      if (index === 6) return runValues(session, { status: 'interrupted' });
+      return runValues(session);
+    });
+    await insertFixtures(sessions, runs);
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toMatchObject({
+      tripped: true,
+      details: {
+        eligibleRunCount: 30,
+        stuckRunCount: 3,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+      },
+    });
+  });
+
+  it('does not count a queued run with dispatch acceptance as stuck', async () => {
+    const sessions = Array.from({ length: 30 }, () => sessionValues());
+    const runs = sessions.map((session, index) => {
+      if (index < 3) return runValues(session, { status: 'queued', terminal_at: null });
+      if (index === 3) {
+        return runValues(session, {
+          status: 'queued',
+          dispatch_accepted_at: minutesBeforeReference(9),
+          terminal_at: null,
+        });
+      }
+      return runValues(session);
+    });
+    await insertFixtures(sessions, runs);
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toMatchObject({
+      tripped: true,
+      details: {
+        eligibleRunCount: 30,
+        stuckRunCount: 3,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+      },
+    });
+  });
+
+  it('does not count a queued run with a terminal timestamp as stuck', async () => {
+    const sessions = Array.from({ length: 30 }, () => sessionValues());
+    const runs = sessions.map((session, index) => {
+      if (index < 3) return runValues(session, { status: 'queued', terminal_at: null });
+      if (index === 3) return runValues(session, { status: 'queued' });
+      return runValues(session);
+    });
+    await insertFixtures(sessions, runs);
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toMatchObject({
+      tripped: true,
+      details: {
+        eligibleRunCount: 30,
+        stuckRunCount: 3,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+      },
+    });
+  });
+
+  it('stays healthy above the rate threshold when fewer than three sessions are affected', async () => {
+    const sessions = Array.from({ length: 10 }, () => sessionValues());
+    const runs = sessions.map((session, index) =>
+      index < 2 ? runValues(session, { status: 'queued', terminal_at: null }) : runValues(session)
+    );
+    await insertFixtures(sessions, runs);
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toEqual({
+      tripped: false,
+    });
+  });
+
+  it('stays healthy with three affected sessions below the rate threshold', async () => {
+    const sessions = Array.from({ length: 31 }, () => sessionValues());
+    const runs = sessions.map((session, index) =>
+      index < 3 ? runValues(session, { status: 'queued', terminal_at: null }) : runValues(session)
+    );
+    await insertFixtures(sessions, runs);
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toEqual({
+      tripped: false,
+    });
+  });
+
+  it('counts multiple stuck runs in one session once toward affected sessions', async () => {
+    const sessions = Array.from({ length: 39 }, () => sessionValues());
+    const runs = [
+      runValues(sessions[0], { status: 'queued', terminal_at: null }),
+      runValues(sessions[0], { status: 'queued', terminal_at: null }),
+      runValues(sessions[1], { status: 'queued', terminal_at: null }),
+      runValues(sessions[2], { status: 'queued', terminal_at: null }),
+      ...sessions.slice(3).map(session => runValues(session)),
+    ];
+    await insertFixtures(sessions, runs);
+
+    await expect(evaluateDispatchHealth(db, REFERENCE_TIME)).resolves.toMatchObject({
+      tripped: true,
+      details: {
+        eligibleRunCount: 40,
+        stuckRunCount: 4,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+      },
+    });
+  });
+
+  it('normalizes PostgreSQL timestamps and returns aggregate details only', async () => {
+    const database = {
+      execute: jest.fn().mockResolvedValue({
+        rows: [
+          {
+            eligible_run_count: '30',
+            stuck_run_count: '3',
+            affected_session_count: 3,
+            oldest_stuck_queued_at: '2026-04-29 01:16:12.945+00',
+          },
+        ],
+      }),
+    };
+
+    await expect(evaluateDispatchHealth(database as never, REFERENCE_TIME)).resolves.toEqual({
+      tripped: true,
+      details: {
+        eligibleRunCount: 30,
+        stuckRunCount: 3,
+        affectedSessionCount: 3,
+        stuckRate: 0.1,
+        oldestStuckQueuedAt: '2026-04-29T01:16:12.945Z',
+      },
+    });
+  });
+});

--- a/apps/web/src/lib/cloud-agent/dispatch-health/detector.ts
+++ b/apps/web/src/lib/cloud-agent/dispatch-health/detector.ts
@@ -1,0 +1,102 @@
+import type { db as defaultDb } from '@/lib/drizzle';
+import { sql } from '@/lib/drizzle';
+import { cloud_agent_session_runs, cloud_agent_sessions } from '@kilocode/db/schema';
+
+export const DISPATCH_HEALTH_COHORT_WINDOW_MINUTES = 15;
+export const DISPATCH_HEALTH_GRACE_MINUTES = 5;
+export const DISPATCH_HEALTH_STUCK_RATE_THRESHOLD = 0.1;
+export const DISPATCH_HEALTH_MINIMUM_AFFECTED_SESSIONS = 3;
+
+type DispatchHealthDb = Pick<typeof defaultDb, 'execute'>;
+type CountValue = string | number | bigint | null | undefined;
+
+type DispatchHealthAggregateRow = {
+  eligible_run_count: CountValue;
+  stuck_run_count: CountValue;
+  affected_session_count: CountValue;
+  oldest_stuck_queued_at: string | Date | null | undefined;
+};
+
+export type DispatchHealthAlertDetails = {
+  eligibleRunCount: number;
+  stuckRunCount: number;
+  affectedSessionCount: number;
+  stuckRate: number;
+  oldestStuckQueuedAt: string;
+};
+
+export type DispatchHealthEvaluation =
+  | { tripped: false }
+  | { tripped: true; details: DispatchHealthAlertDetails };
+
+function toNumber(value: CountValue): number {
+  if (value === null || value === undefined) return 0;
+  return Number(value) || 0;
+}
+
+function rate(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return numerator / denominator;
+}
+
+export async function evaluateDispatchHealth(
+  database: DispatchHealthDb,
+  referenceTime?: Date
+): Promise<DispatchHealthEvaluation> {
+  const referenceTimeSql = referenceTime
+    ? sql`${referenceTime.toISOString()}::timestamptz`
+    : sql`NOW()`;
+  const result = await database.execute<DispatchHealthAggregateRow>(sql`
+    SELECT
+      COUNT(*) AS eligible_run_count,
+      COUNT(*) FILTER (
+        WHERE r.status = 'queued'
+          AND r.dispatch_accepted_at IS NULL
+          AND r.terminal_at IS NULL
+      ) AS stuck_run_count,
+      COUNT(DISTINCT r.cloud_agent_session_id) FILTER (
+        WHERE r.status = 'queued'
+          AND r.dispatch_accepted_at IS NULL
+          AND r.terminal_at IS NULL
+      ) AS affected_session_count,
+      MIN(r.queued_at) FILTER (
+        WHERE r.status = 'queued'
+          AND r.dispatch_accepted_at IS NULL
+          AND r.terminal_at IS NULL
+      ) AS oldest_stuck_queued_at
+    FROM ${cloud_agent_session_runs} AS r
+    INNER JOIN ${cloud_agent_sessions} AS s
+      ON s.cloud_agent_session_id = r.cloud_agent_session_id
+    WHERE r.queued_at >= ${referenceTimeSql} - (${DISPATCH_HEALTH_COHORT_WINDOW_MINUTES} * INTERVAL '1 minute')
+      AND r.queued_at < ${referenceTimeSql} - (${DISPATCH_HEALTH_GRACE_MINUTES} * INTERVAL '1 minute')
+      AND s.failure_at IS NULL
+  `);
+
+  const row = result.rows[0];
+  const eligibleRunCount = toNumber(row?.eligible_run_count);
+  const stuckRunCount = toNumber(row?.stuck_run_count);
+  const affectedSessionCount = toNumber(row?.affected_session_count);
+  const stuckRate = rate(stuckRunCount, eligibleRunCount);
+
+  if (
+    stuckRate < DISPATCH_HEALTH_STUCK_RATE_THRESHOLD ||
+    affectedSessionCount < DISPATCH_HEALTH_MINIMUM_AFFECTED_SESSIONS
+  ) {
+    return { tripped: false };
+  }
+
+  if (row?.oldest_stuck_queued_at === null || row?.oldest_stuck_queued_at === undefined) {
+    throw new Error('Dispatch health aggregate omitted the oldest stuck queue timestamp');
+  }
+
+  return {
+    tripped: true,
+    details: {
+      eligibleRunCount,
+      stuckRunCount,
+      affectedSessionCount,
+      stuckRate,
+      oldestStuckQueuedAt: new Date(row.oldest_stuck_queued_at).toISOString(),
+    },
+  };
+}

--- a/apps/web/src/lib/cloud-agent/dispatch-health/health-response.ts
+++ b/apps/web/src/lib/cloud-agent/dispatch-health/health-response.ts
@@ -1,0 +1,89 @@
+import {
+  DISPATCH_HEALTH_COHORT_WINDOW_MINUTES,
+  DISPATCH_HEALTH_GRACE_MINUTES,
+  DISPATCH_HEALTH_MINIMUM_AFFECTED_SESSIONS,
+  DISPATCH_HEALTH_STUCK_RATE_THRESHOLD,
+  type DispatchHealthAlertDetails,
+} from './detector';
+
+export const CLOUD_AGENT_DISPATCH_RUNBOOK_URL =
+  'https://github.com/Kilo-Org/on-call/blob/main/runbooks/cloud-agent-dispatch-health.md';
+
+export type DispatchHealthAlert = DispatchHealthAlertDetails & {
+  kind: 'stuck_dispatch_rate';
+  label: 'Stuck Dispatch Rate';
+  severity: 'ticket';
+  runbookUrl: string;
+};
+
+export type DispatchHealthResponse = {
+  healthy: boolean;
+  alerts: DispatchHealthAlert[];
+  metadata: {
+    timestamp: string;
+    runbookUrl: string;
+    evaluationStatus: 'completed' | 'failed_open';
+    detector: {
+      cohortWindowMinutes: number;
+      dispatchGraceMinutes: number;
+      stuckRateThreshold: number;
+      minimumAffectedSessions: number;
+    };
+  };
+};
+
+function metadata(
+  evaluationStatus: DispatchHealthResponse['metadata']['evaluationStatus'],
+  timestamp: Date
+): DispatchHealthResponse['metadata'] {
+  return {
+    timestamp: timestamp.toISOString(),
+    runbookUrl: CLOUD_AGENT_DISPATCH_RUNBOOK_URL,
+    evaluationStatus,
+    detector: {
+      cohortWindowMinutes: DISPATCH_HEALTH_COHORT_WINDOW_MINUTES,
+      dispatchGraceMinutes: DISPATCH_HEALTH_GRACE_MINUTES,
+      stuckRateThreshold: DISPATCH_HEALTH_STUCK_RATE_THRESHOLD,
+      minimumAffectedSessions: DISPATCH_HEALTH_MINIMUM_AFFECTED_SESSIONS,
+    },
+  };
+}
+
+export function buildCompletedHealthyResponse(
+  timestamp: Date = new Date()
+): DispatchHealthResponse {
+  return {
+    healthy: true,
+    alerts: [],
+    metadata: metadata('completed', timestamp),
+  };
+}
+
+export function buildCompletedUnhealthyResponse(
+  details: DispatchHealthAlertDetails,
+  timestamp: Date = new Date()
+): DispatchHealthResponse {
+  return {
+    healthy: false,
+    alerts: [
+      {
+        ...details,
+        kind: 'stuck_dispatch_rate',
+        label: 'Stuck Dispatch Rate',
+        severity: 'ticket',
+        runbookUrl: CLOUD_AGENT_DISPATCH_RUNBOOK_URL,
+      },
+    ],
+    metadata: metadata('completed', timestamp),
+  };
+}
+
+export function buildFailedOpenHealthyResponse(
+  timestamp: Date = new Date()
+): DispatchHealthResponse {
+  return {
+    healthy: true,
+    alerts: [],
+    metadata: metadata('failed_open', timestamp),
+  };
+}


### PR DESCRIPTION
## Summary

- Add a BetterStack-polled Cloud Agent dispatch health endpoint backed by the primary database.
- Detect elevated stuck dispatch rates across a bounded 5-15 minute cohort and return aggregate-only ticket diagnostics.
- Fail open on detector errors while reporting failures to Sentry.

## Verification

- Confirmed the aggregate query uses the existing queued-at index against the local database.
- External BetterStack and runbook setup remains an operational deployment step.

## Visual Changes

N/A

## Reviewer Notes

The endpoint intentionally fails open on database/query errors. BetterStack should poll every 3 minutes, confirm after two failures, route ticket severity to the dedicated Slack-only policy, and recover on a healthy response.