### PR TITLE
Cloud Agent Next - Adjust sandbox capacity and observability

### DIFF
--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -27,7 +27,7 @@
       "invocation_logs": true,
     },
     "traces": {
-      "enabled": true,
+      "enabled": false,
       "persist": true,
       "head_sampling_rate": 1,
     },

--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -148,17 +148,17 @@
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.21",
       },
-      "max_instances": 250,
+      "max_instances": 400,
       "rollout_active_grace_period": 1800,
     },
     {
       "class_name": "SandboxSmall",
       "image": "./Dockerfile",
-      "instance_type": "standard-3",
+      "instance_type": "standard-4",
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.21",
       },
-      "max_instances": 200,
+      "max_instances": 300,
       "rollout_active_grace_period": 1800,
     },
     {
@@ -335,7 +335,7 @@
         {
           "class_name": "SandboxSmall",
           "image": "./Dockerfile.dev",
-          "instance_type": "standard-3",
+          "instance_type": "standard-4",
           "image_vars": {
             "KILOCODE_CLI_VERSION": "7.3.21",
           },


### PR DESCRIPTION
## Summary

- Increase the shared sandbox limit from 250 to 400 instances.
- Increase the small sandbox limit from 200 to 300 instances and move it to `standard-4` in production and development.
- Disable Cloudflare Worker traces while retaining logs.

## Verification

- Not manually tested; these are Cloudflare configuration-only changes.

## Visual Changes

N/A

## Reviewer Notes

Review the increased Cloudflare capacity and `standard-4` resource allocation for cost and quota impact.