### PR TITLE
fix(mcp-gateway): harden OAuth consent screen

### DIFF
--- a/.specs/mcp-gateway-auth.md
+++ b/.specs/mcp-gateway-auth.md
@@ -224,27 +224,44 @@ when they appear in all capitals.
 3. The app MUST validate current execution context, route, owner, membership,
    assignment, config status, user eligibility, and instance state before issuing
    an authorization code.
-4. Authorization requests expire within 30 minutes.
-5. Authorization codes expire within 10 minutes, are opaque, and MUST be consumed
-   atomically with expiry enforced in the conditional update.
-6. Authorization codes bind client ID, redirect URI, canonical route URL, route
-   key, scopes, PKCE challenge, execution context, user, and instance.
-7. Refresh tokens bind the same identity and route context as the original code.
-8. Refresh tokens rotate on use and MUST be consumed atomically.
-9. Before issuing any access token from a code or refresh token, the app MUST
-   re-resolve current route, eligibility, config status, assignment, instance,
-   and execution context.
-10. Gateway access tokens are RS256 JWTs with a 15-minute lifetime.
-11. Gateway JWT claims MUST include `sub`, `aud`, `exp`, `iat`, `scope`, `MCPID`,
+4. Interactive authorization MUST present dynamically registered client identity as
+   unverified and MUST distinguish the self-asserted client name from Kilo-controlled
+   identity.
+5. Before approval, the consent screen MUST display the exact validated redirect URI,
+   client ID, connection name, configured endpoint host, owner context, granting Kilo
+   account, and a truthful description of the effective MCP access.
+6. Raw gateway scope labels MUST NOT imply that MCP tools or actions are restricted
+   when the runtime does not enforce those restrictions.
+7. Consent MUST provide explicit allow and deny actions. Denial MUST return
+   `access_denied` only through the validated redirect URI, preserve OAuth `state`,
+   and MUST NOT create authorization, provider, grant, or token state.
+8. Browser approval MUST be bound to the granting user, exact redirect URI, client,
+   resource, scopes, OAuth state, PKCE challenge, and execution context, and MUST
+   expire under server-side validation within 5 minutes.
+9. Consent responses MUST be non-cacheable, prevent framing and cross-origin form
+   submission, suppress referrer disclosure, and avoid loading client-controlled
+   remote assets.
+10. Authorization requests expire within 30 minutes.
+11. Authorization codes expire within 10 minutes, are opaque, and MUST be consumed
+    atomically with expiry enforced in the conditional update.
+12. Authorization codes bind client ID, redirect URI, canonical route URL, route
+    key, scopes, PKCE challenge, execution context, user, and instance.
+13. Refresh tokens bind the same identity and route context as the original code.
+14. Refresh tokens rotate on use and MUST be consumed atomically.
+15. Before issuing any access token from a code or refresh token, the app MUST
+    re-resolve current route, eligibility, config status, assignment, instance,
+    and execution context.
+16. Gateway access tokens are RS256 JWTs with a 15-minute lifetime.
+17. Gateway JWT claims MUST include `sub`, `aud`, `exp`, `iat`, `scope`, `MCPID`,
     `owner_scope`, `owner_id`, `config_id`, `route_key`, `instance_id`,
     `execution_context`, and `config_version`.
-12. `aud` MUST equal the exact canonical scoped route URL.
-13. `MCPID` MUST equal `{owner_scope}:{owner_id}:{config_id}:{route_key}`.
-14. The Worker MUST verify signature, algorithm, issuer, audience, expiry, route
+18. `aud` MUST equal the exact canonical scoped route URL.
+19. `MCPID` MUST equal `{owner_scope}:{owner_id}:{config_id}:{route_key}`.
+20. The Worker MUST verify signature, algorithm, issuer, audience, expiry, route
     identity, owner tuple, instance ID, and execution context before proxying.
-15. Derived connect tokens use the same JWT contract and lifetime but do not
+21. Derived connect tokens use the same JWT contract and lifetime but do not
     issue refresh tokens.
-16. Raw Kilo session/user tokens MUST NOT be accepted as runtime bearer tokens
+22. Raw Kilo session/user tokens MUST NOT be accepted as runtime bearer tokens
     on `/mcp-connect/...` and MUST NEVER be forwarded upstream.
 
 ## Provider Authorization And Grants

--- a/.specs/mcp-gateway-auth.md
+++ b/.specs/mcp-gateway-auth.md
@@ -238,8 +238,9 @@ when they appear in all capitals.
    resource, scopes, OAuth state, PKCE challenge, and execution context, and MUST
    expire under server-side validation within 5 minutes.
 9. Consent responses MUST be non-cacheable, prevent framing, restrict form submission
-   and redirects to the app origin and validated callback origin, suppress referrer
-   disclosure, and avoid loading client-controlled remote assets.
+   and redirects to the app origin, HTTPS destinations, and the exact validated HTTP
+   loopback callback origin, suppress referrer disclosure, and avoid loading
+   client-controlled remote assets.
 10. Authorization requests expire within 30 minutes.
 11. Authorization codes expire within 10 minutes, are opaque, and MUST be consumed
     atomically with expiry enforced in the conditional update.

--- a/.specs/mcp-gateway-auth.md
+++ b/.specs/mcp-gateway-auth.md
@@ -237,9 +237,9 @@ when they appear in all capitals.
 8. Browser approval MUST be bound to the granting user, exact redirect URI, client,
    resource, scopes, OAuth state, PKCE challenge, and execution context, and MUST
    expire under server-side validation within 5 minutes.
-9. Consent responses MUST be non-cacheable, prevent framing and cross-origin form
-   submission, suppress referrer disclosure, and avoid loading client-controlled
-   remote assets.
+9. Consent responses MUST be non-cacheable, prevent framing, restrict form submission
+   and redirects to the app origin and validated callback origin, suppress referrer
+   disclosure, and avoid loading client-controlled remote assets.
 10. Authorization requests expire within 30 minutes.
 11. Authorization codes expire within 10 minutes, are opaque, and MUST be consumed
     atomically with expiry enforced in the conditional update.

--- a/.specs/mcp-gateway-auth.md
+++ b/.specs/mcp-gateway-auth.md
@@ -225,13 +225,12 @@ when they appear in all capitals.
    assignment, config status, user eligibility, and instance state before issuing
    an authorization code.
 4. Interactive authorization MUST present dynamically registered client identity as
-   unverified and MUST distinguish the self-asserted client name from Kilo-controlled
-   identity.
+   unverified and MUST NOT present the self-asserted client name as verified identity.
 5. Before approval, the consent screen MUST display the exact validated redirect URI,
    client ID, connection name, configured endpoint host, owner context, granting Kilo
    account, and a truthful description of the effective MCP access.
-6. Raw gateway scope labels MUST NOT imply that MCP tools or actions are restricted
-   when the runtime does not enforce those restrictions.
+6. Consent MUST describe the effective MCP access independently of protocol scope
+   labels.
 7. Consent MUST provide explicit allow and deny actions. Denial MUST return
    `access_denied` only through the validated redirect URI, preserve OAuth `state`,
    and MUST NOT create authorization, provider, grant, or token state.

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/[scope]/[ownerId]/[configId]/[routeKey]/route.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/[scope]/[ownerId]/[configId]/[routeKey]/route.ts
@@ -31,7 +31,7 @@ export async function POST(
     return await approveRequest(request, parseScopedRouteParams(await params));
   } catch (error) {
     if (error instanceof OAuthAuthorizationRedirectError) {
-      return redirectOAuthError(error);
+      return redirectOAuthError(error, 303);
     }
     return gatewayErrorResponse(error);
   }

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
@@ -166,6 +166,9 @@ describe('POST /api/mcp-gateway/oauth/authorize', () => {
     expect(mockGetUserFromAuth).toHaveBeenCalledTimes(1);
     expect(mockPreviewAuthorization).toHaveBeenCalledTimes(1);
     expect(getResponse.status).toBe(200);
+    expect(getResponse.headers.get('content-security-policy')).toContain(
+      "form-action 'self' https:"
+    );
     const approvalState = document.match(/name="approval_state" value="([^"]+)"/)?.[1];
     const cookie = getResponse.headers.get('set-cookie')?.split(';')[0];
     expect(approvalState).toBeTruthy();
@@ -260,12 +263,8 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
     expect(document).not.toContain('These scope labels do not currently limit');
     expect(response.headers.get('cache-control')).toBe('no-store');
     expect(response.headers.get('content-security-policy')).toContain("frame-ancestors 'none'");
-    expect(response.headers.get('content-security-policy')).toContain(
-      "form-action 'self' https://client.example"
-    );
-    expect(response.headers.get('content-security-policy')).not.toContain(
-      'https://client.example/callback'
-    );
+    expect(response.headers.get('content-security-policy')).toContain("form-action 'self' https:");
+    expect(response.headers.get('content-security-policy')).not.toContain('https://client.example');
     expect(response.headers.get('x-frame-options')).toBe('DENY');
     expect(response.headers.get('x-content-type-options')).toBe('nosniff');
     expect(response.headers.get('referrer-policy')).toBe('no-referrer');
@@ -279,7 +278,7 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
     if (!response) throw new Error('Expected authorization response');
 
     expect(response.headers.get('content-security-policy')).toContain(
-      "form-action 'self' http://127.0.0.1:60424"
+      "form-action 'self' https: http://127.0.0.1:60424"
     );
   });
 

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
@@ -240,7 +240,9 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
 
     expect(response.status).toBe(200);
     expect(document).toContain('Unverified app');
-    expect(document).toContain('Kilo has not verified who operates it');
+    expect(document).toContain(
+      'An app is requesting access. Kilo has not verified who operates it.'
+    );
     expect(document).toContain('mcp:client');
     expect(document).toContain('Production GitHub');
     expect(document).toContain('mcp.github.example');
@@ -254,7 +256,8 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
     expect(document).toContain('Deny access');
     expect(document).toContain('Allow access');
     expect(document).not.toContain('<script>alert(1)</script>');
-    expect(document).toContain('Codex &lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(document).not.toContain('Codex');
+    expect(document).not.toContain('These scope labels do not currently limit');
     expect(response.headers.get('cache-control')).toBe('no-store');
     expect(response.headers.get('content-security-policy')).toContain("frame-ancestors 'none'");
     expect(response.headers.get('content-security-policy')).toContain("form-action 'self'");

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
@@ -260,10 +260,27 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
     expect(document).not.toContain('These scope labels do not currently limit');
     expect(response.headers.get('cache-control')).toBe('no-store');
     expect(response.headers.get('content-security-policy')).toContain("frame-ancestors 'none'");
-    expect(response.headers.get('content-security-policy')).toContain("form-action 'self'");
+    expect(response.headers.get('content-security-policy')).toContain(
+      "form-action 'self' https://client.example"
+    );
+    expect(response.headers.get('content-security-policy')).not.toContain(
+      'https://client.example/callback'
+    );
     expect(response.headers.get('x-frame-options')).toBe('DENY');
     expect(response.headers.get('x-content-type-options')).toBe('nosniff');
     expect(response.headers.get('referrer-policy')).toBe('no-referrer');
+  });
+
+  test('allows a validated loopback callback origin in form redirects', async () => {
+    mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
+    mockPreviewAuthorization.mockResolvedValue(organizationPreview());
+
+    const response = await loadedRoute().GET(new NextRequest(authorizationUrl()));
+    if (!response) throw new Error('Expected authorization response');
+
+    expect(response.headers.get('content-security-policy')).toContain(
+      "form-action 'self' http://127.0.0.1:60424"
+    );
   });
 
   test('uses independent cookies for simultaneous consent flows', async () => {

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.test.ts
@@ -1,16 +1,25 @@
 import { beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { NextRequest } from 'next/server';
 import type * as authorizationRoute from './route';
+import type * as scopedAuthorizationRoute from './[scope]/[ownerId]/[configId]/[routeKey]/route';
+import { OAuthAuthorizationRedirectError } from '@/lib/mcp-gateway/authorization-service';
 
-const mockGetUserFromAuth =
-  jest.fn<
-    (params: { adminOnly: boolean }) => Promise<{ user: { id: string }; organizationId?: string }>
-  >();
+const mockGetUserFromAuth = jest.fn<
+  (params: { adminOnly: boolean }) => Promise<{
+    user: { id: string; google_user_name: string; google_user_email: string };
+    organizationId?: string;
+  }>
+>();
 const mockPreviewAuthorization = jest.fn<
   (params: unknown) => Promise<{
     clientId: string;
     clientName: string;
+    redirectUri: string;
     resource: string;
+    connectionName: string;
+    endpointHost: string;
+    contextName: string;
+    ownerScope: 'personal' | 'organization';
     scopes: string[];
     executionContext: { type: string; organizationId?: string };
   }>
@@ -53,24 +62,56 @@ jest.mock('@/lib/mcp-gateway/services', () => ({
 }));
 
 let route: typeof authorizationRoute | undefined;
+let scopedRoute: typeof scopedAuthorizationRoute | undefined;
 
 beforeAll(async () => {
   route = await import('./route');
+  scopedRoute = await import('./[scope]/[ownerId]/[configId]/[routeKey]/route');
 });
 
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
+const mockUser = {
+  id: 'user-1',
+  google_user_name: 'Alice Developer',
+  google_user_email: 'alice@example.com',
+};
+
+function organizationPreview() {
+  return {
+    clientId: 'mcp:client',
+    clientName: 'Codex',
+    redirectUri: 'http://127.0.0.1:60424/callback',
+    resource:
+      'http://localhost:8806/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
+    connectionName: 'Production GitHub',
+    endpointHost: 'mcp.github.example',
+    contextName: 'Acme Engineering',
+    ownerScope: 'organization' as const,
+    scopes: ['profile'],
+    executionContext: {
+      type: 'organization',
+      organizationId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
+    },
+  };
+}
+
 function loadedRoute(): typeof authorizationRoute {
   if (!route) throw new Error('Route was not loaded');
   return route;
 }
 
-function authorizationUrl() {
+function loadedScopedRoute(): typeof scopedAuthorizationRoute {
+  if (!scopedRoute) throw new Error('Scoped route was not loaded');
+  return scopedRoute;
+}
+
+function authorizationUrl(redirectUri = 'http://127.0.0.1:60424/callback') {
   const query = new URLSearchParams({
     client_id: 'mcp:client',
-    redirect_uri: 'http://127.0.0.1:60424/callback',
+    redirect_uri: redirectUri,
     response_type: 'code',
     resource:
       'http://localhost:8806/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
@@ -80,16 +121,22 @@ function authorizationUrl() {
   return `http://localhost:3000/api/mcp-gateway/oauth/authorize?${query}`;
 }
 
-function approvalRequest(approvalState: string, cookie: string) {
+function approvalRequest(
+  approvalState: string,
+  cookie: string,
+  decision: 'allow' | 'deny' = 'allow',
+  redirectUri = 'http://127.0.0.1:60424/callback'
+) {
   const form = new URLSearchParams({
     client_id: 'mcp:client',
-    redirect_uri: 'http://127.0.0.1:60424/callback',
+    redirect_uri: redirectUri,
     response_type: 'code',
     resource:
       'http://localhost:8806/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
     scope: 'profile',
     state: 'client-state',
     approval_state: approvalState,
+    decision,
   });
   return new NextRequest('http://localhost:3000/api/mcp-gateway/oauth/authorize', {
     method: 'POST',
@@ -104,20 +151,10 @@ function approvalRequest(approvalState: string, cookie: string) {
 describe('POST /api/mcp-gateway/oauth/authorize', () => {
   test('uses a see-other redirect for a browser org provider authorization after approval', async () => {
     mockGetUserFromAuth.mockResolvedValue({
-      user: { id: 'user-1' },
+      user: mockUser,
       organizationId: undefined,
     });
-    mockPreviewAuthorization.mockResolvedValue({
-      clientId: 'mcp:client',
-      clientName: 'Codex',
-      resource:
-        'http://localhost:8806/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
-      scopes: ['profile'],
-      executionContext: {
-        type: 'organization',
-        organizationId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
-      },
-    });
+    mockPreviewAuthorization.mockResolvedValue(organizationPreview());
     mockAuthorize.mockResolvedValue({
       kind: 'provider_redirect',
       authorizationUrl: 'https://mcp.linear.app/authorize?state=provider-state',
@@ -159,22 +196,91 @@ describe('POST /api/mcp-gateway/oauth/authorize', () => {
       })
     );
   });
+
+  test('returns access_denied to the validated callback without authorizing', async () => {
+    mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
+    mockPreviewAuthorization.mockResolvedValue(organizationPreview());
+
+    const getResponse = await loadedRoute().GET(new NextRequest(authorizationUrl()));
+    if (!getResponse) throw new Error('Expected authorization response');
+    const document = await getResponse.text();
+    const approvalState = document.match(/name="approval_state" value="([^"]+)"/)?.[1];
+    const cookie = getResponse.headers.get('set-cookie')?.split(';')[0];
+    if (!approvalState || !cookie) throw new Error('Expected consent approval state');
+
+    const response = await loadedRoute().POST(approvalRequest(approvalState, cookie, 'deny'));
+    if (!response) throw new Error('Expected denial response');
+    const location = response.headers.get('location');
+    if (!location) throw new Error('Expected denial redirect');
+    const redirect = new URL(location);
+
+    expect(response.status).toBe(303);
+    expect(redirect.origin + redirect.pathname).toBe('http://127.0.0.1:60424/callback');
+    expect(redirect.searchParams.get('error')).toBe('access_denied');
+    expect(redirect.searchParams.get('state')).toBe('client-state');
+    expect(mockAuthorize).not.toHaveBeenCalled();
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('set-cookie')).toContain('Max-Age=0');
+  });
 });
 
 describe('GET /api/mcp-gateway/oauth/authorize', () => {
-  test('derives org execution context from an authorized browser resource', async () => {
-    mockGetUserFromAuth.mockResolvedValue({ user: { id: 'user-1' }, organizationId: undefined });
+  test('shows unverified identity, effective access, callback, connection, context, and account', async () => {
+    const redirectUri = 'https://client.example/callback?source=mcp&mode=desktop';
+    mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
     mockPreviewAuthorization.mockResolvedValue({
-      clientId: 'mcp:client',
-      clientName: 'Codex',
-      resource:
-        'http://localhost:8806/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
-      scopes: ['profile'],
-      executionContext: {
-        type: 'organization',
-        organizationId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
-      },
+      ...organizationPreview(),
+      clientName: 'Codex <script>alert(1)</script>',
+      redirectUri,
     });
+
+    const response = await loadedRoute().GET(new NextRequest(authorizationUrl(redirectUri)));
+    if (!response) throw new Error('Expected authorization response');
+    const document = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(document).toContain('Unverified app');
+    expect(document).toContain('Kilo has not verified who operates it');
+    expect(document).toContain('mcp:client');
+    expect(document).toContain('Production GitHub');
+    expect(document).toContain('mcp.github.example');
+    expect(document).toContain('Acme Engineering');
+    expect(document).toContain('Alice Developer');
+    expect(document).toContain('alice@example.com');
+    expect(document).toContain('This grants broad MCP access');
+    expect(document).toContain('all tools and data exposed by this MCP connection');
+    expect(document).toContain('credentials configured for the connection');
+    expect(document).toContain('https://client.example/callback?source=mcp&amp;mode=desktop');
+    expect(document).toContain('Deny access');
+    expect(document).toContain('Allow access');
+    expect(document).not.toContain('<script>alert(1)</script>');
+    expect(document).toContain('Codex &lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('content-security-policy')).toContain("frame-ancestors 'none'");
+    expect(response.headers.get('content-security-policy')).toContain("form-action 'self'");
+    expect(response.headers.get('x-frame-options')).toBe('DENY');
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(response.headers.get('referrer-policy')).toBe('no-referrer');
+  });
+
+  test('uses independent cookies for simultaneous consent flows', async () => {
+    mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
+    mockPreviewAuthorization.mockResolvedValue(organizationPreview());
+
+    const firstResponse = await loadedRoute().GET(new NextRequest(authorizationUrl()));
+    const secondResponse = await loadedRoute().GET(new NextRequest(authorizationUrl()));
+    if (!firstResponse || !secondResponse) throw new Error('Expected authorization responses');
+    const firstCookieName = firstResponse.headers.get('set-cookie')?.split('=')[0];
+    const secondCookieName = secondResponse.headers.get('set-cookie')?.split('=')[0];
+
+    expect(firstCookieName).toMatch(/^mcp_gateway_authorization_approval_/);
+    expect(secondCookieName).toMatch(/^mcp_gateway_authorization_approval_/);
+    expect(firstCookieName).not.toBe(secondCookieName);
+  });
+
+  test('derives org execution context from an authorized browser resource', async () => {
+    mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
+    mockPreviewAuthorization.mockResolvedValue(organizationPreview());
 
     const response = await loadedRoute().GET(new NextRequest(authorizationUrl()));
     if (!response) throw new Error('Expected authorization response');
@@ -189,18 +295,8 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
   });
 
   test('keeps explicit API execution context unchanged', async () => {
-    mockGetUserFromAuth.mockResolvedValue({ user: { id: 'user-1' }, organizationId: undefined });
-    mockPreviewAuthorization.mockResolvedValue({
-      clientId: 'mcp:client',
-      clientName: 'Codex',
-      resource:
-        'http://localhost:8806/mcp-connect/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
-      scopes: ['profile'],
-      executionContext: {
-        type: 'organization',
-        organizationId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
-      },
-    });
+    mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
+    mockPreviewAuthorization.mockResolvedValue(organizationPreview());
     const request = new NextRequest(authorizationUrl(), {
       headers: { Authorization: 'Bearer api-token' },
     });
@@ -216,7 +312,7 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
   });
 
   test('rejects duplicate OAuth singleton query parameters', async () => {
-    mockGetUserFromAuth.mockResolvedValue({ user: { id: 'user-1' }, organizationId: undefined });
+    mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
     const url = new URL(authorizationUrl());
     url.searchParams.append('client_id', 'mcp:other-client');
 
@@ -229,8 +325,97 @@ describe('GET /api/mcp-gateway/oauth/authorize', () => {
 });
 
 describe('POST /api/mcp-gateway/oauth/authorize validation', () => {
+  test('rejects approval after the authenticated account changes', async () => {
+    mockGetUserFromAuth.mockResolvedValueOnce({ user: mockUser, organizationId: undefined });
+    mockPreviewAuthorization.mockResolvedValue(organizationPreview());
+    const getResponse = await loadedRoute().GET(new NextRequest(authorizationUrl()));
+    if (!getResponse) throw new Error('Expected authorization response');
+    const document = await getResponse.text();
+    const approvalState = document.match(/name="approval_state" value="([^"]+)"/)?.[1];
+    const cookie = getResponse.headers.get('set-cookie')?.split(';')[0];
+    if (!approvalState || !cookie) throw new Error('Expected consent approval state');
+
+    mockGetUserFromAuth.mockResolvedValueOnce({
+      user: {
+        id: 'user-2',
+        google_user_name: 'Mallory Developer',
+        google_user_email: 'mallory@example.com',
+      },
+      organizationId: undefined,
+    });
+    const response = await loadedRoute().POST(approvalRequest(approvalState, cookie));
+    if (!response) throw new Error('Expected approval response');
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toContain('error=access_denied');
+    expect(mockAuthorize).not.toHaveBeenCalled();
+  });
+
+  test('rejects approval when the callback changes after consent is rendered', async () => {
+    mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
+    mockPreviewAuthorization.mockImplementation(async input => {
+      const query = (input as { query: { redirect_uri: string } }).query;
+      return { ...organizationPreview(), redirectUri: query.redirect_uri };
+    });
+    const getResponse = await loadedRoute().GET(new NextRequest(authorizationUrl()));
+    if (!getResponse) throw new Error('Expected authorization response');
+    const document = await getResponse.text();
+    const approvalState = document.match(/name="approval_state" value="([^"]+)"/)?.[1];
+    const cookie = getResponse.headers.get('set-cookie')?.split(';')[0];
+    if (!approvalState || !cookie) throw new Error('Expected consent approval state');
+
+    const response = await loadedRoute().POST(
+      approvalRequest(approvalState, cookie, 'allow', 'http://127.0.0.1:60424/alternate-callback')
+    );
+    if (!response) throw new Error('Expected approval response');
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toContain('error=access_denied');
+    expect(mockAuthorize).not.toHaveBeenCalled();
+  });
+
+  test('rejects approval after the server-enforced consent lifetime', async () => {
+    const now = Date.now();
+    const dateNow = jest.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
+      mockPreviewAuthorization.mockResolvedValue(organizationPreview());
+      const getResponse = await loadedRoute().GET(new NextRequest(authorizationUrl()));
+      if (!getResponse) throw new Error('Expected authorization response');
+      const document = await getResponse.text();
+      const approvalState = document.match(/name="approval_state" value="([^"]+)"/)?.[1];
+      const cookie = getResponse.headers.get('set-cookie')?.split(';')[0];
+      if (!approvalState || !cookie) throw new Error('Expected consent approval state');
+
+      dateNow.mockReturnValue(now + 301_000);
+      const response = await loadedRoute().POST(approvalRequest(approvalState, cookie));
+      if (!response) throw new Error('Expected approval response');
+
+      expect(response.status).toBe(303);
+      expect(response.headers.get('location')).toContain('error=access_denied');
+      expect(mockAuthorize).not.toHaveBeenCalled();
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  test('rejects malformed approval state without constructing an invalid cookie name', async () => {
+    mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
+    mockPreviewAuthorization.mockResolvedValue(organizationPreview());
+
+    const response = await loadedRoute().POST(
+      approvalRequest('invalid; Path=/', 'unrelated=value')
+    );
+    if (!response) throw new Error('Expected approval response');
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toContain('error=access_denied');
+    expect(response.headers.get('set-cookie')).toBeNull();
+    expect(mockAuthorize).not.toHaveBeenCalled();
+  });
+
   test('rejects duplicate approval state values', async () => {
-    mockGetUserFromAuth.mockResolvedValue({ user: { id: 'user-1' }, organizationId: undefined });
+    mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
     const form = new URLSearchParams({
       client_id: 'mcp:client',
       redirect_uri: 'http://127.0.0.1:60424/callback',
@@ -253,5 +438,50 @@ describe('POST /api/mcp-gateway/oauth/authorize validation', () => {
 
     expect(response.status).toBe(400);
     expect(mockPreviewAuthorization).not.toHaveBeenCalled();
+  });
+});
+
+describe('scoped POST /api/mcp-gateway/oauth/authorize/...', () => {
+  test('uses a see-other redirect for OAuth errors after form submission', async () => {
+    mockGetUserFromAuth.mockResolvedValue({ user: mockUser, organizationId: undefined });
+    mockPreviewAuthorization.mockRejectedValue(
+      new OAuthAuthorizationRedirectError(
+        'access_denied',
+        'Authorization failed',
+        'http://127.0.0.1:60424/callback',
+        'client-state'
+      )
+    );
+    const form = new URLSearchParams({
+      client_id: 'mcp:client',
+      redirect_uri: 'http://127.0.0.1:60424/callback',
+      response_type: 'code',
+      scope: 'profile',
+      state: 'client-state',
+      approval_state: 'approval-state',
+      decision: 'allow',
+    });
+    const response = await loadedScopedRoute().POST(
+      new NextRequest(
+        'http://localhost:3000/api/mcp-gateway/oauth/authorize/org/2ea138dc-8680-4edf-bfb7-3979329b5a7f/316e173c-1007-4f8a-b805-18fe4d95c203/HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
+        {
+          method: 'POST',
+          body: form,
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        }
+      ),
+      {
+        params: Promise.resolve({
+          scope: 'org',
+          ownerId: '2ea138dc-8680-4edf-bfb7-3979329b5a7f',
+          configId: '316e173c-1007-4f8a-b805-18fe4d95c203',
+          routeKey: 'HdEEQpx1wuG9q_iiHQRVTDQX4jB50UhF483SQuuDRVc',
+        }),
+      }
+    );
+    if (!response) throw new Error('Expected scoped authorization response');
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toContain('error=access_denied');
   });
 });

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
@@ -30,11 +30,12 @@ const consentDecisionValues = ['allow', 'deny'] as const;
 type ConsentDecision = (typeof consentDecisionValues)[number];
 
 function consentSecurityHeaders(redirectUri: string) {
-  const callbackOrigin = new URL(redirectUri).origin;
+  const callback = new URL(redirectUri);
+  const callbackSource = callback.protocol === 'http:' ? ` ${callback.origin}` : '';
   return {
     'Cache-Control': 'no-store',
     Pragma: 'no-cache',
-    'Content-Security-Policy': `default-src 'none'; style-src 'unsafe-inline'; form-action 'self' ${callbackOrigin}; frame-ancestors 'none'; base-uri 'none'; object-src 'none'`,
+    'Content-Security-Policy': `default-src 'none'; style-src 'unsafe-inline'; form-action 'self' https:${callbackSource}; frame-ancestors 'none'; base-uri 'none'; object-src 'none'`,
     'X-Frame-Options': 'DENY',
     'X-Content-Type-Options': 'nosniff',
     'Referrer-Policy': 'no-referrer',

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
@@ -154,7 +154,6 @@ function clearConsentCookie(response: NextResponse, request: NextRequest, approv
 function consentDocument(params: {
   action: string;
   approvalState: string;
-  clientName: string;
   clientId: string;
   redirectUri: string;
   connectionName: string;
@@ -270,7 +269,6 @@ function consentDocument(params: {
         line-height: 1.55;
         text-wrap: pretty;
       }
-      .client-name { color: var(--foreground); font-weight: 700; }
       .client-id { color: var(--muted); font-size: 0.76rem; }
       .warning {
         margin-bottom: 1.25rem;
@@ -320,7 +318,6 @@ function consentDocument(params: {
         font-weight: 600;
       }
       .muted-scope { color: var(--muted); }
-      .scope-note { margin: 0.45rem 0 0; color: var(--muted); font-size: 0.76rem; line-height: 1.45; }
       .actions {
         display: grid;
         grid-template-columns: 1fr 1fr;
@@ -367,7 +364,7 @@ function consentDocument(params: {
           <header class="header">
             <div class="eyebrow"><span class="badge">Unverified app</span></div>
             <h1 id="authorization-title">Allow access to this MCP connection?</h1>
-            <p class="lead"><span class="client-name">${escapeHtml(params.clientName)}</span> is requesting access. This app name was provided by the app; Kilo has not verified who operates it.</p>
+            <p class="lead">An app is requesting access. Kilo has not verified who operates it.</p>
             <code class="client-id">${escapeHtml(params.clientId)}</code>
           </header>
           <div class="content">
@@ -394,7 +391,7 @@ function consentDocument(params: {
               </div>
               <div class="detail">
                 <dt>OAuth scopes</dt>
-                <dd><div class="scopes">${scopes}</div><p class="scope-note">These scope labels do not currently limit which MCP tools or actions the app can use.</p></dd>
+                <dd><div class="scopes">${scopes}</div></dd>
               </div>
             </dl>
           </div>
@@ -461,7 +458,6 @@ async function consentResponse(request: NextRequest, route?: ScopedConnectRoute)
     consentDocument({
       action: request.nextUrl.pathname,
       approvalState,
-      clientName: preview.clientName ?? preview.clientId,
       clientId: preview.clientId,
       redirectUri: preview.redirectUri,
       connectionName: preview.connectionName,

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
@@ -14,7 +14,8 @@ import {
   stringFormParams,
 } from '@/lib/mcp-gateway/oauth-request-params';
 
-const consentCookieName = 'mcp_gateway_authorization_approval';
+const consentCookiePrefix = 'mcp_gateway_authorization_approval_';
+const consentLifetimeSeconds = 300;
 const authorizationSingletonParams = [
   'client_id',
   'redirect_uri',
@@ -25,6 +26,19 @@ const authorizationSingletonParams = [
   'code_challenge',
   'code_challenge_method',
 ] as const;
+const consentDecisionValues = ['allow', 'deny'] as const;
+type ConsentDecision = (typeof consentDecisionValues)[number];
+
+const consentSecurityHeaders = {
+  'Cache-Control': 'no-store',
+  Pragma: 'no-cache',
+  'Content-Security-Policy':
+    "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'; object-src 'none'",
+  'X-Frame-Options': 'DENY',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'no-referrer',
+  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+} as const;
 
 function escapeHtml(value: string): string {
   return value
@@ -43,12 +57,15 @@ function stringParams(entries: IterableIterator<[string, string]>): Record<strin
   return params;
 }
 
-export function redirectOAuthError(error: OAuthAuthorizationRedirectError) {
+export function redirectOAuthError(error: OAuthAuthorizationRedirectError, status = 307) {
   const redirect = new URL(error.redirectUri);
   redirect.searchParams.set('error', error.code);
   redirect.searchParams.set('error_description', error.message);
   if (error.state) redirect.searchParams.set('state', error.state);
-  return NextResponse.redirect(redirect.toString());
+  const response = NextResponse.redirect(redirect.toString(), status);
+  response.headers.set('Cache-Control', 'no-store');
+  response.headers.set('Referrer-Policy', 'no-referrer');
+  return response;
 }
 
 async function authorizationIdentity() {
@@ -73,49 +90,112 @@ async function authorizeRequest(
     executionContext,
     allowBrowserOrgResourceContext,
   });
-  if (result.kind === 'provider_redirect') {
-    return NextResponse.redirect(result.authorizationUrl, 303);
-  }
-  return NextResponse.redirect(result.redirectUrl, 303);
+  const response = NextResponse.redirect(
+    result.kind === 'provider_redirect' ? result.authorizationUrl : result.redirectUrl,
+    303
+  );
+  response.headers.set('Cache-Control', 'no-store');
+  response.headers.set('Referrer-Policy', 'no-referrer');
+  return response;
 }
 
 function approvalSignature(params: {
   approvalState: string;
+  userId: string;
   clientId: string;
+  redirectUri: string;
+  responseType: string;
   resource: string;
   scopes: string[];
+  oauthState: string | null;
+  codeChallenge: string | null;
+  codeChallengeMethod: string | null;
   executionContext: ReturnType<typeof executionContextFromAuth>;
   secret: string;
 }) {
-  return hmacValue(JSON.stringify(params), params.secret);
+  const { secret, ...payload } = params;
+  return hmacValue(JSON.stringify(payload), secret);
+}
+
+function parseConsentDecision(value: FormDataEntryValue | null): ConsentDecision | null {
+  return value === 'allow' || value === 'deny' ? value : null;
+}
+
+function createApprovalState() {
+  return `${Math.floor(Date.now() / 1000)}.${randomToken(32)}`;
+}
+
+function approvalStateIsFresh(approvalState: string) {
+  if (!/^\d{10,}\.[A-Za-z0-9_-]{43}$/.test(approvalState)) return false;
+  const [issuedAt] = approvalState.split('.');
+  const issuedAtSeconds = Number(issuedAt);
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return (
+    Number.isSafeInteger(issuedAtSeconds) &&
+    issuedAtSeconds <= nowSeconds &&
+    nowSeconds - issuedAtSeconds <= consentLifetimeSeconds
+  );
+}
+
+function consentCookieName(approvalState: string) {
+  return `${consentCookiePrefix}${approvalState}`;
+}
+
+function clearConsentCookie(response: NextResponse, request: NextRequest, approvalState: string) {
+  response.cookies.set(consentCookieName(approvalState), '', {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: request.nextUrl.protocol === 'https:',
+    path: request.nextUrl.pathname,
+    maxAge: 0,
+  });
 }
 
 function consentDocument(params: {
   action: string;
   approvalState: string;
   clientName: string;
-  resource: string;
+  clientId: string;
+  redirectUri: string;
+  connectionName: string;
+  endpointHost: string;
+  contextName: string;
+  ownerScope: 'personal' | 'organization';
+  userName: string;
+  userEmail: string;
   scopes: string[];
   inputs: string;
 }) {
-  const scopes = params.scopes.length > 0 ? params.scopes : ['none'];
+  const callback = new URL(params.redirectUri);
+  const callbackIsLoopback = ['127.0.0.1', '[::1]', 'localhost'].includes(callback.hostname);
+  const scopes =
+    params.scopes.length > 0
+      ? params.scopes.map(scope => `<span class="scope">${escapeHtml(scope)}</span>`).join('')
+      : '<span class="scope muted-scope">No additional OAuth scopes</span>';
+  const contextLabel = params.ownerScope === 'organization' ? 'Organization' : 'Context';
+  const callbackExplanation = callbackIsLoopback
+    ? 'Kilo will return the authorization result to an app running on this device.'
+    : 'Kilo will send the authorization result to this external destination.';
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Authorize Kilo Code</title>
+    <title>Allow MCP access | Kilo Code</title>
     <style>
       :root {
         color-scheme: dark;
         --background: oklch(0.145 0 0);
         --surface: oklch(0.205 0 0);
         --surface-muted: oklch(0.269 0 0);
-        --border: oklch(0.325 0 0);
+        --border: oklch(1 0 0 / 12%);
         --foreground: oklch(0.985 0 0);
         --muted: oklch(0.708 0 0);
         --primary: oklch(0.95 0.15 108);
+        --primary-hover: oklch(0.9 0.14 108);
         --primary-foreground: oklch(0.145 0 0);
+        --warning: oklch(0.78 0.14 75);
+        --warning-surface: oklch(0.3 0.04 75);
       }
       * { box-sizing: border-box; }
       body {
@@ -125,26 +205,22 @@ function consentDocument(params: {
         color: var(--foreground);
         font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       }
-      main {
-        width: min(100%, 34rem);
-        margin: 0 auto;
-        padding: 1.5rem;
-      }
       .shell {
         min-height: 100vh;
         display: grid;
         place-items: center;
         padding: 1.5rem;
       }
+      main { width: min(100%, 38rem); }
       .brand {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
+        margin-bottom: 1rem;
         color: var(--muted);
         font-size: 0.8125rem;
         font-weight: 600;
         letter-spacing: 0.02em;
-        margin-bottom: 1rem;
       }
       .brand-mark {
         width: 0.625rem;
@@ -153,11 +229,32 @@ function consentDocument(params: {
         background: var(--primary);
       }
       .card {
-        background: var(--surface);
+        overflow: hidden;
         border: 1px solid var(--border);
-        border-radius: 0.75rem;
-        padding: 1.5rem;
-        box-shadow: 0 10px 24px rgb(0 0 0 / 0.18);
+        border-radius: 0.875rem;
+        background: var(--surface);
+        box-shadow: 0 16px 40px rgb(0 0 0 / 0.22);
+      }
+      .header, .content, .actions { padding: 1.5rem; }
+      .header { border-bottom: 1px solid var(--border); }
+      .eyebrow {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        margin-bottom: 0.7rem;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        border: 1px solid color-mix(in oklch, var(--warning), transparent 45%);
+        border-radius: 999px;
+        background: var(--warning-surface);
+        padding: 0.25rem 0.55rem;
+        color: var(--warning);
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
       }
       h1 {
         margin: 0;
@@ -166,80 +263,100 @@ function consentDocument(params: {
         letter-spacing: -0.025em;
         text-wrap: balance;
       }
-      .lead {
-        margin: 0.75rem 0 0;
+      .lead, .supporting {
+        margin: 0.65rem 0 0;
         color: var(--muted);
-        font-size: 0.95rem;
+        font-size: 0.9rem;
         line-height: 1.55;
         text-wrap: pretty;
       }
-      .section {
-        margin-top: 1.25rem;
+      .client-name { color: var(--foreground); font-weight: 700; }
+      .client-id { color: var(--muted); font-size: 0.76rem; }
+      .warning {
+        margin-bottom: 1.25rem;
+        border: 1px solid color-mix(in oklch, var(--warning), transparent 60%);
+        border-radius: 0.625rem;
+        background: color-mix(in oklch, var(--warning-surface), transparent 15%);
+        padding: 0.9rem;
       }
-      .label {
-        display: block;
-        margin-bottom: 0.45rem;
+      .warning strong { display: block; color: var(--foreground); font-size: 0.9rem; }
+      .warning p { margin: 0.35rem 0 0; color: var(--muted); font-size: 0.82rem; line-height: 1.5; }
+      dl { margin: 0; }
+      .detail {
+        display: grid;
+        grid-template-columns: 8.25rem minmax(0, 1fr);
+        gap: 1rem;
+        padding: 0.85rem 0;
+        border-top: 1px solid var(--border);
+      }
+      .detail:first-child { border-top: 0; padding-top: 0; }
+      dt {
         color: var(--muted);
         font-size: 0.75rem;
         font-weight: 700;
-        letter-spacing: 0.08em;
+        letter-spacing: 0.05em;
         text-transform: uppercase;
       }
-      .resource {
+      dd { min-width: 0; margin: 0; font-size: 0.87rem; line-height: 1.45; }
+      .value-primary { display: block; color: var(--foreground); font-weight: 600; }
+      .value-secondary { display: block; margin-top: 0.15rem; color: var(--muted); font-size: 0.78rem; }
+      code {
         display: block;
+        margin-top: 0.4rem;
         overflow-wrap: anywhere;
-        border: 1px solid var(--border);
-        border-radius: 0.5rem;
-        background: var(--background);
-        padding: 0.75rem;
         color: var(--foreground);
-        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-        font-size: 0.78rem;
-        line-height: 1.45;
+        font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 0.75rem;
+        line-height: 1.5;
       }
-      .scopes {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-      }
+      .scopes { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.45rem; }
       .scope {
         border: 1px solid var(--border);
         border-radius: 999px;
         background: var(--surface-muted);
-        padding: 0.35rem 0.6rem;
+        padding: 0.28rem 0.52rem;
         color: var(--foreground);
-        font-size: 0.78rem;
+        font-size: 0.72rem;
         font-weight: 600;
       }
-      form { margin-top: 1.5rem; }
+      .muted-scope { color: var(--muted); }
+      .scope-note { margin: 0.45rem 0 0; color: var(--muted); font-size: 0.76rem; line-height: 1.45; }
+      .actions {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.75rem;
+        border-top: 1px solid var(--border);
+        background: color-mix(in oklch, var(--surface), var(--background) 18%);
+      }
       button {
-        width: 100%;
-        border: 0;
+        min-height: 2.75rem;
         border-radius: 0.5rem;
-        background: var(--primary);
-        color: var(--primary-foreground);
         padding: 0.72rem 0.95rem;
         font: inherit;
         font-size: 0.9rem;
         font-weight: 700;
         cursor: pointer;
-        transition: transform 160ms ease, background 160ms ease;
+        transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
       }
-      button:hover { background: oklch(0.9 0.14 108); }
-      button:focus-visible {
-        outline: 2px solid var(--primary);
-        outline-offset: 2px;
-      }
+      button:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
       button:active { transform: translateY(1px); }
-      .footer {
-        margin: 1rem 0 0;
-        color: var(--muted);
-        font-size: 0.75rem;
-        line-height: 1.45;
+      .deny {
+        border: 1px solid var(--border);
+        background: transparent;
+        color: var(--foreground);
       }
-      @media (prefers-reduced-motion: reduce) {
-        button { transition: none; }
+      .deny:hover { border-color: color-mix(in oklch, var(--foreground), transparent 55%); background: var(--surface-muted); }
+      .allow { border: 1px solid var(--primary); background: var(--primary); color: var(--primary-foreground); }
+      .allow:hover { background: var(--primary-hover); border-color: var(--primary-hover); }
+      @media (max-width: 34rem) {
+        .shell { padding: 0; place-items: start center; }
+        main { width: 100%; }
+        .brand { margin: 1.25rem 1.25rem 0.9rem; }
+        .card { border-right: 0; border-left: 0; border-radius: 0; }
+        .detail { grid-template-columns: 1fr; gap: 0.3rem; }
+        .actions { grid-template-columns: 1fr; }
       }
+      @media (prefers-reduced-motion: reduce) { button { transition: none; } }
     </style>
   </head>
   <body>
@@ -247,25 +364,49 @@ function consentDocument(params: {
       <main>
         <div class="brand"><span class="brand-mark" aria-hidden="true"></span>Kilo Code</div>
         <section class="card" aria-labelledby="authorization-title">
-          <h1 id="authorization-title">Authorize access</h1>
-          <p class="lead">${escapeHtml(params.clientName)} wants access to this Kilo Code MCP connection.</p>
-          <div class="section">
-            <span class="label">Requested resource</span>
-            <code class="resource">${escapeHtml(params.resource)}</code>
-          </div>
-          <div class="section">
-            <span class="label">Scopes</span>
-            <div class="scopes">${scopes
-              .map(scope => `<span class="scope">${escapeHtml(scope)}</span>`)
-              .join('')}</div>
+          <header class="header">
+            <div class="eyebrow"><span class="badge">Unverified app</span></div>
+            <h1 id="authorization-title">Allow access to this MCP connection?</h1>
+            <p class="lead"><span class="client-name">${escapeHtml(params.clientName)}</span> is requesting access. This app name was provided by the app; Kilo has not verified who operates it.</p>
+            <code class="client-id">${escapeHtml(params.clientId)}</code>
+          </header>
+          <div class="content">
+            <div class="warning">
+              <strong>This grants broad MCP access</strong>
+              <p>The app will be able to use all tools and data exposed by this MCP connection. Requests may use credentials configured for the connection and may read, create, modify, or delete data on connected services.</p>
+            </div>
+            <dl>
+              <div class="detail">
+                <dt>MCP connection</dt>
+                <dd><span class="value-primary">${escapeHtml(params.connectionName)}</span><span class="value-secondary">Endpoint: ${escapeHtml(params.endpointHost)}</span></dd>
+              </div>
+              <div class="detail">
+                <dt>${contextLabel}</dt>
+                <dd><span class="value-primary">${escapeHtml(params.contextName)}</span></dd>
+              </div>
+              <div class="detail">
+                <dt>Granting access as</dt>
+                <dd><span class="value-primary">${escapeHtml(params.userName)}</span><span class="value-secondary">${escapeHtml(params.userEmail)}</span></dd>
+              </div>
+              <div class="detail">
+                <dt>Callback destination</dt>
+                <dd><span class="value-primary">${escapeHtml(callback.host)}</span><span class="value-secondary">${callbackExplanation}</span><code>${escapeHtml(params.redirectUri)}</code></dd>
+              </div>
+              <div class="detail">
+                <dt>OAuth scopes</dt>
+                <dd><div class="scopes">${scopes}</div><p class="scope-note">These scope labels do not currently limit which MCP tools or actions the app can use.</p></dd>
+              </div>
+            </dl>
           </div>
           <form method="post" action="${escapeHtml(params.action)}">
             ${params.inputs}
             <input type="hidden" name="approval_state" value="${escapeHtml(params.approvalState)}">
-            <button type="submit">Approve access</button>
+            <div class="actions">
+              <button class="deny" type="submit" name="decision" value="deny">Deny access</button>
+              <button class="allow" type="submit" name="decision" value="allow">Allow access</button>
+            </div>
           </form>
         </section>
-        <p class="footer">You can revoke this access later from Kilo Code.</p>
       </main>
     </div>
   </body>
@@ -295,15 +436,21 @@ async function consentResponse(request: NextRequest, route?: ScopedConnectRoute)
     redirectErrors: true,
   });
   const resolvedExecutionContext = preview.executionContext;
-  const approvalState = randomToken(32);
-  const approvalCookie = `${approvalState}.${approvalSignature({
+  const approvalState = createApprovalState();
+  const approvalCookie = approvalSignature({
     approvalState,
+    userId: identity.user.id,
     clientId: preview.clientId,
+    redirectUri: preview.redirectUri,
+    responseType: parsed.data.response_type,
     resource: preview.resource,
     scopes: preview.scopes,
+    oauthState: parsed.data.state ?? null,
+    codeChallenge: parsed.data.code_challenge ?? null,
+    codeChallengeMethod: parsed.data.code_challenge_method ?? null,
     executionContext: resolvedExecutionContext,
     secret: services.config.rateLimitSecret,
-  })}`;
+  });
   const inputs = Object.entries(parsed.data)
     .map(
       ([key, value]) =>
@@ -315,18 +462,30 @@ async function consentResponse(request: NextRequest, route?: ScopedConnectRoute)
       action: request.nextUrl.pathname,
       approvalState,
       clientName: preview.clientName ?? preview.clientId,
-      resource: preview.resource,
+      clientId: preview.clientId,
+      redirectUri: preview.redirectUri,
+      connectionName: preview.connectionName,
+      endpointHost: preview.endpointHost,
+      contextName: preview.contextName,
+      ownerScope: preview.ownerScope,
+      userName: identity.user.google_user_name || identity.user.google_user_email,
+      userEmail: identity.user.google_user_email,
       scopes: preview.scopes,
       inputs,
     }),
-    { headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+    {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        ...consentSecurityHeaders,
+      },
+    }
   );
-  response.cookies.set(consentCookieName, approvalCookie, {
+  response.cookies.set(consentCookieName(approvalState), approvalCookie, {
     httpOnly: true,
     sameSite: 'lax',
     secure: request.nextUrl.protocol === 'https:',
     path: request.nextUrl.pathname,
-    maxAge: 300,
+    maxAge: consentLifetimeSeconds,
   });
   return response;
 }
@@ -335,11 +494,21 @@ async function approveRequest(request: NextRequest, route?: ScopedConnectRoute) 
   const identity = await authorizationIdentity();
   if ('response' in identity) return identity.response;
   const form = await request.formData();
-  if (hasDuplicateSingletonParams(form, [...authorizationSingletonParams, 'approval_state'])) {
+  if (
+    hasDuplicateSingletonParams(form, [
+      ...authorizationSingletonParams,
+      'approval_state',
+      'decision',
+    ])
+  ) {
     return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
   }
   const approvalState = form.get('approval_state');
-  const raw = stringFormParams(form, authorizationSingletonParams, ['approval_state']);
+  const decision = parseConsentDecision(form.get('decision'));
+  if (!decision) {
+    return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
+  }
+  const raw = stringFormParams(form, authorizationSingletonParams, ['approval_state', 'decision']);
   const parsed = OAuthAuthorizationQuerySchema.safeParse(raw);
   if (!parsed.success) {
     return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
@@ -355,31 +524,57 @@ async function approveRequest(request: NextRequest, route?: ScopedConnectRoute) 
     redirectErrors: true,
   });
   const resolvedExecutionContext = preview.executionContext;
-  const cookieState = request.cookies.get(consentCookieName)?.value;
-  const [cookieApprovalState, cookieSignature] = cookieState?.split('.') ?? [];
+  const approvalStateValue = typeof approvalState === 'string' ? approvalState : '';
+  const approvalStateValid =
+    approvalStateValue.length > 0 && approvalStateIsFresh(approvalStateValue);
+  const cookieSignature = approvalStateValid
+    ? request.cookies.get(consentCookieName(approvalStateValue))?.value
+    : undefined;
   const expectedSignature = approvalSignature({
-    approvalState: typeof approvalState === 'string' ? approvalState : '',
+    approvalState: approvalStateValue,
+    userId: identity.user.id,
     clientId: preview.clientId,
+    redirectUri: preview.redirectUri,
+    responseType: parsed.data.response_type,
     resource: preview.resource,
     scopes: preview.scopes,
+    oauthState: parsed.data.state ?? null,
+    codeChallenge: parsed.data.code_challenge ?? null,
+    codeChallengeMethod: parsed.data.code_challenge_method ?? null,
     executionContext: resolvedExecutionContext,
     secret: services.config.rateLimitSecret,
   });
   if (
-    typeof approvalState !== 'string' ||
-    !cookieApprovalState ||
+    !approvalStateValid ||
     !cookieSignature ||
-    !timingSafeEqual(approvalState, cookieApprovalState) ||
     !timingSafeEqual(expectedSignature, cookieSignature)
   ) {
-    return redirectOAuthError(
+    const response = redirectOAuthError(
       new OAuthAuthorizationRedirectError(
         'access_denied',
         'Authorization approval was not confirmed',
         parsed.data.redirect_uri,
         parsed.data.state
-      )
+      ),
+      303
     );
+    if (approvalStateValid) {
+      clearConsentCookie(response, request, approvalStateValue);
+    }
+    return response;
+  }
+  if (decision === 'deny') {
+    const response = redirectOAuthError(
+      new OAuthAuthorizationRedirectError(
+        'access_denied',
+        'The user denied the authorization request',
+        preview.redirectUri,
+        parsed.data.state
+      ),
+      303
+    );
+    clearConsentCookie(response, request, approvalStateValue);
+    return response;
   }
   const response = await authorizeRequest(
     parsed.data,
@@ -388,7 +583,7 @@ async function approveRequest(request: NextRequest, route?: ScopedConnectRoute) 
     resolvedExecutionContext,
     !request.headers.has('Authorization')
   );
-  response.cookies.delete(consentCookieName);
+  clearConsentCookie(response, request, approvalStateValue);
   return response;
 }
 
@@ -408,7 +603,7 @@ export async function POST(request: NextRequest) {
     return await approveRequest(request);
   } catch (error) {
     if (error instanceof OAuthAuthorizationRedirectError) {
-      return redirectOAuthError(error);
+      return redirectOAuthError(error, 303);
     }
     return gatewayErrorResponse(error);
   }

--- a/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/mcp-gateway/oauth/authorize/route.ts
@@ -29,16 +29,18 @@ const authorizationSingletonParams = [
 const consentDecisionValues = ['allow', 'deny'] as const;
 type ConsentDecision = (typeof consentDecisionValues)[number];
 
-const consentSecurityHeaders = {
-  'Cache-Control': 'no-store',
-  Pragma: 'no-cache',
-  'Content-Security-Policy':
-    "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'; object-src 'none'",
-  'X-Frame-Options': 'DENY',
-  'X-Content-Type-Options': 'nosniff',
-  'Referrer-Policy': 'no-referrer',
-  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
-} as const;
+function consentSecurityHeaders(redirectUri: string) {
+  const callbackOrigin = new URL(redirectUri).origin;
+  return {
+    'Cache-Control': 'no-store',
+    Pragma: 'no-cache',
+    'Content-Security-Policy': `default-src 'none'; style-src 'unsafe-inline'; form-action 'self' ${callbackOrigin}; frame-ancestors 'none'; base-uri 'none'; object-src 'none'`,
+    'X-Frame-Options': 'DENY',
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'no-referrer',
+    'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+  } as const;
+}
 
 function escapeHtml(value: string): string {
   return value
@@ -472,7 +474,7 @@ async function consentResponse(request: NextRequest, route?: ScopedConnectRoute)
     {
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
-        ...consentSecurityHeaders,
+        ...consentSecurityHeaders(preview.redirectUri),
       },
     }
   );

--- a/apps/web/src/lib/mcp-gateway/authorization-service.ts
+++ b/apps/web/src/lib/mcp-gateway/authorization-service.ts
@@ -308,10 +308,22 @@ export function createAuthorizationService(params: {
     redirectErrors?: boolean;
   }) {
     const prepared = await prepareAuthorization(input);
+    const organization =
+      prepared.resolved.config.owner_scope === 'organization'
+        ? await params.repository.findOrganization(prepared.resolved.config.owner_id)
+        : null;
     return {
       clientId: prepared.client.client_id,
       clientName: prepared.client.client_name,
+      redirectUri: input.query.redirect_uri,
       resource: prepared.resolved.route.canonical_url,
+      connectionName: prepared.resolved.config.name,
+      endpointHost: new URL(prepared.resolved.config.remote_url).host,
+      ownerScope: prepared.resolved.config.owner_scope,
+      contextName:
+        prepared.resolved.config.owner_scope === 'organization'
+          ? (organization?.name ?? 'Organization')
+          : 'Personal',
       scopes: prepared.scopes,
       executionContext: prepared.executionContext,
     };

--- a/apps/web/src/lib/mcp-gateway/oauth-flow.test.ts
+++ b/apps/web/src/lib/mcp-gateway/oauth-flow.test.ts
@@ -169,6 +169,51 @@ describe('MCP gateway app OAuth flow', () => {
     ).rejects.toMatchObject({ code: 'invalid_client_metadata' });
   });
 
+  it('previews truthful consent details for a personal connection', async () => {
+    const config = await createTestConfig();
+    const services = createGatewayServices({ config });
+    const user = await insertTestUser({ id: `gateway-user-${crypto.randomUUID()}` });
+    const created = await services.configService.createPersonalConfig({
+      userId: user.id,
+      name: 'Production GitHub',
+      remoteUrl: 'https://example.com/mcp',
+      authMode: 'none',
+    });
+    const registration = await services.clientService.registerClient({
+      metadata: {
+        redirect_uris: ['https://client.example/callback'],
+        token_endpoint_auth_method: 'client_secret_basic',
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+        scope: 'profile',
+      },
+      headers: new Headers({ 'x-vercel-forwarded-for': '203.0.113.44' }),
+    });
+
+    await expect(
+      services.authorizationService.previewAuthorization({
+        query: OAuthAuthorizationQuerySchema.parse({
+          client_id: registration.clientId,
+          redirect_uri: 'https://client.example/callback',
+          response_type: 'code',
+          scope: 'profile',
+          resource: created.route.canonical_url,
+        }),
+        userId: user.id,
+        executionContext: { type: 'personal' },
+      })
+    ).resolves.toMatchObject({
+      clientId: registration.clientId,
+      redirectUri: 'https://client.example/callback',
+      connectionName: 'Production GitHub',
+      endpointHost: 'example.com',
+      ownerScope: 'personal',
+      contextName: 'Personal',
+      resource: created.route.canonical_url,
+      scopes: ['profile'],
+    });
+  });
+
   it('issues an authorization code and rotates refresh tokens', async () => {
     const config = await createTestConfig();
     const services = createGatewayServices({ config });

--- a/apps/web/src/lib/mcp-gateway/repository.ts
+++ b/apps/web/src/lib/mcp-gateway/repository.ts
@@ -169,6 +169,15 @@ export function createGatewayRepository(database: GatewayDatabase = db) {
     return rows[0]?.organization_memberships ?? null;
   }
 
+  async function findOrganization(organizationId: string) {
+    const rows = await database
+      .select({ id: organizations.id, name: organizations.name })
+      .from(organizations)
+      .where(and(eq(organizations.id, organizationId), isNull(organizations.deleted_at)))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
   async function findActiveAssignment(configId: string, userId: string) {
     const rows = await database
       .select()
@@ -376,6 +385,7 @@ export function createGatewayRepository(database: GatewayDatabase = db) {
     findActiveRouteByCanonicalUrl,
     findUser,
     findMembership,
+    findOrganization,
     findActiveAssignment,
     authorizeUserForRoute,
     findNonTerminalInstance,


### PR DESCRIPTION
## Summary

- Protect users from OAuth consent phishing where publicly registered MCP clients can supply self-asserted metadata and callback URIs.
- Present the requesting client as unverified without displaying its self-asserted app name, and show the stable client ID, exact callback destination, MCP connection, configured endpoint, owner context, granting Kilo account, and effective broad MCP access before approval.
- Add an explicit denial path and harden browser approval with user/request binding, per-flow cookies, server-enforced expiry, safe POST redirects, and restrictive response headers. The change preserves the existing OAuth protocol and requires no database migration.

## Verification

- [x] Manually verified the local consent screen displays the unverified-client warning, connection and account context, broad-access warning, callback destination, and allow/deny actions.
- [x] Manually denied access to Kilo CLI and confirmed the browser follows the `303` to the localhost callback, displays the authorization failure, and releases the CLI from `Starting OAuth flow` without issuing an authorization code.

## Visual Changes

New consent screen (lots of warnings, way more details):

<img width="1036" height="1205" alt="Screenshot 2026-06-18 at 2 27 58 PM" src="https://github.com/user-attachments/assets/962761a5-fa5f-4322-a9fe-c9e33ece9bc3" />

What kilo shows when you click deny:

<img width="775" height="901" alt="Screenshot 2026-06-18 at 2 28 01 PM" src="https://github.com/user-attachments/assets/6eaf7c0c-eaaa-482d-8430-616eb156bc88" />

## Reviewer Notes

- For Kilo CLI after a user clicks **Deny access**, the browser follows the gateway's `303` to the CLI's localhost callback, shows `Authorization Failed` and the denial description, and the terminal stops `Starting OAuth flow` and reports `Authentication failed`. The consent CSP explicitly allows the validated callback origin so the browser can complete that redirect.
- The approval signature now binds the authenticated user and full OAuth request context; scoped POST errors use `303` so form bodies are not replayed to client callbacks.
- Approval remains signed and stateless with a five-minute server-enforced lifetime, and the change adds no schema or migration work.
