### PR TITLE
fix(mobile): release QA fixes

### DIFF
--- a/apps/mobile/src/app/(app)/agent-chat/new.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/new.tsx
@@ -80,7 +80,6 @@ export default function NewSessionScreen() {
 
   // Prompt ref (uncontrolled TextInput on iOS)
   const promptRef = useRef('');
-  const [hasPrompt, setHasPrompt] = useState(false);
   const [promptInputWidth, setPromptInputWidth] = useState(0);
   const promptMeasure = useTextHeight({
     minHeight: PROMPT_INPUT_MIN_HEIGHT,
@@ -163,7 +162,16 @@ export default function NewSessionScreen() {
   const handleCreate = useCallback(async () => {
     const prompt = promptRef.current.trim();
     // The backend requires a non-empty prompt even when attachments are present.
-    if (!prompt || !selectedRepo || !model) {
+    if (!prompt) {
+      toast.error('Enter a prompt first.');
+      return;
+    }
+    if (!selectedRepo) {
+      toast.error('Select a repository first.');
+      return;
+    }
+    if (!model) {
+      toast.error('Select a model first.');
       return;
     }
     if (attachments.isUploading) {
@@ -245,8 +253,6 @@ export default function NewSessionScreen() {
     attachments,
   ]);
 
-  const canStart = hasPrompt && selectedRepo.length > 0 && model.length > 0 && !isCreating;
-
   const { addCandidates } = attachments;
   const handleAddAttachment = useCallback(async () => {
     addCandidates(await pickAgentAttachments());
@@ -303,7 +309,6 @@ export default function NewSessionScreen() {
               onChangeText={text => {
                 promptRef.current = text;
                 promptMeasure.setText(text);
-                setHasPrompt(text.trim().length > 0);
               }}
               onLayout={handlePromptInputLayout}
               scrollEnabled={promptMeasure.height >= PROMPT_INPUT_MAX_HEIGHT}
@@ -374,7 +379,7 @@ export default function NewSessionScreen() {
         <Button
           size="lg"
           className="mt-6"
-          disabled={!canStart}
+          disabled={isCreating}
           onPress={() => {
             void handleCreate();
           }}

--- a/apps/mobile/src/components/agents/child-session-section.tsx
+++ b/apps/mobile/src/components/agents/child-session-section.tsx
@@ -152,10 +152,16 @@ export function ChildSessionSection({
           <Text className="text-sm text-foreground" numberOfLines={1}>
             {subtitle}
           </Text>
-          {currentTool ? (
-            <Text className="text-xs text-muted-foreground" numberOfLines={1}>
-              <Text className="text-xs text-agent-sky">{currentTool.tool}</Text>
-              {currentTool.context ? ` ${currentTool.context}` : ''}
+          {isRunning ? (
+            <Text className="text-xs leading-4 text-muted-foreground" numberOfLines={1}>
+              {currentTool ? (
+                <>
+                  <Text className="text-xs leading-4 text-agent-sky">{currentTool.tool}</Text>
+                  {currentTool.context ? ` ${currentTool.context}` : ''}
+                </>
+              ) : (
+                ' '
+              )}
             </Text>
           ) : null}
         </View>

--- a/apps/mobile/src/components/agents/message-bubble.tsx
+++ b/apps/mobile/src/components/agents/message-bubble.tsx
@@ -58,7 +58,9 @@ export function MessageBubble({
         accessibilityHint="Long press to copy message text"
       >
         <Bubble side="user">
-          {textContent ? <MarkdownText value={textContent} variant="user" /> : null}
+          {textContent ? (
+            <MarkdownText value={textContent} variant="user" selectable={false} />
+          ) : null}
           {fileParts.map(part => (
             <FilePartRenderer key={part.id} part={part} />
           ))}

--- a/apps/mobile/src/components/agents/text-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/text-part-renderer.tsx
@@ -9,5 +9,7 @@ export function TextPartRenderer({ text }: Readonly<TextPartRendererProps>) {
     return null;
   }
 
-  return <MarkdownText value={text} variant="assistant" />;
+  // selectable={false}: the message Pressable's long-press copy sheet and iOS
+  // native text selection would both trigger on the same gesture otherwise.
+  return <MarkdownText value={text} variant="assistant" selectable={false} />;
 }

--- a/apps/mobile/src/components/login-screen.tsx
+++ b/apps/mobile/src/components/login-screen.tsx
@@ -130,7 +130,7 @@ export function LoginScreen() {
                 }}
                 accessibilityLabel="Copy sign-in link"
               >
-                <Text>Copy Link</Text>
+                <Text numberOfLines={1}>Copy Link</Text>
               </Button>
             </View>
             <Button variant="ghost" onPress={cancel} accessibilityLabel="Cancel sign in">

--- a/apps/mobile/src/lib/auth/auth-context.tsx
+++ b/apps/mobile/src/lib/auth/auth-context.tsx
@@ -14,6 +14,7 @@ import { queryClient } from '@/lib/query-client';
 import { setTrpcUnauthorizedHandler } from '@/lib/auth/trpc-unauthorized';
 import { clearAgentModelPreference } from '@/lib/hooks/use-persisted-agent-model';
 import { clearReasoningPreference } from '@/lib/hooks/use-reasoning-preference';
+import { clearLastActiveInstance } from '@/lib/last-active-instance';
 import { resetPurchaseErrorToastDedup } from '@/lib/kilo-pass/use-store-kilo-pass-purchase';
 import {
   AUTH_TOKEN_KEY,
@@ -63,6 +64,7 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
     await SecureStore.deleteItemAsync(ORGANIZATION_STORAGE_KEY);
     await SecureStore.deleteItemAsync(SESSION_FILTERS_KEY);
     await SecureStore.deleteItemAsync(NOTIFICATION_PROMPT_SEEN_KEY);
+    await clearLastActiveInstance();
     clearAgentModelPreference();
     clearReasoningPreference();
     queryClient.clear();

--- a/apps/mobile/src/lib/hooks/use-persisted-agent-session-filters.ts
+++ b/apps/mobile/src/lib/hooks/use-persisted-agent-session-filters.ts
@@ -10,11 +10,10 @@ type AgentSessionFilters = {
 
 type FiltersUpdater = AgentSessionFilters | ((prev: AgentSessionFilters) => AgentSessionFilters);
 type StringArrayUpdater = string[] | ((prev: string[]) => string[]);
-const DEFAULT_PLATFORM_FILTER = ['cloud-agent'];
 
 function createDefaultFilters(): AgentSessionFilters {
   return {
-    platformFilter: [...DEFAULT_PLATFORM_FILTER],
+    platformFilter: [],
     projectFilter: [],
   };
 }

--- a/apps/mobile/src/lib/last-active-instance.ts
+++ b/apps/mobile/src/lib/last-active-instance.ts
@@ -4,6 +4,27 @@ import { LAST_ACTIVE_INSTANCE_KEY } from '@/lib/storage-keys';
 
 let cached: string | null = null;
 
+// Persistence writes are serialized so a sign-out clear can never be
+// overtaken by an in-flight set, which would leak the previous account's
+// sandbox id into the next cold start.
+let writeQueue: Promise<void> | null = null;
+
+async function enqueueWrite(op: () => Promise<void>): Promise<void> {
+  const previous = writeQueue;
+  const next = (async () => {
+    if (previous) {
+      try {
+        await previous;
+      } catch {
+        // An earlier failed write must not block the queue.
+      }
+    }
+    await op();
+  })();
+  writeQueue = next;
+  await next;
+}
+
 export async function loadLastActiveInstance(): Promise<void> {
   const stored = await SecureStore.getItemAsync(LAST_ACTIVE_INSTANCE_KEY);
   cached ??= stored;
@@ -15,10 +36,14 @@ export function getLastActiveInstance(): string | null {
 
 export async function setLastActiveInstance(sandboxId: string): Promise<void> {
   cached = sandboxId;
-  await SecureStore.setItemAsync(LAST_ACTIVE_INSTANCE_KEY, sandboxId);
+  await enqueueWrite(async () => {
+    await SecureStore.setItemAsync(LAST_ACTIVE_INSTANCE_KEY, sandboxId);
+  });
 }
 
 export async function clearLastActiveInstance(): Promise<void> {
   cached = null;
-  await SecureStore.deleteItemAsync(LAST_ACTIVE_INSTANCE_KEY);
+  await enqueueWrite(async () => {
+    await SecureStore.deleteItemAsync(LAST_ACTIVE_INSTANCE_KEY);
+  });
 }

--- a/apps/mobile/src/lib/last-active-instance.ts
+++ b/apps/mobile/src/lib/last-active-instance.ts
@@ -17,3 +17,8 @@ export async function setLastActiveInstance(sandboxId: string): Promise<void> {
   cached = sandboxId;
   await SecureStore.setItemAsync(LAST_ACTIVE_INSTANCE_KEY, sandboxId);
 }
+
+export async function clearLastActiveInstance(): Promise<void> {
+  cached = null;
+  await SecureStore.deleteItemAsync(LAST_ACTIVE_INSTANCE_KEY);
+}

--- a/apps/mobile/src/lib/organization-context.tsx
+++ b/apps/mobile/src/lib/organization-context.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from 'react';
 
+import { useAuth } from '@/lib/auth/auth-context';
 import { ORGANIZATION_STORAGE_KEY } from '@/lib/storage-keys';
 
 type OrganizationContextValue = {
@@ -21,8 +22,18 @@ type OrganizationContextValue = {
 const OrganizationContext = createContext<OrganizationContextValue | undefined>(undefined);
 
 export function OrganizationProvider({ children }: { readonly children: ReactNode }) {
+  const { token } = useAuth();
   const [organizationId, setOrgState] = useState<string | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
+
+  // The provider mounts above the auth gate and never remounts, so the
+  // in-memory selection must be reset when the session ends — otherwise the
+  // previous user's org id keeps being sent after a different account signs in.
+  useEffect(() => {
+    if (!token) {
+      setOrgState(null);
+    }
+  }, [token]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/mobile/src/lib/organization-context.tsx
+++ b/apps/mobile/src/lib/organization-context.tsx
@@ -29,13 +29,14 @@ export function OrganizationProvider({ children }: { readonly children: ReactNod
   // The provider mounts above the auth gate and never remounts, so the
   // in-memory selection must be reset when the session ends — otherwise the
   // previous user's org id keeps being sent after a different account signs in.
+  // Loading from storage is gated on the same token so a sign-out cancels any
+  // in-flight read that would otherwise reinstate the previous user's org id.
   useEffect(() => {
     if (!token) {
       setOrgState(null);
+      setIsLoaded(true);
+      return undefined;
     }
-  }, [token]);
-
-  useEffect(() => {
     let cancelled = false;
     const load = async () => {
       try {
@@ -53,7 +54,7 @@ export function OrganizationProvider({ children }: { readonly children: ReactNod
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [token]);
 
   const setOrganizationId = useCallback((id: string | null) => {
     setOrgState(id);

--- a/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.test.ts
@@ -142,6 +142,32 @@ describe('CliLiveTransport unified user web connection', () => {
     transport.destroy();
   });
 
+  it('re-forwards an unchanged heartbeat status after a disconnect', () => {
+    const { userWebConnection, transport, serviceEvents } = createTransportWithSinks();
+    transport.connect();
+
+    const heartbeat = (sessions: Array<{ id: string; status: string; title: string }>) => {
+      userWebConnection.emitSystem({
+        event: 'sessions.heartbeat',
+        data: { connectionId: 'owner', sessions },
+      });
+    };
+
+    heartbeat([{ id: KILO_SESSION_ID, status: 'idle', title: 'Tracked' }]);
+    heartbeat([]);
+    heartbeat([{ id: KILO_SESSION_ID, status: 'idle', title: 'Tracked' }]);
+
+    // idle → stopped(disconnected) → idle again: the post-reconnect status must
+    // be forwarded even though it matches the pre-disconnect one, because only
+    // a session.status event clears the disconnected UI state.
+    expect(serviceEvents).toEqual([
+      { type: 'session.status', sessionId: KILO_SESSION_ID, status: { type: 'idle' } },
+      { type: 'stopped', reason: 'disconnected' },
+      { type: 'session.status', sessionId: KILO_SESSION_ID, status: { type: 'idle' } },
+    ]);
+    transport.destroy();
+  });
+
   it('buffers chat during initial snapshot replay but does not delay service events', async () => {
     let resolveSnapshot: ((snapshot: SessionSnapshot) => void) | undefined;
     const fetchSnapshot = jest.fn(

--- a/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.ts
@@ -15,12 +15,18 @@ type CliLiveTransportConfig = {
   onError?: (message: string) => void;
 };
 
+// How long after a reconnect to re-fetch the snapshot a second time. Covers
+// the session store's persistence lag behind the live stream; bump if holes
+// still appear after long backgrounding.
+const RECONNECT_RESYNC_DELAY_MS = 5000;
+
 function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactory {
   return (sink: TransportSink) => {
     let generation = 0;
     let cleanup: (() => void) | null = null;
     let sessionStopped = false;
     let ownerConnectionId: string | null = null;
+    let lastForwardedHeartbeatStatus: string | null = null;
 
     function replaySnapshot(snapshot: SessionSnapshot): void {
       sink.onServiceEvent({ type: 'session.created', info: snapshot.info });
@@ -58,6 +64,21 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
       sessionStopped = true;
     }
 
+    // Heartbeats carry the CLI's current per-session status. Forwarding it
+    // re-derives activity after a reconnect: a terminal `session.status: idle`
+    // fired while the socket was dead is never replayed, which otherwise
+    // leaves the UI stuck on a busy indicator forever.
+    function forwardHeartbeatStatus(status: string): void {
+      if (status !== 'idle' && status !== 'busy') return;
+      if (status === lastForwardedHeartbeatStatus) return;
+      lastForwardedHeartbeatStatus = status;
+      sink.onServiceEvent({
+        type: 'session.status',
+        sessionId: config.kiloSessionId,
+        status: { type: status },
+      });
+    }
+
     function handleSystemMessage(event: string, data: unknown): void {
       if (event === 'cli.disconnected') {
         const parsed = cliConnectionDataSchema.safeParse(data);
@@ -75,6 +96,7 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
         if (session) {
           ownerConnectionId = session.connectionId;
           sessionStopped = false;
+          forwardHeartbeatStatus(session.status);
           return;
         }
 
@@ -90,6 +112,7 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
         if (session) {
           ownerConnectionId = parsed.data.connectionId;
           sessionStopped = false;
+          forwardHeartbeatStatus(session.status);
           return;
         }
 
@@ -115,6 +138,8 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
         releaseConnection();
         sessionStopped = false;
         ownerConnectionId = null;
+        lastForwardedHeartbeatStatus = null;
+        let resyncTimer: ReturnType<typeof setTimeout> | null = null;
 
         let bufferedCliEvents: UserWebCliEvent[] | null = [];
         let bufferedEventsFromSupersededSnapshot: UserWebCliEvent[] = [];
@@ -193,6 +218,15 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
         });
         const offReconnect = config.userWebConnection.onReconnect(() => {
           replayCurrentSnapshot(false);
+          // The snapshot store lags the live stream, and the CLI only forwards
+          // events "from now" after a resubscribe — parts finalized while the
+          // socket was dead are in neither. One delayed re-sync picks them up
+          // once persistence catches up.
+          if (resyncTimer) clearTimeout(resyncTimer);
+          resyncTimer = setTimeout(() => {
+            resyncTimer = null;
+            replayCurrentSnapshot(false);
+          }, RECONNECT_RESYNC_DELAY_MS);
         });
         const releaseSubscription = config.userWebConnection.subscribeToCliSession(
           config.kiloSessionId
@@ -201,6 +235,7 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
         cleanup = () => {
           if (released) return;
           released = true;
+          if (resyncTimer) clearTimeout(resyncTimer);
           offCli();
           offSystem();
           offReconnect();

--- a/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.ts
@@ -62,6 +62,10 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
       if (sessionStopped) return;
       sink.onServiceEvent({ type: 'stopped', reason: 'disconnected' });
       sessionStopped = true;
+      // The disconnected state is only cleared by a session.status event, so
+      // the next post-reconnect heartbeat must always forward one — even when
+      // the CLI comes back with the same status it had before the drop.
+      lastForwardedHeartbeatStatus = null;
     }
 
     // Heartbeats carry the CLI's current per-session status. Forwarding it

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-connection.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-connection.ts
@@ -13,7 +13,9 @@ import {
 import type { CloudAgentStreamTicket, CloudAgentStreamTicketResult } from './transport';
 
 export type ConnectionConfig = {
-  websocketUrl: string;
+  /** Static URL, or a builder re-evaluated on every (re)connect attempt so
+   * the caller can vary query params (e.g. a replay cursor). */
+  websocketUrl: string | (() => string);
   ticket: CloudAgentStreamTicketResult;
   onEvent: (event: CloudAgentEvent) => void;
   onConnected: () => void;
@@ -88,7 +90,9 @@ export function createConnection(config: ConnectionConfig): Connection {
     lifecycleHooks: config.lifecycleHooks,
     websocketHeaders: config.websocketHeaders,
     buildUrl: () => {
-      const url = new URL(config.websocketUrl);
+      const url = new URL(
+        typeof config.websocketUrl === 'function' ? config.websocketUrl() : config.websocketUrl
+      );
       url.searchParams.set('ticket', currentTicket.ticket);
       return url.toString();
     },

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
@@ -528,8 +528,23 @@ describe('CloudAgentTransport snapshot refetch on reconnect', () => {
     ws.onmessage?.({ data: JSON.stringify(event) } as MessageEvent);
   }
 
+  /** Kilocode event with the eventId: 0 sentinel — never advances the replay cursor. */
+  function sentinelStatus(): CloudAgentEvent {
+    return {
+      eventId: 0,
+      executionId: null,
+      sessionId: 'ses-1',
+      streamEventType: 'kilocode',
+      timestamp: new Date().toISOString(),
+      data: {
+        type: 'session.status',
+        properties: { sessionID: 'ses-1', status: { type: 'busy' } },
+      },
+    };
+  }
+
   /** Establish connection, simulate close + reconnect, return the new WS mock. */
-  async function simulateReconnect(): Promise<MockWebSocket> {
+  async function simulateReconnect(establishEvent?: CloudAgentEvent): Promise<MockWebSocket> {
     mockWs.onclose?.({ code: 1006, reason: '', wasClean: false } as CloseEvent);
 
     jest.advanceTimersByTime(2000);
@@ -540,13 +555,13 @@ describe('CloudAgentTransport snapshot refetch on reconnect', () => {
     newMockWs.onopen?.(new Event('open'));
     sendRawOn(
       newMockWs,
-      kilocode('session.status', { sessionID: 'ses-1', status: { type: 'busy' } })
+      establishEvent ?? kilocode('session.status', { sessionID: 'ses-1', status: { type: 'busy' } })
     );
 
     return newMockWs;
   }
 
-  it('refetches snapshot on reconnect and replays events into sinks', async () => {
+  it('resumes from the replay cursor on reconnect instead of refetching the snapshot', async () => {
     jest.useFakeTimers();
     try {
       const { transport, serviceEvents, fetchSnapshot } = createTransportWithControllableSnapshot();
@@ -556,20 +571,29 @@ describe('CloudAgentTransport snapshot refetch on reconnect', () => {
 
       expect(fetchSnapshot).toHaveBeenCalledTimes(1);
 
-      // Establish connection in base-connection by sending a valid event
-      sendRaw(kilocode('session.status', { sessionID: 'ses-1', status: { type: 'busy' } }));
+      // Establish connection with a persisted event — its id becomes the cursor.
+      const establish = kilocode('session.status', {
+        sessionID: 'ses-1',
+        status: { type: 'busy' },
+      });
+      sendRaw(establish);
 
       const serviceCountBefore = serviceEvents.length;
 
       const newMockWs = await simulateReconnect();
       await flushMicrotasks();
 
-      expect(fetchSnapshot).toHaveBeenCalledTimes(2);
+      // The socket replays missed events itself via fromId — no snapshot
+      // refetch, and no snapshot-driven session.created.
+      expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+      const reconnectUrl = String(webSocketConstructor.mock.calls.at(-1)?.[0]);
+      expect(reconnectUrl).toContain(`fromId=${establish.eventId}`);
+      expect(reconnectUrl).not.toContain('replay=false');
 
       const replayedCreated = serviceEvents
         .slice(serviceCountBefore)
         .filter(e => e.type === 'session.created');
-      expect(replayedCreated).toHaveLength(1);
+      expect(replayedCreated).toHaveLength(0);
 
       transport.destroy();
       newMockWs.onclose?.({ code: 1000, reason: '', wasClean: true } as CloseEvent);
@@ -578,7 +602,7 @@ describe('CloudAgentTransport snapshot refetch on reconnect', () => {
     }
   });
 
-  it('replayed snapshot with messages upserts into sinks correctly', async () => {
+  it('refetches the snapshot on reconnect when no replay cursor exists and upserts it', async () => {
     jest.useFakeTimers();
     try {
       const snapshotWithMessages = makeSnapshot({ id: 'ses-1' }, [
@@ -613,10 +637,11 @@ describe('CloudAgentTransport snapshot refetch on reconnect', () => {
       expect(chatEvents.filter(e => e.type === 'message.updated')).toHaveLength(1);
       expect(chatEvents.filter(e => e.type === 'message.part.updated')).toHaveLength(1);
 
-      // Establish connection
-      sendRaw(kilocode('session.status', { sessionID: 'ses-1', status: { type: 'busy' } }));
+      // Establish connection with sentinel events only — no replay cursor, so
+      // reconnect falls back to the snapshot refetch.
+      sendRaw(sentinelStatus());
 
-      const newMockWs = await simulateReconnect();
+      const newMockWs = await simulateReconnect(sentinelStatus());
       await flushMicrotasks();
 
       expect(fetchSnapshot).toHaveBeenCalledTimes(2);

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.ts
@@ -35,17 +35,27 @@ type CloudAgentTransportConfig = {
 function createCloudAgentTransport(config: CloudAgentTransportConfig): TransportFactory {
   const websocketBaseUrl = config.websocketBaseUrl;
 
-  function buildWebsocketUrl(): string {
-    const url = new URL('/stream', websocketBaseUrl);
-    url.searchParams.set('cloudAgentSessionId', config.sessionId);
-    url.searchParams.set('replay', 'false');
-    return url.toString();
-  }
-
   return (sink: TransportSink) => {
     let connection: Connection | null = null;
     let lifecycleGeneration = 0;
     let stoppedReceived = false;
+    // Last persisted event id seen on the wire (eventId 0 is the synthetic
+    // sentinel). Used as a replay cursor on reconnect: the DO replays every
+    // stored event after it, so content produced while the socket was dead is
+    // re-delivered in order instead of being left to snapshot freshness.
+    let lastEventId: number | null = null;
+
+    function buildWebsocketUrl(): string {
+      const url = new URL('/stream', websocketBaseUrl);
+      url.searchParams.set('cloudAgentSessionId', config.sessionId);
+      if (lastEventId === null) {
+        // First connect: messages are pre-loaded via REST, skip the full replay.
+        url.searchParams.set('replay', 'false');
+      } else {
+        url.searchParams.set('fromId', String(lastEventId));
+      }
+      return url.toString();
+    }
 
     function closeConnection(mode: 'disconnect' | 'destroy'): void {
       if (!connection) return;
@@ -80,11 +90,15 @@ function createCloudAgentTransport(config: CloudAgentTransportConfig): Transport
       const stoppedEvent: ServiceEvent = { type: 'stopped', reason: 'transport-disconnected' };
 
       const nextConnection = createConnection({
-        websocketUrl: buildWebsocketUrl(),
+        websocketUrl: buildWebsocketUrl,
         ticket,
         lifecycleHooks: config.lifecycleHooks,
         websocketHeaders: config.websocketHeaders,
         onEvent: raw => {
+          if (raw.eventId > 0) {
+            lastEventId = raw.eventId;
+          }
+
           const event = normalize(raw);
           if (!event) return;
 
@@ -113,6 +127,11 @@ function createCloudAgentTransport(config: CloudAgentTransportConfig): Transport
         onReconnected: () => {
           if (expectedGeneration !== lifecycleGeneration) return;
           stoppedReceived = false;
+          // With a replay cursor the socket itself re-delivers everything
+          // missed while dead — replaying a (possibly stale) snapshot on top
+          // would overwrite newer parts. Only fall back to the snapshot when
+          // no cursor exists yet.
+          if (lastEventId !== null) return;
           void config.fetchSnapshot(config.kiloSessionId).then(
             snapshot => {
               if (expectedGeneration !== lifecycleGeneration) return;

--- a/apps/web/src/lib/cloud-agent-sdk/session-routing.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-routing.test.ts
@@ -231,6 +231,7 @@ describe('session transport routing', () => {
         },
         releaseRetain,
         offSystemEvent,
+        subscribeRelease,
       };
     }
 
@@ -265,7 +266,11 @@ describe('session transport routing', () => {
       await Promise.resolve(); // fetchSnapshot resolves
 
       expect(resolveSession).toHaveBeenCalledTimes(1);
-      expect(fake.connection.retain).toHaveBeenCalledTimes(1);
+      // The watcher subscribes (not just retains) so the server pushes
+      // heartbeats/list re-sends for the watched session to this socket.
+      expect(fake.connection.subscribeToCliSession).toHaveBeenCalledTimes(1);
+      expect(fake.connection.subscribeToCliSession).toHaveBeenCalledWith(SES_ID);
+      expect(fake.connection.retain).not.toHaveBeenCalled();
       expect(session.storage.getMessageIds()).toContain('msg-1');
 
       // A heartbeat for a different session must not trigger a re-resolve.
@@ -283,10 +288,10 @@ describe('session transport routing', () => {
       await Promise.resolve(); // second resolveSession resolves
 
       expect(resolveSession).toHaveBeenCalledTimes(2);
-      expect(fake.connection.subscribeToCliSession).toHaveBeenCalledWith(SES_ID);
-      // Watcher is disarmed once the upgrade kicks off.
+      // Watcher is disarmed once the upgrade kicks off: its listener and
+      // subscription are both released.
       expect(fake.offSystemEvent).toHaveBeenCalledTimes(1);
-      expect(fake.releaseRetain).toHaveBeenCalledTimes(1);
+      expect(fake.subscribeRelease).toHaveBeenCalledTimes(1);
 
       session.destroy();
     });
@@ -314,7 +319,7 @@ describe('session transport routing', () => {
 
       session.destroy();
       expect(fake.offSystemEvent).toHaveBeenCalledTimes(1);
-      expect(fake.releaseRetain).toHaveBeenCalledTimes(1);
+      expect(fake.subscribeRelease).toHaveBeenCalledTimes(1);
 
       fake.emitSystemEvent('sessions.heartbeat', {
         connectionId: 'conn-1',

--- a/apps/web/src/lib/cloud-agent-sdk/session.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session.ts
@@ -186,9 +186,11 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
     const connection = config.transport.userWebConnection;
     if (!connection) return;
 
-    // Keep the socket alive while watching — nothing else retains it for a
-    // read-only session, and without it no heartbeats arrive.
-    const release = connection.retain?.();
+    // Subscribe (not just retain) while watching: the server only pushes
+    // sessions.heartbeat and subscribe-triggered sessions.list re-sends to
+    // sockets subscribed to the session, so a bare retain never sees the
+    // upgrade trigger. Subscribing also retains the socket.
+    const release = connection.subscribeToCliSession(config.kiloSessionId);
     const off = connection.onSystemEvent(({ event, data }) => {
       if (event !== 'sessions.list' && event !== 'sessions.heartbeat') return;
       const schema = event === 'sessions.list' ? sessionsListDataSchema : heartbeatDataSchema;
@@ -199,7 +201,7 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
     });
     disarmUpgradeWatcher = () => {
       off();
-      release?.();
+      release();
     };
   }
 


### PR DESCRIPTION
## Summary

Batch of fixes from mobile release QA, covering cloud-agent reconnect reliability and several mobile UI/auth issues.

### cloud-agent-sdk (shared WS layer)

- **Resume reconnects from a replay cursor** — track the last wire `eventId` and reconnect with `fromId` so the DO replays exactly the events missed while the socket was dead. Previously reconnects used `replay=false` and relied on a snapshot refetch, which lost events (truncated messages, stuck busy indicator after foregrounding) when the snapshot lagged. The snapshot refetch remains only as the no-cursor fallback.
- **Heal CLI session reconnect gaps** — CLI sessions have no server-side event log, so after reconnect we re-fetch the snapshot once more shortly after and forward the per-session idle/busy status from heartbeats so activity self-corrects instead of leaving a stuck busy indicator.
- **Subscribe the upgrade watcher** — the read-only→live upgrade watcher (#4390) retained the user-web socket but never subscribed to the session, so the upgrade trigger never arrived and sessions opened inside the heartbeat registration window stayed read-only forever.

### mobile

- **Reset org context and last-active instance on sign-out** — the organization provider mounts above the auth gate and never remounts, so the previous user's org id kept being sent after switching accounts, causing a 401/sign-out loop. Also clears the last-active-chat-instance key and its module cache.
- **Stop native text selection competing with long-press copy** — message markdown is now non-selectable so the iOS native copy callout no longer spawns on top of the copy action sheet; tool-card outputs stay selectable.
- **Reserve subagent running-tool line** to avoid layout shift.
- **Drop default cloud-agent platform filter** on the agents list.
- **Keep the Copy Link sign-in label on one line** on Android.

## Test plan

- Existing cloud-agent-sdk transport/session-routing tests updated and passing (`cloud-agent-transport.test.ts`, `session-routing.test.ts`)
- Manual QA on device: reconnect after backgrounding (cloud-agent + CLI sessions), account switching, long-press copy, agents list filtering