### PR TITLE
tests(kiloclaw) better handle openclaw version smoke testing

### DIFF
--- a/services/kiloclaw/scripts/tests/smoke-helpers.sh
+++ b/services/kiloclaw/scripts/tests/smoke-helpers.sh
@@ -42,38 +42,29 @@ PY
 assert_kilo_chat_plugin_loaded() {
   local cid="$1"
   local plugin_json
+  local plugin_err
   local details
   local diagnostic_details
 
-  if ! plugin_json=$(docker exec "$cid" openclaw plugins inspect kilo-chat --json 2>&1); then
+  # openclaw writes the --json payload to stdout and its logs (e.g. the
+  # "[state-migrations]" warnings emitted by createSubsystemLogger) to stderr.
+  # Capture the two streams separately so the parsed value is pure JSON; keep
+  # stderr only to surface on failure.
+  plugin_err=$(mktemp)
+  if ! plugin_json=$(docker exec "$cid" openclaw plugins inspect kilo-chat --json 2>"$plugin_err"); then
     check "kilo-chat plugin inspect" "loaded" "failed"
     echo "  output: $plugin_json"
+    echo "  stderr: $(cat "$plugin_err")"
+    rm -f "$plugin_err"
     return
   fi
+  rm -f "$plugin_err"
 
   if details=$(python3 -c '
 import json
 import sys
 
-# openclaw >=2026.6.11 may print log lines (e.g. "[state-migrations] ...") on
-# stderr, which the 2>&1 capture interleaves ahead of the JSON payload. A bare
-# "[state-migrations]" line also begins with "[", and a log line may contain a
-# stray "{", so we cannot just take the first bracket — try every "["/"{"
-# candidate offset until one decodes.
-raw = sys.stdin.read()
-doc = None
-for _start in [0] + [i for i, c in enumerate(raw) if c in "[{"]:
-    try:
-        _cand, _ = json.JSONDecoder().raw_decode(raw[_start:])
-    except Exception:
-        continue
-    # Accept only the real payload object, not a self-contained JSON fragment
-    # (e.g. a "[1, 2, 3]" list) embedded in an interleaved log line.
-    if isinstance(_cand, dict) and "plugin" in _cand:
-        doc = _cand
-        break
-if doc is None:
-    raise SystemExit("no plugin JSON object in command output")
+doc = json.load(sys.stdin)
 plugin = doc.get("plugin", {})
 status = plugin.get("status")
 error = plugin.get("error")
@@ -95,22 +86,7 @@ import json
 import sys
 
 known_message = "channel plugin manifest declares kilo-chat without channelConfigs metadata; add openclaw.plugin.json#channelConfigs so config schema and setup surfaces work before runtime loads. Channels without channelConfigs still appear in channel listings, but setup UI may be limited."
-# Tolerate stderr log lines interleaved by the 2>&1 capture (see above): try
-# every "["/"{" candidate offset until one decodes.
-raw = sys.stdin.read()
-doc = None
-for _start in [0] + [i for i, c in enumerate(raw) if c in "[{"]:
-    try:
-        _cand, _ = json.JSONDecoder().raw_decode(raw[_start:])
-    except Exception:
-        continue
-    # Accept only the real payload object, not a self-contained JSON fragment
-    # (e.g. a stray list) embedded in an interleaved log line.
-    if isinstance(_cand, dict) and "diagnostics" in _cand:
-        doc = _cand
-        break
-if doc is None:
-    raise SystemExit("no diagnostics JSON object in command output")
+doc = json.load(sys.stdin)
 diagnostics = doc.get("diagnostics", [])
 if not isinstance(diagnostics, list):
     raise SystemExit("diagnostics is not a list")

--- a/services/kiloclaw/scripts/tests/smoke-live-provider.sh
+++ b/services/kiloclaw/scripts/tests/smoke-live-provider.sh
@@ -299,15 +299,20 @@ assert_kilocode_provider_loaded() {
   # wired in via plugins.load.paths by config-writer. The keyless image-check only
   # proves the package is installed; this proves it is actually present in the
   # RUNNING config and loaded by the gateway — i.e. model routing won't silently die.
+  # Guard the read: if openclaw.json is missing/unreadable/invalid (the very
+  # regression this guards), the embedded python exits non-zero. Testing it in an
+  # `if` keeps `set -e` from aborting the whole run so it fails cleanly here.
   local path_present
-  path_present=$(docker exec -i "$CID" python3 - <<'PY'
+  if ! path_present=$(docker exec -i "$CID" python3 - <<'PY'
 import json
 from pathlib import Path
 doc = json.loads(Path('/root/.openclaw/openclaw.json').read_text())
 paths = (((doc.get('plugins') or {}).get('load') or {}).get('paths') or [])
 print('yes' if '/usr/local/lib/node_modules/@openclaw/kilocode-provider' in paths else 'no')
 PY
-  )
+  ); then
+    path_present="config unreadable"
+  fi
   check "kilocode provider on plugins.load.paths" "yes" "$path_present"
 
   # And confirm the gateway actually loaded it (openclaw writes JSON to stdout,

--- a/services/kiloclaw/scripts/tests/smoke-live-provider.sh
+++ b/services/kiloclaw/scripts/tests/smoke-live-provider.sh
@@ -260,11 +260,13 @@ print(json.dumps({
 PY
   )
 
+  # openclaw writes the --json payload to stdout and logs to stderr; drop stderr
+  # (it can contain provider/credential detail) so the parsed value is pure JSON.
   if ! output=$(docker exec "$CID" openclaw gateway call agent \
     --params "$params" \
     --expect-final \
     --timeout 240000 \
-    --json 2>&1); then
+    --json 2>/dev/null); then
     check "live Auto Free agent turn" "nonce returned" "command failed"
     echo "  Gateway output suppressed because provider errors can contain live credentials."
     return
@@ -275,25 +277,7 @@ import json
 import sys
 
 nonce = sys.argv[1]
-# openclaw >=2026.6.11 may print log lines (e.g. "[state-migrations] ...") on
-# stderr, which the 2>&1 capture interleaves ahead of the JSON payload. A bare
-# "[state-migrations]" line also begins with "[", and a log line may contain a
-# stray "{", so we cannot just take the first bracket — try every "["/"{"
-# candidate offset until one decodes.
-raw = sys.stdin.read()
-doc = None
-for _start in [0] + [i for i, c in enumerate(raw) if c in "[{"]:
-    try:
-        _cand, _ = json.JSONDecoder().raw_decode(raw[_start:])
-    except Exception:
-        continue
-    # Accept only the real response object, not a self-contained JSON fragment
-    # (e.g. a stray list) embedded in an interleaved log line.
-    if isinstance(_cand, dict) and ("result" in _cand or "payloads" in _cand):
-        doc = _cand
-        break
-if doc is None:
-    raise SystemExit("no result JSON object in command output")
+doc = json.load(sys.stdin)
 result = doc.get("result", doc)
 payloads = result.get("payloads", []) if isinstance(result, dict) else []
 texts = [entry.get("text", "") for entry in payloads if isinstance(entry, dict)]
@@ -307,6 +291,35 @@ print("nonce returned")
     echo "  details: $parsed"
     echo "  Gateway output suppressed because provider responses can contain sensitive data."
   fi
+}
+
+assert_kilocode_provider_loaded() {
+  # Guards Fix 1 (openclaw #93470): the kilocode provider was externalized out of
+  # openclaw core into @openclaw/kilocode-provider, installed by the Dockerfile and
+  # wired in via plugins.load.paths by config-writer. The keyless image-check only
+  # proves the package is installed; this proves it is actually present in the
+  # RUNNING config and loaded by the gateway — i.e. model routing won't silently die.
+  local path_present
+  path_present=$(docker exec -i "$CID" python3 - <<'PY'
+import json
+from pathlib import Path
+doc = json.loads(Path('/root/.openclaw/openclaw.json').read_text())
+paths = (((doc.get('plugins') or {}).get('load') or {}).get('paths') or [])
+print('yes' if '/usr/local/lib/node_modules/@openclaw/kilocode-provider' in paths else 'no')
+PY
+  )
+  check "kilocode provider on plugins.load.paths" "yes" "$path_present"
+
+  # And confirm the gateway actually loaded it (openclaw writes JSON to stdout,
+  # logs to stderr which we drop).
+  local status
+  status=$(docker exec "$CID" openclaw plugins inspect kilocode --json 2>/dev/null \
+    | python3 -c 'import json,sys
+try:
+    print((json.load(sys.stdin).get("plugin") or {}).get("status") or "missing")
+except Exception:
+    print("unparseable")')
+  check "kilocode provider plugin loaded" "loaded" "$status"
 }
 
 assert_kilocode_vision_capability() {
@@ -326,37 +339,11 @@ assert_kilocode_vision_capability() {
     result=$(python3 -c '
 import json, sys
 
-raw = sys.stdin.read()
-# Tolerate any non-JSON log preamble (e.g. openclaw [state-migrations]) by trying
-# each candidate JSON start until one decodes to the model catalog shape. A bare
-# "[state-migrations]" line also begins with "[", and a self-contained fragment
-# (e.g. a stray list) in an interleaved log line could parse on its own, so accept
-# only a top-level list of model objects (or a dict with a "models" list).
-def _as_catalog(cand):
-    if isinstance(cand, dict) and isinstance(cand.get("models"), list):
-        cand = cand["models"]
-    # Require a non-empty list whose entries look like model objects (have a
-    # "key" or "provider"), so an empty list or a stray list of unrelated dicts
-    # from interleaved log noise is not mistaken for the real catalog.
-    if (
-        isinstance(cand, list)
-        and cand
-        and all(isinstance(x, dict) for x in cand)
-        and any(("key" in x or "provider" in x) for x in cand)
-    ):
-        return cand
-    return None
-
-models = None
-for start in [0] + [i for i, c in enumerate(raw) if c in "[{"]:
-    try:
-        cand, _ = json.JSONDecoder().raw_decode(raw[start:])
-    except Exception:
-        continue
-    models = _as_catalog(cand)
-    if models is not None:
-        break
-if models is None:
+# openclaw writes the --json catalog to stdout and logs to stderr (dropped via
+# 2>/dev/null above), so stdout is pure JSON.
+data = json.load(sys.stdin)
+models = data.get("models", data) if isinstance(data, dict) else data
+if not isinstance(models, list):
     print("no-catalog"); raise SystemExit(0)
 
 def is_kilocode(m):
@@ -414,6 +401,9 @@ run_phase() {
     assert_app_config_patch "$CID" "$PORT" "$TOKEN"
     assert_app_config_agent_defaults "$CID" "$PORT" "$TOKEN"
     assert_app_config_agents_crud "$CID" "$PORT" "$TOKEN"
+    # Candidate only: confirm the externalized kilocode provider is wired into the
+    # running config and loaded by the gateway (model routing depends on it).
+    assert_kilocode_provider_loaded
     # Candidate only: prove the removed #4054 catalog-refresh workaround is no
     # longer needed — native discovery must supply kilocode image capability.
     assert_kilocode_vision_capability

--- a/services/kiloclaw/scripts/tests/smoke-live-provider.sh
+++ b/services/kiloclaw/scripts/tests/smoke-live-provider.sh
@@ -311,14 +311,20 @@ PY
   check "kilocode provider on plugins.load.paths" "yes" "$path_present"
 
   # And confirm the gateway actually loaded it (openclaw writes JSON to stdout,
-  # logs to stderr which we drop).
+  # logs to stderr which we drop). Capture the inspect output first so a non-zero
+  # exit (e.g. the provider missing — the very case this guards) surfaces as a
+  # clean FAIL instead of aborting the whole run under `set -euo pipefail`.
+  local raw
   local status
-  status=$(docker exec "$CID" openclaw plugins inspect kilocode --json 2>/dev/null \
-    | python3 -c 'import json,sys
+  if ! raw=$(docker exec "$CID" openclaw plugins inspect kilocode --json 2>/dev/null); then
+    check "kilocode provider plugin loaded" "loaded" "inspect failed"
+    return
+  fi
+  status=$(python3 -c 'import json,sys
 try:
     print((json.load(sys.stdin).get("plugin") or {}).get("status") or "missing")
 except Exception:
-    print("unparseable")')
+    print("unparseable")' <<< "$raw")
   check "kilocode provider plugin loaded" "loaded" "$status"
 }
 
@@ -340,8 +346,17 @@ assert_kilocode_vision_capability() {
 import json, sys
 
 # openclaw writes the --json catalog to stdout and logs to stderr (dropped via
-# 2>/dev/null above), so stdout is pure JSON.
-data = json.load(sys.stdin)
+# 2>/dev/null above), so stdout is pure JSON. The `docker exec ... || true` above
+# can still yield empty/non-JSON output while the catalog is warming up, so treat
+# that as a retriable "no-catalog" (exit 0) rather than letting json.load raise
+# and abort the whole poll under `set -euo pipefail`.
+raw = sys.stdin.read().strip()
+if not raw:
+    print("no-catalog"); raise SystemExit(0)
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    print("no-catalog"); raise SystemExit(0)
 models = data.get("models", data) if isinstance(data, dict) else data
 if not isinstance(models, list):
     print("no-catalog"); raise SystemExit(0)


### PR DESCRIPTION
## Summary

The OpenClaw upgrade smoke read `openclaw ... --json` output captured with
`2>&1`, mixing the JSON payload (stdout) with OpenClaw's log lines (stderr, for
example the `[state-migrations]` warnings). To cope, the parsers scanned the
combined stream for a JSON fragment. This PR captures stdout separately from
stderr and parses stdout with a plain `json.load`, removing the scanning. It
also adds a check that the externalized kilocode provider is present in the
running config and loaded by the gateway.

## Changes

- `smoke-helpers.sh`: capture the `openclaw plugins inspect kilo-chat --json`
  stdout separately from stderr (stderr is shown only when the command fails),
  and parse the plugin status and diagnostics from stdout with `json.load`
  instead of scanning for a JSON object.
- `smoke-live-provider.sh`: parse the live agent turn from stdout with
  `json.load` and drop stderr (it can contain provider or credential detail);
  parse the model catalog the same way.
- Add `assert_kilocode_provider_loaded`, run on the candidate image: it checks
  that `/usr/local/lib/node_modules/@openclaw/kilocode-provider` is in
  `plugins.load.paths` in the running container, and that
  `openclaw plugins inspect kilocode` reports `loaded`.
- Guard the catalog poll and the provider inspect against empty or non-JSON
  output (for example while the catalog is warming up, or if the provider is
  missing) so they produce a clean check result instead of aborting the run
  under `set -euo pipefail`.

## Verification

- [ ] Credentialed live smoke passes:
  `KILOCODE_API_KEY=<key> bash services/kiloclaw/scripts/tests/openclaw-upgrade-validate.sh`
  (exercises the changed parsers and the new provider-load checks against a
  booted image).

## Visual Changes

N/A

## Reviewer Notes

- The parsers now assume OpenClaw writes `--json` output to stdout and its logs
  to stderr. If a command ever writes non-JSON to stdout, `json.load` fails and
  surfaces it, rather than the previous scanning that searched past unexpected
  output.
- `assert_kilocode_provider_loaded` runs only on the candidate image (the
  version under test), alongside the existing kilocode vision-capability check.
  It adds two assertions.
- No product code changes. The diff is limited to the two smoke test helper
  scripts.
