### PR TITLE
fix(kiloclaw): prevent checkout settlement quarantine

### DIFF
--- a/apps/web/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
@@ -12,8 +12,8 @@ import { cn } from '@/lib/utils';
 import { useTRPC } from '@/lib/trpc/utils';
 import {
   createKiloClawSignupDisplay,
-  formatKiloClawFirstChargeLabel,
   formatMicrodollars,
+  getKiloClawFundingChoiceCopy,
   isKiloClawStandardIntroCost,
   PLAN_COST_MICRODOLLARS,
   type ClawPlan,
@@ -345,7 +345,7 @@ function CreditEnrollmentSection({
   onEnroll: () => void;
   isPending: boolean;
 }) {
-  const priceLabel = formatKiloClawFirstChargeLabel({ plan: selectedPlan, costMicrodollars });
+  const fundingCopy = getKiloClawFundingChoiceCopy({ plan: selectedPlan, costMicrodollars });
   const isIntro = selectedPlan === 'standard' && isKiloClawStandardIntroCost({ costMicrodollars });
   const hasProjectedBonus = projectedKiloPassBonusMicrodollars > 0;
   const hasSufficientBalance = effectiveBalanceMicrodollars >= costMicrodollars;
@@ -357,11 +357,11 @@ function CreditEnrollmentSection({
       <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
         <div className="mb-3 flex items-center gap-2">
           <Wallet className="h-4 w-4 text-emerald-400" />
-          <span className="text-sm font-semibold text-emerald-300">Pay with credits</span>
+          <span className="text-sm font-semibold text-emerald-300">
+            {fundingCopy.creditHeading}
+          </span>
         </div>
-        <p className="text-muted-foreground mb-1 text-sm">
-          {planLabel} Plan — {priceLabel} from your credit balance
-        </p>
+        <p className="text-muted-foreground mb-1 text-sm">{fundingCopy.creditDescription}</p>
         {hasProjectedBonus ? (
           <div className="mb-3 space-y-1 text-xs text-emerald-400/80">
             <p>Current balance: {formatMicrodollars(rawCreditBalanceMicrodollars)}</p>
@@ -382,7 +382,7 @@ function CreditEnrollmentSection({
           variant="default"
           className="w-full py-3 font-semibold"
         >
-          {isPending ? 'Activating…' : `Pay ${formatMicrodollars(costMicrodollars)} with Credits`}
+          {isPending ? 'Activating…' : fundingCopy.creditButtonLabel}
         </Button>
       </div>
     );
@@ -672,10 +672,14 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
   const hostingOnlyCostMicrodollars = hostingOnlyPlan
     ? (selectedCreditEnrollmentPreview?.costMicrodollars ?? PLAN_COST_MICRODOLLARS[hostingOnlyPlan])
     : null;
-  const hostingOnlyLabel =
+  const hostingFundingCopy =
     hostingOnlyPlan && hostingOnlyCostMicrodollars !== null
-      ? `Subscribe to ${hostingOnlyPlan === 'commit' ? 'Commit' : 'Standard'} plan, ${formatKiloClawFirstChargeLabel({ plan: hostingOnlyPlan, costMicrodollars: hostingOnlyCostMicrodollars })}`
-      : 'Select a plan above';
+      ? getKiloClawFundingChoiceCopy({
+          plan: hostingOnlyPlan,
+          costMicrodollars: hostingOnlyCostMicrodollars,
+        })
+      : null;
+  const hostingOnlyLabel = hostingFundingCopy?.stripeButtonLabel ?? 'Select a plan above';
   const hostingSectionTitle = hasActiveKiloPass ? 'Choose a hosting plan' : 'Hosting only';
   const hostingSectionDescription = hasActiveKiloPass
     ? 'You already have Kilo Pass. Choose a hosting plan and fund it from your credit balance or pay directly via Stripe.'
@@ -835,7 +839,9 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
                 />
                 <div className="my-3 flex items-center gap-3">
                   <div className="bg-border h-px flex-1" />
-                  <span className="text-muted-foreground text-xs">or pay with Stripe</span>
+                  <span className="text-muted-foreground text-xs">
+                    {hostingFundingCopy?.stripeDividerLabel}
+                  </span>
                   <div className="bg-border h-px flex-1" />
                 </div>
               </>
@@ -850,7 +856,7 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
               {checkout.isPending ? 'Redirecting to Stripe…' : hostingOnlyLabel}
             </Button>
             <p className="text-muted-foreground mt-2 text-center text-xs">
-              You&apos;ll be redirected to Stripe to pay
+              {hostingFundingCopy?.stripeDescription ?? "You'll be redirected to Stripe to pay."}
             </p>
           </div>
         </div>

--- a/apps/web/src/app/(app)/claw/components/billing/WelcomePage.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/WelcomePage.tsx
@@ -11,8 +11,8 @@ import { cn } from '@/lib/utils';
 import { useTRPC } from '@/lib/trpc/utils';
 import {
   createKiloClawSignupDisplay,
-  formatKiloClawFirstChargeLabel,
   formatMicrodollars,
+  getKiloClawFundingChoiceCopy,
   isKiloClawStandardIntroCost,
   PLAN_COST_MICRODOLLARS,
   type ClawPlan,
@@ -338,7 +338,7 @@ function CreditEnrollmentBanner({
   onEnroll: () => void;
   isPending: boolean;
 }) {
-  const priceLabel = formatKiloClawFirstChargeLabel({ plan: selectedPlan, costMicrodollars });
+  const fundingCopy = getKiloClawFundingChoiceCopy({ plan: selectedPlan, costMicrodollars });
   const isIntro = selectedPlan === 'standard' && isKiloClawStandardIntroCost({ costMicrodollars });
   const hasProjectedBonus = projectedKiloPassBonusMicrodollars > 0;
   const hasSufficientBalance = effectiveBalanceMicrodollars >= costMicrodollars;
@@ -350,11 +350,11 @@ function CreditEnrollmentBanner({
       <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-5">
         <div className="mb-3 flex items-center gap-2">
           <Wallet className="h-4 w-4 text-emerald-400" />
-          <span className="text-sm font-semibold text-emerald-300">Pay with credits</span>
+          <span className="text-sm font-semibold text-emerald-300">
+            {fundingCopy.creditHeading}
+          </span>
         </div>
-        <p className="text-muted-foreground mb-1 text-sm">
-          {planLabel} Plan — {priceLabel} from your credit balance
-        </p>
+        <p className="text-muted-foreground mb-1 text-sm">{fundingCopy.creditDescription}</p>
         {hasProjectedBonus ? (
           <div className="mb-3 space-y-1 text-xs text-emerald-400/80">
             <p>Current balance: {formatMicrodollars(rawCreditBalanceMicrodollars)}</p>
@@ -375,7 +375,7 @@ function CreditEnrollmentBanner({
           variant="default"
           className="w-full py-3 font-semibold"
         >
-          {isPending ? 'Activating…' : `Pay ${formatMicrodollars(costMicrodollars)} with Credits`}
+          {isPending ? 'Activating…' : fundingCopy.creditButtonLabel}
         </Button>
       </div>
     );
@@ -514,6 +514,9 @@ export function WelcomePage() {
       onSuccess: () => {
         void queryClient.invalidateQueries({
           queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
         });
         void queryClient.invalidateQueries({
           queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
@@ -663,10 +666,14 @@ export function WelcomePage() {
   const hostingOnlyCostMicrodollars = hostingOnlyPlan
     ? (selectedCreditEnrollmentPreview?.costMicrodollars ?? PLAN_COST_MICRODOLLARS[hostingOnlyPlan])
     : null;
-  const hostingOnlyLabel =
+  const hostingFundingCopy =
     hostingOnlyPlan && hostingOnlyCostMicrodollars !== null
-      ? `Subscribe to ${hostingOnlyPlan === 'commit' ? 'Commit' : 'Standard'} plan, ${formatKiloClawFirstChargeLabel({ plan: hostingOnlyPlan, costMicrodollars: hostingOnlyCostMicrodollars })}`
-      : 'Select a plan above';
+      ? getKiloClawFundingChoiceCopy({
+          plan: hostingOnlyPlan,
+          costMicrodollars: hostingOnlyCostMicrodollars,
+        })
+      : null;
+  const hostingOnlyLabel = hostingFundingCopy?.stripeButtonLabel ?? 'Select a plan above';
   const hostingSectionTitle = hasActiveKiloPass ? 'Choose a hosting plan' : 'Hosting only';
   const hostingSectionDescription = hasActiveKiloPass
     ? 'You already have Kilo Pass. Choose a hosting plan and fund it from your credit balance or pay directly via Stripe.'
@@ -823,7 +830,9 @@ export function WelcomePage() {
               />
               <div className="my-3 flex items-center gap-3">
                 <div className="bg-border h-px flex-1" />
-                <span className="text-muted-foreground text-xs">or pay with Stripe</span>
+                <span className="text-muted-foreground text-xs">
+                  {hostingFundingCopy?.stripeDividerLabel}
+                </span>
                 <div className="bg-border h-px flex-1" />
               </div>
             </>
@@ -838,7 +847,7 @@ export function WelcomePage() {
             {checkoutMutation.isPending ? 'Redirecting to Stripe…' : hostingOnlyLabel}
           </Button>
           <p className="text-muted-foreground mt-2 text-center text-xs">
-            You&apos;ll be redirected to Stripe to pay
+            {hostingFundingCopy?.stripeDescription ?? "You'll be redirected to Stripe to pay."}
           </p>
         </div>
       </div>

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
@@ -169,23 +169,25 @@ describe('KiloClaw billing display helpers', () => {
 });
 
 describe('KiloClaw funding and recovery copy', () => {
-  it('prioritizes credit-funded recovery after bundled hosting activation fails', () => {
-    expect(getKiloPassHostingRecoveryCopy('standard')).toEqual({
-      title: 'Credit-funded hosting needs attention',
-      description:
-        'Your Kilo Pass credits are ready, but hosting activation did not finish. Retry credit-funded activation or choose a hosting plan.',
-      destination: '/claw/subscription',
-      destinationLabel: 'Choose hosting plan',
-      canRetry: true,
-    });
-    expect(getKiloPassHostingRecoveryCopy('expired_commit')).toEqual(
-      expect.objectContaining({
-        destination: '/claw/subscription',
-        destinationLabel: 'Choose Standard hosting',
-        canRetry: false,
-      })
-    );
-  });
+  it.each([
+    ['credits_not_settled', true, null, null],
+    ['enrollment_failed', true, '/claw/subscription', 'Choose hosting plan'],
+    ['requires_reprovision', false, null, null],
+    ['missing_instance', false, null, null],
+    ['destroyed_instance', false, null, null],
+    ['stale_intent', false, '/claw/subscription', 'Choose hosting plan'],
+    ['invalid_intent', false, '/claw/subscription', 'Choose hosting plan'],
+    ['insufficient_credits', false, '/claw/subscription', 'Review hosting options'],
+    ['expired_commit', false, '/claw/subscription', 'Choose Standard hosting'],
+    ['unexpected_error', false, null, null],
+  ] as const)(
+    'maps %s to the correct recovery policy',
+    (reason, canRetry, destination, destinationLabel) => {
+      expect(getKiloPassHostingRecoveryCopy(reason)).toEqual(
+        expect.objectContaining({ canRetry, destination, destinationLabel })
+      );
+    }
+  );
 
   it('distinguishes credit-funded hosting from a separate recurring Stripe subscription', () => {
     expect(

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
@@ -5,7 +5,9 @@ import {
   deriveBannerState,
   deriveLockReason,
   formatKiloClawPlanPrice,
+  getKiloClawFundingChoiceCopy,
   getKiloClawRetirementDisplay,
+  getKiloPassHostingRecoveryCopy,
   type ClawBillingStatus,
   type KiloPassUpsellActivationPreview,
 } from './billing-types';
@@ -163,6 +165,40 @@ describe('KiloClaw billing display helpers', () => {
     expect(formatKiloClawPlanPrice({ plan: 'commit', priceVersion: '2026-05-10' })).toBe(
       '$306/6-month commit'
     );
+  });
+});
+
+describe('KiloClaw funding and recovery copy', () => {
+  it('prioritizes credit-funded recovery after bundled hosting activation fails', () => {
+    expect(getKiloPassHostingRecoveryCopy('standard')).toEqual({
+      title: 'Credit-funded hosting needs attention',
+      description:
+        'Your Kilo Pass credits are ready, but hosting activation did not finish. Retry credit-funded activation or choose a hosting plan.',
+      destination: '/claw/subscription',
+      destinationLabel: 'Choose hosting plan',
+      canRetry: true,
+    });
+    expect(getKiloPassHostingRecoveryCopy('expired_commit')).toEqual(
+      expect.objectContaining({
+        destination: '/claw/subscription',
+        destinationLabel: 'Choose Standard hosting',
+        canRetry: false,
+      })
+    );
+  });
+
+  it('distinguishes credit-funded hosting from a separate recurring Stripe subscription', () => {
+    expect(
+      getKiloClawFundingChoiceCopy({ plan: 'standard', costMicrodollars: 55_000_000 })
+    ).toEqual({
+      creditHeading: 'Credit-funded hosting',
+      creditDescription:
+        'Standard first charge: $55/month. Future hosting charges use your credit balance.',
+      creditButtonLabel: 'Activate Standard with credits',
+      stripeDividerLabel: 'or start a separate Stripe subscription',
+      stripeButtonLabel: 'Subscribe with Stripe, $55/month',
+      stripeDescription: 'Creates a separate recurring Stripe charge for hosting.',
+    });
   });
 });
 

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
@@ -262,6 +262,63 @@ export function formatKiloClawFirstChargeLabel(params: {
   return `${price}/month`;
 }
 
+export function getKiloClawFundingChoiceCopy(params: {
+  plan: ClawPlan;
+  costMicrodollars: number;
+}): {
+  creditHeading: string;
+  creditDescription: string;
+  creditButtonLabel: string;
+  stripeDividerLabel: string;
+  stripeButtonLabel: string;
+  stripeDescription: string;
+} {
+  const planLabel = params.plan === 'commit' ? 'Commit' : 'Standard';
+  const priceLabel = formatKiloClawFirstChargeLabel(params);
+
+  return {
+    creditHeading: 'Credit-funded hosting',
+    creditDescription: `${planLabel} first charge: ${priceLabel}. Future hosting charges use your credit balance.`,
+    creditButtonLabel: `Activate ${planLabel} with credits`,
+    stripeDividerLabel: 'or start a separate Stripe subscription',
+    stripeButtonLabel: `Subscribe with Stripe, ${priceLabel}`,
+    stripeDescription:
+      params.plan === 'standard'
+        ? 'Creates a separate recurring Stripe charge for hosting.'
+        : 'Creates separate Stripe billing for hosting.',
+  };
+}
+
+export function getKiloPassHostingRecoveryCopy(
+  hostingIntent: 'none' | 'expired_commit' | 'standard' | 'commit'
+): {
+  title: string;
+  description: string;
+  destination: string;
+  destinationLabel: string;
+  canRetry: boolean;
+} {
+  if (hostingIntent === 'expired_commit') {
+    return {
+      title: 'Kilo Pass credits are ready',
+      description:
+        'Commit hosting is no longer available. Choose Standard and fund hosting from your credit balance.',
+      destination: '/claw/subscription',
+      destinationLabel: 'Choose Standard hosting',
+      canRetry: false,
+    };
+  }
+
+  return {
+    title: 'Credit-funded hosting needs attention',
+    description:
+      'Your Kilo Pass credits are ready, but hosting activation did not finish. Retry credit-funded activation or choose a hosting plan.',
+    destination: '/claw/subscription',
+    destinationLabel: 'Choose hosting plan',
+    canRetry: true,
+  };
+}
+
 /** e.g. "Commit ($51/mo)" or "Standard ($55/mo)" */
 export function planLabel(plan: ClawPlan, priceVersion?: string): string {
   if (plan === 'commit') {

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
@@ -289,34 +289,128 @@ export function getKiloClawFundingChoiceCopy(params: {
   };
 }
 
-export function getKiloPassHostingRecoveryCopy(
-  hostingIntent: 'none' | 'expired_commit' | 'standard' | 'commit'
-): {
+export type KiloPassHostingRecoveryReason =
+  | 'credits_not_settled'
+  | 'enrollment_failed'
+  | 'requires_reprovision'
+  | 'missing_instance'
+  | 'destroyed_instance'
+  | 'stale_intent'
+  | 'invalid_intent'
+  | 'insufficient_credits'
+  | 'expired_commit'
+  | 'unexpected_error';
+
+export function getKiloPassHostingRecoveryCopy(reason: KiloPassHostingRecoveryReason): {
   title: string;
   description: string;
-  destination: string;
-  destinationLabel: string;
+  destination: string | null;
+  destinationLabel: string | null;
   canRetry: boolean;
+  showSupport: boolean;
 } {
-  if (hostingIntent === 'expired_commit') {
-    return {
-      title: 'Kilo Pass credits are ready',
-      description:
-        'Commit hosting is no longer available. Choose Standard and fund hosting from your credit balance.',
-      destination: '/claw/subscription',
-      destinationLabel: 'Choose Standard hosting',
-      canRetry: false,
-    };
+  switch (reason) {
+    case 'credits_not_settled':
+      return {
+        title: 'Hosting credits are still processing',
+        description:
+          'Your Kilo Pass payment is complete, but hosting credits are not ready yet. Retry credit-funded activation shortly.',
+        destination: null,
+        destinationLabel: null,
+        canRetry: true,
+        showSupport: false,
+      };
+    case 'enrollment_failed':
+      return {
+        title: 'Credit-funded hosting needs attention',
+        description:
+          'Your credits are ready, but hosting activation did not finish. Retry credit-funded activation or choose a hosting plan.',
+        destination: '/claw/subscription',
+        destinationLabel: 'Choose hosting plan',
+        canRetry: true,
+        showSupport: true,
+      };
+    case 'requires_reprovision':
+      return {
+        title: 'Reprovision before activating hosting',
+        description:
+          'Your Kilo Pass credits are ready. Your previous KiloClaw billing history must remain unchanged, so support must help provision a fresh KiloClaw before hosting can use those credits.',
+        destination: null,
+        destinationLabel: null,
+        canRetry: false,
+        showSupport: true,
+      };
+    case 'missing_instance':
+      return {
+        title: 'Provision KiloClaw before activating hosting',
+        description:
+          'Your Kilo Pass credits are ready, but no KiloClaw instance is available for hosting. Contact support to provision one without risking billing history.',
+        destination: null,
+        destinationLabel: null,
+        canRetry: false,
+        showSupport: true,
+      };
+    case 'destroyed_instance':
+      return {
+        title: 'Reprovision before activating hosting',
+        description:
+          'Your Kilo Pass credits are ready, but the selected KiloClaw was destroyed. Contact support to provision a fresh KiloClaw before hosting uses those credits.',
+        destination: null,
+        destinationLabel: null,
+        canRetry: false,
+        showSupport: true,
+      };
+    case 'stale_intent':
+      return {
+        title: 'Choose hosting again',
+        description:
+          'Your Kilo Pass credits are ready, but the saved hosting selection no longer matches current billing state. Start a fresh credit-funded selection.',
+        destination: '/claw/subscription',
+        destinationLabel: 'Choose hosting plan',
+        canRetry: false,
+        showSupport: true,
+      };
+    case 'invalid_intent':
+      return {
+        title: 'Choose hosting manually',
+        description:
+          'Your Kilo Pass credits are ready, but the saved hosting selection cannot be used. Choose a hosting plan from KiloClaw.',
+        destination: '/claw/subscription',
+        destinationLabel: 'Choose hosting plan',
+        canRetry: false,
+        showSupport: true,
+      };
+    case 'insufficient_credits':
+      return {
+        title: 'Review hosting options',
+        description:
+          'Your current credit balance no longer covers the selected hosting plan. Review available credit-funded hosting options.',
+        destination: '/claw/subscription',
+        destinationLabel: 'Review hosting options',
+        canRetry: false,
+        showSupport: true,
+      };
+    case 'expired_commit':
+      return {
+        title: 'Kilo Pass credits are ready',
+        description:
+          'Commit hosting is no longer available. Choose Standard and fund hosting from your credit balance.',
+        destination: '/claw/subscription',
+        destinationLabel: 'Choose Standard hosting',
+        canRetry: false,
+        showSupport: false,
+      };
+    case 'unexpected_error':
+      return {
+        title: 'Hosting activation needs support',
+        description:
+          'Your Kilo Pass credits are ready, but hosting activation could not be confirmed. Your credits remain available.',
+        destination: null,
+        destinationLabel: null,
+        canRetry: false,
+        showSupport: true,
+      };
   }
-
-  return {
-    title: 'Credit-funded hosting needs attention',
-    description:
-      'Your Kilo Pass credits are ready, but hosting activation did not finish. Retry credit-funded activation or choose a hosting plan.',
-    destination: '/claw/subscription',
-    destinationLabel: 'Choose hosting plan',
-    canRetry: true,
-  };
 }
 
 /** e.g. "Commit ($51/mo)" or "Standard ($55/mo)" */

--- a/apps/web/src/app/payments/kilo-pass/awarding/KiloPassAwardingCreditsClient.tsx
+++ b/apps/web/src/app/payments/kilo-pass/awarding/KiloPassAwardingCreditsClient.tsx
@@ -11,7 +11,10 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useTRPC } from '@/lib/trpc/utils';
-import { getKiloPassHostingRecoveryCopy } from '@/app/(app)/claw/components/billing/billing-types';
+import {
+  getKiloPassHostingRecoveryCopy,
+  type KiloPassHostingRecoveryReason,
+} from '@/app/(app)/claw/components/billing/billing-types';
 
 const POLL_INTERVAL_MS = 1000;
 const TIMEOUT_MS = 90_000;
@@ -62,23 +65,24 @@ export function KiloPassAwardingCreditsClient() {
   const checkoutSessionId = searchParams.get('session_id') ?? '';
 
   const [activationStep, setActivationStep] = useState<ActivationStep>('payment');
-  const [enrollmentError, setEnrollmentError] = useState<string | null>(null);
+  const [activationFailureReason, setActivationFailureReason] =
+    useState<KiloPassHostingRecoveryReason | null>(null);
 
   const activateCheckoutHosting = useMutation(
     trpc.kiloPass.activateCheckoutHosting.mutationOptions({
       onSuccess: result => {
-        if (result.activated) {
+        if (result.outcome === 'activated') {
           setActivationStep('done');
           return;
         }
-        setEnrollmentError(
-          result.hostingIntent === 'expired_commit'
-            ? 'Commit hosting is no longer available. Activate month-to-month Standard from KiloClaw.'
-            : 'Checkout did not include a hosting activation intent.'
-        );
+        if (result.outcome === 'not_requested') {
+          setActivationFailureReason('invalid_intent');
+          return;
+        }
+        setActivationFailureReason(result.reason);
       },
-      onError: error => {
-        setEnrollmentError(error.message);
+      onError: () => {
+        setActivationFailureReason('unexpected_error');
       },
     })
   );
@@ -180,10 +184,12 @@ export function KiloPassAwardingCreditsClient() {
 
   const fallbackDestination = isClawAutoActivation ? '/claw' : '/profile';
   const fallbackLabel = isClawAutoActivation ? 'Go to KiloClaw' : 'Go to profile';
-  const hostingRecovery = getKiloPassHostingRecoveryCopy(checkoutState?.hostingIntent ?? 'none');
+  const hostingRecovery = activationFailureReason
+    ? getKiloPassHostingRecoveryCopy(activationFailureReason)
+    : null;
 
   function retryCreditFundedHostingActivation() {
-    setEnrollmentError(null);
+    setActivationFailureReason(null);
     activateCheckoutHosting.mutate({ sessionId: checkoutSessionId });
   }
 
@@ -271,7 +277,7 @@ export function KiloPassAwardingCreditsClient() {
   // KiloClaw auto-activation: show progress steps
   if (isClawAutoActivation) {
     // Enrollment error: show fallback with manual activation option
-    if (enrollmentError) {
+    if (hostingRecovery) {
       return (
         <PageContainer>
           <div className="flex min-h-[70vh] items-center justify-center">
@@ -284,7 +290,6 @@ export function KiloPassAwardingCreditsClient() {
               </CardHeader>
               <CardContent className="grid gap-4">
                 <div className="text-muted-foreground text-sm">{hostingRecovery.description}</div>
-                <div className="text-muted-foreground text-sm">Details: {enrollmentError}</div>
                 {showWelcomePromoIneligibleNotice ? <WelcomePromoIneligibleNotice /> : null}
                 <div className="flex flex-wrap gap-2">
                   {hostingRecovery.canRetry ? (
@@ -298,14 +303,29 @@ export function KiloPassAwardingCreditsClient() {
                         : 'Retry credit-funded activation'}
                     </Button>
                   ) : null}
-                  <Button
-                    type="button"
-                    variant={hostingRecovery.canRetry ? 'outline' : 'default'}
-                    onClick={() => router.replace(hostingRecovery.destination)}
-                  >
-                    {hostingRecovery.destinationLabel}
-                  </Button>
+                  {hostingRecovery.destination && hostingRecovery.destinationLabel ? (
+                    <Button
+                      type="button"
+                      variant={hostingRecovery.canRetry ? 'outline' : 'default'}
+                      onClick={() => {
+                        if (hostingRecovery.destination) {
+                          router.replace(hostingRecovery.destination);
+                        }
+                      }}
+                    >
+                      {hostingRecovery.destinationLabel}
+                    </Button>
+                  ) : null}
                 </div>
+                {hostingRecovery.showSupport ? (
+                  <div className="text-muted-foreground text-sm">
+                    If this keeps happening, contact support at{' '}
+                    <a href="https://kilo.ai/support" className="text-primary underline">
+                      https://kilo.ai/support
+                    </a>
+                    .
+                  </div>
+                ) : null}
               </CardContent>
             </Card>
           </div>

--- a/apps/web/src/app/payments/kilo-pass/awarding/KiloPassAwardingCreditsClient.tsx
+++ b/apps/web/src/app/payments/kilo-pass/awarding/KiloPassAwardingCreditsClient.tsx
@@ -11,6 +11,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useTRPC } from '@/lib/trpc/utils';
+import { getKiloPassHostingRecoveryCopy } from '@/app/(app)/claw/components/billing/billing-types';
 
 const POLL_INTERVAL_MS = 1000;
 const TIMEOUT_MS = 90_000;
@@ -95,7 +96,7 @@ export function KiloPassAwardingCreditsClient() {
     };
   }, []);
 
-  const query = useQuery({
+  const { data: checkoutState, isError: checkoutStateIsError } = useQuery({
     ...trpc.kiloPass.getCheckoutReturnState.queryOptions({ sessionId: checkoutSessionId }),
     enabled: checkoutSessionId.length > 0,
     refetchInterval: query => {
@@ -108,12 +109,12 @@ export function KiloPassAwardingCreditsClient() {
     retry: false,
   });
 
-  const isReady = query.data?.creditsAwarded === true;
+  const isReady = checkoutState?.creditsAwarded === true;
   const isClawAutoActivation =
-    query.data?.hostingIntent !== 'none' && query.data?.hostingIntent != null;
-  const hasSubscription = query.data?.subscription != null;
+    checkoutState?.hostingIntent !== 'none' && checkoutState?.hostingIntent != null;
+  const hasSubscription = checkoutState?.subscription != null;
   const showWelcomePromoIneligibleNotice =
-    query.data?.welcomePromoIneligibleDueToReusedFingerprint === true;
+    checkoutState?.welcomePromoIneligibleDueToReusedFingerprint === true;
   const visibleActivationStep =
     activationStep === 'done'
       ? activationStep
@@ -179,8 +180,14 @@ export function KiloPassAwardingCreditsClient() {
 
   const fallbackDestination = isClawAutoActivation ? '/claw' : '/profile';
   const fallbackLabel = isClawAutoActivation ? 'Go to KiloClaw' : 'Go to profile';
+  const hostingRecovery = getKiloPassHostingRecoveryCopy(checkoutState?.hostingIntent ?? 'none');
 
-  if (query.isError) {
+  function retryCreditFundedHostingActivation() {
+    setEnrollmentError(null);
+    activateCheckoutHosting.mutate({ sessionId: checkoutSessionId });
+  }
+
+  if (checkoutStateIsError) {
     return (
       <PageContainer>
         <div className="flex min-h-[70vh] items-center justify-center">
@@ -272,21 +279,31 @@ export function KiloPassAwardingCreditsClient() {
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <AlertTriangle className="h-5 w-5" />
-                  Hosting activation failed
+                  {hostingRecovery.title}
                 </CardTitle>
               </CardHeader>
               <CardContent className="grid gap-4">
-                <div className="text-muted-foreground text-sm">
-                  Your credits were added successfully, but we couldn't activate hosting
-                  automatically: {enrollmentError}
-                </div>
-                <div className="text-muted-foreground text-sm">
-                  You can activate hosting manually from the KiloClaw dashboard.
-                </div>
+                <div className="text-muted-foreground text-sm">{hostingRecovery.description}</div>
+                <div className="text-muted-foreground text-sm">Details: {enrollmentError}</div>
                 {showWelcomePromoIneligibleNotice ? <WelcomePromoIneligibleNotice /> : null}
                 <div className="flex flex-wrap gap-2">
-                  <Button type="button" onClick={() => router.replace('/claw')}>
-                    Go to KiloClaw
+                  {hostingRecovery.canRetry ? (
+                    <Button
+                      type="button"
+                      disabled={activateCheckoutHosting.isPending}
+                      onClick={retryCreditFundedHostingActivation}
+                    >
+                      {activateCheckoutHosting.isPending
+                        ? 'Retrying credit activation…'
+                        : 'Retry credit-funded activation'}
+                    </Button>
+                  ) : null}
+                  <Button
+                    type="button"
+                    variant={hostingRecovery.canRetry ? 'outline' : 'default'}
+                    onClick={() => router.replace(hostingRecovery.destination)}
+                  >
+                    {hostingRecovery.destinationLabel}
                   </Button>
                 </div>
               </CardContent>

--- a/apps/web/src/lib/kiloclaw/credit-billing.ts
+++ b/apps/web/src/lib/kiloclaw/credit-billing.ts
@@ -7,6 +7,7 @@ import { db } from '@/lib/drizzle';
 import {
   getKiloClawPlanCostMicrodollars,
   getKiloClawPricingCatalogEntry,
+  isKiloClawPriceVersion,
   resolveKiloClawEnrollmentPriceVersion,
   insertKiloClawSubscriptionChangeLog,
   type KiloClawPriceVersion,
@@ -96,6 +97,30 @@ class CreditSettlementResolutionError extends Error {
     this.name = 'CreditSettlementResolutionError';
     this.reason = reason;
     this.details = details;
+  }
+}
+
+export type CreditEnrollmentErrorReason =
+  | 'commit_unavailable'
+  | 'user_not_found'
+  | 'instance_not_found'
+  | 'instance_destroyed'
+  | 'active_subscription_exists'
+  | 'unknown_price_version'
+  | 'price_version_mismatch'
+  | 'insufficient_credits'
+  | 'target_unavailable'
+  | 'target_changed'
+  | 'requires_reprovision'
+  | 'duplicate_enrollment';
+
+export class CreditEnrollmentError extends Error {
+  readonly reason: CreditEnrollmentErrorReason;
+
+  constructor(reason: CreditEnrollmentErrorReason, message: string) {
+    super(message);
+    this.name = 'CreditEnrollmentError';
+    this.reason = reason;
   }
 }
 
@@ -1206,7 +1231,12 @@ export async function enrollWithCredits(params: {
   commitQualification?: KiloClawCommitEnrollmentQualification;
 }): Promise<void> {
   const { userId, instanceId, plan, hadPaidSubscription } = params;
-  assertKiloClawCommitAdmission({ plan, qualification: params.commitQualification });
+  try {
+    assertKiloClawCommitAdmission({ plan, qualification: params.commitQualification });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Commit enrollment is unavailable.';
+    throw new CreditEnrollmentError('commit_unavailable', message);
+  }
 
   // Step 1: Read current state
   const [user] = await db
@@ -1221,7 +1251,7 @@ export async function enrollWithCredits(params: {
 
   if (!user) {
     logError('Credit enrollment failed: user not found', { user_id: userId, instanceId });
-    throw new Error('User not found');
+    throw new CreditEnrollmentError('user_not_found', 'User not found');
   }
 
   const [targetInstance] = await db
@@ -1239,10 +1269,13 @@ export async function enrollWithCredits(params: {
     )
     .limit(1);
   if (!targetInstance) {
-    throw new Error('KiloClaw personal instance not found');
+    throw new CreditEnrollmentError('instance_not_found', 'KiloClaw personal instance not found');
   }
   if (targetInstance.destroyedAt) {
-    throw new Error('Cannot enroll a destroyed KiloClaw instance. Reprovision first.');
+    throw new CreditEnrollmentError(
+      'instance_destroyed',
+      'Cannot enroll a destroyed KiloClaw instance. Reprovision first.'
+    );
   }
 
   const [existingSub] = await db
@@ -1267,10 +1300,22 @@ export async function enrollWithCredits(params: {
 
   // Reject if subscription is active, past_due, or unpaid (spec rule 1)
   if (existingSub && existingSub.status !== 'trialing' && existingSub.status !== 'canceled') {
-    throw new Error('Cannot enroll: an active subscription already exists. Cancel it first.');
+    throw new CreditEnrollmentError(
+      'active_subscription_exists',
+      'Cannot enroll: an active subscription already exists. Cancel it first.'
+    );
   }
 
   const isLiveTrialLineage = existingSub?.status === 'trialing';
+  if (
+    existingSub?.status === 'trialing' &&
+    !isKiloClawPriceVersion(existingSub.kiloclaw_price_version)
+  ) {
+    throw new CreditEnrollmentError(
+      'unknown_price_version',
+      `Unknown KiloClaw price version: ${existingSub.kiloclaw_price_version}`
+    );
+  }
   const kiloclawPriceVersion = resolveKiloClawEnrollmentPriceVersion(
     existingSub
       ? {
@@ -1280,7 +1325,8 @@ export async function enrollWithCredits(params: {
       : null
   );
   if (params.expectedPriceVersion && params.expectedPriceVersion !== kiloclawPriceVersion) {
-    throw new Error(
+    throw new CreditEnrollmentError(
+      'price_version_mismatch',
       `Credit enrollment intent price version no longer matches target: intended=${params.expectedPriceVersion} expected=${kiloclawPriceVersion}`
     );
   }
@@ -1325,7 +1371,8 @@ export async function enrollWithCredits(params: {
 
   if (effectiveBalance < costMicrodollars) {
     const shortfall = costMicrodollars - effectiveBalance;
-    throw new Error(
+    throw new CreditEnrollmentError(
+      'insufficient_credits',
       `Insufficient credit balance. You need ${shortfall} more microdollars to enroll.`
     );
   }
@@ -1360,7 +1407,10 @@ export async function enrollWithCredits(params: {
       )
       .limit(1);
     if (!transactionTargetInstance || transactionTargetInstance.destroyedAt) {
-      throw new Error('Credit enrollment target is no longer an active personal instance.');
+      throw new CreditEnrollmentError(
+        'target_unavailable',
+        'Credit enrollment target is no longer an active personal instance.'
+      );
     }
 
     const [currentSubscription] = await tx
@@ -1379,7 +1429,10 @@ export async function enrollWithCredits(params: {
       currentSubscription?.status !== existingSub?.status ||
       currentSubscription?.kiloclaw_price_version !== existingSub?.kiloclaw_price_version
     ) {
-      throw new Error('Credit enrollment target changed before the deduction could be applied.');
+      throw new CreditEnrollmentError(
+        'target_changed',
+        'Credit enrollment target changed before the deduction could be applied.'
+      );
     }
 
     // 5a: Insert negative credit transaction with period-encoded idempotency key
@@ -1414,7 +1467,8 @@ export async function enrollWithCredits(params: {
       existingSub?.status === 'canceled' &&
       existingSub.kiloclaw_price_version !== kiloclawPriceVersion
     ) {
-      throw new Error(
+      throw new CreditEnrollmentError(
+        'requires_reprovision',
         'Canceled legacy KiloClaw history requires reprovisioning before credit enrollment.'
       );
     }
@@ -1512,7 +1566,10 @@ export async function enrollWithCredits(params: {
       });
     }
 
-    throw new Error('Enrollment already processed for this billing period.');
+    throw new CreditEnrollmentError(
+      'duplicate_enrollment',
+      'Enrollment already processed for this billing period.'
+    );
   }
 
   try {

--- a/apps/web/src/lib/kiloclaw/credit-billing.ts
+++ b/apps/web/src/lib/kiloclaw/credit-billing.ts
@@ -1410,6 +1410,15 @@ export async function enrollWithCredits(params: {
       return;
     }
 
+    if (
+      existingSub?.status === 'canceled' &&
+      existingSub.kiloclaw_price_version !== kiloclawPriceVersion
+    ) {
+      throw new Error(
+        'Canceled legacy KiloClaw history requires reprovisioning before credit enrollment.'
+      );
+    }
+
     // 5b: Atomically increment microdollars_used so the deduction counts
     //     as spend toward the Kilo Pass bonus unlock threshold.
     await tx

--- a/apps/web/src/lib/kiloclaw/credit-billing.ts
+++ b/apps/web/src/lib/kiloclaw/credit-billing.ts
@@ -5,9 +5,9 @@ import { addMonths, format } from 'date-fns';
 
 import { db } from '@/lib/drizzle';
 import {
-  CURRENT_KILOCLAW_PRICE_VERSION,
   getKiloClawPlanCostMicrodollars,
   getKiloClawPricingCatalogEntry,
+  resolveKiloClawEnrollmentPriceVersion,
   insertKiloClawSubscriptionChangeLog,
   type KiloClawPriceVersion,
   type KiloClawSubscriptionChangeAction,
@@ -1201,6 +1201,7 @@ export async function enrollWithCredits(params: {
   instanceId: string;
   plan: 'commit' | 'standard';
   hadPaidSubscription: boolean;
+  expectedPriceVersion?: KiloClawPriceVersion;
   actor?: KiloClawSubscriptionChangeActor;
   commitQualification?: KiloClawCommitEnrollmentQualification;
 }): Promise<void> {
@@ -1221,6 +1222,27 @@ export async function enrollWithCredits(params: {
   if (!user) {
     logError('Credit enrollment failed: user not found', { user_id: userId, instanceId });
     throw new Error('User not found');
+  }
+
+  const [targetInstance] = await db
+    .select({
+      id: kiloclaw_instances.id,
+      destroyedAt: kiloclaw_instances.destroyed_at,
+    })
+    .from(kiloclaw_instances)
+    .where(
+      and(
+        eq(kiloclaw_instances.id, instanceId),
+        eq(kiloclaw_instances.user_id, userId),
+        isNull(kiloclaw_instances.organization_id)
+      )
+    )
+    .limit(1);
+  if (!targetInstance) {
+    throw new Error('KiloClaw personal instance not found');
+  }
+  if (targetInstance.destroyedAt) {
+    throw new Error('Cannot enroll a destroyed KiloClaw instance. Reprovision first.');
   }
 
   const [existingSub] = await db
@@ -1249,9 +1271,19 @@ export async function enrollWithCredits(params: {
   }
 
   const isLiveTrialLineage = existingSub?.status === 'trialing';
-  const kiloclawPriceVersion = isLiveTrialLineage
-    ? existingSub.kiloclaw_price_version
-    : CURRENT_KILOCLAW_PRICE_VERSION;
+  const kiloclawPriceVersion = resolveKiloClawEnrollmentPriceVersion(
+    existingSub
+      ? {
+          status: existingSub.status,
+          kiloclawPriceVersion: existingSub.kiloclaw_price_version,
+        }
+      : null
+  );
+  if (params.expectedPriceVersion && params.expectedPriceVersion !== kiloclawPriceVersion) {
+    throw new Error(
+      `Credit enrollment intent price version no longer matches target: intended=${params.expectedPriceVersion} expected=${kiloclawPriceVersion}`
+    );
+  }
   const kiloclawPricing = getKiloClawPricingCatalogEntry(kiloclawPriceVersion);
 
   // First-time standard-plan subscribers in an eligible live pre-rollout lineage
@@ -1316,6 +1348,40 @@ export async function enrollWithCredits(params: {
   const trialEndEntityId = existingSub?.status === 'trialing' ? existingSub.id : undefined;
 
   await db.transaction(async tx => {
+    const [transactionTargetInstance] = await tx
+      .select({ destroyedAt: kiloclaw_instances.destroyed_at })
+      .from(kiloclaw_instances)
+      .where(
+        and(
+          eq(kiloclaw_instances.id, instanceId),
+          eq(kiloclaw_instances.user_id, userId),
+          isNull(kiloclaw_instances.organization_id)
+        )
+      )
+      .limit(1);
+    if (!transactionTargetInstance || transactionTargetInstance.destroyedAt) {
+      throw new Error('Credit enrollment target is no longer an active personal instance.');
+    }
+
+    const [currentSubscription] = await tx
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.user_id, userId),
+          eq(kiloclaw_subscriptions.instance_id, instanceId),
+          isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+        )
+      )
+      .limit(1);
+    if (
+      currentSubscription?.id !== existingSub?.id ||
+      currentSubscription?.status !== existingSub?.status ||
+      currentSubscription?.kiloclaw_price_version !== existingSub?.kiloclaw_price_version
+    ) {
+      throw new Error('Credit enrollment target changed before the deduction could be applied.');
+    }
+
     // 5a: Insert negative credit transaction with period-encoded idempotency key
     const deductionResult = await tx
       .insert(credit_transactions)
@@ -1352,18 +1418,6 @@ export async function enrollWithCredits(params: {
         microdollars_used: sql`${kilocode_users.microdollars_used} + ${costMicrodollars}`,
       })
       .where(eq(kilocode_users.id, userId));
-
-    const [currentSubscription] = await tx
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(
-        and(
-          eq(kiloclaw_subscriptions.user_id, userId),
-          eq(kiloclaw_subscriptions.instance_id, instanceId),
-          isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-        )
-      )
-      .limit(1);
 
     // 5c: Upsert subscription row as pure credit
     const commitEndsAt = plan === 'commit' ? periodEndIso : null;
@@ -1410,9 +1464,12 @@ export async function enrollWithCredits(params: {
       .returning();
 
     if (mutatedSubscription) {
-      const action: KiloClawSubscriptionChangeAction = currentSubscription
-        ? 'payment_source_changed'
-        : 'created';
+      const action: KiloClawSubscriptionChangeAction =
+        currentSubscription?.status === 'canceled'
+          ? 'reactivated'
+          : currentSubscription
+            ? 'payment_source_changed'
+            : 'created';
       await insertKiloClawSubscriptionChangeLog(tx, {
         subscriptionId: mutatedSubscription.id,
         actor: params.actor ?? CREDIT_BILLING_ACTOR,

--- a/apps/web/src/lib/kiloclaw/pricing-catalog.test.ts
+++ b/apps/web/src/lib/kiloclaw/pricing-catalog.test.ts
@@ -5,6 +5,7 @@ import {
   LEGACY_KILOCLAW_PRICE_VERSION,
   getKiloClawPlanCostMicrodollars,
   getKiloClawPricingCatalogEntry,
+  resolveKiloClawEnrollmentPriceVersion,
 } from '@kilocode/db';
 
 describe('KiloClaw pricing catalog', () => {
@@ -47,6 +48,22 @@ describe('KiloClaw pricing catalog', () => {
         useStandardIntro: true,
       })
     ).toBe(55_000_000);
+  });
+
+  it('preserves live trial pricing and uses current pricing after canceled history', () => {
+    expect(
+      resolveKiloClawEnrollmentPriceVersion({
+        status: 'trialing',
+        kiloclawPriceVersion: LEGACY_KILOCLAW_PRICE_VERSION,
+      })
+    ).toBe(LEGACY_KILOCLAW_PRICE_VERSION);
+    expect(
+      resolveKiloClawEnrollmentPriceVersion({
+        status: 'canceled',
+        kiloclawPriceVersion: LEGACY_KILOCLAW_PRICE_VERSION,
+      })
+    ).toBe(CURRENT_KILOCLAW_PRICE_VERSION);
+    expect(resolveKiloClawEnrollmentPriceVersion(null)).toBe(CURRENT_KILOCLAW_PRICE_VERSION);
   });
 
   it('fails closed for unknown price versions', () => {

--- a/apps/web/src/lib/kiloclaw/pricing-catalog.test.ts
+++ b/apps/web/src/lib/kiloclaw/pricing-catalog.test.ts
@@ -73,5 +73,11 @@ describe('KiloClaw pricing catalog', () => {
     expect(() => getKiloClawPricingCatalogEntry('toString')).toThrow(
       'Unknown KiloClaw price version'
     );
+    expect(() =>
+      resolveKiloClawEnrollmentPriceVersion({
+        status: 'trialing',
+        kiloclawPriceVersion: '2099-01-01',
+      })
+    ).toThrow('Unknown KiloClaw price version');
   });
 });

--- a/apps/web/src/lib/kiloclaw/stripe-handlers.ts
+++ b/apps/web/src/lib/kiloclaw/stripe-handlers.ts
@@ -1185,11 +1185,14 @@ export async function handleKiloClawSubscriptionCreated(params: {
     });
   }
 
-  logInfo('KiloClaw subscription.created processed', {
-    stripe_event_id: eventId,
-    user_id: kiloUserId,
-    plan,
-  });
+  if (didProcess) {
+    logInfo('KiloClaw subscription.created processed', {
+      stripe_event_id: eventId,
+      user_id: kiloUserId,
+      plan,
+      outcome: 'local_mutation_applied',
+    });
+  }
 }
 
 /**

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -170,10 +170,27 @@ type KiloPassCaller = {
     hostingIntent: 'none' | 'expired_commit' | 'standard' | 'commit';
     welcomePromoIneligibleDueToReusedFingerprint: boolean;
   }>;
-  activateCheckoutHosting: (input: { sessionId: string }) => Promise<{
-    activated: boolean;
-    hostingIntent: 'none' | 'expired_commit' | 'standard' | 'commit';
-  }>;
+  activateCheckoutHosting: (input: { sessionId: string }) => Promise<
+    | { outcome: 'activated'; hostingIntent: 'standard' | 'commit' }
+    | { outcome: 'not_requested'; hostingIntent: 'none' }
+    | {
+        outcome: 'retryable_failure';
+        hostingIntent: 'standard' | 'commit';
+        reason: 'credits_not_settled' | 'enrollment_failed';
+      }
+    | {
+        outcome: 'action_required';
+        hostingIntent: 'standard' | 'commit' | 'expired_commit';
+        reason:
+          | 'invalid_intent'
+          | 'stale_intent'
+          | 'missing_instance'
+          | 'destroyed_instance'
+          | 'requires_reprovision'
+          | 'insufficient_credits'
+          | 'expired_commit';
+      }
+  >;
   getCustomerPortalUrl: (input: { returnUrl?: string }) => Promise<{ url: string }>;
   getChurnkeyAuthHash: () => Promise<{ hash: string; customerId: string }>;
   cancelSubscription: () => Promise<{ success: boolean }>;
@@ -2094,7 +2111,7 @@ describe('kiloPassRouter', () => {
   });
 
   describe('activateCheckoutHosting', () => {
-    it('activates canceled legacy Standard hosting at the checkout current price after Kilo Pass credits settle', async () => {
+    it('preserves canceled legacy lineage and requires reprovision after Kilo Pass credits settle', async () => {
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-canceled-legacy-hosting@example.com',
         total_microdollars_acquired: 199_000_000,
@@ -2144,6 +2161,11 @@ describe('kiloPassRouter', () => {
       });
 
       const caller = await createCallerForUser(user.id);
+      const expectedResult = {
+        outcome: 'action_required',
+        hostingIntent: 'standard',
+        reason: 'requires_reprovision',
+      };
       await expect(
         Promise.all([
           caller.kiloPass.activateCheckoutHosting({
@@ -2153,15 +2175,12 @@ describe('kiloPassRouter', () => {
             sessionId: 'cs_kilo_pass_canceled_legacy_hosting',
           }),
         ])
-      ).resolves.toEqual([
-        { activated: true, hostingIntent: 'standard' },
-        { activated: true, hostingIntent: 'standard' },
-      ]);
+      ).resolves.toEqual([expectedResult, expectedResult]);
       await expect(
         caller.kiloPass.activateCheckoutHosting({
           sessionId: 'cs_kilo_pass_canceled_legacy_hosting',
         })
-      ).resolves.toEqual({ activated: true, hostingIntent: 'standard' });
+      ).resolves.toEqual(expectedResult);
 
       const [hosting] = await db
         .select()
@@ -2170,11 +2189,12 @@ describe('kiloPassRouter', () => {
         .limit(1);
       expect(hosting).toEqual(
         expect.objectContaining({
-          status: 'active',
+          status: 'canceled',
           plan: 'standard',
           payment_source: 'credits',
-          kiloclaw_price_version: '2026-05-10',
-          stripe_subscription_id: null,
+          kiloclaw_price_version: '2026-03-19',
+          stripe_subscription_id: 'sub_deleted_legacy_hosting',
+          transferred_to_subscription_id: null,
         })
       );
       const hostingRows = await db
@@ -2187,23 +2207,7 @@ describe('kiloPassRouter', () => {
         .select()
         .from(kiloclaw_subscription_change_log)
         .where(eq(kiloclaw_subscription_change_log.subscription_id, hosting?.id ?? ''));
-      expect(changeLog).toHaveLength(1);
-      expect(changeLog[0]).toEqual(
-        expect.objectContaining({
-          action: 'reactivated',
-          reason: 'credit_enrollment',
-          before_state: expect.objectContaining({
-            status: 'canceled',
-            kiloclaw_price_version: '2026-03-19',
-            stripe_subscription_id: 'sub_deleted_legacy_hosting',
-          }),
-          after_state: expect.objectContaining({
-            status: 'active',
-            kiloclaw_price_version: '2026-05-10',
-            stripe_subscription_id: null,
-          }),
-        })
-      );
+      expect(changeLog).toHaveLength(0);
 
       const hostingDeductions = await db
         .select()
@@ -2214,13 +2218,13 @@ describe('kiloPassRouter', () => {
             eq(credit_transactions.amount_microdollars, -55_000_000)
           )
         );
-      expect(hostingDeductions).toHaveLength(1);
+      expect(hostingDeductions).toHaveLength(0);
 
       const [updatedUser] = await db
         .select({ microdollarsUsed: kilocode_users.microdollars_used })
         .from(kilocode_users)
         .where(eq(kilocode_users.id, user.id));
-      expect(updatedUser?.microdollarsUsed).toBe(55_000_000);
+      expect(updatedUser?.microdollarsUsed).toBe(0);
     });
 
     it('rejects hosting activation until Kilo Pass base credits have settled', async () => {
@@ -2271,7 +2275,11 @@ describe('kiloPassRouter', () => {
         caller.kiloPass.activateCheckoutHosting({
           sessionId: 'cs_kilo_pass_hosting_pending_settlement',
         })
-      ).rejects.toThrow('Kilo Pass credits are still processing.');
+      ).resolves.toEqual({
+        outcome: 'retryable_failure',
+        hostingIntent: 'standard',
+        reason: 'credits_not_settled',
+      });
 
       const deductions = await db
         .select()
@@ -2294,9 +2302,9 @@ describe('kiloPassRouter', () => {
       await db.insert(kiloclaw_subscriptions).values({
         user_id: user.id,
         instance_id: instanceId,
-        plan: 'standard',
-        status: 'canceled',
-        kiloclaw_price_version: '2026-03-19',
+        plan: 'trial',
+        status: 'trialing',
+        kiloclaw_price_version: '2026-05-10',
       });
       const { id: kiloPassSubscriptionId } = await insertSubscription({
         kiloUserId: user.id,
@@ -2330,7 +2338,11 @@ describe('kiloPassRouter', () => {
       const caller = await createCallerForUser(user.id);
       await expect(
         caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_stale_hosting_intent' })
-      ).rejects.toThrow('Checkout hosting price version no longer matches instance.');
+      ).resolves.toEqual({
+        outcome: 'action_required',
+        hostingIntent: 'standard',
+        reason: 'stale_intent',
+      });
 
       const deductions = await db
         .select()
@@ -2364,10 +2376,57 @@ describe('kiloPassRouter', () => {
       const caller = await createCallerForUser(user.id);
       await expect(
         caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_invalid_hosting_price_version' })
-      ).rejects.toThrow('Checkout hosting price version is invalid.');
+      ).resolves.toEqual({
+        outcome: 'action_required',
+        hostingIntent: 'standard',
+        reason: 'invalid_intent',
+      });
     });
 
-    it('rejects a destroyed hosting anchor before credit enrollment', async () => {
+    it('returns permanent recovery when checkout instance is missing', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-missing-hosting-instance@example.com',
+      });
+      const { id: kiloPassSubscriptionId } = await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_kilo_pass_missing_hosting_instance',
+        tier: KiloPassTier.Tier199,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+      await insertBaseCreditsIssuance({
+        subscriptionId: kiloPassSubscriptionId,
+        kiloUserId: user.id,
+      });
+
+      const stripeMock = getStripeMock();
+      stripeMock.checkout.sessions.retrieve.mockResolvedValue({
+        status: 'complete',
+        subscription: 'sub_kilo_pass_missing_hosting_instance',
+        metadata: {
+          type: 'kilo-pass',
+          kiloUserId: user.id,
+          kiloclawHostingPlan: 'standard',
+          kiloclawInstanceId: crypto.randomUUID(),
+          kiloclawPriceVersion: '2026-05-10',
+        },
+      });
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_kilo_pass_missing_hosting_instance',
+        created: Math.floor(new Date('2026-06-10T15:00:00.000Z').getTime() / 1000),
+      });
+
+      const caller = await createCallerForUser(user.id);
+      await expect(
+        caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_missing_hosting_instance' })
+      ).resolves.toEqual({
+        outcome: 'action_required',
+        hostingIntent: 'standard',
+        reason: 'missing_instance',
+      });
+    });
+
+    it('returns permanent recovery for a destroyed hosting anchor', async () => {
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-destroyed-hosting-anchor@example.com',
         total_microdollars_acquired: 60_000_000,
@@ -2418,7 +2477,11 @@ describe('kiloPassRouter', () => {
       const caller = await createCallerForUser(user.id);
       await expect(
         caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_destroyed_hosting_anchor' })
-      ).rejects.toThrow('Reprovision KiloClaw before activating hosting.');
+      ).resolves.toEqual({
+        outcome: 'action_required',
+        hostingIntent: 'standard',
+        reason: 'destroyed_instance',
+      });
 
       const deductions = await db
         .select()
@@ -2478,7 +2541,7 @@ describe('kiloPassRouter', () => {
       const caller = await createCallerForUser(user.id);
       await expect(
         caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_qualified_commit_hosting' })
-      ).resolves.toEqual({ activated: true, hostingIntent: 'commit' });
+      ).resolves.toEqual({ outcome: 'activated', hostingIntent: 'commit' });
 
       const [hosting] = await db
         .select()
@@ -2514,7 +2577,11 @@ describe('kiloPassRouter', () => {
       const caller = await createCallerForUser(user.id);
       await expect(
         caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_expired_commit_hosting' })
-      ).resolves.toEqual({ activated: false, hostingIntent: 'expired_commit' });
+      ).resolves.toEqual({
+        outcome: 'action_required',
+        hostingIntent: 'expired_commit',
+        reason: 'expired_commit',
+      });
     });
   });
 

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -13,7 +13,9 @@ import {
   kilo_pass_store_purchases,
   kilo_pass_subscriptions,
   kiloclaw_instances,
+  kiloclaw_subscription_change_log,
   kiloclaw_subscriptions,
+  kilocode_users,
   microdollar_usage,
   microdollar_usage_daily,
   user_affiliate_attributions,
@@ -2092,6 +2094,340 @@ describe('kiloPassRouter', () => {
   });
 
   describe('activateCheckoutHosting', () => {
+    it('activates canceled legacy Standard hosting at the checkout current price after Kilo Pass credits settle', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-canceled-legacy-hosting@example.com',
+        total_microdollars_acquired: 199_000_000,
+      });
+      const instanceId = crypto.randomUUID();
+      await db.insert(kiloclaw_instances).values({
+        id: instanceId,
+        user_id: user.id,
+        sandbox_id: `test-${instanceId}`,
+      });
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        instance_id: instanceId,
+        payment_source: 'credits',
+        plan: 'standard',
+        status: 'canceled',
+        kiloclaw_price_version: '2026-03-19',
+        stripe_subscription_id: 'sub_deleted_legacy_hosting',
+      });
+      const { id: kiloPassSubscriptionId } = await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_kilo_pass_canceled_legacy_hosting',
+        tier: KiloPassTier.Tier199,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+      await insertBaseCreditsIssuance({
+        subscriptionId: kiloPassSubscriptionId,
+        kiloUserId: user.id,
+      });
+
+      const stripeMock = getStripeMock();
+      stripeMock.checkout.sessions.retrieve.mockResolvedValue({
+        status: 'complete',
+        subscription: 'sub_kilo_pass_canceled_legacy_hosting',
+        metadata: {
+          type: 'kilo-pass',
+          kiloUserId: user.id,
+          kiloclawHostingPlan: 'standard',
+          kiloclawInstanceId: instanceId,
+          kiloclawPriceVersion: '2026-05-10',
+        },
+      });
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_kilo_pass_canceled_legacy_hosting',
+        created: Math.floor(new Date('2026-06-10T15:00:00.000Z').getTime() / 1000),
+      });
+
+      const caller = await createCallerForUser(user.id);
+      await expect(
+        Promise.all([
+          caller.kiloPass.activateCheckoutHosting({
+            sessionId: 'cs_kilo_pass_canceled_legacy_hosting',
+          }),
+          caller.kiloPass.activateCheckoutHosting({
+            sessionId: 'cs_kilo_pass_canceled_legacy_hosting',
+          }),
+        ])
+      ).resolves.toEqual([
+        { activated: true, hostingIntent: 'standard' },
+        { activated: true, hostingIntent: 'standard' },
+      ]);
+      await expect(
+        caller.kiloPass.activateCheckoutHosting({
+          sessionId: 'cs_kilo_pass_canceled_legacy_hosting',
+        })
+      ).resolves.toEqual({ activated: true, hostingIntent: 'standard' });
+
+      const [hosting] = await db
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.instance_id, instanceId))
+        .limit(1);
+      expect(hosting).toEqual(
+        expect.objectContaining({
+          status: 'active',
+          plan: 'standard',
+          payment_source: 'credits',
+          kiloclaw_price_version: '2026-05-10',
+          stripe_subscription_id: null,
+        })
+      );
+      const hostingRows = await db
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.user_id, user.id));
+      expect(hostingRows).toHaveLength(1);
+
+      const changeLog = await db
+        .select()
+        .from(kiloclaw_subscription_change_log)
+        .where(eq(kiloclaw_subscription_change_log.subscription_id, hosting?.id ?? ''));
+      expect(changeLog).toHaveLength(1);
+      expect(changeLog[0]).toEqual(
+        expect.objectContaining({
+          action: 'reactivated',
+          reason: 'credit_enrollment',
+          before_state: expect.objectContaining({
+            status: 'canceled',
+            kiloclaw_price_version: '2026-03-19',
+            stripe_subscription_id: 'sub_deleted_legacy_hosting',
+          }),
+          after_state: expect.objectContaining({
+            status: 'active',
+            kiloclaw_price_version: '2026-05-10',
+            stripe_subscription_id: null,
+          }),
+        })
+      );
+
+      const hostingDeductions = await db
+        .select()
+        .from(credit_transactions)
+        .where(
+          and(
+            eq(credit_transactions.kilo_user_id, user.id),
+            eq(credit_transactions.amount_microdollars, -55_000_000)
+          )
+        );
+      expect(hostingDeductions).toHaveLength(1);
+
+      const [updatedUser] = await db
+        .select({ microdollarsUsed: kilocode_users.microdollars_used })
+        .from(kilocode_users)
+        .where(eq(kilocode_users.id, user.id));
+      expect(updatedUser?.microdollarsUsed).toBe(55_000_000);
+    });
+
+    it('rejects hosting activation until Kilo Pass base credits have settled', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-hosting-awaits-settlement@example.com',
+        total_microdollars_acquired: 60_000_000,
+      });
+      const instanceId = crypto.randomUUID();
+      await db.insert(kiloclaw_instances).values({
+        id: instanceId,
+        user_id: user.id,
+        sandbox_id: `test-${instanceId}`,
+      });
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        instance_id: instanceId,
+        plan: 'trial',
+        status: 'trialing',
+        kiloclaw_price_version: '2026-05-10',
+      });
+      await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_kilo_pass_hosting_pending_settlement',
+        tier: KiloPassTier.Tier199,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+
+      const stripeMock = getStripeMock();
+      stripeMock.checkout.sessions.retrieve.mockResolvedValue({
+        status: 'complete',
+        subscription: 'sub_kilo_pass_hosting_pending_settlement',
+        metadata: {
+          type: 'kilo-pass',
+          kiloUserId: user.id,
+          kiloclawHostingPlan: 'standard',
+          kiloclawInstanceId: instanceId,
+          kiloclawPriceVersion: '2026-05-10',
+        },
+      });
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_kilo_pass_hosting_pending_settlement',
+        created: Math.floor(new Date('2026-06-10T15:00:00.000Z').getTime() / 1000),
+      });
+
+      const caller = await createCallerForUser(user.id);
+      await expect(
+        caller.kiloPass.activateCheckoutHosting({
+          sessionId: 'cs_kilo_pass_hosting_pending_settlement',
+        })
+      ).rejects.toThrow('Kilo Pass credits are still processing.');
+
+      const deductions = await db
+        .select()
+        .from(credit_transactions)
+        .where(eq(credit_transactions.kilo_user_id, user.id));
+      expect(deductions).toHaveLength(0);
+    });
+
+    it('rejects a stale checkout price version before credit enrollment', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-stale-hosting-intent@example.com',
+        total_microdollars_acquired: 60_000_000,
+      });
+      const instanceId = crypto.randomUUID();
+      await db.insert(kiloclaw_instances).values({
+        id: instanceId,
+        user_id: user.id,
+        sandbox_id: `test-${instanceId}`,
+      });
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        instance_id: instanceId,
+        plan: 'standard',
+        status: 'canceled',
+        kiloclaw_price_version: '2026-03-19',
+      });
+      const { id: kiloPassSubscriptionId } = await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_kilo_pass_stale_hosting_intent',
+        tier: KiloPassTier.Tier199,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+      await insertBaseCreditsIssuance({
+        subscriptionId: kiloPassSubscriptionId,
+        kiloUserId: user.id,
+      });
+
+      const stripeMock = getStripeMock();
+      stripeMock.checkout.sessions.retrieve.mockResolvedValue({
+        status: 'complete',
+        subscription: 'sub_kilo_pass_stale_hosting_intent',
+        metadata: {
+          type: 'kilo-pass',
+          kiloUserId: user.id,
+          kiloclawHostingPlan: 'standard',
+          kiloclawInstanceId: instanceId,
+          kiloclawPriceVersion: '2026-03-19',
+        },
+      });
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_kilo_pass_stale_hosting_intent',
+        created: Math.floor(new Date('2026-06-10T15:00:00.000Z').getTime() / 1000),
+      });
+
+      const caller = await createCallerForUser(user.id);
+      await expect(
+        caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_stale_hosting_intent' })
+      ).rejects.toThrow('Checkout hosting price version no longer matches instance.');
+
+      const deductions = await db
+        .select()
+        .from(credit_transactions)
+        .where(eq(credit_transactions.kilo_user_id, user.id));
+      expect(deductions).toHaveLength(1);
+      expect(deductions[0]?.amount_microdollars).toBe(1_000_000);
+    });
+
+    it('rejects an unknown checkout price version at the metadata boundary', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-invalid-hosting-price-version@example.com',
+      });
+      const stripeMock = getStripeMock();
+      stripeMock.checkout.sessions.retrieve.mockResolvedValue({
+        status: 'complete',
+        subscription: 'sub_kilo_pass_invalid_hosting_price_version',
+        metadata: {
+          type: 'kilo-pass',
+          kiloUserId: user.id,
+          kiloclawHostingPlan: 'standard',
+          kiloclawInstanceId: crypto.randomUUID(),
+          kiloclawPriceVersion: '2099-01-01',
+        },
+      });
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_kilo_pass_invalid_hosting_price_version',
+        created: Math.floor(new Date('2026-06-10T15:00:00.000Z').getTime() / 1000),
+      });
+
+      const caller = await createCallerForUser(user.id);
+      await expect(
+        caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_invalid_hosting_price_version' })
+      ).rejects.toThrow('Checkout hosting price version is invalid.');
+    });
+
+    it('rejects a destroyed hosting anchor before credit enrollment', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-destroyed-hosting-anchor@example.com',
+        total_microdollars_acquired: 60_000_000,
+      });
+      const instanceId = crypto.randomUUID();
+      await db.insert(kiloclaw_instances).values({
+        id: instanceId,
+        user_id: user.id,
+        sandbox_id: `test-${instanceId}`,
+        destroyed_at: new Date().toISOString(),
+      });
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        instance_id: instanceId,
+        plan: 'standard',
+        status: 'canceled',
+        kiloclaw_price_version: '2026-05-10',
+      });
+      const { id: kiloPassSubscriptionId } = await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_kilo_pass_destroyed_hosting_anchor',
+        tier: KiloPassTier.Tier199,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+      await insertBaseCreditsIssuance({
+        subscriptionId: kiloPassSubscriptionId,
+        kiloUserId: user.id,
+      });
+
+      const stripeMock = getStripeMock();
+      stripeMock.checkout.sessions.retrieve.mockResolvedValue({
+        status: 'complete',
+        subscription: 'sub_kilo_pass_destroyed_hosting_anchor',
+        metadata: {
+          type: 'kilo-pass',
+          kiloUserId: user.id,
+          kiloclawHostingPlan: 'standard',
+          kiloclawInstanceId: instanceId,
+          kiloclawPriceVersion: '2026-05-10',
+        },
+      });
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_kilo_pass_destroyed_hosting_anchor',
+        created: Math.floor(new Date('2026-06-10T15:00:00.000Z').getTime() / 1000),
+      });
+
+      const caller = await createCallerForUser(user.id);
+      await expect(
+        caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_destroyed_hosting_anchor' })
+      ).rejects.toThrow('Reprovision KiloClaw before activating hosting.');
+
+      const deductions = await db
+        .select()
+        .from(credit_transactions)
+        .where(eq(credit_transactions.kilo_user_id, user.id));
+      expect(deductions).toHaveLength(1);
+      expect(deductions[0]?.amount_microdollars).toBe(1_000_000);
+    });
+
     it('activates verified pre-cutoff Commit hosting after cutoff as checkout-qualified', async () => {
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-qualified-commit-hosting@example.com',
@@ -2110,12 +2446,16 @@ describe('kiloPassRouter', () => {
         status: 'trialing',
         kiloclaw_price_version: '2026-05-10',
       });
-      await insertSubscription({
+      const { id: kiloPassSubscriptionId } = await insertSubscription({
         kiloUserId: user.id,
         stripeSubscriptionId: 'sub_qualified_commit_hosting',
         tier: KiloPassTier.Tier49,
         cadence: KiloPassCadence.Yearly,
         status: 'active',
+      });
+      await insertBaseCreditsIssuance({
+        subscriptionId: kiloPassSubscriptionId,
+        kiloUserId: user.id,
       });
 
       const stripeMock = getStripeMock();

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -188,7 +188,8 @@ type KiloPassCaller = {
           | 'destroyed_instance'
           | 'requires_reprovision'
           | 'insufficient_credits'
-          | 'expired_commit';
+          | 'expired_commit'
+          | 'unexpected_error';
       }
   >;
   getCustomerPortalUrl: (input: { returnUrl?: string }) => Promise<{ url: string }>;
@@ -2286,6 +2287,64 @@ describe('kiloPassRouter', () => {
         .from(credit_transactions)
         .where(eq(credit_transactions.kilo_user_id, user.id));
       expect(deductions).toHaveLength(0);
+    });
+
+    it('returns non-retryable recovery when settled credits cannot cover hosting', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-hosting-insufficient-credits@example.com',
+      });
+      const instanceId = crypto.randomUUID();
+      await db.insert(kiloclaw_instances).values({
+        id: instanceId,
+        user_id: user.id,
+        sandbox_id: `test-${instanceId}`,
+      });
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        instance_id: instanceId,
+        plan: 'trial',
+        status: 'trialing',
+        kiloclaw_price_version: '2026-05-10',
+      });
+      const { id: kiloPassSubscriptionId } = await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_kilo_pass_hosting_insufficient_credits',
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+      await insertBaseCreditsIssuance({
+        subscriptionId: kiloPassSubscriptionId,
+        kiloUserId: user.id,
+      });
+
+      const stripeMock = getStripeMock();
+      stripeMock.checkout.sessions.retrieve.mockResolvedValue({
+        status: 'complete',
+        subscription: 'sub_kilo_pass_hosting_insufficient_credits',
+        metadata: {
+          type: 'kilo-pass',
+          kiloUserId: user.id,
+          kiloclawHostingPlan: 'standard',
+          kiloclawInstanceId: instanceId,
+          kiloclawPriceVersion: '2026-05-10',
+        },
+      });
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_kilo_pass_hosting_insufficient_credits',
+        created: Math.floor(new Date('2026-06-10T15:00:00.000Z').getTime() / 1000),
+      });
+
+      const caller = await createCallerForUser(user.id);
+      await expect(
+        caller.kiloPass.activateCheckoutHosting({
+          sessionId: 'cs_kilo_pass_hosting_insufficient_credits',
+        })
+      ).resolves.toEqual({
+        outcome: 'action_required',
+        hostingIntent: 'standard',
+        reason: 'insufficient_credits',
+      });
     });
 
     it('rejects a stale checkout price version before credit enrollment', async () => {

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -1,7 +1,11 @@
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { captureException } from '@sentry/nextjs';
 import { db, readDb } from '@/lib/drizzle';
-import { enrollWithCredits } from '@/lib/kiloclaw/credit-billing';
+import {
+  CreditEnrollmentError,
+  enrollWithCredits,
+  type CreditEnrollmentErrorReason,
+} from '@/lib/kiloclaw/credit-billing';
 import {
   isBeforeKiloClawCommitSalesCutoff,
   isKiloClawPriceVersion,
@@ -801,9 +805,72 @@ const ActivateCheckoutHostingOutputSchema = z.discriminatedUnion('outcome', [
       'requires_reprovision',
       'insufficient_credits',
       'expired_commit',
+      'unexpected_error',
     ]),
   }),
 ]);
+
+type ActivateCheckoutHostingOutput = z.infer<typeof ActivateCheckoutHostingOutputSchema>;
+type HostingActivationActionRequiredReason = Extract<
+  ActivateCheckoutHostingOutput,
+  { outcome: 'action_required' }
+>['reason'];
+
+type CreditEnrollmentDisposition = {
+  idempotentConflict: boolean;
+  actionRequiredReason: HostingActivationActionRequiredReason;
+};
+
+const CREDIT_ENROLLMENT_DISPOSITIONS = {
+  commit_unavailable: {
+    idempotentConflict: false,
+    actionRequiredReason: 'expired_commit',
+  },
+  user_not_found: {
+    idempotentConflict: false,
+    actionRequiredReason: 'unexpected_error',
+  },
+  instance_not_found: {
+    idempotentConflict: false,
+    actionRequiredReason: 'missing_instance',
+  },
+  instance_destroyed: {
+    idempotentConflict: false,
+    actionRequiredReason: 'destroyed_instance',
+  },
+  active_subscription_exists: {
+    idempotentConflict: true,
+    actionRequiredReason: 'stale_intent',
+  },
+  unknown_price_version: {
+    idempotentConflict: false,
+    actionRequiredReason: 'unexpected_error',
+  },
+  price_version_mismatch: {
+    idempotentConflict: false,
+    actionRequiredReason: 'stale_intent',
+  },
+  insufficient_credits: {
+    idempotentConflict: false,
+    actionRequiredReason: 'insufficient_credits',
+  },
+  target_unavailable: {
+    idempotentConflict: false,
+    actionRequiredReason: 'destroyed_instance',
+  },
+  target_changed: {
+    idempotentConflict: true,
+    actionRequiredReason: 'stale_intent',
+  },
+  requires_reprovision: {
+    idempotentConflict: false,
+    actionRequiredReason: 'requires_reprovision',
+  },
+  duplicate_enrollment: {
+    idempotentConflict: true,
+    actionRequiredReason: 'stale_intent',
+  },
+} satisfies Record<CreditEnrollmentErrorReason, CreditEnrollmentDisposition>;
 
 const CreateCheckoutSessionInputSchema = z.object({
   tier: KiloPassTierSchema,
@@ -1523,12 +1590,12 @@ export const kiloPassRouter = createTRPCRouter({
         });
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        const isIdempotentConflict =
-          errorMessage.includes('target changed before the deduction') ||
-          errorMessage.includes('Enrollment already processed') ||
-          errorMessage.includes('active subscription already exists');
+        const enrollmentDisposition =
+          error instanceof CreditEnrollmentError
+            ? CREDIT_ENROLLMENT_DISPOSITIONS[error.reason]
+            : null;
         const concurrentReplaySucceeded =
-          isIdempotentConflict &&
+          enrollmentDisposition?.idempotentConflict === true &&
           (await isExpectedCreditHostingActive({
             userId: ctx.user.id,
             instanceId: instance.id,
@@ -1547,20 +1614,7 @@ export const kiloPassRouter = createTRPCRouter({
           return { outcome: 'activated', hostingIntent: hostingPlan };
         }
 
-        const actionRequiredReason = errorMessage.includes('Insufficient credit balance')
-          ? 'insufficient_credits'
-          : errorMessage.includes('destroyed KiloClaw instance') ||
-              errorMessage.includes('no longer an active personal instance')
-            ? 'destroyed_instance'
-            : errorMessage.includes('personal instance not found')
-              ? 'missing_instance'
-              : errorMessage.includes('price version no longer matches') ||
-                  errorMessage.includes('target changed before the deduction') ||
-                  errorMessage.includes('active subscription already exists')
-                ? 'stale_intent'
-                : errorMessage.includes('requires reprovisioning')
-                  ? 'requires_reprovision'
-                  : null;
+        const actionRequiredReason = enrollmentDisposition?.actionRequiredReason ?? null;
         logHostingActivationWarning('Kilo Pass hosting activation failed', {
           user_id: ctx.user.id,
           checkout_session_id: input.sessionId,

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -775,10 +775,35 @@ const GetCheckoutReturnStateOutputSchema = z.object({
   welcomePromoIneligibleDueToReusedFingerprint: z.boolean(),
 });
 
-const ActivateCheckoutHostingOutputSchema = z.object({
-  activated: z.boolean(),
-  hostingIntent: z.enum(['none', 'expired_commit', 'standard', 'commit']),
-});
+const KiloClawHostingPlanSchema = z.enum(['standard', 'commit']);
+const ActivateCheckoutHostingOutputSchema = z.discriminatedUnion('outcome', [
+  z.object({
+    outcome: z.literal('activated'),
+    hostingIntent: KiloClawHostingPlanSchema,
+  }),
+  z.object({
+    outcome: z.literal('not_requested'),
+    hostingIntent: z.literal('none'),
+  }),
+  z.object({
+    outcome: z.literal('retryable_failure'),
+    hostingIntent: KiloClawHostingPlanSchema,
+    reason: z.enum(['credits_not_settled', 'enrollment_failed']),
+  }),
+  z.object({
+    outcome: z.literal('action_required'),
+    hostingIntent: z.enum(['standard', 'commit', 'expired_commit']),
+    reason: z.enum([
+      'invalid_intent',
+      'stale_intent',
+      'missing_instance',
+      'destroyed_instance',
+      'requires_reprovision',
+      'insufficient_credits',
+      'expired_commit',
+    ]),
+  }),
+]);
 
 const CreateCheckoutSessionInputSchema = z.object({
   tier: KiloPassTierSchema,
@@ -1259,7 +1284,7 @@ export const kiloPassRouter = createTRPCRouter({
           reason: 'no_hosting_intent',
           duration_ms: Date.now() - startedAt,
         });
-        return { activated: false, hostingIntent: 'none' };
+        return { outcome: 'not_requested', hostingIntent: 'none' };
       }
 
       const stripeSubscription = checkoutSession.subscription;
@@ -1273,10 +1298,11 @@ export const kiloPassRouter = createTRPCRouter({
           intended_plan: hostingPlan,
           duration_ms: Date.now() - startedAt,
         });
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Kilo Pass checkout is not complete.',
-        });
+        return {
+          outcome: 'action_required',
+          hostingIntent: hostingPlan,
+          reason: 'invalid_intent',
+        };
       }
       const verifiedSubscription = await stripe.subscriptions.retrieve(stripeSubscriptionId);
       const checkoutConfirmedAt = new Date(verifiedSubscription.created * 1000).toISOString();
@@ -1288,7 +1314,11 @@ export const kiloPassRouter = createTRPCRouter({
           intended_plan: hostingPlan,
           duration_ms: Date.now() - startedAt,
         });
-        return { activated: false, hostingIntent: 'expired_commit' };
+        return {
+          outcome: 'action_required',
+          hostingIntent: 'expired_commit',
+          reason: 'expired_commit',
+        };
       }
 
       const instanceId = metadata.kiloclawInstanceId;
@@ -1302,10 +1332,11 @@ export const kiloPassRouter = createTRPCRouter({
           intended_price_version: priceVersion,
           duration_ms: Date.now() - startedAt,
         });
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Checkout is missing hosting intent metadata.',
-        });
+        return {
+          outcome: 'action_required',
+          hostingIntent: hostingPlan,
+          reason: 'invalid_intent',
+        };
       }
       if (!isKiloClawPriceVersion(priceVersion)) {
         logHostingActivationWarning('Kilo Pass hosting activation failed', {
@@ -1316,10 +1347,11 @@ export const kiloPassRouter = createTRPCRouter({
           intended_price_version: priceVersion,
           duration_ms: Date.now() - startedAt,
         });
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Checkout hosting price version is invalid.',
-        });
+        return {
+          outcome: 'action_required',
+          hostingIntent: hostingPlan,
+          reason: 'invalid_intent',
+        };
       }
       const [instance] = await db
         .select({
@@ -1344,7 +1376,11 @@ export const kiloPassRouter = createTRPCRouter({
           intended_price_version: priceVersion,
           duration_ms: Date.now() - startedAt,
         });
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Hosting instance not found.' });
+        return {
+          outcome: 'action_required',
+          hostingIntent: hostingPlan,
+          reason: 'missing_instance',
+        };
       }
       if (instance.destroyedAt) {
         logHostingActivationWarning('Kilo Pass hosting activation failed', {
@@ -1355,10 +1391,11 @@ export const kiloPassRouter = createTRPCRouter({
           intended_price_version: priceVersion,
           duration_ms: Date.now() - startedAt,
         });
-        throw new TRPCError({
-          code: 'CONFLICT',
-          message: 'Reprovision KiloClaw before activating hosting.',
-        });
+        return {
+          outcome: 'action_required',
+          hostingIntent: hostingPlan,
+          reason: 'destroyed_instance',
+        };
       }
       const [existingSubscription] = await db
         .select({
@@ -1389,10 +1426,11 @@ export const kiloPassRouter = createTRPCRouter({
           intended_price_version: priceVersion,
           duration_ms: Date.now() - startedAt,
         });
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Kilo Pass credits are still processing.',
-        });
+        return {
+          outcome: 'retryable_failure',
+          hostingIntent: hostingPlan,
+          reason: 'credits_not_settled',
+        };
       }
 
       const alreadyActivated =
@@ -1410,7 +1448,7 @@ export const kiloPassRouter = createTRPCRouter({
           intended_price_version: priceVersion,
           duration_ms: Date.now() - startedAt,
         });
-        return { activated: true, hostingIntent: hostingPlan };
+        return { outcome: 'activated', hostingIntent: hostingPlan };
       }
 
       const expectedPriceVersion = resolveKiloClawEnrollmentPriceVersion(
@@ -1421,6 +1459,26 @@ export const kiloPassRouter = createTRPCRouter({
             }
           : null
       );
+      const requiresReprovision =
+        existingSubscription?.status === 'canceled' &&
+        existingSubscription.priceVersion !== expectedPriceVersion;
+      if (requiresReprovision) {
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          instance_id: instance.id,
+          reason: 'canceled_legacy_requires_reprovision',
+          persisted_price_version: existingSubscription.priceVersion,
+          intended_price_version: expectedPriceVersion,
+          duration_ms: Date.now() - startedAt,
+        });
+        return {
+          outcome: 'action_required',
+          hostingIntent: hostingPlan,
+          reason: 'requires_reprovision',
+        };
+      }
+
       if (priceVersion !== expectedPriceVersion) {
         logHostingActivationWarning('Kilo Pass hosting activation failed', {
           user_id: ctx.user.id,
@@ -1431,10 +1489,11 @@ export const kiloPassRouter = createTRPCRouter({
           expected_price_version: expectedPriceVersion,
           duration_ms: Date.now() - startedAt,
         });
-        throw new TRPCError({
-          code: 'CONFLICT',
-          message: 'Checkout hosting price version no longer matches instance.',
-        });
+        return {
+          outcome: 'action_required',
+          hostingIntent: hostingPlan,
+          reason: 'stale_intent',
+        };
       }
 
       const [priorPaidSubscription] = await db
@@ -1485,20 +1544,44 @@ export const kiloPassRouter = createTRPCRouter({
             intended_price_version: priceVersion,
             duration_ms: Date.now() - startedAt,
           });
-          return { activated: true, hostingIntent: hostingPlan };
+          return { outcome: 'activated', hostingIntent: hostingPlan };
         }
 
+        const actionRequiredReason = errorMessage.includes('Insufficient credit balance')
+          ? 'insufficient_credits'
+          : errorMessage.includes('destroyed KiloClaw instance') ||
+              errorMessage.includes('no longer an active personal instance')
+            ? 'destroyed_instance'
+            : errorMessage.includes('personal instance not found')
+              ? 'missing_instance'
+              : errorMessage.includes('price version no longer matches') ||
+                  errorMessage.includes('target changed before the deduction') ||
+                  errorMessage.includes('active subscription already exists')
+                ? 'stale_intent'
+                : errorMessage.includes('requires reprovisioning')
+                  ? 'requires_reprovision'
+                  : null;
         logHostingActivationWarning('Kilo Pass hosting activation failed', {
           user_id: ctx.user.id,
           checkout_session_id: input.sessionId,
           instance_id: instance.id,
-          reason: 'credit_enrollment_failed',
+          reason: actionRequiredReason ?? 'credit_enrollment_failed',
           intended_price_version: priceVersion,
           expected_price_version: expectedPriceVersion,
           duration_ms: Date.now() - startedAt,
           error: errorMessage,
         });
-        throw error;
+        return actionRequiredReason
+          ? {
+              outcome: 'action_required',
+              hostingIntent: hostingPlan,
+              reason: actionRequiredReason,
+            }
+          : {
+              outcome: 'retryable_failure',
+              hostingIntent: hostingPlan,
+              reason: 'enrollment_failed',
+            };
       }
       logHostingActivationInfo('Kilo Pass hosting activation succeeded', {
         user_id: ctx.user.id,
@@ -1507,7 +1590,7 @@ export const kiloPassRouter = createTRPCRouter({
         intended_price_version: priceVersion,
         duration_ms: Date.now() - startedAt,
       });
-      return { activated: true, hostingIntent: hostingPlan };
+      return { outcome: 'activated', hostingIntent: hostingPlan };
     }),
 
   getCustomerPortalUrl: baseProcedure

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -2,7 +2,12 @@ import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { captureException } from '@sentry/nextjs';
 import { db, readDb } from '@/lib/drizzle';
 import { enrollWithCredits } from '@/lib/kiloclaw/credit-billing';
-import { CURRENT_KILOCLAW_PRICE_VERSION, isBeforeKiloClawCommitSalesCutoff } from '@kilocode/db';
+import {
+  isBeforeKiloClawCommitSalesCutoff,
+  isKiloClawPriceVersion,
+  resolveKiloClawEnrollmentPriceVersion,
+  type KiloClawPriceVersion,
+} from '@kilocode/db';
 import { getKiloPassStateForUser, type KiloPassSubscriptionState } from '@/lib/kilo-pass/state';
 import { client as stripe } from '@/lib/stripe-client';
 import { getStripePriceIdForKiloPass } from '@/lib/kilo-pass/stripe-price-ids.server';
@@ -67,6 +72,10 @@ import { getAllMobileStoreKiloPassProducts } from '@/lib/kilo-pass/mobile-store-
 import { verifyAppleKiloPassTransactionJws } from '@/lib/kilo-pass/apple-store-verifier';
 import { completeStoreKiloPassPurchase } from '@/lib/kilo-pass/store-subscription-completion';
 import { getInitialWelcomePromoEligibilityReasonForSubscription } from '@/lib/kilo-pass/welcome-promo-context';
+import { sentryLogger } from '@/lib/utils.server';
+
+const logHostingActivationInfo = sentryLogger('kilo-pass-hosting-activation', 'info');
+const logHostingActivationWarning = sentryLogger('kilo-pass-hosting-activation', 'warning');
 
 const CursorInputSchema = z.object({
   cursor: z.string().nullable().optional(),
@@ -814,6 +823,79 @@ const GetScheduledChangeOutputSchema = z.object({
     .nullable(),
 });
 
+async function isExpectedCreditHostingActive(params: {
+  userId: string;
+  instanceId: string;
+  plan: 'standard' | 'commit';
+  priceVersion: KiloClawPriceVersion;
+}): Promise<boolean> {
+  const [activeSubscription] = await db
+    .select({ id: kiloclaw_subscriptions.id })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, params.userId),
+        eq(kiloclaw_subscriptions.instance_id, params.instanceId),
+        eq(kiloclaw_subscriptions.status, 'active'),
+        eq(kiloclaw_subscriptions.plan, params.plan),
+        eq(kiloclaw_subscriptions.payment_source, 'credits'),
+        isNull(kiloclaw_subscriptions.stripe_subscription_id),
+        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
+        eq(kiloclaw_subscriptions.kiloclaw_price_version, params.priceVersion),
+        isNull(kiloclaw_instances.destroyed_at),
+        isNull(kiloclaw_instances.organization_id)
+      )
+    )
+    .limit(1);
+
+  return activeSubscription !== undefined;
+}
+
+async function getSettledKiloPassCheckoutSubscription(params: {
+  userId: string;
+  stripeSubscriptionId: string;
+}): Promise<{
+  id: string;
+  creditsAwarded: boolean;
+  welcomePromoEligibilityReason: KiloPassWelcomePromoEligibilityReason | null;
+} | null> {
+  const subscription = await db.query.kilo_pass_subscriptions.findFirst({
+    columns: { id: true },
+    where: and(
+      eq(kilo_pass_subscriptions.kilo_user_id, params.userId),
+      eq(kilo_pass_subscriptions.stripe_subscription_id, params.stripeSubscriptionId)
+    ),
+  });
+  if (!subscription) {
+    return null;
+  }
+
+  const [issuedBaseCredits] = await db
+    .select({
+      welcomePromoEligibilityReason: kilo_pass_issuances.initial_welcome_promo_eligibility_reason,
+    })
+    .from(kilo_pass_issuance_items)
+    .innerJoin(
+      kilo_pass_issuances,
+      eq(kilo_pass_issuance_items.kilo_pass_issuance_id, kilo_pass_issuances.id)
+    )
+    .where(
+      and(
+        eq(kilo_pass_issuances.kilo_pass_subscription_id, subscription.id),
+        eq(kilo_pass_issuance_items.kind, KiloPassIssuanceItemKind.Base)
+      )
+    )
+    .orderBy(asc(kilo_pass_issuances.issue_month))
+    .limit(1);
+
+  return {
+    id: subscription.id,
+    creditsAwarded: issuedBaseCredits !== undefined,
+    welcomePromoEligibilityReason: issuedBaseCredits?.welcomePromoEligibilityReason ?? null,
+  };
+}
+
 export const kiloPassRouter = createTRPCRouter({
   getMobileStoreProducts: baseProcedure.query(({ ctx }) => ({
     appAccountToken: ctx.user.app_store_account_token,
@@ -1126,48 +1208,17 @@ export const kiloPassRouter = createTRPCRouter({
         };
       }
 
-      const settledSubscription = await db.query.kilo_pass_subscriptions.findFirst({
-        columns: { id: true },
-        where: and(
-          eq(kilo_pass_subscriptions.kilo_user_id, ctx.user.id),
-          eq(kilo_pass_subscriptions.stripe_subscription_id, stripeSubscriptionId)
-        ),
+      const settledSubscription = await getSettledKiloPassCheckoutSubscription({
+        userId: ctx.user.id,
+        stripeSubscriptionId,
       });
-      if (!settledSubscription) {
-        return {
-          subscription: null,
-          creditsAwarded: false,
-          hostingIntent,
-          welcomePromoIneligibleDueToReusedFingerprint: false,
-        };
-      }
-
-      const issuedBaseCredits = await db
-        .select({
-          id: kilo_pass_issuance_items.id,
-          welcomePromoEligibilityReason:
-            kilo_pass_issuances.initial_welcome_promo_eligibility_reason,
-        })
-        .from(kilo_pass_issuance_items)
-        .innerJoin(
-          kilo_pass_issuances,
-          eq(kilo_pass_issuance_items.kilo_pass_issuance_id, kilo_pass_issuances.id)
-        )
-        .where(
-          and(
-            eq(kilo_pass_issuances.kilo_pass_subscription_id, settledSubscription.id),
-            eq(kilo_pass_issuance_items.kind, KiloPassIssuanceItemKind.Base)
-          )
-        )
-        .orderBy(asc(kilo_pass_issuances.issue_month))
-        .limit(1);
 
       return {
-        subscription,
-        creditsAwarded: issuedBaseCredits.length > 0,
+        subscription: settledSubscription ? subscription : null,
+        creditsAwarded: settledSubscription?.creditsAwarded ?? false,
         hostingIntent,
         welcomePromoIneligibleDueToReusedFingerprint:
-          issuedBaseCredits[0]?.welcomePromoEligibilityReason ===
+          settledSubscription?.welcomePromoEligibilityReason ===
           KiloPassWelcomePromoEligibilityReason.FingerprintPreviouslyClaimed,
       };
     }),
@@ -1176,6 +1227,11 @@ export const kiloPassRouter = createTRPCRouter({
     .input(z.object({ sessionId: z.string().min(1) }))
     .output(ActivateCheckoutHostingOutputSchema)
     .mutation(async ({ ctx, input }) => {
+      const startedAt = Date.now();
+      logHostingActivationInfo('Kilo Pass hosting activation started', {
+        user_id: ctx.user.id,
+        checkout_session_id: input.sessionId,
+      });
       const checkoutSession = await stripe.checkout.sessions.retrieve(input.sessionId);
       const metadata = checkoutSession.metadata ?? {};
       if (
@@ -1183,6 +1239,12 @@ export const kiloPassRouter = createTRPCRouter({
         metadata.type !== 'kilo-pass' ||
         metadata.kiloUserId !== ctx.user.id
       ) {
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          reason: 'invalid_checkout_ownership',
+          duration_ms: Date.now() - startedAt,
+        });
         throw new TRPCError({
           code: 'FORBIDDEN',
           message: 'Checkout session does not belong to user.',
@@ -1191,6 +1253,12 @@ export const kiloPassRouter = createTRPCRouter({
 
       const hostingPlan = metadata.kiloclawHostingPlan;
       if (hostingPlan !== 'standard' && hostingPlan !== 'commit') {
+        logHostingActivationInfo('Kilo Pass hosting activation skipped', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          reason: 'no_hosting_intent',
+          duration_ms: Date.now() - startedAt,
+        });
         return { activated: false, hostingIntent: 'none' };
       }
 
@@ -1198,6 +1266,13 @@ export const kiloPassRouter = createTRPCRouter({
       const stripeSubscriptionId =
         typeof stripeSubscription === 'string' ? stripeSubscription : stripeSubscription?.id;
       if (!stripeSubscriptionId) {
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          reason: 'missing_kilo_pass_subscription',
+          intended_plan: hostingPlan,
+          duration_ms: Date.now() - startedAt,
+        });
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'Kilo Pass checkout is not complete.',
@@ -1206,29 +1281,93 @@ export const kiloPassRouter = createTRPCRouter({
       const verifiedSubscription = await stripe.subscriptions.retrieve(stripeSubscriptionId);
       const checkoutConfirmedAt = new Date(verifiedSubscription.created * 1000).toISOString();
       if (hostingPlan === 'commit' && !isBeforeKiloClawCommitSalesCutoff(checkoutConfirmedAt)) {
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          reason: 'expired_commit_intent',
+          intended_plan: hostingPlan,
+          duration_ms: Date.now() - startedAt,
+        });
         return { activated: false, hostingIntent: 'expired_commit' };
       }
 
       const instanceId = metadata.kiloclawInstanceId;
       const priceVersion = metadata.kiloclawPriceVersion;
       if (!instanceId || !priceVersion) {
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          reason: 'missing_hosting_metadata',
+          intended_plan: hostingPlan,
+          intended_price_version: priceVersion,
+          duration_ms: Date.now() - startedAt,
+        });
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'Checkout is missing hosting intent metadata.',
         });
       }
+      if (!isKiloClawPriceVersion(priceVersion)) {
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          instance_id: instanceId,
+          reason: 'invalid_price_version',
+          intended_price_version: priceVersion,
+          duration_ms: Date.now() - startedAt,
+        });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Checkout hosting price version is invalid.',
+        });
+      }
       const [instance] = await db
-        .select({ id: kiloclaw_instances.id })
+        .select({
+          id: kiloclaw_instances.id,
+          destroyedAt: kiloclaw_instances.destroyed_at,
+        })
         .from(kiloclaw_instances)
         .where(
-          and(eq(kiloclaw_instances.id, instanceId), eq(kiloclaw_instances.user_id, ctx.user.id))
+          and(
+            eq(kiloclaw_instances.id, instanceId),
+            eq(kiloclaw_instances.user_id, ctx.user.id),
+            isNull(kiloclaw_instances.organization_id)
+          )
         )
         .limit(1);
       if (!instance) {
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          instance_id: instanceId,
+          reason: 'missing_personal_instance',
+          intended_price_version: priceVersion,
+          duration_ms: Date.now() - startedAt,
+        });
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Hosting instance not found.' });
       }
+      if (instance.destroyedAt) {
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          instance_id: instance.id,
+          reason: 'destroyed_billing_anchor',
+          intended_price_version: priceVersion,
+          duration_ms: Date.now() - startedAt,
+        });
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Reprovision KiloClaw before activating hosting.',
+        });
+      }
       const [existingSubscription] = await db
-        .select({ priceVersion: kiloclaw_subscriptions.kiloclaw_price_version })
+        .select({
+          status: kiloclaw_subscriptions.status,
+          plan: kiloclaw_subscriptions.plan,
+          paymentSource: kiloclaw_subscriptions.payment_source,
+          stripeSubscriptionId: kiloclaw_subscriptions.stripe_subscription_id,
+          priceVersion: kiloclaw_subscriptions.kiloclaw_price_version,
+        })
         .from(kiloclaw_subscriptions)
         .where(
           and(
@@ -1237,26 +1376,64 @@ export const kiloPassRouter = createTRPCRouter({
           )
         )
         .limit(1);
-      const expectedPriceVersion =
-        existingSubscription?.priceVersion ?? CURRENT_KILOCLAW_PRICE_VERSION;
-      if (priceVersion !== expectedPriceVersion) {
-        throw new TRPCError({
-          code: 'CONFLICT',
-          message: 'Checkout hosting price version no longer matches instance.',
-        });
-      }
-
-      const settledSubscription = await db.query.kilo_pass_subscriptions.findFirst({
-        columns: { id: true, started_at: true },
-        where: and(
-          eq(kilo_pass_subscriptions.kilo_user_id, ctx.user.id),
-          eq(kilo_pass_subscriptions.stripe_subscription_id, stripeSubscriptionId)
-        ),
+      const settledSubscription = await getSettledKiloPassCheckoutSubscription({
+        userId: ctx.user.id,
+        stripeSubscriptionId,
       });
-      if (!settledSubscription) {
+      if (!settledSubscription?.creditsAwarded) {
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          instance_id: instance.id,
+          reason: 'credits_not_settled',
+          intended_price_version: priceVersion,
+          duration_ms: Date.now() - startedAt,
+        });
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'Kilo Pass credits are still processing.',
+        });
+      }
+
+      const alreadyActivated =
+        existingSubscription?.status === 'active' &&
+        existingSubscription.plan === hostingPlan &&
+        existingSubscription.paymentSource === 'credits' &&
+        existingSubscription.stripeSubscriptionId === null &&
+        existingSubscription.priceVersion === priceVersion;
+      if (alreadyActivated) {
+        logHostingActivationInfo('Kilo Pass hosting activation replayed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          instance_id: instance.id,
+          outcome: 'idempotent_noop',
+          intended_price_version: priceVersion,
+          duration_ms: Date.now() - startedAt,
+        });
+        return { activated: true, hostingIntent: hostingPlan };
+      }
+
+      const expectedPriceVersion = resolveKiloClawEnrollmentPriceVersion(
+        existingSubscription
+          ? {
+              status: existingSubscription.status,
+              kiloclawPriceVersion: existingSubscription.priceVersion,
+            }
+          : null
+      );
+      if (priceVersion !== expectedPriceVersion) {
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          instance_id: instance.id,
+          reason: 'stale_price_version',
+          intended_price_version: priceVersion,
+          expected_price_version: expectedPriceVersion,
+          duration_ms: Date.now() - startedAt,
+        });
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Checkout hosting price version no longer matches instance.',
         });
       }
 
@@ -1272,16 +1449,63 @@ export const kiloPassRouter = createTRPCRouter({
         )
         .limit(1);
 
-      await enrollWithCredits({
-        userId: ctx.user.id,
-        instanceId: instance.id,
-        plan: hostingPlan,
-        hadPaidSubscription: Boolean(priorPaidSubscription),
-        actor: { actorType: 'user', actorId: ctx.user.id },
-        commitQualification:
-          hostingPlan === 'commit'
-            ? { source: 'checkout_confirmed_before_cutoff', qualifiedAt: checkoutConfirmedAt }
-            : undefined,
+      try {
+        await enrollWithCredits({
+          userId: ctx.user.id,
+          instanceId: instance.id,
+          plan: hostingPlan,
+          hadPaidSubscription: Boolean(priorPaidSubscription),
+          expectedPriceVersion,
+          actor: { actorType: 'user', actorId: ctx.user.id },
+          commitQualification:
+            hostingPlan === 'commit'
+              ? { source: 'checkout_confirmed_before_cutoff', qualifiedAt: checkoutConfirmedAt }
+              : undefined,
+        });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const isIdempotentConflict =
+          errorMessage.includes('target changed before the deduction') ||
+          errorMessage.includes('Enrollment already processed') ||
+          errorMessage.includes('active subscription already exists');
+        const concurrentReplaySucceeded =
+          isIdempotentConflict &&
+          (await isExpectedCreditHostingActive({
+            userId: ctx.user.id,
+            instanceId: instance.id,
+            plan: hostingPlan,
+            priceVersion: expectedPriceVersion,
+          }));
+        if (concurrentReplaySucceeded) {
+          logHostingActivationInfo('Kilo Pass hosting activation replayed', {
+            user_id: ctx.user.id,
+            checkout_session_id: input.sessionId,
+            instance_id: instance.id,
+            outcome: 'concurrent_idempotent_noop',
+            intended_price_version: priceVersion,
+            duration_ms: Date.now() - startedAt,
+          });
+          return { activated: true, hostingIntent: hostingPlan };
+        }
+
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          instance_id: instance.id,
+          reason: 'credit_enrollment_failed',
+          intended_price_version: priceVersion,
+          expected_price_version: expectedPriceVersion,
+          duration_ms: Date.now() - startedAt,
+          error: errorMessage,
+        });
+        throw error;
+      }
+      logHostingActivationInfo('Kilo Pass hosting activation succeeded', {
+        user_id: ctx.user.id,
+        checkout_session_id: input.sessionId,
+        instance_id: instance.id,
+        intended_price_version: priceVersion,
+        duration_ms: Date.now() - startedAt,
       });
       return { activated: true, hostingIntent: hostingPlan };
     }),

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -2791,7 +2791,7 @@ describe('createKiloPassUpsellCheckout', () => {
     expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
   });
 
-  it('records the current hosting price version for canceled legacy Kilo Pass checkout intent', async () => {
+  it('rejects canceled legacy Kilo Pass hosting before provider checkout', async () => {
     const instance = await createKiloclawInstance(user.id);
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
@@ -2802,32 +2802,26 @@ describe('createKiloPassUpsellCheckout', () => {
       kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
       stripe_subscription_id: 'sub_deleted_legacy_kilo_pass_intent',
     });
-    stripeMock.checkout.sessions.create.mockResolvedValue({
-      url: 'https://checkout.stripe.com/test',
-    });
-
     const caller = await createCallerForUser(user.id);
-    await caller.kiloclaw.createKiloPassUpsellCheckout({
-      instanceId: instance.id,
-      tier: '199',
-      cadence: 'monthly',
-      hostingPlan: 'standard',
-    });
+    await expect(
+      caller.kiloclaw.createKiloPassUpsellCheckout({
+        instanceId: instance.id,
+        tier: '199',
+        cadence: 'monthly',
+        hostingPlan: 'standard',
+      })
+    ).rejects.toThrow('Reprovision KiloClaw before purchasing Kilo Pass with bundled hosting.');
 
-    expect(stripeMock.checkout.sessions.create).toHaveBeenCalledWith(
+    expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
+    const [unchangedSubscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, instance.id));
+    expect(unchangedSubscription).toEqual(
       expect.objectContaining({
-        metadata: expect.objectContaining({
-          kiloclawHostingPlan: 'standard',
-          kiloclawInstanceId: instance.id,
-          kiloclawPriceVersion: CURRENT_KILOCLAW_PRICE_VERSION,
-        }),
-        subscription_data: {
-          metadata: expect.objectContaining({
-            kiloclawHostingPlan: 'standard',
-            kiloclawInstanceId: instance.id,
-            kiloclawPriceVersion: CURRENT_KILOCLAW_PRICE_VERSION,
-          }),
-        },
+        status: 'canceled',
+        kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
+        stripe_subscription_id: 'sub_deleted_legacy_kilo_pass_intent',
       })
     );
   });
@@ -6835,7 +6829,7 @@ describe('enrollWithCredits', () => {
       user_id: user.id,
       instance_id: instance.id,
       plan: 'trial',
-      status: 'canceled',
+      status: 'trialing',
       trial_started_at: new Date(now.getTime() - 17 * 86_400_000).toISOString(),
       trial_ends_at: new Date(now.getTime() - 10 * 86_400_000).toISOString(),
       suspended_at: new Date(now.getTime() - 10 * 86_400_000).toISOString(),
@@ -6895,7 +6889,7 @@ describe('enrollWithCredits', () => {
       user_id: user.id,
       instance_id: instance.id,
       plan: 'trial',
-      status: 'canceled',
+      status: 'trialing',
       trial_started_at: new Date(now.getTime() - 17 * 86_400_000).toISOString(),
       trial_ends_at: new Date(now.getTime() - 10 * 86_400_000).toISOString(),
       suspended_at: new Date(now.getTime() - 10 * 86_400_000).toISOString(),
@@ -7340,25 +7334,25 @@ describe('enrollWithCredits', () => {
     );
   });
 
-  it('enrolls returning subscriber at current recurring standard price after canceled history', async () => {
+  it('rejects canceled legacy credit enrollment without rewriting historical lineage', async () => {
     const instance = await createInstance(user.id);
     await giveUserCredits(user.id, 60_000_000);
 
-    // A canceled non-trial subscription means this is a fresh current-price
-    // enrollment and should not preserve legacy economics.
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       instance_id: instance.id,
       payment_source: 'credits',
       plan: 'standard',
       status: 'canceled',
+      kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
+      stripe_subscription_id: 'sub_deleted_legacy_direct_enrollment',
       cancel_at_period_end: false,
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.enrollWithCredits({ plan: 'standard' });
-
-    expect(result).toEqual({ success: true });
+    await expect(caller.kiloclaw.enrollWithCredits({ plan: 'standard' })).rejects.toThrow(
+      'Canceled legacy KiloClaw history requires reprovisioning before credit enrollment.'
+    );
 
     const [sub] = await db
       .select()
@@ -7366,27 +7360,27 @@ describe('enrollWithCredits', () => {
       .where(eq(kiloclaw_subscriptions.user_id, user.id))
       .limit(1);
 
-    expect(sub.status).toBe('active');
-    expect(sub.payment_source).toBe('credits');
-    expect(sub.kiloclaw_price_version).toBe(CURRENT_KILOCLAW_PRICE_VERSION);
+    expect(sub).toEqual(
+      expect.objectContaining({
+        status: 'canceled',
+        payment_source: 'credits',
+        kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
+        stripe_subscription_id: 'sub_deleted_legacy_direct_enrollment',
+      })
+    );
 
-    // Verify current recurring price deduction ($55, not legacy $9 or $4)
     const txns = await db
       .select()
       .from(credit_transactions)
       .where(eq(credit_transactions.kilo_user_id, user.id));
-
-    const deduction = txns.find(t => t.amount_microdollars < 0);
-    expect(deduction).toBeDefined();
-    expect(deduction!.amount_microdollars).toBe(-55_000_000);
+    expect(txns).toHaveLength(0);
 
     const [updatedUser] = await db
       .select({ used: kilocode_users.microdollars_used })
       .from(kilocode_users)
       .where(eq(kilocode_users.id, user.id))
       .limit(1);
-
-    expect(updatedUser.used).toBe(55_000_000);
+    expect(updatedUser.used).toBe(0);
   });
 
   it('allows enrollment when subscription is trialing', async () => {
@@ -7485,6 +7479,7 @@ describe('enrollWithCredits', () => {
       instance_id: instance.id,
       plan: 'standard',
       status: 'canceled',
+      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
       current_period_end: '2026-04-01T00:00:00.000Z',
     });
 
@@ -7537,6 +7532,7 @@ describe('enrollWithCredits', () => {
       instance_id: instance.id,
       plan: 'trial',
       status: 'canceled',
+      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
       cancel_at_period_end: false,
     });
 

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -2387,28 +2387,20 @@ describe('createSubscriptionCheckout', () => {
     expect(row.scheduled_plan).toBeNull();
   });
 
-  it('allows checkout for active orphan instance with no subscription row', async () => {
-    const instance = await createKiloclawInstance(user.id);
-
-    stripeMock.checkout.sessions.create.mockResolvedValue({
-      url: 'https://checkout.stripe.com/test',
-    });
+  it('rejects checkout for an active orphan instance before provider access', async () => {
+    await createKiloclawInstance(user.id);
 
     const caller = await createCallerForUser(user.id);
-    await expect(caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' })).resolves.toEqual(
-      { url: 'https://checkout.stripe.com/test' }
+    await expect(caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' })).rejects.toThrow(
+      'Reprovision KiloClaw before starting a new Stripe subscription.'
     );
 
-    expect(stripeMock.checkout.sessions.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        metadata: expect.objectContaining({
-          instanceId: instance.id,
-        }),
-      })
-    );
+    expect(stripeMock.subscriptions.list).not.toHaveBeenCalled();
+    expect(stripeMock.checkout.sessions.list).not.toHaveBeenCalled();
+    expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
   });
 
-  it('uses the current recurring standard price for fresh checkout with no prior live lineage', async () => {
+  it('uses the current recurring standard price for a live current-price trial', async () => {
     stripePriceIdsMock.getStripePriceIdForClawPlan.mockImplementation(
       (plan: string, options?: { priceVersion?: string }) =>
         `${options?.priceVersion ?? 'missing-version'}_${plan}`
@@ -2419,6 +2411,13 @@ describe('createSubscriptionCheckout', () => {
     );
 
     const instance = await createKiloclawInstance(user.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      plan: 'trial',
+      status: 'trialing',
+      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+    });
 
     stripeMock.checkout.sessions.create.mockResolvedValue({
       url: 'https://checkout.stripe.com/test',
@@ -2487,31 +2486,58 @@ describe('createSubscriptionCheckout', () => {
     );
   });
 
-  it('uses the regular price for returning canceled standard subscribers', async () => {
-    const instance = await createKiloclawInstance(user.id, '2026-04-01T00:00:00.000Z');
+  it('rejects direct Stripe checkout for canceled legacy lineage before provider access', async () => {
+    const instance = await createKiloclawInstance(user.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      payment_source: 'credits',
+      plan: 'standard',
+      status: 'canceled',
+      kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
+      stripe_subscription_id: 'sub_deleted_returning_standard',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' })).rejects.toThrow(
+      'This KiloClaw lineage cannot accept a new Stripe subscription. Activate hosting with credits or reprovision first.'
+    );
+
+    expect(stripeMock.subscriptions.list).not.toHaveBeenCalled();
+    expect(stripeMock.checkout.sessions.list).not.toHaveBeenCalled();
+    expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
+
+    const [unchangedSubscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, instance.id));
+    expect(unchangedSubscription).toEqual(
+      expect.objectContaining({
+        status: 'canceled',
+        kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
+        stripe_subscription_id: 'sub_deleted_returning_standard',
+      })
+    );
+  });
+
+  it('rejects direct Stripe checkout for a destroyed billing anchor before provider access', async () => {
+    const instance = await createKiloclawInstance(user.id, '2026-06-10T15:01:00.000Z');
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       instance_id: instance.id,
       plan: 'standard',
       status: 'canceled',
-      stripe_subscription_id: 'sub_returning_standard',
-    });
-
-    stripeMock.checkout.sessions.create.mockResolvedValue({
-      url: 'https://checkout.stripe.com/test',
+      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
     });
 
     const caller = await createCallerForUser(user.id);
-    await caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' });
+    await expect(caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' })).rejects.toThrow(
+      'Reprovision KiloClaw before starting a new Stripe subscription.'
+    );
 
-    const callArgs = stripeMock.checkout.sessions.create.mock.calls[0]?.[0] as Record<
-      string,
-      unknown
-    >;
-    // Should use regular price (via getStripePriceIdForClawPlan mock which returns 'price_test_kiloclaw')
-    expect(callArgs.line_items).toEqual([{ price: 'price_test_kiloclaw', quantity: 1 }]);
-    expect(callArgs.allow_promotion_codes).toBe(true);
-    expect(callArgs.discounts).toBeUndefined();
+    expect(stripeMock.subscriptions.list).not.toHaveBeenCalled();
+    expect(stripeMock.checkout.sessions.list).not.toHaveBeenCalled();
+    expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
   });
 
   it('uses the current recurring standard price after canceled trial history', async () => {
@@ -2524,13 +2550,13 @@ describe('createSubscriptionCheckout', () => {
         `${options?.priceVersion ?? 'missing-version'}_${plan}_intro`
     );
 
-    const instance = await createKiloclawInstance(user.id, '2026-04-01T00:00:00.000Z');
+    const instance = await createKiloclawInstance(user.id);
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       instance_id: instance.id,
       plan: 'trial',
       status: 'canceled',
-      kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
+      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
     });
 
     stripeMock.checkout.sessions.create.mockResolvedValue({
@@ -2740,6 +2766,70 @@ describe('createKiloPassUpsellCheckout', () => {
     ).resolves.toEqual({ url: 'https://checkout.stripe.com/test' });
 
     expect(stripeMock.checkout.sessions.create).toHaveBeenCalled();
+  });
+
+  it('rejects Kilo Pass hosting checkout for a destroyed billing anchor before provider access', async () => {
+    const instance = await createKiloclawInstance(user.id, '2026-06-10T15:01:00.000Z');
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      plan: 'standard',
+      status: 'canceled',
+      kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.kiloclaw.createKiloPassUpsellCheckout({
+        instanceId: instance.id,
+        tier: '199',
+        cadence: 'monthly',
+        hostingPlan: 'standard',
+      })
+    ).rejects.toThrow('Reprovision KiloClaw before starting Kilo Pass hosting activation.');
+
+    expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it('records the current hosting price version for canceled legacy Kilo Pass checkout intent', async () => {
+    const instance = await createKiloclawInstance(user.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      payment_source: 'credits',
+      plan: 'standard',
+      status: 'canceled',
+      kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
+      stripe_subscription_id: 'sub_deleted_legacy_kilo_pass_intent',
+    });
+    stripeMock.checkout.sessions.create.mockResolvedValue({
+      url: 'https://checkout.stripe.com/test',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await caller.kiloclaw.createKiloPassUpsellCheckout({
+      instanceId: instance.id,
+      tier: '199',
+      cadence: 'monthly',
+      hostingPlan: 'standard',
+    });
+
+    expect(stripeMock.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          kiloclawHostingPlan: 'standard',
+          kiloclawInstanceId: instance.id,
+          kiloclawPriceVersion: CURRENT_KILOCLAW_PRICE_VERSION,
+        }),
+        subscription_data: {
+          metadata: expect.objectContaining({
+            kiloclawHostingPlan: 'standard',
+            kiloclawInstanceId: instance.id,
+            kiloclawPriceVersion: CURRENT_KILOCLAW_PRICE_VERSION,
+          }),
+        },
+      })
+    );
   });
 
   it('uses empty affiliateTrackingId in Kilo Pass upsell metadata when attribution is absent', async () => {
@@ -4176,6 +4266,121 @@ describe('handleKiloClawSubscriptionCreated', () => {
       status: 'active',
     });
   });
+});
+
+describe('current-price canceled Stripe checkout webhook ordering', () => {
+  let handleKiloClawSubscriptionCreated: (params: {
+    eventId: string;
+    subscription: Stripe.Subscription;
+  }) => Promise<void>;
+  let handleKiloClawInvoicePaid: (params: {
+    eventId: string;
+    invoice: Stripe.Invoice;
+  }) => Promise<void>;
+
+  beforeAll(async () => {
+    const mod = await import('@/lib/kiloclaw/stripe-handlers');
+    handleKiloClawSubscriptionCreated = mod.handleKiloClawSubscriptionCreated;
+    handleKiloClawInvoicePaid = mod.handleKiloClawInvoicePaid;
+  });
+
+  it.each(['subscription.created before invoice.paid', 'invoice.paid before subscription.created'])(
+    'settles safely when %s',
+    async order => {
+      const orderKey = order.startsWith('subscription.created') ? 'created_first' : 'invoice_first';
+      const instance = await createKiloclawInstance(user.id);
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        instance_id: instance.id,
+        stripe_subscription_id: `sub_deleted_old_${orderKey}`,
+        payment_source: 'credits',
+        plan: 'standard',
+        status: 'canceled',
+        kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+      });
+
+      const stripeSubscriptionId = `sub_current_rejoin_${orderKey}`;
+      const subscription = makeStripeSubscription({
+        id: stripeSubscriptionId,
+        metadata: {
+          type: 'kiloclaw',
+          billingContext: 'personal',
+          plan: 'standard',
+          kiloUserId: user.id,
+          instanceId: instance.id,
+          kiloclawPriceVersion: CURRENT_KILOCLAW_PRICE_VERSION,
+        },
+        status: 'active',
+        priceId: 'price_current_standard',
+      });
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        ...subscription,
+        schedule: null,
+      });
+      const invoice = {
+        id: `in_current_rejoin_${orderKey}`,
+        amount_paid: 5_500,
+        currency: 'usd',
+        charge: `ch_current_rejoin_${orderKey}`,
+        parent: {
+          subscription_details: {
+            subscription: stripeSubscriptionId,
+          },
+        },
+        lines: {
+          data: [
+            {
+              pricing: {
+                price_details: {
+                  price: 'price_current_standard',
+                },
+              },
+              period: {
+                start: Math.floor(new Date('2026-06-10T15:03:00.000Z').getTime() / 1000),
+                end: Math.floor(new Date('2026-07-10T15:03:00.000Z').getTime() / 1000),
+              },
+            },
+          ],
+        },
+      } as unknown as Stripe.Invoice;
+
+      if (order.startsWith('subscription.created')) {
+        await handleKiloClawSubscriptionCreated({
+          eventId: `evt_created_${orderKey}`,
+          subscription,
+        });
+        await handleKiloClawInvoicePaid({ eventId: `evt_invoice_${orderKey}`, invoice });
+      } else {
+        await handleKiloClawInvoicePaid({ eventId: `evt_invoice_${orderKey}`, invoice });
+        await handleKiloClawSubscriptionCreated({
+          eventId: `evt_created_${orderKey}`,
+          subscription,
+        });
+      }
+
+      const [row] = await db
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.instance_id, instance.id));
+      expect(row).toEqual(
+        expect.objectContaining({
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+          stripe_subscription_id: stripeSubscriptionId,
+        })
+      );
+
+      const settlementEntries = await db
+        .select()
+        .from(credit_transactions)
+        .where(eq(credit_transactions.kilo_user_id, user.id));
+      expect(
+        settlementEntries.map(entry => entry.amount_microdollars).sort((a, b) => a - b)
+      ).toEqual([-55_000_000, 55_000_000]);
+    }
+  );
 });
 
 describe('handleKiloClawScheduleEvent', () => {
@@ -7098,7 +7303,7 @@ describe('enrollWithCredits', () => {
     );
   });
 
-  it('enrollWithCredits with no instanceId after destroy does NOT produce duplicate_enrollment', async () => {
+  it('rejects a destroyed billing anchor before direct credit enrollment', async () => {
     const instance = await createInstance(user.id);
     await giveUserCredits(user.id, 50_000_000);
     const now = new Date();
@@ -7131,7 +7336,7 @@ describe('enrollWithCredits', () => {
 
     const caller = await createCallerForUser(user.id);
     await expect(caller.kiloclaw.enrollWithCredits({ plan: 'standard' })).rejects.toThrow(
-      'active subscription already exists'
+      'Reprovision KiloClaw before enrolling hosting with credits.'
     );
   });
 

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -129,8 +129,10 @@ import {
   undoKiloClawCommitStandardContinuation,
 } from '@/lib/kiloclaw/commit-retirement';
 import {
+  CreditEnrollmentError,
   enrollWithCredits as enrollWithCreditsImpl,
   getEffectiveCreditBalancePreview,
+  type CreditEnrollmentErrorReason,
 } from '@/lib/kiloclaw/credit-billing';
 import {
   logCreditEnrollmentAttempted,
@@ -343,24 +345,37 @@ async function getLatestPersonalBillingInstance(
   return instance ?? null;
 }
 
-function classifyEnrollWithCreditsError(message: string): {
-  code: 'NOT_FOUND' | 'CONFLICT' | 'BAD_REQUEST' | 'INTERNAL_SERVER_ERROR';
+type CreditEnrollmentRouterErrorDisposition = {
+  code: 'NOT_FOUND' | 'CONFLICT' | 'BAD_REQUEST';
   failureReason: CreditEnrollmentFailureReason;
-} {
-  if (message.includes('requires reprovisioning')) {
-    return { code: 'CONFLICT', failureReason: 'precondition_failed' };
-  }
-  if (message.includes('not found')) {
-    return { code: 'NOT_FOUND', failureReason: 'user_not_found' };
-  }
-  if (message.includes('already processed')) {
-    return { code: 'CONFLICT', failureReason: 'duplicate_enrollment' };
-  }
-  if (message.includes('already exists')) {
-    return { code: 'CONFLICT', failureReason: 'active_subscription_exists' };
-  }
-  if (message.includes('Insufficient credit balance')) {
-    return { code: 'BAD_REQUEST', failureReason: 'insufficient_credits' };
+};
+
+const CREDIT_ENROLLMENT_ROUTER_ERROR_DISPOSITIONS = {
+  commit_unavailable: { code: 'BAD_REQUEST', failureReason: 'precondition_failed' },
+  user_not_found: { code: 'NOT_FOUND', failureReason: 'user_not_found' },
+  instance_not_found: { code: 'NOT_FOUND', failureReason: 'no_instance' },
+  instance_destroyed: { code: 'CONFLICT', failureReason: 'precondition_failed' },
+  active_subscription_exists: {
+    code: 'CONFLICT',
+    failureReason: 'active_subscription_exists',
+  },
+  unknown_price_version: { code: 'CONFLICT', failureReason: 'precondition_failed' },
+  price_version_mismatch: { code: 'CONFLICT', failureReason: 'precondition_failed' },
+  insufficient_credits: { code: 'BAD_REQUEST', failureReason: 'insufficient_credits' },
+  target_unavailable: { code: 'CONFLICT', failureReason: 'precondition_failed' },
+  target_changed: { code: 'CONFLICT', failureReason: 'precondition_failed' },
+  requires_reprovision: { code: 'CONFLICT', failureReason: 'precondition_failed' },
+  duplicate_enrollment: { code: 'CONFLICT', failureReason: 'duplicate_enrollment' },
+} satisfies Record<CreditEnrollmentErrorReason, CreditEnrollmentRouterErrorDisposition>;
+
+function classifyEnrollWithCreditsError(error: unknown):
+  | CreditEnrollmentRouterErrorDisposition
+  | {
+      code: 'INTERNAL_SERVER_ERROR';
+      failureReason: 'internal_error';
+    } {
+  if (error instanceof CreditEnrollmentError) {
+    return CREDIT_ENROLLMENT_ROUTER_ERROR_DISPOSITIONS[error.reason];
   }
   return { code: 'INTERNAL_SERVER_ERROR', failureReason: 'internal_error' };
 }
@@ -5230,7 +5245,7 @@ export const kiloclawRouter = createTRPCRouter({
         }
 
         const message = error instanceof Error ? error.message : 'Credit enrollment failed';
-        const { code, failureReason } = classifyEnrollWithCreditsError(message);
+        const { code, failureReason } = classifyEnrollWithCreditsError(error);
         logCreditEnrollmentFailed({
           userId: ctx.user.id,
           plan: input.plan,

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -347,6 +347,9 @@ function classifyEnrollWithCreditsError(message: string): {
   code: 'NOT_FOUND' | 'CONFLICT' | 'BAD_REQUEST' | 'INTERNAL_SERVER_ERROR';
   failureReason: CreditEnrollmentFailureReason;
 } {
+  if (message.includes('requires reprovisioning')) {
+    return { code: 'CONFLICT', failureReason: 'precondition_failed' };
+  }
   if (message.includes('not found')) {
     return { code: 'NOT_FOUND', failureReason: 'user_not_found' };
   }
@@ -5303,6 +5306,23 @@ export const kiloclawRouter = createTRPCRouter({
             }
           : null
       );
+      if (
+        currentRow?.subscription.status === 'canceled' &&
+        currentRow.subscription.kiloclaw_price_version !== intendedPriceVersion
+      ) {
+        logBillingWarning('KiloClaw Kilo Pass checkout rejected before provider access', {
+          user_id: ctx.user.id,
+          instance_id: anchorInstance.id,
+          subscription_id: currentRow.subscription.id,
+          reason: 'canceled_legacy_requires_reprovision',
+          persisted_price_version: currentRow.subscription.kiloclaw_price_version,
+          intended_price_version: intendedPriceVersion,
+        });
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Reprovision KiloClaw before purchasing Kilo Pass with bundled hosting.',
+        });
+      }
       const intendedPricing = getKiloClawPricingCatalogEntry(intendedPriceVersion);
       const hadPaidSubscription = await hadPriorPaidSubscription(ctx.user.id);
       const useStandardIntro =

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -33,13 +33,13 @@ import {
 import { workerUrlForInstance } from '@/lib/kiloclaw/instance-url';
 import { db, type DrizzleTransaction } from '@/lib/drizzle';
 import {
-  CURRENT_KILOCLAW_PRICE_VERSION,
   classifyKiloClawCommitTerm,
   deriveKiloClawCommitFinalBoundary,
   findLatestPreCutoffUserCommitSwitchQualification,
   getKiloClawPlanCostMicrodollars,
   getKiloClawPricingCatalogEntry,
   insertKiloClawSubscriptionChangeLog,
+  resolveKiloClawEnrollmentPriceVersion,
   maySelectKiloClawCommit,
   PersonalSubscriptionCollapseUQConflictError,
 } from '@kilocode/db';
@@ -1979,8 +1979,14 @@ async function getPersonalBillingStatus(user: {
 
   const creditIntroEligible = !(await hadPriorPaidSubscription(user.id));
   const creditBalanceMicrodollars = user.total_microdollars_acquired - user.microdollars_used;
-  const creditEnrollmentPriceVersion =
-    sub?.status === 'trialing' ? sub.kiloclaw_price_version : CURRENT_KILOCLAW_PRICE_VERSION;
+  const creditEnrollmentPriceVersion = resolveKiloClawEnrollmentPriceVersion(
+    sub
+      ? {
+          status: sub.status,
+          kiloclawPriceVersion: sub.kiloclaw_price_version,
+        }
+      : null
+  );
   const intendedPricing = getKiloClawPricingCatalogEntry(creditEnrollmentPriceVersion);
   const standardCreditCostMicrodollars = getKiloClawPlanCostMicrodollars({
     priceVersion: creditEnrollmentPriceVersion,
@@ -5030,6 +5036,41 @@ export const kiloclawRouter = createTRPCRouter({
         });
       }
 
+      if (anchorInstance.destroyed_at || !currentRow) {
+        logBillingWarning('KiloClaw direct checkout rejected before provider access', {
+          user_id: ctx.user.id,
+          instance_id: anchorInstance.id,
+          reason: anchorInstance.destroyed_at ? 'destroyed_billing_anchor' : 'missing_billing_row',
+        });
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Reprovision KiloClaw before starting a new Stripe subscription.',
+        });
+      }
+
+      const intendedPriceVersion = resolveKiloClawEnrollmentPriceVersion({
+        status: currentRow.subscription.status,
+        kiloclawPriceVersion: currentRow.subscription.kiloclaw_price_version,
+      });
+      if (
+        currentRow.subscription.status === 'canceled' &&
+        currentRow.subscription.kiloclaw_price_version !== intendedPriceVersion
+      ) {
+        logBillingWarning('KiloClaw direct checkout rejected before provider access', {
+          user_id: ctx.user.id,
+          instance_id: anchorInstance.id,
+          subscription_id: currentRow.subscription.id,
+          reason: 'incompatible_canceled_lineage',
+          persisted_price_version: currentRow.subscription.kiloclaw_price_version,
+          intended_price_version: intendedPriceVersion,
+        });
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message:
+            'This KiloClaw lineage cannot accept a new Stripe subscription. Activate hosting with credits or reprovision first.',
+        });
+      }
+
       // Guard against duplicate Stripe subscriptions: the DB check above exempts
       // trialing rows, so also verify against live Stripe state.
       const [activeSubs, trialingSubs, openSessions] = await Promise.all([
@@ -5059,10 +5100,6 @@ export const kiloclawRouter = createTRPCRouter({
         staleKiloClawSessions.map(s => stripe.checkout.sessions.expire(s.id).catch(() => {}))
       );
 
-      const intendedPriceVersion =
-        currentRow?.subscription.status === 'trialing'
-          ? currentRow.subscription.kiloclaw_price_version
-          : CURRENT_KILOCLAW_PRICE_VERSION;
       const intendedPricing = getKiloClawPricingCatalogEntry(intendedPriceVersion);
 
       // Intro pricing eligibility (spec Credit Enrollment rule 3).
@@ -5136,6 +5173,12 @@ export const kiloclawRouter = createTRPCRouter({
           throw new TRPCError({
             code: 'BAD_REQUEST',
             message: 'Provision KiloClaw first before enrolling hosting with credits.',
+          });
+        }
+        if (anchorInstance.destroyed_at) {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'Reprovision KiloClaw before enrolling hosting with credits.',
           });
         }
         resolvedInstanceId = anchorInstance.id;
@@ -5223,6 +5266,12 @@ export const kiloclawRouter = createTRPCRouter({
           message: 'Provision KiloClaw first before starting Kilo Pass hosting activation.',
         });
       }
+      if (anchorInstance.destroyed_at) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Reprovision KiloClaw before starting Kilo Pass hosting activation.',
+        });
+      }
 
       const hasBlockingSubscription = await hasBlockingPersonalKiloclawSubscriptionAtInstance({
         userId: ctx.user.id,
@@ -5246,10 +5295,14 @@ export const kiloclawRouter = createTRPCRouter({
 
       const kiloPassTier = KILO_PASS_UPSELL_TIER_MAP[input.tier];
       const kiloPassCadence = KILO_PASS_UPSELL_CADENCE_MAP[input.cadence];
-      const intendedPriceVersion =
-        currentRow?.subscription.status === 'trialing'
-          ? currentRow.subscription.kiloclaw_price_version
-          : CURRENT_KILOCLAW_PRICE_VERSION;
+      const intendedPriceVersion = resolveKiloClawEnrollmentPriceVersion(
+        currentRow
+          ? {
+              status: currentRow.subscription.status,
+              kiloclawPriceVersion: currentRow.subscription.kiloclaw_price_version,
+            }
+          : null
+      );
       const intendedPricing = getKiloClawPricingCatalogEntry(intendedPriceVersion);
       const hadPaidSubscription = await hadPriorPaidSubscription(ctx.user.id);
       const useStandardIntro =

--- a/packages/db/src/kiloclaw-pricing-catalog.ts
+++ b/packages/db/src/kiloclaw-pricing-catalog.ts
@@ -63,6 +63,22 @@ export function getKiloClawPricingCatalogEntry(priceVersion: string): KiloClawPr
   return KILOCLAW_PRICING_CATALOG[priceVersion];
 }
 
+export function resolveKiloClawEnrollmentPriceVersion(
+  subscription:
+    | {
+        status: string;
+        kiloclawPriceVersion: string;
+      }
+    | null
+    | undefined
+): KiloClawPriceVersion {
+  if (subscription?.status !== 'trialing') {
+    return CURRENT_KILOCLAW_PRICE_VERSION;
+  }
+
+  return getKiloClawPricingCatalogEntry(subscription.kiloclawPriceVersion).priceVersion;
+}
+
 export function getKiloClawPlanCostMicrodollars(params: {
   priceVersion: string;
   plan: Extract<KiloClawPlan, 'standard' | 'commit'>;


### PR DESCRIPTION
## Summary
Prevent KiloClaw checkout flows from charging or deducting against local subscription lineage that cannot settle canonically.

### Why this change is needed
Canceled legacy KiloClaw rows exposed two incompatible paths. Kilo Pass checkout selected current pricing, but return-page activation compared that intent with the historical row price and failed after Kilo Pass credits settled. A later user-initiated direct Stripe checkout could create and charge a current-price subscription even though both canonical webhook handlers rejected the local target, leaving Stripe active while local access remained canceled.

### How this is addressed
- Apply one authoritative enrollment price-version policy across checkout previews, Kilo Pass metadata, activation, and credit enrollment.
- Reject canceled legacy bundled-hosting checkout before Kilo Pass payment instead of rewriting immutable historical lineage.
- Preserve credits and the complete canceled predecessor for already-completed legacy sessions, returning a permanent support-led reprovision outcome without a hosting deduction.
- Require settled Kilo Pass base credits and revalidate instance, ownership, lineage, status, and price intent before deducting credits.
- Return typed activation outcomes so only transient settlement or operational failures offer same-session retry; permanent stale, invalid, missing, destroyed, and reprovision-required states receive distinct recovery guidance.
- Reject missing, destroyed, or incompatible canceled legacy targets before direct Stripe Checkout creates a provider session.
- Preserve valid trial, current-price, pure-credit, and intentional direct-Stripe paths, including both webhook delivery orders.
- Distinguish credit-funded hosting recovery from a separate recurring Stripe hosting subscription in billing UI.

## Human Verification
- Reproduced the original failure before implementation: canceled legacy row with current-price Kilo Pass metadata returned `Checkout hosting price version no longer matches instance`.
- Added failing review regressions proving legacy activation rewrote `2026-03-19` to `2026-05-10` and permanent activation failures were not classified for recovery.
- Verified KiloClaw billing, Kilo Pass activation, pricing policy, webhook-order, destroyed-anchor, immutable-lineage, and recovery-copy coverage across 5 focused suites with 340 passing tests.
- Reviewed behavior against KiloClaw billing, billing lifecycle, and data-model specifications.
- Ran React Doctor on changed UI files; score remained 84/100 with no regression.

## Reviewer Notes
### Human Reviewer Flags
- Existing one-subscription-per-instance schema makes safe same-instance successor creation non-trivial. This PR chooses containment: new canceled-legacy bundled checkouts fail before payment; already-paid sessions retain awarded credits and route to support-led fresh provisioning.
- No canceled legacy row has its price version, provider ownership, status, transfer pointer, or change log rewritten by recovery.
- Incompatible canceled legacy rows use the same fail-before-provider approach for direct Stripe checkout and direct credit enrollment.
- This change does not cancel, refund, or reconcile provider subscriptions or Checkout Sessions created before deployment. Existing production divergence remains an operational incident task.
- No production systems or production data were changed.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Shared price resolution preserves live trial lineage pricing and selects current pricing for fresh enrollment intent after canceled history.
- The credit-enrollment transaction detects duplicate retries first, then rolls back new deductions when canceled legacy history requires a fresh billing anchor.
- Kilo Pass activation requires a matching base issuance item, validates typed checkout metadata, rejects destroyed or organization-owned targets, and returns an exhaustive retryable/action-required outcome union.
- Canceled legacy Kilo Pass checkout is rejected before provider session creation; completed historical sessions return `requires_reprovision` without local billing mutation.
- Direct Stripe preflight runs before provider subscription/session lookups or creation for unsafe local targets.
- `subscription.created processed` emits only when a local mutation occurred.

</details>
