### PR TITLE
fix(orgs): limit auto model audit logs

### DIFF
--- a/apps/web/src/lib/organizations/auto-model-change-log.integration.test.ts
+++ b/apps/web/src/lib/organizations/auto-model-change-log.integration.test.ts
@@ -164,6 +164,66 @@ describe('logAutoModelChangesForAllOrgs', () => {
     expect(logs).toHaveLength(0);
   });
 
+  test('does not write audit logs for enterprise orgs without model restrictions', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('Unrestricted Enterprise Org', owner.id, 0);
+
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] }]);
+
+    const result = await logAutoModelChangesForAllOrgs(oldSnapshot, newSnapshot);
+
+    expect(result.orgCount).toBe(0);
+
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(0);
+  });
+
+  test('does not write audit logs for soft-deleted enterprise orgs', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('Deleted Enterprise Org', owner.id, 0, {
+      provider_allow_list: ['z-ai'],
+    });
+    await db
+      .update(organizations)
+      .set({ deleted_at: new Date().toISOString() })
+      .where(eq(organizations.id, enterpriseOrg.id));
+
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] }]);
+
+    const result = await logAutoModelChangesForAllOrgs(oldSnapshot, newSnapshot);
+
+    expect(result.orgCount).toBe(0);
+
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(0);
+  });
+
+  test('does not write audit logs for hard-expired enterprise orgs without entitlement', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('Expired Enterprise Org', owner.id, 0, {
+      provider_allow_list: ['z-ai'],
+    });
+    await db
+      .update(organizations)
+      .set({
+        free_trial_end_at: '2020-01-01T00:00:00.000Z',
+        require_seats: true,
+      })
+      .where(eq(organizations.id, enterpriseOrg.id));
+
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] }]);
+
+    const result = await logAutoModelChangesForAllOrgs(oldSnapshot, newSnapshot);
+
+    expect(result.orgCount).toBe(0);
+
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(0);
+  });
+
   test('skips enterprise orgs whose effective availability did not change', async () => {
     const owner = await insertTestUser();
     const restrictedOrg = await createTestOrganization('Restricted to openai only', owner.id, 0, {

--- a/apps/web/src/lib/organizations/auto-model-change-log.ts
+++ b/apps/web/src/lib/organizations/auto-model-change-log.ts
@@ -1,7 +1,7 @@
 import { captureException } from '@sentry/nextjs';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 import type { Organization } from '@kilocode/db/schema';
-import { organizations } from '@kilocode/db/schema';
+import { organization_seats_purchases, organizations } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
 import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
 import { getEffectiveModelRestrictions } from '@/lib/organizations/model-restrictions';
@@ -188,10 +188,33 @@ export type LogResult = {
   logCount: number;
 };
 
+const orgHasModelRestrictions = sql<boolean>`(
+  jsonb_typeof(${organizations.settings}->'provider_allow_list') = 'array'
+  OR (
+    jsonb_typeof(${organizations.settings}->'model_deny_list') = 'array'
+    AND jsonb_array_length(${organizations.settings}->'model_deny_list') > 0
+  )
+)`;
+
+const orgHasCurrentEntitlement = sql<boolean>`(
+  ${organizations.require_seats} = false
+  OR ${organizations.settings}->>'suppress_trial_messaging' = 'true'
+  OR ${organizations.settings}->>'oss_sponsorship_tier' IS NOT NULL
+  OR coalesce(${organizations.free_trial_end_at}, ${organizations.created_at} + interval '14 days') >= now() - interval '3 days'
+  OR coalesce((
+    SELECT ${organization_seats_purchases.subscription_status} <> 'ended'
+    FROM ${organization_seats_purchases}
+    WHERE ${organization_seats_purchases.organization_id} = ${organizations.id}
+    ORDER BY ${organization_seats_purchases.created_at} DESC
+    LIMIT 1
+  ), false)
+)`;
+
 /**
  * Compute the diff between the previous and current OpenRouter snapshots and
- * write one audit log row per enterprise organization whose effective model
- * availability changed. Attributed to `System` via null actor fields.
+ * write one audit log row per active enterprise organization with explicit
+ * model/provider restrictions whose effective model availability changed.
+ * Attributed to `System` via null actor fields.
  *
  * Safe to call from inside a background job; individual per-org failures are
  * reported to Sentry and do not break the rest of the loop.
@@ -209,7 +232,14 @@ export async function logAutoModelChangesForAllOrgs(
   const enterpriseOrgs = await db
     .select()
     .from(organizations)
-    .where(eq(organizations.plan, 'enterprise'));
+    .where(
+      and(
+        eq(organizations.plan, 'enterprise'),
+        isNull(organizations.deleted_at),
+        orgHasModelRestrictions,
+        orgHasCurrentEntitlement
+      )
+    );
 
   let logCount = 0;
   for (const organization of enterpriseOrgs) {


### PR DESCRIPTION
## Summary
- Limit auto model-change audit logging to active, non-deleted enterprise organizations with explicit model/provider restrictions.
- Avoid per-sync audit log floods for unrestricted, deleted, or hard-expired organizations while keeping future logs for eligible orgs.
- Add integration coverage for unrestricted, soft-deleted, and hard-expired enterprise organizations.

## Validation
- `pnpm --filter web test -- auto-model-change-log`
- `pnpm --filter web lint`
- `pnpm typecheck`
- `pnpm format`