### PR TITLE
Fix reasoning not working for MiniMax Coding Plan

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -32,6 +32,7 @@ import {
   addCacheBreakpoints,
   enableReasoningSummaries,
   fixResponsesRequest,
+  isReasoningExplicitlyEnabled,
   scrubOpenCodeSpecificProperties,
 } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
 import { isQwenExplicitCacheModel, isQwenModel } from '@/lib/ai-gateway/providers/qwen';
@@ -178,6 +179,16 @@ export function applyProviderSpecificLogic(
 
   if (isQwenExplicitCacheModel(requestedModel)) {
     addCacheBreakpoints(requestToMutate);
+  }
+
+  if (
+    isMinimaxModel(requestedModel) &&
+    !isReasoningExplicitlyEnabled(requestToMutate) &&
+    requestToMutate.kind === 'messages'
+  ) {
+    // MiniMax defaults to thinking, but the Anthropic provider does not include thinking:disabled in the request, creating a mismatch.
+    // https://github.com/vercel/ai/blob/4a441d8fb584b231f771348de3e7f383ab7aa95b/packages/anthropic/src/anthropic-language-model.ts#L421-L453
+    requestToMutate.body.thinking = { type: 'disabled' };
   }
 
   provider.transformRequest({

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -143,8 +143,10 @@ export function getAiSdkProvider(
   if (isOpenCodeGoAnthropicMessagesModel(model)) {
     return 'anthropic';
   }
-  if (isClaudeModel(model)) {
-    // on Vercel AI Gateway, this is necessary to support document attachments
+  if (
+    isClaudeModel(model) || // on Vercel AI Gateway, this is necessary to support document attachments
+    isMinimaxModel(model) // on Vercel AI Gateway, this is necessary for reasoning to show
+  ) {
     return 'anthropic';
   }
   if (isOpenAiModel(model) || isGrokModel(model)) {


### PR DESCRIPTION
Seems to be a Vercel bug: reasoning does not show when using chat completions

Partial fix for: https://github.com/Kilo-Org/kilocode/issues/11334