### PR TITLE
CloudAgent - Remove SessionModelNotice

### DIFF
--- a/apps/mobile/src/components/agents/model-selector.tsx
+++ b/apps/mobile/src/components/agents/model-selector.tsx
@@ -1,16 +1,7 @@
 /* eslint-disable max-lines -- The selector and picker row share model disclosure behavior. */
 import * as Haptics from 'expo-haptics';
 import { type Href, useRouter } from 'expo-router';
-import {
-  AlertTriangle,
-  BookOpenCheck,
-  Brain,
-  Check,
-  ChevronDown,
-  Info,
-  RefreshCw,
-  Star,
-} from 'lucide-react-native';
+import { BookOpenCheck, Brain, Check, ChevronDown, Star } from 'lucide-react-native';
 import { createContext, type ReactNode, useContext, useMemo } from 'react';
 import { Pressable, ScrollView, View } from 'react-native';
 
@@ -25,10 +16,7 @@ import {
   mayTrainOnYourPrompts,
 } from '@/lib/free-model-data-disclosure';
 import { type ModelOption, thinkingEffortLabel } from '@/lib/hooks/use-available-models';
-import {
-  type SessionModelNotice,
-  type SessionModelOption,
-} from '@/lib/hooks/use-session-model-options';
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import {
   type ModelPickerSelection,
@@ -341,45 +329,6 @@ export function ModelPickerOptionRow({
           </ScrollView>
         </View>
       ) : null}
-    </View>
-  );
-}
-
-export function SessionModelNotices({
-  notices,
-  onRetry,
-}: Readonly<{ notices: SessionModelNotice[]; onRetry: () => void }>) {
-  const colors = useThemeColors();
-  if (notices.length === 0) {
-    return null;
-  }
-
-  return (
-    <View className="gap-1 border-t border-warn-tile-border bg-warn-tile-bg px-3 py-2">
-      {notices.map(notice => {
-        const Icon =
-          notice.id === 'legacy' || notice.id === 'local-provider' ? Info : AlertTriangle;
-        return (
-          <View key={notice.id} className="flex-row items-start gap-2">
-            <Icon size={14} color={colors.warn} />
-            <Text selectable className="flex-1 text-xs leading-4 text-foreground">
-              {notice.message}
-            </Text>
-            {notice.retry ? (
-              <Pressable
-                onPress={onRetry}
-                hitSlop={12}
-                accessibilityRole="button"
-                accessibilityLabel="Retry loading CLI models"
-                className="flex-row items-center gap-1 rounded-full bg-secondary px-2 py-1 active:opacity-70"
-              >
-                <RefreshCw size={12} color={colors.foreground} />
-                <Text className="text-xs font-medium text-foreground">Retry</Text>
-              </Pressable>
-            ) : null}
-          </View>
-        );
-      })}
     </View>
   );
 }

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -9,10 +9,7 @@ import { toast } from 'sonner-native';
 import { ChatComposer } from '@/components/agents/chat-composer';
 import { ConnectivityBanner } from '@/components/agents/connectivity-banner';
 import { MessageBubble } from '@/components/agents/message-bubble';
-import {
-  ModelPickerSelectionScopeProvider,
-  SessionModelNotices,
-} from '@/components/agents/model-selector';
+import { ModelPickerSelectionScopeProvider } from '@/components/agents/model-selector';
 import { PermissionCard } from '@/components/agents/permission-card';
 import { QuestionCard } from '@/components/agents/question-card';
 import { getSessionKeyboardContainerKind } from '@/components/agents/session-keyboard-container-state';
@@ -375,12 +372,6 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
             </View>
           ) : (
             <>
-              <SessionModelNotices
-                notices={sessionModels.notices}
-                onRetry={() => {
-                  manager.retryRemoteModels();
-                }}
-              />
               <ModelPickerSelectionScopeProvider
                 selectionScope={modelPickerSelectionScope}
                 isSelectionCurrent={isModelPickerSelectionCurrent}

--- a/apps/mobile/src/lib/hooks/use-session-model-options.ts
+++ b/apps/mobile/src/lib/hooks/use-session-model-options.ts
@@ -17,12 +17,6 @@ type SessionModelSource =
   | 'remote-legacy-gateway'
   | 'remote-unavailable';
 
-export type SessionModelNotice = {
-  id: 'loading' | 'legacy' | 'error' | 'stale' | 'truncated' | 'unavailable' | 'local-provider';
-  message: string;
-  retry: boolean;
-};
-
 export type SessionModelOption = {
   id: string;
   name: string;
@@ -56,7 +50,6 @@ type SessionModelOptions = {
   selectedVariant: string;
   pickerDisabled: boolean;
   isLoading: boolean;
-  notices: SessionModelNotice[];
 };
 
 export function useSessionModelOptions({
@@ -111,7 +104,6 @@ export function buildSessionModelOptions(
     selectedVariant: '',
     pickerDisabled: false,
     isLoading: input.gatewayModelsLoading,
-    notices: [],
   };
 }
 
@@ -129,26 +121,6 @@ function buildUnavailableRemoteOptions(input: BuildSessionModelOptionsInput): Se
         unavailable: true,
       } satisfies SessionModelOption);
   const loading = input.remoteModelState.refresh === 'loading';
-  const notices: SessionModelNotice[] = [
-    loading
-      ? {
-          id: 'loading',
-          message: 'Checking this CLI for available models.',
-          retry: true,
-        }
-      : {
-          id: 'error',
-          message: "Models from this CLI couldn't be loaded. Sending still uses the session model.",
-          retry: true,
-        },
-  ];
-  if (currentSelection) {
-    notices.push({
-      id: 'unavailable',
-      message: `${currentSelection.model.modelID} is the session model. It can't be changed until this CLI's models load.`,
-      retry: false,
-    });
-  }
 
   return {
     source: 'remote-unavailable',
@@ -157,7 +129,6 @@ function buildUnavailableRemoteOptions(input: BuildSessionModelOptionsInput): Se
     selectedVariant: currentSelection?.variant ?? '',
     pickerDisabled: true,
     isLoading: loading,
-    notices,
   };
 }
 
@@ -199,12 +170,10 @@ function buildLegacyGatewayOptions(input: BuildSessionModelOptionsInput): Sessio
         option => option.modelRef && modelRefsEqual(option.modelRef, currentSelection.model)
       )
     : undefined;
-  const notices: SessionModelNotice[] = [];
 
   if (currentSelection && !selectedOption) {
     selectedOption = createUnavailableOption(currentSelection.model);
     options.unshift(selectedOption);
-    notices.push(createUnavailableNotice(currentSelection.model));
   }
 
   const selectedVariant =
@@ -219,7 +188,6 @@ function buildLegacyGatewayOptions(input: BuildSessionModelOptionsInput): Sessio
     selectedVariant,
     pickerDisabled: input.gatewayModelsLoading,
     isLoading: input.gatewayModelsLoading,
-    notices,
   };
 }
 
@@ -256,35 +224,10 @@ function buildCliCatalogOptions(input: BuildSessionModelOptionsInput): SessionMo
         option => option.modelRef && modelRefsEqual(option.modelRef, currentSelection.model)
       )
     : undefined;
-  const notices: SessionModelNotice[] = [];
 
   if (currentSelection && !selectedOption) {
     selectedOption = createUnavailableOption(currentSelection.model);
     options.unshift(selectedOption);
-    notices.push(createUnavailableNotice(currentSelection.model));
-  }
-  if (input.remoteModelState.refresh === 'error') {
-    notices.unshift({
-      id: 'stale',
-      message: 'Showing the last model catalog because refresh failed.',
-      retry: true,
-    });
-  }
-  if (catalog.truncated) {
-    notices.push({
-      id: 'truncated',
-      message: 'This CLI returned a partial model catalog. Some models or variants may be missing.',
-      retry: false,
-    });
-  }
-  if (currentSelection && currentSelection.model.providerID !== 'kilo') {
-    notices.push({
-      id: 'local-provider',
-      message: input.organizationId
-        ? "This model runs through your CLI provider, outside Kilo Gateway billing and this organization's model restrictions."
-        : 'This model runs through your CLI provider, outside Kilo Gateway billing.',
-      retry: false,
-    });
   }
 
   const selectedVariant =
@@ -299,7 +242,6 @@ function buildCliCatalogOptions(input: BuildSessionModelOptionsInput): SessionMo
     selectedVariant,
     pickerDisabled: false,
     isLoading: false,
-    notices,
   };
 }
 
@@ -314,14 +256,6 @@ function createUnavailableOption(modelRef: ModelRef): SessionModelOption {
     modelRef,
     showGatewayMetadata: false,
     unavailable: true,
-  };
-}
-
-function createUnavailableNotice(modelRef: ModelRef): SessionModelNotice {
-  return {
-    id: 'unavailable',
-    message: `${modelRef.modelID} is the session model but is not available in this catalog.`,
-    retry: false,
   };
 }
 

--- a/apps/mobile/src/lib/hooks/use-session-model-options.ts
+++ b/apps/mobile/src/lib/hooks/use-session-model-options.ts
@@ -199,14 +199,7 @@ function buildLegacyGatewayOptions(input: BuildSessionModelOptionsInput): Sessio
         option => option.modelRef && modelRefsEqual(option.modelRef, currentSelection.model)
       )
     : undefined;
-  const notices: SessionModelNotice[] = [
-    {
-      id: 'legacy',
-      message:
-        'This CLI uses Gateway model fallback. Upgrade Kilo CLI to use its configured providers and models.',
-      retry: false,
-    },
-  ];
+  const notices: SessionModelNotice[] = [];
 
   if (currentSelection && !selectedOption) {
     selectedOption = createUnavailableOption(currentSelection.model);

--- a/apps/mobile/src/lib/use-session-model-options.test.ts
+++ b/apps/mobile/src/lib/use-session-model-options.test.ts
@@ -338,7 +338,6 @@ describe('buildSessionModelOptions', () => {
     });
     expect(result.selectedValue).toBe(unavailableOption?.id);
     expect(result.selectedVariant).toBe('');
-    expect(result.notices.map(notice => notice.id)).toEqual(['legacy', 'unavailable']);
   });
 
   it('does not project a removed legacy Gateway override as the selected model', () => {
@@ -393,10 +392,9 @@ describe('buildSessionModelOptions', () => {
     ]);
     expect(result.options.some(option => option.id === gatewayModels[0]?.id)).toBe(false);
     expect(result.pickerDisabled).toBe(true);
-    expect(result.notices).toEqual([expect.objectContaining({ id: 'error', retry: true })]);
   });
 
-  it('retains a stale v1 catalog with truncation and local-provider notices', () => {
+  it('retains a stale v1 catalog with truncation and local-provider selection', () => {
     const result = buildSessionModelOptions({
       activeSessionType: 'remote',
       remoteModelState: {
@@ -438,12 +436,6 @@ describe('buildSessionModelOptions', () => {
 
     const cliOption = result.options.find(option => option.overrideSource === 'cli-catalog');
 
-    expect(result.notices.map(notice => notice.id)).toEqual([
-      'stale',
-      'truncated',
-      'local-provider',
-    ]);
-    expect(result.notices[2]?.message).toContain("organization's model restrictions");
     expect(createRemoteModelOverride(cliOption, 'removed')).toEqual({
       source: 'cli-catalog',
       selection: { model: { providerID: 'local-provider', modelID: 'private-model' } },

--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -5,7 +5,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { useSearchParams } from 'next/navigation';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
-import { ArrowDown, GitBranch, Info, RefreshCw } from 'lucide-react';
+import { ArrowDown, GitBranch } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { KiloSessionId } from '@/lib/cloud-agent-sdk';
@@ -41,7 +41,6 @@ import {
   createRemoteModelOverride,
   useSessionModels,
   validateRemoteModelOverride,
-  type SessionModelNotice,
 } from './hooks/useSessionModels';
 import { ContextUsageIndicator } from './ContextUsageIndicator';
 import { resolveContextWindow } from './model-context-lengths';
@@ -146,41 +145,6 @@ const emptyQuestionRequestIds = new Map<string, string>();
 type CloudChatPageProps = { organizationId?: string };
 
 type TerminalStatusSummary = { status: TerminalStatus; statusText: string };
-
-function SessionModelNotices({
-  notices,
-  onRetry,
-}: {
-  notices: SessionModelNotice[];
-  onRetry: () => void;
-}) {
-  if (notices.length === 0) return null;
-
-  return (
-    <div className="space-y-1.5 px-[max(1rem,calc(50%_-_27rem))] pt-2">
-      {notices.map(notice => (
-        <div
-          key={notice.id}
-          role="status"
-          className="border-border bg-muted/40 text-muted-foreground flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-xs"
-        >
-          <Info className="size-3.5 shrink-0" />
-          <span className="min-w-0 flex-1">{notice.message}</span>
-          {notice.retry && (
-            <button
-              type="button"
-              onClick={onRetry}
-              className="text-foreground hover:bg-accent focus-visible:ring-ring inline-flex h-6 shrink-0 items-center gap-1 rounded-md px-2 font-medium focus-visible:ring-2 focus-visible:outline-none"
-            >
-              <RefreshCw className="size-3" />
-              Retry
-            </button>
-          )}
-        </div>
-      ))}
-    </div>
-  );
-}
 
 function TerminalPaneSlot({
   terminalId,
@@ -515,10 +479,6 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
 
   const handleStopExecution = useCallback(() => {
     void manager.interrupt();
-  }, [manager]);
-
-  const handleRetryRemoteModels = useCallback(() => {
-    manager.retryRemoteModels();
   }, [manager]);
 
   const handleToggleSound = useCallback(() => {
@@ -908,10 +868,6 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                               </div>
                             )}
                             <div className={activeQuestion || activePermission ? 'hidden' : ''}>
-                              <SessionModelNotices
-                                notices={sessionModels.notices}
-                                onRetry={handleRetryRemoteModels}
-                              />
                               <ChatInput
                                 onSend={handleSendMessage}
                                 onSendCommand={handleSendSlashCommand}

--- a/apps/web/src/components/cloud-agent-next/hooks/useSessionModels.test.ts
+++ b/apps/web/src/components/cloud-agent-next/hooks/useSessionModels.test.ts
@@ -72,7 +72,6 @@ describe('buildSessionModels', () => {
     expect(result.selectedVariant).toBe('high');
     expect(result.availableVariants).toEqual(['none', 'high']);
     expect(result.modelPickerDisabled).toBe(false);
-    expect(result.notices).toEqual([]);
     expect(result.gatewayOrganizationId).toBe('org-persisted');
   });
 
@@ -355,7 +354,6 @@ describe('buildSessionModels', () => {
 
     expect(result.source).toBe('remote-legacy-gateway');
     expect(result.gatewayOrganizationId).toBe('org-from-fetched-session');
-    expect(result.notices.map(notice => notice.id)).toEqual(['legacy']);
     expect(gatewayOption).toMatchObject({
       id: 'anthropic/claude-sonnet-4',
       modelRef: { providerID: 'kilo', modelID: 'anthropic/claude-sonnet-4' },
@@ -404,7 +402,6 @@ describe('buildSessionModels', () => {
     expect(result.modelOptions.some(option => option.id === gatewayModels[0].id)).toBe(false);
     expect(result.selectedValue).toBe(result.modelOptions[0].id);
     expect(result.modelPickerDisabled).toBe(true);
-    expect(result.notices).toEqual([expect.objectContaining({ id: 'error', retry: true })]);
   });
 
   it('keeps a stale v1 catalog with truncation and local-provider disclosure', () => {
@@ -450,12 +447,6 @@ describe('buildSessionModels', () => {
     const cliOption = result.modelOptions.find(option => option.overrideSource === 'cli-catalog');
 
     expect(result.source).toBe('remote-cli-catalog');
-    expect(result.notices.map(notice => notice.id)).toEqual([
-      'stale',
-      'truncated',
-      'local-provider',
-    ]);
-    expect(result.notices[2].message).toContain("organization's model restrictions");
     expect(createRemoteModelOverride(cliOption, 'removed-variant')).toEqual({
       source: 'cli-catalog',
       selection: {

--- a/apps/web/src/components/cloud-agent-next/hooks/useSessionModels.ts
+++ b/apps/web/src/components/cloud-agent-next/hooks/useSessionModels.ts
@@ -26,12 +26,6 @@ type SessionModelSource =
   | 'remote-legacy-gateway'
   | 'remote-unavailable';
 
-type SessionModelNotice = {
-  id: 'loading' | 'legacy' | 'error' | 'stale' | 'truncated' | 'local-provider';
-  message: string;
-  retry: boolean;
-};
-
 type SessionModelOption = ModelOption & {
   displayId?: string;
   providerGroup?: { id: string; label: string };
@@ -72,7 +66,6 @@ type SessionModels = {
   availableVariants: string[];
   modelPickerDisabled: boolean;
   isLoadingModels: boolean;
-  notices: SessionModelNotice[];
   gatewayOrganizationId?: string;
 };
 
@@ -185,7 +178,6 @@ export function buildSessionModels(input: BuildSessionModelsInput): SessionModel
     availableVariants: selectedOption?.variants ?? [],
     modelPickerDisabled: false,
     isLoadingModels: input.gatewayModelsLoading,
-    notices: [],
     gatewayOrganizationId: input.gatewayOrganizationId,
   };
 }
@@ -210,20 +202,6 @@ function buildUnavailableRemoteModels(input: BuildSessionModelsInput): SessionMo
     availableVariants: [],
     modelPickerDisabled: true,
     isLoadingModels: loading,
-    notices: [
-      loading
-        ? {
-            id: 'loading',
-            message: 'Checking this CLI for available models.',
-            retry: true,
-          }
-        : {
-            id: 'error',
-            message:
-              "Models from this CLI couldn't be loaded. Sending still uses the session model.",
-            retry: true,
-          },
-    ],
     gatewayOrganizationId: input.gatewayOrganizationId,
   };
 }
@@ -260,7 +238,6 @@ function buildLegacyGatewayModels(input: BuildSessionModelsInput): SessionModels
     availableVariants: selectedOption?.variants ?? [],
     modelPickerDisabled: input.gatewayModelsLoading,
     isLoadingModels: input.gatewayModelsLoading,
-    notices: [],
     gatewayOrganizationId: input.gatewayOrganizationId,
   };
 }
@@ -315,30 +292,6 @@ function buildCliCatalogModels(input: BuildSessionModelsInput): SessionModels {
     currentSelection?.variant && selectedOption?.variants?.includes(currentSelection.variant)
       ? currentSelection.variant
       : undefined;
-  const notices: SessionModelNotice[] = [];
-  if (input.remoteModelState.refresh === 'error') {
-    notices.push({
-      id: 'stale',
-      message: 'Showing the last model catalog because refresh failed.',
-      retry: true,
-    });
-  }
-  if (catalog.truncated) {
-    notices.push({
-      id: 'truncated',
-      message: 'This CLI returned a partial model catalog. Some models or variants may be missing.',
-      retry: false,
-    });
-  }
-  if (currentSelection && currentSelection.model.providerID !== 'kilo') {
-    notices.push({
-      id: 'local-provider',
-      message: input.gatewayOrganizationId
-        ? "This model runs through your CLI provider, outside Kilo Gateway billing and this organization's model restrictions."
-        : 'This model runs through your CLI provider, outside Kilo Gateway billing.',
-      retry: false,
-    });
-  }
 
   return {
     source: 'remote-cli-catalog',
@@ -348,7 +301,6 @@ function buildCliCatalogModels(input: BuildSessionModelsInput): SessionModels {
     availableVariants: selectedOption?.variants ?? [],
     modelPickerDisabled: false,
     isLoadingModels: false,
-    notices,
     gatewayOrganizationId: input.gatewayOrganizationId,
   };
 }
@@ -419,7 +371,6 @@ export function createRemoteModelOverride(
 
 export type {
   BuildSessionModelsInput,
-  SessionModelNotice,
   SessionModelOption,
   SessionModels,
   UseSessionModelsInput,

--- a/apps/web/src/components/cloud-agent-next/hooks/useSessionModels.ts
+++ b/apps/web/src/components/cloud-agent-next/hooks/useSessionModels.ts
@@ -260,14 +260,7 @@ function buildLegacyGatewayModels(input: BuildSessionModelsInput): SessionModels
     availableVariants: selectedOption?.variants ?? [],
     modelPickerDisabled: input.gatewayModelsLoading,
     isLoadingModels: input.gatewayModelsLoading,
-    notices: [
-      {
-        id: 'legacy',
-        message:
-          'This CLI uses Gateway model fallback. Upgrade Kilo CLI to use its configured providers and models.',
-        retry: false,
-      },
-    ],
+    notices: [],
     gatewayOrganizationId: input.gatewayOrganizationId,
   };
 }


### PR DESCRIPTION
## Summary

Remove the `SessionModelNotice` type and `SessionModelNotices` UI from both web and mobile Cloud Agent session model flows, along with the `notices` field produced by `useSessionModels` and `useSessionModelOptions`.

## Verification

- `pnpm format`
- `pnpm --filter web typecheck`
- `pnpm --filter kilo-app typecheck`
- `pnpm --filter web lint`
- `pnpm --filter kilo-app lint`
- `pnpm --filter web test -- useSessionModels.test.ts`
- `pnpm --filter kilo-app test -- apps/mobile/src/lib/use-session-model-options.test.ts`

## Visual Changes

N/A

## Reviewer Notes

N/A