### PR TITLE
fix(mobile): bump app version to 1.0.2

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -25,7 +25,7 @@ const config: ExpoConfig = {
   name: 'Kilo',
   owner: 'kilocode',
   slug: 'kilo-app',
-  version: '1.0.1',
+  version: '1.0.2',
   orientation: 'portrait',
   icon: './assets/images/logo.png',
   scheme: 'kiloapp',


### PR DESCRIPTION
## Summary
- bump the Expo app version from 1.0.1 to 1.0.2

## Validation
- pnpm format
- pnpm --filter kilo-app typecheck
- pnpm --filter kilo-app lint
- pnpm --filter kilo-app check:unused
- pnpm --filter kilo-app format:check
- pnpm --filter kilo-app test (426 tests)