### PR TITLE
perf(ai-gateway): check per-model exists markers instead of full catalog

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -5,7 +5,6 @@ import { getBalanceAndOrgSettings } from '@/lib/organizations/organization-usage
 import { classifyAbuse } from '@/lib/ai-gateway/abuse-service';
 import { getProvider } from '@/lib/ai-gateway/providers/get-provider';
 import { upstreamRequest } from '@/lib/ai-gateway/providers/upstream-request';
-import { getOpenRouterModels } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import { emitApiMetricsForResponse } from '@/lib/ai-gateway/o11y/api-metrics.server';
 import { accountForMicrodollarUsage } from '@/lib/ai-gateway/llm-proxy-helpers';
 import { redisClient } from '@/lib/redis';
@@ -82,7 +81,6 @@ const mockedGetBalanceAndOrgSettings = jest.mocked(getBalanceAndOrgSettings);
 const mockedClassifyAbuse = jest.mocked(classifyAbuse);
 const mockedGetProvider = jest.mocked(getProvider);
 const mockedUpstreamRequest = jest.mocked(upstreamRequest);
-const mockedGetOpenRouterModels = jest.mocked(getOpenRouterModels);
 const mockedEmitApiMetricsForResponse = jest.mocked(emitApiMetricsForResponse);
 const mockedAccountForMicrodollarUsage = jest.mocked(accountForMicrodollarUsage);
 const mockedRedisGet = jest.mocked(redisClient.get);
@@ -184,7 +182,6 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     mockedClassifyAbuse.mockResolvedValue(classifyResult(null));
     mockedRedisGet.mockResolvedValue(null);
     mockedRedisSet.mockResolvedValue('OK');
-    mockedGetOpenRouterModels.mockResolvedValue(new Set(['stepfun/step-3.7-flash:free']));
     mockedUpstreamRequest.mockResolvedValue(
       upstreamJsonResponse({ id: 'chatcmpl-1', model: 'openai/gpt-4o', choices: [] })
     );
@@ -423,7 +420,6 @@ describe('kilo-auto/efficient classifier billing', () => {
     mockedClassifyAbuse.mockResolvedValue(classifyResult(null));
     mockedRedisGet.mockResolvedValue(null);
     mockedRedisSet.mockResolvedValue('OK');
-    mockedGetOpenRouterModels.mockResolvedValue(new Set());
     mockedUpstreamRequest.mockResolvedValue(
       upstreamJsonResponse({ id: 'chatcmpl-1', model: 'anthropic/claude-haiku-4', choices: [] })
     );
@@ -658,7 +654,6 @@ describe('auto-routing shadow classifier', () => {
     mockedClassifyAbuse.mockResolvedValue(classifyResult(null));
     mockedRedisGet.mockResolvedValue(null);
     mockedRedisSet.mockResolvedValue('OK');
-    mockedGetOpenRouterModels.mockResolvedValue(new Set());
     mockedUpstreamRequest.mockResolvedValue(
       upstreamJsonResponse({ id: 'chatcmpl-1', model: 'openai/gpt-4o', choices: [] })
     );

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
-jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
-  getOpenRouterModels: jest.fn(async () => new Set<string>()),
+jest.mock('@/lib/ai-gateway/providers/gateway-model-existence', () => ({
+  gatewayModelExists: jest.fn(async () => false),
 }));
 
 jest.mock('@/lib/kiloclaw/setup-promo', () => ({

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -30,7 +30,7 @@ import {
   findKiloExclusiveModel,
   isKiloExclusiveFreeModel,
 } from '@/lib/ai-gateway/models';
-import { getOpenRouterModels } from '@/lib/ai-gateway/providers/gateway-models-cache';
+import { gatewayModelExists } from '@/lib/ai-gateway/providers/gateway-model-existence';
 import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 
@@ -56,26 +56,27 @@ function resolveMode(modeHeader: string | null, featureHeader: FeatureValue | nu
 /**
  * Returns the candidate models for kilo-auto/free routing.
  *
- * Non-kilo-exclusive free models are only included when they appear in the
- * supplied `openRouterModels` list (sourced from the Redis OpenRouter models
- * cache). Kilo-exclusive free models are included when their gateway supports
- * the current `apiKind`; when `apiKind` is null no API-kind filtering is applied.
+ * Non-kilo-exclusive free models are only included when they currently have an
+ * OpenRouter existence marker in Redis (written by provider sync). Kilo-exclusive
+ * free models are included when their gateway supports the current `apiKind`;
+ * when `apiKind` is null no API-kind filtering is applied.
  */
 export async function getAutoFreeCandidates(
   apiKind: GatewayRequest['kind'] | null
 ): Promise<ReadonlyArray<string>> {
-  const openRouterModels = await getOpenRouterModels();
   const candidates = new Set<string>();
-  for (const model of autoFreeModels) {
-    if (isKiloExclusiveFreeModel(model)) {
-      const kiloModel = findKiloExclusiveModel(model);
-      if (kiloModel && gatewaySupportsApiKind(kiloModel.gateway, apiKind)) {
+  await Promise.all(
+    autoFreeModels.map(async model => {
+      if (isKiloExclusiveFreeModel(model)) {
+        const kiloModel = findKiloExclusiveModel(model);
+        if (kiloModel && gatewaySupportsApiKind(kiloModel.gateway, apiKind)) {
+          candidates.add(model);
+        }
+      } else if (await gatewayModelExists('openrouter', model)) {
         candidates.add(model);
       }
-    } else if (openRouterModels.has(model)) {
-      candidates.add(model);
-    }
-  }
+    })
+  );
   return [...candidates].toSorted();
 }
 

--- a/apps/web/src/lib/ai-gateway/providers/gateway-model-existence.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-model-existence.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
 import type { StoredModel } from '@kilocode/db/schema-types';
+import { redisClient } from '@/lib/redis';
+import {
+  gatewayModelExists,
+  writeGatewayModelExistenceMarkers,
+  routableLanguageModelIds,
+  GATEWAY_MODEL_EXISTENCE_TTL_SECONDS,
+} from './gateway-model-existence';
 
+// NOTE: jest.mock must come after the imports above; with this repo's @swc/jest
+// setup a mock declared before the imports is not applied.
 type FakeRedis = {
-  get: (key: string) => Promise<string | null>;
+  get: jest.Mock;
   set: (key: string, value: string, opts?: { ex?: number }) => void;
   pipeline: () => {
     set: (key: string, value: string, opts?: { ex?: number }) => unknown;
@@ -17,72 +26,58 @@ jest.mock('@/lib/redis', () => {
   let failNextGet = false;
 
   const set = (key: string, value: string, opts?: { ex?: number }) => {
-    store.set(key, {
-      value,
-      expiresAt: opts?.ex ? Date.now() + opts.ex * 1000 : null,
-    });
+    store.set(key, { value, expiresAt: opts?.ex ? Date.now() + opts.ex * 1000 : null });
   };
 
-  const redisClient: FakeRedis = {
-    get: async (key: string) => {
-      if (failNextGet) {
-        failNextGet = false;
-        throw new Error('redis unavailable');
-      }
-      const entry = store.get(key);
-      if (!entry) return null;
-      if (entry.expiresAt !== null && entry.expiresAt <= Date.now()) {
-        store.delete(key);
-        return null;
-      }
-      return entry.value;
-    },
-    set,
-    pipeline: () => {
-      const ops: Array<() => void> = [];
-      const p = {
-        set(key: string, value: string, opts?: { ex?: number }) {
-          ops.push(() => set(key, value, opts));
-          return p;
-        },
-        async exec() {
-          for (const op of ops) op();
-          return [];
-        },
-      };
-      return p;
-    },
-    __store: store,
-    __failNextGet: () => {
-      failNextGet = true;
+  const get = jest.fn(async (key: string) => {
+    if (failNextGet) {
+      failNextGet = false;
+      throw new Error('redis unavailable');
+    }
+    const entry = store.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt !== null && entry.expiresAt <= Date.now()) {
+      store.delete(key);
+      return null;
+    }
+    return entry.value;
+  });
+
+  return {
+    redisClient: {
+      get,
+      set,
+      pipeline: () => {
+        const ops: Array<() => void> = [];
+        const p = {
+          set(key: string, value: string, opts?: { ex?: number }) {
+            ops.push(() => set(key, value, opts));
+            return p;
+          },
+          async exec() {
+            for (const op of ops) op();
+            return [];
+          },
+        };
+        return p;
+      },
+      __store: store,
+      __failNextGet: () => {
+        failNextGet = true;
+      },
     },
   };
-
-  return { redisClient };
 });
-
-import { redisClient } from '@/lib/redis';
-import {
-  gatewayModelExists,
-  writeGatewayModelExistenceMarkers,
-  routableLanguageModelIds,
-  GATEWAY_MODEL_EXISTENCE_TTL_SECONDS,
-} from './gateway-model-existence';
 
 const fakeRedis = redisClient as unknown as FakeRedis;
 
 function model(id: string, overrides: Partial<StoredModel> = {}): StoredModel {
-  return {
-    id,
-    name: id,
-    type: 'language',
-    endpoints: [{ provider_name: 'p' }],
-    ...overrides,
-  };
+  return { id, name: id, type: 'language', endpoints: [{ provider_name: 'p' }], ...overrides };
 }
 
 beforeEach(() => {
   fakeRedis.__store.clear();
+  fakeRedis.get.mockClear();
   jest.useFakeTimers();
   jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
 });
@@ -132,10 +127,31 @@ describe('writeGatewayModelExistenceMarkers + gatewayModelExists', () => {
   });
 
   it('does not write anything when there are no routable models', async () => {
-    await writeGatewayModelExistenceMarkers('openrouter', {
-      a: model('img', { type: 'image' }),
-    });
+    await writeGatewayModelExistenceMarkers('openrouter', { a: model('img', { type: 'image' }) });
     expect(fakeRedis.__store.size).toBe(0);
+  });
+});
+
+describe('gatewayModelExists in-process cache', () => {
+  it('serves repeated lookups of the same model without re-reading Redis', async () => {
+    await gatewayModelExists('vercel', 'cached/model');
+    await gatewayModelExists('vercel', 'cached/model');
+    await gatewayModelExists('vercel', 'cached/model');
+    expect(fakeRedis.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts the oldest entry once the cache cap is exceeded', async () => {
+    await gatewayModelExists('vercel', 'first/model');
+    expect(fakeRedis.get).toHaveBeenCalledTimes(1);
+
+    // Fill the cache past its cap with distinct ids, evicting 'first/model'.
+    for (let i = 0; i <= 2_000; i++) {
+      await gatewayModelExists('vercel', `filler/${i}`);
+    }
+
+    fakeRedis.get.mockClear();
+    await gatewayModelExists('vercel', 'first/model');
+    expect(fakeRedis.get).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -149,8 +165,8 @@ describe('gatewayModelExists fail-open behavior', () => {
     await writeGatewayModelExistenceMarkers('openrouter', { a: model('warm/model') });
     expect(await gatewayModelExists('openrouter', 'warm/model')).toBe(true);
 
-    // Advance past the in-process cache window so the next call hits Redis,
-    // but stay within the marker TTL so the value is still valid.
+    // Advance past the in-process cache window (but within the marker TTL) so the
+    // next call reaches Redis, then make that read fail.
     jest.advanceTimersByTime(120_000);
     fakeRedis.__failNextGet();
 

--- a/apps/web/src/lib/ai-gateway/providers/gateway-model-existence.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-model-existence.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import type { StoredModel } from '@kilocode/db/schema-types';
+
+type FakeRedis = {
+  get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string, opts?: { ex?: number }) => void;
+  pipeline: () => {
+    set: (key: string, value: string, opts?: { ex?: number }) => unknown;
+    exec: () => Promise<unknown[]>;
+  };
+  __store: Map<string, { value: string; expiresAt: number | null }>;
+  __failNextGet: () => void;
+};
+
+jest.mock('@/lib/redis', () => {
+  const store = new Map<string, { value: string; expiresAt: number | null }>();
+  let failNextGet = false;
+
+  const set = (key: string, value: string, opts?: { ex?: number }) => {
+    store.set(key, {
+      value,
+      expiresAt: opts?.ex ? Date.now() + opts.ex * 1000 : null,
+    });
+  };
+
+  const redisClient: FakeRedis = {
+    get: async (key: string) => {
+      if (failNextGet) {
+        failNextGet = false;
+        throw new Error('redis unavailable');
+      }
+      const entry = store.get(key);
+      if (!entry) return null;
+      if (entry.expiresAt !== null && entry.expiresAt <= Date.now()) {
+        store.delete(key);
+        return null;
+      }
+      return entry.value;
+    },
+    set,
+    pipeline: () => {
+      const ops: Array<() => void> = [];
+      const p = {
+        set(key: string, value: string, opts?: { ex?: number }) {
+          ops.push(() => set(key, value, opts));
+          return p;
+        },
+        async exec() {
+          for (const op of ops) op();
+          return [];
+        },
+      };
+      return p;
+    },
+    __store: store,
+    __failNextGet: () => {
+      failNextGet = true;
+    },
+  };
+
+  return { redisClient };
+});
+
+import { redisClient } from '@/lib/redis';
+import {
+  gatewayModelExists,
+  writeGatewayModelExistenceMarkers,
+  routableLanguageModelIds,
+  GATEWAY_MODEL_EXISTENCE_TTL_SECONDS,
+} from './gateway-model-existence';
+
+const fakeRedis = redisClient as unknown as FakeRedis;
+
+function model(id: string, overrides: Partial<StoredModel> = {}): StoredModel {
+  return {
+    id,
+    name: id,
+    type: 'language',
+    endpoints: [{ provider_name: 'p' }],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fakeRedis.__store.clear();
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('routableLanguageModelIds', () => {
+  it('keeps language models with endpoints and drops the rest', () => {
+    const ids = routableLanguageModelIds({
+      a: model('openai/gpt-4o'),
+      b: model('img', { type: 'image' }),
+      c: model('no-endpoints', { endpoints: [] }),
+      d: model('default-type', { type: undefined }),
+    });
+    expect(ids.toSorted()).toEqual(['default-type', 'openai/gpt-4o']);
+  });
+});
+
+describe('writeGatewayModelExistenceMarkers + gatewayModelExists', () => {
+  it('marks routable models as existing and others as not', async () => {
+    await writeGatewayModelExistenceMarkers('openrouter', {
+      a: model('poolside/laguna-m.1:free'),
+      b: model('embedded', { type: 'embedding' }),
+    });
+
+    expect(await gatewayModelExists('openrouter', 'poolside/laguna-m.1:free')).toBe(true);
+    expect(await gatewayModelExists('openrouter', 'embedded')).toBe(false);
+    expect(await gatewayModelExists('openrouter', 'never-synced')).toBe(false);
+  });
+
+  it('keeps openrouter and vercel namespaces separate', async () => {
+    await writeGatewayModelExistenceMarkers('vercel', { a: model('anthropic/claude') });
+
+    expect(await gatewayModelExists('vercel', 'anthropic/claude')).toBe(true);
+    expect(await gatewayModelExists('openrouter', 'anthropic/claude')).toBe(false);
+  });
+
+  it('expires markers after the TTL when sync stops refreshing them', async () => {
+    await writeGatewayModelExistenceMarkers('openrouter', { a: model('stale/model') });
+    expect(await gatewayModelExists('openrouter', 'stale/model')).toBe(true);
+
+    jest.advanceTimersByTime((GATEWAY_MODEL_EXISTENCE_TTL_SECONDS + 1) * 1000);
+
+    expect(await gatewayModelExists('openrouter', 'stale/model')).toBe(false);
+  });
+
+  it('does not write anything when there are no routable models', async () => {
+    await writeGatewayModelExistenceMarkers('openrouter', {
+      a: model('img', { type: 'image' }),
+    });
+    expect(fakeRedis.__store.size).toBe(0);
+  });
+});
+
+describe('gatewayModelExists fail-open behavior', () => {
+  it('returns false on a cold Redis failure', async () => {
+    fakeRedis.__failNextGet();
+    expect(await gatewayModelExists('openrouter', 'cold/failure')).toBe(false);
+  });
+
+  it('returns the last-known value on a later Redis failure', async () => {
+    await writeGatewayModelExistenceMarkers('openrouter', { a: model('warm/model') });
+    expect(await gatewayModelExists('openrouter', 'warm/model')).toBe(true);
+
+    // Advance past the in-process cache window so the next call hits Redis,
+    // but stay within the marker TTL so the value is still valid.
+    jest.advanceTimersByTime(120_000);
+    fakeRedis.__failNextGet();
+
+    expect(await gatewayModelExists('openrouter', 'warm/model')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/gateway-model-existence.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-model-existence.ts
@@ -6,56 +6,49 @@ import {
   type RedisKey,
 } from '@/lib/redis-keys';
 
-/**
- * Per-model "model exists at gateway" markers.
- *
- * The routing hot path only needs a yes/no answer to "is this model available at
- * gateway X?". Loading the entire model catalog blob from Redis (and zod-parsing
- * a few hundred models) just to build a membership Set is wasteful, so provider
- * sync instead writes one tiny marker key per routable model and the hot path
- * reads a single key.
- *
- * Expiry strategy: provider sync runs every 10 minutes and re-writes every
- * marker, but it occasionally fails, so we cannot assume markers are refreshed on
- * schedule. The markers therefore carry a TTL that is several sync cycles long:
- *
- *  - A handful of consecutive sync failures will NOT expire still-valid markers.
- *  - A model removed from a gateway's catalog stops being refreshed and its
- *    marker eventually expires on its own, since sync never deletes markers.
- *
- * If markers do go stale (prolonged sync outage) every marker expires and
- * existence checks return `false`, which is the safe direction for both current
- * callers: Vercel routing falls back to OpenRouter, and auto-free routing simply
- * drops the affected candidates.
- */
-export const GATEWAY_MODEL_EXISTENCE_TTL_SECONDS = 60 * 60; // 1 hour ~= 6 sync cycles
+// Per-model "model exists at gateway" markers let the routing hot path answer
+// "is this model available at gateway X?" with one tiny Redis read instead of
+// loading and zod-parsing the whole catalog blob into a membership Set.
+//
+// Sync re-writes every marker (every ~10 min) but occasionally fails, so markers
+// carry a TTL of several sync cycles: a few failed syncs won't expire valid
+// markers, while a model removed from a gateway expires on its own since sync
+// only writes markers, never deletes them. A full lapse resolves to "not found",
+// the safe direction for both callers.
+export const GATEWAY_MODEL_EXISTENCE_TTL_SECONDS = 60 * 60; // ~6 sync cycles
 
 const EXISTS_MARKER = '1';
 
-/**
- * Short in-process cache so the hot path does not issue a Redis round trip on
- * every request. This only caches the resolved boolean (pure data); the
- * authoritative expiry lives on the Redis keys themselves.
- */
+// Short in-process cache (pure booleans) so the hot path avoids a Redis round
+// trip per request; the authoritative expiry lives on the Redis keys. Bounded
+// because callers pass request-derived (and thus attacker-controlled) model ids;
+// the oldest entry is evicted once the cap is reached so the Map can't grow for
+// the lifetime of the isolate.
 const RESULT_CACHE_TTL_MS = 60_000;
+const RESULT_CACHE_MAX_ENTRIES = 2_000;
 
 const resultCache = new Map<RedisKey, { value: boolean; at: number }>();
+
+function cacheResult(key: RedisKey, value: boolean, at: number): void {
+  // Re-insert so iteration order tracks recency, then drop the oldest if over cap.
+  resultCache.delete(key);
+  resultCache.set(key, { value, at });
+  if (resultCache.size > RESULT_CACHE_MAX_ENTRIES) {
+    const oldest = resultCache.keys().next().value;
+    if (oldest !== undefined) resultCache.delete(oldest);
+  }
+}
 
 function isRoutableLanguageModel(model: StoredModel): boolean {
   return (model.type ?? 'language') === 'language' && model.endpoints.length > 0;
 }
 
-/** The routable language-model ids that get an existence marker on sync. */
 export function routableLanguageModelIds(models: Record<string, StoredModel>): string[] {
   return Object.values(models)
     .filter(isRoutableLanguageModel)
     .map(model => model.id);
 }
 
-/**
- * Write (or refresh) the existence markers for every routable language model of
- * a gateway. Called from provider sync after the catalog blob has been mirrored.
- */
 export async function writeGatewayModelExistenceMarkers(
   provider: GatewayModelExistenceProvider,
   models: Record<string, StoredModel>
@@ -72,13 +65,8 @@ export async function writeGatewayModelExistenceMarkers(
   await pipeline.exec();
 }
 
-/**
- * Whether `modelId` currently has an existence marker for `provider`.
- *
- * Reads a single Redis key (cached briefly in-process). Fails open to the
- * last-known value, or `false` when nothing has been cached yet, so a Redis blip
- * never blocks the routing hot path.
- */
+// Reads a single marker key (cached briefly in-process). Fails open to the
+// last-known value, or `false` when cold, so a Redis blip never blocks routing.
 export async function gatewayModelExists(
   provider: GatewayModelExistenceProvider,
   modelId: string
@@ -93,7 +81,7 @@ export async function gatewayModelExists(
 
   try {
     const value = (await redisClient.get<string>(key)) === EXISTS_MARKER;
-    resultCache.set(key, { value, at: now });
+    cacheResult(key, value, now);
     return value;
   } catch {
     return cached?.value ?? false;

--- a/apps/web/src/lib/ai-gateway/providers/gateway-model-existence.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-model-existence.ts
@@ -1,0 +1,101 @@
+import type { StoredModel } from '@kilocode/db/schema-types';
+import { redisClient } from '@/lib/redis';
+import {
+  gatewayModelExistsRedisKey,
+  type GatewayModelExistenceProvider,
+  type RedisKey,
+} from '@/lib/redis-keys';
+
+/**
+ * Per-model "model exists at gateway" markers.
+ *
+ * The routing hot path only needs a yes/no answer to "is this model available at
+ * gateway X?". Loading the entire model catalog blob from Redis (and zod-parsing
+ * a few hundred models) just to build a membership Set is wasteful, so provider
+ * sync instead writes one tiny marker key per routable model and the hot path
+ * reads a single key.
+ *
+ * Expiry strategy: provider sync runs every 10 minutes and re-writes every
+ * marker, but it occasionally fails, so we cannot assume markers are refreshed on
+ * schedule. The markers therefore carry a TTL that is several sync cycles long:
+ *
+ *  - A handful of consecutive sync failures will NOT expire still-valid markers.
+ *  - A model removed from a gateway's catalog stops being refreshed and its
+ *    marker eventually expires on its own, since sync never deletes markers.
+ *
+ * If markers do go stale (prolonged sync outage) every marker expires and
+ * existence checks return `false`, which is the safe direction for both current
+ * callers: Vercel routing falls back to OpenRouter, and auto-free routing simply
+ * drops the affected candidates.
+ */
+export const GATEWAY_MODEL_EXISTENCE_TTL_SECONDS = 60 * 60; // 1 hour ~= 6 sync cycles
+
+const EXISTS_MARKER = '1';
+
+/**
+ * Short in-process cache so the hot path does not issue a Redis round trip on
+ * every request. This only caches the resolved boolean (pure data); the
+ * authoritative expiry lives on the Redis keys themselves.
+ */
+const RESULT_CACHE_TTL_MS = 60_000;
+
+const resultCache = new Map<RedisKey, { value: boolean; at: number }>();
+
+function isRoutableLanguageModel(model: StoredModel): boolean {
+  return (model.type ?? 'language') === 'language' && model.endpoints.length > 0;
+}
+
+/** The routable language-model ids that get an existence marker on sync. */
+export function routableLanguageModelIds(models: Record<string, StoredModel>): string[] {
+  return Object.values(models)
+    .filter(isRoutableLanguageModel)
+    .map(model => model.id);
+}
+
+/**
+ * Write (or refresh) the existence markers for every routable language model of
+ * a gateway. Called from provider sync after the catalog blob has been mirrored.
+ */
+export async function writeGatewayModelExistenceMarkers(
+  provider: GatewayModelExistenceProvider,
+  models: Record<string, StoredModel>
+): Promise<void> {
+  const ids = routableLanguageModelIds(models);
+  if (ids.length === 0) return;
+
+  const pipeline = redisClient.pipeline();
+  for (const id of ids) {
+    pipeline.set(gatewayModelExistsRedisKey(provider, id), EXISTS_MARKER, {
+      ex: GATEWAY_MODEL_EXISTENCE_TTL_SECONDS,
+    });
+  }
+  await pipeline.exec();
+}
+
+/**
+ * Whether `modelId` currently has an existence marker for `provider`.
+ *
+ * Reads a single Redis key (cached briefly in-process). Fails open to the
+ * last-known value, or `false` when nothing has been cached yet, so a Redis blip
+ * never blocks the routing hot path.
+ */
+export async function gatewayModelExists(
+  provider: GatewayModelExistenceProvider,
+  modelId: string
+): Promise<boolean> {
+  const key = gatewayModelExistsRedisKey(provider, modelId);
+  const now = Date.now();
+
+  const cached = resultCache.get(key);
+  if (cached && now - cached.at < RESULT_CACHE_TTL_MS) {
+    return cached.value;
+  }
+
+  try {
+    const value = (await redisClient.get<string>(key)) === EXISTS_MARKER;
+    resultCache.set(key, { value, at: now });
+    return value;
+  } catch {
+    return cached?.value ?? false;
+  }
+}

--- a/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
@@ -33,19 +33,3 @@ export const getOpenRouterModelsMetadata = createStoredModelsFetcher(
   GATEWAY_METADATA_REDIS_KEYS.openrouterModels,
   'OpenRouter'
 );
-
-function toLanguageModelIdSet(models: StoredModelMap): ReadonlySet<string> {
-  return new Set(
-    Object.values(models)
-      .filter(model => (model.type ?? 'language') === 'language' && model.endpoints.length > 0)
-      .map(model => model.id)
-  );
-}
-
-export async function getVercelModels(): Promise<ReadonlySet<string>> {
-  return toLanguageModelIdSet(await getVercelModelsMetadata());
-}
-
-export async function getOpenRouterModels(): Promise<ReadonlySet<string>> {
-  return toLanguageModelIdSet(await getOpenRouterModelsMetadata());
-}

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -390,9 +390,7 @@ async function mirrorToRedis(values: {
   }
   await Promise.all(entries.map(([key, value]) => redisClient.set(key, JSON.stringify(value))));
 
-  // Per-model existence markers let the routing hot path check "does this model
-  // exist at this gateway?" without re-reading and parsing the whole catalog
-  // above. Best-effort: the catalog blobs (and their DB-backed snapshot) remain
+  // Best-effort: the catalog blobs above (and their DB snapshot) stay
   // authoritative, so a marker-write failure must not fail the sync run.
   try {
     await Promise.all([

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -26,6 +26,7 @@ import type { StoredModel } from '@kilocode/db/schema-types';
 import { EndpointsSchema, ModelsSchema } from '@kilocode/db/schema-types';
 import { redisClient } from '@/lib/redis';
 import { GATEWAY_METADATA_REDIS_KEYS, type RedisKey } from '@/lib/redis-keys';
+import { writeGatewayModelExistenceMarkers } from '@/lib/ai-gateway/providers/gateway-model-existence';
 import { syncDirectByokModels } from '@/lib/ai-gateway/providers/direct-byok/sync-direct-byok';
 import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attribution-headers';
 import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelIdToVercel';
@@ -388,6 +389,20 @@ async function mirrorToRedis(values: {
     entries.push([GATEWAY_METADATA_REDIS_KEYS.openrouterProviders, values.openrouterProviders]);
   }
   await Promise.all(entries.map(([key, value]) => redisClient.set(key, JSON.stringify(value))));
+
+  // Per-model existence markers let the routing hot path check "does this model
+  // exist at this gateway?" without re-reading and parsing the whole catalog
+  // above. Best-effort: the catalog blobs (and their DB-backed snapshot) remain
+  // authoritative, so a marker-write failure must not fail the sync run.
+  try {
+    await Promise.all([
+      writeGatewayModelExistenceMarkers('openrouter', values.openrouter),
+      writeGatewayModelExistenceMarkers('vercel', values.vercel),
+    ]);
+  } catch (err) {
+    console.error('[sync-providers] writing model existence markers failed', err);
+    captureException(err, { tags: { component: 'sync-providers-model-existence' } });
+  }
 }
 
 /**

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -22,7 +22,7 @@ import {
 } from '@/lib/ai-gateway/gateway-config';
 import { VERCEL_ROUTING_REDIS_KEY } from '@/lib/redis-keys';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
-import { getVercelModels } from '@/lib/ai-gateway/providers/gateway-models-cache';
+import { gatewayModelExists } from '@/lib/ai-gateway/providers/gateway-model-existence';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { isFableModel } from '@/lib/ai-gateway/providers/anthropic.constants';
 import { isDeepseekModel } from '@/lib/ai-gateway/providers/deepseek';
@@ -73,10 +73,7 @@ export async function shouldRouteToVercel(
   }
 
   console.debug('[shouldRouteToVercel] randomizing user to either OpenRouter or Vercel');
-  const [routingPercentage, vercelModels] = await Promise.all([
-    getVercelRoutingPercentage(),
-    getVercelModels(),
-  ]);
+  const routingPercentage = await getVercelRoutingPercentage();
 
   const passedRandomization =
     getRandomNumber('vercel_routing_' + randomSeed, 100) < routingPercentage;
@@ -86,7 +83,7 @@ export async function shouldRouteToVercel(
   }
 
   const vercelModelId = mapModelIdToVercel(requestedModel, isReasoningExplicitlyDisabled(request));
-  if (!vercelModels.has(vercelModelId)) {
+  if (!(await gatewayModelExists('vercel', vercelModelId))) {
     console.debug(`[shouldRouteToVercel] model not found in Vercel model list`);
     return false;
   }

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -30,16 +30,8 @@ export const directByokModelsRedisKey = (providerId: DirectUserByokInferenceProv
   redisKey(`ai-gateway.metadata.direct-byok-models:${providerId}`);
 
 /**
- * Per-model "this model is routable at <gateway>" marker keys.
- *
- * Written for every routable language model during provider sync, these let the
- * routing hot path answer "does this model exist?" with a single tiny Redis read
- * instead of loading and zod-parsing the entire model catalog blob just to build
- * a membership Set.
- *
- * The markers carry a TTL (see `GATEWAY_MODEL_EXISTENCE_TTL_SECONDS`) so they
- * eventually expire when sync stops refreshing a removed model — sync runs never
- * delete markers explicitly.
+ * Per-model "this model is routable at <gateway>" marker keys, written for every
+ * routable language model during provider sync. See `gateway-model-existence.ts`.
  */
 export type GatewayModelExistenceProvider = 'openrouter' | 'vercel';
 

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -29,6 +29,25 @@ export const GATEWAY_METADATA_REDIS_KEYS = {
 export const directByokModelsRedisKey = (providerId: DirectUserByokInferenceProviderId) =>
   redisKey(`ai-gateway.metadata.direct-byok-models:${providerId}`);
 
+/**
+ * Per-model "this model is routable at <gateway>" marker keys.
+ *
+ * Written for every routable language model during provider sync, these let the
+ * routing hot path answer "does this model exist?" with a single tiny Redis read
+ * instead of loading and zod-parsing the entire model catalog blob just to build
+ * a membership Set.
+ *
+ * The markers carry a TTL (see `GATEWAY_MODEL_EXISTENCE_TTL_SECONDS`) so they
+ * eventually expire when sync stops refreshing a removed model — sync runs never
+ * delete markers explicitly.
+ */
+export type GatewayModelExistenceProvider = 'openrouter' | 'vercel';
+
+export const gatewayModelExistsRedisKey = (
+  provider: GatewayModelExistenceProvider,
+  modelId: string
+) => redisKey(`ai-gateway.metadata.model-exists:${provider}:${modelId}`);
+
 export const posthogQueryRedisKey = (name: string) => redisKey(`posthog-query:${name}`);
 
 export const LEADERBOARD_MODEL_PROVIDER_USAGE_REDIS_KEY = redisKey(


### PR DESCRIPTION
## Summary

The AI gateway routing hot path read the **entire** model catalog blob from Redis (and zod-parsed a few hundred models into a `Set`) just to answer a boolean: *does this model exist at this gateway?* This happened in `shouldRouteToVercel` (Vercel membership) and `getAutoFreeCandidates` (OpenRouter free-model membership).

This change replaces that with small per-model existence markers:

- **Provider sync** (`mirrorToRedis`) now writes one tiny marker key per routable language model for both gateways: `ai-gateway.metadata.model-exists:<provider>:<modelId>`. Same routability predicate as before (`type === 'language'` and `endpoints.length > 0`).
- **Hot path** checks a single key via the new `gatewayModelExists(provider, modelId)` (backed by a short in-process cache so we don't add a Redis round trip per request, and failing open to last-known/`false` exactly like the previous catalog read).
- Removed the now-unused full-catalog `Set` helpers (`getVercelModels`, `getOpenRouterModels`, `toLanguageModelIdSet`). The metadata fetchers used for pricing/endpoint enrichment and BYOK are untouched.

### Expiry strategy (handling flaky sync)

Provider sync runs every 10 minutes but occasionally fails, so markers cannot rely on being refreshed on schedule. Markers therefore carry a TTL of `GATEWAY_MODEL_EXISTENCE_TTL_SECONDS` (1 hour ≈ 6 sync cycles):

- A handful of consecutive sync failures does **not** expire still-valid markers.
- A model removed from a gateway stops being refreshed and its marker expires on its own — sync only ever *writes* markers, never deletes them.
- If markers do fully lapse (prolonged outage), existence resolves to `false`, which is the safe direction for both callers (Vercel routing falls back to OpenRouter; auto-free simply drops affected candidates).

Marker writes are best-effort within sync: the catalog blobs and their DB snapshot remain authoritative, so a marker-write failure is logged/captured but never fails the sync run.

## Verification

- Targeted typecheck of `apps/web` (`tsgo --noEmit`): no errors. Full repo `pnpm typecheck` skipped (slow in this environment per repo guidance).
- `oxlint` clean on all changed files.
- Added `gateway-model-existence.test.ts` covering routable-id filtering, write→read round trips, gateway namespace isolation, TTL expiry, and cold/warm fail-open behavior. The Jest suite is DB-backed and could not be executed in this sandbox (no Docker/Postgres); please run `pnpm test -- apps/web/src/lib/ai-gateway/providers/gateway-model-existence.test.ts` with the test DB up.

## Visual Changes

N/A

## Reviewer Notes

- TTL choice (1h) is the main tuning knob: long enough to ride out occasional sync failures, short enough to evict removed models reasonably soon. Adjust `GATEWAY_MODEL_EXISTENCE_TTL_SECONDS` if sync reliability differs from expectations.
- The Vercel existence check now runs only after the routing-percentage randomization gate passes (previously fetched in parallel), so most requests never issue the marker read at all.
- `writeGatewayModelExistenceMarkers` uses a single Redis pipeline per gateway; payload is small (keys + `"1"`), comparable to the existing catalog-blob write.