### PR TITLE
fix(ai-gateway): default MiniMax M3 to thinking

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/model-settings.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.test.ts
@@ -1,0 +1,20 @@
+import { MINIMAX_CURRENT_MODEL_ID } from './minimax';
+import { getModelVariants } from './model-settings';
+
+describe('MiniMax model variants', () => {
+  it.each([MINIMAX_CURRENT_MODEL_ID, 'opencode-go/minimax-m3'])(
+    'exposes only adaptive thinking for MiniMax M3 model %s',
+    model => {
+      expect(getModelVariants(model)).toEqual({
+        thinking: { reasoning: { enabled: true, effort: 'high' } },
+      });
+    }
+  );
+
+  it('keeps the reasoning toggle for older MiniMax models', () => {
+    expect(getModelVariants('minimax/minimax-m2.7')).toEqual({
+      instant: { reasoning: { enabled: false, effort: 'none' } },
+      thinking: { reasoning: { enabled: true, effort: 'high' } },
+    });
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.test.ts
@@ -3,17 +3,23 @@ import { getModelVariants } from './model-settings';
 
 describe('MiniMax model variants', () => {
   it.each([MINIMAX_CURRENT_MODEL_ID, 'opencode-go/minimax-m3'])(
-    'exposes disabled and adaptive thinking for MiniMax M3 model %s',
+    'defaults to thinking while exposing instant for MiniMax M3 model %s',
     model => {
-      expect(getModelVariants(model)).toEqual({
-        none: { reasoning: { enabled: false, effort: 'none' } },
+      const variants = getModelVariants(model);
+
+      expect(Object.keys(variants ?? {})).toEqual(['thinking', 'instant']);
+      expect(variants).toEqual({
         thinking: { reasoning: { enabled: true, effort: 'high' } },
+        instant: { reasoning: { enabled: false, effort: 'none' } },
       });
     }
   );
 
-  it('keeps the reasoning toggle for older MiniMax models', () => {
-    expect(getModelVariants('minimax/minimax-m2.7')).toEqual({
+  it('keeps instant as the default for older MiniMax models', () => {
+    const variants = getModelVariants('minimax/minimax-m2.7');
+
+    expect(Object.keys(variants ?? {})).toEqual(['instant', 'thinking']);
+    expect(variants).toEqual({
       instant: { reasoning: { enabled: false, effort: 'none' } },
       thinking: { reasoning: { enabled: true, effort: 'high' } },
     });

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.test.ts
@@ -3,9 +3,10 @@ import { getModelVariants } from './model-settings';
 
 describe('MiniMax model variants', () => {
   it.each([MINIMAX_CURRENT_MODEL_ID, 'opencode-go/minimax-m3'])(
-    'exposes only adaptive thinking for MiniMax M3 model %s',
+    'exposes disabled and adaptive thinking for MiniMax M3 model %s',
     model => {
       expect(getModelVariants(model)).toEqual({
+        none: { reasoning: { enabled: false, effort: 'none' } },
         thinking: { reasoning: { enabled: true, effort: 'high' } },
       });
     }

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -25,13 +25,15 @@ const REASONING_VARIANTS_THINKING_ONLY = {
   thinking: { reasoning: { enabled: true, effort: 'high' } },
 } as const;
 
-const REASONING_VARIANTS_NONE_THINKING = {
-  none: { reasoning: { enabled: false, effort: 'none' } },
+const REASONING_DISABLED = { reasoning: { enabled: false, effort: 'none' } } as const;
+
+const REASONING_VARIANTS_THINKING_INSTANT = {
   ...REASONING_VARIANTS_THINKING_ONLY,
+  instant: REASONING_DISABLED,
 } as const;
 
 export const REASONING_VARIANTS_BINARY = {
-  instant: { reasoning: { enabled: false, effort: 'none' } },
+  instant: REASONING_DISABLED,
   ...REASONING_VARIANTS_THINKING_ONLY,
 } as const;
 
@@ -113,7 +115,7 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
     return REASONING_VARIANTS_THINKING_ONLY;
   }
   if (isMinimaxModel(model) && model.toLowerCase().includes('minimax-m3')) {
-    return REASONING_VARIANTS_NONE_THINKING;
+    return REASONING_VARIANTS_THINKING_INSTANT;
   }
   if (
     isMinimaxModel(model) ||

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -104,7 +104,10 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
   if (model.includes('mistral-medium-3-5')) {
     return REASONING_VARIANTS_BINARY;
   }
-  if (model.includes('kimi-k2.7-code')) {
+  if (
+    model.includes('kimi-k2.7-code') ||
+    (isMinimaxModel(model) && model.toLowerCase().includes('minimax-m3'))
+  ) {
     return REASONING_VARIANTS_THINKING_ONLY;
   }
   if (

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -25,6 +25,11 @@ const REASONING_VARIANTS_THINKING_ONLY = {
   thinking: { reasoning: { enabled: true, effort: 'high' } },
 } as const;
 
+const REASONING_VARIANTS_NONE_THINKING = {
+  none: { reasoning: { enabled: false, effort: 'none' } },
+  ...REASONING_VARIANTS_THINKING_ONLY,
+} as const;
+
 export const REASONING_VARIANTS_BINARY = {
   instant: { reasoning: { enabled: false, effort: 'none' } },
   ...REASONING_VARIANTS_THINKING_ONLY,
@@ -104,11 +109,11 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
   if (model.includes('mistral-medium-3-5')) {
     return REASONING_VARIANTS_BINARY;
   }
-  if (
-    model.includes('kimi-k2.7-code') ||
-    (isMinimaxModel(model) && model.toLowerCase().includes('minimax-m3'))
-  ) {
+  if (model.includes('kimi-k2.7-code')) {
     return REASONING_VARIANTS_THINKING_ONLY;
+  }
+  if (isMinimaxModel(model) && model.toLowerCase().includes('minimax-m3')) {
+    return REASONING_VARIANTS_NONE_THINKING;
   }
   if (
     isMinimaxModel(model) ||


### PR DESCRIPTION
## Summary

Keep the common Kilo Gateway `thinking` / `instant` labels for MiniMax M3, but return `thinking` first so new IDE selections default to adaptive thinking. `instant` remains available as the explicit disabled-thinking option, and older MiniMax models retain their existing instant-first ordering.

## Verification

- [ ] No manual UI verification; this is a model-catalog metadata change covered by focused gateway tests.

## Visual Changes

N/A

## Reviewer Notes

This applies to ordinary Kilo Gateway `minimax/minimax-m3` routing, including Token Plan Plus-installed credentials, and direct OpenCode Go M3 models. The companion Kilo CLI change in Kilo-Org/kilocode#11562 ensures an implicit/default Gateway request also uses adaptive thinking; selecting `instant` explicitly overrides it with disabled thinking.