### PR TITLE
feat(kilo-pass): enable referral sharing for all users

### DIFF
--- a/.specs/impact-referrals.md
+++ b/.specs/impact-referrals.md
@@ -20,6 +20,8 @@ Updated 2026-05-22 -- renamed to `.specs/impact-referrals.md` and expanded to Ki
 Updated 2026-05-28 -- classify enforced Stripe EFW refunds as adverse payments.
 Updated 2026-05-29 -- name the Impact-facing Kilo Pass reward unit `Kilo Pass Bonus Credits`.
 Updated 2026-06-05 -- final Commit term reward-extension behavior.
+Updated 2026-06-12 -- clarify subscription-independent Kilo Pass referral sharing and automatic pending reward
+application.
 
 ## Conventions
 
@@ -192,6 +194,14 @@ application, and Kilo Pass redeems after local referral bonus allocation.
 10. Logged-in users MUST access referral sharing through the product's Impact Verified Access widget.
 
 11. Kilo Pass referral sharing MUST be available from `/subscriptions/kilo-pass/refer` when configured.
+
+11a. Any logged-in Kilo user MUST be able to access and share the Kilo Pass referral link regardless of current or
+     historical Kilo Pass subscription state. Active, paused, canceling, canceled, annual, former, and never-subscribed
+     Kilo users remain eligible to share.
+
+11b. Relevant Kilo Pass surfaces MUST expose a `Refer & earn` path to `/subscriptions/kilo-pass/refer` for active,
+     paused, canceling, canceled, annual, former, and never-subscribed users. Non-subscriber surfaces MUST show only the
+     referral call to action; reward details belong on the dedicated referral page.
 
 12. The Kilo Pass referral page MUST use Kilo Pass-specific widget configuration, token issuance, reward summary, and
     copy. It MUST NOT show KiloClaw referral wording, widgets, links, or rewards as Kilo Pass referral state.
@@ -479,7 +489,8 @@ application, and Kilo Pass redeems after local referral bonus allocation.
 
 107.  If a Kilo Pass beneficiary has no active eligible monthly Kilo Pass subscription when a reward would apply, the
       reward MUST remain pending until the beneficiary starts or reactivates an eligible monthly Kilo Pass subscription,
-      is canceled by adverse-payment handling, is manually resolved, or expires.
+      is canceled by adverse-payment handling, is manually resolved, or expires. Paused, canceling, canceled, annual,
+      and unsubscribed states MUST NOT qualify merely because a subscription record exists.
 
 108.  A pending Kilo Pass referral reward MUST expire and be canceled 12 months after it is earned if it has not been
       consumed.
@@ -521,6 +532,9 @@ application, and Kilo Pass redeems after local referral bonus allocation.
 
 122.  When multiple pending unexpired Kilo Pass referral rewards are eligible for the same issuance, the oldest earned
       reward MUST be consumed first.
+
+122a. Kilo Pass referral reward application MUST be automatic. The system MUST NOT require or expose a user-triggered
+      manual claim action for pending Kilo Pass referral rewards.
 
 123.  A Kilo Pass referral reward MUST apply only to an eligible monthly base issuance after the reward is earned. It MUST
       NOT apply retroactively to the source conversion's base issuance or to any already-created issuance.

--- a/apps/web/src/app/(app)/subscriptions/kilo-pass/refer/page.tsx
+++ b/apps/web/src/app/(app)/subscriptions/kilo-pass/refer/page.tsx
@@ -10,7 +10,7 @@ export default function KiloPassReferralPage() {
   const trpc = useTRPC();
   const rewardSummary = useQuery(trpc.kiloPass.getReferralRewardSummary.queryOptions());
   const state = useQuery(trpc.kiloPass.getState.queryOptions());
-  const subscription = state.data?.subscription ?? null;
+  const subscription = state.isPending ? undefined : (state.data?.subscription ?? null);
 
   return (
     <KiloPassReferralPageContent
@@ -22,8 +22,9 @@ export default function KiloPassReferralPage() {
               cadence: subscription.cadence,
               cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
             }
-          : null
+          : subscription
       }
+      isSubscriptionContextLoading={state.isPending}
       isLoading={rewardSummary.isLoading}
       errorMessage={
         rewardSummary.isError ? 'Rewards are temporarily unavailable. Try again in a minute.' : null

--- a/apps/web/src/app/(app)/subscriptions/kilo-pass/refer/page.tsx
+++ b/apps/web/src/app/(app)/subscriptions/kilo-pass/refer/page.tsx
@@ -9,10 +9,21 @@ import { useTRPC } from '@/lib/trpc/utils';
 export default function KiloPassReferralPage() {
   const trpc = useTRPC();
   const rewardSummary = useQuery(trpc.kiloPass.getReferralRewardSummary.queryOptions());
+  const state = useQuery(trpc.kiloPass.getState.queryOptions());
+  const subscription = state.data?.subscription ?? null;
 
   return (
     <KiloPassReferralPageContent
       summary={rewardSummary.data ?? null}
+      subscriptionContext={
+        subscription
+          ? {
+              status: subscription.status,
+              cadence: subscription.cadence,
+              cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
+            }
+          : null
+      }
       isLoading={rewardSummary.isLoading}
       errorMessage={
         rewardSummary.isError ? 'Rewards are temporarily unavailable. Try again in a minute.' : null

--- a/apps/web/src/components/profile/ProfileKiloPassSection.tsx
+++ b/apps/web/src/components/profile/ProfileKiloPassSection.tsx
@@ -9,6 +9,7 @@ import { useTRPC } from '@/lib/trpc/utils';
 import { KiloPassActiveSubscriptionCard } from '@/components/profile/kilo-pass/KiloPassActiveSubscriptionCard';
 import { KiloPassLoadingCard } from '@/components/profile/kilo-pass/KiloPassLoadingCard';
 import { KiloPassSubscribeCard } from '@/components/profile/kilo-pass/KiloPassSubscribeCard';
+import { KiloPassReferralButton } from '@/components/referrals/KiloPassReferralButton';
 import { isStripeSubscriptionEnded } from '@/lib/kilo-pass/stripe-subscription-status';
 import { recommendKiloPassTierFromAverageMonthlyUsageUsd } from '@/lib/kilo-pass/recommend-tier';
 import { KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF } from '@/lib/kilo-pass/constants';
@@ -73,15 +74,20 @@ export function ProfileKiloPassSection() {
         : null;
 
     return (
-      <KiloPassSubscribeCard
-        cadence={cadence}
-        setCadence={setCadence}
-        pending={pending}
-        showFirstMonthPromo={showFirstMonthPromo}
-        showSecondMonthPromo={showSecondMonthPromo}
-        recommendedTier={recommendedTier}
-        onSelectTier={tier => checkoutMutation.mutate({ tier, cadence })}
-      />
+      <div className="space-y-3">
+        <div className="flex justify-end">
+          <KiloPassReferralButton className="w-full sm:w-auto" />
+        </div>
+        <KiloPassSubscribeCard
+          cadence={cadence}
+          setCadence={setCadence}
+          pending={pending}
+          showFirstMonthPromo={showFirstMonthPromo}
+          showSecondMonthPromo={showSecondMonthPromo}
+          recommendedTier={recommendedTier}
+          onSelectTier={tier => checkoutMutation.mutate({ tier, cadence })}
+        />
+      </div>
     );
   }
 

--- a/apps/web/src/components/profile/ProfileKiloPassSection.tsx
+++ b/apps/web/src/components/profile/ProfileKiloPassSection.tsx
@@ -74,20 +74,16 @@ export function ProfileKiloPassSection() {
         : null;
 
     return (
-      <div className="space-y-3">
-        <div className="flex justify-end">
-          <KiloPassReferralButton className="w-full sm:w-auto" />
-        </div>
-        <KiloPassSubscribeCard
-          cadence={cadence}
-          setCadence={setCadence}
-          pending={pending}
-          showFirstMonthPromo={showFirstMonthPromo}
-          showSecondMonthPromo={showSecondMonthPromo}
-          recommendedTier={recommendedTier}
-          onSelectTier={tier => checkoutMutation.mutate({ tier, cadence })}
-        />
-      </div>
+      <KiloPassSubscribeCard
+        cadence={cadence}
+        setCadence={setCadence}
+        pending={pending}
+        showFirstMonthPromo={showFirstMonthPromo}
+        showSecondMonthPromo={showSecondMonthPromo}
+        headerAction={<KiloPassReferralButton className="w-full sm:w-auto" />}
+        recommendedTier={recommendedTier}
+        onSelectTier={tier => checkoutMutation.mutate({ tier, cadence })}
+      />
     );
   }
 

--- a/apps/web/src/components/profile/kilo-pass/KiloPassSubscribeCard.tsx
+++ b/apps/web/src/components/profile/kilo-pass/KiloPassSubscribeCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { Check, Crown, Loader2 } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
@@ -23,6 +24,7 @@ export function KiloPassSubscribeCard(props: {
   showFirstMonthPromo?: boolean;
   showSecondMonthPromo: boolean;
   showHeader?: boolean;
+  headerAction?: ReactNode;
   unframed?: boolean;
   className?: string;
   contentClassName?: string;
@@ -36,6 +38,7 @@ export function KiloPassSubscribeCard(props: {
     showFirstMonthPromo = false,
     showSecondMonthPromo,
     showHeader = true,
+    headerAction,
     unframed = false,
     className,
     contentClassName,
@@ -130,7 +133,7 @@ export function KiloPassSubscribeCard(props: {
     <Card className={cn('border-border/60 w-full overflow-hidden rounded-xl shadow-sm', className)}>
       {showHeader ? (
         <CardHeader>
-          <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <CardTitle className="flex items-center gap-2">
               <span className="bg-muted/40 ring-border/60 grid size-9 place-items-center rounded-lg ring-1">
                 <Crown className="size-5" />
@@ -145,14 +148,17 @@ export function KiloPassSubscribeCard(props: {
               </span>
             </CardTitle>
 
-            {pending ? (
-              <Badge variant="secondary" className="gap-1.5">
-                <Loader2 className="size-3.5 animate-spin" />
-                Processing
-              </Badge>
-            ) : (
-              <Badge variant="secondary">Subscribe</Badge>
-            )}
+            <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
+              {headerAction}
+              {pending ? (
+                <Badge variant="secondary" className="gap-1.5">
+                  <Loader2 className="size-3.5 animate-spin" />
+                  Processing
+                </Badge>
+              ) : (
+                <Badge variant="secondary">Subscribe</Badge>
+              )}
+            </div>
           </div>
         </CardHeader>
       ) : null}

--- a/apps/web/src/components/referrals/ImpactAdvocateReferralCard.tsx
+++ b/apps/web/src/components/referrals/ImpactAdvocateReferralCard.tsx
@@ -34,18 +34,17 @@ async function getWidgetToken(product: ImpactAdvocateReferralProduct): Promise<W
   } | null;
 
   if (!response.ok || !payload?.token || !payload.widgetId) {
-    const fallbackMessage =
-      product === 'kilo_pass' && response.status === 503
-        ? 'Kilo Pass referral sharing is unavailable right now. Rewards already earned stay pending and apply automatically when eligible.'
-        : response.status === 503
-          ? 'Referral sharing is not configured in this environment.'
-          : 'Referral sharing is temporarily unavailable.';
+    const isKiloPassConfigurationUnavailable = product === 'kilo_pass' && response.status === 503;
+    const fallbackMessage = isKiloPassConfigurationUnavailable
+      ? 'Kilo Pass referral sharing is unavailable right now. Rewards already earned stay pending and apply automatically when eligible.'
+      : response.status === 503
+        ? 'Referral sharing is not configured in this environment.'
+        : 'Referral sharing is temporarily unavailable.';
+    const message = isKiloPassConfigurationUnavailable
+      ? fallbackMessage
+      : (payload?.error ?? fallbackMessage);
 
-    throw new Error(
-      product === 'kilo_pass' && response.status === 503
-        ? fallbackMessage
-        : (payload?.error ?? fallbackMessage)
-    );
+    throw new Error(message);
   }
 
   return { token: payload.token, widgetId: payload.widgetId };

--- a/apps/web/src/components/referrals/ImpactAdvocateReferralCard.tsx
+++ b/apps/web/src/components/referrals/ImpactAdvocateReferralCard.tsx
@@ -34,11 +34,17 @@ async function getWidgetToken(product: ImpactAdvocateReferralProduct): Promise<W
   } | null;
 
   if (!response.ok || !payload?.token || !payload.widgetId) {
-    throw new Error(
-      payload?.error ??
-        (response.status === 503
+    const fallbackMessage =
+      product === 'kilo_pass' && response.status === 503
+        ? 'Kilo Pass referral sharing is unavailable right now. Rewards already earned stay pending and apply automatically when eligible.'
+        : response.status === 503
           ? 'Referral sharing is not configured in this environment.'
-          : 'Referral sharing is temporarily unavailable.')
+          : 'Referral sharing is temporarily unavailable.';
+
+    throw new Error(
+      product === 'kilo_pass' && response.status === 503
+        ? fallbackMessage
+        : (payload?.error ?? fallbackMessage)
     );
   }
 

--- a/apps/web/src/components/referrals/KiloPassReferralButton.tsx
+++ b/apps/web/src/components/referrals/KiloPassReferralButton.tsx
@@ -6,10 +6,13 @@ import { cn } from '@/lib/utils';
 
 export function KiloPassReferralButton({ className }: { className?: string }) {
   return (
-    <Button asChild variant="outline" className={cn('h-9 gap-2', className)}>
+    <Button asChild variant="brand" className={cn('h-9 gap-2 pr-2.5', className)}>
       <Link href="/subscriptions/kilo-pass/refer">
         <Gift className="size-4" aria-hidden="true" />
         <span>Refer &amp; earn</span>
+        <span className="bg-primary-foreground text-brand-primary rounded-full px-1.5 py-0.5 text-[10px] leading-none font-bold tracking-wide uppercase ring-1 ring-primary-foreground/30">
+          New
+        </span>
       </Link>
     </Button>
   );

--- a/apps/web/src/components/referrals/KiloPassReferralButton.tsx
+++ b/apps/web/src/components/referrals/KiloPassReferralButton.tsx
@@ -6,13 +6,10 @@ import { cn } from '@/lib/utils';
 
 export function KiloPassReferralButton({ className }: { className?: string }) {
   return (
-    <Button asChild variant="outline" className={cn('h-9 gap-2 pr-2.5', className)}>
+    <Button asChild variant="outline" className={cn('h-9 gap-2', className)}>
       <Link href="/subscriptions/kilo-pass/refer">
         <Gift className="size-4" aria-hidden="true" />
         <span>Refer &amp; earn</span>
-        <span className="bg-brand-primary text-primary-foreground rounded-full px-1.5 py-0.5 text-[10px] leading-none font-bold tracking-wide uppercase ring-1 ring-brand-primary/30">
-          New
-        </span>
       </Link>
     </Button>
   );

--- a/apps/web/src/components/referrals/KiloPassReferralPageContent.test.ts
+++ b/apps/web/src/components/referrals/KiloPassReferralPageContent.test.ts
@@ -2,7 +2,10 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from '@jest/globals';
 
-import { KiloPassReferralPageContent } from './KiloPassReferralPageContent';
+import {
+  getKiloPassReferralEligibilityPresentation,
+  KiloPassReferralPageContent,
+} from './KiloPassReferralPageContent';
 import type { KiloPassReferralRewardSummary } from './KiloPassReferralPageContent';
 import { KiloPassCadence } from '@/lib/kilo-pass/enums';
 
@@ -140,6 +143,9 @@ describe('KiloPassReferralPageContent', () => {
       'Any Kilo user can refer! Redeem your reward with an active Kilo Pass.'
     );
     expect(unsubscribedHtml).toContain('More info: Kilo Pass referral reward mechanics');
+    expect(getKiloPassReferralEligibilityPresentation(null).details).toBe(
+      'Each reward applies automatically to your next eligible monthly credit bonus when you have an active monthly Kilo Pass.'
+    );
   });
 
   it('summarizes pending, applied, history, and cap-reached reward states', () => {

--- a/apps/web/src/components/referrals/KiloPassReferralPageContent.test.ts
+++ b/apps/web/src/components/referrals/KiloPassReferralPageContent.test.ts
@@ -72,6 +72,22 @@ describe('KiloPassReferralPageContent', () => {
     expect(errorHtml).not.toContain('stack');
   });
 
+  it('does not render unsubscribed eligibility while subscription state is loading', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(KiloPassReferralPageContent, {
+        summary: emptySummary,
+        isSubscriptionContextLoading: true,
+      })
+    );
+
+    expect(html).toContain('Checking Kilo Pass status');
+    expect(html).toContain('Loading referral reward eligibility…');
+    expect(html).not.toContain(
+      'Any Kilo user can refer! Redeem your reward with an active Kilo Pass.'
+    );
+    expect(html).not.toContain('Choose monthly Kilo Pass');
+  });
+
   it('renders contextual eligibility for active monthly, annual, paused, canceling, and unsubscribed states', () => {
     const activeMonthlyHtml = renderToStaticMarkup(
       React.createElement(KiloPassReferralPageContent, {

--- a/apps/web/src/components/referrals/KiloPassReferralPageContent.test.ts
+++ b/apps/web/src/components/referrals/KiloPassReferralPageContent.test.ts
@@ -132,9 +132,14 @@ describe('KiloPassReferralPageContent', () => {
     );
     expect(cancelingHtml).toContain('Manage subscription');
 
-    expect(unsubscribedHtml).toContain('Pending until monthly subscription resumes or activates');
+    expect(unsubscribedHtml).not.toContain(
+      'Pending until monthly subscription resumes or activates'
+    );
     expect(unsubscribedHtml).toContain('Choose monthly Kilo Pass');
-    expect(unsubscribedHtml).toContain('Any Kilo user can share');
+    expect(unsubscribedHtml).toContain(
+      'Any Kilo user can refer! Redeem your reward with an active Kilo Pass.'
+    );
+    expect(unsubscribedHtml).toContain('More info: Kilo Pass referral reward mechanics');
   });
 
   it('summarizes pending, applied, history, and cap-reached reward states', () => {

--- a/apps/web/src/components/referrals/KiloPassReferralPageContent.test.ts
+++ b/apps/web/src/components/referrals/KiloPassReferralPageContent.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from '@jest/globals';
 
 import { KiloPassReferralPageContent } from './KiloPassReferralPageContent';
 import type { KiloPassReferralRewardSummary } from './KiloPassReferralPageContent';
+import { KiloPassCadence } from '@/lib/kilo-pass/enums';
 
 const emptySummary: KiloPassReferralRewardSummary = {
   totals: {
@@ -34,13 +35,16 @@ describe('KiloPassReferralPageContent', () => {
 
     expect(html).toContain('Earn Kilo Pass referral bonuses');
     expect(html).toContain('50% monthly Kilo Pass bonus');
+    expect(html).toContain('href="/subscriptions#kilo-pass"');
     expect(html).toContain('No Kilo Pass referral rewards yet.');
+    expect(html).toContain('applies automatically');
     expect(html).toContain('aria-label="Kilo Pass referral sharing"');
     expect(html).toContain('data-testid="share-widget"');
     expect(html).not.toContain('Share your Kilo Pass referral link');
     expect(html).not.toContain('Use the Kilo Pass referral widget');
     expect(html).not.toContain('KiloClaw');
     expect(html).not.toContain('free month');
+    expect(html.toLowerCase()).not.toContain('claim');
   });
 
   it('renders loading and non-sensitive error states without color-only messaging', () => {
@@ -63,6 +67,74 @@ describe('KiloPassReferralPageContent', () => {
     expect(errorHtml).toContain('Try again in a minute.');
     expect(errorHtml).toContain('role="alert"');
     expect(errorHtml).not.toContain('stack');
+  });
+
+  it('renders contextual eligibility for active monthly, annual, paused, canceling, and unsubscribed states', () => {
+    const activeMonthlyHtml = renderToStaticMarkup(
+      React.createElement(KiloPassReferralPageContent, {
+        summary: emptySummary,
+        subscriptionContext: {
+          status: 'active',
+          cadence: KiloPassCadence.Monthly,
+          cancelAtPeriodEnd: false,
+        },
+      })
+    );
+    const annualHtml = renderToStaticMarkup(
+      React.createElement(KiloPassReferralPageContent, {
+        summary: emptySummary,
+        subscriptionContext: {
+          status: 'active',
+          cadence: KiloPassCadence.Yearly,
+          cancelAtPeriodEnd: false,
+        },
+      })
+    );
+    const pausedHtml = renderToStaticMarkup(
+      React.createElement(KiloPassReferralPageContent, {
+        summary: emptySummary,
+        subscriptionContext: {
+          status: 'paused',
+          cadence: KiloPassCadence.Monthly,
+          cancelAtPeriodEnd: false,
+        },
+      })
+    );
+    const cancelingHtml = renderToStaticMarkup(
+      React.createElement(KiloPassReferralPageContent, {
+        summary: emptySummary,
+        subscriptionContext: {
+          status: 'active',
+          cadence: KiloPassCadence.Monthly,
+          cancelAtPeriodEnd: true,
+        },
+      })
+    );
+    const unsubscribedHtml = renderToStaticMarkup(
+      React.createElement(KiloPassReferralPageContent, {
+        summary: emptySummary,
+        subscriptionContext: null,
+      })
+    );
+
+    expect(activeMonthlyHtml).toContain('Ready for future eligible monthly issuance');
+    expect(activeMonthlyHtml).toContain('oldest pending reward applies automatically');
+    expect(activeMonthlyHtml).not.toContain('Choose monthly Kilo Pass');
+
+    expect(annualHtml).toContain('Annual subscription cannot consume reward');
+    expect(annualHtml).toContain('Manage subscription');
+
+    expect(pausedHtml).toContain('Canceling or paused subscription needs future eligible issuance');
+    expect(pausedHtml).toContain('Manage subscription');
+
+    expect(cancelingHtml).toContain(
+      'Canceling or paused subscription needs future eligible issuance'
+    );
+    expect(cancelingHtml).toContain('Manage subscription');
+
+    expect(unsubscribedHtml).toContain('Pending until monthly subscription resumes or activates');
+    expect(unsubscribedHtml).toContain('Choose monthly Kilo Pass');
+    expect(unsubscribedHtml).toContain('Any Kilo user can share');
   });
 
   it('summarizes pending, applied, history, and cap-reached reward states', () => {
@@ -126,7 +198,9 @@ describe('KiloPassReferralPageContent', () => {
     expect(html).toContain('$9.50');
     expect(html).toContain('Cap reached');
     expect(html).toContain('5 of 5 referrer rewards');
-    expect(html).toContain('Waiting for a future eligible monthly issuance');
+    expect(html).toContain('eligible referees can still earn their reward');
+    expect(html).toContain('will not earn another referrer reward');
+    expect(html).toContain('Pending, applies automatically at future eligible monthly issuance');
     expect(html).toContain('Applied');
     expect(html).toContain('Needs review');
     expect(html).toContain('May 10, 2026');

--- a/apps/web/src/components/referrals/KiloPassReferralPageContent.tsx
+++ b/apps/web/src/components/referrals/KiloPassReferralPageContent.tsx
@@ -154,7 +154,7 @@ export function getKiloPassReferralEligibilityPresentation(
       title: 'Any Kilo user can refer! Redeem your reward with an active Kilo Pass.',
       description: null,
       details:
-        'When a brand-new Kilo user uses your referral and completes their first eligible paid personal monthly Kilo Pass purchase, you earn a pending reward. It applies automatically to your next eligible monthly base issuance while you have an active monthly Kilo Pass.',
+        'When a brand-new Kilo user uses your referral and completes their first eligible paid personal monthly Kilo Pass purchase, you earn a pending reward. It applies automatically to your next eligible monthly credit bonus when you have an active monthly Kilo Pass.',
       action: {
         href: '/subscriptions#kilo-pass',
         label: 'Choose monthly Kilo Pass',

--- a/apps/web/src/components/referrals/KiloPassReferralPageContent.tsx
+++ b/apps/web/src/components/referrals/KiloPassReferralPageContent.tsx
@@ -154,7 +154,7 @@ export function getKiloPassReferralEligibilityPresentation(
       title: 'Any Kilo user can refer! Redeem your reward with an active Kilo Pass.',
       description: null,
       details:
-        'When a brand-new Kilo user uses your referral and completes their first eligible paid personal monthly Kilo Pass purchase, you earn a pending reward. It applies automatically to your next eligible monthly credit bonus when you have an active monthly Kilo Pass.',
+        'Each reward applies automatically to your next eligible monthly credit bonus when you have an active monthly Kilo Pass.',
       action: {
         href: '/subscriptions#kilo-pass',
         label: 'Choose monthly Kilo Pass',

--- a/apps/web/src/components/referrals/KiloPassReferralPageContent.tsx
+++ b/apps/web/src/components/referrals/KiloPassReferralPageContent.tsx
@@ -8,9 +8,16 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { KiloPassCadence } from '@/lib/kilo-pass/enums';
 import { formatIsoDateString_UsaDateOnlyFormat } from '@/lib/utils';
 
 const SHARE_WIDGET_ANCHOR_ID = 'kilo-pass-referral-share';
+
+export type KiloPassReferralSubscriptionContext = {
+  status: string;
+  cadence: KiloPassCadence;
+  cancelAtPeriodEnd: boolean;
+} | null;
 
 export type KiloPassReferralRewardStatus =
   | 'pending'
@@ -50,6 +57,7 @@ export type KiloPassReferralRewardSummary = {
 
 type KiloPassReferralPageContentProps = {
   summary: KiloPassReferralRewardSummary | null;
+  subscriptionContext?: KiloPassReferralSubscriptionContext;
   isLoading?: boolean;
   errorMessage?: string | null;
   children?: ReactNode;
@@ -58,6 +66,15 @@ type KiloPassReferralPageContentProps = {
 type StatusPresentation = {
   label: string;
   className: string;
+};
+
+type EligibilityPresentation = {
+  title: string;
+  description: string;
+  action: {
+    href: string;
+    label: string;
+  } | null;
 };
 
 const usdFormatter = new Intl.NumberFormat('en-US', {
@@ -98,7 +115,7 @@ function rewardStatusPresentation(status: KiloPassReferralRewardStatus): StatusP
     case 'earned':
     case 'pending':
       return {
-        label: 'Waiting for a future eligible monthly issuance',
+        label: 'Pending, applies automatically at future eligible monthly issuance',
         className: 'bg-yellow-500/20 text-yellow-400 ring-yellow-500/20',
       };
     case 'expired':
@@ -124,8 +141,72 @@ function rewardStatusPresentation(status: KiloPassReferralRewardStatus): StatusP
   }
 }
 
+function isTerminalKiloPassStatus(status: string): boolean {
+  return status === 'canceled' || status === 'incomplete_expired';
+}
+
+export function getKiloPassReferralEligibilityPresentation(
+  subscriptionContext: KiloPassReferralSubscriptionContext
+): EligibilityPresentation {
+  if (!subscriptionContext || isTerminalKiloPassStatus(subscriptionContext.status)) {
+    return {
+      title: 'Pending until monthly subscription resumes or activates',
+      description:
+        'Any Kilo user can share. Earned rewards stay pending and the oldest eligible reward applies automatically when you start an eligible personal monthly Kilo Pass.',
+      action: {
+        href: '/subscriptions#kilo-pass',
+        label: 'Choose monthly Kilo Pass',
+      },
+    };
+  }
+
+  if (subscriptionContext.cadence === KiloPassCadence.Yearly) {
+    return {
+      title: 'Annual subscription cannot consume reward',
+      description:
+        'You can keep sharing and earning. Pending rewards apply automatically only to a future eligible personal monthly Kilo Pass base issuance.',
+      action: {
+        href: '/subscriptions/kilo-pass',
+        label: 'Manage subscription',
+      },
+    };
+  }
+
+  if (subscriptionContext.cancelAtPeriodEnd || subscriptionContext.status === 'paused') {
+    return {
+      title: 'Canceling or paused subscription needs future eligible issuance',
+      description:
+        'You can keep sharing. Earned rewards stay pending until your monthly Kilo Pass resumes or renews with an eligible base issuance, then the oldest pending reward applies automatically.',
+      action: {
+        href: '/subscriptions/kilo-pass',
+        label: 'Manage subscription',
+      },
+    };
+  }
+
+  if (subscriptionContext.status !== 'active') {
+    return {
+      title: 'Pending until monthly subscription resumes or activates',
+      description:
+        'You can keep sharing. Earned rewards stay pending until an eligible personal monthly Kilo Pass base issuance is created, then the oldest pending reward applies automatically.',
+      action: {
+        href: '/subscriptions/kilo-pass',
+        label: 'Manage subscription',
+      },
+    };
+  }
+
+  return {
+    title: 'Ready for future eligible monthly issuance',
+    description:
+      'You can share now. Earned rewards stay pending until the next eligible personal monthly Kilo Pass base issuance, then the oldest pending reward applies automatically.',
+    action: null,
+  };
+}
+
 export function KiloPassReferralPageContent({
   summary,
+  subscriptionContext = null,
   isLoading = false,
   errorMessage,
   children,
@@ -141,12 +222,14 @@ export function KiloPassReferralPageContent({
           <div className="space-y-2">
             <h1 className="text-3xl font-bold tracking-tight">Earn Kilo Pass referral bonuses</h1>
             <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
-              Share Kilo Pass with someone else and when their first eligible monthly payment is
-              confirmed, you both earn a 50% monthly Kilo Pass bonus based on their tier.
+              Share Kilo Pass with someone else. When a brand-new Kilo user completes their first
+              eligible paid personal monthly Kilo Pass purchase, you both earn a 50% monthly Kilo
+              Pass bonus. Earned rewards stay pending and apply automatically to future eligible
+              monthly base issuances.
             </p>
           </div>
           <Button asChild variant="outline">
-            <Link href="/subscriptions/kilo-pass">Back to Kilo Pass</Link>
+            <Link href="/subscriptions#kilo-pass">Back to Kilo Pass</Link>
           </Button>
         </div>
       </div>
@@ -164,6 +247,8 @@ export function KiloPassReferralPageContent({
               </output>
             )}
           </section>
+
+          <KiloPassReferralEligibility subscriptionContext={subscriptionContext} />
 
           {isLoading ? (
             <output className="block border-t border-border pt-6 text-sm text-muted-foreground">
@@ -185,6 +270,35 @@ export function KiloPassReferralPageContent({
   );
 }
 
+function KiloPassReferralEligibility({
+  subscriptionContext,
+}: {
+  subscriptionContext: KiloPassReferralSubscriptionContext;
+}) {
+  const presentation = getKiloPassReferralEligibilityPresentation(subscriptionContext);
+
+  return (
+    <section
+      aria-labelledby="kilo-pass-referral-eligibility-heading"
+      className="flex flex-col gap-3 rounded-lg border border-border bg-input/20 p-4 sm:flex-row sm:items-start sm:justify-between"
+    >
+      <div className="space-y-1.5">
+        <h2 id="kilo-pass-referral-eligibility-heading" className="text-sm font-semibold">
+          {presentation.title}
+        </h2>
+        <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+          {presentation.description}
+        </p>
+      </div>
+      {presentation.action ? (
+        <Button asChild variant="outline" className="shrink-0 sm:self-center">
+          <Link href={presentation.action.href}>{presentation.action.label}</Link>
+        </Button>
+      ) : null}
+    </section>
+  );
+}
+
 function KiloPassReferralSummary({ summary }: { summary: KiloPassReferralRewardSummary }) {
   return (
     <section
@@ -196,7 +310,7 @@ function KiloPassReferralSummary({ summary }: { summary: KiloPassReferralRewardS
           Reward summary
         </h2>
         <p className="text-sm text-muted-foreground">
-          Track pending referral bonuses and previous Kilo Pass referral reward history.
+          Track pending referral bonuses and applied Kilo Pass referral reward history.
         </p>
       </div>
 
@@ -206,7 +320,8 @@ function KiloPassReferralSummary({ summary }: { summary: KiloPassReferralRewardS
             <div className="font-medium text-yellow-400">Cap reached</div>
             <div className="text-muted-foreground">
               {summary.referrerCap.grantedRewards} of {summary.referrerCap.limit} referrer rewards
-              granted. Referee rewards do not count toward this cap.
+              granted. You can keep sharing; eligible referees can still earn their reward, but you
+              will not earn another referrer reward.
             </div>
           </div>
         </div>
@@ -217,7 +332,7 @@ function KiloPassReferralSummary({ summary }: { summary: KiloPassReferralRewardS
         <SummaryTile
           label="Pending rewards"
           value={String(summary.totals.pendingRewards)}
-          info="Pending rewards wait for a future eligible monthly Kilo Pass issuance."
+          info="Pending rewards apply automatically to future eligible monthly Kilo Pass base issuances."
           indicator={summary.totals.pendingRewards > 0 ? 'warning' : undefined}
         />
         <SummaryTile label="Applied rewards" value={String(summary.totals.appliedRewards)} />
@@ -248,7 +363,7 @@ function KiloPassReferralSummary({ summary }: { summary: KiloPassReferralRewardS
             >
               Share your referral link
             </a>{' '}
-            to earn a future monthly bonus.
+            to earn a future monthly bonus that stays pending until it applies automatically.
           </div>
         ) : (
           <div className="divide-y divide-border rounded-lg border border-border">
@@ -362,7 +477,9 @@ function RewardRow({ reward }: { reward: KiloPassReferralRewardSummary['rewards'
         ) : reward.status === 'review_required' ? (
           <div>Support review required before this reward changes.</div>
         ) : (
-          <div>Application details appear after the referral bonus is issued.</div>
+          <div>
+            Oldest pending reward applies automatically when an eligible issuance is created.
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/components/referrals/KiloPassReferralPageContent.tsx
+++ b/apps/web/src/components/referrals/KiloPassReferralPageContent.tsx
@@ -58,6 +58,7 @@ export type KiloPassReferralRewardSummary = {
 type KiloPassReferralPageContentProps = {
   summary: KiloPassReferralRewardSummary | null;
   subscriptionContext?: KiloPassReferralSubscriptionContext;
+  isSubscriptionContextLoading?: boolean;
   isLoading?: boolean;
   errorMessage?: string | null;
   children?: ReactNode;
@@ -213,6 +214,7 @@ export function getKiloPassReferralEligibilityPresentation(
 export function KiloPassReferralPageContent({
   summary,
   subscriptionContext = null,
+  isSubscriptionContextLoading = false,
   isLoading = false,
   errorMessage,
   children,
@@ -254,7 +256,10 @@ export function KiloPassReferralPageContent({
             )}
           </section>
 
-          <KiloPassReferralEligibility subscriptionContext={subscriptionContext} />
+          <KiloPassReferralEligibility
+            subscriptionContext={subscriptionContext}
+            isLoading={isSubscriptionContextLoading}
+          />
 
           {isLoading ? (
             <output className="block border-t border-border pt-6 text-sm text-muted-foreground">
@@ -278,9 +283,27 @@ export function KiloPassReferralPageContent({
 
 function KiloPassReferralEligibility({
   subscriptionContext,
+  isLoading,
 }: {
   subscriptionContext: KiloPassReferralSubscriptionContext;
+  isLoading: boolean;
 }) {
+  if (isLoading) {
+    return (
+      <section
+        aria-labelledby="kilo-pass-referral-eligibility-heading"
+        className="rounded-lg border border-border bg-input/20 p-4"
+      >
+        <h2 id="kilo-pass-referral-eligibility-heading" className="text-sm font-semibold">
+          Checking Kilo Pass status
+        </h2>
+        <output className="mt-1.5 block text-sm text-muted-foreground">
+          Loading referral reward eligibility…
+        </output>
+      </section>
+    );
+  }
+
   const presentation = getKiloPassReferralEligibilityPresentation(subscriptionContext);
 
   return (

--- a/apps/web/src/components/referrals/KiloPassReferralPageContent.tsx
+++ b/apps/web/src/components/referrals/KiloPassReferralPageContent.tsx
@@ -70,7 +70,8 @@ type StatusPresentation = {
 
 type EligibilityPresentation = {
   title: string;
-  description: string;
+  description: string | null;
+  details: string | null;
   action: {
     href: string;
     label: string;
@@ -150,9 +151,10 @@ export function getKiloPassReferralEligibilityPresentation(
 ): EligibilityPresentation {
   if (!subscriptionContext || isTerminalKiloPassStatus(subscriptionContext.status)) {
     return {
-      title: 'Pending until monthly subscription resumes or activates',
-      description:
-        'Any Kilo user can share. Earned rewards stay pending and the oldest eligible reward applies automatically when you start an eligible personal monthly Kilo Pass.',
+      title: 'Any Kilo user can refer! Redeem your reward with an active Kilo Pass.',
+      description: null,
+      details:
+        'When a brand-new Kilo user uses your referral and completes their first eligible paid personal monthly Kilo Pass purchase, you earn a pending reward. It applies automatically to your next eligible monthly base issuance while you have an active monthly Kilo Pass.',
       action: {
         href: '/subscriptions#kilo-pass',
         label: 'Choose monthly Kilo Pass',
@@ -165,6 +167,7 @@ export function getKiloPassReferralEligibilityPresentation(
       title: 'Annual subscription cannot consume reward',
       description:
         'You can keep sharing and earning. Pending rewards apply automatically only to a future eligible personal monthly Kilo Pass base issuance.',
+      details: null,
       action: {
         href: '/subscriptions/kilo-pass',
         label: 'Manage subscription',
@@ -177,6 +180,7 @@ export function getKiloPassReferralEligibilityPresentation(
       title: 'Canceling or paused subscription needs future eligible issuance',
       description:
         'You can keep sharing. Earned rewards stay pending until your monthly Kilo Pass resumes or renews with an eligible base issuance, then the oldest pending reward applies automatically.',
+      details: null,
       action: {
         href: '/subscriptions/kilo-pass',
         label: 'Manage subscription',
@@ -189,6 +193,7 @@ export function getKiloPassReferralEligibilityPresentation(
       title: 'Pending until monthly subscription resumes or activates',
       description:
         'You can keep sharing. Earned rewards stay pending until an eligible personal monthly Kilo Pass base issuance is created, then the oldest pending reward applies automatically.',
+      details: null,
       action: {
         href: '/subscriptions/kilo-pass',
         label: 'Manage subscription',
@@ -200,6 +205,7 @@ export function getKiloPassReferralEligibilityPresentation(
     title: 'Ready for future eligible monthly issuance',
     description:
       'You can share now. Earned rewards stay pending until the next eligible personal monthly Kilo Pass base issuance, then the oldest pending reward applies automatically.',
+    details: null,
     action: null,
   };
 }
@@ -280,15 +286,35 @@ function KiloPassReferralEligibility({
   return (
     <section
       aria-labelledby="kilo-pass-referral-eligibility-heading"
-      className="flex flex-col gap-3 rounded-lg border border-border bg-input/20 p-4 sm:flex-row sm:items-start sm:justify-between"
+      className="flex flex-col gap-3 rounded-lg border border-border bg-input/20 p-4 sm:flex-row sm:items-center sm:justify-between"
     >
       <div className="space-y-1.5">
-        <h2 id="kilo-pass-referral-eligibility-heading" className="text-sm font-semibold">
-          {presentation.title}
-        </h2>
-        <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
-          {presentation.description}
-        </p>
+        <div className="flex max-w-3xl items-start gap-1.5">
+          <h2 id="kilo-pass-referral-eligibility-heading" className="min-w-0 text-sm font-semibold">
+            {presentation.title}
+          </h2>
+          {presentation.details ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="More info: Kilo Pass referral reward mechanics"
+                  className="mt-0.5 rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <Info className="size-3.5" aria-hidden="true" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-80 text-left text-balance">
+                {presentation.details}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+        </div>
+        {presentation.description ? (
+          <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+            {presentation.description}
+          </p>
+        ) : null}
       </div>
       {presentation.action ? (
         <Button asChild variant="outline" className="shrink-0 sm:self-center">

--- a/apps/web/src/components/subscriptions/SubscriptionCard.tsx
+++ b/apps/web/src/components/subscriptions/SubscriptionCard.tsx
@@ -19,6 +19,7 @@ export function SubscriptionCard({
   warningTone,
   statusNote,
   action,
+  actionPlacement = 'footer',
 }: {
   icon: ReactNode;
   title: ReactNode;
@@ -33,11 +34,14 @@ export function SubscriptionCard({
   warningTone?: 'warning' | 'info';
   statusNote?: string | null;
   action?: ReactNode;
+  actionPlacement?: 'footer' | 'top-right';
 }) {
+  const hasTopRightAction = action && actionPlacement === 'top-right';
+
   return (
     <Card
       className={cn(
-        'transition-all hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-md',
+        'relative transition-all hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-md',
         isTerminal && 'opacity-55',
         warningTone === 'warning' && 'border-amber-500/40 bg-amber-500/5',
         warningTone === 'info' && 'border-border bg-muted/40'
@@ -47,7 +51,12 @@ export function SubscriptionCard({
         href={href}
         className="block focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >
-        <CardContent className="flex flex-col gap-4 p-5 md:flex-row md:items-start md:justify-between">
+        <CardContent
+          className={cn(
+            'flex flex-col gap-4 p-5 md:flex-row md:items-start md:justify-between',
+            hasTopRightAction && 'md:relative md:pr-72'
+          )}
+        >
           <div className="flex min-w-0 gap-3">
             <div className="bg-muted flex size-11 shrink-0 items-center justify-center rounded-xl">
               {icon}
@@ -85,10 +94,20 @@ export function SubscriptionCard({
               </div>
             </div>
           </div>
-          <ChevronRight className="text-muted-foreground size-5 shrink-0 self-center md:mt-3" />
+          <ChevronRight
+            className={cn(
+              'text-muted-foreground size-5 shrink-0 self-center md:mt-3',
+              hasTopRightAction && 'md:absolute md:top-1/2 md:right-5 md:mt-0 md:-translate-y-1/2'
+            )}
+          />
         </CardContent>
       </Link>
-      {action ? (
+      {hasTopRightAction ? (
+        <div className="flex px-5 pb-5 md:absolute md:top-5 md:right-14 md:z-10 md:p-0 [&>button]:w-full sm:[&>button]:w-auto">
+          {action}
+        </div>
+      ) : null}
+      {action && actionPlacement === 'footer' ? (
         <div className="flex px-5 pb-5 [&>button]:w-full sm:[&>button]:w-auto">{action}</div>
       ) : null}
     </Card>

--- a/apps/web/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
+++ b/apps/web/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
@@ -182,7 +182,7 @@ export function KiloPassDetail() {
           backLabel="Back to subscriptions"
           title="Kilo Pass"
           status={subscriptionDisplay.status}
-          actions={isKiloPassTerminal(subscription.status) ? null : <KiloPassReferralButton />}
+          actions={<KiloPassReferralButton />}
         />
 
         {subscriptionDisplay.detailAlert ? (

--- a/apps/web/src/components/subscriptions/kilo-pass/KiloPassGroup.tsx
+++ b/apps/web/src/components/subscriptions/kilo-pass/KiloPassGroup.tsx
@@ -10,6 +10,7 @@ import { dayjs } from '@/lib/kilo-pass/dayjs';
 import { KiloPassCadence } from '@/lib/kilo-pass/enums';
 import type { KiloPassTier } from '@/lib/kilo-pass/enums';
 import { recommendKiloPassTierFromAverageMonthlyUsageUsd } from '@/lib/kilo-pass/recommend-tier';
+import { KiloPassReferralButton } from '@/components/referrals/KiloPassReferralButton';
 import { KiloPassSubscribeCard } from '@/components/profile/kilo-pass/KiloPassSubscribeCard';
 import { SubscriptionCard } from '@/components/subscriptions/SubscriptionCard';
 import { SubscriptionGroup } from '@/components/subscriptions/SubscriptionGroup';
@@ -131,19 +132,26 @@ export function KiloPassGroup({
                 : undefined
           }
           statusNote={subscriptionDisplay.cardNotice}
+          action={<KiloPassReferralButton className="w-full sm:w-auto" />}
+          actionPlacement="top-right"
         />
       ) : (
-        <KiloPassSubscribeCard
-          cadence={cadence}
-          setCadence={setCadence}
-          pending={checkout.isPending}
-          showFirstMonthPromo={showFirstMonthPromo}
-          showSecondMonthPromo={showSecondMonthPromo}
-          recommendedTier={recommendedTier}
-          onSelectTier={tier => void startCheckout(tier)}
-          showHeader={false}
-          unframed
-        />
+        <div className="space-y-4">
+          <div className="flex justify-end">
+            <KiloPassReferralButton className="w-full sm:w-auto" />
+          </div>
+          <KiloPassSubscribeCard
+            cadence={cadence}
+            setCadence={setCadence}
+            pending={checkout.isPending}
+            showFirstMonthPromo={showFirstMonthPromo}
+            showSecondMonthPromo={showSecondMonthPromo}
+            recommendedTier={recommendedTier}
+            onSelectTier={tier => void startCheckout(tier)}
+            showHeader={false}
+            unframed
+          />
+        </div>
       )}
     </SubscriptionGroup>
   );

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -10,6 +10,8 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        brand:
+          'bg-brand-primary text-primary-foreground shadow hover:bg-brand-primary/90 focus-visible:ring-brand-primary/50',
         primary: 'bg-[#2B6AD2] text-white hover:bg-[#225eb9] focus:ring-[#3b7de8]',
         destructive: 'bg-destructive text-white shadow-sm hover:bg-destructive/90',
         outline:


### PR DESCRIPTION
## Summary
Kilo Pass referral sharing is now available from Kilo Pass surfaces for any Kilo user, with reward eligibility explained on the dedicated referral page.

### Why this change is needed
Referral sharing was tied too closely to subscription state and needed clearer placement and eligibility messaging. Users need to share Kilo Pass regardless of current or historical subscription state, while reward application rules stay unchanged.

### How this is addressed
- Adds explicit Impact referral spec language for subscription-independent Kilo Pass sharing.
- Shows `Refer & earn` across Kilo Pass subscription, profile, former subscriber, and non-subscriber surfaces.
- Keeps referral details on `/subscriptions/kilo-pass/refer` and points back to `/subscriptions#kilo-pass`.
- Adds contextual eligibility copy for active monthly, inactive monthly, annual, paused, canceling, canceled, former, and non-subscribed states.
- Keeps reward processing, attribution, cap, expiry, and issuance behavior unchanged.
- Places the profile non-subscriber referral CTA inside the Kilo Pass subscribe card, uses a yellow CTA with a black `NEW` badge, and keeps the subscription-card chevron pinned to the right edge.
- Collapses non-subscriber reward mechanics behind an info tooltip on the referral page while keeping the primary callout short.

## Human Verification
Local dev environment testing and validation.

<img width="1280" height="1107" alt="localhost_3000_subscriptions_kilo-pass_refer Large" src="https://github.com/user-attachments/assets/b4aa8839-7549-4391-b80a-25cc384fefce" />
<img width="1280" height="1041" alt="localhost_3000_subscriptions_kilo-pass_refer (1) Large" src="https://github.com/user-attachments/assets/1a997c7a-b9da-4e42-9022-3e88d7ad8467" />
<img width="987" height="1280" alt="localhost_3000_subscriptions_kilo-pass_refer (2) Large" src="https://github.com/user-attachments/assets/d015ed22-8ee8-46ca-ba63-e385197d9462" />
<img width="1086" height="1280" alt="localhost_3000_payments_kilo-pass_awarding_session_id=cs_test_b1NDIlAHs4g32E5QOOSwIenWCzsGXnBVFYBS3hBFjBxtnTXdbnF3zXYYXR Large" src="https://github.com/user-attachments/assets/c8736753-2443-4956-bcb1-c2ba18f34e0f" />
<img width="1280" height="1107" alt="localhost_3000_payments_kilo-pass_awarding_session_id=cs_test_b1NDIlAHs4g32E5QOOSwIenWCzsGXnBVFYBS3hBFjBxtnTXdbnF3zXYYXR (1) Large" src="https://github.com/user-attachments/assets/d2b98f6a-563e-494c-89db-840357ddfa08" />


## Reviewer Notes
### Human Reviewer Flags
- Spec now explicitly states subscription-independent sharing eligibility for Kilo Pass referrals.
- Reward eligibility remains intentionally stricter than sharing eligibility; rewards still apply only through future eligible personal monthly base issuance.
- Non-subscriber visible copy now uses `Redeem your reward with an active Kilo Pass`; mechanics still clarify automatic application in the tooltip.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `SubscriptionCard` supports `actionPlacement="top-right"` so Kilo Pass can place its referral CTA beside the header area without changing footer actions for KiloClaw.
- `KiloPassSubscribeCard` accepts `headerAction` so the profile non-subscriber referral CTA can live inside the Kilo Pass card instead of above it.
- Impact unavailable copy remains Kilo Pass-specific for Kilo Pass 503 responses and does not fall back to KiloClaw.
- Existing reward tests cover no active referrer subscription requirement, five-reward cap, referee reward under capped referrer, 12-month expiry, annual ineligibility, oldest pending reward application, and source-conversion exclusion.

</details>
