### PR TITLE
fix(dev): poll for shutdown completion before dev:restart relaunches

### DIFF
--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -638,7 +638,12 @@ async function cmdRestart(serviceName: string): Promise<void> {
     process.exit(1);
   }
 
-  restartServiceInTmux(sessionName, serviceName);
+  console.log(`Restarting ${serviceName} (waiting for the old process to shut down)...`);
+  const outcome = await restartServiceInTmux(sessionName, serviceName);
+  if (outcome === 'gave-up') {
+    console.error(`${serviceName} did not shut down in time; not relaunched`);
+    process.exit(1);
+  }
   console.log(`Restarted ${serviceName}`);
 }
 

--- a/dev/local/dashboard.tsx
+++ b/dev/local/dashboard.tsx
@@ -694,7 +694,7 @@ function Dashboard({
       const item = sidebarItems[selectedIdx];
       if (!item || item.kind !== 'service') return;
       if (!runningServices.has(item.name)) return;
-      restartServiceInTmux(sessionName, item.name);
+      void restartServiceInTmux(sessionName, item.name);
       return;
     }
     if (input === 'q') {

--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -278,13 +278,38 @@ export function showGroupInTmux(
   }
 }
 
-export function restartServiceInTmux(sessionName: string, serviceName: string): void {
+export type RestartOutcome =
+  // Relaunch command sent to the service's (now idle) shell.
+  | 'relaunched'
+  // Pane closed with the process; the service window was recreated.
+  | 'recreated'
+  // Old process refused to die within the deadline; nothing relaunched.
+  | 'gave-up'
+  // No pane for this service (not running), or infra service.
+  | 'not-running'
+  // A newer restart of the same service took over this poll.
+  | 'superseded';
+
+// In-flight restart polls keyed by `session:service`. A repeated restart
+// (e.g. a second keypress in the dashboard) must cancel the previous poll:
+// two concurrent polls would each relaunch, and the slower one would treat
+// the freshly started service as "still shutting down" and interrupt it.
+const inFlightRestarts = new Map<string, () => void>();
+
+export function restartServiceInTmux(
+  sessionName: string,
+  serviceName: string
+): Promise<RestartOutcome> {
   const svc = getService(serviceName);
-  if (svc.type === 'infra') return;
+  if (svc.type === 'infra') return Promise.resolve('not-running');
   const cmd = buildStartCommand(serviceName);
-  // Find the service wherever it lives (own window or joined into window 0)
+  // Find the service wherever it lives (own window or joined into window 0).
+  // Bail before touching the in-flight map: if the pane is already gone, a
+  // previous restart's poll may be mid-recreate and must not be cancelled.
   const pane = findServicePane(sessionName, serviceName);
-  if (!pane) return;
+  if (!pane) return Promise.resolve('not-running');
+  const restartKey = `${sessionName}:${serviceName}`;
+  inFlightRestarts.get(restartKey)?.();
   sendInterrupt(sessionName, pane.windowIndex, pane.paneIndex);
   // Poll until the old process is actually gone before relaunching. A fixed
   // delay is not enough: slow-shutdown services (wrangler with containers
@@ -294,51 +319,62 @@ export function restartServiceInTmux(sessionName: string, serviceName: string): 
   const POLL_MS = 500;
   const ESCALATE_AT_MS = 15_000; // second SIGINT for shutdowns stuck on children
   const GIVE_UP_AT_MS = 60_000;
-  let elapsed = 0;
-  let escalated = false;
-  const timer = setInterval(() => {
-    elapsed += POLL_MS;
-    const currentPane = findServicePane(sessionName, serviceName);
-    if (!currentPane) {
-      // The pane can close together with the process (SIGINT kills the
-      // non-interactive wrapper shell before its `exec $SHELL` runs, and
-      // tmux closes a pane when its process exits). Recreate the service
-      // window instead of leaving the service stopped after reporting
-      // "Restarted"; the new window inherits the tmux session environment.
+  return new Promise<RestartOutcome>(resolve => {
+    let elapsed = 0;
+    let escalated = false;
+    const settle = (outcome: RestartOutcome) => {
       clearInterval(timer);
-      try {
-        startServiceInTmux(sessionName, serviceName);
-      } catch {
-        // Same policy as below: keep the TUI alive; the next explicit
-        // restart/view action can retry.
-      }
-      return;
-    }
-    if (paneHasRunningChild(sessionName, currentPane)) {
-      if (elapsed >= GIVE_UP_AT_MS) {
-        // Refuses to die — typing into it would only feed its stdin.
-        clearInterval(timer);
-      } else if (!escalated && elapsed >= ESCALATE_AT_MS) {
-        // Mirror a human's second ctrl-c: wrangler and friends force-quit
-        // on a repeated interrupt when a graceful shutdown hangs.
-        escalated = true;
+      if (inFlightRestarts.get(restartKey) === cancel) inFlightRestarts.delete(restartKey);
+      resolve(outcome);
+    };
+    const cancel = () => settle('superseded');
+    inFlightRestarts.set(restartKey, cancel);
+    const timer = setInterval(() => {
+      elapsed += POLL_MS;
+      const currentPane = findServicePane(sessionName, serviceName);
+      if (!currentPane) {
+        // The pane can close together with the process (SIGINT kills the
+        // non-interactive wrapper shell before its `exec $SHELL` runs, and
+        // tmux closes a pane when its process exits). Recreate the service
+        // window instead of leaving the service stopped after reporting
+        // "Restarted"; the new window inherits the tmux session environment.
         try {
-          sendInterrupt(sessionName, currentPane.windowIndex, currentPane.paneIndex);
+          startServiceInTmux(sessionName, serviceName);
+          settle('recreated');
         } catch {
-          // Pane may vanish between the check and the signal; next tick
-          // handles it via the recreate branch.
+          // Same policy as below: keep the TUI alive; the next explicit
+          // restart/view action can retry.
+          settle('gave-up');
         }
+        return;
       }
-      return;
-    }
-    clearInterval(timer);
-    try {
-      sendKeys(sessionName, currentPane.windowIndex, cmd, currentPane.paneIndex);
-    } catch {
-      // The dashboard may have moved or closed the pane after we resolved it.
-      // Keep the TUI alive; the next explicit restart/view action can retry.
-    }
-  }, POLL_MS);
+      if (paneHasRunningChild(sessionName, currentPane)) {
+        if (elapsed >= GIVE_UP_AT_MS) {
+          // Refuses to die — typing into it would only feed its stdin.
+          settle('gave-up');
+        } else if (!escalated && elapsed >= ESCALATE_AT_MS) {
+          // Mirror a human's second ctrl-c: wrangler and friends force-quit
+          // on a repeated interrupt when a graceful shutdown hangs.
+          escalated = true;
+          try {
+            sendInterrupt(sessionName, currentPane.windowIndex, currentPane.paneIndex);
+          } catch {
+            // Pane may vanish between the check and the signal; next tick
+            // handles it via the recreate branch.
+          }
+        }
+        return;
+      }
+      try {
+        sendKeys(sessionName, currentPane.windowIndex, cmd, currentPane.paneIndex);
+        settle('relaunched');
+      } catch {
+        // The dashboard may have moved or closed the pane after we resolved it.
+        // Keep the TUI alive; the next explicit restart/view action can retry.
+        settle('gave-up');
+      }
+    }, POLL_MS);
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -14,6 +14,7 @@ import {
   breakPane,
   countPanes,
   findServicePane,
+  paneHasRunningChild,
   selectPane,
   setPaneTitle,
   setMainLeftLayout,
@@ -285,7 +286,18 @@ export function restartServiceInTmux(sessionName: string, serviceName: string): 
   const pane = findServicePane(sessionName, serviceName);
   if (!pane) return;
   sendInterrupt(sessionName, pane.windowIndex, pane.paneIndex);
-  setTimeout(() => {
+  // Poll until the old process is actually gone before relaunching. A fixed
+  // delay is not enough: slow-shutdown services (wrangler with containers
+  // takes 10s+ on SIGINT) are still in the foreground when the relaunch
+  // keystrokes arrive, which feeds the command into the dying process's
+  // stdin instead of the shell and leaves the service stopped.
+  const POLL_MS = 500;
+  const ESCALATE_AT_MS = 15_000; // second SIGINT for shutdowns stuck on children
+  const GIVE_UP_AT_MS = 60_000;
+  let elapsed = 0;
+  let escalated = false;
+  const timer = setInterval(() => {
+    elapsed += POLL_MS;
     const currentPane = findServicePane(sessionName, serviceName);
     if (!currentPane) {
       // The pane can close together with the process (SIGINT kills the
@@ -293,6 +305,7 @@ export function restartServiceInTmux(sessionName: string, serviceName: string): 
       // tmux closes a pane when its process exits). Recreate the service
       // window instead of leaving the service stopped after reporting
       // "Restarted"; the new window inherits the tmux session environment.
+      clearInterval(timer);
       try {
         startServiceInTmux(sessionName, serviceName);
       } catch {
@@ -301,13 +314,31 @@ export function restartServiceInTmux(sessionName: string, serviceName: string): 
       }
       return;
     }
+    if (paneHasRunningChild(sessionName, currentPane)) {
+      if (elapsed >= GIVE_UP_AT_MS) {
+        // Refuses to die — typing into it would only feed its stdin.
+        clearInterval(timer);
+      } else if (!escalated && elapsed >= ESCALATE_AT_MS) {
+        // Mirror a human's second ctrl-c: wrangler and friends force-quit
+        // on a repeated interrupt when a graceful shutdown hangs.
+        escalated = true;
+        try {
+          sendInterrupt(sessionName, currentPane.windowIndex, currentPane.paneIndex);
+        } catch {
+          // Pane may vanish between the check and the signal; next tick
+          // handles it via the recreate branch.
+        }
+      }
+      return;
+    }
+    clearInterval(timer);
     try {
       sendKeys(sessionName, currentPane.windowIndex, cmd, currentPane.paneIndex);
     } catch {
       // The dashboard may have moved or closed the pane after we resolved it.
       // Keep the TUI alive; the next explicit restart/view action can retry.
     }
-  }, 1000);
+  }, POLL_MS);
 }
 
 // ---------------------------------------------------------------------------

--- a/dev/local/tmux.test.ts
+++ b/dev/local/tmux.test.ts
@@ -116,7 +116,7 @@ test(
       );
       tmux('select-pane', '-t', `${sessionName}:0.1`, '-T', serviceName);
 
-      restartServiceInTmux(sessionName, serviceName);
+      void restartServiceInTmux(sessionName, serviceName);
       breakPane(sessionName, 0, 1, serviceName);
 
       await sleep(1200);
@@ -196,9 +196,18 @@ process.stdin.on('data', d => {
       }
       assert.ok(fixtureUp, 'slow-shutdown fixture process should start');
 
-      restartServiceInTmux(sessionName, serviceName);
+      // A second restart before the first settles must take over the poll —
+      // otherwise both would relaunch, and the slower one would interrupt
+      // the freshly started service partway through its own poll.
+      const supersededRestart = restartServiceInTmux(sessionName, serviceName);
+      const outcome = await restartServiceInTmux(sessionName, serviceName);
+      assert.equal(await supersededRestart, 'superseded');
+      assert.ok(
+        outcome === 'relaunched' || outcome === 'recreated',
+        `restart should settle with a relaunch, got '${outcome}'`
+      );
 
-      await sleep(6000);
+      await sleep(500); // let the relaunch keystrokes echo before capturing
       // Depending on the wrapper shell's SIGINT semantics the pane either
       // survives (relaunch typed into its shell) or closes with the process
       // (service window recreated). Both count as a restart; the old fixed
@@ -264,9 +273,9 @@ test(
       );
       tmux('select-pane', '-t', `${sessionName}:0.1`, '-T', serviceName);
 
-      restartServiceInTmux(sessionName, serviceName);
+      const outcome = await restartServiceInTmux(sessionName, serviceName);
 
-      await sleep(1500);
+      assert.equal(outcome, 'recreated');
       assert.ok(
         listWindows(sessionName).some(window => window.name === serviceName),
         'service window should be recreated after its pane closed on interrupt'

--- a/dev/local/tmux.test.ts
+++ b/dev/local/tmux.test.ts
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import test from 'node:test';
 
 import { breakPane, buildInteractiveShellCommand, listWindows } from './tmux';
-import { restartServiceInTmux } from './runner';
+import { buildStartCommand, restartServiceInTmux } from './runner';
 
 test('buildInteractiveShellCommand wraps quoted startup commands in parseable shell syntax', () => {
   const startupCommand =
@@ -119,6 +122,111 @@ test(
       await sleep(1200);
       assert.ok(listWindows(sessionName).some(window => window.name === serviceName));
     } finally {
+      try {
+        tmux('kill-session', '-t', sessionName);
+      } catch {
+        // Session may already be gone if tmux fails during setup.
+      }
+    }
+  }
+);
+
+test(
+  'restartServiceInTmux waits for a slow shutdown before sending the relaunch command',
+  { skip: !hasTmux },
+  async () => {
+    const sessionName = `kilo-tmux-test-${process.pid}-${Date.now()}`;
+    const serviceName = 'stripe';
+    const tmux = (...args: string[]) => execFileSync('tmux', args, { stdio: 'ignore' });
+    // Emulate wrangler-style shutdown: the process holds the tty in raw mode
+    // (interactive hotkeys), so ctrl-c never becomes SIGINT — it arrives as
+    // byte 0x03 and triggers a shutdown that takes seconds. Keystrokes sent
+    // while it is still alive are swallowed by its raw stdin and never reach
+    // the shell — the marker file records any such swallowed input.
+    const script = path.join(os.tmpdir(), `kilo-tmux-test-slow-${process.pid}.js`);
+    const swallowedMarker = path.join(os.tmpdir(), `kilo-tmux-test-swallowed-${process.pid}`);
+    fs.writeFileSync(
+      script,
+      `const fs = require('node:fs');
+process.stdin.setRawMode(true);
+process.stdin.on('data', d => {
+  if (d.includes(3)) { setTimeout(() => process.exit(0), 3000); return; }
+  fs.appendFileSync(${JSON.stringify(swallowedMarker)}, d);
+});`
+    );
+
+    try {
+      tmux('new-session', '-d', '-s', sessionName, '-n', 'dashboard', 'sleep 120');
+      tmux(
+        'new-window',
+        '-d',
+        '-t',
+        sessionName,
+        '-n',
+        serviceName,
+        buildInteractiveShellCommand(`'${process.execPath}' '${script}'`)
+      );
+
+      const serviceWindow = listWindows(sessionName).find(window => window.name === serviceName);
+      assert.ok(serviceWindow);
+
+      tmux(
+        'join-pane',
+        '-h',
+        '-s',
+        `${sessionName}:${serviceWindow.index}.0`,
+        '-t',
+        `${sessionName}:0.0`
+      );
+      tmux('select-pane', '-t', `${sessionName}:0.1`, '-T', serviceName);
+
+      // The wrapper is a login shell whose startup (version managers etc.)
+      // can take seconds; the interrupt must land while the service process
+      // is alive, otherwise this degenerates into the pane-death scenario.
+      // Anchor the pattern to the node binary — the wrapper shell's own
+      // cmdline also contains the script path and must not match.
+      let fixtureUp = false;
+      for (let i = 0; i < 40 && !fixtureUp; i++) {
+        try {
+          execFileSync('pgrep', ['-f', `^${process.execPath} .*${script}`], { stdio: 'ignore' });
+          fixtureUp = true;
+        } catch {
+          await sleep(250);
+        }
+      }
+      assert.ok(fixtureUp, 'slow-shutdown fixture process should start');
+
+      restartServiceInTmux(sessionName, serviceName);
+
+      await sleep(6000);
+      // Depending on the wrapper shell's SIGINT semantics the pane either
+      // survives (relaunch typed into its shell) or closes with the process
+      // (service window recreated). Both count as a restart; the old fixed
+      // 1s delay produced neither — the keystrokes vanished into the dying
+      // process and the service stayed stopped.
+      const windowRecreated = listWindows(sessionName).some(window => window.name === serviceName);
+      let paneEchoedCommand = false;
+      try {
+        const paneContent = execFileSync(
+          'tmux',
+          ['capture-pane', '-p', '-J', '-t', `${sessionName}:0.1`],
+          { encoding: 'utf-8' }
+        );
+        paneEchoedCommand = paneContent.includes(buildStartCommand(serviceName));
+      } catch {
+        // Pane closed with the process — the recreate branch applies.
+      }
+      assert.ok(
+        !fs.existsSync(swallowedMarker),
+        'relaunch keystrokes must not be fed to the still-running process'
+      );
+      assert.ok(
+        windowRecreated || paneEchoedCommand,
+        'service should be relaunched after the slow shutdown completes'
+      );
+    } finally {
+      fs.rmSync(script, { force: true });
+      fs.rmSync(swallowedMarker, { force: true });
       try {
         tmux('kill-session', '-t', sessionName);
       } catch {

--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -404,6 +404,26 @@ function isPaneRunningCommand(sessionName: string, pane: PaneInfo): boolean {
   }
 }
 
+/**
+ * Whether the pane's shell currently has a child process. `pane_current_command`
+ * cannot answer this: services run under a `$SHELL -lc '<cmd>; exec $SHELL -l'`
+ * wrapper, so it reports the wrapper shell even while the service is alive.
+ * Used to tell "service still shutting down" from "idle shell, safe to type".
+ */
+function paneHasRunningChild(sessionName: string, pane: PaneInfo): boolean {
+  try {
+    const panePid = execSync(
+      `tmux display-message -p -t ${sessionName}:${pane.windowIndex}.${pane.paneIndex} "#{pane_pid}"`,
+      { encoding: 'utf-8' }
+    ).trim();
+    if (!/^\d+$/.test(panePid)) return false;
+    execSync(`pgrep -P ${panePid}`, { stdio: 'ignore' });
+    return true; // pgrep exits 0 only when at least one child matches
+  } catch {
+    return false;
+  }
+}
+
 function selectPane(sessionName: string, windowTarget: string | number, pane: number): void {
   execSync(`tmux select-pane -t ${sessionName}:${windowTarget}.${pane}`, { stdio: 'ignore' });
 }
@@ -504,6 +524,7 @@ export {
   countPanes,
   findServicePane,
   isPaneRunningCommand,
+  paneHasRunningChild,
   selectPane,
   setPaneTitle,
   enablePaneBorders,


### PR DESCRIPTION
## Problem

Follow-up to #4401. `pnpm dev:restart <service>` sends the relaunch command a fixed **1 second** after the interrupt. That isn't enough for slow-shutdown services: `wrangler dev` (cloud-agent-next, session-ingest, …) holds the tty in **raw mode**, so ctrl-c arrives as a byte rather than SIGINT, and shutdown with containers takes 10s+. The relaunch keystrokes land while the old process is still in the foreground, get consumed by its stdin, and the service ends up stopped — or worse, half-reloaded (observed today: a wrangler instance left running with no port bound after `dev:restart cloud-agent-next`).

## Fix

`restartServiceInTmux` now polls the pane every 500ms and only sends the relaunch once the pane's shell has no child process left:

- `pane_current_command` can't detect shutdown completion — services run under a `$SHELL -lc '<cmd>; exec $SHELL -l'` wrapper, so it reports the wrapper shell even while the service is alive. A new `paneHasRunningChild` helper checks `pgrep -P <pane_pid>` instead.
- If the process is still alive after **15s**, a second interrupt is sent — mirrors a human's second ctrl-c, which force-quits wrangler when a graceful shutdown hangs.
- After **60s** the restart gives up instead of typing into a wedged process.
- The pane-death fallback from #4401 (recreate the service window) is preserved and now applies at whatever point the pane closes, not only at the 1s mark.

## Verification

- New regression test emulates the wrangler shutdown: a raw-mode fixture treats ctrl-c as byte 0x03 (no SIGINT), exits 3s later, and records any keystrokes it swallows to a marker file. **Fails on the previous fixed-delay implementation** ("relaunch keystrokes must not be fed to the still-running process"), passes with the poll.
- All dev/local tests: 15/15 pass. oxlint and oxfmt clean on the changed files.