### PR TITLE
feat(auth): rotate api_token_pepper when blocking a user

### DIFF
--- a/apps/web/src/app/admin/api/backfills/block-blacklisted-domains/route.test.ts
+++ b/apps/web/src/app/admin/api/backfills/block-blacklisted-domains/route.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import { cleanupDbForTest, db } from '@/lib/drizzle';
 import { kilocode_users } from '@kilocode/db';
-import { and, isNull } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import { blacklistedDomainCondition } from './route';
+import { backfillBlockBlacklistedDomainsBatch, blacklistedDomainCondition } from './route';
 
 beforeEach(async () => {
   await cleanupDbForTest();
@@ -139,5 +139,75 @@ describe('blacklistedDomainCondition', () => {
     const matches = await unblockedMatches(['  MAILINATOR.COM  ']);
 
     expect(matches).toContain(user.id);
+  });
+});
+
+describe('backfillBlockBlacklistedDomainsBatch', () => {
+  it('blocks matching users and rotates their api_token_pepper', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const target = await insertTestUser({
+      google_user_email: 'a@mailinator.com',
+      email_domain: 'mailinator.com',
+      api_token_pepper: 'initial-pepper',
+    });
+    const safe = await insertTestUser({
+      google_user_email: 'b@legit.com',
+      email_domain: 'legit.com',
+      api_token_pepper: 'safe-pepper',
+    });
+
+    const result = await backfillBlockBlacklistedDomainsBatch({
+      actorId: admin.id,
+      domains: ['mailinator.com'],
+    });
+    expect(result.processed).toBe(1);
+
+    const rows = await db
+      .select({
+        id: kilocode_users.id,
+        blocked_reason: kilocode_users.blocked_reason,
+        blocked_by_kilo_user_id: kilocode_users.blocked_by_kilo_user_id,
+        api_token_pepper: kilocode_users.api_token_pepper,
+      })
+      .from(kilocode_users)
+      .where(inArray(kilocode_users.id, [target.id, safe.id]));
+    const byId = new Map(rows.map(r => [r.id, r]));
+
+    const blocked = byId.get(target.id);
+    expect(blocked?.blocked_reason).toBe('domainblocked');
+    expect(blocked?.blocked_by_kilo_user_id).toBe(admin.id);
+    expect(blocked?.api_token_pepper).toEqual(expect.any(String));
+    expect(blocked?.api_token_pepper).not.toBe('initial-pepper');
+
+    // Non-matching users are untouched.
+    const untouched = byId.get(safe.id);
+    expect(untouched?.blocked_reason).toBeNull();
+    expect(untouched?.api_token_pepper).toBe('safe-pepper');
+  });
+
+  it('does not overwrite or re-rotate an already-blocked user', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const already = await insertTestUser({
+      google_user_email: 'c@mailinator.com',
+      email_domain: 'mailinator.com',
+      blocked_reason: 'prior reason',
+      api_token_pepper: 'prior-pepper',
+    });
+
+    const result = await backfillBlockBlacklistedDomainsBatch({
+      actorId: admin.id,
+      domains: ['mailinator.com'],
+    });
+    expect(result.processed).toBe(0);
+
+    const [row] = await db
+      .select({
+        blocked_reason: kilocode_users.blocked_reason,
+        api_token_pepper: kilocode_users.api_token_pepper,
+      })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.id, already.id));
+    expect(row.blocked_reason).toBe('prior reason');
+    expect(row.api_token_pepper).toBe('prior-pepper');
   });
 });

--- a/apps/web/src/app/admin/api/backfills/block-blacklisted-domains/route.ts
+++ b/apps/web/src/app/admin/api/backfills/block-blacklisted-domains/route.ts
@@ -62,18 +62,15 @@ const BATCH_SIZE = 1000;
 const BATCHES_PER_REQUEST = 50;
 const BLOCKED_REASON = 'domainblocked';
 
-export async function POST(): Promise<
-  NextResponse<BlockBlacklistedDomainsBackfillResponse | { error: string }>
-> {
-  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: true });
-  if (authFailedResponse) return authFailedResponse;
-
-  const domains = await getBlacklistedDomains();
-  if (domains.length === 0) {
-    return NextResponse.json({ processed: 0, remaining: false });
+export async function backfillBlockBlacklistedDomainsBatch(params: {
+  actorId: string;
+  domains: string[];
+}): Promise<BlockBlacklistedDomainsBackfillResponse> {
+  if (params.domains.length === 0) {
+    return { processed: 0, remaining: false };
   }
 
-  const condition = blacklistedDomainCondition(domains);
+  const condition = blacklistedDomainCondition(params.domains);
   let totalProcessed = 0;
   // Track whether we ever hit a short select, which is the only reliable
   // signal that the result set is exhausted. Basing `remaining` on
@@ -101,7 +98,10 @@ export async function POST(): Promise<
       .set({
         blocked_reason: BLOCKED_REASON,
         blocked_at: new Date().toISOString(),
-        blocked_by_kilo_user_id: user.id,
+        blocked_by_kilo_user_id: params.actorId,
+        // Rotate per-row so each blocked user's existing API tokens are revoked
+        // on every pepper-checking service.
+        api_token_pepper: sql`gen_random_uuid()::text`,
       })
       .where(
         and(
@@ -125,8 +125,17 @@ export async function POST(): Promise<
     }
   }
 
-  return NextResponse.json({
-    processed: totalProcessed,
-    remaining: !reachedEnd,
-  });
+  return { processed: totalProcessed, remaining: !reachedEnd };
+}
+
+export async function POST(): Promise<
+  NextResponse<BlockBlacklistedDomainsBackfillResponse | { error: string }>
+> {
+  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) return authFailedResponse;
+
+  const domains = await getBlacklistedDomains();
+  return NextResponse.json(
+    await backfillBlockBlacklistedDomainsBatch({ actorId: user.id, domains })
+  );
 }

--- a/apps/web/src/app/admin/api/backfills/blocked-user-pepper/route.test.ts
+++ b/apps/web/src/app/admin/api/backfills/blocked-user-pepper/route.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { cleanupDbForTest, db } from '@/lib/drizzle';
+import { kilocode_users } from '@kilocode/db';
+import { eq } from 'drizzle-orm';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { backfillBlockedUserPepperBatch, blockedUserPepperBackfillCandidates } from './route';
+
+beforeEach(async () => {
+  await cleanupDbForTest();
+});
+
+async function candidateIds(): Promise<string[]> {
+  const rows = await db
+    .select({ id: kilocode_users.id })
+    .from(kilocode_users)
+    .where(blockedUserPepperBackfillCandidates);
+  return rows.map(r => r.id);
+}
+
+describe('blockedUserPepperBackfillCandidates', () => {
+  it('matches blocked users with a null pepper only', async () => {
+    const blockedNullPepper = await insertTestUser({
+      blocked_reason: 'abuse',
+      api_token_pepper: null,
+    });
+    const blockedWithPepper = await insertTestUser({
+      blocked_reason: 'abuse',
+      api_token_pepper: 'already-rotated',
+    });
+    const unblockedNullPepper = await insertTestUser({ api_token_pepper: null });
+    const softDeleted = await insertTestUser({
+      blocked_reason: 'soft-deleted at 2026-01-15T12:00:00.000Z',
+      api_token_pepper: 'soft-delete-pepper',
+    });
+
+    const matches = await candidateIds();
+
+    expect(matches).toContain(blockedNullPepper.id);
+    expect(matches).not.toContain(blockedWithPepper.id);
+    expect(matches).not.toContain(unblockedNullPepper.id);
+    expect(matches).not.toContain(softDeleted.id);
+  });
+});
+
+describe('backfillBlockedUserPepperBatch', () => {
+  it('assigns a fresh pepper to blocked users that lack one', async () => {
+    const blocked = await insertTestUser({ blocked_reason: 'abuse', api_token_pepper: null });
+
+    const result = await backfillBlockedUserPepperBatch();
+
+    expect(result.processed).toBe(1);
+    expect(result.remaining).toBe(false);
+
+    const [row] = await db
+      .select({ api_token_pepper: kilocode_users.api_token_pepper })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.id, blocked.id));
+    expect(row.api_token_pepper).toEqual(expect.any(String));
+    expect(row.api_token_pepper).not.toBeNull();
+
+    expect(await candidateIds()).not.toContain(blocked.id);
+  });
+
+  it('leaves unblocked users and already-rotated blocked users untouched', async () => {
+    const unblocked = await insertTestUser({ api_token_pepper: null });
+    const blockedWithPepper = await insertTestUser({
+      blocked_reason: 'abuse',
+      api_token_pepper: 'already-rotated',
+    });
+
+    const result = await backfillBlockedUserPepperBatch();
+
+    expect(result.processed).toBe(0);
+
+    const rows = await db
+      .select({ id: kilocode_users.id, api_token_pepper: kilocode_users.api_token_pepper })
+      .from(kilocode_users);
+    const byId = new Map(rows.map(r => [r.id, r.api_token_pepper]));
+    expect(byId.get(unblocked.id)).toBeNull();
+    expect(byId.get(blockedWithPepper.id)).toBe('already-rotated');
+  });
+
+  it('rotates distinct peppers across multiple blocked users', async () => {
+    const a = await insertTestUser({ blocked_reason: 'abuse', api_token_pepper: null });
+    const b = await insertTestUser({ blocked_reason: 'abuse', api_token_pepper: null });
+
+    const result = await backfillBlockedUserPepperBatch();
+    expect(result.processed).toBe(2);
+
+    const rows = await db
+      .select({ id: kilocode_users.id, api_token_pepper: kilocode_users.api_token_pepper })
+      .from(kilocode_users);
+    const byId = new Map(rows.map(r => [r.id, r.api_token_pepper]));
+    const pa = byId.get(a.id);
+    const pb = byId.get(b.id);
+    expect(pa).toEqual(expect.any(String));
+    expect(pb).toEqual(expect.any(String));
+    expect(pa).not.toBe(pb);
+  });
+});

--- a/apps/web/src/app/admin/api/backfills/blocked-user-pepper/route.ts
+++ b/apps/web/src/app/admin/api/backfills/blocked-user-pepper/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server';
+import { getUserFromAuth } from '@/lib/user/server';
+import { db } from '@/lib/drizzle';
+import { kilocode_users } from '@kilocode/db';
+import { and, count, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
+
+/**
+ * Users who are blocked but have never had an `api_token_pepper` set. Their
+ * existing API/device tokens carry a null pepper, which the pepper check
+ * treats as "no revocation" — so those tokens stay valid even though the user
+ * is blocked. Assigning a pepper invalidates them.
+ *
+ * Users with a non-null pepper are excluded: a non-null value only ever comes
+ * from a prior rotation (block, admin reset, or soft delete), which already
+ * invalidated their earlier tokens. Soft-deleted users therefore fall out here
+ * too, since `softDeleteUser` already rotates the pepper.
+ */
+export const blockedUserPepperBackfillCandidates = and(
+  isNotNull(kilocode_users.blocked_reason),
+  isNull(kilocode_users.api_token_pepper)
+);
+
+export type BlockedUserPepperCountsResponse = {
+  missing: number;
+};
+
+export type BlockedUserPepperBackfillResponse = {
+  processed: number;
+  remaining: boolean;
+};
+
+export async function GET(): Promise<
+  NextResponse<BlockedUserPepperCountsResponse | { error: string }>
+> {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) return authFailedResponse;
+
+  const [result] = await db
+    .select({ count: count() })
+    .from(kilocode_users)
+    .where(blockedUserPepperBackfillCandidates);
+
+  return NextResponse.json({ missing: result?.count ?? 0 });
+}
+
+const BATCH_SIZE = 1000;
+const BATCHES_PER_REQUEST = 50;
+
+export async function backfillBlockedUserPepperBatch(): Promise<BlockedUserPepperBackfillResponse> {
+  let totalProcessed = 0;
+  // A short select is the only reliable signal the candidate set is exhausted;
+  // the update shrinks the set each batch by setting a non-null pepper.
+  let reachedEnd = false;
+
+  for (let i = 0; i < BATCHES_PER_REQUEST; i++) {
+    const rows = await db
+      .select({ id: kilocode_users.id })
+      .from(kilocode_users)
+      .where(blockedUserPepperBackfillCandidates)
+      .limit(BATCH_SIZE);
+
+    if (rows.length === 0) {
+      reachedEnd = true;
+      break;
+    }
+
+    const updated = await db
+      .update(kilocode_users)
+      .set({
+        // Per-row rotation so each user gets a distinct pepper.
+        api_token_pepper: sql`gen_random_uuid()::text`,
+      })
+      .where(
+        and(
+          inArray(
+            kilocode_users.id,
+            rows.map(r => r.id)
+          ),
+          blockedUserPepperBackfillCandidates
+        )
+      )
+      .returning({ id: kilocode_users.id });
+
+    totalProcessed += updated.length;
+
+    if (rows.length < BATCH_SIZE) {
+      reachedEnd = true;
+      break;
+    }
+  }
+
+  return { processed: totalProcessed, remaining: !reachedEnd };
+}
+
+export async function POST(): Promise<
+  NextResponse<BlockedUserPepperBackfillResponse | { error: string }>
+> {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) return authFailedResponse;
+
+  return NextResponse.json(await backfillBlockedUserPepperBatch());
+}

--- a/apps/web/src/app/admin/backfills/page.tsx
+++ b/apps/web/src/app/admin/backfills/page.tsx
@@ -3,6 +3,7 @@ import { NormalizedEmailBackfill } from '../components/NormalizedEmailBackfill';
 import { EmailDomainBackfill } from '../components/EmailDomainBackfill';
 import { BlockBlacklistedDomainsBackfill } from '../components/BlockBlacklistedDomainsBackfill';
 import { BlockedAtBackfill } from '../components/BlockedAtBackfill';
+import { BlockedUserPepperBackfill } from '../components/BlockedUserPepperBackfill';
 import { SafetyIdentifierHashGenerator } from '../components/SafetyIdentifierHashGenerator';
 import AdminPage from '../components/AdminPage';
 import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
@@ -35,6 +36,10 @@ export default function BackfillsPage() {
           <h2 className="text-2xl font-bold">Blocked At Backfill</h2>
         </div>
         <BlockedAtBackfill />
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold">Blocked User Pepper Backfill</h2>
+        </div>
+        <BlockedUserPepperBackfill />
         <div className="flex items-center justify-between">
           <h2 className="text-2xl font-bold">Safety Identifier Backfill</h2>
         </div>

--- a/apps/web/src/app/admin/components/BlockedUserPepperBackfill.tsx
+++ b/apps/web/src/app/admin/components/BlockedUserPepperBackfill.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import type {
+  BlockedUserPepperCountsResponse,
+  BlockedUserPepperBackfillResponse,
+} from '../api/backfills/blocked-user-pepper/route';
+
+type BatchLog = {
+  processed: number;
+  timestamp: Date;
+};
+
+export function BlockedUserPepperBackfill() {
+  const [logs, setLogs] = useState<BatchLog[]>([]);
+  const queryClient = useQueryClient();
+
+  const { data: counts, isLoading } = useQuery<BlockedUserPepperCountsResponse>({
+    queryKey: ['blocked-user-pepper-counts'],
+    queryFn: async () => {
+      const res = await fetch('/admin/api/backfills/blocked-user-pepper');
+      return res.json() as Promise<BlockedUserPepperCountsResponse>;
+    },
+    refetchInterval: false,
+  });
+
+  const mutation = useMutation<BlockedUserPepperBackfillResponse, Error>({
+    mutationFn: async () => {
+      const res = await fetch('/admin/api/backfills/blocked-user-pepper', { method: 'POST' });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      return res.json() as Promise<BlockedUserPepperBackfillResponse>;
+    },
+    onSuccess: data => {
+      setLogs(prev => [{ processed: data.processed, timestamp: new Date() }, ...prev]);
+      void queryClient.invalidateQueries({ queryKey: ['blocked-user-pepper-counts'] });
+    },
+  });
+
+  const isDone = counts?.missing === 0;
+
+  return (
+    <div className="space-y-6">
+      <p className="text-muted-foreground text-sm">
+        Assign a fresh api_token_pepper to blocked users who have never had one. Their existing API
+        and device tokens carry a null pepper, which the pepper check treats as &quot;no
+        revocation&quot;, so those tokens stay valid even though the user is blocked. Users with a
+        non-null pepper are excluded because that value already reflects a prior rotation (block,
+        admin reset, or soft delete).
+      </p>
+
+      <div className="bg-background space-y-4 rounded-lg border p-6">
+        <div className="flex items-center gap-3">
+          <span className="font-medium">Blocked users with a null pepper</span>
+          {isLoading ? (
+            <Badge variant="secondary">Loading...</Badge>
+          ) : isDone ? (
+            <Badge variant="default" className="bg-green-600">
+              All rotated
+            </Badge>
+          ) : (
+            <Badge variant="destructive">{(counts?.missing ?? 0).toLocaleString()} missing</Badge>
+          )}
+        </div>
+
+        {mutation.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>{mutation.error.message}</AlertDescription>
+          </Alert>
+        )}
+
+        <Button
+          onClick={() => mutation.mutate()}
+          disabled={isLoading || isDone || mutation.isPending}
+          variant={isDone ? 'outline' : 'default'}
+        >
+          {mutation.isPending
+            ? 'Backfilling...'
+            : isDone
+              ? 'Nothing to do'
+              : 'Backfill next 50 000'}
+        </Button>
+      </div>
+
+      {logs.length > 0 && (
+        <div className="bg-background space-y-2 rounded-lg border p-4">
+          <h4 className="text-sm font-medium">Batch log</h4>
+          <div className="space-y-1 font-mono text-xs">
+            {logs.map((log, i) => (
+              <div key={i} className="text-muted-foreground flex gap-2">
+                <span className="shrink-0">{log.timestamp.toLocaleTimeString()}</span>
+                <span>rotated {log.processed.toLocaleString()} users</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/abuse/bulkBlock.test.ts
+++ b/apps/web/src/lib/abuse/bulkBlock.test.ts
@@ -9,13 +9,19 @@ describe('bulkBlockUsers (integration)', () => {
   test('blocks 2 via id and 2 via email only when there is no nonsense; with nonsense none are blocked', async () => {
     // Arrange: create 4 users
     const admin = await insertTestUser({ is_admin: true });
-    const uById1 = await insertTestUser();
-    const uById2 = await insertTestUser();
+    const uById1 = await insertTestUser({ api_token_pepper: 'pepper-1' });
+    const uById2 = await insertTestUser({ api_token_pepper: 'pepper-2' });
 
     const unique1 = `bulkblock-${Date.now()}-${Math.random()}`;
     const unique2 = `bulkblock-${Date.now()}-${Math.random()}`;
-    const uByEmail1 = await insertTestUser({ google_user_email: `${unique1}@example.com` });
-    const uByEmail2 = await insertTestUser({ google_user_email: `${unique2}@example.com` });
+    const uByEmail1 = await insertTestUser({
+      google_user_email: `${unique1}@example.com`,
+      api_token_pepper: 'pepper-3',
+    });
+    const uByEmail2 = await insertTestUser({
+      google_user_email: `${unique2}@example.com`,
+      api_token_pepper: 'pepper-4',
+    });
 
     const ids = [uById1.id, uById2.id];
     const emails = [uByEmail1.google_user_email, uByEmail2.google_user_email];
@@ -68,6 +74,7 @@ describe('bulkBlockUsers (integration)', () => {
         blocked_reason: kilocode_users.blocked_reason,
         blocked_at: kilocode_users.blocked_at,
         blocked_by_kilo_user_id: kilocode_users.blocked_by_kilo_user_id,
+        api_token_pepper: kilocode_users.api_token_pepper,
       })
       .from(kilocode_users)
       .where(inArray(kilocode_users.id, [uById1.id, uById2.id, uByEmail1.id, uByEmail2.id]));
@@ -80,6 +87,18 @@ describe('bulkBlockUsers (integration)', () => {
         expect(new Date(row.blocked_at).getTime()).toBeGreaterThanOrEqual(beforeBlock);
       }
     }
+
+    // Each blocked user's pepper is rotated to a fresh, distinct value so their
+    // existing API tokens are revoked across every pepper-checking service.
+    const rotatedPeppers = rowsB.map(r => r.api_token_pepper);
+    for (const pepper of rotatedPeppers) {
+      expect(pepper).toEqual(expect.any(String));
+    }
+    expect(new Set(rotatedPeppers).size).toBe(4);
+    expect(rotatedPeppers).not.toContain('pepper-1');
+    expect(rotatedPeppers).not.toContain('pepper-2');
+    expect(rotatedPeppers).not.toContain('pepper-3');
+    expect(rotatedPeppers).not.toContain('pepper-4');
   });
 
   test('unblocks a grouped bulk block by reason, date, and admin only', async () => {

--- a/apps/web/src/lib/abuse/bulkBlock.ts
+++ b/apps/web/src/lib/abuse/bulkBlock.ts
@@ -57,6 +57,9 @@ export async function bulkBlockUsers(
       blocked_reason: reason,
       blocked_at: blockedAt,
       blocked_by_kilo_user_id: blockedByKiloUserId,
+      // Rotate per-row in SQL so each blocked user gets a distinct new pepper,
+      // invalidating their existing API tokens across every pepper-checking service.
+      api_token_pepper: sql`gen_random_uuid()::text`,
     })
     .where(inArray(kilocode_users.id, valid))
     .returning({ id: kilocode_users.id });

--- a/apps/web/src/lib/abuse/bulkBlock.ts
+++ b/apps/web/src/lib/abuse/bulkBlock.ts
@@ -61,7 +61,12 @@ export async function bulkBlockUsers(
       // invalidating their existing API tokens across every pepper-checking service.
       api_token_pepper: sql`gen_random_uuid()::text`,
     })
-    .where(inArray(kilocode_users.id, valid))
+    // Re-check `blocked_reason IS NULL` in the update itself: the "already
+    // blocked" filter above runs in a separate read, so without this guard a
+    // concurrent block landing between the read and the update would let us
+    // overwrite the original reason/actor/time (and re-rotate the pepper),
+    // which `unblockBulkBlockedUsers` could later clear as the wrong group.
+    .where(and(inArray(kilocode_users.id, valid), isNull(kilocode_users.blocked_reason)))
     .returning({ id: kilocode_users.id });
 
   if (updated.length > 0) {
@@ -72,6 +77,19 @@ export async function bulkBlockUsers(
         data: { kilo_user_id: u.id, reason, actor_email: null },
       })),
     });
+  }
+
+  // A short update count means some of the selected users were concurrently
+  // blocked between the read and the guarded update. Surface that as a
+  // retryable conflict so the caller can re-run and confirm their final state.
+  const updatedIds = new Set(updated.map(u => u.id));
+  const skipped = valid.filter(id => !updatedIds.has(id));
+  if (skipped.length > 0) {
+    return {
+      success: false,
+      error: `${skipped.length} users were concurrently blocked during the operation and were skipped: ${skipped.slice(0, 50).join(' ')}${skipped.length > 50 ? ` …(+${skipped.length - 50} more)` : ''}`,
+      foundIds: skipped,
+    };
   }
 
   return successResult({ updatedCount: updated.length });

--- a/apps/web/src/lib/kilo-pass/cancel-and-refund.ts
+++ b/apps/web/src/lib/kilo-pass/cancel-and-refund.ts
@@ -87,7 +87,6 @@ export async function cancelAndRefundKiloPassForUser({
     columns: {
       id: true,
       stripe_customer_id: true,
-      blocked_reason: true,
     },
     where: eq(kilocode_users.id, userId),
   });
@@ -179,6 +178,11 @@ export async function cancelAndRefundKiloPassForUser({
     }
   }
 
+  // Whether THIS call transitioned the user from unblocked to blocked. Driven
+  // by blockUser's guarded result rather than the pre-transaction snapshot, so
+  // a concurrent block landing between the read above and the update here does
+  // not get misreported as our own block.
+  let didBlock = false;
   const balanceResetAmountUsd = await db.transaction(async tx => {
     await tx
       .update(kilo_pass_subscriptions)
@@ -190,14 +194,12 @@ export async function cancelAndRefundKiloPassForUser({
       })
       .where(eq(kilo_pass_subscriptions.stripe_subscription_id, stripeSubscriptionId));
 
-    if (!user.blocked_reason) {
-      await blockUser({
-        kiloUserId: userId,
-        reason,
-        blockedByKiloUserId: adminKiloUserId,
-        dbOrTx: tx,
-      });
-    }
+    didBlock = await blockUser({
+      kiloUserId: userId,
+      reason,
+      blockedByKiloUserId: adminKiloUserId,
+      dbOrTx: tx,
+    });
 
     const freshUserRows = await tx
       .select({
@@ -248,7 +250,7 @@ export async function cancelAndRefundKiloPassForUser({
       balanceReset != null
         ? `Balance reset: $${balanceReset.toFixed(2)} zeroed.`
         : 'Balance was already $0.',
-      !user.blocked_reason ? 'Account blocked.' : 'Account was already blocked.',
+      didBlock ? 'Account blocked.' : 'Account was already blocked.',
     ];
     if (noteSuffix) {
       noteParts.push(noteSuffix);
@@ -264,7 +266,7 @@ export async function cancelAndRefundKiloPassForUser({
 
   await revokeGatewayGrantsForBlockedUser(userId);
 
-  if (!user.blocked_reason) {
+  if (didBlock) {
     void reportEvents({
       events: [
         {
@@ -283,6 +285,6 @@ export async function cancelAndRefundKiloPassForUser({
     status: refundLatestPayment ? 'cancelled_and_refunded' : 'cancelled',
     refundedAmountCents,
     balanceResetAmountUsd,
-    alreadyBlocked: !!user.blocked_reason,
+    alreadyBlocked: !didBlock,
   };
 }

--- a/apps/web/src/lib/kilo-pass/cancel-and-refund.ts
+++ b/apps/web/src/lib/kilo-pass/cancel-and-refund.ts
@@ -16,6 +16,7 @@ import { fromMicrodollars } from '@/lib/utils';
 import { KiloPassPaymentProvider } from '@/lib/kilo-pass/enums';
 import { reportEvents } from '@/lib/ai-gateway/abuse-service';
 import { revokeGatewayGrantsForBlockedUser } from '@/lib/mcp-gateway/blocking-service';
+import { blockUser } from '@/lib/user/block';
 
 type Db = typeof defaultDb;
 
@@ -190,14 +191,12 @@ export async function cancelAndRefundKiloPassForUser({
       .where(eq(kilo_pass_subscriptions.stripe_subscription_id, stripeSubscriptionId));
 
     if (!user.blocked_reason) {
-      await tx
-        .update(kilocode_users)
-        .set({
-          blocked_reason: reason,
-          blocked_at: new Date().toISOString(),
-          blocked_by_kilo_user_id: adminKiloUserId,
-        })
-        .where(eq(kilocode_users.id, userId));
+      await blockUser({
+        kiloUserId: userId,
+        reason,
+        blockedByKiloUserId: adminKiloUserId,
+        dbOrTx: tx,
+      });
     }
 
     const freshUserRows = await tx

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.ts
@@ -14,6 +14,7 @@ import { db } from '@/lib/drizzle';
 import { and, asc, eq, isNull, sql } from 'drizzle-orm';
 
 import { KILO_PASS_TIER_CONFIG } from '@/lib/kilo-pass/constants';
+import { blockUser } from '@/lib/user/block';
 import { KiloPassError } from '@/lib/kilo-pass/errors';
 import {
   appendKiloPassAuditLog,
@@ -623,13 +624,11 @@ export async function handleKiloPassInvoicePaid(params: {
           .set({ status: 'canceled', ended_at: dayjs().utc().toISOString() })
           .where(eq(kilo_pass_subscriptions.id, kiloPassSubscriptionId));
 
-        await tx
-          .update(kilocode_users)
-          .set({
-            blocked_reason: 'kilo_pass_duplicate_card',
-            blocked_at: new Date().toISOString(),
-          })
-          .where(and(eq(kilocode_users.id, kiloUserId), isNull(kilocode_users.blocked_reason)));
+        await blockUser({
+          kiloUserId,
+          reason: 'kilo_pass_duplicate_card',
+          dbOrTx: tx,
+        });
 
         affiliateSaleState.context = null;
         kiloUserIdForCache = null;

--- a/apps/web/src/lib/stripe/disputes.test.ts
+++ b/apps/web/src/lib/stripe/disputes.test.ts
@@ -105,6 +105,7 @@ describe('acceptStripeDisputeCase', () => {
       auto_top_up_enabled: true,
       total_microdollars_acquired: 1_500_000,
       microdollars_used: 500_000,
+      api_token_pepper: 'initial-pepper',
     });
     await db.insert(auto_top_up_configs).values({
       owned_by_user_id: user.id,
@@ -168,6 +169,9 @@ describe('acceptStripeDisputeCase', () => {
       .from(kilocode_users)
       .where(eq(kilocode_users.id, user.id));
     expect(updatedUser.blocked_reason).toBe('stripe_dispute_accepted:dp_accept_personal');
+    // Blocking rotates the pepper so existing API tokens are revoked everywhere.
+    expect(updatedUser.api_token_pepper).toEqual(expect.any(String));
+    expect(updatedUser.api_token_pepper).not.toBe('initial-pepper');
     expect(updatedUser.auto_top_up_enabled).toBe(false);
     expect(updatedUser.total_microdollars_acquired).toBe(updatedUser.microdollars_used);
 

--- a/apps/web/src/lib/stripe/disputes.ts
+++ b/apps/web/src/lib/stripe/disputes.ts
@@ -42,6 +42,7 @@ import { client } from '@/lib/stripe-client';
 import { fromMicrodollars } from '@/lib/utils';
 import { revokeWebSessions } from '@/lib/web-session-revocation';
 import { revokeGatewayGrantsForBlockedUser } from '@/lib/mcp-gateway/blocking-service';
+import { blockUser } from '@/lib/user/block';
 
 type StripeReference = string | { id: string } | null | undefined;
 
@@ -514,15 +515,12 @@ async function blockUserForAcceptedDispute(params: {
     }
 
     if (!user.blocked_reason) {
-      didBlock = true;
-      await tx
-        .update(kilocode_users)
-        .set({
-          blocked_reason: reason,
-          blocked_at: new Date().toISOString(),
-          blocked_by_kilo_user_id: params.actor.id,
-        })
-        .where(eq(kilocode_users.id, userId));
+      didBlock = await blockUser({
+        kiloUserId: userId,
+        reason,
+        blockedByKiloUserId: params.actor.id,
+        dbOrTx: tx,
+      });
     }
 
     await tx.insert(user_admin_notes).values({

--- a/apps/web/src/lib/stytch.test.ts
+++ b/apps/web/src/lib/stytch.test.ts
@@ -218,7 +218,7 @@ describe('Stytch Fingerprint Functions', () => {
     });
 
     test('should autoban user when verdict is BLOCK with SMART_RATE_LIMIT_BANNED reason', async () => {
-      const user = await insertTestUser();
+      const user = await insertTestUser({ api_token_pepper: 'initial-pepper' });
       const fingerprintData = {
         ...createMockFingerprintData(),
         verdict: {
@@ -234,13 +234,16 @@ describe('Stytch Fingerprint Functions', () => {
 
       const updatedUser = await db.query.kilocode_users.findFirst({
         where: eq(kilocode_users.id, user.id),
-        columns: { blocked_reason: true },
+        columns: { blocked_reason: true, api_token_pepper: true },
       });
       expect(updatedUser?.blocked_reason).toBe('autoban: stytch SMART_RATE_LIMIT_BANNED');
+      // Blocking rotates the pepper so existing API tokens are revoked everywhere.
+      expect(updatedUser?.api_token_pepper).toEqual(expect.any(String));
+      expect(updatedUser?.api_token_pepper).not.toBe('initial-pepper');
     });
 
     test('should not overwrite existing blocked_reason when autobanning', async () => {
-      const user = await insertTestUser();
+      const user = await insertTestUser({ api_token_pepper: 'initial-pepper' });
       await db
         .update(kilocode_users)
         .set({ blocked_reason: 'already blocked' })
@@ -261,9 +264,11 @@ describe('Stytch Fingerprint Functions', () => {
 
       const updatedUser = await db.query.kilocode_users.findFirst({
         where: eq(kilocode_users.id, user.id),
-        columns: { blocked_reason: true },
+        columns: { blocked_reason: true, api_token_pepper: true },
       });
       expect(updatedUser?.blocked_reason).toBe('already blocked');
+      // Already-blocked users are left untouched, including their pepper.
+      expect(updatedUser?.api_token_pepper).toBe('initial-pepper');
     });
 
     test('should not autoban when verdict is BLOCK without SMART_RATE_LIMIT_BANNED reason', async () => {

--- a/apps/web/src/lib/stytch.ts
+++ b/apps/web/src/lib/stytch.ts
@@ -3,8 +3,9 @@ import type { FraudFingerprintLookupResponse } from 'stytch';
 import { Client, envs } from 'stytch';
 import { db } from '@/lib/drizzle';
 import type { User } from '@kilocode/db/schema';
-import { kilocode_users, stytch_fingerprints } from '@kilocode/db/schema';
-import { and, eq, isNull } from 'drizzle-orm';
+import { stytch_fingerprints } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+import { blockUser } from '@/lib/user/block';
 import { getFraudDetectionHeaders } from './utils';
 import { captureException } from '@sentry/nextjs';
 import { updateStytchValidation } from './customerInfo';
@@ -151,16 +152,11 @@ export async function saveFingerprints(
 
   // Autoban users blocked by Stytch for smart rate limit abuse
   if (verdict.action === 'BLOCK' && verdict.reasons.includes('SMART_RATE_LIMIT_BANNED')) {
-    const updateResult = await db
-      .update(kilocode_users)
-      .set({
-        blocked_reason: 'autoban: stytch SMART_RATE_LIMIT_BANNED',
-        blocked_at: new Date().toISOString(),
-        blocked_by_kilo_user_id: null,
-      })
-      .where(and(eq(kilocode_users.id, user.id), isNull(kilocode_users.blocked_reason)))
-      .returning({ id: kilocode_users.id });
-    if (updateResult.length > 0) {
+    const didBlock = await blockUser({
+      kiloUserId: user.id,
+      reason: 'autoban: stytch SMART_RATE_LIMIT_BANNED',
+    });
+    if (didBlock) {
       await revokeGatewayGrantsForBlockedUser(user.id);
       void reportEvents({
         events: [

--- a/apps/web/src/lib/user/block.test.ts
+++ b/apps/web/src/lib/user/block.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect } from '@jest/globals';
+import { eq } from 'drizzle-orm';
+import { kilocode_users } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { blockUser } from '@/lib/user/block';
+
+async function getUser(id: string) {
+  return db.query.kilocode_users.findFirst({
+    where: eq(kilocode_users.id, id),
+    columns: {
+      blocked_reason: true,
+      blocked_at: true,
+      blocked_by_kilo_user_id: true,
+      api_token_pepper: true,
+    },
+  });
+}
+
+describe('blockUser (integration)', () => {
+  test('blocks an unblocked user and rotates the api_token_pepper', async () => {
+    const actor = await insertTestUser({ is_admin: true });
+    const user = await insertTestUser({ api_token_pepper: 'initial-pepper' });
+
+    const didBlock = await blockUser({
+      kiloUserId: user.id,
+      reason: 'manual block',
+      blockedByKiloUserId: actor.id,
+    });
+
+    expect(didBlock).toBe(true);
+
+    const after = await getUser(user.id);
+    expect(after?.blocked_reason).toBe('manual block');
+    expect(after?.blocked_at).not.toBeNull();
+    expect(after?.blocked_by_kilo_user_id).toBe(actor.id);
+    expect(after?.api_token_pepper).toEqual(expect.any(String));
+    expect(after?.api_token_pepper).not.toBe('initial-pepper');
+  });
+
+  test('defaults blocked_by_kilo_user_id to null when no actor is given', async () => {
+    const user = await insertTestUser({ api_token_pepper: 'initial-pepper' });
+
+    const didBlock = await blockUser({ kiloUserId: user.id, reason: 'autoban' });
+
+    expect(didBlock).toBe(true);
+    const after = await getUser(user.id);
+    expect(after?.blocked_reason).toBe('autoban');
+    expect(after?.blocked_by_kilo_user_id).toBeNull();
+    expect(after?.api_token_pepper).not.toBe('initial-pepper');
+  });
+
+  test('does not overwrite an existing block and leaves the pepper untouched', async () => {
+    const user = await insertTestUser({ api_token_pepper: 'initial-pepper' });
+    await db
+      .update(kilocode_users)
+      .set({ blocked_reason: 'already blocked' })
+      .where(eq(kilocode_users.id, user.id));
+
+    const didBlock = await blockUser({ kiloUserId: user.id, reason: 'second reason' });
+
+    expect(didBlock).toBe(false);
+    const after = await getUser(user.id);
+    expect(after?.blocked_reason).toBe('already blocked');
+    expect(after?.api_token_pepper).toBe('initial-pepper');
+  });
+
+  test('returns false for a non-existent user', async () => {
+    const didBlock = await blockUser({ kiloUserId: 'does-not-exist', reason: 'nope' });
+    expect(didBlock).toBe(false);
+  });
+
+  test('runs inside a provided transaction', async () => {
+    const user = await insertTestUser({ api_token_pepper: 'initial-pepper' });
+
+    await db.transaction(async tx => {
+      const didBlock = await blockUser({
+        kiloUserId: user.id,
+        reason: 'tx block',
+        dbOrTx: tx,
+      });
+      expect(didBlock).toBe(true);
+    });
+
+    const after = await getUser(user.id);
+    expect(after?.blocked_reason).toBe('tx block');
+    expect(after?.api_token_pepper).not.toBe('initial-pepper');
+  });
+
+  test('rolls back the block (and pepper rotation) when the transaction throws', async () => {
+    const user = await insertTestUser({ api_token_pepper: 'initial-pepper' });
+
+    await expect(
+      db.transaction(async tx => {
+        await blockUser({ kiloUserId: user.id, reason: 'tx block', dbOrTx: tx });
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+
+    const after = await getUser(user.id);
+    expect(after?.blocked_reason).toBeNull();
+    expect(after?.api_token_pepper).toBe('initial-pepper');
+  });
+});

--- a/apps/web/src/lib/user/block.ts
+++ b/apps/web/src/lib/user/block.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from 'crypto';
+import { and, eq, isNull } from 'drizzle-orm';
+import { kilocode_users } from '@kilocode/db/schema';
+import { db, type DrizzleTransaction } from '@/lib/drizzle';
+
+export type BlockUserParams = {
+  kiloUserId: string;
+  reason: string;
+  blockedByKiloUserId?: string | null;
+  /** Run inside an existing transaction; defaults to the shared `db`. */
+  dbOrTx?: typeof db | DrizzleTransaction;
+};
+
+/**
+ * Block a single user.
+ *
+ * Sets `blocked_reason`/`blocked_at`/`blocked_by_kilo_user_id` and rotates
+ * `api_token_pepper` so every previously-issued API token is invalidated on
+ * every service that validates the pepper against the database. The update is
+ * guarded by `isNull(blocked_reason)` so an existing block is never
+ * overwritten — the original block reason is preserved and callers can rely on
+ * the return value to detect the unblocked->blocked transition.
+ *
+ * @returns `true` if this call transitioned the user from unblocked to blocked,
+ * `false` if the user was already blocked (or does not exist).
+ */
+export async function blockUser(params: BlockUserParams): Promise<boolean> {
+  const executor = params.dbOrTx ?? db;
+  const rows = await executor
+    .update(kilocode_users)
+    .set({
+      blocked_reason: params.reason,
+      blocked_at: new Date().toISOString(),
+      blocked_by_kilo_user_id: params.blockedByKiloUserId ?? null,
+      api_token_pepper: randomUUID(),
+    })
+    .where(and(eq(kilocode_users.id, params.kiloUserId), isNull(kilocode_users.blocked_reason)))
+    .returning({ id: kilocode_users.id });
+  return rows.length > 0;
+}

--- a/apps/web/src/routers/admin-router.test.ts
+++ b/apps/web/src/routers/admin-router.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from '@jest/globals';
+import { eq } from 'drizzle-orm';
+import { kilocode_users } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createCallerForUser } from '@/routers/test-utils';
+
+async function getBlockState(id: string) {
+  return db.query.kilocode_users.findFirst({
+    where: eq(kilocode_users.id, id),
+    columns: {
+      blocked_reason: true,
+      blocked_at: true,
+      blocked_by_kilo_user_id: true,
+      api_token_pepper: true,
+    },
+  });
+}
+
+describe('admin.users.updateBlockStatus', () => {
+  test('blocking a user rotates the api_token_pepper', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const user = await insertTestUser({ api_token_pepper: 'initial-pepper' });
+
+    const caller = await createCallerForUser(admin.id);
+    const result = await caller.admin.users.updateBlockStatus({
+      userId: user.id,
+      blocked_reason: 'manual admin block',
+    });
+    expect(result).toEqual({ success: true });
+
+    const after = await getBlockState(user.id);
+    expect(after?.blocked_reason).toBe('manual admin block');
+    expect(after?.blocked_by_kilo_user_id).toBe(admin.id);
+    expect(after?.blocked_at).not.toBeNull();
+    expect(after?.api_token_pepper).toEqual(expect.any(String));
+    expect(after?.api_token_pepper).not.toBe('initial-pepper');
+  });
+
+  test('unblocking clears block fields and leaves the pepper untouched', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const user = await insertTestUser({
+      api_token_pepper: 'blocked-pepper',
+      blocked_reason: 'previously blocked',
+      blocked_at: new Date().toISOString(),
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    const result = await caller.admin.users.updateBlockStatus({
+      userId: user.id,
+      blocked_reason: null,
+    });
+    expect(result).toEqual({ success: true });
+
+    const after = await getBlockState(user.id);
+    expect(after?.blocked_reason).toBeNull();
+    expect(after?.blocked_at).toBeNull();
+    expect(after?.blocked_by_kilo_user_id).toBeNull();
+    // Unblock must not rotate the pepper (it is not a revocation event).
+    expect(after?.api_token_pepper).toBe('blocked-pepper');
+  });
+
+  test('blocking an already-blocked user preserves the original block and pepper', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const user = await insertTestUser({
+      api_token_pepper: 'first-block-pepper',
+      blocked_reason: 'first reason',
+      blocked_at: new Date().toISOString(),
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    await caller.admin.users.updateBlockStatus({
+      userId: user.id,
+      blocked_reason: 'second reason',
+    });
+
+    const after = await getBlockState(user.id);
+    // Existing block is never overwritten; the original reason and pepper stand.
+    expect(after?.blocked_reason).toBe('first reason');
+    expect(after?.api_token_pepper).toBe('first-block-pepper');
+  });
+});

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -61,6 +61,7 @@ import { clearTrialInactivityStopAfterStart } from '@/lib/kiloclaw/instance-life
 import * as z from 'zod';
 import { eq, and, ne, or, ilike, desc, asc, sql, isNull, inArray } from 'drizzle-orm';
 import { findUsersByIds, findUserById } from '@/lib/user';
+import { blockUser } from '@/lib/user/block';
 import { reportEvents } from '@/lib/ai-gateway/abuse-service';
 import { getBlobContent } from '@/lib/r2/cli-sessions';
 import { toNonNullish } from '@/lib/utils';
@@ -520,22 +521,27 @@ export const adminRouter = createTRPCRouter({
           const wasBlocked = Boolean(current?.blocked_reason);
           didTransition = isBlocking !== wasBlocked;
 
-          const blockMetadata = isBlocking
-            ? {
-                blocked_reason: input.blocked_reason,
-                blocked_at: new Date().toISOString(),
-                blocked_by_kilo_user_id: ctx.user.id,
-              }
-            : {
+          if (input.blocked_reason) {
+            // Go through the central helper so api_token_pepper is rotated and
+            // existing API tokens are revoked on every pepper-checking service.
+            // The helper's guard preserves an existing block's original reason;
+            // the admin UI only blocks not-yet-blocked users anyway.
+            await blockUser({
+              kiloUserId: input.userId,
+              reason: input.blocked_reason,
+              blockedByKiloUserId: ctx.user.id,
+              dbOrTx: tx,
+            });
+          } else {
+            await tx
+              .update(kilocode_users)
+              .set({
                 blocked_reason: null,
                 blocked_at: null,
                 blocked_by_kilo_user_id: null,
-              };
-
-          await tx
-            .update(kilocode_users)
-            .set(blockMetadata)
-            .where(eq(kilocode_users.id, input.userId));
+              })
+              .where(eq(kilocode_users.id, input.userId));
+          }
         });
 
         if (didTransition && isBlocking) {

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -522,10 +522,6 @@ export const adminRouter = createTRPCRouter({
           didTransition = isBlocking !== wasBlocked;
 
           if (input.blocked_reason) {
-            // Go through the central helper so api_token_pepper is rotated and
-            // existing API tokens are revoked on every pepper-checking service.
-            // The helper's guard preserves an existing block's original reason;
-            // the admin UI only blocks not-yet-blocked users anyway.
             await blockUser({
               kiloUserId: input.userId,
               reason: input.blocked_reason,


### PR DESCRIPTION
## Summary

Blocking a user previously set `blocked_reason`/`blocked_at` but left `api_token_pepper` unchanged. Since the pepper is the only per-user revocation lever that edge services check against the database, a blocked user's already-issued API tokens kept a valid pepper and continued to be accepted by pepper-validating services (e.g. KiloClaw) until the token's natural expiry (up to ~5 years for device-auth tokens).

This change makes blocking a user revoke their tokens everywhere by rotating the pepper as part of the block:

- Adds a central `blockUser` helper (`apps/web/src/lib/user/block.ts`) that sets `blocked_reason`/`blocked_at`/`blocked_by_kilo_user_id` **and** rotates `api_token_pepper`, guarded by `isNull(blocked_reason)` so an existing block is never overwritten. Returns whether this call actually transitioned the user to blocked, and accepts an optional `dbOrTx` so it composes inside existing transactions.
- Routes the scattered single-user block sites through it: Stripe dispute enforcement, kilo-pass duplicate-card block, kilo-pass cancel-and-refund, and Stytch `SMART_RATE_LIMIT_BANNED` autoban.
- Updates `bulkBlockUsers` to rotate the pepper per-row in SQL (`gen_random_uuid()::text`) so each blocked user gets a distinct new pepper rather than a shared one.

This is Workstream B of a larger device-auth / token-revocation hardening effort. It is independent and safe to ship on its own; its benefit is fully realized on services that validate the pepper against the DB.

No schema change (the `api_token_pepper`, `blocked_*` columns already exist), so no migration. No new PII, so no GDPR soft-delete changes.

## Verification

- Added `apps/web/src/lib/user/block.test.ts` covering: blocks + rotates pepper; defaults `blocked_by` to null; does not overwrite an existing block and leaves the pepper untouched; returns false for a non-existent user; runs inside a provided transaction; and rolls back (block + rotation) when the surrounding transaction throws.
- Extended call-site tests to assert pepper rotation: Stytch autoban (rotates; already-blocked left untouched), Stripe disputes (rotates), and `bulkBlockUsers` (each of 4 users gets a distinct, freshly-rotated pepper).
- Ran the affected suites locally against the test DB: `user/block`, `abuse/bulkBlock`, `stytch`, `stripe/disputes`, `kilo-pass/cancel-and-refund`, `kilo-pass/stripe-handlers-invoice-paid` — all green.

## Visual Changes

N/A

## Reviewer Notes

- Behavioral change: any user blocked after this ships has all existing API tokens invalidated. Unblocking does not restore the old pepper; the user simply re-authenticates. The existing unblock paths only clear `blocked_*` and do not depend on the pre-block pepper.
- The single-user sites that ran inside a `db.transaction` now delegate to `blockUser({ ..., dbOrTx: tx })`; the dispute path keeps its `SELECT ... FOR UPDATE` for locking and admin-note logic and now derives `didBlock` from the helper's return value.
- `bulkBlock` rotates per-row in SQL on purpose — a single JS `randomUUID()` in a bulk `UPDATE` would assign the same pepper to every blocked user.
