### PR TITLE
feat(web): add Grok latest model alias

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -15,6 +15,7 @@ import {
   GPT_MINI_CURRENT_VERCEL_MODEL_ID,
 } from '@/lib/ai-gateway/providers/openai';
 import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelIdToVercel';
+import { GROK_CURRENT_VERCEL_MODEL_ID } from '@/lib/ai-gateway/providers/xai';
 
 describe('mapModelIdToVercel', () => {
   describe('tilde-prefixed latest aliases', () => {
@@ -28,6 +29,7 @@ describe('mapModelIdToVercel', () => {
       ['~moonshotai/kimi-latest', KIMI_CURRENT_VERCEL_MODEL_ID],
       ['~google/gemini-pro-latest', GEMINI_PRO_CURRENT_VERCEL_MODEL_ID],
       ['~google/gemini-flash-latest', GEMINI_FLASH_CURRENT_VERCEL_MODEL_ID],
+      ['~x-ai/grok-latest', GROK_CURRENT_VERCEL_MODEL_ID],
     ])('maps %s to the current Vercel model id', (input, expected) => {
       expect(mapModelIdToVercel(input, false)).toBe(expected);
     });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
@@ -15,6 +15,7 @@ import {
   GPT_MINI_CURRENT_VERCEL_MODEL_ID,
 } from '@/lib/ai-gateway/providers/openai';
 import { inferVercelFirstPartyInferenceProviderForModel } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
+import { GROK_CURRENT_VERCEL_MODEL_ID } from '@/lib/ai-gateway/providers/xai';
 
 const vercelModelIdMapping: Record<string, string | undefined> = {
   '~anthropic/claude-fable-latest': CLAUDE_FABLE_CURRENT_VERCEL_MODEL_ID,
@@ -26,6 +27,7 @@ const vercelModelIdMapping: Record<string, string | undefined> = {
   '~moonshotai/kimi-latest': KIMI_CURRENT_VERCEL_MODEL_ID,
   '~google/gemini-pro-latest': GEMINI_PRO_CURRENT_VERCEL_MODEL_ID,
   '~google/gemini-flash-latest': GEMINI_FLASH_CURRENT_VERCEL_MODEL_ID,
+  '~x-ai/grok-latest': GROK_CURRENT_VERCEL_MODEL_ID,
   'mistralai/codestral-2508': 'mistral/codestral',
   'mistralai/devstral-2512': 'mistral/devstral-2',
   'mistralai/mistral-embed-2312': 'mistral/mistral-embed',

--- a/apps/web/src/lib/ai-gateway/providers/xai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/xai.ts
@@ -1,3 +1,5 @@
+export const GROK_CURRENT_VERCEL_MODEL_ID = 'xai/grok-4.3';
+
 export function isGrokModel(requestedModel: string) {
   return requestedModel.includes('grok');
 }


### PR DESCRIPTION
## Summary
- add `~x-ai/grok-latest` as a Vercel model alias
- resolve the alias to `xai/grok-4.3` through an xAI current-model constant
- cover the alias in the existing table-driven mapper test

## Validation
- `pnpm format`
- file-scoped `oxlint` (passed)
- targeted Jest test attempted but blocked by unavailable Postgres/Docker in the agent environment
- `pnpm typecheck` attempted but exceeded the 120-second agent command limit