### PR TITLE
fix(dev): restore .env passthrough for auth URLs and make dev:restart survive pane loss

### DIFF
--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -287,7 +287,20 @@ export function restartServiceInTmux(sessionName: string, serviceName: string): 
   sendInterrupt(sessionName, pane.windowIndex, pane.paneIndex);
   setTimeout(() => {
     const currentPane = findServicePane(sessionName, serviceName);
-    if (!currentPane) return;
+    if (!currentPane) {
+      // The pane can close together with the process (SIGINT kills the
+      // non-interactive wrapper shell before its `exec $SHELL` runs, and
+      // tmux closes a pane when its process exits). Recreate the service
+      // window instead of leaving the service stopped after reporting
+      // "Restarted"; the new window inherits the tmux session environment.
+      try {
+        startServiceInTmux(sessionName, serviceName);
+      } catch {
+        // Same policy as below: keep the TUI alive; the next explicit
+        // restart/view action can retry.
+      }
+      return;
+    }
     try {
       sendKeys(sessionName, currentPane.windowIndex, cmd, currentPane.paneIndex);
     } catch {

--- a/dev/local/tmux.test.ts
+++ b/dev/local/tmux.test.ts
@@ -127,3 +127,48 @@ test(
     }
   }
 );
+
+test(
+  'restartServiceInTmux recreates the service window when the pane dies with the process',
+  { skip: !hasTmux },
+  async () => {
+    const sessionName = `kilo-tmux-test-${process.pid}-${Date.now()}`;
+    const serviceName = 'stripe';
+    const tmux = (...args: string[]) => execFileSync('tmux', args, { stdio: 'ignore' });
+
+    try {
+      tmux('new-session', '-d', '-s', sessionName, '-n', 'dashboard', 'sleep 120');
+      // Run the process directly (no wrapper shell) so the pane closes as
+      // soon as SIGINT kills it — the state restart used to silently bail
+      // on after reporting success.
+      tmux('new-window', '-d', '-t', sessionName, '-n', serviceName, 'sleep 120');
+
+      const serviceWindow = listWindows(sessionName).find(window => window.name === serviceName);
+      assert.ok(serviceWindow);
+
+      tmux(
+        'join-pane',
+        '-h',
+        '-s',
+        `${sessionName}:${serviceWindow.index}.0`,
+        '-t',
+        `${sessionName}:0.0`
+      );
+      tmux('select-pane', '-t', `${sessionName}:0.1`, '-T', serviceName);
+
+      restartServiceInTmux(sessionName, serviceName);
+
+      await sleep(1500);
+      assert.ok(
+        listWindows(sessionName).some(window => window.name === serviceName),
+        'service window should be recreated after its pane closed on interrupt'
+      );
+    } finally {
+      try {
+        tmux('kill-session', '-t', sessionName);
+      } catch {
+        // Session may already be gone if tmux fails during setup.
+      }
+    }
+  }
+);

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -42,12 +42,43 @@ for envfile in .env.local .env.development.local; do
   fi
 done
 
+# Read a value from the local env files without sourcing them. These exports
+# happen before `next dev` starts, and exported process env always beats
+# Next's own .env loading — so without this passthrough, APP_URL_OVERRIDE /
+# NEXTAUTH_URL set in .env.local (e.g. a LAN IP for phone testing) are
+# silently shadowed by the localhost default below.
+read_env_value() {
+  local key="$1"
+  local file
+  local value
+
+  for file in .env.development.local .env.local "$REPO_ROOT/.env.development.local" "$REPO_ROOT/.env.local"; do
+    if [ -f "$file" ]; then
+      value=$(awk -F= -v key="$key" '
+        $1 == key {
+          value = substr($0, length(key) + 2)
+          gsub(/^["'\'']|["'\'']$/, "", value)
+          print value
+          exit
+        }
+      ' "$file")
+      if [ -n "$value" ]; then
+        echo "$value"
+        return
+      fi
+    fi
+  done
+}
+
 export PORT
 export REDIS_URL="${REDIS_URL:-redis://localhost:6379}"
 export UPSTASH_REDIS_REST_URL="${UPSTASH_REDIS_REST_URL:-http://localhost:8079}"
 export UPSTASH_REDIS_REST_TOKEN="${UPSTASH_REDIS_REST_TOKEN:-example_token}"
 NEXT_DEV_HOSTNAME="${NEXT_DEV_HOSTNAME:-0.0.0.0}"
+# Precedence: shell env > .env files > live dev port (auto-increment aware).
+APP_URL_OVERRIDE="${APP_URL_OVERRIDE:-$(read_env_value APP_URL_OVERRIDE)}"
 APP_URL_OVERRIDE="${APP_URL_OVERRIDE:-http://localhost:$PORT}"
+NEXTAUTH_URL="${NEXTAUTH_URL:-$(read_env_value NEXTAUTH_URL)}"
 NEXTAUTH_URL="${NEXTAUTH_URL:-$APP_URL_OVERRIDE}"
 export APP_URL_OVERRIDE
 export NEXT_DEV_HOSTNAME


### PR DESCRIPTION
Two local-dev-runner fixes found while debugging phone sign-in against the local stack (both bit in the same session: `dev:restart nextjs` killed the server without restarting it, and once restarted, sign-in still pointed phones at localhost).

## 1. `scripts/dev.sh`: restore `.env` passthrough for `APP_URL_OVERRIDE` / `NEXTAUTH_URL`

Since #4193, `scripts/dev.sh` hard-defaults `APP_URL_OVERRIDE` to `http://localhost:$PORT` and exports it before `next dev` starts. Exported process env always beats Next's own `.env` loading, so `APP_URL_OVERRIDE` / `NEXTAUTH_URL` values set in `.env.local` (e.g. a LAN IP for testing sign-in from a phone) have been silently ignored — the device-auth `verificationUrl` pointed phones at `localhost`, where sign-in dead-ends.

Restores the `read_env_value()` env-file passthrough that #4193 removed (originally added in #4029), keeping #4193's live-port fallback so auto-offset sessions still redirect to the actual selected port. Resulting precedence:

```
shell env  >  .env.development.local / .env.local  >  http://localhost:$PORT (live port)
```

## 2. `dev:restart`: recreate the service window when the pane dies with the process

`restartServiceInTmux` sends SIGINT, waits 1s, then re-finds the pane to send the start command. When the pane closes together with the process (SIGINT kills the non-interactive wrapper shell before its trailing `exec $SHELL` runs, and tmux closes a pane whose process exits), the re-find came up empty and the function silently returned — the service stayed dead while the CLI had already printed `Restarted <service>`.

Now falls back to `startServiceInTmux` to recreate the service window (with log piping) when the pane is gone; new windows inherit the tmux session environment (`KILO_PORT_OFFSET`, `PATH`).

## Verification

- `bash -n scripts/dev.sh` clean; precedence exercised against the patched script (env-file value wins over fallback; shell env wins over env file; empty env files fall back to the live port; `NEXTAUTH_URL` resolves independently) — all pass.
- Live-verified on the local stack: with `APP_URL_OVERRIDE=http://<lan-ip>:3000` in the server's environment, `POST /api/device-auth/codes` returns a LAN `verificationUrl` and phone sign-in completes; without it, it returns `localhost` regardless of `.env.local`.
- New regression test in `dev/local/tmux.test.ts` (joined service pane running its process directly, so it closes on SIGINT → service window must be recreated): fails against the previous `restartServiceInTmux`, passes with the fix. Full `tmux.test.ts` suite 4/4; `services`/`wrangler-registry`/`mobile-env` tests 10/10; oxlint + oxfmt clean on changed files.