### PR TITLE
fix(billing): stop double-counting nullified credits as expiring soon

### DIFF
--- a/apps/web/src/lib/creditExpiration.ts
+++ b/apps/web/src/lib/creditExpiration.ts
@@ -4,10 +4,12 @@ import {
   kilocode_users,
   organizations,
 } from '@kilocode/db/schema';
-import { db } from '@/lib/drizzle';
+import { db, type DrizzleTransaction } from '@/lib/drizzle';
 import { eq, and, isNull, isNotNull, inArray, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { sentryLogger } from '@/lib/utils.server';
+
+type DbOrTx = typeof db | DrizzleTransaction;
 
 export type ExpiringTransaction = Pick<
   CreditTransaction,
@@ -253,7 +255,7 @@ export function computeNextExpirationAmount(
 
 export async function fetchExpiringTransactionsForOrganization(
   organizationId: string,
-  fromDb: typeof db = db
+  fromDb: DbOrTx = db
 ) {
   const expiredCredits = alias(creditTransactionsTable, 'expired_credits');
 
@@ -284,6 +286,60 @@ export async function fetchExpiringTransactionsForOrganization(
         isNull(expiredCredits.id)
       )
     );
+}
+
+/**
+ * Closes out every still-open (unprocessed) expiring credit grant for an
+ * organization, inserting `credits_expired` entries for any unclaimed portion.
+ *
+ * Without this, an admin who nullifies an organization's credits and later
+ * re-grants credits with a different expiration date leaves the original
+ * grant's row untouched: it still has its original `expiry_date` and no
+ * matching `credits_expired` entry, so every downstream "credits expiring
+ * soon" computation (the org Balance page's `getCreditBlocks`, and the admin
+ * panel's `computeNextExpirationAmount`) keeps counting it, on top of the new
+ * grant, forever inflating the total.
+ *
+ * Must be called inside the same transaction that also nullifies/adjusts the
+ * organization's balance, so the closure is atomic with that change.
+ *
+ * Returns the total microdollars closed out (negative, or 0 if nothing was open).
+ */
+export async function closeOutExpiringOrganizationCredits(
+  organizationId: string,
+  microdollars_used: number,
+  tx: DrizzleTransaction
+): Promise<number> {
+  const openTransactions = await fetchExpiringTransactionsForOrganization(organizationId, tx);
+  if (openTransactions.length === 0) return 0;
+
+  // Use a far-future "now" so every still-open grant is treated as expired
+  // right away, regardless of its actual expiry_date.
+  const forceExpireAt = new Date('9999-01-01T00:00:00.000Z');
+  const expirationResult = computeExpiration(
+    openTransactions,
+    { id: organizationId, microdollars_used },
+    forceExpireAt,
+    'system'
+  );
+
+  if (expirationResult.newTransactions.length) {
+    await tx.insert(creditTransactionsTable).values(
+      expirationResult.newTransactions.map(t => ({
+        ...t,
+        organization_id: organizationId,
+      }))
+    );
+  }
+
+  for (const [transactionId, newBaseline] of expirationResult.newBaselines) {
+    await tx
+      .update(creditTransactionsTable)
+      .set({ expiration_baseline_microdollars_used: newBaseline })
+      .where(eq(creditTransactionsTable.id, transactionId));
+  }
+
+  return expirationResult.newTransactions.reduce((sum, t) => sum + (t.amount_microdollars ?? 0), 0);
 }
 
 type OrganizationForExpiration = {

--- a/apps/web/src/lib/creditExpirationOrg.test.ts
+++ b/apps/web/src/lib/creditExpirationOrg.test.ts
@@ -2,6 +2,7 @@ import { credit_transactions as creditTransactionsTable, organizations } from '@
 import {
   processOrganizationExpirations,
   fetchExpiringTransactionsForOrganization,
+  closeOutExpiringOrganizationCredits,
 } from './creditExpiration';
 import { db } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
@@ -427,5 +428,117 @@ describe('processOrganizationExpirations', () => {
       .where(eq(creditTransactionsTable.credit_category, 'credits_expired'));
     expect(expirations).toHaveLength(1);
     expect(expirations[0].amount_microdollars).toBe(0);
+  });
+});
+
+describe('closeOutExpiringOrganizationCredits', () => {
+  let ownerId: string;
+  let orgId: string;
+
+  beforeAll(async () => {
+    const owner = await insertTestUser({
+      google_user_email: `close-out-exp-org-${Date.now()}@example.com`,
+    });
+    ownerId = owner.id;
+  });
+
+  beforeEach(async () => {
+    const org = await createTestOrg(ownerId);
+    orgId = org!.id;
+  });
+
+  afterEach(async () => {
+    await db
+      .delete(creditTransactionsTable)
+      .where(eq(creditTransactionsTable.organization_id, orgId));
+    await db.delete(organizations).where(eq(organizations.id, orgId));
+  });
+
+  it('does nothing when there are no open expiring transactions', async () => {
+    const closedOut = await db.transaction(tx => closeOutExpiringOrganizationCredits(orgId, 0, tx));
+
+    expect(closedOut).toBe(0);
+    const expirations = await db
+      .select()
+      .from(creditTransactionsTable)
+      .where(eq(creditTransactionsTable.organization_id, orgId));
+    expect(expirations).toHaveLength(0);
+  });
+
+  it('closes out an unclaimed grant regardless of its expiry_date', async () => {
+    const txnId = randomUUID();
+    await db.insert(creditTransactionsTable).values({
+      id: txnId,
+      kilo_user_id: ownerId,
+      organization_id: orgId,
+      amount_microdollars: 10_000_000,
+      is_free: true,
+      expiry_date: '2030-01-01T00:00:00Z', // far in the future, not yet due
+      expiration_baseline_microdollars_used: 0,
+      original_baseline_microdollars_used: 0,
+      description: 'Still-open grant',
+    });
+
+    const closedOut = await db.transaction(tx => closeOutExpiringOrganizationCredits(orgId, 0, tx));
+
+    expect(closedOut).toBe(-10_000_000);
+
+    const expirations = await db
+      .select()
+      .from(creditTransactionsTable)
+      .where(eq(creditTransactionsTable.credit_category, 'credits_expired'));
+    expect(expirations).toHaveLength(1);
+    expect(expirations[0].amount_microdollars).toBe(-10_000_000);
+    expect(expirations[0].original_transaction_id).toBe(txnId);
+
+    // Once closed out, it is no longer reported as an open expiring transaction.
+    const stillOpen = await fetchExpiringTransactionsForOrganization(orgId);
+    expect(stillOpen).toHaveLength(0);
+  });
+
+  it('only closes out the unclaimed portion of a partially-used grant', async () => {
+    const txnId = randomUUID();
+    await db.insert(creditTransactionsTable).values({
+      id: txnId,
+      kilo_user_id: ownerId,
+      organization_id: orgId,
+      amount_microdollars: 10_000_000,
+      is_free: true,
+      expiry_date: '2030-01-01T00:00:00Z',
+      expiration_baseline_microdollars_used: 0,
+      original_baseline_microdollars_used: 0,
+      description: 'Partially used grant',
+    });
+
+    const closedOut = await db.transaction(tx =>
+      closeOutExpiringOrganizationCredits(orgId, 4_000_000, tx)
+    );
+
+    expect(closedOut).toBe(-6_000_000);
+  });
+
+  it('is idempotent — a second call finds nothing left to close out', async () => {
+    await db.insert(creditTransactionsTable).values({
+      kilo_user_id: ownerId,
+      organization_id: orgId,
+      amount_microdollars: 10_000_000,
+      is_free: true,
+      expiry_date: '2030-01-01T00:00:00Z',
+      expiration_baseline_microdollars_used: 0,
+      original_baseline_microdollars_used: 0,
+      description: 'Grant',
+    });
+
+    await db.transaction(tx => closeOutExpiringOrganizationCredits(orgId, 0, tx));
+    const secondCall = await db.transaction(tx =>
+      closeOutExpiringOrganizationCredits(orgId, 0, tx)
+    );
+
+    expect(secondCall).toBe(0);
+    const expirations = await db
+      .select()
+      .from(creditTransactionsTable)
+      .where(eq(creditTransactionsTable.credit_category, 'credits_expired'));
+    expect(expirations).toHaveLength(1);
   });
 });

--- a/apps/web/src/routers/organizations/organization-admin-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.test.ts
@@ -11,6 +11,7 @@ import { eq, and, inArray, sql } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
 import { KiloPassCadence, KiloPassTier } from '@/lib/kilo-pass/enums';
+import { fetchExpiringTransactionsForOrganization } from '@/lib/creditExpiration';
 import type { User, Organization } from '@kilocode/db/schema';
 
 jest.mock('@/lib/organizations/organization-billing', () => ({
@@ -703,6 +704,92 @@ describe('organization admin router', () => {
         .where(eq(organizations.id, testOrganization.id));
 
       expect(updatedOrg.microdollars_balance).toBe(0);
+    });
+  });
+
+  // Regression for the "credits expiring soon" total keeping stale/removed
+  // grants: an admin nullifies credits, then re-grants credits with a new
+  // expiration date. The Balance page's expiring-soon total must reflect
+  // only the current, still-open grant — not the nullified one on top of it.
+  describe('nullifyCredits then re-grant — expiring credits total', () => {
+    beforeEach(async () => {
+      await db
+        .update(organizations)
+        .set({
+          total_microdollars_acquired: 0,
+          microdollars_used: 0,
+          microdollars_balance: 0,
+          next_credit_expiration_at: null,
+        })
+        .where(eq(organizations.id, testOrganization.id));
+
+      await db
+        .delete(credit_transactions)
+        .where(eq(credit_transactions.organization_id, testOrganization.id));
+    });
+
+    it('does not double-count a nullified grant after re-granting with a new expiry', async () => {
+      const caller = await createCallerForUser(adminUser.id);
+
+      // 1. Grant $100 expiring in the future.
+      await caller.organizations.admin.grantCredit({
+        organizationId: testOrganization.id,
+        amount_usd: 100,
+        expiry_date: '2030-01-01T00:00:00.000Z',
+      });
+
+      // 2. Remove (nullify) all credits.
+      await caller.organizations.admin.nullifyCredits({
+        organizationId: testOrganization.id,
+      });
+
+      // 3. Re-add $40 with a different expiration date.
+      await caller.organizations.admin.grantCredit({
+        organizationId: testOrganization.id,
+        amount_usd: 40,
+        expiry_date: '2030-06-01T00:00:00.000Z',
+      });
+
+      const creditBlocks = await caller.organizations.getCreditBlocks({
+        organizationId: testOrganization.id,
+      });
+
+      const expiringTotal = creditBlocks.creditBlocks
+        .filter(block => block.expiry_date !== null)
+        .reduce((sum, block) => sum + block.balance_mUsd, 0);
+
+      // Only the $40 re-grant should count as expiring soon; the nullified
+      // $100 grant must not still be summed in on top of it.
+      expect(expiringTotal).toBe(40_000_000);
+      expect(creditBlocks.totalBalance_mUsd).toBe(40_000_000);
+    });
+
+    it('closes out multiple still-open grants on nullification', async () => {
+      const caller = await createCallerForUser(adminUser.id);
+
+      await caller.organizations.admin.grantCredit({
+        organizationId: testOrganization.id,
+        amount_usd: 60,
+        expiry_date: '2030-01-01T00:00:00.000Z',
+      });
+      await caller.organizations.admin.grantCredit({
+        organizationId: testOrganization.id,
+        amount_usd: 30,
+        expiry_date: '2030-02-01T00:00:00.000Z',
+      });
+
+      await caller.organizations.admin.nullifyCredits({
+        organizationId: testOrganization.id,
+      });
+
+      const expiring = await fetchExpiringTransactionsForOrganization(testOrganization.id);
+      expect(expiring).toHaveLength(0);
+
+      const creditBlocks = await caller.organizations.getCreditBlocks({
+        organizationId: testOrganization.id,
+      });
+      expect(creditBlocks.totalBalance_mUsd).toBe(0);
+      expect(creditBlocks.creditBlocks).toHaveLength(0);
     });
   });
 

--- a/apps/web/src/routers/organizations/organization-admin-router.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.ts
@@ -51,6 +51,7 @@ import {
   fetchExpiringTransactionsForOrganization,
   computeNextExpirationAmount,
   processOrganizationExpirations,
+  closeOutExpiringOrganizationCredits,
 } from '@/lib/creditExpiration';
 import {
   ORGANIZATION_TRIAL_ACTIVE_MIN_DAYS_REMAINING,
@@ -729,17 +730,30 @@ export const organizationAdminRouter = createTRPCRouter({
           });
         }
 
-        await tx.insert(credit_transactions).values({
-          kilo_user_id: user.id,
-          created_by_kilo_user_id: user.id,
-          is_free: true,
-          amount_microdollars: -currentBalance,
-          description: description?.trim() || 'Admin credit nullification',
-          credit_category: 'organization_custom',
-          expiry_date: null,
-          organization_id: organizationId,
-          original_baseline_microdollars_used: lockedOrg.microdollars_used,
-        });
+        // Close out any still-open expiring grants first, so their expiry claim
+        // can never be counted again (e.g. by the Balance page's "credits
+        // expiring soon" total) once this organization's credits are re-granted
+        // later with a different expiration date.
+        const closedOutExpiring = await closeOutExpiringOrganizationCredits(
+          organizationId,
+          lockedOrg.microdollars_used,
+          tx
+        );
+        const remainingToOffset = Math.max(0, currentBalance + closedOutExpiring);
+
+        if (remainingToOffset > 0) {
+          await tx.insert(credit_transactions).values({
+            kilo_user_id: user.id,
+            created_by_kilo_user_id: user.id,
+            is_free: true,
+            amount_microdollars: -remainingToOffset,
+            description: description?.trim() || 'Admin credit nullification',
+            credit_category: 'organization_custom',
+            expiry_date: null,
+            organization_id: organizationId,
+            original_baseline_microdollars_used: lockedOrg.microdollars_used,
+          });
+        }
 
         await tx
           .update(organizations)


### PR DESCRIPTION
## Summary

- Fixes the Organization > Balance page's "credits expiring soon" warning showing an inflated/accumulating amount after an admin removes (nullifies) an org's credits and re-adds them with a different expiration date. The same root cause also affects the admin panel's expiration summary (partially addressed for display in #4280, but the underlying data issue remained).
- Root cause: `nullifyCredits` never closes out the underlying `credit_transactions` grant rows that still carry an `expiry_date` — it only zeroes the organization's aggregate balance columns and inserts an unrelated, non-expiring offsetting transaction. Every "expiring soon" computation (`getCreditBlocks`/`useExpiringCredits` on the Balance page, and `computeNextExpirationAmount` in the admin panel) derives its total purely from still-open `credit_transactions` rows with an `expiry_date`, so a stale nullified grant keeps getting summed on top of any credits re-granted afterward, inflating the total forever.
- Added `closeOutExpiringOrganizationCredits()` in `creditExpiration.ts`, which inserts the same `credits_expired` closure entries that real expiry processing (`processOrganizationExpirations`) would produce, for every still-open expiring transaction, atomically with the nullification. This reuses the existing `credits_expired` exclusion filters already used everywhere (`fetchExpiringTransactionsForOrganization`, `getCreditBlocks`'s dedup), so the fix applies uniformly to both the Balance page and the Admin credit panel without a new schema column or per-display capping logic.
- `nullifyCredits` now inserts its blanket offsetting transaction only for whatever balance remains after closing out expiring grants; behavior and existing tests for organizations with no still-open expiring grants are unchanged.
- `fetchExpiringTransactionsForOrganization` now accepts a transaction handle so the closure can run inside the same DB transaction as the nullification, keeping the fix atomic.

## Verification

- Traced the reported Nexgen org scenario (org id `8426b56a-ea33-4631-90d9-9d5e0c827e3d`) conceptually: grant $X expiring on date A → nullify → grant $Y expiring on date B. Before the fix, the Balance page's expiring total would be $X + $Y; after the fix it is just $Y.
- Could not run the DB-integrated test suite in this sandbox — Docker is unavailable, so the local Postgres test container (`pnpm test:db`) could not be started. `pnpm typecheck` (via `tsgo --noEmit`) and `pnpm lint`/`oxlint` were run against the changed files and pass; full `pnpm typecheck`/`pnpm test` were not run for this reason and should be verified in CI.

## Visual Changes

N/A (data-correctness fix; no UI markup changed)

## Reviewer Notes

- **Why this only touches an admin-router file, but fixes the Org/Personal pages too:** `nullifyCredits` (Admin > Credit Transactions > Nullify) is the *only* mutation that zeroes an entity's whole credit balance while potentially leaving expiring grants un-closed — it only exists for organizations, invoked from the admin panel, since there's no self-serve "wipe my balance" action for orgs or individual users. The org-facing Balance page (`organizations.getCreditBlocks`) and the personal `/credits` page (`user.getCreditBlocks`) both call the *same shared* `getCreditBlocks()` in `apps/web/src/lib/getCreditBlocks.ts`, which already excludes any transaction with a matching `credits_expired`/`orb_credit_expired`/`orb_credit_voided` row via `original_transaction_id`. Once `nullifyCredits` correctly inserts those `credits_expired` closure rows, both the org Balance page and (if a similar personal-nullify action is ever added) the personal `/credits` page will automatically stop double-counting — no separate change was needed in `organization-router.ts`, `user-router.ts`, or the `OrganizationInfoCard`/`ProfileExpiringCredits` UI components, since none of them had their own buggy aggregation logic.
- I confirmed there is currently no individual-user equivalent of `nullifyCredits` (personal credit admin actions in `UserAdminCreditGrant.tsx`/`bulk-user-credits-router.ts` only add/decrement a single transaction and never zero-and-leave-stale-rows; `admin.users.recomputeBalances` preserves balance and correctly replays expiration baselines). So personal balances can't hit this bug today — but if a personal "nullify" action is ever added, it must call an equivalent of `closeOutExpiringOrganizationCredits` (scoped to `kilo_user_id` + `organization_id IS NULL`) before zeroing, or the same bug will appear on `/credits`.
- `closeOutExpiringOrganizationCredits` forces expiry at a far-future timestamp so every still-open grant (regardless of its actual `expiry_date`) is treated as due, mirroring what would eventually happen via `processOrganizationExpirations` anyway.
- The negative reversal path in `grantCredit` (typing in a negative `amount_usd` instead of using the dedicated "Nullify" action) has the same theoretical gap, but wasn't in scope for the reported bug (which is specifically the "remove credits" → re-grant flow via `nullifyCredits`). Flagging as a possible follow-up if that path is also used to reverse expiring grants in practice.
- Added regression tests: `creditExpirationOrg.test.ts` covers `closeOutExpiringOrganizationCredits` directly (including partial-usage and idempotency cases), and `organization-admin-router.test.ts` adds an end-to-end "grant → nullify → re-grant" scenario asserting `organizations.getCreditBlocks`'s expiring total reflects only the current, live grant.

Built for [Jean du Plessis](https://kilo-code.slack.com/archives/C098Y8KH94K/p1782996306831859?thread_ts=1782471596.230759&cid=C098Y8KH94K) by [Kilo for Slack](https://kilo.ai/slack)

