### PR TITLE
feat(web): show model-specific data policies

### DIFF
--- a/apps/web/src/components/organizations/providers-and-models/OrganizationProvidersAndModelsPage.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/OrganizationProvidersAndModelsPage.tsx
@@ -31,7 +31,10 @@ import {
 } from '@/components/organizations/providers-and-models/useProvidersAndModelsAllowListsState';
 import { preferredModels } from '@/lib/ai-gateway/models';
 import { AutoRoutingModeCard } from '@/components/auto-routing/AutoRoutingModeCard';
-import { modelRetainsPrompts } from '@/lib/ai-gateway/providers/openrouter/model-data-policy';
+import {
+  modelRetainsPrompts,
+  modelTrains,
+} from '@/lib/ai-gateway/providers/openrouter/model-data-policy';
 
 type Props = {
   organizationId: string;
@@ -270,7 +273,7 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
         providerSlug: provider.slug,
         providerDisplayName: provider.displayName,
         providerIconUrl: provider.icon?.url ? normalizeProviderIconUrl(provider.icon.url) : null,
-        trains: provider.dataPolicy.training,
+        trains: modelTrains(model, provider.dataPolicy.training),
         retainsPrompts: modelRetainsPrompts(model, provider.dataPolicy.retainsPrompts),
         promptPrice: model.endpoint.pricing.prompt,
         completionPrice: model.endpoint.pricing.completion,
@@ -312,6 +315,7 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
         providerIconUrl: provider.icon?.url ? normalizeProviderIconUrl(provider.icon.url) : null,
         modelCount: providerModels.length,
         trains: provider.dataPolicy.training,
+        retainsPrompts: provider.dataPolicy.retainsPrompts,
         headquarters: provider.headquarters,
         datacenters: provider.datacenters,
       });
@@ -349,6 +353,13 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
         }
       }
 
+      if (state.providerRetainsPromptsFilter !== 'all') {
+        const wantsRetainsPrompts = state.providerRetainsPromptsFilter === 'yes';
+        if (row.retainsPrompts !== wantsRetainsPrompts) {
+          return false;
+        }
+      }
+
       if (state.providerLocationsFilter.length > 0) {
         const matchesLocation =
           (row.headquarters &&
@@ -379,6 +390,7 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
     enabledProviderSlugs,
     state.enabledProvidersOnly,
     state.providerLocationsFilter,
+    state.providerRetainsPromptsFilter,
     providerRows,
     state.providerSearch,
     state.providerTrainsFilter,
@@ -407,6 +419,7 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
         sourceIndex,
         promptPrice: model.endpoint.pricing.prompt,
         completionPrice: model.endpoint.pricing.completion,
+        trains: modelTrains(model, provider.dataPolicy.training),
         retainsPrompts: modelRetainsPrompts(model, provider.dataPolicy.retainsPrompts),
       });
     }
@@ -438,6 +451,7 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
   }
 
   const providerTrainsFilter: ProviderPolicyFilter = state.providerTrainsFilter;
+  const providerRetainsPromptsFilter: ProviderPolicyFilter = state.providerRetainsPromptsFilter;
 
   return (
     <OrganizationContextProvider value={{ userRole: currentRole, isKiloAdmin }}>
@@ -479,6 +493,7 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
               search={state.providerSearch}
               enabledOnly={state.enabledProvidersOnly}
               providerTrainsFilter={providerTrainsFilter}
+              providerRetainsPromptsFilter={providerRetainsPromptsFilter}
               providerLocationsFilter={state.providerLocationsFilter}
               providerLocationOptions={providerLocationOptions}
               filteredProviderRows={filteredProviderRows}
@@ -487,6 +502,7 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
               onSearchChange={actions.setProviderSearch}
               onEnabledOnlyChange={actions.setEnabledProvidersOnly}
               onProviderTrainsFilterChange={actions.setProviderTrainsFilter}
+              onProviderRetainsPromptsFilterChange={actions.setProviderRetainsPromptsFilter}
               onProviderLocationsFilterChange={actions.setProviderLocationsFilter}
               onToggleProviderEnabled={handleToggleProviderEnabled}
               onOpenProviderDetails={actions.setInfoProviderSlug}

--- a/apps/web/src/components/organizations/providers-and-models/OrganizationProvidersAndModelsPage.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/OrganizationProvidersAndModelsPage.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/components/organizations/providers-and-models/useProvidersAndModelsAllowListsState';
 import { preferredModels } from '@/lib/ai-gateway/models';
 import { AutoRoutingModeCard } from '@/components/auto-routing/AutoRoutingModeCard';
+import { modelRetainsPrompts } from '@/lib/ai-gateway/providers/openrouter/model-data-policy';
 
 type Props = {
   organizationId: string;
@@ -270,7 +271,7 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
         providerDisplayName: provider.displayName,
         providerIconUrl: provider.icon?.url ? normalizeProviderIconUrl(provider.icon.url) : null,
         trains: provider.dataPolicy.training,
-        retainsPrompts: provider.dataPolicy.retainsPrompts,
+        retainsPrompts: modelRetainsPrompts(model, provider.dataPolicy.retainsPrompts),
         promptPrice: model.endpoint.pricing.prompt,
         completionPrice: model.endpoint.pricing.completion,
       });
@@ -311,7 +312,6 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
         providerIconUrl: provider.icon?.url ? normalizeProviderIconUrl(provider.icon.url) : null,
         modelCount: providerModels.length,
         trains: provider.dataPolicy.training,
-        retainsPrompts: provider.dataPolicy.retainsPrompts,
         headquarters: provider.headquarters,
         datacenters: provider.datacenters,
       });
@@ -349,13 +349,6 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
         }
       }
 
-      if (state.providerRetainsPromptsFilter !== 'all') {
-        const wantsRetainsPrompts = state.providerRetainsPromptsFilter === 'yes';
-        if (row.retainsPrompts !== wantsRetainsPrompts) {
-          return false;
-        }
-      }
-
       if (state.providerLocationsFilter.length > 0) {
         const matchesLocation =
           (row.headquarters &&
@@ -386,7 +379,6 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
     enabledProviderSlugs,
     state.enabledProvidersOnly,
     state.providerLocationsFilter,
-    state.providerRetainsPromptsFilter,
     providerRows,
     state.providerSearch,
     state.providerTrainsFilter,
@@ -415,6 +407,7 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
         sourceIndex,
         promptPrice: model.endpoint.pricing.prompt,
         completionPrice: model.endpoint.pricing.completion,
+        retainsPrompts: modelRetainsPrompts(model, provider.dataPolicy.retainsPrompts),
       });
     }
 
@@ -445,7 +438,6 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
   }
 
   const providerTrainsFilter: ProviderPolicyFilter = state.providerTrainsFilter;
-  const providerRetainsPromptsFilter: ProviderPolicyFilter = state.providerRetainsPromptsFilter;
 
   return (
     <OrganizationContextProvider value={{ userRole: currentRole, isKiloAdmin }}>
@@ -487,7 +479,6 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
               search={state.providerSearch}
               enabledOnly={state.enabledProvidersOnly}
               providerTrainsFilter={providerTrainsFilter}
-              providerRetainsPromptsFilter={providerRetainsPromptsFilter}
               providerLocationsFilter={state.providerLocationsFilter}
               providerLocationOptions={providerLocationOptions}
               filteredProviderRows={filteredProviderRows}
@@ -496,7 +487,6 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
               onSearchChange={actions.setProviderSearch}
               onEnabledOnlyChange={actions.setEnabledProvidersOnly}
               onProviderTrainsFilterChange={actions.setProviderTrainsFilter}
-              onProviderRetainsPromptsFilterChange={actions.setProviderRetainsPromptsFilter}
               onProviderLocationsFilterChange={actions.setProviderLocationsFilter}
               onToggleProviderEnabled={handleToggleProviderEnabled}
               onOpenProviderDetails={actions.setInfoProviderSlug}

--- a/apps/web/src/components/organizations/providers-and-models/ProviderDetailsDialog.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/ProviderDetailsDialog.tsx
@@ -90,6 +90,7 @@ export function ProviderDetailsDialog({
             <div className="space-y-3">
               <div className="flex flex-wrap items-center gap-2">
                 <ProviderPolicyTag value={infoProvider.trains} variant="trains" />
+                <ProviderPolicyTag value={infoProvider.retainsPrompts} variant="retainsPrompts" />
               </div>
 
               {infoProvider.headquarters ? (
@@ -119,6 +120,7 @@ export function ProviderDetailsDialog({
                 <TableHead>Model</TableHead>
                 <TableHead>In</TableHead>
                 <TableHead>Out</TableHead>
+                <TableHead>Trains</TableHead>
                 <TableHead>Retains prompts</TableHead>
               </TableRow>
             </TableHeader>
@@ -142,6 +144,9 @@ export function ProviderDetailsDialog({
                     </TableCell>
                     <TableCell>{formatPriceCompact(model.promptPrice)}</TableCell>
                     <TableCell>{formatPriceCompact(model.completionPrice)}</TableCell>
+                    <TableCell>
+                      <PolicyPill value={model.trains} variant="trains" />
+                    </TableCell>
                     <TableCell>
                       <PolicyPill value={model.retainsPrompts} variant="retainsPrompts" />
                     </TableCell>

--- a/apps/web/src/components/organizations/providers-and-models/ProviderDetailsDialog.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/ProviderDetailsDialog.tsx
@@ -14,7 +14,10 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { ProviderPolicyTag } from '@/components/organizations/providers-and-models/PolicyPills';
+import {
+  PolicyPill,
+  ProviderPolicyTag,
+} from '@/components/organizations/providers-and-models/PolicyPills';
 import type {
   ProviderModelRow,
   ProviderRow,
@@ -87,7 +90,6 @@ export function ProviderDetailsDialog({
             <div className="space-y-3">
               <div className="flex flex-wrap items-center gap-2">
                 <ProviderPolicyTag value={infoProvider.trains} variant="trains" />
-                <ProviderPolicyTag value={infoProvider.retainsPrompts} variant="retainsPrompts" />
               </div>
 
               {infoProvider.headquarters ? (
@@ -117,6 +119,7 @@ export function ProviderDetailsDialog({
                 <TableHead>Model</TableHead>
                 <TableHead>In</TableHead>
                 <TableHead>Out</TableHead>
+                <TableHead>Retains prompts</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -139,6 +142,9 @@ export function ProviderDetailsDialog({
                     </TableCell>
                     <TableCell>{formatPriceCompact(model.promptPrice)}</TableCell>
                     <TableCell>{formatPriceCompact(model.completionPrice)}</TableCell>
+                    <TableCell>
+                      <PolicyPill value={model.retainsPrompts} variant="retainsPrompts" />
+                    </TableCell>
                   </TableRow>
                 );
               })}

--- a/apps/web/src/components/organizations/providers-and-models/ProvidersTab.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/ProvidersTab.tsx
@@ -28,7 +28,6 @@ export function ProvidersTab({
   search,
   enabledOnly,
   providerTrainsFilter,
-  providerRetainsPromptsFilter,
   providerLocationsFilter,
   providerLocationOptions,
   filteredProviderRows,
@@ -37,7 +36,6 @@ export function ProvidersTab({
   onSearchChange,
   onEnabledOnlyChange,
   onProviderTrainsFilterChange,
-  onProviderRetainsPromptsFilterChange,
   onProviderLocationsFilterChange,
   onToggleProviderEnabled,
   onOpenProviderDetails,
@@ -47,7 +45,6 @@ export function ProvidersTab({
   search: string;
   enabledOnly: boolean;
   providerTrainsFilter: ProviderPolicyFilter;
-  providerRetainsPromptsFilter: ProviderPolicyFilter;
   providerLocationsFilter: string[];
   providerLocationOptions: string[];
   filteredProviderRows: ReadonlyArray<ProviderRow>;
@@ -56,7 +53,6 @@ export function ProvidersTab({
   onSearchChange: (value: string) => void;
   onEnabledOnlyChange: (value: boolean) => void;
   onProviderTrainsFilterChange: (value: ProviderPolicyFilter) => void;
-  onProviderRetainsPromptsFilterChange: (value: ProviderPolicyFilter) => void;
   onProviderLocationsFilterChange: (value: string[]) => void;
   onToggleProviderEnabled: (providerSlug: string, nextEnabled: boolean) => void;
   onOpenProviderDetails: (providerSlug: string) => void;
@@ -91,7 +87,7 @@ export function ProvidersTab({
             <div className="shrink-0 lg:w-80">
               <div className="rounded-lg border p-4">
                 <div className="text-sm font-medium">Filters</div>
-                <div className="mt-3 grid gap-4 sm:grid-cols-2 lg:grid-cols-1">
+                <div className="mt-3 grid gap-4">
                   <div className="space-y-2">
                     <div className="text-muted-foreground text-xs">Trains</div>
                     <RadioButtonGroup
@@ -101,20 +97,6 @@ export function ProvidersTab({
                         const next = parseProviderPolicyFilter(value);
                         if (next) {
                           onProviderTrainsFilterChange(next);
-                        }
-                      }}
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <div className="text-muted-foreground text-xs">Retains prompts</div>
-                    <RadioButtonGroup
-                      options={providerPolicyFilterOptions}
-                      value={providerRetainsPromptsFilter}
-                      onChange={value => {
-                        const next = parseProviderPolicyFilter(value);
-                        if (next) {
-                          onProviderRetainsPromptsFilterChange(next);
                         }
                       }}
                     />
@@ -181,10 +163,6 @@ export function ProvidersTab({
                                   {row.providerDisplayName}
                                 </div>
                                 <ProviderPolicyTag value={row.trains} variant="trains" />
-                                <ProviderPolicyTag
-                                  value={row.retainsPrompts}
-                                  variant="retainsPrompts"
-                                />
                               </div>
                               <div className="text-muted-foreground mt-0.5 truncate text-xs">
                                 {row.providerSlug}

--- a/apps/web/src/components/organizations/providers-and-models/ProvidersTab.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/ProvidersTab.tsx
@@ -28,6 +28,7 @@ export function ProvidersTab({
   search,
   enabledOnly,
   providerTrainsFilter,
+  providerRetainsPromptsFilter,
   providerLocationsFilter,
   providerLocationOptions,
   filteredProviderRows,
@@ -36,6 +37,7 @@ export function ProvidersTab({
   onSearchChange,
   onEnabledOnlyChange,
   onProviderTrainsFilterChange,
+  onProviderRetainsPromptsFilterChange,
   onProviderLocationsFilterChange,
   onToggleProviderEnabled,
   onOpenProviderDetails,
@@ -45,6 +47,7 @@ export function ProvidersTab({
   search: string;
   enabledOnly: boolean;
   providerTrainsFilter: ProviderPolicyFilter;
+  providerRetainsPromptsFilter: ProviderPolicyFilter;
   providerLocationsFilter: string[];
   providerLocationOptions: string[];
   filteredProviderRows: ReadonlyArray<ProviderRow>;
@@ -53,15 +56,20 @@ export function ProvidersTab({
   onSearchChange: (value: string) => void;
   onEnabledOnlyChange: (value: boolean) => void;
   onProviderTrainsFilterChange: (value: ProviderPolicyFilter) => void;
+  onProviderRetainsPromptsFilterChange: (value: ProviderPolicyFilter) => void;
   onProviderLocationsFilterChange: (value: string[]) => void;
   onToggleProviderEnabled: (providerSlug: string, nextEnabled: boolean) => void;
   onOpenProviderDetails: (providerSlug: string) => void;
 }) {
   return (
     <div className="flex flex-col gap-y-4">
-      <p className="text-muted-foreground text-sm">
-        Enable which providers organization members can use.
-      </p>
+      <div className="text-muted-foreground space-y-1 text-sm">
+        <p>Enable which providers organization members can use.</p>
+        <p>
+          Provider policy badges and filters reflect provider defaults. Training and prompt
+          retention policies can differ for individual models.
+        </p>
+      </div>
 
       {isLoading ? (
         <div className="text-muted-foreground flex h-40 items-center justify-center text-sm">
@@ -87,7 +95,7 @@ export function ProvidersTab({
             <div className="shrink-0 lg:w-80">
               <div className="rounded-lg border p-4">
                 <div className="text-sm font-medium">Filters</div>
-                <div className="mt-3 grid gap-4">
+                <div className="mt-3 grid gap-4 sm:grid-cols-2 lg:grid-cols-1">
                   <div className="space-y-2">
                     <div className="text-muted-foreground text-xs">Trains</div>
                     <RadioButtonGroup
@@ -97,6 +105,19 @@ export function ProvidersTab({
                         const next = parseProviderPolicyFilter(value);
                         if (next) {
                           onProviderTrainsFilterChange(next);
+                        }
+                      }}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <div className="text-muted-foreground text-xs">Retains prompts</div>
+                    <RadioButtonGroup
+                      options={providerPolicyFilterOptions}
+                      value={providerRetainsPromptsFilter}
+                      onChange={value => {
+                        const next = parseProviderPolicyFilter(value);
+                        if (next) {
+                          onProviderRetainsPromptsFilterChange(next);
                         }
                       }}
                     />
@@ -163,6 +184,10 @@ export function ProvidersTab({
                                   {row.providerDisplayName}
                                 </div>
                                 <ProviderPolicyTag value={row.trains} variant="trains" />
+                                <ProviderPolicyTag
+                                  value={row.retainsPrompts}
+                                  variant="retainsPrompts"
+                                />
                               </div>
                               <div className="text-muted-foreground mt-0.5 truncate text-xs">
                                 {row.providerSlug}

--- a/apps/web/src/components/organizations/providers-and-models/providersAndModels.types.ts
+++ b/apps/web/src/components/organizations/providers-and-models/providersAndModels.types.ts
@@ -14,7 +14,6 @@ export type ProviderRow = {
   providerIconUrl: string | null;
   modelCount: number;
   trains: boolean;
-  retainsPrompts: boolean;
   headquarters?: string;
   datacenters?: string[];
 };
@@ -36,4 +35,5 @@ export type ProviderModelRow = {
   sourceIndex: number;
   promptPrice: string;
   completionPrice: string;
+  retainsPrompts: boolean;
 };

--- a/apps/web/src/components/organizations/providers-and-models/providersAndModels.types.ts
+++ b/apps/web/src/components/organizations/providers-and-models/providersAndModels.types.ts
@@ -14,6 +14,7 @@ export type ProviderRow = {
   providerIconUrl: string | null;
   modelCount: number;
   trains: boolean;
+  retainsPrompts: boolean;
   headquarters?: string;
   datacenters?: string[];
 };
@@ -35,5 +36,6 @@ export type ProviderModelRow = {
   sourceIndex: number;
   promptPrice: string;
   completionPrice: string;
+  trains: boolean;
   retainsPrompts: boolean;
 };

--- a/apps/web/src/components/organizations/providers-and-models/useProvidersAndModelsAllowListsState.ts
+++ b/apps/web/src/components/organizations/providers-and-models/useProvidersAndModelsAllowListsState.ts
@@ -28,6 +28,7 @@ export type ProvidersAndModelsAllowListsReadyState = {
   providerSearch: string;
   enabledProvidersOnly: boolean;
   providerTrainsFilter: ProviderPolicyFilter;
+  providerRetainsPromptsFilter: ProviderPolicyFilter;
   providerLocationsFilter: string[];
   infoProviderSlug: string | null;
 };
@@ -41,6 +42,7 @@ export type ProvidersAndModelsAllowListsState =
       providerSearch: string;
       enabledProvidersOnly: boolean;
       providerTrainsFilter: ProviderPolicyFilter;
+      providerRetainsPromptsFilter: ProviderPolicyFilter;
       providerLocationsFilter: string[];
       infoProviderSlug: string | null;
     }
@@ -93,6 +95,10 @@ export type ProvidersAndModelsAllowListsAction =
       value: ProviderPolicyFilter;
     }
   | {
+      type: 'SET_PROVIDER_RETAINS_PROMPTS_FILTER';
+      value: ProviderPolicyFilter;
+    }
+  | {
       type: 'SET_PROVIDER_LOCATIONS_FILTER';
       value: string[];
     }
@@ -110,6 +116,7 @@ export function createProvidersAndModelsAllowListsInitialState(): ProvidersAndMo
     providerSearch: '',
     enabledProvidersOnly: false,
     providerTrainsFilter: 'all',
+    providerRetainsPromptsFilter: 'all',
     providerLocationsFilter: [],
     infoProviderSlug: null,
   };
@@ -135,6 +142,7 @@ export function providersAndModelsAllowListsReducer(
         providerSearch: state.providerSearch,
         enabledProvidersOnly: state.enabledProvidersOnly,
         providerTrainsFilter: state.providerTrainsFilter,
+        providerRetainsPromptsFilter: state.providerRetainsPromptsFilter,
         providerLocationsFilter: state.providerLocationsFilter,
         infoProviderSlug: state.infoProviderSlug,
       };
@@ -196,6 +204,8 @@ export function providersAndModelsAllowListsReducer(
       return { ...state, enabledProvidersOnly: action.value };
     case 'SET_PROVIDER_TRAINS_FILTER':
       return { ...state, providerTrainsFilter: action.value };
+    case 'SET_PROVIDER_RETAINS_PROMPTS_FILTER':
+      return { ...state, providerRetainsPromptsFilter: action.value };
     case 'SET_PROVIDER_LOCATIONS_FILTER':
       return { ...state, providerLocationsFilter: action.value };
     case 'SET_INFO_PROVIDER_SLUG':
@@ -234,6 +244,7 @@ export function useProvidersAndModelsAllowListsState(params: {
     setProviderSearch: (value: string) => void;
     setEnabledProvidersOnly: (value: boolean) => void;
     setProviderTrainsFilter: (value: ProviderPolicyFilter) => void;
+    setProviderRetainsPromptsFilter: (value: ProviderPolicyFilter) => void;
     setProviderLocationsFilter: (value: string[]) => void;
     setInfoProviderSlug: (value: string | null) => void;
   };
@@ -350,6 +361,8 @@ export function useProvidersAndModelsAllowListsState(params: {
         dispatch({ type: 'SET_ENABLED_PROVIDERS_ONLY', value }),
       setProviderTrainsFilter: (value: ProviderPolicyFilter) =>
         dispatch({ type: 'SET_PROVIDER_TRAINS_FILTER', value }),
+      setProviderRetainsPromptsFilter: (value: ProviderPolicyFilter) =>
+        dispatch({ type: 'SET_PROVIDER_RETAINS_PROMPTS_FILTER', value }),
       setProviderLocationsFilter: (value: string[]) =>
         dispatch({ type: 'SET_PROVIDER_LOCATIONS_FILTER', value }),
       setInfoProviderSlug: (value: string | null) =>

--- a/apps/web/src/components/organizations/providers-and-models/useProvidersAndModelsAllowListsState.ts
+++ b/apps/web/src/components/organizations/providers-and-models/useProvidersAndModelsAllowListsState.ts
@@ -28,7 +28,6 @@ export type ProvidersAndModelsAllowListsReadyState = {
   providerSearch: string;
   enabledProvidersOnly: boolean;
   providerTrainsFilter: ProviderPolicyFilter;
-  providerRetainsPromptsFilter: ProviderPolicyFilter;
   providerLocationsFilter: string[];
   infoProviderSlug: string | null;
 };
@@ -42,7 +41,6 @@ export type ProvidersAndModelsAllowListsState =
       providerSearch: string;
       enabledProvidersOnly: boolean;
       providerTrainsFilter: ProviderPolicyFilter;
-      providerRetainsPromptsFilter: ProviderPolicyFilter;
       providerLocationsFilter: string[];
       infoProviderSlug: string | null;
     }
@@ -95,10 +93,6 @@ export type ProvidersAndModelsAllowListsAction =
       value: ProviderPolicyFilter;
     }
   | {
-      type: 'SET_PROVIDER_RETAINS_PROMPTS_FILTER';
-      value: ProviderPolicyFilter;
-    }
-  | {
       type: 'SET_PROVIDER_LOCATIONS_FILTER';
       value: string[];
     }
@@ -116,7 +110,6 @@ export function createProvidersAndModelsAllowListsInitialState(): ProvidersAndMo
     providerSearch: '',
     enabledProvidersOnly: false,
     providerTrainsFilter: 'all',
-    providerRetainsPromptsFilter: 'all',
     providerLocationsFilter: [],
     infoProviderSlug: null,
   };
@@ -142,7 +135,6 @@ export function providersAndModelsAllowListsReducer(
         providerSearch: state.providerSearch,
         enabledProvidersOnly: state.enabledProvidersOnly,
         providerTrainsFilter: state.providerTrainsFilter,
-        providerRetainsPromptsFilter: state.providerRetainsPromptsFilter,
         providerLocationsFilter: state.providerLocationsFilter,
         infoProviderSlug: state.infoProviderSlug,
       };
@@ -204,8 +196,6 @@ export function providersAndModelsAllowListsReducer(
       return { ...state, enabledProvidersOnly: action.value };
     case 'SET_PROVIDER_TRAINS_FILTER':
       return { ...state, providerTrainsFilter: action.value };
-    case 'SET_PROVIDER_RETAINS_PROMPTS_FILTER':
-      return { ...state, providerRetainsPromptsFilter: action.value };
     case 'SET_PROVIDER_LOCATIONS_FILTER':
       return { ...state, providerLocationsFilter: action.value };
     case 'SET_INFO_PROVIDER_SLUG':
@@ -244,7 +234,6 @@ export function useProvidersAndModelsAllowListsState(params: {
     setProviderSearch: (value: string) => void;
     setEnabledProvidersOnly: (value: boolean) => void;
     setProviderTrainsFilter: (value: ProviderPolicyFilter) => void;
-    setProviderRetainsPromptsFilter: (value: ProviderPolicyFilter) => void;
     setProviderLocationsFilter: (value: string[]) => void;
     setInfoProviderSlug: (value: string | null) => void;
   };
@@ -361,8 +350,6 @@ export function useProvidersAndModelsAllowListsState(params: {
         dispatch({ type: 'SET_ENABLED_PROVIDERS_ONLY', value }),
       setProviderTrainsFilter: (value: ProviderPolicyFilter) =>
         dispatch({ type: 'SET_PROVIDER_TRAINS_FILTER', value }),
-      setProviderRetainsPromptsFilter: (value: ProviderPolicyFilter) =>
-        dispatch({ type: 'SET_PROVIDER_RETAINS_PROMPTS_FILTER', value }),
       setProviderLocationsFilter: (value: string[]) =>
         dispatch({ type: 'SET_PROVIDER_LOCATIONS_FILTER', value }),
       setInfoProviderSlug: (value: string | null) =>

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from '@jest/globals';
+import { modelRetainsPrompts } from '@/lib/ai-gateway/providers/openrouter/model-data-policy';
+import { OpenRouterSearchResponse } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+
+const baseModel = {
+  slug: 'anthropic/claude-fable-5',
+  name: 'Claude Fable 5',
+  author: 'anthropic',
+  description: '',
+  context_length: 200_000,
+  input_modalities: ['text'],
+  output_modalities: ['text'],
+  group: 'Claude Fable',
+  updated_at: '2026-06-09T00:00:00Z',
+};
+
+describe('modelRetainsPrompts', () => {
+  test('preserves and uses a model endpoint retention override', () => {
+    const response = OpenRouterSearchResponse.parse({
+      data: {
+        models: [
+          {
+            ...baseModel,
+            endpoint: {
+              provider_display_name: 'Amazon Bedrock (BYOK Only)',
+              is_free: false,
+              pricing: { prompt: '0.000005', completion: '0.000025' },
+              data_policy: {
+                training: false,
+                retainsPrompts: true,
+                retentionDays: 30,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const model = response.data.models[0];
+    expect(model?.endpoint?.data_policy).toEqual({ retainsPrompts: true });
+    expect(model && modelRetainsPrompts(model, false)).toBe(true);
+  });
+
+  test('falls back to the provider policy for snapshots without endpoint policy', () => {
+    const response = OpenRouterSearchResponse.parse({
+      data: {
+        models: [
+          {
+            ...baseModel,
+            endpoint: {
+              provider_display_name: 'Amazon Bedrock',
+              is_free: false,
+              pricing: { prompt: '0.000005', completion: '0.000025' },
+            },
+          },
+        ],
+      },
+    });
+
+    const model = response.data.models[0];
+    expect(model && modelRetainsPrompts(model, true)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from '@jest/globals';
-import { modelRetainsPrompts } from '@/lib/ai-gateway/providers/openrouter/model-data-policy';
+import {
+  modelRetainsPrompts,
+  modelTrains,
+} from '@/lib/ai-gateway/providers/openrouter/model-data-policy';
 import { OpenRouterSearchResponse } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
 
 const baseModel = {
@@ -14,8 +17,8 @@ const baseModel = {
   updated_at: '2026-06-09T00:00:00Z',
 };
 
-describe('modelRetainsPrompts', () => {
-  test('preserves and uses a model endpoint retention override', () => {
+describe('model data policy', () => {
+  test('preserves and uses model endpoint policy overrides', () => {
     const response = OpenRouterSearchResponse.parse({
       data: {
         models: [
@@ -37,7 +40,8 @@ describe('modelRetainsPrompts', () => {
     });
 
     const model = response.data.models[0];
-    expect(model?.endpoint?.data_policy).toEqual({ retainsPrompts: true });
+    expect(model?.endpoint?.data_policy).toEqual({ training: false, retainsPrompts: true });
+    expect(model && modelTrains(model, true)).toBe(false);
     expect(model && modelRetainsPrompts(model, false)).toBe(true);
   });
 
@@ -58,6 +62,7 @@ describe('modelRetainsPrompts', () => {
     });
 
     const model = response.data.models[0];
+    expect(model && modelTrains(model, true)).toBe(true);
     expect(model && modelRetainsPrompts(model, true)).toBe(true);
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.ts
@@ -1,5 +1,9 @@
 import type { OpenRouterModel } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
 
+export function modelTrains(model: OpenRouterModel, providerTrains: boolean): boolean {
+  return model.endpoint?.data_policy?.training ?? providerTrains;
+}
+
 export function modelRetainsPrompts(
   model: OpenRouterModel,
   providerRetainsPrompts: boolean

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.ts
@@ -1,0 +1,8 @@
+import type { OpenRouterModel } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+
+export function modelRetainsPrompts(
+  model: OpenRouterModel,
+  providerRetainsPrompts: boolean
+): boolean {
+  return model.endpoint?.data_policy?.retainsPrompts ?? providerRetainsPrompts;
+}

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1419,6 +1419,11 @@ export const OpenRouterEndpoint = z.object({
   provider_display_name: z.string(),
   is_free: z.boolean(),
   pricing: OpenRouterPricing,
+  data_policy: z
+    .object({
+      retainsPrompts: z.boolean().optional(),
+    })
+    .nullish(),
 });
 
 export type OpenRouterModel = z.infer<typeof OpenRouterModel>;

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1421,6 +1421,7 @@ export const OpenRouterEndpoint = z.object({
   pricing: OpenRouterPricing,
   data_policy: z
     .object({
+      training: z.boolean().optional(),
       retainsPrompts: z.boolean().optional(),
     })
     .nullish(),


### PR DESCRIPTION
## Summary
- preserve model-route training and prompt-retention policies from the OpenRouter frontend endpoint
- show model-specific `Trains` and `Retains prompts` values in model and provider detail tables
- retain provider-level policy badges and filters as provider defaults, with a note that individual models can differ
- fall back to provider policy for snapshots created before endpoint policy fields were stored

## OpenRouter evidence
Amazon Bedrock reports `retainsPrompts: false` at the provider level, while its `anthropic/claude-fable-5` route reports `endpoint.data_policy.retainsPrompts: true` and `retentionDays: 30`. The endpoint payload also exposes model-route `training`.

## Validation
- `pnpm format`
- `pnpm --filter @kilocode/db typecheck`
- changed-file web lint: 0 warnings/errors
- standalone model-policy parser/helper assertions
- `git diff --check`

Full web typecheck/lint exceeded the 120-second sandbox limit. The focused Jest test reached repository global setup but could not run because Postgres/Docker is unavailable in this environment.