### PR TITLE
Cloud Agent Next - Use Global Events and Update Runtime Dependencies

### DIFF
--- a/apps/web/src/types/opencode.gen.ts
+++ b/apps/web/src/types/opencode.gen.ts
@@ -163,8 +163,10 @@ export type AssistantMessage = {
 export type Message = UserMessage | AssistantMessage;
 
 export type EventMessageUpdated = {
+  id: string;
   type: 'message.updated';
   properties: {
+    sessionID: string;
     info: Message;
   };
 };
@@ -415,6 +417,7 @@ export type CompactionPart = {
   type: 'compaction';
   auto: boolean;
   overflow?: boolean;
+  tail_start_id?: string;
 };
 
 export type Part =
@@ -432,13 +435,17 @@ export type Part =
   | CompactionPart;
 
 export type EventMessagePartUpdated = {
+  id: string;
   type: 'message.part.updated';
   properties: {
+    sessionID: string;
     part: Part;
+    time: number;
   };
 };
 
 export type EventMessagePartDelta = {
+  id: string;
   type: 'message.part.delta';
   properties: {
     sessionID: string;
@@ -450,6 +457,7 @@ export type EventMessagePartDelta = {
 };
 
 export type EventMessagePartRemoved = {
+  id: string;
   type: 'message.part.removed';
   properties: {
     sessionID: string;
@@ -466,13 +474,27 @@ export type SessionStatus =
       type: 'retry';
       attempt: number;
       message: string;
+      action?: {
+        reason: string;
+        provider: string;
+        title: string;
+        message: string;
+        label: string;
+        link?: string;
+      };
       next: number;
     }
   | {
       type: 'busy';
+    }
+  | {
+      type: 'offline';
+      requestID: string;
+      message: string;
     };
 
 export type EventSessionStatus = {
+  id: string;
   type: 'session.status';
   properties: {
     sessionID: string;
@@ -534,6 +556,7 @@ export type Session = {
   projectID: string;
   workspaceID?: string;
   directory: string;
+  path?: string;
   parentID?: string;
   summary?: {
     additions: number;
@@ -541,11 +564,30 @@ export type Session = {
     files: number;
     diffs?: Array<FileDiff>;
   };
+  cost?: number;
+  tokens?: {
+    input: number;
+    output: number;
+    reasoning: number;
+    cache: {
+      read: number;
+      write: number;
+    };
+  };
   share?: {
     url: string;
   };
   title: string;
+  agent?: string;
+  model?: {
+    id: string;
+    providerID: string;
+    variant?: string;
+  };
   version: string;
+  metadata?: {
+    [key: string]: unknown;
+  };
   time: {
     created: number;
     updated: number;
@@ -562,15 +604,19 @@ export type Session = {
 };
 
 export type EventSessionCreated = {
+  id: string;
   type: 'session.created';
   properties: {
+    sessionID: string;
     info: Session;
   };
 };
 
 export type EventSessionUpdated = {
+  id: string;
   type: 'session.updated';
   properties: {
+    sessionID: string;
     info: Session;
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1683,8 +1683,8 @@ importers:
   services/cloud-agent-next:
     dependencies:
       '@cloudflare/sandbox':
-        specifier: 0.11.0
-        version: 0.11.0(@xterm/xterm@6.0.0)
+        specifier: 0.12.1
+        version: 0.12.1(@xterm/xterm@6.0.0)
       '@hono/trpc-server':
         specifier: 0.4.2
         version: 0.4.2(@trpc/server@11.17.0(typescript@5.9.3))(hono@4.12.18)
@@ -1738,8 +1738,8 @@ importers:
         specifier: 'catalog:'
         version: 0.16.13(@cloudflare/workers-types@4.20260605.1)(@vitest/runner@4.1.6)(@vitest/snapshot@4.1.6)(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vitest@4.1.6)
       '@kilocode/sdk':
-        specifier: 7.3.21
-        version: 7.3.21
+        specifier: 7.3.54
+        version: 7.3.54
       '@types/jsonwebtoken':
         specifier: 'catalog:'
         version: 9.0.10
@@ -1777,8 +1777,8 @@ importers:
   services/cloud-agent-next/wrapper:
     dependencies:
       '@kilocode/sdk':
-        specifier: 7.3.21
-        version: 7.3.21
+        specifier: 7.3.54
+        version: 7.3.54
       fuzzysort:
         specifier: 3.1.0
         version: 3.1.0
@@ -3982,8 +3982,8 @@ packages:
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
     engines: {node: '>=22.0.0'}
 
-  '@cloudflare/sandbox@0.11.0':
-    resolution: {integrity: sha512-OdM26ucJlc5B4en8eZMI0C8/UE3gk9bi2sqmElsGyqZIk6nhAo1HqHQynmuLKIHfNo6qo4bt12tWjTgFzzzgBg==}
+  '@cloudflare/sandbox@0.12.1':
+    resolution: {integrity: sha512-P1ZmNDLYtuEY1ZUcAx0OgTol98VqS617LGd4nf1RTOjSV2yHLDAp59NI36/gg3/pxkHPgmAEyFIjH/ie8FoA7g==}
     peerDependencies:
       '@openai/agents': ^0.3.3
       '@opencode-ai/sdk': ^1.1.40
@@ -5148,8 +5148,8 @@ packages:
   '@kilocode/sdk@7.2.52':
     resolution: {integrity: sha512-j8w6ewvo7dyu/qxjJAg0bcjHGUGGvIZ4F2f5tJnpMwLzPTAu26DJoO/08aoxf1BhfuZLzNS9tA2q+ZPdzPT8Jg==}
 
-  '@kilocode/sdk@7.3.21':
-    resolution: {integrity: sha512-sdoV7l+rIzsAF/bSpKn6crmwQ3HGYo+59HbbdpVmGAfTj758N40CDGqPrgyzwOL7GHAcHgl6LlQKPvk+f69Qmw==}
+  '@kilocode/sdk@7.3.54':
+    resolution: {integrity: sha512-A+g744DVuAHXSU3pu6BLe2AoxEh4fq7NdrYvlET3+waXSS0tG41Blr3ItCKSMLJH5M6C4rK2ZXi7plzkPNbdmA==}
 
   '@lexical/clipboard@0.35.0':
     resolution: {integrity: sha512-ko7xSIIiayvDiqjNDX6fgH9RlcM6r9vrrvJYTcfGVBor5httx16lhIi0QJZ4+RNPvGtTjyFv4bwRmsixRRwImg==}
@@ -19369,7 +19369,7 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/sandbox@0.11.0(@xterm/xterm@6.0.0)':
+  '@cloudflare/sandbox@0.12.1(@xterm/xterm@6.0.0)':
     dependencies:
       '@cloudflare/containers': 0.3.7
       aws4fetch: 1.0.20
@@ -20990,7 +20990,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@kilocode/sdk@7.3.21':
+  '@kilocode/sdk@7.3.54':
     dependencies:
       cross-spawn: 7.0.6
 

--- a/services/cloud-agent-next/Dockerfile
+++ b/services/cloud-agent-next/Dockerfile
@@ -1,9 +1,9 @@
-FROM docker.io/cloudflare/sandbox:0.11.0
+FROM docker.io/cloudflare/sandbox:0.12.1
 
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.21"
+ARG KILOCODE_CLI_VERSION="7.3.54"
 
 # Install latest stable git + git-lfs from the git-core PPA, GitHub CLI, and supporting tools.
 # The default Ubuntu git (2.34.1 on 22.04) is outdated; the git-core PPA ships the latest

--- a/services/cloud-agent-next/Dockerfile.dev
+++ b/services/cloud-agent-next/Dockerfile.dev
@@ -1,9 +1,9 @@
-FROM docker.io/cloudflare/sandbox:0.11.0
+FROM docker.io/cloudflare/sandbox:0.12.1
 
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.21"
+ARG KILOCODE_CLI_VERSION="7.3.54"
 
 # Build the kilo binary:
 #   cd ~/projects/kilocode-backend/cloud-agent

--- a/services/cloud-agent-next/Dockerfile.dind
+++ b/services/cloud-agent-next/Dockerfile.dind
@@ -1,4 +1,4 @@
-ARG SANDBOX_VERSION="0.11.0"
+ARG SANDBOX_VERSION="0.12.1"
 
 FROM docker.io/cloudflare/sandbox:${SANDBOX_VERSION}-musl AS cloudflare-sandbox
 
@@ -9,7 +9,7 @@ USER root
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.21"
+ARG KILOCODE_CLI_VERSION="7.3.54"
 
 # Cloudflare Containers run without root privileges, so Docker must run in
 # rootless mode. The Sandbox SDK server is copied into this image so the

--- a/services/cloud-agent-next/README.md
+++ b/services/cloud-agent-next/README.md
@@ -36,7 +36,7 @@ By default, the script looks for kilo-cli at `$HOME/projects/kilo-cli`. Override
 
 **What's in Dockerfile.dev:**
 
-- Base image: `cloudflare/sandbox:0.11.0`
+- Base image: `cloudflare/sandbox:0.12.1`
 - Pre-built `kilo` binary (from `cloud-agent-build.sh`)
 - GitHub CLI (`gh`) and GitLab CLI (`glab`)
 - Wrapper bundle built inside the container

--- a/services/cloud-agent-next/package.json
+++ b/services/cloud-agent-next/package.json
@@ -30,7 +30,7 @@
     "update-default-slash-commands": "node scripts/update-default-slash-commands.mjs"
   },
   "dependencies": {
-    "@cloudflare/sandbox": "0.11.0",
+    "@cloudflare/sandbox": "0.12.1",
     "@hono/trpc-server": "0.4.2",
     "@kilocode/cloud-agent-profile": "workspace:*",
     "@kilocode/db": "workspace:*",
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@cloudflare/containers": "0.3.7",
     "@cloudflare/vitest-pool-workers": "catalog:",
-    "@kilocode/sdk": "7.3.21",
+    "@kilocode/sdk": "7.3.54",
     "@types/jsonwebtoken": "catalog:",
     "@types/node": "catalog:",
     "@types/ws": "^8.5.12",

--- a/services/cloud-agent-next/src/kilo/devcontainer.ts
+++ b/services/cloud-agent-next/src/kilo/devcontainer.ts
@@ -121,7 +121,7 @@ export const KILO_WRAPPER_PORT_LABEL = 'kilo.wrapperPort';
  * `wrangler.jsonc#image_vars` so the kilo running in the dev container
  * matches the one we use on the outer sandbox.
  */
-export const KILO_CLI_VERSION = '7.3.21';
+export const KILO_CLI_VERSION = '7.3.54';
 
 const DEVCONTAINER_RUNTIME_BUN_VERSION = '1.3.14';
 const DEVCONTAINER_RUNTIME_BOOTSTRAP_TIMEOUT_MS = 10 * 60 * 1000;

--- a/services/cloud-agent-next/src/shared/default-slash-commands.generated.ts
+++ b/services/cloud-agent-next/src/shared/default-slash-commands.generated.ts
@@ -17,7 +17,7 @@ export type SlashCommandInfo = {
  *
  * Regenerate with `pnpm --filter cloud-agent-next update-default-slash-commands`.
  */
-export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.3.21';
+export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.3.54';
 
 /**
  * Default slash command catalog used when no live wrapper-reported catalog is
@@ -25,26 +25,34 @@ export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.3.21';
  */
 export const DEFAULT_SLASH_COMMANDS = [
   {
-    name: 'init',
-    description: 'guided AGENTS.md setup',
-    source: 'command',
-    hints: ['$ARGUMENTS'],
+    name: "init",
+    description: "guided AGENTS.md setup",
+    source: "command",
+    hints: [
+      "$ARGUMENTS"
+    ]
   },
   {
-    name: 'local-review',
-    description: 'local review (current branch, optional base or instructions)',
-    hints: ['$ARGUMENTS'],
+    name: "local-review",
+    description: "local review (current branch, optional base or instructions)",
+    hints: [
+      "$ARGUMENTS"
+    ]
   },
   {
-    name: 'local-review-uncommitted',
-    description: 'local review (uncommitted changes)',
-    hints: ['$ARGUMENTS'],
+    name: "local-review-uncommitted",
+    description: "local review (uncommitted changes)",
+    hints: [
+      "$ARGUMENTS"
+    ]
   },
   {
-    name: 'review',
-    description: 'review changes [commit|branch|pr], defaults to uncommitted',
-    source: 'command',
+    name: "review",
+    description: "review changes [commit|branch|pr], defaults to uncommitted",
+    source: "command",
     subtask: true,
-    hints: ['$ARGUMENTS'],
-  },
+    hints: [
+      "$ARGUMENTS"
+    ]
+  }
 ] satisfies SlashCommandInfo[];

--- a/services/cloud-agent-next/test/e2e/README.md
+++ b/services/cloud-agent-next/test/e2e/README.md
@@ -43,7 +43,7 @@ cloud-agent-next refactor.
 
 ## Running
 
-Official SDK basic-chat acceptance (pinned `@kilocode/sdk/v2` `7.3.21`):
+Official SDK basic-chat acceptance (pinned `@kilocode/sdk/v2` `7.3.54`):
 
 ```bash
 pnpm --filter cloud-agent-next exec tsx test/e2e/sdk-basic-chat.ts

--- a/services/cloud-agent-next/test/unit/wrapper/kilo-api.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/kilo-api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createWrapperKiloClient } from '../../../wrapper/src/kilo-api.js';
+import { createWrapperKiloClient, type KiloEvent } from '../../../wrapper/src/kilo-api.js';
 import type { KiloClient as SDKClient } from '@kilocode/sdk';
 
 function createSdkClient(): SDKClient {
@@ -239,6 +239,56 @@ describe('createWrapperKiloClient network endpoints', () => {
     await expect(client.resumeNetworkWait('net_req_missing')).rejects.toThrow(
       'Network reply net_req_missing failed: missing network wait'
     );
+  });
+});
+
+describe('createWrapperKiloClient event subscription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps global synthetic events that omit properties', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          [
+            'data: {"payload":{"type":"server.connected"}}',
+            '',
+            'data: {"directory":"/workspace/other","payload":{"type":"session.idle","properties":{"sessionID":"other"}}}',
+            '',
+            'data: {"directory":"/workspace/project","payload":{"type":"message.updated","properties":{"id":"msg_1"}}}',
+            '',
+            'data: {"payload":{"type":"server.heartbeat"}}',
+            '',
+            '',
+          ].join('\n'),
+          { status: 200, headers: { 'content-type': 'text/event-stream' } }
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const client = createWrapperKiloClient(createSdkClient(), 'http://127.0.0.1:0', workspacePath);
+
+    const { stream } = await client.subscribeEvents({});
+    if (!stream) throw new Error('Expected event stream');
+
+    const events: KiloEvent[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    const request = fetchMock.mock.calls[0]?.[0];
+    expect(request).toBeInstanceOf(Request);
+    expect(new URL((request as Request).url).pathname).toBe('/global/event');
+    expect(events).toEqual([
+      { type: 'server.connected' },
+      { type: 'message.updated', properties: { id: 'msg_1' } },
+      { type: 'server.heartbeat' },
+    ]);
   });
 });
 

--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -148,7 +148,7 @@
       "image": "./Dockerfile",
       "instance_type": "standard-4",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.21",
+        "KILOCODE_CLI_VERSION": "7.3.54",
       },
       "max_instances": 400,
       "rollout_active_grace_period": 1800,
@@ -158,7 +158,7 @@
       "image": "./Dockerfile",
       "instance_type": "standard-4",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.21",
+        "KILOCODE_CLI_VERSION": "7.3.54",
       },
       "max_instances": 300,
       "rollout_active_grace_period": 1800,
@@ -168,7 +168,7 @@
       "image": "./Dockerfile.dind",
       "instance_type": "standard-3",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.21",
+        "KILOCODE_CLI_VERSION": "7.3.54",
       },
       "max_instances": 20,
       "rollout_active_grace_period": 1800,
@@ -178,7 +178,7 @@
       "image": "./Dockerfile",
       "instance_type": "standard-3",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.21",
+        "KILOCODE_CLI_VERSION": "7.3.54",
       },
       "max_instances": 300,
       "rollout_active_grace_period": 1800,
@@ -358,7 +358,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.21",
+            "KILOCODE_CLI_VERSION": "7.3.54",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,
@@ -368,7 +368,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.21",
+            "KILOCODE_CLI_VERSION": "7.3.54",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -378,7 +378,7 @@
           "image": "./Dockerfile.dind",
           "instance_type": "standard-3",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.21",
+            "KILOCODE_CLI_VERSION": "7.3.54",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -388,7 +388,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-3",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.21",
+            "KILOCODE_CLI_VERSION": "7.3.54",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,

--- a/services/cloud-agent-next/wrapper/package.json
+++ b/services/cloud-agent-next/wrapper/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@kilocode/sdk": "7.3.21",
+    "@kilocode/sdk": "7.3.54",
     "fuzzysort": "3.1.0"
   },
   "devDependencies": {

--- a/services/cloud-agent-next/wrapper/src/kilo-api.ts
+++ b/services/cloud-agent-next/wrapper/src/kilo-api.ts
@@ -2,10 +2,11 @@
  * Adapter between the wrapper and the @kilocode/sdk client.
  *
  * Provides a stable `WrapperKiloClient` interface that all wrapper modules use.
- * Session and event subscription methods use the v1 SDK client (passed in from
- * main.ts, which uses createKilo() from the root @kilocode/sdk). Methods only
- * available in the v2 API (permission reply, question reply/reject, commit
- * message) use a v2 client created internally from the same server URL.
+ * Session methods use the v1 SDK client (passed in from main.ts, which uses
+ * createKilo() from the root @kilocode/sdk). Global event subscription and
+ * methods only available in the v2 API (permission reply, question
+ * reply/reject, commit message) use a v2 client created internally from the
+ * same server URL.
  *
  * The raw SDK client is not exposed on the returned interface — all access
  * goes through named methods.
@@ -18,6 +19,30 @@ import { toSlashCommandInfo, type SlashCommandInfo } from '../../src/shared/slas
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function isKiloEvent(value: unknown): value is KiloEvent {
+  return isRecord(value) && typeof value.type === 'string';
+}
+
+function isSyntheticKiloEvent(event: KiloEvent): boolean {
+  return event.type === 'server.connected' || event.type === 'server.heartbeat';
+}
+
+async function* globalFeedPayloads(
+  stream: AsyncIterable<unknown>,
+  workspacePath: string
+): AsyncGenerator<KiloEvent> {
+  for await (const envelope of stream) {
+    if (!isRecord(envelope)) continue;
+    const payload = envelope.payload;
+    if (!isKiloEvent(payload)) continue;
+
+    const directory = envelope.directory;
+    if (isSyntheticKiloEvent(payload) || directory === workspacePath) {
+      yield payload;
+    }
+  }
 }
 
 function providerIdFromRecord(provider: Record<string, unknown>): string | undefined {
@@ -140,10 +165,9 @@ export type WrapperPtySize = {
 };
 
 /**
- * Shape of an event yielded by `subscribeEvents().stream`. Both the real SDK's
- * `event.subscribe()` generator and the fake kilo's in-memory channel produce
- * values that structurally match this — `connection.ts` only reads `type`
- * and `properties`.
+ * Shape of an event yielded by `subscribeEvents().stream`. The wrapper unwraps
+ * the SDK global event envelope before handing events to `connection.ts`, which
+ * only reads `type` and `properties`.
  */
 export type KiloEvent = {
   type?: string;
@@ -237,10 +261,9 @@ export type WrapperKiloClient = {
 // ---------------------------------------------------------------------------
 
 /**
- * Create a WrapperKiloClient. Session/event operations use the v1 sdkClient
- * (from createKilo()). Permission/question/commitMessage operations use a v2
- * client created from the same server URL, since those APIs are only available
- * in the v2 SDK.
+ * Create a WrapperKiloClient. Session operations use the v1 sdkClient (from
+ * createKilo()). Event, permission, question, and commitMessage operations use
+ * a v2 client created from the same server URL.
  */
 export function createWrapperKiloClient(
   sdkClient: SDKClient,
@@ -254,8 +277,10 @@ export function createWrapperKiloClient(
     serverUrl,
 
     subscribeEvents: async opts => {
-      const result = await sdkClient.event.subscribe({ signal: opts.signal });
-      return { stream: result.stream };
+      const result = await v2Client.global.event({ signal: opts.signal });
+      return {
+        stream: result.stream ? globalFeedPayloads(result.stream, workspacePath) : undefined,
+      };
     },
 
     createSession: async opts => {


### PR DESCRIPTION
## Summary

- Route the Cloud Agent Next wrapper event subscription through Kilo's global event feed while preserving the existing event consumer shape.
- Update Cloud Agent Next Kilo SDK/CLI pins to 7.3.54 and regenerate the default slash-command catalog.
- Update Cloudflare sandbox SDK/base images to the newest age-policy-compliant version, 0.12.1.

## Verification

N/A - no manual verification performed; this change was validated with targeted local automated checks.

## Visual Changes

N/A

## Reviewer Notes

- @cloudflare/containers remains at 0.3.7 because it is already the latest age-compliant release.
- Sandbox 0.12.1 was selected because 0.12.2 is newer than the repo minimum-release-age policy.
- The generated slash-command fallback catalog now reflects Kilo 7.3.54.