### PR TITLE
CloudAgentNext - disable multipart upload for workspace backups

### DIFF
--- a/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.test.ts
@@ -867,6 +867,7 @@ describe('CloudflareAgentSandbox', () => {
     expect(sandboxApi.createBackup).toHaveBeenCalledWith({
       dir: '/workspace/cloudflare',
       ttl: 86_400,
+      multipart: false,
       localBucket: true,
     });
     expect(bucket.put).toHaveBeenCalledOnce();
@@ -1012,6 +1013,7 @@ describe('CloudflareAgentSandbox', () => {
     expect(sandboxApi.createBackup).toHaveBeenCalledWith({
       dir: '/workspace/cloudflare',
       ttl: 86_400,
+      multipart: false,
       localBucket: true,
     });
     expect(bucket.put).toHaveBeenCalledOnce();

--- a/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.ts
@@ -471,6 +471,7 @@ export class CloudflareAgentSandbox implements AgentSandbox {
         backup = await sandbox.createBackup({
           dir: workspacePath,
           ttl: WORKSPACE_BACKUP_TTL_MS / 1000,
+          multipart: false,
           ...(localBucket ? { localBucket: true } : {}),
         });
       } catch (error) {


### PR DESCRIPTION
Disables parallel multipart upload for workspace backups in the Cloudflare agent sandbox.

The `@cloudflare/sandbox` `createBackup` API defaults `multipart` to `true`, which uses parallel multipart upload to R2 for archives over 10 MiB. This change passes `multipart: false` when creating workspace backups, forcing single-part upload instead.

Updates the two affected `createBackup` test assertions to expect `multipart: false`.