### PR TITLE
ci(deploy): avoid pnpm for global app Vercel deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -142,6 +142,11 @@ jobs:
         with:
           lfs: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+
       - run: npx vercel@${{ env.VERCEL_VERSION }} link --project=kilocode-global-app --token=${{ secrets.VERCEL_TOKEN }} --yes
 
       - name: Deploy to Vercel

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -142,13 +142,10 @@ jobs:
         with:
           lfs: true
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - run: pnpm dlx vercel@${{ env.VERCEL_VERSION }} link --project=kilocode-global-app --token=${{ secrets.VERCEL_TOKEN }} --yes
+      - run: npx vercel@${{ env.VERCEL_VERSION }} link --project=kilocode-global-app --token=${{ secrets.VERCEL_TOKEN }} --yes
 
       - name: Deploy to Vercel
-        run: pnpm dlx vercel@${{ env.VERCEL_VERSION }} deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx vercel@${{ env.VERCEL_VERSION }} deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
 
   deploy-kiloclaw:
     needs: [check-production-db-startup, run-migrations]

--- a/.github/workflows/redeploy-web.yml
+++ b/.github/workflows/redeploy-web.yml
@@ -93,6 +93,11 @@ jobs:
         with:
           lfs: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+
       - run: npx vercel@${{ env.VERCEL_VERSION }} link --project=kilocode-global-app --token=${{ secrets.VERCEL_TOKEN }} --yes
 
       - name: Deploy to Vercel

--- a/.github/workflows/redeploy-web.yml
+++ b/.github/workflows/redeploy-web.yml
@@ -93,10 +93,7 @@ jobs:
         with:
           lfs: true
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - run: pnpm dlx vercel@${{ env.VERCEL_VERSION }} link --project=kilocode-global-app --token=${{ secrets.VERCEL_TOKEN }} --yes
+      - run: npx vercel@${{ env.VERCEL_VERSION }} link --project=kilocode-global-app --token=${{ secrets.VERCEL_TOKEN }} --yes
 
       - name: Deploy to Vercel
-        run: pnpm dlx vercel@${{ env.VERCEL_VERSION }} deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx vercel@${{ env.VERCEL_VERSION }} deploy --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch global-app Vercel CLI calls from `pnpm dlx` to `npx` now that the job no longer sets up the repo Node/pnpm toolchain.
- Remove the unused pnpm setup step from the global-app production and manual redeploy jobs.
- Keep the primary app deploy path unchanged.

## Verification
- Confirmed the failed production job dies inside `pnpm dlx` with Node 20 and pnpm 11 before the Vercel link command can run.
- Confirmed the workflow diff only changes global-app deploy jobs.

## Visual Changes
N/A

## Reviewer Notes
- This preserves Vercel-side builds for global-app while avoiding the pnpm 11/Node 20 mismatch on the lightweight deploy runner.