### PR TITLE
fix(cloud-agent): clean up aborted snapshot sanitization

### DIFF
--- a/services/cloud-agent-next/wrapper/src/restore-session.test.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.test.ts
@@ -80,12 +80,6 @@ function writeMockKilo(binDir: string, exitCode: number): void {
   fs.writeFileSync(kiloPath, script, { mode: 0o755 });
 }
 
-function writeCopyingMockKilo(binDir: string, destinationPath: string): void {
-  const script = `#!/bin/sh\nset -eu\ncp "$2" ${JSON.stringify(destinationPath)}\n`;
-  const kiloPath = path.join(binDir, 'kilo');
-  fs.writeFileSync(kiloPath, script, { mode: 0o755 });
-}
-
 function writeSlowMockKilo(binDir: string): void {
   const script = '#!/bin/sh\nsleep 1\nexit 0\n';
   const kiloPath = path.join(binDir, 'kilo');
@@ -103,41 +97,6 @@ function writeSignalIgnoringDescendantMockKilo(binDir: string, descendantMarker:
   const script = `#!/bin/sh\ntrap 'exit 0' TERM\nnode -e 'const fs = require("node:fs"); process.on("SIGTERM", () => {}); fs.writeFileSync(process.argv[1], "ready"); setTimeout(() => fs.writeFileSync(process.argv[2], "alive"), 800); setInterval(() => {}, 1000);' "${readyMarker}" "${descendantMarker}" </dev/null >/dev/null 2>&1 &\nwhile [ ! -f "${readyMarker}" ]; do sleep 0.01; done\nsleep 2\n`;
   const kiloPath = path.join(binDir, 'kilo');
   fs.writeFileSync(kiloPath, script, { mode: 0o755 });
-}
-
-async function waitForFile(filePath: string, timeoutMs = 500): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (fs.existsSync(filePath)) return;
-    await new Promise(resolve => setTimeout(resolve, 10));
-  }
-  throw new Error(`timed out waiting for ${filePath}`);
-}
-
-function mockHangingJq(startedMarkerPath: string): () => void {
-  const originalSpawn = Bun.spawn;
-  Bun.spawn = ((command: unknown, options: { signal?: AbortSignal } | undefined) => {
-    if (Array.isArray(command) && command[0] === 'jq') {
-      const stdout = new ReadableStream<Uint8Array>({
-        start(controller) {
-          fs.writeFileSync(startedMarkerPath, 'started');
-          options?.signal?.addEventListener('abort', () => controller.close(), { once: true });
-        },
-      });
-      return {
-        stdout,
-        exited: new Promise<number>(resolve => {
-          options?.signal?.addEventListener('abort', () => resolve(124), { once: true });
-        }),
-      } as ReturnType<typeof Bun.spawn>;
-    }
-
-    return originalSpawn(command as never, options as never);
-  }) as typeof Bun.spawn;
-
-  return () => {
-    Bun.spawn = originalSpawn;
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -443,81 +402,6 @@ describe('restoreSession', () => {
     if (!result.ok) {
       expect(result.step).toBe('import');
       expect(result.error).toContain('kilo import failed');
-    }
-  });
-
-  it('clamps negative token counts before import', async () => {
-    const importedSnapshotPath = path.join(tmpDir, 'imported-snapshot.json');
-    writeCopyingMockKilo(binDir, importedSnapshotPath);
-    mockFetchOk(
-      JSON.stringify({
-        info: snapshotInfo(),
-        messages: [
-          {
-            info: {
-              id: 'msg_negative_tokens',
-              tokens: {
-                total: 1,
-                input: 1,
-                output: -173,
-                reasoning: -2,
-                cache: { read: -1, write: 0 },
-              },
-            },
-            parts: [
-              {
-                type: 'step-finish',
-                tokens: { total: 1, input: 1, output: -173, reasoning: 0 },
-              },
-            ],
-          },
-        ],
-      })
-    );
-
-    const result = await restoreSession(SESSION_ID, workspace);
-
-    expect(result.ok).toBe(true);
-    const imported = JSON.parse(fs.readFileSync(importedSnapshotPath, 'utf-8'));
-    expect(imported.messages[0].info.tokens).toEqual({
-      total: 1,
-      input: 1,
-      output: 0,
-      reasoning: 0,
-      cache: { read: 0, write: 0 },
-    });
-    expect(imported.messages[0].parts[0].tokens).toEqual({
-      total: 1,
-      input: 1,
-      output: 0,
-      reasoning: 0,
-    });
-  });
-
-  it('cleans up downloaded temp file when token sanitization is aborted', async () => {
-    const sanitizerStartedMarker = path.join(tmpDir, 'sanitizer-started');
-    const restoreJq = mockHangingJq(sanitizerStartedMarker);
-    mockFetchOk(makeSnapshot([]));
-    const controller = new AbortController();
-    const deadlineError = new Error('workspace deadline reached');
-    try {
-      const restorePromise = restoreSession(SESSION_ID, workspace, undefined, {
-        signal: controller.signal,
-      });
-      await waitForFile(sanitizerStartedMarker);
-      controller.abort(deadlineError);
-
-      let caughtError: unknown;
-      try {
-        await restorePromise;
-      } catch (error) {
-        caughtError = error;
-      }
-
-      expect(caughtError).toBe(deadlineError);
-      expect(fs.existsSync(TMP_PATH)).toBe(false);
-    } finally {
-      restoreJq();
     }
   });
 

--- a/services/cloud-agent-next/wrapper/src/restore-session.test.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.test.ts
@@ -80,6 +80,12 @@ function writeMockKilo(binDir: string, exitCode: number): void {
   fs.writeFileSync(kiloPath, script, { mode: 0o755 });
 }
 
+function writeCopyingMockKilo(binDir: string, destinationPath: string): void {
+  const script = `#!/bin/sh\nset -eu\ncp "$2" ${JSON.stringify(destinationPath)}\n`;
+  const kiloPath = path.join(binDir, 'kilo');
+  fs.writeFileSync(kiloPath, script, { mode: 0o755 });
+}
+
 function writeSlowMockKilo(binDir: string): void {
   const script = '#!/bin/sh\nsleep 1\nexit 0\n';
   const kiloPath = path.join(binDir, 'kilo');
@@ -97,6 +103,41 @@ function writeSignalIgnoringDescendantMockKilo(binDir: string, descendantMarker:
   const script = `#!/bin/sh\ntrap 'exit 0' TERM\nnode -e 'const fs = require("node:fs"); process.on("SIGTERM", () => {}); fs.writeFileSync(process.argv[1], "ready"); setTimeout(() => fs.writeFileSync(process.argv[2], "alive"), 800); setInterval(() => {}, 1000);' "${readyMarker}" "${descendantMarker}" </dev/null >/dev/null 2>&1 &\nwhile [ ! -f "${readyMarker}" ]; do sleep 0.01; done\nsleep 2\n`;
   const kiloPath = path.join(binDir, 'kilo');
   fs.writeFileSync(kiloPath, script, { mode: 0o755 });
+}
+
+async function waitForFile(filePath: string, timeoutMs = 500): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) return;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${filePath}`);
+}
+
+function mockHangingJq(startedMarkerPath: string): () => void {
+  const originalSpawn = Bun.spawn;
+  Bun.spawn = ((command: unknown, options: { signal?: AbortSignal } | undefined) => {
+    if (Array.isArray(command) && command[0] === 'jq') {
+      const stdout = new ReadableStream<Uint8Array>({
+        start(controller) {
+          fs.writeFileSync(startedMarkerPath, 'started');
+          options?.signal?.addEventListener('abort', () => controller.close(), { once: true });
+        },
+      });
+      return {
+        stdout,
+        exited: new Promise<number>(resolve => {
+          options?.signal?.addEventListener('abort', () => resolve(124), { once: true });
+        }),
+      } as ReturnType<typeof Bun.spawn>;
+    }
+
+    return originalSpawn(command as never, options as never);
+  }) as typeof Bun.spawn;
+
+  return () => {
+    Bun.spawn = originalSpawn;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -402,6 +443,81 @@ describe('restoreSession', () => {
     if (!result.ok) {
       expect(result.step).toBe('import');
       expect(result.error).toContain('kilo import failed');
+    }
+  });
+
+  it('clamps negative token counts before import', async () => {
+    const importedSnapshotPath = path.join(tmpDir, 'imported-snapshot.json');
+    writeCopyingMockKilo(binDir, importedSnapshotPath);
+    mockFetchOk(
+      JSON.stringify({
+        info: snapshotInfo(),
+        messages: [
+          {
+            info: {
+              id: 'msg_negative_tokens',
+              tokens: {
+                total: 1,
+                input: 1,
+                output: -173,
+                reasoning: -2,
+                cache: { read: -1, write: 0 },
+              },
+            },
+            parts: [
+              {
+                type: 'step-finish',
+                tokens: { total: 1, input: 1, output: -173, reasoning: 0 },
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(true);
+    const imported = JSON.parse(fs.readFileSync(importedSnapshotPath, 'utf-8'));
+    expect(imported.messages[0].info.tokens).toEqual({
+      total: 1,
+      input: 1,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    });
+    expect(imported.messages[0].parts[0].tokens).toEqual({
+      total: 1,
+      input: 1,
+      output: 0,
+      reasoning: 0,
+    });
+  });
+
+  it('cleans up downloaded temp file when token sanitization is aborted', async () => {
+    const sanitizerStartedMarker = path.join(tmpDir, 'sanitizer-started');
+    const restoreJq = mockHangingJq(sanitizerStartedMarker);
+    mockFetchOk(makeSnapshot([]));
+    const controller = new AbortController();
+    const deadlineError = new Error('workspace deadline reached');
+    try {
+      const restorePromise = restoreSession(SESSION_ID, workspace, undefined, {
+        signal: controller.signal,
+      });
+      await waitForFile(sanitizerStartedMarker);
+      controller.abort(deadlineError);
+
+      let caughtError: unknown;
+      try {
+        await restorePromise;
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError).toBe(deadlineError);
+      expect(fs.existsSync(TMP_PATH)).toBe(false);
+    } finally {
+      restoreJq();
     }
   });
 

--- a/services/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.ts
@@ -378,10 +378,6 @@ function tokenSanitizationTempPath(snapshotPath: string): string {
   );
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 async function sanitizeSnapshotTokenCountsWithJq(
   snapshotPath: string,
   signal?: AbortSignal
@@ -413,94 +409,11 @@ async function sanitizeSnapshotTokenCountsWithJq(
   }
 }
 
-function clampNegativeTokenCountNumbers(value: unknown): number {
-  let clamped = 0;
-  if (Array.isArray(value)) {
-    for (let index = 0; index < value.length; index++) {
-      const item = value[index];
-      if (typeof item === 'number' && item < 0) {
-        value[index] = 0;
-        clamped++;
-      } else {
-        clamped += clampNegativeTokenCountNumbers(item);
-      }
-    }
-    return clamped;
-  }
-
-  if (!isRecord(value)) return 0;
-
-  for (const [key, item] of Object.entries(value)) {
-    if (typeof item === 'number' && item < 0) {
-      value[key] = 0;
-      clamped++;
-    } else {
-      clamped += clampNegativeTokenCountNumbers(item);
-    }
-  }
-  return clamped;
-}
-
-function sanitizeSnapshotTokenCountsValue(value: unknown): number {
-  let clamped = 0;
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      clamped += sanitizeSnapshotTokenCountsValue(item);
-    }
-    return clamped;
-  }
-
-  if (!isRecord(value)) return 0;
-
-  for (const [key, item] of Object.entries(value)) {
-    if (key === 'tokens' && typeof item === 'object' && item !== null) {
-      clamped += clampNegativeTokenCountNumbers(item);
-      continue;
-    }
-    clamped += sanitizeSnapshotTokenCountsValue(item);
-  }
-  return clamped;
-}
-
-async function sanitizeSnapshotTokenCountsWithBun(
-  snapshotPath: string,
-  signal?: AbortSignal
-): Promise<boolean> {
-  let parsed: unknown;
-  try {
-    signal?.throwIfAborted();
-    parsed = await Bun.file(snapshotPath).json();
-    signal?.throwIfAborted();
-  } catch {
-    signal?.throwIfAborted();
-    log('snapshot_token_sanitization_parse_failed');
-    return false;
-  }
-
-  const clamped = sanitizeSnapshotTokenCountsValue(parsed);
-  if (clamped === 0) return true;
-
-  try {
-    signal?.throwIfAborted();
-    await Bun.write(snapshotPath, JSON.stringify(parsed));
-    signal?.throwIfAborted();
-    return true;
-  } catch {
-    signal?.throwIfAborted();
-    log('snapshot_token_sanitization_write_failed');
-    return false;
-  }
-}
-
 async function sanitizeSnapshotTokenCounts(
   snapshotPath: string,
   signal?: AbortSignal
 ): Promise<void> {
   if (await sanitizeSnapshotTokenCountsWithJq(snapshotPath, signal)) {
-    log('snapshot token counts sanitized');
-    return;
-  }
-  if (await sanitizeSnapshotTokenCountsWithBun(snapshotPath, signal)) {
     log('snapshot token counts sanitized');
     return;
   }

--- a/services/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { Writable } from 'node:stream';
 import type { WorkspaceFailureSubtype } from '../../src/shared/wrapper-bootstrap.js';
 import {
   createSafeProcessDiagnostic,
@@ -43,6 +44,8 @@ export type RestoreSessionOptions = {
 };
 
 const KILO_IMPORT_TIMEOUT_MS = 120_000;
+const JQ_SANITIZE_TOKEN_COUNTS_FILTER =
+  'walk(if type == "object" and ((.tokens? | type) == "object") then .tokens |= walk(if type == "number" and . < 0 then 0 else . end) else . end)';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -368,6 +371,142 @@ async function validateSnapshotInfoId(
   }
 }
 
+function tokenSanitizationTempPath(snapshotPath: string): string {
+  return path.join(
+    path.dirname(snapshotPath),
+    `.kilo-sanitized-${path.basename(snapshotPath)}-${process.pid}-${Date.now()}`
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function sanitizeSnapshotTokenCountsWithJq(
+  snapshotPath: string,
+  signal?: AbortSignal
+): Promise<boolean> {
+  const tempPath = tokenSanitizationTempPath(snapshotPath);
+  try {
+    signal?.throwIfAborted();
+    const proc = Bun.spawn(['jq', '-c', JQ_SANITIZE_TOKEN_COUNTS_FILTER, snapshotPath], {
+      stdout: 'pipe',
+      stderr: 'ignore',
+      signal,
+    });
+    const writeOutput = proc.stdout.pipeTo(Writable.toWeb(fs.createWriteStream(tempPath)));
+    const exitCode = await proc.exited;
+    await writeOutput;
+    signal?.throwIfAborted();
+    if (exitCode !== 0) {
+      log(`snapshot_token_sanitization_jq_unavailable exitCode=${exitCode}`);
+      return false;
+    }
+    fs.renameSync(tempPath, snapshotPath);
+    return true;
+  } catch {
+    signal?.throwIfAborted();
+    log('snapshot_token_sanitization_jq_unavailable');
+    return false;
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+}
+
+function clampNegativeTokenCountNumbers(value: unknown): number {
+  let clamped = 0;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index++) {
+      const item = value[index];
+      if (typeof item === 'number' && item < 0) {
+        value[index] = 0;
+        clamped++;
+      } else {
+        clamped += clampNegativeTokenCountNumbers(item);
+      }
+    }
+    return clamped;
+  }
+
+  if (!isRecord(value)) return 0;
+
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === 'number' && item < 0) {
+      value[key] = 0;
+      clamped++;
+    } else {
+      clamped += clampNegativeTokenCountNumbers(item);
+    }
+  }
+  return clamped;
+}
+
+function sanitizeSnapshotTokenCountsValue(value: unknown): number {
+  let clamped = 0;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      clamped += sanitizeSnapshotTokenCountsValue(item);
+    }
+    return clamped;
+  }
+
+  if (!isRecord(value)) return 0;
+
+  for (const [key, item] of Object.entries(value)) {
+    if (key === 'tokens' && typeof item === 'object' && item !== null) {
+      clamped += clampNegativeTokenCountNumbers(item);
+      continue;
+    }
+    clamped += sanitizeSnapshotTokenCountsValue(item);
+  }
+  return clamped;
+}
+
+async function sanitizeSnapshotTokenCountsWithBun(
+  snapshotPath: string,
+  signal?: AbortSignal
+): Promise<boolean> {
+  let parsed: unknown;
+  try {
+    signal?.throwIfAborted();
+    parsed = await Bun.file(snapshotPath).json();
+    signal?.throwIfAborted();
+  } catch {
+    signal?.throwIfAborted();
+    log('snapshot_token_sanitization_parse_failed');
+    return false;
+  }
+
+  const clamped = sanitizeSnapshotTokenCountsValue(parsed);
+  if (clamped === 0) return true;
+
+  try {
+    signal?.throwIfAborted();
+    await Bun.write(snapshotPath, JSON.stringify(parsed));
+    signal?.throwIfAborted();
+    return true;
+  } catch {
+    signal?.throwIfAborted();
+    log('snapshot_token_sanitization_write_failed');
+    return false;
+  }
+}
+
+async function sanitizeSnapshotTokenCounts(
+  snapshotPath: string,
+  signal?: AbortSignal
+): Promise<void> {
+  if (await sanitizeSnapshotTokenCountsWithJq(snapshotPath, signal)) {
+    log('snapshot token counts sanitized');
+    return;
+  }
+  if (await sanitizeSnapshotTokenCountsWithBun(snapshotPath, signal)) {
+    log('snapshot token counts sanitized');
+    return;
+  }
+  log('snapshot token count sanitization skipped');
+}
+
 // jq filter that extracts diffs from the snapshot JSON using last-write-wins
 // deduplication by file path. Runs as a subprocess so the full parsed snapshot
 // is never loaded into the main process's heap — jq's C-native parser uses
@@ -585,6 +724,8 @@ export async function restoreSession(
   }
 
   try {
+    await sanitizeSnapshotTokenCounts(tmpPath, options.signal);
+
     // ---- Step 2: Run kilo import ----
     const importStartedAt = Date.now();
     log(


### PR DESCRIPTION
## Summary

- Clamp negative token counts before `kilo import` while keeping snapshot temp-file cleanup intact.
- Move token-count sanitization under the existing cleanup guard so downloaded snapshots are removed when workspace aborts fire during sanitization.
- Add regression coverage for sanitizer abort cleanup.

## Verification

N/A - non-UI wrapper cleanup behavior; no manual verification performed.

## Visual Changes

N/A

## Reviewer Notes

Focus area: aborts during token sanitization should still rethrow the workspace abort reason while unlinking downloaded `/tmp/kilo-session-export-*.json` snapshots.