### PR TITLE
fix(auto-routing): preserve admin routing table rank

### DIFF
--- a/apps/web/src/app/admin/auto-routing/BenchmarksSection.test.ts
+++ b/apps/web/src/app/admin/auto-routing/BenchmarksSection.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import {
   configToFormState,
   costPerAccuracy,
@@ -6,7 +8,7 @@ import {
   formatAccuracy,
   formatUsd,
   formStateToConfig,
-  sortCandidatesByCostPerAccuracy,
+  RoutingTableView,
 } from './BenchmarksSection';
 
 describe('formatAccuracy', () => {
@@ -72,28 +74,42 @@ describe('costPerAccuracy', () => {
   });
 });
 
-describe('sortCandidatesByCostPerAccuracy', () => {
-  it('sorts candidates by lowest cost per accuracy', () => {
-    const sorted = sortCandidatesByCostPerAccuracy([
-      { model: 'higher-cost-per-accuracy', avgCostUsd: 0.006, accuracy: 0.75 },
-      { model: 'zero-accuracy', avgCostUsd: 0, accuracy: 0 },
-      { model: 'best-value', avgCostUsd: 0.004, accuracy: 0.8 },
-    ]);
+describe('RoutingTableView', () => {
+  it('renders candidates in the published serving rank order', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(RoutingTableView, {
+        data: {
+          publishedAt: '2026-06-17T00:00:00.000Z',
+          table: {
+            version: 'run-1',
+            generatedAt: '2026-06-17T00:00:00.000Z',
+            minAccuracy: 0.7,
+            switchCostFactor: 3,
+            source: 'benchmark',
+            routes: {
+              'implementation/code_generation': [
+                {
+                  model: 'threshold-meeting',
+                  accuracy: 0.75,
+                  avgCostUsd: 0.006,
+                  meetsThreshold: true,
+                  reasoningEffort: null,
+                },
+                {
+                  model: 'below-threshold-cheaper',
+                  accuracy: 0.5,
+                  avgCostUsd: 0.001,
+                  meetsThreshold: false,
+                  reasoningEffort: null,
+                },
+              ],
+            },
+          },
+        },
+      })
+    );
 
-    expect(sorted.map(candidate => candidate.model)).toEqual([
-      'best-value',
-      'higher-cost-per-accuracy',
-      'zero-accuracy',
-    ]);
-  });
-
-  it('breaks cost-per-accuracy ties by higher accuracy', () => {
-    const sorted = sortCandidatesByCostPerAccuracy([
-      { model: 'less-accurate', avgCostUsd: 0.004, accuracy: 0.5 },
-      { model: 'more-accurate', avgCostUsd: 0.008, accuracy: 1 },
-    ]);
-
-    expect(sorted.map(candidate => candidate.model)).toEqual(['more-accurate', 'less-accurate']);
+    expect(html.indexOf('threshold-meeting')).toBeLessThan(html.indexOf('below-threshold-cheaper'));
   });
 });
 

--- a/apps/web/src/app/admin/auto-routing/BenchmarksSection.tsx
+++ b/apps/web/src/app/admin/auto-routing/BenchmarksSection.tsx
@@ -70,14 +70,6 @@ export function formatCostPerAccuracy(candidate: Pick<RankedCandidate, 'accuracy
   return Number.isFinite(value) ? formatUsd(value) : '—';
 }
 
-export function sortCandidatesByCostPerAccuracy<
-  T extends Pick<RankedCandidate, 'accuracy' | 'avgCostUsd'>,
->(candidates: readonly T[]): T[] {
-  return [...candidates].sort(
-    (a, b) => costPerAccuracy(a) - costPerAccuracy(b) || b.accuracy - a.accuracy
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Fetch helpers
 // ---------------------------------------------------------------------------
@@ -754,7 +746,7 @@ function BenchmarkRunsTable({ runs }: { runs: BenchmarkRun[] }) {
 // Routing table view
 // ---------------------------------------------------------------------------
 
-function RoutingTableView({ data }: { data: BenchmarkRoutingTableResponse }) {
+export function RoutingTableView({ data }: { data: BenchmarkRoutingTableResponse }) {
   if (!data.table) {
     return <p className="text-muted-foreground text-sm">No routing table published yet.</p>;
   }
@@ -776,7 +768,6 @@ function RoutingTableView({ data }: { data: BenchmarkRoutingTableResponse }) {
       </div>
 
       {routeEntries.map(([routeKey, candidates]) => {
-        const sortedCandidates = sortCandidatesByCostPerAccuracy(candidates);
         return (
           <div key={routeKey}>
             <p className="mb-1.5 font-mono text-sm font-medium">{routeKey}</p>
@@ -792,7 +783,7 @@ function RoutingTableView({ data }: { data: BenchmarkRoutingTableResponse }) {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {sortedCandidates.map((c, i) => (
+                  {candidates.map((c, i) => (
                     <TableRow key={`${routeKey}-${c.model}-${i}`}>
                       <TableCell className="max-w-56 truncate font-mono text-xs">
                         {c.model}


### PR DESCRIPTION
## Summary
- Update the auto-routing admin published routing table to render candidate models in the exact published serving rank order.
- Remove the duplicate client-side cost-per-accuracy sort while keeping the cost-per-accuracy column for inspection.

## Verification
N/A - display ordering change only; no manual browser verification performed.

## Visual Changes
N/A

## Reviewer Notes
Routes are still grouped alphabetically by route key. Only model row ordering now follows the published candidate array returned by the benchmark routing-table API.