### PR TITLE
fix(admin): surface lineage latest destruction in orphan-volume scan

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
@@ -153,6 +153,7 @@ type OrphanVolumeRow = {
   sandbox_id: string;
   organization_id: string | null;
   destroyed_at: string;
+  latest_sandbox_destroyed_at: string | null;
   subscription_status: string | null;
   subscription_ended_at: string | null;
   fly_app: string;
@@ -665,9 +666,13 @@ function OrphanVolumesSection() {
                     <TableHead>Region / Size</TableHead>
                     <TableHead>Volume State</TableHead>
                     <TableHead>DO Status</TableHead>
-                    <TableHead>Destroyed</TableHead>
-                    <TableHead>Subscription</TableHead>
-                    <TableHead title="End of the subscription's current paid or trial period — the closest available proxy for when the user's access ended, not an authoritative cancellation timestamp.">
+                    <TableHead title="Most recent destruction across this sandbox's entire provision history — the date the 7-day orphan grace clock actually runs from. A reprovisioned sandbox can have an older row that matched the scan window; that windowed date is shown beneath when it differs.">
+                      Destroyed
+                    </TableHead>
+                    <TableHead title="Subscription attached to the provision that matched the scan window — for a reprovisioned sandbox this can be an older, already-transferred row, not the lineage's current subscription. The access check (Classification) uses the current successor subscription, not this column.">
+                      Subscription
+                    </TableHead>
+                    <TableHead title="End of the matched provision's paid or trial period — a proxy for when access ended, NOT an authoritative cancellation timestamp. For a reprovisioned sandbox this reflects the windowed provision's subscription, which may differ from the lineage's true end.">
                       Period End
                     </TableHead>
                     <TableHead>Classification</TableHead>
@@ -725,9 +730,31 @@ function OrphanVolumesSection() {
                         )}
                       </TableCell>
                       <TableCell className="text-xs">{volume.do_status ?? 'finalized'}</TableCell>
-                      <TableCell title={new Date(volume.destroyed_at).toLocaleString()}>
-                        {formatRelativeTime(volume.destroyed_at)}
-                      </TableCell>
+                      {(() => {
+                        // The grace clock runs from the lineage's most recent
+                        // destruction. Show that as the primary date so the
+                        // table never appears to predate a subscription that
+                        // lived on a later provision of the same sandbox.
+                        const graceDate = volume.latest_sandbox_destroyed_at ?? volume.destroyed_at;
+                        const windowDiffers =
+                          volume.latest_sandbox_destroyed_at !== null &&
+                          volume.latest_sandbox_destroyed_at !== volume.destroyed_at;
+                        return (
+                          <TableCell title={new Date(graceDate).toLocaleString()}>
+                            {formatRelativeTime(graceDate)}
+                            {windowDiffers && (
+                              <div
+                                className="text-muted-foreground text-xs"
+                                title={`This older provision (destroyed ${new Date(
+                                  volume.destroyed_at
+                                ).toLocaleString()}) matched the scan window; the sandbox was later reprovisioned and destroyed again.`}
+                              >
+                                scan match: {formatRelativeTime(volume.destroyed_at)}
+                              </div>
+                            )}
+                          </TableCell>
+                        );
+                      })()}
                       <TableCell>
                         {volume.subscription_status ? (
                           <Badge

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -3043,6 +3043,108 @@ describe('admin.kiloclawInstances.findOrphanVolumes', () => {
     });
   });
 
+  it('surfaces the lineage latest destruction for a reprovisioned sandbox windowed on an older provision', async () => {
+    // Regression: a reprovisioned sandbox has several destroyed instance rows
+    // sharing one Fly volume. Scanning a window that only matches the OLDER
+    // provision must still report `latest_sandbox_destroyed_at` (the date the
+    // grace clock runs from) so the table never appears to predate a
+    // subscription that lived on a later provision. The windowed row's own
+    // `destroyed_at` and its (older, already-transferred) subscription remain
+    // available for context, but they are NOT the lineage's current state.
+    const oldDestroyedAt = new Date(Date.now() - 30 * 86_400_000).toISOString();
+    const newDestroyedAt = new Date(Date.now() - 10 * 86_400_000).toISOString();
+    const sandboxId = `ki_${crypto.randomUUID().replace(/-/g, '')}`;
+
+    const [oldInstance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        id: crypto.randomUUID(),
+        user_id: regularUser.id,
+        sandbox_id: sandboxId,
+        destroyed_at: oldDestroyedAt,
+      })
+      .returning({ id: kiloclaw_instances.id });
+    const [newInstance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        id: crypto.randomUUID(),
+        user_id: regularUser.id,
+        sandbox_id: sandboxId,
+        destroyed_at: newDestroyedAt,
+      })
+      .returning({ id: kiloclaw_instances.id });
+
+    // Current (head) subscription lives on the newer provision; the older
+    // provision's subscription was transferred to it. Both canceled, so
+    // neither grants access and the volume classifies as a true orphan.
+    const [headSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: regularUser.id,
+        instance_id: newInstance.id,
+        plan: 'trial',
+        status: 'canceled',
+        trial_ends_at: '2026-05-31T03:58:11.084Z',
+      })
+      .returning({ id: kiloclaw_subscriptions.id });
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: regularUser.id,
+      instance_id: oldInstance.id,
+      plan: 'trial',
+      status: 'canceled',
+      trial_ends_at: '2026-03-05T20:56:33.061Z',
+      transferred_to_subscription_id: headSub.id,
+    });
+
+    mockScanOrphanVolumes.mockResolvedValue({
+      flyApp: 'inst-reprovision',
+      appExists: true,
+      expectedVolumeName: 'kiloclaw_reprovision',
+      doStatus: null,
+      doStatusError: null,
+      scanError: null,
+      volumes: [
+        {
+          id: 'vol_reprovision00000',
+          name: 'kiloclaw_reprovision',
+          state: 'created',
+          size_gb: 10,
+          region: 'ord',
+          attached_machine_id: null,
+          created_at: '2026-04-01T00:00:00.000Z',
+          nameMatchesInstance: true,
+          trackedByLiveDo: false,
+        },
+      ],
+    });
+
+    // Window matches only the OLDER provision's destruction.
+    const oldMs = Date.parse(oldDestroyedAt);
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.findOrphanVolumes({
+      destroyedAfter: new Date(oldMs - 60_000).toISOString(),
+      destroyedBefore: new Date(oldMs + 60_000).toISOString(),
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.volumes).toHaveLength(1);
+    // Only the windowed (older) provision was scanned by the worker.
+    expect(mockScanOrphanVolumes).toHaveBeenCalledTimes(1);
+    expect(mockScanOrphanVolumes.mock.calls[0][1]).toBe(oldInstance.id);
+    expect(result.volumes[0]).toMatchObject({
+      instance_id: oldInstance.id,
+      volume_id: 'vol_reprovision00000',
+      // The matched row is the old March-style provision...
+      destroyed_at: oldDestroyedAt,
+      // ...but the grace clock (and the new column) tracks the lineage's true
+      // latest destruction, which is far more recent.
+      latest_sandbox_destroyed_at: newDestroyedAt,
+      // Period End still reflects the windowed (older, transferred) sub.
+      subscription_ended_at: '2026-03-05T20:56:33.061Z',
+      classification: 'safe_destroy',
+    });
+  });
+
   it('scans production-shaped timestamp rows inside a narrow same-day ISO window', async () => {
     const destroyedAt = '2026-05-15 10:06:30.976+00';
     const sandboxId = `ki_${crypto.randomUUID().replace(/-/g, '')}`;

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -4024,6 +4024,13 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       sandbox_id: string;
       organization_id: string | null;
       destroyed_at: string;
+      // Lineage truth: the most recent destruction across ALL provisions of
+      // this (user, sandbox), not just the row that matched the scan window.
+      // This is the date the 7-day orphan grace clock actually runs from. For a
+      // reprovisioned sandbox it can be far more recent than `destroyed_at`
+      // (the windowed row), so surfacing it stops the table from appearing to
+      // contradict the user's subscription timeline.
+      latest_sandbox_destroyed_at: string | null;
       subscription_status: string | null;
       subscription_ended_at: string | null;
       fly_app: string;
@@ -4165,6 +4172,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             sandbox_id: instance.sandbox_id,
             organization_id: instance.organization_id,
             destroyed_at: destroyedAt,
+            latest_sandbox_destroyed_at: instance.latest_sandbox_destroyed_at,
             subscription_status: instance.subscription_status,
             subscription_ended_at: instance.subscription_ended_at,
             fly_app: scan.flyApp,


### PR DESCRIPTION
## Summary

The admin "Leftover Volume Cleanup" scanner could show a destroyed date and "Period End" months earlier than a user's actual subscription, making safe orphan volumes look like premature deletions. This happens for a reprovisioned sandbox: one `sandbox_id` has several `kiloclaw_instances` rows sharing one Fly volume, and the subscription transfers from each destroyed instance to its successor. When an admin scans a date window that matches an older provision, the table showed that old row's `destroyed_at` and its already-transferred subscription, even though the lineage lived for months afterward.

The scan query already computes `latest_sandbox_destroyed_at` (the most recent destruction across all provisions of the sandbox, which is the date the 7-day orphan grace clock actually runs from), but it was discarded before reaching the UI. This PR passes it through and shows it, so the table stops appearing to contradict the user's subscription timeline. This is display only. The deletion safety gates are unchanged.

## Changes

- `admin-kiloclaw-instances-router.ts`: add `latest_sandbox_destroyed_at` to the `findOrphanVolumes` result row and populate it from the value the scan query already computes.
- `KiloclawOrphansTab.tsx`: the "Destroyed" column now shows the lineage's most recent destruction as the primary date. When an older provision matched the scan window, a muted "scan match: ..." line is shown beneath it. Tightened the "Subscription" and "Period End" header tooltips to explain they reflect the windowed provision (which can be an older, already-transferred row), and that the access decision in the Classification column uses the current successor subscription, not those columns.
- `admin-kiloclaw-instances-router.test.ts`: add a regression test for a reprovisioned sandbox windowed on its older provision. It asserts the row reports the old `destroyed_at`, the recent `latest_sandbox_destroyed_at`, the older provision's subscription period end, and a `safe_destroy` classification.

## Verification

- [ ] No manual UI testing performed. This is a display-only change to an admin-only table; the underlying scan logic is covered by automated tests (the `findOrphanVolumes` suite passes, including the new reprovision-lineage case). Typecheck, oxfmt, and oxlint are clean on the touched files.

## Visual Changes

The "Destroyed" column in the Leftover Volume Cleanup table now shows the lineage's latest destruction, with a "scan match:" subline when an older provision matched the window. Header tooltips on Destroyed, Subscription, and Period End were reworded. Screenshots left for the author to add.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- No change to what gets deleted. The worker re-verifies every gate (grace from latest destruction, current access, name/state) before deleting, and that path is untouched.
- `latest_sandbox_destroyed_at` is typed nullable to match the row shape; the UI falls back to `destroyed_at` if it is ever null (it should not be, since the scanned row is always destroyed).
