### PR TITLE
Fix/kiloclaw instance distribution collapse

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
@@ -667,7 +667,9 @@ function OrphanVolumesSection() {
                     <TableHead>DO Status</TableHead>
                     <TableHead>Destroyed</TableHead>
                     <TableHead>Subscription</TableHead>
-                    <TableHead>Sub. Ended</TableHead>
+                    <TableHead title="End of the subscription's current paid or trial period — the closest available proxy for when the user's access ended, not an authoritative cancellation timestamp.">
+                      Period End
+                    </TableHead>
                     <TableHead>Classification</TableHead>
                     <TableHead className="text-right">Actions</TableHead>
                   </TableRow>

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
@@ -154,6 +154,7 @@ type OrphanVolumeRow = {
   organization_id: string | null;
   destroyed_at: string;
   subscription_status: string | null;
+  subscription_ended_at: string | null;
   fly_app: string;
   volume_id: string;
   volume_name: string;
@@ -666,6 +667,7 @@ function OrphanVolumesSection() {
                     <TableHead>DO Status</TableHead>
                     <TableHead>Destroyed</TableHead>
                     <TableHead>Subscription</TableHead>
+                    <TableHead>Sub. Ended</TableHead>
                     <TableHead>Classification</TableHead>
                     <TableHead className="text-right">Actions</TableHead>
                   </TableRow>
@@ -740,6 +742,20 @@ function OrphanVolumesSection() {
                           </Badge>
                         ) : (
                           <span className="text-muted-foreground text-sm">—</span>
+                        )}
+                      </TableCell>
+                      <TableCell
+                        className="text-xs"
+                        title={
+                          volume.subscription_ended_at
+                            ? new Date(volume.subscription_ended_at).toLocaleString()
+                            : undefined
+                        }
+                      >
+                        {volume.subscription_ended_at ? (
+                          formatRelativeTime(volume.subscription_ended_at)
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
                         )}
                       </TableCell>
                       <TableCell>

--- a/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
+++ b/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
@@ -506,6 +506,11 @@ function InstanceDistributionPanel() {
   const otherPinned = collapsedTail.reduce((sum, s) => sum + s.pinnedCount, 0);
   const otherPct = collapsedTail.reduce((sum, s) => sum + s.pct, 0);
   const hasOther = collapsedTail.length > 0;
+  // Count only real versions for the "N versions" label — the "no tag yet"
+  // bucket is unreconciled instances, not a version, so folding it into the
+  // tally would overstate how many image tags "Other" represents. Its
+  // instances still contribute to otherCount / otherPct.
+  const otherVersions = collapsedTail.filter(s => !s.isUnknown).length;
 
   // Bar order mirrors the legend: headline buckets, then the biggest shares,
   // then the single aggregated "Other" segment.
@@ -583,7 +588,7 @@ function InstanceDistributionPanel() {
                 <div
                   className="bg-zinc-500"
                   style={{ width: `${otherPct}%`, minWidth: otherCount > 0 ? '3px' : 0 }}
-                  title={`Other (${collapsedTail.length} versions): ${otherCount} (${Math.round(otherPct)}%)`}
+                  title={`Other (${otherVersions} version${otherVersions === 1 ? '' : 's'}): ${otherCount} (${Math.round(otherPct)}%)`}
                 />
               )}
             </div>
@@ -602,7 +607,7 @@ function InstanceDistributionPanel() {
                 >
                   <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm bg-zinc-500" />
                   <span>
-                    Other ({collapsedTail.length} version{collapsedTail.length === 1 ? '' : 's'})
+                    Other ({otherVersions} version{otherVersions === 1 ? '' : 's'})
                   </span>
                   <span className="font-medium tabular-nums">{Math.round(otherPct)}%</span>
                   <span className="tabular-nums">({otherCount})</span>

--- a/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
+++ b/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
@@ -381,11 +381,60 @@ function StartRolloutButton({
  * Data comes from the denormalized `tracked_image_tag` column on kiloclaw_instances,
  * which is written by the DO alarm reconciler and may lag ~30 min for idle instances.
  */
+// Surface only the headline buckets in the legend; collapse the rest below
+// this share into one "Other" segment. Without a cap, a slow fleet-wide
+// upgrade spreads instances across dozens of image tags and turns the legend
+// into an unreadable rainbow wall of `0% (n)` chips.
+const DISTRIBUTION_MAX_LEGEND_ROWS = 8;
+const DISTRIBUTION_MIN_SHARE_PCT = 2;
+
+type DistributionSegment = {
+  key: string;
+  color: string;
+  label: string;
+  pct: number;
+  count: number;
+  pinnedCount: number;
+  isLatest: boolean;
+  isUnknown: boolean;
+  isCandidate: boolean;
+  rolloutPercent: number | null;
+};
+
+/** One legend row — a color swatch, label, optional candidate badge, share %,
+ *  instance count, and pinned-anchor count. Shared by the top-level legend and
+ *  the expanded "Other" drawer so both render identically. */
+function DistributionLegendEntry({ seg }: { seg: DistributionSegment }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className={`inline-block h-2.5 w-2.5 shrink-0 rounded-sm ${seg.color}`} />
+      <span className={seg.isUnknown ? 'text-muted-foreground italic' : ''} title={seg.label}>
+        {seg.label.length > 22 ? `${seg.label.slice(0, 22)}…` : seg.label}
+      </span>
+      {seg.isCandidate && (
+        <Badge className="bg-purple-600 px-1 py-0 text-[10px] text-white">
+          <Rocket className="mr-0.5 h-2.5 w-2.5" />
+          {seg.rolloutPercent}%
+        </Badge>
+      )}
+      <span className="font-medium tabular-nums">{Math.round(seg.pct)}%</span>
+      <span className="text-muted-foreground tabular-nums">({seg.count})</span>
+      {seg.pinnedCount > 0 && (
+        <span className="text-muted-foreground inline-flex items-center gap-0.5">
+          <Anchor className="h-3 w-3" />
+          {seg.pinnedCount}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function InstanceDistributionPanel() {
   const trpc = useTRPC();
   const { data, isLoading, isError, refetch, isFetching, dataUpdatedAt } = useQuery(
     trpc.admin.kiloclawVersions.getVersionDistribution.queryOptions()
   );
+  const [othersExpanded, setOthersExpanded] = useState(false);
 
   const total = data?.total ?? 0;
   const rows = data?.rows ?? [];
@@ -394,7 +443,7 @@ function InstanceDistributionPanel() {
   // blue = :latest, purple = candidate, red = disabled, amber = old/superseded,
   // muted = "no tag yet" (DO hasn't reconciled). `pct` is unrounded so the bar
   // segments stay proportional; the legend rounds for display.
-  const segments = rows.map((row, i) => {
+  const segments: DistributionSegment[] = rows.map((row, i) => {
     const isLatest = row.is_latest === true;
     const isDisabled = row.status === 'disabled';
     // Match the catalog table's predicate: a disabled row may retain a nonzero
@@ -420,11 +469,47 @@ function InstanceDistributionPanel() {
       pct,
       count: row.count,
       pinnedCount: row.pinned_count,
+      isLatest,
       isUnknown,
       isCandidate,
       rolloutPercent: row.rollout_percent,
     };
   });
+
+  // :latest and the active candidate always stay visible — they're the buckets
+  // ops is steering a rollout toward, regardless of how small their share is.
+  // Everything else is ranked by share; the biggest fill the remaining legend
+  // slots and the rest fold into "Other".
+  const latestAndCandidate = segments.filter(s => s.isLatest || s.isCandidate);
+  const tail = segments
+    .filter(s => !s.isLatest && !s.isCandidate)
+    .sort((a, b) => b.count - a.count);
+
+  const visibleTail: DistributionSegment[] = [];
+  const collapsedTail: DistributionSegment[] = [];
+  for (const seg of tail) {
+    const hasRoom = latestAndCandidate.length + visibleTail.length < DISTRIBUTION_MAX_LEGEND_ROWS;
+    if (hasRoom && seg.pct >= DISTRIBUTION_MIN_SHARE_PCT) {
+      visibleTail.push(seg);
+    } else {
+      collapsedTail.push(seg);
+    }
+  }
+  // Collapsing a lone straggler into "Other (1 version)" hides nothing and just
+  // costs a click — show it inline instead.
+  if (collapsedTail.length === 1) {
+    const only = collapsedTail.pop();
+    if (only) visibleTail.push(only);
+  }
+
+  const otherCount = collapsedTail.reduce((sum, s) => sum + s.count, 0);
+  const otherPinned = collapsedTail.reduce((sum, s) => sum + s.pinnedCount, 0);
+  const otherPct = collapsedTail.reduce((sum, s) => sum + s.pct, 0);
+  const hasOther = collapsedTail.length > 0;
+
+  // Bar order mirrors the legend: headline buckets, then the biggest shares,
+  // then the single aggregated "Other" segment.
+  const visibleSegments = [...latestAndCandidate, ...visibleTail];
 
   return (
     <Card>
@@ -483,9 +568,10 @@ function InstanceDistributionPanel() {
         ) : (
           <div className="flex flex-col gap-3">
             {/* Single stacked bar — fixed height regardless of how many versions
-                are in the fleet, so it never pushes the catalog table down. */}
+                are in the fleet, so it never pushes the catalog table down. The
+                long tail is one aggregated "Other" segment. */}
             <div className="flex h-3 w-full overflow-hidden rounded-full bg-muted">
-              {segments.map(seg => (
+              {visibleSegments.map(seg => (
                 <div
                   key={seg.key}
                   className={seg.color}
@@ -493,35 +579,55 @@ function InstanceDistributionPanel() {
                   title={`${seg.label}: ${seg.count} (${Math.round(seg.pct)}%)`}
                 />
               ))}
+              {hasOther && (
+                <div
+                  className="bg-zinc-500"
+                  style={{ width: `${otherPct}%`, minWidth: otherCount > 0 ? '3px' : 0 }}
+                  title={`Other (${collapsedTail.length} versions): ${otherCount} (${Math.round(otherPct)}%)`}
+                />
+              )}
             </div>
-            {/* Compact wrapping legend — grows far slower than a row-per-version table. */}
+            {/* Compact wrapping legend — grows far slower than a row-per-version
+                table, and the long tail stays folded behind "Other". */}
             <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-xs">
-              {segments.map(seg => (
-                <div key={seg.key} className="flex items-center gap-1.5">
-                  <span className={`inline-block h-2.5 w-2.5 shrink-0 rounded-sm ${seg.color}`} />
-                  <span
-                    className={seg.isUnknown ? 'text-muted-foreground italic' : ''}
-                    title={seg.label}
-                  >
-                    {seg.label.length > 22 ? `${seg.label.slice(0, 22)}…` : seg.label}
+              {visibleSegments.map(seg => (
+                <DistributionLegendEntry key={seg.key} seg={seg} />
+              ))}
+              {hasOther && (
+                <button
+                  type="button"
+                  className="hover:text-foreground text-muted-foreground flex items-center gap-1.5 transition-colors"
+                  onClick={() => setOthersExpanded(v => !v)}
+                  aria-expanded={othersExpanded}
+                >
+                  <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm bg-zinc-500" />
+                  <span>
+                    Other ({collapsedTail.length} version{collapsedTail.length === 1 ? '' : 's'})
                   </span>
-                  {seg.isCandidate && (
-                    <Badge className="bg-purple-600 px-1 py-0 text-[10px] text-white">
-                      <Rocket className="mr-0.5 h-2.5 w-2.5" />
-                      {seg.rolloutPercent}%
-                    </Badge>
-                  )}
-                  <span className="font-medium tabular-nums">{Math.round(seg.pct)}%</span>
-                  <span className="text-muted-foreground tabular-nums">({seg.count})</span>
-                  {seg.pinnedCount > 0 && (
-                    <span className="text-muted-foreground inline-flex items-center gap-0.5">
+                  <span className="font-medium tabular-nums">{Math.round(otherPct)}%</span>
+                  <span className="tabular-nums">({otherCount})</span>
+                  {otherPinned > 0 && (
+                    <span className="inline-flex items-center gap-0.5">
                       <Anchor className="h-3 w-3" />
-                      {seg.pinnedCount}
+                      {otherPinned}
                     </span>
                   )}
-                </div>
-              ))}
+                  {othersExpanded ? (
+                    <ChevronUp className="h-3 w-3" />
+                  ) : (
+                    <ChevronDown className="h-3 w-3" />
+                  )}
+                </button>
+              )}
             </div>
+            {/* Expanded "Other" drawer — the folded long tail, indented. */}
+            {hasOther && othersExpanded && (
+              <div className="border-muted ml-1 flex flex-wrap gap-x-4 gap-y-1.5 border-l-2 pl-3 text-xs">
+                {collapsedTail.map(seg => (
+                  <DistributionLegendEntry key={seg.key} seg={seg} />
+                ))}
+              </div>
+            )}
             <p className="text-muted-foreground text-xs">
               {total} active instance{total === 1 ? '' : 's'} · grouped by each instance's{' '}
               <span className="font-medium">target</span> image tag (applied on next

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -2983,6 +2983,66 @@ describe('admin.kiloclawInstances.findOrphanVolumes', () => {
     });
   });
 
+  it('falls back to trial_ends_at for subscription_ended_at when there is no paid period', async () => {
+    // A never-converted trial has no current_period_end; the scan query
+    // coalesces to trial_ends_at so the volume table still reports an end date
+    // instead of a blank cell that reads as "no subscription".
+    const destroyedAt = new Date(Date.now() - 30 * 86_400_000).toISOString();
+    const sandboxId = `ki_${crypto.randomUUID().replace(/-/g, '')}`;
+    const [instance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        id: crypto.randomUUID(),
+        user_id: regularUser.id,
+        sandbox_id: sandboxId,
+        destroyed_at: destroyedAt,
+      })
+      .returning({ id: kiloclaw_instances.id });
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: regularUser.id,
+      instance_id: instance.id,
+      plan: 'trial',
+      status: 'canceled',
+      trial_ends_at: '2026-02-01T08:00:00.000Z',
+    });
+
+    mockScanOrphanVolumes.mockResolvedValue({
+      flyApp: 'inst-trialend',
+      appExists: true,
+      expectedVolumeName: 'kiloclaw_trialend',
+      doStatus: null,
+      doStatusError: null,
+      scanError: null,
+      volumes: [
+        {
+          id: 'vol_trialend00000000',
+          name: 'kiloclaw_trialend',
+          state: 'created',
+          size_gb: 10,
+          region: 'ord',
+          attached_machine_id: null,
+          created_at: '2026-04-01T00:00:00.000Z',
+          nameMatchesInstance: true,
+          trackedByLiveDo: false,
+        },
+      ],
+    });
+
+    const destroyedMs = Date.parse(destroyedAt);
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.findOrphanVolumes({
+      destroyedAfter: new Date(destroyedMs - 60_000).toISOString(),
+      destroyedBefore: new Date(destroyedMs + 60_000).toISOString(),
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.volumes).toHaveLength(1);
+    expect(result.volumes[0]).toMatchObject({
+      volume_id: 'vol_trialend00000000',
+      subscription_ended_at: '2026-02-01T08:00:00.000Z',
+    });
+  });
+
   it('scans production-shaped timestamp rows inside a narrow same-day ISO window', async () => {
     const destroyedAt = '2026-05-15 10:06:30.976+00';
     const sandboxId = `ki_${crypto.randomUUID().replace(/-/g, '')}`;

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -2935,6 +2935,7 @@ describe('admin.kiloclawInstances.findOrphanVolumes', () => {
       instance_id: instance.id,
       plan: 'trial',
       status: 'canceled',
+      current_period_end: '2026-03-15T12:00:00.000Z',
     });
 
     mockScanOrphanVolumes.mockResolvedValue({
@@ -2975,6 +2976,9 @@ describe('admin.kiloclawInstances.findOrphanVolumes', () => {
       instance_id: instance.id,
       volume_id: 'vol_findorphans00000',
       subscription_status: 'canceled',
+      // current_period_end is surfaced as the "subscription ended" timestamp,
+      // formatted as strict ISO 8601 by the scan query's to_char.
+      subscription_ended_at: '2026-03-15T12:00:00.000Z',
       classification: 'safe_destroy',
     });
   });

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -3982,11 +3982,14 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           ) as latest_sandbox_destroyed_at,
           u.google_user_email as user_email,
           s.status as subscription_status,
-          -- When this user's KiloClaw subscription ended, shown in the admin
-          -- volume table. There is no dedicated canceled_at column, so prefer
-          -- the paid billing-period boundary and fall back to the trial end —
-          -- otherwise a never-converted trial (no current_period_end) would
-          -- render a blank "Sub. Ended" as if no subscription existed.
+          -- Billing/trial period boundary for the subscription tied to this
+          -- destroyed instance — shown in the admin volume table as a proxy for
+          -- when the user's access ended (there is no canonical canceled_at
+          -- column). Prefer the paid period end, fall back to the trial end so
+          -- never-converted trials aren't blank. This is NOT an authoritative
+          -- end event: transfers and immediate cancellations can leave a
+          -- boundary that differs from the lineage's true end, so the UI labels
+          -- this column "Period End" rather than "Ended".
           coalesce(s.current_period_end, s.trial_ends_at) as subscription_ended_at
         from kiloclaw_instances i
         left join kilocode_users u on i.user_id = u.id

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -3922,6 +3922,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       latest_sandbox_destroyed_at: string | null;
       user_email: string | null;
       subscription_status: string | null;
+      subscription_ended_at: string | null;
     };
 
     // 1. The latest destroyed row per (user, sandbox) inside the requested
@@ -3963,7 +3964,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         to_char(ranked.destroyed_at at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as destroyed_at,
         to_char(ranked.latest_sandbox_destroyed_at at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as latest_sandbox_destroyed_at,
         ranked.user_email,
-        ranked.subscription_status
+        ranked.subscription_status,
+        to_char(ranked.subscription_ended_at at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as subscription_ended_at
       from (
         select distinct on (i.user_id, i.sandbox_id)
           i.id,
@@ -3979,7 +3981,12 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
               and latest.destroyed_at is not null
           ) as latest_sandbox_destroyed_at,
           u.google_user_email as user_email,
-          s.status as subscription_status
+          s.status as subscription_status,
+          -- End of the subscription's last paid period — the closest signal
+          -- for "when did this user's KiloClaw subscription end". Used by the
+          -- admin volume table to avoid nuking volumes whose subscription
+          -- ended (or ends) within the recent grace window.
+          s.current_period_end as subscription_ended_at
         from kiloclaw_instances i
         left join kilocode_users u on i.user_id = u.id
         left join kiloclaw_subscriptions s on i.id = s.instance_id
@@ -4014,6 +4021,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       organization_id: string | null;
       destroyed_at: string;
       subscription_status: string | null;
+      subscription_ended_at: string | null;
       fly_app: string;
       volume_id: string;
       volume_name: string;
@@ -4154,6 +4162,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             organization_id: instance.organization_id,
             destroyed_at: destroyedAt,
             subscription_status: instance.subscription_status,
+            subscription_ended_at: instance.subscription_ended_at,
             fly_app: scan.flyApp,
             volume_id: v.id,
             volume_name: v.name,

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -3982,11 +3982,12 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           ) as latest_sandbox_destroyed_at,
           u.google_user_email as user_email,
           s.status as subscription_status,
-          -- End of the subscription's last paid period — the closest signal
-          -- for "when did this user's KiloClaw subscription end". Used by the
-          -- admin volume table to avoid nuking volumes whose subscription
-          -- ended (or ends) within the recent grace window.
-          s.current_period_end as subscription_ended_at
+          -- When this user's KiloClaw subscription ended, shown in the admin
+          -- volume table. There is no dedicated canceled_at column, so prefer
+          -- the paid billing-period boundary and fall back to the trial end —
+          -- otherwise a never-converted trial (no current_period_end) would
+          -- render a blank "Sub. Ended" as if no subscription existed.
+          coalesce(s.current_period_end, s.trial_ends_at) as subscription_ended_at
         from kiloclaw_instances i
         left join kilocode_users u on i.user_id = u.id
         left join kiloclaw_subscriptions s on i.id = s.instance_id


### PR DESCRIPTION
## Summary

Two cleanups to the KiloClaw admin panel.

- Instance Distribution (Versions tab): the legend rendered one chip per image tag with no cap, so a fleet spread across dozens of tags became an unreadable row of `0% (n)` chips. The legend now keeps `:latest` and the active rollout candidate always visible, shows the largest remaining shares, and folds everything else into a single "Other" segment that expands on click.
- Orphan Volumes (Orphans tab): added a "Period End" column to the Leftover Volume Cleanup table showing how long ago each user's subscription billing or trial period ended, so an admin has that context before destroying a leftover volume.

## Changes

Instance Distribution panel (`KiloclawVersionsPage.tsx`):
- Cap the legend at 8 rows and drop shares under 2% into one aggregated "Other" bar segment and legend row.
- Always show `:latest` and the active candidate, regardless of their share.
- "Other" toggles a drawer listing the folded versions. A lone straggler is shown inline instead of as "Other (1 version)".
- "Other (N versions)" counts only real versions and excludes the "no tag yet" (unreconciled) bucket, while that bucket's instances still count toward the segment's total and percentage.
- Pulled the legend row into a shared `DistributionLegendEntry` component used by both the main legend and the drawer.

Orphan Volumes table (`admin-kiloclaw-instances-router.ts`, `KiloclawOrphansTab.tsx`):
- The `findOrphanVolumes` scan query selects `coalesce(current_period_end, trial_ends_at)` as `subscription_ended_at`, formatted as ISO 8601, and threads it through the row types into each volume row.
- New "Period End" column renders the value as relative time with the exact timestamp on hover, and shows "—" when there is no subscription.
- A header tooltip and a SQL comment state this is a billing or trial period boundary used as a proxy for when access ended, not an authoritative cancellation timestamp.
- Added a test covering the `trial_ends_at` fallback when there is no paid period.

## Verification

- [ ] Automated checks pass locally: typecheck, lint, prettier, and the `findOrphanVolumes` router tests including the new trial fallback case.
- [ ] Manual in-app verification of the two admin views was not performed as part of this change.

## Visual Changes

UI changed in two admin tabs (Versions distribution legend, Orphans volume table). Before/after screenshots to be added.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- `subscription_ended_at` comes from a LEFT JOIN on `kiloclaw_subscriptions.instance_id` and is a period boundary, not a canonical end event. Transfers and immediate cancellations can leave a boundary that differs from the lineage's true end, which is why the column is labeled "Period End" rather than "Ended".
- The distribution thresholds (8 legend rows, 2% minimum share) are constants at the top of `KiloclawVersionsPage.tsx` and easy to tune.
