### PR TITLE
fix(byok): block deleting coding-plan-managed keys

### DIFF
--- a/.specs/coding-plans.md
+++ b/.specs/coding-plans.md
@@ -16,7 +16,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 **Managed Plan Credential** - An upstream API key acquired or provisioned by Kilo for a Coding Plan. Kilo manages its assignment and revocation. It is paired with an Upstream Plan ID and is not exposed to the subscriber after it is installed in BYOK.
 
-**Installed BYOK Configuration** - A normal personal BYOK entry that Kilo initially populates with a Managed Plan Credential. While unchanged, it identifies Token Plan Plus as its origin and Kilo may delete it at Effective Cancellation. A subscriber may test, enable, disable, update, or delete it using normal BYOK operations. Replacing its credential transfers cleanup ownership to the subscriber.
+**Installed BYOK Configuration** - A normal personal BYOK entry that Kilo initially populates with a Managed Plan Credential. While unchanged, it identifies Token Plan Plus as its origin and Kilo deletes it at Effective Cancellation. A subscriber may test, enable, disable, or update it using normal BYOK operations, but **MUST NOT** delete it directly while it remains Kilo-managed; it is removed by cancelling the plan in the Subscription Center. Replacing its credential transfers cleanup ownership to the subscriber and makes the resulting user-managed key deletable through normal BYOK operations.
 
 **Availability Notification Intent** - A user's plan-scoped request to be notified when a sold-out Coding Plan has capacity again. It is not a reservation, purchase, subscription, or entitlement.
 
@@ -72,7 +72,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 3.4. On activation, Kilo **MUST** configure an Installed BYOK Configuration in the ordinary personal provider slot so eligible traffic can use the plan through the Kilo Gateway. Activation **MUST** fail without charge or assignment if that provider slot is occupied, including by a disabled key.
 
-3.5. While an Installed BYOK Configuration still contains Kilo's issued credential, user-facing BYOK surfaces **MUST** identify its Coding Plan origin. Ordinary BYOK test, enable/disable, update, and delete operations **MUST** remain available. Before updating, disabling, or deleting that configuration, Kilo **MUST** warn that the operation changes routing but does not cancel subscription billing and **MUST** direct cancellation to the Subscription Center. Updating the credential **MUST** mark the entry as user-managed and detach it from later Coding Plan cleanup; deleting it **MUST NOT** cancel or pause the subscription. Testing or re-enabling the key does not require this warning.
+3.5. While an Installed BYOK Configuration still contains Kilo's issued credential, user-facing BYOK surfaces **MUST** identify its Coding Plan origin. Ordinary BYOK test, enable/disable, and update operations **MUST** remain available. A direct delete of a Kilo-managed Installed BYOK Configuration **MUST** be rejected so a removed routing key cannot strand a still-billed subscription; the surface **MUST** direct the user to cancel the plan in the Subscription Center, which removes the configuration at Effective Cancellation. Before updating or disabling that configuration, Kilo **MUST** warn that the operation changes routing but does not cancel subscription billing and **MUST** direct cancellation to the Subscription Center. Updating the credential **MUST** mark the entry as user-managed, detach it from later Coding Plan cleanup, and restore ordinary delete for the resulting user-managed key. Testing or re-enabling the key does not require this warning.
 
 ## 4. Credential provisioning and inventory
 
@@ -98,7 +98,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## 5. Subscription lifecycle
 
-5.1. A Coding Plan with successful activation enters `active` state and remains billable until its paid period ends or it is terminated immediately under this section. A subscriber's BYOK updates, disablement, or deletion **MUST NOT** change that billing lifecycle.
+5.1. A Coding Plan with successful activation enters `active` state and remains billable until its paid period ends or it is terminated immediately under this section. A subscriber's BYOK updates or disablement, or deletion of a user-managed replacement key, **MUST NOT** change that billing lifecycle.
 
 5.2. When a user requests cancellation, the subscription **MUST** stop renewing and **MUST** remain paid through the end of its current period. On the first billing lifecycle sweep processing the subscription at or after Effective Cancellation, Kilo **MUST** delete its Installed BYOK Configuration only if that configuration is still linked and Kilo-installed, and **MUST** create a Manual Revocation Work Item for the originally issued credential. Kilo **MUST NOT** delete a replacement or later user-created provider key.
 
@@ -110,7 +110,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 5.6. During the `past_due` recovery period, arrival of sufficient credits before the stored grace deadline **MUST** allow one atomic renewal debit and restore `active` status. If renewal cannot be funded by that deadline, the next billing lifecycle sweep **MUST** terminate the subscription, delete only a still-linked Installed BYOK Configuration, and create a Manual Revocation Work Item for the issued credential.
 
-5.7. A user-requested cancellation **MUST NOT** trigger auto-top-up. Updating, disabling, or deleting an Installed BYOK Configuration **MUST NOT** trigger cancellation or affect renewal billing.
+5.7. A user-requested cancellation **MUST NOT** trigger auto-top-up. Updating or disabling an Installed BYOK Configuration, or deleting a user-managed replacement key, **MUST NOT** trigger cancellation or affect renewal billing.
 
 5.8. When a user account is deleted, Kilo **MUST** immediately terminate any Coding Plan subscription, delete the user's BYOK configurations and Availability Notification Intents under the general deletion policy, create a Manual Revocation Work Item for each issued credential, and anonymize subscriber linkage in retained credential disposition records. Account deletion **MUST NOT** wait until the end of a prepaid period. Subscription and charged-term history **MAY** remain associated with the platform's anonymized user record when required for financial or compliance retention.
 
@@ -132,9 +132,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 7.2. Coding Plan surfaces **MUST** display recurring prices and charged-term amounts in USD regardless of payment source. Kilo Credits are valued one-to-one with USD for display. Surfaces **MUST** identify `Credits` as the payment source for credit-funded subscriptions and **MUST NOT** expose internal microdollars.
 
-7.3. While an Installed BYOK Configuration is unchanged, the BYOK surface **MUST** identify it as configured by Token Plan Plus. Before updating, disabling, or deleting it, the surface **MUST** warn that routing changes do not cancel subscription billing and direct the user to Subscription Center to cancel. Saved raw-key view or copy controls **MUST NOT** be added for customer BYOK surfaces.
+7.3. While an Installed BYOK Configuration is unchanged, the BYOK surface **MUST** identify it as configured by Token Plan Plus. Before updating or disabling it, the surface **MUST** warn that routing changes do not cancel subscription billing and direct the user to Subscription Center to cancel. A delete attempt on the Kilo-managed configuration **MUST** be blocked with a message that directs the user to cancel the plan in the Subscription Center. Saved raw-key view or copy controls **MUST NOT** be added for customer BYOK surfaces.
 
-7.4. Purchase messaging **MUST** state that Kilo configures MiniMax in BYOK and **MUST** tell users with an existing MiniMax key to delete it before subscribing. Cancellation messaging **MUST** state when billing ends, that Kilo deletes only its unchanged installed configuration, and that Kilo revokes its issued credential when plan access ends.
+7.4. Purchase messaging **MUST** state that Kilo configures MiniMax in BYOK and **MUST** tell users with an existing user-managed MiniMax key to delete it before subscribing. Cancellation messaging **MUST** state when billing ends, that Kilo deletes only its unchanged installed configuration, and that Kilo revokes its issued credential when plan access ends.
 
 7.5. A `past_due` subscription **MUST** communicate its grace deadline with date and local time, the consequence of unsuccessful payment recovery, and that a replacement or user-created MiniMax BYOK key is not deleted by Coding Plan termination.
 

--- a/.specs/subscription-center.md
+++ b/.specs/subscription-center.md
@@ -25,6 +25,7 @@ Updated 2026-05-28 -- Credit-funded payment source label.
 Updated 2026-05-28 -- Coding Plans API key configuration summary.
 Updated 2026-05-28 -- Coding Plans billing history USD amount display.
 Updated 2026-06-05 -- KiloClaw final Commit term continuation behavior.
+Updated 2026-07-01 -- Coding Plans installed-key deletion blocked in BYOK.
 
 ## Conventions
 
@@ -297,10 +298,12 @@ historical Commit names, prices, invoices, and credit deductions.
     - Inline billing history showing credit transactions with amounts in USD
       (see Billing History rules)
 
-    Before update, disable, or delete, `/byok` MUST warn that routing changes
-    do not cancel or pause Token Plan Plus billing and cancellation is managed
-    in Subscription Center; customer surfaces MUST NOT include saved raw-key
-    view or copy controls.
+    Before update or disable, `/byok` MUST warn that routing changes do not
+    cancel or pause Token Plan Plus billing and cancellation is managed in
+    Subscription Center. `/byok` MUST block a direct delete of the Kilo-managed
+    installed key and direct the user to cancel the plan in Subscription Center,
+    which removes it at Effective Cancellation; customer surfaces MUST NOT
+    include saved raw-key view or copy controls.
 
 31. Coding Plan cancellation, installed MiniMax configuration cleanup,
     and issued-credential revocation MUST follow `.specs/coding-plans.md`.
@@ -315,9 +318,10 @@ historical Commit names, prices, invoices, and credit deductions.
     action. For MiniMax Token Plan Plus, purchase messaging MUST explain
     automatic MiniMax BYOK setup and purchase MUST be blocked when any
     personal MiniMax BYOK key exists, including a disabled key. In that
-    state, the system MUST direct the user to delete the existing key in
-    `/byok` first. An offering without assignable credential capacity MUST
-    display a sold-out state and a `Notify me when available` action. The
+    state, the system MUST direct the user to delete the existing
+    user-managed key in `/byok` first. An offering without assignable
+    credential capacity MUST display a sold-out state and a `Notify me when
+    available` action. The
     action MUST persist one notification intent per user and Plan ID without
     charging credits or reserving inventory, and the surface MUST indicate
     once that intent has been saved.
@@ -462,6 +466,11 @@ not yet enforced in the current codebase:
    the current plan and seat count without management actions.
 
 ## Changelog
+
+### 2026-07-01 -- Coding Plans installed-key deletion blocked
+
+- Blocked direct deletion of a Kilo-managed installed MiniMax key in `/byok`; the key is removed by cancelling the plan in Subscription Center, which cleans it up at Effective Cancellation.
+- Kept update and disable available with the existing billing-separation warning; a replaced, user-managed key remains deletable.
 
 ### 2026-06-05 -- KiloClaw final Commit continuation
 

--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useReducer, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useTRPC } from '@/lib/trpc/utils';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/Button';
@@ -157,7 +158,7 @@ type BYOKKeysManagerProps = {
 type InstalledKeyWarningAction =
   | { type: 'disable'; keyId: string }
   | { type: 'update'; keyId: string }
-  | { type: 'delete'; keyId: string; providerName: string };
+  | { type: 'delete'; keyId: string };
 
 type BYOKDialogState = {
   isDialogOpen: boolean;
@@ -210,6 +211,7 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
 
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   // Build query options - only include organizationId if provided
   const listQueryInput = organizationId ? { organizationId } : {};
@@ -371,7 +373,7 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
 
   const handleDelete = (keyId: string, providerName: string) => {
     if (isInstalledCodingPlanKey(keyId)) {
-      setInstalledKeyWarningAction({ type: 'delete', keyId, providerName });
+      setInstalledKeyWarningAction({ type: 'delete', keyId });
       return;
     }
     if (confirm(`Are you sure you want to delete the API key for ${providerName}?`)) {
@@ -400,7 +402,9 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
         api_key: apiKey,
       });
     } else if (installedKeyWarningAction.type === 'delete') {
-      deleteMutation.mutate({ id: installedKeyWarningAction.keyId });
+      // A coding-plan-managed key can't be deleted directly; it is removed by
+      // cancelling the plan in the Subscription Center.
+      router.push('/subscriptions');
     } else {
       setEnabledMutation.mutate({ id: installedKeyWarningAction.keyId, is_enabled: false });
     }
@@ -432,6 +436,7 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
     title: string;
     description: string;
     actionLabel: string;
+    cancelLabel: string;
   } {
     if (action?.type === 'update') {
       return {
@@ -439,14 +444,16 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
         description:
           'Replacing this key changes MiniMax routing and makes it user-managed. Token Plan Plus billing continues until you cancel it in Subscription Center.',
         actionLabel: 'Replace key',
+        cancelLabel: 'Keep configuration',
       };
     }
     if (action?.type === 'delete') {
       return {
-        title: `Delete ${action.providerName} key?`,
+        title: 'This key is managed by your coding plan',
         description:
-          'Deleting this key stops MiniMax routing through this configuration. Token Plan Plus billing continues until you cancel it in Subscription Center.',
-        actionLabel: 'Delete key',
+          'This MiniMax key routes your Token Plan Plus plan, so it can\u2019t be deleted here. To remove it, cancel the plan in Subscription Center. Your plan stays active and billed until you cancel.',
+        actionLabel: 'Go to Subscription Center',
+        cancelLabel: 'Close',
       };
     }
     return {
@@ -454,6 +461,7 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
       description:
         'Disabling this key stops MiniMax routing while it is disabled. Token Plan Plus billing continues until you cancel it in Subscription Center.',
       actionLabel: 'Disable key',
+      cancelLabel: 'Keep configuration',
     };
   }
 
@@ -817,11 +825,8 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
               <AlertDialogDescription>{installedKeyWarning.description}</AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>Keep configuration</AlertDialogCancel>
-              <AlertDialogAction
-                variant={installedKeyWarningAction?.type === 'delete' ? 'destructive' : 'default'}
-                onClick={confirmInstalledKeyChange}
-              >
+              <AlertDialogCancel>{installedKeyWarning.cancelLabel}</AlertDialogCancel>
+              <AlertDialogAction variant="default" onClick={confirmInstalledKeyChange}>
                 {installedKeyWarning.actionLabel}
               </AlertDialogAction>
             </AlertDialogFooter>

--- a/apps/web/src/routers/byok-router.test.ts
+++ b/apps/web/src/routers/byok-router.test.ts
@@ -581,18 +581,38 @@ describe('BYOK Router', () => {
       expect(updatedSubscription.installed_byok_key_id).toBeNull();
     });
 
-    test('allows deleting installed MiniMax key without canceling subscription', async () => {
+    test('blocks deleting an installed coding-plan MiniMax key', async () => {
       const { key, subscription } = await createInstalledMiniMaxKey();
       const caller = await createCallerForUser(ownerUser.id);
 
-      await expect(caller.byok.delete({ id: key.id })).resolves.toEqual({ success: true });
+      await expect(caller.byok.delete({ id: key.id })).rejects.toThrow(/coding plan/i);
+
+      const remainingKeys = await db
+        .select()
+        .from(byok_api_keys)
+        .where(eq(byok_api_keys.id, key.id));
+      expect(remainingKeys).toHaveLength(1);
+
       const [updatedSubscription] = await db
         .select()
         .from(coding_plan_subscriptions)
         .where(eq(coding_plan_subscriptions.id, subscription.id));
 
       expect(updatedSubscription.status).toBe('active');
-      expect(updatedSubscription.installed_byok_key_id).toBeNull();
+      expect(updatedSubscription.installed_byok_key_id).toBe(key.id);
+    });
+
+    test('still deletes a user-owned key', async () => {
+      const caller = await createCallerForUser(ownerUser.id);
+      const created = await caller.byok.create({ provider_id: 'anthropic', api_key: 'user-key' });
+
+      await expect(caller.byok.delete({ id: created.id })).resolves.toEqual({ success: true });
+
+      const remainingKeys = await db
+        .select()
+        .from(byok_api_keys)
+        .where(eq(byok_api_keys.id, created.id));
+      expect(remainingKeys).toHaveLength(0);
     });
   });
 

--- a/apps/web/src/routers/byok-router.ts
+++ b/apps/web/src/routers/byok-router.ts
@@ -553,6 +553,17 @@ export const byokRouter = createTRPCRouter({
         }
       }
 
+      // Coding-plan-managed keys are user-scoped and back a billed subscription.
+      // Deleting one here would orphan the subscription (FK is set-null) while it
+      // keeps billing. Require cancelling the coding plan instead.
+      if (!organizationId && existingKey.management_source === 'coding_plan') {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message:
+            "This key is managed by your coding plan and can't be deleted directly. Cancel the coding plan to remove it.",
+        });
+      }
+
       // Delete from database
       await db.delete(byok_api_keys).where(eq(byok_api_keys.id, id));
 

--- a/apps/web/src/routers/kiloclaw-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-router.test.ts
@@ -599,7 +599,7 @@ describe('kiloclawRouter fileTree', () => {
       instance_id: instanceId,
       plan: 'trial',
       status: 'trialing',
-      trial_ends_at: '2026-07-01T00:00:00.000Z',
+      trial_ends_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     });
 
     const caller = createCaller({ user });


### PR DESCRIPTION
## Summary
Blocks direct deletion of a coding-plan-managed BYOK key so a billed Token Plan Plus subscription can no longer be silently orphaned.

### Why this change is needed
- Deleting a coding-plan-managed BYOK key removed the row while the owning subscription's FK `installed_byok_key_id` is `onDelete: set null`. The `coding_plan_subscriptions` row stayed `active` and kept billing while routing through nothing.
- This already hit 3 users in production.
- The `delete` handler had no coding-plan handling, unlike the `update` handler which already transfers ownership correctly.

### How this is addressed
- Server: `byok.delete` now rejects with `CONFLICT` when the key is coding-plan-managed (user-scoped), before any delete. User-owned and org keys delete exactly as before, including the org audit log.
- UI (`/byok`): deleting a managed key now shows a blocking dialog that sends the user to Subscription Center to cancel the plan, instead of a destructive confirm that would fail server-side.
- Specs: `.specs/coding-plans.md` and `.specs/subscription-center.md` updated so "a Kilo-managed installed key can't be deleted directly; it is removed by cancelling in Subscription Center" is the governing rule. Update and disable remain available with the existing billing-separation warning; a replaced (user-managed) key stays deletable.
- Unrelated CI unblock (bundled): `kiloclaw-router.test.ts` hardcoded a trial expiry of `2026-07-01`, so the KiloClaw access gate started returning `FORBIDDEN` once that date arrived, failing CI on main and every PR opened that day. Switched it to a relative future expiry. See the dedicated commit.

## Human Verification
- BYOK router tests pass (29), including new coverage: deleting a managed key is rejected while the key row and the `active` subscription link are preserved; a `management_source = 'user'` key still deletes.
- KiloClaw router tests pass (29) after the trial-expiry fix.
- Confirmed the guard keys on `management_source === 'coding_plan'` (Kilo-managed) — matches the updated spec definition.

## Reviewer Notes
### Human Reviewer Flags
- Spec change / decision reversal: the prior specs explicitly required managed-key delete to remain available (coding-plans 3.5, definition, 7.3, 7.4; subscription-center rule 30/32). This PR reverses that to "block + cancel via Subscription Center." Please confirm this behavior-change decision is intended.
- Behavior change: a delete that previously succeeded now errors — but that prior success was the orphaned-billing bug.
- Bundled unrelated fix: the second commit fixes a pre-existing date-dependent KiloClaw test failure (a time-bomb on `main`), included here only to unblock this PR's CI. It can be reviewed independently.
- Edge-case reasoning: the guard checks only `management_source`. A managed key only coexists with a non-terminal subscription and is cleaned up by the billing-lifecycle sweep at cancellation, so no user needs to delete it directly.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Guard placed after existing ownership checks and before `db.delete(...)`; reuses the already-selected `existingKey.management_source`, no extra query.
- `CONFLICT` chosen over `PRECONDITION_FAILED` (more common in `apps/web/src/routers`; fits resource-state conflict).
- UI: delete-case `AlertDialog` action navigates via `router.push('/subscriptions')`; removed the now-unused `providerName` from the delete warning action.
- KiloClaw fix uses `new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()` so the trial stays active regardless of run date; three sibling tests still use a fixed `2026-12-31` expiry (latent, not addressed here).

</details>
