### PR TITLE
feat(o11y): add Gastown container health alerting

### DIFF
--- a/services/o11y/src/alerting/evaluate.ts
+++ b/services/o11y/src/alerting/evaluate.ts
@@ -19,6 +19,7 @@ import { listAlertingConfigs, type AlertingConfig } from './config-store';
 import { listTtfbAlertingConfigs, type TtfbAlertingConfig } from './ttfb-config-store';
 import { evaluateContainerCapacity } from './container-capacity-evaluate';
 import { evaluateQueueBacklogAlert } from './queue-backlog-evaluate';
+import { evaluateGastownHealthAlert } from './gastown-health-evaluate';
 
 /**
  * Compute the burn rate from an observed bad-event fraction and the SLO.
@@ -318,6 +319,12 @@ export async function evaluateAlerts(env: Env): Promise<void> {
     await evaluateQueueBacklogAlert(env);
   } catch (err) {
     errors.push(new Error('queue_backlog evaluation', { cause: err }));
+  }
+
+  try {
+    await evaluateGastownHealthAlert(env);
+  } catch (err) {
+    errors.push(new Error('gastown_container_health evaluation', { cause: err }));
   }
 
   if (errors.length > 0) {

--- a/services/o11y/src/alerting/gastown-health-evaluate.ts
+++ b/services/o11y/src/alerting/gastown-health-evaluate.ts
@@ -1,0 +1,74 @@
+import { queryGastownHealth, type GastownHealthMetrics } from './gastown-health-query';
+import {
+  readGastownHealthState,
+  transitionGastownHealthState,
+  writeGastownHealthState,
+} from './gastown-health-state';
+import { sendAlertNotification, type AlertPayload } from './notify';
+
+export const GASTOWN_HEALTH_THRESHOLDS = {
+  weightedFailedChecks: 20,
+  affectedTowns: 3,
+} as const;
+
+type GastownHealthEnv = {
+  O11Y_ALERT_STATE: KVNamespace;
+  O11Y_CF_ACCOUNT_ID: string;
+  O11Y_CF_AE_API_TOKEN: SecretsStoreSecret;
+  O11Y_SLACK_WEBHOOK_PAGE: SecretsStoreSecret;
+  O11Y_SLACK_WEBHOOK_TICKET: SecretsStoreSecret;
+};
+
+type QueryFn = (
+  env: Pick<GastownHealthEnv, 'O11Y_CF_ACCOUNT_ID' | 'O11Y_CF_AE_API_TOKEN'>
+) => Promise<GastownHealthMetrics>;
+
+type NotifyFn = (alert: AlertPayload, env: GastownHealthEnv) => Promise<void>;
+
+function getCrossedThresholds(
+  metrics: GastownHealthMetrics
+): Array<'failed_checks' | 'affected_towns'> {
+  const crossedThresholds: Array<'failed_checks' | 'affected_towns'> = [];
+  if (metrics.weightedFailedChecks >= GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks) {
+    crossedThresholds.push('failed_checks');
+  }
+  if (metrics.affectedTownCount >= GASTOWN_HEALTH_THRESHOLDS.affectedTowns) {
+    crossedThresholds.push('affected_towns');
+  }
+  return crossedThresholds;
+}
+
+export async function evaluateGastownHealthAlert(
+  env: GastownHealthEnv,
+  queryFn: QueryFn = queryGastownHealth,
+  notifyFn: NotifyFn = sendAlertNotification
+): Promise<void> {
+  const metrics = await queryFn(env);
+  const crossedThresholds = getCrossedThresholds(metrics);
+  const currentState = await readGastownHealthState(env.O11Y_ALERT_STATE);
+  const transition = transitionGastownHealthState(
+    currentState,
+    metrics,
+    crossedThresholds.length > 0
+  );
+
+  if (transition.shouldNotify) {
+    await notifyFn(
+      {
+        alertType: 'gastown_container_health',
+        severity: 'ticket',
+        weightedFailedChecks: metrics.weightedFailedChecks,
+        affectedTownCount: metrics.affectedTownCount,
+        windowMinutes: 5,
+        crossedThresholds,
+        failedChecksThreshold: GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks,
+        affectedTownsThreshold: GASTOWN_HEALTH_THRESHOLDS.affectedTowns,
+      },
+      env
+    );
+  }
+
+  if (transition.stateChanged) {
+    await writeGastownHealthState(env.O11Y_ALERT_STATE, transition.state);
+  }
+}

--- a/services/o11y/src/alerting/gastown-health-query.ts
+++ b/services/o11y/src/alerting/gastown-health-query.ts
@@ -31,6 +31,13 @@ const GastownHealthResponseSchema = z.object({
 
 const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
 
+// Analytics Engine MAX(timestamp) may return strings like "2026-06-24 15:10:00.000"
+// without a timezone offset. Append "Z" when no offset or "Z" suffix is present so
+// new Date() treats the value as UTC rather than the runtime's local timezone.
+function toUtcIsoString(value: string): string {
+  return /[Zz]$|[+-]\d{2}:\d{2}$/.test(value) ? value : `${value}Z`;
+}
+
 export async function queryGastownHealth(
   env: QueryEnv,
   fetchFn: FetchFn = fetch
@@ -78,7 +85,9 @@ export async function queryGastownHealth(
   }
 
   const latestEventTimestamp =
-    row.latest_event_timestamp === null ? null : new Date(row.latest_event_timestamp);
+    row.latest_event_timestamp === null
+      ? null
+      : new Date(toUtcIsoString(row.latest_event_timestamp));
   if (latestEventTimestamp !== null && Number.isNaN(latestEventTimestamp.getTime())) {
     throw new Error('Gastown health Analytics Engine response contains an invalid timestamp');
   }

--- a/services/o11y/src/alerting/gastown-health-query.ts
+++ b/services/o11y/src/alerting/gastown-health-query.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+
+export const GASTOWN_HEALTH_WINDOW_MINUTES = 5;
+
+export type GastownHealthMetrics = {
+  weightedFailedChecks: number;
+  weightedSuccessfulChecks: number;
+  affectedTownCount: number;
+  latestEventTimestamp: Date | null;
+};
+
+type QueryEnv = {
+  O11Y_CF_ACCOUNT_ID: string;
+  O11Y_CF_AE_API_TOKEN: SecretsStoreSecret;
+};
+
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+const GastownHealthResponseSchema = z.object({
+  data: z
+    .array(
+      z.object({
+        weighted_failed_checks: z.number().nonnegative().nullable(),
+        weighted_successful_checks: z.number().nonnegative().nullable(),
+        affected_town_count: z.number().int().nonnegative().nullable(),
+        latest_event_timestamp: z.string().nullable(),
+      })
+    )
+    .max(1),
+});
+
+const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
+
+export async function queryGastownHealth(
+  env: QueryEnv,
+  fetchFn: FetchFn = fetch
+): Promise<GastownHealthMetrics> {
+  const apiToken = await env.O11Y_CF_AE_API_TOKEN.get();
+  if (!apiToken) {
+    throw new Error('O11Y_CF_AE_API_TOKEN secret is not configured');
+  }
+
+  const sql = `
+    SELECT
+      SUM(IF(blob5 != '', _sample_interval, 0)) AS weighted_failed_checks,
+      SUM(IF(blob5 = '', _sample_interval, 0)) AS weighted_successful_checks,
+      uniqExactIf(blob6, blob5 != '' AND blob6 != '') AS affected_town_count,
+      MAX(timestamp) AS latest_event_timestamp
+    FROM gastown_events
+    WHERE timestamp > NOW() - INTERVAL '${GASTOWN_HEALTH_WINDOW_MINUTES}' MINUTE
+      AND blob1 = 'container.health_ping'
+    FORMAT JSON
+  `;
+
+  const response = await fetchFn(
+    `${CF_API_BASE}/accounts/${env.O11Y_CF_ACCOUNT_ID}/analytics_engine/sql`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiToken}` },
+      body: sql,
+      signal: AbortSignal.timeout(5_000),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Gastown health Analytics Engine query failed (${response.status})`);
+  }
+
+  const parsed = GastownHealthResponseSchema.parse(await response.json());
+  const row = parsed.data[0];
+  if (!row) {
+    return {
+      weightedFailedChecks: 0,
+      weightedSuccessfulChecks: 0,
+      affectedTownCount: 0,
+      latestEventTimestamp: null,
+    };
+  }
+
+  const latestEventTimestamp =
+    row.latest_event_timestamp === null ? null : new Date(row.latest_event_timestamp);
+  if (latestEventTimestamp !== null && Number.isNaN(latestEventTimestamp.getTime())) {
+    throw new Error('Gastown health Analytics Engine response contains an invalid timestamp');
+  }
+
+  return {
+    weightedFailedChecks: row.weighted_failed_checks ?? 0,
+    weightedSuccessfulChecks: row.weighted_successful_checks ?? 0,
+    affectedTownCount: row.affected_town_count ?? 0,
+    latestEventTimestamp,
+  };
+}

--- a/services/o11y/src/alerting/gastown-health-state.ts
+++ b/services/o11y/src/alerting/gastown-health-state.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+import type { GastownHealthMetrics } from './gastown-health-query';
+
+const CONSECUTIVE_HEALTHY_TO_RESOLVE = 3;
+const STATE_KEY = 'o11y:gastown_container_health';
+
+const GastownHealthStateSchema = z.discriminatedUnion('active', [
+  z.object({
+    active: z.literal(false),
+    consecutiveHealthyCount: z.literal(0),
+  }),
+  z.object({
+    active: z.literal(true),
+    consecutiveHealthyCount: z
+      .number()
+      .int()
+      .min(0)
+      .max(CONSECUTIVE_HEALTHY_TO_RESOLVE - 1),
+  }),
+]);
+
+export type GastownHealthState = z.infer<typeof GastownHealthStateSchema>;
+
+export type GastownHealthTransition = {
+  state: GastownHealthState;
+  shouldNotify: boolean;
+  stateChanged: boolean;
+};
+
+function inactiveState(): GastownHealthState {
+  return { active: false, consecutiveHealthyCount: 0 };
+}
+
+export function transitionGastownHealthState(
+  state: GastownHealthState,
+  metrics: GastownHealthMetrics,
+  thresholdCrossed: boolean
+): GastownHealthTransition {
+  if (thresholdCrossed) {
+    if (!state.active) {
+      return {
+        state: { active: true, consecutiveHealthyCount: 0 },
+        shouldNotify: true,
+        stateChanged: true,
+      };
+    }
+
+    if (state.consecutiveHealthyCount > 0) {
+      return {
+        state: { active: true, consecutiveHealthyCount: 0 },
+        shouldNotify: false,
+        stateChanged: true,
+      };
+    }
+
+    return { state, shouldNotify: false, stateChanged: false };
+  }
+
+  if (!state.active || metrics.weightedSuccessfulChecks <= 0) {
+    return { state, shouldNotify: false, stateChanged: false };
+  }
+
+  const consecutiveHealthyCount = state.consecutiveHealthyCount + 1;
+  if (consecutiveHealthyCount >= CONSECUTIVE_HEALTHY_TO_RESOLVE) {
+    return { state: inactiveState(), shouldNotify: false, stateChanged: true };
+  }
+
+  return {
+    state: { active: true, consecutiveHealthyCount },
+    shouldNotify: false,
+    stateChanged: true,
+  };
+}
+
+export async function readGastownHealthState(kv: KVNamespace): Promise<GastownHealthState> {
+  const raw = await kv.get(STATE_KEY);
+  if (raw === null) return inactiveState();
+
+  try {
+    const parsed = GastownHealthStateSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : inactiveState();
+  } catch {
+    return inactiveState();
+  }
+}
+
+export async function writeGastownHealthState(
+  kv: KVNamespace,
+  state: GastownHealthState
+): Promise<void> {
+  await kv.put(STATE_KEY, JSON.stringify(state));
+}

--- a/services/o11y/src/alerting/notify.ts
+++ b/services/o11y/src/alerting/notify.ts
@@ -55,10 +55,22 @@ export type QueueBacklogAlertPayload = {
   oldestMessageTimestamp?: Date;
 };
 
+export type GastownHealthAlertPayload = {
+  alertType: 'gastown_container_health';
+  severity: 'ticket';
+  weightedFailedChecks: number;
+  affectedTownCount: number;
+  windowMinutes: number;
+  crossedThresholds: Array<'failed_checks' | 'affected_towns'>;
+  failedChecksThreshold: number;
+  affectedTownsThreshold: number;
+};
+
 export type AlertPayload =
   | SloAlertPayload
   | ContainerCapacityAlertPayload
-  | QueueBacklogAlertPayload;
+  | QueueBacklogAlertPayload
+  | GastownHealthAlertPayload;
 
 // ── Formatting helpers ───────────────────────────────────────────────────────
 
@@ -76,6 +88,8 @@ function formatAlertTypeLabel(alertType: AlertPayload['alertType']): string {
       return 'Container Capacity';
     case 'queue_backlog':
       return 'Queue Backlog';
+    case 'gastown_container_health':
+      return 'Gastown Container Health';
   }
 }
 
@@ -178,9 +192,15 @@ function buildQueueBacklogSlackBlocks(alert: QueueBacklogAlertPayload): object[]
       type: 'section',
       fields: [
         { type: 'mrkdwn', text: `*Queue ID:*\n${alert.model}` },
-        { type: 'mrkdwn', text: `*Backlog:*\n${alert.backlogCount.toLocaleString()} messages` },
-        { type: 'mrkdwn', text: `*Threshold:*\n${alert.thresholdCount.toLocaleString()} messages` },
-        { type: 'mrkdwn', text: `*Backlog bytes:*\n${alert.backlogBytes.toLocaleString()}` },
+        {
+          type: 'mrkdwn',
+          text: `*Backlog:*\n${alert.backlogCount.toLocaleString('en-US')} messages`,
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Threshold:*\n${alert.thresholdCount.toLocaleString('en-US')} messages`,
+        },
+        { type: 'mrkdwn', text: `*Backlog bytes:*\n${alert.backlogBytes.toLocaleString('en-US')}` },
       ],
     },
     {
@@ -188,6 +208,52 @@ function buildQueueBacklogSlackBlocks(alert: QueueBacklogAlertPayload): object[]
       text: {
         type: 'mrkdwn',
         text: `Oldest message: ${oldestMessageTimestamp}`,
+      },
+    },
+  ];
+}
+
+const GASTOWN_DASHBOARD_URL = 'https://ops.kiloapps.io/d/gastown-ops-1/gastown-operations';
+const GASTOWN_HEALTH_RUNBOOK_URL =
+  'https://github.com/Kilo-Org/on-call/blob/main/runbooks/gastown-container-health-failures.md';
+
+function buildGastownHealthSlackBlocks(alert: GastownHealthAlertPayload): object[] {
+  const crossedThresholds = alert.crossedThresholds
+    .map(threshold =>
+      threshold === 'failed_checks'
+        ? `${alert.failedChecksThreshold.toLocaleString('en-US')} failed checks`
+        : `${alert.affectedTownsThreshold.toLocaleString('en-US')} affected towns`
+    )
+    .join(' and ');
+
+  return [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: ':ticket: TICKET — Gastown container health failures',
+      },
+    },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `*Window:*\n${alert.windowMinutes}-minute window` },
+        {
+          type: 'mrkdwn',
+          text: `*Failed checks:*\n${alert.weightedFailedChecks.toLocaleString('en-US')}`,
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Affected towns:*\n${alert.affectedTownCount.toLocaleString('en-US')}`,
+        },
+        { type: 'mrkdwn', text: `*Threshold crossed:*\n${crossedThresholds}` },
+      ],
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `Investigate aggregate container health failures. Do not restart towns without active-session authorization.\n<${GASTOWN_DASHBOARD_URL}|Gastown dashboard> | <${GASTOWN_HEALTH_RUNBOOK_URL}|Container-health runbook>`,
       },
     },
   ];
@@ -203,6 +269,8 @@ export function buildSlackMessage(alert: AlertPayload): object {
       return { blocks: buildCapacitySlackBlocks(alert) };
     case 'queue_backlog':
       return { blocks: buildQueueBacklogSlackBlocks(alert) };
+    case 'gastown_container_health':
+      return { blocks: buildGastownHealthSlackBlocks(alert) };
     default:
       return { blocks: buildSloSlackBlocks(alert) };
   }

--- a/services/o11y/test/gastown-health-evaluate.spec.ts
+++ b/services/o11y/test/gastown-health-evaluate.spec.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateGastownHealthAlert,
+  GASTOWN_HEALTH_THRESHOLDS,
+} from '../src/alerting/gastown-health-evaluate';
+import type { GastownHealthMetrics } from '../src/alerting/gastown-health-query';
+import type { AlertPayload } from '../src/alerting/notify';
+
+const STATE_KEY = 'o11y:gastown_container_health';
+
+function makeKv() {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+    store,
+  } as unknown as KVNamespace & { store: Map<string, string> };
+}
+
+function makeSecret(value: string): SecretsStoreSecret {
+  return { get: async () => value } as unknown as SecretsStoreSecret;
+}
+
+function makeEnv(kv: KVNamespace) {
+  return {
+    O11Y_ALERT_STATE: kv,
+    O11Y_CF_ACCOUNT_ID: 'test-account',
+    O11Y_CF_AE_API_TOKEN: makeSecret('test-token'),
+    O11Y_SLACK_WEBHOOK_PAGE: makeSecret('https://hooks.slack.com/page'),
+    O11Y_SLACK_WEBHOOK_TICKET: makeSecret('https://hooks.slack.com/ticket'),
+  };
+}
+
+function makeMetrics(
+  weightedFailedChecks: number,
+  affectedTownCount: number,
+  weightedSuccessfulChecks = 0
+): GastownHealthMetrics {
+  return {
+    weightedFailedChecks,
+    weightedSuccessfulChecks,
+    affectedTownCount,
+    latestEventTimestamp:
+      weightedFailedChecks + weightedSuccessfulChecks > 0
+        ? new Date('2026-06-24T15:10:00.000Z')
+        : null,
+  };
+}
+
+async function evaluateAt(
+  kv: KVNamespace,
+  result: GastownHealthMetrics,
+  sentAlerts: AlertPayload[]
+): Promise<void> {
+  await evaluateGastownHealthAlert(
+    makeEnv(kv),
+    async () => result,
+    async alert => {
+      sentAlerts.push(alert);
+    }
+  );
+}
+
+describe('evaluateGastownHealthAlert', () => {
+  it('does not alert below both thresholds', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateAt(
+      kv,
+      makeMetrics(
+        GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks - 1,
+        GASTOWN_HEALTH_THRESHOLDS.affectedTowns - 1,
+        10
+      ),
+      sentAlerts
+    );
+
+    expect(sentAlerts).toEqual([]);
+    expect(kv.store.size).toBe(0);
+  });
+
+  it('alerts at 20 weighted failures', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateAt(
+      kv,
+      makeMetrics(GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks, 1),
+      sentAlerts
+    );
+
+    expect(sentAlerts).toMatchObject([
+      {
+        alertType: 'gastown_container_health',
+        severity: 'ticket',
+        weightedFailedChecks: 20,
+        affectedTownCount: 1,
+        crossedThresholds: ['failed_checks'],
+      },
+    ]);
+  });
+
+  it('alerts at three affected towns', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateAt(kv, makeMetrics(3, GASTOWN_HEALTH_THRESHOLDS.affectedTowns), sentAlerts);
+
+    expect(sentAlerts).toMatchObject([
+      {
+        alertType: 'gastown_container_health',
+        crossedThresholds: ['affected_towns'],
+      },
+    ]);
+  });
+
+  it('notifies only once during persistent failure', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+    const failingMetrics = makeMetrics(20, 3);
+
+    await evaluateAt(kv, failingMetrics, sentAlerts);
+    await evaluateAt(kv, failingMetrics, sentAlerts);
+    await evaluateAt(kv, failingMetrics, sentAlerts);
+
+    expect(sentAlerts).toHaveLength(1);
+  });
+
+  it('does not clear active state when no telemetry is observed', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateAt(kv, makeMetrics(20, 1), sentAlerts);
+    await evaluateAt(kv, makeMetrics(0, 0), sentAlerts);
+    await evaluateAt(kv, makeMetrics(0, 0), sentAlerts);
+    await evaluateAt(kv, makeMetrics(0, 0), sentAlerts);
+
+    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
+      active: true,
+      consecutiveHealthyCount: 0,
+    });
+  });
+
+  it('clears after three consecutive healthy evaluations and alerts on recurrence', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateAt(kv, makeMetrics(20, 1), sentAlerts);
+    await evaluateAt(kv, makeMetrics(0, 0, 12), sentAlerts);
+    await evaluateAt(kv, makeMetrics(0, 0, 8), sentAlerts);
+    await evaluateAt(kv, makeMetrics(0, 0, 1), sentAlerts);
+
+    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
+      active: false,
+      consecutiveHealthyCount: 0,
+    });
+
+    await evaluateAt(kv, makeMetrics(20, 1), sentAlerts);
+    expect(sentAlerts).toHaveLength(2);
+  });
+
+  it('resets recovery progress when a threshold is crossed again', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateAt(kv, makeMetrics(20, 1), sentAlerts);
+    await evaluateAt(kv, makeMetrics(0, 0, 1), sentAlerts);
+    await evaluateAt(kv, makeMetrics(20, 1), sentAlerts);
+
+    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
+      active: true,
+      consecutiveHealthyCount: 0,
+    });
+    expect(sentAlerts).toHaveLength(1);
+  });
+
+  it('does not persist active state when notification delivery fails', async () => {
+    const kv = makeKv();
+
+    await expect(
+      evaluateGastownHealthAlert(
+        makeEnv(kv),
+        async () => makeMetrics(20, 1),
+        async () => {
+          throw new Error('Slack unavailable');
+        }
+      )
+    ).rejects.toThrow('Slack unavailable');
+
+    expect(kv.store.size).toBe(0);
+  });
+});

--- a/services/o11y/test/gastown-health-query.spec.ts
+++ b/services/o11y/test/gastown-health-query.spec.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  GASTOWN_HEALTH_WINDOW_MINUTES,
+  queryGastownHealth,
+} from '../src/alerting/gastown-health-query';
+
+const ACCOUNT_ID = 'test-account-123';
+const API_TOKEN = 'test-token-abc';
+
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+function makeSecret(value: string | null): SecretsStoreSecret {
+  return { get: async () => value } as unknown as SecretsStoreSecret;
+}
+
+function makeEnv(token: string | null = API_TOKEN) {
+  return {
+    O11Y_CF_ACCOUNT_ID: ACCOUNT_ID,
+    O11Y_CF_AE_API_TOKEN: makeSecret(token),
+  };
+}
+
+describe('queryGastownHealth', () => {
+  it('queries weighted five-minute container health metrics', async () => {
+    let calledUrl = '';
+    let calledInit: RequestInit | undefined;
+    const fetchFn: FetchFn = async (url, init) => {
+      calledUrl = url;
+      calledInit = init;
+      return Response.json({
+        data: [
+          {
+            weighted_failed_checks: 24,
+            weighted_successful_checks: 150,
+            affected_town_count: 4,
+            latest_event_timestamp: '2026-06-24 15:10:00.000',
+          },
+        ],
+      });
+    };
+
+    await expect(queryGastownHealth(makeEnv(), fetchFn)).resolves.toEqual({
+      weightedFailedChecks: 24,
+      weightedSuccessfulChecks: 150,
+      affectedTownCount: 4,
+      latestEventTimestamp: new Date('2026-06-24 15:10:00.000'),
+    });
+    expect(calledUrl).toBe(
+      `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/analytics_engine/sql`
+    );
+    expect(new Headers(calledInit?.headers).get('Authorization')).toBe(`Bearer ${API_TOKEN}`);
+    expect(calledInit?.signal).toBeInstanceOf(AbortSignal);
+
+    const sql = String(calledInit?.body);
+    expect(sql).toContain('FROM gastown_events');
+    expect(sql).toContain(`INTERVAL '${GASTOWN_HEALTH_WINDOW_MINUTES}' MINUTE`);
+    expect(sql).toContain("blob1 = 'container.health_ping'");
+    expect(sql).toContain("SUM(IF(blob5 != '', _sample_interval, 0))");
+    expect(sql).toContain("SUM(IF(blob5 = '', _sample_interval, 0))");
+    expect(sql).toContain("uniqExactIf(blob6, blob5 != '' AND blob6 != '')");
+    expect(sql).not.toContain('COUNT(');
+  });
+
+  it('maps an empty Analytics Engine result to no telemetry', async () => {
+    const fetchFn: FetchFn = async () => Response.json({ data: [] });
+
+    await expect(queryGastownHealth(makeEnv(), fetchFn)).resolves.toEqual({
+      weightedFailedChecks: 0,
+      weightedSuccessfulChecks: 0,
+      affectedTownCount: 0,
+      latestEventTimestamp: null,
+    });
+  });
+
+  it('maps null aggregates to no telemetry', async () => {
+    const fetchFn: FetchFn = async () =>
+      Response.json({
+        data: [
+          {
+            weighted_failed_checks: null,
+            weighted_successful_checks: null,
+            affected_town_count: 0,
+            latest_event_timestamp: null,
+          },
+        ],
+      });
+
+    await expect(queryGastownHealth(makeEnv(), fetchFn)).resolves.toEqual({
+      weightedFailedChecks: 0,
+      weightedSuccessfulChecks: 0,
+      affectedTownCount: 0,
+      latestEventTimestamp: null,
+    });
+  });
+
+  it('rejects malformed Analytics Engine responses', async () => {
+    const fetchFn: FetchFn = async () =>
+      Response.json({ data: [{ weighted_failed_checks: '20' }] });
+
+    await expect(queryGastownHealth(makeEnv(), fetchFn)).rejects.toThrow();
+  });
+
+  it('rejects non-2xx Analytics Engine responses without exposing response content', async () => {
+    const fetchFn: FetchFn = async () =>
+      new Response('sensitive provider response', { status: 403 });
+
+    await expect(queryGastownHealth(makeEnv(), fetchFn)).rejects.toThrow(
+      'Gastown health Analytics Engine query failed (403)'
+    );
+  });
+
+  it('times out Analytics Engine requests after five seconds', async () => {
+    const controller = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal);
+    let signalReady: (() => void) | undefined;
+    const receivedSignal = new Promise<void>(resolve => {
+      signalReady = resolve;
+    });
+    const fetchFn: FetchFn = async (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason));
+        signalReady?.();
+      });
+
+    const query = queryGastownHealth(makeEnv(), fetchFn);
+    await receivedSignal;
+    controller.abort(new DOMException('Timed out', 'TimeoutError'));
+
+    await expect(query).rejects.toMatchObject({ name: 'TimeoutError' });
+    expect(timeoutSpy).toHaveBeenCalledWith(5_000);
+    timeoutSpy.mockRestore();
+  });
+
+  it('throws when the Analytics Engine token is not configured', async () => {
+    const fetchFn: FetchFn = async () => Response.json({ data: [] });
+
+    await expect(queryGastownHealth(makeEnv(null), fetchFn)).rejects.toThrow(
+      'O11Y_CF_AE_API_TOKEN secret is not configured'
+    );
+  });
+});

--- a/services/o11y/test/gastown-health-query.spec.ts
+++ b/services/o11y/test/gastown-health-query.spec.ts
@@ -43,7 +43,7 @@ describe('queryGastownHealth', () => {
       weightedFailedChecks: 24,
       weightedSuccessfulChecks: 150,
       affectedTownCount: 4,
-      latestEventTimestamp: new Date('2026-06-24 15:10:00.000'),
+      latestEventTimestamp: new Date('2026-06-24T15:10:00.000Z'),
     });
     expect(calledUrl).toBe(
       `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/analytics_engine/sql`

--- a/services/o11y/test/notify.spec.ts
+++ b/services/o11y/test/notify.spec.ts
@@ -4,6 +4,7 @@ import {
   type SloAlertPayload,
   type ContainerCapacityAlertPayload,
   type QueueBacklogAlertPayload,
+  type GastownHealthAlertPayload,
 } from '../src/alerting/notify';
 
 describe('buildSlackMessage — SLO error_rate alert', () => {
@@ -93,6 +94,39 @@ describe('buildSlackMessage — queue_backlog alert', () => {
     expect(allText.some(text => text.includes('50,000'))).toBe(true);
     expect(allText.some(text => text.includes('12,345,678'))).toBe(true);
     expect(allText.some(text => text.includes('2026-06-04T08:00:00.000Z'))).toBe(true);
+  });
+});
+
+describe('buildSlackMessage — gastown_container_health alert', () => {
+  const alert: GastownHealthAlertPayload = {
+    alertType: 'gastown_container_health',
+    severity: 'ticket',
+    weightedFailedChecks: 24,
+    affectedTownCount: 4,
+    windowMinutes: 5,
+    crossedThresholds: ['failed_checks', 'affected_towns'],
+    failedChecksThreshold: 20,
+    affectedTownsThreshold: 3,
+  };
+
+  it('includes counts, crossed thresholds, and investigation guidance', () => {
+    const msg = buildSlackMessage(alert) as {
+      blocks: Array<{ fields?: Array<{ text: string }>; text?: { text: string } }>;
+    };
+    const allText = msg.blocks.flatMap(block => [
+      block.text?.text ?? '',
+      ...(block.fields?.map(field => field.text) ?? []),
+    ]);
+    const text = allText.join('\n');
+
+    expect(text).toContain('Gastown container health failures');
+    expect(text).toContain('5-minute window');
+    expect(text).toContain('24');
+    expect(text).toContain('4');
+    expect(text).toContain('20 failed checks');
+    expect(text).toContain('3 affected towns');
+    expect(text).toContain('gastown-operations');
+    expect(text).toContain('gastown-container-health-failures.md');
   });
 });
 

--- a/services/o11y/test/queue-backlog-integration.spec.ts
+++ b/services/o11y/test/queue-backlog-integration.spec.ts
@@ -30,8 +30,8 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe('evaluateAlerts queue backlog integration', () => {
-  it('sends a page alert even when SLO configuration is unavailable', async () => {
+describe('evaluateAlerts infrastructure isolation', () => {
+  it('continues other evaluations when Gastown health and SLO configuration fail', async () => {
     const kv = makeKv();
     const slackMessages: unknown[] = [];
     const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -48,6 +48,9 @@ describe('evaluateAlerts queue backlog integration', () => {
             oldest_message_timestamp_ms: 1_780_560_000_000,
           },
         });
+      }
+      if (url.includes('/analytics_engine/sql')) {
+        throw new Error('Gastown Analytics Engine unavailable');
       }
       if (url === 'https://hooks.slack.com/page') {
         slackMessages.push(JSON.parse(String(init?.body)));
@@ -67,8 +70,14 @@ describe('evaluateAlerts queue backlog integration', () => {
       O11Y_SLACK_WEBHOOK_TICKET: makeSecret('https://hooks.slack.com/ticket'),
     } as Env;
 
-    await expect(evaluateAlerts(env)).rejects.toThrow('Alert evaluation failed with 2 error(s)');
+    await expect(evaluateAlerts(env)).rejects.toThrow('Alert evaluation failed with 3 error(s)');
 
+    expect(
+      fetchFn.mock.calls.some(([input]) => String(input).includes('/containers/dash/applications'))
+    ).toBe(true);
+    expect(
+      fetchFn.mock.calls.some(([input]) => String(input).includes('/analytics_engine/sql'))
+    ).toBe(true);
     expect(slackMessages).toHaveLength(1);
     expect(JSON.stringify(slackMessages[0])).toContain('Queue Backlog Alert');
     expect(kv.store.has(`o11y:queue_backlog:${MONITORED_QUEUE_ID}`)).toBe(true);

--- a/services/o11y/wrangler.jsonc
+++ b/services/o11y/wrangler.jsonc
@@ -74,6 +74,11 @@
     "O11Y_API_BASE_URL": "https://api.kilo.ai",
   },
   /**
+   * Alert deployment requirements:
+   * - O11Y_CF_AE_API_TOKEN needs account Analytics Read access.
+   * - O11Y_SLACK_WEBHOOK_TICKET must deliver to #o11y-alerts.
+   */
+  /**
    * Secrets Store
    * https://developers.cloudflare.com/workers/configuration/secrets/#secrets-store
    */


### PR DESCRIPTION
## Summary
Add ticket-severity alerting for broad or sustained Gastown container health failures.

### Why this change is needed
A June 23 incident produced 2,887 failed container health checks across 33 towns in about 52 minutes without basic aggregate alerting. On-call needs a low-noise signal when failures become broad or sustained, while telemetry gaps must not be mistaken for recovery.

### How this is addressed
- Query weighted `container.health_ping` successes and failures across a trailing five-minute Analytics Engine window.
- Alert once when failures reach 20 weighted checks or three affected towns.
- Keep alert state active until three consecutive evaluations contain positive health evidence below both thresholds.
- Route ticket notifications through existing ticket webhook with dashboard and runbook guidance.
- Isolate Gastown evaluator failures so existing SLO, container-capacity, and queue-backlog checks continue.
- Normalize Analytics Engine `MAX(timestamp)` strings to UTC before `new Date()` construction so `latestEventTimestamp` is correct on non-UTC workers.

## Human Verification
- Focused Gastown query, lifecycle, notification, and evaluator-isolation tests passed.
- Complete o11y test suite passed: 15 files, 140 tests.
- Seven-focus code review completed; React analyzer passed with no React files in scope.

## Reviewer Notes

### Human Reviewer Flags
- Recovery intentionally requires at least one successful health check in each of three consecutive evaluations. Empty windows do not clear state because they may indicate missing telemetry.
- Deployment must confirm `O11Y_CF_AE_API_TOKEN` has account Analytics Read access.
- Repository configuration cannot prove webhook destination. Confirm `O11Y_SLACK_WEBHOOK_TICKET` delivers to `#o11y-alerts`.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Analytics Engine aggregate responses are validated with Zod, including nullable quiet-window aggregates.
- Weighted event volume uses `_sample_interval`; raw row count is not used.
- KV state persists one aggregate alert lifecycle and excludes town IDs from notifications.

</details>

Built for jeanduplessis by [Kilo](https://kilo.ai)