### PR TITLE
fix(session-ingest): enforce current organization access

### DIFF
--- a/apps/web/src/lib/cloud-agent/session-ownership.test.ts
+++ b/apps/web/src/lib/cloud-agent/session-ownership.test.ts
@@ -8,7 +8,10 @@ import {
   type User,
 } from '@kilocode/db/schema';
 import { and, eq, inArray } from 'drizzle-orm';
-import { queryAccessibleCloudAgentSession } from '@kilocode/worker-utils/cloud-agent-session-access';
+import {
+  queryAccessibleCloudAgentSession,
+  queryAccessibleKiloSession,
+} from '@kilocode/worker-utils/cloud-agent-session-access';
 import {
   verifyOrgOwnsSessionV2ByCloudAgentId,
   verifyUserOwnsSessionV2ByCloudAgentId,
@@ -71,6 +74,10 @@ describe('Cloud Agent session ownership', () => {
   });
 
   beforeEach(async () => {
+    await db
+      .update(organizations)
+      .set({ deleted_at: null })
+      .where(eq(organizations.id, organization.id));
     await db.insert(cli_sessions_v2).values([
       {
         session_id: PERSONAL_SESSION_ID,
@@ -178,6 +185,12 @@ describe('Cloud Agent session ownership', () => {
         cloudAgentSessionId: ORGANIZATION_CLOUD_AGENT_SESSION_ID,
       })
     ).resolves.toBeNull();
+    await expect(
+      queryAccessibleKiloSession(db, {
+        kiloUserId: owner.id,
+        kiloSessionId: ORGANIZATION_SESSION_ID,
+      })
+    ).resolves.toBeNull();
 
     await db.insert(organization_memberships).values({
       organization_id: organization.id,
@@ -202,5 +215,34 @@ describe('Cloud Agent session ownership', () => {
       kiloSessionId: ORGANIZATION_SESSION_ID,
       organizationId: organization.id,
     });
+    await expect(
+      queryAccessibleKiloSession(db, {
+        kiloUserId: owner.id,
+        kiloSessionId: ORGANIZATION_SESSION_ID,
+      })
+    ).resolves.toEqual({
+      kiloSessionId: ORGANIZATION_SESSION_ID,
+      organizationId: organization.id,
+    });
+  });
+
+  it('denies access after the organization is soft-deleted', async () => {
+    await db
+      .update(organizations)
+      .set({ deleted_at: new Date().toISOString() })
+      .where(eq(organizations.id, organization.id));
+
+    await expect(
+      queryAccessibleCloudAgentSession(db, {
+        kiloUserId: owner.id,
+        cloudAgentSessionId: ORGANIZATION_CLOUD_AGENT_SESSION_ID,
+      })
+    ).resolves.toBeNull();
+    await expect(
+      queryAccessibleKiloSession(db, {
+        kiloUserId: owner.id,
+        kiloSessionId: ORGANIZATION_SESSION_ID,
+      })
+    ).resolves.toBeNull();
   });
 });

--- a/apps/web/src/lib/organizations/organizations.test.ts
+++ b/apps/web/src/lib/organizations/organizations.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach } from '@jest/globals';
+import { describe, test, expect, afterEach, beforeEach } from '@jest/globals';
 import { db, sql } from '@/lib/drizzle';
 import {
   organizations,
@@ -25,6 +25,11 @@ import {
 } from './organizations';
 import { fromMicrodollars } from '@/lib/utils';
 import { DEFAULT_MEMBER_DAILY_LIMIT_USD } from '@/lib/organizations/constants';
+import { invalidateOrganizationSessionAccess } from '@/lib/session-ingest-client';
+
+jest.mock('@/lib/session-ingest-client', () => ({
+  invalidateOrganizationSessionAccess: jest.fn().mockResolvedValue(undefined),
+}));
 
 describe('Organizations', () => {
   afterEach(async () => {
@@ -400,6 +405,10 @@ describe('Organizations', () => {
   });
 
   describe('removeUserFromOrganization', () => {
+    beforeEach(() => {
+      jest.mocked(invalidateOrganizationSessionAccess).mockClear();
+    });
+
     test('should remove user from organization', async () => {
       const owner = await insertTestUser();
       const member = await insertTestUser();
@@ -418,6 +427,7 @@ describe('Organizations', () => {
       // Verify user was removed
       memberOrgs = await getUserOrganizationsWithSeats(member.id);
       expect(memberOrgs).toHaveLength(0);
+      expect(invalidateOrganizationSessionAccess).toHaveBeenCalledWith(member.id, organization.id);
     });
 
     test('should handle removing non-existent membership gracefully', async () => {
@@ -430,6 +440,23 @@ describe('Organizations', () => {
 
       expect(result).toBeDefined();
       // Should not throw error, just return empty result
+      expect(invalidateOrganizationSessionAccess).not.toHaveBeenCalled();
+    });
+
+    test('should complete removal when session access invalidation fails', async () => {
+      const owner = await insertTestUser();
+      const member = await insertTestUser();
+      const organization = await createOrganization('Test Org', owner.id);
+      await addUserToOrganization(organization.id, member.id, 'member');
+      jest
+        .mocked(invalidateOrganizationSessionAccess)
+        .mockRejectedValueOnce(new Error('invalidation unavailable'));
+
+      await expect(removeUserFromOrganization(organization.id, member.id)).resolves.toBeDefined();
+
+      const memberOrgs = await getUserOrganizationsWithSeats(member.id);
+      expect(memberOrgs).toHaveLength(0);
+      expect(invalidateOrganizationSessionAccess).toHaveBeenCalledWith(member.id, organization.id);
     });
 
     test('should remove specific user without affecting others', async () => {

--- a/apps/web/src/lib/organizations/organizations.ts
+++ b/apps/web/src/lib/organizations/organizations.ts
@@ -30,7 +30,8 @@ import { randomUUID } from 'crypto';
 import { fromMicrodollars, getLowerDomainFromEmail, normalizeEmail } from '@/lib/utils';
 import { resolveEffectiveOrganizationSsoPolicy } from './organization-sso-policy';
 import { classifyOrganizationEntitlement } from './trial-utils';
-import { logExceptInTest } from '@/lib/utils.server';
+import { errorExceptInTest, logExceptInTest } from '@/lib/utils.server';
+import { invalidateOrganizationSessionAccess } from '@/lib/session-ingest-client';
 import { APP_URL } from '@/lib/constants';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
 import { failureResult, successResult } from '@/lib/maybe-result';
@@ -362,7 +363,7 @@ export async function removeUserFromOrganization(
   userId: User['id'],
   removedBy?: User['id']
 ): Promise<{ rowCount: number | null }> {
-  return await db.transaction(async tx => {
+  const result = await db.transaction(async tx => {
     await lockOrganizationMembershipMutation(tx, organizationId, userId);
     // Look up the user's current role before deleting
     const [membership] = await tx
@@ -422,6 +423,34 @@ export async function removeUserFromOrganization(
 
     return result;
   });
+
+  if ((result.rowCount ?? 0) > 0) {
+    await invalidateRemovedMemberSessionAccess(organizationId, userId);
+  }
+
+  return result;
+}
+
+/**
+ * Best-effort: a removed member loses cached Session Ingest access within the
+ * cache TTL even when this call fails, so removal never fails on it.
+ */
+async function invalidateRemovedMemberSessionAccess(
+  organizationId: Organization['id'],
+  userId: User['id']
+): Promise<void> {
+  try {
+    await invalidateOrganizationSessionAccess(userId, organizationId);
+  } catch (error) {
+    errorExceptInTest(
+      'Failed to invalidate cached session access for removed organization member',
+      {
+        organizationId,
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    );
+  }
 }
 
 export async function updateUserRoleInOrganization(

--- a/apps/web/src/lib/session-ingest-client.test.ts
+++ b/apps/web/src/lib/session-ingest-client.test.ts
@@ -7,6 +7,7 @@ import {
   fetchSessionMessagesPage,
   deleteSession,
   shareSession,
+  invalidateOrganizationSessionAccess,
 } from './session-ingest-client';
 
 // ---------------------------------------------------------------------------
@@ -19,6 +20,7 @@ jest.mock('@sentry/nextjs', () => ({
 
 jest.mock('@/lib/config.server', () => ({
   SESSION_INGEST_WORKER_URL: 'https://ingest.test.example.com',
+  INTERNAL_API_SECRET: 'internal-secret',
 }));
 
 jest.mock('@/lib/tokens', () => ({
@@ -410,6 +412,82 @@ describe('shareSession', () => {
 // ---------------------------------------------------------------------------
 // fetchSessionMessages (thin wrapper)
 // ---------------------------------------------------------------------------
+
+describe('invalidateOrganizationSessionAccess', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockCaptureException.mockReset();
+  });
+
+  it('reports and throws invalidation failures', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      text: () => Promise.resolve('cache unavailable'),
+    });
+
+    await expect(
+      invalidateOrganizationSessionAccess('usr_removed', '11111111-1111-4111-8111-111111111111')
+    ).rejects.toThrow(
+      'Session access invalidation failed: 503 Service Unavailable - cache unavailable'
+    );
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: { source: 'session-ingest-client', endpoint: 'invalidate-session-access' },
+        extra: {
+          kiloUserId: 'usr_removed',
+          organizationId: '11111111-1111-4111-8111-111111111111',
+          status: 503,
+        },
+      })
+    );
+  });
+
+  it('calls the secret-protected organization invalidation endpoint', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 204 });
+
+    await invalidateOrganizationSessionAccess(
+      'usr_removed',
+      '11111111-1111-4111-8111-111111111111'
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ingest.test.example.com/internal/session-access/invalidate',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'X-Internal-Secret': 'internal-secret',
+        },
+        body: JSON.stringify({
+          kiloUserId: 'usr_removed',
+          organizationId: '11111111-1111-4111-8111-111111111111',
+        }),
+        signal: expect.any(AbortSignal),
+      }
+    );
+  });
+
+  it('sets a 30-second invalidation deadline', async () => {
+    const signal = new AbortController().signal;
+    const timeout = jest.spyOn(AbortSignal, 'timeout').mockReturnValue(signal);
+    mockFetch.mockResolvedValue({ ok: true, status: 204 });
+
+    await invalidateOrganizationSessionAccess(
+      'usr_removed',
+      '11111111-1111-4111-8111-111111111111'
+    );
+
+    expect(timeout).toHaveBeenCalledWith(30_000);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ingest.test.example.com/internal/session-access/invalidate',
+      expect.objectContaining({ signal })
+    );
+    timeout.mockRestore();
+  });
+});
 
 describe('fetchSessionMessages', () => {
   beforeEach(() => {

--- a/apps/web/src/lib/session-ingest-client.ts
+++ b/apps/web/src/lib/session-ingest-client.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import { captureException } from '@sentry/nextjs';
 import { z } from 'zod';
-import { SESSION_INGEST_WORKER_URL } from '@/lib/config.server';
+import { INTERNAL_API_SECRET, SESSION_INGEST_WORKER_URL } from '@/lib/config.server';
 import { generateInternalServiceToken } from '@/lib/tokens';
 import type { User } from '@kilocode/db/schema';
 import {
@@ -255,6 +255,44 @@ export async function shareSession(
 
   const body = ShareResponseSchema.parse(await response.json());
   return { public_id: body.public_id };
+}
+
+// ---------------------------------------------------------------------------
+// Authorization cache invalidation
+// ---------------------------------------------------------------------------
+
+export async function invalidateOrganizationSessionAccess(
+  kiloUserId: string,
+  organizationId: string
+): Promise<void> {
+  if (!SESSION_INGEST_WORKER_URL) {
+    throw new Error('SESSION_INGEST_WORKER_URL is not configured');
+  }
+  if (!INTERNAL_API_SECRET) {
+    throw new Error('INTERNAL_API_SECRET is not configured');
+  }
+
+  const response = await fetch(`${SESSION_INGEST_WORKER_URL}/internal/session-access/invalidate`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'X-Internal-Secret': INTERNAL_API_SECRET,
+    },
+    body: JSON.stringify({ kiloUserId, organizationId }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    const error = new Error(
+      `Session access invalidation failed: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ''}`
+    );
+    captureException(error, {
+      tags: { source: 'session-ingest-client', endpoint: 'invalidate-session-access' },
+      extra: { kiloUserId, organizationId, status: response.status },
+    });
+    throw error;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/routers/organizations/organization-members-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-members-router.test.ts
@@ -1,10 +1,19 @@
 import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
-import type { User, Organization } from '@kilocode/db/schema';
-import { organization_memberships, organizations } from '@kilocode/db/schema';
+import {
+  organization_memberships,
+  organizations,
+  type User,
+  type Organization,
+} from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
 import { and, eq } from 'drizzle-orm';
+import { invalidateOrganizationSessionAccess } from '@/lib/session-ingest-client';
+
+jest.mock('@/lib/session-ingest-client', () => ({
+  invalidateOrganizationSessionAccess: jest.fn().mockResolvedValue(undefined),
+}));
 
 // Mock the email service to prevent actual API calls during tests
 jest.mock('@/lib/email', () => ({
@@ -432,6 +441,7 @@ describe('organizations members trpc router', () => {
       });
       const child = await createChildOrganization('Elevated Child Members', childOwner.id);
       await addUserToOrganization(child.id, memberUser.id, 'owner');
+      jest.mocked(invalidateOrganizationSessionAccess).mockClear();
       const caller = await createCallerForUser(regularUser.id);
 
       try {
@@ -442,6 +452,7 @@ describe('organizations members trpc router', () => {
         });
 
         expect(result).toEqual({ success: true, added: [], removed: [child.id] });
+        expect(invalidateOrganizationSessionAccess).toHaveBeenCalledWith(memberUser.id, child.id);
         const [membership] = await db
           .select({ role: organization_memberships.role })
           .from(organization_memberships)
@@ -460,6 +471,10 @@ describe('organizations members trpc router', () => {
 
   describe('remove procedure', () => {
     let testMemberUser: User;
+
+    beforeEach(() => {
+      jest.mocked(invalidateOrganizationSessionAccess).mockClear();
+    });
 
     beforeAll(async () => {
       // Create dedicated test users for remove tests to avoid conflicts
@@ -485,9 +500,45 @@ describe('organizations members trpc router', () => {
         success: true,
         updated: testMemberUser.id,
       });
+      expect(invalidateOrganizationSessionAccess).toHaveBeenCalledWith(
+        testMemberUser.id,
+        testOrganization.id
+      );
 
       // Add the user back for other tests
       await addUserToOrganization(testOrganization.id, testMemberUser.id, 'member');
+    });
+
+    it('should complete removal when session access invalidation fails', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'best-effort-invalidation@example.com',
+        google_user_name: 'Best Effort Invalidation User',
+        is_admin: false,
+      });
+      await addUserToOrganization(testOrganization.id, user.id, 'member');
+      jest
+        .mocked(invalidateOrganizationSessionAccess)
+        .mockRejectedValueOnce(new Error('invalidation unavailable'));
+      const caller = await createCallerForUser(regularUser.id);
+
+      await expect(
+        caller.organizations.members.remove({
+          organizationId: testOrganization.id,
+          memberId: user.id,
+        })
+      ).resolves.toEqual({ success: true, updated: user.id });
+
+      const remainingMembership = await db.query.organization_memberships.findFirst({
+        where: and(
+          eq(organization_memberships.organization_id, testOrganization.id),
+          eq(organization_memberships.kilo_user_id, user.id)
+        ),
+      });
+      expect(remainingMembership).toBeUndefined();
+      expect(invalidateOrganizationSessionAccess).toHaveBeenCalledWith(
+        user.id,
+        testOrganization.id
+      );
     });
 
     it('should allow system admin users to remove any member', async () => {

--- a/apps/web/src/routers/organizations/organization-members-router.ts
+++ b/apps/web/src/routers/organizations/organization-members-router.ts
@@ -328,6 +328,13 @@ export const organizationsMembersRouter = createTRPCRouter({
       }
 
       const result = await removeUserFromOrganization(organizationId, memberId, user.id);
+      if (result.rowCount === 0) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Failed to remove user from organization',
+        });
+      }
+
       const removedUser = await findUserById(memberId);
       await createAuditLog({
         action: 'organization.member.remove',
@@ -337,13 +344,6 @@ export const organizationsMembersRouter = createTRPCRouter({
         message: `Removed user ${removedUser?.google_user_email || 'unknown'}`,
         organization_id: organizationId,
       });
-
-      if (result.rowCount === 0) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Failed to remove user from organization',
-        });
-      }
 
       await revokeGatewayStateForOrganizationMember(db, organizationId, memberId);
 

--- a/packages/worker-utils/src/cloud-agent-session-access.ts
+++ b/packages/worker-utils/src/cloud-agent-session-access.ts
@@ -1,11 +1,14 @@
 import type { WorkerDb } from '@kilocode/db/client';
-import { cli_sessions_v2, organization_memberships } from '@kilocode/db/schema';
+import { cli_sessions_v2, organization_memberships, organizations } from '@kilocode/db/schema';
 import { and, eq, isNotNull, isNull, or } from 'drizzle-orm';
 
-export type AccessibleCloudAgentSession = {
+export type AccessibleSession = {
   kiloSessionId: string;
   organizationId: string | null;
 };
+
+/** Established name used by Cloud Agent consumers. */
+export type AccessibleCloudAgentSession = AccessibleSession;
 
 type SessionAccessDb = Pick<WorkerDb, 'select'>;
 
@@ -15,23 +18,44 @@ type AccessibleCloudAgentSessionQuery = {
   expectedOrganizationId?: string | null;
 };
 
-export async function queryAccessibleCloudAgentSession(
+type AccessibleKiloSessionQuery = {
+  kiloUserId: string;
+  kiloSessionId: string;
+};
+
+type AccessibleSessionQuery = AccessibleCloudAgentSessionQuery | AccessibleKiloSessionQuery;
+
+async function queryAccessibleSession(
   db: SessionAccessDb,
-  query: AccessibleCloudAgentSessionQuery
-): Promise<AccessibleCloudAgentSession | null> {
+  query: AccessibleSessionQuery
+): Promise<AccessibleSession | null> {
   const membershipJoin = and(
     eq(organization_memberships.organization_id, cli_sessions_v2.organization_id),
     eq(organization_memberships.kilo_user_id, query.kiloUserId)
   );
+  const organizationJoin = and(
+    eq(organizations.id, cli_sessions_v2.organization_id),
+    isNull(organizations.deleted_at)
+  );
+  const expectedOrganizationId =
+    'expectedOrganizationId' in query ? query.expectedOrganizationId : undefined;
   const scopeCondition =
-    query.expectedOrganizationId === null
+    expectedOrganizationId === null
       ? isNull(cli_sessions_v2.organization_id)
-      : query.expectedOrganizationId !== undefined
+      : expectedOrganizationId !== undefined
         ? and(
-            eq(cli_sessions_v2.organization_id, query.expectedOrganizationId),
-            isNotNull(organization_memberships.id)
+            eq(cli_sessions_v2.organization_id, expectedOrganizationId),
+            isNotNull(organization_memberships.id),
+            isNotNull(organizations.id)
           )
-        : or(isNull(cli_sessions_v2.organization_id), isNotNull(organization_memberships.id));
+        : or(
+            isNull(cli_sessions_v2.organization_id),
+            and(isNotNull(organization_memberships.id), isNotNull(organizations.id))
+          );
+  const sessionCondition =
+    'cloudAgentSessionId' in query
+      ? eq(cli_sessions_v2.cloud_agent_session_id, query.cloudAgentSessionId)
+      : eq(cli_sessions_v2.session_id, query.kiloSessionId);
 
   const rows = await db
     .select({
@@ -40,14 +64,25 @@ export async function queryAccessibleCloudAgentSession(
     })
     .from(cli_sessions_v2)
     .leftJoin(organization_memberships, membershipJoin)
+    .leftJoin(organizations, organizationJoin)
     .where(
-      and(
-        eq(cli_sessions_v2.kilo_user_id, query.kiloUserId),
-        eq(cli_sessions_v2.cloud_agent_session_id, query.cloudAgentSessionId),
-        scopeCondition
-      )
+      and(eq(cli_sessions_v2.kilo_user_id, query.kiloUserId), sessionCondition, scopeCondition)
     )
     .limit(1);
 
   return rows[0] ?? null;
+}
+
+export async function queryAccessibleCloudAgentSession(
+  db: SessionAccessDb,
+  query: AccessibleCloudAgentSessionQuery
+): Promise<AccessibleCloudAgentSession | null> {
+  return queryAccessibleSession(db, query);
+}
+
+export async function queryAccessibleKiloSession(
+  db: SessionAccessDb,
+  query: AccessibleKiloSessionQuery
+): Promise<AccessibleSession | null> {
+  return queryAccessibleSession(db, query);
 }

--- a/services/session-ingest/drizzle/0003_free_valkyrie.sql
+++ b/services/session-ingest/drizzle/0003_free_valkyrie.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `sessions` ADD `organization_id` text;--> statement-breakpoint
+ALTER TABLE `sessions` ADD `authorization_expires_at` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX `sessions_organization_id_idx` ON `sessions` (`organization_id`);

--- a/services/session-ingest/drizzle/meta/0003_snapshot.json
+++ b/services/session-ingest/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,150 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8a45c160-337b-4fb2-a1db-982ee69fe8f4",
+  "prevId": "7f8bb7f8-414e-4875-bab2-3e6ce4de7a40",
+  "tables": {
+    "ingest_items": {
+      "name": "ingest_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_data_r2_key": {
+          "name": "item_data_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ingest_items_item_id_unique": {
+          "name": "ingest_items_item_id_unique",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": true
+        },
+        "ingest_items_ingested_at_id_idx": {
+          "name": "ingest_items_ingested_at_id_idx",
+          "columns": [
+            "ingested_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ingest_meta": {
+      "name": "ingest_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "authorization_expires_at": {
+          "name": "authorization_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "sessions_organization_id_idx": {
+          "name": "sessions_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/services/session-ingest/drizzle/meta/_journal.json
+++ b/services/session-ingest/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1780499751344,
       "tag": "0002_watery_venus",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1782225417966,
+      "tag": "0003_free_valkyrie",
+      "breakpoints": true
     }
   ]
 }

--- a/services/session-ingest/drizzle/migrations.js
+++ b/services/session-ingest/drizzle/migrations.js
@@ -2,6 +2,7 @@ import journal from './meta/_journal.json';
 import m0000 from './0000_redundant_slyde.sql';
 import m0001 from './0001_common_blackheart.sql';
 import m0002 from './0002_watery_venus.sql';
+import m0003 from './0003_free_valkyrie.sql';
 
 export default {
   journal,
@@ -9,5 +10,6 @@ export default {
     m0000,
     m0001,
     m0002,
+    m0003,
   },
 };

--- a/services/session-ingest/src/app.ts
+++ b/services/session-ingest/src/app.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import { Hono } from 'hono';
 import type { Env } from './env';
 import { z } from 'zod';
@@ -8,10 +9,36 @@ import { cli_sessions_v2 } from '@kilocode/db/schema';
 import { kiloJwtAuthMiddleware } from './middleware/kilo-jwt-auth';
 import { api } from './routes/api';
 import { getSessionIngestDO } from './dos/SessionIngestDO';
+import { getSessionAccessCacheDO } from './dos/SessionAccessCacheDO';
 import { getSessionExport } from './services/session-export';
 import { withDORetry } from '@kilocode/worker-utils';
 
 const sessionIdSchema = z.string().startsWith('ses_').length(30);
+const invalidateSessionAccessSchema = z.object({
+  kiloUserId: z.string().min(1),
+  organizationId: z.uuid(),
+});
+
+async function hasValidInternalSecret(c: {
+  req: { header(name: string): string | undefined };
+  env: Env;
+}): Promise<boolean> {
+  const provided = c.req.header('X-Internal-Secret');
+  const expected = await c.env.INTERNAL_API_SECRET_PROD.get();
+  if (!provided || !expected) return false;
+
+  const encoder = new TextEncoder();
+  const providedBytes = encoder.encode(provided);
+  const expectedBytes = encoder.encode(expected);
+  if (providedBytes.byteLength !== expectedBytes.byteLength) {
+    // timingSafeEqual requires equal lengths; self-compare so a length
+    // mismatch is not observably faster to reject than a value mismatch.
+    timingSafeEqual(providedBytes, providedBytes);
+    return false;
+  }
+
+  return timingSafeEqual(providedBytes, expectedBytes);
+}
 
 export const app = new Hono<{
   Bindings: Env;
@@ -66,20 +93,28 @@ app.get('/session/:sessionId', async c => {
   });
 });
 
-// Internal route for service-binding HTTP fetch (secret-protected)
-app.get('/internal/session/:sessionId/export', async c => {
-  const secret = c.req.header('X-Internal-Secret');
-  const expected = await c.env.INTERNAL_API_SECRET_PROD.get();
-
-  if (!secret || !expected) {
+app.post('/internal/session-access/invalidate', async c => {
+  if (!(await hasValidInternalSecret(c))) {
     return c.json({ success: false, error: 'Unauthorized' }, 401);
   }
 
-  const encoder = new TextEncoder();
-  const a = encoder.encode(secret);
-  const b = encoder.encode(expected);
+  const parsed = invalidateSessionAccessSchema.safeParse(await c.req.json().catch(() => null));
+  if (!parsed.success) {
+    return c.json({ success: false, error: 'Invalid request', issues: parsed.error.issues }, 400);
+  }
 
-  if (a.byteLength !== b.byteLength || !crypto.subtle.timingSafeEqual(a, b)) {
+  await withDORetry(
+    () => getSessionAccessCacheDO(c.env, { kiloUserId: parsed.data.kiloUserId }),
+    sessionCache => sessionCache.invalidateOrganization(parsed.data.organizationId),
+    'SessionAccessCacheDO.invalidateOrganization'
+  );
+
+  return c.body(null, 204);
+});
+
+// Internal route for service-binding HTTP fetch (secret-protected)
+app.get('/internal/session/:sessionId/export', async c => {
+  if (!(await hasValidInternalSecret(c))) {
     return c.json({ success: false, error: 'Unauthorized' }, 401);
   }
 

--- a/services/session-ingest/src/db/sqlite-schema.ts
+++ b/services/session-ingest/src/db/sqlite-schema.ts
@@ -18,6 +18,12 @@ export const ingestMeta = sqliteTable('ingest_meta', {
   value: text('value'),
 });
 
-export const sessions = sqliteTable('sessions', {
-  session_id: text('session_id').primaryKey(),
-});
+export const sessions = sqliteTable(
+  'sessions',
+  {
+    session_id: text('session_id').primaryKey(),
+    organization_id: text('organization_id'),
+    authorization_expires_at: integer('authorization_expires_at').notNull().default(0),
+  },
+  table => [index('sessions_organization_id_idx').on(table.organization_id)]
+);

--- a/services/session-ingest/src/dos/SessionAccessCacheDO.ts
+++ b/services/session-ingest/src/dos/SessionAccessCacheDO.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from 'cloudflare:workers';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, gt, lte } from 'drizzle-orm';
 import { drizzle, type DrizzleSqliteDODatabase } from 'drizzle-orm/durable-sqlite';
 import { migrate } from 'drizzle-orm/durable-sqlite/migrator';
 
@@ -7,8 +7,15 @@ import { sessions } from '../db/sqlite-schema';
 import type { Env } from '../env';
 import migrations from '../../drizzle/migrations';
 
+export const SESSION_ACCESS_CACHE_TTL_MS = 60_000;
+
+export type CachedSessionAccess = {
+  sessionId: string;
+  organizationId: string | null;
+};
+
 /**
- * Strongly-consistent per-user cache of session ids.
+ * Strongly-consistent per-user cache of recently validated session access.
  *
  * Keyed by kiloUserId (one instance per user).
  */
@@ -24,21 +31,60 @@ export class SessionAccessCacheDO extends DurableObject<Env> {
     });
   }
 
-  async has(sessionId: string): Promise<boolean> {
+  async getAccess(sessionId: string): Promise<CachedSessionAccess | null> {
     const row = this.db
-      .select({ ok: sql<number>`1` })
+      .select({
+        sessionId: sessions.session_id,
+        organizationId: sessions.organization_id,
+      })
       .from(sessions)
-      .where(eq(sessions.session_id, sessionId))
+      .where(
+        and(eq(sessions.session_id, sessionId), gt(sessions.authorization_expires_at, Date.now()))
+      )
       .get();
-    return row !== undefined;
+    return row ?? null;
   }
 
-  async add(sessionId: string): Promise<void> {
-    this.db.insert(sessions).values({ session_id: sessionId }).onConflictDoNothing().run();
+  // TODO(session-access-rollout): Remove legacy RPCs after all pre-TTL Workers are retired.
+  /** @deprecated Mixed-version deployment compatibility only. */
+  async has(sessionId: string): Promise<boolean> {
+    return (await this.getAccess(sessionId)) !== null;
+  }
+
+  /** @deprecated The legacy signature cannot safely cache organization-scoped access. */
+  async add(_sessionId: string): Promise<void> {
+    return;
+  }
+
+  async putValidated(access: CachedSessionAccess): Promise<void> {
+    const now = Date.now();
+    const authorizationExpiresAt = now + SESSION_ACCESS_CACHE_TTL_MS;
+    // Expired rows are unreadable but would otherwise accumulate forever;
+    // purging on write keeps per-user storage bounded without a schedule.
+    this.db.delete(sessions).where(lte(sessions.authorization_expires_at, now)).run();
+    this.db
+      .insert(sessions)
+      .values({
+        session_id: access.sessionId,
+        organization_id: access.organizationId,
+        authorization_expires_at: authorizationExpiresAt,
+      })
+      .onConflictDoUpdate({
+        target: sessions.session_id,
+        set: {
+          organization_id: access.organizationId,
+          authorization_expires_at: authorizationExpiresAt,
+        },
+      })
+      .run();
   }
 
   async remove(sessionId: string): Promise<void> {
     this.db.delete(sessions).where(eq(sessions.session_id, sessionId)).run();
+  }
+
+  async invalidateOrganization(organizationId: string): Promise<void> {
+    this.db.delete(sessions).where(eq(sessions.organization_id, organizationId)).run();
   }
 }
 

--- a/services/session-ingest/src/index.test.ts
+++ b/services/session-ingest/src/index.test.ts
@@ -25,9 +25,15 @@ vi.mock('./dos/SessionIngestDO', () => ({
   getSessionIngestDO: vi.fn(),
 }));
 
+vi.mock('./dos/SessionAccessCacheDO', () => ({
+  SessionAccessCacheDO: class SessionAccessCacheDO {},
+  getSessionAccessCacheDO: vi.fn(),
+}));
+
 import { app } from './index';
 import { getWorkerDb } from '@kilocode/db/client';
 import { getSessionIngestDO } from './dos/SessionIngestDO';
+import { getSessionAccessCacheDO } from './dos/SessionAccessCacheDO';
 
 type TestBindings = {
   HYPERDRIVE: { connectionString: string };
@@ -35,6 +41,7 @@ type TestBindings = {
   SESSION_ACCESS_CACHE_DO: unknown;
   NEXTAUTH_SECRET: unknown;
   NEXTAUTH_SECRET_RAW?: string;
+  INTERNAL_API_SECRET_PROD: { get(): Promise<string> };
 };
 
 function makeDbFakes() {
@@ -59,7 +66,98 @@ const defaultEnv: TestBindings = {
   SESSION_ACCESS_CACHE_DO: {},
   NEXTAUTH_SECRET: {},
   NEXTAUTH_SECRET_RAW: 'secret',
+  INTERNAL_API_SECRET_PROD: { get: async () => 'internal-secret' },
 };
+
+describe('session access invalidation route', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects invalidation without the internal secret', async () => {
+    const cache = { invalidateOrganization: vi.fn(async () => undefined) };
+    vi.mocked(getSessionAccessCacheDO).mockReturnValue(
+      cache as unknown as ReturnType<typeof getSessionAccessCacheDO>
+    );
+
+    const res = await app.request(
+      '/internal/session-access/invalidate',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          kiloUserId: 'usr_removed',
+          organizationId: '11111111-1111-4111-8111-111111111111',
+        }),
+      },
+      defaultEnv
+    );
+
+    expect(res.status).toBe(401);
+    expect(cache.invalidateOrganization).not.toHaveBeenCalled();
+  });
+
+  it.each(['wrong-secretxxx', 'wrong'])(
+    'rejects invalidation with an incorrect internal secret: %s',
+    async secret => {
+      const cache = { invalidateOrganization: vi.fn(async () => undefined) };
+      vi.mocked(getSessionAccessCacheDO).mockReturnValue(
+        cache as unknown as ReturnType<typeof getSessionAccessCacheDO>
+      );
+
+      const res = await app.request(
+        '/internal/session-access/invalidate',
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'X-Internal-Secret': secret,
+          },
+          body: JSON.stringify({
+            kiloUserId: 'usr_removed',
+            organizationId: '11111111-1111-4111-8111-111111111111',
+          }),
+        },
+        defaultEnv
+      );
+
+      expect(res.status).toBe(401);
+      expect(getSessionAccessCacheDO).not.toHaveBeenCalled();
+      expect(cache.invalidateOrganization).not.toHaveBeenCalled();
+    }
+  );
+
+  it('invalidates cached access for the removed organization member', async () => {
+    const cache = { invalidateOrganization: vi.fn(async () => undefined) };
+    vi.mocked(getSessionAccessCacheDO).mockReturnValue(
+      cache as unknown as ReturnType<typeof getSessionAccessCacheDO>
+    );
+
+    const res = await app.request(
+      '/internal/session-access/invalidate',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'X-Internal-Secret': 'internal-secret',
+        },
+        body: JSON.stringify({
+          kiloUserId: 'usr_removed',
+          organizationId: '11111111-1111-4111-8111-111111111111',
+        }),
+      },
+      defaultEnv
+    );
+
+    expect(res.status).toBe(204);
+    expect(getSessionAccessCacheDO).toHaveBeenCalledWith(defaultEnv, {
+      kiloUserId: 'usr_removed',
+    });
+    expect(cache.invalidateOrganization).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111'
+    );
+  });
+});
 
 describe('public session route', () => {
   beforeEach(() => {

--- a/services/session-ingest/src/ingest/metadata.ts
+++ b/services/session-ingest/src/ingest/metadata.ts
@@ -1,9 +1,10 @@
 import { and, eq, sql } from 'drizzle-orm';
 import { getWorkerDb } from '@kilocode/db/client';
 import { cli_sessions_v2 } from '@kilocode/db/schema';
-import { normalizeGitUrl } from '@kilocode/worker-utils';
+import { normalizeGitUrl, withDORetry } from '@kilocode/worker-utils';
 
 import type { Env } from '../env';
+import { getSessionAccessCacheDO } from '../dos/SessionAccessCacheDO';
 import { mapSessionEventRow, notifyUserSessionEvent } from '../session-events';
 import { SessionStatusSchema } from '../types/user-connection-protocol';
 
@@ -173,6 +174,23 @@ export async function applyMetadataChanges(
       session: mapSessionEventRow(persistedRow),
     };
   });
+
+  if (mergedChanges.has('orgId')) {
+    try {
+      await withDORetry(
+        () => getSessionAccessCacheDO(env, { kiloUserId }),
+        sessionCache => sessionCache.remove(sessionId),
+        'SessionAccessCacheDO.remove'
+      );
+    } catch (error) {
+      console.error('Failed to invalidate session access after organization scope change', {
+        kiloUserId,
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   if (!notification) return;
 
   if (notification.changedNonStatus) {

--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -31,6 +31,10 @@ vi.mock('./dos/UserConnectionDO', () => ({
   getUserConnectionDO: vi.fn(),
 }));
 
+vi.mock('./dos/SessionAccessCacheDO', () => ({
+  getSessionAccessCacheDO: vi.fn(),
+}));
+
 vi.mock('./session-events', async importOriginal => {
   const actual = await importOriginal<typeof SessionEvents>();
   return {
@@ -50,6 +54,7 @@ vi.mock('./util/ingest-limits', () => ({
 import { getWorkerDb } from '@kilocode/db/client';
 import { getSessionIngestDO } from './dos/SessionIngestDO';
 import { getUserConnectionDO } from './dos/UserConnectionDO';
+import { getSessionAccessCacheDO } from './dos/SessionAccessCacheDO';
 import { notifyUserSessionEvent } from './session-events';
 import { QUEUE_RETRY_DELAY_SECONDS, createItemExtractor, queue } from './queue-consumer';
 import { computeSessionMetadataUpdates } from './ingest/metadata';
@@ -920,6 +925,101 @@ describe('computeSessionMetadataUpdates', () => {
   it('ignores a null "platform" change (creation value stays sticky)', () => {
     const updates = computeSessionMetadataUpdates(new Map([['platform', null]]), fixedNow);
     expect('created_on_platform' in updates).toBe(false);
+  });
+});
+
+describe('queue organization changes', () => {
+  it('invalidates cached session access after persisting organization scope', async () => {
+    const sessionId = 'ses_12345678901234567890123456';
+    const organizationId = '11111111-1111-4111-8111-111111111111';
+    const persistedSession = {
+      session_id: sessionId,
+      created_at: '2026-05-05T00:00:00.000Z',
+      updated_at: '2026-05-05T00:00:01.000Z',
+      title: null,
+      created_on_platform: null,
+      organization_id: organizationId,
+      git_url: null,
+      git_branch: null,
+      parent_session_id: null,
+      status: null,
+      status_updated_at: null,
+    };
+    const selectResults: unknown[][] = [[{ session_id: sessionId }], [persistedSession]];
+    const selectResult = vi.fn(async () => selectResults.shift() ?? []);
+    const select = {
+      from: vi.fn(() => select),
+      where: vi.fn(() => select),
+      limit: vi.fn(() => select),
+      for: vi.fn(() => select),
+      then: vi.fn((resolve: (value: unknown) => unknown) => resolve(selectResult())),
+    };
+    const update = {
+      set: vi.fn(() => update),
+      where: vi.fn(() => update),
+      then: vi.fn((resolve: (value: undefined) => unknown) => resolve(undefined)),
+    };
+    const dbRef: Record<string, unknown> = {};
+    const db = {
+      select: vi.fn(() => select),
+      update: vi.fn(() => update),
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(dbRef)),
+    } as unknown as ReturnType<typeof getWorkerDb>;
+    Object.assign(dbRef, db);
+    vi.mocked(getWorkerDb).mockReturnValue(db);
+    vi.mocked(getSessionIngestDO).mockReturnValue({
+      ingest: vi.fn(async () => ({ changes: [{ name: 'orgId', value: organizationId }] })),
+    } as never);
+    const remove = vi.fn(async () => undefined);
+    vi.mocked(getSessionAccessCacheDO).mockReturnValue({ remove } as never);
+
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            JSON.stringify({
+              data: [
+                { type: 'kilo_meta', data: { platform: 'cloud-agent-web', orgId: organizationId } },
+              ],
+            })
+          )
+        );
+        controller.close();
+      },
+    });
+    const env = {
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+      SESSION_INGEST_R2: {
+        get: vi.fn(async () => ({ body })),
+        delete: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+      },
+    } as never;
+    const ack = vi.fn();
+
+    await queue(
+      {
+        messages: [
+          {
+            body: {
+              r2Key: 'ingest/org-change',
+              kiloUserId: 'usr_test',
+              sessionId,
+              ingestVersion: 1,
+              ingestedAt: 1,
+            },
+            ack,
+            retry: vi.fn(),
+          },
+        ],
+      } as never,
+      env,
+      { waitUntil: vi.fn() } as unknown as ExecutionContext
+    );
+
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(getSessionAccessCacheDO).toHaveBeenCalledWith(env, { kiloUserId: 'usr_test' });
+    expect(remove).toHaveBeenCalledWith(sessionId);
   });
 });
 

--- a/services/session-ingest/src/routes/api.test.ts
+++ b/services/session-ingest/src/routes/api.test.ts
@@ -25,12 +25,17 @@ vi.mock('../ingest/metadata', () => ({
   applyMetadataChanges: vi.fn(async () => undefined),
 }));
 
+vi.mock('../services/session-access', () => ({
+  resolveAccessibleKiloSession: vi.fn(),
+}));
+
 import { getWorkerDb } from '@kilocode/db/client';
 import { getSessionIngestDO } from '../dos/SessionIngestDO';
 import { getSessionAccessCacheDO } from '../dos/SessionAccessCacheDO';
 import { getUserConnectionDO } from '../dos/UserConnectionDO';
 import { applyMetadataChanges } from '../ingest/metadata';
 import { notifyUserSessionEvent } from '../session-events';
+import { resolveAccessibleKiloSession } from '../services/session-access';
 import type * as SessionEvents from '../session-events';
 
 vi.mock('../session-events', async importOriginal => {
@@ -156,7 +161,9 @@ function makeDbFakes() {
   };
 
   // db.execute(sql`...`) for raw SQL (recursive CTE)
-  const executeResult = vi.fn(async () => ({ rows: [] as Array<{ session_id: string }> }));
+  const executeResult = vi.fn(async (_query?: unknown) => ({
+    rows: [] as Array<Record<string, unknown>>,
+  }));
 
   // db.transaction(async (tx) => { ... })
   const transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(dbRef as unknown));
@@ -202,6 +209,10 @@ function makeDbFakes() {
 describe('api routes', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(resolveAccessibleKiloSession).mockResolvedValue({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: null,
+    });
   });
 
   it('returns 400 for invalid sessionId on ingest/delete/share/unshare', async () => {
@@ -209,8 +220,8 @@ describe('api routes', () => {
     vi.mocked(getWorkerDb).mockReturnValue(db);
 
     const sessionCache = {
-      has: vi.fn(async () => true),
-      add: vi.fn(async () => undefined),
+      getAccess: vi.fn(async () => null),
+      putValidated: vi.fn(async () => undefined),
       remove: vi.fn(async () => undefined),
     };
     vi.mocked(getSessionAccessCacheDO).mockReturnValue(
@@ -286,8 +297,8 @@ describe('api routes', () => {
     ]);
 
     const sessionCache = {
-      add: vi.fn(async () => undefined),
-      has: vi.fn(async () => true),
+      getAccess: vi.fn(async () => null),
+      putValidated: vi.fn(async () => undefined),
       remove: vi.fn(async () => undefined),
     };
     vi.mocked(getSessionAccessCacheDO).mockReturnValue(
@@ -323,8 +334,8 @@ describe('api routes', () => {
     fns.insertResult.mockResolvedValueOnce([]);
 
     const sessionCache = {
-      add: vi.fn(async () => undefined),
-      has: vi.fn(async () => true),
+      getAccess: vi.fn(async () => null),
+      putValidated: vi.fn(async () => undefined),
       remove: vi.fn(async () => undefined),
     };
     vi.mocked(getSessionAccessCacheDO).mockReturnValue(
@@ -348,14 +359,27 @@ describe('api routes', () => {
     expect(env.NOTIFICATIONS.sendSessionReadyNotification).not.toHaveBeenCalled();
   });
 
-  it('POST /session persists placeholder and warms cache', async () => {
+  it('POST /session caches a newly created personal session', async () => {
     const { db, fns } = makeDbFakes();
     vi.mocked(getWorkerDb).mockReturnValue(db);
+    fns.insertResult.mockResolvedValueOnce([
+      {
+        session_id: 'ses_12345678901234567890123456',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        title: null,
+        created_on_platform: null,
+        organization_id: null,
+        git_url: null,
+        git_branch: null,
+        parent_session_id: null,
+        status: null,
+        status_updated_at: null,
+      },
+    ]);
 
     const sessionCache = {
-      add: vi.fn(async () => undefined),
-      has: vi.fn(async () => true),
-      remove: vi.fn(async () => undefined),
+      putValidated: vi.fn(async () => undefined),
     };
     vi.mocked(getSessionAccessCacheDO).mockReturnValue(
       sessionCache as unknown as ReturnType<typeof getSessionAccessCacheDO>
@@ -373,7 +397,10 @@ describe('api routes', () => {
 
     expect(res.status).toBe(200);
     expect(fns.insert).toHaveBeenCalled();
-    expect(sessionCache.add).toHaveBeenCalledWith('ses_12345678901234567890123456');
+    expect(sessionCache.putValidated).toHaveBeenCalledWith({
+      sessionId: 'ses_12345678901234567890123456',
+      organizationId: null,
+    });
 
     const json = await res.json();
     expect(json).toEqual({
@@ -382,17 +409,49 @@ describe('api routes', () => {
     });
   });
 
-  it('POST /session/:sessionId/ingest streams to R2 and enqueues on cache hit', async () => {
+  it('POST /session succeeds when cache warming is unavailable during rollout', async () => {
+    const { db, fns } = makeDbFakes();
+    vi.mocked(getWorkerDb).mockReturnValue(db);
+    fns.insertResult.mockResolvedValueOnce([
+      {
+        session_id: 'ses_12345678901234567890123456',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        title: null,
+        created_on_platform: null,
+        organization_id: null,
+        git_url: null,
+        git_branch: null,
+        parent_session_id: null,
+        status: null,
+        status_updated_at: null,
+      },
+    ]);
+    const putValidated = vi.fn(async () => {
+      throw new Error('The RPC receiver does not implement "putValidated".');
+    });
+    vi.mocked(getSessionAccessCacheDO).mockReturnValue({ putValidated } as never);
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const res = await makeApiApp().fetch(
+      new Request('http://local/session', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ sessionId: 'ses_12345678901234567890123456' }),
+      }),
+      makeTestEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(putValidated).toHaveBeenCalled();
+    consoleWarn.mockRestore();
+    consoleError.mockRestore();
+  });
+
+  it('POST /session/:sessionId/ingest streams to R2 after access is resolved', async () => {
     const { db } = makeDbFakes();
     vi.mocked(getWorkerDb).mockReturnValue(db);
-
-    const sessionCache = {
-      has: vi.fn(async () => true),
-      add: vi.fn(async () => undefined),
-    };
-    vi.mocked(getSessionAccessCacheDO).mockReturnValue(
-      sessionCache as unknown as ReturnType<typeof getSessionAccessCacheDO>
-    );
 
     const app = makeApiApp();
     const env = makeTestEnv();
@@ -408,7 +467,10 @@ describe('api routes', () => {
     );
 
     expect(res.status).toBe(200);
-    expect(sessionCache.has).toHaveBeenCalledWith('ses_12345678901234567890123456');
+    expect(resolveAccessibleKiloSession).toHaveBeenCalledWith(env, {
+      kiloUserId: 'usr_test',
+      kiloSessionId: 'ses_12345678901234567890123456',
+    });
     expect(env.SESSION_INGEST_R2.put).toHaveBeenCalledTimes(1);
     expect(env.INGEST_QUEUE.send).toHaveBeenCalledTimes(1);
 
@@ -470,19 +532,37 @@ describe('api routes', () => {
     expect(env.SESSION_INGEST_R2.delete).toHaveBeenCalledWith(r2Key);
   });
 
-  it('POST /session/:sessionId/ingest returns 404 on cache miss + missing session', async () => {
+  it.each([
+    ['DELETE', '/session/ses_12345678901234567890123456'],
+    ['POST', '/session/ses_12345678901234567890123456/unshare'],
+  ])('%s %s denies a removed organization member before mutations', async (method, path) => {
     const { db, fns } = makeDbFakes();
     vi.mocked(getWorkerDb).mockReturnValue(db);
-    // Session existence check fails — returns empty array.
-    fns.selectResult.mockResolvedValueOnce([]);
+    fns.selectResult.mockResolvedValue([
+      {
+        session_id: 'ses_12345678901234567890123456',
+        public_id: '11111111-1111-4111-8111-111111111111',
+      },
+    ]);
+    vi.mocked(resolveAccessibleKiloSession).mockResolvedValueOnce(null);
 
-    const sessionCache = {
-      has: vi.fn(async () => false),
-      add: vi.fn(async () => undefined),
-    };
-    vi.mocked(getSessionAccessCacheDO).mockReturnValue(
-      sessionCache as unknown as ReturnType<typeof getSessionAccessCacheDO>
+    const res = await makeApiApp().fetch(
+      new Request(`http://local${path}`, { method }),
+      makeTestEnv()
     );
+
+    expect(res.status).toBe(404);
+    expect(fns.select).not.toHaveBeenCalled();
+    expect(fns.executeResult).not.toHaveBeenCalled();
+    expect(fns.update).not.toHaveBeenCalled();
+    expect(fns.delete).not.toHaveBeenCalled();
+  });
+
+  it('POST /session/:sessionId/ingest denies a removed organization member before side effects', async () => {
+    const { db, fns } = makeDbFakes();
+    vi.mocked(getWorkerDb).mockReturnValue(db);
+    fns.selectResult.mockResolvedValue([{ session_id: 'ses_12345678901234567890123456' }]);
+    vi.mocked(resolveAccessibleKiloSession).mockResolvedValueOnce(null);
 
     const app = makeApiApp();
     const env = makeTestEnv();
@@ -496,41 +576,9 @@ describe('api routes', () => {
     );
 
     expect(res.status).toBe(404);
-    expect(fns.selectResult).toHaveBeenCalled();
-    // Should NOT have written to R2 or enqueued
+    expect(fns.select).not.toHaveBeenCalled();
     expect(env.SESSION_INGEST_R2.put).not.toHaveBeenCalled();
     expect(env.INGEST_QUEUE.send).not.toHaveBeenCalled();
-  });
-
-  it('POST /session/:sessionId/ingest backfills cache on cache miss + existing session', async () => {
-    const { db, fns } = makeDbFakes();
-    vi.mocked(getWorkerDb).mockReturnValue(db);
-    fns.selectResult.mockResolvedValueOnce([{ session_id: 'ses_12345678901234567890123456' }]);
-
-    const sessionCache = {
-      has: vi.fn(async () => false),
-      add: vi.fn(async () => undefined),
-    };
-    vi.mocked(getSessionAccessCacheDO).mockReturnValue(
-      sessionCache as unknown as ReturnType<typeof getSessionAccessCacheDO>
-    );
-
-    const app = makeApiApp();
-    const env = makeTestEnv();
-    const res = await app.fetch(
-      new Request('http://local/session/ses_12345678901234567890123456/ingest', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ data: [] }),
-      }),
-      env
-    );
-
-    expect(res.status).toBe(200);
-    expect(fns.selectResult).toHaveBeenCalled();
-    expect(sessionCache.add).toHaveBeenCalledWith('ses_12345678901234567890123456');
-    expect(env.SESSION_INGEST_R2.put).toHaveBeenCalledTimes(1);
-    expect(env.INGEST_QUEUE.send).toHaveBeenCalledTimes(1);
   });
 
   describe('direct ingest', () => {
@@ -1045,11 +1093,11 @@ describe('api routes', () => {
     expect(await res.json()).toMatchObject({ success: false, error: 'Invalid sessionId' });
   });
 
-  it('GET /session/:sessionId/export returns 404 when session missing', async () => {
+  it('GET /session/:sessionId/export returns 404 when access is denied', async () => {
     const { db, fns } = makeDbFakes();
     vi.mocked(getWorkerDb).mockReturnValue(db);
-    // Session existence check returns empty.
-    fns.selectResult.mockResolvedValueOnce([]);
+    fns.selectResult.mockResolvedValue([{ session_id: 'ses_12345678901234567890123456' }]);
+    vi.mocked(resolveAccessibleKiloSession).mockResolvedValueOnce(null);
 
     const app = makeApiApp();
     const res = await app.fetch(
@@ -1061,6 +1109,8 @@ describe('api routes', () => {
 
     expect(res.status).toBe(404);
     expect(await res.json()).toMatchObject({ success: false, error: 'session_not_found' });
+    expect(fns.select).not.toHaveBeenCalled();
+    expect(getSessionIngestDO).not.toHaveBeenCalled();
   });
 
   it('GET /session/:sessionId/export returns DO payload for valid session', async () => {
@@ -1280,11 +1330,12 @@ describe('api routes', () => {
     const childSessionId = 'ses_abcdefghijklmnopqrstuvwxyz';
     const { db, fns } = makeDbFakes();
     vi.mocked(getWorkerDb).mockReturnValue(db);
-    // Ownership check
-    fns.selectResult.mockResolvedValueOnce([{ session_id: parentSessionId }]);
     // Recursive CTE
     fns.executeResult.mockResolvedValueOnce({
-      rows: [{ session_id: childSessionId }, { session_id: parentSessionId }],
+      rows: [
+        { session_id: childSessionId, has_access: true },
+        { session_id: parentSessionId, has_access: true },
+      ],
     });
     // Rows selected for session.deleted events
     fns.selectResult.mockResolvedValueOnce([
@@ -1331,7 +1382,7 @@ describe('api routes', () => {
 
     expect(res.status).toBe(200);
 
-    const deletedRowsPredicate = fns.selectWhere.mock.calls[1]?.[0];
+    const deletedRowsPredicate = fns.selectWhere.mock.calls[0]?.[0];
     if (!(deletedRowsPredicate instanceof SQL)) {
       throw new Error('Expected pre-delete predicate');
     }
@@ -1392,15 +1443,37 @@ describe('api routes', () => {
     });
   });
 
+  it('DELETE /session/:sessionId rejects the cascade when a descendant is inaccessible', async () => {
+    const parentSessionId = 'ses_12345678901234567890123456';
+    const childSessionId = 'ses_abcdefghijklmnopqrstuvwxyz';
+    const { db, fns } = makeDbFakes();
+    vi.mocked(getWorkerDb).mockReturnValue(db);
+    fns.executeResult.mockResolvedValueOnce({
+      rows: [
+        { session_id: childSessionId, has_access: false },
+        { session_id: parentSessionId, has_access: true },
+      ],
+    });
+
+    const app = makeApiApp();
+    const res = await app.fetch(
+      new Request(`http://local/session/${parentSessionId}`, { method: 'DELETE' }),
+      makeTestEnv()
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ success: false, error: 'session_not_found' });
+    expect(fns.select).not.toHaveBeenCalled();
+    expect(fns.delete).not.toHaveBeenCalled();
+    expect(fns.transaction).not.toHaveBeenCalled();
+  });
+
   it('POST /session/:sessionId/share returns existing public_id when already shared', async () => {
     const { db, fns } = makeDbFakes();
     vi.mocked(getWorkerDb).mockReturnValue(db);
-    fns.selectResult.mockResolvedValueOnce([
-      {
-        session_id: 'ses_12345678901234567890123456',
-        public_id: '11111111-1111-1111-1111-111111111111',
-      },
-    ]);
+    fns.executeResult.mockResolvedValueOnce({
+      rows: [{ public_id: '11111111-1111-1111-1111-111111111111' }],
+    });
 
     const app = makeApiApp();
     const res = await app.fetch(
@@ -1420,16 +1493,16 @@ describe('api routes', () => {
   it('POST /session/:sessionId/share sets public_id when missing', async () => {
     const { db, fns } = makeDbFakes();
     vi.mocked(getWorkerDb).mockReturnValue(db);
-
-    // First select: not shared yet
-    fns.selectResult.mockResolvedValueOnce([
-      {
-        session_id: 'ses_12345678901234567890123456',
-        public_id: null,
-      },
-    ]);
-    // Update returning succeeds with one row
-    fns.updateResult.mockResolvedValueOnce([{ public_id: 'some-uuid' }]);
+    fns.executeResult.mockImplementationOnce(async query => {
+      if (!(query instanceof SQL)) {
+        throw new Error('Expected share query');
+      }
+      const generated = new PgDialect().sqlToQuery(query);
+      expect(generated.sql).toContain('INNER JOIN "organizations"');
+      expect(generated.sql).toContain('"organizations"."deleted_at" IS NULL');
+      expect(generated.sql).toContain('"organization_memberships"."kilo_user_id" = $4');
+      return { rows: [{ public_id: generated.params[0] }] };
+    });
 
     const app = makeApiApp();
     const res = await app.fetch(
@@ -1447,25 +1520,10 @@ describe('api routes', () => {
     expect((publicId as string).length).toBeGreaterThan(0);
   });
 
-  it('POST /session/:sessionId/share returns existing public_id when update is raced', async () => {
+  it('POST /session/:sessionId/share rejects an authoritative access failure', async () => {
     const { db, fns } = makeDbFakes();
     vi.mocked(getWorkerDb).mockReturnValue(db);
-
-    // First select: not shared yet
-    fns.selectResult.mockResolvedValueOnce([
-      {
-        session_id: 'ses_12345678901234567890123456',
-        public_id: null,
-      },
-    ]);
-    // Update returning returns empty (raced)
-    fns.updateResult.mockResolvedValueOnce([]);
-    // Second select: now has a public_id
-    fns.selectResult.mockResolvedValueOnce([
-      {
-        public_id: '22222222-2222-2222-2222-222222222222',
-      },
-    ]);
+    fns.executeResult.mockResolvedValueOnce({ rows: [] });
 
     const app = makeApiApp();
     const res = await app.fetch(
@@ -1475,11 +1533,9 @@ describe('api routes', () => {
       makeTestEnv()
     );
 
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
-      success: true,
-      public_id: '22222222-2222-2222-2222-222222222222',
-    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ success: false, error: 'session_not_found' });
+    expect(resolveAccessibleKiloSession).not.toHaveBeenCalled();
   });
 
   it('POST /session/:sessionId/unshare clears public_id when session exists', async () => {

--- a/services/session-ingest/src/routes/api.ts
+++ b/services/session-ingest/src/routes/api.ts
@@ -2,7 +2,7 @@ import { Hono, type Context } from 'hono';
 import { z } from 'zod';
 import { sql, eq, and, inArray, isNull, or, isNotNull } from 'drizzle-orm';
 import { getWorkerDb } from '@kilocode/db/client';
-import { cli_sessions_v2, organization_memberships } from '@kilocode/db/schema';
+import { cli_sessions_v2, organization_memberships, organizations } from '@kilocode/db/schema';
 import {
   DEFAULT_KILO_SDK_MESSAGE_PAGE_SIZE,
   getSessionMessagesSchema,
@@ -18,6 +18,7 @@ import { getUserConnectionDO } from '../dos/UserConnectionDO';
 import { getSessionExport } from '../services/session-export';
 import { mapSessionEventRow, notifyUserSessionEvent } from '../session-events';
 import { handleDirectIngestRequest } from '../ingest/direct-ingest';
+import { resolveAccessibleKiloSession } from '../services/session-access';
 
 export type ApiContext = {
   Bindings: Env;
@@ -104,12 +105,25 @@ api.post('/session', zodJsonValidator(createSessionSchema), async c => {
     // first reports the session as remote-controllable — not here.
   }
 
-  // Warm the session cache so the first ingest can skip Postgres.
-  await withDORetry(
-    () => getSessionAccessCacheDO(c.env, { kiloUserId }),
-    sessionCache => sessionCache.add(body.sessionId),
-    'SessionAccessCacheDO.add'
-  );
+  if (createdRow) {
+    try {
+      await withDORetry(
+        () => getSessionAccessCacheDO(c.env, { kiloUserId }),
+        sessionCache =>
+          sessionCache.putValidated({
+            sessionId: body.sessionId,
+            organizationId: null,
+          }),
+        'SessionAccessCacheDO.putValidated'
+      );
+    } catch (error) {
+      console.error('Failed to warm session access cache after create', {
+        kiloUserId,
+        sessionId: body.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
 
   return c.json(
     {
@@ -129,36 +143,59 @@ api.delete('/session/:sessionId', async c => {
 
   const db = getWorkerDb(c.env.HYPERDRIVE.connectionString);
   const kiloUserId = c.get('user_id');
+  const accessibleSession = await resolveAccessibleKiloSession(c.env, {
+    kiloUserId,
+    kiloSessionId: parsed.data,
+  });
 
-  const sessionRows = await db
-    .select({ session_id: cli_sessions_v2.session_id })
-    .from(cli_sessions_v2)
-    .where(
-      and(eq(cli_sessions_v2.session_id, parsed.data), eq(cli_sessions_v2.kilo_user_id, kiloUserId))
-    )
-    .limit(1);
-
-  if (!sessionRows[0]) {
+  if (!accessibleSession) {
     return c.json({ success: false, error: 'session_not_found' }, 404);
   }
 
   // Delete children first (FK is RESTRICT/NO ACTION).
   // This only covers direct/indirect descendants (not arbitrary cycles).
-  const treeResult = await db.execute<{ session_id: string }>(sql`
+  const treeResult = await db.execute<{ session_id: string; has_access: boolean }>(sql`
     WITH RECURSIVE tree AS (
-      SELECT session_id, parent_session_id, kilo_user_id, 0 AS depth, ARRAY[session_id] AS path
+      SELECT
+        session_id,
+        parent_session_id,
+        kilo_user_id,
+        organization_id,
+        0 AS depth,
+        ARRAY[session_id] AS path
       FROM ${cli_sessions_v2}
       WHERE session_id = ${parsed.data} AND kilo_user_id = ${kiloUserId}
       UNION ALL
-      SELECT c.session_id, c.parent_session_id, c.kilo_user_id, t.depth + 1, t.path || c.session_id
+      SELECT
+        c.session_id,
+        c.parent_session_id,
+        c.kilo_user_id,
+        c.organization_id,
+        t.depth + 1,
+        t.path || c.session_id
       FROM ${cli_sessions_v2} c
       INNER JOIN tree t ON c.parent_session_id = t.session_id AND c.kilo_user_id = t.kilo_user_id
       WHERE NOT (c.session_id = ANY(t.path)) AND t.depth < 10
     )
-    SELECT session_id FROM tree ORDER BY depth DESC
+    SELECT
+      tree.session_id,
+      tree.organization_id IS NULL OR EXISTS (
+        SELECT 1
+        FROM ${organization_memberships}
+        INNER JOIN ${organizations}
+          ON ${organizations.id} = ${organization_memberships.organization_id}
+          AND ${organizations.deleted_at} IS NULL
+        WHERE ${organization_memberships.organization_id} = tree.organization_id
+          AND ${organization_memberships.kilo_user_id} = ${kiloUserId}
+      ) AS has_access
+    FROM tree
+    ORDER BY depth DESC
   `);
 
   const treeRows = treeResult.rows;
+  if (treeRows.some(row => !row.has_access)) {
+    return c.json({ success: false, error: 'session_not_found' }, 404);
+  }
   const orderedSessionIds = treeRows.length > 0 ? treeRows.map(r => r.session_id) : [parsed.data];
   const deletedRows = await db
     .select()
@@ -235,35 +272,13 @@ api.post('/session/:sessionId/ingest', async c => {
   const ingestedAt = Date.now();
   const ingestRequestId = crypto.randomUUID();
   const kiloUserId = c.get('user_id');
-  const db = getWorkerDb(c.env.HYPERDRIVE.connectionString);
+  const accessibleSession = await resolveAccessibleKiloSession(c.env, {
+    kiloUserId,
+    kiloSessionId: sessionId,
+  });
 
-  const sessionCacheStubFactory = () => getSessionAccessCacheDO(c.env, { kiloUserId });
-
-  const hasAccess = await withDORetry(
-    sessionCacheStubFactory,
-    sessionCache => sessionCache.has(sessionId),
-    'SessionAccessCacheDO.has'
-  );
-
-  if (!hasAccess) {
-    const sessionRows = await db
-      .select({ session_id: cli_sessions_v2.session_id })
-      .from(cli_sessions_v2)
-      .where(
-        and(eq(cli_sessions_v2.session_id, sessionId), eq(cli_sessions_v2.kilo_user_id, kiloUserId))
-      )
-      .limit(1);
-
-    if (!sessionRows[0]) {
-      return c.json({ success: false, error: 'session_not_found' }, 404);
-    }
-
-    // Backfill so subsequent ingests can skip Postgres.
-    await withDORetry(
-      sessionCacheStubFactory,
-      sessionCache => sessionCache.add(sessionId),
-      'SessionAccessCacheDO.add'
-    );
+  if (!accessibleSession) {
+    return c.json({ success: false, error: 'session_not_found' }, 404);
   }
 
   const ingestVersion = ingestVersionSchema.parse(c.req.query('v') ?? 0);
@@ -421,62 +436,33 @@ api.post('/session/:sessionId/share', async c => {
 
   const db = getWorkerDb(c.env.HYPERDRIVE.connectionString);
   const kiloUserId = c.get('user_id');
+  const publicId = crypto.randomUUID();
+  const shareResult = await db.execute<{ public_id: string }>(sql`
+    UPDATE ${cli_sessions_v2}
+    SET public_id = COALESCE(${cli_sessions_v2.public_id}, ${publicId})
+    WHERE ${cli_sessions_v2.session_id} = ${parsed.data}
+      AND ${cli_sessions_v2.kilo_user_id} = ${kiloUserId}
+      AND (
+        ${cli_sessions_v2.organization_id} IS NULL
+        OR EXISTS (
+          SELECT 1
+          FROM ${organization_memberships}
+          INNER JOIN ${organizations}
+            ON ${organizations.id} = ${organization_memberships.organization_id}
+            AND ${organizations.deleted_at} IS NULL
+          WHERE ${organization_memberships.organization_id} = ${cli_sessions_v2.organization_id}
+            AND ${organization_memberships.kilo_user_id} = ${kiloUserId}
+        )
+      )
+    RETURNING ${cli_sessions_v2.public_id}
+  `);
 
-  const sessionRows = await db
-    .select({
-      session_id: cli_sessions_v2.session_id,
-      public_id: cli_sessions_v2.public_id,
-    })
-    .from(cli_sessions_v2)
-    .where(
-      and(eq(cli_sessions_v2.session_id, parsed.data), eq(cli_sessions_v2.kilo_user_id, kiloUserId))
-    )
-    .limit(1);
-
-  const session = sessionRows[0];
-
-  if (!session) {
+  const sharedSession = shareResult.rows[0];
+  if (!sharedSession) {
     return c.json({ success: false, error: 'session_not_found' }, 404);
   }
 
-  if (session.public_id) {
-    return c.json({ success: true, public_id: session.public_id }, 200);
-  }
-
-  const publicId = crypto.randomUUID();
-  const updated = await db
-    .update(cli_sessions_v2)
-    .set({ public_id: publicId })
-    .where(
-      and(
-        eq(cli_sessions_v2.session_id, parsed.data),
-        eq(cli_sessions_v2.kilo_user_id, kiloUserId),
-        isNull(cli_sessions_v2.public_id)
-      )
-    )
-    .returning({ public_id: cli_sessions_v2.public_id });
-
-  // If another request already set it, just return the existing value.
-  if (updated.length === 0) {
-    const existingRows = await db
-      .select({ public_id: cli_sessions_v2.public_id })
-      .from(cli_sessions_v2)
-      .where(
-        and(
-          eq(cli_sessions_v2.session_id, parsed.data),
-          eq(cli_sessions_v2.kilo_user_id, kiloUserId)
-        )
-      )
-      .limit(1);
-
-    const existing = existingRows[0];
-
-    if (existing?.public_id) {
-      return c.json({ success: true, public_id: existing.public_id }, 200);
-    }
-  }
-
-  return c.json({ success: true, public_id: publicId }, 200);
+  return c.json({ success: true, public_id: sharedSession.public_id }, 200);
 });
 
 api.post('/session/:sessionId/unshare', async c => {
@@ -488,6 +474,14 @@ api.post('/session/:sessionId/unshare', async c => {
 
   const db = getWorkerDb(c.env.HYPERDRIVE.connectionString);
   const kiloUserId = c.get('user_id');
+  const accessibleSession = await resolveAccessibleKiloSession(c.env, {
+    kiloUserId,
+    kiloSessionId: parsed.data,
+  });
+
+  if (!accessibleSession) {
+    return c.json({ success: false, error: 'session_not_found' }, 404);
+  }
 
   const sessionRows = await db
     .select({ session_id: cli_sessions_v2.session_id })

--- a/services/session-ingest/src/services/session-access.test.ts
+++ b/services/session-ingest/src/services/session-access.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryAccessibleKiloSessionMock, sessionCache } = vi.hoisted(() => ({
+  queryAccessibleKiloSessionMock: vi.fn(),
+  sessionCache: {
+    getAccess: vi.fn(),
+    putValidated: vi.fn(),
+  },
+}));
+
+vi.mock('@kilocode/db/client', () => ({
+  getWorkerDb: vi.fn(() => ({ select: vi.fn() })),
+}));
+
+vi.mock('@kilocode/worker-utils/cloud-agent-session-access', () => ({
+  queryAccessibleKiloSession: queryAccessibleKiloSessionMock,
+}));
+
+vi.mock('../dos/SessionAccessCacheDO', () => ({
+  getSessionAccessCacheDO: vi.fn(() => sessionCache),
+}));
+
+const { resolveAccessibleKiloSession } = await import('./session-access');
+
+const env = {
+  HYPERDRIVE: { connectionString: 'postgres://test' },
+} as never;
+
+describe('resolveAccessibleKiloSession', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('denies a session when the user no longer has current access', async () => {
+    sessionCache.getAccess.mockResolvedValue(null);
+    queryAccessibleKiloSessionMock.mockResolvedValue(null);
+
+    await expect(
+      resolveAccessibleKiloSession(env, {
+        kiloUserId: 'usr_removed',
+        kiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).resolves.toBeNull();
+    expect(sessionCache.putValidated).not.toHaveBeenCalled();
+  });
+
+  it('caches an authoritative current organization access result', async () => {
+    sessionCache.getAccess.mockResolvedValue(null);
+    queryAccessibleKiloSessionMock.mockResolvedValue({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org_current',
+    });
+
+    await expect(
+      resolveAccessibleKiloSession(env, {
+        kiloUserId: 'usr_member',
+        kiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).resolves.toEqual({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org_current',
+    });
+    expect(sessionCache.putValidated).toHaveBeenCalledWith({
+      sessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org_current',
+    });
+  });
+
+  it('falls back to authoritative access when the cache is unavailable', async () => {
+    sessionCache.getAccess.mockRejectedValue(new Error('cache unavailable'));
+    queryAccessibleKiloSessionMock.mockResolvedValue({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: null,
+    });
+
+    await expect(
+      resolveAccessibleKiloSession(env, {
+        kiloUserId: 'usr_owner',
+        kiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).resolves.toEqual({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: null,
+    });
+  });
+
+  it('allows authoritative access when the cache write fails', async () => {
+    sessionCache.getAccess.mockResolvedValue(null);
+    sessionCache.putValidated.mockRejectedValue(new Error('cache unavailable'));
+    queryAccessibleKiloSessionMock.mockResolvedValue({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org_current',
+    });
+
+    await expect(
+      resolveAccessibleKiloSession(env, {
+        kiloUserId: 'usr_member',
+        kiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).resolves.toEqual({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org_current',
+    });
+  });
+
+  it('propagates authoritative lookup failures', async () => {
+    sessionCache.getAccess.mockResolvedValue(null);
+    queryAccessibleKiloSessionMock.mockRejectedValue(new Error('database unavailable'));
+
+    await expect(
+      resolveAccessibleKiloSession(env, {
+        kiloUserId: 'usr_member',
+        kiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).rejects.toThrow('database unavailable');
+    expect(sessionCache.putValidated).not.toHaveBeenCalled();
+  });
+
+  it('reuses a recently validated organization access result', async () => {
+    sessionCache.getAccess.mockResolvedValue({
+      sessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org_current',
+    });
+
+    await expect(
+      resolveAccessibleKiloSession(env, {
+        kiloUserId: 'usr_member',
+        kiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).resolves.toEqual({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: 'org_current',
+    });
+    expect(queryAccessibleKiloSessionMock).not.toHaveBeenCalled();
+  });
+});

--- a/services/session-ingest/src/services/session-access.ts
+++ b/services/session-ingest/src/services/session-access.ts
@@ -1,0 +1,58 @@
+import { getWorkerDb } from '@kilocode/db/client';
+import { queryAccessibleKiloSession } from '@kilocode/worker-utils/cloud-agent-session-access';
+import type { Env } from '../env';
+import { getSessionAccessCacheDO } from '../dos/SessionAccessCacheDO';
+import { withDORetry } from '@kilocode/worker-utils';
+
+export type AccessibleKiloSession = {
+  kiloSessionId: string;
+  organizationId: string | null;
+};
+
+type ResolveAccessibleKiloSessionParams = {
+  kiloUserId: string;
+  kiloSessionId: string;
+};
+
+export async function resolveAccessibleKiloSession(
+  env: Env,
+  params: ResolveAccessibleKiloSessionParams
+): Promise<AccessibleKiloSession | null> {
+  try {
+    const cached = await withDORetry(
+      () => getSessionAccessCacheDO(env, { kiloUserId: params.kiloUserId }),
+      sessionCache => sessionCache.getAccess(params.kiloSessionId),
+      'SessionAccessCacheDO.getAccess'
+    );
+    if (cached) {
+      return {
+        kiloSessionId: cached.sessionId,
+        organizationId: cached.organizationId,
+      };
+    }
+  } catch {
+    // Cache availability must not decide authorization.
+  }
+
+  const db = getWorkerDb(env.HYPERDRIVE.connectionString);
+  const session = await queryAccessibleKiloSession(db, params);
+  if (!session) {
+    return null;
+  }
+
+  try {
+    await withDORetry(
+      () => getSessionAccessCacheDO(env, { kiloUserId: params.kiloUserId }),
+      sessionCache =>
+        sessionCache.putValidated({
+          sessionId: session.kiloSessionId,
+          organizationId: session.organizationId,
+        }),
+      'SessionAccessCacheDO.putValidated'
+    );
+  } catch {
+    // A failed cache write does not invalidate the authoritative database result.
+  }
+
+  return session;
+}

--- a/services/session-ingest/src/services/session-export.ts
+++ b/services/session-ingest/src/services/session-export.ts
@@ -1,38 +1,13 @@
-import { eq, and } from 'drizzle-orm';
-import { getWorkerDb } from '@kilocode/db/client';
-import { cli_sessions_v2 } from '@kilocode/db/schema';
-
 import type { Env } from '../env';
 import { getSessionIngestDO } from '../dos/SessionIngestDO';
+import { resolveAccessibleKiloSession } from './session-access';
 import { withDORetry } from '@kilocode/worker-utils';
-
-/**
- * Verify that the session exists in `cli_sessions_v2` and belongs to the
- * given user.
- */
-async function verifySessionOwnership(
-  env: Env,
-  sessionId: string,
-  kiloUserId: string
-): Promise<boolean> {
-  const db = getWorkerDb(env.HYPERDRIVE.connectionString);
-
-  const rows = await db
-    .select({ session_id: cli_sessions_v2.session_id })
-    .from(cli_sessions_v2)
-    .where(
-      and(eq(cli_sessions_v2.session_id, sessionId), eq(cli_sessions_v2.kilo_user_id, kiloUserId))
-    )
-    .limit(1);
-
-  return !!rows[0];
-}
 
 /**
  * Fetch the full session export as a streaming ReadableStream.
  *
- * Verifies that the session exists in `cli_sessions_v2` and belongs to the
- * given user before reading the DO.
+ * Verifies that the session belongs to the user and that organization access
+ * is current before reading the DO.
  *
  * @returns A ReadableStream of the JSON payload, or `null` if the session
  *          does not exist or does not belong to the user.
@@ -42,8 +17,11 @@ export async function getSessionExport(
   sessionId: string,
   kiloUserId: string
 ): Promise<ReadableStream<Uint8Array> | null> {
-  const owned = await verifySessionOwnership(env, sessionId, kiloUserId);
-  if (!owned) {
+  const accessibleSession = await resolveAccessibleKiloSession(env, {
+    kiloUserId,
+    kiloSessionId: sessionId,
+  });
+  if (!accessibleSession) {
     return null;
   }
 

--- a/services/session-ingest/src/session-ingest-rpc.ts
+++ b/services/session-ingest/src/session-ingest-rpc.ts
@@ -114,6 +114,22 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
       })
       .returning();
 
+    if (existingRow && hasMeaningfulChange && persistedRow) {
+      try {
+        await withDORetry(
+          () => getSessionAccessCacheDO(this.env, { kiloUserId: parsed.kiloUserId }),
+          sessionCache => sessionCache.remove(parsed.sessionId),
+          'SessionAccessCacheDO.remove'
+        );
+      } catch (cacheError) {
+        console.error('Failed to invalidate session access after Cloud Agent session write', {
+          sessionId: parsed.sessionId,
+          kiloUserId: parsed.kiloUserId,
+          error: cacheError instanceof Error ? cacheError.message : String(cacheError),
+        });
+      }
+    }
+
     if (hasMeaningfulChange && persistedRow) {
       const session = mapSessionEventRow(persistedRow);
       notifyUserSessionEvent(
@@ -125,22 +141,6 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
         },
         this.ctx
       );
-    }
-
-    // Warm the session cache so subsequent ingests can skip Postgres.
-    // Best-effort: cache miss is acceptable; don't fail the create if the DO is unavailable.
-    try {
-      await withDORetry(
-        () => getSessionAccessCacheDO(this.env, { kiloUserId: parsed.kiloUserId }),
-        sessionCache => sessionCache.add(parsed.sessionId),
-        'SessionAccessCacheDO.add'
-      );
-    } catch (cacheError) {
-      console.error('Failed to warm session cache after create (non-fatal)', {
-        sessionId: parsed.sessionId,
-        kiloUserId: parsed.kiloUserId,
-        error: cacheError instanceof Error ? cacheError.message : String(cacheError),
-      });
     }
   }
 

--- a/services/session-ingest/test/integration/session-access-cache-do.test.ts
+++ b/services/session-ingest/test/integration/session-access-cache-do.test.ts
@@ -1,0 +1,112 @@
+import { env, runInDurableObject } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import { SESSION_ACCESS_CACHE_TTL_MS } from '../../src/dos/SessionAccessCacheDO';
+
+function getStub(kiloUserId: string) {
+  return env.SESSION_ACCESS_CACHE_DO.get(env.SESSION_ACCESS_CACHE_DO.idFromName(kiloUserId));
+}
+
+describe('SessionAccessCacheDO integration', () => {
+  it('expires validated access after the fixed 60-second authorization window', async () => {
+    const stub = getStub('usr_cache_expiry');
+    const beforeWrite = Date.now();
+
+    await stub.putValidated({
+      sessionId: 'ses_12345678901234567890123456',
+      organizationId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    await expect(stub.getAccess('ses_12345678901234567890123456')).resolves.toEqual({
+      sessionId: 'ses_12345678901234567890123456',
+      organizationId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    await runInDurableObject(stub, async (_instance, state) => {
+      const [row] = [
+        ...state.storage.sql.exec<{ authorization_expires_at: number }>(
+          'SELECT authorization_expires_at FROM sessions WHERE session_id = ?',
+          'ses_12345678901234567890123456'
+        ),
+      ];
+      expect(row?.authorization_expires_at).toBeGreaterThanOrEqual(
+        beforeWrite + SESSION_ACCESS_CACHE_TTL_MS
+      );
+      expect(row?.authorization_expires_at).toBeLessThanOrEqual(
+        Date.now() + SESSION_ACCESS_CACHE_TTL_MS
+      );
+      state.storage.sql.exec(
+        'UPDATE sessions SET authorization_expires_at = ? WHERE session_id = ?',
+        Date.now() - 1,
+        'ses_12345678901234567890123456'
+      );
+    });
+
+    await expect(stub.getAccess('ses_12345678901234567890123456')).resolves.toBeNull();
+  });
+
+  it('supports legacy cache checks during mixed-version deployments', async () => {
+    const stub = getStub('usr_legacy_cache_check');
+    await stub.putValidated({
+      sessionId: 'ses_12345678901234567890123456',
+      organizationId: null,
+    });
+
+    await expect(stub.has('ses_12345678901234567890123456')).resolves.toBe(true);
+  });
+
+  it('does not grant access through the legacy context-free cache write', async () => {
+    const stub = getStub('usr_legacy_cache_write');
+
+    await stub.add('ses_12345678901234567890123456');
+
+    await expect(stub.getAccess('ses_12345678901234567890123456')).resolves.toBeNull();
+  });
+
+  it('purges expired rows on write so per-user storage stays bounded', async () => {
+    const stub = getStub('usr_cache_purge');
+    await stub.putValidated({
+      sessionId: 'ses_12345678901234567890123456',
+      organizationId: null,
+    });
+
+    await runInDurableObject(stub, async (_instance, state) => {
+      state.storage.sql.exec(
+        'UPDATE sessions SET authorization_expires_at = ? WHERE session_id = ?',
+        Date.now() - 1,
+        'ses_12345678901234567890123456'
+      );
+    });
+
+    await stub.putValidated({
+      sessionId: 'ses_abcdefghijklmnopqrstuvwxyz',
+      organizationId: null,
+    });
+
+    await runInDurableObject(stub, async (_instance, state) => {
+      const sessionIds = [
+        ...state.storage.sql.exec<{ session_id: string }>('SELECT session_id FROM sessions'),
+      ].map(row => row.session_id);
+      expect(sessionIds).toEqual(['ses_abcdefghijklmnopqrstuvwxyz']);
+    });
+  });
+
+  it('invalidates only cached access for the removed organization', async () => {
+    const stub = getStub('usr_cache_invalidation');
+    await stub.putValidated({
+      sessionId: 'ses_12345678901234567890123456',
+      organizationId: '11111111-1111-4111-8111-111111111111',
+    });
+    await stub.putValidated({
+      sessionId: 'ses_abcdefghijklmnopqrstuvwxyz',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+    });
+
+    await stub.invalidateOrganization('11111111-1111-4111-8111-111111111111');
+
+    await expect(stub.getAccess('ses_12345678901234567890123456')).resolves.toBeNull();
+    await expect(stub.getAccess('ses_abcdefghijklmnopqrstuvwxyz')).resolves.toEqual({
+      sessionId: 'ses_abcdefghijklmnopqrstuvwxyz',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+    });
+  });
+});

--- a/services/session-ingest/test/test-worker.ts
+++ b/services/session-ingest/test/test-worker.ts
@@ -1,4 +1,5 @@
 export { SessionIngestDO } from '../src/dos/SessionIngestDO';
+export { SessionAccessCacheDO } from '../src/dos/SessionAccessCacheDO';
 
 export default {
   fetch(): Response {

--- a/services/session-ingest/wrangler.test.jsonc
+++ b/services/session-ingest/wrangler.test.jsonc
@@ -20,13 +20,17 @@
         "name": "SESSION_INGEST_DO",
         "class_name": "SessionIngestDO",
       },
+      {
+        "name": "SESSION_ACCESS_CACHE_DO",
+        "class_name": "SessionAccessCacheDO",
+      },
     ],
   },
 
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["SessionIngestDO"],
+      "new_sqlite_classes": ["SessionIngestDO", "SessionAccessCacheDO"],
     },
   ],
 


### PR DESCRIPTION
## Summary

### Why

Session Ingest operations (ingest, share, unshare, delete, and export) previously verified only that a session row existed for the requesting user. They did not check whether the user still has access to the owning organization, so a removed member could continue to publish events or manage sessions until their token expired. This change makes current organization membership part of the authorization decision.

### What was done

- Add `resolveAccessibleKiloSession` to the Session Ingest Worker, which joins `cli_sessions_v2` with current `organization_memberships` and caches positive results in the per-user `SessionAccessCacheDO`.
- Extend the Durable Object cache schema to store `organization_id` and a fixed `authorization_expires_at` TTL; legacy cache rows expire immediately via a generated SQLite migration.
- Apply the access check to ingest, share, unshare, delete, and export paths; cache misses remain authoritative through Postgres.
- Add a secret-protected `POST /internal/session-access/invalidate` endpoint and call it from the web app when an organization member is removed.
- Invalidate cached entries when Cloud Agent session metadata changes organization scope or when the RPC updates an existing session mapping.
- Preserve deprecated `has`/`add` Durable Object RPCs as no-ops for mixed-version rollout compatibility.

### High-level architecture

```mermaid
sequenceDiagram
    participant Client as CLI / Extension
    participant Web as Web App (tRPC)
    participant SIW as Session Ingest Worker
    participant DO as SessionAccessCacheDO
    participant PG as Postgres (Hyperdrive)

    Client->>SIW: ingest / share / unshare / delete
    SIW->>DO: getAccess(sessionId)
    alt cache hit
        DO-->>SIW: cached organizationId
    else cache miss
        SIW->>PG: query session + current membership
        PG-->>SIW: accessible session
        SIW->>DO: putValidated(sessionId, organizationId)
    end
    SIW-->>Client: result

    Web->>Web: remove organization member
    Web->>SIW: POST /internal/session-access/invalidate
    SIW->>DO: invalidateOrganization(organizationId)
```

### Architecture decision

**Decision:** Cache positive authorization results in a per-user Durable Object with a fixed 60-second TTL and best-effort invalidation.

**Context:** Session Ingest is on the hot path for every CLI/extension event. A Postgres lookup on every request adds latency and load, but checking only the session row would miss organization membership revocation.

**Rationale:** The Durable Object is already part of the Session Ingest architecture and provides strongly consistent storage per user. A fixed TTL bounds the worst-case staleness, while Postgres remains authoritative on cache misses.

**Alternatives considered:**

- **Query Postgres on every request.** Rejected because it adds measurable latency and database load for a high-frequency path.
- **Use a shared Redis/cache layer.** Rejected to avoid introducing new infrastructure when the existing Durable Object already provides the required consistency model.

**Consequences:** Ingest paths avoid most Postgres authorization lookups; removed members lose access within the 60-second TTL window (or immediately on successful invalidation). Best-effort invalidation means membership removal does not fail if the cache is unreachable.

## Verification

No manual verification was performed. Behavior is covered by Session Ingest unit tests, Worker integration tests, and targeted web tests.

## Visual Changes

N/A

## Reviewer Notes

- The generated Durable Object SQLite migration (`0003_free_valkyrie.sql`) expires legacy cache rows immediately by adding a non-null `authorization_expires_at` default of `0`.
- Deprecated `has`/`add` RPCs are kept for mixed-version deployment compatibility and should be removed once all Workers are updated.
- The invalidation call from the web app has a 30-second timeout and is caught so member removal does not fail if Session Ingest is unavailable.
- Deployment order follows the existing web-before-Worker pattern; cache warming during session create is best-effort and cannot fail session creation.
