### PR TITLE
fix(ai-gateway): order custom LLM variants

### DIFF
--- a/apps/web/src/lib/ai-gateway/custom-llm/listAvailableCustomLlms.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/listAvailableCustomLlms.ts
@@ -1,6 +1,7 @@
 import { custom_llm2 } from '@kilocode/db/schema';
 import { readDb } from '@/lib/drizzle';
 import { CustomLlmDefinitionSchema, type CustomLlmDefinition } from '@kilocode/db/schema-types';
+import { orderOpenCodeSettings } from './order-opencode-variants';
 
 function convert(publicId: string, model: CustomLlmDefinition) {
   return {
@@ -36,7 +37,7 @@ function convert(publicId: string, model: CustomLlmDefinition) {
     per_request_limits: null,
     supported_parameters: ['max_tokens', 'temperature', 'tools', 'reasoning', 'include_reasoning'],
     default_parameters: {},
-    opencode: model.opencode_settings,
+    opencode: orderOpenCodeSettings(model.opencode_settings),
   };
 }
 

--- a/apps/web/src/lib/ai-gateway/custom-llm/order-opencode-variants.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/order-opencode-variants.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from '@jest/globals';
+import { orderOpenCodeSettings, orderOpenCodeVariants } from './order-opencode-variants';
+
+const variant = { reasoning: { enabled: true } };
+
+describe('orderOpenCodeVariants', () => {
+  it('orders reasoning effort variants from least to most intensive', () => {
+    const variants = {
+      max: variant,
+      medium: variant,
+      none: variant,
+      xhigh: variant,
+      low: variant,
+      high: variant,
+      minimal: variant,
+    };
+
+    expect(Object.keys(orderOpenCodeVariants(variants))).toEqual([
+      'none',
+      'minimal',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+    ]);
+    expect(Object.keys(variants)).toEqual([
+      'max',
+      'medium',
+      'none',
+      'xhigh',
+      'low',
+      'high',
+      'minimal',
+    ]);
+  });
+
+  it('orders binary reasoning variants with instant first', () => {
+    expect(Object.keys(orderOpenCodeVariants({ thinking: variant, instant: variant }))).toEqual([
+      'instant',
+      'thinking',
+    ]);
+  });
+
+  it('orders instant and effort variants from least to most intensive', () => {
+    expect(
+      Object.keys(
+        orderOpenCodeVariants({ high: variant, medium: variant, instant: variant, low: variant })
+      )
+    ).toEqual(['instant', 'low', 'medium', 'high']);
+  });
+
+  it('orders arbitrary and mixed variant names alphabetically', () => {
+    expect(
+      Object.keys(orderOpenCodeVariants({ turbo: variant, medium: variant, balanced: variant }))
+    ).toEqual(['balanced', 'medium', 'turbo']);
+  });
+});
+
+describe('orderOpenCodeSettings', () => {
+  it('preserves settings while ordering variants', () => {
+    const settings = {
+      ai_sdk_provider: 'anthropic',
+      variants: { high: variant, low: variant },
+    } as const;
+
+    expect(orderOpenCodeSettings(settings)).toEqual({
+      ai_sdk_provider: 'anthropic',
+      variants: { low: variant, high: variant },
+    });
+  });
+
+  it('returns settings without variants unchanged', () => {
+    const settings = { ai_sdk_provider: 'openai' } as const;
+
+    expect(orderOpenCodeSettings(settings)).toBe(settings);
+    expect(orderOpenCodeSettings(undefined)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/ai-gateway/custom-llm/order-opencode-variants.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/order-opencode-variants.ts
@@ -1,0 +1,39 @@
+import type { OpenCodeSettings } from '@kilocode/db/schema-types';
+
+const VARIANT_ORDERS = [
+  ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
+  ['instant', 'thinking'],
+  ['instant', 'low', 'medium', 'high'],
+] as const;
+
+function compareNames(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+export function orderOpenCodeVariants(
+  variants: NonNullable<OpenCodeSettings['variants']>
+): NonNullable<OpenCodeSettings['variants']> {
+  const entries = Object.entries(variants);
+  const names = entries.map(([name]) => name);
+  const ranks = VARIANT_ORDERS.find(rank =>
+    names.every(name => rank.some(rankedName => rankedName === name))
+  );
+  const rank = (name: string) => ranks?.findIndex(rankedName => rankedName === name) ?? -1;
+
+  return Object.fromEntries(
+    entries.sort(([a], [b]) => (ranks ? rank(a) - rank(b) : compareNames(a, b)))
+  );
+}
+
+export function orderOpenCodeSettings(
+  settings: OpenCodeSettings | undefined
+): OpenCodeSettings | undefined {
+  if (!settings?.variants) return settings;
+
+  return {
+    ...settings,
+    variants: orderOpenCodeVariants(settings.variants),
+  };
+}


### PR DESCRIPTION
## Summary

- Sort custom LLM OpenCode variants from least to most intensive for recognized reasoning schemes.
- Fall back to deterministic alphabetical ordering for arbitrary or mixed variant names.
- Preserve the configured OpenCode settings and original variants object while normalizing model-list output.

## Verification

- [x] Manually exercised known reasoning-effort ordering and arbitrary-name fallback through the ordering helper.

## Visual Changes

N/A

## Reviewer Notes

The change applies only to custom LLM model-list serialization; experiment model metadata is unchanged.