### PR TITLE
fix(review-memory): check repository write access

### DIFF
--- a/apps/web/src/lib/code-reviews/review-memory/github-feedback.test.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/github-feedback.test.ts
@@ -14,17 +14,19 @@ import {
   handleGitHubReviewCommentReply,
   REVIEW_MEMORY_FEEDBACK_EXCERPT_MAX_LENGTH,
   type FetchParentReviewComment,
+  type FetchRepositoryPermission,
 } from './github-feedback';
 import { setReviewMemoryEnabled } from './settings';
 
 describe('GitHub review memory feedback', () => {
   afterEach(async () => {
+    jest.restoreAllMocks();
     await db.delete(code_review_feedback_events);
     await db.delete(agent_configs);
     await db.delete(kilocode_users);
   });
 
-  it('records the first human reply to a Kilo inline comment', async () => {
+  it('records the first human reply with effective write access to a Kilo inline comment', async () => {
     const user = await insertTestUser();
     const owner = { type: 'user' as const, id: user.id };
     await setReviewMemoryEnabled({ owner, platform: 'github', enabled: true, createdBy: user.id });
@@ -33,10 +35,13 @@ describe('GitHub review memory feedback', () => {
       payload: buildPayload({
         parentCommentId: 101,
         body: 'This is intentional in generated code.',
+        authorAssociation: 'CONTRIBUTOR',
+        commentUserLogin: 'write-access-contributor',
       }),
       integration: buildIntegration(user.id),
       deliveryId: 'delivery-1',
       fetchParentComment: parentFetcher({ userLogin: 'kilo-code[bot]' }),
+      fetchRepositoryPermission: permissionFetcher('write'),
     });
 
     expect(result.recorded).toBe(true);
@@ -66,12 +71,14 @@ describe('GitHub review memory feedback', () => {
       integration,
       deliveryId: 'delivery-2',
       fetchParentComment,
+      fetchRepositoryPermission: permissionFetcher('write'),
     });
     const second = await handleGitHubReviewCommentReply({
       payload: buildPayload({ parentCommentId: 202, body: 'Second reply' }),
       integration,
       deliveryId: 'delivery-3',
       fetchParentComment,
+      fetchRepositoryPermission: permissionFetcher('write'),
     });
 
     expect(second.recorded).toBe(false);
@@ -106,12 +113,14 @@ describe('GitHub review memory feedback', () => {
       integration: buildIntegration(firstUser.id),
       deliveryId: 'delivery-3a',
       fetchParentComment: parentFetcher({ userLogin: 'kilo-code[bot]' }),
+      fetchRepositoryPermission: permissionFetcher('write'),
     });
     const second = await handleGitHubReviewCommentReply({
       payload: buildPayload({ parentCommentId: 252, body: 'Second owner reply' }),
       integration: buildIntegration(secondUser.id),
       deliveryId: 'delivery-3b',
       fetchParentComment: parentFetcher({ userLogin: 'kilo-code[bot]' }),
+      fetchRepositoryPermission: permissionFetcher('write'),
     });
 
     expect(first.recorded).toBe(true);
@@ -135,6 +144,7 @@ describe('GitHub review memory feedback', () => {
       integration: buildIntegration(user.id),
       deliveryId: 'delivery-3c',
       fetchParentComment: parentFetcher({ userLogin: 'kilo-code[bot]', body: longParent }),
+      fetchRepositoryPermission: permissionFetcher('write'),
     });
 
     const events = await db
@@ -150,19 +160,38 @@ describe('GitHub review memory feedback', () => {
     const user = await insertTestUser();
     const owner = { type: 'user' as const, id: user.id };
     await setReviewMemoryEnabled({ owner, platform: 'github', enabled: true, createdBy: user.id });
+    const permissionRequests: Array<Parameters<FetchRepositoryPermission>[0]> = [];
 
     const result = await handleGitHubReviewCommentReply({
       payload: buildPayload({ parentCommentId: 303, body: 'Looks wrong.' }),
       integration: buildIntegration(user.id),
       deliveryId: 'delivery-4',
       fetchParentComment: parentFetcher({ userLogin: 'octocat' }),
+      fetchRepositoryPermission: permissionFetcher('write', permissionRequests),
     });
 
     expect(result).toEqual({ recorded: false, reason: 'not-kilo-comment' });
+    expect(permissionRequests).toHaveLength(0);
     await expect(db.select().from(code_review_feedback_events)).resolves.toHaveLength(0);
   });
 
-  it('skips contributor replies to Kilo inline comments', async () => {
+  it.each([
+    {
+      label: 'read',
+      permission: 'read' as const,
+      expectedReason: 'insufficient-repository-permission',
+    },
+    {
+      label: 'none',
+      permission: 'none' as const,
+      expectedReason: 'insufficient-repository-permission',
+    },
+    {
+      label: 'unavailable',
+      permission: null,
+      expectedReason: 'repository-permission-unavailable',
+    },
+  ])('fails closed when repository permission is $label', async testCase => {
     const user = await insertTestUser();
     const owner = { type: 'user' as const, id: user.id };
     await setReviewMemoryEnabled({ owner, platform: 'github', enabled: true, createdBy: user.id });
@@ -171,37 +200,109 @@ describe('GitHub review memory feedback', () => {
       payload: buildPayload({
         parentCommentId: 353,
         body: 'I do not think this applies.',
-        authorAssociation: 'CONTRIBUTOR',
+        authorAssociation: 'OWNER',
+        commentUserLogin: `permission-${testCase.label}-user`,
+        repoFullName: `acme/permission-${testCase.label}`,
       }),
       integration: buildIntegration(user.id),
-      deliveryId: 'delivery-4b',
+      deliveryId: `delivery-4b-${testCase.label}`,
       fetchParentComment: parentFetcher({ userLogin: 'kilo-code[bot]' }),
+      fetchRepositoryPermission: permissionFetcher(testCase.permission),
     });
 
-    expect(result).toEqual({ recorded: false, reason: 'not-maintainer-reply' });
+    expect(result).toEqual({ recorded: false, reason: testCase.expectedReason });
     await expect(db.select().from(code_review_feedback_events)).resolves.toHaveLength(0);
+  });
+
+  it('caches repository permission checks for 30 minutes by normalized repository user key', async () => {
+    const user = await insertTestUser();
+    const owner = { type: 'user' as const, id: user.id };
+    await setReviewMemoryEnabled({ owner, platform: 'github', enabled: true, createdBy: user.id });
+    const integration = buildIntegration(user.id, { githubAppType: 'lite' });
+    const permissionRequests: Array<Parameters<FetchRepositoryPermission>[0]> = [];
+    const fetchRepositoryPermission = permissionFetcher('write', permissionRequests);
+    const nowSpy = jest.spyOn(Date, 'now');
+    const baseMs = new Date('2026-06-01T00:00:00.000Z').getTime();
+    nowSpy.mockReturnValue(baseMs);
+
+    await handleGitHubReviewCommentReply({
+      payload: buildPayload({
+        parentCommentId: 501,
+        body: 'First cached reply',
+        commentUserLogin: 'CacheUser',
+        repoFullName: 'CacheOwner/CacheRepo',
+      }),
+      integration,
+      deliveryId: 'delivery-cache-1',
+      fetchParentComment: parentFetcher({ userLogin: 'kilo-code[bot]' }),
+      fetchRepositoryPermission,
+    });
+    await handleGitHubReviewCommentReply({
+      payload: buildPayload({
+        parentCommentId: 502,
+        body: 'Second cached reply',
+        commentUserLogin: 'cacheuser',
+        repoFullName: 'cacheowner/cacherepo',
+      }),
+      integration,
+      deliveryId: 'delivery-cache-2',
+      fetchParentComment: parentFetcher({ userLogin: 'kilo-code[bot]' }),
+      fetchRepositoryPermission,
+    });
+
+    expect(permissionRequests).toEqual([
+      {
+        installationId: '123',
+        appType: 'lite',
+        owner: 'CacheOwner',
+        repo: 'CacheRepo',
+        username: 'CacheUser',
+      },
+    ]);
+
+    nowSpy.mockReturnValue(baseMs + 30 * 60_000 + 1);
+    await handleGitHubReviewCommentReply({
+      payload: buildPayload({
+        parentCommentId: 503,
+        body: 'Third uncached reply',
+        commentUserLogin: 'CACHEUSER',
+        repoFullName: 'CACHEOWNER/CACHEREPO',
+      }),
+      integration,
+      deliveryId: 'delivery-cache-3',
+      fetchParentComment: parentFetcher({ userLogin: 'kilo-code[bot]' }),
+      fetchRepositoryPermission,
+    });
+
+    expect(permissionRequests).toHaveLength(2);
   });
 
   it('skips replies while review memory is disabled', async () => {
     const user = await insertTestUser();
+    const permissionRequests: Array<Parameters<FetchRepositoryPermission>[0]> = [];
 
     const result = await handleGitHubReviewCommentReply({
       payload: buildPayload({ parentCommentId: 404, body: 'Please stop flagging this.' }),
       integration: buildIntegration(user.id),
       deliveryId: 'delivery-5',
       fetchParentComment: parentFetcher({ userLogin: 'kilo-code[bot]' }),
+      fetchRepositoryPermission: permissionFetcher('write', permissionRequests),
     });
 
     expect(result).toEqual({ recorded: false, reason: 'review-memory-disabled' });
+    expect(permissionRequests).toHaveLength(0);
     await expect(db.select().from(code_review_feedback_events)).resolves.toHaveLength(0);
   });
 });
 
-function buildIntegration(userId: string): PlatformIntegration {
+function buildIntegration(
+  userId: string,
+  input: { githubAppType?: PlatformIntegration['github_app_type'] } = {}
+): PlatformIntegration {
   return {
     owned_by_user_id: userId,
     owned_by_organization_id: null,
-    github_app_type: 'standard',
+    github_app_type: input.githubAppType ?? 'standard',
   } as PlatformIntegration;
 }
 
@@ -209,16 +310,23 @@ function buildPayload(input: {
   parentCommentId: number;
   body: string;
   authorAssociation?: PullRequestReviewCommentPayload['comment']['author_association'];
+  commentUserLogin?: string;
+  installationId?: number;
+  repoFullName?: string;
 }): PullRequestReviewCommentPayload {
+  const repoFullName = input.repoFullName ?? 'acme/widgets';
+  const [repoOwner, repoName] = repoFullName.split('/');
+  const commentUserLogin = input.commentUserLogin ?? 'maintainer';
+
   return {
     action: 'created',
     comment: {
       id: input.parentCommentId + 1,
       body: input.body,
-      user: { login: 'maintainer' },
+      user: { login: commentUserLogin },
       in_reply_to_id: input.parentCommentId,
       created_at: '2026-06-01T00:00:00.000Z',
-      html_url: `https://github.com/acme/widgets/pull/42#discussion_r${input.parentCommentId + 1}`,
+      html_url: `https://github.com/${repoFullName}/pull/42#discussion_r${input.parentCommentId + 1}`,
       path: 'src/widget.ts',
       line: 10,
       diff_hunk: '@@',
@@ -227,20 +335,30 @@ function buildPayload(input: {
     pull_request: {
       number: 42,
       title: 'Test PR',
-      html_url: 'https://github.com/acme/widgets/pull/42',
+      html_url: `https://github.com/${repoFullName}/pull/42`,
       user: { login: 'contributor' },
       head: { sha: 'abc123', ref: 'feature' },
       base: { ref: 'main' },
     },
     repository: {
       id: 1,
-      name: 'widgets',
-      full_name: 'acme/widgets',
+      name: repoName ?? 'widgets',
+      full_name: repoFullName,
       private: true,
-      owner: { login: 'acme' },
+      owner: { login: repoOwner ?? 'acme' },
     },
-    installation: { id: 123 },
-    sender: { login: 'maintainer' },
+    installation: { id: input.installationId ?? 123 },
+    sender: { login: commentUserLogin },
+  };
+}
+
+function permissionFetcher(
+  permission: Awaited<ReturnType<FetchRepositoryPermission>>,
+  requests?: Array<Parameters<FetchRepositoryPermission>[0]>
+): FetchRepositoryPermission {
+  return async request => {
+    requests?.push(request);
+    return permission;
   };
 }
 

--- a/apps/web/src/lib/code-reviews/review-memory/github-feedback.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/github-feedback.ts
@@ -1,7 +1,9 @@
 import type { PlatformIntegration } from '@kilocode/db/schema';
 
 import {
+  getCollaboratorPermissionLevel,
   getGitHubReviewComment,
+  type CollaboratorPermission,
   type GitHubAppType,
 } from '@/lib/integrations/platforms/github/adapter';
 import type { PullRequestReviewCommentPayload } from '@/lib/integrations/platforms/github/webhook-schemas';
@@ -18,8 +20,16 @@ export const KILO_GITHUB_BOT_LOGINS: ReadonlySet<string> = new Set([
   'kilocode[bot]',
 ]);
 
-const MAINTAINER_AUTHOR_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
 export const REVIEW_MEMORY_FEEDBACK_EXCERPT_MAX_LENGTH = 2_000;
+const REVIEW_MEMORY_PERMISSION_CACHE_TTL_MS = 30 * 60_000;
+
+type RepositoryPermissionCacheEntry = {
+  value: CollaboratorPermission;
+  expiresAtMs: number;
+};
+
+const repositoryPermissionCache = new Map<string, RepositoryPermissionCacheEntry>();
+const repositoryPermissionInFlight = new Map<string, Promise<CollaboratorPermission | null>>();
 
 export function isLikelyKiloBotActor(login: string | undefined): boolean {
   return KILO_GITHUB_BOT_LOGINS.has(login?.toLowerCase() ?? '');
@@ -33,11 +43,20 @@ export type FetchParentReviewComment = (input: {
   commentId: number;
 }) => Promise<{ id: number; body: string; userLogin: string | null } | null>;
 
+export type FetchRepositoryPermission = (input: {
+  installationId: string;
+  appType: GitHubAppType;
+  owner: string;
+  repo: string;
+  username: string;
+}) => Promise<CollaboratorPermission | null>;
+
 export async function handleGitHubReviewCommentReply(input: {
   payload: PullRequestReviewCommentPayload;
   integration: PlatformIntegration;
   deliveryId: string;
   fetchParentComment?: FetchParentReviewComment;
+  fetchRepositoryPermission?: FetchRepositoryPermission;
 }): Promise<{ recorded: boolean; reason?: string; eventId?: string }> {
   if (input.payload.action !== 'created') return { recorded: false, reason: 'comment-not-created' };
 
@@ -46,10 +65,6 @@ export async function handleGitHubReviewCommentReply(input: {
 
   if (isLikelyKiloBotActor(input.payload.comment.user.login)) {
     return { recorded: false, reason: 'bot-authored-comment' };
-  }
-
-  if (!MAINTAINER_AUTHOR_ASSOCIATIONS.has(input.payload.comment.author_association)) {
-    return { recorded: false, reason: 'not-maintainer-reply' };
   }
 
   const owner = ownerFromIntegration(input.integration);
@@ -65,6 +80,8 @@ export async function handleGitHubReviewCommentReply(input: {
   const installationId = input.payload.installation.id.toString();
   const appType = input.integration.github_app_type ?? 'standard';
   const fetchParentComment = input.fetchParentComment ?? defaultFetchParentComment;
+  const fetchRepositoryPermission =
+    input.fetchRepositoryPermission ?? defaultFetchRepositoryPermission;
   const parent = await fetchParentComment({
     installationId,
     appType,
@@ -76,6 +93,22 @@ export async function handleGitHubReviewCommentReply(input: {
   if (!parent) return { recorded: false, reason: 'parent-comment-not-found' };
   if (!isLikelyKiloBotActor(parent.userLogin ?? undefined)) {
     return { recorded: false, reason: 'not-kilo-comment' };
+  }
+
+  const repositoryPermission = await fetchRepositoryPermissionWithCache(fetchRepositoryPermission, {
+    installationId,
+    appType,
+    owner: repoOwner,
+    repo,
+    username: input.payload.comment.user.login,
+  });
+
+  if (repositoryPermission === null) {
+    return { recorded: false, reason: 'repository-permission-unavailable' };
+  }
+
+  if (!isTrustedRepositoryPermission(repositoryPermission)) {
+    return { recorded: false, reason: 'insufficient-repository-permission' };
   }
 
   const result = await recordReplyFeedbackEvent({
@@ -106,6 +139,63 @@ function truncateReviewMemoryFeedbackExcerpt(value: string): string {
   return value.slice(0, REVIEW_MEMORY_FEEDBACK_EXCERPT_MAX_LENGTH);
 }
 
+function isTrustedRepositoryPermission(permission: CollaboratorPermission): boolean {
+  return permission === 'admin' || permission === 'write';
+}
+
+async function fetchRepositoryPermissionWithCache(
+  fetchRepositoryPermission: FetchRepositoryPermission,
+  input: Parameters<FetchRepositoryPermission>[0]
+): Promise<CollaboratorPermission | null> {
+  const cacheKey = repositoryPermissionCacheKey(input);
+  const now = Date.now();
+  const cached = repositoryPermissionCache.get(cacheKey);
+  if (cached) {
+    if (cached.expiresAtMs > now) {
+      return cached.value;
+    }
+    repositoryPermissionCache.delete(cacheKey);
+  }
+
+  const inFlight = repositoryPermissionInFlight.get(cacheKey);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const promise = (async () => {
+    const permission = await fetchRepositoryPermission(input);
+    if (permission !== null) {
+      repositoryPermissionCache.set(cacheKey, {
+        value: permission,
+        expiresAtMs: Date.now() + REVIEW_MEMORY_PERMISSION_CACHE_TTL_MS,
+      });
+    }
+    return permission;
+  })();
+
+  repositoryPermissionInFlight.set(cacheKey, promise);
+
+  try {
+    return await promise;
+  } finally {
+    repositoryPermissionInFlight.delete(cacheKey);
+  }
+}
+
+function repositoryPermissionCacheKey(input: Parameters<FetchRepositoryPermission>[0]): string {
+  return JSON.stringify([
+    normalizeCacheKeyComponent(input.installationId),
+    normalizeCacheKeyComponent(input.appType),
+    normalizeCacheKeyComponent(input.owner),
+    normalizeCacheKeyComponent(input.repo),
+    normalizeCacheKeyComponent(input.username),
+  ]);
+}
+
+function normalizeCacheKeyComponent(value: string): string {
+  return value.trim().toLowerCase();
+}
+
 const defaultFetchParentComment: FetchParentReviewComment = async input => {
   const comment = await getGitHubReviewComment(
     input.installationId,
@@ -116,4 +206,14 @@ const defaultFetchParentComment: FetchParentReviewComment = async input => {
   );
   if (!comment) return null;
   return { id: comment.id, body: comment.body, userLogin: comment.userLogin };
+};
+
+const defaultFetchRepositoryPermission: FetchRepositoryPermission = async input => {
+  return getCollaboratorPermissionLevel(
+    input.installationId,
+    input.owner,
+    input.repo,
+    input.username,
+    input.appType
+  );
 };

--- a/apps/web/src/lib/integrations/platforms/github/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.ts
@@ -344,7 +344,7 @@ export async function addReactionToPRReviewComment(
  * if the lookup fails (e.g. the App lacks permission to query collaborators).
  * @param appType - The type of GitHub App to use (defaults to 'standard')
  */
-type CollaboratorPermission = 'admin' | 'write' | 'read' | 'none';
+export type CollaboratorPermission = 'admin' | 'write' | 'read' | 'none';
 
 const KNOWN_PERMISSIONS = new Set<string>(['admin', 'write', 'read', 'none']);
 


### PR DESCRIPTION
## Summary

- Authorize Review Memory replies with the reply author's current GitHub repository access instead of the webhook label.
- Record feedback only for write or admin access, and skip safely when access is read-only or cannot be checked.
- Reuse known access results for 30 minutes in a warm server process to avoid repeated GitHub calls.

## Verification

N/A - no production webhook was replayed because doing so would create GitHub activity and production data.

## Visual Changes

N/A

## Reviewer Notes

Production investigation found that `Kilo-Org/cloud` reply webhooks were labeled `CONTRIBUTOR` even for developers who had write, maintain, or admin access. The cache lives only in one running server process, so another server may repeat a GitHub lookup. Access changes can take up to 30 minutes to affect a warm process. Lookup failures are not cached and fail closed. This PR does not backfill past webhook events.