### PR TITLE
feat(organizations): show admin hierarchy context

### DIFF
--- a/apps/web/src/app/admin/api/organizations/hooks.ts
+++ b/apps/web/src/app/admin/api/organizations/hooks.ts
@@ -125,6 +125,18 @@ export function useAdminOrganizationDetails(organizationId: string) {
   );
 }
 
+export function useAdminOrganizationHierarchy(organizationId: string, enabled: boolean) {
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.organizations.admin.getHierarchy.queryOptions(
+      {
+        organizationId,
+      },
+      { enabled }
+    )
+  );
+}
+
 export function useAdminOrganizationCreditTransactions(organizationId: string) {
   const trpc = useTRPC();
   return useQuery(

--- a/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminDashboard.tsx
+++ b/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminDashboard.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { OrganizationInfoCard } from '@/components/organizations/OrganizationInfoCard';
+import {
+  ChildOrganizationsCard,
+  OrganizationInfoCard,
+} from '@/components/organizations/OrganizationInfoCard';
 import { OrganizationAdminMembers } from '@/components/organizations/OrganizationMembersCard';
 import { OrganizationUsageSummaryCard } from '@/components/organizations/OrganizationUsageSummaryCard';
 import { SeatUsageCard } from '@/components/organizations/SeatUsageCard';
@@ -53,12 +56,9 @@ export function OrganizationAdminDashboard({ organizationId }: { organizationId:
         <div className="flex w-full flex-col gap-y-8">
           <div className="w-full max-w-[1000px]">
             <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-              <div>
-                <OrganizationInfoCard
-                  organizationId={organizationId}
-                  showAdminControls
-                  className="h-full"
-                />
+              <div className="space-y-4">
+                <OrganizationInfoCard organizationId={organizationId} showAdminControls />
+                <ChildOrganizationsCard organizationId={organizationId} />
               </div>
               <div className="space-y-7">
                 <OrganizationUsageSummaryCard organizationId={organizationId} />

--- a/apps/web/src/components/organizations/OrganizationInfoCard.tsx
+++ b/apps/web/src/components/organizations/OrganizationInfoCard.tsx
@@ -43,6 +43,7 @@ import { formatDollars, formatIsoDateTime_IsoOrderNoSeconds, fromMicrodollars } 
 import { SpendingAlertsModal } from './SpendingAlertsModal';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useExpiringCredits } from './useExpiringCredits';
+import { useAdminOrganizationHierarchy } from '@/app/admin/api/organizations/hooks';
 
 const formatDate = (dateString: string) => {
   return new Date(dateString).toLocaleDateString('en-US', {
@@ -72,6 +73,80 @@ type InnerProps = {
   className?: string;
   showAdminControls: boolean;
 };
+
+type OrganizationHierarchySummary = {
+  id: string;
+  name: string;
+};
+
+type OrganizationHierarchySectionProps = {
+  parent: OrganizationHierarchySummary | null;
+};
+
+function OrganizationHierarchySection({ parent }: OrganizationHierarchySectionProps) {
+  if (!parent) {
+    return null;
+  }
+
+  return (
+    <section className="border-b border-border pb-4">
+      <div className="mt-3 space-y-3">
+        {parent ? (
+          <div className="space-y-1">
+            <p className="text-sm text-foreground">
+              This organization is a child of{' '}
+              <Link
+                href={`/admin/organizations/${encodeURIComponent(parent.id)}`}
+                className="text-link hover:text-link-hover inline-flex items-center gap-1 font-medium underline-offset-4 hover:underline"
+              >
+                {parent.name}
+              </Link>
+              .
+            </p>
+            <p className="text-muted-foreground text-sm">
+              Most child organization management should happen through the parent organization.
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+export function ChildOrganizationsCard({ organizationId }: { organizationId: string }) {
+  const hierarchyQuery = useAdminOrganizationHierarchy(organizationId, true);
+  const childOrganizations = hierarchyQuery.data?.children ?? [];
+
+  if (childOrganizations.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Child Organizations</CardTitle>
+        <CardDescription>
+          This organization is the parent of {childOrganizations.length} child organization
+          {childOrganizations.length === 1 ? '' : 's'}:
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-1.5">
+          {childOrganizations.map(childOrganization => (
+            <Link
+              key={childOrganization.id}
+              href={`/admin/organizations/${encodeURIComponent(childOrganization.id)}`}
+              className="hover:bg-surface-hover flex items-center justify-between gap-3 rounded-md py-1.5 text-sm transition-colors"
+            >
+              <span className="truncate font-medium">{childOrganization.name}</span>
+            </Link>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 function Inner(props: InnerProps) {
   const { info, className, showAdminControls } = props;
   const {
@@ -182,6 +257,7 @@ function Inner(props: InnerProps) {
   const isAutoTopUpEnabled = useIsAutoTopUpEnabled();
   const isInAdminDashboard = isKiloAdmin && showAdminControls;
   const isOrgOwner = useCanManagePaymentInfo();
+  const hierarchyQuery = useAdminOrganizationHierarchy(id, isInAdminDashboard);
 
   const handleSeatsRequirementEdit = () => {
     setPendingSeatsValue(!info.require_seats);
@@ -227,6 +303,9 @@ function Inner(props: InnerProps) {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
+        {isInAdminDashboard && hierarchyQuery.data ? (
+          <OrganizationHierarchySection parent={hierarchyQuery.data.parent} />
+        ) : null}
         <div>
           <label className="text-muted-foreground text-sm font-medium">Name</label>
           {isEditing ? (

--- a/apps/web/src/components/organizations/OrganizationInfoCard.tsx
+++ b/apps/web/src/components/organizations/OrganizationInfoCard.tsx
@@ -94,7 +94,7 @@ function OrganizationHierarchySection({ parent }: OrganizationHierarchySectionPr
         {parent ? (
           <div className="space-y-1">
             <p className="text-sm text-foreground">
-              This organization is a child of{' '}
+              Parent organization:{' '}
               <Link
                 href={`/admin/organizations/${encodeURIComponent(parent.id)}`}
                 className="text-link hover:text-link-hover inline-flex items-center gap-1 font-medium underline-offset-4 hover:underline"

--- a/apps/web/src/routers/organizations/organization-admin-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.test.ts
@@ -745,6 +745,55 @@ describe('organization admin router', () => {
     });
   });
 
+  describe('getHierarchy', () => {
+    it('returns parent and child organization summaries', async () => {
+      const searchPrefix = `Admin Org Hierarchy ${crypto.randomUUID()}`;
+      const parentOrganization = await createOrganization(`${searchPrefix} parent`, adminUser.id);
+      const childOrganization = await createOrganization(`${searchPrefix} child`, adminUser.id);
+      const siblingOrganization = await createOrganization(`${searchPrefix} sibling`, adminUser.id);
+
+      try {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: parentOrganization.id })
+          .where(inArray(organizations.id, [childOrganization.id, siblingOrganization.id]));
+
+        const caller = await createCallerForUser(adminUser.id);
+        const childHierarchy = await caller.organizations.admin.getHierarchy({
+          organizationId: childOrganization.id,
+        });
+        const parentHierarchy = await caller.organizations.admin.getHierarchy({
+          organizationId: parentOrganization.id,
+        });
+
+        expect(childHierarchy.parent).toEqual({
+          id: parentOrganization.id,
+          name: parentOrganization.name,
+        });
+        expect(childHierarchy.children).toEqual([]);
+        expect(parentHierarchy.parent).toBeNull();
+        expect(parentHierarchy.children).toEqual([
+          { id: childOrganization.id, name: childOrganization.name },
+          { id: siblingOrganization.id, name: siblingOrganization.name },
+        ]);
+      } finally {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(inArray(organizations.id, [childOrganization.id, siblingOrganization.id]));
+        await db
+          .delete(organizations)
+          .where(
+            inArray(organizations.id, [
+              childOrganization.id,
+              siblingOrganization.id,
+              parentOrganization.id,
+            ])
+          );
+      }
+    });
+  });
+
   describe('list — trial active filter', () => {
     it('uses effective trial end date and trial_active threshold', async () => {
       const searchPrefix = `Admin Trial Active ${crypto.randomUUID()}`;

--- a/apps/web/src/routers/organizations/organization-admin-router.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.ts
@@ -24,6 +24,7 @@ import {
   sql,
   type SQL,
 } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import * as z from 'zod';
 import { AdminCreditTransactionSchema, OrganizationsApiGetResponseSchema } from '@/types/admin';
@@ -125,6 +126,16 @@ const AdminOrganizationDetailsSchema = z.object({
   created_by_kilo_user_id: z.string().nullable(),
   created_by_user_email: z.string().nullable(),
   created_by_user_name: z.string().nullable(),
+});
+
+const OrganizationHierarchySummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+const AdminOrganizationHierarchySchema = z.object({
+  parent: OrganizationHierarchySummarySchema.nullable(),
+  children: z.array(OrganizationHierarchySummarySchema),
 });
 
 const GrantCreditInputSchema = z
@@ -297,6 +308,53 @@ export const organizationAdminRouter = createTRPCRouter({
       }
 
       return organizationDetails[0];
+    }),
+
+  getHierarchy: adminProcedure
+    .input(OrganizationIdInputSchema)
+    .output(AdminOrganizationHierarchySchema)
+    .query(async ({ input }) => {
+      const { organizationId } = input;
+      const parentOrganizations = alias(organizations, 'parent_organizations');
+
+      const [organizationHierarchy] = await db
+        .select({
+          parent_id: parentOrganizations.id,
+          parent_name: parentOrganizations.name,
+        })
+        .from(organizations)
+        .leftJoin(
+          parentOrganizations,
+          eq(organizations.parent_organization_id, parentOrganizations.id)
+        )
+        .where(eq(organizations.id, organizationId))
+        .limit(1);
+
+      if (!organizationHierarchy) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Organization not found',
+        });
+      }
+
+      const children = await db
+        .select({
+          id: organizations.id,
+          name: organizations.name,
+        })
+        .from(organizations)
+        .where(eq(organizations.parent_organization_id, organizationId))
+        .orderBy(asc(organizations.name));
+
+      return {
+        parent: organizationHierarchy.parent_id
+          ? {
+              id: organizationHierarchy.parent_id,
+              name: organizationHierarchy.parent_name ?? 'Unknown organization',
+            }
+          : null,
+        children,
+      };
     }),
 
   creditTransactions: adminProcedure


### PR DESCRIPTION
## Summary
- Adds an admin-only organization hierarchy endpoint for parent and child organization summaries.
- Shows parent context on child organization admin pages and a separate Child Organizations card on parent organization admin pages.
- Keeps standalone organizations unchanged by hiding hierarchy UI when no relationship exists.

## Verification
- Browser verified the child organization admin page at `/admin/organizations/3c65b834-21b9-4bf0-9f48-604b01843383`.
  <img width="1342" height="778" alt="CleanShot 2026-06-23 at 10 40 52@2x" src="https://github.com/user-attachments/assets/fe115c1c-dbc1-403d-9a50-1fe75deee6bd" />
- Browser verified the parent organization admin page at `/admin/organizations/00000000-0000-0000-0000-000000000000`: 
  <img width="1660" height="986" alt="CleanShot 2026-06-23 at 10 40 28@2x" src="https://github.com/user-attachments/assets/e9b511ff-f317-426e-be42-7e0bd7c80141" />


## Visual Changes
Screenshots to be added after submission.

## Reviewer Notes
- The new hierarchy endpoint is admin-only and returns only organization IDs and names.
- Child organization management copy intentionally points admins toward the parent organization.