### PR TITLE
fix(ai-gateway): add versioned gateway models route

### DIFF
--- a/apps/web/src/app/api/gateway/v1/models/route.ts
+++ b/apps/web/src/app/api/gateway/v1/models/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/openrouter/models/route';

--- a/apps/web/src/tests/openrouter-models.test.ts
+++ b/apps/web/src/tests/openrouter-models.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe, afterEach, beforeEach } from '@jest/globals';
 import { mockOpenRouterModels, createMockResponse } from './helpers/openrouter-models.helper';
 import { GET } from '../app/api/openrouter/models/route';
+import { GET as gatewayV1ModelsGET } from '../app/api/gateway/v1/models/route';
 import { NextRequest } from 'next/server';
 
 jest.mock('@/lib/user/server', () => ({
@@ -113,6 +114,12 @@ describe('GET /api/openrouter/models', () => {
 
     expect(response.status).toBe(200);
     expect(model.terminalBench).toEqual({ overallScore: 0.551, avgAttemptCostUsd: 53.37 });
+  });
+});
+
+describe('GET /api/gateway/v1/models', () => {
+  test('uses the OpenRouter models handler', () => {
+    expect(gatewayV1ModelsGET).toBe(GET);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a versioned `/api/gateway/v1/models` Next.js route that reuses the existing OpenRouter models handler, matching the existing unversioned gateway models alias. Adds a regression assertion that the versioned gateway route exports the shared handler.

## Verification

N/A - no manual UI flow; this is an API route alias.

## Visual Changes

N/A

## Reviewer Notes

Local test execution requires the test Postgres service, which was unavailable in this container because Docker is not installed.
