### PR TITLE
feat(ai-gateway): add nex-n2-pro:free to autoFreeModels routing pool

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -47,7 +47,7 @@ export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 
 export const autoFreeModels = [
   'poolside/laguna-m.1:free',
-  'nex-n2-pro:free',
+  'nex-agi/nex-n2-pro:free',
   stepfun_37_flash_free_model.status === 'public' ? stepfun_37_flash_free_model.public_id : null,
 ].filter(m => m !== null);
 

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -47,6 +47,7 @@ export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 
 export const autoFreeModels = [
   'poolside/laguna-m.1:free',
+  'nex-n2-pro:free',
   stepfun_37_flash_free_model.status === 'public' ? stepfun_37_flash_free_model.public_id : null,
 ].filter(m => m !== null);
 


### PR DESCRIPTION
## Summary

- Adds `nex-n2-pro:free` to the `autoFreeModels` array in `apps/web/src/lib/ai-gateway/models.ts`, making it a candidate for `kilo-auto/free` routing.
- The model follows the same `:free` OpenRouter suffix convention as the existing `poolside/laguna-m.1:free` entry, so the existing `getAutoFreeCandidates` runtime filtering (checking the live OpenRouter models cache) will handle it automatically.

## Verification

- Verify that `nex-n2-pro:free` is available in the OpenRouter models cache in the target environment — if it is, requests routed via `kilo-auto/free` will be able to select it.

## Visual Changes

N/A

## Reviewer Notes

N/A

---

Built for [Christiaan Arnoldus](https://kilo-code.slack.com/archives/C0AATMLRMB9/p1781184293865149?thread_ts=1781097129.323079&cid=C0AATMLRMB9) by [Kilo for Slack](https://kilo.ai/slack)