### PR TITLE
fix(auto-free): remove laguna-m1 from auto free models

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -42,7 +42,6 @@ import { type ProviderId } from '@/lib/ai-gateway/providers/types';
 export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 
 export const autoFreeModels = [
-  'poolside/laguna-m.1:free',
   stepfun_37_flash_free_model.status === 'public' ? stepfun_37_flash_free_model.public_id : null,
 ].filter(m => m !== null);
 


### PR DESCRIPTION
## Summary

- Removes `poolside/laguna-m.1:free` (laguna-m1) from the `autoFreeModels` list in `apps/web/src/lib/ai-gateway/models.ts`
- laguna-m1 is an unhealthy instance and should not be included in auto free routing

## Verification

N/A — configuration-only change; no new behaviour to exercise manually.

## Visual Changes

N/A

## Reviewer Notes

This is a single-line deletion from the `autoFreeModels` array. The model is not a Kilo-exclusive model, so no entry in `forbiddenFreeModelIds` is required.

---
Built for [Mark IJbema](https://kilo-code.slack.com/archives/C090U1NLQUC/p1782905435255739?thread_ts=1782904210.307709&cid=C090U1NLQUC) by [Kilo for Slack](https://kilo.ai/slack)