### PR TITLE
fix(dev): stabilize service restarts

### DIFF
--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -285,7 +285,16 @@ export function restartServiceInTmux(sessionName: string, serviceName: string): 
   const pane = findServicePane(sessionName, serviceName);
   if (!pane) return;
   sendInterrupt(sessionName, pane.windowIndex, pane.paneIndex);
-  setTimeout(() => sendKeys(sessionName, pane.windowIndex, cmd, pane.paneIndex), 1000);
+  setTimeout(() => {
+    const currentPane = findServicePane(sessionName, serviceName);
+    if (!currentPane) return;
+    try {
+      sendKeys(sessionName, currentPane.windowIndex, cmd, currentPane.paneIndex);
+    } catch {
+      // The dashboard may have moved or closed the pane after we resolved it.
+      // Keep the TUI alive; the next explicit restart/view action can retry.
+    }
+  }, 1000);
 }
 
 // ---------------------------------------------------------------------------

--- a/dev/local/tmux.test.ts
+++ b/dev/local/tmux.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'node:child_process';
 import test from 'node:test';
 
 import { breakPane, buildInteractiveShellCommand, listWindows } from './tmux';
+import { restartServiceInTmux } from './runner';
 
 test('buildInteractiveShellCommand wraps quoted startup commands in parseable shell syntax', () => {
   const startupCommand =
@@ -24,6 +25,10 @@ const hasTmux = (() => {
     return false;
   }
 })();
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 test(
   'breakPane keeps the requested service window name after tmux automatic rename',
@@ -73,6 +78,46 @@ test(
         ),
         '0'
       );
+    } finally {
+      try {
+        tmux('kill-session', '-t', sessionName);
+      } catch {
+        // Session may already be gone if tmux fails during setup.
+      }
+    }
+  }
+);
+
+test(
+  'restartServiceInTmux re-resolves the service pane after dashboard pane moves',
+  { skip: !hasTmux },
+  async () => {
+    const sessionName = `kilo-tmux-test-${process.pid}-${Date.now()}`;
+    const serviceName = 'stripe';
+    const tmux = (...args: string[]) => execFileSync('tmux', args, { stdio: 'ignore' });
+
+    try {
+      tmux('new-session', '-d', '-s', sessionName, '-n', 'dashboard', 'sleep 120');
+      tmux('new-window', '-d', '-t', sessionName, '-n', serviceName, '/bin/sh');
+
+      const serviceWindow = listWindows(sessionName).find(window => window.name === serviceName);
+      assert.ok(serviceWindow);
+
+      tmux(
+        'join-pane',
+        '-h',
+        '-s',
+        `${sessionName}:${serviceWindow.index}.0`,
+        '-t',
+        `${sessionName}:0.0`
+      );
+      tmux('select-pane', '-t', `${sessionName}:0.1`, '-T', serviceName);
+
+      restartServiceInTmux(sessionName, serviceName);
+      breakPane(sessionName, 0, 1, serviceName);
+
+      await sleep(1200);
+      assert.ok(listWindows(sessionName).some(window => window.name === serviceName));
     } finally {
       try {
         tmux('kill-session', '-t', sessionName);


### PR DESCRIPTION
## Summary
Service restarts in the dev dashboard now survive tmux pane moves during the restart delay.

### Why this change is needed
Restarting a service could crash the dev CLI when the dashboard moved or restored the service pane between the interrupt and the delayed start command. The restart path reused a stale positional tmux target, so tmux could reject the send-keys command and take down the Ink dashboard.

### How this is addressed
- Re-resolves the service pane immediately before sending the delayed restart command.
- Keeps the dashboard alive if the pane disappears or moves after resolution.
- Adds tmux regression coverage for a service pane moving between interrupt and restart.

## Human Verification
- `pnpm exec tsx --test dev/local/tmux.test.ts`

## Reviewer Notes
No notable items for human review beyond what the summary covers.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- The restart still sends the interrupt to the initially resolved pane, then re-finds the service by window name or pane title before sending the start command.
- The new regression uses a disposable tmux session and a known service name to reproduce the stale-pane target without starting the full local dev stack.

</details>
