### PR TITLE
feat(admin): add personal account toggle to user admin page

### DIFF
--- a/apps/web/src/app/admin/components/UserAdmin/PersonalAccountDisabledToggle.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/PersonalAccountDisabledToggle.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Switch } from '@/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useTRPC } from '@/lib/trpc/utils';
+
+export default function PersonalAccountDisabledToggle({
+  userId,
+  initialValue,
+  isInOrganization,
+}: {
+  userId: string;
+  initialValue: boolean;
+  isInOrganization: boolean;
+}) {
+  const trpc = useTRPC();
+  const router = useRouter();
+
+  // UI is framed positively (the switch reflects whether the personal account
+  // is enabled) while the stored flag is `personal_account_disabled`, so
+  // `enabled` is its inverse.
+  const [enabled, setEnabled] = useState(!initialValue);
+
+  // Re-sync with the server value after router.refresh() re-renders the page.
+  useEffect(() => {
+    setEnabled(!initialValue);
+  }, [initialValue]);
+
+  const { mutate, isPending } = useMutation(
+    trpc.admin.users.setPersonalAccountDisabled.mutationOptions({
+      onSuccess: (_result, variables) => {
+        toast.success(
+          variables.value
+            ? 'Personal account disabled for this user'
+            : 'Personal account re-enabled for this user'
+        );
+        router.refresh();
+      },
+      onError: err => {
+        setEnabled(!initialValue);
+        toast.error(`Failed to update personal account: ${err.message}`);
+      },
+    })
+  );
+
+  const switchNode = (
+    <Switch
+      checked={enabled}
+      disabled={isPending || !isInOrganization}
+      onCheckedChange={nextEnabled => {
+        setEnabled(nextEnabled);
+        mutate({ userId, value: !nextEnabled });
+      }}
+      aria-label="Personal account enabled"
+      className={!isInOrganization ? 'pointer-events-none' : undefined}
+    />
+  );
+
+  // A disabled switch doesn't emit hover events, so the tooltip trigger is a
+  // focusable wrapper around it.
+  if (!isInOrganization) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span tabIndex={0} className="inline-flex">
+            {switchNode}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs">
+          Only users who belong to an organization can have their personal account disabled.
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return switchNode;
+}

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
@@ -9,9 +9,11 @@ import type { UserDetailProps } from '@/types/admin';
 import ResetAPIKeyButton from './ResetAPIKeyButton';
 import ResetToMagicLinkLoginButton from './ResetToMagicLinkLoginButton';
 import SignOutBrowserSessionsButton from './SignOutBrowserSessionsButton';
+import PersonalAccountDisabledToggle from './PersonalAccountDisabledToggle';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import Link from 'next/link';
-import { SquareArrowOutUpRight, Webhook } from 'lucide-react';
+import { Info, SquareArrowOutUpRight, Webhook } from 'lucide-react';
 import { createHash } from 'crypto';
 
 function getGravatarUrl(email: string, size: number = 80): string {
@@ -32,7 +34,7 @@ export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
         user.blocked_reason || user.is_blacklisted_by_domain ? 'border-red-500 bg-red-950/50' : ''
       }
     >
-      <CardContent className="pt-5">
+      <CardContent className="pt-6">
         {/* Top row: identity + badges/actions */}
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="flex items-center gap-3">
@@ -100,7 +102,7 @@ export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
         </div>
 
         {/* Metadata grid */}
-        <div className="mt-4 grid grid-cols-2 gap-x-8 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
+        <div className="border-border mt-6 grid grid-cols-2 gap-x-8 gap-y-5 border-t pt-6 sm:grid-cols-3 lg:grid-cols-4">
           <Field label="User ID" mono>
             {user.id} <CopyTextButton text={user.id} />
           </Field>
@@ -151,6 +153,16 @@ export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
               <span className="text-muted-foreground">N/A</span>
             )}
           </Field>
+          <Field
+            label="Personal Account"
+            tooltip="A personal account lets this user accrue usage under their own personal namespace. When disabled, they can't select their personal namespace in the clients or the web app. Either way, they can still join organizations."
+          >
+            <PersonalAccountDisabledToggle
+              userId={user.id}
+              initialValue={user.personal_account_disabled}
+              isInOrganization={user.organization_memberships.length > 0}
+            />
+          </Field>
         </div>
       </CardContent>
     </Card>
@@ -160,15 +172,33 @@ export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
 function Field({
   label,
   mono,
+  tooltip,
   children,
 }: {
   label: string;
   mono?: boolean;
+  tooltip?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-w-0">
-      <h4 className="text-muted-foreground text-xs font-medium">{label}</h4>
+    <div className="flex min-w-0 flex-col gap-1">
+      <h4 className="text-muted-foreground flex items-center gap-1 text-xs font-medium">
+        {label}
+        {tooltip ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="text-muted-foreground/70 hover:text-foreground transition-colors"
+                aria-label={`${label} info`}
+              >
+                <Info className="h-3 w-3" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">{tooltip}</TooltipContent>
+          </Tooltip>
+        ) : null}
+      </h4>
       <div
         className={`flex items-center gap-1 text-sm break-all ${mono ? 'font-mono text-xs' : ''}`}
       >

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -281,6 +281,11 @@ const UpdateUserBlockStatusSchema = z.object({
   blocked_reason: z.string().trim().min(1).nullable(),
 });
 
+const SetPersonalAccountDisabledSchema = z.object({
+  userId: z.string(),
+  value: z.boolean(),
+});
+
 const GetStytchFingerprintsSchema = z.object({
   kilo_user_id: z.string(),
   fingerprint_type: z
@@ -557,6 +562,21 @@ export const adminRouter = createTRPCRouter({
               },
             ],
           });
+        }
+
+        return successResult();
+      }),
+
+    setPersonalAccountDisabled: adminProcedure
+      .input(SetPersonalAccountDisabledSchema)
+      .mutation(async ({ input }) => {
+        const result = await db
+          .update(kilocode_users)
+          .set({ personal_account_disabled: input.value })
+          .where(eq(kilocode_users.id, input.userId));
+
+        if ((result.rowCount ?? 0) === 0) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
         }
 
         return successResult();


### PR DESCRIPTION
## Summary

Adds an admin control on the user detail page (`/admin/users/[id]`) to view and toggle a user's `personal_account_disabled` flag.

- **Toggle** — A `Switch` in the account-info metadata grid, framed positively so *on = personal account enabled* (the stored column is `personal_account_disabled`, so the UI inverts it). Writes via a new `admin.users.setPersonalAccountDisabled` tRPC mutation and `router.refresh()`es the server-rendered page.
- **Org-gated** — The switch is disabled for users who don't belong to any organization, with a tooltip: *"Only users who belong to an organization can have their personal account disabled."*
- **Explanatory label tooltip** — An info icon on the "Personal Account" label explains that a personal account lets the user accrue usage under their own namespace, that disabling removes their ability to select the personal namespace in clients/web, and that they can still join organizations.
- **Card polish** — Touched up the account-info card spacing (divider between header/actions and metadata, looser row gaps, label→value spacing) now that it hosts an interactive control.

## Screenshots
<img width="774" height="282" alt="CleanShot 2026-07-08 at 13 54 54@2x" src="https://github.com/user-attachments/assets/eaf29dd5-ca8c-409a-85b3-1c013c1934a2" />
<img width="786" height="428" alt="CleanShot 2026-07-08 at 13 55 08@2x" src="https://github.com/user-attachments/assets/4262267f-a2c2-476a-9321-1973cef57b42" />
