### PR TITLE
fix(web): make auth layout responsive

### DIFF
--- a/apps/web/src/components/auth/AuthPageLayout.tsx
+++ b/apps/web/src/components/auth/AuthPageLayout.tsx
@@ -11,7 +11,7 @@ export function AuthPageLayout({ children }: AuthPageLayoutProps) {
         {/* Left Column - Content */}
         <main
           style={{ backgroundColor: '#0a0a0a' }}
-          className="flex min-h-screen w-3/5 shrink-0 flex-col items-center justify-center px-5 pt-32 pb-8"
+          className="flex min-h-screen w-full shrink-0 flex-col items-center justify-center px-5 pt-32 pb-8 xl:w-3/5"
         >
           {children}
         </main>


### PR DESCRIPTION
## Summary
- make the shared auth content pane full-width whenever the marketing pane is hidden
- preserve the existing 60/40 auth and marketing split at `xl` and above

## Root cause
The marketing aside was hidden below `xl`, but the auth pane kept `w-3/5` at every viewport width. On mobile, that left the auth pane at 60% of the screen and cramped its content.

## Test plan
- `pnpm format`
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- Browser matrix at 320, 375, 390, 430, 768, 1024, 1279, 1280, 1440, and 1920px; verified no horizontal overflow, one-line provider labels, full-width auth below `xl`, and the desktop 60/40 split at `xl` and above