### PR TITLE
fix(git-token): support bound SCM capability requests

### DIFF
--- a/services/git-token-service/.dev.vars.example
+++ b/services/git-token-service/.dev.vars.example
@@ -23,8 +23,8 @@ USER_GITHUB_APP_TOKEN_ACTIVE_PRIVATE_KEY=
 # @from NEXTAUTH_SECRET
 # Short-lived user-token verification for POST /internal/github-user-authorizations/disconnect
 NEXTAUTH_SECRET=
-# Dedicated 32-byte base64 AES-GCM key for short-lived SCM session capabilities
-SCM_SESSION_CAPABILITY_ENCRYPTION_KEY=
+# Local dev Secrets Store seed for short-lived SCM session capabilities.
+SCM_SESSION_CAPABILITY_ENCRYPTION_KEY_DEV=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
 
 # GitHub Lite App credentials (for OSS organizations with read-only permissions)
 # Same format as standard app credentials above

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -867,6 +867,32 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
     expect(serviceMocks.getTokenForRepo).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    ['POST', 'https://api.github.com/graphql'],
+    ['GET', 'https://github.com/acme/other.git/info/refs?service=git-upload-pack'],
+  ] as const)(
+    'keeps legacy unbound GitHub capabilities repository-confined for %s %s',
+    async (requestMethod, requestUrl) => {
+      const service = createService();
+      const issued = await service.issueGitHubSessionCapability({
+        githubRepo: 'acme/repo',
+        userId: 'user_1',
+      });
+      if (!issued.success) throw new Error('Expected successful issuance');
+      expect(issued.capability).toMatch(/^kgh1\./);
+      serviceMocks.getTokenForRepo.mockClear();
+
+      await expect(
+        service.redeemGitHubSessionCapability({
+          capability: issued.capability,
+          requestMethod,
+          requestUrl,
+        })
+      ).resolves.toEqual({ success: false, reason: 'repository_mismatch' });
+      expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
+    }
+  );
+
   it('rejects tampered capabilities before resolving any upstream authorization', async () => {
     const service = createService();
     const issued = await service.issueGitHubSessionCapability({
@@ -978,17 +1004,15 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
   });
 
   it.each([
-    ['GET', 'https://github.com/acme/repo.git/info/lfs/objects/batch', 'invalid_upstream_request'],
-    [
-      'POST',
-      'https://github.com/acme/repo.git/info/lfs/objects/batch?operation=upload',
-      'invalid_upstream_request',
-    ],
-    ['POST', 'https://github.com/acme/other.git/info/lfs/objects/batch', 'repository_mismatch'],
-    ['POST', 'https://github.com/acme/repo.git/info/lfs/locks', 'invalid_upstream_request'],
+    ['POST', 'https://api.github.com/graphql'],
+    ['GET', 'https://api.github.com/user/repos'],
+    ['DELETE', 'https://api.github.com/repos/acme/other/issues/42/comments/1'],
+    ['GET', 'https://api.github.com/repos/acme/repo/contents/src%2Findex.ts'],
+    ['POST', 'https://uploads.github.com/repos/acme/other/releases/1/assets?name=asset.zip'],
+    ['POST', 'https://github.com/acme/other.git/info/lfs/objects/batch'],
   ] as const)(
-    'rejects unsupported LFS control request %s %s',
-    async (requestMethod, requestUrl, reason) => {
+    'redeems an installation-pinned capability for unrestricted GitHub request %s %s',
+    async (requestMethod, requestUrl) => {
       const service = createService();
       const issued = await service.issueGitHubSessionCapability({
         githubRepo: 'acme/repo',
@@ -1005,8 +1029,13 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
           requestMethod,
           requestUrl,
         })
-      ).resolves.toEqual({ success: false, reason });
-      expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
+      ).resolves.toEqual({
+        success: true,
+        authorization: requestUrl.startsWith('https://github.com/')
+          ? `Basic ${Buffer.from('x-access-token:installation-token').toString('base64')}`
+          : 'Bearer installation-token',
+      });
+      expect(serviceMocks.getTokenForRepo).toHaveBeenCalledOnce();
     }
   );
 
@@ -1067,39 +1096,14 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
   });
 
   it.each([
-    'https://api.github.com/user/repos',
-    'https://api.github.com/repos/acme/other/issues/42/comments',
-    'https://api.github.com/graphql',
-  ])(
-    'does not redeem a GitHub capability for an API request outside its repository: %s',
-    async requestUrl => {
-      const service = createService();
-      const issued = await service.issueGitHubSessionCapability({
-        githubRepo: 'acme/repo',
-        userId: 'user_1',
-        outboundContainerId,
-        allowUserAuthorization: true,
-      });
-      if (!issued.success) throw new Error('Expected successful issuance');
-      serviceMocks.selectUserAuthorization.mockClear();
-
-      await expect(
-        service.redeemGitHubSessionCapability({
-          capability: issued.capability,
-          outboundContainerId,
-          requestMethod: 'POST',
-          requestUrl,
-        })
-      ).resolves.toEqual({ success: false, reason: 'repository_mismatch' });
-      expect(serviceMocks.selectUserAuthorization).not.toHaveBeenCalled();
-    }
-  );
-
-  it.each([
+    ['POST', 'https://api.github.com/graphql'],
+    ['GET', 'https://api.github.com/user/repos'],
+    ['DELETE', 'https://api.github.com/repos/acme/other/issues/42/comments/1'],
+    ['GET', 'https://api.github.com/repos/acme/repo/contents/src%2Findex.ts'],
+    ['POST', 'https://uploads.github.com/repos/acme/other/releases/1/assets?name=asset.zip'],
     ['GET', 'https://github.com/acme/other.git/info/refs?service=git-upload-pack'],
-    ['POST', 'https://github.com/acme/other.git/git-receive-pack'],
   ] as const)(
-    'does not redeem a selected-user capability for another Git repository via %s %s',
+    'redeems a selected-user capability for unrestricted GitHub request %s %s',
     async (requestMethod, requestUrl) => {
       const service = createService();
       const issued = await service.issueGitHubSessionCapability({
@@ -1119,8 +1123,13 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
           requestMethod,
           requestUrl,
         })
-      ).resolves.toEqual({ success: false, reason: 'repository_mismatch' });
-      expect(serviceMocks.selectUserAuthorization).not.toHaveBeenCalled();
+      ).resolves.toEqual({
+        success: true,
+        authorization: requestUrl.startsWith('https://github.com/')
+          ? `Basic ${Buffer.from('x-access-token:user-token').toString('base64')}`
+          : 'Bearer user-token',
+      });
+      expect(serviceMocks.selectUserAuthorization).toHaveBeenCalledOnce();
     }
   );
 
@@ -1145,28 +1154,8 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
       'https://gitlab.com/acme/repo.git/info/refs?service=git-upload-pack',
       'upstream_host_not_allowed',
     ],
-    [
-      'GET',
-      'https://github.com/acme/other.git/info/refs?service=git-upload-pack',
-      'repository_mismatch',
-    ],
-    ['GET', 'https://github.com/acme/repo/settings', 'invalid_upstream_request'],
-    ['GET', 'https://github.com/acme/repo.git/info/refs', 'invalid_upstream_request'],
-    [
-      'POST',
-      'https://github.com/acme/repo.git/info/refs?service=git-upload-pack',
-      'invalid_upstream_request',
-    ],
-    ['GET', 'https://github.com/acme/repo.git/git-receive-pack', 'invalid_upstream_request'],
-    ['CONNECT', 'https://api.github.com/user/repos', 'invalid_upstream_request'],
-    ['PATCH', 'https://api.github.com/repos/acme/repo/pulls/42', 'invalid_upstream_request'],
-    ['PUT', 'https://api.github.com/repos/acme/repo/pulls/42/merge', 'invalid_upstream_request'],
-    ['GET', 'https://api.github.com/repos/acme/repo/actions/variables', 'invalid_upstream_request'],
-    [
-      'POST',
-      'https://api.github.com/repos/acme/repo/issues/42%2F..%2F43/comments',
-      'invalid_upstream_url',
-    ],
+    ['GET', 'https://api.github.com:8443/user/repos', 'upstream_host_not_allowed'],
+    ['GET', 'https://api.github.com/user/repos#fragment', 'invalid_upstream_url'],
   ] as const)(
     'rejects unsafe upstream request %s %s without forwarding authorization',
     async (requestMethod, requestUrl, reason) => {
@@ -1190,6 +1179,29 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
       expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
     }
   );
+
+  it('rejects unsafe selected-user destinations before resolving authorization', async () => {
+    const service = createService();
+    const issued = await service.issueGitHubSessionCapability({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      outboundContainerId,
+      allowUserAuthorization: true,
+    });
+    if (!issued.success) throw new Error('Expected successful issuance');
+    expect(issued.source).toBe('user');
+    serviceMocks.selectUserAuthorization.mockClear();
+
+    await expect(
+      service.redeemGitHubSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestMethod: 'POST',
+        requestUrl: 'https://github.com.evil.example/graphql',
+      })
+    ).resolves.toEqual({ success: false, reason: 'upstream_host_not_allowed' });
+    expect(serviceMocks.selectUserAuthorization).not.toHaveBeenCalled();
+  });
 
   it('rejects user-source redemption rather than falling back to installation authorization', async () => {
     const service = createService();
@@ -1361,6 +1373,28 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
     }
   );
 
+  it('reports a missing GitLab integration identity distinctly from a missing token', async () => {
+    serviceMocks.findGitLabIntegration.mockResolvedValue({
+      success: true,
+      integrationId: 'ef2eb5c7-27ce-4f43-b6d3-8f282abc145c',
+      integrationType: 'oauth',
+      accountId: null,
+      accountLogin: null,
+      metadata: {
+        access_token: 'gitlab-oauth-token',
+        auth_type: 'oauth',
+      },
+    });
+
+    await expect(
+      createService().issueGitLabSessionCapability({
+        gitUrl: 'https://gitlab.com/acme/widgets.git',
+        userId: 'user_1',
+        outboundContainerId,
+      })
+    ).resolves.toEqual({ success: false, reason: 'integration_identity_missing' });
+  });
+
   it('does not redeem a capability from another outbound container or resolve its source', async () => {
     const service = createService();
     const issued = await service.issueGitLabSessionCapability({
@@ -1435,6 +1469,51 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
     expect(serviceMocks.getGitLabToken).toHaveBeenCalledTimes(2);
   });
 
+  it.each([
+    ['POST', 'https://gitlab.com/api/graphql', 'invalid_upstream_request'],
+    ['GET', 'https://gitlab.com/api/v4/projects?membership=true', 'invalid_upstream_request'],
+    ['GET', 'https://gitlab.com/api/v4/projects/acme%2Fother/issues', 'repository_mismatch'],
+    ['CONNECT', 'https://gitlab.com/api/v4/projects', 'invalid_upstream_request'],
+    [
+      'GET',
+      'https://gitlab.com/api/v4/projects/acme%2Fwidgets/variables',
+      'invalid_upstream_request',
+    ],
+    [
+      'PUT',
+      'https://gitlab.com/api/v4/projects/acme%2Fwidgets/merge_requests/42/merge',
+      'invalid_upstream_request',
+    ],
+    [
+      'GET',
+      'https://gitlab.com/other/project.git/info/refs?service=git-upload-pack',
+      'repository_mismatch',
+    ],
+  ] as const)(
+    'keeps legacy unbound GitLab capabilities project-confined for %s %s',
+    async (requestMethod, requestUrl, reason) => {
+      const service = createService();
+      const issued = await service.issueGitLabSessionCapability({
+        gitUrl: 'https://gitlab.com/acme/widgets.git',
+        userId: 'user_1',
+      });
+      if (!issued.success) throw new Error('Expected successful issuance');
+      expect(issued.capability).toMatch(/^kgl1\./);
+      serviceMocks.findGitLabIntegration.mockClear();
+      serviceMocks.getGitLabToken.mockClear();
+
+      await expect(
+        service.redeemGitLabSessionCapability({
+          capability: issued.capability,
+          requestMethod,
+          requestUrl,
+        })
+      ).resolves.toEqual({ success: false, reason });
+      expect(serviceMocks.findGitLabIntegration).not.toHaveBeenCalled();
+      expect(serviceMocks.getGitLabToken).not.toHaveBeenCalled();
+    }
+  );
+
   it('issues an opaque project-source capability for a code-review repository without exposing its token', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ id: 42 })));
     serviceMocks.findAuthorizedGitLabIntegrations.mockResolvedValueOnce({
@@ -1491,13 +1570,34 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
       'https://gitlab.com/api/v4/projects/42/merge_requests/42/changes',
       { 'PRIVATE-TOKEN': 'project-access-token' },
     ],
+    ['POST', 'https://gitlab.com/api/graphql', { 'PRIVATE-TOKEN': 'project-access-token' }],
+    [
+      'DELETE',
+      'https://gitlab.com/api/v4/projects/99/merge_requests/7',
+      { 'PRIVATE-TOKEN': 'project-access-token' },
+    ],
     [
       'GET',
       'https://gitlab.com/acme/widgets.git/info/refs?service=git-upload-pack',
       { authorization: `Basic ${Buffer.from('oauth2:project-access-token').toString('base64')}` },
     ],
+    [
+      'GET',
+      'https://gitlab.com/other/project.git/info/refs?service=git-upload-pack',
+      { authorization: `Basic ${Buffer.from('oauth2:project-access-token').toString('base64')}` },
+    ],
+    [
+      'GET',
+      'https://gitlab.com/api/project.git/info/refs?service=git-upload-pack',
+      { authorization: `Basic ${Buffer.from('oauth2:project-access-token').toString('base64')}` },
+    ],
+    [
+      'POST',
+      'https://gitlab.com/api/v4/project.git/info/lfs/locks/123/unlock',
+      { authorization: `Basic ${Buffer.from('oauth2:project-access-token').toString('base64')}` },
+    ],
   ] as const)(
-    'redeems a project-source capability server-side for %s %s',
+    'redeems an unrestricted bound project-source capability server-side for %s %s',
     async (requestMethod, requestUrl, headers) => {
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ id: 42 })));
       const projectIntegration = {
@@ -1648,6 +1748,18 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
       'https://gitlab.example.com:8443/gitlab/api/v4/projects/acme%2Fplatform%2Fwidgets/merge_requests/42/changes',
       { authorization: 'Bearer refreshed-self-managed-token' },
     ],
+    [
+      'POST',
+      'https://gitlab.example.com:8443/gitlab/api/graphql',
+      { authorization: 'Bearer refreshed-self-managed-token' },
+    ],
+    [
+      'GET',
+      'https://gitlab.example.com:8443/gitlab/other/project.git/info/refs?service=git-upload-pack',
+      {
+        authorization: `Basic ${Buffer.from('oauth2:refreshed-self-managed-token').toString('base64')}`,
+      },
+    ],
   ] as const)(
     'issues and redeems a nested self-managed GitLab capability for %s %s',
     async (requestMethod, requestUrl, headers) => {
@@ -1693,11 +1805,13 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
   );
 
   it.each([
-    ['https://gitlab.example.com:8443/api/v4/projects/42/issues', 'invalid_upstream_request'],
+    ['https://gitlab.example.com:8443/api/v4/projects/42/issues', 'upstream_origin_not_allowed'],
     [
       'https://gitlab.example.com:8443/acme/platform/widgets.git/info/refs?service=git-upload-pack',
-      'repository_mismatch',
+      'upstream_origin_not_allowed',
     ],
+    ['https://gitlab.example.com:8443/gitlab/%2e%2e%2fapi/v4/user', 'invalid_upstream_url'],
+    ['https://gitlab.example.com:8443/gitlab/%252e%252e%252fapi/v4/user', 'invalid_upstream_url'],
   ] as const)('rejects self-managed base-path escape %s', async (requestUrl, reason) => {
     serviceMocks.findGitLabIntegration.mockResolvedValue({
       success: true,
@@ -1736,16 +1850,9 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
     expect(serviceMocks.findGitLabIntegration).not.toHaveBeenCalled();
   });
 
-  it.each([
-    [
-      'https://sibling.example.com/acme/platform/widgets.git/info/refs?service=git-upload-pack',
-      'upstream_origin_not_allowed',
-    ],
-    [
-      'https://gitlab.example.com/acme/platform/sibling.git/info/refs?service=git-upload-pack',
-      'repository_mismatch',
-    ],
-  ] as const)('rejects self-managed sibling scope %s', async (requestUrl, reason) => {
+  it('rejects a self-managed sibling origin', async () => {
+    const requestUrl =
+      'https://sibling.example.com/acme/platform/widgets.git/info/refs?service=git-upload-pack';
     serviceMocks.findGitLabIntegration.mockResolvedValue({
       success: true,
       integrationId: 'ef2eb5c7-27ce-4f43-b6d3-8f282abc145c',
@@ -1779,7 +1886,7 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
         requestMethod: 'GET',
         requestUrl,
       })
-    ).resolves.toEqual({ success: false, reason });
+    ).resolves.toEqual({ success: false, reason: 'upstream_origin_not_allowed' });
     expect(serviceMocks.findGitLabIntegration).not.toHaveBeenCalled();
   });
 
@@ -1882,12 +1989,12 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
   });
 
   it.each([
-    ['GET', 'https://gitlab.com/api/v4/projects?membership=true', 'invalid_upstream_request'],
-    ['POST', 'https://gitlab.com/api/graphql', 'invalid_upstream_request'],
-    ['GET', 'https://gitlab.com/api/v4/projects/acme%2Fother/issues', 'repository_mismatch'],
+    ['GET', 'https://gitlab.com/api/v4/projects?membership=true'],
+    ['POST', 'https://gitlab.com/api/graphql'],
+    ['DELETE', 'https://gitlab.com/api/v4/projects/acme%2Fother/issues/1'],
   ] as const)(
-    'does not redeem a GitLab capability for an API request outside its project: %s %s',
-    async (requestMethod, requestUrl, reason) => {
+    'redeems an unrestricted bound GitLab integration capability for API request %s %s',
+    async (requestMethod, requestUrl) => {
       const service = createService();
       const issued = await service.issueGitLabSessionCapability({
         gitUrl: 'https://gitlab.com/acme/widgets.git',
@@ -1896,6 +2003,11 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
       });
       if (!issued.success) throw new Error('Expected successful issuance');
       serviceMocks.findGitLabIntegration.mockClear();
+      serviceMocks.getGitLabToken.mockResolvedValueOnce({
+        success: true,
+        token: 'refreshed-gitlab-token',
+        instanceUrl: 'https://gitlab.com',
+      });
 
       await expect(
         service.redeemGitLabSessionCapability({
@@ -1904,8 +2016,11 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
           requestMethod,
           requestUrl,
         })
-      ).resolves.toEqual({ success: false, reason });
-      expect(serviceMocks.findGitLabIntegration).not.toHaveBeenCalled();
+      ).resolves.toEqual({
+        success: true,
+        headers: { authorization: 'Bearer refreshed-gitlab-token' },
+      });
+      expect(serviceMocks.findGitLabIntegration).toHaveBeenCalledOnce();
     }
   );
 
@@ -1915,29 +2030,15 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
       'https://other.example.com/acme/widgets.git/info/refs?service=git-upload-pack',
       'upstream_origin_not_allowed',
     ],
+    ['GET', 'https://gitlab.com:8443/api/v4/projects', 'upstream_origin_not_allowed'],
+    ['GET', 'http://gitlab.com/api/v4/projects', 'invalid_upstream_url'],
+    ['GET', 'https://attacker@gitlab.com/api/v4/projects', 'invalid_upstream_url'],
+    ['GET', 'https://gitlab.com/api/v4/projects#fragment', 'invalid_upstream_url'],
+    ['GET', 'https://gitlab.com/../api/v4/projects', 'invalid_upstream_url'],
     [
       'GET',
-      'https://gitlab.com/acme/other.git/info/refs?service=git-upload-pack',
-      'repository_mismatch',
-    ],
-    ['GET', 'https://gitlab.com/acme/widgets/settings', 'invalid_upstream_request'],
-    ['GET', 'https://gitlab.com/oauth/authorize', 'invalid_upstream_request'],
-    ['GET', 'https://gitlab.com/users/sign_in', 'invalid_upstream_request'],
-    [
-      'GET',
-      'https://gitlab.com/acme%2Fwidgets.git/info/refs?service=git-upload-pack',
+      'https://gitlab.com/acme%5Cwidgets.git/info/refs?service=git-upload-pack',
       'invalid_upstream_url',
-    ],
-    ['CONNECT', 'https://gitlab.com/api/v4/projects', 'invalid_upstream_request'],
-    [
-      'GET',
-      'https://gitlab.com/api/v4/projects/acme%2Fwidgets/variables',
-      'invalid_upstream_request',
-    ],
-    [
-      'PUT',
-      'https://gitlab.com/api/v4/projects/acme%2Fwidgets/merge_requests/42/merge',
-      'invalid_upstream_request',
     ],
   ] as const)('rejects unsafe GitLab request %s %s', async (requestMethod, requestUrl, reason) => {
     const service = createService();

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -166,7 +166,13 @@ export type IssueGitLabSessionCapabilitySuccess = {
 export type IssueGitLabSessionCapabilityResult =
   | IssueGitLabSessionCapabilitySuccess
   | GetGitLabTokenFailure
-  | { success: false; reason: GitLabCloneUrlFailureReason | 'capability_configuration_error' };
+  | {
+      success: false;
+      reason:
+        | GitLabCloneUrlFailureReason
+        | 'integration_identity_missing'
+        | 'capability_configuration_error';
+    };
 export type RedeemGitLabSessionCapabilityParams = {
   capability: string;
   outboundContainerId?: string;
@@ -203,6 +209,24 @@ async function resolveSecret(secret: SecretsStoreSecret | string): Promise<strin
 }
 
 function validateGitHubCapabilityUpstream(
+  requestUrl: string
+): RedeemGitHubSessionCapabilityFailureReason | null {
+  let url: URL;
+  try {
+    url = new URL(requestUrl);
+  } catch {
+    return 'invalid_upstream_url';
+  }
+  if (url.protocol !== 'https:') return 'invalid_upstream_url';
+  if (url.username || url.password || url.hash) return 'invalid_upstream_url';
+  if (url.port !== '') return 'upstream_host_not_allowed';
+  if (!['api.github.com', 'uploads.github.com', 'github.com'].includes(url.hostname)) {
+    return 'upstream_host_not_allowed';
+  }
+  return null;
+}
+
+function validateLegacyGitHubCapabilityUpstream(
   requestMethod: string,
   requestUrl: string,
   repository: { owner: string; repo: string }
@@ -268,7 +292,75 @@ function validateGitHubCapabilityUpstream(
   return 'invalid_upstream_request';
 }
 
+function isGitLabGitAuthPath(pathname: string): boolean {
+  return /\.git\/(?:info\/refs|git-upload-pack|git-receive-pack|info\/lfs\/(?:objects\/batch|locks(?:\/verify|\/[^/]+\/unlock)?))$/.test(
+    pathname
+  );
+}
+
+function decodeGitLabPathname(pathname: string): string | null {
+  let decoded = pathname;
+  for (let depth = 0; depth < 4; depth++) {
+    let next: string;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      return null;
+    }
+    if (next === decoded) return decoded;
+    decoded = next;
+  }
+  return null;
+}
+
 function validateGitLabCapabilityUpstream(
+  requestUrl: string,
+  instanceOrigin: string
+): { failure: RedeemGitLabSessionCapabilityFailureReason | null; authSurface: 'git' | 'api' } {
+  if (/%5c/i.test(requestUrl) || /\/(?:(?:\.|%2e){1,2})(?:\/|$)/i.test(requestUrl)) {
+    return { failure: 'invalid_upstream_url', authSurface: 'git' };
+  }
+  const base = parseGitLabBaseUrl(instanceOrigin);
+  if (!base) return { failure: 'invalid_upstream_url', authSurface: 'git' };
+  let url: URL;
+  try {
+    url = new URL(requestUrl);
+  } catch {
+    return { failure: 'invalid_upstream_url', authSurface: 'git' };
+  }
+  if (url.protocol !== 'https:' || url.username || url.password || url.hash) {
+    return { failure: 'invalid_upstream_url', authSurface: 'git' };
+  }
+  if (url.origin !== base.origin) {
+    return { failure: 'upstream_origin_not_allowed', authSurface: 'git' };
+  }
+  const decodedPathname = decodeGitLabPathname(url.pathname);
+  if (
+    decodedPathname === null ||
+    decodedPathname.includes('\\') ||
+    /(?:^|\/)\.{1,2}(?:\/|$)/.test(decodedPathname)
+  ) {
+    return { failure: 'invalid_upstream_url', authSurface: 'git' };
+  }
+  if (
+    base.basePath !== '' &&
+    url.pathname !== base.basePath &&
+    !url.pathname.startsWith(`${base.basePath}/`)
+  ) {
+    return { failure: 'upstream_origin_not_allowed', authSurface: 'git' };
+  }
+  const apiV4Prefix = `${base.basePath}/api/v4`;
+  const authSurface =
+    !isGitLabGitAuthPath(url.pathname) &&
+    (url.pathname === apiV4Prefix ||
+      url.pathname.startsWith(`${apiV4Prefix}/`) ||
+      url.pathname === `${base.basePath}/api/graphql`)
+      ? 'api'
+      : 'git';
+  return { failure: null, authSurface };
+}
+
+function validateLegacyGitLabCapabilityUpstream(
   requestMethod: string,
   requestUrl: string,
   session: {
@@ -604,11 +696,10 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
       return { success: false, reason: 'container_mismatch' };
     }
 
-    const upstreamFailure = validateGitHubCapabilityUpstream(
-      params.requestMethod,
-      params.requestUrl,
-      claims
-    );
+    const upstreamFailure =
+      claims.version === 2
+        ? validateGitHubCapabilityUpstream(params.requestUrl)
+        : validateLegacyGitHubCapabilityUpstream(params.requestMethod, params.requestUrl, claims);
     if (upstreamFailure) return { success: false, reason: upstreamFailure };
 
     const authParams = {
@@ -761,7 +852,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     const repository = parseGitLabCloneUrl(params.gitUrl, instanceOrigin);
     if (!repository.success) return repository;
     const identity = this.getGitLabSessionIdentity(integration);
-    if (!identity) return { success: false, reason: 'no_token' };
+    if (!identity) return { success: false, reason: 'integration_identity_missing' };
 
     let capability: string;
     try {
@@ -814,11 +905,10 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
       return { success: false, reason: 'container_mismatch' };
     }
 
-    const upstream = validateGitLabCapabilityUpstream(
-      params.requestMethod,
-      params.requestUrl,
-      claims
-    );
+    const upstream =
+      claims.version === 2
+        ? validateGitLabCapabilityUpstream(params.requestUrl, claims.instanceOrigin)
+        : validateLegacyGitLabCapabilityUpstream(params.requestMethod, params.requestUrl, claims);
     if (upstream.failure) return { success: false, reason: upstream.failure };
     const context = {
       userId: claims.userId,


### PR DESCRIPTION
## Summary

- Allows bound SCM session capabilities to redeem against safe provider API and Git endpoints instead of legacy repository-limited request surfaces.
- Preserves repository confinement for legacy unbound capabilities and validates provider origin/path before resolving authorization.
- Seeds the local dev Secrets Store source for the SCM capability encryption key.

## Verification

N/A - no manual verification for this Worker-only change.

## Visual Changes

N/A

## Reviewer Notes

Focus on the expanded bound-capability request surface and GitLab base-path/origin validation.