### PR TITLE
docs(mobile): add e2e flow-testing guide for agents

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -20,6 +20,10 @@ Follow the official Expo guide to set up the development environment: https://do
 
 The dev server (`pnpm start`) is always started by the user — do not start it yourself.
 
+## E2E Flow Testing
+
+To verify a flow end-to-end (local backend + app on a simulator, driven via the Maestro MCP), see [e2e/AGENTS.md](e2e/AGENTS.md). It covers starting the local backend, running the Kilo CLI against it, and getting the Maestro MCP set up.
+
 ## Tmux Services
 
 The user typically has a `tmux` session running with all backend services and the Expo dev server in separate windows (e.g., `kilo-chat`, `kiloclaw`, `nextjs`, `postgres`, `redis`, etc.). When debugging mobile issues that touch the backend, inspect the relevant window's logs to confirm what the server actually received:

--- a/apps/mobile/e2e/AGENTS.md
+++ b/apps/mobile/e2e/AGENTS.md
@@ -66,7 +66,7 @@ KILO_API_URL=http://localhost:3000 \
 KILO_SESSION_INGEST_URL=http://localhost:8800 \
 KILO_AUTH_CONTENT='{"kilo":{"type":"api","key":"<token>"}}' \
 KILO_REMOTE=1 \
-./node_modules/.bin/kilo
+/tmp/kilo-cli/node_modules/.bin/kilo
 ```
 
 - `KILO_REMOTE=1` enables remote at startup; mid-session, toggle via the TUI palette (ctrl+p → "Toggle remote").

--- a/apps/mobile/e2e/AGENTS.md
+++ b/apps/mobile/e2e/AGENTS.md
@@ -80,11 +80,10 @@ The Maestro MCP drives the simulator (inspect screen, run YAML flows, screenshot
 **Setup** (once per machine):
 
 ```bash
-brew install maestro                      # or: curl -fsSL "https://get.maestro.mobile.dev" | bash
-claude mcp add maestro -- maestro mcp     # registers the MCP server for Claude Code
+brew install maestro   # or: curl -fsSL "https://get.maestro.mobile.dev" | bash
 ```
 
-Restart the Claude Code session after adding so the `mcp__maestro__*` tools appear.
+Then register the MCP server with your harness: stdio transport, command `maestro mcp` (e.g. `claude mcp add maestro -- maestro mcp` in Claude Code, or the equivalent MCP config entry in your harness). Restart the session after registering so the maestro tools appear.
 
 **Usage**: `list_devices` → pick the booted simulator's device id → `inspect_screen` before targeting any element → `run` with inline YAML. Flows declare `appId: com.kilocode.kiloapp` and start with `launchApp`. Use `cheat_sheet` for unfamiliar Maestro commands.
 

--- a/apps/mobile/e2e/AGENTS.md
+++ b/apps/mobile/e2e/AGENTS.md
@@ -10,14 +10,15 @@ All commands run from the **repo root** unless noted. Assumes a fresh checkout �
 pnpm dev:start --no-attach mobile cloud-agent-next kiloclaw
 ```
 
-- Starts everything in a tmux session named `kilo-dev-<dir>` (e.g. `kilo-dev-cloud`): Expo dev server (:8081), Next.js (:3000), Postgres (:5432), session-ingest (:8800), cloud-agent-next, kiloclaw (+ its tunnel and notifications). Dependencies start automatically.
+- Starts everything in a tmux session named `kilo-dev-<checkout-dir>`: Expo dev server (:8081), Next.js (:3000), Postgres (:5432), session-ingest (:8800), cloud-agent-next, kiloclaw (+ its tunnel and notifications). Dependencies start automatically.
 - `--no-attach` skips the interactive tmux dashboard — required for agents.
 - Verify with `pnpm dev:status`. Stop with `pnpm dev:stop`.
 - Read a service's logs from its tmux window:
 
 ```bash
-tmux list-windows -t kilo-dev-cloud
-tmux capture-pane -p -t kilo-dev-cloud:<window> -S -200
+tmux ls                                            # find the kilo-dev-* session
+tmux list-windows -t <session>
+tmux capture-pane -p -t <session>:<window> -S -200
 ```
 
 Before the first app launch, point the app at the local backend:
@@ -30,8 +31,8 @@ Restart the app (or reload from the Expo dev server) after this so Expo picks up
 
 ## 2. App on the simulator, signed in
 
-- The app is the dev-build `com.kilocode.kiloapp` on an iOS simulator. On Igor's machine the **"Kilo QA"** simulator already has it installed — `xcrun simctl list devices | grep "Kilo QA"`. If no simulator has the build, install one with `npx expo run:ios` from `apps/mobile/` (the `ios/` project is checked in).
-- Sign in with **fake-login**: the local sign-in page (reached via the app's normal sign-in flow) has a "Test Account" form — enter any email; appending `?fakeUser=<email>` to the sign-in URL auto-submits. The established QA account is `e2e-mobile@example.com`.
+- The app is the dev-build `com.kilocode.kiloapp` on an iOS simulator. Check booted simulators for it with `xcrun simctl listapps booted | grep kilocode`. If no simulator has the build, install one with `npx expo run:ios` from `apps/mobile/` (the `ios/` project is checked in).
+- Sign in with **fake-login**: the local sign-in page (reached via the app's normal sign-in flow) has a "Test Account" form — enter any email (an account is created on first login, e.g. `e2e-mobile@example.com`); appending `?fakeUser=<email>` to the sign-in URL auto-submits.
 - Seed data with `pnpm dev:seed` (topics in `dev/seed/`): `app:user-id <email>` to look up a user id, `app:add-credits <userId> <usd>` if completions return 402. Local Postgres is `postgres://postgres:postgres@localhost:5432/postgres`.
 
 ## 3. Kilo CLI against the local backend

--- a/apps/mobile/e2e/AGENTS.md
+++ b/apps/mobile/e2e/AGENTS.md
@@ -1,0 +1,95 @@
+# E2E Flow Testing (Maestro MCP)
+
+This folder documents how an agent tests Kilo App flows end-to-end: local backend + app on a simulator, driven via the Maestro MCP. There is no test suite here and none is planned — the point is interactive flow verification (e.g. "start a CLI session, confirm it shows up in the app, open it, send a message").
+
+All commands run from the **repo root** unless noted. Assumes a fresh checkout — complete the root [DEVELOPMENT.md](../../../DEVELOPMENT.md) setup first (Node via nvm, `pnpm install`, Docker Desktop, root `.env.local`, `pnpm dev:env`).
+
+## 1. Local backend
+
+```bash
+pnpm dev:start --no-attach mobile cloud-agent-next kiloclaw
+```
+
+- Starts everything in a tmux session named `kilo-dev-<dir>` (e.g. `kilo-dev-cloud`): Expo dev server (:8081), Next.js (:3000), Postgres (:5432), session-ingest (:8800), cloud-agent-next, kiloclaw (+ its tunnel and notifications). Dependencies start automatically.
+- `--no-attach` skips the interactive tmux dashboard — required for agents.
+- Verify with `pnpm dev:status`. Stop with `pnpm dev:stop`.
+- Read a service's logs from its tmux window:
+
+```bash
+tmux list-windows -t kilo-dev-cloud
+tmux capture-pane -p -t kilo-dev-cloud:<window> -S -200
+```
+
+Before the first app launch, point the app at the local backend:
+
+```bash
+pnpm dev:env:mobile   # writes apps/mobile/.env.local with LAN-IP URLs for all local services
+```
+
+Restart the app (or reload from the Expo dev server) after this so Expo picks up the env file.
+
+## 2. App on the simulator, signed in
+
+- The app is the dev-build `com.kilocode.kiloapp` on an iOS simulator. On Igor's machine the **"Kilo QA"** simulator already has it installed — `xcrun simctl list devices | grep "Kilo QA"`. If no simulator has the build, install one with `npx expo run:ios` from `apps/mobile/` (the `ios/` project is checked in).
+- Sign in with **fake-login**: the local sign-in page (reached via the app's normal sign-in flow) has a "Test Account" form — enter any email; appending `?fakeUser=<email>` to the sign-in URL auto-submits. The established QA account is `e2e-mobile@example.com`.
+- Seed data with `pnpm dev:seed` (topics in `dev/seed/`): `app:user-id <email>` to look up a user id, `app:add-credits <userId> <usd>` if completions return 402. Local Postgres is `postgres://postgres:postgres@localhost:5432/postgres`.
+
+## 3. Kilo CLI against the local backend
+
+Needed for flows involving remote CLI sessions (the session list, session mirroring, sending messages from the app).
+
+**Install** in a scratch directory — never touch the global CLI:
+
+```bash
+mkdir -p /tmp/kilo-cli && cd /tmp/kilo-cli && npm i @kilocode/cli
+```
+
+**Mint a token** for the SAME user the app is signed in as (otherwise the app won't see the session). It's an HS256 JWT signed with `NEXTAUTH_SECRET` from the root `.env.local` — no deps needed:
+
+```bash
+NEXTAUTH_SECRET=$(grep '^NEXTAUTH_SECRET=' .env.local | cut -d= -f2- | tr -d '"') \
+node -e '
+const crypto = require("crypto");
+const b64 = o => Buffer.from(JSON.stringify(o)).toString("base64url");
+const h = b64({ alg: "HS256", typ: "JWT" });
+const p = b64({ kiloUserId: process.argv[1], apiTokenPepper: null, version: 3 });
+const sig = crypto.createHmac("sha256", process.env.NEXTAUTH_SECRET).update(h + "." + p).digest("base64url");
+console.log(h + "." + p + "." + sig);
+' "<kiloUserId>"
+```
+
+**Run** the CLI pointed at local services:
+
+```bash
+KILO_API_URL=http://localhost:3000 \
+KILO_SESSION_INGEST_URL=http://localhost:8800 \
+KILO_AUTH_CONTENT='{"kilo":{"type":"api","key":"<token>"}}' \
+KILO_REMOTE=1 \
+./node_modules/.bin/kilo
+```
+
+- `KILO_REMOTE=1` enables remote at startup; mid-session, toggle via the TUI palette (ctrl+p → "Toggle remote").
+- A session appears in the app's active list only after WS connect + first heartbeat (~12s after enabling remote). Heartbeats are every ~10s.
+- Drive the TUI from tmux with `send-keys`; for slash commands the first Enter accepts autocomplete, the second submits.
+- Debugging: `KILO_DEBUG_SESSION_INGEST=1` logs ingest flushes. To observe what the app sees: WS to `ws://localhost:8800/api/user/web?token=<jwt>`, send `{"type":"subscribe","sessionId":...}`; full session snapshot at `GET http://localhost:8800/api/session/<id>/export`.
+
+## 4. Maestro MCP
+
+The Maestro MCP drives the simulator (inspect screen, run YAML flows, screenshots).
+
+**Setup** (once per machine):
+
+```bash
+brew install maestro                      # or: curl -fsSL "https://get.maestro.mobile.dev" | bash
+claude mcp add maestro -- maestro mcp     # registers the MCP server for Claude Code
+```
+
+Restart the Claude Code session after adding so the `mcp__maestro__*` tools appear.
+
+**Usage**: `list_devices` → pick the booted simulator's device id → `inspect_screen` before targeting any element → `run` with inline YAML. Flows declare `appId: com.kilocode.kiloapp` and start with `launchApp`. Use `cheat_sheet` for unfamiliar Maestro commands.
+
+Gotchas:
+
+- Cold relaunch (`simctl terminate` + `launch`, or `launchApp` with `clearState: false`) restores navigation state — the app reopens on the last screen. Navigate back explicitly before testing a flow that assumes a starting screen.
+- `simctl io recordVideo` is flaky (1-frame videos after first use). For capturing transitions, loop `simctl io screenshot` in the background (~7.5 fps) and assemble with ffmpeg.
+- Re-inspect the screen after every UI change; element ids/text from a stale inspect will miss.


### PR DESCRIPTION
Adds `apps/mobile/e2e/AGENTS.md` — instructions for agents to test app flows end-to-end (not a test suite):

1. Starting the local backend: `pnpm dev:start --no-attach mobile cloud-agent-next kiloclaw`, `dev:env:mobile`, tmux log inspection
2. Running the Kilo CLI against the local backend: scratch-dir install, token minting, env vars, remote-session gotchas
3. Setting up and using the Maestro MCP

`apps/mobile/AGENTS.md` now points agents at the new folder.