### PR TITLE
fix(config): add notebook experiment schema

### DIFF
--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -103,6 +103,10 @@ export const kiloExtras = {
       description: 'Enable AI-powered codebase search',
       type: 'boolean',
     },
+    native_notebook_tools: {
+      description: 'Enable native tools for reading, editing, and executing VS Code notebooks',
+      type: 'boolean',
+    },
     openTelemetry: {
       description: 'Enable telemetry. Set to false to opt-out.',
       default: true,

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -111,6 +111,9 @@ describe('kilo config.json schema merge', () => {
   test('adds kilo experimental keys without dropping upstream', () => {
     const exp = props.experimental as { properties: Record<string, unknown> };
     expect(exp.properties.codebase_search).toBeDefined();
+    expect(exp.properties.native_notebook_tools).toEqual(
+      expect.objectContaining({ type: 'boolean' })
+    );
     expect(exp.properties.openTelemetry).toBeDefined();
     expect(exp.properties.batch_tool).toBeDefined(); // upstream key preserved
   });


### PR DESCRIPTION
## Summary

Add the `experimental.native_notebook_tools` boolean to the published Kilo config schema so the explicit opt-in introduced by Kilo-Org/kilocode#11644 is recognized by `$schema: https://app.kilo.ai/config.json`.

## Verification

N/A

## Visual Changes

N/A

## Reviewer Notes

The focused schema test could not complete locally because the test Postgres instance was unavailable; it reached the suite setup and failed during database cleanup.
