### PR TITLE
fix(mobile): reset billing cache on kiloclaw destroy

### DIFF
--- a/apps/mobile/src/lib/hooks/use-kiloclaw-mutations.ts
+++ b/apps/mobile/src/lib/hooks/use-kiloclaw-mutations.ts
@@ -390,6 +390,12 @@ export function useKiloClawMutations(organizationId?: string | null) {
         await Promise.all([
           invalidateStatus(),
           queryClient.invalidateQueries({ queryKey: listAllInstancesKey }),
+          // Reset (not invalidate) billing: the onboarding modal dismisses
+          // itself synchronously on cached `has_access` + instanceId before a
+          // refetch can land, and the unmount aborts that refetch — so stale
+          // billing data would make "Create your agent" a no-op until app
+          // relaunch. Dropping the cache forces a fresh fetch on next mount.
+          queryClient.resetQueries({ queryKey: billingStatusKey }),
         ]);
       },
     }),


### PR DESCRIPTION
## Problem

After destroying a KiloClaw instance, tapping **Create your agent** on Home does nothing — the app has to be relaunched before onboarding works again.

## Root cause

`destroy` invalidates `getStatus` and `listAllInstances` but never touches `getBillingStatus`, which is what the mobile onboarding facade is derived from (`derive-mobile-onboarding-state.ts`). The stale cache still reports the destroyed instance as existing, so `OnboardingFlow`'s auto-dismiss effect (`has_access` + instance exists → `router.back()`) closes the modal in the same frame it opens — the button looks dead.

The cache never heals on its own: the mount-triggered refetch is aborted by the instant unmount (tRPC wires the abort signal), and nothing on Home subscribes to the billing query, so its `refetchInterval` never runs.

## Fix

Reset (not invalidate) the billing query in `destroy`'s `onSettled`. Plain invalidation isn't enough — the stale cached data would still be delivered synchronously on mount and the modal would dismiss before the refetch lands. Dropping the cache entry makes the next onboarding mount show the skeleton and fetch fresh state, which correctly lands on the identity step.

## Testing

- `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` all pass in `apps/mobile`.