### PR TITLE
feat(web): show child organizations on org profile

### DIFF
--- a/apps/web/src/app/api/organizations/hooks.ts
+++ b/apps/web/src/app/api/organizations/hooks.ts
@@ -23,6 +23,22 @@ export function useOrganizationWithMembers(id: string, options?: { enabled?: boo
   );
 }
 
+export function useOrganizationChildren(id: string) {
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.organizations.childOrganizations.queryOptions(
+      { organizationId: id },
+      {
+        trpc: {
+          context: {
+            skipBatch: true,
+          },
+        },
+      }
+    )
+  );
+}
+
 const useInvalidateOrganizationAndMembers = () => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();

--- a/apps/web/src/components/organizations/OrganizationChildOrganizationsCard.tsx
+++ b/apps/web/src/components/organizations/OrganizationChildOrganizationsCard.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import Link from 'next/link';
+import { Building2, ChevronRight } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { useOrganizationChildren } from '@/app/api/organizations/hooks';
+
+type Props = {
+  organizationId: string;
+};
+
+export function OrganizationChildOrganizationsCard({ organizationId }: Props) {
+  const { data: children } = useOrganizationChildren(organizationId);
+
+  // Only show the card when there is at least one child organization. While
+  // loading, on error, or when empty, render nothing so the layout stays clean.
+  if (!children || children.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Building2 className="mr-2 inline h-5 w-5" />
+          Child Organizations
+        </CardTitle>
+        <CardDescription>
+          {children.length} child organization{children.length === 1 ? '' : 's'} belong to this
+          organization
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-0.5">
+          {children.map(child => (
+            <Link
+              key={child.id}
+              prefetch={false}
+              href={`/organizations/${encodeURIComponent(child.id)}`}
+              className="hover:bg-surface-hover focus-visible:ring-ring -mx-2 flex items-center justify-between gap-3 rounded-md px-2 py-1.5 text-sm transition-colors focus-visible:ring-1 focus-visible:outline-none"
+            >
+              <span className="truncate font-medium" title={child.name}>
+                {child.name}
+              </span>
+              <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+            </Link>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/organizations/OrganizationChildOrganizationsCard.tsx
+++ b/apps/web/src/components/organizations/OrganizationChildOrganizationsCard.tsx
@@ -2,13 +2,7 @@
 
 import Link from 'next/link';
 import { Building2, ChevronRight } from 'lucide-react';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useOrganizationChildren } from '@/app/api/organizations/hooks';
 
 type Props = {

--- a/apps/web/src/components/organizations/OrganizationDashboard.tsx
+++ b/apps/web/src/components/organizations/OrganizationDashboard.tsx
@@ -18,6 +18,7 @@ import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { MessageCircleQuestion, Terminal } from 'lucide-react';
 import { OrganizationProvidersAndModelsConfigurationCard } from '@/components/organizations/OrganizationProvidersAndModelsConfigurationCard';
+import { OrganizationChildOrganizationsCard } from '@/components/organizations/OrganizationChildOrganizationsCard';
 import { OrganizationEmailPreferencesCard } from '@/components/organizations/OrganizationEmailPreferencesCard';
 import { OrgActiveKiloclawsCard } from '@/components/organizations/OrgActiveKiloclawsCard';
 import { OpenInExtensionButton } from '@/components/auth/OpenInExtensionButton';
@@ -141,6 +142,9 @@ export function OrganizationDashboard({
             <LockableContainer>
               <OrganizationInfoCard organizationId={organizationId} />
             </LockableContainer>
+            {(currentRole === 'owner' || currentRole === 'billing_manager') && (
+              <OrganizationChildOrganizationsCard organizationId={organizationId} />
+            )}
             {organizationData && (
               <>
                 {organizationData.plan === 'teams' ? (

--- a/apps/web/src/routers/organizations/organization-router.ts
+++ b/apps/web/src/routers/organizations/organization-router.ts
@@ -38,7 +38,7 @@ import { organizationsSubscriptionRouter } from '@/routers/organizations/organiz
 import { organizationsSettingsRouter } from '@/routers/organizations/organization-settings-router';
 import { organizationsUsageDetailsRouter } from '@/routers/organizations/organization-usage-details-router';
 import { TRPCError } from '@trpc/server';
-import { and, count, desc, eq, sql } from 'drizzle-orm';
+import { and, asc, count, desc, eq, isNull, sql } from 'drizzle-orm';
 import * as z from 'zod';
 import { getCreditTransactionsForOrganization } from '@/lib/creditTransactions';
 import { getCreditBlocks } from '@/lib/getCreditBlocks';
@@ -243,6 +243,24 @@ export const organizationsRouter = createTRPCRouter({
               configurationError: ssoPolicy.status === 'misconfigured',
             },
     };
+  }),
+
+  // Child organizations parented by this organization. Restricted to
+  // owner/billing_manager because only those roles inherit access to children.
+  childOrganizations: organizationBillingProcedure.query(async opts => {
+    return await db
+      .select({
+        id: organizations.id,
+        name: organizations.name,
+      })
+      .from(organizations)
+      .where(
+        and(
+          eq(organizations.parent_organization_id, opts.input.organizationId),
+          isNull(organizations.deleted_at)
+        )
+      )
+      .orderBy(asc(organizations.name));
   }),
 
   update: organizationBillingMutationProcedure


### PR DESCRIPTION
## Summary
- Adds a **Child Organizations** card to the organization profile page (`OrganizationDashboard`), placed in the left column between *Organization Information* and *Providers and Models*.
- The card lists organizations parented by the current org, linking each to its own profile page. It only renders when at least one child org exists.
- Visibility is restricted to **owner / billing_manager** roles (the roles that inherit access to child orgs). This is enforced server-side via a new `organizations.childOrganizations` tRPC query using `organizationBillingProcedure`, not just in the UI.

## Screenshots
<img width="2298" height="1600" alt="CleanShot 2026-06-25 at 10 50 30@2x" src="https://github.com/user-attachments/assets/9657e1fa-cc2f-441e-bc84-0fc7cabee7bc" />
