### PR TITLE
fix(o11y): use supported Gastown health query

### DIFF
--- a/services/o11y/src/alerting/gastown-health-query.ts
+++ b/services/o11y/src/alerting/gastown-health-query.ts
@@ -17,16 +17,14 @@ type QueryEnv = {
 type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
 
 const GastownHealthResponseSchema = z.object({
-  data: z
-    .array(
-      z.object({
-        weighted_failed_checks: z.number().nonnegative().nullable(),
-        weighted_successful_checks: z.number().nonnegative().nullable(),
-        affected_town_count: z.number().int().nonnegative().nullable(),
-        latest_event_timestamp: z.string().nullable(),
-      })
-    )
-    .max(1),
+  data: z.array(
+    z.object({
+      town_id: z.string(),
+      weighted_failed_checks: z.number().nonnegative().nullable(),
+      weighted_successful_checks: z.number().nonnegative().nullable(),
+      latest_event_timestamp: z.string().nullable(),
+    })
+  ),
 });
 
 const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
@@ -49,13 +47,14 @@ export async function queryGastownHealth(
 
   const sql = `
     SELECT
+      blob6 AS town_id,
       SUM(IF(blob5 != '', _sample_interval, 0)) AS weighted_failed_checks,
       SUM(IF(blob5 = '', _sample_interval, 0)) AS weighted_successful_checks,
-      uniqExactIf(blob6, blob5 != '' AND blob6 != '') AS affected_town_count,
       MAX(timestamp) AS latest_event_timestamp
     FROM gastown_events
     WHERE timestamp > NOW() - INTERVAL '${GASTOWN_HEALTH_WINDOW_MINUTES}' MINUTE
       AND blob1 = 'container.health_ping'
+    GROUP BY blob6
     FORMAT JSON
   `;
 
@@ -73,29 +72,33 @@ export async function queryGastownHealth(
     throw new Error(`Gastown health Analytics Engine query failed (${response.status})`);
   }
 
-  const parsed = GastownHealthResponseSchema.parse(await response.json());
-  const row = parsed.data[0];
-  if (!row) {
-    return {
-      weightedFailedChecks: 0,
-      weightedSuccessfulChecks: 0,
-      affectedTownCount: 0,
-      latestEventTimestamp: null,
-    };
-  }
+  const { data } = GastownHealthResponseSchema.parse(await response.json());
+  let weightedFailedChecks = 0;
+  let weightedSuccessfulChecks = 0;
+  let affectedTownCount = 0;
+  let latestEventTimestamp: Date | null = null;
 
-  const latestEventTimestamp =
-    row.latest_event_timestamp === null
-      ? null
-      : new Date(toUtcIsoString(row.latest_event_timestamp));
-  if (latestEventTimestamp !== null && Number.isNaN(latestEventTimestamp.getTime())) {
-    throw new Error('Gastown health Analytics Engine response contains an invalid timestamp');
+  for (const row of data) {
+    const failedChecks = row.weighted_failed_checks ?? 0;
+    weightedFailedChecks += failedChecks;
+    weightedSuccessfulChecks += row.weighted_successful_checks ?? 0;
+    if (row.town_id !== '' && failedChecks > 0) affectedTownCount += 1;
+
+    if (row.latest_event_timestamp !== null) {
+      const rowTimestamp = new Date(toUtcIsoString(row.latest_event_timestamp));
+      if (Number.isNaN(rowTimestamp.getTime())) {
+        throw new Error('Gastown health Analytics Engine response contains an invalid timestamp');
+      }
+      if (latestEventTimestamp === null || rowTimestamp > latestEventTimestamp) {
+        latestEventTimestamp = rowTimestamp;
+      }
+    }
   }
 
   return {
-    weightedFailedChecks: row.weighted_failed_checks ?? 0,
-    weightedSuccessfulChecks: row.weighted_successful_checks ?? 0,
-    affectedTownCount: row.affected_town_count ?? 0,
+    weightedFailedChecks,
+    weightedSuccessfulChecks,
+    affectedTownCount,
     latestEventTimestamp,
   };
 }

--- a/services/o11y/test/gastown-health-query.spec.ts
+++ b/services/o11y/test/gastown-health-query.spec.ts
@@ -30,19 +30,31 @@ describe('queryGastownHealth', () => {
       return Response.json({
         data: [
           {
-            weighted_failed_checks: 24,
-            weighted_successful_checks: 150,
-            affected_town_count: 4,
+            town_id: 'town-1',
+            weighted_failed_checks: 20,
+            weighted_successful_checks: 100,
+            latest_event_timestamp: '2026-06-24 15:09:00.000',
+          },
+          {
+            town_id: 'town-2',
+            weighted_failed_checks: 4,
+            weighted_successful_checks: 50,
             latest_event_timestamp: '2026-06-24 15:10:00.000',
+          },
+          {
+            town_id: '',
+            weighted_failed_checks: 3,
+            weighted_successful_checks: 2,
+            latest_event_timestamp: '2026-06-24 15:08:00.000',
           },
         ],
       });
     };
 
     await expect(queryGastownHealth(makeEnv(), fetchFn)).resolves.toEqual({
-      weightedFailedChecks: 24,
-      weightedSuccessfulChecks: 150,
-      affectedTownCount: 4,
+      weightedFailedChecks: 27,
+      weightedSuccessfulChecks: 152,
+      affectedTownCount: 2,
       latestEventTimestamp: new Date('2026-06-24T15:10:00.000Z'),
     });
     expect(calledUrl).toBe(
@@ -57,8 +69,9 @@ describe('queryGastownHealth', () => {
     expect(sql).toContain("blob1 = 'container.health_ping'");
     expect(sql).toContain("SUM(IF(blob5 != '', _sample_interval, 0))");
     expect(sql).toContain("SUM(IF(blob5 = '', _sample_interval, 0))");
-    expect(sql).toContain("uniqExactIf(blob6, blob5 != '' AND blob6 != '')");
-    expect(sql).not.toContain('COUNT(');
+    expect(sql).toContain('blob6 AS town_id');
+    expect(sql).toContain('GROUP BY blob6');
+    expect(sql).not.toContain('uniqExactIf');
   });
 
   it('maps an empty Analytics Engine result to no telemetry', async () => {
@@ -77,9 +90,9 @@ describe('queryGastownHealth', () => {
       Response.json({
         data: [
           {
+            town_id: '',
             weighted_failed_checks: null,
             weighted_successful_checks: null,
-            affected_town_count: 0,
             latest_event_timestamp: null,
           },
         ],
@@ -100,12 +113,12 @@ describe('queryGastownHealth', () => {
     await expect(queryGastownHealth(makeEnv(), fetchFn)).rejects.toThrow();
   });
 
-  it('rejects non-2xx Analytics Engine responses without exposing response content', async () => {
+  it('rejects invalid Analytics Engine queries without exposing response content', async () => {
     const fetchFn: FetchFn = async () =>
-      new Response('sensitive provider response', { status: 403 });
+      new Response('sensitive provider response', { status: 422 });
 
     await expect(queryGastownHealth(makeEnv(), fetchFn)).rejects.toThrow(
-      'Gastown health Analytics Engine query failed (403)'
+      'Gastown health Analytics Engine query failed (422)'
     );
   });
 


### PR DESCRIPTION
## Summary
Fix Gastown container-health evaluation so the o11y cron can query Cloudflare Analytics Engine successfully.

### Why this change is needed
PR #4239 deployed a query using `uniqExactIf`, which Cloudflare Analytics Engine does not support. The SQL API returns HTTP 422 on every cron tick, preventing Gastown health alert evaluation and marking the scheduled Worker invocation as an exception.

### How this is addressed
- Replace the unsupported aggregate with a documented `GROUP BY blob6` query.
- Aggregate weighted successes and failures across returned town groups in the Worker.
- Count non-empty town IDs with failures while retaining blank-town telemetry in weighted totals.
- Cover grouped responses and the observed HTTP 422 failure path in tests.

## Human Verification
- Complete o11y test suite passed: 15 files, 140 tests.
- Focused logic review completed after preserving blank-town telemetry semantics; no findings remained.

## Reviewer Notes
### Human Reviewer Flags
- This changes only query construction and response aggregation; alert thresholds and lifecycle behavior remain unchanged.
- Production recovery requires merging and deploying the o11y Worker, then confirming scheduled invocations no longer report Analytics Engine HTTP 422.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Cloudflare documents `GROUP BY` and standard aggregates used here; `uniqExactIf` is absent from the Analytics Engine SQL dialect.
- `_sample_interval` weighting remains applied before client-side aggregation.
- Empty town IDs contribute to health totals but never increase affected-town count.

</details>
