### PR TITLE
feat(web): add GitHub star giveaway notification

### DIFF
--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -37,6 +37,16 @@ const normalUnconditionalNotifications: KiloNotification[] = [
   //If you need to check or personalize the notification, see examples at the bottom of this file
   //if you just want a simple straightforward global message, add it here.
   {
+    id: 'star-giveaway-june-2026',
+    title: 'GitHub Star Giveaway',
+    message:
+      "We're giving away $500 of AI Credits when we reach 25,000 stars on GitHub. Support us:",
+    action: {
+      actionText: 'github.com/Kilo-Org/kilocode',
+      actionURL: 'https://github.com/Kilo-Org/kilocode/',
+    },
+  },
+  {
     id: 'stealth-opus-discount-may-25',
     title: 'Claude Opus 4.7 at 20% Off — Only in Kilo Code!',
     message:


### PR DESCRIPTION
## Summary

Adds the GitHub star giveaway announcement as a server-side notification in the cloud platform, where client-facing notifications belong — rather than hardcoding it into the VS Code extension webview (as done in [kilocode#11379](https://github.com/Kilo-Org/kilocode/pull/11379)).

- Adds a `star-giveaway-june-2026` entry to the static notification list in `apps/web/src/lib/notifications.ts`, served via `GET /api/users/notifications` to the extension and CLI.
- Message: "We're giving away $500 of AI Credits when we reach 25,000 stars on GitHub. Support us:" with an action linking to https://github.com/Kilo-Org/kilocode/
- Because it flows through the centralized notification system, it ships to existing clients without an extension release, is dismissible by `id` like any other notification, and can be edited/removed server-side.

## Verification

- Visit a logged-in account and confirm the notification appears in the extension/CLI notification list and is dismissible.
- Confirm the action link opens https://github.com/Kilo-Org/kilocode/

## Visual Changes

N/A

## Reviewer Notes

- No `expiresAt` is set, mirroring the source PR (shows until dismissed). The existing entries generally favor an expiry to auto-hide server-side — happy to add one (e.g. end of July) if preferred.
- No `showIn` is set, so it targets all clients with notification support.