### PR TITLE
ci(web): use dummy env for build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ permissions:
   contents: read
   pull-requests: read
 
-env:
-  VERCEL_VERSION: '53.3.1'
-
 # Optional repo/org variables for runner migration:
 # - RUNNER_DEFAULT_LABEL=blacksmith-2vcpu-ubuntu-2404
 # - RUNNER_LARGE_LABEL=blacksmith-8vcpu-ubuntu-2404
@@ -288,11 +285,36 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
 
-      - name: Setup Vercel ENV
+      - name: Setup dummy build env
         working-directory: apps/web
         run: |
-          pnpm dlx vercel@${{ env.VERCEL_VERSION }} link --project=kilocode-app --token=${{ secrets.VERCEL_TOKEN }} --yes
-          pnpm dlx vercel@${{ env.VERCEL_VERSION }} env pull .env.production.local --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+          cp .env.test .env.production.local
+          {
+            echo 'VERCEL_ENV=production'
+            echo 'NEXTAUTH_URL=https://ci-build.invalid'
+            echo 'NEXT_PUBLIC_SESSION_INGEST_WS_URL=wss://session-ingest.ci-build.invalid'
+            echo 'POSTGRES_URL=postgres://unused:unused@localhost:5432/unused'
+            echo 'ABUSE_SERVICE_CF_ACCESS_CLIENT_ID=dummy-ci-client-id'
+            echo 'ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET=dummy-ci-client-secret'
+            echo 'GASTOWN_SERVICE_CF_ACCESS_CLIENT_ID=dummy-ci-client-id'
+            echo 'GASTOWN_SERVICE_CF_ACCESS_CLIENT_SECRET=dummy-ci-client-secret'
+            echo 'GITHUB_CLIENT_ID=dummy-ci-github-client-id'
+            echo 'GITHUB_CLIENT_SECRET=dummy-ci-github-client-secret'
+            echo 'GITHUB_APP_CLIENT_ID=dummy-ci-github-app-client-id'
+            echo 'GITHUB_APP_CLIENT_SECRET=dummy-ci-github-app-client-secret'
+            echo 'GITHUB_APP_ID=dummy-ci-github-app-id'
+            echo 'GITHUB_APP_PRIVATE_KEY=dummy-ci-github-app-private-key'
+            echo 'GITHUB_APP_WEBHOOK_SECRET=dummy-ci-webhook-secret'
+            echo 'GITHUB_WEBHOOK_SECRET=dummy-ci-webhook-secret'
+            echo 'LINEAR_CLIENT_ID=dummy-ci-linear-client-id'
+            echo 'LINEAR_CLIENT_SECRET=dummy-ci-linear-client-secret'
+            echo 'LINEAR_WEBHOOK_SECRET=dummy-ci-webhook-secret'
+            echo 'SLACK_CLIENT_ID=dummy-ci-slack-client-id'
+            echo 'SLACK_CLIENT_SECRET=dummy-ci-slack-client-secret'
+            echo 'SLACK_SIGNING_SECRET=dummy-ci-slack-signing-secret'
+            echo 'UPSTASH_REDIS_REST_URL=https://redis.ci-build.invalid'
+            echo 'UPSTASH_REDIS_REST_TOKEN=dummy-ci-redis-token'
+          } >> .env.production.local
 
       - name: Build application
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,38 +287,14 @@ jobs:
 
       - name: Setup dummy build env
         working-directory: apps/web
-        run: |
-          cp .env.test .env.production.local
-          {
-            echo 'VERCEL_ENV=production'
-            echo 'NEXTAUTH_URL=https://ci-build.invalid'
-            echo 'NEXT_PUBLIC_SESSION_INGEST_WS_URL=wss://session-ingest.ci-build.invalid'
-            echo 'POSTGRES_URL=postgres://unused:unused@localhost:5432/unused'
-            echo 'ABUSE_SERVICE_CF_ACCESS_CLIENT_ID=dummy-ci-client-id'
-            echo 'ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET=dummy-ci-client-secret'
-            echo 'GASTOWN_SERVICE_CF_ACCESS_CLIENT_ID=dummy-ci-client-id'
-            echo 'GASTOWN_SERVICE_CF_ACCESS_CLIENT_SECRET=dummy-ci-client-secret'
-            echo 'GITHUB_CLIENT_ID=dummy-ci-github-client-id'
-            echo 'GITHUB_CLIENT_SECRET=dummy-ci-github-client-secret'
-            echo 'GITHUB_APP_CLIENT_ID=dummy-ci-github-app-client-id'
-            echo 'GITHUB_APP_CLIENT_SECRET=dummy-ci-github-app-client-secret'
-            echo 'GITHUB_APP_ID=dummy-ci-github-app-id'
-            echo 'GITHUB_APP_PRIVATE_KEY=dummy-ci-github-app-private-key'
-            echo 'GITHUB_APP_WEBHOOK_SECRET=dummy-ci-webhook-secret'
-            echo 'GITHUB_WEBHOOK_SECRET=dummy-ci-webhook-secret'
-            echo 'LINEAR_CLIENT_ID=dummy-ci-linear-client-id'
-            echo 'LINEAR_CLIENT_SECRET=dummy-ci-linear-client-secret'
-            echo 'LINEAR_WEBHOOK_SECRET=dummy-ci-webhook-secret'
-            echo 'SLACK_CLIENT_ID=dummy-ci-slack-client-id'
-            echo 'SLACK_CLIENT_SECRET=dummy-ci-slack-client-secret'
-            echo 'SLACK_SIGNING_SECRET=dummy-ci-slack-signing-secret'
-            echo 'UPSTASH_REDIS_REST_URL=https://redis.ci-build.invalid'
-            echo 'UPSTASH_REDIS_REST_TOKEN=dummy-ci-redis-token'
-          } >> .env.production.local
+        run: cp .env.test .env.production.local
 
       - name: Build application
         env:
           NODE_ENV: production
+          VERCEL_ENV: production
+          NEXTAUTH_URL: https://ci-build.invalid
+          POSTGRES_URL: postgres://unused:unused@localhost:5432/unused
           SENTRY_AUTH_TOKEN: ''
           NODE_OPTIONS: '--max-old-space-size=8192'
         run: pnpm run build

--- a/apps/web/.env.test
+++ b/apps/web/.env.test
@@ -18,12 +18,12 @@ NEXT_PUBLIC_WASTELAND_URL=https://wasteland.test.invalid
 JEST_SILENT=false
 DEBUG_SHOW_DEV_UI=1
 IS_IN_AUTOMATED_TEST=1
-GITHUB_CLIENT_SECRET=
+GITHUB_CLIENT_SECRET=dummy-test-github-client-secret
 GITLAB_CLIENT_ID=
 GITLAB_CLIENT_SECRET=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CLIENT_ID=
-GITHUB_CLIENT_ID=
+GITHUB_CLIENT_ID=dummy-test-github-client-id
 LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=
 OPENAI_API_KEY=
@@ -45,6 +45,7 @@ STRIPE_ENTERPRISE_ANNUAL_PRICE_ID='price_test_enterprise_annual'
 USER_DEPLOYMENTS_API_BASE_URL=''
 USER_DEPLOYMENTS_API_AUTH_KEY=''
 SESSION_INGEST_WORKER_URL=''
+NEXT_PUBLIC_SESSION_INGEST_WS_URL=wss://session-ingest.test.invalid
 R2_ACCOUNT_ID=mock-test-account-id
 R2_ACCESS_KEY_ID=mock-test-access-key
 R2_SECRET_ACCESS_KEY=mock-test-secret-key
@@ -72,6 +73,27 @@ AGENT_ENV_VARS_PUBLIC_KEY='LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txa
 
 MILVUS_TOKEN=
 MILVUS_ADDRESS=
+
+# Production build validation placeholders. These are non-secret dummy values
+# used by CI to verify the production build without pulling real Vercel envs.
+ABUSE_SERVICE_CF_ACCESS_CLIENT_ID=dummy-test-client-id
+ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET=dummy-test-client-secret
+GASTOWN_SERVICE_CF_ACCESS_CLIENT_ID=dummy-test-client-id
+GASTOWN_SERVICE_CF_ACCESS_CLIENT_SECRET=dummy-test-client-secret
+GITHUB_APP_CLIENT_ID=dummy-test-github-app-client-id
+GITHUB_APP_CLIENT_SECRET=dummy-test-github-app-client-secret
+GITHUB_APP_ID=dummy-test-github-app-id
+GITHUB_APP_PRIVATE_KEY=dummy-test-github-app-private-key
+GITHUB_APP_WEBHOOK_SECRET=dummy-test-webhook-secret
+GITHUB_WEBHOOK_SECRET=dummy-test-webhook-secret
+LINEAR_CLIENT_ID=dummy-test-linear-client-id
+LINEAR_CLIENT_SECRET=dummy-test-linear-client-secret
+LINEAR_WEBHOOK_SECRET=dummy-test-webhook-secret
+SLACK_CLIENT_ID=dummy-test-slack-client-id
+SLACK_CLIENT_SECRET=dummy-test-slack-client-secret
+SLACK_SIGNING_SECRET=dummy-test-slack-signing-secret
+UPSTASH_REDIS_REST_URL=https://redis.test.invalid
+UPSTASH_REDIS_REST_TOKEN=dummy-test-redis-token
 
 # Stripe - Kilo Pass (test mode)
 STRIPE_KILO_PASS_TIER_19_MONTHLY_PRICE_ID=price_test_tier_19_monthly


### PR DESCRIPTION
## Summary
- Replace the CI web build's `vercel env pull` setup with a generated `.env.production.local` based on checked-in test defaults.
- Add non-secret dummy production-only values needed for Next.js build-time validation so CI does not require Vercel env access.
- Remove the now-unused CI `VERCEL_VERSION` env value.

## Verification
- Locally generated `apps/web/.env.production.local` using the same dummy values and confirmed `pnpm run build` completes.

## Visual Changes
N/A

## Reviewer Notes
- Dummy values are only used by the CI build job and should not be used for deploy workflows.
- Static generation still logs an expected handled database connection error for model stats because the dummy Postgres URL is intentionally non-functional.