### PR TITLE
chore(extension): bump package metadata to 0.1.1

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,8 +1,8 @@
 {
   "name": "kilo-extension",
-  "description": "Kilo browser extension.",
+  "description": "Side-panel AI chat agent. Use open-weight or frontier models.",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "wxt --port 3001",

--- a/apps/extension/tests/e2e/firefox-selenium-e2e.ts
+++ b/apps/extension/tests/e2e/firefox-selenium-e2e.ts
@@ -479,7 +479,7 @@ const waitForTextGone = async (driver: WebDriver, text: string): Promise<void> =
 
 const findManifestUrl = async (driver: WebDriver): Promise<string> => {
   await driver.get('about:debugging#/runtime/this-firefox');
-  await waitForText(driver, 'Kilo Extension');
+  await waitForText(driver, 'Kilo Code');
 
   const bodyText = await getBodyText(driver);
   const manifestMatch = /Manifest URL\s+(moz-extension:\/\/\S+\/manifest\.json)/u.exec(bodyText);

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
         id: 'kilo-extension@kilocode.ai',
       },
     },
-    description: 'Kilo browser extension.',
+    description: 'Side-panel AI chat agent. Use open-weight or frontier models.',
     host_permissions: [
       '<all_urls>',
       'file:///*',
@@ -23,7 +23,7 @@ export default defineConfig({
       'http://127.0.0.1/*',
       'http://localhost/*',
     ],
-    name: 'Kilo Extension',
+    name: 'Kilo Code',
     permissions:
       browser === 'firefox'
         ? ['identity', 'scripting', 'storage', 'tabs']


### PR DESCRIPTION
## Summary
Updates the browser extension package metadata for the 0.1.1 release. The generated manifest now uses the Kilo Code title and the new side-panel AI chat agent summary.

## Verification
Generated local Chrome and Firefox extension packages and inspected the built manifests to confirm title, summary, and version.

## Visual Changes
N/A

## Reviewer Notes
Build artifacts are generated locally under apps/extension/.output and are not committed.