### PR TITLE
fix(auth): harden device-auth poll (atomic consume + blocked re-check)

### DIFF
--- a/apps/web/src/lib/device-auth/device-auth.test.ts
+++ b/apps/web/src/lib/device-auth/device-auth.test.ts
@@ -268,6 +268,27 @@ describe('Device Auth', () => {
         expect(expired).toHaveLength(1);
       });
 
+      test('does not mint a token when the user is blocked after approval', async () => {
+        const { code } = await createDeviceAuthRequest({});
+        await approveDeviceAuthRequest(code, testUserId);
+
+        // User becomes blocked between approval and the poll.
+        await db
+          .update(kilocode_users)
+          .set({ blocked_reason: 'blocked after approval' })
+          .where(eq(kilocode_users.id, testUserId));
+
+        const result = await pollDeviceAuthRequest(code);
+
+        expect(result.status).toBe('denied');
+        expect(result.token).toBeUndefined();
+
+        // The approval is consumed, so retrying cannot mint a token either.
+        const retry = await pollDeviceAuthRequest(code);
+        expect(retry.status).toBe('expired');
+        expect(retry.token).toBeUndefined();
+      });
+
       test('normalizes responses - non-existent code returns expired', async () => {
         const result = await pollDeviceAuthRequest('FAKE-CODE');
         expect(result.status).toBe('expired');

--- a/apps/web/src/lib/device-auth/device-auth.test.ts
+++ b/apps/web/src/lib/device-auth/device-auth.test.ts
@@ -253,6 +253,21 @@ describe('Device Auth', () => {
         expect(secondResult.token).toBeUndefined();
       });
 
+      test('concurrent polls mint at most one token from a single approval', async () => {
+        const { code } = await createDeviceAuthRequest({});
+        await approveDeviceAuthRequest(code, testUserId);
+
+        const results = await Promise.all([
+          pollDeviceAuthRequest(code),
+          pollDeviceAuthRequest(code),
+        ]);
+
+        const approved = results.filter(r => r.status === 'approved' && r.token);
+        const expired = results.filter(r => r.status === 'expired');
+        expect(approved).toHaveLength(1);
+        expect(expired).toHaveLength(1);
+      });
+
       test('normalizes responses - non-existent code returns expired', async () => {
         const result = await pollDeviceAuthRequest('FAKE-CODE');
         expect(result.status).toBe('expired');

--- a/apps/web/src/lib/device-auth/device-auth.ts
+++ b/apps/web/src/lib/device-auth/device-auth.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/drizzle';
 import { device_auth_requests, kilocode_users } from '@kilocode/db/schema';
 import { eq, and, lt, sql } from 'drizzle-orm';
 import { generateApiToken } from '@/lib/tokens';
+import { isUserBlacklistedByDomain } from '@/lib/user/server';
 import { randomInt } from 'node:crypto';
 
 const CODE_LENGTH = 8;
@@ -201,6 +202,14 @@ export async function pollDeviceAuthRequest(code: string): Promise<{
 
   if (!user) {
     throw new Error('User not found');
+  }
+
+  // Re-check authorization at mint time. Authorization is verified when the
+  // user approves the request, but they may have been blocked or blacklisted
+  // between approval and this poll. The approval is already consumed above, so
+  // a now-blocked user cannot retry this code into a fresh long-lived token.
+  if (user.blocked_reason || (await isUserBlacklistedByDomain(user))) {
+    return { status: 'denied' };
   }
 
   const token = generateApiToken(user, { deviceAuthRequestCode: code });

--- a/apps/web/src/lib/device-auth/device-auth.ts
+++ b/apps/web/src/lib/device-auth/device-auth.ts
@@ -176,11 +176,27 @@ export async function pollDeviceAuthRequest(code: string): Promise<{
     return { status: request.status as 'pending' | 'denied' };
   }
 
-  // For approved requests, fetch user and generate token
+  // Atomically consume the approval before minting: a single guarded
+  // compare-and-swap flips 'approved' -> 'expired' and returns the row only to
+  // the caller that won. This prevents concurrent polls from each minting a
+  // long-lived token from one approval.
+  const consumed = await db
+    .update(device_auth_requests)
+    .set({ status: 'expired' })
+    .where(and(eq(device_auth_requests.code, code), eq(device_auth_requests.status, 'approved')))
+    .returning({ kiloUserId: device_auth_requests.kilo_user_id });
+
+  if (consumed.length === 0 || !consumed[0].kiloUserId) {
+    // Lost the race to another poller (or the status changed) — normalize to
+    // expired so the code cannot be polled into a second token.
+    return { status: 'expired' };
+  }
+  const kiloUserId = consumed[0].kiloUserId;
+
   const [user] = await db
     .select()
     .from(kilocode_users)
-    .where(eq(kilocode_users.id, request.kilo_user_id))
+    .where(eq(kilocode_users.id, kiloUserId))
     .limit(1);
 
   if (!user) {
@@ -188,14 +204,6 @@ export async function pollDeviceAuthRequest(code: string): Promise<{
   }
 
   const token = generateApiToken(user, { deviceAuthRequestCode: code });
-
-  // Mark as consumed to enforce single-use
-  await db
-    .update(device_auth_requests)
-    .set({
-      status: 'expired',
-    })
-    .where(eq(device_auth_requests.code, code));
 
   return {
     status: 'approved',


### PR DESCRIPTION
## Summary

Follow-up to #4314 (block rotates pepper). That PR was Workstream B; this is **Workstream A** — server-side hardening of the device-authorization poll path in `apps/web/src/lib/device-auth/device-auth.ts`. It closes two findings from the device-auth review:

- **Finding 1 — non-atomic single-use consume.** `pollDeviceAuthRequest` read the approved request, minted a token, then issued an unconditional `status = 'expired'` update. Two concurrent polls could each pass the read and each mint a long-lived API token from one approval. Replaced with a guarded compare-and-swap (`UPDATE ... SET status='expired' WHERE code = ? AND status='approved' RETURNING kilo_user_id`); the token is minted only by the caller that won the swap, and losers normalize to `expired`.
- **Finding 2 — token minted after the user is blocked.** Authorization was only checked at approval time; the later poll minted a long-lived API token with no re-check. A user could approve while in good standing, get blocked, then poll and still receive a fresh token. The poll now re-validates the user at mint time via `blocked_reason` and `isUserBlacklistedByDomain`, returning `denied` instead of minting. Because the approval is consumed first, a blocked user can't retry the code into a token.

No schema change, no migration. The poll API route already maps `denied` -> 403 and `expired` -> 410, so no route change was needed.

## Verification

- `apps/web/src/lib/device-auth/device-auth.test.ts` (24 tests pass), including two new cases:
  - concurrent polls on one approval mint **exactly one** token (the other gets `expired`);
  - a user blocked between approval and poll gets `denied` with no token, and a retry returns `expired`.
- Existing single-use / pending / denied / expired poll tests still pass.
- The domain-blacklist branch shares the same `if` as the blocked-reason check; I did not add a dedicated test for it because `getBlacklistedDomains` is Redis-cached (60s) and not reliably seedable in a unit test.

## Visual Changes

N/A

## Reviewer Notes

- The blocked re-check returns `denied` while the row is set to `expired` by the consume; both are terminal/non-retryable, and `denied` (403) is the more informative signal to the polling device.
- Two atomic commits: Finding 1 (atomic consume) then Finding 2 (blocked/blacklist re-check).
