### PR TITLE
fix(claw): guard onboarding against accidental refresh during provisi…

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -274,6 +274,27 @@ function ClawOnboardingFlowInner({
     posthog?.capture('claw_setup_done_viewed');
   }, [mode, flowState.postProvisioningReady, posthog]);
 
+  // Warn before an accidental reload/close while a fresh instance is
+  // provisioning. The wizard step and bot identity live only in component
+  // state (see the `useState` above) and nothing durable backs them, so a
+  // full-page refresh during this window drops the user back to the identity
+  // step. Re-submitting there fires a SECOND provision against the instance
+  // that's already coming up — which the backend rejects with an error. The
+  // native prompt gives the user a chance to stay put. Scope the listener to
+  // create-first provisioning so it never nags on the complete step (where we
+  // auto-redirect to chat) or in plain post-provisioning reloads. Browsers
+  // ignore custom text, so we only need to opt into the prompt.
+  useEffect(() => {
+    const provisioningInFlight = flowState.createSetupActive && flowState.renderStep !== 'complete';
+    if (!provisioningInFlight) return;
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [flowState.createSetupActive, flowState.renderStep]);
+
   const resetWizardSelections = useCallback(() => {
     setOnboardingStep('identity');
     setBotIdentity(null);


### PR DESCRIPTION
## Summary

The KiloClaw onboarding wizard keeps its current step and the bot identity only in component state, with nothing durable backing them. If a user refreshes or closes the tab while a fresh instance is still provisioning, that state is lost and the wizard re-renders the first (identity) step. Re-submitting there fires a second provision against the instance already coming up, which the backend rejects with an error.

This adds a `beforeunload` listener in `ClawOnboardingFlowInner` that triggers the browser's native "Leave site?" prompt during the provisioning window, giving the user a chance to stay on the page instead of losing their progress.

The listener is scoped to the create-first provisioning window (`flowState.createSetupActive && flowState.renderStep !== 'complete'`), so it does not fire on the complete step (where the wizard auto-redirects to chat) or on plain post-provisioning reloads. It covers both the personal and org onboarding flows since they share this component.

## Verification

- [ ] No manual browser testing was performed. The change uses the standard `beforeunload` pattern already present in the gastown onboarding wizard. Automated checks (format, lint, typecheck, and the claw onboarding state tests) pass locally.

## Visual Changes

N/A. The only user-facing addition is the browser's native unload confirmation dialog during provisioning; no styled UI changed.

## Reviewer Notes

- This closes the accidental-refresh path that triggered the error. It does not make the wizard refresh-durable: an intentional refresh or tab restore would still drop the in-memory step. A follow-up could persist `onboardingStep` and reconcile against live billing/status on mount.
- The effect deps are the two primitive values it reads (`createSetupActive`, `renderStep`), so the listener attaches and detaches as the flow enters and leaves the provisioning window.
