### PR TITLE
feat(mobile): replace Support tile with Feedback flow

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -66,6 +66,7 @@
     "expo-sharing": "~55.0.21",
     "expo-splash-screen": "55.0.22",
     "expo-status-bar": "55.0.6",
+    "expo-store-review": "~55.0.15",
     "expo-tracking-transparency": "55.0.15",
     "expo-web-browser": "55.0.17",
     "jotai": "2.18.1",

--- a/apps/mobile/src/components/profile-screen.tsx
+++ b/apps/mobile/src/components/profile-screen.tsx
@@ -4,13 +4,13 @@ import { type Href, useRouter } from 'expo-router';
 import {
   GitPullRequest,
   KeyRound,
-  LifeBuoy,
   Lock,
   LogOut,
+  MessageSquare,
   ShieldCheck,
   Trash2,
 } from 'lucide-react-native';
-import { Alert, Linking, Platform, Pressable, ScrollView, View } from 'react-native';
+import { Alert, Platform, Pressable, ScrollView, View } from 'react-native';
 import { toast } from 'sonner-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
@@ -23,6 +23,7 @@ import { ConfigureRow } from '@/components/ui/configure-row';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { useAuth } from '@/lib/auth/auth-context';
+import { showFeedbackPrompt } from '@/lib/feedback';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { useOrganization } from '@/lib/organization-context';
@@ -30,8 +31,6 @@ import { getCodeReviewerProfilePath, getProfileAgentScope } from '@/lib/profile-
 import { getSecurityAgentPath } from '@/lib/security-agent';
 import { getTabBarOverlayHeight } from '@/lib/tab-bar-layout';
 import { useTRPC } from '@/lib/trpc';
-
-const SUPPORT_EMAIL = 'hi@kilo.ai';
 
 function providerIcon(_provider: string) {
   return KeyRound;
@@ -96,21 +95,6 @@ export function ProfileScreen() {
   const { userId } = useCurrentUserId({ enabled: isAuthenticated });
 
   const { bottom } = useSafeAreaInsets();
-
-  const openSupportEmail = async () => {
-    const envDetails = [
-      `User ID: ${userId ?? 'unknown'}`,
-      `App version: ${Application.nativeApplicationVersion} (${Application.nativeBuildVersion})`,
-      `OS: ${Platform.OS} ${Platform.Version}`,
-    ].join('\n');
-    const body = `\n\n---\n${envDetails}`;
-    const url = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent('mobile app feedback')}&body=${encodeURIComponent(body)}`;
-    try {
-      await Linking.openURL(url);
-    } catch {
-      toast.error(`No email app available. You can reach us at ${SUPPORT_EMAIL}`);
-    }
-  };
 
   const deleteAccount = useMutation(
     trpc.user.requestAccountDeletion.mutationOptions({
@@ -262,11 +246,11 @@ export function ProfileScreen() {
         <View className="mt-6 gap-3">
           <View className="flex-row gap-3">
             <ActionTile
-              icon={LifeBuoy}
-              label="Support"
+              icon={MessageSquare}
+              label="Feedback"
               color={colors.mutedForeground}
               onPress={() => {
-                void openSupportEmail();
+                showFeedbackPrompt(userId);
               }}
             />
             <ActionTile

--- a/apps/mobile/src/lib/feedback.ts
+++ b/apps/mobile/src/lib/feedback.ts
@@ -1,0 +1,91 @@
+import * as Application from 'expo-application';
+import * as SecureStore from 'expo-secure-store';
+import * as StoreReview from 'expo-store-review';
+import { Alert, Linking, Platform } from 'react-native';
+import { toast } from 'sonner-native';
+
+import { REVIEW_REQUESTED_AT_KEY } from '@/lib/storage-keys';
+
+const SUPPORT_EMAIL = 'hi@kilo.ai';
+
+const STORE_REVIEW_URL = Platform.select({
+  ios: 'https://apps.apple.com/app/id6761193135?action=write-review',
+  default: 'https://play.google.com/store/apps/details?id=com.kilocode.kiloapp',
+});
+
+async function openSupportEmail(userId: string | undefined) {
+  const envDetails = [
+    `User ID: ${userId ?? 'unknown'}`,
+    `App version: ${Application.nativeApplicationVersion} (${Application.nativeBuildVersion})`,
+    `OS: ${Platform.OS} ${Platform.Version}`,
+  ].join('\n');
+  const body = `\n\n---\n${envDetails}`;
+  const url = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent('mobile app feedback')}&body=${encodeURIComponent(body)}`;
+  try {
+    await Linking.openURL(url);
+  } catch {
+    toast.error(`No email app available. You can reach us at ${SUPPORT_EMAIL}`);
+  }
+}
+
+async function rateApp() {
+  // The native review popup silently no-ops when the OS rate limit is hit, so
+  // only use it the first time; afterwards deep-link to the store review page.
+  const alreadyRequested = await SecureStore.getItemAsync(REVIEW_REQUESTED_AT_KEY);
+  if (alreadyRequested == null && (await StoreReview.isAvailableAsync().catch(() => false))) {
+    await SecureStore.setItemAsync(REVIEW_REQUESTED_AT_KEY, new Date().toISOString());
+    try {
+      await StoreReview.requestReview();
+      return;
+    } catch {
+      // Native popup failed — fall through to the store page.
+    }
+  }
+  try {
+    await Linking.openURL(STORE_REVIEW_URL);
+  } catch {
+    toast.error('Could not open the store.');
+  }
+}
+
+export function showFeedbackPrompt(userId: string | undefined) {
+  Alert.alert('How are you liking the Kilo app?', undefined, [
+    { text: 'Cancel', style: 'cancel' },
+    {
+      text: 'I like it',
+      onPress: () => {
+        Alert.alert(
+          "We're glad to hear that!",
+          'A store review would help us out immensely. Thanks for using Kilo!',
+          [
+            { text: 'Not now', style: 'cancel' },
+            {
+              text: 'Rate Kilo',
+              onPress: () => {
+                void rateApp();
+              },
+            },
+          ]
+        );
+      },
+    },
+    {
+      text: 'Needs work',
+      onPress: () => {
+        Alert.alert(
+          "We're sorry to hear that!",
+          'Please let us know what needs to be better. The engineer in charge of the app reads every single report!',
+          [
+            { text: 'Not now', style: 'cancel' },
+            {
+              text: 'Email us',
+              onPress: () => {
+                void openSupportEmail(userId);
+              },
+            },
+          ]
+        );
+      },
+    },
+  ]);
+}

--- a/apps/mobile/src/lib/feedback.ts
+++ b/apps/mobile/src/lib/feedback.ts
@@ -31,15 +31,15 @@ async function openSupportEmail(userId: string | undefined) {
 async function rateApp() {
   // The native review popup silently no-ops when the OS rate limit is hit, so
   // only use it the first time; afterwards deep-link to the store review page.
-  const alreadyRequested = await SecureStore.getItemAsync(REVIEW_REQUESTED_AT_KEY);
-  if (alreadyRequested == null && (await StoreReview.isAvailableAsync().catch(() => false))) {
-    await SecureStore.setItemAsync(REVIEW_REQUESTED_AT_KEY, new Date().toISOString());
-    try {
+  try {
+    const alreadyRequested = await SecureStore.getItemAsync(REVIEW_REQUESTED_AT_KEY);
+    if (alreadyRequested == null && (await StoreReview.isAvailableAsync())) {
+      await SecureStore.setItemAsync(REVIEW_REQUESTED_AT_KEY, new Date().toISOString());
       await StoreReview.requestReview();
       return;
-    } catch {
-      // Native popup failed — fall through to the store page.
     }
+  } catch {
+    // Native popup path failed — fall through to the store page.
   }
   try {
     await Linking.openURL(STORE_REVIEW_URL);

--- a/apps/mobile/src/lib/storage-keys.ts
+++ b/apps/mobile/src/lib/storage-keys.ts
@@ -14,3 +14,4 @@ export const LAST_ACTIVE_INSTANCE_KEY = 'last-active-chat-instance';
 export const CONSENT_USER_KEY_PREFIX = 'consent-accepted-';
 export const AGENT_MODEL_PREFERENCE_KEY = 'agent-model-preference';
 export const REASONING_DEFAULT_EXPANDED_KEY = 'agent-reasoning-default-expanded';
+export const REVIEW_REQUESTED_AT_KEY = 'store-review-requested-at';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,9 @@ importers:
       expo-status-bar:
         specifier: 55.0.6
         version: 55.0.6(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)
+      expo-store-review:
+        specifier: ~55.0.15
+        version: 55.0.15(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6))
       expo-tracking-transparency:
         specifier: 55.0.15
         version: 55.0.15(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6))
@@ -12175,6 +12178,12 @@ packages:
     resolution: {integrity: sha512-ijOUptfdiqYt7rObZ6jrPQ8sE5YN/8MxKCIJx0b7TY4nGkSJxhPIxeoW4GXcXCA8mTQ9PiOHH/ThLZgRVZvUlQ==}
     peerDependencies:
       react: '*'
+      react-native: '*'
+
+  expo-store-review@55.0.15:
+    resolution: {integrity: sha512-p4hnMPMqP/CzX9rI32dI8xwWzIAXYQgCldUpx/me/xA3SBwQhjC1OzaCvmtHolxpVv19ut9YtxH2JXTAoadrVw==}
+    peerDependencies:
+      expo: '*'
       react-native: '*'
 
   expo-symbols@55.0.9:
@@ -28882,6 +28891,11 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)
+
+  expo-store-review@55.0.15(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      expo: 55.0.27(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(bufferutil@4.1.0)(expo-router@55.0.16)(react-dom@19.2.6(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6)
 
   expo-symbols@55.0.9(expo-font@55.0.8)(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0):
     dependencies:


### PR DESCRIPTION
## What

Renames the profile **Support** tile to **Feedback** (icon: MessageSquare) and adds a two-step alert flow:

1. "How are you liking the Kilo app?" → **I like it** / **Needs work** / Cancel
2. **I like it** → "We're glad to hear that!" with a **Rate Kilo** CTA
   - First time: native in-app review popup (`expo-store-review`), with the timestamp recorded in SecureStore
   - Subsequent times (or if the popup is unavailable/fails): deep link to the App Store write-review page / Play Store listing
3. **Needs work** → "We're sorry to hear that!" with an **Email us** CTA that opens the existing support mailto (device details prefilled)

## Why

The native review popup silently no-ops once the OS rate limit is hit (iOS: 3/year), so after the first use we send users to the store page instead, which always works.

## Notes

- New dep: `expo-store-review` (via `npx expo install`; `expo-doctor` passes 19/19)
- Alert chain lives in `src/lib/feedback.ts` to keep `profile-screen.tsx` under the line limit
- `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` all pass
- Not yet e2e-verified on device — that's the next step

## E2E verification (iOS simulator, local backend)

- Profile tile shows **Feedback** with the MessageSquare icon; tapping it opens the "How are you liking the Kilo app?" alert with I like it / Needs work / Cancel.
- **Needs work** → "We're sorry to hear that!" alert → **Email us** fires the mailto; on the simulator (no Mail app) the fallback toast with hi@kilo.ai appeared as designed.
- **I like it** → "We're glad to hear that!" alert → **Rate Kilo** showed the native SKStoreReviewController popup ("Enjoying Kilo? Tap a star to rate it on the App Store") on first use.
- Second pass through the flow correctly skipped the native popup (SecureStore flag) and opened the store deep link; Safari erroring on it is a simulator artifact (no App Store app) — the URL itself resolves to the Kilo listing (HTTP 200).
