### PR TITLE
feat(session-ingest): push notification when a CLI session becomes controllable from the app

### DIFF
--- a/apps/mobile/e2e/AGENTS.md
+++ b/apps/mobile/e2e/AGENTS.md
@@ -7,10 +7,11 @@ All commands run from the **repo root** unless noted. Assumes a fresh checkout �
 ## 1. Local backend
 
 ```bash
-pnpm dev:start --no-attach mobile cloud-agent-next kiloclaw
+pnpm dev:start --no-attach mobile cloud-agent-next kiloclaw event-service
 ```
 
-- Starts everything in a tmux session named `kilo-dev-<checkout-dir>`: Expo dev server (:8081), Next.js (:3000), Postgres (:5432), session-ingest (:8800), cloud-agent-next, kiloclaw (+ its tunnel and notifications). Dependencies start automatically.
+- Starts everything in a tmux session named `kilo-dev-<checkout-dir>`: Expo dev server (:8081), Next.js (:3000), Postgres (:5432), session-ingest (:8800), cloud-agent-next, kiloclaw (+ its tunnel and notifications), event-service (:8809). Dependencies start automatically.
+- event-service tracks presence (which surfaces the user is actively on). The notifications worker queries it to suppress pushes when the user is in-context — e.g. the session-ready push is skipped while the app is foregrounded. Without it, presence lookups fail open: every push dispatches and the notifications logs fill with `Presence lookup failed` warnings, so presence-dependent flows can't be verified.
 - `--no-attach` skips the interactive tmux dashboard — required for agents.
 - Verify with `pnpm dev:status`. Stop with `pnpm dev:stop`.
 - Run DB migrations (`pnpm drizzle migrate` from the repo root) before testing. A local Postgres that's behind on migrations causes seemingly random 500s from the backend (e.g. every authenticated tRPC call failing with "column ... does not exist").

--- a/packages/notifications/src/rpc-schemas.ts
+++ b/packages/notifications/src/rpc-schemas.ts
@@ -156,6 +156,22 @@ export type SendCloudAgentSessionNotificationResult = z.infer<
   typeof sendCloudAgentSessionNotificationOutputSchema
 >;
 
+// ── sendSessionReadyNotification ────────────────────────────────────
+
+export const sendSessionReadyNotificationInputSchema = z.object({
+  userId: z.string().min(1),
+  cliSessionId: z.string().min(1),
+});
+export type SendSessionReadyNotificationParams = z.infer<
+  typeof sendSessionReadyNotificationInputSchema
+>;
+
+export const sendSessionReadyNotificationOutputSchema =
+  sendCloudAgentSessionNotificationOutputSchema;
+export type SendSessionReadyNotificationResult = z.infer<
+  typeof sendSessionReadyNotificationOutputSchema
+>;
+
 // ── dispatchPush (internal DO RPC) ──────────────────────────────────
 
 export const dispatchPushInputSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2787,6 +2787,9 @@ importers:
       '@kilocode/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@kilocode/notifications':
+        specifier: workspace:*
+        version: link:../../packages/notifications
       '@kilocode/session-ingest-contracts':
         specifier: workspace:*
         version: link:../../packages/session-ingest-contracts

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -17,6 +17,8 @@ import {
   type DispatchPushOutcome,
   type SendCloudAgentSessionNotificationParams,
   type SendCloudAgentSessionNotificationResult,
+  type SendSessionReadyNotificationParams,
+  type SendSessionReadyNotificationResult,
   type SendInstanceLifecycleNotificationParams,
   type SendInstanceLifecycleNotificationResult,
   type ListBadgesResponse,
@@ -27,7 +29,11 @@ import {
 } from '@kilocode/notifications';
 
 import { authMiddleware, type AuthContext } from './auth';
-import { dispatchCloudAgentSessionPush } from './lib/cloud-agent-session-push';
+import {
+  dispatchCloudAgentSessionPush,
+  dispatchSessionReadyPush,
+  type DispatchCloudAgentSessionPushDeps,
+} from './lib/cloud-agent-session-push';
 import type { TicketTokenPair } from './lib/expo-push';
 import { sendPushNotifications } from './lib/expo-push';
 import { dispatchInstanceLifecyclePush } from './lib/instance-lifecycle-push';
@@ -222,10 +228,20 @@ export class NotificationsService extends WorkerEntrypoint<Env> {
   async sendCloudAgentSessionNotification(
     params: SendCloudAgentSessionNotificationParams
   ): Promise<SendCloudAgentSessionNotificationResult> {
+    return dispatchCloudAgentSessionPush(params, this.cloudAgentSessionPushDeps());
+  }
+
+  async sendSessionReadyNotification(
+    params: SendSessionReadyNotificationParams
+  ): Promise<SendSessionReadyNotificationResult> {
+    return dispatchSessionReadyPush(params, this.cloudAgentSessionPushDeps());
+  }
+
+  private cloudAgentSessionPushDeps(): DispatchCloudAgentSessionPushDeps {
     let db: ReturnType<typeof getWorkerDb> | undefined;
     const getDbForCall = () => (db ??= getWorkerDb(this.env.HYPERDRIVE.connectionString));
 
-    return dispatchCloudAgentSessionPush(params, {
+    return {
       getSession: async (userId, cliSessionId) => {
         const [session] = await getDbForCall()
           .select({
@@ -261,7 +277,7 @@ export class NotificationsService extends WorkerEntrypoint<Env> {
         ) as unknown as RecipientDOStub;
         return stub.dispatchPush(input);
       },
-    });
+    };
   }
 
   async sendScheduledActionNotice(

--- a/services/notifications/src/lib/cloud-agent-session-push.ts
+++ b/services/notifications/src/lib/cloud-agent-session-push.ts
@@ -1,9 +1,13 @@
+import { presenceContextForPlatform } from '@kilocode/event-service';
 import {
   sendCloudAgentSessionNotificationInputSchema,
+  sendSessionReadyNotificationInputSchema,
   type DispatchPushInput,
   type DispatchPushOutcome,
   type SendCloudAgentSessionNotificationParams,
   type SendCloudAgentSessionNotificationResult,
+  type SendSessionReadyNotificationParams,
+  type SendSessionReadyNotificationResult,
 } from '@kilocode/notifications';
 
 type CloudAgentNotificationSession = {
@@ -20,12 +24,20 @@ export type DispatchCloudAgentSessionPushDeps = {
   dispatchPush: (input: DispatchPushInput) => Promise<DispatchPushOutcome>;
 };
 
-export async function dispatchCloudAgentSessionPush(
-  params: SendCloudAgentSessionNotificationParams,
+type SessionPushContent = {
+  presenceContext: string | null;
+  idempotencyKey: string;
+  title: string;
+  body: string;
+};
+
+async function dispatchSessionPush(
+  userId: string,
+  cliSessionId: string,
+  buildContent: (session: CloudAgentNotificationSession) => SessionPushContent,
   deps: DispatchCloudAgentSessionPushDeps
 ): Promise<SendCloudAgentSessionNotificationResult> {
-  const parsed = sendCloudAgentSessionNotificationInputSchema.parse(params);
-  const session = await deps.getSession(parsed.userId, parsed.cliSessionId);
+  const session = await deps.getSession(userId, cliSessionId);
 
   if (!session) {
     return { dispatched: false, reason: 'missing_session' };
@@ -33,20 +45,21 @@ export async function dispatchCloudAgentSessionPush(
 
   if (
     session.organizationId &&
-    !(await deps.hasOrganizationAccess(parsed.userId, session.organizationId))
+    !(await deps.hasOrganizationAccess(userId, session.organizationId))
   ) {
     return { dispatched: false, reason: 'missing_session' };
   }
 
+  const content = buildContent(session);
   const outcome = await deps.dispatchPush({
-    userId: parsed.userId,
-    presenceContext: null,
-    idempotencyKey: `cloud-agent:${parsed.cliSessionId}:${parsed.executionId}`,
+    userId,
+    presenceContext: content.presenceContext,
+    idempotencyKey: content.idempotencyKey,
     badge: null,
     push: {
-      title: session.title ?? 'Agent session',
-      body: parsed.body,
-      data: { type: 'cloud_agent_session', cliSessionId: parsed.cliSessionId },
+      title: content.title,
+      body: content.body,
+      data: { type: 'cloud_agent_session', cliSessionId },
       sound: 'default',
       priority: 'high',
     },
@@ -57,4 +70,45 @@ export async function dispatchCloudAgentSessionPush(
   }
 
   return { dispatched: true };
+}
+
+export async function dispatchCloudAgentSessionPush(
+  params: SendCloudAgentSessionNotificationParams,
+  deps: DispatchCloudAgentSessionPushDeps
+): Promise<SendCloudAgentSessionNotificationResult> {
+  const parsed = sendCloudAgentSessionNotificationInputSchema.parse(params);
+  return dispatchSessionPush(
+    parsed.userId,
+    parsed.cliSessionId,
+    session => ({
+      presenceContext: null,
+      idempotencyKey: `cloud-agent:${parsed.cliSessionId}:${parsed.executionId}`,
+      title: session.title ?? 'Agent session',
+      body: parsed.body,
+    }),
+    deps
+  );
+}
+
+/**
+ * Push sent when a CLI session first registers with session-ingest, telling
+ * the user they can take over the session from their phone. Suppressed while
+ * the user is actively in the mobile app (they already see the session list).
+ */
+export async function dispatchSessionReadyPush(
+  params: SendSessionReadyNotificationParams,
+  deps: DispatchCloudAgentSessionPushDeps
+): Promise<SendSessionReadyNotificationResult> {
+  const parsed = sendSessionReadyNotificationInputSchema.parse(params);
+  return dispatchSessionPush(
+    parsed.userId,
+    parsed.cliSessionId,
+    () => ({
+      presenceContext: presenceContextForPlatform('app'),
+      idempotencyKey: `cloud-agent:${parsed.cliSessionId}:session-ready`,
+      title: 'Kilo session ready',
+      body: 'Your Kilo session is ready to control from your phone',
+    }),
+    deps
+  );
 }

--- a/services/notifications/src/lib/notifications-service-cloud-agent.test.ts
+++ b/services/notifications/src/lib/notifications-service-cloud-agent.test.ts
@@ -4,6 +4,7 @@ import { type DispatchPushInput, type DispatchPushOutcome } from '@kilocode/noti
 
 import {
   dispatchCloudAgentSessionPush,
+  dispatchSessionReadyPush,
   type DispatchCloudAgentSessionPushDeps,
 } from './cloud-agent-session-push';
 
@@ -204,5 +205,75 @@ describe('dispatchCloudAgentSessionPush', () => {
       )
     ).rejects.toThrow();
     expect(deps.getSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('dispatchSessionReadyPush', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockDispatchPush.mockResolvedValue({ kind: 'delivered', tokenCount: 1 });
+  });
+
+  it('dispatches fixed copy with app presence suppression and per-session idempotency', async () => {
+    const deps = createDeps({ session: { title: null, organizationId: null } });
+
+    const result = await dispatchSessionReadyPush(
+      { userId: 'user-1', cliSessionId: 'ses_1' },
+      deps
+    );
+
+    expect(result).toEqual({ dispatched: true });
+    expect(mockDispatchPush).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        presenceContext: '/presence/app',
+        idempotencyKey: 'cloud-agent:ses_1:session-ready',
+        badge: null,
+        push: expect.objectContaining({
+          title: 'Kilo session ready',
+          body: 'Your Kilo session is ready to control from your phone',
+          data: { type: 'cloud_agent_session', cliSessionId: 'ses_1' },
+        }),
+      })
+    );
+  });
+
+  it('returns missing_session without dispatching when the session row is absent', async () => {
+    const deps = createDeps({ session: null });
+
+    const result = await dispatchSessionReadyPush(
+      { userId: 'user-1', cliSessionId: 'ses_missing' },
+      deps
+    );
+
+    expect(result).toEqual({ dispatched: false, reason: 'missing_session' });
+    expect(mockDispatchPush).not.toHaveBeenCalled();
+  });
+
+  it('does not send for organization sessions the user cannot access', async () => {
+    const deps = createDeps({
+      session: { title: null, organizationId: 'org-1' },
+      hasOrganizationAccess: false,
+    });
+
+    const result = await dispatchSessionReadyPush(
+      { userId: 'former-member', cliSessionId: 'ses_org' },
+      deps
+    );
+
+    expect(result).toEqual({ dispatched: false, reason: 'missing_session' });
+    expect(mockDispatchPush).not.toHaveBeenCalled();
+  });
+
+  it('reports dispatch failures from the recipient notification channel', async () => {
+    const deps = createDeps();
+    mockDispatchPush.mockResolvedValue({ kind: 'failed', error: 'Expo unavailable' });
+
+    const result = await dispatchSessionReadyPush(
+      { userId: 'user-1', cliSessionId: 'ses_1' },
+      deps
+    );
+
+    expect(result).toEqual({ dispatched: false, reason: 'dispatch_failed' });
   });
 });

--- a/services/session-ingest/package.json
+++ b/services/session-ingest/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@kilocode/db": "workspace:*",
+    "@kilocode/notifications": "workspace:*",
     "@kilocode/session-ingest-contracts": "workspace:*",
     "@kilocode/worker-utils": "workspace:*",
     "@streamparser/json": "0.0.22",

--- a/services/session-ingest/src/env.ts
+++ b/services/session-ingest/src/env.ts
@@ -1,3 +1,7 @@
+import type { NotificationsBinding } from './notifications-binding.js';
 import type { O11YBinding } from './o11y-binding.js';
 
-export type Env = Omit<Cloudflare.Env, 'O11Y'> & { O11Y: O11YBinding };
+export type Env = Omit<Cloudflare.Env, 'O11Y' | 'NOTIFICATIONS'> & {
+  O11Y: O11YBinding;
+  NOTIFICATIONS: NotificationsBinding;
+};

--- a/services/session-ingest/src/notifications-binding.ts
+++ b/services/session-ingest/src/notifications-binding.ts
@@ -1,0 +1,18 @@
+/**
+ * RPC method types for the NOTIFICATIONS service binding.
+ *
+ * `wrangler types` only sees `Fetcher` for service bindings; the actual RPC
+ * shape comes from the notifications worker's WorkerEntrypoint and is declared
+ * here from shared package types so the generated file can be freely regenerated.
+ */
+
+import type {
+  SendSessionReadyNotificationParams,
+  SendSessionReadyNotificationResult,
+} from '@kilocode/notifications';
+
+export type NotificationsBinding = Fetcher & {
+  sendSessionReadyNotification(
+    params: SendSessionReadyNotificationParams
+  ): Promise<SendSessionReadyNotificationResult>;
+};

--- a/services/session-ingest/src/routes/api.test.ts
+++ b/services/session-ingest/src/routes/api.test.ts
@@ -42,6 +42,7 @@ type TestBindings = {
   HYPERDRIVE: HyperdriveBinding;
   SESSION_INGEST_R2: { put: ReturnType<typeof vi.fn> };
   INGEST_QUEUE: { send: ReturnType<typeof vi.fn> };
+  NOTIFICATIONS: { sendSessionReadyNotification: ReturnType<typeof vi.fn> };
 };
 
 function makeTestEnv(): TestBindings {
@@ -49,6 +50,7 @@ function makeTestEnv(): TestBindings {
     HYPERDRIVE: { connectionString: 'postgres://test' },
     SESSION_INGEST_R2: { put: vi.fn(async () => undefined) },
     INGEST_QUEUE: { send: vi.fn(async () => undefined) },
+    NOTIFICATIONS: { sendSessionReadyNotification: vi.fn(async () => ({ dispatched: true })) },
   };
 }
 
@@ -245,13 +247,14 @@ describe('api routes', () => {
     );
 
     const app = makeApiApp();
+    const env = makeTestEnv();
     const res = await app.fetch(
       new Request('http://local/session', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ sessionId: 'ses_12345678901234567890123456' }),
       }),
-      makeTestEnv()
+      env
     );
 
     expect(res.status).toBe(200);
@@ -261,6 +264,10 @@ describe('api routes', () => {
       'usr_test',
       expect.objectContaining({ type: 'session.created' })
     );
+    expect(env.NOTIFICATIONS.sendSessionReadyNotification).toHaveBeenCalledWith({
+      userId: 'usr_test',
+      cliSessionId: 'ses_12345678901234567890123456',
+    });
   });
 
   it('POST /session does not emit created when row already exists', async () => {
@@ -278,18 +285,20 @@ describe('api routes', () => {
     );
 
     const app = makeApiApp();
+    const env = makeTestEnv();
     const res = await app.fetch(
       new Request('http://local/session', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ sessionId: 'ses_12345678901234567890123456' }),
       }),
-      makeTestEnv()
+      env
     );
 
     expect(res.status).toBe(200);
     expect(fns.select).not.toHaveBeenCalled();
     expect(notifyUserSessionEvent).not.toHaveBeenCalled();
+    expect(env.NOTIFICATIONS.sendSessionReadyNotification).not.toHaveBeenCalled();
   });
 
   it('POST /session persists placeholder and warms cache', async () => {

--- a/services/session-ingest/src/routes/api.ts
+++ b/services/session-ingest/src/routes/api.ts
@@ -84,6 +84,19 @@ api.post('/session', zodJsonValidator(createSessionSchema), async c => {
       type: 'session.created',
       data: { source: 'v2', session, changedAt: session.updatedAt },
     });
+
+    // Tell the user's phone the session can be taken over remotely. Push
+    // failures must never fail session creation, so log and move on.
+    const pushPromise = c.env.NOTIFICATIONS.sendSessionReadyNotification({
+      userId: kiloUserId,
+      cliSessionId: body.sessionId,
+    }).catch((error: unknown) => {
+      console.error('Failed to send session-ready push (non-fatal)', {
+        sessionId: body.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+    getOptionalExecutionContext(c)?.waitUntil(pushPromise);
   }
 
   // Warm the session cache so the first ingest can skip Postgres.

--- a/services/session-ingest/wrangler.jsonc
+++ b/services/session-ingest/wrangler.jsonc
@@ -96,6 +96,11 @@
       "binding": "O11Y",
       "service": "o11y",
     },
+    {
+      "binding": "NOTIFICATIONS",
+      "service": "notifications",
+      "entrypoint": "NotificationsService",
+    },
   ],
   "secrets_store_secrets": [
     {


### PR DESCRIPTION
## What

When a remote CLI session first registers with session-ingest, the user now gets a push — **"Kilo session ready: Your Kilo session is ready to control from your phone"** — that deep-links straight into the session in the mobile app on tap.

## How

- **`packages/notifications`**: params/result types + Zod schema for a new `sendSessionReadyNotification` RPC.
- **`services/notifications`**: new `dispatchSessionReadyPush` sharing the resolve-session → org-access-check → dispatch skeleton with the existing cloud-agent push. Fixed copy, `presenceContext: /presence/app` (suppressed while the user is actively in the app — the app already subscribes to this context when foregrounded), idempotency key `cloud-agent:{cliSessionId}:session-ready`.
- **`services/session-ingest`**: `NOTIFICATIONS` service binding; `POST /session` fires the RPC fire-and-forget (`waitUntil`) only when a row was actually inserted. Push failures are logged and never fail session creation.
- **Mobile**: zero changes — the push reuses the `cloud_agent_session` payload type, so the existing tap handler already deep-links to `/(app)/agent-chat/{cliSessionId}` (foreground, background, and cold start).

Note: `worker-configuration.d.ts` intentionally not regenerated (local wrangler produces ~3.8k lines of workerd-version churn); the binding is typed via `src/notifications-binding.ts` + the `Env` override, same pattern as cloud-agent-next.

## Verification

- Unit tests: dispatch content/presence/idempotency, missing-session, org-access-revoked, dispatch-failure; session-ingest fires only for newly inserted rows (not on conflict).
- E2E locally with `wrangler dev` for session-ingest + notifications + event-service (bindings `[connected]` via dev registry), real kilo CLI against the local stack:
  - **User not in app**: CLI session start → `POST /api/session 200` → `cli_sessions_v2` row → push dispatched, DO outcome `no_tokens` (no device registered locally — the chain past that point is existing shipped push infra).
  - **User active in app**: with a live `/presence/app` subscription on event-service for the same user (what the app holds while foregrounded), a new CLI session's push came back `suppressed_presence` — no notification, as designed.
- `format` / `typecheck` / `lint` / tests green in all three touched packages; cloud-agent-next typecheck unaffected.