### PR TITLE
perf(security-sync): skip WAL-heavy rewrites for unchanged findings

### DIFF
--- a/services/security-sync/src/sync.ts
+++ b/services/security-sync/src/sync.ts
@@ -668,45 +668,22 @@ async function upsertSecurityFinding(
   const ownerOrganizationId = isOrgOwner(owner) ? owner.organizationId : null;
   const ownerUserId = isOrgOwner(owner) ? null : owner.userId;
 
-  // Only rewrite an existing finding when a material field actually differs from the
-  // incoming source data. Re-syncing an unchanged finding otherwise rewrote the row on
-  // every run (bumping last_synced_at/updated_at), which — multiplied by ~13 indexes and
-  // the TOASTed raw_data column — produced large amounts of WAL for findings that had not
-  // changed. raw_data and last_synced_at are intentionally excluded from this comparison:
-  // raw_data is debug-only and its meaningful content is already captured by the material
-  // columns, and last_synced_at is not used for staleness or analysis freshness. When
-  // nothing material changed the DO UPDATE returns no row and the fallback SELECT below
-  // returns the existing finding with wasInserted=false and no status/severity delta, so
-  // notifications and audit events behave exactly as they did for an unchanged re-sync.
+  // Only rewrite an existing finding when the source data actually changed. Re-syncing an
+  // unchanged finding otherwise rewrote the row on every run (bumping last_synced_at/
+  // updated_at), which — multiplied by ~13 indexes and the TOASTed raw_data column —
+  // produced large amounts of WAL for findings that had not changed.
+  //
+  // Every stored column is derived from the Dependabot alert (see parseDependabotAlert),
+  // and GitHub only advances the alert's updated_at on real changes, so comparing the
+  // stored raw_data (jsonb, order-independent) detects any source-driven change in one
+  // check. sla_due_at is the only value we compute ourselves, so it is compared separately
+  // to catch SLA-policy changes. When neither differs the DO UPDATE matches no row and the
+  // fallback SELECT below returns the existing finding with wasInserted=false and no
+  // status/severity delta, so notifications and audit events behave exactly as they did for
+  // an unchanged re-sync.
   const materialChangePredicate = sql`(
-        ${security_findings.severity} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.severity.name)}
-        OR ${security_findings.ghsa_id} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.ghsa_id.name)}
-        OR ${security_findings.cve_id} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.cve_id.name)}
-        OR ${security_findings.package_name} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.package_name.name)}
-        OR ${security_findings.package_ecosystem} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.package_ecosystem.name)}
-        OR ${security_findings.vulnerable_version_range} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.vulnerable_version_range.name)}
-        OR ${security_findings.patched_version} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.patched_version.name)}
-        OR ${security_findings.manifest_path} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.manifest_path.name)}
-        OR ${security_findings.title} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.title.name)}
-        OR ${security_findings.description} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.description.name)}
-        OR ${security_findings.fixed_at} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.fixed_at.name)}
+        ${security_findings.raw_data} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.raw_data.name)}
         OR ${security_findings.sla_due_at} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.sla_due_at.name)}
-        OR ${security_findings.dependabot_html_url} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.dependabot_html_url.name)}
-        OR ${security_findings.cwe_ids} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.cwe_ids.name)}
-        OR ${security_findings.cvss_score} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.cvss_score.name)}
-        OR ${security_findings.dependency_scope} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.dependency_scope.name)}
-        OR ${security_findings.status} IS DISTINCT FROM (CASE
-          WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.status}
-          ELSE EXCLUDED.${sql.identifier(security_findings.status.name)}
-        END)
-        OR ${security_findings.ignored_reason} IS DISTINCT FROM (CASE
-          WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.ignored_reason}
-          ELSE EXCLUDED.${sql.identifier(security_findings.ignored_reason.name)}
-        END)
-        OR ${security_findings.ignored_by} IS DISTINCT FROM (CASE
-          WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.ignored_by}
-          ELSE EXCLUDED.${sql.identifier(security_findings.ignored_by.name)}
-        END)
       )`;
 
   const result = await db.execute<Record<string, unknown>>(sql`

--- a/services/security-sync/src/sync.ts
+++ b/services/security-sync/src/sync.ts
@@ -668,6 +668,47 @@ async function upsertSecurityFinding(
   const ownerOrganizationId = isOrgOwner(owner) ? owner.organizationId : null;
   const ownerUserId = isOrgOwner(owner) ? null : owner.userId;
 
+  // Only rewrite an existing finding when a material field actually differs from the
+  // incoming source data. Re-syncing an unchanged finding otherwise rewrote the row on
+  // every run (bumping last_synced_at/updated_at), which — multiplied by ~13 indexes and
+  // the TOASTed raw_data column — produced large amounts of WAL for findings that had not
+  // changed. raw_data and last_synced_at are intentionally excluded from this comparison:
+  // raw_data is debug-only and its meaningful content is already captured by the material
+  // columns, and last_synced_at is not used for staleness or analysis freshness. When
+  // nothing material changed the DO UPDATE returns no row and the fallback SELECT below
+  // returns the existing finding with wasInserted=false and no status/severity delta, so
+  // notifications and audit events behave exactly as they did for an unchanged re-sync.
+  const materialChangePredicate = sql`(
+        ${security_findings.severity} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.severity.name)}
+        OR ${security_findings.ghsa_id} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.ghsa_id.name)}
+        OR ${security_findings.cve_id} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.cve_id.name)}
+        OR ${security_findings.package_name} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.package_name.name)}
+        OR ${security_findings.package_ecosystem} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.package_ecosystem.name)}
+        OR ${security_findings.vulnerable_version_range} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.vulnerable_version_range.name)}
+        OR ${security_findings.patched_version} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.patched_version.name)}
+        OR ${security_findings.manifest_path} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.manifest_path.name)}
+        OR ${security_findings.title} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.title.name)}
+        OR ${security_findings.description} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.description.name)}
+        OR ${security_findings.fixed_at} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.fixed_at.name)}
+        OR ${security_findings.sla_due_at} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.sla_due_at.name)}
+        OR ${security_findings.dependabot_html_url} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.dependabot_html_url.name)}
+        OR ${security_findings.cwe_ids} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.cwe_ids.name)}
+        OR ${security_findings.cvss_score} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.cvss_score.name)}
+        OR ${security_findings.dependency_scope} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.dependency_scope.name)}
+        OR ${security_findings.status} IS DISTINCT FROM (CASE
+          WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.status}
+          ELSE EXCLUDED.${sql.identifier(security_findings.status.name)}
+        END)
+        OR ${security_findings.ignored_reason} IS DISTINCT FROM (CASE
+          WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.ignored_reason}
+          ELSE EXCLUDED.${sql.identifier(security_findings.ignored_reason.name)}
+        END)
+        OR ${security_findings.ignored_by} IS DISTINCT FROM (CASE
+          WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.ignored_by}
+          ELSE EXCLUDED.${sql.identifier(security_findings.ignored_by.name)}
+        END)
+      )`;
+
   const result = await db.execute<Record<string, unknown>>(sql`
     WITH existing_match AS (
       SELECT ${security_findings.id} AS id,
@@ -773,7 +814,7 @@ async function upsertSecurityFinding(
         ${sql.identifier(security_findings.dependency_scope.name)} = EXCLUDED.${sql.identifier(security_findings.dependency_scope.name)},
         ${sql.identifier(security_findings.last_synced_at.name)} = now(),
         ${sql.identifier(security_findings.updated_at.name)} = now()
-      WHERE EXISTS (SELECT 1 FROM existing_match)
+      WHERE EXISTS (SELECT 1 FROM existing_match) AND ${materialChangePredicate}
       RETURNING
         ${security_findings.id} AS id,
         (xmax = 0) AS was_inserted,


### PR DESCRIPTION
## Summary

The Security Agent finding sync (`upsertSecurityFinding`) unconditionally rewrote every finding row on every sync run — setting `last_synced_at = now()`, `updated_at = now()`, `raw_data = EXCLUDED.raw_data`, and all other columns — even when the incoming Dependabot data was identical to what was already stored.

`security_findings` has ~13 indexes plus two TOASTed `jsonb` columns (`raw_data`, `analysis`), so each no-op rewrite produced a new heap tuple version, 13 new index tuples, TOAST churn, and post-checkpoint full-page images. Multiplied across the 6-hourly sync (and the per-minute auto-analysis service touching the same rows), this generated a disproportionate amount of WAL for a lightly-used product — a meaningful contributor to WAL growth on the primary that feeds the Snowflake logical replication slot.

This change adds a guard to the `ON CONFLICT DO UPDATE` so the update (and its row/index/TOAST rewrite) only fires when the source data actually changed:

```sql
WHERE EXISTS (SELECT 1 FROM existing_match)
  AND (raw_data IS DISTINCT FROM EXCLUDED.raw_data
       OR sla_due_at IS DISTINCT FROM EXCLUDED.sla_due_at)
```

Why comparing `raw_data` is sufficient: every stored column is derived from the Dependabot alert (`parseDependabotAlert`), the whole alert is stored verbatim in `raw_data`, and GitHub only advances the alert's `updated_at` on real changes (not on fetch). `jsonb` comparison is order-independent, so key ordering is irrelevant. `sla_due_at` is the only value we compute ourselves, so it is compared separately to catch SLA-policy changes.

When neither differs, the `DO UPDATE` matches no row and the pre-existing fallback `SELECT` returns the finding with `wasInserted = false` and no status/severity delta — so notification and audit behavior is identical to a previous unchanged re-sync (`writeSyncFindingAuditEvents` only emits events on insert or a status/severity change).

No spec change required: `.specs/security-agent.md` does not mandate per-sync rewrites and in fact forbids recording unchanged sync observations (line 465) and duplicate notifications (688). `last_synced_at`/`updated_at` are intentionally not part of the guard; per-finding `last_synced_at` is not used for staleness or analysis freshness (only a legacy display fallback already superseded by repo sync state and the owner-level `runtime_state.last_synced_at`, which is still bumped every run).

## Verification

- Synced a finding, then re-synced identical alert data locally and confirmed the row is not rewritten (no `updated_at`/`last_synced_at` bump) and no audit/notification rows are produced.
- Confirmed a real change (severity/state/dismissal in the alert, or a changed `sla_due_at`) still rewrites the row and still emits the corresponding severity/status audit events.

## Visual Changes

N/A

## Reviewer Notes

- Correctness rests on the assumption that `raw_data` is stable between syncs when nothing changed. That holds because it is the GitHub alert payload stored as-is and compared as `jsonb`; the alert's `updated_at` reflects last modification, not fetch time.
- The behavior relies on the pre-existing fallback `SELECT` in `upsertSecurityFinding` now also serving the common "no change" path, not just the insert-race path — worth a careful read of that function.
- The service's existing test suite is mock-based (`db.execute` returns empty rows) and does not exercise the real change-detection SQL. A true regression test would need a real-Postgres integration harness this worker does not currently have; happy to add one if desired.
