### PR TITLE
fix(gastown): auto-recover wedged containers

### DIFF
--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -4974,11 +4974,9 @@ export class TownDO extends DurableObject<Env> {
     try {
       const container = getTownContainerStub(this.env, townId);
 
-      // Measure Cloudflare container cold-start latency from the worker's
-      // perspective: warmUp() invokes startAndWaitForPorts() directly, so the
-      // returned durationMs is the true time-to-ready without the arbitrary
-      // 5s truncation of a plain /health ping. For already-warm containers
-      // this is a cheap RPC that returns { coldStart: false }.
+      // Measure Cloudflare container cold-start latency only when warmUp()
+      // actually starts the container. Already-running containers still rely
+      // on the /health probe below as the application-level liveness source.
       try {
         const warm = await container.warmUp();
         if (warm.coldStart) {

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -30,6 +30,11 @@ import * as patrol from './town/patrol';
 import * as scheduling from './town/scheduling';
 import * as events from './town/events';
 import { stopContainerIfIdle as _stopContainerIfIdle } from './town/container-idle-stop';
+import {
+  CONTAINER_HEALTH_STORAGE_KEYS,
+  recoverContainerIfWedged as _recoverContainerIfWedged,
+  type ContainerHealthPingOutcome,
+} from './town/container-health-watchdog';
 import * as scm from './town/town-scm';
 import * as reconciler from './town/reconciler';
 import * as wasteland from './town/wasteland';
@@ -4551,6 +4556,49 @@ export class TownDO extends DurableObject<Env> {
     });
   }
 
+  private async recordContainerHealthOutcome(
+    townId: string,
+    outcome: ContainerHealthPingOutcome
+  ): Promise<void> {
+    await _recoverContainerIfWedged({
+      townId,
+      outcome,
+      isDraining: () => this._draining,
+      getConsecutiveHealthFailures: () =>
+        this.ctx.storage.get<number>(CONTAINER_HEALTH_STORAGE_KEYS.consecutiveHealthFailures),
+      setConsecutiveHealthFailures: value =>
+        this.ctx.storage.put(CONTAINER_HEALTH_STORAGE_KEYS.consecutiveHealthFailures, value),
+      getFirstHealthFailureAt: () =>
+        this.ctx.storage.get<number>(CONTAINER_HEALTH_STORAGE_KEYS.firstHealthFailureAt),
+      setFirstHealthFailureAt: value =>
+        this.ctx.storage.put(CONTAINER_HEALTH_STORAGE_KEYS.firstHealthFailureAt, value),
+      deleteFirstHealthFailureAt: () =>
+        this.ctx.storage.delete(CONTAINER_HEALTH_STORAGE_KEYS.firstHealthFailureAt),
+      getLastAutoRestartAt: () =>
+        this.ctx.storage.get<number>(CONTAINER_HEALTH_STORAGE_KEYS.lastAutoRestartAt),
+      setLastAutoRestartAt: value =>
+        this.ctx.storage.put(CONTAINER_HEALTH_STORAGE_KEYS.lastAutoRestartAt, value),
+      getAutoRestartWindowStart: () =>
+        this.ctx.storage.get<number>(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartWindowStart),
+      setAutoRestartWindowStart: value =>
+        this.ctx.storage.put(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartWindowStart, value),
+      getAutoRestartsInWindow: () =>
+        this.ctx.storage.get<number>(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartsInWindow),
+      setAutoRestartsInWindow: value =>
+        this.ctx.storage.put(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartsInWindow, value),
+      getAutoRestartExhaustedWindowStart: () =>
+        this.ctx.storage.get<number>(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartExhaustedWindowStart),
+      setAutoRestartExhaustedWindowStart: value =>
+        this.ctx.storage.put(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartExhaustedWindowStart, value),
+      deleteAutoRestartExhaustedWindowStart: () =>
+        this.ctx.storage.delete(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartExhaustedWindowStart),
+      getContainerStub: id => getTownContainerStub(this.env, id),
+      writeEventFn: data => writeEvent(this.env, data),
+      logWarnFn: data => logger.warn('container health watchdog', data),
+      now: () => Date.now(),
+    });
+  }
+
   /**
    * Proactively remint KILOCODE_TOKEN when it's approaching expiry.
    * Throttled to once per day — the 30-day token is refreshed when
@@ -4994,10 +5042,22 @@ export class TownDO extends DurableObject<Env> {
             statusCode: healthResp.status,
             error: `non-ok status ${healthResp.status}`,
           });
+          await this.recordContainerHealthOutcome(townId, {
+            ok: false,
+            reason: 'non_ok',
+            durationMs,
+            statusCode: healthResp.status,
+            error: `non-ok status ${healthResp.status}`,
+          });
         } else {
           writeEvent(this.env, {
             event: 'container.health_ping',
             townId,
+            durationMs,
+            statusCode: healthResp.status,
+          });
+          await this.recordContainerHealthOutcome(townId, {
+            ok: true,
             durationMs,
             statusCode: healthResp.status,
           });
@@ -5046,6 +5106,12 @@ export class TownDO extends DurableObject<Env> {
         writeEvent(this.env, {
           event: 'container.health_ping',
           townId,
+          durationMs,
+          error: 'timeout',
+        });
+        await this.recordContainerHealthOutcome(townId, {
+          ok: false,
+          reason: 'timeout',
           durationMs,
           error: 'timeout',
         });

--- a/services/gastown/src/dos/TownContainer.do.ts
+++ b/services/gastown/src/dos/TownContainer.do.ts
@@ -84,14 +84,12 @@ export class TownContainerDO extends Container<Env> {
   }
 
   /**
-   * Ensure the container is running and its default port is ready to accept
-   * traffic. Returns how long the underlying Container class took to satisfy
-   * that (i.e. `startAndWaitForPorts`), along with whether this call actually
-   * triggered a cold start.
+   * Ensure the container runtime has been started. For an already-running
+   * container this intentionally does not trust or refresh the SDK health
+   * state; TownDO's /health probe is the application-level liveness source.
    *
-   * Intended to be called from the Town DO alarm in place of a manual
-   * /health ping — gives an accurate cold-start measurement without being
-   * capped by an arbitrary client-side timeout.
+   * Returns how long startAndWaitForPorts took when this call actually
+   * triggered a cold start.
    */
   async warmUp(): Promise<{ coldStart: boolean; durationMs: number }> {
     if (this.ctx.container?.running === true) {

--- a/services/gastown/src/dos/TownContainer.do.ts
+++ b/services/gastown/src/dos/TownContainer.do.ts
@@ -94,9 +94,10 @@ export class TownContainerDO extends Container<Env> {
    * capped by an arbitrary client-side timeout.
    */
   async warmUp(): Promise<{ coldStart: boolean; durationMs: number }> {
-    const state = await this.getState();
-    const alreadyHealthy = this.ctx.container?.running === true && state.status === 'healthy';
-    if (alreadyHealthy) {
+    if (this.ctx.container?.running === true) {
+      // Runtime-level fast path only. TownDO's /health probe is the
+      // application-level liveness source and may still recover a wedged
+      // running container.
       return { coldStart: false, durationMs: 0 };
     }
     const t0 = Date.now();

--- a/services/gastown/src/dos/town/container-health-watchdog.test.ts
+++ b/services/gastown/src/dos/town/container-health-watchdog.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  CONTAINER_HEALTH_AUTO_RESTART_THROTTLE_MS,
+  CONTAINER_HEALTH_AUTO_RESTART_WINDOW_MS,
+  CONTAINER_HEALTH_COLD_START_GRACE_MS,
+  CONTAINER_HEALTH_FAILURE_THRESHOLD,
+  CONTAINER_HEALTH_MAX_AUTO_RESTARTS_PER_WINDOW,
+  CONTAINER_HEALTH_STORAGE_KEYS,
+  recoverContainerIfWedged,
+  type ContainerHealthLogData,
+  type ContainerHealthPingOutcome,
+  type ContainerHealthWatchdogDeps,
+} from './container-health-watchdog';
+import type { GastownEventData } from '../../util/analytics.util';
+
+type TestDeps = ContainerHealthWatchdogDeps & {
+  _destroyFn: ReturnType<typeof vi.fn>;
+  _store: Map<string, number>;
+  _events: GastownEventData[];
+  _logs: ContainerHealthLogData[];
+  _setOutcome: (outcome: ContainerHealthPingOutcome) => void;
+  _setNow: (value: number) => void;
+};
+
+function failedOutcome(
+  overrides: Partial<Extract<ContainerHealthPingOutcome, { ok: false }>> = {}
+) {
+  return {
+    ok: false,
+    reason: overrides.reason ?? 'timeout',
+    durationMs: overrides.durationMs ?? 5_000,
+    statusCode: overrides.statusCode,
+    error: overrides.error ?? 'timeout',
+  } satisfies ContainerHealthPingOutcome;
+}
+
+function successOutcome(): ContainerHealthPingOutcome {
+  return {
+    ok: true,
+    durationMs: 25,
+    statusCode: 200,
+  };
+}
+
+function makeDeps(
+  overrides: Partial<
+    Pick<
+      ContainerHealthWatchdogDeps,
+      'isDraining' | 'getContainerStub' | 'writeEventFn' | 'logWarnFn'
+    >
+  > = {}
+): TestDeps {
+  const store = new Map<string, number>();
+  const events: GastownEventData[] = [];
+  const logs: ContainerHealthLogData[] = [];
+  const destroyFn = vi.fn().mockResolvedValue(undefined);
+  let outcome: ContainerHealthPingOutcome = failedOutcome();
+  let currentTime = CONTAINER_HEALTH_COLD_START_GRACE_MS + 1;
+
+  return {
+    townId: 'town-1',
+    get outcome() {
+      return outcome;
+    },
+    isDraining: overrides.isDraining ?? (() => false),
+    getConsecutiveHealthFailures: () =>
+      Promise.resolve(store.get(CONTAINER_HEALTH_STORAGE_KEYS.consecutiveHealthFailures)),
+    setConsecutiveHealthFailures: value => {
+      store.set(CONTAINER_HEALTH_STORAGE_KEYS.consecutiveHealthFailures, value);
+      return Promise.resolve();
+    },
+    getFirstHealthFailureAt: () =>
+      Promise.resolve(store.get(CONTAINER_HEALTH_STORAGE_KEYS.firstHealthFailureAt)),
+    setFirstHealthFailureAt: value => {
+      store.set(CONTAINER_HEALTH_STORAGE_KEYS.firstHealthFailureAt, value);
+      return Promise.resolve();
+    },
+    deleteFirstHealthFailureAt: () =>
+      Promise.resolve(store.delete(CONTAINER_HEALTH_STORAGE_KEYS.firstHealthFailureAt)),
+    getLastAutoRestartAt: () =>
+      Promise.resolve(store.get(CONTAINER_HEALTH_STORAGE_KEYS.lastAutoRestartAt)),
+    setLastAutoRestartAt: value => {
+      store.set(CONTAINER_HEALTH_STORAGE_KEYS.lastAutoRestartAt, value);
+      return Promise.resolve();
+    },
+    getAutoRestartWindowStart: () =>
+      Promise.resolve(store.get(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartWindowStart)),
+    setAutoRestartWindowStart: value => {
+      store.set(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartWindowStart, value);
+      return Promise.resolve();
+    },
+    getAutoRestartsInWindow: () =>
+      Promise.resolve(store.get(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartsInWindow)),
+    setAutoRestartsInWindow: value => {
+      store.set(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartsInWindow, value);
+      return Promise.resolve();
+    },
+    getAutoRestartExhaustedWindowStart: () =>
+      Promise.resolve(store.get(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartExhaustedWindowStart)),
+    setAutoRestartExhaustedWindowStart: value => {
+      store.set(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartExhaustedWindowStart, value);
+      return Promise.resolve();
+    },
+    deleteAutoRestartExhaustedWindowStart: () =>
+      Promise.resolve(store.delete(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartExhaustedWindowStart)),
+    getContainerStub:
+      overrides.getContainerStub ??
+      (() => ({
+        destroy: destroyFn,
+      })),
+    writeEventFn:
+      overrides.writeEventFn ??
+      (data => {
+        events.push(data);
+      }),
+    logWarnFn:
+      overrides.logWarnFn ??
+      (data => {
+        logs.push(data);
+      }),
+    now: () => currentTime,
+    _destroyFn: destroyFn,
+    _store: store,
+    _events: events,
+    _logs: logs,
+    _setOutcome: value => {
+      outcome = value;
+    },
+    _setNow: value => {
+      currentTime = value;
+    },
+  };
+}
+
+function seedRestartReadyFailureState(deps: TestDeps, firstFailureAt: number): void {
+  deps._store.set(
+    CONTAINER_HEALTH_STORAGE_KEYS.consecutiveHealthFailures,
+    CONTAINER_HEALTH_FAILURE_THRESHOLD - 1
+  );
+  deps._store.set(CONTAINER_HEALTH_STORAGE_KEYS.firstHealthFailureAt, firstFailureAt);
+}
+
+async function triggerRestartReadyFailure(deps: TestDeps, now: number): Promise<void> {
+  deps._setNow(now);
+  seedRestartReadyFailureState(deps, now - CONTAINER_HEALTH_COLD_START_GRACE_MS - 1);
+  await recoverContainerIfWedged(deps);
+}
+
+describe('recoverContainerIfWedged', () => {
+  it('does not restart below threshold, then restarts once threshold and grace both pass', async () => {
+    const deps = makeDeps();
+    deps._setNow(0);
+    await recoverContainerIfWedged(deps);
+    deps._setNow(5_000);
+    await recoverContainerIfWedged(deps);
+
+    expect(deps._destroyFn).not.toHaveBeenCalled();
+
+    deps._setNow(CONTAINER_HEALTH_COLD_START_GRACE_MS + 1);
+    await recoverContainerIfWedged(deps);
+
+    expect(deps._destroyFn).toHaveBeenCalledTimes(1);
+    expect(deps._events).toHaveLength(1);
+    expect(deps._events[0]).toMatchObject({
+      event: 'container.auto_restart',
+      townId: 'town-1',
+      reason: 'health_ping_timeout',
+      value: CONTAINER_HEALTH_FAILURE_THRESHOLD,
+    });
+    expect(deps._store.get(CONTAINER_HEALTH_STORAGE_KEYS.consecutiveHealthFailures)).toBe(0);
+  });
+
+  it('resets the consecutive counter on success', async () => {
+    const deps = makeDeps();
+    deps._setNow(0);
+    await recoverContainerIfWedged(deps);
+
+    deps._setOutcome(successOutcome());
+    await recoverContainerIfWedged(deps);
+
+    deps._setOutcome(failedOutcome());
+    deps._setNow(CONTAINER_HEALTH_COLD_START_GRACE_MS + 1);
+    await recoverContainerIfWedged(deps);
+    await recoverContainerIfWedged(deps);
+
+    expect(deps._destroyFn).not.toHaveBeenCalled();
+    expect(deps._store.get(CONTAINER_HEALTH_STORAGE_KEYS.consecutiveHealthFailures)).toBe(2);
+    expect(deps._store.has(CONTAINER_HEALTH_STORAGE_KEYS.firstHealthFailureAt)).toBe(true);
+  });
+
+  it('does not restart while draining', async () => {
+    const deps = makeDeps({ isDraining: () => true });
+    await triggerRestartReadyFailure(deps, CONTAINER_HEALTH_COLD_START_GRACE_MS + 1);
+
+    expect(deps._destroyFn).not.toHaveBeenCalled();
+    expect(deps._logs).toContainEqual(
+      expect.objectContaining({
+        event: 'container.auto_restart_skipped',
+        reason: 'draining',
+      })
+    );
+  });
+
+  it('does not restart before the cold-start grace span has elapsed', async () => {
+    const deps = makeDeps();
+    deps._setNow(10_000);
+    await recoverContainerIfWedged(deps);
+    await recoverContainerIfWedged(deps);
+    await recoverContainerIfWedged(deps);
+
+    expect(deps._destroyFn).not.toHaveBeenCalled();
+    expect(deps._logs).toContainEqual(
+      expect.objectContaining({
+        event: 'container.auto_restart_skipped',
+        reason: 'cold_start_grace',
+      })
+    );
+  });
+
+  it('throttles repeated restart triggers inside the throttle window', async () => {
+    const deps = makeDeps();
+    await triggerRestartReadyFailure(deps, CONTAINER_HEALTH_COLD_START_GRACE_MS + 1);
+
+    await triggerRestartReadyFailure(
+      deps,
+      CONTAINER_HEALTH_COLD_START_GRACE_MS + CONTAINER_HEALTH_AUTO_RESTART_THROTTLE_MS
+    );
+
+    expect(deps._destroyFn).toHaveBeenCalledTimes(1);
+    expect(deps._logs).toContainEqual(
+      expect.objectContaining({
+        event: 'container.auto_restart_skipped',
+        reason: 'throttled',
+      })
+    );
+  });
+
+  it('stops restarting after the fixed-window cap and emits exhausted once per window', async () => {
+    const deps = makeDeps();
+    let now = CONTAINER_HEALTH_COLD_START_GRACE_MS + 1;
+
+    for (let i = 0; i < CONTAINER_HEALTH_MAX_AUTO_RESTARTS_PER_WINDOW; i += 1) {
+      await triggerRestartReadyFailure(deps, now);
+      now += CONTAINER_HEALTH_AUTO_RESTART_THROTTLE_MS + 1;
+    }
+    await triggerRestartReadyFailure(deps, now);
+    await triggerRestartReadyFailure(deps, now + CONTAINER_HEALTH_AUTO_RESTART_THROTTLE_MS + 1);
+
+    expect(deps._destroyFn).toHaveBeenCalledTimes(CONTAINER_HEALTH_MAX_AUTO_RESTARTS_PER_WINDOW);
+    expect(
+      deps._events.filter(event => event.event === 'container.auto_restart_exhausted')
+    ).toHaveLength(1);
+  });
+
+  it('allows restarts again after the fixed window resets', async () => {
+    const deps = makeDeps();
+    const windowStart = CONTAINER_HEALTH_COLD_START_GRACE_MS + 1;
+    let now = windowStart;
+
+    for (let i = 0; i < CONTAINER_HEALTH_MAX_AUTO_RESTARTS_PER_WINDOW; i += 1) {
+      await triggerRestartReadyFailure(deps, now);
+      now += CONTAINER_HEALTH_AUTO_RESTART_THROTTLE_MS + 1;
+    }
+
+    await triggerRestartReadyFailure(
+      deps,
+      windowStart + CONTAINER_HEALTH_AUTO_RESTART_WINDOW_MS + 1
+    );
+
+    expect(deps._destroyFn).toHaveBeenCalledTimes(
+      CONTAINER_HEALTH_MAX_AUTO_RESTARTS_PER_WINDOW + 1
+    );
+    expect(deps._store.get(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartsInWindow)).toBe(1);
+  });
+
+  it('emits an error event without advancing throttle state when destroy throws', async () => {
+    const destroyFn = vi.fn().mockRejectedValue(new Error('destroy failed'));
+    const deps = makeDeps({
+      getContainerStub: () => ({
+        destroy: destroyFn,
+      }),
+    });
+
+    await triggerRestartReadyFailure(deps, CONTAINER_HEALTH_COLD_START_GRACE_MS + 1);
+
+    expect(destroyFn).toHaveBeenCalledTimes(1);
+    expect(deps._events).toHaveLength(1);
+    expect(deps._events[0]).toMatchObject({
+      event: 'container.auto_restart',
+      error: 'destroy failed',
+    });
+    expect(deps._store.has(CONTAINER_HEALTH_STORAGE_KEYS.lastAutoRestartAt)).toBe(false);
+  });
+});

--- a/services/gastown/src/dos/town/container-health-watchdog.ts
+++ b/services/gastown/src/dos/town/container-health-watchdog.ts
@@ -1,0 +1,261 @@
+import type { GastownEventData } from '../../util/analytics.util';
+
+export const CONTAINER_HEALTH_FAILURE_THRESHOLD = 3;
+export const CONTAINER_HEALTH_COLD_START_GRACE_MS = 60_000;
+export const CONTAINER_HEALTH_AUTO_RESTART_THROTTLE_MS = 60_000;
+export const CONTAINER_HEALTH_AUTO_RESTART_WINDOW_MS = 30 * 60_000;
+export const CONTAINER_HEALTH_MAX_AUTO_RESTARTS_PER_WINDOW = 3;
+
+export const CONTAINER_HEALTH_STORAGE_KEYS = {
+  consecutiveHealthFailures: 'container:consecutiveHealthFailures',
+  firstHealthFailureAt: 'container:firstHealthFailureAt',
+  lastAutoRestartAt: 'container:lastAutoRestartAt',
+  autoRestartWindowStart: 'container:autoRestartWindowStart',
+  autoRestartsInWindow: 'container:autoRestartsInWindow',
+  autoRestartExhaustedWindowStart: 'container:autoRestartExhaustedWindowStart',
+} as const;
+
+export type ContainerHealthPingOutcome =
+  | {
+      ok: true;
+      durationMs: number;
+      statusCode: number;
+    }
+  | {
+      ok: false;
+      reason: string;
+      durationMs: number;
+      statusCode?: number;
+      error?: string;
+    };
+
+export type ContainerHealthLogData = {
+  event: string;
+  townId: string;
+  reason?: string;
+  consecutiveFailures?: number;
+  statusCode?: number;
+  error?: string;
+  durationMs?: number;
+};
+
+export type ContainerHealthWatchdogDeps = {
+  townId: string;
+  outcome: ContainerHealthPingOutcome;
+  isDraining: () => boolean;
+  getConsecutiveHealthFailures: () => Promise<number | undefined>;
+  setConsecutiveHealthFailures: (value: number) => Promise<void>;
+  getFirstHealthFailureAt: () => Promise<number | undefined>;
+  setFirstHealthFailureAt: (value: number) => Promise<void>;
+  deleteFirstHealthFailureAt: () => Promise<unknown>;
+  getLastAutoRestartAt: () => Promise<number | undefined>;
+  setLastAutoRestartAt: (value: number) => Promise<void>;
+  getAutoRestartWindowStart: () => Promise<number | undefined>;
+  setAutoRestartWindowStart: (value: number) => Promise<void>;
+  getAutoRestartsInWindow: () => Promise<number | undefined>;
+  setAutoRestartsInWindow: (value: number) => Promise<void>;
+  getAutoRestartExhaustedWindowStart: () => Promise<number | undefined>;
+  setAutoRestartExhaustedWindowStart: (value: number) => Promise<void>;
+  deleteAutoRestartExhaustedWindowStart: () => Promise<unknown>;
+  getContainerStub: (townId: string) => {
+    destroy: () => Promise<void>;
+  };
+  writeEventFn: (data: GastownEventData) => void;
+  logWarnFn: (data: ContainerHealthLogData) => void;
+  now: () => number;
+};
+
+export async function recoverContainerIfWedged(deps: ContainerHealthWatchdogDeps): Promise<void> {
+  try {
+    await recoverContainerIfWedgedInner(deps);
+  } catch (err) {
+    safeLog(deps, {
+      event: 'container.health_watchdog_error',
+      townId: deps.townId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+async function recoverContainerIfWedgedInner(deps: ContainerHealthWatchdogDeps): Promise<void> {
+  if (deps.outcome.ok) {
+    await deps.setConsecutiveHealthFailures(0);
+    await deps.deleteFirstHealthFailureAt();
+    return;
+  }
+
+  const now = deps.now();
+  const previousFailures = (await deps.getConsecutiveHealthFailures()) ?? 0;
+  const consecutiveFailures = previousFailures + 1;
+  const storedFirstFailureAt = await deps.getFirstHealthFailureAt();
+  const firstFailureAt = storedFirstFailureAt ?? now;
+
+  await deps.setConsecutiveHealthFailures(consecutiveFailures);
+  if (storedFirstFailureAt == null) {
+    await deps.setFirstHealthFailureAt(firstFailureAt);
+  }
+
+  if (consecutiveFailures === CONTAINER_HEALTH_FAILURE_THRESHOLD) {
+    safeLog(deps, {
+      event: 'container.health_ping',
+      townId: deps.townId,
+      reason: deps.outcome.reason,
+      consecutiveFailures,
+      statusCode: deps.outcome.statusCode,
+      error: deps.outcome.error,
+      durationMs: deps.outcome.durationMs,
+    });
+  }
+
+  if (consecutiveFailures < CONTAINER_HEALTH_FAILURE_THRESHOLD) return;
+
+  if (deps.isDraining()) {
+    safeLog(deps, {
+      event: 'container.auto_restart_skipped',
+      townId: deps.townId,
+      reason: 'draining',
+      consecutiveFailures,
+      statusCode: deps.outcome.statusCode,
+      durationMs: deps.outcome.durationMs,
+    });
+    return;
+  }
+
+  if (now - firstFailureAt <= CONTAINER_HEALTH_COLD_START_GRACE_MS) {
+    safeLog(deps, {
+      event: 'container.auto_restart_skipped',
+      townId: deps.townId,
+      reason: 'cold_start_grace',
+      consecutiveFailures,
+      statusCode: deps.outcome.statusCode,
+      durationMs: deps.outcome.durationMs,
+    });
+    return;
+  }
+
+  const lastAutoRestartAt = await deps.getLastAutoRestartAt();
+  if (
+    lastAutoRestartAt != null &&
+    now - lastAutoRestartAt < CONTAINER_HEALTH_AUTO_RESTART_THROTTLE_MS
+  ) {
+    safeLog(deps, {
+      event: 'container.auto_restart_skipped',
+      townId: deps.townId,
+      reason: 'throttled',
+      consecutiveFailures,
+      statusCode: deps.outcome.statusCode,
+      durationMs: deps.outcome.durationMs,
+    });
+    return;
+  }
+
+  const windowState = await getRestartWindowState(deps, now);
+  if (windowState.restartsInWindow >= CONTAINER_HEALTH_MAX_AUTO_RESTARTS_PER_WINDOW) {
+    const exhaustedWindowStart = await deps.getAutoRestartExhaustedWindowStart();
+    if (exhaustedWindowStart !== windowState.windowStart) {
+      await deps.setAutoRestartExhaustedWindowStart(windowState.windowStart);
+      const event = {
+        event: 'container.auto_restart_exhausted',
+        townId: deps.townId,
+        reason: deps.outcome.reason,
+        value: consecutiveFailures,
+        durationMs: deps.outcome.durationMs,
+        statusCode: deps.outcome.statusCode,
+      } satisfies GastownEventData;
+      safeWriteEvent(deps, event);
+      safeLog(deps, {
+        event: 'container.auto_restart_exhausted',
+        townId: deps.townId,
+        reason: deps.outcome.reason,
+        consecutiveFailures,
+        statusCode: deps.outcome.statusCode,
+        durationMs: deps.outcome.durationMs,
+      });
+    }
+    return;
+  }
+
+  const reason = `health_ping_${deps.outcome.reason}`;
+  try {
+    safeLog(deps, {
+      event: 'container.auto_restart',
+      townId: deps.townId,
+      reason,
+      consecutiveFailures,
+      statusCode: deps.outcome.statusCode,
+      durationMs: deps.outcome.durationMs,
+    });
+    await deps.getContainerStub(deps.townId).destroy();
+  } catch (err) {
+    const error = err instanceof Error ? err.message.slice(0, 300) : String(err).slice(0, 300);
+    safeWriteEvent(deps, {
+      event: 'container.auto_restart',
+      townId: deps.townId,
+      reason,
+      value: consecutiveFailures,
+      durationMs: deps.outcome.durationMs,
+      statusCode: deps.outcome.statusCode,
+      error,
+    });
+    safeLog(deps, {
+      event: 'container.auto_restart',
+      townId: deps.townId,
+      reason,
+      consecutiveFailures,
+      statusCode: deps.outcome.statusCode,
+      durationMs: deps.outcome.durationMs,
+      error,
+    });
+    return;
+  }
+
+  await deps.setLastAutoRestartAt(now);
+  await deps.setAutoRestartWindowStart(windowState.windowStart);
+  await deps.setAutoRestartsInWindow(windowState.restartsInWindow + 1);
+  await deps.setConsecutiveHealthFailures(0);
+  await deps.deleteFirstHealthFailureAt();
+
+  safeWriteEvent(deps, {
+    event: 'container.auto_restart',
+    townId: deps.townId,
+    reason,
+    value: consecutiveFailures,
+    durationMs: deps.outcome.durationMs,
+    statusCode: deps.outcome.statusCode,
+  });
+}
+
+async function getRestartWindowState(
+  deps: ContainerHealthWatchdogDeps,
+  now: number
+): Promise<{ windowStart: number; restartsInWindow: number }> {
+  const storedWindowStart = await deps.getAutoRestartWindowStart();
+  if (
+    storedWindowStart == null ||
+    now - storedWindowStart >= CONTAINER_HEALTH_AUTO_RESTART_WINDOW_MS
+  ) {
+    await deps.deleteAutoRestartExhaustedWindowStart();
+    return { windowStart: now, restartsInWindow: 0 };
+  }
+
+  return {
+    windowStart: storedWindowStart,
+    restartsInWindow: (await deps.getAutoRestartsInWindow()) ?? 0,
+  };
+}
+
+function safeWriteEvent(deps: ContainerHealthWatchdogDeps, data: GastownEventData): void {
+  try {
+    deps.writeEventFn(data);
+  } catch {
+    // Best-effort — never throw from watchdog observability.
+  }
+}
+
+function safeLog(deps: ContainerHealthWatchdogDeps, data: ContainerHealthLogData): void {
+  try {
+    deps.logWarnFn(data);
+  } catch {
+    // Best-effort — never throw from watchdog observability.
+  }
+}

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -22,6 +22,7 @@
       "head_sampling_rate": 0.1,
     },
   },
+  "logpush": true,
   "upload_source_maps": true,
   "version_metadata": { "binding": "CF_VERSION_METADATA" },
   "routes": [
@@ -121,6 +122,7 @@
 
   "env": {
     "dev": {
+      "logpush": true,
       "vars": {
         "ENVIRONMENT": "development",
         "CF_ACCESS_TEAM": "engineering-e11",

--- a/services/gastown/wrangler.test.jsonc
+++ b/services/gastown/wrangler.test.jsonc
@@ -5,6 +5,7 @@
   "main": "src/gastown.worker.ts",
   "compatibility_date": "2026-02-24",
   "compatibility_flags": ["nodejs_compat", "service_binding_extra_handlers"],
+  "logpush": true,
 
   "containers": [
     {


### PR DESCRIPTION
## Summary
Adds Gastown container health auto-recovery and Worker Logpush visibility for wedged town containers.

### Why this change is needed
Warm Gastown town containers have repeatedly stopped answering `TownContainerDO` health pings while still appearing alive at the container runtime level. Until now, the alarm loop only retried and recovery required manual container restarts, which turned runtime wedges into extended user-facing outages.

Gastown also had Workers observability enabled without Worker Logpush, so affected-town identity and recovery signals were not available through the Axiom `cloudflare-logpush` path used by on-call triage.

### How this is addressed
- Tracks consecutive TownDO health ping failures in Durable Object storage and resets the counter on successful health pings.
- Destroys wedged containers after the failure threshold and cold-start grace have both passed, letting the next alarm cold-start a fresh container placement.
- Adds throttle and fixed-window restart caps to avoid restart storms, with an exhausted event when recovery is suppressed.
- Emits Analytics Engine events and structured Worker log lines for health failures, auto-restarts, and exhausted restart windows.
- Treats `TownContainerDO.warmUp()` as a runtime-start helper while leaving application liveness to the TownDO `/health` probe.
- Enables Worker Logpush for Gastown root, dev, and test Wrangler configs.

## Human Verification
- Ran Gastown Vitest unit suite: 18 test files passed, 287 tests passed.

## Reviewer Notes
### Human Reviewer Flags
- This is Tier 1 mitigation only. The upstream Cloudflare Containers runtime wedge trigger still needs separate escalation.
- Recovery intentionally uses `destroy()` rather than `stop()` so wedged containers are SIGKILLed and re-placed instead of gracefully drained.
- Logpush still requires human/ops deployment and account-level Workers Trace Logpush-to-Axiom confirmation.
- Container stdout routing to `cloudflare-logpush` still needs post-deploy verification.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Watchdog state is dependency-injected and unit-tested without a live Durable Object or Cloudflare container.
- Cold-start grace is based on an explicit `container:firstHealthFailureAt` timestamp instead of deriving elapsed time from alarm cadence.
- Restart exhaustion is tracked with `container:autoRestartExhaustedWindowStart` so `container.auto_restart_exhausted` emits once per fixed window.
- Analytics and log writes are best-effort and do not throw out of the alarm path.

</details>
