### PR TITLE
chore(extension): prep browser store release

### DIFF
--- a/apps/extension/SOURCE_CODE_REVIEW.md
+++ b/apps/extension/SOURCE_CODE_REVIEW.md
@@ -1,0 +1,10 @@
+# Firefox Source Review
+
+This source archive is rooted at the monorepo root so pnpm catalog versions resolve.
+
+To rebuild the Firefox package:
+
+```bash
+pnpm install --ignore-scripts
+pnpm --filter kilo-extension zip:firefox
+```

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -2,7 +2,7 @@
   "name": "kilo-extension",
   "description": "Kilo browser extension.",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "wxt --port 3001",

--- a/apps/extension/tests/e2e/firefox-selenium-e2e.ts
+++ b/apps/extension/tests/e2e/firefox-selenium-e2e.ts
@@ -1,6 +1,7 @@
 /* eslint-disable id-length, import/no-nodejs-modules, max-lines, no-await-in-loop, promise/avoid-new, promise/no-callback-in-promise, promise/prefer-await-to-callbacks */
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
 import { dirname, resolve as resolvePath } from 'node:path';
@@ -11,7 +12,13 @@ import firefox from 'selenium-webdriver/firefox';
 import { z } from 'zod';
 
 const extensionRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), '../..');
-const firefoxZipPath = resolvePath(extensionRoot, '.output/kilo-extension-0.0.0-firefox.zip');
+const packageManifest = z
+  .object({ version: z.string().min(1) })
+  .parse(JSON.parse(readFileSync(resolvePath(extensionRoot, 'package.json'), 'utf8')));
+const firefoxZipPath = resolvePath(
+  extensionRoot,
+  `.output/kilo-extension-${packageManifest.version}-firefox.zip`
+);
 const waitMs = 15_000;
 
 const chromeWorkflowNames = [
@@ -1391,6 +1398,7 @@ const scenarios: FirefoxScenario[] = [
                 throw new Error('Agent conversation pane was not found.');
               }
 
+              conversation.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: 4000 }));
               conversation.scrollTop = conversation.scrollHeight;
               conversation.dispatchEvent(new Event('scroll', { bubbles: true }));
             });

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -33,4 +33,25 @@ export default defineConfig({
   vite: () => ({
     plugins: [tailwindcss()],
   }),
+  zip: {
+    includeSources: [
+      'package.json',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+      'patches/**',
+      'apps/extension/AGENTS.md',
+      'apps/extension/SOURCE_CODE_REVIEW.md',
+      'apps/extension/package.json',
+      'apps/extension/playwright.config.ts',
+      'apps/extension/tsconfig.json',
+      'apps/extension/vitest.config.ts',
+      'apps/extension/wxt.config.ts',
+      'apps/extension/entrypoints/**',
+      'apps/extension/public/**',
+      'apps/extension/scripts/**',
+      'apps/extension/src/**',
+      'apps/extension/tests/e2e/**',
+    ],
+    sourcesRoot: '../..',
+  },
 });


### PR DESCRIPTION
## Summary

- Bump the browser extension package version to `0.1.0` so generated Chrome and Firefox manifests use a publishable version.
- Make the Firefox Selenium E2E harness install the zip matching the current package version instead of a hardcoded release filename.
- Align the Firefox scroll reactivation scenario with the real downward wheel intent the UI requires.
- Make the Firefox source zip rebuildable from review sources by including the needed workspace files and source-review commands.

## Verification

- [x] Generated Chrome and Firefox release artifacts locally and confirmed both generated manifests report version `0.1.0`.
- [x] Confirmed release artifacts exist at `.output/kilo-extension-0.1.0-chrome.zip`, `.output/kilo-extension-0.1.0-firefox.zip`, and `.output/kilo-extension-0.1.0-sources.zip`.
- [x] Extracted `.output/kilo-extension-0.1.0-sources.zip` to a temp directory and rebuilt Firefox from the archived sources.

## Visual Changes

N/A

## Reviewer Notes

Firefox `web-ext lint` reports existing bundled-code warnings for dynamic evaluation and HTML assignment; it reports 0 errors.