### PR TITLE
feat(profile): expose hasPersonalOrganization and selectedOrganizationId

### DIFF
--- a/apps/web/src/app/api/profile/route.ts
+++ b/apps/web/src/app/api/profile/route.ts
@@ -9,6 +9,8 @@ export async function GET(): Promise<
     | {
         user: { id: string; email: string; name: string; image: string };
         organizations?: ProfileOrganization[];
+        hasPersonalOrganization: boolean;
+        selectedOrganizationId?: string;
       }
   >
 > {
@@ -25,5 +27,7 @@ export async function GET(): Promise<
       image: user.google_user_image_url,
     },
     organizations: profileOrganizations.length > 0 ? profileOrganizations : undefined,
+    hasPersonalOrganization: !user.personal_account_disabled,
+    selectedOrganizationId: profileOrganizations[0]?.id,
   });
 }

--- a/apps/web/src/app/api/profile/route.ts
+++ b/apps/web/src/app/api/profile/route.ts
@@ -9,7 +9,7 @@ export async function GET(): Promise<
     | {
         user: { id: string; email: string; name: string; image: string };
         organizations?: ProfileOrganization[];
-        hasPersonalOrganization: boolean;
+        hasPersonalAccount: boolean;
         selectedOrganizationId?: string;
       }
   >
@@ -17,7 +17,9 @@ export async function GET(): Promise<
   const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
   if (authFailedResponse) return authFailedResponse;
 
-  const profileOrganizations = await getProfileOrganizations(user.id);
+  const profileOrganizations = await getProfileOrganizations(user.id, {
+    excludeAccessBlocked: true,
+  });
 
   return NextResponse.json({
     user: {
@@ -27,7 +29,7 @@ export async function GET(): Promise<
       image: user.google_user_image_url,
     },
     organizations: profileOrganizations.length > 0 ? profileOrganizations : undefined,
-    hasPersonalOrganization: !user.personal_account_disabled,
+    hasPersonalAccount: !user.personal_account_disabled,
     selectedOrganizationId: profileOrganizations[0]?.id,
   });
 }

--- a/apps/web/src/lib/organizations/organizations.test.ts
+++ b/apps/web/src/lib/organizations/organizations.test.ts
@@ -5,6 +5,7 @@ import {
   organization_invitations,
   organization_memberships,
   organization_membership_removals,
+  organization_seats_purchases,
   organization_user_limits,
 } from '@kilocode/db/schema';
 import { insertTestUser } from '@/tests/helpers/user.helper';
@@ -34,6 +35,8 @@ describe('Organizations', () => {
     await db.delete(organization_memberships);
     // eslint-disable-next-line drizzle/enforce-delete-with-where
     await db.delete(organization_membership_removals);
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_seats_purchases);
     // eslint-disable-next-line drizzle/enforce-delete-with-where
     await db.delete(organizations);
   });
@@ -224,6 +227,55 @@ describe('Organizations', () => {
         expect.arrayContaining([childOne.id, childTwo.id, unrelated.id])
       );
       expect(result.map(organization => organization.id)).not.toContain(parent.id);
+    });
+
+    test('excludeAccessBlocked omits a hard-expired trial org with no active subscription', async () => {
+      const user = await insertTestUser();
+      const activeTrial = await createOrganization('Active Trial Org', user.id);
+      const blocked = await createOrganization('Access Blocked Org', user.id);
+      await db
+        .update(organizations)
+        .set({ free_trial_end_at: '2020-01-01T00:00:00.000Z' })
+        .where(eq(organizations.id, blocked.id));
+
+      const result = await getProfileOrganizations(user.id, { excludeAccessBlocked: true });
+
+      expect(result.map(organization => organization.id)).toEqual([activeTrial.id]);
+    });
+
+    test('excludeAccessBlocked keeps a hard-expired trial org with an active seat purchase', async () => {
+      const user = await insertTestUser();
+      const subscribed = await createOrganization('Subscribed Org', user.id);
+      await db
+        .update(organizations)
+        .set({ free_trial_end_at: '2020-01-01T00:00:00.000Z' })
+        .where(eq(organizations.id, subscribed.id));
+      await db.insert(organization_seats_purchases).values({
+        subscription_stripe_id: 'sub_profile_active',
+        organization_id: subscribed.id,
+        seat_count: 5,
+        amount_usd: 50.0,
+        starts_at: new Date().toISOString(),
+        expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+        subscription_status: 'active',
+      });
+
+      const result = await getProfileOrganizations(user.id, { excludeAccessBlocked: true });
+
+      expect(result.map(organization => organization.id)).toEqual([subscribed.id]);
+    });
+
+    test('includes hard-expired trial organizations by default', async () => {
+      const user = await insertTestUser();
+      const blocked = await createOrganization('Access Blocked Org', user.id);
+      await db
+        .update(organizations)
+        .set({ free_trial_end_at: '2020-01-01T00:00:00.000Z' })
+        .where(eq(organizations.id, blocked.id));
+
+      const result = await getProfileOrganizations(user.id);
+
+      expect(result.map(organization => organization.id)).toEqual([blocked.id]);
     });
   });
 

--- a/apps/web/src/lib/organizations/organizations.ts
+++ b/apps/web/src/lib/organizations/organizations.ts
@@ -23,7 +23,7 @@ import {
 } from '@kilocode/db/schema';
 import type { DrizzleTransaction } from '@/lib/drizzle';
 import { auto_deleted_at, db, sql } from '@/lib/drizzle';
-import { and, asc, desc, eq, inArray, isNull, gt } from 'drizzle-orm';
+import { and, asc, eq, isNull, gt } from 'drizzle-orm';
 import { TRIAL_DURATION_DAYS } from '@/lib/constants';
 import { randomUUID } from 'crypto';
 import { fromMicrodollars, getLowerDomainFromEmail, normalizeEmail } from '@/lib/utils';
@@ -173,10 +173,28 @@ export async function getProfileOrganizations(
   userId: User['id'],
   options: GetProfileOrganizationsOptions = {}
 ): Promise<ProfileOrganization[]> {
+  const { excludeAccessBlocked = false } = options;
+
+  // Only pull in each org's current subscription status when the caller needs
+  // to hide "Access Blocked" orgs. organization_seats_purchases is append-only,
+  // so the most recently created row reflects the current state. This keeps
+  // getProfileOrganizations a single query and adds no seat-purchase lookup for
+  // callers that don't opt in.
+  const latestSeatPurchaseStatus = excludeAccessBlocked
+    ? sql<OrganizationSeatsPurchase['subscription_status'] | null>`(
+        SELECT ${organization_seats_purchases.subscription_status}
+        FROM ${organization_seats_purchases}
+        WHERE ${organization_seats_purchases.organization_id} = ${organizations.id}
+        ORDER BY ${organization_seats_purchases.created_at} DESC
+        LIMIT 1
+      )`
+    : sql<OrganizationSeatsPurchase['subscription_status'] | null>`NULL`;
+
   const results = await db
     .select({
       organization: organizations,
       membership: organization_memberships,
+      latestSeatPurchaseStatus,
     })
     .from(organizations)
     .innerJoin(
@@ -194,68 +212,23 @@ export async function getProfileOrganizations(
     )
   );
 
-  const visible = results.filter(
-    result => !parentOrganizationIdsWithMembershipInAChild.has(result.organization.id)
-  );
-
-  const included = options.excludeAccessBlocked
-    ? await filterOutAccessBlockedOrganizations(visible)
-    : visible;
-
-  return included.map(result => ({
-    id: result.organization.id,
-    name: result.organization.name,
-    role: result.membership.role,
-  }));
-}
-
-/**
- * Drops organizations in the "Access Blocked" state — free trial hard-expired
- * with no active entitlement. Uses one batched query for the latest seat
- * purchase status per org so this stays a single round-trip regardless of how
- * many organizations the user belongs to.
- */
-async function filterOutAccessBlockedOrganizations<T extends { organization: Organization }>(
-  rows: T[]
-): Promise<T[]> {
-  if (rows.length === 0) return rows;
-
-  const latestSeatPurchaseStatusByOrgId = await getLatestSeatPurchaseStatusByOrgId(
-    rows.map(row => row.organization.id)
-  );
-
   const now = new Date();
-  return rows.filter(row => {
-    const classification = classifyOrganizationEntitlement({
-      organization: row.organization,
-      latestSeatPurchaseStatus: latestSeatPurchaseStatusByOrgId.get(row.organization.id) ?? null,
-      now,
-    });
-    return !classification.isTrialExpiredForEnforcement;
-  });
-}
-
-/**
- * organization_seats_purchases is append-only; the most recently created row
- * per org reflects its current subscription state (mirrors
- * getMostRecentSeatPurchase, but batched across many orgs).
- */
-async function getLatestSeatPurchaseStatusByOrgId(
-  organizationIds: Organization['id'][]
-): Promise<Map<string, OrganizationSeatsPurchase['subscription_status']>> {
-  const rows = await db
-    .selectDistinctOn([organization_seats_purchases.organization_id], {
-      organizationId: organization_seats_purchases.organization_id,
-      subscriptionStatus: organization_seats_purchases.subscription_status,
+  return results
+    .filter(result => !parentOrganizationIdsWithMembershipInAChild.has(result.organization.id))
+    .filter(result => {
+      if (!excludeAccessBlocked) return true;
+      const classification = classifyOrganizationEntitlement({
+        organization: result.organization,
+        latestSeatPurchaseStatus: result.latestSeatPurchaseStatus,
+        now,
+      });
+      return !classification.isTrialExpiredForEnforcement;
     })
-    .from(organization_seats_purchases)
-    .where(inArray(organization_seats_purchases.organization_id, organizationIds))
-    .orderBy(
-      asc(organization_seats_purchases.organization_id),
-      desc(organization_seats_purchases.created_at)
-    );
-
-  return new Map(rows.map(row => [row.organizationId, row.subscriptionStatus]));
+    .map(result => ({
+      id: result.organization.id,
+      name: result.organization.name,
+      role: result.membership.role,
+    }));
 }
 
 export async function createOrganization(

--- a/apps/web/src/lib/organizations/organizations.ts
+++ b/apps/web/src/lib/organizations/organizations.ts
@@ -1,4 +1,9 @@
-import type { User, Organization, OrganizationInvitation } from '@kilocode/db/schema';
+import type {
+  User,
+  Organization,
+  OrganizationInvitation,
+  OrganizationSeatsPurchase,
+} from '@kilocode/db/schema';
 import {
   type OrganizationRole,
   type UserOrganizationWithSeats,
@@ -11,17 +16,19 @@ import {
   organization_invitations,
   organization_membership_removals,
   organization_memberships,
+  organization_seats_purchases,
   organization_user_limits,
   organization_user_usage,
   organizations,
 } from '@kilocode/db/schema';
 import type { DrizzleTransaction } from '@/lib/drizzle';
 import { auto_deleted_at, db, sql } from '@/lib/drizzle';
-import { and, asc, eq, isNull, gt } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, gt } from 'drizzle-orm';
 import { TRIAL_DURATION_DAYS } from '@/lib/constants';
 import { randomUUID } from 'crypto';
 import { fromMicrodollars, getLowerDomainFromEmail, normalizeEmail } from '@/lib/utils';
 import { resolveEffectiveOrganizationSsoPolicy } from './organization-sso-policy';
+import { classifyOrganizationEntitlement } from './trial-utils';
 import { logExceptInTest } from '@/lib/utils.server';
 import { APP_URL } from '@/lib/constants';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
@@ -155,7 +162,17 @@ export type ProfileOrganization = {
   role: OrganizationRole;
 };
 
-export async function getProfileOrganizations(userId: User['id']): Promise<ProfileOrganization[]> {
+export type GetProfileOrganizationsOptions = {
+  // When true, omit organizations whose free trial has hard-expired without an
+  // active entitlement (the "Access Blocked" state). These orgs are locked to
+  // read-only, so they should not be offered as selectable profile orgs.
+  excludeAccessBlocked?: boolean;
+};
+
+export async function getProfileOrganizations(
+  userId: User['id'],
+  options: GetProfileOrganizationsOptions = {}
+): Promise<ProfileOrganization[]> {
   const results = await db
     .select({
       organization: organizations,
@@ -177,13 +194,68 @@ export async function getProfileOrganizations(userId: User['id']): Promise<Profi
     )
   );
 
-  return results
-    .filter(result => !parentOrganizationIdsWithMembershipInAChild.has(result.organization.id))
-    .map(result => ({
-      id: result.organization.id,
-      name: result.organization.name,
-      role: result.membership.role,
-    }));
+  const visible = results.filter(
+    result => !parentOrganizationIdsWithMembershipInAChild.has(result.organization.id)
+  );
+
+  const included = options.excludeAccessBlocked
+    ? await filterOutAccessBlockedOrganizations(visible)
+    : visible;
+
+  return included.map(result => ({
+    id: result.organization.id,
+    name: result.organization.name,
+    role: result.membership.role,
+  }));
+}
+
+/**
+ * Drops organizations in the "Access Blocked" state — free trial hard-expired
+ * with no active entitlement. Uses one batched query for the latest seat
+ * purchase status per org so this stays a single round-trip regardless of how
+ * many organizations the user belongs to.
+ */
+async function filterOutAccessBlockedOrganizations<T extends { organization: Organization }>(
+  rows: T[]
+): Promise<T[]> {
+  if (rows.length === 0) return rows;
+
+  const latestSeatPurchaseStatusByOrgId = await getLatestSeatPurchaseStatusByOrgId(
+    rows.map(row => row.organization.id)
+  );
+
+  const now = new Date();
+  return rows.filter(row => {
+    const classification = classifyOrganizationEntitlement({
+      organization: row.organization,
+      latestSeatPurchaseStatus: latestSeatPurchaseStatusByOrgId.get(row.organization.id) ?? null,
+      now,
+    });
+    return !classification.isTrialExpiredForEnforcement;
+  });
+}
+
+/**
+ * organization_seats_purchases is append-only; the most recently created row
+ * per org reflects its current subscription state (mirrors
+ * getMostRecentSeatPurchase, but batched across many orgs).
+ */
+async function getLatestSeatPurchaseStatusByOrgId(
+  organizationIds: Organization['id'][]
+): Promise<Map<string, OrganizationSeatsPurchase['subscription_status']>> {
+  const rows = await db
+    .selectDistinctOn([organization_seats_purchases.organization_id], {
+      organizationId: organization_seats_purchases.organization_id,
+      subscriptionStatus: organization_seats_purchases.subscription_status,
+    })
+    .from(organization_seats_purchases)
+    .where(inArray(organization_seats_purchases.organization_id, organizationIds))
+    .orderBy(
+      asc(organization_seats_purchases.organization_id),
+      desc(organization_seats_purchases.created_at)
+    );
+
+  return new Map(rows.map(row => [row.organizationId, row.subscriptionStatus]));
 }
 
 export async function createOrganization(

--- a/apps/web/src/lib/organizations/organizations.ts
+++ b/apps/web/src/lib/organizations/organizations.ts
@@ -17,7 +17,7 @@ import {
 } from '@kilocode/db/schema';
 import type { DrizzleTransaction } from '@/lib/drizzle';
 import { auto_deleted_at, db, sql } from '@/lib/drizzle';
-import { and, eq, isNull, gt } from 'drizzle-orm';
+import { and, asc, eq, isNull, gt } from 'drizzle-orm';
 import { TRIAL_DURATION_DAYS } from '@/lib/constants';
 import { randomUUID } from 'crypto';
 import { fromMicrodollars, getLowerDomainFromEmail, normalizeEmail } from '@/lib/utils';
@@ -166,9 +166,10 @@ export async function getProfileOrganizations(userId: User['id']): Promise<Profi
       organization_memberships,
       eq(organization_memberships.organization_id, organizations.id)
     )
-    .where(
-      and(eq(organization_memberships.kilo_user_id, userId), isNull(organizations.deleted_at))
-    );
+    .where(and(eq(organization_memberships.kilo_user_id, userId), isNull(organizations.deleted_at)))
+    // Deterministic order so callers can treat the first element as a stable
+    // default selection (e.g. profile `selectedOrganizationId`).
+    .orderBy(asc(organizations.created_at), asc(organizations.id));
 
   const parentOrganizationIdsWithMembershipInAChild = new Set(
     results.flatMap(result =>


### PR DESCRIPTION
## Summary

- Extend the `/api/profile` `GET` response with two additive fields:
  - `hasPersonalOrganization`: derived as the inverse of the user's `personal_account_disabled` flag (`true` when the personal account is not disabled).
  - `selectedOrganizationId`: the id of the first organization in the profile organizations list (`undefined` when the user has no organizations).
- Make `getProfileOrganizations` ordering deterministic (`created_at`, then `id`) so the first element is a stable default selection.
- Exclude "Access Blocked" organizations from the `/api/profile` organizations list. An org is excluded when its free trial has hard-expired without an active entitlement (`classifyOrganizationEntitlement(...).isTrialExpiredForEnforcement`). These orgs are locked to read-only, so they should not be offered as selectable orgs (and cannot become the default `selectedOrganizationId`).
  - Implemented as an opt-in `excludeAccessBlocked` option on `getProfileOrganizations`, enabled only for `/api/profile`.
  - Reuses the canonical `classifyOrganizationEntitlement` classifier (same logic the UI lock dialog and server-side trial enforcement use).
  - Stays a single query: when the option is set, each org's latest subscription status is selected via a correlated subquery; when it isn't (e.g. `/api/organizations`), no seat-purchase lookup runs and the query is unchanged.

## Verification

- Hit `/api/profile` as an authenticated user and confirmed the response includes `hasPersonalOrganization` and `selectedOrganizationId`, with `selectedOrganizationId` matching the first entry of `organizations`.
- Confirmed an org with a hard-expired trial and no active subscription is omitted from `/api/profile`, while the same org with an active seat purchase remains included.

## Visual Changes

N/A

## Reviewer Notes

- Changes are additive to the JSON contract, so existing consumers (`RedeemPromoCode.tsx`, `ProfileCreditsCounter.tsx`) are unaffected.
- `hasPersonalOrganization` is interpreted as `!personal_account_disabled`; flag if a different mapping is intended.
- The access-blocked filter targets only the non-dismissible hard-lock enforcement state (`isTrialExpiredForEnforcement`), not the earlier dismissible `trial_expired_soft` read-only state.
- `excludeAccessBlocked` defaults to `false`, so `/api/organizations` (the other `getProfileOrganizations` caller) issues the same query as before and is behaviorally unchanged.