### PR TITLE
Allow parent org billing roles to access child orgs

### DIFF
--- a/apps/web/src/lib/organizations/organization-auth.test.ts
+++ b/apps/web/src/lib/organizations/organization-auth.test.ts
@@ -4,7 +4,7 @@ import { db } from '@/lib/drizzle';
 import { organization_memberships, organizations } from '@kilocode/db/schema';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { NextResponse } from 'next/server';
-import { eq } from 'drizzle-orm';
+import { eq, isNotNull } from 'drizzle-orm';
 import type { getUserFromAuth } from '@/lib/user/server';
 import { failureResult } from '@/lib/maybe-result';
 
@@ -27,6 +27,11 @@ describe('getAuthorizedOrgContext', () => {
     // Clean up organization_memberships table
     // eslint-disable-next-line drizzle/enforce-delete-with-where
     await db.delete(organization_memberships);
+    // Self-referential organization FKs require unlinking children before deleting all orgs.
+    await db
+      .update(organizations)
+      .set({ parent_organization_id: null })
+      .where(isNotNull(organizations.parent_organization_id));
     // Clean up organizations table
     // eslint-disable-next-line drizzle/enforce-delete-with-where
     await db.delete(organizations);
@@ -252,6 +257,101 @@ describe('getAuthorizedOrgContext', () => {
         expect(result.nextResponse.status).toBe(404);
         const responseBody = await result.nextResponse.json();
         expect(responseBody.error).toBe('Organization not found');
+      }
+    });
+
+    test('should allow parent organization owners to access child organizations', async () => {
+      const parentOwner = await insertTestUser({ is_admin: false });
+      const [childOrganization] = await db
+        .insert(organizations)
+        .values({ name: 'Child Organization', parent_organization_id: testOrganizationId })
+        .returning();
+
+      await db.insert(organization_memberships).values({
+        organization_id: testOrganizationId,
+        kilo_user_id: parentOwner.id,
+        role: 'owner',
+        invited_by: 'test-admin',
+      });
+
+      const mockGetUserFromAuth: typeof getUserFromAuth = async () => ({
+        user: parentOwner,
+        authFailedResponse: null,
+      });
+
+      const result = await getAuthorizedOrgContext(
+        childOrganization.id,
+        undefined,
+        mockGetUserFromAuth
+      );
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.user).toEqual({ ...parentOwner, role: 'owner' });
+        expect(result.data.organization.id).toBe(childOrganization.id);
+      }
+    });
+
+    test('should allow parent organization billing managers to access child billing pages', async () => {
+      const parentBillingManager = await insertTestUser({ is_admin: false });
+      const [childOrganization] = await db
+        .insert(organizations)
+        .values({ name: 'Child Billing Organization', parent_organization_id: testOrganizationId })
+        .returning();
+
+      await db.insert(organization_memberships).values({
+        organization_id: testOrganizationId,
+        kilo_user_id: parentBillingManager.id,
+        role: 'billing_manager',
+        invited_by: 'test-admin',
+      });
+
+      const mockGetUserFromAuth: typeof getUserFromAuth = async () => ({
+        user: parentBillingManager,
+        authFailedResponse: null,
+      });
+
+      const result = await getAuthorizedOrgContext(
+        childOrganization.id,
+        ['owner', 'billing_manager'],
+        mockGetUserFromAuth
+      );
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.user).toEqual({ ...parentBillingManager, role: 'billing_manager' });
+        expect(result.data.organization.id).toBe(childOrganization.id);
+      }
+    });
+
+    test('should deny parent organization members access to child organizations', async () => {
+      const parentMember = await insertTestUser({ is_admin: false });
+      const [childOrganization] = await db
+        .insert(organizations)
+        .values({ name: 'Child Member Organization', parent_organization_id: testOrganizationId })
+        .returning();
+
+      await db.insert(organization_memberships).values({
+        organization_id: testOrganizationId,
+        kilo_user_id: parentMember.id,
+        role: 'member',
+        invited_by: 'test-admin',
+      });
+
+      const mockGetUserFromAuth: typeof getUserFromAuth = async () => ({
+        user: parentMember,
+        authFailedResponse: null,
+      });
+
+      const result = await getAuthorizedOrgContext(
+        childOrganization.id,
+        undefined,
+        mockGetUserFromAuth
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.nextResponse.status).toBe(404);
       }
     });
   });

--- a/apps/web/src/lib/organizations/organization-auth.test.ts
+++ b/apps/web/src/lib/organizations/organization-auth.test.ts
@@ -274,6 +274,13 @@ describe('getAuthorizedOrgContext', () => {
         invited_by: 'test-admin',
       });
 
+      await db.insert(organization_memberships).values({
+        organization_id: childOrganization.id,
+        kilo_user_id: parentOwner.id,
+        role: 'member',
+        invited_by: 'test-admin',
+      });
+
       const mockGetUserFromAuth: typeof getUserFromAuth = async () => ({
         user: parentOwner,
         authFailedResponse: null,

--- a/apps/web/src/lib/organizations/organization-auth.ts
+++ b/apps/web/src/lib/organizations/organization-auth.ts
@@ -15,6 +15,7 @@ import z from 'zod';
 const warnInSentry = sentryLogger('org_auth', 'warning');
 
 const parentOrganizationAccessRoles = ['owner', 'billing_manager'] satisfies OrganizationRole[];
+const rolePriority = ['owner', 'billing_manager', 'member'] satisfies OrganizationRole[];
 
 type UserWithRole = User & {
   readonly role: OrganizationRole;
@@ -29,8 +30,11 @@ function allowedRole(
   rows: { role: OrganizationRole }[],
   roles?: OrganizationRole[]
 ): OrganizationRole | null {
-  if (!roles || roles.length === 0) return rows[0]?.role ?? null;
-  return rows.find(row => roles.includes(row.role))?.role ?? null;
+  const allowedRoles = roles && roles.length > 0 ? roles : rolePriority;
+  return (
+    rolePriority.find(role => allowedRoles.includes(role) && rows.some(row => row.role === role)) ??
+    null
+  );
 }
 
 export async function getAuthorizedOrgContext(

--- a/apps/web/src/lib/organizations/organization-auth.ts
+++ b/apps/web/src/lib/organizations/organization-auth.ts
@@ -14,6 +14,8 @@ import z from 'zod';
 
 const warnInSentry = sentryLogger('org_auth', 'warning');
 
+const parentOrganizationAccessRoles = ['owner', 'billing_manager'] satisfies OrganizationRole[];
+
 type UserWithRole = User & {
   readonly role: OrganizationRole;
 };
@@ -22,6 +24,14 @@ type DataOrNextError<T> = CustomResult<
   { data: T; nextResponse?: never },
   { data?: never; nextResponse: NextResponse<{ error: string }> }
 >;
+
+function allowedRole(
+  rows: { role: OrganizationRole }[],
+  roles?: OrganizationRole[]
+): OrganizationRole | null {
+  if (!roles || roles.length === 0) return rows[0]?.role ?? null;
+  return rows.find(row => roles.includes(row.role))?.role ?? null;
+}
 
 export async function getAuthorizedOrgContext(
   id: Organization['id'],
@@ -63,8 +73,7 @@ export async function getAuthorizedOrgContext(
       },
     });
   }
-  // if roles are provided, check if the user has one of those roles
-  const rows = await db
+  const directRows = await db
     .select({
       role: organization_memberships.role,
       organization: organizations,
@@ -75,20 +84,37 @@ export async function getAuthorizedOrgContext(
       and(
         eq(organization_memberships.kilo_user_id, user.id),
         eq(organization_memberships.organization_id, organizationId),
-        isNull(organizations.deleted_at),
-        roles && roles.length > 0 ? inArray(organization_memberships.role, roles) : undefined
+        isNull(organizations.deleted_at)
       )
     );
 
-  if (!rows.length) {
+  const inheritedRows = await db
+    .select({
+      role: organization_memberships.role,
+      organization: organizations,
+    })
+    .from(organizations)
+    .innerJoin(
+      organization_memberships,
+      and(
+        eq(organization_memberships.organization_id, organizations.parent_organization_id),
+        eq(organization_memberships.kilo_user_id, user.id),
+        inArray(organization_memberships.role, parentOrganizationAccessRoles)
+      )
+    )
+    .where(and(eq(organizations.id, organizationId), isNull(organizations.deleted_at)));
+
+  const rows = [...directRows, ...inheritedRows];
+  const role = allowedRole(rows, roles);
+
+  if (!role) {
     warnInSentry(
       `User ${user.id} attempted to access organization ${organizationId} without sufficient permissions`
     );
     const res = NextResponse.json({ error: 'Organization not found' }, { status: 404 });
     return { success: false, nextResponse: res };
   }
-  const role = rows[0].role;
-  const organization = rows[0].organization;
+  const organization = rows.find(row => row.role === role)?.organization ?? rows[0].organization;
   return successResult({
     data: {
       user: { ...user, role },

--- a/apps/web/src/routers/organizations/organization-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-router.test.ts
@@ -152,6 +152,97 @@ describe('organizations trpc router', () => {
       ).rejects.toThrow('You do not have access to this organization');
     });
 
+    it('should return child organization data for a parent organization owner', async () => {
+      const parentOwner = await insertTestUser({
+        google_user_email: 'parent-owner-org@example.com',
+        google_user_name: 'Parent Owner Org User',
+        is_admin: false,
+      });
+      const childOwner = await insertTestUser({
+        google_user_email: 'child-owner-org@example.com',
+        google_user_name: 'Child Owner Org User',
+        is_admin: false,
+      });
+      const parentOrganization = await createOrganization(
+        'Parent Access Organization',
+        parentOwner.id
+      );
+      const childOrganization = await createOrganization(
+        'Child Access Organization',
+        childOwner.id
+      );
+      await db
+        .update(organizations)
+        .set({ parent_organization_id: parentOrganization.id })
+        .where(eq(organizations.id, childOrganization.id));
+
+      try {
+        const caller = await createCallerForUser(parentOwner.id);
+        const result = await caller.organizations.withMembers({
+          organizationId: childOrganization.id,
+        });
+
+        expect(result).toMatchObject({
+          id: childOrganization.id,
+          name: 'Child Access Organization',
+        });
+      } finally {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(eq(organizations.id, childOrganization.id));
+        await db.delete(organizations).where(eq(organizations.id, childOrganization.id));
+        await db.delete(organizations).where(eq(organizations.id, parentOrganization.id));
+      }
+    });
+
+    it('should reject child organization data for a regular parent organization member', async () => {
+      const parentOwner = await insertTestUser({
+        google_user_email: 'parent-member-owner-org@example.com',
+        google_user_name: 'Parent Member Owner Org User',
+        is_admin: false,
+      });
+      const parentMember = await insertTestUser({
+        google_user_email: 'parent-member-org@example.com',
+        google_user_name: 'Parent Member Org User',
+        is_admin: false,
+      });
+      const childOwner = await insertTestUser({
+        google_user_email: 'child-member-owner-org@example.com',
+        google_user_name: 'Child Member Owner Org User',
+        is_admin: false,
+      });
+      const parentOrganization = await createOrganization(
+        'Parent Member Access Organization',
+        parentOwner.id
+      );
+      await addUserToOrganization(parentOrganization.id, parentMember.id, 'member');
+      const childOrganization = await createOrganization(
+        'Child Member Access Organization',
+        childOwner.id
+      );
+      await db
+        .update(organizations)
+        .set({ parent_organization_id: parentOrganization.id })
+        .where(eq(organizations.id, childOrganization.id));
+
+      try {
+        const caller = await createCallerForUser(parentMember.id);
+        await expect(
+          caller.organizations.withMembers({
+            organizationId: childOrganization.id,
+          })
+        ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+      } finally {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(eq(organizations.id, childOrganization.id));
+        await db.delete(organizations).where(eq(organizations.id, childOrganization.id));
+        await db.delete(organizations).where(eq(organizations.id, parentOrganization.id));
+      }
+    });
+
     it('should throw UNAUTHORIZED error for non-existent organization', async () => {
       const caller = await createCallerForUser(regularUser.id);
       const nonExistentOrgId = '550e8400-e29b-41d4-a716-446655440001'; // Valid UUID but non-existent

--- a/apps/web/src/routers/organizations/utils.ts
+++ b/apps/web/src/routers/organizations/utils.ts
@@ -14,13 +14,17 @@ export const OrganizationIdInputSchema = z.object({
 });
 
 const parentOrganizationAccessRoles = ['owner', 'billing_manager'] satisfies OrganizationRole[];
+const rolePriority = ['owner', 'billing_manager', 'member'] satisfies OrganizationRole[];
 
 function allowedRole(
   rows: { role: OrganizationRole }[],
   roles?: OrganizationRole[]
 ): OrganizationRole | null {
-  if (!roles || roles.length === 0) return rows[0]?.role ?? null;
-  return rows.find(row => roles.includes(row.role))?.role ?? null;
+  const allowedRoles = roles && roles.length > 0 ? roles : rolePriority;
+  return (
+    rolePriority.find(role => allowedRoles.includes(role) && rows.some(row => row.role === role)) ??
+    null
+  );
 }
 
 export async function ensureOrganizationAccess(

--- a/apps/web/src/routers/organizations/utils.ts
+++ b/apps/web/src/routers/organizations/utils.ts
@@ -6,12 +6,22 @@ import { requireActiveSubscriptionOrTrial } from '@/lib/organizations/trial-midd
 import { baseProcedure } from '@/lib/trpc/init';
 import type { TRPCContext } from '@/lib/trpc/init';
 import { TRPCError } from '@trpc/server';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import * as z from 'zod';
 
 export const OrganizationIdInputSchema = z.object({
   organizationId: z.uuid(),
 });
+
+const parentOrganizationAccessRoles = ['owner', 'billing_manager'] satisfies OrganizationRole[];
+
+function allowedRole(
+  rows: { role: OrganizationRole }[],
+  roles?: OrganizationRole[]
+): OrganizationRole | null {
+  if (!roles || roles.length === 0) return rows[0]?.role ?? null;
+  return rows.find(row => roles.includes(row.role))?.role ?? null;
+}
 
 export async function ensureOrganizationAccess(
   ctx: TRPCContext,
@@ -21,8 +31,7 @@ export async function ensureOrganizationAccess(
   if (ctx.user.is_admin) {
     return 'owner';
   }
-  // if roles are provided, check if the user has one of those roles
-  const rows = await db
+  const directRows = await db
     .select({ role: organization_memberships.role })
     .from(organization_memberships)
     .where(
@@ -32,6 +41,21 @@ export async function ensureOrganizationAccess(
       )
     );
 
+  const inheritedRows = await db
+    .select({ role: organization_memberships.role })
+    .from(organizations)
+    .innerJoin(
+      organization_memberships,
+      and(
+        eq(organization_memberships.organization_id, organizations.parent_organization_id),
+        eq(organization_memberships.kilo_user_id, ctx.user.id),
+        inArray(organization_memberships.role, parentOrganizationAccessRoles)
+      )
+    )
+    .where(eq(organizations.id, organizationId));
+
+  const rows = [...directRows, ...inheritedRows];
+
   if (!rows.length) {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
@@ -39,13 +63,14 @@ export async function ensureOrganizationAccess(
     });
   }
 
-  if (roles && roles.length > 0 && !rows.some(row => roles.includes(row.role))) {
+  const role = allowedRole(rows, roles);
+  if (!role) {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
       message: 'You do not have the required organizational role to access this feature',
     });
   }
-  return rows[0].role;
+  return role;
 }
 
 export async function ensureOrganizationAccessAndFetchOrg(
@@ -66,8 +91,7 @@ export async function ensureOrganizationAccessAndFetchOrg(
     return org;
   }
 
-  // Check membership and fetch organization in a single query
-  const rows = await db
+  const directRows = await db
     .select({
       role: organization_memberships.role,
       organization: organizations,
@@ -81,6 +105,24 @@ export async function ensureOrganizationAccessAndFetchOrg(
       )
     );
 
+  const inheritedRows = await db
+    .select({
+      role: organization_memberships.role,
+      organization: organizations,
+    })
+    .from(organizations)
+    .innerJoin(
+      organization_memberships,
+      and(
+        eq(organization_memberships.organization_id, organizations.parent_organization_id),
+        eq(organization_memberships.kilo_user_id, ctx.user.id),
+        inArray(organization_memberships.role, parentOrganizationAccessRoles)
+      )
+    )
+    .where(eq(organizations.id, organizationId));
+
+  const rows = [...directRows, ...inheritedRows];
+
   if (!rows.length) {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
@@ -88,14 +130,15 @@ export async function ensureOrganizationAccessAndFetchOrg(
     });
   }
 
-  if (roles && roles.length > 0 && !rows.some(row => roles.includes(row.role))) {
+  const role = allowedRole(rows, roles);
+  if (!role) {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
       message: 'You do not have the required organizational role to access this feature',
     });
   }
 
-  return rows[0].organization;
+  return rows.find(row => row.role === role)?.organization ?? rows[0].organization;
 }
 
 // Custom procedure that ensures user has access to the organization (any role)


### PR DESCRIPTION
## Summary
- Allow direct parent organization owners and billing managers to satisfy organization page and tRPC access checks for child organizations.
- Keep regular parent members denied and preserve stricter role-gated checks.
- Add coverage for inherited parent access in server page auth and organization router reads.

## Validation
- Verified that I can now access the child-organization's profile in the browser, but not when I'm just a member