### PR TITLE
fix(kilo-pass): show referral widget blocker hint

### DIFF
--- a/apps/web/src/components/referrals/ImpactAdvocateReferralCard.test.ts
+++ b/apps/web/src/components/referrals/ImpactAdvocateReferralCard.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from '@jest/globals';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
+import {
+  IMPACT_ADVOCATE_WIDGET_LOAD_TIMEOUT_MESSAGE,
+  IMPACT_ADVOCATE_WIDGET_LOAD_TIMEOUT_MS,
+  WidgetFallbackContent,
+} from './ImpactAdvocateReferralCard';
 import { buildImpactAdvocateTokenUrl } from './ImpactAdvocateReferralCard.utils';
 
 describe('buildImpactAdvocateTokenUrl', () => {
@@ -11,5 +18,36 @@ describe('buildImpactAdvocateTokenUrl', () => {
     expect(buildImpactAdvocateTokenUrl('kilo_pass')).toBe(
       '/api/impact-advocate/token?product=kilo_pass'
     );
+  });
+});
+
+describe('WidgetFallbackContent', () => {
+  it('replaces the widget loading copy with an ad blocker hint after the load timeout', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WidgetFallbackContent, {
+        hasTimedOut: true,
+      })
+    );
+
+    expect(IMPACT_ADVOCATE_WIDGET_LOAD_TIMEOUT_MS).toBe(10_000);
+    expect(html).toContain('Referral widget did not load');
+    expect(html).toContain(IMPACT_ADVOCATE_WIDGET_LOAD_TIMEOUT_MESSAGE);
+    expect(html).toContain('Ad blockers or network filters');
+    expect(html).toContain('Either allow the blocked domains');
+    expect(html).not.toContain('Allow Kilo');
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).not.toContain('Loading referral widget');
+  });
+
+  it('keeps the regular loading copy before the timeout', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WidgetFallbackContent, {
+        hasTimedOut: false,
+      })
+    );
+
+    expect(html).toContain('Loading referral widget');
+    expect(html).not.toContain('Referral widget did not load');
   });
 });

--- a/apps/web/src/components/referrals/ImpactAdvocateReferralCard.tsx
+++ b/apps/web/src/components/referrals/ImpactAdvocateReferralCard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { createElement, useEffect } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { createElement, useEffect, useState } from 'react';
 
 import {
   buildImpactAdvocateTokenUrl,
@@ -17,6 +18,11 @@ type WidgetState =
   | { status: 'loading' }
   | { status: 'ready'; token: string; widgetId: string }
   | { status: 'unavailable'; message: string };
+
+export const IMPACT_ADVOCATE_WIDGET_LOAD_TIMEOUT_MS = 10_000;
+
+export const IMPACT_ADVOCATE_WIDGET_LOAD_TIMEOUT_MESSAGE =
+  'Ad blockers or network filters can block the referral widget from loading. Either allow the blocked domains or turn off the ad blocker or network filters to see the referral widget.';
 
 async function getWidgetToken(product: ImpactAdvocateReferralProduct): Promise<WidgetToken> {
   const response = await fetch(buildImpactAdvocateTokenUrl(product), {
@@ -50,7 +56,44 @@ async function getWidgetToken(product: ImpactAdvocateReferralProduct): Promise<W
   return { token: payload.token, widgetId: payload.widgetId };
 }
 
-function WidgetContent({ state }: { state: WidgetState }) {
+export function WidgetFallbackContent({ hasTimedOut }: { hasTimedOut: boolean }) {
+  if (!hasTimedOut) {
+    return <div className="text-muted-foreground text-sm">Loading referral widget…</div>;
+  }
+
+  return (
+    <div
+      className="border-status-warning-border bg-status-warning-surface flex gap-3 rounded-lg border p-4"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <AlertTriangle className="text-status-warning-icon mt-0.5 size-4 shrink-0" />
+      <div>
+        <p className="text-status-warning type-heading">Referral widget did not load</p>
+        <p className="text-muted-foreground type-body mt-1">
+          {IMPACT_ADVOCATE_WIDGET_LOAD_TIMEOUT_MESSAGE}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ImpactWidgetFallback() {
+  const [hasTimedOut, setHasTimedOut] = useState(false);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setHasTimedOut(true);
+    }, IMPACT_ADVOCATE_WIDGET_LOAD_TIMEOUT_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, []);
+
+  return <WidgetFallbackContent hasTimedOut={hasTimedOut} />;
+}
+
+export function WidgetContent({ state }: { state: WidgetState }) {
   switch (state.status) {
     case 'loading':
       return (
@@ -67,7 +110,7 @@ function WidgetContent({ state }: { state: WidgetState }) {
               widget: state.widgetId,
               className: 'block min-h-52 w-full',
             },
-            <div className="text-muted-foreground text-sm">Loading referral widget…</div>
+            <ImpactWidgetFallback />
           )}
         </div>
       );

--- a/apps/web/src/components/referrals/ImpactAdvocateReferralCard.tsx
+++ b/apps/web/src/components/referrals/ImpactAdvocateReferralCard.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { AlertTriangle } from 'lucide-react';
-import { createElement, useEffect, useState } from 'react';
+import React, { createElement, useEffect, useState } from 'react';
 
 import {
   buildImpactAdvocateTokenUrl,


### PR DESCRIPTION
## Summary
Kilo Pass referral sharing now replaces the stuck Impact widget loader with an ad blocker and network filter hint after a timeout.

### Why this change is needed
Users with browser or network blocking can see a persistent “Loading referral widget...” state because the Impact widget never renders. The page needs an actionable explanation instead of an infinite loading state.

### How this is addressed
- Adds a 10-second timeout inside the Impact embed fallback content.
- Replaces only the fallback loading copy with a warning that asks users to allow blocked domains or turn off blockers.
- Keeps token fetching and product-specific Kilo Pass unavailable handling unchanged.
- Covers pre-timeout and timed-out fallback rendering in tests.

## Human Verification
- Checked the Impact referral spec for product-scoped Kilo Pass widget behavior and no KiloClaw fallback.
- Performed a defensive review of the changed React code and removed iframe polling/shadow DOM probing from the implementation.

## Reviewer Notes
### Human Reviewer Flags
- The warning is scoped to the Impact embed fallback. If the widget renders normally and replaces the fallback, the timeout component unmounts and the hint never appears.
- Browser validation with an actual ad blocker or blocked Impact domains was not run in this session.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- The parent referral widget still handles token fetch loading/error/ready states.
- The timeout lives in the fallback child rendered inside `impact-embed`, avoiding parent-level DOM probing.
- Focused Jest was not run because Docker daemon was unavailable and the Jest setup requires Postgres.

</details>
