### PR TITLE
fix(mobile): skip dismissAuthSession on Android

### DIFF
--- a/apps/mobile/src/lib/auth/use-device-auth.ts
+++ b/apps/mobile/src/lib/auth/use-device-auth.ts
@@ -70,7 +70,12 @@ export function useDeviceAuth(): DeviceAuthResult {
             case 200: {
               const data = (await response.json()) as { token: string };
               cleanup();
-              WebBrowser.dismissAuthSession();
+              // dismissAuthSession closes the iOS ASWebAuthenticationSession sheet. On
+              // Android we open a plain custom tab (no auth session) and the native module
+              // has no dismissBrowser, so calling it there is at best a no-op and can throw.
+              if (Platform.OS !== 'android') {
+                WebBrowser.dismissAuthSession();
+              }
               setState(previous => ({
                 status: 'approved',
                 code,


### PR DESCRIPTION
Follow-up to #4376. On Android sign-in now opens a plain custom tab (no auth session), and expo-web-browser's `dismissAuthSession()` on Android routes to a `dismissBrowser` native function that doesn't exist in the Android module — at best a no-op, and a latent `UnavailabilityError` throw site inside the poll's try block that would flip a successful approval into the error state. Guard the call to iOS, where it actually closes the ASWebAuthenticationSession sheet.