### PR TITLE
fix(dev): report live Next.js dev port

### DIFF
--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -473,18 +473,59 @@ function writeManifest(
     wranglerRegistryPath,
     services: serviceNames.map(name => {
       const svc = getService(name);
-      return { name, port: svc.port, group: svc.group, type: svc.type };
+      const port = name === 'nextjs' ? (readNextjsDevPort(repoRoot) ?? svc.port) : svc.port;
+      return { name, port, group: svc.group, type: svc.type };
     }),
   };
   const manifestPath = path.join(repoRoot, 'dev', 'logs', 'manifest.json');
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
 }
 
+function readManifest(repoRoot: string): Manifest | undefined {
+  const manifestPath = path.join(repoRoot, 'dev', 'logs', 'manifest.json');
+  try {
+    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    if (
+      typeof raw?.session !== 'string' ||
+      typeof raw?.portOffset !== 'number' ||
+      !Array.isArray(raw?.services)
+    ) {
+      return undefined;
+    }
+    return raw;
+  } catch {
+    return undefined;
+  }
+}
+
+function readNextjsDevPort(repoRoot: string): number | undefined {
+  try {
+    const raw = fs.readFileSync(path.join(repoRoot, '.dev-port'), 'utf-8').trim();
+    const port = Number(raw);
+    if (Number.isInteger(port) && port > 0 && port <= 65535) return port;
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function getManifestEntry(
+  manifest: Manifest | undefined,
+  serviceName: string
+): ManifestEntry | undefined {
+  return manifest?.services.find(entry => entry.name === serviceName);
+}
+
 async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
   const sessionName = getSessionName();
+  const manifest = readManifest(repoRoot);
+  const activeManifest = manifest?.session === sessionName ? manifest : undefined;
+  const statusPortOffset = activeManifest?.portOffset ?? portOffset;
   if (!sessionExists(sessionName)) {
     if (isJson) {
-      console.log(JSON.stringify({ session: sessionName, portOffset, services: [] }));
+      console.log(
+        JSON.stringify({ session: sessionName, portOffset: statusPortOffset, services: [] })
+      );
     } else {
       console.log('No dev session running');
     }
@@ -497,7 +538,9 @@ async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
   });
   if (runningServices.length === 0) {
     if (isJson) {
-      console.log(JSON.stringify({ session: sessionName, portOffset, services: [] }));
+      console.log(
+        JSON.stringify({ session: sessionName, portOffset: statusPortOffset, services: [] })
+      );
     } else {
       console.log('No services running');
     }
@@ -507,20 +550,24 @@ async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
   const entries: StatusEntry[] = await Promise.all(
     runningServices.map(async ({ name, pane }): Promise<StatusEntry> => {
       const svc = getService(name);
-      const port = svc.port;
+      const manifestEntry = getManifestEntry(activeManifest, name);
+      const port =
+        name === 'nextjs'
+          ? (readNextjsDevPort(repoRoot) ?? manifestEntry?.port ?? svc.port)
+          : (manifestEntry?.port ?? svc.port);
       const isUp = port === 0 ? isPaneRunningCommand(sessionName, pane) : await probePort(port);
       const status: ServiceStatus = isUp ? 'up' : 'down';
       return {
         name,
         port,
         status,
-        group: svc.group,
+        group: manifestEntry?.group ?? svc.group,
       };
     })
   );
 
   if (isJson) {
-    const result = { session: sessionName, portOffset, services: entries };
+    const result = { session: sessionName, portOffset: statusPortOffset, services: entries };
     console.log(JSON.stringify(result));
     return;
   }

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -42,41 +42,14 @@ for envfile in .env.local .env.development.local; do
   fi
 done
 
-read_env_value() {
-  local key="$1"
-  local file
-  local value
-
-  for file in .env.development.local .env.local "$REPO_ROOT/.env.development.local" "$REPO_ROOT/.env.local"; do
-    if [ -f "$file" ]; then
-      value=$(awk -F= -v key="$key" '
-        $1 == key {
-          value = substr($0, length(key) + 2)
-          gsub(/^["'\'']|["'\'']$/, "", value)
-          print value
-          exit
-        }
-      ' "$file")
-      if [ -n "$value" ]; then
-        echo "$value"
-        return
-      fi
-    fi
-  done
-}
-
 export PORT
 export REDIS_URL="${REDIS_URL:-redis://localhost:6379}"
 export UPSTASH_REDIS_REST_URL="${UPSTASH_REDIS_REST_URL:-http://localhost:8079}"
 export UPSTASH_REDIS_REST_TOKEN="${UPSTASH_REDIS_REST_TOKEN:-example_token}"
-APP_URL_OVERRIDE="${APP_URL_OVERRIDE:-$(read_env_value APP_URL_OVERRIDE)}"
-NEXTAUTH_URL="${NEXTAUTH_URL:-$(read_env_value NEXTAUTH_URL)}"
 NEXT_DEV_HOSTNAME="${NEXT_DEV_HOSTNAME:-0.0.0.0}"
-# Only export APP_URL_OVERRIDE when set; an empty export becomes "" in
-# process.env and defeats the `??` fallback in apps/web/src/lib/constants.ts.
-if [ -n "$APP_URL_OVERRIDE" ]; then
-  export APP_URL_OVERRIDE
-fi
+APP_URL_OVERRIDE="${APP_URL_OVERRIDE:-http://localhost:$PORT}"
+NEXTAUTH_URL="${NEXTAUTH_URL:-$APP_URL_OVERRIDE}"
+export APP_URL_OVERRIDE
 export NEXT_DEV_HOSTNAME
-export NEXTAUTH_URL="${NEXTAUTH_URL:-${APP_URL_OVERRIDE:-http://localhost:$PORT}}"
+export NEXTAUTH_URL
 exec next dev -H "$NEXT_DEV_HOSTNAME" -p "$PORT" "$@"


### PR DESCRIPTION
## Summary
- Make `dev:status` report the live Next.js port selected by `scripts/dev.sh` from `.dev-port`, including auto-offset sessions.
- Default `APP_URL_OVERRIDE` and `NEXTAUTH_URL` to the actual selected local Next.js port so auth redirects stay on the running dev server.

## Verification
- User verified `KILO_PORT_OFFSET=auto pnpm dev:start web` followed by `pnpm dev:status` reports the correct Next.js port and redirects to the correct port after sign-in.

## Visual Changes
N/A

## Reviewer Notes
- The live Next.js port is session-local via `.dev-port`; `dev:status` only trusts manifest metadata when it belongs to the current tmux session.