### PR TITLE
fix(byok): exclude deprecated direct models

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -1,0 +1,53 @@
+import { parseModelsDevProviderModels } from './sync-direct-byok';
+
+describe('parseModelsDevProviderModels', () => {
+  test('excludes deprecated models while retaining other statuses', () => {
+    const models = parseModelsDevProviderModels({
+      models: {
+        stable: {
+          id: 'stable',
+          name: 'provider/stable',
+          limit: { context: 128_000, output: 32_000 },
+          modalities: { input: ['text', 'image'], output: ['text'] },
+        },
+        alpha: {
+          id: 'alpha',
+          status: 'alpha',
+        },
+        beta: {
+          id: 'beta',
+          status: 'beta',
+        },
+        deprecated: {
+          id: 'mimo-v2-omni',
+          name: 'MiMo V2 Omni',
+          status: 'deprecated',
+        },
+      },
+    });
+
+    expect(models).toEqual([
+      {
+        id: 'stable',
+        name: 'stable',
+        context_length: 128_000,
+        max_completion_tokens: 32_000,
+        input_modalities: ['text', 'image'],
+      },
+      {
+        id: 'alpha',
+        name: undefined,
+        context_length: undefined,
+        max_completion_tokens: undefined,
+        input_modalities: undefined,
+      },
+      {
+        id: 'beta',
+        name: undefined,
+        context_length: undefined,
+        max_completion_tokens: undefined,
+        input_modalities: undefined,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -18,6 +18,10 @@ describe('parseModelsDevProviderModels', () => {
           id: 'beta',
           status: 'beta',
         },
+        unknownStatus: {
+          id: 'unknown-status',
+          status: 'active',
+        },
         deprecated: {
           id: 'mimo-v2-omni',
           name: 'MiMo V2 Omni',
@@ -43,6 +47,13 @@ describe('parseModelsDevProviderModels', () => {
       },
       {
         id: 'beta',
+        name: undefined,
+        context_length: undefined,
+        max_completion_tokens: undefined,
+        input_modalities: undefined,
+      },
+      {
+        id: 'unknown-status',
         name: undefined,
         context_length: undefined,
         max_completion_tokens: undefined,

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -27,6 +27,7 @@ const OpenAICompatibleModelsResponseSchema = z.object({
 const ModelsDevModelSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
+  status: z.enum(['alpha', 'beta', 'deprecated']).optional(),
   limit: z
     .object({
       context: z.number().optional(),
@@ -100,6 +101,19 @@ function openAICompatibleFetcher(options: {
   };
 }
 
+export function parseModelsDevProviderModels(entry: unknown): RawModel[] {
+  const provider = ModelsDevProviderSchema.parse(entry);
+  return Object.values(provider.models)
+    .filter(model => model.status !== 'deprecated')
+    .map(model => ({
+      id: model.id,
+      name: shortenDisplayName(model.name),
+      context_length: model.limit?.context,
+      max_completion_tokens: model.limit?.output,
+      input_modalities: model.modalities?.input,
+    }));
+}
+
 function modelsDevFetcher(
   providerId: DirectUserByokInferenceProviderId,
   catalogKey: string
@@ -112,14 +126,7 @@ function modelsDevFetcher(
       if (!entry) {
         throw new Error(`models.dev catalog missing ${catalogKey} entry`);
       }
-      const provider = ModelsDevProviderSchema.parse(entry);
-      return Object.values(provider.models).map(model => ({
-        id: model.id,
-        name: shortenDisplayName(model.name),
-        context_length: model.limit?.context,
-        max_completion_tokens: model.limit?.output,
-        input_modalities: model.modalities?.input,
-      }));
+      return parseModelsDevProviderModels(entry);
     },
   };
 }

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -27,7 +27,7 @@ const OpenAICompatibleModelsResponseSchema = z.object({
 const ModelsDevModelSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
-  status: z.enum(['alpha', 'beta', 'deprecated']).optional(),
+  status: z.enum(['alpha', 'beta', 'deprecated']).optional().catch(undefined),
   limit: z
     .object({
       context: z.number().optional(),


### PR DESCRIPTION
## Summary

- Parse the models.dev lifecycle status for direct BYOK model catalogs.
- Exclude deprecated models before writing each provider's synchronized model list to Redis.
- Preserve active, alpha, beta, and unclassified models.

## Verification

- Not manually tested; this change affects the background models.dev catalog synchronization path.

## Visual Changes

N/A

## Reviewer Notes

The status filter applies only to models.dev-backed direct BYOK providers; providers using OpenAI-compatible model endpoints are unchanged.