### PR TITLE
fix(security-agent): harden auto-analysis observability

### DIFF
--- a/services/security-auto-analysis/src/dispatcher.test.ts
+++ b/services/security-auto-analysis/src/dispatcher.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  deleteRetainedSecurityAgentCommands,
+  reconcileStaleSecurityAgentCommands,
+} from '@kilocode/db';
+import { getWorkerDb } from '@kilocode/db/client';
+import { discoverDueOwners, reconcileStaleAnalysisQueueRows } from './db/queries.js';
+import { discoverQueuedRemediationAttempts } from './remediation.js';
+import { dispatchDueOwners } from './dispatcher.js';
+
+const loggerMock = vi.hoisted(() => {
+  const logger = {
+    withTags: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+  logger.withTags.mockReturnValue(logger);
+  return logger;
+});
+
+vi.mock('@kilocode/db', () => ({
+  deleteRetainedSecurityAgentCommands: vi.fn(),
+  reconcileStaleSecurityAgentCommands: vi.fn(),
+}));
+vi.mock('@kilocode/db/client', () => ({ getWorkerDb: vi.fn() }));
+vi.mock('./db/queries.js', () => ({
+  discoverDueOwners: vi.fn(),
+  reconcileStaleAnalysisQueueRows: vi.fn(),
+}));
+vi.mock('./remediation.js', () => ({ discoverQueuedRemediationAttempts: vi.fn() }));
+vi.mock('./logger.js', () => ({
+  logger: loggerMock,
+  sanitizedExceptionName: (error: unknown) =>
+    error instanceof Error ? error.name : 'UnknownError',
+}));
+
+const ownerQueueSend = vi.fn();
+const remediationQueueSend = vi.fn();
+
+function env(): CloudflareEnv {
+  return {
+    ENVIRONMENT: 'test',
+    CF_VERSION_METADATA: { id: 'version-123', tag: '', timestamp: '' },
+    HYPERDRIVE: { connectionString: 'postgres://sensitive-connection' },
+    OWNER_QUEUE: { sendBatch: ownerQueueSend },
+    REMEDIATION_ATTEMPT_QUEUE: { sendBatch: remediationQueueSend },
+  } as unknown as CloudflareEnv;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loggerMock.withTags.mockReturnValue(loggerMock);
+  vi.mocked(getWorkerDb).mockReturnValue({} as never);
+  vi.mocked(reconcileStaleAnalysisQueueRows).mockResolvedValue({
+    requeuedPendingCount: 1,
+    failedRunningCount: 2,
+  });
+  vi.mocked(reconcileStaleSecurityAgentCommands).mockResolvedValue({
+    staleAccepted: [{ id: 'sensitive-command-id' }],
+    staleRunning: [{ id: 'another-sensitive-command-id' }],
+  } as never);
+  vi.mocked(deleteRetainedSecurityAgentCommands).mockResolvedValue(3);
+  vi.mocked(discoverDueOwners).mockResolvedValue([{ type: 'user', id: 'sensitive-owner-id' }]);
+  vi.mocked(discoverQueuedRemediationAttempts).mockResolvedValue(['sensitive-attempt-id']);
+  ownerQueueSend.mockResolvedValue(undefined);
+  remediationQueueSend.mockResolvedValue(undefined);
+});
+
+describe('dispatchDueOwners telemetry', () => {
+  it('emits structured success telemetry for every stage without sensitive identifiers', async () => {
+    const result = await dispatchDueOwners(env());
+
+    expect(result).toMatchObject({
+      discoveredOwners: 1,
+      enqueuedMessages: 1,
+      discoveredRemediationAttempts: 1,
+      enqueuedRemediationMessages: 1,
+    });
+    const stageTags = loggerMock.withTags.mock.calls
+      .map(([tags]) => tags)
+      .filter(tags => tags.event_name === 'security_auto_analysis.dispatcher_stage_succeeded');
+    expect(stageTags.map(tags => tags.dispatcher_stage)).toEqual([
+      'stale_analysis_queue_reconciliation',
+      'stale_command_reconciliation',
+      'retained_command_deletion',
+      'due_owner_discovery',
+      'owner_queue_sends',
+      'remediation_attempt_discovery',
+      'remediation_queue_sends',
+    ]);
+    expect(stageTags[0]).toMatchObject({
+      dispatch_id: result.dispatchId,
+      worker_environment: 'test',
+      worker_version: 'version-123',
+      requeued_pending_count: 1,
+      failed_running_count: 2,
+    });
+    const serializedLogs = JSON.stringify(loggerMock.withTags.mock.calls);
+    expect(serializedLogs).not.toContain('sensitive-owner-id');
+    expect(serializedLogs).not.toContain('sensitive-command-id');
+    expect(serializedLogs).not.toContain('sensitive-attempt-id');
+    expect(serializedLogs).not.toContain('postgres://');
+  });
+
+  it.each([
+    {
+      stage: 'stale_analysis_queue_reconciliation',
+      fail: () => vi.mocked(reconcileStaleAnalysisQueueRows).mockRejectedValueOnce(stageError()),
+    },
+    {
+      stage: 'stale_command_reconciliation',
+      fail: () =>
+        vi.mocked(reconcileStaleSecurityAgentCommands).mockRejectedValueOnce(stageError()),
+    },
+    {
+      stage: 'retained_command_deletion',
+      fail: () =>
+        vi.mocked(deleteRetainedSecurityAgentCommands).mockRejectedValueOnce(stageError()),
+    },
+    {
+      stage: 'due_owner_discovery',
+      fail: () => vi.mocked(discoverDueOwners).mockRejectedValueOnce(stageError()),
+    },
+    {
+      stage: 'owner_queue_sends',
+      fail: () => ownerQueueSend.mockRejectedValueOnce(stageError()),
+    },
+    {
+      stage: 'remediation_attempt_discovery',
+      fail: () => vi.mocked(discoverQueuedRemediationAttempts).mockRejectedValueOnce(stageError()),
+    },
+    {
+      stage: 'remediation_queue_sends',
+      fail: () => remediationQueueSend.mockRejectedValueOnce(stageError()),
+    },
+  ])('logs and rethrows failures from $stage', async ({ stage, fail }) => {
+    const error = stageError();
+    fail();
+
+    await expect(dispatchDueOwners(env())).rejects.toThrow(error.message);
+
+    const failureTags = loggerMock.withTags.mock.calls
+      .map(([tags]) => tags)
+      .find(tags => tags.event_name === 'security_auto_analysis.dispatcher_failed');
+    expect(failureTags).toMatchObject({
+      dispatcher_stage: stage,
+      dispatch_id: expect.any(String),
+      exception_name: 'SensitiveDatabaseError',
+      error_message: 'Dispatcher stage failed',
+      elapsed_ms: expect.any(Number),
+      worker_environment: 'test',
+      worker_version: 'version-123',
+    });
+    expect(loggerMock.error).toHaveBeenCalledWith('security_auto_analysis.dispatcher_failed');
+    const serializedLogs = JSON.stringify([
+      loggerMock.withTags.mock.calls,
+      loggerMock.error.mock.calls,
+    ]);
+    expect(serializedLogs).not.toContain('secret-token');
+    expect(serializedLogs).not.toContain('SELECT');
+    expect(serializedLogs).not.toContain('sensitive-owner-id');
+  });
+});
+
+function stageError(): Error {
+  const error = new Error('secret-token SELECT * FROM users WHERE owner_id=sensitive-owner-id');
+  error.name = 'SensitiveDatabaseError';
+  return error;
+}

--- a/services/security-auto-analysis/src/dispatcher.test.ts
+++ b/services/security-auto-analysis/src/dispatcher.test.ts
@@ -68,9 +68,10 @@ beforeEach(() => {
 
 describe('dispatchDueOwners telemetry', () => {
   it('emits structured success telemetry for every stage without sensitive identifiers', async () => {
-    const result = await dispatchDueOwners(env());
+    const result = await dispatchDueOwners(env(), 'dispatch-123');
 
     expect(result).toMatchObject({
+      dispatchId: 'dispatch-123',
       discoveredOwners: 1,
       enqueuedMessages: 1,
       discoveredRemediationAttempts: 1,

--- a/services/security-auto-analysis/src/dispatcher.ts
+++ b/services/security-auto-analysis/src/dispatcher.ts
@@ -5,12 +5,56 @@ import {
 } from '@kilocode/db';
 import { getWorkerDb } from '@kilocode/db/client';
 import { discoverDueOwners, reconcileStaleAnalysisQueueRows } from './db/queries.js';
-import { logger } from './logger.js';
+import { logger, sanitizedExceptionName, type DispatcherStage } from './logger.js';
 import { getSecurityAgentCommandLifecycleConfig } from './command-lifecycle-config.js';
 import { discoverQueuedRemediationAttempts } from './remediation.js';
 
 const DISPATCH_OWNER_LIMIT = 100;
 const DISPATCH_REMEDIATION_ATTEMPT_LIMIT = 100;
+const QUEUE_SEND_BATCH_LIMIT = 100;
+const DISPATCH_STAGE_SUCCEEDED_EVENT = 'security_auto_analysis.dispatcher_stage_succeeded';
+const DISPATCH_FAILED_EVENT = 'security_auto_analysis.dispatcher_failed';
+
+async function runDispatcherStage<T>(options: {
+  stage: DispatcherStage;
+  dispatchId: string;
+  env: CloudflareEnv;
+  operation: () => Promise<T>;
+  successTags?: (result: T) => Record<string, number>;
+}): Promise<T> {
+  const startedAt = Date.now();
+  try {
+    const result = await options.operation();
+    logger
+      .withTags({
+        event_name: DISPATCH_STAGE_SUCCEEDED_EVENT,
+        dispatcher_stage: options.stage,
+        dispatch_id: options.dispatchId,
+        outcome: 'succeeded',
+        elapsed_ms: Date.now() - startedAt,
+        worker_environment: options.env.ENVIRONMENT,
+        worker_version: options.env.CF_VERSION_METADATA?.id,
+        ...options.successTags?.(result),
+      })
+      .info(DISPATCH_STAGE_SUCCEEDED_EVENT);
+    return result;
+  } catch (error) {
+    logger
+      .withTags({
+        event_name: DISPATCH_FAILED_EVENT,
+        dispatcher_stage: options.stage,
+        dispatch_id: options.dispatchId,
+        outcome: 'failed',
+        exception_name: sanitizedExceptionName(error),
+        error_message: 'Dispatcher stage failed',
+        elapsed_ms: Date.now() - startedAt,
+        worker_environment: options.env.ENVIRONMENT,
+        worker_version: options.env.CF_VERSION_METADATA?.id,
+      })
+      .error(DISPATCH_FAILED_EVENT);
+    throw error;
+  }
+}
 
 export async function dispatchDueOwners(env: CloudflareEnv): Promise<{
   dispatchId: string;
@@ -20,31 +64,60 @@ export async function dispatchDueOwners(env: CloudflareEnv): Promise<{
   enqueuedRemediationMessages: number;
 }> {
   const dispatchId = randomUUID();
-  const db = getWorkerDb(env.HYPERDRIVE.connectionString, { statement_timeout: 30_000 });
 
-  const reconciliation = await reconcileStaleAnalysisQueueRows(db);
-  logger.info('Reconciled stale analysis queue rows before owner dispatch', {
-    requeued_pending_count: reconciliation.requeuedPendingCount,
-    failed_running_count: reconciliation.failedRunningCount,
+  const { db, reconciliation } = await runDispatcherStage({
+    stage: 'stale_analysis_queue_reconciliation',
+    dispatchId,
+    env,
+    operation: async () => {
+      const db = getWorkerDb(env.HYPERDRIVE.connectionString, { statement_timeout: 30_000 });
+      const reconciliation = await reconcileStaleAnalysisQueueRows(db);
+      return { db, reconciliation };
+    },
+    successTags: ({ reconciliation }) => ({
+      requeued_pending_count: reconciliation.requeuedPendingCount,
+      failed_running_count: reconciliation.failedRunningCount,
+    }),
   });
 
   const now = Date.now();
-  const commandLifecycleConfig = getSecurityAgentCommandLifecycleConfig(env);
-  const commandReconciliation = await reconcileStaleSecurityAgentCommands(db, {
-    acceptedBefore: new Date(now - commandLifecycleConfig.acceptedCommandTimeoutMs),
-    runningBefore: new Date(now - commandLifecycleConfig.runningCommandTimeoutMs),
-  });
-  const deletedCommandCount = await deleteRetainedSecurityAgentCommands(
-    db,
-    new Date(now - commandLifecycleConfig.commandRetentionMs)
-  );
-  logger.info('Reconciled stale security agent commands before owner dispatch', {
-    stale_accepted_command_ids: commandReconciliation.staleAccepted.map(command => command.id),
-    stale_running_command_ids: commandReconciliation.staleRunning.map(command => command.id),
-    deleted_terminal_command_count: deletedCommandCount,
+  const { commandLifecycleConfig, commandReconciliation } = await runDispatcherStage({
+    stage: 'stale_command_reconciliation',
+    dispatchId,
+    env,
+    operation: async () => {
+      const commandLifecycleConfig = getSecurityAgentCommandLifecycleConfig(env);
+      const commandReconciliation = await reconcileStaleSecurityAgentCommands(db, {
+        acceptedBefore: new Date(now - commandLifecycleConfig.acceptedCommandTimeoutMs),
+        runningBefore: new Date(now - commandLifecycleConfig.runningCommandTimeoutMs),
+      });
+      return { commandLifecycleConfig, commandReconciliation };
+    },
+    successTags: ({ commandReconciliation }) => ({
+      stale_accepted_command_count: commandReconciliation.staleAccepted.length,
+      stale_running_command_count: commandReconciliation.staleRunning.length,
+    }),
   });
 
-  const owners = await discoverDueOwners(db, DISPATCH_OWNER_LIMIT);
+  const deletedCommandCount = await runDispatcherStage({
+    stage: 'retained_command_deletion',
+    dispatchId,
+    env,
+    operation: () =>
+      deleteRetainedSecurityAgentCommands(
+        db,
+        new Date(now - commandLifecycleConfig.commandRetentionMs)
+      ),
+    successTags: count => ({ deleted_terminal_command_count: count }),
+  });
+
+  const owners = await runDispatcherStage({
+    stage: 'due_owner_discovery',
+    dispatchId,
+    env,
+    operation: () => discoverDueOwners(db, DISPATCH_OWNER_LIMIT),
+    successTags: result => ({ discovered_owner_count: result.length }),
+  });
 
   const messages = owners.map(owner => ({
     body: {
@@ -56,15 +129,25 @@ export async function dispatchDueOwners(env: CloudflareEnv): Promise<{
     contentType: 'json' as const,
   }));
 
-  const QUEUE_SEND_BATCH_LIMIT = 100;
-  for (let i = 0; i < messages.length; i += QUEUE_SEND_BATCH_LIMIT) {
-    await env.OWNER_QUEUE.sendBatch(messages.slice(i, i + QUEUE_SEND_BATCH_LIMIT));
-  }
+  await runDispatcherStage({
+    stage: 'owner_queue_sends',
+    dispatchId,
+    env,
+    operation: async () => {
+      for (let i = 0; i < messages.length; i += QUEUE_SEND_BATCH_LIMIT) {
+        await env.OWNER_QUEUE.sendBatch(messages.slice(i, i + QUEUE_SEND_BATCH_LIMIT));
+      }
+    },
+    successTags: () => ({ enqueued_owner_message_count: messages.length }),
+  });
 
-  const remediationAttemptIds = await discoverQueuedRemediationAttempts(
-    db,
-    DISPATCH_REMEDIATION_ATTEMPT_LIMIT
-  );
+  const remediationAttemptIds = await runDispatcherStage({
+    stage: 'remediation_attempt_discovery',
+    dispatchId,
+    env,
+    operation: () => discoverQueuedRemediationAttempts(db, DISPATCH_REMEDIATION_ATTEMPT_LIMIT),
+    successTags: result => ({ discovered_remediation_attempt_count: result.length }),
+  });
   const remediationMessages = remediationAttemptIds.map(attemptId => ({
     body: {
       attemptId,
@@ -73,19 +156,39 @@ export async function dispatchDueOwners(env: CloudflareEnv): Promise<{
     },
     contentType: 'json' as const,
   }));
-  for (let i = 0; i < remediationMessages.length; i += QUEUE_SEND_BATCH_LIMIT) {
-    await env.REMEDIATION_ATTEMPT_QUEUE.sendBatch(
-      remediationMessages.slice(i, i + QUEUE_SEND_BATCH_LIMIT)
-    );
-  }
 
-  logger.info('Dispatched due owners to queue', {
-    dispatch_id: dispatchId,
-    discovered_owners: owners.length,
-    enqueued_messages: messages.length,
-    discovered_remediation_attempts: remediationAttemptIds.length,
-    enqueued_remediation_messages: remediationMessages.length,
+  await runDispatcherStage({
+    stage: 'remediation_queue_sends',
+    dispatchId,
+    env,
+    operation: async () => {
+      for (let i = 0; i < remediationMessages.length; i += QUEUE_SEND_BATCH_LIMIT) {
+        await env.REMEDIATION_ATTEMPT_QUEUE.sendBatch(
+          remediationMessages.slice(i, i + QUEUE_SEND_BATCH_LIMIT)
+        );
+      }
+    },
+    successTags: () => ({ enqueued_remediation_message_count: remediationMessages.length }),
   });
+
+  logger
+    .withTags({
+      event_name: 'security_auto_analysis.dispatcher_succeeded',
+      dispatch_id: dispatchId,
+      outcome: 'succeeded',
+      worker_environment: env.ENVIRONMENT,
+      worker_version: env.CF_VERSION_METADATA?.id,
+      requeued_pending_count: reconciliation.requeuedPendingCount,
+      failed_running_count: reconciliation.failedRunningCount,
+      stale_accepted_command_count: commandReconciliation.staleAccepted.length,
+      stale_running_command_count: commandReconciliation.staleRunning.length,
+      deleted_terminal_command_count: deletedCommandCount,
+      discovered_owner_count: owners.length,
+      enqueued_owner_message_count: messages.length,
+      discovered_remediation_attempt_count: remediationAttemptIds.length,
+      enqueued_remediation_message_count: remediationMessages.length,
+    })
+    .info('security_auto_analysis.dispatcher_succeeded');
 
   return {
     dispatchId,

--- a/services/security-auto-analysis/src/dispatcher.ts
+++ b/services/security-auto-analysis/src/dispatcher.ts
@@ -56,15 +56,16 @@ async function runDispatcherStage<T>(options: {
   }
 }
 
-export async function dispatchDueOwners(env: CloudflareEnv): Promise<{
+export async function dispatchDueOwners(
+  env: CloudflareEnv,
+  dispatchId: string = randomUUID()
+): Promise<{
   dispatchId: string;
   discoveredOwners: number;
   enqueuedMessages: number;
   discoveredRemediationAttempts: number;
   enqueuedRemediationMessages: number;
 }> {
-  const dispatchId = randomUUID();
-
   const { db, reconciliation } = await runDispatcherStage({
     stage: 'stale_analysis_queue_reconciliation',
     dispatchId,

--- a/services/security-auto-analysis/src/index.test.ts
+++ b/services/security-auto-analysis/src/index.test.ts
@@ -7,21 +7,47 @@ import { deriveCallbackToken } from '@kilocode/worker-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as RemediationModule from './remediation.js';
 import { startManualRemediation } from './remediation.js';
+import { dispatchDueOwners } from './dispatcher.js';
 import worker from './index.js';
+
+const loggerMock = vi.hoisted(() => {
+  const logger = {
+    withTags: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+  logger.withTags.mockReturnValue(logger);
+  return logger;
+});
 
 vi.mock('@kilocode/db', () => ({
   createSecurityAgentCommand: vi.fn(),
   markSecurityAgentCommandQueueAdmissionFailed: vi.fn(),
 }));
 vi.mock('@kilocode/db/client', () => ({ getWorkerDb: vi.fn() }));
+vi.mock('./dispatcher.js', () => ({ dispatchDueOwners: vi.fn() }));
+vi.mock('./logger.js', () => ({
+  logger: loggerMock,
+  sanitizedExceptionName: (error: unknown) =>
+    error instanceof Error ? error.name : 'UnknownError',
+}));
 vi.mock('./remediation.js', async importOriginal => ({
   ...(await importOriginal<typeof RemediationModule>()),
   startManualRemediation: vi.fn(),
 }));
 
 beforeEach(() => {
+  vi.restoreAllMocks();
   vi.clearAllMocks();
+  loggerMock.withTags.mockReturnValue(loggerMock);
   vi.mocked(getWorkerDb).mockReturnValue({} as never);
+  vi.mocked(dispatchDueOwners).mockResolvedValue({
+    dispatchId: 'dispatch-123',
+    discoveredOwners: 0,
+    enqueuedMessages: 0,
+    discoveredRemediationAttempts: 0,
+    enqueuedRemediationMessages: 0,
+  });
   vi.mocked(createSecurityAgentCommand).mockResolvedValue({
     id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
   } as never);
@@ -72,6 +98,29 @@ async function remediationCallbackTokenFor(
   });
 }
 
+function scheduledEnv(heartbeatUrl: string | undefined): CloudflareEnv {
+  return {
+    BETTERSTACK_HEARTBEAT_URL: heartbeatUrl,
+    ENVIRONMENT: 'test',
+    CF_VERSION_METADATA: { id: 'version-123', tag: '', timestamp: '' },
+  } as CloudflareEnv;
+}
+
+async function runScheduled(env: CloudflareEnv): Promise<{
+  scheduledResult: Promise<void>;
+  heartbeatPromise: Promise<unknown>;
+}> {
+  let heartbeatPromise: Promise<unknown> | undefined;
+  const scheduledResult = worker.scheduled({} as ScheduledController, env, {
+    waitUntil(promise) {
+      heartbeatPromise = promise;
+    },
+  } as ExecutionContext);
+  await scheduledResult.catch(() => undefined);
+  if (!heartbeatPromise) throw new Error('Expected heartbeat waitUntil promise');
+  return { scheduledResult, heartbeatPromise };
+}
+
 function manualRemediationRequest(): Request {
   return new Request('https://security-auto-analysis/internal/remediation/start', {
     method: 'POST',
@@ -86,6 +135,110 @@ function manualRemediationRequest(): Request {
       actorUserId: 'user-123',
     }),
   });
+}
+
+describe('scheduled dispatcher heartbeat', () => {
+  it('delivers successful dispatch heartbeats and logs attempted and successful outcomes', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    const { scheduledResult, heartbeatPromise } = await runScheduled(
+      scheduledEnv('https://heartbeat.example/secret')
+    );
+    await expect(scheduledResult).resolves.toBeUndefined();
+    await heartbeatPromise;
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://heartbeat.example/secret',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(heartbeatOutcomes()).toEqual(['attempted', 'succeeded']);
+    expect(JSON.stringify(loggerMock.withTags.mock.calls)).not.toContain('heartbeat.example');
+  });
+
+  it('selects /fail, rethrows dispatcher errors, and preserves them across heartbeat failure', async () => {
+    const dispatcherError = new Error('original dispatcher failure');
+    vi.mocked(dispatchDueOwners).mockRejectedValueOnce(dispatcherError);
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValueOnce(new Error('heartbeat-url credential network failure'));
+
+    const { scheduledResult, heartbeatPromise } = await runScheduled(
+      scheduledEnv('https://heartbeat.example/secret')
+    );
+    await expect(scheduledResult).rejects.toBe(dispatcherError);
+    await expect(heartbeatPromise).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://heartbeat.example/secret/fail',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(heartbeatOutcomes()).toEqual(['attempted', 'failed']);
+    const failureTags = heartbeatTags().at(-1);
+    expect(failureTags).toMatchObject({
+      exception_name: 'Error',
+      error_message: 'Heartbeat network failure',
+      heartbeat_kind: 'failure',
+    });
+    expect(JSON.stringify(loggerMock.withTags.mock.calls)).not.toContain('credential');
+  });
+
+  it('logs skipped delivery when heartbeat binding is absent', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+
+    const { scheduledResult, heartbeatPromise } = await runScheduled(scheduledEnv(undefined));
+    await expect(scheduledResult).resolves.toBeUndefined();
+    await heartbeatPromise;
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(heartbeatOutcomes()).toEqual(['skipped']);
+  });
+
+  it('treats non-2xx responses as delivery failures without failing dispatch', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 503 }));
+
+    const { scheduledResult, heartbeatPromise } = await runScheduled(
+      scheduledEnv('https://heartbeat.example/secret')
+    );
+    await expect(scheduledResult).resolves.toBeUndefined();
+    await heartbeatPromise;
+
+    expect(heartbeatOutcomes()).toEqual(['attempted', 'failed']);
+    expect(heartbeatTags().at(-1)).toMatchObject({
+      response_status: 503,
+      response_status_class: '5xx',
+    });
+  });
+
+  it('logs heartbeat timeouts without failing dispatch', async () => {
+    const timeout = new Error('heartbeat URL timed out');
+    timeout.name = 'TimeoutError';
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(timeout);
+
+    const { scheduledResult, heartbeatPromise } = await runScheduled(
+      scheduledEnv('https://heartbeat.example/secret')
+    );
+    await expect(scheduledResult).resolves.toBeUndefined();
+    await heartbeatPromise;
+
+    expect(heartbeatOutcomes()).toEqual(['attempted', 'timeout']);
+    expect(heartbeatTags().at(-1)).toMatchObject({
+      exception_name: 'TimeoutError',
+      error_message: 'Heartbeat delivery timed out',
+    });
+    expect(JSON.stringify(loggerMock.withTags.mock.calls)).not.toContain('heartbeat URL');
+  });
+});
+
+function heartbeatTags(): Array<Record<string, unknown>> {
+  return loggerMock.withTags.mock.calls
+    .map(([tags]) => tags)
+    .filter(tags => tags.event_name === 'security_auto_analysis.heartbeat_delivery');
+}
+
+function heartbeatOutcomes(): unknown[] {
+  return heartbeatTags().map(tags => tags.outcome);
 }
 
 describe('manual remediation ingress', () => {

--- a/services/security-auto-analysis/src/index.test.ts
+++ b/services/security-auto-analysis/src/index.test.ts
@@ -153,6 +153,11 @@ describe('scheduled dispatcher heartbeat', () => {
       'https://heartbeat.example/secret',
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
+    const dispatchId = vi.mocked(dispatchDueOwners).mock.calls[0]?.[1];
+    expect(dispatchId).toEqual(expect.any(String));
+    expect(heartbeatTags()).toEqual(
+      expect.arrayContaining([expect.objectContaining({ dispatch_id: dispatchId })])
+    );
     expect(heartbeatOutcomes()).toEqual(['attempted', 'succeeded']);
     expect(JSON.stringify(loggerMock.withTags.mock.calls)).not.toContain('heartbeat.example');
   });
@@ -173,6 +178,11 @@ describe('scheduled dispatcher heartbeat', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       'https://heartbeat.example/secret/fail',
       expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    const dispatchId = vi.mocked(dispatchDueOwners).mock.calls[0]?.[1];
+    expect(dispatchId).toEqual(expect.any(String));
+    expect(heartbeatTags()).toEqual(
+      expect.arrayContaining([expect.objectContaining({ dispatch_id: dispatchId })])
     );
     expect(heartbeatOutcomes()).toEqual(['attempted', 'failed']);
     const failureTags = heartbeatTags().at(-1);

--- a/services/security-auto-analysis/src/index.ts
+++ b/services/security-auto-analysis/src/index.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual as nodeTSE } from 'crypto';
+import { randomUUID, timingSafeEqual as nodeTSE } from 'crypto';
 import {
   createSecurityAgentCommand,
   markSecurityAgentCommandQueueAdmissionFailed,
@@ -398,10 +398,9 @@ export default {
     ctx: ExecutionContext
   ): Promise<void> {
     let failed = false;
-    let dispatchId: string | undefined;
+    const dispatchId = randomUUID();
     try {
-      const result = await dispatchDueOwners(env);
-      dispatchId = result.dispatchId;
+      await dispatchDueOwners(env, dispatchId);
     } catch (error) {
       failed = true;
       throw error;

--- a/services/security-auto-analysis/src/index.ts
+++ b/services/security-auto-analysis/src/index.ts
@@ -8,6 +8,7 @@ import { getWorkerDb } from '@kilocode/db/client';
 import { verifyCallbackToken } from '@kilocode/worker-utils';
 import { consumeOwnerBatch } from './consumer.js';
 import { dispatchDueOwners } from './dispatcher.js';
+import { logger, sanitizedExceptionName } from './logger.js';
 import {
   consumeAnalysisCallbackBatch,
   SecurityAnalysisCallbackPayloadSchema,
@@ -25,16 +26,57 @@ import {
   startManualRemediation,
 } from './remediation.js';
 
-async function sendBetterStackHeartbeat(
-  heartbeatUrl: string | undefined,
-  failed: boolean
-): Promise<void> {
-  if (!heartbeatUrl) return;
-  const url = failed ? `${heartbeatUrl}/fail` : heartbeatUrl;
+const HEARTBEAT_EVENT = 'security_auto_analysis.heartbeat_delivery';
+
+async function sendBetterStackHeartbeat(options: {
+  heartbeatUrl: string | undefined;
+  dispatcherFailed: boolean;
+  dispatchId: string | undefined;
+  env: CloudflareEnv;
+}): Promise<void> {
+  const heartbeatKind = options.dispatcherFailed ? 'failure' : 'success';
+  const commonTags = {
+    event_name: HEARTBEAT_EVENT,
+    heartbeat_kind: heartbeatKind,
+    dispatch_id: options.dispatchId,
+    worker_environment: options.env.ENVIRONMENT,
+    worker_version: options.env.CF_VERSION_METADATA?.id,
+  } as const;
+
+  if (!options.heartbeatUrl) {
+    logger.withTags({ ...commonTags, outcome: 'skipped' }).warn(HEARTBEAT_EVENT);
+    return;
+  }
+
+  const startedAt = Date.now();
+  logger.withTags({ ...commonTags, outcome: 'attempted' }).info(HEARTBEAT_EVENT);
+
   try {
-    await fetch(url, { signal: AbortSignal.timeout(5000) });
-  } catch {
-    // best-effort
+    const url = options.dispatcherFailed ? `${options.heartbeatUrl}/fail` : options.heartbeatUrl;
+    const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    const responseTags = {
+      ...commonTags,
+      elapsed_ms: Date.now() - startedAt,
+      response_status: response.status,
+      response_status_class: `${Math.floor(response.status / 100)}xx`,
+    };
+    if (response.ok) {
+      logger.withTags({ ...responseTags, outcome: 'succeeded' }).info(HEARTBEAT_EVENT);
+      return;
+    }
+
+    logger.withTags({ ...responseTags, outcome: 'failed' }).warn(HEARTBEAT_EVENT);
+  } catch (error) {
+    const timedOut = error instanceof Error && error.name === 'TimeoutError';
+    logger
+      .withTags({
+        ...commonTags,
+        outcome: timedOut ? 'timeout' : 'failed',
+        exception_name: sanitizedExceptionName(error),
+        error_message: timedOut ? 'Heartbeat delivery timed out' : 'Heartbeat network failure',
+        elapsed_ms: Date.now() - startedAt,
+      })
+      .warn(HEARTBEAT_EVENT);
   }
 }
 
@@ -356,13 +398,22 @@ export default {
     ctx: ExecutionContext
   ): Promise<void> {
     let failed = false;
+    let dispatchId: string | undefined;
     try {
-      await dispatchDueOwners(env);
+      const result = await dispatchDueOwners(env);
+      dispatchId = result.dispatchId;
     } catch (error) {
       failed = true;
       throw error;
     } finally {
-      ctx.waitUntil(sendBetterStackHeartbeat(env.BETTERSTACK_HEARTBEAT_URL, failed));
+      ctx.waitUntil(
+        sendBetterStackHeartbeat({
+          heartbeatUrl: env.BETTERSTACK_HEARTBEAT_URL,
+          dispatcherFailed: failed,
+          dispatchId,
+          env,
+        })
+      );
     }
   },
 

--- a/services/security-auto-analysis/src/logger.ts
+++ b/services/security-auto-analysis/src/logger.ts
@@ -1,5 +1,43 @@
 import { WorkersLogger } from 'workers-tagged-logger';
 
+export type DispatcherStage =
+  | 'stale_analysis_queue_reconciliation'
+  | 'stale_command_reconciliation'
+  | 'retained_command_deletion'
+  | 'due_owner_discovery'
+  | 'owner_queue_sends'
+  | 'remediation_attempt_discovery'
+  | 'remediation_queue_sends';
+
+export type SecurityAutoAnalysisLogTags = {
+  event_name: string;
+  dispatcher_stage?: DispatcherStage;
+  dispatch_id?: string;
+  outcome?: 'attempted' | 'succeeded' | 'failed' | 'skipped' | 'timeout';
+  heartbeat_kind?: 'success' | 'failure';
+  exception_name?: string;
+  error_message?: string;
+  elapsed_ms?: number;
+  worker_environment?: string;
+  worker_version?: string;
+  response_status?: number;
+  response_status_class?: string;
+  requeued_pending_count?: number;
+  failed_running_count?: number;
+  stale_accepted_command_count?: number;
+  stale_running_command_count?: number;
+  deleted_terminal_command_count?: number;
+  discovered_owner_count?: number;
+  enqueued_owner_message_count?: number;
+  discovered_remediation_attempt_count?: number;
+  enqueued_remediation_message_count?: number;
+};
+
+export function sanitizedExceptionName(error: unknown): string {
+  if (!(error instanceof Error)) return 'UnknownError';
+  return /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/.test(error.name) ? error.name : 'Error';
+}
+
 function getLogLevel(): 'debug' | 'info' | 'warn' | 'error' {
   if (typeof process !== 'undefined' && process.env?.VITEST) {
     return 'error';
@@ -8,6 +46,6 @@ function getLogLevel(): 'debug' | 'info' | 'warn' | 'error' {
   return 'info';
 }
 
-export const logger = new WorkersLogger({
+export const logger = new WorkersLogger<SecurityAutoAnalysisLogTags>({
   minimumLogLevel: getLogLevel(),
 });

--- a/services/security-auto-analysis/worker-configuration.d.ts
+++ b/services/security-auto-analysis/worker-configuration.d.ts
@@ -66,6 +66,7 @@ declare type ExecutionContext = {
 
 declare type CloudflareEnv = {
   HYPERDRIVE: Hyperdrive;
+  CF_VERSION_METADATA: { id: string; tag: string; timestamp: string } | undefined;
   OWNER_QUEUE: Queue<import('./src/types').AutoAnalysisOwnerMessage>;
   CALLBACK_QUEUE: Queue<import('./src/callbacks').SecurityAnalysisCallbackMessage>;
   MANUAL_ANALYSIS_QUEUE: Queue<import('./src/manual-analysis').ManualAnalysisStartCommand>;

--- a/services/security-auto-analysis/wrangler.jsonc
+++ b/services/security-auto-analysis/wrangler.jsonc
@@ -13,6 +13,17 @@
   },
   "observability": {
     "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": false,
+    },
+  },
+  "logpush": true,
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA",
   },
   "routes": [
     {

--- a/services/security-auto-analysis/wrangler.jsonc
+++ b/services/security-auto-analysis/wrangler.jsonc
@@ -21,7 +21,6 @@
       "invocation_logs": false,
     },
   },
-  "logpush": true,
   "version_metadata": {
     "binding": "CF_VERSION_METADATA",
   },

--- a/services/security-auto-analysis/wrangler.jsonc
+++ b/services/security-auto-analysis/wrangler.jsonc
@@ -21,6 +21,7 @@
       "invocation_logs": false,
     },
   },
+  "logpush": true,
   "version_metadata": {
     "binding": "CF_VERSION_METADATA",
   },


### PR DESCRIPTION
## Summary
Adds privacy-safe dispatcher and heartbeat telemetry so transient Security Agent Auto Analysis failures can be diagnosed by stage.

### Why this change is needed
BetterStack reported short dispatcher failures, but existing logs could not identify the failing database or queue operation. Heartbeat delivery also silently ignored missing configuration, network errors, timeouts, and non-2xx responses.

### How this is addressed
- Emit stable structured events for every dispatcher stage, one sanitized failure event, and successful completion counts.
- Preserve dispatcher rethrow behavior while keeping BetterStack heartbeat delivery best-effort and independent.
- Record skipped, attempted, successful, rejected, timed-out, and network-failed heartbeat outcomes without sensitive values.
- Enable persisted Worker application logs, Logpush eligibility, and Worker version metadata while disabling raw invocation logs.
- Cover every dispatcher failure stage, heartbeat outcome, rethrow behavior, `/fail` routing, and log redaction.

## Human Verification
- Focused `security-auto-analysis` test suite passed: 14 files and 125 tests.
- Logic, security, and type-focused code review agents evaluated the changes; invocation logging was disabled based on security review.

## Reviewer Notes
### Human Reviewer Flags
- Application logs use 100% sampling for incident diagnosis, increasing observability volume.
- Account-level Workers Trace Events Logpush routing to Axiom remains a control-plane rollout step; repository configuration only makes the Worker eligible.
- Configure that job to export only `ScriptName`, `ScriptVersion`, `EventTimestampMs`, `Outcome`, and `Logs`, exclude `Event` and `Exceptions`, and filter `ScriptName == security-auto-analysis`.
- Raw Cloudflare invocation logs remain disabled because callback URLs and uncaught exceptions may contain sensitive context.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Dispatcher errors are logged once at the failing stage and rethrown unchanged.
- Error messages are fixed sanitized values; raw exception objects, stack traces, IDs, SQL, payloads, URLs, credentials, and connection strings are excluded.
- `CF_VERSION_METADATA` adds deploy-version correlation to telemetry.

</details>
