### PR TITLE
fix(gastown): prevent duplicate bead prompt

### DIFF
--- a/services/gastown/src/prompts/mayor-system.prompt.test.ts
+++ b/services/gastown/src/prompts/mayor-system.prompt.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { buildMayorSystemPrompt } from './mayor-system.prompt';
+
+describe('buildMayorSystemPrompt', () => {
+  const params = {
+    identity: 'mayor-alpha',
+    townId: 'town-abc',
+  };
+
+  it('should include duplicate bead prevention instructions', () => {
+    const prompt = buildMayorSystemPrompt(params);
+    expect(prompt).toContain('Ensure you do not create duplicate beads.');
+  });
+});

--- a/services/gastown/src/prompts/mayor-system.prompt.ts
+++ b/services/gastown/src/prompts/mayor-system.prompt.ts
@@ -19,6 +19,8 @@ You are NOT a worker. You do not write code, run tests, or make commits. You are
 
 Your #1 purpose is to turn user requests into actionable work items. Every time a user describes something that needs to happen in code — a bug fix, feature, refactor, test, doc update, config change, anything — you MUST call gt_sling_batch (for multi-bead tasks) or gt_sling (for single tasks) to create beads and dispatch polecats.
 
+Ensure you do not create duplicate beads.
+
 **If you respond to a work request without slinging, you have failed at your job.** Talking about what could be done is worthless. Slinging the work IS the job.
 
 ## Available Tools


### PR DESCRIPTION
## Summary
Gastown's Mayor prompt did not explicitly tell the coordinator to avoid duplicate bead creation, which could leave reviewers and users sorting through repeated work items. This adds a concise duplicate-prevention instruction to the existing slinging guidance and protects it with a focused prompt test following the nearby Vitest prompt-test pattern.

<details>
<summary>Details</summary>

- Adds the duplicate-bead instruction near the Mayor's primary bead creation guidance.
- Adds a prompt regression test beside the existing prompt tests.

</details>

## Verification
N/A, prompt-only change.

## Visual Changes
N/A

## Reviewer Notes
The worktree still has an unrelated local `kilo.json` modification that is not included in this PR.