### PR TITLE
revert(ai-gateway): remove organization request logging

### DIFF
--- a/apps/web/src/lib/ai-gateway/handleRequestLogging.ts
+++ b/apps/web/src/lib/ai-gateway/handleRequestLogging.ts
@@ -14,7 +14,6 @@ const users = [
 
 const organizations = [
   '3f48333c176a29aaeeb25f3475e38511fc7184b34321a1605a3c0db54cae6df4', // kilo
-  'e01114329f1378b3bc2add5a30a3782d1c1702d02decaaae182d7f9ad80ff66e', // https://kilo-code.slack.com/archives/C0B8KPSBUTH/p1781869766329419?thread_ts=1781778627.058599&cid=C0B8KPSBUTH
 ];
 
 async function isLoggingEnabledForUser(


### PR DESCRIPTION
## Summary

PR #4124 added an organization hash to the AI Gateway request logging allowlist, enabling persistence of request and response payloads for that organization. This revert removes the organization from the allowlist so its traffic is no longer opted into request logging.

## Verification

- Not manually tested. This allowlist-only change requires traffic from the hashed organization to exercise.

## Visual Changes

N/A

## Reviewer Notes

Reverts #4124.