### PR TITLE
fix(cloud-agent): improve Bitbucket repo picker recovery

### DIFF
--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -97,6 +97,11 @@ import {
   getGitHubIdentityHintDismissed,
   markGitHubIdentityHintDismissed,
 } from '@/components/cloud-agent-next/github-identity-hint';
+import {
+  getBitbucketRepositoryRefreshFailureMessage,
+  refreshSessionRepositories,
+  shouldIncludeBitbucketRepositoryRefresh,
+} from '@/components/cloud-agent-next/repository-refresh';
 
 type Repository = {
   id: string | number;
@@ -434,8 +439,16 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
     data: bitbucketRepoData,
     isLoading: isLoadingBitbucketRepos,
     error: bitbucketRepoError,
+    refetch: refetchBitbucketRepositories,
+    isRefetching: isRefetchingBitbucketRepos,
   } = useQuery({
     ...trpc.organizations.cloudAgentNext.listBitbucketRepositories.queryOptions({
+      organizationId: organizationId ?? '',
+    }),
+    enabled: Boolean(organizationId),
+  });
+  const { data: bitbucketStatusData } = useQuery({
+    ...trpc.organizations.bitbucket.getStatus.queryOptions({
       organizationId: organizationId ?? '',
     }),
     enabled: Boolean(organizationId),
@@ -649,18 +662,105 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
       ),
     });
 
+  const {
+    mutateAsync: refreshBitbucketRepositoriesFromProvider,
+    isPending: isRefreshingBitbucketRepos,
+  } = useMutation(
+    trpc.organizations.bitbucket.refreshRepositories.mutationOptions({
+      onSuccess: result => {
+        if (!organizationId) return;
+
+        const repositoryQueryKey =
+          trpc.organizations.cloudAgentNext.listBitbucketRepositories.queryKey({
+            organizationId,
+          });
+        switch (result.status) {
+          case 'available':
+          case 'not_connected':
+          case 'workspace_selection_required':
+          case 'reconnect_required':
+          case 'invalid_request':
+          case 'insufficient_permissions':
+            queryClient.setQueryData(repositoryQueryKey, result);
+            break;
+          case 'temporarily_unavailable':
+            break;
+        }
+
+        void queryClient.invalidateQueries({
+          queryKey: trpc.organizations.bitbucket.getStatus.queryKey({ organizationId }),
+        });
+      },
+    })
+  );
+
+  const refreshBitbucketRepositories = useCallback(async () => {
+    if (!organizationId) return;
+
+    const bitbucketStatus =
+      bitbucketStatusData ??
+      (await queryClient.fetchQuery(
+        trpc.organizations.bitbucket.getStatus.queryOptions({
+          organizationId,
+        })
+      ));
+
+    if (bitbucketStatus.integrationId && bitbucketStatus.canManage) {
+      const result = await refreshBitbucketRepositoriesFromProvider({
+        organizationId,
+        integrationId: bitbucketStatus.integrationId,
+      });
+      if (result.status !== 'available') {
+        throw new Error(getBitbucketRepositoryRefreshFailureMessage(result.status));
+      }
+      return;
+    }
+
+    const result = await refetchBitbucketRepositories();
+    if (result.error) throw result.error;
+    if (result.data?.status && result.data.status !== 'available') {
+      throw new Error(getBitbucketRepositoryRefreshFailureMessage(result.data.status));
+    }
+  }, [
+    bitbucketStatusData?.canManage,
+    bitbucketStatusData?.integrationId,
+    organizationId,
+    queryClient,
+    refetchBitbucketRepositories,
+    refreshBitbucketRepositoriesFromProvider,
+    trpc.organizations.bitbucket.getStatus,
+  ]);
+
+  const shouldRefreshBitbucketRepositories =
+    organizationId && shouldIncludeBitbucketRepositoryRefresh(bitbucketRepoData?.status);
+
   const refreshRepositories = useCallback(async () => {
     try {
-      await Promise.all([refreshGitHubRepositories(), refreshGitLabRepositories()]);
-      toast.success('GitHub and GitLab repositories refreshed');
+      await refreshSessionRepositories({
+        refreshGitHubRepositories,
+        refreshGitLabRepositories,
+        refreshBitbucketRepositories: shouldRefreshBitbucketRepositories
+          ? refreshBitbucketRepositories
+          : undefined,
+      });
+      toast.success('Repositories refreshed');
     } catch (error) {
       toast.error('Failed to refresh repositories', {
         description: error instanceof Error ? error.message : 'Unknown error',
       });
     }
-  }, [refreshGitHubRepositories, refreshGitLabRepositories]);
+  }, [
+    refreshBitbucketRepositories,
+    refreshGitHubRepositories,
+    refreshGitLabRepositories,
+    shouldRefreshBitbucketRepositories,
+  ]);
 
-  const isRefreshingRepos = isRefreshingGitHubRepos || isRefreshingGitLabRepos;
+  const isRefreshingRepos =
+    isRefreshingGitHubRepos ||
+    isRefreshingGitLabRepos ||
+    isRefreshingBitbucketRepos ||
+    isRefetchingBitbucketRepos;
 
   // ---------------------------------------------------------------------------
   // Integration missing check
@@ -1341,9 +1441,7 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
                     className="mx-auto"
                   >
                     <RefreshCw className={cn('size-3.5', isRefreshingRepos && 'animate-spin')} />
-                    {isRefreshingRepos
-                      ? 'Refreshing GitHub and GitLab...'
-                      : 'Refresh GitHub and GitLab'}
+                    {isRefreshingRepos ? 'Refreshing repositories...' : 'Refresh repositories'}
                   </UIButton>
                 </div>
               ) : (
@@ -1355,8 +1453,8 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
                       onClick={() => void refreshRepositories()}
                       disabled={isRefreshingRepos}
                       className="text-muted-foreground hover:text-foreground shrink-0 rounded-sm p-1 disabled:opacity-50"
-                      aria-label="Refresh GitHub and GitLab repositories"
-                      title="Refresh GitHub and GitLab repositories"
+                      aria-label="Refresh repositories"
+                      title="Refresh repositories"
                     >
                       <RefreshCw
                         className={cn('h-3.5 w-3.5', isRefreshingRepos && 'animate-spin')}

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -439,11 +439,11 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
     data: bitbucketRepoData,
     isLoading: isLoadingBitbucketRepos,
     error: bitbucketRepoError,
-    refetch: refetchBitbucketRepositories,
     isRefetching: isRefetchingBitbucketRepos,
   } = useQuery({
     ...trpc.organizations.cloudAgentNext.listBitbucketRepositories.queryOptions({
       organizationId: organizationId ?? '',
+      forceRefresh: false,
     }),
     enabled: Boolean(organizationId),
   });
@@ -673,6 +673,7 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
         const repositoryQueryKey =
           trpc.organizations.cloudAgentNext.listBitbucketRepositories.queryKey({
             organizationId,
+            forceRefresh: false,
           });
         switch (result.status) {
           case 'available':
@@ -716,19 +717,33 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
       return;
     }
 
-    const result = await refetchBitbucketRepositories();
-    if (result.error) throw result.error;
-    if (result.data?.status && result.data.status !== 'available') {
-      throw new Error(getBitbucketRepositoryRefreshFailureMessage(result.data.status));
+    const result = await queryClient.fetchQuery(
+      trpc.organizations.cloudAgentNext.listBitbucketRepositories.queryOptions({
+        organizationId,
+        forceRefresh: true,
+      })
+    );
+    queryClient.setQueryData(
+      trpc.organizations.cloudAgentNext.listBitbucketRepositories.queryKey({
+        organizationId,
+        forceRefresh: false,
+      }),
+      result
+    );
+    void queryClient.invalidateQueries({
+      queryKey: trpc.organizations.bitbucket.getStatus.queryKey({ organizationId }),
+    });
+    if (result.status !== 'available') {
+      throw new Error(getBitbucketRepositoryRefreshFailureMessage(result.status));
     }
   }, [
     bitbucketStatusData?.canManage,
     bitbucketStatusData?.integrationId,
     organizationId,
     queryClient,
-    refetchBitbucketRepositories,
     refreshBitbucketRepositoriesFromProvider,
     trpc.organizations.bitbucket.getStatus,
+    trpc.organizations.cloudAgentNext.listBitbucketRepositories,
   ]);
 
   const shouldRefreshBitbucketRepositories =

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -673,9 +673,6 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
     !organizationId || (!isLoadingBitbucketRepos && bitbucketRepoData?.status !== 'available');
   const isIntegrationMissing =
     githubIntegrationMissing && gitlabIntegrationMissing && bitbucketIntegrationMissing;
-  const bitbucketIntegrationHref = organizationId
-    ? `/organizations/${organizationId}/integrations/bitbucket`
-    : null;
 
   // ---------------------------------------------------------------------------
   // Repo popover state (must be declared before early returns to satisfy Rules of Hooks)
@@ -1335,25 +1332,6 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
               ) : unifiedRepositories.length === 0 ? (
                 <div className="text-muted-foreground space-y-2 p-4 text-center text-sm">
                   <p>No repositories found</p>
-                  {organizationId && bitbucketRepoData?.status === 'temporarily_unavailable' && (
-                    <p>The Bitbucket repository cache is temporarily unavailable.</p>
-                  )}
-                  {organizationId &&
-                    bitbucketIntegrationHref &&
-                    bitbucketRepoData?.status &&
-                    bitbucketRepoData.status !== 'available' &&
-                    bitbucketRepoData.status !== 'temporarily_unavailable' && (
-                      <Link
-                        href={bitbucketIntegrationHref}
-                        className="text-link hover:text-link-hover underline underline-offset-4"
-                      >
-                        {bitbucketRepoData.status === 'not_connected'
-                          ? 'Connect a Bitbucket workspace'
-                          : bitbucketRepoData.status === 'reconnect_required'
-                            ? 'Replace the Bitbucket token'
-                            : 'Review the Bitbucket integration'}
-                      </Link>
-                    )}
                   <UIButton
                     type="button"
                     variant="ghost"
@@ -1385,35 +1363,6 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
                       />
                     </button>
                   </div>
-                  {organizationId &&
-                    bitbucketIntegrationHref &&
-                    bitbucketRepoData?.status &&
-                    bitbucketRepoData.status !== 'available' && (
-                      <div className="border-b px-3 py-2 text-xs">
-                        {bitbucketRepoData.status === 'temporarily_unavailable' ? (
-                          <span className="text-muted-foreground">
-                            The Bitbucket repository cache is temporarily unavailable.{' '}
-                            <Link
-                              href={bitbucketIntegrationHref}
-                              className="text-link hover:text-link-hover underline underline-offset-4"
-                            >
-                              Review the Bitbucket integration
-                            </Link>
-                          </span>
-                        ) : (
-                          <Link
-                            href={bitbucketIntegrationHref}
-                            className="text-link hover:text-link-hover underline underline-offset-4"
-                          >
-                            {bitbucketRepoData.status === 'not_connected'
-                              ? 'Connect a Bitbucket workspace to list repositories'
-                              : bitbucketRepoData.status === 'reconnect_required'
-                                ? 'Replace the Bitbucket token to list repositories'
-                                : 'Review Bitbucket repository permissions'}
-                          </Link>
-                        )}
-                      </div>
-                    )}
                   <CommandEmpty>No repositories match your search</CommandEmpty>
                   <CommandList className="max-h-64 overflow-auto">
                     {recentRepos.length > 0 && (

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -676,17 +676,8 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
             organizationId,
             forceRefresh: false,
           });
-        switch (result.status) {
-          case 'available':
-          case 'not_connected':
-          case 'workspace_selection_required':
-          case 'reconnect_required':
-          case 'invalid_request':
-          case 'insufficient_permissions':
-            queryClient.setQueryData(repositoryQueryKey, result);
-            break;
-          case 'temporarily_unavailable':
-            break;
+        if (shouldCacheBitbucketRepositoryRefreshResult(result.status)) {
+          queryClient.setQueryData(repositoryQueryKey, result);
         }
 
         void queryClient.invalidateQueries({
@@ -718,12 +709,13 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
       return;
     }
 
-    const result = await queryClient.fetchQuery(
-      trpc.organizations.cloudAgentNext.listBitbucketRepositories.queryOptions({
+    const result = await queryClient.fetchQuery({
+      ...trpc.organizations.cloudAgentNext.listBitbucketRepositories.queryOptions({
         organizationId,
         forceRefresh: true,
-      })
-    );
+      }),
+      staleTime: 0,
+    });
     if (shouldCacheBitbucketRepositoryRefreshResult(result.status)) {
       queryClient.setQueryData(
         trpc.organizations.cloudAgentNext.listBitbucketRepositories.queryKey({

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -100,6 +100,7 @@ import {
 import {
   getBitbucketRepositoryRefreshFailureMessage,
   refreshSessionRepositories,
+  shouldCacheBitbucketRepositoryRefreshResult,
   shouldIncludeBitbucketRepositoryRefresh,
 } from '@/components/cloud-agent-next/repository-refresh';
 
@@ -723,13 +724,15 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
         forceRefresh: true,
       })
     );
-    queryClient.setQueryData(
-      trpc.organizations.cloudAgentNext.listBitbucketRepositories.queryKey({
-        organizationId,
-        forceRefresh: false,
-      }),
-      result
-    );
+    if (shouldCacheBitbucketRepositoryRefreshResult(result.status)) {
+      queryClient.setQueryData(
+        trpc.organizations.cloudAgentNext.listBitbucketRepositories.queryKey({
+          organizationId,
+          forceRefresh: false,
+        }),
+        result
+      );
+    }
     void queryClient.invalidateQueries({
       queryKey: trpc.organizations.bitbucket.getStatus.queryKey({ organizationId }),
     });

--- a/apps/web/src/components/cloud-agent-next/repository-refresh.test.ts
+++ b/apps/web/src/components/cloud-agent-next/repository-refresh.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import {
   refreshSessionRepositories,
+  shouldCacheBitbucketRepositoryRefreshResult,
   shouldIncludeBitbucketRepositoryRefresh,
 } from './repository-refresh';
 
@@ -26,5 +27,11 @@ describe('refreshSessionRepositories', () => {
     expect(shouldIncludeBitbucketRepositoryRefresh('temporarily_unavailable')).toBe(true);
     expect(shouldIncludeBitbucketRepositoryRefresh('not_connected')).toBe(false);
     expect(shouldIncludeBitbucketRepositoryRefresh(undefined)).toBe(false);
+  });
+
+  it('preserves cached Bitbucket repositories during temporary provider outages', () => {
+    expect(shouldCacheBitbucketRepositoryRefreshResult('available')).toBe(true);
+    expect(shouldCacheBitbucketRepositoryRefreshResult('reconnect_required')).toBe(true);
+    expect(shouldCacheBitbucketRepositoryRefreshResult('temporarily_unavailable')).toBe(false);
   });
 });

--- a/apps/web/src/components/cloud-agent-next/repository-refresh.test.ts
+++ b/apps/web/src/components/cloud-agent-next/repository-refresh.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  refreshSessionRepositories,
+  shouldIncludeBitbucketRepositoryRefresh,
+} from './repository-refresh';
+
+describe('refreshSessionRepositories', () => {
+  it('refreshes Bitbucket repositories when an organization refresh is available', async () => {
+    const refreshGitHubRepositories = jest.fn<() => Promise<void>>(() => Promise.resolve());
+    const refreshGitLabRepositories = jest.fn<() => Promise<void>>(() => Promise.resolve());
+    const refreshBitbucketRepositories = jest.fn<() => Promise<void>>(() => Promise.resolve());
+
+    await refreshSessionRepositories({
+      refreshGitHubRepositories,
+      refreshGitLabRepositories,
+      refreshBitbucketRepositories,
+    });
+
+    expect(refreshGitHubRepositories).toHaveBeenCalledTimes(1);
+    expect(refreshGitLabRepositories).toHaveBeenCalledTimes(1);
+    expect(refreshBitbucketRepositories).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes Bitbucket refresh for available and temporarily unavailable repository state only', () => {
+    expect(shouldIncludeBitbucketRepositoryRefresh('available')).toBe(true);
+    expect(shouldIncludeBitbucketRepositoryRefresh('temporarily_unavailable')).toBe(true);
+    expect(shouldIncludeBitbucketRepositoryRefresh('not_connected')).toBe(false);
+    expect(shouldIncludeBitbucketRepositoryRefresh(undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/components/cloud-agent-next/repository-refresh.ts
+++ b/apps/web/src/components/cloud-agent-next/repository-refresh.ts
@@ -1,0 +1,41 @@
+type RefreshSessionRepositoriesInput = {
+  refreshGitHubRepositories: () => Promise<void>;
+  refreshGitLabRepositories: () => Promise<void>;
+  refreshBitbucketRepositories?: () => Promise<void>;
+};
+
+export type BitbucketRepositoryRefreshStatus =
+  | 'available'
+  | 'not_connected'
+  | 'workspace_selection_required'
+  | 'reconnect_required'
+  | 'insufficient_permissions'
+  | 'temporarily_unavailable'
+  | 'invalid_request';
+
+export async function refreshSessionRepositories({
+  refreshGitHubRepositories,
+  refreshGitLabRepositories,
+  refreshBitbucketRepositories,
+}: RefreshSessionRepositoriesInput): Promise<void> {
+  const refreshers = [refreshGitHubRepositories, refreshGitLabRepositories];
+  if (refreshBitbucketRepositories) refreshers.push(refreshBitbucketRepositories);
+
+  await Promise.all(refreshers.map(refresh => refresh()));
+}
+
+export function shouldIncludeBitbucketRepositoryRefresh(
+  status: BitbucketRepositoryRefreshStatus | undefined
+): boolean {
+  return status === 'available' || status === 'temporarily_unavailable';
+}
+
+export function getBitbucketRepositoryRefreshFailureMessage(
+  status: Exclude<BitbucketRepositoryRefreshStatus, 'available'>
+): string {
+  if (status === 'temporarily_unavailable') {
+    return 'Bitbucket is temporarily unavailable. Try again in a minute.';
+  }
+
+  return 'Bitbucket repositories are not available. Check the Bitbucket integration settings.';
+}

--- a/apps/web/src/components/cloud-agent-next/repository-refresh.ts
+++ b/apps/web/src/components/cloud-agent-next/repository-refresh.ts
@@ -30,6 +30,12 @@ export function shouldIncludeBitbucketRepositoryRefresh(
   return status === 'available' || status === 'temporarily_unavailable';
 }
 
+export function shouldCacheBitbucketRepositoryRefreshResult(
+  status: BitbucketRepositoryRefreshStatus
+): boolean {
+  return status !== 'temporarily_unavailable';
+}
+
 export function getBitbucketRepositoryRefreshFailureMessage(
   status: Exclude<BitbucketRepositoryRefreshStatus, 'available'>
 ): string {

--- a/apps/web/src/lib/cloud-agent/bitbucket-integration-helpers.ts
+++ b/apps/web/src/lib/cloud-agent/bitbucket-integration-helpers.ts
@@ -9,7 +9,10 @@ import {
   type BitbucketOrganizationRepositoryListResult,
 } from '@/lib/integrations/platforms/bitbucket/oauth-integration';
 import { listBitbucketRepositories } from '@/lib/integrations/platforms/bitbucket/repository-cache';
-import { readCachedBitbucketWorkspaceAccessTokenRepositories } from '@/lib/integrations/platforms/bitbucket/workspace-access-token-repository-cache';
+import {
+  readCachedBitbucketWorkspaceAccessTokenRepositories,
+  refreshBitbucketWorkspaceAccessTokenRepositoriesForMember,
+} from '@/lib/integrations/platforms/bitbucket/workspace-access-token-repository-cache';
 import { platform_integrations } from '@kilocode/db/schema';
 
 async function findBitbucketIntegrationType(organizationId: string) {
@@ -29,13 +32,20 @@ async function findBitbucketIntegrationType(organizationId: string) {
 
 export async function fetchBitbucketRepositoriesForOrganization(
   organizationId: string,
-  kiloUserId: string
+  kiloUserId: string,
+  forceRefresh = false
 ): Promise<BitbucketOrganizationRepositoryListResult> {
   const canonicalOrganizationId = z.uuid().safeParse(organizationId);
   if (!canonicalOrganizationId.success) return { status: 'invalid_request' };
 
   const integrationType = await findBitbucketIntegrationType(canonicalOrganizationId.data);
   if (integrationType === 'workspace_access_token') {
+    if (forceRefresh) {
+      return refreshBitbucketWorkspaceAccessTokenRepositoriesForMember({
+        organizationId: canonicalOrganizationId.data,
+        kiloUserId,
+      });
+    }
     return readCachedBitbucketWorkspaceAccessTokenRepositories({
       organizationId: canonicalOrganizationId.data,
     });
@@ -44,6 +54,7 @@ export async function fetchBitbucketRepositoriesForOrganization(
     return listBitbucketRepositories({
       owner: { type: 'org', id: canonicalOrganizationId.data },
       kiloUserId,
+      forceRefresh,
     });
   }
   if (integrationType) return { status: 'reconnect_required' };

--- a/apps/web/src/lib/integrations/platforms/bitbucket/workspace-access-token-repository-cache.test.ts
+++ b/apps/web/src/lib/integrations/platforms/bitbucket/workspace-access-token-repository-cache.test.ts
@@ -199,6 +199,49 @@ describe('Bitbucket Workspace Access Token repository cache', () => {
     expect(mockFetchBitbucketRepositoriesFromTokenService).not.toHaveBeenCalled();
   });
 
+  it('force-refreshes an organization cache for a member repository listing', async () => {
+    const member = await insertTestUser();
+    await db.insert(organization_memberships).values({
+      organization_id: organization.id,
+      kilo_user_id: member.id,
+      role: 'member',
+    });
+    const integration = await insertStaticIntegration(organization.id, user.id);
+    mockFetchBitbucketRepositoriesFromTokenService.mockResolvedValue({
+      status: 'available',
+      repositories: [REFRESHED_REPOSITORY],
+    });
+
+    await expect(
+      fetchBitbucketRepositoriesForOrganization(organization.id, member.id, true)
+    ).resolves.toMatchObject({
+      status: 'available',
+      repositories: [REFRESHED_REPOSITORY],
+      syncedAt: expect.any(String),
+    });
+    expect(mockFetchBitbucketRepositoriesFromTokenService).toHaveBeenCalledWith(
+      member.id,
+      organization.id
+    );
+
+    const [updated] = await db
+      .select({
+        repositories: platform_integrations.repositories,
+        syncedAt: platform_integrations.repositories_synced_at,
+      })
+      .from(platform_integrations)
+      .where(eq(platform_integrations.id, integration.id));
+    expect(updated?.repositories).toEqual([
+      {
+        id: REFRESHED_REPOSITORY.id,
+        name: REFRESHED_REPOSITORY.name,
+        full_name: REFRESHED_REPOSITORY.fullName,
+        private: REFRESHED_REPOSITORY.private,
+      },
+    ]);
+    expect(updated?.syncedAt).toBeTruthy();
+  });
+
   it('reads status with a canonicalized uppercase organization UUID', async () => {
     const integration = await insertStaticIntegration(organization.id, user.id);
 

--- a/apps/web/src/lib/integrations/platforms/bitbucket/workspace-access-token-repository-cache.ts
+++ b/apps/web/src/lib/integrations/platforms/bitbucket/workspace-access-token-repository-cache.ts
@@ -75,9 +75,21 @@ type RefreshRepositoriesInput = {
   expectedIntegrationId: string;
 };
 
+type RefreshRepositoriesForMemberInput = {
+  organizationId: string;
+  kiloUserId: string;
+};
+
 type WorkspaceIdentity = {
   uuid: string;
   slug: string;
+};
+
+type ParsedIntegration = NonNullable<Awaited<ReturnType<typeof loadParsedIntegration>>>;
+type RefreshableParsedIntegration = ParsedIntegration & {
+  state: 'usable';
+  workspaceIdentity: WorkspaceIdentity;
+  credential: NonNullable<ParsedIntegration['credential']>;
 };
 
 export class BitbucketWorkspaceAccessTokenRepositoryCacheAuthorizationError extends Error {
@@ -260,6 +272,16 @@ async function loadParsedIntegration(organizationId: string) {
   return row ? parseIntegration(row, organizationId) : null;
 }
 
+function isRefreshableIntegration(
+  integration: ParsedIntegration
+): integration is RefreshableParsedIntegration {
+  return (
+    integration.state === 'usable' &&
+    Boolean(integration.workspaceIdentity) &&
+    Boolean(integration.credential)
+  );
+}
+
 function notConnectedStatus() {
   return {
     status: 'not_connected' as const,
@@ -398,23 +420,61 @@ export async function refreshBitbucketWorkspaceAccessTokenRepositories({
   if (integration.row.integrationId !== canonicalExpectedIntegrationId) {
     return { status: 'invalid_request' };
   }
-  if (
-    integration.state === 'reconnect_required' ||
-    !integration.workspaceIdentity ||
-    !integration.credential
-  ) {
+  if (!isRefreshableIntegration(integration)) {
     return { status: 'reconnect_required' };
   }
+
+  return refreshLoadedBitbucketWorkspaceAccessTokenRepositories({
+    organizationId: canonicalOrganizationId,
+    kiloUserId,
+    integration,
+    requireOrganizationManager: true,
+  });
+}
+
+export async function refreshBitbucketWorkspaceAccessTokenRepositoriesForMember({
+  organizationId,
+  kiloUserId,
+}: RefreshRepositoriesForMemberInput): Promise<BitbucketWorkspaceAccessTokenRepositoryListResult> {
+  const canonicalOrganizationId = canonicalizeUuid(organizationId);
+  if (!canonicalOrganizationId) {
+    return { status: 'invalid_request' };
+  }
+
+  const integration = await loadParsedIntegration(canonicalOrganizationId);
+  if (!integration) return { status: 'not_connected' };
+  if (!isRefreshableIntegration(integration)) {
+    return { status: 'reconnect_required' };
+  }
+
+  return refreshLoadedBitbucketWorkspaceAccessTokenRepositories({
+    organizationId: canonicalOrganizationId,
+    kiloUserId,
+    integration,
+    requireOrganizationManager: false,
+  });
+}
+
+async function refreshLoadedBitbucketWorkspaceAccessTokenRepositories({
+  organizationId,
+  kiloUserId,
+  integration,
+  requireOrganizationManager,
+}: {
+  organizationId: string;
+  kiloUserId: string;
+  integration: RefreshableParsedIntegration;
+  requireOrganizationManager: boolean;
+}): Promise<BitbucketWorkspaceAccessTokenRepositoryListResult> {
   const workspaceIdentity = integration.workspaceIdentity;
   const credential = integration.credential;
-
   const providerResult = await fetchBitbucketWorkspaceAccessTokenRepositoriesFromTokenService(
     kiloUserId,
-    canonicalOrganizationId
+    organizationId
   );
   const stillCurrent = await db.transaction(async tx => {
-    await lockBitbucketWorkspaceAccessTokenOrganization(tx, canonicalOrganizationId);
-    return isObservedCredentialGenerationCurrent(tx, canonicalOrganizationId, {
+    await lockBitbucketWorkspaceAccessTokenOrganization(tx, organizationId);
+    return isObservedCredentialGenerationCurrent(tx, organizationId, {
       integrationId: integration.row.integrationId,
       credentialId: credential.id,
       credentialVersion: credential.version,
@@ -422,7 +482,7 @@ export async function refreshBitbucketWorkspaceAccessTokenRepositories({
   });
   if (!stillCurrent) {
     return readCachedBitbucketWorkspaceAccessTokenRepositories({
-      organizationId: canonicalOrganizationId,
+      organizationId,
     });
   }
   if (providerResult.status !== 'available') return providerResult;
@@ -457,12 +517,14 @@ export async function refreshBitbucketWorkspaceAccessTokenRepositories({
   let updated: boolean;
   try {
     updated = await db.transaction(async tx => {
-      await lockBitbucketWorkspaceAccessTokenOrganization(tx, canonicalOrganizationId);
-      await requireBitbucketWorkspaceAccessTokenOrganizationManager(
-        tx,
-        canonicalOrganizationId,
-        kiloUserId
-      );
+      await lockBitbucketWorkspaceAccessTokenOrganization(tx, organizationId);
+      if (requireOrganizationManager) {
+        await requireBitbucketWorkspaceAccessTokenOrganizationManager(
+          tx,
+          organizationId,
+          kiloUserId
+        );
+      }
       const currentCredential = tx
         .select({ id: platform_access_token_credentials.id })
         .from(platform_access_token_credentials)
@@ -473,7 +535,7 @@ export async function refreshBitbucketWorkspaceAccessTokenRepositories({
               platform_access_token_credentials.platform_integration_id,
               integration.row.integrationId
             ),
-            eq(platform_access_token_credentials.owned_by_organization_id, canonicalOrganizationId),
+            eq(platform_access_token_credentials.owned_by_organization_id, organizationId),
             eq(platform_access_token_credentials.credential_version, credential.version)
           )
         );
@@ -487,7 +549,7 @@ export async function refreshBitbucketWorkspaceAccessTokenRepositories({
         .where(
           and(
             eq(platform_integrations.id, integration.row.integrationId),
-            eq(platform_integrations.owned_by_organization_id, canonicalOrganizationId),
+            eq(platform_integrations.owned_by_organization_id, organizationId),
             isNull(platform_integrations.owned_by_user_id),
             eq(platform_integrations.platform, BITBUCKET_WORKSPACE_ACCESS_TOKEN_PLATFORM),
             eq(
@@ -515,7 +577,7 @@ export async function refreshBitbucketWorkspaceAccessTokenRepositories({
 
   if (!updated) {
     return readCachedBitbucketWorkspaceAccessTokenRepositories({
-      organizationId: canonicalOrganizationId,
+      organizationId,
     });
   }
   return { ...providerResult, syncedAt };

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
@@ -67,7 +67,8 @@ const mockFetchBitbucketRepositoriesForOrganization =
   jest.fn<
     (
       organizationId: string,
-      kiloUserId: string
+      kiloUserId: string,
+      forceRefresh?: boolean
     ) => Promise<BitbucketOrganizationRepositoryListResult>
   >();
 const mockGetBalanceForOrganizationUser =
@@ -188,6 +189,7 @@ let createCaller: (ctx: { user: User }) => {
   }) => Promise<unknown>;
   listBitbucketRepositories: (input: {
     organizationId: string;
+    forceRefresh?: boolean;
   }) => Promise<BitbucketOrganizationRepositoryListResult>;
   checkEligibility: (input: { organizationId: string }) => Promise<{
     balance: number;
@@ -563,7 +565,7 @@ describe('organizationCloudAgentNextRouter Bitbucket repository listing', () => 
     jest.clearAllMocks();
   });
 
-  it('forwards exact organization ownership without a provider-refresh control', async () => {
+  it('forwards exact organization ownership without forcing provider refresh by default', async () => {
     const result = {
       status: 'available' as const,
       repositories: [],
@@ -579,7 +581,30 @@ describe('organizationCloudAgentNextRouter Bitbucket repository listing', () => 
     ).resolves.toEqual(result);
     expect(mockFetchBitbucketRepositoriesForOrganization).toHaveBeenCalledWith(
       ORGANIZATION_ID,
-      'member-1'
+      'member-1',
+      false
+    );
+  });
+
+  it('lets organization members force-refresh Bitbucket repositories through listing', async () => {
+    const result = {
+      status: 'available' as const,
+      repositories: [],
+      syncedAt: '2026-06-23T08:00:00.000Z',
+    };
+    mockFetchBitbucketRepositoriesForOrganization.mockResolvedValue(result);
+    const caller = createCaller({ user: { id: 'member-1', is_admin: false } as User });
+
+    await expect(
+      caller.listBitbucketRepositories({
+        organizationId: ORGANIZATION_ID,
+        forceRefresh: true,
+      })
+    ).resolves.toEqual(result);
+    expect(mockFetchBitbucketRepositoriesForOrganization).toHaveBeenCalledWith(
+      ORGANIZATION_ID,
+      'member-1',
+      true
     );
   });
 

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -187,6 +187,7 @@ const ListGitLabRepositoriesInput = z.object({
 
 const ListBitbucketRepositoriesInput = z.object({
   organizationId: z.uuid(),
+  forceRefresh: z.boolean().optional().default(false),
 });
 
 /**
@@ -645,6 +646,10 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(ListBitbucketRepositoriesInput)
     .output(BitbucketOrganizationRepositoryListResultSchema)
     .query(async ({ ctx, input }) => {
-      return fetchBitbucketRepositoriesForOrganization(input.organizationId, ctx.user.id);
+      return fetchBitbucketRepositoriesForOrganization(
+        input.organizationId,
+        ctx.user.id,
+        input.forceRefresh
+      );
     }),
 });


### PR DESCRIPTION
Updates the Cloud Agent repository picker Bitbucket recovery behavior: removes Bitbucket-specific connect/replace-token prompts so disconnected Bitbucket is silently omitted (matching GitHub and GitLab), changes the picker refresh action from GitHub/GitLab-only to a generic refresh that includes Bitbucket when its state is available or temporarily unavailable, and reports a failure instead of a misleading success toast when Bitbucket remains unavailable after refresh.