### PR TITLE
feat(kiloclaw): announce OpenClaw 2026.6.8 general availability

### DIFF
--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,12 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-06-22',
+    description: 'OpenClaw 2026.6.8 is now generally available to everyone.',
+    category: 'feature',
+    deployHint: 'upgrade_required',
+  },
+  {
     date: '2026-06-18',
     description: 'OpenClaw 2026.6.8 is available now as an Early Access upgrade.',
     category: 'feature',


### PR DESCRIPTION
## Summary

Adds a changelog entry announcing that OpenClaw 2026.6.8 is now generally available to everyone. This appears at the top of the KiloClaw "What's New" feed, following the existing Early Access entry for the same version. It mirrors the prior 2026.6.5 general availability announcement in wording and metadata.

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [ ] No manual testing performed. The change is a single static data entry in `changelog-data.ts` with no logic change.

## Visual Changes

N/A

## Reviewer Notes

- New entry dated `2026-06-22`, category `feature`, `deployHint: 'upgrade_required'`, matching the convention of the prior GA entry.
- Entries are ordered newest-first, so this is inserted at the top of `CHANGELOG_ENTRIES`.
