### PR TITLE
Fix final routed model logging for Messages API

### DIFF
--- a/apps/web/src/lib/ai-gateway/processUsage.messages.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.messages.test.ts
@@ -227,6 +227,27 @@ describe('parseMessagesMicrodollarUsageFromStream approval tests', () => {
 });
 
 describe('parseMessagesMicrodollarUsageFromStream', () => {
+  test('records the successful Vercel routed model instead of the message start model', async () => {
+    const stream = streamFromText(
+      'event: message_start\n' +
+        'data: {"type":"message_start","message":{"id":"generation-id","type":"message","role":"assistant","content":[],"model":"anthropic/claude-fable-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}\n\n' +
+        'event: message_delta\n' +
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":25,"output_tokens":724},"provider_metadata":{"gateway":{"routing":{"canonicalSlug":"anthropic/claude-opus-4.8","finalProvider":"anthropic","modelAttempts":[{"canonicalSlug":"anthropic/claude-fable-5","success":false},{"canonicalSlug":"anthropic/claude-opus-4.8","success":true}]},"cost":"0","marketCost":"0.018225"}}}\n\n' +
+        'event: message_stop\n' +
+        'data: {"type":"message_stop"}\n\n'
+    );
+
+    const result = await parseMessagesMicrodollarUsageFromStream(
+      stream,
+      'fake-user-id',
+      undefined,
+      'vercel',
+      200
+    );
+
+    expect(result.model).toBe('anthropic/claude-opus-4.8');
+  });
+
   test('records stream error events as errored timeout usage', async () => {
     const stream = streamFromText(
       'event: error\n' +

--- a/apps/web/src/lib/ai-gateway/processUsage.messages.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.messages.test.ts
@@ -232,7 +232,7 @@ describe('parseMessagesMicrodollarUsageFromStream', () => {
       'event: message_start\n' +
         'data: {"type":"message_start","message":{"id":"generation-id","type":"message","role":"assistant","content":[],"model":"anthropic/claude-fable-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}\n\n' +
         'event: message_delta\n' +
-        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":25,"output_tokens":724},"provider_metadata":{"gateway":{"routing":{"canonicalSlug":"anthropic/claude-opus-4.8","finalProvider":"anthropic","modelAttempts":[{"canonicalSlug":"anthropic/claude-fable-5","success":false},{"canonicalSlug":"anthropic/claude-opus-4.8","success":true}]},"cost":"0","marketCost":"0.018225"}}}\n\n' +
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":25,"output_tokens":724},"provider_metadata":{"gateway":{"routing":{"canonicalSlug":"anthropic/claude-fable-5","finalProvider":"anthropic","modelAttempts":[{"canonicalSlug":"anthropic/claude-fable-5","success":false},{"canonicalSlug":"anthropic/claude-opus-4.8","success":true}]},"cost":"0","marketCost":"0.018225"}}}\n\n' +
         'event: message_stop\n' +
         'data: {"type":"message_stop"}\n\n'
     );

--- a/apps/web/src/lib/ai-gateway/processUsage.messages.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.messages.ts
@@ -49,6 +49,16 @@ type MessagesApiUsage = Anthropic.Messages.MessageDeltaUsage & {
   cost_details?: { upstream_inference_cost: number };
 };
 
+function getVercelResolvedModel(
+  providerMetadata: VercelProviderMetaData | null | undefined
+): string | undefined {
+  const routing = providerMetadata?.gateway?.routing;
+  return (
+    routing?.modelAttempts?.find(attempt => attempt.success)?.canonicalSlug ??
+    routing?.canonicalSlug
+  );
+}
+
 export function processMessagesApiUsage(
   usage: MessagesApiUsage | null | undefined,
   providerMetadata: VercelProviderMetaData | null | undefined,
@@ -184,6 +194,7 @@ export async function parseMessagesMicrodollarUsageFromStream(
         const meta = (json as MaybeHasVercelProviderMetadata).provider_metadata;
         if (meta) {
           providerMetadata = meta;
+          model = getVercelResolvedModel(meta) ?? model;
           inference_provider = meta.gateway?.routing?.finalProvider ?? inference_provider;
         }
       }
@@ -246,7 +257,7 @@ export function parseMessagesMicrodollarUsageFromString(
   const coreProps = {
     messageId: responseJson?.id ?? null,
     hasError: !responseJson?.model || statusCode >= 400 || isErrorFinishReason(finish_reason),
-    model: responseJson?.model ?? null,
+    model: getVercelResolvedModel(providerMetadata) ?? responseJson?.model ?? null,
     responseContent,
     inference_provider,
     upstream_id: null,

--- a/apps/web/src/lib/ai-gateway/processUsage.types.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.types.ts
@@ -26,6 +26,7 @@ export type VercelProviderAttempt = {
 };
 
 export type VercelModelAttempt = {
+  canonicalSlug?: string;
   success?: boolean;
   providerAttempts?: VercelProviderAttempt[];
 };
@@ -33,6 +34,7 @@ export type VercelModelAttempt = {
 export type VercelProviderMetaData = {
   gateway?: {
     routing?: {
+      canonicalSlug?: string;
       finalProvider?: string;
       modelAttempts?: VercelModelAttempt[];
     };


### PR DESCRIPTION
## Summary
- prefer the successful Vercel gateway model attempt when recording Messages API usage
- fall back to the routing canonical slug, then the response envelope model
- preserve `requested_model` and add regression coverage for a fable-to-opus fallback

## Validation
- `pnpm format`
- targeted oxlint: passed
- focused Jest suite: blocked because Docker/Postgres is unavailable in the sandbox
- `pnpm typecheck`: exceeded the 120-second sandbox command limit without reporting an error