### PR TITLE
fix(kiloclaw): recover credit-funded reprovisioning

### DIFF
--- a/apps/web/src/app/(app)/claw/components/billing/AccessLockedDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/AccessLockedDialog.tsx
@@ -19,9 +19,11 @@ type AccessLockedDialogProps = {
   reason: ClawLockReason;
   billing: ClawBillingStatus;
   onSubscribeClick: () => void;
+  onReprovisionCreditsClick: () => void;
   onUpdatePaymentClick: () => void;
   onDestroyClick: () => void;
   isDestroying?: boolean;
+  isReprovisioning?: boolean;
 };
 
 function getLockContent(reason: ClawLockReason, billing: ClawBillingStatus) {
@@ -65,6 +67,16 @@ function getLockContent(reason: ClawLockReason, billing: ClawBillingStatus) {
         icon: Lock,
       };
     case 'subscription_expired_instance_destroyed':
+      if (billing.creditReprovisionRecovery.eligible) {
+        return {
+          title: 'Subscription Ended',
+          description:
+            'Your previous KiloClaw was destroyed. Your credits can activate a fresh Standard KiloClaw.',
+          cta: 'Reprovision and activate with credits',
+          action: 'reprovision_credits' as const,
+          icon: Coins,
+        };
+      }
       return {
         title: 'Subscription Ended',
         description: 'Your KiloClaw has been destroyed. Subscribe to provision a new one.',
@@ -116,6 +128,12 @@ function getInfoBoxMessage(reason: ClawLockReason, billing: ClawBillingStatus): 
     reason === 'trial_expired_instance_destroyed' ||
     reason === 'subscription_expired_instance_destroyed'
   ) {
+    if (
+      reason === 'subscription_expired_instance_destroyed' &&
+      billing.creditReprovisionRecovery.eligible
+    ) {
+      return 'Your current credits cover Standard hosting once your projected Kilo Pass bonus is included.';
+    }
     return "You'll need to provision a new KiloClaw after subscribing.";
   }
   if (reason === 'past_due_grace_exceeded') {
@@ -143,9 +161,11 @@ export function AccessLockedDialog({
   reason,
   billing,
   onSubscribeClick,
+  onReprovisionCreditsClick,
   onUpdatePaymentClick,
   onDestroyClick,
   isDestroying,
+  isReprovisioning,
 }: AccessLockedDialogProps) {
   const router = useRouter();
   const [confirmDestroy, setConfirmDestroy] = useState(false);
@@ -161,6 +181,8 @@ export function AccessLockedDialog({
   function handleCta() {
     if (content?.action === 'update_payment') {
       onUpdatePaymentClick();
+    } else if (content?.action === 'reprovision_credits') {
+      onReprovisionCreditsClick();
     } else if (content?.action === 'add_credits') {
       router.push('/credits');
     } else {
@@ -202,15 +224,24 @@ export function AccessLockedDialog({
         </div>
 
         <DialogFooter className="flex-col gap-3 sm:flex-col">
-          <Button onClick={handleCta} variant="primary" className="w-full py-3 font-semibold">
-            {content.cta}
+          <Button
+            onClick={handleCta}
+            variant="primary"
+            className="w-full py-3 font-semibold"
+            disabled={content.action === 'reprovision_credits' && isReprovisioning}
+          >
+            {content.action === 'reprovision_credits' && isReprovisioning
+              ? 'Activating...'
+              : content.cta}
           </Button>
           <p className="text-muted-foreground text-center text-xs">
             {content.action === 'add_credits'
               ? "You'll be redirected to the credits page to top up your balance"
-              : reason === 'past_due_grace_exceeded' && !isCreditFunded
-                ? "You'll be redirected to Stripe to update your payment method"
-                : "You'll be redirected to complete your purchase"}
+              : content.action === 'reprovision_credits'
+                ? 'A new KiloClaw will be provisioned before credits are charged'
+                : reason === 'past_due_grace_exceeded' && !isCreditFunded
+                  ? "You'll be redirected to Stripe to update your payment method"
+                  : "You'll be redirected to complete your purchase"}
           </p>
 
           {/* Secondary CTA: for credit-funded past-due, offer Kilo Pass as primary upgrade path */}

--- a/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
@@ -51,6 +51,9 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
   const [showPlanDialog, setShowPlanDialog] = useState(false);
 
   const reactivate = useMutation(trpc.kiloclaw.reactivateSubscriptionAtInstance.mutationOptions());
+  const reprovisionAndEnrollWithCredits = useMutation(
+    trpc.kiloclaw.reprovisionAndEnrollWithCredits.mutationOptions()
+  );
   const billingPortal = useMutation(trpc.kiloclaw.getCustomerPortalUrl.mutationOptions());
   const destroy = useMutation(
     trpc.kiloclaw.destroy.mutationOptions({
@@ -120,6 +123,35 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
     );
   }
 
+  function handleReprovisionCredits() {
+    if (reprovisionAndEnrollWithCredits.isPending) return;
+    reprovisionAndEnrollWithCredits.mutate(
+      { plan: 'standard' },
+      {
+        onSuccess: result => {
+          void Promise.all([
+            queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getStatus.queryKey() }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
+            }),
+          ]);
+          if (result.status === 'activated') {
+            toast.success('KiloClaw activated with credits');
+          } else {
+            toast.error(result.message ?? 'KiloClaw was reprovisioned but activation needs retry.');
+          }
+        },
+        onError: err => toast.error(err.message),
+      }
+    );
+  }
+
   return (
     <>
       {/* Banner — or earlybird card in the banner position */}
@@ -144,6 +176,7 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
         reason={lockReason}
         billing={billing}
         onSubscribeClick={handleSubscribe}
+        onReprovisionCreditsClick={handleReprovisionCredits}
         onUpdatePaymentClick={handleUpdatePayment}
         onDestroyClick={() =>
           destroy.mutate(undefined, {
@@ -152,6 +185,7 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
           })
         }
         isDestroying={destroy.isPending}
+        isReprovisioning={reprovisionAndEnrollWithCredits.isPending}
       />
 
       {/* Dashboard content */}

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
@@ -55,6 +55,14 @@ function createBillingStatus(overrides?: BillingStatusOverrides): ClawBillingSta
         effectiveBalanceMicrodollars: 0,
       },
     },
+    creditReprovisionRecovery: {
+      eligible: false,
+      plan: 'standard',
+      costMicrodollars: 55_000_000,
+      projectedKiloPassBonusMicrodollars: 0,
+      effectiveBalanceMicrodollars: 0,
+      shortfallMicrodollars: 55_000_000,
+    },
     kiloPassUpsellPreview: {
       standard: {
         monthly: { '19': emptyUpsellPreview, '49': emptyUpsellPreview, '199': emptyUpsellPreview },

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
@@ -459,6 +459,14 @@ export type ClawBillingStatus = {
       effectiveBalanceMicrodollars: number;
     }
   >;
+  creditReprovisionRecovery: {
+    eligible: boolean;
+    plan: 'standard';
+    costMicrodollars: number;
+    projectedKiloPassBonusMicrodollars: number;
+    effectiveBalanceMicrodollars: number;
+    shortfallMicrodollars: number;
+  };
   kiloPassUpsellPreview: Record<
     ClawPlan,
     Record<KiloPassUpsellCadence, Record<KiloPassUpsellTier, KiloPassUpsellActivationPreview>>

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -7534,6 +7534,123 @@ describe('enrollWithCredits', () => {
     expect(deductions.map(row => row.amountMicrodollars)).toContain(-55_000_000);
   });
 
+  it('rolls back a duplicate fresh provision when another recovery activates first', async () => {
+    setTestSystemTime('2026-07-01T12:00:00.000Z');
+    const destroyedInstance = await createInstance(user.id);
+    await db
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: '2026-06-30T00:00:00.000Z' })
+      .where(eq(kiloclaw_instances.id, destroyedInstance.id));
+    await db
+      .update(kilocode_users)
+      .set({
+        total_microdollars_acquired: 120_000_000,
+        microdollars_used: 0,
+        kilo_pass_threshold: null,
+      })
+      .where(eq(kilocode_users.id, user.id));
+    const [oldSubscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: destroyedInstance.id,
+        payment_source: 'credits',
+        plan: 'standard',
+        status: 'canceled',
+        kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+        current_period_start: '2026-05-30T00:00:00.000Z',
+        current_period_end: '2026-06-30T00:00:00.000Z',
+        credit_renewal_at: '2026-06-30T00:00:00.000Z',
+      })
+      .returning();
+    const oldSubscriptionId = oldSubscription?.id;
+    if (!oldSubscriptionId) throw new Error('Expected old subscription fixture');
+    const winningInstance = {
+      id: crypto.randomUUID(),
+      sandboxId: `ki_${crypto.randomUUID()}`,
+    };
+    const freshInstance = {
+      id: crypto.randomUUID(),
+      sandboxId: `ki_${crypto.randomUUID()}`,
+    };
+    kiloclawInternalClientMock.__provisionMock.mockImplementationOnce(async () => {
+      await db.insert(kiloclaw_instances).values({
+        id: winningInstance.id,
+        user_id: user.id,
+        sandbox_id: winningInstance.sandboxId,
+      });
+      const [winningSubscription] = await db
+        .insert(kiloclaw_subscriptions)
+        .values({
+          user_id: user.id,
+          instance_id: winningInstance.id,
+          payment_source: 'credits',
+          plan: 'standard',
+          status: 'active',
+          kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+          current_period_start: '2026-07-01T12:00:00.000Z',
+          current_period_end: '2026-08-01T12:00:00.000Z',
+          credit_renewal_at: '2026-08-01T12:00:00.000Z',
+        })
+        .returning();
+      const winningSubscriptionId = winningSubscription?.id;
+      if (!winningSubscriptionId) throw new Error('Expected winning subscription fixture');
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({ transferred_to_subscription_id: winningSubscriptionId })
+        .where(eq(kiloclaw_subscriptions.id, oldSubscriptionId));
+      await db.insert(kiloclaw_instances).values({
+        id: freshInstance.id,
+        user_id: user.id,
+        sandbox_id: freshInstance.sandboxId,
+      });
+      return {
+        instanceId: freshInstance.id,
+        sandboxId: freshInstance.sandboxId,
+      };
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.kiloclaw.reprovisionAndEnrollWithCredits({ plan: 'standard' })
+    ).resolves.toEqual({
+      success: true,
+      status: 'activated',
+      instanceId: winningInstance.id,
+    });
+
+    expect(kiloclawInternalClientMock.__provisionMock).toHaveBeenCalledTimes(1);
+
+    const [freshRow] = await db
+      .select({ destroyedAt: kiloclaw_instances.destroyed_at })
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.id, freshInstance.id))
+      .limit(1);
+    expect(freshRow?.destroyedAt).toEqual(expect.any(String));
+
+    const freshSubscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, freshInstance.id));
+    expect(freshSubscriptions).toEqual([]);
+    expect(kiloclawInternalClientMock.__destroyMock).toHaveBeenCalledWith(
+      user.id,
+      freshInstance.id,
+      { reason: 'stale_provision_cleanup' }
+    );
+
+    const [predecessor] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, oldSubscriptionId))
+      .limit(1);
+    expect(predecessor).toEqual(
+      expect.objectContaining({
+        transferred_to_subscription_id: expect.any(String),
+      })
+    );
+  });
+
   it('rolls back the fresh instance when destroyed-subscription credit recovery enrollment fails', async () => {
     setTestSystemTime('2026-07-01T12:00:00.000Z');
     const destroyedInstance = await createInstance(user.id);

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -23,18 +23,26 @@ import {
   kiloclaw_subscription_change_log,
   kilocode_users,
   credit_transactions,
+  kilo_pass_issuance_items,
+  kilo_pass_issuances,
   kilo_pass_store_purchases,
   kilo_pass_subscriptions,
   user_affiliate_attributions,
   user_affiliate_events,
 } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { sandboxIdFromUserId } from '@/lib/kiloclaw/sandbox-id';
 import { createOrganization } from '@/lib/organizations/organizations';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';
 import type Stripe from 'stripe';
-import { KiloPassTier, KiloPassCadence, KiloPassPaymentProvider } from '@/lib/kilo-pass/enums';
+import {
+  KiloPassTier,
+  KiloPassCadence,
+  KiloPassPaymentProvider,
+  KiloPassIssuanceItemKind,
+  KiloPassIssuanceSource,
+} from '@/lib/kilo-pass/enums';
 import { differenceInCalendarMonths } from 'date-fns';
 import { CURRENT_KILOCLAW_PRICE_VERSION, LEGACY_KILOCLAW_PRICE_VERSION } from '@kilocode/db';
 
@@ -46,6 +54,7 @@ type AnyMock = jest.Mock<(...args: any[]) => any>;
 
 type KiloclawInternalClientMockShape = {
   __provisionMock: AnyMock;
+  __destroyMock: AnyMock;
   __startAsyncMock: AnyMock;
 };
 
@@ -123,12 +132,14 @@ jest.mock('next/server', () => {
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const fn = jest.fn as (...args: unknown[]) => AnyMock;
   const provisionMock = fn().mockResolvedValue({});
+  const destroyMock = fn().mockResolvedValue(undefined);
   const startAsyncMock = fn().mockResolvedValue(undefined);
   return {
     KiloClawInternalClient: fn().mockImplementation(() => ({
       start: fn().mockResolvedValue(undefined),
       startAsync: startAsyncMock,
       stop: fn().mockResolvedValue(undefined),
+      destroy: destroyMock,
       provision: provisionMock,
       getStatus: fn().mockResolvedValue({}),
     })),
@@ -142,6 +153,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
       }
     },
     __provisionMock: provisionMock,
+    __destroyMock: destroyMock,
     __startAsyncMock: startAsyncMock,
   };
 });
@@ -276,6 +288,8 @@ beforeEach(async () => {
   stripeMock.invoices.list.mockResolvedValue({ data: [], has_more: false });
   kiloclawInternalClientMock.__provisionMock.mockReset();
   kiloclawInternalClientMock.__provisionMock.mockResolvedValue(defaultProvisionResult);
+  kiloclawInternalClientMock.__destroyMock.mockReset();
+  kiloclawInternalClientMock.__destroyMock.mockResolvedValue(undefined);
   kiloclawInternalClientMock.__startAsyncMock.mockReset();
   kiloclawInternalClientMock.__startAsyncMock.mockResolvedValue(undefined);
   posthogCaptureMock.mockReset();
@@ -6819,6 +6833,67 @@ describe('enrollWithCredits', () => {
     return instance;
   }
 
+  async function createActiveYearlyTier49KiloPassWithBaseIssuance(userId: string) {
+    const providerSubscriptionId = `kp-recovery-${crypto.randomUUID()}`;
+    const [subscription] = await db
+      .insert(kilo_pass_subscriptions)
+      .values({
+        kilo_user_id: userId,
+        provider_subscription_id: providerSubscriptionId,
+        stripe_subscription_id: providerSubscriptionId,
+        tier: KiloPassTier.Tier49,
+        cadence: KiloPassCadence.Yearly,
+        status: 'active',
+        cancel_at_period_end: false,
+        started_at: '2026-07-01T00:00:00.000Z',
+        current_streak_months: 1,
+        next_yearly_issue_at: '2026-08-01T00:00:00.000Z',
+      })
+      .returning();
+
+    if (!subscription) {
+      throw new Error('Failed to insert Kilo Pass subscription');
+    }
+
+    const [baseCreditTransaction] = await db
+      .insert(credit_transactions)
+      .values({
+        kilo_user_id: userId,
+        amount_microdollars: 49_000_000,
+        is_free: false,
+        description: 'Kilo Pass Pro yearly base credits',
+        credit_category: `kilo-pass-base:${providerSubscriptionId}:2026-07`,
+        check_category_uniqueness: true,
+      })
+      .returning();
+
+    if (!baseCreditTransaction) {
+      throw new Error('Failed to insert Kilo Pass base credit transaction');
+    }
+
+    const [issuance] = await db
+      .insert(kilo_pass_issuances)
+      .values({
+        kilo_pass_subscription_id: subscription.id,
+        issue_month: '2026-07-01',
+        source: KiloPassIssuanceSource.Cron,
+      })
+      .returning();
+
+    if (!issuance) {
+      throw new Error('Failed to insert Kilo Pass issuance');
+    }
+
+    await db.insert(kilo_pass_issuance_items).values({
+      kilo_pass_issuance_id: issuance.id,
+      kind: KiloPassIssuanceItemKind.Base,
+      credit_transaction_id: baseCreditTransaction.id,
+      amount_usd: 49,
+    });
+
+    return { subscription, issuance };
+  }
+
   it('clears destruction fields and records resume retry state when credit enrollment activates a suspended trial', async () => {
     const instance = await createInstance(user.id);
     await giveUserCredits(user.id, 60_000_000);
@@ -7331,6 +7406,261 @@ describe('enrollWithCredits', () => {
     await expect(caller.kiloclaw.enrollWithCredits({ plan: 'standard' })).rejects.toThrow(
       'Reprovision KiloClaw before enrolling hosting with credits.'
     );
+  });
+
+  it('reprovisions a destroyed canceled Standard subscription and activates with Kilo Pass projected bonus credits', async () => {
+    setTestSystemTime('2026-07-01T12:00:00.000Z');
+    const destroyedInstance = await createInstance(user.id);
+    await db
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: '2026-06-30T00:00:00.000Z' })
+      .where(eq(kiloclaw_instances.id, destroyedInstance.id));
+    await db
+      .update(kilocode_users)
+      .set({
+        total_microdollars_acquired: 43_710_000,
+        microdollars_used: 0,
+        kilo_pass_threshold: 49_000_000,
+      })
+      .where(eq(kilocode_users.id, user.id));
+    const { issuance } = await createActiveYearlyTier49KiloPassWithBaseIssuance(user.id);
+    const [oldSubscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: destroyedInstance.id,
+        payment_source: 'credits',
+        plan: 'standard',
+        status: 'canceled',
+        kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+        current_period_start: '2026-05-30T00:00:00.000Z',
+        current_period_end: '2026-06-30T00:00:00.000Z',
+        credit_renewal_at: '2026-06-30T00:00:00.000Z',
+      })
+      .returning();
+    const freshInstance = {
+      id: crypto.randomUUID(),
+      sandboxId: `ki_${crypto.randomUUID()}`,
+    };
+    kiloclawInternalClientMock.__provisionMock.mockImplementationOnce(async () => {
+      await db.insert(kiloclaw_instances).values({
+        id: freshInstance.id,
+        user_id: user.id,
+        sandbox_id: freshInstance.sandboxId,
+      });
+      return {
+        instanceId: freshInstance.id,
+        sandboxId: freshInstance.sandboxId,
+      };
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const beforeStatus = await caller.kiloclaw.getBillingStatus();
+    expect(beforeStatus.creditReprovisionRecovery).toEqual({
+      eligible: true,
+      plan: 'standard',
+      costMicrodollars: 55_000_000,
+      projectedKiloPassBonusMicrodollars: 24_500_000,
+      effectiveBalanceMicrodollars: 68_210_000,
+      shortfallMicrodollars: 0,
+    });
+
+    const result = await caller.kiloclaw.reprovisionAndEnrollWithCredits({ plan: 'standard' });
+
+    expect(result).toEqual({
+      success: true,
+      status: 'activated',
+      instanceId: freshInstance.id,
+    });
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    const predecessor = subscriptions.find(subscription => subscription.id === oldSubscription?.id);
+    const successor = subscriptions.find(
+      subscription => subscription.instance_id === freshInstance.id
+    );
+
+    expect(successor).toEqual(
+      expect.objectContaining({
+        status: 'active',
+        payment_source: 'credits',
+        plan: 'standard',
+        kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+        credit_renewal_at: expect.any(String),
+      })
+    );
+    expect(predecessor?.transferred_to_subscription_id).toBe(successor?.id);
+
+    const [updatedUser] = await db
+      .select({
+        acquired: kilocode_users.total_microdollars_acquired,
+        used: kilocode_users.microdollars_used,
+        threshold: kilocode_users.kilo_pass_threshold,
+      })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.id, user.id))
+      .limit(1);
+    expect(updatedUser).toEqual({
+      acquired: 68_210_000,
+      used: 55_000_000,
+      threshold: null,
+    });
+
+    const bonusItem = await db.query.kilo_pass_issuance_items.findFirst({
+      where: and(
+        eq(kilo_pass_issuance_items.kilo_pass_issuance_id, issuance.id),
+        eq(kilo_pass_issuance_items.kind, KiloPassIssuanceItemKind.Bonus)
+      ),
+      columns: {
+        kind: true,
+        amount_usd: true,
+        bonus_percent_applied: true,
+      },
+    });
+    expect(bonusItem).toEqual(
+      expect.objectContaining({
+        kind: KiloPassIssuanceItemKind.Bonus,
+        amount_usd: 24.5,
+        bonus_percent_applied: 0.5,
+      })
+    );
+
+    const deductions = await db
+      .select({ amountMicrodollars: credit_transactions.amount_microdollars })
+      .from(credit_transactions)
+      .where(eq(credit_transactions.kilo_user_id, user.id));
+    expect(deductions.map(row => row.amountMicrodollars)).toContain(-55_000_000);
+  });
+
+  it('rolls back the fresh instance when destroyed-subscription credit recovery enrollment fails', async () => {
+    setTestSystemTime('2026-07-01T12:00:00.000Z');
+    const destroyedInstance = await createInstance(user.id);
+    await db
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: '2026-06-30T00:00:00.000Z' })
+      .where(eq(kiloclaw_instances.id, destroyedInstance.id));
+    await db
+      .update(kilocode_users)
+      .set({
+        total_microdollars_acquired: 60_000_000,
+        microdollars_used: 0,
+        kilo_pass_threshold: null,
+      })
+      .where(eq(kilocode_users.id, user.id));
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: destroyedInstance.id,
+      payment_source: 'credits',
+      plan: 'standard',
+      status: 'canceled',
+      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+    });
+    const freshInstance = {
+      id: crypto.randomUUID(),
+      sandboxId: `ki_${crypto.randomUUID()}`,
+    };
+    kiloclawInternalClientMock.__provisionMock.mockImplementationOnce(async () => {
+      await db.insert(kiloclaw_instances).values({
+        id: freshInstance.id,
+        user_id: user.id,
+        sandbox_id: freshInstance.sandboxId,
+      });
+      await db.insert(credit_transactions).values({
+        kilo_user_id: user.id,
+        amount_microdollars: -55_000_000,
+        is_free: false,
+        description: 'Duplicate KiloClaw enrollment deduction',
+        credit_category: `kiloclaw-subscription:${freshInstance.id}:2026-07`,
+        check_category_uniqueness: true,
+      });
+      return {
+        instanceId: freshInstance.id,
+        sandboxId: freshInstance.sandboxId,
+      };
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.getBillingStatus()).resolves.toMatchObject({
+      creditReprovisionRecovery: {
+        eligible: true,
+        effectiveBalanceMicrodollars: 60_000_000,
+        shortfallMicrodollars: 0,
+      },
+    });
+
+    const result = await caller.kiloclaw.reprovisionAndEnrollWithCredits({ plan: 'standard' });
+
+    expect(result).toEqual({
+      success: false,
+      status: 'action_required',
+      instanceId: null,
+      message:
+        'Credit activation did not finish, so the new KiloClaw was rolled back. Retry activation or contact support.',
+    });
+    const [rolledBackInstance] = await db
+      .select({ destroyedAt: kiloclaw_instances.destroyed_at })
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.id, freshInstance.id))
+      .limit(1);
+    expect(rolledBackInstance?.destroyedAt).toEqual(expect.any(String));
+    const freshSubscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, freshInstance.id));
+    expect(freshSubscriptions).toEqual([]);
+    await expect(caller.kiloclaw.getBillingStatus()).resolves.toMatchObject({
+      creditReprovisionRecovery: {
+        eligible: true,
+        effectiveBalanceMicrodollars: 60_000_000,
+        shortfallMicrodollars: 0,
+      },
+    });
+    expect(kiloclawInternalClientMock.__destroyMock).toHaveBeenCalledWith(
+      user.id,
+      freshInstance.id,
+      { reason: 'stale_provision_cleanup' }
+    );
+  });
+
+  it('does not offer or run destroyed-subscription credit recovery when effective balance is insufficient', async () => {
+    const destroyedInstance = await createInstance(user.id);
+    await db
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: '2026-06-30T00:00:00.000Z' })
+      .where(eq(kiloclaw_instances.id, destroyedInstance.id));
+    await db
+      .update(kilocode_users)
+      .set({
+        total_microdollars_acquired: 43_710_000,
+        microdollars_used: 0,
+        kilo_pass_threshold: null,
+      })
+      .where(eq(kilocode_users.id, user.id));
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: destroyedInstance.id,
+      payment_source: 'credits',
+      plan: 'standard',
+      status: 'canceled',
+      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const status = await caller.kiloclaw.getBillingStatus();
+    expect(status.creditReprovisionRecovery).toEqual({
+      eligible: false,
+      plan: 'standard',
+      costMicrodollars: 55_000_000,
+      projectedKiloPassBonusMicrodollars: 0,
+      effectiveBalanceMicrodollars: 43_710_000,
+      shortfallMicrodollars: 11_290_000,
+    });
+    await expect(
+      caller.kiloclaw.reprovisionAndEnrollWithCredits({ plan: 'standard' })
+    ).rejects.toThrow('Effective credit balance is insufficient');
+    expect(kiloclawInternalClientMock.__provisionMock).not.toHaveBeenCalled();
   });
 
   it('rejects canceled legacy credit enrollment without rewriting historical lineage', async () => {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2274,6 +2274,27 @@ async function linkDestroyedSubscriptionToCreditRecoverySuccessor(params: {
   });
 }
 
+async function tryLinkDestroyedSubscriptionToCreditRecoverySuccessor(params: {
+  userId: string;
+  predecessorSubscriptionId: string;
+  successorInstanceId: string;
+  context: 'post_activation_recovery' | 'post_enrollment_success';
+}) {
+  try {
+    await linkDestroyedSubscriptionToCreditRecoverySuccessor(params);
+    return true;
+  } catch (error) {
+    logBillingWarning('KiloClaw credit reprovision successor linking failed after activation', {
+      user_id: params.userId,
+      predecessor_subscription_id: params.predecessorSubscriptionId,
+      successor_instance_id: params.successorInstanceId,
+      context: params.context,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
 async function getActivatedCreditRecoverySuccessor(params: { userId: string; instanceId: string }) {
   const [successor] = await db
     .select()
@@ -5590,18 +5611,20 @@ export const kiloclawRouter = createTRPCRouter({
           instanceId: provisioned.instanceId,
         });
         if (activatedSuccessor) {
-          await linkDestroyedSubscriptionToCreditRecoverySuccessor({
+          const linked = await tryLinkDestroyedSubscriptionToCreditRecoverySuccessor({
             userId: ctx.user.id,
             predecessorSubscriptionId: eligibility.subscription.id,
             successorInstanceId: provisioned.instanceId,
+            context: 'post_activation_recovery',
           });
           logBillingWarning(
-            'KiloClaw credit reprovision enrollment threw after activation; linked successor',
+            'KiloClaw credit reprovision enrollment threw after activation; returning activated state',
             {
               user_id: ctx.user.id,
               instance_id: provisioned.instanceId,
               subscription_id: eligibility.subscription.id,
               successor_subscription_id: activatedSuccessor.id,
+              successor_linked: linked,
               error: message,
             }
           );
@@ -5633,10 +5656,11 @@ export const kiloclawRouter = createTRPCRouter({
         };
       }
 
-      await linkDestroyedSubscriptionToCreditRecoverySuccessor({
+      await tryLinkDestroyedSubscriptionToCreditRecoverySuccessor({
         userId: ctx.user.id,
         predecessorSubscriptionId: eligibility.subscription.id,
         successorInstanceId: provisioned.instanceId,
+        context: 'post_enrollment_success',
       });
 
       return {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -42,6 +42,7 @@ import {
   resolveKiloClawEnrollmentPriceVersion,
   maySelectKiloClawCommit,
   PersonalSubscriptionCollapseUQConflictError,
+  type KiloClawPriceVersion,
 } from '@kilocode/db';
 import {
   kiloclaw_version_pins,
@@ -1607,6 +1608,12 @@ const KiloclawCustomerPortalInputSchema = KiloclawInstanceInputSchema.extend({
   returnUrl: z.url().optional(),
 });
 const KiloclawMutationResultSchema = z.object({ success: z.boolean() });
+const KiloclawReprovisionCreditEnrollmentResultSchema = z.object({
+  success: z.boolean(),
+  status: z.enum(['activated', 'action_required']),
+  instanceId: z.string().uuid().nullable(),
+  message: z.string().optional(),
+});
 
 type KiloclawSubscriptionReferralRewards = z.infer<
   typeof KiloclawSubscriptionReferralRewardsSchema
@@ -1622,6 +1629,31 @@ type KiloclawPersonalSubscriptionRow = {
     destroyedAt: string | null;
   };
 };
+
+type CreditReprovisionRecoveryPreview = {
+  eligible: boolean;
+  plan: 'standard';
+  costMicrodollars: number;
+  projectedKiloPassBonusMicrodollars: number;
+  effectiveBalanceMicrodollars: number;
+  shortfallMicrodollars: number;
+};
+
+type CreditReprovisionRecoveryEligibility =
+  | (CreditReprovisionRecoveryPreview & {
+      eligible: true;
+      subscription: typeof kiloclaw_subscriptions.$inferSelect;
+      priceVersion: KiloClawPriceVersion;
+    })
+  | (CreditReprovisionRecoveryPreview & {
+      eligible: false;
+      reason:
+        | 'no_current_subscription'
+        | 'subscription_not_canceled'
+        | 'instance_not_destroyed'
+        | 'active_instance_exists'
+        | 'insufficient_credits';
+    });
 
 // ── Personal subscription helpers ──────────────────────────────────────
 
@@ -2044,6 +2076,18 @@ async function getPersonalBillingStatus(user: {
         commitCostMicrodollars: commitCreditCostMicrodollars,
       }),
     ]);
+  const creditReprovisionRecovery = await getCreditReprovisionRecoveryEligibility({
+    user,
+    currentRow:
+      sub && currentPersonalInstance
+        ? {
+            subscription: sub,
+            instance: { destroyedAt: currentPersonalInstance.destroyed_at },
+          }
+        : null,
+    activeInstance: await getActiveInstance(user.id),
+    kiloPassState,
+  });
 
   return {
     hasAccess,
@@ -2065,12 +2109,229 @@ async function getPersonalBillingStatus(user: {
         ...commitCreditEnrollmentPreview,
       },
     },
+    creditReprovisionRecovery: {
+      eligible: creditReprovisionRecovery.eligible,
+      plan: 'standard',
+      costMicrodollars: creditReprovisionRecovery.costMicrodollars,
+      projectedKiloPassBonusMicrodollars:
+        creditReprovisionRecovery.projectedKiloPassBonusMicrodollars,
+      effectiveBalanceMicrodollars: creditReprovisionRecovery.effectiveBalanceMicrodollars,
+      shortfallMicrodollars: creditReprovisionRecovery.shortfallMicrodollars,
+    },
     kiloPassUpsellPreview,
     trial: trialData,
     subscription: subscriptionData,
     earlybird: earlybirdData,
     instance: instanceData,
   } satisfies ClawBillingStatus;
+}
+
+async function getCreditReprovisionRecoveryEligibility(params: {
+  user: {
+    id: string;
+    total_microdollars_acquired: number;
+    microdollars_used: number;
+    kilo_pass_threshold: number | null;
+  };
+  currentRow: {
+    subscription: typeof kiloclaw_subscriptions.$inferSelect;
+    instance: { destroyedAt: string | null } | null;
+  } | null;
+  activeInstance: ActiveKiloClawInstance | null;
+  kiloPassState?: KiloPassSubscriptionState | null;
+}): Promise<CreditReprovisionRecoveryEligibility> {
+  const priceVersion = resolveKiloClawEnrollmentPriceVersion(
+    params.currentRow
+      ? {
+          status: params.currentRow.subscription.status,
+          kiloclawPriceVersion: params.currentRow.subscription.kiloclaw_price_version,
+        }
+      : null
+  );
+  const costMicrodollars = getKiloClawPlanCostMicrodollars({
+    priceVersion,
+    plan: 'standard',
+  });
+  const balanceMicrodollars =
+    params.user.total_microdollars_acquired - params.user.microdollars_used;
+  const preview = await getEffectiveCreditBalancePreview({
+    userId: params.user.id,
+    balanceMicrodollars,
+    microdollarsUsed: params.user.microdollars_used,
+    kiloPassThreshold: params.user.kilo_pass_threshold,
+    costMicrodollars,
+    subscription: params.kiloPassState,
+  });
+  const base = {
+    plan: 'standard' as const,
+    costMicrodollars,
+    projectedKiloPassBonusMicrodollars: preview.projectedKiloPassBonusMicrodollars,
+    effectiveBalanceMicrodollars: preview.effectiveBalanceMicrodollars,
+    shortfallMicrodollars: Math.max(0, costMicrodollars - preview.effectiveBalanceMicrodollars),
+  };
+
+  if (!params.currentRow) {
+    return { ...base, eligible: false, reason: 'no_current_subscription' };
+  }
+  if (params.currentRow.subscription.status !== 'canceled') {
+    return { ...base, eligible: false, reason: 'subscription_not_canceled' };
+  }
+  if (!params.currentRow.instance?.destroyedAt) {
+    return { ...base, eligible: false, reason: 'instance_not_destroyed' };
+  }
+  if (params.activeInstance) {
+    return { ...base, eligible: false, reason: 'active_instance_exists' };
+  }
+  if (preview.effectiveBalanceMicrodollars < costMicrodollars) {
+    return { ...base, eligible: false, reason: 'insufficient_credits' };
+  }
+
+  return {
+    ...base,
+    eligible: true,
+    subscription: params.currentRow.subscription,
+    priceVersion,
+  };
+}
+
+async function linkDestroyedSubscriptionToCreditRecoverySuccessor(params: {
+  userId: string;
+  predecessorSubscriptionId: string;
+  successorInstanceId: string;
+}) {
+  await db.transaction(async tx => {
+    const [predecessor] = await tx
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.id, params.predecessorSubscriptionId),
+          eq(kiloclaw_subscriptions.user_id, params.userId)
+        )
+      )
+      .for('update')
+      .limit(1);
+
+    if (!predecessor) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'Previous KiloClaw billing state changed before recovery could finish.',
+      });
+    }
+    if (predecessor.transferred_to_subscription_id) {
+      return;
+    }
+
+    const [successor] = await tx
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.user_id, params.userId),
+          eq(kiloclaw_subscriptions.instance_id, params.successorInstanceId),
+          isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+        )
+      )
+      .for('update')
+      .limit(1);
+
+    if (!successor || successor.status !== 'active' || successor.payment_source !== 'credits') {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'Credit activation finished but the new billing row could not be linked.',
+      });
+    }
+
+    const [after] = await tx
+      .update(kiloclaw_subscriptions)
+      .set({ transferred_to_subscription_id: successor.id })
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.id, predecessor.id),
+          isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+        )
+      )
+      .returning();
+
+    if (!after) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'Previous KiloClaw billing state changed before recovery could finish.',
+      });
+    }
+
+    await insertKiloClawSubscriptionChangeLog(tx, {
+      subscriptionId: predecessor.id,
+      actor: {
+        actorType: 'user',
+        actorId: params.userId,
+      },
+      action: 'reassigned',
+      reason: 'credit_reprovision_recovery',
+      before: predecessor,
+      after,
+    });
+  });
+}
+
+async function getActivatedCreditRecoverySuccessor(params: { userId: string; instanceId: string }) {
+  const [successor] = await db
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, params.userId),
+        eq(kiloclaw_subscriptions.instance_id, params.instanceId),
+        eq(kiloclaw_subscriptions.status, 'active'),
+        eq(kiloclaw_subscriptions.payment_source, 'credits'),
+        isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+      )
+    )
+    .limit(1);
+
+  return successor ?? null;
+}
+
+async function cleanupFailedCreditRecoveryProvision(params: {
+  userId: string;
+  instanceId: string;
+  sandboxId: string;
+}) {
+  const [destroyed] = await db
+    .update(kiloclaw_instances)
+    .set({ destroyed_at: new Date().toISOString() })
+    .where(
+      and(
+        eq(kiloclaw_instances.id, params.instanceId),
+        eq(kiloclaw_instances.user_id, params.userId),
+        isNull(kiloclaw_instances.organization_id),
+        isNull(kiloclaw_instances.destroyed_at)
+      )
+    )
+    .returning({ id: kiloclaw_instances.id });
+
+  if (!destroyed) {
+    return false;
+  }
+
+  try {
+    const client = new KiloClawInternalClient();
+    await client.destroy(
+      params.userId,
+      workerInstanceId({ id: params.instanceId, sandboxId: params.sandboxId }),
+      {
+        reason: 'stale_provision_cleanup',
+      }
+    );
+  } catch (error) {
+    logBillingWarning('KiloClaw credit reprovision cleanup failed after DB quarantine', {
+      user_id: params.userId,
+      instance_id: params.instanceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return true;
 }
 
 function maskCustomerEmail(email: string | null): string | null {
@@ -5259,6 +5520,130 @@ export const kiloclawRouter = createTRPCRouter({
         });
         throw new TRPCError({ code, message, cause: error });
       }
+    }),
+
+  reprovisionAndEnrollWithCredits: baseProcedure
+    .input(z.object({ plan: z.literal('standard').optional() }).optional())
+    .output(KiloclawReprovisionCreditEnrollmentResultSchema)
+    .mutation(async ({ ctx, input }) => {
+      const plan = input?.plan ?? 'standard';
+      const currentRow = await (async () => {
+        try {
+          return await resolveCurrentPersonalSubscriptionRow({
+            userId: ctx.user.id,
+            dbOrTx: db,
+          });
+        } catch (error) {
+          mapCurrentSubscriptionResolutionError(error);
+        }
+      })();
+      const [activeInstance, kiloPassState] = await Promise.all([
+        getActiveInstance(ctx.user.id),
+        getKiloPassStateForUser(db, ctx.user.id),
+      ]);
+      const eligibility = await getCreditReprovisionRecoveryEligibility({
+        user: ctx.user,
+        currentRow,
+        activeInstance,
+        kiloPassState,
+      });
+
+      if (!eligibility.eligible) {
+        const message =
+          eligibility.reason === 'insufficient_credits'
+            ? 'Effective credit balance is insufficient to activate Standard hosting.'
+            : 'Credit-funded reprovision recovery is not available for this KiloClaw state.';
+        throw new TRPCError({
+          code: eligibility.reason === 'insufficient_credits' ? 'BAD_REQUEST' : 'CONFLICT',
+          message,
+        });
+      }
+
+      const provisioned = await provisionInstance(
+        ctx.user,
+        {},
+        {
+          instanceId: null,
+          bootstrapSubscription: false,
+        }
+      );
+
+      try {
+        await enrollWithCreditsImpl({
+          userId: ctx.user.id,
+          instanceId: provisioned.instanceId,
+          plan,
+          hadPaidSubscription: true,
+          expectedPriceVersion: eligibility.priceVersion,
+          actor: {
+            actorType: 'user',
+            actorId: ctx.user.id,
+          },
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'KiloClaw was reprovisioned, but credit activation did not finish.';
+        const activatedSuccessor = await getActivatedCreditRecoverySuccessor({
+          userId: ctx.user.id,
+          instanceId: provisioned.instanceId,
+        });
+        if (activatedSuccessor) {
+          await linkDestroyedSubscriptionToCreditRecoverySuccessor({
+            userId: ctx.user.id,
+            predecessorSubscriptionId: eligibility.subscription.id,
+            successorInstanceId: provisioned.instanceId,
+          });
+          logBillingWarning(
+            'KiloClaw credit reprovision enrollment threw after activation; linked successor',
+            {
+              user_id: ctx.user.id,
+              instance_id: provisioned.instanceId,
+              subscription_id: eligibility.subscription.id,
+              successor_subscription_id: activatedSuccessor.id,
+              error: message,
+            }
+          );
+          return {
+            success: true,
+            status: 'activated',
+            instanceId: provisioned.instanceId,
+          };
+        }
+
+        const cleanedUp = await cleanupFailedCreditRecoveryProvision({
+          userId: ctx.user.id,
+          instanceId: provisioned.instanceId,
+          sandboxId: provisioned.sandboxId,
+        });
+        logBillingWarning('KiloClaw credit reprovision enrollment failed after provisioning', {
+          user_id: ctx.user.id,
+          instance_id: provisioned.instanceId,
+          subscription_id: eligibility.subscription.id,
+          error: message,
+          cleanup: cleanedUp ? 'destroyed' : 'not_needed_or_already_destroyed',
+        });
+        return {
+          success: false,
+          status: 'action_required',
+          instanceId: null,
+          message:
+            'Credit activation did not finish, so the new KiloClaw was rolled back. Retry activation or contact support.',
+        };
+      }
+
+      await linkDestroyedSubscriptionToCreditRecoverySuccessor({
+        userId: ctx.user.id,
+        predecessorSubscriptionId: eligibility.subscription.id,
+        successorInstanceId: provisioned.instanceId,
+      });
+
+      return {
+        success: true,
+        status: 'activated',
+        instanceId: provisioned.instanceId,
+      };
     }),
 
   createKiloPassUpsellCheckout: baseProcedure

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2194,6 +2194,24 @@ async function getCreditReprovisionRecoveryEligibility(params: {
   };
 }
 
+function getCreditReprovisionRecoveryUnavailableMessage(
+  eligibility: Exclude<CreditReprovisionRecoveryEligibility, { eligible: true }>
+) {
+  return eligibility.reason === 'insufficient_credits'
+    ? 'Effective credit balance is insufficient to activate Standard hosting.'
+    : 'Credit-funded reprovision recovery is not available for this KiloClaw state.';
+}
+
+function throwCreditReprovisionRecoveryUnavailable(
+  eligibility: Exclude<CreditReprovisionRecoveryEligibility, { eligible: true }>
+): never {
+  const message = getCreditReprovisionRecoveryUnavailableMessage(eligibility);
+  throw new TRPCError({
+    code: eligibility.reason === 'insufficient_credits' ? 'BAD_REQUEST' : 'CONFLICT',
+    message,
+  });
+}
+
 async function linkDestroyedSubscriptionToCreditRecoverySuccessor(params: {
   userId: string;
   predecessorSubscriptionId: string;
@@ -2311,6 +2329,49 @@ async function getActivatedCreditRecoverySuccessor(params: { userId: string; ins
     .limit(1);
 
   return successor ?? null;
+}
+
+async function getCompetingCreditRecoveryActivation(params: {
+  userId: string;
+  instanceId: string;
+}): Promise<
+  { status: 'activated'; instanceId: string } | { status: 'in_progress'; instanceId: string } | null
+> {
+  const [activeSuccessor] = await db
+    .select({ instanceId: kiloclaw_subscriptions.instance_id })
+    .from(kiloclaw_subscriptions)
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, params.userId),
+        ne(kiloclaw_subscriptions.instance_id, params.instanceId),
+        eq(kiloclaw_subscriptions.status, 'active'),
+        eq(kiloclaw_subscriptions.payment_source, 'credits'),
+        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
+        isNull(kiloclaw_instances.organization_id),
+        isNull(kiloclaw_instances.destroyed_at)
+      )
+    )
+    .limit(1);
+
+  if (activeSuccessor?.instanceId) {
+    return { status: 'activated', instanceId: activeSuccessor.instanceId };
+  }
+
+  const [activeInstance] = await db
+    .select({ id: kiloclaw_instances.id })
+    .from(kiloclaw_instances)
+    .where(
+      and(
+        eq(kiloclaw_instances.user_id, params.userId),
+        ne(kiloclaw_instances.id, params.instanceId),
+        isNull(kiloclaw_instances.organization_id),
+        isNull(kiloclaw_instances.destroyed_at)
+      )
+    )
+    .limit(1);
+
+  return activeInstance ? { status: 'in_progress', instanceId: activeInstance.id } : null;
 }
 
 async function cleanupFailedCreditRecoveryProvision(params: {
@@ -5570,14 +5631,7 @@ export const kiloclawRouter = createTRPCRouter({
       });
 
       if (!eligibility.eligible) {
-        const message =
-          eligibility.reason === 'insufficient_credits'
-            ? 'Effective credit balance is insufficient to activate Standard hosting.'
-            : 'Credit-funded reprovision recovery is not available for this KiloClaw state.';
-        throw new TRPCError({
-          code: eligibility.reason === 'insufficient_credits' ? 'BAD_REQUEST' : 'CONFLICT',
-          message,
-        });
+        throwCreditReprovisionRecoveryUnavailable(eligibility);
       }
 
       const provisioned = await provisionInstance(
@@ -5588,6 +5642,36 @@ export const kiloclawRouter = createTRPCRouter({
           bootstrapSubscription: false,
         }
       );
+
+      const competingRecovery = await getCompetingCreditRecoveryActivation({
+        userId: ctx.user.id,
+        instanceId: provisioned.instanceId,
+      });
+      if (competingRecovery) {
+        const cleanedUp = await cleanupFailedCreditRecoveryProvision({
+          userId: ctx.user.id,
+          instanceId: provisioned.instanceId,
+          sandboxId: provisioned.sandboxId,
+        });
+        logBillingWarning('KiloClaw credit reprovision skipped duplicate concurrent provision', {
+          user_id: ctx.user.id,
+          instance_id: provisioned.instanceId,
+          competing_instance_id: competingRecovery.instanceId,
+          competing_status: competingRecovery.status,
+          cleanup: cleanedUp ? 'destroyed' : 'not_needed_or_already_destroyed',
+        });
+        if (competingRecovery.status === 'activated') {
+          return {
+            success: true,
+            status: 'activated',
+            instanceId: competingRecovery.instanceId,
+          };
+        }
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'KiloClaw credit-funded reprovision recovery is already in progress.',
+        });
+      }
 
       try {
         await enrollWithCreditsImpl({


### PR DESCRIPTION
## Summary
Credit-funded KiloClaw recovery now works when a canceled personal subscription points at a destroyed instance but the user's effective balance can cover Standard hosting.

### Why this change is needed
Users with active Kilo Pass can have enough effective credit balance once projected bonus credits are included, while their raw balance remains below the Standard hosting cost. The existing credit enrollment path accepted effective balance, but these users could not reach it because destroyed billing anchors were rejected and provisioning was blocked before they could subscribe again.

### How this is addressed
- Adds a dedicated Standard-only reprovision-and-enroll mutation for canceled personal KiloClaw subscriptions attached to destroyed instances.
- Keeps direct credit enrollment blocked for destroyed billing anchors.
- Provisions a fresh personal KiloClaw, enrolls it with credits, and links the old destroyed subscription row to the new active row with `transferred_to_subscription_id`.
- Cleans up the freshly provisioned instance if credit enrollment fails after provisioning, so retry is not blocked by an active unbilled instance.
- Shows a locked-state UI action to reprovision and activate with credits when recovery is eligible.

## Human Verification
- Reviewed `.specs/kiloclaw-billing.md` before changing billing behavior.
- Verified the focused KiloClaw billing router suite:
  `pnpm --filter web exec jest --runTestsByPath src/routers/kiloclaw-billing-router.test.ts`

## Reviewer Notes
### Human Reviewer Flags
- Recovery is intentionally Standard-only. Commit is not reintroduced through this path.
- The destroyed-instance guard remains in direct `enrollWithCredits`; recovery provisions a fresh instance before charging credits.
- If provisioning succeeds but enrollment fails, the fresh instance is marked destroyed and worker cleanup is attempted before returning an action-required state.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Eligibility uses the existing effective balance preview so projected Kilo Pass bonus credits are included without minting credits during preview.
- Successful recovery preserves billing lineage by linking the predecessor canceled row to the new active credit row.
- The partial-failure path checks whether credit activation actually committed before cleanup; if so, it links the successor and returns success instead of destroying a billed instance.
- Tests cover the Kilo Pass projected bonus case, insufficient effective balance, direct destroyed-anchor rejection, and failed post-provision enrollment cleanup.

</details>
