### PR TITLE
fix(organizations): allow invites without required seats

### DIFF
--- a/.specs/team-enterprise-seat-billing.md
+++ b/.specs/team-enterprise-seat-billing.md
@@ -233,9 +233,9 @@ grants billing access without consuming a seat.
    plus qualifying pending invitations) and total seats purchased.
 7. The system MUST allow seat usage to exceed total purchased seats
    (no hard block on over-usage at the counting layer).
-8. For Teams-plan organizations, the system MUST disable the
-   invitation UI when seat usage equals or exceeds the purchased
-   seat count.
+8. For Teams-plan organizations with the require-seats flag enabled,
+   the system MUST disable the invitation UI when seat usage equals
+   or exceeds the purchased seat count.
 9. For Enterprise-plan organizations, the system MUST NOT restrict
    invitations based on seat usage.
 10. The server MUST NOT enforce seat limits when processing

--- a/apps/web/src/components/organizations/members/InviteMemberDialog.test.ts
+++ b/apps/web/src/components/organizations/members/InviteMemberDialog.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from '@jest/globals';
+import { hasInviteSeatCapacity } from './InviteMemberDialog';
+
+describe('hasInviteSeatCapacity', () => {
+  test('allows Teams invitations when seat requirements are disabled', () => {
+    expect(
+      hasInviteSeatCapacity({
+        plan: 'teams',
+        requireSeats: false,
+        usedSeats: 1,
+        totalSeats: 0,
+      })
+    ).toBe(true);
+  });
+
+  test('blocks Teams invitations when required seats are full', () => {
+    expect(
+      hasInviteSeatCapacity({
+        plan: 'teams',
+        requireSeats: true,
+        usedSeats: 1,
+        totalSeats: 1,
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/organizations/members/InviteMemberDialog.tsx
+++ b/apps/web/src/components/organizations/members/InviteMemberDialog.tsx
@@ -21,7 +21,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import type { OrganizationRole } from '@/lib/organizations/organization-types';
+import type { OrganizationPlan, OrganizationRole } from '@/lib/organizations/organization-types';
 import { Loader2, ChevronDown } from 'lucide-react';
 import { toast } from 'sonner';
 import {
@@ -68,6 +68,22 @@ type InviteMemberDialogProps = {
   blockClose?: boolean; // If true, prevents closing the dialog (hides close button and disables cancel)
 };
 
+type InviteSeatCapacity = {
+  plan: OrganizationPlan | undefined;
+  requireSeats: boolean | undefined;
+  usedSeats: number;
+  totalSeats: number;
+};
+
+export function hasInviteSeatCapacity({
+  plan,
+  requireSeats,
+  usedSeats,
+  totalSeats,
+}: InviteSeatCapacity): boolean {
+  return requireSeats === false || plan === 'enterprise' || totalSeats - usedSeats > 0;
+}
+
 export function InviteMemberDialog({
   open,
   onOpenChange,
@@ -111,11 +127,14 @@ export function InviteMemberDialog({
   // Calculate remaining seats
   const usedSeats = seatUsage?.usedSeats || 0;
   const totalSeats = seatUsage?.totalSeats || 0;
-  const remainingSeats = totalSeats - usedSeats;
   const isOrgEnterprise = organizationData?.plan === 'enterprise';
-  // Enterprise orgs have no seat-based invitation restrictions.
-  // For Teams orgs, seat capacity only gates seat-consuming roles (not billing_manager).
-  const seatCapacityAvailable = isOrgEnterprise || remainingSeats > 0;
+  // Seat capacity only gates seat-consuming roles when seat requirements apply.
+  const seatCapacityAvailable = hasInviteSeatCapacity({
+    plan: organizationData?.plan,
+    requireSeats: organizationData?.require_seats,
+    usedSeats,
+    totalSeats,
+  });
   const isSeatConsumingRole = role !== 'billing_manager';
   const hasSeatsAvailable = seatCapacityAvailable || !isSeatConsumingRole;
 


### PR DESCRIPTION

Teams organizations with seat requirements disabled were still blocked from inviting owners and members when they had no purchased seat capacity. The invite dialog now treats the organization-level seat exemption as available capacity while preserving the existing restriction for Teams organizations that still require seats. The seat-billing contract now states that the Teams invitation gate applies only when seat requirements are enabled.
