### PR TITLE
fix(ai-gateway): retain streamed upstream responses

### DIFF
--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
 import type { MicrodollarUsageContext, MicrodollarUsageStats } from './processUsage.types';
 
 // `countAndStoreEditUsage` schedules the usage write through `next/server`'s
@@ -32,7 +34,108 @@ import {
   parseEmbeddingUsageFromResponse,
   parseEditUsageFromResponse,
   parseTranscriptionUsageFromResponse,
+  wrapInSafeNextResponse,
 } from './llm-proxy-helpers';
+
+describe('wrapInSafeNextResponse', () => {
+  it('keeps a fetched response alive until its returned body is consumed', () => {
+    const tsx = require.resolve('tsx/cli');
+    const fixture = join(__dirname, 'wrap-safe-next-response.gc.ts');
+    const result = spawnSync(process.execPath, ['--conditions=react-server', tsx, fixture], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        NODE_OPTIONS:
+          `${process.env.NODE_OPTIONS ?? ''} --expose-gc --conditions=react-server`.trim(),
+        UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN ?? 'test',
+        UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL ?? 'http://127.0.0.1',
+      },
+      timeout: 30_000,
+    });
+
+    expect({
+      status: result.status,
+      signal: result.signal,
+      error: result.error?.message,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    }).toEqual({
+      status: 0,
+      signal: null,
+      error: undefined,
+      stdout: process.version === 'v24.14.1' ? '' : `skipped on ${process.version}\n`,
+      stderr: '',
+    });
+  });
+
+  it('preserves exact bytes without locking the source eagerly', async () => {
+    const bytes = Uint8Array.from([0, 255, 1, 128, 13, 10]);
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes.subarray(0, 2));
+        controller.enqueue(bytes.subarray(2));
+        controller.close();
+      },
+    });
+    const wrapped = wrapInSafeNextResponse(new Response(source));
+
+    expect(source.locked).toBe(false);
+    expect(new Uint8Array(await wrapped.arrayBuffer())).toEqual(bytes);
+    expect(source.locked).toBe(false);
+  });
+
+  it('propagates source errors', async () => {
+    const error = new Error('source failed');
+    const source = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(error);
+      },
+    });
+    const wrapped = wrapInSafeNextResponse(new Response(source));
+
+    await expect(wrapped.text()).rejects.toBe(error);
+    expect(source.locked).toBe(false);
+  });
+
+  it('propagates cancellation to the source', async () => {
+    const cancelled = jest.fn();
+    const reason = new Error('consumer stopped');
+    const source = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(Uint8Array.of(1));
+      },
+      cancel: cancelled,
+    });
+    const wrapped = wrapInSafeNextResponse(new Response(source));
+    const reader = wrapped.body?.getReader();
+
+    await reader?.read();
+    await reader?.cancel(reason);
+
+    expect(cancelled).toHaveBeenCalledWith(reason);
+    expect(source.locked).toBe(false);
+  });
+
+  it('propagates cancellation before the first pull', async () => {
+    const cancelled = jest.fn();
+    const reason = new Error('consumer stopped early');
+    const source = new ReadableStream<Uint8Array>({ cancel: cancelled });
+    const wrapped = wrapInSafeNextResponse(new Response(source));
+
+    await wrapped.body?.cancel(reason);
+
+    expect(cancelled).toHaveBeenCalledWith(reason);
+    expect(source.locked).toBe(false);
+  });
+
+  it('preserves bodyless responses', () => {
+    const wrapped = wrapInSafeNextResponse(new Response(null, { status: 204 }));
+
+    expect(wrapped.status).toBe(204);
+    expect(wrapped.body).toBeNull();
+  });
+});
 
 describe('checkOrganizationModelRestrictions', () => {
   describe('enterprise plan - model deny list restrictions', () => {

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
@@ -64,7 +64,7 @@ describe('wrapInSafeNextResponse', () => {
       status: 0,
       signal: null,
       error: undefined,
-      stdout: process.version === 'v24.14.1' ? '' : `skipped on ${process.version}\n`,
+      stdout: '',
       stderr: '',
     });
   });
@@ -125,6 +125,22 @@ describe('wrapInSafeNextResponse', () => {
 
     await wrapped.body?.cancel(reason);
 
+    expect(cancelled).toHaveBeenCalledWith(reason);
+    expect(source.locked).toBe(false);
+  });
+
+  it('does not close an already cancelled stream when a pending pull settles', async () => {
+    const cancelled = jest.fn();
+    const reason = new Error('consumer stopped during pull');
+    const source = new ReadableStream<Uint8Array>({ cancel: cancelled });
+    const wrapped = wrapInSafeNextResponse(new Response(source));
+    const reader = wrapped.body?.getReader();
+    const pending = reader?.read();
+
+    await Promise.resolve();
+    await reader?.cancel(reason);
+
+    await expect(pending).resolves.toEqual({ done: true, value: undefined });
     expect(cancelled).toHaveBeenCalledWith(reason);
     expect(source.locked).toBe(false);
   });

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -295,7 +295,45 @@ export function getOutputHeaders(response: Response) {
 }
 
 export function wrapInSafeNextResponse(response: Response) {
-  return new NextResponse(response.body, {
+  const source = response.body;
+  let owner: Response | undefined = response;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  const release = () => {
+    if (!owner) return;
+    reader?.releaseLock();
+    reader = undefined;
+    owner = undefined;
+  };
+  const body = source
+    ? new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          reader ??= owner?.body?.getReader();
+          if (!reader) return;
+          try {
+            const result = await reader.read();
+            if (result.done) {
+              controller.close();
+              release();
+              return;
+            }
+            controller.enqueue(result.value);
+          } catch (error) {
+            release();
+            controller.error(error);
+          }
+        },
+        async cancel(reason) {
+          try {
+            if (reader) await reader.cancel(reason);
+            else await source.cancel(reason);
+          } finally {
+            release();
+          }
+        },
+      })
+    : null;
+
+  return new NextResponse(body, {
     status: response.status,
     statusText: response.statusText,
     headers: getOutputHeaders(response),

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -298,19 +298,23 @@ export function wrapInSafeNextResponse(response: Response) {
   const source = response.body;
   let owner: Response | undefined = response;
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let cancelled = false;
   const release = () => {
     if (!owner) return;
-    reader?.releaseLock();
+    const active = reader;
     reader = undefined;
     owner = undefined;
+    active?.releaseLock();
   };
   const body = source
     ? new ReadableStream<Uint8Array>({
         async pull(controller) {
           reader ??= owner?.body?.getReader();
-          if (!reader) return;
+          const active = reader;
+          if (!active) return;
           try {
-            const result = await reader.read();
+            const result = await active.read();
+            if (cancelled) return;
             if (result.done) {
               controller.close();
               release();
@@ -318,11 +322,13 @@ export function wrapInSafeNextResponse(response: Response) {
             }
             controller.enqueue(result.value);
           } catch (error) {
+            if (cancelled) return;
             release();
             controller.error(error);
           }
         },
         async cancel(reason) {
+          cancelled = true;
           try {
             if (reader) await reader.cancel(reason);
             else await source.cancel(reason);

--- a/apps/web/src/lib/ai-gateway/wrap-safe-next-response.gc.ts
+++ b/apps/web/src/lib/ai-gateway/wrap-safe-next-response.gc.ts
@@ -3,12 +3,6 @@ import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
 async function main() {
-  if (process.version !== 'v24.14.1') {
-    process.stdout.write(`skipped on ${process.version}\n`);
-    return;
-  }
-
-  assert.equal(process.versions.undici, '7.24.4');
   assert.ok(global.gc);
 
   const { wrapInSafeNextResponse } = await import('./llm-proxy-helpers');

--- a/apps/web/src/lib/ai-gateway/wrap-safe-next-response.gc.ts
+++ b/apps/web/src/lib/ai-gateway/wrap-safe-next-response.gc.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+async function main() {
+  if (process.version !== 'v24.14.1') {
+    process.stdout.write(`skipped on ${process.version}\n`);
+    return;
+  }
+
+  assert.equal(process.versions.undici, '7.24.4');
+  assert.ok(global.gc);
+
+  const { wrapInSafeNextResponse } = await import('./llm-proxy-helpers');
+  const chunks = ['first', 'second', 'third'];
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/plain' });
+    response.write(chunks[0]);
+    setTimeout(() => response.write(chunks[1]), 25);
+    setTimeout(() => response.end(chunks[2]), 50);
+  });
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const address = server.address() as AddressInfo;
+    const wrapped = await (async () => {
+      const response = await fetch(`http://127.0.0.1:${address.port}`);
+      const siblingA = response.clone();
+      const siblingB = response.clone();
+      return {
+        response: wrapInSafeNextResponse(response),
+        siblings: [siblingA.text(), siblingB.text()],
+      };
+    })();
+
+    for (let index = 0; index < 10; index++) {
+      global.gc();
+      await new Promise(resolve => setImmediate(resolve));
+    }
+
+    const [body, ...siblings] = await Promise.all([wrapped.response.text(), ...wrapped.siblings]);
+    assert.deepEqual(siblings, [chunks.join(''), chunks.join('')]);
+    assert.equal(body, chunks.join(''));
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close(error => (error ? reject(error) : resolve()))
+    );
+  }
+}
+
+void main();


### PR DESCRIPTION
The proxy returns upstream responses by constructing a new `NextResponse` around `response.body`. For fetched responses, runtime cleanup remains associated with the original `Response` object. Passing only the body to a new response does not transfer that ownership. If the original response becomes unreachable before the downstream reader is acquired, garbage collection can cancel the returned branch even while sibling clones continue consuming the upstream stream.

This is especially hazardous in the shared proxy path, where metrics, usage, and optional request logging create independent tee branches before the original body is handed to Next.js. A sibling branch completing therefore does not protect the client-facing leaf from cleanup tied to the original fetched response.

The response wrapper now uses a lazy identity `ReadableStream` that keeps the original response strongly reachable for the full lifetime of the returned body:

- The source reader is acquired only on the first downstream pull, preserving lazy streaming and backpressure.
- Chunks pass through unchanged without buffering, parsing, or cloning.
- The original response remains reachable until source EOF, source error, or downstream cancellation.
- EOF closes the returned stream and releases both the reader lock and retained owner.
- Source errors propagate after deterministic cleanup.
- Downstream cancellation propagates before or after the first pull.
- A cancellation flag prevents a pending pull from closing or erroring a stream that the consumer has already cancelled.
- Bodyless responses retain a null body, and status, status text, and safe-header behavior remain unchanged.

The fix applies at the common `wrapInSafeNextResponse` boundary used by streaming model responses and other direct proxy routes. It does not change provider selection, response rewriting, retry behavior, protocol interpretation, or completion semantics.