### PR TITLE
feat(autocomplete): make promoted Inception FIM free

### DIFF
--- a/apps/web/src/app/api/edit/completions/route.ts
+++ b/apps/web/src/app/api/edit/completions/route.ts
@@ -6,7 +6,7 @@ import { captureException, setTag, startInactiveSpan } from '@sentry/nextjs';
 import type { MicrodollarUsageContext } from '@/lib/ai-gateway/processUsage.types';
 import { validateFeatureHeader, FEATURE_HEADER } from '@/lib/feature-detection';
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
-import { INCEPTION_PROMO_RUNNING } from '@/lib/constants';
+import { INCEPTION_PROMO_MODEL, INCEPTION_PROMO_RUNNING } from '@/lib/constants';
 import { sentryRootSpan } from '@/lib/getRootSpan';
 import { getUserFromAuth } from '@/lib/user/server';
 import {
@@ -183,8 +183,11 @@ export async function POST(request: NextRequest) {
   // slight replication lag, and provides lower latency for US users.
   const { balance, settings, plan } = await getBalanceAndOrgSettings(organizationId, user, readDb);
 
+  const isInceptionPromoRequest =
+    INCEPTION_PROMO_RUNNING && requestBody.model === INCEPTION_PROMO_MODEL;
+
   if (
-    !INCEPTION_PROMO_RUNNING &&
+    !isInceptionPromoRequest &&
     balance <= 0 &&
     !(await isFreeModel(requestBody.model)) &&
     !userByok

--- a/apps/web/src/app/api/fim/completions/route.test.ts
+++ b/apps/web/src/app/api/fim/completions/route.test.ts
@@ -138,11 +138,11 @@ describe('POST /api/fim/completions', () => {
     expect(response.status).toBe(200);
     expect(mockedFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockedFetch.mock.calls[0];
+    expect(init).toBeDefined();
+    const headers = init?.headers as Record<string, string>;
     expect(url).toBe('https://api.inceptionlabs.ai/v1/fim/completions');
     expect(JSON.parse(init?.body as string).model).toBe('mercury-edit-2');
-    expect((init?.headers as Record<string, string>).Authorization).toBe(
-      'Bearer system-inception-key'
-    );
+    expect(headers.Authorization).toBe('Bearer system-inception-key');
 
     await flushAfter();
     const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
@@ -187,9 +187,9 @@ describe('POST /api/fim/completions', () => {
 
     expect(response.status).toBe(200);
     const [, init] = mockedFetch.mock.calls[0];
-    expect((init?.headers as Record<string, string>).Authorization).toBe(
-      'Bearer user-inception-key'
-    );
+    expect(init).toBeDefined();
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer user-inception-key');
     await flushAfter();
   });
 });

--- a/apps/web/src/app/api/fim/completions/route.test.ts
+++ b/apps/web/src/app/api/fim/completions/route.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterAll } from '@jest/globals';
+import type { User } from '@kilocode/db/schema';
+import { ProxyErrorType } from '@/lib/proxy-error-types';
+import { getUserFromAuth } from '@/lib/user/server';
+import { getBalanceAndOrgSettings } from '@/lib/organizations/organization-usage';
+import { getBYOKforOrganization, getBYOKforUser } from '@/lib/ai-gateway/byok';
+import type {
+  MicrodollarUsageContext,
+  MicrodollarUsageStats,
+} from '@/lib/ai-gateway/processUsage.types';
+
+let mockInceptionPromoRunning = true;
+
+jest.mock('@/lib/constants', () => ({
+  ...(jest.requireActual('@/lib/constants') as Record<string, unknown>),
+  get INCEPTION_PROMO_RUNNING() {
+    return mockInceptionPromoRunning;
+  },
+}));
+
+jest.mock('@/lib/config.server', () => ({
+  INCEPTION_API_KEY: 'system-inception-key',
+  MISTRAL_API_KEY: 'system-mistral-key',
+}));
+jest.mock('@/lib/user/server');
+jest.mock('@/lib/organizations/organization-usage');
+jest.mock('@/lib/ai-gateway/byok');
+jest.mock('@/lib/redis', () => ({
+  redisClient: {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue('OK'),
+    del: jest.fn().mockResolvedValue(0),
+    getdel: jest.fn().mockResolvedValue(null),
+  },
+}));
+jest.mock('@/lib/debugUtils', () => ({
+  debugSaveProxyRequest: jest.fn(),
+  debugSaveProxyResponseStream: jest.fn(),
+}));
+
+jest.mock('next/server', () => ({
+  ...(jest.requireActual('next/server') as Record<string, unknown>),
+  after: jest.fn((work: Promise<unknown> | (() => Promise<unknown>)) => {
+    void (typeof work === 'function' ? work() : work);
+  }),
+}));
+
+const mockedLogMicrodollarUsage = jest.fn(
+  async (_stats: MicrodollarUsageStats, _ctx: MicrodollarUsageContext) => null
+);
+jest.mock('@/lib/ai-gateway/processUsage', () => ({
+  ...(jest.requireActual('@/lib/ai-gateway/processUsage') as Record<string, unknown>),
+  logMicrodollarUsage: (stats: MicrodollarUsageStats, ctx: MicrodollarUsageContext) =>
+    mockedLogMicrodollarUsage(stats, ctx),
+}));
+
+const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
+const mockedGetBalanceAndOrgSettings = jest.mocked(getBalanceAndOrgSettings);
+const mockedGetBYOKforOrganization = jest.mocked(getBYOKforOrganization);
+const mockedGetBYOKforUser = jest.mocked(getBYOKforUser);
+const mockedFetch = jest.fn() as jest.MockedFunction<typeof globalThis.fetch>;
+const originalFetch = globalThis.fetch;
+
+function makeRequest(model = 'inception/mercury-edit-2') {
+  return new Request('http://localhost:3000/api/fim/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-forwarded-for': '127.0.0.1',
+    },
+    body: JSON.stringify({
+      model,
+      prompt: 'const value =',
+      suffix: ';',
+      max_tokens: 100,
+    }),
+  });
+}
+
+function setOrganizationAuth(balance: number) {
+  mockedGetUserFromAuth.mockResolvedValue({
+    user: {
+      id: 'user-123',
+      google_user_email: 'test@example.com',
+      microdollars_used: 0,
+    } as User,
+    authFailedResponse: null,
+    organizationId: 'org-123',
+  });
+  mockedGetBalanceAndOrgSettings.mockResolvedValue({
+    balance,
+    settings: undefined,
+    plan: 'teams',
+  });
+  mockedGetBYOKforOrganization.mockResolvedValue(null);
+  mockedGetBYOKforUser.mockResolvedValue(null);
+}
+
+function makeUpstreamResponse() {
+  return new Response(
+    JSON.stringify({
+      id: 'fim-test',
+      model: 'mercury-edit-2',
+      usage: {
+        prompt_tokens: 1_000,
+        completion_tokens: 100,
+        total_tokens: 1_100,
+      },
+      choices: [{ text: ' completion' }],
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  );
+}
+
+async function flushAfter() {
+  await new Promise(resolve => setImmediate(resolve));
+}
+
+describe('POST /api/fim/completions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockInceptionPromoRunning = true;
+    globalThis.fetch = mockedFetch;
+    mockedLogMicrodollarUsage.mockResolvedValue(null);
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('allows the promoted Inception model with an exhausted balance', async () => {
+    setOrganizationAuth(0);
+    mockedFetch.mockResolvedValue(makeUpstreamResponse());
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockedFetch.mock.calls[0];
+    expect(url).toBe('https://api.inceptionlabs.ai/v1/fim/completions');
+    expect(JSON.parse(init?.body as string).model).toBe('mercury-edit-2');
+    expect((init?.headers as Record<string, string>).Authorization).toBe(
+      'Bearer system-inception-key'
+    );
+
+    await flushAfter();
+    const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
+    expect(stats.cost_mUsd).toBe(0);
+    expect(stats.market_cost).toBe(325);
+  });
+
+  it('rejects an exhausted balance when the promotion is disabled', async () => {
+    mockInceptionPromoRunning = false;
+    setOrganizationAuth(0);
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest() as never);
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toMatchObject({
+      error_type: ProxyErrorType.insufficient_credits,
+    });
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not apply the promotion to other FIM models', async () => {
+    setOrganizationAuth(0);
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest('mistralai/codestral-2508') as never);
+
+    expect(response.status).toBe(402);
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it('continues to allow Inception BYOK when the promotion is disabled', async () => {
+    mockInceptionPromoRunning = false;
+    setOrganizationAuth(0);
+    mockedGetBYOKforOrganization.mockResolvedValue([
+      { providerId: 'inception', decryptedAPIKey: 'user-inception-key' },
+    ] as never);
+    mockedFetch.mockResolvedValue(makeUpstreamResponse());
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest() as never);
+
+    expect(response.status).toBe(200);
+    const [, init] = mockedFetch.mock.calls[0];
+    expect((init?.headers as Record<string, string>).Authorization).toBe(
+      'Bearer user-inception-key'
+    );
+    await flushAfter();
+  });
+});

--- a/apps/web/src/app/api/fim/completions/route.ts
+++ b/apps/web/src/app/api/fim/completions/route.ts
@@ -6,6 +6,7 @@ import { captureException, setTag, startInactiveSpan } from '@sentry/nextjs';
 import type { MicrodollarUsageContext } from '@/lib/ai-gateway/processUsage.types';
 import { validateFeatureHeader, FEATURE_HEADER } from '@/lib/feature-detection';
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
+import { INCEPTION_PROMO_MODEL, INCEPTION_PROMO_RUNNING } from '@/lib/constants';
 import { sentryRootSpan } from '@/lib/getRootSpan';
 import { getUserFromAuth } from '@/lib/user/server';
 import {
@@ -192,7 +193,15 @@ export async function POST(request: NextRequest) {
   // slight replication lag, and provides lower latency for US users
   const { balance, settings, plan } = await getBalanceAndOrgSettings(organizationId, user, readDb);
 
-  if (balance <= 0 && !(await isFreeModel(requestBody.model)) && !userByok) {
+  const isInceptionPromoRequest =
+    INCEPTION_PROMO_RUNNING && requestBody.model === INCEPTION_PROMO_MODEL;
+
+  if (
+    !isInceptionPromoRequest &&
+    balance <= 0 &&
+    !(await isFreeModel(requestBody.model)) &&
+    !userByok
+  ) {
     return NextResponse.json(
       {
         error: { message: 'Insufficient credits' },

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
@@ -36,6 +36,7 @@ jest.mock('./processUsage', () => ({
 import {
   checkOrganizationModelRestrictions,
   countAndStoreEditUsage,
+  countAndStoreFimUsage,
   extractEditPromptInfo,
   extractEmbeddingPromptInfo,
   extractHeaderAndLimitLength,
@@ -419,6 +420,117 @@ describe('parseEditUsageFromResponse', () => {
     // negative cost. The clamp pins cacheHitTokens at prompt_tokens.
     expect(result.cacheHitTokens).toBe(1_000);
     expect(result.cost_mUsd).toBe(25);
+  });
+});
+
+describe('countAndStoreFimUsage', () => {
+  function makeUsageContext(
+    overrides: Partial<MicrodollarUsageContext> = {}
+  ): MicrodollarUsageContext {
+    return {
+      api_kind: 'fim_completions',
+      kiloUserId: 'user-fim-test',
+      provider: 'inception',
+      requested_model: 'inception/mercury-edit-2',
+      promptInfo: {
+        system_prompt_prefix: '',
+        system_prompt_length: 0,
+        user_prompt_prefix: '',
+      },
+      max_tokens: 100,
+      has_middle_out_transform: null,
+      fraudHeaders: {},
+      isStreaming: false,
+      organizationId: undefined,
+      prior_microdollar_usage: 0,
+      posthog_distinct_id: undefined,
+      project_id: null,
+      status_code: 200,
+      editor_name: null,
+      machine_id: null,
+      user_byok: false,
+      has_tools: false,
+      feature: null,
+      session_id: null,
+      mode: null,
+      auto_model: null,
+      ttfb_ms: null,
+      ...overrides,
+    } as MicrodollarUsageContext;
+  }
+
+  function makeUpstreamResponse(): Response {
+    return new Response(
+      JSON.stringify({
+        id: 'fim-test',
+        model: 'mercury-edit-2',
+        usage: {
+          prompt_tokens: 1_000,
+          completion_tokens: 100,
+          total_tokens: 1_100,
+        },
+        choices: [{ text: 'completion' }],
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+  }
+
+  beforeEach(() => {
+    mockInceptionPromoRunning = true;
+    mockedLogMicrodollarUsage.mockClear();
+    mockedLogMicrodollarUsage.mockResolvedValue(null);
+  });
+
+  it('preserves market cost but does not bill the promoted Inception model', async () => {
+    countAndStoreFimUsage(makeUpstreamResponse(), makeUsageContext(), undefined);
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(mockedLogMicrodollarUsage).toHaveBeenCalledTimes(1);
+    const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
+    expect(stats.cost_mUsd).toBe(0);
+    expect(stats.cacheDiscount_mUsd).toBe(0);
+    expect(stats.market_cost).toBe(325);
+  });
+
+  it('bills the Inception model when the promotion is disabled', async () => {
+    mockInceptionPromoRunning = false;
+    countAndStoreFimUsage(makeUpstreamResponse(), makeUsageContext(), undefined);
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
+    expect(stats.cost_mUsd).toBe(325);
+    expect(stats.market_cost).toBe(325);
+  });
+
+  it('does not apply the promotion to other FIM models', async () => {
+    countAndStoreFimUsage(
+      makeUpstreamResponse(),
+      makeUsageContext({
+        provider: 'mistral',
+        requested_model: 'mistralai/codestral-2508',
+      }),
+      undefined
+    );
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
+    expect(stats.cost_mUsd).toBe(390);
+    expect(stats.market_cost).toBe(390);
+  });
+
+  it('does not bill BYOK requests when the promotion is disabled', async () => {
+    mockInceptionPromoRunning = false;
+    countAndStoreFimUsage(makeUpstreamResponse(), makeUsageContext({ user_byok: true }), undefined);
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
+    expect(stats.cost_mUsd).toBe(0);
+    expect(stats.cacheDiscount_mUsd).toBe(0);
+    expect(stats.market_cost).toBe(325);
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -7,7 +7,12 @@ import {
   processTokenData,
 } from '@/lib/ai-gateway/processUsage';
 import { startInactiveSpan, captureException, captureMessage } from '@sentry/nextjs';
-import { APP_URL, FIRST_TOPUP_BONUS_AMOUNT, INCEPTION_PROMO_RUNNING } from '@/lib/constants';
+import {
+  APP_URL,
+  FIRST_TOPUP_BONUS_AMOUNT,
+  INCEPTION_PROMO_MODEL,
+  INCEPTION_PROMO_RUNNING,
+} from '@/lib/constants';
 import { summarizeUserPayments } from '@/lib/creditTransactions';
 import { type User } from '@kilocode/db/schema';
 import { errorExceptInTest, warnExceptInTest } from '@/lib/utils.server';
@@ -733,8 +738,12 @@ export function countAndStoreFimUsage(
 
       usageStats.market_cost = usageStats.cost_mUsd;
 
-      if (usageContext.user_byok) {
+      const isInceptionPromoRequest =
+        INCEPTION_PROMO_RUNNING && usageContext.requested_model === INCEPTION_PROMO_MODEL;
+
+      if (isInceptionPromoRequest || usageContext.user_byok) {
         usageStats.cost_mUsd = 0;
+        usageStats.cacheDiscount_mUsd = 0;
       }
 
       // Use the same logMicrodollarUsage as OpenRouter!
@@ -874,7 +883,10 @@ export function countAndStoreEditUsage(
       // the cache discount we would otherwise have given them must be zeroed
       // too. Otherwise the usage row would claim a discount on spend that never
       // happened and distort "money saved by caching" reporting.
-      if (INCEPTION_PROMO_RUNNING || usageContext.user_byok) {
+      const isInceptionPromoRequest =
+        INCEPTION_PROMO_RUNNING && usageContext.requested_model === INCEPTION_PROMO_MODEL;
+
+      if (isInceptionPromoRequest || usageContext.user_byok) {
         usageStats.cost_mUsd = 0;
         usageStats.cacheDiscount_mUsd = 0;
       }

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -56,6 +56,7 @@ export const APP_URL = resolveAppUrl({
 export const TRIAL_DURATION_DAYS = 14;
 
 export const AUTOCOMPLETE_MODEL = 'codestral-2508';
+export const INCEPTION_PROMO_MODEL = 'inception/mercury-edit-2';
 export const INCEPTION_PROMO_RUNNING = true;
 
 export const ENABLE_DEPLOY_FEATURE = true;


### PR DESCRIPTION
## Summary

- Extend the Inception promotion to FIM requests for `inception/mercury-edit-2`, which supports the KiloCode chat autocomplete FIM fallback from Kilo-Org/kilocode#11592.
- Add `INCEPTION_PROMO_MODEL` so the promo is scoped to the Mercury Edit 2 model instead of all Inception models.
- Preserve market-cost reporting while zeroing billable cost for promoted FIM and Edit requests.
- Add FIM route and usage-accounting coverage for promo enabled/disabled, non-promo models, and BYOK.

## Verification

- [ ] N/A - relying on CI for automated API route and billing coverage.

## Visual Changes

N/A

## Reviewer Notes

The cloud-facing model ID is `inception/mercury-edit-2`; KiloCode's `kilo/inception/mercury-edit-2` is the client/gateway stable model ID and is not accepted directly by this cloud route.
