### PR TITLE
feat(model-selector): show BYOK availability

### DIFF
--- a/apps/mobile/src/app/(app)/agent-chat/model-picker.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/model-picker.tsx
@@ -7,9 +7,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Text } from '@/components/ui/text';
 import {
+  BYOK_MODEL_LABEL,
   FREE_MODEL_DATA_LABEL,
   FREE_MODEL_FREE_LABEL,
-  getFreeModelDataAccessibilityLabel,
+  hasUserByokAvailable,
   isFreeModelOption,
   mayTrainOnYourPrompts,
 } from '@/lib/free-model-data-disclosure';
@@ -203,8 +204,18 @@ export default function ModelPickerScreen() {
         const modelOption = item.model;
         const selected = modelOption.id === selectedModel;
         const free = isFreeModelOption(modelOption);
+        const byok = hasUserByokAvailable(modelOption);
         const collectsData = mayTrainOnYourPrompts(modelOption);
         const hasVariants = modelOption.variants.length > 1;
+        const accessibilityLabel = [
+          modelOption.name,
+          byok ? BYOK_MODEL_LABEL : undefined,
+          free && !byok ? FREE_MODEL_FREE_LABEL : undefined,
+          collectsData ? FREE_MODEL_DATA_LABEL : undefined,
+          selected ? 'selected' : undefined,
+        ]
+          .filter(Boolean)
+          .join(', ');
 
         return (
           <View className="border-b border-border">
@@ -214,20 +225,27 @@ export default function ModelPickerScreen() {
                 handleSelectModel(modelOption.id);
               }}
               accessibilityRole="button"
-              accessibilityLabel={`${collectsData ? getFreeModelDataAccessibilityLabel(modelOption.name) : modelOption.name}${selected ? ', selected' : ''}`}
+              accessibilityLabel={accessibilityLabel}
             >
               <View className="flex-1">
                 <Text className="text-base text-foreground">{modelOption.name}</Text>
                 <Text className="text-xs text-muted-foreground">{modelOption.id}</Text>
-                {free || collectsData ? (
+                {free || byok || collectsData ? (
                   <View className="mt-1 flex-row items-center gap-1 self-start">
-                    {free ? (
+                    {free && !byok ? (
                       <View
                         className="rounded-full px-2 py-0.5"
                         style={{ backgroundColor: colors.good }}
                       >
                         <Text className="text-[11px] font-medium text-white" numberOfLines={1}>
                           {FREE_MODEL_FREE_LABEL}
+                        </Text>
+                      </View>
+                    ) : null}
+                    {byok ? (
+                      <View className="rounded-full bg-neutral-200 px-2 py-0.5 dark:bg-neutral-700">
+                        <Text className="text-[11px] font-medium text-foreground" numberOfLines={1}>
+                          {BYOK_MODEL_LABEL}
                         </Text>
                       </View>
                     ) : null}

--- a/apps/mobile/src/components/agents/model-selector.tsx
+++ b/apps/mobile/src/components/agents/model-selector.tsx
@@ -4,7 +4,9 @@ import { BookOpenCheck, Brain, ChevronDown } from 'lucide-react-native';
 
 import { Text } from '@/components/ui/text';
 import {
+  BYOK_MODEL_LABEL,
   getFreeModelDataAccessibilityLabel,
+  hasUserByokAvailable,
   mayTrainOnYourPrompts,
 } from '@/lib/free-model-data-disclosure';
 import { type ModelOption, thinkingEffortLabel } from '@/lib/hooks/use-available-models';
@@ -43,13 +45,15 @@ export function ModelSelector({
 
   const selectedModel = options.find(m => m.id === value);
   const label = selectedModel?.name ?? (value || 'Model');
+  const byok = hasUserByokAvailable(selectedModel);
   const collectsData = mayTrainOnYourPrompts(selectedModel);
   const hasVariants = selectedModel ? selectedModel.variants.length > 1 : false;
   const variantLabel = variant ? thinkingEffortLabel(variant) : '';
   const compactVariantLabel = variant ? compactThinkingEffortLabel(variant) : '';
   const dataLabel = collectsData ? getFreeModelDataAccessibilityLabel(label) : label;
+  const modelLabel = byok ? `${dataLabel}, ${BYOK_MODEL_LABEL}` : dataLabel;
   const accessibilityLabel =
-    hasVariants && variantLabel ? `${dataLabel}, ${variantLabel} thinking effort` : dataLabel;
+    hasVariants && variantLabel ? `${modelLabel}, ${variantLabel} thinking effort` : modelLabel;
 
   function handlePress() {
     if (effectivelyDisabled) {
@@ -82,6 +86,13 @@ export function ModelSelector({
         >
           {label}
         </Text>
+        {byok ? (
+          <View className="rounded-full bg-neutral-200 px-1.5 py-0.5 dark:bg-neutral-700">
+            <Text className="text-[10px] font-medium text-foreground" numberOfLines={1}>
+              {BYOK_MODEL_LABEL}
+            </Text>
+          </View>
+        ) : null}
         {collectsData ? <BookOpenCheck size={12} color={colors.warn} /> : null}
         {hasVariants && compactVariantLabel ? (
           <View className="flex-row items-center gap-1 rounded-full bg-neutral-200 px-1.5 py-0.5 dark:bg-neutral-800">

--- a/apps/mobile/src/lib/free-model-data-disclosure.test.ts
+++ b/apps/mobile/src/lib/free-model-data-disclosure.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import {
+  BYOK_MODEL_LABEL,
   FREE_MODEL_DATA_LABEL,
   FREE_MODEL_FREE_LABEL,
   getFreeModelDataAccessibilityLabel,
+  hasUserByokAvailable,
   isFreeModelOption,
   mayTrainOnYourPrompts,
 } from './free-model-data-disclosure';
 
 describe('free model data disclosure', () => {
   it('uses the disclosure label expected in model pickers', () => {
+    expect(BYOK_MODEL_LABEL).toBe('BYOK');
     expect(FREE_MODEL_DATA_LABEL).toBe('Data collected');
     expect(FREE_MODEL_FREE_LABEL).toBe('Free');
   });
@@ -37,6 +40,22 @@ describe('free model data disclosure', () => {
       })
     ).toBe(false);
     expect(mayTrainOnYourPrompts({ id: 'free-model', isFree: true })).toBe(false);
+  });
+
+  it('detects only explicit user BYOK availability', () => {
+    expect(
+      hasUserByokAvailable({
+        id: 'anthropic/claude',
+        hasUserByokAvailable: true,
+      })
+    ).toBe(true);
+    expect(
+      hasUserByokAvailable({
+        id: 'anthropic/claude',
+        hasUserByokAvailable: false,
+      })
+    ).toBe(false);
+    expect(hasUserByokAvailable({ id: 'anthropic/claude' })).toBe(false);
   });
 
   it('adds a data collection phrase to accessibility labels', () => {

--- a/apps/mobile/src/lib/free-model-data-disclosure.ts
+++ b/apps/mobile/src/lib/free-model-data-disclosure.ts
@@ -1,3 +1,4 @@
+export const BYOK_MODEL_LABEL = 'BYOK';
 export const FREE_MODEL_DATA_LABEL = 'Data collected';
 export const FREE_MODEL_FREE_LABEL = 'Free';
 
@@ -5,6 +6,7 @@ type ModelDataDisclosure = {
   id: string;
   isFree?: boolean;
   mayTrainOnYourPrompts?: boolean;
+  hasUserByokAvailable?: boolean;
 };
 
 export function isFreeModelOption(model: ModelDataDisclosure | undefined) {
@@ -13,6 +15,10 @@ export function isFreeModelOption(model: ModelDataDisclosure | undefined) {
 
 export function mayTrainOnYourPrompts(model: ModelDataDisclosure | undefined) {
   return model?.mayTrainOnYourPrompts === true;
+}
+
+export function hasUserByokAvailable(model: ModelDataDisclosure | undefined) {
+  return model?.hasUserByokAvailable === true;
 }
 
 export function getFreeModelDataAccessibilityLabel(label: string) {

--- a/apps/mobile/src/lib/hooks/use-available-models.ts
+++ b/apps/mobile/src/lib/hooks/use-available-models.ts
@@ -14,6 +14,7 @@ export type ModelOption = {
   isPreferred: boolean;
   isFree?: boolean;
   mayTrainOnYourPrompts?: boolean;
+  hasUserByokAvailable?: boolean;
 };
 
 type ModelResponse = {
@@ -22,6 +23,7 @@ type ModelResponse = {
     name: string;
     isFree?: boolean;
     mayTrainOnYourPrompts?: boolean;
+    hasUserByokAvailable?: boolean;
     preferredIndex?: number;
     opencode?: {
       variants?: Record<string, unknown>;
@@ -104,6 +106,7 @@ export function useAvailableModels(organizationId: string | undefined) {
       name: formatShortModelName(model.name),
       isFree: model.isFree,
       mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+      hasUserByokAvailable: model.hasUserByokAvailable,
       variants: Object.keys(model.opencode?.variants ?? {}),
       preferredIndex: model.preferredIndex,
     }));
@@ -131,6 +134,7 @@ export function useAvailableModels(organizationId: string | undefined) {
       isPreferred: item.preferredIndex !== undefined,
       isFree: item.isFree,
       mayTrainOnYourPrompts: item.mayTrainOnYourPrompts,
+      hasUserByokAvailable: item.hasUserByokAvailable,
     }));
   }, [data]);
 

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -2135,6 +2135,7 @@ export function SettingsTab({
           name: model.name,
           isFree: model.isFree,
           mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+          hasUserByokAvailable: model.hasUserByokAvailable,
         })),
         trackedOpenClawVersion: trackedVersion,
         runningOpenClawVersion: runningVersion,

--- a/apps/web/src/app/(app)/claw/hooks/useClawModelOptions.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawModelOptions.ts
@@ -57,6 +57,7 @@ export function useClawModelOptions(enabled = true): {
           name: model.name,
           isFree: model.isFree,
           mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+          hasUserByokAvailable: model.hasUserByokAvailable,
         })),
         trackedOpenClawVersion: trackedVersion,
         runningOpenClawVersion: runningVersion,

--- a/apps/web/src/app/(app)/cloud/webhooks/[triggerId]/EditWebhookTriggerContent.tsx
+++ b/apps/web/src/app/(app)/cloud/webhooks/[triggerId]/EditWebhookTriggerContent.tsx
@@ -92,6 +92,7 @@ export function EditWebhookTriggerContent({
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
       })),
     [modelsData?.data]
   );

--- a/apps/web/src/app/(app)/cloud/webhooks/new/CreateWebhookTriggerContent.tsx
+++ b/apps/web/src/app/(app)/cloud/webhooks/new/CreateWebhookTriggerContent.tsx
@@ -78,6 +78,7 @@ export function CreateWebhookTriggerContent({ organizationId }: CreateWebhookTri
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
       })),
     [modelsData?.data]
   );

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient.tsx
@@ -102,6 +102,7 @@ export function RigSettingsPageClient({ townId, rigId, organizationId }: Props) 
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
       })) ?? [],
     [modelsData]
   );

--- a/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -147,6 +147,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
       })) ?? [],
     [modelsData]
   );

--- a/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
+++ b/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
@@ -335,6 +335,7 @@ export function OnboardingStepModel() {
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
       })) ?? [],
     [modelsData]
   );

--- a/apps/web/src/components/app-builder/AppBuilderChat.tsx
+++ b/apps/web/src/components/app-builder/AppBuilderChat.tsx
@@ -539,6 +539,7 @@ export function AppBuilderChat({ organizationId }: AppBuilderChatProps) {
           supportsVision,
           isFree: m.isFree,
           mayTrainOnYourPrompts: m.mayTrainOnYourPrompts,
+          hasUserByokAvailable: m.hasUserByokAvailable,
         };
       }),
     [availableModels]

--- a/apps/web/src/components/app-builder/AppBuilderLanding.tsx
+++ b/apps/web/src/components/app-builder/AppBuilderLanding.tsx
@@ -639,6 +639,7 @@ export function AppBuilderLanding({ organizationId, onProjectCreated }: AppBuild
           supportsVision,
           isFree: m.isFree,
           mayTrainOnYourPrompts: m.mayTrainOnYourPrompts,
+          hasUserByokAvailable: m.hasUserByokAvailable,
         };
       }),
     [availableModels]

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -172,6 +172,7 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
           name: model.name,
           isFree: model.isFree,
           mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+          hasUserByokAvailable: model.hasUserByokAvailable,
           variants: model.opencode?.variants ? Object.keys(model.opencode.variants) : undefined,
         }))
       ),

--- a/apps/web/src/components/cloud-agent-next/hooks/useOrganizationModels.ts
+++ b/apps/web/src/components/cloud-agent-next/hooks/useOrganizationModels.ts
@@ -44,6 +44,7 @@ export function useOrganizationModels(organizationId?: string): UseOrganizationM
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
         variants: model.opencode?.variants ? Object.keys(model.opencode.variants) : undefined,
       })) ?? []
     );

--- a/apps/web/src/components/cloud-agent/CloudSessionsPage.tsx
+++ b/apps/web/src/components/cloud-agent/CloudSessionsPage.tsx
@@ -82,6 +82,7 @@ export function CloudSessionsPage({ organizationId }: CloudSessionsPageProps) {
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
         variants: model.opencode?.variants ? Object.keys(model.opencode.variants) : undefined,
       })),
     [allModels]

--- a/apps/web/src/components/cloud-agent/hooks/useOrganizationModels.ts
+++ b/apps/web/src/components/cloud-agent/hooks/useOrganizationModels.ts
@@ -40,6 +40,7 @@ export function useOrganizationModels(organizationId?: string): UseOrganizationM
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
       })) ?? []
     );
   }, [openRouterModels]);

--- a/apps/web/src/components/cloud-agent/profile-editor/KiloCommandsTab.tsx
+++ b/apps/web/src/components/cloud-agent/profile-editor/KiloCommandsTab.tsx
@@ -190,6 +190,7 @@ function KiloCommandForm(props: KiloCommandFormProps) {
         name: m.name,
         isFree: m.isFree,
         mayTrainOnYourPrompts: m.mayTrainOnYourPrompts,
+        hasUserByokAvailable: m.hasUserByokAvailable,
         variants: m.opencode?.variants ? Object.keys(m.opencode.variants) : undefined,
       })),
     [modelsData]

--- a/apps/web/src/components/cloud-agent/profile-editor/ProfileAgentsTab.tsx
+++ b/apps/web/src/components/cloud-agent/profile-editor/ProfileAgentsTab.tsx
@@ -328,6 +328,7 @@ function AgentForm({
         name: m.name,
         isFree: m.isFree,
         mayTrainOnYourPrompts: m.mayTrainOnYourPrompts,
+        hasUserByokAvailable: m.hasUserByokAvailable,
         variants: m.opencode?.variants ? Object.keys(m.opencode.variants) : undefined,
       })),
     [modelsData]

--- a/apps/web/src/components/integrations/DiscordIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/DiscordIntegrationDetails.tsx
@@ -46,6 +46,7 @@ export function DiscordIntegrationDetails({
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
       })) ?? []
     );
   }, [openRouterModels]);

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -61,6 +61,7 @@ export function GitHubIntegrationDetails({
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
       })) ?? []
     );
   }, [openRouterModels]);

--- a/apps/web/src/components/integrations/LinearIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/LinearIntegrationDetails.tsx
@@ -55,6 +55,7 @@ export function LinearIntegrationDetails({
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
       })) ?? []
     );
   }, [openRouterModels]);

--- a/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
@@ -74,6 +74,7 @@ export function SlackIntegrationDetails({
         name: model.name,
         isFree: model.isFree,
         mayTrainOnYourPrompts: model.mayTrainOnYourPrompts,
+        hasUserByokAvailable: model.hasUserByokAvailable,
       })) ?? []
     );
   }, [openRouterModels]);

--- a/apps/web/src/components/shared/ModelCombobox.tsx
+++ b/apps/web/src/components/shared/ModelCombobox.tsx
@@ -19,9 +19,11 @@ import { preferredModels } from '@/lib/ai-gateway/models';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { formatShortModelDisplayName } from '@/lib/format-model-name';
 import {
+  BYOK_MODEL_LABEL,
   FREE_MODEL_DATA_LABEL,
   FREE_MODEL_FREE_LABEL,
   getFreeModelDataTooltip,
+  hasUserByokAvailable,
   isFreeModelOption,
   mayTrainOnYourPrompts,
 } from '@/components/shared/free-model-data-disclosure';
@@ -32,6 +34,7 @@ export type ModelOption = {
   supportsVision?: boolean;
   isFree?: boolean;
   mayTrainOnYourPrompts?: boolean;
+  hasUserByokAvailable?: boolean;
   /** Ordered list of variant key names (e.g., ["none","low","medium","high","max"]) */
   variants?: string[];
 };
@@ -462,15 +465,21 @@ function FreeModelDataIcon({ compact = false }: { compact?: boolean }) {
 
 function ModelMetadataBadges({ model }: { model: ModelOption }) {
   const free = isFreeModelOption(model);
+  const byok = hasUserByokAvailable(model);
   const collectsData = mayTrainOnYourPrompts(model);
 
-  if (!free && !collectsData) return null;
+  if (!free && !byok && !collectsData) return null;
 
   return (
     <span className="inline-flex shrink-0 items-center gap-1">
-      {free && (
+      {free && !byok && (
         <span className="inline-flex shrink-0 items-center rounded-full bg-green-500/20 px-1.5 py-0.5 text-[10px] font-medium text-green-400 ring-1 ring-green-500/20">
           {FREE_MODEL_FREE_LABEL}
+        </span>
+      )}
+      {byok && (
+        <span className="bg-muted text-muted-foreground ring-border inline-flex shrink-0 items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium ring-1">
+          {BYOK_MODEL_LABEL}
         </span>
       )}
       {collectsData && <FreeModelDataIcon compact />}

--- a/apps/web/src/components/shared/free-model-data-disclosure.test.ts
+++ b/apps/web/src/components/shared/free-model-data-disclosure.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import {
+  BYOK_MODEL_LABEL,
   FREE_MODEL_DATA_LABEL,
   FREE_MODEL_FREE_LABEL,
   getFreeModelDataTooltip,
+  hasUserByokAvailable,
   isFreeModelOption,
   mayTrainOnYourPrompts,
 } from './free-model-data-disclosure';
@@ -11,6 +13,7 @@ describe('free model data disclosure', () => {
   it('uses the disclosure label expected in model pickers', () => {
     expect(FREE_MODEL_DATA_LABEL).toBe('Data collected');
     expect(FREE_MODEL_FREE_LABEL).toBe('Free');
+    expect(BYOK_MODEL_LABEL).toBe('BYOK');
   });
 
   it('detects explicit and known free model options', () => {
@@ -37,6 +40,22 @@ describe('free model data disclosure', () => {
       })
     ).toBe(false);
     expect(mayTrainOnYourPrompts({ id: 'free-model', isFree: true })).toBe(false);
+  });
+
+  it('detects only explicit user BYOK availability', () => {
+    expect(
+      hasUserByokAvailable({
+        id: 'anthropic/claude',
+        hasUserByokAvailable: true,
+      })
+    ).toBe(true);
+    expect(
+      hasUserByokAvailable({
+        id: 'anthropic/claude',
+        hasUserByokAvailable: false,
+      })
+    ).toBe(false);
+    expect(hasUserByokAvailable({ id: 'anthropic/claude' })).toBe(false);
   });
 
   it('uses the short disclosure text as tooltip content', () => {

--- a/apps/web/src/components/shared/free-model-data-disclosure.ts
+++ b/apps/web/src/components/shared/free-model-data-disclosure.ts
@@ -1,5 +1,6 @@
 export const FREE_MODEL_DATA_LABEL = 'Data collected';
 export const FREE_MODEL_FREE_LABEL = 'Free';
+export const BYOK_MODEL_LABEL = 'BYOK';
 
 export function getFreeModelDataTooltip() {
   return FREE_MODEL_DATA_LABEL;
@@ -9,6 +10,7 @@ type ModelDataDisclosure = {
   id: string;
   isFree?: boolean;
   mayTrainOnYourPrompts?: boolean;
+  hasUserByokAvailable?: boolean;
 };
 
 export function isFreeModelOption(model: ModelDataDisclosure | undefined) {
@@ -17,4 +19,8 @@ export function isFreeModelOption(model: ModelDataDisclosure | undefined) {
 
 export function mayTrainOnYourPrompts(model: ModelDataDisclosure | undefined) {
   return model?.mayTrainOnYourPrompts === true;
+}
+
+export function hasUserByokAvailable(model: ModelDataDisclosure | undefined) {
+  return model?.hasUserByokAvailable === true;
 }


### PR DESCRIPTION
## Summary

- Show a neutral `BYOK` badge for models with explicitly available personal or organization provider keys across web and mobile model pickers.
- Prefer `BYOK` over `Free` when both metadata fields are set, while keeping prompt-training disclosure independent.
- Preserve BYOK metadata across every web `ModelCombobox` mapping and the mobile model catalog.
- Include BYOK in mobile selected-model controls and accessibility labels.

## Verification

- [ ] Manual UI verification was not performed because local app services and a mobile dev build were not started.

## Visual Changes

No screenshots captured. Applicable model rows and the mobile selected-model control now show a neutral `BYOK` badge.

## Reviewer Notes

The indicator relies only on `hasUserByokAvailable === true`; absent or false metadata leaves existing model presentation unchanged. Mobile typechecking is currently blocked by unrelated missing `@kilocode/trpc` declarations in this worktree.