### PR TITLE
feat(ai-gateway): recommend Morph open-weight models, exclude apply models

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/morph.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/morph.ts
@@ -17,6 +17,37 @@ export default {
         context_length: 262144,
         max_completion_tokens: 131072,
       },
+      {
+        id: 'morph-minimax3-428b',
+        name: 'MiniMax M3',
+        flags: ['vision'],
+        context_length: 256000,
+        max_completion_tokens: 256000,
+      },
+      {
+        id: 'morph-minimax27-230b',
+        name: 'MiniMax M2.7',
+        context_length: 196608,
+        max_completion_tokens: 196608,
+      },
+      {
+        id: 'morph-glm52-744b',
+        name: 'GLM-5.2',
+        context_length: 1048576,
+        max_completion_tokens: 1048576,
+      },
+      {
+        id: 'morph-dsv4flash',
+        name: 'DeepSeek V4 Flash',
+        context_length: 1048576,
+        max_completion_tokens: 1048576,
+      },
+      {
+        id: 'morph-qwen36-27b',
+        name: 'Qwen 3.6 27B',
+        context_length: 131072,
+        max_completion_tokens: 131072,
+      },
     ],
   }),
 } satisfies DirectByokProvider;

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -16,8 +16,8 @@ describe('parseOpenAICompatibleProviderModels', () => {
           max_output_length: 131072,
         },
         {
-          id: 'morph-v3-fast',
-          max_model_len: 262144,
+          id: 'morph-minimax3-428b',
+          max_model_len: 256000,
         },
       ],
     });
@@ -31,13 +31,24 @@ describe('parseOpenAICompatibleProviderModels', () => {
         input_modalities: ['text', 'image'],
       },
       {
-        id: 'morph-v3-fast',
+        id: 'morph-minimax3-428b',
         name: undefined,
-        context_length: 262144,
+        context_length: 256000,
         max_completion_tokens: undefined,
         input_modalities: undefined,
       },
     ]);
+  });
+
+  test('excludes specified model ids', () => {
+    const models = parseOpenAICompatibleProviderModels(
+      {
+        data: [{ id: 'morph-qwen35-397b' }, { id: 'morph-v3-fast' }, { id: 'morph-v3-large' }],
+      },
+      { excludeModelIds: ['morph-v3-fast', 'morph-v3-large'] }
+    );
+
+    expect(models.map(model => model.id)).toEqual(['morph-qwen35-397b']);
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -79,6 +79,7 @@ function openAICompatibleFetcher(options: {
   providerId: DirectUserByokInferenceProviderId;
   label: string;
   url: string;
+  excludeModelIds?: ReadonlyArray<string>;
 }): ProviderFetcher {
   return {
     providerId: options.providerId,
@@ -89,20 +90,28 @@ function openAICompatibleFetcher(options: {
           `Failed to fetch ${options.label} models: ${response.status} ${response.statusText}`
         );
       }
-      return parseOpenAICompatibleProviderModels(await response.json());
+      return parseOpenAICompatibleProviderModels(await response.json(), {
+        excludeModelIds: options.excludeModelIds,
+      });
     },
   };
 }
 
-export function parseOpenAICompatibleProviderModels(entry: unknown): RawModel[] {
+export function parseOpenAICompatibleProviderModels(
+  entry: unknown,
+  options?: { excludeModelIds?: ReadonlyArray<string> }
+): RawModel[] {
+  const excludedIds = new Set(options?.excludeModelIds);
   const parsed = OpenAICompatibleModelsResponseSchema.parse(entry);
-  return parsed.data.map(model => ({
-    id: model.id,
-    name: shortenDisplayName(model.name),
-    context_length: model.context_length ?? model.max_model_len,
-    max_completion_tokens: model.max_output_length,
-    input_modalities: model.input_modalities,
-  }));
+  return parsed.data
+    .filter(model => !excludedIds.has(model.id))
+    .map(model => ({
+      id: model.id,
+      name: shortenDisplayName(model.name),
+      context_length: model.context_length ?? model.max_model_len,
+      max_completion_tokens: model.max_output_length,
+      input_modalities: model.input_modalities,
+    }));
 }
 
 export function parseModelsDevProviderModels(entry: unknown): RawModel[] {
@@ -185,6 +194,8 @@ const FETCHERS: ReadonlyArray<ProviderFetcher> = [
     providerId: 'morph',
     label: 'Morph',
     url: 'https://www.morphllm.com/api/models/json',
+    // the v3 apply models are specialized code-edit models, not general-purpose chat models
+    excludeModelIds: ['morph-v3-fast', 'morph-v3-large'],
   }),
   modelsDevFetcher('zai-coding', 'zai-coding-plan'),
   modelsDevFetcher('ollama-cloud', 'ollama-cloud'),


### PR DESCRIPTION
## Summary

Follow-up to the Morph BYOK provider, from the Morph team. Two changes:

- **Exclude `morph-v3-fast` / `morph-v3-large` from the Morph model sync.** These are Morph's specialized Fast Apply code-edit models, not general-purpose chat models, so they shouldn't be selectable as BYOK chat models. Implemented as an optional `excludeModelIds` on `openAICompatibleFetcher` so other providers can use it too.
- **List all six Morph-served open-weight models as recommended** (Qwen 3.5 397B, MiniMax M3, MiniMax M2.7, GLM-5.2, DeepSeek V4 Flash, Qwen 3.6 27B) with metadata mirroring the live `/api/models/json` feed, so they're available (with clean display names) before the first sync populates Redis.

## Verification

`jest src/lib/ai-gateway/providers/direct-byok/` — 2 suites, 8 tests passed. Added a unit test covering the exclusion behavior.

## Visual Changes

N/A

## Reviewer Notes

Recommended-model metadata matches the canonical https://www.morphllm.com/api/models/json response (context length, max output, vision modality), which is the same source the sync in this PR consumes — synced entries dedupe against the recommended ones by id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)