### PR TITLE
fix(auto-routing): exclude virtual auto models

### DIFF
--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -125,6 +125,23 @@ describe('resolveAutoModel — kilo-auto/efficient branch', () => {
     expect(result).toEqual({ kind: 'ok', resolved: BALANCED_QWEN_MODEL });
   });
 
+  it('falls back to BALANCED_QWEN_MODEL when the worker returns a virtual auto model', async () => {
+    const result = await resolveAutoModel(
+      {
+        ...baseParams,
+        apiKind: 'chat_completions',
+        efficientDecision: async () => ({
+          ...sampleDecision,
+          model: KILO_AUTO_EFFICIENT_MODEL.id,
+        }),
+      },
+      nullUserPromise,
+      zeroBalancePromise
+    );
+
+    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_QWEN_MODEL });
+  });
+
   it('does not call the thunk more than once', async () => {
     const thunk = jest.fn(async () => sampleDecision);
 

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -9,7 +9,7 @@ import type {
 } from '@/lib/ai-gateway/providers/openrouter/types';
 import type OpenAI from 'openai';
 import type { User } from '@kilocode/db';
-import type { AutoRoutingDecision } from '@kilocode/auto-routing-contracts';
+import { isVirtualAutoModelId, type AutoRoutingDecision } from '@kilocode/auto-routing-contracts';
 import {
   KILO_AUTO_FREE_MODEL,
   KILO_AUTO_SMALL_MODEL,
@@ -122,7 +122,7 @@ export async function resolveAutoModel(
   }
   if (model === KILO_AUTO_EFFICIENT_MODEL.id) {
     const decision = params.efficientDecision ? await params.efficientDecision() : null;
-    if (decision) {
+    if (decision && !isVirtualAutoModelId(decision.model)) {
       // Apply the candidate's pinned reasoning effort so the model runs under
       // the same conditions the benchmark measured it at.
       return {

--- a/apps/web/src/lib/model-stats/auto-routing-decider-candidates.test.ts
+++ b/apps/web/src/lib/model-stats/auto-routing-decider-candidates.test.ts
@@ -50,6 +50,7 @@ describe('summarizeAutoRoutingDeciderCandidates', () => {
         row('model/one-attempt', AUTO_DECIDER_MIN_COST_USD + 1, { nAttempts: 1 }),
         row('model/floored-maximum', AUTO_DECIDER_MAX_COST_USD + 0.99),
         row('kilo/openai/gpt-5.5', 24),
+        row('kilo-auto/efficient', 20),
         row('model/too-expensive', AUTO_DECIDER_MAX_COST_USD + 1),
         row('model/inactive', 20, { active: false }),
         row('kilo-internal/custom', 20),

--- a/apps/web/src/lib/model-stats/auto-routing-decider-candidates.ts
+++ b/apps/web/src/lib/model-stats/auto-routing-decider-candidates.ts
@@ -3,6 +3,7 @@ import { readDb } from '@/lib/drizzle';
 import {
   AUTO_DECIDER_DEFAULT_MAX_COST_USD,
   AUTO_DECIDER_DEFAULT_MIN_COST_USD,
+  isVirtualAutoModelId,
 } from '@kilocode/auto-routing-contracts';
 import { ModelStatsBenchmarksSchema, modelStats } from '@kilocode/db/schema';
 import { unprefixKiloGatewayModelId } from '@kilocode/worker-utils/kilo-model-id';
@@ -62,8 +63,10 @@ export function summarizeAutoRoutingDeciderCandidates(
     ) {
       continue;
     }
+    const id = unprefixKiloGatewayModelId(row.openrouterId) ?? row.openrouterId;
+    if (isVirtualAutoModelId(id)) continue;
     candidates.push({
-      id: unprefixKiloGatewayModelId(row.openrouterId) ?? row.openrouterId,
+      id,
       avgAttemptCostUsd: bench.avgAttemptCostUsd,
     });
   }

--- a/packages/auto-routing-contracts/src/index.ts
+++ b/packages/auto-routing-contracts/src/index.ts
@@ -18,6 +18,10 @@ export const AutoRoutingModeSchema = z.enum(['cost_per_accuracy', 'best_accuracy
 export type AutoRoutingMode = z.infer<typeof AutoRoutingModeSchema>;
 export const DEFAULT_AUTO_ROUTING_MODE: AutoRoutingMode = 'cost_per_accuracy';
 
+export function isVirtualAutoModelId(model: string): boolean {
+  return model.trim().toLowerCase().startsWith('kilo-auto/');
+}
+
 // What the gateway mirrors to the auto-routing worker per request: the
 // already-normalized classifier input plus caller identity. The gateway
 // normalizes before sending so the multi-hundred-KB request body never

--- a/services/auto-routing/src/decision-engine.test.ts
+++ b/services/auto-routing/src/decision-engine.test.ts
@@ -187,6 +187,32 @@ describe('computeDecision', () => {
       sticky: false,
     });
   });
+  it('skips virtual auto-model candidates', () => {
+    const pollutedTable: RoutingTable = {
+      ...table,
+      routes: {
+        ...table.routes,
+        'implementation/code_generation': [
+          {
+            model: 'kilo-auto/efficient',
+            accuracy: 1,
+            avgCostUsd: 0.001,
+            meetsThreshold: true,
+          },
+          {
+            model: 'concrete/chat',
+            accuracy: 0.9,
+            avgCostUsd: 0.002,
+            meetsThreshold: true,
+          },
+        ],
+      },
+    };
+
+    const decision = computeDecision(classification, pollutedTable, null);
+
+    expect(decision).toMatchObject({ model: 'concrete/chat', sticky: false });
+  });
   it('returns null when every route candidate is denied', () => {
     const decision = computeDecision(
       classification,

--- a/services/auto-routing/src/decision-engine.ts
+++ b/services/auto-routing/src/decision-engine.ts
@@ -1,6 +1,7 @@
 import {
   taxonomyRouteKey,
   DEFAULT_AUTO_ROUTING_MODE,
+  isVirtualAutoModelId,
   type AutoRoutingDecision,
   type AutoRoutingMode,
   type ClassifierOutput,
@@ -37,7 +38,9 @@ export function computeDecision(
 ): AutoRoutingDecision | null {
   if (!table) return null;
   const routeKey = taxonomyRouteKey(classification);
-  const candidates = table.routes[routeKey]?.filter(c => !deniedModelIds.has(c.model));
+  const candidates = table.routes[routeKey]?.filter(
+    c => !deniedModelIds.has(c.model) && !isVirtualAutoModelId(c.model)
+  );
   if (!candidates?.length) return null;
   const freshPick = pickFreshCandidate(candidates, mode);
 


### PR DESCRIPTION
## Summary
- Prevent `kilo-auto/*` virtual model IDs from entering auto-routing decider candidate lists.
- Filter virtual auto-model IDs inside the auto-routing worker decision engine so polluted routing tables cannot select them.
- Add a gateway fallback guard so a virtual worker decision resolves to the balanced fallback instead of being sent upstream.

## Verification
N/A - no manual UI flow.

## Visual Changes
N/A

## Reviewer Notes
Current production `routing_table_v1` contains `kilo-auto/efficient`; the worker-side guard handles that polluted table after deploy. The source filter prevents future auto-decider syncs from reintroducing virtual auto models.