### PR TITLE
fix(review): disable cloud reviews on repeated git clone timeouts

### DIFF
--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -80,6 +80,8 @@ const mockBuildReviewSummaryFooter = jest.fn<any>();
 const mockRetryReviewFresh = jest.fn<any>();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockDisableCodeReviewForActionRequiredFailure = jest.fn<any>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDisableCodeReviewForRepeatedCloneTimeoutsToday = jest.fn<any>();
 
 // --- Module mocks ---
 
@@ -160,6 +162,8 @@ jest.mock('@/lib/code-reviews/action-required', () => {
     ...actual,
     disableCodeReviewForActionRequiredFailure: (...args: unknown[]) =>
       mockDisableCodeReviewForActionRequiredFailure(...args),
+    disableCodeReviewForRepeatedCloneTimeoutsToday: (...args: unknown[]) =>
+      mockDisableCodeReviewForRepeatedCloneTimeoutsToday(...args),
   };
 });
 
@@ -401,6 +405,7 @@ beforeEach(async () => {
       footer.usage || footer.reviewGuidance?.used ? 'body with footer' : body
   );
   mockDisableCodeReviewForActionRequiredFailure.mockResolvedValue(undefined);
+  mockDisableCodeReviewForRepeatedCloneTimeoutsToday.mockResolvedValue(null);
   ({ POST } = await import('./route'));
 });
 
@@ -2041,6 +2046,205 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
           errorMessage: 'Unexpected backend failure after prior infra retry',
           terminalReason: 'upstream_error',
         })
+      );
+    });
+
+    it('publishes a normal failure for a below-threshold repository clone timeout', async () => {
+      const errorMessage = 'Repository clone timed out: termination hard_timeout, elapsed 300041ms';
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ status: 'running', session_id: 'agent-clone-timeout-retry' })
+      );
+      mockUpdateCodeReviewAttemptForCallback.mockResolvedValue(
+        makeAttempt({
+          id: '00000000-0000-0000-0000-000000000451',
+          status: 'failed',
+          session_id: 'agent-clone-timeout-retry',
+          retry_reason: 'infra_failure',
+          retry_of_attempt_id: '00000000-0000-0000-0000-000000000450',
+        })
+      );
+      mockGetLatestCodeReviewAttempt.mockResolvedValue(
+        makeAttempt({
+          id: '00000000-0000-0000-0000-000000000451',
+          status: 'failed',
+          session_id: 'agent-clone-timeout-retry',
+          retry_reason: 'infra_failure',
+          retry_of_attempt_id: '00000000-0000-0000-0000-000000000450',
+        })
+      );
+      mockDisableCodeReviewForRepeatedCloneTimeoutsToday.mockResolvedValue(null);
+
+      const response = await POST(
+        makeRequest({
+          status: 'failed',
+          cloudAgentSessionId: 'agent-clone-timeout-retry',
+          errorMessage,
+          terminalReason: 'sandbox_error',
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockCreateInfraRetryAttemptIfMissing).not.toHaveBeenCalled();
+      expect(mockRetryReviewFresh).not.toHaveBeenCalled();
+      expect(mockUpdateCodeReviewStatus).toHaveBeenCalledWith(
+        REVIEW_ID,
+        'failed',
+        expect.objectContaining({ errorMessage, terminalReason: 'sandbox_error' })
+      );
+      expect(mockDisableCodeReviewForRepeatedCloneTimeoutsToday).toHaveBeenCalledWith({
+        owner: { type: 'user', id: 'user-1', userId: 'user-1' },
+        platform: 'github',
+        reviewId: REVIEW_ID,
+        errorMessage,
+      });
+      expect(mockDisableCodeReviewForActionRequiredFailure).not.toHaveBeenCalled();
+      expect(mockUpdateCheckRun).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        12345,
+        expect.objectContaining({
+          conclusion: 'failure',
+          output: expect.objectContaining({
+            title: 'Kilo Code Review failed',
+            summary: expect.stringContaining(errorMessage),
+          }),
+        }),
+        'standard'
+      );
+    });
+
+    it('publishes action-required GitHub check output on the third repository clone timeout', async () => {
+      const errorMessage = 'Repository clone timed out: termination hard_timeout, elapsed 300041ms';
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ status: 'running', session_id: 'agent-third-clone-timeout' })
+      );
+      mockUpdateCodeReviewAttemptForCallback.mockResolvedValue(
+        makeAttempt({
+          id: '00000000-0000-0000-0000-000000000461',
+          status: 'failed',
+          session_id: 'agent-third-clone-timeout',
+          retry_reason: 'infra_failure',
+          retry_of_attempt_id: '00000000-0000-0000-0000-000000000460',
+        })
+      );
+      mockGetLatestCodeReviewAttempt.mockResolvedValue(
+        makeAttempt({
+          id: '00000000-0000-0000-0000-000000000461',
+          status: 'failed',
+          session_id: 'agent-third-clone-timeout',
+          retry_reason: 'infra_failure',
+          retry_of_attempt_id: '00000000-0000-0000-0000-000000000460',
+        })
+      );
+      mockDisableCodeReviewForRepeatedCloneTimeoutsToday.mockResolvedValue(
+        'repeated_repository_clone_timeout'
+      );
+
+      const response = await POST(
+        makeRequest({
+          status: 'failed',
+          cloudAgentSessionId: 'agent-third-clone-timeout',
+          errorMessage,
+          terminalReason: 'sandbox_error',
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockUpdateCodeReviewStatus).toHaveBeenCalledWith(
+        REVIEW_ID,
+        'failed',
+        expect.objectContaining({ errorMessage, terminalReason: 'sandbox_error' })
+      );
+      expect(mockDisableCodeReviewForRepeatedCloneTimeoutsToday).toHaveBeenCalledWith({
+        owner: { type: 'user', id: 'user-1', userId: 'user-1' },
+        platform: 'github',
+        reviewId: REVIEW_ID,
+        errorMessage,
+      });
+      expect(mockDisableCodeReviewForActionRequiredFailure).not.toHaveBeenCalled();
+      expect(mockUpdateCheckRun).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        12345,
+        expect.objectContaining({
+          status: 'completed',
+          conclusion: 'action_required',
+          output: expect.objectContaining({
+            title: 'Repeated repository clone timeouts',
+            summary:
+              'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
+          }),
+        }),
+        'standard'
+      );
+    });
+
+    it('publishes action-required GitLab commit status on the third repository clone timeout', async () => {
+      const errorMessage = 'Repository clone timed out: termination hard_timeout, elapsed 300041ms';
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({
+          status: 'running',
+          session_id: 'agent-third-gitlab-clone-timeout',
+          platform: 'gitlab',
+          platform_project_id: 42,
+          check_run_id: null,
+        })
+      );
+      mockGetIntegrationById.mockResolvedValue(
+        makeIntegration({ platform: 'gitlab', platform_installation_id: null })
+      );
+      mockUpdateCodeReviewAttemptForCallback.mockResolvedValue(
+        makeAttempt({
+          id: '00000000-0000-0000-0000-000000000471',
+          status: 'failed',
+          session_id: 'agent-third-gitlab-clone-timeout',
+          retry_reason: 'infra_failure',
+          retry_of_attempt_id: '00000000-0000-0000-0000-000000000470',
+        })
+      );
+      mockGetLatestCodeReviewAttempt.mockResolvedValue(
+        makeAttempt({
+          id: '00000000-0000-0000-0000-000000000471',
+          status: 'failed',
+          session_id: 'agent-third-gitlab-clone-timeout',
+          retry_reason: 'infra_failure',
+          retry_of_attempt_id: '00000000-0000-0000-0000-000000000470',
+        })
+      );
+      mockDisableCodeReviewForRepeatedCloneTimeoutsToday.mockResolvedValue(
+        'repeated_repository_clone_timeout'
+      );
+
+      const response = await POST(
+        makeRequest({
+          status: 'failed',
+          cloudAgentSessionId: 'agent-third-gitlab-clone-timeout',
+          errorMessage,
+          terminalReason: 'sandbox_error',
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockDisableCodeReviewForRepeatedCloneTimeoutsToday).toHaveBeenCalledWith({
+        owner: { type: 'user', id: 'user-1', userId: 'user-1' },
+        platform: 'gitlab',
+        reviewId: REVIEW_ID,
+        errorMessage,
+      });
+      expect(mockSetCommitStatus).toHaveBeenCalledWith(
+        'mock-token',
+        42,
+        'abc123',
+        'failed',
+        expect.objectContaining({
+          description: 'Code Reviewer disabled after three repository clone timeouts today',
+        }),
+        'https://gitlab.com'
       );
     });
 

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -616,7 +616,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         12345,
         expect.objectContaining({
           conclusion: 'action_required',
-          output: expect.objectContaining({ title: 'BYOK API key needs attention' }),
+          output: expect.objectContaining({ title: 'Code Reviewer disabled: BYOK key issue' }),
         }),
         'standard'
       );
@@ -693,7 +693,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         'abc123',
         'failed',
         expect.objectContaining({
-          description: 'GitLab Project Access Token required for Code Reviewer',
+          description: 'Code Reviewer disabled: GitLab token setup required',
         }),
         'https://gitlab.com'
       );
@@ -747,7 +747,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         12345,
         expect.objectContaining({
           conclusion: 'action_required',
-          output: expect.objectContaining({ title: 'Selected model unavailable' }),
+          output: expect.objectContaining({ title: 'Code Reviewer disabled: model unavailable' }),
         }),
         'standard'
       );
@@ -789,7 +789,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         12345,
         expect.objectContaining({
           conclusion: 'action_required',
-          output: expect.objectContaining({ title: 'Selected model unavailable' }),
+          output: expect.objectContaining({ title: 'Code Reviewer disabled: model unavailable' }),
         }),
         'standard'
       );
@@ -2174,7 +2174,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
           status: 'completed',
           conclusion: 'action_required',
           output: expect.objectContaining({
-            title: 'Repeated repository clone timeouts',
+            title: 'Code Reviewer disabled: clone timeouts',
             summary:
               'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
           }),
@@ -2242,7 +2242,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         'abc123',
         'failed',
         expect.objectContaining({
-          description: 'Code Reviewer disabled after three repository clone timeouts today',
+          description: 'Code Reviewer disabled: three repository clone timeouts today',
         }),
         'https://gitlab.com'
       );

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -83,6 +83,7 @@ import {
 import {
   classifyCodeReviewActionRequiredFailure,
   disableCodeReviewForActionRequiredFailure,
+  disableCodeReviewForRepeatedCloneTimeoutsToday,
   getCodeReviewActionRequiredCopy,
   isCodeReviewActionRequiredReason,
   type CodeReviewActionRequiredReason,
@@ -1276,6 +1277,7 @@ export async function POST(
       await updateCodeReviewStatus(reviewId, status, parentStatusUpdates);
     }
 
+    let providerTerminalReason = terminalReason;
     const actionRequiredReason =
       status === 'failed' ? getActionRequiredTerminalReason(terminalReason, errorMessage) : null;
     if (actionRequiredReason) {
@@ -1297,6 +1299,30 @@ export async function POST(
           captureException(disableError, {
             tags: { source: 'code-review-status-action-required-disable' },
             extra: { reviewId, reason: actionRequiredReason },
+          });
+        }
+      }
+    } else if (status === 'failed') {
+      const ownerResolution = await getTerminalOwnerResolution();
+      if (ownerResolution) {
+        try {
+          const repeatedCloneTimeoutReason = await disableCodeReviewForRepeatedCloneTimeoutsToday({
+            owner: ownerResolution.owner,
+            platform: review.platform === 'gitlab' ? 'gitlab' : 'github',
+            reviewId,
+            errorMessage,
+          });
+          if (repeatedCloneTimeoutReason) {
+            providerTerminalReason = repeatedCloneTimeoutReason;
+          }
+        } catch (disableError) {
+          logExceptInTest(
+            '[code-review-status] Failed to disable Code Reviewer for repeated repository clone timeouts:',
+            disableError
+          );
+          captureException(disableError, {
+            tags: { source: 'code-review-status-repeated-clone-timeout-disable' },
+            extra: { reviewId },
           });
         }
       }
@@ -1323,7 +1349,7 @@ export async function POST(
           integration,
           status,
           errorMessage,
-          terminalReason,
+          providerTerminalReason,
           gitlabAccessToken,
           validGateResult
         );

--- a/apps/web/src/emails/codeReviewDisabled.html
+++ b/apps/web/src/emails/codeReviewDisabled.html
@@ -51,7 +51,7 @@
                       sans-serif;
                   "
                 >
-                  Code Reviewer was disabled because it needs configuration attention.
+                  Code Reviewer was disabled because it needs attention.
                   <strong style="color: #1a1a1a">{{ reason }}</strong>
                 </p>
                 <p
@@ -65,8 +65,8 @@
                       sans-serif;
                   "
                 >
-                  Existing review history remains available. Fix the configuration issue, then
-                  enable Code Reviewer again to resume automatic reviews.
+                  Existing review history remains available. Resolve the issue, then enable Code
+                  Reviewer again to resume automatic reviews.
                 </p>
                 <!-- CTA Button -->
                 <table width="100%" cellpadding="0" cellspacing="0">

--- a/apps/web/src/emails/codeReviewDisabled.html
+++ b/apps/web/src/emails/codeReviewDisabled.html
@@ -51,7 +51,7 @@
                       sans-serif;
                   "
                 >
-                  Code Reviewer was disabled because it needs attention.
+                  Code Reviewer was disabled for this reason:<br />
                   <strong style="color: #1a1a1a">{{ reason }}</strong>
                 </p>
                 <p

--- a/apps/web/src/lib/code-reviews/action-required-shared.ts
+++ b/apps/web/src/lib/code-reviews/action-required-shared.ts
@@ -6,6 +6,7 @@ export const CODE_REVIEW_ACTION_REQUIRED_REASONS = [
   'gitlab_project_access_required',
   'byok_invalid_key',
   'selected_model_unavailable',
+  'repeated_repository_clone_timeout',
 ] as const;
 
 export type CodeReviewActionRequiredReason = (typeof CODE_REVIEW_ACTION_REQUIRED_REASONS)[number];
@@ -85,6 +86,17 @@ const COPY_BY_REASON = {
       'Code Reviewer was disabled because the selected model is not available for cloud agent sessions. Choose an available model, then enable Code Reviewer again.',
     gitlabDescription: 'Selected model unavailable for Code Reviewer',
   },
+  repeated_repository_clone_timeout: {
+    title: 'Code Reviewer needs attention',
+    description:
+      'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
+    recoveryLabel: 'Contact support',
+    emailReason: 'Repository cloning timed out for three code reviews today.',
+    checkTitle: 'Repeated repository clone timeouts',
+    checkSummary:
+      'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
+    gitlabDescription: 'Code Reviewer disabled after three repository clone timeouts today',
+  },
 } satisfies Record<CodeReviewActionRequiredReason, CodeReviewActionRequiredCopy>;
 
 const ACTION_REQUIRED_REASON_SET = new Set<string>(CODE_REVIEW_ACTION_REQUIRED_REASONS);
@@ -113,6 +125,10 @@ export function getCodeReviewActionRequiredRecoveryHref(
 
   if (reason === 'github_ip_allow_list') {
     return 'mailto:hi@kilocode.ai?subject=GitHub%20IP%20allow%20list%20for%20Code%20Reviewer';
+  }
+
+  if (reason === 'repeated_repository_clone_timeout') {
+    return 'mailto:hi@kilocode.ai?subject=Repository%20clone%20timeouts%20for%20Code%20Reviewer';
   }
 
   if (reason === 'gitlab_project_access_required') {

--- a/apps/web/src/lib/code-reviews/action-required-shared.ts
+++ b/apps/web/src/lib/code-reviews/action-required-shared.ts
@@ -36,66 +36,72 @@ const COPY_BY_REASON = {
     description:
       'Code Reviewer was disabled because Kilo cannot access this repository with an active GitHub App installation. Update the GitHub App installation, then enable Code Reviewer again.',
     recoveryLabel: 'Update GitHub App',
-    emailReason: 'Kilo cannot access this repository with an active GitHub App installation.',
-    checkTitle: 'GitHub App access required',
+    emailReason:
+      'Code Reviewer was disabled because Kilo cannot access this repository with an active GitHub App installation. Update the GitHub App installation, then enable Code Reviewer again.',
+    checkTitle: 'Code Reviewer disabled: GitHub App access',
     checkSummary:
       'Code Reviewer was disabled because Kilo cannot access this repository with an active GitHub App installation. Update the GitHub App installation, then enable Code Reviewer again.',
-    gitlabDescription: 'GitHub App access required for Code Reviewer',
+    gitlabDescription: 'Code Reviewer disabled: GitHub App access required',
   },
   github_ip_allow_list: {
     title: 'Code Reviewer needs attention',
     description:
-      'Code Reviewer was disabled because this GitHub organization uses an IP allow list that blocks Kilo. Contact hi@kilocode.ai to discuss supported access options, then enable Code Reviewer again.',
+      'Code Reviewer was disabled because this GitHub organization uses an IP allow list that blocks Kilo. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
     recoveryLabel: 'Contact support',
-    emailReason: 'This GitHub organization uses an IP allow list that blocks Kilo.',
-    checkTitle: 'GitHub IP allow list blocks Kilo',
+    emailReason:
+      'Code Reviewer was disabled because this GitHub organization uses an IP allow list that blocks Kilo. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
+    checkTitle: 'Code Reviewer disabled: IP allow list',
     checkSummary:
-      'Code Reviewer was disabled because this GitHub organization uses an IP allow list that blocks Kilo. Contact hi@kilocode.ai, then enable Code Reviewer again.',
-    gitlabDescription: 'GitHub IP allow list blocks Code Reviewer',
+      'Code Reviewer was disabled because this GitHub organization uses an IP allow list that blocks Kilo. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
+    gitlabDescription: 'Code Reviewer disabled: GitHub IP allow list blocks Kilo',
   },
   gitlab_project_access_required: {
     title: 'Code Reviewer needs attention',
     description:
       'Code Reviewer was disabled because Kilo cannot create a GitLab Project Access Token for this project. Grant Maintainer access or enable Project Access Tokens, then enable Code Reviewer again.',
     recoveryLabel: 'Update GitLab integration',
-    emailReason: 'Kilo cannot create a GitLab Project Access Token for this project.',
-    checkTitle: 'GitLab Project Access Token required',
+    emailReason:
+      'Code Reviewer was disabled because Kilo cannot create a GitLab Project Access Token for this project. Grant Maintainer access or enable Project Access Tokens, then enable Code Reviewer again.',
+    checkTitle: 'Code Reviewer disabled: GitLab token setup',
     checkSummary:
       'Code Reviewer was disabled because Kilo cannot create a GitLab Project Access Token for this project. Grant Maintainer access or enable Project Access Tokens, then enable Code Reviewer again.',
-    gitlabDescription: 'GitLab Project Access Token required for Code Reviewer',
+    gitlabDescription: 'Code Reviewer disabled: GitLab token setup required',
   },
   byok_invalid_key: {
     title: 'Code Reviewer needs attention',
     description:
-      'Code Reviewer was disabled because the selected BYOK API key is invalid, revoked, or lacks permission for this resource. Update the key or choose another model, then enable Code Reviewer again.',
+      'Code Reviewer was disabled because the selected BYOK API key is invalid, revoked, or lacks permission. Update the key or choose another model, then enable Code Reviewer again.',
     recoveryLabel: 'Update BYOK settings',
-    emailReason: 'The selected BYOK API key is invalid, revoked, or lacks permission.',
-    checkTitle: 'BYOK API key needs attention',
+    emailReason:
+      'Code Reviewer was disabled because the selected BYOK API key is invalid, revoked, or lacks permission. Update the key or choose another model, then enable Code Reviewer again.',
+    checkTitle: 'Code Reviewer disabled: BYOK key issue',
     checkSummary:
-      'Code Reviewer was disabled because the selected BYOK API key is invalid, revoked, or lacks permission for this resource. Update the key or choose another model, then enable Code Reviewer again.',
-    gitlabDescription: 'BYOK API key needs attention for Code Reviewer',
+      'Code Reviewer was disabled because the selected BYOK API key is invalid, revoked, or lacks permission. Update the key or choose another model, then enable Code Reviewer again.',
+    gitlabDescription: 'Code Reviewer disabled: BYOK key needs attention',
   },
   selected_model_unavailable: {
     title: 'Code Reviewer needs attention',
     description:
       'Code Reviewer was disabled because the selected model is not available for cloud agent sessions. Choose an available model, then enable Code Reviewer again.',
     recoveryLabel: 'Update Code Reviewer settings',
-    emailReason: 'The selected model is not available for cloud agent sessions.',
-    checkTitle: 'Selected model unavailable',
+    emailReason:
+      'Code Reviewer was disabled because the selected model is not available for cloud agent sessions. Choose an available model, then enable Code Reviewer again.',
+    checkTitle: 'Code Reviewer disabled: model unavailable',
     checkSummary:
       'Code Reviewer was disabled because the selected model is not available for cloud agent sessions. Choose an available model, then enable Code Reviewer again.',
-    gitlabDescription: 'Selected model unavailable for Code Reviewer',
+    gitlabDescription: 'Code Reviewer disabled: selected model unavailable',
   },
   repeated_repository_clone_timeout: {
     title: 'Code Reviewer needs attention',
     description:
       'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
     recoveryLabel: 'Contact support',
-    emailReason: 'Repository cloning timed out for three code reviews today.',
-    checkTitle: 'Repeated repository clone timeouts',
+    emailReason:
+      'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
+    checkTitle: 'Code Reviewer disabled: clone timeouts',
     checkSummary:
       'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
-    gitlabDescription: 'Code Reviewer disabled after three repository clone timeouts today',
+    gitlabDescription: 'Code Reviewer disabled: three repository clone timeouts today',
   },
 } satisfies Record<CodeReviewActionRequiredReason, CodeReviewActionRequiredCopy>;
 

--- a/apps/web/src/lib/code-reviews/action-required.test.ts
+++ b/apps/web/src/lib/code-reviews/action-required.test.ts
@@ -6,11 +6,17 @@ jest.mock('@/lib/email', () => ({
 
 import { db } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import { agent_configs, kilocode_users, type User } from '@kilocode/db/schema';
+import {
+  agent_configs,
+  cloud_agent_code_reviews,
+  kilocode_users,
+  type User,
+} from '@kilocode/db/schema';
 import { and, eq } from 'drizzle-orm';
 import {
   classifyCodeReviewActionRequiredFailure,
   disableCodeReviewForActionRequiredFailure,
+  disableCodeReviewForRepeatedCloneTimeoutsToday,
   getCodeReviewActionRequiredRecoveryHref,
   getCodeReviewActionRequiredState,
 } from './action-required';
@@ -129,6 +135,11 @@ describe('classifyCodeReviewActionRequiredFailure', () => {
         '[BYOK] Your API account has insufficient funds. Please check your billing details with your API provider.'
       )
     ).toBeNull();
+    expect(
+      classifyCodeReviewActionRequiredFailure(
+        'Repository clone timed out: termination hard_timeout, elapsed 300041ms'
+      )
+    ).toBeNull();
   });
 
   it('routes GitLab project access recovery to GitLab integrations', () => {
@@ -148,16 +159,24 @@ describe('classifyCodeReviewActionRequiredFailure', () => {
       '/organizations/org-1/code-reviews'
     );
   });
+
+  it('routes repeated repository clone timeout recovery to support email', () => {
+    expect(getCodeReviewActionRequiredRecoveryHref('repeated_repository_clone_timeout')).toBe(
+      'mailto:hi@kilocode.ai?subject=Repository%20clone%20timeouts%20for%20Code%20Reviewer'
+    );
+  });
 });
 
 describe('disableCodeReviewForActionRequiredFailure', () => {
   let testUser: User;
+  let extraUserIds: string[] = [];
 
   beforeAll(async () => {
     testUser = await insertTestUser();
   });
 
   beforeEach(async () => {
+    extraUserIds = [];
     mockSendCodeReviewDisabledEmail.mockResolvedValue({ sent: true });
     await db.insert(agent_configs).values({
       owned_by_user_id: testUser.id,
@@ -170,6 +189,11 @@ describe('disableCodeReviewForActionRequiredFailure', () => {
   });
 
   afterEach(async () => {
+    for (const userId of [testUser.id, ...extraUserIds]) {
+      await db
+        .delete(cloud_agent_code_reviews)
+        .where(eq(cloud_agent_code_reviews.owned_by_user_id, userId));
+    }
     await db
       .delete(agent_configs)
       .where(
@@ -178,6 +202,9 @@ describe('disableCodeReviewForActionRequiredFailure', () => {
           eq(agent_configs.agent_type, 'code_review')
         )
       );
+    for (const userId of extraUserIds) {
+      await db.delete(kilocode_users).where(eq(kilocode_users.id, userId));
+    }
     mockSendCodeReviewDisabledEmail.mockReset();
   });
 
@@ -198,6 +225,33 @@ describe('disableCodeReviewForActionRequiredFailure', () => {
       )
       .limit(1);
     return config;
+  }
+
+  async function seedFailedReview(params: {
+    ownerId?: string;
+    platform?: 'github' | 'gitlab';
+    errorMessage: string;
+    completedAt?: Date;
+  }): Promise<string> {
+    const id = crypto.randomUUID();
+    await db.insert(cloud_agent_code_reviews).values({
+      id,
+      owned_by_user_id: params.ownerId ?? testUser.id,
+      repo_full_name: `clone-timeout-test/repo-${id}`,
+      pr_number: 1,
+      pr_url: `https://example.com/clone-timeout-test/repo-${id}/pull/1`,
+      pr_title: 'Test PR',
+      pr_author: 'author',
+      base_ref: 'main',
+      head_ref: `feature-${id}`,
+      head_sha: id,
+      platform: params.platform ?? 'github',
+      status: 'failed',
+      error_message: params.errorMessage,
+      terminal_reason: 'sandbox_error',
+      completed_at: (params.completedAt ?? new Date()).toISOString(),
+    });
+    return id;
   }
 
   it('throws when the agent config is missing', async () => {
@@ -308,5 +362,100 @@ describe('disableCodeReviewForActionRequiredFailure', () => {
 
     expect(state?.reason).toBe('github_ip_allow_list');
     expect(mockSendCodeReviewDisabledEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not disable when fewer than three repository clone timeouts completed today', async () => {
+    const owner = { type: 'user' as const, id: testUser.id, userId: testUser.id };
+    const errorMessage = 'Repository clone timed out';
+    await seedFailedReview({ errorMessage });
+    const triggeringReviewId = await seedFailedReview({ errorMessage });
+
+    const result = await disableCodeReviewForRepeatedCloneTimeoutsToday({
+      owner,
+      platform: 'github',
+      reviewId: triggeringReviewId,
+      errorMessage,
+    });
+
+    const config = await getStoredConfig();
+    const [triggeringReview] = await db
+      .select({ terminalReason: cloud_agent_code_reviews.terminal_reason })
+      .from(cloud_agent_code_reviews)
+      .where(eq(cloud_agent_code_reviews.id, triggeringReviewId))
+      .limit(1);
+
+    expect(result).toBeNull();
+    expect(config?.is_enabled).toBe(true);
+    expect(getCodeReviewActionRequiredState(config)).toBeNull();
+    expect(triggeringReview?.terminalReason).toBe('sandbox_error');
+    expect(mockSendCodeReviewDisabledEmail).not.toHaveBeenCalled();
+  });
+
+  it('disables and emails on the third repository clone timeout today', async () => {
+    const owner = { type: 'user' as const, id: testUser.id, userId: testUser.id };
+    await seedFailedReview({ errorMessage: 'repository clone timed out' });
+    await seedFailedReview({ errorMessage: 'Repository clone timed out' });
+    const errorMessage = 'Repository Clone Timed Out: termination hard_timeout, elapsed 300041ms';
+    const triggeringReviewId = await seedFailedReview({ errorMessage });
+
+    const result = await disableCodeReviewForRepeatedCloneTimeoutsToday({
+      owner,
+      platform: 'github',
+      reviewId: triggeringReviewId,
+      errorMessage,
+    });
+
+    const config = await getStoredConfig();
+    const state = getCodeReviewActionRequiredState(config);
+    const [triggeringReview] = await db
+      .select({ terminalReason: cloud_agent_code_reviews.terminal_reason })
+      .from(cloud_agent_code_reviews)
+      .where(eq(cloud_agent_code_reviews.id, triggeringReviewId))
+      .limit(1);
+
+    expect(result).toBe('repeated_repository_clone_timeout');
+    expect(config?.is_enabled).toBe(false);
+    expect(state?.reason).toBe('repeated_repository_clone_timeout');
+    expect(state?.triggeringReviewId).toBe(triggeringReviewId);
+    expect(state?.lastErrorMessage).toBe(
+      'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.'
+    );
+    expect(state?.emailSentAt).toBeTruthy();
+    expect(triggeringReview?.terminalReason).toBe('repeated_repository_clone_timeout');
+    expect(mockSendCodeReviewDisabledEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendCodeReviewDisabledEmail).toHaveBeenCalledWith(
+      testUser.google_user_email,
+      expect.objectContaining({
+        reason: 'Repository cloning timed out for three code reviews today.',
+        recoveryLabel: 'Contact support',
+        recoveryUrl:
+          'mailto:hi@kilocode.ai?subject=Repository%20clone%20timeouts%20for%20Code%20Reviewer',
+      })
+    );
+  });
+
+  it('does not count other owners, other platforms, or yesterday for clone timeout threshold', async () => {
+    const owner = { type: 'user' as const, id: testUser.id, userId: testUser.id };
+    const otherUser = await insertTestUser();
+    extraUserIds.push(otherUser.id);
+    const errorMessage = 'Repository clone timed out';
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const triggeringReviewId = await seedFailedReview({ errorMessage });
+    await seedFailedReview({ ownerId: otherUser.id, errorMessage });
+    await seedFailedReview({ platform: 'gitlab', errorMessage });
+    await seedFailedReview({ errorMessage, completedAt: yesterday });
+
+    const result = await disableCodeReviewForRepeatedCloneTimeoutsToday({
+      owner,
+      platform: 'github',
+      reviewId: triggeringReviewId,
+      errorMessage,
+    });
+
+    const config = await getStoredConfig();
+    expect(result).toBeNull();
+    expect(config?.is_enabled).toBe(true);
+    expect(mockSendCodeReviewDisabledEmail).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/code-reviews/action-required.test.ts
+++ b/apps/web/src/lib/code-reviews/action-required.test.ts
@@ -17,9 +17,11 @@ import {
   classifyCodeReviewActionRequiredFailure,
   disableCodeReviewForActionRequiredFailure,
   disableCodeReviewForRepeatedCloneTimeoutsToday,
+  getCodeReviewActionRequiredCopy,
   getCodeReviewActionRequiredRecoveryHref,
   getCodeReviewActionRequiredState,
 } from './action-required';
+import { CODE_REVIEW_ACTION_REQUIRED_REASONS } from './action-required-shared';
 
 describe('classifyCodeReviewActionRequiredFailure', () => {
   it('classifies GitHub installation, GitHub IP allow-list, BYOK, GitLab, and selected model failures', () => {
@@ -165,6 +167,20 @@ describe('classifyCodeReviewActionRequiredFailure', () => {
       'mailto:hi@kilocode.ai?subject=Repository%20clone%20timeouts%20for%20Code%20Reviewer'
     );
   });
+
+  it.each(CODE_REVIEW_ACTION_REQUIRED_REASONS)(
+    'uses disabled-state copy for %s',
+    actionRequiredReason => {
+      const copy = getCodeReviewActionRequiredCopy(actionRequiredReason);
+
+      expect(copy.emailReason).toMatch(/Code Reviewer was disabled/);
+      expect(copy.checkSummary).toMatch(/Code Reviewer was disabled/);
+      expect(copy.recoveryLabel.trim()).not.toBe('');
+      expect(copy.checkTitle.trim()).not.toBe('');
+      expect(copy.gitlabDescription.trim()).not.toBe('');
+      expect(copy.gitlabDescription.length).toBeLessThanOrEqual(255);
+    }
+  );
 });
 
 describe('disableCodeReviewForActionRequiredFailure', () => {
@@ -426,7 +442,8 @@ describe('disableCodeReviewForActionRequiredFailure', () => {
     expect(mockSendCodeReviewDisabledEmail).toHaveBeenCalledWith(
       testUser.google_user_email,
       expect.objectContaining({
-        reason: 'Repository cloning timed out for three code reviews today.',
+        reason:
+          'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
         recoveryLabel: 'Contact support',
         recoveryUrl:
           'mailto:hi@kilocode.ai?subject=Repository%20clone%20timeouts%20for%20Code%20Reviewer',

--- a/apps/web/src/lib/code-reviews/action-required.ts
+++ b/apps/web/src/lib/code-reviews/action-required.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 import { captureException } from '@sentry/nextjs';
-import { and, eq, type SQL } from 'drizzle-orm';
-import { agent_configs } from '@kilocode/db/schema';
+import { and, count, eq, gte, lt, type SQL } from 'drizzle-orm';
+import { agent_configs, cloud_agent_code_reviews } from '@kilocode/db/schema';
 import { db, sql, type DrizzleTransaction } from '@/lib/drizzle';
 import { NEXTAUTH_URL } from '@/lib/config.server';
 import { sendCodeReviewDisabledEmail } from '@/lib/email';
@@ -44,6 +44,11 @@ const BYOK_INVALID_KEY_MESSAGE =
   '[byok] your api key is invalid or has been revoked. please check your api key configuration.';
 const BYOK_PERMISSION_DENIED_MESSAGE =
   '[byok] your api key does not have permission to access this resource. please check your api key permissions.';
+const REPEATED_REPOSITORY_CLONE_TIMEOUT_REASON =
+  'repeated_repository_clone_timeout' satisfies CodeReviewActionRequiredReason;
+const REPOSITORY_CLONE_TIMEOUT_MESSAGE_FRAGMENT = 'repository clone timed out';
+const REPEATED_REPOSITORY_CLONE_TIMEOUT_THRESHOLD = 3;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 type AgentConfigWithRuntimeState = {
   runtime_state?: Record<string, unknown> | null;
@@ -57,6 +62,13 @@ type DisableCodeReviewForActionRequiredFailureArgs = {
   errorMessage: string;
 };
 
+type DisableCodeReviewForRepeatedCloneTimeoutsTodayArgs = {
+  owner: Owner;
+  platform: CodeReviewPlatform;
+  reviewId: string;
+  errorMessage?: string | null;
+};
+
 type ClearCodeReviewActionRequiredStateArgs = {
   owner: Owner;
   platform: CodeReviewPlatform;
@@ -68,6 +80,15 @@ type MarkActionRequiredEmailSentArgs = {
   reason: CodeReviewActionRequiredReason;
   sentAt: string;
 };
+
+type PersistActionRequiredDisableArgs = {
+  owner: Owner;
+  platform: CodeReviewPlatform;
+  reviewId?: string;
+  reason: CodeReviewActionRequiredReason;
+};
+
+type PersistActionRequiredBeforeUpdate = (tx: DrizzleTransaction) => Promise<boolean>;
 
 function stripKnownErrorPrefixes(errorMessage: string): string {
   let message = errorMessage.trim();
@@ -158,6 +179,54 @@ function ownerConditions(owner: Pick<Owner, 'type' | 'id'>, platform: CodeReview
       ? eq(agent_configs.owned_by_organization_id, owner.id)
       : eq(agent_configs.owned_by_user_id, owner.id),
   ];
+}
+
+function reviewOwnerConditions(
+  owner: Pick<Owner, 'type' | 'id'>,
+  platform: CodeReviewPlatform
+): SQL[] {
+  return [
+    eq(cloud_agent_code_reviews.platform, platform),
+    owner.type === 'org'
+      ? eq(cloud_agent_code_reviews.owned_by_organization_id, owner.id)
+      : eq(cloud_agent_code_reviews.owned_by_user_id, owner.id),
+  ];
+}
+
+function getUtcDayBounds(now = new Date()): { start: string; end: string } {
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  return {
+    start: start.toISOString(),
+    end: new Date(start.getTime() + DAY_MS).toISOString(),
+  };
+}
+
+function isRepositoryCloneTimeoutMessage(errorMessage?: string | null): boolean {
+  return errorMessage
+    ? errorMessage.toLowerCase().includes(REPOSITORY_CLONE_TIMEOUT_MESSAGE_FRAGMENT)
+    : false;
+}
+
+async function countRepositoryCloneTimeoutFailuresToday(
+  tx: DrizzleTransaction,
+  owner: Owner,
+  platform: CodeReviewPlatform
+): Promise<number> {
+  const dayBounds = getUtcDayBounds();
+  const [row] = await tx
+    .select({ timeoutCount: count() })
+    .from(cloud_agent_code_reviews)
+    .where(
+      and(
+        ...reviewOwnerConditions(owner, platform),
+        eq(cloud_agent_code_reviews.status, 'failed'),
+        gte(cloud_agent_code_reviews.completed_at, dayBounds.start),
+        lt(cloud_agent_code_reviews.completed_at, dayBounds.end),
+        sql`LOWER(${cloud_agent_code_reviews.error_message}) LIKE ${`%${REPOSITORY_CLONE_TIMEOUT_MESSAGE_FRAGMENT}%`}`
+      )
+    );
+
+  return row?.timeoutCount ?? 0;
 }
 
 async function updateActionRequiredRuntimeState(
@@ -287,12 +356,13 @@ async function markActionRequiredEmailSent(args: MarkActionRequiredEmailSentArgs
   });
 }
 
-export async function disableCodeReviewForActionRequiredFailure(
-  args: DisableCodeReviewForActionRequiredFailureArgs
-): Promise<void> {
+async function persistActionRequiredDisable(
+  args: PersistActionRequiredDisableArgs,
+  beforeUpdate?: PersistActionRequiredBeforeUpdate
+): Promise<boolean | null> {
   const copy = getCodeReviewActionRequiredCopy(args.reason);
 
-  const shouldSendEmail = await db.transaction(async tx => {
+  return await db.transaction(async tx => {
     await tx.execute(
       sql`SELECT pg_advisory_xact_lock(hashtext(${`code-review-action-required:${args.owner.type}:${args.owner.id}:${args.platform}`}))`
     );
@@ -318,6 +388,11 @@ export async function disableCodeReviewForActionRequiredFailure(
       );
     }
 
+    if (beforeUpdate) {
+      const shouldPersist = await beforeUpdate(tx);
+      if (!shouldPersist) return null;
+    }
+
     const now = new Date().toISOString();
     const existingState = getCodeReviewActionRequiredState(config);
     const shouldSendEmail =
@@ -341,7 +416,12 @@ export async function disableCodeReviewForActionRequiredFailure(
 
     return shouldSendEmail;
   });
+}
 
+async function sendAndMarkActionRequiredEmailNotifications(
+  args: PersistActionRequiredDisableArgs,
+  shouldSendEmail: boolean
+): Promise<void> {
   if (!shouldSendEmail) return;
 
   try {
@@ -373,6 +453,59 @@ export async function disableCodeReviewForActionRequiredFailure(
       },
     });
   }
+}
+
+export async function disableCodeReviewForActionRequiredFailure(
+  args: DisableCodeReviewForActionRequiredFailureArgs
+): Promise<void> {
+  const shouldSendEmail = await persistActionRequiredDisable(args);
+  if (shouldSendEmail === null) return;
+  await sendAndMarkActionRequiredEmailNotifications(args, shouldSendEmail);
+}
+
+export async function disableCodeReviewForRepeatedCloneTimeoutsToday(
+  args: DisableCodeReviewForRepeatedCloneTimeoutsTodayArgs
+): Promise<CodeReviewActionRequiredReason | null> {
+  if (!isRepositoryCloneTimeoutMessage(args.errorMessage)) return null;
+
+  const shouldSendEmail = await persistActionRequiredDisable(
+    {
+      owner: args.owner,
+      platform: args.platform,
+      reviewId: args.reviewId,
+      reason: REPEATED_REPOSITORY_CLONE_TIMEOUT_REASON,
+    },
+    async tx => {
+      const timeoutCount = await countRepositoryCloneTimeoutFailuresToday(
+        tx,
+        args.owner,
+        args.platform
+      );
+      if (timeoutCount < REPEATED_REPOSITORY_CLONE_TIMEOUT_THRESHOLD) return false;
+
+      await tx
+        .update(cloud_agent_code_reviews)
+        .set({
+          terminal_reason: REPEATED_REPOSITORY_CLONE_TIMEOUT_REASON,
+          updated_at: new Date().toISOString(),
+        })
+        .where(eq(cloud_agent_code_reviews.id, args.reviewId));
+
+      return true;
+    }
+  );
+
+  if (shouldSendEmail === null) return null;
+  await sendAndMarkActionRequiredEmailNotifications(
+    {
+      owner: args.owner,
+      platform: args.platform,
+      reviewId: args.reviewId,
+      reason: REPEATED_REPOSITORY_CLONE_TIMEOUT_REASON,
+    },
+    shouldSendEmail
+  );
+  return REPEATED_REPOSITORY_CLONE_TIMEOUT_REASON;
 }
 
 export async function clearCodeReviewActionRequiredState(

--- a/apps/web/src/lib/purchase-emails.test.ts
+++ b/apps/web/src/lib/purchase-emails.test.ts
@@ -154,8 +154,10 @@ describe('kiloPassDuplicateCardCanceled template', () => {
 
 describe('codeReviewDisabled template', () => {
   test('renders neutral wording, reason, and recovery link', () => {
+    const reason =
+      'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.';
     const html = renderTemplate('codeReviewDisabled', {
-      reason: 'Repository cloning timed out for three code reviews today.',
+      reason,
       recovery_url:
         'mailto:hi@kilocode.ai?subject=Repository%20clone%20timeouts%20for%20Code%20Reviewer',
       recovery_label: 'Contact support',
@@ -163,13 +165,14 @@ describe('codeReviewDisabled template', () => {
     });
 
     expect(html).toContain('Code Reviewer Disabled');
-    expect(html).toContain('Code Reviewer was disabled because it needs attention.');
-    expect(html).toContain('Repository cloning timed out for three code reviews today.');
+    expect(html).toContain('Code Reviewer was disabled for this reason');
+    expect(html).toContain(reason);
     expect(html).toMatch(/Resolve the issue, then enable Code\s+Reviewer again/);
     expect(html).toContain(
       'mailto:hi@kilocode.ai?subject=Repository%20clone%20timeouts%20for%20Code%20Reviewer'
     );
     expect(html).toContain('Contact support');
+    expect(html).not.toContain('Code Reviewer was disabled because it needs attention.');
     expect(html).not.toContain('configuration attention');
     expect(html).not.toContain('Fix the configuration issue');
   });

--- a/apps/web/src/lib/purchase-emails.test.ts
+++ b/apps/web/src/lib/purchase-emails.test.ts
@@ -153,18 +153,25 @@ describe('kiloPassDuplicateCardCanceled template', () => {
 });
 
 describe('codeReviewDisabled template', () => {
-  test('renders reason and recovery link', () => {
+  test('renders neutral wording, reason, and recovery link', () => {
     const html = renderTemplate('codeReviewDisabled', {
-      reason: 'The selected BYOK API key is invalid or has been revoked.',
-      recovery_url: 'https://app.kilocode.ai/byok',
-      recovery_label: 'Update BYOK settings',
+      reason: 'Repository cloning timed out for three code reviews today.',
+      recovery_url:
+        'mailto:hi@kilocode.ai?subject=Repository%20clone%20timeouts%20for%20Code%20Reviewer',
+      recovery_label: 'Contact support',
       year: '2026',
     });
 
     expect(html).toContain('Code Reviewer Disabled');
-    expect(html).toContain('The selected BYOK API key is invalid or has been revoked.');
-    expect(html).toContain('https://app.kilocode.ai/byok');
-    expect(html).toContain('Update BYOK settings');
+    expect(html).toContain('Code Reviewer was disabled because it needs attention.');
+    expect(html).toContain('Repository cloning timed out for three code reviews today.');
+    expect(html).toMatch(/Resolve the issue, then enable Code\s+Reviewer again/);
+    expect(html).toContain(
+      'mailto:hi@kilocode.ai?subject=Repository%20clone%20timeouts%20for%20Code%20Reviewer'
+    );
+    expect(html).toContain('Contact support');
+    expect(html).not.toContain('configuration attention');
+    expect(html).not.toContain('Fix the configuration issue');
   });
 });
 

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1440,6 +1440,7 @@ export const CODE_REVIEW_TERMINAL_REASONS = [
   'gitlab_project_access_required',
   'byok_invalid_key',
   'selected_model_unavailable',
+  'repeated_repository_clone_timeout',
   'user_cancelled',
   'superseded',
   'interrupted',

--- a/packages/worker-utils/src/cloud-agent-next-client.ts
+++ b/packages/worker-utils/src/cloud-agent-next-client.ts
@@ -124,6 +124,7 @@ export type CloudAgentTerminalReason =
   | 'gitlab_project_access_required'
   | 'byok_invalid_key'
   | 'selected_model_unavailable'
+  | 'repeated_repository_clone_timeout'
   | 'user_cancelled'
   | 'superseded'
   | 'interrupted'

--- a/services/code-review-infra/src/types.ts
+++ b/services/code-review-infra/src/types.ts
@@ -107,6 +107,7 @@ const InternalStatusTerminalReasonSchema = z
     'gitlab_project_access_required',
     'byok_invalid_key',
     'selected_model_unavailable',
+    'repeated_repository_clone_timeout',
     'user_cancelled',
     'superseded',
     'interrupted',


### PR DESCRIPTION
## Summary
- Disable Code Reviewer after the third repository clone timeout in one UTC day for the same owner and platform.
- Keep first-time clone timeouts retryable, then show action-required status on GitHub or GitLab only when the disable threshold is reached.
- Clarify disabled Code Reviewer copy in the shared notification layer so email, GitHub Check Runs, and GitLab commit statuses explain the reason and next step for clone timeouts and existing setup/configuration problems.

## Verification
1. In a test environment, cause two repository clone timeout failures for the same owner and platform and confirm Code Reviewer stays enabled.
2. Cause a third matching failure on the same UTC day and confirm Code Reviewer is disabled.
3. Confirm the disabled email, GitHub Check Run, or GitLab status clearly says Code Reviewer was disabled and names the relevant reason.

## DB checks

3 users would be disabled when this PR gets out after checking the last 2 days.

## Reviewer Notes
- The threshold uses the existing owner/platform Code Reviewer config scope.
- The copy update intentionally stays in the shared action-required copy layer; sender APIs, callback behavior, dispatch behavior, runtime state, and database state are unchanged.
- No database migration is needed because terminal reasons are stored as text.