### PR TITLE
fix(session-ingest): shrink cli_sessions_v2 status row lock

### DIFF
--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -54,27 +54,36 @@ import {
 const encoder = new TextEncoder();
 
 function mockDbWithSessionGuard(overrides: Record<string, unknown> = {}) {
+  // `db.select(...).from(...).where(...).limit(...)` powers both the session-exists
+  // guard and the parent-existence probe; default it to "the session exists". A
+  // test that also needs `db.execute` (the single atomic write) passes it in via
+  // `overrides`.
   const limit = vi.fn(async () => [{ session_id: 'ses_exists' }]);
   const where = vi.fn(() => ({ limit }));
   const from = vi.fn(() => ({ where }));
   const select = vi.fn(() => ({ from }));
   const db: Record<string, unknown> = { select, ...overrides };
-  // `applyMetadataChanges` runs its writes inside `db.transaction(async tx => ...)`.
-  // Forward the callback the same mocked db so tests can assert against the same
-  // `select`/`update`/`execute` mocks as if they were called directly on `tx`.
-  db.transaction = vi.fn(async (fn: (tx: typeof db) => unknown) => fn(db));
   return db;
 }
 
-function createUpdateReturningMock(rows: unknown[] = []) {
-  const updateQuery = {
-    set: vi.fn(() => updateQuery),
-    where: vi.fn(() => updateQuery),
-    returning: vi.fn(async () => rows),
-  };
+// A `cli_sessions_v2` row as returned by the single `persistSessionChanges`
+// statement, including the CTE-captured previous status/parent columns.
+function makePersistedRow(overrides: Record<string, unknown> = {}) {
   return {
-    update: vi.fn(() => updateQuery),
-    updateQuery,
+    session_id: 'ses_persisted',
+    created_at: '2026-05-05T00:00:00.000Z',
+    updated_at: '2026-05-05T00:00:01.000Z',
+    title: null,
+    created_on_platform: null,
+    organization_id: null,
+    git_url: null,
+    git_branch: null,
+    parent_session_id: null,
+    status: null,
+    status_updated_at: null,
+    previous_status: null,
+    previous_parent_session_id: null,
+    ...overrides,
   };
 }
 
@@ -407,8 +416,8 @@ describe('queue', () => {
     );
     vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
 
-    const { update } = createUpdateReturningMock();
-    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ update }) as never);
+    const execute = vi.fn(async () => ({ rows: [makePersistedRow({ session_id: 'ses_split' })] }));
+    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ execute }) as never);
 
     const items = Array.from({ length: 129 }, (_, i) => ({
       type: 'message',
@@ -466,7 +475,7 @@ describe('queue', () => {
       1,
       undefined
     );
-    expect(update).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(1);
     expect(deleteObject).toHaveBeenCalledWith('staging/split');
     expect(ack).toHaveBeenCalledTimes(1);
     expect(retry).not.toHaveBeenCalled();
@@ -584,8 +593,8 @@ describe('queue', () => {
     const ingest = vi.fn(async () => ({ changes: [] }));
     vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
 
-    const { update } = createUpdateReturningMock();
-    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ update }) as never);
+    const execute = vi.fn(async () => ({ rows: [] }));
+    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ execute }) as never);
 
     const body = '{"data":[{"type":"message","data":{"id":"msg_1"}},broken';
     const deleteObject = vi.fn(async () => undefined);
@@ -621,7 +630,7 @@ describe('queue', () => {
     );
 
     expect(ingest).not.toHaveBeenCalled();
-    expect(update).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
     expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
     expect(ack).not.toHaveBeenCalled();
     expect(deleteObject).not.toHaveBeenCalled();
@@ -640,9 +649,11 @@ describe('queue', () => {
     });
     vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
 
-    // db.select powers the session-exists guard; db.update is the metadata flush.
-    const { update } = createUpdateReturningMock();
-    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ update }) as never);
+    // db.select powers the session-exists guard; db.execute is the metadata flush.
+    const execute = vi.fn(async () => ({
+      rows: [makePersistedRow({ session_id: 'ses_partial' })],
+    }));
+    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ execute }) as never);
 
     // 129 items -> chunk 1 = 128 items (flush succeeds), chunk 2 = 1 item (flush throws).
     const items = Array.from({ length: 129 }, (_, i) => ({
@@ -686,7 +697,7 @@ describe('queue', () => {
     const firstChunkItems = (ingest.mock.calls[0] as unknown[])[0];
     expect(firstChunkItems).toHaveLength(128);
     // Its metadata change was flushed to Postgres despite the later failure.
-    expect(update).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(1);
     // The message is retried and the staging object is preserved for reprocessing.
     expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
     expect(ack).not.toHaveBeenCalled();
@@ -867,41 +878,16 @@ describe('queue status notifications', () => {
     expect(notifyUserSessionEvent).not.toHaveBeenCalled();
   });
 
-  it('rolls back the metadata update when the status update in the same transaction fails', async () => {
-    // Title and status change together. The metadata UPDATE must succeed inside the
-    // transaction, but the status CTE then fails; the whole transaction should roll
-    // back rather than leave the title change committed with the status change lost.
+  it('persists metadata and status atomically, emitting nothing if the single write fails', async () => {
+    // Title and status change together. They are persisted by one atomic
+    // `UPDATE ... RETURNING` statement, so a failure mid-write leaves nothing
+    // committed and fires no notification — no partial title write, no lost
+    // status. The message is retried so the two land together next attempt.
     vi.mocked(notifyUserSessionEvent).mockClear();
-    const { update, updateQuery } = createUpdateReturningMock([
-      {
-        session_id: 'ses_12345678901234567890123456',
-        created_at: '2026-05-05T00:00:00.000Z',
-        updated_at: '2026-05-05T00:00:01.000Z',
-        title: 'New title',
-        created_on_platform: null,
-        organization_id: null,
-        git_url: null,
-        git_branch: null,
-        parent_session_id: null,
-        status: 'busy',
-        status_updated_at: null,
-      },
-    ]);
     const execute = vi.fn(async () => {
       throw new Error('deadlock detected');
     });
-
-    // Mirror mockDbWithSessionGuard's real db.transaction semantics (run the callback
-    // against the same mocked handles, but propagate a thrown error as a rollback
-    // instead of resolving), so we can assert nothing downstream observes the
-    // metadata write as having taken effect.
-    const limit = vi.fn(async () => [{ session_id: 'ses_exists' }]);
-    const where = vi.fn(() => ({ limit }));
-    const from = vi.fn(() => ({ where }));
-    const select = vi.fn(() => ({ from }));
-    const db: Record<string, unknown> = { select, update, execute };
-    db.transaction = vi.fn(async (fn: (tx: typeof db) => unknown) => fn(db));
-    vi.mocked(getWorkerDb).mockReturnValue(db as never);
+    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ execute }) as never);
     vi.mocked(getSessionIngestDO).mockReturnValue({
       ingest: vi.fn(async () => ({
         changes: [
@@ -934,7 +920,7 @@ describe('queue status notifications', () => {
         messages: [
           {
             body: {
-              r2Key: 'ingest/status-tx-failure',
+              r2Key: 'ingest/status-write-failure',
               kiloUserId: 'usr_test',
               sessionId: 'ses_12345678901234567890123456',
               ingestVersion: 1,
@@ -949,12 +935,11 @@ describe('queue status notifications', () => {
       ctx
     );
 
-    // The metadata UPDATE ran inside the same failed transaction as the status CTE, so
-    // it must not be reported as committed and no notification should have fired.
-    expect(updateQuery.set).toHaveBeenCalledWith(expect.objectContaining({ title: 'New title' }));
+    // One atomic statement was attempted; its failure fires no notification.
+    expect(execute).toHaveBeenCalledTimes(1);
     expect(notifyUserSessionEvent).not.toHaveBeenCalled();
     // The whole message is retried so the DO's re-diffed changes get a chance to
-    // reapply the rolled-back metadata and status together on the next attempt.
+    // reapply the metadata and status together on the next attempt.
     expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
     expect(ack).not.toHaveBeenCalled();
   });

--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -58,7 +58,12 @@ function mockDbWithSessionGuard(overrides: Record<string, unknown> = {}) {
   const where = vi.fn(() => ({ limit }));
   const from = vi.fn(() => ({ where }));
   const select = vi.fn(() => ({ from }));
-  return { select, ...overrides };
+  const db: Record<string, unknown> = { select, ...overrides };
+  // `applyMetadataChanges` runs its writes inside `db.transaction(async tx => ...)`.
+  // Forward the callback the same mocked db so tests can assert against the same
+  // `select`/`update`/`execute` mocks as if they were called directly on `tx`.
+  db.transaction = vi.fn(async (fn: (tx: typeof db) => unknown) => fn(db));
+  return db;
 }
 
 function createUpdateReturningMock(rows: unknown[] = []) {
@@ -860,5 +865,97 @@ describe('queue status notifications', () => {
     expect(retry).not.toHaveBeenCalled();
     expect(execute).toHaveBeenCalledTimes(1);
     expect(notifyUserSessionEvent).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the metadata update when the status update in the same transaction fails', async () => {
+    // Title and status change together. The metadata UPDATE must succeed inside the
+    // transaction, but the status CTE then fails; the whole transaction should roll
+    // back rather than leave the title change committed with the status change lost.
+    vi.mocked(notifyUserSessionEvent).mockClear();
+    const { update, updateQuery } = createUpdateReturningMock([
+      {
+        session_id: 'ses_12345678901234567890123456',
+        created_at: '2026-05-05T00:00:00.000Z',
+        updated_at: '2026-05-05T00:00:01.000Z',
+        title: 'New title',
+        created_on_platform: null,
+        organization_id: null,
+        git_url: null,
+        git_branch: null,
+        parent_session_id: null,
+        status: 'busy',
+        status_updated_at: null,
+      },
+    ]);
+    const execute = vi.fn(async () => {
+      throw new Error('deadlock detected');
+    });
+
+    // Mirror mockDbWithSessionGuard's real db.transaction semantics (run the callback
+    // against the same mocked handles, but propagate a thrown error as a rollback
+    // instead of resolving), so we can assert nothing downstream observes the
+    // metadata write as having taken effect.
+    const limit = vi.fn(async () => [{ session_id: 'ses_exists' }]);
+    const where = vi.fn(() => ({ limit }));
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+    const db: Record<string, unknown> = { select, update, execute };
+    db.transaction = vi.fn(async (fn: (tx: typeof db) => unknown) => fn(db));
+    vi.mocked(getWorkerDb).mockReturnValue(db as never);
+    vi.mocked(getSessionIngestDO).mockReturnValue({
+      ingest: vi.fn(async () => ({
+        changes: [
+          { name: 'title', value: 'New title' },
+          { name: 'status', value: 'busy' },
+        ],
+      })),
+    } as never);
+
+    const body = JSON.stringify({
+      data: [
+        { type: 'session', data: { title: 'New title' } },
+        { type: 'session_status', data: { status: 'busy' } },
+      ],
+    });
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => new Response(body)),
+        delete: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+      },
+    } as never;
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const ctx = { waitUntil: vi.fn() } as unknown as ExecutionContext;
+
+    await queue(
+      {
+        messages: [
+          {
+            body: {
+              r2Key: 'ingest/status-tx-failure',
+              kiloUserId: 'usr_test',
+              sessionId: 'ses_12345678901234567890123456',
+              ingestVersion: 1,
+              ingestedAt: 1,
+            },
+            ack,
+            retry,
+          },
+        ],
+      } as never,
+      env,
+      ctx
+    );
+
+    // The metadata UPDATE ran inside the same failed transaction as the status CTE, so
+    // it must not be reported as committed and no notification should have fired.
+    expect(updateQuery.set).toHaveBeenCalledWith(expect.objectContaining({ title: 'New title' }));
+    expect(notifyUserSessionEvent).not.toHaveBeenCalled();
+    // The whole message is retried so the DO's re-diffed changes get a chance to
+    // reapply the rolled-back metadata and status together on the next attempt.
+    expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
+    expect(ack).not.toHaveBeenCalled();
   });
 });

--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -53,6 +53,26 @@ import {
 
 const encoder = new TextEncoder();
 
+function mockDbWithSessionGuard(overrides: Record<string, unknown> = {}) {
+  const limit = vi.fn(async () => [{ session_id: 'ses_exists' }]);
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+  return { select, ...overrides };
+}
+
+function createUpdateReturningMock(rows: unknown[] = []) {
+  const updateQuery = {
+    set: vi.fn(() => updateQuery),
+    where: vi.fn(() => updateQuery),
+    returning: vi.fn(async () => rows),
+  };
+  return {
+    update: vi.fn(() => updateQuery),
+    updateQuery,
+  };
+}
+
 function feedAll(extractor: ReturnType<typeof createItemExtractor>, json: string) {
   extractor.tokenizer.write(encoder.encode(json));
   extractor.tokenizer.end();
@@ -382,12 +402,8 @@ describe('queue', () => {
     );
     vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
 
-    const transaction = vi.fn(async () => null);
-    const limit = vi.fn(async () => [{ session_id: 'ses_split' }]);
-    const where = vi.fn(() => ({ limit }));
-    const from = vi.fn(() => ({ where }));
-    const select = vi.fn(() => ({ from }));
-    vi.mocked(getWorkerDb).mockReturnValue({ select, transaction } as never);
+    const { update } = createUpdateReturningMock();
+    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ update }) as never);
 
     const items = Array.from({ length: 129 }, (_, i) => ({
       type: 'message',
@@ -445,7 +461,7 @@ describe('queue', () => {
       1,
       undefined
     );
-    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledTimes(1);
     expect(deleteObject).toHaveBeenCalledWith('staging/split');
     expect(ack).toHaveBeenCalledTimes(1);
     expect(retry).not.toHaveBeenCalled();
@@ -563,12 +579,8 @@ describe('queue', () => {
     const ingest = vi.fn(async () => ({ changes: [] }));
     vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
 
-    const transaction = vi.fn(async () => null);
-    const limit = vi.fn(async () => [{ session_id: 'ses_malformed' }]);
-    const where = vi.fn(() => ({ limit }));
-    const from = vi.fn(() => ({ where }));
-    const select = vi.fn(() => ({ from }));
-    vi.mocked(getWorkerDb).mockReturnValue({ select, transaction } as never);
+    const { update } = createUpdateReturningMock();
+    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ update }) as never);
 
     const body = '{"data":[{"type":"message","data":{"id":"msg_1"}},broken';
     const deleteObject = vi.fn(async () => undefined);
@@ -604,7 +616,7 @@ describe('queue', () => {
     );
 
     expect(ingest).not.toHaveBeenCalled();
-    expect(transaction).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
     expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
     expect(ack).not.toHaveBeenCalled();
     expect(deleteObject).not.toHaveBeenCalled();
@@ -623,13 +635,9 @@ describe('queue', () => {
     });
     vi.mocked(getSessionIngestDO).mockReturnValue({ ingest } as never);
 
-    // db.select powers the session-exists guard; db.transaction is the metadata flush.
-    const transaction = vi.fn(async () => null);
-    const limit = vi.fn(async () => [{ session_id: 'ses_partial' }]);
-    const where = vi.fn(() => ({ limit }));
-    const from = vi.fn(() => ({ where }));
-    const select = vi.fn(() => ({ from }));
-    vi.mocked(getWorkerDb).mockReturnValue({ select, transaction } as never);
+    // db.select powers the session-exists guard; db.update is the metadata flush.
+    const { update } = createUpdateReturningMock();
+    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ update }) as never);
 
     // 129 items -> chunk 1 = 128 items (flush succeeds), chunk 2 = 1 item (flush throws).
     const items = Array.from({ length: 129 }, (_, i) => ({
@@ -673,7 +681,7 @@ describe('queue', () => {
     const firstChunkItems = (ingest.mock.calls[0] as unknown[])[0];
     expect(firstChunkItems).toHaveLength(128);
     // Its metadata change was flushed to Postgres despite the later failure.
-    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledTimes(1);
     // The message is retried and the staging object is preserved for reprocessing.
     expect(retry).toHaveBeenCalledWith({ delaySeconds: QUEUE_RETRY_DELAY_SECONDS });
     expect(ack).not.toHaveBeenCalled();
@@ -682,28 +690,22 @@ describe('queue', () => {
 });
 
 describe('computeSessionMetadataUpdates', () => {
-  const fixedNow = () => '2026-05-05T00:00:00.000Z';
-
   it('normalizes gitUrl to the canonical form before persisting', () => {
     const updates = computeSessionMetadataUpdates(
-      new Map([['gitUrl', 'https://GitHub.com/ACME/Widgets.git']]),
-      fixedNow
+      new Map([['gitUrl', 'https://GitHub.com/ACME/Widgets.git']])
     );
     expect(updates.git_url).toBe('https://github.com/acme/widgets');
   });
 
   it('collapses scp-style and ssh:// URLs to the same normalized form as https', () => {
     const fromScp = computeSessionMetadataUpdates(
-      new Map([['gitUrl', 'git@github.com:acme/widgets.git']]),
-      fixedNow
+      new Map([['gitUrl', 'git@github.com:acme/widgets.git']])
     );
     const fromSsh = computeSessionMetadataUpdates(
-      new Map([['gitUrl', 'ssh://git@github.com/acme/widgets.git']]),
-      fixedNow
+      new Map([['gitUrl', 'ssh://git@github.com/acme/widgets.git']])
     );
     const fromHttps = computeSessionMetadataUpdates(
-      new Map([['gitUrl', 'https://github.com/acme/widgets']]),
-      fixedNow
+      new Map([['gitUrl', 'https://github.com/acme/widgets']])
     );
     expect(fromScp.git_url).toBe('https://github.com/acme/widgets');
     expect(fromSsh.git_url).toBe(fromScp.git_url);
@@ -711,7 +713,7 @@ describe('computeSessionMetadataUpdates', () => {
   });
 
   it('writes null git_url when the ingest cleared the field', () => {
-    const updates = computeSessionMetadataUpdates(new Map([['gitUrl', null]]), fixedNow);
+    const updates = computeSessionMetadataUpdates(new Map([['gitUrl', null]]));
     expect(updates.git_url).toBeNull();
   });
 
@@ -720,22 +722,21 @@ describe('computeSessionMetadataUpdates', () => {
       new Map([
         ['gitBranch', 'feature/x'],
         ['title', 'hello'],
-      ]),
-      fixedNow
+      ])
     );
     expect('git_url' in updates).toBe(false);
     expect(updates.git_branch).toBe('feature/x');
     expect(updates.title).toBe('hello');
   });
 
-  it('stamps status_updated_at when status changes', () => {
-    const updates = computeSessionMetadataUpdates(new Map([['status', 'running']]), fixedNow);
-    expect(updates.status).toBe('running');
-    expect(updates.status_updated_at).toBe('2026-05-05T00:00:00.000Z');
+  it('does not include status fields in the generic metadata update', () => {
+    const updates = computeSessionMetadataUpdates(new Map([['status', 'running']]));
+    expect('status' in updates).toBe(false);
+    expect('status_updated_at' in updates).toBe(false);
   });
 
   it('ignores a null "platform" change (creation value stays sticky)', () => {
-    const updates = computeSessionMetadataUpdates(new Map([['platform', null]]), fixedNow);
+    const updates = computeSessionMetadataUpdates(new Map([['platform', null]]));
     expect('created_on_platform' in updates).toBe(false);
   });
 });
@@ -755,33 +756,10 @@ describe('queue status notifications', () => {
       parent_session_id: null,
       status: 'idle',
       status_updated_at: '2026-05-05T00:00:01.000Z',
+      previous_status: 'busy',
     };
-    const selectResults: unknown[][] = [
-      [{ session_id: persistedSession.session_id, status: 'idle' }],
-      [{ status: 'busy' }],
-      [persistedSession],
-    ];
-    const selectResult = vi.fn(async () => selectResults.shift() ?? []);
-    const select = {
-      from: vi.fn(() => select),
-      where: vi.fn(() => select),
-      limit: vi.fn(() => select),
-      for: vi.fn(() => select),
-      then: vi.fn((resolve: (value: unknown) => unknown) => resolve(selectResult())),
-    };
-    const update = {
-      set: vi.fn(() => update),
-      where: vi.fn(() => update),
-      then: vi.fn((resolve: (value: undefined) => unknown) => resolve(undefined)),
-    };
-    const dbRef: Record<string, unknown> = {};
-    const db = {
-      select: vi.fn(() => select),
-      update: vi.fn(() => update),
-      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(dbRef)),
-    } as unknown as ReturnType<typeof getWorkerDb>;
-    Object.assign(dbRef, db);
-    vi.mocked(getWorkerDb).mockReturnValue(db);
+    const execute = vi.fn(async () => ({ rows: [persistedSession] }));
+    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ execute }) as never);
     vi.mocked(getSessionIngestDO).mockReturnValue({
       ingest: vi.fn(async () => ({ changes: [{ name: 'status', value: 'idle' }] })),
     } as never);
@@ -825,6 +803,7 @@ describe('queue status notifications', () => {
     await queue(batch, env, ctx);
 
     expect(ack).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(1);
     expect(notifyUserSessionEvent).toHaveBeenCalledWith(
       env,
       'usr_test',
@@ -834,5 +813,52 @@ describe('queue status notifications', () => {
       }),
       ctx
     );
+  });
+
+  it('does not notify or stamp timestamps when the locked status is unchanged', async () => {
+    vi.mocked(notifyUserSessionEvent).mockClear();
+    const execute = vi.fn(async () => ({ rows: [] }));
+    vi.mocked(getWorkerDb).mockReturnValue(mockDbWithSessionGuard({ execute }) as never);
+    vi.mocked(getSessionIngestDO).mockReturnValue({
+      ingest: vi.fn(async () => ({ changes: [{ name: 'status', value: 'idle' }] })),
+    } as never);
+
+    const body = JSON.stringify({ data: [{ type: 'session_status', data: { status: 'idle' } }] });
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => new Response(body)),
+        delete: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+      },
+    } as never;
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const ctx = { waitUntil: vi.fn() } as unknown as ExecutionContext;
+
+    await queue(
+      {
+        messages: [
+          {
+            body: {
+              r2Key: 'ingest/status-noop',
+              kiloUserId: 'usr_test',
+              sessionId: 'ses_12345678901234567890123456',
+              ingestVersion: 1,
+              ingestedAt: 1,
+            },
+            ack,
+            retry,
+          },
+        ],
+      } as never,
+      env,
+      ctx
+    );
+
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(notifyUserSessionEvent).not.toHaveBeenCalled();
   });
 });

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -399,6 +399,12 @@ function createIngestChunker(
   return { stage, flushChunkToSessionDO };
 }
 
+type WorkerDb = ReturnType<typeof getWorkerDb>;
+// A single connection within a `db.transaction(...)` call, used so the three
+// metadata/parent/status writes below commit or roll back together while each
+// remains one round trip (no separate SELECT ... FOR UPDATE round trip).
+type WorkerTransaction = Parameters<Parameters<WorkerDb['transaction']>[0]>[0];
+
 type SessionMetadataUpdates = Partial<
   Pick<
     typeof cli_sessions_v2.$inferInsert,
@@ -454,14 +460,14 @@ export function computeSessionMetadataUpdates(
 }
 
 async function updateSessionMetadata(
-  db: ReturnType<typeof getWorkerDb>,
+  tx: WorkerTransaction,
   kiloUserId: string,
   sessionId: string,
   updates: SessionMetadataUpdates
 ): Promise<SessionEventDbRow | null> {
   if (Object.keys(updates).length === 0) return null;
 
-  const [row] = await db
+  const [row] = await tx
     .update(cli_sessions_v2)
     .set(updates)
     .where(
@@ -472,7 +478,7 @@ async function updateSessionMetadata(
 }
 
 async function updateSessionParent(
-  db: ReturnType<typeof getWorkerDb>,
+  tx: WorkerTransaction,
   kiloUserId: string,
   sessionId: string,
   parentSessionId: string | null | undefined
@@ -480,7 +486,7 @@ async function updateSessionParent(
   if (parentSessionId === undefined) return null;
 
   if (parentSessionId && parentSessionId !== sessionId) {
-    const parentRows = await db
+    const parentRows = await tx
       .select({ session_id: cli_sessions_v2.session_id })
       .from(cli_sessions_v2)
       .where(
@@ -493,7 +499,7 @@ async function updateSessionParent(
 
     if (!parentRows[0]) return null;
 
-    const [row] = await db
+    const [row] = await tx
       .update(cli_sessions_v2)
       .set({ parent_session_id: parentSessionId })
       .where(
@@ -508,7 +514,7 @@ async function updateSessionParent(
   }
 
   if (parentSessionId === null) {
-    const [row] = await db
+    const [row] = await tx
       .update(cli_sessions_v2)
       .set({ parent_session_id: null })
       .where(
@@ -530,14 +536,14 @@ type StatusTransitionRow = SessionEventDbRow & {
 };
 
 async function updateSessionStatus(
-  db: ReturnType<typeof getWorkerDb>,
+  tx: WorkerTransaction,
   kiloUserId: string,
   sessionId: string,
   status: string | null | undefined
 ): Promise<{ session: SessionEventDbRow; previousStatus: SessionStatus | null } | null> {
   if (status === undefined) return null;
 
-  const { rows } = await db.execute<StatusTransitionRow>(sql`
+  const { rows } = await tx.execute<StatusTransitionRow>(sql`
     WITH locked AS (
       SELECT status AS previous_status
       FROM cli_sessions_v2
@@ -594,18 +600,27 @@ async function applyMetadataChanges(
   const parentSessionId = mergedChanges.has('parentId')
     ? (mergedChanges.get('parentId') ?? null)
     : undefined;
-  let changedNonStatus = false;
-  let notificationRow = await updateSessionMetadata(db, kiloUserId, sessionId, updates);
-  if (notificationRow) changedNonStatus = true;
+  // All three writes run in one transaction so a failure partway through (e.g. the
+  // status update) rolls back the metadata/parent updates too. The queue consumer
+  // only re-emits metadata changes that differ from the DO's last-sent value, so a
+  // partial commit here could never be repaired by a retry. Each write remains a
+  // single statement, so the status CTE's row lock is still held for only that one
+  // round trip, not across the whole transaction.
+  const { notificationRow, changedNonStatus, statusChange } = await db.transaction(async tx => {
+    let notificationRow = await updateSessionMetadata(tx, kiloUserId, sessionId, updates);
+    let changedNonStatus = !!notificationRow;
 
-  const parentUpdateRow = await updateSessionParent(db, kiloUserId, sessionId, parentSessionId);
-  if (parentUpdateRow) {
-    changedNonStatus = true;
-    notificationRow = parentUpdateRow;
-  }
+    const parentUpdateRow = await updateSessionParent(tx, kiloUserId, sessionId, parentSessionId);
+    if (parentUpdateRow) {
+      changedNonStatus = true;
+      notificationRow = parentUpdateRow;
+    }
 
-  const statusChange = await updateSessionStatus(db, kiloUserId, sessionId, status);
-  if (statusChange) notificationRow = statusChange.session;
+    const statusChange = await updateSessionStatus(tx, kiloUserId, sessionId, status);
+    if (statusChange) notificationRow = statusChange.session;
+
+    return { notificationRow, changedNonStatus, statusChange };
+  });
 
   const notification = notificationRow
     ? {

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -9,8 +9,12 @@ import { getItemIdentity } from './util/compaction';
 import { MAX_INGEST_ITEM_BYTES, MAX_SINGLE_ITEM_BYTES } from './util/ingest-limits';
 import { getSessionIngestDO } from './dos/SessionIngestDO';
 import { withDORetry, normalizeGitUrl } from '@kilocode/worker-utils';
-import { mapSessionEventRow, notifyUserSessionEvent } from './session-events';
-import { SessionStatusSchema } from './types/user-connection-protocol';
+import {
+  mapSessionEventRow,
+  notifyUserSessionEvent,
+  type SessionEventDbRow,
+} from './session-events';
+import { SessionStatusSchema, type SessionStatus } from './types/user-connection-protocol';
 
 export interface IngestQueueMessage {
   r2Key: string;
@@ -398,27 +402,33 @@ function createIngestChunker(
 type SessionMetadataUpdates = Partial<
   Pick<
     typeof cli_sessions_v2.$inferInsert,
-    | 'title'
-    | 'created_on_platform'
-    | 'organization_id'
-    | 'git_url'
-    | 'git_branch'
-    | 'status'
-    | 'status_updated_at'
+    'title' | 'created_on_platform' | 'organization_id' | 'git_url' | 'git_branch'
   >
 >;
+
+const sessionEventReturningColumns = {
+  session_id: cli_sessions_v2.session_id,
+  created_at: cli_sessions_v2.created_at,
+  updated_at: cli_sessions_v2.updated_at,
+  title: cli_sessions_v2.title,
+  created_on_platform: cli_sessions_v2.created_on_platform,
+  organization_id: cli_sessions_v2.organization_id,
+  git_url: cli_sessions_v2.git_url,
+  git_branch: cli_sessions_v2.git_branch,
+  parent_session_id: cli_sessions_v2.parent_session_id,
+  status: cli_sessions_v2.status,
+  status_updated_at: cli_sessions_v2.status_updated_at,
+};
 
 /**
  * Build the `cli_sessions_v2` partial update from a set of metadata changes.
  *
  * `git_url` is passed through `normalizeGitUrl` on write so that the
  * `github_branch_pull_requests` cache (keyed on the canonical form) can
- * match new sessions without per-read normalization. Status bumps carry
- * `status_updated_at = now()`.
+ * match new sessions without per-read normalization.
  */
 export function computeSessionMetadataUpdates(
-  mergedChanges: Map<string, string | null>,
-  now: () => string = () => new Date().toISOString()
+  mergedChanges: Map<string, string | null>
 ): SessionMetadataUpdates {
   const updates: SessionMetadataUpdates = {};
 
@@ -439,12 +449,134 @@ export function computeSessionMetadataUpdates(
   if (mergedChanges.has('gitBranch')) {
     updates.git_branch = mergedChanges.get('gitBranch') ?? null;
   }
-  if (mergedChanges.has('status')) {
-    updates.status = mergedChanges.get('status') ?? null;
-    updates.status_updated_at = now();
-  }
 
   return updates;
+}
+
+async function updateSessionMetadata(
+  db: ReturnType<typeof getWorkerDb>,
+  kiloUserId: string,
+  sessionId: string,
+  updates: SessionMetadataUpdates
+): Promise<SessionEventDbRow | null> {
+  if (Object.keys(updates).length === 0) return null;
+
+  const [row] = await db
+    .update(cli_sessions_v2)
+    .set(updates)
+    .where(
+      and(eq(cli_sessions_v2.session_id, sessionId), eq(cli_sessions_v2.kilo_user_id, kiloUserId))
+    )
+    .returning(sessionEventReturningColumns);
+  return row ?? null;
+}
+
+async function updateSessionParent(
+  db: ReturnType<typeof getWorkerDb>,
+  kiloUserId: string,
+  sessionId: string,
+  parentSessionId: string | null | undefined
+): Promise<SessionEventDbRow | null> {
+  if (parentSessionId === undefined) return null;
+
+  if (parentSessionId && parentSessionId !== sessionId) {
+    const parentRows = await db
+      .select({ session_id: cli_sessions_v2.session_id })
+      .from(cli_sessions_v2)
+      .where(
+        and(
+          eq(cli_sessions_v2.session_id, parentSessionId),
+          eq(cli_sessions_v2.kilo_user_id, kiloUserId)
+        )
+      )
+      .limit(1);
+
+    if (!parentRows[0]) return null;
+
+    const [row] = await db
+      .update(cli_sessions_v2)
+      .set({ parent_session_id: parentSessionId })
+      .where(
+        and(
+          eq(cli_sessions_v2.session_id, sessionId),
+          eq(cli_sessions_v2.kilo_user_id, kiloUserId),
+          sql`${cli_sessions_v2.parent_session_id} IS DISTINCT FROM ${parentSessionId}`
+        )
+      )
+      .returning(sessionEventReturningColumns);
+    return row ?? null;
+  }
+
+  if (parentSessionId === null) {
+    const [row] = await db
+      .update(cli_sessions_v2)
+      .set({ parent_session_id: null })
+      .where(
+        and(
+          eq(cli_sessions_v2.session_id, sessionId),
+          eq(cli_sessions_v2.kilo_user_id, kiloUserId),
+          sql`${cli_sessions_v2.parent_session_id} IS DISTINCT FROM ${parentSessionId}`
+        )
+      )
+      .returning(sessionEventReturningColumns);
+    return row ?? null;
+  }
+
+  return null;
+}
+
+type StatusTransitionRow = SessionEventDbRow & {
+  previous_status: string | null;
+};
+
+async function updateSessionStatus(
+  db: ReturnType<typeof getWorkerDb>,
+  kiloUserId: string,
+  sessionId: string,
+  status: string | null | undefined
+): Promise<{ session: SessionEventDbRow; previousStatus: SessionStatus | null } | null> {
+  if (status === undefined) return null;
+
+  const { rows } = await db.execute<StatusTransitionRow>(sql`
+    WITH locked AS (
+      SELECT status AS previous_status
+      FROM cli_sessions_v2
+      WHERE session_id = ${sessionId}
+        AND kilo_user_id = ${kiloUserId}
+      FOR UPDATE
+    ), updated AS (
+      UPDATE cli_sessions_v2
+      SET
+        status = ${status},
+        status_updated_at = now(),
+        updated_at = now()
+      FROM locked
+      WHERE cli_sessions_v2.session_id = ${sessionId}
+        AND cli_sessions_v2.kilo_user_id = ${kiloUserId}
+        AND locked.previous_status IS DISTINCT FROM ${status}
+      RETURNING
+        cli_sessions_v2.session_id,
+        cli_sessions_v2.created_at,
+        cli_sessions_v2.updated_at,
+        cli_sessions_v2.title,
+        cli_sessions_v2.created_on_platform,
+        cli_sessions_v2.organization_id,
+        cli_sessions_v2.git_url,
+        cli_sessions_v2.git_branch,
+        cli_sessions_v2.parent_session_id,
+        cli_sessions_v2.status,
+        cli_sessions_v2.status_updated_at,
+        (SELECT previous_status FROM locked) AS previous_status
+    )
+    SELECT * FROM updated
+  `);
+  const row = rows[0];
+  if (!row) return null;
+
+  return {
+    session: row,
+    previousStatus: SessionStatusSchema.nullable().parse(row.previous_status),
+  };
 }
 
 async function applyMetadataChanges(
@@ -462,119 +594,27 @@ async function applyMetadataChanges(
   const parentSessionId = mergedChanges.has('parentId')
     ? (mergedChanges.get('parentId') ?? null)
     : undefined;
-  const changedNonStatus =
-    mergedChanges.has('title') ||
-    mergedChanges.has('platform') ||
-    mergedChanges.has('orgId') ||
-    mergedChanges.has('gitUrl') ||
-    mergedChanges.has('gitBranch') ||
-    parentSessionId !== undefined;
+  let changedNonStatus = false;
+  let notificationRow = await updateSessionMetadata(db, kiloUserId, sessionId, updates);
+  if (notificationRow) changedNonStatus = true;
 
-  const notification = await db.transaction(async tx => {
-    const statusChange =
-      status === undefined
-        ? { changed: false, previousStatus: null }
-        : await (async () => {
-            const [statusRow] = await tx
-              .select({ status: cli_sessions_v2.status })
-              .from(cli_sessions_v2)
-              .where(
-                and(
-                  eq(cli_sessions_v2.session_id, sessionId),
-                  eq(cli_sessions_v2.kilo_user_id, kiloUserId)
-                )
-              )
-              .limit(1)
-              .for('update');
-            if (!statusRow) return null;
-            const previousStatus = SessionStatusSchema.nullable().parse(statusRow.status);
-            return { changed: status !== previousStatus, previousStatus };
-          })();
+  const parentUpdateRow = await updateSessionParent(db, kiloUserId, sessionId, parentSessionId);
+  if (parentUpdateRow) {
+    changedNonStatus = true;
+    notificationRow = parentUpdateRow;
+  }
 
-    if (!statusChange) return null;
+  const statusChange = await updateSessionStatus(db, kiloUserId, sessionId, status);
+  if (statusChange) notificationRow = statusChange.session;
 
-    if (Object.keys(updates).length > 0) {
-      await tx
-        .update(cli_sessions_v2)
-        .set(updates)
-        .where(
-          and(
-            eq(cli_sessions_v2.session_id, sessionId),
-            eq(cli_sessions_v2.kilo_user_id, kiloUserId)
-          )
-        );
-    }
-
-    if (parentSessionId !== undefined) {
-      if (parentSessionId && parentSessionId !== sessionId) {
-        const parentRows = await tx
-          .select({ session_id: cli_sessions_v2.session_id })
-          .from(cli_sessions_v2)
-          .where(
-            and(
-              eq(cli_sessions_v2.session_id, parentSessionId),
-              eq(cli_sessions_v2.kilo_user_id, kiloUserId)
-            )
-          )
-          .limit(1);
-
-        if (parentRows[0]) {
-          await tx
-            .update(cli_sessions_v2)
-            .set({ parent_session_id: parentSessionId })
-            .where(
-              and(
-                eq(cli_sessions_v2.session_id, sessionId),
-                eq(cli_sessions_v2.kilo_user_id, kiloUserId),
-                sql`${cli_sessions_v2.parent_session_id} IS DISTINCT FROM ${parentSessionId}`
-              )
-            );
-        }
-      } else if (parentSessionId === null) {
-        await tx
-          .update(cli_sessions_v2)
-          .set({ parent_session_id: null })
-          .where(
-            and(
-              eq(cli_sessions_v2.session_id, sessionId),
-              eq(cli_sessions_v2.kilo_user_id, kiloUserId),
-              sql`${cli_sessions_v2.parent_session_id} IS DISTINCT FROM ${parentSessionId}`
-            )
-          );
+  const notification = notificationRow
+    ? {
+        changedNonStatus,
+        changedStatus: !!statusChange,
+        previousStatus: statusChange?.previousStatus ?? null,
+        session: mapSessionEventRow(notificationRow),
       }
-    }
-
-    if (!changedNonStatus && !statusChange.changed) return null;
-
-    const [persistedRow] = await tx
-      .select({
-        session_id: cli_sessions_v2.session_id,
-        created_at: cli_sessions_v2.created_at,
-        updated_at: cli_sessions_v2.updated_at,
-        title: cli_sessions_v2.title,
-        created_on_platform: cli_sessions_v2.created_on_platform,
-        organization_id: cli_sessions_v2.organization_id,
-        git_url: cli_sessions_v2.git_url,
-        git_branch: cli_sessions_v2.git_branch,
-        parent_session_id: cli_sessions_v2.parent_session_id,
-        status: cli_sessions_v2.status,
-        status_updated_at: cli_sessions_v2.status_updated_at,
-      })
-      .from(cli_sessions_v2)
-      .where(
-        and(eq(cli_sessions_v2.session_id, sessionId), eq(cli_sessions_v2.kilo_user_id, kiloUserId))
-      )
-      .limit(1);
-
-    if (!persistedRow) return null;
-
-    return {
-      changedNonStatus,
-      changedStatus: statusChange.changed,
-      previousStatus: statusChange.previousStatus,
-      session: mapSessionEventRow(persistedRow),
-    };
-  });
+    : null;
   if (!notification) return;
 
   if (notification.changedNonStatus) {

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql } from 'drizzle-orm';
+import { eq, and, sql, type SQL } from 'drizzle-orm';
 import { getWorkerDb } from '@kilocode/db/client';
 import { cli_sessions_v2 } from '@kilocode/db/schema';
 import { Tokenizer, TokenParser, TokenType } from '@streamparser/json';
@@ -14,7 +14,7 @@ import {
   notifyUserSessionEvent,
   type SessionEventDbRow,
 } from './session-events';
-import { SessionStatusSchema, type SessionStatus } from './types/user-connection-protocol';
+import { SessionStatusSchema } from './types/user-connection-protocol';
 
 export interface IngestQueueMessage {
   r2Key: string;
@@ -400,10 +400,6 @@ function createIngestChunker(
 }
 
 type WorkerDb = ReturnType<typeof getWorkerDb>;
-// A single connection within a `db.transaction(...)` call, used so the three
-// metadata/parent/status writes below commit or roll back together while each
-// remains one round trip (no separate SELECT ... FOR UPDATE round trip).
-type WorkerTransaction = Parameters<Parameters<WorkerDb['transaction']>[0]>[0];
 
 type SessionMetadataUpdates = Partial<
   Pick<
@@ -411,20 +407,6 @@ type SessionMetadataUpdates = Partial<
     'title' | 'created_on_platform' | 'organization_id' | 'git_url' | 'git_branch'
   >
 >;
-
-const sessionEventReturningColumns = {
-  session_id: cli_sessions_v2.session_id,
-  created_at: cli_sessions_v2.created_at,
-  updated_at: cli_sessions_v2.updated_at,
-  title: cli_sessions_v2.title,
-  created_on_platform: cli_sessions_v2.created_on_platform,
-  organization_id: cli_sessions_v2.organization_id,
-  git_url: cli_sessions_v2.git_url,
-  git_branch: cli_sessions_v2.git_branch,
-  parent_session_id: cli_sessions_v2.parent_session_id,
-  status: cli_sessions_v2.status,
-  status_updated_at: cli_sessions_v2.status_updated_at,
-};
 
 /**
  * Build the `cli_sessions_v2` partial update from a set of metadata changes.
@@ -459,130 +441,133 @@ export function computeSessionMetadataUpdates(
   return updates;
 }
 
-async function updateSessionMetadata(
-  tx: WorkerTransaction,
-  kiloUserId: string,
-  sessionId: string,
-  updates: SessionMetadataUpdates
-): Promise<SessionEventDbRow | null> {
-  if (Object.keys(updates).length === 0) return null;
-
-  const [row] = await tx
-    .update(cli_sessions_v2)
-    .set(updates)
-    .where(
-      and(eq(cli_sessions_v2.session_id, sessionId), eq(cli_sessions_v2.kilo_user_id, kiloUserId))
-    )
-    .returning(sessionEventReturningColumns);
-  return row ?? null;
-}
-
-async function updateSessionParent(
-  tx: WorkerTransaction,
+/**
+ * Resolve the `parent_session_id` we should persist, if any.
+ *
+ * Returns `apply: false` when there is no parent write to make — the ingest
+ * carried no parentId, it pointed at the session itself, or it named a parent
+ * that doesn't exist for this user (the self-referential FK would otherwise
+ * reject the write). The existence probe is a plain unlocked read, so it never
+ * extends the row-lock critical section of `persistSessionChanges`.
+ */
+async function resolveParentUpdate(
+  db: WorkerDb,
   kiloUserId: string,
   sessionId: string,
   parentSessionId: string | null | undefined
-): Promise<SessionEventDbRow | null> {
-  if (parentSessionId === undefined) return null;
+): Promise<{ apply: false } | { apply: true; value: string | null }> {
+  if (parentSessionId === undefined) return { apply: false };
+  if (parentSessionId === null) return { apply: true, value: null };
+  if (parentSessionId === sessionId) return { apply: false };
 
-  if (parentSessionId && parentSessionId !== sessionId) {
-    const parentRows = await tx
-      .select({ session_id: cli_sessions_v2.session_id })
-      .from(cli_sessions_v2)
-      .where(
-        and(
-          eq(cli_sessions_v2.session_id, parentSessionId),
-          eq(cli_sessions_v2.kilo_user_id, kiloUserId)
-        )
+  const parentRows = await db
+    .select({ session_id: cli_sessions_v2.session_id })
+    .from(cli_sessions_v2)
+    .where(
+      and(
+        eq(cli_sessions_v2.session_id, parentSessionId),
+        eq(cli_sessions_v2.kilo_user_id, kiloUserId)
       )
-      .limit(1);
+    )
+    .limit(1);
 
-    if (!parentRows[0]) return null;
-
-    const [row] = await tx
-      .update(cli_sessions_v2)
-      .set({ parent_session_id: parentSessionId })
-      .where(
-        and(
-          eq(cli_sessions_v2.session_id, sessionId),
-          eq(cli_sessions_v2.kilo_user_id, kiloUserId),
-          sql`${cli_sessions_v2.parent_session_id} IS DISTINCT FROM ${parentSessionId}`
-        )
-      )
-      .returning(sessionEventReturningColumns);
-    return row ?? null;
-  }
-
-  if (parentSessionId === null) {
-    const [row] = await tx
-      .update(cli_sessions_v2)
-      .set({ parent_session_id: null })
-      .where(
-        and(
-          eq(cli_sessions_v2.session_id, sessionId),
-          eq(cli_sessions_v2.kilo_user_id, kiloUserId),
-          sql`${cli_sessions_v2.parent_session_id} IS DISTINCT FROM ${parentSessionId}`
-        )
-      )
-      .returning(sessionEventReturningColumns);
-    return row ?? null;
-  }
-
-  return null;
+  return parentRows[0] ? { apply: true, value: parentSessionId } : { apply: false };
 }
 
-type StatusTransitionRow = SessionEventDbRow & {
+type ParentUpdate = { apply: false } | { apply: true; value: string | null };
+
+type SessionChangeRow = SessionEventDbRow & {
   previous_status: string | null;
+  previous_parent_session_id: string | null;
 };
 
-async function updateSessionStatus(
-  tx: WorkerTransaction,
+/**
+ * Persist metadata, parent, and status changes for one session in a single
+ * atomic statement, returning the updated row (with the pre-update status and
+ * parent captured under the lock) or `null` when nothing actually changed.
+ *
+ * Everything is one `UPDATE ... RETURNING` guarded by a `SELECT ... FOR UPDATE`
+ * CTE. Because it is a single statement it is inherently atomic — a failure in
+ * any part rolls back the whole write, so Postgres can never be left with a
+ * torn subset of the change — while the row lock is held for exactly one round
+ * trip, never across a parent lookup, a second write, or a final read. Fields
+ * are only assigned when the ingest reported them, and the change guard skips
+ * the write entirely for a pure no-op (e.g. a re-sent identical status), so no
+ * lock is taken and no timestamp is bumped in that case.
+ */
+async function persistSessionChanges(
+  db: WorkerDb,
   kiloUserId: string,
   sessionId: string,
+  updates: SessionMetadataUpdates,
+  parent: ParentUpdate,
   status: string | null | undefined
-): Promise<{ session: SessionEventDbRow; previousStatus: SessionStatus | null } | null> {
-  if (status === undefined) return null;
+): Promise<SessionChangeRow | null> {
+  const assignments: SQL[] = [sql`updated_at = now()`];
+  const changeGuards: SQL[] = [];
 
-  const { rows } = await tx.execute<StatusTransitionRow>(sql`
+  if ('title' in updates) assignments.push(sql`title = ${updates.title ?? null}`);
+  if ('created_on_platform' in updates) {
+    assignments.push(sql`created_on_platform = ${updates.created_on_platform ?? null}`);
+  }
+  if ('organization_id' in updates) {
+    assignments.push(sql`organization_id = ${updates.organization_id ?? null}::uuid`);
+  }
+  if ('git_url' in updates) assignments.push(sql`git_url = ${updates.git_url ?? null}`);
+  if ('git_branch' in updates) assignments.push(sql`git_branch = ${updates.git_branch ?? null}`);
+
+  // A metadata field only reaches here after the DO diff-detected a real change,
+  // so any present field means we must write and emit `session.updated`.
+  if (Object.keys(updates).length > 0) changeGuards.push(sql`true`);
+
+  if (parent.apply) {
+    assignments.push(sql`parent_session_id = ${parent.value}`);
+    changeGuards.push(sql`locked.previous_parent_session_id IS DISTINCT FROM ${parent.value}`);
+  }
+
+  if (status !== undefined) {
+    assignments.push(sql`status = ${status}`);
+    assignments.push(
+      sql`status_updated_at = CASE WHEN locked.previous_status IS DISTINCT FROM ${status} THEN now() ELSE cli_sessions_v2.status_updated_at END`
+    );
+    changeGuards.push(sql`locked.previous_status IS DISTINCT FROM ${status}`);
+  }
+
+  if (changeGuards.length === 0) return null;
+
+  const { rows } = await db.execute<SessionChangeRow>(sql`
     WITH locked AS (
-      SELECT status AS previous_status
+      SELECT
+        status AS previous_status,
+        parent_session_id AS previous_parent_session_id
       FROM cli_sessions_v2
       WHERE session_id = ${sessionId}
         AND kilo_user_id = ${kiloUserId}
       FOR UPDATE
-    ), updated AS (
-      UPDATE cli_sessions_v2
-      SET
-        status = ${status},
-        status_updated_at = now(),
-        updated_at = now()
-      FROM locked
-      WHERE cli_sessions_v2.session_id = ${sessionId}
-        AND cli_sessions_v2.kilo_user_id = ${kiloUserId}
-        AND locked.previous_status IS DISTINCT FROM ${status}
-      RETURNING
-        cli_sessions_v2.session_id,
-        cli_sessions_v2.created_at,
-        cli_sessions_v2.updated_at,
-        cli_sessions_v2.title,
-        cli_sessions_v2.created_on_platform,
-        cli_sessions_v2.organization_id,
-        cli_sessions_v2.git_url,
-        cli_sessions_v2.git_branch,
-        cli_sessions_v2.parent_session_id,
-        cli_sessions_v2.status,
-        cli_sessions_v2.status_updated_at,
-        (SELECT previous_status FROM locked) AS previous_status
     )
-    SELECT * FROM updated
+    UPDATE cli_sessions_v2
+    SET ${sql.join(assignments, sql`, `)}
+    FROM locked
+    WHERE cli_sessions_v2.session_id = ${sessionId}
+      AND cli_sessions_v2.kilo_user_id = ${kiloUserId}
+      AND (${sql.join(changeGuards, sql` OR `)})
+    RETURNING
+      cli_sessions_v2.session_id,
+      cli_sessions_v2.created_at,
+      cli_sessions_v2.updated_at,
+      cli_sessions_v2.title,
+      cli_sessions_v2.created_on_platform,
+      cli_sessions_v2.organization_id,
+      cli_sessions_v2.git_url,
+      cli_sessions_v2.git_branch,
+      cli_sessions_v2.parent_session_id,
+      cli_sessions_v2.status,
+      cli_sessions_v2.status_updated_at,
+      locked.previous_status,
+      locked.previous_parent_session_id
   `);
-  const row = rows[0];
-  if (!row) return null;
 
-  return {
-    session: row,
-    previousStatus: SessionStatusSchema.nullable().parse(row.previous_status),
-  };
+  return rows[0] ?? null;
 }
 
 async function applyMetadataChanges(
@@ -600,39 +585,22 @@ async function applyMetadataChanges(
   const parentSessionId = mergedChanges.has('parentId')
     ? (mergedChanges.get('parentId') ?? null)
     : undefined;
-  // All three writes run in one transaction so a failure partway through (e.g. the
-  // status update) rolls back the metadata/parent updates too. The queue consumer
-  // only re-emits metadata changes that differ from the DO's last-sent value, so a
-  // partial commit here could never be repaired by a retry. Each write remains a
-  // single statement, so the status CTE's row lock is still held for only that one
-  // round trip, not across the whole transaction.
-  const { notificationRow, changedNonStatus, statusChange } = await db.transaction(async tx => {
-    let notificationRow = await updateSessionMetadata(tx, kiloUserId, sessionId, updates);
-    let changedNonStatus = !!notificationRow;
 
-    const parentUpdateRow = await updateSessionParent(tx, kiloUserId, sessionId, parentSessionId);
-    if (parentUpdateRow) {
-      changedNonStatus = true;
-      notificationRow = parentUpdateRow;
-    }
+  // Validate the parent (an unlocked read) before the write, then persist
+  // metadata, parent, and status together in one atomic statement — see
+  // `persistSessionChanges` for why one statement satisfies both atomicity and
+  // minimal lock-hold.
+  const parent = await resolveParentUpdate(db, kiloUserId, sessionId, parentSessionId);
+  const row = await persistSessionChanges(db, kiloUserId, sessionId, updates, parent, status);
+  if (!row) return;
 
-    const statusChange = await updateSessionStatus(tx, kiloUserId, sessionId, status);
-    if (statusChange) notificationRow = statusChange.session;
+  const session = mapSessionEventRow(row);
+  const changedStatus = status !== undefined && row.previous_status !== row.status;
+  const changedNonStatus =
+    Object.keys(updates).length > 0 ||
+    (parent.apply && row.previous_parent_session_id !== row.parent_session_id);
 
-    return { notificationRow, changedNonStatus, statusChange };
-  });
-
-  const notification = notificationRow
-    ? {
-        changedNonStatus,
-        changedStatus: !!statusChange,
-        previousStatus: statusChange?.previousStatus ?? null,
-        session: mapSessionEventRow(notificationRow),
-      }
-    : null;
-  if (!notification) return;
-
-  if (notification.changedNonStatus) {
+  if (changedNonStatus) {
     notifyUserSessionEvent(
       env,
       kiloUserId,
@@ -640,14 +608,14 @@ async function applyMetadataChanges(
         type: 'session.updated',
         data: {
           source: 'v2',
-          session: notification.session,
-          changedAt: notification.session.updatedAt,
+          session,
+          changedAt: session.updatedAt,
         },
       },
       ctx
     );
   }
-  if (notification.changedStatus) {
+  if (changedStatus) {
     notifyUserSessionEvent(
       env,
       kiloUserId,
@@ -655,11 +623,11 @@ async function applyMetadataChanges(
         type: 'session.status.updated',
         data: {
           source: 'v2',
-          session: notification.session,
-          previousStatus: notification.previousStatus,
-          status: notification.session.status,
-          statusUpdatedAt: notification.session.statusUpdatedAt,
-          changedAt: notification.session.updatedAt,
+          session,
+          previousStatus: SessionStatusSchema.nullable().parse(row.previous_status),
+          status: session.status,
+          statusUpdatedAt: session.statusUpdatedAt,
+          changedAt: session.updatedAt,
         },
       },
       ctx

--- a/services/session-ingest/src/types/user-connection-protocol.ts
+++ b/services/session-ingest/src/types/user-connection-protocol.ts
@@ -185,6 +185,7 @@ export type CLIOutboundMessage = z.infer<typeof CLIOutboundMessageSchema>;
 export type CLIInboundMessage = z.infer<typeof CLIInboundMessageSchema>;
 export type WebOutboundMessage = z.infer<typeof WebOutboundMessageSchema>;
 export type WebInboundMessage = z.infer<typeof WebInboundMessageSchema>;
+export type SessionStatus = z.infer<typeof SessionStatusSchema>;
 export type SessionEventV2Row = z.infer<typeof SessionEventV2RowSchema>;
 export type SessionRowEventPayload = z.infer<typeof SessionRowEventPayloadSchema>;
 export type SessionStatusUpdatedPayload = z.infer<typeof SessionStatusUpdatedPayloadSchema>;


### PR DESCRIPTION
## Summary

Reduces per-session row-lock hold time on `cli_sessions_v2`, the second major lock contributor identified in production Supabase lock-wait logs (the `select "status" from "cli_sessions_v2" ... for update` query). Over a representative 7-day window this exact query accounted for 1,440 acquired lock waits, dominated by `ShareLock`-on-transaction waits (max 110s) that the earlier `ExclusiveLock`-only investigation missed.

The previous `applyMetadataChanges` flow opened a JS transaction, took `SELECT ... FOR UPDATE` early, then held that row lock across a metadata `UPDATE`, a parent-session lookup + update, and a final full-row `SELECT` before commit. This change shrinks the locked critical section:

- Status transitions now run as a single statement: a `WITH locked AS (SELECT ... FOR UPDATE)` CTE plus `UPDATE ... RETURNING`, returning both the locked previous status and the updated row. No multi-round-trip JS transaction holds the lock.
- No-op status writes (same status re-sent) no longer stamp `status_updated_at`/`updated_at`, no longer hold the lock through a write, and emit no status notification.
- Non-status metadata and parent-session updates moved out of the status lock path into their own idempotent `UPDATE ... RETURNING` statements.
- The notification payload now comes from `RETURNING` instead of a final in-transaction `SELECT`.

Locked-status notification semantics are preserved: `session.status.updated` still reports the persisted previous status captured under the row lock, not the queued intake snapshot.

## Verification

- Reviewed production Supabase lock-wait logs (Axiom) to confirm the dominant wait mode and that long durations are lock waits on the PK index, not missing-index scans.
- Manually traced the queue-consumer code path to confirm the lock is no longer held across parent lookup, parent update, or the final payload read.

## Visual Changes

N/A

## Reviewer Notes

- The status transition is now raw SQL (`db.execute(sql\`...\`)`) because Drizzle's query builder can't express "return the locked previous value plus the updated row" in one statement. `previous_status` is read via a CTE subquery in `RETURNING` rather than relying on `FROM`-alias visibility, for cross-version safety.
- Behavior change worth confirming: a no-op status re-send no longer bumps `updated_at`/`status_updated_at` and emits no notification. This is intended (it was previously incidental lock-holding work), but flagging in case any consumer relied on the timestamp bump.
- Non-status metadata, parent updates, and the status transition are now separate statements rather than one transaction. They remain individually idempotent and per-session; ordering across them is unchanged.