### PR TITLE
Fix(kiloclaw) gh auth hosts persistence

### DIFF
--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-07-06',
+    description:
+      "Fixed GitHub access for KiloClaw agents. Even with a GitHub token configured, the agent could not use the gh CLI or git, because the credential was never written to the agent's GitHub credential store and recent OpenClaw versions no longer pass the token through to the agent's shell. KiloClaw now saves the credential to the instance during setup, so gh and git authenticate correctly. Redeploy your instance to pick up the fix.",
+    category: 'bugfix',
+    deployHint: 'redeploy_required',
+  },
+  {
     date: '2026-07-01',
     description: 'OpenClaw 2026.6.11 is available now as an Early Access upgrade.',
     category: 'feature',

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -53,6 +53,18 @@ function encryptValue(keyBase64: string, plaintext: string): string {
 
 // ---- Fake deps ----
 
+/**
+ * Optional hook to make the fake `execFileSync` throw for specific calls.
+ * Returning an Error simulates a non-zero exit (e.g. gh refusing to persist
+ * credentials while a token env var is present); returning null/undefined
+ * lets the call succeed.
+ */
+type FakeExecBehavior = (
+  cmd: string,
+  args: string[],
+  opts?: { input?: string; env?: NodeJS.ProcessEnv }
+) => Error | null | undefined;
+
 function fakeDeps(): {
   deps: BootstrapDeps;
   mkdirCalls: string[];
@@ -60,18 +72,22 @@ function fakeDeps(): {
   chdirCalls: string[];
   copyCalls: { src: string; dest: string }[];
   execCalls: { cmd: string; args: string[]; input?: string }[];
+  execEnvCalls: { cmd: string; args: string[]; env?: NodeJS.ProcessEnv }[];
   writeCalls: { path: string; data: string }[];
   renameCalls: { from: string; to: string }[];
   setConfigExists: (v: boolean) => void;
+  setExecBehavior: (fn: FakeExecBehavior | null) => void;
 } {
   const mkdirCalls: string[] = [];
   const chmodCalls: { path: string; mode: number }[] = [];
   const chdirCalls: string[] = [];
   const copyCalls: { src: string; dest: string }[] = [];
   const execCalls: { cmd: string; args: string[]; input?: string }[] = [];
+  const execEnvCalls: { cmd: string; args: string[]; env?: NodeJS.ProcessEnv }[] = [];
   const writeCalls: { path: string; data: string }[] = [];
   const renameCalls: { from: string; to: string }[] = [];
   let configExists = false;
+  let execBehavior: FakeExecBehavior | null = null;
 
   return {
     deps: {
@@ -104,20 +120,29 @@ function fakeDeps(): {
       unlinkSync: vi.fn(),
       readdirSync: vi.fn(() => [] as string[]),
       statSync: vi.fn(() => ({ isDirectory: () => false })),
-      execFileSync: vi.fn((cmd: string, args: string[], opts?: { input?: string }) => {
-        execCalls.push({ cmd, args, input: opts?.input });
-        return '';
-      }),
+      execFileSync: vi.fn(
+        (cmd: string, args: string[], opts?: { input?: string; env?: NodeJS.ProcessEnv }) => {
+          execCalls.push({ cmd, args, input: opts?.input });
+          execEnvCalls.push({ cmd, args, env: opts?.env });
+          const err = execBehavior?.(cmd, args, opts);
+          if (err) throw err;
+          return '';
+        }
+      ),
     },
     mkdirCalls,
     chmodCalls,
     chdirCalls,
     copyCalls,
     execCalls,
+    execEnvCalls,
     writeCalls,
     renameCalls,
     setConfigExists(v: boolean) {
       configExists = v;
+    },
+    setExecBehavior(fn: FakeExecBehavior | null) {
+      execBehavior = fn;
     },
   };
 }
@@ -518,6 +543,77 @@ describe('configureGitHub', () => {
       args: ['auth', 'setup-git'],
       input: undefined,
     });
+  });
+
+  it('runs gh with GH_TOKEN/GITHUB_TOKEN stripped so credentials persist to disk', () => {
+    // Regression guard for the env-conflict bug: `gh` refuses to write
+    // ~/.config/gh/hosts.yml while a token env var is present, and OpenClaw
+    // strips those vars from the agent's exec env — so the persisted store is
+    // the agent's only path to auth. Model gh's real refusal: throw when the
+    // login call still sees GH_TOKEN/GITHUB_TOKEN in its child env.
+    const { deps, execEnvCalls, setExecBehavior } = fakeDeps();
+    setExecBehavior((cmd, args, opts) => {
+      if (
+        cmd === 'gh' &&
+        args.includes('login') &&
+        (opts?.env?.GITHUB_TOKEN || opts?.env?.GH_TOKEN)
+      ) {
+        return new Error(
+          'The value of the GITHUB_TOKEN environment variable is being used for authentication.'
+        );
+      }
+      return null;
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const env: Record<string, string | undefined> = {
+      GITHUB_TOKEN: 'ghp_token123',
+      GH_TOKEN: 'ghp_token123',
+      PATH: '/usr/bin',
+    };
+
+    configureGitHub(env, deps);
+
+    const ghLogin = execEnvCalls.find(c => c.cmd === 'gh' && c.args.includes('login'));
+    const ghSetupGit = execEnvCalls.find(c => c.cmd === 'gh' && c.args.includes('setup-git'));
+
+    // Both gh bootstrap calls run with the token vars removed from the child env...
+    expect(ghLogin).toBeDefined();
+    expect(ghLogin?.env?.GITHUB_TOKEN).toBeUndefined();
+    expect(ghLogin?.env?.GH_TOKEN).toBeUndefined();
+    expect(ghSetupGit?.env?.GITHUB_TOKEN).toBeUndefined();
+    expect(ghSetupGit?.env?.GH_TOKEN).toBeUndefined();
+    // ...but ordinary env is still inherited so gh can resolve its binary/config.
+    expect(ghLogin?.env?.PATH).toBe('/usr/bin');
+    // The token is still delivered to gh via stdin, not the environment.
+    expect(ghLogin && 'env' in ghLogin).toBe(true);
+    // With the tokens stripped, gh no longer refuses → no failure warning.
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('surfaces gh stderr on failure with the token scrubbed', () => {
+    const { deps, setExecBehavior } = fakeDeps();
+    setExecBehavior((cmd, args) => {
+      if (cmd === 'gh' && args.includes('login')) {
+        const err = new Error('Command failed') as Error & { stderr?: string };
+        err.stderr = 'error: token ghp_token123 is invalid or expired';
+        return err;
+      }
+      return null;
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    configureGitHub({ GITHUB_TOKEN: 'ghp_token123' }, deps);
+
+    const logged = warnSpy.mock.calls.map(call => call.join(' ')).join('\n');
+    expect(logged).toContain('gh auth login failed');
+    expect(logged).toContain('is invalid or expired'); // diagnostic surfaced
+    expect(logged).not.toContain('ghp_token123'); // secret scrubbed
+
+    warnSpy.mockRestore();
   });
 
   it('sets git user.name and user.email when provided', () => {

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -585,8 +585,6 @@ describe('configureGitHub', () => {
     expect(ghSetupGit?.env?.GH_TOKEN).toBeUndefined();
     // ...but ordinary env is still inherited so gh can resolve its binary/config.
     expect(ghLogin?.env?.PATH).toBe('/usr/bin');
-    // The token is still delivered to gh via stdin, not the environment.
-    expect(ghLogin && 'env' in ghLogin).toBe(true);
     // With the tokens stripped, gh no longer refuses → no failure warning.
     expect(warnSpy).not.toHaveBeenCalled();
 

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -621,8 +621,8 @@ describe('configureGitHub', () => {
     warnSpy.mockRestore();
   });
 
-  it('surfaces gh stderr on failure with the token scrubbed', () => {
-    const { deps, setExecBehavior } = fakeDeps();
+  it('surfaces gh stderr on failure with the token scrubbed and skips setup-git', () => {
+    const { deps, execCalls, setExecBehavior } = fakeDeps();
     setExecBehavior((cmd, args) => {
       if (cmd === 'gh' && args.includes('login')) {
         const err = new Error('Command failed') as Error & { stderr?: string };
@@ -640,6 +640,10 @@ describe('configureGitHub', () => {
     expect(logged).toContain('gh auth login failed');
     expect(logged).toContain('is invalid or expired'); // diagnostic surfaced
     expect(logged).not.toContain('ghp_token123'); // secret scrubbed
+    // When login fails, setup-git must NOT run — otherwise a second,
+    // differently-labeled warning would surface for the same root cause.
+    expect(execCalls.some(c => c.cmd === 'gh' && c.args.includes('setup-git'))).toBe(false);
+    expect(logged).not.toContain('setup-git failed');
 
     warnSpy.mockRestore();
   });

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -591,6 +591,36 @@ describe('configureGitHub', () => {
     warnSpy.mockRestore();
   });
 
+  it('reports setup-git failure distinctly and still logs login success', () => {
+    // Guards against the shared-try regression: if `gh auth login` succeeds
+    // (hosts.yml written) but `gh auth setup-git` fails, gh still works — the
+    // failure must not be mislabeled "gh auth login failed" and the login
+    // success log must still be emitted.
+    const { deps, setExecBehavior } = fakeDeps();
+    setExecBehavior((cmd, args) => {
+      if (cmd === 'gh' && args.includes('setup-git')) {
+        const err = new Error('Command failed') as Error & { stderr?: string };
+        err.stderr = 'git: command not found';
+        return err;
+      }
+      return null;
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    configureGitHub({ GITHUB_TOKEN: 'ghp_token123' }, deps);
+
+    const logged = logSpy.mock.calls.map(call => call.join(' ')).join('\n');
+    const warned = warnSpy.mock.calls.map(call => call.join(' ')).join('\n');
+    expect(logged).toContain('gh CLI authenticated'); // login success still reported
+    expect(warned).toContain('gh auth setup-git failed'); // accurate, named failure
+    expect(warned).not.toContain('gh auth login failed'); // not mislabeled
+
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
   it('surfaces gh stderr on failure with the token scrubbed', () => {
     const { deps, setExecBehavior } = fakeDeps();
     setExecBehavior((cmd, args) => {

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -667,13 +667,24 @@ export function configureGitHub(env: EnvLike, deps: BootstrapDeps = defaultDeps)
         stdio: 'pipe',
         env: ghEnv,
       });
-      deps.execFileSync('gh', ['auth', 'setup-git'], { stdio: 'pipe', env: ghEnv });
       console.log('gh CLI authenticated');
     } catch (err) {
       // gh's stderr on the env-conflict path carries no secret, but scrub the
       // token defensively in case a future gh error echoes the supplied value.
       console.warn(
         `WARNING: gh auth login failed: ${describeExecFailure(err, [env.GITHUB_TOKEN, env.GH_TOKEN])}`
+      );
+    }
+
+    // Separate try/catch: `gh auth login` already wrote hosts.yml, so if
+    // setup-git fails (e.g. git missing from PATH, or a credential-helper
+    // conflict) `gh` still works. Report it as its own failure rather than
+    // mislabeling it a login failure or discarding the login-success log.
+    try {
+      deps.execFileSync('gh', ['auth', 'setup-git'], { stdio: 'pipe', env: ghEnv });
+    } catch (err) {
+      console.warn(
+        `WARNING: gh auth setup-git failed: ${describeExecFailure(err, [env.GITHUB_TOKEN, env.GH_TOKEN])}`
       );
     }
 

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -612,6 +612,35 @@ export function ensureWeatherSkillInstalled(
 // ---- Step 5: GitHub config ----
 
 /**
+ * Extract a human-readable, secret-scrubbed message from an execFileSync
+ * failure. `execFileSync` errors expose the child's stderr (string when the
+ * dep is configured with an encoding, Buffer otherwise); fall back to the
+ * error message. Any provided secret values are redacted before returning so
+ * the message is safe to log.
+ */
+function describeExecFailure(err: unknown, secrets: Array<string | undefined>): string {
+  let message = '';
+  if (err && typeof err === 'object') {
+    const e = err as { stderr?: unknown; message?: unknown };
+    if (typeof e.stderr === 'string') {
+      message = e.stderr;
+    } else if (Buffer.isBuffer(e.stderr)) {
+      message = e.stderr.toString('utf8');
+    }
+    if (!message.trim() && typeof e.message === 'string') {
+      message = e.message;
+    }
+  }
+  message = message.trim() || 'unknown error';
+  for (const secret of secrets) {
+    if (secret) {
+      message = message.split(secret).join('***');
+    }
+  }
+  return message;
+}
+
+/**
  * Configure or clean up GitHub access (gh CLI + git user config).
  * Best-effort: logs warnings on failure, does not throw.
  */
@@ -619,15 +648,33 @@ export function configureGitHub(env: EnvLike, deps: BootstrapDeps = defaultDeps)
   if (env.GITHUB_TOKEN) {
     console.log('Configuring GitHub access...');
 
+    // `gh` refuses to persist credentials to ~/.config/gh/hosts.yml while
+    // GH_TOKEN/GITHUB_TOKEN is set in its environment — it authenticates from
+    // the env token directly and never writes the credential store. OpenClaw
+    // strips those vars from the agent's tool-exec environment (host-env
+    // security policy), so the agent can ONLY authenticate from the persisted
+    // store. Run the bootstrap `gh` calls with the tokens removed from the
+    // child env so credentials land on disk (on the persistent /root volume)
+    // and survive that stripping. `gh auth setup-git` then wires git's
+    // credential helper to gh, covering both `gh` and `git`.
+    const ghEnv: NodeJS.ProcessEnv = { ...env };
+    delete ghEnv.GITHUB_TOKEN;
+    delete ghEnv.GH_TOKEN;
+
     try {
       deps.execFileSync('gh', ['auth', 'login', '--with-token'], {
         input: env.GITHUB_TOKEN,
         stdio: 'pipe',
+        env: ghEnv,
       });
-      deps.execFileSync('gh', ['auth', 'setup-git'], { stdio: 'pipe' });
+      deps.execFileSync('gh', ['auth', 'setup-git'], { stdio: 'pipe', env: ghEnv });
       console.log('gh CLI authenticated');
-    } catch {
-      console.warn('WARNING: gh auth login failed');
+    } catch (err) {
+      // gh's stderr on the env-conflict path carries no secret, but scrub the
+      // token defensively in case a future gh error echoes the supplied value.
+      console.warn(
+        `WARNING: gh auth login failed: ${describeExecFailure(err, [env.GITHUB_TOKEN, env.GH_TOKEN])}`
+      );
     }
 
     if (env.GITHUB_USERNAME) {

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -664,12 +664,14 @@ export function configureGitHub(env: EnvLike, deps: BootstrapDeps = defaultDeps)
     delete ghEnv.GITHUB_TOKEN;
     delete ghEnv.GH_TOKEN;
 
+    let loginSucceeded = false;
     try {
       deps.execFileSync('gh', ['auth', 'login', '--with-token'], {
         input: env.GITHUB_TOKEN,
         stdio: 'pipe',
         env: ghEnv,
       });
+      loginSucceeded = true;
       console.log('gh CLI authenticated');
     } catch (err) {
       // gh's stderr on the env-conflict path carries no secret, but scrub the
@@ -679,16 +681,20 @@ export function configureGitHub(env: EnvLike, deps: BootstrapDeps = defaultDeps)
       );
     }
 
-    // Separate try/catch: `gh auth login` already wrote hosts.yml, so if
-    // setup-git fails (e.g. git missing from PATH, or a credential-helper
-    // conflict) `gh` still works. Report it as its own failure rather than
-    // mislabeling it a login failure or discarding the login-success log.
-    try {
-      deps.execFileSync('gh', ['auth', 'setup-git'], { stdio: 'pipe', env: ghEnv });
-    } catch (err) {
-      console.warn(
-        `WARNING: gh auth setup-git failed: ${describeExecFailure(err, [env.GITHUB_TOKEN, env.GH_TOKEN])}`
-      );
+    // Only wire git's credential helper once login actually stored a
+    // credential. Separate try/catch so a setup-git failure (git missing from
+    // PATH, credential-helper conflict) after a successful login is reported as
+    // its own distinct failure — not mislabeled a login failure and not
+    // discarding the login-success log. Skipped entirely when login failed, so
+    // a single root-cause warning is emitted instead of two for one problem.
+    if (loginSucceeded) {
+      try {
+        deps.execFileSync('gh', ['auth', 'setup-git'], { stdio: 'pipe', env: ghEnv });
+      } catch (err) {
+        console.warn(
+          `WARNING: gh auth setup-git failed: ${describeExecFailure(err, [env.GITHUB_TOKEN, env.GH_TOKEN])}`
+        );
+      }
     }
 
     if (env.GITHUB_USERNAME) {

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -657,7 +657,10 @@ export function configureGitHub(env: EnvLike, deps: BootstrapDeps = defaultDeps)
     // child env so credentials land on disk (on the persistent /root volume)
     // and survive that stripping. `gh auth setup-git` then wires git's
     // credential helper to gh, covering both `gh` and `git`.
-    const ghEnv: NodeJS.ProcessEnv = { ...env };
+    // Cast: the worker tsconfig augments NodeJS.ProcessEnv with required
+    // provider fields (NF_*) that a spread of `env` doesn't carry at the type
+    // level; at runtime `env` is process.env, which has whatever is set.
+    const ghEnv = { ...env } as NodeJS.ProcessEnv;
     delete ghEnv.GITHUB_TOKEN;
     delete ghEnv.GH_TOKEN;
 

--- a/services/kiloclaw/scripts/tests/smoke-live-provider.sh
+++ b/services/kiloclaw/scripts/tests/smoke-live-provider.sh
@@ -42,6 +42,15 @@ Options:
 Optional version assertions:
   EXPECTED_VERSION_AFTER   Expected OpenClaw version for the candidate/final image.
   EXPECTED_VERSION_BEFORE  Expected OpenClaw version for --upgrade baseline image.
+
+Optional GitHub gh-auth persistence check (assert_github_gh_auth):
+  GITHUB_SMOKE_TOKEN       Disposable GitHub PAT. When set, the smoke boots with
+                           GitHub configured and asserts gh auth still works with
+                           GITHUB_TOKEN/GH_TOKEN stripped from the exec env
+                           (i.e. from the persisted credential store, matching
+                           how the agent actually runs). Skipped when unset.
+  GITHUB_SMOKE_USERNAME    GitHub username (default: kilo-smoke).
+  GITHUB_SMOKE_EMAIL       GitHub email (default: kilo-smoke@example.com).
 EOF
 }
 
@@ -120,6 +129,12 @@ start_container() {
   )
   if [ -n "${KILOCODE_ORGANIZATION_ID:-}" ]; then
     docker_env+=(-e KILOCODE_ORGANIZATION_ID)
+  fi
+  # Optional GitHub credential for the gh-auth persistence check (assert_github_gh_auth).
+  if [ -n "${GITHUB_SMOKE_TOKEN:-}" ]; then
+    docker_env+=(-e GITHUB_TOKEN="$GITHUB_SMOKE_TOKEN")
+    docker_env+=(-e GITHUB_USERNAME="${GITHUB_SMOKE_USERNAME:-kilo-smoke}")
+    docker_env+=(-e GITHUB_EMAIL="${GITHUB_SMOKE_EMAIL:-kilo-smoke@example.com}")
   fi
   CID=$(docker run -d --rm \
     -p "127.0.0.1:${PORT}:18789" \
@@ -396,6 +411,38 @@ else:
   check "kilocode native vision capability (post-#4054-revert)" "image-capable" "$result"
 }
 
+# Verifies the agent can still use GitHub after bootstrap even though OpenClaw
+# strips GITHUB_TOKEN/GH_TOKEN from the agent's tool-exec environment
+# (host-env-security policy). The controller must persist credentials to gh's
+# on-disk store (~/.config/gh/hosts.yml on the /root volume); if it relied only
+# on the inherited env var, `gh`/`git` would be unauthenticated in the agent's
+# stripped shell — the exact regression that silently broke live instances.
+#
+# Gated on GITHUB_SMOKE_TOKEN (a disposable PAT + matching username/email) since
+# it needs a real GitHub credential to complete `gh auth login`.
+assert_github_gh_auth() {
+  if [ -z "${GITHUB_SMOKE_TOKEN:-}" ]; then
+    echo "SKIP: GitHub gh-auth check (set GITHUB_SMOKE_TOKEN to enable)"
+    return 0
+  fi
+
+  # 1) Bootstrap must have written gh's credential store to the volume.
+  if docker exec "$CID" sh -c '[ -f /root/.config/gh/hosts.yml ]'; then
+    check "gh credentials persisted to hosts.yml" "1" "1"
+  else
+    check "gh credentials persisted to hosts.yml" "1" "0"
+  fi
+
+  # 2) The decisive check: gh must authenticate with the token vars stripped
+  #    from the environment — reproducing the agent's real exec context. This
+  #    fails if the controller never persisted creds (env-conflict regression).
+  if docker exec "$CID" env -u GITHUB_TOKEN -u GH_TOKEN gh auth status >/dev/null 2>&1; then
+    check "gh auth status ok with token env stripped" "1" "1"
+  else
+    check "gh auth status ok with token env stripped" "1" "0"
+  fi
+}
+
 run_phase() {
   local label="$1"
   local image="$2"
@@ -429,6 +476,7 @@ run_phase() {
     assert_kilocode_vision_capability
   fi
   assert_exec_approvals_seeded "$CID"
+  assert_github_gh_auth
   echo
   echo "--- live Auto Free agent turn ---"
   assert_live_agent_turn


### PR DESCRIPTION
## Summary

The controller configured the agent's GitHub access by running `gh auth login --with-token` with `GITHUB_TOKEN`/`GH_TOKEN` inherited from `process.env`. `gh` refuses to write its credential store (`~/.config/gh/hosts.yml`) while those variables are set, so credentials were never persisted. OpenClaw now removes those variables from the agent's tool execution environment, so the agent had neither an environment token nor a stored credential, and both `gh` and `git` were left unauthenticated.

This runs the controller's `gh` bootstrap calls with the two variables removed from the child environment so credentials persist to disk and keep working after the stripping.

Changes:

- `configureGitHub` builds a copy of the environment with `GITHUB_TOKEN`/`GH_TOKEN` deleted and passes it to `gh auth login` and `gh auth setup-git`. The token is still delivered to `gh` over stdin. Other variables are preserved and the gateway/agent environment is not modified.
- The two `gh` calls are split into separate `try`/`catch` blocks. `setup-git` runs only after a successful login, so a login failure reports a single root cause, and a `setup-git` failure after a successful login is reported on its own rather than labeled a login failure. The login success log is preserved in that case.
- New `describeExecFailure` helper logs the failing command's stderr with any token value removed, replacing the previous bare `gh auth login failed` warning.
- `bootstrap.test.ts`: the fake `execFileSync` now records the child environment and supports a hook that simulates `gh` throwing when a token variable is present. Added tests for the stripped environment, the `setup-git`-only failure, and the login failure path (which asserts `setup-git` is skipped and the token is absent from the logged message).
- `smoke-live-provider.sh`: added `assert_github_gh_auth`, gated on `GITHUB_SMOKE_TOKEN`. When set, the smoke boots with GitHub configured and asserts `hosts.yml` exists and `gh auth status` succeeds with `GITHUB_TOKEN`/`GH_TOKEN` removed from the environment. Skipped when unset.

## Verification

Built the image locally, ran a KiloClaw instance in Docker, and configured it with a test GitHub user.

- [x] Controller log shows `Configuring GitHub access...` then `gh CLI authenticated`
- [x] `/root/.config/gh/hosts.yml` is present after boot
- [x] `gh auth status` and `gh api user` succeed with `GITHUB_TOKEN` and `GH_TOKEN` removed from the environment (returns the configured account)
- [x] `git` credential helper is set to `!/usr/bin/gh auth git-credential`, so `git` authenticates from the stored credential

## Visual Changes

N/A

## Reviewer Notes

- Scope is `configureGitHub` in the controller plus its tests, and the smoke script. The GitHub phase is best effort and still cannot abort bootstrap.
- The environment strip applies only to the controller's own `gh` calls. The gateway and agent environment are unchanged, so anything that reads `GITHUB_TOKEN` directly still sees it.
- `ghEnv` is annotated with `as NodeJS.ProcessEnv` because the worker tsconfig augments `ProcessEnv` with required `NF_*` fields that a plain spread does not carry at the type level. At runtime the value is `process.env`, which has those fields.
- Existing instances that already had a working `hosts.yml` are unaffected. New instances get one written at boot.
