### PR TITLE
fix(o11y): reduce Gastown health alert noise

### DIFF
--- a/services/o11y/src/alerting/gastown-health-evaluate.ts
+++ b/services/o11y/src/alerting/gastown-health-evaluate.ts
@@ -1,4 +1,8 @@
-import { queryGastownHealth, type GastownHealthMetrics } from './gastown-health-query';
+import {
+  GASTOWN_HEALTH_WINDOW_MINUTES,
+  queryGastownHealth,
+  type GastownHealthMetrics,
+} from './gastown-health-query';
 import {
   readGastownHealthState,
   transitionGastownHealthState,
@@ -7,8 +11,9 @@ import {
 import { sendAlertNotification, type AlertPayload } from './notify';
 
 export const GASTOWN_HEALTH_THRESHOLDS = {
-  weightedFailedChecks: 20,
-  affectedTowns: 3,
+  weightedFailedChecks: 30,
+  affectedTowns: 4,
+  renotifyFailedChecksStep: 30,
 } as const;
 
 type GastownHealthEnv = {
@@ -49,7 +54,8 @@ export async function evaluateGastownHealthAlert(
   const transition = transitionGastownHealthState(
     currentState,
     metrics,
-    crossedThresholds.length > 0
+    crossedThresholds.length === 2,
+    GASTOWN_HEALTH_THRESHOLDS.renotifyFailedChecksStep
   );
 
   if (transition.shouldNotify) {
@@ -59,7 +65,7 @@ export async function evaluateGastownHealthAlert(
         severity: 'ticket',
         weightedFailedChecks: metrics.weightedFailedChecks,
         affectedTownCount: metrics.affectedTownCount,
-        windowMinutes: 5,
+        windowMinutes: GASTOWN_HEALTH_WINDOW_MINUTES,
         crossedThresholds,
         failedChecksThreshold: GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks,
         affectedTownsThreshold: GASTOWN_HEALTH_THRESHOLDS.affectedTowns,

--- a/services/o11y/src/alerting/gastown-health-query.ts
+++ b/services/o11y/src/alerting/gastown-health-query.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const GASTOWN_HEALTH_WINDOW_MINUTES = 5;
+export const GASTOWN_HEALTH_WINDOW_MINUTES = 15;
 
 export type GastownHealthMetrics = {
   weightedFailedChecks: number;

--- a/services/o11y/src/alerting/gastown-health-state.ts
+++ b/services/o11y/src/alerting/gastown-health-state.ts
@@ -16,6 +16,7 @@ const GastownHealthStateSchema = z.discriminatedUnion('active', [
       .int()
       .min(0)
       .max(CONSECUTIVE_HEALTHY_TO_RESOLVE - 1),
+    lastNotifiedWeightedFailedChecks: z.number().finite().nonnegative().optional(),
   }),
 ]);
 
@@ -34,12 +35,44 @@ function inactiveState(): GastownHealthState {
 export function transitionGastownHealthState(
   state: GastownHealthState,
   metrics: GastownHealthMetrics,
-  thresholdCrossed: boolean
+  thresholdCrossed: boolean,
+  renotifyFailedChecksStep: number
 ): GastownHealthTransition {
   if (thresholdCrossed) {
     if (!state.active) {
       return {
-        state: { active: true, consecutiveHealthyCount: 0 },
+        state: {
+          active: true,
+          consecutiveHealthyCount: 0,
+          lastNotifiedWeightedFailedChecks: metrics.weightedFailedChecks,
+        },
+        shouldNotify: true,
+        stateChanged: true,
+      };
+    }
+
+    if (state.lastNotifiedWeightedFailedChecks === undefined) {
+      return {
+        state: {
+          active: true,
+          consecutiveHealthyCount: 0,
+          lastNotifiedWeightedFailedChecks: metrics.weightedFailedChecks,
+        },
+        shouldNotify: false,
+        stateChanged: true,
+      };
+    }
+
+    if (
+      metrics.weightedFailedChecks >=
+      state.lastNotifiedWeightedFailedChecks + renotifyFailedChecksStep
+    ) {
+      return {
+        state: {
+          active: true,
+          consecutiveHealthyCount: 0,
+          lastNotifiedWeightedFailedChecks: metrics.weightedFailedChecks,
+        },
         shouldNotify: true,
         stateChanged: true,
       };
@@ -47,7 +80,11 @@ export function transitionGastownHealthState(
 
     if (state.consecutiveHealthyCount > 0) {
       return {
-        state: { active: true, consecutiveHealthyCount: 0 },
+        state: {
+          active: true,
+          consecutiveHealthyCount: 0,
+          lastNotifiedWeightedFailedChecks: state.lastNotifiedWeightedFailedChecks,
+        },
         shouldNotify: false,
         stateChanged: true,
       };
@@ -66,7 +103,11 @@ export function transitionGastownHealthState(
   }
 
   return {
-    state: { active: true, consecutiveHealthyCount },
+    state: {
+      active: true,
+      consecutiveHealthyCount,
+      lastNotifiedWeightedFailedChecks: state.lastNotifiedWeightedFailedChecks,
+    },
     shouldNotify: false,
     stateChanged: true,
   };

--- a/services/o11y/src/alerting/gastown-health-state.ts
+++ b/services/o11y/src/alerting/gastown-health-state.ts
@@ -56,7 +56,9 @@ export function transitionGastownHealthState(
         state: {
           active: true,
           consecutiveHealthyCount: 0,
-          lastNotifiedWeightedFailedChecks: metrics.weightedFailedChecks,
+          lastNotifiedWeightedFailedChecks:
+            Math.floor(metrics.weightedFailedChecks / renotifyFailedChecksStep) *
+            renotifyFailedChecksStep,
         },
         shouldNotify: false,
         stateChanged: true,

--- a/services/o11y/test/gastown-health-evaluate.spec.ts
+++ b/services/o11y/test/gastown-health-evaluate.spec.ts
@@ -82,13 +82,50 @@ describe('evaluateGastownHealthAlert', () => {
     expect(kv.store.size).toBe(0);
   });
 
-  it('alerts at 20 weighted failures', async () => {
+  it('does not alert when only the failed-check threshold is crossed', async () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
 
     await evaluateAt(
       kv,
-      makeMetrics(GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks, 1),
+      makeMetrics(
+        GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks,
+        GASTOWN_HEALTH_THRESHOLDS.affectedTowns - 1
+      ),
+      sentAlerts
+    );
+
+    expect(sentAlerts).toEqual([]);
+    expect(kv.store.size).toBe(0);
+  });
+
+  it('does not alert when only the affected-town threshold is crossed', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateAt(
+      kv,
+      makeMetrics(
+        GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks - 1,
+        GASTOWN_HEALTH_THRESHOLDS.affectedTowns
+      ),
+      sentAlerts
+    );
+
+    expect(sentAlerts).toEqual([]);
+    expect(kv.store.size).toBe(0);
+  });
+
+  it('alerts when both critical mass thresholds are crossed', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateAt(
+      kv,
+      makeMetrics(
+        GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks,
+        GASTOWN_HEALTH_THRESHOLDS.affectedTowns
+      ),
       sentAlerts
     );
 
@@ -96,23 +133,10 @@ describe('evaluateGastownHealthAlert', () => {
       {
         alertType: 'gastown_container_health',
         severity: 'ticket',
-        weightedFailedChecks: 20,
-        affectedTownCount: 1,
-        crossedThresholds: ['failed_checks'],
-      },
-    ]);
-  });
-
-  it('alerts at three affected towns', async () => {
-    const kv = makeKv();
-    const sentAlerts: AlertPayload[] = [];
-
-    await evaluateAt(kv, makeMetrics(3, GASTOWN_HEALTH_THRESHOLDS.affectedTowns), sentAlerts);
-
-    expect(sentAlerts).toMatchObject([
-      {
-        alertType: 'gastown_container_health',
-        crossedThresholds: ['affected_towns'],
+        weightedFailedChecks: 30,
+        affectedTownCount: 4,
+        windowMinutes: 15,
+        crossedThresholds: ['failed_checks', 'affected_towns'],
       },
     ]);
   });
@@ -120,20 +144,40 @@ describe('evaluateGastownHealthAlert', () => {
   it('notifies only once during persistent failure', async () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
-    const failingMetrics = makeMetrics(20, 3);
+    const failingMetrics = makeMetrics(30, 4);
 
     await evaluateAt(kv, failingMetrics, sentAlerts);
-    await evaluateAt(kv, failingMetrics, sentAlerts);
-    await evaluateAt(kv, failingMetrics, sentAlerts);
+    await evaluateAt(kv, makeMetrics(45, 4), sentAlerts);
+    await evaluateAt(kv, makeMetrics(59, 4), sentAlerts);
 
     expect(sentAlerts).toHaveLength(1);
+  });
+
+  it('renotifies during persistent failure when failed checks climb by another threshold step', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
+    await evaluateAt(kv, makeMetrics(59, 4), sentAlerts);
+    await evaluateAt(kv, makeMetrics(60, 4), sentAlerts);
+
+    expect(sentAlerts).toMatchObject([
+      {
+        weightedFailedChecks: 30,
+        affectedTownCount: 4,
+      },
+      {
+        weightedFailedChecks: 60,
+        affectedTownCount: 4,
+      },
+    ]);
   });
 
   it('does not clear active state when no telemetry is observed', async () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
 
-    await evaluateAt(kv, makeMetrics(20, 1), sentAlerts);
+    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
     await evaluateAt(kv, makeMetrics(0, 0), sentAlerts);
     await evaluateAt(kv, makeMetrics(0, 0), sentAlerts);
     await evaluateAt(kv, makeMetrics(0, 0), sentAlerts);
@@ -141,6 +185,7 @@ describe('evaluateGastownHealthAlert', () => {
     expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
       active: true,
       consecutiveHealthyCount: 0,
+      lastNotifiedWeightedFailedChecks: 30,
     });
   });
 
@@ -148,7 +193,7 @@ describe('evaluateGastownHealthAlert', () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
 
-    await evaluateAt(kv, makeMetrics(20, 1), sentAlerts);
+    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
     await evaluateAt(kv, makeMetrics(0, 0, 12), sentAlerts);
     await evaluateAt(kv, makeMetrics(0, 0, 8), sentAlerts);
     await evaluateAt(kv, makeMetrics(0, 0, 1), sentAlerts);
@@ -158,7 +203,7 @@ describe('evaluateGastownHealthAlert', () => {
       consecutiveHealthyCount: 0,
     });
 
-    await evaluateAt(kv, makeMetrics(20, 1), sentAlerts);
+    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
     expect(sentAlerts).toHaveLength(2);
   });
 
@@ -166,15 +211,31 @@ describe('evaluateGastownHealthAlert', () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
 
-    await evaluateAt(kv, makeMetrics(20, 1), sentAlerts);
+    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
     await evaluateAt(kv, makeMetrics(0, 0, 1), sentAlerts);
-    await evaluateAt(kv, makeMetrics(20, 1), sentAlerts);
+    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
 
     expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
       active: true,
       consecutiveHealthyCount: 0,
+      lastNotifiedWeightedFailedChecks: 30,
     });
     expect(sentAlerts).toHaveLength(1);
+  });
+
+  it('backfills legacy active state without sending a duplicate notification', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+    kv.store.set(STATE_KEY, JSON.stringify({ active: true, consecutiveHealthyCount: 0 }));
+
+    await evaluateAt(kv, makeMetrics(60, 4), sentAlerts);
+
+    expect(sentAlerts).toEqual([]);
+    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
+      active: true,
+      consecutiveHealthyCount: 0,
+      lastNotifiedWeightedFailedChecks: 60,
+    });
   });
 
   it('does not persist active state when notification delivery fails', async () => {
@@ -183,7 +244,7 @@ describe('evaluateGastownHealthAlert', () => {
     await expect(
       evaluateGastownHealthAlert(
         makeEnv(kv),
-        async () => makeMetrics(20, 1),
+        async () => makeMetrics(30, 4),
         async () => {
           throw new Error('Slack unavailable');
         }

--- a/services/o11y/test/gastown-health-evaluate.spec.ts
+++ b/services/o11y/test/gastown-health-evaluate.spec.ts
@@ -223,19 +223,31 @@ describe('evaluateGastownHealthAlert', () => {
     expect(sentAlerts).toHaveLength(1);
   });
 
-  it('backfills legacy active state without sending a duplicate notification', async () => {
+  it('backfills legacy active state to the last step boundary, not the current count', async () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
     kv.store.set(STATE_KEY, JSON.stringify({ active: true, consecutiveHealthyCount: 0 }));
 
-    await evaluateAt(kv, makeMetrics(60, 4), sentAlerts);
+    // weightedFailedChecks=59 is between step boundaries 30 and 60; backfill should be 30
+    await evaluateAt(kv, makeMetrics(59, 4), sentAlerts);
 
     expect(sentAlerts).toEqual([]);
     expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
       active: true,
       consecutiveHealthyCount: 0,
-      lastNotifiedWeightedFailedChecks: 60,
+      lastNotifiedWeightedFailedChecks: 30,
     });
+  });
+
+  it('re-notifies correctly after backfilling legacy active state', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+    kv.store.set(STATE_KEY, JSON.stringify({ active: true, consecutiveHealthyCount: 0 }));
+
+    await evaluateAt(kv, makeMetrics(59, 4), sentAlerts);
+    await evaluateAt(kv, makeMetrics(60, 4), sentAlerts);
+
+    expect(sentAlerts).toMatchObject([{ weightedFailedChecks: 60, affectedTownCount: 4 }]);
   });
 
   it('does not persist active state when notification delivery fails', async () => {

--- a/services/o11y/test/gastown-health-query.spec.ts
+++ b/services/o11y/test/gastown-health-query.spec.ts
@@ -21,7 +21,7 @@ function makeEnv(token: string | null = API_TOKEN) {
 }
 
 describe('queryGastownHealth', () => {
-  it('queries weighted five-minute container health metrics', async () => {
+  it('queries weighted fifteen-minute container health metrics', async () => {
     let calledUrl = '';
     let calledInit: RequestInit | undefined;
     const fetchFn: FetchFn = async (url, init) => {

--- a/services/o11y/test/notify.spec.ts
+++ b/services/o11y/test/notify.spec.ts
@@ -101,12 +101,12 @@ describe('buildSlackMessage — gastown_container_health alert', () => {
   const alert: GastownHealthAlertPayload = {
     alertType: 'gastown_container_health',
     severity: 'ticket',
-    weightedFailedChecks: 24,
+    weightedFailedChecks: 36,
     affectedTownCount: 4,
-    windowMinutes: 5,
+    windowMinutes: 15,
     crossedThresholds: ['failed_checks', 'affected_towns'],
-    failedChecksThreshold: 20,
-    affectedTownsThreshold: 3,
+    failedChecksThreshold: 30,
+    affectedTownsThreshold: 4,
   };
 
   it('includes counts, crossed thresholds, and investigation guidance', () => {
@@ -120,11 +120,11 @@ describe('buildSlackMessage — gastown_container_health alert', () => {
     const text = allText.join('\n');
 
     expect(text).toContain('Gastown container health failures');
-    expect(text).toContain('5-minute window');
-    expect(text).toContain('24');
+    expect(text).toContain('15-minute window');
+    expect(text).toContain('36');
     expect(text).toContain('4');
-    expect(text).toContain('20 failed checks');
-    expect(text).toContain('3 affected towns');
+    expect(text).toContain('30 failed checks');
+    expect(text).toContain('4 affected towns');
     expect(text).toContain('gastown-operations');
     expect(text).toContain('gastown-container-health-failures.md');
   });


### PR DESCRIPTION
## Summary
Gastown container health alerts now require a broader sustained failure signal before notifying and only send follow-up alerts when failures materially increase.

### Why this change is needed
- Gastown health alerts were firing on narrow, low-volume signals because the affected-town threshold could trigger on its own in a 5-minute window.
- Three affected towns with only a few failed checks created ticket alerts without enough evidence of a fleet-level incident.
- Operators should see the first alert at critical mass, then additional alerts only when the incident worsens.

### How this is addressed
- Extends the Gastown container health lookback window to 15 minutes.
- Raises the ticket threshold to 30 weighted failed checks and 4 affected towns.
- Requires both thresholds to be crossed before sending the first ticket alert.
- Tracks the last notified failed-check count for an active incident and sends follow-up alerts only after another 30 weighted failed checks.
- Keeps legacy active alert state compatible by backfilling the last notified count without sending a duplicate alert.

### Fix: legacy backfill uses last step boundary (not raw count)
Previously, backfilling a pre-rollout active alert with no `lastNotifiedWeightedFailedChecks` used `metrics.weightedFailedChecks` directly (e.g. 59). This caused the next re-notify step (e.g. at 60 = 30 + 30) to be skipped entirely because the delta would never reach `renotifyFailedChecksStep`.

The fix calculates the last notification boundary that would have been crossed: `Math.floor(weightedFailedChecks / renotifyFailedChecksStep) * renotifyFailedChecksStep`. For example, with 59 failed checks and a step of 30, the backfilled value is 30, ensuring the re-notify fires correctly at 60.

## Verification
- Ran `pnpm --filter cloudflare-o11y test`; all 148 tests passed.

## Visual Changes
N/A

## Reviewer Notes
- The alerting tradeoff is intentionally more lenient: isolated low-volume town failures no longer ticket unless aggregate failed checks also reach the critical mass threshold.
- Persistent incidents still escalate, but only in 30-failed-check steps to avoid recreating one-alert-per-cron noise.
- The legacy backfill fix ensures the step-boundary math is correct for alerts that were already active before this field was introduced.

Built for jeanduplessis by [Kilo](https://kilo.ai)