### PR TITLE
perf(web): cache public leaderboard reports in-process and unify TTLs

### DIFF
--- a/apps/web/src/app/api/public/leaderboard-model-provider-usage/route.ts
+++ b/apps/web/src/app/api/public/leaderboard-model-provider-usage/route.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { normalizePublicInferenceProvider } from '@/lib/public-inference-provider';
 import {
-  getPublicSnowflakeReport,
+  createPublicSnowflakeReport,
   publicSnowflakeReportOptions,
 } from '@/lib/public-snowflake-report';
 import { LEADERBOARD_MODEL_PROVIDER_USAGE_REDIS_KEY } from '@/lib/redis-keys';
@@ -163,15 +163,13 @@ function parseAndAggregateUsage(rows: string[][]): ModelProviderUsage[] {
     })).filter(usage => usage.errorRate < MAXIMUM_ERROR_RATE);
 }
 
-export async function GET() {
-  return getPublicSnowflakeReport({
-    cacheKey: LEADERBOARD_MODEL_PROVIDER_USAGE_REDIS_KEY,
-    errorMessage: 'Failed to fetch leaderboard model provider usage',
-    parseRows: parseAndAggregateUsage,
-    query: LEADERBOARD_MODEL_PROVIDER_USAGE_QUERY,
-    schema: modelProviderUsageSchema,
-    source: 'public-leaderboard-model-provider-usage-api',
-  });
-}
+export const GET = createPublicSnowflakeReport({
+  cacheKey: LEADERBOARD_MODEL_PROVIDER_USAGE_REDIS_KEY,
+  errorMessage: 'Failed to fetch leaderboard model provider usage',
+  parseRows: parseAndAggregateUsage,
+  query: LEADERBOARD_MODEL_PROVIDER_USAGE_QUERY,
+  schema: modelProviderUsageSchema,
+  source: 'public-leaderboard-model-provider-usage-api',
+});
 
 export const OPTIONS = publicSnowflakeReportOptions;

--- a/apps/web/src/app/api/public/leaderboard-model-usage/route.ts
+++ b/apps/web/src/app/api/public/leaderboard-model-usage/route.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import {
-  getPublicSnowflakeReport,
+  createPublicSnowflakeReport,
   publicSnowflakeReportOptions,
 } from '@/lib/public-snowflake-report';
 import { LEADERBOARD_MODEL_USAGE_REDIS_KEY } from '@/lib/redis-keys';
@@ -60,15 +60,13 @@ function parseModelUsage(rows: string[][]): ModelUsage[] {
   });
 }
 
-export async function GET() {
-  return getPublicSnowflakeReport({
-    cacheKey: LEADERBOARD_MODEL_USAGE_REDIS_KEY,
-    errorMessage: 'Failed to fetch leaderboard model usage',
-    parseRows: parseModelUsage,
-    query: LEADERBOARD_MODEL_USAGE_QUERY,
-    schema: modelUsageSchema,
-    source: 'public-leaderboard-model-usage-api',
-  });
-}
+export const GET = createPublicSnowflakeReport({
+  cacheKey: LEADERBOARD_MODEL_USAGE_REDIS_KEY,
+  errorMessage: 'Failed to fetch leaderboard model usage',
+  parseRows: parseModelUsage,
+  query: LEADERBOARD_MODEL_USAGE_QUERY,
+  schema: modelUsageSchema,
+  source: 'public-leaderboard-model-usage-api',
+});
 
 export const OPTIONS = publicSnowflakeReportOptions;

--- a/apps/web/src/lib/public-snowflake-report.ts
+++ b/apps/web/src/lib/public-snowflake-report.ts
@@ -2,6 +2,7 @@ import { captureException } from '@sentry/nextjs';
 import { NextResponse } from 'next/server';
 import type { ZodType } from 'zod';
 
+import { createCachedFetch } from '@/lib/cached-fetch';
 import { redisClient } from '@/lib/redis';
 import type { RedisKey } from '@/lib/redis-keys';
 import { executeSnowflakeStatement, resolveSnowflakeConfig } from '@/lib/snowflake';
@@ -12,8 +13,11 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Headers': 'Content-Type',
 };
 
-const VERCEL_CACHE_TTL_SECONDS = 60;
-const REDIS_CACHE_TTL_SECONDS = 3600;
+// Single source of truth for every cache layer in front of Snowflake: the
+// Vercel edge cache, the in-process cache, and the Redis cache all expire after
+// one hour so the data served stays consistent across layers.
+const CACHE_TTL_SECONDS = 3600;
+const IN_MEMORY_CACHE_TTL_MS = CACHE_TTL_SECONDS * 1000;
 
 type PublicSnowflakeReportOptions<Usage> = {
   cacheKey: RedisKey;
@@ -28,72 +32,102 @@ function successResponse<Usage>(usage: Usage): NextResponse {
   return NextResponse.json(usage, {
     headers: {
       ...CORS_HEADERS,
-      'Cache-Control': `public, s-maxage=${VERCEL_CACHE_TTL_SECONDS}, stale-while-revalidate=${VERCEL_CACHE_TTL_SECONDS}`,
+      'Cache-Control': `public, s-maxage=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}`,
     },
   });
 }
 
-export async function getPublicSnowflakeReport<Usage>({
-  cacheKey,
-  errorMessage,
-  parseRows,
-  query,
-  schema,
-  source,
-}: PublicSnowflakeReportOptions<Usage>): Promise<NextResponse> {
+/**
+ * Read the report from Redis, falling back to Snowflake on a miss and
+ * repopulating Redis. Throws on Snowflake failure so the in-process cache keeps
+ * serving the last-known-good value (or `null` when nothing has been cached).
+ */
+async function fetchReport<Usage>(
+  options: PublicSnowflakeReportOptions<Usage>
+): Promise<Usage | null> {
   try {
-    const cached = await redisClient.get<string>(cacheKey);
+    const cached = await redisClient.get<string>(options.cacheKey);
     if (cached !== null) {
-      return successResponse(schema.parse(JSON.parse(cached)));
+      return options.schema.parse(JSON.parse(cached));
     }
   } catch (error) {
     captureException(error, {
-      tags: { source, operation: 'redis-read' },
+      tags: { source: options.source, operation: 'redis-read' },
     });
   }
 
   const config = resolveSnowflakeConfig();
   if (!config) {
-    return NextResponse.json(
-      { error: 'Snowflake is not configured' },
-      {
-        status: 503,
-        headers: { ...CORS_HEADERS, 'Cache-Control': 'no-store' },
-      }
-    );
+    return null;
   }
 
   try {
     const rows = await executeSnowflakeStatement({
       config,
-      statement: query,
+      statement: options.query,
       timeoutSeconds: 30,
     });
-    const usage = schema.parse(parseRows(rows));
+    const usage = options.schema.parse(options.parseRows(rows));
 
     try {
-      await redisClient.set(cacheKey, JSON.stringify(usage), {
-        ex: REDIS_CACHE_TTL_SECONDS,
+      await redisClient.set(options.cacheKey, JSON.stringify(usage), {
+        ex: CACHE_TTL_SECONDS,
       });
     } catch (error) {
       captureException(error, {
-        tags: { source, operation: 'redis-write' },
+        tags: { source: options.source, operation: 'redis-write' },
       });
     }
 
-    return successResponse(usage);
+    return usage;
   } catch (error) {
     captureException(error, {
-      tags: { source },
+      tags: { source: options.source },
     });
-    return NextResponse.json(
-      { error: errorMessage },
-      {
-        status: 502,
-        headers: { ...CORS_HEADERS, 'Cache-Control': 'no-store' },
-      }
-    );
+    throw error;
   }
+}
+
+/**
+ * Builds a cached GET handler for a public Snowflake-backed report.
+ *
+ * Caching cascades through three layers, all expiring after one hour: the
+ * Vercel edge cache (`s-maxage`), an in-process `createCachedFetch` so warm
+ * instances avoid Redis entirely, and the Redis cache in front of Snowflake.
+ * The in-process cache is created once per report (module scope) and stores
+ * pure data, so it is safe to share across requests.
+ */
+export function createPublicSnowflakeReport<Usage>(options: PublicSnowflakeReportOptions<Usage>) {
+  const getCachedReport = createCachedFetch<Usage | null>(
+    () => fetchReport(options),
+    IN_MEMORY_CACHE_TTL_MS,
+    null
+  );
+
+  return async function GET(): Promise<NextResponse> {
+    if (!resolveSnowflakeConfig()) {
+      return NextResponse.json(
+        { error: 'Snowflake is not configured' },
+        {
+          status: 503,
+          headers: { ...CORS_HEADERS, 'Cache-Control': 'no-store' },
+        }
+      );
+    }
+
+    const usage = await getCachedReport();
+    if (usage === null) {
+      return NextResponse.json(
+        { error: options.errorMessage },
+        {
+          status: 502,
+          headers: { ...CORS_HEADERS, 'Cache-Control': 'no-store' },
+        }
+      );
+    }
+
+    return successResponse(usage);
+  };
 }
 
 export function publicSnowflakeReportOptions(): NextResponse {


### PR DESCRIPTION
## Summary

Both public leaderboard endpoints (`/api/public/leaderboard-model-usage` and `/api/public/leaderboard-model-provider-usage`) previously read their cached payload from Redis on **every** origin request, with three different cache lifetimes: a 60s Vercel edge cache, no in-process cache, and a 3600s Redis cache.

This change:

- **Adds an in-process `createCachedFetch` layer** in front of the Redis read (shared helper `createPublicSnowflakeReport` in `public-snowflake-report.ts`). Warm instances now serve the report straight from memory and skip Redis entirely, mirroring the pattern already used by `gateway-models-cache.ts` and the model-experiments membership pre-check. The cached value is pure data created at module scope, so it is safe to share across requests.
- **Unifies all three cache TTLs to one hour** (`CACHE_TTL_SECONDS = 3600`): the Vercel edge cache (`s-maxage`/`stale-while-revalidate`), the new in-process cache, and the Redis cache. The edge TTL was bumped from 60s to match.

Architecturally, `getPublicSnowflakeReport(options)` (called per request) becomes a `createPublicSnowflakeReport(options)` factory that builds the cached `GET` handler once. Existing 502 (Snowflake failure) and 503 (Snowflake not configured) behavior is preserved, and Snowflake errors are still reported to Sentry while the in-process cache continues serving the last-known-good value.

## Verification

- Hit both endpoints repeatedly against production and confirmed the responses and edge-cache behavior before the change (CDN `HIT` with rising `age`).
- Confirmed the only callers of the helper are the two leaderboard routes; both updated to the factory form.

## Visual Changes

N/A — public JSON API endpoints, no UI.

## Reviewer Notes

- The in-process cache holds the full parsed payload (`leaderboard-model-usage` is ~300-430KB) in module memory per warm instance; this is expected and bounded to the two reports.
- Behavior change worth noting: the edge cache window grows from 60s to 1h, so newly published Snowflake data can now take up to an hour to appear (previously up to 60s at the edge). This matches the existing 1h Redis lifetime and is intended.
- On Snowflake failure with a warm in-process cache, the handler now serves the last-known-good payload instead of returning 502; 502 is still returned when nothing has been cached yet.