### PR TITLE
fix(db): make 0175 code-review migration idempotent and resumable

### DIFF
--- a/packages/db/src/migrations/0175_spooky_unus.sql
+++ b/packages/db/src/migrations/0175_spooky_unus.sql
@@ -15,7 +15,7 @@ WITH ranked AS (
 UPDATE "cloud_agent_code_reviews" AS r
 SET "status" = 'cancelled',
         "terminal_reason" = 'superseded',
-        "error_message" = 'Superseded by newer review (0175 unique-index backfill)',
+        "error_message" = 'Superseded by newer review (backfill)',
         "completed_at" = now(),
         "updated_at" = now()
 FROM ranked
@@ -23,7 +23,7 @@ WHERE r."id" = ranked."id" AND ranked.rn > 1;--> statement-breakpoint
 UPDATE "cloud_agent_code_review_attempts" AS a
 SET "status" = 'cancelled',
         "terminal_reason" = 'superseded',
-        "error_message" = 'Superseded by newer review (0175 unique-index backfill)',
+        "error_message" = 'Superseded by newer review (backfill)',
         "completed_at" = now(),
         "updated_at" = now()
 FROM "cloud_agent_code_reviews" AS r

--- a/packages/db/src/migrations/0175_spooky_unus.sql
+++ b/packages/db/src/migrations/0175_spooky_unus.sql
@@ -1,8 +1,38 @@
-ALTER TABLE "cloud_agent_code_reviews" ADD COLUMN "manual_config" jsonb;--> statement-breakpoint
-COMMIT;--> statement-breakpoint
-CREATE UNIQUE INDEX CONCURRENTLY "UQ_cloud_agent_code_reviews_webhook_integration_repo_pr_sha" ON "cloud_agent_code_reviews" USING btree ("platform_integration_id","repo_full_name","pr_number","head_sha") WHERE "cloud_agent_code_reviews"."manual_config" IS NULL;--> statement-breakpoint
-CREATE UNIQUE INDEX CONCURRENTLY "UQ_cloud_agent_code_reviews_active_provider_publisher" ON "cloud_agent_code_reviews" USING btree ("platform_integration_id","repo_full_name","pr_number") WHERE "cloud_agent_code_reviews"."platform_integration_id" IS NOT NULL
+ALTER TABLE "cloud_agent_code_reviews" ADD COLUMN IF NOT EXISTS "manual_config" jsonb;--> statement-breakpoint
+DROP INDEX IF EXISTS "UQ_cloud_agent_code_reviews_webhook_integration_repo_pr_sha";--> statement-breakpoint
+DROP INDEX IF EXISTS "UQ_cloud_agent_code_reviews_active_provider_publisher";--> statement-breakpoint
+WITH ranked AS (
+        SELECT "id",
+                row_number() OVER (
+                        PARTITION BY "platform_integration_id", "repo_full_name", "pr_number"
+                        ORDER BY "created_at" DESC, "id" DESC
+                ) AS rn
+        FROM "cloud_agent_code_reviews"
+        WHERE "platform_integration_id" IS NOT NULL
+                AND "status" IN ('pending', 'queued', 'running')
+                AND ("manual_config" IS NULL OR "manual_config"->>'outputMode' = 'provider')
+)
+UPDATE "cloud_agent_code_reviews" AS r
+SET "status" = 'cancelled',
+        "terminal_reason" = 'superseded',
+        "error_message" = 'Superseded by newer review (0175 unique-index backfill)',
+        "completed_at" = now(),
+        "updated_at" = now()
+FROM ranked
+WHERE r."id" = ranked."id" AND ranked.rn > 1;--> statement-breakpoint
+UPDATE "cloud_agent_code_review_attempts" AS a
+SET "status" = 'cancelled',
+        "terminal_reason" = 'superseded',
+        "error_message" = 'Superseded by newer review (0175 unique-index backfill)',
+        "completed_at" = now(),
+        "updated_at" = now()
+FROM "cloud_agent_code_reviews" AS r
+WHERE a."code_review_id" = r."id"
+        AND r."status" = 'cancelled'
+        AND r."terminal_reason" = 'superseded'
+        AND a."status" IN ('pending', 'queued', 'running');--> statement-breakpoint
+CREATE UNIQUE INDEX "UQ_cloud_agent_code_reviews_webhook_integration_repo_pr_sha" ON "cloud_agent_code_reviews" USING btree ("platform_integration_id","repo_full_name","pr_number","head_sha") WHERE "cloud_agent_code_reviews"."manual_config" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "UQ_cloud_agent_code_reviews_active_provider_publisher" ON "cloud_agent_code_reviews" USING btree ("platform_integration_id","repo_full_name","pr_number") WHERE "cloud_agent_code_reviews"."platform_integration_id" IS NOT NULL
         AND "cloud_agent_code_reviews"."status" IN ('pending', 'queued', 'running')
         AND ("cloud_agent_code_reviews"."manual_config" IS NULL OR "cloud_agent_code_reviews"."manual_config"->>'outputMode' = 'provider');--> statement-breakpoint
-DROP INDEX CONCURRENTLY IF EXISTS "UQ_cloud_agent_code_reviews_repo_pr_sha";--> statement-breakpoint
-BEGIN;
+DROP INDEX IF EXISTS "UQ_cloud_agent_code_reviews_repo_pr_sha";

--- a/packages/db/src/migrations/meta/0175_snapshot.json
+++ b/packages/db/src/migrations/meta/0175_snapshot.json
@@ -4898,7 +4898,7 @@
           ],
           "isUnique": true,
           "where": "\"cloud_agent_code_reviews\".\"manual_config\" IS NULL",
-          "concurrently": true,
+          "concurrently": false,
           "method": "btree",
           "with": {}
         },
@@ -4926,7 +4926,7 @@
           ],
           "isUnique": true,
           "where": "\"cloud_agent_code_reviews\".\"platform_integration_id\" IS NOT NULL\n        AND \"cloud_agent_code_reviews\".\"status\" IN ('pending', 'queued', 'running')\n        AND (\"cloud_agent_code_reviews\".\"manual_config\" IS NULL OR \"cloud_agent_code_reviews\".\"manual_config\"->>'outputMode' = 'provider')",
-          "concurrently": true,
+          "concurrently": false,
           "method": "btree",
           "with": {}
         },

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -4139,11 +4139,12 @@ export const cloud_agent_code_reviews = pgTable(
   table => [
     uniqueIndex('UQ_cloud_agent_code_reviews_webhook_integration_repo_pr_sha')
       .on(table.platform_integration_id, table.repo_full_name, table.pr_number, table.head_sha)
-      .concurrently()
       .where(sql`${table.manual_config} IS NULL`),
-    uniqueIndex('UQ_cloud_agent_code_reviews_active_provider_publisher')
-      .on(table.platform_integration_id, table.repo_full_name, table.pr_number)
-      .concurrently().where(sql`${table.platform_integration_id} IS NOT NULL
+    uniqueIndex('UQ_cloud_agent_code_reviews_active_provider_publisher').on(
+      table.platform_integration_id,
+      table.repo_full_name,
+      table.pr_number
+    ).where(sql`${table.platform_integration_id} IS NOT NULL
         AND ${table.status} IN ('pending', 'queued', 'running')
         AND (${table.manual_config} IS NULL OR ${table.manual_config}->>'outputMode' = 'provider')`),
     // Indexes for ownership lookups


### PR DESCRIPTION
## Summary

Migration `0175_spooky_unus` broke the migration pipeline: ever since it merged, `drizzle migrate` fails and no new migrations apply.

**Root cause.** 0175 was hand-edited with raw `COMMIT;`/`BEGIN;` to smuggle `CREATE INDEX CONCURRENTLY` past Drizzle's transactional migrator (`schema.ts` declared the indexes with `.concurrently()`, so `drizzle generate` emitted `CONCURRENTLY`). The stray `COMMIT;` commits the `manual_config` `ADD COLUMN` before the indexes are built. The new partial unique index `UQ_cloud_agent_code_reviews_active_provider_publisher` enforces a constraint that never existed before — at most one active (`pending`/`queued`/`running`) provider review per `(platform_integration_id, repo_full_name, pr_number)`. On any DB with pre-existing duplicate active reviews the concurrent build fails, leaving:

- `manual_config` committed,
- 0175 **unrecorded** in `__drizzle_migrations`,
- an **invalid** leftover index,
- the old `UQ_..._repo_pr_sha` index still present.

Because 0175 is unrecorded, every later `drizzle migrate` re-runs the file and dies immediately on `ALTER TABLE ... ADD COLUMN "manual_config"` → `column already exists`, before reaching any newer migration. That is why "migrations don't run anymore," and why the only visible error is a misleading `already exists` rather than the original duplicate-key failure.

(Note: the first index, `UQ_..._webhook_integration_repo_pr_sha`, is a superset key over a subset of rows vs. the dropped baseline index, so it cannot introduce new duplicates — only the active-review index can. Confirmed by reproduction.)

**Fix.**
- Remove `.concurrently()` from both unique indexes in `schema.ts` so the DDL is plain `CREATE UNIQUE INDEX`, runnable inside Drizzle's transaction. This makes the migration atomic — any failure rolls back cleanly and the run is retriable. `0175` snapshot updated so schema/snapshot/migration agree (`drizzle generate` reports no changes).
- Rewrite `0175` to be idempotent and resumable from the half-applied state: `ADD COLUMN IF NOT EXISTS`, `DROP INDEX IF EXISTS` on the new indexes before recreating, and `DROP INDEX IF EXISTS` on the old index.
- Backfill before building the active-review index: supersede older active duplicates (keep the newest per `integration/repo/pr`) and cancel their active attempts, mirroring `supersedeActiveReviews()` (`status='cancelled'`, `terminal_reason='superseded'`).

On the broken production/staging DBs, re-running `drizzle migrate` with this change resumes from where it broke, records 0175, and unblocks all later migrations — no manual DB editing required.

Trade-off: the indexes now build with a brief write-lock on `cloud_agent_code_reviews` during the migrate step instead of online. `CONCURRENTLY` is fundamentally incompatible with the transactional migrator (that incompatibility is the root cause here), and the table is small enough that this is a non-issue.

## Verification

Reproduced end-to-end against local Postgres with a throwaway DB:
1. Migrated a fresh DB to 0174, seeded three colliding active reviews (`pending`/`queued`/`running`) for the same `(integration, repo, pr)` plus an unrelated active review and two active attempts.
2. Applied the **old** 0175 → failed; confirmed the wedged state (column committed, 0175 unrecorded, invalid index, old index still present).
3. Applied the **new** 0175 → succeeded. Verified: 0175 recorded; both unique indexes `indisvalid`; old index dropped; newest review (`running`) kept while the two older ones and their attempts were set `cancelled`/`superseded`; the unrelated review untouched.
4. Re-ran `drizzle migrate` → clean (idempotent / next-deploy safe).
5. Fresh empty-DB bootstrap with the new 0175 → applies cleanly, both indexes valid.

## Visual Changes

N/A

## Reviewer Notes

- The dedupe `UPDATE`s are destructive but scoped to the exact predicate of the new partial unique index and match existing supersede semantics. They keep the most recently created active review per `(integration, repo, pr)`.
- Editing an already-merged migration file and its snapshot is deliberate here: 0175 is unrecorded on the broken DBs, so a new migration could never be reached. The journal entry (tag/`when`) is unchanged, so DBs that applied 0175 cleanly won't re-run it.
