### PR TITLE
Feat/kiloclaw image model catalog refresh

### DIFF
--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-06-16',
+    description:
+      "Fixed image recognition for KiloClaw agents. Images sent to an agent could not be processed and failed with 'model does not support images', because the models that support images were not being offered to the image pipeline. KiloClaw now refreshes the model list so image understanding works again. Redeploy your instance to pick up the fix.",
+    category: 'bugfix',
+    deployHint: 'redeploy_required',
+  },
+  {
     date: '2026-06-15',
     description: 'OpenClaw 2026.6.5 is now generally available to everyone.',
     category: 'feature',

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -52,6 +52,7 @@ import { writeGogCredentials } from './gog-credentials';
 import { installGogShim } from './gog-shim';
 import { migrateLegacyGoogleCredentialsToBroker } from './legacy-google-migration';
 import { startWatchRenewal, stopWatchRenewal } from './gmail-watch-renewal';
+import { startModelCatalogRefresh, stopModelCatalogRefresh } from './model-catalog-refresh';
 import { bootstrapCritical, bootstrapNonCritical, cleanNpmCache } from './bootstrap';
 import type { ControllerStateRef, ControllerState } from './bootstrap';
 import { getOpenclawVersion } from './openclaw-version';
@@ -300,6 +301,7 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     pairingCache?.cleanup();
     stopCheckin?.();
     stopWatchRenewal();
+    stopModelCatalogRefresh();
     const shutdowns: Promise<void>[] = [];
     if (supervisor) shutdowns.push(supervisor.shutdown(signal));
     if (gmailWatchSupervisor) shutdowns.push(gmailWatchSupervisor.shutdown(signal));
@@ -587,6 +589,9 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
   try {
     await supervisor.start();
     pc.start();
+    // Seed the kilocode model catalog into openclaw.json so OpenClaw's image
+    // capability gate sees vision modalities (TEMPORARY — see model-catalog-refresh.ts).
+    startModelCatalogRefresh(env);
     if (gmailWatchSupervisor && googleAccountEmail) {
       await gmailWatchSupervisor.start();
       startWatchRenewal(googleAccountEmail);

--- a/services/kiloclaw/controller/src/model-catalog-refresh.test.ts
+++ b/services/kiloclaw/controller/src/model-catalog-refresh.test.ts
@@ -40,7 +40,7 @@ const sampleResponse = {
 const baseEnv = {
   KILOCODE_API_KEY: 'secret-key',
   KILOCODE_ORGANIZATION_ID: 'org-1',
-} as NodeJS.ProcessEnv;
+} as unknown as NodeJS.ProcessEnv;
 
 function makeConfig(): Record<string, unknown> {
   return {
@@ -143,7 +143,7 @@ describe('fetchModelCatalog', () => {
 
   it('throws when the API key is missing', async () => {
     await expect(
-      fetchModelCatalog({} as NodeJS.ProcessEnv, {
+      fetchModelCatalog({} as unknown as NodeJS.ProcessEnv, {
         fetch: vi.fn(),
         readConfig: vi.fn(),
         writeConfig: vi.fn(),
@@ -259,7 +259,7 @@ describe('startModelCatalogRefresh', () => {
   it('is disabled when the API key is absent', async () => {
     vi.useFakeTimers();
     const deps = timerDeps();
-    startModelCatalogRefresh({} as NodeJS.ProcessEnv, '/cfg.json', deps);
+    startModelCatalogRefresh({} as unknown as NodeJS.ProcessEnv, '/cfg.json', deps);
 
     await vi.advanceTimersByTimeAsync(30 * 1000 + 24 * 60 * 60 * 1000);
     expect(deps.fetch).not.toHaveBeenCalled();

--- a/services/kiloclaw/controller/src/model-catalog-refresh.test.ts
+++ b/services/kiloclaw/controller/src/model-catalog-refresh.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  fetchModelCatalog,
+  refreshModelCatalog,
+  startModelCatalogRefresh,
+  stopModelCatalogRefresh,
+} from './model-catalog-refresh';
+
+function mockResponse(body: unknown, ok = true, status = 200): Response {
+  return { ok, status, json: async () => body } as unknown as Response;
+}
+
+const sampleResponse = {
+  data: [
+    {
+      id: 'anthropic/claude-sonnet-4.6',
+      name: 'Claude Sonnet 4.6',
+      architecture: { input_modalities: ['text', 'image'] },
+      supported_parameters: ['reasoning', 'tools'],
+      pricing: {
+        prompt: '0.000003',
+        completion: '0.000015',
+        input_cache_read: '0.0000003',
+        input_cache_write: '0.00000375',
+      },
+      context_length: 1_000_000,
+      top_provider: { max_completion_tokens: 64_000 },
+    },
+    {
+      id: 'some/text-only',
+      name: 'Text Only',
+      architecture: { input_modalities: ['text'] },
+      supported_parameters: ['tools'],
+      pricing: { prompt: '0.000001', completion: '0.000002' },
+      context_length: 128_000,
+    },
+  ],
+};
+
+const baseEnv = {
+  KILOCODE_API_KEY: 'secret-key',
+  KILOCODE_ORGANIZATION_ID: 'org-1',
+} as NodeJS.ProcessEnv;
+
+function makeConfig(): Record<string, unknown> {
+  return {
+    other: 'preserved',
+    models: {
+      providers: {
+        kilocode: {
+          baseUrl: 'https://api.kilo.ai/api/gateway/',
+          api: 'openai-completions',
+          models: [],
+          headers: { 'X-KiloCode-OrganizationId': 'org-1' },
+        },
+      },
+    },
+  };
+}
+
+describe('fetchModelCatalog', () => {
+  it('maps vision and text-only modalities, pricing, and reasoning', async () => {
+    const deps = {
+      fetch: vi.fn(async () => mockResponse(sampleResponse)),
+      readConfig: vi.fn(),
+      writeConfig: vi.fn(),
+    };
+
+    const models = await fetchModelCatalog(baseEnv, deps);
+
+    expect(models).toHaveLength(2);
+    const sonnet = models[0];
+    expect(sonnet.id).toBe('anthropic/claude-sonnet-4.6');
+    expect(sonnet.input).toEqual(['text', 'image']);
+    expect(sonnet.reasoning).toBe(true);
+    expect(sonnet.contextWindow).toBe(1_000_000);
+    expect(sonnet.maxTokens).toBe(64_000);
+    // per-token string price -> per-million number
+    expect(sonnet.cost.input).toBeCloseTo(3);
+    expect(sonnet.cost.output).toBeCloseTo(15);
+
+    const textOnly = models[1];
+    expect(textOnly.input).toEqual(['text']);
+    expect(textOnly.reasoning).toBe(false);
+    expect(textOnly.maxTokens).toBe(128_000); // default when top_provider absent
+  });
+
+  it('sends auth, org, and feature headers', async () => {
+    const fetchMock = vi.fn(async () => mockResponse(sampleResponse));
+    await fetchModelCatalog(baseEnv, {
+      fetch: fetchMock,
+      readConfig: vi.fn(),
+      writeConfig: vi.fn(),
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://api.kilo.ai/api/gateway/models');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer secret-key');
+    expect(headers['X-KiloCode-OrganizationId']).toBe('org-1');
+    expect(headers['x-kilocode-feature']).toBe('kiloclaw');
+  });
+
+  it('throws when the API key is missing', async () => {
+    await expect(
+      fetchModelCatalog({} as NodeJS.ProcessEnv, {
+        fetch: vi.fn(),
+        readConfig: vi.fn(),
+        writeConfig: vi.fn(),
+      })
+    ).rejects.toThrow(/KILOCODE_API_KEY/);
+  });
+
+  it('throws on a non-OK gateway response', async () => {
+    await expect(
+      fetchModelCatalog(baseEnv, {
+        fetch: vi.fn(async () => mockResponse({}, false, 503)),
+        readConfig: vi.fn(),
+        writeConfig: vi.fn(),
+      })
+    ).rejects.toThrow(/HTTP 503/);
+  });
+});
+
+describe('refreshModelCatalog', () => {
+  it('writes mapped models while preserving other config fields', async () => {
+    const writeConfig = vi.fn();
+    const result = await refreshModelCatalog(baseEnv, '/cfg.json', {
+      fetch: vi.fn(async () => mockResponse(sampleResponse)),
+      readConfig: vi.fn(() => JSON.stringify(makeConfig())),
+      writeConfig,
+    });
+
+    expect(result).toEqual({ written: true, count: 2 });
+    const written = JSON.parse(writeConfig.mock.calls[0][1] as string);
+    const kilocode = written.models.providers.kilocode;
+    expect(kilocode.models).toHaveLength(2);
+    expect(kilocode.models[0].input).toEqual(['text', 'image']);
+    // untouched fields preserved
+    expect(kilocode.baseUrl).toBe('https://api.kilo.ai/api/gateway/');
+    expect(kilocode.headers['X-KiloCode-OrganizationId']).toBe('org-1');
+    expect(written.other).toBe('preserved');
+  });
+
+  it('skips the write when the kilocode provider block is absent', async () => {
+    const writeConfig = vi.fn();
+    const result = await refreshModelCatalog(baseEnv, '/cfg.json', {
+      fetch: vi.fn(async () => mockResponse(sampleResponse)),
+      readConfig: vi.fn(() => JSON.stringify({ models: { providers: {} } })),
+      writeConfig,
+    });
+
+    expect(result).toEqual({ written: false, count: 0 });
+    expect(writeConfig).not.toHaveBeenCalled();
+  });
+
+  it('skips the write when the gateway returns no models', async () => {
+    const writeConfig = vi.fn();
+    const result = await refreshModelCatalog(baseEnv, '/cfg.json', {
+      fetch: vi.fn(async () => mockResponse({ data: [] })),
+      readConfig: vi.fn(() => JSON.stringify(makeConfig())),
+      writeConfig,
+    });
+
+    expect(result).toEqual({ written: false, count: 0 });
+    expect(writeConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('startModelCatalogRefresh', () => {
+  afterEach(() => {
+    stopModelCatalogRefresh();
+    vi.useRealTimers();
+  });
+
+  function timerDeps() {
+    return {
+      fetch: vi.fn(async () => mockResponse(sampleResponse)),
+      readConfig: vi.fn(() => JSON.stringify(makeConfig())),
+      writeConfig: vi.fn(),
+    };
+  }
+
+  it('does not fetch immediately on start', () => {
+    vi.useFakeTimers();
+    const deps = timerDeps();
+    startModelCatalogRefresh(baseEnv, '/cfg.json', deps);
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches after the initial delay, then repeats daily', async () => {
+    vi.useFakeTimers();
+    const deps = timerDeps();
+    startModelCatalogRefresh(baseEnv, '/cfg.json', deps);
+
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(deps.fetch).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+    expect(deps.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('is disabled when the API key is absent', async () => {
+    vi.useFakeTimers();
+    const deps = timerDeps();
+    startModelCatalogRefresh({} as NodeJS.ProcessEnv, '/cfg.json', deps);
+
+    await vi.advanceTimersByTimeAsync(30 * 1000 + 24 * 60 * 60 * 1000);
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not leak timers on double-start', async () => {
+    vi.useFakeTimers();
+    const deps = timerDeps();
+    startModelCatalogRefresh(baseEnv, '/cfg.json', deps);
+    startModelCatalogRefresh(baseEnv, '/cfg.json', deps);
+
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(deps.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop cancels the pending refresh', async () => {
+    vi.useFakeTimers();
+    const deps = timerDeps();
+    startModelCatalogRefresh(baseEnv, '/cfg.json', deps);
+    stopModelCatalogRefresh();
+
+    await vi.advanceTimersByTimeAsync(30 * 1000 + 24 * 60 * 60 * 1000);
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/services/kiloclaw/controller/src/model-catalog-refresh.test.ts
+++ b/services/kiloclaw/controller/src/model-catalog-refresh.test.ts
@@ -101,6 +101,46 @@ describe('fetchModelCatalog', () => {
     expect(headers['x-kilocode-feature']).toBe('kiloclaw');
   });
 
+  it('accepts null max_completion_tokens/context_length without rejecting the batch', async () => {
+    const body = {
+      data: [
+        {
+          id: 'm/nullable',
+          architecture: { input_modalities: ['text', 'image'] },
+          top_provider: { max_completion_tokens: null },
+          context_length: null,
+        },
+      ],
+    };
+    const models = await fetchModelCatalog(baseEnv, {
+      fetch: vi.fn(async () => mockResponse(body)),
+      readConfig: vi.fn(),
+      writeConfig: vi.fn(),
+    });
+
+    expect(models).toHaveLength(1);
+    expect(models[0].input).toEqual(['text', 'image']);
+    expect(models[0].maxTokens).toBe(128_000);
+    expect(models[0].contextWindow).toBe(1_000_000);
+  });
+
+  it('skips unparseable entries instead of failing the whole catalog', async () => {
+    const body = {
+      data: [
+        { id: 'ok/model', architecture: { input_modalities: ['text'] } },
+        { name: 'missing-id' },
+        42,
+      ],
+    };
+    const models = await fetchModelCatalog(baseEnv, {
+      fetch: vi.fn(async () => mockResponse(body)),
+      readConfig: vi.fn(),
+      writeConfig: vi.fn(),
+    });
+
+    expect(models.map(m => m.id)).toEqual(['ok/model']);
+  });
+
   it('throws when the API key is missing', async () => {
     await expect(
       fetchModelCatalog({} as NodeJS.ProcessEnv, {
@@ -140,6 +180,22 @@ describe('refreshModelCatalog', () => {
     expect(kilocode.baseUrl).toBe('https://api.kilo.ai/api/gateway/');
     expect(kilocode.headers['X-KiloCode-OrganizationId']).toBe('org-1');
     expect(written.other).toBe('preserved');
+  });
+
+  it('skips the write when the catalog is byte-for-byte unchanged', async () => {
+    const fetchMock = vi.fn(async () => mockResponse(sampleResponse));
+    let stored = JSON.stringify(makeConfig());
+    const writeConfig = vi.fn((_p: string, data: string) => {
+      stored = data;
+    });
+    const deps = { fetch: fetchMock, readConfig: vi.fn(() => stored), writeConfig };
+
+    const first = await refreshModelCatalog(baseEnv, '/cfg.json', deps);
+    expect(first.written).toBe(true);
+
+    const second = await refreshModelCatalog(baseEnv, '/cfg.json', deps);
+    expect(second.written).toBe(false);
+    expect(writeConfig).toHaveBeenCalledTimes(1);
   });
 
   it('skips the write when the kilocode provider block is absent', async () => {

--- a/services/kiloclaw/controller/src/model-catalog-refresh.ts
+++ b/services/kiloclaw/controller/src/model-catalog-refresh.ts
@@ -35,6 +35,13 @@ const INITIAL_REFRESH_DELAY_MS = 30 * 1000;
 const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 30 * 1000;
 
+// Numeric/price fields can be `null` in the gateway/OpenRouter contract (e.g.
+// `top_provider.max_completion_tokens` is routinely null), so every optional
+// number/price is also nullable — otherwise one null model would fail the
+// schema. We additionally parse entries individually (see fetchModelCatalog)
+// so a single unexpected entry can never reject the whole catalog.
+const priceField = z.union([z.string(), z.number()]).nullable().optional();
+
 /** Subset of the Kilo Gateway `/models` response we map into the catalog. */
 const GatewayModelSchema = z
   .object({
@@ -44,18 +51,19 @@ const GatewayModelSchema = z
     supported_parameters: z.array(z.string()).optional(),
     pricing: z
       .object({
-        prompt: z.union([z.string(), z.number()]).optional(),
-        completion: z.union([z.string(), z.number()]).optional(),
-        input_cache_read: z.union([z.string(), z.number()]).optional(),
-        input_cache_write: z.union([z.string(), z.number()]).optional(),
+        prompt: priceField,
+        completion: priceField,
+        input_cache_read: priceField,
+        input_cache_write: priceField,
       })
       .optional(),
-    context_length: z.number().optional(),
-    top_provider: z.object({ max_completion_tokens: z.number().optional() }).optional(),
+    context_length: z.number().nullable().optional(),
+    top_provider: z.object({ max_completion_tokens: z.number().nullable().optional() }).optional(),
   })
   .passthrough();
 
-const GatewayModelsResponseSchema = z.object({ data: z.array(GatewayModelSchema) });
+// Only require the envelope shape here; each entry is validated individually.
+const GatewayResponseSchema = z.object({ data: z.array(z.unknown()) });
 
 /** OpenClaw provider model-definition shape written into the config. */
 export type OpenClawModelDef = {
@@ -80,7 +88,7 @@ const defaultDeps: ModelCatalogRefreshDeps = {
   writeConfig: (p, data) => atomicWrite(p, data, undefined, { mode: CONFIG_FILE_MODE }),
 };
 
-function toPricePerMillion(value: string | number | undefined): number {
+function toPricePerMillion(value: string | number | null | undefined): number {
   const n = typeof value === 'number' ? value : Number(value);
   return Number.isFinite(n) && n >= 0 ? n * 1_000_000 : 0;
 }
@@ -138,8 +146,21 @@ export async function fetchModelCatalog(
   if (!res.ok) {
     throw new Error(`gateway /models returned HTTP ${res.status}`);
   }
-  const parsed = GatewayModelsResponseSchema.parse(await res.json());
-  return parsed.data.map(mapGatewayModel);
+  const parsed = GatewayResponseSchema.parse(await res.json());
+  const models: OpenClawModelDef[] = [];
+  let skipped = 0;
+  for (const raw of parsed.data) {
+    const entry = GatewayModelSchema.safeParse(raw);
+    if (!entry.success) {
+      skipped++;
+      continue;
+    }
+    models.push(mapGatewayModel(entry.data));
+  }
+  if (skipped > 0) {
+    console.warn(`[model-catalog-refresh] skipped ${skipped} unparseable model entries`);
+  }
+  return models;
 }
 
 /**
@@ -159,6 +180,12 @@ export async function refreshModelCatalog(
     return { written: false, count: 0 };
   }
 
+  // Read-modify-write is a single synchronous tick (no await between read and
+  // write), so no other handler in this controller process — config restore,
+  // patch, agent mutation — can interleave and have its write silently lost.
+  // The only residual window is the external OpenClaw gateway process writing
+  // this file between readFileSync and renameSync; skip-when-unchanged below
+  // keeps writes rare enough that this is negligible for a temporary shim.
   const config: unknown = JSON.parse(deps.readConfig(configPath));
   const kilocode = (config as { models?: { providers?: Record<string, unknown> } })?.models
     ?.providers?.kilocode;
@@ -167,6 +194,12 @@ export async function refreshModelCatalog(
       '[model-catalog-refresh] kilocode provider block missing; skipping (config-writer owns creation)'
     );
     return { written: false, count: 0 };
+  }
+
+  const current = (kilocode as { models?: unknown }).models;
+  if (JSON.stringify(current) === JSON.stringify(models)) {
+    // Catalog unchanged — avoid a needless write and OpenClaw hot reload.
+    return { written: false, count: models.length };
   }
 
   (kilocode as { models: OpenClawModelDef[] }).models = models;

--- a/services/kiloclaw/controller/src/model-catalog-refresh.ts
+++ b/services/kiloclaw/controller/src/model-catalog-refresh.ts
@@ -1,0 +1,221 @@
+/**
+ * Periodically seeds the kilocode provider's model catalog into openclaw.json.
+ *
+ * TEMPORARY WORKAROUND (Pylon #21841). OpenClaw's live model discovery never
+ * populates the agent model registry for the kilocode provider, so the
+ * image-capability gate resolves every model as text-only (`input: ["text"]`)
+ * and refuses vision — even though the Kilo Gateway advertises the correct
+ * `["text","image"]` modalities. We work around it by writing the live gateway
+ * catalog into `models.providers.kilocode.models`, which the capability gate
+ * DOES read.
+ *
+ * OpenClaw hot-reloads openclaw.json on change — a `models.providers.*.models`
+ * edit is a hot reload, not a restart — so a write takes effect within ~1s with
+ * no gateway bounce.
+ *
+ * Cadence: a short delay after boot (so config-writer has finished its
+ * `models: []` write and the gateway's file watcher is active), then daily. A
+ * model newly added to the gateway becomes vision-capable on the instance
+ * within one refresh interval (or on the next controller start).
+ *
+ * Remove once OpenClaw feeds discovery into the model registry / capability
+ * resolution.
+ */
+import fs from 'node:fs';
+import { z } from 'zod';
+import { atomicWrite } from './atomic-write';
+
+const DEFAULT_CONFIG_PATH = '/root/.openclaw/openclaw.json';
+const DEFAULT_GATEWAY_BASE_URL = 'https://api.kilo.ai/api/gateway/';
+
+// openclaw.json holds secrets (API keys, gateway token); keep it owner-only.
+const CONFIG_FILE_MODE = 0o600;
+
+const INITIAL_REFRESH_DELAY_MS = 30 * 1000;
+const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 30 * 1000;
+
+/** Subset of the Kilo Gateway `/models` response we map into the catalog. */
+const GatewayModelSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    architecture: z.object({ input_modalities: z.array(z.string()).optional() }).optional(),
+    supported_parameters: z.array(z.string()).optional(),
+    pricing: z
+      .object({
+        prompt: z.union([z.string(), z.number()]).optional(),
+        completion: z.union([z.string(), z.number()]).optional(),
+        input_cache_read: z.union([z.string(), z.number()]).optional(),
+        input_cache_write: z.union([z.string(), z.number()]).optional(),
+      })
+      .optional(),
+    context_length: z.number().optional(),
+    top_provider: z.object({ max_completion_tokens: z.number().optional() }).optional(),
+  })
+  .passthrough();
+
+const GatewayModelsResponseSchema = z.object({ data: z.array(GatewayModelSchema) });
+
+/** OpenClaw provider model-definition shape written into the config. */
+export type OpenClawModelDef = {
+  id: string;
+  name: string;
+  reasoning: boolean;
+  input: Array<'text' | 'image'>;
+  cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  contextWindow: number;
+  maxTokens: number;
+};
+
+export type ModelCatalogRefreshDeps = {
+  fetch: typeof fetch;
+  readConfig: (path: string) => string;
+  writeConfig: (path: string, data: string) => void;
+};
+
+const defaultDeps: ModelCatalogRefreshDeps = {
+  fetch: (...args) => fetch(...args),
+  readConfig: p => fs.readFileSync(p, 'utf8'),
+  writeConfig: (p, data) => atomicWrite(p, data, undefined, { mode: CONFIG_FILE_MODE }),
+};
+
+function toPricePerMillion(value: string | number | undefined): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) && n >= 0 ? n * 1_000_000 : 0;
+}
+
+function mapGatewayModel(entry: z.infer<typeof GatewayModelSchema>): OpenClawModelDef {
+  const modalities = entry.architecture?.input_modalities ?? [];
+  const supportsImage = modalities.some(m => m.toLowerCase() === 'image');
+  const params = entry.supported_parameters ?? [];
+  return {
+    id: entry.id,
+    name: entry.name || entry.id,
+    reasoning: params.includes('reasoning') || params.includes('include_reasoning'),
+    input: supportsImage ? ['text', 'image'] : ['text'],
+    cost: {
+      input: toPricePerMillion(entry.pricing?.prompt),
+      output: toPricePerMillion(entry.pricing?.completion),
+      cacheRead: toPricePerMillion(entry.pricing?.input_cache_read),
+      cacheWrite: toPricePerMillion(entry.pricing?.input_cache_write),
+    },
+    contextWindow: entry.context_length ?? 1_000_000,
+    maxTokens: entry.top_provider?.max_completion_tokens ?? 128_000,
+  };
+}
+
+function resolveGatewayModelsUrl(env: NodeJS.ProcessEnv): string {
+  const base = env.KILOCODE_API_BASE_URL || DEFAULT_GATEWAY_BASE_URL;
+  return new URL('models', base.endsWith('/') ? base : `${base}/`).toString();
+}
+
+/**
+ * Fetches the live model catalog from the Kilo Gateway and maps it into the
+ * OpenClaw provider model-definition shape. Uses the same auth/org/feature
+ * headers as the instance so the catalog matches what this org can actually
+ * use. Throws on missing key or non-OK response.
+ */
+export async function fetchModelCatalog(
+  env: NodeJS.ProcessEnv,
+  deps: ModelCatalogRefreshDeps = defaultDeps
+): Promise<OpenClawModelDef[]> {
+  const apiKey = env.KILOCODE_API_KEY;
+  if (!apiKey) {
+    throw new Error('KILOCODE_API_KEY not set; cannot fetch model catalog');
+  }
+  const res = await deps.fetch(resolveGatewayModelsUrl(env), {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      'x-kilocode-feature': env.KILOCODE_FEATURE || 'kiloclaw',
+      ...(env.KILOCODE_ORGANIZATION_ID
+        ? { 'X-KiloCode-OrganizationId': env.KILOCODE_ORGANIZATION_ID }
+        : {}),
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`gateway /models returned HTTP ${res.status}`);
+  }
+  const parsed = GatewayModelsResponseSchema.parse(await res.json());
+  return parsed.data.map(mapGatewayModel);
+}
+
+/**
+ * Fetches the catalog and writes it into `models.providers.kilocode.models`,
+ * preserving every other field. Skips the write (leaving the existing config
+ * untouched) when the fetch yields nothing or the kilocode provider block does
+ * not yet exist — config-writer owns creating that block at boot.
+ */
+export async function refreshModelCatalog(
+  env: NodeJS.ProcessEnv,
+  configPath: string = DEFAULT_CONFIG_PATH,
+  deps: ModelCatalogRefreshDeps = defaultDeps
+): Promise<{ written: boolean; count: number }> {
+  const models = await fetchModelCatalog(env, deps);
+  if (models.length === 0) {
+    console.warn('[model-catalog-refresh] gateway returned 0 models; leaving config unchanged');
+    return { written: false, count: 0 };
+  }
+
+  const config: unknown = JSON.parse(deps.readConfig(configPath));
+  const kilocode = (config as { models?: { providers?: Record<string, unknown> } })?.models
+    ?.providers?.kilocode;
+  if (!kilocode || typeof kilocode !== 'object') {
+    console.warn(
+      '[model-catalog-refresh] kilocode provider block missing; skipping (config-writer owns creation)'
+    );
+    return { written: false, count: 0 };
+  }
+
+  (kilocode as { models: OpenClawModelDef[] }).models = models;
+  deps.writeConfig(configPath, JSON.stringify(config, null, 2));
+  console.log(`[model-catalog-refresh] seeded ${models.length} kilocode models into ${configPath}`);
+  return { written: true, count: models.length };
+}
+
+let initialTimeout: ReturnType<typeof setTimeout> | null = null;
+let refreshInterval: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Starts the periodic catalog refresh: once shortly after boot, then daily.
+ * No-op when `KILOCODE_API_KEY` is absent (nothing to authenticate the fetch).
+ */
+export function startModelCatalogRefresh(
+  env: NodeJS.ProcessEnv,
+  configPath: string = DEFAULT_CONFIG_PATH,
+  deps: ModelCatalogRefreshDeps = defaultDeps
+): void {
+  if (initialTimeout !== null || refreshInterval !== null) {
+    stopModelCatalogRefresh();
+  }
+  if (!env.KILOCODE_API_KEY) {
+    console.warn('[model-catalog-refresh] KILOCODE_API_KEY not set; refresh disabled');
+    return;
+  }
+
+  async function run(): Promise<void> {
+    try {
+      await refreshModelCatalog(env, configPath, deps);
+    } catch (err) {
+      console.error('[model-catalog-refresh] refresh failed:', err);
+    }
+  }
+
+  initialTimeout = setTimeout(() => {
+    void run();
+    refreshInterval = setInterval(() => void run(), REFRESH_INTERVAL_MS);
+  }, INITIAL_REFRESH_DELAY_MS);
+}
+
+export function stopModelCatalogRefresh(): void {
+  if (initialTimeout !== null) {
+    clearTimeout(initialTimeout);
+    initialTimeout = null;
+  }
+  if (refreshInterval !== null) {
+    clearInterval(refreshInterval);
+    refreshInterval = null;
+  }
+}


### PR DESCRIPTION
## Summary

OpenClaw's live model discovery does not populate the agent model registry that
capability resolution reads, so kilocode provider models resolve as text-only and
image understanding is refused even though the Kilo Gateway advertises vision
support. This adds a temporary workaround in the controller: it periodically
fetches the gateway model catalog and writes it into
`models.providers.kilocode.models` in `openclaw.json`, which the capability gate
does read. OpenClaw hot-reloads that change without a restart. Remove this once
OpenClaw feeds discovery into capability resolution.

## Changes

- New `services/kiloclaw/controller/src/model-catalog-refresh.ts`:
  - Fetches `GET /api/gateway/models` using the instance's API key, organization,
    and feature headers.
  - Validates the response with zod per entry (tolerant of null numeric/price
    fields) and skips any entry that does not parse, so one bad entry cannot drop
    the whole catalog.
  - Maps each model to the OpenClaw provider model shape, deriving `input`
    modalities (`text` / `image`) from `architecture.input_modalities`.
  - Writes `models.providers.kilocode.models` with `atomicWrite` (mode `0o600`),
    preserving all other config fields. Skips the write when the catalog is
    unchanged or when the kilocode provider block does not exist yet.
  - Runs once about 30 seconds after the gateway starts, then every 24 hours.
    Follows the existing `gmail-watch-renewal` timer pattern, and is a no-op when
    `KILOCODE_API_KEY` is unset.
- `services/kiloclaw/controller/src/index.ts`: starts the refresh after the
  gateway starts and stops it during shutdown.
- Unit tests covering mapping, header auth, null/unparseable entries, the
  skip-when-unchanged and missing-block guards, and the start/stop scheduling.

## Verification

- [x] Ran the built image locally in Docker. About 30 seconds after gateway start
  the controller logged `[model-catalog-refresh] seeded 332 kilocode models`,
  `openclaw.json` `models.providers.kilocode.models` held 332 entries with
  `anthropic/claude-sonnet-4.6` as `["text","image"]`, and the gateway logged
  `config hot reload applied (models.providers.kilocode.models)` with no restart.
  `openclaw infer image describe` no longer fails the capability gate with
  "model does not support images ... input: text"; it now reaches the model (the
  local image's key returns a 401 sign-in error, unrelated to this change).

## Visual Changes

N/A

## Reviewer Notes

- This is a temporary workaround. The real fix is in OpenClaw (feeding live
  discovery into the model registry / capability resolution); this module should
  be removed when that lands.
- `config-writer` still writes `models: []` at boot, doctor, and restore. The
  refresh re-seeds after those events; the initial run is about 30 seconds after
  gateway start, so there is a short window where the catalog is empty.
- Concurrency: the read, mutate, and write run in one synchronous step (no await
  between read and write), so no in-process writer can lose an update. The only
  residual is the external gateway process writing the file in the brief window
  between read and rename, which skip-when-unchanged keeps rare.
- The seeded `models` array is the full gateway catalog (a few hundred entries)
  written into `openclaw.json` and re-read on hot reload.
