### PR TITLE
ci: deploy staging on main

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,6 +1,8 @@
 name: Deploy Web to Staging
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Trigger the staging deployment workflow on pushes to `main` so it runs alongside production deployments.
- Preserve manual `workflow_dispatch` support for ad hoc staging deploys.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
N/A