### PR TITLE
refactor(usage): type usage dashboard props as a discriminated union

### DIFF
--- a/apps/web/src/app/(app)/usage/page.tsx
+++ b/apps/web/src/app/(app)/usage/page.tsx
@@ -7,7 +7,7 @@ export default async function UsagePage() {
 
   return (
     <Suspense>
-      <UsageAnalyticsDashboard context="personal" organizationId={null} title="Usage" />
+      <UsageAnalyticsDashboard context="personal" title="Usage" />
     </Suspense>
   );
 }

--- a/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
@@ -136,7 +136,6 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
   const organizationId = org?.organizationId ?? null;
   const organizationName = org?.organizationName;
   const callerRole = org?.callerRole;
-  const organizationPlan = org?.organizationPlan;
 
   const trpc = useTRPC();
   // Migrate legacy `?viewAs=org-wide` links (which meant page-org-wide) to the
@@ -145,10 +144,7 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
   // `scope` is present.
   const searchParams = useSearchParams();
   const legacyOrgWideScope =
-    context === 'organization' &&
-    organizationId &&
-    searchParams.get('scope') == null &&
-    searchParams.get('viewAs') === 'org-wide'
+    organizationId && searchParams.get('scope') == null && searchParams.get('viewAs') === 'org-wide'
       ? organizationId
       : undefined;
   const { state, setState } = useUsageDashboardState(
@@ -175,7 +171,11 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
   const adminOrg =
     org && (org.callerRole === 'owner' || org.callerRole === 'billing_manager') ? org : null;
   const isOrgAdmin = adminOrg !== null;
-  const hasEnterpriseUsageViews = context === 'organization' && organizationPlan === 'enterprise';
+  // Enterprise orgs get the dedicated feature-adoption / AI-usage views. Same
+  // pattern as `adminOrg`: a non-null `enterpriseOrg` carries the concrete org
+  // id those views require, so callers don't re-check the nullable local.
+  const enterpriseOrg = org?.organizationPlan === 'enterprise' ? org : null;
+  const hasEnterpriseUsageViews = enterpriseOrg !== null;
   const showDetailedUsage = !hasEnterpriseUsageViews || usageView === 'ai-usage';
 
   // `organizations.list` is always available to the caller and returns the
@@ -687,27 +687,27 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
               </div>
             )}
 
-            {hasEnterpriseUsageViews && organizationId && usageView === 'overview' ? (
+            {enterpriseOrg && usageView === 'overview' ? (
               <>
                 <UsageWarning />
                 <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
                   <FeatureAdoptionView
-                    organizationId={organizationId}
+                    organizationId={enterpriseOrg.organizationId}
                     compact
                     onViewDetails={() => setState({ usageView: 'feature-adoption' })}
                   />
                   <AIAdoptionSummaryCard
-                    organizationId={organizationId}
+                    organizationId={enterpriseOrg.organizationId}
                     dateRange={dateRange}
                     onViewDetails={() => setState({ usageView: 'ai-usage' })}
                   />
                 </div>
               </>
-            ) : hasEnterpriseUsageViews && organizationId && usageView === 'feature-adoption' ? (
+            ) : enterpriseOrg && usageView === 'feature-adoption' ? (
               <div className="space-y-6">
-                <FeatureAdoptionView organizationId={organizationId} />
+                <FeatureAdoptionView organizationId={enterpriseOrg.organizationId} />
                 <RecommendationsView
-                  organizationId={organizationId}
+                  organizationId={enterpriseOrg.organizationId}
                   canDismiss={callerRole === 'owner'}
                 />
               </div>
@@ -808,11 +808,9 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
                   }
                 />
 
-                {isOrgContext &&
-                  effectiveOrgId &&
-                  (callerRole === 'owner' || callerRole === 'billing_manager') && (
-                    <ActiveKiloclawsTable organizationId={effectiveOrgId} />
-                  )}
+                {isOrgAdmin && effectiveOrgId && (
+                  <ActiveKiloclawsTable organizationId={effectiveOrgId} />
+                )}
               </>
             )}
           </div>

--- a/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
@@ -64,24 +64,38 @@ import { FeatureAdoptionView } from './FeatureAdoptionView';
 import { RecommendationsView } from './RecommendationsView';
 import { UsageViewNavigation } from './UsageViewNavigation';
 
-type UsageAnalyticsDashboardProps = {
-  context: 'personal' | 'organization';
-  organizationId: string | null;
-  /**
-   * Organization display name (org context). Used in the "Entire {name}"
-   * toggle label when the caller can view the entire org.
-   */
-  organizationName?: string;
-  /**
-   * Caller's role in `organizationId`. Required for the `organization` context
-   * to decide whether to render the "My Usage / Entire Organization" toggle.
-   * Ignored in personal context (role is resolved per-org via `organizations.list`).
-   */
-  callerRole?: OrganizationRole;
-  organizationPlan?: Organization['plan'];
-  /** Page title override. */
-  title?: string;
-};
+/**
+ * Personal usage never targets a single organization, so org-only props
+ * (`organizationId`, `organizationName`, `callerRole`, `organizationPlan`) are
+ * meaningless there; organization usage always targets a concrete org. Modeling
+ * these as a discriminated union stops callers from mixing the two — e.g.
+ * passing `context="organization"` with a null org id, or leaking org-only
+ * props into the personal page.
+ */
+type UsageAnalyticsDashboardProps =
+  | {
+      context: 'personal';
+      /** Page title override. */
+      title?: string;
+    }
+  | {
+      context: 'organization';
+      /** Target organization. Always present in organization context. */
+      organizationId: string;
+      /**
+       * Organization display name (org context). Used in the "Entire {name}"
+       * toggle label when the caller can view the entire org.
+       */
+      organizationName?: string;
+      /**
+       * Caller's role in `organizationId`. Decides whether to render the
+       * "My Usage / Entire Organization" toggle.
+       */
+      callerRole?: OrganizationRole;
+      organizationPlan?: Organization['plan'];
+      /** Page title override. */
+      title?: string;
+    };
 
 /** Sentinel written by DBT rollups for rows with NULL project_id. */
 const PROJECT_SENTINEL_NONE = '';
@@ -112,14 +126,16 @@ const METRIC_OPTIONS: MetricKey[] = [
   'outputInputRatio',
 ];
 
-export function UsageAnalyticsDashboard({
-  context,
-  organizationId,
-  organizationName,
-  callerRole,
-  organizationPlan,
-  title,
-}: UsageAnalyticsDashboardProps) {
+export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
+  const { context, title } = props;
+  // Normalize the discriminated props into the nullable locals the rest of the
+  // component expects: org-only fields collapse to null/undefined in personal
+  // context, preserving the previous `organizationId: string | null` contract.
+  const organizationId = props.context === 'organization' ? props.organizationId : null;
+  const organizationName = props.context === 'organization' ? props.organizationName : undefined;
+  const callerRole = props.context === 'organization' ? props.callerRole : undefined;
+  const organizationPlan = props.context === 'organization' ? props.organizationPlan : undefined;
+
   const trpc = useTRPC();
   // Migrate legacy `?viewAs=org-wide` links (which meant page-org-wide) to the
   // new `scope` model so existing bookmarks keep opening an org-wide view

--- a/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
@@ -128,13 +128,15 @@ const METRIC_OPTIONS: MetricKey[] = [
 
 export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
   const { context, title } = props;
-  // Normalize the discriminated props into the nullable locals the rest of the
-  // component expects: org-only fields collapse to null/undefined in personal
-  // context, preserving the previous `organizationId: string | null` contract.
-  const organizationId = props.context === 'organization' ? props.organizationId : null;
-  const organizationName = props.context === 'organization' ? props.organizationName : undefined;
-  const callerRole = props.context === 'organization' ? props.callerRole : undefined;
-  const organizationPlan = props.context === 'organization' ? props.organizationPlan : undefined;
+  // Narrow the discriminated union once: personal context has no target org, so
+  // the org-only fields collapse to a single nullable object. The rest of the
+  // component reads these locals (with `organizationId: string | null`) without
+  // re-narrowing the union.
+  const org = props.context === 'organization' ? props : null;
+  const organizationId = org?.organizationId ?? null;
+  const organizationName = org?.organizationName;
+  const callerRole = org?.callerRole;
+  const organizationPlan = org?.organizationPlan;
 
   const trpc = useTRPC();
   // Migrate legacy `?viewAs=org-wide` links (which meant page-org-wide) to the
@@ -167,7 +169,12 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
   const isOrgContext = context === 'organization';
   // Owners/billing_managers are the only roles that may view org-wide usage and
   // (via inheritance) child-org usage, so only they get the expanded scope list.
-  const isOrgAdmin = isOrgContext && (callerRole === 'owner' || callerRole === 'billing_manager');
+  // Keep the narrowed org variant (not just a boolean) so a non-null `adminOrg`
+  // carries the concrete `organizationId`; downstream org-admin queries then
+  // read a guaranteed string id without re-checking it for null.
+  const adminOrg =
+    org && (org.callerRole === 'owner' || org.callerRole === 'billing_manager') ? org : null;
+  const isOrgAdmin = adminOrg !== null;
   const hasEnterpriseUsageViews = context === 'organization' && organizationPlan === 'enterprise';
   const showDetailedUsage = !hasEnterpriseUsageViews || usageView === 'ai-usage';
 
@@ -184,7 +191,7 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
   // owners/billing_managers; members never see the expanded scope list.
   const scopeOrgsQuery = useQuery(
     trpc.usageAnalytics.getScopeOrganizations.queryOptions(
-      isOrgAdmin && organizationId ? { organizationId } : skipToken
+      adminOrg ? { organizationId: adminOrg.organizationId } : skipToken
     )
   );
   const scopeOrgs = scopeOrgsQuery.data;
@@ -228,7 +235,7 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
   // (and persist) the deep-linked grouping/user filters before validation runs.
   // Keyed off `isLoading` (not `!data`) so a failed scope-list fetch falls back
   // to clamping instead of honoring a stale/unknown scope indefinitely.
-  const scopeListPending = isOrgAdmin && !!organizationId && scopeOrgsQuery.isLoading;
+  const scopeListPending = adminOrg != null && scopeOrgsQuery.isLoading;
   const resolvedOrgScope = !isOrgAdmin
     ? ORG_SCOPE_SELF
     : scopeListPending || validOrgScopeValues.has(orgScope)
@@ -248,10 +255,13 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
   const effectiveOrgId: string | null = isOrgContext ? orgContextOrgId : personalEffectiveOrgId;
 
   // Org ids aggregated by the "All Organizations" scope (parent + children).
+  // This scope is reachable only in organization context, so the page org id is
+  // always present; the precondition guard both documents that and narrows the
+  // nullable local to a string. Keyed on the stable `organizationId` primitive
+  // (not the per-render `props`/`org` object) to preserve memoization.
   const effectiveOrganizationIds = useMemo<string[] | null>(() => {
-    if (!isAllOrgsScope) return null;
-    const ids = new Set<string>();
-    if (organizationId) ids.add(organizationId);
+    if (!isAllOrgsScope || organizationId == null) return null;
+    const ids = new Set<string>([organizationId]);
     for (const child of childOrganizations) ids.add(child.organizationId);
     return Array.from(ids);
   }, [isAllOrgsScope, organizationId, childOrganizations]);


### PR DESCRIPTION
## Summary

- Make `UsageAnalyticsDashboardProps` a discriminated union on `context` so the personal and organization dashboards can no longer be mixed at the type level:
  - `context="personal"` accepts only `title`.
  - `context="organization"` requires a non-null `organizationId: string` and is the only variant that accepts `organizationName`, `callerRole`, and `organizationPlan`.
- Normalize the org-only props into the existing nullable locals inside the component so all downstream logic is unchanged; personal context still resolves `organizationId` to `null`.
- Drop the now-invalid `organizationId={null}` from the personal `/usage` page (behavior identical since the component derives `null` for personal).

This continues the personal/organization unification cleanup by removing the convention-based `organizationId: string | null` prop contract in favor of compile-time enforcement.

## Verification

N/A — type-only refactor with no intended runtime/visual behavior change; no manual browser verification performed.

## Visual Changes

N/A

## Reviewer Notes

The component now takes a single `props` argument and narrows via `props.context === 'organization'` to populate `organizationId`/`organizationName`/`callerRole`/`organizationPlan`. The org page already passes a concrete `organization.id`, so it satisfies the stricter organization variant.