### PR TITLE
fix(byok): unify Mistral key routing

### DIFF
--- a/apps/web/src/app/api/fim/completions/route.ts
+++ b/apps/web/src/app/api/fim/completions/route.ts
@@ -25,6 +25,10 @@ import { readDb } from '@/lib/drizzle';
 import { debugSaveProxyRequest } from '@/lib/debugUtils';
 import { sentryLogger } from '@/lib/utils.server';
 import { getBYOKforOrganization, getBYOKforUser } from '@/lib/ai-gateway/byok';
+import {
+  MISTRAL_USER_BYOK_PROVIDER_IDS,
+  type UserByokProviderId,
+} from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 
 // Mistral exposes FIM on two separate, key-incompatible endpoints:
 //   - https://api.mistral.ai          (La Plateforme, paid tier keys)
@@ -153,11 +157,12 @@ export async function POST(request: NextRequest) {
   // Extract properties for usage context
   const promptInfo = extractFimPromptInfo(requestBody);
 
-  const byokProviderKey = fimProvider === 'mistral' ? 'codestral' : 'inception';
+  const byokProviderKeys: UserByokProviderId[] =
+    fimProvider === 'mistral' ? [...MISTRAL_USER_BYOK_PROVIDER_IDS] : ['inception'];
 
   const userByok = organizationId
-    ? await getBYOKforOrganization(readDb, organizationId, [byokProviderKey])
-    : await getBYOKforUser(readDb, user.id, [byokProviderKey]);
+    ? await getBYOKforOrganization(readDb, organizationId, byokProviderKeys)
+    : await getBYOKforUser(readDb, user.id, byokProviderKeys);
 
   const usageContext: MicrodollarUsageContext = {
     api_kind: 'fim_completions',

--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -70,7 +70,7 @@ const VERCEL_BYOK_PROVIDER_NAMES = {
   fireworks: 'Fireworks',
   google: 'Google AI Studio',
   minimax: 'MiniMax',
-  mistral: 'Mistral AI (other models)',
+  mistral: 'Mistral AI',
   moonshotai: 'Moonshot AI',
   novita: 'Novita',
   perplexity: 'Perplexity',
@@ -81,7 +81,10 @@ const VERCEL_BYOK_PROVIDER_NAMES = {
 
 const VERCEL_BYOK_PROVIDERS = [
   ...Object.entries(VERCEL_BYOK_PROVIDER_NAMES).map(([id, name]) => ({ id, name })),
-  { id: DirectUserByokInferenceProviderIdSchema.enum.codestral, name: 'Mistral AI (Codestral)' },
+  {
+    id: DirectUserByokInferenceProviderIdSchema.enum.codestral,
+    name: 'Legacy Codestral-only key',
+  },
 ];
 
 const DIRECT_BYOK_PROVIDERS_LIST = Object.entries(DIRECT_BYOK_PROVIDERS_META).map(([id, name]) => ({

--- a/apps/web/src/lib/ai-gateway/byok/index.ts
+++ b/apps/web/src/lib/ai-gateway/byok/index.ts
@@ -5,18 +5,19 @@ import type { EncryptedData } from '@/lib/ai-gateway/byok/encryption';
 import { decryptApiKey } from '@/lib/ai-gateway/byok/encryption';
 import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
 import {
+  MISTRAL_USER_BYOK_PROVIDER_IDS,
   UserByokProviderIdSchema,
   VercelUserByokInferenceProviderIdSchema,
   type UserByokProviderId,
 } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
-import { isCodestralModel } from '@/lib/ai-gateway/providers/mistral';
+import { isMistralModel } from '@/lib/ai-gateway/providers/mistral';
 import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelIdToVercel';
 import type { BYOKResult } from '@/lib/ai-gateway/providers/types';
 import { getVercelModelsMetadata } from '@/lib/ai-gateway/providers/gateway-models-cache';
 
 export async function getModelUserByokProviders(modelId: string): Promise<UserByokProviderId[]> {
-  if (isCodestralModel(modelId)) {
-    return ['codestral'];
+  if (isMistralModel(modelId)) {
+    return [...MISTRAL_USER_BYOK_PROVIDER_IDS];
   }
   const vercelModelMetadata = await getVercelModelsMetadata();
   if (Object.keys(vercelModelMetadata).length === 0) {
@@ -48,6 +49,23 @@ export function decryptByokRow({
   };
 }
 
+function prioritizeMistralKeys(
+  byok: BYOKResult[],
+  providerIds: UserByokProviderId[]
+): BYOKResult[] {
+  if (!MISTRAL_USER_BYOK_PROVIDER_IDS.every(providerId => providerIds.includes(providerId))) {
+    return byok;
+  }
+  const providerPriority = new Map(
+    MISTRAL_USER_BYOK_PROVIDER_IDS.map((providerId, index) => [providerId, index])
+  );
+  return byok.toSorted(
+    (left, right) =>
+      (providerPriority.get(left.providerId) ?? Number.MAX_SAFE_INTEGER) -
+      (providerPriority.get(right.providerId) ?? Number.MAX_SAFE_INTEGER)
+  );
+}
+
 export async function getBYOKforUser(
   fromDb: typeof db,
   userId: string,
@@ -71,7 +89,12 @@ export async function getBYOKforUser(
     )
     .orderBy(byok_api_keys.created_at);
 
-  return rows.length === 0 ? null : rows.map(row => decryptByokRow(row));
+  return rows.length === 0
+    ? null
+    : prioritizeMistralKeys(
+        rows.map(row => decryptByokRow(row)),
+        providerIds
+      );
 }
 
 export async function getBYOKforOrganization(
@@ -97,5 +120,10 @@ export async function getBYOKforOrganization(
     )
     .orderBy(byok_api_keys.created_at);
 
-  return rows.length === 0 ? null : rows.map(row => decryptByokRow(row));
+  return rows.length === 0
+    ? null
+    : prioritizeMistralKeys(
+        rows.map(row => decryptByokRow(row)),
+        providerIds
+      );
 }

--- a/apps/web/src/lib/ai-gateway/byok/index.ts
+++ b/apps/web/src/lib/ai-gateway/byok/index.ts
@@ -56,7 +56,7 @@ function prioritizeMistralKeys(
   if (!MISTRAL_USER_BYOK_PROVIDER_IDS.every(providerId => providerIds.includes(providerId))) {
     return byok;
   }
-  const providerPriority = new Map(
+  const providerPriority = new Map<UserByokProviderId, number>(
     MISTRAL_USER_BYOK_PROVIDER_IDS.map((providerId, index) => [providerId, index])
   );
   return byok.toSorted(

--- a/apps/web/src/lib/ai-gateway/byok/mistral-routing.test.ts
+++ b/apps/web/src/lib/ai-gateway/byok/mistral-routing.test.ts
@@ -1,0 +1,59 @@
+/* eslint-disable drizzle/enforce-delete-with-where */
+import { getBYOKforUser, getModelUserByokProviders } from '@/lib/ai-gateway/byok';
+import { encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
+import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
+import { db } from '@/lib/drizzle';
+import { applyVercelSettings } from '@/lib/ai-gateway/providers/vercel';
+import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { byok_api_keys, kilocode_users } from '@kilocode/db/schema';
+
+afterEach(async () => {
+  await db.delete(byok_api_keys);
+  await db.delete(kilocode_users);
+});
+
+describe('Mistral BYOK routing', () => {
+  it.each(['mistralai/mistral-small', 'mistralai/codestral-2508'])(
+    'uses both Mistral key types for %s',
+    async modelId => {
+      await expect(getModelUserByokProviders(modelId)).resolves.toEqual(['mistral', 'codestral']);
+    }
+  );
+
+  it('returns the Mistral key before the legacy Codestral key', async () => {
+    const user = await insertTestUser();
+    await db.insert(byok_api_keys).values([
+      {
+        kilo_user_id: user.id,
+        provider_id: 'codestral',
+        encrypted_api_key: encryptApiKey('codestral-key', BYOK_ENCRYPTION_KEY),
+        created_at: '2026-01-01T00:00:00.000Z',
+        created_by: user.id,
+      },
+      {
+        kilo_user_id: user.id,
+        provider_id: 'mistral',
+        encrypted_api_key: encryptApiKey('mistral-key', BYOK_ENCRYPTION_KEY),
+        created_at: '2026-02-01T00:00:00.000Z',
+        created_by: user.id,
+      },
+    ]);
+
+    const byok = await getBYOKforUser(db, user.id, ['mistral', 'codestral']);
+
+    expect(byok?.map(key => key.providerId)).toEqual(['mistral', 'codestral']);
+    expect(byok?.map(key => key.decryptedAPIKey)).toEqual(['mistral-key', 'codestral-key']);
+
+    const request = {
+      kind: 'chat_completions',
+      body: { model: 'mistralai/mistral-small', messages: [] },
+    } as GatewayRequest;
+    applyVercelSettings('mistralai/mistral-small', request, byok);
+
+    expect(request.body.providerOptions?.gateway?.byok?.mistral).toEqual([
+      { apiKey: 'mistral-key' },
+      { apiKey: 'codestral-key' },
+    ]);
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.ts
@@ -122,6 +122,11 @@ export const UserByokProviderIdSchema = VercelUserByokInferenceProviderIdSchema.
 
 export type UserByokProviderId = z.infer<typeof UserByokProviderIdSchema>;
 
+export const MISTRAL_USER_BYOK_PROVIDER_IDS = [
+  VercelUserByokInferenceProviderIdSchema.enum.mistral,
+  DirectUserByokInferenceProviderIdSchema.enum.codestral,
+] satisfies UserByokProviderId[];
+
 export const UserByokTestModels = {
   [VercelUserByokInferenceProviderIdSchema.enum.anthropic]: 'anthropic/claude-haiku-4.5',
   [VercelUserByokInferenceProviderIdSchema.enum.bedrock]: 'anthropic/claude-haiku-4.5',

--- a/apps/web/src/routers/byok-router.ts
+++ b/apps/web/src/routers/byok-router.ts
@@ -38,7 +38,6 @@ import { getVercelInferenceProviderConfigForUserByok } from '@/lib/ai-gateway/pr
 import { decryptByokRow } from '@/lib/ai-gateway/byok';
 import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelIdToVercel';
-import { isCodestralModel } from '@/lib/ai-gateway/providers/mistral';
 import { isKiloExclusiveModel } from '@/lib/ai-gateway/models';
 import DIRECT_BYOK_PROVIDERS from '@/lib/ai-gateway/providers/direct-byok/direct-byok-definitions';
 import {
@@ -108,13 +107,10 @@ async function fetchSupportedModels(): Promise<Record<string, string[]>> {
 
   const result: Record<string, string[]> = {};
 
-  result['codestral'] = ['Codestral (mistralai/codestral-2508)'];
-
   for (const openRouterModel of Object.values(openRouterModelMetadata)) {
     if (isKiloExclusiveModel(openRouterModel.id)) continue;
     const vercelModel = vercelModelMetadata[mapModelIdToVercel(openRouterModel.id, false)];
     if (!vercelModel) continue;
-    if (isCodestralModel(vercelModel.id)) continue;
     if (vercelModel.type !== 'language') continue;
     for (const endpoint of vercelModel.endpoints) {
       const providerParsed = VercelUserByokInferenceProviderIdSchema.safeParse(
@@ -133,6 +129,13 @@ async function fetchSupportedModels(): Promise<Record<string, string[]>> {
       result[provider.id].push(model.name + ' (' + formatDirectByokModelId(provider, model) + ')');
     }
   }
+
+  const mistralProviderId = VercelUserByokInferenceProviderIdSchema.enum.mistral;
+  const mistralModels = result[mistralProviderId] ?? [];
+  const legacyCodestralModel = `Codestral (mistralai/${CODESTRAL_TEST_MODEL})`;
+  if (!mistralModels.includes(legacyCodestralModel)) mistralModels.push(legacyCodestralModel);
+  result[mistralProviderId] = mistralModels;
+  result.codestral = [...mistralModels];
 
   for (const models of Object.values(result)) {
     models.sort();


### PR DESCRIPTION
## Summary

- Rename the general Mistral credential to `Mistral AI` and identify the old credential as `Legacy Codestral-only key`.
- Make both credential types eligible for every Mistral model, including FIM and supported-model listings.
- Prefer the general Mistral key before the legacy Codestral key while preserving the legacy FIM endpoint when it is selected.

## Verification

- [ ] Not manually verified before PR creation, per the requested sequencing.

## Visual Changes

N/A

## Reviewer Notes

The legacy `codestral` provider ID remains supported for existing stored keys. Both IDs map to Vercel's Mistral BYOK provider, with the `mistral` credential ordered first.