### PR TITLE
fix(o11y): bound Gastown health query cardinality

### DIFF
--- a/services/o11y/src/alerting/gastown-health-query.ts
+++ b/services/o11y/src/alerting/gastown-health-query.ts
@@ -45,16 +45,18 @@ export async function queryGastownHealth(
     throw new Error('O11Y_CF_AE_API_TOKEN secret is not configured');
   }
 
+  // Collapse healthy towns into one row so normal fleet size does not inflate the
+  // scheduled Worker's Analytics Engine response and Cloudflare trace payload.
   const sql = `
     SELECT
-      blob6 AS town_id,
+      IF(blob5 != '' AND blob6 != '', blob6, '') AS town_id,
       SUM(IF(blob5 != '', _sample_interval, 0)) AS weighted_failed_checks,
       SUM(IF(blob5 = '', _sample_interval, 0)) AS weighted_successful_checks,
       MAX(timestamp) AS latest_event_timestamp
     FROM gastown_events
     WHERE timestamp > NOW() - INTERVAL '${GASTOWN_HEALTH_WINDOW_MINUTES}' MINUTE
       AND blob1 = 'container.health_ping'
-    GROUP BY blob6
+    GROUP BY IF(blob5 != '' AND blob6 != '', blob6, '')
     FORMAT JSON
   `;
 

--- a/services/o11y/src/alerting/gastown-health-query.ts
+++ b/services/o11y/src/alerting/gastown-health-query.ts
@@ -56,7 +56,7 @@ export async function queryGastownHealth(
     FROM gastown_events
     WHERE timestamp > NOW() - INTERVAL '${GASTOWN_HEALTH_WINDOW_MINUTES}' MINUTE
       AND blob1 = 'container.health_ping'
-    GROUP BY IF(blob5 != '' AND blob6 != '', blob6, '')
+    GROUP BY town_id
     FORMAT JSON
   `;
 

--- a/services/o11y/test/gastown-health-query.spec.ts
+++ b/services/o11y/test/gastown-health-query.spec.ts
@@ -69,8 +69,9 @@ describe('queryGastownHealth', () => {
     expect(sql).toContain("blob1 = 'container.health_ping'");
     expect(sql).toContain("SUM(IF(blob5 != '', _sample_interval, 0))");
     expect(sql).toContain("SUM(IF(blob5 = '', _sample_interval, 0))");
-    expect(sql).toContain('blob6 AS town_id');
-    expect(sql).toContain('GROUP BY blob6');
+    expect(sql).toContain("IF(blob5 != '' AND blob6 != '', blob6, '') AS town_id");
+    expect(sql).toContain("GROUP BY IF(blob5 != '' AND blob6 != '', blob6, '')");
+    expect(sql).not.toContain('GROUP BY blob6');
     expect(sql).not.toContain('uniqExactIf');
   });
 

--- a/services/o11y/test/gastown-health-query.spec.ts
+++ b/services/o11y/test/gastown-health-query.spec.ts
@@ -70,7 +70,7 @@ describe('queryGastownHealth', () => {
     expect(sql).toContain("SUM(IF(blob5 != '', _sample_interval, 0))");
     expect(sql).toContain("SUM(IF(blob5 = '', _sample_interval, 0))");
     expect(sql).toContain("IF(blob5 != '' AND blob6 != '', blob6, '') AS town_id");
-    expect(sql).toContain("GROUP BY IF(blob5 != '' AND blob6 != '', blob6, '')");
+    expect(sql).toContain('GROUP BY town_id');
     expect(sql).not.toContain('GROUP BY blob6');
     expect(sql).not.toContain('uniqExactIf');
   });


### PR DESCRIPTION
## Summary
Bounds Gastown health query cardinality so o11y alert evaluation no longer emits one Analytics Engine row per healthy town.

### Why this change is needed
The per-minute o11y cron began exhausting Cloudflare trace resources after Gastown health alerting grouped results by every active town. Healthy fleet growth inflated response cardinality even though alert state only needs aggregate healthy checks and identities for failed towns.

### How this is addressed
- Collapse all healthy and unidentified-town events into one aggregate row.
- Keep one row per identified town with failed checks so affected-town counts remain exact.
- Preserve weighted failure totals, weighted success totals, and latest-event timestamp semantics.
- Assert bounded grouping SQL and prevent regression to direct grouping by every town.

## Human Verification
- O11y test suite: 15 files and 140 tests passed.
- O11y TypeScript typecheck passed.
- Independent logic and API-contract reviews found no issues.

## Reviewer Notes
### Human Reviewer Flags
- Analytics Engine SQL uses supported `IF`, `SUM`, `MAX`, and expression grouping while trading per-healthy-town detail for bounded response size. Alert evaluation does not consume healthy-town identities.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Failed events with an empty town ID remain included in weighted failure totals but do not increment affected-town count, matching existing behavior.
- Result cardinality changes from all active towns to affected identified towns plus at most one aggregate row.

</details>
