### PR TITLE
fix(format): allow targeted formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "pnpm --filter web test",
     "test:setup-smoke": "pnpm --filter web run test:setup-smoke",
     "lint": "scripts/lint-all.sh",
-    "format": "oxfmt .",
+    "format": "oxfmt",
     "format:check": "oxfmt --list-different .",
     "format:changed": "git diff --name-only $(git merge-base origin/main HEAD) --diff-filter=ACMR -- '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '**/*.json' '**/*.css' '**/*.md' | xargs -r oxfmt --no-error-on-unmatched-pattern",
     "validate": "pnpm run typecheck && pnpm run lint && pnpm run test",


### PR DESCRIPTION
## Summary
- Update the root `format` script to call bare `oxfmt`, preserving full-repo formatting by default while allowing `pnpm format <path>` to format only the supplied target.

## Verification
- Confirmed `pnpm format` formats a deliberately malformed nested TypeScript file.
- Confirmed `pnpm format package.json` runs against only `package.json`.

## Visual Changes
N/A

## Reviewer Notes
N/A