### PR TITLE
fix(review-memory): accept contributor feedback

### DIFF
--- a/apps/web/src/components/code-reviews/ReviewMemoryPanel.tsx
+++ b/apps/web/src/components/code-reviews/ReviewMemoryPanel.tsx
@@ -245,7 +245,7 @@ export function ReviewMemoryPanel({ organizationId, platform }: ReviewMemoryPane
             Review memory
           </CardTitle>
           <CardDescription>
-            Learn from maintainer replies to Kilo review comments and propose editable REVIEW.md
+            Learn from repository feedback on Kilo review comments and propose editable REVIEW.md
             guidance.
           </CardDescription>
         </CardHeader>
@@ -253,8 +253,8 @@ export function ReviewMemoryPanel({ organizationId, platform }: ReviewMemoryPane
           <div className="space-y-1">
             <Label htmlFor="review-memory-enabled">Enable review memory</Label>
             <p className="text-muted-foreground text-sm">
-              Disabled by default. When enabled, Kilo records the first maintainer reply to each
-              Kilo inline review comment.
+              Disabled by default. When enabled, Kilo records the first eligible repository reply to
+              each Kilo inline review comment.
             </p>
           </div>
           <Switch

--- a/apps/web/src/lib/code-reviews/review-memory/aggregation.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/aggregation.ts
@@ -141,14 +141,14 @@ function buildReviewMemoryAnalysisPrompt(input: {
     reply: event.reply_excerpt,
   }));
 
-  return `You analyze maintainer replies to Kilo's automated code-review comments for one repository.
+  return `You analyze replies to Kilo's automated code-review comments for one repository.
 
 Return strict JSON in one of these shapes:
 {"status":"no_change"}
 {"status":"propose","title":"short proposal title","rationale":"why this guidance is justified","proposedMarkdown":"standalone REVIEW.md guidance","positiveCount":0,"negativeCount":0,"neutralCount":0,"evidenceEventIds":["event ids"]}
 
 Rules:
-- Classify each maintainer reply as positive, negative, or neutral.
+- Classify each reply as positive, negative, or neutral.
 - Propose the smallest possible REVIEW.md change only when there is a clear, repeated pattern.
 - Make your proposed markdown precise and evidence-backed: prefer one sentence or bullet that names the specific file pattern, API, workflow, or review rule from the feedback; avoid broad rewrites or generic best practices.
 - Return status "no_change" when the signal is weak, one-off, contradictory, or already too repo-specific to generalize.

--- a/apps/web/src/lib/code-reviews/review-memory/change-request.test.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/change-request.test.ts
@@ -30,12 +30,14 @@ describe('review memory change requests', () => {
       rationale: 'Maintainers corrected repeated generated fixture comments.',
     });
 
-    expect(buildChangeRequestBody(proposal)).toContain(
-      '<!-- kilo-review-memory-change-request -->'
-    );
-    expect(buildChangeRequestBody(proposal)).toContain('## Proposal');
-    expect(buildChangeRequestBody(proposal)).toContain('Generated fixtures');
-    expect(buildChangeRequestBody(proposal)).toContain('## Rationale');
+    const body = buildChangeRequestBody(proposal);
+
+    expect(body).toContain('<!-- kilo-review-memory-change-request -->');
+    expect(body).toContain('## Proposal');
+    expect(body).toContain('Generated fixtures');
+    expect(body).toContain('## Rationale');
+    expect(body).toContain('Kilo analyzed recent replies to review comments');
+    expect(body).toContain('Review and edit the proposed REVIEW.md changes before merging.');
   });
 
   it('applies guarded proposal status transitions', async () => {

--- a/apps/web/src/lib/code-reviews/review-memory/change-request.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/change-request.ts
@@ -52,7 +52,7 @@ ${proposal.title}
 
 ${proposal.rationale}
 
-Kilo analyzed maintainer replies to recent review comments and found repeated feedback that this repository guidance should address. Review and edit the proposed REVIEW.md changes before merging.`;
+Kilo analyzed recent replies to review comments and found repeated feedback that this repository guidance should address. Review and edit the proposed REVIEW.md changes before merging.`;
 }
 
 export async function approveAndOpenReviewMemoryChangeRequest(input: {

--- a/apps/web/src/lib/code-reviews/review-memory/github-feedback.test.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/github-feedback.test.ts
@@ -162,7 +162,7 @@ describe('GitHub review memory feedback', () => {
     await expect(db.select().from(code_review_feedback_events)).resolves.toHaveLength(0);
   });
 
-  it('skips contributor replies to Kilo inline comments', async () => {
+  it('records contributor replies to Kilo inline comments', async () => {
     const user = await insertTestUser();
     const owner = { type: 'user' as const, id: user.id };
     await setReviewMemoryEnabled({ owner, platform: 'github', enabled: true, createdBy: user.id });
@@ -172,13 +172,45 @@ describe('GitHub review memory feedback', () => {
         parentCommentId: 353,
         body: 'I do not think this applies.',
         authorAssociation: 'CONTRIBUTOR',
+        userLogin: 'contributor',
       }),
       integration: buildIntegration(user.id),
       deliveryId: 'delivery-4b',
       fetchParentComment: parentFetcher({ userLogin: 'kilo-code[bot]' }),
     });
 
-    expect(result).toEqual({ recorded: false, reason: 'not-maintainer-reply' });
+    expect(result.recorded).toBe(true);
+    const events = await db.select().from(code_review_feedback_events);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        repo_full_name: 'acme/widgets',
+        pr_number: 42,
+        kilo_comment_id: '353',
+        reply_excerpt: 'I do not think this applies.',
+        kilo_comment_excerpt: 'Kilo review comment',
+      })
+    );
+  });
+
+  it('skips first-time contributor replies to Kilo inline comments', async () => {
+    const user = await insertTestUser();
+    const owner = { type: 'user' as const, id: user.id };
+    await setReviewMemoryEnabled({ owner, platform: 'github', enabled: true, createdBy: user.id });
+
+    const result = await handleGitHubReviewCommentReply({
+      payload: buildPayload({
+        parentCommentId: 363,
+        body: 'I do not think this applies.',
+        authorAssociation: 'FIRST_TIME_CONTRIBUTOR',
+        userLogin: 'first-time-contributor',
+      }),
+      integration: buildIntegration(user.id),
+      deliveryId: 'delivery-4c',
+      fetchParentComment: parentFetcher({ userLogin: 'kilo-code[bot]' }),
+    });
+
+    expect(result).toEqual({ recorded: false, reason: 'ineligible-author-association' });
     await expect(db.select().from(code_review_feedback_events)).resolves.toHaveLength(0);
   });
 
@@ -209,13 +241,16 @@ function buildPayload(input: {
   parentCommentId: number;
   body: string;
   authorAssociation?: PullRequestReviewCommentPayload['comment']['author_association'];
+  userLogin?: string;
 }): PullRequestReviewCommentPayload {
+  const userLogin = input.userLogin ?? 'maintainer';
+
   return {
     action: 'created',
     comment: {
       id: input.parentCommentId + 1,
       body: input.body,
-      user: { login: 'maintainer' },
+      user: { login: userLogin },
       in_reply_to_id: input.parentCommentId,
       created_at: '2026-06-01T00:00:00.000Z',
       html_url: `https://github.com/acme/widgets/pull/42#discussion_r${input.parentCommentId + 1}`,
@@ -240,7 +275,7 @@ function buildPayload(input: {
       owner: { login: 'acme' },
     },
     installation: { id: 123 },
-    sender: { login: 'maintainer' },
+    sender: { login: userLogin },
   };
 }
 

--- a/apps/web/src/lib/code-reviews/review-memory/github-feedback.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/github-feedback.ts
@@ -4,7 +4,10 @@ import {
   getGitHubReviewComment,
   type GitHubAppType,
 } from '@/lib/integrations/platforms/github/adapter';
-import type { PullRequestReviewCommentPayload } from '@/lib/integrations/platforms/github/webhook-schemas';
+import type {
+  GitHubAuthorAssociation,
+  PullRequestReviewCommentPayload,
+} from '@/lib/integrations/platforms/github/webhook-schemas';
 import { recordReplyFeedbackEvent, type ReviewMemoryOwner } from './db';
 import { isReviewMemoryEnabled } from './settings';
 
@@ -18,7 +21,12 @@ export const KILO_GITHUB_BOT_LOGINS: ReadonlySet<string> = new Set([
   'kilocode[bot]',
 ]);
 
-const MAINTAINER_AUTHOR_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+const ELIGIBLE_FEEDBACK_AUTHOR_ASSOCIATIONS = new Set<GitHubAuthorAssociation>([
+  'OWNER',
+  'MEMBER',
+  'COLLABORATOR',
+  'CONTRIBUTOR',
+]);
 export const REVIEW_MEMORY_FEEDBACK_EXCERPT_MAX_LENGTH = 2_000;
 
 export function isLikelyKiloBotActor(login: string | undefined): boolean {
@@ -48,8 +56,8 @@ export async function handleGitHubReviewCommentReply(input: {
     return { recorded: false, reason: 'bot-authored-comment' };
   }
 
-  if (!MAINTAINER_AUTHOR_ASSOCIATIONS.has(input.payload.comment.author_association)) {
-    return { recorded: false, reason: 'not-maintainer-reply' };
+  if (!ELIGIBLE_FEEDBACK_AUTHOR_ASSOCIATIONS.has(input.payload.comment.author_association)) {
+    return { recorded: false, reason: 'ineligible-author-association' };
   }
 
   const owner = ownerFromIntegration(input.integration);


### PR DESCRIPTION
## Why

Followup to https://github.com/Kilo-Org/cloud/pull/3796

GitHub can mark a helpful repo user as a contributor instead of a member. Review Memory was skipping those replies, so it missed feedback it should learn from.

## What changed

Review Memory now accepts replies from contributors when all other checks pass. New or unknown commenters are still skipped. A reply must still be to a Kilo review comment, the feature must still be turned on, and only the first reply is saved. The app text and the pull request text now match this rule.

## How to test

1. Turn on Review Memory for a GitHub repo.
2. Reply to a Kilo review comment as a contributor who has already worked on the repo.
3. Check that Review Memory stores the reply.
4. Reply as a first-time contributor and check that Review Memory skips it.