### PR TITLE
feat(enterprise) feature adoption status dashboard

### DIFF
--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -29,7 +29,7 @@ import {
   ChevronRight,
 } from 'lucide-react';
 import { usePathname } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import OrganizationSwitcher from './OrganizationSwitcher';
 import { useRoleTesting } from '@/contexts/RoleTestingContext';
 import HeaderLogo from '@/components/HeaderLogo';
@@ -61,9 +61,21 @@ export default function OrganizationAppSidebar({
       organizationId,
     }),
     enabled: organizationData?.plan === 'enterprise',
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
+    refetchOnMount: 'always',
   });
   const pendingFeatureAdoptionCount = featureAdoptionQuery.data?.pendingCount ?? 0;
+  const previousPathname = useRef(pathname);
+  useEffect(() => {
+    if (
+      organizationData?.plan === 'enterprise' &&
+      previousPathname.current !== pathname &&
+      previousPathname.current !== `/organizations/${organizationId}/usage-details`
+    ) {
+      void featureAdoptionQuery.refetch();
+    }
+    previousPathname.current = pathname;
+  }, [featureAdoptionQuery.refetch, organizationData?.plan, organizationId, pathname]);
   const kiloClawNavStateQuery = useOrgKiloClawNavState(organizationId);
 
   // Feature flags

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -56,20 +56,34 @@ export default function OrganizationAppSidebar({
   // Fetch full organization data to access settings
   const { data: organizationData } = useOrganizationWithMembers(organizationId);
   const trpc = useTRPC();
+  const usagePath = `/organizations/${organizationId}/usage-details`;
+  const isUsagePath = pathname === usagePath || pathname.startsWith(`${usagePath}/`);
   const featureAdoptionQuery = useQuery({
+    ...trpc.organizations.usageDetails.getFeatureAdoption.queryOptions({ organizationId }),
+    enabled: organizationData?.plan === 'enterprise' && isUsagePath,
+    staleTime: 5 * 60 * 1000,
+  });
+  const pendingFeatureAdoptionQuery = useQuery({
     ...trpc.organizations.usageDetails.getPendingFeatureAdoptionCount.queryOptions({
       organizationId,
     }),
-    enabled: organizationData?.plan === 'enterprise',
+    enabled: organizationData?.plan === 'enterprise' && !isUsagePath,
     staleTime: 5 * 60 * 1000,
   });
-  const pendingFeatureAdoptionCount = featureAdoptionQuery.data?.pendingCount ?? 0;
+  const pendingFeatureAdoptionCount =
+    organizationData?.plan === 'enterprise'
+      ? isUsagePath
+        ? (featureAdoptionQuery.data?.checks.filter(check => !check.adopted).length ?? 0)
+        : (pendingFeatureAdoptionQuery.data?.pendingCount ?? 0)
+      : 0;
   const previousPathname = useRef(pathname);
   useEffect(() => {
     const adoptionConfigurationRoutes = [
       `/organizations/${organizationId}/integrations`,
       `/organizations/${organizationId}/code-reviews`,
       `/organizations/${organizationId}/security-agent`,
+      `/organizations/${organizationId}/cloud`,
+      `/organizations/${organizationId}/deploy`,
     ];
     const previousRouteWasAdoptionConfiguration = adoptionConfigurationRoutes.some(
       route =>
@@ -80,10 +94,17 @@ export default function OrganizationAppSidebar({
       previousPathname.current !== pathname &&
       previousRouteWasAdoptionConfiguration
     ) {
-      void featureAdoptionQuery.refetch();
+      void (isUsagePath ? featureAdoptionQuery.refetch() : pendingFeatureAdoptionQuery.refetch());
     }
     previousPathname.current = pathname;
-  }, [featureAdoptionQuery.refetch, organizationData?.plan, organizationId, pathname]);
+  }, [
+    featureAdoptionQuery.refetch,
+    isUsagePath,
+    organizationData?.plan,
+    organizationId,
+    pathname,
+    pendingFeatureAdoptionQuery.refetch,
+  ]);
   const kiloClawNavStateQuery = useOrgKiloClawNavState(organizationId);
 
   // Feature flags

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -61,16 +61,24 @@ export default function OrganizationAppSidebar({
       organizationId,
     }),
     enabled: organizationData?.plan === 'enterprise',
-    staleTime: 0,
-    refetchOnMount: 'always',
+    staleTime: 5 * 60 * 1000,
   });
   const pendingFeatureAdoptionCount = featureAdoptionQuery.data?.pendingCount ?? 0;
   const previousPathname = useRef(pathname);
   useEffect(() => {
+    const adoptionConfigurationRoutes = [
+      `/organizations/${organizationId}/integrations`,
+      `/organizations/${organizationId}/code-reviews`,
+      `/organizations/${organizationId}/security-agent`,
+    ];
+    const previousRouteWasAdoptionConfiguration = adoptionConfigurationRoutes.some(
+      route =>
+        previousPathname.current === route || previousPathname.current.startsWith(`${route}/`)
+    );
     if (
       organizationData?.plan === 'enterprise' &&
       previousPathname.current !== pathname &&
-      previousPathname.current !== `/organizations/${organizationId}/usage-details`
+      previousRouteWasAdoptionConfiguration
     ) {
       void featureAdoptionQuery.refetch();
     }

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -57,11 +57,13 @@ export default function OrganizationAppSidebar({
   const { data: organizationData } = useOrganizationWithMembers(organizationId);
   const trpc = useTRPC();
   const featureAdoptionQuery = useQuery({
-    ...trpc.organizations.usageDetails.getFeatureAdoption.queryOptions({ organizationId }),
+    ...trpc.organizations.usageDetails.getPendingFeatureAdoptionCount.queryOptions({
+      organizationId,
+    }),
     enabled: organizationData?.plan === 'enterprise',
+    staleTime: 5 * 60 * 1000,
   });
-  const pendingFeatureAdoptionCount =
-    featureAdoptionQuery.data?.checks.filter(check => !check.adopted).length ?? 0;
+  const pendingFeatureAdoptionCount = featureAdoptionQuery.data?.pendingCount ?? 0;
   const kiloClawNavStateQuery = useOrgKiloClawNavState(organizationId);
 
   // Feature flags

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -34,6 +34,8 @@ import OrganizationSwitcher from './OrganizationSwitcher';
 import { useRoleTesting } from '@/contexts/RoleTestingContext';
 import HeaderLogo from '@/components/HeaderLogo';
 import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
 import { useOrgKiloClawNavState } from '@/hooks/useOrgKiloClaw';
 import SidebarMenuList from './SidebarMenuList';
 import SidebarUserFooter from './SidebarUserFooter';
@@ -53,6 +55,13 @@ export default function OrganizationAppSidebar({
   const { assumedRole, setAssumedRole, setOriginalRole } = useRoleTesting();
   // Fetch full organization data to access settings
   const { data: organizationData } = useOrganizationWithMembers(organizationId);
+  const trpc = useTRPC();
+  const featureAdoptionQuery = useQuery({
+    ...trpc.organizations.usageDetails.getFeatureAdoption.queryOptions({ organizationId }),
+    enabled: organizationData?.plan === 'enterprise',
+  });
+  const pendingFeatureAdoptionCount =
+    featureAdoptionQuery.data?.checks.filter(check => !check.adopted).length ?? 0;
   const kiloClawNavStateQuery = useOrgKiloClawNavState(organizationId);
 
   // Feature flags
@@ -105,6 +114,8 @@ export default function OrganizationAppSidebar({
     icon: React.ElementType;
     url: string;
     className?: string;
+    badge?: string;
+    badgeVariant?: 'brand' | 'alert';
   }> = [
     ...(showWelcome
       ? [
@@ -124,6 +135,8 @@ export default function OrganizationAppSidebar({
       title: 'Usage',
       icon: ChartColumnIncreasing,
       url: `/organizations/${organizationId}/usage-details`,
+      badge: pendingFeatureAdoptionCount > 0 ? String(pendingFeatureAdoptionCount) : undefined,
+      badgeVariant: 'alert',
     },
   ];
 

--- a/apps/web/src/app/(app)/components/SidebarMenuList.tsx
+++ b/apps/web/src/app/(app)/components/SidebarMenuList.tsx
@@ -22,6 +22,7 @@ type MenuItem = {
   suffixIcon?: React.ElementType;
   subtitle?: string;
   badge?: string;
+  badgeVariant?: 'brand' | 'alert';
   className?: string;
 };
 
@@ -108,7 +109,14 @@ export default function SidebarMenuList({
                   </SidebarMenuButton>
                 )}
                 {item.badge && (
-                  <SidebarMenuBadge className="bg-brand-primary text-primary-foreground peer-hover/menu-button:text-primary-foreground peer-data-[active=true]/menu-button:text-primary-foreground right-4 !top-1/2 h-4 min-w-0 !-translate-y-1/2 rounded-full px-1.5 text-[10px] font-bold tracking-wide uppercase ring-1 ring-brand-primary/30">
+                  <SidebarMenuBadge
+                    className={cn(
+                      'right-4 !top-1/2 h-4 min-w-0 !-translate-y-1/2 rounded-full px-1.5 text-[10px] font-bold tracking-wide uppercase',
+                      item.badgeVariant === 'alert'
+                        ? 'bg-destructive/15 text-destructive ring-1 ring-destructive/30'
+                        : 'bg-brand-primary text-primary-foreground peer-hover/menu-button:text-primary-foreground peer-data-[active=true]/menu-button:text-primary-foreground ring-1 ring-brand-primary/30'
+                    )}
+                  >
                     {item.badge}
                   </SidebarMenuBadge>
                 )}

--- a/apps/web/src/app/(app)/organizations/[id]/usage-details/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/usage-details/page.tsx
@@ -16,6 +16,7 @@ export default async function OrganizationUsageStatsPage({
           organizationId={organization.id}
           organizationName={organization.name}
           callerRole={role}
+          organizationPlan={organization.plan}
           title={`Usage — ${organization.name}`}
         />
       )}

--- a/apps/web/src/app/api/organizations/hooks.ts
+++ b/apps/web/src/app/api/organizations/hooks.ts
@@ -553,7 +553,8 @@ export type OrganizationAIAdoptionProps = Partial<
 export function useOrganizationAIAdoptionTimeseries(
   organizationId: string,
   startDate: string,
-  endDate: string
+  endDate: string,
+  options?: { enabled?: boolean }
 ) {
   const trpc = useTRPC();
   const { data, error, isLoading } = useQuery(
@@ -576,7 +577,7 @@ export function useOrganizationAIAdoptionTimeseries(
         }
       ),
       {
-        enabled: true,
+        enabled: options?.enabled ?? true,
       }
     )
   );

--- a/apps/web/src/app/api/organizations/hooks.ts
+++ b/apps/web/src/app/api/organizations/hooks.ts
@@ -553,8 +553,7 @@ export type OrganizationAIAdoptionProps = Partial<
 export function useOrganizationAIAdoptionTimeseries(
   organizationId: string,
   startDate: string,
-  endDate: string,
-  options?: { enabled?: boolean }
+  endDate: string
 ) {
   const trpc = useTRPC();
   const { data, error, isLoading } = useQuery(
@@ -577,7 +576,7 @@ export function useOrganizationAIAdoptionTimeseries(
         }
       ),
       {
-        enabled: options?.enabled ?? true,
+        enabled: true,
       }
     )
   );

--- a/apps/web/src/components/usage-analytics/AIAdoptionSummaryCard.tsx
+++ b/apps/web/src/components/usage-analytics/AIAdoptionSummaryCard.tsx
@@ -23,7 +23,7 @@ export function AIAdoptionSummaryCard({
     dateRange.endDate
   );
   const latest = adoption.timeseries?.at(-1);
-  const score = latest ? Math.round(latest.frequency + latest.depth + latest.coverage) : 0;
+  const score = latest ? Math.round(latest.frequency + latest.depth + latest.coverage) : null;
 
   if (adoption.error) {
     return (
@@ -33,6 +33,36 @@ export function AIAdoptionSummaryCard({
           <div>
             <p className="font-medium">AI adoption score is unavailable</p>
             <p className="text-muted-foreground mt-1 text-sm">Open AI usage to try again.</p>
+          </div>
+          <Button variant="secondary" size="sm" onClick={onViewDetails}>
+            View AI usage
+            <ArrowRight className="size-4" />
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!adoption.isLoading && (adoption.isNewOrganization || score === null)) {
+    return (
+      <Card className="h-full">
+        <CardHeader className="gap-3">
+          <div className="bg-muted flex size-9 items-center justify-center rounded-lg">
+            <TrendingUp className="size-4" />
+          </div>
+          <div className="space-y-1.5">
+            <CardTitle className="text-lg">AI adoption score</CardTitle>
+            <p className="text-muted-foreground text-sm">
+              Frequency, depth, and coverage of AI usage.
+            </p>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div>
+            <p className="font-medium">Not enough activity yet</p>
+            <p className="text-muted-foreground mt-1 text-sm">
+              The score appears after at least three days of AI usage.
+            </p>
           </div>
           <Button variant="secondary" size="sm" onClick={onViewDetails}>
             View AI usage

--- a/apps/web/src/components/usage-analytics/AIAdoptionSummaryCard.tsx
+++ b/apps/web/src/components/usage-analytics/AIAdoptionSummaryCard.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { AlertCircle, ArrowRight, TrendingUp } from 'lucide-react';
+import { useOrganizationAIAdoptionTimeseries } from '@/app/api/organizations/hooks';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { DateRange } from './hooks';
+
+export function AIAdoptionSummaryCard({
+  organizationId,
+  dateRange,
+  onViewDetails,
+}: {
+  organizationId: string;
+  dateRange: DateRange;
+  onViewDetails: () => void;
+}) {
+  const adoption = useOrganizationAIAdoptionTimeseries(
+    organizationId,
+    dateRange.startDate,
+    dateRange.endDate
+  );
+  const latest = adoption.timeseries?.at(-1);
+  const score = latest ? Math.round(latest.frequency + latest.depth + latest.coverage) : 0;
+
+  if (adoption.error) {
+    return (
+      <Card className="h-full">
+        <CardContent className="flex h-full min-h-56 flex-col items-center justify-center gap-3 p-6 text-center">
+          <AlertCircle className="text-muted-foreground size-5" />
+          <div>
+            <p className="font-medium">AI adoption score is unavailable</p>
+            <p className="text-muted-foreground mt-1 text-sm">Open AI usage to try again.</p>
+          </div>
+          <Button variant="secondary" size="sm" onClick={onViewDetails}>
+            View AI usage
+            <ArrowRight className="size-4" />
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="gap-3">
+        <div className="bg-muted flex size-9 items-center justify-center rounded-lg">
+          <TrendingUp className="size-4" />
+        </div>
+        <div className="space-y-1.5">
+          <CardTitle className="text-lg">AI adoption score</CardTitle>
+          <p className="text-muted-foreground text-sm">
+            Frequency, depth, and coverage of AI usage.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {adoption.isLoading ? (
+          <Skeleton className="h-12 w-28" />
+        ) : (
+          <div>
+            <div className="text-4xl font-bold tabular-nums">{score}</div>
+            <div className="text-muted-foreground text-sm">out of 100</div>
+          </div>
+        )}
+        <Progress
+          value={score}
+          indicatorClassName="bg-gradient-to-r from-blue-600 via-blue-500 to-green-500"
+          aria-label={`AI adoption score ${score} out of 100`}
+        />
+        <Button variant="secondary" size="sm" onClick={onViewDetails}>
+          View AI usage
+          <ArrowRight className="size-4" />
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/usage-analytics/FeatureAdoptionView.tsx
+++ b/apps/web/src/components/usage-analytics/FeatureAdoptionView.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { AlertCircle, ArrowRight, Bot, Cable, Check, Circle, Shield, Webhook } from 'lucide-react';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { FeatureAdoptionKey } from '@/lib/organizations/feature-adoption';
+
+const featureIcons: Record<FeatureAdoptionKey, typeof Bot> = {
+  'source-control-integration': Cable,
+  'code-reviewer': Bot,
+  'security-agent': Shield,
+  'cloud-agent-webhook': Webhook,
+  'team-integration': Cable,
+};
+
+export function FeatureAdoptionView({
+  organizationId,
+  compact = false,
+  onViewDetails,
+}: {
+  organizationId: string;
+  compact?: boolean;
+  onViewDetails?: () => void;
+}) {
+  const trpc = useTRPC();
+  const { data, isLoading, isError, refetch } = useQuery(
+    trpc.organizations.usageDetails.getFeatureAdoption.queryOptions({ organizationId })
+  );
+
+  if (isLoading) {
+    return <FeatureAdoptionSkeleton compact={compact} />;
+  }
+
+  if (isError) {
+    return (
+      <Card className="h-full">
+        <CardContent className="flex h-full min-h-56 flex-col items-center justify-center gap-3 p-6 text-center">
+          <AlertCircle className="text-muted-foreground size-5" />
+          <div>
+            <p className="font-medium">Feature adoption is unavailable</p>
+            <p className="text-muted-foreground mt-1 text-sm">Try loading the report again.</p>
+          </div>
+          <Button variant="secondary" size="sm" onClick={() => void refetch()}>
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const checks = data?.checks ?? [];
+  const adoptedCount = checks.filter(check => check.adopted).length;
+  const adoptionPercent =
+    checks.length === 0 ? 0 : Math.round((adoptedCount / checks.length) * 100);
+  const visibleChecks = compact
+    ? [...checks].sort((a, b) => Number(a.adopted) - Number(b.adopted)).slice(0, 3)
+    : checks;
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="gap-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <CardTitle className="text-lg">Feature adoption</CardTitle>
+              <Badge variant="secondary">Enterprise</Badge>
+            </div>
+            <p className="text-muted-foreground text-sm">
+              Organization features that are configured and ready to use.
+            </p>
+          </div>
+          <div className="text-right">
+            <div className="text-2xl font-bold tabular-nums">
+              {adoptedCount}/{checks.length}
+            </div>
+            <div className="text-muted-foreground text-xs">features adopted</div>
+          </div>
+        </div>
+        <Progress
+          value={adoptionPercent}
+          indicatorClassName="bg-gradient-to-r from-blue-600 via-blue-500 to-green-500"
+          aria-label={`${adoptionPercent}% of features adopted`}
+        />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="divide-border divide-y rounded-lg border">
+          {visibleChecks.map(check => {
+            const FeatureIcon = featureIcons[check.key];
+            return (
+              <div key={check.key} className="flex items-start gap-3 p-4">
+                <div
+                  className={
+                    check.adopted
+                      ? 'mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md bg-green-500/10 text-green-700 dark:text-green-400'
+                      : 'bg-muted text-muted-foreground mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md'
+                  }
+                >
+                  <FeatureIcon className="size-4" aria-hidden="true" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium">{check.title}</p>
+                  <p className="text-muted-foreground mt-1 text-sm">{check.description}</p>
+                </div>
+                <div className={compact ? 'mt-0.5 w-28 shrink-0' : 'mt-0.5 w-32 shrink-0'}>
+                  <Badge variant={check.adopted ? 'new' : 'outline'} className="gap-1 px-1.5 py-0">
+                    {check.adopted ? (
+                      <Check className="size-3" aria-hidden="true" />
+                    ) : (
+                      <Circle className="size-2.5" aria-hidden="true" />
+                    )}
+                    {check.adopted ? 'Adopted' : 'Not adopted'}
+                  </Badge>
+                </div>
+                {!compact && (
+                  <div className="flex w-44 shrink-0 justify-end">
+                    <Button variant="ghost" size="sm" asChild>
+                      <Link href={check.actionUrl}>{check.actionLabel}</Link>
+                    </Button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        {compact && (
+          <Button variant="secondary" size="sm" onClick={onViewDetails}>
+            View feature adoption
+            <ArrowRight className="size-4" />
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function FeatureAdoptionSkeleton({ compact }: { compact: boolean }) {
+  return (
+    <Card className="h-full">
+      <CardHeader className="space-y-3">
+        <Skeleton className="h-6 w-44" />
+        <Skeleton className="h-4 w-72 max-w-full" />
+        <Skeleton className="h-2 w-full" />
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {Array.from({ length: compact ? 3 : 5 }, (_, index) => (
+          <Skeleton key={index} className="h-16 w-full" />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/usage-analytics/FeatureAdoptionView.tsx
+++ b/apps/web/src/components/usage-analytics/FeatureAdoptionView.tsx
@@ -2,7 +2,17 @@
 
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
-import { AlertCircle, ArrowRight, Bot, Cable, Check, Circle, Shield } from 'lucide-react';
+import {
+  AlertCircle,
+  ArrowRight,
+  Bot,
+  Cable,
+  Check,
+  Circle,
+  Cloud,
+  Rocket,
+  Shield,
+} from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -16,6 +26,8 @@ const featureIcons: Record<FeatureAdoptionKey, typeof Bot> = {
   'code-reviewer': Bot,
   'security-agent': Shield,
   'team-integration': Cable,
+  'cloud-agent-used': Cloud,
+  'project-deployed': Rocket,
 };
 
 export function FeatureAdoptionView({
@@ -71,7 +83,7 @@ export function FeatureAdoptionView({
               <Badge variant="secondary">Enterprise</Badge>
             </div>
             <p className="text-muted-foreground text-sm">
-              Organization features that are configured and ready to use.
+              See which organization features are configured or have been used.
             </p>
           </div>
           <div className="text-right">
@@ -113,7 +125,7 @@ export function FeatureAdoptionView({
                     ) : (
                       <Circle className="size-2.5" aria-hidden="true" />
                     )}
-                    {check.adopted ? 'Adopted' : 'Not adopted'}
+                    {check.adopted ? check.adoptedLabel : check.notAdoptedLabel}
                   </Badge>
                 </div>
                 {!compact && (

--- a/apps/web/src/components/usage-analytics/FeatureAdoptionView.tsx
+++ b/apps/web/src/components/usage-analytics/FeatureAdoptionView.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
-import { AlertCircle, ArrowRight, Bot, Cable, Check, Circle, Shield, Webhook } from 'lucide-react';
+import { AlertCircle, ArrowRight, Bot, Cable, Check, Circle, Shield } from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -15,7 +15,6 @@ const featureIcons: Record<FeatureAdoptionKey, typeof Bot> = {
   'source-control-integration': Cable,
   'code-reviewer': Bot,
   'security-agent': Shield,
-  'cloud-agent-webhook': Webhook,
   'team-integration': Cable,
 };
 

--- a/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
@@ -15,6 +15,7 @@ import {
   formatLargeNumber,
 } from '@/lib/utils';
 import { Download, SlidersHorizontal } from 'lucide-react';
+import type { Organization } from '@kilocode/db/schema';
 import type { OrganizationRole } from '@/lib/organizations/organization-types';
 import { SummarySection } from './SummarySection';
 import { PrimaryChart } from './PrimaryChart';
@@ -53,6 +54,9 @@ import {
 } from './types';
 import { formatDollarsFromMicrodollars, humanize } from './format';
 import { exportUsageTableToCsv } from './csvExport';
+import { AIAdoptionSummaryCard } from './AIAdoptionSummaryCard';
+import { FeatureAdoptionView } from './FeatureAdoptionView';
+import { UsageViewNavigation } from './UsageViewNavigation';
 
 type UsageAnalyticsDashboardProps = {
   context: 'personal' | 'organization';
@@ -68,6 +72,7 @@ type UsageAnalyticsDashboardProps = {
    * Ignored in personal context (role is resolved per-org via `organizations.list`).
    */
   callerRole?: OrganizationRole;
+  organizationPlan?: Organization['plan'];
   /** Page title override. */
   title?: string;
 };
@@ -106,13 +111,25 @@ export function UsageAnalyticsDashboard({
   organizationId,
   organizationName,
   callerRole,
+  organizationPlan,
   title,
 }: UsageAnalyticsDashboardProps) {
   const trpc = useTRPC();
   const { state, setState } = useUsageDashboardState();
-  const { period, granularity, costSource, chartMetric, filters, groupBy, personalView, viewAs } =
-    state;
+  const {
+    period,
+    granularity,
+    costSource,
+    chartMetric,
+    filters,
+    groupBy,
+    personalView,
+    viewAs,
+    usageView,
+  } = state;
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const hasEnterpriseUsageViews = context === 'organization' && organizationPlan === 'enterprise';
+  const showDetailedUsage = !hasEnterpriseUsageViews || usageView === 'ai-usage';
 
   // `organizations.list` is always available to the caller and returns the
   // caller's role per org. We need it in both personal context (for the Scope
@@ -231,13 +248,17 @@ export function UsageAnalyticsDashboard({
     ]
   );
 
-  const { data: summary, isLoading: summaryLoading } = useUsageSummary(commonArgs);
+  const { data: summary, isLoading: summaryLoading } = useUsageSummary({
+    ...commonArgs,
+    enabled: showDetailedUsage,
+  });
 
   const splitByDimension = groupBy !== 'none' ? groupBy : undefined;
   const { data: timeseries, isLoading: timeseriesLoading } = useUsageTimeseries({
     ...commonArgs,
     metric: chartMetric,
     splitBy: splitByDimension,
+    enabled: showDetailedUsage,
   });
 
   const { data: featureBreakdown, isLoading: featureBreakdownLoading } = useUsageBreakdown({
@@ -245,25 +266,28 @@ export function UsageAnalyticsDashboard({
     dimension: 'feature',
     metric: 'cost',
     limit: 20,
+    enabled: showDetailedUsage,
   });
   const { data: modelBreakdown, isLoading: modelBreakdownLoading } = useUsageBreakdown({
     ...commonArgs,
     dimension: 'model',
     metric: 'cost',
     limit: 10,
+    enabled: showDetailedUsage,
   });
   const { data: projectBreakdown, isLoading: projectBreakdownLoading } = useUsageBreakdown({
     ...commonArgs,
     dimension: 'project',
     metric: 'cost',
     limit: 10,
+    enabled: showDetailedUsage,
   });
   const { data: userBreakdown, isLoading: userBreakdownLoading } = useUsageBreakdown({
     ...commonArgs,
     dimension: 'user',
     metric: 'cost',
     limit: 10,
-    enabled: isOrgWideView,
+    enabled: isOrgWideView && showDetailedUsage,
   });
 
   const tableGroupBy = useMemo<Dimension[]>(() => (groupBy === 'none' ? [] : [groupBy]), [groupBy]);
@@ -272,6 +296,7 @@ export function UsageAnalyticsDashboard({
     ...commonArgs,
     groupBy: tableGroupBy,
     limit: 500,
+    enabled: showDetailedUsage,
   });
 
   // Resolve user ID -> email for labels whenever there is an effective org
@@ -506,129 +531,176 @@ export function UsageAnalyticsDashboard({
 
   const pageTitle = title ?? 'Usage Analytics';
 
+  const showUsageControls = !hasEnterpriseUsageViews || usageView === 'ai-usage';
+
   return (
     <div className="flex h-[calc(100dvh-3.5rem)] w-full overflow-hidden">
       {typeof pageTitle === 'string' && <SetPageTitle title={pageTitle} />}
 
-      <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
-        <SheetContent side="left" className="w-80 p-0 lg:hidden">
-          <SheetHeader className="sr-only">
-            <SheetTitle>Filters & Controls</SheetTitle>
-          </SheetHeader>
-          {sidebar}
-        </SheetContent>
-      </Sheet>
+      {showUsageControls && (
+        <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
+          <SheetContent side="left" className="w-80 p-0 lg:hidden">
+            <SheetHeader className="sr-only">
+              <SheetTitle>Filters & Controls</SheetTitle>
+            </SheetHeader>
+            {sidebar}
+          </SheetContent>
+        </Sheet>
+      )}
 
-      <div className="hidden w-80 shrink-0 border-r lg:block">{sidebar}</div>
+      {showUsageControls && <div className="hidden w-80 shrink-0 border-r lg:block">{sidebar}</div>}
 
       <div className="flex h-full flex-1 flex-col overflow-hidden">
-        <div className="bg-background/90 flex items-center gap-3 border-b px-4 py-2 backdrop-blur lg:hidden">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setMobileSidebarOpen(true)}
-            className="gap-2"
-          >
-            <SlidersHorizontal className="h-4 w-4" />
-            Filters
-          </Button>
-        </div>
+        {showUsageControls && (
+          <div className="bg-background/90 flex items-center gap-3 border-b px-4 py-2 backdrop-blur lg:hidden">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setMobileSidebarOpen(true)}
+              className="gap-2"
+            >
+              <SlidersHorizontal className="h-4 w-4" />
+              Filters
+            </Button>
+          </div>
+        )}
 
         <div className="flex-1 overflow-y-auto">
           <div className="m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
-            <UsageWarning />
-
-            {isOrgContext && organizationId && (
-              <AIAdoptionScoreCard organizationId={organizationId} dateRange={dateRange} />
-            )}
-
-            <SummarySection
-              summary={summary}
-              loading={summaryLoading}
-              costSource={costSource}
-              showActiveUsers={isOrgWideView}
-            />
-
-            <BreakdownPieChart
-              title="Features"
-              dimension="feature"
-              data={featureBreakdown}
-              loading={featureBreakdownLoading}
-              labelFor={featureLabelFor}
-            />
-            <BreakdownBarChart
-              title="Models"
-              dimension="model"
-              data={modelBreakdown}
-              loading={modelBreakdownLoading}
-              metric="cost"
-            />
-            <BreakdownBarChart
-              title="Top Projects"
-              dimension="project"
-              data={projectBreakdown}
-              loading={projectBreakdownLoading}
-              metric="cost"
-              labelFor={projectLabelFor}
-            />
-            {isOrgWideView && (
-              <BreakdownBarChart
-                title="Users"
-                dimension="user"
-                data={userBreakdown}
-                loading={userBreakdownLoading}
-                metric="cost"
-                labelFor={userLabelFor}
-              />
-            )}
-
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">Trends</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <PrimaryChart
-                  metric={chartMetric}
-                  costSource={costSource}
-                  data={timeseries}
-                  loading={timeseriesLoading}
-                  splitByLabel={
-                    splitByDimension ? DIMENSION_LABELS[splitByDimension as Dimension] : undefined
-                  }
-                  seriesLabelFor={
-                    splitByDimension ? v => labelForDimensionValue(splitByDimension, v) : undefined
-                  }
-                  period={period}
-                  granularity={granularity}
+            {hasEnterpriseUsageViews && (
+              <div className="space-y-4">
+                <div>
+                  <h1 className="text-2xl font-bold">Usage</h1>
+                  <p className="text-muted-foreground mt-1 text-sm">
+                    Track feature adoption and AI assisted work across {organizationName}.
+                  </p>
+                </div>
+                <UsageViewNavigation
+                  value={usageView}
+                  onValueChange={nextView => setState({ usageView: nextView })}
                 />
-              </CardContent>
-            </Card>
+              </div>
+            )}
 
-            <UsageTableBase
-              title="Detailed Breakdown"
-              columns={tableColumns}
-              data={tableRows}
-              emptyMessage={tableLoading ? 'Loading…' : 'No usage data.'}
-              sortable
-              defaultSort={{ key: 'datetime', direction: 'desc' }}
-              headerActions={
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={handleExportCsv}
-                  disabled={tableLoading || (tableData?.rows.length ?? 0) === 0}
-                >
-                  <Download className="mr-1.5 h-3.5 w-3.5" />
-                  Download CSV
-                </Button>
-              }
-            />
+            {hasEnterpriseUsageViews && organizationId && usageView === 'overview' ? (
+              <>
+                <UsageWarning />
+                <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+                  <FeatureAdoptionView
+                    organizationId={organizationId}
+                    compact
+                    onViewDetails={() => setState({ usageView: 'feature-adoption' })}
+                  />
+                  <AIAdoptionSummaryCard
+                    organizationId={organizationId}
+                    dateRange={dateRange}
+                    onViewDetails={() => setState({ usageView: 'ai-usage' })}
+                  />
+                </div>
+              </>
+            ) : hasEnterpriseUsageViews && organizationId && usageView === 'feature-adoption' ? (
+              <FeatureAdoptionView organizationId={organizationId} />
+            ) : (
+              <>
+                <UsageWarning />
 
-            {isOrgContext &&
-              organizationId &&
-              (callerRole === 'owner' || callerRole === 'billing_manager') && (
-                <ActiveKiloclawsTable organizationId={organizationId} />
-              )}
+                {isOrgContext && organizationId && (
+                  <AIAdoptionScoreCard organizationId={organizationId} dateRange={dateRange} />
+                )}
+
+                <SummarySection
+                  summary={summary}
+                  loading={summaryLoading}
+                  costSource={costSource}
+                  showActiveUsers={isOrgWideView}
+                />
+
+                <BreakdownPieChart
+                  title="Features"
+                  dimension="feature"
+                  data={featureBreakdown}
+                  loading={featureBreakdownLoading}
+                  labelFor={featureLabelFor}
+                />
+                <BreakdownBarChart
+                  title="Models"
+                  dimension="model"
+                  data={modelBreakdown}
+                  loading={modelBreakdownLoading}
+                  metric="cost"
+                />
+                <BreakdownBarChart
+                  title="Top Projects"
+                  dimension="project"
+                  data={projectBreakdown}
+                  loading={projectBreakdownLoading}
+                  metric="cost"
+                  labelFor={projectLabelFor}
+                />
+                {isOrgWideView && (
+                  <BreakdownBarChart
+                    title="Users"
+                    dimension="user"
+                    data={userBreakdown}
+                    loading={userBreakdownLoading}
+                    metric="cost"
+                    labelFor={userLabelFor}
+                  />
+                )}
+
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">Trends</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <PrimaryChart
+                      metric={chartMetric}
+                      costSource={costSource}
+                      data={timeseries}
+                      loading={timeseriesLoading}
+                      splitByLabel={
+                        splitByDimension
+                          ? DIMENSION_LABELS[splitByDimension as Dimension]
+                          : undefined
+                      }
+                      seriesLabelFor={
+                        splitByDimension
+                          ? value => labelForDimensionValue(splitByDimension, value)
+                          : undefined
+                      }
+                      period={period}
+                      granularity={granularity}
+                    />
+                  </CardContent>
+                </Card>
+
+                <UsageTableBase
+                  title="Detailed Breakdown"
+                  columns={tableColumns}
+                  data={tableRows}
+                  emptyMessage={tableLoading ? 'Loading…' : 'No usage data.'}
+                  sortable
+                  defaultSort={{ key: 'datetime', direction: 'desc' }}
+                  headerActions={
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={handleExportCsv}
+                      disabled={tableLoading || (tableData?.rows.length ?? 0) === 0}
+                    >
+                      <Download className="mr-1.5 h-3.5 w-3.5" />
+                      Download CSV
+                    </Button>
+                  }
+                />
+
+                {isOrgContext &&
+                  organizationId &&
+                  (callerRole === 'owner' || callerRole === 'billing_manager') && (
+                    <ActiveKiloclawsTable organizationId={organizationId} />
+                  )}
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/components/usage-analytics/UsageViewNavigation.tsx
+++ b/apps/web/src/components/usage-analytics/UsageViewNavigation.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import type { OrganizationUsageView } from './types';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+const VIEW_LABELS: Array<{ value: OrganizationUsageView; label: string }> = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'feature-adoption', label: 'Feature adoption' },
+  { value: 'ai-usage', label: 'AI usage' },
+];
+
+export function UsageViewNavigation({
+  value,
+  onValueChange,
+}: {
+  value: OrganizationUsageView;
+  onValueChange: (value: OrganizationUsageView) => void;
+}) {
+  return (
+    <nav
+      className="bg-muted flex w-full gap-1 overflow-x-auto rounded-lg p-1 sm:w-fit"
+      aria-label="Usage reports"
+    >
+      {VIEW_LABELS.map(view => (
+        <Button
+          key={view.value}
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-current={value === view.value ? 'page' : undefined}
+          className={cn(value === view.value && 'bg-background text-foreground shadow-sm')}
+          onClick={() => onValueChange(view.value)}
+        >
+          {view.label}
+        </Button>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/src/components/usage-analytics/hooks.ts
+++ b/apps/web/src/components/usage-analytics/hooks.ts
@@ -160,25 +160,30 @@ function commonFilters(args: CommonArgs) {
   };
 }
 
-export function useUsageSummary(args: CommonArgs) {
+export function useUsageSummary(args: CommonArgs & { enabled?: boolean }) {
   const trpc = useTRPC();
-  return useQuery(trpc.usageAnalytics.getSummary.queryOptions(commonFilters(args)));
+  return useQuery({
+    ...trpc.usageAnalytics.getSummary.queryOptions(commonFilters(args)),
+    enabled: args.enabled ?? true,
+  });
 }
 
 export function useUsageTimeseries(
   args: CommonArgs & {
     metric: MetricKey;
     splitBy?: Dimension;
+    enabled?: boolean;
   }
 ) {
   const trpc = useTRPC();
-  return useQuery(
-    trpc.usageAnalytics.getTimeseries.queryOptions({
+  return useQuery({
+    ...trpc.usageAnalytics.getTimeseries.queryOptions({
       ...commonFilters(args),
       metric: args.metric,
       splitBy: args.splitBy,
-    })
-  );
+    }),
+    enabled: args.enabled ?? true,
+  });
 }
 
 export function useUsageBreakdown(
@@ -205,16 +210,18 @@ export function useUsageTable(
   args: CommonArgs & {
     groupBy: Dimension[];
     limit?: number;
+    enabled?: boolean;
   }
 ) {
   const trpc = useTRPC();
-  return useQuery(
-    trpc.usageAnalytics.getTable.queryOptions({
+  return useQuery({
+    ...trpc.usageAnalytics.getTable.queryOptions({
       ...commonFilters(args),
       groupBy: args.groupBy,
       limit: args.limit ?? 1000,
-    })
-  );
+    }),
+    enabled: args.enabled ?? true,
+  });
 }
 
 export function useResolveOrgUsers(organizationId: string | null, userIds: string[]) {

--- a/apps/web/src/components/usage-analytics/types.ts
+++ b/apps/web/src/components/usage-analytics/types.ts
@@ -7,6 +7,8 @@ export type Granularity = 'hour' | 'day' | 'week' | 'month';
 
 export type CostSource = 'cost' | 'market';
 
+export type OrganizationUsageView = 'overview' | 'feature-adoption' | 'ai-usage';
+
 export type Dimension = 'feature' | 'model' | 'mode' | 'user' | 'provider' | 'project';
 
 export type MetricKey =

--- a/apps/web/src/components/usage-analytics/useUsageDashboardState.ts
+++ b/apps/web/src/components/usage-analytics/useUsageDashboardState.ts
@@ -7,6 +7,7 @@ import {
   type Granularity,
   type MetricKey,
   type Dimension,
+  type OrganizationUsageView,
 } from './types';
 import type { UsageFilters } from './hooks';
 import { EMPTY_FILTERS } from './hooks';
@@ -20,11 +21,13 @@ export type DashboardState = {
   groupBy: Dimension | 'none';
   personalView: string;
   viewAs: 'self' | 'org-wide';
+  usageView: OrganizationUsageView;
 };
 
 const VALID_PERIODS: PeriodOption[] = ['today', 'yesterday', '7d', '30d', '1y'];
 const VALID_GRANULARITIES: Granularity[] = ['hour', 'day', 'week', 'month'];
 const VALID_DIMENSIONS: Dimension[] = ['feature', 'model', 'mode', 'user', 'provider', 'project'];
+const VALID_USAGE_VIEWS: OrganizationUsageView[] = ['overview', 'feature-adoption', 'ai-usage'];
 
 const INCLUDE_DIM_KEYS: (keyof UsageFilters)[] = [
   'features',
@@ -199,9 +202,24 @@ export function useUsageDashboardState(defaultState?: Partial<DashboardState>): 
     const viewAsRaw = params.get('viewAs');
     const viewAs = viewAsRaw === 'org-wide' ? 'org-wide' : (defaultState?.viewAs ?? 'self');
 
+    const usageViewRaw = params.get('view');
+    const usageView = VALID_USAGE_VIEWS.includes(usageViewRaw as OrganizationUsageView)
+      ? (usageViewRaw as OrganizationUsageView)
+      : (defaultState?.usageView ?? 'overview');
+
     const filters = deserializeFiltersFromParams(params);
 
-    return { period, granularity, costSource, chartMetric, filters, groupBy, personalView, viewAs };
+    return {
+      period,
+      granularity,
+      costSource,
+      chartMetric,
+      filters,
+      groupBy,
+      personalView,
+      viewAs,
+      usageView,
+    };
   });
 
   const isInitialized = useRef(false);
@@ -241,6 +259,10 @@ export function useUsageDashboardState(defaultState?: Partial<DashboardState>): 
       const personalView = params.get('personalView') ?? state.personalView;
       const viewAsRaw = params.get('viewAs');
       const viewAs = viewAsRaw === 'org-wide' ? 'org-wide' : state.viewAs;
+      const usageViewRaw = params.get('view');
+      const usageView = VALID_USAGE_VIEWS.includes(usageViewRaw as OrganizationUsageView)
+        ? (usageViewRaw as OrganizationUsageView)
+        : 'overview';
       const filters = deserializeFiltersFromParams(params);
 
       setStateInternal({
@@ -252,6 +274,7 @@ export function useUsageDashboardState(defaultState?: Partial<DashboardState>): 
         groupBy,
         personalView,
         viewAs,
+        usageView,
       });
 
       // After the state update flushes, resume pushing to the URL.
@@ -271,6 +294,7 @@ export function useUsageDashboardState(defaultState?: Partial<DashboardState>): 
     state.groupBy,
     state.personalView,
     state.viewAs,
+    state.usageView,
   ]);
 
   // Sync state to URL parameters when state changes
@@ -309,6 +333,12 @@ export function useUsageDashboardState(defaultState?: Partial<DashboardState>): 
       params.set('viewAs', 'org-wide');
     } else {
       params.delete('viewAs');
+    }
+
+    if (state.usageView === 'overview') {
+      params.delete('view');
+    } else {
+      params.set('view', state.usageView);
     }
 
     serializeFiltersToParams(params, state.filters);

--- a/apps/web/src/lib/organizations/feature-adoption.test.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.test.ts
@@ -6,9 +6,11 @@ function buildState(
   overrides: Partial<Parameters<typeof buildFeatureAdoptionChecks>[1]> = {}
 ): Parameters<typeof buildFeatureAdoptionChecks>[1] {
   return {
-    agentConfigs: [],
-    integrations: [],
+    sourceControlConnected: false,
+    codeReviewerEnabled: false,
+    securityAgentEnabled: false,
     hasActiveCloudAgentWebhook: false,
+    teamIntegrationConnected: false,
     ...overrides,
   };
 }
@@ -27,67 +29,35 @@ describe('buildFeatureAdoptionChecks', () => {
     expect(checks.every(check => !check.adopted)).toBe(true);
   });
 
-  it('marks enabled agents and an active webhook as adopted', () => {
+  it('maps shared adoption state to every fixed check', () => {
     const checks = buildFeatureAdoptionChecks(
       organizationId,
       buildState({
-        agentConfigs: [
-          { agentType: 'code_review', platform: 'gitlab', isEnabled: true },
-          { agentType: 'security_scan', platform: 'github', isEnabled: true },
-        ],
+        sourceControlConnected: true,
+        codeReviewerEnabled: true,
+        securityAgentEnabled: true,
         hasActiveCloudAgentWebhook: true,
+        teamIntegrationConnected: true,
       })
     );
 
-    expect(checks.find(check => check.key === 'code-reviewer')?.adopted).toBe(true);
+    expect(checks.every(check => check.adopted)).toBe(true);
+  });
+
+  it('keeps individual checks independent', () => {
+    const checks = buildFeatureAdoptionChecks(
+      organizationId,
+      buildState({
+        sourceControlConnected: true,
+        securityAgentEnabled: true,
+      })
+    );
+
+    expect(checks.find(check => check.key === 'source-control-integration')?.adopted).toBe(true);
     expect(checks.find(check => check.key === 'security-agent')?.adopted).toBe(true);
-    expect(checks.find(check => check.key === 'cloud-agent-webhook')?.adopted).toBe(true);
-  });
-
-  it('does not count disabled agent configurations', () => {
-    const checks = buildFeatureAdoptionChecks(
-      organizationId,
-      buildState({
-        agentConfigs: [
-          { agentType: 'code_review', platform: 'github', isEnabled: false },
-          { agentType: 'security_scan', platform: 'github', isEnabled: false },
-        ],
-      })
-    );
-
     expect(checks.find(check => check.key === 'code-reviewer')?.adopted).toBe(false);
-    expect(checks.find(check => check.key === 'security-agent')?.adopted).toBe(false);
-  });
-
-  it('requires healthy active integrations', () => {
-    const checks = buildFeatureAdoptionChecks(
-      organizationId,
-      buildState({
-        integrations: [
-          {
-            platform: 'github',
-            status: 'active',
-            suspendedAt: null,
-            authInvalidAt: '2026-06-19T00:00:00.000Z',
-          },
-          {
-            platform: 'slack',
-            status: 'suspended',
-            suspendedAt: '2026-06-19T00:00:00.000Z',
-            authInvalidAt: null,
-          },
-          {
-            platform: 'linear',
-            status: 'active',
-            suspendedAt: null,
-            authInvalidAt: null,
-          },
-        ],
-      })
-    );
-
-    expect(checks.find(check => check.key === 'source-control-integration')?.adopted).toBe(false);
-    expect(checks.find(check => check.key === 'team-integration')?.adopted).toBe(true);
+    expect(checks.find(check => check.key === 'cloud-agent-webhook')?.adopted).toBe(false);
+    expect(checks.find(check => check.key === 'team-integration')?.adopted).toBe(false);
   });
 
   it('returns organization-scoped actions', () => {

--- a/apps/web/src/lib/organizations/feature-adoption.test.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.test.ts
@@ -9,21 +9,19 @@ function buildState(
     sourceControlConnected: false,
     codeReviewerEnabled: false,
     securityAgentEnabled: false,
-    hasActiveCloudAgentWebhook: false,
     teamIntegrationConnected: false,
     ...overrides,
   };
 }
 
 describe('buildFeatureAdoptionChecks', () => {
-  it('returns every fixed check as not adopted when no features are configured', () => {
+  it('returns every reliable fixed check as not adopted when no features are configured', () => {
     const checks = buildFeatureAdoptionChecks(organizationId, buildState());
 
     expect(checks.map(check => check.key)).toEqual([
       'source-control-integration',
       'code-reviewer',
       'security-agent',
-      'cloud-agent-webhook',
       'team-integration',
     ]);
     expect(checks.every(check => !check.adopted)).toBe(true);
@@ -36,7 +34,6 @@ describe('buildFeatureAdoptionChecks', () => {
         sourceControlConnected: true,
         codeReviewerEnabled: true,
         securityAgentEnabled: true,
-        hasActiveCloudAgentWebhook: true,
         teamIntegrationConnected: true,
       })
     );
@@ -56,19 +53,12 @@ describe('buildFeatureAdoptionChecks', () => {
     expect(checks.find(check => check.key === 'source-control-integration')?.adopted).toBe(true);
     expect(checks.find(check => check.key === 'security-agent')?.adopted).toBe(true);
     expect(checks.find(check => check.key === 'code-reviewer')?.adopted).toBe(false);
-    expect(checks.find(check => check.key === 'cloud-agent-webhook')?.adopted).toBe(false);
     expect(checks.find(check => check.key === 'team-integration')?.adopted).toBe(false);
   });
 
   it('returns organization-scoped actions', () => {
-    const checks = buildFeatureAdoptionChecks(
-      organizationId,
-      buildState({ hasActiveCloudAgentWebhook: true })
-    );
+    const checks = buildFeatureAdoptionChecks(organizationId, buildState());
 
     expect(checks.every(check => check.actionUrl.includes(organizationId))).toBe(true);
-    expect(checks.find(check => check.key === 'cloud-agent-webhook')?.actionUrl).toBe(
-      `/organizations/${organizationId}/cloud/triggers`
-    );
   });
 });

--- a/apps/web/src/lib/organizations/feature-adoption.test.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.test.ts
@@ -1,0 +1,104 @@
+import { buildFeatureAdoptionChecks } from './feature-adoption';
+
+const organizationId = '00000000-0000-4000-8000-000000000001';
+
+function buildState(
+  overrides: Partial<Parameters<typeof buildFeatureAdoptionChecks>[1]> = {}
+): Parameters<typeof buildFeatureAdoptionChecks>[1] {
+  return {
+    agentConfigs: [],
+    integrations: [],
+    hasActiveCloudAgentWebhook: false,
+    ...overrides,
+  };
+}
+
+describe('buildFeatureAdoptionChecks', () => {
+  it('returns every fixed check as not adopted when no features are configured', () => {
+    const checks = buildFeatureAdoptionChecks(organizationId, buildState());
+
+    expect(checks.map(check => check.key)).toEqual([
+      'source-control-integration',
+      'code-reviewer',
+      'security-agent',
+      'cloud-agent-webhook',
+      'team-integration',
+    ]);
+    expect(checks.every(check => !check.adopted)).toBe(true);
+  });
+
+  it('marks enabled agents and an active webhook as adopted', () => {
+    const checks = buildFeatureAdoptionChecks(
+      organizationId,
+      buildState({
+        agentConfigs: [
+          { agentType: 'code_review', platform: 'gitlab', isEnabled: true },
+          { agentType: 'security_scan', platform: 'github', isEnabled: true },
+        ],
+        hasActiveCloudAgentWebhook: true,
+      })
+    );
+
+    expect(checks.find(check => check.key === 'code-reviewer')?.adopted).toBe(true);
+    expect(checks.find(check => check.key === 'security-agent')?.adopted).toBe(true);
+    expect(checks.find(check => check.key === 'cloud-agent-webhook')?.adopted).toBe(true);
+  });
+
+  it('does not count disabled agent configurations', () => {
+    const checks = buildFeatureAdoptionChecks(
+      organizationId,
+      buildState({
+        agentConfigs: [
+          { agentType: 'code_review', platform: 'github', isEnabled: false },
+          { agentType: 'security_scan', platform: 'github', isEnabled: false },
+        ],
+      })
+    );
+
+    expect(checks.find(check => check.key === 'code-reviewer')?.adopted).toBe(false);
+    expect(checks.find(check => check.key === 'security-agent')?.adopted).toBe(false);
+  });
+
+  it('requires healthy active integrations', () => {
+    const checks = buildFeatureAdoptionChecks(
+      organizationId,
+      buildState({
+        integrations: [
+          {
+            platform: 'github',
+            status: 'active',
+            suspendedAt: null,
+            authInvalidAt: '2026-06-19T00:00:00.000Z',
+          },
+          {
+            platform: 'slack',
+            status: 'suspended',
+            suspendedAt: '2026-06-19T00:00:00.000Z',
+            authInvalidAt: null,
+          },
+          {
+            platform: 'linear',
+            status: 'active',
+            suspendedAt: null,
+            authInvalidAt: null,
+          },
+        ],
+      })
+    );
+
+    expect(checks.find(check => check.key === 'source-control-integration')?.adopted).toBe(false);
+    expect(checks.find(check => check.key === 'team-integration')?.adopted).toBe(true);
+  });
+
+  it('returns organization-scoped actions', () => {
+    const checks = buildFeatureAdoptionChecks(
+      organizationId,
+      buildState({ hasActiveCloudAgentWebhook: true })
+    );
+
+    expect(checks.every(check => check.actionUrl.includes(organizationId))).toBe(true);
+    expect(checks.find(check => check.key === 'cloud-agent-webhook')?.actionUrl).toBe(
+      `/organizations/${organizationId}/cloud/triggers`
+    );
+  });
+});

--- a/apps/web/src/lib/organizations/feature-adoption.test.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.test.ts
@@ -10,12 +10,14 @@ function buildState(
     codeReviewerEnabled: false,
     securityAgentEnabled: false,
     teamIntegrationConnected: false,
+    cloudAgentUsed: false,
+    projectDeployed: false,
     ...overrides,
   };
 }
 
 describe('buildFeatureAdoptionChecks', () => {
-  it('returns every reliable fixed check as not adopted when no features are configured', () => {
+  it('returns every reliable fixed check as incomplete when no features are configured or used', () => {
     const checks = buildFeatureAdoptionChecks(organizationId, buildState());
 
     expect(checks.map(check => check.key)).toEqual([
@@ -23,6 +25,8 @@ describe('buildFeatureAdoptionChecks', () => {
       'code-reviewer',
       'security-agent',
       'team-integration',
+      'cloud-agent-used',
+      'project-deployed',
     ]);
     expect(checks.every(check => !check.adopted)).toBe(true);
   });
@@ -35,10 +39,33 @@ describe('buildFeatureAdoptionChecks', () => {
         codeReviewerEnabled: true,
         securityAgentEnabled: true,
         teamIntegrationConnected: true,
+        cloudAgentUsed: true,
+        projectDeployed: true,
       })
     );
 
     expect(checks.every(check => check.adopted)).toBe(true);
+  });
+
+  it('uses status labels that match what each check measures', () => {
+    const checks = buildFeatureAdoptionChecks(organizationId, buildState());
+
+    expect(checks.find(check => check.key === 'source-control-integration')).toMatchObject({
+      adoptedLabel: 'Connected',
+      notAdoptedLabel: 'Not connected',
+    });
+    expect(checks.find(check => check.key === 'code-reviewer')).toMatchObject({
+      adoptedLabel: 'Enabled',
+      notAdoptedLabel: 'Not enabled',
+    });
+    expect(checks.find(check => check.key === 'cloud-agent-used')).toMatchObject({
+      adoptedLabel: 'Used',
+      notAdoptedLabel: 'Not used',
+    });
+    expect(checks.find(check => check.key === 'project-deployed')).toMatchObject({
+      adoptedLabel: 'Deployed',
+      notAdoptedLabel: 'Not deployed',
+    });
   });
 
   it('keeps individual checks independent', () => {
@@ -47,13 +74,16 @@ describe('buildFeatureAdoptionChecks', () => {
       buildState({
         sourceControlConnected: true,
         securityAgentEnabled: true,
+        cloudAgentUsed: true,
       })
     );
 
     expect(checks.find(check => check.key === 'source-control-integration')?.adopted).toBe(true);
     expect(checks.find(check => check.key === 'security-agent')?.adopted).toBe(true);
+    expect(checks.find(check => check.key === 'cloud-agent-used')?.adopted).toBe(true);
     expect(checks.find(check => check.key === 'code-reviewer')?.adopted).toBe(false);
     expect(checks.find(check => check.key === 'team-integration')?.adopted).toBe(false);
+    expect(checks.find(check => check.key === 'project-deployed')?.adopted).toBe(false);
   });
 
   it('returns organization-scoped actions', () => {

--- a/apps/web/src/lib/organizations/feature-adoption.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.ts
@@ -8,6 +8,8 @@ export const FEATURE_ADOPTION_KEYS = [
   'code-reviewer',
   'security-agent',
   'team-integration',
+  'cloud-agent-used',
+  'project-deployed',
 ] as const;
 
 export type FeatureAdoptionKey = (typeof FEATURE_ADOPTION_KEYS)[number];
@@ -17,6 +19,8 @@ export type FeatureAdoptionCheck = {
   title: string;
   description: string;
   adopted: boolean;
+  adoptedLabel: string;
+  notAdoptedLabel: string;
   actionLabel: string;
   actionUrl: string;
 };
@@ -26,6 +30,8 @@ type FeatureAdoptionState = {
   codeReviewerEnabled: boolean;
   securityAgentEnabled: boolean;
   teamIntegrationConnected: boolean;
+  cloudAgentUsed: boolean;
+  projectDeployed: boolean;
 };
 
 type FeatureAdoptionStateRow = {
@@ -33,6 +39,8 @@ type FeatureAdoptionStateRow = {
   code_reviewer_enabled: boolean;
   security_agent_enabled: boolean;
   team_integration_connected: boolean;
+  cloud_agent_used: boolean;
+  project_deployed: boolean;
 };
 
 export function buildFeatureAdoptionChecks(
@@ -46,6 +54,8 @@ export function buildFeatureAdoptionChecks(
       description:
         'Connect GitHub or GitLab to bring repositories and development workflows into Kilo.',
       adopted: state.sourceControlConnected,
+      adoptedLabel: 'Connected',
+      notAdoptedLabel: 'Not connected',
       actionLabel: state.sourceControlConnected ? 'Manage integrations' : 'Connect source control',
       actionUrl: `/organizations/${organizationId}/integrations`,
     },
@@ -54,6 +64,8 @@ export function buildFeatureAdoptionChecks(
       title: 'Code Reviewer enabled',
       description: 'Run AI assisted reviews on pull requests or merge requests.',
       adopted: state.codeReviewerEnabled,
+      adoptedLabel: 'Enabled',
+      notAdoptedLabel: 'Not enabled',
       actionLabel: state.codeReviewerEnabled ? 'Review settings' : 'Enable Code Reviewer',
       actionUrl: `/organizations/${organizationId}/code-reviews`,
     },
@@ -62,6 +74,8 @@ export function buildFeatureAdoptionChecks(
       title: 'Security Agent enabled',
       description: 'Monitor repositories for Security Findings and remediation opportunities.',
       adopted: state.securityAgentEnabled,
+      adoptedLabel: 'Enabled',
+      notAdoptedLabel: 'Not enabled',
       actionLabel: state.securityAgentEnabled ? 'Review settings' : 'Enable Security Agent',
       actionUrl: `/organizations/${organizationId}/security-agent/config`,
     },
@@ -70,10 +84,32 @@ export function buildFeatureAdoptionChecks(
       title: 'Team workflow connected',
       description: 'Connect Slack, Discord, or Linear to bring Kilo into your team workflow.',
       adopted: state.teamIntegrationConnected,
+      adoptedLabel: 'Connected',
+      notAdoptedLabel: 'Not connected',
       actionLabel: state.teamIntegrationConnected
         ? 'Manage integrations'
         : 'Connect an integration',
       actionUrl: `/organizations/${organizationId}/integrations`,
+    },
+    {
+      key: 'cloud-agent-used',
+      title: 'Cloud Agent',
+      description: 'Start a Cloud Agent session for organization development work.',
+      adopted: state.cloudAgentUsed,
+      adoptedLabel: 'Used',
+      notAdoptedLabel: 'Not used',
+      actionLabel: state.cloudAgentUsed ? 'View Cloud Agent' : 'Start with Cloud Agent',
+      actionUrl: `/organizations/${organizationId}/cloud`,
+    },
+    {
+      key: 'project-deployed',
+      title: 'Deploy',
+      description: 'Deploy a project from a connected repository.',
+      adopted: state.projectDeployed,
+      adoptedLabel: 'Deployed',
+      notAdoptedLabel: 'Not deployed',
+      actionLabel: state.projectDeployed ? 'View deployments' : 'Deploy a project',
+      actionUrl: `/organizations/${organizationId}/deploy`,
     },
   ];
 }
@@ -113,7 +149,26 @@ async function getFeatureAdoptionState(organizationId: string): Promise<FeatureA
             platform IN ('slack', 'discord') OR
             (platform = 'linear' AND metadata -> 'bot_enabled' = 'true'::jsonb)
           )
-      ) AS team_integration_connected
+      ) AS team_integration_connected,
+      (
+        EXISTS (
+          SELECT 1 FROM cli_sessions_v2
+          WHERE organization_id = ${organizationId}
+            AND cloud_agent_session_id IS NOT NULL
+            AND created_on_platform IN ('cloud-agent', 'cloud-agent-web')
+        ) OR EXISTS (
+          SELECT 1 FROM cli_sessions
+          WHERE organization_id = ${organizationId}
+            AND cloud_agent_session_id IS NOT NULL
+            AND created_on_platform IN ('cloud-agent', 'cloud-agent-web')
+        )
+      ) AS cloud_agent_used,
+      EXISTS (
+        SELECT 1 FROM deployments
+        WHERE owned_by_organization_id = ${organizationId}
+          AND created_from = 'deploy'
+          AND last_deployed_at IS NOT NULL
+      ) AS project_deployed
   `);
   const row = result.rows[0] as FeatureAdoptionStateRow | undefined;
   return {
@@ -121,6 +176,8 @@ async function getFeatureAdoptionState(organizationId: string): Promise<FeatureA
     codeReviewerEnabled: row?.code_reviewer_enabled ?? false,
     securityAgentEnabled: row?.security_agent_enabled ?? false,
     teamIntegrationConnected: row?.team_integration_connected ?? false,
+    cloudAgentUsed: row?.cloud_agent_used ?? false,
+    projectDeployed: row?.project_deployed ?? false,
   };
 }
 

--- a/apps/web/src/lib/organizations/feature-adoption.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.ts
@@ -155,12 +155,10 @@ async function getFeatureAdoptionState(organizationId: string): Promise<FeatureA
           SELECT 1 FROM cli_sessions_v2
           WHERE organization_id = ${organizationId}
             AND cloud_agent_session_id IS NOT NULL
-            AND created_on_platform IN ('cloud-agent', 'cloud-agent-web')
         ) OR EXISTS (
           SELECT 1 FROM cli_sessions
           WHERE organization_id = ${organizationId}
             AND cloud_agent_session_id IS NOT NULL
-            AND created_on_platform IN ('cloud-agent', 'cloud-agent-web')
         )
       ) AS cloud_agent_used,
       EXISTS (

--- a/apps/web/src/lib/organizations/feature-adoption.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.ts
@@ -22,91 +22,50 @@ export type FeatureAdoptionCheck = {
   actionUrl: string;
 };
 
-type AdoptionAgentConfig = {
-  agentType: string;
-  platform: string;
-  isEnabled: boolean;
-};
-
-type AdoptionIntegration = {
-  platform: string;
-  status: string | null;
-  suspendedAt: string | null;
-  authInvalidAt: string | null;
-};
-
 type FeatureAdoptionState = {
-  agentConfigs: AdoptionAgentConfig[];
-  integrations: AdoptionIntegration[];
+  sourceControlConnected: boolean;
+  codeReviewerEnabled: boolean;
+  securityAgentEnabled: boolean;
   hasActiveCloudAgentWebhook: boolean;
+  teamIntegrationConnected: boolean;
 };
 
 type FeatureAdoptionStateRow = {
-  agent_configs: AdoptionAgentConfig[];
-  integrations: AdoptionIntegration[];
+  source_control_connected: boolean;
+  code_reviewer_enabled: boolean;
+  security_agent_enabled: boolean;
   has_active_cloud_agent_webhook: boolean;
+  team_integration_connected: boolean;
 };
-
-const SOURCE_CONTROL_PLATFORMS = ['github', 'gitlab'];
-const TEAM_INTEGRATION_PLATFORMS = ['slack', 'discord', 'linear'];
-
-function hasHealthyIntegration(integrations: AdoptionIntegration[], platforms: string[]): boolean {
-  return integrations.some(
-    integration =>
-      platforms.includes(integration.platform) &&
-      integration.status === INTEGRATION_STATUS.ACTIVE &&
-      integration.suspendedAt === null &&
-      integration.authInvalidAt === null
-  );
-}
 
 export function buildFeatureAdoptionChecks(
   organizationId: string,
   state: FeatureAdoptionState
 ): FeatureAdoptionCheck[] {
-  const sourceControlConnected = hasHealthyIntegration(
-    state.integrations,
-    SOURCE_CONTROL_PLATFORMS
-  );
-  const teamIntegrationConnected = hasHealthyIntegration(
-    state.integrations,
-    TEAM_INTEGRATION_PLATFORMS
-  );
-  const codeReviewerEnabled = state.agentConfigs.some(
-    config =>
-      config.agentType === 'code_review' &&
-      SOURCE_CONTROL_PLATFORMS.includes(config.platform) &&
-      config.isEnabled
-  );
-  const securityAgentEnabled = state.agentConfigs.some(
-    config =>
-      config.agentType === 'security_scan' && config.platform === 'github' && config.isEnabled
-  );
-
   return [
     {
       key: 'source-control-integration',
       title: 'Source control connected',
       description:
         'Connect GitHub or GitLab to bring repositories and development workflows into Kilo.',
-      adopted: sourceControlConnected,
-      actionLabel: sourceControlConnected ? 'Manage integrations' : 'Connect source control',
+      adopted: state.sourceControlConnected,
+      actionLabel: state.sourceControlConnected ? 'Manage integrations' : 'Connect source control',
       actionUrl: `/organizations/${organizationId}/integrations`,
     },
     {
       key: 'code-reviewer',
       title: 'Code Reviewer enabled',
       description: 'Run AI assisted reviews on pull requests or merge requests.',
-      adopted: codeReviewerEnabled,
-      actionLabel: codeReviewerEnabled ? 'Review settings' : 'Enable Code Reviewer',
+      adopted: state.codeReviewerEnabled,
+      actionLabel: state.codeReviewerEnabled ? 'Review settings' : 'Enable Code Reviewer',
       actionUrl: `/organizations/${organizationId}/code-reviews`,
     },
     {
       key: 'security-agent',
       title: 'Security Agent enabled',
       description: 'Monitor repositories for Security Findings and remediation opportunities.',
-      adopted: securityAgentEnabled,
-      actionLabel: securityAgentEnabled ? 'Review settings' : 'Enable Security Agent',
+      adopted: state.securityAgentEnabled,
+      actionLabel: state.securityAgentEnabled ? 'Review settings' : 'Enable Security Agent',
       actionUrl: `/organizations/${organizationId}/security-agent/config`,
     },
     {
@@ -121,8 +80,10 @@ export function buildFeatureAdoptionChecks(
       key: 'team-integration',
       title: 'Team workflow connected',
       description: 'Connect Slack, Discord, or Linear to bring Kilo into your team workflow.',
-      adopted: teamIntegrationConnected,
-      actionLabel: teamIntegrationConnected ? 'Manage integrations' : 'Connect an integration',
+      adopted: state.teamIntegrationConnected,
+      actionLabel: state.teamIntegrationConnected
+        ? 'Manage integrations'
+        : 'Connect an integration',
       actionUrl: `/organizations/${organizationId}/integrations`,
     },
   ];
@@ -131,40 +92,51 @@ export function buildFeatureAdoptionChecks(
 async function getFeatureAdoptionState(organizationId: string): Promise<FeatureAdoptionState> {
   const result = await readDb.execute(sql`
     SELECT
-      COALESCE((
-        SELECT jsonb_agg(jsonb_build_object(
-          'agentType', agent_type,
-          'platform', platform,
-          'isEnabled', is_enabled
-        ))
-        FROM agent_configs
-        WHERE owned_by_organization_id = ${organizationId}
-          AND agent_type IN ('code_review', 'security_scan')
-      ), '[]'::jsonb) AS agent_configs,
-      COALESCE((
-        SELECT jsonb_agg(jsonb_build_object(
-          'platform', platform,
-          'status', integration_status,
-          'suspendedAt', suspended_at,
-          'authInvalidAt', auth_invalid_at
-        ))
-        FROM platform_integrations
-        WHERE owned_by_organization_id = ${organizationId}
-      ), '[]'::jsonb) AS integrations,
       EXISTS (
-        SELECT 1
-        FROM cloud_agent_webhook_triggers
+        SELECT 1 FROM platform_integrations
+        WHERE owned_by_organization_id = ${organizationId}
+          AND platform IN ('github', 'gitlab')
+          AND integration_status = ${INTEGRATION_STATUS.ACTIVE}
+          AND suspended_at IS NULL
+          AND auth_invalid_at IS NULL
+      ) AS source_control_connected,
+      EXISTS (
+        SELECT 1 FROM agent_configs
+        WHERE owned_by_organization_id = ${organizationId}
+          AND agent_type = 'code_review'
+          AND platform IN ('github', 'gitlab')
+          AND is_enabled = true
+      ) AS code_reviewer_enabled,
+      EXISTS (
+        SELECT 1 FROM agent_configs
+        WHERE owned_by_organization_id = ${organizationId}
+          AND agent_type = 'security_scan'
+          AND platform = 'github'
+          AND is_enabled = true
+      ) AS security_agent_enabled,
+      EXISTS (
+        SELECT 1 FROM cloud_agent_webhook_triggers
         WHERE organization_id = ${organizationId}
           AND target_type = 'cloud_agent'
           AND activation_mode = 'webhook'
           AND is_active = true
-      ) AS has_active_cloud_agent_webhook
+      ) AS has_active_cloud_agent_webhook,
+      EXISTS (
+        SELECT 1 FROM platform_integrations
+        WHERE owned_by_organization_id = ${organizationId}
+          AND platform IN ('slack', 'discord', 'linear')
+          AND integration_status = ${INTEGRATION_STATUS.ACTIVE}
+          AND suspended_at IS NULL
+          AND auth_invalid_at IS NULL
+      ) AS team_integration_connected
   `);
   const row = result.rows[0] as FeatureAdoptionStateRow | undefined;
   return {
-    agentConfigs: row?.agent_configs ?? [],
-    integrations: row?.integrations ?? [],
+    sourceControlConnected: row?.source_control_connected ?? false,
+    codeReviewerEnabled: row?.code_reviewer_enabled ?? false,
+    securityAgentEnabled: row?.security_agent_enabled ?? false,
     hasActiveCloudAgentWebhook: row?.has_active_cloud_agent_webhook ?? false,
+    teamIntegrationConnected: row?.team_integration_connected ?? false,
   };
 }
 

--- a/apps/web/src/lib/organizations/feature-adoption.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.ts
@@ -1,0 +1,192 @@
+import {
+  agent_configs,
+  cloud_agent_webhook_triggers,
+  organizations,
+  platform_integrations,
+} from '@kilocode/db/schema';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { readDb } from '@/lib/drizzle';
+import { INTEGRATION_STATUS } from '@/lib/integrations/core/constants';
+
+export const FEATURE_ADOPTION_KEYS = [
+  'source-control-integration',
+  'code-reviewer',
+  'security-agent',
+  'cloud-agent-webhook',
+  'team-integration',
+] as const;
+
+export type FeatureAdoptionKey = (typeof FEATURE_ADOPTION_KEYS)[number];
+
+export type FeatureAdoptionCheck = {
+  key: FeatureAdoptionKey;
+  title: string;
+  description: string;
+  adopted: boolean;
+  actionLabel: string;
+  actionUrl: string;
+};
+
+type AdoptionAgentConfig = {
+  agentType: string;
+  platform: string;
+  isEnabled: boolean;
+};
+
+type AdoptionIntegration = {
+  platform: string;
+  status: string | null;
+  suspendedAt: string | null;
+  authInvalidAt: string | null;
+};
+
+type FeatureAdoptionState = {
+  agentConfigs: AdoptionAgentConfig[];
+  integrations: AdoptionIntegration[];
+  hasActiveCloudAgentWebhook: boolean;
+};
+
+const SOURCE_CONTROL_PLATFORMS = ['github', 'gitlab'];
+const TEAM_INTEGRATION_PLATFORMS = ['slack', 'discord', 'linear'];
+
+function hasHealthyIntegration(integrations: AdoptionIntegration[], platforms: string[]): boolean {
+  return integrations.some(
+    integration =>
+      platforms.includes(integration.platform) &&
+      integration.status === INTEGRATION_STATUS.ACTIVE &&
+      integration.suspendedAt === null &&
+      integration.authInvalidAt === null
+  );
+}
+
+export function buildFeatureAdoptionChecks(
+  organizationId: string,
+  state: FeatureAdoptionState
+): FeatureAdoptionCheck[] {
+  const sourceControlConnected = hasHealthyIntegration(
+    state.integrations,
+    SOURCE_CONTROL_PLATFORMS
+  );
+  const teamIntegrationConnected = hasHealthyIntegration(
+    state.integrations,
+    TEAM_INTEGRATION_PLATFORMS
+  );
+  const codeReviewerEnabled = state.agentConfigs.some(
+    config =>
+      config.agentType === 'code_review' &&
+      SOURCE_CONTROL_PLATFORMS.includes(config.platform) &&
+      config.isEnabled
+  );
+  const securityAgentEnabled = state.agentConfigs.some(
+    config =>
+      config.agentType === 'security_scan' && config.platform === 'github' && config.isEnabled
+  );
+
+  return [
+    {
+      key: 'source-control-integration',
+      title: 'Source control connected',
+      description:
+        'Connect GitHub or GitLab to bring repositories and development workflows into Kilo.',
+      adopted: sourceControlConnected,
+      actionLabel: sourceControlConnected ? 'Manage integrations' : 'Connect source control',
+      actionUrl: `/organizations/${organizationId}/integrations`,
+    },
+    {
+      key: 'code-reviewer',
+      title: 'Code Reviewer enabled',
+      description: 'Run AI-assisted reviews on pull requests or merge requests.',
+      adopted: codeReviewerEnabled,
+      actionLabel: codeReviewerEnabled ? 'Review settings' : 'Enable Code Reviewer',
+      actionUrl: `/organizations/${organizationId}/code-reviews`,
+    },
+    {
+      key: 'security-agent',
+      title: 'Security Agent enabled',
+      description: 'Monitor repositories for Security Findings and remediation opportunities.',
+      adopted: securityAgentEnabled,
+      actionLabel: securityAgentEnabled ? 'Review settings' : 'Enable Security Agent',
+      actionUrl: `/organizations/${organizationId}/security-agent/config`,
+    },
+    {
+      key: 'cloud-agent-webhook',
+      title: 'Cloud Agent automation configured',
+      description: 'Start Cloud Agent work from an active external webhook trigger.',
+      adopted: state.hasActiveCloudAgentWebhook,
+      actionLabel: state.hasActiveCloudAgentWebhook ? 'Manage triggers' : 'Create webhook trigger',
+      actionUrl: `/organizations/${organizationId}/cloud/triggers${state.hasActiveCloudAgentWebhook ? '' : '/new'}`,
+    },
+    {
+      key: 'team-integration',
+      title: 'Team workflow connected',
+      description: 'Connect Slack, Discord, or Linear to bring Kilo into your team workflow.',
+      adopted: teamIntegrationConnected,
+      actionLabel: teamIntegrationConnected ? 'Manage integrations' : 'Connect an integration',
+      actionUrl: `/organizations/${organizationId}/integrations`,
+    },
+  ];
+}
+
+export async function getOrganizationFeatureAdoption(organizationId: string): Promise<{
+  plan: 'teams' | 'enterprise';
+  checks: FeatureAdoptionCheck[];
+}> {
+  const organizationRows = await readDb
+    .select({ plan: organizations.plan })
+    .from(organizations)
+    .where(and(eq(organizations.id, organizationId), isNull(organizations.deleted_at)))
+    .limit(1);
+  const organization = organizationRows[0];
+  if (!organization) {
+    throw new Error('Organization not found');
+  }
+  if (organization.plan !== 'enterprise') {
+    return { plan: organization.plan, checks: [] };
+  }
+
+  const [agentConfigRows, integrationRows, webhookRows] = await Promise.all([
+    readDb
+      .select({
+        agentType: agent_configs.agent_type,
+        platform: agent_configs.platform,
+        isEnabled: agent_configs.is_enabled,
+      })
+      .from(agent_configs)
+      .where(
+        and(
+          eq(agent_configs.owned_by_organization_id, organizationId),
+          inArray(agent_configs.agent_type, ['code_review', 'security_scan'])
+        )
+      ),
+    readDb
+      .select({
+        platform: platform_integrations.platform,
+        status: platform_integrations.integration_status,
+        suspendedAt: platform_integrations.suspended_at,
+        authInvalidAt: platform_integrations.auth_invalid_at,
+      })
+      .from(platform_integrations)
+      .where(eq(platform_integrations.owned_by_organization_id, organizationId)),
+    readDb
+      .select({ id: cloud_agent_webhook_triggers.id })
+      .from(cloud_agent_webhook_triggers)
+      .where(
+        and(
+          eq(cloud_agent_webhook_triggers.organization_id, organizationId),
+          eq(cloud_agent_webhook_triggers.target_type, 'cloud_agent'),
+          eq(cloud_agent_webhook_triggers.activation_mode, 'webhook'),
+          eq(cloud_agent_webhook_triggers.is_active, true)
+        )
+      )
+      .limit(1),
+  ]);
+
+  return {
+    plan: organization.plan,
+    checks: buildFeatureAdoptionChecks(organizationId, {
+      agentConfigs: agentConfigRows,
+      integrations: integrationRows,
+      hasActiveCloudAgentWebhook: webhookRows.length > 0,
+    }),
+  };
+}

--- a/apps/web/src/lib/organizations/feature-adoption.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.ts
@@ -7,7 +7,6 @@ export const FEATURE_ADOPTION_KEYS = [
   'source-control-integration',
   'code-reviewer',
   'security-agent',
-  'cloud-agent-webhook',
   'team-integration',
 ] as const;
 
@@ -26,7 +25,6 @@ type FeatureAdoptionState = {
   sourceControlConnected: boolean;
   codeReviewerEnabled: boolean;
   securityAgentEnabled: boolean;
-  hasActiveCloudAgentWebhook: boolean;
   teamIntegrationConnected: boolean;
 };
 
@@ -34,7 +32,6 @@ type FeatureAdoptionStateRow = {
   source_control_connected: boolean;
   code_reviewer_enabled: boolean;
   security_agent_enabled: boolean;
-  has_active_cloud_agent_webhook: boolean;
   team_integration_connected: boolean;
 };
 
@@ -67,14 +64,6 @@ export function buildFeatureAdoptionChecks(
       adopted: state.securityAgentEnabled,
       actionLabel: state.securityAgentEnabled ? 'Review settings' : 'Enable Security Agent',
       actionUrl: `/organizations/${organizationId}/security-agent/config`,
-    },
-    {
-      key: 'cloud-agent-webhook',
-      title: 'Cloud Agent automation configured',
-      description: 'Start Cloud Agent work from an active external webhook trigger.',
-      adopted: state.hasActiveCloudAgentWebhook,
-      actionLabel: state.hasActiveCloudAgentWebhook ? 'Manage triggers' : 'Create webhook trigger',
-      actionUrl: `/organizations/${organizationId}/cloud/triggers${state.hasActiveCloudAgentWebhook ? '' : '/new'}`,
     },
     {
       key: 'team-integration',
@@ -115,19 +104,15 @@ async function getFeatureAdoptionState(organizationId: string): Promise<FeatureA
           AND is_enabled = true
       ) AS security_agent_enabled,
       EXISTS (
-        SELECT 1 FROM cloud_agent_webhook_triggers
-        WHERE organization_id = ${organizationId}
-          AND target_type = 'cloud_agent'
-          AND activation_mode = 'webhook'
-          AND is_active = true
-      ) AS has_active_cloud_agent_webhook,
-      EXISTS (
         SELECT 1 FROM platform_integrations
         WHERE owned_by_organization_id = ${organizationId}
-          AND platform IN ('slack', 'discord', 'linear')
           AND integration_status = ${INTEGRATION_STATUS.ACTIVE}
           AND suspended_at IS NULL
           AND auth_invalid_at IS NULL
+          AND (
+            platform IN ('slack', 'discord') OR
+            (platform = 'linear' AND metadata -> 'bot_enabled' = 'true'::jsonb)
+          )
       ) AS team_integration_connected
   `);
   const row = result.rows[0] as FeatureAdoptionStateRow | undefined;
@@ -135,7 +120,6 @@ async function getFeatureAdoptionState(organizationId: string): Promise<FeatureA
     sourceControlConnected: row?.source_control_connected ?? false,
     codeReviewerEnabled: row?.code_reviewer_enabled ?? false,
     securityAgentEnabled: row?.security_agent_enabled ?? false,
-    hasActiveCloudAgentWebhook: row?.has_active_cloud_agent_webhook ?? false,
     teamIntegrationConnected: row?.team_integration_connected ?? false,
   };
 }

--- a/apps/web/src/lib/organizations/feature-adoption.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.ts
@@ -1,10 +1,5 @@
-import {
-  agent_configs,
-  cloud_agent_webhook_triggers,
-  organizations,
-  platform_integrations,
-} from '@kilocode/db/schema';
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { organizations } from '@kilocode/db/schema';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 import { readDb } from '@/lib/drizzle';
 import { INTEGRATION_STATUS } from '@/lib/integrations/core/constants';
 
@@ -44,6 +39,12 @@ type FeatureAdoptionState = {
   agentConfigs: AdoptionAgentConfig[];
   integrations: AdoptionIntegration[];
   hasActiveCloudAgentWebhook: boolean;
+};
+
+type FeatureAdoptionStateRow = {
+  agent_configs: AdoptionAgentConfig[];
+  integrations: AdoptionIntegration[];
+  has_active_cloud_agent_webhook: boolean;
 };
 
 const SOURCE_CONTROL_PLATFORMS = ['github', 'gitlab'];
@@ -95,7 +96,7 @@ export function buildFeatureAdoptionChecks(
     {
       key: 'code-reviewer',
       title: 'Code Reviewer enabled',
-      description: 'Run AI-assisted reviews on pull requests or merge requests.',
+      description: 'Run AI assisted reviews on pull requests or merge requests.',
       adopted: codeReviewerEnabled,
       actionLabel: codeReviewerEnabled ? 'Review settings' : 'Enable Code Reviewer',
       actionUrl: `/organizations/${organizationId}/code-reviews`,
@@ -127,67 +128,53 @@ export function buildFeatureAdoptionChecks(
   ];
 }
 
-export async function getOrganizationPendingFeatureAdoptionCount(
-  organizationId: string
-): Promise<{ plan: 'teams' | 'enterprise'; pendingCount: number }> {
-  const organizationRows = await readDb
-    .select({ plan: organizations.plan })
-    .from(organizations)
-    .where(and(eq(organizations.id, organizationId), isNull(organizations.deleted_at)))
-    .limit(1);
-  const organization = organizationRows[0];
-  if (!organization) {
-    throw new Error('Organization not found');
-  }
-  if (organization.plan !== 'enterprise') {
-    return { plan: organization.plan, pendingCount: 0 };
-  }
-
-  const rows = await readDb.execute(sql`
+async function getFeatureAdoptionState(organizationId: string): Promise<FeatureAdoptionState> {
+  const result = await readDb.execute(sql`
     SELECT
-      (CASE WHEN EXISTS (
-        SELECT 1 FROM platform_integrations
+      COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+          'agentType', agent_type,
+          'platform', platform,
+          'isEnabled', is_enabled
+        ))
+        FROM agent_configs
         WHERE owned_by_organization_id = ${organizationId}
-          AND platform IN ('github', 'gitlab')
-          AND integration_status = ${INTEGRATION_STATUS.ACTIVE}
-          AND suspended_at IS NULL
-          AND auth_invalid_at IS NULL
-      ) THEN 0 ELSE 1 END) +
-      (CASE WHEN EXISTS (
-        SELECT 1 FROM agent_configs
+          AND agent_type IN ('code_review', 'security_scan')
+      ), '[]'::jsonb) AS agent_configs,
+      COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+          'platform', platform,
+          'status', integration_status,
+          'suspendedAt', suspended_at,
+          'authInvalidAt', auth_invalid_at
+        ))
+        FROM platform_integrations
         WHERE owned_by_organization_id = ${organizationId}
-          AND agent_type = 'code_review'
-          AND platform IN ('github', 'gitlab')
-          AND is_enabled = true
-      ) THEN 0 ELSE 1 END) +
-      (CASE WHEN EXISTS (
-        SELECT 1 FROM agent_configs
-        WHERE owned_by_organization_id = ${organizationId}
-          AND agent_type = 'security_scan'
-          AND platform = 'github'
-          AND is_enabled = true
-      ) THEN 0 ELSE 1 END) +
-      (CASE WHEN EXISTS (
-        SELECT 1 FROM cloud_agent_webhook_triggers
+      ), '[]'::jsonb) AS integrations,
+      EXISTS (
+        SELECT 1
+        FROM cloud_agent_webhook_triggers
         WHERE organization_id = ${organizationId}
           AND target_type = 'cloud_agent'
           AND activation_mode = 'webhook'
           AND is_active = true
-      ) THEN 0 ELSE 1 END) +
-      (CASE WHEN EXISTS (
-        SELECT 1 FROM platform_integrations
-        WHERE owned_by_organization_id = ${organizationId}
-          AND platform IN ('slack', 'discord', 'linear')
-          AND integration_status = ${INTEGRATION_STATUS.ACTIVE}
-          AND suspended_at IS NULL
-          AND auth_invalid_at IS NULL
-      ) THEN 0 ELSE 1 END) AS pending_count
+      ) AS has_active_cloud_agent_webhook
   `);
-
-  const pendingCount = Number(rows.rows[0]?.pending_count);
+  const row = result.rows[0] as FeatureAdoptionStateRow | undefined;
   return {
-    plan: organization.plan,
-    pendingCount: Number.isFinite(pendingCount) ? pendingCount : FEATURE_ADOPTION_KEYS.length,
+    agentConfigs: row?.agent_configs ?? [],
+    integrations: row?.integrations ?? [],
+    hasActiveCloudAgentWebhook: row?.has_active_cloud_agent_webhook ?? false,
+  };
+}
+
+export async function getOrganizationPendingFeatureAdoptionCount(
+  organizationId: string
+): Promise<{ plan: 'teams' | 'enterprise'; pendingCount: number }> {
+  const adoption = await getOrganizationFeatureAdoption(organizationId);
+  return {
+    plan: adoption.plan,
+    pendingCount: adoption.checks.filter(check => !check.adopted).length,
   };
 }
 
@@ -208,49 +195,10 @@ export async function getOrganizationFeatureAdoption(organizationId: string): Pr
     return { plan: organization.plan, checks: [] };
   }
 
-  const [agentConfigRows, integrationRows, webhookRows] = await Promise.all([
-    readDb
-      .select({
-        agentType: agent_configs.agent_type,
-        platform: agent_configs.platform,
-        isEnabled: agent_configs.is_enabled,
-      })
-      .from(agent_configs)
-      .where(
-        and(
-          eq(agent_configs.owned_by_organization_id, organizationId),
-          inArray(agent_configs.agent_type, ['code_review', 'security_scan'])
-        )
-      ),
-    readDb
-      .select({
-        platform: platform_integrations.platform,
-        status: platform_integrations.integration_status,
-        suspendedAt: platform_integrations.suspended_at,
-        authInvalidAt: platform_integrations.auth_invalid_at,
-      })
-      .from(platform_integrations)
-      .where(eq(platform_integrations.owned_by_organization_id, organizationId)),
-    readDb
-      .select({ id: cloud_agent_webhook_triggers.id })
-      .from(cloud_agent_webhook_triggers)
-      .where(
-        and(
-          eq(cloud_agent_webhook_triggers.organization_id, organizationId),
-          eq(cloud_agent_webhook_triggers.target_type, 'cloud_agent'),
-          eq(cloud_agent_webhook_triggers.activation_mode, 'webhook'),
-          eq(cloud_agent_webhook_triggers.is_active, true)
-        )
-      )
-      .limit(1),
-  ]);
+  const state = await getFeatureAdoptionState(organizationId);
 
   return {
     plan: organization.plan,
-    checks: buildFeatureAdoptionChecks(organizationId, {
-      agentConfigs: agentConfigRows,
-      integrations: integrationRows,
-      hasActiveCloudAgentWebhook: webhookRows.length > 0,
-    }),
+    checks: buildFeatureAdoptionChecks(organizationId, state),
   };
 }

--- a/apps/web/src/lib/organizations/feature-adoption.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.ts
@@ -4,7 +4,7 @@ import {
   organizations,
   platform_integrations,
 } from '@kilocode/db/schema';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { readDb } from '@/lib/drizzle';
 import { INTEGRATION_STATUS } from '@/lib/integrations/core/constants';
 
@@ -125,6 +125,70 @@ export function buildFeatureAdoptionChecks(
       actionUrl: `/organizations/${organizationId}/integrations`,
     },
   ];
+}
+
+export async function getOrganizationPendingFeatureAdoptionCount(
+  organizationId: string
+): Promise<{ plan: 'teams' | 'enterprise'; pendingCount: number }> {
+  const organizationRows = await readDb
+    .select({ plan: organizations.plan })
+    .from(organizations)
+    .where(and(eq(organizations.id, organizationId), isNull(organizations.deleted_at)))
+    .limit(1);
+  const organization = organizationRows[0];
+  if (!organization) {
+    throw new Error('Organization not found');
+  }
+  if (organization.plan !== 'enterprise') {
+    return { plan: organization.plan, pendingCount: 0 };
+  }
+
+  const rows = await readDb.execute(sql`
+    SELECT
+      (CASE WHEN EXISTS (
+        SELECT 1 FROM platform_integrations
+        WHERE owned_by_organization_id = ${organizationId}
+          AND platform IN ('github', 'gitlab')
+          AND integration_status = ${INTEGRATION_STATUS.ACTIVE}
+          AND suspended_at IS NULL
+          AND auth_invalid_at IS NULL
+      ) THEN 0 ELSE 1 END) +
+      (CASE WHEN EXISTS (
+        SELECT 1 FROM agent_configs
+        WHERE owned_by_organization_id = ${organizationId}
+          AND agent_type = 'code_review'
+          AND platform IN ('github', 'gitlab')
+          AND is_enabled = true
+      ) THEN 0 ELSE 1 END) +
+      (CASE WHEN EXISTS (
+        SELECT 1 FROM agent_configs
+        WHERE owned_by_organization_id = ${organizationId}
+          AND agent_type = 'security_scan'
+          AND platform = 'github'
+          AND is_enabled = true
+      ) THEN 0 ELSE 1 END) +
+      (CASE WHEN EXISTS (
+        SELECT 1 FROM cloud_agent_webhook_triggers
+        WHERE organization_id = ${organizationId}
+          AND target_type = 'cloud_agent'
+          AND activation_mode = 'webhook'
+          AND is_active = true
+      ) THEN 0 ELSE 1 END) +
+      (CASE WHEN EXISTS (
+        SELECT 1 FROM platform_integrations
+        WHERE owned_by_organization_id = ${organizationId}
+          AND platform IN ('slack', 'discord', 'linear')
+          AND integration_status = ${INTEGRATION_STATUS.ACTIVE}
+          AND suspended_at IS NULL
+          AND auth_invalid_at IS NULL
+      ) THEN 0 ELSE 1 END) AS pending_count
+  `);
+
+  const pendingCount = Number(rows.rows[0]?.pending_count);
+  return {
+    plan: organization.plan,
+    pendingCount: Number.isFinite(pendingCount) ? pendingCount : FEATURE_ADOPTION_KEYS.length,
+  };
 }
 
 export async function getOrganizationFeatureAdoption(organizationId: string): Promise<{

--- a/apps/web/src/routers/organizations/organization-usage-details-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-usage-details-router.test.ts
@@ -3,7 +3,7 @@ import { insertTestUser } from '@/tests/helpers/user.helper';
 import { insertUsageWithOverrides } from '@/tests/helpers/microdollar-usage.helper';
 import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
 import { db, pool } from '@/lib/drizzle';
-import { microdollar_usage, organizations } from '@kilocode/db/schema';
+import { microdollar_usage, organizations, platform_integrations } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import type { User, Organization } from '@kilocode/db/schema';
 
@@ -50,10 +50,15 @@ describe('organizations usage details trpc router', () => {
   });
 
   afterEach(async () => {
-    // Clean up microdollar usage data after each test
-    await db
-      .delete(microdollar_usage)
-      .where(eq(microdollar_usage.organization_id, testOrganization.id));
+    // Clean up usage and feature adoption data after each test
+    await Promise.all([
+      db
+        .delete(microdollar_usage)
+        .where(eq(microdollar_usage.organization_id, testOrganization.id)),
+      db
+        .delete(platform_integrations)
+        .where(eq(platform_integrations.owned_by_organization_id, testOrganization.id)),
+    ]);
   });
 
   describe('getFeatureAdoption procedure', () => {
@@ -68,7 +73,7 @@ describe('organizations usage details trpc router', () => {
         organizationId: testOrganization.id,
       });
 
-      expect(result.checks).toHaveLength(5);
+      expect(result.checks).toHaveLength(4);
       expect(result.checks.every(check => !check.adopted)).toBe(true);
     });
 
@@ -83,7 +88,43 @@ describe('organizations usage details trpc router', () => {
         organizationId: testOrganization.id,
       });
 
-      expect(result).toEqual({ pendingCount: 5 });
+      expect(result).toEqual({ pendingCount: 4 });
+    });
+
+    it('requires a bot-enabled Linear integration for team workflow adoption', async () => {
+      await db
+        .update(organizations)
+        .set({ plan: 'enterprise' })
+        .where(eq(organizations.id, testOrganization.id));
+      await db.insert(platform_integrations).values({
+        owned_by_organization_id: testOrganization.id,
+        platform: 'linear',
+        integration_type: 'app',
+        platform_installation_id: `linear-${crypto.randomUUID()}`,
+        platform_account_login: 'test-linear-workspace',
+        repository_access: 'all',
+        integration_status: 'active',
+        metadata: { bot_enabled: false },
+      });
+      const caller = await createCallerForUser(memberUser.id);
+
+      const disabledResult = await caller.organizations.usageDetails.getFeatureAdoption({
+        organizationId: testOrganization.id,
+      });
+      expect(disabledResult.checks.find(check => check.key === 'team-integration')?.adopted).toBe(
+        false
+      );
+
+      await db
+        .update(platform_integrations)
+        .set({ metadata: { bot_enabled: true } })
+        .where(eq(platform_integrations.owned_by_organization_id, testOrganization.id));
+      const enabledResult = await caller.organizations.usageDetails.getFeatureAdoption({
+        organizationId: testOrganization.id,
+      });
+      expect(enabledResult.checks.find(check => check.key === 'team-integration')?.adopted).toBe(
+        true
+      );
     });
 
     it('rejects feature adoption reporting for a Teams organization', async () => {

--- a/apps/web/src/routers/organizations/organization-usage-details-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-usage-details-router.test.ts
@@ -73,7 +73,7 @@ describe('organizations usage details trpc router', () => {
         organizationId: testOrganization.id,
       });
 
-      expect(result.checks).toHaveLength(4);
+      expect(result.checks).toHaveLength(6);
       expect(result.checks.every(check => !check.adopted)).toBe(true);
     });
 
@@ -88,7 +88,7 @@ describe('organizations usage details trpc router', () => {
         organizationId: testOrganization.id,
       });
 
-      expect(result).toEqual({ pendingCount: 4 });
+      expect(result).toEqual({ pendingCount: 6 });
     });
 
     it('requires a bot-enabled Linear integration for team workflow adoption', async () => {

--- a/apps/web/src/routers/organizations/organization-usage-details-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-usage-details-router.test.ts
@@ -3,7 +3,7 @@ import { insertTestUser } from '@/tests/helpers/user.helper';
 import { insertUsageWithOverrides } from '@/tests/helpers/microdollar-usage.helper';
 import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
 import { db, pool } from '@/lib/drizzle';
-import { microdollar_usage } from '@kilocode/db/schema';
+import { microdollar_usage, organizations } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import type { User, Organization } from '@kilocode/db/schema';
 
@@ -54,6 +54,37 @@ describe('organizations usage details trpc router', () => {
     await db
       .delete(microdollar_usage)
       .where(eq(microdollar_usage.organization_id, testOrganization.id));
+  });
+
+  describe('getFeatureAdoption procedure', () => {
+    it('returns feature checks to a member of an Enterprise organization', async () => {
+      await db
+        .update(organizations)
+        .set({ plan: 'enterprise' })
+        .where(eq(organizations.id, testOrganization.id));
+      const caller = await createCallerForUser(memberUser.id);
+
+      const result = await caller.organizations.usageDetails.getFeatureAdoption({
+        organizationId: testOrganization.id,
+      });
+
+      expect(result.checks).toHaveLength(5);
+      expect(result.checks.every(check => !check.adopted)).toBe(true);
+    });
+
+    it('rejects feature adoption reporting for a Teams organization', async () => {
+      await db
+        .update(organizations)
+        .set({ plan: 'teams' })
+        .where(eq(organizations.id, testOrganization.id));
+      const caller = await createCallerForUser(memberUser.id);
+
+      await expect(
+        caller.organizations.usageDetails.getFeatureAdoption({
+          organizationId: testOrganization.id,
+        })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
   });
 
   describe('get procedure', () => {

--- a/apps/web/src/routers/organizations/organization-usage-details-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-usage-details-router.test.ts
@@ -72,6 +72,20 @@ describe('organizations usage details trpc router', () => {
       expect(result.checks.every(check => !check.adopted)).toBe(true);
     });
 
+    it('returns the pending feature count to an Enterprise member', async () => {
+      await db
+        .update(organizations)
+        .set({ plan: 'enterprise' })
+        .where(eq(organizations.id, testOrganization.id));
+      const caller = await createCallerForUser(memberUser.id);
+
+      const result = await caller.organizations.usageDetails.getPendingFeatureAdoptionCount({
+        organizationId: testOrganization.id,
+      });
+
+      expect(result).toEqual({ pendingCount: 5 });
+    });
+
     it('rejects feature adoption reporting for a Teams organization', async () => {
       await db
         .update(organizations)

--- a/apps/web/src/routers/organizations/organization-usage-details-router.ts
+++ b/apps/web/src/routers/organizations/organization-usage-details-router.ts
@@ -90,6 +90,8 @@ const FeatureAdoptionOutputSchema = z.object({
       title: z.string(),
       description: z.string(),
       adopted: z.boolean(),
+      adoptedLabel: z.string(),
+      notAdoptedLabel: z.string(),
       actionLabel: z.string(),
       actionUrl: z.string(),
     })

--- a/apps/web/src/routers/organizations/organization-usage-details-router.ts
+++ b/apps/web/src/routers/organizations/organization-usage-details-router.ts
@@ -11,7 +11,9 @@ import { microdollar_usage, kilocode_users } from '@kilocode/db/schema';
 import { eq, sum, count, sql, and, gte, lte } from 'drizzle-orm';
 import * as z from 'zod';
 import { AUTOCOMPLETE_MODEL } from '@/lib/constants';
+import { getOrganizationFeatureAdoption } from '@/lib/organizations/feature-adoption';
 import { getOrganizationMembers } from '@/lib/organizations/organizations';
+import { TRPCError } from '@trpc/server';
 import {
   getAgentInteractionsPerDay,
   getCloudAgentSessionsPerDay,
@@ -77,6 +79,25 @@ const AutocompleteMetricsOutputSchema = z.object({
   tokens: z.number(),
 });
 
+const FeatureAdoptionOutputSchema = z.object({
+  checks: z.array(
+    z.object({
+      key: z.enum([
+        'source-control-integration',
+        'code-reviewer',
+        'security-agent',
+        'cloud-agent-webhook',
+        'team-integration',
+      ]),
+      title: z.string(),
+      description: z.string(),
+      adopted: z.boolean(),
+      actionLabel: z.string(),
+      actionUrl: z.string(),
+    })
+  ),
+});
+
 const AIAdoptionTimeseriesOutputSchema = z.object({
   timeseries: z.array(
     z.object({
@@ -138,6 +159,19 @@ function getDateThreshold(period: string): string | null {
 }
 
 export const organizationsUsageDetailsRouter = createTRPCRouter({
+  getFeatureAdoption: organizationMemberProcedure
+    .input(OrganizationIdInputSchema)
+    .output(FeatureAdoptionOutputSchema)
+    .query(async ({ input }) => {
+      const adoption = await getOrganizationFeatureAdoption(input.organizationId);
+      if (adoption.plan !== 'enterprise') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Feature adoption reporting is available on the Enterprise plan.',
+        });
+      }
+      return { checks: adoption.checks };
+    }),
   getTimeSeries: organizationMemberProcedure
     .input(UsageTimeseriesInputSchema)
     .output(UsageTimeseriesOutputSchema)

--- a/apps/web/src/routers/organizations/organization-usage-details-router.ts
+++ b/apps/web/src/routers/organizations/organization-usage-details-router.ts
@@ -11,7 +11,11 @@ import { microdollar_usage, kilocode_users } from '@kilocode/db/schema';
 import { eq, sum, count, sql, and, gte, lte } from 'drizzle-orm';
 import * as z from 'zod';
 import { AUTOCOMPLETE_MODEL } from '@/lib/constants';
-import { getOrganizationFeatureAdoption } from '@/lib/organizations/feature-adoption';
+import {
+  FEATURE_ADOPTION_KEYS,
+  getOrganizationFeatureAdoption,
+  getOrganizationPendingFeatureAdoptionCount,
+} from '@/lib/organizations/feature-adoption';
 import { getOrganizationMembers } from '@/lib/organizations/organizations';
 import { TRPCError } from '@trpc/server';
 import {
@@ -82,13 +86,7 @@ const AutocompleteMetricsOutputSchema = z.object({
 const FeatureAdoptionOutputSchema = z.object({
   checks: z.array(
     z.object({
-      key: z.enum([
-        'source-control-integration',
-        'code-reviewer',
-        'security-agent',
-        'cloud-agent-webhook',
-        'team-integration',
-      ]),
+      key: z.enum(FEATURE_ADOPTION_KEYS),
       title: z.string(),
       description: z.string(),
       adopted: z.boolean(),
@@ -96,6 +94,10 @@ const FeatureAdoptionOutputSchema = z.object({
       actionUrl: z.string(),
     })
   ),
+});
+
+const PendingFeatureAdoptionOutputSchema = z.object({
+  pendingCount: z.number().int().min(0).max(FEATURE_ADOPTION_KEYS.length),
 });
 
 const AIAdoptionTimeseriesOutputSchema = z.object({
@@ -159,6 +161,19 @@ function getDateThreshold(period: string): string | null {
 }
 
 export const organizationsUsageDetailsRouter = createTRPCRouter({
+  getPendingFeatureAdoptionCount: organizationMemberProcedure
+    .input(OrganizationIdInputSchema)
+    .output(PendingFeatureAdoptionOutputSchema)
+    .query(async ({ input }) => {
+      const adoption = await getOrganizationPendingFeatureAdoptionCount(input.organizationId);
+      if (adoption.plan !== 'enterprise') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Feature adoption reporting is available on the Enterprise plan.',
+        });
+      }
+      return { pendingCount: adoption.pendingCount };
+    }),
   getFeatureAdoption: organizationMemberProcedure
     .input(OrganizationIdInputSchema)
     .output(FeatureAdoptionOutputSchema)


### PR DESCRIPTION
## Summary

Adds an Enterprise-only feature adoption report to the organization usage page. It
surfaces which organization features are configured or have been used (source
control, Code Reviewer, Security Agent, team workflow integrations, Cloud Agent,
and project deploys) and shows the count of not-yet-adopted features as a badge on
the Usage sidebar item.

For Enterprise organizations, the usage page now has three views (Overview,
Feature adoption, AI usage) selected by a tab control, with the active view stored
in a `view` URL parameter. Non-Enterprise organizations keep the existing single
usage dashboard unchanged.

## Changes

- Add `lib/organizations/feature-adoption.ts`: a single SQL query computes six
  adoption checks for an organization, and `buildFeatureAdoptionChecks` maps that
  state to titles, status labels, and action links. Exposes
  `getOrganizationFeatureAdoption` and `getOrganizationPendingFeatureAdoptionCount`.
- Add two tRPC procedures to `organization-usage-details-router.ts`:
  `getFeatureAdoption` and `getPendingFeatureAdoptionCount`. Both return
  `FORBIDDEN` when the organization is not on the Enterprise plan.
- Add `FeatureAdoptionView`, `AIAdoptionSummaryCard`, and `UsageViewNavigation`
  components. `FeatureAdoptionView` supports a `compact` mode used on the overview
  and a full mode used on its own tab.
- Update `UsageAnalyticsDashboard` to render the three-view layout for Enterprise
  organizations and skip the detailed usage queries when those views are not
  visible. Threads a new `organizationPlan` prop through from the usage page.
- Add an `enabled` option to `useUsageSummary`, `useUsageTimeseries`, and
  `useUsageTable` so usage queries don't run when the detailed view is hidden.
- Add `usageView` to the dashboard state and sync it to the `view` URL parameter.
- Add an `alert` badge variant to `SidebarMenuList` and show the pending adoption
  count on the Usage item in `OrganizationAppSidebar` for Enterprise organizations.
  The count refetches when navigating away from feature configuration routes.
- Add tests for `buildFeatureAdoptionChecks` and for the two new router
  procedures, including the Enterprise plan guard and the bot-enabled Linear
  requirement for team workflow adoption.

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [ ]

## Visual Changes
<img width="1211" height="722" alt="Screenshot 2026-06-22 at 9 03 04 AM" src="https://github.com/user-attachments/assets/be0dc4c8-d590-4ae3-ac10-7a27005aedb1" />

<img width="1119" height="768" alt="Screenshot 2026-06-22 at 9 03 34 AM" src="https://github.com/user-attachments/assets/33fad334-654d-446e-97f6-d6727b51c151" />


## Reviewer Notes

- The adoption checks read from `platform_integrations`, `agent_configs`,
  `cli_sessions_v2`, `cli_sessions`, and `deployments`. The Cloud Agent check
  unions both `cli_sessions_v2` and `cli_sessions`.
- Both new procedures use `organizationMemberProcedure`, so any organization
  member can read adoption status; the Enterprise plan is the only gate.
