### PR TITLE
feat(git-token-service): add Kilo session capability RPCs

### DIFF
--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -1302,6 +1302,171 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
   });
 });
 
+describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
+  const kiloTargets = {
+    backendBaseUrl: 'https://api.kilo.ai',
+    providerBaseUrl: 'https://api.kilo.ai',
+    sessionIngestBaseUrl: 'https://ingest.kilosessions.ai',
+  };
+  const kiloSubject = {
+    userId: 'user_1',
+    cloudAgentSessionId: 'cloud-agent-session-1',
+    kiloSessionId: 'kilo-session-1',
+    outboundContainerId,
+    userToken: 'raw-user-token',
+    providerToken: 'raw-provider-token',
+    targets: kiloTargets,
+  };
+
+  it('issues an opaque Kilo capability that does not leak the enclosed tokens', async () => {
+    const result = await createService().issueKiloSessionCapability(kiloSubject);
+
+    expect(result).toMatchObject({ success: true });
+    if (!result.success) throw new Error('Expected successful issuance');
+    expect(result.capability).toMatch(/^kka1\./);
+    expect(result.capability).not.toContain(kiloSubject.userToken);
+    expect(result.capability).not.toContain(kiloSubject.providerToken);
+  });
+
+  it('rejects issuance for malformed targets', async () => {
+    const result = await createService().issueKiloSessionCapability({
+      ...kiloSubject,
+      targets: { ...kiloTargets, backendBaseUrl: 'https://user@api.kilo.ai' },
+    });
+
+    expect(result).toEqual({ success: false, reason: 'invalid_targets' });
+  });
+
+  it('returns a sanitized declared failure when capability key configuration is invalid', async () => {
+    const service = new GitTokenRPCEntrypoint(
+      {} as ExecutionContext,
+      { SCM_SESSION_CAPABILITY_ENCRYPTION_KEY: 'not-a-valid-key' } as unknown as CloudflareEnv
+    );
+
+    await expect(service.issueKiloSessionCapability(kiloSubject)).resolves.toEqual({
+      success: false,
+      reason: 'capability_configuration_error',
+    });
+  });
+
+  it('redeems the provider token for provider model routes', async () => {
+    const service = createService();
+    const issued = await service.issueKiloSessionCapability(kiloSubject);
+    if (!issued.success) throw new Error('Expected successful issuance');
+
+    await expect(
+      service.redeemKiloSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestUrl: 'https://api.kilo.ai/api/openrouter/v1/chat/completions',
+      })
+    ).resolves.toEqual({
+      success: true,
+      authorization: 'Bearer raw-provider-token',
+      routeClass: 'provider_model',
+    });
+  });
+
+  it('redeems the user token for backend API routes', async () => {
+    const service = createService();
+    const issued = await service.issueKiloSessionCapability(kiloSubject);
+    if (!issued.success) throw new Error('Expected successful issuance');
+
+    await expect(
+      service.redeemKiloSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestUrl: 'https://api.kilo.ai/api/users/me',
+      })
+    ).resolves.toEqual({
+      success: true,
+      authorization: 'Bearer raw-user-token',
+      routeClass: 'backend_api',
+    });
+  });
+
+  it('falls back to the user token for provider routes when no provider token was issued', async () => {
+    const service = createService();
+    const issued = await service.issueKiloSessionCapability({
+      ...kiloSubject,
+      providerToken: undefined,
+    });
+    if (!issued.success) throw new Error('Expected successful issuance');
+
+    await expect(
+      service.redeemKiloSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestUrl: 'https://api.kilo.ai/api/openrouter/v1/chat/completions',
+      })
+    ).resolves.toEqual({
+      success: true,
+      authorization: 'Bearer raw-user-token',
+      routeClass: 'provider_model',
+    });
+  });
+
+  it('redeems the user token for session export/import routes', async () => {
+    const service = createService();
+    const issued = await service.issueKiloSessionCapability(kiloSubject);
+    if (!issued.success) throw new Error('Expected successful issuance');
+
+    await expect(
+      service.redeemKiloSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestUrl: 'https://ingest.kilosessions.ai/api/session/kilo-session-1/export',
+      })
+    ).resolves.toEqual({
+      success: true,
+      authorization: 'Bearer raw-user-token',
+      routeClass: 'session_ingest',
+    });
+  });
+
+  it('does not redeem a session ingest route for another Kilo session', async () => {
+    const service = createService();
+    const issued = await service.issueKiloSessionCapability(kiloSubject);
+    if (!issued.success) throw new Error('Expected successful issuance');
+
+    await expect(
+      service.redeemKiloSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestUrl: 'https://ingest.kilosessions.ai/api/session/another-session/export',
+      })
+    ).resolves.toEqual({ success: false, reason: 'upstream_not_allowed' });
+  });
+
+  it('does not redeem a capability from another outbound container', async () => {
+    const service = createService();
+    const issued = await service.issueKiloSessionCapability(kiloSubject);
+    if (!issued.success) throw new Error('Expected successful issuance');
+
+    await expect(
+      service.redeemKiloSessionCapability({
+        capability: issued.capability,
+        outboundContainerId: 'another-outbound-container',
+        requestUrl: 'https://api.kilo.ai/api/users/me',
+      })
+    ).resolves.toEqual({ success: false, reason: 'container_mismatch' });
+  });
+
+  it('rejects redemption against a disallowed upstream', async () => {
+    const service = createService();
+    const issued = await service.issueKiloSessionCapability(kiloSubject);
+    if (!issued.success) throw new Error('Expected successful issuance');
+
+    await expect(
+      service.redeemKiloSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestUrl: 'https://evil.example.com/api/users/me',
+      })
+    ).resolves.toEqual({ success: false, reason: 'upstream_not_allowed' });
+  });
+});
+
 describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -1314,18 +1314,16 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
     kiloSessionId: 'kilo-session-1',
     outboundContainerId,
     userToken: 'raw-user-token',
-    providerToken: 'raw-provider-token',
     targets: kiloTargets,
   };
 
-  it('issues an opaque Kilo capability that does not leak the enclosed tokens', async () => {
+  it('issues an opaque Kilo capability that does not leak the enclosed token', async () => {
     const result = await createService().issueKiloSessionCapability(kiloSubject);
 
     expect(result).toMatchObject({ success: true });
     if (!result.success) throw new Error('Expected successful issuance');
     expect(result.capability).toMatch(/^kka1\./);
     expect(result.capability).not.toContain(kiloSubject.userToken);
-    expect(result.capability).not.toContain(kiloSubject.providerToken);
   });
 
   it('rejects issuance for malformed targets', async () => {
@@ -1349,7 +1347,7 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
     });
   });
 
-  it('redeems the provider token for provider model routes', async () => {
+  it('redeems the user token for provider model routes', async () => {
     const service = createService();
     const issued = await service.issueKiloSessionCapability(kiloSubject);
     if (!issued.success) throw new Error('Expected successful issuance');
@@ -1362,7 +1360,7 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
       })
     ).resolves.toEqual({
       success: true,
-      authorization: 'Bearer raw-provider-token',
+      authorization: 'Bearer raw-user-token',
       routeClass: 'provider_model',
     });
   });
@@ -1382,27 +1380,6 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
       success: true,
       authorization: 'Bearer raw-user-token',
       routeClass: 'backend_api',
-    });
-  });
-
-  it('falls back to the user token for provider routes when no provider token was issued', async () => {
-    const service = createService();
-    const issued = await service.issueKiloSessionCapability({
-      ...kiloSubject,
-      providerToken: undefined,
-    });
-    if (!issued.success) throw new Error('Expected successful issuance');
-
-    await expect(
-      service.redeemKiloSessionCapability({
-        capability: issued.capability,
-        outboundContainerId,
-        requestUrl: 'https://api.kilo.ai/api/openrouter/v1/chat/completions',
-      })
-    ).resolves.toEqual({
-      success: true,
-      authorization: 'Bearer raw-user-token',
-      routeClass: 'provider_model',
     });
   });
 

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -1438,6 +1438,27 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
     ).resolves.toEqual({ success: false, reason: 'upstream_not_allowed' });
   });
 
+  it('does not leak the user token to another session ingest route on a shared origin', async () => {
+    const service = createService();
+    const issued = await service.issueKiloSessionCapability({
+      ...kiloSubject,
+      targets: {
+        backendBaseUrl: 'https://api.kilo.ai',
+        providerBaseUrl: 'https://api.kilo.ai/api/openrouter',
+        sessionIngestBaseUrl: 'https://api.kilo.ai',
+      },
+    });
+    if (!issued.success) throw new Error('Expected successful issuance');
+
+    await expect(
+      service.redeemKiloSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestUrl: 'https://api.kilo.ai/api/session/another-session/export',
+      })
+    ).resolves.toEqual({ success: false, reason: 'upstream_not_allowed' });
+  });
+
   it('does not redeem a capability from another outbound container', async () => {
     const service = createService();
     const issued = await service.issueKiloSessionCapability(kiloSubject);

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -1119,13 +1119,9 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
       return { success: false, reason: classification.reason };
     }
 
-    const token =
-      classification.credential === 'provider'
-        ? (claims.providerToken ?? claims.userToken)
-        : claims.userToken;
     return {
       success: true,
-      authorization: `Bearer ${token}`,
+      authorization: `Bearer ${claims.userToken}`,
       routeClass: classification.routeClass,
     };
   }

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -61,6 +61,17 @@ import {
   BitbucketEnsureWebhookRequestSchema,
   BitbucketPullRequestRequestSchema,
 } from './bitbucket-code-review-service.js';
+import {
+  KiloSessionCapabilityCodec,
+  KiloSessionCapabilityError,
+  type KiloSessionCapabilityFailureReason,
+  type KiloSessionCapabilitySubject,
+} from './kilo-session-capability.js';
+import {
+  areValidKiloCapabilityTargets,
+  classifyKiloCapabilityRequest,
+  type KiloCapabilityRouteClass,
+} from './kilo-capability-policy.js';
 
 export type GetTokenForRepoParams = {
   githubRepo: string;
@@ -207,6 +218,25 @@ export type RedeemGitLabSessionCapabilityResult =
         | { authorization?: never; 'PRIVATE-TOKEN': string };
     }
   | { success: false; reason: RedeemGitLabSessionCapabilityFailureReason };
+
+export type IssueKiloSessionCapabilityParams = KiloSessionCapabilitySubject;
+export type IssueKiloSessionCapabilityResult =
+  | { success: true; capability: string }
+  | { success: false; reason: KiloSessionCapabilityFailureReason | 'invalid_targets' };
+
+export type RedeemKiloSessionCapabilityParams = {
+  capability: string;
+  outboundContainerId: string;
+  requestUrl: string;
+};
+export type RedeemKiloSessionCapabilityFailureReason =
+  | KiloSessionCapabilityFailureReason
+  | 'container_mismatch'
+  | 'invalid_upstream_url'
+  | 'upstream_not_allowed';
+export type RedeemKiloSessionCapabilityResult =
+  | { success: true; authorization: string; routeClass: KiloCapabilityRouteClass }
+  | { success: false; reason: RedeemKiloSessionCapabilityFailureReason };
 
 const DISCONNECT_PATH = '/internal/github-user-authorizations/disconnect';
 const BITBUCKET_REPOSITORIES_PATH = '/internal/bitbucket/repositories';
@@ -1041,6 +1071,63 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
       return { success: true, headers: { 'PRIVATE-TOKEN': token } };
     }
     return { success: true, headers: { authorization: `Bearer ${token}` } };
+  }
+
+  async issueKiloSessionCapability(
+    params: IssueKiloSessionCapabilityParams
+  ): Promise<IssueKiloSessionCapabilityResult> {
+    if (!areValidKiloCapabilityTargets(params.targets)) {
+      return { success: false, reason: 'invalid_targets' };
+    }
+
+    try {
+      const encryptionKey = await resolveSecret(this.env.SCM_SESSION_CAPABILITY_ENCRYPTION_KEY);
+      const capability = new KiloSessionCapabilityCodec(encryptionKey).issue(params);
+      return { success: true, capability };
+    } catch (error) {
+      if (error instanceof KiloSessionCapabilityError) {
+        return { success: false, reason: error.reason };
+      }
+      return { success: false, reason: 'capability_configuration_error' };
+    }
+  }
+
+  async redeemKiloSessionCapability(
+    params: RedeemKiloSessionCapabilityParams
+  ): Promise<RedeemKiloSessionCapabilityResult> {
+    let claims;
+    try {
+      const encryptionKey = await resolveSecret(this.env.SCM_SESSION_CAPABILITY_ENCRYPTION_KEY);
+      claims = new KiloSessionCapabilityCodec(encryptionKey).decode(params.capability);
+    } catch (error) {
+      if (error instanceof KiloSessionCapabilityError) {
+        return { success: false, reason: error.reason };
+      }
+      return { success: false, reason: 'capability_configuration_error' };
+    }
+
+    if (claims.outboundContainerId !== params.outboundContainerId) {
+      return { success: false, reason: 'container_mismatch' };
+    }
+
+    const classification = classifyKiloCapabilityRequest(
+      params.requestUrl,
+      claims.targets,
+      claims.kiloSessionId
+    );
+    if (!classification.success) {
+      return { success: false, reason: classification.reason };
+    }
+
+    const token =
+      classification.credential === 'provider'
+        ? (claims.providerToken ?? claims.userToken)
+        : claims.userToken;
+    return {
+      success: true,
+      authorization: `Bearer ${token}`,
+      routeClass: classification.routeClass,
+    };
   }
 
   private getGitLabAuthType(integration: GitLabLookupSuccess): GitLabAuthType | null {

--- a/services/git-token-service/src/kilo-capability-policy.test.ts
+++ b/services/git-token-service/src/kilo-capability-policy.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  areValidKiloCapabilityTargets,
+  classifyKiloCapabilityRequest,
+} from './kilo-capability-policy.js';
+
+const targets = {
+  backendBaseUrl: 'https://api.kilo.ai',
+  providerBaseUrl: 'https://api.kilo.ai',
+  sessionIngestBaseUrl: 'https://ingest.kilosessions.ai',
+};
+
+describe('classifyKiloCapabilityRequest', () => {
+  const kiloSessionId = 'kilo-session-1';
+
+  it.each([
+    [
+      'provider model',
+      'https://api.kilo.ai/api/openrouter/v1/chat/completions',
+      'provider_model',
+      'provider',
+    ],
+    [
+      'organization models',
+      'https://api.kilo.ai/api/organizations/org_1/models',
+      'organization_models',
+      'provider',
+    ],
+    ['backend api', 'https://api.kilo.ai/api/users/me', 'backend_api', 'user'],
+    [
+      'session ingest',
+      'https://ingest.kilosessions.ai/api/session/kilo-session-1/export',
+      'session_ingest',
+      'user',
+    ],
+  ] as const)(
+    'routes %s with the right credential',
+    (_description, requestUrl, routeClass, credential) => {
+      expect(classifyKiloCapabilityRequest(requestUrl, targets, kiloSessionId)).toEqual({
+        success: true,
+        routeClass,
+        credential,
+      });
+    }
+  );
+
+  it('allows percent-encoded characters in the query string', () => {
+    expect(
+      classifyKiloCapabilityRequest(
+        'https://api.kilo.ai/api/openrouter/v1/chat?redirect=%2Ffoo&ref=a%2Fb',
+        targets,
+        kiloSessionId
+      )
+    ).toMatchObject({ success: true, routeClass: 'provider_model' });
+  });
+
+  it.each([
+    ['encoded slash in path', 'https://api.kilo.ai/api/openrouter%2fsecret'],
+    ['encoded traversal in path', 'https://api.kilo.ai/api/openrouter/%2e%2e/secret'],
+    ['userinfo', 'https://user@api.kilo.ai/api/users/me'],
+    ['disallowed origin', 'https://evil.example.com/api/users/me'],
+    ['plain http production host', 'http://api.kilo.ai/api/users/me'],
+    ['different session ingest route', 'https://ingest.kilosessions.ai/api/session/other/export'],
+    ['unscoped session ingest route', 'https://ingest.kilosessions.ai/sessions/s1/logs'],
+  ] as const)('rejects %s', (_description, requestUrl) => {
+    expect(classifyKiloCapabilityRequest(requestUrl, targets, kiloSessionId).success).toBe(false);
+  });
+
+  it('refuses to serve provider routes with the user credential when the provider lives elsewhere', () => {
+    expect(
+      classifyKiloCapabilityRequest(
+        'https://api.kilo.ai/api/openrouter/v1/chat',
+        {
+          ...targets,
+          providerBaseUrl: 'https://provider.kilo.ai',
+        },
+        kiloSessionId
+      )
+    ).toEqual({ success: false, reason: 'upstream_not_allowed' });
+  });
+});
+
+describe('areValidKiloCapabilityTargets', () => {
+  it('accepts well-formed https targets', () => {
+    expect(areValidKiloCapabilityTargets(targets)).toBe(true);
+  });
+
+  it('rejects a target carrying userinfo', () => {
+    expect(
+      areValidKiloCapabilityTargets({
+        ...targets,
+        backendBaseUrl: 'https://user@api.kilo.ai',
+      })
+    ).toBe(false);
+  });
+});

--- a/services/git-token-service/src/kilo-capability-policy.test.ts
+++ b/services/git-token-service/src/kilo-capability-policy.test.ts
@@ -18,37 +18,29 @@ describe('classifyKiloCapabilityRequest', () => {
       'provider model',
       'https://api.kilo.ai/api/openrouter/v1/chat/completions',
       'provider_model',
-      'provider',
     ],
     [
       'organization models',
       'https://api.kilo.ai/api/organizations/org_1/models',
       'organization_models',
-      'provider',
     ],
-    ['backend api', 'https://api.kilo.ai/api/users/me', 'backend_api', 'user'],
+    ['backend api', 'https://api.kilo.ai/api/users/me', 'backend_api'],
     [
       'session ingest',
       'https://ingest.kilosessions.ai/api/session/kilo-session-1/export',
       'session_ingest',
-      'user',
     ],
     [
       'session ingest upload',
       'https://ingest.kilosessions.ai/api/session/kilo-session-1/ingest',
       'session_ingest',
-      'user',
     ],
-  ] as const)(
-    'routes %s with the right credential',
-    (_description, requestUrl, routeClass, credential) => {
-      expect(classifyKiloCapabilityRequest(requestUrl, targets, kiloSessionId)).toEqual({
-        success: true,
-        routeClass,
-        credential,
-      });
-    }
-  );
+  ] as const)('routes %s to the right route class', (_description, requestUrl, routeClass) => {
+    expect(classifyKiloCapabilityRequest(requestUrl, targets, kiloSessionId)).toEqual({
+      success: true,
+      routeClass,
+    });
+  });
 
   it('allows percent-encoded characters in the query string', () => {
     expect(
@@ -72,7 +64,7 @@ describe('classifyKiloCapabilityRequest', () => {
     expect(classifyKiloCapabilityRequest(requestUrl, targets, kiloSessionId).success).toBe(false);
   });
 
-  it('refuses to serve provider routes with the user credential when the provider lives elsewhere', () => {
+  it('refuses to serve provider routes against the backend when the provider lives elsewhere', () => {
     expect(
       classifyKiloCapabilityRequest(
         'https://api.kilo.ai/api/openrouter/v1/chat',
@@ -119,7 +111,7 @@ describe('classifyKiloCapabilityRequest', () => {
           sharedOriginTargets,
           kiloSessionId
         )
-      ).toEqual({ success: true, routeClass: 'session_ingest', credential: 'user' });
+      ).toEqual({ success: true, routeClass: 'session_ingest' });
     });
 
     it.each(['export', 'ingest'] as const)(

--- a/services/git-token-service/src/kilo-capability-policy.test.ts
+++ b/services/git-token-service/src/kilo-capability-policy.test.ts
@@ -33,6 +33,12 @@ describe('classifyKiloCapabilityRequest', () => {
       'session_ingest',
       'user',
     ],
+    [
+      'session ingest upload',
+      'https://ingest.kilosessions.ai/api/session/kilo-session-1/ingest',
+      'session_ingest',
+      'user',
+    ],
   ] as const)(
     'routes %s with the right credential',
     (_description, requestUrl, routeClass, credential) => {
@@ -91,6 +97,10 @@ describe('classifyKiloCapabilityRequest', () => {
       providerBaseUrl: 'https://api.kilo.ai/api/openrouter',
       sessionIngestBaseUrl: 'https://api.kilo.ai',
     };
+    const prefixedSessionIngestTargets = {
+      ...sharedOriginTargets,
+      sessionIngestBaseUrl: 'https://api.kilo.ai/ingest',
+    };
 
     it('does not let the backend catch-all shadow another session ingest route', () => {
       expect(
@@ -111,6 +121,19 @@ describe('classifyKiloCapabilityRequest', () => {
         )
       ).toEqual({ success: true, routeClass: 'session_ingest', credential: 'user' });
     });
+
+    it.each(['export', 'ingest'] as const)(
+      'does not let the backend catch-all shadow a prefixed %s route for another session',
+      operation => {
+        expect(
+          classifyKiloCapabilityRequest(
+            `https://api.kilo.ai/ingest/api/session/other-session/${operation}`,
+            prefixedSessionIngestTargets,
+            kiloSessionId
+          )
+        ).toEqual({ success: false, reason: 'upstream_not_allowed' });
+      }
+    );
   });
 });
 

--- a/services/git-token-service/src/kilo-capability-policy.test.ts
+++ b/services/git-token-service/src/kilo-capability-policy.test.ts
@@ -14,11 +14,7 @@ describe('classifyKiloCapabilityRequest', () => {
   const kiloSessionId = 'kilo-session-1';
 
   it.each([
-    [
-      'provider model',
-      'https://api.kilo.ai/api/openrouter/v1/chat/completions',
-      'provider_model',
-    ],
+    ['provider model', 'https://api.kilo.ai/api/openrouter/v1/chat/completions', 'provider_model'],
     [
       'organization models',
       'https://api.kilo.ai/api/organizations/org_1/models',

--- a/services/git-token-service/src/kilo-capability-policy.test.ts
+++ b/services/git-token-service/src/kilo-capability-policy.test.ts
@@ -78,6 +78,40 @@ describe('classifyKiloCapabilityRequest', () => {
       )
     ).toEqual({ success: false, reason: 'upstream_not_allowed' });
   });
+
+  it('fails closed for a non-string request url', () => {
+    expect(
+      classifyKiloCapabilityRequest(null as unknown as string, targets, kiloSessionId)
+    ).toEqual({ success: false, reason: 'invalid_upstream_url' });
+  });
+
+  describe('when backend and session ingest share an origin', () => {
+    const sharedOriginTargets = {
+      backendBaseUrl: 'https://api.kilo.ai',
+      providerBaseUrl: 'https://api.kilo.ai/api/openrouter',
+      sessionIngestBaseUrl: 'https://api.kilo.ai',
+    };
+
+    it('does not let the backend catch-all shadow another session ingest route', () => {
+      expect(
+        classifyKiloCapabilityRequest(
+          'https://api.kilo.ai/api/session/other-session/export',
+          sharedOriginTargets,
+          kiloSessionId
+        )
+      ).toEqual({ success: false, reason: 'upstream_not_allowed' });
+    });
+
+    it('still routes the bound session ingest route', () => {
+      expect(
+        classifyKiloCapabilityRequest(
+          `https://api.kilo.ai/api/session/${kiloSessionId}/export`,
+          sharedOriginTargets,
+          kiloSessionId
+        )
+      ).toEqual({ success: true, routeClass: 'session_ingest', credential: 'user' });
+    });
+  });
 });
 
 describe('areValidKiloCapabilityTargets', () => {

--- a/services/git-token-service/src/kilo-capability-policy.ts
+++ b/services/git-token-service/src/kilo-capability-policy.ts
@@ -104,13 +104,17 @@ function isOrganizationModelsRoute(pathname: string, basePath: string): boolean 
 
 function isSessionIngestRoute(pathname: string, basePath: string, kiloSessionId: string): boolean {
   const sessionPrefix = appendPath(basePath, `/api/session/${encodeURIComponent(kiloSessionId)}`);
-  return pathname === `${sessionPrefix}/export` || pathname === `${sessionPrefix}/import`;
+  return (
+    pathname === `${sessionPrefix}/export` ||
+    pathname === `${sessionPrefix}/import` ||
+    pathname === `${sessionPrefix}/ingest`
+  );
 }
 
 function isSessionIngestShapedRoute(pathname: string, basePath: string): boolean {
   const sessionsPrefix = appendPath(basePath, '/api/session/');
   if (!pathname.startsWith(sessionsPrefix)) return false;
-  return /^[^/]+\/(?:export|import)$/.test(pathname.slice(sessionsPrefix.length));
+  return /^[^/]+\/(?:export|import|ingest)$/.test(pathname.slice(sessionsPrefix.length));
 }
 
 export function classifyKiloCapabilityRequest(
@@ -174,7 +178,8 @@ export function classifyKiloCapabilityRequest(
   if (isWithinTarget(url, backend)) {
     if (
       isProviderRoute(url.pathname, backend.basePath) ||
-      isSessionIngestShapedRoute(url.pathname, backend.basePath)
+      (url.origin === sessionIngest.origin &&
+        isSessionIngestShapedRoute(url.pathname, sessionIngest.basePath))
     ) {
       return { success: false, reason: 'upstream_not_allowed' };
     }

--- a/services/git-token-service/src/kilo-capability-policy.ts
+++ b/services/git-token-service/src/kilo-capability-policy.ts
@@ -107,11 +107,23 @@ function isSessionIngestRoute(pathname: string, basePath: string, kiloSessionId:
   return pathname === `${sessionPrefix}/export` || pathname === `${sessionPrefix}/import`;
 }
 
+function isSessionIngestShapedRoute(pathname: string, basePath: string): boolean {
+  const sessionsPrefix = appendPath(basePath, '/api/session/');
+  if (!pathname.startsWith(sessionsPrefix)) return false;
+  return /^[^/]+\/(?:export|import)$/.test(pathname.slice(sessionsPrefix.length));
+}
+
 export function classifyKiloCapabilityRequest(
   requestUrl: string,
   targets: KiloSessionCapabilityTargets,
   kiloSessionId: string
 ): KiloCapabilityRouteClassification {
+  // requestUrl is only compile-time typed at the WorkerEntrypoint RPC boundary; a
+  // caller can still send a non-string, which must fail closed like every other
+  // branch instead of throwing from the .split below.
+  if (typeof requestUrl !== 'string') {
+    return { success: false, reason: 'invalid_upstream_url' };
+  }
   // Only the path is subject to the traversal/encoding guard; query strings may
   // legitimately carry percent-encoded slashes and dots.
   if (hasUnsafeEncodedPath(requestUrl.split(/[?#]/, 1)[0])) {
@@ -149,17 +161,24 @@ export function classifyKiloCapabilityRequest(
       credential: 'provider',
     };
   }
-  if (isWithinTarget(url, backend)) {
-    if (isProviderRoute(url.pathname, backend.basePath)) {
-      return { success: false, reason: 'upstream_not_allowed' };
-    }
-    return { success: true, routeClass: 'backend_api', credential: 'user' };
-  }
   if (
     isWithinTarget(url, sessionIngest) &&
     isSessionIngestRoute(url.pathname, sessionIngest.basePath, kiloSessionId)
   ) {
     return { success: true, routeClass: 'session_ingest', credential: 'user' };
+  }
+  // Backend is the catch-all for its origin, so it must exclude provider- and
+  // session-ingest-shaped paths. Otherwise a shared backend/session-ingest origin
+  // would let this branch serve another session's ingest route as backend_api,
+  // bypassing the bound-session guard above.
+  if (isWithinTarget(url, backend)) {
+    if (
+      isProviderRoute(url.pathname, backend.basePath) ||
+      isSessionIngestShapedRoute(url.pathname, backend.basePath)
+    ) {
+      return { success: false, reason: 'upstream_not_allowed' };
+    }
+    return { success: true, routeClass: 'backend_api', credential: 'user' };
   }
   return { success: false, reason: 'upstream_not_allowed' };
 }

--- a/services/git-token-service/src/kilo-capability-policy.ts
+++ b/services/git-token-service/src/kilo-capability-policy.ts
@@ -7,11 +7,7 @@ export type KiloCapabilityRouteClass =
   | 'session_ingest';
 
 export type KiloCapabilityRouteClassification =
-  | {
-      success: true;
-      routeClass: KiloCapabilityRouteClass;
-      credential: 'user' | 'provider';
-    }
+  | { success: true; routeClass: KiloCapabilityRouteClass }
   | { success: false; reason: 'invalid_upstream_url' | 'upstream_not_allowed' };
 
 type ParsedTarget = {
@@ -152,24 +148,16 @@ export function classifyKiloCapabilityRequest(
   }
 
   if (isWithinTarget(url, provider) && isProviderRoute(url.pathname, provider.basePath)) {
-    return {
-      success: true,
-      routeClass: 'provider_model',
-      credential: 'provider',
-    };
+    return { success: true, routeClass: 'provider_model' };
   }
   if (isWithinTarget(url, backend) && isOrganizationModelsRoute(url.pathname, backend.basePath)) {
-    return {
-      success: true,
-      routeClass: 'organization_models',
-      credential: 'provider',
-    };
+    return { success: true, routeClass: 'organization_models' };
   }
   if (
     isWithinTarget(url, sessionIngest) &&
     isSessionIngestRoute(url.pathname, sessionIngest.basePath, kiloSessionId)
   ) {
-    return { success: true, routeClass: 'session_ingest', credential: 'user' };
+    return { success: true, routeClass: 'session_ingest' };
   }
   // Backend is the catch-all for its origin, so it must exclude provider- and
   // session-ingest-shaped paths. Otherwise a shared backend/session-ingest origin
@@ -183,7 +171,7 @@ export function classifyKiloCapabilityRequest(
     ) {
       return { success: false, reason: 'upstream_not_allowed' };
     }
-    return { success: true, routeClass: 'backend_api', credential: 'user' };
+    return { success: true, routeClass: 'backend_api' };
   }
   return { success: false, reason: 'upstream_not_allowed' };
 }

--- a/services/git-token-service/src/kilo-capability-policy.ts
+++ b/services/git-token-service/src/kilo-capability-policy.ts
@@ -1,0 +1,165 @@
+import type { KiloSessionCapabilityTargets } from './kilo-session-capability.js';
+
+export type KiloCapabilityRouteClass =
+  | 'provider_model'
+  | 'organization_models'
+  | 'backend_api'
+  | 'session_ingest';
+
+export type KiloCapabilityRouteClassification =
+  | {
+      success: true;
+      routeClass: KiloCapabilityRouteClass;
+      credential: 'user' | 'provider';
+    }
+  | { success: false; reason: 'invalid_upstream_url' | 'upstream_not_allowed' };
+
+type ParsedTarget = {
+  origin: string;
+  basePath: string;
+};
+
+function hasUnsafeEncodedPath(value: string): boolean {
+  let decoded = value;
+  for (let depth = 0; depth < 4; depth++) {
+    if (/%(?:2f|5c)/i.test(decoded) || /\/(?:\.|%2e){1,2}(?:\/|$)/i.test(decoded)) {
+      return true;
+    }
+    let next: string;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      return true;
+    }
+    if (next === decoded) break;
+    decoded = next;
+  }
+  return decoded.includes('\\') || /(?:^|\/)\.{1,2}(?:\/|$)/.test(decoded);
+}
+
+function isAllowedProtocol(url: URL): boolean {
+  if (url.protocol === 'https:') return true;
+  return (
+    url.protocol === 'http:' &&
+    ['localhost', '127.0.0.1', 'host.docker.internal'].includes(url.hostname)
+  );
+}
+
+function parseTarget(value: string): ParsedTarget | null {
+  if (hasUnsafeEncodedPath(value)) return null;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (!isAllowedProtocol(url) || url.username || url.password || url.hash || url.search) {
+    return null;
+  }
+  const basePath = url.pathname === '/' ? '' : url.pathname.replace(/\/+$/, '');
+  return { origin: url.origin, basePath };
+}
+
+export function areValidKiloCapabilityTargets(targets: KiloSessionCapabilityTargets): boolean {
+  return Object.values(targets).every(target => parseTarget(target) !== null);
+}
+
+function isWithinTarget(url: URL, target: ParsedTarget): boolean {
+  return (
+    url.origin === target.origin &&
+    (target.basePath === '' ||
+      url.pathname === target.basePath ||
+      url.pathname.startsWith(`${target.basePath}/`))
+  );
+}
+
+function appendPath(basePath: string, suffix: string): string {
+  return `${basePath}${suffix}` || '/';
+}
+
+function providerPrefixes(basePath: string): string[] {
+  if (/\/api\/(?:openrouter|gateway)$/.test(basePath)) return [basePath];
+  if (basePath.endsWith('/api')) {
+    return [appendPath(basePath, '/openrouter'), appendPath(basePath, '/gateway')];
+  }
+  return [appendPath(basePath, '/api/openrouter'), appendPath(basePath, '/api/gateway')];
+}
+
+function matchesPrefix(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+function isProviderRoute(pathname: string, basePath: string): boolean {
+  return providerPrefixes(basePath).some(prefix => matchesPrefix(pathname, prefix));
+}
+
+function isOrganizationModelsRoute(pathname: string, basePath: string): boolean {
+  const organizationsPrefix = basePath.endsWith('/api')
+    ? `${basePath}/organizations/`
+    : `${basePath}/api/organizations/`;
+  if (!pathname.startsWith(organizationsPrefix)) return false;
+  const relativePath = pathname.slice(organizationsPrefix.length);
+  return /^[^/]+\/models(?:\/|$)/.test(relativePath);
+}
+
+function isSessionIngestRoute(pathname: string, basePath: string, kiloSessionId: string): boolean {
+  const sessionPrefix = appendPath(basePath, `/api/session/${encodeURIComponent(kiloSessionId)}`);
+  return pathname === `${sessionPrefix}/export` || pathname === `${sessionPrefix}/import`;
+}
+
+export function classifyKiloCapabilityRequest(
+  requestUrl: string,
+  targets: KiloSessionCapabilityTargets,
+  kiloSessionId: string
+): KiloCapabilityRouteClassification {
+  // Only the path is subject to the traversal/encoding guard; query strings may
+  // legitimately carry percent-encoded slashes and dots.
+  if (hasUnsafeEncodedPath(requestUrl.split(/[?#]/, 1)[0])) {
+    return { success: false, reason: 'invalid_upstream_url' };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(requestUrl);
+  } catch {
+    return { success: false, reason: 'invalid_upstream_url' };
+  }
+  if (!isAllowedProtocol(url) || url.username || url.password || url.hash) {
+    return { success: false, reason: 'invalid_upstream_url' };
+  }
+
+  const backend = parseTarget(targets.backendBaseUrl);
+  const provider = parseTarget(targets.providerBaseUrl);
+  const sessionIngest = parseTarget(targets.sessionIngestBaseUrl);
+  if (!backend || !provider || !sessionIngest) {
+    return { success: false, reason: 'invalid_upstream_url' };
+  }
+
+  if (isWithinTarget(url, provider) && isProviderRoute(url.pathname, provider.basePath)) {
+    return {
+      success: true,
+      routeClass: 'provider_model',
+      credential: 'provider',
+    };
+  }
+  if (isWithinTarget(url, backend) && isOrganizationModelsRoute(url.pathname, backend.basePath)) {
+    return {
+      success: true,
+      routeClass: 'organization_models',
+      credential: 'provider',
+    };
+  }
+  if (isWithinTarget(url, backend)) {
+    if (isProviderRoute(url.pathname, backend.basePath)) {
+      return { success: false, reason: 'upstream_not_allowed' };
+    }
+    return { success: true, routeClass: 'backend_api', credential: 'user' };
+  }
+  if (
+    isWithinTarget(url, sessionIngest) &&
+    isSessionIngestRoute(url.pathname, sessionIngest.basePath, kiloSessionId)
+  ) {
+    return { success: true, routeClass: 'session_ingest', credential: 'user' };
+  }
+  return { success: false, reason: 'upstream_not_allowed' };
+}

--- a/services/git-token-service/src/kilo-session-capability.test.ts
+++ b/services/git-token-service/src/kilo-session-capability.test.ts
@@ -109,10 +109,10 @@ describe('KiloSessionCapabilityCodec', () => {
     );
   });
 
-  it('rejects a capability issued in the future', () => {
+  it('rejects a capability issued beyond the clock-skew tolerance', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-07T12:00:00.000Z'));
-    const issuedAt = Date.now() + 60_000;
+    const issuedAt = Date.now() + 5 * 60_000;
     const capability = encryptedCapability({
       purpose: 'kilo_api_session',
       version: 1,
@@ -124,6 +124,24 @@ describe('KiloSessionCapabilityCodec', () => {
     expect(() => new KiloSessionCapabilityCodec(encryptionKey).decode(capability)).toThrowError(
       expect.objectContaining({ reason: 'invalid_capability' })
     );
+    vi.useRealTimers();
+  });
+
+  it('accepts a capability issued within the clock-skew tolerance', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-07T12:00:00.000Z'));
+    const issuedAt = Date.now() + 30_000;
+    const capability = encryptedCapability({
+      purpose: 'kilo_api_session',
+      version: 1,
+      ...claims,
+      issuedAt,
+      expiresAt: issuedAt + 60_000,
+    });
+
+    expect(new KiloSessionCapabilityCodec(encryptionKey).decode(capability)).toMatchObject({
+      issuedAt,
+    });
     vi.useRealTimers();
   });
 

--- a/services/git-token-service/src/kilo-session-capability.test.ts
+++ b/services/git-token-service/src/kilo-session-capability.test.ts
@@ -13,7 +13,6 @@ const claims = {
   kiloSessionId: 'kilo-session-1',
   outboundContainerId: 'outbound-container-1',
   userToken: 'raw-user-token-sentinel',
-  providerToken: 'raw-provider-token-sentinel',
   targets: {
     backendBaseUrl: 'https://api.kilo.ai',
     providerBaseUrl: 'https://api.kilo.ai',
@@ -35,7 +34,6 @@ describe('KiloSessionCapabilityCodec', () => {
 
     expect(capability).toMatch(/^kka1\./);
     expect(capability).not.toContain(claims.userToken);
-    expect(capability).not.toContain(claims.providerToken);
     expect(codec.decode(capability)).toEqual({
       purpose: 'kilo_api_session',
       version: 1,
@@ -161,7 +159,6 @@ describe('KiloSessionCapabilityCodec', () => {
     expect(expiredError).toBeInstanceOf(KiloSessionCapabilityError);
     expect(expiredError).toMatchObject({ reason: 'expired_capability' });
     expect(JSON.stringify(expiredError)).not.toContain(claims.userToken);
-    expect(JSON.stringify(expiredError)).not.toContain(claims.providerToken);
 
     const changedOffset = capability.lastIndexOf('.') + 4;
     const changedCharacter = capability[changedOffset] === 'A' ? 'B' : 'A';

--- a/services/git-token-service/src/kilo-session-capability.test.ts
+++ b/services/git-token-service/src/kilo-session-capability.test.ts
@@ -1,0 +1,156 @@
+import { encryptWithSymmetricKey } from '@kilocode/encryption';
+import { describe, expect, it, vi } from 'vitest';
+import { GitHubSessionCapabilityCodec } from './github-session-capability.js';
+import {
+  KiloSessionCapabilityCodec,
+  KiloSessionCapabilityError,
+} from './kilo-session-capability.js';
+
+const encryptionKey = Buffer.alloc(32, 7).toString('base64');
+const claims = {
+  userId: 'user_1',
+  cloudAgentSessionId: 'cloud-agent-session-1',
+  kiloSessionId: 'kilo-session-1',
+  outboundContainerId: 'outbound-container-1',
+  userToken: 'raw-user-token-sentinel',
+  providerToken: 'raw-provider-token-sentinel',
+  targets: {
+    backendBaseUrl: 'https://api.kilo.ai',
+    providerBaseUrl: 'https://api.kilo.ai',
+    sessionIngestBaseUrl: 'https://ingest.kilosessions.ai',
+  },
+} as const;
+
+function encryptedCapability(value: unknown): string {
+  return `kka1.${encryptWithSymmetricKey(JSON.stringify(value), encryptionKey)}`;
+}
+
+describe('KiloSessionCapabilityCodec', () => {
+  it('issues an opaque four-hour capability bound to the session and container', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-07T12:00:00.000Z'));
+    const codec = new KiloSessionCapabilityCodec(encryptionKey);
+
+    const capability = codec.issue(claims);
+
+    expect(capability).toMatch(/^kka1\./);
+    expect(capability).not.toContain(claims.userToken);
+    expect(capability).not.toContain(claims.providerToken);
+    expect(codec.decode(capability)).toEqual({
+      purpose: 'kilo_api_session',
+      version: 1,
+      ...claims,
+      issuedAt: Date.parse('2026-06-07T12:00:00.000Z'),
+      expiresAt: Date.parse('2026-06-07T16:00:00.000Z'),
+    });
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['wrong prefix', 'kka2.not-supported'],
+    [
+      'SCM capability',
+      new GitHubSessionCapabilityCodec(encryptionKey).issue({
+        userId: 'user_1',
+        outboundContainerId: 'outbound-container-1',
+        owner: 'acme',
+        repo: 'widgets',
+        source: 'installation',
+        identity: {
+          installationId: 'installation_1',
+          accountLogin: 'acme',
+          appType: 'standard',
+          gitAuthor: { name: 'Kilo', email: 'kilo@example.com' },
+        },
+      }),
+    ],
+    ['non-canonical ciphertext', 'kka1.AA:AA:AA'],
+  ])('rejects %s', (_description, capability) => {
+    expect(() => new KiloSessionCapabilityCodec(encryptionKey).decode(capability)).toThrowError(
+      expect.objectContaining({ reason: 'invalid_capability' })
+    );
+  });
+
+  it.each([
+    ['wrong purpose', { purpose: 'github_scm_session' }],
+    ['unknown claim', { extra: true }],
+    ['unknown target claim', { targets: { ...claims.targets, extra: true } }],
+    ['invalid timestamp order', { issuedAt: 2, expiresAt: 1 }],
+    ['excessive lifetime', { issuedAt: 1, expiresAt: 1 + 4 * 60 * 60 * 1000 + 1 }],
+  ])('rejects decrypted claims with %s', (_description, override) => {
+    const issuedAt = Date.now();
+    const base = {
+      purpose: 'kilo_api_session',
+      version: 1,
+      ...claims,
+      issuedAt,
+      expiresAt: issuedAt + 60_000,
+    };
+    const capability = encryptedCapability({ ...base, ...override });
+
+    expect(() => new KiloSessionCapabilityCodec(encryptionKey).decode(capability)).toThrowError(
+      expect.objectContaining({ reason: 'invalid_capability' })
+    );
+  });
+
+  it('rejects oversized encrypted claims', () => {
+    const issuedAt = Date.now();
+    const capability = encryptedCapability({
+      purpose: 'kilo_api_session',
+      version: 1,
+      ...claims,
+      userToken: 'x'.repeat(70_000),
+      issuedAt,
+      expiresAt: issuedAt + 60_000,
+    });
+
+    expect(() => new KiloSessionCapabilityCodec(encryptionKey).decode(capability)).toThrowError(
+      expect.objectContaining({ reason: 'invalid_capability' })
+    );
+  });
+
+  it('rejects a capability issued in the future', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-07T12:00:00.000Z'));
+    const issuedAt = Date.now() + 60_000;
+    const capability = encryptedCapability({
+      purpose: 'kilo_api_session',
+      version: 1,
+      ...claims,
+      issuedAt,
+      expiresAt: issuedAt + 60_000,
+    });
+
+    expect(() => new KiloSessionCapabilityCodec(encryptionKey).decode(capability)).toThrowError(
+      expect.objectContaining({ reason: 'invalid_capability' })
+    );
+    vi.useRealTimers();
+  });
+
+  it('rejects expiry and tampering without exposing enclosed tokens in errors', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-07T12:00:00.000Z'));
+    const codec = new KiloSessionCapabilityCodec(encryptionKey);
+    const capability = codec.issue(claims);
+
+    vi.setSystemTime(new Date('2026-06-07T16:00:00.000Z'));
+    let expiredError: unknown;
+    try {
+      codec.decode(capability);
+    } catch (error) {
+      expiredError = error;
+    }
+    expect(expiredError).toBeInstanceOf(KiloSessionCapabilityError);
+    expect(expiredError).toMatchObject({ reason: 'expired_capability' });
+    expect(JSON.stringify(expiredError)).not.toContain(claims.userToken);
+    expect(JSON.stringify(expiredError)).not.toContain(claims.providerToken);
+
+    const changedOffset = capability.lastIndexOf('.') + 4;
+    const changedCharacter = capability[changedOffset] === 'A' ? 'B' : 'A';
+    const tampered = `${capability.slice(0, changedOffset)}${changedCharacter}${capability.slice(changedOffset + 1)}`;
+    expect(() => codec.decode(tampered)).toThrowError(
+      expect.objectContaining({ reason: 'invalid_capability' })
+    );
+    vi.useRealTimers();
+  });
+});

--- a/services/git-token-service/src/kilo-session-capability.ts
+++ b/services/git-token-service/src/kilo-session-capability.ts
@@ -6,6 +6,10 @@ const CAPABILITY_PREFIX = 'kka1.';
 const CAPABILITY_PURPOSE = 'kilo_api_session';
 const MAX_KILO_SESSION_CAPABILITY_LIFETIME_MS = 4 * 60 * 60 * 1000;
 const MAX_KILO_SESSION_CAPABILITY_LENGTH = 64 * 1024;
+// issue() and decode() can run on different isolates whose clocks are not
+// perfectly aligned; allow a small future skew so a freshly issued capability is
+// not spuriously rejected as forged on the first redemption.
+const KILO_SESSION_CAPABILITY_CLOCK_SKEW_TOLERANCE_MS = 60 * 1000;
 
 const KiloSessionCapabilityTargetsSchema = z
   .object({
@@ -110,7 +114,10 @@ export class KiloSessionCapabilityCodec {
     }
 
     const parsed = KiloSessionCapabilityClaimsSchema.safeParse(value);
-    if (!parsed.success || parsed.data.issuedAt > Date.now()) {
+    if (
+      !parsed.success ||
+      parsed.data.issuedAt > Date.now() + KILO_SESSION_CAPABILITY_CLOCK_SKEW_TOLERANCE_MS
+    ) {
       throw new KiloSessionCapabilityError('invalid_capability');
     }
     if (parsed.data.expiresAt <= Date.now()) {

--- a/services/git-token-service/src/kilo-session-capability.ts
+++ b/services/git-token-service/src/kilo-session-capability.ts
@@ -28,7 +28,6 @@ const KiloSessionCapabilityClaimsSchema = z
     kiloSessionId: z.string().min(1),
     outboundContainerId: z.string().min(1),
     userToken: z.string().min(1),
-    providerToken: z.string().min(1).optional(),
     targets: KiloSessionCapabilityTargetsSchema,
     issuedAt: z.number().int().nonnegative(),
     expiresAt: z.number().int().positive(),
@@ -44,7 +43,6 @@ export type KiloSessionCapabilitySubject = {
   kiloSessionId: string;
   outboundContainerId: string;
   userToken: string;
-  providerToken?: string;
   targets: KiloSessionCapabilityTargets;
 };
 export type KiloSessionCapabilityClaims = z.infer<typeof KiloSessionCapabilityClaimsSchema>;

--- a/services/git-token-service/src/kilo-session-capability.ts
+++ b/services/git-token-service/src/kilo-session-capability.ts
@@ -1,0 +1,121 @@
+import { decryptWithSymmetricKey, encryptWithSymmetricKey } from '@kilocode/encryption';
+import { z } from 'zod';
+import { hasCanonicalEncryptedValueFormat } from './github-session-capability.js';
+
+const CAPABILITY_PREFIX = 'kka1.';
+const CAPABILITY_PURPOSE = 'kilo_api_session';
+const MAX_KILO_SESSION_CAPABILITY_LIFETIME_MS = 4 * 60 * 60 * 1000;
+const MAX_KILO_SESSION_CAPABILITY_LENGTH = 64 * 1024;
+
+const KiloSessionCapabilityTargetsSchema = z
+  .object({
+    backendBaseUrl: z.string().url(),
+    providerBaseUrl: z.string().url(),
+    sessionIngestBaseUrl: z.string().url(),
+  })
+  .strict();
+
+const KiloSessionCapabilityClaimsSchema = z
+  .object({
+    version: z.literal(1),
+    purpose: z.literal(CAPABILITY_PURPOSE),
+    userId: z.string().min(1),
+    cloudAgentSessionId: z.string().min(1),
+    kiloSessionId: z.string().min(1),
+    outboundContainerId: z.string().min(1),
+    userToken: z.string().min(1),
+    providerToken: z.string().min(1).optional(),
+    targets: KiloSessionCapabilityTargetsSchema,
+    issuedAt: z.number().int().nonnegative(),
+    expiresAt: z.number().int().positive(),
+  })
+  .strict()
+  .refine(claims => claims.expiresAt > claims.issuedAt)
+  .refine(claims => claims.expiresAt - claims.issuedAt <= MAX_KILO_SESSION_CAPABILITY_LIFETIME_MS);
+
+export type KiloSessionCapabilityTargets = z.infer<typeof KiloSessionCapabilityTargetsSchema>;
+export type KiloSessionCapabilitySubject = {
+  userId: string;
+  cloudAgentSessionId: string;
+  kiloSessionId: string;
+  outboundContainerId: string;
+  userToken: string;
+  providerToken?: string;
+  targets: KiloSessionCapabilityTargets;
+};
+export type KiloSessionCapabilityClaims = z.infer<typeof KiloSessionCapabilityClaimsSchema>;
+export type KiloSessionCapabilityFailureReason =
+  | 'invalid_capability'
+  | 'expired_capability'
+  | 'capability_configuration_error';
+
+export class KiloSessionCapabilityError extends Error {
+  constructor(readonly reason: KiloSessionCapabilityFailureReason) {
+    super(reason);
+    this.name = 'KiloSessionCapabilityError';
+  }
+}
+
+export class KiloSessionCapabilityCodec {
+  constructor(private readonly encryptionKey: string) {}
+
+  issue(subject: KiloSessionCapabilitySubject): string {
+    const issuedAt = Date.now();
+    const parsed = KiloSessionCapabilityClaimsSchema.safeParse({
+      version: 1,
+      purpose: CAPABILITY_PURPOSE,
+      ...subject,
+      issuedAt,
+      expiresAt: issuedAt + MAX_KILO_SESSION_CAPABILITY_LIFETIME_MS,
+    });
+    if (!parsed.success) throw new KiloSessionCapabilityError('invalid_capability');
+
+    try {
+      const capability = `${CAPABILITY_PREFIX}${encryptWithSymmetricKey(JSON.stringify(parsed.data), this.encryptionKey)}`;
+      if (capability.length > MAX_KILO_SESSION_CAPABILITY_LENGTH) {
+        throw new KiloSessionCapabilityError('invalid_capability');
+      }
+      return capability;
+    } catch (error) {
+      if (error instanceof KiloSessionCapabilityError) throw error;
+      throw new KiloSessionCapabilityError('capability_configuration_error');
+    }
+  }
+
+  decode(capability: string): KiloSessionCapabilityClaims {
+    if (capability.length > MAX_KILO_SESSION_CAPABILITY_LENGTH) {
+      throw new KiloSessionCapabilityError('invalid_capability');
+    }
+    if (!capability.startsWith(CAPABILITY_PREFIX)) {
+      throw new KiloSessionCapabilityError('invalid_capability');
+    }
+
+    const encrypted = capability.slice(CAPABILITY_PREFIX.length);
+    if (!hasCanonicalEncryptedValueFormat(encrypted)) {
+      throw new KiloSessionCapabilityError('invalid_capability');
+    }
+
+    let serialized: string;
+    try {
+      serialized = decryptWithSymmetricKey(encrypted, this.encryptionKey);
+    } catch {
+      throw new KiloSessionCapabilityError('invalid_capability');
+    }
+
+    let value: unknown;
+    try {
+      value = JSON.parse(serialized);
+    } catch {
+      throw new KiloSessionCapabilityError('invalid_capability');
+    }
+
+    const parsed = KiloSessionCapabilityClaimsSchema.safeParse(value);
+    if (!parsed.success || parsed.data.issuedAt > Date.now()) {
+      throw new KiloSessionCapabilityError('invalid_capability');
+    }
+    if (parsed.data.expiresAt <= Date.now()) {
+      throw new KiloSessionCapabilityError('expired_capability');
+    }
+    return parsed.data;
+  }
+}


### PR DESCRIPTION
## Summary

Adds `issueKiloSessionCapability` and `redeemKiloSessionCapability` RPCs to `GitTokenRPCEntrypoint`, letting outbound containers call Kilo backend, provider, and session-ingest routes through an opaque encrypted capability instead of holding raw tokens.

- `kilo-session-capability.ts` — encodes and decodes `kka1.*` capability tokens (encrypted, versioned claims: user token, allow-listed targets, container binding, issued/expiry timestamps, max 4h lifetime).
- `kilo-capability-policy.ts` — classifies a redeeming request URL against the capability's targets into `provider_model`, `organization_models`, `backend_api`, or `session_ingest` route classes, rejecting path-traversal/encoding tricks, session mismatches, and disallowed upstreams.
- `index.ts` — wires the two new RPC methods, including container-binding and target-validation checks before delegating to the codec/policy.
- Follow-up fixes tighten cross-session redemption safety, correctly handle shared backend/session-ingest origins, and remove the short-lived `providerToken` field so all routes redeem with the user token only.

## Verification

No manual verification beyond the existing automated test suite. The service-level tests cover issuance, redemption, target classification, token leakage, expiry, container/session binding, and cross-session rejection.

## Visual Changes

N/A

## Reviewer Notes

The final commit removes the optional `providerToken` and the per-route credential switch. `provider_model` and `organization_models` routes now use the user token, matching the simplified security model. Confirm that outbound containers do not need a separate provider credential for these upstreams.
