### PR TITLE
feat(bot): inject current date into bot system prompt at runtime

### DIFF
--- a/apps/web/src/lib/bot/agent-runner.ts
+++ b/apps/web/src/lib/bot/agent-runner.ts
@@ -97,7 +97,11 @@ async function buildSystemPrompt(
     botPlatform.getConversationContext({ thread, triggerMessage, platformIntegration }),
   ]);
 
+  const currentDate = new Date().toISOString();
+
   return `You are Kilo Bot, a helpful AI assistant.
+
+Today's date: ${currentDate}
 
 ## Core behavior
 - Be concise and direct. Prefer short messages over long explanations.


### PR DESCRIPTION
## Summary
- Adds the current date (via `new Date().toISOString()`) to the bot's system prompt in `buildSystemPrompt` in `apps/web/src/lib/bot/agent-runner.ts`
- The date is placed near the top of the prompt, immediately after the opening identity line, so the model always knows today's date without it being hardcoded

## Verification
- Trigger a message to Kilo Bot and inspect the system prompt in logs; the `Today's date:` line should reflect the current UTC timestamp at request time

## Visual Changes
N/A

## Reviewer Notes
N/A

---
Built for [Remon Oldenbeuving](https://kilo-code.slack.com/archives/C0A44MC6NK0/p1782825992685559?thread_ts=1782824247.984859&cid=C0A44MC6NK0) by [Kilo for Slack](https://kilo.ai/slack)