### PR TITLE
fix(extension): guard auto-compaction against stale usage after a failed run

### DIFF
--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -425,8 +425,10 @@ export const AgentChatPanel = ({
         updateThinkingBlock(conversationId, eventId, thinkingText);
       }
     };
+    let currentRunHasUsage = false;
     const updateRunUsage = (usage: { promptTokens: number }): void => {
       if (isCurrentRun()) {
+        currentRunHasUsage = true;
         store.set(contextUsageAtomFamily(conversationId), { promptTokens: usage.promptTokens });
       }
     };
@@ -473,7 +475,11 @@ export const AgentChatPanel = ({
           )?.contextLength;
           const ratio = getContextRatio(latest, runContextLength);
 
-          if (ratio !== undefined && ratio >= AUTO_COMPACT_RATIO) {
+          /*
+           * Only auto-compact off a usage value this run actually produced; a run that fails
+           * before any usage chunk would otherwise compact on the prior run's stale count.
+           */
+          if (currentRunHasUsage && ratio !== undefined && ratio >= AUTO_COMPACT_RATIO) {
             void compactConversation(conversationId);
           }
         }

--- a/apps/extension/tests/e2e/context-usage.test.ts
+++ b/apps/extension/tests/e2e/context-usage.test.ts
@@ -170,6 +170,7 @@ test('auto-compaction fires when usage exceeds 85% threshold', async () => {
 
 test('manual "Compact now" compacts the conversation', async () => {
   const fixture = await startFixtureServer();
+  const seenChatBodies: unknown[] = [];
   const { context, extensionId, userDataDir } = await launchExtensionContext();
 
   try {
@@ -188,6 +189,7 @@ test('manual "Compact now" compacts the conversation', async () => {
       secondCompletionEvents: [
         { choices: [{ delta: { content: 'SUMMARY: manually compacted.' } }] },
       ],
+      seenChatBodies,
       toolNames: safeToolNames,
     });
 
@@ -212,6 +214,19 @@ test('manual "Compact now" compacts the conversation', async () => {
     await expect(sidePanel.getByText(/Compacted earlier context/u)).toBeVisible({
       timeout: 10_000,
     });
+
+    /*
+     * Assert the compaction actually rewrote stored events (not just rendered a prefix): the
+     * summary is persisted and the earliest seeded messages are gone, and the summarization call
+     * fired with tool_choice: 'none'.
+     */
+    await waitForStoredConversationText(sidePanel, 'SUMMARY: manually compacted.');
+    const conversationsJson = await readStoredConversationsJson(sidePanel);
+    expect(conversationsJson).not.toContain('First message');
+    expect(conversationsJson).not.toContain('Second message');
+    const [, summarizationBody] = seenChatBodies;
+    expect(summarizationBody).toMatchObject({ tool_choice: 'none' });
+
     /*
      * Compaction released the input lock: with a fresh draft, Send is enabled again. It stays
      * disabled on an empty draft, which is unrelated to compaction.


### PR DESCRIPTION
Follow-up to the review on #4283 (auto-merged before the final review's comments could land). Addresses the two comments from the approving review [#pullrequestreview-4592644672](https://github.com/Kilo-Org/cloud/pull/4283#pullrequestreview-4592644672).

## MUST-FIX: auto-compaction reads stale usage after a failed run

`updateRunUsage` is the only writer to `contextUsageAtomFamily`, and it fires only on `completion.usage`. Nothing clears the atom on run start, failure, or abort. So a run that exits before any usage chunk (network failure, gateway error) leaves the *previous* run's token count in the atom, and the run's `finally` reads it to decide whether to auto-compact.

Concrete path: run A succeeds at `promptTokens = 900` / contextLength `1000` → auto-compact fires. Atom stays at 900. Run B's `fetch` fails before any SSE → no usage emitted → `finally` reads stale 900, ratio `0.9 ≥ 0.85` → conversation history is irreversibly compacted over events that include run B's failure message, with no user action.

Fix: track whether the current run produced a fresh usage value (`currentRunHasUsage`) and gate auto-compaction on it.

## SUGGESTION: strengthen the manual-compaction e2e test

The manual `Compact now` test only checked prefix visibility and send re-enablement — a regression where compaction no-ops while a stale prefix already exists would stay green. Mirrored the auto-compaction test: assert the summary is persisted, the seeded messages are gone, and the summarization call fired with `tool_choice: 'none'`.

## Testing
- Unit (Vitest): 115 passing
- E2E (Playwright, Chrome): `context-usage.test.ts` 3/3 passing, including the strengthened manual-compaction assertions
- typecheck, lint, format clean