### PR TITLE
CloudAgent - Destroy single sandbox when wrapper cleanup is exhausted

### DIFF
--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -709,6 +709,12 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
             return { status: 'inspection-failed', error: 'Session metadata unavailable' };
           return createAgentSandbox(this.env, metadata).stopWrappers(request);
         },
+        deleteSandbox: async reason => {
+          if (this.orchestrator || (!this.env.Sandbox && !this.env.SandboxSmall)) return;
+          const metadata = await this.getMetadata();
+          if (!metadata) return;
+          await createAgentSandbox(this.env, metadata).delete(reason);
+        },
         recordSharedSandboxFailover: routeKey =>
           this.sharedSandboxFailoverRecorder
             ? this.sharedSandboxFailoverRecorder(routeKey)

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
@@ -2049,6 +2049,31 @@ describe('WrapperSupervisor', () => {
     expect(harness.deleteSandbox).not.toHaveBeenCalled();
   });
 
+  it('does not destroy a sandbox when metadata.workspace is unset when cleanup is exhausted', async () => {
+    const metadata = createMetadata();
+    const harness = createHarness(
+      [
+        [
+          'wrapper_lease',
+          {
+            state: 'stop_needed',
+            nextInstanceGeneration: 2,
+            target: { kind: 'session' },
+            reason: 'unhealthy-wrapper',
+            requestedAt: 1_000,
+            nextAttemptAt: 1_000,
+            attempts: 5,
+          },
+        ],
+      ],
+      { metadata }
+    );
+
+    await harness.supervisor.runMaintenance(1_000);
+
+    expect(harness.deleteSandbox).not.toHaveBeenCalled();
+  });
+
   it('clears timeout evidence after cleanup confirms wrapper absence', async () => {
     const harness = createHarness([
       [

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
@@ -132,6 +132,7 @@ function createHarness(
   const sentPings: string[] = [];
   const stops: string[] = [];
   const stopWrappers = vi.fn().mockResolvedValue({ status: 'absent' });
+  const deleteSandbox = vi.fn().mockResolvedValue(undefined);
   const requestedAlarms: number[] = [];
   const currentMetadata = options?.metadata ?? createMetadata();
   const settlementOutbox = createMessageSettlementOutbox({
@@ -174,6 +175,7 @@ function createHarness(
     ensureAcceptedMessageBeforeTerminal:
       options?.ensureAcceptedMessageBeforeTerminal ?? (async () => {}),
     stopWrappers,
+    deleteSandbox,
     recordSharedSandboxFailover: routeKey => recordSharedSandboxFailover(routeKey),
     requestAlarmAtOrBefore: async deadline => {
       requestedAlarms.push(deadline);
@@ -188,6 +190,7 @@ function createHarness(
     sentPings,
     stops,
     stopWrappers,
+    deleteSandbox,
     requestedAlarms,
     requestPendingDrainIfNeeded,
     recordSharedSandboxFailover,
@@ -1949,6 +1952,101 @@ describe('WrapperSupervisor', () => {
       listProcessesTimeouts: 2,
       failoverPublication: { status: 'recorded', routeKey },
     });
+  });
+
+  it('destroys a single sandbox when wrapper cleanup is exhausted', async () => {
+    const sandboxId = `ses-${'a'.repeat(48)}` as SandboxId;
+    const metadata = {
+      ...createMetadata(),
+      workspace: {
+        sandboxId,
+      },
+    } satisfies SessionMetadata;
+    const harness = createHarness(
+      [
+        [
+          'wrapper_lease',
+          {
+            state: 'stop_needed',
+            nextInstanceGeneration: 2,
+            target: { kind: 'session' },
+            reason: 'unhealthy-wrapper',
+            requestedAt: 1_000,
+            nextAttemptAt: 1_000,
+            attempts: 5,
+          },
+        ],
+      ],
+      { metadata }
+    );
+
+    await harness.supervisor.runMaintenance(1_000);
+
+    expect(harness.deleteSandbox).toHaveBeenCalledOnce();
+    expect(harness.deleteSandbox).toHaveBeenCalledWith('recovery');
+  });
+
+  it('does not destroy a shared sandbox when wrapper cleanup is exhausted', async () => {
+    const routeKey = `usr-${'d'.repeat(48)}` as SandboxId;
+    const metadata = {
+      ...createMetadata(),
+      workspace: {
+        sandboxId: routeKey,
+        sandboxRoute: { kind: 'shared', routeKey },
+      },
+    } satisfies SessionMetadata;
+    const harness = createHarness(
+      [
+        [
+          'wrapper_lease',
+          {
+            state: 'stop_needed',
+            nextInstanceGeneration: 2,
+            target: { kind: 'session' },
+            reason: 'unhealthy-wrapper',
+            requestedAt: 1_000,
+            nextAttemptAt: 1_000,
+            attempts: 5,
+          },
+        ],
+      ],
+      { metadata }
+    );
+
+    await harness.supervisor.runMaintenance(1_000);
+
+    expect(harness.deleteSandbox).not.toHaveBeenCalled();
+  });
+
+  it('does not destroy a legacy shared sandbox missing sandboxRoute when cleanup is exhausted', async () => {
+    const sandboxId = `usr-${'e'.repeat(48)}` as SandboxId;
+    const metadata = {
+      ...createMetadata(),
+      workspace: {
+        sandboxId,
+      },
+    } satisfies SessionMetadata;
+    const harness = createHarness(
+      [
+        [
+          'wrapper_lease',
+          {
+            state: 'stop_needed',
+            nextInstanceGeneration: 2,
+            target: { kind: 'session' },
+            reason: 'unhealthy-wrapper',
+            requestedAt: 1_000,
+            nextAttemptAt: 1_000,
+            attempts: 5,
+          },
+        ],
+      ],
+      { metadata }
+    );
+
+    await harness.supervisor.runMaintenance(1_000);
+
+    expect(harness.deleteSandbox).not.toHaveBeenCalled();
   });
 
   it('clears timeout evidence after cleanup confirms wrapper absence', async () => {

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { logger } from '../logger.js';
 import type { SessionMetadata } from '../persistence/session-metadata.js';
 import type {
+  SandboxDeleteReason,
   StopWrappersResult,
   WrapperStopReason,
   WrapperStopTarget,
@@ -21,6 +22,7 @@ import {
 import type { WrapperTerminalFailureCode } from '../shared/protocol.js';
 import type { LatestAssistantMessage } from './types.js';
 import type { SandboxId } from '../types.js';
+import { isGeneratedSharedSandboxId } from '../sandbox-id.js';
 import {
   MODEL_NOT_FOUND_RUNTIME_DIAGNOSTIC_LOG_CHUNK_SIZE,
   MODEL_NOT_FOUND_RUNTIME_DIAGNOSTIC_MAX_SERIALIZED_BYTES,
@@ -174,6 +176,7 @@ export type WrapperSupervisorDependencies = {
     attemptId: string;
     reason: WrapperStopReason;
   }) => Promise<StopWrappersResult>;
+  deleteSandbox?: (reason: SandboxDeleteReason) => Promise<void>;
   recordSharedSandboxFailover: (routeKey: SandboxId) => Promise<void>;
   requestAlarmAtOrBefore?: (deadline: number) => Promise<void>;
   getSessionIdForLogs: () => string | undefined;
@@ -358,6 +361,7 @@ export function createWrapperSupervisor(
     clearInterruptRequest,
     ensureAcceptedMessageBeforeTerminal,
     stopWrappers,
+    deleteSandbox,
     recordSharedSandboxFailover,
     requestAlarmAtOrBefore,
     getSessionIdForLogs,
@@ -995,6 +999,33 @@ export function createWrapperSupervisor(
         logTag: 'wrapper_cleanup_exhausted',
       })
       .error('Wrapper cleanup attempt limit exhausted');
+    await destroySingleSandboxIfCleanupExhausted();
+  }
+
+  async function destroySingleSandboxIfCleanupExhausted(): Promise<void> {
+    if (!deleteSandbox) return;
+    const metadata = await getMetadata();
+    if (!metadata) return;
+    const workspace = metadata.workspace;
+    if (workspace?.sandboxRoute?.kind === 'shared') return;
+    if (workspace?.sandboxId && isGeneratedSharedSandboxId(workspace.sandboxId)) return;
+    try {
+      await deleteSandbox('recovery');
+      logger
+        .withFields({
+          sessionId: getSessionIdForLogs(),
+          logTag: 'single_sandbox_destroyed_after_cleanup_exhausted',
+        })
+        .warn('Destroyed single sandbox after wrapper cleanup was exhausted');
+    } catch (error) {
+      logger
+        .withFields({
+          sessionId: getSessionIdForLogs(),
+          error: error instanceof Error ? error.message : String(error),
+          logTag: 'single_sandbox_destroy_after_cleanup_exhausted_failed',
+        })
+        .error('Failed to destroy single sandbox after wrapper cleanup was exhausted');
+    }
   }
 
   let sharedSandboxFailoverReconciliation: Promise<void> | undefined;

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.ts
@@ -1007,8 +1007,9 @@ export function createWrapperSupervisor(
     const metadata = await getMetadata();
     if (!metadata) return;
     const workspace = metadata.workspace;
-    if (workspace?.sandboxRoute?.kind === 'shared') return;
-    if (workspace?.sandboxId && isGeneratedSharedSandboxId(workspace.sandboxId)) return;
+    if (!workspace?.sandboxId) return;
+    if (workspace.sandboxRoute?.kind === 'shared') return;
+    if (isGeneratedSharedSandboxId(workspace.sandboxId)) return;
     try {
       await deleteSandbox('recovery');
       logger


### PR DESCRIPTION
## Summary

Destroy the single sandbox when wrapper cleanup attempts are exhausted, so a fresh sandbox can be created on the next session start. Skip deletion for shared sandboxes and legacy shared sandbox IDs to avoid impacting other sessions.

## Verification

No manual tests; the change is covered by unit tests in `wrapper-supervisor.test.ts`.

## Visual Changes

N/A

## Reviewer Notes

Deletion is gated by `sandboxRoute.kind === 'shared'` and `isGeneratedSharedSandboxId` for legacy sandboxes missing route metadata.