### PR TITLE
fix(ai-gateway): skip unmatched direct BYOK model loads

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+jest.mock('@/lib/drizzle', () => ({
+  readDb: {},
+}));
+
+jest.mock('@/lib/ai-gateway/byok', () => ({
+  getBYOKforOrganization: jest.fn(),
+  getBYOKforUser: jest.fn(),
+}));
+
+jest.mock('@/lib/ai-gateway/models', () => ({
+  preferredModels: [],
+}));
+
+jest.mock('@/lib/ai-gateway/providers/model-settings', () => ({
+  getAiSdkProvider: jest.fn(),
+  getModelVariants: jest.fn(),
+}));
+
+jest.mock('./direct-byok-definitions', () => ({
+  __esModule: true,
+  default: [
+    {
+      id: 'chutes-byok',
+      base_url: 'https://chutes.example.com/v1',
+      models: jest.fn(async () => [
+        {
+          id: 'supported-model',
+          name: 'Supported Model',
+          context_length: 4096,
+          max_completion_tokens: 1024,
+        },
+      ]),
+      supported_chat_apis: ['chat_completions'],
+      default_ai_sdk_provider: 'openai-compatible',
+      transformRequest: jest.fn(),
+    },
+    {
+      id: 'crofai',
+      base_url: 'https://crofai.example.com/v1',
+      models: jest.fn(async () => [
+        {
+          id: 'other-model',
+          name: 'Other Model',
+          context_length: 4096,
+          max_completion_tokens: 1024,
+        },
+      ]),
+      supported_chat_apis: ['chat_completions'],
+      default_ai_sdk_provider: 'openai-compatible',
+      transformRequest: jest.fn(),
+    },
+  ],
+}));
+
+async function loadDirectByokModule() {
+  const directByokProviders = (await import('./direct-byok-definitions')).default;
+  const { getDirectByokModel } = await import('.');
+
+  return { directByokProviders, getDirectByokModel };
+}
+
+describe('getDirectByokModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('skips loading model lists when the provider prefix is not direct BYOK', async () => {
+    const { directByokProviders, getDirectByokModel } = await loadDirectByokModule();
+
+    await expect(getDirectByokModel('openrouter/supported-model')).resolves.toEqual({
+      provider: null,
+      model: null,
+    });
+
+    expect(directByokProviders[0].models).not.toHaveBeenCalled();
+    expect(directByokProviders[1].models).not.toHaveBeenCalled();
+  });
+
+  test('loads only the model list for the matching provider prefix', async () => {
+    const { directByokProviders, getDirectByokModel } = await loadDirectByokModule();
+
+    const result = await getDirectByokModel('chutes-byok/supported-model');
+
+    expect(result.model?.id).toBe('supported-model');
+    expect(result.provider?.id).toBe('chutes-byok');
+    expect(directByokProviders[0].models).toHaveBeenCalledTimes(1);
+    expect(directByokProviders[1].models).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/index.ts
@@ -81,14 +81,20 @@ export async function getDirectByokModel(requestedModel: string): Promise<{
   provider: DirectByokProvider | null;
   model: DirectByokModel | null;
 }> {
-  for (const provider of DIRECT_BYOK_PROVIDERS) {
-    const model = (await provider.models()).find(
-      model => formatDirectByokModelId(provider, model) === requestedModel
-    );
-    if (model) {
-      return { provider, model };
-    }
+  const provider = DIRECT_BYOK_PROVIDERS.find(provider =>
+    requestedModel.startsWith(`${provider.id}/`)
+  );
+  if (!provider) {
+    return { provider: null, model: null };
   }
+
+  const model = (await provider.models()).find(
+    model => formatDirectByokModelId(provider, model) === requestedModel
+  );
+  if (model) {
+    return { provider, model };
+  }
+
   return { provider: null, model: null };
 }
 


### PR DESCRIPTION
## Summary

- Skip direct BYOK provider model-list loading when the requested model ID does not start with a direct BYOK provider prefix.
- Limit direct BYOK resolution to the single matching provider prefix and add regression coverage for the short-circuit behavior.

## Verification

No manual verification performed; this is a backend model-resolution optimization with no UI path.

## Visual Changes

N/A

## Reviewer Notes

N/A