### PR TITLE
fix(organizations): restrict member management takeover paths

### DIFF
--- a/apps/web/src/components/organizations/OrganizationMembersCard.tsx
+++ b/apps/web/src/components/organizations/OrganizationMembersCard.tsx
@@ -73,6 +73,9 @@ function DailyUsageLimitDisplay({ member }: DailyUsageLimitDisplayProps) {
 const canManageMembers = (role: OrganizationRole, isKiloAdmin: boolean): boolean =>
   isKiloAdmin || role === 'owner';
 
+const canInviteMembers = (role: OrganizationRole, isKiloAdmin: boolean): boolean =>
+  canManageMembers(role, isKiloAdmin) || role === 'billing_manager';
+
 // Business rules for member removal:
 // - Kilo admins can remove anyone
 // - Owners can remove anyone except themselves
@@ -352,7 +355,7 @@ export function OrganizationAdminMembers({
   // Show "Add Member" button only for Kilo admins
   const showAddMemberButton = isKiloAdmin;
 
-  const showInviteMemberButton = canManageMembers(currentUserRole, isKiloAdmin);
+  const showInviteMemberButton = canInviteMembers(currentUserRole, isKiloAdmin);
 
   return (
     <>

--- a/apps/web/src/components/organizations/OrganizationMembersCard.tsx
+++ b/apps/web/src/components/organizations/OrganizationMembersCard.tsx
@@ -70,17 +70,16 @@ function DailyUsageLimitDisplay({ member }: DailyUsageLimitDisplayProps) {
   return null;
 }
 
-const isPrivilegedRole = (role: OrganizationRole): boolean =>
-  role === 'owner' || role === 'billing_manager';
+const canManageMembers = (role: OrganizationRole, isKiloAdmin: boolean): boolean =>
+  isKiloAdmin || role === 'owner';
 
 // Business rules for member removal:
 // - Kilo admins can remove anyone
-// - Owners and billing managers can remove anyone except themselves
+// - Owners can remove anyone except themselves
 // - Members cannot remove anyone
 const canRemoveMember = (
   currentUserRole: OrganizationRole,
   isKiloAdmin: boolean,
-  targetMemberRole: OrganizationRole,
   isCurrentUser: boolean
 ): boolean => {
   // Kilo admin can remove anyone including themselves
@@ -89,8 +88,7 @@ const canRemoveMember = (
   // Cannot remove yourself
   if (isCurrentUser) return false;
 
-  // Owners and billing managers can remove anyone (except themselves)
-  if (isPrivilegedRole(currentUserRole)) return true;
+  if (canManageMembers(currentUserRole, isKiloAdmin)) return true;
 
   // Members cannot remove anyone
   return false;
@@ -114,7 +112,7 @@ function DeleteMemberButton({ organizationId, member }: DeleteMemberButtonProps)
     (member.status === 'active' && member.id === kiloUserId) || member.email === kiloUserEmail;
 
   // Only show delete button for active members and if user has permission to remove
-  const canRemove = canRemoveMember(currentUserRole, isKiloAdmin, member.role, isCurrentUser);
+  const canRemove = canRemoveMember(currentUserRole, isKiloAdmin, isCurrentUser);
 
   if (member.status !== 'active' || !canRemove) {
     return null;
@@ -152,10 +150,7 @@ function DeleteInvitationButton({ organizationId, member }: DeleteInvitationButt
     return null;
   }
 
-  // Apply same role restrictions as invitation creation
-  // - Owners and billing managers can delete any invitation
-  // - Members cannot delete invitations
-  const canDelete = isKiloAdmin || isPrivilegedRole(currentUserRole);
+  const canDelete = canManageMembers(currentUserRole, isKiloAdmin);
 
   if (!canDelete) {
     return null;
@@ -192,7 +187,7 @@ function InvitedBadge({ member }: InvitedBadgeProps) {
     return null;
   }
 
-  const canCopy = isKiloAdmin || isPrivilegedRole(currentUserRole);
+  const canCopy = canManageMembers(currentUserRole, isKiloAdmin);
 
   const handleCopy = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -245,9 +240,8 @@ function EditLimitButton({ organization, member }: EditLimitButtonProps) {
     return null;
   }
 
-  // Only show edit limit button for active members and if user has permission (admin/owner/billing_manager)
-  const canEditLimit =
-    member.status === 'active' && (isKiloAdmin || isPrivilegedRole(currentUserRole));
+  // This uses the same mutation as role changes, so it follows owner-only member management.
+  const canEditLimit = member.status === 'active' && canManageMembers(currentUserRole, isKiloAdmin);
 
   if (!canEditLimit) {
     return null;
@@ -358,8 +352,7 @@ export function OrganizationAdminMembers({
   // Show "Add Member" button only for Kilo admins
   const showAddMemberButton = isKiloAdmin;
 
-  // Show "Invite Member" button for all roles except 'member'
-  const showInviteMemberButton = currentUserRole !== 'member';
+  const showInviteMemberButton = canManageMembers(currentUserRole, isKiloAdmin);
 
   return (
     <>
@@ -416,16 +409,16 @@ export function OrganizationAdminMembers({
                   // Determine what actions are available for this member
                   const canEditRole =
                     member.status === 'active' &&
-                    (isKiloAdmin || isPrivilegedRole(currentUserRole)) &&
+                    canManageMembers(currentUserRole, isKiloAdmin) &&
                     (!isCurrentUser || isKiloAdmin);
                   const canEditLimit =
                     organizationData.plan === 'enterprise' &&
                     member.status === 'active' &&
-                    (isKiloAdmin || isPrivilegedRole(currentUserRole));
+                    canManageMembers(currentUserRole, isKiloAdmin);
                   const canDelete =
                     member.status === 'active'
-                      ? canRemoveMember(currentUserRole, isKiloAdmin, member.role, isCurrentUser)
-                      : isKiloAdmin || isPrivilegedRole(currentUserRole);
+                      ? canRemoveMember(currentUserRole, isKiloAdmin, isCurrentUser)
+                      : canManageMembers(currentUserRole, isKiloAdmin);
 
                   const hasAnyEditableActions = canEditRole || canEditLimit || canDelete;
 

--- a/apps/web/src/components/organizations/members/InviteMemberDialog.tsx
+++ b/apps/web/src/components/organizations/members/InviteMemberDialog.tsx
@@ -45,18 +45,14 @@ const ROLE_LABELS = {
 } as const;
 
 // Business rules for inviting members:
-// - Owners can invite anyone (owner, admin, member)
-// - Admins can only invite admin or member (not owner)
-// - Members cannot invite anyone (handled at component level)
+// - Owners and Kilo admins can invite anyone
+// - Members and billing managers cannot invite anyone
 const getAvailableInviteRoles = (
   currentUserRole: OrganizationRole,
   isKiloAdmin: boolean
 ): OrganizationRole[] => {
-  // Kilo admin can invite anyone
-  if (isKiloAdmin || currentUserRole === 'owner' || currentUserRole === 'billing_manager')
-    return ['owner', 'member', 'billing_manager'];
+  if (isKiloAdmin || currentUserRole === 'owner') return ['owner', 'member', 'billing_manager'];
 
-  // Members cannot invite anyone
   return [];
 };
 
@@ -104,6 +100,7 @@ export function InviteMemberDialog({
   const availableRoles = useMemo(() => {
     return getAvailableInviteRoles(currentUserRole, isKiloAdmin);
   }, [currentUserRole, isKiloAdmin]);
+  const canInviteMembers = availableRoles.length > 0;
 
   const isEmailValid = useMemo(() => {
     if (!email.trim()) return false;
@@ -139,6 +136,11 @@ export function InviteMemberDialog({
   const hasSeatsAvailable = seatCapacityAvailable || !isSeatConsumingRole;
 
   const handleInviteMember = () => {
+    if (!canInviteMembers) {
+      toast.error('Only organization owners can invite members');
+      return;
+    }
+
     if (!email.trim()) {
       toast.error('Please enter an email address');
       return;
@@ -339,6 +341,7 @@ export function InviteMemberDialog({
                 !isEmailValid ||
                 emailDomainMatchesSSODomain ||
                 inviteMemberMutation.isPending ||
+                !canInviteMembers ||
                 !hasSeatsAvailable
               }
             >

--- a/apps/web/src/components/organizations/members/InviteMemberDialog.tsx
+++ b/apps/web/src/components/organizations/members/InviteMemberDialog.tsx
@@ -46,12 +46,14 @@ const ROLE_LABELS = {
 
 // Business rules for inviting members:
 // - Owners and Kilo admins can invite anyone
-// - Members and billing managers cannot invite anyone
+// - Billing managers can invite members only
+// - Members cannot invite anyone
 const getAvailableInviteRoles = (
   currentUserRole: OrganizationRole,
   isKiloAdmin: boolean
 ): OrganizationRole[] => {
   if (isKiloAdmin || currentUserRole === 'owner') return ['owner', 'member', 'billing_manager'];
+  if (currentUserRole === 'billing_manager') return ['member'];
 
   return [];
 };
@@ -137,7 +139,7 @@ export function InviteMemberDialog({
 
   const handleInviteMember = () => {
     if (!canInviteMembers) {
-      toast.error('Only organization owners can invite members');
+      toast.error('Only organization owners and billing managers can invite members');
       return;
     }
 
@@ -301,8 +303,9 @@ export function InviteMemberDialog({
             {!seatCapacityAvailable && !isOrgEnterprise && (
               <div className="rounded-md border border-amber-800 bg-amber-950/30 p-3">
                 <p className="text-sm text-amber-300">
-                  All seats are in use ({usedSeats}/{totalSeats}). You can still invite billing
-                  managers, who don&apos;t consume a seat.
+                  {availableRoles.includes('billing_manager')
+                    ? `All seats are in use (${usedSeats}/${totalSeats}). You can still invite billing managers, who don't consume a seat.`
+                    : `All seats are in use (${usedSeats}/${totalSeats}). Ask an organization owner to add seats before inviting more members.`}
                 </p>
               </div>
             )}

--- a/apps/web/src/components/organizations/members/MemberRoleDropdown.tsx
+++ b/apps/web/src/components/organizations/members/MemberRoleDropdown.tsx
@@ -39,9 +39,7 @@ const getAvailableRoles = (
   currentUserRole: OrganizationRole,
   isKiloAdmin: boolean
 ): OrganizationRole[] => {
-  return isKiloAdmin || currentUserRole === 'owner' || currentUserRole === 'billing_manager'
-    ? ['owner', 'member', 'billing_manager']
-    : [];
+  return isKiloAdmin || currentUserRole === 'owner' ? ['owner', 'member', 'billing_manager'] : [];
 };
 
 type MemberRoleDropdownProps = {

--- a/apps/web/src/routers/organizations/organization-members-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-members-router.test.ts
@@ -18,6 +18,7 @@ jest.mock('@/lib/email', () => ({
 let regularUser: User;
 let adminUser: User;
 let memberUser: User;
+let billingManagerUser: User;
 let nonMemberUser: User;
 let testOrganization: Organization;
 
@@ -42,6 +43,12 @@ describe('organizations members trpc router', () => {
       is_admin: false,
     });
 
+    billingManagerUser = await insertTestUser({
+      google_user_email: 'billing-manager-members@example.com',
+      google_user_name: 'Billing Manager Members User',
+      is_admin: false,
+    });
+
     nonMemberUser = await insertTestUser({
       google_user_email: 'non-member-members@example.com',
       google_user_name: 'Non Member Members User',
@@ -53,6 +60,7 @@ describe('organizations members trpc router', () => {
 
     // Add member user to organization using CRUD method
     await addUserToOrganization(testOrganization.id, memberUser.id, 'member');
+    await addUserToOrganization(testOrganization.id, billingManagerUser.id, 'billing_manager');
   });
 
   describe('update procedure', () => {
@@ -130,6 +138,49 @@ describe('organizations members trpc router', () => {
           organizationId: testOrganization.id,
           memberId: targetUser.id,
           role: 'owner',
+        })
+      ).rejects.toThrow('You do not have the required organizational role to access this feature');
+    });
+
+    it('should reject billing managers promoting members to owner', async () => {
+      const targetUser = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@billing-manager-promote.example.com`,
+        google_user_name: 'Billing Manager Promote Target',
+        is_admin: false,
+      });
+      await addUserToOrganization(testOrganization.id, targetUser.id, 'member');
+
+      const caller = await createCallerForUser(billingManagerUser.id);
+
+      await expect(
+        caller.organizations.members.update({
+          organizationId: testOrganization.id,
+          memberId: targetUser.id,
+          role: 'owner',
+        })
+      ).rejects.toThrow('You do not have the required organizational role to access this feature');
+    });
+
+    it('should reject billing managers changing owner roles', async () => {
+      const caller = await createCallerForUser(billingManagerUser.id);
+
+      await expect(
+        caller.organizations.members.update({
+          organizationId: testOrganization.id,
+          memberId: regularUser.id,
+          role: 'member',
+        })
+      ).rejects.toThrow('You do not have the required organizational role to access this feature');
+    });
+
+    it('should reject billing managers updating member usage limits', async () => {
+      const caller = await createCallerForUser(billingManagerUser.id);
+
+      await expect(
+        caller.organizations.members.update({
+          organizationId: testOrganization.id,
+          memberId: memberUser.id,
+          dailyUsageLimitUsd: 50.0,
         })
       ).rejects.toThrow('You do not have the required organizational role to access this feature');
     });
@@ -272,6 +323,17 @@ describe('organizations members trpc router', () => {
       ).rejects.toThrow('You do not have access to this organization');
     });
 
+    it('should reject billing managers removing owners', async () => {
+      const caller = await createCallerForUser(billingManagerUser.id);
+
+      await expect(
+        caller.organizations.members.remove({
+          organizationId: testOrganization.id,
+          memberId: regularUser.id,
+        })
+      ).rejects.toThrow('You do not have the required organizational role to access this feature');
+    });
+
     it('should validate input schema', async () => {
       const caller = await createCallerForUser(regularUser.id);
 
@@ -323,6 +385,42 @@ describe('organizations members trpc router', () => {
 
       expect(result).toHaveProperty('acceptInviteUrl');
       expect(result.acceptInviteUrl).toMatch(/^https?:\/\/.+\/users\/accept-invite\/.+$/);
+    });
+
+    it('should reject billing managers inviting owners', async () => {
+      const caller = await createCallerForUser(billingManagerUser.id);
+
+      await expect(
+        caller.organizations.members.invite({
+          organizationId: testOrganization.id,
+          email: `${crypto.randomUUID()}@billing-manager-owner-invite.example.com`,
+          role: 'owner',
+        })
+      ).rejects.toThrow('You do not have the required organizational role to access this feature');
+    });
+
+    it('should reject billing managers inviting members', async () => {
+      const caller = await createCallerForUser(billingManagerUser.id);
+
+      await expect(
+        caller.organizations.members.invite({
+          organizationId: testOrganization.id,
+          email: `${crypto.randomUUID()}@billing-manager-member-invite.example.com`,
+          role: 'member',
+        })
+      ).rejects.toThrow('You do not have the required organizational role to access this feature');
+    });
+
+    it('should reject billing managers inviting billing managers', async () => {
+      const caller = await createCallerForUser(billingManagerUser.id);
+
+      await expect(
+        caller.organizations.members.invite({
+          organizationId: testOrganization.id,
+          email: `${crypto.randomUUID()}@billing-manager-billing-invite.example.com`,
+          role: 'billing_manager',
+        })
+      ).rejects.toThrow('You do not have the required organizational role to access this feature');
     });
 
     it('should throw UNAUTHORIZED error for non-member users', async () => {
@@ -514,6 +612,40 @@ describe('organizations members trpc router', () => {
         success: true,
         updated: inviteId,
       });
+    });
+
+    it('should reject billing managers deleting invitations', async () => {
+      const ownerCaller = await createCallerForUser(regularUser.id);
+      const invitedEmail = `${crypto.randomUUID()}@billing-manager-delete-invite.example.com`;
+      await ownerCaller.organizations.members.invite({
+        organizationId: testOrganization.id,
+        email: invitedEmail,
+        role: 'member',
+      });
+
+      const { db } = await import('@/lib/drizzle');
+      const { organization_invitations } = await import('@kilocode/db/schema');
+      const { eq, and } = await import('drizzle-orm');
+
+      const invitation = await db
+        .select()
+        .from(organization_invitations)
+        .where(
+          and(
+            eq(organization_invitations.organization_id, testOrganization.id),
+            eq(organization_invitations.email, invitedEmail)
+          )
+        )
+        .limit(1);
+
+      const caller = await createCallerForUser(billingManagerUser.id);
+
+      await expect(
+        caller.organizations.members.deleteInvite({
+          organizationId: testOrganization.id,
+          inviteId: invitation[0].id,
+        })
+      ).rejects.toThrow('You do not have the required organizational role to access this feature');
     });
 
     it('should throw NOT_FOUND error for non-existent invitation', async () => {

--- a/apps/web/src/routers/organizations/organization-members-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-members-router.test.ts
@@ -399,16 +399,17 @@ describe('organizations members trpc router', () => {
       ).rejects.toThrow('You do not have the required organizational role to access this feature');
     });
 
-    it('should reject billing managers inviting members', async () => {
+    it('should allow billing managers inviting members', async () => {
       const caller = await createCallerForUser(billingManagerUser.id);
 
-      await expect(
-        caller.organizations.members.invite({
-          organizationId: testOrganization.id,
-          email: `${crypto.randomUUID()}@billing-manager-member-invite.example.com`,
-          role: 'member',
-        })
-      ).rejects.toThrow('You do not have the required organizational role to access this feature');
+      const result = await caller.organizations.members.invite({
+        organizationId: testOrganization.id,
+        email: `${crypto.randomUUID()}@billing-manager-member-invite.example.com`,
+        role: 'member',
+      });
+
+      expect(result).toHaveProperty('acceptInviteUrl');
+      expect(result.acceptInviteUrl).toMatch(/^https?:\/\/.+\/users\/accept-invite\/.+$/);
     });
 
     it('should reject billing managers inviting billing managers', async () => {

--- a/apps/web/src/routers/organizations/organization-members-router.ts
+++ b/apps/web/src/routers/organizations/organization-members-router.ts
@@ -14,7 +14,9 @@ import {
 import { db, sql } from '@/lib/drizzle';
 import { createTRPCRouter } from '@/lib/trpc/init';
 import {
+  ensureOrganizationAccess,
   OrganizationIdInputSchema,
+  organizationBillingMutationProcedure,
   organizationOwnerMutationProcedure,
 } from '@/routers/organizations/utils';
 import { sendOrganizationInviteEmail } from '@/lib/email';
@@ -218,11 +220,15 @@ export const organizationsMembersRouter = createTRPCRouter({
 
       return successResult({ updated: memberId });
     }),
-  invite: organizationOwnerMutationProcedure
+  invite: organizationBillingMutationProcedure
     .input(InviteMemberSchema)
     .mutation(async ({ input, ctx }) => {
       const { user } = ctx;
       const { organizationId, email, role } = input;
+
+      if (role !== 'member') {
+        await ensureOrganizationAccess(ctx, organizationId, ['owner']);
+      }
 
       // Get organization details
       const organization = await getOrganizationById(organizationId);
@@ -233,7 +239,7 @@ export const organizationsMembersRouter = createTRPCRouter({
         });
       }
 
-      // Owners and Kilo admins can invite anyone (owner or member)
+      // Owners and Kilo admins can invite any role. Billing managers can invite members only.
       let invitation;
       try {
         invitation = await inviteUserToOrganization(organizationId, user.id, email, role);

--- a/apps/web/src/routers/organizations/organization-members-router.ts
+++ b/apps/web/src/routers/organizations/organization-members-router.ts
@@ -15,7 +15,7 @@ import { db, sql } from '@/lib/drizzle';
 import { createTRPCRouter } from '@/lib/trpc/init';
 import {
   OrganizationIdInputSchema,
-  organizationBillingMutationProcedure,
+  organizationOwnerMutationProcedure,
 } from '@/routers/organizations/utils';
 import { sendOrganizationInviteEmail } from '@/lib/email';
 import { TRPCError } from '@trpc/server';
@@ -50,7 +50,7 @@ const DeleteInviteSchema = OrganizationIdInputSchema.extend({
 });
 
 export const organizationsMembersRouter = createTRPCRouter({
-  update: organizationBillingMutationProcedure
+  update: organizationOwnerMutationProcedure
     .input(UpdateMemberSchema)
     .mutation(async ({ input, ctx }) => {
       const { user } = ctx;
@@ -118,7 +118,7 @@ export const organizationsMembersRouter = createTRPCRouter({
         updated: role !== undefined ? 'role and limit' : 'limit',
       });
     }),
-  remove: organizationBillingMutationProcedure
+  remove: organizationOwnerMutationProcedure
     .input(RemoveMemberSchema)
     .mutation(async ({ input, ctx }) => {
       const { user } = ctx;
@@ -218,7 +218,7 @@ export const organizationsMembersRouter = createTRPCRouter({
 
       return successResult({ updated: memberId });
     }),
-  invite: organizationBillingMutationProcedure
+  invite: organizationOwnerMutationProcedure
     .input(InviteMemberSchema)
     .mutation(async ({ input, ctx }) => {
       const { user } = ctx;
@@ -289,7 +289,7 @@ export const organizationsMembersRouter = createTRPCRouter({
         acceptInviteUrl,
       };
     }),
-  deleteInvite: organizationBillingMutationProcedure
+  deleteInvite: organizationOwnerMutationProcedure
     .input(DeleteInviteSchema)
     .mutation(async ({ input, ctx }) => {
       const { organizationId, inviteId } = input;

--- a/apps/web/src/routers/organizations/utils.ts
+++ b/apps/web/src/routers/organizations/utils.ts
@@ -130,6 +130,23 @@ export const organizationMemberMutationProcedure = baseProcedure
     return next();
   });
 
+// Custom procedure that ensures user has owner access to the organization
+export const organizationOwnerProcedure = baseProcedure
+  .input(OrganizationIdInputSchema)
+  .use(async ({ ctx, next, input }) => {
+    await ensureOrganizationAccess(ctx, input.organizationId, ['owner']);
+    return next();
+  });
+
+// Owner procedure that also enforces trial/subscription status on mutations
+export const organizationOwnerMutationProcedure = baseProcedure
+  .input(OrganizationIdInputSchema)
+  .use(async ({ ctx, next, input }) => {
+    await ensureOrganizationAccess(ctx, input.organizationId, ['owner']);
+    await requireActiveSubscriptionOrTrial(input.organizationId);
+    return next();
+  });
+
 // Custom procedure that ensures user has owner or billing_manager access to the organization
 export const organizationBillingProcedure = baseProcedure
   .input(OrganizationIdInputSchema)


### PR DESCRIPTION
## Summary

- Restricts organization role changes, member removal, invite revocation, and usage-limit edits to organization owners and Kilo platform admins so billing managers cannot take over organizations.
- Keeps billing managers able to invite ordinary members only, while owner and billing-manager invitations require organization owner access.
- Aligns member-management UI permissions with the backend and adds regression tests for billing-manager invite and takeover cases.

## Verification

Not manually verified in browser; this is an authorization-boundary change with permission-gated controls and no visual redesign.

## Visual Changes

N/A - permission-gated controls only; no visual redesign.

## Reviewer Notes

- The existing `members.update` mutation combines role updates and per-member usage-limit updates, so usage-limit editing remains owner-only in this fix.
- Billing-manager permissions for documented billing/subscription surfaces are intentionally unchanged.