### PR TITLE
fix(mobile): 44dp touch targets, accessibility, and tokenized model-picker

### DIFF
--- a/apps/mobile/src/app/(app)/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/_layout.tsx
@@ -16,8 +16,8 @@ const TAB_BAR_ICON_STYLE = {
 } satisfies ViewStyle;
 const TAB_BAR_LABEL_STYLE = {
   fontFamily: 'JetBrainsMono_500Medium',
-  fontSize: 10,
-  letterSpacing: 0,
+  fontSize: 11,
+  letterSpacing: 0.2,
   marginTop: 2,
   minWidth: TAB_BAR_ITEM_CONTENT_WIDTH,
   textAlign: 'center',

--- a/apps/mobile/src/app/(app)/kiloclaw/[instance-id]/settings/model-list.tsx
+++ b/apps/mobile/src/app/(app)/kiloclaw/[instance-id]/settings/model-list.tsx
@@ -83,11 +83,17 @@ export default function ModelListScreen() {
             <Text className="text-xs text-muted-foreground">{item.id}</Text>
           </View>
           {item.supportsVision && <Eye size={14} color={colors.mutedForeground} />}
-          {selected && <Check size={16} color="#3b82f6" />}
+          {selected && <Check size={16} color={colors.primary} />}
         </Pressable>
       );
     },
-    [currentModel, handleSelect, mutations.updateModel.isPending, colors.mutedForeground]
+    [
+      currentModel,
+      handleSelect,
+      mutations.updateModel.isPending,
+      colors.mutedForeground,
+      colors.primary,
+    ]
   );
 
   const sections = [

--- a/apps/mobile/src/components/agents/chat-composer.tsx
+++ b/apps/mobile/src/components/agents/chat-composer.tsx
@@ -166,6 +166,10 @@ export function ChatComposer({
           <Pressable
             onPress={handleStop}
             disabled={disabled}
+            hitSlop={6}
+            accessibilityRole="button"
+            accessibilityLabel="Stop generating"
+            accessibilityState={{ disabled }}
             className="h-8 w-8 items-center justify-center rounded-full bg-neutral-400 active:opacity-70 dark:bg-neutral-500"
           >
             <Square size={14} color="white" fill="white" />
@@ -174,6 +178,10 @@ export function ChatComposer({
           <Pressable
             onPress={handleSend}
             disabled={!canSend}
+            hitSlop={6}
+            accessibilityRole="button"
+            accessibilityLabel="Send message"
+            accessibilityState={{ disabled: !canSend }}
             className={`h-8 w-8 items-center justify-center rounded-full active:opacity-70 ${
               canSend ? 'bg-accent-soft' : 'bg-muted'
             }`}

--- a/apps/mobile/src/components/agents/child-session-section.tsx
+++ b/apps/mobile/src/components/agents/child-session-section.tsx
@@ -116,7 +116,7 @@ export function ChildSessionSection({
 
   const currentTool = isRunning ? getCurrentRunningTool(childMessages) : undefined;
 
-  const borderColor = getStatusBorderColor(status, colors.destructive);
+  const borderColor = getStatusBorderColor(status, colors);
 
   const handlePress = useCallback(() => {
     setIsExpanded(prev => !prev);
@@ -142,7 +142,11 @@ export function ChildSessionSection({
           style={{ transform: [{ rotate: isExpanded ? '90deg' : '0deg' }] }}
         />
 
-        {isRunning ? <Loader2 size={16} color="#3b82f6" /> : <Bot size={16} color="#3b82f6" />}
+        {isRunning ? (
+          <Loader2 size={16} color={colors.agentSky} />
+        ) : (
+          <Bot size={16} color={colors.agentSky} />
+        )}
 
         <View className="flex-1">
           <Text className="text-sm text-foreground" numberOfLines={1}>
@@ -150,7 +154,7 @@ export function ChildSessionSection({
           </Text>
           {currentTool ? (
             <Text className="text-xs text-muted-foreground" numberOfLines={1}>
-              <Text className="text-xs text-blue-500">{currentTool.tool}</Text>
+              <Text className="text-xs text-agent-sky">{currentTool.tool}</Text>
               {currentTool.context ? ` ${currentTool.context}` : ''}
             </Text>
           ) : null}
@@ -261,14 +265,14 @@ function ChildSessionMessage({
   );
 }
 
-function getStatusBorderColor(status: string, destructiveColor: string): string {
+function getStatusBorderColor(status: string, colors: ReturnType<typeof useThemeColors>): string {
   if (status === 'error') {
-    return destructiveColor;
+    return colors.destructive;
   }
   if (status === 'completed') {
-    return '#22c55e';
+    return colors.good;
   }
-  return '#3b82f6';
+  return colors.agentSky;
 }
 
 function StatusBadge({ status }: Readonly<{ status: string }>) {

--- a/apps/mobile/src/components/agents/child-session-section.tsx
+++ b/apps/mobile/src/components/agents/child-session-section.tsx
@@ -5,7 +5,7 @@ import Animated, { FadeIn, LinearTransition } from 'react-native-reanimated';
 import { type Part, type StoredMessage, type ToolPart } from 'cloud-agent-sdk';
 
 import { Text } from '@/components/ui/text';
-import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { type ThemeColors, useThemeColors } from '@/lib/hooks/use-theme-colors';
 
 import { MessageErrorBoundary } from './message-error-boundary';
 import { isToolPart } from './part-types';
@@ -265,7 +265,7 @@ function ChildSessionMessage({
   );
 }
 
-function getStatusBorderColor(status: string, colors: ReturnType<typeof useThemeColors>): string {
+function getStatusBorderColor(status: string, colors: ThemeColors): string {
   if (status === 'error') {
     return colors.destructive;
   }

--- a/apps/mobile/src/components/agents/session-list-screen.tsx
+++ b/apps/mobile/src/components/agents/session-list-screen.tsx
@@ -234,7 +234,8 @@ export function AgentSessionListScreen() {
               onPress={() => {
                 router.push(getNewAgentSessionPath(organizationId) as Href);
               }}
-              hitSlop={11}
+              // right slop capped so the expanded targets don't overlap inside the 16px gap
+              hitSlop={{ top: 11, bottom: 11, left: 11, right: 8 }}
               accessibilityRole="button"
               accessibilityLabel="New session"
               className="active:opacity-70"
@@ -245,7 +246,7 @@ export function AgentSessionListScreen() {
               onPress={() => {
                 setShowFilterModal(true);
               }}
-              hitSlop={12}
+              hitSlop={{ top: 12, bottom: 12, left: 8, right: 12 }}
               accessibilityRole="button"
               accessibilityLabel="Filter sessions"
               className="active:opacity-70"

--- a/apps/mobile/src/components/agents/session-list-screen.tsx
+++ b/apps/mobile/src/components/agents/session-list-screen.tsx
@@ -234,8 +234,10 @@ export function AgentSessionListScreen() {
               onPress={() => {
                 router.push(getNewAgentSessionPath(organizationId) as Href);
               }}
-              hitSlop={8}
+              hitSlop={11}
+              accessibilityRole="button"
               accessibilityLabel="New session"
+              className="active:opacity-70"
             >
               <Plus size={22} color={colors.foreground} />
             </Pressable>
@@ -243,8 +245,10 @@ export function AgentSessionListScreen() {
               onPress={() => {
                 setShowFilterModal(true);
               }}
-              hitSlop={8}
+              hitSlop={12}
+              accessibilityRole="button"
               accessibilityLabel="Filter sessions"
+              className="active:opacity-70"
             >
               <SlidersHorizontal
                 size={20}

--- a/apps/mobile/src/components/kiloclaw/model-picker.tsx
+++ b/apps/mobile/src/components/kiloclaw/model-picker.tsx
@@ -122,7 +122,9 @@ export function ModelPicker() {
             <Pressable
               key={card.id}
               className={`relative gap-3 rounded-lg border p-4 active:opacity-80 ${
-                selected ? 'border-primary bg-accent-soft' : 'border-border bg-secondary'
+                selected
+                  ? 'border-primary bg-neutral-100 dark:bg-neutral-800'
+                  : 'border-border bg-secondary'
               }`}
               disabled={mutations.updateModel.isPending}
               onPress={() => {
@@ -130,7 +132,7 @@ export function ModelPicker() {
               }}
               accessibilityRole="button"
               accessibilityState={{ selected, disabled: mutations.updateModel.isPending }}
-              accessibilityLabel={`${card.label} auto model${selected ? ', selected' : ''}`}
+              accessibilityLabel={`${card.label} auto model`}
             >
               {selected && (
                 <View className="absolute right-3 top-3">

--- a/apps/mobile/src/components/kiloclaw/model-picker.tsx
+++ b/apps/mobile/src/components/kiloclaw/model-picker.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { useInstanceContext } from '@/lib/hooks/use-instance-context';
 import { useKiloClawConfig, useKiloClawMutations } from '@/lib/hooks/use-kiloclaw-queries';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { addModelPrefix, stripModelPrefix } from '@/lib/model-id';
 
 type AutoModelCard = {
@@ -14,7 +15,7 @@ type AutoModelCard = {
   description: string;
   icon: LucideIcon;
   iconBg: string;
-  iconColor: string;
+  iconColorKey: 'agentSky' | 'agentYuki';
   cost: number;
   performance: number;
   performanceDotColor: string;
@@ -26,8 +27,8 @@ const AUTO_MODEL_CARDS: AutoModelCard[] = [
     label: 'Frontier',
     description: 'Highest performance. Routes to frontier models with reasoning.',
     icon: Zap,
-    iconBg: 'bg-purple-500/20',
-    iconColor: '#a855f7',
+    iconBg: 'bg-agent-yuki-tile-bg',
+    iconColorKey: 'agentYuki',
     cost: 3,
     performance: 3,
     performanceDotColor: 'bg-purple-400',
@@ -37,8 +38,8 @@ const AUTO_MODEL_CARDS: AutoModelCard[] = [
     label: 'Balanced',
     description: 'Smart balance of speed and capability at lower cost.',
     icon: Scale,
-    iconBg: 'bg-blue-500/20',
-    iconColor: '#3b82f6',
+    iconBg: 'bg-agent-sky-tile-bg',
+    iconColorKey: 'agentSky',
     cost: 2,
     performance: 2,
     performanceDotColor: 'bg-blue-400',
@@ -87,6 +88,7 @@ export function ModelPicker() {
   const { organizationId } = useInstanceContext(instanceId);
   const { data: config, isLoading } = useKiloClawConfig(organizationId);
   const mutations = useKiloClawMutations(organizationId);
+  const colors = useThemeColors();
 
   const currentModel = stripModelPrefix(config?.kilocodeDefaultModel);
   const isAutoModel = AUTO_MODEL_IDS.has(currentModel);
@@ -119,19 +121,24 @@ export function ModelPicker() {
           return (
             <Pressable
               key={card.id}
-              className={`relative gap-3 rounded-lg border p-4 ${selected ? 'border-blue-500 bg-blue-500/5' : 'border-border bg-secondary'}`}
+              className={`relative gap-3 rounded-lg border p-4 active:opacity-80 ${
+                selected ? 'border-primary bg-accent-soft' : 'border-border bg-secondary'
+              }`}
               disabled={mutations.updateModel.isPending}
               onPress={() => {
                 handleSelectAutoModel(card.id);
               }}
+              accessibilityRole="button"
+              accessibilityState={{ selected, disabled: mutations.updateModel.isPending }}
+              accessibilityLabel={`${card.label} auto model${selected ? ', selected' : ''}`}
             >
               {selected && (
                 <View className="absolute right-3 top-3">
-                  <CheckCircle2 size={20} color="#3b82f6" />
+                  <CheckCircle2 size={20} color={colors.primary} />
                 </View>
               )}
               <View className={`h-9 w-9 items-center justify-center rounded-lg ${card.iconBg}`}>
-                <Icon size={20} color={card.iconColor} />
+                <Icon size={20} color={colors[card.iconColorKey]} />
               </View>
               <View className="gap-1">
                 <Text className="font-semibold">{card.label}</Text>
@@ -161,10 +168,12 @@ export function ModelPicker() {
 
       {/* Navigate to full model list */}
       <Pressable
-        className="items-center py-2 active:opacity-70"
+        className="min-h-11 items-center justify-center py-2 active:opacity-70"
         onPress={() => {
           router.push(`/(app)/kiloclaw/${instanceId}/settings/model-list` as Href);
         }}
+        accessibilityRole="link"
+        accessibilityLabel="Browse all 500+ models"
       >
         <Text className="text-sm text-muted-foreground">or select from 500+ models</Text>
       </Pressable>

--- a/apps/mobile/src/components/profile-avatar-button.tsx
+++ b/apps/mobile/src/components/profile-avatar-button.tsx
@@ -17,6 +17,8 @@ export function ProfileAvatarButton() {
       }}
       accessibilityRole="button"
       accessibilityLabel="Open profile"
+      className="h-11 w-11 items-center justify-center rounded-full active:opacity-70"
+      hitSlop={6}
     >
       <CircleUserRound size={22} color={colors.foreground} />
     </Pressable>

--- a/apps/mobile/src/components/profile-avatar-button.tsx
+++ b/apps/mobile/src/components/profile-avatar-button.tsx
@@ -18,7 +18,6 @@ export function ProfileAvatarButton() {
       accessibilityRole="button"
       accessibilityLabel="Open profile"
       className="h-11 w-11 items-center justify-center rounded-full active:opacity-70"
-      hitSlop={6}
     >
       <CircleUserRound size={22} color={colors.foreground} />
     </Pressable>

--- a/apps/mobile/src/components/screen-header.tsx
+++ b/apps/mobile/src/components/screen-header.tsx
@@ -91,6 +91,7 @@ export function ScreenHeader({
                 }
               }}
               hitSlop={12}
+              accessibilityRole="button"
               accessibilityLabel="Go back"
               className="-ml-1 mr-1 active:opacity-70"
             >

--- a/apps/mobile/src/components/screen-header.tsx
+++ b/apps/mobile/src/components/screen-header.tsx
@@ -64,7 +64,9 @@ export function ScreenHeader({
     titleNode = onTitlePress ? (
       <Pressable
         onPress={onTitlePress}
-        hitSlop={8}
+        hitSlop={13}
+        accessibilityRole="button"
+        accessibilityLabel={title ? `Open menu for ${title}` : 'Open menu'}
         className="flex-row items-center gap-1 active:opacity-70"
       >
         {titleText}

--- a/apps/mobile/src/components/ui/button.tsx
+++ b/apps/mobile/src/components/ui/button.tsx
@@ -22,7 +22,6 @@ const buttonVariants = cva(
         sm: 'h-9 gap-1.5 rounded-md px-3',
         lg: 'h-11 rounded-md px-6',
         icon: 'h-10 w-10',
-        touch: 'h-11 min-w-11 px-4 py-2',
       },
     },
     defaultVariants: {
@@ -48,7 +47,6 @@ const buttonTextVariants = cva('text-foreground text-sm font-semibold', {
       sm: '',
       lg: '',
       icon: '',
-      touch: '',
     },
   },
   defaultVariants: {
@@ -73,21 +71,5 @@ function Button({ className, variant, size, ...props }: ButtonProps) {
   );
 }
 
-type IconButtonProps = Omit<ButtonProps, 'accessibilityLabel' | 'children' | 'role'> & {
-  /** Required — icon-only buttons must announce their action. */
-  accessibilityLabel: string;
-  children: React.ReactNode;
-};
-
-/**
- * Icon-only `Button`. Requires `accessibilityLabel` at the type level so
- * VoiceOver / TalkBack always has a name. Use for dense toolbars; consider
- * adding `hitSlop` to reach a 44dp effective target where the visual is
- * smaller than 44dp.
- */
-function IconButton({ className, variant = 'outline', size = 'icon', ...props }: IconButtonProps) {
-  return <Button variant={variant} size={size} className={className} role="button" {...props} />;
-}
-
-export { Button, buttonTextVariants, buttonVariants, IconButton };
-export type { ButtonProps, IconButtonProps };
+export { Button, buttonTextVariants, buttonVariants };
+export type { ButtonProps };

--- a/apps/mobile/src/components/ui/button.tsx
+++ b/apps/mobile/src/components/ui/button.tsx
@@ -22,6 +22,7 @@ const buttonVariants = cva(
         sm: 'h-9 gap-1.5 rounded-md px-3',
         lg: 'h-11 rounded-md px-6',
         icon: 'h-10 w-10',
+        touch: 'h-11 min-w-11 px-4 py-2',
       },
     },
     defaultVariants: {
@@ -47,6 +48,7 @@ const buttonTextVariants = cva('text-foreground text-sm font-semibold', {
       sm: '',
       lg: '',
       icon: '',
+      touch: '',
     },
   },
   defaultVariants: {
@@ -71,5 +73,21 @@ function Button({ className, variant, size, ...props }: ButtonProps) {
   );
 }
 
-export { Button, buttonTextVariants, buttonVariants };
-export type { ButtonProps };
+type IconButtonProps = Omit<ButtonProps, 'accessibilityLabel' | 'children' | 'role'> & {
+  /** Required — icon-only buttons must announce their action. */
+  accessibilityLabel: string;
+  children: React.ReactNode;
+};
+
+/**
+ * Icon-only `Button`. Requires `accessibilityLabel` at the type level so
+ * VoiceOver / TalkBack always has a name. Use for dense toolbars; consider
+ * adding `hitSlop` to reach a 44dp effective target where the visual is
+ * smaller than 44dp.
+ */
+function IconButton({ className, variant = 'outline', size = 'icon', ...props }: IconButtonProps) {
+  return <Button variant={variant} size={size} className={className} role="button" {...props} />;
+}
+
+export { Button, buttonTextVariants, buttonVariants, IconButton };
+export type { ButtonProps, IconButtonProps };

--- a/apps/mobile/src/components/ui/configure-row.tsx
+++ b/apps/mobile/src/components/ui/configure-row.tsx
@@ -57,10 +57,8 @@ export function ConfigureRow({
         <Icon size={16} color={iconColor} />
       </View>
       <View className="flex-1">
-        <Text className="text-[14px] font-medium text-foreground">{title}</Text>
-        {subtitle ? (
-          <Text className="mt-0.5 text-[11.5px] text-muted-foreground">{subtitle}</Text>
-        ) : null}
+        <Text className="text-sm font-medium text-foreground">{title}</Text>
+        {subtitle ? <Text className="mt-0.5 text-xs text-muted-foreground">{subtitle}</Text> : null}
       </View>
       {trailing ?? <ChevronRight size={14} color={colors.mutedForeground} />}
     </View>

--- a/apps/mobile/src/components/ui/session-row.tsx
+++ b/apps/mobile/src/components/ui/session-row.tsx
@@ -79,21 +79,18 @@ export function SessionRow({
           <Eyebrow className={color.hueTextClass}>{agentLabel}</Eyebrow>
           {live && <StatusDot tone="good" glow />}
           {!live && meta && (
-            <Text variant="mono" className="text-[10.5px] text-ink2">
+            <Text variant="mono" className="text-xs text-ink2">
               {meta}
             </Text>
           )}
         </View>
-        <Text
-          className="text-[14.5px] font-medium tracking-tight leading-[19px] text-foreground"
-          numberOfLines={1}
-        >
+        <Text className="text-sm font-medium tracking-tight text-foreground" numberOfLines={1}>
           {title}
         </Text>
         {subtitle ? (
           <Text
             variant="mono"
-            className="mt-1 text-[10.5px] tracking-[0.3px] text-muted-soft"
+            className="mt-1 text-xs tracking-[0.3px] text-muted-soft"
             numberOfLines={1}
           >
             {subtitle}


### PR DESCRIPTION
## Summary

Closes the remediation phases of `.plans/mobile-readability-touch-target-audit.md`. The audit report itself is in `.plans/mobile-ui-audit-findings.md` (not committed, per repo policy on plans).

Touch targets and accessibility
- `agents/chat-composer.tsx`: send/stop now have `hitSlop` reaching 44dp, plus `accessibilityRole`, `accessibilityLabel`, and `accessibilityState`.
- `profile-avatar-button.tsx`: full 44dp box (`h-11 w-11`) with `accessibilityRole` and pressed feedback.
- `screen-header.tsx`: title dropdown gets 44dp `hitSlop` + role/label; the back button now has `accessibilityRole="button"`.
- `agents/session-list-screen.tsx` (plus/filter): 44dp-reaching `hitSlop`, `accessibilityRole`, pressed feedback. The facing slops are capped at 8 so the two expanded targets don't overlap inside the 16px gap (overlapping sibling hit rects let the later sibling steal taps).

Readability
- `ui/session-row.tsx`, `ui/configure-row.tsx`: replace `text-[10.5px]` / `text-[11.5px]` / `text-[14.5px]` arbitrary sizes with the nearest sanctioned `text-xs` / `text-sm` utilities.
- `app/(app)/(tabs)/_layout.tsx`: raise tab-label font size from 10px to 11px (with small letter-spacing).

Tokenization (no more hardcoded brand-blue)
- `kiloclaw/model-picker.tsx`: selected state moves from `border-blue-500 bg-blue-500/5` + `#3b82f6` to `border-primary bg-neutral-100 dark:bg-neutral-800` + `colors.primary` (the established selected-card pattern from `exec-policy.tsx`; an opaque `bg-accent-soft` fill was tried first but is `#E8F27A` in both themes, which made dark-mode card text and the primary-colored checkmark illegible). Decorative `Balanced` / `Frontier` icon tints now use the existing `agent-sky` / `agent-yuki` tile-bg tokens. The 'or select from 500+ models' link is enlarged to a 44dp target with `accessibilityRole='link'` and a label.
- `kiloclaw/settings/model-list.tsx`: selected `Check` color → `colors.primary`.
- `agents/child-session-section.tsx`: running-tool icons / text / border move from `#3b82f6` / `text-blue-500` to the `agent-sky` token set (theme-aware light + dark).

Out of scope: chat gutters (already consistent at `px-4` on both `message-bubble.tsx` files), status-badge palettes (green / red / blue is a deliberate semantic set), the model-picker `performanceDotColor` dots (same deliberate-decorative category), and the eyebrow / 10-11px metadata typography (intentional per the design contract).

A `size='touch'` Button variant and an a11y-enforcing `IconButton` wrapper were originally added in `ui/button.tsx` but dropped in review: nothing consumed them, and knip ignores `src/components/ui/**` so they would have shipped as permanently unchecked dead code. They can return in the same PR as their first call site.

## Verification

Manual device verification is required but was not done by the agent (no simulator / device access in this worktree). Items to spot-check on iOS and Android, light + dark:
- `ChatComposer` (agent chat): tap reliability and VoiceOver / TalkBack announcement of 'Send message' / 'Stop generating'.
- `SessionHeader` (`ScreenHeader` with `onTitlePress`): title now announces 'Open menu for \<title\>'. Back button announces as a button.
- Profile avatar, Agents list plus / filter: tap reliability near the screen edge, and that a tap between the plus and filter icons hits the intended control.
- KiloClaw model picker: selected card contrast in light + dark (neutral fill + `primary` border/check); the 'select from 500+ models' link target.
- `SessionRow` / `ConfigureRow` long-title truncation (already had `numberOfLines={1}`, now at `text-sm` / `text-xs`).
- Tab bar at default and 130% Dynamic Type: 'KiloClaw' label still fits the 64dp content width.

Automated checks: `pnpm format`, `pnpm typecheck` (mobile + full repo), `pnpm lint`, `pnpm test` (360/360), `pnpm check:unused` all clean.

## Visual Changes

Visual changes are limited to:
- Tab labels slightly larger (10 → 11px) at the bottom of every screen.
- KiloClaw model picker selected state changes from a blue ring to a brand yellow-green (`primary`) border on a neutral fill (`bg-neutral-100` / `dark:bg-neutral-800`).
- `SessionRow` and `ConfigureRow` row titles / subtitles are 1-2px larger.
- All `hitSlop` changes are invisible; they expand the tap area without changing visual size.

Screenshots were not captured by the agent; visual confirmation is part of the manual checklist above.

## Reviewer Notes

Seven small commits; the last one applies review findings (dark-mode selected-card contrast, overlapping hitSlop rects, dropping the unused `IconButton`/`touch` surface, `ThemeColors` type reuse, double 'selected' screen-reader announcement).

Risk areas
- `getStatusBorderColor` in `child-session-section.tsx` now takes the full `ThemeColors` object instead of just `destructiveColor`. Tested only by typecheck and existing tests.
- The asymmetric `hitSlop` insets on the session-list header buttons trade ~3dp of horizontal target for non-overlapping hit rects; vertical targets stay at 44dp.
