### PR TITLE
fix(mobile): avoid stuck WebBrowser auth session on Android

### DIFF
--- a/apps/mobile/src/lib/auth/use-device-auth.ts
+++ b/apps/mobile/src/lib/auth/use-device-auth.ts
@@ -1,5 +1,6 @@
 import * as WebBrowser from 'expo-web-browser';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Platform } from 'react-native';
 
 import { API_BASE_URL, WEB_BASE_URL } from '@/lib/config';
 
@@ -20,6 +21,16 @@ type DeviceAuthResult = DeviceAuthState & {
 };
 
 const POLL_INTERVAL_MS = 3000;
+
+// Android has no native auth session; expo-web-browser's polyfill keeps
+// module-level state that can get stuck and reject every future call
+// (KILO-APP-22). We poll the server for approval instead of relying on a
+// redirect, so a plain browser open is all Android needs.
+async function openAuthBrowser(url: string) {
+  await (Platform.OS === 'android'
+    ? WebBrowser.openBrowserAsync(url)
+    : WebBrowser.openAuthSessionAsync(url));
+}
 
 export function useDeviceAuth(): DeviceAuthResult {
   const [state, setState] = useState<DeviceAuthState>({
@@ -174,7 +185,7 @@ export function useDeviceAuth(): DeviceAuthResult {
         abortReference.current = abort;
         poll(data.code, abort);
 
-        await WebBrowser.openAuthSessionAsync(browserUrl);
+        await openAuthBrowser(browserUrl);
       } catch {
         setState({
           status: 'error',
@@ -201,7 +212,17 @@ export function useDeviceAuth(): DeviceAuthResult {
 
   const openBrowser = useCallback(async () => {
     if (state.verificationUrl) {
-      await WebBrowser.openAuthSessionAsync(state.verificationUrl);
+      try {
+        await openAuthBrowser(state.verificationUrl);
+      } catch {
+        setState(previous => ({
+          status: 'error',
+          code: previous.code,
+          token: undefined,
+          error: 'Could not open browser. Please try again.',
+          verificationUrl: previous.verificationUrl,
+        }));
+      }
     }
   }, [state.verificationUrl]);
 


### PR DESCRIPTION
## Summary

Fixes Sentry issue KILO-APP-22: on Android, sign-in could permanently fail with `The WebBrowser's auth session is in an invalid state with a redirect handler set when it should not be` until the app was restarted.

Fixes KILO-APP-22

## Mechanism

Android has no native auth session, so expo-web-browser's `openAuthSessionAsync` falls back to a JS polyfill that keeps module-level state (`_redirectSubscription`, `_onWebBrowserCloseAndroid`). The polyfill only resolves on an AppState `active` transition and swallows the first AppState event after module load, so a session can get stuck unresolved — after which every subsequent `openAuthSessionAsync` call throws, making sign-in impossible.

## Fix

We never rely on the redirect deep-link on Android — the app polls the server for device-auth approval. So on Android we bypass the broken polyfill entirely and use `WebBrowser.openBrowserAsync` instead (new `openAuthBrowser` helper used by both `start()` and `openBrowser()`). Also added error handling to `openBrowser()`, which previously surfaced throws as unhandled rejections; it now sets an error state with a user-visible message.