### PR TITLE
fix(ai-gateway): defer model retirement labels

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -59,6 +59,14 @@ function buildModel(overrides: Partial<OpenRouterModel> = {}): OpenRouterModel {
 describe('formatName', () => {
   const NOT_PREFERRED = -1;
 
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-17T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('appends ($$$$) for expensive models', () => {
     const model = buildModel({ pricing: { prompt: '0.00001', completion: '0' } });
     expect(formatName(model, NOT_PREFERRED)).toBe('Test Model ($$$$)');
@@ -98,14 +106,19 @@ describe('formatName', () => {
     expect(formatName(model, 0)).toBe('Test Model');
   });
 
-  it('appends the retirement date in UTC when an expiration date is set', () => {
-    const model = buildModel({ expiration_date: '2026-12-01' });
-    expect(formatName(model, NOT_PREFERRED)).toBe('Test Model (retires Dec 1)');
+  it('appends the retirement date in UTC when it is within one month', () => {
+    const model = buildModel({ expiration_date: '2026-07-01' });
+    expect(formatName(model, NOT_PREFERRED)).toBe('Test Model (retires Jul 1)');
+  });
+
+  it('does not append the retirement date when it is more than one month away', () => {
+    const model = buildModel({ expiration_date: '2026-07-18' });
+    expect(formatName(model, NOT_PREFERRED)).toBe('Test Model');
   });
 
   it('prefers the (new) marker over the retirement marker', () => {
     const recentlyCreated = Math.floor(Date.now() / 1000) - 24 * 3600;
-    const model = buildModel({ created: recentlyCreated, expiration_date: '2026-12-01' });
+    const model = buildModel({ created: recentlyCreated, expiration_date: '2026-07-01' });
     expect(formatName(model, 0)).toBe('Test Model (new)');
   });
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -28,6 +28,7 @@ import { getTerminalBenchSummaries, terminalBenchFor } from '@/lib/model-stats/t
 import { isFreeNemotronModel, NVIDIA_TRIAL_TOS } from '@/lib/ai-gateway/providers/nvidia';
 import { applyCustomPricingToModel } from '@/lib/ai-gateway/custom-pricing';
 import { isFableModel } from '@/lib/ai-gateway/providers/anthropic.constants';
+import { addMonths } from 'date-fns';
 
 // Re-export from shared module for backwards compatibility
 export { normalizeModelId } from '@/lib/ai-gateway/model-utils';
@@ -88,12 +89,15 @@ export function formatName(model: OpenRouterModel, preferredIndex: number) {
   const isNew = preferredIndex >= 0 && ageDays >= 0 && ageDays < 7;
   if (isNew) return model.name + ' (new)';
   if (model.expiration_date) {
-    const suffix = new Date(model.expiration_date).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      timeZone: 'UTC',
-    });
-    return model.name + ' (retires ' + suffix + ')';
+    const expirationDate = new Date(model.expiration_date);
+    if (expirationDate <= addMonths(new Date(), 1)) {
+      const suffix = expirationDate.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      });
+      return model.name + ' (retires ' + suffix + ')';
+    }
   }
   return model.name;
 }


### PR DESCRIPTION
## Summary

- Show the `(retires ...)` model-name suffix only when the expiration date is within one calendar month.
- Keep distant retirement dates hidden until they become timely, with deterministic boundary coverage.

## Verification

- Not manually tested; this is isolated model-name formatting behavior.

## Visual Changes

N/A

## Reviewer Notes

The threshold uses a calendar month rather than a fixed number of days.