### PR TITLE
feat(extension): context usage donut and compaction

### DIFF
--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -1,0 +1,116 @@
+name: extension CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/extension/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/extension-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/extension/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/extension-ci.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  # Compiler, linter, formatting and unit tests, via the extension's own `verify`
+  # script so the extension's stricter (type-aware) oxlint config is what runs.
+  verify:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    steps:
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify (typecheck, lint, format, unit tests)
+        run: pnpm --filter kilo-extension verify
+
+  # Prove the Firefox MV3 target still builds (the Chrome build runs inside e2e).
+  build-firefox:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    steps:
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build (Firefox MV3)
+        run: pnpm --filter kilo-extension build:firefox
+
+  # Chrome end-to-end tests. `e2e:chrome` builds the Chrome MV3 bundle first, so this
+  # also covers the Chrome build. Firefox Selenium e2e (`e2e:firefox`) is intentionally
+  # not run here: it relies on geckodriver tab detection that is unreliable headless.
+  e2e-chrome:
+    needs: verify
+    runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
+    timeout-minutes: 20
+    env:
+      CI: 'true'
+    steps:
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter kilo-extension exec playwright install --with-deps chromium
+
+      - name: Run Chrome e2e (builds the Chrome MV3 bundle first)
+        run: pnpm --filter kilo-extension e2e:chrome
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: extension-playwright-report
+          path: |
+            apps/extension/playwright-report
+            apps/extension/test-results
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -6,12 +6,16 @@ on:
     paths:
       - 'apps/extension/**'
       - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.nvmrc'
       - '.github/workflows/extension-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'apps/extension/**'
       - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.nvmrc'
       - '.github/workflows/extension-ci.yml'
 
 concurrency:

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -36,16 +36,27 @@ interface ChromeRuntimeApi {
 /*
  * Trust boundary for the eval/debugger message path. Today only the extension's own pages (the
  * side panel) can reach this listener — there is no externally_connectable and no content script.
- * Accept only same-extension, non-tab senders so adding either later can't silently widen access
- * to the dangerous eval path. Content scripts carry a `tab`; external pages carry a different `id`.
+ * Accept only same-extension senders whose origin is this extension, so adding a content script
+ * later can't silently widen access to the dangerous eval path: a content script shares the
+ * extension `id` but reports the host page's origin, while an extension page reports
+ * `chrome-extension://<id>`.
  */
 const isTrustedExtensionSender = (sender: unknown, runtimeId: string | undefined): boolean => {
   if (runtimeId === undefined || typeof sender !== 'object' || sender === null) {
     return false;
   }
 
-  const { id, tab } = sender as { id?: unknown; tab?: unknown };
-  return id === runtimeId && tab === undefined;
+  const { id, origin, url } = sender as { id?: unknown; origin?: unknown; url?: unknown };
+
+  if (id !== runtimeId) {
+    return false;
+  }
+
+  const extensionOrigin = `chrome-extension://${runtimeId}`;
+
+  return (
+    origin === extensionOrigin || (typeof url === 'string' && url.startsWith(`${extensionOrigin}/`))
+  );
 };
 
 const handleTabDebuggerRequest = async ({

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -36,11 +36,15 @@ interface ChromeRuntimeApi {
 /*
  * Trust boundary for the eval/debugger message path. Today only the extension's own pages (the
  * side panel) can reach this listener — there is no externally_connectable and no content script.
- * Accept only same-extension senders whose origin is this extension, so adding a content script
+ * Accept only same-extension senders whose origin is an extension page, so adding a content script
  * later can't silently widen access to the dangerous eval path: a content script shares the
- * extension `id` but reports the host page's origin, while an extension page reports
- * `chrome-extension://<id>`.
+ * extension `id` but reports the host page's web origin, while an extension page reports an
+ * extension-scheme origin (`chrome-extension://` on Chrome, `moz-extension://` on Firefox).
  */
+const isExtensionScheme = (value: unknown): boolean =>
+  typeof value === 'string' &&
+  (value.startsWith('chrome-extension://') || value.startsWith('moz-extension://'));
+
 const isTrustedExtensionSender = (sender: unknown, runtimeId: string | undefined): boolean => {
   if (runtimeId === undefined || typeof sender !== 'object' || sender === null) {
     return false;
@@ -48,15 +52,8 @@ const isTrustedExtensionSender = (sender: unknown, runtimeId: string | undefined
 
   const { id, origin, url } = sender as { id?: unknown; origin?: unknown; url?: unknown };
 
-  if (id !== runtimeId) {
-    return false;
-  }
-
-  const extensionOrigin = `chrome-extension://${runtimeId}`;
-
-  return (
-    origin === extensionOrigin || (typeof url === 'string' && url.startsWith(`${extensionOrigin}/`))
-  );
+  // Same-extension is already pinned by `id === runtimeId`, so origin only separates an extension page from a content script.
+  return id === runtimeId && (isExtensionScheme(origin) || isExtensionScheme(url));
 };
 
 const handleTabDebuggerRequest = async ({

--- a/apps/extension/entrypoints/sidepanel/agent-chat-atoms.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-atoms.ts
@@ -1,0 +1,15 @@
+import { atom } from 'jotai';
+import { atomFamily } from 'jotai-family';
+import type { ContextUsage } from '@/src/shared/context-usage';
+
+// Per-conversation in-memory draft text (reset on reload by design).
+export const draftAtomFamily = atomFamily((_conversationId: string) => atom(''));
+
+// Per-conversation context usage from the latest gateway turn (in-memory only).
+export const contextUsageAtomFamily = atomFamily((_conversationId: string) =>
+  atom<ContextUsage | undefined>()
+);
+
+// Ids of conversations with an in-flight run / compaction.
+export const runningConversationIdsAtom = atom<readonly string[]>([]);
+export const compactingConversationIdsAtom = atom<readonly string[]>([]);

--- a/apps/extension/entrypoints/sidepanel/agent-chat-atoms.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-atoms.ts
@@ -1,13 +1,13 @@
-import { atom } from 'jotai';
+import { atom, getDefaultStore } from 'jotai';
 import { atomFamily } from 'jotai-family';
 import type { ContextUsage } from '@/src/shared/context-usage';
 
 // Per-conversation in-memory draft text (reset on reload by design).
-// Keys for closed-but-not-deleted conversations are kept for the session so their drafts survive reopen; the set is small and resets on reload.
+// Keys for closed-but-not-deleted conversations are kept so their drafts survive reopen; evicted on delete and on sign-out.
 export const draftAtomFamily = atomFamily((_conversationId: string) => atom(''));
 
 // Per-conversation context usage from the latest gateway turn (in-memory only).
-// Keys for closed-but-not-deleted conversations are kept for the session; only deleted conversations have their keys evicted via .remove().
+// Same lifecycle as drafts: kept across close, evicted on delete and on sign-out.
 export const contextUsageAtomFamily = atomFamily((_conversationId: string) =>
   atom<ContextUsage | undefined>()
 );
@@ -15,3 +15,25 @@ export const contextUsageAtomFamily = atomFamily((_conversationId: string) =>
 // Ids of conversations with an in-flight run / compaction.
 export const runningConversationIdsAtom = atom<readonly string[]>([]);
 export const compactingConversationIdsAtom = atom<readonly string[]>([]);
+
+// Evict a single conversation's in-memory atoms (draft + context usage).
+export const evictConversationAtoms = (conversationId: string): void => {
+  draftAtomFamily.remove(conversationId);
+  contextUsageAtomFamily.remove(conversationId);
+};
+
+/*
+ * Drop all per-conversation in-memory state. Called on sign-out so a different
+ * account on the same profile (no reload) never inherits the prior user's
+ * drafts/usage — conversation ids are deterministic (conversation-1, ...), so
+ * the atom families would otherwise hand back the old account's values.
+ */
+export const clearPerConversationAtoms = (): void => {
+  const ids = new Set([...draftAtomFamily.getParams(), ...contextUsageAtomFamily.getParams()]);
+  for (const id of ids) {
+    evictConversationAtoms(id);
+  }
+  const store = getDefaultStore();
+  store.set(runningConversationIdsAtom, []);
+  store.set(compactingConversationIdsAtom, []);
+};

--- a/apps/extension/entrypoints/sidepanel/agent-chat-atoms.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-atoms.ts
@@ -3,9 +3,11 @@ import { atomFamily } from 'jotai-family';
 import type { ContextUsage } from '@/src/shared/context-usage';
 
 // Per-conversation in-memory draft text (reset on reload by design).
+// Keys for closed-but-not-deleted conversations are kept for the session so their drafts survive reopen; the set is small and resets on reload.
 export const draftAtomFamily = atomFamily((_conversationId: string) => atom(''));
 
 // Per-conversation context usage from the latest gateway turn (in-memory only).
+// Keys for closed-but-not-deleted conversations are kept for the session; only deleted conversations have their keys evicted via .remove().
 export const contextUsageAtomFamily = atomFamily((_conversationId: string) =>
   atom<ContextUsage | undefined>()
 );

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -179,7 +179,7 @@ export const AgentChatPanel = ({
   onHeaderBeforeSettingsChange?: (node?: ReactNode) => void;
   organizationId: string | undefined;
 }): JSX.Element => {
-  const [draft, setDraft] = useState('');
+  const [draftsByConversation, setDraftsByConversation] = useState<Record<string, string>>({});
   const [conversationStore, setConversationStore, isConversationStoreLoaded] =
     useStoredAgentConversations(createDefaultConversationEvents);
   const [runningConversationIds, setRunningConversationIds] = useState<string[]>([]);
@@ -193,6 +193,11 @@ export const AgentChatPanel = ({
   });
   const activeConversation = getActiveStoredConversation(conversationStore);
   const { events, id: activeConversationId, mode = defaultMode } = activeConversation;
+  // Ponytail: drafts are in-memory only; they reset on reload like the rest of transient UI state.
+  const draft = draftsByConversation[activeConversationId] ?? '';
+  const setActiveDraft = (value: string): void => {
+    setDraftsByConversation(current => ({ ...current, [activeConversationId]: value }));
+  };
   const selectedTabId = getSelectedInspectableTabId({
     inspectableTabs,
     selectedTabId: activeConversation.selectedTabId,
@@ -455,7 +460,7 @@ export const AgentChatPanel = ({
       return;
     }
 
-    setDraft('');
+    setDraftsByConversation(current => ({ ...current, [activeConversationId]: '' }));
     submitMessage(text);
   };
 
@@ -475,7 +480,6 @@ export const AgentChatPanel = ({
       thinkingEffort,
     };
 
-    setDraft('');
     conversationStoreRef.current = createNextStoredConversation(
       conversationStoreRef.current,
       createDefaultConversationEvents(),
@@ -549,7 +553,6 @@ export const AgentChatPanel = ({
         return;
       }
 
-      setDraft('');
       setConversationStore(store =>
         openStoredConversation({
           conversationId,
@@ -622,7 +625,7 @@ export const AgentChatPanel = ({
           className="min-h-20 w-full resize-none rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm leading-5 text-zinc-100 outline-none transition placeholder:text-zinc-600 focus:border-[#EDFF00] focus:ring-2 focus:ring-[#EDFF00]/30"
           id="agent-message"
           onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
-            setDraft(event.currentTarget.value);
+            setActiveDraft(event.currentTarget.value);
           }}
           onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
             if (event.key === 'Enter' && !event.shiftKey) {

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -190,7 +190,7 @@ export const AgentChatPanel = ({
         });
 
         if (compacted !== undefined) {
-          // Ponytail: wholesale replace is safe only because the conversation can't receive new events while compacting (guarded above + send disabled). Reconcile against currentEvents if that ever changes.
+          // Wholesale replace is safe only because the conversation can't receive new events while compacting (guarded above + send disabled). Reconcile against currentEvents if that ever changes.
           setConversationStore(currentStore =>
             updateStoredConversationEvents(currentStore, conversationId, () => compacted)
           );
@@ -200,7 +200,7 @@ export const AgentChatPanel = ({
         setCompactingConversationIds(current => current.filter(id => id !== conversationId));
       }
     },
-    // Ponytail: compaction is a single short gateway call; no abort wiring until it proves slow.
+    // Compaction is a single short gateway call; no abort wiring until it proves slow.
     [
       auth.token,
       isConversationStoreLoaded,

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -270,6 +270,7 @@ export const AgentChatPanel = ({
         });
 
         if (compacted !== undefined) {
+          // Ponytail: wholesale replace is safe only because the conversation can't receive new events while compacting (guarded above + send disabled). Reconcile against currentEvents if that ever changes.
           setConversationStore(store =>
             updateStoredConversationEvents(store, conversationId, () => compacted)
           );

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -7,6 +7,7 @@ import {
   groupConversationEvents,
 } from '@/src/shared/agent-conversation';
 import type { AgentConversationEvent } from '@/src/shared/agent-conversation';
+import { compactConversationEvents } from '@/src/shared/agent-context-compaction';
 import { defaultMode } from '@/src/shared/agent-chat-placeholder';
 import { getKiloApiBaseUrl } from '@/src/shared/auth';
 import type { StoredAuth } from '@/src/shared/auth';
@@ -31,6 +32,7 @@ import { AgentFooterControls } from './agent-footer-controls';
 import { ContextDonut } from './context-donut';
 import { runDangerousLlmTurn, runSafeLlmTurn } from './agent-turn-runners';
 import type { ContextUsage } from '@/src/shared/context-usage';
+import { AUTO_COMPACT_RATIO, getContextRatio } from '@/src/shared/context-usage';
 import { useTabDebugger } from './use-tab-debugger';
 import { ConversationList } from './conversation-list';
 import { ConversationHistoryButton } from './conversation-history-button';
@@ -39,8 +41,6 @@ import { useGatewayModels } from './use-gateway-models';
 const apiBaseUrl = getKiloApiBaseUrl();
 const fetchFromWindow = (input: string, init?: RequestInit): Promise<Response> =>
   fetch(input, init);
-// Ponytail: stub, replaced in compaction task
-const compactActiveConversation = async (): Promise<void> => {};
 const createDefaultConversationEvents = (): AgentConversationEvent[] => [
   createAssistantMessage('Pick a tab and ask Kilo to inspect it.'),
 ];
@@ -89,20 +89,20 @@ export const formatSelectedTabSystemEnvironment = ({
 
 const ConversationTabs = ({
   activeConversationId,
+  busyConversationIds,
   conversations,
   isDisabled,
   onCloseConversation,
   onCreateConversation,
   onSelectConversation,
-  runningConversationIds,
 }: {
   activeConversationId: string;
+  busyConversationIds: readonly string[];
   conversations: StoredAgentConversation[];
   isDisabled: boolean;
   onCloseConversation: (conversationId: string) => void;
   onCreateConversation: () => void;
   onSelectConversation: (conversationId: string) => void;
-  runningConversationIds: readonly string[];
 }): JSX.Element => (
   <div className="border-b border-zinc-900 bg-zinc-950">
     <div
@@ -113,7 +113,7 @@ const ConversationTabs = ({
       {conversations.map(conversation => {
         const title = getStoredConversationTitle(conversation);
         const isActive = conversation.id === activeConversationId;
-        const isRunning = runningConversationIds.includes(conversation.id);
+        const isRunning = busyConversationIds.includes(conversation.id);
 
         return (
           <div
@@ -191,9 +191,12 @@ export const AgentChatPanel = ({
   const [conversationStore, setConversationStore, isConversationStoreLoaded] =
     useStoredAgentConversations(createDefaultConversationEvents);
   const [runningConversationIds, setRunningConversationIds] = useState<string[]>([]);
+  const [compactingConversationIds, setCompactingConversationIds] = useState<string[]>([]);
   const conversationStoreRef = useRef(conversationStore);
   const runStatesRef = useRef(new Map<string, ConversationRunState>());
   const runTokenRef = useRef(0);
+  // Ponytail: ref mirror exists only because auto-compact reads usage synchronously in the run's finally.
+  const latestUsageRef = useRef<Record<string, ContextUsage>>({});
   const { inspectableTabs, isLoadingTabs, tabDebuggerError } = useTabDebugger();
   const { modelLoadError, modelOptions, refetchModels } = useGatewayModels({
     auth,
@@ -230,13 +233,80 @@ export const AgentChatPanel = ({
   );
   const thinkingEffort = activeConversation.thinkingEffort ?? thinkingOptions[0] ?? '';
   const isRunning = runningConversationIds.includes(activeConversationId);
+  const isCompacting = compactingConversationIds.includes(activeConversationId);
   const activeUsage = contextUsageByConversation[activeConversationId];
   const activePromptTokens = activeUsage?.promptTokens ?? 0;
   const contextLength = selectedModel?.contextLength;
+
+  const compactConversation = useCallback(
+    async (conversationId: string): Promise<void> => {
+      if (
+        !isConversationStoreLoaded ||
+        runningConversationIds.includes(conversationId) ||
+        compactingConversationIds.includes(conversationId)
+      ) {
+        return;
+      }
+
+      const conversation = conversationStoreRef.current.conversations.find(
+        item => item.id === conversationId
+      );
+      const runModel = conversation?.model ?? modelOptions[0]?.id ?? '';
+
+      if (conversation === undefined || runModel === '') {
+        return;
+      }
+
+      setCompactingConversationIds(current => [...current, conversationId]);
+
+      try {
+        const compacted = await compactConversationEvents({
+          apiBaseUrl,
+          events: conversation.events,
+          fetch: fetchFromWindow,
+          model: runModel,
+          organizationId,
+          token: auth.token,
+        });
+
+        if (compacted !== undefined) {
+          setConversationStore(store =>
+            updateStoredConversationEvents(store, conversationId, () => compacted)
+          );
+          const nextRef = { ...latestUsageRef.current };
+          delete nextRef[conversationId];
+          latestUsageRef.current = nextRef;
+          setContextUsageByConversation(current => {
+            const next = { ...current };
+            delete next[conversationId];
+            return next;
+          });
+        }
+      } finally {
+        setCompactingConversationIds(current => current.filter(id => id !== conversationId));
+      }
+    },
+    // Ponytail: compaction is a single short gateway call; no abort wiring until it proves slow.
+    [
+      auth.token,
+      compactingConversationIds,
+      isConversationStoreLoaded,
+      modelOptions,
+      organizationId,
+      runningConversationIds,
+      setConversationStore,
+    ]
+  );
+
+  const compactActiveConversation = useCallback(
+    (): Promise<void> => compactConversation(activeConversationId),
+    [activeConversationId, compactConversation]
+  );
+
   const contextDonut = useMemo(
     () => (
       <ContextDonut
-        canCompact={!isRunning && activePromptTokens > 0}
+        canCompact={!isRunning && !isCompacting && activePromptTokens > 0}
         contextLength={contextLength}
         onCompact={() => {
           void compactActiveConversation();
@@ -244,7 +314,12 @@ export const AgentChatPanel = ({
         promptTokens={activePromptTokens}
       />
     ),
-    [activePromptTokens, contextLength, isRunning]
+    [activePromptTokens, compactActiveConversation, contextLength, isCompacting, isRunning]
+  );
+
+  const busyConversationIds = useMemo(
+    () => [...runningConversationIds, ...compactingConversationIds],
+    [compactingConversationIds, runningConversationIds]
   );
   const isModelSelectDisabled = modelOptions.length === 0;
   const isThinkingSelectDisabled = thinkingOptions.length === 0;
@@ -253,7 +328,8 @@ export const AgentChatPanel = ({
     !isConversationStoreLoaded ||
     draft.trim() === '' ||
     modelControlValue === '' ||
-    selectedTabId === undefined;
+    selectedTabId === undefined ||
+    isCompacting;
 
   conversationStoreRef.current = conversationStore;
 
@@ -426,6 +502,10 @@ export const AgentChatPanel = ({
     };
     const updateRunUsage = (usage: { promptTokens: number }): void => {
       if (isCurrentRun()) {
+        latestUsageRef.current = {
+          ...latestUsageRef.current,
+          [conversationId]: { promptTokens: usage.promptTokens },
+        };
         setContextUsageByConversation(current => ({
           ...current,
           [conversationId]: { promptTokens: usage.promptTokens },
@@ -468,6 +548,16 @@ export const AgentChatPanel = ({
           setRunningConversationIds(currentIds =>
             currentIds.filter(currentId => currentId !== conversationId)
           );
+
+          const latest = latestUsageRef.current[conversationId]?.promptTokens ?? 0;
+          const runContextLength = modelOptions.find(
+            option => option.id === runModel
+          )?.contextLength;
+          const ratio = getContextRatio(latest, runContextLength);
+
+          if (ratio !== undefined && ratio >= AUTO_COMPACT_RATIO) {
+            void compactConversation(conversationId);
+          }
         }
       }
     })();
@@ -631,12 +721,12 @@ export const AgentChatPanel = ({
     <div className="flex min-h-0 flex-1 flex-col">
       <ConversationTabs
         activeConversationId={activeConversationId}
+        busyConversationIds={busyConversationIds}
         conversations={openConversations}
         isDisabled={!isConversationStoreLoaded}
         onCloseConversation={closeConversation}
         onCreateConversation={createConversation}
         onSelectConversation={selectConversation}
-        runningConversationIds={runningConversationIds}
       />
       <ConversationList items={groupedEvents} />
 

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/max-dependencies, max-lines */
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import type { ChangeEvent, JSX, KeyboardEvent, ReactNode } from 'react';
+import type { JSX, ReactNode } from 'react';
 import { useAtomValue, useSetAtom, useStore } from 'jotai';
 import {
   compactingConversationIdsAtom,
@@ -30,7 +30,6 @@ import {
   getActiveStoredConversation,
   getOpenStoredConversations,
   getSortedStoredConversationHistory,
-  getStoredConversationTitle,
   isStoredConversationEmpty,
   isStoredConversationOpen,
   openStoredConversation,
@@ -39,13 +38,14 @@ import {
   updateStoredConversationSettings,
   useStoredAgentConversations,
 } from './agent-conversation-storage';
-import type { StoredAgentConversation } from './agent-conversation-storage';
 import { AgentFooterControls } from './agent-footer-controls';
 import { ContextDonut } from './context-donut';
 import { runDangerousLlmTurn, runSafeLlmTurn } from './agent-turn-runners';
 import { AUTO_COMPACT_RATIO, getContextRatio } from '@/src/shared/context-usage';
 import { useTabDebugger } from './use-tab-debugger';
 import { ConversationList } from './conversation-list';
+import { ConversationTabs } from './conversation-tabs';
+import { MessageComposer } from './message-composer';
 import { ConversationHistoryButton } from './conversation-history-button';
 import { useGatewayModels } from './use-gateway-models';
 
@@ -98,93 +98,6 @@ export const formatSelectedTabSystemEnvironment = ({
 }): string =>
   `<system_environment>\nSelected tab title: ${sanitizeTabContextText(title)}\nSelected tab URL: ${sanitizeTabContextUrl(url)}\nCurrent time: ${new Date().toISOString()}\nTimezone: ${new Intl.DateTimeFormat().resolvedOptions().timeZone}\n</system_environment>`;
 
-const ConversationTabs = ({
-  activeConversationId,
-  busyConversationIds,
-  conversations,
-  isDisabled,
-  onCloseConversation,
-  onCreateConversation,
-  onSelectConversation,
-}: {
-  activeConversationId: string;
-  busyConversationIds: readonly string[];
-  conversations: StoredAgentConversation[];
-  isDisabled: boolean;
-  onCloseConversation: (conversationId: string) => void;
-  onCreateConversation: () => void;
-  onSelectConversation: (conversationId: string) => void;
-}): JSX.Element => (
-  <div className="border-b border-zinc-900 bg-zinc-950">
-    <div
-      aria-label="Conversation tabs"
-      className="agent-conversation-scrollbar flex min-w-0 items-center gap-1 overflow-x-auto px-2 py-2"
-      role="tablist"
-    >
-      {conversations.map(conversation => {
-        const title = getStoredConversationTitle(conversation);
-        const isActive = conversation.id === activeConversationId;
-        const isRunning = busyConversationIds.includes(conversation.id);
-
-        return (
-          <div
-            className={
-              isActive
-                ? 'flex h-8 max-w-44 shrink-0 items-center rounded-md border border-[#EDFF00]/70 bg-zinc-900 text-zinc-50'
-                : 'flex h-8 max-w-44 shrink-0 items-center rounded-md border border-zinc-800 bg-zinc-950 text-zinc-400 hover:border-zinc-700 hover:text-zinc-100'
-            }
-            key={conversation.id}
-          >
-            <button
-              aria-selected={isActive}
-              className="flex h-full min-w-0 items-center gap-1.5 px-2 text-left text-xs font-medium outline-none focus:ring-2 focus:ring-[#EDFF00]/50 disabled:cursor-not-allowed disabled:text-zinc-600"
-              disabled={isDisabled}
-              onClick={() => {
-                onSelectConversation(conversation.id);
-              }}
-              role="tab"
-              title={title}
-              type="button"
-            >
-              {isRunning ? (
-                <span
-                  aria-hidden="true"
-                  className="size-2 shrink-0 animate-pulse rounded-full bg-[#EDFF00]"
-                />
-              ) : null}
-              <span className="truncate">{title}</span>
-            </button>
-            <button
-              aria-label={`Close ${title}`}
-              className="mr-1 flex size-6 shrink-0 items-center justify-center rounded-sm text-zinc-500 outline-none transition hover:bg-zinc-800 hover:text-zinc-100 focus:ring-2 focus:ring-[#EDFF00]/50"
-              disabled={isDisabled}
-              onClick={() => {
-                onCloseConversation(conversation.id);
-              }}
-              type="button"
-            >
-              <span aria-hidden="true" className="text-sm leading-none">
-                x
-              </span>
-            </button>
-          </div>
-        );
-      })}
-      <button
-        aria-label="New conversation"
-        className="flex size-8 shrink-0 items-center justify-center rounded-md border border-zinc-800 bg-zinc-950 text-zinc-300 outline-none transition hover:border-zinc-700 hover:bg-zinc-900 hover:text-zinc-100 focus:ring-2 focus:ring-[#EDFF00]/50 disabled:cursor-not-allowed disabled:text-zinc-600"
-        disabled={isDisabled}
-        onClick={onCreateConversation}
-        type="button"
-      >
-        <span aria-hidden="true" className="text-lg leading-none">
-          +
-        </span>
-      </button>
-    </div>
-  </div>
-);
-
 export const AgentChatPanel = ({
   auth,
   onHeaderBeforeSettingsChange,
@@ -212,7 +125,6 @@ export const AgentChatPanel = ({
   const activeConversation = getActiveStoredConversation(conversationStore);
   const { events, id: activeConversationId, mode = defaultMode } = activeConversation;
   const draft = useAtomValue(draftAtomFamily(activeConversationId));
-  const setActiveDraft = useSetAtom(draftAtomFamily(activeConversationId));
   const selectedTabId = getSelectedInspectableTabId({
     inspectableTabs,
     selectedTabId: activeConversation.selectedTabId,
@@ -335,19 +247,14 @@ export const AgentChatPanel = ({
     ]
   );
 
-  const busyConversationIds = useMemo(
-    () => [...runningConversationIds, ...compactingConversationIds],
-    [compactingConversationIds, runningConversationIds]
-  );
   const isModelSelectDisabled = modelOptions.length === 0;
   const isThinkingSelectDisabled = thinkingOptions.length === 0;
   const modelControlValue = modelOptions.length === 0 ? '' : model;
-  const isSendDisabled =
-    !isConversationStoreLoaded ||
-    draft.trim() === '' ||
-    modelControlValue === '' ||
-    selectedTabId === undefined ||
-    isCompacting;
+  const canSend =
+    isConversationStoreLoaded &&
+    modelControlValue !== '' &&
+    selectedTabId !== undefined &&
+    !isCompacting;
 
   conversationStoreRef.current = conversationStore;
 
@@ -741,7 +648,6 @@ export const AgentChatPanel = ({
     <div className="flex min-h-0 flex-1 flex-col">
       <ConversationTabs
         activeConversationId={activeConversationId}
-        busyConversationIds={busyConversationIds}
         conversations={openConversations}
         isDisabled={!isConversationStoreLoaded}
         onCloseConversation={closeConversation}
@@ -750,42 +656,13 @@ export const AgentChatPanel = ({
       />
       <ConversationList items={groupedEvents} />
 
-      <form
-        className="border-t border-zinc-900 px-4 py-3"
-        onSubmit={event => {
-          event.preventDefault();
-          submitDraft();
-        }}
-      >
-        <label className="sr-only" htmlFor="agent-message">
-          Message agent
-        </label>
-        <textarea
-          className="min-h-20 w-full resize-none rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm leading-5 text-zinc-100 outline-none transition placeholder:text-zinc-600 focus:border-[#EDFF00] focus:ring-2 focus:ring-[#EDFF00]/30"
-          id="agent-message"
-          onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
-            setActiveDraft(event.currentTarget.value);
-          }}
-          onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
-            if (event.key === 'Enter' && !event.shiftKey) {
-              event.preventDefault();
-              submitDraft();
-            }
-          }}
-          placeholder="Ask Kilo to inspect this tab..."
-          value={draft}
-        />
-        <div className="mt-2 grid gap-2">
-          <button
-            className="h-9 w-full rounded-md bg-[#EDFF00] px-3 text-sm font-semibold text-zinc-950 transition hover:bg-[#d9ea00] focus:outline-none focus:ring-2 focus:ring-[#EDFF00] focus:ring-offset-2 focus:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:bg-zinc-800 disabled:text-zinc-500"
-            disabled={isRunning ? false : isSendDisabled}
-            onClick={isRunning ? stopRun : undefined}
-            type={isRunning ? 'button' : 'submit'}
-          >
-            {isRunning ? 'Stop' : 'Send message'}
-          </button>
-        </div>
-      </form>
+      <MessageComposer
+        activeConversationId={activeConversationId}
+        canSend={canSend}
+        isRunning={isRunning}
+        onStop={stopRun}
+        onSubmit={submitDraft}
+      />
 
       <footer className="border-t border-zinc-900 bg-zinc-950 px-4 py-2">
         <AgentFooterControls

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -614,6 +614,7 @@ export const AgentChatPanel = ({
           evictConversationAtoms(conversation.id);
         }
       }
+      conversationStoreRef.current = nextStore;
       setConversationStore(nextStore);
     },
     [isConversationStoreLoaded, setConversationStore, store]

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -124,7 +124,6 @@ export const AgentChatPanel = ({
   });
   const activeConversation = getActiveStoredConversation(conversationStore);
   const { events, id: activeConversationId, mode = defaultMode } = activeConversation;
-  const draft = useAtomValue(draftAtomFamily(activeConversationId));
   const selectedTabId = getSelectedInspectableTabId({
     inspectableTabs,
     selectedTabId: activeConversation.selectedTabId,
@@ -482,7 +481,7 @@ export const AgentChatPanel = ({
   };
 
   const submitDraft = (): void => {
-    const text = draft.trim();
+    const text = store.get(draftAtomFamily(activeConversationId)).trim();
     const conversation = getActiveStoredConversation(conversationStoreRef.current);
     const conversationModel = conversation.model ?? modelOptions[0]?.id ?? '';
     const conversationSelectedTabId = getSelectedInspectableTabId({
@@ -587,6 +586,9 @@ export const AgentChatPanel = ({
       setConversationStore(currentStore =>
         deleteStoredConversation(currentStore, conversationId, createDefaultConversationEvents())
       );
+      // Free per-conversation atoms; a deleted conversation can never be reopened.
+      draftAtomFamily.remove(conversationId);
+      contextUsageAtomFamily.remove(conversationId);
     },
     [abortConversationRun, conversationStore, isConversationStoreLoaded, setConversationStore]
   );

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -1,6 +1,13 @@
 /* eslint-disable import/max-dependencies, max-lines */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { ChangeEvent, JSX, KeyboardEvent, ReactNode } from 'react';
+import { useAtomValue, useSetAtom, useStore } from 'jotai';
+import {
+  compactingConversationIdsAtom,
+  contextUsageAtomFamily,
+  draftAtomFamily,
+  runningConversationIdsAtom,
+} from './agent-chat-atoms';
 import {
   createAssistantMessage,
   createUserMessage,
@@ -36,7 +43,6 @@ import type { StoredAgentConversation } from './agent-conversation-storage';
 import { AgentFooterControls } from './agent-footer-controls';
 import { ContextDonut } from './context-donut';
 import { runDangerousLlmTurn, runSafeLlmTurn } from './agent-turn-runners';
-import type { ContextUsage } from '@/src/shared/context-usage';
 import { AUTO_COMPACT_RATIO, getContextRatio } from '@/src/shared/context-usage';
 import { useTabDebugger } from './use-tab-debugger';
 import { ConversationList } from './conversation-list';
@@ -188,20 +194,16 @@ export const AgentChatPanel = ({
   onHeaderBeforeSettingsChange?: (node?: ReactNode) => void;
   organizationId: string | undefined;
 }): JSX.Element => {
-  const [draftsByConversation, setDraftsByConversation] = useState<Record<string, string>>({});
-  // Ponytail: in-memory only, recomputed from the next gateway turn after reload.
-  const [contextUsageByConversation, setContextUsageByConversation] = useState<
-    Record<string, ContextUsage>
-  >({});
+  const store = useStore();
   const [conversationStore, setConversationStore, isConversationStoreLoaded] =
     useStoredAgentConversations(createDefaultConversationEvents);
-  const [runningConversationIds, setRunningConversationIds] = useState<string[]>([]);
-  const [compactingConversationIds, setCompactingConversationIds] = useState<string[]>([]);
+  const runningConversationIds = useAtomValue(runningConversationIdsAtom);
+  const setRunningConversationIds = useSetAtom(runningConversationIdsAtom);
+  const compactingConversationIds = useAtomValue(compactingConversationIdsAtom);
+  const setCompactingConversationIds = useSetAtom(compactingConversationIdsAtom);
   const conversationStoreRef = useRef(conversationStore);
   const runStatesRef = useRef(new Map<string, ConversationRunState>());
   const runTokenRef = useRef(0);
-  // Ponytail: ref mirror exists only because auto-compact reads usage synchronously in the run's finally.
-  const latestUsageRef = useRef<Record<string, ContextUsage>>({});
   const { inspectableTabs, isLoadingTabs, tabDebuggerError } = useTabDebugger();
   const { modelLoadError, modelOptions, refetchModels } = useGatewayModels({
     auth,
@@ -209,11 +211,8 @@ export const AgentChatPanel = ({
   });
   const activeConversation = getActiveStoredConversation(conversationStore);
   const { events, id: activeConversationId, mode = defaultMode } = activeConversation;
-  // Ponytail: drafts are in-memory only; they reset on reload like the rest of transient UI state.
-  const draft = draftsByConversation[activeConversationId] ?? '';
-  const setActiveDraft = (value: string): void => {
-    setDraftsByConversation(current => ({ ...current, [activeConversationId]: value }));
-  };
+  const draft = useAtomValue(draftAtomFamily(activeConversationId));
+  const setActiveDraft = useSetAtom(draftAtomFamily(activeConversationId));
   const selectedTabId = getSelectedInspectableTabId({
     inspectableTabs,
     selectedTabId: activeConversation.selectedTabId,
@@ -239,7 +238,7 @@ export const AgentChatPanel = ({
   const thinkingEffort = activeConversation.thinkingEffort ?? thinkingOptions[0] ?? '';
   const isRunning = runningConversationIds.includes(activeConversationId);
   const isCompacting = compactingConversationIds.includes(activeConversationId);
-  const activeUsage = contextUsageByConversation[activeConversationId];
+  const activeUsage = useAtomValue(contextUsageAtomFamily(activeConversationId));
   const activePromptTokens = activeUsage?.promptTokens ?? 0;
   const contextLength = selectedModel?.contextLength;
 
@@ -250,8 +249,8 @@ export const AgentChatPanel = ({
     ): Promise<void> => {
       if (
         !isConversationStoreLoaded ||
-        runningConversationIds.includes(conversationId) ||
-        compactingConversationIds.includes(conversationId)
+        store.get(runningConversationIdsAtom).includes(conversationId) ||
+        store.get(compactingConversationIdsAtom).includes(conversationId)
       ) {
         return;
       }
@@ -280,17 +279,10 @@ export const AgentChatPanel = ({
 
         if (compacted !== undefined) {
           // Ponytail: wholesale replace is safe only because the conversation can't receive new events while compacting (guarded above + send disabled). Reconcile against currentEvents if that ever changes.
-          setConversationStore(store =>
-            updateStoredConversationEvents(store, conversationId, () => compacted)
+          setConversationStore(currentStore =>
+            updateStoredConversationEvents(currentStore, conversationId, () => compacted)
           );
-          const nextRef = { ...latestUsageRef.current };
-          delete nextRef[conversationId];
-          latestUsageRef.current = nextRef;
-          setContextUsageByConversation(current => {
-            const next = { ...current };
-            delete next[conversationId];
-            return next;
-          });
+          store.set(contextUsageAtomFamily(conversationId), undefined);
         }
       } finally {
         setCompactingConversationIds(current => current.filter(id => id !== conversationId));
@@ -299,12 +291,12 @@ export const AgentChatPanel = ({
     // Ponytail: compaction is a single short gateway call; no abort wiring until it proves slow.
     [
       auth.token,
-      compactingConversationIds,
       isConversationStoreLoaded,
       modelOptions,
       organizationId,
-      runningConversationIds,
       setConversationStore,
+      setCompactingConversationIds,
+      store,
     ]
   );
 
@@ -392,8 +384,8 @@ export const AgentChatPanel = ({
       return;
     }
 
-    setConversationStore(store =>
-      updateStoredConversationSettings(store, activeConversationId, {
+    setConversationStore(currentStore =>
+      updateStoredConversationSettings(currentStore, activeConversationId, {
         selectedTabId: nextSelectedTabId,
       })
     );
@@ -410,8 +402,8 @@ export const AgentChatPanel = ({
     }
 
     if (!modelOptions.some(option => option.id === model)) {
-      setConversationStore(store =>
-        updateStoredConversationSettings(store, activeConversationId, {
+      setConversationStore(currentStore =>
+        updateStoredConversationSettings(currentStore, activeConversationId, {
           model: modelOptions[0]?.id ?? '',
         })
       );
@@ -424,8 +416,8 @@ export const AgentChatPanel = ({
     }
 
     if (!thinkingOptions.includes(thinkingEffort)) {
-      setConversationStore(store =>
-        updateStoredConversationSettings(store, activeConversationId, {
+      setConversationStore(currentStore =>
+        updateStoredConversationSettings(currentStore, activeConversationId, {
           thinkingEffort: thinkingOptions[0] ?? '',
         })
       );
@@ -433,8 +425,8 @@ export const AgentChatPanel = ({
   }, [activeConversationId, setConversationStore, thinkingEffort, thinkingOptions]);
 
   const appendEvents = (conversationId: string, nextEvents: AgentConversationEvent[]): void => {
-    setConversationStore(store =>
-      updateStoredConversationEvents(store, conversationId, currentEvents => [
+    setConversationStore(currentStore =>
+      updateStoredConversationEvents(currentStore, conversationId, currentEvents => [
         ...currentEvents,
         ...nextEvents,
       ])
@@ -442,8 +434,8 @@ export const AgentChatPanel = ({
   };
 
   const updateAssistantMessage = (conversationId: string, eventId: string, text: string): void => {
-    setConversationStore(store =>
-      updateStoredConversationEvents(store, conversationId, currentEvents =>
+    setConversationStore(currentStore =>
+      updateStoredConversationEvents(currentStore, conversationId, currentEvents =>
         currentEvents.map(event =>
           event.id === eventId && event.type === 'message' && event.role === 'assistant'
             ? { ...event, text }
@@ -454,8 +446,8 @@ export const AgentChatPanel = ({
   };
 
   const updateThinkingBlock = (conversationId: string, eventId: string, text: string): void => {
-    setConversationStore(store =>
-      updateStoredConversationEvents(store, conversationId, currentEvents =>
+    setConversationStore(currentStore =>
+      updateStoredConversationEvents(currentStore, conversationId, currentEvents =>
         currentEvents.map(event =>
           event.id === eventId && event.type === 'thinking' ? { ...event, text } : event
         )
@@ -475,8 +467,8 @@ export const AgentChatPanel = ({
       conversationStoreRef.current.activeConversationId,
       settings
     );
-    setConversationStore(store =>
-      updateStoredConversationSettings(store, store.activeConversationId, settings)
+    setConversationStore(currentStore =>
+      updateStoredConversationSettings(currentStore, currentStore.activeConversationId, settings)
     );
   };
 
@@ -528,14 +520,7 @@ export const AgentChatPanel = ({
     };
     const updateRunUsage = (usage: { promptTokens: number }): void => {
       if (isCurrentRun()) {
-        latestUsageRef.current = {
-          ...latestUsageRef.current,
-          [conversationId]: { promptTokens: usage.promptTokens },
-        };
-        setContextUsageByConversation(current => ({
-          ...current,
-          [conversationId]: { promptTokens: usage.promptTokens },
-        }));
+        store.set(contextUsageAtomFamily(conversationId), { promptTokens: usage.promptTokens });
       }
     };
 
@@ -575,7 +560,7 @@ export const AgentChatPanel = ({
             currentIds.filter(currentId => currentId !== conversationId)
           );
 
-          const latest = latestUsageRef.current[conversationId]?.promptTokens ?? 0;
+          const latest = store.get(contextUsageAtomFamily(conversationId))?.promptTokens ?? 0;
           const runContextLength = modelOptions.find(
             option => option.id === runModel
           )?.contextLength;
@@ -597,8 +582,10 @@ export const AgentChatPanel = ({
       inspectableTabs,
       selectedTabId: conversation.selectedTabId,
     });
-    const isConversationRunning = runningConversationIds.includes(conversation.id);
-    const isConversationCompacting = compactingConversationIds.includes(conversation.id);
+    const isConversationRunning = store.get(runningConversationIdsAtom).includes(conversation.id);
+    const isConversationCompacting = store
+      .get(compactingConversationIdsAtom)
+      .includes(conversation.id);
 
     if (
       !isConversationStoreLoaded ||
@@ -611,7 +598,7 @@ export const AgentChatPanel = ({
       return;
     }
 
-    setDraftsByConversation(current => ({ ...current, [activeConversationId]: '' }));
+    store.set(draftAtomFamily(activeConversationId), '');
     submitMessage(text);
   };
 
@@ -651,13 +638,16 @@ export const AgentChatPanel = ({
     setConversationStore(conversationStoreRef.current);
   };
 
-  const abortConversationRun = useCallback((conversationId: string): void => {
-    runStatesRef.current.get(conversationId)?.abort.abort();
-    runStatesRef.current.delete(conversationId);
-    setRunningConversationIds(currentIds =>
-      currentIds.filter(currentId => currentId !== conversationId)
-    );
-  }, []);
+  const abortConversationRun = useCallback(
+    (conversationId: string): void => {
+      runStatesRef.current.get(conversationId)?.abort.abort();
+      runStatesRef.current.delete(conversationId);
+      setRunningConversationIds(currentIds =>
+        currentIds.filter(currentId => currentId !== conversationId)
+      );
+    },
+    [setRunningConversationIds]
+  );
 
   const closeConversation = useCallback(
     (conversationId: string): void => {
@@ -666,8 +656,8 @@ export const AgentChatPanel = ({
       }
 
       abortConversationRun(conversationId);
-      setConversationStore(store =>
-        closeStoredConversationTab(store, conversationId, createDefaultConversationEvents())
+      setConversationStore(currentStore =>
+        closeStoredConversationTab(currentStore, conversationId, createDefaultConversationEvents())
       );
     },
     [abortConversationRun, isConversationStoreLoaded, setConversationStore]
@@ -687,8 +677,8 @@ export const AgentChatPanel = ({
       }
 
       abortConversationRun(conversationId);
-      setConversationStore(store =>
-        deleteStoredConversation(store, conversationId, createDefaultConversationEvents())
+      setConversationStore(currentStore =>
+        deleteStoredConversation(currentStore, conversationId, createDefaultConversationEvents())
       );
     },
     [abortConversationRun, conversationStore, isConversationStoreLoaded, setConversationStore]
@@ -700,17 +690,19 @@ export const AgentChatPanel = ({
         return;
       }
 
-      setConversationStore(store =>
+      const runningIds = store.get(runningConversationIdsAtom);
+
+      setConversationStore(currentStore =>
         openStoredConversation({
           conversationId,
           isActiveConversationEmpty:
-            !runningConversationIds.includes(store.activeConversationId) &&
-            isStoredConversationEmpty(getActiveStoredConversation(store)),
-          store,
+            !runningIds.includes(currentStore.activeConversationId) &&
+            isStoredConversationEmpty(getActiveStoredConversation(currentStore)),
+          store: currentStore,
         })
       );
     },
-    [isConversationStoreLoaded, runningConversationIds, setConversationStore]
+    [isConversationStoreLoaded, setConversationStore, store]
   );
 
   useEffect(() => {

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -6,6 +6,7 @@ import {
   compactingConversationIdsAtom,
   contextUsageAtomFamily,
   draftAtomFamily,
+  evictConversationAtoms,
   runningConversationIdsAtom,
 } from './agent-chat-atoms';
 import {
@@ -587,8 +588,7 @@ export const AgentChatPanel = ({
         deleteStoredConversation(currentStore, conversationId, createDefaultConversationEvents())
       );
       // Free per-conversation atoms; a deleted conversation can never be reopened.
-      draftAtomFamily.remove(conversationId);
-      contextUsageAtomFamily.remove(conversationId);
+      evictConversationAtoms(conversationId);
     },
     [abortConversationRun, conversationStore, isConversationStoreLoaded, setConversationStore]
   );
@@ -600,16 +600,21 @@ export const AgentChatPanel = ({
       }
 
       const runningIds = store.get(runningConversationIdsAtom);
-
-      setConversationStore(currentStore =>
-        openStoredConversation({
-          conversationId,
-          isActiveConversationEmpty:
-            !runningIds.includes(currentStore.activeConversationId) &&
-            isStoredConversationEmpty(getActiveStoredConversation(currentStore)),
-          store: currentStore,
-        })
-      );
+      const currentStore = conversationStoreRef.current;
+      const nextStore = openStoredConversation({
+        conversationId,
+        isActiveConversationEmpty:
+          !runningIds.includes(currentStore.activeConversationId) &&
+          isStoredConversationEmpty(getActiveStoredConversation(currentStore)),
+        store: currentStore,
+      });
+      // Opening history can drop the active empty conversation; free its atoms.
+      for (const conversation of currentStore.conversations) {
+        if (!nextStore.conversations.some(next => next.id === conversation.id)) {
+          evictConversationAtoms(conversation.id);
+        }
+      }
+      setConversationStore(nextStore);
     },
     [isConversationStoreLoaded, setConversationStore, store]
   );

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -7,7 +7,12 @@ import {
   groupConversationEvents,
 } from '@/src/shared/agent-conversation';
 import type { AgentConversationEvent } from '@/src/shared/agent-conversation';
-import { compactConversationEvents } from '@/src/shared/agent-context-compaction';
+import {
+  KEEP_RECENT_EXCHANGES,
+  KEEP_RECENT_EXCHANGES_MANUAL,
+  compactConversationEvents,
+  hasCompactableHistory,
+} from '@/src/shared/agent-context-compaction';
 import { defaultMode } from '@/src/shared/agent-chat-placeholder';
 import { getKiloApiBaseUrl } from '@/src/shared/auth';
 import type { StoredAuth } from '@/src/shared/auth';
@@ -239,7 +244,10 @@ export const AgentChatPanel = ({
   const contextLength = selectedModel?.contextLength;
 
   const compactConversation = useCallback(
-    async (conversationId: string): Promise<void> => {
+    async (
+      conversationId: string,
+      keepRecentExchanges: number = KEEP_RECENT_EXCHANGES
+    ): Promise<void> => {
       if (
         !isConversationStoreLoaded ||
         runningConversationIds.includes(conversationId) ||
@@ -264,6 +272,7 @@ export const AgentChatPanel = ({
           apiBaseUrl,
           events: conversation.events,
           fetch: fetchFromWindow,
+          keepRecentExchanges,
           model: runModel,
           organizationId,
           token: auth.token,
@@ -300,14 +309,23 @@ export const AgentChatPanel = ({
   );
 
   const compactActiveConversation = useCallback(
-    (): Promise<void> => compactConversation(activeConversationId),
+    (): Promise<void> => compactConversation(activeConversationId, KEEP_RECENT_EXCHANGES_MANUAL),
     [activeConversationId, compactConversation]
+  );
+
+  /*
+   * Gate on summarizable history (not measured usage) so the button is never enabled-but-inert and
+   * still works after a reload, when in-memory usage has reset to zero.
+   */
+  const canCompactActive = useMemo(
+    () => hasCompactableHistory(events, KEEP_RECENT_EXCHANGES_MANUAL),
+    [events]
   );
 
   const contextDonut = useMemo(
     () => (
       <ContextDonut
-        canCompact={!isRunning && !isCompacting && activePromptTokens > 0}
+        canCompact={!isRunning && !isCompacting && canCompactActive}
         contextLength={contextLength}
         onCompact={() => {
           void compactActiveConversation();
@@ -315,7 +333,14 @@ export const AgentChatPanel = ({
         promptTokens={activePromptTokens}
       />
     ),
-    [activePromptTokens, compactActiveConversation, contextLength, isCompacting, isRunning]
+    [
+      activePromptTokens,
+      canCompactActive,
+      compactActiveConversation,
+      contextLength,
+      isCompacting,
+      isRunning,
+    ]
   );
 
   const busyConversationIds = useMemo(

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -514,10 +514,6 @@ export const AgentChatPanel = ({
         return;
       }
 
-      if (!globalThis.confirm('Close this conversation tab? It will stay in History.')) {
-        return;
-      }
-
       abortConversationRun(conversationId);
       setConversationStore(store =>
         closeStoredConversationTab(store, conversationId, createDefaultConversationEvents())

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -572,11 +572,13 @@ export const AgentChatPanel = ({
       selectedTabId: conversation.selectedTabId,
     });
     const isConversationRunning = runningConversationIds.includes(conversation.id);
+    const isConversationCompacting = compactingConversationIds.includes(conversation.id);
 
     if (
       !isConversationStoreLoaded ||
       text === '' ||
       isConversationRunning ||
+      isConversationCompacting ||
       conversationModel === '' ||
       conversationSelectedTabId === undefined
     ) {

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -28,7 +28,9 @@ import {
 } from './agent-conversation-storage';
 import type { StoredAgentConversation } from './agent-conversation-storage';
 import { AgentFooterControls } from './agent-footer-controls';
+import { ContextDonut } from './context-donut';
 import { runDangerousLlmTurn, runSafeLlmTurn } from './agent-turn-runners';
+import type { ContextUsage } from '@/src/shared/context-usage';
 import { useTabDebugger } from './use-tab-debugger';
 import { ConversationList } from './conversation-list';
 import { ConversationHistoryButton } from './conversation-history-button';
@@ -37,6 +39,8 @@ import { useGatewayModels } from './use-gateway-models';
 const apiBaseUrl = getKiloApiBaseUrl();
 const fetchFromWindow = (input: string, init?: RequestInit): Promise<Response> =>
   fetch(input, init);
+// Ponytail: stub, replaced in compaction task
+const compactActiveConversation = async (): Promise<void> => {};
 const createDefaultConversationEvents = (): AgentConversationEvent[] => [
   createAssistantMessage('Pick a tab and ask Kilo to inspect it.'),
 ];
@@ -180,6 +184,10 @@ export const AgentChatPanel = ({
   organizationId: string | undefined;
 }): JSX.Element => {
   const [draftsByConversation, setDraftsByConversation] = useState<Record<string, string>>({});
+  // Ponytail: in-memory only, recomputed from the next gateway turn after reload.
+  const [contextUsageByConversation, setContextUsageByConversation] = useState<
+    Record<string, ContextUsage>
+  >({});
   const [conversationStore, setConversationStore, isConversationStoreLoaded] =
     useStoredAgentConversations(createDefaultConversationEvents);
   const [runningConversationIds, setRunningConversationIds] = useState<string[]>([]);
@@ -222,6 +230,22 @@ export const AgentChatPanel = ({
   );
   const thinkingEffort = activeConversation.thinkingEffort ?? thinkingOptions[0] ?? '';
   const isRunning = runningConversationIds.includes(activeConversationId);
+  const activeUsage = contextUsageByConversation[activeConversationId];
+  const activePromptTokens = activeUsage?.promptTokens ?? 0;
+  const contextLength = selectedModel?.contextLength;
+  const contextDonut = useMemo(
+    () => (
+      <ContextDonut
+        canCompact={!isRunning && activePromptTokens > 0}
+        contextLength={contextLength}
+        onCompact={() => {
+          void compactActiveConversation();
+        }}
+        promptTokens={activePromptTokens}
+      />
+    ),
+    [activePromptTokens, contextLength, isRunning]
+  );
   const isModelSelectDisabled = modelOptions.length === 0;
   const isThinkingSelectDisabled = thinkingOptions.length === 0;
   const modelControlValue = modelOptions.length === 0 ? '' : model;
@@ -400,6 +424,14 @@ export const AgentChatPanel = ({
         updateThinkingBlock(conversationId, eventId, thinkingText);
       }
     };
+    const updateRunUsage = (usage: { promptTokens: number }): void => {
+      if (isCurrentRun()) {
+        setContextUsageByConversation(current => ({
+          ...current,
+          [conversationId]: { promptTokens: usage.promptTokens },
+        }));
+      }
+    };
 
     runStatesRef.current.set(conversationId, {
       abort,
@@ -420,6 +452,7 @@ export const AgentChatPanel = ({
           conversationEvents: conversationWithUserMessage,
           fetch: fetchFromWindow,
           model: runModel,
+          onUsage: updateRunUsage,
           organizationId,
           selectedTabId: runSelectedTabId,
           signal: abort.signal,
@@ -646,6 +679,7 @@ export const AgentChatPanel = ({
 
       <footer className="border-t border-zinc-900 bg-zinc-950 px-4 py-2">
         <AgentFooterControls
+          contextDonut={contextDonut}
           inspectableTabs={inspectableTabs}
           isLoadingTabs={isLoadingTabs}
           isConversationStoreLoaded={isConversationStoreLoaded}

--- a/apps/extension/entrypoints/sidepanel/agent-footer-controls.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-footer-controls.tsx
@@ -129,6 +129,7 @@ const ModeControl = ({
 };
 
 export const AgentFooterControls = ({
+  contextDonut,
   inspectableTabs,
   isLoadingTabs,
   isConversationStoreLoaded,
@@ -149,6 +150,7 @@ export const AgentFooterControls = ({
   thinkingEffort,
   thinkingOptions,
 }: {
+  contextDonut?: ReactNode;
   inspectableTabs: InspectableTab[];
   isLoadingTabs: boolean;
   isConversationStoreLoaded: boolean;
@@ -249,6 +251,7 @@ export const AgentFooterControls = ({
             ))
           )}
         </CompactSelectControl>
+        {contextDonut}
       </div>
       {modelLoadError === undefined ? null : (
         <div className="flex items-center justify-between gap-2">

--- a/apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.ts
@@ -4,6 +4,7 @@ import {
   createSafeToolDefinitions,
 } from '@/src/shared/agent-llm-harness';
 import { runLlmTurn } from '@/src/shared/agent-llm-turn-runner-core';
+import type { OnTurnUsage } from '@/src/shared/agent-llm-turn-runner-core';
 import { maxAgentToolRounds } from '@/src/shared/agent-tool-round-limit';
 import type { FetchLike } from '@/src/shared/auth';
 import { executeEvalToolCall } from './agent-eval-runtime';
@@ -18,6 +19,7 @@ interface RunDangerousLlmTurnOptions {
   readonly model: string;
   readonly organizationId?: string | undefined;
   readonly selectedTabId: number;
+  readonly onUsage?: OnTurnUsage | undefined;
   readonly signal?: AbortSignal | undefined;
   readonly supportsImages?: boolean;
   readonly thinkingEffort?: string | undefined;

--- a/apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.ts
@@ -1,6 +1,7 @@
 import type { AgentConversationEvent } from '@/src/shared/agent-conversation';
 import { createSafeToolDefinitions } from '@/src/shared/agent-llm-harness';
 import { runLlmTurn } from '@/src/shared/agent-llm-turn-runner-core';
+import type { OnTurnUsage } from '@/src/shared/agent-llm-turn-runner-core';
 import { maxAgentToolRounds } from '@/src/shared/agent-tool-round-limit';
 import type { FetchLike } from '@/src/shared/auth';
 import { executeSafeToolCall } from './agent-safe-tool-runtime';
@@ -14,6 +15,7 @@ interface RunSafeLlmTurnOptions {
   readonly model: string;
   readonly organizationId?: string | undefined;
   readonly selectedTabId: number;
+  readonly onUsage?: OnTurnUsage | undefined;
   readonly signal?: AbortSignal | undefined;
   readonly supportsImages?: boolean;
   readonly thinkingEffort?: string | undefined;

--- a/apps/extension/entrypoints/sidepanel/app.tsx
+++ b/apps/extension/entrypoints/sidepanel/app.tsx
@@ -21,6 +21,7 @@ import {
   SignedOutView,
   ValidationErrorView,
 } from './auth-views';
+import { clearPerConversationAtoms } from './agent-chat-atoms';
 
 const pollIntervalMs = 3000;
 const apiBaseUrl = getKiloApiBaseUrl();
@@ -86,6 +87,7 @@ export const App = (): JSX.Element => {
       if (result.status === 'invalid') {
         // Clear all account-scoped state (conversations included) like sign-out so a later account on this profile never loads the expired user's data. Message returned below.
         await clearStoredSession(storage);
+        clearPerConversationAtoms();
         return { message: 'Your session expired. Sign in again.', status: 'signedOut' };
       }
 
@@ -188,6 +190,7 @@ export const App = (): JSX.Element => {
       try {
         await clearStoredSession(storage);
       } finally {
+        clearPerConversationAtoms();
         queryClient.setQueryData(storedAuthQueryKey, undefined);
         if (storedAuth !== undefined) {
           queryClient.setQueryData(getAuthValidationQueryKey(storedAuth.token), {

--- a/apps/extension/entrypoints/sidepanel/app.tsx
+++ b/apps/extension/entrypoints/sidepanel/app.tsx
@@ -50,8 +50,10 @@ export const App = (): JSX.Element => {
     isSuccess: isStoredAuthSuccess,
     refetch: refetchStoredAuth,
   } = useQuery({
-    // React Query forbids a queryFn resolving to undefined, but "no stored auth" is the
-    // common signed-out state; return null from the fn and map it back to undefined for the UI.
+    /*
+     * React Query forbids a queryFn resolving to undefined. Return null for the
+     * signed-out state and map it back to undefined for the UI via select.
+     */
     queryFn: async () => (await loadStoredAuth(storage)) ?? null,
     queryKey: storedAuthQueryKey,
     select: data => data ?? undefined,

--- a/apps/extension/entrypoints/sidepanel/context-donut.tsx
+++ b/apps/extension/entrypoints/sidepanel/context-donut.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import type { JSX } from 'react';
 import { formatContextSummary, getContextRatio, getContextTone } from '@/src/shared/context-usage';
 
@@ -21,6 +22,7 @@ export const ContextDonut = ({
   onCompact: () => void;
   promptTokens: number;
 }): JSX.Element => {
+  const detailsRef = useRef<HTMLDetailsElement>(null);
   const ratio = getContextRatio(promptTokens, contextLength);
   const stroke = ratio === undefined ? '#52525b' : toneStroke[getContextTone(ratio)];
   const dash = ratio === undefined ? 0 : ratio * CIRCUMFERENCE;
@@ -28,7 +30,7 @@ export const ContextDonut = ({
   const label = `Context usage: ${summary}`;
 
   return (
-    <details className="relative shrink-0">
+    <details className="relative shrink-0" ref={detailsRef}>
       <summary
         aria-label={label}
         className="flex size-8 cursor-pointer list-none items-center justify-center rounded-md border border-zinc-800 bg-zinc-950 outline-none transition hover:border-zinc-700 focus-visible:ring-2 focus-visible:ring-[#EDFF00]/50"
@@ -55,7 +57,10 @@ export const ContextDonut = ({
         <button
           className="mt-3 h-7 w-full rounded-md bg-[#EDFF00] px-2 text-xs font-semibold text-zinc-950 outline-none transition hover:bg-[#d9ea00] focus:ring-2 focus:ring-[#EDFF00]/50 disabled:cursor-not-allowed disabled:bg-zinc-800 disabled:text-zinc-500"
           disabled={!canCompact}
-          onClick={onCompact}
+          onClick={() => {
+            detailsRef.current?.removeAttribute('open');
+            onCompact();
+          }}
           type="button"
         >
           Compact now

--- a/apps/extension/entrypoints/sidepanel/context-donut.tsx
+++ b/apps/extension/entrypoints/sidepanel/context-donut.tsx
@@ -1,0 +1,70 @@
+import type { JSX } from 'react';
+import {
+  formatContextSummary,
+  getContextRatio,
+  getContextTone,
+} from '@/src/shared/context-usage';
+
+const toneStroke: Record<'danger' | 'safe' | 'warn', string> = {
+  danger: '#f87171',
+  safe: '#EDFF00',
+  warn: '#fbbf24',
+};
+
+const RADIUS = 6;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export const ContextDonut = ({
+  canCompact,
+  contextLength,
+  onCompact,
+  promptTokens,
+}: {
+  canCompact: boolean;
+  contextLength: number | undefined;
+  onCompact: () => void;
+  promptTokens: number;
+}): JSX.Element => {
+  const ratio = getContextRatio(promptTokens, contextLength);
+  const stroke = ratio === undefined ? '#52525b' : toneStroke[getContextTone(ratio)];
+  const dash = ratio === undefined ? 0 : ratio * CIRCUMFERENCE;
+  const summary = formatContextSummary(promptTokens, contextLength);
+  const label = `Context usage: ${summary}`;
+
+  return (
+    <details className="relative shrink-0">
+      <summary
+        aria-label={label}
+        className="flex size-8 cursor-pointer list-none items-center justify-center rounded-md border border-zinc-800 bg-zinc-950 outline-none transition hover:border-zinc-700 focus-visible:ring-2 focus-visible:ring-[#EDFF00]/50"
+        title={summary}
+      >
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" width="16">
+          <circle cx="8" cy="8" fill="none" r={RADIUS} stroke="#27272a" strokeWidth="3" />
+          <circle
+            cx="8"
+            cy="8"
+            fill="none"
+            r={RADIUS}
+            stroke={stroke}
+            strokeDasharray={`${dash} ${CIRCUMFERENCE}`}
+            strokeLinecap="round"
+            strokeWidth="3"
+            transform="rotate(-90 8 8)"
+          />
+        </svg>
+      </summary>
+      <div className="absolute bottom-10 right-0 z-20 w-56 rounded-md border border-zinc-800 bg-zinc-950 p-3 text-xs text-zinc-300 shadow-lg shadow-zinc-950/60">
+        <p className="font-medium text-zinc-100">Context</p>
+        <p className="mt-1 text-zinc-400">{summary}</p>
+        <button
+          className="mt-3 h-7 w-full rounded-md bg-[#EDFF00] px-2 text-xs font-semibold text-zinc-950 outline-none transition hover:bg-[#d9ea00] focus:ring-2 focus:ring-[#EDFF00]/50 disabled:cursor-not-allowed disabled:bg-zinc-800 disabled:text-zinc-500"
+          disabled={!canCompact}
+          onClick={onCompact}
+          type="button"
+        >
+          Compact now
+        </button>
+      </div>
+    </details>
+  );
+};

--- a/apps/extension/entrypoints/sidepanel/context-donut.tsx
+++ b/apps/extension/entrypoints/sidepanel/context-donut.tsx
@@ -1,9 +1,5 @@
 import type { JSX } from 'react';
-import {
-  formatContextSummary,
-  getContextRatio,
-  getContextTone,
-} from '@/src/shared/context-usage';
+import { formatContextSummary, getContextRatio, getContextTone } from '@/src/shared/context-usage';
 
 const toneStroke: Record<'danger' | 'safe' | 'warn', string> = {
   danger: '#f87171',

--- a/apps/extension/entrypoints/sidepanel/conversation-list.tsx
+++ b/apps/extension/entrypoints/sidepanel/conversation-list.tsx
@@ -88,36 +88,6 @@ export const ConversationList = ({ items }: { items: GroupedConversationItem[] }
     }
   }, []);
 
-  // Drive the scroll to the bottom directly on the DOM node across a few frames so late virtualizer row measurements cannot leave us short. Every pass re-checks the stuck flag, so a user scroll-up that flips it stops the chain immediately.
-  const pinToBottom = useCallback((): void => {
-    cancelPin();
-
-    const runPass = (remainingPasses: number): void => {
-      const element = listRef.current;
-
-      if (element === null || !isStuckToBottomRef.current || items.length === 0) {
-        pinFrameRef.current = null;
-        return;
-      }
-
-      virtualizer.scrollToIndex(items.length - 1, { align: 'end' });
-      element.scrollTop = element.scrollHeight;
-      lastPinnedTopRef.current = element.scrollTop;
-      lastScrollTopRef.current = element.scrollTop;
-
-      if (remainingPasses > 0) {
-        pinFrameRef.current = requestAnimationFrame(() => {
-          runPass(remainingPasses - 1);
-        });
-        return;
-      }
-
-      pinFrameRef.current = null;
-    };
-
-    runPass(5);
-  }, [cancelPin, items.length, virtualizer]);
-
   const releaseToManualScroll = useCallback((): void => {
     if (!isStuckToBottomRef.current) {
       return;
@@ -136,6 +106,49 @@ export const ConversationList = ({ items }: { items: GroupedConversationItem[] }
     isStuckToBottomRef.current = true;
     setShowJumpButton(false);
   }, []);
+
+  // Pin to the bottom across a few frames so late virtualizer measurements cannot leave us short. An auto-pin (force false) bails when the position sits above the last pin: a scrollbar drag's scroll event can coalesce with our pin write so handleScroll misses it, but sampling scrollTop here catches the upward move and releases instead of yanking the view back.
+  const pinToBottom = useCallback(
+    (force = false): void => {
+      cancelPin();
+
+      const runPass = (remainingPasses: number, allowRelease: boolean): void => {
+        const element = listRef.current;
+
+        if (element === null || !isStuckToBottomRef.current || items.length === 0) {
+          pinFrameRef.current = null;
+          return;
+        }
+
+        if (
+          allowRelease &&
+          lastPinnedTopRef.current - element.scrollTop > 16 &&
+          !isScrolledToBottom(element)
+        ) {
+          releaseToManualScroll();
+          return;
+        }
+
+        virtualizer.scrollToIndex(items.length - 1, { align: 'end' });
+        element.scrollTop = element.scrollHeight;
+        lastPinnedTopRef.current = element.scrollTop;
+        lastScrollTopRef.current = element.scrollTop;
+
+        if (remainingPasses > 0) {
+          pinFrameRef.current = requestAnimationFrame(() => {
+            runPass(remainingPasses - 1, true);
+          });
+          return;
+        }
+
+        pinFrameRef.current = null;
+      };
+
+      // A forced pin (jump-to-latest) re-pins from wherever the user is, so it skips the release check on its first pass; later passes re-enable it once the fresh baseline is set.
+      runPass(5, !force);
+    },
+    [cancelPin, items.length, releaseToManualScroll, virtualizer]
+  );
 
   // Bind scroll detection straight to the DOM node so upward intent is seen on the input event itself, before any in-flight pin can write the position back to the bottom.
   useEffect(() => {
@@ -209,7 +222,7 @@ export const ConversationList = ({ items }: { items: GroupedConversationItem[] }
 
   const jumpToLatest = (): void => {
     followBottomAgain();
-    pinToBottom();
+    pinToBottom(true);
   };
   const virtualItems = virtualizer.getVirtualItems();
 

--- a/apps/extension/entrypoints/sidepanel/conversation-tabs.tsx
+++ b/apps/extension/entrypoints/sidepanel/conversation-tabs.tsx
@@ -1,0 +1,97 @@
+import type { JSX } from 'react';
+import { useAtomValue } from 'jotai';
+import { compactingConversationIdsAtom, runningConversationIdsAtom } from './agent-chat-atoms';
+import { getStoredConversationTitle } from './agent-conversation-storage';
+import type { StoredAgentConversation } from './agent-conversation-storage';
+
+export const ConversationTabs = ({
+  activeConversationId,
+  conversations,
+  isDisabled,
+  onCloseConversation,
+  onCreateConversation,
+  onSelectConversation,
+}: {
+  activeConversationId: string;
+  conversations: StoredAgentConversation[];
+  isDisabled: boolean;
+  onCloseConversation: (conversationId: string) => void;
+  onCreateConversation: () => void;
+  onSelectConversation: (conversationId: string) => void;
+}): JSX.Element => {
+  const runningConversationIds = useAtomValue(runningConversationIdsAtom);
+  const compactingConversationIds = useAtomValue(compactingConversationIdsAtom);
+
+  return (
+    <div className="border-b border-zinc-900 bg-zinc-950">
+      <div
+        aria-label="Conversation tabs"
+        className="agent-conversation-scrollbar flex min-w-0 items-center gap-1 overflow-x-auto px-2 py-2"
+        role="tablist"
+      >
+        {conversations.map(conversation => {
+          const title = getStoredConversationTitle(conversation);
+          const isActive = conversation.id === activeConversationId;
+          const isRunning =
+            runningConversationIds.includes(conversation.id) ||
+            compactingConversationIds.includes(conversation.id);
+
+          return (
+            <div
+              className={
+                isActive
+                  ? 'flex h-8 max-w-44 shrink-0 items-center rounded-md border border-[#EDFF00]/70 bg-zinc-900 text-zinc-50'
+                  : 'flex h-8 max-w-44 shrink-0 items-center rounded-md border border-zinc-800 bg-zinc-950 text-zinc-400 hover:border-zinc-700 hover:text-zinc-100'
+              }
+              key={conversation.id}
+            >
+              <button
+                aria-selected={isActive}
+                className="flex h-full min-w-0 items-center gap-1.5 px-2 text-left text-xs font-medium outline-none focus:ring-2 focus:ring-[#EDFF00]/50 disabled:cursor-not-allowed disabled:text-zinc-600"
+                disabled={isDisabled}
+                onClick={() => {
+                  onSelectConversation(conversation.id);
+                }}
+                role="tab"
+                title={title}
+                type="button"
+              >
+                {isRunning ? (
+                  <span
+                    aria-hidden="true"
+                    className="size-2 shrink-0 animate-pulse rounded-full bg-[#EDFF00]"
+                  />
+                ) : null}
+                <span className="truncate">{title}</span>
+              </button>
+              <button
+                aria-label={`Close ${title}`}
+                className="mr-1 flex size-6 shrink-0 items-center justify-center rounded-sm text-zinc-500 outline-none transition hover:bg-zinc-800 hover:text-zinc-100 focus:ring-2 focus:ring-[#EDFF00]/50"
+                disabled={isDisabled}
+                onClick={() => {
+                  onCloseConversation(conversation.id);
+                }}
+                type="button"
+              >
+                <span aria-hidden="true" className="text-sm leading-none">
+                  x
+                </span>
+              </button>
+            </div>
+          );
+        })}
+        <button
+          aria-label="New conversation"
+          className="flex size-8 shrink-0 items-center justify-center rounded-md border border-zinc-800 bg-zinc-950 text-zinc-300 outline-none transition hover:border-zinc-700 hover:bg-zinc-900 hover:text-zinc-100 focus:ring-2 focus:ring-[#EDFF00]/50 disabled:cursor-not-allowed disabled:text-zinc-600"
+          disabled={isDisabled}
+          onClick={onCreateConversation}
+          type="button"
+        >
+          <span aria-hidden="true" className="text-lg leading-none">
+            +
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/apps/extension/entrypoints/sidepanel/message-composer.tsx
+++ b/apps/extension/entrypoints/sidepanel/message-composer.tsx
@@ -1,0 +1,59 @@
+import type { ChangeEvent, JSX, KeyboardEvent } from 'react';
+import { useAtom } from 'jotai';
+import { draftAtomFamily } from './agent-chat-atoms';
+
+export const MessageComposer = ({
+  activeConversationId,
+  canSend,
+  isRunning,
+  onStop,
+  onSubmit,
+}: {
+  activeConversationId: string;
+  canSend: boolean;
+  isRunning: boolean;
+  onStop: () => void;
+  onSubmit: () => void;
+}): JSX.Element => {
+  const [draft, setDraft] = useAtom(draftAtomFamily(activeConversationId));
+  const isSendDisabled = !canSend || draft.trim() === '';
+
+  return (
+    <form
+      className="border-t border-zinc-900 px-4 py-3"
+      onSubmit={event => {
+        event.preventDefault();
+        onSubmit();
+      }}
+    >
+      <label className="sr-only" htmlFor="agent-message">
+        Message agent
+      </label>
+      <textarea
+        className="min-h-20 w-full resize-none rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm leading-5 text-zinc-100 outline-none transition placeholder:text-zinc-600 focus:border-[#EDFF00] focus:ring-2 focus:ring-[#EDFF00]/30"
+        id="agent-message"
+        onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
+          setDraft(event.currentTarget.value);
+        }}
+        onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
+          if (event.key === 'Enter' && !event.shiftKey) {
+            event.preventDefault();
+            onSubmit();
+          }
+        }}
+        placeholder="Ask Kilo to inspect this tab..."
+        value={draft}
+      />
+      <div className="mt-2 grid gap-2">
+        <button
+          className="h-9 w-full rounded-md bg-[#EDFF00] px-3 text-sm font-semibold text-zinc-950 transition hover:bg-[#d9ea00] focus:outline-none focus:ring-2 focus:ring-[#EDFF00] focus:ring-offset-2 focus:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:bg-zinc-800 disabled:text-zinc-500"
+          disabled={isRunning ? false : isSendDisabled}
+          onClick={isRunning ? onStop : undefined}
+          type={isRunning ? 'button' : 'submit'}
+        >
+          {isRunning ? 'Stop' : 'Send message'}
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -31,6 +31,8 @@
   "dependencies": {
     "@tanstack/react-query": "catalog:",
     "@tanstack/react-virtual": "^3.14.3",
+    "jotai": "2.18.1",
+    "jotai-family": "1.0.2",
     "lucide-react": "0.552.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",

--- a/apps/extension/src/shared/agent-chat-atoms.test.ts
+++ b/apps/extension/src/shared/agent-chat-atoms.test.ts
@@ -1,0 +1,41 @@
+import { getDefaultStore } from 'jotai';
+import { describe, expect, it } from 'vitest';
+// Atoms module lives under entrypoints/ but has no #imports dependency.
+// Imported here, under src/, because that is where the vitest glob runs.
+import {
+  clearPerConversationAtoms,
+  compactingConversationIdsAtom,
+  contextUsageAtomFamily,
+  draftAtomFamily,
+  evictConversationAtoms,
+  runningConversationIdsAtom,
+} from '@/entrypoints/sidepanel/agent-chat-atoms';
+
+describe('per-conversation atom eviction', () => {
+  it('evictConversationAtoms resets draft and usage for a conversation id', () => {
+    const store = getDefaultStore();
+    store.set(draftAtomFamily('conversation-1'), 'hello');
+    store.set(contextUsageAtomFamily('conversation-1'), { promptTokens: 42 });
+
+    evictConversationAtoms('conversation-1');
+
+    // A fresh atom (post-remove) starts from its initial value.
+    expect(store.get(draftAtomFamily('conversation-1'))).toBe('');
+    expect(store.get(contextUsageAtomFamily('conversation-1'))).toBeUndefined();
+  });
+
+  it('clearPerConversationAtoms wipes all drafts, usage, and run-state on sign-out', () => {
+    const store = getDefaultStore();
+    store.set(draftAtomFamily('conversation-1'), 'prev account draft');
+    store.set(contextUsageAtomFamily('conversation-2'), { promptTokens: 999 });
+    store.set(runningConversationIdsAtom, ['conversation-1']);
+    store.set(compactingConversationIdsAtom, ['conversation-2']);
+
+    clearPerConversationAtoms();
+
+    expect(store.get(draftAtomFamily('conversation-1'))).toBe('');
+    expect(store.get(contextUsageAtomFamily('conversation-2'))).toBeUndefined();
+    expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+    expect(store.get(compactingConversationIdsAtom)).toStrictEqual([]);
+  });
+});

--- a/apps/extension/src/shared/agent-context-compaction.test.ts
+++ b/apps/extension/src/shared/agent-context-compaction.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createAssistantMessage,
+  createUserMessage,
+} from './agent-conversation';
+import {
+  KEEP_RECENT_EXCHANGES,
+  SUMMARY_PREFIX,
+  renderEventsAsTranscript,
+  splitEventsForCompaction,
+} from './agent-context-compaction';
+
+describe('split events for compaction', () => {
+  it('keeps the last N exchanges and summarizes the rest', () => {
+    const events = [
+      createAssistantMessage('greeting'),
+      createUserMessage('one'),
+      createAssistantMessage('a1'),
+      createUserMessage('two'),
+      createAssistantMessage('a2'),
+      createUserMessage('three'),
+      createAssistantMessage('a3'),
+    ];
+
+    const { toKeep, toSummarize } = splitEventsForCompaction(events);
+
+    // KEEP_RECENT_EXCHANGES = 2 → keep from the 2nd-to-last user message ('two')
+    expect(toKeep[0]).toMatchObject({ role: 'user', text: 'two' });
+    expect(toKeep.at(-1)).toMatchObject({ text: 'a3' });
+    expect(toSummarize).toMatchObject([
+      { text: 'greeting' },
+      { text: 'one' },
+      { text: 'a1' },
+    ]);
+  });
+
+  it('summarizes nothing when there are too few user messages', () => {
+    const events = [createAssistantMessage('greeting'), createUserMessage('one')];
+    const { toKeep, toSummarize } = splitEventsForCompaction(events);
+    expect(toSummarize).toStrictEqual([]);
+    expect(toKeep).toStrictEqual(events);
+  });
+});
+
+describe('render events as transcript', () => {
+  it('renders user and assistant lines', () => {
+    const text = renderEventsAsTranscript([
+      createUserMessage('hello'),
+      createAssistantMessage('hi there'),
+    ]);
+    expect(text).toContain('User: hello');
+    expect(text).toContain('Assistant: hi there');
+  });
+});
+
+describe('tuning constants', () => {
+  it('exposes tuning constants', () => {
+    expect(KEEP_RECENT_EXCHANGES).toBe(2);
+    expect(SUMMARY_PREFIX.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/extension/src/shared/agent-context-compaction.test.ts
+++ b/apps/extension/src/shared/agent-context-compaction.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { createAssistantMessage, createUserMessage } from './agent-conversation';
 import {
   KEEP_RECENT_EXCHANGES,
+  KEEP_RECENT_EXCHANGES_MANUAL,
   SUMMARY_PREFIX,
+  hasCompactableHistory,
   renderEventsAsTranscript,
   splitEventsForCompaction,
 } from './agent-context-compaction';
@@ -33,6 +35,24 @@ describe('split events for compaction', () => {
     expect(toSummarize).toStrictEqual([]);
     expect(toKeep).toStrictEqual(events);
   });
+
+  it('compacts a two-exchange conversation at the manual threshold (keep 1)', () => {
+    const events = [
+      createAssistantMessage('greeting'),
+      createUserMessage('one'),
+      createAssistantMessage('a1'),
+      createUserMessage('two'),
+      createAssistantMessage('a2'),
+    ];
+
+    // The auto threshold keeps everything (too few exchanges), so the manual click would be inert.
+    expect(hasCompactableHistory(events)).toBe(false);
+    expect(hasCompactableHistory(events, KEEP_RECENT_EXCHANGES_MANUAL)).toBe(true);
+
+    const { toKeep, toSummarize } = splitEventsForCompaction(events, KEEP_RECENT_EXCHANGES_MANUAL);
+    expect(toKeep[0]).toMatchObject({ role: 'user', text: 'two' });
+    expect(toSummarize).toMatchObject([{ text: 'greeting' }, { text: 'one' }, { text: 'a1' }]);
+  });
 });
 
 describe('render events as transcript', () => {
@@ -49,6 +69,7 @@ describe('render events as transcript', () => {
 describe('tuning constants', () => {
   it('exposes tuning constants', () => {
     expect(KEEP_RECENT_EXCHANGES).toBe(2);
+    expect(KEEP_RECENT_EXCHANGES_MANUAL).toBe(1);
     expect(SUMMARY_PREFIX.length).toBeGreaterThan(0);
   });
 });

--- a/apps/extension/src/shared/agent-context-compaction.test.ts
+++ b/apps/extension/src/shared/agent-context-compaction.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  createAssistantMessage,
-  createUserMessage,
-} from './agent-conversation';
+import { createAssistantMessage, createUserMessage } from './agent-conversation';
 import {
   KEEP_RECENT_EXCHANGES,
   SUMMARY_PREFIX,
@@ -27,11 +24,7 @@ describe('split events for compaction', () => {
     // KEEP_RECENT_EXCHANGES = 2 → keep from the 2nd-to-last user message ('two')
     expect(toKeep[0]).toMatchObject({ role: 'user', text: 'two' });
     expect(toKeep.at(-1)).toMatchObject({ text: 'a3' });
-    expect(toSummarize).toMatchObject([
-      { text: 'greeting' },
-      { text: 'one' },
-      { text: 'a1' },
-    ]);
+    expect(toSummarize).toMatchObject([{ text: 'greeting' }, { text: 'one' }, { text: 'a1' }]);
   });
 
   it('summarizes nothing when there are too few user messages', () => {

--- a/apps/extension/src/shared/agent-context-compaction.test.ts
+++ b/apps/extension/src/shared/agent-context-compaction.test.ts
@@ -84,6 +84,19 @@ describe('render events as transcript', () => {
     expect(text).toContain('Tool result (error): boom');
   });
 
+  it('omits screenshot data URLs instead of dumping base64 into the transcript', () => {
+    const dataUrl = `data:image/png;base64,${'A'.repeat(5000)}`;
+    const text = renderEventsAsTranscript([
+      createToolResult({
+        ok: true,
+        toolCallId: 'call-1',
+        value: { dataUrl, mediaType: 'image/png' },
+      }),
+    ]);
+    expect(text).toContain('[image/png screenshot omitted]');
+    expect(text).not.toContain('AAAA');
+  });
+
   it('truncates oversized tool result payloads', () => {
     const text = renderEventsAsTranscript([
       createToolResult({ ok: true, toolCallId: 'call-1', value: 'x'.repeat(5000) }),

--- a/apps/extension/src/shared/agent-context-compaction.test.ts
+++ b/apps/extension/src/shared/agent-context-compaction.test.ts
@@ -97,6 +97,21 @@ describe('render events as transcript', () => {
     expect(text).not.toContain('AAAA');
   });
 
+  it('omits persisted screenshot stubs instead of dumping their JSON into the transcript', () => {
+    const text = renderEventsAsTranscript([
+      createToolResult({
+        ok: true,
+        toolCallId: 'call-1',
+        value: {
+          mediaType: 'image/png',
+          note: 'Viewport screenshot omitted from persisted history.',
+        },
+      }),
+    ]);
+    expect(text).toContain('[image/png screenshot omitted]');
+    expect(text).not.toContain('note');
+  });
+
   it('truncates oversized tool result payloads', () => {
     const text = renderEventsAsTranscript([
       createToolResult({ ok: true, toolCallId: 'call-1', value: 'x'.repeat(5000) }),

--- a/apps/extension/src/shared/agent-context-compaction.test.ts
+++ b/apps/extension/src/shared/agent-context-compaction.test.ts
@@ -36,22 +36,25 @@ describe('split events for compaction', () => {
     expect(toKeep).toStrictEqual(events);
   });
 
-  it('compacts a two-exchange conversation at the manual threshold (keep 1)', () => {
+  it('summarizes the whole conversation at the manual threshold (keep 0)', () => {
     const events = [
       createAssistantMessage('greeting'),
       createUserMessage('one'),
       createAssistantMessage('a1'),
-      createUserMessage('two'),
-      createAssistantMessage('a2'),
     ];
 
-    // The auto threshold keeps everything (too few exchanges), so the manual click would be inert.
+    // A single exchange has nothing to summarize at the auto threshold, but manual compacts it all.
     expect(hasCompactableHistory(events)).toBe(false);
     expect(hasCompactableHistory(events, KEEP_RECENT_EXCHANGES_MANUAL)).toBe(true);
 
     const { toKeep, toSummarize } = splitEventsForCompaction(events, KEEP_RECENT_EXCHANGES_MANUAL);
-    expect(toKeep[0]).toMatchObject({ role: 'user', text: 'two' });
-    expect(toSummarize).toMatchObject([{ text: 'greeting' }, { text: 'one' }, { text: 'a1' }]);
+    expect(toKeep).toStrictEqual([]);
+    expect(toSummarize).toStrictEqual(events);
+  });
+
+  it('has nothing to compact without a user message', () => {
+    const events = [createAssistantMessage('greeting')];
+    expect(hasCompactableHistory(events, KEEP_RECENT_EXCHANGES_MANUAL)).toBe(false);
   });
 });
 
@@ -69,7 +72,7 @@ describe('render events as transcript', () => {
 describe('tuning constants', () => {
   it('exposes tuning constants', () => {
     expect(KEEP_RECENT_EXCHANGES).toBe(2);
-    expect(KEEP_RECENT_EXCHANGES_MANUAL).toBe(1);
+    expect(KEEP_RECENT_EXCHANGES_MANUAL).toBe(0);
     expect(SUMMARY_PREFIX.length).toBeGreaterThan(0);
   });
 });

--- a/apps/extension/src/shared/agent-context-compaction.test.ts
+++ b/apps/extension/src/shared/agent-context-compaction.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { createAssistantMessage, createUserMessage } from './agent-conversation';
+import {
+  createAssistantMessage,
+  createEvalToolCall,
+  createToolResult,
+  createUserMessage,
+} from './agent-conversation';
 import {
   KEEP_RECENT_EXCHANGES,
   KEEP_RECENT_EXCHANGES_MANUAL,
@@ -66,6 +71,25 @@ describe('render events as transcript', () => {
     ]);
     expect(text).toContain('User: hello');
     expect(text).toContain('Assistant: hi there');
+  });
+
+  it('preserves tool inputs and result payloads', () => {
+    const text = renderEventsAsTranscript([
+      createEvalToolCall({ code: 'return document.title;', tabId: 1 }),
+      createToolResult({ ok: true, toolCallId: 'call-1', value: 'Example Domain' }),
+      createToolResult({ error: 'boom', ok: false, toolCallId: 'call-2' }),
+    ]);
+    expect(text).toContain('Tool call (eval): return document.title;');
+    expect(text).toContain('Tool result (ok): Example Domain');
+    expect(text).toContain('Tool result (error): boom');
+  });
+
+  it('truncates oversized tool result payloads', () => {
+    const text = renderEventsAsTranscript([
+      createToolResult({ ok: true, toolCallId: 'call-1', value: 'x'.repeat(5000) }),
+    ]);
+    expect(text).toContain('[truncated 3000 chars]');
+    expect(text.length).toBeLessThan(3000);
   });
 });
 

--- a/apps/extension/src/shared/agent-context-compaction.ts
+++ b/apps/extension/src/shared/agent-context-compaction.ts
@@ -1,6 +1,9 @@
 import { createAssistantMessage } from './agent-conversation';
 import type { AgentConversationEvent } from './agent-conversation';
-import { isViewportScreenshotValue } from './agent-conversation-persistence';
+import {
+  isPersistedScreenshotStub,
+  isViewportScreenshotValue,
+} from './agent-conversation-persistence';
 import type { FetchLike } from './auth';
 import { fetchKiloGatewayChatCompletionStream } from './kilo-api-client';
 import type { KiloGatewayChatMessage } from './kilo-gateway-chat-client';
@@ -97,8 +100,9 @@ const renderEvent = (event: AgentConversationEvent): string | undefined => {
         return 'Tool result (ok)';
       }
 
-      // A screenshot value is a base64 data URL; keep a placeholder out of the summary, not the PNG.
-      if (isViewportScreenshotValue(event.value)) {
+      // A screenshot value is a base64 data URL (live) or a stripped {mediaType, note} stub
+      // (after a reload); keep a placeholder out of the summary either way, never the PNG or its JSON.
+      if (isViewportScreenshotValue(event.value) || isPersistedScreenshotStub(event.value)) {
         return `Tool result (ok): [${event.value.mediaType} screenshot omitted]`;
       }
 

--- a/apps/extension/src/shared/agent-context-compaction.ts
+++ b/apps/extension/src/shared/agent-context-compaction.ts
@@ -1,5 +1,6 @@
 import { createAssistantMessage } from './agent-conversation';
 import type { AgentConversationEvent } from './agent-conversation';
+import { isViewportScreenshotValue } from './agent-conversation-persistence';
 import type { FetchLike } from './auth';
 import { fetchKiloGatewayChatCompletionStream } from './kilo-api-client';
 import type { KiloGatewayChatMessage } from './kilo-gateway-chat-client';
@@ -92,10 +93,17 @@ const renderEvent = (event: AgentConversationEvent): string | undefined => {
         return `Tool result (error): ${event.error ?? 'unknown error'}`;
       }
 
+      if (event.value === undefined) {
+        return 'Tool result (ok)';
+      }
+
+      // A screenshot value is a base64 data URL; keep a placeholder out of the summary, not the PNG.
+      if (isViewportScreenshotValue(event.value)) {
+        return `Tool result (ok): [${event.value.mediaType} screenshot omitted]`;
+      }
+
       // The result payload (snapshot text, eval return, element details) is often the only record.
-      return event.value === undefined
-        ? 'Tool result (ok)'
-        : `Tool result (ok): ${truncateToolText(stringifyToolValue(event.value))}`;
+      return `Tool result (ok): ${truncateToolText(stringifyToolValue(event.value))}`;
     }
   }
 };

--- a/apps/extension/src/shared/agent-context-compaction.ts
+++ b/apps/extension/src/shared/agent-context-compaction.ts
@@ -73,7 +73,6 @@ interface CompactConversationOptions {
   readonly fetch: FetchLike;
   readonly model: string;
   readonly organizationId?: string | undefined;
-  readonly signal?: AbortSignal | undefined;
   readonly token: string;
 }
 
@@ -83,7 +82,6 @@ export const compactConversationEvents = async ({
   fetch,
   model,
   organizationId,
-  signal,
   token,
 }: CompactConversationOptions): Promise<AgentConversationEvent[] | undefined> => {
   const { toKeep, toSummarize } = splitEventsForCompaction(events);
@@ -99,7 +97,6 @@ export const compactConversationEvents = async ({
     model,
     onContentDelta: () => {},
     organizationId,
-    signal,
     token,
     tools: [],
   });

--- a/apps/extension/src/shared/agent-context-compaction.ts
+++ b/apps/extension/src/shared/agent-context-compaction.ts
@@ -5,6 +5,12 @@ import { fetchKiloGatewayChatCompletionStream } from './kilo-api-client';
 import type { KiloGatewayChatMessage } from './kilo-gateway-chat-client';
 
 export const KEEP_RECENT_EXCHANGES = 2;
+/*
+ * Manual "Compact now" is explicit, so it keeps only the latest exchange. This lets a user compact
+ * a short conversation (2 exchanges) instead of clicking an enabled-but-inert button;
+ * auto-compaction stays at KEEP_RECENT_EXCHANGES for safer continuity near the context limit.
+ */
+export const KEEP_RECENT_EXCHANGES_MANUAL = 1;
 export const SUMMARY_PREFIX = '🗜️ Compacted earlier context\n\n';
 
 const SUMMARY_SYSTEM_PROMPT =
@@ -16,23 +22,33 @@ const isUserMessage = (event: AgentConversationEvent): boolean =>
 // Keep complete exchanges only: cut just before the Nth-from-last user message so kept
 // Events always begin at a user turn and no tool-call/tool-result pair is split.
 export const splitEventsForCompaction = (
-  events: AgentConversationEvent[]
+  events: AgentConversationEvent[],
+  keepRecentExchanges: number = KEEP_RECENT_EXCHANGES
 ): { toKeep: AgentConversationEvent[]; toSummarize: AgentConversationEvent[] } => {
   const userIndexes = events
     .map((event, index) => (isUserMessage(event) ? index : -1))
     .filter(index => index !== -1);
 
-  if (userIndexes.length <= KEEP_RECENT_EXCHANGES) {
+  if (userIndexes.length <= keepRecentExchanges) {
     return { toKeep: events, toSummarize: [] };
   }
 
-  const boundary = userIndexes[userIndexes.length - KEEP_RECENT_EXCHANGES] ?? 0;
+  const boundary = userIndexes[userIndexes.length - keepRecentExchanges] ?? 0;
 
   return {
     toKeep: events.slice(boundary),
     toSummarize: events.slice(0, boundary),
   };
 };
+
+/*
+ * Whether compacting would actually summarize anything. Gates the "Compact now" button so it is
+ * never enabled-but-inert.
+ */
+export const hasCompactableHistory = (
+  events: AgentConversationEvent[],
+  keepRecentExchanges: number = KEEP_RECENT_EXCHANGES
+): boolean => splitEventsForCompaction(events, keepRecentExchanges).toSummarize.length > 0;
 
 const renderEvent = (event: AgentConversationEvent): string | undefined => {
   switch (event.type) {
@@ -71,6 +87,7 @@ interface CompactConversationOptions {
   readonly apiBaseUrl: string;
   readonly events: AgentConversationEvent[];
   readonly fetch: FetchLike;
+  readonly keepRecentExchanges?: number;
   readonly model: string;
   readonly organizationId?: string | undefined;
   readonly token: string;
@@ -80,11 +97,12 @@ export const compactConversationEvents = async ({
   apiBaseUrl,
   events,
   fetch,
+  keepRecentExchanges = KEEP_RECENT_EXCHANGES,
   model,
   organizationId,
   token,
 }: CompactConversationOptions): Promise<AgentConversationEvent[] | undefined> => {
-  const { toKeep, toSummarize } = splitEventsForCompaction(events);
+  const { toKeep, toSummarize } = splitEventsForCompaction(events, keepRecentExchanges);
 
   if (toSummarize.length === 0) {
     return undefined;

--- a/apps/extension/src/shared/agent-context-compaction.ts
+++ b/apps/extension/src/shared/agent-context-compaction.ts
@@ -1,0 +1,114 @@
+import { createAssistantMessage } from './agent-conversation';
+import type { AgentConversationEvent } from './agent-conversation';
+import type { FetchLike } from './auth';
+import { fetchKiloGatewayChatCompletionStream } from './kilo-api-client';
+import type { KiloGatewayChatMessage } from './kilo-gateway-chat-client';
+
+export const KEEP_RECENT_EXCHANGES = 2;
+export const SUMMARY_PREFIX = '🗜️ Compacted earlier context\n\n';
+
+const SUMMARY_SYSTEM_PROMPT =
+  'You compress a browser-agent conversation. Produce a concise but complete summary that preserves: the user’s goals and open requests, key findings about the inspected page(s), decisions made, tool actions taken and their results, and anything needed to continue the task. Use compact prose or bullet points. Do not add new actions or speculation.';
+
+const isUserMessage = (event: AgentConversationEvent): boolean =>
+  event.type === 'message' && event.role === 'user';
+
+// Keep complete exchanges only: cut just before the Nth-from-last user message so kept
+// Events always begin at a user turn and no tool-call/tool-result pair is split.
+export const splitEventsForCompaction = (
+  events: AgentConversationEvent[]
+): { toKeep: AgentConversationEvent[]; toSummarize: AgentConversationEvent[] } => {
+  const userIndexes = events
+    .map((event, index) => (isUserMessage(event) ? index : -1))
+    .filter(index => index !== -1);
+
+  if (userIndexes.length <= KEEP_RECENT_EXCHANGES) {
+    return { toKeep: events, toSummarize: [] };
+  }
+
+  const boundary = userIndexes[userIndexes.length - KEEP_RECENT_EXCHANGES] ?? 0;
+
+  return {
+    toKeep: events.slice(boundary),
+    toSummarize: events.slice(0, boundary),
+  };
+};
+
+const renderEvent = (event: AgentConversationEvent): string | undefined => {
+  switch (event.type) {
+    case 'message': {
+      return `${event.role === 'user' ? 'User' : 'Assistant'}: ${event.text}`;
+    }
+    case 'thinking': {
+      return undefined;
+    }
+    case 'tool-call': {
+      return `Tool call (${event.name})`;
+    }
+    case 'tool-result': {
+      return `Tool result (${event.ok ? 'ok' : 'error'})`;
+    }
+  }
+};
+
+export const renderEventsAsTranscript = (events: AgentConversationEvent[]): string =>
+  events
+    .map(event => renderEvent(event))
+    .filter((line): line is string => line !== undefined)
+    .join('\n');
+
+export const buildSummarizationMessages = (
+  events: AgentConversationEvent[]
+): KiloGatewayChatMessage[] => [
+  { content: SUMMARY_SYSTEM_PROMPT, role: 'system' },
+  {
+    content: `Summarize the following conversation so it can continue with less context.\n\n${renderEventsAsTranscript(events)}`,
+    role: 'user',
+  },
+];
+
+interface CompactConversationOptions {
+  readonly apiBaseUrl: string;
+  readonly events: AgentConversationEvent[];
+  readonly fetch: FetchLike;
+  readonly model: string;
+  readonly organizationId?: string | undefined;
+  readonly signal?: AbortSignal | undefined;
+  readonly token: string;
+}
+
+export const compactConversationEvents = async ({
+  apiBaseUrl,
+  events,
+  fetch,
+  model,
+  organizationId,
+  signal,
+  token,
+}: CompactConversationOptions): Promise<AgentConversationEvent[] | undefined> => {
+  const { toKeep, toSummarize } = splitEventsForCompaction(events);
+
+  if (toSummarize.length === 0) {
+    return undefined;
+  }
+
+  const completion = await fetchKiloGatewayChatCompletionStream({
+    apiBaseUrl,
+    fetch,
+    messages: buildSummarizationMessages(toSummarize),
+    model,
+    onContentDelta: () => {},
+    organizationId,
+    signal,
+    token,
+    tools: [],
+  });
+
+  const summary = completion.content ?? '';
+
+  if (summary.trim() === '') {
+    return undefined;
+  }
+
+  return [createAssistantMessage(`${SUMMARY_PREFIX}${summary}`), ...toKeep];
+};

--- a/apps/extension/src/shared/agent-context-compaction.ts
+++ b/apps/extension/src/shared/agent-context-compaction.ts
@@ -6,11 +6,11 @@ import type { KiloGatewayChatMessage } from './kilo-gateway-chat-client';
 
 export const KEEP_RECENT_EXCHANGES = 2;
 /*
- * Manual "Compact now" is explicit, so it keeps only the latest exchange. This lets a user compact
- * a short conversation (2 exchanges) instead of clicking an enabled-but-inert button;
- * auto-compaction stays at KEEP_RECENT_EXCHANGES for safer continuity near the context limit.
+ * Manual "Compact now" is explicit: it summarizes the whole conversation (keeps no recent exchange),
+ * so the user can compact whenever there is anything to compact. Auto-compaction keeps
+ * KEEP_RECENT_EXCHANGES for safer continuity near the context limit.
  */
-export const KEEP_RECENT_EXCHANGES_MANUAL = 1;
+export const KEEP_RECENT_EXCHANGES_MANUAL = 0;
 export const SUMMARY_PREFIX = '🗜️ Compacted earlier context\n\n';
 
 const SUMMARY_SYSTEM_PROMPT =
@@ -33,7 +33,8 @@ export const splitEventsForCompaction = (
     return { toKeep: events, toSummarize: [] };
   }
 
-  const boundary = userIndexes[userIndexes.length - keepRecentExchanges] ?? 0;
+  // A keep count of 0 keeps nothing: the cut falls past the last user message (whole transcript).
+  const boundary = userIndexes[userIndexes.length - keepRecentExchanges] ?? events.length;
 
   return {
     toKeep: events.slice(boundary),

--- a/apps/extension/src/shared/agent-context-compaction.ts
+++ b/apps/extension/src/shared/agent-context-compaction.ts
@@ -51,6 +51,25 @@ export const hasCompactableHistory = (
   keepRecentExchanges: number = KEEP_RECENT_EXCHANGES
 ): boolean => splitEventsForCompaction(events, keepRecentExchanges).toSummarize.length > 0;
 
+// Cap each tool input/output so a big snapshot or screenshot can't blow up the summarization prompt.
+const MAX_TOOL_TEXT_CHARS = 2000;
+const truncateToolText = (text: string): string =>
+  text.length <= MAX_TOOL_TEXT_CHARS
+    ? text
+    : `${text.slice(0, MAX_TOOL_TEXT_CHARS)}… [truncated ${text.length - MAX_TOOL_TEXT_CHARS} chars]`;
+
+const stringifyToolValue = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
 const renderEvent = (event: AgentConversationEvent): string | undefined => {
   switch (event.type) {
     case 'message': {
@@ -60,10 +79,23 @@ const renderEvent = (event: AgentConversationEvent): string | undefined => {
       return undefined;
     }
     case 'tool-call': {
-      return `Tool call (${event.name})`;
+      // The tool input carries the facts the next turn needs (the eval code, the query/element).
+      const detail =
+        event.name === 'eval' ? event.code : (event.query ?? event.elementId ?? event.snapshotId);
+
+      return detail === undefined || detail === ''
+        ? `Tool call (${event.name})`
+        : `Tool call (${event.name}): ${truncateToolText(detail)}`;
     }
     case 'tool-result': {
-      return `Tool result (${event.ok ? 'ok' : 'error'})`;
+      if (!event.ok) {
+        return `Tool result (error): ${event.error ?? 'unknown error'}`;
+      }
+
+      // The result payload (snapshot text, eval return, element details) is often the only record.
+      return event.value === undefined
+        ? 'Tool result (ok)'
+        : `Tool result (ok): ${truncateToolText(stringifyToolValue(event.value))}`;
     }
   }
 };

--- a/apps/extension/src/shared/agent-conversation-persistence.ts
+++ b/apps/extension/src/shared/agent-conversation-persistence.ts
@@ -3,7 +3,7 @@ import type { AgentConversationEvent } from './agent-conversation';
 type ToolCallEvent = Extract<AgentConversationEvent, { readonly type: 'tool-call' }>;
 type ToolResultEvent = Extract<AgentConversationEvent, { readonly type: 'tool-result' }>;
 
-const isViewportScreenshotValue = (
+export const isViewportScreenshotValue = (
   value: unknown
 ): value is { readonly mediaType: string; readonly dataUrl: string } =>
   typeof value === 'object' &&

--- a/apps/extension/src/shared/agent-conversation-persistence.ts
+++ b/apps/extension/src/shared/agent-conversation-persistence.ts
@@ -14,6 +14,18 @@ export const isViewportScreenshotValue = (
   'mediaType' in value &&
   typeof value.mediaType === 'string';
 
+// The persisted counterpart of a screenshot result: dataUrl stripped, mediaType + note kept.
+export const isPersistedScreenshotStub = (
+  value: unknown
+): value is { readonly mediaType: string; readonly note: string } =>
+  typeof value === 'object' &&
+  value !== null &&
+  !('dataUrl' in value) &&
+  'mediaType' in value &&
+  typeof value.mediaType === 'string' &&
+  'note' in value &&
+  typeof value.note === 'string';
+
 const toPersistedToolResult = (
   event: ToolResultEvent,
   toolCall: ToolCallEvent | undefined

--- a/apps/extension/src/shared/agent-llm-turn-runner-core.test.ts
+++ b/apps/extension/src/shared/agent-llm-turn-runner-core.test.ts
@@ -57,6 +57,42 @@ const streamResponse = (chunks: string[]): Response => {
 };
 
 describe('agent LLM turn runner core', () => {
+  it('forwards completion usage to onUsage', async () => {
+    const usageCalls: unknown[] = [];
+    const fetch: FetchLike = () =>
+      streamResponse([
+        'data: {"choices":[{"delta":{"content":"Done."}}]}\n\n',
+        'data: {"choices":[],"usage":{"completion_tokens":5,"prompt_tokens":999,"total_tokens":1004}}\n\n',
+        'data: [DONE]\n\n',
+      ]);
+
+    await runLlmTurn({
+      apiBaseUrl: 'https://app.kilo.ai',
+      appendEvents: () => {},
+      conversationEvents: [createUserMessage('Hello')],
+      executeToolCall: () => Promise.resolve({ ok: true, value: { text: '' } }),
+      failureMessage: String,
+      fetch,
+      maxToolRounds: 4,
+      model: 'anthropic/claude-sonnet-4',
+      noResponseMessage: 'No response.',
+      onUsage: usage => usageCalls.push(usage),
+      signal: undefined,
+      toToolCallEvents: () => [],
+      token: 'token-1',
+      tooManyToolRoundsMessage: 'Too many rounds.',
+      tools: [],
+      updateAssistantMessage: () => {},
+      updateThinkingBlock: () => {},
+    });
+
+    expect(usageCalls).toContainEqual({
+      completionTokens: 5,
+      promptTokens: 999,
+      totalTokens: 1004,
+    });
+  });
+
   it('streams, runs tools, and continues with tool results', async () => {
     const appendedEvents: AgentConversationEvent[] = [];
     const updatedMessages: string[] = [];

--- a/apps/extension/src/shared/agent-llm-turn-runner-core.test.ts
+++ b/apps/extension/src/shared/agent-llm-turn-runner-core.test.ts
@@ -87,9 +87,7 @@ describe('agent LLM turn runner core', () => {
     });
 
     expect(usageCalls).toContainEqual({
-      completionTokens: 5,
       promptTokens: 999,
-      totalTokens: 1004,
     });
   });
 

--- a/apps/extension/src/shared/agent-llm-turn-runner-core.ts
+++ b/apps/extension/src/shared/agent-llm-turn-runner-core.ts
@@ -10,9 +10,7 @@ import type { EvalTabResult } from './tab-debugger';
 type ToolCallEvent = Extract<AgentConversationEvent, { readonly type: 'tool-call' }>;
 
 export interface TurnUsage {
-  readonly completionTokens: number;
   readonly promptTokens: number;
-  readonly totalTokens: number;
 }
 
 export type OnTurnUsage = (usage: TurnUsage) => void;

--- a/apps/extension/src/shared/agent-llm-turn-runner-core.ts
+++ b/apps/extension/src/shared/agent-llm-turn-runner-core.ts
@@ -9,6 +9,14 @@ import type { EvalTabResult } from './tab-debugger';
 
 type ToolCallEvent = Extract<AgentConversationEvent, { readonly type: 'tool-call' }>;
 
+export interface TurnUsage {
+  readonly completionTokens: number;
+  readonly promptTokens: number;
+  readonly totalTokens: number;
+}
+
+export type OnTurnUsage = (usage: TurnUsage) => void;
+
 interface RunLlmTurnOptions<ToolCall extends ToolCallEvent> {
   readonly apiBaseUrl: string;
   readonly appendEvents: (events: AgentConversationEvent[]) => void;
@@ -19,6 +27,7 @@ interface RunLlmTurnOptions<ToolCall extends ToolCallEvent> {
   readonly maxToolRounds: number;
   readonly model: string;
   readonly noResponseMessage: string;
+  readonly onUsage?: OnTurnUsage | undefined;
   readonly organizationId?: string | undefined;
   readonly signal?: AbortSignal | undefined;
   readonly supportsImages?: boolean | undefined;
@@ -60,6 +69,7 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
   maxToolRounds,
   model,
   noResponseMessage,
+  onUsage,
   organizationId,
   signal,
   supportsImages = false,
@@ -132,6 +142,10 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
         updateThinkingBlock(streamedThinkingEventId, streamedThinkingText);
       }
     );
+
+    if (completion.usage !== undefined) {
+      onUsage?.(completion.usage);
+    }
 
     if (streamedThinkingEventId !== undefined) {
       const finalStreamedThinkingText = completion.reasoning ?? streamedThinkingText;

--- a/apps/extension/src/shared/context-usage.test.ts
+++ b/apps/extension/src/shared/context-usage.test.ts
@@ -29,4 +29,8 @@ describe('context summary formatting', () => {
   it('omits percent without a context length', () => {
     expect(formatContextSummary(1200, undefined as number | undefined)).toBe('1,200 tokens');
   });
+
+  it('caps the percent at 100% when tokens exceed the window', () => {
+    expect(formatContextSummary(300_000, 200_000)).toBe('300,000 / 200,000 tokens (100%)');
+  });
 });

--- a/apps/extension/src/shared/context-usage.test.ts
+++ b/apps/extension/src/shared/context-usage.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  formatContextSummary,
-  getContextRatio,
-  getContextTone,
-} from './context-usage';
+import { formatContextSummary, getContextRatio, getContextTone } from './context-usage';
 
 describe('context ratio', () => {
   it('returns undefined without a context length', () => {

--- a/apps/extension/src/shared/context-usage.test.ts
+++ b/apps/extension/src/shared/context-usage.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatContextSummary,
+  getContextRatio,
+  getContextTone,
+} from './context-usage';
+
+describe('context ratio', () => {
+  it('returns undefined without a context length', () => {
+    expect(getContextRatio(100, undefined as number | undefined)).toBeUndefined();
+    expect(getContextRatio(100, 0)).toBeUndefined();
+  });
+
+  it('returns a clamped ratio', () => {
+    expect(getContextRatio(50, 200)).toBeCloseTo(0.25);
+    expect(getContextRatio(500, 200)).toBe(1);
+  });
+});
+
+describe('context tone', () => {
+  it('maps ratio to tone', () => {
+    expect(getContextTone(0.5)).toBe('safe');
+    expect(getContextTone(0.75)).toBe('warn');
+    expect(getContextTone(0.95)).toBe('danger');
+  });
+});
+
+describe('context summary formatting', () => {
+  it('formats tokens and percent', () => {
+    expect(formatContextSummary(1200, 200_000)).toBe('1,200 / 200,000 tokens (1%)');
+  });
+
+  it('omits percent without a context length', () => {
+    expect(formatContextSummary(1200, undefined as number | undefined)).toBe('1,200 tokens');
+  });
+});

--- a/apps/extension/src/shared/context-usage.ts
+++ b/apps/extension/src/shared/context-usage.ts
@@ -39,7 +39,8 @@ export const formatContextSummary = (
     return `${formatCount(promptTokens)} tokens`;
   }
 
-  const percent = Math.round((promptTokens / contextLength) * 100);
+  // Clamp keeps a malformed (e.g. NaN) promptTokens from rendering as "NaN%".
+  const percent = Math.round(clamp01(promptTokens / contextLength) * 100);
 
   return `${formatCount(promptTokens)} / ${formatCount(contextLength)} tokens (${percent}%)`;
 };

--- a/apps/extension/src/shared/context-usage.ts
+++ b/apps/extension/src/shared/context-usage.ts
@@ -1,0 +1,45 @@
+export interface ContextUsage {
+  readonly promptTokens: number;
+}
+
+export const AUTO_COMPACT_RATIO = 0.85;
+
+const clamp01 = (value: number): number => Math.min(1, Math.max(0, value));
+
+export const getContextRatio = (
+  promptTokens: number,
+  contextLength: number | undefined
+): number | undefined => {
+  if (contextLength === undefined || contextLength <= 0) {
+    return undefined;
+  }
+
+  return clamp01(promptTokens / contextLength);
+};
+
+export const getContextTone = (ratio: number): 'danger' | 'safe' | 'warn' => {
+  if (ratio >= 0.9) {
+    return 'danger';
+  }
+
+  if (ratio >= 0.7) {
+    return 'warn';
+  }
+
+  return 'safe';
+};
+
+const formatCount = (value: number): string => value.toLocaleString('en-US');
+
+export const formatContextSummary = (
+  promptTokens: number,
+  contextLength: number | undefined
+): string => {
+  if (contextLength === undefined || contextLength <= 0) {
+    return `${formatCount(promptTokens)} tokens`;
+  }
+
+  const percent = Math.round((promptTokens / contextLength) * 100);
+
+  return `${formatCount(promptTokens)} / ${formatCount(contextLength)} tokens (${percent}%)`;
+};

--- a/apps/extension/src/shared/context-usage.ts
+++ b/apps/extension/src/shared/context-usage.ts
@@ -39,7 +39,7 @@ export const formatContextSummary = (
     return `${formatCount(promptTokens)} tokens`;
   }
 
-  // Clamp keeps a malformed (e.g. NaN) promptTokens from rendering as "NaN%".
+  // Clamp caps the displayed percent at 100% when prompt tokens exceed the context window.
   const percent = Math.round(clamp01(promptTokens / contextLength) * 100);
 
   return `${formatCount(promptTokens)} / ${formatCount(contextLength)} tokens (${percent}%)`;

--- a/apps/extension/src/shared/kilo-api-client.test.ts
+++ b/apps/extension/src/shared/kilo-api-client.test.ts
@@ -177,6 +177,14 @@ describe('kilo API client', () => {
     );
   });
 
+  it('parses context_length into contextLength', () => {
+    const options = parseKiloGatewayModelsResponse({
+      data: [{ context_length: 200_000, id: 'a/b', name: 'A: B', opencode: { variants: {} } }],
+    });
+
+    expect(options[0]?.contextLength).toBe(200_000);
+  });
+
   it('labels thinking efforts compactly', () => {
     expect(thinkingEffortLabel('medium')).toBe('Med');
     expect(thinkingEffortLabel('xhigh')).toBe('XHigh');

--- a/apps/extension/src/shared/kilo-api-client.ts
+++ b/apps/extension/src/shared/kilo-api-client.ts
@@ -14,6 +14,7 @@ export type {
 } from './kilo-gateway-chat-client';
 
 export interface KiloGatewayModelOption {
+  readonly contextLength?: number;
   readonly hasUserByokAvailable?: boolean;
   readonly id: string;
   readonly isFree?: boolean;
@@ -45,6 +46,7 @@ interface FetchKiloOrganizationsOptions {
 }
 
 interface ParsedGatewayModelOption {
+  contextLength?: number;
   hasUserByokAvailable?: boolean;
   id: string;
   isFree?: boolean;
@@ -64,6 +66,7 @@ const modelSchema = z.object({
       input_modalities: z.array(z.string()).optional(),
     })
     .optional(),
+  context_length: z.number().nullable().optional(),
   hasUserByokAvailable: z.boolean().optional(),
   id: nonEmptyStringSchema,
   isFree: z.boolean().optional(),
@@ -129,6 +132,7 @@ const compareModelOptions = (
 
 const toGatewayModelOption = (model: ParsedGatewayModelOption): KiloGatewayModelOption => {
   const option: {
+    contextLength?: number;
     hasUserByokAvailable?: boolean;
     id: string;
     isFree?: boolean;
@@ -143,6 +147,10 @@ const toGatewayModelOption = (model: ParsedGatewayModelOption): KiloGatewayModel
     name: model.name,
     variants: model.variants,
   };
+
+  if (model.contextLength !== undefined) {
+    option.contextLength = model.contextLength;
+  }
 
   if (model.hasUserByokAvailable !== undefined) {
     option.hasUserByokAvailable = model.hasUserByokAvailable;
@@ -183,6 +191,11 @@ export const parseKiloGatewayModelsResponse = (value: unknown): KiloGatewayModel
         isPreferred: model.data.preferredIndex !== undefined,
         name: formatShortModelName(model.data.name),
         variants: getModelVariants(model.data),
+        ...(model.data.context_length !== undefined &&
+        model.data.context_length !== null &&
+        model.data.context_length > 0
+          ? { contextLength: model.data.context_length }
+          : {}),
         ...(model.data.hasUserByokAvailable === undefined
           ? {}
           : { hasUserByokAvailable: model.data.hasUserByokAvailable }),

--- a/apps/extension/src/shared/kilo-gateway-chat-client.ts
+++ b/apps/extension/src/shared/kilo-gateway-chat-client.ts
@@ -54,4 +54,9 @@ export interface KiloGatewayChatCompletion {
   readonly reasoning?: string;
   readonly reasoningDetails?: readonly unknown[];
   readonly toolCalls: KiloGatewayToolCallRequest[];
+  readonly usage?: {
+    readonly completionTokens: number;
+    readonly promptTokens: number;
+    readonly totalTokens: number;
+  };
 }

--- a/apps/extension/src/shared/kilo-gateway-chat-client.ts
+++ b/apps/extension/src/shared/kilo-gateway-chat-client.ts
@@ -55,8 +55,6 @@ export interface KiloGatewayChatCompletion {
   readonly reasoningDetails?: readonly unknown[];
   readonly toolCalls: KiloGatewayToolCallRequest[];
   readonly usage?: {
-    readonly completionTokens: number;
     readonly promptTokens: number;
-    readonly totalTokens: number;
   };
 }

--- a/apps/extension/src/shared/kilo-gateway-chat-stream-client.test.ts
+++ b/apps/extension/src/shared/kilo-gateway-chat-stream-client.test.ts
@@ -476,9 +476,7 @@ describe('kilo gateway chat stream client', () => {
     const completion = parseKiloGatewayChatCompletionStream(sse, () => {});
 
     expect(completion.usage).toStrictEqual({
-      completionTokens: 34,
       promptTokens: 1200,
-      totalTokens: 1234,
     });
   });
 });

--- a/apps/extension/src/shared/kilo-gateway-chat-stream-client.test.ts
+++ b/apps/extension/src/shared/kilo-gateway-chat-stream-client.test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable max-lines */
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { fetchKiloGatewayChatCompletionStream } from './kilo-api-client';
+import {
+  fetchKiloGatewayChatCompletionStream,
+  parseKiloGatewayChatCompletionStream,
+} from './kilo-api-client';
 import type { FetchLike } from './auth';
 
 const jsonRequestBodySchema = z.record(z.string(), z.unknown());
@@ -461,5 +464,21 @@ describe('kilo gateway chat stream client', () => {
     });
 
     expect(seenBody).not.toHaveProperty('reasoning');
+  });
+
+  it('extracts usage from the trailing usage chunk', () => {
+    const sse = [
+      'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+      'data: {"choices":[],"usage":{"prompt_tokens":1200,"completion_tokens":34,"total_tokens":1234}}\n\n',
+      'data: [DONE]\n\n',
+    ].join('');
+
+    const completion = parseKiloGatewayChatCompletionStream(sse, () => {});
+
+    expect(completion.usage).toStrictEqual({
+      completionTokens: 34,
+      promptTokens: 1200,
+      totalTokens: 1234,
+    });
   });
 });

--- a/apps/extension/src/shared/kilo-gateway-chat-stream-client.ts
+++ b/apps/extension/src/shared/kilo-gateway-chat-stream-client.ts
@@ -36,6 +36,7 @@ interface StreamingAccumulator {
   reasoning: string;
   reasoningDetailsByIndex: Map<number, Record<string, unknown>>;
   toolCallsByIndex: Map<number, StreamingToolCallBuffer>;
+  usage: KiloGatewayChatCompletion['usage'];
 }
 
 interface StreamingDeltaHandlers {
@@ -81,6 +82,11 @@ const streamingToolCallDeltaSchema = z.object({
   id: z.string().optional(),
   index: z.number(),
 });
+const usageSchema = z.object({
+  completion_tokens: z.number(),
+  prompt_tokens: z.number(),
+  total_tokens: z.number(),
+});
 const streamDataSchema = z.object({
   choices: z.array(
     z.object({
@@ -92,6 +98,7 @@ const streamDataSchema = z.object({
       }),
     })
   ),
+  usage: usageSchema.nullable().optional(),
 });
 // Reasoning blocks stream incrementally like content: text accumulates while structural fields (type/signature/data/index) carry their final value. Providers may require these signed/encrypted blocks replayed verbatim on the assistant tool-call message or they reject the continuation.
 const appendableReasoningKeys = new Set(['data', 'summary', 'text']);
@@ -247,6 +254,14 @@ const applyStreamingData = (
     return;
   }
 
+  if (parsed.data.usage !== undefined && parsed.data.usage !== null) {
+    accumulator.usage = {
+      completionTokens: parsed.data.usage.completion_tokens,
+      promptTokens: parsed.data.usage.prompt_tokens,
+      totalTokens: parsed.data.usage.total_tokens,
+    };
+  }
+
   const choice = parsed.data.choices.at(0);
 
   if (choice === undefined) {
@@ -287,6 +302,7 @@ const toCompletion = (accumulator: StreamingAccumulator): KiloGatewayChatComplet
     ...(accumulator.content === '' ? {} : { content: accumulator.content }),
     ...(accumulator.reasoning === '' ? {} : { reasoning: accumulator.reasoning }),
     ...(reasoningDetails.length === 0 ? {} : { reasoningDetails }),
+    ...(accumulator.usage === undefined ? {} : { usage: accumulator.usage }),
     toolCalls: [...accumulator.toolCallsByIndex.values()].map(toolCall =>
       parseToolCallBuffer(toolCall)
     ),
@@ -305,6 +321,7 @@ export const parseKiloGatewayChatCompletionStream = (
     reasoning: '',
     reasoningDetailsByIndex: new Map(),
     toolCallsByIndex: new Map(),
+    usage: undefined,
   };
   const handlers = { onContentDelta, onReasoningDelta };
 
@@ -362,6 +379,7 @@ const consumeKiloGatewayChatCompletionStream = async (
     reasoning: '',
     reasoningDetailsByIndex: new Map(),
     toolCallsByIndex: new Map(),
+    usage: undefined,
   };
   const reader = body.getReader();
   const decoder = new TextDecoder();
@@ -393,6 +411,7 @@ export const fetchKiloGatewayChatCompletionStream = async ({
     messages,
     model,
     stream: true,
+    stream_options: { include_usage: true },
     temperature: 0,
     tool_choice: tools.length === 0 ? 'none' : 'auto',
     tools,

--- a/apps/extension/src/shared/kilo-gateway-chat-stream-client.ts
+++ b/apps/extension/src/shared/kilo-gateway-chat-stream-client.ts
@@ -82,10 +82,9 @@ const streamingToolCallDeltaSchema = z.object({
   id: z.string().optional(),
   index: z.number(),
 });
+// Only prompt_tokens is consumed (the context-usage ratio); other usage fields are ignored.
 const usageSchema = z.object({
-  completion_tokens: z.number(),
   prompt_tokens: z.number(),
-  total_tokens: z.number(),
 });
 const streamDataSchema = z.object({
   choices: z.array(
@@ -255,11 +254,7 @@ const applyStreamingData = (
   }
 
   if (parsed.data.usage !== undefined && parsed.data.usage !== null) {
-    accumulator.usage = {
-      completionTokens: parsed.data.usage.completion_tokens,
-      promptTokens: parsed.data.usage.prompt_tokens,
-      totalTokens: parsed.data.usage.total_tokens,
-    };
+    accumulator.usage = { promptTokens: parsed.data.usage.prompt_tokens };
   }
 
   const choice = parsed.data.choices.at(0);

--- a/apps/extension/src/shared/tab-debugger.ts
+++ b/apps/extension/src/shared/tab-debugger.ts
@@ -304,7 +304,7 @@ const getPngDimensions = (dataUrl: string): { height: number; width: number } | 
   }
 };
 
-// Ponytail: one global capture lock since captureVisibleTab grabs whichever tab is active in a window, so the activate/capture/restore window must not interleave (screenshots are rare; key per-window only if throughput matters).
+// One global capture lock since captureVisibleTab grabs whichever tab is active in a window, so the activate/capture/restore window must not interleave (screenshots are rare; key per-window only if throughput matters).
 const ignoreSettled = (): void => {};
 // eslint-disable-next-line promise/prefer-await-to-then
 let screenshotCaptureChain: Promise<unknown> = Promise.resolve();

--- a/apps/extension/tests/e2e/context-usage.test.ts
+++ b/apps/extension/tests/e2e/context-usage.test.ts
@@ -2,14 +2,42 @@
 import { expect, test } from '@playwright/test';
 import { rm } from 'node:fs/promises';
 import { mockKiloApi } from './kilo-api-fixture';
+import type { Page } from '@playwright/test';
 import {
   launchExtensionContext,
   seedExtensionAuth,
   setExtensionStorage,
   startFixtureServer,
+  waitForStoredConversationText,
 } from './extension-context-fixture';
 
 const safeToolNames = ['get_page_snapshot', 'get_element_details', 'find_in_page'];
+
+/*
+ * Read the persisted conversation store as a JSON string. Storage is the source of truth and is
+ * immune to the virtualized conversation list's render/scroll timing, so assertions against it are
+ * not racy while auto-compaction rewrites events.
+ */
+const readStoredConversationsJson = (page: Page): Promise<string> =>
+  page.evaluate(async () => {
+    const storage = (
+      globalThis as typeof globalThis & {
+        chrome?: {
+          storage?: {
+            local?: { get: (keys: string[]) => Promise<Record<string, unknown>> };
+          };
+        };
+      }
+    ).chrome?.storage?.local;
+
+    if (storage === undefined) {
+      throw new Error('Extension runtime storage is unavailable.');
+    }
+
+    const items = await storage.get(['kiloAgentConversations']);
+
+    return JSON.stringify(items['kiloAgentConversations'] ?? null);
+  });
 
 const modelWithContextLength = [
   {
@@ -114,16 +142,21 @@ test('auto-compaction fires when usage exceeds 85% threshold', async () => {
     await sidePanel.getByLabel('Message agent').fill('Trigger compact');
     await expect(sidePanel.getByRole('button', { name: 'Send message' })).toBeEnabled();
     await sidePanel.getByLabel('Message agent').press('Enter');
-    await expect(sidePanel.getByText('Threshold reply.')).toBeVisible();
 
-    // Wait for the compacted prefix to appear (auto-compact fires asynchronously after the turn)
-    await expect(sidePanel.getByText(/Compacted earlier context/u)).toBeVisible({
-      timeout: 10_000,
-    });
+    /*
+     * Auto-compaction fires in the run's finally. Assert against persisted storage rather than the
+     * virtualized list, which can momentarily unmount rows while compaction rewrites events.
+     */
+    await waitForStoredConversationText(sidePanel, 'Compacted earlier context');
 
-    // Earliest seeded user messages should be gone
-    await expect(sidePanel.getByText('First message')).toBeHidden();
-    await expect(sidePanel.getByText('Second message')).toBeHidden();
+    /*
+     * The summary replaced the earliest seeded messages in the same atomic write, so once the
+     * prefix is stored the old messages are already gone.
+     */
+    const conversationsJson = await readStoredConversationsJson(sidePanel);
+    expect(conversationsJson).toContain('SUMMARY: user inspected the page.');
+    expect(conversationsJson).not.toContain('First message');
+    expect(conversationsJson).not.toContain('Second message');
 
     // The summarization call must have tool_choice: 'none' (sent with tools: [])
     const [, summarizationBody] = seenChatBodies;
@@ -141,8 +174,14 @@ test('manual "Compact now" compacts the conversation', async () => {
 
   try {
     await mockKiloApi(context, {
-      // First call: normal user turn (no threshold breach — low usage)
-      firstCompletionEvents: [{ choices: [{ delta: { content: 'Normal reply.' } }] }],
+      /*
+       * First call: normal user turn. Sub-threshold usage (300/1000 = 30%) leaves auto-compaction
+       * untriggered but gives the donut a non-zero token count so "Compact now" is enabled.
+       */
+      firstCompletionEvents: [
+        { choices: [{ delta: { content: 'Normal reply.' } }] },
+        { choices: [], usage: { completion_tokens: 10, prompt_tokens: 300, total_tokens: 310 } },
+      ],
       models: modelWithContextLength,
       // Second call: summarization triggered by "Compact now"
       secondCompletionEvents: [
@@ -172,7 +211,11 @@ test('manual "Compact now" compacts the conversation', async () => {
     await expect(sidePanel.getByText(/Compacted earlier context/u)).toBeVisible({
       timeout: 10_000,
     });
-    // Send button should be re-enabled after compaction
+    /*
+     * Compaction released the input lock: with a fresh draft, Send is enabled again. It stays
+     * disabled on an empty draft, which is unrelated to compaction.
+     */
+    await sidePanel.getByLabel('Message agent').fill('After compaction');
     await expect(sidePanel.getByRole('button', { name: 'Send message' })).toBeEnabled();
   } finally {
     await context.close();

--- a/apps/extension/tests/e2e/context-usage.test.ts
+++ b/apps/extension/tests/e2e/context-usage.test.ts
@@ -20,7 +20,6 @@ const modelWithContextLength = [
   },
 ];
 
-
 // Three-user-message conversation for compaction (splitEventsForCompaction needs >KEEP_RECENT_EXCHANGES=2 user messages)
 const seededConversationStore = {
   activeConversationId: 'conv-1',
@@ -94,11 +93,11 @@ test('auto-compaction fires when usage exceeds 85% threshold', async () => {
         { choices: [], usage: { completion_tokens: 10, prompt_tokens: 900, total_tokens: 910 } },
       ],
       models: modelWithContextLength,
-      seenChatBodies,
       // Second call: the summarization request (tool_choice: 'none')
       secondCompletionEvents: [
         { choices: [{ delta: { content: 'SUMMARY: user inspected the page.' } }] },
       ],
+      seenChatBodies,
       toolNames: safeToolNames,
     });
 
@@ -127,7 +126,7 @@ test('auto-compaction fires when usage exceeds 85% threshold', async () => {
     await expect(sidePanel.getByText('Second message')).toBeHidden();
 
     // The summarization call must have tool_choice: 'none' (sent with tools: [])
-    const summarizationBody = seenChatBodies[1];
+    const [, summarizationBody] = seenChatBodies;
     expect(summarizationBody).toMatchObject({ tool_choice: 'none' });
   } finally {
     await context.close();

--- a/apps/extension/tests/e2e/context-usage.test.ts
+++ b/apps/extension/tests/e2e/context-usage.test.ts
@@ -176,7 +176,8 @@ test('manual "Compact now" compacts the conversation', async () => {
     await mockKiloApi(context, {
       /*
        * First call: normal user turn. Sub-threshold usage (300/1000 = 30%) leaves auto-compaction
-       * untriggered but gives the donut a non-zero token count so "Compact now" is enabled.
+       * untriggered and gives the donut a non-zero token count. "Compact now" is enabled by having
+       * summarizable history (the seeded conversation), not by this usage value.
        */
       firstCompletionEvents: [
         { choices: [{ delta: { content: 'Normal reply.' } }] },

--- a/apps/extension/tests/e2e/context-usage.test.ts
+++ b/apps/extension/tests/e2e/context-usage.test.ts
@@ -1,0 +1,183 @@
+/* eslint-disable import/no-nodejs-modules, max-lines */
+import { expect, test } from '@playwright/test';
+import { rm } from 'node:fs/promises';
+import { mockKiloApi } from './kilo-api-fixture';
+import {
+  launchExtensionContext,
+  seedExtensionAuth,
+  setExtensionStorage,
+  startFixtureServer,
+} from './extension-context-fixture';
+
+const safeToolNames = ['get_page_snapshot', 'get_element_details', 'find_in_page'];
+
+const modelWithContextLength = [
+  {
+    contextLength: 1000,
+    id: 'anthropic/claude-sonnet-4',
+    name: 'Anthropic: Claude Sonnet 4',
+    variants: { high: {}, low: {}, medium: {} },
+  },
+];
+
+
+// Three-user-message conversation for compaction (splitEventsForCompaction needs >KEEP_RECENT_EXCHANGES=2 user messages)
+const seededConversationStore = {
+  activeConversationId: 'conv-1',
+  conversations: [
+    {
+      events: [
+        { id: 'e1', role: 'user', text: 'First message', type: 'message' },
+        { id: 'e2', role: 'assistant', text: 'First reply', type: 'message' },
+        { id: 'e3', role: 'user', text: 'Second message', type: 'message' },
+        { id: 'e4', role: 'assistant', text: 'Second reply', type: 'message' },
+        { id: 'e5', role: 'user', text: 'Third message', type: 'message' },
+        { id: 'e6', role: 'assistant', text: 'Third reply', type: 'message' },
+      ],
+      id: 'conv-1',
+      title: 'Seeded conversation',
+      updatedAt: '2026-06-26T10:00:00.000Z',
+    },
+  ],
+  openConversationIds: ['conv-1'],
+};
+
+test('context donut shows usage after a reply', async () => {
+  const fixture = await startFixtureServer();
+  const { context, extensionId, userDataDir } = await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context, {
+      firstCompletionEvents: [
+        { choices: [{ delta: { content: 'Donut reply.' } }] },
+        { choices: [], usage: { completion_tokens: 10, prompt_tokens: 850, total_tokens: 860 } },
+      ],
+      models: modelWithContextLength,
+      toolNames: safeToolNames,
+    });
+
+    const page = await context.newPage();
+    await page.goto(fixture.url);
+
+    const sidePanel = await context.newPage();
+    await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
+    await seedExtensionAuth(sidePanel);
+    await sidePanel.reload();
+
+    await sidePanel.getByLabel('Message agent').fill('Show me usage');
+    // Wait for send to be enabled (model + target tab ready)
+    await expect(sidePanel.getByRole('button', { name: 'Send message' })).toBeEnabled();
+    await sidePanel.getByLabel('Message agent').press('Enter');
+    await expect(sidePanel.getByText('Donut reply.')).toBeVisible();
+
+    // The donut <summary> aria-label is "Context usage: <summary>"
+    const donut = sidePanel.getByLabel(/^Context usage:/u);
+    await expect(donut).toBeVisible();
+    await expect(donut).toHaveAttribute('aria-label', 'Context usage: 850 / 1,000 tokens (85%)');
+  } finally {
+    await context.close();
+    await fixture.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});
+
+test('auto-compaction fires when usage exceeds 85% threshold', async () => {
+  const fixture = await startFixtureServer();
+  const seenChatBodies: unknown[] = [];
+  const { context, extensionId, userDataDir } = await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context, {
+      // First call: the user's turn — returns usage ≥85% which triggers auto-compact
+      firstCompletionEvents: [
+        { choices: [{ delta: { content: 'Threshold reply.' } }] },
+        { choices: [], usage: { completion_tokens: 10, prompt_tokens: 900, total_tokens: 910 } },
+      ],
+      models: modelWithContextLength,
+      seenChatBodies,
+      // Second call: the summarization request (tool_choice: 'none')
+      secondCompletionEvents: [
+        { choices: [{ delta: { content: 'SUMMARY: user inspected the page.' } }] },
+      ],
+      toolNames: safeToolNames,
+    });
+
+    const page = await context.newPage();
+    await page.goto(fixture.url);
+
+    const sidePanel = await context.newPage();
+    await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
+    await seedExtensionAuth(sidePanel);
+    // Seed a conversation with 3 user messages so splitEventsForCompaction has something to compact
+    await setExtensionStorage(sidePanel, { kiloAgentConversations: seededConversationStore });
+    await sidePanel.reload();
+
+    await sidePanel.getByLabel('Message agent').fill('Trigger compact');
+    await expect(sidePanel.getByRole('button', { name: 'Send message' })).toBeEnabled();
+    await sidePanel.getByLabel('Message agent').press('Enter');
+    await expect(sidePanel.getByText('Threshold reply.')).toBeVisible();
+
+    // Wait for the compacted prefix to appear (auto-compact fires asynchronously after the turn)
+    await expect(sidePanel.getByText(/Compacted earlier context/u)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Earliest seeded user messages should be gone
+    await expect(sidePanel.getByText('First message')).toBeHidden();
+    await expect(sidePanel.getByText('Second message')).toBeHidden();
+
+    // The summarization call must have tool_choice: 'none' (sent with tools: [])
+    const summarizationBody = seenChatBodies[1];
+    expect(summarizationBody).toMatchObject({ tool_choice: 'none' });
+  } finally {
+    await context.close();
+    await fixture.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});
+
+test('manual "Compact now" compacts the conversation', async () => {
+  const fixture = await startFixtureServer();
+  const { context, extensionId, userDataDir } = await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context, {
+      // First call: normal user turn (no threshold breach — low usage)
+      firstCompletionEvents: [{ choices: [{ delta: { content: 'Normal reply.' } }] }],
+      models: modelWithContextLength,
+      // Second call: summarization triggered by "Compact now"
+      secondCompletionEvents: [
+        { choices: [{ delta: { content: 'SUMMARY: manually compacted.' } }] },
+      ],
+      toolNames: safeToolNames,
+    });
+
+    const page = await context.newPage();
+    await page.goto(fixture.url);
+
+    const sidePanel = await context.newPage();
+    await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
+    await seedExtensionAuth(sidePanel);
+    await setExtensionStorage(sidePanel, { kiloAgentConversations: seededConversationStore });
+    await sidePanel.reload();
+
+    await sidePanel.getByLabel('Message agent').fill('Manual compact trigger');
+    await expect(sidePanel.getByRole('button', { name: 'Send message' })).toBeEnabled();
+    await sidePanel.getByLabel('Message agent').press('Enter');
+    await expect(sidePanel.getByText('Normal reply.')).toBeVisible();
+
+    // Open the donut popover and click Compact now
+    await sidePanel.getByLabel(/^Context usage:/u).click();
+    await sidePanel.getByRole('button', { name: 'Compact now' }).click();
+
+    await expect(sidePanel.getByText(/Compacted earlier context/u)).toBeVisible({
+      timeout: 10_000,
+    });
+    // Send button should be re-enabled after compaction
+    await expect(sidePanel.getByRole('button', { name: 'Send message' })).toBeEnabled();
+  } finally {
+    await context.close();
+    await fixture.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});

--- a/apps/extension/tests/e2e/conversation-drafts.test.ts
+++ b/apps/extension/tests/e2e/conversation-drafts.test.ts
@@ -1,0 +1,55 @@
+/* eslint-disable import/no-nodejs-modules */
+import { expect, test } from '@playwright/test';
+import { rm } from 'node:fs/promises';
+import { mockKiloApi } from './kilo-api-fixture';
+import {
+  launchExtensionContext,
+  seedExtensionAuth,
+  startFixtureServer,
+} from './extension-context-fixture';
+
+test('per-conversation drafts are preserved when switching tabs', async () => {
+  const fixture = await startFixtureServer();
+  const { context, extensionId, userDataDir } = await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context);
+
+    const page = await context.newPage();
+    await page.goto(fixture.url);
+
+    const sidePanel = await context.newPage();
+    await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
+    await seedExtensionAuth(sidePanel);
+    await sidePanel.reload();
+
+    const input = sidePanel.getByLabel('Message agent');
+
+    // Wait for the panel to be ready (model loaded)
+    await expect(sidePanel.getByLabel('Model')).not.toContainText('Loading');
+
+    // Type a draft in conversation 1
+    await input.fill('draft A');
+    await expect(input).toHaveValue('draft A');
+
+    // Open a new conversation — input should be empty
+    await sidePanel.getByLabel('New conversation').click();
+    await expect(input).toHaveValue('');
+
+    // Type a draft in conversation 2
+    await input.fill('draft B');
+    await expect(input).toHaveValue('draft B');
+
+    // Switch back to conversation 1 — draft A restored
+    await sidePanel.getByRole('tab', { name: /Conversation 1/u }).click();
+    await expect(input).toHaveValue('draft A');
+
+    // Switch to conversation 2 — draft B restored
+    await sidePanel.getByRole('tab', { name: /Conversation 2/u }).click();
+    await expect(input).toHaveValue('draft B');
+  } finally {
+    await context.close();
+    await fixture.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});

--- a/apps/extension/tests/e2e/conversation-tabs.test.ts
+++ b/apps/extension/tests/e2e/conversation-tabs.test.ts
@@ -534,9 +534,11 @@ test('closing a conversation removes only that tab', async () => {
     await sidePanel.getByLabel('Message agent').press('Enter');
     await expect(sidePanel.getByText('Close this reply.')).toBeVisible();
 
+    // Closing a tab must NOT raise a dialog — it closes immediately
+    let dialogFired = false;
     sidePanel.once('dialog', async dialog => {
-      expect(dialog.message()).toContain('Close this conversation tab?');
-      await dialog.accept();
+      dialogFired = true;
+      await dialog.dismiss();
     });
     await sidePanel.getByLabel('Close Close this').click();
 
@@ -544,6 +546,7 @@ test('closing a conversation removes only that tab', async () => {
     await expect(sidePanel.getByText('Close this reply.')).toBeHidden();
     await expect(sidePanel.getByRole('tab', { name: /Keep this/u })).toBeVisible();
     await expect(sidePanel.getByText('Keep this reply.')).toBeVisible();
+    expect(dialogFired).toBe(false);
 
     await sidePanel.getByLabel('History').click();
     await sidePanel.getByLabel('Open Close this').click();
@@ -585,9 +588,6 @@ test('history can delete closed conversations without confirmation', async () =>
     await sidePanel.getByLabel('Message agent').press('Enter');
     await expect(sidePanel.getByText('Keep open reply.')).toBeVisible();
 
-    sidePanel.once('dialog', async dialog => {
-      await dialog.accept();
-    });
     await sidePanel.getByLabel('Close Delete later').click();
     await expect(sidePanel.getByRole('tab', { name: /Delete later/u })).toBeHidden();
 
@@ -632,9 +632,6 @@ test('history reuses an empty inactive tab when opening a closed conversation', 
     await expect(sidePanel.getByText('Restore me reply.')).toBeVisible();
 
     await sidePanel.getByLabel('New conversation').click();
-    sidePanel.once('dialog', async dialog => {
-      await dialog.accept();
-    });
     await sidePanel.getByLabel('Close Restore me').click();
 
     await sidePanel.getByLabel('History').click();

--- a/apps/extension/tests/e2e/firefox-selenium-e2e.ts
+++ b/apps/extension/tests/e2e/firefox-selenium-e2e.ts
@@ -470,28 +470,6 @@ const waitForTextGone = async (driver: WebDriver, text: string): Promise<void> =
   );
 };
 
-const acceptAlertWithText = async (driver: WebDriver, text: string): Promise<void> => {
-  await driver.wait(
-    async () => {
-      try {
-        const alert = await driver.switchTo().alert();
-        const alertText = await alert.getText();
-
-        if (!alertText.includes(text)) {
-          return false;
-        }
-
-        await alert.accept();
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    waitMs,
-    `Timed out waiting for alert text: ${text}`
-  );
-};
-
 const findManifestUrl = async (driver: WebDriver): Promise<string> => {
   await driver.get('about:debugging#/runtime/this-firefox');
   await waitForText(driver, 'Kilo Extension');

--- a/apps/extension/tests/e2e/firefox-selenium-e2e.ts
+++ b/apps/extension/tests/e2e/firefox-selenium-e2e.ts
@@ -1067,8 +1067,8 @@ const scenarios: FirefoxScenario[] = [
           await sendMessage(session.driver, 'Close this');
           await waitForText(session.driver, 'Close this reply.');
 
+          // Close-without-confirm: no dialog fires — tab closes immediately
           await clickButtonByLabel(session.driver, 'Close Close this');
-          await acceptAlertWithText(session.driver, 'Close this conversation tab?');
           await waitForTextGone(session.driver, 'Close this reply.');
           await waitForText(session.driver, 'Keep this reply.');
 

--- a/apps/extension/tests/e2e/kilo-api-fixture.ts
+++ b/apps/extension/tests/e2e/kilo-api-fixture.ts
@@ -51,6 +51,7 @@ const evalFixtureCode = `const ${longEvalIdentifier} = document.documentElement.
 const chatCompletionsPath = '/api/gateway/v1/chat/completions';
 const dangerousToolNames = ['get_page_snapshot', 'get_element_details', 'find_in_page', 'eval'];
 interface MockGatewayModel {
+  readonly contextLength?: number;
   readonly id: string;
   readonly name: string;
   readonly variants?: Record<string, unknown>;
@@ -127,6 +128,7 @@ export const mockKiloApi = async (
         id: model.id,
         name: model.name,
         opencode: { variants: model.variants ?? { high: {}, low: {}, medium: {} } },
+        ...(model.contextLength !== undefined ? { context_length: model.contextLength } : {}),
       };
 
       return Object.assign(
@@ -163,26 +165,34 @@ export const mockKiloApi = async (
     const toolNames =
       options.toolNamesByCall?.[chatCompletionCalls - 1] ?? options.toolNames ?? dangerousToolNames;
 
-    expect(body).toMatchObject({ stream: true, tool_choice: 'auto' });
-    expect(parsedBody.success ? expectedModelIds.includes(parsedBody.data.model) : false).toBe(
-      true
-    );
-    expect(
-      parsedBody.success && parsedBody.data.tools !== undefined
-        ? parsedBody.data.tools.map(tool => {
-            const parsedTool = toolDefinitionSchema.safeParse(tool);
+    // Summarization calls use tool_choice: 'none' (tools: []); skip normal-turn assertions for them.
+    const isSummarizationCall =
+      parsedBody.success &&
+      Array.isArray(parsedBody.data.tools) &&
+      parsedBody.data.tools.length === 0;
 
-            return parsedTool.success ? parsedTool.data.function.name : undefined;
-          })
-        : []
-    ).toStrictEqual(toolNames);
-    const userMessages = messages
-      .map(message => userMessageSchema.safeParse(message))
-      .filter(message => message.success)
-      .map(message => message.data);
-    expect(userMessages.at(-1)?.content).toEqual(expect.stringContaining('<system_environment>'));
-    expect(userMessages.at(-1)?.content).toEqual(expect.stringContaining('Current time:'));
-    expect(userMessages.at(-1)?.content).toEqual(expect.stringContaining('Timezone:'));
+    if (!isSummarizationCall) {
+      expect(body).toMatchObject({ stream: true, tool_choice: 'auto' });
+      expect(parsedBody.success ? expectedModelIds.includes(parsedBody.data.model) : false).toBe(
+        true
+      );
+      expect(
+        parsedBody.success && parsedBody.data.tools !== undefined
+          ? parsedBody.data.tools.map(tool => {
+              const parsedTool = toolDefinitionSchema.safeParse(tool);
+
+              return parsedTool.success ? parsedTool.data.function.name : undefined;
+            })
+          : []
+      ).toStrictEqual(toolNames);
+      const userMessages = messages
+        .map(message => userMessageSchema.safeParse(message))
+        .filter(message => message.success)
+        .map(message => message.data);
+      expect(userMessages.at(-1)?.content).toEqual(expect.stringContaining('<system_environment>'));
+      expect(userMessages.at(-1)?.content).toEqual(expect.stringContaining('Current time:'));
+      expect(userMessages.at(-1)?.content).toEqual(expect.stringContaining('Timezone:'));
+    }
 
     if (chatCompletionCalls === 1) {
       if (options.beforeFirstCompletion !== undefined) {

--- a/apps/extension/tests/e2e/kilo-api-fixture.ts
+++ b/apps/extension/tests/e2e/kilo-api-fixture.ts
@@ -128,7 +128,7 @@ export const mockKiloApi = async (
         id: model.id,
         name: model.name,
         opencode: { variants: model.variants ?? { high: {}, low: {}, medium: {} } },
-        ...(model.contextLength !== undefined ? { context_length: model.contextLength } : {}),
+        ...(model.contextLength === undefined ? {} : { context_length: model.contextLength }),
       };
 
       return Object.assign(
@@ -171,7 +171,9 @@ export const mockKiloApi = async (
       Array.isArray(parsedBody.data.tools) &&
       parsedBody.data.tools.length === 0;
 
-    if (!isSummarizationCall) {
+    if (isSummarizationCall) {
+      // Summarization calls skip normal-turn assertions (tool_choice: 'none', tools: [])
+    } else {
       expect(body).toMatchObject({ stream: true, tool_choice: 'auto' });
       expect(parsedBody.success ? expectedModelIds.includes(parsedBody.data.model) : false).toBe(
         true

--- a/apps/extension/tests/e2e/local-backend-live.test.ts
+++ b/apps/extension/tests/e2e/local-backend-live.test.ts
@@ -931,8 +931,8 @@ test('live local backend manual Compact now compacts a frontier conversation', a
     const messageInput = sidePanel.getByLabel('Message agent');
 
     /*
-     * A short two-exchange conversation: manual "Compact now" keeps only the latest exchange, so
-     * there is still earlier history to summarize. (With the auto threshold this would be inert.)
+     * A short two-exchange conversation: manual "Compact now" summarizes the whole conversation, so
+     * it still compacts. (With the auto threshold this little history would be inert.)
      */
     for (const text of [
       'COMPACT_ONE: reply with one short sentence.',

--- a/apps/extension/tests/e2e/local-backend-live.test.ts
+++ b/apps/extension/tests/e2e/local-backend-live.test.ts
@@ -911,3 +911,59 @@ test('live local backend dangerous mode eval can update the selected page', asyn
     await rm(userDataDir, { force: true, recursive: true });
   }
 });
+
+test('live local backend manual Compact now compacts a frontier conversation', async () => {
+  const fixture = await startFixtureServer({ title: 'Kilo live compaction target' });
+  const requests: ChatRequestSummary[] = [];
+  const { context, extensionId, userDataDir } = await launchExtensionContext();
+
+  recordChatRequests(context, requests);
+
+  try {
+    const targetPage = await context.newPage();
+    await targetPage.goto(fixture.url);
+
+    const sidePanel = await context.newPage();
+    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo live compaction target');
+    await selectFrontierModel(sidePanel);
+
+    const messageInput = sidePanel.getByLabel('Message agent');
+
+    /*
+     * A short two-exchange conversation: manual "Compact now" keeps only the latest exchange, so
+     * there is still earlier history to summarize. (With the auto threshold this would be inert.)
+     */
+    for (const text of [
+      'COMPACT_ONE: reply with one short sentence.',
+      'COMPACT_TWO: reply with one short sentence.',
+    ]) {
+      await messageInput.fill(text);
+      await messageInput.press('Enter');
+      await expect(sidePanel.getByRole('button', { name: 'Send message' })).toBeVisible({
+        timeout: 120_000,
+      });
+    }
+
+    const donut = sidePanel.getByLabel(/^Context usage:/u);
+    await expect(donut).toBeVisible();
+    await donut.click();
+    const compactButton = sidePanel.getByRole('button', { name: 'Compact now' });
+
+    await expect(compactButton).toBeEnabled();
+    await compactButton.click();
+
+    await waitForStoredConversationSnapshot(sidePanel, snapshot =>
+      snapshot.includes('Compacted earlier context')
+    );
+
+    // The summarization request goes out with no tools (tool_choice: 'none').
+    expect(
+      requests.some(request => request.model === frontierModel && request.toolNames.length === 0)
+    ).toBe(true);
+  } finally {
+    await context.close();
+    await fixture.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,12 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.14.3
         version: 3.14.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      jotai:
+        specifier: 2.18.1
+        version: 2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.6)
+      jotai-family:
+        specifier: 1.0.2
+        version: 1.0.2(jotai@2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.6))
       lucide-react:
         specifier: 0.552.0
         version: 0.552.0(react@19.2.6)
@@ -13546,6 +13552,12 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  jotai-family@1.0.2:
+    resolution: {integrity: sha512-U1aTMGxmsmz2Z8gaJD1/ljmMnsmG4/dqrcsfwGbjWV7p6boB9Vy3+75YwUpwPj7GbLNJk9O8rl1VNi8d7+6Rxw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      jotai: '>=2.9.0'
 
   jotai-minidb@0.0.8:
     resolution: {integrity: sha512-rC8tK12VlPxOOdPF27TQV2ov5B5BBgvW+YtKzodKAy5vfT3EoRwnBTBbPDevFJFqAtxw2CdKnKlznSk63Rs1cw==}
@@ -30672,6 +30684,10 @@ snapshots:
   jose@5.9.6: {}
 
   jose@6.2.3: {}
+
+  jotai-family@1.0.2(jotai@2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.6)):
+    dependencies:
+      jotai: 2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.6)
 
   jotai-minidb@0.0.8(jotai@2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.6)):
     dependencies:


### PR DESCRIPTION
## What

Adds context-usage visibility and context compaction to the browser-agent side panel, plus two small conversation-UX fixes.

### Features
- **Context donut** — a small SVG ring in the footer showing how full the model's context window is, driven by real gateway `usage.prompt_tokens` / model `context_length`. Hover/click opens a popover with the exact token counts and a **Compact now** button. Green < 70%, amber 70–90%, red ≥ 90%; grey when the model reports no context length.
- **Automatic compaction** — after a turn reaches ≥ 85% of the context window, older events are summarized (one gateway call) into a single `🗜️ Compacted earlier context` assistant message, keeping the last 2 exchanges verbatim.
- **Manual compaction** — the **Compact now** button does the same on demand.

### Small fixes
- **Per-conversation drafts** — the message draft is kept per conversation; switching tabs preserves each conversation's in-progress text.
- **Remove close confirmation** — closing a conversation tab no longer prompts; it closes immediately (the history *delete* confirmation is unchanged).

## How it works
- The streaming client sends `stream_options: { include_usage: true }` and parses the trailing `usage` chunk into `KiloGatewayChatCompletion.usage`; `context_length` is parsed from `/models`.
- Usage flows up through an `onUsage` callback (`runLlmTurn` → turn runners → chat panel).
- Per-conversation context usage and drafts are in-memory maps keyed by conversation id (reset on reload by design). All per-conversation state (usage, drafts, running/compacting ids) is keyed by conversation id and gated by the existing `isCurrentRun()` token, so parallel conversations don't interfere.
- Compaction summarizes via the gateway with `tools: []`; `splitEventsForCompaction` always cuts on a user-message boundary so no tool-call/tool-result pair is orphaned.

## Incidental fix: side-panel message-path trust check
While adding e2e coverage I found the background's `isTrustedExtensionSender` gated senders on `sender.tab === undefined`. That holds for the real side panel, but **no message-flow e2e test could ever pass** because the harness loads the side panel as a tab (so `sender.tab` is defined) and the background silently never responded — every message-sending test failed at "No tab selected". Changed the gate to trust the sender's **extension origin** (`chrome-extension://<id>`) instead: a content script shares the extension id but reports the host page's origin, so this is a stronger boundary and also lets the e2e suite drive the real message path. This unblocked the entire pre-existing message-flow e2e suite (safe mode, eval, run abort, etc.).

## Testing
- **Unit (Vitest): 106 passing** — usage parsing, `context_length` parsing, usage forwarding, context-usage helpers, `splitEventsForCompaction`/transcript rendering.
- **E2E (Playwright, Chrome): full suite green locally (49 tests)** after the trust-check fix, including new coverage for the donut reflecting usage, auto-compaction at threshold, manual compaction, per-conversation drafts, and close-without-confirmation. Auto-compaction assertions read persisted storage to avoid the virtualized list's render timing.
  - Note: CI does **not** currently run the extension e2e suite (no workflow invokes `e2e:chrome`/`e2e:firefox`; the extension's `verify` is typecheck+lint+format+unit). These were run locally.
  - Firefox Selenium e2e has a separate pre-existing tab-detection limitation in headless and was not fully run; the close-without-confirm change is mirrored there.
- typecheck, lint (0 errors), and format are clean.
