### PR TITLE
fix(ci): stabilize setup smoke test

### DIFF
--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Wait for web app
         run: |
-          for i in {1..60}; do
+          for _ in {1..60}; do
             if curl -fsSL http://localhost:3000/users/sign_in >/dev/null; then
               exit 0
             fi
@@ -100,13 +100,44 @@ jobs:
       - name: Run setup smoke tests
         run: pnpm test:setup-smoke
 
+      - name: Summarize setup smoke tests
+        if: always()
+        run: |
+          report='apps/web/test-results/setup-smoke-results.json'
+
+          echo '## Setup smoke test results' >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ ! -f "$report" ]]; then
+            echo 'Playwright did not produce a JSON report.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          clean=$(jq -r '.stats.expected // 0' "$report")
+          flaky=$(jq -r '.stats.flaky // 0' "$report")
+          failed=$(jq -r '.stats.unexpected // 0' "$report")
+          skipped=$(jq -r '.stats.skipped // 0' "$report")
+
+          {
+            echo '| Outcome | Tests |'
+            echo '|---|---:|'
+            echo "| Passed without retries | $clean |"
+            echo "| Passed after retry | $flaky |"
+            echo "| Failed | $failed |"
+            echo "| Skipped | $skipped |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if (( flaky > 0 )); then
+            echo "::warning::$flaky setup smoke test(s) passed only after retry"
+          fi
+
       - name: Stop dev stack
         if: always()
         run: pnpm dev:stop --force
 
       - name: Upload setup smoke artifacts
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: setup-smoke-artifacts
           path: |

--- a/apps/web/playwright.setup-smoke.config.ts
+++ b/apps/web/playwright.setup-smoke.config.ts
@@ -9,11 +9,17 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: process.env.CI ? 'html' : 'list',
+  reporter: process.env.CI
+    ? [
+        ['html', { open: 'never' }],
+        ['json', { outputFile: 'test-results/setup-smoke-results.json' }],
+      ]
+    : 'list',
   outputDir: 'test-results/setup-smoke',
   use: {
     baseURL,
-    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    trace: 'on-all-retries',
   },
   projects: [
     {

--- a/apps/web/src/components/profile/UserProfileCard.tsx
+++ b/apps/web/src/components/profile/UserProfileCard.tsx
@@ -41,7 +41,7 @@ export function UserProfileCard({
 
   return (
     <>
-      <div className="flex items-start justify-between gap-2">
+      <section aria-label="User profile" className="flex items-start justify-between gap-2">
         <div className="flex min-w-0 items-center space-x-4">
           <Avatar className="h-14 w-14 shrink-0">
             {imageUrl ? <AvatarImage src={imageUrl} alt={name} /> : null}
@@ -83,7 +83,7 @@ export function UserProfileCard({
         >
           <Edit className="text-muted-foreground hover:text-foreground h-4 w-4" />
         </button>
-      </div>
+      </section>
 
       <EditProfileDialog
         open={editDialogOpen}

--- a/apps/web/tests/setup-smoke/profile.spec.ts
+++ b/apps/web/tests/setup-smoke/profile.spec.ts
@@ -4,10 +4,6 @@ import { kilocode_users } from '@kilocode/db/schema';
 import { hosted_domain_specials } from '@/lib/auth/constants';
 import { randomUUID } from 'node:crypto';
 
-function isSignedInDestination(url: URL): boolean {
-  return url.pathname === '/profile' || url.pathname.startsWith('/organizations/');
-}
-
 test.describe('local setup smoke', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
@@ -35,6 +31,7 @@ test.describe('local setup smoke', () => {
         hosted_domain: hosted_domain_specials.fake_devonly,
         stripe_customer_id: `cus_setup_smoke_${uniqueId}`,
         completed_welcome_form: true,
+        customer_source: 'Setup smoke test',
         has_validation_stytch: true,
       });
     } finally {
@@ -42,24 +39,12 @@ test.describe('local setup smoke', () => {
     }
 
     await page.goto(signInUrl);
-    await page.waitForURL(
-      url => url.pathname === '/customer-source-survey' || isSignedInDestination(url),
-      { timeout: 30_000, waitUntil: 'networkidle' }
-    );
+    await page.waitForURL(url => url.pathname === '/profile', { timeout: 30_000 });
 
-    if (new URL(page.url()).pathname === '/customer-source-survey') {
-      await page.getByRole('button', { name: 'Skip' }).click();
-      await page.waitForURL(url => isSignedInDestination(url), {
-        timeout: 15_000,
-        waitUntil: 'networkidle',
-      });
-    }
-
-    const profileResponse = await page.goto('/profile', { waitUntil: 'domcontentloaded' });
-    expect(profileResponse?.ok()).toBe(true);
-    await expect(page).toHaveURL(/\/profile$/);
+    const profileCard = page.getByRole('region', { name: 'User profile' });
+    await expect(profileCard).toBeVisible({ timeout: 30_000 });
     await expect(page.getByRole('link', { name: 'Your Profile' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Edit profile' })).toBeVisible();
-    await expect(page.getByText(testEmail)).toBeVisible();
+    await expect(profileCard.getByRole('button', { name: 'Edit profile' })).toBeVisible();
+    await expect(profileCard.getByText(testEmail, { exact: true })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Make the profile smoke flow deterministic by bypassing unrelated survey state and waiting on the rendered profile region.
- Scope profile assertions to semantic UI boundaries so duplicate sidebar content cannot trigger strict-locator failures.
- Surface retry outcomes in the Actions summary, retain richer failure artifacts, and move artifact upload to its Node 24 runtime.

## Verification

- [x] Exercised the setup smoke flow ten consecutive times against the local development stack and confirmed all ten reached the profile page without retries.
- [x] Confirmed the profile page renders the expected user email and profile controls after fake authentication.

## Visual Changes

N/A

## Reviewer Notes

The smoke workflow still permits two retries, but now reports retry-assisted passes explicitly instead of hiding them in a green run.