### PR TITLE
Cloud Agent - Export ContainerProxy From Worker

### DIFF
--- a/services/cloud-agent-next/src/index.ts
+++ b/services/cloud-agent-next/src/index.ts
@@ -1,4 +1,9 @@
 export { default } from './server.js';
-export { Sandbox, Sandbox as SandboxSmall, Sandbox as SandboxDIND } from '@cloudflare/sandbox';
+export {
+  ContainerProxy,
+  Sandbox,
+  Sandbox as SandboxSmall,
+  Sandbox as SandboxDIND,
+} from '@cloudflare/sandbox';
 export { CloudAgentSession } from './persistence/CloudAgentSession.js';
 export { UserKiloFacade } from './kilo-facade/user-kilo-facade.js';


### PR DESCRIPTION
## Summary

Export `ContainerProxy` from the Cloud Agent Worker entrypoint so Cloudflare Sandbox container startup can resolve the required proxy class.

## Verification

N/A — export-only change.

## Visual Changes

N/A

## Reviewer Notes

The export intentionally comes from `@cloudflare/sandbox` to preserve Sandbox-specific proxy behavior.