### PR TITLE
feat(mobile): organization management screens

### DIFF
--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/_layout.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/_layout.tsx
@@ -1,0 +1,7 @@
+import { Stack } from 'expo-router';
+
+// formSheet screens (rename, invite, etc.) get registered here in a later
+// task — see src/app/(app)/_layout.tsx for the Android fullSheetDetent pattern.
+export default function OrganizationLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/_layout.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/_layout.tsx
@@ -1,7 +1,29 @@
 import { Stack } from 'expo-router';
+import { Platform, StatusBar, useWindowDimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-// formSheet screens (rename, invite, etc.) get registered here in a later
-// task — see src/app/(app)/_layout.tsx for the Android fullSheetDetent pattern.
+// Mirrors apps/(app)/_layout.tsx's Android-safe full-sheet detent — Android
+// formSheets can't hit 1.0 without clipping under the status bar.
 export default function OrganizationLayout() {
-  return <Stack screenOptions={{ headerShown: false }} />;
+  const { height } = useWindowDimensions();
+  const { top } = useSafeAreaInsets();
+  const androidTopInset = top > 0 ? top : (StatusBar.currentHeight ?? 0);
+  const androidFullSheetDetent =
+    height > 0 ? Math.max(0.5, (height - androidTopInset) / height) : 1;
+  const fullSheetDetent = Platform.OS === 'android' ? androidFullSheetDetent : 1;
+
+  const sheetOptions = {
+    presentation: 'formSheet' as const,
+    sheetAllowedDetents: [0.5, fullSheetDetent] as [number, number],
+    sheetGrabberVisible: true,
+    headerShown: false,
+  };
+
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="invite-member" options={sheetOptions} />
+      <Stack.Screen name="member-limit" options={sheetOptions} />
+      <Stack.Screen name="low-balance-alert" options={sheetOptions} />
+    </Stack>
+  );
 }

--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/credit-activity.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/credit-activity.tsx
@@ -1,0 +1,5 @@
+import { OrganizationCreditActivityScreen } from '@/components/organization/credit-activity-screen';
+
+export default function OrganizationCreditActivityRoute() {
+  return <OrganizationCreditActivityScreen />;
+}

--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/index.tsx
@@ -1,0 +1,5 @@
+import { OrganizationHubScreen } from '@/components/organization/hub-screen';
+
+export default function OrganizationHubRoute() {
+  return <OrganizationHubScreen />;
+}

--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/invite-member.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/invite-member.tsx
@@ -1,0 +1,5 @@
+import { InviteMemberSheet } from '@/components/organization/invite-member-sheet';
+
+export default function InviteMemberRoute() {
+  return <InviteMemberSheet />;
+}

--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/invoices.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/invoices.tsx
@@ -1,0 +1,5 @@
+import { OrganizationInvoicesScreen } from '@/components/organization/invoices-screen';
+
+export default function OrganizationInvoicesRoute() {
+  return <OrganizationInvoicesScreen />;
+}

--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/low-balance-alert.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/low-balance-alert.tsx
@@ -1,0 +1,5 @@
+import { LowBalanceAlertSheet } from '@/components/organization/low-balance-alert-sheet';
+
+export default function LowBalanceAlertRoute() {
+  return <LowBalanceAlertSheet />;
+}

--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/member-limit.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/member-limit.tsx
@@ -1,0 +1,8 @@
+import { useLocalSearchParams } from 'expo-router';
+
+import { MemberLimitSheet } from '@/components/organization/member-limit-sheet';
+
+export default function MemberLimitRoute() {
+  const { memberId } = useLocalSearchParams<{ memberId: string }>();
+  return <MemberLimitSheet memberId={memberId} />;
+}

--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/members.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/organization/members.tsx
@@ -1,0 +1,5 @@
+import { OrganizationMembersScreen } from '@/components/organization/members-screen';
+
+export default function OrganizationMembersRoute() {
+  return <OrganizationMembersScreen />;
+}

--- a/apps/mobile/src/components/organization/credit-activity-screen.tsx
+++ b/apps/mobile/src/components/organization/credit-activity-screen.tsx
@@ -1,0 +1,103 @@
+import { Receipt } from 'lucide-react-native';
+import { FlatList, View } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+
+import { EmptyState } from '@/components/empty-state';
+import { ScreenHeader } from '@/components/screen-header';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Text } from '@/components/ui/text';
+import {
+  type CreditTransaction,
+  useOrgCreditTransactions,
+  useOrgRole,
+} from '@/lib/hooks/use-organization-queries';
+import { cn, firstNonEmpty, parseTimestamp } from '@/lib/utils';
+
+function humanizeCategory(category: string): string {
+  const spaced = category.replaceAll('_', ' ');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function CreditRowSkeleton() {
+  return (
+    <View className="gap-1.5 rounded-lg bg-secondary p-3">
+      <Skeleton className="h-4 w-40 rounded" />
+      <Skeleton className="h-3 w-24 rounded" />
+    </View>
+  );
+}
+
+function CreditRow({ transaction }: Readonly<{ transaction: CreditTransaction }>) {
+  const amount = transaction.amount_microdollars / 1_000_000;
+  const isPositive = amount >= 0;
+  const title = firstNonEmpty(
+    transaction.description,
+    transaction.credit_category ? humanizeCategory(transaction.credit_category) : undefined,
+    'Credit transaction'
+  );
+
+  return (
+    <View className="gap-1 rounded-lg bg-secondary p-3">
+      <View className="flex-row items-center justify-between gap-3">
+        <Text className="flex-1 text-sm font-medium text-foreground" numberOfLines={1}>
+          {title}
+        </Text>
+        <Text className={cn('text-sm font-medium', isPositive ? 'text-good' : 'text-foreground')}>
+          {isPositive ? '+' : '-'}${Math.abs(amount).toFixed(2)}
+        </Text>
+      </View>
+      <View className="flex-row items-center justify-between">
+        <Text className="text-xs text-muted-foreground">
+          {parseTimestamp(transaction.created_at).toLocaleDateString()}
+        </Text>
+        {transaction.expiry_date != null && (
+          <Text className="text-xs text-muted-foreground">
+            Expires {parseTimestamp(transaction.expiry_date).toLocaleDateString()}
+          </Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+export function OrganizationCreditActivityScreen() {
+  const { organizationId } = useOrgRole();
+  const query = useOrgCreditTransactions(organizationId);
+
+  if (organizationId == null) {
+    return null;
+  }
+
+  const isLoading = query.isLoading || !query.data;
+  const transactions = query.data ?? [];
+
+  return (
+    <View className="flex-1 bg-background">
+      <ScreenHeader title="Credit activity" />
+      {isLoading ? (
+        <Animated.View exiting={FadeOut.duration(150)} className="gap-3 px-6 pt-4">
+          <CreditRowSkeleton />
+          <CreditRowSkeleton />
+          <CreditRowSkeleton />
+        </Animated.View>
+      ) : (
+        <Animated.View entering={FadeIn.duration(200)} className="flex-1">
+          <FlatList
+            data={transactions}
+            keyExtractor={item => item.id}
+            renderItem={({ item }) => <CreditRow transaction={item} />}
+            contentContainerClassName="gap-3 px-6 pb-8 pt-4"
+            ListEmptyComponent={
+              <EmptyState
+                icon={Receipt}
+                className="pt-16"
+                title="No credit activity"
+                description="Credit transactions for this organization will show up here."
+              />
+            }
+          />
+        </Animated.View>
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/organization/hub-screen.tsx
+++ b/apps/mobile/src/components/organization/hub-screen.tsx
@@ -74,7 +74,9 @@ export function OrganizationHubScreen() {
                   </Pressable>
                 )}
               </View>
-              {showMoney && <KvRow label="Balance" value={`$${org.balance.toFixed(2)}`} />}
+              {showMoney && (
+                <KvRow label="Balance" value={`$${(org.balance / 1_000_000).toFixed(2)}`} />
+              )}
               <KvRow label="Seats" value={`${org.seatCount.used} / ${org.seatCount.total}`} last />
             </Animated.View>
           )}

--- a/apps/mobile/src/components/organization/hub-screen.tsx
+++ b/apps/mobile/src/components/organization/hub-screen.tsx
@@ -1,0 +1,145 @@
+import * as Haptics from 'expo-haptics';
+import { type Href, useRouter } from 'expo-router';
+import { Bell, FileText, Pencil, Receipt, Users } from 'lucide-react-native';
+import { useState } from 'react';
+import { Pressable, ScrollView, View } from 'react-native';
+import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
+
+import { OrgUsageStats } from '@/components/organization/org-usage-stats';
+import { RenameOrgModal } from '@/components/organization/rename-org-modal';
+import { ScreenHeader } from '@/components/screen-header';
+import { ConfigureRow } from '@/components/ui/configure-row';
+import { KvRow } from '@/components/ui/kv-row';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Text } from '@/components/ui/text';
+import { useOrganizationMutations } from '@/lib/hooks/use-organization-mutations';
+import { isMoneyRole, useOrgRole, useOrgWithMembers } from '@/lib/hooks/use-organization-queries';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+
+function InfoCardSkeleton() {
+  return (
+    <View className="gap-2.5 rounded-lg bg-secondary px-3 py-3">
+      <Skeleton className="h-5 w-2/3 rounded-md" />
+      <Skeleton className="h-5 w-1/3 rounded-md" />
+      <Skeleton className="h-5 w-1/3 rounded-md" />
+    </View>
+  );
+}
+
+export function OrganizationHubScreen() {
+  const router = useRouter();
+  const colors = useThemeColors();
+  const { organizationId, role, org, isLoading } = useOrgRole();
+  const orgWithMembers = useOrgWithMembers(organizationId ?? '');
+  const mutations = useOrganizationMutations(organizationId ?? '');
+  const [renameVisible, setRenameVisible] = useState(false);
+
+  if (organizationId == null) {
+    return null;
+  }
+
+  const showMoney = isMoneyRole(role);
+  const minimumBalance = orgWithMembers.data?.settings.minimum_balance;
+  const lowBalanceSubtitle = minimumBalance != null ? `Below $${minimumBalance.toFixed(2)}` : 'Off';
+
+  return (
+    <View className="flex-1 bg-background">
+      <ScreenHeader title={org?.organizationName ?? 'Organization'} />
+      <ScrollView
+        className="flex-1 px-6"
+        contentContainerClassName="gap-6 pt-4 pb-8"
+        showsVerticalScrollIndicator={false}
+      >
+        <Animated.View layout={LinearTransition}>
+          {isLoading || !org ? (
+            <Animated.View exiting={FadeOut.duration(150)}>
+              <InfoCardSkeleton />
+            </Animated.View>
+          ) : (
+            <Animated.View entering={FadeIn.duration(200)} className="rounded-lg bg-secondary px-3">
+              <View className="flex-row items-center justify-between border-b-[0.5px] border-hair-soft py-3">
+                <Text className="flex-1 pr-3 text-sm font-medium text-foreground" numberOfLines={1}>
+                  {org.organizationName}
+                </Text>
+                {role === 'owner' && (
+                  <Pressable
+                    onPress={() => {
+                      setRenameVisible(true);
+                    }}
+                    hitSlop={12}
+                    accessibilityRole="button"
+                    accessibilityLabel="Rename organization"
+                    className="active:opacity-70"
+                  >
+                    <Pencil size={16} color={colors.mutedForeground} />
+                  </Pressable>
+                )}
+              </View>
+              {showMoney && <KvRow label="Balance" value={`$${org.balance.toFixed(2)}`} />}
+              <KvRow label="Seats" value={`${org.seatCount.used} / ${org.seatCount.total}`} last />
+            </Animated.View>
+          )}
+        </Animated.View>
+
+        <OrgUsageStats organizationId={organizationId} />
+
+        <View className="rounded-lg bg-secondary px-3">
+          <ConfigureRow
+            icon={Users}
+            title="Members"
+            last={!showMoney}
+            onPress={() => {
+              router.push('/(app)/(tabs)/(3_profile)/organization/members' as Href);
+            }}
+          />
+          {showMoney && (
+            <>
+              <ConfigureRow
+                icon={Receipt}
+                title="Credit activity"
+                onPress={() => {
+                  router.push('/(app)/(tabs)/(3_profile)/organization/credit-activity' as Href);
+                }}
+              />
+              <ConfigureRow
+                icon={FileText}
+                title="Invoices"
+                onPress={() => {
+                  router.push('/(app)/(tabs)/(3_profile)/organization/invoices' as Href);
+                }}
+              />
+              <ConfigureRow
+                icon={Bell}
+                title="Low balance alert"
+                subtitle={lowBalanceSubtitle}
+                last
+                onPress={() => {
+                  router.push('/(app)/(tabs)/(3_profile)/organization/low-balance-alert' as Href);
+                }}
+              />
+            </>
+          )}
+        </View>
+      </ScrollView>
+
+      {renameVisible && org && (
+        <RenameOrgModal
+          defaultName={org.organizationName}
+          onSubmit={name => {
+            mutations.rename.mutate(
+              { name },
+              {
+                onSuccess: () => {
+                  void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+                },
+              }
+            );
+          }}
+          onClose={() => {
+            setRenameVisible(false);
+          }}
+        />
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/organization/hub-screen.tsx
+++ b/apps/mobile/src/components/organization/hub-screen.tsx
@@ -60,7 +60,7 @@ export function OrganizationHubScreen() {
                 <Text className="flex-1 pr-3 text-sm font-medium text-foreground" numberOfLines={1}>
                   {org.organizationName}
                 </Text>
-                {role === 'owner' && (
+                {showMoney && (
                   <Pressable
                     onPress={() => {
                       setRenameVisible(true);

--- a/apps/mobile/src/components/organization/hub-screen.tsx
+++ b/apps/mobile/src/components/organization/hub-screen.tsx
@@ -21,7 +21,6 @@ function InfoCardSkeleton() {
     <View className="gap-2.5 rounded-lg bg-secondary px-3 py-3">
       <Skeleton className="h-5 w-2/3 rounded-md" />
       <Skeleton className="h-5 w-1/3 rounded-md" />
-      <Skeleton className="h-5 w-1/3 rounded-md" />
     </View>
   );
 }
@@ -30,7 +29,7 @@ export function OrganizationHubScreen() {
   const router = useRouter();
   const colors = useThemeColors();
   const { organizationId, role, org, isLoading } = useOrgRole();
-  const orgWithMembers = useOrgWithMembers(organizationId ?? '');
+  const orgWithMembers = useOrgWithMembers(organizationId);
   const mutations = useOrganizationMutations(organizationId ?? '');
   const [renameVisible, setRenameVisible] = useState(false);
 

--- a/apps/mobile/src/components/organization/invite-member-sheet.tsx
+++ b/apps/mobile/src/components/organization/invite-member-sheet.tsx
@@ -101,6 +101,10 @@ export function InviteMemberSheet() {
         </View>
       )}
 
+      {mutations.invite.isError && (
+        <Text className="text-sm text-destructive">{mutations.invite.error.message}</Text>
+      )}
+
       <Button disabled={!canSubmit || mutations.invite.isPending} onPress={onSubmit}>
         {mutations.invite.isPending ? (
           <ActivityIndicator size="small" color={colors.primaryForeground} />

--- a/apps/mobile/src/components/organization/invite-member-sheet.tsx
+++ b/apps/mobile/src/components/organization/invite-member-sheet.tsx
@@ -10,9 +10,8 @@ import { Text } from '@/components/ui/text';
 import { useOrganizationMutations } from '@/lib/hooks/use-organization-mutations';
 import { type OrgRole, useOrgRole } from '@/lib/hooks/use-organization-queries';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
-import { cn } from '@/lib/utils';
+import { cn, EMAIL_PATTERN } from '@/lib/utils';
 
-const EMAIL_PATTERN = /.+@.+\..+/;
 const INVITABLE_ROLES: OrgRole[] = ['member', 'billing_manager', 'owner'];
 
 export function InviteMemberSheet() {

--- a/apps/mobile/src/components/organization/invite-member-sheet.tsx
+++ b/apps/mobile/src/components/organization/invite-member-sheet.tsx
@@ -1,0 +1,113 @@
+import * as Haptics from 'expo-haptics';
+import { useRouter } from 'expo-router';
+import { Check } from 'lucide-react-native';
+import { useRef, useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
+
+import { ROLE_LABEL } from '@/components/organization/member-row';
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { useOrganizationMutations } from '@/lib/hooks/use-organization-mutations';
+import { type OrgRole, useOrgRole } from '@/lib/hooks/use-organization-queries';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { cn } from '@/lib/utils';
+
+const EMAIL_PATTERN = /.+@.+\..+/;
+const INVITABLE_ROLES: OrgRole[] = ['member', 'billing_manager', 'owner'];
+
+export function InviteMemberSheet() {
+  const router = useRouter();
+  const colors = useThemeColors();
+  const { organizationId, role: myRole } = useOrgRole();
+  const mutations = useOrganizationMutations(organizationId ?? '');
+  const emailRef = useRef('');
+  const [canSubmit, setCanSubmit] = useState(false);
+  const isBillingManager = myRole === 'billing_manager';
+  const [role, setRole] = useState<OrgRole>('member');
+
+  const onSubmit = () => {
+    const email = emailRef.current.trim().toLowerCase();
+    if (!EMAIL_PATTERN.test(email)) {
+      return;
+    }
+    mutations.invite.mutate(
+      { email, role: isBillingManager ? 'member' : role },
+      {
+        onSuccess: () => {
+          void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+          router.back();
+        },
+      }
+    );
+  };
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background px-6"
+      contentContainerClassName="gap-6 pb-8 pt-4"
+      automaticallyAdjustKeyboardInsets
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text className="text-center text-lg font-semibold text-foreground">Invite member</Text>
+
+      <View className="gap-2">
+        <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
+          Email
+        </Text>
+        <TextInput
+          accessibilityLabel="Email"
+          className="h-11 rounded-lg bg-secondary px-3 text-sm leading-5 text-foreground"
+          placeholder="name@company.com"
+          placeholderTextColor={colors.mutedForeground}
+          keyboardType="email-address"
+          autoCapitalize="none"
+          autoCorrect={false}
+          autoFocus
+          onChangeText={value => {
+            emailRef.current = value;
+            setCanSubmit(EMAIL_PATTERN.test(value.trim()));
+          }}
+        />
+      </View>
+
+      {isBillingManager ? (
+        <Text variant="muted">Role: Member</Text>
+      ) : (
+        <View className="gap-2">
+          <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
+            Role
+          </Text>
+          <View className="overflow-hidden rounded-lg bg-secondary">
+            {INVITABLE_ROLES.map((value, index) => {
+              const selected = role === value;
+              return (
+                <Pressable
+                  key={value}
+                  className={cn(
+                    'min-h-11 flex-row items-center justify-between px-4 py-3 active:opacity-70',
+                    index < INVITABLE_ROLES.length - 1 && 'border-b-[0.5px] border-hair-soft'
+                  )}
+                  onPress={() => {
+                    setRole(value);
+                  }}
+                  accessibilityRole="radio"
+                  accessibilityState={{ selected }}
+                >
+                  <Text className="flex-1 text-sm">{ROLE_LABEL[value]}</Text>
+                  {selected && <Check size={16} color={colors.primary} />}
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+      )}
+
+      <Button disabled={!canSubmit || mutations.invite.isPending} onPress={onSubmit}>
+        {mutations.invite.isPending ? (
+          <ActivityIndicator size="small" color={colors.primaryForeground} />
+        ) : null}
+        <Text className="text-primary-foreground">Send invite</Text>
+      </Button>
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/components/organization/invited-member-row.tsx
+++ b/apps/mobile/src/components/organization/invited-member-row.tsx
@@ -4,8 +4,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Text } from '@/components/ui/text';
 import { useOrganizationMutations } from '@/lib/hooks/use-organization-mutations';
-import { type InvitedOrgMember, type OrgRole } from '@/lib/hooks/use-organization-queries';
+import { type InvitedOrgMember } from '@/lib/hooks/use-organization-queries';
 import { cn, parseTimestamp } from '@/lib/utils';
+
+import { ROLE_LABEL } from './member-row';
 
 type InvitedMemberRowProps = {
   invite: InvitedOrgMember;
@@ -14,12 +16,6 @@ type InvitedMemberRowProps = {
   organizationId: string;
   /** Suppress bottom divider on the last row of a group. */
   last?: boolean;
-};
-
-const ROLE_LABEL: Record<OrgRole, string> = {
-  owner: 'Owner',
-  member: 'Member',
-  billing_manager: 'Billing manager',
 };
 
 function inviteDateLabel(inviteDate: string | null): string | null {

--- a/apps/mobile/src/components/organization/invited-member-row.tsx
+++ b/apps/mobile/src/components/organization/invited-member-row.tsx
@@ -1,0 +1,114 @@
+import { useActionSheet } from '@expo/react-native-action-sheet';
+import { Alert, Pressable, Share, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Text } from '@/components/ui/text';
+import { useOrganizationMutations } from '@/lib/hooks/use-organization-mutations';
+import { type InvitedOrgMember, type OrgRole } from '@/lib/hooks/use-organization-queries';
+import { cn, parseTimestamp } from '@/lib/utils';
+
+type InvitedMemberRowProps = {
+  invite: InvitedOrgMember;
+  /** Caller is owner. */
+  canManage: boolean;
+  organizationId: string;
+  /** Suppress bottom divider on the last row of a group. */
+  last?: boolean;
+};
+
+const ROLE_LABEL: Record<OrgRole, string> = {
+  owner: 'Owner',
+  member: 'Member',
+  billing_manager: 'Billing manager',
+};
+
+function inviteDateLabel(inviteDate: string | null): string | null {
+  if (inviteDate == null) {
+    return null;
+  }
+  return `Invited ${parseTimestamp(inviteDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`;
+}
+
+export function InvitedMemberRow({
+  invite,
+  canManage,
+  organizationId,
+  last,
+}: Readonly<InvitedMemberRowProps>) {
+  const { bottom } = useSafeAreaInsets();
+  const { showActionSheetWithOptions } = useActionSheet();
+  const mutations = useOrganizationMutations(organizationId);
+  const dateLabel = inviteDateLabel(invite.inviteDate);
+
+  function confirmRevoke() {
+    Alert.alert('Revoke invitation', `Revoke the invitation sent to ${invite.email}?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Revoke',
+        style: 'destructive',
+        onPress: () => {
+          mutations.deleteInvite.mutate({ inviteId: invite.inviteId });
+        },
+      },
+    ]);
+  }
+
+  function openActions() {
+    const options = ['Share invite link', 'Revoke invitation', 'Cancel'];
+    showActionSheetWithOptions(
+      {
+        options,
+        cancelButtonIndex: 2,
+        destructiveButtonIndex: 1,
+        containerStyle: { paddingBottom: bottom },
+      },
+      index => {
+        if (index === 0) {
+          void Share.share({ message: invite.inviteUrl });
+        } else if (index === 1) {
+          confirmRevoke();
+        }
+      }
+    );
+  }
+
+  const inner = (
+    <View
+      className={cn(
+        'flex-row items-center justify-between gap-3 py-3',
+        !last && 'border-b-[0.5px] border-hair-soft'
+      )}
+    >
+      <View className="min-w-0 flex-1">
+        <Text className="text-sm font-medium text-foreground" numberOfLines={1}>
+          {invite.email}
+        </Text>
+        {dateLabel && (
+          <Text className="mt-0.5 text-xs text-muted-foreground" numberOfLines={1}>
+            {dateLabel}
+          </Text>
+        )}
+      </View>
+      <View className="rounded-full bg-muted px-2 py-0.5">
+        <Text className="text-[11px] font-medium text-muted-foreground">
+          {ROLE_LABEL[invite.role]}
+        </Text>
+      </View>
+    </View>
+  );
+
+  if (!canManage) {
+    return <View className="px-3">{inner}</View>;
+  }
+
+  return (
+    <Pressable
+      onPress={openActions}
+      accessibilityRole="button"
+      accessibilityLabel={`Manage invitation for ${invite.email}`}
+      className="px-3 active:opacity-70"
+    >
+      {inner}
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/organization/invoices-screen.tsx
+++ b/apps/mobile/src/components/organization/invoices-screen.tsx
@@ -1,0 +1,103 @@
+import { FileText } from 'lucide-react-native';
+import { FlatList, View } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+
+import { EmptyState } from '@/components/empty-state';
+import { ScreenHeader } from '@/components/screen-header';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Text } from '@/components/ui/text';
+import { type OrgInvoice, useOrgInvoices, useOrgRole } from '@/lib/hooks/use-organization-queries';
+import { cn, firstNonEmpty } from '@/lib/utils';
+
+const STATUS_META: Record<string, { label: string; pillClass: string; textClass: string }> = {
+  paid: { label: 'Paid', pillClass: 'bg-good', textClass: 'text-good-foreground' },
+  open: { label: 'Open', pillClass: 'bg-warn', textClass: 'text-warn-foreground' },
+  void: { label: 'Void', pillClass: 'bg-muted', textClass: 'text-muted-foreground' },
+};
+
+function statusMeta(status: string): { label: string; pillClass: string; textClass: string } {
+  return (
+    STATUS_META[status] ?? {
+      label: status.charAt(0).toUpperCase() + status.slice(1),
+      pillClass: 'bg-muted',
+      textClass: 'text-muted-foreground',
+    }
+  );
+}
+
+function InvoiceRowSkeleton() {
+  return (
+    <View className="gap-1.5 rounded-lg bg-secondary p-3">
+      <Skeleton className="h-4 w-40 rounded" />
+      <Skeleton className="h-3 w-24 rounded" />
+    </View>
+  );
+}
+
+function InvoiceRow({ invoice }: Readonly<{ invoice: OrgInvoice }>) {
+  const meta = statusMeta(invoice.status);
+  const title = firstNonEmpty(invoice.number, invoice.description, 'Invoice');
+
+  return (
+    <View className="gap-1 rounded-lg bg-secondary p-3">
+      <View className="flex-row items-center justify-between gap-3">
+        <Text className="flex-1 text-sm font-medium text-foreground" numberOfLines={1}>
+          {title}
+        </Text>
+        <Text className="text-sm font-medium text-foreground">
+          ${(invoice.amount_due / 100).toFixed(2)}
+        </Text>
+      </View>
+      <View className="flex-row items-center justify-between">
+        <Text className="text-xs text-muted-foreground">
+          {new Date(invoice.created * 1000).toLocaleDateString()}
+        </Text>
+        <View className={cn('rounded-full px-2 py-0.5', meta.pillClass)}>
+          <Text className={cn('text-[11px] font-medium', meta.textClass)}>{meta.label}</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function OrganizationInvoicesScreen() {
+  const { organizationId } = useOrgRole();
+  const query = useOrgInvoices(organizationId);
+
+  if (organizationId == null) {
+    return null;
+  }
+
+  const isLoading = query.isLoading || !query.data;
+  const invoices = query.data ?? [];
+
+  return (
+    <View className="flex-1 bg-background">
+      <ScreenHeader title="Invoices" />
+      {isLoading ? (
+        <Animated.View exiting={FadeOut.duration(150)} className="gap-3 px-6 pt-4">
+          <InvoiceRowSkeleton />
+          <InvoiceRowSkeleton />
+          <InvoiceRowSkeleton />
+        </Animated.View>
+      ) : (
+        <Animated.View entering={FadeIn.duration(200)} className="flex-1">
+          <FlatList
+            data={invoices}
+            keyExtractor={item => item.id}
+            renderItem={({ item }) => <InvoiceRow invoice={item} />}
+            contentContainerClassName="gap-3 px-6 pb-8 pt-4"
+            ListEmptyComponent={
+              <EmptyState
+                icon={FileText}
+                className="pt-16"
+                title="No invoices"
+                description="Invoices for this organization will show up here."
+              />
+            }
+          />
+        </Animated.View>
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/organization/low-balance-alert-sheet.tsx
+++ b/apps/mobile/src/components/organization/low-balance-alert-sheet.tsx
@@ -4,13 +4,17 @@ import { useRef, useState } from 'react';
 import { ActivityIndicator, ScrollView, Switch, TextInput, View } from 'react-native';
 
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
 import { useOrganizationMutations } from '@/lib/hooks/use-organization-mutations';
-import { useOrgRole, useOrgWithMembers } from '@/lib/hooks/use-organization-queries';
+import {
+  type OrgWithMembers,
+  useOrgRole,
+  useOrgWithMembers,
+} from '@/lib/hooks/use-organization-queries';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
-
-const EMAIL_PATTERN = /.+@.+\..+/;
+import { EMAIL_PATTERN } from '@/lib/utils';
 
 function parseThreshold(value: string): number | null {
   const trimmed = value.trim();
@@ -28,38 +32,46 @@ function parseEmails(value: string): string[] {
     .filter(email => email !== '');
 }
 
-export function LowBalanceAlertSheet() {
+type LowBalanceAlertFormProps = Readonly<{
+  organizationId: string | null;
+  settings: OrgWithMembers['settings'];
+}>;
+
+function LowBalanceAlertForm({ organizationId, settings }: LowBalanceAlertFormProps) {
   const router = useRouter();
   const colors = useThemeColors();
-  const { organizationId } = useOrgRole();
-  const orgWithMembers = useOrgWithMembers(organizationId);
   const mutations = useOrganizationMutations(organizationId ?? '');
   const { email: myEmail } = useCurrentUserId();
-  const settings = orgWithMembers.data?.settings;
 
-  const [enabled, setEnabled] = useState(settings?.minimum_balance !== undefined);
+  const [enabled, setEnabled] = useState(settings.minimum_balance !== undefined);
   const thresholdRef = useRef(
-    settings?.minimum_balance != null ? String(settings.minimum_balance) : ''
+    settings.minimum_balance != null ? String(settings.minimum_balance) : ''
   );
-  const emailsRef = useRef((settings?.minimum_balance_alert_email ?? []).join(', '));
-  const [canSave, setCanSave] = useState(
-    !enabled ||
+  const emailsRef = useRef((settings.minimum_balance_alert_email ?? []).join(', '));
+  const [canSave, setCanSave] = useState(() => {
+    const emails = parseEmails(emailsRef.current);
+    return (
+      !enabled ||
       (parseThreshold(thresholdRef.current) != null &&
-        parseEmails(emailsRef.current).some(email => EMAIL_PATTERN.test(email)))
-  );
+        emails.length > 0 &&
+        emails.every(email => EMAIL_PATTERN.test(email)))
+    );
+  });
 
   const revalidate = (nextEnabled: boolean, thresholdValue: string, emailsValue: string) => {
+    const emails = parseEmails(emailsValue);
     setCanSave(
       !nextEnabled ||
         (parseThreshold(thresholdValue) != null &&
-          parseEmails(emailsValue).some(email => EMAIL_PATTERN.test(email)))
+          emails.length > 0 &&
+          emails.every(email => EMAIL_PATTERN.test(email)))
     );
   };
 
   const onSave = () => {
     const threshold = parseThreshold(thresholdRef.current);
-    const emails = parseEmails(emailsRef.current).filter(email => EMAIL_PATTERN.test(email));
-    if (enabled && (threshold == null || emails.length === 0)) {
+    const emails = parseEmails(emailsRef.current);
+    if (enabled && (threshold == null || emails.length === 0 || !canSave)) {
       return;
     }
     mutations.updateMinimumBalanceAlert.mutate(
@@ -79,14 +91,7 @@ export function LowBalanceAlertSheet() {
   };
 
   return (
-    <ScrollView
-      className="flex-1 bg-background px-6"
-      contentContainerClassName="gap-6 pb-8 pt-4"
-      automaticallyAdjustKeyboardInsets
-      keyboardShouldPersistTaps="handled"
-    >
-      <Text className="text-center text-lg font-semibold text-foreground">Low balance alert</Text>
-
+    <>
       <View className="flex-row items-center justify-between rounded-lg bg-secondary p-4">
         <Text className="text-sm font-medium">Enabled</Text>
         <Switch
@@ -151,6 +156,34 @@ export function LowBalanceAlertSheet() {
         ) : null}
         <Text className="text-primary-foreground">Save</Text>
       </Button>
+    </>
+  );
+}
+
+export function LowBalanceAlertSheet() {
+  const { organizationId } = useOrgRole();
+  const orgWithMembers = useOrgWithMembers(organizationId);
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background px-6"
+      contentContainerClassName="gap-6 pb-8 pt-4"
+      automaticallyAdjustKeyboardInsets
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text className="text-center text-lg font-semibold text-foreground">Low balance alert</Text>
+
+      {orgWithMembers.data ? (
+        <LowBalanceAlertForm
+          organizationId={organizationId}
+          settings={orgWithMembers.data.settings}
+        />
+      ) : (
+        <>
+          <Skeleton className="h-[52px] rounded-lg" />
+          <Skeleton className="h-11 rounded-lg" />
+        </>
+      )}
     </ScrollView>
   );
 }

--- a/apps/mobile/src/components/organization/low-balance-alert-sheet.tsx
+++ b/apps/mobile/src/components/organization/low-balance-alert-sheet.tsx
@@ -1,0 +1,156 @@
+import * as Haptics from 'expo-haptics';
+import { useRouter } from 'expo-router';
+import { useRef, useState } from 'react';
+import { ActivityIndicator, ScrollView, Switch, TextInput, View } from 'react-native';
+
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
+import { useOrganizationMutations } from '@/lib/hooks/use-organization-mutations';
+import { useOrgRole, useOrgWithMembers } from '@/lib/hooks/use-organization-queries';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+
+const EMAIL_PATTERN = /.+@.+\..+/;
+
+function parseThreshold(value: string): number | null {
+  const trimmed = value.trim();
+  const parsed = Number(trimmed);
+  if (trimmed === '' || !Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}
+
+function parseEmails(value: string): string[] {
+  return value
+    .split(',')
+    .map(email => email.trim())
+    .filter(email => email !== '');
+}
+
+export function LowBalanceAlertSheet() {
+  const router = useRouter();
+  const colors = useThemeColors();
+  const { organizationId } = useOrgRole();
+  const orgWithMembers = useOrgWithMembers(organizationId);
+  const mutations = useOrganizationMutations(organizationId ?? '');
+  const { email: myEmail } = useCurrentUserId();
+  const settings = orgWithMembers.data?.settings;
+
+  const [enabled, setEnabled] = useState(settings?.minimum_balance !== undefined);
+  const thresholdRef = useRef(
+    settings?.minimum_balance != null ? String(settings.minimum_balance) : ''
+  );
+  const emailsRef = useRef((settings?.minimum_balance_alert_email ?? []).join(', '));
+  const [canSave, setCanSave] = useState(
+    !enabled ||
+      (parseThreshold(thresholdRef.current) != null &&
+        parseEmails(emailsRef.current).some(email => EMAIL_PATTERN.test(email)))
+  );
+
+  const revalidate = (nextEnabled: boolean, thresholdValue: string, emailsValue: string) => {
+    setCanSave(
+      !nextEnabled ||
+        (parseThreshold(thresholdValue) != null &&
+          parseEmails(emailsValue).some(email => EMAIL_PATTERN.test(email)))
+    );
+  };
+
+  const onSave = () => {
+    const threshold = parseThreshold(thresholdRef.current);
+    const emails = parseEmails(emailsRef.current).filter(email => EMAIL_PATTERN.test(email));
+    if (enabled && (threshold == null || emails.length === 0)) {
+      return;
+    }
+    mutations.updateMinimumBalanceAlert.mutate(
+      {
+        enabled,
+        ...(enabled && threshold != null
+          ? { minimum_balance: threshold, minimum_balance_alert_email: emails }
+          : {}),
+      },
+      {
+        onSuccess: () => {
+          void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+          router.back();
+        },
+      }
+    );
+  };
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background px-6"
+      contentContainerClassName="gap-6 pb-8 pt-4"
+      automaticallyAdjustKeyboardInsets
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text className="text-center text-lg font-semibold text-foreground">Low balance alert</Text>
+
+      <View className="flex-row items-center justify-between rounded-lg bg-secondary p-4">
+        <Text className="text-sm font-medium">Enabled</Text>
+        <Switch
+          accessibilityLabel="Enable low balance alert"
+          value={enabled}
+          onValueChange={value => {
+            void Haptics.selectionAsync();
+            setEnabled(value);
+            revalidate(value, thresholdRef.current, emailsRef.current);
+          }}
+        />
+      </View>
+
+      {enabled && (
+        <>
+          <View className="gap-2">
+            <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
+              Alert below (USD)
+            </Text>
+            <TextInput
+              accessibilityLabel="Alert threshold"
+              className="h-11 rounded-lg bg-secondary px-3 text-sm leading-5 text-foreground"
+              placeholder="10.00"
+              placeholderTextColor={colors.mutedForeground}
+              keyboardType="decimal-pad"
+              defaultValue={thresholdRef.current || undefined}
+              onChangeText={value => {
+                thresholdRef.current = value;
+                revalidate(enabled, value, emailsRef.current);
+              }}
+            />
+          </View>
+
+          <View className="gap-2">
+            <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
+              Notify emails
+            </Text>
+            <TextInput
+              accessibilityLabel="Notify emails"
+              className="h-11 rounded-lg bg-secondary px-3 text-sm leading-5 text-foreground"
+              placeholder={myEmail ?? 'name@company.com'}
+              placeholderTextColor={colors.mutedForeground}
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              defaultValue={emailsRef.current || undefined}
+              onChangeText={value => {
+                emailsRef.current = value;
+                revalidate(enabled, thresholdRef.current, value);
+              }}
+            />
+            <Text variant="muted" className="text-xs">
+              Separate multiple emails with commas.
+            </Text>
+          </View>
+        </>
+      )}
+
+      <Button disabled={!canSave || mutations.updateMinimumBalanceAlert.isPending} onPress={onSave}>
+        {mutations.updateMinimumBalanceAlert.isPending ? (
+          <ActivityIndicator size="small" color={colors.primaryForeground} />
+        ) : null}
+        <Text className="text-primary-foreground">Save</Text>
+      </Button>
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/components/organization/low-balance-alert-sheet.tsx
+++ b/apps/mobile/src/components/organization/low-balance-alert-sheet.tsx
@@ -150,6 +150,12 @@ function LowBalanceAlertForm({ organizationId, settings }: LowBalanceAlertFormPr
         </>
       )}
 
+      {mutations.updateMinimumBalanceAlert.isError && (
+        <Text className="text-sm text-destructive">
+          {mutations.updateMinimumBalanceAlert.error.message}
+        </Text>
+      )}
+
       <Button disabled={!canSave || mutations.updateMinimumBalanceAlert.isPending} onPress={onSave}>
         {mutations.updateMinimumBalanceAlert.isPending ? (
           <ActivityIndicator size="small" color={colors.primaryForeground} />

--- a/apps/mobile/src/components/organization/member-limit-sheet.tsx
+++ b/apps/mobile/src/components/organization/member-limit-sheet.tsx
@@ -1,0 +1,120 @@
+import * as Haptics from 'expo-haptics';
+import { useRouter } from 'expo-router';
+import { useRef, useState } from 'react';
+import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
+
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { useOrganizationMutations } from '@/lib/hooks/use-organization-mutations';
+import {
+  type ActiveOrgMember,
+  useOrgRole,
+  useOrgWithMembers,
+} from '@/lib/hooks/use-organization-queries';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { firstNonEmpty } from '@/lib/utils';
+
+const MAX_DAILY_LIMIT_USD = 2000;
+
+function parseLimit(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > MAX_DAILY_LIMIT_USD) {
+    return null;
+  }
+  return parsed;
+}
+
+function isValidLimit(value: string): boolean {
+  return parseLimit(value) != null;
+}
+
+export function MemberLimitSheet({ memberId }: Readonly<{ memberId: string }>) {
+  const router = useRouter();
+  const colors = useThemeColors();
+  const { organizationId } = useOrgRole();
+  const orgWithMembers = useOrgWithMembers(organizationId);
+  const mutations = useOrganizationMutations(organizationId ?? '');
+  const member = orgWithMembers.data?.members.find(
+    (m): m is ActiveOrgMember => m.status === 'active' && m.id === memberId
+  );
+  const currentLimit = member?.dailyUsageLimitUsd ?? null;
+
+  const limitRef = useRef(currentLimit != null ? String(currentLimit) : '');
+  const [canSave, setCanSave] = useState(isValidLimit(limitRef.current));
+
+  const onSaved = () => {
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    router.back();
+  };
+
+  const onSave = () => {
+    const parsed = parseLimit(limitRef.current);
+    if (parsed == null) {
+      return;
+    }
+    mutations.updateMember.mutate({ memberId, dailyUsageLimitUsd: parsed }, { onSuccess: onSaved });
+  };
+
+  const onRemove = () => {
+    mutations.updateMember.mutate({ memberId, dailyUsageLimitUsd: null }, { onSuccess: onSaved });
+  };
+
+  if (!member) {
+    return <ScrollView className="flex-1 bg-background" />;
+  }
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background px-6"
+      contentContainerClassName="gap-6 pb-8 pt-4"
+      automaticallyAdjustKeyboardInsets
+      keyboardShouldPersistTaps="handled"
+    >
+      <View className="gap-1">
+        <Text className="text-center text-lg font-semibold text-foreground">Daily usage limit</Text>
+        <Text className="text-center text-sm text-muted-foreground" numberOfLines={1}>
+          {firstNonEmpty(member.name, member.email)}
+        </Text>
+      </View>
+
+      <View className="gap-2">
+        <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
+          Limit (USD per day)
+        </Text>
+        <TextInput
+          accessibilityLabel="Daily usage limit"
+          className="h-11 rounded-lg bg-secondary px-3 text-sm leading-5 text-foreground"
+          placeholder="No limit"
+          placeholderTextColor={colors.mutedForeground}
+          keyboardType="decimal-pad"
+          defaultValue={currentLimit != null ? String(currentLimit) : undefined}
+          onChangeText={value => {
+            limitRef.current = value;
+            setCanSave(isValidLimit(value));
+          }}
+        />
+      </View>
+
+      <Button disabled={!canSave || mutations.updateMember.isPending} onPress={onSave}>
+        {mutations.updateMember.isPending ? (
+          <ActivityIndicator size="small" color={colors.primaryForeground} />
+        ) : null}
+        <Text className="text-primary-foreground">Save</Text>
+      </Button>
+
+      {currentLimit != null && (
+        <Button
+          variant="destructive"
+          disabled={mutations.updateMember.isPending}
+          onPress={onRemove}
+        >
+          <Text className="text-destructive-foreground">Remove limit</Text>
+        </Button>
+      )}
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/components/organization/member-limit-sheet.tsx
+++ b/apps/mobile/src/components/organization/member-limit-sheet.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
 
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { useOrganizationMutations } from '@/lib/hooks/use-organization-mutations';
 import {
@@ -63,8 +64,26 @@ export function MemberLimitSheet({ memberId }: Readonly<{ memberId: string }>) {
     mutations.updateMember.mutate({ memberId, dailyUsageLimitUsd: null }, { onSuccess: onSaved });
   };
 
+  if (orgWithMembers.isLoading) {
+    return (
+      <ScrollView className="flex-1 bg-background px-6" contentContainerClassName="gap-6 pb-8 pt-4">
+        <View className="gap-1">
+          <Text className="text-center text-lg font-semibold text-foreground">
+            Daily usage limit
+          </Text>
+        </View>
+        <Skeleton className="h-11 rounded-lg" />
+      </ScrollView>
+    );
+  }
+
   if (!member) {
-    return <ScrollView className="flex-1 bg-background" />;
+    return (
+      <ScrollView className="flex-1 bg-background px-6" contentContainerClassName="gap-6 pb-8 pt-4">
+        <Text className="text-center text-lg font-semibold text-foreground">Daily usage limit</Text>
+        <Text className="text-center text-sm text-muted-foreground">Member not found</Text>
+      </ScrollView>
+    );
   }
 
   return (

--- a/apps/mobile/src/components/organization/member-limit-sheet.tsx
+++ b/apps/mobile/src/components/organization/member-limit-sheet.tsx
@@ -33,16 +33,17 @@ function isValidLimit(value: string): boolean {
   return parseLimit(value) != null;
 }
 
-export function MemberLimitSheet({ memberId }: Readonly<{ memberId: string }>) {
+type MemberLimitFormProps = Readonly<{
+  memberId: string;
+  organizationId: string | null;
+  member: ActiveOrgMember;
+}>;
+
+function MemberLimitForm({ memberId, organizationId, member }: MemberLimitFormProps) {
   const router = useRouter();
   const colors = useThemeColors();
-  const { organizationId } = useOrgRole();
-  const orgWithMembers = useOrgWithMembers(organizationId);
   const mutations = useOrganizationMutations(organizationId ?? '');
-  const member = orgWithMembers.data?.members.find(
-    (m): m is ActiveOrgMember => m.status === 'active' && m.id === memberId
-  );
-  const currentLimit = member?.dailyUsageLimitUsd ?? null;
+  const currentLimit = member.dailyUsageLimitUsd;
 
   const limitRef = useRef(currentLimit != null ? String(currentLimit) : '');
   const [canSave, setCanSave] = useState(isValidLimit(limitRef.current));
@@ -64,42 +65,8 @@ export function MemberLimitSheet({ memberId }: Readonly<{ memberId: string }>) {
     mutations.updateMember.mutate({ memberId, dailyUsageLimitUsd: null }, { onSuccess: onSaved });
   };
 
-  if (orgWithMembers.isLoading) {
-    return (
-      <ScrollView className="flex-1 bg-background px-6" contentContainerClassName="gap-6 pb-8 pt-4">
-        <View className="gap-1">
-          <Text className="text-center text-lg font-semibold text-foreground">
-            Daily usage limit
-          </Text>
-        </View>
-        <Skeleton className="h-11 rounded-lg" />
-      </ScrollView>
-    );
-  }
-
-  if (!member) {
-    return (
-      <ScrollView className="flex-1 bg-background px-6" contentContainerClassName="gap-6 pb-8 pt-4">
-        <Text className="text-center text-lg font-semibold text-foreground">Daily usage limit</Text>
-        <Text className="text-center text-sm text-muted-foreground">Member not found</Text>
-      </ScrollView>
-    );
-  }
-
   return (
-    <ScrollView
-      className="flex-1 bg-background px-6"
-      contentContainerClassName="gap-6 pb-8 pt-4"
-      automaticallyAdjustKeyboardInsets
-      keyboardShouldPersistTaps="handled"
-    >
-      <View className="gap-1">
-        <Text className="text-center text-lg font-semibold text-foreground">Daily usage limit</Text>
-        <Text className="text-center text-sm text-muted-foreground" numberOfLines={1}>
-          {firstNonEmpty(member.name, member.email)}
-        </Text>
-      </View>
-
+    <>
       <View className="gap-2">
         <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
           Limit (USD per day)
@@ -138,6 +105,54 @@ export function MemberLimitSheet({ memberId }: Readonly<{ memberId: string }>) {
           <Text className="text-destructive-foreground">Remove limit</Text>
         </Button>
       )}
+    </>
+  );
+}
+
+export function MemberLimitSheet({ memberId }: Readonly<{ memberId: string }>) {
+  const { organizationId } = useOrgRole();
+  const orgWithMembers = useOrgWithMembers(organizationId);
+  const member = orgWithMembers.data?.members.find(
+    (m): m is ActiveOrgMember => m.status === 'active' && m.id === memberId
+  );
+
+  if (orgWithMembers.isLoading) {
+    return (
+      <ScrollView className="flex-1 bg-background px-6" contentContainerClassName="gap-6 pb-8 pt-4">
+        <View className="gap-1">
+          <Text className="text-center text-lg font-semibold text-foreground">
+            Daily usage limit
+          </Text>
+        </View>
+        <Skeleton className="h-11 rounded-lg" />
+      </ScrollView>
+    );
+  }
+
+  if (!member) {
+    return (
+      <ScrollView className="flex-1 bg-background px-6" contentContainerClassName="gap-6 pb-8 pt-4">
+        <Text className="text-center text-lg font-semibold text-foreground">Daily usage limit</Text>
+        <Text className="text-center text-sm text-muted-foreground">Member not found</Text>
+      </ScrollView>
+    );
+  }
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background px-6"
+      contentContainerClassName="gap-6 pb-8 pt-4"
+      automaticallyAdjustKeyboardInsets
+      keyboardShouldPersistTaps="handled"
+    >
+      <View className="gap-1">
+        <Text className="text-center text-lg font-semibold text-foreground">Daily usage limit</Text>
+        <Text className="text-center text-sm text-muted-foreground" numberOfLines={1}>
+          {firstNonEmpty(member.name, member.email)}
+        </Text>
+      </View>
+
+      <MemberLimitForm memberId={memberId} organizationId={organizationId} member={member} />
     </ScrollView>
   );
 }

--- a/apps/mobile/src/components/organization/member-limit-sheet.tsx
+++ b/apps/mobile/src/components/organization/member-limit-sheet.tsx
@@ -118,6 +118,10 @@ export function MemberLimitSheet({ memberId }: Readonly<{ memberId: string }>) {
         />
       </View>
 
+      {mutations.updateMember.isError && (
+        <Text className="text-sm text-destructive">{mutations.updateMember.error.message}</Text>
+      )}
+
       <Button disabled={!canSave || mutations.updateMember.isPending} onPress={onSave}>
         {mutations.updateMember.isPending ? (
           <ActivityIndicator size="small" color={colors.primaryForeground} />

--- a/apps/mobile/src/components/organization/member-row.tsx
+++ b/apps/mobile/src/components/organization/member-row.tsx
@@ -19,7 +19,7 @@ type MemberRowProps = {
   last?: boolean;
 };
 
-const ROLE_LABEL: Record<OrgRole, string> = {
+export const ROLE_LABEL: Record<OrgRole, string> = {
   owner: 'Owner',
   member: 'Member',
   billing_manager: 'Billing manager',

--- a/apps/mobile/src/components/organization/member-row.tsx
+++ b/apps/mobile/src/components/organization/member-row.tsx
@@ -1,0 +1,161 @@
+import { useActionSheet } from '@expo/react-native-action-sheet';
+import * as Haptics from 'expo-haptics';
+import { type Href, useRouter } from 'expo-router';
+import { Alert, Pressable, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Text } from '@/components/ui/text';
+import { useOrganizationMutations } from '@/lib/hooks/use-organization-mutations';
+import { type ActiveOrgMember, type OrgRole } from '@/lib/hooks/use-organization-queries';
+import { cn, firstNonEmpty } from '@/lib/utils';
+
+type MemberRowProps = {
+  member: ActiveOrgMember;
+  /** Caller is owner and this isn't their own row. */
+  canManage: boolean;
+  enableUsageLimits: boolean;
+  organizationId: string;
+  /** Suppress bottom divider on the last row of a group. */
+  last?: boolean;
+};
+
+const ROLE_LABEL: Record<OrgRole, string> = {
+  owner: 'Owner',
+  member: 'Member',
+  billing_manager: 'Billing manager',
+};
+
+const ROLE_OPTIONS: OrgRole[] = ['owner', 'member', 'billing_manager'];
+
+export function MemberRow({
+  member,
+  canManage,
+  enableUsageLimits,
+  organizationId,
+  last,
+}: Readonly<MemberRowProps>) {
+  const router = useRouter();
+  const { bottom } = useSafeAreaInsets();
+  const { showActionSheetWithOptions } = useActionSheet();
+  const mutations = useOrganizationMutations(organizationId);
+  const displayName = firstNonEmpty(member.name, member.email);
+
+  function openRoleSheet() {
+    const options = [...ROLE_OPTIONS.map(role => ROLE_LABEL[role]), 'Cancel'];
+    showActionSheetWithOptions(
+      {
+        options,
+        cancelButtonIndex: options.length - 1,
+        containerStyle: { paddingBottom: bottom },
+      },
+      index => {
+        const role = index !== undefined ? ROLE_OPTIONS[index] : undefined;
+        if (!role) {
+          return;
+        }
+        mutations.updateMember.mutate(
+          { memberId: member.id, role },
+          {
+            onSuccess: () => {
+              void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+            },
+          }
+        );
+      }
+    );
+  }
+
+  function confirmRemove() {
+    Alert.alert('Remove member', `Remove ${displayName} from this organization?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Remove',
+        style: 'destructive',
+        onPress: () => {
+          mutations.removeMember.mutate(
+            { memberId: member.id },
+            {
+              onSuccess: () => {
+                void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+              },
+            }
+          );
+        },
+      },
+    ]);
+  }
+
+  function openActions() {
+    const options = [
+      'Change role',
+      ...(enableUsageLimits ? ['Set daily usage limit'] : []),
+      'Remove member',
+      'Cancel',
+    ];
+    showActionSheetWithOptions(
+      {
+        options,
+        cancelButtonIndex: options.length - 1,
+        destructiveButtonIndex: options.length - 2,
+        containerStyle: { paddingBottom: bottom },
+      },
+      index => {
+        const label = index !== undefined ? options[index] : undefined;
+        if (label === 'Change role') {
+          openRoleSheet();
+        } else if (label === 'Set daily usage limit') {
+          router.push(
+            `/(app)/(tabs)/(3_profile)/organization/member-limit?memberId=${member.id}` as Href
+          );
+        } else if (label === 'Remove member') {
+          confirmRemove();
+        }
+      }
+    );
+  }
+
+  const inner = (
+    <View
+      className={cn(
+        'flex-row items-center justify-between gap-3 py-3',
+        !last && 'border-b-[0.5px] border-hair-soft'
+      )}
+    >
+      <View className="min-w-0 flex-1">
+        <Text className="text-sm font-medium text-foreground" numberOfLines={1}>
+          {displayName}
+        </Text>
+        <Text className="mt-0.5 text-xs text-muted-foreground" numberOfLines={1}>
+          {member.email}
+        </Text>
+      </View>
+      <View className="items-end gap-1">
+        <View className="rounded-full bg-muted px-2 py-0.5">
+          <Text className="text-[11px] font-medium text-muted-foreground">
+            {ROLE_LABEL[member.role]}
+          </Text>
+        </View>
+        {member.dailyUsageLimitUsd != null && (
+          <Text className="text-xs text-muted-foreground">
+            ${member.dailyUsageLimitUsd.toFixed(2)}/day
+          </Text>
+        )}
+      </View>
+    </View>
+  );
+
+  if (!canManage) {
+    return <View className="px-3">{inner}</View>;
+  }
+
+  return (
+    <Pressable
+      onPress={openActions}
+      accessibilityRole="button"
+      accessibilityLabel={`Manage ${displayName}`}
+      className="px-3 active:opacity-70"
+    >
+      {inner}
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/organization/members-screen.tsx
+++ b/apps/mobile/src/components/organization/members-screen.tsx
@@ -1,0 +1,148 @@
+import { type Href, useRouter } from 'expo-router';
+import { UserPlus } from 'lucide-react-native';
+import { Pressable, ScrollView, View } from 'react-native';
+import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
+
+import { InvitedMemberRow } from '@/components/organization/invited-member-row';
+import { MemberRow } from '@/components/organization/member-row';
+import { ScreenHeader } from '@/components/screen-header';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Text } from '@/components/ui/text';
+import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
+import {
+  type ActiveOrgMember,
+  type InvitedOrgMember,
+  isMoneyRole,
+  useOrgRole,
+  useOrgWithMembers,
+} from '@/lib/hooks/use-organization-queries';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { firstNonEmpty, parseTimestamp } from '@/lib/utils';
+
+function sortActiveMembers(members: ActiveOrgMember[]): ActiveOrgMember[] {
+  // eslint-disable-next-line unicorn/no-array-sort -- toSorted() is not available in Hermes
+  return [...members].sort((a, b) =>
+    firstNonEmpty(a.name, a.email).localeCompare(firstNonEmpty(b.name, b.email))
+  );
+}
+
+function sortInvitedMembers(invites: InvitedOrgMember[]): InvitedOrgMember[] {
+  // eslint-disable-next-line unicorn/no-array-sort -- toSorted() is not available in Hermes
+  return [...invites].sort((a, b) => {
+    if (a.inviteDate == null) {
+      return b.inviteDate == null ? 0 : 1;
+    }
+    if (b.inviteDate == null) {
+      return -1;
+    }
+    return parseTimestamp(b.inviteDate).getTime() - parseTimestamp(a.inviteDate).getTime();
+  });
+}
+
+function MemberRowSkeleton({ last }: Readonly<{ last?: boolean }>) {
+  return (
+    <View className={!last ? 'border-b-[0.5px] border-hair-soft' : undefined}>
+      <View className="gap-1.5 px-3 py-3">
+        <Skeleton className="h-4 w-32 rounded" />
+        <Skeleton className="h-3 w-44 rounded" />
+      </View>
+    </View>
+  );
+}
+
+export function OrganizationMembersScreen() {
+  const router = useRouter();
+  const colors = useThemeColors();
+  const { organizationId, role } = useOrgRole();
+  const orgWithMembers = useOrgWithMembers(organizationId);
+  const { userId: currentUserId } = useCurrentUserId();
+
+  if (organizationId == null) {
+    return null;
+  }
+
+  const isLoading = orgWithMembers.isLoading || !orgWithMembers.data;
+  const enableUsageLimits = orgWithMembers.data?.settings.enable_usage_limits !== false;
+  const canInvite = isMoneyRole(role);
+  const isOwner = role === 'owner';
+
+  const activeMembers = sortActiveMembers(
+    orgWithMembers.data?.members.filter(m => m.status === 'active') ?? []
+  );
+  const invitedMembers = sortInvitedMembers(
+    orgWithMembers.data?.members.filter(m => m.status === 'invited') ?? []
+  );
+
+  return (
+    <View className="flex-1 bg-background">
+      <ScreenHeader
+        title="Members"
+        headerRight={
+          canInvite ? (
+            <Pressable
+              onPress={() => {
+                router.push('/(app)/(tabs)/(3_profile)/organization/invite-member' as Href);
+              }}
+              hitSlop={12}
+              accessibilityRole="button"
+              accessibilityLabel="Invite member"
+              className="active:opacity-70"
+            >
+              <UserPlus size={22} color={colors.foreground} />
+            </Pressable>
+          ) : undefined
+        }
+      />
+      <ScrollView
+        className="flex-1 px-6"
+        contentContainerClassName="gap-6 pt-4 pb-8"
+        showsVerticalScrollIndicator={false}
+      >
+        <Animated.View layout={LinearTransition} className="gap-2">
+          <Text variant="eyebrow">Members</Text>
+          {isLoading ? (
+            <Animated.View exiting={FadeOut.duration(150)} className="rounded-lg bg-secondary">
+              <MemberRowSkeleton />
+              <MemberRowSkeleton />
+              <MemberRowSkeleton last />
+            </Animated.View>
+          ) : (
+            <Animated.View entering={FadeIn.duration(200)} className="rounded-lg bg-secondary">
+              {activeMembers.map((member, index) => (
+                <MemberRow
+                  key={member.id}
+                  member={member}
+                  canManage={isOwner && member.id !== currentUserId}
+                  enableUsageLimits={enableUsageLimits}
+                  organizationId={organizationId}
+                  last={index === activeMembers.length - 1}
+                />
+              ))}
+            </Animated.View>
+          )}
+        </Animated.View>
+
+        {!isLoading && invitedMembers.length > 0 && (
+          <Animated.View
+            entering={FadeIn.duration(200)}
+            layout={LinearTransition}
+            className="gap-2"
+          >
+            <Text variant="eyebrow">Pending invitations</Text>
+            <View className="rounded-lg bg-secondary">
+              {invitedMembers.map((invite, index) => (
+                <InvitedMemberRow
+                  key={invite.inviteId}
+                  invite={invite}
+                  canManage={isOwner}
+                  organizationId={organizationId}
+                  last={index === invitedMembers.length - 1}
+                />
+              ))}
+            </View>
+          </Animated.View>
+        )}
+      </ScrollView>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/organization/org-usage-stats.tsx
+++ b/apps/mobile/src/components/organization/org-usage-stats.tsx
@@ -1,0 +1,64 @@
+import { View } from 'react-native';
+import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { Text } from '@/components/ui/text';
+import { useOrgUsageStats } from '@/lib/hooks/use-organization-queries';
+
+function StatTile({ label, value }: Readonly<{ label: string; value: string }>) {
+  return (
+    <View className="flex-1 gap-1 rounded-lg bg-secondary px-3 py-3">
+      <Text className="text-lg font-bold text-foreground">{value}</Text>
+      <Text className="text-xs text-muted-foreground">{label}</Text>
+    </View>
+  );
+}
+
+function StatTileSkeleton() {
+  return (
+    <View className="flex-1 gap-1 rounded-lg bg-secondary px-3 py-3">
+      <Skeleton className="h-[22px] w-16 rounded-md" />
+      <Skeleton className="h-4 w-20 rounded-md" />
+    </View>
+  );
+}
+
+type OrgUsageStatsProps = {
+  organizationId: string;
+};
+
+/** "Last 30 days" eyebrow + 2x2 usage stat tile grid. Visible to all org roles. */
+export function OrgUsageStats({ organizationId }: Readonly<OrgUsageStatsProps>) {
+  const { data, isLoading } = useOrgUsageStats(organizationId);
+
+  return (
+    <Animated.View layout={LinearTransition} className="gap-3">
+      <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
+        Last 30 days
+      </Text>
+      {isLoading || !data ? (
+        <Animated.View exiting={FadeOut.duration(150)} className="gap-3">
+          <View className="flex-row gap-3">
+            <StatTileSkeleton />
+            <StatTileSkeleton />
+          </View>
+          <View className="flex-row gap-3">
+            <StatTileSkeleton />
+            <StatTileSkeleton />
+          </View>
+        </Animated.View>
+      ) : (
+        <Animated.View entering={FadeIn.duration(200)} className="gap-3">
+          <View className="flex-row gap-3">
+            <StatTile label="Cost" value={`$${(data.totalCost / 1_000_000).toFixed(2)}`} />
+            <StatTile label="Requests" value={data.totalRequestCount.toLocaleString()} />
+          </View>
+          <View className="flex-row gap-3">
+            <StatTile label="Input Tokens" value={data.totalInputTokens.toLocaleString()} />
+            <StatTile label="Output Tokens" value={data.totalOutputTokens.toLocaleString()} />
+          </View>
+        </Animated.View>
+      )}
+    </Animated.View>
+  );
+}

--- a/apps/mobile/src/components/organization/rename-org-modal.tsx
+++ b/apps/mobile/src/components/organization/rename-org-modal.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react';
+import { Modal, Platform, Pressable, TextInput, View } from 'react-native';
+
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+
+type RenameOrgModalProps = {
+  defaultName: string;
+  onSubmit: (name: string) => void;
+  onClose: () => void;
+};
+
+export function RenameOrgModal({ defaultName, onSubmit, onClose }: Readonly<RenameOrgModalProps>) {
+  const colors = useThemeColors();
+  const nameRef = useRef(defaultName);
+  const inputRef = useRef<TextInput>(null);
+
+  // autoFocus doesn't reliably raise the keyboard inside Modal on Android
+  useEffect(() => {
+    if (Platform.OS !== 'android') {
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      inputRef.current?.focus();
+    }, 100);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable className="flex-1 justify-start px-6 pt-[25%]" onPress={onClose}>
+        <View className="absolute inset-0 bg-black opacity-50" />
+        <Pressable
+          className="rounded-xl bg-card p-5 gap-4"
+          onPress={e => {
+            e.stopPropagation();
+          }}
+        >
+          <Text className="text-base font-semibold">Rename Organization</Text>
+          <TextInput
+            ref={inputRef}
+            className="rounded-md border border-input bg-background px-3 py-2.5 text-sm leading-5 text-foreground"
+            placeholder="Enter organization name"
+            placeholderTextColor={colors.mutedForeground}
+            defaultValue={defaultName}
+            onChangeText={val => {
+              nameRef.current = val;
+            }}
+            autoFocus={Platform.OS !== 'android'}
+            maxLength={50}
+          />
+          <View className="flex-row justify-end gap-3">
+            <Button variant="outline" onPress={onClose}>
+              <Text>Cancel</Text>
+            </Button>
+            <Button
+              onPress={() => {
+                const trimmed = nameRef.current.trim();
+                if (trimmed) {
+                  onSubmit(trimmed);
+                }
+                onClose();
+              }}
+            >
+              <Text className="text-primary-foreground">Save</Text>
+            </Button>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/components/profile-action-tile.tsx
+++ b/apps/mobile/src/components/profile-action-tile.tsx
@@ -1,0 +1,35 @@
+import { Pressable } from 'react-native';
+
+import { Text } from '@/components/ui/text';
+
+export function ActionTile({
+  icon: Icon,
+  label,
+  color,
+  onPress,
+  destructive,
+  disabled,
+}: {
+  icon: React.ComponentType<{ size?: number; color?: string }>;
+  label: string;
+  color: string;
+  onPress: () => void;
+  destructive?: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <Pressable
+      className={`flex-1 items-center gap-2 rounded-lg bg-secondary py-4 active:opacity-70 ${disabled ? 'opacity-50' : ''}`}
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityLabel={label}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: Boolean(disabled) }}
+    >
+      <Icon size={20} color={color} />
+      <Text className={`text-sm ${destructive ? 'text-destructive' : 'text-muted-foreground'}`}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/profile-screen.tsx
+++ b/apps/mobile/src/components/profile-screen.tsx
@@ -182,7 +182,7 @@ export function ProfileScreen() {
             </Text>
             <ConfigureRow
               icon={Building2}
-              title={orgRole === 'member' ? 'View org' : 'Manage org'}
+              title={orgRole === 'member' ? 'View organization' : 'Manage organization'}
               subtitle={orgName}
               className="rounded-lg bg-secondary px-3"
               disabled={!orgRole}

--- a/apps/mobile/src/components/profile-screen.tsx
+++ b/apps/mobile/src/components/profile-screen.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import * as Application from 'expo-application';
 import { type Href, useRouter } from 'expo-router';
 import {
+  Building2,
   GitPullRequest,
   KeyRound,
   LifeBuoy,
@@ -17,6 +18,7 @@ import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanim
 
 import { RestorePurchasesButton } from '@/components/kilo-pass/restore-purchases-button';
 import { NotificationsCard } from '@/components/notifications-card';
+import { ActionTile } from '@/components/profile-action-tile';
 import { CreditsCard } from '@/components/profile-credits-card';
 import { ScreenHeader } from '@/components/screen-header';
 import { ConfigureRow } from '@/components/ui/configure-row';
@@ -35,38 +37,6 @@ const SUPPORT_EMAIL = 'hi@kilo.ai';
 
 function providerIcon(_provider: string) {
   return KeyRound;
-}
-
-function ActionTile({
-  icon: Icon,
-  label,
-  color,
-  onPress,
-  destructive,
-  disabled,
-}: {
-  icon: React.ComponentType<{ size?: number; color?: string }>;
-  label: string;
-  color: string;
-  onPress: () => void;
-  destructive?: boolean;
-  disabled?: boolean;
-}) {
-  return (
-    <Pressable
-      className={`flex-1 items-center gap-2 rounded-lg bg-secondary py-4 active:opacity-70 ${disabled ? 'opacity-50' : ''}`}
-      onPress={onPress}
-      disabled={disabled}
-      accessibilityLabel={label}
-      accessibilityRole="button"
-      accessibilityState={{ disabled: Boolean(disabled) }}
-    >
-      <Icon size={20} color={color} />
-      <Text className={`text-sm ${destructive ? 'text-destructive' : 'text-muted-foreground'}`}>
-        {label}
-      </Text>
-    </Pressable>
-  );
 }
 
 export function ProfileScreen() {
@@ -92,6 +62,9 @@ export function ProfileScreen() {
   const agentScope = organizationContextLoaded
     ? getProfileAgentScope(organizationId, orgs, organizationsFetching)
     : undefined;
+  const selectedOrg = orgs?.find(org => org.organizationId === organizationId);
+  const orgRole = selectedOrg?.role;
+  const orgName = selectedOrg?.organizationName;
 
   const { userId } = useCurrentUserId({ enabled: isAuthenticated });
 
@@ -200,6 +173,26 @@ export function ProfileScreen() {
             }}
           />
         </View>
+
+        {/* Organization */}
+        {organizationId != null && (
+          <View className="mt-6 gap-3">
+            <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
+              Organization
+            </Text>
+            <ConfigureRow
+              icon={Building2}
+              title={orgRole === 'member' ? 'View org' : 'Manage org'}
+              subtitle={orgName}
+              className="rounded-lg bg-secondary px-3"
+              disabled={!orgRole}
+              last
+              onPress={() => {
+                router.push('/(app)/(tabs)/(3_profile)/organization' as Href);
+              }}
+            />
+          </View>
+        )}
 
         {/* Linked accounts */}
         <Animated.View className="mt-6 gap-3" layout={LinearTransition}>

--- a/apps/mobile/src/lib/hooks/use-organization-mutations.ts
+++ b/apps/mobile/src/lib/hooks/use-organization-mutations.ts
@@ -1,0 +1,191 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner-native';
+
+import {
+  type OrgListEntry,
+  type OrgRole,
+  type OrgWithMembers,
+} from '@/lib/hooks/use-organization-queries';
+import { trpcClient, useTRPC } from '@/lib/trpc';
+
+const onMutationError = (error: { message: string }) => {
+  toast.error(error.message || 'Something went wrong');
+};
+
+export function useOrganizationMutations(organizationId: string) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const withMembersKey = trpc.organizations.withMembers.queryKey({ organizationId });
+  const listKey = trpc.organizations.list.queryKey();
+
+  const invalidateAll = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: withMembersKey }),
+      queryClient.invalidateQueries({ queryKey: listKey }),
+    ]);
+  };
+
+  const invalidateWithMembers = async () => {
+    await queryClient.invalidateQueries({ queryKey: withMembersKey });
+  };
+
+  // Every optimistic mutation here only touches the withMembers cache, so the
+  // key is fixed rather than threaded through like use-kiloclaw-mutations.ts
+  // (which juggles many caches across a personal/org split).
+  function optimistic<TInput>(updater: (old: OrgWithMembers, input: TInput) => OrgWithMembers) {
+    return {
+      onMutate: async (input: TInput) => {
+        await queryClient.cancelQueries({ queryKey: withMembersKey });
+        const previous = queryClient.getQueryData<OrgWithMembers>(withMembersKey);
+        queryClient.setQueryData<OrgWithMembers>(withMembersKey, old =>
+          old ? updater(old, input) : old
+        );
+        return { previous };
+      },
+      onError: (
+        error: { message: string },
+        _input: TInput,
+        context?: { previous?: OrgWithMembers }
+      ) => {
+        if (context?.previous) {
+          queryClient.setQueryData(withMembersKey, context.previous);
+        }
+        onMutationError(error);
+      },
+      onSettled: invalidateAll,
+    };
+  }
+
+  return {
+    rename: useMutation({
+      // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
+      mutationFn: (input: { name: string }) =>
+        trpcClient.organizations.update.mutate({ organizationId, name: input.name }),
+      onMutate: async (input: { name: string }) => {
+        await Promise.all([
+          queryClient.cancelQueries({ queryKey: withMembersKey }),
+          queryClient.cancelQueries({ queryKey: listKey }),
+        ]);
+        const previousWithMembers = queryClient.getQueryData<OrgWithMembers>(withMembersKey);
+        const previousList = queryClient.getQueryData<OrgListEntry[]>(listKey);
+        queryClient.setQueryData<OrgWithMembers>(withMembersKey, old =>
+          old ? { ...old, name: input.name } : old
+        );
+        queryClient.setQueryData<OrgListEntry[]>(listKey, old =>
+          old
+            ? old.map(entry =>
+                entry.organizationId === organizationId
+                  ? { ...entry, organizationName: input.name }
+                  : entry
+              )
+            : old
+        );
+        return { previousWithMembers, previousList };
+      },
+      onError: (
+        error: { message: string },
+        _input,
+        context?: { previousWithMembers?: OrgWithMembers; previousList?: OrgListEntry[] }
+      ) => {
+        if (context?.previousWithMembers) {
+          queryClient.setQueryData(withMembersKey, context.previousWithMembers);
+        }
+        if (context?.previousList) {
+          queryClient.setQueryData(listKey, context.previousList);
+        }
+        onMutationError(error);
+      },
+      onSettled: invalidateAll,
+    }),
+
+    invite: useMutation({
+      // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
+      mutationFn: (input: { email: string; role: OrgRole }) =>
+        trpcClient.organizations.members.invite.mutate({ organizationId, ...input }),
+      onSuccess: invalidateWithMembers,
+      onError: onMutationError,
+      onSettled: invalidateAll,
+    }),
+
+    updateMember: useMutation({
+      // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
+      mutationFn: (input: {
+        memberId: string;
+        role?: OrgRole;
+        dailyUsageLimitUsd?: number | null;
+      }) => trpcClient.organizations.members.update.mutate({ organizationId, ...input }),
+      ...optimistic<{ memberId: string; role?: OrgRole; dailyUsageLimitUsd?: number | null }>(
+        (old, input) => ({
+          ...old,
+          members: old.members.map(member =>
+            member.status === 'active' && member.id === input.memberId
+              ? {
+                  ...member,
+                  ...(input.role !== undefined && { role: input.role }),
+                  ...(input.dailyUsageLimitUsd !== undefined && {
+                    dailyUsageLimitUsd: input.dailyUsageLimitUsd,
+                  }),
+                }
+              : member
+          ),
+        })
+      ),
+    }),
+
+    removeMember: useMutation({
+      // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
+      mutationFn: (input: { memberId: string }) =>
+        trpcClient.organizations.members.remove.mutate({ organizationId, ...input }),
+      ...optimistic<{ memberId: string }>((old, input) => ({
+        ...old,
+        members: old.members.filter(
+          member => !(member.status === 'active' && member.id === input.memberId)
+        ),
+      })),
+    }),
+
+    deleteInvite: useMutation({
+      // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
+      mutationFn: (input: { inviteId: string }) =>
+        trpcClient.organizations.members.deleteInvite.mutate({ organizationId, ...input }),
+      ...optimistic<{ inviteId: string }>((old, input) => ({
+        ...old,
+        members: old.members.filter(
+          member => !(member.status === 'invited' && member.inviteId === input.inviteId)
+        ),
+      })),
+    }),
+
+    updateMinimumBalanceAlert: useMutation({
+      // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
+      mutationFn: (input: {
+        enabled: boolean;
+        minimum_balance?: number;
+        minimum_balance_alert_email?: string[];
+      }) =>
+        trpcClient.organizations.settings.updateMinimumBalanceAlert.mutate({
+          organizationId,
+          ...input,
+        }),
+      ...optimistic<{
+        enabled: boolean;
+        minimum_balance?: number;
+        minimum_balance_alert_email?: string[];
+      }>((old, input) => {
+        if (input.enabled) {
+          return {
+            ...old,
+            settings: {
+              ...old.settings,
+              minimum_balance: input.minimum_balance,
+              minimum_balance_alert_email: input.minimum_balance_alert_email,
+            },
+          };
+        }
+        const { minimum_balance: _mb, minimum_balance_alert_email: _mbae, ...rest } = old.settings;
+        return { ...old, settings: rest };
+      }),
+    }),
+  };
+}

--- a/apps/mobile/src/lib/hooks/use-organization-queries.ts
+++ b/apps/mobile/src/lib/hooks/use-organization-queries.ts
@@ -1,0 +1,60 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useAuth } from '@/lib/auth/auth-context';
+import { useOrganization } from '@/lib/organization-context';
+import { useTRPC } from '@/lib/trpc';
+
+/**
+ * The current user's role in the active organization. `trpc.organizations.list`
+ * requires auth (not an active org selection), so it's gated on the token
+ * rather than on `organizationId` — mirrors profile-screen's `orgs` query.
+ */
+export function useOrgRole() {
+  const trpc = useTRPC();
+  const { token } = useAuth();
+  const { organizationId } = useOrganization();
+  const { data: orgs, isLoading } = useQuery({
+    ...trpc.organizations.list.queryOptions(),
+    enabled: token != null,
+  });
+  const org = orgs?.find(entry => entry.organizationId === organizationId);
+  return { organizationId, role: org?.role, org, isLoading };
+}
+
+export type OrgListEntry = NonNullable<ReturnType<typeof useOrgRole>['org']>;
+export type OrgRole = OrgListEntry['role'];
+
+export function isMoneyRole(role: OrgRole | undefined): boolean {
+  return role === 'owner' || role === 'billing_manager';
+}
+
+export function useOrgWithMembers(organizationId: string) {
+  const trpc = useTRPC();
+  return useQuery(trpc.organizations.withMembers.queryOptions({ organizationId }));
+}
+
+export type OrgWithMembers = NonNullable<ReturnType<typeof useOrgWithMembers>['data']>;
+export type OrgMember = OrgWithMembers['members'][number];
+export type ActiveOrgMember = Extract<OrgMember, { status: 'active' }>;
+export type InvitedOrgMember = Extract<OrgMember, { status: 'invited' }>;
+
+export function useOrgUsageStats(organizationId: string) {
+  const trpc = useTRPC();
+  return useQuery(trpc.organizations.usageStats.queryOptions({ organizationId }));
+}
+
+export function useOrgCreditTransactions(organizationId: string) {
+  const trpc = useTRPC();
+  return useQuery(trpc.organizations.creditTransactions.queryOptions({ organizationId }));
+}
+
+export type CreditTransaction = NonNullable<
+  ReturnType<typeof useOrgCreditTransactions>['data']
+>[number];
+
+export function useOrgInvoices(organizationId: string) {
+  const trpc = useTRPC();
+  return useQuery(trpc.organizations.invoices.queryOptions({ organizationId, period: 'year' }));
+}
+
+export type OrgInvoice = NonNullable<ReturnType<typeof useOrgInvoices>['data']>[number];

--- a/apps/mobile/src/lib/hooks/use-organization-queries.ts
+++ b/apps/mobile/src/lib/hooks/use-organization-queries.ts
@@ -28,9 +28,14 @@ export function isMoneyRole(role: OrgRole | undefined): boolean {
   return role === 'owner' || role === 'billing_manager';
 }
 
-export function useOrgWithMembers(organizationId: string) {
+export function useOrgWithMembers(organizationId: string | null) {
   const trpc = useTRPC();
-  return useQuery(trpc.organizations.withMembers.queryOptions({ organizationId }));
+  return useQuery(
+    trpc.organizations.withMembers.queryOptions(
+      { organizationId: organizationId ?? '' },
+      { enabled: organizationId != null }
+    )
+  );
 }
 
 export type OrgWithMembers = NonNullable<ReturnType<typeof useOrgWithMembers>['data']>;
@@ -38,23 +43,38 @@ export type OrgMember = OrgWithMembers['members'][number];
 export type ActiveOrgMember = Extract<OrgMember, { status: 'active' }>;
 export type InvitedOrgMember = Extract<OrgMember, { status: 'invited' }>;
 
-export function useOrgUsageStats(organizationId: string) {
+export function useOrgUsageStats(organizationId: string | null) {
   const trpc = useTRPC();
-  return useQuery(trpc.organizations.usageStats.queryOptions({ organizationId }));
+  return useQuery(
+    trpc.organizations.usageStats.queryOptions(
+      { organizationId: organizationId ?? '' },
+      { enabled: organizationId != null }
+    )
+  );
 }
 
-export function useOrgCreditTransactions(organizationId: string) {
+export function useOrgCreditTransactions(organizationId: string | null) {
   const trpc = useTRPC();
-  return useQuery(trpc.organizations.creditTransactions.queryOptions({ organizationId }));
+  return useQuery(
+    trpc.organizations.creditTransactions.queryOptions(
+      { organizationId: organizationId ?? '' },
+      { enabled: organizationId != null }
+    )
+  );
 }
 
 export type CreditTransaction = NonNullable<
   ReturnType<typeof useOrgCreditTransactions>['data']
 >[number];
 
-export function useOrgInvoices(organizationId: string) {
+export function useOrgInvoices(organizationId: string | null) {
   const trpc = useTRPC();
-  return useQuery(trpc.organizations.invoices.queryOptions({ organizationId, period: 'year' }));
+  return useQuery(
+    trpc.organizations.invoices.queryOptions(
+      { organizationId: organizationId ?? '', period: 'year' },
+      { enabled: organizationId != null }
+    )
+  );
 }
 
 export type OrgInvoice = NonNullable<ReturnType<typeof useOrgInvoices>['data']>[number];

--- a/apps/mobile/src/lib/utils.ts
+++ b/apps/mobile/src/lib/utils.ts
@@ -5,6 +5,8 @@ function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+const EMAIL_PATTERN = /.+@.+\..+/;
+
 /**
  * Parse a Drizzle `mode: 'string'` timestamp into a Date.
  * Hermes can't parse PostgreSQL's default format (`2026-03-13 14:30:00+00`),
@@ -64,4 +66,4 @@ function firstNonEmpty(...values: (string | null | undefined)[]): string {
   return '';
 }
 
-export { asyncNoop, cn, firstNonEmpty, parseTimestamp, timeAgo };
+export { asyncNoop, cn, EMAIL_PATTERN, firstNonEmpty, parseTimestamp, timeAgo };


### PR DESCRIPTION
Adds role-gated organization management to the mobile app, reached from the profile screen when an org is selected: **Manage organization** (owner / billing manager) or **View organization** (member).

## What's included

**Hub screen** (`/organization`)
- Org info card: name (owner can rename, optimistic), balance + seats (owner/billing only), 30-day usage stats (all roles)
- Drill-in rows: Members (all roles); Credit activity, Invoices, Low balance alert (owner/billing only)

**Members screen**
- Active members + pending invitations, sorted, role badges, daily-limit hints
- Invite (owner: any role; billing manager: member only, no picker) via form sheet
- Owner-only member actions (never on own row): change role, set/clear daily usage limit (hidden when `enable_usage_limits === false`), remove member (destructive confirm)
- Pending invite actions (owner): share invite link via native share sheet, revoke

**Read-only money screens** (owner/billing): credit activity list, invoices list — deliberately no tap actions and zero Stripe surface (App Store review)

**Form sheets**: invite member / daily usage limit / low balance alert — native formSheet presentation, inline mutation error display (toasts render behind native sheets — see notes)

All operations call existing tRPC procedures (`organizations.*`); server enforces permissions, client gating is visibility only. Caller role derives from the already-cached `organizations.list`. No backend changes.

## Notable fixes found during e2e
- `organizations.list` `balance` is **microdollars** — was rendered as dollars
- sonner-native toasts render **behind** iOS formSheets, so mutation errors inside sheets were silent → sheets now render the error inline (the same latent issue exists in pre-existing security-agent sheets)
- Org-scoped query hooks gate on a resolved org id (no more empty-string queries while org context loads)

## Verification (local stack, iOS simulator, all three roles)
- **Owner**: rename (optimistic + DB), low-balance alert config (DB settings verified), invite with 3-role picker → pending invite → share sheet → revoke, role change Member↔Billing manager (UI + DB), daily limit set/remove (server round-trip), remove member (UI + DB), credit activity row, invoices empty state, self-row inert, invite-conflict error shown inline (server 409)
- **Billing manager**: balance visible, no rename pencil, invite locked to Member with no picker, member rows inert
- **Member**: "View organization", hub shows name/seats/usage/Members only (zero money UI), members list read-only, no invite button
- `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` all clean