### PR TITLE
Cloud Agent - Enforce current session access

### DIFF
--- a/apps/web/src/app/api/cloud-agent-next/sessions/stream-ticket/route.ts
+++ b/apps/web/src/app/api/cloud-agent-next/sessions/stream-ticket/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user/server';
-import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { db } from '@/lib/drizzle';
 import {
   verifyUserOwnsSessionV2ByCloudAgentId,
@@ -38,7 +37,7 @@ function handleTRPCError(error: unknown): NextResponse {
  *
  * Supports both personal and organization contexts:
  * - Personal: verifies the user owns the session
- * - Organization: verifies org membership and that the org owns the session
+ * - Organization: verifies the user owns the session and is a current org member
  *
  * The ticket includes:
  * - type: 'stream_ticket' to identify ticket type
@@ -82,9 +81,6 @@ export async function POST(request: Request) {
     const { cloudAgentSessionId, organizationId } = validation.data;
 
     if (organizationId) {
-      // Organization context: verify membership then session ownership
-      await ensureOrganizationAccess({ user }, organizationId);
-
       const sessionOwnership = await verifyOrgOwnsSessionV2ByCloudAgentId(
         db,
         organizationId,

--- a/apps/web/src/lib/cloud-agent/session-ownership.test.ts
+++ b/apps/web/src/lib/cloud-agent/session-ownership.test.ts
@@ -1,0 +1,206 @@
+import { db } from '@/lib/drizzle';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import {
+  cli_sessions_v2,
+  organization_memberships,
+  organizations,
+  type Organization,
+  type User,
+} from '@kilocode/db/schema';
+import { and, eq, inArray } from 'drizzle-orm';
+import { queryAccessibleCloudAgentSession } from '@kilocode/worker-utils/cloud-agent-session-access';
+import {
+  verifyOrgOwnsSessionV2ByCloudAgentId,
+  verifyUserOwnsSessionV2ByCloudAgentId,
+} from './session-ownership';
+
+const PERSONAL_SESSION_ID = 'ses_access_personal_1234567890';
+const PERSONAL_CLOUD_AGENT_SESSION_ID = 'agent_access_personal';
+const ORGANIZATION_SESSION_ID = 'ses_access_organization_123456';
+const ORGANIZATION_CLOUD_AGENT_SESSION_ID = 'agent_access_organization';
+
+let owner: User;
+let otherMember: User;
+let organization: Organization;
+let otherOrganization: Organization;
+
+describe('Cloud Agent session ownership', () => {
+  beforeAll(async () => {
+    owner = await insertTestUser({
+      google_user_email: 'cloud-agent-session-owner@example.com',
+      google_user_name: 'Cloud Agent Session Owner',
+      is_admin: false,
+    });
+    otherMember = await insertTestUser({
+      google_user_email: 'cloud-agent-session-other-member@example.com',
+      google_user_name: 'Cloud Agent Session Other Member',
+      is_admin: false,
+    });
+
+    [organization, otherOrganization] = await db
+      .insert(organizations)
+      .values([
+        {
+          name: 'Cloud Agent Session Access Organization',
+          created_by_kilo_user_id: owner.id,
+        },
+        {
+          name: 'Other Cloud Agent Session Access Organization',
+          created_by_kilo_user_id: owner.id,
+        },
+      ])
+      .returning();
+
+    await db.insert(organization_memberships).values([
+      {
+        organization_id: organization.id,
+        kilo_user_id: owner.id,
+        role: 'owner',
+      },
+      {
+        organization_id: organization.id,
+        kilo_user_id: otherMember.id,
+        role: 'member',
+      },
+      {
+        organization_id: otherOrganization.id,
+        kilo_user_id: owner.id,
+        role: 'owner',
+      },
+    ]);
+  });
+
+  beforeEach(async () => {
+    await db.insert(cli_sessions_v2).values([
+      {
+        session_id: PERSONAL_SESSION_ID,
+        kilo_user_id: owner.id,
+        cloud_agent_session_id: PERSONAL_CLOUD_AGENT_SESSION_ID,
+        created_on_platform: 'cloud-agent-web',
+      },
+      {
+        session_id: ORGANIZATION_SESSION_ID,
+        kilo_user_id: owner.id,
+        cloud_agent_session_id: ORGANIZATION_CLOUD_AGENT_SESSION_ID,
+        organization_id: organization.id,
+        created_on_platform: 'cloud-agent-web',
+      },
+    ]);
+  });
+
+  afterEach(async () => {
+    await db
+      .delete(cli_sessions_v2)
+      .where(inArray(cli_sessions_v2.session_id, [PERSONAL_SESSION_ID, ORGANIZATION_SESSION_ID]));
+  });
+
+  afterAll(async () => {
+    await db
+      .delete(organization_memberships)
+      .where(
+        inArray(organization_memberships.organization_id, [organization.id, otherOrganization.id])
+      );
+    await db
+      .delete(organizations)
+      .where(inArray(organizations.id, [organization.id, otherOrganization.id]));
+  });
+
+  it('requires the creator and personal scope for personal session access', async () => {
+    await expect(
+      verifyUserOwnsSessionV2ByCloudAgentId(db, owner.id, PERSONAL_CLOUD_AGENT_SESSION_ID)
+    ).resolves.toEqual({ kiloSessionId: PERSONAL_SESSION_ID });
+    await expect(
+      queryAccessibleCloudAgentSession(db, {
+        kiloUserId: owner.id,
+        cloudAgentSessionId: PERSONAL_CLOUD_AGENT_SESSION_ID,
+      })
+    ).resolves.toEqual({ kiloSessionId: PERSONAL_SESSION_ID, organizationId: null });
+
+    await expect(
+      verifyUserOwnsSessionV2ByCloudAgentId(db, otherMember.id, PERSONAL_CLOUD_AGENT_SESSION_ID)
+    ).resolves.toBeNull();
+
+    await expect(
+      verifyUserOwnsSessionV2ByCloudAgentId(db, owner.id, ORGANIZATION_CLOUD_AGENT_SESSION_ID)
+    ).resolves.toBeNull();
+  });
+
+  it('requires the creator, exact organization, and current membership', async () => {
+    await expect(
+      verifyOrgOwnsSessionV2ByCloudAgentId(
+        db,
+        organization.id,
+        owner.id,
+        ORGANIZATION_CLOUD_AGENT_SESSION_ID
+      )
+    ).resolves.toEqual({ kiloSessionId: ORGANIZATION_SESSION_ID });
+
+    await expect(
+      verifyOrgOwnsSessionV2ByCloudAgentId(
+        db,
+        organization.id,
+        otherMember.id,
+        ORGANIZATION_CLOUD_AGENT_SESSION_ID
+      )
+    ).resolves.toBeNull();
+
+    await expect(
+      verifyOrgOwnsSessionV2ByCloudAgentId(
+        db,
+        otherOrganization.id,
+        owner.id,
+        ORGANIZATION_CLOUD_AGENT_SESSION_ID
+      )
+    ).resolves.toBeNull();
+  });
+
+  it('denies access after removal and restores it after rejoining', async () => {
+    await db
+      .delete(organization_memberships)
+      .where(
+        and(
+          eq(organization_memberships.organization_id, organization.id),
+          eq(organization_memberships.kilo_user_id, owner.id)
+        )
+      );
+
+    await expect(
+      verifyOrgOwnsSessionV2ByCloudAgentId(
+        db,
+        organization.id,
+        owner.id,
+        ORGANIZATION_CLOUD_AGENT_SESSION_ID
+      )
+    ).resolves.toBeNull();
+    await expect(
+      queryAccessibleCloudAgentSession(db, {
+        kiloUserId: owner.id,
+        cloudAgentSessionId: ORGANIZATION_CLOUD_AGENT_SESSION_ID,
+      })
+    ).resolves.toBeNull();
+
+    await db.insert(organization_memberships).values({
+      organization_id: organization.id,
+      kilo_user_id: owner.id,
+      role: 'owner',
+    });
+
+    await expect(
+      verifyOrgOwnsSessionV2ByCloudAgentId(
+        db,
+        organization.id,
+        owner.id,
+        ORGANIZATION_CLOUD_AGENT_SESSION_ID
+      )
+    ).resolves.toEqual({ kiloSessionId: ORGANIZATION_SESSION_ID });
+    await expect(
+      queryAccessibleCloudAgentSession(db, {
+        kiloUserId: owner.id,
+        cloudAgentSessionId: ORGANIZATION_CLOUD_AGENT_SESSION_ID,
+      })
+    ).resolves.toEqual({
+      kiloSessionId: ORGANIZATION_SESSION_ID,
+      organizationId: organization.id,
+    });
+  });
+});

--- a/apps/web/src/lib/cloud-agent/session-ownership.ts
+++ b/apps/web/src/lib/cloud-agent/session-ownership.ts
@@ -1,6 +1,7 @@
-import { cliSessions, cli_sessions_v2, organization_memberships } from '@kilocode/db/schema';
+import { cliSessions, organization_memberships } from '@kilocode/db/schema';
 import type { db } from '@/lib/drizzle';
 import { and, eq } from 'drizzle-orm';
+import { queryAccessibleCloudAgentSession } from '@kilocode/worker-utils/cloud-agent-session-access';
 
 /**
  * Database type for dependency injection in functions.
@@ -77,25 +78,20 @@ export async function verifyUserOwnsSessionV2ByCloudAgentId(
   userId: string,
   cloudAgentSessionId: string
 ): Promise<{ kiloSessionId: string } | null> {
-  const [session] = await fromDb
-    .select({ session_id: cli_sessions_v2.session_id })
-    .from(cli_sessions_v2)
-    .where(
-      and(
-        eq(cli_sessions_v2.cloud_agent_session_id, cloudAgentSessionId),
-        eq(cli_sessions_v2.kilo_user_id, userId)
-      )
-    )
-    .limit(1);
+  const session = await queryAccessibleCloudAgentSession(fromDb, {
+    kiloUserId: userId,
+    cloudAgentSessionId,
+    expectedOrganizationId: null,
+  });
 
-  return session ? { kiloSessionId: session.session_id } : null;
+  return session ? { kiloSessionId: session.kiloSessionId } : null;
 }
 
 /**
- * Verifies that an organization owns a V2 session by cloud_agent_session_id
- * and that the user is a member of that organization.
+ * Verifies that a user owns a V2 organization session by cloud_agent_session_id
+ * and is currently a member of that exact organization.
  *
- * @returns The kiloSessionId if organization owns the session, null otherwise
+ * @returns The kiloSessionId if the user can access the organization session, null otherwise
  */
 export async function verifyOrgOwnsSessionV2ByCloudAgentId(
   fromDb: DrizzleDb,
@@ -103,25 +99,13 @@ export async function verifyOrgOwnsSessionV2ByCloudAgentId(
   userId: string,
   cloudAgentSessionId: string
 ): Promise<{ kiloSessionId: string } | null> {
-  const [session] = await fromDb
-    .select({ session_id: cli_sessions_v2.session_id })
-    .from(cli_sessions_v2)
-    .innerJoin(
-      organization_memberships,
-      and(
-        eq(organization_memberships.organization_id, cli_sessions_v2.organization_id),
-        eq(organization_memberships.kilo_user_id, userId)
-      )
-    )
-    .where(
-      and(
-        eq(cli_sessions_v2.cloud_agent_session_id, cloudAgentSessionId),
-        eq(cli_sessions_v2.organization_id, organizationId)
-      )
-    )
-    .limit(1);
+  const session = await queryAccessibleCloudAgentSession(fromDb, {
+    kiloUserId: userId,
+    cloudAgentSessionId,
+    expectedOrganizationId: organizationId,
+  });
 
-  return session ? { kiloSessionId: session.session_id } : null;
+  return session ? { kiloSessionId: session.kiloSessionId } : null;
 }
 
 /**

--- a/apps/web/src/routers/cli-sessions-v2-router.test.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.test.ts
@@ -307,6 +307,86 @@ describe('cli-sessions-v2-router', () => {
     });
   });
 
+  describe('session read authorization', () => {
+    const organizationSessionId = 'ses_read_auth_org_1234';
+    const cloudAgentSessionId = 'cloud-agent-read-auth-org-1234';
+
+    async function removeCreatorMembership() {
+      await db
+        .delete(organization_memberships)
+        .where(
+          and(
+            eq(organization_memberships.organization_id, testOrganization.id),
+            eq(organization_memberships.kilo_user_id, regularUser.id)
+          )
+        );
+    }
+
+    beforeEach(async () => {
+      await db.insert(organization_memberships).values({
+        organization_id: testOrganization.id,
+        kilo_user_id: regularUser.id,
+        role: 'member',
+      });
+      await db.insert(cli_sessions_v2).values({
+        session_id: organizationSessionId,
+        cloud_agent_session_id: cloudAgentSessionId,
+        kilo_user_id: regularUser.id,
+        organization_id: testOrganization.id,
+        created_on_platform: 'cloud-agent',
+      });
+    });
+
+    afterEach(async () => {
+      await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, organizationSessionId));
+      await removeCreatorMembership();
+    });
+
+    it('get rejects an organization session after its creator loses membership', async () => {
+      await removeCreatorMembership();
+
+      const caller = await createCallerForUser(regularUser.id);
+
+      await expect(
+        caller.cliSessionsV2.get({ session_id: organizationSessionId })
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    });
+
+    it('getByCloudAgentSessionId rejects an organization session after its creator loses membership', async () => {
+      await removeCreatorMembership();
+
+      const caller = await createCallerForUser(regularUser.id);
+
+      await expect(
+        caller.cliSessionsV2.getByCloudAgentSessionId({
+          cloud_agent_session_id: cloudAgentSessionId,
+        })
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    });
+
+    it('getSessionMessages rejects an organization session before fetching messages after its creator loses membership', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ info: {}, messages: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      try {
+        await removeCreatorMembership();
+
+        const caller = await createCallerForUser(regularUser.id);
+
+        await expect(
+          caller.cliSessionsV2.getSessionMessages({ session_id: organizationSessionId })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
   describe('parseGitHubOwnerRepo', () => {
     it('parses https URLs', () => {
       expect(parseGitHubOwnerRepo('https://github.com/Kilo/repo')).toEqual({

--- a/apps/web/src/routers/cli-sessions-v2-router.test.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.test.ts
@@ -43,6 +43,7 @@ const mockedFetchPullRequestForBranch =
 
 let regularUser: User;
 let otherUser: User;
+let adminUser: User;
 let testOrganization: Organization;
 
 describe('cli-sessions-v2-router', () => {
@@ -57,6 +58,12 @@ describe('cli-sessions-v2-router', () => {
       google_user_email: 'cli-sessions-v2-other@example.com',
       google_user_name: 'CLI Sessions V2 Other User',
       is_admin: false,
+    });
+
+    adminUser = await insertTestUser({
+      google_user_email: 'cli-sessions-v2-admin@example.com',
+      google_user_name: 'CLI Sessions V2 Admin',
+      is_admin: true,
     });
 
     const [org] = await db
@@ -307,7 +314,7 @@ describe('cli-sessions-v2-router', () => {
     });
   });
 
-  describe('session read authorization', () => {
+  describe('session authorization', () => {
     const organizationSessionId = 'ses_read_auth_org_1234';
     const cloudAgentSessionId = 'cloud-agent-read-auth-org-1234';
 
@@ -340,6 +347,176 @@ describe('cli-sessions-v2-router', () => {
     afterEach(async () => {
       await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, organizationSessionId));
       await removeCreatorMembership();
+    });
+
+    it('list omits organization sessions after their creator loses membership', async () => {
+      const personalSessionId = 'ses_read_auth_personal_1234';
+      await db.insert(cli_sessions_v2).values({
+        session_id: personalSessionId,
+        kilo_user_id: regularUser.id,
+        created_on_platform: 'cloud-agent',
+      });
+
+      try {
+        const caller = await createCallerForUser(regularUser.id);
+        const beforeRemoval = await caller.cliSessionsV2.list({});
+        expect(beforeRemoval.cliSessions.map(session => session.session_id)).toEqual(
+          expect.arrayContaining([organizationSessionId, personalSessionId])
+        );
+
+        await removeCreatorMembership();
+
+        const afterRemoval = await caller.cliSessionsV2.list({});
+        expect(afterRemoval.cliSessions.map(session => session.session_id)).toContain(
+          personalSessionId
+        );
+        expect(afterRemoval.cliSessions.map(session => session.session_id)).not.toContain(
+          organizationSessionId
+        );
+      } finally {
+        await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, personalSessionId));
+      }
+    });
+
+    it('list preserves platform-admin access without organization membership', async () => {
+      const adminSessionId = 'ses_read_auth_admin_1234';
+      await db.insert(cli_sessions_v2).values({
+        session_id: adminSessionId,
+        kilo_user_id: adminUser.id,
+        organization_id: testOrganization.id,
+        created_on_platform: 'cloud-agent',
+      });
+
+      try {
+        const caller = await createCallerForUser(adminUser.id);
+        const result = await caller.cliSessionsV2.list({});
+
+        expect(result.cliSessions.map(session => session.session_id)).toContain(adminSessionId);
+      } finally {
+        await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, adminSessionId));
+      }
+    });
+
+    it('search omits organization sessions after their creator loses membership', async () => {
+      await db
+        .update(cli_sessions_v2)
+        .set({ title: 'removed-member-search-result' })
+        .where(eq(cli_sessions_v2.session_id, organizationSessionId));
+      await removeCreatorMembership();
+
+      const caller = await createCallerForUser(regularUser.id);
+      const result = await caller.cliSessionsV2.search({
+        search_string: 'removed-member-search-result',
+      });
+
+      expect(result.results).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('recentRepositories omits organization sessions after their creator loses membership', async () => {
+      const personalSessionId = 'ses_recent_repo_personal_1234';
+      const personalGitUrl = 'https://github.com/kilo/personal-repository';
+      const organizationGitUrl = 'https://github.com/kilo/organization-repository';
+      await db
+        .update(cli_sessions_v2)
+        .set({ git_url: organizationGitUrl })
+        .where(eq(cli_sessions_v2.session_id, organizationSessionId));
+      await db.insert(cli_sessions_v2).values({
+        session_id: personalSessionId,
+        kilo_user_id: regularUser.id,
+        created_on_platform: 'cloud-agent',
+        git_url: personalGitUrl,
+      });
+
+      try {
+        await removeCreatorMembership();
+
+        const caller = await createCallerForUser(regularUser.id);
+        const result = await caller.cliSessionsV2.recentRepositories({
+          updatedSince: '2026-01-01T00:00:00.000Z',
+        });
+        const gitUrls = result.repositories.map(repository => repository.gitUrl);
+
+        expect(gitUrls).toContain(personalGitUrl);
+        expect(gitUrls).not.toContain(organizationGitUrl);
+      } finally {
+        await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, personalSessionId));
+      }
+    });
+
+    it('delete rejects an organization session before cleanup after its creator loses membership', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      try {
+        await removeCreatorMembership();
+
+        const caller = await createCallerForUser(regularUser.id);
+        await expect(
+          caller.cliSessionsV2.delete({ session_id: organizationSessionId })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it('rename permits a current organization member', async () => {
+      const caller = await createCallerForUser(regularUser.id);
+      const result = await caller.cliSessionsV2.rename({
+        session_id: organizationSessionId,
+        title: 'renamed by current member',
+      });
+
+      expect(result.title).toBe('renamed by current member');
+    });
+
+    it('rename rejects an organization session after its creator loses membership', async () => {
+      const originalTitle = 'organization session title';
+      await db
+        .update(cli_sessions_v2)
+        .set({ title: originalTitle })
+        .where(eq(cli_sessions_v2.session_id, organizationSessionId));
+      await removeCreatorMembership();
+
+      const caller = await createCallerForUser(regularUser.id);
+      await expect(
+        caller.cliSessionsV2.rename({
+          session_id: organizationSessionId,
+          title: 'renamed after removal',
+        })
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+      const [session] = await db
+        .select({ title: cli_sessions_v2.title })
+        .from(cli_sessions_v2)
+        .where(eq(cli_sessions_v2.session_id, organizationSessionId));
+      expect(session?.title).toBe(originalTitle);
+    });
+
+    it('share rejects an organization session before publishing after its creator loses membership', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ success: true, public_id: 'test-public-uuid' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      try {
+        await removeCreatorMembership();
+
+        const caller = await createCallerForUser(regularUser.id);
+        await expect(
+          caller.cliSessionsV2.share({ session_id: organizationSessionId })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
     });
 
     it('get rejects an organization session after its creator loses membership', async () => {

--- a/apps/web/src/routers/cli-sessions-v2-router.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.ts
@@ -623,6 +623,10 @@ export const cliSessionsV2Router = createTRPCRouter({
       });
     }
 
+    if (session.organization_id) {
+      await ensureOrganizationAccess(ctx, session.organization_id);
+    }
+
     return session;
   }),
 
@@ -653,6 +657,10 @@ export const cliSessionsV2Router = createTRPCRouter({
         });
       }
 
+      if (session.organization_id) {
+        await ensureOrganizationAccess(ctx, session.organization_id);
+      }
+
       return session;
     }),
 
@@ -662,7 +670,10 @@ export const cliSessionsV2Router = createTRPCRouter({
   getSessionMessages: baseProcedure
     .input(z.object({ session_id: sessionIdField }))
     .query(async ({ ctx, input }) => {
-      await getSessionWithOwnerCheck(input.session_id, ctx.user.id);
+      const session = await getSessionWithOwnerCheck(input.session_id, ctx.user.id);
+      if (session.organization_id) {
+        await ensureOrganizationAccess(ctx, session.organization_id);
+      }
 
       try {
         const messages = await fetchSessionMessages(input.session_id, ctx.user);

--- a/apps/web/src/routers/cli-sessions-v2-router.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.ts
@@ -19,7 +19,11 @@ import {
 import { TRPCError } from '@trpc/server';
 import { captureException } from '@sentry/nextjs';
 import { TRPCClientError } from '@trpc/client';
-import { cli_sessions_v2, github_branch_pull_requests } from '@kilocode/db/schema';
+import {
+  cli_sessions_v2,
+  github_branch_pull_requests,
+  organization_memberships,
+} from '@kilocode/db/schema';
 import { createCloudAgentNextClient } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { generateApiToken, generateInternalServiceToken } from '@/lib/tokens';
 import {
@@ -267,13 +271,18 @@ const sessionIdField = z.string().min(1);
 const cloudAgentSessionIdField = z.string().min(1).max(255);
 
 /**
- * Verify user owns the session. Returns the session if found.
+ * Verify the user owns the session and still has access to its organization.
  */
-async function getSessionWithOwnerCheck(sessionId: string, userId: string) {
+async function getSessionWithAccessCheck(
+  sessionId: string,
+  ctx: Parameters<typeof ensureOrganizationAccess>[0]
+) {
   const [session] = await db
     .select()
     .from(cli_sessions_v2)
-    .where(and(eq(cli_sessions_v2.session_id, sessionId), eq(cli_sessions_v2.kilo_user_id, userId)))
+    .where(
+      and(eq(cli_sessions_v2.session_id, sessionId), eq(cli_sessions_v2.kilo_user_id, ctx.user.id))
+    )
     .limit(1);
 
   if (!session) {
@@ -281,6 +290,10 @@ async function getSessionWithOwnerCheck(sessionId: string, userId: string) {
       code: 'NOT_FOUND',
       message: 'Session not found',
     });
+  }
+
+  if (session.organization_id) {
+    await ensureOrganizationAccess(ctx, session.organization_id);
   }
 
   return session;
@@ -397,6 +410,17 @@ async function addOrganizationCondition(
   organizationId: string | null | undefined
 ): Promise<void> {
   if (organizationId === undefined) {
+    if (!ctx.user.is_admin) {
+      whereConditions.push(sql`(
+        ${cli_sessions_v2.organization_id} IS NULL
+        OR EXISTS (
+          SELECT 1
+          FROM ${organization_memberships}
+          WHERE ${organization_memberships.organization_id} = ${cli_sessions_v2.organization_id}
+            AND ${organization_memberships.kilo_user_id} = ${ctx.user.id}
+        )
+      )`);
+    }
     return;
   }
 
@@ -670,10 +694,7 @@ export const cliSessionsV2Router = createTRPCRouter({
   getSessionMessages: baseProcedure
     .input(z.object({ session_id: sessionIdField }))
     .query(async ({ ctx, input }) => {
-      const session = await getSessionWithOwnerCheck(input.session_id, ctx.user.id);
-      if (session.organization_id) {
-        await ensureOrganizationAccess(ctx, session.organization_id);
-      }
+      await getSessionWithAccessCheck(input.session_id, ctx);
 
       try {
         const messages = await fetchSessionMessages(input.session_id, ctx.user);
@@ -1118,7 +1139,7 @@ export const cliSessionsV2Router = createTRPCRouter({
    */
   delete: baseProcedure.input(DeleteSessionInputSchema).mutation(async ({ ctx, input }) => {
     const { session_id } = input;
-    const session = await getSessionWithOwnerCheck(session_id, ctx.user.id);
+    const session = await getSessionWithAccessCheck(session_id, ctx);
 
     if (session.cloud_agent_session_id) {
       const authToken = generateApiToken(ctx.user);
@@ -1156,7 +1177,7 @@ export const cliSessionsV2Router = createTRPCRouter({
    */
   rename: baseProcedure.input(RenameSessionInputSchema).mutation(async ({ ctx, input }) => {
     const { session_id, title } = input;
-    const session = await getSessionWithOwnerCheck(session_id, ctx.user.id);
+    const session = await getSessionWithAccessCheck(session_id, ctx);
 
     const [updated] = await db
       .update(cli_sessions_v2)
@@ -1187,7 +1208,7 @@ export const cliSessionsV2Router = createTRPCRouter({
    */
   share: baseProcedure.input(ShareSessionInputSchema).mutation(async ({ ctx, input }) => {
     const { session_id } = input;
-    await getSessionWithOwnerCheck(session_id, ctx.user.id);
+    await getSessionWithAccessCheck(session_id, ctx);
 
     try {
       const result = await shareSessionIngest(session_id, ctx.user.id);

--- a/apps/web/src/routers/cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/cloud-agent-next-router.test.ts
@@ -49,6 +49,8 @@ const mockCreateCloudAgentNextClient = jest.fn(() => ({
 
 const mockIsFeatureFlagEnabledOrDevelopment =
   jest.fn<(flagName: string, distinctId: string) => Promise<boolean>>();
+const mockVerifyUserOwnsSessionV2ByCloudAgentId =
+  jest.fn<() => Promise<{ kiloSessionId: string } | null>>();
 
 jest.mock('@/lib/tokens', () => ({
   generateCloudAgentToken: jest.fn(() => 'cloud-agent-token'),
@@ -66,6 +68,10 @@ jest.mock('@/lib/posthog-feature-flags', () => ({
 jest.mock('@/lib/r2/cloud-agent-attachments', () => ({
   generateImageUploadUrl: jest.fn(),
   generateCloudAgentAttachmentUploadUrl: mockGenerateCloudAgentAttachmentUploadUrl,
+}));
+
+jest.mock('@/lib/cloud-agent/session-ownership', () => ({
+  verifyUserOwnsSessionV2ByCloudAgentId: mockVerifyUserOwnsSessionV2ByCloudAgentId,
 }));
 
 let createCaller: (ctx: { user: User }) => {
@@ -103,6 +109,23 @@ beforeAll(async () => {
 describe('cloudAgentNextRouter attachment forwarding', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockVerifyUserOwnsSessionV2ByCloudAgentId.mockResolvedValue({
+      kiloSessionId: 'ses_12345678901234567890123456',
+    });
+  });
+
+  it('denies a session the authenticated user does not own before calling the Worker', async () => {
+    mockVerifyUserOwnsSessionV2ByCloudAgentId.mockResolvedValueOnce(null);
+    const caller = createCaller({ user: { id: 'user-1', is_admin: false } as User });
+
+    await expect(
+      caller.sendMessage({
+        cloudAgentSessionId: 'agent_123',
+        payload: { type: 'prompt', prompt: 'Read PDF', mode: 'code', model: 'test' },
+      })
+    ).rejects.toThrow('Session not found or access denied');
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
   it('forwards canonical document attachments when sending a message', async () => {

--- a/apps/web/src/routers/cloud-agent-next-router.ts
+++ b/apps/web/src/routers/cloud-agent-next-router.ts
@@ -84,10 +84,7 @@ function createTerminalTicket(params: {
   };
 }
 
-async function assertUserOwnsTerminalSession(
-  userId: string,
-  cloudAgentSessionId: string
-): Promise<void> {
+async function assertUserOwnsSession(userId: string, cloudAgentSessionId: string): Promise<void> {
   const sessionOwnership = await verifyUserOwnsSessionV2ByCloudAgentId(
     db,
     userId,
@@ -182,6 +179,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseInitiateFromPreparedSessionNextSchema)
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
+      await assertUserOwnsSession(ctx.user.id, input.cloudAgentSessionId);
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
@@ -208,6 +206,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseSendMessageNextSchema)
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
+      await assertUserOwnsSession(ctx.user.id, input.cloudAgentSessionId);
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
@@ -230,7 +229,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseCreateTerminalNextSchema)
     .output(baseCreateTerminalNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      await assertUserOwnsTerminalSession(ctx.user.id, input.cloudAgentSessionId);
+      await assertUserOwnsSession(ctx.user.id, input.cloudAgentSessionId);
 
       try {
         const authToken = generateCloudAgentToken(ctx.user);
@@ -256,7 +255,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseRefreshTerminalTicketNextSchema)
     .output(baseRefreshTerminalTicketNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      await assertUserOwnsTerminalSession(ctx.user.id, input.cloudAgentSessionId);
+      await assertUserOwnsSession(ctx.user.id, input.cloudAgentSessionId);
 
       return createTerminalTicket({
         userId: ctx.user.id,
@@ -269,7 +268,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseResizeTerminalNextSchema)
     .output(baseResizeTerminalNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      await assertUserOwnsTerminalSession(ctx.user.id, input.cloudAgentSessionId);
+      await assertUserOwnsSession(ctx.user.id, input.cloudAgentSessionId);
 
       try {
         const authToken = generateCloudAgentToken(ctx.user);
@@ -284,7 +283,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseCloseTerminalNextSchema)
     .output(baseCloseTerminalNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      await assertUserOwnsTerminalSession(ctx.user.id, input.cloudAgentSessionId);
+      await assertUserOwnsSession(ctx.user.id, input.cloudAgentSessionId);
 
       try {
         const authToken = generateCloudAgentToken(ctx.user);
@@ -339,6 +338,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      await assertUserOwnsSession(ctx.user.id, input.sessionId);
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
@@ -349,6 +349,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseAnswerQuestionNextSchema)
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
+      await assertUserOwnsSession(ctx.user.id, input.sessionId);
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
       return await client.answerQuestion(input);
@@ -358,6 +359,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseRejectQuestionNextSchema)
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
+      await assertUserOwnsSession(ctx.user.id, input.sessionId);
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
       return await client.rejectQuestion(input);
@@ -367,6 +369,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseAnswerPermissionNextSchema)
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
+      await assertUserOwnsSession(ctx.user.id, input.sessionId);
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
       return await client.answerPermission(input);
@@ -380,6 +383,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseGetSessionNextSchema)
     .output(baseGetSessionNextOutputSchema)
     .query(async ({ ctx, input }) => {
+      await assertUserOwnsSession(ctx.user.id, input.cloudAgentSessionId);
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
@@ -53,6 +53,8 @@ const mockCreateCloudAgentNextClient = jest.fn(() => ({
 
 const mockIsFeatureFlagEnabledOrDevelopment =
   jest.fn<(flagName: string, distinctId: string) => Promise<boolean>>();
+const mockVerifyOrgOwnsSessionV2ByCloudAgentId =
+  jest.fn<() => Promise<{ kiloSessionId: string } | null>>();
 
 jest.mock('@/lib/tokens', () => ({
   generateCloudAgentToken: jest.fn(() => 'cloud-agent-token'),
@@ -70,6 +72,10 @@ jest.mock('@/lib/posthog-feature-flags', () => ({
 jest.mock('@/lib/r2/cloud-agent-attachments', () => ({
   generateImageUploadUrl: jest.fn(),
   generateCloudAgentAttachmentUploadUrl: mockGenerateCloudAgentAttachmentUploadUrl,
+}));
+
+jest.mock('@/lib/cloud-agent/session-ownership', () => ({
+  verifyOrgOwnsSessionV2ByCloudAgentId: mockVerifyOrgOwnsSessionV2ByCloudAgentId,
 }));
 
 jest.mock('@/routers/organizations/utils', () => {
@@ -119,6 +125,24 @@ beforeAll(async () => {
 describe('organizationCloudAgentNextRouter attachment forwarding', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockVerifyOrgOwnsSessionV2ByCloudAgentId.mockResolvedValue({
+      kiloSessionId: 'ses_12345678901234567890123456',
+    });
+  });
+
+  it('denies an inaccessible organization session before calling the Worker', async () => {
+    mockVerifyOrgOwnsSessionV2ByCloudAgentId.mockResolvedValueOnce(null);
+    const caller = createCaller({ user: { id: 'user-1', is_admin: false } as User });
+
+    await expect(
+      caller.sendMessage({
+        organizationId: ORGANIZATION_ID,
+        cloudAgentSessionId: 'agent_123',
+        payload: { type: 'prompt', prompt: 'Read notes', mode: 'code', model: 'test' },
+      })
+    ).rejects.toThrow('Organization does not own this session');
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
   it('forwards canonical document attachments without organization middleware fields', async () => {

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -90,7 +90,7 @@ function createTerminalTicket(params: {
   };
 }
 
-async function assertOrganizationOwnsTerminalSession(params: {
+async function assertOrganizationOwnsSession(params: {
   organizationId: string;
   userId: string;
   cloudAgentSessionId: string;
@@ -259,6 +259,11 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(InitiateFromPreparedSessionInput)
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
+      await assertOrganizationOwnsSession({
+        organizationId: input.organizationId,
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.cloudAgentSessionId,
+      });
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
@@ -285,6 +290,11 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(SendMessageInput)
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
+      await assertOrganizationOwnsSession({
+        organizationId: input.organizationId,
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.cloudAgentSessionId,
+      });
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
@@ -309,7 +319,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(CreateTerminalInput)
     .output(baseCreateTerminalNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      await assertOrganizationOwnsTerminalSession({
+      await assertOrganizationOwnsSession({
         organizationId: input.organizationId,
         userId: ctx.user.id,
         cloudAgentSessionId: input.cloudAgentSessionId,
@@ -344,7 +354,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(RefreshTerminalTicketInput)
     .output(baseRefreshTerminalTicketNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      await assertOrganizationOwnsTerminalSession({
+      await assertOrganizationOwnsSession({
         organizationId: input.organizationId,
         userId: ctx.user.id,
         cloudAgentSessionId: input.cloudAgentSessionId,
@@ -362,7 +372,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(ResizeTerminalInput)
     .output(baseResizeTerminalNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      await assertOrganizationOwnsTerminalSession({
+      await assertOrganizationOwnsSession({
         organizationId: input.organizationId,
         userId: ctx.user.id,
         cloudAgentSessionId: input.cloudAgentSessionId,
@@ -386,7 +396,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(CloseTerminalInput)
     .output(baseCloseTerminalNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      await assertOrganizationOwnsTerminalSession({
+      await assertOrganizationOwnsSession({
         organizationId: input.organizationId,
         userId: ctx.user.id,
         cloudAgentSessionId: input.cloudAgentSessionId,
@@ -448,6 +458,11 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      await assertOrganizationOwnsSession({
+        organizationId: input.organizationId,
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.sessionId,
+      });
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
@@ -458,6 +473,11 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(AnswerQuestionInput)
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
+      await assertOrganizationOwnsSession({
+        organizationId: input.organizationId,
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.sessionId,
+      });
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
       return await client.answerQuestion({
@@ -471,6 +491,11 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(RejectQuestionInput)
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
+      await assertOrganizationOwnsSession({
+        organizationId: input.organizationId,
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.sessionId,
+      });
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
       return await client.rejectQuestion({
@@ -483,6 +508,11 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(AnswerPermissionInput)
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
+      await assertOrganizationOwnsSession({
+        organizationId: input.organizationId,
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.sessionId,
+      });
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
       return await client.answerPermission({
@@ -500,6 +530,11 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(GetSessionInput)
     .output(baseGetSessionNextOutputSchema)
     .query(async ({ ctx, input }) => {
+      await assertOrganizationOwnsSession({
+        organizationId: input.organizationId,
+        userId: ctx.user.id,
+        cloudAgentSessionId: input.cloudAgentSessionId,
+      });
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -17,6 +17,7 @@
     "./git-url": "./src/git-url.ts",
     "./callback-token": "./src/callback-token.ts",
     "./cloud-agent-next-client": "./src/cloud-agent-next-client.ts",
+    "./cloud-agent-session-access": "./src/cloud-agent-session-access.ts",
     "./kilo-model-id": "./src/kilo-model-id.ts",
     "./cloud-agent-queue-report": "./src/cloud-agent-queue-report.ts",
     "./cloud-agent-failure": "./src/cloud-agent-failure.ts",

--- a/packages/worker-utils/src/cloud-agent-session-access.ts
+++ b/packages/worker-utils/src/cloud-agent-session-access.ts
@@ -1,0 +1,53 @@
+import type { WorkerDb } from '@kilocode/db/client';
+import { cli_sessions_v2, organization_memberships } from '@kilocode/db/schema';
+import { and, eq, isNotNull, isNull, or } from 'drizzle-orm';
+
+export type AccessibleCloudAgentSession = {
+  kiloSessionId: string;
+  organizationId: string | null;
+};
+
+type SessionAccessDb = Pick<WorkerDb, 'select'>;
+
+type AccessibleCloudAgentSessionQuery = {
+  kiloUserId: string;
+  cloudAgentSessionId: string;
+  expectedOrganizationId?: string | null;
+};
+
+export async function queryAccessibleCloudAgentSession(
+  db: SessionAccessDb,
+  query: AccessibleCloudAgentSessionQuery
+): Promise<AccessibleCloudAgentSession | null> {
+  const membershipJoin = and(
+    eq(organization_memberships.organization_id, cli_sessions_v2.organization_id),
+    eq(organization_memberships.kilo_user_id, query.kiloUserId)
+  );
+  const scopeCondition =
+    query.expectedOrganizationId === null
+      ? isNull(cli_sessions_v2.organization_id)
+      : query.expectedOrganizationId !== undefined
+        ? and(
+            eq(cli_sessions_v2.organization_id, query.expectedOrganizationId),
+            isNotNull(organization_memberships.id)
+          )
+        : or(isNull(cli_sessions_v2.organization_id), isNotNull(organization_memberships.id));
+
+  const rows = await db
+    .select({
+      kiloSessionId: cli_sessions_v2.session_id,
+      organizationId: cli_sessions_v2.organization_id,
+    })
+    .from(cli_sessions_v2)
+    .leftJoin(organization_memberships, membershipJoin)
+    .where(
+      and(
+        eq(cli_sessions_v2.kilo_user_id, query.kiloUserId),
+        eq(cli_sessions_v2.cloud_agent_session_id, query.cloudAgentSessionId),
+        scopeCondition
+      )
+    )
+    .limit(1);
+
+  return rows[0] ?? null;
+}

--- a/services/cloud-agent-next/src/hono-context.ts
+++ b/services/cloud-agent-next/src/hono-context.ts
@@ -1,4 +1,4 @@
-import type { Env } from './types.js';
+import type { Env, ValidatedSessionAccess } from './types.js';
 
 export type HonoContext = {
   Bindings: Env;
@@ -6,5 +6,6 @@ export type HonoContext = {
     userId?: string;
     authToken?: string;
     botId?: string;
+    validatedSessionAccess?: ValidatedSessionAccess;
   };
 };

--- a/services/cloud-agent-next/src/middleware/balance.test.ts
+++ b/services/cloud-agent-next/src/middleware/balance.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { HonoContext } from '../hono-context.js';
 import type { Env } from '../types.js';
 
+const { requireCurrentSessionAccessMock } = vi.hoisted(() => ({
+  requireCurrentSessionAccessMock: vi.fn(),
+}));
+
 vi.mock('../balance-validation.js', () => ({
   BALANCE_REQUIRED_MUTATIONS: new Set([
     'initiateFromKilocodeSessionV2',
@@ -24,6 +28,11 @@ vi.mock('../logger.js', () => ({
   },
 }));
 
+vi.mock('../session-access.js', () => ({
+  requireCurrentSessionAccess: requireCurrentSessionAccessMock,
+  projectSessionAccessHttpError: () => new Response('Session access denied', { status: 403 }),
+}));
+
 const { balanceMiddleware } = await import('./balance.js');
 const { fetchOrgIdForSession, validateBalanceOnly } = await import('../balance-validation.js');
 
@@ -33,6 +42,10 @@ describe('balanceMiddleware', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(validateBalanceOnly).mockResolvedValue({ success: true });
+    requireCurrentSessionAccessMock.mockResolvedValue({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org-current',
+    });
   });
 
   function createApp() {
@@ -43,7 +56,9 @@ describe('balanceMiddleware', () => {
       await next();
     });
     app.use('/trpc/*', balanceMiddleware);
-    app.post('/trpc/:procedure', c => c.json({ ok: true }));
+    app.post('/trpc/:procedure', c =>
+      c.json({ ok: true, validatedSessionAccess: c.get('validatedSessionAccess') })
+    );
     return app;
   }
 
@@ -105,5 +120,29 @@ describe('balanceMiddleware', () => {
     expect(response.status).toBe(200);
     expect(validateBalanceOnly).toHaveBeenCalledWith('token-123', orgId, env);
     expect(fetchOrgIdForSession).not.toHaveBeenCalled();
+  });
+
+  it('validates caller-supplied organization context against the stored session scope', async () => {
+    const response = await postTrpc('send', {
+      cloudAgentSessionId: 'agent-existing',
+      kilocodeOrganizationId: 'org-requested',
+    });
+
+    expect(response.status).toBe(200);
+    expect(requireCurrentSessionAccessMock).toHaveBeenCalledWith({
+      env,
+      kiloUserId: 'user-123',
+      cloudAgentSessionId: 'agent-existing',
+      expectedOrganizationId: 'org-requested',
+    });
+    expect(validateBalanceOnly).toHaveBeenCalledWith('token-123', 'org-current', env);
+    await expect(response.json()).resolves.toMatchObject({
+      validatedSessionAccess: {
+        kiloUserId: 'user-123',
+        cloudAgentSessionId: 'agent-existing',
+        kiloSessionId: 'ses_12345678901234567890123456',
+        organizationId: 'org-current',
+      },
+    });
   });
 });

--- a/services/cloud-agent-next/src/middleware/balance.ts
+++ b/services/cloud-agent-next/src/middleware/balance.ts
@@ -6,9 +6,9 @@ import { buildTrpcErrorResponse } from '../trpc-error.js';
 import {
   validateBalanceOnly,
   extractProcedureName,
-  fetchOrgIdForSession,
   BALANCE_REQUIRED_MUTATIONS,
 } from '../balance-validation.js';
+import { projectSessionAccessHttpError, requireCurrentSessionAccess } from '../session-access.js';
 
 /**
  * Middleware that validates user balance for mutations that require it.
@@ -63,18 +63,30 @@ export const balanceMiddleware = createMiddleware<HonoContext>(
       return buildTrpcErrorResponse(401, 'Missing auth token', procedureName);
     }
 
-    // For message-send procedures the caller only supplies cloudAgentSessionId;
-    // resolve the org for balance checks from the DO metadata. `start` always
-    // carries `kilocodeOrganizationId` in the body, so it is not included here.
     if (
       (procedureName === 'sendMessageV2' ||
         procedureName === 'initiateFromKilocodeSessionV2' ||
         procedureName === 'send') &&
-      !orgId &&
       sessionId &&
       userId
     ) {
-      orgId = await fetchOrgIdForSession(c.env, userId, sessionId);
+      try {
+        const access = await requireCurrentSessionAccess({
+          env: c.env,
+          kiloUserId: userId,
+          cloudAgentSessionId: sessionId,
+          expectedOrganizationId: orgId,
+        });
+        c.set('validatedSessionAccess', {
+          kiloUserId: userId,
+          cloudAgentSessionId: sessionId,
+          ...access,
+        });
+        orgId = access.organizationId ?? undefined;
+      } catch (error) {
+        const response = projectSessionAccessHttpError(error);
+        return buildTrpcErrorResponse(response.status, await response.text(), procedureName);
+      }
     }
 
     // Use balance-only validation since auth was already done by authMiddleware

--- a/services/cloud-agent-next/src/router.test.ts
+++ b/services/cloud-agent-next/src/router.test.ts
@@ -641,6 +641,33 @@ describe('router sessionId validation', () => {
             ).rejects.toThrow('Authentication required');
           });
 
+          it('denies deletion when current access to an existing session has been removed', async () => {
+            const sessionId: SessionId = 'agent_12341234-5678-9012-3456-789012345678';
+            vi.mocked(fetchSessionMetadata).mockResolvedValue(
+              legacySessionMetadata({
+                version: 123456789,
+                sessionId,
+                orgId: 'org-123',
+                userId: 'test-user-123',
+                timestamp: 123456789,
+              })
+            );
+            requireCurrentSessionAccessMock.mockRejectedValueOnce(
+              new TRPCError({ code: 'FORBIDDEN', message: 'Session access denied' })
+            );
+
+            await expect(caller.deleteSession({ sessionId })).rejects.toMatchObject({
+              code: 'FORBIDDEN',
+            });
+
+            expect(requireCurrentSessionAccessMock).toHaveBeenCalledWith({
+              env: mockContext.env,
+              kiloUserId: 'test-user-123',
+              cloudAgentSessionId: sessionId,
+            });
+            expect(cloudAgentSession.get).not.toHaveBeenCalled();
+          });
+
           it('does not delete runtime state for a guessed session belonging to another user', async () => {
             const sessionId: SessionId = 'agent_99999999-8888-7777-6666-555555555555';
             vi.mocked(fetchSessionMetadata).mockResolvedValue(null);

--- a/services/cloud-agent-next/src/router.test.ts
+++ b/services/cloud-agent-next/src/router.test.ts
@@ -25,6 +25,16 @@ const { preflightExistingPromptModelMock, preflightPreparedInitialPromptModelMoc
     preflightPreparedInitialPromptModelMock: vi.fn(),
   })
 );
+const { requireCurrentSessionAccessMock } = vi.hoisted(() => ({
+  requireCurrentSessionAccessMock: vi.fn().mockResolvedValue({
+    kiloSessionId: 'ses_12345678901234567890123456',
+    organizationId: null,
+  }),
+}));
+
+vi.mock('./session-access.js', () => ({
+  requireCurrentSessionAccess: requireCurrentSessionAccessMock,
+}));
 
 vi.mock('./session/model-preflight.js', () => ({
   preflightExistingPromptModel: preflightExistingPromptModelMock,
@@ -490,18 +500,28 @@ describe('router sessionId validation', () => {
         });
 
         describe('idempotency', () => {
-          it('treats deletion without runtime metadata as idempotent', async () => {
+          it('treats deletion without ownership or runtime metadata as idempotent', async () => {
             const sessionId: SessionId = 'agent_00000000-0000-0000-0000-000000000000';
             vi.mocked(fetchSessionMetadata).mockResolvedValue(null);
+            requireCurrentSessionAccessMock.mockRejectedValue(
+              new TRPCError({ code: 'FORBIDDEN', message: 'Session access denied' })
+            );
 
-            const result = await caller.deleteSession({ sessionId });
+            try {
+              const result = await caller.deleteSession({ sessionId });
 
-            expect(result).toEqual({
-              success: true,
-              message: 'Session not found or already deleted',
-            });
-            expect(getSandbox).not.toHaveBeenCalled();
-            expect(cloudAgentSession.get).not.toHaveBeenCalled();
+              expect(result).toEqual({
+                success: true,
+                message: 'Session not found or already deleted',
+              });
+              expect(getSandbox).not.toHaveBeenCalled();
+              expect(cloudAgentSession.get).not.toHaveBeenCalled();
+            } finally {
+              requireCurrentSessionAccessMock.mockResolvedValue({
+                kiloSessionId: 'ses_12345678901234567890123456',
+                organizationId: null,
+              });
+            }
           });
         });
 
@@ -1667,6 +1687,34 @@ describe('router terminal procedures', () => {
     });
     expect(cloudAgentSession.idFromName).toHaveBeenCalledWith(`test-user-123:${sessionId}`);
     expect(createTerminal).toHaveBeenCalledWith({ cols: 120, rows: 32 });
+  });
+
+  it('denies terminal creation before Durable Object access', async () => {
+    requireCurrentSessionAccessMock.mockRejectedValueOnce(
+      new TRPCError({ code: 'FORBIDDEN', message: 'Session access denied' })
+    );
+    const cloudAgentSession: MockCAS = {
+      idFromName: vi.fn(),
+      get: vi.fn(),
+    };
+    const caller = appRouter.createCaller({
+      userId: 'test-user-123',
+      authToken: 'token',
+      botId: undefined,
+      request: new Request('http://test.local'),
+      env: { CLOUD_AGENT_SESSION: cloudAgentSession },
+    } as unknown as TRPCContext);
+
+    await expect(
+      caller.createTerminal({
+        cloudAgentSessionId: 'agent_12345678-1234-1234-1234-123456789abc',
+        cols: 120,
+        rows: 32,
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    expect(cloudAgentSession.idFromName).not.toHaveBeenCalled();
+    expect(cloudAgentSession.get).not.toHaveBeenCalled();
   });
 });
 

--- a/services/cloud-agent-next/src/router/handlers/session-execution.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-execution.ts
@@ -32,6 +32,7 @@ import type {
 } from '../../execution/types.js';
 import type { QueueAckResponse } from '../schemas.js';
 import { preflightPreparedInitialPromptModel } from '../../session/model-preflight.js';
+import { requireCurrentSessionAccess } from '../../session-access.js';
 
 function withLegacyExecutionId(ack: QueueAckResponse): LegacyExecutionResponse {
   return {
@@ -50,6 +51,12 @@ export function createSessionExecutionV2Handlers() {
           const sessionId = input.cloudAgentSessionId as SessionId;
           logger.setTags({ userId: ctx.userId, sessionId, preparedSession: true });
           logger.info('Initiating V2 session from prepared session');
+          await requireCurrentSessionAccess({
+            env: ctx.env,
+            kiloUserId: ctx.userId,
+            cloudAgentSessionId: input.cloudAgentSessionId,
+            validatedSessionAccess: ctx.validatedSessionAccess,
+          });
           const admissionInput = { cloudAgentSessionId: input.cloudAgentSessionId };
           const admissionContext = { env: ctx.env, userId: ctx.userId, botId: ctx.botId };
           const replay = await replayLegacyPreparedInitialMessageIfAlreadyAdmitted(
@@ -78,6 +85,12 @@ export function createSessionExecutionV2Handlers() {
           const sessionId = input.cloudAgentSessionId as SessionId;
           logger.setTags({ userId: ctx.userId, sessionId });
           logger.info('Sending V2 message to existing session');
+          await requireCurrentSessionAccess({
+            env: ctx.env,
+            kiloUserId: ctx.userId,
+            cloudAgentSessionId: input.cloudAgentSessionId,
+            validatedSessionAccess: ctx.validatedSessionAccess,
+          });
 
           const commandPayload =
             'payload' in input && input.payload.type === 'command' ? input.payload : undefined;

--- a/services/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-management.ts
@@ -27,6 +27,7 @@ import { readProfileBundle } from '../../session-profile.js';
 import type { CloudAgentSession } from '../../persistence/CloudAgentSession.js';
 import type { CloudAgentSessionState } from '../../persistence/types.js';
 import type { MessageResultRPCResponse } from '../../session/message-result.js';
+import { requireCurrentSessionAccess } from '../../session-access.js';
 
 function publicRepositoryFields(metadata: CloudAgentSessionState): {
   githubRepo?: string;
@@ -145,6 +146,11 @@ export function createSessionManagementHandlers() {
 
           logger.setTags({ userId, sessionId });
           logger.info('Starting session interruption');
+          await requireCurrentSessionAccess({
+            env,
+            kiloUserId: userId,
+            cloudAgentSessionId: sessionId,
+          });
 
           try {
             const metadata = await fetchSessionMetadata(env, userId, sessionId);
@@ -223,6 +229,11 @@ export function createSessionManagementHandlers() {
 
           logger.setTags({ userId, sessionId });
           logger.info('Fetching session metadata');
+          await requireCurrentSessionAccess({
+            env,
+            kiloUserId: userId,
+            cloudAgentSessionId: sessionId,
+          });
 
           // Get DO stub keyed by userId:sessionId for user isolation
           const doKey = `${userId}:${sessionId}`;
@@ -336,6 +347,11 @@ export function createSessionManagementHandlers() {
 
           logger.setTags({ userId, sessionId });
           logger.info('Fetching session health');
+          await requireCurrentSessionAccess({
+            env,
+            kiloUserId: userId,
+            cloudAgentSessionId: sessionId,
+          });
 
           const doKey = `${userId}:${sessionId}`;
           const getStub = () =>
@@ -412,6 +428,11 @@ export function createSessionManagementHandlers() {
         return withLogTags({ source: 'getMessageResult' }, async () => {
           const sessionId = input.cloudAgentSessionId as SessionId;
           const { userId, env } = ctx;
+          await requireCurrentSessionAccess({
+            env,
+            kiloUserId: userId,
+            cloudAgentSessionId: sessionId,
+          });
           const doKey = `${userId}:${sessionId}`;
           const getStub = () =>
             env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(doKey));
@@ -451,6 +472,11 @@ export function createSessionManagementHandlers() {
 
           logger.setTags({ userId, sessionId });
           logger.info('Fetching latest assistant message');
+          await requireCurrentSessionAccess({
+            env,
+            kiloUserId: userId,
+            cloudAgentSessionId: sessionId,
+          });
 
           const doKey = `${userId}:${sessionId}`;
           const getStub = () =>

--- a/services/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-management.ts
@@ -48,7 +48,8 @@ function publicRepositoryFields(metadata: CloudAgentSessionState): {
 async function deleteSessionResources(
   sessionId: SessionId,
   userId: string,
-  env: TRPCContext['env']
+  env: TRPCContext['env'],
+  authorizeExistingSession?: () => Promise<void>
 ): Promise<{ success: true; message?: string }> {
   logger.setTags({ userId, sessionId });
   logger.info('Starting session deletion');
@@ -59,6 +60,8 @@ async function deleteSessionResources(
       logger.info('Session not found or already deleted');
       return { success: true, message: 'Session not found or already deleted' };
     }
+
+    await authorizeExistingSession?.();
 
     try {
       const doKey = `${userId}:${sessionId}`;
@@ -111,8 +114,15 @@ export function createSessionManagementHandlers() {
         })
       )
       .mutation(async ({ input, ctx }) => {
+        const sessionId = input.sessionId as SessionId;
         return withLogTags({ source: 'deleteSession' }, () =>
-          deleteSessionResources(input.sessionId as SessionId, ctx.userId, ctx.env)
+          deleteSessionResources(sessionId, ctx.userId, ctx.env, async () => {
+            await requireCurrentSessionAccess({
+              env: ctx.env,
+              kiloUserId: ctx.userId,
+              cloudAgentSessionId: sessionId,
+            });
+          })
         );
       }),
 

--- a/services/cloud-agent-next/src/router/handlers/session-questions.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-questions.ts
@@ -7,6 +7,7 @@ import { fetchSessionMetadata } from '../../session-service.js';
 import { protectedProcedure } from '../auth.js';
 import { sessionIdSchema } from '../schemas.js';
 import type { WrapperClient } from '../../kilo/wrapper-client.js';
+import { requireCurrentSessionAccess } from '../../session-access.js';
 
 async function resolveWrapperClient(opts: {
   sessionId: SessionId;
@@ -14,6 +15,11 @@ async function resolveWrapperClient(opts: {
   env: Env;
 }): Promise<WrapperClient> {
   const { sessionId, userId, env } = opts;
+  await requireCurrentSessionAccess({
+    env,
+    kiloUserId: userId,
+    cloudAgentSessionId: sessionId,
+  });
   const metadata = await fetchSessionMetadata(env, userId, sessionId);
   if (!metadata) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Session not found' });

--- a/services/cloud-agent-next/src/router/handlers/session-send.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-send.ts
@@ -12,6 +12,7 @@ import { logger, withLogTags } from '../../logger.js';
 import { SendMessageInput, ExecutionResponse } from '../schemas.js';
 import { preflightAndQueuePromptMessage } from '../../session/queue-message.js';
 import type { SessionId } from '../../types/ids.js';
+import { requireCurrentSessionAccess } from '../../session-access.js';
 
 type SessionSendHandlers = {
   send: typeof sendMessageHandler;
@@ -29,6 +30,12 @@ const sendMessageHandler = protectedProcedure
       const sessionId = input.cloudAgentSessionId as SessionId;
       logger.setTags({ userId: ctx.userId, sessionId });
       logger.info('Sending message via unified send endpoint');
+      await requireCurrentSessionAccess({
+        env: ctx.env,
+        kiloUserId: ctx.userId,
+        cloudAgentSessionId: input.cloudAgentSessionId,
+        validatedSessionAccess: ctx.validatedSessionAccess,
+      });
       const queuedMessage = {
         cloudAgentSessionId: input.cloudAgentSessionId,
         turn: {

--- a/services/cloud-agent-next/src/router/handlers/session-terminal.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-terminal.ts
@@ -6,6 +6,7 @@ import type { WrapperPty } from '../../kilo/wrapper-client.js';
 import type { SessionId } from '../../types/ids.js';
 import { withDORetry } from '../../utils/do-retry.js';
 import { protectedProcedure } from '../auth.js';
+import { requireCurrentSessionAccess } from '../../session-access.js';
 import {
   CloseTerminalInput,
   CloseTerminalOutput,
@@ -49,6 +50,11 @@ export function createSessionTerminalHandlers() {
           const sessionId = input.cloudAgentSessionId as SessionId;
           logger.setTags({ userId: ctx.userId, sessionId });
           logger.withFields({ cols: input.cols, rows: input.rows }).info('Creating terminal');
+          await requireCurrentSessionAccess({
+            env: ctx.env,
+            kiloUserId: ctx.userId,
+            cloudAgentSessionId: sessionId,
+          });
 
           const result = await withDORetry<
             DurableObjectStub<CloudAgentSession>,
@@ -79,6 +85,11 @@ export function createSessionTerminalHandlers() {
         return withLogTags({ source: 'resizeTerminal' }, async () => {
           const sessionId = input.cloudAgentSessionId as SessionId;
           logger.setTags({ userId: ctx.userId, sessionId, ptyId: input.ptyId });
+          await requireCurrentSessionAccess({
+            env: ctx.env,
+            kiloUserId: ctx.userId,
+            cloudAgentSessionId: sessionId,
+          });
           const result = await withDORetry<
             DurableObjectStub<CloudAgentSession>,
             OperationResult<{ pty: WrapperPty }>
@@ -109,6 +120,11 @@ export function createSessionTerminalHandlers() {
           const sessionId = input.cloudAgentSessionId as SessionId;
           logger.setTags({ userId: ctx.userId, sessionId, ptyId: input.ptyId });
           logger.info('Closing terminal');
+          await requireCurrentSessionAccess({
+            env: ctx.env,
+            kiloUserId: ctx.userId,
+            cloudAgentSessionId: sessionId,
+          });
 
           const result = await withDORetry<
             DurableObjectStub<CloudAgentSession>,

--- a/services/cloud-agent-next/src/server.test.ts
+++ b/services/cloud-agent-next/src/server.test.ts
@@ -6,10 +6,12 @@ const {
   getRunningTerminalClientMock,
   consumeCloudAgentReportBatchMock,
   removeExpiredCloudAgentReportDataMock,
+  requireCurrentSessionAccessMock,
 } = vi.hoisted(() => ({
   getRunningTerminalClientMock: vi.fn(),
   consumeCloudAgentReportBatchMock: vi.fn().mockResolvedValue(undefined),
   removeExpiredCloudAgentReportDataMock: vi.fn().mockResolvedValue(undefined),
+  requireCurrentSessionAccessMock: vi.fn(),
 }));
 
 vi.mock('./logger.js', () => {
@@ -73,6 +75,19 @@ vi.mock('./middleware/balance.js', () => ({
   balanceMiddleware: vi.fn(),
 }));
 
+vi.mock('./session-access.js', () => ({
+  requireCurrentSessionAccess: requireCurrentSessionAccessMock,
+  projectSessionAccessHttpError: (error: unknown) =>
+    new Response(
+      error instanceof Error && 'code' in error && error.code === 'FORBIDDEN'
+        ? 'Session access denied'
+        : 'Session access is temporarily unavailable',
+      {
+        status: error instanceof Error && 'code' in error && error.code === 'FORBIDDEN' ? 403 : 503,
+      }
+    ),
+}));
+
 vi.mock('./persistence/CloudAgentSession.js', () => ({
   CloudAgentSession: class CloudAgentSession {},
 }));
@@ -131,6 +146,10 @@ beforeEach(() => {
   getRunningTerminalClientMock.mockReset();
   consumeCloudAgentReportBatchMock.mockClear();
   removeExpiredCloudAgentReportDataMock.mockClear();
+  requireCurrentSessionAccessMock.mockReset().mockResolvedValue({
+    kiloSessionId: 'ses_12345678901234567890123456',
+    organizationId: null,
+  });
 });
 
 describe('server /stream', () => {
@@ -156,6 +175,34 @@ describe('server /stream', () => {
 
     expect(response.status).toBe(401);
     await expect(response.text()).resolves.toBe('Ticket expired');
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+    expect(env.CLOUD_AGENT_SESSION.get).not.toHaveBeenCalled();
+  });
+
+  it('rejects a valid ticket when current session access has been removed', async () => {
+    const ticket = jwt.sign(
+      {
+        type: 'stream_ticket',
+        userId: 'user-1',
+        kiloSessionId: 'ses_12345678901234567890123456',
+        cloudAgentSessionId: 'session-1',
+      },
+      secret,
+      { algorithm: 'HS256', expiresIn: 60 }
+    );
+    const env = createEnv();
+    requireCurrentSessionAccessMock.mockRejectedValue(
+      Object.assign(new Error('Session access denied'), { code: 'FORBIDDEN' })
+    );
+    const request = new Request(
+      `http://worker.test/stream?cloudAgentSessionId=session-1&ticket=${encodeURIComponent(ticket)}`,
+      { headers: { Upgrade: 'websocket' } }
+    );
+
+    const response = await fetchWorker(request, env);
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe('Session access denied');
     expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
     expect(env.CLOUD_AGENT_SESSION.get).not.toHaveBeenCalled();
   });
@@ -266,6 +313,35 @@ describe('server /terminal', () => {
     expect(fetch).not.toHaveBeenCalled();
     expect(getRunningTerminalClientMock).toHaveBeenCalledOnce();
     expect(connectTerminal).toHaveBeenCalledWith('pty_123', request);
+  });
+
+  it('rejects removed session access before Durable Object lookup', async () => {
+    const ticket = jwt.sign(
+      {
+        type: 'stream_ticket',
+        purpose: 'terminal',
+        userId: 'user-1',
+        cloudAgentSessionId: 'session-1',
+        ptyId: 'pty_123',
+      },
+      secret,
+      { algorithm: 'HS256', expiresIn: 60 }
+    );
+    requireCurrentSessionAccessMock.mockRejectedValue(
+      Object.assign(new Error('Session access denied'), { code: 'FORBIDDEN' })
+    );
+    const env = createEnv();
+    const request = new Request(
+      `http://worker.test/terminal?cloudAgentSessionId=session-1&ptyId=pty_123&ticket=${encodeURIComponent(ticket)}`,
+      { headers: { Upgrade: 'websocket' } }
+    );
+
+    const response = await fetchWorker(request, env);
+
+    expect(response.status).toBe(403);
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+    expect(env.CLOUD_AGENT_SESSION.get).not.toHaveBeenCalled();
+    expect(getRunningTerminalClientMock).not.toHaveBeenCalled();
   });
 
   it('rejects stream-purpose tickets', async () => {

--- a/services/cloud-agent-next/src/server.ts
+++ b/services/cloud-agent-next/src/server.ts
@@ -19,6 +19,7 @@ import { balanceMiddleware } from './middleware/balance.js';
 import { resolveTerminalWrapperClient } from './terminal/access.js';
 import { requestMethodAllowsBody } from './shared/http-proxy.js';
 import { hasDuplicateQueryParameters } from './shared/http-query.js';
+import { projectSessionAccessHttpError, requireCurrentSessionAccess } from './session-access.js';
 import {
   KILO_FACADE_AUTH_TOKEN_HEADER,
   KILO_FACADE_GLOBAL_FEED_PATH,
@@ -98,6 +99,18 @@ async function handleTerminalWebSocket(request: Request, env: Env): Promise<Resp
   if (ticketResult.payload.ptyId !== ptyId) {
     logger.withFields({ cloudAgentSessionId, userId, ptyId }).warn('/terminal: PTY mismatch');
     return new Response('PTY mismatch', { status: 403 });
+  }
+
+  try {
+    await requireCurrentSessionAccess({
+      env,
+      kiloUserId: userId,
+      cloudAgentSessionId,
+      expectedOrganizationId: ticketResult.payload.organizationId ?? null,
+      expectedKiloSessionId: ticketResult.payload.kiloSessionId,
+    });
+  } catch (error) {
+    return projectSessionAccessHttpError(error);
   }
 
   logger.withFields({ cloudAgentSessionId, userId, ptyId }).info('/terminal: WebSocket authorized');
@@ -234,6 +247,18 @@ app.get('/stream', async (c: Context<HonoContext>) => {
     return c.text('Session mismatch', 403);
   }
 
+  try {
+    await requireCurrentSessionAccess({
+      env: c.env,
+      kiloUserId: userId,
+      cloudAgentSessionId,
+      expectedOrganizationId: ticketResult.payload.organizationId ?? null,
+      expectedKiloSessionId: ticketResult.payload.kiloSessionId,
+    });
+  } catch (error) {
+    return projectSessionAccessHttpError(error);
+  }
+
   logger.withFields({ cloudAgentSessionId, userId }).info('/stream: WebSocket upgrade authorized');
 
   const doId = c.env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${cloudAgentSessionId}`);
@@ -295,6 +320,17 @@ app.all('/sessions/:userId/:sessionId/kilo-global-ingest', async (c: Context<Hon
     return c.text('Invalid global feed producer identity', 400);
   }
 
+  try {
+    await requireCurrentSessionAccess({
+      env: c.env,
+      kiloUserId: userId,
+      cloudAgentSessionId,
+      expectedKiloSessionId: kiloSessionId,
+    });
+  } catch (error) {
+    return projectSessionAccessHttpError(error);
+  }
+
   const sessionDoId = c.env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${cloudAgentSessionId}`);
   const sessionStub = c.env.CLOUD_AGENT_SESSION.get(sessionDoId);
   const validation = await sessionStub.validateKiloGlobalFeedProducer({
@@ -352,6 +388,16 @@ app.all('/sessions/:userId/:sessionId/ingest', async (c: Context<HonoContext>) =
     return c.text('Token does not match session user', 403);
   }
 
+  try {
+    await requireCurrentSessionAccess({
+      env: c.env,
+      kiloUserId: userId,
+      cloudAgentSessionId: sessionId,
+    });
+  } catch (error) {
+    return projectSessionAccessHttpError(error);
+  }
+
   const doId = c.env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
   const stub = c.env.CLOUD_AGENT_SESSION.get(doId);
   const doUrl = new URL(c.req.url);
@@ -392,6 +438,16 @@ app.put(
     }
     if (authResult.userId !== userId) {
       return c.text('Token does not match session user', 403);
+    }
+
+    try {
+      await requireCurrentSessionAccess({
+        env: c.env,
+        kiloUserId: userId,
+        cloudAgentSessionId: sessionId,
+      });
+    } catch (error) {
+      return projectSessionAccessHttpError(error);
     }
 
     const contentLength = parseInt(c.req.header('Content-Length') ?? '', 10);
@@ -442,6 +498,7 @@ app.use(
       userId: c.get('userId'),
       authToken: c.get('authToken'),
       botId: c.get('botId'),
+      validatedSessionAccess: c.get('validatedSessionAccess'),
       request: c.req.raw,
     }),
     onError: ({ error, path }: { error: Error; path?: string }) => {

--- a/services/cloud-agent-next/src/session-access.test.ts
+++ b/services/cloud-agent-next/src/session-access.test.ts
@@ -1,0 +1,153 @@
+import { TRPCError } from '@trpc/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from './types.js';
+
+const { queryAccessibleCloudAgentSessionMock } = vi.hoisted(() => ({
+  queryAccessibleCloudAgentSessionMock: vi.fn(),
+}));
+
+vi.mock('@kilocode/db/client', () => ({
+  getWorkerDb: vi.fn(() => ({ select: vi.fn() })),
+}));
+
+vi.mock('@kilocode/worker-utils/cloud-agent-session-access', () => ({
+  queryAccessibleCloudAgentSession: queryAccessibleCloudAgentSessionMock,
+}));
+
+const { projectSessionAccessHttpError, requireCurrentSessionAccess } =
+  await import('./session-access.js');
+
+function createEnv(): Pick<Env, 'HYPERDRIVE'> {
+  return {
+    HYPERDRIVE: { connectionString: 'postgres://test' } as Hyperdrive,
+  };
+}
+
+describe('requireCurrentSessionAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the authoritative current session identity', async () => {
+    queryAccessibleCloudAgentSessionMock.mockResolvedValue({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org_current',
+    });
+
+    await expect(
+      requireCurrentSessionAccess({
+        env: createEnv(),
+        kiloUserId: 'usr_owner',
+        cloudAgentSessionId: 'agent_owned',
+        expectedOrganizationId: 'org_current',
+        expectedKiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).resolves.toEqual({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org_current',
+    });
+  });
+
+  it('reuses session access already validated for the same request', async () => {
+    const validatedSessionAccess = {
+      kiloUserId: 'usr_owner',
+      cloudAgentSessionId: 'agent_owned',
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org_current',
+    };
+
+    await expect(
+      requireCurrentSessionAccess({
+        env: createEnv(),
+        kiloUserId: 'usr_owner',
+        cloudAgentSessionId: 'agent_owned',
+        expectedOrganizationId: 'org_current',
+        expectedKiloSessionId: 'ses_12345678901234567890123456',
+        validatedSessionAccess,
+      })
+    ).resolves.toEqual({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org_current',
+    });
+    expect(queryAccessibleCloudAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('queries current access when validated access belongs to another session', async () => {
+    queryAccessibleCloudAgentSessionMock.mockResolvedValue({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: null,
+    });
+
+    await expect(
+      requireCurrentSessionAccess({
+        env: createEnv(),
+        kiloUserId: 'usr_owner',
+        cloudAgentSessionId: 'agent_owned',
+        validatedSessionAccess: {
+          kiloUserId: 'usr_owner',
+          cloudAgentSessionId: 'agent_other',
+          kiloSessionId: 'ses_00000000000000000000000000',
+          organizationId: null,
+        },
+      })
+    ).resolves.toEqual({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: null,
+    });
+    expect(queryAccessibleCloudAgentSessionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ cloudAgentSessionId: 'agent_owned' })
+    );
+  });
+
+  it.each([
+    ['missing access', null, {}],
+    [
+      'organization mismatch',
+      { kiloSessionId: 'ses_12345678901234567890123456', organizationId: 'org_other' },
+      { expectedOrganizationId: 'org_current' },
+    ],
+    [
+      'Kilo session mismatch',
+      { kiloSessionId: 'ses_12345678901234567890123456', organizationId: null },
+      { expectedKiloSessionId: 'ses_00000000000000000000000000' },
+    ],
+  ])('denies %s', async (_name, result, expected) => {
+    queryAccessibleCloudAgentSessionMock.mockResolvedValue(result);
+
+    await expect(
+      requireCurrentSessionAccess({
+        env: createEnv(),
+        kiloUserId: 'usr_owner',
+        cloudAgentSessionId: 'agent_owned',
+        ...expected,
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('fails closed when current access cannot be resolved', async () => {
+    queryAccessibleCloudAgentSessionMock.mockRejectedValue(new Error('database unavailable'));
+
+    await expect(
+      requireCurrentSessionAccess({
+        env: createEnv(),
+        kiloUserId: 'usr_owner',
+        cloudAgentSessionId: 'agent_owned',
+      })
+    ).rejects.toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
+  });
+});
+
+describe('projectSessionAccessHttpError', () => {
+  it('projects authorization failures without exposing infrastructure errors', async () => {
+    const denied = projectSessionAccessHttpError(
+      new TRPCError({ code: 'FORBIDDEN', message: 'Session access denied' })
+    );
+    const unavailable = projectSessionAccessHttpError(new Error('database unavailable'));
+
+    expect(denied.status).toBe(403);
+    await expect(denied.text()).resolves.toBe('Session access denied');
+    expect(unavailable.status).toBe(503);
+    await expect(unavailable.text()).resolves.toBe('Session access is temporarily unavailable');
+  });
+});

--- a/services/cloud-agent-next/src/session-access.ts
+++ b/services/cloud-agent-next/src/session-access.ts
@@ -1,0 +1,71 @@
+import { getWorkerDb } from '@kilocode/db/client';
+import { TRPCError } from '@trpc/server';
+import {
+  queryAccessibleCloudAgentSession,
+  type AccessibleCloudAgentSession,
+} from '@kilocode/worker-utils/cloud-agent-session-access';
+import type { Env, ValidatedSessionAccess } from './types.js';
+
+type CurrentSessionAccessRequest = {
+  env: Pick<Env, 'HYPERDRIVE'>;
+  kiloUserId: string;
+  cloudAgentSessionId: string;
+  expectedOrganizationId?: string | null;
+  expectedKiloSessionId?: string;
+  validatedSessionAccess?: ValidatedSessionAccess;
+};
+
+function matchesExpectedSession(
+  session: AccessibleCloudAgentSession,
+  request: CurrentSessionAccessRequest
+): boolean {
+  return (
+    (request.expectedOrganizationId === undefined ||
+      session.organizationId === request.expectedOrganizationId) &&
+    (request.expectedKiloSessionId === undefined ||
+      session.kiloSessionId === request.expectedKiloSessionId)
+  );
+}
+
+export async function requireCurrentSessionAccess(
+  request: CurrentSessionAccessRequest
+): Promise<AccessibleCloudAgentSession> {
+  const validatedSessionAccess = request.validatedSessionAccess;
+  if (
+    validatedSessionAccess?.kiloUserId === request.kiloUserId &&
+    validatedSessionAccess.cloudAgentSessionId === request.cloudAgentSessionId &&
+    matchesExpectedSession(validatedSessionAccess, request)
+  ) {
+    return {
+      kiloSessionId: validatedSessionAccess.kiloSessionId,
+      organizationId: validatedSessionAccess.organizationId,
+    };
+  }
+
+  let session: AccessibleCloudAgentSession | null;
+  try {
+    const db = getWorkerDb(request.env.HYPERDRIVE.connectionString);
+    session = await queryAccessibleCloudAgentSession(db, {
+      kiloUserId: request.kiloUserId,
+      cloudAgentSessionId: request.cloudAgentSessionId,
+    });
+  } catch {
+    throw new TRPCError({
+      code: 'SERVICE_UNAVAILABLE',
+      message: 'Session access is temporarily unavailable',
+    });
+  }
+
+  if (!session || !matchesExpectedSession(session, request)) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'Session access denied' });
+  }
+
+  return session;
+}
+
+export function projectSessionAccessHttpError(error: unknown): Response {
+  if (error instanceof TRPCError && error.code === 'FORBIDDEN') {
+    return new Response('Session access denied', { status: 403 });
+  }
+  return new Response('Session access is temporarily unavailable', { status: 503 });
+}

--- a/services/cloud-agent-next/src/types.ts
+++ b/services/cloud-agent-next/src/types.ts
@@ -1,6 +1,7 @@
 import type { getSandbox, ExecutionSession, Sandbox } from '@cloudflare/sandbox';
 import type { CloudAgentSession } from './persistence/CloudAgentSession.js';
 import type { CloudAgentQueueReport } from '@kilocode/worker-utils/cloud-agent-queue-report';
+import type { AccessibleCloudAgentSession } from '@kilocode/worker-utils/cloud-agent-session-access';
 import type { UserKiloFacade } from './kilo-facade/user-kilo-facade.js';
 import type { CallbackJob } from './callbacks/index.js';
 import type { NotificationsBinding } from './notifications-binding.js';
@@ -258,6 +259,11 @@ export type Env = {
   HYPERDRIVE: Hyperdrive;
 };
 
+export type ValidatedSessionAccess = AccessibleCloudAgentSession & {
+  kiloUserId: string;
+  cloudAgentSessionId: string;
+};
+
 /** tRPC context passed to all procedures */
 export type TRPCContext = {
   env: Env;
@@ -265,6 +271,7 @@ export type TRPCContext = {
   request: Request;
   authToken: string;
   botId?: string;
+  validatedSessionAccess?: ValidatedSessionAccess;
 };
 
 export type SystemSandboxUsageEvent = {

--- a/services/git-token-service/src/installation-lookup-service.behavior.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.behavior.test.ts
@@ -160,7 +160,7 @@ describe('InstallationLookupService', () => {
     });
   });
 
-  it('accepts selected repository metadata with a stale owner after account rename', async () => {
+  it('rejects selected repository metadata for a different owner', async () => {
     const service = createService([
       {
         platform_installation_id: '100',
@@ -168,7 +168,7 @@ describe('InstallationLookupService', () => {
         github_app_type: 'standard',
         owned_by_organization_id: null,
         repository_access: 'selected',
-        repositories: [{ full_name: 'pre-rename-owner/repository' }],
+        repositories: [{ full_name: 'other-owner/repository' }],
         permissions: { contents: 'write', pull_requests: 'write' },
       },
     ]);
@@ -178,14 +178,7 @@ describe('InstallationLookupService', () => {
       userId: 'user-1',
     });
 
-    expect(result).toEqual({
-      success: true,
-      installationId: '100',
-      accountLogin: 'renamed-owner',
-      githubAppType: 'standard',
-      repoName: 'repository',
-      permissions: { contents: 'write', pull_requests: 'write' },
-    });
+    expect(result).toEqual({ success: false, reason: 'repository_not_installed' });
   });
 
   it('fails closed when organization and personal installations both match the requested owner', async () => {

--- a/services/git-token-service/src/installation-lookup-service.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.test.ts
@@ -33,9 +33,17 @@ describe('buildInstallationLookupQuery', () => {
     expect(query.sql).toContain('"organization_memberships"."id" is not null');
     expect(query.sql).toContain('"platform_integrations"."owned_by_organization_id" =');
     expect(query.sql).toContain('"platform_integrations"."owned_by_user_id" =');
-    expect(query.params.filter(param => param === 'user-1')).toHaveLength(3);
+    expect(query.params.filter(param => param === 'user-1')).toHaveLength(4);
     expect(query.params).toContain('00000000-0000-4000-8000-000000000001');
     expect(query.params).toContain(2);
+  });
+
+  it('requires current membership for every organization-scoped credential candidate', () => {
+    const query = buildQuery();
+
+    expect(query.sql).toContain('exists (select');
+    expect(query.params.filter(param => param === params.orgId)).toHaveLength(2);
+    expect(query.params.filter(param => param === params.userId)).toHaveLength(4);
   });
 
   it('loads up to ten authorized repair candidates without relying on stale account login metadata', () => {

--- a/services/git-token-service/src/installation-lookup-service.ts
+++ b/services/git-token-service/src/installation-lookup-service.ts
@@ -5,7 +5,7 @@ import {
   organization_memberships,
   kilocode_users,
 } from '@kilocode/db/schema';
-import { eq, and, isNull, isNotNull, or, sql } from 'drizzle-orm';
+import { eq, and, exists, isNull, isNotNull, or, sql } from 'drizzle-orm';
 
 export type FindInstallationParams = {
   githubRepo: string;
@@ -87,6 +87,20 @@ function buildAuthorizedInstallationsQuery(
     repoOwner === undefined
       ? undefined
       : sql`lower(${platform_integrations.platform_account_login}) = lower(${repoOwner})`;
+  const requestedOrganizationMembership =
+    params.orgId === undefined
+      ? undefined
+      : exists(
+          db
+            .select({ id: organization_memberships.id })
+            .from(organization_memberships)
+            .where(
+              and(
+                eq(organization_memberships.organization_id, sql`${params.orgId}::uuid`),
+                eq(organization_memberships.kilo_user_id, params.userId)
+              )
+            )
+        );
 
   return db
     .select({
@@ -121,6 +135,7 @@ function buildAuthorizedInstallationsQuery(
         eq(platform_integrations.integration_status, 'active'),
         accountLoginFilter,
         isNotNull(platform_integrations.platform_installation_id),
+        requestedOrganizationMembership,
         or(
           and(
             isNotNull(platform_integrations.owned_by_organization_id),

--- a/services/git-token-service/src/installation-lookup-service.ts
+++ b/services/git-token-service/src/installation-lookup-service.ts
@@ -308,15 +308,9 @@ export class InstallationLookupService {
 
     if (
       selected.repository_access === 'selected' &&
-      !selected.repositories?.some(repository => {
-        const [storedOwner, storedRepoName, ...unexpectedParts] = repository.full_name.split('/');
-        return (
-          storedOwner !== undefined &&
-          storedOwner.length > 0 &&
-          storedRepoName?.toLowerCase() === repoName.toLowerCase() &&
-          unexpectedParts.length === 0
-        );
-      })
+      !selected.repositories?.some(
+        repository => repository.full_name.toLowerCase() === params.githubRepo.toLowerCase()
+      )
     ) {
       return { success: false, reason: 'repository_not_installed' };
     }


### PR DESCRIPTION
## Summary

- Require the session creator and current organization membership before Cloud Agent API, Durable Object, ingest, terminal, and WebSocket access.
- Centralize the authoritative Postgres access query across the web app and Cloud Agent Next, while reusing access validated by balance middleware within the same request.
- Require current organization membership when resolving organization-scoped Git credentials.

## Verification

- [x] Tested locally by removing an organization member and then calling Cloud Agent APIs; confirmed the requests were denied after membership removal.

## Visual Changes

N/A

## Reviewer Notes

Existing open sockets are not actively revoked; current access is checked on each new API call or WebSocket upgrade.