### PR TITLE
fix(remote): preserve CLI model for remote sessions

### DIFF
--- a/apps/mobile/src/app/(app)/agent-chat/model-picker.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/model-picker.tsx
@@ -4,6 +4,7 @@ import { BookOpenCheck, Check, Search } from 'lucide-react-native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, Pressable, ScrollView, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { CLI_MODEL_ID } from 'cloud-agent-sdk/cli-model';
 
 import { Text } from '@/components/ui/text';
 import {
@@ -207,6 +208,7 @@ export default function ModelPickerScreen() {
         const byok = hasUserByokAvailable(modelOption);
         const collectsData = mayTrainOnYourPrompts(modelOption);
         const hasVariants = modelOption.variants.length > 1;
+        const isCliModel = modelOption.id === CLI_MODEL_ID;
         const accessibilityLabel = [
           modelOption.name,
           byok ? BYOK_MODEL_LABEL : undefined,
@@ -229,7 +231,9 @@ export default function ModelPickerScreen() {
             >
               <View className="flex-1">
                 <Text className="text-base text-foreground">{modelOption.name}</Text>
-                <Text className="text-xs text-muted-foreground">{modelOption.id}</Text>
+                {!isCliModel && (
+                  <Text className="text-xs text-muted-foreground">{modelOption.id}</Text>
+                )}
                 {free || byok || collectsData ? (
                   <View className="mt-1 flex-row items-center gap-1 self-start">
                     {free && !byok ? (

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable max-lines */
 import { type CloudStatus, type KiloSessionId, type StoredMessage } from 'cloud-agent-sdk';
+import { CLI_MODEL_ID, cliModelLabel } from 'cloud-agent-sdk/cli-model';
 import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useMemo } from 'react';
 import { ActivityIndicator, FlatList, KeyboardAvoidingView, Platform, View } from 'react-native';
@@ -61,6 +63,7 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
   const totalCost = useAtomValue(manager.atoms.totalCost);
   const getChildMessages = useAtomValue(manager.atoms.childMessages);
   const pendingMessages = useAtomValue(manager.atoms.pendingMessages);
+  const sessionType = useAtomValue(manager.atoms.sessionType);
 
   const { isConnected } = useAppLifecycle();
   const { bottom } = useSafeAreaInsets();
@@ -76,6 +79,22 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
   const organizationId = fetchedData?.organizationId ?? undefined;
 
   const { models: modelOptions } = useAvailableModels(organizationId);
+  const isRemote = sessionType === 'remote';
+  const composerModelOptions = useMemo(
+    () =>
+      isRemote
+        ? [
+            {
+              id: CLI_MODEL_ID,
+              name: cliModelLabel(sessionConfig),
+              variants: [],
+              isPreferred: false,
+            },
+            ...modelOptions,
+          ]
+        : modelOptions,
+    [isRemote, modelOptions, sessionConfig]
+  );
 
   const {
     currentMode,
@@ -84,7 +103,12 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
     setCurrentMode,
     setCurrentModel,
     setCurrentVariant,
-  } = useSessionConfigSync({ fetchedData, sessionConfig, modelOptions });
+  } = useSessionConfigSync({
+    fetchedData,
+    sessionConfig,
+    modelOptions: composerModelOptions,
+    isRemote,
+  });
 
   const {
     flatListRef,
@@ -168,13 +192,14 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
         return;
       }
       try {
+        const isCliModel = currentModel === CLI_MODEL_ID;
         await manager.send({
           payload: {
             type: 'prompt',
             prompt: text,
             mode: currentMode,
-            model: currentModel,
-            variant: currentVariant || undefined,
+            model: isCliModel ? '' : currentModel,
+            variant: isCliModel ? undefined : currentVariant || undefined,
           },
         });
       } catch {
@@ -259,7 +284,7 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
               onModeChange={setCurrentMode}
               model={currentModel}
               variant={currentVariant}
-              modelOptions={modelOptions}
+              modelOptions={composerModelOptions}
               onModelSelect={(modelId, newVariant) => {
                 setCurrentModel(modelId);
                 setCurrentVariant(newVariant);

--- a/apps/mobile/src/components/agents/use-session-config-sync.ts
+++ b/apps/mobile/src/components/agents/use-session-config-sync.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { normalizeAgentMode } from '@/components/agents/mode-options';
 import { type AgentMode } from '@/components/agents/mode-selector';
 import { type ModelOption } from '@/lib/hooks/use-available-models';
+import { CLI_MODEL_ID } from 'cloud-agent-sdk/cli-model';
 
 type SessionConfigSnapshot = {
   mode?: string | null;
@@ -14,6 +15,7 @@ type UseSessionConfigSyncOptions = {
   fetchedData: SessionConfigSnapshot | null;
   sessionConfig: SessionConfigSnapshot | null | undefined;
   modelOptions: ModelOption[];
+  isRemote: boolean;
 };
 
 type UseSessionConfigSyncResult = {
@@ -33,6 +35,7 @@ export function useSessionConfigSync({
   fetchedData,
   sessionConfig,
   modelOptions,
+  isRemote,
 }: UseSessionConfigSyncOptions): UseSessionConfigSyncResult {
   const [currentMode, setCurrentMode] = useState<AgentMode>(() =>
     normalizeAgentMode(fetchedData?.mode)
@@ -46,16 +49,19 @@ export function useSessionConfigSync({
       setCurrentMode(normalizeAgentMode(mode));
     }
 
-    const model = sessionConfig?.model ?? fetchedData?.model;
-    if (model) {
-      setCurrentModel(model);
-    }
+    if (!isRemote) {
+      const model = sessionConfig?.model ?? fetchedData?.model;
+      if (model) {
+        setCurrentModel(model);
+      }
 
-    const variant = sessionConfig?.variant ?? fetchedData?.variant;
-    if (variant) {
-      setCurrentVariant(variant);
+      const variant = sessionConfig?.variant ?? fetchedData?.variant;
+      if (variant) {
+        setCurrentVariant(variant);
+      }
     }
   }, [
+    isRemote,
     sessionConfig?.mode,
     sessionConfig?.model,
     sessionConfig?.variant,
@@ -65,7 +71,7 @@ export function useSessionConfigSync({
   ]);
 
   useEffect(() => {
-    if (currentModel || modelOptions.length === 0 || fetchedData === null) {
+    if (isRemote || currentModel || modelOptions.length === 0 || fetchedData === null) {
       return;
     }
     const firstModel = modelOptions[0];
@@ -73,7 +79,15 @@ export function useSessionConfigSync({
       setCurrentModel(firstModel.id);
       setCurrentVariant(firstModel.variants[0] ?? '');
     }
-  }, [currentModel, modelOptions, fetchedData]);
+  }, [isRemote, currentModel, modelOptions, fetchedData]);
+
+  useEffect(() => {
+    if (!isRemote) {
+      return;
+    }
+    setCurrentModel(CLI_MODEL_ID);
+    setCurrentVariant('');
+  }, [isRemote]);
 
   return {
     currentMode,

--- a/apps/mobile/src/lib/model-picker-rows.test.ts
+++ b/apps/mobile/src/lib/model-picker-rows.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { type ModelOption } from '@/lib/hooks/use-available-models';
+import { CLI_MODEL_ID } from 'cloud-agent-sdk/cli-model';
 
 import { buildModelPickerRows } from './model-picker-rows';
 
@@ -18,6 +19,13 @@ const models: ModelOption[] = [
     isPreferred: false,
   },
 ];
+
+const cliModel: ModelOption = {
+  id: CLI_MODEL_ID,
+  name: 'CLI model — anthropic/claude-sonnet-4',
+  variants: [],
+  isPreferred: false,
+};
 
 describe('buildModelPickerRows', () => {
   it('groups preferred models before all other models', () => {
@@ -40,6 +48,22 @@ describe('buildModelPickerRows', () => {
     expect(buildModelPickerRows({ models, search: 'openai/' })).toEqual([
       { key: 'all', title: 'ALL MODELS', type: 'header' },
       { key: 'model:openai/gpt-5', model: models[1], type: 'model' },
+    ]);
+  });
+
+  it('keeps the CLI model row first before section headers', () => {
+    expect(buildModelPickerRows({ models: [cliModel, ...models], search: '' })).toEqual([
+      { key: `model:${CLI_MODEL_ID}`, model: cliModel, type: 'model' },
+      { key: 'recommended', title: 'RECOMMENDED', type: 'header' },
+      { key: 'model:anthropic/claude-sonnet-4', model: models[0], type: 'model' },
+      { key: 'all', title: 'ALL MODELS', type: 'header' },
+      { key: 'model:openai/gpt-5', model: models[1], type: 'model' },
+    ]);
+  });
+
+  it('filters the CLI model row by name', () => {
+    expect(buildModelPickerRows({ models: [cliModel, ...models], search: 'CLI model' })).toEqual([
+      { key: `model:${CLI_MODEL_ID}`, model: cliModel, type: 'model' },
     ]);
   });
 });

--- a/apps/mobile/src/lib/model-picker-rows.ts
+++ b/apps/mobile/src/lib/model-picker-rows.ts
@@ -1,4 +1,5 @@
 import { type ModelOption } from '@/lib/hooks/use-available-models';
+import { CLI_MODEL_ID } from 'cloud-agent-sdk/cli-model';
 
 export type ModelPickerRow =
   | { key: string; title: string; type: 'header' }
@@ -17,8 +18,13 @@ export function buildModelPickerRows({
   );
 
   const recommended = filtered.filter(m => m.isPreferred);
-  const all = filtered.filter(m => !m.isPreferred);
+  const cliModel = filtered.find(m => m.id === CLI_MODEL_ID);
+  const all = filtered.filter(m => !m.isPreferred && m.id !== CLI_MODEL_ID);
   const result: ModelPickerRow[] = [];
+
+  if (cliModel) {
+    result.push({ key: `model:${cliModel.id}`, model: cliModel, type: 'model' });
+  }
 
   if (recommended.length > 0) {
     result.push({ key: 'recommended', title: 'RECOMMENDED', type: 'header' });

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -6,6 +6,15 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      'cloud-agent-sdk/message-id': fileURLToPath(
+        new URL('../../apps/web/src/lib/cloud-agent-sdk/message-id.ts', import.meta.url)
+      ),
+      'cloud-agent-sdk/cli-model': fileURLToPath(
+        new URL('../../apps/web/src/lib/cloud-agent-sdk/cli-model.ts', import.meta.url)
+      ),
+      'cloud-agent-sdk': fileURLToPath(
+        new URL('../../apps/web/src/lib/cloud-agent-sdk/index.ts', import.meta.url)
+      ),
     },
   },
   test: {

--- a/apps/web/src/components/cloud-agent-next/ChatInput.tsx
+++ b/apps/web/src/components/cloud-agent-next/ChatInput.tsx
@@ -64,6 +64,8 @@ type ChatInputProps = {
   model?: string;
   /** Available model options for the toolbar */
   modelOptions?: ModelOption[];
+  /** Optional model option pinned above regular gateway models. */
+  pinnedModelOption?: ModelOption;
   /** Whether models are loading */
   isLoadingModels?: boolean;
   /** Callback when mode changes */
@@ -103,6 +105,7 @@ export function ChatInput({
   mode,
   model,
   modelOptions = [],
+  pinnedModelOption,
   isLoadingModels = false,
   onModeChange,
   onModelChange,
@@ -157,8 +160,8 @@ export function ChatInput({
   // back to the raw id when the model isn't in the org's allowed list (e.g. an
   // agent pinned a model that was later restricted).
   const lockedModelOption = useMemo(
-    () => modelOptions.find(m => m.id === model),
-    [modelOptions, model]
+    () => [pinnedModelOption, ...modelOptions].find(m => m?.id === model),
+    [pinnedModelOption, modelOptions, model]
   );
   const lockedModelLabel = lockedModelOption
     ? formatShortModelDisplayName(lockedModelOption.name)
@@ -361,7 +364,8 @@ export function ChatInput({
     : undefined;
 
   // Check if toolbar should be rendered (has callbacks and options)
-  const hasToolbar = showToolbar && onModeChange && onModelChange && modelOptions.length > 0;
+  const hasToolbar =
+    showToolbar && onModeChange && onModelChange && (modelOptions.length > 0 || pinnedModelOption);
 
   return (
     <div className="px-[max(1rem,calc(50%_-_27rem))] py-3 md:py-4">
@@ -503,6 +507,7 @@ export function ChatInput({
                 onModeChange={onModeChange}
                 model={model}
                 modelOptions={modelOptions}
+                pinnedModelOption={pinnedModelOption}
                 onModelChange={onModelChange}
                 isLoadingModels={isLoadingModels}
                 variant={variant}
@@ -545,6 +550,7 @@ export function ChatInput({
                 ) : (
                   <ModelCombobox
                     models={modelOptions}
+                    pinnedModel={pinnedModelOption}
                     value={model}
                     onValueChange={onModelChange}
                     variant="compact"

--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useSearchParams } from 'next/navigation';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -8,7 +8,7 @@ import { useTRPC } from '@/lib/trpc/utils';
 import { ArrowDown, GitBranch } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 
-import type { KiloSessionId } from '@/lib/cloud-agent-sdk';
+import { CLI_MODEL_ID, cliModelLabel, type KiloSessionId } from '@/lib/cloud-agent-sdk';
 import { useManager } from './CloudAgentProvider';
 import { MobileSidebarToggle } from './MobileSidebarToggle';
 import { ChatHeader } from './ChatHeader';
@@ -222,8 +222,10 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const contextUsage = useAtomValue(manager.atoms.contextUsage);
   const getChildMessages = useAtomValue(manager.atoms.childMessages);
   const fetchedSessionData = useAtomValue(manager.atoms.fetchedSessionData);
+  const sessionType = useAtomValue(manager.atoms.sessionType);
 
   const setSessionConfig = useSetAtom(manager.atoms.sessionConfig);
+  const [useCliModel, setUseCliModel] = useState(false);
 
   const [attachmentMessageUuid] = useState(() => uuidv4());
   const [workspaceTabs, setWorkspaceTabs] = useState(createWorkspaceTabsState);
@@ -240,8 +242,18 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   // -- Organization models --------------------------------------------------
   const { modelOptions, isLoadingModels, contextLengthByModelId } =
     useOrganizationModels(organizationId);
+  const isRemote = sessionType === 'remote';
+  const pinnedModelOption = useMemo(
+    () =>
+      isRemote ? { id: CLI_MODEL_ID, name: cliModelLabel(sessionConfig), variants: [] } : undefined,
+    [isRemote, sessionConfig]
+  );
   const contextWindow = resolveContextWindow(contextUsage, contextLengthByModelId);
   const { availableCommands } = useSlashCommandSets();
+
+  useEffect(() => {
+    setUseCliModel(sessionType === 'remote');
+  }, [sessionType, sessionIdFromParams]);
 
   // -- Sound effects --------------------------------------------------------
   const { play: playCelebrationSound, soundEnabled, setSoundEnabled } = useCelebrationSound();
@@ -406,10 +418,16 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
           type: 'prompt',
           prompt,
           mode: sessionConfig?.mode ?? 'code',
-          model: agentModelOverrideForSend ?? sessionConfig?.model ?? '',
-          variant: agentModelOverrideForSend
-            ? agentVariantOverrideForSend
-            : (sessionConfig?.variant ?? undefined),
+          model:
+            useCliModel && !agentModelOverrideForSend
+              ? ''
+              : (agentModelOverrideForSend ?? sessionConfig?.model ?? ''),
+          variant:
+            useCliModel && !agentModelOverrideForSend
+              ? undefined
+              : agentModelOverrideForSend
+                ? agentVariantOverrideForSend
+                : (sessionConfig?.variant ?? undefined),
         },
         attachments: supportsAttachments ? attachments : undefined,
       });
@@ -421,7 +439,7 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
       }
       return accepted;
     },
-    [manager, scheduleScrollToBottom, sessionConfig, setChatUI, supportsAttachments]
+    [manager, scheduleScrollToBottom, sessionConfig, setChatUI, supportsAttachments, useCliModel]
   );
 
   const handleSendSlashCommand = useCallback(
@@ -581,6 +599,11 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const handleModelChange = useCallback(
     (model: string) => {
       if (!sessionConfig) return;
+      if (model === CLI_MODEL_ID) {
+        setUseCliModel(true);
+        return;
+      }
+      setUseCliModel(false);
       // Reset variant to first available (typically "none") when switching models if current is invalid
       const newModelVariants = modelOptions.find(m => m.id === model)?.variants ?? [];
       const validVariant =
@@ -625,6 +648,13 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
     ? agentVariantOverride
     : (sessionConfig?.variant ?? undefined);
   const displayAvailableVariants = modelPickerLocked ? [] : availableVariants;
+  const inputModel = modelPickerLocked ? displayModel : useCliModel ? CLI_MODEL_ID : displayModel;
+  const inputVariant = modelPickerLocked
+    ? displayVariant
+    : useCliModel
+      ? undefined
+      : displayVariant;
+  const inputAvailableVariants = modelPickerLocked || useCliModel ? [] : displayAvailableVariants;
 
   const placeholder = isLoading
     ? 'Loading session…'
@@ -807,14 +837,15 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                                 placeholder={placeholder}
                                 slashCommands={availableCommands}
                                 mode={sessionConfig?.mode as AgentMode | undefined}
-                                model={displayModel}
+                                model={inputModel}
                                 modelOptions={modelOptions}
+                                pinnedModelOption={pinnedModelOption}
                                 isLoadingModels={isLoadingModels}
                                 onModeChange={handleModeChange}
                                 onModelChange={handleModelChange}
-                                variant={displayVariant}
+                                variant={inputVariant}
                                 onVariantChange={handleVariantChange}
-                                availableVariants={displayAvailableVariants}
+                                availableVariants={inputAvailableVariants}
                                 showToolbar={Boolean(sessionIdFromParams)}
                                 initialValue={failedPrompt ?? undefined}
                                 customModeOptions={customModeOptions}

--- a/apps/web/src/components/cloud-agent-next/MobileToolbarPopover.tsx
+++ b/apps/web/src/components/cloud-agent-next/MobileToolbarPopover.tsx
@@ -17,6 +17,7 @@ type MobileToolbarPopoverProps = {
   onModeChange?: (mode: AgentMode) => void;
   model?: string;
   modelOptions: ModelOption[];
+  pinnedModelOption?: ModelOption;
   onModelChange?: (model: string) => void;
   isLoadingModels?: boolean;
   variant?: string;
@@ -38,6 +39,7 @@ export function MobileToolbarPopover({
   onModeChange,
   model,
   modelOptions,
+  pinnedModelOption,
   onModelChange,
   isLoadingModels,
   variant,
@@ -53,7 +55,7 @@ export function MobileToolbarPopover({
 }: MobileToolbarPopoverProps) {
   const [open, setOpen] = useState(false);
 
-  const selectedModel = modelOptions.find(m => m.id === model);
+  const selectedModel = [pinnedModelOption, ...modelOptions].find(m => m?.id === model);
   const displayName = selectedModel
     ? formatShortModelDisplayName(selectedModel.name)
     : 'Select model';
@@ -99,6 +101,7 @@ export function MobileToolbarPopover({
             ) : (
               <ModelCombobox
                 models={modelOptions}
+                pinnedModel={pinnedModelOption}
                 value={model}
                 onValueChange={onModelChange}
                 isLoading={isLoadingModels}

--- a/apps/web/src/components/shared/ModelCombobox.tsx
+++ b/apps/web/src/components/shared/ModelCombobox.tsx
@@ -59,6 +59,8 @@ export type ModelComboboxProps = {
   className?: string;
   /** Whether the combobox is disabled */
   disabled?: boolean;
+  /** Optional model option rendered above all grouped models without an id subtitle. */
+  pinnedModel?: ModelOption;
   /**
    * Render the popover as a modal layer. Required when the combobox is
    * itself inside a Radix Dialog — without this, the dialog's focus/pointer
@@ -85,6 +87,7 @@ export function ModelCombobox({
   variant = 'full',
   className,
   disabled = false,
+  pinnedModel,
   modal = false,
 }: ModelComboboxProps) {
   const [open, setOpen] = useState(false);
@@ -120,7 +123,7 @@ export function ModelCombobox({
     return { preferred, others };
   }, [models]);
 
-  const selectedModel = models.find(model => model.id === value);
+  const selectedModel = [pinnedModel, ...models].find(model => model?.id === value);
   const isCompact = variant === 'compact';
   const showLabel = !isCompact && label;
   const selectedCollectsData = mayTrainOnYourPrompts(selectedModel);
@@ -175,7 +178,7 @@ export function ModelCombobox({
     );
   }
 
-  if (!models || models.length === 0) {
+  if ((!models || models.length === 0) && !pinnedModel) {
     if (isCompact) {
       return (
         <Button
@@ -236,6 +239,32 @@ export function ModelCombobox({
             <CommandInput placeholder={searchPlaceholder} onValueChange={handleSearchChange} />
             <CommandEmpty>{noResultsText}</CommandEmpty>
             <CommandList ref={listRef} className="max-h-64 overflow-auto">
+              {pinnedModel && (
+                <CommandGroup>
+                  <CommandItem
+                    key={pinnedModel.id}
+                    value={`${pinnedModel.name} ${pinnedModel.id}`}
+                    keywords={[pinnedModel.id, pinnedModel.name]}
+                    onSelect={() => {
+                      onValueChange(pinnedModel.id);
+                      setOpen(false);
+                    }}
+                    className="flex items-center gap-2"
+                  >
+                    <div className="flex flex-col truncate">
+                      <div className="flex items-center gap-1.5">
+                        <span className="truncate">{pinnedModel.name}</span>
+                      </div>
+                    </div>
+                    <Check
+                      className={cn(
+                        'ml-auto h-4 w-4 shrink-0',
+                        pinnedModel.id === value ? 'opacity-100' : 'opacity-0'
+                      )}
+                    />
+                  </CommandItem>
+                </CommandGroup>
+              )}
               {sortedModels.preferred.length > 0 && (
                 <CommandGroup heading="Recommended">
                   {sortedModels.preferred.map(model => (
@@ -360,6 +389,32 @@ export function ModelCombobox({
             <CommandInput placeholder={searchPlaceholder} onValueChange={handleSearchChange} />
             <CommandEmpty>{noResultsText}</CommandEmpty>
             <CommandList ref={listRef} className="max-h-64 overflow-auto">
+              {pinnedModel && (
+                <CommandGroup>
+                  <CommandItem
+                    key={pinnedModel.id}
+                    value={`${pinnedModel.name} ${pinnedModel.id}`}
+                    keywords={[pinnedModel.id, pinnedModel.name]}
+                    onSelect={() => {
+                      onValueChange(pinnedModel.id);
+                      setOpen(false);
+                    }}
+                    className="flex items-center gap-2"
+                  >
+                    <div className="flex flex-col truncate">
+                      <div className="flex items-center gap-1.5">
+                        <span className="truncate">{pinnedModel.name}</span>
+                      </div>
+                    </div>
+                    <Check
+                      className={cn(
+                        'ml-auto h-4 w-4 shrink-0',
+                        pinnedModel.id === value ? 'opacity-100' : 'opacity-0'
+                      )}
+                    />
+                  </CommandItem>
+                </CommandGroup>
+              )}
               {sortedModels.preferred.length > 0 && (
                 <CommandGroup heading="Recommended">
                   {sortedModels.preferred.map(model => (

--- a/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.test.ts
@@ -258,6 +258,22 @@ describe('CliLiveTransport unified user web connection', () => {
         variant: 'v',
       },
     ],
+    [
+      'send',
+      () => ({
+        payload: {
+          type: 'prompt' as const,
+          prompt: 'hello',
+          mode: 'code',
+        },
+      }),
+      'send_message',
+      {
+        sessionID: KILO_SESSION_ID,
+        parts: [{ type: 'text', text: 'hello' }],
+        agent: 'code',
+      },
+    ],
     ['interrupt', () => undefined, 'interrupt', {}],
     [
       'answer',

--- a/apps/web/src/lib/cloud-agent-sdk/cli-model.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cli-model.ts
@@ -1,0 +1,8 @@
+export const CLI_MODEL_ID = '__cli-model__';
+
+export function cliModelLabel(
+  config: { model: string; providerID?: string | null } | null
+): string {
+  if (!config?.model) return 'CLI default';
+  return `CLI model — ${config.providerID ? `${config.providerID}/` : ''}${config.model}`;
+}

--- a/apps/web/src/lib/cloud-agent-sdk/index.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/index.ts
@@ -1,5 +1,8 @@
-export { createSessionManager, formatError as formatSessionError } from './session-manager';
+export { formatError as formatSessionError } from './session-manager';
+export { createSessionManager } from './session-manager';
+export { CLI_MODEL_ID, cliModelLabel } from './cli-model';
 export type {
+  ActiveSessionType,
   SessionManager,
   SessionManagerConfig,
   SessionManagerAtoms,

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -1,5 +1,6 @@
 import { createStore } from 'jotai';
 import {
+  cliModelLabel,
   createSessionManager,
   formatError,
   type SessionManagerConfig,
@@ -317,6 +318,7 @@ describe('createSessionManager', () => {
         repository: string;
         mode: string;
         model: string;
+        providerID?: string | null;
         variant?: string | null;
       }>(config.store, mgr.atoms.sessionConfig);
       expect(sessionConfig).toEqual({
@@ -324,7 +326,9 @@ describe('createSessionManager', () => {
         repository: 'test/repo',
         mode: 'code',
         model: 'claude-3-5-sonnet',
+        providerID: null,
         variant: null,
+        runtimeAgents: undefined,
       });
     });
 
@@ -2338,6 +2342,19 @@ describe('formatError', () => {
     expect(formatError('just a string')).toBe('Something went wrong. Please retry in a moment.');
     expect(formatError(null)).toBe('Something went wrong. Please retry in a moment.');
     expect(formatError(42)).toBe('Something went wrong. Please retry in a moment.');
+  });
+});
+
+describe('cliModelLabel', () => {
+  it.each([
+    [null, 'CLI default'],
+    [{ model: 'claude-3-5-sonnet', providerID: null }, 'CLI model — claude-3-5-sonnet'],
+    [
+      { model: 'claude-3-5-sonnet', providerID: 'anthropic' },
+      'CLI model — anthropic/claude-3-5-sonnet',
+    ],
+  ])('formats %p as %s', (config, expected) => {
+    expect(cliModelLabel(config)).toBe(expected);
   });
 });
 

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
@@ -35,6 +35,7 @@ import type { UserWebConnection } from './user-web-connection';
 import { generateMessageId } from './message-id';
 import { findLatestContextUsage } from './context-usage';
 import type { ContextUsage } from './context-usage';
+import { CLI_MODEL_ID, cliModelLabel } from './cli-model';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -51,6 +52,7 @@ type SessionConfig = {
   repository: string;
   mode: string;
   model: string;
+  providerID?: string | null;
   variant?: string | null;
   /** Custom modes exposed by this session's profile stack (slug + name, plus optional model and thinking-effort overrides). */
   runtimeAgents?: Array<{ slug: string; name: string; model?: string; variant?: string }>;
@@ -177,6 +179,7 @@ type SessionManagerAtoms = {
   agentStatus: W<AgentStatus>;
   cloudStatus: W<CloudStatus | null>;
   sessionConfig: W<SessionConfig | null>;
+  sessionType: W<ActiveSessionType | null>;
   chatUI: W<{ shouldAutoScroll: boolean }>;
   permission: W<PermissionState | null>;
   suggestion: W<SuggestionState | null>;
@@ -333,6 +336,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
   const agentStatusAtom = atom<AgentStatus>({ type: 'idle' });
   const cloudStatusAtom = atom<CloudStatus | null>(null);
   const sessionConfigAtom = atom<SessionConfig | null>(null);
+  const sessionTypeAtom = atom<ActiveSessionType | null>(null);
   const chatUIAtom = atom<{ shouldAutoScroll: boolean }>({ shouldAutoScroll: true });
   const activeQuestionAtom = atom<StandaloneQuestion | null>(null);
   const permissionAtom = atom<PermissionState | null>(null);
@@ -443,6 +447,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     store.set(agentStatusAtom, { type: 'idle' });
     store.set(cloudStatusAtom, null);
     store.set(sessionConfigAtom, null);
+    store.set(sessionTypeAtom, null);
     store.set(activeQuestionAtom, null);
     store.set(permissionAtom, null);
     store.set(activePermissionAtom, null);
@@ -662,6 +667,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       repository: data.repository ?? '',
       mode: data.mode ?? '',
       model: data.model ?? '',
+      providerID: null,
       variant: data.variant ?? null,
       runtimeAgents: data.runtimeAgents,
     });
@@ -724,6 +730,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       },
       onResolved: resolved => {
         activeSessionType = resolved.type;
+        store.set(sessionTypeAtom, resolved.type);
         store.set(supportsAttachmentsAtom, resolved.type === 'cloud-agent');
       },
       onBranchChanged: branch => {
@@ -760,12 +767,14 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
           if (
             currentConfig &&
             (currentConfig.model !== event.info.modelID ||
+              currentConfig.providerID !== event.info.providerID ||
               currentConfig.mode !== event.info.agent ||
               currentConfig.variant !== (event.info.variant ?? null))
           ) {
             store.set(sessionConfigAtom, {
               ...currentConfig,
               model: event.info.modelID,
+              providerID: event.info.providerID,
               mode: event.info.agent,
               variant: event.info.variant ?? null,
             });
@@ -954,6 +963,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       agentStatus: agentStatusAtom,
       cloudStatus: cloudStatusAtom,
       sessionConfig: sessionConfigAtom,
+      sessionType: sessionTypeAtom,
       chatUI: chatUIAtom,
       activeQuestion: activeQuestionAtom,
       permission: permissionAtom,
@@ -975,8 +985,9 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
   };
 }
 
-export { createSessionManager, formatError };
+export { CLI_MODEL_ID, cliModelLabel, createSessionManager, formatError };
 export type {
+  ActiveSessionType,
   SessionManager,
   SessionManagerConfig,
   SessionManagerAtoms,


### PR DESCRIPTION
## Summary
- Add SDK session type/provider tracking and a shared CLI model sentinel/label for remote sessions.
- Pin a "CLI model" option in mobile and web remote composers, selected by default, so sends omit model/variant and preserve the CLI session provider.
- Keep explicit gateway model selection behavior available and covered by SDK/mobile picker tests.

## Verification
- Manual end-to-end BYOK remote session verification left for reviewer: start a CLI remote session on an Anthropic BYOK model, send from phone/web with CLI model selected, verify the CLI remains on the Anthropic provider, then explicitly select a gateway model and verify it switches.

## Visual Changes
N/A

## Reviewer Notes
- Branch is currently behind latest main by unrelated commits; PR diff is limited to this feature.
- PLAN.md is intentionally left untracked and not included.