### PR TITLE
fix(dev): remove nested log entries safely

### DIFF
--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -192,7 +192,7 @@ async function cmdUp(args: string[], repoRoot: string): Promise<void> {
   const logDir = path.join(repoRoot, 'dev', 'logs');
   fs.mkdirSync(logDir, { recursive: true });
   for (const entry of fs.readdirSync(logDir)) {
-    fs.unlinkSync(path.join(logDir, entry));
+    fs.rmSync(path.join(logDir, entry), { recursive: true, force: true });
   }
 
   // --- Create tmux session ---


### PR DESCRIPTION
## Summary

- Use recursive `fs.rmSync` when clearing `dev/logs` so local dev startup can remove nested log entries safely.

## Verification

- N/A. This is a local dev cleanup path and was not manually exercised in this branch.

## Visual Changes

N/A

## Reviewer Notes

N/A