### PR TITLE
fix(extension): stop side panel auth query resolving to undefined

### DIFF
--- a/apps/extension/entrypoints/sidepanel/app.tsx
+++ b/apps/extension/entrypoints/sidepanel/app.tsx
@@ -50,8 +50,11 @@ export const App = (): JSX.Element => {
     isSuccess: isStoredAuthSuccess,
     refetch: refetchStoredAuth,
   } = useQuery({
-    queryFn: () => loadStoredAuth(storage),
+    // React Query forbids a queryFn resolving to undefined, but "no stored auth" is the
+    // common signed-out state; return null from the fn and map it back to undefined for the UI.
+    queryFn: async () => (await loadStoredAuth(storage)) ?? null,
     queryKey: storedAuthQueryKey,
+    select: data => data ?? undefined,
   });
   const {
     data: authValidationData,


### PR DESCRIPTION
## Problem

Logging in via the browser extension side panel throws:

> Query data cannot be undefined. Please make sure to return a value other than undefined from your query function. Affected query key: ["side-panel","stored-auth"]

`loadStoredAuth` returns `undefined` for the normal signed-out state, but React Query v5 rejects a `queryFn` that resolves to `undefined`.

## Fix

Return `null` from the `queryFn` and map it back to `undefined` via `select`, so the rest of the component keeps seeing `StoredAuth | undefined` exactly as before — no other code paths change.