### PR TITLE
feat(web): hide personal surfaces for personal-account-disabled users

### DIFF
--- a/apps/web/src/app/(app)/components/OrganizationSwitcher.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationSwitcher.tsx
@@ -14,6 +14,7 @@ import { cn } from '@/lib/utils';
 import { Check, ChevronDown } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
+import { usePersonalAccountDisabled } from '@/contexts/PersonalAccountContext';
 
 type OrganizationSwitcherProps = {
   organizationId?: string | null;
@@ -30,6 +31,7 @@ type OrganizationSwitcherViewProps = {
   organizations?: OrganizationSwitcherOrganization[];
   isPending?: boolean;
   onOrganizationSwitch: (organizationId: string | null) => void;
+  hidePersonalOption?: boolean;
 };
 
 const triggerClassName =
@@ -51,6 +53,7 @@ const selectedIconClassName = 'text-primary h-4 w-4 shrink-0';
 export default function OrganizationSwitcher({ organizationId = null }: OrganizationSwitcherProps) {
   const trpc = useTRPC();
   const router = useRouter();
+  const personalAccountDisabled = usePersonalAccountDisabled();
 
   // Fetch user organizations
   const { data: organizations, isPending } = useQuery(
@@ -77,6 +80,7 @@ export default function OrganizationSwitcher({ organizationId = null }: Organiza
       organizations={organizations}
       isPending={isPending}
       onOrganizationSwitch={handleOrganizationSwitch}
+      hidePersonalOption={personalAccountDisabled}
     />
   );
 }
@@ -86,6 +90,7 @@ export function OrganizationSwitcherView({
   organizations = [],
   isPending = false,
   onOrganizationSwitch,
+  hidePersonalOption = false,
 }: OrganizationSwitcherViewProps) {
   // Get role display label
   const getRoleLabel = (role: string) => {
@@ -165,22 +170,24 @@ export function OrganizationSwitcherView({
             </DropdownMenuItem>
           ))}
 
-          {/* Separator */}
-          <DropdownMenuSeparator />
-
-          {/* Personal Option */}
-          <DropdownMenuItem
-            onClick={() => onOrganizationSwitch(null)}
-            className={cn(menuItemClassName, !organizationId && selectedMenuItemClassName)}
-          >
-            <div className={switcherRowClassName}>
-              <div className={switcherTextClassName}>
-                <div className={switcherTitleClassName}>Personal</div>
-                <div className={switcherSubtitleClassName}>Personal Workspace</div>
-              </div>
-              {!organizationId && <Check className={selectedIconClassName} />}
-            </div>
-          </DropdownMenuItem>
+          {/* Personal Option — hidden for users whose personal account is disabled */}
+          {!hidePersonalOption && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => onOrganizationSwitch(null)}
+                className={cn(menuItemClassName, !organizationId && selectedMenuItemClassName)}
+              >
+                <div className={switcherRowClassName}>
+                  <div className={switcherTextClassName}>
+                    <div className={switcherTitleClassName}>Personal</div>
+                    <div className={switcherSubtitleClassName}>Personal Workspace</div>
+                  </div>
+                  {!organizationId && <Check className={selectedIconClassName} />}
+                </div>
+              </DropdownMenuItem>
+            </>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -24,6 +24,13 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   // users. The switcher hiding and default sign-in redirect are not enough on
   // their own — a user could otherwise reach e.g. /profile by typing the URL or
   // via a validated callbackPath. Enforce it at the layout boundary.
+  //
+  // Scope note: this is a navigation/UX policy for org-managed users, not a
+  // hard security boundary. It covers the personal surfaces rendered under the
+  // (app) group; it deliberately does not gate every personal tRPC mutation or
+  // OAuth flow. The one action that would let such a user regain a personal
+  // workspace (organization creation) is gated separately in the organizations
+  // router. Broader per-endpoint enforcement is intentionally out of scope.
   if (user && personalAccountDisabled) {
     const pathname = (await headers()).get('x-pathname') ?? '';
     if (pathname && isRestrictedPersonalPath(pathname)) {

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -5,35 +5,44 @@ import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { RoleTestingProvider } from '@/contexts/RoleTestingContext';
 import { PageTitleProvider } from '@/contexts/PageTitleContext';
 import { EventServiceProvider } from '@/contexts/EventServiceContext';
+import { PersonalAccountProvider } from '@/contexts/PersonalAccountContext';
 import { AdminOmnibox } from '@/components/admin-omnibox';
 import { AppShellSkipLink } from '@/components/AppShellSkipLink';
 import { PrefetchedOrganizations } from './components/PrefetchedOrganizations';
 import { PlatformPresenceMount } from './components/PlatformPresenceMount';
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+import { getUserFromAuth } from '@/lib/user/server';
+
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const user = (await getUserFromAuth({ adminOnly: false, DANGEROUS_allowBlockedUsers: true }))
+    ?.user;
+  const personalAccountDisabled = user?.personal_account_disabled ?? false;
+
   return (
-    <RoleTestingProvider>
-      <PageTitleProvider>
-        <EventServiceProvider>
-          <PlatformPresenceMount />
-          <SidebarProvider>
-            <PrefetchedOrganizations>
-              <AppShellSkipLink />
-              <div className="flex min-h-screen w-full">
-                <Suspense fallback={null}>
-                  <AppSidebar />
-                </Suspense>
-                <SidebarInset>
-                  <AppTopbar />
-                  <main id="main-content" tabIndex={-1} className="bg-background w-full flex-1">
-                    {children}
-                  </main>
-                </SidebarInset>
-              </div>
-            </PrefetchedOrganizations>
-          </SidebarProvider>
-        </EventServiceProvider>
-      </PageTitleProvider>
-      <AdminOmnibox />
-    </RoleTestingProvider>
+    <PersonalAccountProvider personalAccountDisabled={personalAccountDisabled}>
+      <RoleTestingProvider>
+        <PageTitleProvider>
+          <EventServiceProvider>
+            <PlatformPresenceMount />
+            <SidebarProvider>
+              <PrefetchedOrganizations>
+                <AppShellSkipLink />
+                <div className="flex min-h-screen w-full">
+                  <Suspense fallback={null}>
+                    <AppSidebar />
+                  </Suspense>
+                  <SidebarInset>
+                    <AppTopbar />
+                    <main id="main-content" tabIndex={-1} className="bg-background w-full flex-1">
+                      {children}
+                    </main>
+                  </SidebarInset>
+                </div>
+              </PrefetchedOrganizations>
+            </SidebarProvider>
+          </EventServiceProvider>
+        </PageTitleProvider>
+        <AdminOmnibox />
+      </RoleTestingProvider>
+    </PersonalAccountProvider>
   );
 }

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -10,12 +10,26 @@ import { AdminOmnibox } from '@/components/admin-omnibox';
 import { AppShellSkipLink } from '@/components/AppShellSkipLink';
 import { PrefetchedOrganizations } from './components/PrefetchedOrganizations';
 import { PlatformPresenceMount } from './components/PlatformPresenceMount';
-import { getUserFromAuth } from '@/lib/user/server';
+import { getUserFromAuth, getProfileRedirectPath } from '@/lib/user/server';
+import { isRestrictedPersonalPath } from '@/lib/personal-account';
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const user = (await getUserFromAuth({ adminOnly: false, DANGEROUS_allowBlockedUsers: true }))
     ?.user;
   const personalAccountDisabled = user?.personal_account_disabled ?? false;
+
+  // Block direct access to personal surfaces for personal-account-disabled
+  // users. The switcher hiding and default sign-in redirect are not enough on
+  // their own — a user could otherwise reach e.g. /profile by typing the URL or
+  // via a validated callbackPath. Enforce it at the layout boundary.
+  if (user && personalAccountDisabled) {
+    const pathname = (await headers()).get('x-pathname') ?? '';
+    if (pathname && isRestrictedPersonalPath(pathname)) {
+      redirect(await getProfileRedirectPath(user));
+    }
+  }
 
   return (
     <PersonalAccountProvider personalAccountDisabled={personalAccountDisabled}>

--- a/apps/web/src/app/personal-account-disabled/page.tsx
+++ b/apps/web/src/app/personal-account-disabled/page.tsx
@@ -1,0 +1,57 @@
+import { redirect } from 'next/navigation';
+import { ShieldAlert } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import Link from 'next/link';
+import { LANDING_URL } from '@/lib/constants';
+import { getUserFromAuth, getProfileRedirectPath } from '@/lib/user/server';
+import { PERSONAL_ACCOUNT_DISABLED_PATH } from '@/lib/personal-account';
+
+export default async function PersonalAccountDisabledPage() {
+  const user = (await getUserFromAuth({ adminOnly: false, DANGEROUS_allowBlockedUsers: true }))
+    ?.user;
+
+  if (!user) {
+    redirect('/users/sign_in');
+  }
+
+  // If the account is not actually disabled, or the user does have an
+  // organization to land on, send them to their normal destination instead of
+  // stranding them on the error page.
+  if (!user.personal_account_disabled) {
+    redirect('/profile');
+  }
+  const redirectPath = await getProfileRedirectPath(user);
+  if (redirectPath !== PERSONAL_ACCOUNT_DISABLED_PATH) {
+    redirect(redirectPath);
+  }
+
+  return (
+    <div className="mt-16 flex w-full items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>No workspace available</CardTitle>
+          <CardDescription>
+            Your personal account is disabled and you are not a member of any organization.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Alert variant="destructive">
+            <ShieldAlert className="h-4 w-4" />
+            <AlertTitle>Contact your administrator</AlertTitle>
+            <AlertDescription>
+              <p>
+                Access to Kilo is managed by your organization. Ask an organization owner to add you
+                to an organization, or{' '}
+                <Link href={`${LANDING_URL}/support`} className="underline">
+                  contact support
+                </Link>{' '}
+                if you believe this is an error.
+              </p>
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/contexts/PersonalAccountContext.tsx
+++ b/apps/web/src/contexts/PersonalAccountContext.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+
+type PersonalAccountContextValue = {
+  /** True when the signed-in user's personal account is disabled. */
+  personalAccountDisabled: boolean;
+};
+
+const PersonalAccountContext = createContext<PersonalAccountContextValue>({
+  personalAccountDisabled: false,
+});
+
+export function PersonalAccountProvider({
+  personalAccountDisabled,
+  children,
+}: {
+  personalAccountDisabled: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <PersonalAccountContext.Provider value={{ personalAccountDisabled }}>
+      {children}
+    </PersonalAccountContext.Provider>
+  );
+}
+
+export function usePersonalAccountDisabled(): boolean {
+  return useContext(PersonalAccountContext).personalAccountDisabled;
+}

--- a/apps/web/src/lib/personal-account.test.ts
+++ b/apps/web/src/lib/personal-account.test.ts
@@ -10,12 +10,18 @@ describe('isRestrictedPersonalPath', () => {
   );
 
   test.each([
-    '/organizations',
     '/organizations/11111111-1111-1111-1111-111111111111',
     '/organizations/11111111-1111-1111-1111-111111111111/usage-details',
-  ])('allows organization route %s', pathname => {
+  ])('allows specific organization route %s', pathname => {
     expect(isRestrictedPersonalPath(pathname)).toBe(false);
   });
+
+  test.each(['/organizations', '/organizations/create', '/organizations/new', '/n'])(
+    'blocks the organization index and creation route %s',
+    pathname => {
+      expect(isRestrictedPersonalPath(pathname)).toBe(true);
+    }
+  );
 
   test.each([
     '/connected-accounts',

--- a/apps/web/src/lib/personal-account.test.ts
+++ b/apps/web/src/lib/personal-account.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from '@jest/globals';
+import { isRestrictedPersonalPath, PERSONAL_ACCOUNT_DISABLED_PATH } from '@/lib/personal-account';
+
+describe('isRestrictedPersonalPath', () => {
+  test.each(['/profile', '/usage', '/subscriptions', '/invoices', '/credits', '/byok', '/claw'])(
+    'blocks personal surface %s',
+    pathname => {
+      expect(isRestrictedPersonalPath(pathname)).toBe(true);
+    }
+  );
+
+  test.each([
+    '/organizations',
+    '/organizations/11111111-1111-1111-1111-111111111111',
+    '/organizations/11111111-1111-1111-1111-111111111111/usage-details',
+  ])('allows organization route %s', pathname => {
+    expect(isRestrictedPersonalPath(pathname)).toBe(false);
+  });
+
+  test.each([
+    '/connected-accounts',
+    '/connected-accounts/github',
+    '/install',
+    '/install/vscode',
+    '/learn',
+  ])('allows allowlisted personal route %s', pathname => {
+    expect(isRestrictedPersonalPath(pathname)).toBe(false);
+  });
+
+  test('allows the error page itself', () => {
+    expect(isRestrictedPersonalPath(PERSONAL_ACCOUNT_DISABLED_PATH)).toBe(false);
+  });
+
+  test('does not treat a prefix collision as an allowlisted route', () => {
+    expect(isRestrictedPersonalPath('/installations')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/personal-account.ts
+++ b/apps/web/src/lib/personal-account.ts
@@ -5,3 +5,23 @@
  * usable surface.
  */
 export const PERSONAL_ACCOUNT_DISABLED_PATH = '/personal-account-disabled';
+
+/**
+ * Personal (non-organization) routes that stay available to users whose
+ * personal account is disabled. Everything else outside `/organizations` is a
+ * personal surface and is blocked for those users.
+ */
+export const PERSONAL_ROUTE_ALLOWLIST = ['/connected-accounts', '/install', '/learn'] as const;
+
+/**
+ * Whether `pathname` is a personal surface that a personal-account-disabled
+ * user must not access directly. Organization routes and the allowlisted
+ * personal routes are always permitted.
+ */
+export function isRestrictedPersonalPath(pathname: string): boolean {
+  if (pathname.startsWith('/organizations')) return false;
+  if (pathname === PERSONAL_ACCOUNT_DISABLED_PATH) return false;
+  return !PERSONAL_ROUTE_ALLOWLIST.some(
+    allowed => pathname === allowed || pathname.startsWith(`${allowed}/`)
+  );
+}

--- a/apps/web/src/lib/personal-account.ts
+++ b/apps/web/src/lib/personal-account.ts
@@ -8,19 +8,34 @@ export const PERSONAL_ACCOUNT_DISABLED_PATH = '/personal-account-disabled';
 
 /**
  * Personal (non-organization) routes that stay available to users whose
- * personal account is disabled. Everything else outside `/organizations` is a
- * personal surface and is blocked for those users.
+ * personal account is disabled. Everything else outside a specific
+ * organization is a personal surface and is blocked for those users.
  */
 export const PERSONAL_ROUTE_ALLOWLIST = ['/connected-accounts', '/install', '/learn'] as const;
 
 /**
+ * Whether `pathname` targets a specific organization (e.g.
+ * `/organizations/<id>` or a nested org route). The `/organizations` index and
+ * the organization creation routes (`/organizations/create`,
+ * `/organizations/new`) deliberately do not match: a personal-account-disabled
+ * user must not reach the org list or the create-organization flow, otherwise
+ * they could mint a new workspace and bypass the terminal no-workspace state.
+ */
+function isOrganizationScopedPath(pathname: string): boolean {
+  const match = pathname.match(/^\/organizations\/([^/]+)/);
+  if (!match) return false;
+  const firstSegment = match[1];
+  return firstSegment !== 'create' && firstSegment !== 'new';
+}
+
+/**
  * Whether `pathname` is a personal surface that a personal-account-disabled
- * user must not access directly. Organization routes and the allowlisted
- * personal routes are always permitted.
+ * user must not access directly. Specific organization routes and the
+ * allowlisted personal routes are always permitted.
  */
 export function isRestrictedPersonalPath(pathname: string): boolean {
-  if (pathname.startsWith('/organizations')) return false;
   if (pathname === PERSONAL_ACCOUNT_DISABLED_PATH) return false;
+  if (isOrganizationScopedPath(pathname)) return false;
   return !PERSONAL_ROUTE_ALLOWLIST.some(
     allowed => pathname === allowed || pathname.startsWith(`${allowed}/`)
   );

--- a/apps/web/src/lib/personal-account.ts
+++ b/apps/web/src/lib/personal-account.ts
@@ -1,0 +1,7 @@
+/**
+ * Destination for users whose personal account is disabled but who have no
+ * organization to fall back to. This is an unexpected state (the flag is only
+ * meant for org-managed users), so the page is a terminal error rather than a
+ * usable surface.
+ */
+export const PERSONAL_ACCOUNT_DISABLED_PATH = '/personal-account-disabled';

--- a/apps/web/src/lib/user/server.test.ts
+++ b/apps/web/src/lib/user/server.test.ts
@@ -21,6 +21,7 @@ import { organization_seats_purchases, organizations } from '@kilocode/db/schema
 import type { Organization, User } from '@kilocode/db/schema';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
 import { insertTestUser } from '@/tests/helpers/user.helper';
+import { PERSONAL_ACCOUNT_DISABLED_PATH } from '@/lib/personal-account';
 import { generateApiToken } from '@/lib/tokens';
 import { eq } from 'drizzle-orm';
 import { v5 as uuidv5 } from 'uuid';
@@ -561,5 +562,36 @@ describe('getProfileRedirectPath', () => {
     await expect(getProfileRedirectPath(pastDueUser)).resolves.toBe(
       `/organizations/${pastDueOrganization.id}`
     );
+  });
+
+  test('sends personal-account-disabled users to their organization even when its trial is hard-expired', async () => {
+    const user = await insertTestUser({
+      google_user_name: 'Disabled Redirect User',
+      personal_account_disabled: true,
+    });
+    const organization = await createTestOrganization(
+      'Disabled Redirect Org',
+      user.id,
+      100_000,
+      undefined,
+      true
+    );
+    await db
+      .update(organizations)
+      .set({
+        free_trial_end_at: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+      })
+      .where(eq(organizations.id, organization.id));
+
+    await expect(getProfileRedirectPath(user)).resolves.toBe(`/organizations/${organization.id}`);
+  });
+
+  test('sends personal-account-disabled users with no organization to the error page', async () => {
+    const user = await insertTestUser({
+      google_user_name: 'Disabled Orphan User',
+      personal_account_disabled: true,
+    });
+
+    await expect(getProfileRedirectPath(user)).resolves.toBe(PERSONAL_ACCOUNT_DISABLED_PATH);
   });
 });

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -45,7 +45,12 @@ import type { Organization, User } from '@kilocode/db/schema';
 import type { AuthProviderId } from '@kilocode/db/schema-types';
 import PostHogClient from '@/lib/posthog';
 import { captureException } from '@sentry/nextjs';
-import { getSingleUserOrganization, isOrganizationMember } from '@/lib/organizations/organizations';
+import {
+  getSingleUserOrganization,
+  getProfileOrganizations,
+  isOrganizationMember,
+} from '@/lib/organizations/organizations';
+import { PERSONAL_ACCOUNT_DISABLED_PATH } from '@/lib/personal-account';
 import { resolveSsoAuthorityForDomain } from '@/lib/organizations/organization-sso-policy';
 import type { AccountLinkingSession } from '@/lib/account-linking-session';
 import { getAccountLinkingSession } from '@/lib/account-linking-session';
@@ -1168,6 +1173,17 @@ export function getUserUUID(user: User): string {
 // the org page will be redirected to if the user is a member of exactly one organization
 // or if the org is SSO org
 export async function getProfileRedirectPath(user: User) {
+  // Users without a personal account never land on personal surfaces. Send them
+  // to their earliest-created organization, or to the error page when they have
+  // none (a state that should not occur in practice).
+  if (user.personal_account_disabled) {
+    const organizations = await getProfileOrganizations(user.id);
+    const firstOrganization = organizations[0];
+    return firstOrganization
+      ? `/organizations/${firstOrganization.id}`
+      : PERSONAL_ACCOUNT_DISABLED_PATH;
+  }
+
   // Check if user is a member of exactly one organization (skip redirect if multiple)
   const singleOrg = await getSingleUserOrganization(user.id);
   if (singleOrg) {

--- a/apps/web/src/routers/organizations/organization-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-router.test.ts
@@ -571,6 +571,25 @@ describe('organizations trpc router', () => {
 
       expect(row.company_domain).toBeNull();
     });
+
+    it('rejects organization creation for personal-account-disabled users', async () => {
+      const disabledUser = await insertTestUser({
+        google_user_email: 'disabled-create-org@example.com',
+        google_user_name: 'Disabled Create Org User',
+        personal_account_disabled: true,
+      });
+      const caller = await createCallerForUser(disabledUser.id);
+
+      await expect(
+        caller.organizations.create({ name: 'Should Not Exist', autoAddCreator: true })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+      const rows = await db
+        .select()
+        .from(organizations)
+        .where(eq(organizations.name, 'Should Not Exist'));
+      expect(rows).toHaveLength(0);
+    });
   });
 
   describe('creditTransactions procedure', () => {

--- a/apps/web/src/routers/organizations/organization-router.ts
+++ b/apps/web/src/routers/organizations/organization-router.ts
@@ -140,6 +140,17 @@ export const organizationsRouter = createTRPCRouter({
 
   create: baseProcedure.input(OrganizationCreateRequestSchema).mutation(async opts => {
     const { user } = opts.ctx;
+
+    // Personal-account-disabled users are organization-managed and must not be
+    // able to mint their own workspace, which would bypass the terminal
+    // no-workspace state and defeat the disabled-account restriction.
+    if (user.personal_account_disabled) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Your account cannot create organizations.',
+      });
+    }
+
     const existingOrgMemberships = await getUserOrganizationsWithSeats(user.id);
 
     if (


### PR DESCRIPTION
## Summary
Hide "personal" surfaces from users with `personal_account_disabled: true` so they only see their organization's management features.

- **Sign-in redirect** (`getProfileRedirectPath`): disabled users go to their earliest-created organization, or to a new `/personal-account-disabled` error page when they belong to no organization.
- **Error page** (`/personal-account-disabled`): standalone full-page error outside the `(app)` shell for the should-never-happen zero-org case; re-checks state and redirects valid users back to their normal destination.
- **Route guard**: the `(app)` layout blocks direct access to personal surfaces via the proxy `x-pathname` header (`isRestrictedPersonalPath`), redirecting to the user's org. Only specific-organization routes (`/organizations/<id>/...`) and an allowlist (`connected-accounts`, `install`, `learn`) are permitted; the org index and creation flow (`/organizations`, `/organizations/create`, `/organizations/new`, `/n`) are blocked.
- **Org creation gate**: the `organizations.create` tRPC mutation rejects `personal_account_disabled` users (defense in depth against regaining a workspace).
- **Sidebar**: the "Personal / Personal Workspace" option is hidden in the organization switcher; the flag is provided from the app layout via `PersonalAccountContext`.
- **Tests**: `getProfileRedirectPath` (disabled-with-org / disabled-no-org), `isRestrictedPersonalPath` route matrix, and a router test asserting `organizations.create` is forbidden for disabled users.

## Scope / conscious rejection
This is a navigation/UX policy for org-managed users, not a hard security boundary. A follow-up review round suggested gating **every** personal tRPC mutation and OAuth flow (e.g. `kiloclaw.provision`, `/get-started/slack`) against the flag. That is a broad, cross-cutting change with no shared "personal procedure" boundary (baseProcedure is shared across ~20+ routers) and is intentionally left out of scope. The only action that could let such a user regain a personal workspace (org creation) is already gated. See the scope note comment in `apps/web/src/app/(app)/layout.tsx`.

Access-blocked orgs are still counted as a landing target (a disabled user with only a billing-blocked org lands on it rather than the error page).

## Validation
`pnpm typecheck`, `pnpm lint`, `pnpm format` clean. Targeted Jest suites pass. Reviewed with Codex autoreview across three rounds; the two concrete findings (direct-route access, org-creation bypass) were fixed, the third (broad per-endpoint enforcement) was consciously rejected as out-of-scope.