### PR TITLE
perf(ai-gateway): read model existence from lightweight Redis lists

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
@@ -45,10 +45,29 @@ export function getLanguageModelIds(models: StoredModelMap): string[] {
     .map(model => model.id);
 }
 
-export async function getVercelModels(): Promise<ReadonlySet<string>> {
-  return new Set(getLanguageModelIds(await getVercelModelsMetadata()));
+const ModelIdsSchema = z.array(z.string());
+
+function createModelIdsFetcher(redisKey: RedisKey, name: string) {
+  return createCachedFetch<ReadonlySet<string>>(
+    async () => {
+      const raw = JSON.parse((await redisClient.get<string>(redisKey)) ?? 'null');
+      if (!Array.isArray(raw) || raw.length === 0) {
+        console.debug(`[getGatewayModels] no ${name} model ids found in Redis`);
+        return new Set<string>();
+      }
+      return new Set(ModelIdsSchema.parse(raw));
+    },
+    600_000,
+    new Set<string>()
+  );
 }
 
-export async function getOpenRouterModels(): Promise<ReadonlySet<string>> {
-  return new Set(getLanguageModelIds(await getOpenRouterModelsMetadata()));
-}
+export const getVercelModels = createModelIdsFetcher(
+  GATEWAY_METADATA_REDIS_KEYS.vercelModelIds,
+  'Vercel'
+);
+
+export const getOpenRouterModels = createModelIdsFetcher(
+  GATEWAY_METADATA_REDIS_KEYS.openrouterModelIds,
+  'OpenRouter'
+);


### PR DESCRIPTION
## Summary

Follow-up consumer change to #4320 (already merged). Repoints the existence-only readers at the lightweight model-id Redis keys that the producer now populates during provider sync:

- `getVercelModels` → `ai-gateway.metadata:vercel-model-ids`
- `getOpenRouterModels` → `ai-gateway.metadata:openrouter-model-ids`

These functions previously loaded the full model catalog (every `StoredModel` with all endpoints) just to derive a `Set<string>` of ids. They now read the small id list directly. Both callers are pure existence checks, so behavior is unchanged:

- `shouldRouteToVercel` — `vercelModels.has(vercelModelId)`
- `getAutoFreeCandidates` — `openRouterModels.has(model)`

The full-catalog fetchers (`getVercelModelsMetadata` / `getOpenRouterModelsMetadata`) remain for consumers that need endpoint metadata.

## Verification

- `pnpm --filter web exec tsgo --noEmit` passes.
- DB-backed Jest suites could not run in this environment (no Docker/Postgres). The affected functions are mocked in `resolution.test.ts` and the openrouter route tests, with signatures unchanged.

## Visual Changes

N/A

## Reviewer Notes

- Deploy only after #4320 has run at least one provider sync so the new id-list keys are populated. Until then the fetchers return an empty set (Vercel routing off, non-kilo-exclusive free auto candidates excluded) — the same safe fallback as an empty catalog.