### PR TITLE
feat(config): expose stable sandbox schema

### DIFF
--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -75,6 +75,27 @@ export const kiloExtras = {
       description: 'Hide Kilo Gateway models that may train on your prompts from model listings',
       type: 'boolean',
     },
+    sandbox: {
+      type: 'object',
+      properties: {
+        enabled: {
+          type: 'boolean',
+          description: 'Enable sandbox confinement for new sessions (default: false)',
+        },
+        network: {
+          type: 'string',
+          enum: ['allow', 'deny'],
+          description: 'Control outbound network access from sandboxed tools (default: deny)',
+        },
+        writable_paths: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Additional filesystem paths that sandboxed tools may write to',
+        },
+      },
+      additionalProperties: false,
+      description: 'Sandbox configuration for agent tools',
+    },
     commit_message: {
       description: 'Configuration for AI-generated commit messages',
       type: 'object',

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -51,6 +51,7 @@ describe('kilo config.json schema merge', () => {
     expect(props.terminal_command_display).toBeDefined();
     expect(props.code_edit_display).toBeDefined();
     expect(props.hide_prompt_training_models).toBeDefined();
+    expect(props.sandbox).toBeDefined();
   });
 
   test('auto_collapse_reasoning is a boolean', () => {
@@ -75,6 +76,22 @@ describe('kilo config.json schema merge', () => {
   test('commit_message has a prompt string property', () => {
     const cm = props.commit_message as { properties: { prompt: unknown } };
     expect(cm.properties.prompt).toEqual(expect.objectContaining({ type: 'string' }));
+  });
+
+  test('sandbox is a first-class config object', () => {
+    const sandbox = props.sandbox as {
+      properties: Record<string, { type: string; enum?: string[] }>;
+      additionalProperties: boolean;
+    };
+    expect(sandbox.properties.enabled.type).toBe('boolean');
+    expect(sandbox.properties.network.enum).toEqual(['allow', 'deny']);
+    expect(sandbox.properties.writable_paths.type).toBe('array');
+    expect(sandbox.additionalProperties).toBe(false);
+
+    const experimental = props.experimental as { properties: Record<string, unknown> };
+    expect(experimental.properties.sandbox).toBeUndefined();
+    expect(experimental.properties.sandbox_restrict_network).toBeUndefined();
+    expect(experimental.properties.sandbox_writable_paths).toBeUndefined();
   });
 
   test('allows null on model and small_model', () => {


### PR DESCRIPTION
The CLI now exposes sandboxing as a first-class top-level configuration object rather than a set of experimental fields. Without a matching cloud overlay, `https://app.kilo.ai/config.json` would report the released settings as unknown properties.

This adds the exact `sandbox.enabled`, `sandbox.network`, and `sandbox.writable_paths` schema emitted by the CLI, including the network enum and closed object shape. The schema regression coverage also verifies that the retired experimental sandbox fields are not reintroduced.