### PR TITLE
ci(deploy): stage production Vercel deploys

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,7 +13,7 @@ concurrency:
 
 env:
   VERCEL_VERSION: '53.3.1'
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
 
 jobs:
   check-production-db-startup:
@@ -84,6 +84,9 @@ jobs:
     outputs:
       deployment_url: ${{ steps.deploy.outputs.deployment_url }}
 
+    env:
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
+
     steps:
       - name: Checkout code
         uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
@@ -92,9 +95,6 @@ jobs:
 
       - name: Install Vercel CLI
         run: npm install -g vercel@${{ env.VERCEL_VERSION }}
-
-      - name: Link Vercel project
-        run: vercel link --project=kilocode-app --token=${{ secrets.VERCEL_TOKEN }} --yes
 
       - name: Stage Vercel deployment
         id: deploy
@@ -110,6 +110,9 @@ jobs:
     outputs:
       deployment_url: ${{ steps.deploy.outputs.deployment_url }}
 
+    env:
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GLOBAL_APP }}
+
     steps:
       - name: Checkout code
         uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
@@ -118,9 +121,6 @@ jobs:
 
       - name: Install Vercel CLI
         run: npm install -g vercel@${{ env.VERCEL_VERSION }}
-
-      - name: Link Vercel project
-        run: vercel link --project=kilocode-global-app --token=${{ secrets.VERCEL_TOKEN }} --yes
 
       - name: Stage Vercel deployment
         id: deploy

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -76,14 +76,13 @@ jobs:
       - name: Run Drizzle migrations
         run: NODE_ENV=production pnpm run drizzle migrate
 
-  deploy-app:
+  stage-app:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 30
-    needs: [check-production-db-startup, run-migrations]
     environment: production
 
-    env:
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_APP }}
+    outputs:
+      deployment_url: ${{ steps.deploy.outputs.deployment_url }}
 
     steps:
       - name: Checkout code
@@ -94,17 +93,22 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@${{ env.VERCEL_VERSION }}
 
-      - name: Deploy to Vercel
-        run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Link Vercel project
+        run: vercel link --project=kilocode-app --token=${{ secrets.VERCEL_TOKEN }} --yes
 
-  deploy-global-app:
+      - name: Stage Vercel deployment
+        id: deploy
+        run: |
+          deployment_url=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
+          echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
+
+  stage-global-app:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 30
-    needs: [check-production-db-startup, run-migrations]
     environment: production
 
-    env:
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_GLOBAL_APP }}
+    outputs:
+      deployment_url: ${{ steps.deploy.outputs.deployment_url }}
 
     steps:
       - name: Checkout code
@@ -115,8 +119,40 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@${{ env.VERCEL_VERSION }}
 
-      - name: Deploy to Vercel
-        run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Link Vercel project
+        run: vercel link --project=kilocode-global-app --token=${{ secrets.VERCEL_TOKEN }} --yes
+
+      - name: Stage Vercel deployment
+        id: deploy
+        run: |
+          deployment_url=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
+          echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
+
+  promote-app:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    needs: [stage-app, check-production-db-startup, run-migrations]
+    environment: production
+
+    steps:
+      - name: Install Vercel CLI
+        run: npm install -g vercel@${{ env.VERCEL_VERSION }}
+
+      - name: Promote Vercel deployment
+        run: vercel promote "${{ needs.stage-app.outputs.deployment_url }}" --token=${{ secrets.VERCEL_TOKEN }} --yes
+
+  promote-global-app:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    needs: [stage-global-app, check-production-db-startup, run-migrations]
+    environment: production
+
+    steps:
+      - name: Install Vercel CLI
+        run: npm install -g vercel@${{ env.VERCEL_VERSION }}
+
+      - name: Promote Vercel deployment
+        run: vercel promote "${{ needs.stage-global-app.outputs.deployment_url }}" --token=${{ secrets.VERCEL_TOKEN }} --yes
 
   deploy-kiloclaw:
     needs: [check-production-db-startup, run-migrations]

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -99,7 +99,12 @@ jobs:
       - name: Stage Vercel deployment
         id: deploy
         run: |
-          deployment_url=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
+          deployment_output=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
+          deployment_url=$(printf '%s\n' "$deployment_output" | tail -n 1)
+          if [[ ! "$deployment_url" =~ ^https:// ]]; then
+            echo "Vercel deploy did not print a deployment URL" >&2
+            exit 1
+          fi
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
 
   stage-global-app:
@@ -125,7 +130,12 @@ jobs:
       - name: Stage Vercel deployment
         id: deploy
         run: |
-          deployment_url=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
+          deployment_output=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
+          deployment_url=$(printf '%s\n' "$deployment_output" | tail -n 1)
+          if [[ ! "$deployment_url" =~ ^https:// ]]; then
+            echo "Vercel deploy did not print a deployment URL" >&2
+            exit 1
+          fi
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
 
   promote-app:


### PR DESCRIPTION
## Summary
- Stage both production Vercel deployments immediately with `vercel deploy --prod --skip-domain` so build/upload work can run in parallel with production DB gates.
- Promote each staged deployment only after its stage job plus `check-production-db-startup` and `run-migrations` succeed.
- Use GitHub Actions variables for `VERCEL_ORG_ID` and each `VERCEL_PROJECT_ID`, keeping deploy confirmation disabled so unexpected prompts fail CI.

## Verification
N/A - production workflow was not manually run.

## Visual Changes
N/A

## Reviewer Notes
- Staged deployments are production-environment deployments and have unique Vercel URLs before promotion, but they are not assigned production domains until `vercel promote` runs.
- `vercel deploy` intentionally does not use `--yes`; if the configured `VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` variables are missing or Vercel otherwise prompts, the workflow should fail rather than accept defaults.