### PR TITLE
chore(email): add auto-fix sunset notice script

### DIFF
--- a/apps/web/src/emails/AGENTS.md
+++ b/apps/web/src/emails/AGENTS.md
@@ -72,7 +72,7 @@ Every template must include this branding footer below the content table:
 | `balanceAlert.html` | `minimum_balance`, `organization_url`, `year` | `16` |
 | `autoTopUpFailed.html` | `reason`, `credits_url`, `year` | `17` |
 | `codeReviewDisabled.html` | `reason`, `recovery_url`, `recovery_label`, `year` | — |
-| `autoFixFeatureSunset.html` | `disable_date`, `github_app_url`, `contact_email`, `year` | — |
+| `autoFixFeatureSunset.html` | `disable_date`, `github_docs_url`, `contact_email`, `year` | — |
 | `ossInviteNewUser.html` | `tier_name`, `seats`, `seat_value`, `credits_section`, `accept_invite_url`, `integrations_url`, `code_reviews_url`, `year` | `18` |
 | `ossInviteExistingUser.html` | `tier_name`, `seats`, `seat_value`, `credits_section`, `organization_url`, `integrations_url`, `code_reviews_url`, `year` | `19` |
 | `ossExistingOrgProvisioned.html` | `tier_name`, `seats`, `seat_value`, `credits_section`, `organization_url`, `integrations_url`, `code_reviews_url`, `year` | `20` |

--- a/apps/web/src/emails/AGENTS.md
+++ b/apps/web/src/emails/AGENTS.md
@@ -72,6 +72,7 @@ Every template must include this branding footer below the content table:
 | `balanceAlert.html` | `minimum_balance`, `organization_url`, `year` | `16` |
 | `autoTopUpFailed.html` | `reason`, `credits_url`, `year` | `17` |
 | `codeReviewDisabled.html` | `reason`, `recovery_url`, `recovery_label`, `year` | — |
+| `autoFixFeatureSunset.html` | `disable_date`, `github_app_url`, `contact_email`, `year` | — |
 | `ossInviteNewUser.html` | `tier_name`, `seats`, `seat_value`, `credits_section`, `accept_invite_url`, `integrations_url`, `code_reviews_url`, `year` | `18` |
 | `ossInviteExistingUser.html` | `tier_name`, `seats`, `seat_value`, `credits_section`, `organization_url`, `integrations_url`, `code_reviews_url`, `year` | `19` |
 | `ossExistingOrgProvisioned.html` | `tier_name`, `seats`, `seat_value`, `credits_section`, `organization_url`, `integrations_url`, `code_reviews_url`, `year` | `20` |

--- a/apps/web/src/emails/autoFixFeatureSunset.html
+++ b/apps/web/src/emails/autoFixFeatureSunset.html
@@ -105,7 +105,7 @@
                             sans-serif;
                         "
                       >
-                        @kilocode fix this issue
+                        @kilocode-bot fix this issue
                       </p>
                       <p
                         style="
@@ -118,7 +118,7 @@
                             sans-serif;
                         "
                       >
-                        @kilocode please update this PR to handle the failing test
+                        @kilocode-bot please update this PR to handle the failing test
                       </p>
                     </td>
                   </tr>

--- a/apps/web/src/emails/autoFixFeatureSunset.html
+++ b/apps/web/src/emails/autoFixFeatureSunset.html
@@ -49,8 +49,9 @@
                       sans-serif;
                   "
                 >
-                  You're receiving this because you've used Kilo's auto-fix feature. We plan to
-                  disable auto-fix on <strong style="color: #1a1a1a">{{ disable_date }}</strong>.
+                  You're receiving this because you've used the Kilo Auto-Fix feature. We plan to
+                  disable the Kilo Auto-Fix feature on
+                  <strong style="color: #1a1a1a">{{ disable_date }}</strong>.
                 </p>
                 <p
                   style="
@@ -133,14 +134,15 @@
                       sans-serif;
                   "
                 >
-                  The main difference from auto-fix is that the bot only responds when mentioned
-                  right now, so it will not automatically pick up issues unless you tag it.
+                  The main difference from the Kilo Auto-Fix feature is that the bot only responds
+                  when mentioned right now, so it will not automatically pick up issues unless you
+                  tag it.
                 </p>
                 <table width="100%" cellpadding="0" cellspacing="0">
                   <tr>
                     <td align="center" style="padding: 10px 0 20px">
                       <a
-                        href="{{ github_app_url }}"
+                        href="{{ github_docs_url }}"
                         style="
                           display: inline-block;
                           padding: 10px 20px;
@@ -155,7 +157,7 @@
                             sans-serif;
                         "
                       >
-                        Install Kilo for GitHub
+                        Read the GitHub bot docs
                       </a>
                     </td>
                   </tr>

--- a/apps/web/src/emails/autoFixFeatureSunset.html
+++ b/apps/web/src/emails/autoFixFeatureSunset.html
@@ -1,0 +1,226 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Auto-Fix Feature Sunset</title>
+  </head>
+  <body
+    style="
+      margin: 0;
+      padding: 0;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
+    "
+  >
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
+      <tr>
+        <td align="center" style="padding: 40px 20px">
+          <table width="520" cellpadding="0" cellspacing="0">
+            <tr>
+              <td style="padding: 40px 40px 20px">
+                <h1
+                  style="
+                    margin: 0;
+                    font-size: 24px;
+                    font-weight: 700;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
+                  "
+                >
+                  Auto-Fix Feature Sunset
+                </h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 0 40px 30px">
+                <p
+                  style="
+                    margin: 0 0 16px;
+                    font-size: 14px;
+                    line-height: 20px;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
+                  "
+                >
+                  You're receiving this because you've used Kilo's auto-fix feature. We plan to
+                  disable auto-fix on <strong style="color: #1a1a1a">{{ disable_date }}</strong>.
+                </p>
+                <p
+                  style="
+                    margin: 0 0 16px;
+                    font-size: 14px;
+                    line-height: 20px;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
+                  "
+                >
+                  As a replacement, we've been working on the Kilo for GitHub bot. You can use it to
+                  fix issues by installing the GitHub app, then mentioning Kilo in a GitHub issue or
+                  pull request comment with the fix you'd like it to make.
+                </p>
+                <table
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="
+                    margin: 0 0 20px;
+                    background-color: #f6f6f4;
+                    border: 1px solid #ebebea;
+                    border-radius: 10px;
+                  "
+                >
+                  <tr>
+                    <td style="padding: 16px 18px">
+                      <p
+                        style="
+                          margin: 0 0 10px;
+                          font-size: 14px;
+                          line-height: 20px;
+                          color: #333;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
+                        "
+                      >
+                        Example comments:
+                      </p>
+                      <p
+                        style="
+                          margin: 0 0 8px;
+                          font-size: 13px;
+                          line-height: 19px;
+                          color: #555;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
+                        "
+                      >
+                        @kilocode fix this issue
+                      </p>
+                      <p
+                        style="
+                          margin: 0;
+                          font-size: 13px;
+                          line-height: 19px;
+                          color: #555;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
+                        "
+                      >
+                        @kilocode please update this PR to handle the failing test
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+                <p
+                  style="
+                    margin: 0 0 20px;
+                    font-size: 14px;
+                    line-height: 20px;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
+                  "
+                >
+                  The main difference from auto-fix is that the bot only responds when mentioned
+                  right now, so it will not automatically pick up issues unless you tag it.
+                </p>
+                <table width="100%" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td align="center" style="padding: 10px 0 20px">
+                      <a
+                        href="{{ github_app_url }}"
+                        style="
+                          display: inline-block;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
+                          text-decoration: none;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
+                        "
+                      >
+                        Install Kilo for GitHub
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+                <p
+                  style="
+                    margin: 0;
+                    font-size: 14px;
+                    line-height: 20px;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
+                  "
+                >
+                  If you have thoughts or concerns about the Kilo for GitHub bot, reply to this
+                  email or contact us at
+                  <a
+                    href="mailto:{{ contact_email }}"
+                    style="color: #1a1a1a; text-decoration: underline"
+                    >{{ contact_email }}</a
+                  >.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
+                <p
+                  style="
+                    margin: 20px 0 0;
+                    font-size: 14px;
+                    line-height: 20px;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
+                  "
+                >
+                  The Kilo Team
+                </p>
+              </td>
+            </tr>
+          </table>
+          <!-- Branding Footer -->
+          <table width="520" cellpadding="0" cellspacing="0">
+            <tr>
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
+                <p
+                  style="
+                    margin: 0;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
+                  "
+                >
+                  © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San
+                  Francisco, CA 94105, USA
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -18,6 +18,7 @@ export const subjects = {
   balanceAlert: 'Kilo: Low Balance Alert',
   autoTopUpFailed: 'Kilo: Auto Top-Up Failed',
   codeReviewDisabled: 'Action Required: Code Reviewer Disabled',
+  autoFixFeatureSunset: 'Kilo: Auto-Fix Feature Sunset',
   ossInviteNewUser: 'Kilo: OSS Sponsorship Offer',
   ossInviteExistingUser: 'Kilo: OSS Sponsorship Offer',
   ossExistingOrgProvisioned: 'Kilo: OSS Sponsorship Offer',
@@ -241,6 +242,18 @@ export async function sendCodeReviewDisabledEmail(
       reason: props.reason,
       recovery_url: props.recoveryUrl,
       recovery_label: props.recoveryLabel,
+    },
+  });
+}
+
+export async function sendAutoFixFeatureSunsetEmail(to: string): Promise<SendResult> {
+  return send({
+    to,
+    templateName: 'autoFixFeatureSunset',
+    templateVars: {
+      disable_date: 'June 17, 2026',
+      github_app_url: 'https://github.com/apps/kilo-code',
+      contact_email: 'hi@kilocode.ai',
     },
   });
 }

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -251,8 +251,8 @@ export async function sendAutoFixFeatureSunsetEmail(to: string): Promise<SendRes
     to,
     templateName: 'autoFixFeatureSunset',
     templateVars: {
-      disable_date: 'June 17, 2026',
-      github_app_url: 'https://github.com/apps/kilo-code',
+      disable_date: 'June 18, 2026',
+      github_docs_url: 'https://kilo.ai/docs/code-with-ai/platforms/github',
       contact_email: 'hi@kilocode.ai',
     },
   });

--- a/apps/web/src/scripts/send-auto-fix-feature-sunset-email.ts
+++ b/apps/web/src/scripts/send-auto-fix-feature-sunset-email.ts
@@ -1,0 +1,54 @@
+import { sendAutoFixFeatureSunsetEmail } from '@/lib/email';
+
+const recipients = [
+  // Add the 17 identified auto-fix users here before running with --send.
+] satisfies string[];
+
+async function main() {
+  const shouldSend = process.argv.includes('--send');
+
+  if (recipients.length === 0) {
+    console.error('No recipients configured. Add the auto-fix user emails to recipients first.');
+    process.exit(1);
+  }
+
+  const uniqueRecipients = Array.from(new Set(recipients));
+  if (uniqueRecipients.length !== recipients.length) {
+    console.error('Duplicate recipients found. Remove duplicates before sending.');
+    process.exit(1);
+  }
+
+  if (!shouldSend) {
+    console.log('Dry run. Pass --send to send the auto-fix feature sunset email.');
+    console.log(`Would send to ${uniqueRecipients.length} recipients:`);
+    for (const recipient of uniqueRecipients) console.log(`- ${recipient}`);
+    return;
+  }
+
+  console.log(`Sending auto-fix feature sunset email to ${uniqueRecipients.length} recipients.`);
+
+  const failedRecipients: string[] = [];
+  for (const recipient of uniqueRecipients) {
+    const result = await sendAutoFixFeatureSunsetEmail(recipient);
+    if (result.sent) {
+      console.log(`Sent: ${recipient}`);
+      continue;
+    }
+
+    failedRecipients.push(`${recipient} (${result.reason})`);
+    console.error(`Failed: ${recipient} (${result.reason})`);
+  }
+
+  if (failedRecipients.length > 0) {
+    console.error('Some recipients failed:');
+    for (const recipient of failedRecipients) console.error(`- ${recipient}`);
+    process.exit(1);
+  }
+
+  console.log('All emails sent.');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/web/src/scripts/send-auto-fix-feature-sunset-email.ts
+++ b/apps/web/src/scripts/send-auto-fix-feature-sunset-email.ts
@@ -1,42 +1,129 @@
-import { sendAutoFixFeatureSunsetEmail } from '@/lib/email';
+import fs from 'fs';
+import path from 'path';
+import Mailgun from 'mailgun.js';
+import FormData from 'form-data';
+
+const templateVars = {
+  disable_date: 'June 18, 2026',
+  github_docs_url: 'https://kilo.ai/docs/code-with-ai/platforms/github',
+  contact_email: 'hi@kilocode.ai',
+  year: String(new Date().getFullYear()),
+} satisfies Record<string, string>;
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function renderTemplate(name: string, vars: Record<string, string>): string {
+  const templatePath = path.join(process.cwd(), 'src', 'emails', `${name}.html`);
+  const html = fs.readFileSync(templatePath, 'utf-8');
+
+  return html.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key: string) => {
+    const value = vars[key];
+    if (value === undefined) throw new Error(`Missing template variable '${key}'`);
+    return escapeHtml(value);
+  });
+}
+
+async function sendAutoFixFeatureSunsetEmail(to: string): Promise<void> {
+  const { MAILGUN_API_KEY, MAILGUN_DOMAIN } = process.env;
+  if (!MAILGUN_API_KEY || !MAILGUN_DOMAIN) {
+    throw new Error('MAILGUN_API_KEY/MAILGUN_DOMAIN not configured');
+  }
+
+  const mailgun = new Mailgun(FormData);
+  const client = mailgun.client({ username: 'api', key: MAILGUN_API_KEY });
+  await client.messages.create(MAILGUN_DOMAIN, {
+    from: 'Kilo Code <hi@app.kilocode.ai>',
+    'h:Reply-To': 'hi@kilocode.ai',
+    to,
+    subject: 'Kilo: Auto-Fix Feature Sunset',
+    html: renderTemplate('autoFixFeatureSunset', templateVars),
+  });
+}
+
+function getTestRecipient(): string | undefined {
+  const testFlagIndex = process.argv.indexOf('--test');
+  if (testFlagIndex === -1) return undefined;
+
+  const recipient = process.argv[testFlagIndex + 1];
+  if (!recipient || recipient.startsWith('--')) {
+    console.error(
+      'Usage: pnpm exec tsx src/scripts/send-auto-fix-feature-sunset-email.ts --test <email>'
+    );
+    process.exit(1);
+  }
+
+  return recipient;
+}
 
 const recipients = [
+  'remon@kilocode.ai',
+  'kimptoc@gmail.com',
+  'dutch2005@gmail.com',
+  'gemejl1337@gmail.com',
+  'pmaclyman@gmail.com',
+  'mutdashboard@gmail.com',
+  'petr.plenkov@gmail.com',
+  'arthursrodrigues@gmail.com',
+  'beowulf4756@gmail.com',
+  'vivetbilab@gmail.com',
+  'tomkristian.abel@tomabel.ee',
+  'thomas.brugman.teb3@gmail.com',
+  'sylvain.gavel@gmail.com',
+  'kilo@talk2machines.com',
+  'thompson.trent@gmail.com',
+  'billlzzz19@gmail.com',
+  'romanfinal@proton.me',
+  'github@mail.vkvikram.com',
   // Add the 17 identified auto-fix users here before running with --send.
 ] satisfies string[];
 
 async function main() {
   const shouldSend = process.argv.includes('--send');
+  const testRecipient = getTestRecipient();
+  const targetRecipients = testRecipient ? [testRecipient] : recipients;
 
-  if (recipients.length === 0) {
+  if (targetRecipients.length === 0) {
     console.error('No recipients configured. Add the auto-fix user emails to recipients first.');
     process.exit(1);
   }
 
-  const uniqueRecipients = Array.from(new Set(recipients));
-  if (uniqueRecipients.length !== recipients.length) {
+  const uniqueRecipients = Array.from(new Set(targetRecipients));
+  if (uniqueRecipients.length !== targetRecipients.length) {
     console.error('Duplicate recipients found. Remove duplicates before sending.');
     process.exit(1);
   }
 
-  if (!shouldSend) {
+  if (!shouldSend && !testRecipient) {
     console.log('Dry run. Pass --send to send the auto-fix feature sunset email.');
+    console.log('Pass --test <email> to send a single test email.');
     console.log(`Would send to ${uniqueRecipients.length} recipients:`);
     for (const recipient of uniqueRecipients) console.log(`- ${recipient}`);
     return;
   }
 
-  console.log(`Sending auto-fix feature sunset email to ${uniqueRecipients.length} recipients.`);
+  console.log(
+    testRecipient
+      ? `Sending test auto-fix feature sunset email to ${testRecipient}.`
+      : `Sending auto-fix feature sunset email to ${uniqueRecipients.length} recipients.`
+  );
 
   const failedRecipients: string[] = [];
   for (const recipient of uniqueRecipients) {
-    const result = await sendAutoFixFeatureSunsetEmail(recipient);
-    if (result.sent) {
+    try {
+      await sendAutoFixFeatureSunsetEmail(recipient);
       console.log(`Sent: ${recipient}`);
-      continue;
+    } catch (error) {
+      failedRecipients.push(recipient);
+      console.error(`Failed: ${recipient}`);
+      console.error(error);
     }
-
-    failedRecipients.push(`${recipient} (${result.reason})`);
-    console.error(`Failed: ${recipient} (${result.reason})`);
   }
 
   if (failedRecipients.length > 0) {


### PR DESCRIPTION
## Summary
- Add a one-time auto-fix sunset email template and sender helper.
- Add a dry-run-first script for notifying identified auto-fix users about the June 17, 2026 sunset and the Kilo for GitHub replacement flow.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
The script intentionally has an empty recipient list and requires `--send` so recipients must be added deliberately before any email is sent.