### PR TITLE
feat(kiloclaw) version image display

### DIFF
--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -2367,7 +2367,11 @@ export function SettingsTab({
           <div className="mt-4 space-y-6 border-t pt-4">
             <VersionPinCard
               trackedImageTag={status.trackedImageTag}
+              trackedOpenClawVersion={runningVersion ?? trackedVersion}
               latestImageTag={variantsMatch ? (latestVersion?.imageTag ?? null) : null}
+              latestOpenClawVersion={
+                variantsMatch ? cleanVersion(latestVersion?.openclawVersion) : null
+              }
               mutations={mutations}
             />
             <EarlyAccessCard />

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -2367,7 +2367,13 @@ export function SettingsTab({
           <div className="mt-4 space-y-6 border-t pt-4">
             <VersionPinCard
               trackedImageTag={status.trackedImageTag}
-              trackedOpenClawVersion={runningVersion ?? trackedVersion}
+              // Pair the tracked image with the version baked into THAT image
+              // (trackedVersion), not the live controller version. They diverge
+              // when OpenClaw self-updates (the "Modified" state above), and
+              // attributing the runtime version to the tracked image tag would
+              // be inaccurate — and could falsely trigger the "same version,
+              // different image" tooltip on the Latest row.
+              trackedOpenClawVersion={trackedVersion}
               latestImageTag={variantsMatch ? (latestVersion?.imageTag ?? null) : null}
               latestOpenClawVersion={
                 variantsMatch ? cleanVersion(latestVersion?.openclawVersion) : null

--- a/apps/web/src/app/(app)/claw/components/VersionPinCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/VersionPinCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Pin, PinOff, Info } from 'lucide-react';
 import { toast } from 'sonner';
 import { toastPinMutationResult } from '@/lib/kiloclaw/pin-sync-toast';
@@ -16,16 +16,133 @@ import {
 } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
+function truncateTag(tag: string) {
+  if (tag.length <= 20) return tag;
+  return `${tag.slice(0, 8)}...${tag.slice(-8)}`;
+}
+
+/**
+ * One row in the compact image table: a label plus the OpenClaw version and
+ * the (truncated) image tag/hash. Either piece may be missing — a row renders
+ * whatever it has, falling back to "Unknown" only when both are absent.
+ */
+function ImageRow({
+  label,
+  openclawVersion,
+  imageTag,
+  tooltip,
+  spaced = false,
+}: {
+  label: string;
+  openclawVersion: string | null | undefined;
+  imageTag: string | null | undefined;
+  /** Optional explanatory text surfaced via an info icon next to the label. */
+  tooltip?: string;
+  spaced?: boolean;
+}) {
+  return (
+    <tr>
+      <td className={`text-muted-foreground pr-3 align-top${spaced ? ' pt-1' : ''}`}>
+        <span className="inline-flex items-center gap-1">
+          {label}
+          {tooltip && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button type="button" aria-label={tooltip} className="inline-flex cursor-help">
+                  <Info className="size-3.5 shrink-0" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">{tooltip}</TooltipContent>
+            </Tooltip>
+          )}
+        </span>
+      </td>
+      <td className={spaced ? 'pt-1' : undefined}>
+        <span className="inline-flex flex-wrap items-center gap-1.5">
+          {openclawVersion && <span className="text-foreground">OpenClaw {openclawVersion}</span>}
+          {imageTag ? (
+            <code className="bg-muted rounded px-1.5 py-0.5 text-xs" title={imageTag}>
+              {truncateTag(imageTag)}
+            </code>
+          ) : (
+            !openclawVersion && <span className="text-muted-foreground">Unknown</span>
+          )}
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * The "Active" and "Latest" image rows shown to an unpinned instance. Each
+ * pairs the OpenClaw version with its image tag/hash so the two columns read
+ * e.g. "Active  OpenClaw 2026.6.5  img-5f02b9408089". Rendered inside a
+ * <tbody>; a row is omitted only when both its version and tag are absent.
+ */
+export function VersionImageMetadata({
+  currentOpenClawVersion,
+  trackedImageTag,
+  latestOpenClawVersion,
+  latestImageTag,
+}: {
+  currentOpenClawVersion: string | null | undefined;
+  trackedImageTag: string | null | undefined;
+  latestOpenClawVersion: string | null | undefined;
+  latestImageTag: string | null | undefined;
+}) {
+  // The active and latest images can share the same OpenClaw version while
+  // still being different builds (the image tag differs). In that case the
+  // "Update available" framing would be confusing, so explain that the latest
+  // image carries non-version changes rather than a newer OpenClaw release.
+  const sameOpenClawVersionDifferentImage =
+    !!currentOpenClawVersion &&
+    !!latestOpenClawVersion &&
+    currentOpenClawVersion === latestOpenClawVersion &&
+    !!trackedImageTag &&
+    !!latestImageTag &&
+    trackedImageTag !== latestImageTag;
+
+  return (
+    <>
+      {(trackedImageTag || currentOpenClawVersion) && (
+        <ImageRow
+          label="Active"
+          openclawVersion={currentOpenClawVersion}
+          imageTag={trackedImageTag}
+        />
+      )}
+      {(latestImageTag || latestOpenClawVersion) && (
+        <ImageRow
+          label="Latest"
+          openclawVersion={latestOpenClawVersion}
+          imageTag={latestImageTag}
+          tooltip={
+            sameOpenClawVersionDifferentImage
+              ? 'Both images run the same OpenClaw version, but the latest image includes additional fixes, improvements, and features.'
+              : undefined
+          }
+          spaced
+        />
+      )}
+    </>
+  );
+}
+
 export function VersionPinCard({
   trackedImageTag,
+  trackedOpenClawVersion,
   latestImageTag,
+  latestOpenClawVersion,
   mutations,
 }: {
   trackedImageTag: string | null;
+  trackedOpenClawVersion: string | null;
   latestImageTag: string | null;
+  latestOpenClawVersion: string | null;
   mutations: ClawMutations;
 }) {
   const { data: myPin, isLoading: pinLoading } = useClawMyPin();
@@ -89,11 +206,6 @@ export function VersionPinCard({
       </div>
     );
   }
-
-  const truncateTag = (tag: string) => {
-    if (tag.length <= 20) return tag;
-    return `${tag.slice(0, 8)}...${tag.slice(-8)}`;
-  };
 
   return (
     <div>
@@ -219,46 +331,18 @@ export function VersionPinCard({
           <table>
             <tbody>
               {isPinned ? (
-                <tr>
-                  <td className="text-muted-foreground pr-3 align-top">Pinned image</td>
-                  <td>
-                    <code
-                      className="bg-muted rounded px-1.5 py-0.5 text-xs"
-                      title={myPin.image_tag}
-                    >
-                      {truncateTag(myPin.image_tag)}
-                    </code>
-                  </td>
-                </tr>
+                <ImageRow
+                  label="Pinned image"
+                  openclawVersion={myPin.openclaw_version}
+                  imageTag={myPin.image_tag}
+                />
               ) : (
-                <>
-                  {trackedImageTag && (
-                    <tr>
-                      <td className="text-muted-foreground pr-3 align-top">Current image</td>
-                      <td>
-                        <code
-                          className="bg-muted rounded px-1.5 py-0.5 text-xs"
-                          title={trackedImageTag}
-                        >
-                          {truncateTag(trackedImageTag)}
-                        </code>
-                      </td>
-                    </tr>
-                  )}
-                  {latestImageTag && (
-                    <tr>
-                      <td className="text-muted-foreground pr-3 pt-1 align-top">Latest image</td>
-                      <td className="pt-1">
-                        <code
-                          className="bg-muted rounded px-1.5 py-0.5 text-xs"
-                          title={latestImageTag}
-                        >
-                          {truncateTag(latestImageTag)}
-                        </code>
-                      </td>
-                    </tr>
-                  )}
-                </>
+                <VersionImageMetadata
+                  currentOpenClawVersion={trackedOpenClawVersion}
+                  trackedImageTag={trackedImageTag}
+                  latestOpenClawVersion={latestOpenClawVersion}
+                  latestImageTag={latestImageTag}
+                />
               )}
             </tbody>
           </table>

--- a/apps/web/src/app/(app)/claw/components/version-display.test.ts
+++ b/apps/web/src/app/(app)/claw/components/version-display.test.ts
@@ -1,0 +1,77 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { VersionImageMetadata } from './VersionPinCard';
+
+describe('KiloClaw version display', () => {
+  it('pairs current and latest OpenClaw versions with their image tags', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        'table',
+        null,
+        createElement(
+          'tbody',
+          null,
+          createElement(VersionImageMetadata, {
+            currentOpenClawVersion: '2026.6.5',
+            trackedImageTag: 'img-5f02b9408089',
+            latestOpenClawVersion: '2026.6.8',
+            latestImageTag: 'img-048842db6829',
+          })
+        )
+      )
+    );
+
+    expect(html).toContain('Active');
+    expect(html).toContain('OpenClaw 2026.6.5');
+    expect(html).toContain('img-5f02b9408089');
+    expect(html).toContain('Latest');
+    expect(html).toContain('OpenClaw 2026.6.8');
+    expect(html).toContain('img-048842db6829');
+    // Different OpenClaw versions: no "same version" explanation.
+    expect(html).not.toContain('the same OpenClaw version');
+  });
+
+  it('explains when active and latest share an OpenClaw version but differ by image', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        'table',
+        null,
+        createElement(
+          'tbody',
+          null,
+          createElement(VersionImageMetadata, {
+            currentOpenClawVersion: '2026.6.8',
+            trackedImageTag: 'img-5f02b9408089',
+            latestOpenClawVersion: '2026.6.8',
+            latestImageTag: 'img-048842db6829',
+          })
+        )
+      )
+    );
+
+    expect(html).toContain(
+      'Both images run the same OpenClaw version, but the latest image includes additional fixes, improvements, and features.'
+    );
+  });
+
+  it('omits the explanation when active and latest are the same image', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        'table',
+        null,
+        createElement(
+          'tbody',
+          null,
+          createElement(VersionImageMetadata, {
+            currentOpenClawVersion: '2026.6.8',
+            trackedImageTag: 'img-048842db6829',
+            latestOpenClawVersion: '2026.6.8',
+            latestImageTag: 'img-048842db6829',
+          })
+        )
+      )
+    );
+
+    expect(html).not.toContain('the same OpenClaw version');
+  });
+});

--- a/apps/web/src/app/(app)/claw/components/version-display.test.ts
+++ b/apps/web/src/app/(app)/claw/components/version-display.test.ts
@@ -2,6 +2,15 @@ import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { VersionImageMetadata } from './VersionPinCard';
 
+// The same-version explanation is surfaced as the info trigger's accessible
+// name (aria-label), which renders into static markup. We deliberately assert
+// against the aria-label rather than the Radix TooltipContent: that content
+// lives in a portal and only mounts when the tooltip is open, so it never
+// appears in renderToStaticMarkup output.
+const SAME_VERSION_EXPLANATION =
+  'Both images run the same OpenClaw version, but the latest image includes additional fixes, improvements, and features.';
+const SAME_VERSION_ARIA_LABEL = `aria-label="${SAME_VERSION_EXPLANATION}"`;
+
 describe('KiloClaw version display', () => {
   it('pairs current and latest OpenClaw versions with their image tags', () => {
     const html = renderToStaticMarkup(
@@ -27,8 +36,8 @@ describe('KiloClaw version display', () => {
     expect(html).toContain('Latest');
     expect(html).toContain('OpenClaw 2026.6.8');
     expect(html).toContain('img-048842db6829');
-    // Different OpenClaw versions: no "same version" explanation.
-    expect(html).not.toContain('the same OpenClaw version');
+    // Different OpenClaw versions: no "same version" explanation trigger.
+    expect(html).not.toContain(SAME_VERSION_ARIA_LABEL);
   });
 
   it('explains when active and latest share an OpenClaw version but differ by image', () => {
@@ -49,9 +58,7 @@ describe('KiloClaw version display', () => {
       )
     );
 
-    expect(html).toContain(
-      'Both images run the same OpenClaw version, but the latest image includes additional fixes, improvements, and features.'
-    );
+    expect(html).toContain(SAME_VERSION_ARIA_LABEL);
   });
 
   it('omits the explanation when active and latest are the same image', () => {
@@ -72,6 +79,6 @@ describe('KiloClaw version display', () => {
       )
     );
 
-    expect(html).not.toContain('the same OpenClaw version');
+    expect(html).not.toContain(SAME_VERSION_ARIA_LABEL);
   });
 });


### PR DESCRIPTION
## Summary

The Manage Version section of the KiloClaw settings page showed only image tag
hashes, which are hard to read on their own. This pairs each image tag with its
OpenClaw version so the rows read like "Active  OpenClaw 2026.6.5  img-5f02...".
The "Current image" and "Latest image" labels are renamed to "Active" and
"Latest".

## Changes

- `VersionPinCard` now renders the OpenClaw version beside the image tag for the
  Active, Latest, and Pinned rows. Labels changed from "Current image" / "Latest
  image" to "Active" / "Latest".
- Extracted an exported `VersionImageMetadata` component (plus a shared
  `ImageRow` helper) that renders the Active and Latest rows. A row now shows
  whenever it has either a version or a tag, falling back to "Unknown" only when
  both are absent (previously a row required the image tag).
- The Active row pairs the tracked image tag with the version baked into that
  image (`trackedVersion`), not the live controller version. These diverge when
  OpenClaw self-updates (the "Modified" state), so using the runtime version
  would misattribute it to the tracked image and could also falsely trigger the
  same-version tooltip.
- Added an info tooltip on the Latest row when Active and Latest share the same
  OpenClaw version but have different image tags, explaining that the latest
  image carries additional fixes and improvements rather than a newer OpenClaw
  release.
- `SettingsTab` passes the tracked and latest OpenClaw versions into
  `VersionPinCard`. The latest version is only passed when the image variants
  match, matching the existing behavior for the latest image tag.
- Added `version-display.test.ts` covering the version/tag pairing, the
  same-version-different-image tooltip, and the same-image case where the
  tooltip is suppressed.

## Verification

- [x] Opened the Manage Version panel in the running app and confirmed the
      Active and Latest rows show the OpenClaw version next to the image tag.

## Visual Changes

<!-- Add before/after screenshots of the Manage Version panel. -->

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- The `import React` added to `VersionPinCard.tsx` is needed because the Jest
  SWC transform uses the classic JSX runtime, matching the pattern in other
  rendered-component tests (for example `ReferralRewardsSummary.tsx`).
- The tooltip gate requires both image tags to be present and different, so an
  identical Active/Latest image does not show the "same version" explanation.
