### PR TITLE
fix(review): pause clone timeout auto-disable

### DIFF
--- a/apps/web/src/lib/code-reviews/action-required.test.ts
+++ b/apps/web/src/lib/code-reviews/action-required.test.ts
@@ -407,7 +407,7 @@ describe('disableCodeReviewForActionRequiredFailure', () => {
     expect(mockSendCodeReviewDisabledEmail).not.toHaveBeenCalled();
   });
 
-  it('disables and emails on the third repository clone timeout today', async () => {
+  it('keeps Code Reviewer enabled on the third repository clone timeout while auto-disable is paused', async () => {
     const owner = { type: 'user' as const, id: testUser.id, userId: testUser.id };
     await seedFailedReview({ errorMessage: 'repository clone timed out' });
     await seedFailedReview({ errorMessage: 'Repository clone timed out' });
@@ -422,33 +422,17 @@ describe('disableCodeReviewForActionRequiredFailure', () => {
     });
 
     const config = await getStoredConfig();
-    const state = getCodeReviewActionRequiredState(config);
     const [triggeringReview] = await db
       .select({ terminalReason: cloud_agent_code_reviews.terminal_reason })
       .from(cloud_agent_code_reviews)
       .where(eq(cloud_agent_code_reviews.id, triggeringReviewId))
       .limit(1);
 
-    expect(result).toBe('repeated_repository_clone_timeout');
-    expect(config?.is_enabled).toBe(false);
-    expect(state?.reason).toBe('repeated_repository_clone_timeout');
-    expect(state?.triggeringReviewId).toBe(triggeringReviewId);
-    expect(state?.lastErrorMessage).toBe(
-      'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.'
-    );
-    expect(state?.emailSentAt).toBeTruthy();
-    expect(triggeringReview?.terminalReason).toBe('repeated_repository_clone_timeout');
-    expect(mockSendCodeReviewDisabledEmail).toHaveBeenCalledTimes(1);
-    expect(mockSendCodeReviewDisabledEmail).toHaveBeenCalledWith(
-      testUser.google_user_email,
-      expect.objectContaining({
-        reason:
-          'Code Reviewer was disabled after three repository clone timeouts today. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
-        recoveryLabel: 'Contact support',
-        recoveryUrl:
-          'mailto:hi@kilocode.ai?subject=Repository%20clone%20timeouts%20for%20Code%20Reviewer',
-      })
-    );
+    expect(result).toBeNull();
+    expect(config?.is_enabled).toBe(true);
+    expect(getCodeReviewActionRequiredState(config)).toBeNull();
+    expect(triggeringReview?.terminalReason).toBe('sandbox_error');
+    expect(mockSendCodeReviewDisabledEmail).not.toHaveBeenCalled();
   });
 
   it('does not count other owners, other platforms, or yesterday for clone timeout threshold', async () => {

--- a/apps/web/src/lib/code-reviews/action-required.ts
+++ b/apps/web/src/lib/code-reviews/action-required.ts
@@ -483,15 +483,17 @@ export async function disableCodeReviewForRepeatedCloneTimeoutsToday(
       );
       if (timeoutCount < REPEATED_REPOSITORY_CLONE_TIMEOUT_THRESHOLD) return false;
 
-      await tx
-        .update(cloud_agent_code_reviews)
-        .set({
-          terminal_reason: REPEATED_REPOSITORY_CLONE_TIMEOUT_REASON,
-          updated_at: new Date().toISOString(),
-        })
-        .where(eq(cloud_agent_code_reviews.id, args.reviewId));
-
-      return true;
+      // Temporarily disabled until after focus week: this is too sensitive to
+      // GitHub clone outages and could disable many cloud reviews at once.
+      // await tx
+      //   .update(cloud_agent_code_reviews)
+      //   .set({
+      //     terminal_reason: REPEATED_REPOSITORY_CLONE_TIMEOUT_REASON,
+      //     updated_at: new Date().toISOString(),
+      //   })
+      //   .where(eq(cloud_agent_code_reviews.id, args.reviewId));
+      // return true;
+      return false;
     }
   );
 


### PR DESCRIPTION
## Summary
- Temporarily pauses the repeated repository clone timeout auto-disable added in https://github.com/Kilo-Org/cloud/pull/4125 by commenting out the terminal update/return path while leaving detection in place.
- This is disabled for now because the current threshold is too sensitive to GitHub clone outages and could disable Code Reviewer for many cloud reviews at once.
- We will revisit a more robust implementation next week after focus week.

## Verification
N/A - backend-only temporary guard; no manual UI flow.

## Visual Changes
N/A

## Reviewer Notes
- The helper still detects and counts repeated clone timeouts, but it now exits without disabling Code Reviewer, marking the triggering review action-required, or sending the disabled email.
- Local DB-backed test execution was blocked because Docker was not available in this session.