### PR TITLE
feat(notifications): add Kilo Console beta notification for CLI users

### DIFF
--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -65,6 +65,17 @@ const normalUnconditionalNotifications: KiloNotification[] = [
     showIn: ['extension', 'cli'],
   },
   {
+    id: 'kilo-console-beta',
+    title: 'Try Kilo Console (Beta)',
+    message: 'Manage git worktrees, sessions, and all CLI settings from a browser-based UI.',
+    action: {
+      actionText: 'How to install',
+      actionURL:
+        'https://blog.kilo.ai/p/kilo-console-beta-is-live?utm_source=kilo-cli&utm_medium=notifications&utm_campaign=cli-tips',
+    },
+    showIn: ['cli'],
+  },
+  {
     id: 'app-builder-promo-mar-6',
     title: 'Try App Builder',
     message: "Don't feel like coding? Try App Builder to build with natural language from the web",


### PR DESCRIPTION
## Summary

- Adds a new `kilo-console-beta` entry to `normalUnconditionalNotifications` in `apps/web/src/lib/notifications.ts`
- Targets CLI users only (`showIn: ['cli']`) with a prompt to try Kilo Console (Beta)
- Links to the blog announcement with UTM tracking parameters

## Verification

- Notification appears for CLI users via the existing `/api/notifications` endpoint
- Not shown in extension clients (correctly scoped to `['cli']`)

## Visual Changes

N/A

## Reviewer Notes

N/A

---

Built for [Arkadiy Kondrashov](https://kilo-code.slack.com/archives/C09GD7US2UB/p1781537097019529?thread_ts=1781535679.235409&cid=C09GD7US2UB) by [Kilo for Slack](https://kilo.ai/slack)