### PR TITLE
feat(web): distinguish the staging environment

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -46,6 +46,7 @@ This document lists all environment variables used in the Kilo Code cloud monore
 ### Vercel & Build Info
 
 - `VERCEL_ENV` - Vercel environment (`development`, `preview`, `production`); used in `apps/web/next.config.mjs`, `apps/web/src/lib/constants.ts`, and `apps/web/.env.test`. [SERVER]
+- `VERCEL_TARGET_ENV` - Vercel system or custom deployment environment (`development`, `preview`, `production`, `staging`, etc.); used in `apps/web/src/app/layout.tsx` to identify staging UI. [SERVER]
 - `VERCEL_URL` - Auto-injected by Vercel; current deployment URL. Used in `apps/web/src/lib/buildInfo.ts`. [SERVER]
 - `VERCEL_GIT_COMMIT_SHA` - Auto-injected by Vercel; Git commit SHA of the current deployment. Used in `apps/web/src/lib/buildInfo.ts`. [SERVER]
 - `NEXT_PUBLIC_VERCEL_URL` - Client-exposed Vercel deployment URL from build info. [PUBLIC]

--- a/apps/web/public/kilo-v1-STAGING.svg
+++ b/apps/web/public/kilo-v1-STAGING.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#fbbf24"/>
+  <g fill="#000000">
+    <path d="M23,26v-2h3v-5l-2-2h-4v2h-3v5l2,2h4ZM20,20h3v3h-3v-3Z"/>
+    <rect x="12" y="17" width="3" height="3"/>
+    <polygon points="26 12 23 12 23 9 20 6 17 6 17 9 20 9 20 12 17 12 17 15 26 15 26 12"/>
+    <path d="M0,0v32h32V0H0ZM29,29H3V3h26v26Z"/>
+    <polygon points="15 26 15 23 9 23 9 17 6 17 6 23.1875 8.8125 26 15 26"/>
+    <rect x="12" y="6" width="3" height="3"/>
+    <polygon points="9 12 12 12 12 15 15 15 15 12 12 9 9 9 9 6 6 6 6 15 9 15 9 12"/>
+  </g>
+</svg>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { PostHogProvider } from '../components/PostHogProvider';
 import { Providers } from '../components/Providers';
 import { DataLayerProvider } from '../components/DataLayerProvider';
 import { ImpactIdentify } from '@/components/ImpactIdentify';
+import { StagingEnvironmentBanner } from '@/components/shared/StagingEnvironmentBanner';
 import { APP_URL } from '@/lib/constants';
 
 const inter = Inter({
@@ -25,6 +26,9 @@ const jetbrainsMono = JetBrains_Mono({
   display: 'swap',
   variable: '--font-jetbrains',
 });
+
+const isStagingEnvironment = process.env.VERCEL_TARGET_ENV === 'staging';
+const stagingFavicon = '/kilo-v1-STAGING.svg';
 
 export const metadata: Metadata = {
   title: 'Kilo Code - Open source AI agent VS Code extension',
@@ -47,8 +51,9 @@ export const metadata: Metadata = {
       'Write code more efficiently by generating code, automating tasks, and providing suggestions',
   },
   icons: {
-    icon:
-      process.env.NODE_ENV !== 'production'
+    icon: isStagingEnvironment
+      ? [{ url: stagingFavicon, type: 'image/svg+xml' }]
+      : process.env.NODE_ENV !== 'production'
         ? [{ url: '/kilo-v1-DEV.svg', type: 'image/svg+xml' }]
         : [
             { url: '/favicon.ico', sizes: '48x48', type: 'image/x-icon' },
@@ -59,24 +64,28 @@ export const metadata: Metadata = {
       sizes: '180x180',
       type: 'image/png',
     },
-    shortcut: { url: '/favicon.ico' },
+    shortcut: { url: isStagingEnvironment ? stagingFavicon : '/favicon.ico' },
     other: [
       {
         rel: 'manifest',
         url: '/site.webmanifest',
       },
-      {
-        rel: 'icon',
-        type: 'image/png',
-        sizes: '192x192',
-        url: '/favicon/android-chrome-192x192.png',
-      },
-      {
-        rel: 'icon',
-        type: 'image/png',
-        sizes: '512x512',
-        url: '/favicon/android-chrome-512x512.png',
-      },
+      ...(isStagingEnvironment
+        ? []
+        : [
+            {
+              rel: 'icon',
+              type: 'image/png',
+              sizes: '192x192',
+              url: '/favicon/android-chrome-192x192.png',
+            },
+            {
+              rel: 'icon',
+              type: 'image/png',
+              sizes: '512x512',
+              url: '/favicon/android-chrome-512x512.png',
+            },
+          ]),
     ],
   },
   other: {
@@ -107,6 +116,7 @@ export default function RootLayout({
     >
       <head />
       <body>
+        {isStagingEnvironment ? <StagingEnvironmentBanner /> : null}
         <Providers>
           <DataLayerProvider />
           <ImpactIdentify />

--- a/apps/web/src/components/shared/StagingEnvironmentBanner.tsx
+++ b/apps/web/src/components/shared/StagingEnvironmentBanner.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { FlaskConical } from 'lucide-react';
 

--- a/apps/web/src/components/shared/StagingEnvironmentBanner.tsx
+++ b/apps/web/src/components/shared/StagingEnvironmentBanner.tsx
@@ -1,12 +1,25 @@
+import { useState } from 'react';
 import { FlaskConical } from 'lucide-react';
 
 export function StagingEnvironmentBanner() {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
   return (
     <aside className="relative z-50 flex min-h-9 w-full shrink-0 items-center justify-center gap-2 border-b border-amber-300 bg-amber-400 px-3 py-2 text-center text-xs font-medium text-amber-950 sm:text-sm">
       <FlaskConical aria-hidden="true" className="size-4 shrink-0" />
       <span className="font-bold tracking-wider uppercase">Staging</span>
       <span aria-hidden="true" className="h-3 w-px bg-amber-950/30" />
       <span>This is a test environment.</span>
+      <button
+        type="button"
+        aria-label="Dismiss staging banner"
+        onClick={() => setDismissed(true)}
+        className="absolute right-3 font-bold text-amber-950/70 hover:text-amber-950"
+      >
+        ×
+      </button>
     </aside>
   );
 }

--- a/apps/web/src/components/shared/StagingEnvironmentBanner.tsx
+++ b/apps/web/src/components/shared/StagingEnvironmentBanner.tsx
@@ -1,0 +1,12 @@
+import { FlaskConical } from 'lucide-react';
+
+export function StagingEnvironmentBanner() {
+  return (
+    <aside className="relative z-50 flex min-h-9 w-full shrink-0 items-center justify-center gap-2 border-b border-amber-300 bg-amber-400 px-3 py-2 text-center text-xs font-medium text-amber-950 sm:text-sm">
+      <FlaskConical aria-hidden="true" className="size-4 shrink-0" />
+      <span className="font-bold tracking-wider uppercase">Staging</span>
+      <span aria-hidden="true" className="h-3 w-px bg-amber-950/30" />
+      <span>This is a test environment.</span>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a full-width staging banner so test deployments are immediately distinguishable from production.
- Select an amber staging favicon from `VERCEL_TARGET_ENV` without changing production or development branding.
- Document the Vercel custom-environment variable used by the web app.
- Add an in-memory dismiss button (×) to the staging banner so it can be hidden for the current session.

## Verification

- Opened the web app locally with `VERCEL_TARGET_ENV=staging` and confirmed the banner appears across the full viewport.
- Confirmed the rendered shortcut and icon metadata point to `/kilo-v1-STAGING.svg`.
- Checked the banner at desktop and narrow viewport widths.
- Confirmed the × button dismisses the banner (renders null) and the banner reappears on page reload.

## Visual Changes

<img width="1396" height="1029" alt="CleanShot 2026-06-17 at 17 28 18@2x" src="https://github.com/user-attachments/assets/792c1116-352b-4e74-8268-1ee142f3b047" />

## Reviewer Notes

Staging detection relies on Vercel injecting `VERCEL_TARGET_ENV=staging` for the custom deployment target.

---

Built for markijbema by [Kilo](https://kilo.ai)