### PR TITLE
fix(mobile): address Kilo Pass Apple review

### DIFF
--- a/apps/mobile/src/components/kilo-pass/kilo-pass-subscription-screen.tsx
+++ b/apps/mobile/src/components/kilo-pass/kilo-pass-subscription-screen.tsx
@@ -12,9 +12,14 @@ import { WEB_BASE_URL } from '@/lib/config';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { getKiloPassLegalLinks, KILO_PASS_LEGAL_DISCLOSURE } from '@/lib/kilo-pass/legal-links';
 import { ensureProfileAfterKiloPassPurchase } from '@/lib/kilo-pass/navigation';
+import {
+  formatKiloPassTierDescription,
+  KILO_PASS_SUBSCRIPTION_HEADER_DESCRIPTION,
+} from '@/lib/kilo-pass/subscription-page-copy';
 import { type AppStoreKiloPassProduct } from '@/lib/kilo-pass/store-products';
 import { useStoreKiloPassProducts } from '@/lib/kilo-pass/use-store-kilo-pass-products';
 import { useStoreKiloPassPurchase } from '@/lib/kilo-pass/use-store-kilo-pass-purchase';
+import { RestorePurchasesButton } from './restore-purchases-button';
 
 function formatTier(product: AppStoreKiloPassProduct): string {
   return `$${product.webMonthlyPriceUsd} credits`;
@@ -50,6 +55,10 @@ export function KiloPassSubscriptionScreen() {
           contentContainerClassName="gap-3 px-1 pb-6"
           showsVerticalScrollIndicator={false}
         >
+          <Text className="px-1 text-sm leading-5 text-muted-foreground">
+            {KILO_PASS_SUBSCRIPTION_HEADER_DESCRIPTION}
+          </Text>
+
           {productsQuery.isLoading &&
             [0, 1, 2].map(index => (
               <Skeleton key={index} className="h-[112px] w-full rounded-xl" />
@@ -97,7 +106,7 @@ export function KiloPassSubscriptionScreen() {
                   <View className="flex-1 gap-1.5">
                     <Text className="font-semibold text-foreground">{formatTier(product)}</Text>
                     <Text className="text-xs text-muted-foreground">
-                      Monthly Kilo Pass with bonus progress.
+                      {formatKiloPassTierDescription(product.webMonthlyPriceUsd)}
                     </Text>
                   </View>
                   <Text className="text-base font-semibold text-foreground tabular-nums">
@@ -106,6 +115,8 @@ export function KiloPassSubscriptionScreen() {
                 </View>
               </Pressable>
             ))}
+
+          <RestorePurchasesButton />
 
           <Text className="px-1 pt-1 text-xs leading-5 text-muted-foreground">
             {KILO_PASS_LEGAL_DISCLOSURE}

--- a/apps/mobile/src/components/kilo-pass/restore-purchases-button.tsx
+++ b/apps/mobile/src/components/kilo-pass/restore-purchases-button.tsx
@@ -1,0 +1,46 @@
+import * as Haptics from 'expo-haptics';
+import { ActivityIndicator, Platform } from 'react-native';
+import { toast } from 'sonner-native';
+
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { useStoreKiloPassPurchase } from '@/lib/kilo-pass/use-store-kilo-pass-purchase';
+
+export function RestorePurchasesButton() {
+  const colors = useThemeColors();
+  const { isPending, isRestoringPurchases, restorePurchases } = useStoreKiloPassPurchase();
+
+  if (Platform.OS !== 'ios') {
+    return null;
+  }
+
+  const disabled = isPending || isRestoringPurchases;
+
+  const handlePress = () => {
+    void Haptics.selectionAsync();
+    void (async () => {
+      const result = await restorePurchases();
+      if (result === 'restored') {
+        toast.success('Subscription restored.');
+      }
+      if (result === 'empty') {
+        toast.info('No purchases to restore.');
+      }
+    })();
+  };
+
+  return (
+    <Button
+      accessibilityLabel="Restore Purchases"
+      accessibilityState={{ busy: isRestoringPurchases, disabled }}
+      className="self-center px-3"
+      disabled={disabled}
+      onPress={handlePress}
+      variant="link"
+    >
+      {isRestoringPurchases && <ActivityIndicator size="small" color={colors.primary} />}
+      <Text>{isRestoringPurchases ? 'Restoring Purchases' : 'Restore Purchases'}</Text>
+    </Button>
+  );
+}

--- a/apps/mobile/src/components/profile-credits-card.tsx
+++ b/apps/mobile/src/components/profile-credits-card.tsx
@@ -6,6 +6,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
 import { KiloPassSubscriptionCard } from '@/components/kilo-pass/kilo-pass-subscription-card';
+import { RestorePurchasesButton } from '@/components/kilo-pass/restore-purchases-button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
@@ -149,7 +150,12 @@ export function CreditsCard({ enabled, orgs }: Readonly<CreditsCardProps>) {
           {balanceFetching && <ActivityIndicator size="small" color={colors.mutedForeground} />}
         </View>
       )}
-      {enabled && !selectedOrgId && <KiloPassSubscriptionCard />}
+      {enabled && !selectedOrgId ? (
+        <>
+          <KiloPassSubscriptionCard />
+          <RestorePurchasesButton />
+        </>
+      ) : null}
     </View>
   );
 }

--- a/apps/mobile/src/lib/kilo-pass/legal-links.test.ts
+++ b/apps/mobile/src/lib/kilo-pass/legal-links.test.ts
@@ -16,9 +16,19 @@ describe('Kilo Pass legal disclosure links', () => {
     ]);
   });
 
-  it('uses platform-neutral subscription disclosure copy', () => {
+  it('uses App Store auto-renewable monthly subscription disclosure copy', () => {
     expect(KILO_PASS_LEGAL_DISCLOSURE).toBe(
-      'Subscriptions renew monthly until canceled. Manage or cancel anytime through your app store account settings.'
+      'Kilo Pass is an auto-renewable monthly subscription. Payment is charged to your Apple ID at confirmation of purchase. Subscriptions renew automatically each month at the price shown unless canceled at least 24 hours before the end of the current period. Manage or cancel anytime in your App Store account settings.'
+    );
+  });
+
+  it('composes the full footer disclosure with legal link labels', () => {
+    const [privacyPolicyLink, termsOfUseLink] = getKiloPassLegalLinks('https://app.example.com');
+
+    expect(
+      `${KILO_PASS_LEGAL_DISCLOSURE} By subscribing, you agree to the ${termsOfUseLink.label} and acknowledge the ${privacyPolicyLink.label}.`
+    ).toBe(
+      'Kilo Pass is an auto-renewable monthly subscription. Payment is charged to your Apple ID at confirmation of purchase. Subscriptions renew automatically each month at the price shown unless canceled at least 24 hours before the end of the current period. Manage or cancel anytime in your App Store account settings. By subscribing, you agree to the Terms of Use (EULA) and acknowledge the Privacy Policy.'
     );
   });
 });

--- a/apps/mobile/src/lib/kilo-pass/legal-links.ts
+++ b/apps/mobile/src/lib/kilo-pass/legal-links.ts
@@ -1,5 +1,5 @@
 export const KILO_PASS_LEGAL_DISCLOSURE =
-  'Subscriptions renew monthly until canceled. Manage or cancel anytime through your app store account settings.';
+  'Kilo Pass is an auto-renewable monthly subscription. Payment is charged to your Apple ID at confirmation of purchase. Subscriptions renew automatically each month at the price shown unless canceled at least 24 hours before the end of the current period. Manage or cancel anytime in your App Store account settings.';
 
 type KiloPassLegalLink = {
   label: 'Privacy Policy' | 'Terms of Use (EULA)';

--- a/apps/mobile/src/lib/kilo-pass/subscription-page-copy.test.ts
+++ b/apps/mobile/src/lib/kilo-pass/subscription-page-copy.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatKiloPassTierDescription,
+  KILO_PASS_SUBSCRIPTION_HEADER_DESCRIPTION,
+} from './subscription-page-copy';
+
+describe('Kilo Pass subscription page copy', () => {
+  it('describes the monthly subscription uses requested for App Store review', () => {
+    expect(KILO_PASS_SUBSCRIPTION_HEADER_DESCRIPTION).toBe(
+      'A monthly subscription that adds credits to your Kilo balance for running AI coding sessions in Kilo App — Cloud Agents, remote sessions, and KiloClaw chats.'
+    );
+  });
+
+  it('describes guaranteed paid credits added monthly for each tier card', () => {
+    expect(formatKiloPassTierDescription(19)).toBe(
+      '$19 paid credits added monthly for Kilo App usage.'
+    );
+  });
+});

--- a/apps/mobile/src/lib/kilo-pass/subscription-page-copy.ts
+++ b/apps/mobile/src/lib/kilo-pass/subscription-page-copy.ts
@@ -1,0 +1,6 @@
+export const KILO_PASS_SUBSCRIPTION_HEADER_DESCRIPTION =
+  'A monthly subscription that adds credits to your Kilo balance for running AI coding sessions in Kilo App — Cloud Agents, remote sessions, and KiloClaw chats.';
+
+export function formatKiloPassTierDescription(webMonthlyPriceUsd: number): string {
+  return `$${webMonthlyPriceUsd} paid credits added monthly for Kilo App usage.`;
+}

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
@@ -632,6 +632,25 @@ describe('createAppStoreKiloPassPurchaseActions', () => {
     expect(invalidateAfterCompletion).toHaveBeenCalledTimes(1);
   });
 
+  it('loads product IDs before deciding an explicit restore is empty', async () => {
+    const purchase = createPurchase();
+    const loadEnabledAppleProductIds = vi.fn().mockResolvedValue([product.appleProductId]);
+    const completeAppStorePurchase = vi.fn().mockResolvedValue({ alreadyProcessed: false });
+    const actions = createActions({
+      completeAppStorePurchase,
+      enabledAppleProductIds: [],
+      getAvailablePurchases: vi.fn().mockResolvedValue([purchase]),
+      loadEnabledAppleProductIds,
+      restorePurchases: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await actions.restorePurchases();
+
+    expect(result).toBe('restored');
+    expect(loadEnabledAppleProductIds).toHaveBeenCalledTimes(1);
+    expect(completeAppStorePurchase).toHaveBeenCalledWith({ signedTransactionJws: 'signed-jws' });
+  });
+
   it('returns empty when StoreKit has no active Kilo Pass purchases to restore', async () => {
     const completeAppStorePurchase = vi.fn();
     const actions = createActions({

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
@@ -237,6 +237,14 @@ function createDeferredPromise() {
   return { promise, resolve: resolvePromise };
 }
 
+function createDeferredRejectablePromise() {
+  let rejectPromise: (reason?: unknown) => void = ignoreDeferredResolution;
+  const promise = new Promise((_resolve, reject) => {
+    rejectPromise = reject;
+  });
+  return { promise, reject: rejectPromise };
+}
+
 function createPurchase(overrides: Partial<Purchase> = {}): Purchase {
   return {
     id: 'purchase-1',
@@ -687,6 +695,37 @@ describe('createAppStoreKiloPassPurchaseActions', () => {
     const result = await actions.restorePurchases();
 
     expect(result).toBe('failed');
+    expect(showError).toHaveBeenCalledWith(
+      'This App Store subscription is linked to another Kilo account.'
+    );
+  });
+
+  it('shows explicit restore errors when silent recovery already started completion', async () => {
+    const purchase = createPurchase();
+    const backendCompletion = createDeferredRejectablePromise();
+    const showError = vi.fn();
+    const actions = createActions({
+      completeAppStorePurchase: vi.fn().mockReturnValue(backendCompletion.promise),
+      getAvailablePurchases: vi.fn().mockResolvedValue([purchase]),
+      restorePurchases: vi.fn().mockResolvedValue(undefined),
+      showError: message => {
+        showError(message);
+      },
+    });
+
+    const silentRecovery = actions.handlePurchaseSuccess(purchase, {
+      notifyCompletion: false,
+      notifyErrors: false,
+    });
+    const explicitRestore = actions.restorePurchases();
+    await flushPromises();
+    backendCompletion.reject(
+      new Error('App Store purchase account token does not match the signed-in user.')
+    );
+
+    const [, restoreResult] = await Promise.all([silentRecovery, explicitRestore]);
+
+    expect(restoreResult).toBe('failed');
     expect(showError).toHaveBeenCalledWith(
       'This App Store subscription is linked to another Kilo account.'
     );

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
@@ -20,6 +20,7 @@ const mockedIap = vi.hoisted(() => ({
     onPurchaseSuccess: (purchase: Purchase) => void;
   } | null,
   requestPurchase: vi.fn(),
+  restorePurchases: vi.fn(),
 }));
 
 const mockedReactQuery = vi.hoisted(() => ({
@@ -37,6 +38,7 @@ vi.mock('expo-iap', () => ({
     AlreadyOwned: 'already-owned',
     UserCancelled: 'user-cancelled',
   },
+  getAvailablePurchases: mockedIap.getAvailablePurchases,
   useIAP: (handlers: {
     onPurchaseError: (error: Error) => void;
     onPurchaseSuccess: (purchase: Purchase) => void;
@@ -46,6 +48,7 @@ vi.mock('expo-iap', () => ({
     finishTransaction: mockedIap.finishTransaction,
     getAvailablePurchases: mockedIap.getAvailablePurchases,
     requestPurchase: mockedIap.requestPurchase,
+    restorePurchases: mockedIap.restorePurchases,
     ...(() => {
       mockedIap.handlers = handlers;
       return {};
@@ -69,7 +72,7 @@ vi.mock('@tanstack/react-query', () => ({
 }));
 
 vi.mock('sonner-native', () => ({
-  toast: { error: vi.fn() },
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
 }));
 
 vi.mock('@/lib/trpc', () => ({
@@ -93,7 +96,9 @@ type StoreKiloPassPurchaseContextValue = {
     product: AppStoreKiloPassProduct,
     options?: { onCompleted?: () => void }
   ) => Promise<void>;
+  restorePurchases: () => Promise<'restored' | 'empty' | 'failed'>;
   isPending: boolean;
+  isRestoringPurchases: boolean;
 };
 
 type ReactInternals = {
@@ -215,8 +220,10 @@ function createActions(
     completeAppStorePurchase: vi.fn(),
     enabledAppleProductIds: [product.appleProductId],
     finishTransaction: vi.fn(),
+    getAvailablePurchases: vi.fn().mockResolvedValue([]),
     invalidateAfterCompletion: vi.fn(),
     requestPurchase: vi.fn(),
+    restorePurchases: vi.fn(),
     showError: () => undefined,
     ...overrides,
   });
@@ -255,6 +262,7 @@ beforeEach(() => {
   mockedIap.getAvailablePurchases.mockResolvedValue(undefined);
   mockedIap.handlers = null;
   mockedIap.requestPurchase.mockResolvedValue(null);
+  mockedIap.restorePurchases.mockResolvedValue(undefined);
   mockedReactQuery.completeAppStorePurchase.mockResolvedValue({ alreadyProcessed: false });
   mockedReactQuery.completeAppStorePurchaseIsPending = false;
   mockedReactQuery.invalidateQueries.mockResolvedValue(undefined);
@@ -567,19 +575,23 @@ describe('createAppStoreKiloPassPurchaseActions', () => {
       completeAppStorePurchase: completeFromRecovery,
       enabledAppleProductIds: [product.appleProductId],
       finishTransaction: finishFromRecovery,
+      getAvailablePurchases: vi.fn().mockResolvedValue([]),
       invalidateAfterCompletion: vi.fn(),
       requestPurchase: vi.fn(),
+      restorePurchases: vi.fn(),
       showError: () => undefined,
     });
     const sheetActions = createAppStoreKiloPassPurchaseActions({
       completeAppStorePurchase: completeFromSheet,
       enabledAppleProductIds: [product.appleProductId],
       finishTransaction: finishFromSheet,
+      getAvailablePurchases: vi.fn().mockResolvedValue([]),
       invalidateAfterCompletion: vi.fn(),
       onPurchaseCompleted: () => {
         onPurchaseCompleted();
       },
       requestPurchase: vi.fn(),
+      restorePurchases: vi.fn(),
       showError: () => undefined,
     });
 
@@ -593,6 +605,88 @@ describe('createAppStoreKiloPassPurchaseActions', () => {
     expect(finishFromRecovery).toHaveBeenCalledTimes(1);
     expect(finishFromSheet).not.toHaveBeenCalled();
     expect(onPurchaseCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('explicitly restores active Kilo Pass purchases through StoreKit and backend completion', async () => {
+    const purchase = createPurchase();
+    const restorePurchases = vi.fn().mockResolvedValue(undefined);
+    const getAvailablePurchases = vi.fn().mockResolvedValue([purchase]);
+    const completeAppStorePurchase = vi.fn().mockResolvedValue({ alreadyProcessed: false });
+    const finishTransaction = vi.fn();
+    const invalidateAfterCompletion = vi.fn();
+    const actions = createActions({
+      completeAppStorePurchase,
+      finishTransaction,
+      getAvailablePurchases,
+      invalidateAfterCompletion,
+      restorePurchases,
+    });
+
+    const result = await actions.restorePurchases();
+
+    expect(result).toBe('restored');
+    expect(restorePurchases).toHaveBeenCalledTimes(1);
+    expect(getAvailablePurchases).toHaveBeenCalledTimes(1);
+    expect(completeAppStorePurchase).toHaveBeenCalledWith({ signedTransactionJws: 'signed-jws' });
+    expect(finishTransaction).toHaveBeenCalledWith({ purchase, isConsumable: false });
+    expect(invalidateAfterCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty when StoreKit has no active Kilo Pass purchases to restore', async () => {
+    const completeAppStorePurchase = vi.fn();
+    const actions = createActions({
+      completeAppStorePurchase,
+      getAvailablePurchases: vi
+        .fn()
+        .mockResolvedValue([
+          createPurchase({ productId: 'other.product', transactionId: 'other-tx' }),
+        ]),
+      restorePurchases: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await actions.restorePurchases();
+
+    expect(result).toBe('empty');
+    expect(completeAppStorePurchase).not.toHaveBeenCalled();
+  });
+
+  it('does not report empty when an eligible restored purchase belongs to another Kilo account', async () => {
+    const showError = vi.fn();
+    const actions = createActions({
+      completeAppStorePurchase: vi
+        .fn()
+        .mockRejectedValue(
+          new Error('App Store purchase account token does not match the signed-in user.')
+        ),
+      getAvailablePurchases: vi.fn().mockResolvedValue([createPurchase()]),
+      restorePurchases: vi.fn().mockResolvedValue(undefined),
+      showError: message => {
+        showError(message);
+      },
+    });
+
+    const result = await actions.restorePurchases();
+
+    expect(result).toBe('failed');
+    expect(showError).toHaveBeenCalledWith(
+      'This App Store subscription is linked to another Kilo account.'
+    );
+  });
+
+  it('shows a generic retryable error when StoreKit restore fails', async () => {
+    const showError = vi.fn();
+    const actions = createActions({
+      getAvailablePurchases: vi.fn(),
+      restorePurchases: vi.fn().mockRejectedValue(new Error('StoreKit unavailable')),
+      showError: message => {
+        showError(message);
+      },
+    });
+
+    const result = await actions.restorePurchases();
+
+    expect(result).toBe('failed');
+    expect(showError).toHaveBeenCalledWith('Failed to restore purchases. Try again.');
   });
 });
 

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
@@ -62,6 +62,7 @@ type AppStoreKiloPassPurchaseActionsDeps = {
   completeAppStorePurchase: (input: { signedTransactionJws: string }) => Promise<unknown>;
   finishTransaction: (params: { purchase: Purchase; isConsumable: false }) => Promise<void>;
   enabledAppleProductIds: readonly string[];
+  loadEnabledAppleProductIds?: () => Promise<readonly string[]>;
   invalidateAfterCompletion: () => Promise<void> | void;
   onPurchaseCompleted?: () => void;
   setPendingPurchaseCompletedCallback?: (callback: (() => void) | null) => void;
@@ -100,6 +101,10 @@ type PurchaseCompletionOptions = {
 
 type PurchaseSuccessOptions = PurchaseCompletionOptions & {
   notifyCompletion?: boolean;
+};
+
+type RecoverPurchasesOptions = PurchaseCompletionOptions & {
+  enabledAppleProductIds?: readonly string[];
 };
 
 function isRecoverableKiloPassPurchase(
@@ -221,13 +226,21 @@ export function createAppStoreKiloPassPurchaseActions(deps: AppStoreKiloPassPurc
     return completed;
   }
 
+  async function getEnabledAppleProductIdsForRestore() {
+    if (deps.enabledAppleProductIds.length > 0) {
+      return deps.enabledAppleProductIds;
+    }
+    return (await deps.loadEnabledAppleProductIds?.()) ?? [];
+  }
+
   async function recoverPurchases(
     purchases: Purchase[],
-    options: PurchaseCompletionOptions = {}
+    options: RecoverPurchasesOptions = {}
   ): Promise<Purchase[]> {
+    const enabledAppleProductIds = options.enabledAppleProductIds ?? deps.enabledAppleProductIds;
     const recoveryResults = await Promise.all(
       purchases
-        .filter(purchase => isRecoverableKiloPassPurchase(purchase, deps.enabledAppleProductIds))
+        .filter(purchase => isRecoverableKiloPassPurchase(purchase, enabledAppleProductIds))
         .map(async purchase => {
           const completed = await handlePurchaseSuccess(purchase, {
             invalidateAfterCompletion: false,
@@ -278,14 +291,21 @@ export function createAppStoreKiloPassPurchaseActions(deps: AppStoreKiloPassPurc
       try {
         await deps.restorePurchases();
         const availablePurchases = await deps.getAvailablePurchases();
+        const enabledAppleProductIds = await getEnabledAppleProductIdsForRestore();
+        if (enabledAppleProductIds.length === 0) {
+          deps.showError(RESTORE_PURCHASES_ERROR_MESSAGE);
+          return 'failed';
+        }
+
         const kiloPassPurchases = availablePurchases.filter(purchase =>
-          isRecoverableKiloPassPurchase(purchase, deps.enabledAppleProductIds)
+          isRecoverableKiloPassPurchase(purchase, enabledAppleProductIds)
         );
         if (kiloPassPurchases.length === 0) {
           return 'empty';
         }
 
         const completedPurchases = await recoverPurchases(kiloPassPurchases, {
+          enabledAppleProductIds,
           notifyErrors: true,
         });
         return completedPurchases.length > 0 ? 'restored' : 'failed';
@@ -313,6 +333,7 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
     ...trpc.kiloPass.getMobileStoreProducts.queryOptions(),
     enabled: Platform.OS === 'ios',
   });
+  const { refetch: refetchMobileStoreProducts } = mobileStoreProductsQuery;
   const enabledAppleProductIds = useMemo(
     () => mobileStoreProductsQuery.data?.products.map(product => product.appleProductId) ?? [],
     [mobileStoreProductsQuery.data]
@@ -387,6 +408,10 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
         restorePurchases: restoreStorePurchases,
         completeAppStorePurchase: completeAppStorePurchase.mutateAsync,
         enabledAppleProductIds,
+        loadEnabledAppleProductIds: async () => {
+          const result = await refetchMobileStoreProducts();
+          return result.data?.products.map(product => product.appleProductId) ?? [];
+        },
         finishTransaction,
         invalidateAfterCompletion,
         onPurchaseCompleted: () => {
@@ -406,6 +431,7 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
       enabledAppleProductIds,
       finishTransaction,
       invalidateAfterCompletion,
+      refetchMobileStoreProducts,
       requestPurchase,
       restoreStorePurchases,
     ]

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
@@ -87,7 +87,11 @@ type StoreKiloPassPurchaseContextValue = {
 };
 
 const StoreKiloPassPurchaseContext = createContext<StoreKiloPassPurchaseContextValue | null>(null);
-const sharedPurchaseCompletions = new Map<string, Promise<boolean>>();
+type PurchaseCompletionResult =
+  | { completed: true; errorMessage?: never }
+  | { completed: false; errorMessage: string | null };
+
+const sharedPurchaseCompletions = new Map<string, Promise<PurchaseCompletionResult>>();
 let lastPurchaseErrorToast: { message: string; shownAt: number } | null = null;
 
 export function resetPurchaseErrorToastDedup() {
@@ -181,7 +185,7 @@ export function createAppStoreKiloPassPurchaseActions(deps: AppStoreKiloPassPurc
   async function completePurchase(
     purchase: Purchase,
     options: PurchaseCompletionOptions = {}
-  ): Promise<boolean> {
+  ): Promise<PurchaseCompletionResult> {
     try {
       const signedTransactionJws = getPurchaseToken(purchase);
       await deps.completeAppStorePurchase({ signedTransactionJws });
@@ -189,13 +193,19 @@ export function createAppStoreKiloPassPurchaseActions(deps: AppStoreKiloPassPurc
         await deps.invalidateAfterCompletion();
       }
       await deps.finishTransaction({ purchase, isConsumable: false });
-      return true;
+      return { completed: true };
     } catch (error) {
       const message = getKiloPassPurchaseErrorMessage(error, 'Failed to complete purchase.');
-      if (message && (options.notifyErrors ?? true)) {
-        deps.showError(message);
-      }
-      return false;
+      return { completed: false, errorMessage: message };
+    }
+  }
+
+  function reportPurchaseCompletionErrorIfNeeded(
+    result: PurchaseCompletionResult,
+    options: PurchaseCompletionOptions
+  ) {
+    if (!result.completed && result.errorMessage && (options.notifyErrors ?? true)) {
+      deps.showError(result.errorMessage);
     }
   }
 
@@ -206,14 +216,20 @@ export function createAppStoreKiloPassPurchaseActions(deps: AppStoreKiloPassPurc
     const purchaseId = getPurchaseCompletionId(purchase);
     const existingCompletion = sharedPurchaseCompletions.get(purchaseId);
     if (existingCompletion) {
-      return existingCompletion;
+      const result = await existingCompletion;
+      reportPurchaseCompletionErrorIfNeeded(result, options);
+      return result.completed;
     }
 
     const completion = completePurchase(purchase, options);
     sharedPurchaseCompletions.set(purchaseId, completion);
-    const completed = await completion;
-    sharedPurchaseCompletions.delete(purchaseId);
-    return completed;
+    try {
+      const result = await completion;
+      reportPurchaseCompletionErrorIfNeeded(result, options);
+      return result.completed;
+    } finally {
+      sharedPurchaseCompletions.delete(purchaseId);
+    }
   }
 
   async function handlePurchaseSuccess(purchase: Purchase, options: PurchaseSuccessOptions = {}) {

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
@@ -12,7 +12,12 @@ import {
   useState,
 } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ErrorCode, type Purchase, useIAP } from 'expo-iap';
+import {
+  ErrorCode,
+  getAvailablePurchases as getAvailableIapPurchases,
+  type Purchase,
+  useIAP,
+} from 'expo-iap';
 import { Platform } from 'react-native';
 import { toast } from 'sonner-native';
 import { z } from 'zod';
@@ -45,12 +50,15 @@ const APP_STORE_SUBSCRIPTION_OWNED_BY_ANOTHER_ACCOUNT_MESSAGE =
 const APP_STORE_PURCHASE_NOT_LINKED_USER_MESSAGE =
   "This App Store purchase isn't linked to your Kilo account. Sign in to the Apple ID used for the purchase, then try again.";
 const PURCHASE_ERROR_TOAST_DEDUPE_MS = 1500;
+const RESTORE_PURCHASES_ERROR_MESSAGE = 'Failed to restore purchases. Try again.';
 
 type AppStoreKiloPassPurchaseActionsDeps = {
   requestPurchase: (params: {
     request: { apple: { appAccountToken: string; sku: string } };
     type: 'subs';
   }) => Promise<unknown>;
+  getAvailablePurchases: () => Promise<Purchase[]>;
+  restorePurchases: () => Promise<void>;
   completeAppStorePurchase: (input: { signedTransactionJws: string }) => Promise<unknown>;
   finishTransaction: (params: { purchase: Purchase; isConsumable: false }) => Promise<void>;
   enabledAppleProductIds: readonly string[];
@@ -64,13 +72,17 @@ type StoreKiloPassPurchaseOptions = {
   onCompleted?: () => void;
 };
 
+type StoreKiloPassRestorePurchasesResult = 'restored' | 'empty' | 'failed';
+
 type StoreKiloPassPurchaseContextValue = {
   appStoreOwnershipPreflight: AppStoreKiloPassOwnershipPreflight;
   purchase: (
     product: AppStoreKiloPassProduct,
     options?: StoreKiloPassPurchaseOptions
   ) => Promise<void>;
+  restorePurchases: () => Promise<StoreKiloPassRestorePurchasesResult>;
   isPending: boolean;
+  isRestoringPurchases: boolean;
 };
 
 const StoreKiloPassPurchaseContext = createContext<StoreKiloPassPurchaseContextValue | null>(null);
@@ -209,6 +221,31 @@ export function createAppStoreKiloPassPurchaseActions(deps: AppStoreKiloPassPurc
     return completed;
   }
 
+  async function recoverPurchases(
+    purchases: Purchase[],
+    options: PurchaseCompletionOptions = {}
+  ): Promise<Purchase[]> {
+    const recoveryResults = await Promise.all(
+      purchases
+        .filter(purchase => isRecoverableKiloPassPurchase(purchase, deps.enabledAppleProductIds))
+        .map(async purchase => {
+          const completed = await handlePurchaseSuccess(purchase, {
+            invalidateAfterCompletion: false,
+            notifyCompletion: false,
+            notifyErrors: options.notifyErrors ?? false,
+          });
+          return { completed, purchase };
+        })
+    );
+    const completedPurchases = recoveryResults
+      .filter(result => result.completed)
+      .map(result => result.purchase);
+    if (completedPurchases.length > 0) {
+      await deps.invalidateAfterCompletion();
+    }
+    return completedPurchases;
+  }
+
   return {
     purchase: async (
       product: AppStoreKiloPassProduct,
@@ -236,26 +273,26 @@ export function createAppStoreKiloPassPurchaseActions(deps: AppStoreKiloPassPurc
       }
     },
     handlePurchaseSuccess,
-    recoverPurchases: async (purchases: Purchase[]) => {
-      const recoveryResults = await Promise.all(
-        purchases
-          .filter(purchase => isRecoverableKiloPassPurchase(purchase, deps.enabledAppleProductIds))
-          .map(async purchase => {
-            const completed = await handlePurchaseSuccess(purchase, {
-              invalidateAfterCompletion: false,
-              notifyCompletion: false,
-              notifyErrors: false,
-            });
-            return { completed, purchase };
-          })
-      );
-      const completedPurchases = recoveryResults
-        .filter(result => result.completed)
-        .map(result => result.purchase);
-      if (completedPurchases.length > 0) {
-        await deps.invalidateAfterCompletion();
+    recoverPurchases,
+    restorePurchases: async (): Promise<StoreKiloPassRestorePurchasesResult> => {
+      try {
+        await deps.restorePurchases();
+        const availablePurchases = await deps.getAvailablePurchases();
+        const kiloPassPurchases = availablePurchases.filter(purchase =>
+          isRecoverableKiloPassPurchase(purchase, deps.enabledAppleProductIds)
+        );
+        if (kiloPassPurchases.length === 0) {
+          return 'empty';
+        }
+
+        const completedPurchases = await recoverPurchases(kiloPassPurchases, {
+          notifyErrors: true,
+        });
+        return completedPurchases.length > 0 ? 'restored' : 'failed';
+      } catch {
+        deps.showError(RESTORE_PURCHASES_ERROR_MESSAGE);
+        return 'failed';
       }
-      return completedPurchases;
     },
   };
 }
@@ -264,6 +301,7 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const [isRequestingPurchase, setIsRequestingPurchase] = useState(false);
+  const [isRestoringPurchases, setIsRestoringPurchases] = useState(false);
   const recoveredPurchaseIdsRef = useRef(new Set<string>());
   const recoveryInFlightPurchaseIdsRef = useRef(new Set<string>());
   const activePurchaseRequestRef = useRef<{ sku: string } | null>(null);
@@ -328,6 +366,7 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
     finishTransaction,
     getAvailablePurchases,
     requestPurchase,
+    restorePurchases: restoreStorePurchases,
   } = actionsRef;
   const appStoreOwnershipPreflight = useMemo(
     () =>
@@ -344,6 +383,8 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
     () =>
       createAppStoreKiloPassPurchaseActions({
         requestPurchase,
+        getAvailablePurchases: getAvailableIapPurchases,
+        restorePurchases: restoreStorePurchases,
         completeAppStorePurchase: completeAppStorePurchase.mutateAsync,
         enabledAppleProductIds,
         finishTransaction,
@@ -366,6 +407,7 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
       finishTransaction,
       invalidateAfterCompletion,
       requestPurchase,
+      restoreStorePurchases,
     ]
   );
 
@@ -389,6 +431,23 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
     },
     [actions, completeAppStorePurchase.isPending, releasePurchaseRequest]
   );
+
+  const restorePurchases = useCallback(async (): Promise<StoreKiloPassRestorePurchasesResult> => {
+    if (
+      activePurchaseRequestRef.current ||
+      isRestoringPurchases ||
+      completeAppStorePurchase.isPending
+    ) {
+      return 'failed';
+    }
+
+    setIsRestoringPurchases(true);
+    try {
+      return await actions.restorePurchases();
+    } finally {
+      setIsRestoringPurchases(false);
+    }
+  }, [actions, completeAppStorePurchase.isPending, isRestoringPurchases]);
 
   useEffect(() => {
     if (Platform.OS !== 'ios' || !connected) {
@@ -441,12 +500,16 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
     () => ({
       appStoreOwnershipPreflight,
       purchase: startPurchase,
-      isPending: isRequestingPurchase || completeAppStorePurchase.isPending,
+      restorePurchases,
+      isPending: isRequestingPurchase || completeAppStorePurchase.isPending || isRestoringPurchases,
+      isRestoringPurchases,
     }),
     [
       appStoreOwnershipPreflight,
       completeAppStorePurchase.isPending,
       isRequestingPurchase,
+      isRestoringPurchases,
+      restorePurchases,
       startPurchase,
     ]
   );


### PR DESCRIPTION
## Summary
- Update Kilo Pass subscription screen copy for Apple review disclosure requirements.
- Add Restore Purchases actions on the Kilo Pass paywall and Profile screen.
- Route explicit restore through StoreKit restore plus existing backend purchase completion and ownership checks.

## Verification
N/A - no simulator/App Store sandbox session was run for this copy and restore-button update.

## Visual Changes
Restore Purchases text button added to the Kilo Pass subscription screen and Profile screen. Screenshots not captured.

## Reviewer Notes
Restore uses the existing App Store completion mutation so cross-account transaction ownership errors continue to come from the backend validation path.