### PR TITLE
fix(api): clean up compressed request logs

### DIFF
--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
@@ -4,7 +4,7 @@ jest.mock('@/lib/config.server', () => ({
   CRON_SECRET: 'cron-secret',
 }));
 
-import { api_request_log } from '@kilocode/db/schema';
+import { api_request_compress_log, api_request_log } from '@kilocode/db/schema';
 import { db, sql } from '@/lib/drizzle';
 import { GET } from './route';
 
@@ -37,9 +37,25 @@ async function insertApiRequestLogRecords(count: number, created_at: string) {
   );
 }
 
+async function insertApiRequestCompressLogRecord(created_at: string) {
+  const [row] = await db
+    .insert(api_request_compress_log)
+    .values({
+      created_at,
+      kilo_user_id: 'test-user',
+      provider: 'test-provider',
+      model: 'test-model',
+      request: {},
+      result: {},
+    })
+    .returning();
+  return row;
+}
+
 describe('GET /api/cron/cleanup-api-request-log', () => {
   beforeEach(async () => {
     await db.delete(api_request_log).where(sql`true`);
+    await db.delete(api_request_compress_log).where(sql`true`);
   });
 
   it('rejects requests without authorization header', async () => {
@@ -74,6 +90,23 @@ describe('GET /api/cron/cleanup-api-request-log', () => {
     expect(body.hasMore).toBe(false);
 
     const remaining = await db.select().from(api_request_log);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(recent.id);
+  });
+
+  it('deletes expired compression records and preserves recent records', async () => {
+    await insertApiRequestCompressLogRecord(daysAgo(45));
+    await insertApiRequestCompressLogRecord(daysAgo(31));
+    const recent = await insertApiRequestCompressLogRecord(daysAgo(1));
+
+    const response = await GET(makeRequest({ authorization: 'Bearer cron-secret' }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.deletedCount).toBe(2);
+    expect(body.hasMore).toBe(false);
+
+    const remaining = await db.select().from(api_request_compress_log);
     expect(remaining).toHaveLength(1);
     expect(remaining[0].id).toBe(recent.id);
   });

--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/drizzle';
-import { api_request_log } from '@kilocode/db/schema';
+import { api_request_compress_log, api_request_log } from '@kilocode/db/schema';
 import { asc, inArray, lt } from 'drizzle-orm';
 import { CRON_SECRET } from '@/lib/config.server';
 
@@ -32,10 +32,25 @@ export async function GET(request: Request) {
       ? await db.delete(api_request_log).where(inArray(api_request_log.id, batchIds))
       : null;
 
+  const expiredCompressRows = await db
+    .select({ id: api_request_compress_log.id })
+    .from(api_request_compress_log)
+    .where(lt(api_request_compress_log.created_at, cutoffDate))
+    .orderBy(asc(api_request_compress_log.created_at))
+    .limit(BATCH_SIZE + 1);
+
+  const compressBatchIds = expiredCompressRows.slice(0, BATCH_SIZE).map(row => row.id);
+  const compressResult =
+    compressBatchIds.length > 0
+      ? await db
+          .delete(api_request_compress_log)
+          .where(inArray(api_request_compress_log.id, compressBatchIds))
+      : null;
+
   return NextResponse.json({
-    deletedCount: result?.rowCount ?? 0,
+    deletedCount: (result?.rowCount ?? 0) + (compressResult?.rowCount ?? 0),
     batchSize: BATCH_SIZE,
-    hasMore: expiredRows.length > BATCH_SIZE,
+    hasMore: expiredRows.length > BATCH_SIZE || expiredCompressRows.length > BATCH_SIZE,
     cutoffDate,
     timestamp: new Date().toISOString(),
   });


### PR DESCRIPTION
## Summary
- Apply the existing 30-day API request log retention policy to `api_request_compress_log`.
- Delete compressed request logs in bounded 1,000-row batches and include them in cleanup result counts and continuation state.
- Add regression coverage for deleting expired compression logs while preserving recent entries.

## Verification
N/A (database-backed cron endpoint; no manual environment available).

## Visual Changes
N/A

## Reviewer Notes
Each log table has an independent 1,000-row batch limit, so one invocation can delete up to 2,000 rows total.