### PR TITLE
refactor(web): consolidate overlay components

### DIFF
--- a/apps/storybook/src/decorators/withGastownTRPC.tsx
+++ b/apps/storybook/src/decorators/withGastownTRPC.tsx
@@ -1,0 +1,24 @@
+import React, { useState, type ReactNode } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import type { Decorator } from '@storybook/nextjs';
+import { GastownTRPCProvider, createGastownTRPCClient } from '@/lib/gastown/trpc';
+
+// Provides the Gastown worker tRPC context so components that call
+// `useGastownTRPC()` render in isolation. The client has no working token
+// endpoint in Storybook, so stories must avoid triggering network requests
+// (render shells / open states only; mutations fire on interaction).
+function GastownProviders({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
+  const [trpcClient] = useState(() => createGastownTRPCClient());
+  return (
+    <GastownTRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+      {children}
+    </GastownTRPCProvider>
+  );
+}
+
+export const withGastownTRPC: Decorator = Story => (
+  <GastownProviders>
+    <Story />
+  </GastownProviders>
+);

--- a/apps/storybook/stories/claw/kilo-chat/ConversationItem.stories.tsx
+++ b/apps/storybook/stories/claw/kilo-chat/ConversationItem.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import type { ReactNode } from 'react';
+import { ConversationItem } from '@/app/(app)/claw/kilo-chat/components/ConversationItem';
+import {
+  KiloChatContext,
+  type KiloChatContextValue,
+} from '@/app/(app)/claw/kilo-chat/components/kiloChatContext';
+
+// ConversationItem only reads `basePath` from context; the rest of the
+// KiloChatContextValue (event-service / kilo-chat clients) is not exercised in
+// these isolated stories, so a minimal value is cast to satisfy the provider.
+const mockContext = { basePath: '/claw/kilo-chat' } as KiloChatContextValue;
+
+function ChatSidebar({ children }: { children: ReactNode }) {
+  return (
+    <KiloChatContext.Provider value={mockContext}>
+      <div className="bg-background min-h-screen p-4">
+        <div className="border-border w-72 rounded-lg border p-2">{children}</div>
+      </div>
+    </KiloChatContext.Provider>
+  );
+}
+
+const now = Date.now();
+const baseConversation = {
+  conversationId: 'conv-1',
+  title: 'Refactor billing lifecycle',
+  lastActivityAt: now - 60_000,
+  lastReadAt: now - 60_000,
+  joinedAt: now - 3_600_000,
+};
+
+const noop = () => {};
+
+// Radix menu/popover triggers open on pointerdown, not a bare click, so the
+// play functions dispatch a full pointer sequence.
+function openByPointer(el: Element | null | undefined) {
+  if (!el) return;
+  const opts = { bubbles: true, cancelable: true, composed: true, button: 0 };
+  el.dispatchEvent(new PointerEvent('pointerdown', opts));
+  el.dispatchEvent(new PointerEvent('pointerup', opts));
+  (el as HTMLElement).click();
+}
+
+const meta: Meta<typeof ConversationItem> = {
+  title: 'Overlays/Menus/ConversationItem',
+  component: ConversationItem,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const List: Story = {
+  render: () => (
+    <ChatSidebar>
+      <ConversationItem conversation={baseConversation} isActive onRename={noop} onLeave={noop} />
+      <ConversationItem
+        conversation={{
+          ...baseConversation,
+          conversationId: 'conv-2',
+          title: 'Unread: deploy backend',
+          lastActivityAt: now,
+          lastReadAt: now - 600_000,
+        }}
+        isActive={false}
+        onRename={noop}
+        onLeave={noop}
+      />
+      <ConversationItem
+        conversation={{ ...baseConversation, conversationId: 'conv-3', title: null }}
+        isActive={false}
+        onRename={noop}
+        onLeave={noop}
+      />
+    </ChatSidebar>
+  ),
+};
+
+// Opens the kebab menu (Radix DropdownMenu).
+export const MenuOpen: Story = {
+  render: () => (
+    <ChatSidebar>
+      <ConversationItem conversation={baseConversation} isActive onRename={noop} onLeave={noop} />
+    </ChatSidebar>
+  ),
+  play: async () => {
+    await new Promise(resolve => setTimeout(resolve, 50));
+    openByPointer(document.querySelector('button[aria-label="Conversation options"]'));
+  },
+};
+
+// Opens the kebab menu then the leave-confirmation AlertDialog.
+export const LeaveConfirm: Story = {
+  render: () => (
+    <ChatSidebar>
+      <ConversationItem conversation={baseConversation} isActive onRename={noop} onLeave={noop} />
+    </ChatSidebar>
+  ),
+  play: async () => {
+    await new Promise(resolve => setTimeout(resolve, 50));
+    openByPointer(document.querySelector('button[aria-label="Conversation options"]'));
+    await new Promise(resolve => setTimeout(resolve, 120));
+    const leave = Array.from(document.querySelectorAll('[role="menuitem"]')).find(
+      el => el.textContent?.trim() === 'Leave'
+    );
+    openByPointer(leave);
+    await new Promise(resolve => setTimeout(resolve, 150));
+  },
+};

--- a/apps/storybook/stories/claw/kilo-chat/EmojiPicker.stories.tsx
+++ b/apps/storybook/stories/claw/kilo-chat/EmojiPicker.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+import { EmojiPicker } from '@/app/(app)/claw/kilo-chat/components/EmojiPicker';
+
+const meta: Meta<typeof EmojiPicker> = {
+  title: 'Overlays/Popovers/EmojiPicker',
+  component: EmojiPicker,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// EmojiPicker is a Radix Popover anchored to its trigger. The story opens it by
+// default so the emoji-mart panel is captured in isolation.
+function EmojiPickerDemo() {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="flex min-h-[520px] items-center justify-center">
+      <EmojiPicker
+        open={open}
+        onOpenChange={setOpen}
+        onSelect={emoji => console.log('select', emoji)}
+      >
+        <button type="button" className="bg-muted text-foreground rounded-2xl px-3 py-2 text-sm">
+          Add reaction
+        </button>
+      </EmojiPicker>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <EmojiPickerDemo />,
+};

--- a/apps/storybook/stories/claw/kilo-chat/EmojiQuickPick.stories.tsx
+++ b/apps/storybook/stories/claw/kilo-chat/EmojiQuickPick.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { EmojiQuickPick } from '@/app/(app)/claw/kilo-chat/components/EmojiQuickPick';
+
+const meta: Meta<typeof EmojiQuickPick> = {
+  title: 'Overlays/Popovers/EmojiQuickPick',
+  component: EmojiQuickPick,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    onSelect: emoji => console.log('select', emoji),
+    onOpenFullPicker: () => console.log('open full picker'),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    currentUserReactions: new Set<string>(),
+  },
+};
+
+export const WithActiveReactions: Story = {
+  args: {
+    currentUserReactions: new Set<string>(['👍', '🎉']),
+  },
+};

--- a/apps/storybook/stories/deployments/EnvironmentSettings.stories.tsx
+++ b/apps/storybook/stories/deployments/EnvironmentSettings.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { EnvironmentSettings } from '@/components/deployments/EnvironmentSettings';
+import { DeploymentProvider } from '@/components/deployments/DeploymentContext';
+import type { DeploymentQueries, DeploymentMutations } from '@/lib/user-deployments/router-types';
+
+// EnvironmentSettings reads env vars + mutations from DeploymentContext.
+// Stories supply a fixture provider so the populated list (and its hand-rolled
+// `fixed inset-0` delete-confirmation modal, slated to move to AlertDialog)
+// render without a backend. The full query/mutation surfaces are large, so
+// only the fields this component touches are mocked and cast (fixture-only).
+const envVars = [
+  { key: 'DATABASE_URL', value: 'redacted-database-url', isSecret: true },
+  { key: 'NODE_ENV', value: 'production', isSecret: false },
+  { key: 'STRIPE_SECRET_KEY', value: 'redacted-stripe-secret', isSecret: true },
+];
+
+const queries = {
+  listEnvVars: () => ({
+    data: envVars,
+    isLoading: false,
+    error: null,
+    refetch: () => Promise.resolve(),
+  }),
+} as unknown as DeploymentQueries;
+
+const noopMutation = { mutate: () => {}, isPending: false };
+const mutations = {
+  setEnvVar: noopMutation,
+  deleteEnvVar: noopMutation,
+  renameEnvVar: noopMutation,
+} as unknown as DeploymentMutations;
+
+const meta: Meta<typeof EnvironmentSettings> = {
+  title: 'Overlays/Dialogs/EnvironmentSettings',
+  component: EnvironmentSettings,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <DeploymentProvider queries={queries} mutations={mutations}>
+        <div className="bg-background min-h-screen p-8">
+          <div className="m-auto w-full max-w-3xl">
+            <Story />
+          </div>
+        </div>
+      </DeploymentProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const List: Story = {
+  render: () => <EnvironmentSettings deploymentId="dep-1" />,
+};
+
+// Opens the hand-rolled delete-confirmation modal.
+export const DeleteConfirm: Story = {
+  render: () => <EnvironmentSettings deploymentId="dep-1" />,
+  play: async () => {
+    await new Promise(resolve => setTimeout(resolve, 50));
+    document.querySelector<HTMLButtonElement>('button[aria-label="Delete variable"]')?.click();
+  },
+};

--- a/apps/storybook/stories/deployments/EnvironmentSettings.stories.tsx
+++ b/apps/storybook/stories/deployments/EnvironmentSettings.stories.tsx
@@ -4,10 +4,9 @@ import { DeploymentProvider } from '@/components/deployments/DeploymentContext';
 import type { DeploymentQueries, DeploymentMutations } from '@/lib/user-deployments/router-types';
 
 // EnvironmentSettings reads env vars + mutations from DeploymentContext.
-// Stories supply a fixture provider so the populated list (and its hand-rolled
-// `fixed inset-0` delete-confirmation modal, slated to move to AlertDialog)
-// render without a backend. The full query/mutation surfaces are large, so
-// only the fields this component touches are mocked and cast (fixture-only).
+// Stories supply a fixture provider so the populated list and AlertDialog delete
+// confirmation render without a backend. The full query/mutation surfaces are
+// large, so only the fields this component touches are mocked and cast.
 const envVars = [
   { key: 'DATABASE_URL', value: 'redacted-database-url', isSecret: true },
   { key: 'NODE_ENV', value: 'production', isSecret: false },
@@ -56,7 +55,7 @@ export const List: Story = {
   render: () => <EnvironmentSettings deploymentId="dep-1" />,
 };
 
-// Opens the hand-rolled delete-confirmation modal.
+// Opens the delete confirmation AlertDialog.
 export const DeleteConfirm: Story = {
   render: () => <EnvironmentSettings deploymentId="dep-1" />,
   play: async () => {

--- a/apps/storybook/stories/gastown/CreateBeadDrawer.stories.tsx
+++ b/apps/storybook/stories/gastown/CreateBeadDrawer.stories.tsx
@@ -4,7 +4,7 @@ import { CreateBeadDrawer } from '@/components/gastown/CreateBeadDrawer';
 import { Button } from '@/components/Button';
 import { withGastownTRPC } from '../../src/decorators/withGastownTRPC';
 
-// CreateBeadDrawer is a vaul drawer (slated to move to Sheet). It calls
+// CreateBeadDrawer renders inside a Sheet drawer. It calls
 // useGastownTRPC for enrichment/create, which only fire on interaction, so the
 // open shell renders under the gastown tRPC provider without network.
 

--- a/apps/storybook/stories/gastown/CreateBeadDrawer.stories.tsx
+++ b/apps/storybook/stories/gastown/CreateBeadDrawer.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+import { CreateBeadDrawer } from '@/components/gastown/CreateBeadDrawer';
+import { Button } from '@/components/Button';
+import { withGastownTRPC } from '../../src/decorators/withGastownTRPC';
+
+// CreateBeadDrawer is a vaul drawer (slated to move to Sheet). It calls
+// useGastownTRPC for enrichment/create, which only fire on interaction, so the
+// open shell renders under the gastown tRPC provider without network.
+
+const meta: Meta<typeof CreateBeadDrawer> = {
+  title: 'Overlays/Drawers/CreateBeadDrawer',
+  component: CreateBeadDrawer,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [withGastownTRPC],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function CreateBeadDrawerDemo() {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <div className="bg-background min-h-screen p-6">
+      <Button onClick={() => setIsOpen(true)}>Open create bead</Button>
+      <CreateBeadDrawer
+        rigId="rig-1"
+        townId="town-1"
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <CreateBeadDrawerDemo />,
+};

--- a/apps/storybook/stories/gastown/OnboardingTooltip.stories.tsx
+++ b/apps/storybook/stories/gastown/OnboardingTooltip.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { OnboardingTooltipPopover } from '@/components/gastown/OnboardingTooltips';
+import { ONBOARDING_TOOLTIPS } from '@/components/gastown/useOnboardingTooltips';
+
+// The onboarding coachmark (Radix Popover anchored to the target element via a
+// virtual anchor). It anchors to an element carrying `data-onboarding-target`,
+// so the story renders one and the popover positions against it.
+
+const tooltip = ONBOARDING_TOOLTIPS[0];
+
+const meta: Meta<typeof OnboardingTooltipPopover> = {
+  title: 'Overlays/Coachmarks/OnboardingTooltip',
+  component: OnboardingTooltipPopover,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="bg-background min-h-screen p-10">
+      <div className="flex gap-3">
+        <button
+          type="button"
+          data-onboarding-target={tooltip.target}
+          className="rounded-md border border-white/15 bg-[#1a1a2e] px-4 py-2 text-sm text-white/80"
+        >
+          {tooltip.title} anchor
+        </button>
+      </div>
+      <OnboardingTooltipPopover tooltip={tooltip} onDismiss={() => {}} onDismissAll={() => {}} />
+    </div>
+  ),
+};

--- a/apps/storybook/stories/gastown/TerminalBarPickers.stories.tsx
+++ b/apps/storybook/stories/gastown/TerminalBarPickers.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { PositionPicker, BugReportMenu } from '@/components/gastown/TerminalBar';
+
+// PositionPicker (Radix Popover) and BugReportMenu (Radix DropdownMenu) are the
+// gastown terminal-bar overlays. Each renders its own trigger; the stories open
+// the overlay via a play function so the screenshot captures the open state.
+
+const meta: Meta = {
+  title: 'Overlays/Popovers/TerminalBarPickers',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+// Radix menu/popover triggers open on pointerdown, not a bare click.
+function openByPointer(el: Element | null | undefined) {
+  if (!el) return;
+  const opts = { bubbles: true, cancelable: true, composed: true, button: 0 };
+  el.dispatchEvent(new PointerEvent('pointerdown', opts));
+  el.dispatchEvent(new PointerEvent('pointerup', opts));
+  (el as HTMLElement).click();
+}
+
+function TerminalControlStrip({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
+      <div className="flex items-center gap-2 rounded-md border border-white/[0.08] bg-[#0a0a0a] px-2 py-1">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export const Position: Story = {
+  render: () => (
+    <TerminalControlStrip>
+      <PositionPicker current="bottom" onSelect={() => {}} horizontal />
+    </TerminalControlStrip>
+  ),
+  play: async () => {
+    await new Promise(resolve => setTimeout(resolve, 50));
+    openByPointer(document.querySelector('button[aria-label="Change terminal position"]'));
+    await new Promise(resolve => setTimeout(resolve, 150));
+  },
+};
+
+export const BugReport: Story = {
+  render: () => (
+    <TerminalControlStrip>
+      <BugReportMenu />
+    </TerminalControlStrip>
+  ),
+  play: async () => {
+    await new Promise(resolve => setTimeout(resolve, 50));
+    openByPointer(document.querySelector('button[aria-label="Report a bug"]'));
+    await new Promise(resolve => setTimeout(resolve, 150));
+  },
+};

--- a/apps/storybook/stories/organizations/custom-modes/ModeDrawer.stories.tsx
+++ b/apps/storybook/stories/organizations/custom-modes/ModeDrawer.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+import { ModeDrawer } from '@/components/organizations/custom-modes/ModeDrawer';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const meta: Meta<typeof ModeDrawer> = {
+  title: 'Overlays/Drawers/ModeDrawer',
+  component: ModeDrawer,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ModeDrawerDemo({ withFooter }: { withFooter?: boolean }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="bg-background min-h-screen p-6">
+      <Button onClick={() => setOpen(true)}>Open mode drawer</Button>
+      <ModeDrawer
+        open={open}
+        onOpenChange={setOpen}
+        title="Create custom mode"
+        description="Define a reusable mode that your organization's members can select."
+        footer={
+          withFooter ? (
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={() => setOpen(false)}>Save mode</Button>
+            </div>
+          ) : undefined
+        }
+      >
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="mode-name">Name</Label>
+            <Input
+              id="mode-name"
+              placeholder="e.g. Security Reviewer"
+              defaultValue="Security Reviewer"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="mode-slug">Slug</Label>
+            <Input
+              id="mode-slug"
+              placeholder="security-reviewer"
+              defaultValue="security-reviewer"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="mode-instructions">Custom instructions</Label>
+            <textarea
+              id="mode-instructions"
+              rows={8}
+              className="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+              defaultValue={
+                'You are a meticulous security reviewer. Flag injection, auth bypass, and unsafe deserialization.'
+              }
+            />
+          </div>
+        </div>
+      </ModeDrawer>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <ModeDrawerDemo withFooter />,
+};
+
+export const WithoutFooter: Story = {
+  render: () => <ModeDrawerDemo />,
+};

--- a/apps/storybook/stories/organizations/usage-details/AIAdoptionEmptyState.stories.tsx
+++ b/apps/storybook/stories/organizations/usage-details/AIAdoptionEmptyState.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { AIAdoptionEmptyState } from '@/components/organizations/usage-details/components/AIAdoptionEmptyState';
+
+const meta: Meta<typeof AIAdoptionEmptyState> = {
+  title: 'Overlays/Drawers/AIAdoptionEmptyState',
+  component: AIAdoptionEmptyState,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className="bg-background min-h-screen p-8">
+        <div className="m-auto w-full max-w-[1140px]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+// The "Learn More" drawer is self-stateful (no open prop), so open it via its
+// trigger button to capture the drawer surface.
+export const DrawerOpen: Story = {
+  play: async () => {
+    await new Promise(resolve => setTimeout(resolve, 50));
+    const buttons = Array.from(document.querySelectorAll('button'));
+    const trigger = buttons.find(b => b.textContent?.includes('Learn More About AI Adoption'));
+    trigger?.click();
+  },
+};

--- a/apps/storybook/stories/organizations/usage-details/MetricDetailDrawer.stories.tsx
+++ b/apps/storybook/stories/organizations/usage-details/MetricDetailDrawer.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+import { MetricDetailDrawer } from '@/components/organizations/usage-details/components/MetricDetailDrawer';
+import { Button } from '@/components/ui/button';
+
+const meta: Meta<typeof MetricDetailDrawer> = {
+  title: 'Overlays/Drawers/MetricDetailDrawer',
+  component: MetricDetailDrawer,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const chartData = Array.from({ length: 14 }, (_, i) => {
+  const date = new Date(2026, 5, i + 1);
+  const frequency = 40 + Math.round(Math.sin(i / 2) * 15 + i);
+  const depth = 30 + Math.round(Math.cos(i / 3) * 12 + i);
+  const coverage = 25 + Math.round(Math.sin(i / 4) * 10 + i);
+  return {
+    date: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    timestamp: date.getTime(),
+    Frequency: frequency,
+    Depth: depth,
+    Coverage: coverage,
+    total: frequency + depth + coverage,
+  };
+});
+
+function MetricDetailDrawerDemo({ metric }: { metric: 'frequency' | 'depth' | 'coverage' }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="bg-background min-h-screen p-6">
+      <Button onClick={() => setOpen(true)}>Open metric detail</Button>
+      <MetricDetailDrawer
+        open={open}
+        onOpenChange={setOpen}
+        metric={metric}
+        organizationId="fake-org-1"
+        chartData={chartData}
+      />
+    </div>
+  );
+}
+
+export const Frequency: Story = {
+  render: () => <MetricDetailDrawerDemo metric="frequency" />,
+};
+
+export const Depth: Story = {
+  render: () => <MetricDetailDrawerDemo metric="depth" />,
+};
+
+export const Coverage: Story = {
+  render: () => <MetricDetailDrawerDemo metric="coverage" />,
+};

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/ConversationItem.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/ConversationItem.tsx
@@ -5,6 +5,22 @@ import Link from 'next/link';
 import { MoreVertical } from 'lucide-react';
 import type { ConversationListItem } from '@kilocode/kilo-chat';
 import { CONVERSATION_TITLE_MAX_CHARS } from '@kilocode/kilo-chat';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { useKiloChatContext } from './kiloChatContext';
 
 type ConversationItemProps = {
@@ -26,7 +42,6 @@ export function ConversationItem({
   const [isConfirmingLeave, setIsConfirmingLeave] = useState(false);
   const [renameValue, setRenameValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
 
   const timestamp = conversation.lastActivityAt ?? conversation.joinedAt;
   const displayTime = new Date(timestamp).toLocaleTimeString([], {
@@ -41,18 +56,6 @@ export function ConversationItem({
       inputRef.current.select();
     }
   }, [isRenaming]);
-
-  // Close menu on outside click
-  useEffect(() => {
-    if (!menuOpen) return;
-    function handleClick(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [menuOpen]);
 
   const handleStartRename = useCallback(() => {
     setRenameValue(conversation.title ?? '');
@@ -141,26 +144,6 @@ export function ConversationItem({
             className="bg-transparent min-w-0 flex-1 text-sm font-medium outline-none border-b border-current/20"
             maxLength={CONVERSATION_TITLE_MAX_CHARS}
           />
-        ) : isConfirmingLeave ? (
-          <>
-            <span className="text-sm">Leave?</span>
-            <span className="flex shrink-0 gap-1.5 text-xs">
-              <button
-                type="button"
-                onClick={handleConfirmLeave}
-                className="text-destructive hover:underline font-medium cursor-pointer"
-              >
-                Yes
-              </button>
-              <button
-                type="button"
-                onClick={handleCancelLeave}
-                className="text-muted-foreground hover:underline cursor-pointer"
-              >
-                No
-              </button>
-            </span>
-          </>
         ) : (
           <>
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
@@ -186,47 +169,49 @@ export function ConversationItem({
               >
                 {displayTime}
               </span>
-              <div ref={menuRef} className="relative">
-                <button
-                  type="button"
+              <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+                <DropdownMenuTrigger
                   aria-label="Conversation options"
-                  aria-haspopup="menu"
-                  aria-expanded={menuOpen}
-                  onClick={() => setMenuOpen(prev => !prev)}
                   className={`hover:bg-muted rounded p-0.5 cursor-pointer transition-colors ${
                     menuOpen ? 'block' : 'hidden group-hover:block'
                   }`}
                 >
                   <MoreVertical className="h-3.5 w-3.5" />
-                </button>
-                {menuOpen && (
-                  <div
-                    role="menu"
-                    className="bg-popover border-border absolute right-0 top-full z-10 mt-1 w-32 rounded-md border py-1 shadow-md"
-                  >
-                    <button
-                      type="button"
-                      role="menuitem"
-                      onClick={handleStartRename}
-                      className="hover:bg-muted w-full px-3 py-1.5 text-left text-sm cursor-pointer transition-colors"
-                    >
-                      Rename
-                    </button>
-                    <button
-                      type="button"
-                      role="menuitem"
-                      onClick={handleStartLeave}
-                      className="text-destructive hover:bg-muted w-full px-3 py-1.5 text-left text-sm cursor-pointer transition-colors"
-                    >
-                      Leave
-                    </button>
-                  </div>
-                )}
-              </div>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-32">
+                  <DropdownMenuItem onSelect={handleStartRename}>Rename</DropdownMenuItem>
+                  <DropdownMenuItem variant="destructive" onSelect={handleStartLeave}>
+                    Leave
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </>
         )}
       </div>
+
+      <AlertDialog
+        open={isConfirmingLeave}
+        onOpenChange={open => {
+          if (!open) handleCancelLeave();
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Leave this conversation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You will stop receiving messages from &ldquo;{title}&rdquo; and it will be removed
+              from your list.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Stay</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleConfirmLeave}>
+              Leave conversation
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/EmojiPicker.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/EmojiPicker.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useRef, useState, lazy, Suspense } from 'react';
-import { createPortal } from 'react-dom';
+import { lazy, Suspense } from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 const LazyPicker = lazy(async () => {
   const [{ default: data }, { default: Picker }] = await Promise.all([
@@ -15,67 +15,61 @@ const LazyPicker = lazy(async () => {
   };
 });
 
-/** Approximate height of the emoji-mart picker. */
-const PICKER_HEIGHT = 435;
+/**
+ * The emoji-mart picker panel without any positioning concerns. Render it
+ * inside a Popover (see EmojiPicker) or any other anchored surface.
+ */
+export function EmojiMartPanel({ onSelect }: { onSelect: (emoji: string) => void }) {
+  return (
+    <Suspense
+      fallback={<div className="bg-muted rounded-lg p-8 text-center text-sm">Loading&hellip;</div>}
+    >
+      <LazyPicker
+        onEmojiSelect={(emoji: { native: string }) => {
+          onSelect(emoji.native);
+        }}
+        // Intentionally hardcoded to "dark" — the chat UI is dark-themed and
+        // "auto" causes a jarring white picker when the OS is in light mode.
+        theme="dark"
+        previewPosition="none"
+        skinTonePosition="none"
+        maxFrequentRows={1}
+      />
+    </Suspense>
+  );
+}
 
 type EmojiPickerProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onSelect: (emoji: string) => void;
-  onClose: () => void;
-  /** Element to anchor the picker to. If omitted, renders inline. */
-  anchorRef?: React.RefObject<HTMLElement | null>;
+  align?: 'start' | 'center' | 'end';
+  /** The trigger element (e.g. an add-reaction button). */
+  children: React.ReactNode;
 };
 
-export function EmojiPicker({ onSelect, onClose, anchorRef }: EmojiPickerProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [style, setStyle] = useState<React.CSSProperties | undefined>(undefined);
-
-  useEffect(() => {
-    if (!anchorRef?.current) return;
-    const rect = anchorRef.current.getBoundingClientRect();
-    const spaceAbove = rect.top;
-    const placeAbove = spaceAbove >= PICKER_HEIGHT + 8;
-
-    setStyle({
-      position: 'fixed',
-      left: Math.max(8, Math.min(rect.left, window.innerWidth - 360)),
-      ...(placeAbove
-        ? { top: rect.top - 4, transform: 'translateY(-100%)' }
-        : { top: rect.bottom + 4 }),
-    });
-  }, [anchorRef]);
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [onClose]);
-
-  const picker = (
-    <div ref={containerRef} className="z-[100]" style={style}>
-      <Suspense
-        fallback={<div className="bg-muted rounded-lg p-8 text-center text-sm">Loading...</div>}
-      >
-        <LazyPicker
-          onEmojiSelect={(emoji: { native: string }) => {
-            onSelect(emoji.native);
+/**
+ * Full emoji picker anchored to its trigger via Radix Popover. Radix supplies
+ * collision handling, outside-click dismissal, Escape, and focus management.
+ */
+export function EmojiPicker({
+  open,
+  onOpenChange,
+  onSelect,
+  align = 'start',
+  children,
+}: EmojiPickerProps) {
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent align={align} className="w-auto border-none bg-transparent p-0 shadow-none">
+        <EmojiMartPanel
+          onSelect={emoji => {
+            onSelect(emoji);
+            onOpenChange(false);
           }}
-          // Intentionally hardcoded to "dark" — the chat UI is dark-themed and
-          // "auto" causes a jarring white picker when the OS is in light mode.
-          theme="dark"
-          previewPosition="none"
-          skinTonePosition="none"
-          maxFrequentRows={1}
         />
-      </Suspense>
-    </div>
+      </PopoverContent>
+    </Popover>
   );
-
-  if (anchorRef) {
-    return createPortal(picker, document.body);
-  }
-  return picker;
 }

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/EmojiQuickPick.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/EmojiQuickPick.tsx
@@ -14,10 +14,11 @@ export function EmojiQuickPick({
   onOpenFullPicker,
 }: EmojiQuickPickProps) {
   return (
-    <div className="flex items-center gap-0.5 rounded-lg bg-background border border-border p-1 shadow-md">
+    <div className="bg-popover text-popover-foreground border-border flex items-center gap-0.5 rounded-lg border p-1 shadow-md">
       {QUICK_EMOJIS.map(emoji => (
         <button
           key={emoji}
+          type="button"
           onClick={() => onSelect(emoji)}
           className={`rounded p-1 text-base cursor-pointer transition-colors hover:bg-muted ${
             currentUserReactions.has(emoji) ? 'bg-primary/10' : ''
@@ -28,6 +29,7 @@ export function EmojiQuickPick({
         </button>
       ))}
       <button
+        type="button"
         onClick={onOpenFullPicker}
         className="rounded p-1 text-sm cursor-pointer transition-colors hover:bg-muted text-muted-foreground"
         title="More emoji"

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/MessageBubble.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/MessageBubble.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useMemo, useState, useRef, memo } from 'react';
+import { useMemo, useState, memo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Pencil, Trash2, Reply, X, Check, AlertCircle, Smile, Copy } from 'lucide-react';
 import { EmojiQuickPick } from './EmojiQuickPick';
-import { EmojiPicker } from './EmojiPicker';
+import { EmojiMartPanel } from './EmojiPicker';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { ReactionPills } from './ReactionPills';
 import type {
   Message,
@@ -94,9 +95,9 @@ export const MessageBubble = memo(function MessageBubble({
   const [removedAttachmentIds, setRemovedAttachmentIds] = useState<Set<string>>(new Set());
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [showActions, setShowActions] = useState(false);
-  const [showQuickPick, setShowQuickPick] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const [reactionMenuOpen, setReactionMenuOpen] = useState(false);
   const [showFullPicker, setShowFullPicker] = useState(false);
-  const bubbleRef = useRef<HTMLDivElement>(null);
 
   const isBot = message.senderId.startsWith('bot:');
   const isOptimistic = message.id.startsWith('pending-');
@@ -205,8 +206,7 @@ export const MessageBubble = memo(function MessageBubble({
     );
   }
 
-  function handleQuickPickSelect(emoji: string) {
-    setShowQuickPick(false);
+  function applyReaction(emoji: string) {
     if (!actionAvailability.canReact) return;
     if (myReactions.has(emoji)) {
       onRemoveReaction(message.id, emoji);
@@ -215,14 +215,21 @@ export const MessageBubble = memo(function MessageBubble({
     }
   }
 
+  function handleQuickPickSelect(emoji: string) {
+    handleReactionMenuOpenChange(false);
+    applyReaction(emoji);
+  }
+
   function handleFullPickerSelect(emoji: string) {
-    setShowFullPicker(false);
-    setShowQuickPick(false);
-    if (!actionAvailability.canReact) return;
-    if (myReactions.has(emoji)) {
-      onRemoveReaction(message.id, emoji);
-    } else {
-      onAddReaction(message.id, emoji);
+    handleReactionMenuOpenChange(false);
+    applyReaction(emoji);
+  }
+
+  function handleReactionMenuOpenChange(open: boolean) {
+    setReactionMenuOpen(open);
+    if (!open) {
+      setShowFullPicker(false);
+      if (!isHovered) setShowActions(false);
     }
   }
 
@@ -235,13 +242,31 @@ export const MessageBubble = memo(function MessageBubble({
       }`}
     >
       {actionAvailability.canReact && (
-        <button
-          onClick={() => setShowQuickPick(prev => !prev)}
-          className="hover:bg-muted rounded p-1 cursor-pointer transition-colors"
-          title="React"
-        >
-          <Smile className="h-3.5 w-3.5" />
-        </button>
+        <Popover open={reactionMenuOpen} onOpenChange={handleReactionMenuOpenChange}>
+          <PopoverTrigger
+            type="button"
+            className="hover:bg-muted rounded p-1 cursor-pointer transition-colors"
+            title="React"
+            aria-label="React"
+          >
+            <Smile className="h-3.5 w-3.5" />
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            side="top"
+            className="w-auto border-none bg-transparent p-0 shadow-none"
+          >
+            {showFullPicker ? (
+              <EmojiMartPanel onSelect={handleFullPickerSelect} />
+            ) : (
+              <EmojiQuickPick
+                currentUserReactions={myReactions}
+                onSelect={handleQuickPickSelect}
+                onOpenFullPicker={() => setShowFullPicker(true)}
+              />
+            )}
+          </PopoverContent>
+        </Popover>
       )}
       <button
         onClick={() => {
@@ -288,12 +313,13 @@ export const MessageBubble = memo(function MessageBubble({
   return (
     <div
       className={`group flex [content-visibility:auto] [contain-intrinsic-size:0_120px] px-4 py-1 ${isOwn ? 'justify-end' : 'justify-start'}`}
-      onMouseEnter={() => setShowActions(true)}
+      onMouseEnter={() => {
+        setIsHovered(true);
+        setShowActions(true);
+      }}
       onMouseLeave={() => {
-        if (!showFullPicker) {
-          setShowActions(false);
-          setShowQuickPick(false);
-        }
+        setIsHovered(false);
+        if (!reactionMenuOpen) setShowActions(false);
       }}
     >
       <div className={`flex max-w-[75%] min-w-0 flex-col ${isOwn ? 'items-end' : 'items-start'}`}>
@@ -316,27 +342,7 @@ export const MessageBubble = memo(function MessageBubble({
 
         <div className="relative min-w-0 max-w-full">
           {actionButtons}
-          {showQuickPick && actionAvailability.canReact && (
-            <div className={`absolute z-20 ${isOwn ? 'right-full mr-1' : 'left-full ml-1'} top-0`}>
-              <EmojiQuickPick
-                currentUserReactions={myReactions}
-                onSelect={handleQuickPickSelect}
-                onOpenFullPicker={() => {
-                  setShowQuickPick(false);
-                  setShowFullPicker(true);
-                }}
-              />
-            </div>
-          )}
-          {showFullPicker && actionAvailability.canReact && (
-            <EmojiPicker
-              onSelect={handleFullPickerSelect}
-              onClose={() => setShowFullPicker(false)}
-              anchorRef={bubbleRef}
-            />
-          )}
           <div
-            ref={bubbleRef}
             className={`overflow-hidden rounded-2xl px-3 py-2 ${
               isOwn ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'
             }`}

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/ReactionPills.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/ReactionPills.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import type { ReactionSummary } from '@kilocode/kilo-chat';
 import { EmojiPicker } from './EmojiPicker';
 
@@ -20,7 +20,6 @@ export function ReactionPills({
   onRemove,
 }: ReactionPillsProps) {
   const [showPicker, setShowPicker] = useState(false);
-  const addButtonRef = useRef<HTMLButtonElement>(null);
 
   const handlePickerSelect = useCallback(
     (emoji: string) => {
@@ -59,21 +58,16 @@ export function ReactionPills({
           </button>
         );
       })}
-      <button
-        ref={addButtonRef}
-        onClick={() => setShowPicker(prev => !prev)}
-        className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-sm cursor-pointer transition-colors border bg-muted border-border hover:bg-accent text-muted-foreground"
-        title="Add reaction"
-      >
-        +
-      </button>
-      {showPicker && (
-        <EmojiPicker
-          onSelect={handlePickerSelect}
-          onClose={() => setShowPicker(false)}
-          anchorRef={addButtonRef}
-        />
-      )}
+      <EmojiPicker open={showPicker} onOpenChange={setShowPicker} onSelect={handlePickerSelect}>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-sm cursor-pointer transition-colors border bg-muted border-border hover:bg-accent text-muted-foreground"
+          title="Add reaction"
+          aria-label="Add reaction"
+        >
+          +
+        </button>
+      </EmojiPicker>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/TownListPageClient.tsx
@@ -11,6 +11,7 @@ import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { GastownBackdrop } from '@/components/gastown/GastownBackdrop';
+import { useConfirm } from '@/components/ui/confirm';
 import { Plus, Factory, Trash2, Skull } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
@@ -43,6 +44,7 @@ export function TownListPageClient() {
   const router = useRouter();
   const trpc = useGastownTRPC();
   const wastelandTrpc = useWastelandTRPC();
+  const confirm = useConfirm();
 
   const queryClient = useQueryClient();
   const townsQuery = useQuery(trpc.gastown.listTowns.queryOptions());
@@ -160,13 +162,21 @@ export function TownListPageClient() {
                   </p>
                 </div>
                 <button
+                  type="button"
                   onClick={e => {
                     e.stopPropagation();
-                    if (
-                      confirm(`Delete town "${town.name}"? This will also delete all its rigs.`)
-                    ) {
-                      deleteTown.mutate({ townId: town.id });
-                    }
+                    void (async () => {
+                      if (
+                        await confirm({
+                          title: `Delete town "${town.name}"?`,
+                          description: 'This also deletes all of its rigs and cannot be undone.',
+                          confirmLabel: 'Delete town',
+                          destructive: true,
+                        })
+                      ) {
+                        deleteTown.mutate({ townId: town.id });
+                      }
+                    })();
                   }}
                   className="rounded p-1.5 text-white/35 transition-colors hover:bg-red-500/10 hover:text-red-300"
                 >

--- a/apps/web/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -39,6 +39,7 @@ import type { GastownOutputs } from '@/lib/gastown/trpc';
 import { AdminViewingBanner } from '@/components/gastown/AdminViewingBanner';
 import { DrainStatusBanner } from '@/components/gastown/DrainStatusBanner';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useConfirm } from '@/components/ui/confirm';
 
 type Agent = GastownOutputs['gastown']['listAgents'][number];
 
@@ -97,6 +98,7 @@ export function TownOverviewPageClient({
   const townBasePath = basePathOverride ?? `/gastown/${townId}`;
   const router = useRouter();
   const trpc = useGastownTRPC();
+  const confirm = useConfirm();
   const [isCreateRigOpen, setIsCreateRigOpen] = useState(false);
   const [convoysCollapsed, setConvoysCollapsed] = useState(false);
   const { open: openDrawer } = useDrawerStack();
@@ -467,11 +469,21 @@ export function TownOverviewPageClient({
                       </div>
                     </div>
                     <button
+                      type="button"
                       onClick={e => {
                         e.stopPropagation();
-                        if (confirm(`Delete rig "${rig.name}"?`)) {
-                          deleteRig.mutate({ rigId: rig.id });
-                        }
+                        void (async () => {
+                          if (
+                            await confirm({
+                              title: `Delete rig "${rig.name}"?`,
+                              description: 'This permanently removes the rig and cannot be undone.',
+                              confirmLabel: 'Delete rig',
+                              destructive: true,
+                            })
+                          ) {
+                            deleteRig.mutate({ rigId: rig.id });
+                          }
+                        })();
                       }}
                       className="rounded p-1 text-white/20 opacity-0 transition-all group-hover:opacity-100 hover:bg-red-500/10 hover:text-red-400"
                     >

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -23,6 +23,7 @@ import {
   Settings,
 } from 'lucide-react';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useConfirm } from '@/components/ui/confirm';
 import { motion, AnimatePresence } from 'motion/react';
 import Link from 'next/link';
 
@@ -39,6 +40,7 @@ export function RigDetailPageClient({
 }: RigDetailPageClientProps) {
   const townBasePath = basePathOverride ?? `/gastown/${townId}`;
   const trpc = useGastownTRPC();
+  const confirm = useConfirm();
   const [isCreateBeadOpen, setIsCreateBeadOpen] = useState(false);
   const [convoysCollapsed, setConvoysCollapsed] = useState(false);
   const { open: openDrawer } = useDrawerStack();
@@ -233,9 +235,18 @@ export function RigDetailPageClient({
               beads={beads}
               isLoading={beadsQuery.isLoading}
               onDeleteBead={beadId => {
-                if (confirm('Delete this bead?')) {
-                  deleteBead.mutate({ rigId, beadId });
-                }
+                void (async () => {
+                  if (
+                    await confirm({
+                      title: 'Delete this bead?',
+                      description: 'This permanently removes the bead and cannot be undone.',
+                      confirmLabel: 'Delete bead',
+                      destructive: true,
+                    })
+                  ) {
+                    deleteBead.mutate({ rigId, beadId });
+                  }
+                })();
               }}
               onSelectBead={bead => openDrawer({ type: 'bead', beadId: bead.bead_id, rigId })}
               onStartBead={beadId => startBead.mutate({ rigId, beadId })}
@@ -284,9 +295,18 @@ export function RigDetailPageClient({
                     isSelected={false}
                     onSelect={() => openDrawer({ type: 'agent', agentId: agent.id, rigId, townId })}
                     onDelete={() => {
-                      if (confirm(`Delete agent "${agent.name}"?`)) {
-                        deleteAgent.mutate({ rigId, agentId: agent.id });
-                      }
+                      void (async () => {
+                        if (
+                          await confirm({
+                            title: `Delete agent "${agent.name}"?`,
+                            description: 'This permanently removes the agent and cannot be undone.',
+                            confirmLabel: 'Delete agent',
+                            destructive: true,
+                          })
+                        ) {
+                          deleteAgent.mutate({ rigId, agentId: agent.id });
+                        }
+                      })();
                     }}
                   />
                 </motion.div>

--- a/apps/web/src/app/(app)/organizations/[id]/gastown/OrgTownListPageClient.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/gastown/OrgTownListPageClient.tsx
@@ -9,6 +9,7 @@ import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { GastownBackdrop } from '@/components/gastown/GastownBackdrop';
+import { useConfirm } from '@/components/ui/confirm';
 import { Plus, Factory, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
@@ -22,6 +23,7 @@ export function OrgTownListPageClient({ organizationId, role }: OrgTownListPageC
   const isOwner = role === 'owner';
   const router = useRouter();
   const trpc = useGastownTRPC();
+  const confirm = useConfirm();
   const onboardingUrl = `/gastown/onboarding?orgId=${encodeURIComponent(organizationId)}`;
 
   const queryClient = useQueryClient();
@@ -132,13 +134,21 @@ export function OrgTownListPageClient({ organizationId, role }: OrgTownListPageC
                 </div>
                 {isOwner && (
                   <button
+                    type="button"
                     onClick={e => {
                       e.stopPropagation();
-                      if (
-                        confirm(`Delete town "${town.name}"? This will also delete all its rigs.`)
-                      ) {
-                        deleteTown.mutate({ organizationId, townId: town.id });
-                      }
+                      void (async () => {
+                        if (
+                          await confirm({
+                            title: `Delete town "${town.name}"?`,
+                            description: 'This also deletes all of its rigs and cannot be undone.',
+                            confirmLabel: 'Delete town',
+                            destructive: true,
+                          })
+                        ) {
+                          deleteTown.mutate({ organizationId, townId: town.id });
+                        }
+                      })();
                     }}
                     className="rounded p-1.5 text-white/35 transition-colors hover:bg-red-500/10 hover:text-red-300"
                   >

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
@@ -315,12 +315,17 @@ function DailyChart({ data }: { data: DailyChartData[] }) {
 
 // --- Dev Nuke All Button ---
 
-function DevNukeAllButton() {
-  if (process.env.NODE_ENV !== 'development') return null;
+type NukeResult = {
+  destroyed: number;
+  total: number;
+  errors: { userId: string; error: string }[];
+};
 
+function DevNukeAllButton() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
+  const [result, setResult] = useState<NukeResult | null>(null);
 
   const nukeAll = useMutation(
     trpc.admin.kiloclawInstances.devNukeAll.mutationOptions({
@@ -331,14 +336,12 @@ function DevNukeAllButton() {
         void queryClient.invalidateQueries({
           queryKey: trpc.admin.kiloclawInstances.stats.queryKey(),
         });
-        const errorSuffix =
-          data.errors.length > 0
-            ? `\n${data.errors.length} failed:\n${data.errors.map(e => `  ${e.userId}: ${e.error}`).join('\n')}`
-            : '';
-        alert(`Destroyed ${data.destroyed}/${data.total} instances${errorSuffix}`);
+        setResult({ destroyed: data.destroyed, total: data.total, errors: data.errors });
       },
     })
   );
+
+  if (process.env.NODE_ENV !== 'development') return null;
 
   return (
     <>
@@ -366,6 +369,38 @@ function DevNukeAllButton() {
             >
               Nuke All
             </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Result summary — persistent so per-user failures stay readable. */}
+      <AlertDialog open={result !== null} onOpenChange={open => !open && setResult(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Destroyed {result?.destroyed ?? 0}/{result?.total ?? 0} instances
+            </AlertDialogTitle>
+            {result && result.errors.length > 0 ? (
+              <AlertDialogDescription>
+                {result.errors.length} failed to destroy.
+              </AlertDialogDescription>
+            ) : (
+              <AlertDialogDescription>All instances destroyed successfully.</AlertDialogDescription>
+            )}
+          </AlertDialogHeader>
+          {result && result.errors.length > 0 && (
+            <div className="max-h-64 overflow-y-auto rounded-md border border-border bg-surface-inset p-3">
+              <ul className="space-y-1 font-mono text-xs">
+                {result.errors.map(e => (
+                  <li key={e.userId}>
+                    <span className="text-muted-foreground">{e.userId}:</span> {e.error}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => setResult(null)}>Close</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
+++ b/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
@@ -41,6 +41,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { useConfirm } from '@/components/ui/confirm';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
@@ -119,6 +120,7 @@ function RolloutStatusPanel({
 }) {
   const [optimisticPercent, setOptimisticPercent] = useState<number | null>(null);
   const displayPercent = optimisticPercent ?? candidate?.rollout_percent ?? 0;
+  const confirm = useConfirm();
 
   /**
    * Commit a percent change with edge-case affordances:
@@ -144,12 +146,12 @@ function RolloutStatusPanel({
         });
       }
       if (next === 100 && previous < 100) {
-        const ok = window.confirm(
-          `Reached 100% — every instance now qualifies for ${imageTag}. ` +
-            `Promote it to :latest now? This replaces the current :latest. ` +
-            `New instances and unpinned upgrades will go to this image, ` +
-            `and the rollout will close.\n\nClick Cancel to keep observing at 100% without promoting.`
-        );
+        const ok = await confirm({
+          title: 'Promote to :latest now?',
+          description: `Reached 100% — every instance now qualifies for ${imageTag}. Promoting replaces the current :latest, sends new instances and unpinned upgrades to this image, and closes the rollout.`,
+          confirmLabel: 'Promote to :latest',
+          cancelLabel: 'Keep observing at 100%',
+        });
         if (ok) {
           await onPromoteCandidate(imageTag);
         }
@@ -221,13 +223,18 @@ function RolloutStatusPanel({
                 size="sm"
                 className="h-7 text-xs"
                 onClick={() => {
-                  if (
-                    window.confirm(
-                      `Promote ${candidate.image_tag} to :latest? This replaces the current :latest. New instances and unpinned upgrades will go to this image.`
-                    )
-                  ) {
-                    void onPromoteCandidate(candidate.image_tag);
-                  }
+                  void (async () => {
+                    if (
+                      await confirm({
+                        title: `Promote ${candidate.image_tag} to :latest?`,
+                        description:
+                          'This replaces the current :latest. New instances and unpinned upgrades will go to this image.',
+                        confirmLabel: 'Promote to :latest',
+                      })
+                    ) {
+                      void onPromoteCandidate(candidate.image_tag);
+                    }
+                  })();
                 }}
               >
                 <CheckCircle2 className="mr-1 h-3 w-3" /> Promote to :latest
@@ -685,6 +692,7 @@ function SortableHeader({
 export function VersionsTab() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const confirm = useConfirm();
   const [page, setPage] = useState(0);
   const [statusFilter, setStatusFilter] = useState<'all' | 'available' | 'disabled'>('all');
   const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
@@ -1184,15 +1192,23 @@ export function VersionsTab() {
                                   className="h-8 w-8 p-0"
                                   aria-label="Make :latest"
                                   onClick={() => {
-                                    if (
-                                      window.confirm(
-                                        isCandidate
-                                          ? `Promote ${version.image_tag} to :latest? This replaces the current :latest and ends the rollout.`
-                                          : `Mark ${version.image_tag} as :latest? This replaces the current :latest and clears any rollout percent on this image.`
-                                      )
-                                    ) {
-                                      void markLatest({ imageTag: version.image_tag });
-                                    }
+                                    void (async () => {
+                                      if (
+                                        await confirm({
+                                          title: isCandidate
+                                            ? `Promote ${version.image_tag} to :latest?`
+                                            : `Mark ${version.image_tag} as :latest?`,
+                                          description: isCandidate
+                                            ? 'This replaces the current :latest and ends the rollout.'
+                                            : 'This replaces the current :latest and clears any rollout percent on this image.',
+                                          confirmLabel: isCandidate
+                                            ? 'Promote to :latest'
+                                            : 'Make :latest',
+                                        })
+                                      ) {
+                                        void markLatest({ imageTag: version.image_tag });
+                                      }
+                                    })();
                                   }}
                                 >
                                   <Anchor className="h-4 w-4" />
@@ -1215,16 +1231,22 @@ export function VersionsTab() {
                                   className="h-8 w-8 p-0 text-red-500 hover:bg-red-950/30 hover:text-red-400"
                                   aria-label="Disable image"
                                   onClick={() => {
-                                    if (
-                                      window.confirm(
-                                        `Disable ${version.image_tag}? It will no longer be available for new pins or rollouts. Already pinned instances continue running it.`
-                                      )
-                                    ) {
-                                      void updateStatus({
-                                        imageTag: version.image_tag,
-                                        status: 'disabled',
-                                      });
-                                    }
+                                    void (async () => {
+                                      if (
+                                        await confirm({
+                                          title: `Disable ${version.image_tag}?`,
+                                          description:
+                                            'It will no longer be available for new pins or rollouts. Already pinned instances continue running it.',
+                                          confirmLabel: 'Disable image',
+                                          destructive: true,
+                                        })
+                                      ) {
+                                        void updateStatus({
+                                          imageTag: version.image_tag,
+                                          status: 'disabled',
+                                        });
+                                      }
+                                    })();
                                   }}
                                 >
                                   <Ban className="h-4 w-4" />

--- a/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationWorkOSCard.tsx
+++ b/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationWorkOSCard.tsx
@@ -11,6 +11,7 @@ import {
   DialogFooter,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import { useConfirm } from '@/components/ui/confirm';
 import { Shield, Loader2, CheckCircle, Edit, X, Trash2 } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
@@ -239,16 +240,20 @@ export function OrganizationWorkOSCard({ organizationId }: OrganizationWorkOSCar
   } = useOrganizationSSOConfig(organizationId);
   const createConfig = useCreateSSOConfig();
   const deleteConfig = useDeleteSSOConfig();
+  const confirm = useConfirm();
 
   const handleEnrollInWorkOS = () => {
     createConfig.mutate({ organizationId });
   };
 
-  const handleDeleteSSO = () => {
+  const handleDeleteSSO = async () => {
     if (
-      confirm(
-        'Are you sure you want to delete the SSO configuration? This action cannot be undone.'
-      )
+      await confirm({
+        title: 'Delete the SSO configuration?',
+        description: 'This permanently removes the WorkOS SSO configuration and cannot be undone.',
+        confirmLabel: 'Delete configuration',
+        destructive: true,
+      })
     ) {
       deleteConfig.mutate({ organizationId });
     }

--- a/apps/web/src/app/admin/debug/ai-attribution/AIAttributionDebug.tsx
+++ b/apps/web/src/app/admin/debug/ai-attribution/AIAttributionDebug.tsx
@@ -9,6 +9,7 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
+import { useConfirm } from '@/components/ui/confirm';
 import { Loader2, Search, Plus, Minus, CheckCircle, XCircle, Clock, Trash2 } from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
@@ -17,6 +18,7 @@ import { ProjectCombobox, FilePathCombobox, BranchCombobox } from './CodeIndexin
 
 export function AIAttributionDebug() {
   const trpc = useTRPC();
+  const confirm = useConfirm();
   const [organizationId, setOrganizationId] = useState('');
   const [projectId, setProjectId] = useState('');
   const [filePath, setFilePath] = useState('');
@@ -44,11 +46,14 @@ export function AIAttributionDebug() {
     })
   );
 
-  const handleDeleteAttribution = (attributionId: number) => {
+  const handleDeleteAttribution = async (attributionId: number) => {
     if (
-      window.confirm(
-        `Are you sure you want to delete attribution #${attributionId}? This will also delete all associated lines added/removed records.`
-      )
+      await confirm({
+        title: `Delete attribution #${attributionId}?`,
+        description: 'This also deletes all associated lines added/removed records.',
+        confirmLabel: 'Delete attribution',
+        destructive: true,
+      })
     ) {
       deleteAttributionMutation.mutate({
         organization_id: organizationId,

--- a/apps/web/src/components/Providers.tsx
+++ b/apps/web/src/components/Providers.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Toaster } from '@/components/ui/sonner';
+import { ConfirmProvider } from '@/components/ui/confirm';
 import { TRPCContext } from '@/lib/trpc/client';
 import { GastownTRPCProvider, createGastownTRPCClient } from '@/lib/gastown/trpc';
 import { WastelandTRPCProvider, createWastelandTRPCClient } from '@/lib/wasteland/trpc';
@@ -33,7 +34,7 @@ export function Providers({ children }: PropsWithChildren) {
             <WastelandTRPCProvider trpcClient={wastelandClient} queryClient={queryClient}>
               <SessionProvider>
                 <SignInHintEmailSyncer />
-                {children}
+                <ConfirmProvider>{children}</ConfirmProvider>
               </SessionProvider>
             </WastelandTRPCProvider>
           </GastownTRPCProvider>

--- a/apps/web/src/components/deployments/DeploymentDetails.tsx
+++ b/apps/web/src/components/deployments/DeploymentDetails.tsx
@@ -15,6 +15,7 @@ import { Badge } from '@/components/ui/badge';
 import { formatDistanceToNow } from 'date-fns';
 import { isDeploymentFinished, isDeploymentInProgress } from '@/lib/user-deployments/types';
 import { toast } from 'sonner';
+import { useConfirm } from '@/components/ui/confirm';
 import Link from 'next/link';
 
 type DeploymentDetailsProps = {
@@ -26,6 +27,7 @@ type DeploymentDetailsProps = {
 export function DeploymentDetails({ deploymentId, isOpen, onClose }: DeploymentDetailsProps) {
   const [activeTab, setActiveTab] = useState<'overview' | 'environment' | 'password'>('overview');
   const { queries, mutations, organizationId } = useDeploymentQueries();
+  const confirm = useConfirm();
 
   // Check if password features are available (org-only)
   const hasPasswordFeature = !!mutations.setPassword;
@@ -62,10 +64,18 @@ export function DeploymentDetails({ deploymentId, isOpen, onClose }: DeploymentD
     );
   };
 
-  const handleCancel = () => {
+  const handleCancel = async () => {
     if (!latestBuild) return;
 
-    if (window.confirm('Are you sure you want to cancel this build?')) {
+    if (
+      await confirm({
+        title: 'Cancel this build?',
+        description: 'The in-progress build will stop. You can redeploy afterwards.',
+        confirmLabel: 'Cancel build',
+        cancelLabel: 'Keep building',
+        destructive: true,
+      })
+    ) {
       cancelBuildMutation.mutate(
         { deploymentId, buildId: latestBuild.id },
         {
@@ -80,11 +90,14 @@ export function DeploymentDetails({ deploymentId, isOpen, onClose }: DeploymentD
     }
   };
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (
-      window.confirm(
-        'Are you sure you want to delete this deployment? This action cannot be undone.'
-      )
+      await confirm({
+        title: 'Delete this deployment?',
+        description: 'This permanently removes the deployment and cannot be undone.',
+        confirmLabel: 'Delete deployment',
+        destructive: true,
+      })
     ) {
       deleteDeploymentMutation.mutate(
         { id: deploymentId },

--- a/apps/web/src/components/deployments/EnvironmentSettings.tsx
+++ b/apps/web/src/components/deployments/EnvironmentSettings.tsx
@@ -2,6 +2,16 @@
 
 import { useState } from 'react';
 import { Button } from '@/components/Button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import type { EnvVarInputValue } from './EnvVarInput';
 import { EnvVarInput } from './EnvVarInput';
 import { Loader2, Plus, EyeOff, Pencil, Trash2, AlertCircle } from 'lucide-react';
@@ -305,17 +315,17 @@ export function EnvironmentSettings({ deploymentId }: EnvironmentSettingsProps) 
                         originalKey: envVar.key,
                       })
                     }
-                    className="gap-1.5"
+                    className="border-border text-foreground hover:bg-surface-hover hover:text-foreground active:bg-surface-selected focus:ring-ring gap-1.5"
                     aria-label="Edit variable"
                   >
                     <Pencil className="size-4" />
                     Edit
                   </Button>
                   <Button
-                    variant="danger"
+                    variant="outline"
                     size="sm"
                     onClick={() => setDeleteConfirm(envVar.key)}
-                    className="gap-1.5"
+                    className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive focus:ring-destructive/30 gap-1.5"
                     aria-label="Delete variable"
                   >
                     <Trash2 className="size-4" />
@@ -338,47 +348,48 @@ export function EnvironmentSettings({ deploymentId }: EnvironmentSettingsProps) 
       )}
 
       {/* Delete Confirmation Dialog */}
-      {deleteConfirm && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="w-full max-w-md rounded-lg border border-gray-700 bg-gray-900 p-6 shadow-xl">
-            <h3 className="text-lg font-semibold text-gray-100">Delete Environment Variable</h3>
-            <p className="mt-4 text-sm text-gray-400">
-              Are you sure you want to delete the environment variable{' '}
-              <code className="rounded bg-gray-700 px-1.5 py-0.5 font-mono text-gray-100">
+      <AlertDialog
+        open={deleteConfirm !== null}
+        onOpenChange={open => {
+          if (!open && !deleteEnvVarMutation.isPending) setDeleteConfirm(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this environment variable?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently removes{' '}
+              <code className="bg-surface-overlay text-foreground rounded px-1.5 py-0.5 font-mono">
                 {deleteConfirm}
-              </code>
-              ? This action cannot be undone.
-            </p>
-            <div className="mt-6 flex justify-end gap-2">
-              <Button
-                variant="secondary"
-                onClick={() => setDeleteConfirm(null)}
-                disabled={deleteEnvVarMutation.isPending}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="danger"
-                onClick={() => handleDeleteVariable(deleteConfirm)}
-                disabled={deleteEnvVarMutation.isPending}
-                className="gap-1.5"
-              >
-                {deleteEnvVarMutation.isPending ? (
-                  <>
-                    <Loader2 className="size-4 animate-spin" />
-                    Deleting...
-                  </>
-                ) : (
-                  <>
-                    <Trash2 className="size-4" />
-                    Delete Variable
-                  </>
-                )}
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+              </code>{' '}
+              and cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteEnvVarMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                if (deleteConfirm) handleDeleteVariable(deleteConfirm);
+              }}
+              disabled={deleteEnvVarMutation.isPending}
+              className="gap-1.5"
+            >
+              {deleteEnvVarMutation.isPending ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                <>
+                  <Trash2 className="size-4" />
+                  Delete variable
+                </>
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/web/src/components/dev/CreateKilocodeOrgButton.tsx
+++ b/apps/web/src/components/dev/CreateKilocodeOrgButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 
 export function CreateKilocodeOrgButton() {
   const [isLoading, setIsLoading] = useState(false);
@@ -34,7 +35,7 @@ export function CreateKilocodeOrgButton() {
       router.push(`/organizations/${data.organizationId}`);
     } catch (error) {
       console.error('Error creating organization:', error);
-      alert(
+      toast.error(
         error instanceof Error ? error.message : 'Failed to create organization. Please try again.'
       );
     } finally {

--- a/apps/web/src/components/dev/DevConsumeCreditsButton.tsx
+++ b/apps/web/src/components/dev/DevConsumeCreditsButton.tsx
@@ -5,9 +5,11 @@ import { Button } from '@/components/Button';
 import { Input } from '@/components/ui/input';
 import { DollarSign } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 
 export function DevConsumeCreditsButton() {
   const [amount, setAmount] = useState('');
+  const [amountError, setAmountError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
@@ -16,9 +18,10 @@ export function DevConsumeCreditsButton() {
   const handleConsume = async () => {
     const dollarAmount = parseFloat(amount);
     if (isNaN(dollarAmount) || dollarAmount <= 0) {
-      alert('Please enter a valid amount greater than 0');
+      setAmountError('Enter an amount greater than 0.');
       return;
     }
+    setAmountError(null);
 
     setIsLoading(true);
     try {
@@ -40,7 +43,7 @@ export function DevConsumeCreditsButton() {
       router.refresh();
     } catch (error) {
       console.error('Error consuming credits:', error);
-      alert(
+      toast.error(
         error instanceof Error ? error.message : 'Failed to consume credits. Please try again.'
       );
     } finally {
@@ -57,9 +60,14 @@ export function DevConsumeCreditsButton() {
           min="0"
           placeholder="Amount in dollars"
           value={amount}
-          onChange={e => setAmount(e.target.value)}
+          onChange={e => {
+            setAmount(e.target.value);
+            if (amountError) setAmountError(null);
+          }}
           className="max-w-[200px]"
           disabled={isLoading}
+          aria-invalid={amountError !== null}
+          aria-describedby={amountError ? 'dev-consume-amount-error' : undefined}
         />
         <Button
           type="button"
@@ -73,6 +81,11 @@ export function DevConsumeCreditsButton() {
           {isLoading ? 'Consuming... (very slow, be patient)' : 'Consume'}
         </Button>
       </div>
+      {amountError && (
+        <p id="dev-consume-amount-error" className="text-destructive text-xs">
+          {amountError}
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/gastown/CreateBeadDrawer.tsx
+++ b/apps/web/src/components/gastown/CreateBeadDrawer.tsx
@@ -2,12 +2,12 @@
 
 import { useState, useEffect, useRef } from 'react';
 import dynamic from 'next/dynamic';
-import { Drawer } from 'vaul';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { toast } from 'sonner';
 import { Button } from '@/components/Button';
 import { Input } from '@/components/ui/input';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { X, Plus, Sparkles, Loader2 } from 'lucide-react';
 
 const MDXEditorComponent = dynamic(
@@ -182,175 +182,157 @@ export function CreateBeadDrawer({ rigId, townId, isOpen, onClose }: CreateBeadD
   const allLabels = [...labels, ...aiLabels];
 
   return (
-    <Drawer.Root open={isOpen} onOpenChange={open => !open && handleClose()} direction="right">
-      <Drawer.Portal>
-        <Drawer.Overlay className="fixed inset-0 z-50 bg-black/60" />
-        <Drawer.Content
-          className="fixed top-0 right-0 bottom-0 z-50 flex w-[620px] max-w-[94vw] flex-col outline-none"
-          style={{ '--initial-transform': 'calc(100% + 8px)' } as React.CSSProperties}
-        >
-          <div className="flex h-full flex-col overflow-hidden rounded-l-2xl border-l border-white/[0.08] bg-[oklch(0.12_0_0)]">
-            {/* Header */}
-            <div className="flex items-center justify-between border-b border-white/[0.06] px-5 py-4">
-              <Drawer.Title className="text-base font-semibold text-white/90">
-                New Bead
-              </Drawer.Title>
-              <button
-                onClick={handleClose}
-                className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-white/5 hover:text-white/60"
-              >
-                <X className="size-4" />
-              </button>
+    <Sheet open={isOpen} onOpenChange={open => !open && handleClose()}>
+      <SheetContent side="right" className="w-[620px] max-w-[94vw] gap-0 p-0 sm:max-w-[620px]">
+        {/* Header */}
+        <SheetHeader className="border-b border-white/[0.06] px-5 py-4">
+          <SheetTitle className="text-base font-semibold text-white/90">New Bead</SheetTitle>
+        </SheetHeader>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-hidden">
+          <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-5">
+            {/* Title */}
+            <div>
+              <div className="mb-1.5 flex items-center gap-1.5">
+                <label className="text-xs font-medium text-white/50">Title</label>
+                {isEnriching && <Loader2 className="size-3 animate-spin text-white/30" />}
+              </div>
+              <Input
+                value={title}
+                onChange={handleTitleChange}
+                placeholder="What needs to be done?"
+                autoFocus
+                className={`border-white/[0.08] bg-black/20 text-white/90 placeholder:text-white/25 focus:border-white/20 ${isEnriching && !userEditedTitle ? 'animate-pulse' : ''}`}
+              />
             </div>
 
-            {/* Form */}
-            <form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-hidden">
-              <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-5">
-                {/* Title */}
-                <div>
-                  <div className="mb-1.5 flex items-center gap-1.5">
-                    <label className="text-xs font-medium text-white/50">Title</label>
-                    {isEnriching && <Loader2 className="size-3 animate-spin text-white/30" />}
-                  </div>
-                  <Input
-                    value={title}
-                    onChange={handleTitleChange}
-                    placeholder="What needs to be done?"
-                    autoFocus
-                    className={`border-white/[0.08] bg-black/20 text-white/90 placeholder:text-white/25 focus:border-white/20 ${isEnriching && !userEditedTitle ? 'animate-pulse' : ''}`}
-                  />
-                </div>
-
-                {/* Labels */}
-                <div>
-                  <div className="mb-1.5 flex items-center gap-1.5">
-                    <label className="text-xs font-medium text-white/50">Labels</label>
-                    {isEnriching && <Loader2 className="size-3 animate-spin text-white/30" />}
-                  </div>
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    {/* AI-suggested labels */}
-                    {aiLabels.map(label => (
-                      <span
-                        key={`ai-${label}`}
-                        className="inline-flex items-center gap-1 rounded-md border border-[color:oklch(0.95_0.15_108_/_0.25)] bg-[color:oklch(0.95_0.15_108_/_0.08)] px-2 py-0.5 text-[11px] text-[color:oklch(0.95_0.15_108_/_0.8)]"
-                      >
-                        <Sparkles className="size-2.5" />
-                        {label}
-                        <button
-                          type="button"
-                          onClick={() => removeAiLabel(label)}
-                          className="ml-0.5 opacity-60 hover:opacity-100"
-                        >
-                          <X className="size-2.5" />
-                        </button>
-                      </span>
-                    ))}
-                    {/* Manually added labels */}
-                    {labels.map(label => (
-                      <span
-                        key={`manual-${label}`}
-                        className="inline-flex items-center gap-1 rounded-md border border-white/[0.12] bg-white/[0.06] px-2 py-0.5 text-[11px] text-white/60"
-                      >
-                        {label}
-                        <button
-                          type="button"
-                          onClick={() => removeLabel(label)}
-                          className="ml-0.5 opacity-60 hover:opacity-100"
-                        >
-                          <X className="size-2.5" />
-                        </button>
-                      </span>
-                    ))}
-                    {/* Add label input */}
-                    {showLabelInput ? (
-                      <input
-                        autoFocus
-                        value={labelInput}
-                        onChange={e => setLabelInput(e.target.value)}
-                        onKeyDown={handleLabelKeyDown}
-                        onBlur={handleAddLabel}
-                        placeholder="label name"
-                        className="rounded-md border border-white/[0.12] bg-white/[0.04] px-2 py-0.5 text-[11px] text-white/70 placeholder:text-white/25 outline-none focus:border-white/20"
-                        style={{ width: '80px' }}
-                      />
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => setShowLabelInput(true)}
-                        className="inline-flex items-center gap-0.5 rounded-md border border-dashed border-white/[0.1] px-2 py-0.5 text-[11px] text-white/30 transition-colors hover:border-white/20 hover:text-white/50"
-                      >
-                        <Plus className="size-2.5" />
-                        add
-                      </button>
-                    )}
-                    {allLabels.length === 0 && !showLabelInput && (
-                      <span className="text-[11px] text-white/20">No labels yet</span>
-                    )}
-                  </div>
-                </div>
-
-                {/* Body / MDXEditor */}
-                <div className="flex-1">
-                  <label className="mb-1.5 block text-xs font-medium text-white/50">
-                    Description
-                  </label>
-                  <MDXEditorComponent
-                    value={body}
-                    onChange={setBody}
-                    placeholder="Describe the work..."
-                  />
-                </div>
+            {/* Labels */}
+            <div>
+              <div className="mb-1.5 flex items-center gap-1.5">
+                <label className="text-xs font-medium text-white/50">Labels</label>
+                {isEnriching && <Loader2 className="size-3 animate-spin text-white/30" />}
               </div>
-
-              {/* Footer */}
-              <div className="border-t border-white/[0.06] px-5 py-4">
-                {/* Start immediately toggle */}
-                <div className="mb-4">
-                  <label className="flex cursor-pointer items-start gap-2.5">
-                    <input
-                      type="checkbox"
-                      checked={startImmediately}
-                      onChange={e => setStartImmediately(e.target.checked)}
-                      className="mt-0.5 size-4 cursor-pointer rounded border-white/20 bg-white/5 accent-[color:oklch(0.95_0.15_108)]"
-                    />
-                    <div>
-                      <span className="text-sm text-white/75">Start immediately</span>
-                      {!startImmediately && (
-                        <p className="mt-0.5 text-xs text-white/35">
-                          The mayor will be notified and can help plan this work
-                        </p>
-                      )}
-                    </div>
-                  </label>
-                </div>
-
-                {/* Action buttons */}
-                <div className="flex justify-end gap-2">
-                  <Button variant="secondary" size="md" type="button" onClick={handleClose}>
-                    Cancel
-                  </Button>
-                  <Button
-                    variant="primary"
-                    size="md"
-                    type="submit"
-                    disabled={!title.trim() || createBead.isPending}
-                    className="bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+              <div className="flex flex-wrap items-center gap-1.5">
+                {/* AI-suggested labels */}
+                {aiLabels.map(label => (
+                  <span
+                    key={`ai-${label}`}
+                    className="inline-flex items-center gap-1 rounded-md border border-[color:oklch(0.95_0.15_108_/_0.25)] bg-[color:oklch(0.95_0.15_108_/_0.08)] px-2 py-0.5 text-[11px] text-[color:oklch(0.95_0.15_108_/_0.8)]"
                   >
-                    {createBead.isPending ? (
-                      <>
-                        <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-                        Creating...
-                      </>
-                    ) : (
-                      'Create'
-                    )}
-                  </Button>
-                </div>
+                    <Sparkles className="size-2.5" />
+                    {label}
+                    <button
+                      type="button"
+                      onClick={() => removeAiLabel(label)}
+                      className="ml-0.5 opacity-60 hover:opacity-100"
+                    >
+                      <X className="size-2.5" />
+                    </button>
+                  </span>
+                ))}
+                {/* Manually added labels */}
+                {labels.map(label => (
+                  <span
+                    key={`manual-${label}`}
+                    className="inline-flex items-center gap-1 rounded-md border border-white/[0.12] bg-white/[0.06] px-2 py-0.5 text-[11px] text-white/60"
+                  >
+                    {label}
+                    <button
+                      type="button"
+                      onClick={() => removeLabel(label)}
+                      className="ml-0.5 opacity-60 hover:opacity-100"
+                    >
+                      <X className="size-2.5" />
+                    </button>
+                  </span>
+                ))}
+                {/* Add label input */}
+                {showLabelInput ? (
+                  <input
+                    autoFocus
+                    value={labelInput}
+                    onChange={e => setLabelInput(e.target.value)}
+                    onKeyDown={handleLabelKeyDown}
+                    onBlur={handleAddLabel}
+                    placeholder="label name"
+                    className="rounded-md border border-white/[0.12] bg-white/[0.04] px-2 py-0.5 text-[11px] text-white/70 placeholder:text-white/25 outline-none focus:border-white/20"
+                    style={{ width: '80px' }}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setShowLabelInput(true)}
+                    className="inline-flex items-center gap-0.5 rounded-md border border-dashed border-white/[0.1] px-2 py-0.5 text-[11px] text-white/30 transition-colors hover:border-white/20 hover:text-white/50"
+                  >
+                    <Plus className="size-2.5" />
+                    add
+                  </button>
+                )}
+                {allLabels.length === 0 && !showLabelInput && (
+                  <span className="text-[11px] text-white/20">No labels yet</span>
+                )}
               </div>
-            </form>
+            </div>
+
+            {/* Body / MDXEditor */}
+            <div className="flex-1">
+              <label className="mb-1.5 block text-xs font-medium text-white/50">Description</label>
+              <MDXEditorComponent
+                value={body}
+                onChange={setBody}
+                placeholder="Describe the work..."
+              />
+            </div>
           </div>
-        </Drawer.Content>
-      </Drawer.Portal>
-    </Drawer.Root>
+
+          {/* Footer */}
+          <div className="border-t border-white/[0.06] px-5 py-4">
+            {/* Start immediately toggle */}
+            <div className="mb-4">
+              <label className="flex cursor-pointer items-start gap-2.5">
+                <input
+                  type="checkbox"
+                  checked={startImmediately}
+                  onChange={e => setStartImmediately(e.target.checked)}
+                  className="mt-0.5 size-4 cursor-pointer rounded border-white/20 bg-white/5 accent-[color:oklch(0.95_0.15_108)]"
+                />
+                <div>
+                  <span className="text-sm text-white/75">Start immediately</span>
+                  {!startImmediately && (
+                    <p className="mt-0.5 text-xs text-white/35">
+                      The mayor will be notified and can help plan this work
+                    </p>
+                  )}
+                </div>
+              </label>
+            </div>
+
+            {/* Action buttons */}
+            <div className="flex justify-end gap-2">
+              <Button variant="secondary" size="md" type="button" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                size="md"
+                type="submit"
+                disabled={!title.trim() || createBead.isPending}
+                className="bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+              >
+                {createBead.isPending ? (
+                  <>
+                    <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                    Creating...
+                  </>
+                ) : (
+                  'Create'
+                )}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/apps/web/src/components/gastown/OnboardingTooltips.tsx
+++ b/apps/web/src/components/gastown/OnboardingTooltips.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { X } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 import { useOnboardingTooltips, ONBOARDING_TOOLTIPS } from './useOnboardingTooltips';
 
 // ── localStorage key for tracking whether first-task completion was detected ──
@@ -99,7 +100,7 @@ export function OnboardingTooltips({ townId }: OnboardingTooltipsProps) {
 
 // ── Individual tooltip popover ───────────────────────────────────────────
 
-function OnboardingTooltipPopover({
+export function OnboardingTooltipPopover({
   tooltip,
   onDismiss,
   onDismissAll,
@@ -108,23 +109,20 @@ function OnboardingTooltipPopover({
   onDismiss: () => void;
   onDismissAll: () => void;
 }) {
+  const [anchorEl, setAnchorEl] = useState<Element | null>(null);
   const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
 
-  // Find the anchor element via data attribute and observe its position
+  // Find the anchor element via its data attribute and track its rect so the
+  // highlight ring stays aligned on scroll/resize. Radix repositions the
+  // popover itself via the virtual anchor below.
   useEffect(() => {
     const findAnchor = () => {
       const el = document.querySelector(`[data-onboarding-target="${tooltip.target}"]`);
-      if (el) {
-        setAnchorRect(el.getBoundingClientRect());
-      }
+      setAnchorEl(el);
+      if (el) setAnchorRect(el.getBoundingClientRect());
     };
 
-    // Initial find with a brief delay for DOM rendering
     const timer = setTimeout(findAnchor, 300);
-
-    // Re-find on scroll/resize
     const handleUpdate = () => findAnchor();
     window.addEventListener('resize', handleUpdate);
     window.addEventListener('scroll', handleUpdate, true);
@@ -136,127 +134,79 @@ function OnboardingTooltipPopover({
     };
   }, [tooltip.target]);
 
-  // Calculate position relative to anchor
-  useEffect(() => {
-    if (!anchorRect || !popoverRef.current) return;
-
-    const popoverRect = popoverRef.current.getBoundingClientRect();
-    const gap = 12;
-
-    // Position to the right of the anchor by default
-    let top = anchorRect.top + anchorRect.height / 2 - popoverRect.height / 2;
-    let left = anchorRect.right + gap;
-
-    // If too far right, position to the left
-    if (left + popoverRect.width > window.innerWidth - 16) {
-      left = anchorRect.left - popoverRect.width - gap;
-    }
-
-    // If still off-screen (e.g., for terminal at bottom), position above
-    if (left < 16) {
-      left = anchorRect.left + anchorRect.width / 2 - popoverRect.width / 2;
-      top = anchorRect.top - popoverRect.height - gap;
-    }
-
-    // Clamp to viewport
-    top = Math.max(8, Math.min(top, window.innerHeight - popoverRect.height - 8));
-    left = Math.max(8, Math.min(left, window.innerWidth - popoverRect.width - 8));
-
-    setPosition({ top, left });
-  }, [anchorRect]);
-
-  // Dismiss on Escape key
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onDismiss();
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onDismiss]);
-
-  // Click outside to dismiss
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (
-        popoverRef.current &&
-        e.target instanceof Node &&
-        !popoverRef.current.contains(e.target)
-      ) {
-        onDismiss();
-      }
+  const virtualRef = {
+    current: {
+      getBoundingClientRect: () => anchorEl?.getBoundingClientRect() ?? new DOMRect(),
     },
-    [onDismiss]
-  );
+  };
 
-  if (!anchorRect) return null;
+  if (!anchorEl || !anchorRect) return null;
 
   return (
-    <AnimatePresence>
-      {/* Semi-transparent backdrop to catch outside clicks */}
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.15 }}
-        className="fixed inset-0 z-[100]"
-        onClick={handleBackdropClick}
-      >
-        {/* Highlight ring on the anchor element */}
+    <>
+      {/* Highlight ring on the anchor element (Radix popover is non-modal, so
+          there is no backdrop — the ring is portaled on top of the page). */}
+      {createPortal(
         <div
-          className="pointer-events-none absolute rounded-md ring-2 ring-[color:oklch(85%_0.15_250)] ring-offset-2 ring-offset-transparent"
+          aria-hidden="true"
+          className="pointer-events-none fixed z-50 rounded-md ring-2 ring-[color:oklch(85%_0.15_250)] ring-offset-2 ring-offset-transparent"
           style={{
             top: anchorRect.top - 4,
             left: anchorRect.left - 4,
             width: anchorRect.width + 8,
             height: anchorRect.height + 8,
           }}
-        />
+        />,
+        document.body
+      )}
 
-        {/* Popover content */}
-        <motion.div
-          ref={popoverRef}
-          initial={{ opacity: 0, scale: 0.95, y: 4 }}
-          animate={{ opacity: 1, scale: 1, y: 0 }}
-          exit={{ opacity: 0, scale: 0.95, y: 4 }}
-          transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
-          className="pointer-events-auto absolute z-[101] w-72 rounded-lg border border-white/[0.15] bg-[#1a1a2e] p-4 shadow-2xl"
-          style={position ?? { top: anchorRect.top, left: anchorRect.right + 12, opacity: 0 }}
+      <Popover
+        open
+        onOpenChange={open => {
+          if (!open) onDismiss();
+        }}
+      >
+        <PopoverAnchor virtualRef={virtualRef} />
+        <PopoverContent
+          side="right"
+          align="center"
+          sideOffset={12}
+          collisionPadding={8}
+          className="w-72 p-4 motion-reduce:animate-none"
+          onOpenAutoFocus={e => e.preventDefault()}
         >
           {/* Close button */}
           <button
-            onClick={e => {
-              e.stopPropagation();
-              onDismiss();
-            }}
-            className="absolute top-2 right-2 rounded-md p-1 text-white/30 transition-colors hover:bg-white/[0.08] hover:text-white/60"
+            type="button"
+            onClick={onDismiss}
+            aria-label="Dismiss tip"
+            className="text-muted-foreground hover:bg-surface-hover hover:text-foreground absolute top-2 right-2 rounded-md p-1 transition-colors"
           >
             <X className="size-3.5" />
           </button>
 
           {/* Title */}
-          <div className="mb-1 text-sm font-semibold text-white/90">{tooltip.title}</div>
+          <div className="text-foreground mb-1 text-sm font-semibold">{tooltip.title}</div>
 
           {/* Description */}
-          <p className="mb-3 text-xs leading-relaxed text-white/55">{tooltip.description}</p>
+          <p className="text-muted-foreground mb-3 text-xs leading-relaxed">
+            {tooltip.description}
+          </p>
 
           {/* Actions */}
           <div className="flex items-center justify-between">
             <button
-              onClick={e => {
-                e.stopPropagation();
-                onDismissAll();
-              }}
-              className="text-[10px] text-white/25 transition-colors hover:text-white/50"
+              type="button"
+              onClick={onDismissAll}
+              className="text-muted-foreground hover:text-foreground text-[10px] transition-colors"
             >
               Don&apos;t show these again
             </button>
 
             <button
-              onClick={e => {
-                e.stopPropagation();
-                onDismiss();
-              }}
-              className="rounded-md bg-white/[0.08] px-3 py-1 text-xs font-medium text-white/70 transition-colors hover:bg-white/[0.14] hover:text-white/90"
+              type="button"
+              onClick={onDismiss}
+              className="bg-surface-hover text-foreground hover:bg-surface-selected rounded-md px-3 py-1 text-xs font-medium transition-colors"
             >
               Got it
             </button>
@@ -268,13 +218,13 @@ function OnboardingTooltipPopover({
               <div
                 key={t.id}
                 className={`size-1.5 rounded-full transition-colors ${
-                  t.id === tooltip.id ? 'bg-[color:oklch(85%_0.15_250)]' : 'bg-white/15'
+                  t.id === tooltip.id ? 'bg-[color:oklch(85%_0.15_250)]' : 'bg-border'
                 }`}
               />
             ))}
           </div>
-        </motion.div>
-      </motion.div>
-    </AnimatePresence>
+        </PopoverContent>
+      </Popover>
+    </>
   );
 }

--- a/apps/web/src/components/gastown/TerminalBar.tsx
+++ b/apps/web/src/components/gastown/TerminalBar.tsx
@@ -6,6 +6,13 @@ import { useRouter } from 'next/navigation';
 import { useGastownTRPC, gastownWsUrl, type GastownOutputs } from '@/lib/gastown/trpc';
 
 import { useSidebar } from '@/components/ui/sidebar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import {
   useTerminalBar,
   COLLAPSED_SIZE,
@@ -502,30 +509,6 @@ function TabBar({
   setPosition: (position: TerminalPosition) => void;
   closeTab: (tabId: string) => void;
 }) {
-  const [showPositionPicker, setShowPositionPicker] = useState(false);
-  const [showBugMenu, setShowBugMenu] = useState(false);
-  const pickerRef = useRef<HTMLDivElement>(null);
-  const bugMenuRef = useRef<HTMLDivElement>(null);
-
-  // Close picker on outside click
-  useEffect(() => {
-    if (!showPositionPicker && !showBugMenu) return;
-    const handler = (e: MouseEvent) => {
-      if (
-        showPositionPicker &&
-        pickerRef.current &&
-        !pickerRef.current.contains(e.target as Node)
-      ) {
-        setShowPositionPicker(false);
-      }
-      if (showBugMenu && bugMenuRef.current && !bugMenuRef.current.contains(e.target as Node)) {
-        setShowBugMenu(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [showPositionPicker, showBugMenu]);
-
   const borderClass = horizontal ? 'border-b border-white/[0.06]' : 'border-r border-white/[0.06]';
 
   return (
@@ -612,50 +595,13 @@ function TabBar({
 
       {/* Bug report dropdown */}
       {horizontal && (
-        <div ref={bugMenuRef} className="relative shrink-0">
-          <button
-            onClick={() => setShowBugMenu(p => !p)}
-            className="mr-2 flex items-center gap-1 rounded px-2 py-1 text-[10px] text-white/30 transition-colors hover:bg-white/[0.04] hover:text-white/50"
-          >
-            <Bug className="size-3" />
-            <span className="hidden sm:inline">Report a Bug</span>
-          </button>
-          {showBugMenu && (
-            <BugReportMenu
-              position={position}
-              triggerRef={bugMenuRef}
-              onClose={() => setShowBugMenu(false)}
-            />
-          )}
+        <div className="shrink-0">
+          <BugReportMenu />
         </div>
       )}
 
       {/* Position picker */}
-      <div ref={pickerRef}>
-        <button
-          onClick={() => setShowPositionPicker(p => !p)}
-          className={`flex items-center justify-center text-white/30 transition-colors hover:text-white/50 ${
-            horizontal ? 'h-full px-2' : 'w-full py-2'
-          }`}
-          title="Change terminal position"
-        >
-          {position === 'bottom' && <PanelBottom className="size-3.5" />}
-          {position === 'top' && <PanelTop className="size-3.5" />}
-          {position === 'left' && <PanelLeft className="size-3.5" />}
-          {position === 'right' && <PanelRight className="size-3.5" />}
-        </button>
-        {showPositionPicker && (
-          <PositionPicker
-            current={position}
-            onSelect={p => {
-              setPosition(p);
-              setShowPositionPicker(false);
-            }}
-            position={position}
-            triggerRef={pickerRef}
-          />
-        )}
-      </div>
+      <PositionPicker current={position} onSelect={setPosition} horizontal={horizontal} />
     </div>
   );
 }
@@ -669,76 +615,54 @@ const POSITION_OPTIONS: { value: TerminalPosition; label: string; Icon: typeof P
   { value: 'right', label: 'Right', Icon: PanelRight },
 ];
 
-function PositionPicker({
+export function PositionPicker({
   current,
   onSelect,
-  position,
-  triggerRef,
+  horizontal,
 }: {
   current: TerminalPosition;
   onSelect: (p: TerminalPosition) => void;
-  position: TerminalPosition;
-  triggerRef: React.RefObject<HTMLDivElement | null>;
+  horizontal: boolean;
 }) {
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const [style, setStyle] = useState<React.CSSProperties>({ opacity: 0 });
-
-  useEffect(() => {
-    const trigger = triggerRef.current;
-    const popover = popoverRef.current;
-    if (!trigger || !popover) return;
-    const tr = trigger.getBoundingClientRect();
-    const pr = popover.getBoundingClientRect();
-    const gap = 4;
-
-    let top: number;
-    let left: number;
-
-    if (position === 'bottom') {
-      top = tr.top - pr.height - gap;
-      left = tr.right - pr.width;
-    } else if (position === 'top') {
-      top = tr.bottom + gap;
-      left = tr.right - pr.width;
-    } else if (position === 'left') {
-      top = tr.top;
-      left = tr.right + gap;
-    } else {
-      // right
-      top = tr.top;
-      left = tr.left - pr.width - gap;
-    }
-
-    // Clamp to viewport
-    top = Math.max(4, Math.min(top, window.innerHeight - pr.height - 4));
-    left = Math.max(4, Math.min(left, window.innerWidth - pr.width - 4));
-
-    setStyle({ top, left, opacity: 1 });
-  }, [position, triggerRef]);
+  const [open, setOpen] = useState(false);
+  const CurrentIcon = { bottom: PanelBottom, top: PanelTop, left: PanelLeft, right: PanelRight }[
+    current
+  ];
 
   return (
-    <div
-      ref={popoverRef}
-      className="fixed z-[60] w-max rounded-lg border border-white/[0.15] bg-[#1e1e1e] p-1.5 shadow-2xl backdrop-blur-sm"
-      style={style}
-    >
-      <div className="grid grid-cols-2 gap-1">
-        {POSITION_OPTIONS.map(({ value, label, Icon }) => (
-          <button
-            key={value}
-            onClick={() => onSelect(value)}
-            className={`flex items-center gap-1.5 rounded-md px-3 py-2 text-[11px] whitespace-nowrap transition-colors ${
-              current === value
-                ? 'bg-white/[0.12] text-white/90'
-                : 'text-white/50 hover:bg-white/[0.07] hover:text-white/70'
-            }`}
-          >
-            <Icon className="size-3.5" />
-            {label}
-          </button>
-        ))}
-      </div>
-    </div>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        title="Change terminal position"
+        aria-label="Change terminal position"
+        className={`flex items-center justify-center text-white/30 transition-colors hover:text-white/50 ${
+          horizontal ? 'h-full px-2' : 'w-full py-2'
+        }`}
+      >
+        <CurrentIcon className="size-3.5" />
+      </PopoverTrigger>
+      <PopoverContent align="end" sideOffset={6} className="w-max p-1.5">
+        <div className="grid grid-cols-2 gap-1">
+          {POSITION_OPTIONS.map(({ value, label, Icon }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => {
+                onSelect(value);
+                setOpen(false);
+              }}
+              className={`flex items-center gap-1.5 rounded-md px-3 py-2 text-[11px] whitespace-nowrap transition-colors ${
+                current === value
+                  ? 'bg-surface-selected text-foreground'
+                  : 'text-muted-foreground hover:bg-surface-hover hover:text-foreground'
+              }`}
+            >
+              <Icon className="size-3.5" />
+              {label}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -757,71 +681,27 @@ const BUG_REPORT_OPTIONS = [
   },
 ];
 
-function BugReportMenu({
-  position,
-  triggerRef,
-  onClose,
-}: {
-  position: TerminalPosition;
-  triggerRef: React.RefObject<HTMLDivElement | null>;
-  onClose: () => void;
-}) {
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const [style, setStyle] = useState<React.CSSProperties>({ opacity: 0 });
-
-  useEffect(() => {
-    const trigger = triggerRef.current;
-    const popover = popoverRef.current;
-    if (!trigger || !popover) return;
-    const tr = trigger.getBoundingClientRect();
-    const pr = popover.getBoundingClientRect();
-    const gap = 4;
-
-    let top: number;
-    let left: number;
-
-    if (position === 'bottom') {
-      top = tr.top - pr.height - gap;
-      left = tr.left;
-    } else if (position === 'top') {
-      top = tr.bottom + gap;
-      left = tr.left;
-    } else if (position === 'left') {
-      top = tr.top;
-      left = tr.right + gap;
-    } else {
-      top = tr.top;
-      left = tr.left - pr.width - gap;
-    }
-
-    top = Math.max(4, Math.min(top, window.innerHeight - pr.height - 4));
-    left = Math.max(4, Math.min(left, window.innerWidth - pr.width - 4));
-
-    setStyle({ top, left, opacity: 1 });
-  }, [position, triggerRef]);
-
+export function BugReportMenu() {
   return (
-    <div
-      ref={popoverRef}
-      className="fixed z-[60] w-max rounded-lg border border-white/[0.15] bg-[#1e1e1e] p-1.5 shadow-2xl backdrop-blur-sm"
-      style={style}
-    >
-      <div className="flex flex-col gap-0.5">
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label="Report a bug"
+        className="mr-2 flex items-center gap-1 rounded px-2 py-1 text-[10px] text-white/30 transition-colors hover:bg-white/[0.04] hover:text-white/50"
+      >
+        <Bug className="size-3" />
+        <span className="hidden sm:inline">Report a Bug</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={6} className="w-max">
         {BUG_REPORT_OPTIONS.map(({ label, href, Icon }) => (
-          <a
-            key={label}
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={onClose}
-            className="flex items-center gap-2 rounded-md px-3 py-2 text-[11px] text-white/50 whitespace-nowrap transition-colors hover:bg-white/[0.07] hover:text-white/70"
-          >
-            <Icon className="size-3.5" />
-            {label}
-          </a>
+          <DropdownMenuItem key={label} asChild>
+            <a href={href} target="_blank" rel="noopener noreferrer">
+              <Icon className="size-3.5" />
+              {label}
+            </a>
+          </DropdownMenuItem>
         ))}
-      </div>
-    </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/apps/web/src/components/integrations/DiscordIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/DiscordIntegrationDetails.tsx
@@ -12,6 +12,7 @@ import { useTRPC } from '@/lib/trpc/utils';
 import { IS_DEVELOPMENT } from '@/lib/constants';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
+import { useConfirm } from '@/components/ui/confirm';
 
 type DiscordIntegrationDetailsProps = {
   organizationId?: string;
@@ -26,6 +27,7 @@ export function DiscordIntegrationDetails({
 }: DiscordIntegrationDetailsProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const confirm = useConfirm();
   const input = organizationId ? { organizationId } : undefined;
 
   // Fetch Discord installation status
@@ -129,8 +131,15 @@ export function DiscordIntegrationDetails({
     );
   };
 
-  const handleUninstall = () => {
-    if (confirm('Are you sure you want to disconnect Discord?')) {
+  const handleUninstall = async () => {
+    if (
+      await confirm({
+        title: 'Disconnect Discord?',
+        description: 'Kilo will stop responding in your Discord server. You can reconnect later.',
+        confirmLabel: 'Disconnect',
+        destructive: true,
+      })
+    ) {
       uninstallApp.mutate(input, {
         onSuccess: async () => {
           toast.success('Discord disconnected');
@@ -145,11 +154,14 @@ export function DiscordIntegrationDetails({
     }
   };
 
-  const handleDevRemoveDbRowOnly = () => {
+  const handleDevRemoveDbRowOnly = async () => {
     if (
-      confirm(
-        'This will remove the database row but keep the Discord bot in the server. Are you sure?'
-      )
+      await confirm({
+        title: 'Remove database row?',
+        description: 'This removes the database row but keeps the Discord bot in the server.',
+        confirmLabel: 'Remove row',
+        destructive: true,
+      })
     ) {
       devRemoveDbRowOnly.mutate(input, {
         onSuccess: async () => {

--- a/apps/web/src/components/integrations/DoltHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/DoltHubIntegrationDetails.tsx
@@ -11,6 +11,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { getPlatformOAuthConnectPath } from '@/lib/integrations/oauth/paths';
+import { useConfirm } from '@/components/ui/confirm';
 
 type DoltHubIntegrationDetailsProps = {
   organizationId?: string;
@@ -25,6 +26,7 @@ export function DoltHubIntegrationDetails({
 }: DoltHubIntegrationDetailsProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const confirm = useConfirm();
   const input = organizationId ? { organizationId } : undefined;
 
   const {
@@ -59,8 +61,15 @@ export function DoltHubIntegrationDetails({
     window.location.href = getPlatformOAuthConnectPath(PLATFORM.DOLTHUB, organizationId);
   };
 
-  const handleDisconnect = () => {
-    if (confirm('Are you sure you want to disconnect DoltHub?')) {
+  const handleDisconnect = async () => {
+    if (
+      await confirm({
+        title: 'Disconnect DoltHub?',
+        description: 'Kilo will lose access to your DoltHub databases. You can reconnect later.',
+        confirmLabel: 'Disconnect',
+        destructive: true,
+      })
+    ) {
       disconnect.mutate(input, {
         onSuccess: async () => {
           toast.success('DoltHub disconnected');

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -24,6 +24,7 @@ import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import { buildGitHubInstallState } from './github-install-state';
+import { useConfirm } from '@/components/ui/confirm';
 
 type GitHubIntegrationDetailsProps = {
   organizationId?: string;
@@ -48,6 +49,7 @@ export function GitHubIntegrationDetails({
 }: GitHubIntegrationDetailsProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const confirm = useConfirm();
   const input = organizationId ? { organizationId } : undefined;
 
   // Fetch organization data to check GitHub app type
@@ -277,8 +279,15 @@ export function GitHubIntegrationDetails({
     });
   };
 
-  const handleDisconnectIdentity = () => {
-    if (confirm('Disconnect your GitHub identity from Kilo?')) {
+  const handleDisconnectIdentity = async () => {
+    if (
+      await confirm({
+        title: 'Disconnect your GitHub identity?',
+        description: 'Kilo will no longer act on your behalf with your personal GitHub account.',
+        confirmLabel: 'Disconnect',
+        destructive: true,
+      })
+    ) {
       disconnectUserAuthorization.mutate(undefined, {
         onError: error => {
           toast.error('Failed to disconnect GitHub identity', { description: error.message });
@@ -287,8 +296,15 @@ export function GitHubIntegrationDetails({
     }
   };
 
-  const handleUninstall = () => {
-    if (confirm('Are you sure you want to uninstall the Kilo GitHub App?')) {
+  const handleUninstall = async () => {
+    if (
+      await confirm({
+        title: 'Uninstall the Kilo GitHub App?',
+        description: 'Kilo will lose access to your repositories until the app is reinstalled.',
+        confirmLabel: 'Uninstall',
+        destructive: true,
+      })
+    ) {
       uninstallApp.mutate(input, {
         onSuccess: async () => {
           toast.success('GitHub App uninstalled');
@@ -303,8 +319,16 @@ export function GitHubIntegrationDetails({
     }
   };
 
-  const handleCancelPending = () => {
-    if (confirm('Are you sure you want to cancel this installation request?')) {
+  const handleCancelPending = async () => {
+    if (
+      await confirm({
+        title: 'Cancel this installation request?',
+        description: 'The pending GitHub App installation request will be withdrawn.',
+        confirmLabel: 'Cancel request',
+        cancelLabel: 'Keep request',
+        destructive: true,
+      })
+    ) {
       cancelPendingInstallation.mutate(input, {
         onSuccess: async () => {
           toast.success('Installation request cancelled');

--- a/apps/web/src/components/integrations/GitLabIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitLabIntegrationDetails.tsx
@@ -27,6 +27,7 @@ import {
   getPlatformOAuthCallbackPath,
   getPlatformOAuthConnectPath,
 } from '@/lib/integrations/oauth/paths';
+import { useConfirm } from '@/components/ui/confirm';
 
 type GitLabIntegrationDetailsProps = {
   organizationId?: string;
@@ -87,6 +88,7 @@ export function GitLabIntegrationDetails({
 
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const confirm = useConfirm();
   const validationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const patValidationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const gitLabOAuthCallbackPath = getPlatformOAuthCallbackPath(PLATFORM.GITLAB);
@@ -341,8 +343,15 @@ export function GitLabIntegrationDetails({
     window.location.href = queryString ? `${basePath}?${queryString}` : basePath;
   };
 
-  const handleDisconnect = () => {
-    if (confirm('Are you sure you want to disconnect GitLab?')) {
+  const handleDisconnect = async () => {
+    if (
+      await confirm({
+        title: 'Disconnect GitLab?',
+        description: 'Kilo will lose access to your GitLab projects and stop running workflows.',
+        confirmLabel: 'Disconnect',
+        destructive: true,
+      })
+    ) {
       disconnectMutation.mutate(input, {
         onSuccess: () => {
           toast.success('GitLab disconnected');

--- a/apps/web/src/components/integrations/LinearIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/LinearIntegrationDetails.tsx
@@ -14,6 +14,7 @@ import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombob
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { getPlatformOAuthConnectPath } from '@/lib/integrations/oauth/paths';
+import { useConfirm } from '@/components/ui/confirm';
 
 type LinearIntegrationDetailsProps = {
   organizationId?: string;
@@ -37,6 +38,7 @@ export function LinearIntegrationDetails({
 }: LinearIntegrationDetailsProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const confirm = useConfirm();
   const input = organizationId ? { organizationId } : undefined;
 
   const {
@@ -113,8 +115,15 @@ export function LinearIntegrationDetails({
     window.location.href = getPlatformOAuthConnectPath(PLATFORM.LINEAR, organizationId);
   };
 
-  const handleUninstall = () => {
-    if (confirm('Are you sure you want to disconnect Linear?')) {
+  const handleUninstall = async () => {
+    if (
+      await confirm({
+        title: 'Disconnect Linear?',
+        description: 'Kilo will stop responding to @-mentions on your Linear issues and comments.',
+        confirmLabel: 'Disconnect',
+        destructive: true,
+      })
+    ) {
       uninstallApp.mutate(input, {
         onSuccess: async () => {
           toast.success('Linear disconnected');
@@ -129,9 +138,14 @@ export function LinearIntegrationDetails({
     }
   };
 
-  const handleDevRemoveDbRowOnly = () => {
+  const handleDevRemoveDbRowOnly = async () => {
     if (
-      confirm('This will remove the database row but keep the Linear app installed. Are you sure?')
+      await confirm({
+        title: 'Remove database row?',
+        description: 'This removes the database row but keeps the Linear app installed.',
+        confirmLabel: 'Remove row',
+        destructive: true,
+      })
     ) {
       devRemoveDbRowOnly.mutate(input, {
         onSuccess: async () => {

--- a/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
@@ -21,6 +21,7 @@ import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombob
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { getPlatformOAuthConnectPath } from '@/lib/integrations/oauth/paths';
+import { useConfirm } from '@/components/ui/confirm';
 
 type SlackIntegrationDetailsProps = {
   organizationId?: string;
@@ -54,6 +55,7 @@ export function SlackIntegrationDetails({
 }: SlackIntegrationDetailsProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const confirm = useConfirm();
   const input = organizationId ? { organizationId } : undefined;
 
   // Fetch Slack installation status
@@ -160,8 +162,15 @@ export function SlackIntegrationDetails({
     window.location.href = getPlatformOAuthConnectPath(PLATFORM.SLACK, organizationId);
   };
 
-  const handleUninstall = () => {
-    if (confirm('Are you sure you want to disconnect Slack?')) {
+  const handleUninstall = async () => {
+    if (
+      await confirm({
+        title: 'Disconnect Slack?',
+        description: 'Kilo will stop responding in your Slack workspace. You can reconnect later.',
+        confirmLabel: 'Disconnect',
+        destructive: true,
+      })
+    ) {
       uninstallApp.mutate(input, {
         onSuccess: async () => {
           toast.success('Slack disconnected');
@@ -176,9 +185,14 @@ export function SlackIntegrationDetails({
     }
   };
 
-  const handleDevRemoveDbRowOnly = () => {
+  const handleDevRemoveDbRowOnly = async () => {
     if (
-      confirm('This will remove the database row but keep the Slack app installed. Are you sure?')
+      await confirm({
+        title: 'Remove database row?',
+        description: 'This removes the database row but keeps the Slack app installed.',
+        confirmLabel: 'Remove row',
+        destructive: true,
+      })
     ) {
       devRemoveDbRowOnly.mutate(input, {
         onSuccess: async () => {

--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -22,6 +22,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { useConfirm } from '@/components/ui/confirm';
 import {
   Select,
   SelectContent,
@@ -212,6 +213,7 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const router = useRouter();
+  const confirm = useConfirm();
 
   // Build query options - only include organizationId if provided
   const listQueryInput = organizationId ? { organizationId } : {};
@@ -371,12 +373,19 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
     setIsDialogOpen(true);
   };
 
-  const handleDelete = (keyId: string, providerName: string) => {
+  const handleDelete = async (keyId: string, providerName: string) => {
     if (isInstalledCodingPlanKey(keyId)) {
       setInstalledKeyWarningAction({ type: 'delete', keyId });
       return;
     }
-    if (confirm(`Are you sure you want to delete the API key for ${providerName}?`)) {
+    if (
+      await confirm({
+        title: `Delete the ${providerName} API key?`,
+        description: 'This key will be removed and can no longer be used for requests.',
+        confirmLabel: 'Delete key',
+        destructive: true,
+      })
+    ) {
       deleteMutation.mutate({ ...(organizationId && { organizationId }), id: keyId });
     }
   };

--- a/apps/web/src/components/organizations/custom-modes/ModeDrawer.tsx
+++ b/apps/web/src/components/organizations/custom-modes/ModeDrawer.tsx
@@ -1,8 +1,12 @@
 'use client';
 
-import { Drawer } from 'vaul';
-import { X } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
 import type { ReactNode } from 'react';
 
 type ModeDrawerProps = {
@@ -23,44 +27,17 @@ export function ModeDrawer({
   footer,
 }: ModeDrawerProps) {
   return (
-    <Drawer.Root open={open} onOpenChange={onOpenChange} direction="right">
-      <Drawer.Portal>
-        <Drawer.Overlay className="fixed inset-0 bg-black/40" />
-        <Drawer.Content
-          className="fixed top-2 right-2 bottom-2 z-50 flex w-full max-w-2xl outline-none"
-          style={{ '--initial-transform': 'calc(100% + 8px)' } as React.CSSProperties}
-        >
-          <div className="flex h-full w-full grow flex-col rounded-[16px] border-l-2 border-l-[#cccccc1f] bg-[#111]">
-            {/* Header */}
-            <div className="border-border flex flex-shrink-0 items-start justify-between border-b px-6 py-4">
-              <div className="flex-1">
-                <Drawer.Title className="text-xl font-semibold">{title}</Drawer.Title>
-                {description && (
-                  <Drawer.Description className="text-muted-foreground mt-1 text-sm">
-                    {description}
-                  </Drawer.Description>
-                )}
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => onOpenChange(false)}
-                className="ml-4 flex-shrink-0"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full gap-0 p-0 sm:max-w-2xl">
+        <SheetHeader className="border-border flex-shrink-0 border-b px-6 py-4">
+          <SheetTitle className="text-xl font-semibold">{title}</SheetTitle>
+          {description && <SheetDescription>{description}</SheetDescription>}
+        </SheetHeader>
 
-            {/* Content */}
-            <div className="flex-1 overflow-y-auto px-6 pt-4 pb-10">{children}</div>
+        <div className="flex-1 overflow-y-auto px-6 pt-4 pb-10">{children}</div>
 
-            {/* Footer */}
-            {footer && (
-              <div className="border-border flex-shrink-0 border-t px-6 py-4">{footer}</div>
-            )}
-          </div>
-        </Drawer.Content>
-      </Drawer.Portal>
-    </Drawer.Root>
+        {footer && <div className="border-border flex-shrink-0 border-t px-6 py-4">{footer}</div>}
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/apps/web/src/components/organizations/usage-details/components/AIAdoptionEmptyState.tsx
+++ b/apps/web/src/components/organizations/usage-details/components/AIAdoptionEmptyState.tsx
@@ -2,8 +2,14 @@
 
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Drawer } from 'vaul';
-import { X, TrendingUp, Zap, Layers, Users, Target } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { TrendingUp, Zap, Layers, Users, Target } from 'lucide-react';
 
 export function AIAdoptionEmptyState() {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -63,133 +69,115 @@ export function AIAdoptionEmptyState() {
       </div>
 
       {/* Learn More Drawer */}
-      <Drawer.Root open={drawerOpen} onOpenChange={setDrawerOpen} direction="right">
-        <Drawer.Portal>
-          <Drawer.Overlay className="fixed inset-0 bg-black/40" />
-          <Drawer.Content
-            className="fixed top-2 right-2 bottom-2 z-50 flex w-full max-w-2xl outline-none"
-            style={{ '--initial-transform': 'calc(100% + 8px)' } as React.CSSProperties}
-          >
-            <div className="flex h-full w-full grow flex-col rounded-[16px] border-l-2 border-l-[#cccccc1f] bg-[#111]">
-              {/* Header */}
-              <div className="border-border flex flex-shrink-0 items-start justify-between border-b px-6 py-4">
-                <div className="flex flex-1 items-center gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-500/20">
-                    <TrendingUp className="h-5 w-5 text-purple-400" />
-                  </div>
-                  <div>
-                    <Drawer.Title className="text-xl font-semibold">AI Adoption Score</Drawer.Title>
-                    <Drawer.Description className="text-muted-foreground mt-1 text-sm">
-                      Track your organization's AI integration progress
-                    </Drawer.Description>
-                  </div>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setDrawerOpen(false)}
-                  className="ml-4 flex-shrink-0"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
+      <Sheet open={drawerOpen} onOpenChange={setDrawerOpen}>
+        <SheetContent side="right" className="w-full gap-0 p-0 sm:max-w-2xl">
+          {/* Header */}
+          <SheetHeader className="border-border flex-row items-center gap-3 space-y-0 border-b px-6 py-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-500/20">
+              <TrendingUp className="h-5 w-5 text-purple-400" />
+            </div>
+            <div>
+              <SheetTitle className="text-xl font-semibold">AI Adoption Score</SheetTitle>
+              <SheetDescription className="mt-1">
+                Track your organization&apos;s AI integration progress
+              </SheetDescription>
+            </div>
+          </SheetHeader>
+
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto px-6 pt-6 pb-10">
+            <div className="space-y-6">
+              {/* Overview */}
+              <div>
+                <h3 className="mb-3 text-lg font-semibold">What is the AI Adoption Score?</h3>
+                <p className="mb-4 text-sm text-gray-300">
+                  The AI Adoption Score measures how effectively your team is integrating AI tools
+                  into their daily workflows. It's calculated across three key dimensions:
+                </p>
               </div>
 
-              {/* Content */}
-              <div className="flex-1 overflow-y-auto px-6 pt-6 pb-10">
-                <div className="space-y-6">
-                  {/* Overview */}
-                  <div>
-                    <h3 className="mb-3 text-lg font-semibold">What is the AI Adoption Score?</h3>
-                    <p className="mb-4 text-sm text-gray-300">
-                      The AI Adoption Score measures how effectively your team is integrating AI
-                      tools into their daily workflows. It's calculated across three key dimensions:
-                    </p>
+              {/* Metrics Breakdown */}
+              <div className="space-y-4">
+                {/* Frequency */}
+                <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-4">
+                  <div className="mb-2 flex items-center gap-2">
+                    <Zap className="h-4 w-4 text-blue-400" />
+                    <h4 className="font-semibold">Frequency (40 points)</h4>
                   </div>
-
-                  {/* Metrics Breakdown */}
-                  <div className="space-y-4">
-                    {/* Frequency */}
-                    <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-4">
-                      <div className="mb-2 flex items-center gap-2">
-                        <Zap className="h-4 w-4 text-blue-400" />
-                        <h4 className="font-semibold">Frequency (40 points)</h4>
-                      </div>
-                      <p className="mb-2 text-sm text-gray-300">
-                        How often your team uses AI tools daily
-                      </p>
-                      <ul className="ml-4 space-y-1 text-xs text-gray-400">
-                        <li>• Agent interactions per day</li>
-                        <li>• Autocomplete acceptances</li>
-                        <li>• Cloud Agent sessions</li>
-                        <li>• Code review runs</li>
-                      </ul>
-                    </div>
-
-                    {/* Depth */}
-                    <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-4">
-                      <div className="mb-2 flex items-center gap-2">
-                        <Layers className="h-4 w-4 text-green-400" />
-                        <h4 className="font-semibold">Depth (40 points)</h4>
-                      </div>
-                      <p className="mb-2 text-sm text-gray-300">
-                        How deeply AI is integrated into workflows
-                      </p>
-                      <ul className="ml-4 space-y-1 text-xs text-gray-400">
-                        <li>• Queries per hour worked</li>
-                        <li>• Suggestion acceptance rate</li>
-                        <li>• Multi-agent workflow chains</li>
-                      </ul>
-                    </div>
-
-                    {/* Coverage */}
-                    <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-4">
-                      <div className="mb-2 flex items-center gap-2">
-                        <Users className="h-4 w-4 text-amber-400" />
-                        <h4 className="font-semibold">Coverage (20 points)</h4>
-                      </div>
-                      <p className="mb-2 text-sm text-gray-300">
-                        How broadly AI is adopted across your team
-                      </p>
-                      <ul className="ml-4 space-y-1 text-xs text-gray-400">
-                        <li>• Percentage of users active weekly</li>
-                        <li>• Multi-agent adoption rate</li>
-                        <li>• Consistency across weekdays</li>
-                      </ul>
-                    </div>
-
-                    {/* Total */}
-                    <div className="rounded-lg border border-gray-700 bg-gradient-to-r from-blue-900/20 to-green-900/20 p-4">
-                      <div className="mb-2 flex items-center gap-2">
-                        <Target className="h-4 w-4 text-purple-400" />
-                        <h4 className="font-semibold">Total Score (100 points)</h4>
-                      </div>
-                      <p className="text-sm text-gray-300">
-                        The sum of all three metrics, representing your organization's overall AI
-                        integration maturity
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* Getting Started */}
-                  <div className="rounded-lg border border-blue-800/50 bg-blue-900/20 p-4">
-                    <h4 className="mb-2 font-semibold">Getting Started</h4>
-                    <p className="text-sm text-gray-300">
-                      Your AI Adoption Score will become available once we've collected at least 3
-                      days of usage data. In the meantime, encourage your team to:
-                    </p>
-                    <ul className="mt-2 ml-4 space-y-1 text-sm text-gray-300">
-                      <li>• Use Kilo's AI agents for daily coding tasks</li>
-                      <li>• Enable autocomplete in their IDE</li>
-                      <li>• Try the Cloud Agent for complex workflows</li>
-                      <li>• Set up code reviews with the Reviewer Agent</li>
-                    </ul>
-                  </div>
+                  <p className="mb-2 text-sm text-gray-300">
+                    How often your team uses AI tools daily
+                  </p>
+                  <ul className="ml-4 space-y-1 text-xs text-gray-400">
+                    <li>• Agent interactions per day</li>
+                    <li>• Autocomplete acceptances</li>
+                    <li>• Cloud Agent sessions</li>
+                    <li>• Code review runs</li>
+                  </ul>
                 </div>
+
+                {/* Depth */}
+                <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-4">
+                  <div className="mb-2 flex items-center gap-2">
+                    <Layers className="h-4 w-4 text-green-400" />
+                    <h4 className="font-semibold">Depth (40 points)</h4>
+                  </div>
+                  <p className="mb-2 text-sm text-gray-300">
+                    How deeply AI is integrated into workflows
+                  </p>
+                  <ul className="ml-4 space-y-1 text-xs text-gray-400">
+                    <li>• Queries per hour worked</li>
+                    <li>• Suggestion acceptance rate</li>
+                    <li>• Multi-agent workflow chains</li>
+                  </ul>
+                </div>
+
+                {/* Coverage */}
+                <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-4">
+                  <div className="mb-2 flex items-center gap-2">
+                    <Users className="h-4 w-4 text-amber-400" />
+                    <h4 className="font-semibold">Coverage (20 points)</h4>
+                  </div>
+                  <p className="mb-2 text-sm text-gray-300">
+                    How broadly AI is adopted across your team
+                  </p>
+                  <ul className="ml-4 space-y-1 text-xs text-gray-400">
+                    <li>• Percentage of users active weekly</li>
+                    <li>• Multi-agent adoption rate</li>
+                    <li>• Consistency across weekdays</li>
+                  </ul>
+                </div>
+
+                {/* Total */}
+                <div className="rounded-lg border border-gray-700 bg-gradient-to-r from-blue-900/20 to-green-900/20 p-4">
+                  <div className="mb-2 flex items-center gap-2">
+                    <Target className="h-4 w-4 text-purple-400" />
+                    <h4 className="font-semibold">Total Score (100 points)</h4>
+                  </div>
+                  <p className="text-sm text-gray-300">
+                    The sum of all three metrics, representing your organization's overall AI
+                    integration maturity
+                  </p>
+                </div>
+              </div>
+
+              {/* Getting Started */}
+              <div className="rounded-lg border border-blue-800/50 bg-blue-900/20 p-4">
+                <h4 className="mb-2 font-semibold">Getting Started</h4>
+                <p className="text-sm text-gray-300">
+                  Your AI Adoption Score will become available once we've collected at least 3 days
+                  of usage data. In the meantime, encourage your team to:
+                </p>
+                <ul className="mt-2 ml-4 space-y-1 text-sm text-gray-300">
+                  <li>• Use Kilo's AI agents for daily coding tasks</li>
+                  <li>• Enable autocomplete in their IDE</li>
+                  <li>• Try the Cloud Agent for complex workflows</li>
+                  <li>• Set up code reviews with the Reviewer Agent</li>
+                </ul>
               </div>
             </div>
-          </Drawer.Content>
-        </Drawer.Portal>
-      </Drawer.Root>
+          </div>
+        </SheetContent>
+      </Sheet>
     </>
   );
 }

--- a/apps/web/src/components/organizations/usage-details/components/MetricDetailDrawer.tsx
+++ b/apps/web/src/components/organizations/usage-details/components/MetricDetailDrawer.tsx
@@ -1,8 +1,13 @@
 'use client';
 
-import { Drawer } from 'vaul';
-import { X, Zap, Layers, Users } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { Zap, Layers, Users } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { useMemo } from 'react';
 import Link from 'next/link';
@@ -224,108 +229,84 @@ export function MetricDetailDrawer({
   const IconComponent = info.icon;
 
   return (
-    <Drawer.Root open={open} onOpenChange={onOpenChange} direction="right">
-      <Drawer.Portal>
-        <Drawer.Overlay className="fixed inset-0 bg-black/40" />
-        <Drawer.Content
-          className="fixed top-2 right-2 bottom-2 z-50 flex w-full max-w-2xl outline-none"
-          style={{ '--initial-transform': 'calc(100% + 8px)' } as React.CSSProperties}
-        >
-          <div className="flex h-full w-full grow flex-col rounded-[16px] border-l-2 border-l-[#cccccc1f] bg-[#111]">
-            {/* Header */}
-            <div className="border-border flex flex-shrink-0 items-start justify-between border-b px-6 py-4">
-              <div className="flex flex-1 items-center gap-3">
-                <div
-                  className="flex h-10 w-10 items-center justify-center rounded-lg"
-                  style={{ backgroundColor: `${info.color}20` }}
-                >
-                  <IconComponent className="h-5 w-5" style={{ color: info.color }} />
-                </div>
-                <div>
-                  <Drawer.Title className="text-xl font-semibold">{info.title}</Drawer.Title>
-                  <Drawer.Description className="text-muted-foreground mt-1 text-sm">
-                    Detailed analysis and improvement suggestions
-                  </Drawer.Description>
-                </div>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => onOpenChange(false)}
-                className="ml-4 flex-shrink-0"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full gap-0 p-0 sm:max-w-2xl">
+        {/* Header */}
+        <SheetHeader className="border-border flex-row items-center gap-3 space-y-0 border-b px-6 py-4">
+          <div
+            className="flex h-10 w-10 items-center justify-center rounded-lg"
+            style={{ backgroundColor: `${info.color}20` }}
+          >
+            <IconComponent className="h-5 w-5" style={{ color: info.color }} />
+          </div>
+          <div>
+            <SheetTitle className="text-xl font-semibold">{info.title}</SheetTitle>
+            <SheetDescription className="mt-1">
+              Detailed analysis and improvement suggestions
+            </SheetDescription>
+          </div>
+        </SheetHeader>
 
-            {/* Content */}
-            <div className="flex-1 overflow-y-auto px-6 pt-6 pb-10">
-              {/* Condensed Chart */}
-              <div className="mb-8">
-                <h3 className="mb-3 text-sm font-medium text-gray-400">Trend Over Time</h3>
-                <div className="h-32 w-full rounded-lg border border-gray-800 bg-gray-900/50 p-4">
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={metricChartData}
-                      margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
-                    >
-                      <CartesianGrid strokeDasharray="3 3" stroke="#222" />
-                      <XAxis
-                        dataKey="date"
-                        stroke="#a1a1a1"
-                        tick={{ fontSize: 9 }}
-                        interval="preserveStartEnd"
-                      />
-                      <YAxis stroke="#a1a1a1" tick={{ fontSize: 9 }} width={30} />
-                      <Tooltip
-                        contentStyle={{
-                          backgroundColor: 'rgba(17, 24, 39, 0.95)',
-                          border: '1px solid #374151',
-                          borderRadius: '8px',
-                        }}
-                      />
-                      <Bar
-                        dataKey="value"
-                        fill={info.color}
-                        radius={[4, 4, 0, 0]}
-                        isAnimationActive={false}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </div>
-
-              {/* Improvement Section */}
-              <div>
-                <h3 className="mb-2 text-lg font-semibold">{info.improvementTitle}</h3>
-                <p className="text-muted-foreground mb-6 text-sm">
-                  <strong>Goal:</strong> {info.improvementGoal}
-                </p>
-
-                <div className="space-y-6">
-                  {info.options.map((option, index) => (
-                    <div
-                      key={index}
-                      className="rounded-lg border border-gray-800 bg-gray-900/50 p-4"
-                    >
-                      <div className="mb-2">
-                        <h4 className="font-semibold">{option.title}</h4>
-                        <p className="text-xs text-gray-400">{option.subtitle}</p>
-                      </div>
-                      <p className="mb-3 text-sm text-gray-300">{option.description}</p>
-                      {option.action && (
-                        <div className="rounded bg-gray-800/50 px-3 py-2">
-                          <code className="text-xs text-blue-400">{option.action}</code>
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-6 pt-6 pb-10">
+          {/* Condensed Chart */}
+          <div className="mb-8">
+            <h3 className="mb-3 text-sm font-medium text-gray-400">Trend Over Time</h3>
+            <div className="h-32 w-full rounded-lg border border-gray-800 bg-gray-900/50 p-4">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={metricChartData} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#222" />
+                  <XAxis
+                    dataKey="date"
+                    stroke="#a1a1a1"
+                    tick={{ fontSize: 9 }}
+                    interval="preserveStartEnd"
+                  />
+                  <YAxis stroke="#a1a1a1" tick={{ fontSize: 9 }} width={30} />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'rgba(17, 24, 39, 0.95)',
+                      border: '1px solid #374151',
+                      borderRadius: '8px',
+                    }}
+                  />
+                  <Bar
+                    dataKey="value"
+                    fill={info.color}
+                    radius={[4, 4, 0, 0]}
+                    isAnimationActive={false}
+                  />
+                </BarChart>
+              </ResponsiveContainer>
             </div>
           </div>
-        </Drawer.Content>
-      </Drawer.Portal>
-    </Drawer.Root>
+
+          {/* Improvement Section */}
+          <div>
+            <h3 className="mb-2 text-lg font-semibold">{info.improvementTitle}</h3>
+            <p className="text-muted-foreground mb-6 text-sm">
+              <strong>Goal:</strong> {info.improvementGoal}
+            </p>
+
+            <div className="space-y-6">
+              {info.options.map((option, index) => (
+                <div key={index} className="rounded-lg border border-gray-800 bg-gray-900/50 p-4">
+                  <div className="mb-2">
+                    <h4 className="font-semibold">{option.title}</h4>
+                    <p className="text-xs text-gray-400">{option.subtitle}</p>
+                  </div>
+                  <p className="mb-3 text-sm text-gray-300">{option.description}</p>
+                  {option.action && (
+                    <div className="rounded bg-gray-800/50 px-3 py-2">
+                      <code className="text-xs text-blue-400">{option.action}</code>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/apps/web/src/components/profile/kilo-pass/kiloPassChurnkeyCancelFlow.test.ts
+++ b/apps/web/src/components/profile/kilo-pass/kiloPassChurnkeyCancelFlow.test.ts
@@ -80,8 +80,8 @@ function buildCancelFlowParams(overrides: Partial<OpenKiloPassChurnkeyCancelFlow
     fallbackCancelSubscription: () => {
       directFallbackCancellations.push('fallback');
     },
-    confirmFallbackCancel: message => {
-      confirmations.push(message);
+    confirmFallbackCancel: () => {
+      confirmations.push('fallback-confirm');
       return true;
     },
     notifyCancellationScheduled: () => {
@@ -188,9 +188,7 @@ describe('createKiloPassChurnkeyCancelFlow', () => {
 
     expect(calls.openedFlows).toHaveLength(0);
     expect(calls.errors).toEqual(['CHURNKEY_API_SECRET is not configured']);
-    expect(calls.confirmations).toEqual([
-      'Are you sure you want to cancel your Kilo Pass subscription?',
-    ]);
+    expect(calls.confirmations).toEqual(['fallback-confirm']);
     expect(calls.directFallbackCancellations).toEqual(['fallback']);
     expect(coordinator.getIsInFlight()).toBe(false);
   });
@@ -216,17 +214,15 @@ describe('createKiloPassChurnkeyCancelFlow', () => {
       getChurnkeyAuthHash: async () => {
         throw new Error('auth unavailable');
       },
-      confirmFallbackCancel: message => {
-        calls.confirmations.push(message);
+      confirmFallbackCancel: () => {
+        calls.confirmations.push('fallback-confirm');
         return false;
       },
     });
 
     await coordinator.openCancelFlow(params);
 
-    expect(calls.confirmations).toEqual([
-      'Are you sure you want to cancel your Kilo Pass subscription?',
-    ]);
+    expect(calls.confirmations).toEqual(['fallback-confirm']);
     expect(calls.directFallbackCancellations).toHaveLength(0);
   });
 

--- a/apps/web/src/components/profile/kilo-pass/kiloPassChurnkeyCancelFlow.ts
+++ b/apps/web/src/components/profile/kilo-pass/kiloPassChurnkeyCancelFlow.ts
@@ -18,7 +18,7 @@ export type OpenKiloPassChurnkeyCancelFlowParams = {
   invalidateKiloPassState: () => MaybePromise<unknown>;
   invalidateKiloPassScheduledChange: () => MaybePromise<unknown>;
   fallbackCancelSubscription: () => void;
-  confirmFallbackCancel: (message: string) => boolean;
+  confirmFallbackCancel: (message: string) => MaybePromise<boolean>;
   notifyCancellationScheduled: () => void;
   notifyError: (message: string) => void;
   onBeforeOpen?: () => void;
@@ -88,13 +88,15 @@ export function createKiloPassChurnkeyCancelFlow() {
           },
         });
       } catch (error) {
-        setIsInFlight(false, params);
-
         const message = error instanceof Error ? error.message : 'Failed to open cancel flow';
         params.notifyError(message);
 
-        if (params.confirmFallbackCancel(FALLBACK_CANCEL_CONFIRM_MESSAGE)) {
-          params.fallbackCancelSubscription();
+        try {
+          if (await params.confirmFallbackCancel(FALLBACK_CANCEL_CONFIRM_MESSAGE)) {
+            params.fallbackCancelSubscription();
+          }
+        } finally {
+          setIsInFlight(false, params);
         }
       }
     },

--- a/apps/web/src/components/profile/kilo-pass/kiloPassChurnkeyCancelFlow.ts
+++ b/apps/web/src/components/profile/kilo-pass/kiloPassChurnkeyCancelFlow.ts
@@ -1,8 +1,5 @@
 import type { ShowCancelFlowParams } from '@/lib/churnkey/loader';
 
-const FALLBACK_CANCEL_CONFIRM_MESSAGE =
-  'Are you sure you want to cancel your Kilo Pass subscription?';
-
 export type KiloPassChurnkeyAuth = {
   hash: string;
   customerId: string;
@@ -18,7 +15,7 @@ export type OpenKiloPassChurnkeyCancelFlowParams = {
   invalidateKiloPassState: () => MaybePromise<unknown>;
   invalidateKiloPassScheduledChange: () => MaybePromise<unknown>;
   fallbackCancelSubscription: () => void;
-  confirmFallbackCancel: (message: string) => MaybePromise<boolean>;
+  confirmFallbackCancel: () => MaybePromise<boolean>;
   notifyCancellationScheduled: () => void;
   notifyError: (message: string) => void;
   onBeforeOpen?: () => void;
@@ -92,7 +89,7 @@ export function createKiloPassChurnkeyCancelFlow() {
         params.notifyError(message);
 
         try {
-          if (await params.confirmFallbackCancel(FALLBACK_CANCEL_CONFIRM_MESSAGE)) {
+          if (await params.confirmFallbackCancel()) {
             params.fallbackCancelSubscription();
           }
         } finally {

--- a/apps/web/src/components/profile/kilo-pass/useKiloPassChurnkeyCancelFlow.ts
+++ b/apps/web/src/components/profile/kilo-pass/useKiloPassChurnkeyCancelFlow.ts
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { showCancelFlow } from '@/lib/churnkey/loader';
+import { useConfirm } from '@/components/ui/confirm';
 import { useRawTRPCClient, useTRPC } from '@/lib/trpc/utils';
 
 import { createKiloPassChurnkeyCancelFlow } from './kiloPassChurnkeyCancelFlow';
@@ -48,6 +49,7 @@ export function useKiloPassChurnkeyCancelFlow(params: UseKiloPassChurnkeyCancelF
   const trpc = useTRPC();
   const trpcClient = useRawTRPCClient();
   const queryClient = useQueryClient();
+  const confirm = useConfirm();
   const sharedCancelFlow = useContext(KiloPassChurnkeyCancelFlowContext);
   const [localIsOpeningCancelFlow, setLocalIsOpeningCancelFlow] = useState(false);
   const [localCoordinator] = useState(() => createKiloPassChurnkeyCancelFlow());
@@ -75,13 +77,22 @@ export function useKiloPassChurnkeyCancelFlow(params: UseKiloPassChurnkeyCancelF
           queryKey: trpc.kiloPass.getScheduledChange.queryKey(),
         }),
       fallbackCancelSubscription,
-      confirmFallbackCancel: message => window.confirm(message),
+      confirmFallbackCancel: () =>
+        confirm({
+          title: 'Cancel your Kilo Pass subscription?',
+          description:
+            'The cancellation flow could not load, so this cancels the subscription directly.',
+          confirmLabel: 'Cancel subscription',
+          cancelLabel: 'Keep subscription',
+          destructive: true,
+        }),
       notifyCancellationScheduled: () => toast('Cancellation scheduled'),
       notifyError: message => toast.error(message),
       onBeforeOpen,
       onInFlightChange: setIsOpeningCancelFlow,
     });
   }, [
+    confirm,
     coordinator,
     fallbackCancelSubscription,
     onBeforeOpen,

--- a/apps/web/src/components/subscriptions/seats/SeatsDetail.tsx
+++ b/apps/web/src/components/subscriptions/seats/SeatsDetail.tsx
@@ -15,6 +15,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { useConfirm } from '@/components/ui/confirm';
 import { useRawTRPCClient, useTRPC } from '@/lib/trpc/utils';
 import { capitalize } from '@/lib/utils';
 import { SEAT_PRICING } from '@/lib/organizations/constants';
@@ -28,6 +29,7 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
   const trpc = useTRPC();
   const trpcClient = useRawTRPCClient();
   const queryClient = useQueryClient();
+  const confirm = useConfirm();
   const [seatDialogOpen, setSeatDialogOpen] = useState(false);
   const [billingCycleDialogOpen, setBillingCycleDialogOpen] = useState(false);
   const [seatCount, setSeatCount] = useState('1');
@@ -95,6 +97,29 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
         setIsOpeningPortal(false);
       }
     })();
+  }
+
+  async function handleCancelSubscription() {
+    if (
+      !(await confirm({
+        title: 'Cancel seats subscription?',
+        description:
+          'The subscription stays active until the end of the current billing period, then cancels.',
+        confirmLabel: 'Cancel at period end',
+        cancelLabel: 'Keep subscription',
+        destructive: true,
+      }))
+    ) {
+      return;
+    }
+
+    try {
+      await trpcClient.organizations.subscription.cancel.mutate({ organizationId });
+      toast.success('Subscription will cancel at period end');
+      await refreshData();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to cancel subscription');
+    }
   }
 
   const subscription = subscriptionQuery.data?.subscription ?? null;
@@ -269,20 +294,7 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
             <Button
               variant="outline"
               className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-              onClick={() => {
-                if (!window.confirm('Cancel this seats subscription at period end?')) return;
-                void (async () => {
-                  try {
-                    await trpcClient.organizations.subscription.cancel.mutate({ organizationId });
-                    toast.success('Subscription will cancel at period end');
-                    await refreshData();
-                  } catch (error) {
-                    toast.error(
-                      error instanceof Error ? error.message : 'Failed to cancel subscription'
-                    );
-                  }
-                })();
-              }}
+              onClick={() => void handleCancelSubscription()}
             >
               Cancel Subscription
             </Button>

--- a/apps/web/src/components/subscriptions/seats/SeatsDetail.tsx
+++ b/apps/web/src/components/subscriptions/seats/SeatsDetail.tsx
@@ -34,6 +34,7 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
   const [billingCycleDialogOpen, setBillingCycleDialogOpen] = useState(false);
   const [seatCount, setSeatCount] = useState('1');
   const [isOpeningPortal, setIsOpeningPortal] = useState(false);
+  const [isCancelingSubscription, setIsCancelingSubscription] = useState(false);
   const [isCancelingCycleChange, setIsCancelingCycleChange] = useState(false);
 
   const organizationQuery = useOrganizationWithMembers(organizationId, {
@@ -100,25 +101,27 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
   }
 
   async function handleCancelSubscription() {
-    if (
-      !(await confirm({
+    if (isCancelingSubscription) return;
+    setIsCancelingSubscription(true);
+
+    try {
+      const shouldCancel = await confirm({
         title: 'Cancel seats subscription?',
         description:
           'The subscription stays active until the end of the current billing period, then cancels.',
         confirmLabel: 'Cancel at period end',
         cancelLabel: 'Keep subscription',
         destructive: true,
-      }))
-    ) {
-      return;
-    }
+      });
+      if (!shouldCancel) return;
 
-    try {
       await trpcClient.organizations.subscription.cancel.mutate({ organizationId });
       toast.success('Subscription will cancel at period end');
       await refreshData();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to cancel subscription');
+    } finally {
+      setIsCancelingSubscription(false);
     }
   }
 
@@ -295,8 +298,9 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
               variant="outline"
               className="text-destructive hover:bg-destructive/10 hover:text-destructive"
               onClick={() => void handleCancelSubscription()}
+              disabled={isCancelingSubscription}
             >
-              Cancel Subscription
+              {isCancelingSubscription ? 'Canceling...' : 'Cancel Subscription'}
             </Button>
           )}
           <Button variant="outline" onClick={openCustomerPortal} disabled={isOpeningPortal}>

--- a/apps/web/src/components/ui/confirm.tsx
+++ b/apps/web/src/components/ui/confirm.tsx
@@ -50,6 +50,14 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
+  React.useEffect(
+    () => () => {
+      resolverRef.current?.(false);
+      resolverRef.current = null;
+    },
+    []
+  );
+
   const handleOpenChange = React.useCallback(
     (open: boolean) => {
       if (!open) settle(false);

--- a/apps/web/src/components/ui/confirm.tsx
+++ b/apps/web/src/components/ui/confirm.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import * as React from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+export type ConfirmOptions = {
+  title: string;
+  description?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+};
+
+type ConfirmFn = (options: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = React.createContext<ConfirmFn | null>(null);
+
+type ConfirmState = ConfirmOptions & { open: boolean };
+
+/**
+ * Mounts a single AlertDialog and exposes an imperative, promise-based
+ * confirm() via context. Resolves true on the confirm action; resolves false
+ * on Cancel / Escape / outside-click so every dismissal maps to "keep".
+ */
+export function ConfirmProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = React.useState<ConfirmState | null>(null);
+  const resolverRef = React.useRef<((value: boolean) => void) | null>(null);
+
+  const settle = React.useCallback((result: boolean) => {
+    resolverRef.current?.(result);
+    resolverRef.current = null;
+    setState(prev => (prev ? { ...prev, open: false } : prev));
+  }, []);
+
+  const confirm = React.useCallback<ConfirmFn>(options => {
+    // Resolve any in-flight prompt as cancelled before replacing it.
+    resolverRef.current?.(false);
+    return new Promise<boolean>(resolve => {
+      resolverRef.current = resolve;
+      setState({ ...options, open: true });
+    });
+  }, []);
+
+  const handleOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (!open) settle(false);
+    },
+    [settle]
+  );
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      <AlertDialog open={state?.open ?? false} onOpenChange={handleOpenChange}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{state?.title}</AlertDialogTitle>
+            {state?.description != null && (
+              <AlertDialogDescription>{state.description}</AlertDialogDescription>
+            )}
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{state?.cancelLabel ?? 'Cancel'}</AlertDialogCancel>
+            <AlertDialogAction
+              variant={state?.destructive ? 'destructive' : 'default'}
+              onClick={() => settle(true)}
+            >
+              {state?.confirmLabel ?? 'Confirm'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </ConfirmContext.Provider>
+  );
+}
+
+/**
+ * Returns a stable confirm() that resolves true on confirm, false otherwise.
+ *
+ *   const confirm = useConfirm();
+ *   if (await confirm({ title: 'Disconnect Slack?', destructive: true })) { … }
+ */
+export function useConfirm(): ConfirmFn {
+  const confirm = React.useContext(ConfirmContext);
+  if (!confirm) {
+    throw new Error('useConfirm must be used within a ConfirmProvider');
+  }
+  return confirm;
+}


### PR DESCRIPTION
## Summary
Consolidates web overlay behavior on shared Radix/shadcn primitives and adds Storybook coverage for the migrated surfaces.

### Why this change is needed
Several product flows used hand-rolled or inconsistent overlay behavior for confirmations, drawers, popovers, and menus. That made keyboard behavior, dismissal, focus handling, and design-token usage vary by surface. Storybook coverage was also missing for many of these overlays, which made visual regressions harder to catch.

### How this is addressed
- Adds a reusable `useConfirm` dialog provider and replaces native `window.confirm` paths in integration, BYOK, seats, dev, and Kilo Pass cancellation flows.
- Migrates Vaul drawers and custom-positioned popovers/menus to existing Sheet, Popover, DropdownMenu, and AlertDialog primitives.
- Aligns migrated overlay surfaces with Kilo design tokens, including popover surfaces, destructive actions, and Environment Settings row actions.
- Fixes reaction picker dismissal so message action controls do not stay visible after closing the popover off-hover.
- Adds Storybook stories for chat overlays, deployment env-var dialogs, Gastown drawers/popovers, and organization usage drawers.

Closes #4173.

## Human Verification
No manual browser pass was run in this session.

## Reviewer Notes
### Human Reviewer Flags
- The row-level delete action in Environment Settings is now destructive-outline, while the final confirmation action remains filled destructive red.
- The Gastown onboarding tooltip keeps its non-token blue highlight ring as an intentional coachmark accent.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Local review found React issues in `OnboardingTooltips` and `MessageBubble`; both are fixed.
- `react-doctor` still reports pre-existing warnings on unchanged lines in `MetricDetailDrawer`, `CreateBeadDrawer`, and `DeploymentDetails`.

</details>
