### PR TITLE
fix(config): add agent requirements schema

### DIFF
--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -103,6 +103,11 @@ export const kiloExtras = {
       description: 'Enable AI-powered codebase search',
       type: 'boolean',
     },
+    agent_requirements: {
+      description:
+        'Require declared agent skills, MCPs, and VS Code extensions before VS Code prompts can run',
+      type: 'boolean',
+    },
     native_notebook_tools: {
       description: 'Enable native tools for reading, editing, and executing VS Code notebooks',
       type: 'boolean',

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -58,7 +58,10 @@ describe('kilo config.json schema merge', () => {
   });
 
   test('terminal_command_display is an enum of expanded/collapsed', () => {
-    const tcd = props.terminal_command_display as { type: string; enum: string[] };
+    const tcd = props.terminal_command_display as {
+      type: string;
+      enum: string[];
+    };
     expect(tcd.type).toBe('string');
     expect(tcd.enum).toEqual(['expanded', 'collapsed']);
   });
@@ -91,7 +94,9 @@ describe('kilo config.json schema merge', () => {
 
   test('adds notebook permission keys without dropping upstream', () => {
     const defs = out.$defs as Record<string, unknown>;
-    const permissionConfig = defs.PermissionConfig as { anyOf: Array<Record<string, unknown>> };
+    const permissionConfig = defs.PermissionConfig as {
+      anyOf: Array<Record<string, unknown>>;
+    };
     const permissionObject = permissionConfig.anyOf.find(variant => variant.type === 'object') as {
       properties: Record<string, unknown>;
     };
@@ -111,6 +116,7 @@ describe('kilo config.json schema merge', () => {
   test('adds kilo experimental keys without dropping upstream', () => {
     const exp = props.experimental as { properties: Record<string, unknown> };
     expect(exp.properties.codebase_search).toBeDefined();
+    expect(exp.properties.agent_requirements).toEqual(expect.objectContaining({ type: 'boolean' }));
     expect(exp.properties.native_notebook_tools).toEqual(
       expect.objectContaining({ type: 'boolean' })
     );


### PR DESCRIPTION
## Summary

Add `experimental.agent_requirements` to the published Kilo config JSON schema so the explicit opt-in introduced by Kilo-Org/kilocode#11762 is recognized by `$schema: https://app.kilo.ai/config.json`.

## Verification

N/A

## Visual Changes

N/A

## Reviewer Notes

Companion cloud schema update for Kilo-Org/kilocode#11762. The focused schema test could not complete locally because the Docker daemon/Postgres test database was unavailable in this environment.
