### PR TITLE
fix(worktree): preserve and sync prepare env

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "drizzle:verify-bootstrap": "bash scripts/verify-drizzle-bootstrap.sh",
     "test:e2e": "pnpm --filter web run test:e2e",
     "dependency-cycle-check": "pnpm --filter web run dependency-cycle-check",
-    "worktree:prepare": "bash scripts/worktree-prepare.sh",
+    "dev:worktree:prepare": "bash scripts/worktree-prepare.sh",
     "test:db": "docker compose -f dev/docker-compose.yml up -d --wait postgres && pnpm drizzle migrate",
     "dev:db:reset": "pnpm --filter web db:empty-database",
     "dev:start": "tsx dev/local/cli.ts up",

--- a/scripts/worktree-prepare.sh
+++ b/scripts/worktree-prepare.sh
@@ -1,10 +1,54 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Prepares a git worktree by installing dependencies, linking the Vercel
-# project, and copying .env.development.local from the main worktree.
+# project, and copying local env files from the main worktree.
 
 MAIN_WORKTREE="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
-ENV_FILE="apps/web/.env.development.local"
+MAIN_WORKTREE_REALPATH="$(cd "$MAIN_WORKTREE" && pwd -P)"
+CURRENT_WORKTREE_REALPATH="$(pwd -P)"
+ROOT_ENV_FILE=".env.local"
+WEB_ENV_FILE="apps/web/.env.development.local"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+upsert_env_line() {
+  local file="$1"
+  local line="$2"
+  local key="${line%%=*}"
+  local tmp_file="$TMP_DIR/${key}.env"
+
+  if [ -f "$file" ]; then
+    awk -v key="$key" 'index($0, key "=") != 1 { print }' "$file" > "$tmp_file"
+    cp "$tmp_file" "$file"
+  else
+    : > "$file"
+  fi
+
+  if [ -s "$file" ]; then
+    local last_byte
+    last_byte="$(tail -c 1 "$file" | od -An -tx1 | tr -d ' \n')"
+    if [ "$last_byte" != "0a" ]; then
+      printf '\n' >> "$file"
+    fi
+  fi
+
+  printf '%s\n' "$line" >> "$file"
+}
+
+ROOT_ENV_SOURCE=""
+ROOT_ENV_SOURCE_LABEL=""
+PRE_LINK_ROOT_ENV="$TMP_DIR/pre-link-root.env.local"
+POST_LINK_ROOT_ENV="$TMP_DIR/post-link-root.env.local"
+
+if [ -f "$ROOT_ENV_FILE" ]; then
+  cp "$ROOT_ENV_FILE" "$PRE_LINK_ROOT_ENV"
+  ROOT_ENV_SOURCE="$PRE_LINK_ROOT_ENV"
+  ROOT_ENV_SOURCE_LABEL="$ROOT_ENV_FILE before Vercel link"
+elif [ "$MAIN_WORKTREE_REALPATH" != "$CURRENT_WORKTREE_REALPATH" ] &&
+  [ -f "$MAIN_WORKTREE/$ROOT_ENV_FILE" ]; then
+  ROOT_ENV_SOURCE="$MAIN_WORKTREE/$ROOT_ENV_FILE"
+  ROOT_ENV_SOURCE_LABEL="main worktree"
+fi
 
 if command -v nvm &>/dev/null || [ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]; then
   echo "==> Switching to correct Node version…"
@@ -21,11 +65,30 @@ pnpm install
 echo "==> Linking Vercel project…"
 vercel link --yes --project kilocode-app --scope kilocode
 
-if [ "$(cd "$MAIN_WORKTREE" && pwd -P)" = "$(pwd -P)" ]; then
-  echo "==> Skipping $ENV_FILE copy (already in primary worktree)"
-elif [ -f "$MAIN_WORKTREE/$ENV_FILE" ]; then
-  echo "==> Copying $ENV_FILE from main worktree…"
-  cp "$MAIN_WORKTREE/$ENV_FILE" "./$ENV_FILE"
+if [ -f "$ROOT_ENV_FILE" ]; then
+  cp "$ROOT_ENV_FILE" "$POST_LINK_ROOT_ENV"
+fi
+
+if [ -n "$ROOT_ENV_SOURCE" ]; then
+  if [ "$ROOT_ENV_SOURCE" = "$PRE_LINK_ROOT_ENV" ]; then
+    echo "==> Restoring $ROOT_ENV_FILE after Vercel link…"
+  else
+    echo "==> Copying $ROOT_ENV_FILE from ${ROOT_ENV_SOURCE_LABEL}…"
+  fi
+  cp "$ROOT_ENV_SOURCE" "./$ROOT_ENV_FILE"
+
+  vercel_oidc_token_line="$(grep -m 1 '^VERCEL_OIDC_TOKEN=' "$POST_LINK_ROOT_ENV" 2>/dev/null || true)"
+  if [ -n "$vercel_oidc_token_line" ]; then
+    upsert_env_line "$ROOT_ENV_FILE" "$vercel_oidc_token_line"
+    echo "==> Preserved fresh VERCEL_OIDC_TOKEN in $ROOT_ENV_FILE"
+  fi
+fi
+
+if [ "$MAIN_WORKTREE_REALPATH" = "$CURRENT_WORKTREE_REALPATH" ]; then
+  echo "==> Skipping $WEB_ENV_FILE copy (already in primary worktree)"
+elif [ -f "$MAIN_WORKTREE/$WEB_ENV_FILE" ]; then
+  echo "==> Copying $WEB_ENV_FILE from main worktree…"
+  cp "$MAIN_WORKTREE/$WEB_ENV_FILE" "./$WEB_ENV_FILE"
 fi
 
 echo "==> Worktree ready."

--- a/scripts/worktree-prepare.sh
+++ b/scripts/worktree-prepare.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Prepares a git worktree by installing dependencies, linking the Vercel
-# project, and copying local env files from the main worktree.
+# project, copying local env files from the main worktree, and syncing the
+# web development env from the shared dev env tooling.
 
 MAIN_WORKTREE="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
 MAIN_WORKTREE_REALPATH="$(cd "$MAIN_WORKTREE" && pwd -P)"
@@ -90,5 +91,8 @@ elif [ -f "$MAIN_WORKTREE/$WEB_ENV_FILE" ]; then
   echo "==> Copying $WEB_ENV_FILE from main worktree…"
   cp "$MAIN_WORKTREE/$WEB_ENV_FILE" "./$WEB_ENV_FILE"
 fi
+
+echo "==> Syncing Next.js development env…"
+pnpm dev:env -y nextjs
 
 echo "==> Worktree ready."


### PR DESCRIPTION
## Summary
Worktree preparation now preserves local env files during Vercel linking and reuses the shared dev env sync for Next.js overrides.

### Why this change is needed
Vercel CLI now writes `.env.local` during `vercel link`, which can replace the local env file that developers expect to carry into a worktree. The prepare flow also had its own web env handling, even though `dev:env` is the shared path for keeping Next.js development env values aligned.

### How this is addressed
- Preserves an existing root `.env.local`, or copies it from the primary worktree for a fresh linked worktree.
- Keeps the fresh `VERCEL_OIDC_TOKEN` generated by `vercel link` without letting that generated file replace the rest of the local env.
- Copies `apps/web/.env.development.local` from the primary worktree when preparing a secondary worktree.
- Runs `pnpm dev:env -y nextjs` after the env files are in place so Next.js local overrides are normalized by the existing dev env tooling.
- Renames the user-facing command from `worktree:prepare` to `dev:worktree:prepare`.

## Human Verification
- `bash -n scripts/worktree-prepare.sh`
- `pnpm exec tsx --test dev/local/env-sync/plan.test.ts`

<details>
<summary>Manual worktree prepare smoke check</summary>

Mocked a detached secondary worktree with fake `pnpm` and `vercel` commands. Verified that `.env.local` was copied/restored from the primary worktree, the fresh `VERCEL_OIDC_TOKEN` from Vercel link was preserved, and `apps/web/.env.development.local` was copied into the secondary worktree.

</details>

## Reviewer Notes
### Human Reviewer Flags
- The command rename means developers should now run `pnpm dev:worktree:prepare`; `pnpm worktree:prepare` is intentionally removed.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- The script snapshots `.env.local` before `vercel link`, captures the post-link file separately, then restores the chosen source file before upserting only `VERCEL_OIDC_TOKEN`.
- The `dev:env -y nextjs` pass runs after root and web env files are in place, so it can derive values from the restored `.env.local` and update the copied web env file.

</details>
