### PR TITLE
fix(cloud-agent): harden workspace bootstrap

### DIFF
--- a/services/cloud-agent-next/src/execution/orchestrator.ts
+++ b/services/cloud-agent-next/src/execution/orchestrator.ts
@@ -24,7 +24,7 @@ import { logSandboxOperationTimeout } from '../sandbox-timeout-logging.js';
 import { withPreparationInfrastructureRecovery } from '../sandbox-recovery.js';
 import type { AgentSandbox, WrapperInstanceLease } from '../agent-sandbox/protocol.js';
 
-/** Maximum time allowed for wrapper readiness workspace preparation. */
+/** Maximum time allowed for complete wrapper readiness, including Kilo startup. */
 const PREPARE_WORKSPACE_TIMEOUT_MS = 10 * 60 * 1000;
 
 const CODE_REVIEW_DISABLED_TOOLS = {

--- a/services/cloud-agent-next/test/unit/execution/orchestrator.test.ts
+++ b/services/cloud-agent-next/test/unit/execution/orchestrator.test.ts
@@ -423,6 +423,26 @@ describe('ExecutionOrchestrator bootstrap execution', () => {
     ]);
   });
 
+  it('allows wrapper readiness eight minutes but enforces the ten-minute startup budget', async () => {
+    vi.useFakeTimers();
+    const { sandbox } = createMockSandbox({ workspaceWarm: true });
+    const { ensureSessionReady, prompt } = stubWrapperBootstrap();
+    ensureSessionReady.mockImplementation(() => new Promise(() => {}));
+    const orchestrator = createOrchestrator(sandbox);
+
+    const execution = orchestrator.execute(createExecutionPlan());
+    const rejection = expect(execution).rejects.toThrow(
+      'Workspace preparation timed out during wrapper readiness after 600s'
+    );
+    await vi.advanceTimersByTimeAsync(8 * 60 * 1000);
+
+    expect(ensureSessionReady).toHaveBeenCalledOnce();
+    expect(prompt).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+    await rejection;
+  });
+
   it('reports Kilo startup progress when delivering to a warm workspace', async () => {
     const { sandbox } = createMockSandbox({ workspaceWarm: true });
     const { ensureSessionReady, prompt } = stubWrapperBootstrap();

--- a/services/cloud-agent-next/test/unit/wrapper/utils.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/utils.test.ts
@@ -83,6 +83,68 @@ describe('createSafeProcessDiagnostic', () => {
   ])('reports structured termination metadata', ({ result, expected }) => {
     expect(createSafeProcessDiagnostic(result)).toBe(expected);
   });
+
+  it('terminates a process after its output becomes inactive', async () => {
+    const result = await runProcess(process.execPath, ['-e', 'setTimeout(() => {}, 10_000)'], {
+      inactivityTimeoutMs: 50,
+      hardTimeoutMs: 5_000,
+      terminationGraceMs: 50,
+    });
+
+    expect(result.exitCode).toBe(124);
+    expect(result.terminationReason).toBe('inactivity_timeout');
+    expect(result.stderr).toContain('exec inactivity timeout reached');
+  });
+
+  it('keeps a process alive while it produces output', async () => {
+    const outputs: string[] = [];
+    const result = await runProcess(
+      process.execPath,
+      [
+        '-e',
+        'let count = 0; const timer = setInterval(() => { console.log(++count); if (count === 4) clearInterval(timer); }, 100)',
+      ],
+      {
+        inactivityTimeoutMs: 500,
+        hardTimeoutMs: 2_000,
+        onOutput: (_stream, output) => outputs.push(output),
+      }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('4');
+    expect(outputs.join('')).toBe(result.stdout);
+  });
+
+  it('enforces a hard limit even while a process produces output', async () => {
+    const result = await runProcess(
+      process.execPath,
+      ['-e', 'console.log("active"); setInterval(() => console.log("active"), 100)'],
+      {
+        inactivityTimeoutMs: 2_000,
+        hardTimeoutMs: 1_000,
+        terminationGraceMs: 50,
+      }
+    );
+
+    expect(result.exitCode).toBe(124);
+    expect(result.terminationReason).toBe('hard_timeout');
+    expect(result.stderr).toContain('exec hard timeout reached');
+    expect(result.stdout).toContain('active');
+  });
+
+  it('retains only the tail of large process output', async () => {
+    const result = await runProcess(
+      process.execPath,
+      ['-e', 'process.stdout.write("x".repeat(1_100_000) + "END")'],
+      { timeoutMs: 5_000 }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(Buffer.byteLength(result.stdout)).toBeLessThanOrEqual(64 * 1_024);
+    expect(result.stdout.endsWith('END')).toBe(true);
+    expect(result.stdoutTruncated).toBe(true);
+  });
 });
 
 describe('git', () => {

--- a/services/cloud-agent-next/wrapper/src/main.ts
+++ b/services/cloud-agent-next/wrapper/src/main.ts
@@ -233,6 +233,10 @@ async function main() {
   let connectionManager: ReturnType<typeof createConnectionManager> | undefined;
   let lifecycleManager: ReturnType<typeof createLifecycleManager> | undefined;
   let runtimeWorkspacePath = initialWorkspacePath;
+  let isShuttingDown = false;
+  const workspaceBootstrapController = new AbortController();
+  const activeWorkspaceBootstraps = new Set<ReturnType<typeof prepareWrapperBootstrapWorkspace>>();
+  const activeRuntimeStartups = new Set<Promise<void>>();
 
   const unavailableKiloClient = new Proxy(
     {},
@@ -504,9 +508,22 @@ async function main() {
     }
   }
 
+  function wrapperFinalizingResponse(): WrapperSessionReadyResponse {
+    return {
+      status: 'error',
+      error: {
+        code: 'WRAPPER_FINALIZING',
+        message: 'Wrapper is shutting down',
+        retryable: true,
+      },
+    };
+  }
+
   async function readySession(
     request: WrapperSessionReadyRequest
   ): Promise<WrapperSessionReadyResponse> {
+    if (isShuttingDown) return wrapperFinalizingResponse();
+
     const readyStartedAt = Date.now();
     let progressChannel: Awaited<ReturnType<typeof openIngestProgressChannel>> | undefined;
     logToFile(
@@ -549,16 +566,29 @@ async function main() {
         progressChannel = await openIngestProgressChannel(state);
       }
 
+      if (isShuttingDown) return wrapperFinalizingResponse();
+
       logToFile(
         `session/ready bootstrap workspace starting kiloSessionId=${request.kiloSessionId}`
       );
-      await prepareWrapperBootstrapWorkspace(request, (step, message) => {
-        state.sendToIngest({
-          streamEventType: 'preparing',
-          data: { step, message },
-          timestamp: new Date().toISOString(),
-        });
-      });
+      const workspaceBootstrap = prepareWrapperBootstrapWorkspace(
+        request,
+        (step, message) => {
+          state.sendToIngest({
+            streamEventType: 'preparing',
+            data: { step, message },
+            timestamp: new Date().toISOString(),
+          });
+        },
+        {},
+        workspaceBootstrapController.signal
+      );
+      activeWorkspaceBootstraps.add(workspaceBootstrap);
+      try {
+        await workspaceBootstrap;
+      } finally {
+        activeWorkspaceBootstraps.delete(workspaceBootstrap);
+      }
       logToFile(
         `session/ready bootstrap workspace finished kiloSessionId=${request.kiloSessionId}`
       );
@@ -566,7 +596,17 @@ async function main() {
       progressChannel?.close();
       progressChannel = undefined;
 
-      await startKiloRuntime(request.workspace.workspacePath, request.kiloSessionId);
+      if (isShuttingDown) return wrapperFinalizingResponse();
+      const runtimeStartup = startKiloRuntime(
+        request.workspace.workspacePath,
+        request.kiloSessionId
+      );
+      activeRuntimeStartups.add(runtimeStartup);
+      try {
+        await runtimeStartup;
+      } finally {
+        activeRuntimeStartups.delete(runtimeStartup);
+      }
       if (!kiloClient) {
         throw kiloServerBootstrapError('Kilo server did not start');
       }
@@ -586,6 +626,12 @@ async function main() {
         },
       };
     } catch (error) {
+      if (isShuttingDown) {
+        logToFile(
+          `session/ready aborted by shutdown kiloSessionId=${request.kiloSessionId} elapsedMs=${Date.now() - readyStartedAt}`
+        );
+        return wrapperFinalizingResponse();
+      }
       const bootstrapError =
         error instanceof WrapperBootstrapError
           ? error
@@ -632,7 +678,6 @@ async function main() {
   // ---------------------------------------------------------------------------
   // Graceful shutdown
   // ---------------------------------------------------------------------------
-  let isShuttingDown = false;
 
   async function handleShutdown(signal: string): Promise<void> {
     if (isShuttingDown) return;
@@ -641,7 +686,14 @@ async function main() {
     logToFile(`shutdown signal: ${signal}`);
     console.error(`Received ${signal}, shutting down...`);
 
-    // Send interrupted event if connected
+    // Force exit after timeout
+    setTimeout(() => {
+      logToFile('force exit after timeout');
+      process.exit(1);
+    }, SHUTDOWN_TIMEOUT_MS);
+
+    // Send interrupted event if connected — before waiting on startup cleanup,
+    // which can outlast the force-exit window
     state.sendToIngest({
       streamEventType: 'interrupted',
       data: {
@@ -651,15 +703,21 @@ async function main() {
       timestamp: new Date().toISOString(),
     });
 
+    workspaceBootstrapController.abort();
+    const workspaceBootstraps = [...activeWorkspaceBootstraps];
+    const runtimeStartups = [...activeRuntimeStartups];
+    const pendingStartupOperations = [...workspaceBootstraps, ...runtimeStartups];
+    if (pendingStartupOperations.length > 0) {
+      logToFile(
+        `shutdown waiting for startup cleanup workspaceBootstraps=${workspaceBootstraps.length} runtimeStartups=${runtimeStartups.length}`
+      );
+      await Promise.allSettled(pendingStartupOperations);
+      logToFile('shutdown startup cleanup finished');
+    }
+
     // Stop lifecycle timers
     lifecycleManager?.stop();
     globalFeedManager.close();
-
-    // Force exit after timeout
-    setTimeout(() => {
-      logToFile('force exit after timeout');
-      process.exit(1);
-    }, SHUTDOWN_TIMEOUT_MS);
 
     // Best-effort final log upload
     const uploader = state.logUploader;

--- a/services/cloud-agent-next/wrapper/src/restore-session.test.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.test.ts
@@ -369,6 +369,29 @@ describe('restoreSession', () => {
     expect(fs.existsSync(TMP_PATH)).toBe(false);
   });
 
+  it('terminates kilo import when the workspace deadline is aborted', async () => {
+    mockFetchOk(makeSnapshot([]));
+    writeSlowMockKilo(binDir);
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 50);
+    const startedAt = Date.now();
+
+    const result = await restoreSession(SESSION_ID, workspace, undefined, {
+      importTimeoutMs: 5_000,
+      importTerminationGraceMs: 50,
+      signal: controller.signal,
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.step).toBe('import');
+      expect(result.error).toContain('kilo import failed');
+    }
+    expect(elapsedMs).toBeLessThan(800);
+    expect(fs.existsSync(TMP_PATH)).toBe(false);
+  });
+
   it('returns import error when kilo import is terminated by a signal', async () => {
     mockFetchOk(makeSnapshot([]));
     writeSignalTerminatedMockKilo(binDir);
@@ -757,6 +780,23 @@ describe('extractDiffs', () => {
 
     const diffs = await extractDiffs(filePath);
     expect(diffs).toEqual([]);
+  });
+
+  it('does not start diff extraction after the workspace deadline expires', async () => {
+    const filePath = path.join(tmpDir, 'snapshot.json');
+    fs.writeFileSync(filePath, JSON.stringify({ messages: [] }));
+    const controller = new AbortController();
+    const deadlineError = new Error('workspace deadline reached');
+    controller.abort(deadlineError);
+    let caughtError: unknown;
+
+    try {
+      await extractDiffs(filePath, controller.signal);
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toBe(deadlineError);
   });
 
   it('returns null on invalid JSON', async () => {

--- a/services/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.ts
@@ -2,7 +2,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { WorkspaceFailureSubtype } from '../../src/shared/wrapper-bootstrap.js';
-import { createSafeProcessDiagnostic, logToFile, runProcess } from './utils.js';
+import {
+  createSafeProcessDiagnostic,
+  isTimeoutTermination,
+  logToFile,
+  runProcess,
+} from './utils.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -593,7 +598,7 @@ export async function restoreSession(
     });
     const importElapsedMs = Date.now() - importStartedAt;
 
-    if (importResult.terminationReason === 'timeout') {
+    if (isTimeoutTermination(importResult)) {
       log(
         `kilo import finished outcome=timeout kiloSessionId=${kiloSessionId} input=${downloaded ? 'downloaded' : 'provided'} cwd=${workspacePath} home=${process.env.HOME ?? '(unset)'} elapsedMs=${importElapsedMs} timeoutMs=${importTimeoutMs}`
       );

--- a/services/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.ts
@@ -34,6 +34,7 @@ type SnapshotDiff = {
 export type RestoreSessionOptions = {
   importTimeoutMs?: number;
   importTerminationGraceMs?: number;
+  signal?: AbortSignal;
 };
 
 const KILO_IMPORT_TIMEOUT_MS = 120_000;
@@ -108,7 +109,7 @@ function isStreamChunkResult(value: unknown): value is StreamChunkResult {
   return typeof value === 'object' && value !== null;
 }
 
-function createJsonCharReader(snapshotPath: string): JsonCharReader {
+function createJsonCharReader(snapshotPath: string, signal?: AbortSignal): JsonCharReader {
   const stream = fs.createReadStream(snapshotPath, { encoding: 'utf8' });
   const iterator = stream[Symbol.asyncIterator]();
   let buffer = '';
@@ -117,6 +118,7 @@ function createJsonCharReader(snapshotPath: string): JsonCharReader {
 
   return {
     async next(): Promise<string | null> {
+      signal?.throwIfAborted();
       if (unreadChar !== undefined) {
         const char = unreadChar;
         unreadChar = undefined;
@@ -307,8 +309,11 @@ async function validateInfoObject(reader: JsonCharReader): Promise<InfoObjectVal
   }
 }
 
-async function validateSnapshotInfoId(snapshotPath: string): Promise<SnapshotInfoValidationResult> {
-  const reader = createJsonCharReader(snapshotPath);
+async function validateSnapshotInfoId(
+  snapshotPath: string,
+  signal?: AbortSignal
+): Promise<SnapshotInfoValidationResult> {
+  const reader = createJsonCharReader(snapshotPath, signal);
   try {
     if ((await nextNonWhitespace(reader)) !== '{') return { validation: 'invalid' };
 
@@ -373,13 +378,19 @@ const JQ_EXTRACT_DIFFS_FILTER =
  * the devcontainer flow: the user's image is only required to ship `node` +
  * `bun`, so `jq` may be missing.
  */
-export async function extractDiffs(snapshotPath: string): Promise<SnapshotDiff[] | null> {
+export async function extractDiffs(
+  snapshotPath: string,
+  signal?: AbortSignal
+): Promise<SnapshotDiff[] | null> {
+  signal?.throwIfAborted();
   try {
     const proc = Bun.spawn(['jq', '-c', JQ_EXTRACT_DIFFS_FILTER, snapshotPath], {
       stdout: 'pipe',
       stderr: 'ignore',
+      signal,
     });
     const exitCode = await proc.exited;
+    signal?.throwIfAborted();
     if (exitCode === 0) {
       const stdout = await new Response(proc.stdout).text();
       try {
@@ -391,10 +402,11 @@ export async function extractDiffs(snapshotPath: string): Promise<SnapshotDiff[]
     }
     log(`jq_unavailable exitCode=${exitCode}`);
   } catch {
+    signal?.throwIfAborted();
     log('jq_unavailable');
   }
 
-  return extractDiffsWithBun(snapshotPath);
+  return extractDiffsWithBun(snapshotPath, signal);
 }
 
 /**
@@ -402,7 +414,10 @@ export async function extractDiffs(snapshotPath: string): Promise<SnapshotDiff[]
  * into the V8 heap and applies the same last-write-wins dedup the jq filter
  * does. Higher peak memory than jq but avoids a hard dependency.
  */
-async function extractDiffsWithBun(snapshotPath: string): Promise<SnapshotDiff[] | null> {
+async function extractDiffsWithBun(
+  snapshotPath: string,
+  signal?: AbortSignal
+): Promise<SnapshotDiff[] | null> {
   type SnapshotShape = {
     sessionDiff?: SnapshotDiff[];
     messages?: Array<{
@@ -413,8 +428,11 @@ async function extractDiffsWithBun(snapshotPath: string): Promise<SnapshotDiff[]
   };
   let parsed: SnapshotShape;
   try {
+    signal?.throwIfAborted();
     parsed = (await Bun.file(snapshotPath).json()) as SnapshotShape;
+    signal?.throwIfAborted();
   } catch {
+    signal?.throwIfAborted();
     log('snapshot_parse_failed');
     return null;
   }
@@ -435,19 +453,27 @@ async function extractDiffsWithBun(snapshotPath: string): Promise<SnapshotDiff[]
   return Array.from(dedup.values());
 }
 
-function applyPatch(workspacePath: string, diff: SnapshotDiff): boolean {
+async function applyPatch(
+  workspacePath: string,
+  diff: SnapshotDiff,
+  signal?: AbortSignal
+): Promise<boolean> {
   if (!diff.patch) return false;
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-session-diff-'));
   const file = path.join(dir, 'change.patch');
   try {
+    signal?.throwIfAborted();
     fs.writeFileSync(file, diff.patch);
-    const proc = Bun.spawnSync(['git', 'apply', '--3way', '--whitespace=nowarn', file], {
+    const proc = Bun.spawn(['git', 'apply', '--3way', '--whitespace=nowarn', file], {
       cwd: workspacePath,
       stdout: 'pipe',
       stderr: 'pipe',
+      signal,
     });
-    if (proc.exitCode === 0) return true;
-    log(`git apply failed file=${diff.file} exitCode=${proc.exitCode}`);
+    const exitCode = await proc.exited;
+    signal?.throwIfAborted();
+    if (exitCode === 0) return true;
+    log(`git apply failed file=${diff.file} exitCode=${exitCode}`);
     return false;
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -494,9 +520,13 @@ export async function restoreSession(
     log('downloading snapshot');
     try {
       const url = `${ingestUrl}/api/session/${encodeURIComponent(kiloSessionId)}/export`;
+      const downloadTimeoutSignal = AbortSignal.timeout(300_000);
+      const downloadSignal = options.signal
+        ? AbortSignal.any([options.signal, downloadTimeoutSignal])
+        : downloadTimeoutSignal;
       const res = await fetch(url, {
         headers: { Authorization: `Bearer ${token}` },
-        signal: AbortSignal.timeout(300_000),
+        signal: downloadSignal,
       });
 
       if (!res.ok) {
@@ -516,7 +546,7 @@ export async function restoreSession(
       // kilo with a cryptic `undefined is not an object (evaluating 'info2.id')`
       // and exit 1. Stream only the top-level metadata guardrail instead of
       // materializing the full export in the wrapper heap.
-      const snapshotInfoValidation = await validateSnapshotInfoId(tmpPath);
+      const snapshotInfoValidation = await validateSnapshotInfoId(tmpPath, options.signal);
       log(
         `snapshot metadata validated status=${snapshotInfoValidation.validation} expectedKiloSessionId=${kiloSessionId} snapshotInfoId=${snapshotInfoValidation.infoId ?? '(missing)'} idMatchesExpected=${snapshotInfoValidation.infoId === kiloSessionId} bytes=${bytesWritten}`
       );
@@ -539,11 +569,12 @@ export async function restoreSession(
   } else {
     log(`using provided file=${filePath}`);
     try {
-      const providedInfoValidation = await validateSnapshotInfoId(tmpPath);
+      const providedInfoValidation = await validateSnapshotInfoId(tmpPath, options.signal);
       log(
         `provided snapshot metadata inspected status=${providedInfoValidation.validation} expectedKiloSessionId=${kiloSessionId} snapshotInfoId=${providedInfoValidation.infoId ?? '(missing)'} idMatchesExpected=${providedInfoValidation.infoId === kiloSessionId}`
       );
     } catch {
+      options.signal?.throwIfAborted();
       log(`provided snapshot metadata inspection failed expectedKiloSessionId=${kiloSessionId}`);
     }
   }
@@ -557,6 +588,7 @@ export async function restoreSession(
     const importResult = await runProcess('kilo', ['import', tmpPath], {
       cwd: workspacePath,
       timeoutMs: importTimeoutMs,
+      signal: options.signal,
       terminationGraceMs: options.importTerminationGraceMs,
     });
     const importElapsedMs = Date.now() - importStartedAt;
@@ -593,7 +625,7 @@ export async function restoreSession(
     // ---- Step 3: Apply diffs ----
     // Extract diffs in a subprocess so the full snapshot JSON is never loaded
     // into this process's heap — only the small diff array crosses the boundary.
-    const uniqueDiffs = await extractDiffs(tmpPath);
+    const uniqueDiffs = await extractDiffs(tmpPath, options.signal);
     if (uniqueDiffs === null) {
       return fail('failed to parse snapshot JSON', null, 'diffs');
     }
@@ -616,8 +648,9 @@ export async function restoreSession(
     let skipped = 0;
 
     for (const diff of uniqueDiffs) {
+      options.signal?.throwIfAborted();
       if (diff.patch) {
-        if (applyPatch(workspacePath, diff)) {
+        if (await applyPatch(workspacePath, diff, options.signal)) {
           applied++;
         } else {
           skipped++;

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -59,6 +59,12 @@ function asFetch(
   return Object.assign(fn, { preconnect: fetch.preconnect });
 }
 
+async function createCompleteGitWorkspace(workspacePath: string): Promise<void> {
+  const gitPath = path.join(workspacePath, '.git');
+  await fsp.mkdir(gitPath, { recursive: true });
+  await fsp.writeFile(path.join(gitPath, 'kilo-bootstrap-complete'), 'ready\n');
+}
+
 describe('prepareWrapperBootstrapWorkspace', () => {
   let tmpDir: string;
   let originalEnv: Record<string, string | undefined>;
@@ -85,6 +91,7 @@ describe('prepareWrapperBootstrapWorkspace', () => {
 
   it('prepares a cold workspace, restores Kilo, and runs setup commands', async () => {
     const request = makeRequest(tmpDir);
+    const progress = mock(() => {});
     const gitCalls: string[][] = [];
     const setupCalls: string[][] = [];
     const restoreCalls: Array<{ kiloSessionId: string; workspacePath: string; filePath?: string }> =
@@ -115,15 +122,17 @@ describe('prepareWrapperBootstrapWorkspace', () => {
       },
     };
 
-    const result = await prepareWrapperBootstrapWorkspace(request, undefined, deps);
+    const result = await prepareWrapperBootstrapWorkspace(request, progress, deps);
 
     expect(result.workspaceWasWarm).toBe(false);
+    expect(progress).toHaveBeenLastCalledWith('kilo_server', 'Starting Kilo...');
     expect(gitCalls[0]).toEqual([
       'clone',
+      '--progress',
       'https://x-access-token:gh-token@github.com/acme/repo.git',
       request.workspace.workspacePath,
     ]);
-    expect(gitCalls.some(args => args.join(' ') === 'checkout -b main')).toBe(true);
+    expect(gitCalls.some(args => args.join(' ') === 'checkout --progress -b main')).toBe(true);
     expect(setupCalls).toEqual([['sh', '-lc', 'pnpm install']]);
     expect(restoreCalls[0]).toMatchObject({
       kiloSessionId: 'kilo_sess_1',
@@ -141,6 +150,196 @@ describe('prepareWrapperBootstrapWorkspace', () => {
         'utf8'
       )
     ).toBe(buildCloudAgentRules(request.agentSessionId));
+    expect(
+      fs.existsSync(path.join(request.workspace.workspacePath, '.git', 'kilo-bootstrap-complete'))
+    ).toBe(true);
+  });
+
+  it('uses activity watchdogs and reports sanitized progress for long git operations', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.setupCommands = [];
+    const gitCalls: Array<{
+      args: string[];
+      opts: Parameters<NonNullable<WrapperBootstrapDeps['git']>>[1];
+    }> = [];
+    const progress = mock(() => {});
+
+    await prepareWrapperBootstrapWorkspace(request, progress, {
+      git: async (args, opts) => {
+        gitCalls.push({ args, opts });
+        if (args[0] === 'clone') {
+          await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
+          opts?.onOutput?.(
+            'stderr',
+            'remote: https://x-access-token:gh-token@github.com/acme/repo.git Receiving objects: 42% (42/100)\n'
+          );
+        }
+        if (args[0] === 'rev-parse') {
+          return { stdout: '', stderr: '', exitCode: 1 };
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+      restoreSession: async () => ({
+        ok: true,
+        downloaded: false,
+        imported: true,
+        diffs: { applied: 0, skipped: 0, total: 0 },
+      }),
+    });
+
+    const cloneCall = gitCalls.find(call => call.args[0] === 'clone');
+    expect(cloneCall?.args).toContain('--progress');
+    expect(cloneCall?.opts?.inactivityTimeoutMs).toBe(120_000);
+    expect(cloneCall?.opts?.hardTimeoutMs).toBe(300_000);
+    expect(gitCalls.some(call => call.args.join(' ') === 'fetch --progress origin')).toBe(true);
+    expect(gitCalls.some(call => call.args.join(' ') === 'checkout --progress -b main')).toBe(true);
+    expect(progress).toHaveBeenCalledWith(
+      'cloning',
+      'Cloning repository... Receiving objects: 42%'
+    );
+    expect(progress.mock.calls.flat().join(' ')).not.toContain('gh-token');
+  });
+
+  it('fails and cleans up when a repository fetch reaches its hard limit', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.setupCommands = [];
+
+    let caughtError: unknown;
+    try {
+      await prepareWrapperBootstrapWorkspace(request, undefined, {
+        git: async args => {
+          if (args[0] === 'clone') {
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+          }
+          if (args[0] === 'fetch') {
+            return {
+              stdout: '',
+              stderr: 'exec hard timeout reached',
+              exitCode: 124,
+              terminationReason: 'hard_timeout',
+            };
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => {
+          throw new Error('restore should not run after fetch timeout');
+        },
+      });
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toMatchObject({
+      code: 'WORKSPACE_SETUP_FAILED',
+      subtype: 'git_checkout_timeout',
+      retryable: true,
+      message: 'Repository checkout timed out',
+      detail: 'termination hard_timeout',
+    });
+    expect(JSON.stringify(caughtError)).not.toContain('exec hard timeout reached');
+    expect(fs.existsSync(request.workspace.workspacePath)).toBe(false);
+    expect(fs.existsSync(request.workspace.sessionHome)).toBe(false);
+  });
+
+  it('aborts active work and cleans up when the shared workspace deadline expires', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.setupCommands = [];
+    let commandSignal: AbortSignal | undefined;
+    let caughtError: unknown;
+
+    try {
+      await prepareWrapperBootstrapWorkspace(request, undefined, {
+        workspacePreparationTimeoutMs: 20,
+        git: async (args, opts) => {
+          if (args[0] !== 'clone') {
+            return { stdout: '', stderr: '', exitCode: 0 };
+          }
+
+          await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
+          commandSignal = opts?.signal;
+          if (!commandSignal) {
+            return { stdout: '', stderr: 'missing workspace signal', exitCode: 1 };
+          }
+          if (!commandSignal.aborted) {
+            await new Promise<void>(resolve =>
+              commandSignal?.addEventListener('abort', () => resolve(), { once: true })
+            );
+          }
+          return {
+            stdout: '',
+            stderr: 'exec aborted',
+            exitCode: 124,
+            terminationReason: 'abort',
+          };
+        },
+      });
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(commandSignal?.aborted).toBe(true);
+    expect(caughtError).toMatchObject({
+      code: 'WORKSPACE_SETUP_FAILED',
+      subtype: 'workspace_setup_unknown',
+      retryable: true,
+      message: expect.stringContaining('Workspace preparation timed out'),
+    });
+    expect(fs.existsSync(request.workspace.workspacePath)).toBe(false);
+    expect(fs.existsSync(request.workspace.sessionHome)).toBe(false);
+  });
+
+  it('uses shared command watchdogs and generic progress for setup commands', async () => {
+    const request = makeRequest(tmpDir);
+    const progress = mock(() => {});
+    let setupOptions: Parameters<NonNullable<WrapperBootstrapDeps['runProcess']>>[2];
+    let markerExistedDuringSetup = true;
+
+    await prepareWrapperBootstrapWorkspace(request, progress, {
+      git: async (args, opts) => {
+        if (args[0] === 'clone') {
+          await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
+        }
+        if (args[0] === 'rev-parse') {
+          return { stdout: '', stderr: '', exitCode: 1 };
+        }
+        opts?.onOutput?.('stderr', 'Updating files: 100% (1/1)\n');
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+      runProcess: async (_command, _args, opts) => {
+        setupOptions = opts;
+        markerExistedDuringSetup = fs.existsSync(
+          path.join(request.workspace.workspacePath, '.git', 'kilo-bootstrap-complete')
+        );
+        opts?.onOutput?.('stdout', 'secret setup output');
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+      restoreSession: async () => ({
+        ok: true,
+        downloaded: false,
+        imported: true,
+        diffs: { applied: 0, skipped: 0, total: 0 },
+      }),
+    });
+
+    expect(setupOptions?.inactivityTimeoutMs).toBe(120_000);
+    expect(setupOptions?.hardTimeoutMs).toBe(300_000);
+    expect(markerExistedDuringSetup).toBe(false);
+    expect(
+      fs.existsSync(path.join(request.workspace.workspacePath, '.git', 'kilo-bootstrap-complete'))
+    ).toBe(true);
+    expect(fs.existsSync(path.join(request.workspace.sessionHome, '.kilo-bootstrap-pending'))).toBe(
+      false
+    );
+    expect(progress).toHaveBeenCalledWith(
+      'setup_commands',
+      'Setup command 1 of 1 is still running...'
+    );
+    expect(progress.mock.calls.flat().join(' ')).not.toContain('secret setup output');
   });
 
   it('fetches and checks out strict GitHub pull refs directly', async () => {
@@ -167,8 +366,14 @@ describe('prepareWrapperBootstrapWorkspace', () => {
 
     await prepareWrapperBootstrapWorkspace(request, undefined, deps);
 
-    expect(gitCalls).toContainEqual(['fetch', 'origin', 'refs/pull/123/head']);
-    expect(gitCalls).toContainEqual(['checkout', '-B', 'refs/pull/123/head', 'FETCH_HEAD']);
+    expect(gitCalls).toContainEqual(['fetch', '--progress', 'origin', 'refs/pull/123/head']);
+    expect(gitCalls).toContainEqual([
+      'checkout',
+      '--progress',
+      '-B',
+      'refs/pull/123/head',
+      'FETCH_HEAD',
+    ]);
     expect(gitCalls.some(args => args[0] === 'rev-parse')).toBe(false);
   });
 
@@ -196,9 +401,15 @@ describe('prepareWrapperBootstrapWorkspace', () => {
 
     await prepareWrapperBootstrapWorkspace(request, undefined, deps);
 
-    expect(gitCalls).toContainEqual(['fetch', 'origin', 'refs/merge-requests/99/head']);
+    expect(gitCalls).toContainEqual([
+      'fetch',
+      '--progress',
+      'origin',
+      'refs/merge-requests/99/head',
+    ]);
     expect(gitCalls).toContainEqual([
       'checkout',
+      '--progress',
       '-B',
       'refs/merge-requests/99/head',
       'FETCH_HEAD',
@@ -531,9 +742,49 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     });
   });
 
-  it('resumes unfinished cold bootstraps when a prior attempt left a git workspace behind', async () => {
+  it('migrates a valid legacy warm workspace without recloning it', async () => {
+    const request = makeRequest(tmpDir);
+    request.workspace.preferSnapshot = true;
+    await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
+    const authPath = path.join(request.workspace.sessionHome, '.local/share/kilo/auth.json');
+    await fsp.mkdir(path.dirname(authPath), { recursive: true });
+    await fsp.writeFile(authPath, '{}');
+    const gitCalls: string[][] = [];
+
+    const result = await prepareWrapperBootstrapWorkspace(request, undefined, {
+      git: async args => {
+        gitCalls.push(args);
+        if (args.join(' ') === 'rev-parse --is-inside-work-tree') {
+          return { stdout: 'true\n', stderr: '', exitCode: 0 };
+        }
+        throw new Error(`Unexpected git command: ${args.join(' ')}`);
+      },
+      runProcess: async () => {
+        throw new Error('setup commands should not run for a migrated warm workspace');
+      },
+      restoreSession: async () => {
+        throw new Error('restore should not run for a migrated warm workspace');
+      },
+    });
+
+    expect(result.workspaceWasWarm).toBe(true);
+    expect(gitCalls).toEqual([['rev-parse', '--is-inside-work-tree']]);
+    expect(
+      fs.existsSync(path.join(request.workspace.workspacePath, '.git', 'kilo-bootstrap-complete'))
+    ).toBe(true);
+  });
+
+  it('reclones unfinished workspaces that have no bootstrap marker', async () => {
     const request = makeRequest(tmpDir);
     await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
+    await fsp.writeFile(path.join(request.workspace.workspacePath, 'partial-clone.txt'), 'stale');
+    const authPath = path.join(request.workspace.sessionHome, '.local/share/kilo/auth.json');
+    await fsp.mkdir(path.dirname(authPath), { recursive: true });
+    await fsp.writeFile(authPath, '{}');
+    await fsp.writeFile(
+      path.join(request.workspace.sessionHome, '.kilo-bootstrap-pending'),
+      'pending\n'
+    );
 
     const gitCalls: string[][] = [];
     const setupCalls: string[][] = [];
@@ -542,6 +793,9 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     const deps: WrapperBootstrapDeps = {
       git: async args => {
         gitCalls.push(args);
+        if (args[0] === 'clone') {
+          await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
+        }
         if (args[0] === 'rev-parse') {
           return { stdout: '', stderr: '', exitCode: 1 };
         }
@@ -564,9 +818,13 @@ describe('prepareWrapperBootstrapWorkspace', () => {
 
     const result = await prepareWrapperBootstrapWorkspace(request, undefined, deps);
 
-    expect(result.workspaceWasWarm).toBe(true);
-    expect(gitCalls.some(args => args[0] === 'clone')).toBe(false);
-    expect(gitCalls.some(args => args.join(' ') === 'checkout -b main')).toBe(true);
+    expect(result.workspaceWasWarm).toBe(false);
+    expect(gitCalls.some(args => args[0] === 'clone')).toBe(true);
+    expect(gitCalls.some(args => args.join(' ') === 'rev-parse --is-inside-work-tree')).toBe(false);
+    expect(gitCalls.some(args => args.join(' ') === 'checkout --progress -b main')).toBe(true);
+    expect(fs.existsSync(path.join(request.workspace.workspacePath, 'partial-clone.txt'))).toBe(
+      false
+    );
     expect(restoreCalls[0]).toMatchObject({
       kiloSessionId: 'kilo_sess_1',
       workspacePath: request.workspace.workspacePath,
@@ -591,7 +849,7 @@ describe('prepareWrapperBootstrapWorkspace', () => {
         refreshRemote: true,
       },
     });
-    await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
+    await createCompleteGitWorkspace(request.workspace.workspacePath);
     const rulesPath = path.join(request.workspace.sessionHome, '.kilocode/rules/cloud-agent.md');
     await fsp.mkdir(path.dirname(rulesPath), { recursive: true });
     await fsp.writeFile(rulesPath, 'stale rules');
@@ -614,7 +872,7 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     const result = await prepareWrapperBootstrapWorkspace(request, progress, deps);
 
     expect(result.workspaceWasWarm).toBe(true);
-    expect(progress).not.toHaveBeenCalled();
+    expect(progress).toHaveBeenCalledWith('kilo_server', 'Starting Kilo...');
     expect(gitCalls).toEqual([
       ['remote', 'set-url', 'origin', 'https://oauth2:gitlab-token@gitlab.com/acme/repo.git'],
     ]);
@@ -642,7 +900,7 @@ describe('prepareWrapperBootstrapWorkspace', () => {
         env: { GH_TOKEN: 'user-token' },
       },
     });
-    await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
+    await createCompleteGitWorkspace(request.workspace.workspacePath);
     const gitCalls: string[][] = [];
 
     await prepareWrapperBootstrapWorkspace(request, undefined, {

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -396,9 +396,6 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     expect(
       fs.existsSync(path.join(request.workspace.workspacePath, '.git', 'kilo-bootstrap-complete'))
     ).toBe(true);
-    expect(fs.existsSync(path.join(request.workspace.sessionHome, '.kilo-bootstrap-pending'))).toBe(
-      false
-    );
     expect(progress).toHaveBeenCalledWith(
       'setup_commands',
       'Setup command 1 of 1 is still running...'
@@ -806,43 +803,11 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     });
   });
 
-  it('wraps the error and cleans up when warm workspace detection fails', async () => {
+  it('reclones legacy markerless workspaces instead of trusting auth.json', async () => {
     const request = makeRequest(tmpDir);
     request.workspace.preferSnapshot = true;
-    // A `.git` file (not a directory) makes the migration marker write fail.
-    await fsp.mkdir(request.workspace.workspacePath, { recursive: true });
-    await fsp.writeFile(path.join(request.workspace.workspacePath, '.git'), 'gitdir: elsewhere');
-    const authPath = path.join(request.workspace.sessionHome, '.local/share/kilo/auth.json');
-    await fsp.mkdir(path.dirname(authPath), { recursive: true });
-    await fsp.writeFile(authPath, '{}');
-
-    let caughtError: unknown;
-    try {
-      await prepareWrapperBootstrapWorkspace(request, undefined, {
-        git: async args => {
-          if (args.join(' ') === 'rev-parse --is-inside-work-tree') {
-            return { stdout: 'true\n', stderr: '', exitCode: 0 };
-          }
-          throw new Error(`Unexpected git command: ${args.join(' ')}`);
-        },
-      });
-    } catch (error) {
-      caughtError = error;
-    }
-
-    expect(caughtError).toMatchObject({
-      code: 'WORKSPACE_SETUP_FAILED',
-      subtype: 'workspace_setup_unknown',
-      retryable: true,
-      message: 'Workspace setup failed',
-    });
-    expect(fs.existsSync(request.workspace.workspacePath)).toBe(false);
-    expect(fs.existsSync(request.workspace.sessionHome)).toBe(false);
-  });
-
-  it('migrates a valid legacy warm workspace without recloning it', async () => {
-    const request = makeRequest(tmpDir);
-    request.workspace.preferSnapshot = true;
+    // The legacy flow wrote auth.json before restore and setup commands ran,
+    // so its presence does not prove bootstrap completed.
     await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
     const authPath = path.join(request.workspace.sessionHome, '.local/share/kilo/auth.json');
     await fsp.mkdir(path.dirname(authPath), { recursive: true });
@@ -852,21 +817,25 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     const result = await prepareWrapperBootstrapWorkspace(request, undefined, {
       git: async args => {
         gitCalls.push(args);
-        if (args.join(' ') === 'rev-parse --is-inside-work-tree') {
-          return { stdout: 'true\n', stderr: '', exitCode: 0 };
+        if (args[0] === 'clone') {
+          await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
         }
-        throw new Error(`Unexpected git command: ${args.join(' ')}`);
+        if (args[0] === 'rev-parse') {
+          return { stdout: '', stderr: '', exitCode: 1 };
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
       },
-      runProcess: async () => {
-        throw new Error('setup commands should not run for a migrated warm workspace');
-      },
-      restoreSession: async () => {
-        throw new Error('restore should not run for a migrated warm workspace');
-      },
+      runProcess: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+      restoreSession: async () => ({
+        ok: true,
+        downloaded: false,
+        imported: true,
+        diffs: { applied: 0, skipped: 0, total: 0 },
+      }),
     });
 
-    expect(result.workspaceWasWarm).toBe(true);
-    expect(gitCalls).toEqual([['rev-parse', '--is-inside-work-tree']]);
+    expect(result.workspaceWasWarm).toBe(false);
+    expect(gitCalls.some(args => args[0] === 'clone')).toBe(true);
     expect(
       fs.existsSync(path.join(request.workspace.workspacePath, '.git', 'kilo-bootstrap-complete'))
     ).toBe(true);
@@ -879,10 +848,6 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     const authPath = path.join(request.workspace.sessionHome, '.local/share/kilo/auth.json');
     await fsp.mkdir(path.dirname(authPath), { recursive: true });
     await fsp.writeFile(authPath, '{}');
-    await fsp.writeFile(
-      path.join(request.workspace.sessionHome, '.kilo-bootstrap-pending'),
-      'pending\n'
-    );
 
     const gitCalls: string[][] = [];
     const setupCalls: string[][] = [];

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -293,7 +293,71 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     expect(fs.existsSync(request.workspace.sessionHome)).toBe(false);
   });
 
-  it('uses shared command watchdogs and generic progress for setup commands', async () => {
+  it('aborts active work and cleans up when the wrapper shuts down', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.setupCommands = [];
+    const shutdownController = new AbortController();
+    let commandSignal: AbortSignal | undefined;
+    let notifyCloneStarted: (() => void) | undefined;
+    const cloneStarted = new Promise<void>(resolve => {
+      notifyCloneStarted = resolve;
+    });
+
+    const bootstrap = prepareWrapperBootstrapWorkspace(
+      request,
+      undefined,
+      {
+        workspacePreparationTimeoutMs: 100,
+        git: async (args, opts) => {
+          if (args[0] !== 'clone') {
+            return { stdout: '', stderr: '', exitCode: 0 };
+          }
+
+          await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
+          commandSignal = opts?.signal;
+          notifyCloneStarted?.();
+          if (!commandSignal) {
+            return { stdout: '', stderr: 'missing workspace signal', exitCode: 1 };
+          }
+          if (!commandSignal.aborted) {
+            await new Promise<void>(resolve =>
+              commandSignal?.addEventListener('abort', () => resolve(), { once: true })
+            );
+          }
+          await Bun.sleep(120);
+          return {
+            stdout: '',
+            stderr: 'exec aborted',
+            exitCode: 124,
+            terminationReason: 'abort',
+          };
+        },
+      },
+      shutdownController.signal
+    );
+
+    await cloneStarted;
+    shutdownController.abort();
+
+    let caughtError: unknown;
+    try {
+      await bootstrap;
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toMatchObject({
+      code: 'WORKSPACE_SETUP_FAILED',
+      subtype: 'workspace_setup_unknown',
+      retryable: true,
+      message: 'Repository clone failed',
+    });
+    expect(commandSignal?.aborted).toBe(true);
+    expect(fs.existsSync(request.workspace.workspacePath)).toBe(false);
+    expect(fs.existsSync(request.workspace.sessionHome)).toBe(false);
+  });
+
+  it('uses a lenient inactivity watchdog and generic progress for setup commands', async () => {
     const request = makeRequest(tmpDir);
     const progress = mock(() => {});
     let setupOptions: Parameters<NonNullable<WrapperBootstrapDeps['runProcess']>>[2];
@@ -326,7 +390,7 @@ describe('prepareWrapperBootstrapWorkspace', () => {
       }),
     });
 
-    expect(setupOptions?.inactivityTimeoutMs).toBe(120_000);
+    expect(setupOptions?.inactivityTimeoutMs).toBe(240_000);
     expect(setupOptions?.hardTimeoutMs).toBe(300_000);
     expect(markerExistedDuringSetup).toBe(false);
     expect(
@@ -740,6 +804,40 @@ describe('prepareWrapperBootstrapWorkspace', () => {
       code: 'WORKSPACE_SETUP_FAILED',
       subtype: 'workspace_setup_unknown',
     });
+  });
+
+  it('wraps the error and cleans up when warm workspace detection fails', async () => {
+    const request = makeRequest(tmpDir);
+    request.workspace.preferSnapshot = true;
+    // A `.git` file (not a directory) makes the migration marker write fail.
+    await fsp.mkdir(request.workspace.workspacePath, { recursive: true });
+    await fsp.writeFile(path.join(request.workspace.workspacePath, '.git'), 'gitdir: elsewhere');
+    const authPath = path.join(request.workspace.sessionHome, '.local/share/kilo/auth.json');
+    await fsp.mkdir(path.dirname(authPath), { recursive: true });
+    await fsp.writeFile(authPath, '{}');
+
+    let caughtError: unknown;
+    try {
+      await prepareWrapperBootstrapWorkspace(request, undefined, {
+        git: async args => {
+          if (args.join(' ') === 'rev-parse --is-inside-work-tree') {
+            return { stdout: 'true\n', stderr: '', exitCode: 0 };
+          }
+          throw new Error(`Unexpected git command: ${args.join(' ')}`);
+        },
+      });
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toMatchObject({
+      code: 'WORKSPACE_SETUP_FAILED',
+      subtype: 'workspace_setup_unknown',
+      retryable: true,
+      message: 'Workspace setup failed',
+    });
+    expect(fs.existsSync(request.workspace.workspacePath)).toBe(false);
+    expect(fs.existsSync(request.workspace.sessionHome)).toBe(false);
   });
 
   it('migrates a valid legacy warm workspace without recloning it', async () => {

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -10,6 +10,7 @@ import { buildCloudAgentRules } from '../../src/shared/cloud-agent-rules.js';
 import {
   createSafeProcessDiagnostic,
   git,
+  isTimeoutTermination,
   logToFile,
   runProcess,
   type ExecResult,
@@ -21,6 +22,10 @@ import { WrapperBootstrapError, workspaceBootstrapError } from './bootstrap-erro
 
 const LONG_COMMAND_INACTIVITY_TIMEOUT_MS = 120_000;
 const LONG_COMMAND_HARD_TIMEOUT_MS = 300_000;
+// Setup commands may legitimately stay silent for minutes (piped tools often
+// buffer), unlike git commands which run with --progress, so they get a more
+// lenient silence watchdog.
+const SETUP_COMMAND_INACTIVITY_TIMEOUT_MS = 4 * 60_000;
 const WORKSPACE_PREPARATION_TIMEOUT_MS = 8 * 60_000;
 const WORKSPACE_CLEANUP_TIMEOUT_MS = 60_000;
 const SHORT_GIT_COMMAND_TIMEOUT_MS = 120_000;
@@ -77,11 +82,7 @@ const GIT_FAILURE_PATTERNS = [
 ] as const;
 
 function classifyGitFailure(result: ExecResult, operation: 'clone' | 'checkout') {
-  if (
-    result.terminationReason === 'timeout' ||
-    result.terminationReason === 'inactivity_timeout' ||
-    result.terminationReason === 'hard_timeout'
-  ) {
+  if (isTimeoutTermination(result)) {
     return operation === 'clone' ? 'git_clone_timeout' : 'git_checkout_timeout';
   }
   const output = `${result.stderr}\n${result.stdout}`;
@@ -103,11 +104,7 @@ function gitOperationError(
 ): WrapperBootstrapError {
   const label = operation === 'clone' ? 'Repository clone' : 'Repository checkout';
   const subtype = classifyGitFailure(result, operation);
-  const timedOut =
-    result.terminationReason === 'timeout' ||
-    result.terminationReason === 'inactivity_timeout' ||
-    result.terminationReason === 'hard_timeout';
-  const message = timedOut ? `${label} timed out` : `${label} failed`;
+  const message = isTimeoutTermination(result) ? `${label} timed out` : `${label} failed`;
   return workspaceBootstrapError(subtype, message, createSafeProcessDiagnostic(result));
 }
 
@@ -222,7 +219,9 @@ async function removePath(filePath: string, signal?: AbortSignal): Promise<void>
     signal,
   });
   if (result.exitCode !== 0) {
-    throw new Error(`Failed to remove workspace path: ${filePath}`);
+    throw new Error(
+      `Failed to remove workspace path: ${filePath} (${createSafeProcessDiagnostic(result)})`
+    );
   }
 }
 
@@ -559,7 +558,7 @@ async function runSetupCommands(
     const startedAt = Date.now();
     const result = await run('sh', ['-lc', command], {
       cwd: request.workspace.workspacePath,
-      inactivityTimeoutMs: LONG_COMMAND_INACTIVITY_TIMEOUT_MS,
+      inactivityTimeoutMs: SETUP_COMMAND_INACTIVITY_TIMEOUT_MS,
       hardTimeoutMs: LONG_COMMAND_HARD_TIMEOUT_MS,
       onOutput: () => {
         const now = Date.now();
@@ -575,10 +574,7 @@ async function runSetupCommands(
       `bootstrap setup command finished kiloSessionId=${request.kiloSessionId} index=${index + 1} count=${setupCommands.length} elapsedMs=${Date.now() - startedAt} exitCode=${result.exitCode} terminationReason=${result.terminationReason ?? '(none)'}`
     );
     if (result.exitCode !== 0 && failFast) {
-      const timedOut =
-        result.terminationReason === 'timeout' ||
-        result.terminationReason === 'inactivity_timeout' ||
-        result.terminationReason === 'hard_timeout';
+      const timedOut = isTimeoutTermination(result);
       throw workspaceBootstrapError(
         timedOut ? 'setup_command_timeout' : 'setup_command_failed',
         `Setup command ${index + 1} ${timedOut ? 'timed out' : 'failed'}`,
@@ -657,18 +653,22 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
 
   Object.assign(process.env, request.materialized.env);
 
-  const workspaceWasWarm = await isCompleteGitWorkspace(request, runGit);
-  const workspaceNeedsBootstrap = !workspaceWasWarm || !request.workspace.preferSnapshot;
-  logToFile(
-    `bootstrap workspace plan kiloSessionId=${request.kiloSessionId} preferSnapshot=${request.workspace.preferSnapshot} workspaceWasWarm=${workspaceWasWarm} workspaceNeedsBootstrap=${workspaceNeedsBootstrap} workspacePath=${request.workspace.workspacePath} sessionHome=${request.workspace.sessionHome} home=${process.env.HOME ?? '(unset)'} homeMatchesSessionHome=${process.env.HOME === request.workspace.sessionHome} repoKind=${request.repo?.kind ?? '(none)'} setupCommandCount=${request.materialized.setupCommands?.length ?? 0} runtimeSkillCount=${request.materialized.runtimeSkills?.length ?? 0}`
-  );
-  if (!workspaceWasWarm) {
-    progress?.('workspace_setup', 'Setting up workspace...');
-  }
-  await ensureWorkspaceDirectories(request);
-  signal.throwIfAborted();
+  let workspaceWasWarm = false;
+  let workspaceNeedsBootstrap = true;
 
   try {
+    workspaceWasWarm = await isCompleteGitWorkspace(request, runGit);
+    workspaceNeedsBootstrap = !workspaceWasWarm || !request.workspace.preferSnapshot;
+    logToFile(
+      `bootstrap workspace plan kiloSessionId=${request.kiloSessionId} preferSnapshot=${request.workspace.preferSnapshot} workspaceWasWarm=${workspaceWasWarm} workspaceNeedsBootstrap=${workspaceNeedsBootstrap} workspacePath=${request.workspace.workspacePath} sessionHome=${request.workspace.sessionHome} home=${process.env.HOME ?? '(unset)'} homeMatchesSessionHome=${process.env.HOME === request.workspace.sessionHome} repoKind=${request.repo?.kind ?? '(none)'} setupCommandCount=${request.materialized.setupCommands?.length ?? 0} runtimeSkillCount=${request.materialized.runtimeSkills?.length ?? 0}`
+    );
+    if (!workspaceWasWarm) {
+      progress?.('workspace_setup', 'Setting up workspace...');
+    }
+
+    await ensureWorkspaceDirectories(request);
+    signal.throwIfAborted();
+
     if (workspaceNeedsBootstrap) {
       await fs.rm(gitBootstrapMarkerPath(request.workspace.workspacePath), { force: true });
       await fs.writeFile(bootstrapPendingMarkerPath(request.workspace.sessionHome), 'pending\n');
@@ -755,7 +755,8 @@ function withWorkspaceSignal(
 export async function prepareWrapperBootstrapWorkspace(
   request: WrapperSessionReadyRequest,
   progress?: BootstrapProgress,
-  deps: WrapperBootstrapDeps = {}
+  deps: WrapperBootstrapDeps = {},
+  externalSignal?: AbortSignal
 ): Promise<WrapperBootstrapResult> {
   const workspacePreparationTimeoutMs =
     deps.workspacePreparationTimeoutMs ?? WORKSPACE_PREPARATION_TIMEOUT_MS;
@@ -765,6 +766,9 @@ export async function prepareWrapperBootstrapWorkspace(
   );
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(timeoutError), workspacePreparationTimeoutMs);
+  const workspaceSignal = externalSignal
+    ? AbortSignal.any([controller.signal, externalSignal])
+    : controller.signal;
   const runGit = deps.git ?? git;
   const run = deps.runProcess ?? runProcess;
   const restore = deps.restoreSession ?? restoreSession;
@@ -775,21 +779,21 @@ export async function prepareWrapperBootstrapWorkspace(
       progress,
       {
         ...deps,
-        git: (args, options) => runGit(args, withWorkspaceSignal(options, controller.signal)),
+        git: (args, options) => runGit(args, withWorkspaceSignal(options, workspaceSignal)),
         runProcess: (command, args, options) =>
-          run(command, args, withWorkspaceSignal(options, controller.signal)),
+          run(command, args, withWorkspaceSignal(options, workspaceSignal)),
         restoreSession: (kiloSessionId, workspacePath, filePath, options) =>
           restore(kiloSessionId, workspacePath, filePath, {
             ...options,
             signal: options?.signal
-              ? AbortSignal.any([options.signal, controller.signal])
-              : controller.signal,
+              ? AbortSignal.any([options.signal, workspaceSignal])
+              : workspaceSignal,
           }),
       },
-      controller.signal
+      workspaceSignal
     );
   } catch (error) {
-    if (controller.signal.aborted) throw timeoutError;
+    if (workspaceSignal.reason === timeoutError) throw timeoutError;
     throw error;
   } finally {
     clearTimeout(timeout);

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -13,12 +13,20 @@ import {
   logToFile,
   runProcess,
   type ExecResult,
+  type ProcessOptions,
+  type ProcessOutputStream,
 } from './utils.js';
 import { restoreSession } from './restore-session.js';
 import { WrapperBootstrapError, workspaceBootstrapError } from './bootstrap-error.js';
 
-const SETUP_COMMAND_TIMEOUT_MS = 300_000;
-const GIT_COMMAND_TIMEOUT_MS = 120_000;
+const LONG_COMMAND_INACTIVITY_TIMEOUT_MS = 120_000;
+const LONG_COMMAND_HARD_TIMEOUT_MS = 300_000;
+const WORKSPACE_PREPARATION_TIMEOUT_MS = 8 * 60_000;
+const WORKSPACE_CLEANUP_TIMEOUT_MS = 60_000;
+const SHORT_GIT_COMMAND_TIMEOUT_MS = 120_000;
+const PROGRESS_UPDATE_INTERVAL_MS = 5_000;
+const GIT_BOOTSTRAP_MARKER = 'kilo-bootstrap-complete';
+const BOOTSTRAP_PENDING_MARKER = '.kilo-bootstrap-pending';
 const MAX_ATTACHMENT_BYTES = 5_242_880;
 
 export type BootstrapProgressStep =
@@ -37,20 +45,18 @@ export type WrapperBootstrapResult = {
   workspaceWasWarm: boolean;
 };
 
-type GitRunner = (
-  args: string[],
-  opts?: { cwd?: string; timeoutMs?: number }
-) => Promise<ExecResult>;
+type GitRunner = (args: string[], opts?: ProcessOptions) => Promise<ExecResult>;
 type ProcessRunner = (
   command: string,
   args: string[],
-  opts?: { cwd?: string; timeoutMs?: number }
+  opts?: ProcessOptions
 ) => Promise<ExecResult>;
 
 export type WrapperBootstrapDeps = {
   git?: GitRunner;
   runProcess?: ProcessRunner;
   restoreSession?: typeof restoreSession;
+  workspacePreparationTimeoutMs?: number;
 };
 
 const GIT_FAILURE_PATTERNS = [
@@ -71,7 +77,11 @@ const GIT_FAILURE_PATTERNS = [
 ] as const;
 
 function classifyGitFailure(result: ExecResult, operation: 'clone' | 'checkout') {
-  if (result.terminationReason === 'timeout') {
+  if (
+    result.terminationReason === 'timeout' ||
+    result.terminationReason === 'inactivity_timeout' ||
+    result.terminationReason === 'hard_timeout'
+  ) {
     return operation === 'clone' ? 'git_clone_timeout' : 'git_checkout_timeout';
   }
   const output = `${result.stderr}\n${result.stdout}`;
@@ -93,8 +103,56 @@ function gitOperationError(
 ): WrapperBootstrapError {
   const label = operation === 'clone' ? 'Repository clone' : 'Repository checkout';
   const subtype = classifyGitFailure(result, operation);
-  const message = result.terminationReason === 'timeout' ? `${label} timed out` : `${label} failed`;
+  const timedOut =
+    result.terminationReason === 'timeout' ||
+    result.terminationReason === 'inactivity_timeout' ||
+    result.terminationReason === 'hard_timeout';
+  const message = timedOut ? `${label} timed out` : `${label} failed`;
   return workspaceBootstrapError(subtype, message, createSafeProcessDiagnostic(result));
+}
+
+const GIT_PROGRESS_PATTERN =
+  /\b(Receiving objects|Resolving deltas|Updating files|Checking out files|Compressing objects):\s+(\d+)%/g;
+
+function gitProgressReporter(
+  progress: BootstrapProgress | undefined,
+  step: 'cloning' | 'branch',
+  prefix: string
+): (stream: ProcessOutputStream, output: string) => void {
+  let bufferedOutput = '';
+  let lastReportedProgress = '';
+  let lastReportedAt = 0;
+
+  return (_stream, output) => {
+    bufferedOutput = (bufferedOutput + output).slice(-1_024);
+    const matches = [...bufferedOutput.matchAll(GIT_PROGRESS_PATTERN)];
+    const latest = matches.at(-1);
+    if (!latest) return;
+
+    const progressText = `${latest[1]}: ${latest[2]}%`;
+    if (progressText === lastReportedProgress) return;
+
+    const now = Date.now();
+    if (lastReportedAt !== 0 && now - lastReportedAt < PROGRESS_UPDATE_INTERVAL_MS) return;
+
+    lastReportedProgress = progressText;
+    lastReportedAt = now;
+    progress?.(step, `${prefix} ${progressText}`);
+  };
+}
+
+function longGitOptions(
+  progress: BootstrapProgress | undefined,
+  step: 'cloning' | 'branch',
+  progressPrefix: string,
+  cwd?: string
+): ProcessOptions {
+  return {
+    cwd,
+    inactivityTimeoutMs: LONG_COMMAND_INACTIVITY_TIMEOUT_MS,
+    hardTimeoutMs: LONG_COMMAND_HARD_TIMEOUT_MS,
+    onOutput: gitProgressReporter(progress, step, progressPrefix),
+  };
 }
 
 function authenticatedUrl(
@@ -118,21 +176,68 @@ async function exists(filePath: string): Promise<boolean> {
   }
 }
 
+function gitBootstrapMarkerPath(workspacePath: string): string {
+  return path.join(workspacePath, '.git', GIT_BOOTSTRAP_MARKER);
+}
+
+function bootstrapPendingMarkerPath(sessionHome: string): string {
+  return path.join(sessionHome, BOOTSTRAP_PENDING_MARKER);
+}
+
+function sessionAuthFilePath(sessionHome: string): string {
+  return path.join(sessionHome, '.local/share/kilo/auth.json');
+}
+
+async function isCompleteGitWorkspace(
+  request: WrapperSessionReadyRequest,
+  runGit: GitRunner
+): Promise<boolean> {
+  const { workspacePath, sessionHome } = request.workspace;
+  if (!(await exists(path.join(workspacePath, '.git')))) return false;
+  if (await exists(gitBootstrapMarkerPath(workspacePath))) return true;
+  if (await exists(bootstrapPendingMarkerPath(sessionHome))) return false;
+  if (!(await exists(sessionAuthFilePath(sessionHome)))) return false;
+
+  const result = await runGit(['rev-parse', '--is-inside-work-tree'], {
+    cwd: workspacePath,
+    timeoutMs: SHORT_GIT_COMMAND_TIMEOUT_MS,
+  });
+  if (result.exitCode !== 0 || result.stdout.trim() !== 'true') return false;
+
+  await fs.writeFile(gitBootstrapMarkerPath(workspacePath), 'ready\n');
+  logToFile(
+    `bootstrap migrated legacy workspace kiloSessionId=${request.kiloSessionId} workspacePath=${workspacePath}`
+  );
+  return true;
+}
+
 async function ensureWorkspaceDirectories(request: WrapperSessionReadyRequest): Promise<void> {
   await fs.mkdir(request.workspace.workspacePath, { recursive: true });
   await fs.mkdir(request.workspace.sessionHome, { recursive: true });
 }
 
+async function removePath(filePath: string, signal?: AbortSignal): Promise<void> {
+  const result = await runProcess('rm', ['-rf', '--', filePath], {
+    hardTimeoutMs: WORKSPACE_CLEANUP_TIMEOUT_MS,
+    signal,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to remove workspace path: ${filePath}`);
+  }
+}
+
 async function cleanupWorkspace(request: WrapperSessionReadyRequest): Promise<void> {
   await Promise.allSettled([
-    fs.rm(request.workspace.workspacePath, { recursive: true, force: true }),
-    fs.rm(request.workspace.sessionHome, { recursive: true, force: true }),
+    removePath(request.workspace.workspacePath),
+    removePath(request.workspace.sessionHome),
   ]);
 }
 
 async function cloneRepository(
   request: WrapperSessionReadyRequest,
-  runGit: GitRunner
+  runGit: GitRunner,
+  progress: BootstrapProgress | undefined,
+  signal: AbortSignal
 ): Promise<void> {
   const repo = request.repo;
   if (!repo) {
@@ -142,16 +247,16 @@ async function cloneRepository(
   const gitUrl = repo.kind === 'github' ? `https://github.com/${repo.repo}.git` : repo.url;
   const platform = repo.kind === 'git' ? repo.platform : 'github';
   const repoUrl = authenticatedUrl(gitUrl, repo.token, platform);
-  const args = ['clone'];
+  const args = ['clone', '--progress'];
   if (repo.shallow) {
     args.push('--depth', '1');
   }
   args.push(repoUrl, request.workspace.workspacePath);
 
-  await fs.rm(request.workspace.workspacePath, { recursive: true, force: true });
+  await removePath(request.workspace.workspacePath, signal);
   await fs.mkdir(path.dirname(request.workspace.workspacePath), { recursive: true });
 
-  const result = await runGit(args, { timeoutMs: GIT_COMMAND_TIMEOUT_MS });
+  const result = await runGit(args, longGitOptions(progress, 'cloning', 'Cloning repository...'));
   if (result.exitCode !== 0) {
     throw gitOperationError(result, 'clone');
   }
@@ -162,11 +267,11 @@ async function cloneRepository(
     repo.kind === 'github' ? (repo.gitAuthor?.email ?? 'agent@kilocode.ai') : 'agent@kilocode.ai';
   const authorNameResult = await runGit(['config', 'user.name', authorName], {
     cwd: request.workspace.workspacePath,
-    timeoutMs: GIT_COMMAND_TIMEOUT_MS,
+    timeoutMs: SHORT_GIT_COMMAND_TIMEOUT_MS,
   });
   const authorEmailResult = await runGit(['config', 'user.email', authorEmail], {
     cwd: request.workspace.workspacePath,
-    timeoutMs: GIT_COMMAND_TIMEOUT_MS,
+    timeoutMs: SHORT_GIT_COMMAND_TIMEOUT_MS,
   });
   if (authorNameResult.exitCode !== 0 || authorEmailResult.exitCode !== 0) {
     throw new Error('Failed to configure git author identity');
@@ -182,7 +287,7 @@ async function branchExists(
   const ref = remote ? `origin/${branch}` : branch;
   const result = await runGit(['rev-parse', '--verify', '--quiet', ref], {
     cwd: workspacePath,
-    timeoutMs: GIT_COMMAND_TIMEOUT_MS,
+    timeoutMs: SHORT_GIT_COMMAND_TIMEOUT_MS,
   });
   if (result.exitCode === 0) return true;
   if (result.exitCode !== 1 || result.terminationReason !== undefined) {
@@ -201,20 +306,21 @@ function isSyntheticReviewRef(branchName: string): boolean {
 async function fetchSyntheticReviewRef(
   runGit: GitRunner,
   workspacePath: string,
-  branchName: string
+  branchName: string,
+  progress: BootstrapProgress | undefined
 ): Promise<void> {
-  const fetchResult = await runGit(['fetch', 'origin', branchName], {
-    cwd: workspacePath,
-    timeoutMs: GIT_COMMAND_TIMEOUT_MS,
-  });
+  const fetchResult = await runGit(
+    ['fetch', '--progress', 'origin', branchName],
+    longGitOptions(progress, 'branch', 'Fetching review branch...', workspacePath)
+  );
   if (fetchResult.exitCode !== 0) {
     throw gitOperationError(fetchResult, 'checkout');
   }
 
-  const checkoutResult = await runGit(['checkout', '-B', branchName, 'FETCH_HEAD'], {
-    cwd: workspacePath,
-    timeoutMs: GIT_COMMAND_TIMEOUT_MS,
-  });
+  const checkoutResult = await runGit(
+    ['checkout', '--progress', '-B', branchName, 'FETCH_HEAD'],
+    longGitOptions(progress, 'branch', 'Checking out review branch...', workspacePath)
+  );
   if (checkoutResult.exitCode !== 0) {
     throw gitOperationError(checkoutResult, 'checkout');
   }
@@ -222,27 +328,28 @@ async function fetchSyntheticReviewRef(
 
 async function prepareBranch(
   request: WrapperSessionReadyRequest,
-  runGit: GitRunner
+  runGit: GitRunner,
+  progress: BootstrapProgress | undefined
 ): Promise<void> {
   const { workspacePath, branchName, strictBranch } = request.workspace;
   if (strictBranch && isSyntheticReviewRef(branchName)) {
-    await fetchSyntheticReviewRef(runGit, workspacePath, branchName);
+    await fetchSyntheticReviewRef(runGit, workspacePath, branchName, progress);
     return;
   }
 
-  const fetchResult = await runGit(['fetch', 'origin'], {
-    cwd: workspacePath,
-    timeoutMs: GIT_COMMAND_TIMEOUT_MS,
-  });
+  const fetchResult = await runGit(
+    ['fetch', '--progress', 'origin'],
+    longGitOptions(progress, 'branch', 'Fetching repository...', workspacePath)
+  );
   if (fetchResult.exitCode !== 0) {
     throw gitOperationError(fetchResult, 'checkout');
   }
 
   if (await branchExists(runGit, workspacePath, branchName, false)) {
-    const result = await runGit(['checkout', branchName], {
-      cwd: workspacePath,
-      timeoutMs: GIT_COMMAND_TIMEOUT_MS,
-    });
+    const result = await runGit(
+      ['checkout', '--progress', branchName],
+      longGitOptions(progress, 'branch', 'Checking out branch...', workspacePath)
+    );
     if (result.exitCode !== 0) {
       throw gitOperationError(result, 'checkout');
     }
@@ -250,10 +357,10 @@ async function prepareBranch(
   }
 
   if (await branchExists(runGit, workspacePath, branchName, true)) {
-    const result = await runGit(['checkout', '-B', branchName, `origin/${branchName}`], {
-      cwd: workspacePath,
-      timeoutMs: GIT_COMMAND_TIMEOUT_MS,
-    });
+    const result = await runGit(
+      ['checkout', '--progress', '-B', branchName, `origin/${branchName}`],
+      longGitOptions(progress, 'branch', 'Checking out branch...', workspacePath)
+    );
     if (result.exitCode !== 0) {
       throw gitOperationError(result, 'checkout');
     }
@@ -269,12 +376,12 @@ async function prepareBranch(
     );
   }
 
-  const result = await runGit(['checkout', '-b', branchName], {
-    cwd: workspacePath,
-    timeoutMs: GIT_COMMAND_TIMEOUT_MS,
-  });
+  const result = await runGit(
+    ['checkout', '--progress', '-b', branchName],
+    longGitOptions(progress, 'branch', 'Creating branch...', workspacePath)
+  );
   if (result.exitCode !== 0) {
-    throw new Error(`Failed to create session branch ${branchName}`);
+    throw gitOperationError(result, 'checkout');
   }
 }
 
@@ -290,7 +397,7 @@ async function refreshGitRemoteToken(
   const nextUrl = authenticatedUrl(gitUrl, repo.token, platform);
   const result = await runGit(['remote', 'set-url', 'origin', nextUrl], {
     cwd: request.workspace.workspacePath,
-    timeoutMs: GIT_COMMAND_TIMEOUT_MS,
+    timeoutMs: SHORT_GIT_COMMAND_TIMEOUT_MS,
   });
   if (result.exitCode !== 0) {
     throw new Error('Failed to update git remote URL');
@@ -298,11 +405,11 @@ async function refreshGitRemoteToken(
   if (repo.kind === 'github' && repo.gitAuthor) {
     const nameResult = await runGit(['config', 'user.name', repo.gitAuthor.name], {
       cwd: request.workspace.workspacePath,
-      timeoutMs: GIT_COMMAND_TIMEOUT_MS,
+      timeoutMs: SHORT_GIT_COMMAND_TIMEOUT_MS,
     });
     const emailResult = await runGit(['config', 'user.email', repo.gitAuthor.email], {
       cwd: request.workspace.workspacePath,
-      timeoutMs: GIT_COMMAND_TIMEOUT_MS,
+      timeoutMs: SHORT_GIT_COMMAND_TIMEOUT_MS,
     });
     if (nameResult.exitCode !== 0 || emailResult.exitCode !== 0) {
       throw new Error('Failed to configure git author identity');
@@ -311,10 +418,10 @@ async function refreshGitRemoteToken(
 }
 
 async function writeSessionAuthFile(request: WrapperSessionReadyRequest): Promise<void> {
-  const kiloAuthDir = path.join(request.workspace.sessionHome, '.local/share/kilo');
-  await fs.mkdir(kiloAuthDir, { recursive: true });
+  const authFilePath = sessionAuthFilePath(request.workspace.sessionHome);
+  await fs.mkdir(path.dirname(authFilePath), { recursive: true });
   await fs.writeFile(
-    path.join(kiloAuthDir, 'auth.json'),
+    authFilePath,
     JSON.stringify({ kilo: { type: 'api', key: request.session.workerAuthToken } }, null, 2)
   );
 }
@@ -440,22 +547,41 @@ async function restoreOrBootstrapKiloSession(
 async function runSetupCommands(
   request: WrapperSessionReadyRequest,
   run: ProcessRunner,
-  failFast: boolean
+  failFast: boolean,
+  progress: BootstrapProgress | undefined
 ): Promise<void> {
   const setupCommands = request.materialized.setupCommands ?? [];
   logToFile(
     `bootstrap setup commands starting kiloSessionId=${request.kiloSessionId} count=${setupCommands.length} failFast=${failFast} workspacePath=${request.workspace.workspacePath}`
   );
-  for (const [commandIndex, command] of setupCommands.entries()) {
+  for (const [index, command] of setupCommands.entries()) {
+    let lastProgressAt = 0;
+    const startedAt = Date.now();
     const result = await run('sh', ['-lc', command], {
       cwd: request.workspace.workspacePath,
-      timeoutMs: SETUP_COMMAND_TIMEOUT_MS,
+      inactivityTimeoutMs: LONG_COMMAND_INACTIVITY_TIMEOUT_MS,
+      hardTimeoutMs: LONG_COMMAND_HARD_TIMEOUT_MS,
+      onOutput: () => {
+        const now = Date.now();
+        if (lastProgressAt !== 0 && now - lastProgressAt < PROGRESS_UPDATE_INTERVAL_MS) return;
+        lastProgressAt = now;
+        progress?.(
+          'setup_commands',
+          `Setup command ${index + 1} of ${setupCommands.length} is still running...`
+        );
+      },
     });
+    logToFile(
+      `bootstrap setup command finished kiloSessionId=${request.kiloSessionId} index=${index + 1} count=${setupCommands.length} elapsedMs=${Date.now() - startedAt} exitCode=${result.exitCode} terminationReason=${result.terminationReason ?? '(none)'}`
+    );
     if (result.exitCode !== 0 && failFast) {
-      const timedOut = result.terminationReason === 'timeout';
+      const timedOut =
+        result.terminationReason === 'timeout' ||
+        result.terminationReason === 'inactivity_timeout' ||
+        result.terminationReason === 'hard_timeout';
       throw workspaceBootstrapError(
         timedOut ? 'setup_command_timeout' : 'setup_command_failed',
-        `Setup command ${commandIndex + 1} ${timedOut ? 'timed out' : 'failed'}`,
+        `Setup command ${index + 1} ${timedOut ? 'timed out' : 'failed'}`,
         createSafeProcessDiagnostic(result)
       );
     }
@@ -519,10 +645,11 @@ export async function materializePromptAttachments(
   };
 }
 
-export async function prepareWrapperBootstrapWorkspace(
+async function prepareWrapperBootstrapWorkspaceWithinDeadline(
   request: WrapperSessionReadyRequest,
-  progress?: BootstrapProgress,
-  deps: WrapperBootstrapDeps = {}
+  progress: BootstrapProgress | undefined,
+  deps: WrapperBootstrapDeps,
+  signal: AbortSignal
 ): Promise<WrapperBootstrapResult> {
   const runGit = deps.git ?? git;
   const run = deps.runProcess ?? runProcess;
@@ -530,7 +657,7 @@ export async function prepareWrapperBootstrapWorkspace(
 
   Object.assign(process.env, request.materialized.env);
 
-  const workspaceWasWarm = await exists(path.join(request.workspace.workspacePath, '.git'));
+  const workspaceWasWarm = await isCompleteGitWorkspace(request, runGit);
   const workspaceNeedsBootstrap = !workspaceWasWarm || !request.workspace.preferSnapshot;
   logToFile(
     `bootstrap workspace plan kiloSessionId=${request.kiloSessionId} preferSnapshot=${request.workspace.preferSnapshot} workspaceWasWarm=${workspaceWasWarm} workspaceNeedsBootstrap=${workspaceNeedsBootstrap} workspacePath=${request.workspace.workspacePath} sessionHome=${request.workspace.sessionHome} home=${process.env.HOME ?? '(unset)'} homeMatchesSessionHome=${process.env.HOME === request.workspace.sessionHome} repoKind=${request.repo?.kind ?? '(none)'} setupCommandCount=${request.materialized.setupCommands?.length ?? 0} runtimeSkillCount=${request.materialized.runtimeSkills?.length ?? 0}`
@@ -539,8 +666,14 @@ export async function prepareWrapperBootstrapWorkspace(
     progress?.('workspace_setup', 'Setting up workspace...');
   }
   await ensureWorkspaceDirectories(request);
+  signal.throwIfAborted();
 
   try {
+    if (workspaceNeedsBootstrap) {
+      await fs.rm(gitBootstrapMarkerPath(request.workspace.workspacePath), { force: true });
+      await fs.writeFile(bootstrapPendingMarkerPath(request.workspace.sessionHome), 'pending\n');
+    }
+
     await writeCloudAgentRules(request);
 
     if (workspaceWasWarm) {
@@ -554,7 +687,7 @@ export async function prepareWrapperBootstrapWorkspace(
       logToFile(
         `bootstrap cold workspace cloning repository kiloSessionId=${request.kiloSessionId}`
       );
-      await cloneRepository(request, runGit);
+      await cloneRepository(request, runGit, progress, signal);
       logToFile(`bootstrap cold workspace clone ready kiloSessionId=${request.kiloSessionId}`);
     }
 
@@ -563,7 +696,7 @@ export async function prepareWrapperBootstrapWorkspace(
       logToFile(
         `bootstrap branch preparation starting kiloSessionId=${request.kiloSessionId} branchName=${request.workspace.branchName} strictBranch=${request.workspace.strictBranch ?? false}`
       );
-      await prepareBranch(request, runGit);
+      await prepareBranch(request, runGit, progress);
       logToFile(
         `bootstrap branch preparation ready kiloSessionId=${request.kiloSessionId} branchName=${request.workspace.branchName}`
       );
@@ -579,13 +712,19 @@ export async function prepareWrapperBootstrapWorkspace(
 
       if (request.materialized.setupCommands?.length) {
         progress?.('setup_commands', 'Running setup commands...');
-        await runSetupCommands(request, run, !request.workspace.preferSnapshot);
+        await runSetupCommands(request, run, !request.workspace.preferSnapshot, progress);
       }
+
+      signal.throwIfAborted();
+      await fs.writeFile(gitBootstrapMarkerPath(request.workspace.workspacePath), 'ready\n');
+      await fs.rm(bootstrapPendingMarkerPath(request.workspace.sessionHome), { force: true });
     }
 
+    signal.throwIfAborted();
     logToFile(
       `bootstrap workspace ready kiloSessionId=${request.kiloSessionId} workspaceWasWarm=${workspaceWasWarm} workspaceNeedsBootstrap=${workspaceNeedsBootstrap}`
     );
+    progress?.('kilo_server', 'Starting Kilo...');
     return { workspaceWasWarm };
   } catch (error) {
     const bootstrapError =
@@ -600,5 +739,59 @@ export async function prepareWrapperBootstrapWorkspace(
       logToFile(`bootstrap workspace cleanup finished kiloSessionId=${request.kiloSessionId}`);
     }
     throw bootstrapError;
+  }
+}
+
+function withWorkspaceSignal(
+  options: ProcessOptions | undefined,
+  workspaceSignal: AbortSignal
+): ProcessOptions {
+  const signal = options?.signal
+    ? AbortSignal.any([options.signal, workspaceSignal])
+    : workspaceSignal;
+  return { ...options, signal };
+}
+
+export async function prepareWrapperBootstrapWorkspace(
+  request: WrapperSessionReadyRequest,
+  progress?: BootstrapProgress,
+  deps: WrapperBootstrapDeps = {}
+): Promise<WrapperBootstrapResult> {
+  const workspacePreparationTimeoutMs =
+    deps.workspacePreparationTimeoutMs ?? WORKSPACE_PREPARATION_TIMEOUT_MS;
+  const timeoutError = workspaceBootstrapError(
+    'workspace_setup_unknown',
+    `Workspace preparation timed out after ${workspacePreparationTimeoutMs / 1000}s`
+  );
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(timeoutError), workspacePreparationTimeoutMs);
+  const runGit = deps.git ?? git;
+  const run = deps.runProcess ?? runProcess;
+  const restore = deps.restoreSession ?? restoreSession;
+
+  try {
+    return await prepareWrapperBootstrapWorkspaceWithinDeadline(
+      request,
+      progress,
+      {
+        ...deps,
+        git: (args, options) => runGit(args, withWorkspaceSignal(options, controller.signal)),
+        runProcess: (command, args, options) =>
+          run(command, args, withWorkspaceSignal(options, controller.signal)),
+        restoreSession: (kiloSessionId, workspacePath, filePath, options) =>
+          restore(kiloSessionId, workspacePath, filePath, {
+            ...options,
+            signal: options?.signal
+              ? AbortSignal.any([options.signal, controller.signal])
+              : controller.signal,
+          }),
+      },
+      controller.signal
+    );
+  } catch (error) {
+    if (controller.signal.aborted) throw timeoutError;
+    throw error;
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -31,7 +31,6 @@ const WORKSPACE_CLEANUP_TIMEOUT_MS = 60_000;
 const SHORT_GIT_COMMAND_TIMEOUT_MS = 120_000;
 const PROGRESS_UPDATE_INTERVAL_MS = 5_000;
 const GIT_BOOTSTRAP_MARKER = 'kilo-bootstrap-complete';
-const BOOTSTRAP_PENDING_MARKER = '.kilo-bootstrap-pending';
 const MAX_ATTACHMENT_BYTES = 5_242_880;
 
 export type BootstrapProgressStep =
@@ -177,35 +176,16 @@ function gitBootstrapMarkerPath(workspacePath: string): string {
   return path.join(workspacePath, '.git', GIT_BOOTSTRAP_MARKER);
 }
 
-function bootstrapPendingMarkerPath(sessionHome: string): string {
-  return path.join(sessionHome, BOOTSTRAP_PENDING_MARKER);
-}
-
 function sessionAuthFilePath(sessionHome: string): string {
   return path.join(sessionHome, '.local/share/kilo/auth.json');
 }
 
-async function isCompleteGitWorkspace(
-  request: WrapperSessionReadyRequest,
-  runGit: GitRunner
-): Promise<boolean> {
-  const { workspacePath, sessionHome } = request.workspace;
-  if (!(await exists(path.join(workspacePath, '.git')))) return false;
-  if (await exists(gitBootstrapMarkerPath(workspacePath))) return true;
-  if (await exists(bootstrapPendingMarkerPath(sessionHome))) return false;
-  if (!(await exists(sessionAuthFilePath(sessionHome)))) return false;
-
-  const result = await runGit(['rev-parse', '--is-inside-work-tree'], {
-    cwd: workspacePath,
-    timeoutMs: SHORT_GIT_COMMAND_TIMEOUT_MS,
-  });
-  if (result.exitCode !== 0 || result.stdout.trim() !== 'true') return false;
-
-  await fs.writeFile(gitBootstrapMarkerPath(workspacePath), 'ready\n');
-  logToFile(
-    `bootstrap migrated legacy workspace kiloSessionId=${request.kiloSessionId} workspacePath=${workspacePath}`
-  );
-  return true;
+// The marker is removed before re-bootstrapping and written only after restore
+// and setup commands finish, so its presence is the sole evidence that a
+// workspace completed bootstrap. Anything else (a bare .git, auth.json) can be
+// left behind by an interrupted bootstrap and must be rebuilt.
+async function isCompleteGitWorkspace(workspacePath: string): Promise<boolean> {
+  return exists(gitBootstrapMarkerPath(workspacePath));
 }
 
 async function ensureWorkspaceDirectories(request: WrapperSessionReadyRequest): Promise<void> {
@@ -657,7 +637,7 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
   let workspaceNeedsBootstrap = true;
 
   try {
-    workspaceWasWarm = await isCompleteGitWorkspace(request, runGit);
+    workspaceWasWarm = await isCompleteGitWorkspace(request.workspace.workspacePath);
     workspaceNeedsBootstrap = !workspaceWasWarm || !request.workspace.preferSnapshot;
     logToFile(
       `bootstrap workspace plan kiloSessionId=${request.kiloSessionId} preferSnapshot=${request.workspace.preferSnapshot} workspaceWasWarm=${workspaceWasWarm} workspaceNeedsBootstrap=${workspaceNeedsBootstrap} workspacePath=${request.workspace.workspacePath} sessionHome=${request.workspace.sessionHome} home=${process.env.HOME ?? '(unset)'} homeMatchesSessionHome=${process.env.HOME === request.workspace.sessionHome} repoKind=${request.repo?.kind ?? '(none)'} setupCommandCount=${request.materialized.setupCommands?.length ?? 0} runtimeSkillCount=${request.materialized.runtimeSkills?.length ?? 0}`
@@ -671,7 +651,6 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
 
     if (workspaceNeedsBootstrap) {
       await fs.rm(gitBootstrapMarkerPath(request.workspace.workspacePath), { force: true });
-      await fs.writeFile(bootstrapPendingMarkerPath(request.workspace.sessionHome), 'pending\n');
     }
 
     await writeCloudAgentRules(request);
@@ -717,7 +696,6 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
 
       signal.throwIfAborted();
       await fs.writeFile(gitBootstrapMarkerPath(request.workspace.workspacePath), 'ready\n');
-      await fs.rm(bootstrapPendingMarkerPath(request.workspace.sessionHome), { force: true });
     }
 
     signal.throwIfAborted();

--- a/services/cloud-agent-next/wrapper/src/utils.ts
+++ b/services/cloud-agent-next/wrapper/src/utils.ts
@@ -45,6 +45,14 @@ const TRUNCATION_MARKER = 'output truncated';
 
 export type TerminationReason = 'timeout' | 'inactivity_timeout' | 'hard_timeout' | 'abort';
 
+export function isTimeoutTermination(result: ExecResult): boolean {
+  return (
+    result.terminationReason === 'timeout' ||
+    result.terminationReason === 'inactivity_timeout' ||
+    result.terminationReason === 'hard_timeout'
+  );
+}
+
 function utf8Tail(value: string, maxBytes: number): string {
   const bytes = Buffer.from(value);
   if (bytes.length <= maxBytes) return value;

--- a/services/cloud-agent-next/wrapper/src/utils.ts
+++ b/services/cloud-agent-next/wrapper/src/utils.ts
@@ -11,12 +11,17 @@ export type ExecResult = {
   stderrTruncated?: boolean;
 };
 
+export type ProcessOutputStream = 'stdout' | 'stderr';
+
 export type ProcessOptions = {
   cwd?: string;
   timeoutMs?: number;
+  inactivityTimeoutMs?: number;
+  hardTimeoutMs?: number;
   signal?: AbortSignal;
   terminationGraceMs?: number;
   maxOutputBytes?: number;
+  onOutput?: (stream: ProcessOutputStream, output: string) => void;
 };
 
 export type GitOptions = ProcessOptions;
@@ -32,11 +37,13 @@ const EXEC_TIMEOUT_EXIT_CODE = 124;
 const EXEC_TERMINATION_GRACE_MS = 2_000;
 const EXEC_TERMINATION_POLL_MS = 25;
 const EXEC_TIMEOUT_MESSAGE = 'exec timeout reached';
+const EXEC_INACTIVITY_TIMEOUT_MESSAGE = 'exec inactivity timeout reached';
+const EXEC_HARD_TIMEOUT_MESSAGE = 'exec hard timeout reached';
 const EXEC_ABORTED_MESSAGE = 'exec aborted';
 const DEFAULT_MAX_OUTPUT_BYTES = 64 * 1_024;
 const TRUNCATION_MARKER = 'output truncated';
 
-export type TerminationReason = 'timeout' | 'abort';
+export type TerminationReason = 'timeout' | 'inactivity_timeout' | 'hard_timeout' | 'abort';
 
 function utf8Tail(value: string, maxBytes: number): string {
   const bytes = Buffer.from(value);
@@ -74,6 +81,19 @@ export function createSafeProcessDiagnostic(result: ExecResult): string {
     .join(', ');
 }
 
+function terminationMessage(reason: TerminationReason): string {
+  switch (reason) {
+    case 'timeout':
+      return EXEC_TIMEOUT_MESSAGE;
+    case 'inactivity_timeout':
+      return EXEC_INACTIVITY_TIMEOUT_MESSAGE;
+    case 'hard_timeout':
+      return EXEC_HARD_TIMEOUT_MESSAGE;
+    case 'abort':
+      return EXEC_ABORTED_MESSAGE;
+  }
+}
+
 export function runProcess(
   command: string,
   args: string[],
@@ -103,6 +123,9 @@ export function runProcess(
     const maxOutputBytes = opts?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
     let settled = false;
     let terminationReason: TerminationReason | null = null;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    let inactivityTimer: ReturnType<typeof setTimeout> | undefined;
+    let hardTimeoutTimer: ReturnType<typeof setTimeout> | undefined;
     let terminationTimer: ReturnType<typeof setTimeout> | undefined;
     let terminationPollTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -111,7 +134,9 @@ export function runProcess(
     }
 
     const clearTimers = () => {
-      if (timer) clearTimeout(timer);
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      if (inactivityTimer) clearTimeout(inactivityTimer);
+      if (hardTimeoutTimer) clearTimeout(hardTimeoutTimer);
       if (terminationTimer) clearTimeout(terminationTimer);
       if (terminationPollTimer) clearTimeout(terminationPollTimer);
     };
@@ -134,7 +159,7 @@ export function runProcess(
       if (destroyOpenPipes) destroyPipes();
       const boundedStderr = appendBoundedTail(
         stderr,
-        `${stderr.endsWith('\n') || stderr.length === 0 ? '' : '\n'}${reason === 'timeout' ? EXEC_TIMEOUT_MESSAGE : EXEC_ABORTED_MESSAGE}`,
+        `${stderr.endsWith('\n') || stderr.length === 0 ? '' : '\n'}${terminationMessage(reason)}`,
         maxOutputBytes
       );
       resolve({
@@ -180,7 +205,7 @@ export function runProcess(
     const terminate = (reason: TerminationReason): void => {
       if (settled || terminationReason !== null) return;
       terminationReason = reason;
-      if (timer) clearTimeout(timer);
+      clearTimers();
       killProcess('SIGTERM');
       terminationTimer = setTimeout(() => {
         killProcess('SIGKILL');
@@ -188,21 +213,41 @@ export function runProcess(
       }, opts?.terminationGraceMs ?? EXEC_TERMINATION_GRACE_MS);
     };
 
-    const timer =
-      opts?.timeoutMs !== undefined
-        ? setTimeout(() => terminate('timeout'), opts.timeoutMs)
-        : undefined;
+    const resetInactivityTimer = (): void => {
+      if (opts?.inactivityTimeoutMs === undefined || terminationReason !== null) return;
+      if (inactivityTimer) clearTimeout(inactivityTimer);
+      inactivityTimer = setTimeout(() => terminate('inactivity_timeout'), opts.inactivityTimeoutMs);
+    };
 
-    proc.stdout.on('data', (chunk: Buffer) => {
-      const bounded = appendBoundedTail(stdout, chunk, maxOutputBytes);
-      stdout = bounded.value;
-      stdoutTruncated ||= bounded.truncated;
-    });
-    proc.stderr.on('data', (chunk: Buffer) => {
-      const bounded = appendBoundedTail(stderr, chunk, maxOutputBytes);
-      stderr = bounded.value;
-      stderrTruncated ||= bounded.truncated;
-    });
+    const captureOutput = (stream: ProcessOutputStream, output: Buffer): void => {
+      const text = output.toString();
+      if (stream === 'stdout') {
+        const bounded = appendBoundedTail(stdout, text, maxOutputBytes);
+        stdout = bounded.value;
+        stdoutTruncated ||= bounded.truncated;
+      } else {
+        const bounded = appendBoundedTail(stderr, text, maxOutputBytes);
+        stderr = bounded.value;
+        stderrTruncated ||= bounded.truncated;
+      }
+      resetInactivityTimer();
+      try {
+        opts?.onOutput?.(stream, text);
+      } catch {
+        // Progress reporting must not affect process execution.
+      }
+    };
+
+    if (opts?.timeoutMs !== undefined) {
+      timeoutTimer = setTimeout(() => terminate('timeout'), opts.timeoutMs);
+    }
+    resetInactivityTimer();
+    if (opts?.hardTimeoutMs !== undefined) {
+      hardTimeoutTimer = setTimeout(() => terminate('hard_timeout'), opts.hardTimeoutMs);
+    }
+
+    proc.stdout.on('data', (output: Buffer) => captureOutput('stdout', output));
+    proc.stderr.on('data', (output: Buffer) => captureOutput('stderr', output));
 
     if (opts?.signal) {
       if (opts.signal.aborted) {


### PR DESCRIPTION
## Summary

### Why

Large repositories can remain healthy while cloning or checking out for longer than the wrapper's previous two-minute wall-clock limit. When those operations were interrupted, the remaining `.git` directory could also make a later attempt reuse an incomplete workspace, turning one timeout into repeated setup failures.

### What was done

- Replace fixed long-command timeouts with a two-minute output-inactivity watchdog and a five-minute hard limit for Git and setup commands.
- Bound the complete workspace phase to eight minutes and propagate cancellation through Git, setup, snapshot restore, and patch application, preserving headroom inside the existing ten-minute wrapper readiness budget.
- Mark bootstrap attempts as pending and write a Git completion marker only after branch preparation, session restore, and setup commands finish; incomplete new workspaces are removed and cloned again.
- Report sanitized Git percentages and generic setup activity without exposing credentials or setup output, then advance the status to `Starting Kilo...` while the runtime starts.
- Bound captured subprocess output and failed-workspace cleanup so noisy or interrupted commands cannot grow memory or cleanup time without limit.

### High-level architecture

```mermaid
sequenceDiagram
  participant Orchestrator
  participant Wrapper
  participant Workspace
  participant Kilo
  Orchestrator->>Wrapper: POST /session/ready (10-minute outer budget)
  Wrapper->>Workspace: Prepare repository and session (8-minute shared budget)
  alt Workspace is complete
    Workspace-->>Wrapper: Reuse and refresh credentials
  else Workspace is incomplete or cold
    Wrapper->>Workspace: Mark pending, remove stale state, clone, restore, and run setup
    Wrapper->>Workspace: Write completion marker
  end
  Wrapper->>Kilo: Start runtime
  Wrapper-->>Orchestrator: Session ready
```

### Architecture decision

**Decision:** Keep bootstrap lifecycle policy in the wrapper and combine activity-aware command watchdogs with a shared workspace deadline and explicit completion markers.

**Context:** A single elapsed timeout could not distinguish a slow, active checkout from a stalled process, while `.git` existence alone could not distinguish a usable workspace from an interrupted clone.

**Rationale:** The wrapper owns the subprocesses and persisted workspace state, so it can observe output, cancel child processes, and write completion state at the point where bootstrap actually succeeds. Layered two-minute inactivity, five-minute command, eight-minute workspace, and ten-minute readiness limits keep each boundary finite without colliding with startup cleanup.

**Alternatives considered:**

- **Only increase the old Git timeout.** This would allow larger repositories but would still wait too long on silent hangs and reuse interrupted workspaces.
- **Continue treating any `.git` directory as warm.** This avoids recloning but preserves the failure mode where partial checkouts are mistaken for complete workspaces.

**Consequences:** Active long-running operations receive more time and interrupted new workspaces recover deterministically. Silent commands can still time out after two minutes, markerless legacy workspaces use a compatibility heuristic, and cleanup remains best-effort so the original setup failure is preserved.

## Verification

- [ ] Verified locally

## Visual Changes

<img width="1021" height="261" alt="Screenshot 2026-06-10 at 15 02 36" src="https://github.com/user-attachments/assets/20537a5c-2db1-43fa-a23b-baefc0912914" />


## Reviewer Notes

- Review the nested timeout policy and cancellation propagation through repository preparation and snapshot restore.
- Markerless legacy workspaces are migrated when Kilo auth exists and Git validates the worktree. A narrowly interrupted pre-marker workspace can still satisfy that heuristic; this is accepted because sessions are predominantly new.
- The separate App Builder `Unauthorized: Invalid token` clone failure is intentionally not addressed by this PR.