### PR TITLE
fix(auto-routing): chunk classifier benchmark jobs

### DIFF
--- a/services/auto-routing-benchmark/src/admin.test.ts
+++ b/services/auto-routing-benchmark/src/admin.test.ts
@@ -7,6 +7,7 @@ import type {
 import { app } from './index';
 import { computeEngineIdentity } from './run';
 import type * as DbModule from './db';
+import { CLASSIFIER_CASES } from './datasets/classifier-cases';
 
 function makeSummary(model: string): BenchmarkModelSummary {
   return {
@@ -394,7 +395,18 @@ describe('POST /admin/runs', () => {
     const [, runArg] = vi.mocked(insertRun).mock.calls[0];
     expect(runArg.min_accuracy).toBe(TEST_CONFIG.minAccuracy);
     expect(runArg.switch_cost_factor).toBe(TEST_CONFIG.switchCostFactor);
-    expect(queueSendBatch).toHaveBeenCalledOnce();
+    const queuedMessages = queueSendBatch.mock.calls.flatMap(([messages]) => messages);
+    expect(queueSendBatch).toHaveBeenCalledTimes(2);
+    expect(queuedMessages).toHaveLength(
+      TEST_CONFIG.classifierModels.length *
+        TEST_CONFIG.classifierRepetitions *
+        CLASSIFIER_CASES.length
+    );
+    expect(queuedMessages[0].body).toMatchObject({
+      kind: 'classifier',
+      caseIds: [CLASSIFIER_CASES[0].id],
+      rep: 0,
+    });
   });
 
   it('carries a decider model only when its benchmark identity still matches', async () => {

--- a/services/auto-routing-benchmark/src/run.test.ts
+++ b/services/auto-routing-benchmark/src/run.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { CaseResultRow } from './db';
 import {
   BenchmarkJobMessageSchema,
+  buildClassifierMessages,
   buildDeciderMessages,
   chunkArray,
   computeEngineIdentity,
@@ -464,6 +465,34 @@ describe('decider message fan-out', () => {
     for (let chunkIdx = 0; chunkIdx < chunks.length; chunkIdx++) {
       const forChunk = messages.filter(m => m.body.chunk === chunkIdx);
       for (const { body } of forChunk) {
+        expect(body.caseIds).toEqual(chunks[chunkIdx].map(c => c.id));
+      }
+    }
+  });
+});
+
+describe('classifier message fan-out', () => {
+  it('buildClassifierMessages: produces models × reps × chunks messages with case IDs', () => {
+    const cases72 = Array.from({ length: 72 }, (_, i) => ({ id: `case-${i}` }));
+    const chunks = chunkArray(cases72, 4);
+    expect(chunks).toHaveLength(18);
+
+    const models = ['model/a', 'model/b'];
+    const repetitions = 3;
+    const messages = buildClassifierMessages('run-test', models, repetitions, chunks);
+
+    expect(messages).toHaveLength(models.length * repetitions * chunks.length);
+
+    for (let rep = 0; rep < repetitions; rep++) {
+      const forRep = messages.filter(m => m.body.rep === rep);
+      expect(forRep).toHaveLength(models.length * chunks.length);
+    }
+
+    for (let chunkIdx = 0; chunkIdx < chunks.length; chunkIdx++) {
+      const forChunk = messages.filter(m => m.body.chunk === chunkIdx);
+      expect(forChunk).toHaveLength(models.length * repetitions);
+      for (const { body } of forChunk) {
+        expect(body.kind).toBe('classifier');
         expect(body.caseIds).toEqual(chunks[chunkIdx].map(c => c.id));
       }
     }

--- a/services/auto-routing-benchmark/src/run.ts
+++ b/services/auto-routing-benchmark/src/run.ts
@@ -40,11 +40,11 @@ export type BenchmarkJobMessage = {
   runId: string;
   kind: BenchmarkKind;
   model: string;
-  // Decider only: the case ids this message is responsible for, plus the chunk
-  // index used to key the container instance. Absent for classifier messages.
+  // The case ids this message is responsible for, plus the chunk index. Decider
+  // chunks also use this index to key their container instance.
   caseIds?: string[];
   chunk?: number;
-  // Repetition index (0-based). Absent for classifier messages.
+  // Repetition index (0-based).
   rep?: number;
 };
 
@@ -61,6 +61,11 @@ export const BenchmarkJobMessageSchema = z.object({
 // each). Chunking caps how many cases a single queue invocation processes so
 // each stays well under CF's wall-clock limit.
 const DECIDER_CHUNK_SIZE = 5;
+
+// Classifier calls are OpenRouter HTTP requests. Some candidate models can take
+// several minutes per request, so each queue invocation owns exactly one case to
+// keep it below Cloudflare Queues' 15-minute wall-clock limit.
+const CLASSIFIER_CHUNK_SIZE = 1;
 
 // Cloudflare Queues caps a single sendBatch at 100 messages. A decider fan-out
 // is models × reps × ceil(76 / 5) messages, which clears 100 with as few as two
@@ -153,6 +158,28 @@ export function buildDeciderMessages(
         body: {
           runId,
           kind,
+          model,
+          chunk,
+          rep,
+          caseIds: chunkCases.map(c => c.id),
+        } satisfies BenchmarkJobMessage,
+      }))
+    ).flat()
+  );
+}
+
+export function buildClassifierMessages(
+  runId: string,
+  modelIds: string[],
+  repetitions: number,
+  chunks: readonly (readonly { id: string }[])[]
+): { body: BenchmarkJobMessage }[] {
+  return modelIds.flatMap(model =>
+    Array.from({ length: repetitions }, (_, rep) =>
+      chunks.map((chunkCases, chunk) => ({
+        body: {
+          runId,
+          kind: 'classifier',
           model,
           chunk,
           rep,
@@ -308,13 +335,9 @@ export async function startRun(
   }
 
   if (kind === 'classifier') {
-    await enqueueRunMessages(
-      env,
-      runId,
-      enqueuedModelIds.map(model => ({
-        body: { runId, kind, model } satisfies BenchmarkJobMessage,
-      }))
-    );
+    const chunks = chunkArray(CLASSIFIER_CASES, CLASSIFIER_CHUNK_SIZE);
+    const messages = buildClassifierMessages(runId, enqueuedModelIds, repetitions, chunks);
+    await enqueueRunMessages(env, runId, messages);
     return { runId, enqueuedModels: enqueuedModelIds.length, skippedModels };
   }
 
@@ -345,15 +368,24 @@ export async function processJob(env: Env, rawMessage: unknown): Promise<void> {
   const state = await getRunState(env, message.runId);
 
   if (message.kind === 'classifier') {
+    if (!message.caseIds?.length || message.rep === undefined) {
+      console.warn(
+        JSON.stringify({
+          event: 'benchmark_classifier_job_missing_chunk',
+          runId: message.runId,
+          model: message.model,
+        })
+      );
+      return;
+    }
+
     // Create the OpenRouter client inside processJob — no module-scope transport clients.
     const client = await createOpenRouterClient(env);
-    // Expand cases × repetitions into a flat work list.
-    const expandedItems: { benchCase: (typeof CLASSIFIER_CASES)[number]; rep: number }[] = [];
-    for (let rep = 0; rep < state.repetitions; rep++) {
-      for (const benchCase of CLASSIFIER_CASES) {
-        expandedItems.push({ benchCase, rep });
-      }
-    }
+    const caseIds = new Set(message.caseIds);
+    const rep = message.rep;
+    const expandedItems = CLASSIFIER_CASES.filter(benchCase => caseIds.has(benchCase.id)).map(
+      benchCase => ({ benchCase, rep })
+    );
     await runCasesWithConcurrency(
       expandedItems,
       state.maxConcurrency,


### PR DESCRIPTION
## Summary

Split classifier benchmark queue work into per-case chunk messages instead of one full-model message. The classifier runner now processes the message's `caseIds` and `rep`, which keeps slow OpenRouter calls from making a whole model job exceed Cloudflare Queues' wall-time limit.

## Verification

N/A - not manually exercised against production; this changes queue fan-out logic only.

## Visual Changes

N/A

## Reviewer Notes

Classifier starts now enqueue `models × repetitions × cases` messages and rely on the existing 100-message `sendBatch` slicing. Existing DLQ messages from the old full-model shape should not be replayed; start a fresh classifier run after this deploy.