### PR TITLE
Fix(sidebar) remove feature adoption badge from nav

### DIFF
--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -29,13 +29,11 @@ import {
   ChevronRight,
 } from 'lucide-react';
 import { usePathname } from 'next/navigation';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import OrganizationSwitcher from './OrganizationSwitcher';
 import { useRoleTesting } from '@/contexts/RoleTestingContext';
 import HeaderLogo from '@/components/HeaderLogo';
 import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
-import { useQuery } from '@tanstack/react-query';
-import { useTRPC } from '@/lib/trpc/utils';
 import { useOrgKiloClawNavState } from '@/hooks/useOrgKiloClaw';
 import SidebarMenuList from './SidebarMenuList';
 import SidebarUserFooter from './SidebarUserFooter';
@@ -55,56 +53,6 @@ export default function OrganizationAppSidebar({
   const { assumedRole, setAssumedRole, setOriginalRole } = useRoleTesting();
   // Fetch full organization data to access settings
   const { data: organizationData } = useOrganizationWithMembers(organizationId);
-  const trpc = useTRPC();
-  const usagePath = `/organizations/${organizationId}/usage-details`;
-  const isUsagePath = pathname === usagePath || pathname.startsWith(`${usagePath}/`);
-  const featureAdoptionQuery = useQuery({
-    ...trpc.organizations.usageDetails.getFeatureAdoption.queryOptions({ organizationId }),
-    enabled: organizationData?.plan === 'enterprise' && isUsagePath,
-    staleTime: 5 * 60 * 1000,
-  });
-  const pendingFeatureAdoptionQuery = useQuery({
-    ...trpc.organizations.usageDetails.getPendingFeatureAdoptionCount.queryOptions({
-      organizationId,
-    }),
-    enabled: organizationData?.plan === 'enterprise' && !isUsagePath,
-    staleTime: 5 * 60 * 1000,
-  });
-  const pendingFeatureAdoptionCount =
-    organizationData?.plan === 'enterprise'
-      ? isUsagePath
-        ? (featureAdoptionQuery.data?.checks.filter(check => !check.adopted).length ?? 0)
-        : (pendingFeatureAdoptionQuery.data?.pendingCount ?? 0)
-      : 0;
-  const previousPathname = useRef(pathname);
-  useEffect(() => {
-    const adoptionConfigurationRoutes = [
-      `/organizations/${organizationId}/integrations`,
-      `/organizations/${organizationId}/code-reviews`,
-      `/organizations/${organizationId}/security-agent`,
-      `/organizations/${organizationId}/cloud`,
-      `/organizations/${organizationId}/deploy`,
-    ];
-    const previousRouteWasAdoptionConfiguration = adoptionConfigurationRoutes.some(
-      route =>
-        previousPathname.current === route || previousPathname.current.startsWith(`${route}/`)
-    );
-    if (
-      organizationData?.plan === 'enterprise' &&
-      previousPathname.current !== pathname &&
-      previousRouteWasAdoptionConfiguration
-    ) {
-      void (isUsagePath ? featureAdoptionQuery.refetch() : pendingFeatureAdoptionQuery.refetch());
-    }
-    previousPathname.current = pathname;
-  }, [
-    featureAdoptionQuery.refetch,
-    isUsagePath,
-    organizationData?.plan,
-    organizationId,
-    pathname,
-    pendingFeatureAdoptionQuery.refetch,
-  ]);
   const kiloClawNavStateQuery = useOrgKiloClawNavState(organizationId);
 
   // Feature flags
@@ -157,8 +105,6 @@ export default function OrganizationAppSidebar({
     icon: React.ElementType;
     url: string;
     className?: string;
-    badge?: string;
-    badgeVariant?: 'brand' | 'alert';
   }> = [
     ...(showWelcome
       ? [
@@ -178,8 +124,6 @@ export default function OrganizationAppSidebar({
       title: 'Usage',
       icon: ChartColumnIncreasing,
       url: `/organizations/${organizationId}/usage-details`,
-      badge: pendingFeatureAdoptionCount > 0 ? String(pendingFeatureAdoptionCount) : undefined,
-      badgeVariant: 'alert',
     },
   ];
 

--- a/apps/web/src/app/(app)/components/SidebarMenuList.tsx
+++ b/apps/web/src/app/(app)/components/SidebarMenuList.tsx
@@ -22,7 +22,6 @@ type MenuItem = {
   suffixIcon?: React.ElementType;
   subtitle?: string;
   badge?: string;
-  badgeVariant?: 'brand' | 'alert';
   className?: string;
 };
 
@@ -109,14 +108,7 @@ export default function SidebarMenuList({
                   </SidebarMenuButton>
                 )}
                 {item.badge && (
-                  <SidebarMenuBadge
-                    className={cn(
-                      'right-4 !top-1/2 h-4 min-w-0 !-translate-y-1/2 rounded-full px-1.5 text-[10px] font-bold tracking-wide uppercase',
-                      item.badgeVariant === 'alert'
-                        ? 'bg-destructive/15 text-destructive ring-1 ring-destructive/30'
-                        : 'bg-brand-primary text-primary-foreground peer-hover/menu-button:text-primary-foreground peer-data-[active=true]/menu-button:text-primary-foreground ring-1 ring-brand-primary/30'
-                    )}
-                  >
+                  <SidebarMenuBadge className="bg-brand-primary text-primary-foreground peer-hover/menu-button:text-primary-foreground peer-data-[active=true]/menu-button:text-primary-foreground right-4 !top-1/2 h-4 min-w-0 !-translate-y-1/2 rounded-full px-1.5 text-[10px] font-bold tracking-wide uppercase ring-1 ring-brand-primary/30">
                     {item.badge}
                   </SidebarMenuBadge>
                 )}

--- a/apps/web/src/lib/organizations/feature-adoption.ts
+++ b/apps/web/src/lib/organizations/feature-adoption.ts
@@ -179,16 +179,6 @@ async function getFeatureAdoptionState(organizationId: string): Promise<FeatureA
   };
 }
 
-export async function getOrganizationPendingFeatureAdoptionCount(
-  organizationId: string
-): Promise<{ plan: 'teams' | 'enterprise'; pendingCount: number }> {
-  const adoption = await getOrganizationFeatureAdoption(organizationId);
-  return {
-    plan: adoption.plan,
-    pendingCount: adoption.checks.filter(check => !check.adopted).length,
-  };
-}
-
 export async function getOrganizationFeatureAdoption(organizationId: string): Promise<{
   plan: 'teams' | 'enterprise';
   checks: FeatureAdoptionCheck[];

--- a/apps/web/src/routers/organizations/organization-usage-details-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-usage-details-router.test.ts
@@ -77,20 +77,6 @@ describe('organizations usage details trpc router', () => {
       expect(result.checks.every(check => !check.adopted)).toBe(true);
     });
 
-    it('returns the pending feature count to an Enterprise member', async () => {
-      await db
-        .update(organizations)
-        .set({ plan: 'enterprise' })
-        .where(eq(organizations.id, testOrganization.id));
-      const caller = await createCallerForUser(memberUser.id);
-
-      const result = await caller.organizations.usageDetails.getPendingFeatureAdoptionCount({
-        organizationId: testOrganization.id,
-      });
-
-      expect(result).toEqual({ pendingCount: 6 });
-    });
-
     it('requires a bot-enabled Linear integration for team workflow adoption', async () => {
       await db
         .update(organizations)

--- a/apps/web/src/routers/organizations/organization-usage-details-router.ts
+++ b/apps/web/src/routers/organizations/organization-usage-details-router.ts
@@ -14,7 +14,6 @@ import { AUTOCOMPLETE_MODEL } from '@/lib/constants';
 import {
   FEATURE_ADOPTION_KEYS,
   getOrganizationFeatureAdoption,
-  getOrganizationPendingFeatureAdoptionCount,
 } from '@/lib/organizations/feature-adoption';
 import { getOrganizationMembers } from '@/lib/organizations/organizations';
 import { TRPCError } from '@trpc/server';
@@ -98,10 +97,6 @@ const FeatureAdoptionOutputSchema = z.object({
   ),
 });
 
-const PendingFeatureAdoptionOutputSchema = z.object({
-  pendingCount: z.number().int().min(0).max(FEATURE_ADOPTION_KEYS.length),
-});
-
 const AIAdoptionTimeseriesOutputSchema = z.object({
   timeseries: z.array(
     z.object({
@@ -163,19 +158,6 @@ function getDateThreshold(period: string): string | null {
 }
 
 export const organizationsUsageDetailsRouter = createTRPCRouter({
-  getPendingFeatureAdoptionCount: organizationMemberProcedure
-    .input(OrganizationIdInputSchema)
-    .output(PendingFeatureAdoptionOutputSchema)
-    .query(async ({ input }) => {
-      const adoption = await getOrganizationPendingFeatureAdoptionCount(input.organizationId);
-      if (adoption.plan !== 'enterprise') {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'Feature adoption reporting is available on the Enterprise plan.',
-        });
-      }
-      return { pendingCount: adoption.pendingCount };
-    }),
   getFeatureAdoption: organizationMemberProcedure
     .input(OrganizationIdInputSchema)
     .output(FeatureAdoptionOutputSchema)


### PR DESCRIPTION
## Summary

Removes the feature adoption count badge from the organization sidebar's Usage
item. The badge lived in the persistent sidebar, so to render a count it ran an
organization lookup plus the full feature adoption query on every non-Usage route
for every Enterprise member, including a scan of the organization's full session
history for the Cloud Agent check. It also split the count across two query caches
that could disagree. Removing the badge drops that recurring background database
work. The Usage page itself still shows feature adoption through the existing
`getFeatureAdoption` query, which only runs when a user opens that page.

## Changes

- Remove the badge wiring from `OrganizationAppSidebar`: the `getFeatureAdoption`
  and `getPendingFeatureAdoptionCount` queries, the derived count, the route
  checks, and the refetch effect. Drop the now-unused `useRef`, `useQuery`, and
  `useTRPC` imports and the `badge`/`badgeVariant` fields on the Usage nav item.
- Delete the `getPendingFeatureAdoptionCount` tRPC procedure and its output
  schema, plus the `getOrganizationPendingFeatureAdoptionCount` helper in
  `feature-adoption.ts`. Nothing else consumed them.
- Remove the router test that covered the deleted procedure.
- Revert `SidebarMenuList` to the brand-only badge: drop the `badgeVariant` type
  member and the `alert` styling branch that the Usage badge was the only producer
  of. The generic `badge` (used elsewhere, for example the "NEW" badge) is
  unchanged.

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [ ] No manual testing. This is a deletion of a background query and an optional
  badge with no new behavior. Verified with typecheck, lint, and the
  `feature-adoption` unit tests and `organization-usage-details-router` tests.

## Visual Changes

The Usage sidebar item no longer shows the pending feature adoption count badge
for Enterprise organizations. No other visual change.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- The `getFeatureAdoption` procedure and the Usage page's feature adoption view are
  intentionally kept; only the sidebar badge path is removed.
- Client/server version skew: a browser tab still running the pre-deploy bundle can
  call the removed `getPendingFeatureAdoptionCount` and get a tRPC NOT_FOUND until
  it reloads. The old sidebar code falls back to no badge on error, so there is no
  user-facing breakage, only transient log noise that self-heals on reload.
