### PR TITLE
fix(cloud-agent): simplify Bitbucket repo picker banner to token replacement prompt only

### DIFF
--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -1512,7 +1512,7 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
                     </button>
                   </div>
                   {(bitbucketRepoData?.status === 'reconnect_required' ||
-                    bitbucketRepoData.status === 'insufficient_permissions') &&
+                    bitbucketRepoData?.status === 'insufficient_permissions') &&
                     bitbucketIntegrationHref && (
                       <div className="border-b px-3 py-2 text-xs">
                         <Link

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -1511,30 +1511,6 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
                       />
                     </button>
                   </div>
-                  {organizationId &&
-                    bitbucketIntegrationHref &&
-                    bitbucketRepoData?.status &&
-                    bitbucketRepoData.status !== 'available' && (
-                      <div className="border-b px-3 py-2 text-xs">
-                        {bitbucketRepoData.status === 'temporarily_unavailable' ? (
-                          <span className="text-muted-foreground">
-                            Bitbucket is temporarily unavailable. Refresh repositories to try again.
-                          </span>
-                        ) : (
-                          <Link
-                            href={bitbucketIntegrationHref}
-                            className="text-link hover:text-link-hover underline underline-offset-4"
-                          >
-                            {bitbucketRepoData.status === 'reconnect_required' ||
-                            bitbucketRepoData.status === 'insufficient_permissions'
-                              ? 'Replace the Bitbucket token to list repositories'
-                              : bitbucketRepoData.status === 'invalid_request'
-                                ? 'Review the Bitbucket connection'
-                                : 'Connect Bitbucket to list repositories'}
-                          </Link>
-                        )}
-                      </div>
-                    )}
                   <CommandEmpty>No repositories match your search</CommandEmpty>
                   <CommandList className="max-h-64 overflow-auto">
                     {recentRepos.length > 0 && (

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -1511,6 +1511,18 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
                       />
                     </button>
                   </div>
+                  {(bitbucketRepoData?.status === 'reconnect_required' ||
+                    bitbucketRepoData.status === 'insufficient_permissions') &&
+                    bitbucketIntegrationHref && (
+                      <div className="border-b px-3 py-2 text-xs">
+                        <Link
+                          href={bitbucketIntegrationHref}
+                          className="text-link hover:text-link-hover underline underline-offset-4"
+                        >
+                          Replace the Bitbucket token to list repositories
+                        </Link>
+                      </div>
+                    )}
                   <CommandEmpty>No repositories match your search</CommandEmpty>
                   <CommandList className="max-h-64 overflow-auto">
                     {recentRepos.length > 0 && (


### PR DESCRIPTION
## Summary

Refines the Bitbucket integration banner in the repo picker—keeps only the "Replace the Bitbucket token to list repositories" prompt, removing less actionable "Connect Bitbucket" / "Review the Bitbucket connection" / "temporarily unavailable" states.

## Verification

Change not manually tested; the component was not run locally for this small UI-only update.

## Visual Changes

N/A

## Reviewer Notes

N/A
