### PR TITLE
refactor(cloud-agent-next): drop elapsed ms from process diagnostic

### DIFF
--- a/services/cloud-agent-next/src/kilo/wrapper-ready-error.test.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-ready-error.test.ts
@@ -11,7 +11,7 @@ describe('wrapper ready error parsing', () => {
         error: 'WORKSPACE_SETUP_FAILED',
         subtype: 'git_clone_timeout',
         message: 'Repository clone timed out',
-        detail: 'termination timeout, elapsed 120000ms, output truncated',
+        detail: 'termination timeout, output truncated',
         retryable: true,
         wrapperRunId: 'wrapper_run_1',
       })
@@ -19,7 +19,7 @@ describe('wrapper ready error parsing', () => {
       error: 'WORKSPACE_SETUP_FAILED',
       subtype: 'git_clone_timeout',
       message: 'Repository clone timed out',
-      detail: 'termination timeout, elapsed 120000ms, output truncated',
+      detail: 'termination timeout, output truncated',
       retryable: true,
       wrapperRunId: 'wrapper_run_1',
     });

--- a/services/cloud-agent-next/test/unit/wrapper/utils.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/utils.test.ts
@@ -63,7 +63,7 @@ describe('createSafeProcessDiagnostic', () => {
       stdoutTruncated: true,
     });
 
-    expect(detail).toBe('termination nonzero exit, exit code 2, elapsed 42ms, output truncated');
+    expect(detail).toBe('termination nonzero exit, exit code 2, output truncated');
     for (const sensitiveValue of sensitiveValues) expect(detail).not.toContain(sensitiveValue);
   });
 
@@ -78,7 +78,7 @@ describe('createSafeProcessDiagnostic', () => {
     },
     {
       result: { stdout: '', stderr: '', exitCode: 0, elapsedMs: 7 },
-      expected: 'termination completed, elapsed 7ms',
+      expected: 'termination completed',
     },
   ])('reports structured termination metadata', ({ result, expected }) => {
     expect(createSafeProcessDiagnostic(result)).toBe(expected);

--- a/services/cloud-agent-next/wrapper/src/server.test.ts
+++ b/services/cloud-agent-next/wrapper/src/server.test.ts
@@ -121,7 +121,7 @@ describe('session readiness errors', () => {
           code: 'WORKSPACE_SETUP_FAILED',
           subtype: 'git_clone_timeout',
           message: 'Repository clone timed out',
-          detail: 'termination timeout, elapsed 120000ms, output truncated',
+          detail: 'termination timeout, output truncated',
           retryable: true,
         },
       }),
@@ -156,7 +156,7 @@ describe('session readiness errors', () => {
       error: 'WORKSPACE_SETUP_FAILED',
       subtype: 'git_clone_timeout',
       message: 'Repository clone timed out',
-      detail: 'termination timeout, elapsed 120000ms, output truncated',
+      detail: 'termination timeout, output truncated',
       retryable: true,
     });
     expect(fetchHandler).toBeDefined();

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -738,7 +738,7 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     });
     expect(setupError.message).toBe('Setup command 1 failed');
     expect(setupError).toMatchObject({
-      detail: 'termination nonzero exit, exit code 1, elapsed 17ms, output truncated',
+      detail: 'termination nonzero exit, exit code 1, output truncated',
     });
     const projectedError = JSON.stringify(setupError);
     for (const sensitiveValue of [

--- a/services/cloud-agent-next/wrapper/src/utils.ts
+++ b/services/cloud-agent-next/wrapper/src/utils.ts
@@ -80,7 +80,6 @@ export function createSafeProcessDiagnostic(result: ExecResult): string {
     result.terminationReason === undefined && result.exitCode !== 0
       ? `exit code ${result.exitCode}`
       : undefined,
-    result.elapsedMs === undefined ? undefined : `elapsed ${result.elapsedMs}ms`,
     result.stdoutTruncated === true || result.stderrTruncated === true
       ? TRUNCATION_MARKER
       : undefined,


### PR DESCRIPTION
## Summary

Drop the `elapsed Nms` clause from the user-facing process diagnostic emitted by `createSafeProcessDiagnostic` in `services/cloud-agent-next/wrapper/src/utils.ts`. This clause carried no operational signal for recipients — duration varied by host, command, and redaction — and it inflated the termination detail that gets re-prefixed by `safe-failure-projection` for every workspace-setup and command-runner error path. The result surfaces as shorter, more focused details in user-visible messages such as:

- `Workspace setup failed: sandbox storage full: termination nonzero exit, exit code 128` (down from `... elapsed 182966ms`)

`ExecResult.elapsedMs` is preserved on the wrapper side for telemetry.

## Verification

- `pnpm --filter cloud-agent-next exec vitest run test/unit/wrapper/utils.test.ts wrapper/src/session-bootstrap.test.ts wrapper/src/server.test.ts src/kilo/wrapper-ready-error.test.ts` — 20/20 pass.
- `pnpm --filter cloud-agent-next run format` — clean.
- `pnpm --filter cloud-agent-next run lint` — clean.
- `pnpm --filter cloud-agent-next exec typecheck` was not run; the change is one source line and matching test-assertion text updates, with no signature/type surface changes.

## Visual Changes

N/A — affects an internal log/diagnostic string only; no UI change.

## Reviewer Notes

- Touches 1 production line and 4 test files (5 assertion updates). The two wrapper test files (`server.test.ts`, `session-bootstrap.test.ts`) and `kilo/wrapper-ready-error.test.ts` only have expected-detail string updates.
- `ExecResult.elapsedMs` is intentionally retained: it is still set by `runProcess` and consumed by other call sites for timing (e.g. `kilo import finished outcome=... elapsedMs=...` structured logs in `restore-session.ts`).
- The commit was force-pushed with `--force-with-lease` after rebasing onto the latest `main` ("Skip Bedrock for Fable" moved in) and replacing a stale `wip` commit that had also bundled an unrelated oxfmt pass on the auto-generated `default-slash-commands.generated.ts`.