### PR TITLE
fix(auto-routing): chunk summary inserts

### DIFF
--- a/services/auto-routing-benchmark/src/db-replace-summaries.test.ts
+++ b/services/auto-routing-benchmark/src/db-replace-summaries.test.ts
@@ -1,0 +1,61 @@
+import type { BenchmarkModelSummary } from '@kilocode/auto-routing-contracts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const deleteStatement = { kind: 'delete' };
+  const where = vi.fn(() => deleteStatement);
+  const deleteFrom = vi.fn(() => ({ where }));
+  const insertValues = vi.fn((rows: unknown[]) => ({ kind: 'insert', rows }));
+  const insertInto = vi.fn(() => ({ values: insertValues }));
+  const batch = vi.fn(async (_stmts: unknown[]) => []);
+
+  return { batch, deleteFrom, deleteStatement, insertInto, insertValues, where };
+});
+
+vi.mock('drizzle-orm/d1', () => ({
+  drizzle: vi.fn(() => ({
+    batch: mocks.batch,
+    delete: mocks.deleteFrom,
+    insert: mocks.insertInto,
+  })),
+}));
+
+import { replaceModelSummaries } from './db';
+
+function makeSummary(model: string): BenchmarkModelSummary {
+  return {
+    model,
+    tier: '*',
+    accuracy: 0.9,
+    avgCostUsd: 0.001,
+    avgLatencyMs: 100,
+    p50LatencyMs: 90,
+    p95LatencyMs: 120,
+    cases: 216,
+    errors: 0,
+    timeouts: 0,
+  };
+}
+
+describe('replaceModelSummaries', () => {
+  beforeEach(() => {
+    mocks.batch.mockClear();
+    mocks.deleteFrom.mockClear();
+    mocks.insertInto.mockClear();
+    mocks.insertValues.mockClear();
+    mocks.where.mockClear();
+  });
+
+  it('chunks summary inserts to stay below D1 SQL variable limits', async () => {
+    const summaries = Array.from({ length: 10 }, (_, i) => makeSummary(`model/${i}`));
+
+    await replaceModelSummaries({} as D1Database, 'run-1', summaries);
+
+    expect(mocks.insertValues).toHaveBeenCalledTimes(2);
+    expect(mocks.insertValues.mock.calls.map(([rows]) => (rows as unknown[]).length)).toEqual([
+      8, 2,
+    ]);
+    expect(mocks.batch).toHaveBeenCalledTimes(1);
+    expect(mocks.batch.mock.calls[0]?.[0]).toHaveLength(3);
+  });
+});

--- a/services/auto-routing-benchmark/src/db.ts
+++ b/services/auto-routing-benchmark/src/db.ts
@@ -29,6 +29,11 @@ export type RunModelRow = typeof runModels.$inferSelect;
 export type ConfigDeciderModelRow = typeof configDeciderModels.$inferSelect;
 type ModelSummaryRow = typeof modelSummaries.$inferSelect;
 
+// D1 rejects statements with too many bound variables. A model summary insert
+// binds 12 values per row, so 8 rows keeps each INSERT below the 100-variable
+// ceiling while still batching the delete plus inserts together.
+const MODEL_SUMMARY_INSERT_BATCH_SIZE = 8;
+
 // ---------------------------------------------------------------------------
 // Row mapping helpers
 // ---------------------------------------------------------------------------
@@ -265,25 +270,30 @@ export async function replaceModelSummaries(
     await deleteStmt;
     return;
   }
-  await orm.batch([
-    deleteStmt,
-    orm.insert(modelSummaries).values(
-      summaries.map(s => ({
-        run_id: runId,
-        model: s.model,
-        tier: s.tier,
-        accuracy: s.accuracy,
-        avg_cost_usd: s.avgCostUsd,
-        avg_latency_ms: s.avgLatencyMs,
-        p50_latency_ms: s.p50LatencyMs,
-        p95_latency_ms: s.p95LatencyMs,
-        cases: s.cases,
-        errors: s.errors,
-        timeouts: s.timeouts,
-        carried: false,
-      }))
-    ),
-  ]);
+
+  const stmts: [BatchItem<'sqlite'>, ...BatchItem<'sqlite'>[]] = [deleteStmt];
+  for (let i = 0; i < summaries.length; i += MODEL_SUMMARY_INSERT_BATCH_SIZE) {
+    const summaryChunk = summaries.slice(i, i + MODEL_SUMMARY_INSERT_BATCH_SIZE);
+    stmts.push(
+      orm.insert(modelSummaries).values(
+        summaryChunk.map(s => ({
+          run_id: runId,
+          model: s.model,
+          tier: s.tier,
+          accuracy: s.accuracy,
+          avg_cost_usd: s.avgCostUsd,
+          avg_latency_ms: s.avgLatencyMs,
+          p50_latency_ms: s.p50LatencyMs,
+          p95_latency_ms: s.p95LatencyMs,
+          cases: s.cases,
+          errors: s.errors,
+          timeouts: s.timeouts,
+          carried: false,
+        }))
+      )
+    );
+  }
+  await orm.batch(stmts);
 }
 
 export async function getSummaries(


### PR DESCRIPTION
## Summary

- Chunk `model_summaries` inserts so classifier and decider finalization stay under D1 SQL variable limits.
- Add a regression test covering the 10-summary classifier case that failed the production run finalizer.

## Verification

- Verified the production classifier run `classifier-2026-06-15T18-41-15-467Z` had all 2160 case rows and failed finalization with `D1_ERROR: too many SQL variables` before applying the manual recovery.
- Verified the recovered run is now completed in D1 with 10 summaries covering 2160 cases and no case errors/timeouts.

## Visual Changes

N/A

## Reviewer Notes

The D1 limit is per generated SQL statement, so the fix keeps one delete plus multiple smaller insert statements in the same Drizzle batch.