### PR TITLE
feat(autocomplete): add free next-edit promotion

### DIFF
--- a/apps/web/src/app/api/edit/completions/route.test.ts
+++ b/apps/web/src/app/api/edit/completions/route.test.ts
@@ -214,22 +214,21 @@ describe('POST /api/edit/completions', () => {
     expect(mockedFetch).not.toHaveBeenCalled();
   });
 
-  it('rejects requests when balance is exhausted and the user has no BYOK', async () => {
+  it('allows requests when balance is exhausted', async () => {
     setOrganizationAuth();
     mockedGetBalanceAndOrgSettings.mockResolvedValue({
       balance: 0,
       settings: undefined,
       plan: 'teams',
     });
+    mockedFetch.mockResolvedValue(makeUpstreamResponse());
 
     const { POST } = await import('./route');
     const response = await POST(makeRequest(makeValidRequestBody()) as never);
 
-    expect(response.status).toBe(402);
-    expect(await response.json()).toMatchObject({
-      error_type: ProxyErrorType.insufficient_credits,
-    });
-    expect(mockedFetch).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    await flushAfter();
   });
 
   it('forwards a single user message to Inception', async () => {
@@ -249,7 +248,7 @@ describe('POST /api/edit/completions', () => {
     expect(upstreamBody.model).toBe('mercury-edit-2');
   });
 
-  it('persists computed cost and cache discount for paid (non-BYOK) requests', async () => {
+  it('persists market cost without billing non-BYOK requests', async () => {
     setOrganizationAuth();
     mockedFetch.mockResolvedValue(makeUpstreamResponse());
 
@@ -263,8 +262,8 @@ describe('POST /api/edit/completions', () => {
     const [stats, ctx] = mockedLogMicrodollarUsage.mock.calls[0];
     expect(ctx.api_kind).toBe('edit_completions');
     expect(ctx.user_byok).toBe(false);
-    expect(stats.cost_mUsd).toBe(4_750);
-    expect(stats.cacheDiscount_mUsd).toBe(20_250);
+    expect(stats.cost_mUsd).toBe(0);
+    expect(stats.cacheDiscount_mUsd).toBe(0);
     expect(stats.market_cost).toBe(4_750);
   });
 
@@ -311,7 +310,7 @@ describe('POST /api/edit/completions', () => {
     expect(mockedLogMicrodollarUsage).toHaveBeenCalledTimes(1);
     const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
     expect(stats.cost_mUsd).toBe(0);
-    expect(stats.cacheDiscount_mUsd).toBeUndefined();
+    expect(stats.cacheDiscount_mUsd).toBe(0);
     expect(stats.inputTokens).toBe(0);
     expect(stats.outputTokens).toBe(0);
   });

--- a/apps/web/src/app/api/edit/completions/route.test.ts
+++ b/apps/web/src/app/api/edit/completions/route.test.ts
@@ -10,6 +10,15 @@ import type {
   MicrodollarUsageStats,
 } from '@/lib/ai-gateway/processUsage.types';
 
+let mockInceptionPromoRunning = true;
+
+jest.mock('@/lib/constants', () => ({
+  ...(jest.requireActual('@/lib/constants') as Record<string, unknown>),
+  get INCEPTION_PROMO_RUNNING() {
+    return mockInceptionPromoRunning;
+  },
+}));
+
 jest.mock('@/lib/config.server', () => ({
   INCEPTION_API_KEY: 'system-inception-key',
 }));
@@ -146,6 +155,7 @@ async function flushAfter() {
 describe('POST /api/edit/completions', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    mockInceptionPromoRunning = true;
     globalThis.fetch = mockedFetch;
     mockedLogMicrodollarUsage.mockResolvedValue(null);
   });
@@ -214,7 +224,7 @@ describe('POST /api/edit/completions', () => {
     expect(mockedFetch).not.toHaveBeenCalled();
   });
 
-  it('allows requests when balance is exhausted', async () => {
+  it('allows requests when balance is exhausted during the promotion', async () => {
     setOrganizationAuth();
     mockedGetBalanceAndOrgSettings.mockResolvedValue({
       balance: 0,
@@ -229,6 +239,25 @@ describe('POST /api/edit/completions', () => {
     expect(response.status).toBe(200);
     expect(mockedFetch).toHaveBeenCalledTimes(1);
     await flushAfter();
+  });
+
+  it('rejects requests with exhausted balance when the promotion is disabled', async () => {
+    mockInceptionPromoRunning = false;
+    setOrganizationAuth();
+    mockedGetBalanceAndOrgSettings.mockResolvedValue({
+      balance: 0,
+      settings: undefined,
+      plan: 'teams',
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeValidRequestBody()) as never);
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toMatchObject({
+      error_type: ProxyErrorType.insufficient_credits,
+    });
+    expect(mockedFetch).not.toHaveBeenCalled();
   });
 
   it('forwards a single user message to Inception', async () => {

--- a/apps/web/src/app/api/edit/completions/route.ts
+++ b/apps/web/src/app/api/edit/completions/route.ts
@@ -179,6 +179,8 @@ export async function POST(request: NextRequest) {
 
   setTag('ui.ai_model', requestBody.model);
 
+  // Use read replica for balance check - this is a read-only operation that can tolerate
+  // slight replication lag, and provides lower latency for US users.
   const { balance, settings, plan } = await getBalanceAndOrgSettings(organizationId, user, readDb);
 
   if (

--- a/apps/web/src/app/api/edit/completions/route.ts
+++ b/apps/web/src/app/api/edit/completions/route.ts
@@ -5,7 +5,6 @@ import z from 'zod';
 import { captureException, setTag, startInactiveSpan } from '@sentry/nextjs';
 import type { MicrodollarUsageContext } from '@/lib/ai-gateway/processUsage.types';
 import { validateFeatureHeader, FEATURE_HEADER } from '@/lib/feature-detection';
-import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
 import { sentryRootSpan } from '@/lib/getRootSpan';
 import { getUserFromAuth } from '@/lib/user/server';
 import {
@@ -178,19 +177,7 @@ export async function POST(request: NextRequest) {
 
   setTag('ui.ai_model', requestBody.model);
 
-  // Use read replica for balance check - this is a read-only operation that can tolerate
-  // slight replication lag, and provides lower latency for US users.
-  const { balance, settings, plan } = await getBalanceAndOrgSettings(organizationId, user, readDb);
-
-  if (balance <= 0 && !(await isFreeModel(requestBody.model)) && !userByok) {
-    return NextResponse.json(
-      {
-        error: { message: 'Insufficient credits' },
-        error_type: ProxyErrorType.insufficient_credits,
-      },
-      { status: 402 }
-    );
-  }
+  const { settings, plan } = await getBalanceAndOrgSettings(organizationId, user, readDb);
 
   const { error: modelRestrictionError, providerConfig } = checkOrganizationModelRestrictions({
     modelId: requestBody.model,

--- a/apps/web/src/app/api/edit/completions/route.ts
+++ b/apps/web/src/app/api/edit/completions/route.ts
@@ -5,6 +5,8 @@ import z from 'zod';
 import { captureException, setTag, startInactiveSpan } from '@sentry/nextjs';
 import type { MicrodollarUsageContext } from '@/lib/ai-gateway/processUsage.types';
 import { validateFeatureHeader, FEATURE_HEADER } from '@/lib/feature-detection';
+import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
+import { INCEPTION_PROMO_RUNNING } from '@/lib/constants';
 import { sentryRootSpan } from '@/lib/getRootSpan';
 import { getUserFromAuth } from '@/lib/user/server';
 import {
@@ -177,7 +179,22 @@ export async function POST(request: NextRequest) {
 
   setTag('ui.ai_model', requestBody.model);
 
-  const { settings, plan } = await getBalanceAndOrgSettings(organizationId, user, readDb);
+  const { balance, settings, plan } = await getBalanceAndOrgSettings(organizationId, user, readDb);
+
+  if (
+    !INCEPTION_PROMO_RUNNING &&
+    balance <= 0 &&
+    !(await isFreeModel(requestBody.model)) &&
+    !userByok
+  ) {
+    return NextResponse.json(
+      {
+        error: { message: 'Insufficient credits' },
+        error_type: ProxyErrorType.insufficient_credits,
+      },
+      { status: 402 }
+    );
+  }
 
   const { error: modelRestrictionError, providerConfig } = checkOrganizationModelRestrictions({
     modelId: requestBody.model,

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
@@ -487,7 +487,7 @@ describe('countAndStoreEditUsage', () => {
     expect(stats.market_cost).toBe(4_750);
   });
 
-  it('preserves cost_mUsd and cacheDiscount_mUsd for non-BYOK requests', async () => {
+  it('preserves market cost but does not bill non-BYOK requests', async () => {
     const response = makeUpstreamResponse({
       id: 'edit-paid',
       model: 'mercury-edit-2',
@@ -506,8 +506,8 @@ describe('countAndStoreEditUsage', () => {
 
     expect(mockedLogMicrodollarUsage).toHaveBeenCalledTimes(1);
     const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
-    expect(stats.cost_mUsd).toBe(4_750);
-    expect(stats.cacheDiscount_mUsd).toBe(20_250);
+    expect(stats.cost_mUsd).toBe(0);
+    expect(stats.cacheDiscount_mUsd).toBe(0);
     expect(stats.market_cost).toBe(4_750);
   });
 

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
@@ -2,6 +2,15 @@ import { describe, it, expect, beforeEach } from '@jest/globals';
 import type { MicrodollarUsageContext, MicrodollarUsageStats } from './processUsage.types';
 import type { GatewayRequest } from './providers/openrouter/types';
 
+let mockInceptionPromoRunning = true;
+
+jest.mock('@/lib/constants', () => ({
+  ...(jest.requireActual('@/lib/constants') as Record<string, unknown>),
+  get INCEPTION_PROMO_RUNNING() {
+    return mockInceptionPromoRunning;
+  },
+}));
+
 // `countAndStoreEditUsage` schedules the usage write through `next/server`'s
 // `after()` post-response hook, which only works in a request context. Replace
 // it with an immediate invocation so the test can await the work synchronously.
@@ -457,6 +466,7 @@ describe('countAndStoreEditUsage', () => {
   }
 
   beforeEach(() => {
+    mockInceptionPromoRunning = true;
     mockedLogMicrodollarUsage.mockClear();
     mockedLogMicrodollarUsage.mockResolvedValue(null);
   });
@@ -487,7 +497,7 @@ describe('countAndStoreEditUsage', () => {
     expect(stats.market_cost).toBe(4_750);
   });
 
-  it('preserves market cost but does not bill non-BYOK requests', async () => {
+  it('preserves market cost but does not bill non-BYOK requests during the promotion', async () => {
     const response = makeUpstreamResponse({
       id: 'edit-paid',
       model: 'mercury-edit-2',
@@ -508,6 +518,31 @@ describe('countAndStoreEditUsage', () => {
     const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
     expect(stats.cost_mUsd).toBe(0);
     expect(stats.cacheDiscount_mUsd).toBe(0);
+    expect(stats.market_cost).toBe(4_750);
+  });
+
+  it('bills non-BYOK requests when the promotion is disabled', async () => {
+    mockInceptionPromoRunning = false;
+    const response = makeUpstreamResponse({
+      id: 'edit-paid',
+      model: 'mercury-edit-2',
+      usage: {
+        prompt_tokens: 100_000,
+        cached_input_tokens: 90_000,
+        completion_tokens: 0,
+        total_tokens: 100_000,
+      },
+      choices: [],
+    });
+
+    countAndStoreEditUsage(response, makeUsageContext({ user_byok: false }), undefined);
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(mockedLogMicrodollarUsage).toHaveBeenCalledTimes(1);
+    const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
+    expect(stats.cost_mUsd).toBe(4_750);
+    expect(stats.cacheDiscount_mUsd).toBe(20_250);
     expect(stats.market_cost).toBe(4_750);
   });
 

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -869,6 +869,11 @@ export function countAndStoreEditUsage(
 
       usageStats.market_cost = usageStats.cost_mUsd;
 
+      // Mirror the canonical chat path in `processOpenRouterUsage`: when the
+      // promotion is running or the request is BYOK we don't bill the user, so
+      // the cache discount we would otherwise have given them must be zeroed
+      // too. Otherwise the usage row would claim a discount on spend that never
+      // happened and distort "money saved by caching" reporting.
       if (INCEPTION_PROMO_RUNNING || usageContext.user_byok) {
         usageStats.cost_mUsd = 0;
         usageStats.cacheDiscount_mUsd = 0;

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -7,7 +7,7 @@ import {
   processTokenData,
 } from '@/lib/ai-gateway/processUsage';
 import { startInactiveSpan, captureException, captureMessage } from '@sentry/nextjs';
-import { APP_URL, FIRST_TOPUP_BONUS_AMOUNT } from '@/lib/constants';
+import { APP_URL, FIRST_TOPUP_BONUS_AMOUNT, INCEPTION_PROMO_RUNNING } from '@/lib/constants';
 import { summarizeUserPayments } from '@/lib/creditTransactions';
 import { type User } from '@kilocode/db/schema';
 import { errorExceptInTest, warnExceptInTest } from '@/lib/utils.server';
@@ -868,8 +868,11 @@ export function countAndStoreEditUsage(
       }
 
       usageStats.market_cost = usageStats.cost_mUsd;
-      usageStats.cost_mUsd = 0;
-      usageStats.cacheDiscount_mUsd = 0;
+
+      if (INCEPTION_PROMO_RUNNING || usageContext.user_byok) {
+        usageStats.cost_mUsd = 0;
+        usageStats.cacheDiscount_mUsd = 0;
+      }
 
       return logMicrodollarUsage(usageStats, usageContext);
     })

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -868,16 +868,8 @@ export function countAndStoreEditUsage(
       }
 
       usageStats.market_cost = usageStats.cost_mUsd;
-
-      // Mirror the canonical chat path in `processOpenRouterUsage`: when the
-      // request is BYOK we don't bill the user, so the cache discount we
-      // would otherwise have given them must be zeroed too. Otherwise the
-      // usage row would claim a discount on spend that never happened and
-      // distort "money saved by caching" reporting.
-      if (usageContext.user_byok) {
-        usageStats.cost_mUsd = 0;
-        usageStats.cacheDiscount_mUsd = 0;
-      }
+      usageStats.cost_mUsd = 0;
+      usageStats.cacheDiscount_mUsd = 0;
 
       return logMicrodollarUsage(usageStats, usageContext);
     })

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -56,6 +56,7 @@ export const APP_URL = resolveAppUrl({
 export const TRIAL_DURATION_DAYS = 14;
 
 export const AUTOCOMPLETE_MODEL = 'codestral-2508';
+export const INCEPTION_PROMO_RUNNING = true;
 
 export const ENABLE_DEPLOY_FEATURE = true;
 


### PR DESCRIPTION
## Summary

- Add `INCEPTION_PROMO_RUNNING` as a code-level switch for the autocomplete next-edit promotion.
- While enabled, allow next-edit requests with exhausted Kilo balances and persist zero billable cost and cache discount.
- When disabled, restore the existing balance check and calculated Inception token cost while preserving BYOK behavior.
- Preserve provider market cost during the promotion for internal spend reporting.

## Verification

- [ ] N/A - API-only billing behavior; no manual environment verification performed.

## Visual Changes

N/A

## Reviewer Notes

Disable the promotion by setting `INCEPTION_PROMO_RUNNING` to `false` in `apps/web/src/lib/constants.ts`.
