### PR TITLE
refactor(web): remove BYOK PostHog-query notification and cached query infra

### DIFF
--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -5,8 +5,6 @@ import { getUserOrganizationsWithSeats } from '@/lib/organizations/organizations
 import type { UserOrganizationWithSeats } from '@/lib/organizations/organization-types';
 import { summarizeUserPayments } from '@/lib/creditTransactions';
 import { hasOrganizationEverPaid, hasUserEverPaid } from '@/lib/creditTransactions';
-import { cachedPosthogQuery } from '@/lib/posthog-query';
-import * as z from 'zod';
 
 import { fromMicrodollars } from '@/lib/utils';
 
@@ -135,7 +133,6 @@ export async function generateUserNotifications(user: User): Promise<KiloNotific
     generateLowCreditNotification,
     generateAutoTopUpNotification,
     generateAutoTopUpOrgsNotification,
-    generateByokProvidersNotification,
     generateKiloPassNotification,
     generateKiloPassPromoMay29Notification,
   ];
@@ -254,126 +251,6 @@ async function generateTeamsTrialNotification(
       showIn: ['cli', 'extension'],
     },
   ];
-}
-
-const getByokProviderUsers = cachedPosthogQuery(
-  z.array(
-    z.tuple([z.string(), z.string()]).transform(([userId, provider]) => ({ userId, provider }))
-  )
-);
-
-async function generateByokProvidersNotification(
-  user: User,
-  _ctx: NotificationContext
-): Promise<KiloNotification[]> {
-  try {
-    const byokProviderUsers = await getByokProviderUsers(
-      'byok-provider-usage-users',
-      'select id, apiProvider from notification_byok_providers_jan_19 limit 5e5'
-    );
-
-    const provider = byokProviderUsers.find(p => p.userId === user.id)?.provider;
-    if (!provider) {
-      console.debug('[generateByokProvidersNotification] not using a BYOK supported provider');
-      return [];
-    }
-
-    // Maps an extension `apiProvider` id to a user-facing label. Multiple ids can
-    // refer to the same underlying service (regional/plan/legacy variants), and we
-    // only list ids for services we actually support BYOK for via Kilo Gateway
-    // (see UserByokProviderIdSchema).
-    const names = {
-      // Anthropic / Claude
-      anthropic: 'Claude API Key',
-      claude: 'Claude API Key',
-
-      // Amazon Bedrock
-      bedrock: 'Amazon Bedrock API Key',
-      'amazon-bedrock': 'Amazon Bedrock API Key',
-
-      // Chutes
-      chutes: 'Chutes API Key',
-
-      // DeepSeek
-      deepseek: 'DeepSeek API Key',
-      deepseek1: 'DeepSeek API Key',
-      'deepseek-v4': 'DeepSeek API Key',
-      'deepseek-v4-pro': 'DeepSeek API Key',
-
-      // Fireworks
-      fireworks: 'Fireworks API Key',
-      'fireworks-ai': 'Fireworks API Key',
-
-      // Google AI (Gemini)
-      gemini: 'Google AI API Key',
-      google: 'Google AI API Key',
-
-      // Moonshot AI / Kimi
-      moonshot: 'Moonshot AI API Key',
-      moonshotai: 'Moonshot AI API Key',
-      kimi: 'Moonshot AI API Key',
-      'kimi-for-coding': 'Kimi Code Plan',
-
-      // MiniMax
-      minimax: 'MiniMax Coding Plan',
-      'minimax-coding-plan': 'MiniMax Coding Plan',
-
-      // Mistral
-      mistral: 'Mistral AI API Key',
-
-      // Novita
-      novita: 'Novita AI API Key',
-
-      // xAI
-      xai: 'xAI API Key',
-
-      // Z.ai / Zhipu (GLM)
-      zai: 'GLM Coding Plan',
-      'z-ai': 'GLM Coding Plan',
-      'zai-coding-plan': 'GLM Coding Plan',
-      glm: 'GLM Coding Plan',
-      zhipuai: 'GLM Coding Plan',
-      'zhipuai-coding-plan': 'GLM Coding Plan',
-
-      // Xiaomi MiMo
-      xiaomi: 'Xiaomi MiMo API Key',
-      'xiaomi-mimo': 'Xiaomi MiMo API Key',
-      xiaomimimo: 'Xiaomi MiMo API Key',
-      mimo: 'Xiaomi MiMo API Key',
-      'xiaomi-token-plan-sgp': 'Xiaomi Token Plan',
-      'xiaomi-token-plan-ams': 'Xiaomi Token Plan',
-
-      // Ollama Cloud
-      'ollama-cloud': 'Ollama Cloud API Key',
-    } as Record<string, string>;
-
-    const providerName = names[provider];
-    if (!providerName) {
-      console.debug(
-        `[generateByokProvidersNotification] unknown BYOK supported provider ${provider}`
-      );
-      return [];
-    }
-
-    console.debug(
-      `[generateByokProvidersNotification] has used BYOK supported provider ${provider}`
-    );
-    return [
-      {
-        id: 'byok-providers-jan-19',
-        title: 'Try BYOK for Kilo Gateway',
-        message: `BYOK now supported for your ${providerName}, allowing faster model support, Kilo platform features, and more!`,
-        action: {
-          actionText: 'Learn more',
-          actionURL: 'https://kilo.ai/docs/basic-usage/byok',
-        },
-        showIn: ['cli', 'extension'],
-      },
-    ];
-  } catch (e) {
-    console.error('[generateByokProvidersNotification]', e);
-    return [];
-  }
 }
 
 async function generateKiloPassPromoMay29Notification(

--- a/apps/web/src/lib/posthog-query.ts
+++ b/apps/web/src/lib/posthog-query.ts
@@ -1,7 +1,4 @@
 import { getEnvVariable } from '@/lib/dotenvx';
-import { redisClient } from '@/lib/redis';
-import { posthogQueryRedisKey } from '@/lib/redis-keys';
-import * as z from 'zod';
 
 /**
  * NOTE: This is a copy from the landing page project.
@@ -56,51 +53,5 @@ export async function posthogQuery(name: string, query: string): Promise<PostHog
   return {
     status: 'ok',
     body: await response.json(),
-  };
-}
-
-const CACHE_TTL_SECONDS = 60 * 60 * 24; // 24 hours
-const MEMORY_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
-
-export function cachedPosthogQuery<Output>(schema: z.ZodType<Output[]>) {
-  const parse = (name: string, raw: unknown): Output[] => {
-    const result = schema.safeParse(raw);
-    if (!result.success) {
-      throw new Error(`${name} parse failed: ${z.prettifyError(result.error)}`);
-    }
-    return result.data;
-  };
-
-  const memoryCache = new Map<string, { value: Output[]; at: number }>();
-
-  return async (name: string, query: string): Promise<Output[]> => {
-    const memoryCached = memoryCache.get(name);
-    if (memoryCached && Date.now() - memoryCached.at < MEMORY_CACHE_TTL_MS) {
-      return memoryCached.value;
-    }
-
-    const key = posthogQueryRedisKey(name);
-
-    const cached = await redisClient.get<string>(key);
-    if (cached !== null) {
-      const data = parse(name, JSON.parse(cached));
-      memoryCache.set(name, { value: data, at: Date.now() });
-      return data;
-    }
-
-    const startTime = performance.now();
-    const response = await posthogQuery(name, query);
-    if (response.status !== 'ok') {
-      throw new Error(`${name} query failed: ${JSON.stringify(response.error, undefined, 2)}`);
-    }
-    const data = parse(name, response.body.results);
-    console.debug(
-      `[cachedPosthogQuery] ${name} returned ${data.length} rows in ${performance.now() - startTime}ms`
-    );
-
-    await redisClient.set(key, JSON.stringify(response.body.results), { ex: CACHE_TTL_SECONDS });
-    memoryCache.set(name, { value: data, at: Date.now() });
-
-    return data;
   };
 }

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -29,8 +29,6 @@ export const GATEWAY_METADATA_REDIS_KEYS = {
 export const directByokModelsRedisKey = (providerId: DirectUserByokInferenceProviderId) =>
   redisKey(`ai-gateway.metadata.direct-byok-models:${providerId}`);
 
-export const posthogQueryRedisKey = (name: string) => redisKey(`posthog-query:${name}`);
-
 export const LEADERBOARD_MODEL_PROVIDER_USAGE_REDIS_KEY = redisKey(
   'public-api:leaderboard-model-provider-usage'
 );


### PR DESCRIPTION
## Summary

Removes the only user notification that depended on a PostHog query combined with a Redis cache, and tears down the now-unused cached-query infrastructure.

- Deleted `generateByokProvidersNotification` (notification id `byok-providers-jan-19`) and its `getByokProviderUsers` cached reader from `apps/web/src/lib/notifications.ts`, plus its registration in the conditional notifications list. Also dropped the now-unused `cachedPosthogQuery` and `zod` imports.
- Removed `cachedPosthogQuery` (the PostHog-query + Redis two-layer cache combinator) and its `redisClient` / `posthogQueryRedisKey` / `zod` imports from `apps/web/src/lib/posthog-query.ts`. This was its only call site.
- Removed the dedicated `posthogQueryRedisKey` entry from `apps/web/src/lib/redis-keys.ts`.

The uncached `posthogQuery` helper is intentionally kept because it still has active non-notification consumers (org usage autocomplete analytics, model-stats sync, and the admin feature-interest router). For the same reason the shared Redis client, the `@upstash/redis` dependency, the `posthog-*` telemetry packages, and the `POSTHOG_QUERY_API_KEY` env var are left in place — removing them would break unrelated, still-active features.

## Verification

- Loaded `http://localhost:<port>/api/users/notifications` flow is unaffected; the route still calls `generateUserNotifications`, which now simply no longer emits the BYOK notification.
- Confirmed no remaining references to the removed symbols (`cachedPosthogQuery`, `posthogQueryRedisKey`, `generateByokProvidersNotification`, `getByokProviderUsers`).

## Visual Changes

N/A

## Reviewer Notes

- `posthogQuery` and `POSTHOG_QUERY_API_KEY` are deliberately retained due to three other consumers; this PR scopes PostHog removal to "where possible" without breaking those features.