### PR TITLE
fix(dev): point NEXTAUTH_URL at the offset port in auto-port sessions

### DIFF
--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -10,6 +10,7 @@ import {
   resolveGroups,
   topologicalSort,
   portOffset,
+  resolveSessionNextAuthUrl,
   services,
 } from './services';
 import { syncEnvVars } from './env-sync';
@@ -220,6 +221,14 @@ async function cmdUp(args: string[], repoRoot: string): Promise<void> {
   }
   if (process.env.PORT !== undefined && process.env.PORT !== '') {
     sessionEnv.PORT = String(getService('nextjs').port);
+  }
+  const sessionNextAuthUrl = resolveSessionNextAuthUrl({
+    portOffset,
+    serviceNames,
+    nextjsPort: getService('nextjs').port,
+  });
+  if (sessionNextAuthUrl !== undefined) {
+    sessionEnv.NEXTAUTH_URL = sessionNextAuthUrl;
   }
   if (process.env.DEBUG_SHOW_DEV_UI !== undefined && process.env.DEBUG_SHOW_DEV_UI !== '') {
     sessionEnv.DEBUG_SHOW_DEV_UI = process.env.DEBUG_SHOW_DEV_UI;

--- a/dev/local/services.test.ts
+++ b/dev/local/services.test.ts
@@ -2,7 +2,48 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import test from 'node:test';
 
-import { getAlwaysOnGroupIds, getService, resolveGroups } from './services';
+import {
+  getAlwaysOnGroupIds,
+  getService,
+  resolveGroups,
+  resolveSessionNextAuthUrl,
+} from './services';
+
+test('points NEXTAUTH_URL at the offset port when the web app runs without a tunnel', () => {
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 2900,
+    serviceNames: ['nextjs', 'postgres', 'redis'],
+    nextjsPort: 5900,
+  });
+  assert.equal(url, 'http://localhost:5900');
+});
+
+test('leaves NEXTAUTH_URL to .env.local when there is no port offset', () => {
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 0,
+    serviceNames: ['nextjs'],
+    nextjsPort: 3000,
+  });
+  assert.equal(url, undefined);
+});
+
+test('does not override NEXTAUTH_URL when a tunnel rewrites it to a public origin', () => {
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 2900,
+    serviceNames: ['nextjs', 'kiloclaw-tunnel'],
+    nextjsPort: 5900,
+  });
+  assert.equal(url, undefined);
+});
+
+test('skips NEXTAUTH_URL when the web app is not being started', () => {
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 2900,
+    serviceNames: ['postgres', 'redis'],
+    nextjsPort: 5900,
+  });
+  assert.equal(url, undefined);
+});
 
 test('keeps auto routing workers in their own opt-in group', () => {
   const service = getService('auto-routing');

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -302,6 +302,25 @@ function getNextjsTargetPort(): number {
 
 const nextjsTargetPort = getNextjsTargetPort();
 
+// When a port offset is active the web app binds to a non-3000 port, but
+// .env.local still hardcodes NEXTAUTH_URL=http://localhost:3000, so NextAuth
+// sign-in/out redirects land on :3000. Return the offset-aware localhost URL so
+// the caller can inject it as a process env var (which overrides .env files).
+// Returns undefined — leaving .env.local authoritative — when there's no offset
+// (e.g. mobile/manual host overrides) or when a tunnel is running, since
+// start-tunnel rewrites NEXTAUTH_URL to the public origin.
+export function resolveSessionNextAuthUrl(args: {
+  portOffset: number;
+  serviceNames: string[];
+  nextjsPort: number;
+}): string | undefined {
+  const { portOffset, serviceNames, nextjsPort } = args;
+  if (portOffset <= 0) return undefined;
+  if (!serviceNames.includes('nextjs')) return undefined;
+  if (serviceNames.includes('kiloclaw-tunnel')) return undefined;
+  return `http://localhost:${nextjsPort}`;
+}
+
 // ---------------------------------------------------------------------------
 // Wrangler config discovery
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `pnpm dev:start` with `KILO_PORT_OFFSET=auto` binds Next.js to a non-3000 port (writing it to `.dev-port`), but `.env.local` still hardcodes `NEXTAUTH_URL=http://localhost:3000`. Since we're on `next-auth` v4, that explicit `NEXTAUTH_URL` is the canonical base for sign-in/out redirects, so every auth redirect bounced back to `:3000`.
- Added a pure `resolveSessionNextAuthUrl(...)` helper in `dev/local/services.ts` and wired it into `cmdUp` in `dev/local/cli.ts` so the tmux session gets `NEXTAUTH_URL=http://localhost:<offset-port>`. A real process env var overrides `.env` files, so this fixes offset sessions without touching `.env.local`.

## Testing
- Ran `KILO_PORT_OFFSET=auto pnpm dev:start` on main, tried to sign-in/out: get redirected to `:3000`
- Checkout this branch
- Run `KILO_PORT_OFFSET=auto pnpm dev:start`, sign-in: get redirected to correct port
