### PR TITLE
GitLab - Search cached active repositories

### DIFF
--- a/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
+++ b/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useMemo, useState } from 'react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Lock, Unlock, Search, Loader2 } from 'lucide-react';
+import { Lock, Unlock, Search } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export type Repository = {
@@ -18,86 +18,21 @@ export type RepositoryMultiSelectProps = {
   repositories: Repository[];
   selectedIds: number[];
   onSelectionChange: (selectedIds: number[]) => void;
-  /** Callback when a repository from API search results is added to the list */
-  onAddFromSearch?: (repo: Repository) => void;
-  /** Callback to search for repositories via API (for GitLab with 100+ repos) */
-  onSearch?: (query: string) => Promise<Repository[]>;
 };
-
-/**
- * Custom hook for debouncing a value
- */
-function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value);
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [value, delay]);
-
-  return debouncedValue;
-}
 
 export function RepositoryMultiSelect({
   repositories,
   selectedIds,
   onSelectionChange,
-  onAddFromSearch,
-  onSearch,
 }: RepositoryMultiSelectProps) {
   const [searchQuery, setSearchQuery] = useState('');
-  const [isSearching, setIsSearching] = useState(false);
-  const [apiSearchResults, setApiSearchResults] = useState<Repository[]>([]);
 
-  // Debounce search query for API calls
-  const debouncedSearchQuery = useDebounce(searchQuery, 300);
-
-  // Filter local repositories based on search query (instant)
-  const filteredLocalRepositories = useMemo(() => {
+  const filteredRepositories = useMemo(() => {
     if (!searchQuery.trim()) return repositories;
 
     const query = searchQuery.toLowerCase();
     return repositories.filter(repo => repo.full_name.toLowerCase().includes(query));
   }, [repositories, searchQuery]);
-
-  // Perform API search when debounced query changes
-  const performApiSearch = useCallback(
-    async (query: string) => {
-      if (!onSearch || query.length < 2) {
-        setApiSearchResults([]);
-        return;
-      }
-
-      setIsSearching(true);
-      try {
-        const results = await onSearch(query);
-        // Filter out repos that are already in the local list
-        const localIds = new Set(repositories.map(r => r.id));
-        const newResults = results.filter(r => !localIds.has(r.id));
-        setApiSearchResults(newResults);
-      } catch (error) {
-        console.error('API search failed:', error);
-        setApiSearchResults([]);
-      } finally {
-        setIsSearching(false);
-      }
-    },
-    [onSearch, repositories]
-  );
-
-  // Trigger API search when debounced query changes
-  useEffect(() => {
-    if (debouncedSearchQuery.length >= 2 && onSearch) {
-      void performApiSearch(debouncedSearchQuery);
-    } else {
-      setApiSearchResults([]);
-    }
-  }, [debouncedSearchQuery, performApiSearch, onSearch]);
 
   const handleToggle = (repoId: number) => {
     const newSelection = selectedIds.includes(repoId)
@@ -118,24 +53,8 @@ export function RepositoryMultiSelect({
   const isAllSelected = selectedIds.length === repositories.length && repositories.length > 0;
   const isNoneSelected = selectedIds.length === 0;
 
-  // Handle selecting a repo from API search results
-  const handleSelectSearchResult = (repo: Repository) => {
-    // Add to the repository list via callback if provided
-    if (onAddFromSearch) {
-      onAddFromSearch(repo);
-    }
-    // Also select it
-    if (!selectedIds.includes(repo.id)) {
-      onSelectionChange([...selectedIds, repo.id]);
-    }
-  };
-
-  const hasApiResults = apiSearchResults.length > 0;
-  const showApiSection = onSearch && (isSearching || hasApiResults) && searchQuery.length >= 2;
-
   return (
     <div className="space-y-3">
-      {/* Search Input */}
       <div className="relative">
         <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
         <Input
@@ -145,12 +64,8 @@ export function RepositoryMultiSelect({
           onChange={e => setSearchQuery(e.target.value)}
           className="pl-9"
         />
-        {isSearching && (
-          <Loader2 className="text-muted-foreground absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 animate-spin" />
-        )}
       </div>
 
-      {/* Select All / Deselect All */}
       <div className="flex flex-wrap gap-2">
         <Button
           type="button"
@@ -174,103 +89,47 @@ export function RepositoryMultiSelect({
         </Button>
       </div>
 
-      {/* Repository List */}
       <div className="border-border bg-background h-64 overflow-y-auto rounded-md border">
         <div className="space-y-3 p-4">
-          {/* Local Results */}
-          {filteredLocalRepositories.length === 0 && !showApiSection ? (
+          {filteredRepositories.length === 0 ? (
             <div className="text-muted-foreground py-8 text-center text-sm">
               {searchQuery ? 'No repositories match your search' : 'No repositories available'}
             </div>
           ) : (
-            <>
-              {filteredLocalRepositories.map(repo => {
-                const isChecked = selectedIds.includes(repo.id);
+            filteredRepositories.map(repo => {
+              const isChecked = selectedIds.includes(repo.id);
 
-                return (
-                  <div
-                    key={repo.id}
-                    className={cn(
-                      'hover:bg-accent flex items-center gap-3 rounded-md p-2 transition-colors',
-                      isChecked && 'bg-accent text-accent-foreground'
-                    )}
+              return (
+                <div
+                  key={repo.id}
+                  className={cn(
+                    'hover:bg-accent flex items-center gap-3 rounded-md p-2 transition-colors',
+                    isChecked && 'bg-accent text-accent-foreground'
+                  )}
+                >
+                  <Checkbox
+                    id={`repo-${repo.id}`}
+                    checked={isChecked}
+                    onCheckedChange={() => handleToggle(repo.id)}
+                  />
+                  <label
+                    htmlFor={`repo-${repo.id}`}
+                    className="flex flex-1 cursor-pointer items-center gap-2 text-sm"
                   >
-                    <Checkbox
-                      id={`repo-${repo.id}`}
-                      checked={isChecked}
-                      onCheckedChange={() => handleToggle(repo.id)}
-                    />
-                    <label
-                      htmlFor={`repo-${repo.id}`}
-                      className="flex flex-1 cursor-pointer items-center gap-2 text-sm"
-                    >
-                      {repo.private ? (
-                        <Lock className="text-primary h-3.5 w-3.5 shrink-0" />
-                      ) : (
-                        <Unlock className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-                      )}
-                      <span className="truncate font-mono">{repo.full_name}</span>
-                    </label>
-                  </div>
-                );
-              })}
-
-              {/* API Search Results Section */}
-              {showApiSection && (
-                <>
-                  <div className="border-border my-3 flex items-center gap-2 border-t pt-3">
-                    <span className="text-muted-foreground text-xs">
-                      {isSearching ? (
-                        <span className="flex items-center gap-1">
-                          <Loader2 className="h-3 w-3 animate-spin" />
-                          Searching...
-                        </span>
-                      ) : hasApiResults ? (
-                        `${apiSearchResults.length} additional result${apiSearchResults.length === 1 ? '' : 's'}`
-                      ) : (
-                        'No additional results'
-                      )}
-                    </span>
-                  </div>
-
-                  {apiSearchResults.map(repo => {
-                    const isChecked = selectedIds.includes(repo.id);
-
-                    return (
-                      <div
-                        key={`api-${repo.id}`}
-                        className={cn(
-                          'hover:bg-accent flex items-center gap-3 rounded-md p-2 transition-colors',
-                          isChecked && 'bg-accent text-accent-foreground'
-                        )}
-                      >
-                        <Checkbox
-                          id={`api-repo-${repo.id}`}
-                          checked={isChecked}
-                          onCheckedChange={() => handleSelectSearchResult(repo)}
-                        />
-                        <label
-                          htmlFor={`api-repo-${repo.id}`}
-                          className="flex flex-1 cursor-pointer items-center gap-2 text-sm"
-                        >
-                          {repo.private ? (
-                            <Lock className="text-primary h-3.5 w-3.5 shrink-0" />
-                          ) : (
-                            <Unlock className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-                          )}
-                          <span className="truncate font-mono">{repo.full_name}</span>
-                        </label>
-                      </div>
-                    );
-                  })}
-                </>
-              )}
-            </>
+                    {repo.private ? (
+                      <Lock className="text-primary h-3.5 w-3.5 shrink-0" />
+                    ) : (
+                      <Unlock className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+                    )}
+                    <span className="truncate font-mono">{repo.full_name}</span>
+                  </label>
+                </div>
+              );
+            })
           )}
         </div>
       </div>
 
-      {/* Selection Count */}
       <div className="text-muted-foreground text-xs">
         {selectedIds.length} of {repositories.length} repositories selected
       </div>

--- a/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
@@ -19,7 +19,7 @@ import {
   ChevronDown,
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
-import { useTRPC, useRawTRPCClient } from '@/lib/trpc/utils';
+import { useTRPC } from '@/lib/trpc/utils';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -29,7 +29,7 @@ import { useRefreshRepositories } from '@/hooks/useRefreshRepositories';
 import { useOrganizationModels } from '@/components/cloud-agent/hooks/useOrganizationModels';
 import { ModelCombobox } from '@/components/shared/ModelCombobox';
 import { cn } from '@/lib/utils';
-import { RepositoryMultiSelect, type Repository } from './RepositoryMultiSelect';
+import { RepositoryMultiSelect } from './RepositoryMultiSelect';
 import { CodeReviewActionRequiredAlert } from './CodeReviewActionRequiredAlert';
 import { PRIMARY_DEFAULT_MODEL } from '@/lib/ai-gateway/models';
 import {
@@ -101,7 +101,6 @@ export function ReviewConfigForm({
   gitlabStatusData,
 }: ReviewConfigFormProps) {
   const trpc = useTRPC();
-  const trpcClient = useRawTRPCClient();
   const queryClient = useQueryClient();
   const isGitLab = platform === 'gitlab';
   const platformLabel = isGitLab ? 'GitLab' : 'GitHub';
@@ -211,8 +210,6 @@ export function ReviewConfigForm({
   const [repositorySelectionMode, setRepositorySelectionMode] = useState<'all' | 'selected'>('all');
   const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
   const [useReviewMd, setUseReviewMd] = useState(true);
-  // Repositories added from search results (for GitLab where pagination limits initial results)
-  const [searchAddedRepos, setSearchAddedRepos] = useState<Repository[]>([]);
   // GitLab-specific: auto-configure webhooks
   const [autoConfigureWebhooks, setAutoConfigureWebhooks] = useState(true);
   // Webhook sync result from last save
@@ -312,17 +309,6 @@ export function ReviewConfigForm({
       setRepositorySelectionMode(isGitLab ? 'selected' : repoMode);
       setSelectedRepositoryIds(configData.selectedRepositoryIds || []);
       setUseReviewMd(!(configData.disableReviewMd ?? false));
-      // Load repositories that were added from search results
-      if (configData.manuallyAddedRepositories) {
-        setSearchAddedRepos(
-          configData.manuallyAddedRepositories.map(repo => ({
-            id: repo.id,
-            name: repo.name,
-            full_name: repo.full_name,
-            private: repo.private,
-          }))
-        );
-      }
     }
   }, [configData, isGitLab]);
 
@@ -439,14 +425,8 @@ export function ReviewConfigForm({
     // Clear previous webhook sync result
     setWebhookSyncResult(null);
 
-    // Convert search-added repos to the format expected by the API
-    // Note: The API field is still called manuallyAddedRepositories for backwards compatibility
-    const manuallyAddedRepositories = searchAddedRepos.map(repo => ({
-      id: repo.id,
-      name: repo.name,
-      full_name: repo.full_name,
-      private: repo.private,
-    }));
+    // Preserve legacy live-search selections until their persisted contract is migrated.
+    const manuallyAddedRepositories = configData?.manuallyAddedRepositories ?? [];
 
     if (organizationId) {
       orgSaveMutation.mutate({
@@ -740,59 +720,14 @@ export function ReviewConfigForm({
                   {(isGitLab || repositorySelectionMode === 'selected') && (
                     <div className="mt-4">
                       <RepositoryMultiSelect
-                        repositories={
-                          [
-                            ...repositoriesData.repositories.map(repo => ({
-                              id: repo.id,
-                              name: repo.name,
-                              full_name: repo.fullName,
-                              private: repo.private,
-                            })),
-                            ...searchAddedRepos,
-                          ] as Repository[]
-                        }
+                        repositories={repositoriesData.repositories.map(repo => ({
+                          id: repo.id,
+                          name: repo.name,
+                          full_name: repo.fullName,
+                          private: repo.private,
+                        }))}
                         selectedIds={selectedRepositoryIds}
                         onSelectionChange={setSelectedRepositoryIds}
-                        onAddFromSearch={(repo: Repository) => {
-                          // Add to search-added repos and auto-select it
-                          setSearchAddedRepos(prev => [...prev, repo]);
-                          setSelectedRepositoryIds(prev => [...prev, repo.id]);
-                        }}
-                        onSearch={
-                          isGitLab
-                            ? async (query: string) => {
-                                // Call the appropriate search endpoint based on context
-                                if (organizationId) {
-                                  const result =
-                                    await trpcClient.organizations.reviewAgent.searchGitLabRepositories.query(
-                                      {
-                                        organizationId,
-                                        query,
-                                      }
-                                    );
-                                  return result.repositories.map(repo => ({
-                                    id: repo.id,
-                                    name: repo.name,
-                                    full_name: repo.fullName,
-                                    private: repo.private,
-                                  }));
-                                } else {
-                                  const result =
-                                    await trpcClient.personalReviewAgent.searchGitLabRepositories.query(
-                                      {
-                                        query,
-                                      }
-                                    );
-                                  return result.repositories.map(repo => ({
-                                    id: repo.id,
-                                    name: repo.name,
-                                    full_name: repo.fullName,
-                                    private: repo.private,
-                                  }));
-                                }
-                              }
-                            : undefined
-                        }
                       />
                     </div>
                   )}

--- a/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
@@ -237,6 +237,21 @@ export function ReviewConfigForm({
     [selectedModel]
   );
 
+  const selectableRepositories = useMemo(() => {
+    const cachedRepositories = (repositoriesData?.repositories ?? []).map(repo => ({
+      id: repo.id,
+      name: repo.name,
+      full_name: repo.fullName,
+      private: repo.private,
+    }));
+    const cachedRepositoryIds = new Set(cachedRepositories.map(repo => repo.id));
+    const legacyRepositories = (configData?.manuallyAddedRepositories ?? []).filter(
+      repo => !cachedRepositoryIds.has(repo.id)
+    );
+
+    return [...cachedRepositories, ...legacyRepositories];
+  }, [configData?.manuallyAddedRepositories, repositoriesData?.repositories]);
+
   // Reset thinking effort when the model changes and the current selection is invalid
   useEffect(() => {
     if (thinkingEffort && !availableVariants.includes(thinkingEffort)) {
@@ -425,8 +440,11 @@ export function ReviewConfigForm({
     // Clear previous webhook sync result
     setWebhookSyncResult(null);
 
-    // Preserve legacy live-search selections until their persisted contract is migrated.
-    const manuallyAddedRepositories = configData?.manuallyAddedRepositories ?? [];
+    // Preserve selected legacy live-search entries until their persisted contract is migrated.
+    const selectedRepositoryIdSet = new Set(selectedRepositoryIds);
+    const manuallyAddedRepositories = (configData?.manuallyAddedRepositories ?? []).filter(repo =>
+      selectedRepositoryIdSet.has(repo.id)
+    );
 
     if (organizationId) {
       orgSaveMutation.mutate({
@@ -683,7 +701,7 @@ export function ReviewConfigForm({
                       `${platformLabel} integration is not connected. Please connect ${platformLabel} in the Integrations page to configure repository selection.`}
                   </p>
                 </div>
-              ) : repositoriesData.repositories.length === 0 ? (
+              ) : selectableRepositories.length === 0 ? (
                 <div className="rounded-md border border-yellow-500/50 bg-yellow-500/10 p-3">
                   <p className="text-sm text-yellow-200">
                     No repositories found. Please ensure the {platformLabel}{' '}
@@ -720,12 +738,7 @@ export function ReviewConfigForm({
                   {(isGitLab || repositorySelectionMode === 'selected') && (
                     <div className="mt-4">
                       <RepositoryMultiSelect
-                        repositories={repositoriesData.repositories.map(repo => ({
-                          id: repo.id,
-                          name: repo.name,
-                          full_name: repo.fullName,
-                          private: repo.private,
-                        }))}
+                        repositories={selectableRepositories}
                         selectedIds={selectedRepositoryIds}
                         onSelectionChange={setSelectedRepositoryIds}
                       />

--- a/apps/web/src/lib/cloud-agent/gitlab-integration-helpers.ts
+++ b/apps/web/src/lib/cloud-agent/gitlab-integration-helpers.ts
@@ -5,10 +5,7 @@ import {
   updateRepositoriesForIntegration,
 } from '@/lib/integrations/db/platform-integrations';
 import { getGitLabIntegration, getValidGitLabToken } from '@/lib/integrations/gitlab-service';
-import {
-  fetchGitLabProjects,
-  searchGitLabProjects,
-} from '@/lib/integrations/platforms/gitlab/adapter';
+import { fetchGitLabProjects } from '@/lib/integrations/platforms/gitlab/adapter';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import type { PlatformRepository } from '@/lib/integrations/core/types';
 
@@ -293,86 +290,4 @@ export async function getGitLabInstanceUrlForOrganization(organizationId: string
 
   const metadata = integration.metadata as GitLabMetadata | null;
   return metadata?.gitlab_instance_url || DEFAULT_GITLAB_URL;
-}
-
-type GitLabSearchResult = {
-  repositories: {
-    id: number;
-    name: string;
-    fullName: string;
-    private: boolean;
-  }[];
-  errorMessage?: string;
-};
-
-/**
- * Search GitLab repositories for a user by query string
- * Uses GitLab's project search API to find repositories beyond the cached list
- * @param userId - The user ID
- * @param query - Search query string (minimum 2 characters recommended)
- */
-export async function searchGitLabRepositoriesForUser(
-  userId: string,
-  query: string
-): Promise<GitLabSearchResult> {
-  const integration = await getIntegrationForOwner({ type: 'user', id: userId }, PLATFORM.GITLAB);
-
-  if (!integration) {
-    return {
-      repositories: [],
-      errorMessage: 'No GitLab integration found for this user',
-    };
-  }
-
-  const metadata = integration.metadata as GitLabMetadata | null;
-  const instanceUrl = metadata?.gitlab_instance_url || DEFAULT_GITLAB_URL;
-
-  try {
-    const accessToken = await getValidGitLabToken(integration);
-    const repositories = await searchGitLabProjects(accessToken, query, instanceUrl);
-    return {
-      repositories: mapRepositories(repositories),
-    };
-  } catch (_error) {
-    throw new TRPCError({
-      code: 'INTERNAL_SERVER_ERROR',
-      message: 'Failed to search GitLab repositories',
-    });
-  }
-}
-
-/**
- * Search GitLab repositories for an organization by query string
- * Uses GitLab's project search API to find repositories beyond the cached list
- * @param organizationId - The organization ID
- * @param query - Search query string (minimum 2 characters recommended)
- */
-export async function searchGitLabRepositoriesForOrganization(
-  organizationId: string,
-  query: string
-): Promise<GitLabSearchResult> {
-  const integration = await getIntegrationForOrganization(organizationId, PLATFORM.GITLAB);
-
-  if (!integration) {
-    return {
-      repositories: [],
-      errorMessage: 'No GitLab integration found for this organization',
-    };
-  }
-
-  const metadata = integration.metadata as GitLabMetadata | null;
-  const instanceUrl = metadata?.gitlab_instance_url || DEFAULT_GITLAB_URL;
-
-  try {
-    const accessToken = await getValidGitLabToken(integration);
-    const repositories = await searchGitLabProjects(accessToken, query, instanceUrl);
-    return {
-      repositories: mapRepositories(repositories),
-    };
-  } catch (_error) {
-    throw new TRPCError({
-      code: 'INTERNAL_SERVER_ERROR',
-      message: 'Failed to search GitLab repositories',
-    });
-  }
 }

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.test.ts
@@ -17,8 +17,7 @@ import {
   validatePersonalAccessToken,
   createProjectWebhook,
   deleteProjectWebhook,
-  searchGitLabProjects,
-  normalizeGitLabSearchQuery,
+  fetchGitLabProjects,
   fetchGitLabRootTextFileAtRef,
   fetchGitLabRepositorySize,
 } from './adapter';
@@ -94,72 +93,48 @@ function mockSelfHostedGitLabError(error: Error) {
   });
 }
 
-describe('normalizeGitLabSearchQuery', () => {
-  it('should extract project path from full GitLab URL', () => {
-    const result = normalizeGitLabSearchQuery('https://gitlab.com/group123/project123');
-    expect(result).toBe('group123/project123');
-  });
-
-  it('should extract project path from GitLab URL with trailing slash', () => {
-    const result = normalizeGitLabSearchQuery('https://gitlab.com/group123/project123/');
-    expect(result).toBe('group123/project123');
-  });
-
-  it('should extract project path from GitLab URL with subgroups', () => {
-    const result = normalizeGitLabSearchQuery('https://gitlab.com/group/subgroup/project-name');
-    expect(result).toBe('group/subgroup/project-name');
-  });
-
-  it('should extract project path from self-hosted GitLab URL', () => {
-    const result = normalizeGitLabSearchQuery('https://gitlab.example.com/team/my-project');
-    expect(result).toBe('team/my-project');
-  });
-
-  it('should strip /-/ suffixes from GitLab URLs (tree/branch)', () => {
-    const result = normalizeGitLabSearchQuery('https://gitlab.com/group123/project123/-/tree/main');
-    expect(result).toBe('group123/project123');
-  });
-
-  it('should strip /-/ suffixes from GitLab URLs (merge_requests)', () => {
-    const result = normalizeGitLabSearchQuery(
-      'https://gitlab.com/group123/project123/-/merge_requests'
-    );
-    expect(result).toBe('group123/project123');
-  });
-
-  it('should strip /-/ suffixes from GitLab URLs (issues)', () => {
-    const result = normalizeGitLabSearchQuery(
-      'https://gitlab.com/group123/project123/-/issues/123'
-    );
-    expect(result).toBe('group123/project123');
-  });
-
-  it('should return path format as-is', () => {
-    const result = normalizeGitLabSearchQuery('group123/project123');
-    expect(result).toBe('group123/project123');
-  });
-
-  it('should return project name only as-is', () => {
-    const result = normalizeGitLabSearchQuery('project123');
-    expect(result).toBe('project123');
-  });
-
-  it('should trim whitespace from query', () => {
-    const result = normalizeGitLabSearchQuery('  project123  ');
-    expect(result).toBe('project123');
-  });
-
-  it('should handle http URLs', () => {
-    const result = normalizeGitLabSearchQuery('http://gitlab.local/team/project');
-    expect(result).toBe('team/project');
-  });
-
-  it('should return invalid URL-like strings as-is', () => {
-    // This doesn't start with http:// or https://, so it's treated as a search term
-    const result = normalizeGitLabSearchQuery('gitlab.com/team/project');
-    expect(result).toBe('gitlab.com/team/project');
-  });
-});
+function createGitLabProjectDiscoveryResponse() {
+  return [
+    {
+      id: 123,
+      name: 'active-project',
+      path_with_namespace: 'group/active-project',
+      visibility: 'private',
+      default_branch: 'main',
+      web_url: 'https://gitlab.com/group/active-project',
+      archived: false,
+    },
+    {
+      id: 456,
+      name: 'archived-project',
+      path_with_namespace: 'group/archived-project',
+      visibility: 'private',
+      default_branch: 'main',
+      web_url: 'https://gitlab.com/group/archived-project',
+      archived: true,
+    },
+    {
+      id: 789,
+      name: 'scheduled-project',
+      path_with_namespace: 'group/scheduled-project',
+      visibility: 'private',
+      default_branch: 'main',
+      web_url: 'https://gitlab.com/group/scheduled-project',
+      archived: false,
+      marked_for_deletion_on: '2026-07-01',
+    },
+    {
+      id: 101,
+      name: 'legacy-scheduled-project',
+      path_with_namespace: 'group/legacy-scheduled-project',
+      visibility: 'private',
+      default_branch: 'main',
+      web_url: 'https://gitlab.com/group/legacy-scheduled-project',
+      archived: false,
+      marked_for_deletion_at: '2026-07-01',
+    },
+  ];
+}
 
 describe('GitLab OAuth endpoint safety', () => {
   beforeEach(() => {
@@ -412,281 +387,48 @@ describe('validateGitLabInstance', () => {
   });
 });
 
-describe('searchGitLabProjects', () => {
+describe('fetchGitLabProjects', () => {
   beforeEach(() => {
     mockFetch.mockReset();
   });
 
-  it('should search projects and return mapped results', async () => {
-    const mockProjects = [
+  it('returns active projects across every page', async () => {
+    const projects = createGitLabProjectDiscoveryResponse();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => projects.slice(1),
+        headers: {
+          get: (name: string) => (name === 'x-next-page' ? '2' : null),
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => projects.slice(0, 1),
+        headers: {
+          get: () => null,
+        },
+      });
+
+    const result = await fetchGitLabProjects('test-token');
+
+    expect(result).toEqual([
       {
         id: 123,
-        name: 'my-project',
-        path_with_namespace: 'group/my-project',
-        visibility: 'private',
-        default_branch: 'main',
-        web_url: 'https://gitlab.com/group/my-project',
-        archived: false,
+        name: 'active-project',
+        full_name: 'group/active-project',
+        private: true,
       },
-      {
-        id: 456,
-        name: 'another-project',
-        path_with_namespace: 'group/another-project',
-        visibility: 'public',
-        default_branch: 'main',
-        web_url: 'https://gitlab.com/group/another-project',
-        archived: false,
-      },
-    ];
-
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockProjects,
-    });
-
-    const result = await searchGitLabProjects('test-token', 'my-project');
-
-    expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({
-      id: 123,
-      name: 'my-project',
-      full_name: 'group/my-project',
-      private: true,
-    });
-    expect(result[1]).toEqual({
-      id: 456,
-      name: 'another-project',
-      full_name: 'group/another-project',
-      private: false,
-    });
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://gitlab.com/api/v4/projects?membership=true&search=my-project&per_page=20&archived=false',
-      expect.objectContaining({
-        headers: {
-          Authorization: 'Bearer test-token',
-        },
-      })
-    );
-  });
-
-  it('should use custom instance URL', async () => {
-    mockSelfHostedGitLabResponse({ status: 200, json: [] });
-
-    await searchGitLabProjects('test-token', 'query', 'https://gitlab.example.com');
-
-    expect(mockHttpsRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        hostname: 'gitlab.example.com',
-        path: '/api/v4/projects?membership=true&search=query&per_page=20&archived=false',
-      }),
-      expect.any(Function)
-    );
-  });
-
-  it('should use custom limit', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    });
-
-    await searchGitLabProjects('test-token', 'query', 'https://gitlab.com', 50);
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://gitlab.com/api/v4/projects?membership=true&search=query&per_page=50&archived=false',
-      expect.anything()
-    );
-  });
-
-  it('should URL-encode the search query', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    });
-
-    // Use a query without / to test pure search encoding
-    await searchGitLabProjects('test-token', 'my project name');
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://gitlab.com/api/v4/projects?membership=true&search=my%20project%20name&per_page=20&archived=false',
-      expect.anything()
-    );
-  });
-
-  it('should throw error on API failure', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 401,
-      text: async () => 'Unauthorized',
-    });
-
-    await expect(searchGitLabProjects('invalid-token', 'query')).rejects.toThrow(
-      'GitLab projects search failed: 401'
-    );
-  });
-
-  it('should return empty array when no projects match', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    });
-
-    const result = await searchGitLabProjects('test-token', 'nonexistent');
-
-    expect(result).toEqual([]);
-  });
-
-  it('should try direct path lookup first when query contains /', async () => {
-    const mockProject = {
-      id: 123,
-      name: 'project123',
-      path_with_namespace: 'group123/project123',
-      visibility: 'private',
-      default_branch: 'main',
-      web_url: 'https://gitlab.com/group123/project123',
-      archived: false,
-    };
-
-    // First call: direct path lookup succeeds
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockProject,
-    });
-
-    const result = await searchGitLabProjects(
-      'test-token',
-      'https://gitlab.com/group123/project123'
-    );
-
-    // Should return the directly fetched project
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
-      id: 123,
-      name: 'project123',
-      full_name: 'group123/project123',
-      private: true,
-    });
-
-    // Should have called the direct project endpoint
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://gitlab.com/api/v4/projects/group123%2Fproject123',
-      expect.objectContaining({
-        headers: {
-          Authorization: 'Bearer test-token',
-        },
-      })
-    );
-
-    // Should NOT have called the search endpoint
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('should fall back to search when direct path lookup returns 404', async () => {
-    // First call: direct path lookup fails with 404
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-    });
-
-    // Second call: search returns results
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    });
-
-    await searchGitLabProjects('test-token', 'group123/project123');
-
-    // Should have called both endpoints
+    ]);
     expect(mockFetch).toHaveBeenCalledTimes(2);
-
-    // First call: direct lookup
     expect(mockFetch).toHaveBeenNthCalledWith(
       1,
-      'https://gitlab.com/api/v4/projects/group123%2Fproject123',
+      'https://gitlab.com/api/v4/projects?membership=true&per_page=100&page=1&archived=false',
       expect.anything()
     );
-
-    // Second call: search fallback
     expect(mockFetch).toHaveBeenNthCalledWith(
       2,
-      'https://gitlab.com/api/v4/projects?membership=true&search=group123%2Fproject123&per_page=20&archived=false',
-      expect.anything()
-    );
-  });
-
-  it('should skip archived projects in direct path lookup', async () => {
-    const mockArchivedProject = {
-      id: 123,
-      name: 'project123',
-      path_with_namespace: 'group123/project123',
-      visibility: 'private',
-      default_branch: 'main',
-      web_url: 'https://gitlab.com/group123/project123',
-      archived: true, // Project is archived
-    };
-
-    // First call: direct path lookup returns archived project
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockArchivedProject,
-    });
-
-    // Second call: search fallback
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    });
-
-    const result = await searchGitLabProjects('test-token', 'group123/project123');
-
-    // Should fall back to search and return empty
-    expect(result).toEqual([]);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-  });
-
-  it('should normalize GitLab URL with /-/ suffix and do direct lookup', async () => {
-    const mockProject = {
-      id: 123,
-      name: 'project123',
-      path_with_namespace: 'group123/project123',
-      visibility: 'public',
-      default_branch: 'main',
-      web_url: 'https://gitlab.com/group123/project123',
-      archived: false,
-    };
-
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockProject,
-    });
-
-    const result = await searchGitLabProjects(
-      'test-token',
-      'https://gitlab.com/group123/project123/-/merge_requests'
-    );
-
-    // Should return the project from direct lookup
-    expect(result).toHaveLength(1);
-    expect(result[0].full_name).toBe('group123/project123');
-
-    // Should have called direct lookup with cleaned path (no /-/merge_requests)
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://gitlab.com/api/v4/projects/group123%2Fproject123',
-      expect.anything()
-    );
-  });
-
-  it('should not do direct lookup for simple project names without /', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    });
-
-    await searchGitLabProjects('test-token', 'project123');
-
-    // Should only call search, not direct lookup
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://gitlab.com/api/v4/projects?membership=true&search=project123&per_page=20&archived=false',
+      'https://gitlab.com/api/v4/projects?membership=true&per_page=100&page=2&archived=false',
       expect.anything()
     );
   });

--- a/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/gitlab/adapter.ts
@@ -282,7 +282,13 @@ export type GitLabProject = {
   default_branch: string;
   web_url: string;
   archived: boolean;
+  marked_for_deletion_on?: string | null;
+  marked_for_deletion_at?: string | null;
 };
+
+function isActiveGitLabProject(project: GitLabProject): boolean {
+  return !project.archived && !project.marked_for_deletion_on && !project.marked_for_deletion_at;
+}
 
 export type GitLabBranch = {
   name: string;
@@ -514,7 +520,7 @@ export async function fetchGitLabProjects(
     const data = (await response.json()) as GitLabProject[];
 
     projects.push(
-      ...data.map(project => ({
+      ...data.filter(isActiveGitLabProject).map(project => ({
         id: project.id,
         name: project.name,
         full_name: project.path_with_namespace,
@@ -522,195 +528,17 @@ export async function fetchGitLabProjects(
       }))
     );
 
-    // Check if there are more pages
-    const totalPages = parseInt(response.headers.get('x-total-pages') || '1', 10);
-    if (page >= totalPages) break;
+    const nextPage = Number.parseInt(response.headers.get('x-next-page') || '', 10);
+    if (Number.isInteger(nextPage) && nextPage > page) {
+      page = nextPage;
+      continue;
+    }
+
+    if (data.length < perPage) break;
     page++;
   }
 
   logExceptInTest('GitLab projects fetched', { count: projects.length });
-
-  return projects;
-}
-
-/**
- * Normalizes a search query by extracting the project path from a GitLab URL if provided.
- * Supports multiple input formats:
- * - Full URL: https://gitlab.com/group123/project123
- * - Path format: group123/project123
- * - Project name only: project123
- *
- * @param query - The search query (may be a URL, path, or project name)
- * @returns The normalized search query (project path or name)
- */
-export function normalizeGitLabSearchQuery(query: string): string {
-  const trimmedQuery = query.trim();
-
-  // Check if it looks like a URL
-  if (trimmedQuery.startsWith('http://') || trimmedQuery.startsWith('https://')) {
-    try {
-      const url = new URL(trimmedQuery);
-      // Extract the pathname and remove leading slash
-      // e.g., /group123/project123 -> group123/project123
-      const path = url.pathname.replace(/^\//, '').replace(/\/$/, '');
-
-      // Remove common GitLab URL suffixes like /-/tree/main, /-/merge_requests, etc.
-      const cleanPath = path.replace(/\/-\/.*$/, '');
-
-      if (cleanPath) {
-        logExceptInTest('Normalized GitLab URL to path', {
-          originalQuery: trimmedQuery,
-          extractedPath: cleanPath,
-        });
-        return cleanPath;
-      }
-    } catch {
-      // Not a valid URL, use as-is
-    }
-  }
-
-  // Return the query as-is (could be a path like "group/project" or just "project")
-  return trimmedQuery;
-}
-
-/**
- * Fetches a GitLab project by path and returns it as a PlatformRepository
- * Returns null if the project is not found or user doesn't have access
- *
- * @param accessToken - OAuth access token
- * @param projectPath - Project path (e.g., "group/project")
- * @param instanceUrl - GitLab instance URL (defaults to gitlab.com)
- */
-async function fetchProjectByPath(
-  accessToken: string,
-  projectPath: string,
-  instanceUrl: string = DEFAULT_GITLAB_URL
-): Promise<PlatformRepository | null> {
-  const encodedPath = encodeURIComponent(projectPath);
-
-  const response = await fetchGitLab(
-    buildGitLabUrl(instanceUrl, `/api/v4/projects/${encodedPath}`),
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }
-  );
-
-  if (!response.ok) {
-    // 404 means project not found or no access - this is expected
-    if (response.status === 404) {
-      logExceptInTest('GitLab project not found by path', { projectPath });
-      return null;
-    }
-    // Other errors - log but don't throw, we'll fall back to search
-    logExceptInTest('GitLab project fetch by path failed:', {
-      status: response.status,
-      projectPath,
-    });
-    return null;
-  }
-
-  const project = (await response.json()) as GitLabProject;
-
-  // Skip archived projects
-  if (project.archived) {
-    logExceptInTest('GitLab project found but is archived', { projectPath });
-    return null;
-  }
-
-  logExceptInTest('GitLab project found by path', {
-    projectPath,
-    projectId: project.id,
-    name: project.name,
-  });
-
-  return {
-    id: project.id,
-    name: project.name,
-    full_name: project.path_with_namespace,
-    private: project.visibility === 'private',
-  };
-}
-
-/**
- * Searches GitLab projects by name using the GitLab API
- * Used when users have 100+ repositories and need to find specific ones
- *
- * Supports multiple input formats:
- * - Full URL: https://gitlab.com/group123/project123
- * - Path format: group123/project123
- * - Project name only: project123
- *
- * When a URL or path is provided, the function first tries to fetch the project
- * directly by path. If that fails, it falls back to a text search.
- *
- * @param accessToken - OAuth access token
- * @param query - Search query string (URL, path, or project name - minimum 2 characters recommended)
- * @param instanceUrl - GitLab instance URL (defaults to gitlab.com)
- * @param limit - Maximum number of results to return (default 20)
- */
-export async function searchGitLabProjects(
-  accessToken: string,
-  query: string,
-  instanceUrl: string = DEFAULT_GITLAB_URL,
-  limit: number = 20
-): Promise<PlatformRepository[]> {
-  // Normalize the query to handle URLs
-  const normalizedQuery = normalizeGitLabSearchQuery(query);
-
-  // If the query looks like a project path (contains /), try direct lookup first
-  if (normalizedQuery.includes('/')) {
-    const directProject = await fetchProjectByPath(accessToken, normalizedQuery, instanceUrl);
-    if (directProject) {
-      logExceptInTest('GitLab search: returning direct path match', {
-        originalQuery: query,
-        normalizedQuery,
-        projectId: directProject.id,
-      });
-      return [directProject];
-    }
-    // If direct lookup failed, fall through to search
-    logExceptInTest('GitLab search: direct path lookup failed, falling back to search', {
-      originalQuery: query,
-      normalizedQuery,
-    });
-  }
-
-  const response = await fetchGitLab(
-    buildGitLabUrl(instanceUrl, '/api/v4/projects', {
-      membership: true,
-      search: normalizedQuery,
-      per_page: limit,
-      archived: false,
-    }),
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }
-  );
-
-  if (!response.ok) {
-    const error = await response.text();
-    logExceptInTest('GitLab projects search failed:', { status: response.status, error });
-    throw new Error(`GitLab projects search failed: ${response.status}`);
-  }
-
-  const data = (await response.json()) as GitLabProject[];
-
-  const projects = data.map(project => ({
-    id: project.id,
-    name: project.name,
-    full_name: project.path_with_namespace,
-    private: project.visibility === 'private',
-  }));
-
-  logExceptInTest('GitLab projects search completed', {
-    originalQuery: query,
-    normalizedQuery,
-    count: projects.length,
-  });
 
   return projects;
 }

--- a/apps/web/src/routers/code-reviews-router.ts
+++ b/apps/web/src/routers/code-reviews-router.ts
@@ -12,10 +12,7 @@ import {
 } from '@/lib/agent-config/db/agent-configs';
 import type { CodeReviewAgentConfig } from '@/lib/agent-config/core/types';
 import { fetchGitHubRepositoriesForUser } from '@/lib/cloud-agent/github-integration-helpers';
-import {
-  fetchGitLabRepositoriesForUser,
-  searchGitLabRepositoriesForUser,
-} from '@/lib/cloud-agent/gitlab-integration-helpers';
+import { fetchGitLabRepositoriesForUser } from '@/lib/cloud-agent/gitlab-integration-helpers';
 import { PRIMARY_DEFAULT_MODEL } from '@/lib/ai-gateway/models';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import {
@@ -133,16 +130,6 @@ export const personalReviewAgentRouter = createTRPCRouter({
     .input(z.object({ forceRefresh: z.boolean().optional().default(false) }).optional())
     .query(async ({ ctx, input }) => {
       return await fetchGitLabRepositoriesForUser(ctx.user.id, input?.forceRefresh ?? false);
-    }),
-
-  /**
-   * Search GitLab repositories by query string
-   * Used when users have 100+ repositories and need to find specific ones
-   */
-  searchGitLabRepositories: baseProcedure
-    .input(z.object({ query: z.string().min(2) }))
-    .query(async ({ ctx, input }) => {
-      return await searchGitLabRepositoriesForUser(ctx.user.id, input.query);
     }),
 
   /**

--- a/apps/web/src/routers/organizations/organization-code-reviews-router.ts
+++ b/apps/web/src/routers/organizations/organization-code-reviews-router.ts
@@ -19,10 +19,7 @@ import {
 
 import type { CodeReviewAgentConfig } from '@/lib/agent-config/core/types';
 import { fetchGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
-import {
-  fetchGitLabRepositoriesForOrganization,
-  searchGitLabRepositoriesForOrganization,
-} from '@/lib/cloud-agent/gitlab-integration-helpers';
+import { fetchGitLabRepositoriesForOrganization } from '@/lib/cloud-agent/gitlab-integration-helpers';
 import { PRIMARY_DEFAULT_MODEL } from '@/lib/ai-gateway/models';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import {
@@ -147,20 +144,6 @@ export const organizationReviewAgentRouter = createTRPCRouter({
     )
     .query(async ({ input }) => {
       return await fetchGitLabRepositoriesForOrganization(input.organizationId, input.forceRefresh);
-    }),
-
-  /**
-   * Search GitLab repositories by query string
-   * Used when organizations have 100+ repositories and need to find specific ones
-   */
-  searchGitLabRepositories: organizationMemberProcedure
-    .input(
-      OrganizationIdInputSchema.extend({
-        query: z.string().min(2),
-      })
-    )
-    .query(async ({ input }) => {
-      return await searchGitLabRepositoriesForOrganization(input.organizationId, input.query);
     }),
 
   /**


### PR DESCRIPTION
## Summary

- Exclude archived and deletion-scheduled GitLab projects from the synchronized repository cache.
- Search the complete cached repository inventory locally and use explicit refreshes for freshness.
- Remove the redundant live GitLab search API path while preserving legacy repository selections.

## Verification

- Manual verification not run; this path requires a configured GitLab integration with archived or deletion-scheduled projects.

## Visual Changes

N/A

## Reviewer Notes

Repository refresh pagination now follows `x-next-page` with a full-page fallback when pagination headers are omitted.