### PR TITLE
fix(mobile): show repo setup when none connected

### DIFF
--- a/apps/mobile/src/app/(app)/agent-chat/new.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/new.tsx
@@ -112,6 +112,7 @@ export default function NewSessionScreen() {
   const showGitHubIntegrationPrompt = shouldShowGitHubIntegrationPrompt({
     isLoadingRepos,
     integrationInstalled: repoData?.integrationInstalled,
+    repositoryCount: repoData?.repositories.length,
   });
 
   const repositories = useMemo(() => {

--- a/apps/mobile/src/lib/agent-github-integration.test.ts
+++ b/apps/mobile/src/lib/agent-github-integration.test.ts
@@ -25,8 +25,19 @@ describe('agent GitHub integration helpers', () => {
       shouldShowGitHubIntegrationPrompt({
         isLoadingRepos: false,
         integrationInstalled: true,
+        repositoryCount: 1,
       })
     ).toBe(false);
+  });
+
+  it('shows the setup prompt when GitHub has no connected repositories', () => {
+    expect(
+      shouldShowGitHubIntegrationPrompt({
+        isLoadingRepos: false,
+        integrationInstalled: true,
+        repositoryCount: 0,
+      })
+    ).toBe(true);
   });
 
   it('builds personal and organization GitHub integration URLs', () => {

--- a/apps/mobile/src/lib/agent-github-integration.ts
+++ b/apps/mobile/src/lib/agent-github-integration.ts
@@ -1,11 +1,13 @@
 export function shouldShowGitHubIntegrationPrompt({
   isLoadingRepos,
   integrationInstalled,
+  repositoryCount,
 }: {
   isLoadingRepos: boolean;
   integrationInstalled: boolean | undefined;
+  repositoryCount?: number;
 }): boolean {
-  return !isLoadingRepos && integrationInstalled === false;
+  return !isLoadingRepos && (integrationInstalled === false || repositoryCount === 0);
 }
 
 export function getGitHubIntegrationUrl(webBaseUrl: string, organizationId?: string): string {


### PR DESCRIPTION
## Summary

Show the mobile GitHub setup prompt when the repository query loads with zero connected repositories, not only when the GitHub integration is missing.

## Verification

Not run manually; this state is covered by the focused helper regression test.

## Visual Changes

N/A

## Reviewer Notes

Applies to both personal and organization New Session contexts because the condition runs after the context-specific repository query resolves.
