### PR TITLE
Fix Vercel app promotion

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -152,6 +152,9 @@ jobs:
     needs: [stage-app, check-production-db-startup, run-migrations]
     environment: production
 
+    env:
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
+
     steps:
       - name: Install Vercel CLI
         run: npm install -g vercel@${{ env.VERCEL_VERSION }}
@@ -164,6 +167,9 @@ jobs:
     timeout-minutes: 15
     needs: [stage-global-app, check-production-db-startup, run-migrations]
     environment: production
+
+    env:
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GLOBAL_APP }}
 
     steps:
       - name: Install Vercel CLI


### PR DESCRIPTION
We somehow forgot to link the correct project IDs in the promote steps, so Vercel didn't know what project to promote

<img width="2122" height="516" alt="CleanShot 2026-06-11 at 10 30 16@2x" src="https://github.com/user-attachments/assets/86ed0fa9-ac6e-449c-b75d-a426b43030bc" />
