### PR TITLE
fix(dev): keep dashboard pane selection synced

### DIFF
--- a/dev/local/dashboard.tsx
+++ b/dev/local/dashboard.tsx
@@ -303,6 +303,7 @@ function Dashboard({
     () => new Map(initialServiceNames.map(n => [n, 'starting' as const]))
   );
   const [selectedIdx, setSelectedIdx] = useState(0);
+  const [, bumpViewedRevision] = useState(0);
 
   const viewedRef = useRef<ViewedTarget>(
     initialViewed ? { kind: 'service' as const, name: initialViewed } : null
@@ -319,6 +320,7 @@ function Dashboard({
     toggleGroupOn: (_groupId: string) => {},
     toggleGroupOff: (_groupId: string) => {},
     showGroup: (_groupId: string) => {},
+    showService: (_serviceName: string) => {},
   });
 
   // --- Restore sidebar width after terminal resize / tab switch ---
@@ -345,6 +347,22 @@ function Dashboard({
 
   // --- Derived ---
   const sidebarItems = useMemo(() => buildSidebarItems(enabledGroups), [enabledGroups]);
+
+  const showServiceView = useCallback((serviceName: string) => {
+    const previous = currentViewedEncoded(viewedRef.current);
+    doShowService(serviceName, viewedRef);
+    if (currentViewedEncoded(viewedRef.current) !== previous) {
+      bumpViewedRevision(revision => revision + 1);
+    }
+  }, []);
+
+  const showGroupView = useCallback((groupId: string, runningServiceNames: string[]) => {
+    const previous = currentViewedEncoded(viewedRef.current);
+    doShowGroup(groupId, runningServiceNames, viewedRef);
+    if (currentViewedEncoded(viewedRef.current) !== previous) {
+      bumpViewedRevision(revision => revision + 1);
+    }
+  }, []);
 
   // --- Status polling ---
   useEffect(() => {
@@ -447,7 +465,7 @@ function Dashboard({
 
           // Show the group in multi-pane view
           const running = getGroupServiceNames(groupId).filter(n => nextRunningServices.has(n));
-          doShowGroup(groupId, running, viewedRef);
+          showGroupView(groupId, running);
 
           // Phase 1 is complete; keep UI responsive while tunnel gate runs in background.
           togglingRef.current = false;
@@ -516,7 +534,7 @@ function Dashboard({
             const updatedRunning = getGroupServiceNames(groupId).filter(n =>
               runningAfterCapture.has(n)
             );
-            doShowGroup(groupId, updatedRunning, viewedRef);
+            showGroupView(groupId, updatedRunning);
           }
 
           startTimeRef.current = Date.now();
@@ -527,7 +545,7 @@ function Dashboard({
         }
       })();
     },
-    [runningServices]
+    [runningServices, showGroupView]
   );
 
   // --- Toggle group OFF ---
@@ -556,7 +574,7 @@ function Dashboard({
         for (const name of toStop) allRunning.delete(name);
         const replacement = findViewableService([...allRunning], allRunning);
         if (replacement) {
-          doShowService(replacement, viewedRef);
+          showServiceView(replacement);
         }
       }
 
@@ -586,15 +604,15 @@ function Dashboard({
       });
       togglingRef.current = false;
     },
-    [enabledGroups, runningServices]
+    [enabledGroups, runningServices, showServiceView]
   );
 
   const showGroup = useCallback(
     (groupId: string) => {
       const running = getGroupServiceNames(groupId).filter(n => runningServices.has(n));
-      doShowGroup(groupId, running, viewedRef);
+      showGroupView(groupId, running);
     },
-    [runningServices]
+    [runningServices, showGroupView]
   );
 
   mouseStateRef.current = {
@@ -604,6 +622,7 @@ function Dashboard({
     toggleGroupOn,
     toggleGroupOff,
     showGroup,
+    showService: showServiceView,
   };
 
   // --- Keyboard ---
@@ -632,7 +651,7 @@ function Dashboard({
         if (enabledGroups.has(item.groupId)) {
           // Group is running — show all its services in multi-pane view
           const running = getGroupServiceNames(item.groupId).filter(n => runningServices.has(n));
-          doShowGroup(item.groupId, running, viewedRef);
+          showGroupView(item.groupId, running);
         } else {
           // Group is off — start it (which will also show it)
           if (!alwaysOnGroupIds.has(item.groupId)) {
@@ -642,7 +661,7 @@ function Dashboard({
       } else {
         // Service: show single pane
         if (runningServices.has(item.name)) {
-          doShowService(item.name, viewedRef);
+          showServiceView(item.name);
         }
       }
       return;
@@ -662,7 +681,7 @@ function Dashboard({
       } else {
         // Service: show single pane (same as Enter for services)
         if (runningServices.has(item.name)) {
-          doShowService(item.name, viewedRef);
+          showServiceView(item.name);
         }
       }
       return;
@@ -724,6 +743,7 @@ function Dashboard({
           runningServices: running,
           toggleGroupOn: onGroupOn,
           showGroup: onShowGroup,
+          showService: onShowService,
         } = mouseStateRef.current;
 
         // 2 header rows, then visible items starting from scrollRef offset
@@ -747,7 +767,7 @@ function Dashboard({
           }
         } else {
           if (running.has(item.name)) {
-            doShowService(item.name, viewedRef);
+            onShowService(item.name);
           }
         }
       }

--- a/dev/local/dashboard.tsx
+++ b/dev/local/dashboard.tsx
@@ -132,7 +132,11 @@ function doShowGroup(
   const current = viewedRef.current;
   const result = showGroupInTmux(sessionName, runningServiceNames, currentViewedEncoded(current));
   if (result !== currentViewedEncoded(current)) {
-    viewedRef.current = { kind: 'group', groupId, serviceNames: runningServiceNames };
+    const joinedServiceNames = result.split(',').filter(Boolean);
+    viewedRef.current =
+      joinedServiceNames.length > 0
+        ? { kind: 'group', groupId, serviceNames: joinedServiceNames }
+        : null;
   }
 }
 

--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -167,7 +167,7 @@ function setRightPanes(
   sessionName: string,
   serviceNames: string[],
   currentPaneNames: string
-): void {
+): string[] {
   // Break all current right-side panes (>= 1) back to their own named windows
   const total = countPanes(sessionName, 0);
   const current = currentPaneNames ? currentPaneNames.split(',') : [];
@@ -196,12 +196,13 @@ function setRightPanes(
     }
   }
 
-  if (serviceNames.length === 0) return;
+  if (serviceNames.length === 0) return [];
 
   // Join first service horizontally (right of sidebar pane 0)
   const firstWin = listWindows(sessionName).find(w => w.name === serviceNames[0]);
-  if (!firstWin) return;
+  if (!firstWin) return [];
   joinPane(sessionName, firstWin.index, 0, 0, 0, 'h');
+  const joinedServiceNames = [serviceNames[0]];
 
   // Join subsequent services vertically below pane 1 (stacked in the right column)
   for (let i = 1; i < serviceNames.length; i++) {
@@ -209,6 +210,7 @@ function setRightPanes(
     if (!win) continue;
     try {
       joinPane(sessionName, win.index, 0, 0, i, 'v');
+      joinedServiceNames.push(serviceNames[i]);
     } catch {
       // skip service if join fails
     }
@@ -223,15 +225,16 @@ function setRightPanes(
   }
 
   // Label each right-side pane so pane border titles show the service name
-  for (let i = 0; i < serviceNames.length; i++) {
+  for (let i = 0; i < joinedServiceNames.length; i++) {
     try {
-      setPaneTitle(sessionName, 0, i + 1, serviceNames[i]);
+      setPaneTitle(sessionName, 0, i + 1, joinedServiceNames[i]);
     } catch {
       /* best-effort */
     }
   }
 
   selectPane(sessionName, 0, 0);
+  return joinedServiceNames;
 }
 
 /**
@@ -247,8 +250,10 @@ export function showServiceInTmux(
 ): string {
   if (serviceName === currentPaneNames && !currentViewedIsGroup) return currentPaneNames;
   try {
-    setRightPanes(sessionName, [serviceName], currentPaneNames);
-    return serviceName;
+    const joinedServiceNames = setRightPanes(sessionName, [serviceName], currentPaneNames);
+    return joinedServiceNames.length === 1 && joinedServiceNames[0] === serviceName
+      ? serviceName
+      : '';
   } catch {
     return currentPaneNames;
   }
@@ -265,8 +270,8 @@ export function showGroupInTmux(
 ): string {
   if (serviceNames.length === 0) return currentPaneNames;
   try {
-    setRightPanes(sessionName, serviceNames, currentPaneNames);
-    return serviceNames.join(',');
+    const joinedServiceNames = setRightPanes(sessionName, serviceNames, currentPaneNames);
+    return joinedServiceNames.length > 0 ? joinedServiceNames.join(',') : '';
   } catch {
     return currentPaneNames;
   }

--- a/dev/local/tmux.test.ts
+++ b/dev/local/tmux.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import test from 'node:test';
 
-import { buildInteractiveShellCommand } from './tmux';
+import { breakPane, buildInteractiveShellCommand, listWindows } from './tmux';
 
 test('buildInteractiveShellCommand wraps quoted startup commands in parseable shell syntax', () => {
   const startupCommand =
@@ -15,3 +15,70 @@ test('buildInteractiveShellCommand wraps quoted startup commands in parseable sh
   assert.match(wrapped, /PATH/);
   execFileSync('/bin/sh', ['-n', '-c', wrapped]);
 });
+
+const hasTmux = (() => {
+  try {
+    execFileSync('tmux', ['-V'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+test(
+  'breakPane keeps the requested service window name after tmux automatic rename',
+  { skip: !hasTmux },
+  () => {
+    const sessionName = `kilo-tmux-test-${process.pid}-${Date.now()}`;
+    const serviceName = 'nextjs';
+    const tmux = (...args: string[]) => execFileSync('tmux', args, { stdio: 'ignore' });
+    const tmuxOutput = (...args: string[]) =>
+      execFileSync('tmux', args, { encoding: 'utf-8' }).trim();
+
+    try {
+      tmux('new-session', '-d', '-s', sessionName, '-n', 'dashboard', 'sleep 120');
+      tmux(
+        'new-window',
+        '-d',
+        '-t',
+        sessionName,
+        '-n',
+        serviceName,
+        'sh -lc "while true; do sleep 60; done"'
+      );
+
+      const serviceWindow = listWindows(sessionName).find(window => window.name === serviceName);
+      assert.ok(serviceWindow);
+
+      tmux(
+        'join-pane',
+        '-h',
+        '-s',
+        `${sessionName}:${serviceWindow.index}.0`,
+        '-t',
+        `${sessionName}:0.0`
+      );
+
+      const newWindowIndex = breakPane(sessionName, 0, 1, serviceName);
+      const window = listWindows(sessionName).find(entry => entry.index === newWindowIndex);
+
+      assert.deepEqual(window, { index: newWindowIndex, name: serviceName });
+      assert.equal(
+        tmuxOutput(
+          'display-message',
+          '-p',
+          '-t',
+          `${sessionName}:${newWindowIndex}`,
+          '#{automatic-rename}'
+        ),
+        '0'
+      );
+    } finally {
+      try {
+        tmux('kill-session', '-t', sessionName);
+      } catch {
+        // Session may already be gone if tmux fails during setup.
+      }
+    }
+  }
+);

--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -211,7 +211,9 @@ function listWindows(sessionName: string): WindowInfo[] {
 }
 
 function renameWindow(sessionName: string, windowTarget: string | number, newName: string): void {
-  execSync(`tmux rename-window -t ${sessionName}:${windowTarget} ${newName}`, { stdio: 'ignore' });
+  execSync(`tmux rename-window -t ${sessionName}:${windowTarget} ${escapeForShell(newName)}`, {
+    stdio: 'ignore',
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -328,10 +330,23 @@ function breakPane(
   newWindowName: string
 ): number {
   const output = execSync(
-    `tmux break-pane -d -s ${sessionName}:${windowTarget}.${pane} -n ${newWindowName} -P -F "#{window_index}"`,
+    `tmux break-pane -d -s ${sessionName}:${windowTarget}.${pane} -n ${escapeForShell(
+      newWindowName
+    )} -P -F "#{window_index}"`,
     { encoding: 'utf-8' }
   ).trim();
-  return parseInt(output, 10);
+  const windowIndex = parseInt(output, 10);
+
+  // tmux creates windows from break-pane with automatic-rename enabled. On
+  // tmux 3.7, the new window is immediately renamed to the shell command
+  // (for example "zsh"), even when -n is provided. The dev dashboard later
+  // finds service panes by window name, so pin the service name after moving.
+  execSync(`tmux set-window-option -t ${sessionName}:${windowIndex} automatic-rename off`, {
+    stdio: 'ignore',
+  });
+  renameWindow(sessionName, windowIndex, newWindowName);
+
+  return windowIndex;
 }
 
 /** Count panes in a window */


### PR DESCRIPTION
## Summary
Dev dashboard service switching now keeps right-pane output and active sidebar indicators in sync.

### Why this change is needed
Selecting a different service in `pnpm dev:start` could leave dashboard state stale. tmux could rename broken-out service windows to shell command names like `zsh`, so switching back to `nextjs` failed to find original pane. Keyboard selection also updated a ref without triggering Ink render, so active marker stayed on old service until another navigation event.

### How this is addressed
- Pins service window names after `break-pane` by disabling tmux `automatic-rename` and renaming window back to service name.
- Tracks panes actually joined into dashboard view so UI state does not claim failed pane switches succeeded.
- Re-renders dashboard active marker after service or group view changes from keyboard and mouse paths.
- Adds tmux regression coverage for `breakPane` preserving service window names.

## Human Verification
- Ran focused tmux regression test: `pnpm exec tsx --test dev/local/tmux.test.ts`.
- Verified dummy tmux switch sequence `nextjs -> postgres -> nextjs` reports `rightPaneHasNextjs: true`.

## Reviewer Notes
### Human Reviewer Flags
No notable items for human review beyond what the summary covers.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `breakPane` now shells quotes requested window names, disables `automatic-rename`, then calls `renameWindow`.
- `setRightPanes` returns actual joined services so callers can keep dashboard state aligned with tmux results.
- Dashboard keeps `viewedRef` for imperative tmux coordination, but bumps render state after view changes so Ink updates marker immediately.

</details>
