### PR TITLE
fix(code-review): enable code review retries when sandbox does not respond

### DIFF
--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -1383,6 +1383,229 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
       );
     });
 
+    it('allows one fresh retry for a pre-dispatch sandbox connection failure when usage is unavailable', async () => {
+      const retryFlow = mockCreatedInfraRetryFlow({
+        sessionId: 'agent-sandbox-connect-failed',
+        cliSessionId: 'ses_sandbox_connect_failed',
+      });
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ status: 'running', session_id: retryFlow.sessionId })
+      );
+      mockGetSessionUsageFromBilling.mockResolvedValue(null);
+
+      const response = await POST(
+        makeRequest({
+          status: 'failed',
+          cloudAgentSessionId: retryFlow.sessionId,
+          kiloSessionId: retryFlow.cliSessionId,
+          errorMessage: 'Could not connect to the sandbox',
+          terminalReason: 'sandbox_error',
+          failure: {
+            stage: 'pre_dispatch',
+            code: 'sandbox_connect_failed',
+            attempts: 2,
+            message: 'Sandbox connection failed after 2 attempts',
+          },
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({ success: true, retried: true });
+      expect(mockGetSessionUsageFromBilling).toHaveBeenCalledWith(
+        'ses_sandbox_connect_failed',
+        '2025-01-01T00:00:00Z'
+      );
+      expect(mockCreateInfraRetryAttemptIfMissing).toHaveBeenCalledWith({
+        codeReviewId: REVIEW_ID,
+        retryOfAttemptId: retryFlow.failedAttemptId,
+      });
+      expect(mockRetryReviewFresh).toHaveBeenCalledWith(REVIEW_ID, {
+        sessionId: retryFlow.sessionId,
+        reason: 'Could not connect to the sandbox',
+        failedAttemptId: retryFlow.failedAttemptId,
+        retryAttemptId: retryFlow.retryAttemptId,
+      });
+      expect(mockUpdateCodeReviewStatus).not.toHaveBeenCalled();
+      expect(mockUpdateCheckRun).not.toHaveBeenCalled();
+      expect(mockTryDispatchPendingReviews).not.toHaveBeenCalled();
+    });
+
+    it('does not infer the unavailable-usage exception from sandbox connection error text', async () => {
+      const retryFlow = mockCreatedInfraRetryFlow({
+        sessionId: 'agent-sandbox-connect-text-only',
+        cliSessionId: 'ses_sandbox_connect_text_only',
+      });
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ status: 'running', session_id: retryFlow.sessionId })
+      );
+      mockGetSessionUsageFromBilling.mockResolvedValue(null);
+
+      const response = await POST(
+        makeRequest({
+          status: 'failed',
+          cloudAgentSessionId: retryFlow.sessionId,
+          kiloSessionId: retryFlow.cliSessionId,
+          errorMessage: 'Could not connect to the sandbox',
+          terminalReason: 'sandbox_error',
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockGetSessionUsageFromBilling).toHaveBeenCalledWith(
+        'ses_sandbox_connect_text_only',
+        '2025-01-01T00:00:00Z'
+      );
+      expect(mockCreateInfraRetryAttemptIfMissing).not.toHaveBeenCalled();
+      expect(mockRetryReviewFresh).not.toHaveBeenCalled();
+      expect(mockUpdateCodeReviewStatus).toHaveBeenCalledWith(
+        REVIEW_ID,
+        'failed',
+        expect.objectContaining({ terminalReason: 'sandbox_error' })
+      );
+    });
+
+    it.each([
+      {
+        name: 'sandbox connection failure after dispatch',
+        failure: { stage: 'agent_activity', code: 'sandbox_connect_failed' },
+      },
+      {
+        name: 'different pre-dispatch failure code',
+        failure: { stage: 'pre_dispatch', code: 'workspace_setup_failed' },
+      },
+      {
+        name: 'incomplete failure data',
+        failure: { stage: 'pre_dispatch' },
+      },
+      {
+        name: 'future-shaped failure data',
+        failure: {
+          stage: 'pre_dispatch',
+          code: 'sandbox_connect_failed',
+          diagnostic: 'future field',
+        },
+      },
+    ])('keeps unavailable usage fail-closed for $name', async ({ failure }) => {
+      const retryFlow = mockCreatedInfraRetryFlow({
+        sessionId: 'agent-sandbox-connect-near-miss',
+        cliSessionId: 'ses_sandbox_connect_near_miss',
+      });
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ status: 'running', session_id: retryFlow.sessionId })
+      );
+      mockGetSessionUsageFromBilling.mockResolvedValue(null);
+
+      const response = await POST(
+        makeRequest({
+          status: 'failed',
+          cloudAgentSessionId: retryFlow.sessionId,
+          kiloSessionId: retryFlow.cliSessionId,
+          errorMessage: 'Could not connect to the sandbox',
+          terminalReason: 'sandbox_error',
+          failure,
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockGetSessionUsageFromBilling).toHaveBeenCalledWith(
+        'ses_sandbox_connect_near_miss',
+        '2025-01-01T00:00:00Z'
+      );
+      expect(mockCreateInfraRetryAttemptIfMissing).not.toHaveBeenCalled();
+      expect(mockRetryReviewFresh).not.toHaveBeenCalled();
+      expect(mockUpdateCodeReviewStatus).toHaveBeenCalledWith(
+        REVIEW_ID,
+        'failed',
+        expect.objectContaining({ terminalReason: 'sandbox_error' })
+      );
+    });
+
+    it('ignores structured failure fields on legacy orchestrator payloads', async () => {
+      const retryFlow = mockCreatedInfraRetryFlow({
+        sessionId: 'agent-legacy-sandbox-connect',
+        cliSessionId: 'ses_legacy_sandbox_connect',
+      });
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ status: 'running', session_id: retryFlow.sessionId })
+      );
+      mockGetSessionUsageFromBilling.mockResolvedValue(null);
+
+      const response = await POST(
+        makeRequest({
+          status: 'failed',
+          sessionId: retryFlow.sessionId,
+          cliSessionId: retryFlow.cliSessionId,
+          errorMessage: 'Could not connect to the sandbox',
+          terminalReason: 'sandbox_error',
+          failure: {
+            stage: 'pre_dispatch',
+            code: 'sandbox_connect_failed',
+          },
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockGetSessionUsageFromBilling).toHaveBeenCalledWith(
+        'ses_legacy_sandbox_connect',
+        '2025-01-01T00:00:00Z'
+      );
+      expect(mockCreateInfraRetryAttemptIfMissing).not.toHaveBeenCalled();
+      expect(mockRetryReviewFresh).not.toHaveBeenCalled();
+      expect(mockUpdateCodeReviewStatus).toHaveBeenCalledWith(
+        REVIEW_ID,
+        'failed',
+        expect.objectContaining({ terminalReason: 'sandbox_error' })
+      );
+    });
+
+    it('applies measured usage thresholds to pre-dispatch sandbox connection failures', async () => {
+      const retryFlow = mockCreatedInfraRetryFlow({
+        sessionId: 'agent-expensive-sandbox-connect',
+        cliSessionId: 'ses_expensive_sandbox_connect',
+      });
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ status: 'running', session_id: retryFlow.sessionId })
+      );
+      mockGetSessionUsageFromBilling.mockResolvedValue({
+        model: 'anthropic/claude-sonnet-4.6',
+        totalTokensIn: 99_999,
+        totalTokensOut: 0,
+        totalCostMusd: 200_000,
+      });
+
+      const response = await POST(
+        makeRequest({
+          status: 'failed',
+          cloudAgentSessionId: retryFlow.sessionId,
+          kiloSessionId: retryFlow.cliSessionId,
+          errorMessage: 'Could not connect to the sandbox',
+          terminalReason: 'sandbox_error',
+          failure: {
+            stage: 'pre_dispatch',
+            code: 'sandbox_connect_failed',
+          },
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockGetSessionUsageFromBilling).toHaveBeenCalledWith(
+        'ses_expensive_sandbox_connect',
+        '2025-01-01T00:00:00Z'
+      );
+      expect(mockCreateInfraRetryAttemptIfMissing).not.toHaveBeenCalled();
+      expect(mockRetryReviewFresh).not.toHaveBeenCalled();
+      expect(mockUpdateCodeReviewStatus).toHaveBeenCalledWith(
+        REVIEW_ID,
+        'failed',
+        expect.objectContaining({ terminalReason: 'sandbox_error' })
+      );
+    });
+
     it.each([
       {
         name: 'cost and tokens are below thresholds',
@@ -1748,7 +1971,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
       expect(mockUpdateCodeReviewStatus).not.toHaveBeenCalled();
     });
 
-    it('terminalizes the parent when the infra retry attempt fails', async () => {
+    it('terminalizes a retry attempt with the targeted pre-dispatch sandbox failure', async () => {
       mockGetCodeReviewById.mockResolvedValue(
         makeReview({ status: 'running', session_id: 'agent-second-failure' })
       );
@@ -1757,6 +1980,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
           id: '00000000-0000-0000-0000-000000000403',
           status: 'failed',
           session_id: 'agent-second-failure',
+          cli_session_id: 'ses_second_failure',
           retry_reason: 'infra_failure',
           retry_of_attempt_id: '00000000-0000-0000-0000-000000000402',
         })
@@ -1766,6 +1990,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
           id: '00000000-0000-0000-0000-000000000403',
           status: 'failed',
           session_id: 'agent-second-failure',
+          cli_session_id: 'ses_second_failure',
           retry_reason: 'infra_failure',
           retry_of_attempt_id: '00000000-0000-0000-0000-000000000402',
         })
@@ -1775,8 +2000,13 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         makeRequest({
           status: 'failed',
           cloudAgentSessionId: 'agent-second-failure',
+          kiloSessionId: 'ses_second_failure',
           errorMessage: 'Unexpected backend failure after prior infra retry',
           terminalReason: 'upstream_error',
+          failure: {
+            stage: 'pre_dispatch',
+            code: 'sandbox_connect_failed',
+          },
         }),
         makeParams(REVIEW_ID)
       );

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -77,6 +77,10 @@ import {
 } from '@kilocode/db/schema-types';
 import { isCloudAgentNextBillingErrorBody } from '@kilocode/worker-utils/cloud-agent-next-client';
 import {
+  CloudAgentCallbackFailureSchema,
+  type CloudAgentSafeFailure,
+} from '@kilocode/worker-utils/cloud-agent-failure';
+import {
   classifyCodeReviewActionRequiredFailure,
   disableCodeReviewForActionRequiredFailure,
   getCodeReviewActionRequiredCopy,
@@ -109,6 +113,7 @@ type CloudAgentNextCallbackPayload = {
   errorMessage?: string;
   terminalReason?: CodeReviewTerminalReason;
   modelNotFoundRuntimeDiagnostics?: unknown;
+  failure?: unknown;
   lastSeenBranch?: string;
   gateResult?: 'pass' | 'fail';
 };
@@ -260,6 +265,7 @@ function normalizePayload(raw: StatusUpdatePayload): {
   errorMessage?: string;
   terminalReason?: CodeReviewTerminalReason;
   gateResult?: 'pass' | 'fail';
+  failure?: CloudAgentSafeFailure;
 } {
   // Map cloud-agent-next 'interrupted' → 'cancelled'
   let status: 'running' | 'completed' | 'failed' | 'cancelled' =
@@ -276,6 +282,8 @@ function normalizePayload(raw: StatusUpdatePayload): {
   // Map cloud-agent-next 'cloudAgentSessionId' → 'sessionId' as fallback
   const sessionId =
     raw.sessionId ?? ('cloudAgentSessionId' in raw ? raw.cloudAgentSessionId : undefined);
+  const failure =
+    'cloudAgentSessionId' in raw ? CloudAgentCallbackFailureSchema.parse(raw.failure) : undefined;
 
   // Validate terminalReason against allowlist to prevent free-form text in the DB
   const validReasons: ReadonlySet<string> = new Set(CODE_REVIEW_TERMINAL_REASONS);
@@ -325,6 +333,7 @@ function normalizePayload(raw: StatusUpdatePayload): {
     errorMessage: raw.errorMessage,
     terminalReason,
     gateResult: raw.gateResult,
+    failure,
   };
 }
 
@@ -421,6 +430,10 @@ function isInfraRetryAttempt(attempt: CloudAgentCodeReviewAttempt): boolean {
   return attempt.retry_reason === 'infra_failure' || attempt.retry_of_attempt_id !== null;
 }
 
+function isPreDispatchSandboxConnectFailure(failure?: CloudAgentSafeFailure): boolean {
+  return failure?.stage === 'pre_dispatch' && failure.code === 'sandbox_connect_failed';
+}
+
 type FailedSessionUsage = NonNullable<Awaited<ReturnType<typeof getSessionUsageFromBilling>>>;
 
 function failedSessionTokenCount(usage: FailedSessionUsage): number {
@@ -439,6 +452,7 @@ async function shouldSkipAutoRetryForFailedSessionUsage(params: {
   failedAttemptId: string;
   failedCliSessionId?: string | null;
   reviewCreatedAt: string;
+  failure?: CloudAgentSafeFailure;
 }): Promise<boolean> {
   if (!params.failedCliSessionId) {
     logExceptInTest('[code-review-status] Auto-retry token guard could not measure usage', {
@@ -451,13 +465,17 @@ async function shouldSkipAutoRetryForFailedSessionUsage(params: {
 
   const usage = await getSessionUsageFromBilling(params.failedCliSessionId, params.reviewCreatedAt);
   if (!usage) {
+    const allowUnavailableUsage = isPreDispatchSandboxConnectFailure(params.failure);
     logExceptInTest('[code-review-status] Auto-retry token guard could not measure usage', {
       reviewId: params.reviewId,
       failedAttemptId: params.failedAttemptId,
       cliSessionId: params.failedCliSessionId,
       reason: 'usage_unavailable',
+      failureStage: params.failure?.stage,
+      failureCode: params.failure?.code,
+      allowUnavailableUsage,
     });
-    return true;
+    return !allowUnavailableUsage;
   }
 
   const failedSessionTokens = failedSessionTokenCount(usage);
@@ -964,7 +982,7 @@ export async function POST(
 
     const rawPayload: StatusUpdatePayload = await req.json();
     const attemptId = callbackAttemptId || undefined;
-    const { status, sessionId, cliSessionId, errorMessage, terminalReason, gateResult } =
+    const { status, sessionId, cliSessionId, errorMessage, terminalReason, gateResult, failure } =
       normalizePayload(rawPayload);
     const executionId = 'executionId' in rawPayload ? rawPayload.executionId : undefined;
 
@@ -1116,6 +1134,7 @@ export async function POST(
           failedAttemptId: attempt.id,
           failedCliSessionId,
           reviewCreatedAt: review.created_at,
+          failure,
         });
 
         if (!skipRetryForSessionUsage) {


### PR DESCRIPTION
## Summary

44% of unhandled code reviews errors in the last 7 days are `Could not connect to the sandbox`.

The primary cause is a mismatch between observed Cloudflare Sandbox discovery latency and the application retry policy introduced by PR #3910:
- Wrapper discovery was reduced from 30 seconds to 10 seconds.
- Only one retry is permitted, after 5 seconds.
- Two misses terminalize the message after roughly 25 seconds.
- The PR explicitly accepted that outages longer than this retry window would fail messages, but recorded no manual production validation of the threshold.

Cloudflare Sandbox `listProcesses()` latency/unavailability is the downstream trigger. The aggressive timeout and retry policy turns it into a user-visible terminal failure.

A secondary application issue makes the impact worse: a pre-dispatch failure normally has no billing usage row, but `usage_unavailable` causes the code-review retry guard to fail closed, preventing the intended fresh-session infrastructure retry.

This PR enables the targeted fresh Code Reviewer retry for `usage_unavailable` only when all of these hold:
- valid callback token
- status = failed
- failure.stage = pre_dispatch
- failure.code = sandbox_connect_failed
- no prior infra retry exists

This is the safest immediate mitigation because it does not alter the Cloud Agent session’s wrapper fence or alarm durability.

## Verification

1. Send a first-attempt callback with `pre_dispatch` and `sandbox_connect_failed` while session usage is unavailable; confirm one fresh retry is scheduled and the review stays active.
2. Send callbacks with missing, invalid, or near-match failure details; confirm the review stops without a retry.
3. Send the exact failure with usage at the current limit, or from an existing retry attempt; confirm no extra retry is created.

## Reviewer Notes

The missing-usage exception is limited to the exact validated pre-dispatch sandbox connection failure. Failure messages and legacy callback fields cannot enable it.