### PR TITLE
fix(byok): clarify organization restriction handling

### DIFF
--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -775,7 +775,8 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
                         </p>
                         <p className="mt-2 font-medium">
                           Organization restrictions: This Vercel-backed provider is subject to
-                          organization-configured model and provider restrictions.
+                          organization-configured model restrictions, but the provider itself is
+                          considered trusted.
                         </p>
                       </AlertDescription>
                     </Alert>

--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -756,6 +756,10 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
                             you may need to wait a few minutes and restart your client for this
                             entry to appear.
                           </p>
+                          <p className="mt-2 font-medium">
+                            Organization restrictions: Direct providers are considered trusted in
+                            the context of organization-defined restrictions.
+                          </p>
                         </AlertDescription>
                       </Alert>
                     );
@@ -764,9 +768,15 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
                     <Alert>
                       <Info className="size-4" />
                       <AlertDescription>
-                        Once saved, your key will automatically be used whenever your client
-                        requests one of the supported models above. If multiple keys apply to the
-                        same model, they are tried in unspecified order until one succeeds.
+                        <p>
+                          Once saved, your key will automatically be used whenever your client
+                          requests one of the supported models above. If multiple keys apply to the
+                          same model, they are tried in unspecified order until one succeeds.
+                        </p>
+                        <p className="mt-2 font-medium">
+                          Organization restrictions: This Vercel-backed provider is subject to
+                          organization-configured model and provider restrictions.
+                        </p>
                       </AlertDescription>
                     </Alert>
                   );

--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -757,8 +757,9 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
                             entry to appear.
                           </p>
                           {organizationId ? (
-                            <p className="mt-2 font-medium">
-                              Organization restrictions: This provider is considered trusted.
+                            <p className="mt-2">
+                              This provider is considered trusted in the context of organization
+                              restrictions.
                             </p>
                           ) : null}
                         </AlertDescription>
@@ -775,10 +776,9 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
                           same model, they are tried in unspecified order until one succeeds.
                         </p>
                         {organizationId ? (
-                          <p className="mt-2 font-medium">
-                            Organization restrictions: Models remain subject to
-                            organization-configured model restrictions, but this provider is
-                            considered trusted.
+                          <p className="mt-2">
+                            Models of this provider are subject to organization-configured model
+                            restrictions, but the provider itself is considered trusted.
                           </p>
                         ) : null}
                       </AlertDescription>

--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -756,10 +756,11 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
                             you may need to wait a few minutes and restart your client for this
                             entry to appear.
                           </p>
-                          <p className="mt-2 font-medium">
-                            Organization restrictions: Direct providers are considered trusted in
-                            the context of organization-defined restrictions.
-                          </p>
+                          {organizationId ? (
+                            <p className="mt-2 font-medium">
+                              Organization restrictions: This provider is considered trusted.
+                            </p>
+                          ) : null}
                         </AlertDescription>
                       </Alert>
                     );
@@ -773,11 +774,13 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
                           requests one of the supported models above. If multiple keys apply to the
                           same model, they are tried in unspecified order until one succeeds.
                         </p>
-                        <p className="mt-2 font-medium">
-                          Organization restrictions: This Vercel-backed provider is subject to
-                          organization-configured model restrictions, but the provider itself is
-                          considered trusted.
-                        </p>
+                        {organizationId ? (
+                          <p className="mt-2 font-medium">
+                            Organization restrictions: Models remain subject to
+                            organization-configured model restrictions, but this provider is
+                            considered trusted.
+                          </p>
+                        ) : null}
                       </AlertDescription>
                     </Alert>
                   );


### PR DESCRIPTION
## Summary

- Show organization restriction notices only while configuring organization-owned BYOK keys.
- Clarify that configured providers are trusted, while models that are applied automatically remain subject to organization-configured model restrictions.
- Keep routing implementation details out of the user-facing notices.

## Verification

- Not manually tested; the latest branch updates conditional copy in the existing BYOK provider guidance alerts.

## Visual Changes

N/A (copy-only change)

## Reviewer Notes

The notices intentionally differ between provider-prefixed model entries and providers that apply automatically to supported models.