### PR TITLE
fix(o11y): parse Analytics Engine aggregate strings

### DIFF
--- a/services/o11y/src/alerting/gastown-health-query.ts
+++ b/services/o11y/src/alerting/gastown-health-query.ts
@@ -16,12 +16,17 @@ type QueryEnv = {
 
 type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
 
+const AnalyticsEngineNumberSchema = z.preprocess(
+  value => (typeof value === 'string' && value.trim() !== '' ? Number(value) : value),
+  z.number().finite().nonnegative().nullable()
+);
+
 const GastownHealthResponseSchema = z.object({
   data: z.array(
     z.object({
       town_id: z.string(),
-      weighted_failed_checks: z.number().nonnegative().nullable(),
-      weighted_successful_checks: z.number().nonnegative().nullable(),
+      weighted_failed_checks: AnalyticsEngineNumberSchema,
+      weighted_successful_checks: AnalyticsEngineNumberSchema,
       latest_event_timestamp: z.string().nullable(),
     })
   ),

--- a/services/o11y/test/gastown-health-query.spec.ts
+++ b/services/o11y/test/gastown-health-query.spec.ts
@@ -31,20 +31,20 @@ describe('queryGastownHealth', () => {
         data: [
           {
             town_id: 'town-1',
-            weighted_failed_checks: 20,
-            weighted_successful_checks: 100,
+            weighted_failed_checks: '20',
+            weighted_successful_checks: '100',
             latest_event_timestamp: '2026-06-24 15:09:00.000',
           },
           {
             town_id: 'town-2',
-            weighted_failed_checks: 4,
-            weighted_successful_checks: 50,
+            weighted_failed_checks: '4',
+            weighted_successful_checks: '50',
             latest_event_timestamp: '2026-06-24 15:10:00.000',
           },
           {
             town_id: '',
-            weighted_failed_checks: 3,
-            weighted_successful_checks: 2,
+            weighted_failed_checks: '3',
+            weighted_successful_checks: '2',
             latest_event_timestamp: '2026-06-24 15:08:00.000',
           },
         ],
@@ -106,6 +106,25 @@ describe('queryGastownHealth', () => {
       latestEventTimestamp: null,
     });
   });
+
+  it.each(['', 'not-a-number', '-1', 'Infinity'])(
+    'rejects invalid Analytics Engine aggregate %j',
+    async aggregate => {
+      const fetchFn: FetchFn = async () =>
+        Response.json({
+          data: [
+            {
+              town_id: '',
+              weighted_failed_checks: aggregate,
+              weighted_successful_checks: '0',
+              latest_event_timestamp: null,
+            },
+          ],
+        });
+
+      await expect(queryGastownHealth(makeEnv(), fetchFn)).rejects.toThrow();
+    }
+  );
 
   it('rejects malformed Analytics Engine responses', async () => {
     const fetchFn: FetchFn = async () =>


### PR DESCRIPTION
## Summary
Parses Analytics Engine aggregate strings before validating Gastown health metrics.

### Why this change is needed
Cloudflare Analytics Engine serializes `SUM(...)` values as strings in JSON. The o11y worker expected JSON numbers, so every Gastown health evaluation failed schema validation after the cardinality fix reached production.

### How this is addressed
- Convert non-empty aggregate strings to numbers before strict validation.
- Continue accepting JSON numbers and nullable aggregates.
- Reject empty, non-numeric, negative, and non-finite aggregate values.
- Exercise production-shaped string aggregates in the main query test.

## Human Verification
- O11y test suite: 15 files and 144 tests passed.
- O11y TypeScript typecheck passed.
- Independent logic and API-contract reviews found no issues.
- Production Cloudflare logs confirmed `SUM(...)` fields arrive as strings.

## Reviewer Notes
### Human Reviewer Flags
No notable items for human review beyond what the summary covers.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Parsed output remains `number | null`, preserving downstream metric contracts.
- Validation rejects malformed numeric strings instead of using permissive coercion defaults.

</details>
