### PR TITLE
fix(config): add notebook permission schema

### DIFF
--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -15,6 +15,7 @@
  *   3. Paste that shape into the right bucket below:
  *        - Top-level: `top`
  *        - New primary agent: `agents`
+ *        - Permission key: `permissions`
  *        - Under `experimental`: `experimental`
  *        - Anywhere else nested: add a new bucket here AND extend the merge
  *          logic in `./route.ts` to overlay that section.
@@ -91,6 +92,11 @@ export const kiloExtras = {
     ask: agentConfig,
     debug: agentConfig,
     orchestrator: agentConfig,
+  },
+  permissions: {
+    notebook_read: { $ref: '#/$defs/PermissionRuleConfig' },
+    notebook_edit: { $ref: '#/$defs/PermissionRuleConfig' },
+    notebook_execute: { $ref: '#/$defs/PermissionRuleConfig' },
   },
   experimental: {
     codebase_search: {

--- a/apps/web/src/app/config.json/route.ts
+++ b/apps/web/src/app/config.json/route.ts
@@ -30,6 +30,21 @@ export function merge(schema: Schema): Schema {
   };
   properties.agent = agent;
 
+  const defs = isObject(schema.$defs) ? { ...schema.$defs } : undefined;
+  if (defs && isObject(defs.PermissionConfig)) {
+    const permissionConfig = { ...defs.PermissionConfig };
+    if (Array.isArray(permissionConfig.anyOf)) {
+      permissionConfig.anyOf = permissionConfig.anyOf.map(variant => {
+        if (!isObject(variant) || !isObject(variant.properties)) return variant;
+        return {
+          ...variant,
+          properties: { ...variant.properties, ...kiloExtras.permissions },
+        };
+      });
+      defs.PermissionConfig = permissionConfig;
+    }
+  }
+
   const experimental = isObject(properties.experimental) ? { ...properties.experimental } : {};
   experimental.properties = {
     ...(isObject(experimental.properties) ? experimental.properties : {}),
@@ -37,7 +52,7 @@ export function merge(schema: Schema): Schema {
   };
   properties.experimental = experimental;
 
-  return { ...schema, properties };
+  return { ...schema, ...(defs ? { $defs: defs } : {}), properties };
 }
 
 export async function GET() {

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -4,6 +4,20 @@ const upstream: Schema = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
   ref: 'Config',
   type: 'object',
+  $defs: {
+    PermissionConfig: {
+      anyOf: [
+        { $ref: '#/$defs/PermissionActionConfig' },
+        {
+          type: 'object',
+          properties: {
+            read: { $ref: '#/$defs/PermissionRuleConfig' },
+          },
+          additionalProperties: { $ref: '#/$defs/PermissionRuleConfig' },
+        },
+      ],
+    },
+  },
   properties: {
     agent: {
       type: 'object',
@@ -73,6 +87,25 @@ describe('kilo config.json schema merge', () => {
     expect(agent.properties.debug).toBeDefined();
     expect(agent.properties.orchestrator).toBeDefined();
     expect(agent.properties.build).toBeDefined(); // upstream key preserved
+  });
+
+  test('adds notebook permission keys without dropping upstream', () => {
+    const defs = out.$defs as Record<string, unknown>;
+    const permissionConfig = defs.PermissionConfig as { anyOf: Array<Record<string, unknown>> };
+    const permissionObject = permissionConfig.anyOf.find(variant => variant.type === 'object') as {
+      properties: Record<string, unknown>;
+    };
+
+    expect(permissionObject.properties.notebook_read).toEqual({
+      $ref: '#/$defs/PermissionRuleConfig',
+    });
+    expect(permissionObject.properties.notebook_edit).toEqual({
+      $ref: '#/$defs/PermissionRuleConfig',
+    });
+    expect(permissionObject.properties.notebook_execute).toEqual({
+      $ref: '#/$defs/PermissionRuleConfig',
+    });
+    expect(permissionObject.properties.read).toBeDefined();
   });
 
   test('adds kilo experimental keys without dropping upstream', () => {


### PR DESCRIPTION
## Summary

- Add `notebook_read`, `notebook_edit`, and `notebook_execute` to Kilo's published CLI permission schema.
- Extend the upstream schema overlay to merge Kilo permission definitions without dropping existing permission keys.
- Add regression coverage for the nested `PermissionConfig` merge.

## Verification

- N/A — schema-only change with no manual user flow.

## Visual Changes

N/A

## Reviewer Notes

Follow-up for Kilo-Org/kilocode#11644 discussion_r3473007520.