### PR TITLE
fix(security-agent): improve finding remediation and reports

### DIFF
--- a/.specs/security-agent.md
+++ b/.specs/security-agent.md
@@ -104,6 +104,8 @@ Findings whose analysis recommends `monitor` MUST NOT be remediated automaticall
 
 Findings whose exploitability is unknown MUST NOT be remediated automatically. Manual Remediation MAY proceed after the user reviews the finding when the analysis recommends opening a PR or manual review and the analysis or source metadata provides a concrete remediation path.
 
+Findings whose analysis says the vulnerable feature is not reachable MUST NOT be remediated automatically. Manual Remediation MAY proceed when the finding remains open and the analysis or source metadata provides a concrete dependency patch path or suggested fix.
+
 Triage-only analysis MUST NOT be enough to start remediation.
 
 ### Scenario: Eligible Finding
@@ -199,7 +201,7 @@ Manual Remediation MUST bypass automatic policy gates and MAY use the reviewed-f
 - Auto Remediation does not need to be enabled;
 - the finding does not need to meet the automatic severity threshold;
 - the analysis does not need to have completed after Auto Remediation was enabled.
-- the analysis MAY have unknown exploitability or recommend manual review when the user chooses to proceed and a concrete remediation path exists.
+- the analysis MAY have unknown exploitability, find the vulnerable feature unreachable, or recommend manual review when the user chooses to proceed and a concrete remediation path exists.
 
 Manual Remediation MUST still honor ownership, scope, freshness, concrete-fix, active-attempt, and duplicate-PR safety gates.
 
@@ -235,6 +237,13 @@ Given a finding has unknown exploitability or a manual-review recommendation
 And the finding has no concrete dependency patch path or suggested fix
 When the user views the finding
 Then Security Agent SHOULD explain that remediation needs a concrete fix path.
+
+Given a finding is open
+And Sandbox Analysis says the vulnerable feature is not reachable
+And the finding has a concrete dependency patch path or suggested fix
+When the user reviews the finding and clicks "Start remediation"
+Then Security Agent MAY start a manual Security Remediation.
+And Security Agent MUST NOT start Automatic Remediation for that finding.
 
 ## Remediation Execution
 
@@ -438,7 +447,7 @@ The report evidence basis MUST be Security Finding Activity Events. A Security F
 
 Security Agent MAY include supplemental legacy audit records when they can be mapped to a Security Finding without ambiguity. Legacy supplemental activity MUST be labeled as potentially incomplete. Ambiguous legacy records MUST NOT be guessed into a Security Finding group.
 
-Every report MUST display the reliable event-coverage start. Baseline events for existing Security Findings, if produced, MUST use actual capture time and MUST NOT be backdated or presented as original creation events.
+The customer UI does not need to display report provenance or reliable event-coverage metadata. Baseline events for existing Security Findings, if produced, MUST use actual capture time and MUST NOT be backdated or presented as original creation events.
 
 ### Reportable activity
 
@@ -481,7 +490,7 @@ Every platform-admin report generation MUST be audited after successful report a
 
 Successful reports MUST include every matching reportable Security Finding Activity Event recorded through the displayed cutoff. Timeout, over-budget, or query failure MUST return no report content and MUST NOT return a partial report.
 
-Each Security Finding group SHOULD show stable Security Finding and source identity, repository, title, severity, status, safe advisory metadata, first detected time, canonical Security Finding ID when recorded, and deletion status when applicable.
+Each Security Finding group SHOULD show stable Security Finding and source identity, repository, title, severity, status, safe advisory metadata, first detected time, canonical Security Finding ID when recorded, and deletion status when applicable. When legacy activity has a Security Finding ID but no recorded snapshot, Security Agent SHOULD fill missing descriptive metadata from the current owner-scoped Security Finding row. Recorded snapshots MUST take precedence, and deleted findings MUST remain renderable without a current row.
 
 Human actions MUST show an event-time display name and stable typed actor reference. Automated actions MUST show explicit system attribution. Actor email and notification recipient identity MUST NOT be report evidence.
 
@@ -540,13 +549,6 @@ Then Security Agent MUST allow the report.
 Given an ordinary organization member or non-member requests the report
 When Security Agent checks authorization
 Then Security Agent MUST reject access before loading counts or report data.
-
-### Scenario: Legacy coverage wording
-
-Given a report period overlaps activity before reliable event coverage began
-When Security Agent renders the report
-Then the report MUST state that it contains activity recorded by Kilo.
-And it MUST label supplemental legacy activity as potentially incomplete.
 
 ### Scenario: Repository report filter
 

--- a/apps/web/src/components/security-agent/FindingDetailDialog.tsx
+++ b/apps/web/src/components/security-agent/FindingDetailDialog.tsx
@@ -334,7 +334,7 @@ function getAnalysisStatus(analysis: FindingAnalysis, analysisStatus: string | n
     case 'exploitable':
       return { value: 'Exploitable', tone: 'destructive' };
     case 'not-exploitable':
-      return { value: 'No reachable path', tone: 'success' };
+      return { value: 'Unreachable', tone: 'success' };
     case 'safe-to-dismiss':
       return { value: 'Safe to dismiss', tone: 'success' };
     case 'analysis-required':
@@ -795,7 +795,11 @@ function FindingDetailActions({
         </Button>
       )}
       {action.kind === 'remediation' && (
-        <Button className="h-control-touch" onClick={() => onSelectTab('remediation')}>
+        <Button
+          variant="outline"
+          className="h-control-touch"
+          onClick={() => onSelectTab('remediation')}
+        >
           <GitPullRequest aria-hidden="true" />
           {action.label}
         </Button>
@@ -812,14 +816,6 @@ function FindingDetailActions({
         <Button className="h-control-touch" onClick={() => onOpenFinding(supersedingFindingId)}>
           <GitMerge aria-hidden="true" />
           {action.label}
-        </Button>
-      )}
-      {finding.status === 'open' && finding.dependabot_html_url && (
-        <Button variant="ghost" className="h-control-touch" asChild>
-          <a href={finding.dependabot_html_url} target="_blank" rel="noopener noreferrer">
-            <ExternalLink aria-hidden="true" />
-            View on GitHub
-          </a>
         </Button>
       )}
       {canDismiss && finding.status === 'open' && (
@@ -901,6 +897,17 @@ function FindingDetails({
               <DetailFactCell key={fact.label} fact={fact} />
             ))}
           </dl>
+          {finding.dependabot_html_url && (
+            <a
+              href={finding.dependabot_html_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-link hover:text-link-hover focus-visible:ring-ring type-label mt-3 inline-flex items-center gap-1 rounded-sm underline decoration-current/40 underline-offset-4 outline-none hover:underline focus-visible:ring-[3px]"
+            >
+              View on GitHub
+              <ExternalLink className="size-icon-sm" aria-hidden="true" />
+            </a>
+          )}
         </section>
 
         <section className="max-w-[70ch] space-y-3">
@@ -1133,7 +1140,7 @@ function getAnalysisPresentation({
         title: 'Review the generated report',
         description:
           'Read the technical evidence or ask Cloud Agent to explain it. Keep the finding open until the result is clear.',
-        buttonLabel: 'Ask Cloud Agent',
+        buttonLabel: 'Inspect analysis',
         buttonIcon: CircleHelp,
         kind: 'cloud-agent',
       },
@@ -1228,12 +1235,13 @@ function getAnalysisPresentation({
       action: {
         label: 'Next step',
         title: 'Update during routine maintenance',
-        description:
-          sandbox.suggestedFix ||
-          'Review the source advisory and update the dependency during routine maintenance.',
-        buttonLabel: 'View source record',
-        buttonIcon: ExternalLink,
-        kind: 'source',
+        description: canStartRemediation
+          ? 'A patched version or suggested fix is available for a user-reviewed manual remediation.'
+          : sandbox.suggestedFix ||
+            'Review the source advisory and update the dependency during routine maintenance.',
+        buttonLabel: canStartRemediation ? 'View remediation' : 'View source record',
+        buttonIcon: canStartRemediation ? GitPullRequest : ExternalLink,
+        kind: canStartRemediation ? 'view-remediation' : 'source',
       },
       disclosureTitle: 'How Security Agent reached this decision',
     };
@@ -1279,7 +1287,7 @@ function getAnalysisPresentation({
         description: canStartRemediation
           ? 'A concrete fix path is available for a user-reviewed manual remediation.'
           : 'Inspect the recorded usage locations and ask Cloud Agent for more context.',
-        buttonLabel: canStartRemediation ? 'View remediation' : 'Ask Cloud Agent',
+        buttonLabel: canStartRemediation ? 'View remediation' : 'Inspect analysis',
         buttonIcon: canStartRemediation ? GitPullRequest : CircleHelp,
         kind: canStartRemediation ? 'view-remediation' : 'cloud-agent',
         primary: true,
@@ -1693,7 +1701,7 @@ function FindingAnalysisPanel({
             <Button variant="ghost" className="h-control-touch" asChild>
               <Link href={sessionHref}>
                 <CircleHelp aria-hidden="true" />
-                Ask Cloud Agent
+                Inspect analysis
               </Link>
             </Button>
           )}

--- a/apps/web/src/components/security-agent/SecurityAuditReportPage.test.ts
+++ b/apps/web/src/components/security-agent/SecurityAuditReportPage.test.ts
@@ -1,13 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
-import { createElement } from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 import type {
   SecurityAgentAuditReport,
   SecurityAgentAuditReportEvent,
   SecurityFindingAuditSection,
 } from '@/lib/security-agent/db/security-audit-report';
 import {
-  AuditReportProvenance,
   auditReportControlsReducer,
   buildAuditReportSearchParams,
   createAuditReportControlsState,
@@ -16,7 +13,6 @@ import {
   formatDateTime24Hour,
   getAuditEventDetails,
   getDefaultAuditReportDateRange,
-  getAuditReportProvenance,
   getAuditReportRepositoryHref,
   getAuditReportRepositoryOptions,
   hasSecurityAgentAuditReportOwnerContext,
@@ -136,6 +132,37 @@ describe('audit report control state', () => {
     expect(nextState.submittedFilters).toBe(submittedFilters);
     expect(nextState.draftRange).toBe(state.draftRange);
     expect(nextState.isRangePickerOpen).toBe(false);
+  });
+
+  it('keeps the date picker open while selecting a complete range', () => {
+    const initialState = createAuditReportControlsState({
+      initialRange: { startDate: '2026-03-19', endDate: '2026-06-16' },
+      initialFilters: { severity: 'all', state: 'all', repository: null },
+    });
+    const openState = auditReportControlsReducer(initialState, {
+      type: 'set-range-picker-open',
+      open: true,
+    });
+    const startSelectedState = auditReportControlsReducer(openState, {
+      type: 'select-range-start',
+      date: new Date(2026, 4, 1),
+    });
+    const completeRangeState = auditReportControlsReducer(startSelectedState, {
+      type: 'select-range-end',
+      range: { from: new Date(2026, 4, 1), to: new Date(2026, 4, 31) },
+    });
+
+    expect(startSelectedState).toMatchObject({
+      isRangePickerOpen: true,
+      isSelectingRangeEnd: true,
+      draftRange: { from: new Date(2026, 4, 1) },
+    });
+    expect(completeRangeState.isRangePickerOpen).toBe(true);
+    expect(completeRangeState.isSelectingRangeEnd).toBe(false);
+    expect(completeRangeState.draftRange).toEqual({
+      from: new Date(2026, 4, 1),
+      to: new Date(2026, 4, 31),
+    });
   });
 
   it('synchronizes submitted controls when browser navigation changes the URL', () => {
@@ -373,45 +400,6 @@ describe('audit report filters', () => {
     expect(normalizeAuditReportRepositoryFilter(validFilters, ['kilo/api', 'kilo/web'])).toBe(
       validFilters
     );
-  });
-});
-
-describe('audit report provenance', () => {
-  it('renders provenance and coverage warning for a successful empty report', () => {
-    const html = renderToStaticMarkup(createElement(AuditReportProvenance, { report: report([]) }));
-
-    expect(html).toContain('Security Finding activity recorded by Kilo.');
-    expect(html).toContain('Data cutoff');
-    expect(html).toContain('Jun 16, 2026 at 00:00 UTC');
-    expect(html).toContain('Reliable coverage starts');
-    expect(html).toContain('Jun 12, 2026 at 00:00 UTC');
-    expect(html).toContain(
-      'This period starts before reliable event coverage, and supplemental legacy activity may be incomplete.'
-    );
-  });
-
-  it('warns independently for pre-coverage periods and supplemental legacy activity', () => {
-    const baseReport = report([]);
-    const preCoverage = {
-      ...baseReport,
-      hasLegacySupplementalActivity: false,
-    };
-    const legacySupplemental = {
-      ...baseReport,
-      period: { ...baseReport.period, start: baseReport.reliableCoverageStart },
-    };
-    const completeCoverage = {
-      ...legacySupplemental,
-      hasLegacySupplementalActivity: false,
-    };
-
-    expect(getAuditReportProvenance(preCoverage).warning).toBe(
-      'Activity before reliable event coverage may be incomplete.'
-    );
-    expect(getAuditReportProvenance(legacySupplemental).warning).toBe(
-      'Supplemental legacy activity may be incomplete.'
-    );
-    expect(getAuditReportProvenance(completeCoverage).warning).toBeNull();
   });
 });
 

--- a/apps/web/src/components/security-agent/SecurityAuditReportPage.tsx
+++ b/apps/web/src/components/security-agent/SecurityAuditReportPage.tsx
@@ -76,6 +76,7 @@ export type AuditReportControlsState = {
   draftFilters: AuditReportFilters;
   submittedFilters: AuditReportFilters;
   isRangePickerOpen: boolean;
+  isSelectingRangeEnd: boolean;
 };
 
 type AuditReportControlsStateInput = {
@@ -89,9 +90,12 @@ type AuditReportControlsAction =
       open: boolean;
     }
   | {
-      type: 'select-draft-range';
-      range: DayPickerDateRange | undefined;
-      closePicker: boolean;
+      type: 'select-range-start';
+      date: Date;
+    }
+  | {
+      type: 'select-range-end';
+      range: DayPickerDateRange;
     }
   | {
       type: 'set-draft-filter';
@@ -207,6 +211,7 @@ export function createAuditReportControlsState({
     draftFilters: initialFilters,
     submittedFilters: initialFilters,
     isRangePickerOpen: false,
+    isSelectingRangeEnd: false,
   };
 }
 
@@ -216,12 +221,22 @@ export function auditReportControlsReducer(
 ): AuditReportControlsState {
   switch (action.type) {
     case 'set-range-picker-open':
-      return { ...state, isRangePickerOpen: action.open };
-    case 'select-draft-range':
+      return {
+        ...state,
+        isRangePickerOpen: action.open,
+        isSelectingRangeEnd: action.open ? state.isSelectingRangeEnd : false,
+      };
+    case 'select-range-start':
+      return {
+        ...state,
+        draftRange: { from: action.date },
+        isSelectingRangeEnd: true,
+      };
+    case 'select-range-end':
       return {
         ...state,
         draftRange: action.range,
-        isRangePickerOpen: action.closePicker ? false : state.isRangePickerOpen,
+        isSelectingRangeEnd: false,
       };
     case 'set-draft-filter':
       return {
@@ -235,6 +250,7 @@ export function auditReportControlsReducer(
         draftFilters: action.filters,
         submittedFilters: action.filters,
         isRangePickerOpen: false,
+        isSelectingRangeEnd: false,
       };
     case 'submit-report':
       return {
@@ -277,8 +293,14 @@ export function SecurityAuditReportPage() {
     { initialRange, initialFilters },
     createAuditReportControlsState
   );
-  const { draftRange, submittedRange, draftFilters, submittedFilters, isRangePickerOpen } =
-    controlsState;
+  const {
+    draftRange,
+    submittedRange,
+    draftFilters,
+    submittedFilters,
+    isRangePickerOpen,
+    isSelectingRangeEnd,
+  } = controlsState;
 
   useEffect(() => {
     dispatchControlsState({
@@ -347,13 +369,18 @@ export function SecurityAuditReportPage() {
     if (isSameRange) void refetchReport();
   }
 
-  function handleDateRangeSelect(nextRange: DayPickerDateRange | undefined) {
-    if (nextRange?.from && nextRange.to && !isWithinAuditReportRangeLimit(nextRange)) return;
-    dispatchControlsState({
-      type: 'select-draft-range',
-      range: nextRange,
-      closePicker: Boolean(nextRange?.from && nextRange.to),
-    });
+  function handleDateRangeSelect(_nextRange: DayPickerDateRange | undefined, selectedDate: Date) {
+    if (!isSelectingRangeEnd || !draftRange?.from) {
+      dispatchControlsState({ type: 'select-range-start', date: selectedDate });
+      return;
+    }
+
+    const range =
+      selectedDate < draftRange.from
+        ? { from: selectedDate, to: draftRange.from }
+        : { from: draftRange.from, to: selectedDate };
+    if (!isWithinAuditReportRangeLimit(range)) return;
+    dispatchControlsState({ type: 'select-range-end', range });
   }
 
   function handleClearFilters() {
@@ -405,6 +432,7 @@ export function SecurityAuditReportPage() {
                     >
                       <Calendar
                         mode="range"
+                        showOutsideDays={false}
                         selected={draftRange}
                         onSelect={handleDateRangeSelect}
                         defaultMonth={draftRange?.from}
@@ -414,9 +442,24 @@ export function SecurityAuditReportPage() {
                         excludeDisabled
                         autoFocus
                       />
-                      <p className="border-border text-muted-foreground type-label border-t px-3 py-2">
-                        Report periods can include up to {MAX_AUDIT_REPORT_DAYS} calendar days.
-                      </p>
+                      <div className="border-border flex items-center justify-between gap-3 border-t px-3 py-2">
+                        <p className="text-muted-foreground type-label">
+                          {isSelectingRangeEnd
+                            ? `Now select an end date, up to ${MAX_AUDIT_REPORT_DAYS} calendar days.`
+                            : 'Select a start date for a new report period.'}
+                        </p>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          disabled={!completeDraftRange}
+                          onClick={() =>
+                            dispatchControlsState({ type: 'set-range-picker-open', open: false })
+                          }
+                        >
+                          Use period
+                        </Button>
+                      </div>
                     </PopoverContent>
                   </Popover>
                 </SecurityAgentActionBarField>
@@ -548,7 +591,6 @@ export function SecurityAuditReportPage() {
       {hasOwnerContext && report && unfilteredReport && (
         <AuditReportView
           report={report}
-          provenanceReport={unfilteredReport}
           totalFindingCount={unfilteredReport.summary.findingCount}
           hasActiveFilters={hasActiveAuditReportFilters(effectiveSubmittedFilters)}
           onClearFilters={handleClearFilters}
@@ -560,20 +602,17 @@ export function SecurityAuditReportPage() {
 
 function AuditReportView({
   report,
-  provenanceReport,
   totalFindingCount,
   hasActiveFilters,
   onClearFilters,
 }: {
   report: SecurityAgentAuditReport;
-  provenanceReport: SecurityAgentAuditReport;
   totalFindingCount: number;
   hasActiveFilters: boolean;
   onClearFilters: () => void;
 }) {
   return (
     <div className="space-y-6">
-      <AuditReportProvenance report={provenanceReport} />
       <ReportSummary report={report} />
 
       {report.findings.length === 0 ? (
@@ -587,73 +626,6 @@ function AuditReportView({
         <FindingTimelineList findings={report.findings} totalFindingCount={totalFindingCount} />
       )}
     </div>
-  );
-}
-
-export function getAuditReportProvenance(report: SecurityAgentAuditReport) {
-  const startsBeforeReliableCoverage =
-    Date.parse(report.period.start) < Date.parse(report.reliableCoverageStart);
-  let warning: string | null = null;
-
-  if (startsBeforeReliableCoverage && report.hasLegacySupplementalActivity) {
-    warning =
-      'This period starts before reliable event coverage, and supplemental legacy activity may be incomplete.';
-  } else if (startsBeforeReliableCoverage) {
-    warning = 'Activity before reliable event coverage may be incomplete.';
-  } else if (report.hasLegacySupplementalActivity) {
-    warning = 'Supplemental legacy activity may be incomplete.';
-  }
-
-  return {
-    evidence: {
-      recorded_by_kilo: 'Security Finding activity recorded by Kilo.',
-    }[report.evidenceBasis],
-    dataThrough: formatReportDateTime(report.dataThrough),
-    reliableCoverageStart: formatReportDateTime(report.reliableCoverageStart),
-    warning,
-  };
-}
-
-export function AuditReportProvenance({ report }: { report: SecurityAgentAuditReport }) {
-  const provenance = getAuditReportProvenance(report);
-
-  return (
-    <section
-      className="border-border bg-surface-inset rounded-lg border px-4 py-3"
-      aria-labelledby="report-provenance-title"
-    >
-      <div className="flex items-start gap-3">
-        <Info className="text-muted-foreground mt-0.5 size-4 shrink-0" aria-hidden="true" />
-        <div className="min-w-0 flex-1">
-          <h2 id="report-provenance-title" className="type-label text-foreground">
-            Report provenance
-          </h2>
-          <p className="text-muted-foreground type-body mt-0.5">{provenance.evidence}</p>
-          <dl className="text-muted-foreground type-label mt-2 flex flex-wrap gap-x-5 gap-y-1">
-            <div className="flex flex-wrap gap-x-1.5">
-              <dt>Data cutoff</dt>
-              <dd className="text-foreground tabular-nums">
-                <time dateTime={report.dataThrough}>{provenance.dataThrough}</time>
-              </dd>
-            </div>
-            <div className="flex flex-wrap gap-x-1.5">
-              <dt>Reliable coverage starts</dt>
-              <dd className="text-foreground tabular-nums">
-                <time dateTime={report.reliableCoverageStart}>
-                  {provenance.reliableCoverageStart}
-                </time>
-              </dd>
-            </div>
-          </dl>
-          {provenance.warning && (
-            <p className="text-status-warning type-label mt-2 flex items-start gap-1.5">
-              <TriangleAlert className="mt-px size-3.5 shrink-0" aria-hidden="true" />
-              <span>{provenance.warning}</span>
-            </p>
-          )}
-        </div>
-      </div>
-    </section>
   );
 }
 

--- a/apps/web/src/components/security-agent/SecurityFindingRow.test.ts
+++ b/apps/web/src/components/security-agent/SecurityFindingRow.test.ts
@@ -59,6 +59,23 @@ describe('Security Finding list presentation', () => {
     });
   });
 
+  it('uses a terse label when analysis finds no reachable path', () => {
+    const finding = findingWith({
+      analysis_status: 'completed',
+      analysis: {
+        sandboxAnalysis: {
+          isExploitable: false,
+          summary: 'No reachable vulnerable path found.',
+        },
+      } as SecurityFindingWithRemediation['analysis'],
+    });
+
+    expect(getAnalysisPresentation(finding)).toMatchObject({
+      label: 'Unreachable',
+      tone: 'success',
+    });
+  });
+
   it('uses shared review states for failed extraction and unknown exploitability', () => {
     const extractionFailed = findingWith({
       analysis_status: 'completed',

--- a/apps/web/src/components/security-agent/remediation-unavailable-copy.test.ts
+++ b/apps/web/src/components/security-agent/remediation-unavailable-copy.test.ts
@@ -12,6 +12,12 @@ describe('getRemediationUnavailableCopy', () => {
     expect(getRemediationUnavailableCopy('finding_not_found')).toBe(
       'Security finding no longer exists.'
     );
+    expect(getRemediationUnavailableCopy('not_exploitable')).toBe(
+      'Analysis found no reachable vulnerable path. Auto Remediation is unavailable.'
+    );
+    expect(getRemediationUnavailableCopy('action_not_concrete')).toBe(
+      'No concrete dependency patch or suggested fix is available.'
+    );
   });
 });
 

--- a/apps/web/src/components/security-agent/remediation-unavailable-copy.ts
+++ b/apps/web/src/components/security-agent/remediation-unavailable-copy.ts
@@ -10,14 +10,14 @@ const REMEDIATION_UNAVAILABLE_COPY: Record<SecurityRemediationAdmissionRejection
   analysis_required: 'Run codebase analysis before starting remediation.',
   sandbox_analysis_required: 'Run codebase analysis before starting remediation.',
   stale_analysis: 'Finding changed after analysis. Rerun analysis before starting remediation.',
-  not_exploitable: 'Analysis marked this finding not exploitable in this repository.',
+  not_exploitable: 'Analysis found no reachable vulnerable path. Auto Remediation is unavailable.',
   exploitability_unknown:
     'Analysis could not confirm exploitability. Manual review is required before one-click remediation.',
   manual_review_required:
     'Analysis recommends manual review, so one-click remediation is unavailable.',
   monitor_required: 'Analysis recommends monitoring instead of opening a PR.',
   triage_only: 'Only triage has completed. Run codebase analysis before starting remediation.',
-  action_not_concrete: 'Analysis did not return a concrete PR fix path.',
+  action_not_concrete: 'No concrete dependency patch or suggested fix is available.',
   remediation_active: 'A remediation attempt is already active.',
   pr_already_opened: 'A remediation PR is already open.',
   duplicate_analysis_result: 'This analysis result already produced remediation work.',

--- a/apps/web/src/components/security-agent/security-finding-list-presentation.ts
+++ b/apps/web/src/components/security-agent/security-finding-list-presentation.ts
@@ -122,7 +122,7 @@ export function getAnalysisPresentation(finding: SecurityFinding): FindingStatus
     case 'not-exploitable':
       return {
         icon: ShieldCheck,
-        label: 'No reachable path',
+        label: 'Unreachable',
         tone: 'success',
         tooltip: sandbox?.summary || 'Codebase analysis found no reachable vulnerable path',
       };

--- a/apps/web/src/lib/security-agent/db/security-audit-report.test.ts
+++ b/apps/web/src/lib/security-agent/db/security-audit-report.test.ts
@@ -538,10 +538,98 @@ describe('buildSecurityAgentAuditReportFromRows', () => {
     });
     expect(report.findings[1]).toMatchObject({
       findingId: '22222222-2222-4222-8222-222222222222',
-      title: 'Legacy Security Finding',
+      title: 'Security Finding 22222222-2222-4222-8222-222222222222',
       hasLegacySupplementalActivity: true,
     });
     expect(report.hasLegacySupplementalActivity).toBe(true);
+  });
+
+  it('uses current finding metadata to describe legacy activity', () => {
+    const legacyFindingId = '22222222-2222-4222-8222-222222222222';
+    const report = buildSecurityAgentAuditReportFromRows({
+      owner: {
+        type: 'organization',
+        id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        displayName: 'Acme',
+      },
+      period,
+      generatedAt: '2026-06-12T15:00:00.000Z',
+      dataThrough: '2026-06-12T15:00:00.000Z',
+      isRequestingUserKiloAdmin: false,
+      rows: [
+        row({
+          finding_id: null,
+          resource_id: legacyFindingId,
+          occurred_at: null,
+          finding_snapshot: null,
+        }),
+      ],
+      currentFindings: [
+        {
+          findingId: legacyFindingId,
+          snapshot: {
+            source: 'dependabot',
+            source_id: '84',
+            repo_full_name: 'kilo/cloud',
+            title: 'Cross-origin request routing in undici',
+            severity: 'high',
+            status: 'ignored',
+            package_name: 'undici',
+            package_ecosystem: 'npm',
+            manifest_path: 'pnpm-lock.yaml',
+            patched_version: '7.28.0',
+            first_detected_at: '2026-03-28T17:40:00.000Z',
+          },
+        },
+      ],
+    });
+
+    expect(report.findings[0]).toMatchObject({
+      findingId: legacyFindingId,
+      source: 'dependabot',
+      sourceId: '84',
+      repository: 'kilo/cloud',
+      title: 'Cross-origin request routing in undici',
+      severity: 'high',
+      status: 'ignored',
+      packageName: 'undici',
+      packageEcosystem: 'npm',
+      manifestPath: 'pnpm-lock.yaml',
+      patchedVersion: '7.28.0',
+      firstDetectedAt: '2026-03-28T17:40:00.000Z',
+      hasLegacySupplementalActivity: true,
+    });
+  });
+
+  it('prefers recorded snapshots over current finding metadata', () => {
+    const report = buildSecurityAgentAuditReportFromRows({
+      owner: {
+        type: 'organization',
+        id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        displayName: 'Acme',
+      },
+      period,
+      generatedAt: '2026-06-12T15:00:00.000Z',
+      dataThrough: '2026-06-12T15:00:00.000Z',
+      isRequestingUserKiloAdmin: false,
+      rows: [row({})],
+      currentFindings: [
+        {
+          findingId: '11111111-1111-4111-8111-111111111111',
+          snapshot: {
+            title: 'Current title',
+            severity: 'low',
+            repo_full_name: 'kilo/current',
+          },
+        },
+      ],
+    });
+
+    expect(report.findings[0]).toMatchObject({
+      title: 'Prototype Pollution in lodash',
+      severity: 'high',
+      repository: 'kilo/repo',
+    });
   });
 
   it('masks actors from persisted classification', () => {

--- a/apps/web/src/lib/security-agent/db/security-audit-report.ts
+++ b/apps/web/src/lib/security-agent/db/security-audit-report.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { captureException, startSpan } from '@sentry/nextjs';
-import { security_audit_log } from '@kilocode/db/schema';
+import { security_audit_log, security_findings } from '@kilocode/db/schema';
 import {
   SecurityAuditLogAction,
   SecurityAuditLogActorType,
@@ -187,6 +187,11 @@ type AuditReportRow = {
 type AuditReportCursor = {
   effectiveAt: string;
   id: string;
+};
+
+type AuditReportCurrentFinding = {
+  findingId: string;
+  snapshot: Record<string, unknown>;
 };
 
 type AuditReportFindingCutoffState = {
@@ -435,7 +440,7 @@ async function assembleSecurityAgentAuditReport(params: {
   isRequestingUserKiloAdmin: boolean;
   onEventCount: (eventCount: number) => void;
 }): Promise<SecurityAgentAuditReport> {
-  const { dataThrough, rows, cutoffStates } = await db.transaction(
+  const { dataThrough, rows, cutoffStates, currentFindings } = await db.transaction(
     async tx => {
       const dataThrough = await getDatabaseNow(tx);
       const eventCount = await countReportEvents(tx, params.owner, params.period);
@@ -461,9 +466,12 @@ async function assembleSecurityAgentAuditReport(params: {
           rows.map(getRowFindingId).filter((findingId): findingId is string => Boolean(findingId))
         )
       );
-      const cutoffStates = await loadReportFindingCutoffStates(tx, params.owner, findingIds);
+      const [cutoffStates, currentFindings] = await Promise.all([
+        loadReportFindingCutoffStates(tx, params.owner, findingIds),
+        loadCurrentReportFindings(tx, params.owner, findingIds),
+      ]);
 
-      return { dataThrough, rows, cutoffStates };
+      return { dataThrough, rows, cutoffStates, currentFindings };
     },
     { isolationLevel: 'repeatable read', accessMode: 'read only' }
   );
@@ -475,6 +483,7 @@ async function assembleSecurityAgentAuditReport(params: {
     dataThrough,
     rows,
     cutoffStates,
+    currentFindings,
     isRequestingUserKiloAdmin: params.isRequestingUserKiloAdmin,
   });
   assertSecurityAgentAuditReportSerializedByteBudget(report);
@@ -488,6 +497,7 @@ export function buildSecurityAgentAuditReportFromRows(params: {
   dataThrough: string;
   rows: AuditReportRow[];
   cutoffStates?: AuditReportFindingCutoffState[];
+  currentFindings?: AuditReportCurrentFinding[];
   isRequestingUserKiloAdmin: boolean;
 }): SecurityAgentAuditReport {
   const groups = new Map<string, AuditReportRow[]>();
@@ -502,8 +512,17 @@ export function buildSecurityAgentAuditReportFromRows(params: {
   const cutoffStateByFindingId = new Map(
     params.cutoffStates?.map(state => [state.findingId, state]) ?? []
   );
+  const currentFindingByFindingId = new Map(
+    params.currentFindings?.map(finding => [finding.findingId, finding.snapshot]) ?? []
+  );
   const findings = Array.from(groups.entries()).map(([findingId, rows]) =>
-    buildFindingSection(findingId, rows, params, cutoffStateByFindingId.get(findingId))
+    buildFindingSection(
+      findingId,
+      rows,
+      params,
+      cutoffStateByFindingId.get(findingId),
+      currentFindingByFindingId.get(findingId)
+    )
   );
 
   findings.sort((left, right) => {
@@ -725,6 +744,79 @@ async function loadReportFindingCutoffStates(
   }
 }
 
+async function loadCurrentReportFindings(
+  tx: DrizzleTransaction,
+  owner: SecurityAgentAuditReportOwner,
+  findingIds: string[]
+): Promise<AuditReportCurrentFinding[]> {
+  if (findingIds.length === 0) return [];
+
+  try {
+    const rows = await withSecurityAgentAuditReportTimeout(
+      tx
+        .select({
+          findingId: security_findings.id,
+          source: security_findings.source,
+          sourceId: security_findings.source_id,
+          repository: security_findings.repo_full_name,
+          title: security_findings.title,
+          severity: security_findings.severity,
+          status: security_findings.status,
+          packageName: security_findings.package_name,
+          packageEcosystem: security_findings.package_ecosystem,
+          manifestPath: security_findings.manifest_path,
+          patchedVersion: security_findings.patched_version,
+          ghsaId: security_findings.ghsa_id,
+          cveId: security_findings.cve_id,
+          cweIds: security_findings.cwe_ids,
+          cvssScore: security_findings.cvss_score,
+          dependabotUrl: security_findings.dependabot_html_url,
+          firstDetectedAt: security_findings.first_detected_at,
+        })
+        .from(security_findings)
+        .where(
+          and(
+            inArray(security_findings.id, findingIds),
+            owner.type === 'user'
+              ? eq(security_findings.owned_by_user_id, owner.id)
+              : eq(security_findings.owned_by_organization_id, owner.id)
+          )
+        ),
+      SECURITY_AGENT_AUDIT_REPORT_QUERY_TIMEOUT_MS,
+      'scan'
+    );
+
+    return rows.map(row => ({
+      findingId: row.findingId,
+      snapshot: {
+        finding_id: row.findingId,
+        source: row.source,
+        source_id: row.sourceId,
+        repo_full_name: row.repository,
+        title: row.title,
+        severity: row.severity,
+        status: row.status,
+        package_name: row.packageName,
+        package_ecosystem: row.packageEcosystem,
+        manifest_path: row.manifestPath,
+        patched_version: row.patchedVersion,
+        ghsa_id: row.ghsaId,
+        cve_id: row.cveId,
+        cwe_ids: row.cweIds,
+        cvss_score: row.cvssScore,
+        dependabot_html_url: row.dependabotUrl,
+        first_detected_at: row.firstDetectedAt,
+      },
+    }));
+  } catch (error) {
+    if (error instanceof SecurityAgentAuditReportQueryError) throw error;
+    throw new SecurityAgentAuditReportQueryError(
+      error instanceof Error ? error.message : 'Report query did not finish',
+      'scan'
+    );
+  }
+}
+
 function baseReportConditions(
   owner: SecurityAgentAuditReportOwner,
   period: NormalizedAuditReportPeriod
@@ -821,15 +913,17 @@ function buildFindingSection(
     dataThrough: string;
     isRequestingUserKiloAdmin: boolean;
   },
-  cutoffState: AuditReportFindingCutoffState | undefined
+  cutoffState: AuditReportFindingCutoffState | undefined,
+  currentFindingSnapshot: Record<string, unknown> | undefined
 ): SecurityFindingAuditSection {
   rows.sort(
     (left, right) =>
       left.effective_at.localeCompare(right.effective_at) || left.id.localeCompare(right.id)
   );
   const latestSnapshot = latestFindingSnapshot(rows);
+  const descriptiveSnapshot = mergeSnapshotFallback(latestSnapshot, currentFindingSnapshot);
   const evidenceSnapshot = withRecordedTimelineEvidence(rows, latestSnapshot);
-  const stateSnapshot = cutoffState ? cutoffState.snapshot : evidenceSnapshot;
+  const stateSnapshot = cutoffState?.snapshot ?? evidenceSnapshot ?? currentFindingSnapshot ?? null;
   const events = rows.map(row => buildReportEvent(row, reportParams.isRequestingUserKiloAdmin));
   const deleted = cutoffState
     ? cutoffState.deleted
@@ -838,22 +932,24 @@ function buildFindingSection(
 
   return {
     findingId,
-    source: stringFromSnapshot(latestSnapshot, 'source'),
-    sourceId: stringFromSnapshot(latestSnapshot, 'source_id'),
-    repository: stringFromSnapshot(latestSnapshot, 'repo_full_name'),
-    title: stringFromSnapshot(latestSnapshot, 'title') ?? 'Legacy Security Finding',
-    severity: severityFromSnapshot(latestSnapshot),
+    source: stringFromSnapshot(descriptiveSnapshot, 'source'),
+    sourceId: stringFromSnapshot(descriptiveSnapshot, 'source_id'),
+    repository: stringFromSnapshot(descriptiveSnapshot, 'repo_full_name'),
+    title: stringFromSnapshot(descriptiveSnapshot, 'title') ?? `Security Finding ${findingId}`,
+    severity: severityFromSnapshot(descriptiveSnapshot),
     status: stringFromSnapshot(stateSnapshot, 'status'),
-    packageName: stringFromSnapshot(latestSnapshot, 'package_name'),
-    packageEcosystem: stringFromSnapshot(latestSnapshot, 'package_ecosystem'),
-    manifestPath: stringFromSnapshot(latestSnapshot, 'manifest_path'),
-    patchedVersion: stringFromSnapshot(latestSnapshot, 'patched_version'),
-    ghsaId: stringFromSnapshot(latestSnapshot, 'ghsa_id'),
-    cveId: stringFromSnapshot(latestSnapshot, 'cve_id'),
-    cweIds: stringArrayFromSnapshot(latestSnapshot, 'cwe_ids'),
-    cvssScore: cvssFromSnapshot(latestSnapshot),
-    dependabotUrl: safeUrl(stringFromSnapshot(latestSnapshot, 'dependabot_html_url')),
-    firstDetectedAt: stringFromSnapshot(evidenceSnapshot, 'first_detected_at'),
+    packageName: stringFromSnapshot(descriptiveSnapshot, 'package_name'),
+    packageEcosystem: stringFromSnapshot(descriptiveSnapshot, 'package_ecosystem'),
+    manifestPath: stringFromSnapshot(descriptiveSnapshot, 'manifest_path'),
+    patchedVersion: stringFromSnapshot(descriptiveSnapshot, 'patched_version'),
+    ghsaId: stringFromSnapshot(descriptiveSnapshot, 'ghsa_id'),
+    cveId: stringFromSnapshot(descriptiveSnapshot, 'cve_id'),
+    cweIds: stringArrayFromSnapshot(descriptiveSnapshot, 'cwe_ids'),
+    cvssScore: cvssFromSnapshot(descriptiveSnapshot),
+    dependabotUrl: safeUrl(stringFromSnapshot(descriptiveSnapshot, 'dependabot_html_url')),
+    firstDetectedAt:
+      stringFromSnapshot(evidenceSnapshot, 'first_detected_at') ??
+      stringFromSnapshot(descriptiveSnapshot, 'first_detected_at'),
     canonicalFindingId: stringFromSnapshot(stateSnapshot, 'canonical_finding_id'),
     deleted,
     sla: buildSlaEvidence(stateSnapshot, reportParams.dataThrough, deleted),
@@ -924,6 +1020,15 @@ function latestFindingSnapshot(rows: AuditReportRow[]): Record<string, unknown> 
     if (snapshot) return snapshot;
   }
   return null;
+}
+
+function mergeSnapshotFallback(
+  recordedSnapshot: Record<string, unknown> | null,
+  currentSnapshot: Record<string, unknown> | undefined
+): Record<string, unknown> | null {
+  if (!recordedSnapshot) return currentSnapshot ?? null;
+  if (!currentSnapshot) return recordedSnapshot;
+  return { ...currentSnapshot, ...recordedSnapshot };
 }
 
 function withRecordedTimelineEvidence(

--- a/packages/worker-utils/src/security-remediation-policy.test.ts
+++ b/packages/worker-utils/src/security-remediation-policy.test.ts
@@ -263,6 +263,87 @@ describe('decideSecurityRemediationEligibility', () => {
     expect(decision).toMatchObject({ eligible: true, reason: 'eligible' });
   });
 
+  it('allows manual remediation for an unreachable finding with a patched version', () => {
+    const unreachableFinding = withCurrentFindingDataSnapshot({
+      ...baseFinding,
+      manifest_path: null,
+      analysis: {
+        ...baseFinding.analysis,
+        sandboxAnalysis: {
+          ...baseFinding.analysis!.sandboxAnalysis!,
+          isExploitable: false,
+          suggestedAction: 'dismiss',
+          suggestedFix: null,
+          usageLocations: [],
+        },
+      },
+    });
+
+    const decision = decideSecurityRemediationEligibility({
+      finding: unreachableFinding,
+      config: baseConfig,
+      isAgentEnabled: true,
+      repoFullNamesInScope: ['kilo/repo'],
+      origin: 'manual',
+      blockState: emptyBlockState,
+    });
+
+    expect(decision).toMatchObject({ eligible: true, reason: 'eligible' });
+  });
+
+  it('requires a concrete fix path for manual remediation of an unreachable finding', () => {
+    const decision = decideSecurityRemediationEligibility({
+      finding: withCurrentFindingDataSnapshot({
+        ...baseFinding,
+        patched_version: null,
+        manifest_path: null,
+        analysis: {
+          ...baseFinding.analysis,
+          sandboxAnalysis: {
+            ...baseFinding.analysis!.sandboxAnalysis!,
+            isExploitable: false,
+            suggestedAction: 'dismiss',
+            suggestedFix: null,
+            usageLocations: [],
+          },
+        },
+      }),
+      config: baseConfig,
+      isAgentEnabled: true,
+      repoFullNamesInScope: ['kilo/repo'],
+      origin: 'manual',
+      blockState: emptyBlockState,
+    });
+
+    expect(decision).toMatchObject({ eligible: false, reason: 'action_not_concrete' });
+  });
+
+  it.each(['auto_policy', 'bulk_existing'] as const)(
+    'keeps %s remediation blocked for unreachable findings',
+    origin => {
+      const decision = decideSecurityRemediationEligibility({
+        finding: withCurrentFindingDataSnapshot({
+          ...baseFinding,
+          analysis: {
+            ...baseFinding.analysis,
+            sandboxAnalysis: {
+              ...baseFinding.analysis!.sandboxAnalysis!,
+              isExploitable: false,
+              suggestedAction: 'dismiss',
+            },
+          },
+        }),
+        config: baseConfig,
+        isAgentEnabled: true,
+        repoFullNamesInScope: ['kilo/repo'],
+        origin,
+        blockState: emptyBlockState,
+      });
+
+      expect(decision).toMatchObject({ eligible: false, reason: 'not_exploitable' });
+    }
+  );
+
   it('keeps automatic remediation blocked for manual-review analysis', () => {
     const decision = decideSecurityRemediationEligibility({
       finding: {

--- a/packages/worker-utils/src/security-remediation-policy.ts
+++ b/packages/worker-utils/src/security-remediation-policy.ts
@@ -289,15 +289,9 @@ function hasConcreteRemediationPath(finding: SecurityRemediationFinding): boolea
   const sandbox = finding.analysis?.sandboxAnalysis;
   if (!sandbox) return false;
   const hasPatchedPackagePath =
-    Boolean(finding.patched_version?.trim()) &&
-    Boolean(finding.package_name?.trim()) &&
-    Boolean(finding.manifest_path?.trim());
+    Boolean(finding.patched_version?.trim()) && Boolean(finding.package_name?.trim());
   const hasSuggestedFix = Boolean(sandbox.suggestedFix?.trim());
-  const hasUsageAndFix =
-    Array.isArray(sandbox.usageLocations) &&
-    sandbox.usageLocations.length > 0 &&
-    Boolean(sandbox.suggestedFix?.trim());
-  return hasPatchedPackagePath || hasSuggestedFix || hasUsageAndFix;
+  return hasPatchedPackagePath || hasSuggestedFix;
 }
 
 function isAnalysisFresh(finding: SecurityRemediationFinding, completedAt: string): boolean {
@@ -343,14 +337,17 @@ export function decideSecurityRemediationEligibility(
   if (!sandbox) return reject('sandbox_analysis_required');
   if (!analysisCompletedAt || !analysisFingerprint) return reject('analysis_required');
   if (!isAnalysisFresh(params.finding, analysisCompletedAt)) return reject('stale_analysis');
-  if (sandbox.isExploitable === false) return reject('not_exploitable');
   const hasConcretePath = hasConcreteRemediationPath(params.finding);
   if (params.blockState.hasActiveAttempt) return reject('remediation_active');
   if (params.blockState.hasPrOpened) return reject('pr_already_opened');
 
   if (params.origin === 'manual') {
     if (sandbox.suggestedAction === 'monitor') return reject('monitor_required');
-    if (sandbox.suggestedAction !== 'open_pr' && sandbox.suggestedAction !== 'manual_review') {
+    if (
+      sandbox.isExploitable !== false &&
+      sandbox.suggestedAction !== 'open_pr' &&
+      sandbox.suggestedAction !== 'manual_review'
+    ) {
       return reject(sandbox.isExploitable === 'unknown' ? 'exploitability_unknown' : 'triage_only');
     }
     if (!hasConcretePath) return reject('action_not_concrete');
@@ -370,6 +367,7 @@ export function decideSecurityRemediationEligibility(
     };
   }
 
+  if (sandbox.isExploitable === false) return reject('not_exploitable');
   if (sandbox.isExploitable === 'unknown') return reject('exploitability_unknown');
   if (sandbox.suggestedAction === 'manual_review') return reject('manual_review_required');
   if (sandbox.suggestedAction === 'monitor') return reject('monitor_required');


### PR DESCRIPTION
## Summary
Improve Security Agent remediation controls, finding details, and audit report usability.

### Why this change is needed
Users could not manually remediate findings marked unreachable even when a concrete patched version existed. Finding details used inconsistent actions and unclear wording. Audit reports exposed internal provenance language, omitted available finding metadata from legacy events, and had a difficult date-range picker.

### How this is addressed
- Allow user-reviewed manual remediation for unreachable findings with a concrete dependency patch or suggested fix while keeping automatic remediation blocked.
- Simplify analysis labels and align finding-detail actions, links, and remediation styling.
- Enrich legacy audit activity from owner-scoped current finding records without overriding recorded audit snapshots.
- Remove customer-facing provenance metadata from audit reports.
- Make report period selection an explicit start-date then end-date flow, keep the picker open until confirmed, and hide adjacent-month dates.

## Human Verification
- Verified remediation policy behavior with worker-utils tests.
- Verified finding presentation, remediation copy, audit report controls, and audit report enrichment with targeted Jest tests.
- Confirmed Security Agent specification matches manual-remediation and audit-report behavior.

## Reviewer Notes
### Human Reviewer Flags
- Manual remediation now intentionally differs from automatic policy: unreachable findings remain blocked from automatic remediation but users may proceed when a concrete fix path exists.
- Audit report enrichment uses current owner-scoped finding data only as fallback. Recorded snapshots remain authoritative, and deleted findings remain independent of current rows.
- Customer-facing provenance metadata was removed while report evidence fields remain in the underlying report contract.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Remediation eligibility still enforces ownership, scope, analysis freshness, active-attempt, duplicate-PR, and concrete-fix gates.
- Current finding enrichment runs inside the existing repeatable-read report transaction and applies explicit owner filtering.
- Date range selection normalizes a second date before the first date and enforces the existing 90-day limit.

</details>
