### PR TITLE
Retain OpenRouter's modality field

### DIFF
--- a/apps/web/src/lib/organizations/organization-types.ts
+++ b/apps/web/src/lib/organizations/organization-types.ts
@@ -213,6 +213,7 @@ const OpenRouterModelSchema = z.object({
   created: z.number(),
   description: z.string(),
   architecture: z.object({
+    modality: z.string().nullable().optional(),
     input_modalities: z.array(z.string()),
     output_modalities: z.array(z.string()),
     tokenizer: z.string(),


### PR DESCRIPTION
I don't expect this to make a difference for anything, but it's a bit strange we discard it