### PR TITLE
Remove OpenAI API key notifications

### DIFF
--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -308,11 +308,6 @@ async function generateByokProvidersNotification(
       gemini: 'Google AI API Key',
       google: 'Google AI API Key',
 
-      // OpenAI
-      'openai-native': 'OpenAI API Key',
-      openai: 'OpenAI API Key',
-      'openai-responses': 'OpenAI API Key',
-
       // Moonshot AI / Kimi
       moonshot: 'Moonshot AI API Key',
       moonshotai: 'Moonshot AI API Key',


### PR DESCRIPTION
Since you can't use your ChatGPT sub in the cloud it doesn't make a lot of sense to show people the notification