### PR TITLE
fix(auto-routing): raise benchmark container capacity

### DIFF
--- a/services/auto-routing-benchmark/wrangler.jsonc
+++ b/services/auto-routing-benchmark/wrangler.jsonc
@@ -32,7 +32,7 @@
       "class_name": "BenchRunnerContainer",
       "image": "./container/Dockerfile",
       "instance_type": "standard-2",
-      "max_instances": 40,
+      "max_instances": 50,
     },
   ],
   "durable_objects": {


### PR DESCRIPTION
## Summary
- Increase the auto-routing benchmark runner container cap from 40 to 50 concurrent instances.
- Gives the decider benchmark enough room for one model fan-out at 3 repetitions and 16 chunks without immediate container-capacity failures.

## Verification
- Observed the prod decider run recording case failures from Cloudflare container start errors after hitting the 40-instance cap.
- Checked current Cloudflare Wrangler container config docs: `max_instances` is the production concurrent running-container cap and start requests beyond it error.

## Visual Changes
N/A

## Reviewer Notes
This is a tactical capacity bump. A follow-up could reduce decider container fan-out or make container-capacity failures retryable so infra capacity does not get recorded as model failure.