### PR TITLE
feat(config): add code edit display schema

### DIFF
--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -64,6 +64,12 @@ export const kiloExtras = {
       type: 'string',
       enum: ['expanded', 'collapsed'],
     },
+    code_edit_display: {
+      description:
+        'Controls whether code edit and diff blocks are expanded or collapsed by default in the VS Code chat UI',
+      type: 'string',
+      enum: ['expanded', 'collapsed'],
+    },
     hide_prompt_training_models: {
       description: 'Hide Kilo Gateway models that may train on your prompts from model listings',
       type: 'boolean',

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -35,6 +35,7 @@ describe('kilo config.json schema merge', () => {
     expect(props.auto_expand_history).toBeDefined();
     expect(props.auto_collapse_reasoning).toBeDefined();
     expect(props.terminal_command_display).toBeDefined();
+    expect(props.code_edit_display).toBeDefined();
     expect(props.hide_prompt_training_models).toBeDefined();
   });
 
@@ -46,6 +47,12 @@ describe('kilo config.json schema merge', () => {
     const tcd = props.terminal_command_display as { type: string; enum: string[] };
     expect(tcd.type).toBe('string');
     expect(tcd.enum).toEqual(['expanded', 'collapsed']);
+  });
+
+  test('code_edit_display is an enum of expanded/collapsed', () => {
+    const ced = props.code_edit_display as { type: string; enum: string[] };
+    expect(ced.type).toBe('string');
+    expect(ced.enum).toEqual(['expanded', 'collapsed']);
   });
 
   test('commit_message has a prompt string property', () => {


### PR DESCRIPTION
## Summary

- Mirror the Kilo CLI's new `code_edit_display` setting in the cloud-hosted config schema.
- Validate that the setting accepts the same `expanded` and `collapsed` values as the merged CLI schema.

## Verification

- Not manually tested; this is a JSON Schema-only change with no interactive user path.

## Visual Changes

N/A

## Reviewer Notes

The targeted schema test is covered in `cli-config-schema.test.ts`. Its local run was blocked during global setup because Postgres and Docker are unavailable in the cloud agent environment; formatting, lint, and diff checks pass.