### PR TITLE
feat(gastown): integrate gastown into dev:env secret management

### DIFF
--- a/services/gastown/.dev.vars.example
+++ b/services/gastown/.dev.vars.example
@@ -1,0 +1,7 @@
+# Shared secret for JWT token validation (same as NextAuth.js secret)
+# @from NEXTAUTH_SECRET
+NEXTAUTH_SECRET=your-nextauth-secret-here
+
+# Secret for Gastown JWT signing (town access tokens, container tokens, etc.)
+# @from GASTOWN_JWT_SECRET
+GASTOWN_JWT_SECRET=your-gastown-jwt-secret-here


### PR DESCRIPTION
## Summary

Creates `services/gastown/.dev.vars.example` with `@from` annotations for `NEXTAUTH_SECRET` and `GASTOWN_JWT_SECRET`, enabling the `dev:env` sync system to generate `.dev.vars` and auto-create Secrets Store entries for Gastown locally.

Closes #4013

Previously Gastown hardcoded dev secrets in `wrangler.jsonc` `env.dev.vars`, which drifted from `.env.local` and couldn't benefit from the centralized secret management pipeline. The committed `wrangler.jsonc` already has correct `secrets_store_secrets` bindings in both top-level (production) and `env.dev` (local) sections, so no wrangler config changes are needed.

## Verification

- [ ] Run `pnpm dev:env`  and verify Gastown secrets are generated.

## Visual Changes

N/A

## Reviewer Notes

- The only file change is the new `.dev.vars.example`. The `wrangler.jsonc` already had correct `secrets_store_secrets` bindings in `env.dev` from a prior commit.
- `GASTOWN_JWT_SECRET` must be added to `.env.local`; otherwise the placeholder value from `.dev.vars.example` is used.
- Production deployment is completely unaffected. `wrangler deploy` uses top-level `secrets_store_secrets` bindings which are unchanged.