### PR TITLE
fix(kilo-pass): remove legacy Subscribe badge from header

### DIFF
--- a/apps/web/src/components/profile/kilo-pass/KiloPassSubscribeCard.tsx
+++ b/apps/web/src/components/profile/kilo-pass/KiloPassSubscribeCard.tsx
@@ -155,9 +155,7 @@ export function KiloPassSubscribeCard(props: {
                   <Loader2 className="size-3.5 animate-spin" />
                   Processing
                 </Badge>
-              ) : (
-                <Badge variant="secondary">Subscribe</Badge>
-              )}
+              ) : null}
             </div>
           </div>
         </CardHeader>


### PR DESCRIPTION
## Summary

Removes the legacy "Subscribe" badge that appeared next to the "Refer & earn" CTA in the Kilo Pass subscribe card header (`KiloPassSubscribeCard`). This badge was a stale UI artifact from before the referral CTA was added to the header; it no longer conveys any useful state (the "Processing" badge already covers the in-progress case), so it has been removed while leaving the header layout and the referral CTA intact.

## Verification

Visually confirmed via code inspection that the "Subscribe" badge only rendered in the non-pending branch of the `CardHeader` in `KiloPassSubscribeCard.tsx`, directly beside the `headerAction` slot where `KiloPassReferralButton` ("Refer & earn") is rendered from `ProfileKiloPassSection`. Confirmed the `Badge` import is still used for the "Processing" state, so no unused imports remain.

## Visual Changes

N/A (badge removed, no screenshots available in this environment)

## Reviewer Notes

Low risk, purely a UI cleanup removing a static badge with no associated logic or state.

---

Built for [Jean du Plessis](https://kilo-code.slack.com/archives/C08J1DAFT18/p1783336011188789?thread_ts=1783335911.537639&cid=C08J1DAFT18) by [Kilo for Slack](https://kilo.ai/slack)
