### PR TITLE
fix(ai-gateway): decouple usage rollup writes

### DIFF
--- a/.specs/cost-insights.md
+++ b/.specs/cost-insights.md
@@ -6,7 +6,7 @@ This spec defines business rules and invariants for Cost Insights, Spend Alerts,
 
 ## Status
 
-Draft -- created 2026-06-24. Updated 2026-06-24 to remove spend-blocking controls. Updated 2026-06-25 to rename the feature from Spend Insights to Cost Insights and add Cost Suggestions. Updated 2026-06-26 to require local-time UI timestamps, make Spend Anomaly Alerts opt-out by default, add independent rolling 7-day and rolling 30-day spend thresholds, and limit initial access to Kilo platform admins. Updated 2026-07-03 to render the 7-day spend-over-time evidence chart in daily buckets instead of hourly for readability; hourly owner-hour rollups and anomaly detection remain unchanged.
+Draft -- created 2026-06-24. Updated 2026-06-24 to remove spend-blocking controls. Updated 2026-06-25 to rename the feature from Spend Insights to Cost Insights and add Cost Suggestions. Updated 2026-06-26 to require local-time UI timestamps, make Spend Anomaly Alerts opt-out by default, add independent rolling 7-day and rolling 30-day spend thresholds, and limit initial access to Kilo platform admins. Updated 2026-07-03 to render the 7-day spend-over-time evidence chart in daily buckets instead of hourly for readability; hourly owner-hour rollups and anomaly detection remain unchanged. Updated 2026-07-07 to allow post-commit best-effort Cost Insights rollup capture for high-volume request-metered spend paths, preserving billing availability while relying on source-of-truth usage rows for repair/backfill.
 
 ## Conventions
 
@@ -170,8 +170,8 @@ Cost Insights does not replace low-balance alerts, auto-top-up setup, existing o
 11. V1 source taxonomy MUST include `ai_gateway`, `kiloclaw`, `coding_plan`, and `other`.
 12. Driver buckets MUST store actor user ID for both personal and organization spend.
 13. Driver buckets MUST store total spend and contributing spend-record count.
-14. Every Credit spend path MUST update owner-hour totals and applicable driver buckets atomically with spend recording.
-15. Credit spend MUST NOT commit unless the corresponding owner-hour total and applicable driver-bucket updates also commit.
+14. Credit spend paths SHOULD update owner-hour totals and applicable driver buckets as close to spend recording as practical.
+15. High-volume request-metered Credit spend paths MAY update Cost Insights rollups asynchronously after billing-critical spend recording commits, provided failures do not block or roll back the source-of-truth spend record and rollups can be repaired from source-of-truth Postgres usage data.
 16. Spend Alert evaluation and notification side effects SHOULD run asynchronously after spend recording.
 17. Enabling Spend Alerts MUST use already-maintained owner-hour totals for baseline data when available.
 18. Enabling Spend Alerts MUST backfill or repair the owner's last 7 days of hourly baseline from Postgres historical usage data when rollups are missing or incomplete.

--- a/.specs/cost-insights.md
+++ b/.specs/cost-insights.md
@@ -6,7 +6,7 @@ This spec defines business rules and invariants for Cost Insights, Spend Alerts,
 
 ## Status
 
-Draft -- created 2026-06-24. Updated 2026-06-24 to remove spend-blocking controls. Updated 2026-06-25 to rename the feature from Spend Insights to Cost Insights and add Cost Suggestions. Updated 2026-06-26 to require local-time UI timestamps, make Spend Anomaly Alerts opt-out by default, add independent rolling 7-day and rolling 30-day spend thresholds, and limit initial access to Kilo platform admins. Updated 2026-07-03 to render the 7-day spend-over-time evidence chart in daily buckets instead of hourly for readability; hourly owner-hour rollups and anomaly detection remain unchanged. Updated 2026-07-07 to allow post-commit best-effort Cost Insights rollup capture for high-volume request-metered spend paths, preserving billing availability while relying on source-of-truth usage rows for repair/backfill.
+Draft -- created 2026-06-24. Updated 2026-06-24 to remove spend-blocking controls. Updated 2026-06-25 to rename the feature from Spend Insights to Cost Insights and add Cost Suggestions. Updated 2026-06-26 to require local-time UI timestamps, make Spend Anomaly Alerts opt-out by default, add independent rolling 7-day and rolling 30-day spend thresholds, and limit initial personal access to Kilo platform admins. Updated 2026-07-03 to render the 7-day spend-over-time evidence chart in daily buckets instead of hourly for readability; hourly owner-hour rollups and anomaly detection remain unchanged. Updated 2026-07-07 to allow post-commit best-effort Cost Insights rollup capture for high-volume request-metered spend paths, preserving billing availability while relying on source-of-truth usage rows for repair/backfill, and to gate organization Cost Insights by direct owner/billing-manager role plus organization release toggle instead of global admin status.
 
 ## Conventions
 
@@ -44,22 +44,24 @@ Cost Insights does not replace low-balance alerts, auto-top-up setup, existing o
 2. Spend Alerts MUST evaluate Credit spend at the Spend owner boundary, not per product by default.
 3. All Credit spend charged to a Spend owner MUST count toward that owner's Spend Alert evaluation.
 4. Spend Alerts MUST remain inactive until a Spend owner explicitly enables them.
-5. During initial rollout, Cost Insights v1 MUST be available only to users whose current Kilo platform user record has `is_admin` set to `true`; this access restriction MUST NOT depend on a release-toggle gate.
-6. First enabling Spend Alerts MUST immediately evaluate every enabled alert sub-option: current anomaly state plus each configured rolling 24-hour, rolling 7-day, and rolling 30-day threshold window.
-7. First enabling Spend Alerts MAY create alert email and banner when current spend already crosses enabled controls.
-8. Disabling Spend Alerts MUST keep the owner config row disabled rather than deleting it.
-9. Re-enabling Spend Alerts MUST reuse existing saved settings unless an authorized manager changes them.
-10. Re-enabling Spend Alerts MUST immediately evaluate every enabled alert sub-option using current spend, including all three configured threshold windows.
-11. While Spend Alerts are disabled, settings changes MUST save only and MUST NOT evaluate controls, create Cost Insight Events, or send emails.
+5. During initial rollout, personal Cost Insights v1 MUST be available only to users whose current Kilo platform user record has `is_admin` set to `true`; this personal access restriction MUST NOT depend on a release-toggle gate.
+6. During initial rollout, organization Cost Insights v1 MUST be available only to direct organization owners and billing managers when the organization's `cost-insights` release toggle is enabled.
+7. First enabling Spend Alerts MUST immediately evaluate every enabled alert sub-option: current anomaly state plus each configured rolling 24-hour, rolling 7-day, and rolling 30-day threshold window.
+8. First enabling Spend Alerts MAY create alert email and banner when current spend already crosses enabled controls.
+9. Disabling Spend Alerts MUST keep the owner config row disabled rather than deleting it.
+10. Re-enabling Spend Alerts MUST reuse existing saved settings unless an authorized manager changes them.
+11. Re-enabling Spend Alerts MUST immediately evaluate every enabled alert sub-option using current spend, including all three configured threshold windows.
+12. While Spend Alerts are disabled, settings changes MUST save only and MUST NOT evaluate controls, create Cost Insight Events, or send emails.
 
 ### Authorization
 
 1. Personal Spend Alerts MUST be visible and manageable only when the personal user is a Kilo platform admin.
-2. Organization Cost Insights MUST be visible only to Kilo platform admins.
-3. Users whose current Kilo platform user record does not have `is_admin` set to `true` MUST NOT view personal or organization Cost Insights dashboards or settings, including through direct route or API access.
-4. Cost Insights navigation and attention queries MUST be hidden from non-admin users.
-5. Kilo platform admins MAY inspect organization Spend Alerts according to existing administrative access patterns.
-6. Kilo platform admins MUST NOT disable organization Spend Alerts or change customer Spend Alert settings in v1 unless they also have owner or billing-manager authority for that owner.
+2. Organization Cost Insights MUST be visible and manageable only to direct organization owners and billing managers while the organization's `cost-insights` release toggle is enabled.
+3. Users whose current Kilo platform user record does not have `is_admin` set to `true` MUST NOT view personal Cost Insights dashboards or settings, including through direct route or API access.
+4. Users without direct owner or billing-manager membership in an organization MUST NOT view that organization's Cost Insights dashboards or settings, including through direct route or API access.
+5. Organization Cost Insights navigation and attention queries MUST be hidden from users who are not direct organization owners or billing managers, and from all users while the organization's `cost-insights` release toggle is disabled.
+6. Kilo platform admins MAY inspect organization Spend Alerts according to existing administrative access patterns only when they also have owner or billing-manager authority for that owner in v1.
+7. Kilo platform admins MUST NOT disable organization Spend Alerts or change customer Spend Alert settings in v1 unless they also have owner or billing-manager authority for that owner.
 
 ### Routes
 
@@ -67,9 +69,11 @@ Cost Insights does not replace low-balance alerts, auto-top-up setup, existing o
 2. Personal Cost Insights settings MUST be served at `/cost-insights/config`.
 3. Organization Cost Insights dashboard MUST be served at `/organizations/[id]/cost-insights`.
 4. Organization Cost Insights settings MUST be served at `/organizations/[id]/cost-insights/config`.
-5. Cost Insights MUST appear directly below Usage in personal and organization sidebars for Kilo platform admins only.
-6. Cost Insights sidebar item MUST show attention state when owner has an unreviewed Spend Alert or active Cost Suggestion.
-7. Cost Insights routes MUST require current Kilo platform admin authorization and MUST NOT require a feature flag in v1.
+5. Personal Cost Insights MUST appear directly below Usage in the personal sidebar for Kilo platform admins only.
+6. Organization Cost Insights MUST appear directly below Usage in organization sidebars for direct organization owners and billing managers only while the organization's `cost-insights` release toggle is enabled.
+7. Cost Insights sidebar item MUST show attention state when owner has an unreviewed Spend Alert or active Cost Suggestion.
+8. Personal Cost Insights routes MUST require current Kilo platform admin authorization and MUST NOT require a feature flag in v1.
+9. Organization Cost Insights routes MUST require direct organization owner or billing-manager authorization and the organization's `cost-insights` release toggle in v1.
 
 ### Dashboard and Settings
 
@@ -183,7 +187,7 @@ Cost Insights does not replace low-balance alerts, auto-top-up setup, existing o
 1. Spend Alerts v1 MUST send email and show owner-scoped in-app banner until alert acknowledgment.
 2. Spend Alerts v1 MUST NOT send mobile or push notifications.
 3. Personal Spend Alerts MUST be sent to the personal user's email only while that user is a Kilo platform admin.
-4. Organization Spend Alerts MUST be sent only to active organization owners and billing managers who are also Kilo platform admins.
+4. Organization Spend Alerts MUST be sent only to active organization owners and billing managers while the organization's `cost-insights` release toggle is enabled.
 5. Spend Alert emails MUST link to Cost Insights dashboard review context.
 6. Spend Alerts MUST store owner-scoped Cost Insight Events separately from per-recipient notification delivery rows.
 7. Per-recipient notification delivery rows MAY be retried without creating duplicate owner-scoped Cost Insight Events.

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -113,7 +113,7 @@ export default function OrganizationAppSidebar({
     enabled: hasOwnerLevelAccess,
     staleTime: 60_000,
   });
-  const canViewCostInsights = costInsightsAccess?.enabled === true;
+  const canViewCostInsights = hasOwnerLevelAccess && costInsightsAccess?.enabled === true;
   const { data: costInsightsAttention } = useQuery({
     ...trpc.organizations.costInsights.getAttentionState.queryOptions({ organizationId }),
     enabled: canViewCostInsights,

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -108,7 +108,12 @@ export default function OrganizationAppSidebar({
   }, [actualRole, user?.is_admin, setOriginalRole, setAssumedRole]);
 
   const hasOwnerLevelAccess = currentRole === 'owner' || currentRole === 'billing_manager';
-  const canViewCostInsights = Boolean(user?.is_admin);
+  const { data: costInsightsAccess } = useQuery({
+    ...trpc.organizations.costInsights.getAccessState.queryOptions({ organizationId }),
+    enabled: hasOwnerLevelAccess,
+    staleTime: 60_000,
+  });
+  const canViewCostInsights = costInsightsAccess?.enabled === true;
   const { data: costInsightsAttention } = useQuery({
     ...trpc.organizations.costInsights.getAttentionState.queryOptions({ organizationId }),
     enabled: canViewCostInsights,

--- a/apps/web/src/app/(app)/organizations/[id]/cost-insights/layout.test.ts
+++ b/apps/web/src/app/(app)/organizations/[id]/cost-insights/layout.test.ts
@@ -1,0 +1,88 @@
+import type { ReactElement, ReactNode } from 'react';
+
+const mockIsReleaseToggleEnabled = jest.fn<Promise<boolean>, [string, string]>();
+
+function renderElement<Props, Result>(element: ReactElement<Props>): Result {
+  return (element.type as (props: Props) => Result)(element.props);
+}
+
+jest.mock('@/lib/posthog-feature-flags', () => ({
+  isReleaseToggleEnabled: (flagName: string, distinctId: string) =>
+    mockIsReleaseToggleEnabled(flagName, distinctId),
+}));
+
+jest.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new Error('NEXT_NOT_FOUND');
+  },
+}));
+
+jest.mock('@/components/cost-insights/CostInsightsLayout', () => ({
+  CostInsightsLayout: ({ children }: { children: ReactNode }) => children,
+}));
+
+jest.mock('@/components/organizations/OrganizationByPageLayout', () => ({
+  OrganizationByPageLayout: (props: {
+    render: (params: {
+      organization: { id: string };
+      role: 'owner' | 'billing_manager';
+      isGlobalAdmin: boolean;
+    }) => ReactElement;
+  }) =>
+    props.render({
+      organization: { id: 'org-cost-insights-layout' },
+      role: 'owner',
+      isGlobalAdmin: false,
+    }),
+}));
+
+describe('OrganizationCostInsightsLayout', () => {
+  beforeEach(() => {
+    mockIsReleaseToggleEnabled.mockReset();
+  });
+
+  it('renders for non-admin organization owners when the organization flag is enabled', async () => {
+    mockIsReleaseToggleEnabled.mockResolvedValue(true);
+    const { default: OrganizationCostInsightsLayout } =
+      await import('@/app/(app)/organizations/[id]/cost-insights/layout');
+
+    const layoutElement = OrganizationCostInsightsLayout({
+      params: Promise.resolve({ id: 'org-cost-insights-layout' }),
+      children: 'cost insights content',
+    }) as ReactElement<{ children: ReactNode }>;
+    const guardElement = renderElement(layoutElement) as ReactElement<{
+      organizationId: string;
+      children: ReactNode;
+    }>;
+
+    const costInsightsLayoutElement = (await renderElement(guardElement)) as ReactElement<{
+      basePath: string;
+      children: ReactNode;
+    }>;
+    expect(costInsightsLayoutElement.props).toMatchObject({
+      basePath: '/organizations/org-cost-insights-layout/cost-insights',
+      children: 'cost insights content',
+    });
+    expect(mockIsReleaseToggleEnabled).toHaveBeenCalledWith(
+      'cost-insights',
+      'org-cost-insights-layout'
+    );
+  });
+
+  it('not-founds when the organization flag is disabled', async () => {
+    mockIsReleaseToggleEnabled.mockResolvedValue(false);
+    const { default: OrganizationCostInsightsLayout } =
+      await import('@/app/(app)/organizations/[id]/cost-insights/layout');
+
+    const layoutElement = OrganizationCostInsightsLayout({
+      params: Promise.resolve({ id: 'org-cost-insights-layout' }),
+      children: 'cost insights content',
+    }) as ReactElement<{ children: ReactNode }>;
+    const guardElement = renderElement(layoutElement) as ReactElement<{
+      organizationId: string;
+      children: ReactNode;
+    }>;
+
+    await expect(Promise.resolve(renderElement(guardElement))).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+});

--- a/apps/web/src/app/(app)/organizations/[id]/cost-insights/layout.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/cost-insights/layout.tsx
@@ -1,6 +1,10 @@
 import { CostInsightsLayout } from '@/components/cost-insights/CostInsightsLayout';
 import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
 import { notFound } from 'next/navigation';
+import React from 'react';
+
+const COST_INSIGHTS_FEATURE_FLAG = 'cost-insights';
 
 export const metadata = {
   title: 'Cost Insights | Kilo Code',
@@ -12,19 +16,34 @@ type LayoutProps = {
   children: React.ReactNode;
 };
 
+async function OrganizationCostInsightsRouteGuard({
+  organizationId,
+  children,
+}: {
+  organizationId: string;
+  children: React.ReactNode;
+}) {
+  const enabled = await isReleaseToggleEnabled(COST_INSIGHTS_FEATURE_FLAG, organizationId);
+  if (!enabled) notFound();
+
+  return (
+    <CostInsightsLayout basePath={`/organizations/${organizationId}/cost-insights`}>
+      {children}
+    </CostInsightsLayout>
+  );
+}
+
 export default function OrganizationCostInsightsLayout({ params, children }: LayoutProps) {
   return (
     <OrganizationByPageLayout
       params={params}
       roles={['owner', 'billing_manager']}
       fullBleed
-      render={({ organization, isGlobalAdmin }) => {
-        if (!isGlobalAdmin) notFound();
-
+      render={({ organization }) => {
         return (
-          <CostInsightsLayout basePath={`/organizations/${organization.id}/cost-insights`}>
+          <OrganizationCostInsightsRouteGuard organizationId={organization.id}>
             {children}
-          </CostInsightsLayout>
+          </OrganizationCostInsightsRouteGuard>
         );
       }}
     />

--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -1,4 +1,4 @@
-import { test, describe, expect } from '@jest/globals';
+import { test, describe, expect, jest } from '@jest/globals';
 import type { MicrodollarUsageStats, MicrodollarUsageContext } from './processUsage.types';
 import {
   extractPromptInfo,
@@ -387,6 +387,23 @@ describe('logMicrodollarUsage', () => {
       ttfb_ms: null,
     }) satisfies MicrodollarUsageContext;
 
+  async function waitForExpectation(expectation: () => Promise<void>): Promise<void> {
+    const deadline = Date.now() + 2000;
+    let lastError: unknown;
+
+    while (Date.now() < deadline) {
+      try {
+        await expectation();
+        return;
+      } catch (error) {
+        lastError = error;
+        await new Promise(resolve => setTimeout(resolve, 20));
+      }
+    }
+
+    throw lastError;
+  }
+
   test('stores usage data and increments user microdollars for positive cost', async () => {
     const user = await insertTestUser({
       id: 'test-log-user-1',
@@ -428,30 +445,32 @@ describe('logMicrodollarUsage', () => {
     expect(usageRecord?.created_at).toBeTruthy();
     expect(metadataRecord?.created_at).toBe(usageRecord?.created_at);
 
-    const [total] = await db
-      .select()
-      .from(cost_insight_owner_hour_totals)
-      .where(eq(cost_insight_owner_hour_totals.owned_by_user_id, user.id));
-    expect(total).toMatchObject({
-      owned_by_organization_id: null,
-      spend_category: 'variable',
-      total_microdollars: 500,
-      spend_record_count: 1,
-    });
+    await waitForExpectation(async () => {
+      const [total] = await db
+        .select()
+        .from(cost_insight_owner_hour_totals)
+        .where(eq(cost_insight_owner_hour_totals.owned_by_user_id, user.id));
+      expect(total).toMatchObject({
+        owned_by_organization_id: null,
+        spend_category: 'variable',
+        total_microdollars: 500,
+        spend_record_count: 1,
+      });
 
-    const [driver] = await db
-      .select()
-      .from(cost_insight_owner_hour_driver_buckets)
-      .where(eq(cost_insight_owner_hour_driver_buckets.owned_by_user_id, user.id));
-    expect(driver).toMatchObject({
-      source: 'ai_gateway',
-      product_key: 'vscode-extension',
-      feature_key: 'chat_completions',
-      model_or_plan_key: 'anthropic/claude-3.7-sonnet',
-      provider_key: 'Provider',
-      actor_user_id: user.id,
-      total_microdollars: 500,
-      spend_record_count: 1,
+      const [driver] = await db
+        .select()
+        .from(cost_insight_owner_hour_driver_buckets)
+        .where(eq(cost_insight_owner_hour_driver_buckets.owned_by_user_id, user.id));
+      expect(driver).toMatchObject({
+        source: 'ai_gateway',
+        product_key: 'vscode-extension',
+        feature_key: 'chat_completions',
+        model_or_plan_key: 'anthropic/claude-3.7-sonnet',
+        provider_key: 'Provider',
+        actor_user_id: user.id,
+        total_microdollars: 500,
+        spend_record_count: 1,
+      });
     });
   });
 
@@ -568,26 +587,73 @@ describe('logMicrodollarUsage', () => {
     expect(totals).toHaveLength(0);
   });
 
-  test('rolls back AI source rows when mandatory capture fails', async () => {
+  test('keeps AI source rows when post-commit cost insight capture fails', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const { core, metadata } = await defineMicrodollarUsage();
     const missingUserId = `missing-ai-user-${crypto.randomUUID()}`;
 
-    const result = await insertUsageRecord(
-      { ...core, kilo_user_id: missingUserId, cost: 1000 },
-      metadata
-    );
+    try {
+      const result = await insertUsageRecord(
+        { ...core, kilo_user_id: missingUserId, cost: 1000 },
+        metadata
+      );
 
-    expect(result).toBeNull();
-    const sourceRows = await db
-      .select()
-      .from(microdollar_usage)
-      .where(eq(microdollar_usage.kilo_user_id, missingUserId));
-    const totals = await db
-      .select()
-      .from(cost_insight_owner_hour_totals)
-      .where(eq(cost_insight_owner_hour_totals.owned_by_user_id, missingUserId));
-    expect(sourceRows).toHaveLength(0);
-    expect(totals).toHaveLength(0);
+      expect(result).toMatchObject({ usageId: core.id, newMicrodollarsUsed: null });
+      const sourceRows = await db
+        .select()
+        .from(microdollar_usage)
+        .where(eq(microdollar_usage.kilo_user_id, missingUserId));
+      expect(sourceRows).toHaveLength(1);
+
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      const totals = await db
+        .select()
+        .from(cost_insight_owner_hour_totals)
+        .where(eq(cost_insight_owner_hour_totals.owned_by_user_id, missingUserId));
+      expect(totals).toHaveLength(0);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  test('keeps usage and balance write when post-commit cost insight capture fails', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const user = await insertTestUser({
+      id: ` test-cost-insight-failure-user-${crypto.randomUUID()} `,
+      microdollars_used: 0,
+      google_user_email: 'cost-insight-failure@example.com',
+    });
+    const { core, metadata } = await defineMicrodollarUsage();
+
+    try {
+      const result = await insertUsageRecord(
+        { ...core, kilo_user_id: user.id, organization_id: null, cost: 1000 },
+        metadata
+      );
+
+      expect(result).toMatchObject({ usageId: core.id, newMicrodollarsUsed: 1000 });
+      const updatedUser = await findUserById(user.id);
+      expect(updatedUser?.microdollars_used).toBe(1000);
+
+      const sourceRows = await db
+        .select()
+        .from(microdollar_usage)
+        .where(eq(microdollar_usage.kilo_user_id, user.id));
+      expect(sourceRows).toHaveLength(1);
+
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      const totals = await db
+        .select()
+        .from(cost_insight_owner_hour_totals)
+        .where(eq(cost_insight_owner_hour_totals.owned_by_user_id, user.id));
+      expect(totals).toHaveLength(0);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   test('stores 3 usage records with overlapping data and tests metadata deduplication', async () => {
@@ -762,30 +828,32 @@ describe('logMicrodollarUsage', () => {
     expect(usageRecord?.model).toBe('anthropic/claude-3.7-sonnet');
     expect(usageRecord?.provider).toBe('openrouter');
 
-    const [chargedOrganization] = await db
-      .select({ microdollars_used: organizations.microdollars_used })
-      .from(organizations)
-      .where(eq(organizations.id, organization.id));
-    expect(chargedOrganization.microdollars_used).toBe(500);
+    await waitForExpectation(async () => {
+      const [chargedOrganization] = await db
+        .select({ microdollars_used: organizations.microdollars_used })
+        .from(organizations)
+        .where(eq(organizations.id, organization.id));
+      expect(chargedOrganization.microdollars_used).toBe(500);
 
-    const [memberUsage] = await db
-      .select()
-      .from(organization_user_usage)
-      .where(eq(organization_user_usage.organization_id, organization.id));
-    expect(memberUsage).toMatchObject({
-      kilo_user_id: user.id,
-      microdollar_usage: 500,
-    });
+      const [memberUsage] = await db
+        .select()
+        .from(organization_user_usage)
+        .where(eq(organization_user_usage.organization_id, organization.id));
+      expect(memberUsage).toMatchObject({
+        kilo_user_id: user.id,
+        microdollar_usage: 500,
+      });
 
-    const [total] = await db
-      .select()
-      .from(cost_insight_owner_hour_totals)
-      .where(eq(cost_insight_owner_hour_totals.owned_by_organization_id, organization.id));
-    expect(total).toMatchObject({
-      owned_by_user_id: null,
-      spend_category: 'variable',
-      total_microdollars: 500,
-      spend_record_count: 1,
+      const [total] = await db
+        .select()
+        .from(cost_insight_owner_hour_totals)
+        .where(eq(cost_insight_owner_hour_totals.owned_by_organization_id, organization.id));
+      expect(total).toMatchObject({
+        owned_by_user_id: null,
+        spend_category: 'variable',
+        total_microdollars: 500,
+        spend_record_count: 1,
+      });
     });
   });
 

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -428,7 +428,6 @@ type UsageStatementResult = UsageRecordInsertResult & {
 
 type UsageTransactionResult = {
   inserted: UsageStatementResult;
-  organizationUsage: OrganizationUsageMutationResult | null;
 };
 
 async function insertUsageTransaction(
@@ -441,29 +440,66 @@ async function insertUsageTransaction(
       coreUsageFields,
       metadataFields
     );
-    const organizationUsage = coreUsageFields.organization_id
-      ? await mutateOrganizationUsage(tx, coreUsageFields)
-      : null;
+    return { inserted };
+  });
+}
 
-    if (coreUsageFields.cost > 0) {
-      await captureCostInsightSpend(tx, {
-        owner: coreUsageFields.organization_id
-          ? { type: 'organization', id: coreUsageFields.organization_id }
-          : { type: 'user', id: coreUsageFields.kilo_user_id },
-        actorUserId: coreUsageFields.kilo_user_id,
-        occurredAt: coreUsageFields.created_at,
-        amountMicrodollars: coreUsageFields.cost,
+function scheduleOrganizationUsageMutation(usage: MicrodollarUsage): void {
+  const organizationId = usage.organization_id;
+  if (!organizationId) return;
+
+  void db
+    .transaction(tx => mutateOrganizationUsage(tx, usage))
+    .then((result: OrganizationUsageMutationResult) =>
+      scheduleOrganizationLowBalanceAlert(organizationId, result)
+    )
+    .catch(error => {
+      console.error('post-commit organization usage mutation failed', error);
+      captureException(error, {
+        tags: { source: 'postCommitOrganizationUsageMutation' },
+        extra: { usageId: usage.id, organizationId },
+      });
+    });
+}
+
+function scheduleCostInsightSpendCapture(
+  usage: MicrodollarUsage,
+  metadataFields: UsageMetaData
+): void {
+  if (usage.cost <= 0) return;
+
+  const owner = usage.organization_id
+    ? { type: 'organization' as const, id: usage.organization_id }
+    : { type: 'user' as const, id: usage.kilo_user_id };
+
+  void db
+    .transaction(tx =>
+      captureCostInsightSpend(tx, {
+        owner,
+        actorUserId: usage.kilo_user_id,
+        occurredAt: usage.created_at,
+        amountMicrodollars: usage.cost,
         category: 'variable',
         source: 'ai_gateway',
         productKey: getAiGatewayCostInsightProductKey(metadataFields.feature),
         featureKey: getAiGatewayCostInsightFeatureKey(metadataFields.api_kind),
-        modelOrPlanKey: coreUsageFields.requested_model || coreUsageFields.model || 'other',
-        providerKey: coreUsageFields.inference_provider || coreUsageFields.provider || 'other',
+        modelOrPlanKey: usage.requested_model || usage.model || 'other',
+        providerKey: usage.inference_provider || usage.provider || 'other',
+      })
+    )
+    .then(() => scheduleCostInsightEvaluationAfterSpend(owner))
+    .catch(error => {
+      console.error('post-commit cost insight spend capture failed', error);
+      captureException(error, {
+        tags: {
+          source: 'postCommitCostInsightSpendCapture',
+          spendCategory: 'variable',
+          spendSource: 'ai_gateway',
+          ownerType: owner.type,
+        },
+        extra: { usageId: usage.id, ownerId: owner.id },
       });
-    }
-
-    return { inserted, organizationUsage };
-  });
+    });
 }
 
 function scheduleKiloPassBonusIfNeeded(
@@ -511,7 +547,7 @@ export async function insertUsageRecord(
         while (true) {
           try {
             // This can fail if new deduplicated values are inserted simultaneously.
-            // Every retry opens a fresh transaction for source, charge, and rollups.
+            // Every retry opens a fresh transaction for the usage and balance write.
             return await insertUsageTransaction(coreUsageFields, metadataFields);
           } catch (error) {
             if (attempt >= 2) throw error;
@@ -526,19 +562,8 @@ export async function insertUsageRecord(
       }
     );
 
-    if (coreUsageFields.organization_id && result.organizationUsage) {
-      scheduleOrganizationLowBalanceAlert(
-        coreUsageFields.organization_id,
-        result.organizationUsage
-      );
-    }
-    if (coreUsageFields.cost > 0) {
-      scheduleCostInsightEvaluationAfterSpend(
-        coreUsageFields.organization_id
-          ? { type: 'organization', id: coreUsageFields.organization_id }
-          : { type: 'user', id: coreUsageFields.kilo_user_id }
-      );
-    }
+    scheduleOrganizationUsageMutation(coreUsageFields);
+    scheduleCostInsightSpendCapture(coreUsageFields, metadataFields);
     scheduleKiloPassBonusIfNeeded(coreUsageFields, result.inserted);
     return {
       usageId: result.inserted.usageId,

--- a/apps/web/src/lib/cost-insights/repository.ts
+++ b/apps/web/src/lib/cost-insights/repository.ts
@@ -461,12 +461,10 @@ export async function listCostInsightNotificationRecipientUserIds(
   const rows = await database
     .select({ userId: organization_memberships.kilo_user_id })
     .from(organization_memberships)
-    .innerJoin(kilocode_users, eq(kilocode_users.id, organization_memberships.kilo_user_id))
     .where(
       and(
         eq(organization_memberships.organization_id, owner.id),
-        inArray(organization_memberships.role, ['owner', 'billing_manager']),
-        eq(kilocode_users.is_admin, true)
+        inArray(organization_memberships.role, ['owner', 'billing_manager'])
       )
     )
     .orderBy(organization_memberships.kilo_user_id);
@@ -1056,13 +1054,11 @@ export async function hasCurrentCostInsightAccess(
   const [row] = await database
     .select({ id: organization_memberships.id })
     .from(organization_memberships)
-    .innerJoin(kilocode_users, eq(kilocode_users.id, organization_memberships.kilo_user_id))
     .where(
       and(
         eq(organization_memberships.organization_id, owner.id),
         eq(organization_memberships.kilo_user_id, userId),
-        inArray(organization_memberships.role, ['owner', 'billing_manager']),
-        eq(kilocode_users.is_admin, true)
+        inArray(organization_memberships.role, ['owner', 'billing_manager'])
       )
     )
     .limit(1);

--- a/apps/web/src/routers/organizations/organization-cost-insights-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-cost-insights-router.test.ts
@@ -18,11 +18,18 @@ jest.mock('@/lib/cost-insights/posthog-tracking', () => ({
   trackCostInsightsUiInteraction: jest.fn(),
 }));
 
+jest.mock('@/lib/posthog-feature-flags', () => ({
+  isReleaseToggleEnabled: jest.fn(async () => true),
+}));
+
 const trackingMock: {
   trackCostInsightsAlertAction: jest.Mock;
   trackCostInsightsSuggestionAction: jest.Mock;
   trackCostInsightsUiInteraction: jest.Mock;
 } = jest.requireMock('@/lib/cost-insights/posthog-tracking');
+const featureFlagMock: {
+  isReleaseToggleEnabled: jest.Mock;
+} = jest.requireMock('@/lib/posthog-feature-flags');
 
 let createCallerForUser: typeof CreateCallerForUser;
 
@@ -35,10 +42,12 @@ describe('Organization Cost Insights tracking', () => {
     trackingMock.trackCostInsightsAlertAction.mockClear();
     trackingMock.trackCostInsightsSuggestionAction.mockClear();
     trackingMock.trackCostInsightsUiInteraction.mockClear();
+    featureFlagMock.isReleaseToggleEnabled.mockReset();
+    featureFlagMock.isReleaseToggleEnabled.mockImplementation(async () => true);
   });
 
-  it('attributes UI interactions to the acting admin organization owner', async () => {
-    const owner = await insertTestUser({ is_admin: true });
+  it('attributes UI interactions to the acting enabled organization owner', async () => {
+    const owner = await insertTestUser();
     const organization = await createOrganization('Cost Insights Tracking Org', owner.id);
     const caller = await createCallerForUser(owner.id);
 
@@ -63,11 +72,15 @@ describe('Organization Cost Insights tracking', () => {
         filter: 'alerts',
       }
     );
+    expect(featureFlagMock.isReleaseToggleEnabled).toHaveBeenCalledWith(
+      'cost-insights',
+      organization.id
+    );
   });
 
-  it('allows admin billing managers to track suggestion CTA engagement', async () => {
+  it('allows enabled billing managers to track suggestion CTA engagement', async () => {
     const owner = await insertTestUser();
-    const billingManager = await insertTestUser({ is_admin: true });
+    const billingManager = await insertTestUser();
     const organization = await createOrganization('Cost Insights Billing Org', owner.id);
     await addUserToOrganization(organization.id, billingManager.id, 'billing_manager');
     const caller = await createCallerForUser(billingManager.id);
@@ -91,7 +104,7 @@ describe('Organization Cost Insights tracking', () => {
   });
 
   it('acknowledges only the displayed organization alert event', async () => {
-    const owner = await insertTestUser({ is_admin: true });
+    const owner = await insertTestUser();
     const organization = await createOrganization('Cost Insights Review Org', owner.id);
     const [alertEvent] = await db
       .insert(cost_insight_events)
@@ -136,35 +149,33 @@ describe('Organization Cost Insights tracking', () => {
     expect(trackingMock.trackCostInsightsAlertAction).toHaveBeenCalledTimes(1);
   });
 
-  it('limits notification access to admin owners and billing managers', async () => {
+  it('limits notification access to owners and billing managers', async () => {
     const owner = await insertTestUser();
-    const adminBillingManager = await insertTestUser({ is_admin: true });
-    const nonAdminBillingManager = await insertTestUser();
-    const adminMember = await insertTestUser({ is_admin: true });
+    const billingManager = await insertTestUser();
+    const member = await insertTestUser();
     const adminPersonalOwner = await insertTestUser({ is_admin: true });
     const organization = await createOrganization('Cost Insights Notification Org', owner.id);
-    await addUserToOrganization(organization.id, adminBillingManager.id, 'billing_manager');
-    await addUserToOrganization(organization.id, nonAdminBillingManager.id, 'billing_manager');
-    await addUserToOrganization(organization.id, adminMember.id, 'member');
+    await addUserToOrganization(organization.id, billingManager.id, 'billing_manager');
+    await addUserToOrganization(organization.id, member.id, 'member');
 
     await expect(
       listCostInsightNotificationRecipientUserIds(db, {
         type: 'organization',
         id: organization.id,
       })
-    ).resolves.toEqual([adminBillingManager.id]);
+    ).resolves.toEqual([billingManager.id, owner.id].sort());
     await expect(
       hasCurrentCostInsightAccess(
         db,
         { type: 'organization', id: organization.id },
-        adminBillingManager.id
+        billingManager.id
       )
     ).resolves.toBe(true);
     await expect(
       hasCurrentCostInsightAccess(db, { type: 'organization', id: organization.id }, owner.id)
-    ).resolves.toBe(false);
+    ).resolves.toBe(true);
     await expect(
-      hasCurrentCostInsightAccess(db, { type: 'organization', id: organization.id }, adminMember.id)
+      hasCurrentCostInsightAccess(db, { type: 'organization', id: organization.id }, member.id)
     ).resolves.toBe(false);
     await expect(
       listCostInsightNotificationRecipientUserIds(db, { type: 'user', id: owner.id })
@@ -177,9 +188,10 @@ describe('Organization Cost Insights tracking', () => {
     ).resolves.toEqual([adminPersonalOwner.id]);
   });
 
-  it('rejects every Cost Insights procedure for non-admin organization owners', async () => {
+  it('rejects every Cost Insights procedure when the organization flag is disabled', async () => {
+    featureFlagMock.isReleaseToggleEnabled.mockImplementation(async () => false);
     const owner = await insertTestUser();
-    const organization = await createOrganization('Cost Insights Non-Admin Org', owner.id);
+    const organization = await createOrganization('Cost Insights Disabled Org', owner.id);
     const caller = await createCallerForUser(owner.id);
     const organizationId = organization.id;
     const calls = [
@@ -229,10 +241,29 @@ describe('Organization Cost Insights tracking', () => {
     for (const call of calls) {
       await expect(call()).rejects.toMatchObject({
         code: 'FORBIDDEN',
-        message: 'Admin access required',
+        message: 'Cost Insights is not enabled for this organization.',
       });
     }
     expect(trackingMock.trackCostInsightsUiInteraction).not.toHaveBeenCalled();
     expect(trackingMock.trackCostInsightsSuggestionAction).not.toHaveBeenCalled();
+  });
+
+  it('rejects enabled organization members without owner or billing manager role', async () => {
+    const owner = await insertTestUser();
+    const member = await insertTestUser();
+    const organization = await createOrganization('Cost Insights Member Org', owner.id);
+    await addUserToOrganization(organization.id, member.id, 'member');
+    const caller = await createCallerForUser(member.id);
+
+    await expect(
+      caller.organizations.costInsights.getDashboard({ organizationId: organization.id })
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Only an organization owner or billing manager can access Cost Insights.',
+    });
+    await expect(
+      caller.organizations.costInsights.getAccessState({ organizationId: organization.id })
+    ).resolves.toEqual({ enabled: false });
+    expect(featureFlagMock.isReleaseToggleEnabled).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/routers/organizations/organization-cost-insights-router.ts
+++ b/apps/web/src/routers/organizations/organization-cost-insights-router.ts
@@ -3,7 +3,9 @@ import { and, eq } from 'drizzle-orm';
 
 import { organization_memberships, organizations } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
-import { adminProcedure, createTRPCRouter, type TRPCContext } from '@/lib/trpc/init';
+import { baseProcedure, createTRPCRouter, type TRPCContext } from '@/lib/trpc/init';
+import type { OrganizationRole } from '@/lib/organizations/organization-types';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
 import {
   buildCostInsightsDashboardData,
   buildCostInsightsEventHistoryData,
@@ -23,6 +25,12 @@ import {
 } from '@/lib/cost-insights/posthog-tracking';
 import { OrganizationIdInputSchema } from './utils';
 import { costInsightsRouterInternals } from '../cost-insights-router';
+
+const COST_INSIGHTS_FEATURE_FLAG = 'cost-insights';
+
+function hasCostInsightsRole(role: OrganizationRole | null): role is 'owner' | 'billing_manager' {
+  return role === 'owner' || role === 'billing_manager';
+}
 
 async function getDirectCostInsightsRole(organizationId: string, userId: string) {
   const [membership] = await db
@@ -52,11 +60,17 @@ async function getOrganizationName(organizationId: string): Promise<string> {
 async function resolveOrgReadContext(ctx: TRPCContext, organizationId: string) {
   const name = await getOrganizationName(organizationId);
   const directRole = await getDirectCostInsightsRole(organizationId, ctx.user.id);
-  const canManage = directRole === 'owner' || directRole === 'billing_manager';
+  if (!hasCostInsightsRole(directRole)) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Only an organization owner or billing manager can access Cost Insights.',
+    });
+  }
+  await ensureOrganizationCostInsightsEnabled(organizationId);
   return {
     name,
-    authorizedRole: canManage ? directRole : 'admin',
-    readOnly: !canManage,
+    authorizedRole: directRole,
+    readOnly: false,
   } as const;
 }
 
@@ -76,17 +90,37 @@ function organizationTrackingContext(
 
 async function ensureOrgManageAccess(ctx: TRPCContext, organizationId: string) {
   const directRole = await getDirectCostInsightsRole(organizationId, ctx.user.id);
-  if (directRole !== 'owner' && directRole !== 'billing_manager') {
+  if (!hasCostInsightsRole(directRole)) {
     throw new TRPCError({
       code: 'FORBIDDEN',
       message: 'Only an organization owner or billing manager can change Cost Insights.',
     });
   }
+  await ensureOrganizationCostInsightsEnabled(organizationId);
   return directRole;
 }
 
+async function ensureOrganizationCostInsightsEnabled(organizationId: string) {
+  const enabled = await isReleaseToggleEnabled(COST_INSIGHTS_FEATURE_FLAG, organizationId);
+  if (!enabled) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Cost Insights is not enabled for this organization.',
+    });
+  }
+}
+
 export const organizationCostInsightsRouter = createTRPCRouter({
-  trackUiInteraction: adminProcedure
+  getAccessState: baseProcedure.input(OrganizationIdInputSchema).query(async ({ ctx, input }) => {
+    const directRole = await getDirectCostInsightsRole(input.organizationId, ctx.user.id);
+    if (!hasCostInsightsRole(directRole)) {
+      return { enabled: false };
+    }
+    return {
+      enabled: await isReleaseToggleEnabled(COST_INSIGHTS_FEATURE_FLAG, input.organizationId),
+    };
+  }),
+  trackUiInteraction: baseProcedure
     .input(costInsightsRouterInternals.OrganizationCostInsightsUiInteractionSchema)
     .mutation(async ({ ctx, input }) => {
       const access = await resolveOrgReadContext(ctx, input.organizationId);
@@ -96,7 +130,7 @@ export const organizationCostInsightsRouter = createTRPCRouter({
       );
       return { success: true };
     }),
-  trackSuggestionCta: adminProcedure
+  trackSuggestionCta: baseProcedure
     .input(costInsightsRouterInternals.OrganizationCostInsightsSuggestionCtaSchema)
     .mutation(async ({ ctx, input }) => {
       const role = await ensureOrgManageAccess(ctx, input.organizationId);
@@ -108,7 +142,7 @@ export const organizationCostInsightsRouter = createTRPCRouter({
       });
       return { success: true };
     }),
-  getDashboard: adminProcedure.input(OrganizationIdInputSchema).query(async ({ ctx, input }) => {
+  getDashboard: baseProcedure.input(OrganizationIdInputSchema).query(async ({ ctx, input }) => {
     const access = await resolveOrgReadContext(ctx, input.organizationId);
     return await buildCostInsightsDashboardData({
       database: db,
@@ -120,7 +154,7 @@ export const organizationCostInsightsRouter = createTRPCRouter({
       },
     });
   }),
-  getSettings: adminProcedure.input(OrganizationIdInputSchema).query(async ({ ctx, input }) => {
+  getSettings: baseProcedure.input(OrganizationIdInputSchema).query(async ({ ctx, input }) => {
     const access = await resolveOrgReadContext(ctx, input.organizationId);
     return await buildCostInsightsSettingsData({
       database: db,
@@ -133,7 +167,7 @@ export const organizationCostInsightsRouter = createTRPCRouter({
       readOnly: access.readOnly,
     });
   }),
-  listEvents: adminProcedure
+  listEvents: baseProcedure
     .input(
       OrganizationIdInputSchema.merge(costInsightsRouterInternals.CostInsightEventHistorySchema)
     )
@@ -147,7 +181,7 @@ export const organizationCostInsightsRouter = createTRPCRouter({
         pageSize: input.pageSize,
       });
     }),
-  getAttentionState: adminProcedure
+  getAttentionState: baseProcedure
     .input(OrganizationIdInputSchema)
     .query(async ({ ctx, input }) => {
       await resolveOrgReadContext(ctx, input.organizationId);
@@ -160,7 +194,7 @@ export const organizationCostInsightsRouter = createTRPCRouter({
         reviewItemCount,
       };
     }),
-  updateSettings: adminProcedure
+  updateSettings: baseProcedure
     .input(
       OrganizationIdInputSchema.merge(costInsightsRouterInternals.UpdateCostInsightsSettingsSchema)
     )
@@ -173,7 +207,7 @@ export const organizationCostInsightsRouter = createTRPCRouter({
         input,
       });
     }),
-  acknowledgeAlert: adminProcedure
+  acknowledgeAlert: baseProcedure
     .input(
       OrganizationIdInputSchema.merge(costInsightsRouterInternals.AcknowledgeCostInsightAlertSchema)
     )
@@ -194,7 +228,7 @@ export const organizationCostInsightsRouter = createTRPCRouter({
       }
       return { success: true };
     }),
-  dismissSuggestion: adminProcedure
+  dismissSuggestion: baseProcedure
     .input(
       OrganizationIdInputSchema.merge(
         costInsightsRouterInternals.DismissCostInsightSuggestionSchema


### PR DESCRIPTION
## Summary
Cost Insights access is gated for organizations, and AI Gateway usage writes no longer hold billing, organization, and Cost Insights rollup locks in one transaction.

### Why this change is needed
Organization Cost Insights needs to stay limited to authorized organization owners or billing managers while rollout is controlled by the `cost-insights` release toggle.

After Cost Insights landed, high-volume AI Gateway usage writes began timing out under load because one transaction held locks across the usage/daily-rollup write, organization usage mutation, and Cost Insights rollup capture. Billing writes must stay durable and retry-safe, but non-critical analytics and alerting rollups should not extend the hot lock window.

### How this is addressed
- Gates organization Cost Insights reads, writes, tracking, sidebar navigation, and attention state behind direct owner/billing-manager access plus the `cost-insights` release toggle.
- Keeps the AI Gateway billing-critical unit atomic: `microdollar_usage` insert, metadata insert, `microdollar_usage_daily` upsert, and personal balance update still commit together.
- Moves organization usage mutation into its own post-commit transaction so the `organizations` `FOR UPDATE` lock is not held with the daily-rollup row lock.
- Moves Cost Insights spend capture into a separate post-commit best-effort transaction so rollup failures do not block or roll back successful usage/billing writes.
- Updates the Cost Insights spec to allow asynchronous repairable rollup capture for high-volume request-metered spend paths.

## Human Verification
- `pnpm --filter web test -- src/lib/ai-gateway/processUsage.test.ts src/lib/organizations/organization-usage.test.ts`

## Reviewer Notes
### Human Reviewer Flags
- Cost Insights spec now prioritizes billing availability for high-volume request-metered spend paths over synchronous rollup completeness.
- Cost Insights rollup capture for AI Gateway is now best-effort after commit; missing rollups must be repairable from source-of-truth Postgres usage rows.
- Organization usage mutation remains transactional, but it is scoped to its own short transaction after billing persistence.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Check that no transaction now includes all three hot sections: `microdollar_usage_daily` upsert, `organizations FOR UPDATE`, and Cost Insights rollup writes.
- Check that `insertUsageRecord` retry behavior still wraps only the core usage/balance transaction, so dedup-value retry semantics remain fresh-transaction safe.
- Check that post-commit failures are logged/captured without changing the public success result of a persisted usage write.

</details>
