### PR TITLE
fix(ai-gateway): use Qwen for all balanced APIs

### DIFF
--- a/apps/web/src/lib/ai-gateway/auto-model/index.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/index.ts
@@ -77,16 +77,6 @@ export const FRONTIER_MODE_TO_MODEL: Record<Mode, ResolvedAutoModel> = {
   code: SONNET_FRONTIER,
 };
 
-export const BALANCED_RESPONSES_FALLBACK_MODEL: ResolvedAutoModel = {
-  model: 'openai/gpt-5.5',
-  reasoning: { enabled: true, effort: 'low' },
-};
-
-export const BALANCED_MESSAGES_FALLBACK_MODEL: ResolvedAutoModel = {
-  model: CLAUDE_SONNET_CURRENT_MODEL_ID,
-  reasoning: { enabled: true, effort: 'low' },
-};
-
 export const BALANCED_CLAW_SETUP_MODEL: ResolvedAutoModel = {
   model: claude_sonnet_clawsetup_model.public_id,
   reasoning: { enabled: true, effort: 'high' },

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -16,12 +16,10 @@ import {
   modeSchema,
   BALANCED_CLAW_SETUP_MODEL,
   BALANCED_QWEN_MODEL,
-  BALANCED_RESPONSES_FALLBACK_MODEL,
   FRONTIER_MODE_TO_MODEL,
   FRONTIER_CODE_MODEL,
   type ResolvedAutoModel,
   KILO_AUTO_LEGACY_MODEL,
-  BALANCED_MESSAGES_FALLBACK_MODEL,
 } from '@/lib/ai-gateway/auto-model';
 import { userIsWithinFirstKiloClawInstanceWindow } from '@/lib/kiloclaw/setup-promo';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
@@ -126,17 +124,7 @@ export async function resolveAutoModel(
       }
     }
 
-    // Alibaba doesn't expose a messages endpoint
-    // and does not support prompt caching on the responses endpoint
-    // so we use a fallback in those cases.
-    // This should be rare, both CLI and KiloClaw default to chat completions.
-    if (apiKind === 'responses') {
-      return { kind: 'ok', resolved: BALANCED_RESPONSES_FALLBACK_MODEL };
-    } else if (apiKind === 'messages') {
-      return { kind: 'ok', resolved: BALANCED_MESSAGES_FALLBACK_MODEL };
-    } else {
-      return { kind: 'ok', resolved: BALANCED_QWEN_MODEL };
-    }
+    return { kind: 'ok', resolved: BALANCED_QWEN_MODEL };
   }
   return {
     kind: 'ok',


### PR DESCRIPTION
## Summary

- Route balanced model requests through Qwen for chat completions, Responses, and Messages APIs now that Qwen supports all three.
- Remove the obsolete GPT and Claude API-specific fallback model definitions.

## Verification

- [ ] Not manually tested before PR creation, per request to avoid long-running tasks until after push and PR creation.

## Visual Changes

N/A

## Reviewer Notes

The existing KiloClaw setup-window override remains unchanged and still takes precedence over balanced Qwen routing.