### PR TITLE
feat(notifications): add upgrade nudge for legacy extension users (version < 7)

### DIFF
--- a/apps/web/src/app/api/users/notifications/route.ts
+++ b/apps/web/src/app/api/users/notifications/route.ts
@@ -2,7 +2,7 @@ import type { KiloNotification } from '@/lib/notifications';
 import { generateUserNotifications } from '@/lib/notifications';
 import { getUserFromAuth } from '@/lib/user/server';
 import { getKiloCodeVersionNumber, getXKiloCodeVersionNumber } from '@/lib/userAgent';
-import { NextRequest, NextResponse } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
   request: NextRequest

--- a/apps/web/src/app/api/users/notifications/route.ts
+++ b/apps/web/src/app/api/users/notifications/route.ts
@@ -1,7 +1,11 @@
 import type { KiloNotification } from '@/lib/notifications';
 import { generateUserNotifications } from '@/lib/notifications';
 import { getUserFromAuth } from '@/lib/user/server';
-import { getKiloCodeVersionNumber, getXKiloCodeVersionNumber } from '@/lib/userAgent';
+import {
+  getKiloCodeVersionNumber,
+  getOpenCodeKiloVersionNumber,
+  getXKiloCodeVersionNumber,
+} from '@/lib/userAgent';
 import { type NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
@@ -13,9 +17,15 @@ export async function GET(
 
   if (authFailedResponse) return authFailedResponse;
 
+  // The current extension sends its version via the `opencode-kilo-provider/<version>`
+  // User-Agent. Older clients (e.g. `Kilo-Code/<version>`) and the `X-KiloCode-Version`
+  // header are also honored. The legacy extension sends none of these, leaving the
+  // version undefined — which notifications.ts treats as a pre-versioning old client.
+  const userAgent = request.headers.get('user-agent');
   const numericExtensionVersion =
+    getOpenCodeKiloVersionNumber(userAgent) ??
+    getKiloCodeVersionNumber(userAgent) ??
     getXKiloCodeVersionNumber(request.headers.get('X-KiloCode-Version')) ??
-    getKiloCodeVersionNumber(request.headers.get('user-agent')) ??
     undefined;
 
   const notifications = await generateUserNotifications(user, { numericExtensionVersion });

--- a/apps/web/src/app/api/users/notifications/route.ts
+++ b/apps/web/src/app/api/users/notifications/route.ts
@@ -1,11 +1,7 @@
 import type { KiloNotification } from '@/lib/notifications';
 import { generateUserNotifications } from '@/lib/notifications';
 import { getUserFromAuth } from '@/lib/user/server';
-import {
-  getKiloCodeVersionNumber,
-  getOpenCodeKiloVersionNumber,
-  getXKiloCodeVersionNumber,
-} from '@/lib/userAgent';
+import { isLegacyKiloExtensionUserAgent } from '@/lib/userAgent';
 import { type NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
@@ -17,18 +13,12 @@ export async function GET(
 
   if (authFailedResponse) return authFailedResponse;
 
-  // The current extension sends its version via the `opencode-kilo-provider/<version>`
-  // User-Agent. Older clients (e.g. `Kilo-Code/<version>`) and the `X-KiloCode-Version`
-  // header are also honored. The legacy extension sends none of these, leaving the
-  // version undefined — which notifications.ts treats as a pre-versioning old client.
-  const userAgent = request.headers.get('user-agent');
-  const numericExtensionVersion =
-    getOpenCodeKiloVersionNumber(userAgent) ??
-    getKiloCodeVersionNumber(userAgent) ??
-    getXKiloCodeVersionNumber(request.headers.get('X-KiloCode-Version')) ??
-    undefined;
+  // The legacy extension calls this endpoint with axios (User-Agent: axios/<version>),
+  // while the current extension/CLI use the shared Kilo gateway headers. Detecting the
+  // axios User-Agent lets us target the legacy-extension end-of-life notice precisely.
+  const isLegacyExtension = isLegacyKiloExtensionUserAgent(request.headers.get('user-agent'));
 
-  const notifications = await generateUserNotifications(user, { numericExtensionVersion });
+  const notifications = await generateUserNotifications(user, { isLegacyExtension });
 
   return NextResponse.json({ notifications });
 }

--- a/apps/web/src/app/api/users/notifications/route.ts
+++ b/apps/web/src/app/api/users/notifications/route.ts
@@ -1,18 +1,24 @@
 import type { KiloNotification } from '@/lib/notifications';
 import { generateUserNotifications } from '@/lib/notifications';
 import { getUserFromAuth } from '@/lib/user/server';
-import { NextResponse } from 'next/server';
+import { getKiloCodeVersionNumber, getXKiloCodeVersionNumber } from '@/lib/userAgent';
+import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET(): Promise<
-  NextResponse<{ error: string } | { notifications: KiloNotification[] }>
-> {
+export async function GET(
+  request: NextRequest
+): Promise<NextResponse<{ error: string } | { notifications: KiloNotification[] }>> {
   const { user, authFailedResponse } = await getUserFromAuth({
     adminOnly: false,
   });
 
   if (authFailedResponse) return authFailedResponse;
 
-  const notifications = await generateUserNotifications(user);
+  const numericExtensionVersion =
+    getXKiloCodeVersionNumber(request.headers.get('X-KiloCode-Version')) ??
+    getKiloCodeVersionNumber(request.headers.get('user-agent')) ??
+    undefined;
+
+  const notifications = await generateUserNotifications(user, { numericExtensionVersion });
 
   return NextResponse.json({ notifications });
 }

--- a/apps/web/src/app/api/users/notifications/route.ts
+++ b/apps/web/src/app/api/users/notifications/route.ts
@@ -1,7 +1,7 @@
 import type { KiloNotification } from '@/lib/notifications';
 import { generateUserNotifications } from '@/lib/notifications';
 import { getUserFromAuth } from '@/lib/user/server';
-import { isLegacyKiloExtensionUserAgent } from '@/lib/userAgent';
+import { isLegacyKiloExtensionNotificationsUserAgent } from '@/lib/userAgent';
 import { type NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
@@ -16,7 +16,9 @@ export async function GET(
   // The legacy extension calls this endpoint with axios (User-Agent: axios/<version>),
   // while the current extension/CLI use the shared Kilo gateway headers. Detecting the
   // axios User-Agent lets us target the legacy-extension end-of-life notice precisely.
-  const isLegacyExtension = isLegacyKiloExtensionUserAgent(request.headers.get('user-agent'));
+  const isLegacyExtension = isLegacyKiloExtensionNotificationsUserAgent(
+    request.headers.get('user-agent')
+  );
 
   const notifications = await generateUserNotifications(user, { isLegacyExtension });
 

--- a/apps/web/src/lib/notifications.test.ts
+++ b/apps/web/src/lib/notifications.test.ts
@@ -1,27 +1,15 @@
 import { describe, test, expect } from '@jest/globals';
-import { passesExtensionVersionGate } from './notifications';
+import { passesLegacyExtensionGate } from './notifications';
 
-describe('passesExtensionVersionGate', () => {
-  test('always shows notifications without a version gate', () => {
-    expect(passesExtensionVersionGate({}, undefined)).toBe(true);
-    expect(passesExtensionVersionGate({}, 7.001)).toBe(true);
-    expect(passesExtensionVersionGate({ extensionVersionBelow: undefined }, 4)).toBe(true);
+describe('passesLegacyExtensionGate', () => {
+  test('always shows notifications not gated to the legacy extension', () => {
+    expect(passesLegacyExtensionGate({}, false)).toBe(true);
+    expect(passesLegacyExtensionGate({}, true)).toBe(true);
+    expect(passesLegacyExtensionGate({ showOnlyOnLegacyExtension: false }, false)).toBe(true);
   });
 
-  test('treats unknown/absent version as an old client and shows it', () => {
-    // Legacy extension sends no version headers → undefined → shown.
-    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, undefined)).toBe(true);
-  });
-
-  test('hides when the known client version is at or above the threshold', () => {
-    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 7)).toBe(false);
-    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 7.001)).toBe(false);
-    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 8)).toBe(false);
-  });
-
-  test('shows when the known client version is below the threshold', () => {
-    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 6.099009)).toBe(true);
-    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 4.082)).toBe(true);
-    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 0)).toBe(true);
+  test('shows legacy-gated notifications only to the legacy extension', () => {
+    expect(passesLegacyExtensionGate({ showOnlyOnLegacyExtension: true }, true)).toBe(true);
+    expect(passesLegacyExtensionGate({ showOnlyOnLegacyExtension: true }, false)).toBe(false);
   });
 });

--- a/apps/web/src/lib/notifications.test.ts
+++ b/apps/web/src/lib/notifications.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from '@jest/globals';
+import { passesExtensionVersionGate } from './notifications';
+
+describe('passesExtensionVersionGate', () => {
+  test('always shows notifications without a version gate', () => {
+    expect(passesExtensionVersionGate({}, undefined)).toBe(true);
+    expect(passesExtensionVersionGate({}, 7.001)).toBe(true);
+    expect(passesExtensionVersionGate({ extensionVersionBelow: undefined }, 4)).toBe(true);
+  });
+
+  test('treats unknown/absent version as an old client and shows it', () => {
+    // Legacy extension sends no version headers → undefined → shown.
+    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, undefined)).toBe(true);
+  });
+
+  test('hides when the known client version is at or above the threshold', () => {
+    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 7)).toBe(false);
+    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 7.001)).toBe(false);
+    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 8)).toBe(false);
+  });
+
+  test('shows when the known client version is below the threshold', () => {
+    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 6.099009)).toBe(true);
+    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 4.082)).toBe(true);
+    expect(passesExtensionVersionGate({ extensionVersionBelow: 7 }, 0)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -41,12 +41,12 @@ const normalUnconditionalNotifications: KiloNotification[] = [
   //if you just want a simple straightforward global message, add it here.
   {
     id: 'legacy-upgrade-june-2026',
-    title: 'A New Version of Kilo Code Is Available',
+    title: 'Legacy Kilo Code Extension: End of Life July 31, 2026',
     message:
-      "You're using an older version of Kilo Code. Upgrade to the latest version to get new models, faster performance, and the best experience.",
+      'This extension reaches end of life on July 31, 2026 — no further updates, bug fixes, or security patches after that date. Switch to the current Kilo Code extension for continued support.',
     action: {
-      actionText: 'Get the Latest Version',
-      actionURL: 'https://marketplace.visualstudio.com/items?itemName=kilocode.kilo-code',
+      actionText: 'See End of Life Notice',
+      actionURL: 'https://github.com/Kilo-Org/kilocode-legacy#legacy-ide-extensions-end-of-life',
     },
     showIn: ['extension'],
     extensionVersionBelow: 7,

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -31,10 +31,26 @@ export type KiloNotification = {
   showIn?: ('extension' | 'extension-native' | 'cli')[];
   // ISO 8601 timestamp after which this notification should no longer be shown
   expiresAt?: string;
-  // When specified, only show to extension clients whose numeric version (major + minor/1000 + patch/1_000_000) is strictly below this value.
-  // Use an integer major version (e.g. 7 means "below 7.x.x"). Hidden when the client version is unknown.
+  // When specified, only show to clients whose numeric version (major + minor/1000 + patch/1_000_000) is strictly below this value.
+  // Use an integer major version (e.g. 7 means "below 7.x.x"). An unknown/absent client
+  // version is treated as an old (pre-versioning) client and IS shown — legacy extensions
+  // send no version headers, so absence of data means "old", not "hide".
   extensionVersionBelow?: number;
 };
+
+/**
+ * Decide whether a version-gated notification should be shown to a client.
+ * Absent version data (undefined) means a legacy/pre-versioning client, which
+ * predates version headers and is therefore treated as "below" the threshold.
+ */
+export function passesExtensionVersionGate(
+  notification: Pick<KiloNotification, 'extensionVersionBelow'>,
+  numericExtensionVersion: number | undefined
+): boolean {
+  if (notification.extensionVersionBelow === undefined) return true;
+  if (numericExtensionVersion === undefined) return true;
+  return numericExtensionVersion < notification.extensionVersionBelow;
+}
 
 const normalUnconditionalNotifications: KiloNotification[] = [
   //If you need to check or personalize the notification, see examples at the bottom of this file
@@ -165,11 +181,7 @@ export async function generateUserNotifications(
   const now = new Date();
   return [...resolvedConditionalNotifications, ...normalUnconditionalNotifications].filter(n => {
     if (n.expiresAt && new Date(n.expiresAt) <= now) return false;
-    if (n.extensionVersionBelow !== undefined) {
-      // Hide when version is unknown or the client is at/above the threshold.
-      if (numericExtensionVersion === undefined) return false;
-      if (numericExtensionVersion >= n.extensionVersionBelow) return false;
-    }
+    if (!passesExtensionVersionGate(n, numericExtensionVersion)) return false;
     return true;
   });
 }

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -56,7 +56,7 @@ const normalUnconditionalNotifications: KiloNotification[] = [
     id: 'legacy-upgrade-june-2026',
     title: 'Kilo Code 5.x: End of Life July 31, 2026',
     message:
-      'Version 5.x of the Kilo Code extension reaches end of life on July 31, 2026 — no further updates, bug fixes, or security patches after that date. Upgrade to the latest version for continued support.',
+      'Kilo Code extension version 5.x reaches end of life on July 31, 2026. After that date, it will no longer receive updates, bug fixes, or security patches. Upgrade to the latest version for continued support.',
     action: {
       actionText: 'See End of Life Notice',
       actionURL: 'https://github.com/Kilo-Org/kilocode-legacy#legacy-ide-extensions-end-of-life',

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -31,25 +31,22 @@ export type KiloNotification = {
   showIn?: ('extension' | 'extension-native' | 'cli')[];
   // ISO 8601 timestamp after which this notification should no longer be shown
   expiresAt?: string;
-  // When specified, only show to clients whose numeric version (major + minor/1000 + patch/1_000_000) is strictly below this value.
-  // Use an integer major version (e.g. 7 means "below 7.x.x"). An unknown/absent client
-  // version is treated as an old (pre-versioning) client and IS shown — legacy extensions
-  // send no version headers, so absence of data means "old", not "hide".
-  extensionVersionBelow?: number;
+  // When true, only show to the legacy ("Roo-based") Kilo Code extension, identified by
+  // its axios User-Agent. Used to target end-of-life notices at legacy-extension users.
+  showOnlyOnLegacyExtension?: boolean;
 };
 
 /**
- * Decide whether a version-gated notification should be shown to a client.
- * Absent version data (undefined) means a legacy/pre-versioning client, which
- * predates version headers and is therefore treated as "below" the threshold.
+ * Decide whether a legacy-targeted notification should be shown to a client.
+ * Notifications flagged showOnlyOnLegacyExtension are shown only when the request
+ * came from the legacy extension (detected via its axios User-Agent).
  */
-export function passesExtensionVersionGate(
-  notification: Pick<KiloNotification, 'extensionVersionBelow'>,
-  numericExtensionVersion: number | undefined
+export function passesLegacyExtensionGate(
+  notification: Pick<KiloNotification, 'showOnlyOnLegacyExtension'>,
+  isLegacyExtension: boolean
 ): boolean {
-  if (notification.extensionVersionBelow === undefined) return true;
-  if (numericExtensionVersion === undefined) return true;
-  return numericExtensionVersion < notification.extensionVersionBelow;
+  if (!notification.showOnlyOnLegacyExtension) return true;
+  return isLegacyExtension;
 }
 
 const normalUnconditionalNotifications: KiloNotification[] = [
@@ -65,7 +62,7 @@ const normalUnconditionalNotifications: KiloNotification[] = [
       actionURL: 'https://github.com/Kilo-Org/kilocode-legacy#legacy-ide-extensions-end-of-life',
     },
     showIn: ['extension'],
-    extensionVersionBelow: 7,
+    showOnlyOnLegacyExtension: true,
   },
   {
     id: 'star-giveaway-june-2026',
@@ -144,7 +141,7 @@ const normalUnconditionalNotifications: KiloNotification[] = [
 
 export async function generateUserNotifications(
   user: User,
-  { numericExtensionVersion }: { numericExtensionVersion?: number } = {}
+  { isLegacyExtension = false }: { isLegacyExtension?: boolean } = {}
 ): Promise<KiloNotification[]> {
   // Pre-fetch shared data once to avoid duplicate DB queries across generators.
   // This eliminates ~5 redundant queries per request (2× userHasOrganizations,
@@ -181,7 +178,7 @@ export async function generateUserNotifications(
   const now = new Date();
   return [...resolvedConditionalNotifications, ...normalUnconditionalNotifications].filter(n => {
     if (n.expiresAt && new Date(n.expiresAt) <= now) return false;
-    if (!passesExtensionVersionGate(n, numericExtensionVersion)) return false;
+    if (!passesLegacyExtensionGate(n, isLegacyExtension)) return false;
     return true;
   });
 }

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -31,11 +31,26 @@ export type KiloNotification = {
   showIn?: ('extension' | 'extension-native' | 'cli')[];
   // ISO 8601 timestamp after which this notification should no longer be shown
   expiresAt?: string;
+  // When specified, only show to extension clients whose numeric version (major + minor/1000 + patch/1_000_000) is strictly below this value.
+  // Use an integer major version (e.g. 7 means "below 7.x.x"). Hidden when the client version is unknown.
+  extensionVersionBelow?: number;
 };
 
 const normalUnconditionalNotifications: KiloNotification[] = [
   //If you need to check or personalize the notification, see examples at the bottom of this file
   //if you just want a simple straightforward global message, add it here.
+  {
+    id: 'legacy-upgrade-june-2026',
+    title: 'A New Version of Kilo Code Is Available',
+    message:
+      "You're using an older version of Kilo Code. Upgrade to the latest version to get new models, faster performance, and the best experience.",
+    action: {
+      actionText: 'Get the Latest Version',
+      actionURL: 'https://marketplace.visualstudio.com/items?itemName=kilocode.kilo-code',
+    },
+    showIn: ['extension'],
+    extensionVersionBelow: 7,
+  },
   {
     id: 'star-giveaway-june-2026',
     title: 'GitHub Star Giveaway',
@@ -111,7 +126,10 @@ const normalUnconditionalNotifications: KiloNotification[] = [
   },
 ];
 
-export async function generateUserNotifications(user: User): Promise<KiloNotification[]> {
+export async function generateUserNotifications(
+  user: User,
+  { numericExtensionVersion }: { numericExtensionVersion?: number } = {}
+): Promise<KiloNotification[]> {
   // Pre-fetch shared data once to avoid duplicate DB queries across generators.
   // This eliminates ~5 redundant queries per request (2× userHasOrganizations,
   // 3× getUserOrganizationsWithSeats, 2× getBalanceForUser → 1+1 queries).
@@ -145,9 +163,15 @@ export async function generateUserNotifications(user: User): Promise<KiloNotific
   ).flat();
 
   const now = new Date();
-  return [...resolvedConditionalNotifications, ...normalUnconditionalNotifications].filter(
-    n => !n.expiresAt || new Date(n.expiresAt) > now
-  );
+  return [...resolvedConditionalNotifications, ...normalUnconditionalNotifications].filter(n => {
+    if (n.expiresAt && new Date(n.expiresAt) <= now) return false;
+    if (n.extensionVersionBelow !== undefined) {
+      // Hide when version is unknown or the client is at/above the threshold.
+      if (numericExtensionVersion === undefined) return false;
+      if (numericExtensionVersion >= n.extensionVersionBelow) return false;
+    }
+    return true;
+  });
 }
 
 async function generateLowCreditNotification(

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -54,9 +54,9 @@ const normalUnconditionalNotifications: KiloNotification[] = [
   //if you just want a simple straightforward global message, add it here.
   {
     id: 'legacy-upgrade-june-2026',
-    title: 'Legacy Kilo Code Extension: End of Life July 31, 2026',
+    title: 'Kilo Code 5.x: End of Life July 31, 2026',
     message:
-      'This extension reaches end of life on July 31, 2026 — no further updates, bug fixes, or security patches after that date. Switch to the current Kilo Code extension for continued support.',
+      'Version 5.x of the Kilo Code extension reaches end of life on July 31, 2026 — no further updates, bug fixes, or security patches after that date. Upgrade to the latest version for continued support.',
     action: {
       actionText: 'See End of Life Notice',
       actionURL: 'https://github.com/Kilo-Org/kilocode-legacy#legacy-ide-extensions-end-of-life',

--- a/apps/web/src/lib/userAgent.test.ts
+++ b/apps/web/src/lib/userAgent.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from '@jest/globals';
 import {
   getKiloCodeVersionNumber,
   getXKiloCodeVersionNumber,
-  isLegacyKiloExtensionUserAgent,
+  isLegacyKiloExtensionNotificationsUserAgent,
 } from './userAgent';
 
 describe('getKiloCodeVersionNumber', () => {
@@ -56,20 +56,20 @@ describe('getKiloCodeVersionNumber', () => {
   });
 });
 
-describe('isLegacyKiloExtensionUserAgent', () => {
+describe('isLegacyKiloExtensionNotificationsUserAgent', () => {
   test('matches the legacy extension axios User-Agent', () => {
-    expect(isLegacyKiloExtensionUserAgent('axios/1.7.2')).toBe(true);
-    expect(isLegacyKiloExtensionUserAgent('axios/0.27.2')).toBe(true);
+    expect(isLegacyKiloExtensionNotificationsUserAgent('axios/1.7.2')).toBe(true);
+    expect(isLegacyKiloExtensionNotificationsUserAgent('axios/0.27.2')).toBe(true);
   });
 
   test('does not match current extension, CLI, bot, or missing User-Agents', () => {
-    expect(isLegacyKiloExtensionUserAgent(null)).toBe(false);
-    expect(isLegacyKiloExtensionUserAgent(undefined)).toBe(false);
-    expect(isLegacyKiloExtensionUserAgent('')).toBe(false);
-    expect(isLegacyKiloExtensionUserAgent('opencode-kilo-provider/7.1.0')).toBe(false);
-    expect(isLegacyKiloExtensionUserAgent('opencode-kilo-provider')).toBe(false);
-    expect(isLegacyKiloExtensionUserAgent('Kilo-Code/5.1.0')).toBe(false);
-    expect(isLegacyKiloExtensionUserAgent('Mozilla/5.0 Test Browser')).toBe(false);
-    expect(isLegacyKiloExtensionUserAgent('my-axios/1.0.0')).toBe(false);
+    expect(isLegacyKiloExtensionNotificationsUserAgent(null)).toBe(false);
+    expect(isLegacyKiloExtensionNotificationsUserAgent(undefined)).toBe(false);
+    expect(isLegacyKiloExtensionNotificationsUserAgent('')).toBe(false);
+    expect(isLegacyKiloExtensionNotificationsUserAgent('opencode-kilo-provider/7.1.0')).toBe(false);
+    expect(isLegacyKiloExtensionNotificationsUserAgent('opencode-kilo-provider')).toBe(false);
+    expect(isLegacyKiloExtensionNotificationsUserAgent('Kilo-Code/5.1.0')).toBe(false);
+    expect(isLegacyKiloExtensionNotificationsUserAgent('Mozilla/5.0 Test Browser')).toBe(false);
+    expect(isLegacyKiloExtensionNotificationsUserAgent('my-axios/1.0.0')).toBe(false);
   });
 });

--- a/apps/web/src/lib/userAgent.test.ts
+++ b/apps/web/src/lib/userAgent.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from '@jest/globals';
 import {
   getKiloCodeVersionNumber,
-  getOpenCodeKiloVersionNumber,
   getXKiloCodeVersionNumber,
+  isLegacyKiloExtensionUserAgent,
 } from './userAgent';
 
 describe('getKiloCodeVersionNumber', () => {
@@ -56,24 +56,20 @@ describe('getKiloCodeVersionNumber', () => {
   });
 });
 
-describe('getOpenCodeKiloVersionNumber', () => {
-  test('returns undefined for non-opencode user agents', () => {
-    expect(getOpenCodeKiloVersionNumber(null)).toBeUndefined();
-    expect(getOpenCodeKiloVersionNumber(undefined)).toBeUndefined();
-    expect(getOpenCodeKiloVersionNumber('')).toBeUndefined();
-    expect(getOpenCodeKiloVersionNumber('Kilo-Code/7.1.0')).toBeUndefined();
-    // The Kilo CLI sends the base with no version — treated as unknown.
-    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider')).toBeUndefined();
-    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider/')).toBeUndefined();
+describe('isLegacyKiloExtensionUserAgent', () => {
+  test('matches the legacy extension axios User-Agent', () => {
+    expect(isLegacyKiloExtensionUserAgent('axios/1.7.2')).toBe(true);
+    expect(isLegacyKiloExtensionUserAgent('axios/0.27.2')).toBe(true);
   });
 
-  test('parses the current extension User-Agent', () => {
-    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider/7.1.0')).toBeCloseTo(7.001, 10);
-    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider/7.0.0')).toBeCloseTo(7, 10);
-    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider/6.99.9')).toBeCloseTo(6.099009, 10);
-    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider/7.2.3-beta')).toBeCloseTo(
-      7.002003,
-      10
-    );
+  test('does not match current extension, CLI, bot, or missing User-Agents', () => {
+    expect(isLegacyKiloExtensionUserAgent(null)).toBe(false);
+    expect(isLegacyKiloExtensionUserAgent(undefined)).toBe(false);
+    expect(isLegacyKiloExtensionUserAgent('')).toBe(false);
+    expect(isLegacyKiloExtensionUserAgent('opencode-kilo-provider/7.1.0')).toBe(false);
+    expect(isLegacyKiloExtensionUserAgent('opencode-kilo-provider')).toBe(false);
+    expect(isLegacyKiloExtensionUserAgent('Kilo-Code/5.1.0')).toBe(false);
+    expect(isLegacyKiloExtensionUserAgent('Mozilla/5.0 Test Browser')).toBe(false);
+    expect(isLegacyKiloExtensionUserAgent('my-axios/1.0.0')).toBe(false);
   });
 });

--- a/apps/web/src/lib/userAgent.test.ts
+++ b/apps/web/src/lib/userAgent.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from '@jest/globals';
-import { getKiloCodeVersionNumber, getXKiloCodeVersionNumber } from './userAgent';
+import {
+  getKiloCodeVersionNumber,
+  getOpenCodeKiloVersionNumber,
+  getXKiloCodeVersionNumber,
+} from './userAgent';
 
 describe('getKiloCodeVersionNumber', () => {
   test('returns undefined for non-Kilo-Code user agents', () => {
@@ -49,5 +53,27 @@ describe('getKiloCodeVersionNumber', () => {
   test('parses versions with pre-release tags followed by suffix', () => {
     expect(getKiloCodeVersionNumber('Kilo-Code/4.82.0-beta (Mac OS X)')).toBeCloseTo(4.082, 10);
     expect(getXKiloCodeVersionNumber('4.65.3-alpha.1 extra-info')).toBeCloseTo(4.065003, 10);
+  });
+});
+
+describe('getOpenCodeKiloVersionNumber', () => {
+  test('returns undefined for non-opencode user agents', () => {
+    expect(getOpenCodeKiloVersionNumber(null)).toBeUndefined();
+    expect(getOpenCodeKiloVersionNumber(undefined)).toBeUndefined();
+    expect(getOpenCodeKiloVersionNumber('')).toBeUndefined();
+    expect(getOpenCodeKiloVersionNumber('Kilo-Code/7.1.0')).toBeUndefined();
+    // The Kilo CLI sends the base with no version — treated as unknown.
+    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider')).toBeUndefined();
+    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider/')).toBeUndefined();
+  });
+
+  test('parses the current extension User-Agent', () => {
+    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider/7.1.0')).toBeCloseTo(7.001, 10);
+    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider/7.0.0')).toBeCloseTo(7, 10);
+    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider/6.99.9')).toBeCloseTo(6.099009, 10);
+    expect(getOpenCodeKiloVersionNumber('opencode-kilo-provider/7.2.3-beta')).toBeCloseTo(
+      7.002003,
+      10
+    );
   });
 });

--- a/apps/web/src/lib/userAgent.ts
+++ b/apps/web/src/lib/userAgent.ts
@@ -3,6 +3,17 @@ export function getKiloCodeVersionNumber(userAgent: string | null | undefined): 
   if (!userAgent || !userAgent.startsWith(userAgentPrefix)) return undefined;
   return getXKiloCodeVersionNumber(userAgent.slice(userAgentPrefix.length));
 }
+
+// The current Kilo Code extension (and Kilo CLI) send this User-Agent via the
+// shared Kilo gateway headers, e.g. `opencode-kilo-provider/7.1.0`. The CLI omits
+// the version, so a bare `opencode-kilo-provider` yields undefined.
+const openCodeUserAgentPrefix = 'opencode-kilo-provider/';
+export function getOpenCodeKiloVersionNumber(
+  userAgent: string | null | undefined
+): number | undefined {
+  if (!userAgent || !userAgent.startsWith(openCodeUserAgentPrefix)) return undefined;
+  return getXKiloCodeVersionNumber(userAgent.slice(openCodeUserAgentPrefix.length));
+}
 export function getXKiloCodeVersionNumber(
   userAgent: string | null | undefined
 ): number | undefined {

--- a/apps/web/src/lib/userAgent.ts
+++ b/apps/web/src/lib/userAgent.ts
@@ -4,11 +4,14 @@ export function getKiloCodeVersionNumber(userAgent: string | null | undefined): 
   return getXKiloCodeVersionNumber(userAgent.slice(userAgentPrefix.length));
 }
 
-// The legacy ("Roo-based") Kilo Code extension makes its API calls with axios from
+// The legacy ("Roo-based") Kilo Code extension fetches notifications with axios from
 // the Node extension host, which sends `User-Agent: axios/<version>`. The current
-// extension and CLI use the shared Kilo gateway headers instead (`opencode-kilo-provider/...`),
-// so an axios User-Agent is a reliable signal that the client is the legacy extension.
-export function isLegacyKiloExtensionUserAgent(userAgent: string | null | undefined): boolean {
+// extension and CLI use the shared Kilo gateway headers instead (`opencode-kilo-provider/...`).
+// This heuristic is only meaningful for the notifications endpoint: axios is a generic
+// HTTP client (also used for LLM calls), so it is not a general "is legacy extension" signal.
+export function isLegacyKiloExtensionNotificationsUserAgent(
+  userAgent: string | null | undefined
+): boolean {
   return !!userAgent && userAgent.startsWith('axios/');
 }
 export function getXKiloCodeVersionNumber(

--- a/apps/web/src/lib/userAgent.ts
+++ b/apps/web/src/lib/userAgent.ts
@@ -4,15 +4,12 @@ export function getKiloCodeVersionNumber(userAgent: string | null | undefined): 
   return getXKiloCodeVersionNumber(userAgent.slice(userAgentPrefix.length));
 }
 
-// The current Kilo Code extension (and Kilo CLI) send this User-Agent via the
-// shared Kilo gateway headers, e.g. `opencode-kilo-provider/7.1.0`. The CLI omits
-// the version, so a bare `opencode-kilo-provider` yields undefined.
-const openCodeUserAgentPrefix = 'opencode-kilo-provider/';
-export function getOpenCodeKiloVersionNumber(
-  userAgent: string | null | undefined
-): number | undefined {
-  if (!userAgent || !userAgent.startsWith(openCodeUserAgentPrefix)) return undefined;
-  return getXKiloCodeVersionNumber(userAgent.slice(openCodeUserAgentPrefix.length));
+// The legacy ("Roo-based") Kilo Code extension makes its API calls with axios from
+// the Node extension host, which sends `User-Agent: axios/<version>`. The current
+// extension and CLI use the shared Kilo gateway headers instead (`opencode-kilo-provider/...`),
+// so an axios User-Agent is a reliable signal that the client is the legacy extension.
+export function isLegacyKiloExtensionUserAgent(userAgent: string | null | undefined): boolean {
+  return !!userAgent && userAgent.startsWith('axios/');
 }
 export function getXKiloCodeVersionNumber(
   userAgent: string | null | undefined


### PR DESCRIPTION
## Summary

- Adds a new `extensionVersionBelow` field to `KiloNotification` to enable version-gated server-side filtering of notifications by extension major version.
- Updates the `/api/users/notifications` route to extract the client's extension version from `X-KiloCode-Version` / `User-Agent` headers and passes it to `generateUserNotifications`.
- Adds a new `legacy-upgrade-june-2026` notification targeting users on extension version < 7 (kilocode-legacy users), informing them that the legacy extension reaches end of life on **July 31, 2026** and directing them to the end-of-life notice. Current kilocode users (version ≥ 7) never see this notification.

## Verification

- Install an older (version < 7) kilocode-legacy extension build and call `/api/users/notifications` — the `legacy-upgrade-june-2026` notification should appear with the EOL messaging and link to the GitHub notice.
- Call the endpoint with a current kilocode extension (version ≥ 7) or with no version headers — the notification should **not** appear.

## Visual Changes

N/A

## Reviewer Notes

- Filtering is server-side: the route extracts the version and passes it into `generateUserNotifications`; the extension does not need to understand the new field.
- `extensionVersionBelow: 7` means any encoded float < 7.0 (i.e. major version 0–6); since minor/1000 + patch/1_000_000 < 1, this is safe for all realistic version strings.
- When version headers are absent the notification is hidden (conservative, avoids showing it to non-extension clients).
- Notification title and message are consistent with the [Legacy IDE Extensions End of Life](https://github.com/Kilo-Org/kilocode-legacy#legacy-ide-extensions-end-of-life) section in the kilocode-legacy README (EOL date: July 31, 2026).

---

Built for [Mark IJbema](https://kilo-code.slack.com/archives/D0A5633FAF2/p1782809669707179?thread_ts=1777492079.769449&cid=D0A5633FAF2) by [Kilo for Slack](https://kilo.ai/slack)