### PR TITLE
ci: fix Sentry sourcemaps blocking Wasteland/Gastown deploy via pnpm lifecycle

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -280,7 +280,7 @@ jobs:
       - name: Upload Wasteland source maps
         if: needs.detect-gastown-wasteland-changes.outputs.deploy_wasteland == 'true'
         continue-on-error: true
-        run: pnpm --filter cloudflare-wasteland postdeploy:prod
+        run: pnpm --filter cloudflare-wasteland sentry:sourcemaps
 
       - name: Deploy Gastown
         if: needs.detect-gastown-wasteland-changes.outputs.deploy_gastown == 'true'
@@ -289,7 +289,7 @@ jobs:
       - name: Upload Gastown source maps
         if: needs.detect-gastown-wasteland-changes.outputs.deploy_gastown == 'true'
         continue-on-error: true
-        run: pnpm --filter cloudflare-gastown postdeploy:prod
+        run: pnpm --filter cloudflare-gastown sentry:sourcemaps
 
   deploy-kiloclaw:
     needs: [check-production-db-startup, run-migrations]

--- a/services/gastown/package.json
+++ b/services/gastown/package.json
@@ -8,7 +8,6 @@
     "preinstall": "npx only-allow pnpm",
     "container:prepare": "node scripts/prepare-container.mjs",
     "deploy:prod": "pnpm container:prepare && wrangler deploy --env=\"\" --outdir dist --var SENTRY_RELEASE:$(sentry-cli releases propose-version)",
-    "postdeploy:prod": "pnpm sentry:sourcemaps",
     "deploy:dev": "pnpm container:prepare && wrangler deploy --env dev",
     "sentry:sourcemaps": "_SENTRY_RELEASE=$(sentry-cli releases propose-version) && sentry-cli releases new $_SENTRY_RELEASE --org=kilo-code --project=gastown-service && sentry-cli sourcemaps upload --org=kilo-code --project=gastown-service --release=$_SENTRY_RELEASE --strip-prefix 'dist/..' dist",
     "dev": "pnpm container:prepare && wrangler dev --env dev",

--- a/services/wasteland/package.json
+++ b/services/wasteland/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "deploy:prod": "wrangler deploy --env=\"\" --outdir dist --var SENTRY_RELEASE:$(sentry-cli releases propose-version)",
-    "postdeploy:prod": "pnpm sentry:sourcemaps",
     "deploy:dev": "wrangler deploy --env dev",
     "sentry:sourcemaps": "_SENTRY_RELEASE=$(sentry-cli releases propose-version) && sentry-cli releases new $_SENTRY_RELEASE --org=kilo-code --project=wasteland-service && sentry-cli sourcemaps upload --org=kilo-code --project=wasteland-service --release=$_SENTRY_RELEASE --strip-prefix 'dist/..' dist",
     "dev": "wrangler dev --env dev",


### PR DESCRIPTION
## Summary

- Removes `postdeploy:prod` lifecycle scripts from `services/wasteland/package.json` and `services/gastown/package.json`
- Updates the \"Upload Wasteland/Gastown source maps\" workflow steps to call `sentry:sourcemaps` directly instead of `postdeploy:prod`

**Root cause:** `postdeploy:prod` is a pnpm lifecycle hook that auto-runs after `deploy:prod`. When the CI step ran `pnpm --filter cloudflare-wasteland deploy:prod`, pnpm chained `postdeploy:prod` → `sentry:sourcemaps` automatically. This hit a Sentry 401 (invalid/missing `SENTRY_AUTH_TOKEN`), failed the \"Deploy Wasteland\" step, and caused all subsequent steps (Deploy Gastown, both sourcemap uploads) to be skipped entirely.

The previous PR added `continue-on-error: true` to the explicit \"Upload source maps\" steps, but those steps were never reached because the failure happened inside the deploy step itself.

**Fix:** Remove the `postdeploy:prod` lifecycle hooks so `deploy:prod` only runs wrangler. The CI workflow's explicit sourcemap steps (with `continue-on-error: true`) handle the upload and tolerate Sentry failures.

## Verification

N/A — workflow and package.json script-only change. The Wasteland/Gastown deploy steps will now complete even when `SENTRY_AUTH_TOKEN` is unavailable.

## Visual Changes

N/A

## Reviewer Notes

`postdeploy:prod` was being run twice per deploy (once by pnpm lifecycle, once by the explicit CI step). Removing it from package.json also eliminates this duplication. Local developers running `pnpm deploy:prod` will no longer auto-upload sourcemaps, but they typically lack `SENTRY_AUTH_TOKEN` anyway so it would have failed silently.

---
Built for [Evgeny Shurakov](https://kilo-code.slack.com/archives/C08H16KGBUK/p1782828651891969?thread_ts=1782828520.970749&cid=C08H16KGBUK) by [Kilo for Slack](https://kilo.ai/slack)