### PR TITLE
test(gateway): verify Parakeet transcription compatibility

### DIFF
--- a/apps/web/src/app/api/openrouter/audio/transcriptions/route.test.ts
+++ b/apps/web/src/app/api/openrouter/audio/transcriptions/route.test.ts
@@ -121,6 +121,39 @@ describe('POST /api/gateway/v1/audio/transcriptions', () => {
     });
   });
 
+  it('proxies Parakeet requests without prompt conditioning', async () => {
+    setUserAuth();
+    mockedFetch.mockResolvedValue(
+      makeUpstreamResponse({
+        text: 'hello world',
+        model: 'nvidia/parakeet-tdt-0.6b-v3',
+        usage: { seconds: 60, cost: 0.0015, is_byok: false },
+      })
+    );
+
+    const { POST } = await import('./route');
+    const response = await POST(
+      makeRequest({
+        model: 'nvidia/parakeet-tdt-0.6b-v3',
+        input_audio: { data: 'UklGRiQA', format: 'wav' },
+        language: 'en',
+      }) as never
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      text: 'hello world',
+      model: 'nvidia/parakeet-tdt-0.6b-v3',
+    });
+
+    const [, init] = mockedFetch.mock.calls[0];
+    const upstream = JSON.parse(init?.body as string);
+    expect(upstream.model).toBe('nvidia/parakeet-tdt-0.6b-v3');
+    expect(upstream.input_audio).toEqual({ data: 'UklGRiQA', format: 'wav' });
+    expect(upstream.language).toBe('en');
+    expect(upstream.prompt).toBeUndefined();
+  });
+
   it('forwards organization provider policy through the OpenRouter provider field', async () => {
     setUserAuth();
     mockedGetBalanceAndOrgSettings.mockResolvedValue({

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
@@ -817,6 +817,26 @@ describe('parseTranscriptionUsageFromResponse', () => {
     expect(result.generation_time).toBe(2.5);
   });
 
+  it('accounts for duration-priced Parakeet responses without token fields', () => {
+    const result = parseTranscriptionUsageFromResponse(
+      makeResponse({
+        model: 'nvidia/parakeet-tdt-0.6b-v3',
+        usage: { seconds: 60, cost: 0.0015, is_byok: false },
+      }),
+      200,
+      'nvidia/parakeet-tdt-0.6b-v3'
+    );
+
+    expect(result).toMatchObject({
+      model: 'nvidia/parakeet-tdt-0.6b-v3',
+      cost_mUsd: 1500,
+      inputTokens: 0,
+      outputTokens: 0,
+      generation_time: 60,
+      hasError: false,
+    });
+  });
+
   it('falls back to requested model when response model is absent', () => {
     const parsed = JSON.parse(makeResponse());
     delete parsed.model;


### PR DESCRIPTION
## Summary

OpenRouter now exposes `nvidia/parakeet-tdt-0.6b-v3` through the audio transcription endpoint already used by Kilo Gateway. Add regression coverage confirming that the generic proxy forwards the Parakeet model, audio, and language without introducing model-specific routing or prompt conditioning.

Cover Parakeet's duration-priced response shape so OpenRouter cost and audio duration remain accounted for when token counts are absent. Keeping this behavior model-agnostic avoids a static allowlist that would drift as OpenRouter adds transcription models.

## Verification

N/A. This PR adds regression coverage for existing proxy behavior.

## Visual Changes

N/A

## Reviewer Notes

No production routing or billing logic changes. The covered risks are rejecting the model identifier, adding incompatible prompt conditioning, or assuming every transcription response includes token counts. Companion client support is in Kilo-Org/kilocode#11693.