### PR TITLE
fix(organizations): reduce usage lock contention

### DIFF
--- a/apps/web/src/lib/organizations/organization-usage.test.ts
+++ b/apps/web/src/lib/organizations/organization-usage.test.ts
@@ -2,10 +2,14 @@ import { describe, test, expect, afterEach } from '@jest/globals';
 import { after } from 'next/server';
 import { sendBalanceAlertEmail } from '@/lib/email';
 import { db } from '@/lib/drizzle';
-import { organizations, organization_user_usage } from '@kilocode/db/schema';
+import {
+  organizations,
+  organization_memberships,
+  organization_user_usage,
+} from '@kilocode/db/schema';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import {
   createOrganization,
   addUserToOrganization,
@@ -204,6 +208,78 @@ describe('Organization Usage Functions', () => {
         minimum_balance: 0.04,
         to: ['billing@example.com'],
       });
+    });
+
+    test('does not report low-balance crossing when usage stays above threshold', async () => {
+      const user = await insertTestUser();
+      const organization = await createTestOrganization('Balance Alert Org', user.id, 50_000, {
+        minimum_balance: 0.04,
+        minimum_balance_alert_email: ['billing@example.com'],
+      });
+      const usage = await createOrganizationUsage(5_000, user.id, organization.id);
+
+      const result = await db.transaction(tx => mutateOrganizationUsage(tx, usage));
+
+      expect(result).toEqual({
+        crossedMinimumBalance: false,
+        recipients: [],
+        minimumBalanceMicrodollars: 40_000,
+      });
+
+      scheduleOrganizationLowBalanceAlert(organization.id, result);
+
+      expect(jest.mocked(after)).not.toHaveBeenCalled();
+      expect(jest.mocked(sendBalanceAlertEmail)).not.toHaveBeenCalled();
+    });
+
+    test('returns no organization balance alert result for missing organization', async () => {
+      const user = await insertTestUser();
+      const missingOrganizationId = '00000000-0000-0000-0000-000000000000';
+      await db.insert(organization_memberships).values({
+        organization_id: missingOrganizationId,
+        kilo_user_id: user.id,
+        role: 'member',
+      });
+      const usage = await createOrganizationUsage(5_000, user.id, missingOrganizationId);
+
+      const result = await db.transaction(tx => mutateOrganizationUsage(tx, usage));
+
+      expect(result).toEqual({
+        crossedMinimumBalance: false,
+        recipients: [],
+        minimumBalanceMicrodollars: null,
+      });
+
+      const usageRows = await db
+        .select({ id: organization_user_usage.id })
+        .from(organization_user_usage)
+        .where(eq(organization_user_usage.organization_id, missingOrganizationId));
+
+      expect(usageRows).toEqual([]);
+    });
+
+    test('increments organization user usage for same daily bucket', async () => {
+      const user = await insertTestUser();
+      const organization = await createTestOrganization('User Usage Org', user.id, 50_000);
+      const firstUsage = await createOrganizationUsage(5_000, user.id, organization.id);
+      const secondUsage = await createOrganizationUsage(7_000, user.id, organization.id);
+
+      await db.transaction(tx => mutateOrganizationUsage(tx, firstUsage));
+      await db.transaction(tx => mutateOrganizationUsage(tx, secondUsage));
+
+      const usageRows = await db
+        .select({ microdollar_usage: organization_user_usage.microdollar_usage })
+        .from(organization_user_usage)
+        .where(
+          and(
+            eq(organization_user_usage.organization_id, organization.id),
+            eq(organization_user_usage.kilo_user_id, user.id),
+            eq(organization_user_usage.limit_type, 'daily')
+          )
+        );
+
+      expect(usageRows).toHaveLength(1);
+      expect(usageRows[0]?.microdollar_usage).toBe(12_000);
     });
 
     test('should handle large cost usage', async () => {

--- a/apps/web/src/lib/organizations/organization-usage.ts
+++ b/apps/web/src/lib/organizations/organization-usage.ts
@@ -230,38 +230,6 @@ export async function mutateOrganizationUsage(
   const { cost, kilo_user_id, organization_id, created_at } = usage;
   if (!organization_id) return NO_ORGANIZATION_BALANCE_ALERT;
 
-  const [orgData] = await tx
-    .select({
-      total_microdollars_acquired: organizations.total_microdollars_acquired,
-      microdollars_used: organizations.microdollars_used,
-      settings: organizations.settings,
-    })
-    .from(organizations)
-    .where(eq(organizations.id, organization_id))
-    .limit(1)
-    .for('update');
-
-  if (!orgData) return NO_ORGANIZATION_BALANCE_ALERT;
-
-  const currentBalance = orgData.total_microdollars_acquired - orgData.microdollars_used;
-  const minimumBalance = orgData.settings?.minimum_balance
-    ? toMicrodollars(orgData.settings.minimum_balance)
-    : null;
-  const newBalance = currentBalance - cost;
-  const crossedMinimumBalance =
-    minimumBalance != null && currentBalance >= minimumBalance && newBalance < minimumBalance;
-  const recipients = crossedMinimumBalance
-    ? (orgData.settings?.minimum_balance_alert_email ?? [])
-    : [];
-
-  await tx
-    .update(organizations)
-    .set({
-      microdollars_used: sql`${organizations.microdollars_used} + ${cost}`,
-      microdollars_balance: sql`${organizations.microdollars_balance} - ${cost}`,
-    })
-    .where(eq(organizations.id, organization_id));
-
   const limitType: OrganizationUserLimitType = 'daily';
   await tx.execute(sql`
     INSERT INTO ${organization_user_usage} (
@@ -287,11 +255,45 @@ export async function mutateOrganizationUsage(
       WHERE ${organization_memberships.organization_id} = ${organization_id}
         AND ${organization_memberships.kilo_user_id} = ${kilo_user_id}
     )
+      AND EXISTS (
+        SELECT 1
+        FROM ${organizations}
+        WHERE ${organizations.id} = ${organization_id}
+      )
     ON CONFLICT (organization_id, kilo_user_id, limit_type, usage_date)
     DO UPDATE SET
       microdollar_usage = ${organization_user_usage.microdollar_usage} + ${cost},
       updated_at = NOW()
   `);
+
+  const [orgData] = await tx
+    .update(organizations)
+    .set({
+      microdollars_used: sql`${organizations.microdollars_used} + ${cost}`,
+      microdollars_balance: sql`${organizations.microdollars_balance} - ${cost}`,
+    })
+    .where(eq(organizations.id, organization_id))
+    .returning({
+      total_microdollars_acquired: organizations.total_microdollars_acquired,
+      previous_microdollars_used: sql<number>`${organizations.microdollars_used} - ${cost}`.mapWith(
+        Number
+      ),
+      new_microdollars_used: organizations.microdollars_used,
+      settings: organizations.settings,
+    });
+
+  if (!orgData) return NO_ORGANIZATION_BALANCE_ALERT;
+
+  const currentBalance = orgData.total_microdollars_acquired - orgData.previous_microdollars_used;
+  const newBalance = orgData.total_microdollars_acquired - orgData.new_microdollars_used;
+  const minimumBalance = orgData.settings?.minimum_balance
+    ? toMicrodollars(orgData.settings.minimum_balance)
+    : null;
+  const crossedMinimumBalance =
+    minimumBalance != null && currentBalance >= minimumBalance && newBalance < minimumBalance;
+  const recipients = crossedMinimumBalance
+    ? (orgData.settings?.minimum_balance_alert_email ?? [])
+    : [];
 
   return {
     crossedMinimumBalance,


### PR DESCRIPTION
## Summary

Organization usage mutations no longer serialize on a long-lived `SELECT ... FOR UPDATE` lock when recording spend.

### Why this change is needed

High-volume organizations can emit hundreds of usage events per minute. Each event previously locked the same `organizations` row before doing additional usage accounting, which caused long lock queues and elevated DB wait time.

### How this is addressed

- Moves daily per-user usage accounting before the organization balance mutation so secondary upsert contention does not extend the organization row lock.
- Replaces the explicit `SELECT ... FOR UPDATE` plus later update with one atomic `UPDATE ... RETURNING`.
- Preserves low-balance alert crossing logic by returning previous and new usage totals from the balance update.
- Guards per-user usage accounting against stale membership rows when the organization row no longer exists.

## Human Verification

- `pnpm --filter web test -- organization-usage.test.ts` passed: 53 tests.
- Test run emitted existing Upstash Redis missing URL/token warnings from the usage helper path.

## Reviewer Notes

### Human Reviewer Flags

- This intentionally preserves the existing behavior where organization totals can still be charged for an existing organization even if the user membership guard prevents a per-user daily usage row.

### Code Reviewer Agent

<details>
<summary>Code Reviewer Notes</summary>

- The hot query from `mutateOrganizationUsage` no longer calls `.for('update')`.
- PostgreSQL `RETURNING` reads post-update values, so `previous_microdollars_used` is computed as returned `microdollars_used - cost`.
- Missing-organization behavior now includes a regression test with a stale membership row and asserts no orphan `organization_user_usage` record is created.

</details>
