### PR TITLE
feat(organizations): add gated organization mode defaults

### DIFF
--- a/apps/web/src/app/api/openrouter/hooks.ts
+++ b/apps/web/src/app/api/openrouter/hooks.ts
@@ -100,9 +100,10 @@ export function useOpenRouterProviders() {
   });
 }
 
-export function useModelSelectorList(organizationId: string | undefined) {
+export function useModelSelectorList(organizationId: string | undefined, enabled = true) {
   const query = useQuery({
     queryKey: ['openrouter-models', organizationId],
+    enabled,
     queryFn: async (): Promise<OpenRouterModelsResponse> => {
       const response = await fetch(
         organizationId ? `/api/organizations/${organizationId}/models` : '/api/openrouter/models'

--- a/apps/web/src/app/api/organizations/[id]/modes/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/modes/route.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from '@jest/globals';
+import { NextRequest, NextResponse } from 'next/server';
+import { GET } from './route';
+import { getAuthorizedOrgContext } from '@/lib/organizations/organization-auth';
+import { getAllOrganizationModes } from '@/lib/organizations/organization-modes';
+
+jest.mock('@/lib/organizations/organization-auth');
+jest.mock('@/lib/organizations/organization-modes');
+
+const mockedGetAuthorizedOrgContext = jest.mocked(getAuthorizedOrgContext);
+const mockedGetAllOrganizationModes = jest.mocked(getAllOrganizationModes);
+
+describe('GET /api/organizations/[id]/modes', () => {
+  test('returns defaultModel as part of the additive mode payload', async () => {
+    mockedGetAuthorizedOrgContext.mockResolvedValue({
+      success: true,
+      data: {
+        organization: { id: 'org-1' },
+      },
+    } as never);
+    mockedGetAllOrganizationModes.mockResolvedValue([
+      {
+        id: 'mode-1',
+        organization_id: 'org-1',
+        name: 'Code',
+        slug: 'code',
+        created_by: 'user-1',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          groups: ['read'],
+          defaultModel: 'openai/gpt-4o',
+        },
+      },
+    ]);
+
+    const response = await GET(new NextRequest('http://localhost:3000'), {
+      params: Promise.resolve({ id: 'org-1' }),
+    });
+
+    expect(response).toBeInstanceOf(NextResponse);
+    await expect(response.json()).resolves.toEqual({
+      modes: [
+        {
+          id: 'mode-1',
+          organization_id: 'org-1',
+          name: 'Code',
+          slug: 'code',
+          created_by: 'user-1',
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+          config: {
+            roleDefinition: 'You are a coding assistant',
+            groups: ['read'],
+            defaultModel: 'openai/gpt-4o',
+          },
+        },
+      ],
+    });
+    expect(mockedGetAllOrganizationModes).toHaveBeenCalledWith('org-1');
+  });
+
+  test('returns a legacy mode row without defaultModel unchanged', async () => {
+    mockedGetAuthorizedOrgContext.mockResolvedValue({
+      success: true,
+      data: {
+        organization: { id: 'org-1' },
+      },
+    } as never);
+    mockedGetAllOrganizationModes.mockResolvedValue([
+      {
+        id: 'mode-1',
+        organization_id: 'org-1',
+        name: 'Code',
+        slug: 'code',
+        created_by: 'user-1',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          groups: ['read'],
+        },
+      },
+    ]);
+
+    const response = await GET(new NextRequest('http://localhost:3000'), {
+      params: Promise.resolve({ id: 'org-1' }),
+    });
+
+    await expect(response.json()).resolves.toEqual({
+      modes: [
+        {
+          id: 'mode-1',
+          organization_id: 'org-1',
+          name: 'Code',
+          slug: 'code',
+          created_by: 'user-1',
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+          config: {
+            roleDefinition: 'You are a coding assistant',
+            groups: ['read'],
+          },
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/src/components/organizations/custom-modes/CustomModesLayout.tsx
+++ b/apps/web/src/components/organizations/custom-modes/CustomModesLayout.tsx
@@ -27,6 +27,7 @@ import { ModeDrawer } from './ModeDrawer';
 import { NewModeForm } from './NewModeForm';
 import { EditModeForm } from './EditModeForm';
 import { useOrganizationReadOnly } from '@/lib/organizations/use-organization-read-only';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
 
 type CustomModesLayoutProps = {
   organizationId: string;
@@ -43,9 +44,16 @@ type ModesListProps = {
   readonly: boolean;
   onDeleteClick: (mode: DisplayMode) => void;
   onEditClick: (mode: DisplayMode) => void;
+  isDefaultModelConfigEnabled: boolean;
 };
 
-function ModesList({ modes, readonly, onDeleteClick, onEditClick }: ModesListProps) {
+function ModesList({
+  modes,
+  readonly,
+  onDeleteClick,
+  onEditClick,
+  isDefaultModelConfigEnabled,
+}: ModesListProps) {
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
       {modes.map((mode, index) => (
@@ -99,7 +107,15 @@ function ModesList({ modes, readonly, onDeleteClick, onEditClick }: ModesListPro
               </div>
             </CardHeader>
             <CardContent className="flex-1">
-              <div className="flex h-full flex-col">
+              <div className="flex h-full flex-col gap-4">
+                {isDefaultModelConfigEnabled && mode.config.defaultModel && (
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-muted-foreground text-xs font-medium">Default model</span>
+                    <Badge variant="secondary" className="max-w-full font-mono text-xs">
+                      <span className="break-all">{mode.config.defaultModel}</span>
+                    </Badge>
+                  </div>
+                )}
                 {mode.config?.groups && mode.config.groups.length > 0 && (
                   <div className="flex-1">
                     <h4 className="mb-2 text-sm font-medium">Available Tools</h4>
@@ -153,7 +169,9 @@ export function CustomModesLayout({ organizationId }: CustomModesLayoutProps) {
   const [drawerMode, setDrawerMode] = useState<'create' | 'edit'>('create');
   const [editingMode, setEditingMode] = useState<DisplayMode | null>(null);
   const isReadOnly = useOrganizationReadOnly(organizationId);
-
+  const isDefaultModelFeatureEnabled = useFeatureFlagEnabled('org-default-model-config');
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  const isDefaultModelConfigEnabled = isDevelopment || isDefaultModelFeatureEnabled === true;
   const readonly = isReadOnly;
 
   // Separate built-in modes and custom modes
@@ -297,6 +315,7 @@ export function CustomModesLayout({ organizationId }: CustomModesLayoutProps) {
               readonly={readonly}
               onDeleteClick={openDeleteDialog}
               onEditClick={handleEditMode}
+              isDefaultModelConfigEnabled={isDefaultModelConfigEnabled}
             />
           </div>
 
@@ -310,6 +329,7 @@ export function CustomModesLayout({ organizationId }: CustomModesLayoutProps) {
                 readonly={readonly}
                 onDeleteClick={openDeleteDialog}
                 onEditClick={handleEditMode}
+                isDefaultModelConfigEnabled={isDefaultModelConfigEnabled}
               />
             </div>
           )}
@@ -383,6 +403,7 @@ export function CustomModesLayout({ organizationId }: CustomModesLayoutProps) {
               defaultModeSlug={
                 editingMode?.isDefault && !editingMode?.isOverridden ? editingMode.slug : undefined
               }
+              isDefaultModelConfigEnabled={isDefaultModelConfigEnabled}
               onSuccess={handleDrawerClose}
               onCancel={handleDrawerClose}
             />
@@ -390,6 +411,8 @@ export function CustomModesLayout({ organizationId }: CustomModesLayoutProps) {
             <EditModeForm
               organizationId={organizationId}
               modeId={editingMode.id}
+              defaultModeSlug={editingMode.isDefault ? editingMode.slug : undefined}
+              isDefaultModelConfigEnabled={isDefaultModelConfigEnabled}
               onSuccess={handleDrawerClose}
               onCancel={handleDrawerClose}
             />

--- a/apps/web/src/components/organizations/custom-modes/CustomModesLayout.tsx
+++ b/apps/web/src/components/organizations/custom-modes/CustomModesLayout.tsx
@@ -2,7 +2,11 @@
 
 import { useState, useMemo } from 'react';
 import { motion } from 'motion/react';
-import { useOrganizationModes, useDeleteOrganizationMode } from '@/app/api/organizations/hooks';
+import {
+  useOrganizationModes,
+  useDeleteOrganizationMode,
+  useOrganizationWithMembers,
+} from '@/app/api/organizations/hooks';
 import { Button } from '@/components/ui/button';
 import { LockableContainer } from '../LockableContainer';
 import { Badge } from '@/components/ui/badge';
@@ -162,6 +166,7 @@ function ModesList({
 
 export function CustomModesLayout({ organizationId }: CustomModesLayoutProps) {
   const { data, isLoading, error } = useOrganizationModes(organizationId);
+  const { data: organizationData } = useOrganizationWithMembers(organizationId);
   const deleteMutation = useDeleteOrganizationMode();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [modeToDelete, setModeToDelete] = useState<DisplayMode | null>(null);
@@ -172,6 +177,7 @@ export function CustomModesLayout({ organizationId }: CustomModesLayoutProps) {
   const isDefaultModelFeatureEnabled = useFeatureFlagEnabled('org-default-model-config');
   const isDevelopment = process.env.NODE_ENV === 'development';
   const isDefaultModelConfigEnabled = isDevelopment || isDefaultModelFeatureEnabled === true;
+  const canSetDefaultModel = organizationData?.plan === 'enterprise';
   const readonly = isReadOnly;
 
   // Separate built-in modes and custom modes
@@ -404,6 +410,7 @@ export function CustomModesLayout({ organizationId }: CustomModesLayoutProps) {
                 editingMode?.isDefault && !editingMode?.isOverridden ? editingMode.slug : undefined
               }
               isDefaultModelConfigEnabled={isDefaultModelConfigEnabled}
+              canSetDefaultModel={canSetDefaultModel}
               onSuccess={handleDrawerClose}
               onCancel={handleDrawerClose}
             />
@@ -413,6 +420,7 @@ export function CustomModesLayout({ organizationId }: CustomModesLayoutProps) {
               modeId={editingMode.id}
               defaultModeSlug={editingMode.isDefault ? editingMode.slug : undefined}
               isDefaultModelConfigEnabled={isDefaultModelConfigEnabled}
+              canSetDefaultModel={canSetDefaultModel}
               onSuccess={handleDrawerClose}
               onCancel={handleDrawerClose}
             />

--- a/apps/web/src/components/organizations/custom-modes/EditModeForm.test.ts
+++ b/apps/web/src/components/organizations/custom-modes/EditModeForm.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from '@jest/globals';
+import { matchesBuiltInModeState } from './EditModeForm';
+import { DEFAULT_MODES } from './default-modes';
+import type { ModeFormData } from './ModeForm';
+
+function codeModeForm(overrides: Partial<ModeFormData> = {}): ModeFormData {
+  const codeMode = DEFAULT_MODES.find(mode => mode.slug === 'code')!;
+
+  return {
+    name: codeMode.name,
+    slug: codeMode.slug,
+    roleDefinition: codeMode.config.roleDefinition || '',
+    description: codeMode.config.description || '',
+    whenToUse: codeMode.config.whenToUse || '',
+    groups: [...(codeMode.config.groups || [])],
+    customInstructions: codeMode.config.customInstructions || '',
+    ...overrides,
+  };
+}
+
+describe('matchesBuiltInModeState', () => {
+  test('returns true for a built-in mode state with reordered groups', () => {
+    const formData = codeModeForm({ groups: [...codeModeForm().groups].reverse() });
+
+    expect(matchesBuiltInModeState(formData, 'code')).toBe(true);
+  });
+
+  test('returns false when another customization remains', () => {
+    const formData = codeModeForm({ description: 'Customized description' });
+
+    expect(matchesBuiltInModeState(formData, 'code')).toBe(false);
+  });
+
+  test('returns false when the mode name was changed', () => {
+    const formData = codeModeForm({ name: 'Renamed Code' });
+
+    expect(matchesBuiltInModeState(formData, 'code')).toBe(false);
+  });
+});

--- a/apps/web/src/components/organizations/custom-modes/EditModeForm.tsx
+++ b/apps/web/src/components/organizations/custom-modes/EditModeForm.tsx
@@ -4,26 +4,79 @@ import {
   useOrganizationModeById,
   useUpdateOrganizationMode,
   useOrganizationModes,
+  useDeleteOrganizationMode,
 } from '@/app/api/organizations/hooks';
 import { ModeForm, type ModeFormData } from './ModeForm';
 import { LoadingCard } from '@/components/LoadingCard';
 import { ErrorCard } from '@/components/ErrorCard';
 import { toast } from 'sonner';
+import { DEFAULT_MODES } from './default-modes';
 
 type EditModeFormProps = {
   organizationId: string;
   modeId: string;
+  defaultModeSlug?: string;
+  isDefaultModelConfigEnabled?: boolean;
   onSuccess?: () => void;
   onCancel?: () => void;
 };
 
-export function EditModeForm({ organizationId, modeId, onSuccess, onCancel }: EditModeFormProps) {
+function normalizeOptionalValue(value: string | undefined): string | undefined {
+  return value || undefined;
+}
+
+function matchesBuiltInModeState(formData: ModeFormData, defaultModeSlug: string): boolean {
+  const defaultMode = DEFAULT_MODES.find(mode => mode.slug === defaultModeSlug);
+  if (!defaultMode) {
+    return false;
+  }
+
+  return (
+    formData.name === defaultMode.name &&
+    formData.slug === defaultMode.slug &&
+    formData.roleDefinition === defaultMode.config.roleDefinition &&
+    normalizeOptionalValue(formData.description) === defaultMode.config.description &&
+    normalizeOptionalValue(formData.whenToUse) === defaultMode.config.whenToUse &&
+    JSON.stringify(formData.groups) === JSON.stringify(defaultMode.config.groups) &&
+    normalizeOptionalValue(formData.customInstructions) === defaultMode.config.customInstructions
+  );
+}
+
+export function EditModeForm({
+  organizationId,
+  modeId,
+  defaultModeSlug,
+  isDefaultModelConfigEnabled = false,
+  onSuccess,
+  onCancel,
+}: EditModeFormProps) {
   const { data, isLoading, error } = useOrganizationModeById(organizationId, modeId);
   const { data: modesData } = useOrganizationModes(organizationId);
   const updateMutation = useUpdateOrganizationMode();
+  const deleteMutation = useDeleteOrganizationMode();
 
   const handleSubmit = async (formData: ModeFormData) => {
     try {
+      if (
+        defaultModeSlug &&
+        !formData.defaultModel &&
+        matchesBuiltInModeState(formData, defaultModeSlug)
+      ) {
+        await deleteMutation.mutateAsync({
+          organizationId,
+          modeId,
+        });
+        toast.success(`Mode "${formData.name}" reverted successfully`);
+        onSuccess?.();
+        return;
+      }
+
+      const persistedDefaultModel = data?.mode?.config.defaultModel ?? '';
+      const defaultModelUpdate =
+        formData.defaultModel === persistedDefaultModel
+          ? {}
+          : { defaultModel: formData.defaultModel || null };
+
       await updateMutation.mutateAsync({
         organizationId,
         modeId,
@@ -35,6 +88,7 @@ export function EditModeForm({ organizationId, modeId, onSuccess, onCancel }: Ed
           whenToUse: formData.whenToUse,
           groups: formData.groups as ('read' | 'edit' | 'browser' | 'command' | 'mcp')[],
           customInstructions: formData.customInstructions,
+          ...defaultModelUpdate,
         },
       });
       toast.success(`Mode "${formData.name}" updated successfully`);
@@ -63,9 +117,12 @@ export function EditModeForm({ organizationId, modeId, onSuccess, onCancel }: Ed
 
   return (
     <ModeForm
+      organizationId={organizationId}
       mode={data.mode}
       onSubmit={handleSubmit}
-      isSubmitting={updateMutation.isPending}
+      isSubmitting={updateMutation.isPending || deleteMutation.isPending}
+      isEditingBuiltIn={!!defaultModeSlug}
+      isDefaultModelConfigEnabled={isDefaultModelConfigEnabled}
       existingModes={modesData?.modes || []}
       onCancel={onCancel}
       renderButtons={() => null}

--- a/apps/web/src/components/organizations/custom-modes/EditModeForm.tsx
+++ b/apps/web/src/components/organizations/custom-modes/EditModeForm.tsx
@@ -25,6 +25,14 @@ function normalizeOptionalValue(value: string | undefined): string | undefined {
   return value || undefined;
 }
 
+function normalizeGroups(groups: unknown): string[] | undefined {
+  if (!Array.isArray(groups)) {
+    return undefined;
+  }
+
+  return groups.map(group => JSON.stringify(group)).sort();
+}
+
 function matchesBuiltInModeState(formData: ModeFormData, defaultModeSlug: string): boolean {
   const defaultMode = DEFAULT_MODES.find(mode => mode.slug === defaultModeSlug);
   if (!defaultMode) {
@@ -37,7 +45,8 @@ function matchesBuiltInModeState(formData: ModeFormData, defaultModeSlug: string
     formData.roleDefinition === defaultMode.config.roleDefinition &&
     normalizeOptionalValue(formData.description) === defaultMode.config.description &&
     normalizeOptionalValue(formData.whenToUse) === defaultMode.config.whenToUse &&
-    JSON.stringify(formData.groups) === JSON.stringify(defaultMode.config.groups) &&
+    JSON.stringify(normalizeGroups(formData.groups)) ===
+      JSON.stringify(normalizeGroups(defaultMode.config.groups)) &&
     normalizeOptionalValue(formData.customInstructions) === defaultMode.config.customInstructions
   );
 }

--- a/apps/web/src/components/organizations/custom-modes/EditModeForm.tsx
+++ b/apps/web/src/components/organizations/custom-modes/EditModeForm.tsx
@@ -17,6 +17,7 @@ type EditModeFormProps = {
   modeId: string;
   defaultModeSlug?: string;
   isDefaultModelConfigEnabled?: boolean;
+  canSetDefaultModel?: boolean;
   onSuccess?: () => void;
   onCancel?: () => void;
 };
@@ -33,7 +34,7 @@ function normalizeGroups(groups: unknown): string[] | undefined {
   return groups.map(group => JSON.stringify(group)).sort();
 }
 
-function matchesBuiltInModeState(formData: ModeFormData, defaultModeSlug: string): boolean {
+export function matchesBuiltInModeState(formData: ModeFormData, defaultModeSlug: string): boolean {
   const defaultMode = DEFAULT_MODES.find(mode => mode.slug === defaultModeSlug);
   if (!defaultMode) {
     return false;
@@ -56,6 +57,7 @@ export function EditModeForm({
   modeId,
   defaultModeSlug,
   isDefaultModelConfigEnabled = false,
+  canSetDefaultModel = true,
   onSuccess,
   onCancel,
 }: EditModeFormProps) {
@@ -132,6 +134,7 @@ export function EditModeForm({
       isSubmitting={updateMutation.isPending || deleteMutation.isPending}
       isEditingBuiltIn={!!defaultModeSlug}
       isDefaultModelConfigEnabled={isDefaultModelConfigEnabled}
+      canSetDefaultModel={canSetDefaultModel}
       existingModes={modesData?.modes || []}
       onCancel={onCancel}
       renderButtons={() => null}

--- a/apps/web/src/components/organizations/custom-modes/ModeForm.tsx
+++ b/apps/web/src/components/organizations/custom-modes/ModeForm.tsx
@@ -58,6 +58,7 @@ type ModeFormProps = {
   isSubmitting: boolean;
   isEditingBuiltIn?: boolean;
   isDefaultModelConfigEnabled?: boolean;
+  canSetDefaultModel?: boolean;
   existingModes?: OrganizationMode[];
   onCancel?: () => void;
   renderButtons?: (props: { isDirty: boolean; isSubmitting: boolean }) => React.ReactNode;
@@ -103,6 +104,7 @@ export function ModeForm({
   isSubmitting,
   isEditingBuiltIn = false,
   isDefaultModelConfigEnabled = false,
+  canSetDefaultModel = true,
   existingModes = [],
   onCancel,
   renderButtons,
@@ -150,13 +152,18 @@ export function ModeForm({
     data: modelsData,
     isLoading: modelsLoading,
     error: modelsError,
-  } = useModelSelectorList(organizationId, isDefaultModelConfigEnabled);
+  } = useModelSelectorList(organizationId, isDefaultModelConfigEnabled && canSetDefaultModel);
   const modelOptions = useMemo(() => modelsData?.data || [], [modelsData?.data]);
   const hasCurrentDefaultModelOption =
-    !!formData.defaultModel && modelOptions.some(model => model.id === formData.defaultModel);
+    canSetDefaultModel &&
+    !!formData.defaultModel &&
+    modelOptions.some(model => model.id === formData.defaultModel);
   const shouldRenderCurrentDefaultModel = !!formData.defaultModel && !hasCurrentDefaultModelOption;
   const hasUnavailableDefaultModel =
-    shouldRenderCurrentDefaultModel && !modelsLoading && !modelsError;
+    canSetDefaultModel && shouldRenderCurrentDefaultModel && !modelsLoading && !modelsError;
+  const shouldShowDefaultModelControl =
+    isDefaultModelConfigEnabled && (canSetDefaultModel || !!formData.defaultModel);
+  const defaultModelChanged = formData.defaultModel !== initialFormData.defaultModel;
 
   // Update form data when mode prop changes
   useEffect(() => {
@@ -261,7 +268,7 @@ export function ModeForm({
       newErrors.slug = `A mode with the slug "${formData.slug}" already exists`;
     }
 
-    if (isDefaultModelConfigEnabled && hasUnavailableDefaultModel) {
+    if (defaultModelChanged && hasUnavailableDefaultModel) {
       newErrors.defaultModel = 'Choose an allowed model or clear this value.';
     }
 
@@ -447,7 +454,7 @@ export function ModeForm({
             </p>
           </div>
 
-          {isDefaultModelConfigEnabled && (
+          {shouldShowDefaultModelControl && (
             <div className="space-y-2">
               <Label htmlFor="defaultModel">Mode Default Model</Label>
               <Select
@@ -463,7 +470,14 @@ export function ModeForm({
                 <SelectTrigger
                   id="defaultModel"
                   className="w-full"
-                  aria-describedby="defaultModel-help"
+                  aria-describedby={[
+                    'defaultModel-help',
+                    hasUnavailableDefaultModel ? 'defaultModel-warning' : undefined,
+                    errors.defaultModel ? 'defaultModel-error' : undefined,
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                  aria-invalid={Boolean(errors.defaultModel)}
                 >
                   <SelectValue
                     placeholder={modelsLoading ? 'Loading models...' : 'No default model'}
@@ -476,42 +490,53 @@ export function ModeForm({
                       <div className="flex flex-col">
                         <span className="font-mono text-sm">{formData.defaultModel}</span>
                         <span className="text-muted-foreground text-xs">
-                          {modelsLoading
-                            ? 'Checking organization policy...'
-                            : modelsError
-                              ? 'Unable to verify organization policy'
-                              : 'Unavailable under current organization policy'}
+                          {!canSetDefaultModel
+                            ? 'Existing default; clear only while on Teams plan'
+                            : modelsLoading
+                              ? 'Checking organization policy...'
+                              : modelsError
+                                ? 'Unable to verify organization policy'
+                                : 'Unavailable under current organization policy'}
                         </span>
                       </div>
                     </SelectItem>
                   )}
-                  {modelOptions.map(model => (
-                    <SelectItem key={model.id} value={model.id}>
-                      <div className="flex flex-col">
-                        <span className="font-mono text-sm">{model.id}</span>
-                        {model.name !== model.id && (
-                          <span className="text-muted-foreground text-xs">{model.name}</span>
-                        )}
-                      </div>
-                    </SelectItem>
-                  ))}
+                  {canSetDefaultModel &&
+                    modelOptions.map(model => (
+                      <SelectItem key={model.id} value={model.id}>
+                        <div className="flex flex-col">
+                          <span className="font-mono text-sm">{model.id}</span>
+                          {model.name !== model.id && (
+                            <span className="text-muted-foreground text-xs">{model.name}</span>
+                          )}
+                        </div>
+                      </SelectItem>
+                    ))}
                 </SelectContent>
               </Select>
               <p id="defaultModel-help" className="text-muted-foreground text-xs">
-                {modelsLoading
-                  ? 'Loading organization-allowed models...'
-                  : modelsError
-                    ? 'Unable to load organization models.'
-                    : modelOptions.length === 0
-                      ? 'No organization-allowed models are available.'
-                      : 'Members can still override this locally in Kilo Code.'}
+                {!canSetDefaultModel
+                  ? 'This organization must be on Enterprise to set mode defaults. Existing defaults can still be cleared.'
+                  : modelsLoading
+                    ? 'Loading organization-allowed models...'
+                    : modelsError
+                      ? 'Unable to load organization models.'
+                      : modelOptions.length === 0
+                        ? 'No organization-allowed models are available.'
+                        : 'Members can still override this locally in Kilo Code.'}
               </p>
               {hasUnavailableDefaultModel && (
-                <p className="text-sm text-amber-600">
-                  Choose an allowed model or clear this value before saving.
+                <p id="defaultModel-warning" className="text-sm text-amber-600">
+                  {defaultModelChanged
+                    ? 'Choose an allowed model or clear this value before saving.'
+                    : 'This model is no longer allowed by current organization policy. Leave it unchanged to preserve it, or clear or replace it.'}
                 </p>
               )}
-              {errors.defaultModel && <p className="text-sm text-red-600">{errors.defaultModel}</p>}
+              {errors.defaultModel && (
+                <p id="defaultModel-error" className="text-sm text-red-600" role="alert">
+                  {errors.defaultModel}
+                </p>
+              )}
             </div>
           )}
 

--- a/apps/web/src/components/organizations/custom-modes/ModeForm.tsx
+++ b/apps/web/src/components/organizations/custom-modes/ModeForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { FormEvent } from 'react';
-import { useState, useEffect } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import * as z from 'zod';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -19,6 +19,7 @@ import type { OrganizationMode } from '@/lib/organizations/organization-modes';
 import type { EditGroupConfig } from '@/lib/organizations/organization-types';
 import { Save, FileText } from 'lucide-react';
 import { useModeTemplates } from './useModeTemplates';
+import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 
 const availableGroups = [
   { value: 'read', label: 'Read Files' },
@@ -27,6 +28,8 @@ const availableGroups = [
   { value: 'command', label: 'Run Commands' },
   { value: 'mcp', label: 'Use MCP' },
 ] as const;
+
+const noDefaultModelValue = '__no-mode-specific-default__';
 
 const modeFormSchema = z.object({
   name: z
@@ -43,15 +46,18 @@ const modeFormSchema = z.object({
   whenToUse: z.string().optional(),
   groups: z.any(), // Will be validated separately
   customInstructions: z.string().optional(),
+  defaultModel: z.string().min(1, 'Default model cannot be empty').optional(),
 });
 
 export type ModeFormData = z.infer<typeof modeFormSchema>;
 
 type ModeFormProps = {
+  organizationId: string;
   mode?: OrganizationMode;
   onSubmit: (data: ModeFormData) => Promise<void>;
   isSubmitting: boolean;
   isEditingBuiltIn?: boolean;
+  isDefaultModelConfigEnabled?: boolean;
   existingModes?: OrganizationMode[];
   onCancel?: () => void;
   renderButtons?: (props: { isDirty: boolean; isSubmitting: boolean }) => React.ReactNode;
@@ -91,10 +97,12 @@ function denormalizeGroups(
 }
 
 export function ModeForm({
+  organizationId,
   mode,
   onSubmit,
   isSubmitting,
   isEditingBuiltIn = false,
+  isDefaultModelConfigEnabled = false,
   existingModes = [],
   onCancel,
   renderButtons,
@@ -106,6 +114,7 @@ export function ModeForm({
     description: mode?.config?.description || '',
     whenToUse: mode?.config?.whenToUse || '',
     customInstructions: mode?.config?.customInstructions || '',
+    defaultModel: mode?.config?.defaultModel || '',
   });
   const [selectedGroups, setSelectedGroups] = useState<string[]>(() => {
     const { simpleGroups } = normalizeGroups(mode?.config?.groups || []);
@@ -123,6 +132,7 @@ export function ModeForm({
     description: mode?.config?.description || '',
     whenToUse: mode?.config?.whenToUse || '',
     customInstructions: mode?.config?.customInstructions || '',
+    defaultModel: mode?.config?.defaultModel || '',
   });
   const [initialGroups, setInitialGroups] = useState<string[]>(() => {
     const { simpleGroups } = normalizeGroups(mode?.config?.groups || []);
@@ -136,6 +146,17 @@ export function ModeForm({
 
   // Fetch mode templates
   const { data: templates, isLoading: templatesLoading } = useModeTemplates();
+  const {
+    data: modelsData,
+    isLoading: modelsLoading,
+    error: modelsError,
+  } = useModelSelectorList(organizationId, isDefaultModelConfigEnabled);
+  const modelOptions = useMemo(() => modelsData?.data || [], [modelsData?.data]);
+  const hasCurrentDefaultModelOption =
+    !!formData.defaultModel && modelOptions.some(model => model.id === formData.defaultModel);
+  const shouldRenderCurrentDefaultModel = !!formData.defaultModel && !hasCurrentDefaultModelOption;
+  const hasUnavailableDefaultModel =
+    shouldRenderCurrentDefaultModel && !modelsLoading && !modelsError;
 
   // Update form data when mode prop changes
   useEffect(() => {
@@ -147,6 +168,7 @@ export function ModeForm({
         description: mode.config?.description || '',
         whenToUse: mode.config?.whenToUse || '',
         customInstructions: mode.config?.customInstructions || '',
+        defaultModel: mode.config?.defaultModel || '',
       };
       const { simpleGroups, editConfig } = normalizeGroups(mode.config?.groups || []);
       const newEditConfig = editConfig || { fileRegex: '', description: '' };
@@ -168,6 +190,7 @@ export function ModeForm({
     formData.description !== initialFormData.description ||
     formData.whenToUse !== initialFormData.whenToUse ||
     formData.customInstructions !== initialFormData.customInstructions ||
+    formData.defaultModel !== initialFormData.defaultModel ||
     JSON.stringify(selectedGroups.sort()) !== JSON.stringify(initialGroups.sort()) ||
     editGroupConfig.fileRegex !== initialEditConfig.fileRegex ||
     editGroupConfig.description !== initialEditConfig.description;
@@ -205,6 +228,7 @@ export function ModeForm({
       description: template.config.description || '',
       whenToUse: template.config.whenToUse || '',
       customInstructions: template.config.customInstructions || '',
+      defaultModel: '',
     };
 
     const { simpleGroups, editConfig } = normalizeGroups(template.config.groups || []);
@@ -237,6 +261,10 @@ export function ModeForm({
       newErrors.slug = `A mode with the slug "${formData.slug}" already exists`;
     }
 
+    if (isDefaultModelConfigEnabled && hasUnavailableDefaultModel) {
+      newErrors.defaultModel = 'Choose an allowed model or clear this value.';
+    }
+
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors);
       return;
@@ -249,6 +277,7 @@ export function ModeForm({
 
     const result = modeFormSchema.safeParse({
       ...formData,
+      defaultModel: formData.defaultModel || undefined,
       groups,
     });
 
@@ -417,6 +446,74 @@ export function ModeForm({
               Add behavioral guidelines specific to this mode
             </p>
           </div>
+
+          {isDefaultModelConfigEnabled && (
+            <div className="space-y-2">
+              <Label htmlFor="defaultModel">Mode Default Model</Label>
+              <Select
+                value={formData.defaultModel || noDefaultModelValue}
+                onValueChange={value =>
+                  setFormData(prev => ({
+                    ...prev,
+                    defaultModel: value === noDefaultModelValue ? '' : value,
+                  }))
+                }
+                disabled={isSubmitting || modelsLoading}
+              >
+                <SelectTrigger
+                  id="defaultModel"
+                  className="w-full"
+                  aria-describedby="defaultModel-help"
+                >
+                  <SelectValue
+                    placeholder={modelsLoading ? 'Loading models...' : 'No default model'}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={noDefaultModelValue}>No mode-specific default</SelectItem>
+                  {shouldRenderCurrentDefaultModel && (
+                    <SelectItem value={formData.defaultModel} disabled>
+                      <div className="flex flex-col">
+                        <span className="font-mono text-sm">{formData.defaultModel}</span>
+                        <span className="text-muted-foreground text-xs">
+                          {modelsLoading
+                            ? 'Checking organization policy...'
+                            : modelsError
+                              ? 'Unable to verify organization policy'
+                              : 'Unavailable under current organization policy'}
+                        </span>
+                      </div>
+                    </SelectItem>
+                  )}
+                  {modelOptions.map(model => (
+                    <SelectItem key={model.id} value={model.id}>
+                      <div className="flex flex-col">
+                        <span className="font-mono text-sm">{model.id}</span>
+                        {model.name !== model.id && (
+                          <span className="text-muted-foreground text-xs">{model.name}</span>
+                        )}
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p id="defaultModel-help" className="text-muted-foreground text-xs">
+                {modelsLoading
+                  ? 'Loading organization-allowed models...'
+                  : modelsError
+                    ? 'Unable to load organization models.'
+                    : modelOptions.length === 0
+                      ? 'No organization-allowed models are available.'
+                      : 'Members can still override this locally in Kilo Code.'}
+              </p>
+              {hasUnavailableDefaultModel && (
+                <p className="text-sm text-amber-600">
+                  Choose an allowed model or clear this value before saving.
+                </p>
+              )}
+              {errors.defaultModel && <p className="text-sm text-red-600">{errors.defaultModel}</p>}
+            </div>
+          )}
 
           {/* Available Tools */}
           <div className="space-y-4">

--- a/apps/web/src/components/organizations/custom-modes/NewModeForm.tsx
+++ b/apps/web/src/components/organizations/custom-modes/NewModeForm.tsx
@@ -10,6 +10,7 @@ import { useMemo } from 'react';
 type NewModeFormProps = {
   organizationId: string;
   defaultModeSlug?: string;
+  isDefaultModelConfigEnabled?: boolean;
   onSuccess?: () => void;
   onCancel?: () => void;
 };
@@ -17,6 +18,7 @@ type NewModeFormProps = {
 export function NewModeForm({
   organizationId,
   defaultModeSlug: propDefaultModeSlug,
+  isDefaultModelConfigEnabled = false,
   onSuccess,
   onCancel,
 }: NewModeFormProps) {
@@ -58,6 +60,7 @@ export function NewModeForm({
           whenToUse: data.whenToUse,
           groups: data.groups as ('read' | 'edit' | 'browser' | 'command' | 'mcp')[],
           customInstructions: data.customInstructions,
+          ...(data.defaultModel ? { defaultModel: data.defaultModel } : {}),
         },
       });
       toast.success(`Mode "${data.name}" created successfully`);
@@ -71,10 +74,12 @@ export function NewModeForm({
 
   return (
     <ModeForm
+      organizationId={organizationId}
       mode={initialMode}
       onSubmit={handleSubmit}
       isSubmitting={createMutation.isPending}
       isEditingBuiltIn={!!defaultMode}
+      isDefaultModelConfigEnabled={isDefaultModelConfigEnabled}
       existingModes={modesData?.modes || []}
       onCancel={onCancel}
       renderButtons={() => null}

--- a/apps/web/src/components/organizations/custom-modes/NewModeForm.tsx
+++ b/apps/web/src/components/organizations/custom-modes/NewModeForm.tsx
@@ -11,6 +11,7 @@ type NewModeFormProps = {
   organizationId: string;
   defaultModeSlug?: string;
   isDefaultModelConfigEnabled?: boolean;
+  canSetDefaultModel?: boolean;
   onSuccess?: () => void;
   onCancel?: () => void;
 };
@@ -19,6 +20,7 @@ export function NewModeForm({
   organizationId,
   defaultModeSlug: propDefaultModeSlug,
   isDefaultModelConfigEnabled = false,
+  canSetDefaultModel = true,
   onSuccess,
   onCancel,
 }: NewModeFormProps) {
@@ -80,6 +82,7 @@ export function NewModeForm({
       isSubmitting={createMutation.isPending}
       isEditingBuiltIn={!!defaultMode}
       isDefaultModelConfigEnabled={isDefaultModelConfigEnabled}
+      canSetDefaultModel={canSetDefaultModel}
       existingModes={modesData?.modes || []}
       onCancel={onCancel}
       renderButtons={() => null}

--- a/apps/web/src/lib/organizations/organization-modes.test.ts
+++ b/apps/web/src/lib/organizations/organization-modes.test.ts
@@ -6,6 +6,7 @@ import { createOrganization } from './organizations';
 import {
   createOrganizationMode,
   getAllOrganizationModes,
+  getOrganizationModeById,
   updateOrganizationMode,
 } from './organization-modes';
 
@@ -198,6 +199,33 @@ describe('updateOrganizationMode', () => {
       roleDefinition: 'You are a coding assistant',
       description: 'Write code',
       groups: ['read', 'edit'],
+    });
+  });
+
+  test('should not lose concurrent partial config updates', async () => {
+    const user = await insertTestUser();
+    const organization = await createOrganization('Test Org', user.id);
+    const mode = await createOrganizationMode(organization.id, user.id, 'Code Mode', 'code', {
+      roleDefinition: 'You are a coding assistant',
+      groups: ['read'],
+    });
+
+    await Promise.all([
+      updateOrganizationMode(organization.id, mode!.id, {
+        config: { description: 'Write code' },
+      }),
+      updateOrganizationMode(organization.id, mode!.id, {
+        config: { defaultModel: 'openai/gpt-4o' },
+      }),
+    ]);
+
+    const updatedMode = await getOrganizationModeById(organization.id, mode!.id);
+
+    expect(updatedMode?.config).toEqual({
+      roleDefinition: 'You are a coding assistant',
+      groups: ['read'],
+      description: 'Write code',
+      defaultModel: 'openai/gpt-4o',
     });
   });
 

--- a/apps/web/src/lib/organizations/organization-modes.test.ts
+++ b/apps/web/src/lib/organizations/organization-modes.test.ts
@@ -168,7 +168,7 @@ describe('updateOrganizationMode', () => {
       groups: ['read', 'edit'],
     });
 
-    const updatedMode = await updateOrganizationMode(mode!.id, {
+    const updatedMode = await updateOrganizationMode(organization.id, mode!.id, {
       config: { defaultModel: 'openai/gpt-4o' },
     });
 
@@ -190,7 +190,7 @@ describe('updateOrganizationMode', () => {
       defaultModel: 'openai/gpt-4o',
     });
 
-    const updatedMode = await updateOrganizationMode(mode!.id, {
+    const updatedMode = await updateOrganizationMode(organization.id, mode!.id, {
       config: { defaultModel: undefined },
     });
 
@@ -199,6 +199,22 @@ describe('updateOrganizationMode', () => {
       description: 'Write code',
       groups: ['read', 'edit'],
     });
+  });
+
+  test('should not update a mode through another organization', async () => {
+    const user = await insertTestUser();
+    const organization = await createOrganization('Test Org', user.id);
+    const otherOrganization = await createOrganization('Other Org', user.id);
+    const mode = await createOrganizationMode(organization.id, user.id, 'Code Mode', 'code', {
+      roleDefinition: 'You are a coding assistant',
+      groups: ['read'],
+    });
+
+    const updatedMode = await updateOrganizationMode(otherOrganization.id, mode!.id, {
+      config: { defaultModel: 'openai/gpt-4o' },
+    });
+
+    expect(updatedMode).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/organizations/organization-modes.test.ts
+++ b/apps/web/src/lib/organizations/organization-modes.test.ts
@@ -3,7 +3,11 @@ import { db } from '@/lib/drizzle';
 import { organizations } from '@kilocode/db/schema';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization } from './organizations';
-import { createOrganizationMode, getAllOrganizationModes } from './organization-modes';
+import {
+  createOrganizationMode,
+  getAllOrganizationModes,
+  updateOrganizationMode,
+} from './organization-modes';
 
 describe('createOrganizationMode', () => {
   afterEach(async () => {
@@ -133,6 +137,68 @@ describe('createOrganizationMode', () => {
 
     expect(mode).not.toBeNull();
     expect(mode?.config).toEqual(config);
+  });
+
+  test('should preserve an optional default model', async () => {
+    const user = await insertTestUser();
+    const organization = await createOrganization('Test Org', user.id);
+
+    const mode = await createOrganizationMode(organization.id, user.id, 'Code Mode', 'code', {
+      roleDefinition: 'You are a coding assistant',
+      groups: ['read', 'edit'],
+      defaultModel: 'openai/gpt-4o',
+    });
+
+    expect(mode?.config.defaultModel).toBe('openai/gpt-4o');
+  });
+});
+
+describe('updateOrganizationMode', () => {
+  afterEach(async () => {
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organizations);
+  });
+
+  test('should preserve existing config when updating only defaultModel', async () => {
+    const user = await insertTestUser();
+    const organization = await createOrganization('Test Org', user.id);
+    const mode = await createOrganizationMode(organization.id, user.id, 'Code Mode', 'code', {
+      roleDefinition: 'You are a coding assistant',
+      description: 'Write code',
+      groups: ['read', 'edit'],
+    });
+
+    const updatedMode = await updateOrganizationMode(mode!.id, {
+      config: { defaultModel: 'openai/gpt-4o' },
+    });
+
+    expect(updatedMode?.config).toEqual({
+      roleDefinition: 'You are a coding assistant',
+      description: 'Write code',
+      groups: ['read', 'edit'],
+      defaultModel: 'openai/gpt-4o',
+    });
+  });
+
+  test('should clear defaultModel without dropping the rest of config', async () => {
+    const user = await insertTestUser();
+    const organization = await createOrganization('Test Org', user.id);
+    const mode = await createOrganizationMode(organization.id, user.id, 'Code Mode', 'code', {
+      roleDefinition: 'You are a coding assistant',
+      description: 'Write code',
+      groups: ['read', 'edit'],
+      defaultModel: 'openai/gpt-4o',
+    });
+
+    const updatedMode = await updateOrganizationMode(mode!.id, {
+      config: { defaultModel: undefined },
+    });
+
+    expect(updatedMode?.config).toEqual({
+      roleDefinition: 'You are a coding assistant',
+      description: 'Write code',
+      groups: ['read', 'edit'],
+    });
   });
 });
 

--- a/apps/web/src/lib/organizations/organization-modes.ts
+++ b/apps/web/src/lib/organizations/organization-modes.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/drizzle';
 import { orgnaization_modes, ORGANIZATION_MODES_ORG_SLUG_CONSTRAINT } from '@kilocode/db/schema';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import type { OrganizationModeConfig } from '@/lib/organizations/organization-types';
 
 export type OrganizationMode = typeof orgnaization_modes.$inferSelect;
@@ -80,24 +80,14 @@ export async function updateOrganizationMode(
     updateData.slug = updates.slug;
   }
   if (updates.config !== undefined) {
-    const [existingMode] = await db
-      .select()
-      .from(orgnaization_modes)
-      .where(
-        and(
-          eq(orgnaization_modes.id, modeId),
-          eq(orgnaization_modes.organization_id, organizationId)
-        )
-      );
+    const configPatch = Object.fromEntries(
+      Object.entries(updates.config).map(([key, value]) => [
+        key,
+        value === undefined ? null : value,
+      ])
+    );
 
-    if (!existingMode) {
-      return null;
-    }
-
-    updateData.config = mergeToSatisfy({
-      ...mergeToSatisfy(existingMode.config),
-      ...updates.config,
-    });
+    updateData.config = sql`jsonb_strip_nulls(((${JSON.stringify(defaultConfig)}::jsonb || COALESCE(${orgnaization_modes.config}, '{}'::jsonb)) || ${JSON.stringify(configPatch)}::jsonb))`;
   }
 
   try {

--- a/apps/web/src/lib/organizations/organization-modes.ts
+++ b/apps/web/src/lib/organizations/organization-modes.ts
@@ -63,6 +63,7 @@ export async function getOrganizationModeById(
 }
 
 export async function updateOrganizationMode(
+  organizationId: string,
   modeId: string,
   updates: {
     name?: string;
@@ -82,7 +83,12 @@ export async function updateOrganizationMode(
     const [existingMode] = await db
       .select()
       .from(orgnaization_modes)
-      .where(eq(orgnaization_modes.id, modeId));
+      .where(
+        and(
+          eq(orgnaization_modes.id, modeId),
+          eq(orgnaization_modes.organization_id, organizationId)
+        )
+      );
 
     if (!existingMode) {
       return null;
@@ -98,7 +104,12 @@ export async function updateOrganizationMode(
     const [mode] = await db
       .update(orgnaization_modes)
       .set(updateData)
-      .where(eq(orgnaization_modes.id, modeId))
+      .where(
+        and(
+          eq(orgnaization_modes.id, modeId),
+          eq(orgnaization_modes.organization_id, organizationId)
+        )
+      )
       .returning();
 
     return mode ? { ...mode, config: mergeToSatisfy(mode.config) } : null;

--- a/apps/web/src/lib/organizations/organization-modes.ts
+++ b/apps/web/src/lib/organizations/organization-modes.ts
@@ -79,7 +79,19 @@ export async function updateOrganizationMode(
     updateData.slug = updates.slug;
   }
   if (updates.config !== undefined) {
-    updateData.config = mergeToSatisfy(updates.config);
+    const [existingMode] = await db
+      .select()
+      .from(orgnaization_modes)
+      .where(eq(orgnaization_modes.id, modeId));
+
+    if (!existingMode) {
+      return null;
+    }
+
+    updateData.config = mergeToSatisfy({
+      ...mergeToSatisfy(existingMode.config),
+      ...updates.config,
+    });
   }
 
   try {

--- a/apps/web/src/routers/organizations/organization-modes-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-modes-router.test.ts
@@ -126,6 +126,90 @@ describe('organization modes tRPC router', () => {
         })
       ).rejects.toThrow();
     });
+
+    it('should allow an organization mode default that is not denied', async () => {
+      const caller = await createCallerForUser(owner.id);
+      const organization = await createTestOrganization(
+        'Allowed Default Model Org',
+        owner.id,
+        0,
+        { model_deny_list: ['anthropic/claude-3-opus'] },
+        false
+      );
+
+      const result = await caller.organizations.modes.create({
+        organizationId: organization.id,
+        name: 'Code Mode',
+        slug: 'code',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          groups: ['read'],
+          defaultModel: 'openai/gpt-4o',
+        },
+      });
+
+      expect(result.mode.config.defaultModel).toBe('openai/gpt-4o');
+    });
+
+    it('should reject an organization mode default that is denied', async () => {
+      const caller = await createCallerForUser(owner.id);
+      const organization = await createTestOrganization(
+        'Denied Default Model Org',
+        owner.id,
+        0,
+        { model_deny_list: ['openai/gpt-4o'] },
+        false
+      );
+
+      await expect(
+        caller.organizations.modes.create({
+          organizationId: organization.id,
+          name: 'Code Mode',
+          slug: 'code',
+          config: {
+            roleDefinition: 'You are a coding assistant',
+            groups: ['read'],
+            defaultModel: 'openai/gpt-4o',
+          },
+        })
+      ).rejects.toThrow(
+        "Default model 'openai/gpt-4o' is not in the organization's allowed models list"
+      );
+    });
+
+    it('should reject an empty organization mode default', async () => {
+      const caller = await createCallerForUser(owner.id);
+
+      await expect(
+        caller.organizations.modes.create({
+          organizationId: testOrganization.id,
+          name: 'Code Mode',
+          slug: 'empty-default-model',
+          config: {
+            roleDefinition: 'You are a coding assistant',
+            groups: ['read'],
+            defaultModel: '',
+          },
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should reject a wildcard organization mode default', async () => {
+      const caller = await createCallerForUser(owner.id);
+
+      await expect(
+        caller.organizations.modes.create({
+          organizationId: testOrganization.id,
+          name: 'Code Mode',
+          slug: 'wildcard-default-model',
+          config: {
+            roleDefinition: 'You are a coding assistant',
+            groups: ['read'],
+            defaultModel: 'openai/*',
+          },
+        })
+      ).rejects.toThrow("Default model 'openai/*' is not a concrete model identifier");
+    });
   });
 
   describe('list procedure', () => {
@@ -347,6 +431,90 @@ describe('organization modes tRPC router', () => {
           slug: 'slug-a',
         })
       ).rejects.toThrow();
+    });
+
+    it('should reject a denied organization mode default on update', async () => {
+      const caller = await createCallerForUser(owner.id);
+      const organization = await createTestOrganization(
+        'Denied Update Default Model Org',
+        owner.id,
+        0,
+        { model_deny_list: ['openai/gpt-4o'] },
+        false
+      );
+      const created = await caller.organizations.modes.create({
+        organizationId: organization.id,
+        name: 'Code Mode',
+        slug: 'code',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          groups: ['read'],
+        },
+      });
+
+      await expect(
+        caller.organizations.modes.update({
+          organizationId: organization.id,
+          modeId: created.mode.id,
+          config: {
+            defaultModel: 'openai/gpt-4o',
+          },
+        })
+      ).rejects.toThrow(
+        "Default model 'openai/gpt-4o' is not in the organization's allowed models list"
+      );
+    });
+
+    it('should reject a wildcard organization mode default on update', async () => {
+      const caller = await createCallerForUser(owner.id);
+      const created = await caller.organizations.modes.create({
+        organizationId: testOrganization.id,
+        name: 'Code Mode',
+        slug: 'wildcard-update-default-model',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          groups: ['read'],
+        },
+      });
+
+      await expect(
+        caller.organizations.modes.update({
+          organizationId: testOrganization.id,
+          modeId: created.mode.id,
+          config: {
+            defaultModel: 'openai/*',
+          },
+        })
+      ).rejects.toThrow("Default model 'openai/*' is not a concrete model identifier");
+    });
+
+    it('should clear an organization mode default on update', async () => {
+      const caller = await createCallerForUser(owner.id);
+      const created = await caller.organizations.modes.create({
+        organizationId: testOrganization.id,
+        name: 'Code Mode',
+        slug: 'clear-default-model',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          description: 'Write code',
+          groups: ['read'],
+          defaultModel: 'openai/gpt-4o',
+        },
+      });
+
+      const result = await caller.organizations.modes.update({
+        organizationId: testOrganization.id,
+        modeId: created.mode.id,
+        config: {
+          defaultModel: null,
+        },
+      });
+
+      expect(result.mode.config).toEqual({
+        roleDefinition: 'You are a coding assistant',
+        description: 'Write code',
+        groups: ['read'],
+      });
     });
   });
 

--- a/apps/web/src/routers/organizations/organization-modes-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-modes-router.test.ts
@@ -6,11 +6,23 @@ import { getAllOrganizationModes } from '@/lib/organizations/organization-modes'
 import type { User, Organization } from '@kilocode/db/schema';
 import { randomUUID } from 'crypto';
 
+jest.mock('@/lib/posthog-feature-flags', () => ({
+  isReleaseToggleEnabled: jest.fn(async () => true),
+}));
+
+const mockedIsReleaseToggleEnabled = jest.mocked(
+  jest.requireMock('@/lib/posthog-feature-flags').isReleaseToggleEnabled
+);
+
 let owner: User;
 let member: User;
 let testOrganization: Organization;
 
 describe('organization modes tRPC router', () => {
+  beforeEach(() => {
+    mockedIsReleaseToggleEnabled.mockResolvedValue(true);
+  });
+
   beforeAll(async () => {
     owner = await insertTestUser({
       google_user_email: 'owner-modes@example.com',
@@ -194,6 +206,56 @@ describe('organization modes tRPC router', () => {
       ).rejects.toThrow();
     });
 
+    it('should reject mode default writes when the release flag is disabled', async () => {
+      mockedIsReleaseToggleEnabled.mockResolvedValueOnce(false);
+      const caller = await createCallerForUser(owner.id);
+
+      await expect(
+        caller.organizations.modes.create({
+          organizationId: testOrganization.id,
+          name: 'Code Mode',
+          slug: 'flag-disabled-default-model',
+          config: {
+            roleDefinition: 'You are a coding assistant',
+            groups: ['read'],
+            defaultModel: 'openai/gpt-4o',
+          },
+        })
+      ).rejects.toThrow('Mode default model configuration is not available');
+    });
+
+    it('should allow mode default writes in development when the release flag is disabled', async () => {
+      mockedIsReleaseToggleEnabled.mockResolvedValue(false);
+      const replacedEnv = jest.replaceProperty(process, 'env', {
+        ...process.env,
+        NODE_ENV: 'development',
+      });
+      const caller = await createCallerForUser(owner.id);
+
+      try {
+        await expect(
+          caller.organizations.modes.create({
+            organizationId: testOrganization.id,
+            name: 'Code Mode',
+            slug: 'development-default-model',
+            config: {
+              roleDefinition: 'You are a coding assistant',
+              groups: ['read'],
+              defaultModel: 'openai/gpt-4o',
+            },
+          })
+        ).resolves.toMatchObject({
+          mode: {
+            config: {
+              defaultModel: 'openai/gpt-4o',
+            },
+          },
+        });
+      } finally {
+        replacedEnv.restore();
+      }
+    });
+
     it('should reject a wildcard organization mode default', async () => {
       const caller = await createCallerForUser(owner.id);
 
@@ -209,6 +271,23 @@ describe('organization modes tRPC router', () => {
           },
         })
       ).rejects.toThrow("Default model 'openai/*' is not a concrete model identifier");
+    });
+
+    it('should reject a wildcard organization mode default with a variant suffix', async () => {
+      const caller = await createCallerForUser(owner.id);
+
+      await expect(
+        caller.organizations.modes.create({
+          organizationId: testOrganization.id,
+          name: 'Code Mode',
+          slug: 'wildcard-variant-default-model',
+          config: {
+            roleDefinition: 'You are a coding assistant',
+            groups: ['read'],
+            defaultModel: 'openai/*:free',
+          },
+        })
+      ).rejects.toThrow("Default model 'openai/*:free' is not a concrete model identifier");
     });
   });
 
@@ -486,6 +565,84 @@ describe('organization modes tRPC router', () => {
           },
         })
       ).rejects.toThrow("Default model 'openai/*' is not a concrete model identifier");
+    });
+
+    it('should reject a wildcard organization mode default with a variant suffix on update', async () => {
+      const caller = await createCallerForUser(owner.id);
+      const created = await caller.organizations.modes.create({
+        organizationId: testOrganization.id,
+        name: 'Code Mode',
+        slug: 'wildcard-variant-update-default-model',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          groups: ['read'],
+        },
+      });
+
+      await expect(
+        caller.organizations.modes.update({
+          organizationId: testOrganization.id,
+          modeId: created.mode.id,
+          config: {
+            defaultModel: 'openai/*:free',
+          },
+        })
+      ).rejects.toThrow("Default model 'openai/*:free' is not a concrete model identifier");
+    });
+
+    it('should reject clearing a mode default when the release flag is disabled', async () => {
+      const caller = await createCallerForUser(owner.id);
+      const created = await caller.organizations.modes.create({
+        organizationId: testOrganization.id,
+        name: 'Code Mode',
+        slug: 'flag-disabled-clear-default-model',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          groups: ['read'],
+          defaultModel: 'openai/gpt-4o',
+        },
+      });
+      mockedIsReleaseToggleEnabled.mockResolvedValueOnce(false);
+
+      await expect(
+        caller.organizations.modes.update({
+          organizationId: testOrganization.id,
+          modeId: created.mode.id,
+          config: {
+            defaultModel: null,
+          },
+        })
+      ).rejects.toThrow('Mode default model configuration is not available');
+    });
+
+    it('should allow ordinary mode edits when the release flag is disabled', async () => {
+      mockedIsReleaseToggleEnabled.mockResolvedValue(false);
+      const caller = await createCallerForUser(owner.id);
+      const created = await caller.organizations.modes.create({
+        organizationId: testOrganization.id,
+        name: 'Code Mode',
+        slug: 'flag-disabled-normal-update',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          groups: ['read'],
+        },
+      });
+
+      await expect(
+        caller.organizations.modes.update({
+          organizationId: testOrganization.id,
+          modeId: created.mode.id,
+          config: {
+            description: 'Updated description',
+          },
+        })
+      ).resolves.toMatchObject({
+        mode: {
+          config: {
+            description: 'Updated description',
+          },
+        },
+      });
     });
 
     it('should clear an organization mode default on update', async () => {

--- a/apps/web/src/routers/organizations/organization-modes-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-modes-router.test.ts
@@ -3,7 +3,10 @@ import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
 import { addUserToOrganization } from '@/lib/organizations/organizations';
 import { getAllOrganizationModes } from '@/lib/organizations/organization-modes';
+import { db } from '@/lib/drizzle';
+import { organizations } from '@kilocode/db/schema';
 import type { User, Organization } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
 
 jest.mock('@/lib/posthog-feature-flags', () => ({
@@ -161,6 +164,30 @@ describe('organization modes tRPC router', () => {
       });
 
       expect(result.mode.config.defaultModel).toBe('openai/gpt-4o');
+    });
+
+    it('should reject an organization mode default for a non-enterprise organization', async () => {
+      const caller = await createCallerForUser(owner.id);
+      const organization = await createTestOrganization(
+        'Teams Default Model Org',
+        owner.id,
+        0,
+        {},
+        true
+      );
+
+      await expect(
+        caller.organizations.modes.create({
+          organizationId: organization.id,
+          name: 'Code Mode',
+          slug: 'code',
+          config: {
+            roleDefinition: 'You are a coding assistant',
+            groups: ['read'],
+            defaultModel: 'openai/gpt-4o',
+          },
+        })
+      ).rejects.toThrow('Model access configuration is not available for this organization.');
     });
 
     it('should reject an organization mode default that is denied', async () => {
@@ -512,6 +539,36 @@ describe('organization modes tRPC router', () => {
       ).rejects.toThrow();
     });
 
+    it('should reject an organization mode default on update for a non-enterprise organization', async () => {
+      const caller = await createCallerForUser(owner.id);
+      const organization = await createTestOrganization(
+        'Teams Update Default Model Org',
+        owner.id,
+        0,
+        {},
+        true
+      );
+      const created = await caller.organizations.modes.create({
+        organizationId: organization.id,
+        name: 'Code Mode',
+        slug: 'code',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          groups: ['read'],
+        },
+      });
+
+      await expect(
+        caller.organizations.modes.update({
+          organizationId: organization.id,
+          modeId: created.mode.id,
+          config: {
+            defaultModel: 'openai/gpt-4o',
+          },
+        })
+      ).rejects.toThrow('Model access configuration is not available for this organization.');
+    });
+
     it('should reject a denied organization mode default on update', async () => {
       const caller = await createCallerForUser(owner.id);
       const organization = await createTestOrganization(
@@ -588,6 +645,89 @@ describe('organization modes tRPC router', () => {
           },
         })
       ).rejects.toThrow("Default model 'openai/*:free' is not a concrete model identifier");
+    });
+
+    it('should allow unrelated mode edits after a stored default becomes denied', async () => {
+      const caller = await createCallerForUser(owner.id);
+      const organization = await createTestOrganization(
+        'Stale Default Model Org',
+        owner.id,
+        0,
+        {},
+        false
+      );
+      const created = await caller.organizations.modes.create({
+        organizationId: organization.id,
+        name: 'Code Mode',
+        slug: 'stale-default-model',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          groups: ['read'],
+          defaultModel: 'openai/gpt-4o',
+        },
+      });
+      await db
+        .update(organizations)
+        .set({ settings: { model_deny_list: ['openai/gpt-4o'] } })
+        .where(eq(organizations.id, organization.id));
+
+      await expect(
+        caller.organizations.modes.update({
+          organizationId: organization.id,
+          modeId: created.mode.id,
+          config: {
+            description: 'Updated description',
+          },
+        })
+      ).resolves.toMatchObject({
+        mode: {
+          config: {
+            description: 'Updated description',
+            defaultModel: 'openai/gpt-4o',
+          },
+        },
+      });
+    });
+
+    it('should allow clearing a mode default after an enterprise organization downgrades', async () => {
+      const caller = await createCallerForUser(owner.id);
+      const organization = await createTestOrganization(
+        'Downgraded Default Model Org',
+        owner.id,
+        0,
+        {},
+        false
+      );
+      const created = await caller.organizations.modes.create({
+        organizationId: organization.id,
+        name: 'Code Mode',
+        slug: 'downgraded-clear-default-model',
+        config: {
+          roleDefinition: 'You are a coding assistant',
+          groups: ['read'],
+          defaultModel: 'openai/gpt-4o',
+        },
+      });
+      await db
+        .update(organizations)
+        .set({ plan: 'teams' })
+        .where(eq(organizations.id, organization.id));
+
+      await expect(
+        caller.organizations.modes.update({
+          organizationId: organization.id,
+          modeId: created.mode.id,
+          config: {
+            defaultModel: null,
+          },
+        })
+      ).resolves.toMatchObject({
+        mode: {
+          config: {
+            roleDefinition: 'You are a coding assistant',
+          },
+        },
+      });
     });
 
     it('should reject clearing a mode default when the release flag is disabled', async () => {

--- a/apps/web/src/routers/organizations/organization-modes-router.ts
+++ b/apps/web/src/routers/organizations/organization-modes-router.ts
@@ -22,6 +22,10 @@ import { getOrganizationById } from '@/lib/organizations/organizations';
 import { successResult } from '@/lib/maybe-result';
 import { createAllowPredicateFromRestrictions } from '@/lib/model-allow.server';
 import { getEffectiveModelRestrictions } from '@/lib/organizations/model-restrictions';
+import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+
+const ORGANIZATION_MODE_DEFAULT_MODEL_FLAG = 'org-default-model-config';
 
 const ModeConfigInputSchema = OrganizationModeConfigSchema.partial();
 
@@ -30,6 +34,9 @@ const ModeUpdateConfigInputSchema = ModeConfigInputSchema.extend({
 });
 
 type ModeUpdateConfigInput = z.infer<typeof ModeUpdateConfigInputSchema>;
+type DefaultModelConfig = {
+  defaultModel?: string | null;
+};
 
 const CreateModeInputSchema = OrganizationIdInputSchema.extend({
   name: z
@@ -64,6 +71,29 @@ const ModeIdInputSchema = OrganizationIdInputSchema.extend({
   modeId: z.uuid(),
 });
 
+function hasDefaultModelUpdate(config: ModeUpdateConfigInput | undefined): boolean {
+  return !!config && Object.prototype.hasOwnProperty.call(config, 'defaultModel');
+}
+
+async function ensureDefaultModelConfigEnabled(
+  userId: string,
+  config: ModeUpdateConfigInput | undefined
+): Promise<void> {
+  if (!hasDefaultModelUpdate(config)) {
+    return;
+  }
+
+  if (
+    process.env.NODE_ENV !== 'development' &&
+    !(await isReleaseToggleEnabled(ORGANIZATION_MODE_DEFAULT_MODEL_FLAG, userId))
+  ) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Mode default model configuration is not available',
+    });
+  }
+}
+
 function normalizeModeConfig(
   config: ModeUpdateConfigInput | undefined
 ): Partial<OrganizationModeConfig> | undefined {
@@ -84,14 +114,15 @@ function normalizeModeConfig(
 
 async function validateDefaultModel(
   organization: Awaited<ReturnType<typeof getOrganizationById>>,
-  config: ModeUpdateConfigInput | undefined
+  config: DefaultModelConfig | undefined
 ): Promise<void> {
   const defaultModel = config?.defaultModel;
   if (!organization || defaultModel === undefined || defaultModel === null) {
     return;
   }
 
-  if (defaultModel.endsWith('/*')) {
+  const normalizedDefaultModel = normalizeModelId(defaultModel);
+  if (normalizedDefaultModel.endsWith('/*')) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
       message: `Default model '${defaultModel}' is not a concrete model identifier`,
@@ -102,7 +133,7 @@ async function validateDefaultModel(
     getEffectiveModelRestrictions(organization)
   );
 
-  if (!(await isAllowed(defaultModel))) {
+  if (!(await isAllowed(normalizedDefaultModel))) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
       message: `Default model '${defaultModel}' is not in the organization's allowed models list`,
@@ -124,6 +155,7 @@ export const organizationModesRouter = createTRPCRouter({
         });
       }
 
+      await ensureDefaultModelConfigEnabled(ctx.user.id, config);
       await validateDefaultModel(organization, config);
 
       const mode = await createOrganizationMode(
@@ -198,11 +230,16 @@ export const organizationModesRouter = createTRPCRouter({
         });
       }
 
-      await validateDefaultModel(organization, updates.config);
+      await ensureDefaultModelConfigEnabled(ctx.user.id, updates.config);
+      const normalizedConfig = normalizeModeConfig(updates.config);
+      const effectiveConfig = normalizedConfig
+        ? { ...existingMode.config, ...normalizedConfig }
+        : existingMode.config;
+      await validateDefaultModel(organization, effectiveConfig);
 
-      const mode = await updateOrganizationMode(modeId, {
+      const mode = await updateOrganizationMode(organizationId, modeId, {
         ...updates,
-        config: normalizeModeConfig(updates.config),
+        config: normalizedConfig,
       });
 
       if (!mode) {

--- a/apps/web/src/routers/organizations/organization-modes-router.ts
+++ b/apps/web/src/routers/organizations/organization-modes-router.ts
@@ -13,10 +13,23 @@ import {
   updateOrganizationMode,
   deleteOrganizationMode,
 } from '@/lib/organizations/organization-modes';
-import { OrganizationModeConfigSchema } from '@/lib/organizations/organization-types';
+import {
+  OrganizationModeConfigSchema,
+  type OrganizationModeConfig,
+} from '@/lib/organizations/organization-types';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
 import { getOrganizationById } from '@/lib/organizations/organizations';
 import { successResult } from '@/lib/maybe-result';
+import { createAllowPredicateFromRestrictions } from '@/lib/model-allow.server';
+import { getEffectiveModelRestrictions } from '@/lib/organizations/model-restrictions';
+
+const ModeConfigInputSchema = OrganizationModeConfigSchema.partial();
+
+const ModeUpdateConfigInputSchema = ModeConfigInputSchema.extend({
+  defaultModel: z.string().min(1, 'Default model cannot be empty').nullable().optional(),
+});
+
+type ModeUpdateConfigInput = z.infer<typeof ModeUpdateConfigInputSchema>;
 
 const CreateModeInputSchema = OrganizationIdInputSchema.extend({
   name: z
@@ -28,7 +41,7 @@ const CreateModeInputSchema = OrganizationIdInputSchema.extend({
     .min(1, 'Mode slug is required')
     .max(50, 'Mode slug must be less than 50 characters')
     .regex(/^[a-z0-9-]+$/, 'Mode slug must contain only lowercase letters, numbers, and hyphens'),
-  config: OrganizationModeConfigSchema.partial().optional(),
+  config: ModeConfigInputSchema.optional(),
 });
 
 const UpdateModeInputSchema = OrganizationIdInputSchema.extend({
@@ -40,7 +53,7 @@ const UpdateModeInputSchema = OrganizationIdInputSchema.extend({
     .max(50)
     .regex(/^[a-z0-9-]+$/)
     .optional(),
-  config: OrganizationModeConfigSchema.partial().optional(),
+  config: ModeUpdateConfigInputSchema.optional(),
 });
 
 const DeleteModeInputSchema = OrganizationIdInputSchema.extend({
@@ -50,6 +63,52 @@ const DeleteModeInputSchema = OrganizationIdInputSchema.extend({
 const ModeIdInputSchema = OrganizationIdInputSchema.extend({
   modeId: z.uuid(),
 });
+
+function normalizeModeConfig(
+  config: ModeUpdateConfigInput | undefined
+): Partial<OrganizationModeConfig> | undefined {
+  if (!config) {
+    return undefined;
+  }
+
+  const { defaultModel, ...rest } = config;
+  if (defaultModel === null) {
+    return { ...rest, defaultModel: undefined };
+  }
+  if (defaultModel === undefined) {
+    return rest;
+  }
+
+  return { ...rest, defaultModel };
+}
+
+async function validateDefaultModel(
+  organization: Awaited<ReturnType<typeof getOrganizationById>>,
+  config: ModeUpdateConfigInput | undefined
+): Promise<void> {
+  const defaultModel = config?.defaultModel;
+  if (!organization || defaultModel === undefined || defaultModel === null) {
+    return;
+  }
+
+  if (defaultModel.endsWith('/*')) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Default model '${defaultModel}' is not a concrete model identifier`,
+    });
+  }
+
+  const isAllowed = createAllowPredicateFromRestrictions(
+    getEffectiveModelRestrictions(organization)
+  );
+
+  if (!(await isAllowed(defaultModel))) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Default model '${defaultModel}' is not in the organization's allowed models list`,
+    });
+  }
+}
 
 export const organizationModesRouter = createTRPCRouter({
   create: organizationMemberMutationProcedure
@@ -65,7 +124,15 @@ export const organizationModesRouter = createTRPCRouter({
         });
       }
 
-      const mode = await createOrganizationMode(organizationId, ctx.user.id, name, slug, config);
+      await validateDefaultModel(organization, config);
+
+      const mode = await createOrganizationMode(
+        organizationId,
+        ctx.user.id,
+        name,
+        slug,
+        normalizeModeConfig(config)
+      );
 
       if (!mode) {
         throw new TRPCError({
@@ -123,7 +190,20 @@ export const organizationModesRouter = createTRPCRouter({
         });
       }
 
-      const mode = await updateOrganizationMode(modeId, updates);
+      const organization = await getOrganizationById(organizationId);
+      if (!organization) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Organization not found',
+        });
+      }
+
+      await validateDefaultModel(organization, updates.config);
+
+      const mode = await updateOrganizationMode(modeId, {
+        ...updates,
+        config: normalizeModeConfig(updates.config),
+      });
 
       if (!mode) {
         throw new TRPCError({
@@ -142,33 +222,59 @@ export const organizationModesRouter = createTRPCRouter({
       if (updates.config) {
         const configChanges: string[] = [];
 
-        if (updates.config.roleDefinition !== existingMode.config.roleDefinition) {
+        if (
+          'roleDefinition' in updates.config &&
+          updates.config.roleDefinition !== existingMode.config.roleDefinition
+        ) {
           const oldValue = existingMode.config.roleDefinition || '(empty)';
           const newValue = updates.config.roleDefinition || '(empty)';
           configChanges.push(
             `roleDefinition: "${oldValue.substring(0, 50)}${oldValue.length > 50 ? '...' : ''}" → "${newValue.substring(0, 50)}${newValue.length > 50 ? '...' : ''}"`
           );
         }
-        if (updates.config.whenToUse !== existingMode.config.whenToUse) {
+        if (
+          'whenToUse' in updates.config &&
+          updates.config.whenToUse !== existingMode.config.whenToUse
+        ) {
           const oldValue = existingMode.config.whenToUse || '(empty)';
           const newValue = updates.config.whenToUse || '(empty)';
           configChanges.push(
             `whenToUse: "${oldValue.substring(0, 50)}${oldValue.length > 50 ? '...' : ''}" → "${newValue.substring(0, 50)}${newValue.length > 50 ? '...' : ''}"`
           );
         }
-        if (updates.config.description !== existingMode.config.description) {
+        if (
+          'description' in updates.config &&
+          updates.config.description !== existingMode.config.description
+        ) {
           const oldValue = existingMode.config.description || '(empty)';
           const newValue = updates.config.description || '(empty)';
           configChanges.push(
             `description: "${oldValue.substring(0, 50)}${oldValue.length > 50 ? '...' : ''}" → "${newValue.substring(0, 50)}${newValue.length > 50 ? '...' : ''}"`
           );
         }
-        if (updates.config.customInstructions !== existingMode.config.customInstructions) {
+        if (
+          'customInstructions' in updates.config &&
+          updates.config.customInstructions !== existingMode.config.customInstructions
+        ) {
           const oldValue = existingMode.config.customInstructions || '(empty)';
           const newValue = updates.config.customInstructions || '(empty)';
           configChanges.push(
             `customInstructions: "${oldValue.substring(0, 50)}${oldValue.length > 50 ? '...' : ''}" → "${newValue.substring(0, 50)}${newValue.length > 50 ? '...' : ''}"`
           );
+        }
+        if (
+          'defaultModel' in updates.config &&
+          updates.config.defaultModel !== existingMode.config.defaultModel
+        ) {
+          if (existingMode.config.defaultModel && updates.config.defaultModel) {
+            configChanges.push(
+              `defaultModel: "${existingMode.config.defaultModel}" → "${updates.config.defaultModel}"`
+            );
+          } else if (updates.config.defaultModel) {
+            configChanges.push(`defaultModel: set to "${updates.config.defaultModel}"`);
+          } else if (existingMode.config.defaultModel) {
+            configChanges.push(`defaultModel: cleared "${existingMode.config.defaultModel}"`);
+          }
         }
         if (
           updates.config.groups !== undefined &&

--- a/apps/web/src/routers/organizations/organization-modes-router.ts
+++ b/apps/web/src/routers/organizations/organization-modes-router.ts
@@ -71,21 +71,32 @@ const ModeIdInputSchema = OrganizationIdInputSchema.extend({
   modeId: z.uuid(),
 });
 
-function hasDefaultModelUpdate(config: DefaultModelConfig | undefined): boolean {
-  return !!config && Object.prototype.hasOwnProperty.call(config, 'defaultModel');
+type DefaultModelChange =
+  | { kind: 'none' }
+  | { kind: 'clear' }
+  | { kind: 'set'; defaultModel: string };
+
+function getDefaultModelChange(config: DefaultModelConfig | undefined): DefaultModelChange {
+  if (!config || !Object.prototype.hasOwnProperty.call(config, 'defaultModel')) {
+    return { kind: 'none' };
+  }
+
+  if (config.defaultModel === null) {
+    return { kind: 'clear' };
+  }
+
+  if (typeof config.defaultModel === 'string') {
+    return { kind: 'set', defaultModel: config.defaultModel };
+  }
+
+  return { kind: 'none' };
 }
 
-function hasDefaultModelValue(
-  config: DefaultModelConfig | undefined
-): config is DefaultModelConfig & { defaultModel: string } {
-  return !!config && hasDefaultModelUpdate(config) && typeof config.defaultModel === 'string';
-}
-
-function ensureDefaultModelCanBeSet(
+function assertDefaultModelCanBeSet(
   organization: NonNullable<Awaited<ReturnType<typeof getOrganizationById>>>,
-  config: DefaultModelConfig | undefined
+  change: DefaultModelChange
 ): void {
-  if (!hasDefaultModelValue(config)) {
+  if (change.kind !== 'set') {
     return;
   }
 
@@ -97,11 +108,11 @@ function ensureDefaultModelCanBeSet(
   }
 }
 
-async function ensureDefaultModelConfigEnabled(
+async function assertDefaultModelConfigEnabled(
   userId: string,
-  config: DefaultModelConfig | undefined
+  change: DefaultModelChange
 ): Promise<void> {
-  if (!hasDefaultModelUpdate(config)) {
+  if (change.kind === 'none') {
     return;
   }
 
@@ -135,14 +146,9 @@ function normalizeModeConfig(
 }
 
 async function validateDefaultModel(
-  organization: Awaited<ReturnType<typeof getOrganizationById>>,
-  config: DefaultModelConfig | undefined
+  organization: NonNullable<Awaited<ReturnType<typeof getOrganizationById>>>,
+  defaultModel: string
 ): Promise<void> {
-  const defaultModel = config?.defaultModel;
-  if (!organization || defaultModel === undefined || defaultModel === null) {
-    return;
-  }
-
   const normalizedDefaultModel = normalizeModelId(defaultModel);
   if (normalizedDefaultModel.endsWith('/*')) {
     throw new TRPCError({
@@ -177,10 +183,11 @@ export const organizationModesRouter = createTRPCRouter({
         });
       }
 
-      ensureDefaultModelCanBeSet(organization, config);
-      await ensureDefaultModelConfigEnabled(ctx.user.id, config);
-      if (hasDefaultModelValue(config)) {
-        await validateDefaultModel(organization, config);
+      const defaultModelChange = getDefaultModelChange(config);
+      assertDefaultModelCanBeSet(organization, defaultModelChange);
+      await assertDefaultModelConfigEnabled(ctx.user.id, defaultModelChange);
+      if (defaultModelChange.kind === 'set') {
+        await validateDefaultModel(organization, defaultModelChange.defaultModel);
       }
 
       const mode = await createOrganizationMode(
@@ -255,10 +262,11 @@ export const organizationModesRouter = createTRPCRouter({
         });
       }
 
-      ensureDefaultModelCanBeSet(organization, updates.config);
-      await ensureDefaultModelConfigEnabled(ctx.user.id, updates.config);
-      if (hasDefaultModelValue(updates.config)) {
-        await validateDefaultModel(organization, updates.config);
+      const defaultModelChange = getDefaultModelChange(updates.config);
+      assertDefaultModelCanBeSet(organization, defaultModelChange);
+      await assertDefaultModelConfigEnabled(ctx.user.id, defaultModelChange);
+      if (defaultModelChange.kind === 'set') {
+        await validateDefaultModel(organization, defaultModelChange.defaultModel);
       }
       const normalizedConfig = normalizeModeConfig(updates.config);
 

--- a/apps/web/src/routers/organizations/organization-modes-router.ts
+++ b/apps/web/src/routers/organizations/organization-modes-router.ts
@@ -71,13 +71,35 @@ const ModeIdInputSchema = OrganizationIdInputSchema.extend({
   modeId: z.uuid(),
 });
 
-function hasDefaultModelUpdate(config: ModeUpdateConfigInput | undefined): boolean {
+function hasDefaultModelUpdate(config: DefaultModelConfig | undefined): boolean {
   return !!config && Object.prototype.hasOwnProperty.call(config, 'defaultModel');
+}
+
+function hasDefaultModelValue(
+  config: DefaultModelConfig | undefined
+): config is DefaultModelConfig & { defaultModel: string } {
+  return !!config && hasDefaultModelUpdate(config) && typeof config.defaultModel === 'string';
+}
+
+function ensureDefaultModelCanBeSet(
+  organization: NonNullable<Awaited<ReturnType<typeof getOrganizationById>>>,
+  config: DefaultModelConfig | undefined
+): void {
+  if (!hasDefaultModelValue(config)) {
+    return;
+  }
+
+  if (organization.plan !== 'enterprise') {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Model access configuration is not available for this organization.',
+    });
+  }
 }
 
 async function ensureDefaultModelConfigEnabled(
   userId: string,
-  config: ModeUpdateConfigInput | undefined
+  config: DefaultModelConfig | undefined
 ): Promise<void> {
   if (!hasDefaultModelUpdate(config)) {
     return;
@@ -155,8 +177,11 @@ export const organizationModesRouter = createTRPCRouter({
         });
       }
 
+      ensureDefaultModelCanBeSet(organization, config);
       await ensureDefaultModelConfigEnabled(ctx.user.id, config);
-      await validateDefaultModel(organization, config);
+      if (hasDefaultModelValue(config)) {
+        await validateDefaultModel(organization, config);
+      }
 
       const mode = await createOrganizationMode(
         organizationId,
@@ -230,12 +255,12 @@ export const organizationModesRouter = createTRPCRouter({
         });
       }
 
+      ensureDefaultModelCanBeSet(organization, updates.config);
       await ensureDefaultModelConfigEnabled(ctx.user.id, updates.config);
+      if (hasDefaultModelValue(updates.config)) {
+        await validateDefaultModel(organization, updates.config);
+      }
       const normalizedConfig = normalizeModeConfig(updates.config);
-      const effectiveConfig = normalizedConfig
-        ? { ...existingMode.config, ...normalizedConfig }
-        : existingMode.config;
-      await validateDefaultModel(organization, effectiveConfig);
 
       const mode = await updateOrganizationMode(organizationId, modeId, {
         ...updates,

--- a/apps/web/src/routers/organizations/organization-modes-router.ts
+++ b/apps/web/src/routers/organizations/organization-modes-router.ts
@@ -282,69 +282,67 @@ export const organizationModesRouter = createTRPCRouter({
         changes.push(`slug: "${existingMode.slug}" → "${updates.slug}"`);
       }
       if (updates.config) {
+        const auditConfig = normalizedConfig ?? updates.config;
         const configChanges: string[] = [];
 
         if (
-          'roleDefinition' in updates.config &&
-          updates.config.roleDefinition !== existingMode.config.roleDefinition
+          'roleDefinition' in auditConfig &&
+          auditConfig.roleDefinition !== existingMode.config.roleDefinition
         ) {
           const oldValue = existingMode.config.roleDefinition || '(empty)';
-          const newValue = updates.config.roleDefinition || '(empty)';
+          const newValue = auditConfig.roleDefinition || '(empty)';
           configChanges.push(
             `roleDefinition: "${oldValue.substring(0, 50)}${oldValue.length > 50 ? '...' : ''}" → "${newValue.substring(0, 50)}${newValue.length > 50 ? '...' : ''}"`
           );
         }
-        if (
-          'whenToUse' in updates.config &&
-          updates.config.whenToUse !== existingMode.config.whenToUse
-        ) {
+        if ('whenToUse' in auditConfig && auditConfig.whenToUse !== existingMode.config.whenToUse) {
           const oldValue = existingMode.config.whenToUse || '(empty)';
-          const newValue = updates.config.whenToUse || '(empty)';
+          const newValue = auditConfig.whenToUse || '(empty)';
           configChanges.push(
             `whenToUse: "${oldValue.substring(0, 50)}${oldValue.length > 50 ? '...' : ''}" → "${newValue.substring(0, 50)}${newValue.length > 50 ? '...' : ''}"`
           );
         }
         if (
-          'description' in updates.config &&
-          updates.config.description !== existingMode.config.description
+          'description' in auditConfig &&
+          auditConfig.description !== existingMode.config.description
         ) {
           const oldValue = existingMode.config.description || '(empty)';
-          const newValue = updates.config.description || '(empty)';
+          const newValue = auditConfig.description || '(empty)';
           configChanges.push(
             `description: "${oldValue.substring(0, 50)}${oldValue.length > 50 ? '...' : ''}" → "${newValue.substring(0, 50)}${newValue.length > 50 ? '...' : ''}"`
           );
         }
         if (
-          'customInstructions' in updates.config &&
-          updates.config.customInstructions !== existingMode.config.customInstructions
+          'customInstructions' in auditConfig &&
+          auditConfig.customInstructions !== existingMode.config.customInstructions
         ) {
           const oldValue = existingMode.config.customInstructions || '(empty)';
-          const newValue = updates.config.customInstructions || '(empty)';
+          const newValue = auditConfig.customInstructions || '(empty)';
           configChanges.push(
             `customInstructions: "${oldValue.substring(0, 50)}${oldValue.length > 50 ? '...' : ''}" → "${newValue.substring(0, 50)}${newValue.length > 50 ? '...' : ''}"`
           );
         }
         if (
-          'defaultModel' in updates.config &&
-          updates.config.defaultModel !== existingMode.config.defaultModel
+          'defaultModel' in auditConfig &&
+          auditConfig.defaultModel !== existingMode.config.defaultModel
         ) {
-          if (existingMode.config.defaultModel && updates.config.defaultModel) {
+          if (existingMode.config.defaultModel && auditConfig.defaultModel) {
             configChanges.push(
-              `defaultModel: "${existingMode.config.defaultModel}" → "${updates.config.defaultModel}"`
+              `defaultModel: "${existingMode.config.defaultModel}" → "${auditConfig.defaultModel}"`
             );
-          } else if (updates.config.defaultModel) {
-            configChanges.push(`defaultModel: set to "${updates.config.defaultModel}"`);
+          } else if (auditConfig.defaultModel) {
+            configChanges.push(`defaultModel: set to "${auditConfig.defaultModel}"`);
           } else if (existingMode.config.defaultModel) {
             configChanges.push(`defaultModel: cleared "${existingMode.config.defaultModel}"`);
           }
         }
         if (
-          updates.config.groups !== undefined &&
+          auditConfig.groups !== undefined &&
           existingMode.config.groups !== undefined &&
-          JSON.stringify(updates.config.groups) !== JSON.stringify(existingMode.config.groups)
+          JSON.stringify(auditConfig.groups) !== JSON.stringify(existingMode.config.groups)
         ) {
           const oldValue = JSON.stringify(existingMode.config.groups);
-          const newValue = JSON.stringify(updates.config.groups);
+          const newValue = JSON.stringify(auditConfig.groups);
           configChanges.push(
             `groups: ${oldValue.substring(0, 50)}${oldValue.length > 50 ? '...' : ''} → ${newValue.substring(0, 50)}${newValue.length > 50 ? '...' : ''}`
           );

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -765,6 +765,7 @@ export const OrganizationModeConfigSchema = z.object({
   description: z.string().optional(),
   customInstructions: z.string().optional(),
   groups: z.array(GroupEntrySchema),
+  defaultModel: z.string().min(1, 'Default model cannot be empty').optional(),
 });
 
 export type OrganizationModeConfig = z.infer<typeof OrganizationModeConfigSchema>;


### PR DESCRIPTION
## Summary

- Add optional `defaultModel` support to organization mode config so organizations can choose a model per mode before CLI and VSCode clients begin consuming that field.
- This enables organizations to steer different workflows toward different models, such as using a stronger planning model for `architect` while keeping `code` on a faster coding model, without removing user-level model overrides.
- The follow-up CLI and VSCode work will consume these mode defaults below user-driven selection, so cloud admins can establish sensible organizational defaults while users retain the ability to override them locally.
- This is the cloud-side first step of a staged rollout: it establishes the additive storage contract, validation, audit behavior, and UI controls while keeping existing clients unchanged.
- Add server-side validation for concrete model IDs, organization allow/deny policy checks, enterprise-only setting behavior, audit diffs, and release-flag-gated writes through `org-default-model-config`.
- Add the cloud UI picker and mode-card display behind the same flag, including built-in override clear behavior, downgraded-org clear-only behavior, and development-mode visibility.
- Keep the picker sourced from the existing org-scoped model list so mode defaults are selected only from models currently allowed for that organization.
- Make partial mode config updates atomic in JSONB so concurrent description/default-model edits do not overwrite each other.

## Verification

API response sample

```
❯ http GET http://localhost:3000/api/organizations/9c3780e5-69ce-4d18-a0a8-b1ec0998db83/modes \
  Authorization:"Bearer [redacted]" \
  X-KiloCode-OrganizationId:"9c3780e5-69ce-4d18-a0a8-b1ec0998db83"
HTTP/1.1 200 OK
<headers trimmed>

{
    "modes": [
        {
            "config": {
                "customInstructions": "",
                "defaultModel": "kilo-auto/balanced",
                "description": "Write, modify, and refactor code",
                "groups": [
                    "browser",
                    "command",
                    "edit",
                    "mcp",
                    "read"
                ],
                "roleDefinition": "You are Kilo Code, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.",
                "whenToUse": "Use this mode when you need to write, modify, or refactor code. Ideal for implementing features, fixing bugs, creating new files, or making code improvements across any programming language or framework."
            },
            "created_at": "2026-06-11 21:54:37.803677+00",
            "created_by": "[redacted]",
            "id": "3b325243-bd36-48aa-b9ee-3cb4e8a83cc1",
            "name": "Code",
            "organization_id": "9c3780e5-69ce-4d18-a0a8-b1ec0998db83",
            "slug": "code",
            "updated_at": "2026-06-12 14:14:30.317325+00"
        }
    ]
}
```

## Visual Changes

| Before | After |
|---|---|
| Mode drawer without a mode default model control | Mode drawer with gated `Mode Default Model` picker |
| Mode cards without model metadata | Mode cards showing gated default-model metadata |
| Built-in mode overrides only supported config edits | Built-in mode overrides can clear the last default-model override and revert |

<img width="798" height="282" alt="SCR-20260612-ipys" src="https://github.com/user-attachments/assets/23c24657-7a06-4b90-a1ee-434f18d18fd4" />

<img width="658" height="290" alt="Screenshot 2026-06-12 at 9 18 04 AM" src="https://github.com/user-attachments/assets/a294bc05-270b-4f35-8cf1-413260b58f88" />

<img width="693" height="276" alt="Screenshot 2026-06-12 at 9 18 16 AM" src="https://github.com/user-attachments/assets/c3446fc4-9c8a-46e9-9bfe-d8e3ccc3f14f" />

## Reviewer Notes

- This is intentionally additive and safe for existing mode rows because `defaultModel` is optional in the JSONB config.
- The flag is off for all users except `*kilocode.ai` emails, so existing cloud behavior remains unchanged until the CLI PR lands and is vetted.
- Setting a mode default is enterprise-only; clearing an existing default remains allowed after downgrade.
- Stored defaults that later become disallowed do not block unrelated mode edits.
- The main risk area is the distinction between clearing a mode-specific default and deleting the last built-in override row.
