### PR TITLE
Add admin child organization management

### DIFF
--- a/apps/web/src/app/admin/api/organizations/hooks.ts
+++ b/apps/web/src/app/admin/api/organizations/hooks.ts
@@ -137,13 +137,18 @@ export function useAdminOrganizationHierarchy(organizationId: string, enabled: b
   );
 }
 
-export function useSearchAdminOrganizations(search: string, limit = 10) {
+export function useSearchAdminOrganizations(
+  search: string,
+  limit = 10,
+  childOfOrganizationId?: string
+) {
   const trpc = useTRPC();
   return useQuery(
     trpc.organizations.admin.search.queryOptions(
       {
         search,
         limit,
+        childOfOrganizationId,
       },
       { enabled: search.trim().length > 0 }
     )

--- a/apps/web/src/app/admin/api/organizations/hooks.ts
+++ b/apps/web/src/app/admin/api/organizations/hooks.ts
@@ -137,6 +137,64 @@ export function useAdminOrganizationHierarchy(organizationId: string, enabled: b
   );
 }
 
+export function useSearchAdminOrganizations(search: string, limit = 10) {
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.organizations.admin.search.queryOptions(
+      {
+        search,
+        limit,
+      },
+      { enabled: search.trim().length > 0 }
+    )
+  );
+}
+
+export function useSetParentOrganization(organizationId: string) {
+  const queryClient = useQueryClient();
+  const invalidate = useInvalidateAllOrganizationData();
+  const trpc = useTRPC();
+
+  return useMutation(
+    trpc.organizations.admin.setParent.mutationOptions({
+      onSuccess: (_data, variables) => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.organizations.admin.getHierarchy.queryKey({ organizationId }),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.organizations.admin.getHierarchy.queryKey({
+            organizationId: variables.organizationId,
+          }),
+        });
+        void queryClient.invalidateQueries({ queryKey: ['admin-organizations'] });
+        void invalidate();
+      },
+    })
+  );
+}
+
+export function useCreateAdminOrganization(parentOrganizationId?: string) {
+  const queryClient = useQueryClient();
+  const invalidate = useInvalidateAllOrganizationData();
+  const trpc = useTRPC();
+
+  return useMutation(
+    trpc.organizations.admin.create.mutationOptions({
+      onSuccess: () => {
+        if (parentOrganizationId) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.organizations.admin.getHierarchy.queryKey({
+              organizationId: parentOrganizationId,
+            }),
+          });
+        }
+        void queryClient.invalidateQueries({ queryKey: ['admin-organizations'] });
+        void invalidate();
+      },
+    })
+  );
+}
+
 export function useAdminOrganizationCreditTransactions(organizationId: string) {
   const trpc = useTRPC();
   return useQuery(

--- a/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminDashboard.tsx
+++ b/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminDashboard.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import {
-  ChildOrganizationsCard,
-  OrganizationInfoCard,
-} from '@/components/organizations/OrganizationInfoCard';
+import { OrganizationInfoCard } from '@/components/organizations/OrganizationInfoCard';
 import { OrganizationAdminMembers } from '@/components/organizations/OrganizationMembersCard';
 import { OrganizationUsageSummaryCard } from '@/components/organizations/OrganizationUsageSummaryCard';
 import { SeatUsageCard } from '@/components/organizations/SeatUsageCard';
@@ -12,6 +9,7 @@ import { OrganizationAdminDelete } from './OrganizationAdminDelete';
 import { OrganizationAdminCreditGrant } from './OrganizationAdminCreditGrant';
 import { OrganizationAdminCreditNullify } from './OrganizationAdminCreditNullify';
 import { OrganizationAdminCreatedBy } from './OrganizationAdminCreatedBy';
+import { OrganizationAdminHierarchyManagement } from './OrganizationAdminHierarchyManagement';
 import { OrganizationWorkOSCard } from './OrganizationWorkOSCard';
 import { OrganizationAdminWebhooks } from './OrganizationAdminWebhooks';
 import { OrganizationContextProvider } from '@/components/organizations/OrganizationContext';
@@ -58,7 +56,7 @@ export function OrganizationAdminDashboard({ organizationId }: { organizationId:
             <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
               <div className="space-y-4">
                 <OrganizationInfoCard organizationId={organizationId} showAdminControls />
-                <ChildOrganizationsCard organizationId={organizationId} />
+                <OrganizationAdminHierarchyManagement organizationId={organizationId} />
               </div>
               <div className="space-y-7">
                 <OrganizationUsageSummaryCard organizationId={organizationId} />

--- a/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminHierarchyManagement.tsx
+++ b/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminHierarchyManagement.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { useDeferredValue, useState, type FormEvent } from 'react';
+import Link from 'next/link';
+import { Building2, Loader2, Plus, Search, Unlink } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  useAdminOrganizationHierarchy,
+  useAdminOrganizationDetails,
+  useCreateAdminOrganization,
+  useSearchAdminOrganizations,
+  useSetParentOrganization,
+} from '@/app/admin/api/organizations/hooks';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type OrganizationSearchResult = {
+  id: string;
+  name: string;
+};
+
+type OrganizationAdminHierarchyManagementProps = {
+  organizationId: string;
+};
+
+export function OrganizationAdminHierarchyManagement({
+  organizationId,
+}: OrganizationAdminHierarchyManagementProps) {
+  const hierarchyQuery = useAdminOrganizationHierarchy(organizationId, true);
+  const organizationDetailsQuery = useAdminOrganizationDetails(organizationId);
+  const setParentOrganization = useSetParentOrganization(organizationId);
+  const createOrganization = useCreateAdminOrganization(organizationId);
+  const [newChildName, setNewChildName] = useState('');
+  const [childSearch, setChildSearch] = useState('');
+  const [isAddExistingDialogOpen, setIsAddExistingDialogOpen] = useState(false);
+  const [isCreateNewDialogOpen, setIsCreateNewDialogOpen] = useState(false);
+  const [pendingChild, setPendingChild] = useState<OrganizationSearchResult | null>(null);
+  const deferredChildSearch = useDeferredValue(childSearch.trim());
+  const organizationSearchQuery = useSearchAdminOrganizations(deferredChildSearch);
+
+  const childOrganizations = hierarchyQuery.data?.children ?? [];
+  const organizationName = organizationDetailsQuery.data?.name ?? organizationId;
+  const childOrganizationIds = new Set(childOrganizations.map(child => child.id));
+  const searchResults = (organizationSearchQuery.data ?? []).filter(
+    organization => organization.id !== organizationId && !childOrganizationIds.has(organization.id)
+  );
+
+  const handleCreateChild = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const name = newChildName.trim();
+
+    if (!name) {
+      toast.error('Organization name is required');
+      return;
+    }
+
+    createOrganization.mutate(
+      { name, parentOrganizationId: organizationId },
+      {
+        onSuccess: data => {
+          toast.success(`Created child organization "${data.organization.name}"`);
+          setNewChildName('');
+          setIsCreateNewDialogOpen(false);
+        },
+        onError: error => {
+          toast.error(error.message || 'Failed to create child organization');
+        },
+      }
+    );
+  };
+
+  const handleAddExistingChild = () => {
+    if (!pendingChild) {
+      toast.error('Select an organization to add as a child');
+      return;
+    }
+
+    setParentOrganization.mutate(
+      { organizationId: pendingChild.id, parentOrganizationId: organizationId },
+      {
+        onSuccess: () => {
+          toast.success(`Added "${pendingChild.name}" as a child organization`);
+          setPendingChild(null);
+          setChildSearch('');
+        },
+        onError: error => {
+          toast.error(error.message || 'Failed to add child organization');
+        },
+      }
+    );
+  };
+
+  const handleDetachChild = (child: OrganizationSearchResult) => {
+    setParentOrganization.mutate(
+      { organizationId: child.id, parentOrganizationId: null },
+      {
+        onSuccess: () => {
+          toast.success(`Detached "${child.name}" from this parent organization`);
+        },
+        onError: error => {
+          toast.error(error.message || 'Failed to detach child organization');
+        },
+      }
+    );
+  };
+
+  const handleSelectChild = (organization: OrganizationSearchResult) => {
+    setPendingChild(organization);
+    setIsAddExistingDialogOpen(false);
+  };
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Building2 className="size-5" />
+            Child Organizations
+          </CardTitle>
+          <CardDescription>
+            Attach an existing organization as a child, or create a new empty child organization.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Button type="button" onClick={() => setIsAddExistingDialogOpen(true)}>
+              <Plus className="mr-2 size-4" />
+              Add Existing
+            </Button>
+            <Button type="button" variant="outline" onClick={() => setIsCreateNewDialogOpen(true)}>
+              <Plus className="mr-2 size-4" />
+              Create New
+            </Button>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="type-label text-foreground">Current children</h3>
+              {hierarchyQuery.isFetching ? (
+                <Loader2 className="text-muted-foreground size-4 animate-spin" />
+              ) : null}
+            </div>
+            {childOrganizations.length > 0 ? (
+              <div className="space-y-2">
+                {childOrganizations.map(childOrganization => (
+                  <div
+                    key={childOrganization.id}
+                    className="border-border bg-surface-raised flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+                  >
+                    <Link
+                      href={`/admin/organizations/${encodeURIComponent(childOrganization.id)}`}
+                      className="text-link hover:text-link-hover min-w-0 truncate text-sm font-medium underline-offset-4 hover:underline"
+                    >
+                      {childOrganization.name}
+                    </Link>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleDetachChild(childOrganization)}
+                      disabled={setParentOrganization.isPending}
+                    >
+                      <Unlink className="mr-2 size-4" />
+                      Detach
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-muted-foreground text-sm">No child organizations yet.</p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={isAddExistingDialogOpen} onOpenChange={setIsAddExistingDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Existing Organization</DialogTitle>
+            <DialogDescription>
+              Search for an organization to attach under {organizationName}.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-3">
+            <Label htmlFor="child-organization-search">Organization</Label>
+            <div className="relative">
+              <Input
+                id="child-organization-search"
+                type="text"
+                autoComplete="off"
+                value={childSearch}
+                onChange={event => setChildSearch(event.target.value)}
+                placeholder="Search by organization name or ID"
+                className="pr-10"
+              />
+              {organizationSearchQuery.isFetching ? (
+                <Loader2 className="text-muted-foreground absolute top-1/2 right-3 size-4 -translate-y-1/2 animate-spin" />
+              ) : (
+                <Search className="text-muted-foreground absolute top-1/2 right-3 size-4 -translate-y-1/2" />
+              )}
+            </div>
+            {searchResults.length > 0 ? (
+              <div className="bg-popover max-h-56 overflow-y-auto rounded-md border shadow-lg">
+                {searchResults.map(organization => (
+                  <button
+                    key={organization.id}
+                    type="button"
+                    className="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground w-full px-3 py-2 text-left text-sm focus:outline-none"
+                    onClick={() => handleSelectChild(organization)}
+                  >
+                    <span className="block font-medium">{organization.name}</span>
+                    <span className="text-muted-foreground block truncate text-xs">
+                      {organization.id}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : childSearch.trim().length > 0 && !organizationSearchQuery.isFetching ? (
+              <p className="text-muted-foreground text-sm">No matching organizations found.</p>
+            ) : null}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isCreateNewDialogOpen} onOpenChange={setIsCreateNewDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create New Child Organization</DialogTitle>
+            <DialogDescription>
+              Create a new empty organization under {organizationName}.
+            </DialogDescription>
+          </DialogHeader>
+          <form className="grid gap-4" onSubmit={handleCreateChild}>
+            <div className="grid gap-2">
+              <Label htmlFor="new-child-organization-name">Organization name</Label>
+              <Input
+                id="new-child-organization-name"
+                value={newChildName}
+                onChange={event => setNewChildName(event.target.value)}
+                autoComplete="off"
+                placeholder="New organization name"
+              />
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setIsCreateNewDialogOpen(false)}
+                disabled={createOrganization.isPending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={createOrganization.isPending}>
+                {createOrganization.isPending ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : (
+                  <Plus className="mr-2 size-4" />
+                )}
+                Create Organization
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={pendingChild !== null}
+        onOpenChange={open => {
+          if (!open) {
+            setPendingChild(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Add child organization?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure that you want to add {pendingChild?.name ?? 'this organization'} as a
+              child of {organizationName}?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={setParentOrganization.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleAddExistingChild}
+              disabled={setParentOrganization.isPending}
+            >
+              {setParentOrganization.isPending ? (
+                <Loader2 className="mr-2 size-4 animate-spin" />
+              ) : null}
+              Add Child
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminHierarchyManagement.tsx
+++ b/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminHierarchyManagement.tsx
@@ -37,6 +37,12 @@ import { Label } from '@/components/ui/label';
 type OrganizationSearchResult = {
   id: string;
   name: string;
+  has_children: boolean;
+};
+
+type OrganizationSummary = {
+  id: string;
+  name: string;
 };
 
 type OrganizationAdminHierarchyManagementProps = {
@@ -68,7 +74,8 @@ export function OrganizationAdminHierarchyManagement({
     organization =>
       organization.id !== organizationId &&
       !childOrganizationIds.has(organization.id) &&
-      !ancestorOrganizationIds.has(organization.id)
+      !ancestorOrganizationIds.has(organization.id) &&
+      !organization.has_children
   );
 
   const handleCreateChild = (event: FormEvent<HTMLFormElement>) => {
@@ -116,7 +123,7 @@ export function OrganizationAdminHierarchyManagement({
     );
   };
 
-  const handleDetachChild = (child: OrganizationSearchResult) => {
+  const handleDetachChild = (child: OrganizationSummary) => {
     setParentOrganization.mutate(
       { organizationId: child.id, parentOrganizationId: null },
       {

--- a/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminHierarchyManagement.tsx
+++ b/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminHierarchyManagement.tsx
@@ -61,8 +61,14 @@ export function OrganizationAdminHierarchyManagement({
   const childOrganizations = hierarchyQuery.data?.children ?? [];
   const organizationName = organizationDetailsQuery.data?.name ?? organizationId;
   const childOrganizationIds = new Set(childOrganizations.map(child => child.id));
+  const ancestorOrganizationIds = new Set(
+    (hierarchyQuery.data?.ancestors ?? []).map(ancestor => ancestor.id)
+  );
   const searchResults = (organizationSearchQuery.data ?? []).filter(
-    organization => organization.id !== organizationId && !childOrganizationIds.has(organization.id)
+    organization =>
+      organization.id !== organizationId &&
+      !childOrganizationIds.has(organization.id) &&
+      !ancestorOrganizationIds.has(organization.id)
   );
 
   const handleCreateChild = (event: FormEvent<HTMLFormElement>) => {

--- a/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminHierarchyManagement.tsx
+++ b/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminHierarchyManagement.tsx
@@ -37,7 +37,6 @@ import { Label } from '@/components/ui/label';
 type OrganizationSearchResult = {
   id: string;
   name: string;
-  has_children: boolean;
 };
 
 type OrganizationSummary = {
@@ -62,21 +61,16 @@ export function OrganizationAdminHierarchyManagement({
   const [isCreateNewDialogOpen, setIsCreateNewDialogOpen] = useState(false);
   const [pendingChild, setPendingChild] = useState<OrganizationSearchResult | null>(null);
   const deferredChildSearch = useDeferredValue(childSearch.trim());
-  const organizationSearchQuery = useSearchAdminOrganizations(deferredChildSearch);
+  const organizationSearchQuery = useSearchAdminOrganizations(
+    deferredChildSearch,
+    10,
+    organizationId
+  );
 
   const childOrganizations = hierarchyQuery.data?.children ?? [];
   const organizationName = organizationDetailsQuery.data?.name ?? organizationId;
-  const childOrganizationIds = new Set(childOrganizations.map(child => child.id));
-  const ancestorOrganizationIds = new Set(
-    (hierarchyQuery.data?.ancestors ?? []).map(ancestor => ancestor.id)
-  );
-  const searchResults = (organizationSearchQuery.data ?? []).filter(
-    organization =>
-      organization.id !== organizationId &&
-      !childOrganizationIds.has(organization.id) &&
-      !ancestorOrganizationIds.has(organization.id) &&
-      !organization.has_children
-  );
+  const canManageChildren = hierarchyQuery.data?.parent === null;
+  const searchResults = organizationSearchQuery.data ?? [];
 
   const handleCreateChild = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -156,15 +150,29 @@ export function OrganizationAdminHierarchyManagement({
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="flex flex-col gap-2 sm:flex-row">
-            <Button type="button" onClick={() => setIsAddExistingDialogOpen(true)}>
+            <Button
+              type="button"
+              onClick={() => setIsAddExistingDialogOpen(true)}
+              disabled={!canManageChildren}
+            >
               <Plus className="mr-2 size-4" />
               Add Existing
             </Button>
-            <Button type="button" variant="outline" onClick={() => setIsCreateNewDialogOpen(true)}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setIsCreateNewDialogOpen(true)}
+              disabled={!canManageChildren}
+            >
               <Plus className="mr-2 size-4" />
               Create New
             </Button>
           </div>
+          {!canManageChildren ? (
+            <p className="text-muted-foreground text-sm">
+              Child organizations cannot have their own child organizations yet.
+            </p>
+          ) : null}
 
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-3">

--- a/apps/web/src/routers/organizations/organization-admin-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.test.ts
@@ -7,11 +7,15 @@ import {
   organization_memberships,
   kilo_pass_subscriptions,
 } from '@kilocode/db/schema';
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, inArray, sql } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
 import { KiloPassCadence, KiloPassTier } from '@/lib/kilo-pass/enums';
 import type { User, Organization } from '@kilocode/db/schema';
+
+jest.mock('@/lib/organizations/organization-billing', () => ({
+  getOrCreateStripeCustomerIdForOrganization: jest.fn().mockResolvedValue('cus_test_admin_org'),
+}));
 
 let adminUser: User;
 let adminWithoutCreditAccess: User;
@@ -790,6 +794,127 @@ describe('organization admin router', () => {
               parentOrganization.id,
             ])
           );
+      }
+    });
+  });
+
+  describe('hierarchy management', () => {
+    it('creates an empty child organization under a parent organization', async () => {
+      const searchPrefix = `Admin Create Child Org ${crypto.randomUUID()}`;
+      const parentOrganization = await createOrganization(`${searchPrefix} parent`, adminUser.id);
+      const caller = await createCallerForUser(adminUser.id);
+      let childOrganizationId: string | null = null;
+
+      try {
+        const result = await caller.organizations.admin.create({
+          name: `${searchPrefix} child`,
+          parentOrganizationId: parentOrganization.id,
+        });
+        childOrganizationId = result.organization.id;
+
+        const [childOrganization] = await db
+          .select({
+            parent_organization_id: organizations.parent_organization_id,
+            member_count: sql<number>`(
+              SELECT COUNT(*)::int
+              FROM ${organization_memberships}
+              WHERE ${organization_memberships.organization_id} = ${organizations.id}
+            )`,
+          })
+          .from(organizations)
+          .where(eq(organizations.id, childOrganizationId));
+
+        expect(result.organization.parent_organization_id).toBe(parentOrganization.id);
+        expect(childOrganization.parent_organization_id).toBe(parentOrganization.id);
+        expect(childOrganization.member_count).toBe(0);
+      } finally {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(eq(organizations.parent_organization_id, parentOrganization.id));
+        if (childOrganizationId) {
+          await db.delete(organizations).where(eq(organizations.id, childOrganizationId));
+        }
+        await db.delete(organizations).where(eq(organizations.id, parentOrganization.id));
+      }
+    });
+
+    it('sets an existing organization as a child organization', async () => {
+      const searchPrefix = `Admin Set Child Org ${crypto.randomUUID()}`;
+      const parentOrganization = await createOrganization(`${searchPrefix} parent`, adminUser.id);
+      const childOrganization = await createOrganization(`${searchPrefix} child`, adminUser.id);
+
+      try {
+        const caller = await createCallerForUser(adminUser.id);
+        await caller.organizations.admin.setParent({
+          organizationId: childOrganization.id,
+          parentOrganizationId: parentOrganization.id,
+        });
+
+        const hierarchy = await caller.organizations.admin.getHierarchy({
+          organizationId: parentOrganization.id,
+        });
+
+        expect(hierarchy.children).toContainEqual({
+          id: childOrganization.id,
+          name: childOrganization.name,
+        });
+      } finally {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(eq(organizations.id, childOrganization.id));
+        await db
+          .delete(organizations)
+          .where(inArray(organizations.id, [childOrganization.id, parentOrganization.id]));
+      }
+    });
+
+    it('rejects hierarchy cycles', async () => {
+      const searchPrefix = `Admin Hierarchy Cycle ${crypto.randomUUID()}`;
+      const parentOrganization = await createOrganization(`${searchPrefix} parent`, adminUser.id);
+      const childOrganization = await createOrganization(`${searchPrefix} child`, adminUser.id);
+
+      try {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: parentOrganization.id })
+          .where(eq(organizations.id, childOrganization.id));
+
+        const caller = await createCallerForUser(adminUser.id);
+        await expect(
+          caller.organizations.admin.setParent({
+            organizationId: parentOrganization.id,
+            parentOrganizationId: childOrganization.id,
+          })
+        ).rejects.toThrow('Cannot create a cycle in the organization hierarchy');
+      } finally {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(inArray(organizations.id, [childOrganization.id, parentOrganization.id]));
+        await db
+          .delete(organizations)
+          .where(inArray(organizations.id, [childOrganization.id, parentOrganization.id]));
+      }
+    });
+
+    it('rejects self-parenting', async () => {
+      const organization = await createOrganization(
+        `Admin Hierarchy Self Parent ${crypto.randomUUID()}`,
+        adminUser.id
+      );
+
+      try {
+        const caller = await createCallerForUser(adminUser.id);
+        await expect(
+          caller.organizations.admin.setParent({
+            organizationId: organization.id,
+            parentOrganizationId: organization.id,
+          })
+        ).rejects.toThrow('An organization cannot be its own parent');
+      } finally {
+        await db.delete(organizations).where(eq(organizations.id, organization.id));
       }
     });
   });

--- a/apps/web/src/routers/organizations/organization-admin-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.test.ts
@@ -926,10 +926,7 @@ describe('organization admin router', () => {
           childOfOrganizationId: parentOrganization.id,
         });
 
-        expect(results.map(organization => organization.id)).toEqual([
-          addableOrganization.id,
-          childOfCandidate.id,
-        ]);
+        expect(results.map(organization => organization.id)).toEqual([addableOrganization.id]);
       } finally {
         await db
           .update(organizations)

--- a/apps/web/src/routers/organizations/organization-admin-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.test.ts
@@ -752,11 +752,19 @@ describe('organization admin router', () => {
   describe('getHierarchy', () => {
     it('returns parent and child organization summaries', async () => {
       const searchPrefix = `Admin Org Hierarchy ${crypto.randomUUID()}`;
+      const grandparentOrganization = await createOrganization(
+        `${searchPrefix} grandparent`,
+        adminUser.id
+      );
       const parentOrganization = await createOrganization(`${searchPrefix} parent`, adminUser.id);
       const childOrganization = await createOrganization(`${searchPrefix} child`, adminUser.id);
       const siblingOrganization = await createOrganization(`${searchPrefix} sibling`, adminUser.id);
 
       try {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: grandparentOrganization.id })
+          .where(eq(organizations.id, parentOrganization.id));
         await db
           .update(organizations)
           .set({ parent_organization_id: parentOrganization.id })
@@ -774,8 +782,18 @@ describe('organization admin router', () => {
           id: parentOrganization.id,
           name: parentOrganization.name,
         });
+        expect(childHierarchy.ancestors).toEqual([
+          { id: parentOrganization.id, name: parentOrganization.name },
+          { id: grandparentOrganization.id, name: grandparentOrganization.name },
+        ]);
         expect(childHierarchy.children).toEqual([]);
-        expect(parentHierarchy.parent).toBeNull();
+        expect(parentHierarchy.parent).toEqual({
+          id: grandparentOrganization.id,
+          name: grandparentOrganization.name,
+        });
+        expect(parentHierarchy.ancestors).toEqual([
+          { id: grandparentOrganization.id, name: grandparentOrganization.name },
+        ]);
         expect(parentHierarchy.children).toEqual([
           { id: childOrganization.id, name: childOrganization.name },
           { id: siblingOrganization.id, name: siblingOrganization.name },
@@ -784,7 +802,13 @@ describe('organization admin router', () => {
         await db
           .update(organizations)
           .set({ parent_organization_id: null })
-          .where(inArray(organizations.id, [childOrganization.id, siblingOrganization.id]));
+          .where(
+            inArray(organizations.id, [
+              childOrganization.id,
+              siblingOrganization.id,
+              parentOrganization.id,
+            ])
+          );
         await db
           .delete(organizations)
           .where(
@@ -792,6 +816,7 @@ describe('organization admin router', () => {
               childOrganization.id,
               siblingOrganization.id,
               parentOrganization.id,
+              grandparentOrganization.id,
             ])
           );
       }

--- a/apps/web/src/routers/organizations/organization-admin-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.test.ts
@@ -895,6 +895,100 @@ describe('organization admin router', () => {
       }
     });
 
+    it('only returns addable organizations from child autocomplete search', async () => {
+      const searchPrefix = `Admin Addable Child Search ${crypto.randomUUID()}`;
+      const parentOrganization = await createOrganization(`${searchPrefix} parent`, adminUser.id);
+      const directChildOrganization = await createOrganization(
+        `${searchPrefix} direct child`,
+        adminUser.id
+      );
+      const parentCandidate = await createOrganization(`${searchPrefix} has child`, adminUser.id);
+      const childOfCandidate = await createOrganization(
+        `${searchPrefix} child of candidate`,
+        adminUser.id
+      );
+      const addableOrganization = await createOrganization(`${searchPrefix} addable`, adminUser.id);
+
+      try {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: parentOrganization.id })
+          .where(eq(organizations.id, directChildOrganization.id));
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: parentCandidate.id })
+          .where(eq(organizations.id, childOfCandidate.id));
+
+        const caller = await createCallerForUser(adminUser.id);
+        const results = await caller.organizations.admin.search({
+          search: searchPrefix,
+          limit: 20,
+          childOfOrganizationId: parentOrganization.id,
+        });
+
+        expect(results.map(organization => organization.id)).toEqual([
+          addableOrganization.id,
+          childOfCandidate.id,
+        ]);
+      } finally {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(inArray(organizations.id, [directChildOrganization.id, childOfCandidate.id]));
+        await db
+          .delete(organizations)
+          .where(
+            inArray(organizations.id, [
+              addableOrganization.id,
+              childOfCandidate.id,
+              parentCandidate.id,
+              directChildOrganization.id,
+              parentOrganization.id,
+            ])
+          );
+      }
+    });
+
+    it('returns no addable autocomplete results when the target parent is a child', async () => {
+      const searchPrefix = `Admin Child Target Search ${crypto.randomUUID()}`;
+      const rootOrganization = await createOrganization(`${searchPrefix} root`, adminUser.id);
+      const childOrganization = await createOrganization(`${searchPrefix} child`, adminUser.id);
+      const candidateOrganization = await createOrganization(
+        `${searchPrefix} candidate`,
+        adminUser.id
+      );
+
+      try {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: rootOrganization.id })
+          .where(eq(organizations.id, childOrganization.id));
+
+        const caller = await createCallerForUser(adminUser.id);
+        const results = await caller.organizations.admin.search({
+          search: searchPrefix,
+          limit: 20,
+          childOfOrganizationId: childOrganization.id,
+        });
+
+        expect(results).toEqual([]);
+      } finally {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(eq(organizations.id, childOrganization.id));
+        await db
+          .delete(organizations)
+          .where(
+            inArray(organizations.id, [
+              candidateOrganization.id,
+              childOrganization.id,
+              rootOrganization.id,
+            ])
+          );
+      }
+    });
+
     it('rejects hierarchy cycles', async () => {
       const searchPrefix = `Admin Hierarchy Cycle ${crypto.randomUUID()}`;
       const parentOrganization = await createOrganization(`${searchPrefix} parent`, adminUser.id);

--- a/apps/web/src/routers/organizations/organization-admin-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.test.ts
@@ -912,7 +912,9 @@ describe('organization admin router', () => {
             organizationId: parentOrganization.id,
             parentOrganizationId: childOrganization.id,
           })
-        ).rejects.toThrow('Cannot create a cycle in the organization hierarchy');
+        ).rejects.toThrow(
+          'Cannot add a parent to an organization that already has child organizations'
+        );
       } finally {
         await db
           .update(organizations)
@@ -921,6 +923,100 @@ describe('organization admin router', () => {
         await db
           .delete(organizations)
           .where(inArray(organizations.id, [childOrganization.id, parentOrganization.id]));
+      }
+    });
+
+    it('rejects adding child organizations to a child organization', async () => {
+      const searchPrefix = `Admin Child Parent ${crypto.randomUUID()}`;
+      const rootOrganization = await createOrganization(`${searchPrefix} root`, adminUser.id);
+      const childOrganization = await createOrganization(`${searchPrefix} child`, adminUser.id);
+      const newChildOrganization = await createOrganization(
+        `${searchPrefix} new child`,
+        adminUser.id
+      );
+
+      try {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: rootOrganization.id })
+          .where(eq(organizations.id, childOrganization.id));
+
+        const caller = await createCallerForUser(adminUser.id);
+        await expect(
+          caller.organizations.admin.setParent({
+            organizationId: newChildOrganization.id,
+            parentOrganizationId: childOrganization.id,
+          })
+        ).rejects.toThrow(
+          'Cannot add child organizations to an organization that is already a child'
+        );
+
+        await expect(
+          caller.organizations.admin.create({
+            name: `${searchPrefix} created child`,
+            parentOrganizationId: childOrganization.id,
+          })
+        ).rejects.toThrow(
+          'Cannot add child organizations to an organization that is already a child'
+        );
+      } finally {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(inArray(organizations.id, [childOrganization.id, newChildOrganization.id]));
+        await db
+          .delete(organizations)
+          .where(
+            inArray(organizations.id, [
+              newChildOrganization.id,
+              childOrganization.id,
+              rootOrganization.id,
+            ])
+          );
+      }
+    });
+
+    it('rejects adding a parent to an organization with child organizations', async () => {
+      const searchPrefix = `Admin Parent Child ${crypto.randomUUID()}`;
+      const parentOrganization = await createOrganization(`${searchPrefix} parent`, adminUser.id);
+      const existingParentOrganization = await createOrganization(
+        `${searchPrefix} existing parent`,
+        adminUser.id
+      );
+      const existingChildOrganization = await createOrganization(
+        `${searchPrefix} existing child`,
+        adminUser.id
+      );
+
+      try {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: existingParentOrganization.id })
+          .where(eq(organizations.id, existingChildOrganization.id));
+
+        const caller = await createCallerForUser(adminUser.id);
+        await expect(
+          caller.organizations.admin.setParent({
+            organizationId: existingParentOrganization.id,
+            parentOrganizationId: parentOrganization.id,
+          })
+        ).rejects.toThrow(
+          'Cannot add a parent to an organization that already has child organizations'
+        );
+      } finally {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(eq(organizations.id, existingChildOrganization.id));
+        await db
+          .delete(organizations)
+          .where(
+            inArray(organizations.id, [
+              existingChildOrganization.id,
+              existingParentOrganization.id,
+              parentOrganization.id,
+            ])
+          );
       }
     });
 

--- a/apps/web/src/routers/organizations/organization-admin-router.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.ts
@@ -1,5 +1,5 @@
 import { adminProcedure, createTRPCRouter, creditManagerProcedure } from '@/lib/trpc/init';
-import { db } from '@/lib/drizzle';
+import { db, type DrizzleTransaction } from '@/lib/drizzle';
 import {
   organizations,
   organization_memberships,
@@ -195,9 +195,10 @@ const AddMemberInputSchema = z.object({
 
 async function validateParentOrganizationChange(
   organizationId: string,
-  parentOrganizationId: string | null
+  parentOrganizationId: string | null,
+  txn: DrizzleTransaction
 ) {
-  const [organization] = await db
+  const [organization] = await txn
     .select({ id: organizations.id })
     .from(organizations)
     .where(and(eq(organizations.id, organizationId), isNull(organizations.deleted_at)))
@@ -240,7 +241,7 @@ async function validateParentOrganizationChange(
     }
     visitedOrganizationIds.add(currentParentId);
 
-    const [parentOrganization] = await db
+    const [parentOrganization] = await txn
       .select({ parent_organization_id: organizations.parent_organization_id })
       .from(organizations)
       .where(and(eq(organizations.id, currentParentId), isNull(organizations.deleted_at)))
@@ -294,12 +295,15 @@ export const organizationAdminRouter = createTRPCRouter({
   }),
 
   setParent: adminProcedure.input(SetParentOrganizationInputSchema).mutation(async ({ input }) => {
-    await validateParentOrganizationChange(input.organizationId, input.parentOrganizationId);
+    await db.transaction(async tx => {
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(20260624, 1)`);
+      await validateParentOrganizationChange(input.organizationId, input.parentOrganizationId, tx);
 
-    await db
-      .update(organizations)
-      .set({ parent_organization_id: input.parentOrganizationId })
-      .where(eq(organizations.id, input.organizationId));
+      await tx
+        .update(organizations)
+        .set({ parent_organization_id: input.parentOrganizationId })
+        .where(eq(organizations.id, input.organizationId));
+    });
 
     return successResult();
   }),

--- a/apps/web/src/routers/organizations/organization-admin-router.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.ts
@@ -144,6 +144,7 @@ const OrganizationHierarchySummarySchema = z.object({
 
 const AdminOrganizationHierarchySchema = z.object({
   parent: OrganizationHierarchySummarySchema.nullable(),
+  ancestors: z.array(OrganizationHierarchySummarySchema),
   children: z.array(OrganizationHierarchySummarySchema),
 });
 
@@ -453,6 +454,34 @@ export const organizationAdminRouter = createTRPCRouter({
         });
       }
 
+      const ancestors: Array<z.infer<typeof OrganizationHierarchySummarySchema>> = [];
+      const visitedAncestorIds = new Set<string>();
+      let currentParentId = organizationHierarchy.parent_id;
+
+      while (currentParentId) {
+        if (visitedAncestorIds.has(currentParentId)) {
+          break;
+        }
+        visitedAncestorIds.add(currentParentId);
+
+        const [ancestor] = await db
+          .select({
+            id: organizations.id,
+            name: organizations.name,
+            parent_organization_id: organizations.parent_organization_id,
+          })
+          .from(organizations)
+          .where(eq(organizations.id, currentParentId))
+          .limit(1);
+
+        if (!ancestor) {
+          break;
+        }
+
+        ancestors.push({ id: ancestor.id, name: ancestor.name });
+        currentParentId = ancestor.parent_organization_id;
+      }
+
       const children = await db
         .select({
           id: organizations.id,
@@ -469,6 +498,7 @@ export const organizationAdminRouter = createTRPCRouter({
               name: organizationHierarchy.parent_name ?? 'Unknown organization',
             }
           : null,
+        ancestors,
         children,
       };
     }),

--- a/apps/web/src/routers/organizations/organization-admin-router.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.ts
@@ -89,12 +89,12 @@ const OrganizationListInputSchema = z.object({
 const OrganizationSearchInputSchema = z.object({
   search: z.string().min(1),
   limit: z.number().int().min(1).max(50).default(10),
+  childOfOrganizationId: z.uuid().optional(),
 });
 
 const OrganizationSearchResultSchema = z.object({
   id: z.string(),
   name: z.string(),
-  has_children: z.boolean(),
 });
 
 const OrganizationCreateInputSchema = z.object({
@@ -1242,7 +1242,7 @@ export const organizationAdminRouter = createTRPCRouter({
     .input(OrganizationSearchInputSchema)
     .output(z.array(OrganizationSearchResultSchema))
     .query(async ({ input }) => {
-      const { search, limit } = input;
+      const { search, limit, childOfOrganizationId } = input;
       const searchTerm = search.trim();
 
       if (!searchTerm) {
@@ -1255,17 +1255,35 @@ export const organizationAdminRouter = createTRPCRouter({
         searchConditions.push(eq(organizations.id, searchTerm));
       }
 
+      const conditions = [or(...searchConditions), isNull(organizations.deleted_at)];
+
+      if (childOfOrganizationId) {
+        const [parentOrganization] = await db
+          .select({ parent_organization_id: organizations.parent_organization_id })
+          .from(organizations)
+          .where(and(eq(organizations.id, childOfOrganizationId), isNull(organizations.deleted_at)))
+          .limit(1);
+
+        if (!parentOrganization || parentOrganization.parent_organization_id) {
+          return [];
+        }
+
+        conditions.push(ne(organizations.id, childOfOrganizationId));
+        conditions.push(
+          sql`${organizations.parent_organization_id} IS DISTINCT FROM ${childOfOrganizationId}`
+        );
+        conditions.push(
+          sql`NOT EXISTS (SELECT 1 FROM ${organizations} child_organizations WHERE child_organizations.parent_organization_id = ${organizations.id} AND child_organizations.deleted_at IS NULL)`
+        );
+      }
+
       const results = await db
         .select({
           id: organizations.id,
           name: organizations.name,
-          has_children:
-            sql<boolean>`EXISTS (SELECT 1 FROM organizations child_organizations WHERE child_organizations.parent_organization_id = ${organizations.id} AND child_organizations.deleted_at IS NULL)`.as(
-              'has_children'
-            ),
         })
         .from(organizations)
-        .where(and(or(...searchConditions), isNull(organizations.deleted_at)))
+        .where(and(...conditions))
         .orderBy(asc(organizations.name))
         .limit(limit);
 

--- a/apps/web/src/routers/organizations/organization-admin-router.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.ts
@@ -94,6 +94,7 @@ const OrganizationSearchInputSchema = z.object({
 const OrganizationSearchResultSchema = z.object({
   id: z.string(),
   name: z.string(),
+  has_children: z.boolean(),
 });
 
 const OrganizationCreateInputSchema = z.object({
@@ -223,6 +224,24 @@ async function validateParentOrganizationChange(
     });
   }
 
+  const [childOrganization] = await txn
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(
+      and(
+        eq(organizations.parent_organization_id, organizationId),
+        isNull(organizations.deleted_at)
+      )
+    )
+    .limit(1);
+
+  if (childOrganization) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Cannot add a parent to an organization that already has child organizations',
+    });
+  }
+
   let currentParentId: string | null = parentOrganizationId;
   const visitedOrganizationIds = new Set<string>();
 
@@ -255,6 +274,13 @@ async function validateParentOrganizationChange(
       });
     }
 
+    if (currentParentId === parentOrganizationId && parentOrganization.parent_organization_id) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Cannot add child organizations to an organization that is already a child',
+      });
+    }
+
     currentParentId = parentOrganization.parent_organization_id;
   }
 }
@@ -262,37 +288,41 @@ async function validateParentOrganizationChange(
 export const organizationAdminRouter = createTRPCRouter({
   create: adminProcedure.input(OrganizationCreateInputSchema).mutation(async opts => {
     const parentOrganizationId = opts.input.parentOrganizationId ?? null;
-    if (parentOrganizationId) {
-      const [parentOrganization] = await db
-        .select({ id: organizations.id })
-        .from(organizations)
-        .where(and(eq(organizations.id, parentOrganizationId), isNull(organizations.deleted_at)))
-        .limit(1);
 
-      if (!parentOrganization) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Parent organization not found',
-        });
-      }
+    if (!parentOrganizationId) {
+      const organization = await createOrganization(opts.input.name);
+      await getOrCreateStripeCustomerIdForOrganization(organization.id);
+      return { organization };
     }
 
-    const organization = await createOrganization(opts.input.name);
+    const organization = await db.transaction(async tx => {
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(20260624, 1)`);
 
-    const organizationWithParent = parentOrganizationId
-      ? { ...organization, parent_organization_id: parentOrganizationId }
-      : organization;
+      const now = new Date();
+      const trialEndDate = new Date(
+        now.getTime() + ORGANIZATION_TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000
+      );
+      const [createdOrganization] = await tx
+        .insert(organizations)
+        .values({
+          name: opts.input.name,
+          require_seats: true,
+          free_trial_end_at: trialEndDate.toISOString(),
+          parent_organization_id: parentOrganizationId,
+          settings: {
+            enable_usage_limits: false,
+            code_indexing_enabled: true,
+          },
+        })
+        .returning();
 
-    if (parentOrganizationId) {
-      await db
-        .update(organizations)
-        .set({ parent_organization_id: parentOrganizationId })
-        .where(eq(organizations.id, organization.id));
-    }
+      await validateParentOrganizationChange(createdOrganization.id, parentOrganizationId, tx);
+      return createdOrganization;
+    });
 
     // create stripe customer id on org creation
     await getOrCreateStripeCustomerIdForOrganization(organization.id);
-    return { organization: organizationWithParent };
+    return { organization };
   }),
 
   setParent: adminProcedure.input(SetParentOrganizationInputSchema).mutation(async ({ input }) => {
@@ -1229,6 +1259,10 @@ export const organizationAdminRouter = createTRPCRouter({
         .select({
           id: organizations.id,
           name: organizations.name,
+          has_children:
+            sql<boolean>`EXISTS (SELECT 1 FROM organizations child_organizations WHERE child_organizations.parent_organization_id = ${organizations.id} AND child_organizations.deleted_at IS NULL)`.as(
+              'has_children'
+            ),
         })
         .from(organizations)
         .where(and(or(...searchConditions), isNull(organizations.deleted_at)))

--- a/apps/web/src/routers/organizations/organization-admin-router.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.ts
@@ -98,6 +98,7 @@ const OrganizationSearchResultSchema = z.object({
 
 const OrganizationCreateInputSchema = z.object({
   name: z.string().min(1, 'Organization name is required').trim(),
+  parentOrganizationId: z.uuid().nullable().optional(),
 });
 
 const OrganizationIdInputSchema = z.object({
@@ -107,6 +108,11 @@ const OrganizationIdInputSchema = z.object({
 const UpdateCreatedByInputSchema = z.object({
   organizationId: z.uuid(),
   userId: z.string().uuid().nullable(),
+});
+
+const SetParentOrganizationInputSchema = z.object({
+  organizationId: z.uuid(),
+  parentOrganizationId: z.uuid().nullable(),
 });
 
 const UpdateFreeTrialEndAtInputSchema = z.object({
@@ -187,12 +193,115 @@ const AddMemberInputSchema = z.object({
   role: z.enum(['owner', 'member', 'billing_manager']),
 });
 
+async function validateParentOrganizationChange(
+  organizationId: string,
+  parentOrganizationId: string | null
+) {
+  const [organization] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(and(eq(organizations.id, organizationId), isNull(organizations.deleted_at)))
+    .limit(1);
+
+  if (!organization) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Organization not found',
+    });
+  }
+
+  if (!parentOrganizationId) {
+    return;
+  }
+
+  if (organizationId === parentOrganizationId) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'An organization cannot be its own parent',
+    });
+  }
+
+  let currentParentId: string | null = parentOrganizationId;
+  const visitedOrganizationIds = new Set<string>();
+
+  while (currentParentId) {
+    if (currentParentId === organizationId) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Cannot create a cycle in the organization hierarchy',
+      });
+    }
+
+    if (visitedOrganizationIds.has(currentParentId)) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Existing organization hierarchy contains a cycle',
+      });
+    }
+    visitedOrganizationIds.add(currentParentId);
+
+    const [parentOrganization] = await db
+      .select({ parent_organization_id: organizations.parent_organization_id })
+      .from(organizations)
+      .where(and(eq(organizations.id, currentParentId), isNull(organizations.deleted_at)))
+      .limit(1);
+
+    if (!parentOrganization) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Parent organization not found',
+      });
+    }
+
+    currentParentId = parentOrganization.parent_organization_id;
+  }
+}
+
 export const organizationAdminRouter = createTRPCRouter({
   create: adminProcedure.input(OrganizationCreateInputSchema).mutation(async opts => {
+    const parentOrganizationId = opts.input.parentOrganizationId ?? null;
+    if (parentOrganizationId) {
+      const [parentOrganization] = await db
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(and(eq(organizations.id, parentOrganizationId), isNull(organizations.deleted_at)))
+        .limit(1);
+
+      if (!parentOrganization) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Parent organization not found',
+        });
+      }
+    }
+
     const organization = await createOrganization(opts.input.name);
+
+    const organizationWithParent = parentOrganizationId
+      ? { ...organization, parent_organization_id: parentOrganizationId }
+      : organization;
+
+    if (parentOrganizationId) {
+      await db
+        .update(organizations)
+        .set({ parent_organization_id: parentOrganizationId })
+        .where(eq(organizations.id, organization.id));
+    }
+
     // create stripe customer id on org creation
     await getOrCreateStripeCustomerIdForOrganization(organization.id);
-    return { organization };
+    return { organization: organizationWithParent };
+  }),
+
+  setParent: adminProcedure.input(SetParentOrganizationInputSchema).mutation(async ({ input }) => {
+    await validateParentOrganizationChange(input.organizationId, input.parentOrganizationId);
+
+    await db
+      .update(organizations)
+      .set({ parent_organization_id: input.parentOrganizationId })
+      .where(eq(organizations.id, input.organizationId));
+
+    return successResult();
   }),
 
   updateCreatedBy: adminProcedure.input(UpdateCreatedByInputSchema).mutation(async ({ input }) => {

--- a/apps/web/src/routers/organizations/organization-admin-router.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.ts
@@ -1269,9 +1269,7 @@ export const organizationAdminRouter = createTRPCRouter({
         }
 
         conditions.push(ne(organizations.id, childOfOrganizationId));
-        conditions.push(
-          sql`${organizations.parent_organization_id} IS DISTINCT FROM ${childOfOrganizationId}`
-        );
+        conditions.push(isNull(organizations.parent_organization_id));
         conditions.push(
           sql`NOT EXISTS (SELECT 1 FROM ${organizations} child_organizations WHERE child_organizations.parent_organization_id = ${organizations.id} AND child_organizations.deleted_at IS NULL)`
         );


### PR DESCRIPTION
## Summary
- Add admin TRPC mutations to create child organizations and attach/detach existing child organizations with self-parent and cycle validation.
- Add a child organization management card on admin organization detail pages with dialog-based add-existing and create-new flows.
- Cover hierarchy management behavior with focused organization admin router tests.

https://github.com/user-attachments/assets/0b5210fa-68bd-465b-b88e-905af840ac00
