### PR TITLE
fix(mobile): bump app version to 1.0.1

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -15,7 +15,7 @@ const config: ExpoConfig = {
   name: 'Kilo',
   owner: 'kilocode',
   slug: 'kilo-app',
-  version: '1.0.0',
+  version: '1.0.1',
   orientation: 'portrait',
   icon: './assets/images/logo.png',
   scheme: 'kiloapp',


### PR DESCRIPTION
## Problem

TestFlight submissions fail with:

> The value for key CFBundleShortVersionString [1.0.0] in the Info.plist file must contain a higher version than that of the previously approved version [1.0.0]
> Invalid Pre-Release Train. The train version '1.0.0' is closed for new build submissions

Apple approved 1.0.0 and closed its release train, so every new build must carry a higher marketing version. EAS `autoIncrement` only bumps the build number, not `CFBundleShortVersionString`.

## Fix

Bump `version` in `apps/mobile/app.config.ts` from 1.0.0 to 1.0.1. A new build is required after merging — the failing IPA was compiled with 1.0.0 baked in.