### PR TITLE
ci(cloud-agent-next): add staging worker config

### DIFF
--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -265,6 +265,148 @@
    * https://developers.cloudflare.com/workers/wrangler/configuration/#named-environments
    */
   "env": {
+    "staging": {
+      "name": "cloud-agent-next-staging",
+      "workers_dev": true,
+      "preview_urls": false,
+      "triggers": {
+        "crons": ["17 2 * * *"],
+      },
+      "routes": [],
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE",
+          "id": "624ec80650dd414199349f4e217ddb10",
+          "localConnectionString": "postgres://postgres:postgres@localhost:5432/postgres",
+        },
+      ],
+      "vars": {
+        "KILOCODE_BACKEND_BASE_URL": "https://staging-app.kilo.ai",
+        "KILO_OPENROUTER_BASE": "https://staging-app.kilo.ai/api",
+        "GITHUB_APP_SLUG": "kiloconnect-development",
+        "GITHUB_APP_BOT_USER_ID": "242397087",
+        "GITHUB_LITE_APP_SLUG": "",
+        "GITHUB_LITE_APP_BOT_USER_ID": "",
+        "WORKER_URL": "https://cloud-agent-next-staging.engineering-e11.workers.dev",
+        "CLI_TIMEOUT_SECONDS": "900",
+        "REAPER_INTERVAL_MS": "300000",
+        "R2_ATTACHMENTS_BUCKET": "cloud-agent-attachments-staging",
+        "WS_ALLOWED_ORIGINS": "https://staging-app.kilo.ai",
+        "KILO_SESSION_INGEST_URL": "https://session-ingest-staging.engineering-e11.workers.dev",
+        "PER_SESSION_SANDBOX_ORG_IDS": "*",
+      },
+      "services": [
+        {
+          "binding": "SESSION_INGEST",
+          "service": "session-ingest-staging",
+          "entrypoint": "SessionIngestRPC",
+        },
+        {
+          "binding": "GIT_TOKEN_SERVICE",
+          "service": "git-token-service-staging",
+          "entrypoint": "GitTokenRPCEntrypoint",
+        },
+        {
+          "binding": "NOTIFICATIONS",
+          "service": "notifications-staging",
+          "entrypoint": "NotificationsService",
+        },
+      ],
+      "secrets_store_secrets": [
+        {
+          "binding": "INTERNAL_API_SECRET_PROD",
+          "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+          "secret_name": "INTERNAL_API_SECRET_PROD",
+        },
+      ],
+      "r2_buckets": [
+        {
+          "binding": "R2_BUCKET",
+          "bucket_name": "kilocode-sessions-staging",
+        },
+      ],
+      "containers": [
+        {
+          "class_name": "Sandbox",
+          "image": "./Dockerfile",
+          "instance_type": "standard-4",
+          "image_vars": {
+            "KILOCODE_CLI_VERSION": "7.3.21",
+          },
+          "max_instances": 10,
+          "rollout_active_grace_period": 300,
+        },
+        {
+          "class_name": "SandboxSmall",
+          "image": "./Dockerfile",
+          "instance_type": "standard-4",
+          "image_vars": {
+            "KILOCODE_CLI_VERSION": "7.3.21",
+          },
+          "max_instances": 2,
+          "rollout_active_grace_period": 300,
+        },
+        {
+          "class_name": "SandboxDIND",
+          "image": "./Dockerfile.dind",
+          "instance_type": "standard-3",
+          "image_vars": {
+            "KILOCODE_CLI_VERSION": "7.3.21",
+          },
+          "max_instances": 1,
+          "rollout_active_grace_period": 300,
+        },
+      ],
+      "durable_objects": {
+        "bindings": [
+          {
+            "class_name": "Sandbox",
+            "name": "Sandbox",
+          },
+          {
+            "class_name": "SandboxSmall",
+            "name": "SandboxSmall",
+          },
+          {
+            "class_name": "SandboxDIND",
+            "name": "SandboxDIND",
+          },
+          {
+            "class_name": "CloudAgentSession",
+            "name": "CLOUD_AGENT_SESSION",
+          },
+          {
+            "class_name": "UserKiloFacade",
+            "name": "USER_KILO_FACADE",
+          },
+        ],
+      },
+      "queues": {
+        "producers": [
+          {
+            "binding": "CALLBACK_QUEUE",
+            "queue": "cloud-agent-next-callback-queue-staging",
+          },
+          {
+            "binding": "CLOUD_AGENT_REPORT_QUEUE",
+            "queue": "cloud-agent-next-report-queue-staging",
+          },
+        ],
+        "consumers": [
+          {
+            "queue": "cloud-agent-next-callback-queue-staging",
+            "max_batch_size": 5,
+            // Keep aligned with CALLBACK_DELIVERY_MAX_ATTEMPTS = initial attempt + 4 redeliveries.
+            "max_retries": 4,
+          },
+          {
+            "queue": "cloud-agent-next-report-queue-staging",
+            "max_retries": 3,
+            "dead_letter_queue": "cloud-agent-next-report-queue-dlq-staging",
+          },
+        ],
+      },
+    },
     "dev": {
       "name": "cloud-agent-next-dev",
       "triggers": {

--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -272,7 +272,13 @@
       "triggers": {
         "crons": ["17 2 * * *"],
       },
-      "routes": [],
+      "routes": [
+        {
+          "pattern": "staging.cloud-agent-next.kilosessions.ai",
+          "zone_name": "kilosessions.ai",
+          "custom_domain": true,
+        },
+      ],
       "hyperdrive": [
         {
           "binding": "HYPERDRIVE",
@@ -287,7 +293,7 @@
         "GITHUB_APP_BOT_USER_ID": "242397087",
         "GITHUB_LITE_APP_SLUG": "",
         "GITHUB_LITE_APP_BOT_USER_ID": "",
-        "WORKER_URL": "https://cloud-agent-next-staging.engineering-e11.workers.dev",
+        "WORKER_URL": "https://staging.cloud-agent-next.kilosessions.ai",
         "CLI_TIMEOUT_SECONDS": "900",
         "REAPER_INTERVAL_MS": "300000",
         "R2_ATTACHMENTS_BUCKET": "cloud-agent-attachments-staging",

--- a/services/event-service/wrangler.jsonc
+++ b/services/event-service/wrangler.jsonc
@@ -46,4 +46,35 @@
       "secret_name": "NEXTAUTH_SECRET_PROD",
     },
   ],
+  "env": {
+    "staging": {
+      "name": "event-service-staging",
+      "workers_dev": true,
+      "routes": [],
+      "vars": { "WORKER_ENV": "staging" },
+      "observability": { "enabled": true },
+      "logpush": true,
+      "placement": { "mode": "smart" },
+      "durable_objects": {
+        "bindings": [
+          { "name": "USER_SESSION_DO", "class_name": "UserSessionDO" },
+          { "name": "CONNECTION_TICKET_DO", "class_name": "ConnectionTicketDO" },
+        ],
+      },
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE",
+          "id": "624ec80650dd414199349f4e217ddb10",
+          "localConnectionString": "postgres://postgres:postgres@localhost:5432/postgres",
+        },
+      ],
+      "secrets_store_secrets": [
+        {
+          "binding": "NEXTAUTH_SECRET",
+          "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+          "secret_name": "NEXTAUTH_SECRET_DEV",
+        },
+      ],
+    },
+  },
 }

--- a/services/git-token-service/wrangler.jsonc
+++ b/services/git-token-service/wrangler.jsonc
@@ -53,6 +53,43 @@
     "port": 8802,
   },
   "env": {
+    "staging": {
+      "name": "git-token-service-staging",
+      "workers_dev": true,
+      "preview_urls": false,
+      "routes": [],
+      "vars": {
+        "GITHUB_APP_SLUG": "kiloconnect-development",
+        "GITHUB_APP_BOT_USER_ID": "242397087",
+        "GITHUB_LITE_APP_SLUG": "",
+        "GITHUB_LITE_APP_BOT_USER_ID": "",
+      },
+      "kv_namespaces": [
+        {
+          "binding": "TOKEN_CACHE",
+          "id": "7e0b82f3dd30498490a7ebb11f1d20b9",
+        },
+      ],
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE",
+          "id": "624ec80650dd414199349f4e217ddb10",
+          "localConnectionString": "postgres://postgres:postgres@localhost:5432/postgres",
+        },
+      ],
+      "secrets_store_secrets": [
+        {
+          "binding": "NEXTAUTH_SECRET",
+          "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+          "secret_name": "NEXTAUTH_SECRET_DEV",
+        },
+        {
+          "binding": "SCM_SESSION_CAPABILITY_ENCRYPTION_KEY",
+          "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+          "secret_name": "SCM_SESSION_CAPABILITY_ENCRYPTION_KEY_DEV",
+        },
+      ],
+    },
     "dev": {
       "name": "git-token-service-dev",
       "vars": {

--- a/services/git-token-service/wrangler.jsonc
+++ b/services/git-token-service/wrangler.jsonc
@@ -67,7 +67,7 @@
       "kv_namespaces": [
         {
           "binding": "TOKEN_CACHE",
-          "id": "7e0b82f3dd30498490a7ebb11f1d20b9",
+          "id": "613ad8efa4c14134bed156cffd6eebe9",
         },
       ],
       "hyperdrive": [

--- a/services/notifications/wrangler.jsonc
+++ b/services/notifications/wrangler.jsonc
@@ -78,4 +78,68 @@
       "new_classes": ["NotificationChannelDO"],
     },
   ],
+  "env": {
+    "staging": {
+      "name": "notifications-staging",
+      "workers_dev": true,
+      "routes": [],
+      "placement": { "mode": "smart" },
+      "observability": { "enabled": true },
+      "vars": { "WORKER_ENV": "staging" },
+
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE",
+          "id": "624ec80650dd414199349f4e217ddb10",
+          "localConnectionString": "postgres://postgres:postgres@localhost:5432/postgres",
+        },
+      ],
+
+      "durable_objects": {
+        "bindings": [
+          {
+            "name": "NOTIFICATION_CHANNEL_DO",
+            "class_name": "NotificationChannelDO",
+          },
+        ],
+      },
+
+      "queues": {
+        "producers": [
+          {
+            "binding": "RECEIPTS_QUEUE",
+            "queue": "notifications-receipts-staging",
+          },
+        ],
+        "consumers": [
+          {
+            "queue": "notifications-receipts-staging",
+            "max_retries": 3,
+            "dead_letter_queue": "notifications-receipts-dlq-staging",
+            "retry_delay": 60,
+          },
+        ],
+      },
+
+      "services": [
+        {
+          "binding": "EVENT_SERVICE",
+          "service": "event-service-staging",
+        },
+      ],
+
+      "secrets_store_secrets": [
+        {
+          "binding": "EXPO_ACCESS_TOKEN",
+          "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+          "secret_name": "EXPO_ACCESS_TOKEN",
+        },
+        {
+          "binding": "NEXTAUTH_SECRET",
+          "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+          "secret_name": "NEXTAUTH_SECRET_DEV",
+        },
+      ],
+    },
+  },
 }

--- a/services/session-ingest/wrangler.jsonc
+++ b/services/session-ingest/wrangler.jsonc
@@ -111,4 +111,86 @@
       "secret_name": "INTERNAL_API_SECRET_PROD",
     },
   ],
+  "env": {
+    "staging": {
+      "name": "session-ingest-staging",
+      "workers_dev": true,
+      "routes": [],
+      "placement": {
+        "mode": "smart",
+      },
+      "observability": {
+        "enabled": true,
+      },
+      "logpush": true,
+      "kv_namespaces": [
+        {
+          "binding": "USER_EXISTS_CACHE",
+          "id": "ab836697b6034a95beb92aceea474b10",
+        },
+      ],
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE",
+          "id": "624ec80650dd414199349f4e217ddb10",
+          "localConnectionString": "postgres://postgres:postgres@localhost:5432/postgres",
+        },
+      ],
+      "durable_objects": {
+        "bindings": [
+          {
+            "name": "SESSION_INGEST_DO",
+            "class_name": "SessionIngestDO",
+          },
+          {
+            "name": "SESSION_ACCESS_CACHE_DO",
+            "class_name": "SessionAccessCacheDO",
+          },
+          {
+            "name": "USER_CONNECTION_DO",
+            "class_name": "UserConnectionDO",
+          },
+        ],
+      },
+      "r2_buckets": [
+        {
+          "binding": "SESSION_INGEST_R2",
+          "bucket_name": "session-ingest-staging",
+        },
+      ],
+      "queues": {
+        "producers": [
+          {
+            "binding": "INGEST_QUEUE",
+            "queue": "session-ingest-processing-staging",
+          },
+        ],
+        "consumers": [
+          {
+            "queue": "session-ingest-processing-staging",
+            "max_retries": 3,
+            "dead_letter_queue": "session-ingest-dlq-staging",
+          },
+        ],
+      },
+      "services": [
+        {
+          "binding": "O11Y",
+          "service": "o11y",
+        },
+      ],
+      "secrets_store_secrets": [
+        {
+          "binding": "NEXTAUTH_SECRET_PROD",
+          "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+          "secret_name": "NEXTAUTH_SECRET_DEV",
+        },
+        {
+          "binding": "INTERNAL_API_SECRET_PROD",
+          "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+          "secret_name": "INTERNAL_API_SECRET_PROD",
+        },
+      ],
+    },
+  },
 }


### PR DESCRIPTION
## Summary

Adds explicit `staging` Wrangler environments for `services/cloud-agent-next` and the service-binding dependencies it needs to deploy cleanly: `git-token-service`, `session-ingest`, `notifications`, and `event-service`.

The staging Cloud Agent Next Worker uses the custom domain `staging.cloud-agent-next.kilosessions.ai`, isolated staging queues/R2/container capacity, and staging-named service bindings so staging deploy validation does not silently bind to production workers.

## Verification

Manual verification was limited to Wrangler dry-run behavior for the staging Worker graph. Live Cloudflare deploys require pre-created named queues/R2 buckets and authenticated Wrangler access to the Kilo Cloudflare account.

## Visual Changes

N/A

## Reviewer Notes

Deploy dependency order:

1. `event-service-staging`
2. `git-token-service-staging`
3. `session-ingest-staging`
4. `notifications-staging`
5. `cloud-agent-next-staging`

`session-ingest-staging` still binds to the existing `o11y` service. A fully isolated staging observability stack would require separate Analytics Engine/Pipelines/secrets and is intentionally left out of this PR.