### PR TITLE
ci(deploy): reuse Vercel deployment workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -78,35 +78,10 @@ jobs:
         run: NODE_ENV=production pnpm run drizzle migrate
 
   stage-app:
-    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
-    timeout-minutes: 30
-    environment: production
-
-    outputs:
-      deployment_url: ${{ steps.deploy.outputs.deployment_url }}
-
-    env:
-      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
-
-    steps:
-      - name: Checkout code
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
-        with:
-          lfs: true
-
-      - name: Install Vercel CLI
-        run: npm install -g vercel@${{ env.VERCEL_VERSION }}
-
-      - name: Stage Vercel deployment
-        id: deploy
-        run: |
-          deployment_output=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
-          deployment_url=$(printf '%s\n' "$deployment_output" | tail -n 1)
-          if [[ ! "$deployment_url" =~ ^https:// ]]; then
-            echo "Vercel deploy did not print a deployment URL" >&2
-            exit 1
-          fi
-          echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
+    uses: ./.github/workflows/stage-vercel-deployment.yml
+    with:
+      vercel_project_id_var: VERCEL_PROJECT_ID_APP
+    secrets: inherit
 
   stage-global-app:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -84,35 +84,10 @@ jobs:
     secrets: inherit
 
   stage-global-app:
-    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
-    timeout-minutes: 30
-    environment: production
-
-    outputs:
-      deployment_url: ${{ steps.deploy.outputs.deployment_url }}
-
-    env:
-      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GLOBAL_APP }}
-
-    steps:
-      - name: Checkout code
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
-        with:
-          lfs: true
-
-      - name: Install Vercel CLI
-        run: npm install -g vercel@${{ env.VERCEL_VERSION }}
-
-      - name: Stage Vercel deployment
-        id: deploy
-        run: |
-          deployment_output=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
-          deployment_url=$(printf '%s\n' "$deployment_output" | tail -n 1)
-          if [[ ! "$deployment_url" =~ ^https:// ]]; then
-            echo "Vercel deploy did not print a deployment URL" >&2
-            exit 1
-          fi
-          echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
+    uses: ./.github/workflows/stage-vercel-deployment.yml
+    with:
+      vercel_project_id_var: VERCEL_PROJECT_ID_GLOBAL_APP
+    secrets: inherit
 
   promote-app:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -90,30 +90,18 @@ jobs:
     secrets: inherit
 
   promote-app:
-    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
-    timeout-minutes: 15
     needs: [stage-app, check-production-db-startup, run-migrations]
-    environment: production
-
-    steps:
-      - name: Install Vercel CLI
-        run: npm install -g vercel@${{ env.VERCEL_VERSION }}
-
-      - name: Promote Vercel deployment
-        run: vercel promote "${{ needs.stage-app.outputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_TOKEN }}
+    uses: ./.github/workflows/promote-vercel-deployment.yml
+    with:
+      deployment_url: ${{ needs.stage-app.outputs.deployment_url }}
+    secrets: inherit
 
   promote-global-app:
-    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
-    timeout-minutes: 15
     needs: [stage-global-app, check-production-db-startup, run-migrations]
-    environment: production
-
-    steps:
-      - name: Install Vercel CLI
-        run: npm install -g vercel@${{ env.VERCEL_VERSION }}
-
-      - name: Promote Vercel deployment
-        run: vercel promote "${{ needs.stage-global-app.outputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_TOKEN }}
+    uses: ./.github/workflows/promote-vercel-deployment.yml
+    with:
+      deployment_url: ${{ needs.stage-global-app.outputs.deployment_url }}
+    secrets: inherit
 
   resolve-worker-base:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}

--- a/.github/workflows/promote-vercel-deployment.yml
+++ b/.github/workflows/promote-vercel-deployment.yml
@@ -1,0 +1,28 @@
+name: Promote Vercel Deployment
+
+on:
+  workflow_call:
+    inputs:
+      deployment_url:
+        description: 'Vercel deployment URL to promote'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    environment: production
+
+    env:
+      VERCEL_VERSION: '53.3.1'
+
+    steps:
+      - name: Install Vercel CLI
+        run: npm install -g vercel@${{ env.VERCEL_VERSION }}
+
+      - name: Promote Vercel deployment
+        run: vercel promote "${{ inputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/redeploy-web.yml
+++ b/.github/workflows/redeploy-web.yml
@@ -10,9 +10,6 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
-env:
-  VERCEL_VERSION: '53.3.1'
-
 jobs:
   verify-main:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
@@ -26,54 +23,30 @@ jobs:
             exit 1
           fi
 
-  deploy-app:
+  stage-app:
     needs: verify-main
-    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
-    timeout-minutes: 30
-    environment: production
+    uses: ./.github/workflows/stage-vercel-deployment.yml
+    with:
+      vercel_project_id_var: VERCEL_PROJECT_ID_APP
+    secrets: inherit
 
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_APP }}
-
-    steps:
-      - name: Checkout code
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
-        with:
-          lfs: true
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: '.nvmrc'
-
-      - run: npx vercel@${{ env.VERCEL_VERSION }} link --project=kilocode-app --token=${{ secrets.VERCEL_TOKEN }} --yes
-
-      - name: Deploy to Vercel
-        run: npx vercel@${{ env.VERCEL_VERSION }} deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
-
-  deploy-global-app:
+  stage-global-app:
     needs: verify-main
-    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
-    timeout-minutes: 30
-    environment: production
+    uses: ./.github/workflows/stage-vercel-deployment.yml
+    with:
+      vercel_project_id_var: VERCEL_PROJECT_ID_GLOBAL_APP
+    secrets: inherit
 
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_GLOBAL_APP }}
+  promote-app:
+    needs: stage-app
+    uses: ./.github/workflows/promote-vercel-deployment.yml
+    with:
+      deployment_url: ${{ needs.stage-app.outputs.deployment_url }}
+    secrets: inherit
 
-    steps:
-      - name: Checkout code
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
-        with:
-          lfs: true
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: '.nvmrc'
-
-      - run: npx vercel@${{ env.VERCEL_VERSION }} link --project=kilocode-global-app --token=${{ secrets.VERCEL_TOKEN }} --yes
-
-      - name: Deploy to Vercel
-        run: npx vercel@${{ env.VERCEL_VERSION }} deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+  promote-global-app:
+    needs: stage-global-app
+    uses: ./.github/workflows/promote-vercel-deployment.yml
+    with:
+      deployment_url: ${{ needs.stage-global-app.outputs.deployment_url }}
+    secrets: inherit

--- a/.github/workflows/stage-vercel-deployment.yml
+++ b/.github/workflows/stage-vercel-deployment.yml
@@ -1,0 +1,50 @@
+name: Stage Vercel Deployment
+
+on:
+  workflow_call:
+    inputs:
+      vercel_project_id_var:
+        description: 'Name of the GitHub variable containing the Vercel project ID to deploy'
+        required: true
+        type: string
+    outputs:
+      deployment_url:
+        description: 'Staged Vercel deployment URL'
+        value: ${{ jobs.stage.outputs.deployment_url }}
+
+permissions:
+  contents: read
+
+jobs:
+  stage:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    environment: production
+
+    outputs:
+      deployment_url: ${{ steps.deploy.outputs.deployment_url }}
+
+    env:
+      VERCEL_VERSION: '53.3.1'
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars[inputs.vercel_project_id_var] }}
+
+    steps:
+      - name: Checkout code
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        with:
+          lfs: true
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@${{ env.VERCEL_VERSION }}
+
+      - name: Stage Vercel deployment
+        id: deploy
+        run: |
+          deployment_output=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
+          deployment_url=$(printf '%s\n' "$deployment_output" | tail -n 1)
+          if [[ ! "$deployment_url" =~ ^https:// ]]; then
+            echo "Vercel deploy did not print a deployment URL" >&2
+            exit 1
+          fi
+          echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Extracts the production Vercel pre-promotion deploy step into reusable `stage-vercel-deployment.yml` and `promote-vercel-deployment.yml` workflows.
- Switches both production Vercel apps (`kilocode-app` and `kilocode-global-app`) to the reusable stage/promote workflows while preserving the production deployment dependency graph.
- Reuses the same stage/promote workflows in the manual web redeploy flow, replacing its duplicated direct Vercel deployment logic.

## Verification
- N/A — workflow-only refactor; reviewed the generated workflow graphs and commands for behavioral parity.

## Visual Changes
N/A

## Reviewer Notes
- The reusable workflows still target the production GitHub environment.
- The stage workflow uses `vercel deploy --prod --skip-domain`; promotion remains a separate job using `vercel promote`.
- Normal production promotion still waits for the staged deployment plus production DB startup checks and migrations.
- Manual redeploy still requires `main` and shares the production concurrency group, but now stages and promotes instead of deploying directly to the production domain.