### PR TITLE
fix(cloud-agent-sdk): reconnect immediately on foreground after long background

### DIFF
--- a/apps/web/src/lib/cloud-agent-sdk/base-connection.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/base-connection.test.ts
@@ -277,6 +277,56 @@ describe('createBaseConnection – stale WebSocket recovery', () => {
 
       connection.destroy();
     });
+
+    it('reconnects immediately on resume when hidden for the full staleness window (zombie socket)', async () => {
+      const { connection, onDisconnected } = createTestConnection();
+      connection.connect();
+      connectSocket(0);
+
+      simulateVisibilityChange('hidden');
+      jest.advanceTimersByTime(DEFAULT_STALENESS_TIMEOUT_MS);
+
+      // Socket still reports OPEN (zombie) — resume should reconnect without
+      // waiting for another full staleness window.
+      simulateVisibilityChange('visible');
+
+      // No advanceTimersByTime here — reconnect should happen right away
+      // (refreshAndConnect resolves on a microtask when no refreshAuth is configured).
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(sockets[0].close).toHaveBeenCalled();
+      expect(onDisconnected).toHaveBeenCalled();
+      expect(sockets).toHaveLength(2);
+
+      connection.destroy();
+    });
+
+    it('preserves the passive staleness wait when hidden only briefly', () => {
+      const { connection, onDisconnected } = createTestConnection();
+      connection.connect();
+      connectSocket(0);
+
+      // Last message is already stale before hiding.
+      jest.advanceTimersByTime(DEFAULT_STALENESS_TIMEOUT_MS);
+
+      simulateVisibilityChange('hidden');
+      // Hidden only briefly — well under the staleness threshold.
+      jest.advanceTimersByTime(5000);
+      simulateVisibilityChange('visible');
+
+      // Not hidden long enough to skip the passive wait — timer armed, not fired yet.
+      expect(sockets).toHaveLength(1);
+
+      // Advance past the staleness timeout — the timer should still govern.
+      jest.advanceTimersByTime(DEFAULT_STALENESS_TIMEOUT_MS);
+
+      expect(sockets[0].close).toHaveBeenCalled();
+      expect(onDisconnected).toHaveBeenCalled();
+      expect(sockets).toHaveLength(2);
+
+      connection.destroy();
+    });
   });
 
   describe('BFCache (pageshow)', () => {

--- a/apps/web/src/lib/cloud-agent-sdk/base-connection.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/base-connection.ts
@@ -76,6 +76,7 @@ export function createBaseConnection<T>(config: BaseConnectionConfig<T>): Connec
   let hasConnectedOnce = false;
   let stalenessTimeoutId: ReturnType<typeof setTimeout> | null = null;
   let lastMessageTime = 0;
+  let hiddenAt = 0;
   let preconnectAuthRefreshAttempted = false;
   const stalenessTimeoutMs = config.stalenessTimeoutMs ?? DEFAULT_STALENESS_TIMEOUT_MS;
 
@@ -289,11 +290,28 @@ export function createBaseConnection<T>(config: BaseConnectionConfig<T>): Connec
     };
   }
 
+  function replaceStaleSocketAndReconnect(currentGeneration: number): void {
+    if (destroyed || intentionalDisconnect || currentGeneration !== generation) return;
+    if (!notifyReplacingConnection(currentGeneration)) return;
+    const staleWs = ws;
+    if (staleWs !== null) {
+      ws = null;
+      staleWs.close();
+    }
+    if (connected) {
+      connected = false;
+      config.onDisconnected();
+    }
+    void refreshAndConnect(currentGeneration);
+  }
+
   function handleVisibilityResume(): void {
     if (destroyed || intentionalDisconnect) return;
 
     // Tab became visible
     reconnectAttempt = 0;
+    const wasHiddenSince = hiddenAt;
+    hiddenAt = 0;
 
     if (ws === null || ws.readyState !== WebSocket.OPEN) {
       clearReconnectTimer();
@@ -306,28 +324,28 @@ export function createBaseConnection<T>(config: BaseConnectionConfig<T>): Connec
       return;
     }
 
+    // If we were hidden for at least a full staleness window, JS may have been
+    // suspended (e.g. mobile backgrounding) long enough for the OS to silently
+    // drop the socket while readyState still reports OPEN. Waiting another full
+    // timeout for a heartbeat that will never arrive on a zombie socket just
+    // freezes the UI — reconnect immediately instead.
+    if (wasHiddenSince !== 0 && Date.now() - wasHiddenSince >= stalenessTimeoutMs) {
+      replaceStaleSocketAndReconnect(generation);
+      return;
+    }
+
     // Socket appears open but no recent message — wait for the next server
     // heartbeat to confirm liveness; if nothing arrives, treat as stale.
     const currentGeneration = generation;
     stalenessTimeoutId = setTimeout(() => {
       stalenessTimeoutId = null;
-      if (destroyed || intentionalDisconnect || currentGeneration !== generation) return;
-      if (!notifyReplacingConnection(currentGeneration)) return;
-      const staleWs = ws;
-      if (staleWs !== null) {
-        ws = null;
-        staleWs.close();
-      }
-      if (connected) {
-        connected = false;
-        config.onDisconnected();
-      }
-      void refreshAndConnect(currentGeneration);
+      replaceStaleSocketAndReconnect(currentGeneration);
     }, stalenessTimeoutMs);
   }
 
   function handleVisibilityHidden(): void {
     if (destroyed || intentionalDisconnect) return;
+    hiddenAt = Date.now();
     clearStalenessTimeout();
   }
 


### PR DESCRIPTION
## Problem

Mobile users report that agent chats (cloud agent / remote CLI sessions) don't resume with the latest messages after backgrounding the app and foregrounding it later (directly or via notification tap). Worse on Android.

## Root cause

On Android, backgrounding routinely leaves a **zombie socket**: the OS silently drops the connection while `ws.readyState` still reports `OPEN`, and JS suspension means `lastMessageTime` is always stale on resume. `handleVisibilityResume()` in the shared `base-connection.ts` (used by the cloud-agent `/stream`, user-web ingest, and kiloclaw connections, on both web and mobile) handled this case by arming a `stalenessTimeoutMs` (30s) timer and passively waiting for a server heartbeat before tearing down and reconnecting — so every foreground after >30s of background showed a frozen chat for a full 30 seconds. If the agent had finished while backgrounded, no heartbeats flow at all, guaranteeing the full wait.

Catch-up itself was never broken: reconnect already triggers a snapshot refetch via `onReconnected`, and the server sends a `connected` event immediately on socket open. The bug was purely *when* reconnect fires.

## Fix

Track when the connection went hidden (`hiddenAt`). On resume, if the socket looks OPEN but no message arrived within the staleness window **and** the app was hidden for at least that window, skip the passive wait and tear down + reconnect immediately (same guarded body the staleness timer used, extracted into a helper).

Quick tab switches on web are unaffected: hidden tabs keep running JS, so live connections keep `lastMessageTime` fresh and hit the unchanged trust branch. Web resume-after-laptop-sleep improves for free. No new config, no server changes, no mobile-side changes.

## Tests

- New: resume after being hidden for the full staleness window with a zombie-OPEN socket → old socket closed and new connection established immediately (no 30s wait).
- Guard: brief hide → passive staleness wait still governs (existing behavior preserved).
- `cloud-agent-sdk` jest suite: 746/746 passing; typecheck + lint clean.

## Verification on device

Open a cloud-agent session mid-run → background the app >1 min → foreground: messages catch up within ~1-2s (ticket + snapshot fetch) instead of 30s. Same via notification tap and for remote CLI sessions.