### PR TITLE
fix(session-ingest,mobile): session-ready push only for remote-controllable sessions + back button on push-opened sessions

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -218,7 +218,7 @@ function RootLayoutNav() {
       // Navigate to pending notification deep link (cold start / background tap)
       const pendingNavigation = resolvePendingNotificationNavigation(getPendingNotificationLink());
       if (pendingNavigation) {
-        router.replace(pendingNavigation.href as Href);
+        router.navigate(pendingNavigation.href as Href);
       }
     }
   }, [

--- a/apps/mobile/src/components/code-reviewer/manual-review-screen.tsx
+++ b/apps/mobile/src/components/code-reviewer/manual-review-screen.tsx
@@ -176,14 +176,17 @@ export function ManualReviewScreen({ scope }: Readonly<{ scope: string }>) {
           <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
             Model
           </Text>
-          <ModelSelector
-            options={models}
-            value={effectiveModel.modelSlug}
-            variant={effectiveModel.thinkingEffort ?? ''}
-            onSelect={(modelId, variant) => {
-              setModelChoice({ modelSlug: modelId, thinkingEffort: variant || null });
-            }}
-          />
+          {/* flex-row so the pill hugs its content instead of stretching to column width */}
+          <View className="flex-row">
+            <ModelSelector
+              options={models}
+              value={effectiveModel.modelSlug}
+              variant={effectiveModel.thinkingEffort ?? ''}
+              onSelect={(modelId, variant) => {
+                setModelChoice({ modelSlug: modelId, thinkingEffort: variant || null });
+              }}
+            />
+          </View>
         </View>
 
         <Button

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -93,8 +93,11 @@ export function setupNotificationResponseHandler() {
     const path = notificationPathForData(data);
     Notifications.clearLastNotificationResponse();
     // If the router is ready, navigate immediately; otherwise store as pending.
+    // navigate (not replace) so the target screen keeps a back stack — replace
+    // on a stack root leaves canGoBack() false and strands the user — while
+    // still deduplicating if the route is already on top.
     try {
-      router.replace(path as Href);
+      router.navigate(path as Href);
     } catch {
       pendingNotificationLink = path;
     }

--- a/apps/mobile/src/lib/pending-notification-navigation.test.ts
+++ b/apps/mobile/src/lib/pending-notification-navigation.test.ts
@@ -7,10 +7,10 @@ describe('pending notification navigation', () => {
     expect(resolvePendingNotificationNavigation(null)).toBeNull();
   });
 
-  it('replaces the current route instead of pushing a duplicate history entry', () => {
+  it('navigates so the target screen keeps a back stack without duplicate history entries', () => {
     expect(resolvePendingNotificationNavigation('/chat/sandbox/conversation')).toEqual({
       href: '/chat/sandbox/conversation',
-      method: 'replace',
+      method: 'navigate',
     });
   });
 });

--- a/apps/mobile/src/lib/pending-notification-navigation.ts
+++ b/apps/mobile/src/lib/pending-notification-navigation.ts
@@ -1,13 +1,16 @@
 type PendingNotificationNavigation = {
   href: string;
-  method: 'replace';
+  method: 'navigate';
 };
 
+// `navigate` rather than `replace`: replacing the stack root leaves the target
+// screen with no back stack (no back button, user stranded), while `navigate`
+// pushes an entry yet still dedupes if the route is already current.
 export function resolvePendingNotificationNavigation(
   pendingLink: string | null
 ): PendingNotificationNavigation | null {
   if (!pendingLink) {
     return null;
   }
-  return { href: pendingLink, method: 'replace' };
+  return { href: pendingLink, method: 'navigate' };
 }

--- a/services/session-ingest/src/dos/SessionIngestDO.test.ts
+++ b/services/session-ingest/src/dos/SessionIngestDO.test.ts
@@ -280,20 +280,15 @@ describe('SessionIngestDO session-ready push', () => {
     return {
       durableObject: new SessionIngestDO(state, env),
       sendSessionReadyNotification,
+      rows,
       settle: () => Promise.all(waitUntilPromises),
     };
   }
 
-  it('pushes once when the session record first arrives without a parent', async () => {
+  it('pushes on first claim and never again', async () => {
     const { durableObject, sendSessionReadyNotification, settle } = makeHarness();
 
-    await durableObject.ingest(
-      [{ type: 'session', data: { title: 'Hello' } }],
-      'usr_push',
-      'ses_push',
-      1,
-      1
-    );
+    durableObject.claimSessionReadyPush('usr_push', 'ses_push');
     await settle();
 
     expect(sendSessionReadyNotification).toHaveBeenCalledTimes(1);
@@ -302,79 +297,38 @@ describe('SessionIngestDO session-ready push', () => {
       cliSessionId: 'ses_push',
     });
 
-    // Later session-record updates (e.g. title change) must not re-push.
-    await durableObject.ingest(
-      [{ type: 'session', data: { title: 'Renamed' } }],
-      'usr_push',
-      'ses_push',
-      1,
-      2
-    );
+    // Re-claims (CLI reconnect, UserConnectionDO eviction) must not re-push.
+    durableObject.claimSessionReadyPush('usr_push', 'ses_push');
     await settle();
 
     expect(sendSessionReadyNotification).toHaveBeenCalledTimes(1);
   });
 
-  it('never pushes for a subagent session record', async () => {
-    const { durableObject, sendSessionReadyNotification, settle } = makeHarness();
+  it('never pushes for a deleted session', async () => {
+    const { durableObject, sendSessionReadyNotification, rows, settle } = makeHarness();
+    rows.set('deleted', { value: 'true' });
 
-    await durableObject.ingest(
-      [{ type: 'session', data: { title: 'Sub', parentID: 'ses_parent' } }],
-      'usr_push',
-      'ses_sub',
-      1,
-      1
-    );
+    durableObject.claimSessionReadyPush('usr_push', 'ses_gone');
     await settle();
 
     expect(sendSessionReadyNotification).not.toHaveBeenCalled();
   });
 
-  it('does not push for payloads without a session record, even for a subagent whose record arrives later', async () => {
+  it('does not push from ingest, even for a parentless session record', async () => {
     const { durableObject, sendSessionReadyNotification, settle } = makeHarness();
 
     await durableObject.ingest(
-      [{ type: 'message', data: { id: 'msg_1' } }],
+      [
+        { type: 'kilo_meta', data: { platform: 'cli' } },
+        { type: 'session', data: { title: 'Main' } },
+      ],
       'usr_push',
-      'ses_sub',
+      'ses_main',
       1,
       1
     );
     await settle();
+
     expect(sendSessionReadyNotification).not.toHaveBeenCalled();
-
-    await durableObject.ingest(
-      [{ type: 'session', data: { title: 'Sub', parentID: 'ses_parent' } }],
-      'usr_push',
-      'ses_sub',
-      1,
-      2
-    );
-    await settle();
-    expect(sendSessionReadyNotification).not.toHaveBeenCalled();
-  });
-
-  it('pushes when a main session record arrives after message-only payloads', async () => {
-    const { durableObject, sendSessionReadyNotification, settle } = makeHarness();
-
-    await durableObject.ingest(
-      [{ type: 'message', data: { id: 'msg_1' } }],
-      'usr_push',
-      'ses_late',
-      1,
-      1
-    );
-    await settle();
-    expect(sendSessionReadyNotification).not.toHaveBeenCalled();
-
-    await durableObject.ingest(
-      [{ type: 'session', data: { title: 'Late main' } }],
-      'usr_push',
-      'ses_late',
-      1,
-      2
-    );
-    await settle();
-    expect(sendSessionReadyNotification).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/session-ingest/src/dos/SessionIngestDO.ts
+++ b/services/session-ingest/src/dos/SessionIngestDO.ts
@@ -284,8 +284,6 @@ export class SessionIngestDO extends DurableObject<Env> {
       }
     }
 
-    this.maybeSendSessionReadyPush(payload, kiloUserId, sessionId);
-
     // Clean up orphaned R2 blobs after metadata is persisted. R2 is external I/O,
     // so awaiting it before metadata writes can let another DO request interleave
     // and then be overwritten by stale pre-await metadata from this request.
@@ -308,29 +306,20 @@ export class SessionIngestDO extends DurableObject<Env> {
   }
 
   /**
-   * Push "session ready to control from your phone" the first time this
-   * session's record arrives with no parent. The session record carries
-   * `parentID` from creation, so its first sight — not ingest timing — is what
-   * safely distinguishes a main session from a subagent; the extractor loop
-   * has already persisted any `parentID` from this payload by the time we read
-   * it. The `sessionReadyNotified` meta row flips exactly once and commits
-   * with this DO call, so a failure later in the queue message can neither
-   * re-arm nor permanently drop the push. Push failures are non-fatal: log
-   * and move on.
+   * Push "session ready to control from your phone" the first time it is
+   * claimed for this session. The caller (UserConnectionDO) invokes this when
+   * a CLI heartbeat first reports the session as remote-controllable; the
+   * `sessionReadyNotified` meta row here makes the push once-ever durable —
+   * CLI reconnects and UserConnectionDO evictions can't re-arm it. Push
+   * failures are non-fatal: log and move on.
    */
-  private maybeSendSessionReadyPush(
-    payload: IngestBatch,
-    kiloUserId: string,
-    sessionId: string
-  ): void {
-    if (!payload.some(item => item.type === 'session')) return;
-
-    const parentIdRow = this.db
+  claimSessionReadyPush(kiloUserId: string, sessionId: string): void {
+    const deletedRow = this.db
       .select({ value: ingestMeta.value })
       .from(ingestMeta)
-      .where(eq(ingestMeta.key, 'parentId'))
+      .where(eq(ingestMeta.key, 'deleted'))
       .get();
-    if ((parentIdRow?.value ?? null) !== null) return;
+    if (deletedRow?.value === 'true') return;
 
     const notified = writeIngestMetaIfChanged(this.db, {
       key: 'sessionReadyNotified',

--- a/services/session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.test.ts
@@ -77,6 +77,7 @@ function createMockCtx() {
         storage: {
           setAlarm: vi.fn(),
         },
+        waitUntil: vi.fn(),
       };
     },
   };
@@ -2144,6 +2145,100 @@ describe('UserConnectionDO', () => {
 
       // Should not throw
       sendCliResponse(doInstance, cliWs, { id: 'nonexistent', result: 'ok' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Session-ready push claim
+  // -------------------------------------------------------------------------
+
+  describe('session-ready push claim', () => {
+    function setupWithIngestDO() {
+      const mockCtx = createMockCtx();
+      const ctx = mockCtx.build();
+      const claimSessionReadyPush = vi.fn(async () => {});
+      const env = {
+        SESSION_INGEST_DO: {
+          idFromName: vi.fn((name: string) => name),
+          get: vi.fn(() => ({ claimSessionReadyPush })),
+        },
+      };
+      const doInstance = new UserConnectionDO(ctx as never, env as never);
+      return { doInstance, mockCtx, claimSessionReadyPush };
+    }
+
+    function addCliSocketForUser(
+      mockCtx: ReturnType<typeof createMockCtx>,
+      connectionId: string,
+      kiloUserId: string
+    ): MockWS {
+      const attachment = { role: 'cli' as const, connectionId, sessions: [], kiloUserId };
+      const ws = createMockWs(['cli'], attachment);
+      mockCtx.addSocket(ws);
+      return ws;
+    }
+
+    it('claims the push the first time a parentless session appears in a heartbeat', () => {
+      const { doInstance, mockCtx, claimSessionReadyPush } = setupWithIngestDO();
+      const cliWs = addCliSocketForUser(mockCtx, 'cli-1', 'usr_1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('ses_main')]);
+
+      expect(claimSessionReadyPush).toHaveBeenCalledTimes(1);
+      expect(claimSessionReadyPush).toHaveBeenCalledWith('usr_1', 'ses_main');
+
+      // Subsequent heartbeats for the same session must not re-claim.
+      sendHeartbeat(doInstance, cliWs, [makeSession('ses_main')]);
+      expect(claimSessionReadyPush).toHaveBeenCalledTimes(1);
+    });
+
+    it('never claims for subagent sessions', () => {
+      const { doInstance, mockCtx, claimSessionReadyPush } = setupWithIngestDO();
+      const cliWs = addCliSocketForUser(mockCtx, 'cli-1', 'usr_1');
+
+      sendHeartbeat(doInstance, cliWs, [
+        makeSession('ses_main'),
+        makeSession('ses_sub', 'busy', 'Sub', 'ses_main'),
+      ]);
+
+      expect(claimSessionReadyPush).toHaveBeenCalledTimes(1);
+      expect(claimSessionReadyPush).toHaveBeenCalledWith('usr_1', 'ses_main');
+    });
+
+    it('does not claim on sockets without a kiloUserId (legacy attachment)', () => {
+      const { doInstance, mockCtx, claimSessionReadyPush } = setupWithIngestDO();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('ses_main')]);
+
+      expect(claimSessionReadyPush).not.toHaveBeenCalled();
+    });
+
+    it('stores the kiloUserId from the connection URL on the attachment', () => {
+      const { doInstance } = setupWithIngestDO();
+      const client = createMockWs();
+      const server = createMockWs();
+      vi.stubGlobal(
+        'WebSocketPair',
+        class {
+          0 = client;
+          1 = server;
+        }
+      );
+      vi.stubGlobal(
+        'Response',
+        class {
+          constructor(_body?: BodyInit | null, _init?: ResponseInit) {}
+        }
+      );
+
+      doInstance.fetch(
+        new Request('http://local/cli?connectionId=cli-1&kiloUserId=usr_1', {
+          headers: { Upgrade: 'websocket' },
+        })
+      );
+
+      expect(server.deserializeAttachment()).toMatchObject({ role: 'cli', kiloUserId: 'usr_1' });
     });
   });
 });

--- a/services/session-ingest/src/dos/UserConnectionDO.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from 'cloudflare:workers';
 
 import type { Env } from '../env';
+import { getSessionIngestDO } from './SessionIngestDO';
 import {
   CLIOutboundMessageSchema,
   type CLIInboundMessage,
@@ -28,6 +29,9 @@ type WSAttachment =
       // CLI hasn't sent its first heartbeat, or it's a legacy build that
       // predates this field entirely. Both cases fall back to legacy behavior.
       protocolVersion?: string;
+      // Set from the authenticated /user/cli route; undefined on sockets
+      // accepted before this field existed. Needed for the session-ready push.
+      kiloUserId?: string;
     }
   | { role: 'web'; connectionId: string; subscribedSessions: string[]; replaced?: true };
 
@@ -164,7 +168,8 @@ export class UserConnectionDO extends DurableObject<Env> {
       // Close any stale socket from a previous connection with the same ID (CLI reconnect)
       const reconnect = this.closeStaleSocket(connectionId);
 
-      const attachment: WSAttachment = { role: 'cli', connectionId, sessions: [] };
+      const kiloUserId = url.searchParams.get('kiloUserId') ?? undefined;
+      const attachment: WSAttachment = { role: 'cli', connectionId, sessions: [], kiloUserId };
       this.ctx.acceptWebSocket(server, ['cli']);
       server.serializeAttachment(attachment);
       const now = Date.now();
@@ -356,6 +361,12 @@ export class UserConnectionDO extends DurableObject<Env> {
       if (previousOwner && previousOwner !== connectionId) {
         this.failPendingCommandsForOwnerChange(session.id, connectionId);
       }
+      // First sight of a main session on this DO means it just became
+      // remote-controllable — the only moment the session-ready push fires.
+      // The durable claim in SessionIngestDO makes reconnect re-sights no-ops.
+      if (!previousOwner && !session.parentSessionId && attachment.kiloUserId) {
+        this.claimSessionReadyPush(attachment.kiloUserId, session.id);
+      }
       this.sessionOwners.set(session.id, connectionId);
     }
 
@@ -373,6 +384,7 @@ export class UserConnectionDO extends DurableObject<Env> {
       connectionId,
       sessions,
       protocolVersion,
+      kiloUserId: attachment.kiloUserId,
     };
     ws.serializeAttachment(updatedAttachment);
 
@@ -401,6 +413,22 @@ export class UserConnectionDO extends DurableObject<Env> {
     }
 
     this.sendToCli(ws, { type: 'heartbeat_ack' });
+  }
+
+  /**
+   * Fire-and-forget "session ready to control from your phone" push via the
+   * session's SessionIngestDO, which holds the durable once-ever claim.
+   */
+  private claimSessionReadyPush(kiloUserId: string, sessionId: string): void {
+    const stub = getSessionIngestDO(this.env, { kiloUserId, sessionId });
+    this.ctx.waitUntil(
+      stub.claimSessionReadyPush(kiloUserId, sessionId).catch((error: unknown) => {
+        console.error('Failed to claim session-ready push (non-fatal)', {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      })
+    );
   }
 
   private handleCliEvent(

--- a/services/session-ingest/src/routes/api.ts
+++ b/services/session-ingest/src/routes/api.ts
@@ -84,8 +84,8 @@ api.post('/session', zodJsonValidator(createSessionSchema), async c => {
       type: 'session.created',
       data: { source: 'v2', session, changedAt: session.updatedAt },
     });
-    // The session-ready push fires from the queue consumer on first ingest,
-    // not here — a subagent's parentID isn't known at creation time.
+    // The session-ready push fires from UserConnectionDO when a CLI heartbeat
+    // first reports the session as remote-controllable — not here.
   }
 
   // Warm the session cache so the first ingest can skip Postgres.
@@ -408,6 +408,9 @@ api.get('/user/cli', async c => {
   const stub = getUserConnectionDO(c.env, { kiloUserId });
   const wsUrl = new URL(c.req.url);
   wsUrl.pathname = '/cli';
+  // The DO can't recover the user from its idFromName-derived id; it needs the
+  // authenticated user for the session-ready push.
+  wsUrl.searchParams.set('kiloUserId', kiloUserId);
 
   return stub.fetch(new Request(wsUrl.toString(), c.req.raw));
 });


### PR DESCRIPTION
## What

Follow-up to #4451, fixing two reports (plus one UI nit):

1. Push notifications fired for non-remote sessions — every synced CLI session (local terminal, vscode) triggered "Kilo session ready".
2. On iOS, opening a session from the push showed no back button, stranding the user on the session screen.
3. Manual review form: the model select was way too wide.

## How

**Push trigger moved from ingest to remote-control registration.** The only sessions worth a "ready to control from your phone" push are the ones that can actually be remote-controlled — and the precise signal for that is the CLI's user-connection WebSocket, which it only opens with remote control enabled (`/remote`, `KILO_REMOTE=1`, or `remote_control` config; the kiloclaw wrapper doesn't enable it). `UserConnectionDO` now claims the push when a CLI heartbeat first reports a parentless session; subagent entries (`parentSessionId`) never claim. `SessionIngestDO.ingest` no longer pushes at all.

The durable once-ever claim stays in `SessionIngestDO` meta (`sessionReadyNotified`, deleted-session guarded), so CLI reconnects, heartbeat churn, and `UserConnectionDO` evictions can't re-push — the notifications idempotency record alone wouldn't be enough (1h TTL). The authenticated user id rides along on the `/user/cli` WS URL since the DO can't recover it from its `idFromName`-derived id; legacy sockets without it simply never claim.

**Back button.** Notification-tap navigation (`setupNotificationResponseHandler` + the cold-start pending path) used `router.replace`, which on a stack root leaves `canGoBack()` false — `ScreenHeader` then hides the back button. Both paths now use `router.navigate`, which pushes a history entry (back works) while still deduplicating if the route is already current (the reason replace was chosen in 824f41b4d).

**Model select.** The `ModelSelector` pill stretched to the column width in the manual review form (default cross-axis stretch); wrapped in a `flex-row` so it hugs content, matching the chat toolbar.

## Verification

- Unit: `UserConnectionDO` claims once on first heartbeat sight, never for subagents, never without a kiloUserId; `SessionIngestDO.claimSessionReadyPush` pushes once-ever, never for deleted sessions, and ingest no longer pushes. 310 session-ingest + 408 mobile tests green.
- E2E locally (full tmux stack, real kilo CLI 7.4.1 against local session-ingest):
  - CLI session **without** remote → session created + ingested, no push claim.
  - Toggling remote on mid-session → WS connect → first heartbeat → exactly one claim + dispatch `{ dispatched: true }`.
  - Toggling remote off/on (reconnect) → re-claim is a no-op (`changed: false`), no second push.
- E2E on iOS simulator (Kilo QA, dev build): delivered the session-ready push via `simctl push`, tapped it → session screen opens **with back button**, and back returns to the previous screen. Manual review model select verified visually via Maestro (before: full-width pill; after: hugs content).
- `format` / `typecheck` / `lint` / `check:unused` green in both packages.