### PR TITLE
feat(organizations): disable personal account for new users joining via invite

### DIFF
--- a/apps/web/src/app/users/accept-invite/[token]/page.tsx
+++ b/apps/web/src/app/users/accept-invite/[token]/page.tsx
@@ -19,15 +19,10 @@ export default async function AcceptInvitePage({ params }: AcceptInvitePageProps
   );
 
   const session = await getServerSession(authOptions);
-  const result = await acceptOrganizationInvite(
-    user.id,
-    token,
-    {
-      provider: session?.authProvider,
-      ssoSourceOrganizationId: session?.ssoSourceOrganizationId,
-    },
-    session?.isNewUser ?? false
-  );
+  const result = await acceptOrganizationInvite(user.id, token, {
+    provider: session?.authProvider,
+    ssoSourceOrganizationId: session?.ssoSourceOrganizationId,
+  });
 
   if (result.success) {
     // we need to set user to be styched if they're not so they don't get styched since they were invited to an org

--- a/apps/web/src/app/users/accept-invite/[token]/page.tsx
+++ b/apps/web/src/app/users/accept-invite/[token]/page.tsx
@@ -19,10 +19,15 @@ export default async function AcceptInvitePage({ params }: AcceptInvitePageProps
   );
 
   const session = await getServerSession(authOptions);
-  const result = await acceptOrganizationInvite(user.id, token, {
-    provider: session?.authProvider,
-    ssoSourceOrganizationId: session?.ssoSourceOrganizationId,
-  });
+  const result = await acceptOrganizationInvite(
+    user.id,
+    token,
+    {
+      provider: session?.authProvider,
+      ssoSourceOrganizationId: session?.ssoSourceOrganizationId,
+    },
+    session?.isNewUser ?? false
+  );
 
   if (result.success) {
     // we need to set user to be styched if they're not so they don't get styched since they were invited to an org

--- a/apps/web/src/lib/organizations/organizations.test.ts
+++ b/apps/web/src/lib/organizations/organizations.test.ts
@@ -1598,7 +1598,7 @@ describe('Organizations', () => {
         expect(storedInvitation?.accepted_at).not.toBeNull();
       });
 
-      test('disables the personal account for a new user joining via invite', async () => {
+      test('disables the personal account when the account was created after the invite', async () => {
         const owner = await insertTestUser();
         const invitee = await insertTestUser();
         const organization = await createOrganization('Test Org', owner.id);
@@ -1609,8 +1609,13 @@ describe('Organizations', () => {
           invitee.google_user_email,
           'member'
         );
+        // Simulate a brand-new account created to accept an already-pending invite.
+        await db
+          .update(organization_invitations)
+          .set({ created_at: sql`NOW() - INTERVAL '1 hour'` })
+          .where(eq(organization_invitations.id, invitation.id));
 
-        const result = await acceptOrganizationInvite(invitee.id, invitation.token, {}, true);
+        const result = await acceptOrganizationInvite(invitee.id, invitation.token);
         expect(result.success).toBe(true);
 
         const updatedInvitee = await db.query.kilocode_users.findFirst({
@@ -1619,11 +1624,13 @@ describe('Organizations', () => {
         expect(updatedInvitee?.personal_account_disabled).toBe(true);
       });
 
-      test('leaves the personal account untouched for an existing user joining via invite', async () => {
+      test('leaves the personal account untouched when the account predates the invite', async () => {
         const owner = await insertTestUser();
         const invitee = await insertTestUser();
         const organization = await createOrganization('Test Org', owner.id);
 
+        // The invitation is created after the invitee's account, matching an
+        // existing user who is later invited to an organization.
         const invitation = await inviteUserToOrganization(
           organization.id,
           owner.id,

--- a/apps/web/src/lib/organizations/organizations.test.ts
+++ b/apps/web/src/lib/organizations/organizations.test.ts
@@ -7,6 +7,7 @@ import {
   organization_membership_removals,
   organization_seats_purchases,
   organization_user_limits,
+  kilocode_users,
 } from '@kilocode/db/schema';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { eq, and } from 'drizzle-orm';
@@ -1595,6 +1596,48 @@ describe('Organizations', () => {
         });
         expect(storedInvitation?.accepted_at).toBeDefined();
         expect(storedInvitation?.accepted_at).not.toBeNull();
+      });
+
+      test('disables the personal account for a new user joining via invite', async () => {
+        const owner = await insertTestUser();
+        const invitee = await insertTestUser();
+        const organization = await createOrganization('Test Org', owner.id);
+
+        const invitation = await inviteUserToOrganization(
+          organization.id,
+          owner.id,
+          invitee.google_user_email,
+          'member'
+        );
+
+        const result = await acceptOrganizationInvite(invitee.id, invitation.token, {}, true);
+        expect(result.success).toBe(true);
+
+        const updatedInvitee = await db.query.kilocode_users.findFirst({
+          where: eq(kilocode_users.id, invitee.id),
+        });
+        expect(updatedInvitee?.personal_account_disabled).toBe(true);
+      });
+
+      test('leaves the personal account untouched for an existing user joining via invite', async () => {
+        const owner = await insertTestUser();
+        const invitee = await insertTestUser();
+        const organization = await createOrganization('Test Org', owner.id);
+
+        const invitation = await inviteUserToOrganization(
+          organization.id,
+          owner.id,
+          invitee.google_user_email,
+          'member'
+        );
+
+        const result = await acceptOrganizationInvite(invitee.id, invitation.token);
+        expect(result.success).toBe(true);
+
+        const updatedInvitee = await db.query.kilocode_users.findFirst({
+          where: eq(kilocode_users.id, invitee.id),
+        });
+        expect(updatedInvitee?.personal_account_disabled).toBe(false);
       });
 
       test('rejects accepting a pre-existing invitation into a child organization', async () => {

--- a/apps/web/src/lib/organizations/organizations.ts
+++ b/apps/web/src/lib/organizations/organizations.ts
@@ -661,10 +661,7 @@ export type InvitationAuthenticationContext = {
 export async function acceptOrganizationInvite(
   userId: User['id'],
   inviteToken: string,
-  authentication: InvitationAuthenticationContext = {},
-  // When a brand-new account is created specifically to accept an org invite,
-  // we disable its personal account. Existing users keep their current value.
-  isNewUser = false
+  authentication: InvitationAuthenticationContext = {}
 ): Promise<AcceptInviteResult> {
   try {
     const result = await db.transaction(async tx => {
@@ -695,6 +692,7 @@ export async function acceptOrganizationInvite(
         .select({
           email: kilocode_users.google_user_email,
           normalizedEmail: kilocode_users.normalized_email,
+          createdAt: kilocode_users.created_at,
         })
         .from(kilocode_users)
         .where(eq(kilocode_users.id, userId))
@@ -784,9 +782,13 @@ export async function acceptOrganizationInvite(
         invited_by: invitation.invited_by,
       });
 
-      // A newly created account that joins an organization via invite should
-      // not have a personal account. Existing users keep their current value.
-      if (isNewUser) {
+      // If the invitation predates the account, the account was created after
+      // (i.e. because of) a pending invite: this is a brand-new user joining an
+      // organization via invite, so disable their personal account. Existing
+      // users — whose account predates the invitation — keep their value.
+      const accountCreatedForInvite =
+        new Date(invitation.created_at).getTime() < new Date(acceptingUser.createdAt).getTime();
+      if (accountCreatedForInvite) {
         await tx
           .update(kilocode_users)
           .set({ personal_account_disabled: true })

--- a/apps/web/src/lib/organizations/organizations.ts
+++ b/apps/web/src/lib/organizations/organizations.ts
@@ -661,7 +661,10 @@ export type InvitationAuthenticationContext = {
 export async function acceptOrganizationInvite(
   userId: User['id'],
   inviteToken: string,
-  authentication: InvitationAuthenticationContext = {}
+  authentication: InvitationAuthenticationContext = {},
+  // When a brand-new account is created specifically to accept an org invite,
+  // we disable its personal account. Existing users keep their current value.
+  isNewUser = false
 ): Promise<AcceptInviteResult> {
   try {
     const result = await db.transaction(async tx => {
@@ -780,6 +783,15 @@ export async function acceptOrganizationInvite(
         role: invitation.role,
         invited_by: invitation.invited_by,
       });
+
+      // A newly created account that joins an organization via invite should
+      // not have a personal account. Existing users keep their current value.
+      if (isNewUser) {
+        await tx
+          .update(kilocode_users)
+          .set({ personal_account_disabled: true })
+          .where(eq(kilocode_users.id, userId));
+      }
 
       // Clear any previous removal record so the user isn't treated as "removed"
       // by subsequent webhook events (Subscription Lifecycle 2)


### PR DESCRIPTION
## Summary
- Set `personal_account_disabled = true` for brand-new accounts that are created specifically to accept an organization invite, at the moment they join.
- Existing users who accept an invite keep their current `personal_account_disabled` value.

## Implementation
- `acceptOrganizationInvite` gains an `isNewUser` parameter (default `false`). When a new membership is inserted and `isNewUser` is true, it updates the user's `personal_account_disabled` to `true` within the same transaction. The "already a member" path is unaffected.
- The accept-invite page passes `session.isNewUser`, which is set at signup time and propagated through the JWT/session, so it is `true` exactly when the account was just created and `false` for existing users signing in.

## Testing
- `pnpm --filter web typecheck`
- Added and ran tests in `organizations.test.ts` covering both the new-user (disabled) and existing-user (unchanged) paths.