### PR TITLE
Add internal replication lag endpoint

### DIFF
--- a/apps/web/src/app/api/internal/db/replication-lag/route.test.ts
+++ b/apps/web/src/app/api/internal/db/replication-lag/route.test.ts
@@ -1,0 +1,90 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/lib/drizzle';
+
+jest.mock('@/lib/config.server', () => ({
+  INTERNAL_API_SECRET: 'internal-secret',
+}));
+
+jest.mock('@/lib/drizzle', () => ({
+  db: {
+    execute: jest.fn(),
+  },
+}));
+
+import { GET } from './route';
+
+const mockExecute = jest.mocked(db.execute);
+
+function queryResult(rows: Record<string, unknown>[]) {
+  return {
+    command: 'SELECT',
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows,
+  };
+}
+
+function createRequest(headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost:3000/api/internal/db/replication-lag', {
+    method: 'GET',
+    headers,
+  });
+}
+
+describe('GET /api/internal/db/replication-lag', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExecute.mockResolvedValue(queryResult([]));
+  });
+
+  it('returns 401 without the internal secret', async () => {
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(401);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('returns replication lag for every target reported by Postgres', async () => {
+    mockExecute.mockResolvedValue(
+      queryResult([
+        {
+          pid: 123,
+          application_name: 'walreceiver',
+          client_addr: '10.0.0.10',
+          client_hostname: null,
+          client_port: 5432,
+          state: 'streaming',
+          sync_state: 'async',
+          sent_lsn: '0/5000000',
+          write_lsn: '0/4FFFFF0',
+          flush_lsn: '0/4FFFFE0',
+          replay_lsn: '0/4FFFFD0',
+          sent_lag_bytes: '0',
+          write_lag_bytes: '16',
+          flush_lag_bytes: '32',
+          replay_lag_bytes: '48',
+          write_lag_seconds: 0.1,
+          flush_lag_seconds: 0.2,
+          replay_lag_seconds: 0.3,
+        },
+      ])
+    );
+
+    const response = await GET(createRequest({ 'X-Internal-Secret': 'internal-secret' }));
+
+    expect(response.status).toBe(200);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toEqual({
+      targets: [
+        expect.objectContaining({
+          application_name: 'walreceiver',
+          client_addr: '10.0.0.10',
+          replay_lag_bytes: '48',
+          replay_lag_seconds: 0.3,
+        }),
+      ],
+      timestamp: expect.any(String),
+    });
+  });
+});

--- a/apps/web/src/app/api/internal/db/replication-lag/route.ts
+++ b/apps/web/src/app/api/internal/db/replication-lag/route.ts
@@ -1,0 +1,70 @@
+import { timingSafeEqual } from 'crypto';
+import { sql } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { INTERNAL_API_SECRET } from '@/lib/config.server';
+import { db } from '@/lib/drizzle';
+
+type ReplicationLagRow = {
+  pid: number;
+  application_name: string;
+  client_addr: string | null;
+  client_hostname: string | null;
+  client_port: number | null;
+  state: string | null;
+  sync_state: string | null;
+  sent_lsn: string | null;
+  write_lsn: string | null;
+  flush_lsn: string | null;
+  replay_lsn: string | null;
+  sent_lag_bytes: string;
+  write_lag_bytes: string;
+  flush_lag_bytes: string;
+  replay_lag_bytes: string;
+  write_lag_seconds: number | null;
+  flush_lag_seconds: number | null;
+  replay_lag_seconds: number | null;
+};
+
+function secretMatches(provided: string | null, expected: string): boolean {
+  if (!provided) return false;
+
+  const providedBuffer = Buffer.from(provided);
+  const expectedBuffer = Buffer.from(expected);
+  if (providedBuffer.length !== expectedBuffer.length) return false;
+
+  return timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+export async function GET(request: Request) {
+  const secret = request.headers.get('X-Internal-Secret');
+  if (!INTERNAL_API_SECRET || !secretMatches(secret, INTERNAL_API_SECRET)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { rows } = await db.execute<ReplicationLagRow>(sql`
+    SELECT
+      pid,
+      application_name,
+      client_addr::text,
+      client_hostname,
+      client_port,
+      state,
+      sync_state,
+      sent_lsn::text,
+      write_lsn::text,
+      flush_lsn::text,
+      replay_lsn::text,
+      COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), sent_lsn), 0)::text AS sent_lag_bytes,
+      COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), write_lsn), 0)::text AS write_lag_bytes,
+      COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), flush_lsn), 0)::text AS flush_lag_bytes,
+      COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn), 0)::text AS replay_lag_bytes,
+      EXTRACT(EPOCH FROM write_lag)::double precision AS write_lag_seconds,
+      EXTRACT(EPOCH FROM flush_lag)::double precision AS flush_lag_seconds,
+      EXTRACT(EPOCH FROM replay_lag)::double precision AS replay_lag_seconds
+    FROM pg_stat_replication
+    ORDER BY application_name, client_addr, client_port
+  `);
+
+  return NextResponse.json({ targets: rows, timestamp: new Date().toISOString() });
+}


### PR DESCRIPTION
## Summary
- Add an internal `GET /api/internal/db/replication-lag` endpoint protected by `X-Internal-Secret`.
- Query `pg_stat_replication` directly so replication targets are discovered from Postgres instead of environment configuration.
- Include coverage for auth rejection and returning dynamically reported target lag rows.

## Validation
- `pnpm --filter web test -- src/app/api/internal/db/replication-lag/route.test.ts`
- `pnpm typecheck`