### PR TITLE
fix(ai-gateway): log rewritten request tool names

### DIFF
--- a/apps/web/src/lib/ai-gateway/schema-rewrite.test.ts
+++ b/apps/web/src/lib/ai-gateway/schema-rewrite.test.ts
@@ -141,6 +141,7 @@ describe('rewriteChatCompletionsOneOfAsAnyOf logging', () => {
       event: 'ai_gateway_chat_completions_one_of_rewritten',
       model: 'zai/glm-4.6',
       count: 1,
+      toolNames: ['get_weather'],
     });
   });
 
@@ -150,7 +151,9 @@ describe('rewriteChatCompletionsOneOfAsAnyOf logging', () => {
     const request = makeRequest({
       tools: [
         toolWith('a', { type: 'object', oneOf: [{ type: 'string' }] }),
+        toolWith('a', { type: 'object', oneOf: [{ type: 'integer' }] }),
         toolWith('b', { type: 'object', oneOf: [{ type: 'number' }, { type: 'boolean' }] }),
+        toolWith('unchanged', { type: 'object' }),
       ],
       response_format: {
         type: 'json_schema',
@@ -161,8 +164,9 @@ describe('rewriteChatCompletionsOneOfAsAnyOf logging', () => {
     rewriteChatCompletionsOneOfAsAnyOf(request, log);
 
     expect(calls).toHaveLength(1);
-    const details = calls[0] as { count: number };
-    expect(details.count).toBe(3);
+    const details = calls[0] as { count: number; toolNames: string[] };
+    expect(details.count).toBe(4);
+    expect(details.toolNames).toEqual(['a', 'b', 'unchanged']);
   });
 
   it('does not log when nothing is rewritten', () => {

--- a/apps/web/src/lib/ai-gateway/schema-rewrite.ts
+++ b/apps/web/src/lib/ai-gateway/schema-rewrite.ts
@@ -14,6 +14,7 @@ type OneOfRewriteLogDetails = {
   event: 'ai_gateway_chat_completions_one_of_rewritten';
   model: string;
   count: number;
+  toolNames: string[];
 };
 
 type OneOfRewriteLogger = (message: string, details: OneOfRewriteLogDetails) => void;
@@ -86,11 +87,15 @@ export function rewriteChatCompletionsOneOfAsAnyOf(
   log: OneOfRewriteLogger = warnExceptInTest
 ): void {
   let rewritten = 0;
+  const toolNames = new Set<string>();
 
   if (Array.isArray(request.tools)) {
     for (const tool of request.tools) {
       if (!isRecord(tool) || tool.type !== 'function' || !isRecord(tool.function)) continue;
       rewritten += rewriteOneOfAsAnyOf(tool.function.parameters);
+      if (typeof tool.function.name === 'string') {
+        toolNames.add(tool.function.name);
+      }
     }
   }
 
@@ -109,5 +114,6 @@ export function rewriteChatCompletionsOneOfAsAnyOf(
     event: 'ai_gateway_chat_completions_one_of_rewritten',
     model: request.model,
     count: rewritten,
+    toolNames: [...toolNames],
   });
 }


### PR DESCRIPTION
## Summary

- Include unique function tool names in `ai_gateway_chat_completions_one_of_rewritten` log details.
- Preserve request order while deduplicating repeated tool names, with coverage for unchanged and duplicate tools.

## Verification

- [ ] Not manually tested; this change only enriches internal telemetry emitted by the schema rewrite path.

## Visual Changes

N/A

## Reviewer Notes

Tool names include all function tools in the rewritten request, not only tools whose parameter schemas contained `oneOf`.