### PR TITLE
fix(mobile): model picker sheet header overlapping list content

### DIFF
--- a/apps/mobile/src/components/agents/model-picker-content.tsx
+++ b/apps/mobile/src/components/agents/model-picker-content.tsx
@@ -3,9 +3,9 @@ import { useFocusEffect, useRouter } from 'expo-router';
 import { Search } from 'lucide-react-native';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { FlatList, Pressable, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ModelPickerOptionRow } from '@/components/agents/model-selector';
-import { ScreenHeader } from '@/components/screen-header';
 import { Text } from '@/components/ui/text';
 import { useModelPreferences } from '@/lib/hooks/use-model-preferences';
 import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
@@ -25,6 +25,7 @@ import {
 export function ModelPickerContent() {
   const router = useRouter();
   const colors = useThemeColors();
+  const { bottom } = useSafeAreaInsets();
   const { favorites, toggleFavorite } = useModelPreferences(undefined);
   const favoriteIds = useMemo(() => new Set(favorites), [favorites]);
   const [search, setSearch] = useState('');
@@ -132,87 +133,79 @@ export function ModelPickerContent() {
 
   if (!bridge) {
     return (
-      <View className="flex-1 bg-background">
-        <ScreenHeader title="Select model" />
-        <View className="flex-1 items-center justify-center px-6">
-          <Text className="text-center text-muted-foreground">No models available</Text>
-        </View>
+      <View className="flex-1 items-center justify-center bg-background">
+        <Text className="text-muted-foreground">No models available</Text>
       </View>
     );
   }
 
   return (
-    <View className="flex-1 bg-background">
-      <ScreenHeader
-        title="Select model"
-        onBack={closePicker}
-        showBackButton
-        headerRight={
-          <Pressable
-            onPress={closePicker}
-            accessibilityRole="button"
-            accessibilityLabel="Done selecting model"
-            className="rounded-full bg-secondary px-4 py-2 active:opacity-70"
-          >
-            <Text className="text-base font-medium text-foreground">Done</Text>
-          </Pressable>
-        }
-      />
-      <FlatList
-        className="flex-1"
-        data={rows}
-        keyExtractor={item => item.key}
-        keyboardShouldPersistTaps="handled"
-        keyboardDismissMode="on-drag"
-        contentInsetAdjustmentBehavior="automatic"
-        ListHeaderComponent={
-          <View className="border-b border-border bg-background px-4 pb-3">
-            <View className="flex-row items-center gap-2 rounded-full bg-secondary px-3 py-2">
-              <Search size={18} color={colors.mutedForeground} />
-              <TextInput
-                placeholder="Search models..."
-                placeholderTextColor={colors.mutedForeground}
-                autoCapitalize="none"
-                autoCorrect={false}
-                clearButtonMode="while-editing"
-                returnKeyType="search"
-                className="h-8 flex-1 p-0 text-base leading-5 text-foreground"
-                onChangeText={setSearch}
-              />
-            </View>
+    <FlatList
+      className="flex-1 bg-background"
+      data={rows}
+      keyExtractor={item => item.key}
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
+      contentContainerStyle={{ paddingBottom: bottom }}
+      ListHeaderComponent={
+        <View className="border-b border-border bg-background px-4 pb-3 pt-4">
+          <View className="h-11 flex-row items-center justify-center">
+            <Text className="text-lg font-semibold text-foreground">Select Model</Text>
+            <Pressable
+              onPress={closePicker}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel="Done selecting model"
+              className="absolute right-0 rounded-full bg-secondary px-4 py-2 active:opacity-70 will-change-pressable"
+            >
+              <Text className="text-base font-medium text-foreground">Done</Text>
+            </Pressable>
           </View>
-        }
-        ListEmptyComponent={
-          <View className="items-center justify-center px-6 py-16">
-            <Text className="text-center text-sm text-muted-foreground">
-              {search.trim() ? 'No models match your search' : 'No models available'}
-            </Text>
-          </View>
-        }
-        renderItem={({ item }) => {
-          if (item.type === 'header') {
-            return (
-              <View className="bg-secondary px-4 py-2">
-                <Text className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                  {item.title}
-                </Text>
-              </View>
-            );
-          }
-
-          return (
-            <ModelPickerOptionRow
-              option={item.model}
-              selected={item.model.id === selectedModel}
-              selectedVariant={selectedVariant}
-              isFavorite={item.isFavorite}
-              onSelectModel={handleSelectModel}
-              onSelectVariant={handleSelectVariant}
-              onToggleFavorite={handleToggleFavorite}
+          <View className="mt-2 flex-row items-center gap-2 rounded-full bg-secondary px-3 py-2">
+            <Search size={18} color={colors.mutedForeground} />
+            <TextInput
+              placeholder="Search models..."
+              placeholderTextColor={colors.mutedForeground}
+              autoCapitalize="none"
+              autoCorrect={false}
+              clearButtonMode="while-editing"
+              returnKeyType="search"
+              className="h-8 flex-1 p-0 text-base leading-5 text-foreground"
+              onChangeText={setSearch}
             />
+          </View>
+        </View>
+      }
+      ListEmptyComponent={
+        <View className="items-center justify-center px-6 py-16">
+          <Text className="text-center text-sm text-muted-foreground">
+            {search.trim() ? 'No models match your search' : 'No models available'}
+          </Text>
+        </View>
+      }
+      renderItem={({ item }) => {
+        if (item.type === 'header') {
+          return (
+            <View className="bg-secondary px-4 py-2">
+              <Text className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {item.title}
+              </Text>
+            </View>
           );
-        }}
-      />
-    </View>
+        }
+
+        return (
+          <ModelPickerOptionRow
+            option={item.model}
+            selected={item.model.id === selectedModel}
+            selectedVariant={selectedVariant}
+            isFavorite={item.isFavorite}
+            onSelectModel={handleSelectModel}
+            onSelectVariant={handleSelectVariant}
+            onToggleFavorite={handleToggleFavorite}
+          />
+        );
+      }}
+    />
   );
 }


### PR DESCRIPTION
## Problem

Since #4325 the model picker formSheet rendered a `ScreenHeader` above its `FlatList`. Inside the sheet the header pads itself by the window top inset and ends up overlapping the list — the "Select model" title and Done button float over the favorites rows:

| Half detent | Full detent |
|---|---|
| header floats mid-sheet over rows | header strikes through "Auto Frontier" |

## Fix

Restore the pre-#4325 structure, which is also what `repo-picker` (same formSheet setup) uses: the title row (+ Done) and the search field live in the FlatList's `ListHeaderComponent`; no `ScreenHeader` inside the sheet. Behavior (selection commit on close, favorites, search, thinking-effort variants) is unchanged.

## Verification

Reproduced and re-verified on the iOS simulator via Maestro: opened New Session → model picker at both detents, confirmed header/search render at the sheet top with no overlap, scrolling works, selecting a model closes the sheet and updates the composer chip, checks (`format`, `typecheck`, `lint`, `check:unused`) pass.