### PR TITLE
feat(ai-gateway): recommend GLM 5.2

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/zai-coding.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/zai-coding.ts
@@ -16,9 +16,9 @@ export default {
     providerId: 'zai-coding',
     recommendedModels: [
       {
-        id: 'glm-5.1',
-        name: 'GLM-5.1',
-        context_length: 200000,
+        id: 'glm-5.2',
+        name: 'GLM-5.2',
+        context_length: 1000000,
         max_completion_tokens: 131072,
       },
     ],

--- a/apps/web/src/lib/ai-gateway/providers/zai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/zai.ts
@@ -2,4 +2,4 @@ export function isGlmModel(model: string) {
   return model.includes('glm');
 }
 
-export const GLM_CURRENT_MODEL_ID = 'z-ai/glm-5.1';
+export const GLM_CURRENT_MODEL_ID = 'z-ai/glm-5.2';

--- a/apps/web/src/tests/openrouter-models-config.test.ts
+++ b/apps/web/src/tests/openrouter-models-config.test.ts
@@ -7,6 +7,7 @@ describe('OpenRouter Models Config', () => {
       'google/gemini-3.1-pro-preview',
       'anthropic/claude-sonnet-4.6',
       'openai/gpt-5.5',
+      'z-ai/glm-5.2',
     ];
 
     expectedModels.forEach(model => {


### PR DESCRIPTION
## Summary

- Promote GLM 5.2 over GLM 5.1 in the normal recommended model list.
- Recommend GLM 5.2 for Z.AI Coding Plan BYOK users with its 1M-token context window.
- Add coverage ensuring GLM 5.2 remains in the recommended model configuration.

## Verification

- Not manually tested; this is a model configuration-only change with no visual flow.

## Visual Changes

N/A

## Reviewer Notes

GLM 5.1 remains available through provider-synced model catalogs but is no longer recommended.