### PR TITLE
Cloud Agent Next - Reject plan follow-up questions

### DIFF
--- a/services/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
@@ -1510,6 +1510,45 @@ describe('ingest WS reconnection', () => {
     expect(callbacks.onRootSessionActivity).toHaveBeenCalledTimes(2);
   });
 
+  it('rejects real-time plan follow-up questions without disconnecting', async () => {
+    state = new WrapperState();
+    state.bindSession(createSessionContext({ platform: 'cloud-agent-web' }));
+    const rejectQuestion = vi.fn().mockResolvedValue(true);
+    const kiloClient = createMockKiloClient({
+      rejectQuestion,
+      subscribeEvents: vi.fn().mockResolvedValue({
+        stream: createEventStream([
+          {
+            type: 'question.asked',
+            properties: {
+              id: 'q_plan_followup',
+              sessionID: 'kilo_sess_456',
+              questions: [
+                {
+                  question: 'Ready to implement?',
+                  questionKey: 'plan.followup.question',
+                  header: 'Implement',
+                  options: [],
+                },
+              ],
+            },
+          },
+        ]),
+      }),
+    });
+
+    const manager = createManagerWithClient(kiloClient);
+    const ws = await openConnection(manager);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const questionEvents = parseSentMessages(ws).filter(
+      event => event.streamEventType === 'kilocode' && event.data.event === 'question.asked'
+    );
+    expect(questionEvents).toHaveLength(0);
+    expect(rejectQuestion).toHaveBeenCalledWith('q_plan_followup');
+    expect(callbacks.onDisconnect).not.toHaveBeenCalled();
+  });
+
   it('rejects real-time code-review questions without disconnecting', async () => {
     state = new WrapperState();
     state.bindSession(createCodeReviewSessionContext());

--- a/services/cloud-agent-next/wrapper/src/connection.ts
+++ b/services/cloud-agent-next/wrapper/src/connection.ts
@@ -25,6 +25,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+const PLAN_FOLLOWUP_QUESTION_KEY = 'plan.followup.question';
+
+function isPlanFollowupQuestion(value: unknown): boolean {
+  if (!isRecord(value) || !Array.isArray(value.questions) || value.questions.length !== 1) {
+    return false;
+  }
+  const question: unknown = value.questions[0];
+  return isRecord(question) && question.questionKey === PLAN_FOLLOWUP_QUESTION_KEY;
+}
+
 function isCodeReviewJob(state: WrapperState): boolean {
   return state.currentSession?.platform === 'code-review';
 }
@@ -95,14 +105,15 @@ function isRootSessionActivity(
 export const CODE_REVIEW_PERMISSION_REJECTION_MESSAGE =
   'Permission rejected for code-review non-interactive mode. Continue using another read-only, non-interactive method if available.';
 
-function rejectCodeReviewQuestion(
+function rejectQuestion(
   questionId: string | undefined,
+  reason: 'code-review' | 'plan-follow-up',
   kiloClient: WrapperKiloClient
 ): void {
   if (!questionId) return;
   kiloClient.rejectQuestion(questionId).catch(err => {
     logToFile(
-      `failed to reject code-review question ${questionId}: ${err instanceof Error ? err.message : String(err)}`
+      `failed to reject ${reason} question ${questionId}: ${err instanceof Error ? err.message : String(err)}`
     );
   });
 }
@@ -1074,14 +1085,21 @@ export function createConnectionManager(
             continue;
           }
 
-          if (isCodeReviewJob(state)) {
-            if (eventType === 'question.asked') {
-              const questionId = typeof properties.id === 'string' ? properties.id : undefined;
-              rejectCodeReviewQuestion(questionId, config.kiloClient);
+          if (eventType === 'question.asked') {
+            const questionId = typeof properties.id === 'string' ? properties.id : undefined;
+            if (isPlanFollowupQuestion(properties)) {
+              rejectQuestion(questionId, 'plan-follow-up', config.kiloClient);
               callbacks.onSseEvent?.();
               continue;
             }
+            if (isCodeReviewJob(state)) {
+              rejectQuestion(questionId, 'code-review', config.kiloClient);
+              callbacks.onSseEvent?.();
+              continue;
+            }
+          }
 
+          if (isCodeReviewJob(state)) {
             if (
               eventType === 'session.status' &&
               isInteractiveStatusType(statusTypeFromProperties(properties))


### PR DESCRIPTION
## Summary

Reject Kilo plan follow-up questions in the wrapper before forwarding them to Cloud Agent, preventing plan completion from creating an untracked root session. Preserve existing Code Reviewer question rejection and add regression coverage for the live event path.

## Verification

Not manually verified; this is a non-UI wrapper event-handling change.

## Visual Changes

N/A

## Reviewer Notes

The filter applies only to newly received single-question events with the `plan.followup.question` key.