### PR TITLE
Cloud Agent Next - Update Sandbox Instance Types

### DIFF
--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -55,7 +55,6 @@
     "R2_ATTACHMENTS_BUCKET": "cloud-agent-attachments",
     "WS_ALLOWED_ORIGINS": "https://app.kilo.ai,https://api.kilo.ai",
     "KILO_SESSION_INGEST_URL": "https://ingest.kilosessions.ai",
-    "MANAGED_SCM_CONTAINMENT_ORG_IDS": "",
   },
   "placement": { "mode": "smart" },
   /**

--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -146,7 +146,11 @@
     {
       "class_name": "Sandbox",
       "image": "./Dockerfile",
-      "instance_type": "standard-4",
+      "instance_type": {
+        "vcpu": 4,
+        "memory_mib": 12288,
+        "disk_mb": 20000,
+      },
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.54",
       },
@@ -156,7 +160,11 @@
     {
       "class_name": "SandboxSmall",
       "image": "./Dockerfile",
-      "instance_type": "standard-4",
+      "instance_type": {
+        "vcpu": 2,
+        "memory_mib": 6144,
+        "disk_mb": 10000,
+      },
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.54",
       },
@@ -166,7 +174,11 @@
     {
       "class_name": "SandboxDIND",
       "image": "./Dockerfile.dind",
-      "instance_type": "standard-3",
+      "instance_type": {
+        "vcpu": 2,
+        "memory_mib": 6144,
+        "disk_mb": 10000,
+      },
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.54",
       },
@@ -190,7 +202,11 @@
     {
       "class_name": "SandboxContainment",
       "image": "./Dockerfile",
-      "instance_type": "standard-4",
+      "instance_type": {
+        "vcpu": 4,
+        "memory_mib": 12288,
+        "disk_mb": 20000,
+      },
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.54",
       },
@@ -200,7 +216,11 @@
     {
       "class_name": "SandboxSmallContainment",
       "image": "./Dockerfile",
-      "instance_type": "standard-4",
+      "instance_type": {
+        "vcpu": 2,
+        "memory_mib": 6144,
+        "disk_mb": 10000,
+      },
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.54",
       },


### PR DESCRIPTION
## Summary

Replace named Cloudflare container instance_type presets (standard-3/standard-4) with explicit resource objects in services/cloud-agent-next/wrangler.jsonc. This gives direct control over vCPU, memory, and disk sizing for Sandbox, SandboxSmall, SandboxDIND, SandboxContainment, and SandboxSmallContainment.

## Verification

- Verified all explicit allocations stay within Cloudflare container limits (vCPU 1-4, memory ≤ 12 GiB, disk ≤ 20 GB, ≥ 3 GiB memory/vCPU, ≤ 2 GB disk/GiB memory).
- No manual deploy or runtime test performed; this is a config-only change.

## Visual Changes

N/A

## Reviewer Notes

- SandboxDIND, SandboxSmall, and SandboxSmallContainment are now sized at 2 vCPU / 6 GiB / 10 GB, smaller than their previous presets. Confirm these workloads fit the reduced resources before rollout.
- The dev environment still uses string presets for SandboxSmall/SandboxDIND/SandboxSmallContainment, so dev/prod resource parity should be reviewed.