### PR TITLE
feat(admin): add manual platform-admin grant/revoke management

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -291,10 +291,14 @@ http://localhost:3000/users/sign_in?fakeUser=someone@example.com&callbackPath=/p
 
 ### Admin access
 
-Some features (e.g., admin panels) are only visible to users with `is_admin = true`. The admin flag is set at user-creation time based on the email address:
+Some features (e.g., admin panels) are only visible to users with `is_admin = true`.
 
-- **Real OAuth:** emails ending in `@kilocode.ai` with the `kilocode.ai` hosted domain are admins.
-- **Fake login:** emails must end in `@admin.example.com` to get admin access.
+- **Real OAuth:** new `@kilocode.ai` signups are never automatically made admins. An existing
+  qualifying `@kilocode.ai` admin must grant access explicitly from `/admin/admins`.
+- **Fake login:** emails must end in `@admin.example.com` to get admin access automatically at
+  signup. This bootstrap only applies in environments where fake login is enabled; note that a
+  fake-login `someone@kilocode.ai` user does not qualify for production-domain admin grants
+  because its hosted domain is `@@fake@@`, not `kilocode.ai`.
 
 To sign in as a fake admin:
 

--- a/apps/web/src/app/admin/admins/page.tsx
+++ b/apps/web/src/app/admin/admins/page.tsx
@@ -1,0 +1,25 @@
+import AdminPage from '../components/AdminPage';
+import { PlatformAdminsContent } from '../components/PlatformAdminsContent';
+import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
+
+const breadcrumbs = (
+  <>
+    <BreadcrumbItem>
+      <BreadcrumbPage>Admins</BreadcrumbPage>
+    </BreadcrumbItem>
+  </>
+);
+
+export default async function AdminsPage() {
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <div className="flex w-full flex-col gap-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold">Platform Admins</h2>
+        </div>
+
+        <PlatformAdminsContent />
+      </div>
+    </AdminPage>
+  );
+}

--- a/apps/web/src/app/admin/api/credit-categories/[key]/route.test.ts
+++ b/apps/web/src/app/admin/api/credit-categories/[key]/route.test.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/drizzle';
+import { credit_transactions } from '@kilocode/db/schema';
+import { getUserFromAuth } from '@/lib/user/server';
+import { defineTestUser, insertTestUser } from '@/tests/helpers/user.helper';
+import { GET } from './route';
+
+jest.mock('@/lib/user/server', () => ({
+  getUserFromAuth: jest.fn(),
+}));
+
+const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
+
+function createRequest() {
+  return new NextRequest('http://localhost:3000/admin/api/credit-categories/%3Cnull:paid%3E');
+}
+
+describe('GET /admin/api/credit-categories/[key]', () => {
+  beforeEach(() => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: defineTestUser({ is_admin: true }),
+      authFailedResponse: null,
+    });
+  });
+
+  it('returns users for a current admin', async () => {
+    const user = await insertTestUser();
+    await db.insert(credit_transactions).values({
+      kilo_user_id: user.id,
+      credit_category: null,
+      amount_microdollars: 1_000_000,
+      is_free: false,
+    });
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({ key: '<null:paid>' }),
+    });
+    expect(response.status).toBe(200);
+    expect(mockedGetUserFromAuth).toHaveBeenCalledWith({ adminOnly: true });
+    const body = await response.json();
+    expect(body).toHaveProperty('users');
+    expect(body.users.map((u: { kilo_user_id: string }) => u.kilo_user_id)).toContain(user.id);
+  });
+
+  it('rejects the request before touching the database when authorization fails', async () => {
+    const user = await insertTestUser();
+    await db.insert(credit_transactions).values({
+      kilo_user_id: user.id,
+      credit_category: null,
+      amount_microdollars: 1_000_000,
+      is_free: false,
+    });
+
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: null,
+      authFailedResponse: NextResponse.json(
+        { success: false as const, error: 'Unauthorized' },
+        { status: 401 }
+      ),
+    });
+
+    const selectSpy = jest.spyOn(db, 'select');
+    try {
+      const response = await GET(createRequest(), {
+        params: Promise.resolve({ key: '<null:paid>' }),
+      });
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ success: false, error: 'Unauthorized' });
+      // The route must return the auth-failure response before ever querying
+      // credit_transactions/kilocode_users — not just produce a matching body.
+      expect(selectSpy).not.toHaveBeenCalled();
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+});

--- a/apps/web/src/app/admin/api/credit-categories/[key]/route.ts
+++ b/apps/web/src/app/admin/api/credit-categories/[key]/route.ts
@@ -12,11 +12,14 @@ import type {
 import { toGuiCreditCategory } from '@/lib/PromoCreditCategoryConfig';
 import { promoCreditCategoriesByKey } from '@/lib/promoCreditCategories';
 import { getUserFromAuth } from '@/lib/user/server';
+import type { FailureResult } from '@/lib/maybe-result';
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ key: string }> }
-): Promise<NextResponse<{ error: string } | CreditCategoryUsersApiResponse>> {
+): Promise<
+  NextResponse<FailureResult<string> | { error: string } | CreditCategoryUsersApiResponse>
+> {
   const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
   if (authFailedResponse) {
     return authFailedResponse;

--- a/apps/web/src/app/admin/api/credit-categories/[key]/route.ts
+++ b/apps/web/src/app/admin/api/credit-categories/[key]/route.ts
@@ -11,11 +11,17 @@ import type {
 } from '@/lib/PromoCreditCategoryConfig';
 import { toGuiCreditCategory } from '@/lib/PromoCreditCategoryConfig';
 import { promoCreditCategoriesByKey } from '@/lib/promoCreditCategories';
+import { getUserFromAuth } from '@/lib/user/server';
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ key: string }> }
 ): Promise<NextResponse<{ error: string } | CreditCategoryUsersApiResponse>> {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) {
+    return authFailedResponse;
+  }
+
   const { key } = await params;
   const searchParams = request.nextUrl.searchParams;
   const page = parseInt(searchParams.get('page') || '1');

--- a/apps/web/src/app/admin/api/credit-categories/route.test.ts
+++ b/apps/web/src/app/admin/api/credit-categories/route.test.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/drizzle';
+import { credit_transactions } from '@kilocode/db/schema';
+import { getUserFromAuth } from '@/lib/user/server';
+import { defineTestUser, insertTestUser } from '@/tests/helpers/user.helper';
+import { GET } from './route';
+
+jest.mock('@/lib/user/server', () => ({
+  getUserFromAuth: jest.fn(),
+}));
+
+const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
+
+function createRequest() {
+  return new NextRequest('http://localhost:3000/admin/api/credit-categories');
+}
+
+describe('GET /admin/api/credit-categories', () => {
+  beforeEach(() => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: defineTestUser({ is_admin: true }),
+      authFailedResponse: null,
+    });
+  });
+
+  it('returns credit category stats for a current admin', async () => {
+    const user = await insertTestUser();
+    await db.insert(credit_transactions).values({
+      kilo_user_id: user.id,
+      credit_category: null,
+      amount_microdollars: 1_000_000,
+      is_free: false,
+    });
+
+    const response = await GET(createRequest());
+    expect(response.status).toBe(200);
+    expect(mockedGetUserFromAuth).toHaveBeenCalledWith({ adminOnly: true });
+    const body = await response.json();
+    expect(body).toHaveProperty('creditCategories');
+    expect(Array.isArray(body.creditCategories)).toBe(true);
+  });
+
+  it('rejects the request before touching the database when authorization fails', async () => {
+    const user = await insertTestUser();
+    await db.insert(credit_transactions).values({
+      kilo_user_id: user.id,
+      credit_category: null,
+      amount_microdollars: 1_000_000,
+      is_free: false,
+    });
+
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: null,
+      authFailedResponse: NextResponse.json(
+        { success: false as const, error: 'Unauthorized' },
+        { status: 401 }
+      ),
+    });
+
+    const selectSpy = jest.spyOn(db, 'select');
+    try {
+      const response = await GET(createRequest());
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ success: false, error: 'Unauthorized' });
+      // The route must return the auth-failure response before ever querying
+      // credit_transactions/kilocode_users — not just produce a matching body.
+      expect(selectSpy).not.toHaveBeenCalled();
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+});

--- a/apps/web/src/app/admin/api/credit-categories/route.ts
+++ b/apps/web/src/app/admin/api/credit-categories/route.ts
@@ -9,10 +9,16 @@ import type {
 } from '@/lib/PromoCreditCategoryConfig';
 import { toGuiCreditCategory } from '@/lib/PromoCreditCategoryConfig';
 import { promoCreditCategories, promoCreditCategoriesByKey } from '@/lib/promoCreditCategories';
+import { getUserFromAuth } from '@/lib/user/server';
 
 export async function GET(
   request: NextRequest
-): Promise<NextResponse<CreditCategoriesApiResponse>> {
+): Promise<NextResponse<{ error: string } | CreditCategoriesApiResponse>> {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) {
+    return authFailedResponse;
+  }
+
   const searchParams = request.nextUrl.searchParams;
   const key = searchParams.get('key'); // Filter by specific credit category key
   const oneWeekAgo = new Date();

--- a/apps/web/src/app/admin/api/credit-categories/route.ts
+++ b/apps/web/src/app/admin/api/credit-categories/route.ts
@@ -10,10 +10,11 @@ import type {
 import { toGuiCreditCategory } from '@/lib/PromoCreditCategoryConfig';
 import { promoCreditCategories, promoCreditCategoriesByKey } from '@/lib/promoCreditCategories';
 import { getUserFromAuth } from '@/lib/user/server';
+import type { FailureResult } from '@/lib/maybe-result';
 
 export async function GET(
   request: NextRequest
-): Promise<NextResponse<{ error: string } | CreditCategoriesApiResponse>> {
+): Promise<NextResponse<FailureResult<string> | CreditCategoriesApiResponse>> {
   const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
   if (authFailedResponse) {
     return authFailedResponse;

--- a/apps/web/src/app/admin/components/AppSidebar.tsx
+++ b/apps/web/src/app/admin/components/AppSidebar.tsx
@@ -8,6 +8,7 @@ import {
   Building2,
   Clock,
   Shield,
+  ShieldCheck,
   Ban,
   Database,
   BarChart,
@@ -70,6 +71,11 @@ const userManagementItems: MenuItem[] = [
     title: () => 'Users',
     url: '/admin/users',
     icon: () => <Users />,
+  },
+  {
+    title: () => 'Admins',
+    url: '/admin/admins',
+    icon: () => <ShieldCheck />,
   },
   {
     title: () => 'Organizations',

--- a/apps/web/src/app/admin/components/PlatformAdminsContent.tsx
+++ b/apps/web/src/app/admin/components/PlatformAdminsContent.tsx
@@ -1,0 +1,361 @@
+'use client';
+
+import { useMemo, useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { inferRouterOutputs } from '@trpc/server';
+import { toast } from 'sonner';
+import type { RootRouter } from '@/routers/root-router';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { UserAvatarLink } from './UserAvatarLink';
+import { UserSearchInput } from './UserSearchInput';
+
+type RouterOutputs = inferRouterOutputs<RootRouter>;
+// Both procedures share the same server-side column projection
+// (`platformAdminUserColumns` in admin-router.ts), so their outputs have the
+// same shape; deriving from the roster's output type here means this type
+// can't drift from the server contract the way a hand-copied literal could.
+type PlatformAdminUser = RouterOutputs['admin']['users']['listPlatformAdmins']['admins'][number];
+
+type ConfirmAction =
+  | { type: 'grant'; user: PlatformAdminUser }
+  | { type: 'revoke'; user: PlatformAdminUser };
+
+function AccountStatusBadge({ user }: { user: PlatformAdminUser }) {
+  if (user.blocked_reason) {
+    return <Badge variant="destructive">Blocked</Badge>;
+  }
+  return <Badge variant="secondary">Active</Badge>;
+}
+
+export function PlatformAdminsContent() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+  // Stable focus target for after the confirmation dialog closes. The row that
+  // triggered the dialog (a roster "Revoke" button or a candidate "Grant"
+  // button) is removed from the DOM once the mutation succeeds and the roster/
+  // candidate queries are invalidated, so Radix's default trigger-based focus
+  // restoration has nothing to return focus to and would otherwise fall back
+  // to <body>.
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const trimmedSearchTerm = searchTerm.trim();
+
+  const {
+    data: rosterData,
+    isLoading: isRosterLoading,
+    error: rosterError,
+  } = useQuery(trpc.admin.users.listPlatformAdmins.queryOptions());
+
+  const canGrantAdmins = rosterData?.canGrantAdmins ?? false;
+
+  const { data: candidates, isFetching: isSearching } = useQuery({
+    ...trpc.admin.users.searchPlatformAdminCandidates.queryOptions({ query: trimmedSearchTerm }),
+    enabled: canGrantAdmins && trimmedSearchTerm.length > 0,
+  });
+
+  function invalidateAfterChange() {
+    void queryClient.invalidateQueries({
+      queryKey: trpc.admin.users.listPlatformAdmins.queryKey(),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: trpc.admin.users.searchPlatformAdminCandidates.queryKey(),
+    });
+  }
+
+  const setAccessMutation = useMutation(
+    trpc.admin.users.setPlatformAdminAccess.mutationOptions({
+      onSuccess: (result, variables) => {
+        invalidateAfterChange();
+        setConfirmAction(null);
+        if (!result.changed) {
+          toast.message(
+            variables.isAdmin
+              ? `${result.user.google_user_email} already has platform admin access.`
+              : `${result.user.google_user_email} already does not have platform admin access.`
+          );
+          return;
+        }
+        if (variables.isAdmin) {
+          setSearchTerm('');
+          toast.success(`Granted platform admin access to ${result.user.google_user_email}.`);
+        } else {
+          toast.success(`Revoked platform admin access from ${result.user.google_user_email}.`);
+        }
+      },
+      onError: error => {
+        toast.error(error.message || 'Failed to update platform admin access');
+      },
+    })
+  );
+
+  const pendingUserId =
+    setAccessMutation.isPending && setAccessMutation.variables
+      ? setAccessMutation.variables.userId
+      : null;
+
+  const admins = rosterData?.admins ?? [];
+  const currentUserId = rosterData?.currentUserId;
+
+  const candidateRows = useMemo(() => candidates ?? [], [candidates]);
+
+  function requestRevoke(user: PlatformAdminUser) {
+    setConfirmAction({ type: 'revoke', user });
+  }
+
+  function requestGrant(user: PlatformAdminUser) {
+    setConfirmAction({ type: 'grant', user });
+  }
+
+  function confirmPendingAction() {
+    if (!confirmAction) return;
+    setAccessMutation.mutate({
+      userId: confirmAction.user.id,
+      isAdmin: confirmAction.type === 'grant',
+    });
+  }
+
+  return (
+    <div ref={contentRef} tabIndex={-1} className="flex flex-col gap-y-6 outline-none">
+      <Card>
+        <CardHeader>
+          <CardTitle>Current admins</CardTitle>
+          <CardDescription>
+            Everyone with platform admin access today. Revoking a credit manager also removes
+            credit-management permission.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isRosterLoading ? (
+            <div className="text-muted-foreground py-8 text-center text-sm">Loading admins...</div>
+          ) : rosterError ? (
+            <div className="text-destructive py-8 text-center text-sm">
+              {rosterError.message || 'Failed to load admins'}
+            </div>
+          ) : admins.length === 0 ? (
+            <div className="text-muted-foreground py-8 text-center text-sm">
+              No platform admins found.
+            </div>
+          ) : (
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>User</TableHead>
+                    <TableHead>Hosted domain</TableHead>
+                    <TableHead>Account status</TableHead>
+                    <TableHead>Credit management</TableHead>
+                    <TableHead className="text-right">Action</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {admins.map(admin => (
+                    <TableRow key={admin.id}>
+                      <TableCell>
+                        <UserAvatarLink user={admin} displayFormat="email-name" className="flex" />
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-sm">
+                        {admin.hosted_domain ?? '—'}
+                      </TableCell>
+                      <TableCell>
+                        <AccountStatusBadge user={admin} />
+                      </TableCell>
+                      <TableCell>
+                        {admin.can_manage_credits ? (
+                          <Badge variant="secondary">Credit manager</Badge>
+                        ) : (
+                          <span className="text-muted-foreground text-sm">—</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {admin.id === currentUserId ? (
+                          <span className="text-muted-foreground text-sm">You</span>
+                        ) : (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={pendingUserId === admin.id}
+                            onClick={() => requestRevoke(admin)}
+                          >
+                            Revoke
+                          </Button>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Grant admin access</CardTitle>
+          <CardDescription>
+            {canGrantAdmins
+              ? 'Search registered kilocode.ai users who are not already admins.'
+              : 'Only a qualifying kilocode.ai admin can grant platform admin access. You can still revoke other admins from the roster above.'}
+          </CardDescription>
+        </CardHeader>
+        {canGrantAdmins && (
+          <CardContent className="flex flex-col gap-4">
+            <UserSearchInput
+              value={searchTerm}
+              onChange={setSearchTerm}
+              isLoading={isSearching}
+              placeholder="Search by email or name..."
+            />
+
+            {trimmedSearchTerm.length === 0 ? (
+              <div className="text-muted-foreground py-4 text-center text-sm">
+                Enter an email or name to search for eligible users.
+              </div>
+            ) : candidateRows.length === 0 && !isSearching ? (
+              <div className="text-muted-foreground py-4 text-center text-sm">
+                No eligible kilocode.ai users matched that search.
+              </div>
+            ) : (
+              <div className="rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>User</TableHead>
+                      <TableHead>Hosted domain</TableHead>
+                      <TableHead>Account status</TableHead>
+                      <TableHead className="text-right">Action</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {candidateRows.map(candidate => (
+                      <TableRow key={candidate.id}>
+                        <TableCell>
+                          <UserAvatarLink
+                            user={candidate}
+                            displayFormat="email-name"
+                            className="flex"
+                          />
+                        </TableCell>
+                        <TableCell className="text-muted-foreground text-sm">
+                          {candidate.hosted_domain ?? '—'}
+                        </TableCell>
+                        <TableCell>
+                          <AccountStatusBadge user={candidate} />
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Button
+                            size="sm"
+                            disabled={pendingUserId === candidate.id}
+                            onClick={() => requestGrant(candidate)}
+                          >
+                            Grant
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        )}
+      </Card>
+
+      <Dialog
+        open={confirmAction !== null}
+        onOpenChange={open => {
+          // Ignore Escape/backdrop/close-button dismissal while a mutation is
+          // in flight: this is the single mutation shared by every row in both
+          // tables, so letting the dialog close mid-request would let an admin
+          // open a second confirmation for a different user before the first
+          // request resolves, defeating the "one action at a time" intent of
+          // `pendingUserId`-based row disabling below.
+          if (!open && !setAccessMutation.isPending) {
+            setConfirmAction(null);
+          }
+        }}
+      >
+        <DialogContent
+          showCloseButton={!setAccessMutation.isPending}
+          onCloseAutoFocus={event => {
+            // The row that triggered this dialog is gone by the time it closes
+            // (see `contentRef` above); redirect focus there instead of letting
+            // Radix's default trigger-focus restoration fall back to <body>.
+            event.preventDefault();
+            contentRef.current?.focus();
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>
+              {confirmAction
+                ? confirmAction.type === 'grant'
+                  ? 'Grant platform admin access'
+                  : 'Revoke platform admin access'
+                : ''}
+            </DialogTitle>
+            <DialogDescription>
+              {confirmAction && confirmAction.type === 'grant' ? (
+                <>
+                  Are you sure you want to grant platform admin access to{' '}
+                  <span className="font-medium">{confirmAction.user.google_user_email}</span>? This
+                  will not grant credit-management permission. Their current browser sessions will
+                  be signed out.
+                </>
+              ) : confirmAction ? (
+                <>
+                  Are you sure you want to revoke platform admin access from{' '}
+                  <span className="font-medium">{confirmAction.user.google_user_email}</span>? Their
+                  current browser sessions will be signed out.
+                  {confirmAction.user.can_manage_credits && (
+                    <> Credit-management permission will also be removed.</>
+                  )}
+                </>
+              ) : null}
+            </DialogDescription>
+          </DialogHeader>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline" disabled={setAccessMutation.isPending}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              variant={confirmAction?.type === 'revoke' ? 'destructive' : 'default'}
+              onClick={confirmPendingAction}
+              disabled={setAccessMutation.isPending}
+            >
+              {setAccessMutation.isPending
+                ? 'Saving...'
+                : confirmAction?.type === 'grant'
+                  ? 'Grant Access'
+                  : 'Revoke Access'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/components/PlatformAdminsContent.tsx
+++ b/apps/web/src/app/admin/components/PlatformAdminsContent.tsx
@@ -53,15 +53,14 @@ export function PlatformAdminsContent() {
   const queryClient = useQueryClient();
   const [searchTerm, setSearchTerm] = useState('');
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
-  // Stable focus target for the case where the confirmation dialog closes
-  // because its mutation succeeded: the row that triggered it (a roster
-  // "Revoke" or candidate "Grant" button) is removed from the DOM once the
-  // roster/candidate queries are invalidated, so Radix's default trigger-based
-  // focus restoration has nothing to return to and would fall back to <body>.
-  // On a plain cancel/Escape/close-button dismissal the trigger still exists,
-  // so we let Radix restore focus to it normally (see onCloseAutoFocus below).
+  // The dialog is controlled and has no DialogTrigger, so Radix has no trigger
+  // ref to restore focus to on close and would leave focus on <body>. We track
+  // the element that opened the dialog (the clicked Grant/Revoke button) and
+  // restore focus to it if it's still connected — which it is for a plain
+  // cancel/Escape/close-button dismissal. On a state-changing mutation that
+  // row is unmounted, so we fall back to a stable container instead.
   const contentRef = useRef<HTMLDivElement>(null);
-  const redirectFocusOnCloseRef = useRef(false);
+  const openerRef = useRef<HTMLElement | null>(null);
 
   const trimmedSearchTerm = searchTerm.trim();
 
@@ -96,11 +95,6 @@ export function PlatformAdminsContent() {
     trpc.admin.users.setPlatformAdminAccess.mutationOptions({
       onSuccess: (result, variables) => {
         invalidateAfterChange();
-        // A changed result removes the triggering row from its table, so the
-        // dialog's close should redirect focus to a stable element rather than
-        // a now-unmounted trigger. A no-op leaves the trigger in place, so let
-        // Radix restore focus to it as usual.
-        redirectFocusOnCloseRef.current = result.changed;
         setConfirmAction(null);
         if (!result.changed) {
           toast.message(
@@ -133,11 +127,13 @@ export function PlatformAdminsContent() {
 
   const candidateRows = useMemo(() => candidates ?? [], [candidates]);
 
-  function requestRevoke(user: PlatformAdminUser) {
+  function requestRevoke(user: PlatformAdminUser, event: React.MouseEvent<HTMLButtonElement>) {
+    openerRef.current = event.currentTarget;
     setConfirmAction({ type: 'revoke', user });
   }
 
-  function requestGrant(user: PlatformAdminUser) {
+  function requestGrant(user: PlatformAdminUser, event: React.MouseEvent<HTMLButtonElement>) {
+    openerRef.current = event.currentTarget;
     setConfirmAction({ type: 'grant', user });
   }
 
@@ -209,7 +205,7 @@ export function PlatformAdminsContent() {
                             size="sm"
                             variant="outline"
                             disabled={pendingUserId === admin.id}
-                            onClick={() => requestRevoke(admin)}
+                            onClick={event => requestRevoke(admin, event)}
                           >
                             Revoke
                           </Button>
@@ -247,8 +243,14 @@ export function PlatformAdminsContent() {
                 onChange={setSearchTerm}
                 isLoading={isSearching}
                 placeholder="Search by email or name..."
-                aria-label="Search for a kilocode.ai user to grant platform admin access"
+                aria-describedby="platform-admin-candidate-search-hint"
               />
+              <p
+                id="platform-admin-candidate-search-hint"
+                className="text-muted-foreground text-xs"
+              >
+                Only registered kilocode.ai users who are not already admins can be granted access.
+              </p>
             </div>
 
             {trimmedSearchTerm.length === 0 ? (
@@ -296,7 +298,7 @@ export function PlatformAdminsContent() {
                           <Button
                             size="sm"
                             disabled={pendingUserId === candidate.id}
-                            onClick={() => requestGrant(candidate)}
+                            onClick={event => requestGrant(candidate, event)}
                           >
                             Grant
                           </Button>
@@ -328,16 +330,18 @@ export function PlatformAdminsContent() {
         <DialogContent
           showCloseButton={!setAccessMutation.isPending}
           onCloseAutoFocus={event => {
-            // Only override Radix's focus restoration when the close was caused
-            // by a state-changing mutation that removed the triggering row (see
-            // `redirectFocusOnCloseRef`). For a plain cancel/Escape/close-button
-            // dismissal the trigger still exists, so let Radix return focus to
-            // it instead of stealing focus to the container.
-            if (redirectFocusOnCloseRef.current) {
-              event.preventDefault();
+            // Controlled dialog with no DialogTrigger: Radix can't restore focus
+            // on its own. Return focus to the opener button if it's still in the
+            // DOM (cancel/Escape/close-button paths), otherwise fall back to the
+            // stable container (the opener row was unmounted by a state change).
+            event.preventDefault();
+            const opener = openerRef.current;
+            if (opener && opener.isConnected) {
+              opener.focus();
+            } else {
               contentRef.current?.focus();
-              redirectFocusOnCloseRef.current = false;
             }
+            openerRef.current = null;
           }}
         >
           <DialogHeader>

--- a/apps/web/src/app/admin/components/PlatformAdminsContent.tsx
+++ b/apps/web/src/app/admin/components/PlatformAdminsContent.tsx
@@ -56,11 +56,19 @@ export function PlatformAdminsContent() {
   // The dialog is controlled and has no DialogTrigger, so Radix has no trigger
   // ref to restore focus to on close and would leave focus on <body>. We track
   // the element that opened the dialog (the clicked Grant/Revoke button) and
-  // restore focus to it if it's still connected — which it is for a plain
-  // cancel/Escape/close-button dismissal. On a state-changing mutation that
-  // row is unmounted, so we fall back to a stable container instead.
+  // restore focus to it on cancel/Escape/close-button/no-op closes.
+  //
+  // For a state-changing mutation we must NOT rely on `opener.isConnected` at
+  // close time: onCloseAutoFocus fires right after the ~200ms Radix close
+  // animation, but the opener row only unmounts once the invalidated queries
+  // refetch (a network round trip that typically outlasts the animation). So
+  // the opener is usually still connected at close time, we'd focus it, and
+  // then the later refetch would drop focus to <body>. Instead we decide
+  // deterministically in onSuccess: a changed result means the row is going
+  // away, so redirect focus to the stable container.
   const contentRef = useRef<HTMLDivElement>(null);
   const openerRef = useRef<HTMLElement | null>(null);
+  const redirectFocusToContainerRef = useRef(false);
 
   const trimmedSearchTerm = searchTerm.trim();
 
@@ -95,6 +103,10 @@ export function PlatformAdminsContent() {
     trpc.admin.users.setPlatformAdminAccess.mutationOptions({
       onSuccess: (result, variables) => {
         invalidateAfterChange();
+        // A changed result unmounts the opener row once the refetch settles, so
+        // send focus to the stable container rather than the doomed button. A
+        // no-op leaves the row in place, so keep focus on the opener.
+        redirectFocusToContainerRef.current = result.changed;
         setConfirmAction(null);
         if (!result.changed) {
           toast.message(
@@ -331,17 +343,20 @@ export function PlatformAdminsContent() {
           showCloseButton={!setAccessMutation.isPending}
           onCloseAutoFocus={event => {
             // Controlled dialog with no DialogTrigger: Radix can't restore focus
-            // on its own. Return focus to the opener button if it's still in the
-            // DOM (cancel/Escape/close-button paths), otherwise fall back to the
-            // stable container (the opener row was unmounted by a state change).
+            // on its own. A state-changing mutation (flagged deterministically in
+            // onSuccess) will unmount the opener row after its refetch settles, so
+            // send focus to the stable container. Otherwise (cancel/Escape/close/
+            // no-op) the opener still exists — restore focus to it, falling back
+            // to the container only if it has somehow already been removed.
             event.preventDefault();
             const opener = openerRef.current;
-            if (opener && opener.isConnected) {
-              opener.focus();
-            } else {
+            if (redirectFocusToContainerRef.current || !opener || !opener.isConnected) {
               contentRef.current?.focus();
+            } else {
+              opener.focus();
             }
             openerRef.current = null;
+            redirectFocusToContainerRef.current = false;
           }}
         >
           <DialogHeader>

--- a/apps/web/src/app/admin/components/PlatformAdminsContent.tsx
+++ b/apps/web/src/app/admin/components/PlatformAdminsContent.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
 import {
   Dialog,
   DialogClose,
@@ -52,13 +53,15 @@ export function PlatformAdminsContent() {
   const queryClient = useQueryClient();
   const [searchTerm, setSearchTerm] = useState('');
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
-  // Stable focus target for after the confirmation dialog closes. The row that
-  // triggered the dialog (a roster "Revoke" button or a candidate "Grant"
-  // button) is removed from the DOM once the mutation succeeds and the roster/
-  // candidate queries are invalidated, so Radix's default trigger-based focus
-  // restoration has nothing to return focus to and would otherwise fall back
-  // to <body>.
+  // Stable focus target for the case where the confirmation dialog closes
+  // because its mutation succeeded: the row that triggered it (a roster
+  // "Revoke" or candidate "Grant" button) is removed from the DOM once the
+  // roster/candidate queries are invalidated, so Radix's default trigger-based
+  // focus restoration has nothing to return to and would fall back to <body>.
+  // On a plain cancel/Escape/close-button dismissal the trigger still exists,
+  // so we let Radix restore focus to it normally (see onCloseAutoFocus below).
   const contentRef = useRef<HTMLDivElement>(null);
+  const redirectFocusOnCloseRef = useRef(false);
 
   const trimmedSearchTerm = searchTerm.trim();
 
@@ -70,7 +73,12 @@ export function PlatformAdminsContent() {
 
   const canGrantAdmins = rosterData?.canGrantAdmins ?? false;
 
-  const { data: candidates, isFetching: isSearching } = useQuery({
+  const {
+    data: candidates,
+    isFetching: isSearching,
+    isError: isSearchError,
+    error: searchError,
+  } = useQuery({
     ...trpc.admin.users.searchPlatformAdminCandidates.queryOptions({ query: trimmedSearchTerm }),
     enabled: canGrantAdmins && trimmedSearchTerm.length > 0,
   });
@@ -88,6 +96,11 @@ export function PlatformAdminsContent() {
     trpc.admin.users.setPlatformAdminAccess.mutationOptions({
       onSuccess: (result, variables) => {
         invalidateAfterChange();
+        // A changed result removes the triggering row from its table, so the
+        // dialog's close should redirect focus to a stable element rather than
+        // a now-unmounted trigger. A no-op leaves the trigger in place, so let
+        // Radix restore focus to it as usual.
+        redirectFocusOnCloseRef.current = result.changed;
         setConfirmAction(null);
         if (!result.changed) {
           toast.message(
@@ -215,23 +228,38 @@ export function PlatformAdminsContent() {
         <CardHeader>
           <CardTitle>Grant admin access</CardTitle>
           <CardDescription>
-            {canGrantAdmins
-              ? 'Search registered kilocode.ai users who are not already admins.'
-              : 'Only a qualifying kilocode.ai admin can grant platform admin access. You can still revoke other admins from the roster above.'}
+            {isRosterLoading
+              ? 'Checking your permissions…'
+              : rosterError
+                ? 'Could not determine your permissions. Reload to try again.'
+                : canGrantAdmins
+                  ? 'Search registered kilocode.ai users who are not already admins.'
+                  : 'Only a qualifying kilocode.ai admin can grant platform admin access. You can still revoke other admins from the roster above.'}
           </CardDescription>
         </CardHeader>
-        {canGrantAdmins && (
+        {!isRosterLoading && !rosterError && canGrantAdmins && (
           <CardContent className="flex flex-col gap-4">
-            <UserSearchInput
-              value={searchTerm}
-              onChange={setSearchTerm}
-              isLoading={isSearching}
-              placeholder="Search by email or name..."
-            />
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="platform-admin-candidate-search">Search for a user to grant</Label>
+              <UserSearchInput
+                id="platform-admin-candidate-search"
+                value={searchTerm}
+                onChange={setSearchTerm}
+                isLoading={isSearching}
+                placeholder="Search by email or name..."
+                aria-label="Search for a kilocode.ai user to grant platform admin access"
+              />
+            </div>
 
             {trimmedSearchTerm.length === 0 ? (
               <div className="text-muted-foreground py-4 text-center text-sm">
                 Enter an email or name to search for eligible users.
+              </div>
+            ) : isSearchError ? (
+              <div className="text-destructive py-4 text-center text-sm">
+                {searchError instanceof Error
+                  ? searchError.message
+                  : 'Something went wrong while searching. Try again.'}
               </div>
             ) : candidateRows.length === 0 && !isSearching ? (
               <div className="text-muted-foreground py-4 text-center text-sm">
@@ -300,11 +328,16 @@ export function PlatformAdminsContent() {
         <DialogContent
           showCloseButton={!setAccessMutation.isPending}
           onCloseAutoFocus={event => {
-            // The row that triggered this dialog is gone by the time it closes
-            // (see `contentRef` above); redirect focus there instead of letting
-            // Radix's default trigger-focus restoration fall back to <body>.
-            event.preventDefault();
-            contentRef.current?.focus();
+            // Only override Radix's focus restoration when the close was caused
+            // by a state-changing mutation that removed the triggering row (see
+            // `redirectFocusOnCloseRef`). For a plain cancel/Escape/close-button
+            // dismissal the trigger still exists, so let Radix return focus to
+            // it instead of stealing focus to the container.
+            if (redirectFocusOnCloseRef.current) {
+              event.preventDefault();
+              contentRef.current?.focus();
+              redirectFocusOnCloseRef.current = false;
+            }
           }}
         >
           <DialogHeader>

--- a/apps/web/src/app/admin/components/UserSearchInput.tsx
+++ b/apps/web/src/app/admin/components/UserSearchInput.tsx
@@ -12,8 +12,14 @@ interface UserSearchInputProps {
   placeholder?: string;
   /** Forwarded to the underlying input so a visible <Label htmlFor> can bind to it. */
   id?: string;
-  /** Accessible name for the input. Falls back to the placeholder text. */
+  /**
+   * Explicit accessible name. Only pass this when there is no visible
+   * <Label htmlFor>, since aria-label overrides an associated label. When
+   * neither is provided the placeholder is used as a last-resort name.
+   */
   'aria-label'?: string;
+  /** Forwarded to the input so helper text can be associated for screen readers. */
+  'aria-describedby'?: string;
 }
 
 export function UserSearchInput({
@@ -23,7 +29,12 @@ export function UserSearchInput({
   placeholder = 'Search by email...',
   id,
   'aria-label': ariaLabel,
+  'aria-describedby': ariaDescribedby,
 }: UserSearchInputProps) {
+  // Don't let the placeholder fall back into aria-label when the input is
+  // bound to a visible <Label htmlFor id> — that would override the visible
+  // label's text as the accessible name.
+  const resolvedAriaLabel = ariaLabel ?? (id ? undefined : placeholder);
   const [localValue, setLocalValue] = useState(value);
 
   // Update local value when prop value changes
@@ -64,7 +75,8 @@ export function UserSearchInput({
           id={id}
           type="text"
           placeholder={placeholder}
-          aria-label={ariaLabel ?? placeholder}
+          aria-label={resolvedAriaLabel}
+          aria-describedby={ariaDescribedby}
           value={localValue}
           onChange={e => setLocalValue(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/apps/web/src/app/admin/components/UserSearchInput.tsx
+++ b/apps/web/src/app/admin/components/UserSearchInput.tsx
@@ -10,6 +10,10 @@ interface UserSearchInputProps {
   onChange: (value: string) => void;
   isLoading?: boolean;
   placeholder?: string;
+  /** Forwarded to the underlying input so a visible <Label htmlFor> can bind to it. */
+  id?: string;
+  /** Accessible name for the input. Falls back to the placeholder text. */
+  'aria-label'?: string;
 }
 
 export function UserSearchInput({
@@ -17,6 +21,8 @@ export function UserSearchInput({
   onChange,
   isLoading = false,
   placeholder = 'Search by email...',
+  id,
+  'aria-label': ariaLabel,
 }: UserSearchInputProps) {
   const [localValue, setLocalValue] = useState(value);
 
@@ -55,8 +61,10 @@ export function UserSearchInput({
       <div className="relative">
         <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
         <Input
+          id={id}
           type="text"
           placeholder={placeholder}
+          aria-label={ariaLabel ?? placeholder}
           value={localValue}
           onChange={e => setLocalValue(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/apps/web/src/app/admin/credit-categories/[key]/CreditCategoryStats.tsx
+++ b/apps/web/src/app/admin/credit-categories/[key]/CreditCategoryStats.tsx
@@ -16,18 +16,44 @@ const fetchCreditCategoryStats = async (
   const response = await fetch(
     `/admin/api/credit-categories?key=${encodeURIComponent(creditCategoryKey)}`
   );
-  const data: CreditCategoriesApiResponse = await response.json();
 
+  // The endpoint can return an auth-failure body (e.g. expired/revoked admin
+  // access), so don't treat every JSON payload as the success contract.
+  if (!response.ok) {
+    throw new Error(
+      response.status === 401 || response.status === 403
+        ? 'You no longer have access to credit category statistics.'
+        : 'Failed to load credit category statistics.'
+    );
+  }
+
+  const data: CreditCategoriesApiResponse = await response.json();
   return data.creditCategories.length === 1 ? data.creditCategories[0] : null;
 };
 
 export function CreditCategoryStats({ creditCategoryKey }: CreditCategoryStatsProps) {
-  const { data: stats, isLoading } = useQuery({
+  const {
+    data: stats,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
     queryKey: ['credit-category-stats', creditCategoryKey],
     queryFn: () => fetchCreditCategoryStats(creditCategoryKey),
   });
 
   const valueClassName = isLoading ? 'bg-muted h-6 animate-pulse rounded' : 'text-2xl font-bold';
+
+  if (isError) {
+    return (
+      <div>
+        <h2 className="text-xl font-semibold">Credit category usage statistics</h2>
+        <p className="text-destructive mt-2 text-sm">
+          {error instanceof Error ? error.message : 'Failed to load credit category statistics.'}
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/apps/web/src/lib/admin/platform-admin.test.ts
+++ b/apps/web/src/lib/admin/platform-admin.test.ts
@@ -1,0 +1,65 @@
+import { isEligibleForPlatformAdmin, shouldAutoProvisionPlatformAdmin } from './platform-admin';
+
+describe('isEligibleForPlatformAdmin', () => {
+  it('is eligible for an exact lowercase kilocode.ai email and hosted domain', () => {
+    expect(isEligibleForPlatformAdmin('person@kilocode.ai', 'kilocode.ai')).toBe(true);
+  });
+
+  it('is not eligible when the hosted domain is a personal/provider placeholder', () => {
+    expect(isEligibleForPlatformAdmin('person@kilocode.ai', '@@personal@@')).toBe(false);
+  });
+
+  it('is not eligible when the hosted domain is null', () => {
+    expect(isEligibleForPlatformAdmin('person@kilocode.ai', null)).toBe(false);
+  });
+
+  it('is not eligible when the hosted domain matches but the email is not a kilocode.ai email', () => {
+    expect(isEligibleForPlatformAdmin('person@example.com', 'kilocode.ai')).toBe(false);
+  });
+
+  it('is not eligible for uppercase email variants', () => {
+    expect(isEligibleForPlatformAdmin('Person@Kilocode.ai', 'kilocode.ai')).toBe(false);
+  });
+
+  it('is not eligible for uppercase hosted domain variants', () => {
+    expect(isEligibleForPlatformAdmin('person@kilocode.ai', 'Kilocode.ai')).toBe(false);
+  });
+
+  it('is not eligible for a subdomain lookalike', () => {
+    expect(isEligibleForPlatformAdmin('person@sub.kilocode.ai', 'kilocode.ai')).toBe(false);
+  });
+
+  it('is not eligible for a registrable-parent-domain lookalike', () => {
+    expect(isEligibleForPlatformAdmin('person@notkilocode.ai', 'kilocode.ai')).toBe(false);
+  });
+
+  it('is not eligible for a fake-login hosted domain even with a kilocode.ai email', () => {
+    expect(isEligibleForPlatformAdmin('person@kilocode.ai', '@@fake@@')).toBe(false);
+  });
+});
+
+describe('shouldAutoProvisionPlatformAdmin', () => {
+  it('auto-provisions a fake-login admin.example.com user when fake login is enabled', () => {
+    expect(shouldAutoProvisionPlatformAdmin('someone@admin.example.com', '@@fake@@', true)).toBe(
+      true
+    );
+  });
+
+  it('does not auto-provision when fake login is disabled', () => {
+    expect(shouldAutoProvisionPlatformAdmin('someone@admin.example.com', '@@fake@@', false)).toBe(
+      false
+    );
+  });
+
+  it('does not auto-provision when the hosted domain is not the fake-login domain', () => {
+    expect(shouldAutoProvisionPlatformAdmin('someone@admin.example.com', null, true)).toBe(false);
+  });
+
+  it('does not auto-provision a fake-login user with a non-admin email', () => {
+    expect(shouldAutoProvisionPlatformAdmin('someone@example.com', '@@fake@@', true)).toBe(false);
+  });
+
+  it('never auto-provisions a real production kilocode.ai user, even when fake login is enabled', () => {
+    expect(shouldAutoProvisionPlatformAdmin('person@kilocode.ai', 'kilocode.ai', true)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/admin/platform-admin.ts
+++ b/apps/web/src/lib/admin/platform-admin.ts
@@ -1,0 +1,42 @@
+import 'server-only';
+
+import { hosted_domain_specials } from '@/lib/auth/constants';
+
+/**
+ * Exact eligibility rule for the Kilo production platform-admin domain.
+ *
+ * This intentionally preserves current case-sensitive behavior: the hosted
+ * domain must equal `kilocode.ai` exactly and the email must end with
+ * `@kilocode.ai` exactly. It does not broaden matching to uppercase
+ * variants, subdomains, or registrable parent domains.
+ *
+ * Used both to gate the production auto-provisioning rule (historically)
+ * and, going forward, to gate manual grant/revoke eligibility and candidate
+ * search for the `/admin/admins` page. Search filtering is not a security
+ * boundary — callers performing a grant must re-check this themselves
+ * against freshly loaded rows.
+ */
+export function isEligibleForPlatformAdmin(email: string, hostedDomain: string | null): boolean {
+  return (
+    hostedDomain === hosted_domain_specials.kilocode_admin &&
+    email.endsWith('@' + hosted_domain_specials.kilocode_admin)
+  );
+}
+
+/**
+ * Fake-login-only automatic admin bootstrap rule for ephemeral development
+ * and staging environments. Production auto-provisioning was removed; new
+ * production users always start as non-admin and must be granted access
+ * explicitly through `/admin/admins`.
+ */
+export function shouldAutoProvisionPlatformAdmin(
+  email: string,
+  hostedDomain: string | null,
+  fakeLoginEnabled: boolean
+): boolean {
+  return (
+    fakeLoginEnabled &&
+    hostedDomain === hosted_domain_specials.fake_devonly &&
+    email.endsWith('@admin.example.com')
+  );
+}

--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -285,6 +285,25 @@ describe('User', () => {
       );
     });
 
+    it('does not auto-provision admin access for a new production-shaped @kilocode.ai signup', async () => {
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'new-admin-candidate@kilocode.ai',
+          google_user_name: 'New Admin Candidate',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: 'kilocode.ai',
+          provider: 'google',
+          provider_account_id: 'google-new-admin-candidate',
+        },
+        undefined,
+        false
+      );
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.user.is_admin).toBe(false);
+    });
+
     it('rejects new signups after the per-IP burst threshold (100/24h)', async () => {
       const signupIp = '203.0.113.50';
       for (let i = 1; i <= 100; i++) {

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -98,7 +98,7 @@ import {
 import { eq, and, inArray, isNotNull, isNull, sql, or, gte, count } from 'drizzle-orm';
 import { allow_fake_login, IS_DEVELOPMENT } from '@/lib/constants';
 import type { AuthErrorType } from '@/lib/auth/constants';
-import { hosted_domain_specials } from '@/lib/auth/constants';
+import { shouldAutoProvisionPlatformAdmin } from '@/lib/admin/platform-admin';
 import { strict as assert } from 'node:assert';
 import type { OptionalError, Result } from '@/lib/maybe-result';
 import { failureResult, successResult, trpcFailure } from '@/lib/maybe-result';
@@ -242,21 +242,6 @@ async function checkNormalizedEmailUnique(
   });
 
   return failureResult('EMAIL-ALREADY-USED');
-}
-
-/**
- * Determines if a user should have admin privileges based on their email and hosted domain.
- * Centralized logic ensures all auth providers (Google, magic link, GitHub, etc.) get
- * consistent admin status based on the same rules.
- */
-function shouldBeAdmin(email: string, hosted_domain: string | null): boolean {
-  return (
-    (hosted_domain === hosted_domain_specials.kilocode_admin &&
-      email.endsWith('@' + hosted_domain_specials.kilocode_admin)) ||
-    (allow_fake_login &&
-      hosted_domain === hosted_domain_specials.fake_devonly &&
-      email.endsWith('@admin.example.com'))
-  );
 }
 
 export type CreateOrUpdateUserArgs = {
@@ -644,7 +629,11 @@ export async function createOrUpdateUser(
     google_user_name: args.google_user_name,
     google_user_image_url: args.google_user_image_url,
     hosted_domain: args.hosted_domain,
-    is_admin: shouldBeAdmin(args.google_user_email, args.hosted_domain),
+    is_admin: shouldAutoProvisionPlatformAdmin(
+      args.google_user_email,
+      args.hosted_domain,
+      allow_fake_login
+    ),
     stripe_customer_id: stripeCustomer.id,
     signup_ip: signupIp,
     openrouter_upstream_safety_identifier: generateOpenRouterUpstreamSafetyIdentifier(newUserId),

--- a/apps/web/src/lib/user/server.test.ts
+++ b/apps/web/src/lib/user/server.test.ts
@@ -17,10 +17,11 @@ import {
   getUserFromAuth,
 } from './server';
 import { db } from '@/lib/drizzle';
-import { organization_seats_purchases, organizations } from '@kilocode/db/schema';
+import { kilocode_users, organization_seats_purchases, organizations } from '@kilocode/db/schema';
 import type { Organization, User } from '@kilocode/db/schema';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
 import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createCallerForUser } from '@/routers/test-utils';
 import { generateApiToken } from '@/lib/tokens';
 import { eq } from 'drizzle-orm';
 import { v5 as uuidv5 } from 'uuid';
@@ -445,6 +446,45 @@ describe('getUserFromAuth', () => {
 
     expect(result.authFailedResponse).toBeNull();
     expect(result.user?.id).toBe(user.id);
+  });
+
+  test('an API token minted before a platform-admin grant cannot reach admin-only paths afterward', async () => {
+    // Regression: granting platform admin rotates api_token_pepper, so a
+    // bearer token issued while the user was non-admin must stop working
+    // rather than silently becoming admin-capable.
+    const grantingAdmin = await insertTestUser({
+      google_user_email: `granting-admin-${crypto.randomUUID()}@kilocode.ai`,
+      hosted_domain: 'kilocode.ai',
+      is_admin: true,
+    });
+    const target = await insertTestUser({
+      google_user_email: `grant-target-${crypto.randomUUID()}@kilocode.ai`,
+      hosted_domain: 'kilocode.ai',
+      is_admin: false,
+      api_token_pepper: 'pre-grant-pepper',
+    });
+
+    const preGrantToken = generateApiToken(target);
+    mockHeaders.mockResolvedValue(new Headers({ Authorization: `Bearer ${preGrantToken}` }));
+
+    // Before the grant the token is valid but non-admin: an admin-only check fails.
+    const beforeGrant = await getUserFromAuth({ adminOnly: true });
+    expect(beforeGrant.authFailedResponse).not.toBeNull();
+
+    const caller = await createCallerForUser(grantingAdmin.id);
+    await caller.admin.users.setPlatformAdminAccess({ userId: target.id, isAdmin: true });
+
+    const rotated = await db.query.kilocode_users.findFirst({
+      where: eq(kilocode_users.id, target.id),
+    });
+    expect(rotated?.is_admin).toBe(true);
+    expect(rotated?.api_token_pepper).not.toBe('pre-grant-pepper');
+
+    // The pre-grant token now carries a stale pepper and must be rejected —
+    // it must NOT be silently upgraded to admin-capable.
+    const afterGrant = await getUserFromAuth({ adminOnly: true });
+    expect(afterGrant.authFailedResponse).not.toBeNull();
+    expect(afterGrant.user).toBeNull();
   });
 });
 

--- a/apps/web/src/routers/admin-platform-admins.test.ts
+++ b/apps/web/src/routers/admin-platform-admins.test.ts
@@ -271,6 +271,28 @@ describe('admin.users.setPlatformAdminAccess — grant', () => {
     expect(notes).toHaveLength(1);
   });
 
+  test('a redundant grant against an already-admin, ineligible (grandfathered) target is a no-op, not FORBIDDEN', async () => {
+    const admin = await insertQualifyingAdmin();
+    const grandfatheredTarget = await insertGrandfatheredAdmin({
+      web_session_pepper: 'before-redundant-grant-pepper',
+    });
+    const caller = await createCallerForUser(admin.id);
+
+    const result = await caller.admin.users.setPlatformAdminAccess({
+      userId: grandfatheredTarget.id,
+      isAdmin: true,
+    });
+
+    expect(result.changed).toBe(false);
+
+    const unchanged = await getUser(grandfatheredTarget.id);
+    expect(unchanged.is_admin).toBe(true);
+    expect(unchanged.web_session_pepper).toBe('before-redundant-grant-pepper');
+
+    const notes = await getUserAdminNotes(grandfatheredTarget.id);
+    expect(notes).toHaveLength(0);
+  });
+
   test('non-admin callers cannot grant', async () => {
     const nonAdmin = await insertTestUser({ is_admin: false });
     const target = await insertEligibleCandidate();

--- a/apps/web/src/routers/admin-platform-admins.test.ts
+++ b/apps/web/src/routers/admin-platform-admins.test.ts
@@ -196,7 +196,10 @@ describe('admin.users.searchPlatformAdminCandidates', () => {
 describe('admin.users.setPlatformAdminAccess — grant', () => {
   test('a qualifying admin can grant an eligible target', async () => {
     const admin = await insertQualifyingAdmin();
-    const target = await insertEligibleCandidate({ web_session_pepper: 'before-grant-pepper' });
+    const target = await insertEligibleCandidate({
+      web_session_pepper: 'before-grant-pepper',
+      api_token_pepper: 'before-grant-api-pepper',
+    });
     const caller = await createCallerForUser(admin.id);
 
     const result = await caller.admin.users.setPlatformAdminAccess({
@@ -212,6 +215,9 @@ describe('admin.users.setPlatformAdminAccess — grant', () => {
     // Grant sets only is_admin — can_manage_credits must remain untouched.
     expect(updated.can_manage_credits).toBe(false);
     expect(updated.web_session_pepper).not.toBe('before-grant-pepper');
+    // Grant must rotate api_token_pepper so pre-grant bearer tokens can't
+    // inherit admin capability.
+    expect(updated.api_token_pepper).not.toBe('before-grant-api-pepper');
 
     const notes = await getUserAdminNotes(target.id);
     expect(notes).toHaveLength(1);
@@ -266,6 +272,7 @@ describe('admin.users.setPlatformAdminAccess — grant', () => {
 
     const afterSecondGrant = await getUser(target.id);
     expect(afterSecondGrant.web_session_pepper).toBe(afterFirstGrant.web_session_pepper);
+    expect(afterSecondGrant.api_token_pepper).toBe(afterFirstGrant.api_token_pepper);
 
     const notes = await getUserAdminNotes(target.id);
     expect(notes).toHaveLength(1);
@@ -275,6 +282,7 @@ describe('admin.users.setPlatformAdminAccess — grant', () => {
     const admin = await insertQualifyingAdmin();
     const grandfatheredTarget = await insertGrandfatheredAdmin({
       web_session_pepper: 'before-redundant-grant-pepper',
+      api_token_pepper: 'before-redundant-grant-api-pepper',
     });
     const caller = await createCallerForUser(admin.id);
 
@@ -288,6 +296,7 @@ describe('admin.users.setPlatformAdminAccess — grant', () => {
     const unchanged = await getUser(grandfatheredTarget.id);
     expect(unchanged.is_admin).toBe(true);
     expect(unchanged.web_session_pepper).toBe('before-redundant-grant-pepper');
+    expect(unchanged.api_token_pepper).toBe('before-redundant-grant-api-pepper');
 
     const notes = await getUserAdminNotes(grandfatheredTarget.id);
     expect(notes).toHaveLength(0);
@@ -322,6 +331,7 @@ describe('admin.users.setPlatformAdminAccess — revoke', () => {
     const target = await insertQualifyingAdmin({
       can_manage_credits: true,
       web_session_pepper: 'before-revoke-pepper',
+      api_token_pepper: 'before-revoke-api-pepper',
     });
     const caller = await createCallerForUser(admin.id);
 
@@ -336,6 +346,9 @@ describe('admin.users.setPlatformAdminAccess — revoke', () => {
     expect(updated.is_admin).toBe(false);
     expect(updated.can_manage_credits).toBe(false);
     expect(updated.web_session_pepper).not.toBe('before-revoke-pepper');
+    // Revoke must rotate api_token_pepper so pre-revoke bearer tokens lose
+    // their admin capability immediately.
+    expect(updated.api_token_pepper).not.toBe('before-revoke-api-pepper');
 
     const notes = await getUserAdminNotes(target.id);
     expect(notes).toHaveLength(1);

--- a/apps/web/src/routers/admin-platform-admins.test.ts
+++ b/apps/web/src/routers/admin-platform-admins.test.ts
@@ -1,0 +1,424 @@
+import { describe, test, expect } from '@jest/globals';
+import { eq, and } from 'drizzle-orm';
+import { kilocode_users, user_admin_notes } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createCallerForUser } from '@/routers/test-utils';
+import { hosted_domain_specials } from '@/lib/auth/constants';
+
+const KILO_DOMAIN = hosted_domain_specials.kilocode_admin;
+
+async function insertQualifyingAdmin(overrides: Parameters<typeof insertTestUser>[0] = {}) {
+  return insertTestUser({
+    google_user_email: `qualifying-admin-${crypto.randomUUID()}@kilocode.ai`,
+    hosted_domain: KILO_DOMAIN,
+    is_admin: true,
+    ...overrides,
+  });
+}
+
+async function insertGrandfatheredAdmin(overrides: Parameters<typeof insertTestUser>[0] = {}) {
+  return insertTestUser({
+    google_user_email: `grandfathered-admin-${crypto.randomUUID()}@example.com`,
+    hosted_domain: hosted_domain_specials.non_workspace_google_account,
+    is_admin: true,
+    ...overrides,
+  });
+}
+
+async function insertEligibleCandidate(overrides: Parameters<typeof insertTestUser>[0] = {}) {
+  return insertTestUser({
+    google_user_email: `candidate-${crypto.randomUUID()}@kilocode.ai`,
+    hosted_domain: KILO_DOMAIN,
+    is_admin: false,
+    ...overrides,
+  });
+}
+
+async function getUserAdminNotes(userId: string) {
+  return db.query.user_admin_notes.findMany({
+    where: eq(user_admin_notes.kilo_user_id, userId),
+  });
+}
+
+async function getUser(userId: string) {
+  const user = await db.query.kilocode_users.findFirst({
+    where: eq(kilocode_users.id, userId),
+  });
+  if (!user) throw new Error(`Expected test user ${userId} to exist`);
+  return user;
+}
+
+describe('admin.users.listPlatformAdmins', () => {
+  test('non-admin callers cannot list admins', async () => {
+    const nonAdmin = await insertTestUser({ is_admin: false });
+    const caller = await createCallerForUser(nonAdmin.id);
+
+    await expect(caller.admin.users.listPlatformAdmins()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+  });
+
+  test('includes both qualifying and grandfathered current admins', async () => {
+    const qualifying = await insertQualifyingAdmin();
+    const grandfathered = await insertGrandfatheredAdmin();
+    await insertTestUser({ is_admin: false });
+
+    const caller = await createCallerForUser(qualifying.id);
+    const result = await caller.admin.users.listPlatformAdmins();
+
+    const adminIds = result.admins.map(admin => admin.id);
+    expect(adminIds).toContain(qualifying.id);
+    expect(adminIds).toContain(grandfathered.id);
+  });
+
+  test('reports canGrantAdmins true for a qualifying kilocode.ai admin', async () => {
+    const qualifying = await insertQualifyingAdmin();
+    const caller = await createCallerForUser(qualifying.id);
+
+    const result = await caller.admin.users.listPlatformAdmins();
+    expect(result.canGrantAdmins).toBe(true);
+    expect(result.currentUserId).toBe(qualifying.id);
+  });
+
+  test('reports canGrantAdmins false for a grandfathered outside-domain admin', async () => {
+    const grandfathered = await insertGrandfatheredAdmin();
+    const caller = await createCallerForUser(grandfathered.id);
+
+    const result = await caller.admin.users.listPlatformAdmins();
+    expect(result.canGrantAdmins).toBe(false);
+  });
+});
+
+describe('admin.users.searchPlatformAdminCandidates', () => {
+  test('non-admin callers cannot search candidates', async () => {
+    const nonAdmin = await insertTestUser({ is_admin: false });
+    const caller = await createCallerForUser(nonAdmin.id);
+
+    await expect(
+      caller.admin.users.searchPlatformAdminCandidates({ query: 'candidate' })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  test('a grandfathered outside-domain admin cannot search candidates', async () => {
+    const grandfathered = await insertGrandfatheredAdmin();
+    const caller = await createCallerForUser(grandfathered.id);
+
+    await expect(
+      caller.admin.users.searchPlatformAdminCandidates({ query: 'candidate' })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  test('returns only non-admin users satisfying both exact Kilo eligibility rules', async () => {
+    const searchToken = crypto.randomUUID();
+    const admin = await insertQualifyingAdmin();
+
+    const eligible = await insertEligibleCandidate({
+      google_user_email: `${searchToken}@kilocode.ai`,
+    });
+    const alreadyAdmin = await insertTestUser({
+      google_user_email: `${searchToken}-already-admin@kilocode.ai`,
+      hosted_domain: KILO_DOMAIN,
+      is_admin: true,
+    });
+    const fakeLoginUser = await insertTestUser({
+      google_user_email: `${searchToken}-fake@kilocode.ai`,
+      hosted_domain: hosted_domain_specials.fake_devonly,
+      is_admin: false,
+    });
+    const wrongDomainUser = await insertTestUser({
+      google_user_email: `${searchToken}-wrong-domain@kilocode.ai`,
+      hosted_domain: hosted_domain_specials.non_workspace_google_account,
+      is_admin: false,
+    });
+    const wrongEmailUser = await insertTestUser({
+      google_user_email: `${searchToken}@example.com`,
+      hosted_domain: KILO_DOMAIN,
+      is_admin: false,
+    });
+    const uppercaseEmailUser = await insertTestUser({
+      google_user_email: `${searchToken.toUpperCase()}@Kilocode.ai`,
+      hosted_domain: KILO_DOMAIN,
+      is_admin: false,
+    });
+    const subdomainUser = await insertTestUser({
+      google_user_email: `${searchToken}@sub.kilocode.ai`,
+      hosted_domain: KILO_DOMAIN,
+      is_admin: false,
+    });
+    const lookalikeDomainUser = await insertTestUser({
+      google_user_email: `${searchToken}@notkilocode.ai`,
+      hosted_domain: KILO_DOMAIN,
+      is_admin: false,
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    const results = await caller.admin.users.searchPlatformAdminCandidates({
+      query: searchToken,
+    });
+
+    const resultIds = results.map(user => user.id);
+    expect(resultIds).toEqual([eligible.id]);
+    expect(resultIds).not.toContain(alreadyAdmin.id);
+    expect(resultIds).not.toContain(fakeLoginUser.id);
+    expect(resultIds).not.toContain(wrongDomainUser.id);
+    expect(resultIds).not.toContain(wrongEmailUser.id);
+    expect(resultIds).not.toContain(uppercaseEmailUser.id);
+    expect(resultIds).not.toContain(subdomainUser.id);
+    expect(resultIds).not.toContain(lookalikeDomainUser.id);
+  });
+
+  test('escapes a literal underscore so it cannot act as a single-character SQL wildcard', async () => {
+    const admin = await insertQualifyingAdmin();
+    const token = crypto.randomUUID().replace(/-/g, '');
+
+    const literalMatch = await insertEligibleCandidate({
+      google_user_email: `${token}_probe@kilocode.ai`,
+    });
+    // If the underscore in the search query were passed to ILIKE unescaped, this
+    // decoy (any single character standing in for "_") would incorrectly match too.
+    const wildcardDecoy = await insertEligibleCandidate({
+      google_user_email: `${token}Xprobe@kilocode.ai`,
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    const results = await caller.admin.users.searchPlatformAdminCandidates({
+      query: `${token}_probe`,
+    });
+
+    const resultIds = results.map(user => user.id);
+    expect(resultIds).toContain(literalMatch.id);
+    expect(resultIds).not.toContain(wildcardDecoy.id);
+    expect(results.length).toBeLessThanOrEqual(20);
+  });
+});
+
+describe('admin.users.setPlatformAdminAccess — grant', () => {
+  test('a qualifying admin can grant an eligible target', async () => {
+    const admin = await insertQualifyingAdmin();
+    const target = await insertEligibleCandidate({ web_session_pepper: 'before-grant-pepper' });
+    const caller = await createCallerForUser(admin.id);
+
+    const result = await caller.admin.users.setPlatformAdminAccess({
+      userId: target.id,
+      isAdmin: true,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.user.is_admin).toBe(true);
+
+    const updated = await getUser(target.id);
+    expect(updated.is_admin).toBe(true);
+    // Grant sets only is_admin — can_manage_credits must remain untouched.
+    expect(updated.can_manage_credits).toBe(false);
+    expect(updated.web_session_pepper).not.toBe('before-grant-pepper');
+
+    const notes = await getUserAdminNotes(target.id);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.note_content).toBe('Granted platform admin access.');
+    expect(notes[0]?.admin_kilo_user_id).toBe(admin.id);
+  });
+
+  test('rejects granting an ineligible target even if submitted directly', async () => {
+    const admin = await insertQualifyingAdmin();
+    const ineligibleTarget = await insertTestUser({
+      google_user_email: 'not-eligible@example.com',
+      hosted_domain: hosted_domain_specials.non_workspace_google_account,
+      is_admin: false,
+    });
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(
+      caller.admin.users.setPlatformAdminAccess({ userId: ineligibleTarget.id, isAdmin: true })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    const unchanged = await getUser(ineligibleTarget.id);
+    expect(unchanged.is_admin).toBe(false);
+  });
+
+  test('a grandfathered outside-domain admin cannot grant', async () => {
+    const grandfathered = await insertGrandfatheredAdmin();
+    const target = await insertEligibleCandidate();
+    const caller = await createCallerForUser(grandfathered.id);
+
+    await expect(
+      caller.admin.users.setPlatformAdminAccess({ userId: target.id, isAdmin: true })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    const unchanged = await getUser(target.id);
+    expect(unchanged.is_admin).toBe(false);
+  });
+
+  test('repeated grant is an idempotent no-op with no second note or session rotation', async () => {
+    const admin = await insertQualifyingAdmin();
+    const target = await insertEligibleCandidate();
+    const caller = await createCallerForUser(admin.id);
+
+    await caller.admin.users.setPlatformAdminAccess({ userId: target.id, isAdmin: true });
+    const afterFirstGrant = await getUser(target.id);
+
+    const secondResult = await caller.admin.users.setPlatformAdminAccess({
+      userId: target.id,
+      isAdmin: true,
+    });
+
+    expect(secondResult.changed).toBe(false);
+
+    const afterSecondGrant = await getUser(target.id);
+    expect(afterSecondGrant.web_session_pepper).toBe(afterFirstGrant.web_session_pepper);
+
+    const notes = await getUserAdminNotes(target.id);
+    expect(notes).toHaveLength(1);
+  });
+
+  test('non-admin callers cannot grant', async () => {
+    const nonAdmin = await insertTestUser({ is_admin: false });
+    const target = await insertEligibleCandidate();
+    const caller = await createCallerForUser(nonAdmin.id);
+
+    await expect(
+      caller.admin.users.setPlatformAdminAccess({ userId: target.id, isAdmin: true })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  test('unknown target returns NOT_FOUND', async () => {
+    const admin = await insertQualifyingAdmin();
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(
+      caller.admin.users.setPlatformAdminAccess({
+        userId: 'does-not-exist',
+        isAdmin: true,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
+
+describe('admin.users.setPlatformAdminAccess — revoke', () => {
+  test('a qualifying admin can revoke another admin, clearing credit management together', async () => {
+    const admin = await insertQualifyingAdmin();
+    const target = await insertQualifyingAdmin({
+      can_manage_credits: true,
+      web_session_pepper: 'before-revoke-pepper',
+    });
+    const caller = await createCallerForUser(admin.id);
+
+    const result = await caller.admin.users.setPlatformAdminAccess({
+      userId: target.id,
+      isAdmin: false,
+    });
+
+    expect(result.changed).toBe(true);
+
+    const updated = await getUser(target.id);
+    expect(updated.is_admin).toBe(false);
+    expect(updated.can_manage_credits).toBe(false);
+    expect(updated.web_session_pepper).not.toBe('before-revoke-pepper');
+
+    const notes = await getUserAdminNotes(target.id);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.note_content).toBe('Revoked platform admin access.');
+    expect(notes[0]?.admin_kilo_user_id).toBe(admin.id);
+  });
+
+  test('a grandfathered outside-domain admin can revoke another admin', async () => {
+    const grandfathered = await insertGrandfatheredAdmin();
+    const target = await insertQualifyingAdmin();
+    const caller = await createCallerForUser(grandfathered.id);
+
+    const result = await caller.admin.users.setPlatformAdminAccess({
+      userId: target.id,
+      isAdmin: false,
+    });
+
+    expect(result.changed).toBe(true);
+    const updated = await getUser(target.id);
+    expect(updated.is_admin).toBe(false);
+  });
+
+  test('self-revocation is forbidden', async () => {
+    const admin = await insertQualifyingAdmin();
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(
+      caller.admin.users.setPlatformAdminAccess({ userId: admin.id, isAdmin: false })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    const unchanged = await getUser(admin.id);
+    expect(unchanged.is_admin).toBe(true);
+  });
+
+  test('repeated revoke is an idempotent no-op with no new note or session rotation', async () => {
+    const admin = await insertQualifyingAdmin();
+    const target = await insertQualifyingAdmin();
+    const caller = await createCallerForUser(admin.id);
+
+    await caller.admin.users.setPlatformAdminAccess({ userId: target.id, isAdmin: false });
+    const afterFirstRevoke = await getUser(target.id);
+
+    const secondResult = await caller.admin.users.setPlatformAdminAccess({
+      userId: target.id,
+      isAdmin: false,
+    });
+
+    expect(secondResult.changed).toBe(false);
+
+    const afterSecondRevoke = await getUser(target.id);
+    expect(afterSecondRevoke.web_session_pepper).toBe(afterFirstRevoke.web_session_pepper);
+
+    const notes = await getUserAdminNotes(target.id);
+    expect(notes).toHaveLength(1);
+  });
+
+  test('non-admin callers cannot revoke', async () => {
+    const nonAdmin = await insertTestUser({ is_admin: false });
+    const target = await insertQualifyingAdmin();
+    const caller = await createCallerForUser(nonAdmin.id);
+
+    await expect(
+      caller.admin.users.setPlatformAdminAccess({ userId: target.id, isAdmin: false })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+});
+
+test('candidate search and grant eligibility never disagree for a hosted-domain-only mismatch', async () => {
+  // Regression guard for the case=sensitive suffix check: a user whose email
+  // ends with the Kilo suffix but whose hosted domain does not match must be
+  // excluded from search AND rejected by the mutation if submitted directly.
+  const admin = await insertQualifyingAdmin();
+  const target = await insertTestUser({
+    google_user_email: `mismatch-${crypto.randomUUID()}@kilocode.ai`,
+    hosted_domain: hosted_domain_specials.non_workspace_google_account,
+    is_admin: false,
+  });
+  const caller = await createCallerForUser(admin.id);
+
+  const searchResults = await caller.admin.users.searchPlatformAdminCandidates({
+    query: target.google_user_email,
+  });
+  expect(searchResults.map(u => u.id)).not.toContain(target.id);
+
+  await expect(
+    caller.admin.users.setPlatformAdminAccess({ userId: target.id, isAdmin: true })
+  ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+});
+
+// Ensure the note-column assertion helper stays honest about which table it reads.
+test('user_admin_notes rows are scoped to the target user, not the actor', async () => {
+  const admin = await insertQualifyingAdmin();
+  const target = await insertEligibleCandidate();
+  const caller = await createCallerForUser(admin.id);
+
+  await caller.admin.users.setPlatformAdminAccess({ userId: target.id, isAdmin: true });
+
+  const actorNotes = await getUserAdminNotes(admin.id);
+  expect(actorNotes).toHaveLength(0);
+
+  const targetNotes = await db.query.user_admin_notes.findMany({
+    where: and(
+      eq(user_admin_notes.kilo_user_id, target.id),
+      eq(user_admin_notes.admin_kilo_user_id, admin.id)
+    ),
+  });
+  expect(targetNotes).toHaveLength(1);
+});

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -1,6 +1,8 @@
 // admin-router.ts
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { userCanManageCredits } from '@/lib/admin/credit-management';
+import { isEligibleForPlatformAdmin } from '@/lib/admin/platform-admin';
+import { hosted_domain_specials } from '@/lib/auth/constants';
 import { db, type DrizzleTransaction } from '@/lib/drizzle';
 import { insertKiloClawSubscriptionChangeLog, type KiloClawSubscription } from '@kilocode/db';
 import {
@@ -59,7 +61,8 @@ import { adminModelEvalIngestRouter } from '@/routers/admin-model-eval-ingest-ro
 import { workerInstanceId } from '@/lib/kiloclaw/instance-registry';
 import { clearTrialInactivityStopAfterStart } from '@/lib/kiloclaw/instance-lifecycle';
 import * as z from 'zod';
-import { eq, and, ne, or, ilike, desc, asc, sql, isNull, inArray } from 'drizzle-orm';
+import { eq, and, ne, or, ilike, like, desc, asc, sql, isNull, inArray } from 'drizzle-orm';
+import type { InferColumnsDataTypes } from 'drizzle-orm';
 import { findUsersByIds, findUserById } from '@/lib/user';
 import { blockUser } from '@/lib/user/block';
 import { reportEvents } from '@/lib/ai-gateway/abuse-service';
@@ -285,6 +288,46 @@ const SetPersonalAccountDisabledSchema = z.object({
   userId: z.string(),
   value: z.boolean(),
 });
+
+const SearchPlatformAdminCandidatesSchema = z.object({
+  query: z.string().trim().min(1).max(200),
+});
+
+const SetPlatformAdminAccessSchema = z.object({
+  userId: z.string().min(1),
+  isAdmin: z.boolean(),
+});
+
+// Narrow column projection shared by the platform-admin roster and
+// candidate-search results. Both `.select(...)` call sites below reuse this
+// same object (rather than repeating the column list) so their result shapes
+// cannot drift from each other; `PlatformAdminUser` is derived from it so the
+// type can't drift from either query either.
+const platformAdminUserColumns = {
+  id: kilocode_users.id,
+  google_user_email: kilocode_users.google_user_email,
+  google_user_name: kilocode_users.google_user_name,
+  google_user_image_url: kilocode_users.google_user_image_url,
+  hosted_domain: kilocode_users.hosted_domain,
+  blocked_reason: kilocode_users.blocked_reason,
+  can_manage_credits: kilocode_users.can_manage_credits,
+  is_admin: kilocode_users.is_admin,
+};
+
+type PlatformAdminUser = InferColumnsDataTypes<typeof platformAdminUserColumns>;
+
+function toPlatformAdminUser(user: typeof kilocode_users.$inferSelect): PlatformAdminUser {
+  return {
+    id: user.id,
+    google_user_email: user.google_user_email,
+    google_user_name: user.google_user_name,
+    google_user_image_url: user.google_user_image_url,
+    hosted_domain: user.hosted_domain,
+    blocked_reason: user.blocked_reason,
+    can_manage_credits: user.can_manage_credits,
+    is_admin: user.is_admin,
+  };
+}
 
 const GetStytchFingerprintsSchema = z.object({
   kilo_user_id: z.string(),
@@ -1450,6 +1493,151 @@ export const adminRouter = createTRPCRouter({
           balanceResetAmountUsd: result.balanceResetAmountUsd,
           alreadyBlocked: result.alreadyBlocked,
         };
+      }),
+
+    listPlatformAdmins: adminProcedure.query(async ({ ctx }) => {
+      const admins = await db
+        .select(platformAdminUserColumns)
+        .from(kilocode_users)
+        .where(eq(kilocode_users.is_admin, true))
+        .orderBy(asc(kilocode_users.google_user_email));
+
+      return {
+        currentUserId: ctx.user.id,
+        canGrantAdmins: isEligibleForPlatformAdmin(
+          ctx.user.google_user_email,
+          ctx.user.hosted_domain
+        ),
+        admins,
+      };
+    }),
+
+    // Server-filtered so results only ever contain non-admin, exact-eligibility
+    // kilocode.ai users. Filtering here is a UX convenience, not a security
+    // boundary: setPlatformAdminAccess independently re-validates eligibility
+    // against freshly locked rows before granting.
+    searchPlatformAdminCandidates: adminProcedure
+      .input(SearchPlatformAdminCandidatesSchema)
+      .query(async ({ input, ctx }) => {
+        if (!isEligibleForPlatformAdmin(ctx.user.google_user_email, ctx.user.hosted_domain)) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Only a qualifying kilocode.ai admin can search for grant candidates.',
+          });
+        }
+
+        const escaped = input.query.replace(/[%_\\]/g, '\\$&');
+
+        const candidates = await db
+          .select(platformAdminUserColumns)
+          .from(kilocode_users)
+          .where(
+            and(
+              eq(kilocode_users.is_admin, false),
+              eq(kilocode_users.hosted_domain, hosted_domain_specials.kilocode_admin),
+              // Case-sensitive suffix match — `like` (not `ilike`) so search
+              // eligibility cannot disagree with isEligibleForPlatformAdmin.
+              like(kilocode_users.google_user_email, `%@${hosted_domain_specials.kilocode_admin}`),
+              or(
+                ilike(kilocode_users.google_user_email, `%${escaped}%`),
+                ilike(kilocode_users.google_user_name, `%${escaped}%`),
+                eq(kilocode_users.id, input.query)
+              )
+            )
+          )
+          .limit(20);
+
+        return candidates;
+      }),
+
+    setPlatformAdminAccess: adminProcedure
+      .input(SetPlatformAdminAccessSchema)
+      .mutation(async ({ input, ctx }) => {
+        const actorId = ctx.user.id;
+        const targetId = input.userId;
+
+        if (!input.isAdmin && actorId === targetId) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'You cannot revoke your own platform admin access.',
+          });
+        }
+
+        return await db.transaction(async tx => {
+          // Deterministic lock ordering (by ID) avoids deadlocks when two
+          // admins concurrently act on each other in opposite directions.
+          const lockIds = [...new Set([actorId, targetId])].sort();
+          const lockedRows = await tx
+            .select()
+            .from(kilocode_users)
+            .where(inArray(kilocode_users.id, lockIds))
+            .orderBy(asc(kilocode_users.id))
+            .for('update');
+
+          const actor = lockedRows.find(row => row.id === actorId);
+          const target = lockedRows.find(row => row.id === targetId);
+
+          if (!actor || !actor.is_admin) {
+            throw new TRPCError({ code: 'FORBIDDEN', message: 'Admin access required' });
+          }
+
+          if (!target) {
+            throw new TRPCError({ code: 'NOT_FOUND', message: 'Target user not found' });
+          }
+
+          if (input.isAdmin) {
+            if (!isEligibleForPlatformAdmin(actor.google_user_email, actor.hosted_domain)) {
+              throw new TRPCError({
+                code: 'FORBIDDEN',
+                message: 'Only a qualifying kilocode.ai admin can grant platform admin access.',
+              });
+            }
+            if (!isEligibleForPlatformAdmin(target.google_user_email, target.hosted_domain)) {
+              throw new TRPCError({
+                code: 'FORBIDDEN',
+                message: 'Target user is not eligible for platform admin access.',
+              });
+            }
+          }
+
+          // No-op: the target already has the requested state. Return early
+          // without rotating the session pepper or inserting a duplicate note —
+          // there is no permission change here, so there is nothing to sign out of.
+          if (target.is_admin === input.isAdmin) {
+            return { changed: false as const, user: toPlatformAdminUser(target) };
+          }
+
+          const [updatedTarget] = await tx
+            .update(kilocode_users)
+            .set(
+              input.isAdmin
+                ? { is_admin: true, web_session_pepper: crypto.randomUUID() }
+                : {
+                    is_admin: false,
+                    can_manage_credits: false,
+                    web_session_pepper: crypto.randomUUID(),
+                  }
+            )
+            .where(eq(kilocode_users.id, target.id))
+            .returning();
+
+          if (!updatedTarget) {
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+              message: 'Failed to update target user',
+            });
+          }
+
+          await tx.insert(user_admin_notes).values({
+            kilo_user_id: target.id,
+            admin_kilo_user_id: actor.id,
+            note_content: input.isAdmin
+              ? 'Granted platform admin access.'
+              : 'Revoked platform admin access.',
+          });
+
+          return { changed: true as const, user: toPlatformAdminUser(updatedTarget) };
+        });
       }),
   }),
 

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -1585,6 +1585,16 @@ export const adminRouter = createTRPCRouter({
             throw new TRPCError({ code: 'NOT_FOUND', message: 'Target user not found' });
           }
 
+          // No-op: the target already has the requested state. Return early
+          // without rotating the session pepper or inserting a duplicate note —
+          // there is no permission change here, so there is nothing to sign out of.
+          // Checked before eligibility so a redundant "grant" against an
+          // already-admin target (e.g. a grandfathered admin outside
+          // kilocode.ai) is always a no-op, not a FORBIDDEN error.
+          if (target.is_admin === input.isAdmin) {
+            return { changed: false as const, user: toPlatformAdminUser(target) };
+          }
+
           if (input.isAdmin) {
             if (!isEligibleForPlatformAdmin(actor.google_user_email, actor.hosted_domain)) {
               throw new TRPCError({
@@ -1598,13 +1608,6 @@ export const adminRouter = createTRPCRouter({
                 message: 'Target user is not eligible for platform admin access.',
               });
             }
-          }
-
-          // No-op: the target already has the requested state. Return early
-          // without rotating the session pepper or inserting a duplicate note —
-          // there is no permission change here, so there is nothing to sign out of.
-          if (target.is_admin === input.isAdmin) {
-            return { changed: false as const, user: toPlatformAdminUser(target) };
           }
 
           const [updatedTarget] = await tx

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -1545,6 +1545,9 @@ export const adminRouter = createTRPCRouter({
               )
             )
           )
+          // Deterministic ordering so the truncated top-20 is stable across
+          // repeated identical searches regardless of DB plan/physical order.
+          .orderBy(asc(kilocode_users.google_user_email), asc(kilocode_users.id))
           .limit(20);
 
         return candidates;
@@ -1610,15 +1613,27 @@ export const adminRouter = createTRPCRouter({
             }
           }
 
+          // Rotate both the web session pepper AND the API token pepper on any
+          // privilege change. getUserFromAuth authorizes bearer tokens from the
+          // current DB is_admin value after only matching api_token_pepper, so a
+          // token minted while the user was non-admin would otherwise become
+          // admin-capable the instant we grant (and, on revoke, a pre-revoke
+          // token would retain admin capability). Rotating the pepper here
+          // invalidates every previously-issued token in the same transaction.
           const [updatedTarget] = await tx
             .update(kilocode_users)
             .set(
               input.isAdmin
-                ? { is_admin: true, web_session_pepper: crypto.randomUUID() }
+                ? {
+                    is_admin: true,
+                    web_session_pepper: crypto.randomUUID(),
+                    api_token_pepper: crypto.randomUUID(),
+                  }
                 : {
                     is_admin: false,
                     can_manage_credits: false,
                     web_session_pepper: crypto.randomUUID(),
+                    api_token_pepper: crypto.randomUUID(),
                   }
             )
             .where(eq(kilocode_users.id, target.id))


### PR DESCRIPTION
## Summary

Replaces production email-based platform-admin auto-provisioning with explicit, auditable grant/revoke management on top of the existing `kilocode_users.is_admin` flag.

Previously, any real Google OAuth signup with `hosted_domain === 'kilocode.ai'` and an `@kilocode.ai` email automatically became a platform admin at account creation. This PR removes that production auto-provisioning branch entirely — new `@kilocode.ai` signups now always start as non-admin — while leaving the fake-login `@admin.example.com` bootstrap (used in ephemeral development/staging environments) unchanged. Existing `is_admin = true` rows are untouched; no migration or backfill is involved.

In place of auto-provisioning, a new `/admin/admins` page lets a qualifying `@kilocode.ai` admin search for and grant admin access to eligible existing users, and lets any current admin (including "grandfathered" admins outside the `kilocode.ai` domain) revoke another admin's access — but never their own. Revoking also clears `can_manage_credits`, since the schema enforces that credit managers must be admins. Both grant and revoke rotate the target's `web_session_pepper` (signing them out of their current browser sessions) and insert an attributed note in `user_admin_notes`.

Architecturally:
- Added a pure `apps/web/src/lib/admin/platform-admin.ts` helper (`isEligibleForPlatformAdmin`, `shouldAutoProvisionPlatformAdmin`) as the single source of truth for the exact, case-sensitive `kilocode.ai` eligibility rule, shared by both the (now fake-login-only) auto-provisioning path and the new manual grant/search paths.
- Hardened the two credit-category admin API routes (`/admin/api/credit-categories`, `/admin/api/credit-categories/[key]`) with a fresh, database-backed `getUserFromAuth({ adminOnly: true })` check, closing a gap where they previously relied solely on a potentially-stale JWT `isAdmin` claim from middleware.

## Verification

- [x] Signed in via fake-login bootstrap (`@admin.example.com`) and confirmed the new admin appears in the `/admin/admins` roster with a read-only "grant" section (grandfathered, non-`kilocode.ai` domain).
- [x] Promoted a seeded user to a qualifying `kilocode.ai` admin and confirmed the grant search/section becomes available; searched for and granted an eligible candidate, confirming the confirmation dialog names the exact target email and mentions both credit-management and session sign-out effects.
- [x] Verified after granting: `is_admin` set, `can_manage_credits` untouched, `web_session_pepper` rotated, and a "Granted platform admin access." note attributed to the acting admin appeared on the target's Admin Tools tab.
- [x] Revoked a credit-manager admin and confirmed the dialog's credit-management warning, and that the revoke cleared both `is_admin` and `can_manage_credits` together, rotated the session pepper, and recorded a "Revoked platform admin access." note.
- [x] Confirmed the signed-in admin's own roster row has no revoke control ("You" instead of a button) — self-revocation is unreachable from the UI in addition to being rejected server-side.
- [x] Confirmed a fresh production-shaped `@kilocode.ai` Google sign-in no longer auto-provisions admin access.

## Visual Changes

| Before | After |
|---|---|
| No dedicated admin-management page existed; the sidebar had no "Admins" entry. | ![Admins page listing a grandfathered and a qualifying admin, with a grant-search section](https://gist.githubusercontent.com/pandemicsyn/74d83468f31a7490c0a802f54870d402/raw/pr-admins-roster.png) |
| N/A | ![Grant confirmation dialog naming the target email and describing side effects](https://gist.githubusercontent.com/pandemicsyn/74d83468f31a7490c0a802f54870d402/raw/pr-admins-grant-dialog.png) |

## Reviewer Notes

- No last-grant-capable-admin protection was added by design: since self-revocation is blocked but revoking *other* admins is not otherwise limited, it is possible for a qualifying admin to revoke all other qualifying `kilocode.ai` admins while a grandfathered, revoke-only admin remains — that admin could no longer grant. This is an accepted product tradeoff, not an oversight.
- `user_admin_notes` is visible/attributed operator history, not a tamper-proof audit ledger (notes are deletable and removed with the user). If compliance-grade audit history is later required, that's a separate schema/retention project.
- Eligibility (`isEligibleForPlatformAdmin`) is intentionally case-sensitive and exact, matching pre-existing production behavior — an uppercase-domain or subdomain `kilocode.ai` lookalike will not qualify for grant/search
