### PR TITLE
fix(cloud-agent-next): isolate wrapper error parsing

### DIFF
--- a/services/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -26,13 +26,13 @@ import { KILO_AGENT_SESSION_LABEL, type DevContainerHandle } from './devcontaine
 import { WRAPPER_VERSION } from '../shared/wrapper-version.js';
 import { shellQuote, validShellEnvEntries } from './utils.js';
 import {
-  parseWrapperSessionReadyErrorResponse,
   type WorkspaceFailureSubtype,
   type WrapperCommandRequest,
   type WrapperPromptRequest,
   type WrapperSessionReadyRequest,
   type WrapperSessionReadySuccessResponse,
 } from '../shared/wrapper-bootstrap.js';
+import { parseWrapperSessionReadyErrorResponse } from './wrapper-ready-error.js';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/services/cloud-agent-next/src/kilo/wrapper-ready-error.test.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-ready-error.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isWrapperSessionReadyErrorResponse,
+  parseWrapperSessionReadyErrorResponse,
+} from './wrapper-ready-error.js';
+
+describe('wrapper ready error parsing', () => {
+  it('accepts structured and legacy wrapper errors', () => {
+    expect(
+      parseWrapperSessionReadyErrorResponse({
+        error: 'WORKSPACE_SETUP_FAILED',
+        subtype: 'git_clone_timeout',
+        message: 'Repository clone timed out',
+        detail: 'termination timeout, elapsed 120000ms, output truncated',
+        retryable: true,
+        wrapperRunId: 'wrapper_run_1',
+      })
+    ).toEqual({
+      error: 'WORKSPACE_SETUP_FAILED',
+      subtype: 'git_clone_timeout',
+      message: 'Repository clone timed out',
+      detail: 'termination timeout, elapsed 120000ms, output truncated',
+      retryable: true,
+      wrapperRunId: 'wrapper_run_1',
+    });
+    expect(
+      isWrapperSessionReadyErrorResponse({ error: 'WORKSPACE_SETUP_FAILED', message: 'old' })
+    ).toBe(true);
+  });
+
+  it.each([
+    {
+      error: 'WORKSPACE_SETUP_FAILED',
+      subtype: 'not_allowed',
+      message: 'bad',
+    },
+    {
+      error: 'WORKSPACE_SETUP_FAILED',
+      message: 'm'.repeat(4_097),
+    },
+    {
+      error: 'WORKSPACE_SETUP_FAILED',
+      message: 'bounded',
+      detail: 'd'.repeat(8_193),
+    },
+    {
+      error: 'WORKSPACE_SETUP_FAILED',
+      message: 'bounded',
+      retryable: 'false',
+    },
+    {
+      error: 'WORKSPACE_SETUP_FAILED',
+      message: 'bounded',
+      wrapperRunId: 42,
+    },
+  ])('rejects malformed wrapper error %#', value => {
+    expect(isWrapperSessionReadyErrorResponse(value)).toBe(false);
+  });
+});

--- a/services/cloud-agent-next/src/kilo/wrapper-ready-error.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-ready-error.ts
@@ -1,0 +1,64 @@
+import { isWorkspaceFailureSubtype } from '@kilocode/worker-utils/cloud-agent-failure';
+import {
+  WRAPPER_READY_ERROR_DETAIL_MAX_LENGTH,
+  WRAPPER_READY_ERROR_MESSAGE_MAX_LENGTH,
+  type WrapperSessionReadyErrorResponse,
+} from '../shared/wrapper-bootstrap.js';
+
+export type FlattenedWrapperSessionReadyError = {
+  error: WrapperSessionReadyErrorResponse['error']['code'];
+  message: string;
+} & Omit<WrapperSessionReadyErrorResponse['error'], 'code' | 'message'>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasString(value: Record<string, unknown>, key: string): boolean {
+  return typeof value[key] === 'string' && value[key].length > 0;
+}
+
+export function parseWrapperSessionReadyErrorResponse(
+  value: unknown
+): FlattenedWrapperSessionReadyError | undefined {
+  if (!isRecord(value) || !hasString(value, 'error') || !hasString(value, 'message'))
+    return undefined;
+  if (
+    typeof value.message !== 'string' ||
+    value.message.length > WRAPPER_READY_ERROR_MESSAGE_MAX_LENGTH
+  ) {
+    return undefined;
+  }
+  if (value.subtype !== undefined && !isWorkspaceFailureSubtype(value.subtype)) return undefined;
+  if (
+    value.detail !== undefined &&
+    (typeof value.detail !== 'string' ||
+      value.detail.length > WRAPPER_READY_ERROR_DETAIL_MAX_LENGTH)
+  ) {
+    return undefined;
+  }
+  if (value.retryable !== undefined && typeof value.retryable !== 'boolean') return undefined;
+  if (value.wrapperRunId !== undefined && typeof value.wrapperRunId !== 'string') return undefined;
+  if (
+    value.error !== 'INVALID_REQUEST' &&
+    value.error !== 'WRAPPER_FINALIZING' &&
+    value.error !== 'WORKSPACE_SETUP_FAILED' &&
+    value.error !== 'KILO_SERVER_FAILED'
+  ) {
+    return undefined;
+  }
+  return {
+    error: value.error,
+    message: value.message,
+    ...(value.subtype !== undefined ? { subtype: value.subtype } : {}),
+    ...(value.detail !== undefined ? { detail: value.detail } : {}),
+    ...(value.retryable !== undefined ? { retryable: value.retryable } : {}),
+    ...(value.wrapperRunId !== undefined ? { wrapperRunId: value.wrapperRunId } : {}),
+  };
+}
+
+export function isWrapperSessionReadyErrorResponse(
+  value: unknown
+): value is FlattenedWrapperSessionReadyError {
+  return parseWrapperSessionReadyErrorResponse(value) !== undefined;
+}

--- a/services/cloud-agent-next/src/session/pending-messages.ts
+++ b/services/cloud-agent-next/src/session/pending-messages.ts
@@ -9,8 +9,8 @@ import { logger } from '../logger.js';
 import { AttachmentsSchema, CallbackTargetSchema } from '../persistence/schemas.js';
 import { Limits } from '../schema.js';
 import { MESSAGE_ID_FORMAT_DESCRIPTION, MESSAGE_ID_PATTERN } from './message-id.js';
+import { isWorkspaceFailureSubtype } from '@kilocode/worker-utils/cloud-agent-failure';
 import {
-  isWorkspaceFailureSubtype,
   WRAPPER_READY_ERROR_DETAIL_MAX_LENGTH,
   type WorkspaceFailureSubtype,
 } from '../shared/wrapper-bootstrap.js';

--- a/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
+++ b/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
@@ -1,11 +1,6 @@
-import { isWorkspaceFailureSubtype } from '@kilocode/worker-utils/cloud-agent-failure';
-
-export {
-  isWorkspaceFailureSubtype,
-  WORKSPACE_FAILURE_SUBTYPES,
-  type WorkspaceFailureSubtype,
-} from '@kilocode/worker-utils/cloud-agent-failure';
 import type { WorkspaceFailureSubtype } from '@kilocode/worker-utils/cloud-agent-failure';
+
+export type { WorkspaceFailureSubtype } from '@kilocode/worker-utils/cloud-agent-failure';
 
 export type WrapperCommitCoAuthor = {
   name: string;
@@ -183,56 +178,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function hasString(value: Record<string, unknown>, key: string): boolean {
   return typeof value[key] === 'string' && value[key].length > 0;
-}
-
-export type FlattenedWrapperSessionReadyError = {
-  error: WrapperSessionReadyErrorResponse['error']['code'];
-  message: string;
-} & Omit<WrapperSessionReadyErrorResponse['error'], 'code' | 'message'>;
-
-export function parseWrapperSessionReadyErrorResponse(
-  value: unknown
-): FlattenedWrapperSessionReadyError | undefined {
-  if (!isRecord(value) || !hasString(value, 'error') || !hasString(value, 'message'))
-    return undefined;
-  if (
-    typeof value.message !== 'string' ||
-    value.message.length > WRAPPER_READY_ERROR_MESSAGE_MAX_LENGTH
-  ) {
-    return undefined;
-  }
-  if (value.subtype !== undefined && !isWorkspaceFailureSubtype(value.subtype)) return undefined;
-  if (
-    value.detail !== undefined &&
-    (typeof value.detail !== 'string' ||
-      value.detail.length > WRAPPER_READY_ERROR_DETAIL_MAX_LENGTH)
-  ) {
-    return undefined;
-  }
-  if (value.retryable !== undefined && typeof value.retryable !== 'boolean') return undefined;
-  if (value.wrapperRunId !== undefined && typeof value.wrapperRunId !== 'string') return undefined;
-  if (
-    value.error !== 'INVALID_REQUEST' &&
-    value.error !== 'WRAPPER_FINALIZING' &&
-    value.error !== 'WORKSPACE_SETUP_FAILED' &&
-    value.error !== 'KILO_SERVER_FAILED'
-  ) {
-    return undefined;
-  }
-  return {
-    error: value.error,
-    message: value.message,
-    ...(value.subtype !== undefined ? { subtype: value.subtype } : {}),
-    ...(value.detail !== undefined ? { detail: value.detail } : {}),
-    ...(value.retryable !== undefined ? { retryable: value.retryable } : {}),
-    ...(value.wrapperRunId !== undefined ? { wrapperRunId: value.wrapperRunId } : {}),
-  };
-}
-
-export function isWrapperSessionReadyErrorResponse(
-  value: unknown
-): value is FlattenedWrapperSessionReadyError {
-  return parseWrapperSessionReadyErrorResponse(value) !== undefined;
 }
 
 function isWrapperDevContainerMetadata(value: unknown): value is WrapperDevContainerMetadata {

--- a/services/cloud-agent-next/src/telemetry/queue-reports.ts
+++ b/services/cloud-agent-next/src/telemetry/queue-reports.ts
@@ -7,7 +7,7 @@ import {
 import { logger } from '../logger.js';
 import { workspaceFailureMessage } from '../session/safe-failure-projection.js';
 import type { SessionMessageState } from '../session/session-message-state.js';
-import { isWorkspaceFailureSubtype } from '../shared/wrapper-bootstrap.js';
+import { isWorkspaceFailureSubtype } from '@kilocode/worker-utils/cloud-agent-failure';
 
 type ReportQueue = {
   send(report: CloudAgentQueueReport): Promise<unknown>;

--- a/services/cloud-agent-next/wrapper/src/server.test.ts
+++ b/services/cloud-agent-next/wrapper/src/server.test.ts
@@ -9,7 +9,6 @@ import {
   resolvePtyClientClose,
   type WrapperServer,
 } from './server';
-import { isWrapperSessionReadyErrorResponse } from '../../src/shared/wrapper-bootstrap';
 import type { WrapperKiloClient, WrapperPty, WrapperPtySize } from './kilo-api';
 
 type PtyCall = {
@@ -160,44 +159,6 @@ describe('session readiness errors', () => {
       detail: 'termination timeout, elapsed 120000ms, output truncated',
       retryable: true,
     });
-    expect(isWrapperSessionReadyErrorResponse(body)).toBe(true);
-    expect(
-      isWrapperSessionReadyErrorResponse({ error: 'WORKSPACE_SETUP_FAILED', message: 'old' })
-    ).toBe(true);
-    expect(
-      isWrapperSessionReadyErrorResponse({
-        error: 'WORKSPACE_SETUP_FAILED',
-        subtype: 'not_allowed',
-        message: 'bad',
-      })
-    ).toBe(false);
-    expect(
-      isWrapperSessionReadyErrorResponse({
-        error: 'WORKSPACE_SETUP_FAILED',
-        message: 'm'.repeat(4_097),
-      })
-    ).toBe(false);
-    expect(
-      isWrapperSessionReadyErrorResponse({
-        error: 'WORKSPACE_SETUP_FAILED',
-        message: 'bounded',
-        detail: 'd'.repeat(8_193),
-      })
-    ).toBe(false);
-    expect(
-      isWrapperSessionReadyErrorResponse({
-        error: 'WORKSPACE_SETUP_FAILED',
-        message: 'bounded',
-        retryable: 'false',
-      })
-    ).toBe(false);
-    expect(
-      isWrapperSessionReadyErrorResponse({
-        error: 'WORKSPACE_SETUP_FAILED',
-        message: 'bounded',
-        wrapperRunId: 42,
-      })
-    ).toBe(false);
     expect(fetchHandler).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- Move wrapper-ready error parsing into the worker-side Kilo client boundary.
- Keep the shared wrapper bootstrap module free of runtime `worker-utils` exports so the wrapper bundle does not pull in worker-only dependencies.
- Preserve parser validation coverage in a focused unit test.

## Verification

No manual verification was performed; this is a non-visual module-boundary change.

## Visual Changes

N/A

## Reviewer Notes

The wrapper bundle and Cloud Agent Next typecheck both complete successfully after separating the runtime parser.