### PR TITLE
feat(gastown,o11y): definitive recovery signal and wedge-only paging

### DIFF
--- a/services/gastown/docs/post-deploy-monitoring.md
+++ b/services/gastown/docs/post-deploy-monitoring.md
@@ -366,6 +366,9 @@ The `gastown_events` dataset maps fields as follows:
 | blob11 | convoyId | Convoy ID |
 | blob12 | role | Agent role (`polecat`, `refinery`, `mayor`) |
 | blob13 | beadType | Bead type |
+| blob14 | reason | Failure/action reason (e.g. `timeout`, `auto_restart`) |
+| blob15 | containerStartedAt | Container boot timestamp (ISO) |
+| blob16 | containerId | Cloudflare container id (TownContainerDO Durable Object id) |
 | double1 | durationMs | Duration in milliseconds |
 | double2 | value | Generic numeric value |
 | double3 | actionsEmitted | (reconciler_tick) actions count |

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -34,6 +34,7 @@ import {
   CONTAINER_HEALTH_STORAGE_KEYS,
   recoverContainerIfWedged as _recoverContainerIfWedged,
   type ContainerHealthPingOutcome,
+  type ContainerRecoveryPathHint,
 } from './town/container-health-watchdog';
 import * as scm from './town/town-scm';
 import * as reconciler from './town/reconciler';
@@ -64,7 +65,7 @@ import {
 } from '../db/tables/agent-nudges.table';
 import { query } from '../util/query.util';
 import { getAgentDOStub } from './Agent.do';
-import { getTownContainerStub } from './TownContainer.do';
+import { getTownContainerDoId, getTownContainerStub } from './TownContainer.do';
 
 import { kiloTokenPayload } from '@kilocode/worker-utils';
 import { jwtVerify } from 'jose';
@@ -4562,6 +4563,7 @@ export class TownDO extends DurableObject<Env> {
   ): Promise<void> {
     await _recoverContainerIfWedged({
       townId,
+      containerDoId: getTownContainerDoId(this.env, townId),
       outcome,
       isDraining: () => this._draining,
       getConsecutiveHealthFailures: () =>
@@ -4592,6 +4594,20 @@ export class TownDO extends DurableObject<Env> {
         this.ctx.storage.put(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartExhaustedWindowStart, value),
       deleteAutoRestartExhaustedWindowStart: () =>
         this.ctx.storage.delete(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartExhaustedWindowStart),
+      getUnhealthyEpisodeStartedAt: () =>
+        this.ctx.storage.get<number>(CONTAINER_HEALTH_STORAGE_KEYS.unhealthyEpisodeStartedAt),
+      setUnhealthyEpisodeStartedAt: value =>
+        this.ctx.storage.put(CONTAINER_HEALTH_STORAGE_KEYS.unhealthyEpisodeStartedAt, value),
+      deleteUnhealthyEpisodeStartedAt: () =>
+        this.ctx.storage.delete(CONTAINER_HEALTH_STORAGE_KEYS.unhealthyEpisodeStartedAt),
+      getRecoveryPathHint: () =>
+        this.ctx.storage.get<ContainerRecoveryPathHint>(
+          CONTAINER_HEALTH_STORAGE_KEYS.recoveryPathHint
+        ),
+      setRecoveryPathHint: value =>
+        this.ctx.storage.put(CONTAINER_HEALTH_STORAGE_KEYS.recoveryPathHint, value),
+      deleteRecoveryPathHint: () =>
+        this.ctx.storage.delete(CONTAINER_HEALTH_STORAGE_KEYS.recoveryPathHint),
       getContainerStub: id => getTownContainerStub(this.env, id),
       writeEventFn: data => writeEvent(this.env, data),
       logWarnFn: data => logger.warn('container health watchdog', data),
@@ -4971,6 +4987,10 @@ export class TownDO extends DurableObject<Env> {
     const townId = this.townId;
     if (!townId) return;
 
+    // Cloudflare container identity, stamped on boot lifecycle telemetry so it
+    // correlates with Cloudflare support/dashboard and the watchdog events.
+    const containerId = getTownContainerDoId(this.env, townId);
+
     try {
       const container = getTownContainerStub(this.env, townId);
 
@@ -4983,14 +5003,31 @@ export class TownDO extends DurableObject<Env> {
           writeEvent(this.env, {
             event: 'container.cold_start',
             townId,
+            containerId,
+            durationMs: warm.durationMs,
+          });
+          // Dual-write boot lifecycle to Logpush (watchdog envelope) so Axiom
+          // carries it too. Runs inside the alarm's withLogTags source scope.
+          logger.warn('container health watchdog', {
+            event: 'container.cold_start',
+            townId,
+            containerId,
             durationMs: warm.durationMs,
           });
         }
       } catch (err) {
+        const error = err instanceof Error ? err.message.slice(0, 300) : String(err).slice(0, 300);
         writeEvent(this.env, {
           event: 'container.cold_start',
           townId,
-          error: err instanceof Error ? err.message.slice(0, 300) : String(err).slice(0, 300),
+          containerId,
+          error,
+        });
+        logger.warn('container health watchdog', {
+          event: 'container.cold_start',
+          townId,
+          containerId,
+          error,
         });
         // Fall through to /health ping anyway — the container may recover.
       }
@@ -5036,6 +5073,7 @@ export class TownDO extends DurableObject<Env> {
           writeEvent(this.env, {
             event: 'container.health_ping',
             townId,
+            containerId,
             durationMs,
             statusCode: healthResp.status,
             error: `non-ok status ${healthResp.status}`,
@@ -5051,6 +5089,7 @@ export class TownDO extends DurableObject<Env> {
           writeEvent(this.env, {
             event: 'container.health_ping',
             townId,
+            containerId,
             durationMs,
             statusCode: healthResp.status,
           });
@@ -5070,11 +5109,20 @@ export class TownDO extends DurableObject<Env> {
           const body = HealthBody.safeParse(rawBody);
           if (body.success && body.data.startedAt) {
             const containerStartedAt = new Date(body.data.startedAt).getTime();
+            const readyDurationMs = Date.now() - containerStartedAt;
             writeEvent(this.env, {
               event: 'container.ready_observed',
               townId,
+              containerId,
               containerStartedAt: body.data.startedAt,
-              durationMs: Date.now() - containerStartedAt,
+              durationMs: readyDurationMs,
+            });
+            // Dual-write boot lifecycle to Logpush (watchdog envelope) for Axiom.
+            logger.warn('container health watchdog', {
+              event: 'container.ready_observed',
+              townId,
+              containerId,
+              durationMs: readyDurationMs,
             });
 
             // Emit mayor.session_ready exactly once per container instance.
@@ -5104,6 +5152,7 @@ export class TownDO extends DurableObject<Env> {
         writeEvent(this.env, {
           event: 'container.health_ping',
           townId,
+          containerId,
           durationMs,
           error: 'timeout',
         });

--- a/services/gastown/src/dos/TownContainer.do.ts
+++ b/services/gastown/src/dos/TownContainer.do.ts
@@ -122,3 +122,13 @@ export class TownContainerDO extends Container<Env> {
 export function getTownContainerStub(env: Env, townId: string) {
   return env.TOWN_CONTAINER.get(env.TOWN_CONTAINER.idFromName(townId));
 }
+
+/**
+ * Stable Cloudflare identity of a town's container: the TownContainerDO's
+ * Durable Object id (hex). This is the id Cloudflare support correlates a
+ * container instance by, and the same value TownContainerDO logs in its
+ * onStart/onStop/onError callbacks. Deterministic from townId, no I/O.
+ */
+export function getTownContainerDoId(env: Env, townId: string): string {
+  return env.TOWN_CONTAINER.idFromName(townId).toString();
+}

--- a/services/gastown/src/dos/town/container-health-watchdog.test.ts
+++ b/services/gastown/src/dos/town/container-health-watchdog.test.ts
@@ -10,6 +10,7 @@ import {
   type ContainerHealthLogData,
   type ContainerHealthPingOutcome,
   type ContainerHealthWatchdogDeps,
+  type ContainerRecoveryPathHint,
 } from './container-health-watchdog';
 import type { GastownEventData } from '../../util/analytics.util';
 
@@ -54,11 +55,13 @@ function makeDeps(
   const events: GastownEventData[] = [];
   const logs: ContainerHealthLogData[] = [];
   const destroyFn = vi.fn().mockResolvedValue(undefined);
+  let recoveryPathHint: ContainerRecoveryPathHint | undefined;
   let outcome: ContainerHealthPingOutcome = failedOutcome();
   let currentTime = CONTAINER_HEALTH_COLD_START_GRACE_MS + 1;
 
   return {
     townId: 'town-1',
+    containerDoId: 'container-do-abc',
     get outcome() {
       return outcome;
     },
@@ -103,6 +106,23 @@ function makeDeps(
     },
     deleteAutoRestartExhaustedWindowStart: () =>
       Promise.resolve(store.delete(CONTAINER_HEALTH_STORAGE_KEYS.autoRestartExhaustedWindowStart)),
+    getUnhealthyEpisodeStartedAt: () =>
+      Promise.resolve(store.get(CONTAINER_HEALTH_STORAGE_KEYS.unhealthyEpisodeStartedAt)),
+    setUnhealthyEpisodeStartedAt: value => {
+      store.set(CONTAINER_HEALTH_STORAGE_KEYS.unhealthyEpisodeStartedAt, value);
+      return Promise.resolve();
+    },
+    deleteUnhealthyEpisodeStartedAt: () =>
+      Promise.resolve(store.delete(CONTAINER_HEALTH_STORAGE_KEYS.unhealthyEpisodeStartedAt)),
+    getRecoveryPathHint: () => Promise.resolve(recoveryPathHint),
+    setRecoveryPathHint: value => {
+      recoveryPathHint = value;
+      return Promise.resolve();
+    },
+    deleteRecoveryPathHint: () => {
+      recoveryPathHint = undefined;
+      return Promise.resolve(true);
+    },
     getContainerStub:
       overrides.getContainerStub ??
       (() => ({
@@ -164,9 +184,14 @@ describe('recoverContainerIfWedged', () => {
     expect(deps._events[0]).toMatchObject({
       event: 'container.auto_restart',
       townId: 'town-1',
+      containerId: 'container-do-abc',
       reason: 'health_ping_timeout',
       value: CONTAINER_HEALTH_FAILURE_THRESHOLD,
     });
+    // The Cloudflare container id is stamped on both sinks for support debugging.
+    expect(deps._logs).toContainEqual(
+      expect.objectContaining({ event: 'container.auto_restart', containerId: 'container-do-abc' })
+    );
     expect(deps._store.get(CONTAINER_HEALTH_STORAGE_KEYS.consecutiveHealthFailures)).toBe(0);
   });
 
@@ -290,5 +315,113 @@ describe('recoverContainerIfWedged', () => {
       error: 'destroy failed',
     });
     expect(deps._store.has(CONTAINER_HEALTH_STORAGE_KEYS.lastAutoRestartAt)).toBe(false);
+  });
+
+  it('emits health_recovered with recoveredAfter=auto_restart after a restart heals', async () => {
+    const deps = makeDeps();
+    await triggerRestartReadyFailure(deps, CONTAINER_HEALTH_COLD_START_GRACE_MS + 1);
+    expect(deps._destroyFn).toHaveBeenCalledTimes(1);
+
+    deps._setOutcome(successOutcome());
+    deps._setNow(CONTAINER_HEALTH_COLD_START_GRACE_MS + 10_000);
+    await recoverContainerIfWedged(deps);
+
+    const recovered = deps._events.find(e => e.event === 'container.health_recovered');
+    // consecutiveFailures is 0 here: the auto_restart reset the streak counter,
+    // and the very next ping succeeded — the post-last-restart streak semantic.
+    expect(recovered).toMatchObject({
+      event: 'container.health_recovered',
+      townId: 'town-1',
+      reason: 'auto_restart',
+      value: 0,
+    });
+    expect(recovered?.durationMs ?? 0).toBeGreaterThan(0);
+    expect(deps._logs).toContainEqual(
+      expect.objectContaining({ event: 'container.health_recovered', reason: 'auto_restart' })
+    );
+    // Episode markers cleared so a subsequent success does not re-emit recovery.
+    expect(deps._store.has(CONTAINER_HEALTH_STORAGE_KEYS.unhealthyEpisodeStartedAt)).toBe(false);
+    await recoverContainerIfWedged(deps);
+    expect(deps._events.filter(e => e.event === 'container.health_recovered')).toHaveLength(1);
+  });
+
+  it('emits health_recovered with recoveredAfter=self for sub-threshold flapping', async () => {
+    const deps = makeDeps();
+    deps._setNow(1_000);
+    await recoverContainerIfWedged(deps);
+    deps._setNow(2_000);
+    await recoverContainerIfWedged(deps);
+
+    deps._setOutcome(successOutcome());
+    deps._setNow(5_000);
+    await recoverContainerIfWedged(deps);
+
+    expect(deps._destroyFn).not.toHaveBeenCalled();
+    expect(deps._events).toContainEqual(
+      expect.objectContaining({
+        event: 'container.health_recovered',
+        reason: 'self',
+        value: 2,
+        durationMs: 4_000,
+      })
+    );
+  });
+
+  it('emits health_recovered with recoveredAfter=cold_start_grace when only a grace-skip occurred', async () => {
+    const deps = makeDeps();
+    deps._setNow(1_000);
+    await recoverContainerIfWedged(deps);
+    deps._setNow(2_000);
+    await recoverContainerIfWedged(deps);
+    deps._setNow(3_000);
+    await recoverContainerIfWedged(deps);
+
+    expect(deps._destroyFn).not.toHaveBeenCalled();
+    expect(deps._logs).toContainEqual(
+      expect.objectContaining({
+        event: 'container.auto_restart_skipped',
+        reason: 'cold_start_grace',
+      })
+    );
+
+    deps._setOutcome(successOutcome());
+    deps._setNow(10_000);
+    await recoverContainerIfWedged(deps);
+
+    expect(deps._events).toContainEqual(
+      expect.objectContaining({
+        event: 'container.health_recovered',
+        reason: 'cold_start_grace',
+        value: CONTAINER_HEALTH_FAILURE_THRESHOLD,
+        durationMs: 9_000,
+      })
+    );
+  });
+
+  it('does not emit health_recovered on a clean success with no prior episode', async () => {
+    const deps = makeDeps();
+    deps._setOutcome(successOutcome());
+    deps._setNow(1_000);
+    await recoverContainerIfWedged(deps);
+
+    expect(deps._events).toHaveLength(0);
+    expect(deps._logs).toHaveLength(0);
+  });
+
+  it('writes container.health_watchdog_error to AE and Logpush when the watchdog throws', async () => {
+    const deps = makeDeps({
+      isDraining: () => {
+        throw new Error('boom');
+      },
+    });
+
+    await triggerRestartReadyFailure(deps, CONTAINER_HEALTH_COLD_START_GRACE_MS + 1);
+
+    expect(deps._events).toContainEqual(
+      expect.objectContaining({ event: 'container.health_watchdog_error', error: 'boom' })
+    );
+    expect(deps._logs).toContainEqual(
+      expect.objectContaining({ event: 'container.health_watchdog_error', error: 'boom' })
+    );
   });
 });

--- a/services/gastown/src/dos/town/container-health-watchdog.ts
+++ b/services/gastown/src/dos/town/container-health-watchdog.ts
@@ -13,7 +13,21 @@ export const CONTAINER_HEALTH_STORAGE_KEYS = {
   autoRestartWindowStart: 'container:autoRestartWindowStart',
   autoRestartsInWindow: 'container:autoRestartsInWindow',
   autoRestartExhaustedWindowStart: 'container:autoRestartExhaustedWindowStart',
+  // Whole-episode marker. Unlike firstHealthFailureAt (cleared on every restart),
+  // this is set once at the first failure of an unhealthy episode and only cleared
+  // on the first success — so it can measure end-to-end downtime across restarts.
+  unhealthyEpisodeStartedAt: 'container:unhealthyEpisodeStartedAt',
+  // Strongest recovery action taken during the current episode, used to attribute
+  // container.health_recovered. Cleared on the recovering success after the emit.
+  recoveryPathHint: 'container:recoveryPathHint',
 } as const;
+
+// How the container recovered from an unhealthy episode. `auto_restart` takes
+// priority over `cold_start_grace` (a restart is the strongest signal); `self`
+// means the container recovered without the watchdog restarting or waiting out
+// cold-start grace (e.g. sub-threshold flapping that cleared on its own).
+export type ContainerRecoveryPathHint = 'auto_restart' | 'cold_start_grace';
+export type ContainerRecoveredAfter = ContainerRecoveryPathHint | 'self';
 
 export type ContainerHealthPingOutcome =
   | {
@@ -32,6 +46,7 @@ export type ContainerHealthPingOutcome =
 export type ContainerHealthLogData = {
   event: string;
   townId: string;
+  containerId?: string;
   reason?: string;
   consecutiveFailures?: number;
   statusCode?: number;
@@ -41,6 +56,9 @@ export type ContainerHealthLogData = {
 
 export type ContainerHealthWatchdogDeps = {
   townId: string;
+  // Cloudflare container identity (TownContainerDO Durable Object id), stamped
+  // onto every emitted event/log to aid Cloudflare-support debugging.
+  containerDoId: string;
   outcome: ContainerHealthPingOutcome;
   isDraining: () => boolean;
   getConsecutiveHealthFailures: () => Promise<number | undefined>;
@@ -57,6 +75,12 @@ export type ContainerHealthWatchdogDeps = {
   getAutoRestartExhaustedWindowStart: () => Promise<number | undefined>;
   setAutoRestartExhaustedWindowStart: (value: number) => Promise<void>;
   deleteAutoRestartExhaustedWindowStart: () => Promise<unknown>;
+  getUnhealthyEpisodeStartedAt: () => Promise<number | undefined>;
+  setUnhealthyEpisodeStartedAt: (value: number) => Promise<void>;
+  deleteUnhealthyEpisodeStartedAt: () => Promise<unknown>;
+  getRecoveryPathHint: () => Promise<ContainerRecoveryPathHint | undefined>;
+  setRecoveryPathHint: (value: ContainerRecoveryPathHint) => Promise<void>;
+  deleteRecoveryPathHint: () => Promise<unknown>;
   getContainerStub: (townId: string) => {
     destroy: () => Promise<void>;
   };
@@ -69,16 +93,25 @@ export async function recoverContainerIfWedged(deps: ContainerHealthWatchdogDeps
   try {
     await recoverContainerIfWedgedInner(deps);
   } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    // Dual-write: Logpush for on-call visibility, AE so Workstream B's o11y
+    // monitor can fingerprint deploy churn ("…code was updated.") cross-town.
+    safeWriteEvent(deps, {
+      event: 'container.health_watchdog_error',
+      townId: deps.townId,
+      error,
+    });
     safeLog(deps, {
       event: 'container.health_watchdog_error',
       townId: deps.townId,
-      error: err instanceof Error ? err.message : String(err),
+      error,
     });
   }
 }
 
 async function recoverContainerIfWedgedInner(deps: ContainerHealthWatchdogDeps): Promise<void> {
   if (deps.outcome.ok) {
+    await emitRecoveryIfEpisodeEnded(deps);
     await deps.setConsecutiveHealthFailures(0);
     await deps.deleteFirstHealthFailureAt();
     return;
@@ -93,6 +126,13 @@ async function recoverContainerIfWedgedInner(deps: ContainerHealthWatchdogDeps):
   await deps.setConsecutiveHealthFailures(consecutiveFailures);
   if (storedFirstFailureAt == null) {
     await deps.setFirstHealthFailureAt(firstFailureAt);
+  }
+
+  // Mark the start of the unhealthy episode on its first failure. This marker
+  // survives auto-restarts (which clear firstHealthFailureAt) so the recovery
+  // event can report whole-episode downtime.
+  if ((await deps.getUnhealthyEpisodeStartedAt()) == null) {
+    await deps.setUnhealthyEpisodeStartedAt(now);
   }
 
   if (consecutiveFailures === CONTAINER_HEALTH_FAILURE_THRESHOLD) {
@@ -122,6 +162,11 @@ async function recoverContainerIfWedgedInner(deps: ContainerHealthWatchdogDeps):
   }
 
   if (now - firstFailureAt <= CONTAINER_HEALTH_COLD_START_GRACE_MS) {
+    // Attribute a later recovery to cold-start grace, but never downgrade an
+    // episode that already performed an auto_restart (a restart is stronger).
+    if ((await deps.getRecoveryPathHint()) !== 'auto_restart') {
+      await deps.setRecoveryPathHint('cold_start_grace');
+    }
     safeLog(deps, {
       event: 'container.auto_restart_skipped',
       townId: deps.townId,
@@ -214,6 +259,7 @@ async function recoverContainerIfWedgedInner(deps: ContainerHealthWatchdogDeps):
   await deps.setAutoRestartsInWindow(windowState.restartsInWindow + 1);
   await deps.setConsecutiveHealthFailures(0);
   await deps.deleteFirstHealthFailureAt();
+  await deps.setRecoveryPathHint('auto_restart');
 
   safeWriteEvent(deps, {
     event: 'container.auto_restart',
@@ -223,6 +269,43 @@ async function recoverContainerIfWedgedInner(deps: ContainerHealthWatchdogDeps):
     durationMs: deps.outcome.durationMs,
     statusCode: deps.outcome.statusCode,
   });
+}
+
+/**
+ * On the first successful ping after an unhealthy episode, emit
+ * `container.health_recovered` (to AE + Logpush) then clear the episode markers.
+ *
+ * `consecutiveFailures` reports the failing streak that just ended. Note it is
+ * the POST-last-restart streak — an auto_restart resets the counter, so a clean
+ * recovery right after a restart reports 0. `downtimeMs` spans the WHOLE episode
+ * from the persistent marker, independent of restarts.
+ */
+async function emitRecoveryIfEpisodeEnded(deps: ContainerHealthWatchdogDeps): Promise<void> {
+  const episodeStartedAt = await deps.getUnhealthyEpisodeStartedAt();
+  if (episodeStartedAt == null) return;
+
+  const now = deps.now();
+  const consecutiveFailures = (await deps.getConsecutiveHealthFailures()) ?? 0;
+  const recoveredAfter: ContainerRecoveredAfter = (await deps.getRecoveryPathHint()) ?? 'self';
+  const downtimeMs = now - episodeStartedAt;
+
+  safeWriteEvent(deps, {
+    event: 'container.health_recovered',
+    townId: deps.townId,
+    reason: recoveredAfter,
+    value: consecutiveFailures,
+    durationMs: downtimeMs,
+  });
+  safeLog(deps, {
+    event: 'container.health_recovered',
+    townId: deps.townId,
+    reason: recoveredAfter,
+    consecutiveFailures,
+    durationMs: downtimeMs,
+  });
+
+  await deps.deleteUnhealthyEpisodeStartedAt();
+  await deps.deleteRecoveryPathHint();
 }
 
 async function getRestartWindowState(
@@ -246,7 +329,7 @@ async function getRestartWindowState(
 
 function safeWriteEvent(deps: ContainerHealthWatchdogDeps, data: GastownEventData): void {
   try {
-    deps.writeEventFn(data);
+    deps.writeEventFn({ containerId: deps.containerDoId, ...data });
   } catch {
     // Best-effort — never throw from watchdog observability.
   }
@@ -254,7 +337,7 @@ function safeWriteEvent(deps: ContainerHealthWatchdogDeps, data: GastownEventDat
 
 function safeLog(deps: ContainerHealthWatchdogDeps, data: ContainerHealthLogData): void {
   try {
-    deps.logWarnFn(data);
+    deps.logWarnFn({ containerId: deps.containerDoId, ...data });
   } catch {
     // Best-effort — never throw from watchdog observability.
   }

--- a/services/gastown/src/util/analytics.util.ts
+++ b/services/gastown/src/util/analytics.util.ts
@@ -49,6 +49,9 @@ export type GastownEventData = {
   // Use error (absence = success) instead of a wasSuccess boolean.
   statusCode?: number;
   containerStartedAt?: string;
+  // Cloudflare container identity (TownContainerDO Durable Object id) — aids
+  // correlation with Cloudflare support and the dashboard for container events.
+  containerId?: string;
   // Additional doubles for reconciler_tick events (double3–double10).
   // Analytics Engine supports up to 20 doubles per data point.
   double3?: number;
@@ -88,6 +91,7 @@ export function writeEvent(
         data.beadType ?? '', // blob13
         data.reason ?? '', // blob14
         data.containerStartedAt ?? '', // blob15
+        data.containerId ?? '', // blob16
       ],
       doubles: [
         data.durationMs ?? 0, // double1

--- a/services/o11y/src/alerting/gastown-health-evaluate.ts
+++ b/services/o11y/src/alerting/gastown-health-evaluate.ts
@@ -8,13 +8,20 @@ import {
   transitionGastownHealthState,
   writeGastownHealthState,
 } from './gastown-health-state';
-import { sendAlertNotification, type AlertPayload } from './notify';
+import { sendAlertNotification, type AlertPayload, type GastownHealthAlertPayload } from './notify';
 
-export const GASTOWN_HEALTH_THRESHOLDS = {
-  weightedFailedChecks: 30,
-  affectedTowns: 4,
-  renotifyFailedChecksStep: 30,
-} as const;
+// A town failing continuously for this long with no recovery and no successful
+// ping is a confirmed wedge that needs a human — roughly 2.5x the watchdog's
+// ~4-minute recovery budget (60s cold-start grace + 3x >=60s restart throttle).
+// Also catches a dead alarm loop that stops emitting watchdog events entirely.
+export const SUSTAINED_FAILURE_MINUTES = 10;
+
+// A "code was updated" watchdog error spanning at least this many towns in the
+// window looks like deploy churn (a rollout resetting Town DOs) rather than an
+// incident, so those towns' failures are treated as deploy-caused, not paged.
+export const DEPLOY_CHURN_WATCHDOG_ERROR_TOWNS = 3;
+
+export { GASTOWN_HEALTH_WINDOW_MINUTES };
 
 type GastownHealthEnv = {
   O11Y_ALERT_STATE: KVNamespace;
@@ -30,17 +37,104 @@ type QueryFn = (
 
 type NotifyFn = (alert: AlertPayload, env: GastownHealthEnv) => Promise<void>;
 
-function getCrossedThresholds(
-  metrics: GastownHealthMetrics
-): Array<'failed_checks' | 'affected_towns'> {
-  const crossedThresholds: Array<'failed_checks' | 'affected_towns'> = [];
-  if (metrics.weightedFailedChecks >= GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks) {
-    crossedThresholds.push('failed_checks');
-  }
-  if (metrics.affectedTownCount >= GASTOWN_HEALTH_THRESHOLDS.affectedTowns) {
-    crossedThresholds.push('affected_towns');
-  }
-  return crossedThresholds;
+export type GastownHealthClassification = {
+  // Watchdog gave up restarting — a confirmed wedge. Pages even during deploy
+  // churn (a genuine wedge), but the ticket carries the churn annotation.
+  exhaustedTownIds: string[];
+  // Continuous failure >= SUSTAINED_FAILURE_MINUTES with no recovery/success.
+  sustainedTownIds: string[];
+  // Towns whose window carries the "code was updated" deploy-churn fingerprint.
+  deployChurnTownIds: string[];
+  deployChurnSuspected: boolean;
+  // Union of exhausted + sustained — the towns that justify paging a human.
+  wedgeTownIds: string[];
+  // Info-trend aggregate (never pages on its own).
+  affectedTownCount: number;
+  aggregateWeightedFailedChecks: number;
+  aggregateWeightedSuccessfulChecks: number;
+  totalWeightedRecovered: number;
+};
+
+export function classifyGastownHealth(metrics: GastownHealthMetrics): GastownHealthClassification {
+  const sustainedFailureMs = SUSTAINED_FAILURE_MINUTES * 60_000;
+
+  const deployChurnTownIds = metrics.townSignals
+    .filter(town => town.weightedWatchdogCodeUpdated > 0)
+    .map(town => town.townId);
+  const deployChurnSuspected = deployChurnTownIds.length >= DEPLOY_CHURN_WATCHDOG_ERROR_TOWNS;
+  const churnTowns = new Set(deployChurnTownIds);
+
+  const exhaustedTownIds = metrics.townSignals
+    .filter(town => town.weightedExhausted > 0)
+    .map(town => town.townId);
+
+  const sustainedTownIds = metrics.townSignals
+    .filter(town => {
+      if (town.weightedFailedChecks <= 0) return false;
+      if (town.weightedSuccessfulChecks > 0) return false;
+      if (town.weightedRecovered > 0) return false;
+      if (town.firstEventAt === null || town.lastEventAt === null) return false;
+      const spanMs = town.lastEventAt.getTime() - town.firstEventAt.getTime();
+      if (spanMs < sustainedFailureMs) return false;
+      // During broad deploy churn, treat a churn town's failures as deploy-caused.
+      if (deployChurnSuspected && churnTowns.has(town.townId)) return false;
+      return true;
+    })
+    .map(town => town.townId);
+
+  const wedgeTownIds = [...new Set([...exhaustedTownIds, ...sustainedTownIds])].sort();
+
+  return {
+    exhaustedTownIds: [...exhaustedTownIds].sort(),
+    sustainedTownIds: [...sustainedTownIds].sort(),
+    deployChurnTownIds: [...deployChurnTownIds].sort(),
+    deployChurnSuspected,
+    wedgeTownIds,
+    affectedTownCount: metrics.townSignals.filter(town => town.weightedFailedChecks > 0).length,
+    aggregateWeightedFailedChecks: metrics.aggregateWeightedFailedChecks,
+    aggregateWeightedSuccessfulChecks: metrics.aggregateWeightedSuccessfulChecks,
+    totalWeightedRecovered: metrics.townSignals.reduce(
+      (sum, town) => sum + town.weightedRecovered,
+      0
+    ),
+  };
+}
+
+// Non-paging visibility: the aggregate flapping signal is emitted every tick so
+// it stays on the Grafana panel / Logpush trend without paging on self-healed
+// flapping. o11y has logpush enabled, so a structured console.info is captured.
+function emitGastownHealthTrend(classification: GastownHealthClassification): void {
+  console.info(
+    JSON.stringify({
+      event: 'gastown_container_health_trend',
+      windowMinutes: GASTOWN_HEALTH_WINDOW_MINUTES,
+      affectedTownCount: classification.affectedTownCount,
+      weightedFailedChecks: classification.aggregateWeightedFailedChecks,
+      weightedSuccessfulChecks: classification.aggregateWeightedSuccessfulChecks,
+      weightedRecovered: classification.totalWeightedRecovered,
+      exhaustedTownCount: classification.exhaustedTownIds.length,
+      sustainedTownCount: classification.sustainedTownIds.length,
+      deployChurnSuspected: classification.deployChurnSuspected,
+      deployChurnTownCount: classification.deployChurnTownIds.length,
+    })
+  );
+}
+
+function buildGastownHealthAlertPayload(
+  classification: GastownHealthClassification
+): GastownHealthAlertPayload {
+  return {
+    alertType: 'gastown_container_health',
+    severity: 'ticket',
+    windowMinutes: GASTOWN_HEALTH_WINDOW_MINUTES,
+    sustainedFailureMinutes: SUSTAINED_FAILURE_MINUTES,
+    exhaustedTownIds: classification.exhaustedTownIds,
+    sustainedTownIds: classification.sustainedTownIds,
+    deployChurnSuspected: classification.deployChurnSuspected,
+    deployChurnTownCount: classification.deployChurnTownIds.length,
+    affectedTownCount: classification.affectedTownCount,
+    weightedFailedChecks: classification.aggregateWeightedFailedChecks,
+  };
 }
 
 export async function evaluateGastownHealthAlert(
@@ -49,29 +143,20 @@ export async function evaluateGastownHealthAlert(
   notifyFn: NotifyFn = sendAlertNotification
 ): Promise<void> {
   const metrics = await queryFn(env);
-  const crossedThresholds = getCrossedThresholds(metrics);
+  const classification = classifyGastownHealth(metrics);
+
+  emitGastownHealthTrend(classification);
+
   const currentState = await readGastownHealthState(env.O11Y_ALERT_STATE);
-  const transition = transitionGastownHealthState(
-    currentState,
-    metrics,
-    crossedThresholds.length === 2,
-    GASTOWN_HEALTH_THRESHOLDS.renotifyFailedChecksStep
-  );
+  const transition = transitionGastownHealthState(currentState, {
+    wedgeTownIds: classification.wedgeTownIds,
+    // Only a fleet with successful health pings is proof of life; a blackout
+    // (zero pings) must not be mistaken for recovery.
+    healthObserved: classification.aggregateWeightedSuccessfulChecks > 0,
+  });
 
   if (transition.shouldNotify) {
-    await notifyFn(
-      {
-        alertType: 'gastown_container_health',
-        severity: 'ticket',
-        weightedFailedChecks: metrics.weightedFailedChecks,
-        affectedTownCount: metrics.affectedTownCount,
-        windowMinutes: GASTOWN_HEALTH_WINDOW_MINUTES,
-        crossedThresholds,
-        failedChecksThreshold: GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks,
-        affectedTownsThreshold: GASTOWN_HEALTH_THRESHOLDS.affectedTowns,
-      },
-      env
-    );
+    await notifyFn(buildGastownHealthAlertPayload(classification), env);
   }
 
   if (transition.stateChanged) {

--- a/services/o11y/src/alerting/gastown-health-query.ts
+++ b/services/o11y/src/alerting/gastown-health-query.ts
@@ -2,10 +2,33 @@ import { z } from 'zod';
 
 export const GASTOWN_HEALTH_WINDOW_MINUTES = 15;
 
-export type GastownHealthMetrics = {
+/**
+ * Per-town container-health signals over the evaluation window. Only towns with
+ * evidence of a problem are returned (see the HAVING clause below); a fully
+ * healthy fleet produces zero rows here — fleet liveness is confirmed separately
+ * via the aggregate heartbeat query.
+ */
+export type GastownTownSignal = {
+  townId: string;
   weightedFailedChecks: number;
   weightedSuccessfulChecks: number;
-  affectedTownCount: number;
+  weightedExhausted: number;
+  weightedRecovered: number;
+  weightedWatchdogCodeUpdated: number;
+  // MIN/MAX event timestamps for the town over the window. For a sustained-wedge
+  // town (zero successes and zero recoveries) the only events are failed pings,
+  // so this span is exactly the continuous-failure span used by the predicate.
+  firstEventAt: Date | null;
+  lastEventAt: Date | null;
+};
+
+export type GastownHealthMetrics = {
+  townSignals: GastownTownSignal[];
+  // Fleet-wide aggregate over container.health_ping (info trend + liveness).
+  // Drives the non-paging flapping signal and lets the state machine tell a
+  // recovered fleet apart from a telemetry blackout.
+  aggregateWeightedFailedChecks: number;
+  aggregateWeightedSuccessfulChecks: number;
   latestEventTimestamp: Date | null;
 };
 
@@ -21,10 +44,24 @@ const AnalyticsEngineNumberSchema = z.preprocess(
   z.number().finite().nonnegative().nullable()
 );
 
-const GastownHealthResponseSchema = z.object({
+const TownSignalResponseSchema = z.object({
   data: z.array(
     z.object({
       town_id: z.string(),
+      weighted_failed_checks: AnalyticsEngineNumberSchema,
+      weighted_successful_checks: AnalyticsEngineNumberSchema,
+      weighted_exhausted: AnalyticsEngineNumberSchema,
+      weighted_recovered: AnalyticsEngineNumberSchema,
+      weighted_watchdog_code_updated: AnalyticsEngineNumberSchema,
+      first_event_timestamp: z.string().nullable(),
+      last_event_timestamp: z.string().nullable(),
+    })
+  ),
+});
+
+const AggregateResponseSchema = z.object({
+  data: z.array(
+    z.object({
       weighted_failed_checks: AnalyticsEngineNumberSchema,
       weighted_successful_checks: AnalyticsEngineNumberSchema,
       latest_event_timestamp: z.string().nullable(),
@@ -34,6 +71,11 @@ const GastownHealthResponseSchema = z.object({
 
 const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
 
+// Deploy-churn fingerprint: a "code was updated" watchdog error means the Town
+// DO was reset mid-alarm by a code deploy, not a genuine wedge. A broad spike of
+// these across many towns indicates deploy churn rather than an incident.
+const DEPLOY_CHURN_FINGERPRINT = 'code was updated';
+
 // Analytics Engine MAX(timestamp) may return strings like "2026-06-24 15:10:00.000"
 // without a timezone offset. Append "Z" when no offset or "Z" suffix is present so
 // new Date() treats the value as UTC rather than the runtime's local timezone.
@@ -41,30 +83,21 @@ function toUtcIsoString(value: string): string {
   return /[Zz]$|[+-]\d{2}:\d{2}$/.test(value) ? value : `${value}Z`;
 }
 
-export async function queryGastownHealth(
-  env: QueryEnv,
-  fetchFn: FetchFn = fetch
-): Promise<GastownHealthMetrics> {
-  const apiToken = await env.O11Y_CF_AE_API_TOKEN.get();
-  if (!apiToken) {
-    throw new Error('O11Y_CF_AE_API_TOKEN secret is not configured');
+function parseTimestamp(value: string | null): Date | null {
+  if (value === null) return null;
+  const parsed = new Date(toUtcIsoString(value));
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('Gastown health Analytics Engine response contains an invalid timestamp');
   }
+  return parsed;
+}
 
-  // Collapse healthy towns into one row so normal fleet size does not inflate the
-  // scheduled Worker's Analytics Engine response and Cloudflare trace payload.
-  const sql = `
-    SELECT
-      IF(blob5 != '' AND blob6 != '', blob6, '') AS town_id,
-      SUM(IF(blob5 != '', _sample_interval, 0)) AS weighted_failed_checks,
-      SUM(IF(blob5 = '', _sample_interval, 0)) AS weighted_successful_checks,
-      MAX(timestamp) AS latest_event_timestamp
-    FROM gastown_events
-    WHERE timestamp > NOW() - INTERVAL '${GASTOWN_HEALTH_WINDOW_MINUTES}' MINUTE
-      AND blob1 = 'container.health_ping'
-    GROUP BY town_id
-    FORMAT JSON
-  `;
-
+async function runQuery(
+  env: QueryEnv,
+  fetchFn: FetchFn,
+  apiToken: string,
+  sql: string
+): Promise<unknown> {
   const response = await fetchFn(
     `${CF_API_BASE}/accounts/${env.O11Y_CF_ACCOUNT_ID}/analytics_engine/sql`,
     {
@@ -79,33 +112,84 @@ export async function queryGastownHealth(
     throw new Error(`Gastown health Analytics Engine query failed (${response.status})`);
   }
 
-  const { data } = GastownHealthResponseSchema.parse(await response.json());
-  let weightedFailedChecks = 0;
-  let weightedSuccessfulChecks = 0;
-  let affectedTownCount = 0;
-  let latestEventTimestamp: Date | null = null;
+  return response.json();
+}
 
-  for (const row of data) {
-    const failedChecks = row.weighted_failed_checks ?? 0;
-    weightedFailedChecks += failedChecks;
-    weightedSuccessfulChecks += row.weighted_successful_checks ?? 0;
-    if (row.town_id !== '' && failedChecks > 0) affectedTownCount += 1;
+// Per-town wedge signals. Groups every container health event by town, then uses
+// HAVING to drop fully healthy towns so a large healthy fleet does not inflate the
+// scheduled Worker's Analytics Engine response and Cloudflare trace payload.
+const TOWN_SIGNAL_SQL = `
+  SELECT
+    blob6 AS town_id,
+    SUM(IF(blob1 = 'container.health_ping' AND blob5 != '', _sample_interval, 0)) AS weighted_failed_checks,
+    SUM(IF(blob1 = 'container.health_ping' AND blob5 = '', _sample_interval, 0)) AS weighted_successful_checks,
+    SUM(IF(blob1 = 'container.auto_restart_exhausted', _sample_interval, 0)) AS weighted_exhausted,
+    SUM(IF(blob1 = 'container.health_recovered', _sample_interval, 0)) AS weighted_recovered,
+    SUM(IF(blob1 = 'container.health_watchdog_error' AND position('${DEPLOY_CHURN_FINGERPRINT}' IN blob5) > 0, _sample_interval, 0)) AS weighted_watchdog_code_updated,
+    MIN(timestamp) AS first_event_timestamp,
+    MAX(timestamp) AS last_event_timestamp
+  FROM gastown_events
+  WHERE timestamp > NOW() - INTERVAL '${GASTOWN_HEALTH_WINDOW_MINUTES}' MINUTE
+    AND blob6 != ''
+    AND blob1 IN (
+      'container.health_ping',
+      'container.auto_restart_exhausted',
+      'container.health_recovered',
+      'container.health_watchdog_error'
+    )
+  GROUP BY town_id
+  HAVING weighted_failed_checks > 0
+      OR weighted_exhausted > 0
+      OR weighted_recovered > 0
+      OR weighted_watchdog_code_updated > 0
+  FORMAT JSON
+`;
 
-    if (row.latest_event_timestamp !== null) {
-      const rowTimestamp = new Date(toUtcIsoString(row.latest_event_timestamp));
-      if (Number.isNaN(rowTimestamp.getTime())) {
-        throw new Error('Gastown health Analytics Engine response contains an invalid timestamp');
-      }
-      if (latestEventTimestamp === null || rowTimestamp > latestEventTimestamp) {
-        latestEventTimestamp = rowTimestamp;
-      }
-    }
+// Fleet-wide health-ping aggregate: a single row confirming liveness and giving
+// the info-trend flapping totals independent of the per-town HAVING filter.
+const AGGREGATE_SQL = `
+  SELECT
+    SUM(IF(blob5 != '', _sample_interval, 0)) AS weighted_failed_checks,
+    SUM(IF(blob5 = '', _sample_interval, 0)) AS weighted_successful_checks,
+    MAX(timestamp) AS latest_event_timestamp
+  FROM gastown_events
+  WHERE timestamp > NOW() - INTERVAL '${GASTOWN_HEALTH_WINDOW_MINUTES}' MINUTE
+    AND blob1 = 'container.health_ping'
+  FORMAT JSON
+`;
+
+export async function queryGastownHealth(
+  env: QueryEnv,
+  fetchFn: FetchFn = fetch
+): Promise<GastownHealthMetrics> {
+  const apiToken = await env.O11Y_CF_AE_API_TOKEN.get();
+  if (!apiToken) {
+    throw new Error('O11Y_CF_AE_API_TOKEN secret is not configured');
   }
 
+  const [townSignalRaw, aggregateRaw] = await Promise.all([
+    runQuery(env, fetchFn, apiToken, TOWN_SIGNAL_SQL),
+    runQuery(env, fetchFn, apiToken, AGGREGATE_SQL),
+  ]);
+
+  const townRows = TownSignalResponseSchema.parse(townSignalRaw).data;
+  const townSignals: GastownTownSignal[] = townRows.map(row => ({
+    townId: row.town_id,
+    weightedFailedChecks: row.weighted_failed_checks ?? 0,
+    weightedSuccessfulChecks: row.weighted_successful_checks ?? 0,
+    weightedExhausted: row.weighted_exhausted ?? 0,
+    weightedRecovered: row.weighted_recovered ?? 0,
+    weightedWatchdogCodeUpdated: row.weighted_watchdog_code_updated ?? 0,
+    firstEventAt: parseTimestamp(row.first_event_timestamp),
+    lastEventAt: parseTimestamp(row.last_event_timestamp),
+  }));
+
+  const aggregateRow = AggregateResponseSchema.parse(aggregateRaw).data[0];
+
   return {
-    weightedFailedChecks,
-    weightedSuccessfulChecks,
-    affectedTownCount,
-    latestEventTimestamp,
+    townSignals,
+    aggregateWeightedFailedChecks: aggregateRow?.weighted_failed_checks ?? 0,
+    aggregateWeightedSuccessfulChecks: aggregateRow?.weighted_successful_checks ?? 0,
+    latestEventTimestamp: parseTimestamp(aggregateRow?.latest_event_timestamp ?? null),
   };
 }

--- a/services/o11y/src/alerting/gastown-health-state.ts
+++ b/services/o11y/src/alerting/gastown-health-state.ts
@@ -1,9 +1,12 @@
 import { z } from 'zod';
-import type { GastownHealthMetrics } from './gastown-health-query';
 
 const CONSECUTIVE_HEALTHY_TO_RESOLVE = 3;
 const STATE_KEY = 'o11y:gastown_container_health';
 
+// Event-driven dedup: an alert episode stays active while any town is wedged
+// (exhausted or sustained). We page once when the episode opens and again only
+// when the wedged town set escalates (a new town appears), then auto-resolve
+// after CONSECUTIVE_HEALTHY_TO_RESOLVE clean evaluations.
 const GastownHealthStateSchema = z.discriminatedUnion('active', [
   z.object({
     active: z.literal(false),
@@ -16,11 +19,19 @@ const GastownHealthStateSchema = z.discriminatedUnion('active', [
       .int()
       .min(0)
       .max(CONSECUTIVE_HEALTHY_TO_RESOLVE - 1),
-    lastNotifiedWeightedFailedChecks: z.number().finite().nonnegative().optional(),
+    notifiedTownIds: z.array(z.string()),
   }),
 ]);
 
 export type GastownHealthState = z.infer<typeof GastownHealthStateSchema>;
+
+export type GastownHealthStateInput = {
+  // Towns that justify paging this evaluation (exhausted or sustained).
+  wedgeTownIds: string[];
+  // Whether the fleet showed any successful health pings — proof the monitor is
+  // seeing live telemetry, so a clean evaluation can count toward resolution.
+  healthObserved: boolean;
+};
 
 export type GastownHealthTransition = {
   state: GastownHealthState;
@@ -32,60 +43,49 @@ function inactiveState(): GastownHealthState {
   return { active: false, consecutiveHealthyCount: 0 };
 }
 
+function mergeSorted(existing: string[], incoming: string[]): string[] {
+  return [...new Set([...existing, ...incoming])].sort();
+}
+
 export function transitionGastownHealthState(
   state: GastownHealthState,
-  metrics: GastownHealthMetrics,
-  thresholdCrossed: boolean,
-  renotifyFailedChecksStep: number
+  input: GastownHealthStateInput
 ): GastownHealthTransition {
-  if (thresholdCrossed) {
+  const wedged = input.wedgeTownIds.length > 0;
+
+  if (wedged) {
     if (!state.active) {
       return {
         state: {
           active: true,
           consecutiveHealthyCount: 0,
-          lastNotifiedWeightedFailedChecks: metrics.weightedFailedChecks,
+          notifiedTownIds: [...input.wedgeTownIds].sort(),
         },
         shouldNotify: true,
         stateChanged: true,
       };
     }
 
-    if (state.lastNotifiedWeightedFailedChecks === undefined) {
+    const escalated = input.wedgeTownIds.some(id => !state.notifiedTownIds.includes(id));
+    if (escalated) {
       return {
         state: {
           active: true,
           consecutiveHealthyCount: 0,
-          lastNotifiedWeightedFailedChecks:
-            Math.floor(metrics.weightedFailedChecks / renotifyFailedChecksStep) *
-            renotifyFailedChecksStep,
-        },
-        shouldNotify: false,
-        stateChanged: true,
-      };
-    }
-
-    if (
-      metrics.weightedFailedChecks >=
-      state.lastNotifiedWeightedFailedChecks + renotifyFailedChecksStep
-    ) {
-      return {
-        state: {
-          active: true,
-          consecutiveHealthyCount: 0,
-          lastNotifiedWeightedFailedChecks: metrics.weightedFailedChecks,
+          notifiedTownIds: mergeSorted(state.notifiedTownIds, input.wedgeTownIds),
         },
         shouldNotify: true,
         stateChanged: true,
       };
     }
 
+    // Still wedged, no new towns — reset any recovery progress without paging.
     if (state.consecutiveHealthyCount > 0) {
       return {
         state: {
           active: true,
           consecutiveHealthyCount: 0,
-          lastNotifiedWeightedFailedChecks: state.lastNotifiedWeightedFailedChecks,
+          notifiedTownIds: state.notifiedTownIds,
         },
         shouldNotify: false,
         stateChanged: true,
@@ -95,7 +95,8 @@ export function transitionGastownHealthState(
     return { state, shouldNotify: false, stateChanged: false };
   }
 
-  if (!state.active || metrics.weightedSuccessfulChecks <= 0) {
+  // No wedged towns this evaluation.
+  if (!state.active || !input.healthObserved) {
     return { state, shouldNotify: false, stateChanged: false };
   }
 
@@ -108,7 +109,7 @@ export function transitionGastownHealthState(
     state: {
       active: true,
       consecutiveHealthyCount,
-      lastNotifiedWeightedFailedChecks: state.lastNotifiedWeightedFailedChecks,
+      notifiedTownIds: state.notifiedTownIds,
     },
     shouldNotify: false,
     stateChanged: true,
@@ -121,6 +122,8 @@ export async function readGastownHealthState(kv: KVNamespace): Promise<GastownHe
 
   try {
     const parsed = GastownHealthStateSchema.safeParse(JSON.parse(raw));
+    // Legacy state shapes (pre-event-driven dedup) fail the schema and safely
+    // fall back to inactive — the next wedge re-opens a fresh episode.
     return parsed.success ? parsed.data : inactiveState();
   } catch {
     return inactiveState();

--- a/services/o11y/src/alerting/notify.ts
+++ b/services/o11y/src/alerting/notify.ts
@@ -58,12 +58,18 @@ export type QueueBacklogAlertPayload = {
 export type GastownHealthAlertPayload = {
   alertType: 'gastown_container_health';
   severity: 'ticket';
-  weightedFailedChecks: number;
-  affectedTownCount: number;
   windowMinutes: number;
-  crossedThresholds: Array<'failed_checks' | 'affected_towns'>;
-  failedChecksThreshold: number;
-  affectedTownsThreshold: number;
+  sustainedFailureMinutes: number;
+  // Towns whose watchdog exhausted its restart budget — confirmed wedges.
+  exhaustedTownIds: string[];
+  // Towns failing continuously past the sustained threshold with no recovery.
+  sustainedTownIds: string[];
+  // Broad "code was updated" churn is suspected; the page carries an annotation.
+  deployChurnSuspected: boolean;
+  deployChurnTownCount: number;
+  // Info-trend context (does not gate paging).
+  affectedTownCount: number;
+  weightedFailedChecks: number;
 };
 
 export type AlertPayload =
@@ -217,14 +223,32 @@ const GASTOWN_DASHBOARD_URL = 'https://ops.kiloapps.io/d/gastown-ops-1/gastown-o
 const GASTOWN_HEALTH_RUNBOOK_URL =
   'https://github.com/Kilo-Org/on-call/blob/main/runbooks/gastown-container-health-failures.md';
 
+function formatTownList(townIds: string[]): string {
+  if (townIds.length === 0) return 'none';
+  const shown = townIds.slice(0, 10).join(', ');
+  return townIds.length > 10 ? `${shown} (+${townIds.length - 10} more)` : shown;
+}
+
+function buildGastownHealthReason(alert: GastownHealthAlertPayload): string {
+  const reasons: string[] = [];
+  if (alert.exhaustedTownIds.length > 0) {
+    reasons.push(
+      `${alert.exhaustedTownIds.length} town(s) exhausted auto-restarts (confirmed wedge): ${formatTownList(alert.exhaustedTownIds)}`
+    );
+  }
+  if (alert.sustainedTownIds.length > 0) {
+    reasons.push(
+      `${alert.sustainedTownIds.length} town(s) failing >= ${alert.sustainedFailureMinutes} min with no recovery: ${formatTownList(alert.sustainedTownIds)}`
+    );
+  }
+  return reasons.length > 0 ? reasons.join('\n') : 'Container health wedge detected.';
+}
+
 function buildGastownHealthSlackBlocks(alert: GastownHealthAlertPayload): object[] {
-  const crossedThresholds = alert.crossedThresholds
-    .map(threshold =>
-      threshold === 'failed_checks'
-        ? `${alert.failedChecksThreshold.toLocaleString('en-US')} failed checks`
-        : `${alert.affectedTownsThreshold.toLocaleString('en-US')} affected towns`
-    )
-    .join(' and ');
+  const wedgeTownCount = new Set([...alert.exhaustedTownIds, ...alert.sustainedTownIds]).size;
+  const churnNote = alert.deployChurnSuspected
+    ? `\n:warning: Deploy churn suspected across ${alert.deployChurnTownCount} town(s) ("code was updated"). Deploy-caused failures are excluded; the wedges above still need attention.`
+    : '';
 
   return [
     {
@@ -238,22 +262,29 @@ function buildGastownHealthSlackBlocks(alert: GastownHealthAlertPayload): object
       type: 'section',
       fields: [
         { type: 'mrkdwn', text: `*Window:*\n${alert.windowMinutes}-minute window` },
+        { type: 'mrkdwn', text: `*Wedged towns:*\n${wedgeTownCount.toLocaleString('en-US')}` },
         {
           type: 'mrkdwn',
-          text: `*Failed checks:*\n${alert.weightedFailedChecks.toLocaleString('en-US')}`,
+          text: `*Exhausted:*\n${alert.exhaustedTownIds.length.toLocaleString('en-US')}`,
         },
         {
           type: 'mrkdwn',
-          text: `*Affected towns:*\n${alert.affectedTownCount.toLocaleString('en-US')}`,
+          text: `*Sustained:*\n${alert.sustainedTownIds.length.toLocaleString('en-US')}`,
         },
-        { type: 'mrkdwn', text: `*Threshold crossed:*\n${crossedThresholds}` },
       ],
     },
     {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `Investigate aggregate container health failures. Do not restart towns without active-session authorization.\n<${GASTOWN_DASHBOARD_URL}|Gastown dashboard> | <${GASTOWN_HEALTH_RUNBOOK_URL}|Container-health runbook>`,
+        text: `${buildGastownHealthReason(alert)}${churnNote}`,
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `Trend (non-paging): ${alert.weightedFailedChecks.toLocaleString('en-US')} weighted failed checks across ${alert.affectedTownCount.toLocaleString('en-US')} town(s).\nDo not restart towns without active-session authorization.\n<${GASTOWN_DASHBOARD_URL}|Gastown dashboard> | <${GASTOWN_HEALTH_RUNBOOK_URL}|Container-health runbook>`,
       },
     },
   ];

--- a/services/o11y/test/gastown-health-evaluate.spec.ts
+++ b/services/o11y/test/gastown-health-evaluate.spec.ts
@@ -1,12 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  classifyGastownHealth,
+  DEPLOY_CHURN_WATCHDOG_ERROR_TOWNS,
   evaluateGastownHealthAlert,
-  GASTOWN_HEALTH_THRESHOLDS,
+  SUSTAINED_FAILURE_MINUTES,
 } from '../src/alerting/gastown-health-evaluate';
-import type { GastownHealthMetrics } from '../src/alerting/gastown-health-query';
-import type { AlertPayload } from '../src/alerting/notify';
+import type { GastownHealthMetrics, GastownTownSignal } from '../src/alerting/gastown-health-query';
+import type { AlertPayload, GastownHealthAlertPayload } from '../src/alerting/notify';
 
 const STATE_KEY = 'o11y:gastown_container_health';
+const WINDOW_START = new Date('2026-06-24T15:00:00.000Z');
 
 function makeKv() {
   const store = new Map<string, string>();
@@ -33,19 +36,47 @@ function makeEnv(kv: KVNamespace) {
   };
 }
 
-function makeMetrics(
-  weightedFailedChecks: number,
-  affectedTownCount: number,
-  weightedSuccessfulChecks = 0
+function town(overrides: Partial<GastownTownSignal> & { townId: string }): GastownTownSignal {
+  return {
+    townId: overrides.townId,
+    weightedFailedChecks: overrides.weightedFailedChecks ?? 0,
+    weightedSuccessfulChecks: overrides.weightedSuccessfulChecks ?? 0,
+    weightedExhausted: overrides.weightedExhausted ?? 0,
+    weightedRecovered: overrides.weightedRecovered ?? 0,
+    weightedWatchdogCodeUpdated: overrides.weightedWatchdogCodeUpdated ?? 0,
+    firstEventAt: overrides.firstEventAt ?? null,
+    lastEventAt: overrides.lastEventAt ?? null,
+  };
+}
+
+function span(minutes: number): Pick<GastownTownSignal, 'firstEventAt' | 'lastEventAt'> {
+  return {
+    firstEventAt: WINDOW_START,
+    lastEventAt: new Date(WINDOW_START.getTime() + minutes * 60_000),
+  };
+}
+
+// A town wedged past the sustained threshold: continuous failures, no success,
+// no recovery, spanning longer than SUSTAINED_FAILURE_MINUTES.
+function sustainedTown(townId: string): GastownTownSignal {
+  return town({
+    townId,
+    weightedFailedChecks: 12,
+    ...span(SUSTAINED_FAILURE_MINUTES + 1),
+  });
+}
+
+function metrics(
+  townSignals: GastownTownSignal[],
+  aggregate: { failed?: number; successful?: number } = {}
 ): GastownHealthMetrics {
   return {
-    weightedFailedChecks,
-    weightedSuccessfulChecks,
-    affectedTownCount,
-    latestEventTimestamp:
-      weightedFailedChecks + weightedSuccessfulChecks > 0
-        ? new Date('2026-06-24T15:10:00.000Z')
-        : null,
+    townSignals,
+    aggregateWeightedFailedChecks:
+      aggregate.failed ?? townSignals.reduce((sum, t) => sum + t.weightedFailedChecks, 0),
+    aggregateWeightedSuccessfulChecks:
+      aggregate.successful ?? townSignals.reduce((sum, t) => sum + t.weightedSuccessfulChecks, 0),
+    latestEventTimestamp: townSignals.length > 0 ? WINDOW_START : null,
   };
 }
 
@@ -63,17 +94,125 @@ async function evaluateAt(
   );
 }
 
+describe('classifyGastownHealth', () => {
+  it('does not flag self-healed flapping (no exhaustion, has successes/recoveries)', () => {
+    const result = classifyGastownHealth(
+      metrics([
+        town({
+          townId: 'town-1',
+          weightedFailedChecks: 8,
+          weightedSuccessfulChecks: 4,
+          weightedRecovered: 3,
+          ...span(SUSTAINED_FAILURE_MINUTES + 5),
+        }),
+      ])
+    );
+
+    expect(result.wedgeTownIds).toEqual([]);
+    expect(result.exhaustedTownIds).toEqual([]);
+    expect(result.sustainedTownIds).toEqual([]);
+    expect(result.affectedTownCount).toBe(1);
+  });
+
+  it('flags a town that exhausted its restart budget', () => {
+    const result = classifyGastownHealth(
+      metrics([town({ townId: 'town-1', weightedFailedChecks: 9, weightedExhausted: 1 })])
+    );
+
+    expect(result.exhaustedTownIds).toEqual(['town-1']);
+    expect(result.wedgeTownIds).toEqual(['town-1']);
+  });
+
+  it('flags a sustained failure with no recovery or success', () => {
+    const result = classifyGastownHealth(metrics([sustainedTown('town-1')]));
+
+    expect(result.sustainedTownIds).toEqual(['town-1']);
+    expect(result.wedgeTownIds).toEqual(['town-1']);
+  });
+
+  it('does not flag failures shorter than the sustained threshold', () => {
+    const result = classifyGastownHealth(
+      metrics([
+        town({ townId: 'town-1', weightedFailedChecks: 5, ...span(SUSTAINED_FAILURE_MINUTES - 2) }),
+      ])
+    );
+
+    expect(result.sustainedTownIds).toEqual([]);
+    expect(result.wedgeTownIds).toEqual([]);
+  });
+
+  it('suppresses sustained towns during broad deploy churn but keeps exhausted ones', () => {
+    const churnTowns = Array.from({ length: DEPLOY_CHURN_WATCHDOG_ERROR_TOWNS }, (_, i) =>
+      town({
+        townId: `churn-${i}`,
+        weightedFailedChecks: 12,
+        weightedWatchdogCodeUpdated: 4,
+        ...span(SUSTAINED_FAILURE_MINUTES + 1),
+      })
+    );
+    const exhausted = town({
+      townId: 'wedged',
+      weightedFailedChecks: 9,
+      weightedExhausted: 1,
+      weightedWatchdogCodeUpdated: 2,
+    });
+
+    const result = classifyGastownHealth(metrics([...churnTowns, exhausted]));
+
+    expect(result.deployChurnSuspected).toBe(true);
+    expect(result.sustainedTownIds).toEqual([]);
+    // A genuine wedge (exhausted) still pages even when it also carries the
+    // deploy-churn fingerprint.
+    expect(result.exhaustedTownIds).toEqual(['wedged']);
+    expect(result.wedgeTownIds).toEqual(['wedged']);
+  });
+
+  it('does not suspect deploy churn below the town threshold', () => {
+    const result = classifyGastownHealth(
+      metrics([
+        town({
+          townId: 'town-1',
+          weightedFailedChecks: 12,
+          weightedWatchdogCodeUpdated: 3,
+          ...span(SUSTAINED_FAILURE_MINUTES + 1),
+        }),
+      ])
+    );
+
+    expect(result.deployChurnSuspected).toBe(false);
+    // Not excluded as churn, so still a sustained wedge.
+    expect(result.sustainedTownIds).toEqual(['town-1']);
+  });
+});
+
 describe('evaluateGastownHealthAlert', () => {
-  it('does not alert below both thresholds', async () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+  });
+
+  it('does not page on self-healed flapping', async () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
 
     await evaluateAt(
       kv,
-      makeMetrics(
-        GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks - 1,
-        GASTOWN_HEALTH_THRESHOLDS.affectedTowns - 1,
-        10
+      metrics(
+        [
+          town({
+            townId: 'town-1',
+            weightedFailedChecks: 8,
+            weightedSuccessfulChecks: 4,
+            weightedRecovered: 3,
+            ...span(SUSTAINED_FAILURE_MINUTES + 5),
+          }),
+        ],
+        { successful: 200 }
       ),
       sentAlerts
     );
@@ -82,172 +221,141 @@ describe('evaluateGastownHealthAlert', () => {
     expect(kv.store.size).toBe(0);
   });
 
-  it('does not alert when only the failed-check threshold is crossed', async () => {
+  it('always emits the aggregate trend info log', async () => {
     const kv = makeKv();
-    const sentAlerts: AlertPayload[] = [];
+    await evaluateAt(kv, metrics([], { failed: 0, successful: 500 }), []);
 
-    await evaluateAt(
-      kv,
-      makeMetrics(
-        GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks,
-        GASTOWN_HEALTH_THRESHOLDS.affectedTowns - 1
-      ),
-      sentAlerts
-    );
-
-    expect(sentAlerts).toEqual([]);
-    expect(kv.store.size).toBe(0);
-  });
-
-  it('does not alert when only the affected-town threshold is crossed', async () => {
-    const kv = makeKv();
-    const sentAlerts: AlertPayload[] = [];
-
-    await evaluateAt(
-      kv,
-      makeMetrics(
-        GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks - 1,
-        GASTOWN_HEALTH_THRESHOLDS.affectedTowns
-      ),
-      sentAlerts
-    );
-
-    expect(sentAlerts).toEqual([]);
-    expect(kv.store.size).toBe(0);
-  });
-
-  it('alerts when both critical mass thresholds are crossed', async () => {
-    const kv = makeKv();
-    const sentAlerts: AlertPayload[] = [];
-
-    await evaluateAt(
-      kv,
-      makeMetrics(
-        GASTOWN_HEALTH_THRESHOLDS.weightedFailedChecks,
-        GASTOWN_HEALTH_THRESHOLDS.affectedTowns
-      ),
-      sentAlerts
-    );
-
-    expect(sentAlerts).toMatchObject([
-      {
-        alertType: 'gastown_container_health',
-        severity: 'ticket',
-        weightedFailedChecks: 30,
-        affectedTownCount: 4,
-        windowMinutes: 15,
-        crossedThresholds: ['failed_checks', 'affected_towns'],
-      },
-    ]);
-  });
-
-  it('notifies only once during persistent failure', async () => {
-    const kv = makeKv();
-    const sentAlerts: AlertPayload[] = [];
-    const failingMetrics = makeMetrics(30, 4);
-
-    await evaluateAt(kv, failingMetrics, sentAlerts);
-    await evaluateAt(kv, makeMetrics(45, 4), sentAlerts);
-    await evaluateAt(kv, makeMetrics(59, 4), sentAlerts);
-
-    expect(sentAlerts).toHaveLength(1);
-  });
-
-  it('renotifies during persistent failure when failed checks climb by another threshold step', async () => {
-    const kv = makeKv();
-    const sentAlerts: AlertPayload[] = [];
-
-    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
-    await evaluateAt(kv, makeMetrics(59, 4), sentAlerts);
-    await evaluateAt(kv, makeMetrics(60, 4), sentAlerts);
-
-    expect(sentAlerts).toMatchObject([
-      {
-        weightedFailedChecks: 30,
-        affectedTownCount: 4,
-      },
-      {
-        weightedFailedChecks: 60,
-        affectedTownCount: 4,
-      },
-    ]);
-  });
-
-  it('does not clear active state when no telemetry is observed', async () => {
-    const kv = makeKv();
-    const sentAlerts: AlertPayload[] = [];
-
-    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
-    await evaluateAt(kv, makeMetrics(0, 0), sentAlerts);
-    await evaluateAt(kv, makeMetrics(0, 0), sentAlerts);
-    await evaluateAt(kv, makeMetrics(0, 0), sentAlerts);
-
-    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
-      active: true,
-      consecutiveHealthyCount: 0,
-      lastNotifiedWeightedFailedChecks: 30,
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(String(infoSpy.mock.calls[0]?.[0]));
+    expect(payload).toMatchObject({
+      event: 'gastown_container_health_trend',
+      weightedSuccessfulChecks: 500,
+      exhaustedTownCount: 0,
+      sustainedTownCount: 0,
     });
   });
 
-  it('clears after three consecutive healthy evaluations and alerts on recurrence', async () => {
+  it('pages once for an exhausted town', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+    const exhausted = metrics(
+      [town({ townId: 'town-1', weightedFailedChecks: 9, weightedExhausted: 1 })],
+      { successful: 100 }
+    );
+
+    await evaluateAt(kv, exhausted, sentAlerts);
+    await evaluateAt(kv, exhausted, sentAlerts);
+
+    expect(sentAlerts).toHaveLength(1);
+    const alert = sentAlerts[0] as GastownHealthAlertPayload;
+    expect(alert).toMatchObject({
+      alertType: 'gastown_container_health',
+      severity: 'ticket',
+      exhaustedTownIds: ['town-1'],
+      sustainedTownIds: [],
+      deployChurnSuspected: false,
+    });
+  });
+
+  it('pages on a sustained wedge with no recovery', async () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
 
-    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
-    await evaluateAt(kv, makeMetrics(0, 0, 12), sentAlerts);
-    await evaluateAt(kv, makeMetrics(0, 0, 8), sentAlerts);
-    await evaluateAt(kv, makeMetrics(0, 0, 1), sentAlerts);
+    await evaluateAt(kv, metrics([sustainedTown('town-1')], { successful: 50 }), sentAlerts);
+
+    expect(sentAlerts).toHaveLength(1);
+    expect((sentAlerts[0] as GastownHealthAlertPayload).sustainedTownIds).toEqual(['town-1']);
+  });
+
+  it('does not page during broad deploy churn without a genuine wedge', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+    const churnTowns = Array.from({ length: DEPLOY_CHURN_WATCHDOG_ERROR_TOWNS }, (_, i) =>
+      town({
+        townId: `churn-${i}`,
+        weightedFailedChecks: 12,
+        weightedWatchdogCodeUpdated: 4,
+        ...span(SUSTAINED_FAILURE_MINUTES + 1),
+      })
+    );
+
+    await evaluateAt(kv, metrics(churnTowns, { successful: 100 }), sentAlerts);
+
+    expect(sentAlerts).toEqual([]);
+    expect(kv.store.size).toBe(0);
+  });
+
+  it('re-notifies when the wedged town set escalates', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+
+    await evaluateAt(
+      kv,
+      metrics([town({ townId: 'town-1', weightedExhausted: 1, weightedFailedChecks: 9 })], {
+        successful: 100,
+      }),
+      sentAlerts
+    );
+    await evaluateAt(
+      kv,
+      metrics(
+        [
+          town({ townId: 'town-1', weightedExhausted: 1, weightedFailedChecks: 9 }),
+          town({ townId: 'town-2', weightedExhausted: 1, weightedFailedChecks: 9 }),
+        ],
+        { successful: 100 }
+      ),
+      sentAlerts
+    );
+
+    expect(sentAlerts).toHaveLength(2);
+    expect((sentAlerts[1] as GastownHealthAlertPayload).exhaustedTownIds).toEqual([
+      'town-1',
+      'town-2',
+    ]);
+  });
+
+  it('resolves after three clean evaluations and re-pages on recurrence', async () => {
+    const kv = makeKv();
+    const sentAlerts: AlertPayload[] = [];
+    const wedge = metrics(
+      [town({ townId: 'town-1', weightedExhausted: 1, weightedFailedChecks: 9 })],
+      { successful: 100 }
+    );
+    const clean = metrics([], { successful: 200 });
+
+    await evaluateAt(kv, wedge, sentAlerts);
+    await evaluateAt(kv, clean, sentAlerts);
+    await evaluateAt(kv, clean, sentAlerts);
+    await evaluateAt(kv, clean, sentAlerts);
 
     expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
       active: false,
       consecutiveHealthyCount: 0,
     });
 
-    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
+    await evaluateAt(kv, wedge, sentAlerts);
     expect(sentAlerts).toHaveLength(2);
   });
 
-  it('resets recovery progress when a threshold is crossed again', async () => {
+  it('does not resolve during a telemetry blackout', async () => {
     const kv = makeKv();
     const sentAlerts: AlertPayload[] = [];
+    const wedge = metrics(
+      [town({ townId: 'town-1', weightedExhausted: 1, weightedFailedChecks: 9 })],
+      { successful: 100 }
+    );
 
-    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
-    await evaluateAt(kv, makeMetrics(0, 0, 1), sentAlerts);
-    await evaluateAt(kv, makeMetrics(30, 4), sentAlerts);
+    await evaluateAt(kv, wedge, sentAlerts);
+    // No wedge towns and zero successful pings — a blackout, not a recovery.
+    await evaluateAt(kv, metrics([], { successful: 0 }), sentAlerts);
+    await evaluateAt(kv, metrics([], { successful: 0 }), sentAlerts);
+    await evaluateAt(kv, metrics([], { successful: 0 }), sentAlerts);
 
-    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
+    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toMatchObject({
       active: true,
-      consecutiveHealthyCount: 0,
-      lastNotifiedWeightedFailedChecks: 30,
+      notifiedTownIds: ['town-1'],
     });
-    expect(sentAlerts).toHaveLength(1);
-  });
-
-  it('backfills legacy active state to the last step boundary, not the current count', async () => {
-    const kv = makeKv();
-    const sentAlerts: AlertPayload[] = [];
-    kv.store.set(STATE_KEY, JSON.stringify({ active: true, consecutiveHealthyCount: 0 }));
-
-    // weightedFailedChecks=59 is between step boundaries 30 and 60; backfill should be 30
-    await evaluateAt(kv, makeMetrics(59, 4), sentAlerts);
-
-    expect(sentAlerts).toEqual([]);
-    expect(JSON.parse(kv.store.get(STATE_KEY) ?? '')).toEqual({
-      active: true,
-      consecutiveHealthyCount: 0,
-      lastNotifiedWeightedFailedChecks: 30,
-    });
-  });
-
-  it('re-notifies correctly after backfilling legacy active state', async () => {
-    const kv = makeKv();
-    const sentAlerts: AlertPayload[] = [];
-    kv.store.set(STATE_KEY, JSON.stringify({ active: true, consecutiveHealthyCount: 0 }));
-
-    await evaluateAt(kv, makeMetrics(59, 4), sentAlerts);
-    await evaluateAt(kv, makeMetrics(60, 4), sentAlerts);
-
-    expect(sentAlerts).toMatchObject([{ weightedFailedChecks: 60, affectedTownCount: 4 }]);
   });
 
   it('does not persist active state when notification delivery fails', async () => {
@@ -256,7 +364,10 @@ describe('evaluateGastownHealthAlert', () => {
     await expect(
       evaluateGastownHealthAlert(
         makeEnv(kv),
-        async () => makeMetrics(30, 4),
+        async () =>
+          metrics([town({ townId: 'town-1', weightedExhausted: 1, weightedFailedChecks: 9 })], {
+            successful: 100,
+          }),
         async () => {
           throw new Error('Slack unavailable');
         }

--- a/services/o11y/test/gastown-health-query.spec.ts
+++ b/services/o11y/test/gastown-health-query.spec.ts
@@ -9,6 +9,23 @@ const API_TOKEN = 'test-token-abc';
 
 type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
 
+type TownRow = {
+  town_id: string;
+  weighted_failed_checks: string | number | null;
+  weighted_successful_checks: string | number | null;
+  weighted_exhausted: string | number | null;
+  weighted_recovered: string | number | null;
+  weighted_watchdog_code_updated: string | number | null;
+  first_event_timestamp: string | null;
+  last_event_timestamp: string | null;
+};
+
+type AggregateRow = {
+  weighted_failed_checks: string | number | null;
+  weighted_successful_checks: string | number | null;
+  latest_event_timestamp: string | null;
+};
+
 function makeSecret(value: string | null): SecretsStoreSecret {
   return { get: async () => value } as unknown as SecretsStoreSecret;
 }
@@ -20,89 +37,135 @@ function makeEnv(token: string | null = API_TOKEN) {
   };
 }
 
+// The query runs two AE statements; route each response by inspecting the SQL.
+function isTownSignalSql(body: unknown): boolean {
+  return String(body).includes('GROUP BY town_id');
+}
+
+function makeFetchFn(responses: { townRows: TownRow[]; aggregateRow: AggregateRow | null }): {
+  fetchFn: FetchFn;
+  calls: Array<{ url: string; init?: RequestInit }>;
+} {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchFn: FetchFn = async (url, init) => {
+    calls.push({ url, init });
+    if (isTownSignalSql(init?.body)) {
+      return Response.json({ data: responses.townRows });
+    }
+    return Response.json({ data: responses.aggregateRow ? [responses.aggregateRow] : [] });
+  };
+  return { fetchFn, calls };
+}
+
 describe('queryGastownHealth', () => {
-  it('queries weighted fifteen-minute container health metrics', async () => {
-    let calledUrl = '';
-    let calledInit: RequestInit | undefined;
-    const fetchFn: FetchFn = async (url, init) => {
-      calledUrl = url;
-      calledInit = init;
-      return Response.json({
-        data: [
-          {
-            town_id: 'town-1',
-            weighted_failed_checks: '20',
-            weighted_successful_checks: '100',
-            latest_event_timestamp: '2026-06-24 15:09:00.000',
-          },
-          {
-            town_id: 'town-2',
-            weighted_failed_checks: '4',
-            weighted_successful_checks: '50',
-            latest_event_timestamp: '2026-06-24 15:10:00.000',
-          },
-          {
-            town_id: '',
-            weighted_failed_checks: '3',
-            weighted_successful_checks: '2',
-            latest_event_timestamp: '2026-06-24 15:08:00.000',
-          },
-        ],
-      });
-    };
-
-    await expect(queryGastownHealth(makeEnv(), fetchFn)).resolves.toEqual({
-      weightedFailedChecks: 27,
-      weightedSuccessfulChecks: 152,
-      affectedTownCount: 2,
-      latestEventTimestamp: new Date('2026-06-24T15:10:00.000Z'),
+  it('parses per-town signals and the fleet aggregate', async () => {
+    const { fetchFn, calls } = makeFetchFn({
+      townRows: [
+        {
+          town_id: 'town-1',
+          weighted_failed_checks: '12',
+          weighted_successful_checks: '0',
+          weighted_exhausted: '1',
+          weighted_recovered: '0',
+          weighted_watchdog_code_updated: '0',
+          first_event_timestamp: '2026-06-24 15:00:00.000',
+          last_event_timestamp: '2026-06-24 15:12:00.000',
+        },
+        {
+          town_id: 'town-2',
+          weighted_failed_checks: '4',
+          weighted_successful_checks: '3',
+          weighted_exhausted: '0',
+          weighted_recovered: '2',
+          weighted_watchdog_code_updated: '5',
+          first_event_timestamp: '2026-06-24 15:05:00.000',
+          last_event_timestamp: '2026-06-24 15:09:00.000',
+        },
+      ],
+      aggregateRow: {
+        weighted_failed_checks: '16',
+        weighted_successful_checks: '150',
+        latest_event_timestamp: '2026-06-24 15:12:00.000',
+      },
     });
-    expect(calledUrl).toBe(
-      `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/analytics_engine/sql`
-    );
-    expect(new Headers(calledInit?.headers).get('Authorization')).toBe(`Bearer ${API_TOKEN}`);
-    expect(calledInit?.signal).toBeInstanceOf(AbortSignal);
 
-    const sql = String(calledInit?.body);
-    expect(sql).toContain('FROM gastown_events');
-    expect(sql).toContain(`INTERVAL '${GASTOWN_HEALTH_WINDOW_MINUTES}' MINUTE`);
-    expect(sql).toContain("blob1 = 'container.health_ping'");
-    expect(sql).toContain("SUM(IF(blob5 != '', _sample_interval, 0))");
-    expect(sql).toContain("SUM(IF(blob5 = '', _sample_interval, 0))");
-    expect(sql).toContain("IF(blob5 != '' AND blob6 != '', blob6, '') AS town_id");
-    expect(sql).toContain('GROUP BY town_id');
-    expect(sql).not.toContain('GROUP BY blob6');
-    expect(sql).not.toContain('uniqExactIf');
+    const metrics = await queryGastownHealth(makeEnv(), fetchFn);
+
+    expect(metrics.aggregateWeightedFailedChecks).toBe(16);
+    expect(metrics.aggregateWeightedSuccessfulChecks).toBe(150);
+    expect(metrics.latestEventTimestamp).toEqual(new Date('2026-06-24T15:12:00.000Z'));
+    expect(metrics.townSignals).toEqual([
+      {
+        townId: 'town-1',
+        weightedFailedChecks: 12,
+        weightedSuccessfulChecks: 0,
+        weightedExhausted: 1,
+        weightedRecovered: 0,
+        weightedWatchdogCodeUpdated: 0,
+        firstEventAt: new Date('2026-06-24T15:00:00.000Z'),
+        lastEventAt: new Date('2026-06-24T15:12:00.000Z'),
+      },
+      {
+        townId: 'town-2',
+        weightedFailedChecks: 4,
+        weightedSuccessfulChecks: 3,
+        weightedExhausted: 0,
+        weightedRecovered: 2,
+        weightedWatchdogCodeUpdated: 5,
+        firstEventAt: new Date('2026-06-24T15:05:00.000Z'),
+        lastEventAt: new Date('2026-06-24T15:09:00.000Z'),
+      },
+    ]);
+
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(call.url).toBe(
+        `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/analytics_engine/sql`
+      );
+      expect(new Headers(call.init?.headers).get('Authorization')).toBe(`Bearer ${API_TOKEN}`);
+      expect(call.init?.signal).toBeInstanceOf(AbortSignal);
+    }
+
+    const townSql = String(calls.find(c => isTownSignalSql(c.init?.body))?.init?.body);
+    expect(townSql).toContain('FROM gastown_events');
+    expect(townSql).toContain(`INTERVAL '${GASTOWN_HEALTH_WINDOW_MINUTES}' MINUTE`);
+    expect(townSql).toContain("'container.auto_restart_exhausted'");
+    expect(townSql).toContain("'container.health_recovered'");
+    expect(townSql).toContain("'container.health_watchdog_error'");
+    expect(townSql).toContain("position('code was updated' IN blob5) > 0");
+    expect(townSql).toContain('GROUP BY town_id');
+    expect(townSql).toContain('HAVING');
+
+    const aggregateSql = String(calls.find(c => !isTownSignalSql(c.init?.body))?.init?.body);
+    expect(aggregateSql).toContain("blob1 = 'container.health_ping'");
+    expect(aggregateSql).not.toContain('GROUP BY');
   });
 
-  it('maps an empty Analytics Engine result to no telemetry', async () => {
-    const fetchFn: FetchFn = async () => Response.json({ data: [] });
+  it('maps empty Analytics Engine results to no telemetry', async () => {
+    const { fetchFn } = makeFetchFn({ townRows: [], aggregateRow: null });
 
     await expect(queryGastownHealth(makeEnv(), fetchFn)).resolves.toEqual({
-      weightedFailedChecks: 0,
-      weightedSuccessfulChecks: 0,
-      affectedTownCount: 0,
+      townSignals: [],
+      aggregateWeightedFailedChecks: 0,
+      aggregateWeightedSuccessfulChecks: 0,
       latestEventTimestamp: null,
     });
   });
 
-  it('maps null aggregates to no telemetry', async () => {
-    const fetchFn: FetchFn = async () =>
-      Response.json({
-        data: [
-          {
-            town_id: '',
-            weighted_failed_checks: null,
-            weighted_successful_checks: null,
-            latest_event_timestamp: null,
-          },
-        ],
-      });
+  it('maps null aggregates to zero', async () => {
+    const { fetchFn } = makeFetchFn({
+      townRows: [],
+      aggregateRow: {
+        weighted_failed_checks: null,
+        weighted_successful_checks: null,
+        latest_event_timestamp: null,
+      },
+    });
 
     await expect(queryGastownHealth(makeEnv(), fetchFn)).resolves.toEqual({
-      weightedFailedChecks: 0,
-      weightedSuccessfulChecks: 0,
-      affectedTownCount: 0,
+      townSignals: [],
+      aggregateWeightedFailedChecks: 0,
+      aggregateWeightedSuccessfulChecks: 0,
       latestEventTimestamp: null,
     });
   });
@@ -110,21 +173,42 @@ describe('queryGastownHealth', () => {
   it.each(['', 'not-a-number', '-1', 'Infinity'])(
     'rejects invalid Analytics Engine aggregate %j',
     async aggregate => {
-      const fetchFn: FetchFn = async () =>
-        Response.json({
-          data: [
-            {
-              town_id: '',
-              weighted_failed_checks: aggregate,
-              weighted_successful_checks: '0',
-              latest_event_timestamp: null,
-            },
-          ],
-        });
+      const { fetchFn } = makeFetchFn({
+        townRows: [],
+        aggregateRow: {
+          weighted_failed_checks: aggregate,
+          weighted_successful_checks: '0',
+          latest_event_timestamp: null,
+        },
+      });
 
       await expect(queryGastownHealth(makeEnv(), fetchFn)).rejects.toThrow();
     }
   );
+
+  it('rejects an invalid per-town timestamp', async () => {
+    const { fetchFn } = makeFetchFn({
+      townRows: [
+        {
+          town_id: 'town-1',
+          weighted_failed_checks: '12',
+          weighted_successful_checks: '0',
+          weighted_exhausted: '0',
+          weighted_recovered: '0',
+          weighted_watchdog_code_updated: '0',
+          first_event_timestamp: 'not-a-timestamp',
+          last_event_timestamp: '2026-06-24 15:12:00.000',
+        },
+      ],
+      aggregateRow: {
+        weighted_failed_checks: '12',
+        weighted_successful_checks: '0',
+        latest_event_timestamp: '2026-06-24 15:12:00.000',
+      },
+    });
+
+    await expect(queryGastownHealth(makeEnv(), fetchFn)).rejects.toThrow('invalid timestamp');
+  });
 
   it('rejects malformed Analytics Engine responses', async () => {
     const fetchFn: FetchFn = async () =>
@@ -133,7 +217,7 @@ describe('queryGastownHealth', () => {
     await expect(queryGastownHealth(makeEnv(), fetchFn)).rejects.toThrow();
   });
 
-  it('rejects invalid Analytics Engine queries without exposing response content', async () => {
+  it('rejects failed Analytics Engine queries without exposing response content', async () => {
     const fetchFn: FetchFn = async () =>
       new Response('sensitive provider response', { status: 422 });
 

--- a/services/o11y/test/notify.spec.ts
+++ b/services/o11y/test/notify.spec.ts
@@ -101,32 +101,48 @@ describe('buildSlackMessage — gastown_container_health alert', () => {
   const alert: GastownHealthAlertPayload = {
     alertType: 'gastown_container_health',
     severity: 'ticket',
-    weightedFailedChecks: 36,
-    affectedTownCount: 4,
     windowMinutes: 15,
-    crossedThresholds: ['failed_checks', 'affected_towns'],
-    failedChecksThreshold: 30,
-    affectedTownsThreshold: 4,
+    sustainedFailureMinutes: 10,
+    exhaustedTownIds: ['town-a', 'town-b'],
+    sustainedTownIds: ['town-c'],
+    deployChurnSuspected: false,
+    deployChurnTownCount: 0,
+    affectedTownCount: 4,
+    weightedFailedChecks: 36,
   };
 
-  it('includes counts, crossed thresholds, and investigation guidance', () => {
-    const msg = buildSlackMessage(alert) as {
+  function renderText(payload: GastownHealthAlertPayload): string {
+    const msg = buildSlackMessage(payload) as {
       blocks: Array<{ fields?: Array<{ text: string }>; text?: { text: string } }>;
     };
-    const allText = msg.blocks.flatMap(block => [
-      block.text?.text ?? '',
-      ...(block.fields?.map(field => field.text) ?? []),
-    ]);
-    const text = allText.join('\n');
+    return msg.blocks
+      .flatMap(block => [block.text?.text ?? '', ...(block.fields?.map(field => field.text) ?? [])])
+      .join('\n');
+  }
+
+  it('names the wedged towns and keeps guidance links', () => {
+    const text = renderText(alert);
 
     expect(text).toContain('Gastown container health failures');
     expect(text).toContain('15-minute window');
+    expect(text).toContain('exhausted auto-restarts');
+    expect(text).toContain('town-a, town-b');
+    expect(text).toContain('failing >= 10 min');
+    expect(text).toContain('town-c');
     expect(text).toContain('36');
-    expect(text).toContain('4');
-    expect(text).toContain('30 failed checks');
-    expect(text).toContain('4 affected towns');
     expect(text).toContain('gastown-operations');
     expect(text).toContain('gastown-container-health-failures.md');
+  });
+
+  it('does not render a deploy-churn annotation when churn is not suspected', () => {
+    expect(renderText(alert)).not.toContain('Deploy churn suspected');
+  });
+
+  it('renders the deploy-churn annotation when churn is suspected', () => {
+    const text = renderText({ ...alert, deployChurnSuspected: true, deployChurnTownCount: 5 });
+
+    expect(text).toContain('Deploy churn suspected across 5 town(s)');
+    expect(text).toContain('code was updated');
   });
 });
 


### PR DESCRIPTION
## Summary
Close the observability + alerting gap behind the recurring "Gastown container health failures" page by making recovery/wedge-cause definitive and paging only when a human is actually needed.

### Why this change is needed
- The watchdog auto-restarts wedged towns but emitted no recovery signal, so on-call couldn't tell self-healed flapping from a stuck wedge — and the monitor paged on raw flapping (noisy, low-actionability).
- Whole-episode downtime and wedge cause weren't derivable: `firstHealthFailureAt` is cleared on every restart, with no cross-restart episode marker.
- Deploy churn (Town DOs reset by a rollout) looked identical to incidents.
- Container-health telemetry carried only `townId`, so incidents couldn't be correlated to a specific Cloudflare container instance when working with Cloudflare support.

### How this is addressed
Workstream A (`services/gastown`):
- Emit `container.health_recovered` (AE + Logpush) on the first healthy ping after an unhealthy episode, with whole-episode `downtimeMs` (via a restart-surviving `unhealthyEpisodeStartedAt` marker) and a `recoveredAfter` attribution (`auto_restart` | `cold_start_grace` | `self`).
- Dual-write `container.health_watchdog_error` to Analytics Engine (was Logpush-only) so the monitor can fingerprint deploy churn.
- Mirror container boot lifecycle (`cold_start`, `ready_observed`) to the Logpush watchdog envelope for Axiom.
- Stamp the Cloudflare container id (TownContainerDO Durable Object id) onto every container-health event on both sinks (new AE blob16) for Cloudflare-support correlation.

Workstream B (`services/o11y`):
- Page only on confirmed wedges: a town that exhausted its restart budget, or one failing continuously ≥10 min with no recovery/success. Raw flapping no longer pages.
- Suppress broad deploy churn (≥3 towns with "code was updated") from the sustained path while still paging genuine exhausted wedges (annotated).
- Event-driven dedup: page once per episode, re-page on escalation, resolve after 3 clean evaluations; a telemetry blackout no longer counts as recovery.
- Keep the aggregate flapping signal as a non-paging structured trend log each tick.

Relates to the prior auto-recovery work (#4349).

## Human Verification
- gastown watchdog unit tests 13/13 (recovery attribution, sub-threshold self-heal, cold-start-grace, no-episode no-emit, watchdog_error dual-write, container-id stamping).
- Full gastown suite 292/292; full o11y suite 156/156.
- Confirmed against the plan's locked decisions: AE-native (no Axiom client/token), additive DO storage keys, backward-safe KV state (legacy → inactive), no renamed event values, no AE schema migration (reused blobs/doubles + additive blob16).

## Reviewer Notes

### Human Reviewer Flags
- Alerting behavior change: PAGE gates move from raw weighted-flapping thresholds (30 failed / 4 towns) to confirmed-wedge criteria. `SUSTAINED_FAILURE_MINUTES=10` and `DEPLOY_CHURN_WATCHDOG_ERROR_TOWNS=3` are reasoned from watchdog config and need calibration against the incident logs/runbook in `github.com/Kilo-Org/on-call` before/at rollout.
- Hard rollout ordering: ship + verify Workstream A in AE first (B's predicate reads `container.health_recovered` + `container.health_watchdog_error`). Until B ships, the existing flapping page remains (safe but noisy). No production deploy without sign-off.
- Deploy-churn detection uses the "code was updated" watchdog-error fingerprint as a proxy for ScriptVersion.ID; may be sparse — documented fallback is a CF version-metadata deploy marker.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Recovery `consecutiveFailures` is the post-last-restart streak (auto_restart resets the counter); `durationMs` spans the whole episode from the persistent marker — documented in code.
- `recoveredAfter` gives `auto_restart` priority over `cold_start_grace` (won't downgrade after a restart).
- o11y query is two time-bounded AE statements (5s timeout each): a per-town wedge-signal query using `GROUP BY town_id` + `HAVING` to drop healthy towns (payload control), and a single-row fleet heartbeat used for the info trend and to distinguish recovery from a telemetry blackout. `HAVING`/`position(x IN y)` support confirmed against the Cloudflare AE SQL reference.
- Sustained-span uses MIN/MAX event timestamps; consulted only when success=0 and recovered=0, where events are failed pings, so the span equals the continuous-failure span.
- Container id is stamped centrally in the watchdog's `safeWriteEvent`/`safeLog`; blob16 is additive (no remap; existing blob1–15 queries unaffected).

</details>
