### PR TITLE
CloudAgentNext - Fix outboundHandlers static field shadowing bug

### DIFF
--- a/services/cloud-agent-next/src/sandbox-outbound.test.ts
+++ b/services/cloud-agent-next/src/sandbox-outbound.test.ts
@@ -130,14 +130,14 @@ describe('managed GitHub sandbox outbound configuration', () => {
         headers: { Authorization: basicCredential(CAPABILITY) },
       }),
       env,
-      { containerId: 'container-test' }
+      { containerId: 'container-test', className: 'SandboxSmallContainment' }
     );
     await handler(
       new Request('https://api.github.com/user', {
         headers: { Authorization: `token ${CAPABILITY}` },
       }),
       env,
-      { containerId: 'container-test' }
+      { containerId: 'container-test', className: 'SandboxSmallContainment' }
     );
 
     expect(redeemGitHubSessionCapability).toHaveBeenCalledTimes(2);

--- a/services/cloud-agent-next/src/sandbox-outbound.ts
+++ b/services/cloud-agent-next/src/sandbox-outbound.ts
@@ -422,17 +422,20 @@ export class SandboxCodeReview extends StockSandbox<Cloudflare.Env> {
 
 export class SandboxContainment extends Sandbox {
   interceptHttps = true;
-  static outboundHandlers = managedScmOutboundHandlers;
 }
+// Assignment (not a static class field) so it invokes the inherited Container.outboundHandlers
+// setter and registers into @cloudflare/containers' internal outboundHandlersRegistry. A static
+// class field here would shadow the inherited accessor and silently no-op the registration.
+SandboxContainment.outboundHandlers = managedScmOutboundHandlers;
 
 export class SandboxSmallContainment extends SandboxSmall {
   interceptHttps = true;
-  static outboundHandlers = managedScmOutboundHandlers;
 }
+SandboxSmallContainment.outboundHandlers = managedScmOutboundHandlers;
 
 export class SandboxCodeReviewContainment extends SandboxCodeReview {
   interceptHttps = true;
-  static outboundHandlers = managedScmOutboundHandlers;
 }
+SandboxCodeReviewContainment.outboundHandlers = managedScmOutboundHandlers;
 
 export { ContainerProxy };


### PR DESCRIPTION
## Summary

Fixed a bug in `SandboxContainment`, `SandboxSmallContainment`, and `SandboxCodeReviewContainment`: assigning `outboundHandlers` as a static class field shadowed the inherited `Container.outboundHandlers` setter, silently no-op'ing registration into @cloudflare/containers' internal `outboundHandlersRegistry`. Managed SCM outbound handlers were therefore never actually registered for these containment classes.

Changed the static field declarations to plain assignments after the class declaration so the inherited setter runs and registration succeeds.

## Verification

N/A — code fix verified via updated unit test asserting handlers are invoked for `SandboxSmallContainment`.

## Visual Changes

N/A

## Reviewer Notes

N/A