### PR TITLE
feat(web): hide personal surface for users with disabled personal account

### DIFF
--- a/apps/web/src/app/(app)/components/AppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/AppSidebar.tsx
@@ -54,10 +54,10 @@ export default function AppSidebar(props: React.ComponentProps<typeof Sidebar>) 
   const searchParams = useSearchParams();
   const setupStep = searchParams.get('step');
   const { open, setOpenMobile, setOpenTransient } = useSidebar();
-  const isInvitedOnly = Boolean(user?.personal_account_disabled);
+  const personalAccountDisabled = Boolean(user?.personal_account_disabled);
   const { data: organizations, isPending: isOrganizationsPending } = useQuery(
     trpc.organizations.list.queryOptions(undefined, {
-      enabled: isInvitedOnly && !currentOrgId,
+      enabled: personalAccountDisabled && !currentOrgId,
       trpc: { context: { skipBatch: true } },
     })
   );
@@ -142,16 +142,16 @@ export default function AppSidebar(props: React.ComponentProps<typeof Sidebar>) 
     return <OrganizationAppSidebar organizationId={currentOrgId} {...props} />;
   }
 
-  // Invited-only users (personal account disabled) have no personal surface.
+  // Users with a disabled personal account have no personal surface.
   // On non-org routes that remain reachable to them (e.g. /connected-accounts),
   // keep them in their default organization's sidebar rather than the personal one.
-  if (isInvitedOnly) {
+  if (personalAccountDisabled) {
     if (defaultOrganizationId) {
       return <OrganizationAppSidebar organizationId={defaultOrganizationId} {...props} />;
     }
     // Avoid flashing the personal sidebar while resolving their default org.
-    // Only fall through to the personal sidebar for the rare orphan case
-    // (invited-only user who belongs to no organizations).
+    // Only fall through to the personal sidebar for the rare case of a user with
+    // a disabled personal account who belongs to no organizations.
     if (isOrganizationsPending) {
       return <Sidebar {...props} />;
     }

--- a/apps/web/src/app/(app)/components/AppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/AppSidebar.tsx
@@ -14,6 +14,9 @@ import { WastelandSidebar } from '@/components/wasteland/WastelandSidebar';
 
 const UUID = '[0-9a-f-]{36}';
 
+// Routes linked from the footer user menu (see SidebarUserFooter). Keep in sync.
+const FOOTER_MENU_ROUTES = ['/connected-accounts', '/install', '/learn'];
+
 /** Extract the townId from a /gastown/[townId] pathname, or null. */
 function extractGastownTownId(pathname: string): string | null {
   const match = pathname.match(new RegExp(`^/gastown/(${UUID})`));
@@ -55,17 +58,17 @@ export default function AppSidebar(props: React.ComponentProps<typeof Sidebar>) 
   const setupStep = searchParams.get('step');
   const { open, setOpenMobile, setOpenTransient } = useSidebar();
   const personalAccountDisabled = Boolean(user?.personal_account_disabled);
-  // The only personal route we still link to for these users (footer user menu).
-  // For that route we keep them in their org sidebar instead of the personal one;
-  // other personal routes are not linked but remain accessible with the personal
-  // sidebar if reached directly.
-  const isLinkedAccountRoute =
-    pathname === '/connected-accounts' || pathname.startsWith('/connected-accounts/');
-  const useOrgSidebarForAccountRoute =
-    personalAccountDisabled && !currentOrgId && isLinkedAccountRoute;
+  // Routes we still link to for these users via the footer user menu. On these we
+  // keep them in their org sidebar instead of switching to the personal one; other
+  // personal routes are not linked but remain accessible with the personal sidebar
+  // if reached directly.
+  const isFooterMenuRoute = FOOTER_MENU_ROUTES.some(
+    route => pathname === route || pathname.startsWith(route + '/')
+  );
+  const useOrgSidebarForFooterRoute = personalAccountDisabled && !currentOrgId && isFooterMenuRoute;
   const { data: organizations, isPending: isOrganizationsPending } = useQuery(
     trpc.organizations.list.queryOptions(undefined, {
-      enabled: useOrgSidebarForAccountRoute,
+      enabled: useOrgSidebarForFooterRoute,
       trpc: { context: { skipBatch: true } },
     })
   );
@@ -150,10 +153,10 @@ export default function AppSidebar(props: React.ComponentProps<typeof Sidebar>) 
     return <OrganizationAppSidebar organizationId={currentOrgId} {...props} />;
   }
 
-  // On the account route we link to from the footer, keep users with a disabled
+  // On routes we link to from the footer user menu, keep users with a disabled
   // personal account in their default organization's sidebar rather than the
   // personal one. Any other personal route falls through to the personal sidebar.
-  if (useOrgSidebarForAccountRoute) {
+  if (useOrgSidebarForFooterRoute) {
     if (defaultOrganizationId) {
       return <OrganizationAppSidebar organizationId={defaultOrganizationId} {...props} />;
     }

--- a/apps/web/src/app/(app)/components/AppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/AppSidebar.tsx
@@ -55,9 +55,17 @@ export default function AppSidebar(props: React.ComponentProps<typeof Sidebar>) 
   const setupStep = searchParams.get('step');
   const { open, setOpenMobile, setOpenTransient } = useSidebar();
   const personalAccountDisabled = Boolean(user?.personal_account_disabled);
+  // The only personal route we still link to for these users (footer user menu).
+  // For that route we keep them in their org sidebar instead of the personal one;
+  // other personal routes are not linked but remain accessible with the personal
+  // sidebar if reached directly.
+  const isLinkedAccountRoute =
+    pathname === '/connected-accounts' || pathname.startsWith('/connected-accounts/');
+  const useOrgSidebarForAccountRoute =
+    personalAccountDisabled && !currentOrgId && isLinkedAccountRoute;
   const { data: organizations, isPending: isOrganizationsPending } = useQuery(
     trpc.organizations.list.queryOptions(undefined, {
-      enabled: personalAccountDisabled && !currentOrgId,
+      enabled: useOrgSidebarForAccountRoute,
       trpc: { context: { skipBatch: true } },
     })
   );
@@ -142,16 +150,16 @@ export default function AppSidebar(props: React.ComponentProps<typeof Sidebar>) 
     return <OrganizationAppSidebar organizationId={currentOrgId} {...props} />;
   }
 
-  // Users with a disabled personal account have no personal surface.
-  // On non-org routes that remain reachable to them (e.g. /connected-accounts),
-  // keep them in their default organization's sidebar rather than the personal one.
-  if (personalAccountDisabled) {
+  // On the account route we link to from the footer, keep users with a disabled
+  // personal account in their default organization's sidebar rather than the
+  // personal one. Any other personal route falls through to the personal sidebar.
+  if (useOrgSidebarForAccountRoute) {
     if (defaultOrganizationId) {
       return <OrganizationAppSidebar organizationId={defaultOrganizationId} {...props} />;
     }
     // Avoid flashing the personal sidebar while resolving their default org.
-    // Only fall through to the personal sidebar for the rare case of a user with
-    // a disabled personal account who belongs to no organizations.
+    // Only fall through for the rare case of a user with a disabled personal
+    // account who belongs to no organizations.
     if (isOrganizationsPending) {
       return <Sidebar {...props} />;
     }

--- a/apps/web/src/app/(app)/components/AppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/AppSidebar.tsx
@@ -2,8 +2,11 @@
 
 import { useEffect, useRef } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { useSidebar, type Sidebar } from '@/components/ui/sidebar';
+import { useQuery } from '@tanstack/react-query';
+import { Sidebar, useSidebar } from '@/components/ui/sidebar';
 import { useUrlOrganizationId } from '@/hooks/useUrlOrganizationId';
+import { useUser } from '@/hooks/useUser';
+import { useTRPC } from '@/lib/trpc/utils';
 import PersonalAppSidebar from './PersonalAppSidebar';
 import OrganizationAppSidebar from './OrganizationAppSidebar';
 import { GastownTownSidebar } from '@/components/gastown/GastownTownSidebar';
@@ -44,11 +47,28 @@ function extractOrgWastelandId(pathname: string): { orgId: string; wastelandId: 
 }
 
 export default function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
+  const trpc = useTRPC();
   const currentOrgId = useUrlOrganizationId();
+  const { data: user } = useUser();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const setupStep = searchParams.get('step');
   const { open, setOpenMobile, setOpenTransient } = useSidebar();
+  const isInvitedOnly = Boolean(user?.personal_account_disabled);
+  const { data: organizations, isPending: isOrganizationsPending } = useQuery(
+    trpc.organizations.list.queryOptions(undefined, {
+      enabled: isInvitedOnly && !currentOrgId,
+      trpc: { context: { skipBatch: true } },
+    })
+  );
+  // Match the server-side default (oldest org) so the sidebar org is consistent
+  // with getProfileRedirectPath.
+  const defaultOrganizationId = organizations?.length
+    ? [...organizations].sort((a, b) => {
+        const byCreatedAt = a.created_at.localeCompare(b.created_at);
+        return byCreatedAt !== 0 ? byCreatedAt : a.organizationId.localeCompare(b.organizationId);
+      })[0].organizationId
+    : null;
   const previousSidebarOpen = useRef<boolean | null>(null);
   const currentSidebarOpen = useRef(open);
   const sidebarActions = useRef({ setOpenMobile, setOpenTransient });
@@ -120,6 +140,21 @@ export default function AppSidebar(props: React.ComponentProps<typeof Sidebar>) 
   // Render organization sidebar if viewing an organization
   if (currentOrgId) {
     return <OrganizationAppSidebar organizationId={currentOrgId} {...props} />;
+  }
+
+  // Invited-only users (personal account disabled) have no personal surface.
+  // On non-org routes that remain reachable to them (e.g. /connected-accounts),
+  // keep them in their default organization's sidebar rather than the personal one.
+  if (isInvitedOnly) {
+    if (defaultOrganizationId) {
+      return <OrganizationAppSidebar organizationId={defaultOrganizationId} {...props} />;
+    }
+    // Avoid flashing the personal sidebar while resolving their default org.
+    // Only fall through to the personal sidebar for the rare orphan case
+    // (invited-only user who belongs to no organizations).
+    if (isOrganizationsPending) {
+      return <Sidebar {...props} />;
+    }
   }
 
   // Otherwise render personal sidebar

--- a/apps/web/src/app/(app)/components/OrganizationSwitcher.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationSwitcher.tsx
@@ -14,6 +14,7 @@ import { cn } from '@/lib/utils';
 import { Check, ChevronDown } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
+import { useUser } from '@/hooks/useUser';
 
 type OrganizationSwitcherProps = {
   organizationId?: string | null;
@@ -29,6 +30,7 @@ type OrganizationSwitcherViewProps = {
   organizationId?: string | null;
   organizations?: OrganizationSwitcherOrganization[];
   isPending?: boolean;
+  showPersonalOption?: boolean;
   onOrganizationSwitch: (organizationId: string | null) => void;
 };
 
@@ -51,6 +53,7 @@ const selectedIconClassName = 'text-primary h-4 w-4 shrink-0';
 export default function OrganizationSwitcher({ organizationId = null }: OrganizationSwitcherProps) {
   const trpc = useTRPC();
   const router = useRouter();
+  const { data: user } = useUser();
 
   // Fetch user organizations
   const { data: organizations, isPending } = useQuery(
@@ -76,6 +79,7 @@ export default function OrganizationSwitcher({ organizationId = null }: Organiza
       organizationId={organizationId}
       organizations={organizations}
       isPending={isPending}
+      showPersonalOption={!user?.personal_account_disabled}
       onOrganizationSwitch={handleOrganizationSwitch}
     />
   );
@@ -85,6 +89,7 @@ export function OrganizationSwitcherView({
   organizationId = null,
   organizations = [],
   isPending = false,
+  showPersonalOption = true,
   onOrganizationSwitch,
 }: OrganizationSwitcherViewProps) {
   // Get role display label
@@ -165,22 +170,26 @@ export function OrganizationSwitcherView({
             </DropdownMenuItem>
           ))}
 
-          {/* Separator */}
-          <DropdownMenuSeparator />
+          {showPersonalOption && (
+            <>
+              {/* Separator */}
+              <DropdownMenuSeparator />
 
-          {/* Personal Option */}
-          <DropdownMenuItem
-            onClick={() => onOrganizationSwitch(null)}
-            className={cn(menuItemClassName, !organizationId && selectedMenuItemClassName)}
-          >
-            <div className={switcherRowClassName}>
-              <div className={switcherTextClassName}>
-                <div className={switcherTitleClassName}>Personal</div>
-                <div className={switcherSubtitleClassName}>Personal Workspace</div>
-              </div>
-              {!organizationId && <Check className={selectedIconClassName} />}
-            </div>
-          </DropdownMenuItem>
+              {/* Personal Option */}
+              <DropdownMenuItem
+                onClick={() => onOrganizationSwitch(null)}
+                className={cn(menuItemClassName, !organizationId && selectedMenuItemClassName)}
+              >
+                <div className={switcherRowClassName}>
+                  <div className={switcherTextClassName}>
+                    <div className={switcherTitleClassName}>Personal</div>
+                    <div className={switcherSubtitleClassName}>Personal Workspace</div>
+                  </div>
+                  {!organizationId && <Check className={selectedIconClassName} />}
+                </div>
+              </DropdownMenuItem>
+            </>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -9,7 +9,6 @@ import {
   Coins,
   Receipt,
   User,
-  UserCog,
   Building2,
   Plus,
   Rocket,
@@ -274,11 +273,6 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
       title: 'Credits',
       icon: Coins,
       url: '/credits',
-    },
-    {
-      title: 'Connected Accounts',
-      icon: UserCog,
-      url: '/connected-accounts',
     },
     {
       title: 'Bring Your Own Key (BYOK)',

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -19,8 +19,6 @@ import {
   List,
   Shield,
   ListChecks,
-  Download,
-  BookOpen,
   Key,
   Wrench,
   Webhook,
@@ -281,25 +279,6 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
     },
   ];
 
-  // Start group
-  const startItems: Array<{
-    title: string;
-    icon: React.ElementType;
-    url: string;
-    className?: string;
-  }> = [
-    {
-      title: 'Install',
-      icon: Download,
-      url: '/install',
-    },
-    {
-      title: 'Learn',
-      icon: BookOpen,
-      url: '/learn',
-    },
-  ];
-
   const kiloClawBaseUrl = '/claw';
   const kiloClawInstanceState = kiloClawNavStateQuery.isSuccess
     ? kiloClawNavStateQuery.data.hasActiveInstance
@@ -363,7 +342,6 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
     ...kiloClawItems,
     ...cloudItems,
     ...accountItems,
-    ...startItems,
   ].map(i => (typeof i === 'string' ? i : i.url));
 
   return (
@@ -393,7 +371,6 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
               <SidebarMenuList label="Cloud" items={cloudItems} allUrls={allUrls} />
             )}
             <SidebarMenuList label="Account" items={accountItems} allUrls={allUrls} />
-            <SidebarMenuList label="Start" items={startItems} allUrls={allUrls} />
           </>
         )}
       </SidebarContent>

--- a/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
+++ b/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
@@ -1,11 +1,18 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
 import { SidebarFooter } from '@/components/ui/sidebar';
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarImage, AvatarFallback } from '@radix-ui/react-avatar';
-import { LogOut } from 'lucide-react';
+import { ChevronsUpDown, LogOut, UserCog } from 'lucide-react';
 import { signOut } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 
 type User = {
   google_user_name: string;
@@ -18,22 +25,24 @@ type SidebarUserFooterProps = {
   isLoading: boolean;
 };
 
+// Get user initials for avatar fallback
+function getUserInitials(name: string) {
+  const parts = name.split(' ');
+  if (parts.length >= 2) {
+    return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+  }
+  return name.slice(0, 2).toUpperCase();
+}
+
 export default function SidebarUserFooter({ user, isLoading }: SidebarUserFooterProps) {
+  const router = useRouter();
+
   const handleLogout = async () => {
     try {
       await fetch('/api/auth/revoke-web-session', { method: 'POST' });
     } finally {
       await signOut({ callbackUrl: '/' });
     }
-  };
-
-  // Get user initials for avatar fallback
-  const getUserInitials = (name: string) => {
-    const parts = name.split(' ');
-    if (parts.length >= 2) {
-      return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
-    }
-    return name.slice(0, 2).toUpperCase();
   };
 
   return (
@@ -48,31 +57,41 @@ export default function SidebarUserFooter({ user, isLoading }: SidebarUserFooter
           <Skeleton className="h-8 w-8" />
         </div>
       ) : user ? (
-        <div className="flex items-center gap-3 p-2">
-          <Avatar className="bg-surface-overlay h-8 w-8 overflow-hidden rounded-full border border-border text-foreground">
-            <AvatarImage
-              src={user.google_user_image_url}
-              alt={user.google_user_name}
-              className="h-full w-full object-cover"
-            />
-            <AvatarFallback className="bg-surface-overlay flex h-full w-full items-center justify-center text-sm font-medium">
-              {getUserInitials(user.google_user_name)}
-            </AvatarFallback>
-          </Avatar>
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium">{user.google_user_name}</p>
-            <p className="text-muted-foreground truncate text-xs">{user.google_user_email}</p>
-          </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-8 w-8 p-0"
-            onClick={handleLogout}
-            title="Sign out"
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger className="hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-3 rounded-md p-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            <Avatar className="bg-surface-overlay h-8 w-8 overflow-hidden rounded-full border border-border text-foreground">
+              <AvatarImage
+                src={user.google_user_image_url}
+                alt={user.google_user_name}
+                className="h-full w-full object-cover"
+              />
+              <AvatarFallback className="bg-surface-overlay flex h-full w-full items-center justify-center text-sm font-medium">
+                {getUserInitials(user.google_user_name)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium">{user.google_user_name}</p>
+              <p className="text-muted-foreground truncate text-xs">{user.google_user_email}</p>
+            </div>
+            <ChevronsUpDown className="text-muted-foreground h-4 w-4 shrink-0" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-56"
+            align="start"
+            side="top"
+            sideOffset={4}
           >
-            <LogOut className="h-4 w-4" />
-          </Button>
-        </div>
+            <DropdownMenuItem onClick={() => router.push('/connected-accounts')}>
+              <UserCog className="h-4 w-4" />
+              Connected Accounts
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={handleLogout}>
+              <LogOut className="h-4 w-4" />
+              Sign out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       ) : null}
     </SidebarFooter>
   );

--- a/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
+++ b/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarImage, AvatarFallback } from '@radix-ui/react-avatar';
-import { ChevronsUpDown, LogOut, UserCog } from 'lucide-react';
+import { BookOpen, ChevronsUpDown, Download, LogOut, UserCog } from 'lucide-react';
 import { signOut } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 
@@ -84,6 +84,14 @@ export default function SidebarUserFooter({ user, isLoading }: SidebarUserFooter
             <DropdownMenuItem onClick={() => router.push('/connected-accounts')}>
               <UserCog className="h-4 w-4" />
               Connected Accounts
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => router.push('/install')}>
+              <Download className="h-4 w-4" />
+              Install
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => router.push('/learn')}>
+              <BookOpen className="h-4 w-4" />
+              Learn
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleLogout}>

--- a/apps/web/src/lib/user/server.test.ts
+++ b/apps/web/src/lib/user/server.test.ts
@@ -562,4 +562,28 @@ describe('getProfileRedirectPath', () => {
       `/organizations/${pastDueOrganization.id}`
     );
   });
+
+  describe('invited-only users (personal account disabled)', () => {
+    test('redirects multi-organization users to one of their organizations', async () => {
+      const invitedUser = await insertTestUser({
+        google_user_name: 'Invited Multi Org User',
+        personal_account_disabled: true,
+      });
+      const orgA = await createTestOrganization('Invited Org A', invitedUser.id, 100_000);
+      const orgB = await createTestOrganization('Invited Org B', invitedUser.id, 100_000);
+
+      await expect(getProfileRedirectPath(invitedUser)).resolves.toMatch(
+        new RegExp(`^/organizations/(${orgA.id}|${orgB.id})$`)
+      );
+    });
+
+    test('falls back to connected accounts when the user has no organizations', async () => {
+      const orphanUser = await insertTestUser({
+        google_user_name: 'Invited Orphan User',
+        personal_account_disabled: true,
+      });
+
+      await expect(getProfileRedirectPath(orphanUser)).resolves.toBe('/connected-accounts');
+    });
+  });
 });

--- a/apps/web/src/lib/user/server.test.ts
+++ b/apps/web/src/lib/user/server.test.ts
@@ -563,7 +563,7 @@ describe('getProfileRedirectPath', () => {
     );
   });
 
-  describe('invited-only users (personal account disabled)', () => {
+  describe('users with personal account disabled', () => {
     test('redirects multi-organization users to one of their organizations', async () => {
       const invitedUser = await insertTestUser({
         google_user_name: 'Invited Multi Org User',

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -1059,27 +1059,14 @@ export async function getUserFromAuthOrRedirect(
   if (user.blocked_reason) {
     redirect('/account-blocked');
   }
-  await redirectPersonalAccountDisabledUserOffPersonalRoutes(user);
   return user;
 }
 
-// Personal routes that remain reachable for users whose personal account is
-// disabled. Connected Accounts is a user-global identity surface, not a
-// personal-account feature.
-const PERSONAL_ACCOUNT_DISABLED_ALLOWED_PATHS = ['/connected-accounts'];
-
-function isPersonalRoute(pathname: string): boolean {
-  if (pathname.startsWith('/organizations/') || pathname === '/organizations') {
-    return false;
-  }
-  return !PERSONAL_ACCOUNT_DISABLED_ALLOWED_PATHS.some(
-    allowed => pathname === allowed || pathname.startsWith(allowed + '/')
-  );
-}
-
-// Resolve where a user whose personal account is disabled should land.
+// Resolve where a user whose personal account is disabled should land by default.
 // Prefers their oldest organization (stable across requests); falls back to an
 // allowed personal route when they somehow belong to no organizations.
+// Note: this only affects where we send them by default (e.g. after login); we
+// do not block direct navigation to personal routes.
 async function resolvePersonalAccountDisabledLandingPath(userId: User['id']): Promise<string> {
   const orgs = await getUserOrganizationsWithSeats(userId);
   const firstOrg = [...orgs].sort((a, b) => {
@@ -1087,18 +1074,6 @@ async function resolvePersonalAccountDisabledLandingPath(userId: User['id']): Pr
     return byCreatedAt !== 0 ? byCreatedAt : a.organizationId.localeCompare(b.organizationId);
   })[0];
   return firstOrg ? `/organizations/${firstOrg.organizationId}` : '/connected-accounts';
-}
-
-async function redirectPersonalAccountDisabledUserOffPersonalRoutes(user: User): Promise<void> {
-  if (!user.personal_account_disabled) {
-    return;
-  }
-  const headersList = await headers();
-  const pathname = headersList.get('x-pathname');
-  if (!pathname || !isPersonalRoute(pathname)) {
-    return;
-  }
-  redirect(await resolvePersonalAccountDisabledLandingPath(user.id));
 }
 
 export async function signInUrlWithCallbackPath(): Promise<string> {

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -1059,28 +1059,28 @@ export async function getUserFromAuthOrRedirect(
   if (user.blocked_reason) {
     redirect('/account-blocked');
   }
-  await redirectInvitedOnlyUserOffPersonalRoutes(user);
+  await redirectPersonalAccountDisabledUserOffPersonalRoutes(user);
   return user;
 }
 
-// Personal routes that remain reachable for invited-only users
-// (accounts whose personal account is disabled). Connected Accounts is a
-// user-global identity surface, not a personal-account feature.
-const INVITED_ONLY_ALLOWED_PERSONAL_PATHS = ['/connected-accounts'];
+// Personal routes that remain reachable for users whose personal account is
+// disabled. Connected Accounts is a user-global identity surface, not a
+// personal-account feature.
+const PERSONAL_ACCOUNT_DISABLED_ALLOWED_PATHS = ['/connected-accounts'];
 
 function isPersonalRoute(pathname: string): boolean {
   if (pathname.startsWith('/organizations/') || pathname === '/organizations') {
     return false;
   }
-  return !INVITED_ONLY_ALLOWED_PERSONAL_PATHS.some(
+  return !PERSONAL_ACCOUNT_DISABLED_ALLOWED_PATHS.some(
     allowed => pathname === allowed || pathname.startsWith(allowed + '/')
   );
 }
 
-// Resolve where an invited-only user (personal account disabled) should land.
+// Resolve where a user whose personal account is disabled should land.
 // Prefers their oldest organization (stable across requests); falls back to an
 // allowed personal route when they somehow belong to no organizations.
-async function resolveInvitedOnlyLandingPath(userId: User['id']): Promise<string> {
+async function resolvePersonalAccountDisabledLandingPath(userId: User['id']): Promise<string> {
   const orgs = await getUserOrganizationsWithSeats(userId);
   const firstOrg = [...orgs].sort((a, b) => {
     const byCreatedAt = a.created_at.localeCompare(b.created_at);
@@ -1089,7 +1089,7 @@ async function resolveInvitedOnlyLandingPath(userId: User['id']): Promise<string
   return firstOrg ? `/organizations/${firstOrg.organizationId}` : '/connected-accounts';
 }
 
-async function redirectInvitedOnlyUserOffPersonalRoutes(user: User): Promise<void> {
+async function redirectPersonalAccountDisabledUserOffPersonalRoutes(user: User): Promise<void> {
   if (!user.personal_account_disabled) {
     return;
   }
@@ -1098,7 +1098,7 @@ async function redirectInvitedOnlyUserOffPersonalRoutes(user: User): Promise<voi
   if (!pathname || !isPersonalRoute(pathname)) {
     return;
   }
-  redirect(await resolveInvitedOnlyLandingPath(user.id));
+  redirect(await resolvePersonalAccountDisabledLandingPath(user.id));
 }
 
 export async function signInUrlWithCallbackPath(): Promise<string> {
@@ -1211,10 +1211,10 @@ export function getUserUUID(user: User): string {
 // the org page will be redirected to if the user is a member of exactly one organization
 // or if the org is SSO org
 export async function getProfileRedirectPath(user: User) {
-  // Invited-only users (personal account disabled) have no personal surface;
+  // Users whose personal account is disabled have no personal surface;
   // always send them into an organization regardless of org count.
   if (user.personal_account_disabled) {
-    return resolveInvitedOnlyLandingPath(user.id);
+    return resolvePersonalAccountDisabledLandingPath(user.id);
   }
 
   // Check if user is a member of exactly one organization (skip redirect if multiple)

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -45,7 +45,11 @@ import type { Organization, User } from '@kilocode/db/schema';
 import type { AuthProviderId } from '@kilocode/db/schema-types';
 import PostHogClient from '@/lib/posthog';
 import { captureException } from '@sentry/nextjs';
-import { getSingleUserOrganization, isOrganizationMember } from '@/lib/organizations/organizations';
+import {
+  getSingleUserOrganization,
+  getUserOrganizationsWithSeats,
+  isOrganizationMember,
+} from '@/lib/organizations/organizations';
 import { resolveSsoAuthorityForDomain } from '@/lib/organizations/organization-sso-policy';
 import type { AccountLinkingSession } from '@/lib/account-linking-session';
 import { getAccountLinkingSession } from '@/lib/account-linking-session';
@@ -1055,7 +1059,46 @@ export async function getUserFromAuthOrRedirect(
   if (user.blocked_reason) {
     redirect('/account-blocked');
   }
+  await redirectInvitedOnlyUserOffPersonalRoutes(user);
   return user;
+}
+
+// Personal routes that remain reachable for invited-only users
+// (accounts whose personal account is disabled). Connected Accounts is a
+// user-global identity surface, not a personal-account feature.
+const INVITED_ONLY_ALLOWED_PERSONAL_PATHS = ['/connected-accounts'];
+
+function isPersonalRoute(pathname: string): boolean {
+  if (pathname.startsWith('/organizations/') || pathname === '/organizations') {
+    return false;
+  }
+  return !INVITED_ONLY_ALLOWED_PERSONAL_PATHS.some(
+    allowed => pathname === allowed || pathname.startsWith(allowed + '/')
+  );
+}
+
+// Resolve where an invited-only user (personal account disabled) should land.
+// Prefers their oldest organization (stable across requests); falls back to an
+// allowed personal route when they somehow belong to no organizations.
+async function resolveInvitedOnlyLandingPath(userId: User['id']): Promise<string> {
+  const orgs = await getUserOrganizationsWithSeats(userId);
+  const firstOrg = [...orgs].sort((a, b) => {
+    const byCreatedAt = a.created_at.localeCompare(b.created_at);
+    return byCreatedAt !== 0 ? byCreatedAt : a.organizationId.localeCompare(b.organizationId);
+  })[0];
+  return firstOrg ? `/organizations/${firstOrg.organizationId}` : '/connected-accounts';
+}
+
+async function redirectInvitedOnlyUserOffPersonalRoutes(user: User): Promise<void> {
+  if (!user.personal_account_disabled) {
+    return;
+  }
+  const headersList = await headers();
+  const pathname = headersList.get('x-pathname');
+  if (!pathname || !isPersonalRoute(pathname)) {
+    return;
+  }
+  redirect(await resolveInvitedOnlyLandingPath(user.id));
 }
 
 export async function signInUrlWithCallbackPath(): Promise<string> {
@@ -1168,6 +1211,12 @@ export function getUserUUID(user: User): string {
 // the org page will be redirected to if the user is a member of exactly one organization
 // or if the org is SSO org
 export async function getProfileRedirectPath(user: User) {
+  // Invited-only users (personal account disabled) have no personal surface;
+  // always send them into an organization regardless of org count.
+  if (user.personal_account_disabled) {
+    return resolveInvitedOnlyLandingPath(user.id);
+  }
+
   // Check if user is a member of exactly one organization (skip redirect if multiple)
   const singleOrg = await getSingleUserOrganization(user.id);
   if (singleOrg) {


### PR DESCRIPTION
## What

Builds on #4447 (`personal_account_disabled`). When a user's personal account is disabled — i.e. the login exists only because they were invited to an org — we stop surfacing the personal-account UI and default them into their organization instead.

Approach: **we don't link these users to personal pages**, but we don't hard-block them either. Direct navigation to a personal route still works and renders the page (with the personal sidebar), it's just no longer reachable through our own navigation.

## Changes

- **Default landing** (`getProfileRedirectPath`): users with a disabled personal account are always sent into an organization (their oldest, deterministic ordering) regardless of org count; falls back to `/connected-accounts` if they somehow belong to no orgs. This is a default-destination choice, not a block.
- **Org switcher**: hides the "Personal" entry for these users.
- **Footer user menu** (`SidebarUserFooter`): the avatar/name row becomes a dropdown containing **Connected Accounts** + **Sign out** — the home for user-global identity surfaces, shown in both the personal and org sidebars.
- **Personal sidebar**: drops the Connected Accounts item (now in the footer for everyone).
- **Sidebar selection** (`AppSidebar`): on `/connected-accounts` (the one personal route we still link to, from the footer), these users get their default org's sidebar instead of the personal one. Every other personal route falls through to the normal personal sidebar so the page renders.

## What this intentionally does NOT do

- No catch-all server-side redirect guard blocking personal routes. Direct navigation to `/profile`, `/subscriptions`, `/cost-insights`, etc. is allowed and renders normally; those routes are simply not linked for these users.
- The org menu stays strictly org-scoped and untouched — Connected Accounts lives in the footer, not the org Account group.

## Design notes

- Connected Accounts is genuinely *user-global* (primary email + linked auth providers), not personal-account-scoped, which is why it moves to the footer user menu.
- Terminology is kept tied to the `personal_account_disabled` field (no "invited-only" synonym) so the concept stays greppable.

## Testing

- Added `getProfileRedirectPath` tests: disabled personal account with multiple orgs (→ an org) and with zero orgs (→ `/connected-accounts`).
- `pnpm --filter web typecheck`, `server.test.ts` (56/56), `pnpm --filter web lint` (clean), `pnpm format`.
