### PR TITLE
fix(ai-gateway): log only rewritten tool names

### DIFF
--- a/apps/web/src/lib/ai-gateway/schema-rewrite.test.ts
+++ b/apps/web/src/lib/ai-gateway/schema-rewrite.test.ts
@@ -166,7 +166,7 @@ describe('rewriteChatCompletionsOneOfAsAnyOf logging', () => {
     expect(calls).toHaveLength(1);
     const details = calls[0] as { count: number; toolNames: string[] };
     expect(details.count).toBe(4);
-    expect(details.toolNames).toEqual(['a', 'b', 'unchanged']);
+    expect(details.toolNames).toEqual(['a', 'b']);
   });
 
   it('does not log when nothing is rewritten', () => {

--- a/apps/web/src/lib/ai-gateway/schema-rewrite.ts
+++ b/apps/web/src/lib/ai-gateway/schema-rewrite.ts
@@ -92,8 +92,9 @@ export function rewriteChatCompletionsOneOfAsAnyOf(
   if (Array.isArray(request.tools)) {
     for (const tool of request.tools) {
       if (!isRecord(tool) || tool.type !== 'function' || !isRecord(tool.function)) continue;
-      rewritten += rewriteOneOfAsAnyOf(tool.function.parameters);
-      if (typeof tool.function.name === 'string') {
+      const toolRewritten = rewriteOneOfAsAnyOf(tool.function.parameters);
+      rewritten += toolRewritten;
+      if (toolRewritten > 0 && typeof tool.function.name === 'string') {
         toolNames.add(tool.function.name);
       }
     }


### PR DESCRIPTION
## Summary

- Restrict Friendli schema rewrite telemetry to tool names whose parameter schemas actually changed.
- Preserve deduplication and request order while excluding unchanged tools.

## Verification

Not manually tested; this change only corrects internal telemetry emitted by the schema rewrite path.

## Visual Changes

N/A

## Reviewer Notes

Follow-up to #4087, which was merged before this correction could be pushed.