### PR TITLE
perf(wasteland): optimize wanted board queries

### DIFF
--- a/apps/web/src/app/(app)/wasteland/[owner]/[repo]/fork/ForkClient.tsx
+++ b/apps/web/src/app/(app)/wasteland/[owner]/[repo]/fork/ForkClient.tsx
@@ -178,7 +178,10 @@ export function ForkClient() {
   const invalidateWorkshop = () => {
     void queryClient.invalidateQueries({ queryKey: branchesQueryKey });
     void queryClient.invalidateQueries({
-      queryKey: trpc.wasteland.browseWantedBoard.queryKey({ wastelandId: repo.wastelandId }),
+      queryKey: trpc.wasteland.browseWantedBoard.pathKey(),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: trpc.wasteland.getWantedBoardCounts.pathKey(),
     });
     void queryClient.invalidateQueries({
       queryKey: trpc.wasteland.listMyPendingClaims.queryKey({ wastelandId: repo.wastelandId }),

--- a/apps/web/src/app/(app)/wasteland/by-id/[wastelandId]/wanted/WantedBoardClient.tsx
+++ b/apps/web/src/app/(app)/wasteland/by-id/[wastelandId]/wanted/WantedBoardClient.tsx
@@ -33,11 +33,22 @@ import { toast } from 'sonner';
 import { lastActivityMs, parseDoltDate } from '@/lib/wasteland/date';
 
 type WantedItem = WastelandOutputs['wasteland']['browseWantedBoard'][number];
+type WantedBoardCounts = WastelandOutputs['wasteland']['getWantedBoardCounts'];
 
 type SortField = 'priority' | 'activity';
 
 const STATUS_FILTERS = ['open', 'claimed', 'in_review', 'completed'] as const;
 type StatusFilter = (typeof STATUS_FILTERS)[number];
+const WANTED_BOARD_PAGE_LIMIT = 50;
+const WANTED_BOARD_MAX_LIMIT = 500;
+const EMPTY_STATUS_COUNTS: WantedBoardCounts = {
+  open: 0,
+  claimed: 0,
+  in_review: 0,
+  completed: 0,
+  validated: 0,
+  withdrawn: 0,
+};
 
 const STATUS_COLORS: Record<string, string> = {
   open: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
@@ -156,11 +167,16 @@ export function WantedBoardClient({
   const sortField = parseSortField(searchParams?.get('sort'));
 
   const [localSearch, setLocalSearch] = useState(search);
+  const [pageLimit, setPageLimit] = useState(WANTED_BOARD_PAGE_LIMIT);
   const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setLocalSearch(search);
   }, [search]);
+
+  useEffect(() => {
+    setPageLimit(WANTED_BOARD_PAGE_LIMIT);
+  }, [statusFilter, search, sortField]);
 
   useEffect(() => {
     return () => {
@@ -219,8 +235,34 @@ export function WantedBoardClient({
   const [closeItem, setCloseItem] = useState<WantedItem | null>(null);
   const [unclaimItem, setUnclaimItem] = useState<WantedItem | null>(null);
 
+  const wantedBoardInput = useMemo(() => {
+    const trimmedSearch = search.trim();
+    return {
+      wastelandId,
+      ...(statusFilter === 'all' ? {} : { status: statusFilter }),
+      ...(trimmedSearch ? { search: trimmedSearch } : {}),
+      sort: sortField,
+      limit: pageLimit,
+      includeForkBranches: !isUpstream,
+    };
+  }, [wastelandId, statusFilter, search, sortField, pageLimit, isUpstream]);
+
+  const countsInput = useMemo(() => {
+    const trimmedSearch = search.trim();
+    return {
+      wastelandId,
+      ...(trimmedSearch ? { search: trimmedSearch } : {}),
+    };
+  }, [wastelandId, search]);
+
   const wantedQuery = useQuery({
-    ...trpc.wasteland.browseWantedBoard.queryOptions({ wastelandId }),
+    ...trpc.wasteland.browseWantedBoard.queryOptions(wantedBoardInput),
+    refetchInterval: 30_000,
+  });
+
+  const countsQuery = useQuery({
+    ...trpc.wasteland.getWantedBoardCounts.queryOptions(countsInput),
+    placeholderData: EMPTY_STATUS_COUNTS,
     refetchInterval: 30_000,
   });
 
@@ -293,7 +335,10 @@ export function WantedBoardClient({
     prevPendingIdsRef.current = current;
     if (disappeared) {
       void queryClient.invalidateQueries({
-        queryKey: trpc.wasteland.browseWantedBoard.queryKey({ wastelandId }),
+        queryKey: trpc.wasteland.browseWantedBoard.pathKey(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: trpc.wasteland.getWantedBoardCounts.pathKey(),
       });
     }
   }, [pendingByItemId, queryClient, trpc, wastelandId]);
@@ -302,7 +347,10 @@ export function WantedBoardClient({
     isPending: false,
     mutate: () => {
       void queryClient.invalidateQueries({
-        queryKey: trpc.wasteland.browseWantedBoard.queryKey({ wastelandId }),
+        queryKey: trpc.wasteland.browseWantedBoard.pathKey(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: trpc.wasteland.getWantedBoardCounts.pathKey(),
       });
       void queryClient.invalidateQueries({
         queryKey: trpc.wasteland.listMyPendingClaims.queryKey({ wastelandId }),
@@ -312,7 +360,10 @@ export function WantedBoardClient({
 
   const invalidateBoard = useCallback(() => {
     void queryClient.invalidateQueries({
-      queryKey: trpc.wasteland.browseWantedBoard.queryKey({ wastelandId }),
+      queryKey: trpc.wasteland.browseWantedBoard.pathKey(),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: trpc.wasteland.getWantedBoardCounts.pathKey(),
     });
     void queryClient.invalidateQueries({
       queryKey: trpc.wasteland.listMyPendingClaims.queryKey({ wastelandId }),
@@ -320,33 +371,23 @@ export function WantedBoardClient({
   }, [queryClient, trpc, wastelandId]);
 
   const items = wantedQuery.data ?? [];
-
-  const statusCounts = useMemo(() => {
-    const counts: Record<string, number> = {
-      open: 0,
-      claimed: 0,
-      in_review: 0,
-      completed: 0,
-    };
-    for (const item of items) {
-      counts[item.status] = (counts[item.status] ?? 0) + 1;
-    }
-    return counts;
-  }, [items]);
+  const statusCounts = countsQuery.data ?? EMPTY_STATUS_COUNTS;
+  const totalCount = Object.values(statusCounts).reduce((sum, count) => sum + count, 0);
 
   const filteredItems = useMemo(() => {
-    let result = items;
+    const trimmedSearch = search.trim().toLowerCase();
+    const result = items.filter(item => {
+      if (statusFilter !== 'all' && item.status !== statusFilter) return false;
+      if (!trimmedSearch) return true;
 
-    if (statusFilter !== 'all') {
-      result = result.filter(item => item.status === statusFilter);
-    }
+      return [item.title, item.description, item.tags].some(value =>
+        String(value ?? '')
+          .toLowerCase()
+          .includes(trimmedSearch)
+      );
+    });
 
-    if (search.trim()) {
-      const q = search.toLowerCase();
-      result = result.filter(item => item.title.toLowerCase().includes(q));
-    }
-
-    result = [...result].sort((a, b) => {
+    return [...result].sort((a, b) => {
       if (sortField === 'priority') {
         return (Number(a.priority) || 3) - (Number(b.priority) || 3);
       }
@@ -354,13 +395,18 @@ export function WantedBoardClient({
         lastActivityMs(b.updated_at, b.created_at) - lastActivityMs(a.updated_at, a.created_at)
       );
     });
-
-    return result;
   }, [items, statusFilter, search, sortField]);
+
+  const activeCount = statusFilter === 'all' ? totalCount : (statusCounts[statusFilter] ?? 0);
+  const displayCount = Math.max(activeCount, filteredItems.length);
 
   const handleRefresh = useCallback(() => {
     refreshMutation.mutate();
   }, [refreshMutation, wastelandId]);
+
+  const handleLoadMore = useCallback(() => {
+    setPageLimit(limit => Math.min(limit + WANTED_BOARD_PAGE_LIMIT, WANTED_BOARD_MAX_LIMIT));
+  }, []);
 
   const toggleSort = useCallback(() => {
     updateFilterParams({ sort: sortField === 'priority' ? 'activity' : 'priority' });
@@ -402,7 +448,7 @@ export function WantedBoardClient({
   useSetWastelandPageHeader({
     title: headerTitle ?? (isUpstream ? 'Upstream' : 'Wanted Board'),
     icon: <ScrollText className="size-4 text-[color:oklch(70%_0.15_30_/_0.6)]" />,
-    count: items.length,
+    count: displayCount,
     actions: (
       <>
         <button
@@ -454,7 +500,7 @@ export function WantedBoardClient({
           <div className="flex items-center gap-1">
             <FilterChip
               label="All"
-              count={items.length}
+              count={totalCount}
               active={statusFilter === 'all'}
               onClick={() => updateFilterParams({ status: 'all' })}
             />
@@ -584,6 +630,24 @@ export function WantedBoardClient({
               );
             })}
           </AnimatePresence>
+
+          {!wantedQuery.isLoading && displayCount > filteredItems.length && (
+            <div className="flex items-center justify-between border-t border-white/[0.04] px-6 py-2 text-[10px] text-white/30">
+              <span>
+                Showing first {filteredItems.length} of {displayCount}.
+                {pageLimit >= WANTED_BOARD_MAX_LIMIT ? ' Refine search to narrow results.' : ''}
+              </span>
+              {pageLimit < WANTED_BOARD_MAX_LIMIT && (
+                <button
+                  type="button"
+                  onClick={handleLoadMore}
+                  className="rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-1 font-medium text-white/55 transition-colors hover:bg-white/[0.06] hover:text-white/85"
+                >
+                  Load more
+                </button>
+              )}
+            </div>
+          )}
         </div>
       </div>
 

--- a/apps/web/src/app/(app)/wasteland/by-id/[wastelandId]/wanted/WantedBoardClient.tsx
+++ b/apps/web/src/app/(app)/wasteland/by-id/[wastelandId]/wanted/WantedBoardClient.tsx
@@ -252,8 +252,9 @@ export function WantedBoardClient({
     return {
       wastelandId,
       ...(trimmedSearch ? { search: trimmedSearch } : {}),
+      includeForkBranches: !isUpstream,
     };
-  }, [wastelandId, search]);
+  }, [wastelandId, search, isUpstream]);
 
   const wantedQuery = useQuery({
     ...trpc.wasteland.browseWantedBoard.queryOptions(wantedBoardInput),

--- a/apps/web/src/components/wasteland/drawer/WantedItemBranchTab.tsx
+++ b/apps/web/src/components/wasteland/drawer/WantedItemBranchTab.tsx
@@ -277,7 +277,10 @@ function MarkDoneInlineForm({ wastelandId, item }: { wastelandId: string; item: 
       );
       setEvidence('');
       void queryClient.invalidateQueries({
-        queryKey: trpc.wasteland.browseWantedBoard.queryKey({ wastelandId }),
+        queryKey: trpc.wasteland.browseWantedBoard.pathKey(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: trpc.wasteland.getWantedBoardCounts.pathKey(),
       });
       void queryClient.invalidateQueries({
         queryKey: trpc.wasteland.getWantedItem.queryKey({ wastelandId, itemId: item.id }),
@@ -546,7 +549,10 @@ export function ClaimAction({ wastelandId, item }: { wastelandId: string; item: 
         toast.success('Item claimed');
       }
       void queryClient.invalidateQueries({
-        queryKey: trpc.wasteland.browseWantedBoard.queryKey({ wastelandId }),
+        queryKey: trpc.wasteland.browseWantedBoard.pathKey(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: trpc.wasteland.getWantedBoardCounts.pathKey(),
       });
       void queryClient.invalidateQueries({
         queryKey: trpc.wasteland.getWantedItem.queryKey({ wastelandId, itemId: item.id }),

--- a/apps/web/src/components/wasteland/drawer/WantedItemPanel.tsx
+++ b/apps/web/src/components/wasteland/drawer/WantedItemPanel.tsx
@@ -255,7 +255,10 @@ function PendingReviewSection({ wastelandId, itemId }: { wastelandId: string; it
     const isPending = pending !== undefined;
     if (wasPendingRef.current && !isPending) {
       void queryClient.invalidateQueries({
-        queryKey: trpc.wasteland.browseWantedBoard.queryKey({ wastelandId }),
+        queryKey: trpc.wasteland.browseWantedBoard.pathKey(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: trpc.wasteland.getWantedBoardCounts.pathKey(),
       });
       void queryClient.invalidateQueries({
         queryKey: trpc.wasteland.getWantedItem.queryKey({ wastelandId, itemId }),

--- a/apps/web/src/lib/wasteland/types/router.d.ts
+++ b/apps/web/src/lib/wasteland/types/router.d.ts
@@ -338,6 +338,7 @@ export declare const wastelandRouter: import('@trpc/server').TRPCBuiltRouter<
       input: {
         wastelandId: string;
         search?: string;
+        includeForkBranches?: boolean;
       };
       output: {
         open: number;
@@ -1248,6 +1249,7 @@ export declare const wrappedWastelandRouter: import('@trpc/server').TRPCBuiltRou
           input: {
             wastelandId: string;
             search?: string;
+            includeForkBranches?: boolean;
           };
           output: {
             open: number;

--- a/apps/web/src/lib/wasteland/types/router.d.ts
+++ b/apps/web/src/lib/wasteland/types/router.d.ts
@@ -307,6 +307,11 @@ export declare const wastelandRouter: import('@trpc/server').TRPCBuiltRouter<
     browseWantedBoard: import('@trpc/server').TRPCQueryProcedure<{
       input: {
         wastelandId: string;
+        status?: 'open' | 'claimed' | 'in_review' | 'completed' | 'validated' | 'withdrawn';
+        search?: string;
+        sort?: 'priority' | 'activity';
+        limit?: number;
+        includeForkBranches?: boolean;
       };
       output: {
         id: string;
@@ -327,6 +332,21 @@ export declare const wastelandRouter: import('@trpc/server').TRPCBuiltRouter<
         created_at: string | null;
         updated_at: string | null;
       }[];
+      meta: object;
+    }>;
+    getWantedBoardCounts: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        wastelandId: string;
+        search?: string;
+      };
+      output: {
+        open: number;
+        claimed: number;
+        in_review: number;
+        completed: number;
+        validated: number;
+        withdrawn: number;
+      };
       meta: object;
     }>;
     listMyPendingClaims: import('@trpc/server').TRPCQueryProcedure<{
@@ -1197,6 +1217,11 @@ export declare const wrappedWastelandRouter: import('@trpc/server').TRPCBuiltRou
         browseWantedBoard: import('@trpc/server').TRPCQueryProcedure<{
           input: {
             wastelandId: string;
+            status?: 'open' | 'claimed' | 'in_review' | 'completed' | 'validated' | 'withdrawn';
+            search?: string;
+            sort?: 'priority' | 'activity';
+            limit?: number;
+            includeForkBranches?: boolean;
           };
           output: {
             id: string;
@@ -1217,6 +1242,21 @@ export declare const wrappedWastelandRouter: import('@trpc/server').TRPCBuiltRou
             created_at: string | null;
             updated_at: string | null;
           }[];
+          meta: object;
+        }>;
+        getWantedBoardCounts: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            wastelandId: string;
+            search?: string;
+          };
+          output: {
+            open: number;
+            claimed: number;
+            in_review: number;
+            completed: number;
+            validated: number;
+            withdrawn: number;
+          };
           meta: object;
         }>;
         listMyPendingClaims: import('@trpc/server').TRPCQueryProcedure<{

--- a/apps/web/src/lib/wasteland/types/schemas.d.ts
+++ b/apps/web/src/lib/wasteland/types/schemas.d.ts
@@ -131,6 +131,17 @@ export declare const WantedBoardRowOutput: z.ZodObject<
   },
   z.core.$strip
 >;
+export declare const WantedBoardCountsOutput: z.ZodObject<
+  {
+    open: z.ZodNumber;
+    claimed: z.ZodNumber;
+    in_review: z.ZodNumber;
+    completed: z.ZodNumber;
+    validated: z.ZodNumber;
+    withdrawn: z.ZodNumber;
+  },
+  z.core.$strip
+>;
 export declare const MergePullOutput: z.ZodObject<
   {
     pull_id: z.ZodString;
@@ -465,6 +476,20 @@ export declare const RpcWantedBoardRowOutput: z.ZodPipe<
       sandbox_min_tier: z.ZodDefault<z.ZodNullable<z.ZodString>>;
       created_at: z.ZodDefault<z.ZodNullable<z.ZodString>>;
       updated_at: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcWantedBoardCountsOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      open: z.ZodNumber;
+      claimed: z.ZodNumber;
+      in_review: z.ZodNumber;
+      completed: z.ZodNumber;
+      validated: z.ZodNumber;
+      withdrawn: z.ZodNumber;
     },
     z.core.$strip
   >

--- a/packages/wl-sdk/src/client.ts
+++ b/packages/wl-sdk/src/client.ts
@@ -240,7 +240,10 @@ export class WlClient {
 
   // ── Reads ──────────────────────────────────────────────────────
 
-  async browse(filter?: BrowseFilter): Promise<BrowseEntry[]> {
+  async browse(
+    filter?: BrowseFilter,
+    options?: { includeForkBranches?: boolean }
+  ): Promise<BrowseEntry[]> {
     return unwrap(
       await browse({
         auth: this.#auth,
@@ -248,6 +251,7 @@ export class WlClient {
         fork: this.#fork,
         rigHandle: this.#config.rigHandle,
         filter,
+        includeForkBranches: options?.includeForkBranches,
         fetch: this.#config.fetch,
         hooks: this.#hooks,
       }),

--- a/packages/wl-sdk/src/ops/browse.test.ts
+++ b/packages/wl-sdk/src/ops/browse.test.ts
@@ -151,6 +151,30 @@ describe('browse', () => {
     expect(decodeURIComponent(calls[0].url)).toContain('LIMIT 10');
   });
 
+  it('supports activity sorting and skipping fork branch overlay reads', async () => {
+    const { fetch: f, calls } = makeFetch([
+      {
+        status: 200,
+        body: { query_execution_status: 'Success', rows: [] },
+      },
+    ]);
+    const result = await browse({
+      auth: { token: 't' },
+      upstream: { owner: 'hop', db: 'wl' },
+      fork: { forkOwner: 'alice', forkDb: 'wl' },
+      rigHandle: 'alice',
+      filter: { status: 'open', sort: 'activity', limit: 50 },
+      includeForkBranches: false,
+      fetch: f,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    const sql = decodeURIComponent(calls[0].url);
+    expect(sql).toContain("status = 'open'");
+    expect(sql).toContain('ORDER BY COALESCE(updated_at, created_at) DESC, created_at DESC');
+    expect(sql).toContain('LIMIT 50');
+  });
+
   it('applies search filter as a literal substring match', async () => {
     const { fetch: f, calls } = makeFetch([
       {

--- a/packages/wl-sdk/src/ops/browse.test.ts
+++ b/packages/wl-sdk/src/ops/browse.test.ts
@@ -175,7 +175,7 @@ describe('browse', () => {
     expect(sql).toContain('LIMIT 50');
   });
 
-  it('applies search filter as a literal substring match', async () => {
+  it('applies search filter as a case-insensitive literal substring match', async () => {
     const { fetch: f, calls } = makeFetch([
       {
         status: 200,
@@ -189,13 +189,15 @@ describe('browse', () => {
       upstream: { owner: 'hop', db: 'wl' },
       fork: { forkOwner: 'alice', forkDb: 'wl' },
       rigHandle: 'alice',
-      filter: { search: "100%_\\bob's" },
+      filter: { search: "100%_\\Bob's" },
       fetch: f,
     });
 
     expect(result.ok).toBe(true);
     const sql = decodeURIComponent(calls[0].url);
-    expect(sql).toContain("INSTR(title, '100%_\\\\bob''s') > 0");
+    expect(sql).toContain("INSTR(LOWER(title), '100%_\\\\bob''s') > 0");
+    expect(sql).toContain("INSTR(LOWER(COALESCE(description,'')), '100%_\\\\bob''s') > 0");
+    expect(sql).toContain("INSTR(LOWER(COALESCE(tags,'')), '100%_\\\\bob''s') > 0");
     expect(sql).not.toContain('LIKE');
   });
 

--- a/packages/wl-sdk/src/ops/browse.ts
+++ b/packages/wl-sdk/src/ops/browse.ts
@@ -33,6 +33,8 @@ export type BrowseFilter = {
   search?: string;
   /** ISO8601 / SQL timestamp string; rows with `updated_at >= since`. */
   since?: string;
+  /** Sort rows before applying limit. Defaults to priority order. */
+  sort?: 'priority' | 'activity';
   /** Omit to return every matching row. */
   limit?: number;
 };
@@ -57,6 +59,8 @@ export type BrowseOptions = {
   fork: { forkOwner: string; forkDb: string };
   rigHandle: RigHandle;
   filter?: BrowseFilter;
+  /** Skip fork branch overlay reads for fast list views. Defaults to true. */
+  includeForkBranches?: boolean;
   fetch?: typeof fetch;
   hooks?: DoltFetchHooks;
 };
@@ -128,7 +132,11 @@ function buildBrowseSql(filter: BrowseFilter | undefined): string {
 
   let sql = 'SELECT * FROM wanted';
   if (conditions.length > 0) sql += ` WHERE ${conditions.join(' AND ')}`;
-  sql += ' ORDER BY priority ASC, created_at DESC';
+  if (filter?.sort === 'activity') {
+    sql += ' ORDER BY COALESCE(updated_at, created_at) DESC, created_at DESC';
+  } else {
+    sql += ' ORDER BY priority ASC, created_at DESC';
+  }
   if (filter?.limit && filter.limit > 0) sql += ` LIMIT ${filter.limit}`;
   return sql;
 }
@@ -180,6 +188,7 @@ export async function browse(opts: BrowseOptions): Promise<WlResult<BrowseEntry[
     for (const row of mainRows) {
       byId.set(row.id, { wantedId: row.id, upstream: row, fork: null, source: 'main' });
     }
+    if (opts.includeForkBranches === false) return { ok: true, data: Array.from(byId.values()) };
 
     // 2. Caller's fork branches: list, filter to `wl/<rig>/*`, then
     //    read each branch's wanted row.

--- a/packages/wl-sdk/src/ops/browse.ts
+++ b/packages/wl-sdk/src/ops/browse.ts
@@ -124,9 +124,9 @@ function buildBrowseSql(filter: BrowseFilter | undefined): string {
   if (filter?.claimedBy) conditions.push(`claimed_by = '${escapeSqlString(filter.claimedBy)}'`);
   if (filter?.since) conditions.push(`updated_at >= '${escapeSqlString(filter.since)}'`);
   if (filter?.search) {
-    const s = escapeSqlString(filter.search);
+    const s = escapeSqlString(filter.search.toLowerCase());
     conditions.push(
-      `(INSTR(title, '${s}') > 0 OR INSTR(COALESCE(description,''), '${s}') > 0 OR INSTR(COALESCE(tags,''), '${s}') > 0)`
+      `(INSTR(LOWER(title), '${s}') > 0 OR INSTR(LOWER(COALESCE(description,'')), '${s}') > 0 OR INSTR(LOWER(COALESCE(tags,'')), '${s}') > 0)`
     );
   }
 

--- a/services/gastown/container/plugin/client.ts
+++ b/services/gastown/container/plugin/client.ts
@@ -581,7 +581,7 @@ export class MayorGastownClient {
   // The wasteland is auto-resolved by the worker from the town's connection.
 
   async wastelandBrowse(input: {
-    status?: 'open' | 'claimed' | 'done';
+    status?: 'open' | 'claimed' | 'in_review' | 'completed' | 'validated' | 'withdrawn';
     limit?: number;
   }): Promise<Array<Record<string, unknown>>> {
     const params = new URLSearchParams();

--- a/services/gastown/container/plugin/mayor-tools.ts
+++ b/services/gastown/container/plugin/mayor-tools.ts
@@ -536,7 +536,7 @@ export function createMayorTools(client: MayorGastownClient) {
         'Optionally filter by status and limit the number of results.',
       args: {
         status: tool.schema
-          .enum(['open', 'claimed', 'done'])
+          .enum(['open', 'claimed', 'in_review', 'completed', 'validated', 'withdrawn'])
           .describe('Filter by item status')
           .optional(),
         limit: tool.schema

--- a/services/gastown/src/handlers/wasteland-tools.handler.ts
+++ b/services/gastown/src/handlers/wasteland-tools.handler.ts
@@ -111,21 +111,16 @@ export async function handleWastelandBrowse(c: Context<GastownEnv>, params: { to
   const result = await c.env.WASTELAND_SERVICE.browseWantedBoard({
     wastelandId,
     userId,
+    status: statusRaw,
+    limit,
+    includeForkBranches: false,
   });
 
   if (!result.success) {
     return wastelandFailureToResponse(c, result);
   }
 
-  let items = result.data;
-  if (statusRaw) {
-    items = items.filter(item => item.status === statusRaw);
-  }
-  if (limit !== undefined) {
-    items = items.slice(0, limit);
-  }
-
-  return c.json(resSuccess(items));
+  return c.json(resSuccess(result.data));
 }
 
 /**

--- a/services/gastown/src/handlers/wasteland-tools.handler.ts
+++ b/services/gastown/src/handlers/wasteland-tools.handler.ts
@@ -132,7 +132,7 @@ export async function handleWastelandBrowse(c: Context<GastownEnv>, params: { to
     userId,
     status,
     limit,
-    includeForkBranches: false,
+    includeForkBranches: true,
   });
 
   if (!result.success) {

--- a/services/gastown/src/handlers/wasteland-tools.handler.ts
+++ b/services/gastown/src/handlers/wasteland-tools.handler.ts
@@ -33,6 +33,15 @@ const WastelandDoneBody = z.object({
   evidence: z.string().url(),
 });
 
+const WastelandWantedStatus = z.enum([
+  'open',
+  'claimed',
+  'in_review',
+  'completed',
+  'validated',
+  'withdrawn',
+]);
+
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 /** Resolve the userId of the caller from the mayor auth middleware. */
@@ -94,9 +103,19 @@ export async function handleWastelandBrowse(c: Context<GastownEnv>, params: { to
 
   const statusRaw = c.req.query('status');
   const limitRaw = c.req.query('limit');
+  let status: z.infer<typeof WastelandWantedStatus> | undefined;
 
-  if (statusRaw && !['open', 'claimed', 'done'].includes(statusRaw)) {
-    return c.json(resError('Invalid status filter. Must be one of: open, claimed, done'), 400);
+  if (statusRaw) {
+    const parsed = WastelandWantedStatus.safeParse(statusRaw);
+    if (!parsed.success) {
+      return c.json(
+        resError(
+          `Invalid status filter. Must be one of: ${WastelandWantedStatus.options.join(', ')}`
+        ),
+        400
+      );
+    }
+    status = parsed.data;
   }
 
   const limit = limitRaw !== undefined ? Number(limitRaw) : undefined;
@@ -111,7 +130,7 @@ export async function handleWastelandBrowse(c: Context<GastownEnv>, params: { to
   const result = await c.env.WASTELAND_SERVICE.browseWantedBoard({
     wastelandId,
     userId,
-    status: statusRaw,
+    status,
     limit,
     includeForkBranches: false,
   });

--- a/services/gastown/src/util/wasteland-client.util.ts
+++ b/services/gastown/src/util/wasteland-client.util.ts
@@ -9,7 +9,7 @@ export const WantedItemOutput = z.object({
   item_id: z.string(),
   title: z.string(),
   description: z.string(),
-  status: z.enum(['open', 'claimed', 'done']),
+  status: z.enum(['open', 'claimed', 'in_review', 'completed', 'validated', 'withdrawn']),
   priority: z.enum(['low', 'medium', 'high', 'critical']),
   type: z.enum(['feature', 'bug', 'docs', 'other']),
   claimed_by: z.string().nullable(),

--- a/services/gastown/worker-configuration.d.ts
+++ b/services/gastown/worker-configuration.d.ts
@@ -27,10 +27,15 @@ type WastelandRpcFailure = {
 };
 type WastelandRpcResult<T> = WastelandRpcSuccess<T> | WastelandRpcFailure;
 type WastelandService = {
-	browseWantedBoard(params: {
-		wastelandId: string;
-		userId: string;
-	}): Promise<WastelandRpcResult<Array<Record<string, unknown>>>>;
+		browseWantedBoard(params: {
+			wastelandId: string;
+			userId: string;
+			status?: string;
+			search?: string;
+			sort?: 'priority' | 'activity';
+			limit?: number;
+			includeForkBranches?: boolean;
+		}): Promise<WastelandRpcResult<Array<Record<string, unknown>>>>;
 	claimWantedItem(params: {
 		wastelandId: string;
 		userId: string;

--- a/services/gastown/worker-configuration.d.ts
+++ b/services/gastown/worker-configuration.d.ts
@@ -30,7 +30,7 @@ type WastelandService = {
 		browseWantedBoard(params: {
 			wastelandId: string;
 			userId: string;
-			status?: string;
+			status?: 'open' | 'claimed' | 'in_review' | 'completed' | 'validated' | 'withdrawn';
 			search?: string;
 			sort?: 'priority' | 'activity';
 			limit?: number;

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -183,7 +183,7 @@
         {
           "binding": "NEXTAUTH_SECRET",
           "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
-          "secret_name": "NEXTAUTH_SECRET",
+          "secret_name": "NEXTAUTH_SECRET_DEV",
         },
       ],
     },

--- a/services/wasteland/src/trpc/router.ts
+++ b/services/wasteland/src/trpc/router.ts
@@ -273,6 +273,7 @@ const WantedBoardBrowseInput = z.object({
 const WantedBoardCountsInput = z.object({
   wastelandId: z.string().uuid(),
   search: z.string().trim().min(1).max(200).optional(),
+  includeForkBranches: z.boolean().optional(),
 });
 
 export const wastelandRouter = router({
@@ -1064,6 +1065,7 @@ export const wastelandRouter = router({
       try {
         return await wantedBoard.getWantedBoardCounts(ctx.env, input.wastelandId, ctx.userId, {
           search: input.search,
+          includeForkBranches: input.includeForkBranches,
         });
       } catch (err) {
         if (err instanceof WantedBoardOpError && err.code === 'PRECONDITION_FAILED') {

--- a/services/wasteland/src/trpc/router.ts
+++ b/services/wasteland/src/trpc/router.ts
@@ -28,6 +28,7 @@ import {
   RpcWastelandConfigOutput,
   RpcWastelandCredentialStatusOutput,
   RpcConnectedTownOutput,
+  RpcWantedBoardCountsOutput,
   RpcWantedBoardRowOutput,
   RpcInboxItemOutput,
   RpcUpstreamAdminVerifyOutput,
@@ -250,6 +251,29 @@ async function requireOwnerAccess(env: Env, ctx: TRPCContext, wastelandId: strin
 }
 
 // ── Router ─────────────────────────────────────────────────────────────
+
+const WantedBoardStatusInput = z.enum([
+  'open',
+  'claimed',
+  'in_review',
+  'completed',
+  'validated',
+  'withdrawn',
+]);
+
+const WantedBoardBrowseInput = z.object({
+  wastelandId: z.string().uuid(),
+  status: WantedBoardStatusInput.optional(),
+  search: z.string().trim().min(1).max(200).optional(),
+  sort: z.enum(['priority', 'activity']).optional(),
+  limit: z.number().int().min(1).max(500).optional(),
+  includeForkBranches: z.boolean().optional(),
+});
+
+const WantedBoardCountsInput = z.object({
+  wastelandId: z.string().uuid(),
+  search: z.string().trim().min(1).max(200).optional(),
+});
 
 export const wastelandRouter = router({
   // ── Create ──────────────────────────────────────────────────────────
@@ -1005,16 +1029,52 @@ export const wastelandRouter = router({
   // ── Wanted Board ──────────────────────────────────────────────────
 
   browseWantedBoard: procedure
-    .input(z.object({ wastelandId: z.string().uuid() }))
+    .input(WantedBoardBrowseInput)
     .output(z.array(RpcWantedBoardRowOutput))
     .query(async ({ ctx, input }) => {
       await resolveWastelandOwnership(ctx.env, ctx, input.wastelandId);
       try {
-        return await wantedBoard.browseWantedBoard(ctx.env, input.wastelandId, ctx.userId);
+        const filter =
+          input.status || input.search || input.sort || input.limit
+            ? {
+                status: input.status,
+                search: input.search,
+                sort: input.sort,
+                limit: input.limit,
+              }
+            : undefined;
+        return await wantedBoard.browseWantedBoard(ctx.env, input.wastelandId, ctx.userId, {
+          filter,
+          includeForkBranches: input.includeForkBranches,
+        });
       } catch (err) {
         // Browse degrades to empty list if not yet configured
         if (err instanceof WantedBoardOpError && err.code === 'PRECONDITION_FAILED') {
           return [];
+        }
+        return wantedBoardErrorToTRPC(err);
+      }
+    }),
+
+  getWantedBoardCounts: procedure
+    .input(WantedBoardCountsInput)
+    .output(RpcWantedBoardCountsOutput)
+    .query(async ({ ctx, input }) => {
+      await resolveWastelandOwnership(ctx.env, ctx, input.wastelandId);
+      try {
+        return await wantedBoard.getWantedBoardCounts(ctx.env, input.wastelandId, ctx.userId, {
+          search: input.search,
+        });
+      } catch (err) {
+        if (err instanceof WantedBoardOpError && err.code === 'PRECONDITION_FAILED') {
+          return {
+            open: 0,
+            claimed: 0,
+            in_review: 0,
+            completed: 0,
+            validated: 0,
+            withdrawn: 0,
+          };
         }
         return wantedBoardErrorToTRPC(err);
       }

--- a/services/wasteland/src/trpc/router.ts
+++ b/services/wasteland/src/trpc/router.ts
@@ -40,6 +40,8 @@ import {
   RpcForkBranchOutput,
   RpcMyPullOutput,
   RpcPublishBranchOutput,
+  WantedBoardBrowseInput,
+  WantedBoardCountsInput,
   WantedBoardRowOutput,
 } from './schemas';
 import type { TRPCContext } from './init';
@@ -251,30 +253,6 @@ async function requireOwnerAccess(env: Env, ctx: TRPCContext, wastelandId: strin
 }
 
 // ── Router ─────────────────────────────────────────────────────────────
-
-const WantedBoardStatusInput = z.enum([
-  'open',
-  'claimed',
-  'in_review',
-  'completed',
-  'validated',
-  'withdrawn',
-]);
-
-const WantedBoardBrowseInput = z.object({
-  wastelandId: z.string().uuid(),
-  status: WantedBoardStatusInput.optional(),
-  search: z.string().trim().min(1).max(200).optional(),
-  sort: z.enum(['priority', 'activity']).optional(),
-  limit: z.number().int().min(1).max(500).optional(),
-  includeForkBranches: z.boolean().optional(),
-});
-
-const WantedBoardCountsInput = z.object({
-  wastelandId: z.string().uuid(),
-  search: z.string().trim().min(1).max(200).optional(),
-  includeForkBranches: z.boolean().optional(),
-});
 
 export const wastelandRouter = router({
   // ── Create ──────────────────────────────────────────────────────────

--- a/services/wasteland/src/trpc/schemas.test.ts
+++ b/services/wasteland/src/trpc/schemas.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { WastelandRpcBrowseWantedBoardInput } from './schemas';
+
+const WASTELAND_ID = '6d86793c-8c50-44b7-8da9-df0c7d2f4d0b';
+
+describe('WastelandRpcBrowseWantedBoardInput', () => {
+  it('accepts and normalizes valid browse filters', () => {
+    const parsed = WastelandRpcBrowseWantedBoardInput.parse({
+      wastelandId: WASTELAND_ID,
+      userId: 'user-1',
+      status: 'in_review',
+      search: ' Bug ',
+      sort: 'activity',
+      limit: 500,
+      includeForkBranches: true,
+    });
+
+    expect(parsed.search).toBe('Bug');
+    expect(parsed.status).toBe('in_review');
+    expect(parsed.limit).toBe(500);
+    expect(parsed.includeForkBranches).toBe(true);
+  });
+
+  it('rejects malformed or unbounded browse filters', () => {
+    expect(() =>
+      WastelandRpcBrowseWantedBoardInput.parse({
+        wastelandId: WASTELAND_ID,
+        userId: 'user-1',
+        status: 'done',
+      })
+    ).toThrow();
+
+    expect(() =>
+      WastelandRpcBrowseWantedBoardInput.parse({
+        wastelandId: WASTELAND_ID,
+        userId: 'user-1',
+        limit: 501,
+      })
+    ).toThrow();
+
+    expect(() =>
+      WastelandRpcBrowseWantedBoardInput.parse({
+        wastelandId: WASTELAND_ID,
+        userId: 'user-1',
+        search: ' ',
+      })
+    ).toThrow();
+  });
+});

--- a/services/wasteland/src/trpc/schemas.ts
+++ b/services/wasteland/src/trpc/schemas.ts
@@ -107,6 +107,15 @@ export const WantedBoardRowOutput = z.object({
   updated_at: z.string().nullable().default(null),
 });
 
+export const WantedBoardCountsOutput = z.object({
+  open: z.number(),
+  claimed: z.number(),
+  in_review: z.number(),
+  completed: z.number(),
+  validated: z.number(),
+  withdrawn: z.number(),
+});
+
 // ── Admin: mergeUpstreamPR result ───────────────────────────────────────
 
 export const MergePullOutput = z.object({
@@ -342,6 +351,7 @@ export const RpcWastelandConfigOutput = rpcSafe(WastelandConfigOutput);
 export const RpcConnectedTownOutput = rpcSafe(ConnectedTownOutput);
 export const RpcWantedItemOutput = rpcSafe(WantedItemOutput);
 export const RpcWantedBoardRowOutput = rpcSafe(WantedBoardRowOutput);
+export const RpcWantedBoardCountsOutput = rpcSafe(WantedBoardCountsOutput);
 export const RpcMergePullOutput = rpcSafe(MergePullOutput);
 export const RpcPendingClaimOutput = rpcSafe(PendingClaimOutput);
 export const RpcUpstreamAdminVerifyOutput = rpcSafe(UpstreamAdminVerifyOutput);

--- a/services/wasteland/src/trpc/schemas.ts
+++ b/services/wasteland/src/trpc/schemas.ts
@@ -116,6 +116,34 @@ export const WantedBoardCountsOutput = z.object({
   withdrawn: z.number(),
 });
 
+export const WantedBoardStatusInput = z.enum([
+  'open',
+  'claimed',
+  'in_review',
+  'completed',
+  'validated',
+  'withdrawn',
+]);
+
+export const WantedBoardBrowseInput = z.object({
+  wastelandId: z.string().uuid(),
+  status: WantedBoardStatusInput.optional(),
+  search: z.string().trim().min(1).max(200).optional(),
+  sort: z.enum(['priority', 'activity']).optional(),
+  limit: z.number().int().min(1).max(500).optional(),
+  includeForkBranches: z.boolean().optional(),
+});
+
+export const WantedBoardCountsInput = z.object({
+  wastelandId: z.string().uuid(),
+  search: z.string().trim().min(1).max(200).optional(),
+  includeForkBranches: z.boolean().optional(),
+});
+
+export const WastelandRpcBrowseWantedBoardInput = WantedBoardBrowseInput.extend({
+  userId: z.string().min(1),
+});
+
 // ── Admin: mergeUpstreamPR result ───────────────────────────────────────
 
 export const MergePullOutput = z.object({

--- a/services/wasteland/src/wanted-board/wanted-board-ops-sdk-inner.ts
+++ b/services/wasteland/src/wanted-board/wanted-board-ops-sdk-inner.ts
@@ -210,11 +210,43 @@ function buildCountsSql(search: string | undefined): string {
   return sql;
 }
 
+function rowMatchesSearch(row: Record<string, unknown>, search: string | undefined): boolean {
+  if (!search) return true;
+  const q = search.toLowerCase();
+  const toSearchText = (value: unknown) =>
+    typeof value === 'string' || typeof value === 'number' ? String(value) : '';
+  return [row.title, row.description, row.tags].some(value =>
+    toSearchText(value).toLowerCase().includes(q)
+  );
+}
+
+function countRowsByStatus(
+  rows: Array<Record<string, unknown>>,
+  search: string | undefined
+): WantedBoardCounts {
+  const counts = zeroWantedBoardCounts();
+  for (const row of rows) {
+    if (!rowMatchesSearch(row, search)) continue;
+    const status = typeof row.status === 'string' ? row.status : null;
+    if (status !== null && status in counts) {
+      counts[status as keyof WantedBoardCounts] += 1;
+    }
+  }
+  return counts;
+}
+
 export async function countWantedBoardByStatusViaSdk(
   ctx: SdkContext,
-  options?: { search?: string },
+  options?: { search?: string; includeForkBranches?: boolean },
   fetchImpl?: typeof fetch
 ): Promise<WantedBoardCounts> {
+  if (options?.includeForkBranches) {
+    return countRowsByStatus(
+      await browseViaSdk(ctx, { includeForkBranches: true }, fetchImpl),
+      options.search
+    );
+  }
+
   const slash = ctx.upstream.indexOf('/');
   if (slash <= 0) {
     throw new WantedBoardOpError('Counts failed: upstream is invalid', 'PRECONDITION_FAILED');

--- a/services/wasteland/src/wanted-board/wanted-board-ops-sdk-inner.ts
+++ b/services/wasteland/src/wanted-board/wanted-board-ops-sdk-inner.ts
@@ -203,8 +203,8 @@ const CountRow = z.object({
 function buildCountsSql(search: string | undefined): string {
   let sql = 'SELECT status, COUNT(*) AS item_count FROM wanted';
   if (search && search.length > 0) {
-    const s = escapeSqlString(search);
-    sql += ` WHERE (INSTR(title, '${s}') > 0 OR INSTR(COALESCE(description,''), '${s}') > 0 OR INSTR(COALESCE(tags,''), '${s}') > 0)`;
+    const s = escapeSqlString(search.toLowerCase());
+    sql += ` WHERE (INSTR(LOWER(title), '${s}') > 0 OR INSTR(LOWER(COALESCE(description,'')), '${s}') > 0 OR INSTR(LOWER(COALESCE(tags,'')), '${s}') > 0)`;
   }
   sql += ' GROUP BY status';
   return sql;

--- a/services/wasteland/src/wanted-board/wanted-board-ops-sdk-inner.ts
+++ b/services/wasteland/src/wanted-board/wanted-board-ops-sdk-inner.ts
@@ -14,7 +14,14 @@
  */
 
 import { z } from 'zod';
-import { WlClient, WlError, doltRead, type WlClientConfig } from '@kilocode/wl-sdk';
+import {
+  WlClient,
+  WlError,
+  doltRead,
+  escapeSqlString,
+  type BrowseFilter,
+  type WlClientConfig,
+} from '@kilocode/wl-sdk';
 import { WantedBoardOpError } from './errors';
 import { listMyForkBranchesViaSdk } from '../branch-ops/branch-ops-inner';
 
@@ -25,6 +32,29 @@ export type SdkContext = {
   token: string;
   isUpstreamAdmin: boolean;
 };
+
+export type BrowseWantedBoardOptions = {
+  filter?: BrowseFilter;
+  includeForkBranches?: boolean;
+};
+
+export type WantedBoardCounts = {
+  open: number;
+  claimed: number;
+  in_review: number;
+  completed: number;
+  validated: number;
+  withdrawn: number;
+};
+
+const zeroWantedBoardCounts = (): WantedBoardCounts => ({
+  open: 0,
+  claimed: 0,
+  in_review: 0,
+  completed: 0,
+  validated: 0,
+  withdrawn: 0,
+});
 
 function makeClient(ctx: SdkContext, fetchImpl?: typeof fetch): WlClient {
   const config: WlClientConfig = {
@@ -139,12 +169,17 @@ async function readLatestCompletion(
 
 export async function browseViaSdk(
   ctx: SdkContext,
+  optionsOrFetch?: BrowseWantedBoardOptions | typeof fetch,
   fetchImpl?: typeof fetch
 ): Promise<Array<Record<string, unknown>>> {
-  const wl = makeClient(ctx, fetchImpl);
+  const options = typeof optionsOrFetch === 'function' ? undefined : optionsOrFetch;
+  const fetchToUse = typeof optionsOrFetch === 'function' ? optionsOrFetch : fetchImpl;
+  const wl = makeClient(ctx, fetchToUse);
   let entries;
   try {
-    entries = await wl.browse();
+    entries = await wl.browse(options?.filter, {
+      includeForkBranches: options?.includeForkBranches,
+    });
   } catch (err) {
     throw wrapSdkError(err, 'Browse');
   }
@@ -158,6 +193,52 @@ export async function browseViaSdk(
     if (row === null || row === undefined) return { id: entry.wantedId };
     return { ...row };
   });
+}
+
+const CountRow = z.object({
+  status: z.string(),
+  item_count: z.union([z.string(), z.number()]),
+});
+
+function buildCountsSql(search: string | undefined): string {
+  let sql = 'SELECT status, COUNT(*) AS item_count FROM wanted';
+  if (search && search.length > 0) {
+    const s = escapeSqlString(search);
+    sql += ` WHERE (INSTR(title, '${s}') > 0 OR INSTR(COALESCE(description,''), '${s}') > 0 OR INSTR(COALESCE(tags,''), '${s}') > 0)`;
+  }
+  sql += ' GROUP BY status';
+  return sql;
+}
+
+export async function countWantedBoardByStatusViaSdk(
+  ctx: SdkContext,
+  options?: { search?: string },
+  fetchImpl?: typeof fetch
+): Promise<WantedBoardCounts> {
+  const slash = ctx.upstream.indexOf('/');
+  if (slash <= 0) {
+    throw new WantedBoardOpError('Counts failed: upstream is invalid', 'PRECONDITION_FAILED');
+  }
+  const owner = ctx.upstream.slice(0, slash);
+  const db = ctx.upstream.slice(slash + 1);
+  try {
+    const res = await doltRead({
+      auth: { token: ctx.token },
+      owner,
+      db,
+      query: buildCountsSql(options?.search),
+      fetch: fetchImpl,
+    });
+    const counts = zeroWantedBoardCounts();
+    for (const row of z.array(CountRow).parse(res.rows)) {
+      if (row.status in counts) {
+        counts[row.status as keyof WantedBoardCounts] = Number(row.item_count) || 0;
+      }
+    }
+    return counts;
+  } catch (err) {
+    throw wrapSdkError(err, 'Counts');
+  }
 }
 
 export async function claimViaSdk(

--- a/services/wasteland/src/wanted-board/wanted-board-ops-sdk.test.ts
+++ b/services/wasteland/src/wanted-board/wanted-board-ops-sdk.test.ts
@@ -179,12 +179,14 @@ describe('browseViaSdk', () => {
       ]),
     ]);
 
-    const result = await countWantedBoardByStatusViaSdk(baseCtx, { search: "bob's" }, fetch);
+    const result = await countWantedBoardByStatusViaSdk(baseCtx, { search: "Bob's" }, fetch);
 
     expect(result).toMatchObject({ open: 12, claimed: 3, completed: 9, in_review: 0 });
     const sql = decodeURIComponent(calls[0].url);
     expect(sql).toContain('SELECT status, COUNT(*) AS item_count FROM wanted');
-    expect(sql).toContain("INSTR(title, 'bob''s') > 0");
+    expect(sql).toContain("INSTR(LOWER(title), 'bob''s') > 0");
+    expect(sql).toContain("INSTR(LOWER(COALESCE(description,'')), 'bob''s') > 0");
+    expect(sql).toContain("INSTR(LOWER(COALESCE(tags,'')), 'bob''s') > 0");
     expect(sql).toContain('GROUP BY status');
   });
 
@@ -227,7 +229,7 @@ describe('browseViaSdk', () => {
 
     const result = await countWantedBoardByStatusViaSdk(
       baseCtx,
-      { search: 'visible', includeForkBranches: true },
+      { search: 'VISIBLE', includeForkBranches: true },
       fetch
     );
 

--- a/services/wasteland/src/wanted-board/wanted-board-ops-sdk.test.ts
+++ b/services/wasteland/src/wanted-board/wanted-board-ops-sdk.test.ts
@@ -20,6 +20,7 @@ import {
   acceptViaSdk,
   browseViaSdk,
   claimViaSdk,
+  countWantedBoardByStatusViaSdk,
   closeViaSdk,
   doneViaSdk,
   postViaSdk,
@@ -147,6 +148,44 @@ describe('browseViaSdk', () => {
     // Subsequent fetch lists branches on the fork.
     const branchListCall = calls.find(c => c.url.includes('/alice/wl/branches'));
     expect(branchListCall).toBeDefined();
+  });
+
+  it('passes filtered fast-list options to the SDK browse path', async () => {
+    const { fetch, calls } = makeFetch([readRows([fixtureWantedRow({ id: 'w-1' })])]);
+
+    const result = await browseViaSdk(
+      baseCtx,
+      {
+        filter: { status: 'open', sort: 'activity', limit: 50 },
+        includeForkBranches: false,
+      },
+      fetch
+    );
+
+    expect(result).toHaveLength(1);
+    expect(calls).toHaveLength(1);
+    const sql = decodeURIComponent(calls[0].url);
+    expect(sql).toContain("status = 'open'");
+    expect(sql).toContain('ORDER BY COALESCE(updated_at, created_at) DESC, created_at DESC');
+    expect(sql).toContain('LIMIT 50');
+  });
+
+  it('counts upstream wanted rows by status', async () => {
+    const { fetch, calls } = makeFetch([
+      readRows([
+        { status: 'open', item_count: '12' },
+        { status: 'claimed', item_count: 3 },
+        { status: 'completed', item_count: '9' },
+      ]),
+    ]);
+
+    const result = await countWantedBoardByStatusViaSdk(baseCtx, { search: "bob's" }, fetch);
+
+    expect(result).toMatchObject({ open: 12, claimed: 3, completed: 9, in_review: 0 });
+    const sql = decodeURIComponent(calls[0].url);
+    expect(sql).toContain('SELECT status, COUNT(*) AS item_count FROM wanted');
+    expect(sql).toContain("INSTR(title, 'bob''s') > 0");
+    expect(sql).toContain('GROUP BY status');
   });
 
   it('prefers fork row when a wl/<rig>/* branch is ahead of upstream main', async () => {

--- a/services/wasteland/src/wanted-board/wanted-board-ops-sdk.test.ts
+++ b/services/wasteland/src/wanted-board/wanted-board-ops-sdk.test.ts
@@ -188,6 +188,52 @@ describe('browseViaSdk', () => {
     expect(sql).toContain('GROUP BY status');
   });
 
+  it('counts fork branch overlays when requested', async () => {
+    const { fetch } = makeFetch([
+      readRows([
+        fixtureWantedRow({
+          id: 'w-1',
+          title: 'Visible task',
+          status: 'open',
+          updated_at: '2024-01-01 00:00:00',
+        }),
+      ]),
+      readRows([]),
+      readRows([]),
+      readRows([]),
+      readRows([]),
+      readRows([]),
+      {
+        status: 200,
+        body: { branches: [{ branch_name: 'wl/alice/w-1' }, { branch_name: 'wl/alice/w-2' }] },
+      },
+      readRows([
+        fixtureWantedRow({
+          id: 'w-1',
+          title: 'Visible task',
+          status: 'claimed',
+          updated_at: '2024-01-02 00:00:00',
+        }),
+      ]),
+      readRows([
+        fixtureWantedRow({
+          id: 'w-2',
+          title: 'Visible fork task',
+          status: 'in_review',
+          updated_at: '2024-01-02 00:00:00',
+        }),
+      ]),
+    ]);
+
+    const result = await countWantedBoardByStatusViaSdk(
+      baseCtx,
+      { search: 'visible', includeForkBranches: true },
+      fetch
+    );
+
+    expect(result).toMatchObject({ open: 0, claimed: 1, in_review: 1 });
+  });
+
   it('prefers fork row when a wl/<rig>/* branch is ahead of upstream main', async () => {
     // Fork wins only when its `updated_at` is strictly newer than the
     // upstream main row's — that's the SDK's "fork has fresh in-progress

--- a/services/wasteland/src/wanted-board/wanted-board-ops-sdk.ts
+++ b/services/wasteland/src/wanted-board/wanted-board-ops-sdk.ts
@@ -32,12 +32,15 @@ import {
   acceptViaSdk,
   browseViaSdk,
   claimViaSdk,
+  countWantedBoardByStatusViaSdk,
   closeViaSdk,
   doneViaSdk,
   editViaSdk,
   postViaSdk,
   rejectViaSdk,
   unclaimViaSdk,
+  type BrowseWantedBoardOptions,
+  type WantedBoardCounts,
   type SdkContext,
 } from './wanted-board-ops-sdk-inner';
 
@@ -122,10 +125,21 @@ export async function loadSdkContext(
 export async function browseWantedBoard(
   env: Env,
   wastelandId: string,
-  userId: string
+  userId: string,
+  options?: BrowseWantedBoardOptions
 ): Promise<Array<Record<string, unknown>>> {
   const ctx = await loadSdkContext(env, wastelandId, userId);
-  return browseViaSdk(ctx);
+  return browseViaSdk(ctx, options);
+}
+
+export async function getWantedBoardCounts(
+  env: Env,
+  wastelandId: string,
+  userId: string,
+  options?: { search?: string }
+): Promise<WantedBoardCounts> {
+  const ctx = await loadSdkContext(env, wastelandId, userId);
+  return countWantedBoardByStatusViaSdk(ctx, options);
 }
 
 export async function claimWantedItem(

--- a/services/wasteland/src/wanted-board/wanted-board-ops-sdk.ts
+++ b/services/wasteland/src/wanted-board/wanted-board-ops-sdk.ts
@@ -136,7 +136,7 @@ export async function getWantedBoardCounts(
   env: Env,
   wastelandId: string,
   userId: string,
-  options?: { search?: string }
+  options?: { search?: string; includeForkBranches?: boolean }
 ): Promise<WantedBoardCounts> {
   const ctx = await loadSdkContext(env, wastelandId, userId);
   return countWantedBoardByStatusViaSdk(ctx, options);

--- a/services/wasteland/src/wasteland-rpc.entrypoint.ts
+++ b/services/wasteland/src/wasteland-rpc.entrypoint.ts
@@ -32,8 +32,29 @@ function wrap<T>(fn: () => Promise<T>): Promise<WastelandRpcResult<T>> {
 }
 
 export class WastelandRPCEntrypoint extends WorkerEntrypoint<Env> {
-  async browseWantedBoard(params: { wastelandId: string; userId: string }) {
-    return wrap(() => wantedBoard.browseWantedBoard(this.env, params.wastelandId, params.userId));
+  async browseWantedBoard(params: {
+    wastelandId: string;
+    userId: string;
+    status?: string;
+    search?: string;
+    sort?: 'priority' | 'activity';
+    limit?: number;
+    includeForkBranches?: boolean;
+  }) {
+    return wrap(() =>
+      wantedBoard.browseWantedBoard(this.env, params.wastelandId, params.userId, {
+        filter:
+          params.status || params.search || params.sort || params.limit
+            ? {
+                status: params.status,
+                search: params.search,
+                sort: params.sort,
+                limit: params.limit,
+              }
+            : undefined,
+        includeForkBranches: params.includeForkBranches,
+      })
+    );
   }
 
   async claimWantedItem(params: {

--- a/services/wasteland/src/wasteland-rpc.entrypoint.ts
+++ b/services/wasteland/src/wasteland-rpc.entrypoint.ts
@@ -12,49 +12,54 @@
  */
 
 import { WorkerEntrypoint } from 'cloudflare:workers';
+import { z } from 'zod';
 import * as wantedBoard from './wanted-board/wanted-board-ops-sdk';
 import { WantedBoardOpError } from './wanted-board/errors';
+import { WastelandRpcBrowseWantedBoardInput } from './trpc/schemas';
 
 export type WastelandRpcResult<T> =
   | { success: true; data: T }
   | { success: false; code: WantedBoardOpError['code']; message: string };
 
-function wrap<T>(fn: () => Promise<T>): Promise<WastelandRpcResult<T>> {
-  return fn().then(
-    data => ({ success: true as const, data }),
-    err => {
-      if (err instanceof WantedBoardOpError) {
-        return { success: false as const, code: err.code, message: err.message };
-      }
-      throw err;
+async function wrap<T>(fn: () => Promise<T>): Promise<WastelandRpcResult<T>> {
+  try {
+    return { success: true as const, data: await fn() };
+  } catch (err) {
+    if (err instanceof WantedBoardOpError) {
+      return { success: false as const, code: err.code, message: err.message };
     }
-  );
+    if (err instanceof z.ZodError) {
+      return {
+        success: false as const,
+        code: 'PRECONDITION_FAILED',
+        message: 'Invalid RPC input',
+      };
+    }
+    throw err;
+  }
 }
 
 export class WastelandRPCEntrypoint extends WorkerEntrypoint<Env> {
-  async browseWantedBoard(params: {
-    wastelandId: string;
-    userId: string;
-    status?: string;
-    search?: string;
-    sort?: 'priority' | 'activity';
-    limit?: number;
-    includeForkBranches?: boolean;
-  }) {
-    return wrap(() =>
-      wantedBoard.browseWantedBoard(this.env, params.wastelandId, params.userId, {
-        filter:
-          params.status || params.search || params.sort || params.limit
-            ? {
-                status: params.status,
-                search: params.search,
-                sort: params.sort,
-                limit: params.limit,
-              }
-            : undefined,
-        includeForkBranches: params.includeForkBranches,
-      })
-    );
+  async browseWantedBoard(params: z.input<typeof WastelandRpcBrowseWantedBoardInput>) {
+    return wrap(() => {
+      const input = WastelandRpcBrowseWantedBoardInput.parse(params);
+      const filter =
+        input.status !== undefined ||
+        input.search !== undefined ||
+        input.sort !== undefined ||
+        input.limit !== undefined
+          ? {
+              status: input.status,
+              search: input.search,
+              sort: input.sort,
+              limit: input.limit,
+            }
+          : undefined;
+      return wantedBoard.browseWantedBoard(this.env, input.wastelandId, input.userId, {
+        filter,
+        includeForkBranches: input.includeForkBranches,
+      });
+    });
   }
 
   async claimWantedItem(params: {

--- a/services/wasteland/wrangler.jsonc
+++ b/services/wasteland/wrangler.jsonc
@@ -123,17 +123,17 @@
         {
           "binding": "NEXTAUTH_SECRET",
           "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
-          "secret_name": "NEXTAUTH_SECRET",
+          "secret_name": "NEXTAUTH_SECRET_DEV",
         },
         {
           "binding": "WASTELAND_ENCRYPTION_KEY",
           "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
-          "secret_name": "WASTELAND_ENCRYPTION_KEY",
+          "secret_name": "WASTELAND_ENCRYPTION_KEY_DEV",
         },
         {
           "binding": "INTERNAL_API_SECRET",
           "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
-          "secret_name": "INTERNAL_API_SECRET_PROD",
+          "secret_name": "INTERNAL_API_SECRET_DEV",
         },
       ],
     },


### PR DESCRIPTION
## Summary
Wanted board loads fewer Wasteland/DoltHub rows while preserving fork-mode visibility and fixing local Worker secret bindings.

### Why this change is needed
Wanted board could be slow because the list view fetched the full board plus fork-branch overlays, then filtered client-side. Local Gastown/Wasteland dev also failed auth or credential flows when Workers resolved prod or missing secret names.

### How this is addressed
- Pushes status, search, sort, and limit into Wasteland browse flow and wl-sdk SQL.
- Adds status-count endpoint so UI can show counts without fetching full list.
- Keeps fork-branch overlays enabled for fork-mode boards while disabling them for upstream list views.
- Invalidates board/count query families after mutations, drawer actions, and fork publish/discard paths.
- Uses dev-specific `NEXTAUTH_SECRET_DEV`, `INTERNAL_API_SECRET_DEV`, and `WASTELAND_ENCRYPTION_KEY_DEV` bindings for local Workers.

## Human Verification
- `pnpm --filter @kilocode/wl-sdk test -- src/ops/browse.test.ts`
- `pnpm --filter cloudflare-wasteland test -- src/wanted-board/wanted-board-ops-sdk.test.ts`
- Local Wasteland tRPC probe: `wasteland.listWastelands` accepted local-signed JWT and returned `{"ok":true,"count":2}`.

<details>
<summary>Manual verification</summary>

- Synced local Wasteland secrets and restarted `cloudflare-wasteland`.
- Verified `http://localhost:8811/health` returned 200.
- Created local `WASTELAND_ENCRYPTION_KEY_DEV`; confirmed local Secrets Store lists it active.

</details>

## Reviewer Notes
### Human Reviewer Flags
- Wanted board list and count queries now split. Counts cover main/upstream rows, while fork-mode list rows can still include fork branch overlays for in-flight items.
- Local dev Workers now depend on DEV Secrets Store names. Existing locally encrypted Wasteland credentials created with a different local key may need re-entry.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `includeForkBranches` defaults true in the SDK; callers opt out only for fast upstream list views.
- `getWantedBoardCounts` counts by status through same SDK context instead of deriving counts from paged list results.
- Gastown/Wasteland production secret bindings stay unchanged; only `env.dev` secret names change.

</details>
