### PR TITLE
Admin - simplify Cloud Agent health dashboard

### DIFF
--- a/apps/web/src/app/admin/api/cloud-agent-next/hooks.ts
+++ b/apps/web/src/app/admin/api/cloud-agent-next/hooks.ts
@@ -10,10 +10,7 @@ type CloudAgentNextFilters = {
   endDate: string;
 };
 
-export type CloudAgentNextHealthFilters = CloudAgentNextFilters & {
-  bucket: 'hour' | 'day';
-  createdOnPlatform?: string | null;
-};
+export type CloudAgentNextHealthFilters = CloudAgentNextFilters;
 
 type CloudAgentNextHealthError = {
   source: 'setup' | 'run';
@@ -23,11 +20,6 @@ type CloudAgentNextHealthError = {
 
 function enabledForInterval(params: CloudAgentNextFilters) {
   return Boolean(params.startDate && params.endDate);
-}
-
-export function useCloudAgentNextHealthPlatforms() {
-  const trpc = useTRPC();
-  return useQuery(trpc.admin.cloudAgentNext.listHealthPlatforms.queryOptions());
 }
 
 export function useCloudAgentNextHealthOverview(
@@ -40,6 +32,7 @@ export function useCloudAgentNextHealthOverview(
     enabled: enabled && enabledForInterval(params),
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
+    staleTime: 60 * 1000,
   });
 }
 
@@ -55,7 +48,6 @@ export function useCloudAgentNextHealthErrorSessions(
       source: error?.source ?? 'run',
       stage: error?.stage ?? 'not-selected',
       code: error?.code ?? 'not-selected',
-      createdOnPlatform: params.createdOnPlatform,
     }),
     enabled: enabledForInterval(params) && Boolean(error),
   });

--- a/apps/web/src/app/admin/components/CloudAgentNextTelemetry/CloudAgentNextOutcomesPage.tsx
+++ b/apps/web/src/app/admin/components/CloudAgentNextTelemetry/CloudAgentNextOutcomesPage.tsx
@@ -2,21 +2,10 @@
 
 import { useEffect, useState } from 'react';
 import { AlertCircle, ChevronRight, Loader2, RefreshCw } from 'lucide-react';
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Legend,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
 import AdminPage from '@/app/admin/components/AdminPage';
 import {
   useCloudAgentNextHealthErrorSessions,
   useCloudAgentNextHealthOverview,
-  useCloudAgentNextHealthPlatforms,
   type CloudAgentNextHealthFilters,
 } from '@/app/admin/api/cloud-agent-next/hooks';
 import { CopyButton } from '@/components/admin/CopyButton';
@@ -62,50 +51,26 @@ import {
 } from '@/components/ui/table';
 
 type RangeValue = HealthPeriod;
-type HealthBucket = CloudAgentNextHealthFilters['bucket'];
 type RangeOption = {
   value: RangeValue;
   label: string;
   durationMs: number;
-  bucket: HealthBucket;
 };
 
 const RANGE_OPTIONS = [
-  { value: '1h', label: 'Last hour', durationMs: 60 * 60 * 1000, bucket: 'hour' },
-  { value: '3h', label: 'Last 3 hours', durationMs: 3 * 60 * 60 * 1000, bucket: 'hour' },
+  { value: '1h', label: 'Last hour', durationMs: 60 * 60 * 1000 },
+  { value: '3h', label: 'Last 3 hours', durationMs: 3 * 60 * 60 * 1000 },
   {
     value: '24h',
     label: 'Last 24 hours',
     durationMs: 24 * 60 * 60 * 1000,
-    bucket: 'hour',
   },
-  { value: '7d', label: 'Last 7 days', durationMs: 7 * 24 * 60 * 60 * 1000, bucket: 'hour' },
-  { value: '14d', label: 'Last 14 days', durationMs: 14 * 24 * 60 * 60 * 1000, bucket: 'day' },
-  { value: '30d', label: 'Last 30 days', durationMs: 30 * 24 * 60 * 60 * 1000, bucket: 'day' },
+  { value: '7d', label: 'Last 7 days', durationMs: 7 * 24 * 60 * 60 * 1000 },
+  { value: '14d', label: 'Last 14 days', durationMs: 14 * 24 * 60 * 60 * 1000 },
+  { value: '30d', label: 'Last 30 days', durationMs: 30 * 24 * 60 * 60 * 1000 },
 ] satisfies ReadonlyArray<RangeOption>;
 
-type HealthData = NonNullable<ReturnType<typeof useCloudAgentNextHealthOverview>['data']>;
-type SeriesPoint = HealthData['series'][number];
-type TopError = HealthData['topErrors'][number];
-type TooltipPayload = { payload: SeriesPoint };
-
 const DEFAULT_RANGE: RangeValue = DEFAULT_HEALTH_PERIOD;
-const ALL_PLATFORMS_VALUE = 'all-platforms';
-const UNKNOWN_PLATFORM_VALUE = 'unknown-platform';
-const EXACT_PLATFORM_PREFIX = 'platform:';
-
-function platformSelectionValue(platform: string): string {
-  return `${EXACT_PLATFORM_PREFIX}${platform}`;
-}
-
-function createdOnPlatformForSelection(selection: string): string | null | undefined {
-  if (selection === ALL_PLATFORMS_VALUE) return undefined;
-  if (selection === UNKNOWN_PLATFORM_VALUE) return null;
-  if (selection.startsWith(EXACT_PLATFORM_PREFIX)) {
-    return selection.slice(EXACT_PLATFORM_PREFIX.length);
-  }
-  return undefined;
-}
 
 const utcLongLabel = new Intl.DateTimeFormat('en-US', {
   timeZone: 'UTC',
@@ -115,43 +80,10 @@ const utcLongLabel = new Intl.DateTimeFormat('en-US', {
   minute: '2-digit',
   hourCycle: 'h23',
 });
-const utcShortTime = new Intl.DateTimeFormat('en-US', {
-  timeZone: 'UTC',
-  hour: '2-digit',
-  hourCycle: 'h23',
-});
-const utcShortDay = new Intl.DateTimeFormat('en-US', {
-  timeZone: 'UTC',
-  month: 'short',
-  day: 'numeric',
-});
 
-function intervalForRange(
-  range: RangeValue,
-  platformSelection = ALL_PLATFORMS_VALUE
-): CloudAgentNextHealthFilters {
+function intervalForRange(range: RangeValue): CloudAgentNextHealthFilters {
   const selectedRange = RANGE_OPTIONS.find(option => option.value === range) ?? RANGE_OPTIONS[3];
-  const createdOnPlatform = createdOnPlatformForSelection(platformSelection);
-  return {
-    ...rollingHealthInterval(selectedRange),
-    ...(createdOnPlatform === undefined ? {} : { createdOnPlatform }),
-  };
-}
-
-function formatBucketLabel(bucketStart: string, range: RangeValue): string {
-  if (range === '1h' || range === '3h' || range === '24h') {
-    return utcShortTime.format(new Date(bucketStart));
-  }
-  return utcShortDay.format(new Date(bucketStart));
-}
-
-function bucketLabel(bucket: HealthBucket): string {
-  return bucket === 'day' ? 'Daily' : 'Hourly';
-}
-
-function formatBucketStart(bucketStart: string, bucket: HealthBucket): string {
-  const date = new Date(bucketStart);
-  return bucket === 'day' ? `${utcShortDay.format(date)} UTC` : `${utcLongLabel.format(date)} UTC`;
+  return rollingHealthInterval(selectedRange);
 }
 
 type MetricTone = 'success' | 'danger' | 'warning';
@@ -196,7 +128,6 @@ function DashboardSkeleton() {
   return (
     <div className="flex flex-col gap-6" role="status" aria-label="Loading Cloud Agent health">
       <Skeleton className="h-32 w-full" />
-      <Skeleton className="h-96 w-full" />
       <Skeleton className="h-72 w-full" />
     </div>
   );
@@ -238,106 +169,6 @@ function HealthSummary({ summary }: { summary: HealthData['summary'] }) {
           detail="Excluded from failure rate"
           tone="warning"
         />
-      </CardContent>
-    </Card>
-  );
-}
-
-function HealthTooltip({
-  active,
-  payload,
-  bucket,
-}: {
-  active?: boolean;
-  payload?: TooltipPayload[];
-  bucket: HealthBucket;
-}) {
-  const point = active ? payload?.[0]?.payload : undefined;
-  if (!point) return null;
-  return (
-    <div className="bg-popover text-popover-foreground rounded-lg border p-3 shadow-md">
-      <p className="mb-2 text-xs font-medium">{formatBucketStart(point.bucketStart, bucket)}</p>
-      <div className="grid gap-1 text-xs tabular-nums">
-        <p className="flex justify-between gap-8">
-          <span className="text-muted-foreground">Completed runs</span>
-          <span>{point.completedRuns.toLocaleString()}</span>
-        </p>
-        <p className="flex justify-between gap-8">
-          <span className="text-muted-foreground">Failed runs</span>
-          <span>{point.failedRuns.toLocaleString()}</span>
-        </p>
-        <p className="flex justify-between gap-8">
-          <span className="text-muted-foreground">Setup failures</span>
-          <span>{point.setupFailures.toLocaleString()}</span>
-        </p>
-        <p className="flex justify-between gap-8">
-          <span className="text-muted-foreground">Interrupted runs</span>
-          <span>{point.interruptedRuns.toLocaleString()}</span>
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function OutcomeTrendChart({
-  data,
-  range,
-  bucket,
-}: {
-  data: SeriesPoint[];
-  range: RangeValue;
-  bucket: HealthBucket;
-}) {
-  const label = bucketLabel(bucket);
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{label} outcomes</CardTitle>
-        <CardDescription>
-          Completed, failed, setup-failed, and interrupted events in UTC-
-          {bucket === 'day' ? 'day' : 'hour'} buckets. Edge buckets may be partial.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div
-          className="h-80 w-full"
-          role="img"
-          aria-label={`${label} Cloud Agent outcome counts during the selected period`}
-        >
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={data} margin={{ top: 8, right: 8, left: -8, bottom: 8 }}>
-              <CartesianGrid strokeDasharray="3 3" className="stroke-border" vertical={false} />
-              <XAxis
-                dataKey="bucketStart"
-                tickFormatter={bucketStart => formatBucketLabel(String(bucketStart), range)}
-                minTickGap={32}
-                tick={{ fontSize: 11 }}
-              />
-              <YAxis allowDecimals={false} width={46} tick={{ fontSize: 11 }} />
-              <Tooltip content={<HealthTooltip bucket={bucket} />} />
-              <Legend wrapperStyle={{ fontSize: '12px' }} />
-              <Bar
-                dataKey="completedRuns"
-                stackId="outcomes"
-                fill="var(--chart-2)"
-                name="Completed"
-              />
-              <Bar dataKey="failedRuns" stackId="outcomes" fill="var(--chart-5)" name="Failed" />
-              <Bar
-                dataKey="setupFailures"
-                stackId="outcomes"
-                fill="var(--chart-3)"
-                name="Setup failed"
-              />
-              <Bar
-                dataKey="interruptedRuns"
-                stackId="outcomes"
-                fill="var(--chart-1)"
-                name="Interrupted"
-              />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
       </CardContent>
     </Card>
   );
@@ -525,14 +356,14 @@ function TopErrors({
   );
 }
 
+type HealthData = NonNullable<ReturnType<typeof useCloudAgentNextHealthOverview>['data']>;
+type TopError = HealthData['topErrors'][number];
+
 export default function CloudAgentNextOutcomesPage() {
   const [range, setRange] = useState<RangeValue>(DEFAULT_RANGE);
-  const [platformSelection, setPlatformSelection] = useState(ALL_PLATFORMS_VALUE);
   const [interval, setInterval] = useState(() => intervalForRange(DEFAULT_RANGE));
   const [hasLoadedPeriodPreference, setHasLoadedPeriodPreference] = useState(false);
-  const healthPlatforms = useCloudAgentNextHealthPlatforms();
   const health = useCloudAgentNextHealthOverview(interval, hasLoadedPeriodPreference);
-  const bucket = interval.bucket;
 
   useEffect(() => {
     const storedRange = getStoredHealthPeriod();
@@ -547,21 +378,14 @@ export default function CloudAgentNextOutcomesPage() {
     if (!isHealthPeriod(value)) return;
     setStoredHealthPeriod(value);
     setRange(value);
-    setInterval(intervalForRange(value, platformSelection));
-  }
-
-  function updatePlatformSelection(value: string) {
-    setPlatformSelection(value);
-    setInterval(intervalForRange(range, value));
+    setInterval(intervalForRange(value));
   }
 
   function refresh() {
-    const nextInterval = intervalForRange(range, platformSelection);
+    const nextInterval = intervalForRange(range);
     if (
       nextInterval.startDate === interval.startDate &&
-      nextInterval.endDate === interval.endDate &&
-      nextInterval.bucket === interval.bucket &&
-      nextInterval.createdOnPlatform === interval.createdOnPlatform
+      nextInterval.endDate === interval.endDate
     ) {
       void health.refetch();
       return;
@@ -587,57 +411,27 @@ export default function CloudAgentNextOutcomesPage() {
           <div>
             <h1 className="text-2xl font-bold tracking-tight">Cloud Agent health</h1>
             <p className="text-muted-foreground mt-1 max-w-2xl text-sm">
-              Operational outcome trends from best-effort Cloud Agent reporting.
+              Operational outcomes from best-effort Cloud Agent reporting.
             </p>
           </div>
-          <div className="grid w-full gap-3 sm:grid-cols-2 md:w-auto md:min-w-[32rem]">
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="cloud-agent-health-period">Period</Label>
-              <Select value={range} onValueChange={updateRange}>
-                <SelectTrigger id="cloud-agent-health-period" className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {RANGE_OPTIONS.map(option => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="cloud-agent-health-platform">Created on platform</Label>
-              <Select value={platformSelection} onValueChange={updatePlatformSelection}>
-                <SelectTrigger id="cloud-agent-health-platform" className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={ALL_PLATFORMS_VALUE}>All platforms</SelectItem>
-                  {healthPlatforms.isLoading && (
-                    <SelectItem value="loading-platforms" disabled>
-                      Loading platforms...
-                    </SelectItem>
-                  )}
-                  {healthPlatforms.error && (
-                    <SelectItem value="platforms-unavailable" disabled>
-                      Platforms unavailable
-                    </SelectItem>
-                  )}
-                  {healthPlatforms.data?.map(platform => (
-                    <SelectItem key={platform} value={platformSelectionValue(platform)}>
-                      <span className="font-mono text-xs">{platform}</span>
-                    </SelectItem>
-                  ))}
-                  <SelectItem value={UNKNOWN_PLATFORM_VALUE}>Unknown / unlinked</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+          <div className="flex flex-col gap-2 md:w-72">
+            <Label htmlFor="cloud-agent-health-period">Period</Label>
+            <Select value={range} onValueChange={updateRange}>
+              <SelectTrigger id="cloud-agent-health-period" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RANGE_OPTIONS.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         </div>
         <p className="text-muted-foreground text-xs">
-          Reporting is best-effort, so totals can undercount execution. Periods end at refresh time;
-          edge UTC {bucket === 'day' ? 'days' : 'hours'} may be partial.
+          Reporting is best-effort, so totals can undercount execution. Periods end at refresh time.
         </p>
         {health.error && (
           <Alert variant="destructive">
@@ -656,7 +450,6 @@ export default function CloudAgentNextOutcomesPage() {
         ) : health.data ? (
           <>
             <HealthSummary summary={health.data.summary} />
-            <OutcomeTrendChart data={health.data.series} range={range} bucket={bucket} />
             <TopErrors errors={health.data.topErrors} interval={interval} />
           </>
         ) : null}

--- a/apps/web/src/app/admin/components/CloudAgentNextTelemetry/health-interval.test.ts
+++ b/apps/web/src/app/admin/components/CloudAgentNextTelemetry/health-interval.test.ts
@@ -1,16 +1,15 @@
 import { rollingHealthInterval } from './health-interval';
 
 describe('rollingHealthInterval', () => {
-  it('ends an hourly range at the exact refresh time', () => {
+  it('ends the range at the exact refresh time', () => {
     expect(
       rollingHealthInterval(
-        { durationMs: 3 * 60 * 60 * 1000, bucket: 'hour' },
+        { durationMs: 3 * 60 * 60 * 1000 },
         new Date('2035-01-10T12:34:56.789Z')
       )
     ).toEqual({
       startDate: '2035-01-10T09:34:56.789Z',
       endDate: '2035-01-10T12:34:56.789Z',
-      bucket: 'hour',
     });
   });
 });

--- a/apps/web/src/app/admin/components/CloudAgentNextTelemetry/health-interval.ts
+++ b/apps/web/src/app/admin/components/CloudAgentNextTelemetry/health-interval.ts
@@ -1,20 +1,15 @@
-export type HealthBucket = 'hour' | 'day';
-
 type HealthRange = {
   durationMs: number;
-  bucket: HealthBucket;
 };
 
 type HealthInterval = {
   startDate: string;
   endDate: string;
-  bucket: HealthBucket;
 };
 
 export function rollingHealthInterval(range: HealthRange, now = new Date()): HealthInterval {
   return {
     startDate: new Date(now.getTime() - range.durationMs).toISOString(),
     endDate: now.toISOString(),
-    bucket: range.bucket,
   };
 }

--- a/apps/web/src/routers/admin-cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/admin-cloud-agent-next-router.test.ts
@@ -2,7 +2,6 @@ import { db } from '@/lib/drizzle';
 import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import {
-  cli_sessions_v2,
   cloud_agent_session_runs,
   cloud_agent_sessions,
   kilocode_users,
@@ -82,20 +81,6 @@ describe('adminCloudAgentNextRouter', () => {
         created_at: '2025-01-10T00:20:00.000Z',
       },
     ]);
-    await db.insert(cli_sessions_v2).values([
-      {
-        session_id: 'ses_admin_outcomes_mapped',
-        kilo_user_id: adminUser.id,
-        cloud_agent_session_id: ids.mapped,
-        created_on_platform: 'vscode',
-      },
-      {
-        session_id: 'ses_admin_setup_failed_later',
-        kilo_user_id: adminUser.id,
-        cloud_agent_session_id: ids.setupFailedLater,
-        created_on_platform: ' code-review ',
-      },
-    ]);
     await db.insert(cloud_agent_session_runs).values([
       {
         cloud_agent_session_id: ids.mapped,
@@ -139,7 +124,6 @@ describe('adminCloudAgentNextRouter', () => {
   });
 
   afterEach(async () => {
-    await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.kilo_user_id, adminUser.id));
     await db
       .delete(cloud_agent_sessions)
       .where(inArray(cloud_agent_sessions.cloud_agent_session_id, Object.values(ids)));
@@ -153,12 +137,9 @@ describe('adminCloudAgentNextRouter', () => {
   it('requires admin access and rejects invalid or overlong intervals', async () => {
     const regularCaller = await createCallerForUser(regularUser.id);
     const adminCaller = await createCallerForUser(adminUser.id);
-    await expect(regularCaller.admin.cloudAgentNext.listHealthPlatforms()).rejects.toThrow(
+    await expect(regularCaller.admin.cloudAgentNext.getHealthOverview(interval())).rejects.toThrow(
       'Admin access required'
     );
-    await expect(
-      regularCaller.admin.cloudAgentNext.getHealthOverview({ ...interval(), bucket: 'hour' })
-    ).rejects.toThrow('Admin access required');
     await expect(
       regularCaller.admin.cloudAgentNext.listHealthErrorSessions({
         ...interval(),
@@ -169,24 +150,21 @@ describe('adminCloudAgentNextRouter', () => {
     ).rejects.toThrow('Admin access required');
     await expect(
       adminCaller.admin.cloudAgentNext.getHealthOverview({
-        ...interval({ startDate: END_DATE, endDate: END_DATE }),
-        bucket: 'hour',
+        startDate: END_DATE,
+        endDate: END_DATE,
       })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
     await expect(
       adminCaller.admin.cloudAgentNext.getHealthOverview({
-        ...interval({ endDate: '2035-04-11T00:00:00.000Z' }),
-        bucket: 'day',
+        startDate: START_DATE,
+        endDate: '2035-04-11T00:00:00.000Z',
       })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
-  it('summarizes hourly health and ranks operational errors without interruptions', async () => {
+  it('summarizes health and ranks operational errors without interruptions', async () => {
     const caller = await createCallerForUser(adminUser.id);
-    const health = await caller.admin.cloudAgentNext.getHealthOverview({
-      ...interval(),
-      bucket: 'hour',
-    });
+    const health = await caller.admin.cloudAgentNext.getHealthOverview(interval());
 
     expect(health.summary).toEqual({
       completedRuns: 1,
@@ -194,58 +172,6 @@ describe('adminCloudAgentNextRouter', () => {
       interruptedRuns: 1,
       setupFailures: 2,
     });
-    expect(health.series).toHaveLength(24);
-    expect(health.series.slice(0, 7)).toEqual([
-      {
-        bucketStart: '2035-01-10T00:00:00.000Z',
-        completedRuns: 0,
-        failedRuns: 0,
-        interruptedRuns: 0,
-        setupFailures: 1,
-      },
-      {
-        bucketStart: '2035-01-10T01:00:00.000Z',
-        completedRuns: 1,
-        failedRuns: 0,
-        interruptedRuns: 0,
-        setupFailures: 0,
-      },
-      {
-        bucketStart: '2035-01-10T02:00:00.000Z',
-        completedRuns: 0,
-        failedRuns: 1,
-        interruptedRuns: 0,
-        setupFailures: 0,
-      },
-      {
-        bucketStart: '2035-01-10T03:00:00.000Z',
-        completedRuns: 0,
-        failedRuns: 1,
-        interruptedRuns: 0,
-        setupFailures: 0,
-      },
-      {
-        bucketStart: '2035-01-10T04:00:00.000Z',
-        completedRuns: 0,
-        failedRuns: 0,
-        interruptedRuns: 1,
-        setupFailures: 0,
-      },
-      {
-        bucketStart: '2035-01-10T05:00:00.000Z',
-        completedRuns: 0,
-        failedRuns: 0,
-        interruptedRuns: 0,
-        setupFailures: 1,
-      },
-      {
-        bucketStart: '2035-01-10T06:00:00.000Z',
-        completedRuns: 0,
-        failedRuns: 0,
-        interruptedRuns: 0,
-        setupFailures: 0,
-      },
-    ]);
     expect(health.topErrors).toEqual(
       expect.arrayContaining([
         {
@@ -262,189 +188,13 @@ describe('adminCloudAgentNextRouter', () => {
     expect(JSON.stringify(health.topErrors)).not.toContain('wrapper_start_failed');
   });
 
-  it('filters health and error drilldowns by exact or unknown created platform', async () => {
+  it('excludes runs whose session falls outside the 90-day retention window', async () => {
     const caller = await createCallerForUser(adminUser.id);
-    const platforms = await caller.admin.cloudAgentNext.listHealthPlatforms();
-    const vscodeHealth = await caller.admin.cloudAgentNext.getHealthOverview({
-      ...interval(),
-      bucket: 'hour',
-      createdOnPlatform: 'vscode',
-    });
-    const legacyRawPlatformHealth = await caller.admin.cloudAgentNext.getHealthOverview({
-      ...interval(),
-      bucket: 'hour',
-      createdOnPlatform: ' code-review ',
-    });
-    await db
-      .update(cli_sessions_v2)
-      .set({ created_on_platform: 'unknown' })
-      .where(eq(cli_sessions_v2.cloud_agent_session_id, ids.setupFailedLater));
-    const platformsAfterStoredUnknown = await caller.admin.cloudAgentNext.listHealthPlatforms();
-    const unknownHealth = await caller.admin.cloudAgentNext.getHealthOverview({
-      ...interval(),
-      bucket: 'hour',
-      createdOnPlatform: null,
-    });
-    const vscodeRunSessions = await caller.admin.cloudAgentNext.listHealthErrorSessions({
-      ...interval(),
-      source: 'run',
-      stage: 'pre_dispatch',
-      code: 'workspace_setup_failed',
-      createdOnPlatform: 'vscode',
-    });
-    const unknownSetupSessions = await caller.admin.cloudAgentNext.listHealthErrorSessions({
-      ...interval(),
-      source: 'setup',
-      stage: 'initial_admission',
-      code: 'initial_admission_rejected',
-      createdOnPlatform: null,
-    });
+    const health = await caller.admin.cloudAgentNext.getHealthOverview(interval());
 
-    expect(platforms).toEqual([' code-review ', 'vscode']);
-    expect(platformsAfterStoredUnknown).toEqual(['vscode']);
-    expect(vscodeHealth.summary).toEqual({
-      completedRuns: 1,
-      failedRuns: 1,
-      interruptedRuns: 0,
-      setupFailures: 0,
-    });
-    expect(vscodeHealth.topErrors).toEqual([
-      { source: 'run', stage: 'pre_dispatch', code: 'workspace_setup_failed', count: 1 },
-    ]);
-    expect(legacyRawPlatformHealth.summary).toEqual({
-      completedRuns: 0,
-      failedRuns: 0,
-      interruptedRuns: 0,
-      setupFailures: 1,
-    });
-    expect(unknownHealth.summary).toEqual({
-      completedRuns: 0,
-      failedRuns: 1,
-      interruptedRuns: 1,
-      setupFailures: 2,
-    });
-    expect(vscodeRunSessions.rows).toEqual([
-      expect.objectContaining({ cloudAgentSessionId: ids.mapped }),
-    ]);
-    expect(unknownSetupSessions).toMatchObject({ totalSessions: 2 });
-    expect(unknownSetupSessions.rows).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ cloudAgentSessionId: ids.setupFailed }),
-        expect.objectContaining({ cloudAgentSessionId: ids.setupFailedLater }),
-      ])
-    );
-  });
-
-  it('summarizes longer health ranges into daily UTC buckets', async () => {
-    const caller = await createCallerForUser(adminUser.id);
-    const health = await caller.admin.cloudAgentNext.getHealthOverview({
-      startDate: '2035-01-10T00:00:00.000Z',
-      endDate: '2035-01-12T00:00:00.000Z',
-      bucket: 'day',
-    });
-
-    expect(health.series).toEqual([
-      {
-        bucketStart: '2035-01-10T00:00:00.000Z',
-        completedRuns: 1,
-        failedRuns: 2,
-        interruptedRuns: 1,
-        setupFailures: 2,
-      },
-      {
-        bucketStart: '2035-01-11T00:00:00.000Z',
-        completedRuns: 0,
-        failedRuns: 0,
-        interruptedRuns: 0,
-        setupFailures: 0,
-      },
-    ]);
-  });
-
-  it('summarizes rolling health intervals across partial daily UTC buckets', async () => {
-    const caller = await createCallerForUser(adminUser.id);
-    const health = await caller.admin.cloudAgentNext.getHealthOverview({
-      startDate: '2035-01-09T12:00:00.000Z',
-      endDate: at(5, 30),
-      bucket: 'day',
-    });
-
-    expect(health.series).toEqual([
-      {
-        bucketStart: '2035-01-09T00:00:00.000Z',
-        completedRuns: 0,
-        failedRuns: 0,
-        interruptedRuns: 0,
-        setupFailures: 0,
-      },
-      {
-        bucketStart: START_DATE,
-        completedRuns: 1,
-        failedRuns: 2,
-        interruptedRuns: 1,
-        setupFailures: 2,
-      },
-    ]);
-  });
-
-  it('summarizes rolling health intervals across partial hourly UTC buckets', async () => {
-    const caller = await createCallerForUser(adminUser.id);
-    const health = await caller.admin.cloudAgentNext.getHealthOverview({
-      startDate: at(0, 30),
-      endDate: at(5, 30),
-      bucket: 'hour',
-    });
-
-    expect(health.summary).toEqual({
-      completedRuns: 1,
-      failedRuns: 2,
-      interruptedRuns: 1,
-      setupFailures: 1,
-    });
-    expect(health.series).toEqual([
-      {
-        bucketStart: at(0),
-        completedRuns: 0,
-        failedRuns: 0,
-        interruptedRuns: 0,
-        setupFailures: 0,
-      },
-      {
-        bucketStart: at(1),
-        completedRuns: 1,
-        failedRuns: 0,
-        interruptedRuns: 0,
-        setupFailures: 0,
-      },
-      {
-        bucketStart: at(2),
-        completedRuns: 0,
-        failedRuns: 1,
-        interruptedRuns: 0,
-        setupFailures: 0,
-      },
-      {
-        bucketStart: at(3),
-        completedRuns: 0,
-        failedRuns: 1,
-        interruptedRuns: 0,
-        setupFailures: 0,
-      },
-      {
-        bucketStart: at(4),
-        completedRuns: 0,
-        failedRuns: 0,
-        interruptedRuns: 1,
-        setupFailures: 0,
-      },
-      {
-        bucketStart: at(5),
-        completedRuns: 0,
-        failedRuns: 0,
-        interruptedRuns: 0,
-        setupFailures: 1,
-      },
-    ]);
+    expect(health.summary.failedRuns).toBe(2);
+    expect(health.summary.completedRuns).toBe(1);
+    expect(JSON.stringify(health.topErrors)).not.toContain('wrapper_start_failed');
   });
 
   it('lists affected sessions for an exact top-error source and occurrence interval', async () => {

--- a/apps/web/src/routers/admin-cloud-agent-next-router.ts
+++ b/apps/web/src/routers/admin-cloud-agent-next-router.ts
@@ -1,33 +1,12 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
-import {
-  cli_sessions_v2,
-  cloud_agent_session_runs,
-  cloud_agent_sessions,
-} from '@kilocode/db/schema';
-import {
-  and,
-  asc,
-  desc,
-  eq,
-  exists,
-  gte,
-  isNotNull,
-  isNull,
-  lt,
-  ne,
-  notExists,
-  or,
-  sql,
-  type SQL,
-} from 'drizzle-orm';
+import { cloud_agent_session_runs, cloud_agent_sessions } from '@kilocode/db/schema';
+import { and, desc, eq, gte, isNotNull, isNull, lt, or, sql, type SQL } from 'drizzle-orm';
 import * as z from 'zod';
 
 const MAX_INTERVAL_MS = 90 * 24 * 60 * 60 * 1000;
 const HEALTH_ERROR_SESSION_LIMIT = 100;
-const healthBucketSchema = z.enum(['hour', 'day']);
 const healthErrorSourceSchema = z.enum(['setup', 'run']);
-const createdOnPlatformSchema = z.string().min(1).max(100).nullable().optional();
 const intervalShape = { startDate: z.string().datetime(), endDate: z.string().datetime() };
 
 function hasAscendingInterval(input: { startDate: string; endDate: string }) {
@@ -39,11 +18,7 @@ function hasBoundedInterval(input: { startDate: string; endDate: string }) {
 }
 
 const HealthOverviewFilterSchema = z
-  .object({
-    ...intervalShape,
-    bucket: healthBucketSchema,
-    createdOnPlatform: createdOnPlatformSchema,
-  })
+  .object({ ...intervalShape })
   .refine(input => hasAscendingInterval(input), {
     message: 'Start date must be before end date',
     path: ['endDate'],
@@ -58,7 +33,6 @@ const HealthErrorSessionsFilterSchema = z
     source: healthErrorSourceSchema,
     stage: z.string().trim().min(1).max(100),
     code: z.string().trim().min(1).max(100),
-    createdOnPlatform: createdOnPlatformSchema,
   })
   .refine(input => hasAscendingInterval(input), {
     message: 'Start date must be before end date',
@@ -69,7 +43,6 @@ const HealthErrorSessionsFilterSchema = z
     path: ['endDate'],
   });
 type IntervalFilter = { startDate: string; endDate: string };
-type HealthOverviewFilter = z.infer<typeof HealthOverviewFilterSchema>;
 
 function iso(value: string): string {
   return new Date(value).toISOString();
@@ -99,52 +72,6 @@ function terminalRunIntervalConditions(input: IntervalFilter): SQL[] {
   ];
 }
 
-function createdOnPlatformConditions(input: { createdOnPlatform?: string | null }): SQL[] {
-  if (input.createdOnPlatform === undefined) return [];
-  if (input.createdOnPlatform === null) {
-    return [
-      notExists(
-        db
-          .select({ one: sql`1` })
-          .from(cli_sessions_v2)
-          .where(
-            and(
-              eq(
-                cli_sessions_v2.cloud_agent_session_id,
-                cloud_agent_sessions.cloud_agent_session_id
-              ),
-              ne(cli_sessions_v2.created_on_platform, 'unknown')
-            )
-          )
-      ),
-    ];
-  }
-  return [
-    exists(
-      db
-        .select({ one: sql`1` })
-        .from(cli_sessions_v2)
-        .where(
-          and(
-            eq(cli_sessions_v2.cloud_agent_session_id, cloud_agent_sessions.cloud_agent_session_id),
-            eq(cli_sessions_v2.created_on_platform, input.createdOnPlatform)
-          )
-        )
-    ),
-  ];
-}
-
-const HOUR_MS = 60 * 60 * 1000;
-const DAY_MS = 24 * HOUR_MS;
-
-type HealthSeriesPoint = {
-  bucketStart: string;
-  completedRuns: number;
-  failedRuns: number;
-  interruptedRuns: number;
-  setupFailures: number;
-};
-
 type HealthError = {
   source: 'setup' | 'run';
   stage: string;
@@ -152,56 +79,15 @@ type HealthError = {
   count: number;
 };
 
-function emptyHealthSeries(input: HealthOverviewFilter): HealthSeriesPoint[] {
-  const firstBucket = new Date(input.startDate);
-  if (input.bucket === 'day') firstBucket.setUTCHours(0, 0, 0, 0);
-  else firstBucket.setUTCMinutes(0, 0, 0);
-  const end = new Date(input.endDate).getTime();
-  const bucketMs = input.bucket === 'day' ? DAY_MS : HOUR_MS;
-  const series: HealthSeriesPoint[] = [];
-  for (let timestamp = firstBucket.getTime(); timestamp < end; timestamp += bucketMs) {
-    series.push({
-      bucketStart: new Date(timestamp).toISOString(),
-      completedRuns: 0,
-      failedRuns: 0,
-      interruptedRuns: 0,
-      setupFailures: 0,
-    });
-  }
-  return series;
-}
-
 export const adminCloudAgentNextRouter = createTRPCRouter({
-  listHealthPlatforms: adminProcedure.query(async () => {
-    const rows = await db
-      .selectDistinct({ createdOnPlatform: cli_sessions_v2.created_on_platform })
-      .from(cloud_agent_sessions)
-      .innerJoin(
-        cli_sessions_v2,
-        eq(cli_sessions_v2.cloud_agent_session_id, cloud_agent_sessions.cloud_agent_session_id)
-      )
-      .where(and(retainedSessionCondition(), ne(cli_sessions_v2.created_on_platform, 'unknown')))
-      .orderBy(asc(cli_sessions_v2.created_on_platform));
-    return rows.map(row => row.createdOnPlatform);
-  }),
-
   getHealthOverview: adminProcedure.input(HealthOverviewFilterSchema).query(async ({ input }) => {
-    const terminalBucket =
-      input.bucket === 'day'
-        ? sql<string>`TO_CHAR(DATE_TRUNC('day', ${cloud_agent_session_runs.terminal_at} AT TIME ZONE 'UTC'), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`
-        : sql<string>`TO_CHAR(DATE_TRUNC('hour', ${cloud_agent_session_runs.terminal_at} AT TIME ZONE 'UTC'), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`;
-    const setupBucket =
-      input.bucket === 'day'
-        ? sql<string>`TO_CHAR(DATE_TRUNC('day', ${cloud_agent_sessions.failure_at} AT TIME ZONE 'UTC'), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`
-        : sql<string>`TO_CHAR(DATE_TRUNC('hour', ${cloud_agent_sessions.failure_at} AT TIME ZONE 'UTC'), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`;
     const sessionStage = sql<string>`COALESCE(${cloud_agent_sessions.failure_stage}, 'unclassified')`;
     const sessionCode = sql<string>`COALESCE(${cloud_agent_sessions.failure_code}, 'unclassified')`;
     const runStage = sql<string>`COALESCE(${cloud_agent_session_runs.failure_stage}, 'unknown')`;
     const runCode = sql<string>`COALESCE(${cloud_agent_session_runs.failure_code}, 'unclassified')`;
-    const [terminalRows, setupRows, runErrorRows] = await Promise.all([
+    const [summaryRows, setupRows, runErrorRows] = await Promise.all([
       db
         .select({
-          bucketStart: terminalBucket,
           completed: sql<number>`COUNT(*) FILTER (WHERE ${cloud_agent_session_runs.status} = 'completed')`,
           failed: sql<number>`COUNT(*) FILTER (WHERE ${cloud_agent_session_runs.status} = 'failed')`,
           interrupted: sql<number>`COUNT(*) FILTER (WHERE ${cloud_agent_session_runs.status} = 'interrupted')`,
@@ -214,12 +100,9 @@ export const adminCloudAgentNextRouter = createTRPCRouter({
             cloud_agent_sessions.cloud_agent_session_id
           )
         )
-        .where(and(...terminalRunIntervalConditions(input), ...createdOnPlatformConditions(input)))
-        .groupBy(terminalBucket)
-        .orderBy(terminalBucket),
+        .where(and(...terminalRunIntervalConditions(input))),
       db
         .select({
-          bucketStart: setupBucket,
           stage: sessionStage,
           code: sessionCode,
           count: sql<number>`COUNT(*)`,
@@ -230,12 +113,11 @@ export const adminCloudAgentNextRouter = createTRPCRouter({
             isNotNull(cloud_agent_sessions.failure_at),
             gte(cloud_agent_sessions.failure_at, input.startDate),
             lt(cloud_agent_sessions.failure_at, input.endDate),
-            retainedSessionCondition(),
-            ...createdOnPlatformConditions(input)
+            retainedSessionCondition()
           )
         )
-        .groupBy(setupBucket, sessionStage, sessionCode)
-        .orderBy(setupBucket),
+        .groupBy(sessionStage, sessionCode)
+        .orderBy(sessionStage, sessionCode),
       db
         .select({ stage: runStage, code: runCode, count: sql<number>`COUNT(*)` })
         .from(cloud_agent_session_runs)
@@ -249,57 +131,44 @@ export const adminCloudAgentNextRouter = createTRPCRouter({
         .where(
           and(
             eq(cloud_agent_session_runs.status, 'failed'),
-            ...terminalRunIntervalConditions(input),
-            ...createdOnPlatformConditions(input)
+            ...terminalRunIntervalConditions(input)
           )
         )
         .groupBy(runStage, runCode),
     ]);
-    const series = emptyHealthSeries(input);
-    const pointsByBucket = new Map(series.map(point => [point.bucketStart, point]));
-    for (const row of terminalRows) {
-      const point = pointsByBucket.get(row.bucketStart);
-      if (!point) continue;
-      point.completedRuns = count(row.completed);
-      point.failedRuns = count(row.failed);
-      point.interruptedRuns = count(row.interrupted);
-    }
+    const row = summaryRows[0];
+    const summary = {
+      completedRuns: count(row?.completed),
+      failedRuns: count(row?.failed),
+      interruptedRuns: count(row?.interrupted),
+      setupFailures: 0,
+    };
     const setupErrorsByCode = new Map<string, HealthError>();
-    for (const row of setupRows) {
-      const occurrences = count(row.count);
-      const point = pointsByBucket.get(row.bucketStart);
-      if (point) point.setupFailures += occurrences;
-      const key = `${row.stage}:${row.code}`;
+    for (const setupRow of setupRows) {
+      const occurrences = count(setupRow.count);
+      summary.setupFailures += occurrences;
+      const key = `${setupRow.stage}:${setupRow.code}`;
       const existingError = setupErrorsByCode.get(key);
       if (existingError) {
         existingError.count += occurrences;
       } else {
         setupErrorsByCode.set(key, {
           source: 'setup',
-          stage: row.stage,
-          code: row.code,
+          stage: setupRow.stage,
+          code: setupRow.code,
           count: occurrences,
         });
       }
     }
-    const summary = series.reduce(
-      (totals, point) => ({
-        completedRuns: totals.completedRuns + point.completedRuns,
-        failedRuns: totals.failedRuns + point.failedRuns,
-        interruptedRuns: totals.interruptedRuns + point.interruptedRuns,
-        setupFailures: totals.setupFailures + point.setupFailures,
-      }),
-      { completedRuns: 0, failedRuns: 0, interruptedRuns: 0, setupFailures: 0 }
-    );
     const topErrors = [
       ...setupErrorsByCode.values(),
       ...runErrorRows.map(
-        row =>
+        runRow =>
           ({
             source: 'run',
-            stage: row.stage,
-            code: row.code,
-            count: count(row.count),
+            stage: runRow.stage,
+            code: runRow.code,
+            count: count(runRow.count),
           }) satisfies HealthError
       ),
     ]
@@ -311,7 +180,7 @@ export const adminCloudAgentNextRouter = createTRPCRouter({
           left.code.localeCompare(right.code)
       )
       .slice(0, 10);
-    return { summary, series, topErrors };
+    return { summary, topErrors };
   }),
 
   listHealthErrorSessions: adminProcedure
@@ -324,8 +193,7 @@ export const adminCloudAgentNextRouter = createTRPCRouter({
           isNotNull(cloud_agent_sessions.failure_at),
           gte(cloud_agent_sessions.failure_at, input.startDate),
           lt(cloud_agent_sessions.failure_at, input.endDate),
-          retainedSessionCondition(),
-          ...createdOnPlatformConditions(input)
+          retainedSessionCondition()
         );
         const [totals, rows] = await Promise.all([
           db
@@ -376,8 +244,7 @@ export const adminCloudAgentNextRouter = createTRPCRouter({
       const where = and(
         eq(cloud_agent_session_runs.status, 'failed'),
         selectedFailureCondition,
-        ...terminalRunIntervalConditions(input),
-        ...createdOnPlatformConditions(input)
+        ...terminalRunIntervalConditions(input)
       );
       const latestOccurredAt = sql<string>`MAX(${cloud_agent_session_runs.terminal_at})`;
       const [totals, rows] = await Promise.all([


### PR DESCRIPTION
## Summary

The `/admin/cloud-agent-next` page was slow to load because it ran expensive queries whose output didn't serve the page's core job (is Cloud Agent healthy, and what's failing). Rather than add indexes to support the heavy queries, the dashboard is simplified to drop the work that drove the cost.

- Removed the hourly/daily time-series chart (`OutcomeTrendChart`) and its `series` output. This was the heaviest query: a `GROUP BY hour` bucket scan with `TO_CHAR` over the rolling window plus an in-JS bucket-fill loop, and it pulled in recharts.
- Removed the "Created on platform" filter. This removed the `listHealthPlatforms` procedure (a `SELECT DISTINCT created_on_platform` over a 90-day join that ran on every mount) and the per-row `EXISTS`/`NOT EXISTS` subquery against `cli_sessions_v2` that `createdOnPlatformConditions` injected into every other query.
- Collapsed the duplicate runs scan: `getHealthOverview` previously scanned `cloud_agent_session_runs` twice (all runs for the series, then failed runs for top errors). The summary is now a single `COUNT(*) FILTER (...)` aggregate with no bucketing, and the failed-runs scan for top errors remains.
- Added `staleTime: 60s` to the health overview hook so revisits don't refetch.

`getHealthOverview` now returns `{ summary, topErrors }` (no `series`, no `bucket`). `listHealthErrorSessions` keeps its shape minus the `createdOnPlatform` param. The page keeps the period selector, summary metrics, top-errors table, and the affected-sessions drilldown. ~600 lines removed across router/page/tests.

Remaining queries are indexed range scans on `terminal_at`, the existing partial index on `failure_at`, and `IDX_cloud_agent_session_runs_status_terminal` for run errors. No schema/migration changes.

## Verification

- Loaded `/admin/cloud-agent-next` locally and confirmed the summary metrics, top-errors table, and the affected-sessions drilldown all render and refresh correctly with the period selector.
- Confirmed the platform filter and trend chart are gone and no queries fire for them.

## Visual Changes

| Before | After |
|---|---|
| N/A | N/A |

The dashboard layout changed substantively (chart and platform filter removed); a side-by-side screenshot isn't available here, but the page now shows: header + period selector, observed-health summary card, and a top-errors card with a drilldown dialog. Reviewers should verify the simplified layout reads well.

## Reviewer Notes

- The `retainedSessionCondition` (`cloud_agent_sessions.created_at > now() - interval '90 days'`) is preserved on all runs queries, so the retention/exclusion semantics are unchanged (the `expired` ancient-session case still works).
- Removed procedures (`listHealthPlatforms`) and params (`bucket`, `createdOnPlatform`) are only consumed by this admin page plus its own tests, so no other callers are affected.
- `recharts` remains a dependency (used by other admin pages).