### PR TITLE
fix(gateway): configure Fable fallback models

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -189,7 +189,6 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     return malformedJsonResponse(e);
   }
 
-  delete requestBodyParsed.body.models; // OpenRouter specific field we do not support
   if (
     typeof requestBodyParsed.body.model !== 'string' ||
     requestBodyParsed.body.model.trim().length === 0

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/anthropic.constants';
-import { applyOpenRouterModelsFallback } from '@/lib/ai-gateway/providers/apply-provider-specific-logic';
+import { applyGatewayModelsFallback } from '@/lib/ai-gateway/providers/apply-provider-specific-logic';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 
@@ -15,13 +15,13 @@ function makeRequest(model: string, models?: string[]): GatewayRequest {
   };
 }
 
-describe('applyOpenRouterModelsFallback', () => {
+describe('applyGatewayModelsFallback', () => {
   it.each<ProviderId>(['openrouter', 'vercel'])(
     'sets Opus as the Fable fallback for the %s provider',
     providerId => {
       const request = makeRequest('anthropic/claude-fable-5', ['caller/fallback']);
 
-      applyOpenRouterModelsFallback(providerId, 'anthropic/claude-fable-5', request);
+      applyGatewayModelsFallback(providerId, 'anthropic/claude-fable-5', request);
 
       expect(request.body.models).toEqual([
         'anthropic/claude-fable-5',
@@ -33,7 +33,7 @@ describe('applyOpenRouterModelsFallback', () => {
   it('removes caller-provided fallbacks for Fable on other providers', () => {
     const request = makeRequest('anthropic/claude-fable-5', ['caller/fallback']);
 
-    applyOpenRouterModelsFallback('martian', 'anthropic/claude-fable-5', request);
+    applyGatewayModelsFallback('martian', 'anthropic/claude-fable-5', request);
 
     expect(request.body.models).toBeUndefined();
   });
@@ -41,7 +41,7 @@ describe('applyOpenRouterModelsFallback', () => {
   it('removes caller-provided fallbacks for other models', () => {
     const request = makeRequest('openai/gpt-4o', ['caller/fallback']);
 
-    applyOpenRouterModelsFallback('openrouter', 'openai/gpt-4o', request);
+    applyGatewayModelsFallback('openrouter', 'openai/gpt-4o', request);
 
     expect(request.body.models).toBeUndefined();
   });

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from '@jest/globals';
+import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/anthropic.constants';
+import { applyOpenRouterModelsFallback } from '@/lib/ai-gateway/providers/apply-provider-specific-logic';
+import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+
+function makeRequest(model: string, models?: string[]): GatewayRequest {
+  return {
+    kind: 'chat_completions',
+    body: {
+      model,
+      models,
+      messages: [{ role: 'user', content: 'hello' }],
+    },
+  };
+}
+
+describe('applyOpenRouterModelsFallback', () => {
+  it('sets Opus as the fallback for Fable requests', () => {
+    const request = makeRequest('anthropic/claude-fable-5', ['caller/fallback']);
+
+    applyOpenRouterModelsFallback(request.body.model, request);
+
+    expect(request.body.models).toEqual([request.body.model, CLAUDE_OPUS_CURRENT_MODEL_ID]);
+  });
+
+  it('removes caller-provided fallbacks for other models', () => {
+    const request = makeRequest('openai/gpt-4o', ['caller/fallback']);
+
+    applyOpenRouterModelsFallback(request.body.model, request);
+
+    expect(request.body.models).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/anthropic.constants';
 import { applyOpenRouterModelsFallback } from '@/lib/ai-gateway/providers/apply-provider-specific-logic';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 
 function makeRequest(model: string, models?: string[]): GatewayRequest {
   return {
@@ -15,18 +16,32 @@ function makeRequest(model: string, models?: string[]): GatewayRequest {
 }
 
 describe('applyOpenRouterModelsFallback', () => {
-  it('sets Opus as the fallback for Fable requests', () => {
+  it.each<ProviderId>(['openrouter', 'vercel'])(
+    'sets Opus as the Fable fallback for the %s provider',
+    providerId => {
+      const request = makeRequest('anthropic/claude-fable-5', ['caller/fallback']);
+
+      applyOpenRouterModelsFallback(providerId, 'anthropic/claude-fable-5', request);
+
+      expect(request.body.models).toEqual([
+        'anthropic/claude-fable-5',
+        CLAUDE_OPUS_CURRENT_MODEL_ID,
+      ]);
+    }
+  );
+
+  it('removes caller-provided fallbacks for Fable on other providers', () => {
     const request = makeRequest('anthropic/claude-fable-5', ['caller/fallback']);
 
-    applyOpenRouterModelsFallback(request.body.model, request);
+    applyOpenRouterModelsFallback('martian', 'anthropic/claude-fable-5', request);
 
-    expect(request.body.models).toEqual([request.body.model, CLAUDE_OPUS_CURRENT_MODEL_ID]);
+    expect(request.body.models).toBeUndefined();
   });
 
   it('removes caller-provided fallbacks for other models', () => {
     const request = makeRequest('openai/gpt-4o', ['caller/fallback']);
 
-    applyOpenRouterModelsFallback(request.body.model, request);
+    applyOpenRouterModelsFallback('openrouter', 'openai/gpt-4o', request);
 
     expect(request.body.models).toBeUndefined();
   });

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -91,7 +91,7 @@ function applyPreferredProvider(
   }
 }
 
-export function applyOpenRouterModelsFallback(
+export function applyGatewayModelsFallback(
   providerId: ProviderId,
   requestedModel: string,
   requestToMutate: GatewayRequest
@@ -114,7 +114,7 @@ export function applyProviderSpecificLogic(
   userId: string,
   taskId: string | null
 ) {
-  applyOpenRouterModelsFallback(provider.id, requestedModel, requestToMutate);
+  applyGatewayModelsFallback(provider.id, requestedModel, requestToMutate);
   applyTrackingIds(requestToMutate, provider, userId, taskId);
 
   sanitizeBinaryToolResults(requestToMutate);

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -17,7 +17,7 @@ import { OpenRouterInferenceProviderIdSchema } from '@/lib/ai-gateway/providers/
 import { applyMoonshotModelSettings, isKimiModel } from '@/lib/ai-gateway/providers/moonshotai';
 import { isGlmModel } from '@/lib/ai-gateway/providers/zai';
 import { isMinimaxModel } from '@/lib/ai-gateway/providers/minimax';
-import type { BYOKResult, Provider } from '@/lib/ai-gateway/providers/types';
+import type { BYOKResult, Provider, ProviderId } from '@/lib/ai-gateway/providers/types';
 import { isStepModel } from '@/lib/ai-gateway/providers/stepfun';
 import { isDeepseekModel } from '@/lib/ai-gateway/providers/deepseek';
 import { isOpenCodeBasedClient, type FraudDetectionHeaders } from '@/lib/utils';
@@ -92,11 +92,12 @@ function applyPreferredProvider(
 }
 
 export function applyOpenRouterModelsFallback(
+  providerId: ProviderId,
   requestedModel: string,
   requestToMutate: GatewayRequest
 ) {
-  if (isFableModel(requestedModel)) {
-    requestToMutate.body.models = [requestToMutate.body.model, CLAUDE_OPUS_CURRENT_MODEL_ID];
+  if (isFableModel(requestedModel) && (providerId === 'openrouter' || providerId === 'vercel')) {
+    requestToMutate.body.models = [requestedModel, CLAUDE_OPUS_CURRENT_MODEL_ID];
     return;
   }
 
@@ -113,7 +114,7 @@ export function applyProviderSpecificLogic(
   userId: string,
   taskId: string | null
 ) {
-  applyOpenRouterModelsFallback(requestedModel, requestToMutate);
+  applyOpenRouterModelsFallback(provider.id, requestedModel, requestToMutate);
   applyTrackingIds(requestToMutate, provider, userId, taskId);
 
   sanitizeBinaryToolResults(requestToMutate);

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -8,7 +8,11 @@ import { applyMistralModelSettings, isMistralModel } from '@/lib/ai-gateway/prov
 import { findKiloExclusiveModel } from '@/lib/ai-gateway/models';
 import { applyKiloExclusiveModelSettings } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 import { applyAnthropicModelSettings } from '@/lib/ai-gateway/providers/anthropic';
-import { isClaudeModel } from '@/lib/ai-gateway/providers/anthropic.constants';
+import {
+  CLAUDE_OPUS_CURRENT_MODEL_ID,
+  isClaudeModel,
+  isFableModel,
+} from '@/lib/ai-gateway/providers/anthropic.constants';
 import { OpenRouterInferenceProviderIdSchema } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import { applyMoonshotModelSettings, isKimiModel } from '@/lib/ai-gateway/providers/moonshotai';
 import { isGlmModel } from '@/lib/ai-gateway/providers/zai';
@@ -87,6 +91,18 @@ function applyPreferredProvider(
   }
 }
 
+export function applyOpenRouterModelsFallback(
+  requestedModel: string,
+  requestToMutate: GatewayRequest
+) {
+  if (isFableModel(requestedModel)) {
+    requestToMutate.body.models = [requestToMutate.body.model, CLAUDE_OPUS_CURRENT_MODEL_ID];
+    return;
+  }
+
+  delete requestToMutate.body.models;
+}
+
 export function applyProviderSpecificLogic(
   provider: Provider,
   requestedModel: string,
@@ -97,6 +113,7 @@ export function applyProviderSpecificLogic(
   userId: string,
   taskId: string | null
 ) {
+  applyOpenRouterModelsFallback(requestedModel, requestToMutate);
   applyTrackingIds(requestToMutate, provider, userId, taskId);
 
   sanitizeBinaryToolResults(requestToMutate);


### PR DESCRIPTION
## Summary

- Move gateway `models` sanitization into the existing provider-specific request handling flow.
- Configure Fable requests routed through OpenRouter or Vercel with the requested Fable model first and the current Claude Opus model as fallback.
- Remove caller-provided `models` values for non-Fable requests and providers other than OpenRouter or Vercel.
- Cover supported providers, unsupported providers, and non-Fable requests with focused unit tests.

## Verification

- [ ] Manual verification not performed; this request-path change is covered by focused unit tests.

## Visual Changes

N/A

## Reviewer Notes

- `pnpm format` completed successfully.
- Focused `oxlint` and the `@kilocode/trpc` build completed successfully.
- The focused Jest test could not complete locally because Docker is unavailable for the required test Postgres instance. CI provides the authoritative test result.