### PR TITLE
ci(deploy): call worker deploy from production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -165,7 +165,7 @@ jobs:
         run: vercel promote "${{ needs.stage-global-app.outputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_TOKEN }}
 
   deploy-workers:
-    needs: [check-production-db-startup, run-migrations]
+    needs: [promote-app]
     uses: ./.github/workflows/deploy-workers.yml
     with:
       base_sha: ${{ github.event.before }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -164,6 +164,13 @@ jobs:
       - name: Promote Vercel deployment
         run: vercel promote "${{ needs.stage-global-app.outputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_TOKEN }}
 
+  deploy-workers:
+    needs: [check-production-db-startup, run-migrations]
+    uses: ./.github/workflows/deploy-workers.yml
+    with:
+      base_sha: ${{ github.event.before }}
+    secrets: inherit
+
   deploy-kiloclaw:
     needs: [check-production-db-startup, run-migrations]
     # Ceiling for the reusable workflow's GITHUB_TOKEN (a called workflow cannot

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -165,7 +165,25 @@ jobs:
         run: vercel promote "${{ needs.stage-global-app.outputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_TOKEN }}
 
   deploy-workers:
-    needs: [promote-app]
+    needs:
+      [
+        check-production-db-startup,
+        run-migrations,
+        stage-app,
+        stage-global-app,
+        promote-app,
+        promote-global-app,
+      ]
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.check-production-db-startup.result == 'success' &&
+        needs.run-migrations.result == 'success' &&
+        contains(fromJSON('["success","skipped"]'), needs.stage-app.result) &&
+        contains(fromJSON('["success","skipped"]'), needs.stage-global-app.result) &&
+        contains(fromJSON('["success","skipped"]'), needs.promote-app.result) &&
+        contains(fromJSON('["success","skipped"]'), needs.promote-global-app.result)
+      }}
     uses: ./.github/workflows/deploy-workers.yml
     with:
       base_sha: ${{ github.event.before }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: deploy-production
@@ -164,11 +165,39 @@ jobs:
       - name: Promote Vercel deployment
         run: vercel promote "${{ needs.stage-global-app.outputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_TOKEN }}
 
+  resolve-worker-base:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    outputs:
+      base_sha: ${{ steps.base.outputs.sha }}
+
+    steps:
+      - name: Resolve last successful production SHA
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha=$(gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow deploy-production.yml \
+            --branch main \
+            --status success \
+            --json headSha \
+            --limit 1 \
+            --jq '.[0].headSha')
+
+          if [ -z "$sha" ] || [ "$sha" = "null" ]; then
+            sha="${{ github.event.before }}"
+          fi
+
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
   deploy-workers:
     needs:
       [
         check-production-db-startup,
         run-migrations,
+        resolve-worker-base,
         stage-app,
         stage-global-app,
         promote-app,
@@ -179,6 +208,7 @@ jobs:
         !cancelled() &&
         needs.check-production-db-startup.result == 'success' &&
         needs.run-migrations.result == 'success' &&
+        needs.resolve-worker-base.result == 'success' &&
         contains(fromJSON('["success","skipped"]'), needs.stage-app.result) &&
         contains(fromJSON('["success","skipped"]'), needs.stage-global-app.result) &&
         contains(fromJSON('["success","skipped"]'), needs.promote-app.result) &&
@@ -186,7 +216,7 @@ jobs:
       }}
     uses: ./.github/workflows/deploy-workers.yml
     with:
-      base_sha: ${{ github.event.before }}
+      base_sha: ${{ needs.resolve-worker-base.outputs.base_sha }}
     secrets: inherit
 
   deploy-kiloclaw:

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-workers
+  cancel-in-progress: false
+
 jobs:
   deploy-manual:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -1,24 +1,23 @@
 name: Deploy Cloudflare Workers
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       worker:
         description: 'Worker folder to deploy (e.g. services/app-builder)'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      base_sha:
+        description: 'Base SHA to diff against when detecting changed workers'
+        required: true
+        type: string
 
 permissions:
   contents: read
 
-concurrency:
-  group: deploy-workers-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
-  # ── Manual dispatch: deploy a single specified worker ──────────────────────
   deploy-manual:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
@@ -48,9 +47,8 @@ jobs:
           workingDirectory: ${{ inputs.worker }}
           command: deploy
 
-  # ── Push to main: detect changed workers, deploy each one ─────────────────
   detect-changes:
-    if: github.event_name == 'push'
+    if: github.event_name == 'workflow_call'
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 5
     outputs:
@@ -70,7 +68,7 @@ jobs:
           # Diff against the SHA before the push so that multi-commit pushes
           # (e.g. a merge commit that squashes several commits) don't miss workers
           # that were only touched in earlier commits of the same push.
-          BASE_SHA="${{ github.event.before }}"
+          BASE_SHA="${{ inputs.base_sha }}"
 
           # Workers excluded from this workflow (they have custom deploy pipelines):
           EXCLUDED=(

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -48,7 +48,7 @@ jobs:
           command: deploy
 
   detect-changes:
-    if: github.event_name == 'workflow_call'
+    if: inputs.base_sha != ''
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
## Summary
- Convert the Cloudflare Workers deploy workflow into a reusable workflow while keeping manual single-worker dispatch.
- Call the worker deploy from the production deployment workflow after the production DB startup check and migrations, matching the KiloClaw reusable workflow pattern.

## Verification
- Confirmed the production workflow now invokes the worker deployment after the shared production DB gate.
- Confirmed manual worker dispatch remains available in the worker workflow.

## Visual Changes
N/A

## Reviewer Notes
- The standalone `push` trigger was removed from `deploy-workers.yml`; main-branch worker deployments now run through `deploy-production.yml`.