### PR TITLE
Eliminate console warnings in fixResponsesRequest

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -195,11 +195,9 @@ export function fixResponsesRequest(request: GatewayResponsesRequest) {
       continue;
     }
     if (!outputMsg.type) {
-      console.warn('[fixResponsesRequest] assistant message missing type, fixing');
       outputMsg.type = 'message';
     }
     if (!outputMsg.status) {
-      console.warn('[fixResponsesRequest] assistant message missing status, fixing');
       outputMsg.status = 'completed';
     }
   }


### PR DESCRIPTION
Remove console warnings for missing type and status in assistant messages.
