### PR TITLE
CloudAgentNext - Enable tool cgroup resource limits for all orgs

### DIFF
--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -57,6 +57,10 @@
     "CLOUDFLARE_R2_ACCOUNT_ID": "e115e769bcdd4c3d66af59d3332cb394",
     "WS_ALLOWED_ORIGINS": "https://app.kilo.ai,https://api.kilo.ai",
     "KILO_SESSION_INGEST_URL": "https://ingest.kilosessions.ai",
+    "TOOL_CGROUP_ORG_IDS": "*",
+    "TOOL_CGROUP_MODE": "enforce",
+    "TOOL_CGROUP_RESERVE_MB": "1024",
+    "TOOL_CGROUP_CPU_WEIGHT": "50",
   },
   "placement": { "mode": "smart" },
   /**


### PR DESCRIPTION
## What
Permanently enable the sandbox tool/server cgroup partition in production (was disabled for every org by default).

## Changes
Adds production `vars` to `services/cloud-agent-next/wrangler.jsonc`:
- `TOOL_CGROUP_ORG_IDS=*` — opens the per-org gate to all orgs (was unset → off for everyone)
- `TOOL_CGROUP_MODE=enforce` — applies `memory.max` to the tool slice (was defaulting to `off`)
- `TOOL_CGROUP_RESERVE_MB=1024` — 1GB reserved back from the tool cap (default was 1536)
- `TOOL_CGROUP_CPU_WEIGHT=50` — tool slice `cpu.weight`; the kilo-server slice keeps the kernel default (100), giving the server 2x the CPU share of tools under contention

## Effect
Tool cap = `MemTotal − 1GB`. Smallest sandbox (4GB) yields a 3GB cap, clearing the 1GB minimum-cap floor on every container class, so `enforce` applies everywhere. A runaway tool is now OOM-killed in seconds instead of thrashing the whole container.

Dev (`env.dev`) stays disabled (`TOOL_CGROUP_ORG_IDS=""`); macOS local dev can't do cgroups.

## Verification
- `wrangler.jsonc` parses; production values confirmed, dev unchanged.
- Config-reading tests pass (40/40): `queue-config.test.ts`, `devcontainer.test.ts`.
- Cgroup gating/passthrough tests pass (130/130): `cloudflare-agent-sandbox.test.ts`, `wrapper-client.test.ts`.
- Wrapper cgroup unit tests pass (216/216).