### PR TITLE
fix(auth): allow API tokens for SSO users

### DIFF
--- a/apps/web/src/lib/user/server.test.ts
+++ b/apps/web/src/lib/user/server.test.ts
@@ -1,4 +1,11 @@
-import { beforeAll, describe, test, expect } from '@jest/globals';
+const mockHeaders = jest.fn<Promise<Headers>, []>();
+
+jest.mock('next/headers', () => ({
+  headers: () => mockHeaders(),
+  cookies: jest.fn(),
+}));
+
+import { beforeAll, beforeEach, describe, test, expect } from '@jest/globals';
 import {
   isEmailBlacklistedByDomain,
   isBlockedTLD,
@@ -7,17 +14,23 @@ import {
   uuidSchema,
   parseSignInRedirectContext,
   getProfileRedirectPath,
+  getUserFromAuth,
 } from './server';
 import { db } from '@/lib/drizzle';
 import { organization_seats_purchases, organizations } from '@kilocode/db/schema';
 import type { Organization, User } from '@kilocode/db/schema';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
 import { insertTestUser } from '@/tests/helpers/user.helper';
+import { generateApiToken } from '@/lib/tokens';
 import { eq } from 'drizzle-orm';
 import { v5 as uuidv5 } from 'uuid';
 
 // Same namespace UUID used in user.server.ts
 const USER_UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+
+beforeEach(() => {
+  mockHeaders.mockReset();
+});
 
 describe('isEmailBlacklistedByDomain', () => {
   test('should return false when blacklisted_domains is undefined', () => {
@@ -409,6 +422,29 @@ describe('uuidSchema (organization ID validation)', () => {
   test('should reject numbers', () => {
     expect(uuidSchema.safeParse(12345).success).toBe(false);
     expect(uuidSchema.safeParse(0).success).toBe(false);
+  });
+});
+
+describe('getUserFromAuth', () => {
+  test('allows API-token authentication for users from SSO-protected domains', async () => {
+    const ssoDomain = `${crypto.randomUUID()}.example.com`;
+    const user = await insertTestUser({
+      google_user_email: `api-token-user@${ssoDomain}`,
+      api_token_pepper: 'api-token-pepper',
+    });
+    const organization = await createTestOrganization('API Token SSO Domain Org', user.id, 0);
+    await db
+      .update(organizations)
+      .set({ sso_domain: ssoDomain })
+      .where(eq(organizations.id, organization.id));
+
+    const token = generateApiToken(user);
+    mockHeaders.mockResolvedValue(new Headers({ Authorization: `Bearer ${token}` }));
+
+    const result = await getUserFromAuth({ adminOnly: false });
+
+    expect(result.authFailedResponse).toBeNull();
+    expect(result.user?.id).toBe(user.id);
   });
 });
 

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -41,8 +41,8 @@ import { getMostRecentSeatPurchase } from '@/lib/organizations/organization-seat
 import { secondsInDay } from 'date-fns/constants';
 import type { AdapterUser } from 'next-auth/adapters';
 import assert from 'node:assert';
-import { user_auth_provider, type Organization, type User } from '@kilocode/db/schema';
-import { and, eq } from 'drizzle-orm';
+import type { Organization, User } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
 import type { AuthProviderId } from '@kilocode/db/schema-types';
 import PostHogClient from '@/lib/posthog';
 import { captureException } from '@sentry/nextjs';
@@ -985,39 +985,6 @@ type GetAuthResponse =
       tokenSource?: string;
     };
 
-async function hasCurrentSsoAuthentication(
-  user: User,
-  session?: { authProvider?: string; ssoSourceOrganizationId?: string }
-): Promise<boolean> {
-  if (user.is_bot) return true;
-
-  const domain = getLowerDomainFromEmail(user.google_user_email);
-  if (!domain || domain === 'gmail.com') return true;
-
-  const authority = await resolveSsoAuthorityForDomain(domain);
-  if (authority.status === 'not_required') return true;
-  if (authority.status === 'misconfigured') return false;
-
-  if (session?.authProvider === 'fake-login' && allow_fake_login) return true;
-
-  if (session) {
-    return (
-      session.authProvider === 'workos' &&
-      session.ssoSourceOrganizationId === authority.sourceOrganizationId
-    );
-  }
-
-  const provider = await readDb.query.user_auth_provider.findFirst({
-    where: and(
-      eq(user_auth_provider.kilo_user_id, user.id),
-      eq(user_auth_provider.provider, 'workos'),
-      eq(user_auth_provider.hosted_domain, authority.domain)
-    ),
-    columns: { kilo_user_id: true },
-  });
-  return Boolean(provider);
-}
-
 export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAuthResponse> {
   const headersList = await headers();
 
@@ -1038,10 +1005,6 @@ export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAut
     ) {
       return authError(401, 'Invalid API token', user.id);
     }
-    if (user && !(await hasCurrentSsoAuthentication(user))) {
-      return authError(401, 'SSO reauthentication required', user.id);
-    }
-
     const organizationId = headersList.get(ORGANIZATION_ID_HEADER) || undefined;
     const internalApiUse = authorizationValidationResult.internalApiUse;
     const botId = authorizationValidationResult.botId;

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -42,7 +42,6 @@ import { secondsInDay } from 'date-fns/constants';
 import type { AdapterUser } from 'next-auth/adapters';
 import assert from 'node:assert';
 import type { Organization, User } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
 import type { AuthProviderId } from '@kilocode/db/schema-types';
 import PostHogClient from '@/lib/posthog';
 import { captureException } from '@sentry/nextjs';


### PR DESCRIPTION
## Summary
- Remove SSO reauthentication enforcement from bearer/API-token authentication so profile and balance API calls keep working for SSO-domain users.
- Add a regression test for API-token authentication on an SSO-protected domain without a WorkOS auth provider.

## Verification
- N/A

## Visual Changes
N/A

## Reviewer Notes
- This preserves existing API-token validation, pepper revocation, blocked-user, admin, and organization-membership checks.