### PR TITLE
fix(web): align shared UI primitives with DESIGN.md

### DIFF
--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -21,6 +21,12 @@ const meta: Meta<typeof Table> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const usageRows = [
+  { session: 'Storybook QA', model: 'GPT-5.5', cost: '$4.20', selected: true },
+  { session: 'Billing review', model: 'Claude Opus 4.8', cost: '$7.14', selected: false },
+  { session: 'Docs cleanup', model: 'Gemini 3.5', cost: '$1.88', selected: false },
+] as const;
+
 export const Usage: Story = {
   render: () => (
     <div className="w-[640px] rounded-xl border border-border bg-card p-4">
@@ -34,15 +40,11 @@ export const Usage: Story = {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {[
-            ['Storybook QA', 'GPT-5.5', '$4.20'],
-            ['Billing review', 'Claude Opus 4.8', '$7.14'],
-            ['Docs cleanup', 'Gemini 3.5', '$1.88'],
-          ].map(row => (
-            <TableRow key={row[0]}>
-              <TableCell className="font-medium">{row[0]}</TableCell>
-              <TableCell>{row[1]}</TableCell>
-              <TableCell className="text-right tabular-nums">{row[2]}</TableCell>
+          {usageRows.map(row => (
+            <TableRow key={row.session} data-state={row.selected ? 'selected' : undefined}>
+              <TableCell className="font-medium">{row.session}</TableCell>
+              <TableCell>{row.model}</TableCell>
+              <TableCell className="text-right tabular-nums">{row.cost}</TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/apps/storybook/stories/Textarea.stories.tsx
+++ b/apps/storybook/stories/Textarea.stories.tsx
@@ -30,3 +30,33 @@ export const Disabled: Story = {
     </div>
   ),
 };
+
+export const FocusVisible: Story = {
+  render: () => (
+    <div className="w-80 space-y-2">
+      <Label htmlFor="textarea-focus">Review notes</Label>
+      <Textarea
+        id="textarea-focus"
+        defaultValue="Summarize token drift before handoff."
+        className="border-ring ring-ring/50 ring-[3px]"
+      />
+    </div>
+  ),
+};
+
+export const Invalid: Story = {
+  render: () => (
+    <div className="w-80 space-y-2">
+      <Label htmlFor="textarea-invalid">Run notes</Label>
+      <Textarea
+        id="textarea-invalid"
+        defaultValue="Needs more context."
+        aria-invalid
+        aria-describedby="textarea-invalid-error"
+      />
+      <p id="textarea-invalid-error" className="type-label text-status-destructive">
+        Add enough context for reviewer handoff.
+      </p>
+    </div>
+  ),
+};

--- a/apps/storybook/stories/design-system/Stickersheet.stories.tsx
+++ b/apps/storybook/stories/design-system/Stickersheet.stories.tsx
@@ -5,6 +5,14 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 
 const meta: Meta = {
   title: 'Design System/Stickersheet',
@@ -215,6 +223,93 @@ function StickersheetPage() {
             Beta
           </Badge>
           <Badge variant="destructive">Action needed</Badge>
+        </div>
+      </Section>
+
+      <Section
+        eyebrow="06"
+        title="Overlays"
+        description="Overlay surfaces keep distinct radius and padding so popovers, dialogs, and sheets read as separate layers."
+      >
+        <div className="grid gap-4 lg:grid-cols-[minmax(14rem,1fr)_minmax(18rem,1.25fr)_minmax(14rem,1fr)]">
+          <div className="rounded-lg border border-border bg-popover p-3 text-popover-foreground">
+            <p className="type-label">Popover</p>
+            <p className="type-body text-muted-foreground mt-1">
+              Quick filters and compact actions.
+            </p>
+          </div>
+          <div className="rounded-xl border border-border bg-card p-6 text-card-foreground">
+            <p className="type-heading">Dialog</p>
+            <p className="type-body text-muted-foreground mt-2">
+              Confirm changes before applying organization policy updates.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button variant="secondary">Cancel</Button>
+              <Button>Apply</Button>
+            </div>
+          </div>
+          <div className="border-border bg-card text-card-foreground flex min-h-40 flex-col border-l p-6">
+            <p className="type-heading">Sheet</p>
+            <p className="type-body text-muted-foreground mt-2">Session settings</p>
+            <Button className="mt-auto" variant="outline">
+              Save changes
+            </Button>
+          </div>
+        </div>
+      </Section>
+
+      <Section
+        eyebrow="07"
+        title="Tables"
+        description="Rows use 48px height, visible hover affordance, and selected surface state for persistent selection."
+      >
+        <div className="rounded-xl border border-border bg-card p-4">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Run</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Spend</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow data-state="selected">
+                <TableCell className="font-medium">Primitive audit</TableCell>
+                <TableCell>Reviewing</TableCell>
+                <TableCell className="text-right tabular-nums">$4.20</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell className="font-medium">Storybook QA</TableCell>
+                <TableCell>Ready</TableCell>
+                <TableCell className="text-right tabular-nums">$1.88</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+      </Section>
+
+      <Section
+        eyebrow="08"
+        title="Sidebar"
+        description="Sidebar samples preserve dark navigation surfaces, selected row contrast, and compact action spacing."
+      >
+        <div className="max-w-sm rounded-xl border border-sidebar-border bg-sidebar p-2 text-sidebar-foreground">
+          <div className="px-2 py-2">
+            <p className="type-label text-sidebar-foreground/70">Workspace</p>
+          </div>
+          <div className="grid gap-1">
+            <div className="flex h-8 items-center justify-between rounded-md bg-sidebar-accent px-2 text-sidebar-accent-foreground">
+              <span className="type-body">Dashboard</span>
+              <Badge variant="secondary">4</Badge>
+            </div>
+            <div className="hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex h-8 items-center justify-between rounded-md px-2 transition-colors">
+              <span className="type-body">Cloud sessions</span>
+              <Badge variant="secondary-outline">12</Badge>
+            </div>
+            <div className="hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex h-8 items-center rounded-md px-2 transition-colors">
+              <span className="type-body">Billing</span>
+            </div>
+          </div>
         </div>
       </Section>
     </StoryCanvas>

--- a/apps/storybook/stories/design-system/Stickersheet.stories.tsx
+++ b/apps/storybook/stories/design-system/Stickersheet.stories.tsx
@@ -298,7 +298,7 @@ function StickersheetPage() {
             <p className="type-label text-sidebar-foreground/70">Workspace</p>
           </div>
           <div className="grid gap-1">
-            <div className="flex h-8 items-center justify-between rounded-md bg-sidebar-accent px-2 text-sidebar-accent-foreground">
+            <div className="flex h-8 items-center justify-between rounded-md bg-surface-selected px-2 text-sidebar-accent-foreground">
               <span className="type-body">Dashboard</span>
               <Badge variant="secondary">4</Badge>
             </div>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -128,12 +128,9 @@
 }
 
 /*
-  The default border color has changed to `currentcolor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
-
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
+  Tailwind CSS v4 defaults border color to `currentcolor`. Keep implicit
+  borders on Kilo's semantic border token so legacy bare `border` utilities
+  do not fall back to gray.
 */
 @layer base {
   *,
@@ -141,7 +138,7 @@
   ::before,
   ::backdrop,
   ::file-selector-button {
-    border-color: var(--color-gray-200, currentcolor);
+    border-color: var(--border);
   }
 }
 

--- a/apps/web/src/components/ui/badge-variants.ts
+++ b/apps/web/src/components/ui/badge-variants.ts
@@ -1,19 +1,18 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 
 const badgeVariants = cva(
-  'type-label inline-flex items-center justify-center rounded-md border px-2 py-0.5 w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  'type-label inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border px-2 py-0.5 whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [&>svg]:pointer-events-none [&>svg]:size-3 aria-invalid:border-destructive aria-invalid:ring-destructive/40',
   {
     variants: {
       variant: {
         default: 'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
-        secondary:
-          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        secondary: 'border-border bg-secondary text-secondary-foreground [a&]:hover:bg-accent',
         'secondary-outline': 'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         destructive:
-          'border-transparent bg-destructive/60 text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/40',
+          'border-status-destructive-border bg-status-destructive-surface text-status-destructive [a&]:hover:bg-destructive/20 focus-visible:ring-destructive/40',
         outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
-        beta: 'rounded-full bg-blue-500/10 px-3 py-1 font-semibold text-blue-400 ring-1 ring-blue-500/20 border-transparent',
-        new: 'rounded-full bg-green-500/10 px-3 py-1 font-semibold text-green-400 ring-1 ring-green-500/20 border-transparent',
+        beta: 'border-status-neutral-border bg-status-neutral-surface text-status-neutral',
+        new: 'border-status-success-border bg-status-success-surface text-status-success',
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/button-variants.ts
+++ b/apps/web/src/components/ui/button-variants.ts
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 
 const buttonVariants = cva(
-  'type-label inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'type-label inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md transition-colors focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -11,16 +11,16 @@ const buttonVariants = cva(
         primary: 'bg-primary text-primary-foreground hover:bg-primary-hover',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive-hover',
         outline:
-          'border border-input bg-input-background hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground hover:bg-accent',
+          'border border-border bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground',
+        secondary: 'border border-border bg-secondary text-secondary-foreground hover:bg-accent',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-link underline-offset-4 hover:text-link-hover hover:underline',
       },
       size: {
-        default: 'h-9 px-4 py-2',
+        default: 'h-control-default px-3.5 py-2',
         sm: 'h-8 rounded-md px-3',
-        lg: 'h-10 rounded-md px-8',
-        icon: 'h-9 w-9',
+        lg: 'h-10 rounded-md px-4',
+        icon: 'size-control-default',
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -2,54 +2,66 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+const cardClassName = 'bg-card text-card-foreground rounded-xl border border-border';
+const cardHeaderClassName = 'flex flex-col gap-1.5 p-6 pb-2';
+const cardTitleClassName = 'type-heading';
+const cardDescriptionClassName = 'type-body text-muted-foreground';
+const cardContentClassName = 'p-6 pt-0';
+const cardFooterClassName = 'flex items-center p-6 pt-0';
+
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn('bg-card text-card-foreground rounded-xl border shadow', className)}
-      {...props}
-    />
+    <div ref={ref} className={cn(cardClassName, className)} {...props} />
   )
 );
 Card.displayName = 'Card';
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6 pb-2', className)} {...props} />
+    <div ref={ref} className={cn(cardHeaderClassName, className)} {...props} />
   )
 );
 CardHeader.displayName = 'CardHeader';
 
 const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn('leading-none font-semibold tracking-tight', className)}
-      {...props}
-    />
+    <div ref={ref} className={cn(cardTitleClassName, className)} {...props} />
   )
 );
 CardTitle.displayName = 'CardTitle';
 
 const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('text-muted-foreground text-sm', className)} {...props} />
+    <div ref={ref} className={cn(cardDescriptionClassName, className)} {...props} />
   )
 );
 CardDescription.displayName = 'CardDescription';
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+    <div ref={ref} className={cn(cardContentClassName, className)} {...props} />
   )
 );
 CardContent.displayName = 'CardContent';
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+    <div ref={ref} className={cn(cardFooterClassName, className)} {...props} />
   )
 );
 CardFooter.displayName = 'CardFooter';
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  cardClassName,
+  cardHeaderClassName,
+  cardTitleClassName,
+  cardDescriptionClassName,
+  cardContentClassName,
+  cardFooterClassName,
+};

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 
+import {
+  cardClassName,
+  cardContentClassName,
+  cardDescriptionClassName,
+  cardFooterClassName,
+  cardHeaderClassName,
+  cardTitleClassName,
+} from '@/components/ui/primitive-classnames';
 import { cn } from '@/lib/utils';
-
-const cardClassName = 'bg-card text-card-foreground rounded-xl border border-border';
-const cardHeaderClassName = 'flex flex-col gap-1.5 p-6 pb-2';
-const cardTitleClassName = 'type-heading';
-const cardDescriptionClassName = 'type-body text-muted-foreground';
-const cardContentClassName = 'p-6 pt-0';
-const cardFooterClassName = 'flex items-center p-6 pt-0';
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
@@ -51,17 +52,4 @@ const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 );
 CardFooter.displayName = 'CardFooter';
 
-export {
-  Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
-  CardDescription,
-  CardContent,
-  cardClassName,
-  cardHeaderClassName,
-  cardTitleClassName,
-  cardDescriptionClassName,
-  cardContentClassName,
-  cardFooterClassName,
-};
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/apps/web/src/components/ui/design-primitives.test.ts
+++ b/apps/web/src/components/ui/design-primitives.test.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { cardClassName, cardDescriptionClassName, cardTitleClassName } from '@/components/ui/card';
+import { inputClassName } from '@/components/ui/input';
+import { textareaClassName } from '@/components/ui/textarea';
+import { buttonVariants } from '@/components/ui/button-variants';
+import { badgeVariants } from '@/components/ui/badge-variants';
+import { popoverContentClassName } from '@/components/ui/popover';
+import { hoverCardContentClassName } from '@/components/ui/hover-card';
+import {
+  dialogContentClassName,
+  dialogDescriptionClassName,
+  dialogOverlayClassName,
+  dialogTitleClassName,
+} from '@/components/ui/dialog';
+import {
+  sheetContentClassName,
+  sheetDescriptionClassName,
+  sheetDismissibleOverlayClassName,
+  sheetOverlayClassName,
+  sheetTitleClassName,
+} from '@/components/ui/sheet';
+import { tableCellClassName, tableHeadClassName, tableRowClassName } from '@/components/ui/table';
+import { sidebarMenuButtonVariants, sidebarMenuSubButtonClassName } from '@/components/ui/sidebar';
+
+const expectClasses = (className: string, expectedClasses: string[]) => {
+  for (const expectedClass of expectedClasses) {
+    expect(className).toContain(expectedClass);
+  }
+};
+
+describe('design primitive defaults', () => {
+  it('uses semantic global border fallback', () => {
+    const globalsCss = readFileSync(join(process.cwd(), 'src/app/globals.css'), 'utf8');
+
+    expect(globalsCss).toContain('border-color: var(--border);');
+    expect(globalsCss).not.toContain('var(--color-gray-200');
+  });
+
+  it('keeps cards on raised surface without default shadow depth', () => {
+    expectClasses(cardClassName, [
+      'bg-card',
+      'text-card-foreground',
+      'rounded-xl',
+      'border-border',
+    ]);
+    expect(cardClassName).not.toContain(' shadow');
+    expect(cardTitleClassName).toBe('type-heading');
+    expect(cardDescriptionClassName).toBe('type-body text-muted-foreground');
+  });
+
+  it('uses canonical field fill, border, and focus treatment', () => {
+    expectClasses(inputClassName, [
+      'bg-input-background',
+      'border-input',
+      'h-control-default',
+      'focus-visible:border-ring',
+      'focus-visible:ring-ring/50',
+      'focus-visible:ring-[3px]',
+    ]);
+    expect(inputClassName).not.toContain('bg-input/30');
+    expect(inputClassName).not.toContain('shadow-xs');
+
+    expectClasses(textareaClassName, [
+      'bg-input-background',
+      'border-input',
+      'focus-visible:border-ring',
+      'focus-visible:ring-ring/50',
+      'focus-visible:ring-[3px]',
+    ]);
+    expect(textareaClassName).not.toContain('bg-background');
+    expect(textareaClassName).not.toContain('ring-offset');
+  });
+
+  it('aligns button defaults with Kilo action roles', () => {
+    expectClasses(buttonVariants(), [
+      'type-label',
+      'bg-primary',
+      'text-primary-foreground',
+      'h-control-default',
+      'px-3.5',
+      'focus-visible:ring-ring/50',
+    ]);
+    expectClasses(buttonVariants({ variant: 'secondary' }), [
+      'border-border',
+      'bg-secondary',
+      'text-secondary-foreground',
+      'hover:bg-accent',
+    ]);
+    expectClasses(buttonVariants({ variant: 'outline' }), [
+      'border-border',
+      'bg-transparent',
+      'hover:bg-accent',
+    ]);
+  });
+
+  it('uses pill badge geometry and semantic status surfaces', () => {
+    expectClasses(badgeVariants(), ['type-label', 'rounded-full', 'bg-primary']);
+    expectClasses(badgeVariants({ variant: 'new' }), [
+      'rounded-full',
+      'bg-status-success-surface',
+      'text-status-success',
+      'border-status-success-border',
+    ]);
+    expectClasses(badgeVariants({ variant: 'destructive' }), [
+      'rounded-full',
+      'bg-status-destructive-surface',
+      'text-status-destructive',
+      'border-status-destructive-border',
+    ]);
+  });
+
+  it('uses canonical floating overlay surface, radius, and padding', () => {
+    for (const className of [popoverContentClassName, hoverCardContentClassName]) {
+      expectClasses(className, ['bg-popover', 'rounded-lg', 'border-border', 'p-3', 'shadow-none']);
+      expect(className).not.toContain('rounded-md');
+      expect(className).not.toContain('p-4');
+      expect(className).not.toContain('shadow-md');
+    }
+  });
+
+  it('replaces raw black dialog and sheet scrims with semantic surfaces', () => {
+    expectClasses(dialogOverlayClassName, ['bg-surface-inset/80']);
+    expect(dialogOverlayClassName).not.toContain('bg-black');
+    expectClasses(dialogContentClassName, ['bg-card', 'rounded-xl', 'border-border', 'p-6']);
+    expect(dialogTitleClassName).toBe('type-heading');
+    expect(dialogDescriptionClassName).toBe('type-body text-muted-foreground');
+
+    expectClasses(sheetOverlayClassName, ['bg-surface-inset/70']);
+    expectClasses(sheetDismissibleOverlayClassName, ['bg-surface-inset/70']);
+    expect(sheetOverlayClassName).not.toContain('bg-black');
+    expect(sheetDismissibleOverlayClassName).not.toContain('bg-black');
+    expectClasses(sheetContentClassName, ['bg-card', 'text-card-foreground', 'border-border']);
+    expect(sheetTitleClassName).toBe('type-heading text-foreground');
+    expect(sheetDescriptionClassName).toBe('type-body text-muted-foreground');
+  });
+
+  it('sets table density and interaction surfaces', () => {
+    expectClasses(tableRowClassName, [
+      'h-12',
+      'hover:bg-surface-hover',
+      'data-[state=selected]:bg-surface-selected',
+    ]);
+    expectClasses(tableHeadClassName, ['type-label', 'h-12', 'text-muted-foreground']);
+    expectClasses(tableCellClassName, ['px-3', 'py-3']);
+  });
+
+  it('keeps active sidebar rows distinct from hover rows', () => {
+    const menuButtonClassName = sidebarMenuButtonVariants();
+
+    expectClasses(menuButtonClassName, [
+      'hover:bg-sidebar-accent',
+      'data-[active=true]:bg-surface-selected',
+    ]);
+    expect(menuButtonClassName).not.toContain('data-[active=true]:bg-sidebar-accent');
+
+    expectClasses(sidebarMenuSubButtonClassName, [
+      'hover:bg-sidebar-accent',
+      'data-[active=true]:bg-surface-selected',
+    ]);
+    expect(sidebarMenuSubButtonClassName).not.toContain('data-[active=true]:bg-sidebar-accent');
+  });
+});

--- a/apps/web/src/components/ui/design-primitives.test.ts
+++ b/apps/web/src/components/ui/design-primitives.test.ts
@@ -57,6 +57,8 @@ describe('design primitive defaults', () => {
     expectClasses(inputClassName, [
       'bg-input-background',
       'border-input',
+      'text-base',
+      'md:text-sm',
       'h-control-default',
       'focus-visible:border-ring',
       'focus-visible:ring-ring/50',
@@ -64,6 +66,7 @@ describe('design primitive defaults', () => {
     ]);
     expect(inputClassName).not.toContain('bg-input/30');
     expect(inputClassName).not.toContain('shadow-xs');
+    expect(inputClassName).not.toContain('type-body');
 
     expectClasses(textareaClassName, [
       'bg-input-background',

--- a/apps/web/src/components/ui/design-primitives.test.ts
+++ b/apps/web/src/components/ui/design-primitives.test.ts
@@ -1,28 +1,31 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { cardClassName, cardDescriptionClassName, cardTitleClassName } from '@/components/ui/card';
-import { inputClassName } from '@/components/ui/input';
-import { textareaClassName } from '@/components/ui/textarea';
 import { buttonVariants } from '@/components/ui/button-variants';
 import { badgeVariants } from '@/components/ui/badge-variants';
-import { popoverContentClassName } from '@/components/ui/popover';
-import { hoverCardContentClassName } from '@/components/ui/hover-card';
 import {
+  cardClassName,
+  cardDescriptionClassName,
+  cardTitleClassName,
   dialogContentClassName,
   dialogDescriptionClassName,
   dialogOverlayClassName,
   dialogTitleClassName,
-} from '@/components/ui/dialog';
-import {
+  hoverCardContentClassName,
+  inputClassName,
+  popoverContentClassName,
+  sidebarMenuButtonVariants,
+  sidebarMenuSubButtonClassName,
   sheetContentClassName,
   sheetDescriptionClassName,
   sheetDismissibleOverlayClassName,
   sheetOverlayClassName,
   sheetTitleClassName,
-} from '@/components/ui/sheet';
-import { tableCellClassName, tableHeadClassName, tableRowClassName } from '@/components/ui/table';
-import { sidebarMenuButtonVariants, sidebarMenuSubButtonClassName } from '@/components/ui/sidebar';
+  tableCellClassName,
+  tableHeadClassName,
+  tableRowClassName,
+  textareaClassName,
+} from '@/components/ui/primitive-classnames';
 
 const expectClasses = (className: string, expectedClasses: string[]) => {
   for (const expectedClass of expectedClasses) {

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -13,18 +13,20 @@ const DialogPortal = DialogPrimitive.Portal;
 
 const DialogClose = DialogPrimitive.Close;
 
+const dialogOverlayClassName =
+  'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-surface-inset/80 duration-200';
+const dialogContentClassName =
+  'bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98 fixed top-[50%] left-[50%] z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border border-border p-6 shadow-none duration-200';
+const dialogCloseClassName =
+  'focus-visible:ring-ring/50 data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-3 right-3 flex size-control-default cursor-pointer items-center justify-center rounded-md opacity-70 transition-opacity hover:bg-accent hover:opacity-100 focus-visible:ring-[3px] focus-visible:outline-none disabled:pointer-events-none';
+const dialogTitleClassName = 'type-heading';
+const dialogDescriptionClassName = 'type-body text-muted-foreground';
+
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(
-      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 duration-200',
-      className
-    )}
-    {...props}
-  />
+  <DialogPrimitive.Overlay ref={ref} className={cn(dialogOverlayClassName, className)} {...props} />
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
@@ -39,20 +41,10 @@ const DialogContent = React.forwardRef<
 >(({ className, children, container, showCloseButton = true, ...props }, ref) => (
   <DialogPortal container={container}>
     <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'bg-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98 border-border fixed top-[50%] left-[50%] z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border p-6 shadow-lg duration-200',
-        className
-      )}
-      {...props}
-    >
+    <DialogPrimitive.Content ref={ref} className={cn(dialogContentClassName, className)} {...props}>
       {children}
       {showCloseButton && (
-        <DialogClose
-          className="focus-visible:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-3 right-3 flex size-9 cursor-pointer items-center justify-center rounded-md opacity-70 transition-opacity hover:bg-accent hover:opacity-100 focus-visible:ring-[3px] focus-visible:outline-none disabled:pointer-events-none"
-          aria-label="Close dialog"
-        >
+        <DialogClose className={dialogCloseClassName} aria-label="Close dialog">
           <X className="size-4" aria-hidden="true" />
         </DialogClose>
       )}
@@ -78,11 +70,7 @@ const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn('text-lg leading-none font-semibold tracking-tight', className)}
-    {...props}
-  />
+  <DialogPrimitive.Title ref={ref} className={cn(dialogTitleClassName, className)} {...props} />
 ));
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
@@ -92,7 +80,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-muted-foreground text-sm', className)}
+    className={cn(dialogDescriptionClassName, className)}
     {...props}
   />
 ));
@@ -109,4 +97,9 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
+  dialogOverlayClassName,
+  dialogContentClassName,
+  dialogCloseClassName,
+  dialogTitleClassName,
+  dialogDescriptionClassName,
 };

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -3,6 +3,13 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
+import {
+  dialogCloseClassName,
+  dialogContentClassName,
+  dialogDescriptionClassName,
+  dialogOverlayClassName,
+  dialogTitleClassName,
+} from '@/components/ui/primitive-classnames';
 import { cn } from '@/lib/utils';
 
 const Dialog = DialogPrimitive.Root;
@@ -12,15 +19,6 @@ const DialogTrigger = DialogPrimitive.Trigger;
 const DialogPortal = DialogPrimitive.Portal;
 
 const DialogClose = DialogPrimitive.Close;
-
-const dialogOverlayClassName =
-  'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-surface-inset/80 duration-200';
-const dialogContentClassName =
-  'bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98 fixed top-[50%] left-[50%] z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border border-border p-6 shadow-none duration-200';
-const dialogCloseClassName =
-  'focus-visible:ring-ring/50 data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-3 right-3 flex size-control-default cursor-pointer items-center justify-center rounded-md opacity-70 transition-opacity hover:bg-accent hover:opacity-100 focus-visible:ring-[3px] focus-visible:outline-none disabled:pointer-events-none';
-const dialogTitleClassName = 'type-heading';
-const dialogDescriptionClassName = 'type-body text-muted-foreground';
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -97,9 +95,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-  dialogOverlayClassName,
-  dialogContentClassName,
-  dialogCloseClassName,
-  dialogTitleClassName,
-  dialogDescriptionClassName,
 };

--- a/apps/web/src/components/ui/hover-card.tsx
+++ b/apps/web/src/components/ui/hover-card.tsx
@@ -3,14 +3,12 @@
 import * as React from 'react';
 import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
 
+import { hoverCardContentClassName } from '@/components/ui/primitive-classnames';
 import { cn } from '@/lib/utils';
 
 const HoverCard = HoverCardPrimitive.Root;
 
 const HoverCardTrigger = HoverCardPrimitive.Trigger;
-
-const hoverCardContentClassName =
-  'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-[--radix-hover-card-content-transform-origin] rounded-lg border border-border p-3 shadow-none outline-none';
 
 const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
@@ -28,4 +26,4 @@ const HoverCardContent = React.forwardRef<
 ));
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
 
-export { HoverCard, HoverCardTrigger, HoverCardContent, hoverCardContentClassName };
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/apps/web/src/components/ui/hover-card.tsx
+++ b/apps/web/src/components/ui/hover-card.tsx
@@ -9,6 +9,9 @@ const HoverCard = HoverCardPrimitive.Root;
 
 const HoverCardTrigger = HoverCardPrimitive.Trigger;
 
+const hoverCardContentClassName =
+  'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-[--radix-hover-card-content-transform-origin] rounded-lg border border-border p-3 shadow-none outline-none';
+
 const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
@@ -18,14 +21,11 @@ const HoverCardContent = React.forwardRef<
       ref={ref}
       align={align}
       sideOffset={sideOffset}
-      className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-[--radix-hover-card-content-transform-origin] rounded-md border p-4 shadow-md outline-none',
-        className
-      )}
+      className={cn(hoverCardContentClassName, className)}
       {...props}
     />
   </HoverCardPrimitive.Portal>
 ));
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
 
-export { HoverCard, HoverCardTrigger, HoverCardContent };
+export { HoverCard, HoverCardTrigger, HoverCardContent, hoverCardContentClassName };

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -2,22 +2,15 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-interface InputProps extends React.ComponentProps<'input'> {}
+type InputProps = React.ComponentProps<'input'>;
+
+const inputClassName =
+  'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input bg-input-background type-body flex h-control-default w-full min-w-0 rounded-md border px-3 py-1 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive';
 
 function Input({ className, type, ...props }: InputProps) {
   return (
-    <input
-      type={type}
-      data-slot="input"
-      className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input bg-input/30 file:bg-input/30 flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-        'aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
-        className
-      )}
-      {...props}
-    />
+    <input type={type} data-slot="input" className={cn(inputClassName, className)} {...props} />
   );
 }
 
-export { Input };
+export { Input, inputClassName };

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 
+import { inputClassName } from '@/components/ui/primitive-classnames';
 import { cn } from '@/lib/utils';
 
 type InputProps = React.ComponentProps<'input'>;
-
-const inputClassName =
-  'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input bg-input-background type-body flex h-control-default w-full min-w-0 rounded-md border px-3 py-1 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive';
 
 function Input({ className, type, ...props }: InputProps) {
   return (
@@ -13,4 +11,4 @@ function Input({ className, type, ...props }: InputProps) {
   );
 }
 
-export { Input, inputClassName };
+export { Input };

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -11,6 +11,9 @@ const PopoverTrigger = PopoverPrimitive.Trigger;
 
 const PopoverAnchor = PopoverPrimitive.Anchor;
 
+const popoverContentClassName =
+  'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-[--radix-popover-content-transform-origin] rounded-lg border border-border p-3 shadow-none outline-none';
+
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
@@ -20,14 +23,11 @@ const PopoverContent = React.forwardRef<
       ref={ref}
       align={align}
       sideOffset={sideOffset}
-      className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-[--radix-popover-content-transform-origin] rounded-md border p-4 shadow-md outline-none',
-        className
-      )}
+      className={cn(popoverContentClassName, className)}
       {...props}
     />
   </PopoverPrimitive.Portal>
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor, popoverContentClassName };

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 
+import { popoverContentClassName } from '@/components/ui/primitive-classnames';
 import { cn } from '@/lib/utils';
 
 const Popover = PopoverPrimitive.Root;
@@ -10,9 +11,6 @@ const Popover = PopoverPrimitive.Root;
 const PopoverTrigger = PopoverPrimitive.Trigger;
 
 const PopoverAnchor = PopoverPrimitive.Anchor;
-
-const popoverContentClassName =
-  'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-[--radix-popover-content-transform-origin] rounded-lg border border-border p-3 shadow-none outline-none';
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
@@ -30,4 +28,4 @@ const PopoverContent = React.forwardRef<
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor, popoverContentClassName };
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/apps/web/src/components/ui/primitive-classnames.ts
+++ b/apps/web/src/components/ui/primitive-classnames.ts
@@ -1,0 +1,78 @@
+import { cva } from 'class-variance-authority';
+
+export const cardClassName = 'bg-card text-card-foreground rounded-xl border border-border';
+export const cardHeaderClassName = 'flex flex-col gap-1.5 p-6 pb-2';
+export const cardTitleClassName = 'type-heading';
+export const cardDescriptionClassName = 'type-body text-muted-foreground';
+export const cardContentClassName = 'p-6 pt-0';
+export const cardFooterClassName = 'flex items-center p-6 pt-0';
+
+export const inputClassName =
+  'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input bg-input-background type-body flex h-control-default w-full min-w-0 rounded-md border px-3 py-1 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive';
+
+export const textareaClassName =
+  'border-input bg-input-background type-body placeholder:text-muted-foreground flex min-h-20 w-full rounded-md border px-3 py-2 transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive';
+
+export const popoverContentClassName =
+  'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-[--radix-popover-content-transform-origin] rounded-lg border border-border p-3 shadow-none outline-none';
+
+export const hoverCardContentClassName =
+  'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-[--radix-hover-card-content-transform-origin] rounded-lg border border-border p-3 shadow-none outline-none';
+
+export const dialogOverlayClassName =
+  'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-surface-inset/80 duration-200';
+export const dialogContentClassName =
+  'bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98 fixed top-[50%] left-[50%] z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border border-border p-6 shadow-none duration-200';
+export const dialogCloseClassName =
+  'focus-visible:ring-ring/50 data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-3 right-3 flex size-control-default cursor-pointer items-center justify-center rounded-md opacity-70 transition-opacity hover:bg-accent hover:opacity-100 focus-visible:ring-[3px] focus-visible:outline-none disabled:pointer-events-none';
+export const dialogTitleClassName = 'type-heading';
+export const dialogDescriptionClassName = 'type-body text-muted-foreground';
+
+export const sheetOverlayClassName =
+  'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-surface-inset/70';
+export const sheetDismissibleOverlayClassName =
+  'absolute inset-0 z-50 cursor-default bg-surface-inset/70';
+export const sheetContentClassName =
+  'bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 border-border shadow-none transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500';
+export const sheetCloseClassName =
+  'focus-visible:ring-ring/50 data-[state=open]:bg-accent absolute top-4 right-4 flex size-control-default items-center justify-center rounded-md opacity-70 transition-opacity hover:bg-accent hover:opacity-100 focus-visible:ring-[3px] focus-visible:outline-none disabled:pointer-events-none';
+export const sheetHeaderClassName = 'flex flex-col gap-1.5 p-6 pb-2';
+export const sheetFooterClassName = 'mt-auto flex flex-col gap-2 p-6 pt-2';
+export const sheetTitleClassName = 'type-heading text-foreground';
+export const sheetDescriptionClassName = 'type-body text-muted-foreground';
+
+export const tableClassName = 'type-body w-full caption-bottom';
+export const tableHeaderClassName = 'border-b border-border';
+export const tableBodyClassName = '[&_tr:last-child]:border-0';
+export const tableFooterClassName = 'bg-surface-raised border-t border-border font-medium';
+export const tableRowClassName =
+  'h-12 border-b border-border transition-colors hover:bg-surface-hover data-[state=selected]:bg-surface-selected';
+export const tableHeadClassName =
+  'type-label text-muted-foreground h-12 px-3 text-left align-middle whitespace-nowrap';
+export const tableCellClassName = 'px-3 py-3 align-middle';
+export const tableCaptionClassName = 'type-body text-muted-foreground mt-4';
+
+export const sidebarMenuSubButtonClassName =
+  'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-surface-selected active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 data-[active=true]:bg-surface-selected data-[active=true]:text-sidebar-accent-foreground';
+
+export const sidebarMenuButtonVariants = cva(
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-surface-selected active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-surface-selected data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        outline:
+          'border border-sidebar-border bg-sidebar hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+      },
+      size: {
+        default: 'h-8 text-sm',
+        sm: 'h-7 text-xs',
+        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);

--- a/apps/web/src/components/ui/primitive-classnames.ts
+++ b/apps/web/src/components/ui/primitive-classnames.ts
@@ -8,7 +8,7 @@ export const cardContentClassName = 'p-6 pt-0';
 export const cardFooterClassName = 'flex items-center p-6 pt-0';
 
 export const inputClassName =
-  'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input bg-input-background type-body flex h-control-default w-full min-w-0 rounded-md border px-3 py-1 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive';
+  'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input bg-input-background font-sans text-base leading-6 md:text-sm md:leading-[1.5] flex h-control-default w-full min-w-0 rounded-md border px-3 py-1 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive';
 
 export const textareaClassName =
   'border-input bg-input-background type-body placeholder:text-muted-foreground flex min-h-20 w-full rounded-md border px-3 py-2 transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive';

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -6,6 +6,18 @@ import { XIcon } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
+const sheetOverlayClassName =
+  'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-surface-inset/70';
+const sheetDismissibleOverlayClassName = 'absolute inset-0 z-50 cursor-default bg-surface-inset/70';
+const sheetContentClassName =
+  'bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 border-border shadow-none transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500';
+const sheetCloseClassName =
+  'focus-visible:ring-ring/50 data-[state=open]:bg-accent absolute top-4 right-4 flex size-control-default items-center justify-center rounded-md opacity-70 transition-opacity hover:bg-accent hover:opacity-100 focus-visible:ring-[3px] focus-visible:outline-none disabled:pointer-events-none';
+const sheetHeaderClassName = 'flex flex-col gap-1.5 p-6 pb-2';
+const sheetFooterClassName = 'mt-auto flex flex-col gap-2 p-6 pt-2';
+const sheetTitleClassName = 'type-heading text-foreground';
+const sheetDescriptionClassName = 'type-body text-muted-foreground';
+
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
@@ -29,10 +41,7 @@ function SheetOverlay({
   return (
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
-      className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
-        className
-      )}
+      className={cn(sheetOverlayClassName, className)}
       {...props}
     />
   );
@@ -63,7 +72,7 @@ function SheetContent({
               type="button"
               aria-label="Close sheet"
               data-slot="sheet-overlay"
-              className={cn('absolute inset-0 z-50 cursor-default bg-black/50', overlayClassName)}
+              className={cn(sheetDismissibleOverlayClassName, overlayClassName)}
             />
           </SheetPrimitive.Close>
         ) : (
@@ -72,7 +81,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+          sheetContentClassName,
           side === 'right' &&
             'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
           side === 'left' &&
@@ -86,8 +95,8 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-4" />
+        <SheetPrimitive.Close className={sheetCloseClassName}>
+          <XIcon className="size-4" aria-hidden="true" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>
@@ -97,21 +106,13 @@ function SheetContent({
 
 function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
-    <div
-      data-slot="sheet-header"
-      className={cn('flex flex-col gap-1.5 p-4', className)}
-      {...props}
-    />
+    <div data-slot="sheet-header" className={cn(sheetHeaderClassName, className)} {...props} />
   );
 }
 
 function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
-    <div
-      data-slot="sheet-footer"
-      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
-      {...props}
-    />
+    <div data-slot="sheet-footer" className={cn(sheetFooterClassName, className)} {...props} />
   );
 }
 
@@ -119,7 +120,7 @@ function SheetTitle({ className, ...props }: React.ComponentProps<typeof SheetPr
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn('text-foreground font-semibold', className)}
+      className={cn(sheetTitleClassName, className)}
       {...props}
     />
   );
@@ -132,7 +133,7 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn('text-muted-foreground text-sm', className)}
+      className={cn(sheetDescriptionClassName, className)}
       {...props}
     />
   );
@@ -147,4 +148,12 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
+  sheetOverlayClassName,
+  sheetDismissibleOverlayClassName,
+  sheetContentClassName,
+  sheetCloseClassName,
+  sheetHeaderClassName,
+  sheetFooterClassName,
+  sheetTitleClassName,
+  sheetDescriptionClassName,
 };

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -4,19 +4,17 @@ import * as React from 'react';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { XIcon } from 'lucide-react';
 
+import {
+  sheetCloseClassName,
+  sheetContentClassName,
+  sheetDescriptionClassName,
+  sheetDismissibleOverlayClassName,
+  sheetFooterClassName,
+  sheetHeaderClassName,
+  sheetOverlayClassName,
+  sheetTitleClassName,
+} from '@/components/ui/primitive-classnames';
 import { cn } from '@/lib/utils';
-
-const sheetOverlayClassName =
-  'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-surface-inset/70';
-const sheetDismissibleOverlayClassName = 'absolute inset-0 z-50 cursor-default bg-surface-inset/70';
-const sheetContentClassName =
-  'bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 border-border shadow-none transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500';
-const sheetCloseClassName =
-  'focus-visible:ring-ring/50 data-[state=open]:bg-accent absolute top-4 right-4 flex size-control-default items-center justify-center rounded-md opacity-70 transition-opacity hover:bg-accent hover:opacity-100 focus-visible:ring-[3px] focus-visible:outline-none disabled:pointer-events-none';
-const sheetHeaderClassName = 'flex flex-col gap-1.5 p-6 pb-2';
-const sheetFooterClassName = 'mt-auto flex flex-col gap-2 p-6 pt-2';
-const sheetTitleClassName = 'type-heading text-foreground';
-const sheetDescriptionClassName = 'type-body text-muted-foreground';
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
@@ -148,12 +146,4 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
-  sheetOverlayClassName,
-  sheetDismissibleOverlayClassName,
-  sheetContentClassName,
-  sheetCloseClassName,
-  sheetHeaderClassName,
-  sheetFooterClassName,
-  sheetTitleClassName,
-  sheetDescriptionClassName,
 };

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -3,13 +3,15 @@
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import type { VariantProps } from 'class-variance-authority';
-import { cva } from 'class-variance-authority';
 import { PanelLeftIcon } from 'lucide-react';
 
 import { useIsMobile } from '@/hooks/use-mobile';
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import {
+  sidebarMenuButtonVariants,
+  sidebarMenuSubButtonClassName,
+} from '@/components/ui/primitive-classnames';
 import { Separator } from '@/components/ui/separator';
 import {
   Sheet,
@@ -20,6 +22,7 @@ import {
 } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 import { secondsInWeek } from 'date-fns/constants';
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state';
@@ -28,8 +31,6 @@ const SIDEBAR_WIDTH = '16rem';
 const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
-const sidebarMenuSubButtonClassName =
-  'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-surface-selected active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 data-[active=true]:bg-surface-selected data-[active=true]:text-sidebar-accent-foreground';
 
 type SidebarOpenValue = boolean | ((open: boolean) => boolean);
 
@@ -469,28 +470,6 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
   );
 }
 
-const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-surface-selected active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-surface-selected data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
-  {
-    variants: {
-      variant: {
-        default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-        outline:
-          'border border-sidebar-border bg-sidebar hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-      },
-      size: {
-        default: 'h-8 text-sm',
-        sm: 'h-7 text-xs',
-        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
-      size: 'default',
-    },
-  }
-);
-
 function SidebarMenuButton({
   asChild = false,
   isActive = false,
@@ -706,7 +685,5 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  sidebarMenuButtonVariants,
-  sidebarMenuSubButtonClassName,
   useSidebar,
 };

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -28,6 +28,8 @@ const SIDEBAR_WIDTH = '16rem';
 const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
+const sidebarMenuSubButtonClassName =
+  'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-surface-selected active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 data-[active=true]:bg-surface-selected data-[active=true]:text-sidebar-accent-foreground';
 
 type SidebarOpenValue = boolean | ((open: boolean) => boolean);
 
@@ -468,13 +470,13 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-surface-selected active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-surface-selected data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       variant: {
         default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
         outline:
-          'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
+          'border border-sidebar-border bg-sidebar hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
       },
       size: {
         default: 'h-8 text-sm',
@@ -669,8 +671,7 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
-        'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
+        sidebarMenuSubButtonClassName,
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',
         'group-data-[collapsible=icon]:hidden',
@@ -705,5 +706,7 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
+  sidebarMenuButtonVariants,
+  sidebarMenuSubButtonClassName,
   useSidebar,
 };

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -4,46 +4,64 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+const tableClassName = 'type-body w-full caption-bottom';
+const tableHeaderClassName = 'border-b border-border';
+const tableBodyClassName = '[&_tr:last-child]:border-0';
+const tableFooterClassName = 'bg-surface-raised border-t border-border font-medium';
+const tableRowClassName =
+  'h-12 border-b border-border transition-colors hover:bg-surface-hover data-[state=selected]:bg-surface-selected';
+const tableHeadClassName =
+  'type-label text-muted-foreground h-12 px-3 text-left align-middle whitespace-nowrap';
+const tableCellClassName = 'px-3 py-3 align-middle';
+const tableCaptionClassName = 'type-body text-muted-foreground mt-4';
+
 function Table({ className, ...props }: React.ComponentProps<'table'>) {
-  return <table className={cn('w-full caption-bottom text-sm', className)} {...props} />;
+  return <table className={cn(tableClassName, className)} {...props} />;
 }
 
 function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
-  return <thead className={cn('border-b', className)} {...props} />;
+  return <thead className={cn(tableHeaderClassName, className)} {...props} />;
 }
 
 function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
-  return <tbody className={cn('[&_tr:last-child]:border-0', className)} {...props} />;
+  return <tbody className={cn(tableBodyClassName, className)} {...props} />;
 }
 
 function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
-  return <tfoot className={cn('bg-muted/50 border-t font-medium', className)} {...props} />;
+  return <tfoot className={cn(tableFooterClassName, className)} {...props} />;
 }
 
 function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
-  return (
-    <tr className={cn('hover:bg-muted/50 border-b transition-colors', className)} {...props} />
-  );
+  return <tr className={cn(tableRowClassName, className)} {...props} />;
 }
 
 function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
-  return (
-    <th
-      className={cn(
-        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap',
-        className
-      )}
-      {...props}
-    />
-  );
+  return <th className={cn(tableHeadClassName, className)} {...props} />;
 }
 
 function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
-  return <td className={cn('px-2 py-1 align-middle', className)} {...props} />;
+  return <td className={cn(tableCellClassName, className)} {...props} />;
 }
 
 function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
-  return <caption className={cn('text-muted-foreground mt-4 text-sm', className)} {...props} />;
+  return <caption className={cn(tableCaptionClassName, className)} {...props} />;
 }
 
-export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+  tableClassName,
+  tableHeaderClassName,
+  tableBodyClassName,
+  tableFooterClassName,
+  tableRowClassName,
+  tableHeadClassName,
+  tableCellClassName,
+  tableCaptionClassName,
+};

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -2,18 +2,17 @@
 
 import * as React from 'react';
 
+import {
+  tableBodyClassName,
+  tableCaptionClassName,
+  tableCellClassName,
+  tableClassName,
+  tableFooterClassName,
+  tableHeadClassName,
+  tableHeaderClassName,
+  tableRowClassName,
+} from '@/components/ui/primitive-classnames';
 import { cn } from '@/lib/utils';
-
-const tableClassName = 'type-body w-full caption-bottom';
-const tableHeaderClassName = 'border-b border-border';
-const tableBodyClassName = '[&_tr:last-child]:border-0';
-const tableFooterClassName = 'bg-surface-raised border-t border-border font-medium';
-const tableRowClassName =
-  'h-12 border-b border-border transition-colors hover:bg-surface-hover data-[state=selected]:bg-surface-selected';
-const tableHeadClassName =
-  'type-label text-muted-foreground h-12 px-3 text-left align-middle whitespace-nowrap';
-const tableCellClassName = 'px-3 py-3 align-middle';
-const tableCaptionClassName = 'type-body text-muted-foreground mt-4';
 
 function Table({ className, ...props }: React.ComponentProps<'table'>) {
   return <table className={cn(tableClassName, className)} {...props} />;
@@ -47,21 +46,4 @@ function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) 
   return <caption className={cn(tableCaptionClassName, className)} {...props} />;
 }
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-  tableClassName,
-  tableHeaderClassName,
-  tableBodyClassName,
-  tableFooterClassName,
-  tableRowClassName,
-  tableHeadClassName,
-  tableCellClassName,
-  tableCaptionClassName,
-};
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 
+import { textareaClassName } from '@/components/ui/primitive-classnames';
 import { cn } from '@/lib/utils';
 
 export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
-
-const textareaClassName =
-  'border-input bg-input-background type-body placeholder:text-muted-foreground flex min-h-20 w-full rounded-md border px-3 py-2 transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive';
 
 export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
@@ -13,5 +11,3 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   }
 );
 Textarea.displayName = 'Textarea';
-
-export { textareaClassName };

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -2,20 +2,16 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const textareaClassName =
+  'border-input bg-input-background type-body placeholder:text-muted-foreground flex min-h-20 w-full rounded-md border px-3 py-2 transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive';
 
 export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
-    return (
-      <textarea
-        className={cn(
-          'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
+    return <textarea className={cn(textareaClassName, className)} ref={ref} {...props} />;
   }
 );
 Textarea.displayName = 'Textarea';
+
+export { textareaClassName };

--- a/dev/local/services.test.ts
+++ b/dev/local/services.test.ts
@@ -38,6 +38,12 @@ test('keeps auto routing package dev script compatible with local launcher flags
   assert.equal(launcherFlags.filter(part => part === '--ip').length, 1);
 });
 
+test('starts Storybook with Storybook v10 port flags', () => {
+  const service = getService('storybook');
+
+  assert.deepEqual(service.command, ['pnpm', 'run', 'storybook', '-p', '6006']);
+});
+
 test('preserves auto routing backend auth secret name', () => {
   const service = getService('auto-routing');
   const wranglerConfig = fs.readFileSync(`${service.dir}/wrangler.jsonc`, 'utf-8');

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -418,7 +418,7 @@ function buildServiceDefs(): ServiceDef[] {
         dir: 'apps/storybook',
         port: 6006 + portOffset,
         dependsOn: meta.dependsOn,
-        command: ['pnpm', 'run', 'storybook', '--', '-p', String(6006 + portOffset)],
+        command: ['pnpm', 'run', 'storybook', '-p', String(6006 + portOffset)],
         group: meta.group,
       });
       continue;


### PR DESCRIPTION
## Summary
Aligns shared web UI primitives with the DESIGN.md token contract and keeps Storybook/local dev coverage current.

### Why this change is needed
Shared primitives encoded geometry, surfaces, typography, focus, and state behavior that drifted from DESIGN.md. That drift affected every consuming feature and made Storybook less reliable as design authority.

### How this is addressed
- Aligned card, field, button, badge, popover, hover card, dialog, sheet, table, and sidebar defaults with canonical surface, radius, spacing, typography, focus, hover, and selected-state roles.
- Added primitive class contract tests for changed defaults.
- Expanded Storybook coverage for textarea focus/error states, selected table rows, and Stickersheet overlay/table/sidebar samples.
- Fixed local dev Storybook startup for Storybook v10 by removing the obsolete pnpm argument separator.

Closes #4170

## Human Verification

- Local review of Storybook and app UI to confirm UI elements match intended design,.

<details>
<summary>Manual verification performed</summary>

1. Ran targeted primitive regression test with local Postgres: `POSTGRES_URL=postgres://postgres:postgres@localhost:5432/postgres pnpm --filter web test -- src/components/ui/design-primitives.test.ts`.
2. Built static Storybook with `pnpm --filter @kilocode/storybook build-storybook`.
3. Loaded updated Stickersheet in `agent-browser` at desktop and mobile widths; checked rendered sections and browser errors.
4. Started local Storybook through pnpm filter command with `-p 6017`; confirmed Storybook v10 accepts generated CLI flags.
5. Ran React Doctor against changed files with `npx -y react-doctor@latest . --verbose --scope changed --base main`; no changed-file diagnostics remained.

</details>

## Reviewer Notes
### Human Reviewer Flags
- Shared primitive defaults changed across broad web surfaces. Review consuming product UI for intended visual shifts in density, radius, focus, and selected states.
- Storybook Stickersheet overlay samples are static surface references, not live Radix portal examples, to keep the reference page scannable.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Primitive class-name constants live in `primitive-classnames.ts` so component files continue exporting components only for Fast Refresh.
- Tests assert DESIGN.md contract coverage through the shared class-name constants without rendering every Radix wrapper.
- Table selected state uses `data-state="selected"` and sidebar active state uses selected/accent surface roles instead of hover-only styling.
- Local dev Storybook command now passes `-p` directly after `pnpm run storybook`; Storybook v10 rejects `storybook dev -- -p`.

</details>
