### PR TITLE
fix(bot): prevent GitHub self-replies

### DIFF
--- a/apps/web/src/lib/bot/github-adapter.ts
+++ b/apps/web/src/lib/bot/github-adapter.ts
@@ -6,5 +6,6 @@ export const githubAdapter = createGitHubAdapter({
   appId: githubAppCredentials.appId,
   privateKey: githubAppCredentials.privateKey,
   webhookSecret: githubAppCredentials.webhookSecret,
+  botUserId: process.env.NODE_ENV === 'development' ? 242397087 : 240665456,
   userName: process.env.NODE_ENV === 'development' ? 'kilocode-dev' : 'kilocode-bot',
 });


### PR DESCRIPTION
## Summary

- Configure the GitHub chat adapter with the development and production bot user IDs.
- Allow Chat SDK to identify comments authored by the bot and avoid responding to its own messages.

## Verification

- Mentioned `@kilocode-dev` with an instruction to repeat the message in a code block.
- Confirmed the bot posted the requested response once and did not respond to its own comment.

![GitHub bot self-message verification](https://raw.githubusercontent.com/Kilo-Org/cloud/pr-assets/road-ash/github-bot-self-message-verification.png)

## Visual Changes

N/A

## Reviewer Notes

The configured IDs match the existing KiloConnect development and production GitHub App bot identities.