### PR TITLE
fix(ai-gateway): preserve direct BYOK MiniMax protocol

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts
@@ -16,4 +16,8 @@ describe('isOpenCodeGoAnthropicMessagesModel', () => {
       expect(isOpenCodeGoAnthropicMessagesModel(model)).toBe(false);
     }
   );
+
+  test('keeps direct BYOK MiniMax models on the provider default', () => {
+    expect(getAiSdkProvider('other-provider/minimax-m3')).toBeUndefined();
+  });
 });

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -144,7 +144,7 @@ export function getAiSdkProvider(
   }
   if (
     isClaudeModel(model) || // on Vercel AI Gateway, this is necessary to support document attachments
-    isMinimaxModel(model) // on Vercel AI Gateway, this is necessary for reasoning to show
+    (model.startsWith('minimax/') && isMinimaxModel(model)) // on Vercel AI Gateway, this is necessary for reasoning to show
   ) {
     return 'anthropic';
   }


### PR DESCRIPTION
## Summary

- Scope the Anthropic SDK preference to Vercel AI Gateway MiniMax model IDs.
- Keep direct BYOK MiniMax models on each provider's OpenAI-compatible default while preserving the OpenCode Go Messages exception.
- Add regression coverage for a direct provider MiniMax model.

## Verification

- [ ] Not manually tested; this is a model metadata protocol-selection change with no interactive path.

## Visual Changes

N/A

## Reviewer Notes

Direct providers that only support Chat Completions previously received Anthropic Messages metadata whenever the model ID contained `minimax`.