### PR TITLE
fix(auth): preserve client sessions on SSO changes

### DIFF
--- a/.specs/organization-sso.md
+++ b/.specs/organization-sso.md
@@ -42,7 +42,7 @@ Active.
 4. The final authentication callback MUST independently enforce SSO even when discovery or UI routing was bypassed.
 5. Authentication discovery errors and disagreement between local policy and WorkOS MUST NOT fall back to ordinary signup.
 6. Development fake login MAY bypass SSO only when the existing non-production fake-login feature is enabled.
-7. Converting an existing user to WorkOS MUST invalidate their existing browser sessions and API tokens.
+7. Converting an existing user to WorkOS MUST invalidate their existing browser sessions and MUST NOT eagerly invalidate their API tokens solely through credential-pepper rotation.
 
 ### Invitations
 

--- a/.specs/organization-sso.md
+++ b/.specs/organization-sso.md
@@ -72,7 +72,7 @@ Active.
 
 ### Policy Transitions
 
-1. Enabling SSO or attaching a child to an SSO authority MUST invalidate affected Same-domain users' existing browser sessions and API tokens before enforcement is considered complete.
+1. Enabling SSO or attaching a child to an SSO authority MUST NOT eagerly invalidate affected Same-domain users' existing browser sessions or API tokens solely through credential-pepper rotation; SSO requirements MUST instead be enforced at authentication and authorization boundaries.
 2. Pending authentication artifacts that could mint credentials after the transition SHOULD be expired.
 3. Existing Same-domain ordinary invitations MUST NOT remain usable after the transition.
 4. Policy transitions, configuration failures, denied membership admissions, and administrative overrides MUST be audited without recording tokens, cookies, credentials, or authentication headers.

--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -464,6 +464,35 @@ describe('User', () => {
       );
       consoleError.mockRestore();
     });
+
+    it('preserves API token pepper when upgrading an existing user to WorkOS', async () => {
+      const existingUser = await insertTestUser({
+        google_user_email: 'workos-upgrade@example.com',
+        api_token_pepper: 'api-pepper-before-workos',
+        web_session_pepper: 'web-pepper-before-workos',
+      });
+
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'workos-upgrade@example.com',
+          google_user_name: 'WorkOS Upgrade',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: 'example.com',
+          provider: 'workos',
+          provider_account_id: 'workos-upgrade-provider-id',
+        },
+        undefined,
+        true
+      );
+
+      expect(result.success).toBe(true);
+      const updatedUser = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, existingUser.id),
+      });
+      expect(updatedUser?.api_token_pepper).toBe('api-pepper-before-workos');
+      expect(updatedUser?.web_session_pepper).toEqual(expect.any(String));
+      expect(updatedUser?.web_session_pepper).not.toBe('web-pepper-before-workos');
+    });
   });
 
   describe('softDeleteUser', () => {

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -569,11 +569,10 @@ export async function createOrUpdateUser(
             .update(kilocode_users)
             .set({
               web_session_pepper: randomUUID(),
-              api_token_pepper: randomUUID(),
             })
             .where(eq(kilocode_users.id, userByEmail.id))
             .returning();
-          if (!updatedUser) throw new Error('Failed to rotate credentials for WorkOS user');
+          if (!updatedUser) throw new Error('Failed to rotate web sessions for WorkOS user');
           return updatedUser;
         });
       } else {

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -1070,8 +1070,6 @@ export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAut
 
   if (!isWebSessionCurrent(session.webSessionPepper, user))
     return authError(401, 'Reauthentication required', maybeKiloUserId);
-  if (!(await hasCurrentSsoAuthentication(user, session)))
-    return authError(401, 'SSO reauthentication required', maybeKiloUserId);
 
   // NOTE: we currently do not thread organization id through here as its only used for extension-originated requests
   return await validateUserAuthorization(

--- a/apps/web/src/routers/organizations/organization-sso-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-sso-router.test.ts
@@ -10,7 +10,6 @@ import { insertTestUser } from '@/tests/helpers/user.helper';
 describe('organization SSO router', () => {
   let admin: User;
   let sameDomainUser: User;
-  let sameDomainBot: User;
   let organization: Organization;
 
   beforeAll(async () => {
@@ -23,12 +22,6 @@ describe('organization SSO router', () => {
       api_token_pepper: 'old-api-pepper',
       web_session_pepper: 'old-web-pepper',
     });
-    sameDomainBot = await insertTestUser({
-      google_user_email: 'bot@example.com',
-      api_token_pepper: 'bot-api-pepper',
-      web_session_pepper: 'bot-web-pepper',
-      is_bot: true,
-    });
     organization = await createOrganization('SSO Router Organization', admin.id);
   });
 
@@ -36,7 +29,7 @@ describe('organization SSO router', () => {
     await db.delete(organizations).where(eq(organizations.id, organization.id));
   });
 
-  test('rotates same-domain human credentials when SSO is enabled', async () => {
+  test('does not eagerly rotate same-domain credentials when SSO is enabled', async () => {
     const caller = await createCallerForUser(admin.id);
 
     await caller.organizations.sso.updateSsoDomain({
@@ -47,13 +40,8 @@ describe('organization SSO router', () => {
     const updatedUser = await db.query.kilocode_users.findFirst({
       where: eq(kilocode_users.id, sameDomainUser.id),
     });
-    const unchangedBot = await db.query.kilocode_users.findFirst({
-      where: eq(kilocode_users.id, sameDomainBot.id),
-    });
 
-    expect(updatedUser?.api_token_pepper).not.toBe('old-api-pepper');
-    expect(updatedUser?.web_session_pepper).not.toBe('old-web-pepper');
-    expect(unchangedBot?.api_token_pepper).toBe('bot-api-pepper');
-    expect(unchangedBot?.web_session_pepper).toBe('bot-web-pepper');
+    expect(updatedUser?.api_token_pepper).toBe('old-api-pepper');
+    expect(updatedUser?.web_session_pepper).toBe('old-web-pepper');
   });
 });

--- a/apps/web/src/routers/organizations/organization-sso-router.ts
+++ b/apps/web/src/routers/organizations/organization-sso-router.ts
@@ -10,8 +10,8 @@ import { TRPCError } from '@trpc/server';
 import { GeneratePortalLinkIntent, WorkOS, OrganizationDomainState } from '@workos-inc/node';
 import * as z from 'zod';
 import { db } from '@/lib/drizzle';
-import { kilocode_users, organizations } from '@kilocode/db/schema';
-import { and, eq, sql } from 'drizzle-orm';
+import { organizations } from '@kilocode/db/schema';
+import { eq, sql } from 'drizzle-orm';
 import { OrganizationSSODomainSchema } from '@/lib/organizations/organization-types';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
 import { successResult } from '@/lib/maybe-result';
@@ -166,21 +166,6 @@ export const organizationSsoRouter = createTRPCRouter({
         .update(organizations)
         .set({ sso_domain: ssoDomain })
         .where(eq(organizations.id, organizationId));
-
-      if (organization.sso_domain !== ssoDomain) {
-        await tx
-          .update(kilocode_users)
-          .set({
-            api_token_pepper: sql`pg_catalog.gen_random_uuid()::text`,
-            web_session_pepper: sql`pg_catalog.gen_random_uuid()::text`,
-          })
-          .where(
-            and(
-              eq(kilocode_users.is_bot, false),
-              sql`lower(split_part(${kilocode_users.google_user_email}, '@', 2)) = ${ssoDomain}`
-            )
-          );
-      }
 
       await createAuditLog({
         action: 'organization.sso.set_domain',


### PR DESCRIPTION
## Summary

- Stop rotating API-token and web-session peppers when setting an organization SSO domain so existing CLI and VS Code extension tokens are not eagerly invalidated.
- Preserve API-token peppers when upgrading an existing user to WorkOS while still rotating browser-session peppers for that conversion.
- Remove the web-session SSO reauthentication gate from `getUserFromAuth` while preserving normal web-session freshness checks.
- Update the organization SSO spec and regression tests to codify boundary enforcement instead of eager API-token revocation.

## Verification

N/A

## Visual Changes

N/A

## Reviewer Notes

Risk area: bearer-token authorization still enforces current SSO authentication separately; this PR removes eager API-token pepper rotation and the web-session SSO reauth check.