### PR TITLE
perf(ai-gateway): mirror lightweight model-id lists to Redis

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
@@ -34,18 +34,21 @@ export const getOpenRouterModelsMetadata = createStoredModelsFetcher(
   'OpenRouter'
 );
 
-function toLanguageModelIdSet(models: StoredModelMap): ReadonlySet<string> {
-  return new Set(
-    Object.values(models)
-      .filter(model => (model.type ?? 'language') === 'language' && model.endpoints.length > 0)
-      .map(model => model.id)
-  );
+/**
+ * The ids of language models that have at least one endpoint. This is the list
+ * mirrored to the lightweight `*-model-ids` Redis keys so existence checks can
+ * avoid loading the full model catalog.
+ */
+export function getLanguageModelIds(models: StoredModelMap): string[] {
+  return Object.values(models)
+    .filter(model => (model.type ?? 'language') === 'language' && model.endpoints.length > 0)
+    .map(model => model.id);
 }
 
 export async function getVercelModels(): Promise<ReadonlySet<string>> {
-  return toLanguageModelIdSet(await getVercelModelsMetadata());
+  return new Set(getLanguageModelIds(await getVercelModelsMetadata()));
 }
 
 export async function getOpenRouterModels(): Promise<ReadonlySet<string>> {
-  return toLanguageModelIdSet(await getOpenRouterModelsMetadata());
+  return new Set(getLanguageModelIds(await getOpenRouterModelsMetadata()));
 }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -26,6 +26,7 @@ import type { StoredModel } from '@kilocode/db/schema-types';
 import { EndpointsSchema, ModelsSchema } from '@kilocode/db/schema-types';
 import { redisClient } from '@/lib/redis';
 import { GATEWAY_METADATA_REDIS_KEYS, type RedisKey } from '@/lib/redis-keys';
+import { getLanguageModelIds } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import { syncDirectByokModels } from '@/lib/ai-gateway/providers/direct-byok/sync-direct-byok';
 import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attribution-headers';
 import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelIdToVercel';
@@ -383,6 +384,8 @@ async function mirrorToRedis(values: {
     [GATEWAY_METADATA_REDIS_KEYS.allProviders, values.providers],
     [GATEWAY_METADATA_REDIS_KEYS.openrouterModels, values.openrouter],
     [GATEWAY_METADATA_REDIS_KEYS.vercelModels, values.vercel],
+    [GATEWAY_METADATA_REDIS_KEYS.openrouterModelIds, getLanguageModelIds(values.openrouter)],
+    [GATEWAY_METADATA_REDIS_KEYS.vercelModelIds, getLanguageModelIds(values.vercel)],
   ];
   if (values.openrouterProviders) {
     entries.push([GATEWAY_METADATA_REDIS_KEYS.openrouterProviders, values.openrouterProviders]);

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -23,6 +23,11 @@ export const GATEWAY_METADATA_REDIS_KEYS = {
   allProviders: redisKey('ai-gateway.metadata:all-providers'),
   openrouterModels: redisKey('ai-gateway.metadata:openrouter-models'),
   vercelModels: redisKey('ai-gateway.metadata:vercel-models'),
+  // Lightweight lists of language model ids, mirrored alongside the full
+  // catalogs above so existence checks don't need to load every model's
+  // metadata and endpoints.
+  openrouterModelIds: redisKey('ai-gateway.metadata:openrouter-model-ids'),
+  vercelModelIds: redisKey('ai-gateway.metadata:vercel-model-ids'),
   openrouterProviders: redisKey('ai-gateway.metadata:openrouter-providers'),
 } as const;
 


### PR DESCRIPTION
## Summary

First of two PRs. This **producer** change writes two new lightweight Redis items during provider sync, each containing **only** the language model ids for a gateway:

- `ai-gateway.metadata:openrouter-model-ids`
- `ai-gateway.metadata:vercel-model-ids`

The id list (language-type models with at least one endpoint) is extracted into a shared `getLanguageModelIds` helper, reused by the existing readers so there is **no behavior change**: `getVercelModels` / `getOpenRouterModels` still derive their sets from the full catalog. This PR only starts populating the new keys.

Deploying this first ensures the keys are populated before the follow-up consumer PR repoints those readers at the lightweight lists (avoiding a transient empty-set window).

## Verification

- `pnpm --filter web exec tsgo --noEmit` passes.
- No reader paths change, so runtime behavior is unchanged until the keys are consumed in the follow-up PR.

## Visual Changes

N/A

## Reviewer Notes

- Follow-up consumer PR (#4318) repoints `getVercelModels` / `getOpenRouterModels` to read these keys and should merge/deploy only after this one has run at least one sync.