### PR TITLE
feat(admin): add Linear/Log Y-axis toggle to kiloclaw Daily Instances chart

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
@@ -166,6 +166,9 @@ type CustomTooltipProps = {
 function DailyChart({ data }: { data: DailyChartData[] }) {
   const [showCreated, setShowCreated] = useState(true);
   const [showDestroyed, setShowDestroyed] = useState(true);
+  // Default to log scale: least lossy, absorbs future spikes without re-tuning,
+  // and the toggle lets you read absolute magnitudes on a linear axis when needed.
+  const [logScale, setLogScale] = useState(true);
 
   const chartData = data.map(item => ({
     date: format(parseISO(item.date), 'MM/dd'),
@@ -211,6 +214,9 @@ function DailyChart({ data }: { data: DailyChartData[] }) {
     1
   );
   const yAxisMax = Math.ceil(maxVal * 1.1) || 10;
+  // Log scale can't include 0, so floor the domain at a small positive value;
+  // bars of value 1 still render with visible height above the 0.5 baseline.
+  const yAxisDomain: [number, number] = logScale ? [0.5, yAxisMax] : [0, yAxisMax];
 
   return (
     <Card>
@@ -250,6 +256,32 @@ function DailyChart({ data }: { data: DailyChartData[] }) {
               Destroyed
             </span>
           </button>
+          <div className="bg-muted/50 flex items-center rounded-md p-0.5">
+            <button
+              type="button"
+              aria-pressed={!logScale}
+              className={`cursor-pointer rounded px-1.5 py-0.5 transition-colors ${
+                !logScale
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+              onClick={() => setLogScale(false)}
+            >
+              Linear
+            </button>
+            <button
+              type="button"
+              aria-pressed={logScale}
+              className={`cursor-pointer rounded px-1.5 py-0.5 transition-colors ${
+                logScale
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+              onClick={() => setLogScale(true)}
+            >
+              Log
+            </button>
+          </div>
         </div>
       </CardHeader>
       <CardContent className="pb-3">
@@ -263,7 +295,13 @@ function DailyChart({ data }: { data: DailyChartData[] }) {
                 minTickGap={24}
                 tick={{ fontSize: 10 }}
               />
-              <YAxis domain={[0, yAxisMax]} width={28} tick={{ fontSize: 10 }} />
+              <YAxis
+                scale={logScale ? 'log' : 'linear'}
+                domain={yAxisDomain}
+                allowDataOverflow={logScale}
+                width={28}
+                tick={{ fontSize: 10 }}
+              />
               <Tooltip content={<CustomTooltip />} />
               {showCreated && <Bar dataKey="created" fill="#22c55e" name="Created" />}
               {showDestroyed && <Bar dataKey="destroyed" fill="#ef4444" name="Destroyed" />}


### PR DESCRIPTION
## Summary

Adds a Linear/Log toggle for the Y-axis on the kiloclaw admin "Daily Instances"
chart and defaults it to log scale. Log scale keeps small daily counts readable
alongside large spikes without re-tuning the axis, and the toggle switches back
to a linear axis when you want to read absolute magnitudes.

## Changes

- Add a `logScale` state (defaults to `true`) to the `DailyChart` component in
  `KiloclawInstancesPage.tsx`.
- Add a segmented `Linear | Log` control in the chart's card header, styled to
  match the existing Created/Destroyed legend buttons, with `aria-pressed` on
  each segment.
- Pass `scale` and `allowDataOverflow` to the recharts `YAxis` based on the
  toggle. Log scale floors the domain at `0.5` (since log cannot include `0`) so
  bars with a value of `1` still render with visible height; linear keeps the
  `[0, max]` domain.

## Verification

- [ ] No manual testing run yet. Verified with the repo's format check, lint,
  and typecheck. Recommend a quick local check of the admin page to confirm the
  toggle switches the axis and that zero-count days render as expected on log
  scale.

## Visual Changes

A `Linear | Log` toggle now appears in the Daily Instances chart header and the
Y-axis renders on a log scale by default. Before/after screenshots to be added.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

The log domain floor of `0.5` is the notable detail: recharts renders a blank
axis if a log scale includes `0`, so the floor keeps value-`1` bars visible
while excluding empty days.
