### PR TITLE
fix(git-token-service): authorize bound Kilo ingest bootstrap

### DIFF
--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -1356,6 +1356,7 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
       service.redeemKiloSessionCapability({
         capability: issued.capability,
         outboundContainerId,
+        requestMethod: 'POST',
         requestUrl: 'https://api.kilo.ai/api/openrouter/v1/chat/completions',
       })
     ).resolves.toEqual({
@@ -1374,6 +1375,7 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
       service.redeemKiloSessionCapability({
         capability: issued.capability,
         outboundContainerId,
+        requestMethod: 'GET',
         requestUrl: 'https://api.kilo.ai/api/users/me',
       })
     ).resolves.toEqual({
@@ -1392,7 +1394,28 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
       service.redeemKiloSessionCapability({
         capability: issued.capability,
         outboundContainerId,
+        requestMethod: 'GET',
         requestUrl: 'https://ingest.kilosessions.ai/api/session/kilo-session-1/export',
+      })
+    ).resolves.toEqual({
+      success: true,
+      authorization: 'Bearer raw-user-token',
+      routeClass: 'session_ingest',
+    });
+  });
+
+  it('redeems the user token for a bootstrap bound to the Kilo session', async () => {
+    const service = createService();
+    const issued = await service.issueKiloSessionCapability(kiloSubject);
+    if (!issued.success) throw new Error('Expected successful issuance');
+
+    await expect(
+      service.redeemKiloSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestMethod: 'POST',
+        requestUrl: 'https://ingest.kilosessions.ai/api/session',
+        bootstrapKiloSessionId: kiloSubject.kiloSessionId,
       })
     ).resolves.toEqual({
       success: true,
@@ -1410,6 +1433,7 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
       service.redeemKiloSessionCapability({
         capability: issued.capability,
         outboundContainerId,
+        requestMethod: 'GET',
         requestUrl: 'https://ingest.kilosessions.ai/api/session/another-session/export',
       })
     ).resolves.toEqual({ success: false, reason: 'upstream_not_allowed' });
@@ -1431,6 +1455,7 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
       service.redeemKiloSessionCapability({
         capability: issued.capability,
         outboundContainerId,
+        requestMethod: 'GET',
         requestUrl: 'https://api.kilo.ai/api/session/another-session/export',
       })
     ).resolves.toEqual({ success: false, reason: 'upstream_not_allowed' });
@@ -1445,6 +1470,7 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
       service.redeemKiloSessionCapability({
         capability: issued.capability,
         outboundContainerId: 'another-outbound-container',
+        requestMethod: 'GET',
         requestUrl: 'https://api.kilo.ai/api/users/me',
       })
     ).resolves.toEqual({ success: false, reason: 'container_mismatch' });
@@ -1459,6 +1485,7 @@ describe('GitTokenRPCEntrypoint Kilo session capability RPCs', () => {
       service.redeemKiloSessionCapability({
         capability: issued.capability,
         outboundContainerId,
+        requestMethod: 'GET',
         requestUrl: 'https://evil.example.com/api/users/me',
       })
     ).resolves.toEqual({ success: false, reason: 'upstream_not_allowed' });

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -227,7 +227,9 @@ export type IssueKiloSessionCapabilityResult =
 export type RedeemKiloSessionCapabilityParams = {
   capability: string;
   outboundContainerId: string;
+  requestMethod: string;
   requestUrl: string;
+  bootstrapKiloSessionId?: string;
 };
 export type RedeemKiloSessionCapabilityFailureReason =
   | KiloSessionCapabilityFailureReason
@@ -1113,7 +1115,11 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     const classification = classifyKiloCapabilityRequest(
       params.requestUrl,
       claims.targets,
-      claims.kiloSessionId
+      claims.kiloSessionId,
+      {
+        requestMethod: params.requestMethod,
+        bootstrapKiloSessionId: params.bootstrapKiloSessionId,
+      }
     );
     if (!classification.success) {
       return { success: false, reason: classification.reason };

--- a/services/git-token-service/src/kilo-capability-policy.test.ts
+++ b/services/git-token-service/src/kilo-capability-policy.test.ts
@@ -38,6 +38,32 @@ describe('classifyKiloCapabilityRequest', () => {
     });
   });
 
+  it('routes a matching session-ingest bootstrap request', () => {
+    expect(
+      classifyKiloCapabilityRequest(
+        'https://ingest.kilosessions.ai/api/session',
+        targets,
+        kiloSessionId,
+        { requestMethod: 'POST', bootstrapKiloSessionId: kiloSessionId }
+      )
+    ).toEqual({ success: true, routeClass: 'session_ingest' });
+  });
+
+  it.each([
+    ['another session', 'POST', 'another-kilo-session'],
+    ['missing session identity', 'POST', undefined],
+    ['wrong method', 'GET', kiloSessionId],
+  ] as const)('rejects a session-ingest bootstrap request with %s', (_description, method, id) => {
+    expect(
+      classifyKiloCapabilityRequest(
+        'https://ingest.kilosessions.ai/api/session',
+        targets,
+        kiloSessionId,
+        { requestMethod: method, bootstrapKiloSessionId: id }
+      )
+    ).toEqual({ success: false, reason: 'upstream_not_allowed' });
+  });
+
   it('allows percent-encoded characters in the query string', () => {
     expect(
       classifyKiloCapabilityRequest(
@@ -108,6 +134,17 @@ describe('classifyKiloCapabilityRequest', () => {
           kiloSessionId
         )
       ).toEqual({ success: true, routeClass: 'session_ingest' });
+    });
+
+    it('does not let the backend catch-all serve an unbound bootstrap request', () => {
+      expect(
+        classifyKiloCapabilityRequest(
+          'https://api.kilo.ai/api/session',
+          sharedOriginTargets,
+          kiloSessionId,
+          { requestMethod: 'POST' }
+        )
+      ).toEqual({ success: false, reason: 'upstream_not_allowed' });
     });
 
     it.each(['export', 'ingest'] as const)(

--- a/services/git-token-service/src/kilo-capability-policy.ts
+++ b/services/git-token-service/src/kilo-capability-policy.ts
@@ -10,6 +10,11 @@ export type KiloCapabilityRouteClassification =
   | { success: true; routeClass: KiloCapabilityRouteClass }
   | { success: false; reason: 'invalid_upstream_url' | 'upstream_not_allowed' };
 
+export type KiloCapabilityRequestIdentity = {
+  requestMethod?: string;
+  bootstrapKiloSessionId?: string;
+};
+
 type ParsedTarget = {
   origin: string;
   basePath: string;
@@ -107,7 +112,12 @@ function isSessionIngestRoute(pathname: string, basePath: string, kiloSessionId:
   );
 }
 
+function isSessionBootstrapRoute(pathname: string, basePath: string): boolean {
+  return pathname === appendPath(basePath, '/api/session');
+}
+
 function isSessionIngestShapedRoute(pathname: string, basePath: string): boolean {
+  if (pathname === appendPath(basePath, '/api/session')) return true;
   const sessionsPrefix = appendPath(basePath, '/api/session/');
   if (!pathname.startsWith(sessionsPrefix)) return false;
   return /^[^/]+\/(?:export|import|ingest)$/.test(pathname.slice(sessionsPrefix.length));
@@ -116,7 +126,8 @@ function isSessionIngestShapedRoute(pathname: string, basePath: string): boolean
 export function classifyKiloCapabilityRequest(
   requestUrl: string,
   targets: KiloSessionCapabilityTargets,
-  kiloSessionId: string
+  kiloSessionId: string,
+  requestIdentity: KiloCapabilityRequestIdentity = {}
 ): KiloCapabilityRouteClassification {
   // requestUrl is only compile-time typed at the WorkerEntrypoint RPC boundary; a
   // caller can still send a non-string, which must fail closed like every other
@@ -158,6 +169,18 @@ export function classifyKiloCapabilityRequest(
     isSessionIngestRoute(url.pathname, sessionIngest.basePath, kiloSessionId)
   ) {
     return { success: true, routeClass: 'session_ingest' };
+  }
+  if (
+    isWithinTarget(url, sessionIngest) &&
+    isSessionBootstrapRoute(url.pathname, sessionIngest.basePath)
+  ) {
+    if (
+      requestIdentity.requestMethod?.toUpperCase() === 'POST' &&
+      requestIdentity.bootstrapKiloSessionId === kiloSessionId
+    ) {
+      return { success: true, routeClass: 'session_ingest' };
+    }
+    return { success: false, reason: 'upstream_not_allowed' };
   }
   // Backend is the catch-all for its origin, so it must exclude provider- and
   // session-ingest-shaped paths. Otherwise a shared backend/session-ingest origin


### PR DESCRIPTION
## Summary
- Authorize Kilo session-ingest bootstrap only when its supplied session ID matches the opaque capability claim.
- Require a request method and optional validated bootstrap session identity at the Kilo capability redemption boundary.
- Preserve exact-session restrictions and add regressions for mismatched identities and shared-origin fallback.

## Verification
N/A - broker-only change.

## Visual Changes
N/A.

## Reviewer Notes
Deploy alongside the matching Cloud Agent outbound-handler change, which supplies the request method and parsed bootstrap session ID. Deploying this broker first is safe; session-ingest bootstrap remains blocked until the handler deploy follows.