### PR TITLE
feat(coding-plans): add pending key rotation

### DIFF
--- a/apps/web/src/app/admin/coding-plans/CodingPlansOperationsContent.tsx
+++ b/apps/web/src/app/admin/coding-plans/CodingPlansOperationsContent.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useReducer } from 'react';
+import Link from 'next/link';
+import { useReducer, useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { ExternalLink, RefreshCw, ShieldAlert, Upload } from 'lucide-react';
+import { Copy, ExternalLink, RefreshCw, ShieldAlert, Upload } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -17,6 +18,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -36,6 +38,14 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
+import { SubscriptionStatusBadge } from '@/components/subscriptions/SubscriptionStatusBadge';
+import {
+  formatCodingPlanPrice,
+  formatDateLabel,
+  formatLocalDateTimeLabel,
+  getCodingPlanBillingDate,
+  getCodingPlanDisplayStatus,
+} from '@/components/subscriptions/helpers';
 import type { UserByokProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import type { CodingPlanId } from '@/lib/coding-plans/pricing';
 import { useTRPC } from '@/lib/trpc/utils';
@@ -45,8 +55,8 @@ type OperationsState = {
   planId: CodingPlanId;
   entriesText: string;
   completeInventoryId: string | null;
-  failureInventoryId: string | null;
-  failureReason: string;
+  replacementInventoryId: string | null;
+  replacementApiKey: string;
 };
 
 const INITIAL_OPERATIONS_STATE: OperationsState = {
@@ -54,8 +64,8 @@ const INITIAL_OPERATIONS_STATE: OperationsState = {
   planId: 'minimax-token-plan-plus',
   entriesText: '',
   completeInventoryId: null,
-  failureInventoryId: null,
-  failureReason: '',
+  replacementInventoryId: null,
+  replacementApiKey: '',
 };
 
 function updateOperationsState(state: OperationsState, update: Partial<OperationsState>) {
@@ -65,29 +75,39 @@ function updateOperationsState(state: OperationsState, update: Partial<Operation
 export function CodingPlansOperationsContent() {
   const trpc = useTRPC();
   const [state, updateState] = useReducer(updateOperationsState, INITIAL_OPERATIONS_STATE);
+  const [insightsRangeDays, setInsightsRangeDays] = useState<InsightsRangeDays>(7);
   const {
     providerId,
     planId,
     entriesText,
     completeInventoryId,
-    failureInventoryId,
-    failureReason,
+    replacementInventoryId,
+    replacementApiKey,
   } = state;
   const setProviderId = (providerId: UserByokProviderId) => updateState({ providerId });
   const setPlanId = (planId: CodingPlanId) => updateState({ planId });
   const setEntriesText = (entriesText: string) => updateState({ entriesText });
   const setCompleteInventoryId = (completeInventoryId: string | null) =>
     updateState({ completeInventoryId });
-  const setFailureInventoryId = (failureInventoryId: string | null) =>
-    updateState({ failureInventoryId });
-  const setFailureReason = (failureReason: string) => updateState({ failureReason });
+  const setReplacementInventoryId = (replacementInventoryId: string | null) =>
+    updateState({ replacementInventoryId });
+  const setReplacementApiKey = (replacementApiKey: string) => updateState({ replacementApiKey });
 
   const countsQuery = useQuery(trpc.codingPlans.adminKeyInventory.queryOptions({}));
   const queueQuery = useQuery(trpc.codingPlans.adminRevocationQueue.queryOptions({}));
+  const subscriptionsQuery = useQuery(trpc.codingPlans.adminListSubscriptions.queryOptions({}));
+  const availabilityIntentCountsQuery = useQuery(
+    trpc.codingPlans.adminAvailabilityIntentCounts.queryOptions({})
+  );
   const catalogQuery = useQuery(trpc.codingPlans.catalog.queryOptions());
 
   const refreshOperations = async () => {
-    await Promise.all([countsQuery.refetch(), queueQuery.refetch()]);
+    await Promise.all([
+      countsQuery.refetch(),
+      queueQuery.refetch(),
+      subscriptionsQuery.refetch(),
+      availabilityIntentCountsQuery.refetch(),
+    ]);
   };
 
   const uploadMutation = useMutation(
@@ -106,39 +126,31 @@ export function CodingPlansOperationsContent() {
     trpc.codingPlans.adminMarkRevocationComplete.mutationOptions({
       onSuccess: async () => {
         setCompleteInventoryId(null);
-        toast.success('MiniMax plan marked revoked.');
+        toast.success('MiniMax credential removed from stock.');
         await refreshOperations();
       },
       onError: error => toast.error(error.message || 'Unable to mark credential revoked.'),
     })
   );
-  const failureMutation = useMutation(
-    trpc.codingPlans.adminMarkRevocationFailed.mutationOptions({
+  const replacementMutation = useMutation(
+    trpc.codingPlans.adminReplaceRevocationCredential.mutationOptions({
       onSuccess: async () => {
-        setFailureInventoryId(null);
-        setFailureReason('');
-        toast.success('Revocation failure recorded for retry.');
+        setReplacementInventoryId(null);
+        setReplacementApiKey('');
+        toast.success('MiniMax credential replaced and returned to stock.');
         await refreshOperations();
       },
-      onError: error => toast.error(error.message || 'Unable to record revocation failure.'),
+      onError: error => toast.error(error.message || 'Unable to replace credential.'),
     })
   );
-  const requeueMutation = useMutation(
-    trpc.codingPlans.adminRequeueRevocation.mutationOptions({
-      onSuccess: async () => {
-        toast.success('Credential requeued for manual revocation.');
-        await refreshOperations();
-      },
-      onError: error => toast.error(error.message || 'Unable to requeue credential.'),
-    })
-  );
-
   const submittedEntries = entriesText
     .split('\n')
     .map(entry => entry.trim())
     .filter(entry => entry.length > 0);
   const workItems = queueQuery.data ?? [];
   const inventoryCounts = countsQuery.data ?? [];
+  const subscriptions = subscriptionsQuery.data ?? [];
+  const availabilityIntentCounts = availabilityIntentCountsQuery.data ?? [];
   const catalog = catalogQuery.data ?? [];
   const providerOptions = Array.from(
     new Map(
@@ -161,24 +173,62 @@ export function CodingPlansOperationsContent() {
     {
       label: 'Total credentials in system',
       count: totalCredentialCount,
-      detail: 'All inventory states',
     },
     {
       label: 'Available credentials in system',
       count: countCredentialsByStatus('available'),
-      detail: 'Ready for assignment',
     },
     {
-      label: 'Revoked credentials',
-      count: countCredentialsByStatus('revoked'),
-      detail: 'Confirmed complete',
+      label: 'Assigned credentials',
+      count: countCredentialsByStatus('assigned'),
     },
     {
       label: 'Pending revocation credentials',
       count: countCredentialsByStatus('revocation_pending'),
-      detail: 'Awaiting manual action',
     },
   ];
+  const countSubscriptionsByDisplayStatus = (status: string) =>
+    subscriptions.reduce(
+      (total, subscription) =>
+        total + (getCodingPlanDisplayStatus(subscription) === status ? 1 : 0),
+      0
+    );
+  const subscriptionSummary = [
+    {
+      label: 'Total subscriptions',
+      count: subscriptions.length,
+    },
+    {
+      label: 'Active subscriptions',
+      count: countSubscriptionsByDisplayStatus('active'),
+    },
+    {
+      label: 'Cancellation pending',
+      count: countSubscriptionsByDisplayStatus('pending_cancellation'),
+    },
+    {
+      label: 'Past due subscriptions',
+      count: countSubscriptionsByDisplayStatus('past_due'),
+    },
+  ];
+  const insights = getCodingPlanInsights(subscriptions, insightsRangeDays);
+  const planPerformanceRows = getPlanPerformanceRows({
+    catalog,
+    subscriptions,
+    inventoryCounts,
+    availabilityIntentCounts,
+    rangeDays: insightsRangeDays,
+  });
+  const insightsLoading =
+    subscriptionsQuery.isLoading ||
+    countsQuery.isLoading ||
+    catalogQuery.isLoading ||
+    availabilityIntentCountsQuery.isLoading;
+  const insightsError =
+    subscriptionsQuery.isError ||
+    countsQuery.isError ||
+    catalogQuery.isError ||
+    availabilityIntentCountsQuery.isError;
 
   return (
     <div className="flex w-full flex-col gap-6">
@@ -186,7 +236,7 @@ export function CodingPlansOperationsContent() {
         <div className="space-y-2">
           <h2 className="text-2xl font-bold">Coding plans operations</h2>
           <p className="text-muted-foreground max-w-4xl text-sm">
-            Manage validated MiniMax Coding Plan inventory and manual credential revocation.
+            Track Coding Plan subscriptions, inventory capacity, and manual credential revocation.
           </p>
         </div>
         <Button variant="secondary" asChild>
@@ -201,72 +251,145 @@ export function CodingPlansOperationsContent() {
         </Button>
       </div>
 
-      <InventorySummaryCards
-        items={inventorySummary}
-        isLoading={countsQuery.isLoading}
-        isError={countsQuery.isError}
-      />
+      <Tabs defaultValue="insights" className="space-y-4">
+        <TabsList className="h-auto w-full flex-col items-stretch justify-start gap-1 rounded-xl p-1 sm:w-fit sm:flex-row sm:items-center">
+          <TabsTrigger value="insights">Insights</TabsTrigger>
+          <TabsTrigger value="subscriptions">Subscriptions</TabsTrigger>
+          <TabsTrigger value="inventory-management">Inventory management</TabsTrigger>
+        </TabsList>
 
-      <InventoryCountsTable
-        items={inventoryCounts}
-        isLoading={countsQuery.isLoading}
-        isError={countsQuery.isError}
-      />
+        <TabsContent value="insights" className="mt-0 space-y-6">
+          <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
+            <p className="text-muted-foreground text-sm">
+              Rolling metrics use the selected window. Current-state cards show live totals.
+            </p>
+            <InsightsRangeFilter value={insightsRangeDays} onChange={setInsightsRangeDays} />
+          </div>
+          <KpiCards
+            items={insights}
+            isLoading={subscriptionsQuery.isLoading}
+            isError={subscriptionsQuery.isError}
+          />
+          <PlanPerformanceTable
+            rows={planPerformanceRows}
+            rangeDays={insightsRangeDays}
+            isLoading={insightsLoading}
+            isError={insightsError}
+          />
+        </TabsContent>
 
-      <OperationsTabs
-        workItems={workItems}
-        queueLoading={queueQuery.isLoading}
-        queueError={queueQuery.isError}
-        providerOptions={providerOptions}
-        planOptions={planOptions}
-        selectedProviderId={selectedProviderId}
-        selectedPlanId={selectedPlanId}
-        catalogLoading={catalogQuery.isLoading}
-        catalogError={catalogQuery.isError}
-        entriesText={entriesText}
-        submittedEntries={submittedEntries}
-        uploadPending={uploadMutation.isPending}
-        requeuePending={requeueMutation.isPending}
-        onRefresh={() => void refreshOperations()}
-        onComplete={setCompleteInventoryId}
-        onFailure={setFailureInventoryId}
-        onRequeue={inventoryKeyId => requeueMutation.mutate({ inventoryKeyId })}
-        onProviderChange={value => setProviderId(value as UserByokProviderId)}
-        onPlanChange={value => setPlanId(value as CodingPlanId)}
-        onEntriesTextChange={setEntriesText}
-        onUpload={() => {
-          if (!selectedPlan) {
-            return;
-          }
+        <TabsContent value="subscriptions" className="mt-0 space-y-6">
+          <SummaryCards
+            items={subscriptionSummary}
+            isLoading={subscriptionsQuery.isLoading}
+            isError={subscriptionsQuery.isError}
+            ariaLabel="Coding Plan subscription summary"
+          />
 
-          uploadMutation.mutate({
-            providerId: selectedProviderId as UserByokProviderId,
-            planId: selectedPlanId as CodingPlanId,
-            entries: submittedEntries,
-          });
-        }}
-      />
+          <SubscriptionsTable
+            items={subscriptions}
+            isLoading={subscriptionsQuery.isLoading}
+            isError={subscriptionsQuery.isError}
+          />
+        </TabsContent>
+
+        <TabsContent value="inventory-management" className="mt-0">
+          <OperationsTabs
+            inventorySummary={inventorySummary}
+            inventoryCounts={inventoryCounts}
+            inventoryLoading={countsQuery.isLoading}
+            inventoryError={countsQuery.isError}
+            workItems={workItems}
+            queueLoading={queueQuery.isLoading}
+            queueError={queueQuery.isError}
+            providerOptions={providerOptions}
+            planOptions={planOptions}
+            selectedProviderId={selectedProviderId}
+            selectedPlanId={selectedPlanId}
+            catalogLoading={catalogQuery.isLoading}
+            catalogError={catalogQuery.isError}
+            entriesText={entriesText}
+            submittedEntries={submittedEntries}
+            uploadPending={uploadMutation.isPending}
+            onRefresh={() => void refreshOperations()}
+            onComplete={setCompleteInventoryId}
+            onReplace={setReplacementInventoryId}
+            onProviderChange={value => setProviderId(value as UserByokProviderId)}
+            onPlanChange={value => setPlanId(value as CodingPlanId)}
+            onEntriesTextChange={setEntriesText}
+            onUpload={() => {
+              if (!selectedPlan) {
+                return;
+              }
+
+              uploadMutation.mutate({
+                providerId: selectedProviderId as UserByokProviderId,
+                planId: selectedPlanId as CodingPlanId,
+                entries: submittedEntries,
+              });
+            }}
+          />
+        </TabsContent>
+      </Tabs>
 
       <OperationsDialogs
         completeInventoryId={completeInventoryId}
         completePending={completeMutation.isPending}
-        failureInventoryId={failureInventoryId}
-        failureReason={failureReason}
-        failurePending={failureMutation.isPending}
+        replacementInventoryId={replacementInventoryId}
+        replacementApiKey={replacementApiKey}
+        replacementPending={replacementMutation.isPending}
         onCloseComplete={() => setCompleteInventoryId(null)}
         onComplete={inventoryKeyId => completeMutation.mutate({ inventoryKeyId })}
-        onCloseFailure={() => setFailureInventoryId(null)}
-        onFailureReasonChange={setFailureReason}
-        onFailure={(inventoryKeyId, reason) => failureMutation.mutate({ inventoryKeyId, reason })}
+        onCloseReplacement={() => {
+          setReplacementInventoryId(null);
+          setReplacementApiKey('');
+        }}
+        onReplacementApiKeyChange={setReplacementApiKey}
+        onReplace={(inventoryKeyId, apiKey) =>
+          replacementMutation.mutate({ inventoryKeyId, apiKey })
+        }
       />
     </div>
   );
 }
 
-type InventorySummaryItem = {
+type SummaryItem = {
   label: string;
   count: number;
+};
+
+type KpiItem = {
+  label: string;
+  value: string;
   detail: string;
+};
+
+type InsightsRangeDays = 7 | 14 | 30;
+
+type AdminCodingPlanCatalogItem = {
+  planId: string;
+  providerName: string;
+  name: string;
+  providerId: string;
+  costKiloCredits: number;
+  billingPeriodDays: number;
+};
+
+type AvailabilityIntentCountItem = {
+  planId: string;
+  count: number;
+};
+
+type PlanPerformanceRow = {
+  planId: string;
+  planName: string;
+  providerName: string;
+  activeSubscriptions: number;
+  monthlyRecurringValue: number;
+  newSubscriptionsInRange: number;
+  canceledSubscriptionsInRange: number;
+  availableCredentials: number;
+  waitlistIntents: number;
 };
 
 type InventoryCountItem = {
@@ -276,6 +399,42 @@ type InventoryCountItem = {
   count: number;
 };
 
+type InventoryCountRow = {
+  providerId: string;
+  planId: string;
+  loadedCount: number;
+  statusCounts: Record<string, number>;
+};
+
+type AdminCodingPlanSubscriptionItem = {
+  id: string;
+  userId: string;
+  userName: string;
+  planId: string;
+  planName: string;
+  providerId: string;
+  providerName: string;
+  status: string;
+  billingPeriodDays: number;
+  currentPeriodEnd: string;
+  creditRenewalAt: string;
+  cancelAtPeriodEnd: boolean;
+  paymentGraceExpiresAt: string | null;
+  canceledAt: string | null;
+  createdAt: string;
+  costKiloCredits: number;
+};
+
+const INVENTORY_STATUS_ORDER = [
+  'assigned',
+  'available',
+  'revocation_pending',
+  'revocation_failed',
+  'revoked',
+];
+
+const INSIGHTS_RANGE_OPTIONS = [7, 14, 30] satisfies InsightsRangeDays[];
+
 type RevocationWorkItem = {
   inventoryKeyId: string;
   providerId: string;
@@ -284,21 +443,21 @@ type RevocationWorkItem = {
   status: string;
   revocationRequestedAt: string | null;
   subscriptionExpiresAt: string | null;
-  revocationAttemptCount: number;
-  lastRevocationError: string | null;
 };
 
-function InventorySummaryCards({
+function SummaryCards({
   items,
   isLoading,
   isError,
+  ariaLabel,
 }: {
-  items: InventorySummaryItem[];
+  items: SummaryItem[];
   isLoading: boolean;
   isError: boolean;
+  ariaLabel: string;
 }) {
   return (
-    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4" aria-label="Credential summary">
+    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4" aria-label={ariaLabel}>
       {items.map(summary => (
         <Card key={summary.label}>
           <CardContent className="space-y-2 p-4">
@@ -310,7 +469,6 @@ function InventorySummaryCards({
             ) : (
               <p className="font-mono text-2xl font-semibold tabular-nums">{summary.count}</p>
             )}
-            <p className="text-muted-foreground text-xs">{summary.detail}</p>
           </CardContent>
         </Card>
       ))}
@@ -318,57 +476,149 @@ function InventorySummaryCards({
   );
 }
 
-function InventoryCountsTable({
+function InsightsRangeFilter({
+  value,
+  onChange,
+}: {
+  value: InsightsRangeDays;
+  onChange: (value: InsightsRangeDays) => void;
+}) {
+  return (
+    <fieldset className="flex flex-wrap gap-2" aria-label="Insights date range">
+      {INSIGHTS_RANGE_OPTIONS.map(option => {
+        const selected = option === value;
+        return (
+          <Button
+            key={option}
+            type="button"
+            variant={selected ? 'secondary' : 'ghost'}
+            size="sm"
+            aria-pressed={selected}
+            onClick={() => onChange(option)}
+          >
+            Last {option} days
+          </Button>
+        );
+      })}
+    </fieldset>
+  );
+}
+
+function KpiCards({
   items,
   isLoading,
   isError,
 }: {
-  items: InventoryCountItem[];
+  items: KpiItem[];
   isLoading: boolean;
   isError: boolean;
 }) {
   return (
+    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4" aria-label="Coding Plan insights">
+      {items.map(item => (
+        <Card key={item.label}>
+          <CardContent className="space-y-3 p-4">
+            <div className="space-y-1">
+              <p className="text-muted-foreground text-xs">{item.label}</p>
+              {isLoading ? (
+                <Skeleton aria-hidden="true" className="h-8 w-24" />
+              ) : isError ? (
+                <p className="text-muted-foreground text-sm">Unavailable</p>
+              ) : (
+                <p className="font-mono text-2xl font-semibold tabular-nums">{item.value}</p>
+              )}
+            </div>
+            <p className="text-muted-foreground text-xs leading-5">{item.detail}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </section>
+  );
+}
+
+function PlanPerformanceTable({
+  rows,
+  rangeDays,
+  isLoading,
+  isError,
+}: {
+  rows: PlanPerformanceRow[];
+  rangeDays: InsightsRangeDays;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  const rangeLabel = formatInsightsRangeLabel(rangeDays);
+
+  return (
     <Card>
       <CardHeader>
-        <CardTitle>Inventory counts</CardTitle>
+        <CardTitle>Plan performance</CardTitle>
         <CardDescription>
-          Credential inventory grouped by provider, plan, and status.
+          Subscription movement, recurring value, capacity, and demand by plan.
         </CardDescription>
       </CardHeader>
       <CardContent>
         <div className="overflow-x-auto rounded-lg border">
-          <Table>
+          <Table className="min-w-[76rem] table-fixed">
+            <colgroup>
+              <col className="w-72" />
+              <col className="w-36" />
+              <col className="w-36" />
+              <col className="w-48" />
+              <col className="w-48" />
+              <col className="w-48" />
+              <col className="w-48" />
+            </colgroup>
             <TableHeader>
               <TableRow>
-                <TableHead>Provider</TableHead>
                 <TableHead>Plan</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead className="text-right">Count</TableHead>
+                <TableHead className="text-right">Active subs</TableHead>
+                <TableHead className="text-right">MRR</TableHead>
+                <TableHead className="text-right">New ({rangeLabel})</TableHead>
+                <TableHead className="text-right">Canceled ({rangeLabel})</TableHead>
+                <TableHead className="text-right">Available inventory</TableHead>
+                <TableHead className="text-right">Waitlist</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {isError ? (
                 <TableRow>
-                  <TableCell colSpan={4} className="h-24 text-center text-red-300">
-                    Unable to load inventory counts.
+                  <TableCell colSpan={7} className="h-24 text-center text-red-300">
+                    Unable to load plan performance.
                   </TableCell>
                 </TableRow>
-              ) : items.length === 0 ? (
+              ) : rows.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={4} className="text-muted-foreground h-24 text-center">
-                    {isLoading ? 'Loading inventory counts...' : 'No inventory recorded.'}
+                  <TableCell colSpan={7} className="text-muted-foreground h-24 text-center">
+                    {isLoading ? 'Loading plan performance...' : 'No plan performance data.'}
                   </TableCell>
                 </TableRow>
               ) : (
-                items.map(item => (
-                  <TableRow key={`${item.providerId}:${item.planId}:${item.status}`}>
-                    <TableCell className="font-mono text-xs">{item.providerId}</TableCell>
-                    <TableCell className="font-mono text-xs">{item.planId}</TableCell>
-                    <TableCell>
-                      <Badge variant="secondary">{formatStatus(item.status)}</Badge>
+                rows.map(row => (
+                  <TableRow key={row.planId}>
+                    <TableCell className="min-w-64">
+                      <div className="font-medium">{row.planName}</div>
+                      <div className="text-muted-foreground mt-1 font-mono text-xs">
+                        {row.providerName} / {row.planId}
+                      </div>
                     </TableCell>
                     <TableCell className="text-right font-mono tabular-nums">
-                      {item.count}
+                      {formatIntegerValue(row.activeSubscriptions)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatCurrencyValue(row.monthlyRecurringValue)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatIntegerValue(row.newSubscriptionsInRange)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatIntegerValue(row.canceledSubscriptionsInRange)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatIntegerValue(row.availableCredentials)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatIntegerValue(row.waitlistIntents)}
                     </TableCell>
                   </TableRow>
                 ))
@@ -381,7 +631,465 @@ function InventoryCountsTable({
   );
 }
 
+function getCodingPlanInsights(
+  subscriptions: AdminCodingPlanSubscriptionItem[],
+  rangeDays: InsightsRangeDays
+): KpiItem[] {
+  const now = new Date();
+  const rangeStart = addDays(now, -rangeDays);
+  const priorRangeStart = addDays(now, -rangeDays * 2);
+  const rangeLabel = `${rangeDays}-day`;
+  const rangeDetailLabel = `last ${rangeDays} days`;
+  const priorRangeDetailLabel = `prior ${rangeDays} days`;
+  const liveSubscriptions = subscriptions.filter(subscription => isLiveSubscription(subscription));
+  const pendingCancellationSubscriptions = liveSubscriptions.filter(
+    subscription => getCodingPlanDisplayStatus(subscription) === 'pending_cancellation'
+  );
+  const pastDueSubscriptions = liveSubscriptions.filter(
+    subscription => subscription.status === 'past_due'
+  );
+  const createdInRange = subscriptions.filter(subscription =>
+    isTimestampBetween(subscription.createdAt, rangeStart, now)
+  );
+  const createdInPriorRange = subscriptions.filter(subscription =>
+    isTimestampBetween(subscription.createdAt, priorRangeStart, rangeStart)
+  );
+  const canceledInRange = subscriptions.filter(
+    subscription =>
+      subscription.status === 'canceled' &&
+      subscription.canceledAt !== null &&
+      isTimestampBetween(subscription.canceledAt, rangeStart, now)
+  );
+  const subscriptionsActiveAtPeriodStart = subscriptions.filter(subscription =>
+    wasSubscriptionLiveAt(subscription, rangeStart)
+  );
+  const retainedSubscriptions = subscriptionsActiveAtPeriodStart.filter(
+    subscription => subscription.status !== 'canceled'
+  );
+  const mrr = liveSubscriptions.reduce(
+    (total, subscription) => total + getMonthlyKiloCreditValue(subscription),
+    0
+  );
+  const revenueAtRisk = [...pendingCancellationSubscriptions, ...pastDueSubscriptions].reduce(
+    (total, subscription) => total + getMonthlyKiloCreditValue(subscription),
+    0
+  );
+  const periodGrowthRate = calculateRate(
+    createdInRange.length - canceledInRange.length,
+    createdInPriorRange.length
+  );
+  const retentionRate = calculateRate(
+    retainedSubscriptions.length,
+    subscriptionsActiveAtPeriodStart.length
+  );
+  const churnRate = calculateRate(canceledInRange.length, subscriptionsActiveAtPeriodStart.length);
+
+  return [
+    {
+      label: 'Active MRR',
+      value: formatCurrencyValue(mrr),
+      detail: `${liveSubscriptions.length} live subscription${liveSubscriptions.length === 1 ? '' : 's'}`,
+    },
+    {
+      label: `${rangeLabel} growth`,
+      value: formatPercentValue(periodGrowthRate),
+      detail: `${formatSignedCount(createdInRange.length - canceledInRange.length)} net in ${rangeDetailLabel}`,
+    },
+    {
+      label: `${rangeLabel} retention`,
+      value: formatPercentValue(retentionRate),
+      detail: `${retainedSubscriptions.length}/${subscriptionsActiveAtPeriodStart.length} retained from ${rangeDays} days ago`,
+    },
+    {
+      label: `${rangeLabel} churn`,
+      value: formatPercentValue(churnRate),
+      detail: `${canceledInRange.length} canceled in ${rangeDetailLabel}`,
+    },
+    {
+      label: 'Revenue at risk',
+      value: formatCurrencyValue(revenueAtRisk),
+      detail: `${pendingCancellationSubscriptions.length} canceling, ${pastDueSubscriptions.length} past due`,
+    },
+    {
+      label: 'New subscriptions',
+      value: formatIntegerValue(createdInRange.length),
+      detail: `${createdInPriorRange.length} created in ${priorRangeDetailLabel}`,
+    },
+    {
+      label: 'Cancellation pending',
+      value: formatPercentValue(
+        calculateRate(pendingCancellationSubscriptions.length, liveSubscriptions.length)
+      ),
+      detail: `${pendingCancellationSubscriptions.length}/${liveSubscriptions.length} live subscriptions`,
+    },
+    {
+      label: 'Past due exposure',
+      value: formatCurrencyValue(
+        pastDueSubscriptions.reduce(
+          (total, subscription) => total + getMonthlyKiloCreditValue(subscription),
+          0
+        )
+      ),
+      detail: `${pastDueSubscriptions.length} subscription${pastDueSubscriptions.length === 1 ? '' : 's'} in recovery`,
+    },
+  ];
+}
+
+function getPlanPerformanceRows({
+  catalog,
+  subscriptions,
+  inventoryCounts,
+  availabilityIntentCounts,
+  rangeDays,
+}: {
+  catalog: AdminCodingPlanCatalogItem[];
+  subscriptions: AdminCodingPlanSubscriptionItem[];
+  inventoryCounts: InventoryCountItem[];
+  availabilityIntentCounts: AvailabilityIntentCountItem[];
+  rangeDays: InsightsRangeDays;
+}): PlanPerformanceRow[] {
+  const now = new Date();
+  const rangeStart = addDays(now, -rangeDays);
+
+  return catalog.map(plan => {
+    const planSubscriptions = subscriptions.filter(
+      subscription => subscription.planId === plan.planId
+    );
+    const liveSubscriptions = planSubscriptions.filter(subscription =>
+      isLiveSubscription(subscription)
+    );
+    const newSubscriptionsInRange = planSubscriptions.filter(subscription =>
+      isTimestampBetween(subscription.createdAt, rangeStart, now)
+    ).length;
+    const canceledSubscriptionsInRange = planSubscriptions.filter(
+      subscription =>
+        subscription.status === 'canceled' &&
+        subscription.canceledAt !== null &&
+        isTimestampBetween(subscription.canceledAt, rangeStart, now)
+    ).length;
+    const availableCredentials = inventoryCounts
+      .filter(item => item.planId === plan.planId && item.status === 'available')
+      .reduce((total, item) => total + item.count, 0);
+    const waitlistIntents =
+      availabilityIntentCounts.find(item => item.planId === plan.planId)?.count ?? 0;
+    const monthlyRecurringValue = liveSubscriptions.reduce(
+      (total, subscription) => total + getMonthlyKiloCreditValue(subscription),
+      0
+    );
+
+    return {
+      planId: plan.planId,
+      planName: plan.name,
+      providerName: plan.providerName,
+      activeSubscriptions: liveSubscriptions.length,
+      monthlyRecurringValue,
+      newSubscriptionsInRange,
+      canceledSubscriptionsInRange,
+      availableCredentials,
+      waitlistIntents,
+    };
+  });
+}
+
+function InventoryCountsTable({
+  items,
+  isLoading,
+  isError,
+}: {
+  items: InventoryCountItem[];
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  const statusColumns = getInventoryStatusColumns(items);
+  const rows = getInventoryCountRows(items);
+  const columnCount = 3 + statusColumns.length;
+  const metricColumnKeys = ['loaded', ...statusColumns];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Inventory counts</CardTitle>
+        <CardDescription>Credential inventory grouped by provider and plan.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto rounded-lg border">
+          <Table className="min-w-[72rem] table-fixed">
+            <colgroup>
+              <col className="w-32" />
+              <col className="w-80" />
+              {metricColumnKeys.map(key => (
+                <col key={key} />
+              ))}
+            </colgroup>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Provider</TableHead>
+                <TableHead>Plan</TableHead>
+                <TableHead className="text-center">Loaded</TableHead>
+                {statusColumns.map(status => (
+                  <TableHead key={status} className="text-center">
+                    {formatStatusTitle(status)}
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isError ? (
+                <TableRow>
+                  <TableCell colSpan={columnCount} className="h-24 text-center text-red-300">
+                    Unable to load inventory counts.
+                  </TableCell>
+                </TableRow>
+              ) : rows.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={columnCount}
+                    className="text-muted-foreground h-24 text-center"
+                  >
+                    {isLoading ? 'Loading inventory counts...' : 'No inventory recorded.'}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                rows.map(row => (
+                  <TableRow key={`${row.providerId}:${row.planId}`}>
+                    <TableCell className="min-w-32 font-mono text-xs">{row.providerId}</TableCell>
+                    <TableCell className="min-w-64 font-mono text-xs">{row.planId}</TableCell>
+                    <TableCell className="text-center font-mono tabular-nums">
+                      {row.loadedCount}
+                    </TableCell>
+                    {statusColumns.map(status => (
+                      <TableCell key={status} className="text-center font-mono tabular-nums">
+                        {row.statusCounts[status] ?? 0}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function getInventoryStatusColumns(items: InventoryCountItem[]) {
+  const statuses = new Set(items.map(item => item.status));
+  const knownStatuses = INVENTORY_STATUS_ORDER.filter(status => statuses.has(status));
+  const unknownStatuses = Array.from(statuses)
+    .filter(status => !INVENTORY_STATUS_ORDER.includes(status))
+    .sort();
+
+  return [...knownStatuses, ...unknownStatuses];
+}
+
+function getInventoryCountRows(items: InventoryCountItem[]): InventoryCountRow[] {
+  const rowsByKey = new Map<string, InventoryCountRow>();
+
+  for (const item of items) {
+    const rowKey = `${item.providerId}\u0000${item.planId}`;
+    const existingRow = rowsByKey.get(rowKey);
+    const row = existingRow ?? {
+      providerId: item.providerId,
+      planId: item.planId,
+      loadedCount: 0,
+      statusCounts: {},
+    };
+
+    row.loadedCount += item.count;
+    row.statusCounts[item.status] = (row.statusCounts[item.status] ?? 0) + item.count;
+    rowsByKey.set(rowKey, row);
+  }
+
+  return Array.from(rowsByKey.values()).sort(
+    (left, right) =>
+      left.providerId.localeCompare(right.providerId) || left.planId.localeCompare(right.planId)
+  );
+}
+
+function isLiveSubscription(subscription: AdminCodingPlanSubscriptionItem): boolean {
+  return subscription.status === 'active' || subscription.status === 'past_due';
+}
+
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+function isTimestampBetween(value: string, start: Date, end: Date): boolean {
+  const timestamp = new Date(value).getTime();
+  return timestamp >= start.getTime() && timestamp < end.getTime();
+}
+
+function wasSubscriptionLiveAt(subscription: AdminCodingPlanSubscriptionItem, date: Date): boolean {
+  const createdAt = new Date(subscription.createdAt).getTime();
+  const canceledAt = subscription.canceledAt ? new Date(subscription.canceledAt).getTime() : null;
+  const target = date.getTime();
+
+  return createdAt < target && (canceledAt === null || canceledAt >= target);
+}
+
+function getMonthlyKiloCreditValue(subscription: AdminCodingPlanSubscriptionItem): number {
+  return subscription.costKiloCredits * (30 / subscription.billingPeriodDays);
+}
+
+function calculateRate(numerator: number, denominator: number): number | null {
+  return denominator === 0 ? null : numerator / denominator;
+}
+
+function formatCurrencyValue(value: number): string {
+  return value.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: Number.isInteger(value) ? 0 : 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatPercentValue(value: number | null): string {
+  if (value === null) {
+    return '—';
+  }
+
+  return value.toLocaleString('en-US', {
+    style: 'percent',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  });
+}
+
+function formatIntegerValue(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+function formatSignedCount(value: number): string {
+  return value > 0 ? `+${formatIntegerValue(value)}` : formatIntegerValue(value);
+}
+
+function formatInsightsRangeLabel(rangeDays: InsightsRangeDays): string {
+  return `last ${rangeDays} days`;
+}
+
+function SubscriptionsTable({
+  items,
+  isLoading,
+  isError,
+}: {
+  items: AdminCodingPlanSubscriptionItem[];
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Subscriptions</CardTitle>
+        <CardDescription>Coding Plan subscriptions and billing state.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>User</TableHead>
+                <TableHead>Subscription</TableHead>
+                <TableHead>Provider / plan</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Billing date</TableHead>
+                <TableHead className="text-right">Price</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isError ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-24 text-center text-red-300">
+                    Unable to load subscriptions.
+                  </TableCell>
+                </TableRow>
+              ) : items.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="text-muted-foreground h-24 text-center">
+                    {isLoading ? 'Loading subscriptions...' : 'No subscriptions recorded.'}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                items.map(item => {
+                  const displayStatus = getCodingPlanDisplayStatus(item);
+                  const billingDate = getCodingPlanBillingDate(item);
+                  const formattedBillingDate =
+                    item.status === 'past_due'
+                      ? formatLocalDateTimeLabel(billingDate.date)
+                      : formatDateLabel(billingDate.date);
+
+                  return (
+                    <TableRow key={item.id}>
+                      <TableCell className="min-w-56 font-mono text-xs">
+                        <Link
+                          href={`/admin/users/${encodeURIComponent(item.userId)}`}
+                          className="text-link hover:text-link-hover underline-offset-4 hover:underline"
+                        >
+                          {item.userName}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="min-w-56 font-mono text-xs">
+                        <div className="flex items-center gap-2">
+                          <span>{item.id}</span>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-7 text-muted-foreground hover:text-foreground"
+                            aria-label={`Copy subscription ${item.id}`}
+                            onClick={() => void copySubscriptionId(item.id)}
+                          >
+                            <Copy className="size-3.5" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                      <TableCell className="min-w-56 font-mono text-xs">
+                        <div>{item.providerName}</div>
+                        <div className="text-muted-foreground mt-1">{item.planName}</div>
+                      </TableCell>
+                      <TableCell>
+                        <SubscriptionStatusBadge status={displayStatus} />
+                      </TableCell>
+                      <TableCell className="min-w-40">
+                        <div className="text-muted-foreground text-xs">{billingDate.label}</div>
+                        <div className="font-mono text-xs tabular-nums">{formattedBillingDate}</div>
+                      </TableCell>
+                      <TableCell className="text-right font-mono tabular-nums">
+                        {formatCodingPlanPrice(
+                          item.costKiloCredits,
+                          item.billingPeriodDays,
+                          item.planId
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+async function copySubscriptionId(subscriptionId: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(subscriptionId);
+    toast.success('Subscription ID copied');
+  } catch {
+    toast.error('Failed to copy subscription ID');
+  }
+}
+
 function OperationsTabs({
+  inventorySummary,
+  inventoryCounts,
+  inventoryLoading,
+  inventoryError,
   workItems,
   queueLoading,
   queueError,
@@ -394,16 +1102,18 @@ function OperationsTabs({
   entriesText,
   submittedEntries,
   uploadPending,
-  requeuePending,
   onRefresh,
   onComplete,
-  onFailure,
-  onRequeue,
+  onReplace,
   onProviderChange,
   onPlanChange,
   onEntriesTextChange,
   onUpload,
 }: {
+  inventorySummary: SummaryItem[];
+  inventoryCounts: InventoryCountItem[];
+  inventoryLoading: boolean;
+  inventoryError: boolean;
   workItems: RevocationWorkItem[];
   queueLoading: boolean;
   queueError: boolean;
@@ -416,11 +1126,9 @@ function OperationsTabs({
   entriesText: string;
   submittedEntries: string[];
   uploadPending: boolean;
-  requeuePending: boolean;
   onRefresh: () => void;
   onComplete: (inventoryKeyId: string) => void;
-  onFailure: (inventoryKeyId: string) => void;
-  onRequeue: (inventoryKeyId: string) => void;
+  onReplace: (inventoryKeyId: string) => void;
   onProviderChange: (providerId: string) => void;
   onPlanChange: (planId: string) => void;
   onEntriesTextChange: (entriesText: string) => void;
@@ -429,19 +1137,36 @@ function OperationsTabs({
   const hasSelectedPlan = planOptions.some(plan => plan.planId === selectedPlanId);
 
   return (
-    <Tabs defaultValue="revocation-queue" className="space-y-4">
+    <Tabs defaultValue="overview" className="space-y-4">
       <TabsList className="h-auto w-full flex-col items-stretch justify-start gap-1 rounded-xl p-1 sm:w-fit sm:flex-row sm:items-center">
-        <TabsTrigger value="revocation-queue">Manual revocation queue</TabsTrigger>
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="revocation-queue">Pending Key Rotation</TabsTrigger>
         <TabsTrigger value="inventory-upload">Upload validated inventory</TabsTrigger>
       </TabsList>
+
+      <TabsContent value="overview" className="mt-0 space-y-6">
+        <SummaryCards
+          items={inventorySummary}
+          isLoading={inventoryLoading}
+          isError={inventoryError}
+          ariaLabel="Credential inventory summary"
+        />
+
+        <InventoryCountsTable
+          items={inventoryCounts}
+          isLoading={inventoryLoading}
+          isError={inventoryError}
+        />
+      </TabsContent>
 
       <TabsContent value="revocation-queue" className="mt-0">
         <Card>
           <CardHeader className="flex flex-row items-start justify-between gap-4">
             <div className="space-y-1.5">
-              <CardTitle>Manual revocation queue</CardTitle>
+              <CardTitle>Pending Key Rotation</CardTitle>
               <CardDescription>
-                Pending and failed issued credentials requiring action in MiniMax admin tooling.
+                Pending and failed issued credentials requiring MiniMax admin action. Revoke removes
+                stock permanently; Replace validates a newly generated key for the same plan ID.
               </CardDescription>
             </div>
             <Button variant="secondary" size="sm" onClick={onRefresh}>
@@ -460,21 +1185,19 @@ function OperationsTabs({
                     <TableHead>Status</TableHead>
                     <TableHead>Requested</TableHead>
                     <TableHead>Subscription expires</TableHead>
-                    <TableHead className="text-right">Attempts</TableHead>
-                    <TableHead>Latest failure</TableHead>
                     <TableHead className="text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {queueError ? (
                     <TableRow>
-                      <TableCell colSpan={9} className="h-24 text-center text-red-300">
+                      <TableCell colSpan={7} className="h-24 text-center text-red-300">
                         Unable to load manual revocation work. Refresh to retry.
                       </TableCell>
                     </TableRow>
                   ) : workItems.length === 0 ? (
                     <TableRow>
-                      <TableCell colSpan={9} className="text-muted-foreground h-24 text-center">
+                      <TableCell colSpan={7} className="text-muted-foreground h-24 text-center">
                         {queueLoading ? 'Loading manual work...' : 'No revocation work pending.'}
                       </TableCell>
                     </TableRow>
@@ -509,38 +1232,22 @@ function OperationsTabs({
                         <TableCell className="whitespace-nowrap font-mono text-xs">
                           {formatTimestamp(item.subscriptionExpiresAt)}
                         </TableCell>
-                        <TableCell className="text-right font-mono tabular-nums">
-                          {item.revocationAttemptCount}
-                        </TableCell>
-                        <TableCell className="text-muted-foreground max-w-72 text-sm">
-                          {item.lastRevocationError ?? 'None'}
-                        </TableCell>
                         <TableCell>
                           <div className="flex justify-end gap-2">
                             <Button
-                              variant="secondary"
+                              variant="destructive"
                               size="sm"
                               onClick={() => onComplete(item.inventoryKeyId)}
                             >
-                              Mark revoked
+                              Revoke
                             </Button>
                             <Button
                               variant="secondary"
                               size="sm"
-                              onClick={() => onFailure(item.inventoryKeyId)}
+                              onClick={() => onReplace(item.inventoryKeyId)}
                             >
-                              Mark failed
+                              Replace
                             </Button>
-                            {item.status === 'revocation_failed' ? (
-                              <Button
-                                variant="secondary"
-                                size="sm"
-                                onClick={() => onRequeue(item.inventoryKeyId)}
-                                disabled={requeuePending}
-                              >
-                                Requeue
-                              </Button>
-                            ) : null}
                           </div>
                         </TableCell>
                       </TableRow>
@@ -646,35 +1353,35 @@ function OperationsTabs({
 function OperationsDialogs({
   completeInventoryId,
   completePending,
-  failureInventoryId,
-  failureReason,
-  failurePending,
+  replacementInventoryId,
+  replacementApiKey,
+  replacementPending,
   onCloseComplete,
   onComplete,
-  onCloseFailure,
-  onFailureReasonChange,
-  onFailure,
+  onCloseReplacement,
+  onReplacementApiKeyChange,
+  onReplace,
 }: {
   completeInventoryId: string | null;
   completePending: boolean;
-  failureInventoryId: string | null;
-  failureReason: string;
-  failurePending: boolean;
+  replacementInventoryId: string | null;
+  replacementApiKey: string;
+  replacementPending: boolean;
   onCloseComplete: () => void;
   onComplete: (inventoryKeyId: string) => void;
-  onCloseFailure: () => void;
-  onFailureReasonChange: (reason: string) => void;
-  onFailure: (inventoryKeyId: string, reason: string) => void;
+  onCloseReplacement: () => void;
+  onReplacementApiKeyChange: (apiKey: string) => void;
+  onReplace: (inventoryKeyId: string, apiKey: string) => void;
 }) {
   return (
     <>
       <Dialog open={completeInventoryId !== null} onOpenChange={open => !open && onCloseComplete()}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Record confirmed revocation?</DialogTitle>
+            <DialogTitle>Revoke credential?</DialogTitle>
             <DialogDescription>
-              Confirm only after MiniMax deprovisioning succeeds. Kilo records this plan ID as
-              revoked and keeps issued credentials unavailable for reuse.
+              Use this only when MiniMax access should be completely removed from stock. Kilo
+              records the plan ID as revoked and keeps this credential unavailable for reuse.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -682,44 +1389,50 @@ function OperationsDialogs({
               Keep pending
             </Button>
             <Button
+              variant="destructive"
               onClick={() => completeInventoryId && onComplete(completeInventoryId)}
               disabled={completePending}
             >
-              {completePending ? 'Recording...' : 'Record revoked'}
+              {completePending ? 'Revoking...' : 'Revoke'}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      <Dialog open={failureInventoryId !== null} onOpenChange={open => !open && onCloseFailure()}>
+      <Dialog
+        open={replacementInventoryId !== null}
+        onOpenChange={open => !open && onCloseReplacement()}
+      >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Record revocation failure</DialogTitle>
+            <DialogTitle>Replace MiniMax API key</DialogTitle>
             <DialogDescription>
-              Store a sanitized operational explanation only. Never include a credential, auth
-              header, or provider response body.
+              Paste the newly generated MiniMax API key for this same upstream plan ID. Kilo
+              validates the key before returning this plan to available inventory.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">
-            <Label htmlFor="revocation-failure-reason">Sanitized failure reason</Label>
-            <Textarea
-              id="revocation-failure-reason"
-              value={failureReason}
-              onChange={event => onFailureReasonChange(event.target.value)}
-              maxLength={300}
-              placeholder="Example: Provider admin console was unavailable during support attempt."
+            <Label htmlFor="replacement-api-key">Replacement API key</Label>
+            <Input
+              id="replacement-api-key"
+              type="password"
+              value={replacementApiKey}
+              onChange={event => onReplacementApiKeyChange(event.target.value)}
+              autoComplete="off"
+              placeholder="Paste new MiniMax API key"
             />
           </div>
           <DialogFooter>
-            <Button variant="secondary" onClick={onCloseFailure}>
+            <Button variant="secondary" onClick={onCloseReplacement}>
               Keep pending
             </Button>
             <Button
-              variant="destructive"
-              onClick={() => failureInventoryId && onFailure(failureInventoryId, failureReason)}
-              disabled={failureReason.trim().length === 0 || failurePending}
+              onClick={() =>
+                replacementInventoryId && onReplace(replacementInventoryId, replacementApiKey)
+              }
+              disabled={replacementApiKey.trim().length === 0 || replacementPending}
             >
-              {failurePending ? 'Recording...' : 'Record failure'}
+              {replacementPending ? 'Validating...' : 'Validate and replace'}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -730,6 +1443,10 @@ function OperationsDialogs({
 
 function formatStatus(status: string): string {
   return status.replaceAll('_', ' ');
+}
+
+function formatStatusTitle(status: string): string {
+  return formatStatus(status).replace(/\b\w/g, character => character.toUpperCase());
 }
 
 function formatTimestamp(value: string | null): string {

--- a/apps/web/src/components/subscriptions/SubscriptionStatusBadge.tsx
+++ b/apps/web/src/components/subscriptions/SubscriptionStatusBadge.tsx
@@ -18,7 +18,7 @@ const statusStyles: Record<string, string> = {
 };
 
 function formatStatusLabel(status: string): string {
-  if (status === 'pending_cancellation') return 'Cancellation Scheduled';
+  if (status === 'pending_cancellation') return 'Cancellation Pending';
   return status.replace(/_/g, ' ').replace(/\b\w/g, char => char.toUpperCase());
 }
 

--- a/apps/web/src/components/subscriptions/helpers.test.ts
+++ b/apps/web/src/components/subscriptions/helpers.test.ts
@@ -37,6 +37,13 @@ describe('Coding Plan subscription helpers', () => {
     expect(getCodingPlanDisplayStatus({ ...activeSubscription, cancelAtPeriodEnd: true })).toBe(
       'pending_cancellation'
     );
+    expect(
+      getCodingPlanDisplayStatus({
+        ...activeSubscription,
+        status: 'past_due',
+        cancelAtPeriodEnd: true,
+      })
+    ).toBe('pending_cancellation');
     expect(getCodingPlanBillingDate({ ...activeSubscription, cancelAtPeriodEnd: true })).toEqual({
       label: 'Access ends',
       date: activeSubscription.currentPeriodEnd,

--- a/apps/web/src/components/subscriptions/helpers.test.ts
+++ b/apps/web/src/components/subscriptions/helpers.test.ts
@@ -43,7 +43,7 @@ describe('Coding Plan subscription helpers', () => {
         status: 'past_due',
         cancelAtPeriodEnd: true,
       })
-    ).toBe('pending_cancellation');
+    ).toBe('past_due');
     expect(getCodingPlanBillingDate({ ...activeSubscription, cancelAtPeriodEnd: true })).toEqual({
       label: 'Access ends',
       date: activeSubscription.currentPeriodEnd,

--- a/apps/web/src/components/subscriptions/helpers.ts
+++ b/apps/web/src/components/subscriptions/helpers.ts
@@ -20,7 +20,7 @@ export function getCodingPlanDisplayStatus(params: {
   status: string;
   cancelAtPeriodEnd: boolean;
 }): string {
-  return params.status !== 'canceled' && params.cancelAtPeriodEnd
+  return params.status === 'active' && params.cancelAtPeriodEnd
     ? 'pending_cancellation'
     : params.status;
 }

--- a/apps/web/src/components/subscriptions/helpers.ts
+++ b/apps/web/src/components/subscriptions/helpers.ts
@@ -20,7 +20,7 @@ export function getCodingPlanDisplayStatus(params: {
   status: string;
   cancelAtPeriodEnd: boolean;
 }): string {
-  return params.status === 'active' && params.cancelAtPeriodEnd
+  return params.status !== 'canceled' && params.cancelAtPeriodEnd
     ? 'pending_cancellation'
     : params.status;
 }

--- a/apps/web/src/lib/coding-plans/credential-fingerprint.ts
+++ b/apps/web/src/lib/coding-plans/credential-fingerprint.ts
@@ -1,0 +1,14 @@
+import 'server-only';
+
+import { createHmac } from 'node:crypto';
+
+import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
+
+export function codingPlanCredentialFingerprint(apiKey: string): string {
+  if (!BYOK_ENCRYPTION_KEY) {
+    throw new Error('BYOK encryption is not configured');
+  }
+
+  // Keyed API-key fingerprint for duplicate detection, not password storage.
+  return createHmac('sha256', BYOK_ENCRYPTION_KEY).update(apiKey).digest('hex');
+}

--- a/apps/web/src/lib/coding-plans/index.test.ts
+++ b/apps/web/src/lib/coding-plans/index.test.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 
 import { encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
 import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
+import { codingPlanCredentialFingerprint } from '@/lib/coding-plans/credential-fingerprint';
 import {
   cancelCodingPlanSubscription,
   getKeyInventoryCounts,
@@ -572,6 +573,51 @@ describe('coding plans', () => {
       .where(eq(coding_plan_key_inventory.id, subscription.key_inventory_id!));
     expect(credential.status).toBe('revocation_pending');
     expect(credential.encrypted_api_key).toBeNull();
+  });
+
+  it('rejects unchanged and duplicate replacement credentials before validating upstream', async () => {
+    const user = await createUserWithBalance(COST_MICRODOLLARS);
+    const validateCredential = jest.fn(async () => true);
+    await uploadKeysToInventory(
+      PROVIDER_ID,
+      PLAN_ID,
+      [
+        inventoryEntry('replace-unchanged-original-key', 'minimax-replace-unchanged-plan'),
+        inventoryEntry('replace-duplicate-existing-key', 'minimax-replace-duplicate-plan'),
+      ],
+      validatedInventoryUpload
+    );
+    const activation = await subscribeToCodingPlan(user.id, PLAN_ID, 'replace-unchanged');
+    const [subscription] = await db
+      .select()
+      .from(coding_plan_subscriptions)
+      .where(eq(coding_plan_subscriptions.id, activation.subscriptionId));
+    await terminateCodingPlanImmediately(activation.subscriptionId);
+
+    await expect(
+      replaceManualCredentialRevocation(
+        subscription.key_inventory_id!,
+        'replace-unchanged-original-key',
+        { validateCredential }
+      )
+    ).rejects.toThrow('must be different');
+    await expect(
+      replaceManualCredentialRevocation(
+        subscription.key_inventory_id!,
+        'replace-duplicate-existing-key',
+        { validateCredential }
+      )
+    ).rejects.toThrow('already present');
+
+    const [credential] = await db
+      .select()
+      .from(coding_plan_key_inventory)
+      .where(eq(coding_plan_key_inventory.id, subscription.key_inventory_id!));
+    expect(credential.status).toBe('revocation_pending');
+    expect(credential.credential_fingerprint).toBe(
+      codingPlanCredentialFingerprint('replace-unchanged-original-key')
+    );
+    expect(validateCredential).not.toHaveBeenCalled();
   });
 
   it('keeps failed manual revocation terminal and retryable', async () => {

--- a/apps/web/src/lib/coding-plans/index.test.ts
+++ b/apps/web/src/lib/coding-plans/index.test.ts
@@ -15,6 +15,7 @@ import {
   markCredentialManuallyRevoked,
   markCredentialManualRevocationFailed,
   requeueManualCredentialRevocation,
+  replaceManualCredentialRevocation,
 } from '@/lib/coding-plans/revocation';
 import { db } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
@@ -475,7 +476,7 @@ describe('coding plans', () => {
     ]);
   });
 
-  it('clears credential material once revocation work starts and records completion by plan ID', async () => {
+  it('clears credential material once revocation work starts and can remove stock permanently', async () => {
     const user = await createUserWithBalance(COST_MICRODOLLARS);
     await uploadKeysToInventory(
       PROVIDER_ID,
@@ -508,6 +509,69 @@ describe('coding plans', () => {
     expect(credential.upstream_plan_id).toBe('minimax-revoke-plan');
     expect(credential.encrypted_api_key).toBeNull();
     expect(credential.revocation_attempt_count).toBe(1);
+  });
+
+  it('validates and stores a replacement credential for the same upstream plan ID', async () => {
+    const user = await createUserWithBalance(COST_MICRODOLLARS);
+    const validateCredential = jest.fn(async () => true);
+    await uploadKeysToInventory(
+      PROVIDER_ID,
+      PLAN_ID,
+      [inventoryEntry('replace-original-key', 'minimax-replace-plan')],
+      validatedInventoryUpload
+    );
+    const activation = await subscribeToCodingPlan(user.id, PLAN_ID, 'replace-success');
+    const [subscription] = await db
+      .select()
+      .from(coding_plan_subscriptions)
+      .where(eq(coding_plan_subscriptions.id, activation.subscriptionId));
+    await terminateCodingPlanImmediately(activation.subscriptionId);
+
+    await replaceManualCredentialRevocation(subscription.key_inventory_id!, ' replace-new-key ', {
+      validateCredential,
+    });
+    const [credential] = await db
+      .select()
+      .from(coding_plan_key_inventory)
+      .where(eq(coding_plan_key_inventory.id, subscription.key_inventory_id!));
+
+    expect(validateCredential).toHaveBeenCalledWith({
+      apiKey: 'replace-new-key',
+      planId: PLAN_ID,
+      upstreamPlanId: 'minimax-replace-plan',
+    });
+    expect(credential.status).toBe('available');
+    expect(credential.upstream_plan_id).toBe('minimax-replace-plan');
+    expect(credential.encrypted_api_key).not.toBeNull();
+    expect(credential.assigned_to_user_id).toBeNull();
+    expect(credential.revocation_requested_at).toBeNull();
+    expect(credential.revocation_attempt_count).toBe(1);
+    expect(await getKeyInventoryCounts(PLAN_ID)).toEqual([
+      { providerId: PROVIDER_ID, planId: PLAN_ID, status: 'available', count: 1 },
+    ]);
+  });
+
+  it('rejects invalid replacement credentials before returning stock to inventory', async () => {
+    const user = await createUserWithBalance(COST_MICRODOLLARS);
+    await seedInventoryKey('replace-invalid-original-key');
+    const activation = await subscribeToCodingPlan(user.id, PLAN_ID, 'replace-invalid');
+    const [subscription] = await db
+      .select()
+      .from(coding_plan_subscriptions)
+      .where(eq(coding_plan_subscriptions.id, activation.subscriptionId));
+    await terminateCodingPlanImmediately(activation.subscriptionId);
+
+    await expect(
+      replaceManualCredentialRevocation(subscription.key_inventory_id!, 'replace-invalid-key', {
+        validateCredential: async () => false,
+      })
+    ).rejects.toThrow('failed validation');
+    const [credential] = await db
+      .select()
+      .from(coding_plan_key_inventory)
+      .where(eq(coding_plan_key_inventory.id, subscription.key_inventory_id!));
+    expect(credential.status).toBe('revocation_pending');
+    expect(credential.encrypted_api_key).toBeNull();
   });
 
   it('keeps failed manual revocation terminal and retryable', async () => {

--- a/apps/web/src/lib/coding-plans/index.ts
+++ b/apps/web/src/lib/coding-plans/index.ts
@@ -1,12 +1,13 @@
 import 'server-only';
 
-import { createHash, createHmac } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { addDays } from 'date-fns';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import pLimit from 'p-limit';
 
 import { decryptApiKey, encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
 import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
+import { codingPlanCredentialFingerprint } from '@/lib/coding-plans/credential-fingerprint';
 import {
   type MiniMaxCodingPlanCredentialValidationInput,
   validateMiniMaxCodingPlanCredential,
@@ -45,13 +46,6 @@ type SubscriptionOutcome = {
 
 function idempotencyFingerprint(idempotencyKey: string): string {
   return createHash('sha256').update(idempotencyKey).digest('hex');
-}
-
-function credentialFingerprint(apiKey: string): string {
-  if (!BYOK_ENCRYPTION_KEY) {
-    throw new Error('BYOK encryption is not configured');
-  }
-  return createHmac('sha256', BYOK_ENCRYPTION_KEY).update(apiKey).digest('hex');
 }
 
 async function evaluateUsageBonus(userId: string): Promise<void> {
@@ -429,7 +423,7 @@ export async function uploadKeysToInventory(
           provider_id: providerId,
           upstream_plan_id: entry.upstreamPlanId,
           encrypted_api_key: encryptApiKey(entry.apiKey, BYOK_ENCRYPTION_KEY),
-          credential_fingerprint: credentialFingerprint(entry.apiKey),
+          credential_fingerprint: codingPlanCredentialFingerprint(entry.apiKey),
           status: 'available' as const,
         }))
       )

--- a/apps/web/src/lib/coding-plans/revocation.ts
+++ b/apps/web/src/lib/coding-plans/revocation.ts
@@ -1,10 +1,10 @@
 import 'server-only';
 
-import { createHmac } from 'node:crypto';
 import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 
 import { encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
 import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
+import { codingPlanCredentialFingerprint } from '@/lib/coding-plans/credential-fingerprint';
 import {
   type MiniMaxCodingPlanCredentialValidationInput,
   validateMiniMaxCodingPlanCredential,
@@ -22,14 +22,6 @@ type InventoryCredentialValidator = (
 type ManualCredentialReplacementOptions = {
   validateCredential?: InventoryCredentialValidator;
 };
-
-function credentialFingerprint(apiKey: string): string {
-  if (!BYOK_ENCRYPTION_KEY) {
-    throw new Error('BYOK encryption is not configured');
-  }
-
-  return createHmac('sha256', BYOK_ENCRYPTION_KEY).update(apiKey).digest('hex');
-}
 
 export async function listManualCredentialRevocations(input: {
   planId?: CodingPlanId;
@@ -157,7 +149,7 @@ export async function replaceManualCredentialRevocation(
     .set({
       status: 'available',
       encrypted_api_key: encryptApiKey(normalizedApiKey, BYOK_ENCRYPTION_KEY),
-      credential_fingerprint: credentialFingerprint(normalizedApiKey),
+      credential_fingerprint: codingPlanCredentialFingerprint(normalizedApiKey),
       assigned_to_user_id: null,
       assigned_at: null,
       revocation_requested_at: null,

--- a/apps/web/src/lib/coding-plans/revocation.ts
+++ b/apps/web/src/lib/coding-plans/revocation.ts
@@ -1,12 +1,35 @@
 import 'server-only';
 
+import { createHmac } from 'node:crypto';
 import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 
-import type { CodingPlanId } from '@/lib/coding-plans/pricing';
+import { encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
+import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
+import {
+  type MiniMaxCodingPlanCredentialValidationInput,
+  validateMiniMaxCodingPlanCredential,
+} from '@/lib/coding-plans/inventory-validation';
+import { isCodingPlanId, type CodingPlanId } from '@/lib/coding-plans/pricing';
 import { db } from '@/lib/drizzle';
 import { coding_plan_key_inventory, coding_plan_subscriptions } from '@kilocode/db/schema';
 
 export type ManualRevocationStatus = 'revocation_pending' | 'revocation_failed';
+
+type InventoryCredentialValidator = (
+  input: MiniMaxCodingPlanCredentialValidationInput
+) => Promise<boolean>;
+
+type ManualCredentialReplacementOptions = {
+  validateCredential?: InventoryCredentialValidator;
+};
+
+function credentialFingerprint(apiKey: string): string {
+  if (!BYOK_ENCRYPTION_KEY) {
+    throw new Error('BYOK encryption is not configured');
+  }
+
+  return createHmac('sha256', BYOK_ENCRYPTION_KEY).update(apiKey).digest('hex');
+}
 
 export async function listManualCredentialRevocations(input: {
   planId?: CodingPlanId;
@@ -80,6 +103,77 @@ export async function markCredentialManuallyRevoked(inventoryKeyId: string): Pro
 
   if ((result.rowCount ?? 0) === 0) {
     throw new Error('Credential is not eligible for manual revocation completion.');
+  }
+}
+
+export async function replaceManualCredentialRevocation(
+  inventoryKeyId: string,
+  apiKey: string,
+  options: ManualCredentialReplacementOptions = {}
+): Promise<void> {
+  if (!BYOK_ENCRYPTION_KEY) {
+    throw new Error('BYOK encryption is not configured');
+  }
+
+  const normalizedApiKey = apiKey.trim();
+  if (!normalizedApiKey) {
+    throw new Error('A replacement MiniMax API key is required.');
+  }
+
+  const [credential] = await db
+    .select({
+      planId: coding_plan_key_inventory.plan_id,
+      upstreamPlanId: coding_plan_key_inventory.upstream_plan_id,
+    })
+    .from(coding_plan_key_inventory)
+    .where(
+      and(
+        eq(coding_plan_key_inventory.id, inventoryKeyId),
+        inArray(coding_plan_key_inventory.status, ['revocation_pending', 'revocation_failed'])
+      )
+    )
+    .limit(1);
+  if (!credential) {
+    throw new Error('Credential is not eligible for replacement.');
+  }
+  if (!isCodingPlanId(credential.planId)) {
+    throw new Error('Credential has an unsupported Coding Plan ID.');
+  }
+
+  const validateCredential = options.validateCredential ?? validateMiniMaxCodingPlanCredential;
+  const isValid = await validateCredential({
+    apiKey: normalizedApiKey,
+    planId: credential.planId,
+    upstreamPlanId: credential.upstreamPlanId,
+  });
+  if (!isValid) {
+    throw new Error(
+      'Replacement MiniMax credential failed validation. Confirm plan access and supported model behavior, then try again.'
+    );
+  }
+
+  const result = await db
+    .update(coding_plan_key_inventory)
+    .set({
+      status: 'available',
+      encrypted_api_key: encryptApiKey(normalizedApiKey, BYOK_ENCRYPTION_KEY),
+      credential_fingerprint: credentialFingerprint(normalizedApiKey),
+      assigned_to_user_id: null,
+      assigned_at: null,
+      revocation_requested_at: null,
+      revoked_at: null,
+      revocation_attempt_count: sql`${coding_plan_key_inventory.revocation_attempt_count} + 1`,
+      last_revocation_error: null,
+    })
+    .where(
+      and(
+        eq(coding_plan_key_inventory.id, inventoryKeyId),
+        inArray(coding_plan_key_inventory.status, ['revocation_pending', 'revocation_failed'])
+      )
+    );
+
+  if ((result.rowCount ?? 0) === 0) {
+    throw new Error('Credential is not eligible for replacement.');
   }
 }
 

--- a/apps/web/src/lib/coding-plans/revocation.ts
+++ b/apps/web/src/lib/coding-plans/revocation.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, ne, sql } from 'drizzle-orm';
 
 import { encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
 import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
@@ -116,6 +116,7 @@ export async function replaceManualCredentialRevocation(
     .select({
       planId: coding_plan_key_inventory.plan_id,
       upstreamPlanId: coding_plan_key_inventory.upstream_plan_id,
+      credentialFingerprint: coding_plan_key_inventory.credential_fingerprint,
     })
     .from(coding_plan_key_inventory)
     .where(
@@ -130,6 +131,26 @@ export async function replaceManualCredentialRevocation(
   }
   if (!isCodingPlanId(credential.planId)) {
     throw new Error('Credential has an unsupported Coding Plan ID.');
+  }
+  const replacementFingerprint = codingPlanCredentialFingerprint(normalizedApiKey);
+  if (replacementFingerprint === credential.credentialFingerprint) {
+    throw new Error(
+      'Replacement MiniMax credential must be different from the current credential.'
+    );
+  }
+
+  const [duplicateCredential] = await db
+    .select({ id: coding_plan_key_inventory.id })
+    .from(coding_plan_key_inventory)
+    .where(
+      and(
+        eq(coding_plan_key_inventory.credential_fingerprint, replacementFingerprint),
+        ne(coding_plan_key_inventory.id, inventoryKeyId)
+      )
+    )
+    .limit(1);
+  if (duplicateCredential) {
+    throw new Error('Replacement MiniMax credential is already present in inventory.');
   }
 
   const validateCredential = options.validateCredential ?? validateMiniMaxCodingPlanCredential;
@@ -149,7 +170,7 @@ export async function replaceManualCredentialRevocation(
     .set({
       status: 'available',
       encrypted_api_key: encryptApiKey(normalizedApiKey, BYOK_ENCRYPTION_KEY),
-      credential_fingerprint: codingPlanCredentialFingerprint(normalizedApiKey),
+      credential_fingerprint: replacementFingerprint,
       assigned_to_user_id: null,
       assigned_at: null,
       revocation_requested_at: null,

--- a/apps/web/src/routers/coding-plans-router.test.ts
+++ b/apps/web/src/routers/coding-plans-router.test.ts
@@ -454,7 +454,23 @@ describe('coding plans router', () => {
     expect(failed.encrypted_api_key).toBeNull();
     expect(failed.last_revocation_error).toContain('bearer [redacted]');
 
-    await adminCaller.codingPlans.adminRequeueRevocation({ inventoryKeyId: workItem.id });
+    mockedGenerateText.mockResolvedValueOnce({ finishReason: 'stop' } as never);
+    await adminCaller.codingPlans.adminReplaceRevocationCredential({
+      inventoryKeyId: workItem.id,
+      apiKey: 'replacement-minimax-key',
+    });
+    let [credential] = await db
+      .select()
+      .from(coding_plan_key_inventory)
+      .where(eq(coding_plan_key_inventory.id, workItem.id));
+    expect(credential.status).toBe('available');
+    expect(credential.upstream_plan_id).toBe('minimax-deprovision-plan');
+    expect(credential.encrypted_api_key).not.toBeNull();
+
+    await db
+      .update(coding_plan_key_inventory)
+      .set({ status: 'revocation_pending', encrypted_api_key: null })
+      .where(eq(coding_plan_key_inventory.id, workItem.id));
     await adminCaller.codingPlans.adminMarkRevocationComplete({ inventoryKeyId: workItem.id });
     const [revoked] = await db
       .select()

--- a/apps/web/src/routers/coding-plans-router.test.ts
+++ b/apps/web/src/routers/coding-plans-router.test.ts
@@ -459,7 +459,7 @@ describe('coding plans router', () => {
       inventoryKeyId: workItem.id,
       apiKey: 'replacement-minimax-key',
     });
-    let [credential] = await db
+    const [credential] = await db
       .select()
       .from(coding_plan_key_inventory)
       .where(eq(coding_plan_key_inventory.id, workItem.id));

--- a/apps/web/src/routers/coding-plans-router.ts
+++ b/apps/web/src/routers/coding-plans-router.ts
@@ -373,7 +373,9 @@ export const codingPlansRouter = createTRPCRouter({
     }),
 
   adminReplaceRevocationCredential: adminProcedure
-    .input(z.object({ inventoryKeyId: z.string().uuid(), apiKey: z.string().trim().min(1) }))
+    .input(
+      z.object({ inventoryKeyId: z.string().uuid(), apiKey: z.string().trim().min(1).max(500) })
+    )
     .mutation(async ({ input }) => {
       try {
         await replaceManualCredentialRevocation(input.inventoryKeyId, input.apiKey);

--- a/apps/web/src/routers/coding-plans-router.ts
+++ b/apps/web/src/routers/coding-plans-router.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from 'drizzle-orm';
+import { and, count, desc, eq } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
 
@@ -17,6 +17,7 @@ import {
   markCredentialManuallyRevoked,
   markCredentialManualRevocationFailed,
   requeueManualCredentialRevocation,
+  replaceManualCredentialRevocation,
 } from '@/lib/coding-plans/revocation';
 import {
   CODING_PLAN_IDS,
@@ -28,9 +29,11 @@ import { UserByokProviderIdSchema } from '@/lib/ai-gateway/providers/openrouter/
 import { billingHistoryResponseSchema } from '@/lib/subscriptions/subscription-center';
 import { baseProcedure, adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import {
+  coding_plan_availability_intents,
   coding_plan_subscriptions,
   coding_plan_terms,
   credit_transactions,
+  kilocode_users,
 } from '@kilocode/db/schema';
 
 const CodingPlanIdSchema = z.enum(CODING_PLAN_IDS);
@@ -43,8 +46,10 @@ const BillingHistoryInputSchema = z.object({
 
 const codingPlanSubscriptionColumns = {
   id: coding_plan_subscriptions.id,
+  userId: coding_plan_subscriptions.user_id,
   planId: coding_plan_subscriptions.plan_id,
   providerId: coding_plan_subscriptions.provider_id,
+  keyInventoryId: coding_plan_subscriptions.key_inventory_id,
   installedByokKeyId: coding_plan_subscriptions.installed_byok_key_id,
   status: coding_plan_subscriptions.status,
   costMicrodollars: coding_plan_subscriptions.cost_microdollars,
@@ -156,6 +161,33 @@ export const codingPlansRouter = createTRPCRouter({
   listSubscriptions: baseProcedure.query(async ({ ctx }) => {
     const subscriptions = await listOwnedSubscriptions(ctx.user.id);
     return subscriptions.map(toCodingPlanSubscriptionView);
+  }),
+
+  adminListSubscriptions: adminProcedure.input(z.object({})).query(async () => {
+    const subscriptions = await db
+      .select({
+        ...codingPlanSubscriptionColumns,
+        userName: kilocode_users.google_user_name,
+      })
+      .from(coding_plan_subscriptions)
+      .innerJoin(kilocode_users, eq(kilocode_users.id, coding_plan_subscriptions.user_id))
+      .orderBy(desc(coding_plan_subscriptions.created_at));
+
+    return subscriptions.map(subscription => ({
+      ...toCodingPlanSubscriptionView(subscription),
+      userId: subscription.userId,
+      userName: subscription.userName,
+    }));
+  }),
+
+  adminAvailabilityIntentCounts: adminProcedure.input(z.object({})).query(async () => {
+    return db
+      .select({
+        planId: coding_plan_availability_intents.plan_id,
+        count: count(),
+      })
+      .from(coding_plan_availability_intents)
+      .groupBy(coding_plan_availability_intents.plan_id);
   }),
 
   getSubscriptionDetail: baseProcedure
@@ -334,6 +366,17 @@ export const codingPlansRouter = createTRPCRouter({
     .mutation(async ({ input }) => {
       try {
         await markCredentialManuallyRevoked(input.inventoryKeyId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new TRPCError({ code: 'PRECONDITION_FAILED', message });
+      }
+    }),
+
+  adminReplaceRevocationCredential: adminProcedure
+    .input(z.object({ inventoryKeyId: z.string().uuid(), apiKey: z.string().trim().min(1) }))
+    .mutation(async ({ input }) => {
+      try {
+        await replaceManualCredentialRevocation(input.inventoryKeyId, input.apiKey);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         throw new TRPCError({ code: 'PRECONDITION_FAILED', message });

--- a/dev/seed/coding-plans/demo-data.ts
+++ b/dev/seed/coding-plans/demo-data.ts
@@ -1,0 +1,706 @@
+import { createCipheriv, createHash, createHmac, randomBytes, randomUUID } from 'node:crypto';
+
+import {
+  byok_api_keys,
+  coding_plan_availability_intents,
+  coding_plan_key_inventory,
+  coding_plan_subscriptions,
+  coding_plan_terms,
+  credit_transactions,
+  kilocode_users,
+} from '@kilocode/db/schema';
+import type { EncryptedData } from '@kilocode/db/schema-types';
+import { inArray, like } from 'drizzle-orm';
+
+import { getSeedDb } from '../lib/db';
+import { normalizeSeedEmail } from '../lib/email';
+import { createSeedStripeCustomer, deleteSeedStripeCustomer } from '../lib/stripe';
+import type { SeedResult } from '../index';
+
+const PROVIDER_ID = 'minimax';
+const PROVIDER_NAME = 'MiniMax';
+const KEY_PREFIX = 'dev-seed:coding-plans:demo-data';
+const EMAIL_DOMAIN = 'example.com';
+const MICRODOLLARS_PER_DOLLAR = 1_000_000;
+
+type PlanId = 'minimax-token-plan-plus' | 'minimax-token-plan-max' | 'minimax-token-plan-ultra';
+type SubscriptionStatus = 'active' | 'past_due' | 'canceled';
+type CredentialStatus =
+  | 'available'
+  | 'assigned'
+  | 'revocation_pending'
+  | 'revocation_failed'
+  | 'revoked';
+type SubscriptionUserSlug =
+  | 'active-plus'
+  | 'canceling-max'
+  | 'past-due-ultra'
+  | 'canceled-pending-plus'
+  | 'canceled-failed-max';
+type UserSlug = SubscriptionUserSlug | 'waitlist-ultra';
+
+type PlanFixture = {
+  planId: PlanId;
+  planName: string;
+  costMicrodollars: number;
+  billingPeriodDays: number;
+};
+
+type UserFixture = {
+  slug: UserSlug;
+  name: string;
+};
+
+type SubscriptionFixture = {
+  slug: SubscriptionUserSlug;
+  planId: PlanId;
+  status: SubscriptionStatus;
+  inventoryStatus: CredentialStatus;
+  cancelAtPeriodEnd: boolean;
+  startedDaysAgo: number;
+  periodEndsInDays: number;
+  graceEndsInHours: number | null;
+  canceledDaysAgo: number | null;
+  cancellationReason: string | null;
+  revocationRequestedDaysAgo: number | null;
+  revocationAttemptCount: number;
+  lastRevocationError: string | null;
+};
+
+type InventoryFixture = {
+  slug: string;
+  planId: PlanId;
+  status: CredentialStatus;
+  assignedToUserSlug: UserSlug | null;
+  revocationRequestedDaysAgo: number | null;
+  revokedDaysAgo: number | null;
+  revocationAttemptCount: number;
+  lastRevocationError: string | null;
+};
+
+type SeedUser = {
+  slug: UserSlug;
+  id: string;
+  name: string;
+  email: string;
+  normalizedEmail: string;
+  stripeCustomerId: string;
+};
+
+type InventoryRow = {
+  slug: string;
+  id: string;
+};
+
+const PLANS: Record<PlanId, PlanFixture> = {
+  'minimax-token-plan-plus': {
+    planId: 'minimax-token-plan-plus',
+    planName: 'Token Plan Plus',
+    costMicrodollars: 20 * MICRODOLLARS_PER_DOLLAR,
+    billingPeriodDays: 30,
+  },
+  'minimax-token-plan-max': {
+    planId: 'minimax-token-plan-max',
+    planName: 'Token Plan Max',
+    costMicrodollars: 50 * MICRODOLLARS_PER_DOLLAR,
+    billingPeriodDays: 30,
+  },
+  'minimax-token-plan-ultra': {
+    planId: 'minimax-token-plan-ultra',
+    planName: 'Token Plan Ultra',
+    costMicrodollars: 120 * MICRODOLLARS_PER_DOLLAR,
+    billingPeriodDays: 30,
+  },
+};
+
+const USER_FIXTURES: UserFixture[] = [
+  { slug: 'active-plus', name: 'Coding Plan Active Plus' },
+  { slug: 'canceling-max', name: 'Coding Plan Canceling Max' },
+  { slug: 'past-due-ultra', name: 'Coding Plan Past Due Ultra' },
+  { slug: 'canceled-pending-plus', name: 'Coding Plan Canceled Pending Plus' },
+  { slug: 'canceled-failed-max', name: 'Coding Plan Canceled Failed Max' },
+  { slug: 'waitlist-ultra', name: 'Coding Plan Waitlist Ultra' },
+];
+
+const SUBSCRIPTION_FIXTURES: SubscriptionFixture[] = [
+  {
+    slug: 'active-plus',
+    planId: 'minimax-token-plan-plus',
+    status: 'active',
+    inventoryStatus: 'assigned',
+    cancelAtPeriodEnd: false,
+    startedDaysAgo: 4,
+    periodEndsInDays: 26,
+    graceEndsInHours: null,
+    canceledDaysAgo: null,
+    cancellationReason: null,
+    revocationRequestedDaysAgo: null,
+    revocationAttemptCount: 0,
+    lastRevocationError: null,
+  },
+  {
+    slug: 'canceling-max',
+    planId: 'minimax-token-plan-max',
+    status: 'active',
+    inventoryStatus: 'assigned',
+    cancelAtPeriodEnd: true,
+    startedDaysAgo: 12,
+    periodEndsInDays: 18,
+    graceEndsInHours: null,
+    canceledDaysAgo: null,
+    cancellationReason: null,
+    revocationRequestedDaysAgo: null,
+    revocationAttemptCount: 0,
+    lastRevocationError: null,
+  },
+  {
+    slug: 'past-due-ultra',
+    planId: 'minimax-token-plan-ultra',
+    status: 'past_due',
+    inventoryStatus: 'assigned',
+    cancelAtPeriodEnd: false,
+    startedDaysAgo: 31,
+    periodEndsInDays: -1,
+    graceEndsInHours: 12,
+    canceledDaysAgo: null,
+    cancellationReason: null,
+    revocationRequestedDaysAgo: null,
+    revocationAttemptCount: 0,
+    lastRevocationError: null,
+  },
+  {
+    slug: 'canceled-pending-plus',
+    planId: 'minimax-token-plan-plus',
+    status: 'canceled',
+    inventoryStatus: 'revocation_pending',
+    cancelAtPeriodEnd: false,
+    startedDaysAgo: 46,
+    periodEndsInDays: -16,
+    graceEndsInHours: null,
+    canceledDaysAgo: 16,
+    cancellationReason: 'user_canceled',
+    revocationRequestedDaysAgo: 15,
+    revocationAttemptCount: 0,
+    lastRevocationError: null,
+  },
+  {
+    slug: 'canceled-failed-max',
+    planId: 'minimax-token-plan-max',
+    status: 'canceled',
+    inventoryStatus: 'revocation_failed',
+    cancelAtPeriodEnd: false,
+    startedDaysAgo: 54,
+    periodEndsInDays: -24,
+    graceEndsInHours: null,
+    canceledDaysAgo: 24,
+    cancellationReason: 'insufficient_credits',
+    revocationRequestedDaysAgo: 23,
+    revocationAttemptCount: 2,
+    lastRevocationError: 'MiniMax admin portal returned a transient 502.',
+  },
+];
+
+const EXTRA_INVENTORY_FIXTURES: InventoryFixture[] = [
+  {
+    slug: 'available-plus-1',
+    planId: 'minimax-token-plan-plus',
+    status: 'available',
+    assignedToUserSlug: null,
+    revocationRequestedDaysAgo: null,
+    revokedDaysAgo: null,
+    revocationAttemptCount: 0,
+    lastRevocationError: null,
+  },
+  {
+    slug: 'available-plus-2',
+    planId: 'minimax-token-plan-plus',
+    status: 'available',
+    assignedToUserSlug: null,
+    revocationRequestedDaysAgo: null,
+    revokedDaysAgo: null,
+    revocationAttemptCount: 0,
+    lastRevocationError: null,
+  },
+  {
+    slug: 'available-max-1',
+    planId: 'minimax-token-plan-max',
+    status: 'available',
+    assignedToUserSlug: null,
+    revocationRequestedDaysAgo: null,
+    revokedDaysAgo: null,
+    revocationAttemptCount: 0,
+    lastRevocationError: null,
+  },
+  {
+    slug: 'available-ultra-1',
+    planId: 'minimax-token-plan-ultra',
+    status: 'available',
+    assignedToUserSlug: null,
+    revocationRequestedDaysAgo: null,
+    revokedDaysAgo: null,
+    revocationAttemptCount: 0,
+    lastRevocationError: null,
+  },
+  {
+    slug: 'revoked-plus-1',
+    planId: 'minimax-token-plan-plus',
+    status: 'revoked',
+    assignedToUserSlug: null,
+    revocationRequestedDaysAgo: 18,
+    revokedDaysAgo: 17,
+    revocationAttemptCount: 1,
+    lastRevocationError: null,
+  },
+];
+
+export const usage = '[scenario]';
+
+function printUsage(): void {
+  console.log(`Usage: pnpm dev:seed coding-plans:demo-data ${usage}`);
+  console.log('');
+  console.log('Seeds local Coding Plan users, subscriptions, inventory, and revocation data.');
+  console.log('Designed for Admin UI > Coding plans testing. Placeholder credentials are invalid.');
+  console.log('');
+  console.log('Examples:');
+  console.log('  pnpm dev:seed coding-plans:demo-data');
+  console.log('  pnpm dev:seed coding-plans:demo-data admin-tabs');
+}
+
+function requireScenario(value: string | undefined): string {
+  const scenario = value?.trim() || 'admin-overview';
+  if (!/^[a-zA-Z0-9_-]{1,64}$/.test(scenario)) {
+    throw new Error('scenario must contain 1-64 letters, digits, underscores, or hyphens');
+  }
+  return scenario.toLowerCase();
+}
+
+function requireEncryptionKey(): Buffer {
+  const keyBase64 = process.env.BYOK_ENCRYPTION_KEY;
+  if (!keyBase64) {
+    throw new Error('BYOK_ENCRYPTION_KEY is not configured');
+  }
+
+  const key = Buffer.from(keyBase64, 'base64');
+  if (key.length !== 32) {
+    throw new Error('BYOK_ENCRYPTION_KEY must decode to 32 bytes');
+  }
+  return key;
+}
+
+function addDays(baseDate: Date, days: number): string {
+  const result = new Date(baseDate);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result.toISOString();
+}
+
+function addHours(baseDate: Date, hours: number): string {
+  const result = new Date(baseDate);
+  result.setUTCHours(result.getUTCHours() + hours);
+  return result.toISOString();
+}
+
+function idempotencyFingerprint(idempotencyKey: string): string {
+  return createHash('sha256').update(idempotencyKey).digest('hex');
+}
+
+function credentialFingerprint(plaintext: string, key: Buffer): string {
+  return createHmac('sha256', key).update(plaintext).digest('hex');
+}
+
+function encryptCredential(plaintext: string, key: Buffer): EncryptedData {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+
+  return {
+    iv: iv.toString('base64'),
+    data: encrypted.toString('base64'),
+    authTag: cipher.getAuthTag().toString('base64'),
+  };
+}
+
+function seedUserId(scenario: string, slug: UserSlug): string {
+  return `dev-seed-coding-plans-${scenario}-${slug}`;
+}
+
+function seedEmail(scenario: string, slug: UserSlug): string {
+  return `dev-seed-coding-plans-${scenario}-${slug}@${EMAIL_DOMAIN}`;
+}
+
+function inventorySlugForSubscription(slug: SubscriptionUserSlug): string {
+  return `subscription-${slug}`;
+}
+
+function plaintextCredential(scenario: string, slug: string): string {
+  return `${KEY_PREFIX}:${scenario}:credential:${slug}`;
+}
+
+function upstreamPlanId(scenario: string, slug: string): string {
+  return `${KEY_PREFIX}:${scenario}:upstream-plan:${slug}`;
+}
+
+function creditGrantAmount(subscription: SubscriptionFixture | null): number {
+  if (!subscription) return 0;
+  const costMicrodollars = PLANS[subscription.planId].costMicrodollars;
+  return subscription.status === 'past_due' ? costMicrodollars : costMicrodollars + 80_000_000;
+}
+
+function makeInventoryFixtures(): InventoryFixture[] {
+  const subscriptionInventory = SUBSCRIPTION_FIXTURES.map(subscription => ({
+    slug: inventorySlugForSubscription(subscription.slug),
+    planId: subscription.planId,
+    status: subscription.inventoryStatus,
+    assignedToUserSlug: subscription.slug,
+    revocationRequestedDaysAgo: subscription.revocationRequestedDaysAgo,
+    revokedDaysAgo: null,
+    revocationAttemptCount: subscription.revocationAttemptCount,
+    lastRevocationError: subscription.lastRevocationError,
+  }));
+
+  return [...subscriptionInventory, ...EXTRA_INVENTORY_FIXTURES];
+}
+
+function getSeedUsers(scenario: string, stripeCustomerIds: Record<UserSlug, string>): SeedUser[] {
+  return USER_FIXTURES.map(user => {
+    const email = seedEmail(scenario, user.slug);
+    return {
+      slug: user.slug,
+      id: seedUserId(scenario, user.slug),
+      name: user.name,
+      email,
+      normalizedEmail: normalizeSeedEmail(email),
+      stripeCustomerId: stripeCustomerIds[user.slug],
+    };
+  });
+}
+
+function getUser(users: SeedUser[], slug: UserSlug): SeedUser {
+  const user = users.find(candidate => candidate.slug === slug);
+  if (!user) {
+    throw new Error(`Missing seed user fixture for ${slug}`);
+  }
+  return user;
+}
+
+function getInventoryRow(rows: InventoryRow[], slug: string): InventoryRow {
+  const row = rows.find(candidate => candidate.slug === slug);
+  if (!row) {
+    throw new Error(`Missing inventory fixture for ${slug}`);
+  }
+  return row;
+}
+
+async function cleanupScenario(scenario: string): Promise<string[]> {
+  const db = getSeedDb();
+  const normalizedEmails = USER_FIXTURES.map(user =>
+    normalizeSeedEmail(seedEmail(scenario, user.slug))
+  );
+  const existingUsers = await db
+    .select({ id: kilocode_users.id, stripeCustomerId: kilocode_users.stripe_customer_id })
+    .from(kilocode_users)
+    .where(inArray(kilocode_users.normalized_email, normalizedEmails));
+  const existingUserIds = existingUsers.map(user => user.id);
+
+  await db.transaction(async tx => {
+    if (existingUserIds.length > 0) {
+      await tx
+        .delete(coding_plan_availability_intents)
+        .where(inArray(coding_plan_availability_intents.user_id, existingUserIds));
+      await tx.delete(coding_plan_terms).where(inArray(coding_plan_terms.user_id, existingUserIds));
+      await tx
+        .delete(coding_plan_subscriptions)
+        .where(inArray(coding_plan_subscriptions.user_id, existingUserIds));
+      await tx.delete(byok_api_keys).where(inArray(byok_api_keys.kilo_user_id, existingUserIds));
+      await tx
+        .delete(credit_transactions)
+        .where(inArray(credit_transactions.kilo_user_id, existingUserIds));
+      await tx.delete(kilocode_users).where(inArray(kilocode_users.id, existingUserIds));
+    }
+
+    await tx
+      .delete(coding_plan_key_inventory)
+      .where(like(coding_plan_key_inventory.upstream_plan_id, `${KEY_PREFIX}:${scenario}:%`));
+  });
+
+  return existingUsers.map(user => user.stripeCustomerId);
+}
+
+async function createStripeCustomers(scenario: string): Promise<Record<UserSlug, string>> {
+  const stripeCustomerIds: Partial<Record<UserSlug, string>> = {};
+  try {
+    for (const user of USER_FIXTURES) {
+      const stripeCustomer = await createSeedStripeCustomer({
+        email: seedEmail(scenario, user.slug),
+        name: user.name,
+        kiloUserId: seedUserId(scenario, user.slug),
+      });
+      stripeCustomerIds[user.slug] = stripeCustomer.id;
+    }
+  } catch (error) {
+    await Promise.all(
+      Object.values(stripeCustomerIds).map(customerId => deleteSeedStripeCustomer(customerId))
+    );
+    throw error;
+  }
+
+  const completeStripeCustomerIds: Record<UserSlug, string> = {
+    'active-plus': stripeCustomerIds['active-plus'] ?? '',
+    'canceling-max': stripeCustomerIds['canceling-max'] ?? '',
+    'past-due-ultra': stripeCustomerIds['past-due-ultra'] ?? '',
+    'canceled-pending-plus': stripeCustomerIds['canceled-pending-plus'] ?? '',
+    'canceled-failed-max': stripeCustomerIds['canceled-failed-max'] ?? '',
+    'waitlist-ultra': stripeCustomerIds['waitlist-ultra'] ?? '',
+  };
+
+  for (const [slug, customerId] of Object.entries(completeStripeCustomerIds)) {
+    if (!customerId) {
+      throw new Error(`Failed to create Stripe customer for ${slug}`);
+    }
+  }
+
+  return completeStripeCustomerIds;
+}
+
+async function seedScenario(scenario: string, key: Buffer, users: SeedUser[]): Promise<SeedResult> {
+  const now = new Date();
+  const db = getSeedDb();
+  const inventoryFixtures = makeInventoryFixtures();
+
+  return db.transaction(async tx => {
+    await tx.insert(kilocode_users).values(
+      users.map(user => {
+        const subscription = SUBSCRIPTION_FIXTURES.find(fixture => fixture.slug === user.slug);
+        const grantAmount = creditGrantAmount(subscription ?? null);
+        return {
+          id: user.id,
+          google_user_email: user.email,
+          google_user_name: user.name,
+          google_user_image_url: `https://example.com/${encodeURIComponent(user.id)}.png`,
+          stripe_customer_id: user.stripeCustomerId,
+          normalized_email: user.normalizedEmail,
+          email_domain: EMAIL_DOMAIN,
+          has_validation_stytch: true,
+          customer_source: 'dev-seed',
+          total_microdollars_acquired: grantAmount,
+          microdollars_used: subscription ? PLANS[subscription.planId].costMicrodollars : 0,
+          auto_top_up_enabled: subscription?.status === 'past_due',
+        } satisfies typeof kilocode_users.$inferInsert;
+      })
+    );
+
+    await tx.insert(coding_plan_key_inventory).values(
+      inventoryFixtures.map(fixture => {
+        const plaintext = plaintextCredential(scenario, fixture.slug);
+        const isSecretRetained = fixture.status === 'available' || fixture.status === 'assigned';
+        const assignedUser = fixture.assignedToUserSlug
+          ? getUser(users, fixture.assignedToUserSlug)
+          : null;
+        return {
+          plan_id: fixture.planId,
+          provider_id: PROVIDER_ID,
+          upstream_plan_id: upstreamPlanId(scenario, fixture.slug),
+          encrypted_api_key: isSecretRetained ? encryptCredential(plaintext, key) : null,
+          credential_fingerprint: credentialFingerprint(plaintext, key),
+          status: fixture.status,
+          assigned_to_user_id: assignedUser?.id ?? null,
+          assigned_at: assignedUser ? addDays(now, -20) : null,
+          revocation_requested_at: fixture.revocationRequestedDaysAgo
+            ? addDays(now, -fixture.revocationRequestedDaysAgo)
+            : null,
+          revoked_at: fixture.revokedDaysAgo ? addDays(now, -fixture.revokedDaysAgo) : null,
+          revocation_attempt_count: fixture.revocationAttemptCount,
+          last_revocation_error: fixture.lastRevocationError,
+        } satisfies typeof coding_plan_key_inventory.$inferInsert;
+      })
+    );
+
+    const insertedInventory = await tx
+      .select({
+        id: coding_plan_key_inventory.id,
+        upstreamPlanId: coding_plan_key_inventory.upstream_plan_id,
+      })
+      .from(coding_plan_key_inventory)
+      .where(like(coding_plan_key_inventory.upstream_plan_id, `${KEY_PREFIX}:${scenario}:%`));
+    const inventoryRows = insertedInventory.map(row => ({
+      id: row.id,
+      slug: row.upstreamPlanId.replace(`${KEY_PREFIX}:${scenario}:upstream-plan:`, ''),
+    }));
+
+    const byokRows = await tx
+      .insert(byok_api_keys)
+      .values(
+        SUBSCRIPTION_FIXTURES.filter(subscription => subscription.status !== 'canceled').map(
+          subscription => {
+            const user = getUser(users, subscription.slug);
+            return {
+              kilo_user_id: user.id,
+              organization_id: null,
+              provider_id: PROVIDER_ID,
+              encrypted_api_key: encryptCredential(
+                plaintextCredential(scenario, inventorySlugForSubscription(subscription.slug)),
+                key
+              ),
+              management_source: 'coding_plan',
+              created_by: user.id,
+              is_enabled: true,
+            } satisfies typeof byok_api_keys.$inferInsert;
+          }
+        )
+      )
+      .returning({ id: byok_api_keys.id, userId: byok_api_keys.kilo_user_id });
+
+    for (const subscription of SUBSCRIPTION_FIXTURES) {
+      const user = getUser(users, subscription.slug);
+      const plan = PLANS[subscription.planId];
+      const subscriptionId = randomUUID();
+      const purchaseTransactionId = randomUUID();
+      const requestKey = idempotencyFingerprint(
+        `${KEY_PREFIX}:${scenario}:subscribe:${subscription.slug}`
+      );
+      const periodStart = addDays(now, -subscription.startedDaysAgo);
+      const periodEnd = addDays(now, subscription.periodEndsInDays);
+      const installedByokKey = byokRows.find(row => row.userId === user.id);
+      const inventoryRow = getInventoryRow(
+        inventoryRows,
+        inventorySlugForSubscription(subscription.slug)
+      );
+      const canceledAt = subscription.canceledDaysAgo
+        ? addDays(now, -subscription.canceledDaysAgo)
+        : null;
+      const paymentGraceExpiresAt = subscription.graceEndsInHours
+        ? addHours(now, subscription.graceEndsInHours)
+        : null;
+
+      await tx.insert(credit_transactions).values([
+        {
+          kilo_user_id: user.id,
+          amount_microdollars: creditGrantAmount(subscription),
+          is_free: true,
+          description: 'Dev seed credits for Coding Plan fixtures',
+          credit_category: `${KEY_PREFIX}:${scenario}:grant:${subscription.slug}`,
+          created_at: addDays(now, -subscription.startedDaysAgo - 1),
+          original_baseline_microdollars_used: 0,
+          check_category_uniqueness: true,
+        } satisfies typeof credit_transactions.$inferInsert,
+        {
+          id: purchaseTransactionId,
+          kilo_user_id: user.id,
+          amount_microdollars: -plan.costMicrodollars,
+          is_free: false,
+          description: `Coding plan: ${PROVIDER_NAME} ${plan.planName}`,
+          credit_category: `coding-plan:${plan.planId}:${requestKey}`,
+          created_at: periodStart,
+          original_baseline_microdollars_used: 0,
+          check_category_uniqueness: true,
+        } satisfies typeof credit_transactions.$inferInsert,
+      ]);
+
+      await tx.insert(coding_plan_subscriptions).values({
+        id: subscriptionId,
+        user_id: user.id,
+        plan_id: plan.planId,
+        provider_id: PROVIDER_ID,
+        key_inventory_id: inventoryRow.id,
+        installed_byok_key_id:
+          subscription.status === 'canceled' ? null : (installedByokKey?.id ?? null),
+        status: subscription.status,
+        cost_microdollars: plan.costMicrodollars,
+        billing_period_days: plan.billingPeriodDays,
+        current_period_start: periodStart,
+        current_period_end: periodEnd,
+        credit_renewal_at: periodEnd,
+        cancel_at_period_end: subscription.cancelAtPeriodEnd,
+        past_due_started_at: subscription.status === 'past_due' ? periodEnd : null,
+        payment_grace_expires_at: paymentGraceExpiresAt,
+        auto_top_up_attempted_for_due: subscription.status === 'past_due' ? periodEnd : null,
+        canceled_at: canceledAt,
+        cancellation_reason: subscription.cancellationReason,
+        created_at: periodStart,
+      } satisfies typeof coding_plan_subscriptions.$inferInsert);
+
+      await tx.insert(coding_plan_terms).values({
+        subscription_id: subscriptionId,
+        user_id: user.id,
+        plan_id: plan.planId,
+        kind: 'activation',
+        idempotency_key: requestKey,
+        period_start: periodStart,
+        period_end: periodEnd,
+        cost_microdollars: plan.costMicrodollars,
+        credit_transaction_id: purchaseTransactionId,
+        created_at: periodStart,
+      } satisfies typeof coding_plan_terms.$inferInsert);
+    }
+
+    const waitlistUser = getUser(users, 'waitlist-ultra');
+    const [availabilityIntent] = await tx
+      .insert(coding_plan_availability_intents)
+      .values({
+        user_id: waitlistUser.id,
+        plan_id: 'minimax-token-plan-ultra',
+      } satisfies typeof coding_plan_availability_intents.$inferInsert)
+      .returning({ id: coding_plan_availability_intents.id });
+
+    return {
+      scenario,
+      usersCreated: users.length,
+      subscriptionsCreated: SUBSCRIPTION_FIXTURES.length,
+      activeSubscriptions: 1,
+      cancellationPendingSubscriptions: 1,
+      pastDueSubscriptions: 1,
+      canceledSubscriptions: 2,
+      inventoryRowsCreated: inventoryFixtures.length,
+      availableCredentials: 4,
+      assignedCredentials: 3,
+      revocationPendingCredentials: 1,
+      revocationFailedCredentials: 1,
+      revokedCredentials: 1,
+      availabilityIntentId: availabilityIntent?.id ?? null,
+      activeUserId: getUser(users, 'active-plus').id,
+      cancelingUserId: getUser(users, 'canceling-max').id,
+      pastDueUserId: getUser(users, 'past-due-ultra').id,
+      canceledPendingUserId: getUser(users, 'canceled-pending-plus').id,
+      canceledFailedUserId: getUser(users, 'canceled-failed-max').id,
+      waitlistUserId: waitlistUser.id,
+      activeUserEmail: getUser(users, 'active-plus').email,
+      cancelingUserEmail: getUser(users, 'canceling-max').email,
+      pastDueUserEmail: getUser(users, 'past-due-ultra').email,
+      providerTrafficValid: false,
+    } satisfies SeedResult;
+  });
+}
+
+export async function run(...args: string[]): Promise<SeedResult | void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const [rawScenario, ...rest] = args;
+  if (rest.length > 0) {
+    printUsage();
+    throw new Error(`Unexpected extra arguments: ${rest.join(' ')}`);
+  }
+
+  const scenario = requireScenario(rawScenario);
+  const key = requireEncryptionKey();
+  const oldStripeCustomerIds = await cleanupScenario(scenario);
+  await Promise.all(oldStripeCustomerIds.map(customerId => deleteSeedStripeCustomer(customerId)));
+  const stripeCustomerIds = await createStripeCustomers(scenario);
+  const newStripeCustomerIds = Object.values(stripeCustomerIds);
+  const users = getSeedUsers(scenario, stripeCustomerIds);
+
+  try {
+    const result = await seedScenario(scenario, key, users);
+
+    console.log(
+      'Seeded Coding Plan admin fixtures: active, cancellation pending, past due, canceled, and revocation states.'
+    );
+    console.log('Placeholder MiniMax credentials are encrypted but invalid for provider traffic.');
+
+    return result;
+  } catch (error) {
+    await Promise.all(newStripeCustomerIds.map(customerId => deleteSeedStripeCustomer(customerId)));
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
Adds admin support for rotating MiniMax Coding Plan keys without losing the existing upstream plan ID.

### Why this change is needed
MiniMax key revocation now requires generating a replacement key for the same user plan instead of only marking the old key revoked. Admins need one workflow for permanent removal and one workflow for replacing the credential while keeping the plan available in Kilo.

### How this is addressed
- Renames the manual revocation queue surface to Pending Key Rotation.
- Adds separate Revoke and Replace actions for queued inventory items.
- Validates replacement MiniMax API keys using the same provider check as inventory upload.
- Stores valid replacement keys encrypted against the existing upstream plan ID and returns the item to available stock.
- Keeps Revoke as permanent stock removal.

## Human Verification
- `pnpm --filter web test -- apps/web/src/lib/coding-plans/index.test.ts apps/web/src/routers/coding-plans-router.test.ts`

## Reviewer Notes
### Human Reviewer Flags
- Replacement keeps the existing `upstream_plan_id` and changes only Kilo's stored API key material.
- Revoke remains available for permanent removal, but Mark failed/Requeue are intentionally removed from the admin UI because they do not match current operations.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `replaceManualCredentialRevocation` validates the new key before writing encrypted credential material back to inventory.
- Failed replacement validation leaves queued inventory unchanged.
- Admin router exposes `adminReplaceRevocationCredential` and maps validation/precondition failures to `PRECONDITION_FAILED`.
- Existing backend Mark failed/Requeue procedures remain for compatibility, but no longer appear in the Pending Key Rotation UI.

</details>
