### PR TITLE
fix(extension): change Firefox add-on id to browser-agent@kilo.ai

### DIFF
--- a/apps/extension/tests/e2e/firefox-extension.test.ts
+++ b/apps/extension/tests/e2e/firefox-extension.test.ts
@@ -8,7 +8,7 @@ import { dirname, join, resolve as resolvePath } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { z } from 'zod';
 
-const extensionId = 'kilo-extension@kilocode.ai';
+const extensionId = 'browser-agent@kilo.ai';
 const firefoxExtensionPath = resolvePath(import.meta.dirname, '../../.output/firefox-mv3');
 
 interface InstalledFirefoxAddon {

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
         data_collection_permissions: {
           required: ['none'],
         },
-        id: 'kilo-extension@kilocode.ai',
+        id: 'browser-agent@kilo.ai',
       },
     },
     description: 'Side-panel AI chat agent. Use open-weight or frontier models.',


### PR DESCRIPTION
## Why

Product can't submit the extension to the Firefox store: the current gecko id `kilo-extension@kilocode.ai` **collides** on AMO. It also still uses the retired `kilocode.ai` domain while the rest of the extension is on `kilo.ai`.

## What

- Rename the Firefox add-on id to `browser-agent@kilo.ai` in `wxt.config.ts` (source of truth for the manifest).
- Update the one e2e test that hard-codes the id.

Firefox add-on ids only need to be globally unique on AMO; the email form is a convention and the `@kilo.ai` part doesn't need to be a real mailbox.

## Chrome

No change. Chrome's extension id is derived from the Web Store upload and isn't pinned via a `key` in the manifest, so there's nothing to rename and nothing collides.

## Safety

Firefox OAuth redirects use `browser.identity.getRedirectURL()`, which is built from a per-install UUID — not the gecko id — so changing the id does not affect auth flows.

## Verification

- `pnpm --filter kilo-extension build:firefox` → generated `manifest.json` now shows `"id":"browser-agent@kilo.ai"`.