### PR TITLE
fix(ai-gateway): align messages tool repair

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -23,7 +23,7 @@ import { isDeepseekModel } from '@/lib/ai-gateway/providers/deepseek';
 import { isOpenCodeBasedClient, type FraudDetectionHeaders } from '@/lib/utils';
 import { applyTrackingIds } from '@/lib/ai-gateway/providerHash';
 import {
-  repairTools,
+  repairChatCompletionsTools,
   repairMessagesTools,
   sanitizeBinaryToolResults,
 } from '@/lib/ai-gateway/tool-calling';
@@ -130,8 +130,7 @@ export async function applyProviderSpecificLogic(
   if (requestToMutate.kind === 'chat_completions') {
     scrubOpenCodeSpecificProperties(requestToMutate.body);
 
-    // Mostly a workaround for bugs in the old extension.
-    repairTools(requestToMutate.body);
+    repairChatCompletionsTools(requestToMutate.body);
 
     if (isOpenCodeBasedClient(originalHeaders)) {
       // Workaround for bugs in the chat completions client.

--- a/apps/web/src/lib/ai-gateway/tool-calling.test.ts
+++ b/apps/web/src/lib/ai-gateway/tool-calling.test.ts
@@ -4,7 +4,11 @@ import type {
   GatewayResponsesRequest,
   OpenRouterChatCompletionRequest,
 } from '@/lib/ai-gateway/providers/openrouter/types';
-import { repairTools, repairMessagesTools, sanitizeBinaryToolResults } from './tool-calling';
+import {
+  repairChatCompletionsTools,
+  repairMessagesTools,
+  sanitizeBinaryToolResults,
+} from './tool-calling';
 
 function createRequest(
   overrides: Partial<OpenRouterChatCompletionRequest> = {}
@@ -16,7 +20,7 @@ function createRequest(
   };
 }
 
-describe('repairTools', () => {
+describe('repairChatCompletionsTools', () => {
   describe('spurious tool result removal', () => {
     it('should remove tool results without matching tool calls', () => {
       const request = createRequest({
@@ -26,7 +30,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(1);
       expect(request.messages[0]).toEqual({ role: 'user', content: 'Hello' });
@@ -47,7 +51,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(3);
     });
@@ -62,7 +66,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(2);
       expect(request.messages.map(m => m.role)).toEqual(['user', 'assistant']);
@@ -85,7 +89,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(4);
       expect(request.messages[2]).toEqual({
@@ -111,7 +115,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(5);
       expect(request.messages[2]).toEqual({
@@ -143,7 +147,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       // Missing result for call_2 is inserted right after the assistant message
       // So the order becomes: user, assistant, call_2_result (inserted), call_1_result (existing), user
@@ -169,7 +173,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(3);
     });
@@ -196,7 +200,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(6);
       expect(request.messages[2]).toEqual({
@@ -229,7 +233,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       // Orphan removed, missing result inserted
       expect(request.messages).toHaveLength(4);
@@ -278,7 +282,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       // Stray result removed, missing result inserted
       expect(request.messages).toHaveLength(6);
@@ -294,7 +298,7 @@ describe('repairTools', () => {
     it('should handle empty messages array', () => {
       const request = createRequest({ messages: [] });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toEqual([]);
     });
@@ -307,7 +311,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(2);
     });
@@ -320,7 +324,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(2);
     });
@@ -341,7 +345,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(4);
     });
@@ -371,7 +375,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       // All messages should remain - both tool results match their respective tool calls
       expect(request.messages).toHaveLength(6);
@@ -405,7 +409,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(3);
       const assistantMsg = request.messages[1];
@@ -431,7 +435,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(3);
       expect(request.messages[2]).toEqual({
@@ -472,7 +476,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(4);
       const assistantMsg = request.messages[1];
@@ -508,7 +512,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       // Should deduplicate to single tool call, then insert missing result
       expect(request.messages).toHaveLength(4);
@@ -543,7 +547,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       // Duplicate tool calls removed (2 unique), duplicate results removed
       expect(request.messages).toHaveLength(4);
@@ -582,7 +586,7 @@ describe('repairTools', () => {
         ],
       });
 
-      repairTools(request);
+      repairChatCompletionsTools(request);
 
       expect(request.messages).toHaveLength(3);
       const assistantMsg = request.messages[1];
@@ -1041,6 +1045,147 @@ describe('sanitizeBinaryToolResults', () => {
       const user = request.body.messages[1];
       if (user.role !== 'user') throw new Error('expected user');
       expect(user.content).toEqual([{ type: 'tool_result', tool_use_id: 'tu_1', content: 'ok' }]);
+    });
+
+    it('should insert missing tool results before existing results and user content', () => {
+      const request = {
+        model: 'test-model',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'tu_1', name: 'read', input: {} },
+              { type: 'tool_use', id: 'tu_2', name: 'write', input: {} },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              { type: 'tool_result', tool_use_id: 'tu_1', content: 'read result' },
+              { type: 'text', text: 'Continue' },
+            ],
+          },
+        ],
+      } as GatewayMessagesRequest;
+
+      repairMessagesTools(request);
+
+      expect(request.messages[1]).toEqual({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_2',
+            content: 'Tool execution was interrupted before completion.',
+          },
+          { type: 'tool_result', tool_use_id: 'tu_1', content: 'read result' },
+          { type: 'text', text: 'Continue' },
+        ],
+      });
+    });
+
+    it('should keep only the first matching tool result', () => {
+      const request = {
+        model: 'test-model',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tu_1', name: 'read', input: {} }],
+          },
+          {
+            role: 'user',
+            content: [
+              { type: 'tool_result', tool_use_id: 'tu_1', content: 'first' },
+              { type: 'tool_result', tool_use_id: 'tu_1', content: 'duplicate' },
+            ],
+          },
+        ],
+      } as GatewayMessagesRequest;
+
+      repairMessagesTools(request);
+
+      expect(request.messages[1]).toEqual({
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: 'first' }],
+      });
+    });
+
+    it('should scope results to their assistant turn when tool ids are reused', () => {
+      const request = {
+        model: 'test-model',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tu_1', name: 'read', input: {} }],
+          },
+          { role: 'user', content: 'Continue' },
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tu_1', name: 'write', input: {} }],
+          },
+          {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: 'write result' }],
+          },
+        ],
+      } as GatewayMessagesRequest;
+
+      repairMessagesTools(request);
+
+      expect(request.messages).toEqual([
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'tu_1', name: 'read', input: {} }],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu_1',
+              content: 'Tool execution was interrupted before completion.',
+            },
+            { type: 'text', text: 'Continue' },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'tu_1', name: 'write', input: {} }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: 'write result' }],
+        },
+      ]);
+    });
+
+    it('should insert a user message when the final tool use has no result', () => {
+      const request = {
+        model: 'test-model',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tu_1', name: 'read', input: {} }],
+          },
+        ],
+      } as GatewayMessagesRequest;
+
+      repairMessagesTools(request);
+
+      expect(request.messages[1]).toEqual({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_1',
+            content: 'Tool execution was interrupted before completion.',
+          },
+        ],
+      });
     });
 
     it('should preserve content arrays with no duplicates', () => {

--- a/apps/web/src/lib/ai-gateway/tool-calling.ts
+++ b/apps/web/src/lib/ai-gateway/tool-calling.ts
@@ -5,6 +5,7 @@ import type {
   OpenRouterChatCompletionRequest,
 } from '@/lib/ai-gateway/providers/openrouter/types';
 import crypto from 'crypto';
+import type Anthropic from '@anthropic-ai/sdk';
 import type OpenAI from 'openai';
 
 const BINARY_DATA_REPLACEMENT =
@@ -79,7 +80,7 @@ function deduplicateToolUses(assistantMessage: OpenAI.ChatCompletionAssistantMes
     if (toolCallIds.has(toolCall.id)) {
       const toolName = toolCall.type === 'function' ? toolCall.function?.name : 'unknown';
       console.warn(
-        `[repairTools] removing duplicate use of tool ${toolName} with tool call id ${toolCall.id}`
+        `[repairChatCompletionsTools] removing duplicate use of tool ${toolName} with tool call id ${toolCall.id}`
       );
       return false;
     }
@@ -88,7 +89,7 @@ function deduplicateToolUses(assistantMessage: OpenAI.ChatCompletionAssistantMes
   });
 }
 
-export function repairTools(requestToMutate: OpenRouterChatCompletionRequest) {
+export function repairChatCompletionsTools(requestToMutate: OpenRouterChatCompletionRequest) {
   const groups = groupByAssistantMessage(requestToMutate.messages);
 
   for (const group of groups) {
@@ -109,7 +110,7 @@ export function repairTools(requestToMutate: OpenRouterChatCompletionRequest) {
       }
       const toolName = toolCall.type === 'function' ? toolCall.function?.name : 'unknown';
       console.warn(
-        `[repairTools] inserting missing result for tool ${toolName} with tool call id ${toolCall.id}`
+        `[repairChatCompletionsTools] inserting missing result for tool ${toolName} with tool call id ${toolCall.id}`
       );
       missingResults.push({
         role: 'tool',
@@ -123,7 +124,7 @@ export function repairTools(requestToMutate: OpenRouterChatCompletionRequest) {
     group.otherMessages = group.otherMessages.filter(message => {
       if (message.role === 'tool' && !toolCallIdsToVerify.delete(message.tool_call_id)) {
         console.warn(
-          `[repairTools] deleting duplicate/orphan tool result for tool call id ${message.tool_call_id}`
+          `[repairChatCompletionsTools] deleting duplicate/orphan tool result for tool call id ${message.tool_call_id}`
         );
         return false;
       }
@@ -217,42 +218,110 @@ function sanitizeResponsesToolResults(body: GatewayResponsesRequest): void {
   }
 }
 
-export function repairMessagesTools(body: GatewayMessagesRequest): void {
-  for (const msg of body.messages) {
-    if (msg.role !== 'assistant' || !Array.isArray(msg.content)) continue;
-    const toolUseIds = new Set<string>();
-    msg.content = msg.content.filter(block => {
-      if (typeof block !== 'object' || block.type !== 'tool_use') return true;
-      if (toolUseIds.has(block.id)) {
-        console.warn(`[repairMessagesTools] removing duplicate tool_use block with id ${block.id}`);
-        return false;
-      }
-      toolUseIds.add(block.id);
-      return true;
-    });
-  }
+function groupMessagesByAssistant(messages: Anthropic.MessageParam[]) {
+  const groups = new Array<{
+    assistantMessage?: Anthropic.MessageParam;
+    otherMessages: Anthropic.MessageParam[];
+  }>();
 
-  const allToolUseIds = new Set<string>();
-  for (const msg of body.messages) {
-    if (msg.role !== 'assistant' || !Array.isArray(msg.content)) continue;
-    for (const block of msg.content) {
-      if (typeof block === 'object' && block.type === 'tool_use') {
-        allToolUseIds.add(block.id);
-      }
+  groups.push({ otherMessages: [] });
+
+  for (const message of messages) {
+    if (message.role === 'assistant') {
+      groups.push({ assistantMessage: message, otherMessages: [] });
+    } else {
+      groups.at(-1)?.otherMessages.push(message);
     }
   }
 
-  for (const msg of body.messages) {
-    if (msg.role !== 'user' || !Array.isArray(msg.content)) continue;
-    msg.content = msg.content.filter(block => {
-      if (typeof block !== 'object' || block.type !== 'tool_result') return true;
-      if (allToolUseIds.has(block.tool_use_id)) return true;
+  return groups;
+}
+
+function deduplicateMessagesToolUses(message: Anthropic.MessageParam): void {
+  if (!Array.isArray(message.content)) return;
+
+  const toolUseIds = new Set<string>();
+  message.content = message.content.filter(block => {
+    if (block.type !== 'tool_use') return true;
+    if (toolUseIds.has(block.id)) {
       console.warn(
-        `[repairMessagesTools] removing orphan tool_result for tool_use_id ${block.tool_use_id}`
+        `[repairMessagesTools] removing duplicate use of tool ${block.name} with tool call id ${block.id}`
       );
       return false;
-    });
+    }
+    toolUseIds.add(block.id);
+    return true;
+  });
+}
+
+export function repairMessagesTools(body: GatewayMessagesRequest): void {
+  const groups = groupMessagesByAssistant(body.messages);
+
+  for (const group of groups) {
+    if (group.assistantMessage) {
+      deduplicateMessagesToolUses(group.assistantMessage);
+    }
+
+    const toolUses =
+      group.assistantMessage && Array.isArray(group.assistantMessage.content)
+        ? group.assistantMessage.content.filter(block => block.type === 'tool_use')
+        : [];
+    const expectedToolUseIds = new Set(toolUses.map(block => block.id));
+    const matchedToolUseIds = new Set<string>();
+    const existingResults = new Array<Anthropic.ToolResultBlockParam>();
+
+    for (const message of group.otherMessages) {
+      if (!Array.isArray(message.content)) continue;
+      message.content = message.content.filter(block => {
+        if (block.type !== 'tool_result') return true;
+        if (
+          !expectedToolUseIds.has(block.tool_use_id) ||
+          matchedToolUseIds.has(block.tool_use_id)
+        ) {
+          console.warn(
+            `[repairMessagesTools] deleting duplicate/orphan tool result for tool call id ${block.tool_use_id}`
+          );
+          return false;
+        }
+        matchedToolUseIds.add(block.tool_use_id);
+        existingResults.push(block);
+        return false;
+      });
+    }
+
+    const missingResults = new Array<Anthropic.ToolResultBlockParam>();
+    for (const toolUse of toolUses) {
+      if (matchedToolUseIds.has(toolUse.id)) continue;
+      console.warn(
+        `[repairMessagesTools] inserting missing result for tool ${toolUse.name} with tool call id ${toolUse.id}`
+      );
+      missingResults.push({
+        type: 'tool_result',
+        tool_use_id: toolUse.id,
+        content: 'Tool execution was interrupted before completion.',
+      });
+    }
+
+    const results = [...missingResults, ...existingResults];
+    if (results.length > 0) {
+      const firstUserMessage = group.otherMessages[0];
+      if (firstUserMessage) {
+        firstUserMessage.content = Array.isArray(firstUserMessage.content)
+          ? [...results, ...firstUserMessage.content]
+          : [...results, { type: 'text', text: firstUserMessage.content }];
+      } else {
+        group.otherMessages.push({ role: 'user', content: results });
+      }
+    }
+
+    group.otherMessages = group.otherMessages.filter(
+      message => !Array.isArray(message.content) || message.content.length > 0
+    );
   }
+
+  body.messages = groups.flatMap(group =>
+    group.assistantMessage ? [group.assistantMessage, ...group.otherMessages] : group.otherMessages
+  );
 }
 
 function sanitizeMessagesToolResults(body: GatewayMessagesRequest): void {


### PR DESCRIPTION
## Summary

- Make Anthropic Messages tool repair match Chat Completions behavior by inserting interrupted results and removing duplicate or turn-orphaned results.
- Scope tool-use matching to each assistant turn so reused IDs remain valid, while preserving Anthropic result ordering.
- Rename the Chat Completions helper for format clarity and remove the obsolete old-extension comment.

## Verification

- Manual verification not performed; this change repairs serialized gateway request payloads and has no interactive path.

## Visual Changes

N/A

## Reviewer Notes

Responses API repair behavior is intentionally unchanged.