### PR TITLE
Manage child memberships from parent members table

### DIFF
--- a/apps/storybook/src/mockData/organizations.ts
+++ b/apps/storybook/src/mockData/organizations.ts
@@ -23,6 +23,15 @@ function generateMember(): OrganizationMember {
       inviteDate: randomBoolean(rng, 0.5) ? new Date().toISOString() : null,
       dailyUsageLimitUsd,
       currentDailyUsageUsd,
+      childOrganizationMemberships: randomBoolean(rng, 0.35)
+        ? [
+            {
+              id: randomId(rng, 'org'),
+              name: `Team ${randomInt(rng, 1, 9)}`,
+              role: 'member',
+            },
+          ]
+        : [],
     };
   }
 
@@ -46,6 +55,10 @@ export function generateOrganization(): OrganizationWithMembers {
   return {
     ...base,
     name: `Company ${randomInt(rng, 0, 999)} ${companyType}`,
+    childOrganizations: [
+      { id: randomId(rng, 'org'), name: 'Platform Team' },
+      { id: randomId(rng, 'org'), name: 'Product Team' },
+    ],
     members: Array.from({ length: randomInt(rng, 2, 7) }, generateMember),
     effectiveSsoPolicy: {
       required: false,

--- a/apps/web/src/app/api/organizations/hooks.ts
+++ b/apps/web/src/app/api/organizations/hooks.ts
@@ -153,6 +153,16 @@ export function useInviteMember() {
   );
 }
 
+export function useSetChildMemberships() {
+  const trpc = useTRPC();
+  const onSuccess = useInvalidateOrganizationAndMembers();
+  return useMutation(
+    trpc.organizations.members.setChildMemberships.mutationOptions({
+      onSuccess,
+    })
+  );
+}
+
 export function useUpdateOrganizationName() {
   const trpc = useTRPC();
   const onSuccess = useInvalidateOrganizationAndMembers();

--- a/apps/web/src/components/organizations/OrganizationMembersCard.tsx
+++ b/apps/web/src/components/organizations/OrganizationMembersCard.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Plus,
   Copy,
@@ -13,6 +15,7 @@ import {
   UserPen,
   ChevronRight,
   UserCog,
+  Loader2,
 } from 'lucide-react';
 import Link from 'next/link';
 import { AddMemberDialog } from '../../app/admin/components/OrganizationAdmin/AddMemberDialog';
@@ -24,6 +27,7 @@ import {
   useOrganizationWithMembers,
   useDeleteOrganizationInvitation,
   useRemoveMember,
+  useSetChildMemberships,
 } from '@/app/api/organizations/hooks';
 import { ErrorCard } from '../ErrorCard';
 import { LoadingCard } from '../LoadingCard';
@@ -281,6 +285,115 @@ function EditLimitButton({ organization, member }: EditLimitButtonProps) {
   );
 }
 
+type ChildTeamsControlProps = {
+  organization: OrganizationWithMembers;
+  member: OrganizationMember;
+  editable: boolean;
+};
+
+function ChildTeamsControl({ organization, member, editable }: ChildTeamsControlProps) {
+  const mutation = useSetChildMemberships();
+
+  if (member.status !== 'active') return null;
+
+  const childMemberships = member.childOrganizationMemberships ?? [];
+  const childMembershipsById = new Map(childMemberships.map(child => [child.id, child]));
+
+  if (organization.childOrganizations.length === 0 && childMemberships.length === 0) return null;
+
+  const handleToggleChildOrganization = (childOrganizationId: string, checked: boolean) => {
+    const currentChildOrganizationIds = new Set(childMemberships.map(child => child.id));
+    if (checked) {
+      currentChildOrganizationIds.add(childOrganizationId);
+    } else {
+      currentChildOrganizationIds.delete(childOrganizationId);
+    }
+
+    mutation.mutate(
+      {
+        organizationId: organization.id,
+        memberId: member.id,
+        childOrganizationIds: Array.from(currentChildOrganizationIds),
+      },
+      {
+        onSuccess: () => {
+          toast.success(`Updated child teams for ${member.name || member.email}`);
+        },
+        onError: error => {
+          toast.error(error instanceof Error ? error.message : 'Failed to update child teams');
+        },
+      }
+    );
+  };
+
+  const labels =
+    childMemberships.length > 0 ? (
+      <div className="flex flex-wrap gap-1">
+        {childMemberships.map(child => (
+          <Badge key={child.id} variant="outline" className="text-xs font-normal">
+            {child.name}
+            {child.role !== 'member' ? ` · ${child.role === 'owner' ? 'Owner' : 'Billing'}` : ''}
+          </Badge>
+        ))}
+      </div>
+    ) : (
+      <span className="text-muted-foreground text-xs">No child teams</span>
+    );
+
+  if (!editable) return labels;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="h-8 gap-2">
+          {mutation.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+          Child teams
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-72 p-0" align="end">
+        <div className="border-b p-3">
+          <p className="text-sm font-medium">Child teams</p>
+          <p className="text-muted-foreground text-xs">Assign this parent member to child teams.</p>
+        </div>
+        <div className="max-h-72 overflow-y-auto p-2">
+          {organization.childOrganizations.length === 0 ? (
+            <p className="text-muted-foreground px-2 py-4 text-sm">No child teams found.</p>
+          ) : (
+            organization.childOrganizations.map(childOrganization => {
+              const membership = childMembershipsById.get(childOrganization.id);
+              const checked = Boolean(membership);
+              const locked = membership && membership.role !== 'member';
+              return (
+                <label
+                  key={childOrganization.id}
+                  className="hover:bg-accent flex cursor-pointer items-start gap-2 rounded-md px-2 py-2 text-sm"
+                >
+                  <Checkbox
+                    checked={checked}
+                    disabled={mutation.isPending || locked}
+                    onCheckedChange={nextChecked =>
+                      handleToggleChildOrganization(childOrganization.id, nextChecked)
+                    }
+                    className="mt-0.5"
+                  />
+                  <span className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate">{childOrganization.name}</span>
+                    {locked ? (
+                      <span className="text-muted-foreground text-xs">
+                        {membership.role === 'owner' ? 'Owner' : 'Billing manager'} in child team
+                      </span>
+                    ) : null}
+                  </span>
+                </label>
+              );
+            })
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 export function OrganizationAdminMembers({
   organizationId,
   showAdminLinks = false,
@@ -422,8 +535,11 @@ export function OrganizationAdminMembers({
                     member.status === 'active'
                       ? canRemoveMember(currentUserRole, isKiloAdmin, isCurrentUser)
                       : canManageMembers(currentUserRole, isKiloAdmin);
+                  const canEditChildTeams =
+                    member.status === 'active' && canInviteMembers(currentUserRole, isKiloAdmin);
 
-                  const hasAnyEditableActions = canEditRole || canEditLimit || canDelete;
+                  const hasAnyEditableActions =
+                    canEditRole || canEditLimit || canDelete || canEditChildTeams;
 
                   return (
                     <div
@@ -459,6 +575,11 @@ export function OrganizationAdminMembers({
                             </span>
                             <DailyUsageLimitDisplay member={member} />
                           </div>
+                          <ChildTeamsControl
+                            organization={organizationData}
+                            member={member}
+                            editable={false}
+                          />
                         </div>
                       </div>
 
@@ -491,6 +612,13 @@ export function OrganizationAdminMembers({
                               member={member}
                               showAsReadOnly={false}
                             />
+                            {canEditChildTeams && (
+                              <ChildTeamsControl
+                                organization={organizationData}
+                                member={member}
+                                editable={true}
+                              />
+                            )}
                             <EditLimitButton organization={organizationData} member={member} />
                             <DeleteMemberButton organizationId={organizationId} member={member} />
                             <DeleteInvitationButton

--- a/apps/web/src/components/organizations/OrganizationMembersCard.tsx
+++ b/apps/web/src/components/organizations/OrganizationMembersCard.tsx
@@ -289,9 +289,15 @@ type ChildTeamsControlProps = {
   organization: OrganizationWithMembers;
   member: OrganizationMember;
   editable: boolean;
+  canOpenChildOrganizations: boolean;
 };
 
-function ChildTeamsControl({ organization, member, editable }: ChildTeamsControlProps) {
+function ChildTeamsControl({
+  organization,
+  member,
+  editable,
+  canOpenChildOrganizations,
+}: ChildTeamsControlProps) {
   const mutation = useSetChildMemberships();
 
   if (member.status !== 'active') return null;
@@ -329,12 +335,28 @@ function ChildTeamsControl({ organization, member, editable }: ChildTeamsControl
   const labels =
     childMemberships.length > 0 ? (
       <div className="flex flex-wrap gap-1">
-        {childMemberships.map(child => (
-          <Badge key={child.id} variant="outline" className="text-xs font-normal">
-            {child.name}
-            {child.role !== 'member' ? ` · ${child.role === 'owner' ? 'Owner' : 'Billing'}` : ''}
-          </Badge>
-        ))}
+        {childMemberships.map(child => {
+          const label = `${child.name}${child.role !== 'member' ? ` · ${child.role === 'owner' ? 'Owner' : 'Billing'}` : ''}`;
+
+          if (!canOpenChildOrganizations) {
+            return (
+              <Badge key={child.id} variant="outline" className="text-xs font-normal">
+                {label}
+              </Badge>
+            );
+          }
+
+          return (
+            <Badge
+              key={child.id}
+              variant="outline"
+              asChild
+              className="text-xs font-normal hover:bg-accent focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+            >
+              <Link href={`/organizations/${encodeURIComponent(child.id)}`}>{label}</Link>
+            </Badge>
+          );
+        })}
       </div>
     ) : (
       <span className="text-muted-foreground text-xs">No child teams</span>
@@ -579,6 +601,7 @@ export function OrganizationAdminMembers({
                             organization={organizationData}
                             member={member}
                             editable={false}
+                            canOpenChildOrganizations={showInviteMemberButton}
                           />
                         </div>
                       </div>
@@ -617,6 +640,7 @@ export function OrganizationAdminMembers({
                                 organization={organizationData}
                                 member={member}
                                 editable={true}
+                                canOpenChildOrganizations={showInviteMemberButton}
                               />
                             )}
                             <EditLimitButton organization={organizationData} member={member} />

--- a/apps/web/src/lib/organizations/organization-types.ts
+++ b/apps/web/src/lib/organizations/organization-types.ts
@@ -111,9 +111,19 @@ type ActiveMember = {
   inviteDate: string | null;
   dailyUsageLimitUsd: number | null;
   currentDailyUsageUsd: number | null;
+  childOrganizationMemberships?: ChildOrganizationMembership[];
 };
 
 export type OrganizationMember = InvitedMember | ActiveMember;
+
+export type ChildOrganizationSummary = {
+  id: string;
+  name: string;
+};
+
+export type ChildOrganizationMembership = ChildOrganizationSummary & {
+  role: OrganizationRole;
+};
 
 export type OrganizationSsoPolicyView = {
   required: boolean;
@@ -124,6 +134,7 @@ export type OrganizationSsoPolicyView = {
 
 export type OrganizationWithMembers = z.infer<typeof OrganizationSchema> & {
   members: OrganizationMember[];
+  childOrganizations: ChildOrganizationSummary[];
   effectiveSsoPolicy: OrganizationSsoPolicyView;
 };
 

--- a/apps/web/src/routers/organizations/organization-members-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-members-router.test.ts
@@ -376,7 +376,7 @@ describe('organizations members trpc router', () => {
       }
     });
 
-    it('does not remove elevated child organization memberships from the parent control', async () => {
+    it('removes unselected child organization memberships regardless of role', async () => {
       const childOwner = await insertTestUser({
         google_user_email: `${crypto.randomUUID()}@elevated-child-owner.example.com`,
         google_user_name: 'Elevated Child Owner',
@@ -393,7 +393,7 @@ describe('organizations members trpc router', () => {
           childOrganizationIds: [],
         });
 
-        expect(result).toEqual({ success: true, added: [], removed: [] });
+        expect(result).toEqual({ success: true, added: [], removed: [child.id] });
         const [membership] = await db
           .select({ role: organization_memberships.role })
           .from(organization_memberships)
@@ -403,7 +403,7 @@ describe('organizations members trpc router', () => {
               eq(organization_memberships.kilo_user_id, memberUser.id)
             )
           );
-        expect(membership?.role).toBe('owner');
+        expect(membership).toBeUndefined();
       } finally {
         await cleanupChildOrganizations([child.id]);
       }

--- a/apps/web/src/routers/organizations/organization-members-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-members-router.test.ts
@@ -2,6 +2,9 @@ import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
 import type { User, Organization } from '@kilocode/db/schema';
+import { organization_memberships, organizations } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { and, eq } from 'drizzle-orm';
 
 // Mock the email service to prevent actual API calls during tests
 jest.mock('@/lib/email', () => ({
@@ -226,6 +229,184 @@ describe('organizations members trpc router', () => {
           dailyUsageLimitUsd: -10,
         })
       ).rejects.toThrow();
+    });
+  });
+
+  describe('setChildMemberships procedure', () => {
+    async function createChildOrganization(name: string, ownerId: string): Promise<Organization> {
+      const child = await createOrganization(name, ownerId);
+      await db
+        .update(organizations)
+        .set({ parent_organization_id: testOrganization.id, require_seats: false })
+        .where(eq(organizations.id, child.id));
+      return child;
+    }
+
+    async function cleanupChildOrganizations(childOrganizationIds: string[]): Promise<void> {
+      if (childOrganizationIds.length === 0) return;
+      for (const childOrganizationId of childOrganizationIds) {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(eq(organizations.id, childOrganizationId));
+        await db.delete(organizations).where(eq(organizations.id, childOrganizationId));
+      }
+    }
+
+    it('allows parent owners to assign parent members to child organizations', async () => {
+      const childOwner = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@child-owner.example.com`,
+        google_user_name: 'Child Owner',
+        is_admin: false,
+      });
+      const childA = await createChildOrganization('Child Members A', childOwner.id);
+      const childB = await createChildOrganization('Child Members B', childOwner.id);
+      const caller = await createCallerForUser(regularUser.id);
+
+      try {
+        const result = await caller.organizations.members.setChildMemberships({
+          organizationId: testOrganization.id,
+          memberId: memberUser.id,
+          childOrganizationIds: [childA.id, childB.id],
+        });
+
+        expect(result).toEqual({ success: true, added: [childA.id, childB.id], removed: [] });
+        const rows = await db
+          .select({ organizationId: organization_memberships.organization_id })
+          .from(organization_memberships)
+          .where(eq(organization_memberships.kilo_user_id, memberUser.id));
+        expect(rows.map(row => row.organizationId)).toEqual(
+          expect.arrayContaining([childA.id, childB.id])
+        );
+      } finally {
+        await cleanupChildOrganizations([childA.id, childB.id]);
+      }
+    });
+
+    it('allows parent billing managers to assign parent members to child organizations as members', async () => {
+      const childOwner = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@billing-child-owner.example.com`,
+        google_user_name: 'Billing Child Owner',
+        is_admin: false,
+      });
+      const child = await createChildOrganization('Billing Child Members', childOwner.id);
+      const caller = await createCallerForUser(billingManagerUser.id);
+
+      try {
+        const result = await caller.organizations.members.setChildMemberships({
+          organizationId: testOrganization.id,
+          memberId: memberUser.id,
+          childOrganizationIds: [child.id],
+        });
+
+        expect(result).toEqual({ success: true, added: [child.id], removed: [] });
+      } finally {
+        await cleanupChildOrganizations([child.id]);
+      }
+    });
+
+    it('rejects parent members assigning child memberships', async () => {
+      const childOwner = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@member-child-owner.example.com`,
+        google_user_name: 'Member Child Owner',
+        is_admin: false,
+      });
+      const child = await createChildOrganization('Member Child Members', childOwner.id);
+      const caller = await createCallerForUser(memberUser.id);
+
+      try {
+        await expect(
+          caller.organizations.members.setChildMemberships({
+            organizationId: testOrganization.id,
+            memberId: memberUser.id,
+            childOrganizationIds: [child.id],
+          })
+        ).rejects.toThrow(
+          'You do not have the required organizational role to access this feature'
+        );
+      } finally {
+        await cleanupChildOrganizations([child.id]);
+      }
+    });
+
+    it('rejects assigning users who are not parent organization members', async () => {
+      const childOwner = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@non-parent-child-owner.example.com`,
+        google_user_name: 'Non Parent Child Owner',
+        is_admin: false,
+      });
+      const child = await createChildOrganization('Non Parent Child Members', childOwner.id);
+      const caller = await createCallerForUser(regularUser.id);
+
+      try {
+        await expect(
+          caller.organizations.members.setChildMemberships({
+            organizationId: testOrganization.id,
+            memberId: nonMemberUser.id,
+            childOrganizationIds: [child.id],
+          })
+        ).rejects.toThrow('User is not a member of the parent organization');
+      } finally {
+        await cleanupChildOrganizations([child.id]);
+      }
+    });
+
+    it('rejects assigning members to organizations that are not direct children', async () => {
+      const unrelatedOwner = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@unrelated-child-owner.example.com`,
+        google_user_name: 'Unrelated Child Owner',
+        is_admin: false,
+      });
+      const unrelatedOrganization = await createOrganization(
+        'Unrelated Members Org',
+        unrelatedOwner.id
+      );
+      const caller = await createCallerForUser(regularUser.id);
+
+      try {
+        await expect(
+          caller.organizations.members.setChildMemberships({
+            organizationId: testOrganization.id,
+            memberId: memberUser.id,
+            childOrganizationIds: [unrelatedOrganization.id],
+          })
+        ).rejects.toThrow('Selected organizations must be direct child organizations');
+      } finally {
+        await db.delete(organizations).where(eq(organizations.id, unrelatedOrganization.id));
+      }
+    });
+
+    it('does not remove elevated child organization memberships from the parent control', async () => {
+      const childOwner = await insertTestUser({
+        google_user_email: `${crypto.randomUUID()}@elevated-child-owner.example.com`,
+        google_user_name: 'Elevated Child Owner',
+        is_admin: false,
+      });
+      const child = await createChildOrganization('Elevated Child Members', childOwner.id);
+      await addUserToOrganization(child.id, memberUser.id, 'owner');
+      const caller = await createCallerForUser(regularUser.id);
+
+      try {
+        const result = await caller.organizations.members.setChildMemberships({
+          organizationId: testOrganization.id,
+          memberId: memberUser.id,
+          childOrganizationIds: [],
+        });
+
+        expect(result).toEqual({ success: true, added: [], removed: [] });
+        const [membership] = await db
+          .select({ role: organization_memberships.role })
+          .from(organization_memberships)
+          .where(
+            and(
+              eq(organization_memberships.organization_id, child.id),
+              eq(organization_memberships.kilo_user_id, memberUser.id)
+            )
+          );
+        expect(membership?.role).toBe('owner');
+      } finally {
+        await cleanupChildOrganizations([child.id]);
+      }
     });
   });
 

--- a/apps/web/src/routers/organizations/organization-members-router.ts
+++ b/apps/web/src/routers/organizations/organization-members-router.ts
@@ -31,7 +31,6 @@ import { successResult } from '@/lib/maybe-result';
 import { destroyOrgInstancesForUser } from '@/lib/kiloclaw/instance-registry';
 import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { revokeGatewayStateForOrganizationMember } from '@/lib/mcp-gateway/lifecycle-service';
-import { getOrganizationSeatUsage } from '@/lib/organizations/organization-seats';
 
 const MAX_DAILY_LIMIT_USD = 2000;
 
@@ -188,9 +187,6 @@ export const organizationsMembersRouter = createTRPCRouter({
       const childOrganizations = await db
         .select({
           id: organizations.id,
-          name: organizations.name,
-          plan: organizations.plan,
-          requireSeats: organizations.require_seats,
         })
         .from(organizations)
         .where(
@@ -238,38 +234,6 @@ export const organizationsMembersRouter = createTRPCRouter({
 
       for (const childOrganizationId of childOrganizationIds) {
         if (existingMembershipsByOrganizationId.has(childOrganizationId)) continue;
-
-        const childOrganization = childOrganizationsById.get(childOrganizationId);
-        if (!childOrganization) continue;
-
-        const [pendingInvitation] = await db
-          .select({ id: organization_invitations.id })
-          .from(organization_invitations)
-          .where(
-            and(
-              eq(organization_invitations.organization_id, childOrganizationId),
-              eq(organization_invitations.email, parentMember.email),
-              isNull(organization_invitations.accepted_at),
-              sql`${organization_invitations.expires_at} > NOW()`
-            )
-          )
-          .limit(1);
-        if (pendingInvitation) {
-          throw new TRPCError({
-            code: 'CONFLICT',
-            message: `${parentMember.email} already has a pending invitation for ${childOrganization.name}`,
-          });
-        }
-
-        if (childOrganization.requireSeats && childOrganization.plan !== 'enterprise') {
-          const seatUsage = await getOrganizationSeatUsage(childOrganizationId);
-          if (seatUsage.used >= seatUsage.total) {
-            throw new TRPCError({
-              code: 'PRECONDITION_FAILED',
-              message: `${childOrganization.name} has no available seats`,
-            });
-          }
-        }
 
         const wasAdded = await addUserToOrganization(childOrganizationId, memberId, 'member');
         if (wasAdded) {

--- a/apps/web/src/routers/organizations/organization-members-router.ts
+++ b/apps/web/src/routers/organizations/organization-members-router.ts
@@ -1,6 +1,7 @@
 import {
   updateUserRoleInOrganization,
   removeUserFromOrganization,
+  addUserToOrganization,
   getOrganizationById,
   inviteUserToOrganization,
   getAcceptInviteUrl,
@@ -10,6 +11,7 @@ import {
   organization_memberships,
   organization_invitations,
   kilocode_users,
+  organizations,
 } from '@kilocode/db/schema';
 import { db, sql } from '@/lib/drizzle';
 import { createTRPCRouter } from '@/lib/trpc/init';
@@ -21,7 +23,7 @@ import {
 } from '@/routers/organizations/utils';
 import { sendOrganizationInviteEmail } from '@/lib/email';
 import { TRPCError } from '@trpc/server';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import * as z from 'zod';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
 import { findUserById } from '@/lib/user';
@@ -29,6 +31,7 @@ import { successResult } from '@/lib/maybe-result';
 import { destroyOrgInstancesForUser } from '@/lib/kiloclaw/instance-registry';
 import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { revokeGatewayStateForOrganizationMember } from '@/lib/mcp-gateway/lifecycle-service';
+import { getOrganizationSeatUsage } from '@/lib/organizations/organization-seats';
 
 const MAX_DAILY_LIMIT_USD = 2000;
 
@@ -50,6 +53,29 @@ const InviteMemberSchema = OrganizationIdInputSchema.extend({
 const DeleteInviteSchema = OrganizationIdInputSchema.extend({
   inviteId: z.string(),
 });
+
+const SetChildMembershipsSchema = OrganizationIdInputSchema.extend({
+  memberId: z.string(),
+  childOrganizationIds: z.array(z.uuid()),
+});
+
+async function getDirectOrganizationRole(
+  organizationId: string,
+  userId: string
+): Promise<'owner' | 'member' | 'billing_manager' | null> {
+  const [membership] = await db
+    .select({ role: organization_memberships.role })
+    .from(organization_memberships)
+    .where(
+      and(
+        eq(organization_memberships.organization_id, organizationId),
+        eq(organization_memberships.kilo_user_id, userId)
+      )
+    )
+    .limit(1);
+
+  return membership?.role ?? null;
+}
 
 export const organizationsMembersRouter = createTRPCRouter({
   update: organizationOwnerMutationProcedure
@@ -119,6 +145,170 @@ export const organizationsMembersRouter = createTRPCRouter({
       return successResult({
         updated: role !== undefined ? 'role and limit' : 'limit',
       });
+    }),
+  setChildMemberships: organizationBillingMutationProcedure
+    .input(SetChildMembershipsSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { user } = ctx;
+      const { organizationId, memberId } = input;
+      const childOrganizationIds = Array.from(new Set(input.childOrganizationIds));
+
+      const directRole = user.is_admin
+        ? 'owner'
+        : await getDirectOrganizationRole(organizationId, user.id);
+      if (directRole !== 'owner' && directRole !== 'billing_manager') {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'You do not have the required organizational role to access this feature',
+        });
+      }
+
+      const [parentMember] = await db
+        .select({
+          email: kilocode_users.google_user_email,
+          isBot: kilocode_users.is_bot,
+        })
+        .from(organization_memberships)
+        .innerJoin(kilocode_users, eq(kilocode_users.id, organization_memberships.kilo_user_id))
+        .where(
+          and(
+            eq(organization_memberships.organization_id, organizationId),
+            eq(organization_memberships.kilo_user_id, memberId)
+          )
+        )
+        .limit(1);
+
+      if (!parentMember || parentMember.isBot) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'User is not a member of the parent organization',
+        });
+      }
+
+      const childOrganizations = await db
+        .select({
+          id: organizations.id,
+          name: organizations.name,
+          plan: organizations.plan,
+          requireSeats: organizations.require_seats,
+        })
+        .from(organizations)
+        .where(
+          and(
+            eq(organizations.parent_organization_id, organizationId),
+            isNull(organizations.deleted_at)
+          )
+        );
+      const childOrganizationsById = new Map(childOrganizations.map(child => [child.id, child]));
+
+      if (
+        childOrganizationIds.some(
+          childOrganizationId => !childOrganizationsById.has(childOrganizationId)
+        )
+      ) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Selected organizations must be direct child organizations',
+        });
+      }
+
+      const childIds = childOrganizations.map(child => child.id);
+      const existingMemberships =
+        childIds.length > 0
+          ? await db
+              .select({
+                organizationId: organization_memberships.organization_id,
+                role: organization_memberships.role,
+              })
+              .from(organization_memberships)
+              .where(
+                and(
+                  eq(organization_memberships.kilo_user_id, memberId),
+                  inArray(organization_memberships.organization_id, childIds)
+                )
+              )
+          : [];
+      const existingMembershipsByOrganizationId = new Map(
+        existingMemberships.map(membership => [membership.organizationId, membership])
+      );
+      const selectedChildOrganizationIds = new Set(childOrganizationIds);
+
+      const added: string[] = [];
+      const removed: string[] = [];
+
+      for (const childOrganizationId of childOrganizationIds) {
+        if (existingMembershipsByOrganizationId.has(childOrganizationId)) continue;
+
+        const childOrganization = childOrganizationsById.get(childOrganizationId);
+        if (!childOrganization) continue;
+
+        const [pendingInvitation] = await db
+          .select({ id: organization_invitations.id })
+          .from(organization_invitations)
+          .where(
+            and(
+              eq(organization_invitations.organization_id, childOrganizationId),
+              eq(organization_invitations.email, parentMember.email),
+              isNull(organization_invitations.accepted_at),
+              sql`${organization_invitations.expires_at} > NOW()`
+            )
+          )
+          .limit(1);
+        if (pendingInvitation) {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: `${parentMember.email} already has a pending invitation for ${childOrganization.name}`,
+          });
+        }
+
+        if (childOrganization.requireSeats && childOrganization.plan !== 'enterprise') {
+          const seatUsage = await getOrganizationSeatUsage(childOrganizationId);
+          if (seatUsage.used >= seatUsage.total) {
+            throw new TRPCError({
+              code: 'PRECONDITION_FAILED',
+              message: `${childOrganization.name} has no available seats`,
+            });
+          }
+        }
+
+        const wasAdded = await addUserToOrganization(childOrganizationId, memberId, 'member');
+        if (wasAdded) {
+          added.push(childOrganizationId);
+          await createAuditLog({
+            action: 'organization.member.admin_add',
+            actor_email: user.google_user_email,
+            actor_id: user.id,
+            actor_name: user.google_user_name,
+            message: `Added parent organization member ${parentMember.email} as a member from parent organization ${organizationId}`,
+            organization_id: childOrganizationId,
+          });
+        }
+      }
+
+      for (const membership of existingMemberships) {
+        if (selectedChildOrganizationIds.has(membership.organizationId)) continue;
+        if (membership.role !== 'member') continue;
+
+        const result = await removeUserFromOrganization(
+          membership.organizationId,
+          memberId,
+          user.id
+        );
+        if ((result.rowCount ?? 0) > 0) {
+          removed.push(membership.organizationId);
+          await revokeGatewayStateForOrganizationMember(db, membership.organizationId, memberId);
+          await createAuditLog({
+            action: 'organization.member.remove',
+            actor_email: user.google_user_email,
+            actor_id: user.id,
+            actor_name: user.google_user_name,
+            message: `Removed parent organization member ${parentMember.email} from child organization via parent organization ${organizationId}`,
+            organization_id: membership.organizationId,
+          });
+        }
+      }
+
+      return successResult({ added, removed });
     }),
   remove: organizationOwnerMutationProcedure
     .input(RemoveMemberSchema)

--- a/apps/web/src/routers/organizations/organization-members-router.ts
+++ b/apps/web/src/routers/organizations/organization-members-router.ts
@@ -251,7 +251,6 @@ export const organizationsMembersRouter = createTRPCRouter({
 
       for (const membership of existingMemberships) {
         if (selectedChildOrganizationIds.has(membership.organizationId)) continue;
-        if (membership.role !== 'member') continue;
 
         const result = await removeUserFromOrganization(
           membership.organizationId,

--- a/apps/web/src/routers/organizations/organization-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-router.test.ts
@@ -196,6 +196,60 @@ describe('organizations trpc router', () => {
       }
     });
 
+    it('should include child organization memberships for parent organization members', async () => {
+      const parentOwner = await insertTestUser({
+        google_user_email: 'parent-label-owner-org@example.com',
+        google_user_name: 'Parent Label Owner Org User',
+        is_admin: false,
+      });
+      const parentMember = await insertTestUser({
+        google_user_email: 'parent-label-member-org@example.com',
+        google_user_name: 'Parent Label Member Org User',
+        is_admin: false,
+      });
+      const childOwner = await insertTestUser({
+        google_user_email: 'child-label-owner-org@example.com',
+        google_user_name: 'Child Label Owner Org User',
+        is_admin: false,
+      });
+      const parentOrganization = await createOrganization(
+        'Parent Label Organization',
+        parentOwner.id
+      );
+      await addUserToOrganization(parentOrganization.id, parentMember.id, 'member');
+      const childOrganization = await createOrganization('Child Label Organization', childOwner.id);
+      await db
+        .update(organizations)
+        .set({ parent_organization_id: parentOrganization.id })
+        .where(eq(organizations.id, childOrganization.id));
+      await addUserToOrganization(childOrganization.id, parentMember.id, 'member');
+
+      try {
+        const caller = await createCallerForUser(parentOwner.id);
+        const result = await caller.organizations.withMembers({
+          organizationId: parentOrganization.id,
+        });
+
+        expect(result.childOrganizations).toEqual([
+          { id: childOrganization.id, name: 'Child Label Organization' },
+        ]);
+        const member = result.members.find(m => m.status === 'active' && m.id === parentMember.id);
+        expect(member).toMatchObject({
+          status: 'active',
+          childOrganizationMemberships: [
+            { id: childOrganization.id, name: 'Child Label Organization', role: 'member' },
+          ],
+        });
+      } finally {
+        await db
+          .update(organizations)
+          .set({ parent_organization_id: null })
+          .where(eq(organizations.id, childOrganization.id));
+        await db.delete(organizations).where(eq(organizations.id, childOrganization.id));
+        await db.delete(organizations).where(eq(organizations.id, parentOrganization.id));
+      }
+    });
+
     it('should reject child organization data for a regular parent organization member', async () => {
       const parentOwner = await insertTestUser({
         google_user_email: 'parent-member-owner-org@example.com',

--- a/apps/web/src/routers/organizations/organization-router.ts
+++ b/apps/web/src/routers/organizations/organization-router.ts
@@ -1,5 +1,6 @@
 import {
   microdollar_usage,
+  organization_memberships,
   organization_seats_purchases,
   organizations,
 } from '@kilocode/db/schema';
@@ -38,7 +39,7 @@ import { organizationsSubscriptionRouter } from '@/routers/organizations/organiz
 import { organizationsSettingsRouter } from '@/routers/organizations/organization-settings-router';
 import { organizationsUsageDetailsRouter } from '@/routers/organizations/organization-usage-details-router';
 import { TRPCError } from '@trpc/server';
-import { and, count, desc, eq, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import * as z from 'zod';
 import { getCreditTransactionsForOrganization } from '@/lib/creditTransactions';
 import { getCreditBlocks } from '@/lib/getCreditBlocks';
@@ -220,14 +221,68 @@ export const organizationsRouter = createTRPCRouter({
       }
     }
 
-    const [members, ssoPolicy] = await Promise.all([
+    const [members, ssoPolicy, childOrganizations] = await Promise.all([
       getOrganizationMembers(organizationId),
       resolveEffectiveOrganizationSsoPolicy(organizationId),
+      db
+        .select({ id: organizations.id, name: organizations.name })
+        .from(organizations)
+        .where(
+          and(
+            eq(organizations.parent_organization_id, organizationId),
+            isNull(organizations.deleted_at)
+          )
+        )
+        .orderBy(organizations.name),
     ]);
+
+    const activeMemberIds = members.flatMap(member =>
+      member.status === 'active' ? [member.id] : []
+    );
+    const childOrganizationIds = childOrganizations.map(child => child.id);
+    const childMembershipRows =
+      activeMemberIds.length > 0 && childOrganizationIds.length > 0
+        ? await db
+            .select({
+              userId: organization_memberships.kilo_user_id,
+              organizationId: organization_memberships.organization_id,
+              role: organization_memberships.role,
+            })
+            .from(organization_memberships)
+            .where(
+              and(
+                inArray(organization_memberships.kilo_user_id, activeMemberIds),
+                inArray(organization_memberships.organization_id, childOrganizationIds)
+              )
+            )
+        : [];
+    const childOrganizationsById = new Map(childOrganizations.map(child => [child.id, child]));
+    const childMembershipsByUserId = new Map<
+      string,
+      Array<{ id: string; name: string; role: (typeof childMembershipRows)[number]['role'] }>
+    >();
+    for (const row of childMembershipRows) {
+      const childOrganization = childOrganizationsById.get(row.organizationId);
+      if (!childOrganization) continue;
+      const existing = childMembershipsByUserId.get(row.userId) ?? [];
+      existing.push({ ...childOrganization, role: row.role });
+      childMembershipsByUserId.set(row.userId, existing);
+    }
+
+    const membersWithChildOrganizations = members.map(member => {
+      if (member.status !== 'active') return member;
+      return {
+        ...member,
+        childOrganizationMemberships: (childMembershipsByUserId.get(member.id) ?? []).sort((a, b) =>
+          a.name.localeCompare(b.name)
+        ),
+      };
+    });
 
     return {
       ...organization,
-      members,
+      members: membersWithChildOrganizations,
+      childOrganizations,
       effectiveSsoPolicy:
         ssoPolicy.status === 'required'
           ? {


### PR DESCRIPTION
## Summary
- Adds child organization labels to the parent organization members table.
- Adds a child teams selector for parent owners/billing managers to assign parent members to direct child orgs.
- Extends organization member APIs and tests to enforce direct-child validation, parent membership requirements, seat checks, and safe handling of elevated child roles.

https://github.com/user-attachments/assets/5694c1c6-1cff-4df3-bb93-ddb64ebf6f9b
