### PR TITLE
feat(o11y): add code review sandbox to monitored container apps

### DIFF
--- a/services/o11y/src/alerting/container-capacity.ts
+++ b/services/o11y/src/alerting/container-capacity.ts
@@ -48,6 +48,7 @@ export const CONTAINER_CAPACITY_THRESHOLDS = {
 export const MONITORED_CONTAINER_APPS: readonly string[] = [
   'cloud-agent-next-sandbox',
   'cloud-agent-next-sandboxsmall',
+  'cloud-agent-next-sandboxcodereview',
 ];
 
 // ── Zod schemas for the Cloudflare Containers API ───────────────────────────

--- a/services/o11y/test/container-capacity-query.spec.ts
+++ b/services/o11y/test/container-capacity-query.spec.ts
@@ -72,6 +72,19 @@ const smallDetailApp = {
   max_instances: 100,
 };
 
+const codeReviewListApp = {
+  id: 'code-review-id',
+  name: 'cloud-agent-next-sandboxcodereview',
+  instances: 10,
+};
+
+const codeReviewDetailApp = {
+  id: 'code-review-id',
+  name: 'cloud-agent-next-sandboxcodereview',
+  instances: 10,
+  max_instances: 1000,
+};
+
 const unmonitoredListApp = {
   id: 'other-id',
   name: 'some-other-app',
@@ -169,6 +182,26 @@ describe('queryContainerApplications', () => {
       'cloud-agent-next-sandbox',
       'cloud-agent-next-sandboxsmall',
     ]);
+  });
+
+  it('fetches the code review sandbox application', async () => {
+    const responses = new Map<string, object>([
+      [
+        `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/containers/dash/applications?page=1&per_page=20`,
+        makeListResponse([codeReviewListApp, unmonitoredListApp]),
+      ],
+      [
+        `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/containers/applications/code-review-id`,
+        makeDetailResponse(codeReviewDetailApp),
+      ],
+    ]);
+
+    const apps = await queryContainerApplications(makeEnv(), makeFetch(responses));
+
+    expect(apps).toHaveLength(1);
+    expect(apps[0].name).toBe('cloud-agent-next-sandboxcodereview');
+    expect(apps[0].instances).toBe(10);
+    expect(apps[0].maxInstances).toBe(1000);
   });
 
   it('returns empty array when no monitored apps are found in the list', async () => {

--- a/services/o11y/test/container-capacity.spec.ts
+++ b/services/o11y/test/container-capacity.spec.ts
@@ -8,6 +8,7 @@ import {
 
 const MONITORED = MONITORED_CONTAINER_APPS[0]; // 'cloud-agent-next-sandbox'
 const MONITORED_SMALL = MONITORED_CONTAINER_APPS[1]; // 'cloud-agent-next-sandboxsmall'
+const MONITORED_CODE_REVIEW = MONITORED_CONTAINER_APPS[2]; // 'cloud-agent-next-sandboxcodereview'
 
 function makeApp(
   overrides: Partial<ContainerApplication> & Pick<ContainerApplication, 'name'>
@@ -110,5 +111,15 @@ describe('evaluateCapacityThresholds', () => {
     const smallAlert = alerts.find(a => a.applicationName === MONITORED_SMALL);
     expect(sandboxAlert?.severity).toBe('ticket');
     expect(smallAlert?.severity).toBe('page');
+  });
+
+  it('evaluates the code review sandbox app', () => {
+    const apps = [
+      makeApp({ id: 'app-id-3', name: MONITORED_CODE_REVIEW, instances: 96, maxInstances: 100 }),
+    ];
+    const alerts = evaluateCapacityThresholds(apps);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].applicationName).toBe(MONITORED_CODE_REVIEW);
+    expect(alerts[0].severity).toBe('page');
   });
 });


### PR DESCRIPTION
## Summary

- Added `cloud-agent-next-sandboxcodereview` to `MONITORED_CONTAINER_APPS` in `services/o11y/src/alerting/container-capacity.ts` so the o11y service's container-capacity alerting covers the new sandbox code review containers (Cloudflare Containers application `a03c4996-835f-4297-bcdd-3c127143afa9`, account `e115e769bcdd4c3d66af59d3332cb394`), matching the `SandboxCodeReview` container class already deployed in `cloud-agent-next`.
- No architectural change: the o11y capacity query client resolves Cloudflare application IDs dynamically from the Containers list API by matching on name, and the whole service already shares a single account ID that matches this application's account, so this is a one-line allowlist addition.

## Verification

- Manual verification was not possible in this sandbox (no Cloudflare API credentials); the monitored name `cloud-agent-next-sandboxcodereview` was inferred from the existing `<worker-name>-<class_name lowercased>` pattern used by the other two monitored apps. Recommend confirming this matches the actual `name` field returned by `GET /accounts/e115e769bcdd4c3d66af59d3332cb394/containers/applications/a03c4996-835f-4297-bcdd-3c127143afa9` before merging.

## Visual Changes

N/A

## Reviewer Notes

- Added unit tests in `services/o11y/test/container-capacity.spec.ts` and `services/o11y/test/container-capacity-query.spec.ts` covering threshold evaluation and list/detail fetching for the new monitored app.
- Risk area: if Cloudflare's actual application name differs from `cloud-agent-next-sandboxcodereview`, alerting will silently not cover this app (the list-filter step just skips unmatched names, no error is raised).