### PR TITLE
fix(ai-gateway): exclude Fable from OpenRouter models

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
+++ b/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
@@ -133,5 +133,5 @@ export function isOpusModel(requestedModel: string) {
 }
 
 export function isFableModel(requestedModel: string) {
-  return requestedModel.includes('fable');
+  return requestedModel.includes('claude-fable');
 }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -179,34 +179,6 @@ describe('isFableModel', () => {
   });
 });
 
-describe('Fable model filtering', () => {
-  beforeEach(() => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve(
-        createMockResponse({
-          jsonData: {
-            data: [
-              buildModel({ id: 'anthropic/claude-fable-5' }),
-              buildModel({ id: 'vendor/fable-model' }),
-            ],
-          },
-        })
-      )
-    ) as unknown as typeof fetch;
-  });
-
-  afterEach(() => {
-    global.fetch = originalFetch;
-  });
-
-  it('excludes Claude Fable while retaining unrelated model IDs containing fable', async () => {
-    const models = await getEnhancedOpenRouterModels();
-
-    expect(models.data.some(model => model.id === 'anthropic/claude-fable-5')).toBe(false);
-    expect(models.data.some(model => model.id === 'vendor/fable-model')).toBe(true);
-  });
-});
-
 describe('disabled paid Kilo-exclusive model fallback', () => {
   beforeEach(() => {
     kiloExclusiveModels.push(disabledPaidModel);

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -17,6 +17,7 @@ import {
   kiloExclusiveModels,
 } from '@/lib/ai-gateway/models';
 import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
+import { isFableModel } from '@/lib/ai-gateway/providers/anthropic.constants';
 
 jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
   getOpenRouterModelsMetadata: jest.fn(() => Promise.resolve({})),
@@ -168,6 +169,41 @@ describe('shouldSuppressOpenRouterModel', () => {
   it('suppresses hidden Kilo-exclusive models from OpenRouter', () => {
     expect(gemma_4_26b_a4b_it_free_model.status).toBe('hidden');
     expect(shouldSuppressOpenRouterModel(gemma_4_26b_a4b_it_free_model)).toBe(true);
+  });
+});
+
+describe('isFableModel', () => {
+  it('only matches Claude Fable model IDs', () => {
+    expect(isFableModel('anthropic/claude-fable-5')).toBe(true);
+    expect(isFableModel('vendor/fable-model')).toBe(false);
+  });
+});
+
+describe('Fable model filtering', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve(
+        createMockResponse({
+          jsonData: {
+            data: [
+              buildModel({ id: 'anthropic/claude-fable-5' }),
+              buildModel({ id: 'vendor/fable-model' }),
+            ],
+          },
+        })
+      )
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('excludes Claude Fable while retaining unrelated model IDs containing fable', async () => {
+    const models = await getEnhancedOpenRouterModels();
+
+    expect(models.data.some(model => model.id === 'anthropic/claude-fable-5')).toBe(false);
+    expect(models.data.some(model => model.id === 'vendor/fable-model')).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -27,6 +27,7 @@ import { normalizeInferenceProviderId } from '@/lib/ai-gateway/providers/openrou
 import { getTerminalBenchSummaries, terminalBenchFor } from '@/lib/model-stats/terminal-bench';
 import { isFreeNemotronModel, NVIDIA_TRIAL_TOS } from '@/lib/ai-gateway/providers/nvidia';
 import { applyCustomPricingToModel } from '@/lib/ai-gateway/custom-pricing';
+import { isFableModel } from '@/lib/ai-gateway/providers/anthropic.constants';
 
 // Re-export from shared module for backwards compatibility
 export { normalizeModelId } from '@/lib/ai-gateway/model-utils';
@@ -128,7 +129,9 @@ async function enhancedModelList(models: OpenRouterModel[]) {
         (model: OpenRouterModel) =>
           !kiloExclusiveModels.some(
             m => m.public_id === model.id && shouldSuppressOpenRouterModel(m)
-          ) && !isForbiddenFreeModel(model.id)
+          ) &&
+          !isForbiddenFreeModel(model.id) &&
+          !isFableModel(model.id)
       )
       .map(model => {
         const preferredProvider = getPreferredProviderOrder(model.id).at(0);


### PR DESCRIPTION
## Summary

- Exclude Claude Fable models from the enhanced OpenRouter model list, alongside forbidden free models.
- Narrow `isFableModel` matching to the `claude-fable` substring so unrelated model IDs containing `fable` retain existing behavior.
- Preserve all existing Fable routing and optimization logic elsewhere.

## Verification

- Not manually tested before PR creation, per requested operation ordering.

## Visual Changes

N/A

## Reviewer Notes

The exclusion applies only while constructing the enhanced OpenRouter model list; no broader model blocking or optimization changes are included.