### PR TITLE
feat(config-schema): mirror experimental swe_pruner keys from CLI config

### DIFF
--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -117,5 +117,15 @@ export const kiloExtras = {
       default: true,
       type: 'boolean',
     },
+    swe_pruner: {
+      description:
+        'Enable SWE-Pruner: task-aware pruning of large read/grep tool outputs guided by a focus question provided by the agent (default: false)',
+      type: 'boolean',
+    },
+    swe_pruner_model: {
+      description:
+        'Model used by SWE-Pruner to skim tool outputs, in "provider/model" format (default: the configured small model)',
+      type: 'string',
+    },
   },
 } as const;

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -121,6 +121,8 @@ describe('kilo config.json schema merge', () => {
       expect.objectContaining({ type: 'boolean' })
     );
     expect(exp.properties.openTelemetry).toBeDefined();
+    expect(exp.properties.swe_pruner).toEqual(expect.objectContaining({ type: 'boolean' }));
+    expect(exp.properties.swe_pruner_model).toEqual(expect.objectContaining({ type: 'string' }));
     expect(exp.properties.batch_tool).toBeDefined(); // upstream key preserved
   });
 


### PR DESCRIPTION
## Summary

Mirrors two new experimental CLI config keys in the config JSON Schema overlay, per the sync convention documented at the top of `apps/web/src/app/config.json/extras.ts`:

- `experimental.swe_pruner` (boolean) — enables SWE-Pruner, task-aware pruning of large read/grep tool outputs
- `experimental.swe_pruner_model` (string) — optional `provider/model` override for the skimming model

Both keys are added in Kilo-Org/kilocode#11980 (marked `kilocode_change` in `packages/opencode/src/config/config.ts`). Without this mirror, users with `$schema: https://app.kilo.ai/config.json` get "unknown property" warnings when setting these keys. Descriptions are copied verbatim from the zod schema, and the matching assertions were added to `apps/web/src/tests/cli-config-schema.test.ts` (step 4 of the documented procedure).

## Verification

- [ ] No manual testing performed: the change is two schema literal entries plus two test assertions following the exact pattern of the adjacent `codebase_search` / `native_notebook_tools` entries. The local environment lacks Node >=24 required by this repo's engines field, so `pnpm test` / `pnpm format` could not be run locally — relying on CI for the jest suite and format check. The edits copy the existing file style (quotes, indentation, trailing commas) so oxfmt should be a no-op.

## Visual Changes

N/A

## Reviewer Notes

Companion to Kilo-Org/kilocode#11980 — best merged once that PR lands (the keys are harmless in the schema overlay before then; the CLI simply ignores unknown experimental keys). Note that `sandbox` / `sandbox_restrict_network` / `speech_to_text_model` from the same `kilocode_change` experimental block are currently absent from this overlay too; left untouched here to keep this PR scoped, but may be worth a follow-up sweep.
