### PR TITLE
fix(webhooks): heal pr_state from closed to open on synchronize after missed reopen

### DIFF
--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.test.ts
@@ -644,6 +644,76 @@ describe('upsertCliSessionPullRequestsFromWebhook', () => {
     expect(rows[0].pr_head_sha).toBe('sha-203-reopen');
   });
 
+  it('heals pr_state from closed -> open on synchronize when the reopened webhook was missed', async () => {
+    const branch = 'feature/missed-reopen-then-sync';
+    await seedSession({ branch, owner: testOwner });
+
+    // PR gets closed.
+    await upsertCliSessionPullRequestsFromWebhook(
+      makePayload({
+        action: 'closed',
+        prNumber: 210,
+        state: 'closed',
+        merged: false,
+        headRef: branch,
+        headSha: 'sha-210',
+      }),
+      testOwner
+    );
+
+    // The `reopened` webhook for this PR is never delivered (missed/deduped),
+    // but new commits are pushed to the now-actually-open PR, so GitHub
+    // delivers a `synchronize` event carrying a new head sha and the PR's
+    // real current state (open).
+    await upsertCliSessionPullRequestsFromWebhook(
+      makePayload({
+        action: 'synchronize',
+        prNumber: 210,
+        state: 'open',
+        headRef: branch,
+        headSha: 'sha-210-new-commit',
+      }),
+      testOwner
+    );
+
+    const rows = await readUserRow({ userId: testUserId, branch });
+    expect(rows[0].pr_state).toBe('open');
+    expect(rows[0].pr_head_sha).toBe('sha-210-new-commit');
+  });
+
+  it('does not heal pr_state from closed -> open on a stale synchronize redelivery with the same head sha', async () => {
+    const branch = 'feature/stale-sync-same-sha';
+    await seedSession({ branch, owner: testOwner });
+
+    await upsertCliSessionPullRequestsFromWebhook(
+      makePayload({
+        action: 'closed',
+        prNumber: 211,
+        state: 'closed',
+        merged: false,
+        headRef: branch,
+        headSha: 'sha-211',
+      }),
+      testOwner
+    );
+
+    // A redelivered/duplicate `synchronize` event for the same commit is not
+    // evidence of a new push, so pr_state stays closed.
+    await upsertCliSessionPullRequestsFromWebhook(
+      makePayload({
+        action: 'synchronize',
+        prNumber: 211,
+        state: 'open',
+        headRef: branch,
+        headSha: 'sha-211',
+      }),
+      testOwner
+    );
+
+    const rows = await readUserRow({ userId: testUserId, branch });
+    expect(rows[0].pr_state).toBe('closed');
+  });
+
   it('does not regress pr_state from merged -> closed on stale closed-unmerged redelivery', async () => {
     const branch = 'feature/monotonic-merged-closed';
     await seedSession({ branch, owner: testOwner });

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.ts
@@ -145,6 +145,19 @@ export async function upsertCliSessionPullRequestsFromWebhook(
     const state = derivePrState(pull_request, action);
 
     // Defense-in-depth against out-of-order webhook deliveries.
+    //
+    // `closed` must not be permanently sticky: if the `reopened` webhook that
+    // should have flipped it back to open is missed or deduplicated, a later
+    // `synchronize` delivery carrying a new head sha (i.e. new commits were
+    // actually pushed, which can only happen on a PR that is really open) is
+    // used to self-heal pr_state instead of trusting only the `reopened`
+    // action name. A `synchronize` redelivery with the *same* head sha is
+    // treated as a stale/duplicate event and does not heal the state.
+    const closedStaysStickyUnlessNewCommit =
+      action === GITHUB_ACTION.SYNCHRONIZE
+        ? sql`AND ${github_branch_pull_requests.pr_head_sha} = excluded.pr_head_sha`
+        : sql``;
+
     const prStateSet =
       action === GITHUB_ACTION.REOPENED
         ? sql`excluded.pr_state`
@@ -156,6 +169,7 @@ export async function upsertCliSessionPullRequestsFromWebhook(
             WHEN ${github_branch_pull_requests.pr_number} = excluded.pr_number
               AND ${github_branch_pull_requests.pr_state} = 'closed'
               AND excluded.pr_state IN ('open', 'draft')
+              ${closedStaysStickyUnlessNewCommit}
             THEN ${github_branch_pull_requests.pr_state}
             ELSE excluded.pr_state
           END`;


### PR DESCRIPTION
## Summary

Fixed `upsertCliSessionPullRequestsFromWebhook` (`apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.ts`), which upserts `github_branch_pull_requests.pr_state` from GitHub `pull_request` webhooks.

The monotonic guard treated `pr_state = 'closed'` as sticky/trapped, only allowing the exact `reopened` webhook `action` to flip it back to `open`. If that `reopened` delivery was missed, deduplicated, or failed to process, later events such as `synchronize` (new commits pushed) never updated `pr_state`, leaving the UI permanently stuck showing "closed" for a PR that was actually reopened and receiving commits (e.g. github.com/Kilo-Org/cloud/pull/4316).

The fix relaxes the sticky-closed guard specifically for `synchronize` deliveries: a `synchronize` event carrying a **new** `pr_head_sha` is proof that a real commit was just pushed, which can only happen on a genuinely open PR — so it now heals `pr_state` from `closed` back to `open`/`draft` even without an explicit `reopened` action. A `synchronize` redelivery with the **same** `pr_head_sha` is still treated as a stale/duplicate event and does not heal the state, preserving the existing out-of-order-delivery protections (verified by existing tests for `merged`/`closed` staleness).

`merged` remains fully sticky/terminal regardless of action or head sha, since GitHub's own state machine never allows a merged PR to become open again.

## Verification

- Traced the updated SQL `CASE` logic against every existing out-of-order/staleness test in `upsert-cli-session-pull-requests.test.ts` to confirm none regress (`closed` stays sticky for `opened`/`converted_to_draft` actions and for `synchronize` redeliveries with an unchanged head sha; `merged` stays sticky in all cases).
- Added two new tests: one reproducing the reported bug (`closed` → missed `reopened` → `synchronize` with a new head sha → `pr_state` heals to `open`), and one guarding against over-correction (`closed` → `synchronize` redelivery with the *same* head sha → `pr_state` stays `closed`).
- Could not run the Jest suite in this sandbox (no Docker/Postgres available to satisfy `pnpm test:db`); please run `pnpm test -- apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.test.ts` in CI/locally to confirm.

## Visual Changes

N/A

## Reviewer Notes

The only behavior change is scoped to the `synchronize` action's SQL `CASE` branch for the `closed` (unmerged) state; `reopened` handling and all `merged`-state stickiness are untouched. Worth double-checking that `synchronize` webhooks reliably carry the pushed-to head sha (they do, per GitHub's payload schema) since that's the signal now used to distinguish "real new commit" from "stale redelivery."

Built for [Evgeny Shurakov](https://kilo-code.slack.com/archives/C09M96CFZQX/p1783419520653779?thread_ts=1783417630.550879&cid=C09M96CFZQX) by [Kilo for Slack](https://kilo.ai/slack)
