### PR TITLE
feat(gateway): expose efficient auto routing models

### DIFF
--- a/apps/web/src/app/api/openrouter/models/route.test.ts
+++ b/apps/web/src/app/api/openrouter/models/route.test.ts
@@ -9,6 +9,7 @@ import { addUserByokAvailability, getUserByokProviderIds } from '@/lib/ai-gatewa
 import { getAvailableModelsForOrganization } from '@/lib/organizations/organization-models';
 import { GET } from './route';
 import { getBenchmarkRoutingTable } from '@/lib/ai-gateway/auto-routing-benchmark-admin-client';
+import { getAutoFreeCandidates } from '@/lib/ai-gateway/auto-model/resolution';
 
 jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
 jest.mock('@/lib/user/server', () => ({ getUserFromAuth: jest.fn() }));
@@ -31,6 +32,9 @@ jest.mock('@/lib/organizations/organization-models', () => ({
 jest.mock('@/lib/ai-gateway/auto-routing-benchmark-admin-client', () => ({
   getBenchmarkRoutingTable: jest.fn(),
 }));
+jest.mock('@/lib/ai-gateway/auto-model/resolution', () => ({
+  getAutoFreeCandidates: jest.fn(),
+}));
 jest.mock('@/lib/drizzle', () => ({ readDb: {} }));
 
 const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
@@ -41,6 +45,7 @@ const mockedAddUserByokAvailability = jest.mocked(addUserByokAvailability);
 const mockedGetUserByokProviderIds = jest.mocked(getUserByokProviderIds);
 const mockedGetAvailableModelsForOrganization = jest.mocked(getAvailableModelsForOrganization);
 const mockedGetBenchmarkRoutingTable = jest.mocked(getBenchmarkRoutingTable);
+const mockedGetAutoFreeCandidates = jest.mocked(getAutoFreeCandidates);
 
 function makeModel(id: string): OpenRouterModel {
   return {
@@ -80,6 +85,7 @@ describe('GET /api/openrouter/models', () => {
       status: 200,
       body: { table: null, publishedAt: null },
     });
+    mockedGetAutoFreeCandidates.mockResolvedValue([]);
   });
 
   test('leaves BYOK availability undefined for unauthenticated requests', async () => {
@@ -115,14 +121,20 @@ describe('GET /api/openrouter/models', () => {
     });
   });
 
-  test('adds efficient auto-routing models from the published routing table', async () => {
+  test('adds auto-routing models from routing sources', async () => {
     const efficientModel = makeModel('kilo-auto/efficient');
+    const freeModel = makeModel('kilo-auto/free');
     const balancedModel = makeModel('kilo-auto/balanced');
     const geminiModel = makeModel('google/gemini-2.5-flash');
     const gptMiniModel = makeModel('openai/gpt-5.4-mini');
+    const poolsideModel = makeModel('poolside/laguna-m.1:free');
     mockedGetEnhancedOpenRouterModels.mockResolvedValue({
-      data: [efficientModel, balancedModel, geminiModel, gptMiniModel],
+      data: [efficientModel, freeModel, balancedModel, geminiModel, gptMiniModel, poolsideModel],
     });
+    mockedGetAutoFreeCandidates.mockResolvedValue([
+      'poolside/laguna-m.1:free',
+      'missing/free-model',
+    ]);
     mockedGetBenchmarkRoutingTable.mockResolvedValue({
       status: 200,
       body: {
@@ -152,9 +164,16 @@ describe('GET /api/openrouter/models', () => {
             models: ['google/gemini-2.5-flash', 'openai/gpt-5.4-mini'],
           },
         },
+        {
+          ...freeModel,
+          autoRouting: {
+            models: ['poolside/laguna-m.1:free'],
+          },
+        },
         balancedModel,
         geminiModel,
         gptMiniModel,
+        poolsideModel,
       ],
     });
   });

--- a/apps/web/src/app/api/openrouter/models/route.test.ts
+++ b/apps/web/src/app/api/openrouter/models/route.test.ts
@@ -8,6 +8,7 @@ import { listAvailableExperimentModels } from '@/lib/ai-gateway/experiments/list
 import { addUserByokAvailability, getUserByokProviderIds } from '@/lib/ai-gateway/byok';
 import { getAvailableModelsForOrganization } from '@/lib/organizations/organization-models';
 import { GET } from './route';
+import { getBenchmarkRoutingTable } from '@/lib/ai-gateway/auto-routing-benchmark-admin-client';
 
 jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
 jest.mock('@/lib/user/server', () => ({ getUserFromAuth: jest.fn() }));
@@ -27,6 +28,9 @@ jest.mock('@/lib/ai-gateway/byok', () => ({
 jest.mock('@/lib/organizations/organization-models', () => ({
   getAvailableModelsForOrganization: jest.fn(),
 }));
+jest.mock('@/lib/ai-gateway/auto-routing-benchmark-admin-client', () => ({
+  getBenchmarkRoutingTable: jest.fn(),
+}));
 jest.mock('@/lib/drizzle', () => ({ readDb: {} }));
 
 const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
@@ -36,6 +40,7 @@ const mockedListAvailableExperimentModels = jest.mocked(listAvailableExperimentM
 const mockedAddUserByokAvailability = jest.mocked(addUserByokAvailability);
 const mockedGetUserByokProviderIds = jest.mocked(getUserByokProviderIds);
 const mockedGetAvailableModelsForOrganization = jest.mocked(getAvailableModelsForOrganization);
+const mockedGetBenchmarkRoutingTable = jest.mocked(getBenchmarkRoutingTable);
 
 function makeModel(id: string): OpenRouterModel {
   return {
@@ -71,6 +76,10 @@ describe('GET /api/openrouter/models', () => {
     mockedListAvailableExperimentModels.mockResolvedValue([]);
     mockedGetUserByokProviderIds.mockResolvedValue([]);
     mockedGetAvailableModelsForOrganization.mockResolvedValue(null);
+    mockedGetBenchmarkRoutingTable.mockResolvedValue({
+      status: 200,
+      body: { table: null, publishedAt: null },
+    });
   });
 
   test('leaves BYOK availability undefined for unauthenticated requests', async () => {
@@ -103,6 +112,50 @@ describe('GET /api/openrouter/models', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       data: [{ ...publicModel, hasUserByokAvailable: true }, directModel, experimentModel],
+    });
+  });
+
+  test('adds efficient auto-routing models from the published routing table', async () => {
+    const efficientModel = makeModel('kilo-auto/efficient');
+    const balancedModel = makeModel('kilo-auto/balanced');
+    const geminiModel = makeModel('google/gemini-2.5-flash');
+    const gptMiniModel = makeModel('openai/gpt-5.4-mini');
+    mockedGetEnhancedOpenRouterModels.mockResolvedValue({
+      data: [efficientModel, balancedModel, geminiModel, gptMiniModel],
+    });
+    mockedGetBenchmarkRoutingTable.mockResolvedValue({
+      status: 200,
+      body: {
+        table: {
+          routes: {
+            'implementation/code_generation': [
+              { model: 'google/gemini-2.5-flash' },
+              { model: 'openai/gpt-5.4-mini' },
+            ],
+            'analysis/debugging': [
+              { model: 'kilo-auto/balanced' },
+              { model: 'google/gemini-2.5-flash' },
+            ],
+          },
+        },
+      },
+    } as never);
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      data: [
+        {
+          ...efficientModel,
+          autoRouting: {
+            models: ['google/gemini-2.5-flash', 'openai/gpt-5.4-mini'],
+          },
+        },
+        balancedModel,
+        geminiModel,
+        gptMiniModel,
+      ],
     });
   });
 });

--- a/apps/web/src/app/api/openrouter/models/route.ts
+++ b/apps/web/src/app/api/openrouter/models/route.ts
@@ -25,6 +25,12 @@ async function tryGetUserFromAuth() {
   }
 }
 
+function visibleConcreteModelIds(models: Iterable<string>, availableModelIds: ReadonlySet<string>) {
+  return [
+    ...new Set([...models].filter(id => availableModelIds.has(id) && !isVirtualAutoModelId(id))),
+  ].sort((left, right) => left.localeCompare(right));
+}
+
 async function addAutoRoutingModels(models: OpenRouterModelsResponse['data']) {
   const availableModelIds = new Set(models.map(model => model.id));
   const [routingTableResult, autoFreeCandidates] = await Promise.all([
@@ -36,32 +42,22 @@ async function addAutoRoutingModels(models: OpenRouterModelsResponse['data']) {
     routingTableResult?.status === 200 && 'table' in routingTableResult.body
       ? routingTableResult.body.table
       : null;
-  const efficientModelIds = table
-    ? [
-        ...new Set(
-          Object.values(table.routes)
-            .flat()
-            .map(candidate => candidate.model)
-            .filter(model => availableModelIds.has(model) && !isVirtualAutoModelId(model))
-        ),
-      ].sort((left, right) => left.localeCompare(right))
-    : [];
-  const freeModelIds = [
-    ...new Set(
-      autoFreeCandidates.filter(
-        model => availableModelIds.has(model) && !isVirtualAutoModelId(model)
-      )
-    ),
-  ].sort((left, right) => left.localeCompare(right));
-  if (efficientModelIds.length === 0 && freeModelIds.length === 0) return models;
-
-  return models.map(model =>
-    model.id === KILO_AUTO_EFFICIENT_MODEL.id && efficientModelIds.length > 0
-      ? { ...model, autoRouting: { models: efficientModelIds } }
-      : model.id === KILO_AUTO_FREE_MODEL.id && freeModelIds.length > 0
-        ? { ...model, autoRouting: { models: freeModelIds } }
-        : model
+  const efficientModelIds = visibleConcreteModelIds(
+    Object.values(table?.routes ?? {})
+      .flat()
+      .map(candidate => candidate.model),
+    availableModelIds
   );
+  const freeModelIds = visibleConcreteModelIds(autoFreeCandidates, availableModelIds);
+  const autoRoutingChoices = new Map([
+    [KILO_AUTO_EFFICIENT_MODEL.id, efficientModelIds],
+    [KILO_AUTO_FREE_MODEL.id, freeModelIds],
+  ]);
+
+  return models.map(model => {
+    const modelIds = autoRoutingChoices.get(model.id);
+    return modelIds?.length ? { ...model, autoRouting: { models: modelIds } } : model;
+  });
 }
 
 /**

--- a/apps/web/src/app/api/openrouter/models/route.ts
+++ b/apps/web/src/app/api/openrouter/models/route.ts
@@ -12,7 +12,8 @@ import { listAvailableExperimentModels } from '@/lib/ai-gateway/experiments/list
 import { addUserByokAvailability, getUserByokProviderIds } from '@/lib/ai-gateway/byok';
 import { readDb } from '@/lib/drizzle';
 import { getBenchmarkRoutingTable } from '@/lib/ai-gateway/auto-routing-benchmark-admin-client';
-import { KILO_AUTO_EFFICIENT_MODEL } from '@/lib/ai-gateway/auto-model';
+import { KILO_AUTO_EFFICIENT_MODEL, KILO_AUTO_FREE_MODEL } from '@/lib/ai-gateway/auto-model';
+import { getAutoFreeCandidates } from '@/lib/ai-gateway/auto-model/resolution';
 import { isVirtualAutoModelId } from '@kilocode/auto-routing-contracts';
 
 async function tryGetUserFromAuth() {
@@ -24,26 +25,42 @@ async function tryGetUserFromAuth() {
   }
 }
 
-async function addEfficientRoutingModels(models: OpenRouterModelsResponse['data']) {
-  const result = await getBenchmarkRoutingTable().catch(() => null);
-  const table = result?.status === 200 && 'table' in result.body ? result.body.table : null;
-  if (!table) return models;
-
+async function addAutoRoutingModels(models: OpenRouterModelsResponse['data']) {
   const availableModelIds = new Set(models.map(model => model.id));
-  const modelIds = [
+  const [routingTableResult, autoFreeCandidates] = await Promise.all([
+    getBenchmarkRoutingTable().catch(() => null),
+    getAutoFreeCandidates(null).catch(() => []),
+  ]);
+
+  const table =
+    routingTableResult?.status === 200 && 'table' in routingTableResult.body
+      ? routingTableResult.body.table
+      : null;
+  const efficientModelIds = table
+    ? [
+        ...new Set(
+          Object.values(table.routes)
+            .flat()
+            .map(candidate => candidate.model)
+            .filter(model => availableModelIds.has(model) && !isVirtualAutoModelId(model))
+        ),
+      ].sort((left, right) => left.localeCompare(right))
+    : [];
+  const freeModelIds = [
     ...new Set(
-      Object.values(table.routes)
-        .flat()
-        .map(candidate => candidate.model)
-        .filter(model => availableModelIds.has(model) && !isVirtualAutoModelId(model))
+      autoFreeCandidates.filter(
+        model => availableModelIds.has(model) && !isVirtualAutoModelId(model)
+      )
     ),
   ].sort((left, right) => left.localeCompare(right));
-  if (modelIds.length === 0) return models;
+  if (efficientModelIds.length === 0 && freeModelIds.length === 0) return models;
 
   return models.map(model =>
-    model.id === KILO_AUTO_EFFICIENT_MODEL.id
-      ? { ...model, autoRouting: { models: modelIds } }
-      : model
+    model.id === KILO_AUTO_EFFICIENT_MODEL.id && efficientModelIds.length > 0
+      ? { ...model, autoRouting: { models: efficientModelIds } }
+      : model.id === KILO_AUTO_FREE_MODEL.id && freeModelIds.length > 0
+        ? { ...model, autoRouting: { models: freeModelIds } }
+        : model
   );
 }
 
@@ -61,7 +78,7 @@ export async function GET(
       ? await getAvailableModelsForOrganization(auth.organizationId)
       : null;
     if (result) {
-      const models = await addEfficientRoutingModels(result.data);
+      const models = await addAutoRoutingModels(result.data);
       return NextResponse.json({
         ...result,
         data: filterByFeature(models, feature),
@@ -72,7 +89,7 @@ export async function GET(
     if (!Array.isArray(data.data)) {
       return NextResponse.json(data);
     }
-    const models = await addEfficientRoutingModels(data.data);
+    const models = await addAutoRoutingModels(data.data);
     if (!auth?.user) {
       const experimentModels = await listAvailableExperimentModels();
       return NextResponse.json({

--- a/apps/web/src/app/api/openrouter/models/route.ts
+++ b/apps/web/src/app/api/openrouter/models/route.ts
@@ -11,6 +11,9 @@ import { filterByFeature } from '@/lib/ai-gateway/models';
 import { listAvailableExperimentModels } from '@/lib/ai-gateway/experiments/list-available-experiment-models';
 import { addUserByokAvailability, getUserByokProviderIds } from '@/lib/ai-gateway/byok';
 import { readDb } from '@/lib/drizzle';
+import { getBenchmarkRoutingTable } from '@/lib/ai-gateway/auto-routing-benchmark-admin-client';
+import { KILO_AUTO_EFFICIENT_MODEL } from '@/lib/ai-gateway/auto-model';
+import { isVirtualAutoModelId } from '@kilocode/auto-routing-contracts';
 
 async function tryGetUserFromAuth() {
   try {
@@ -19,6 +22,29 @@ async function tryGetUserFromAuth() {
     console.error('[tryGetUserFromAuth] failed to get user from auth', e);
     return { user: null, organizationId: null };
   }
+}
+
+async function addEfficientRoutingModels(models: OpenRouterModelsResponse['data']) {
+  const result = await getBenchmarkRoutingTable().catch(() => null);
+  const table = result?.status === 200 && 'table' in result.body ? result.body.table : null;
+  if (!table) return models;
+
+  const availableModelIds = new Set(models.map(model => model.id));
+  const modelIds = [
+    ...new Set(
+      Object.values(table.routes)
+        .flat()
+        .map(candidate => candidate.model)
+        .filter(model => availableModelIds.has(model) && !isVirtualAutoModelId(model))
+    ),
+  ].sort((left, right) => left.localeCompare(right));
+  if (modelIds.length === 0) return models;
+
+  return models.map(model =>
+    model.id === KILO_AUTO_EFFICIENT_MODEL.id
+      ? { ...model, autoRouting: { models: modelIds } }
+      : model
+  );
 }
 
 /**
@@ -35,9 +61,10 @@ export async function GET(
       ? await getAvailableModelsForOrganization(auth.organizationId)
       : null;
     if (result) {
+      const models = await addEfficientRoutingModels(result.data);
       return NextResponse.json({
         ...result,
-        data: filterByFeature(result.data, feature),
+        data: filterByFeature(models, feature),
       });
     }
 
@@ -45,10 +72,11 @@ export async function GET(
     if (!Array.isArray(data.data)) {
       return NextResponse.json(data);
     }
+    const models = await addEfficientRoutingModels(data.data);
     if (!auth?.user) {
       const experimentModels = await listAvailableExperimentModels();
       return NextResponse.json({
-        data: filterByFeature(data.data.concat(experimentModels), feature),
+        data: filterByFeature(models.concat(experimentModels), feature),
       });
     }
 
@@ -58,7 +86,7 @@ export async function GET(
       getUserByokProviderIds(readDb, auth.user.id),
     ]);
     const modelsWithByokAvailability = await addUserByokAvailability(
-      data.data,
+      models,
       enabledByokProviderIds
     );
     return NextResponse.json({

--- a/apps/web/src/lib/organizations/organization-types.ts
+++ b/apps/web/src/lib/organizations/organization-types.ts
@@ -221,6 +221,11 @@ const OpenRouterModelSchema = z.object({
   isFree: z.boolean().optional(),
   mayTrainOnYourPrompts: z.boolean().optional(),
   hasUserByokAvailable: z.boolean().optional(),
+  autoRouting: z
+    .object({
+      models: z.array(z.string()),
+    })
+    .optional(),
   terminalBench: z
     .object({
       overallScore: z.number(),


### PR DESCRIPTION
## Summary

- Adds `autoRouting.models` metadata to the `kilo-auto/efficient` model in `/api/openrouter/models`.
- Populates the list from the published benchmark routing table using concrete model ids already present in the model response.
- Keeps other auto models unchanged because they are not benchmark-table backed.

## Verification

- Ran local web with a mock benchmark routing table and verified `curl -s http://localhost:3000/api/openrouter/models | jq '.data[] | select(.id=="kilo-auto/efficient" or .id=="kilo-auto/free") | {id, autoRouting}'` returned concrete `autoRouting.models`.

```
  {
    "id": "kilo-auto/efficient",
    "autoRouting": {
      "models": [
        "anthropic/claude-sonnet-4.6",
        "openai/gpt-5.5"
      ]
    }
  }
  {
    "id": "kilo-auto/free",
    "autoRouting": {
      "models": [
        "stepfun/step-3.7-flash:free"
      ]
    }
  }
```

- Comman

## Visual Changes

N/A

## Reviewer Notes

- `autoRouting.models` is omitted when no benchmark routing table is published or no concrete candidate ids are present.
- Virtual `kilo-auto/*` candidates are excluded from the exposed model list.
