### PR TITLE
fix(mobile): make agent approval cards scroll instead of overflowing the screen

### DIFF
--- a/apps/mobile/src/components/agents/permission-card.tsx
+++ b/apps/mobile/src/components/agents/permission-card.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, ScrollView, View } from 'react-native';
 import * as Haptics from 'expo-haptics';
 
 import { Button } from '@/components/ui/button';
@@ -38,37 +38,39 @@ export function PermissionCard({
     .join(' ');
 
   return (
-    <View className="mx-4 my-2 overflow-hidden rounded-xl border border-border bg-card">
+    <View className="mx-4 my-2 shrink overflow-hidden rounded-xl border border-border bg-card">
       <View className="border-b border-border bg-secondary px-4 py-3">
         <Text className="text-sm font-medium">Permission Required</Text>
       </View>
 
-      <View className="gap-3 p-4">
-        <Text className="text-sm text-foreground">
-          Allow <Text className="font-medium">{permissionDisplay}</Text>?
-        </Text>
+      <ScrollView className="max-h-96 shrink">
+        <View className="gap-3 p-4">
+          <Text className="text-sm text-foreground">
+            Allow <Text className="font-medium">{permissionDisplay}</Text>?
+          </Text>
 
-        {patterns.length > 0 && (
-          <View className="gap-1 rounded-lg bg-muted p-2">
-            <Text className="text-xs font-medium text-muted-foreground">Applies to:</Text>
-            {patterns.map((pattern, index) => (
-              <Text key={index} className="text-xs text-muted-foreground">
-                • {pattern}
-              </Text>
-            ))}
-          </View>
-        )}
+          {patterns.length > 0 && (
+            <View className="gap-1 rounded-lg bg-muted p-2">
+              <Text className="text-xs font-medium text-muted-foreground">Applies to:</Text>
+              {patterns.map((pattern, index) => (
+                <Text key={index} className="text-xs text-muted-foreground">
+                  • {pattern}
+                </Text>
+              ))}
+            </View>
+          )}
 
-        {metadata && Object.keys(metadata).length > 0 && (
-          <View className="gap-1">
-            {Object.entries(metadata).map(([key, value]) => (
-              <Text key={key} className="text-xs text-muted-foreground">
-                {key}: {String(value)}
-              </Text>
-            ))}
-          </View>
-        )}
-      </View>
+          {metadata && Object.keys(metadata).length > 0 && (
+            <View className="gap-1">
+              {Object.entries(metadata).map(([key, value]) => (
+                <Text key={key} className="text-xs text-muted-foreground">
+                  {key}: {String(value)}
+                </Text>
+              ))}
+            </View>
+          )}
+        </View>
+      </ScrollView>
 
       <View className="flex-row gap-2 border-t border-border p-3">
         <Button

--- a/apps/mobile/src/components/agents/question-card.tsx
+++ b/apps/mobile/src/components/agents/question-card.tsx
@@ -135,12 +135,12 @@ export function QuestionCard({
   const hasAnyAnswer = hasOptionSelected || hasCustomAnswer;
 
   return (
-    <View className="mx-4 my-2 overflow-hidden rounded-xl border border-border bg-card">
+    <View className="mx-4 my-2 shrink overflow-hidden rounded-xl border border-border bg-card">
       <View className="border-b border-border bg-secondary px-4 py-3">
         <Text className="text-sm font-medium">Agent Needs Input</Text>
       </View>
 
-      <ScrollView className="max-h-96" keyboardShouldPersistTaps="handled">
+      <ScrollView className="max-h-96 shrink" keyboardShouldPersistTaps="handled">
         <View className="gap-4 p-4">
           {questions.map((question, qIndex) => {
             const allowCustom = question.custom !== false;


### PR DESCRIPTION
## Problem

Reported by a user: when a cloud agent asks for approval and the request content is taller than the screen, you can't scroll to see the full thing and can't approve/deny it.

`PermissionCard` (cloud agent chat) rendered `patterns` and `metadata` — which typically contain the full command being approved — in plain `View`s with no height limit. Since the card is a pinned, non-scrolling footer between the message list and the composer in `session-detail-content.tsx`, a long command grew the card past the screen height, clipping the Deny / Allow Once / Always Allow row off-screen with nothing scrollable.

`QuestionCard` already capped its body at `max-h-96`, but the card as a whole couldn't shrink, so on small screens with the keyboard open (its custom-answer input) the Skip/Submit buttons could also end up clipped.

## Fix

- Wrap `PermissionCard`'s body in a `ScrollView` capped at `max-h-96` (same pattern `QuestionCard` already uses), keeping the header and button row pinned.
- Add `shrink` to both cards' root and body `ScrollView` so when the available height is smaller than the cap (keyboard open, small screens), the scrollable body shrinks instead of pushing the buttons off-screen.

## Testing

`pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` in `apps/mobile` — all green.