### PR TITLE
fix(ai-gateway): mark Messages stream errors

### DIFF
--- a/apps/web/src/lib/ai-gateway/processUsage.messages.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.messages.test.ts
@@ -12,6 +12,15 @@ import { Readable } from 'node:stream';
 
 const sampleDir = join(process.cwd(), 'src/tests/sample');
 
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+
 describe('processMessagesApiUsage', () => {
   const coreProps = {
     messageId: 'test-message-id',
@@ -214,6 +223,45 @@ describe('parseMessagesMicrodollarUsageFromStream approval tests', () => {
     const resultString = JSON.stringify(result, null, 2);
     const approvalFilePath = inputFile + '.approved.json';
     await verifyApproval(resultString, approvalFilePath);
+  });
+});
+
+describe('parseMessagesMicrodollarUsageFromStream', () => {
+  test('records stream error events as errored timeout usage', async () => {
+    const stream = streamFromText(
+      'event: error\n' +
+        'data: {"type":"error","error":{"type":"api_error","message":"Upstream idle timeout exceeded","error_type":"timeout"}}\n\n'
+    );
+
+    const result = await parseMessagesMicrodollarUsageFromStream(
+      stream,
+      'fake-user-id',
+      undefined,
+      'openrouter',
+      200
+    );
+
+    expect(result.hasError).toBe(true);
+    expect(result.finish_reason).toBe('timeout');
+    expect(result.status_code).toBe(200);
+    expect(result.cost_mUsd).toBe(0);
+  });
+
+  test('falls back to error finish reason when stream error has no error_type', async () => {
+    const stream = streamFromText(
+      'event: error\n' + 'data: {"type":"error","error":{"message":"Upstream failed"}}\n\n'
+    );
+
+    const result = await parseMessagesMicrodollarUsageFromStream(
+      stream,
+      'fake-user-id',
+      undefined,
+      'openrouter',
+      200
+    );
+
+    expect(result.hasError).toBe(true);
+    expect(result.finish_reason).toBe('error');
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/processUsage.messages.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.messages.ts
@@ -31,6 +31,15 @@ type MaybeHasOpenRouterProvider = {
   provider?: string | null;
 };
 
+type MessagesApiStreamErrorEvent = {
+  type: 'error';
+  error?: {
+    type?: string | null;
+    error_type?: string | null;
+    message?: string | null;
+  };
+};
+
 // Anthropic usage combined with OpenRouter cost fields
 // ref: https://docs.anthropic.com/en/api/messages
 // ref: https://openrouter.ai/docs/use-cases/usage-accounting#response-format
@@ -105,7 +114,7 @@ export async function parseMessagesMicrodollarUsageFromStream(
   let messageId: string | null = null;
   let model: string | null = null;
   let responseContent = '';
-  const reportedError = statusCode >= 400;
+  let reportedError = statusCode >= 400;
   const startedAt = performance.now();
   let firstTokenReceived = false;
   let usage: MessagesApiUsage | null = null;
@@ -128,12 +137,27 @@ export async function parseMessagesMicrodollarUsageFromStream(
         return;
       }
 
-      const json = JSON.parse(event.data) as Anthropic.Messages.MessageStreamEvent;
+      const json = JSON.parse(event.data) as
+        | Anthropic.Messages.MessageStreamEvent
+        | MessagesApiStreamErrorEvent;
 
       if (!json) {
         captureException(new Error('SUSPICIOUS: No JSON in SSE event'), {
           extra: { event },
         });
+        return;
+      }
+
+      if (json.type === 'error') {
+        reportedError = true;
+        finish_reason = json.error?.error_type ?? json.error?.type ?? 'error';
+        captureException(
+          new Error(`Messages API stream error: ${json.error?.message ?? 'unknown'}`),
+          {
+            tags: { source: 'messages_sse_processing' },
+            extra: { json, event },
+          }
+        );
         return;
       }
 


### PR DESCRIPTION
## Summary
- Mark Anthropic Messages API `event: error` stream frames as errored usage even when the HTTP status is 200.
- Persist `error.error_type` as `finish_reason` when present, falling back to the upstream error type or `error`.
- Add regression coverage for timeout stream errors and missing `error_type` fallback behavior.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
- Automated checks run locally: targeted Messages usage Jest file attempted but the environment lacks a reachable test Postgres; focused lint, web typecheck, and formatting completed.