### PR TITLE
feat(code-reviewer) update object shape to handle future review types

### DIFF
--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
@@ -531,8 +531,8 @@ describe('prepareReviewPayload', () => {
       reviewType: 'standard',
       agents: [{ role: 'standard', model: 'test-model', thinkingEffort: 'high' }],
     });
-    expect(payload.reviewAgents?.agents[0].model).toBe(payload.sessionInput.model);
-    expect(payload.reviewAgents?.agents[0].thinkingEffort).toBe(payload.sessionInput.variant);
+    expect(payload.reviewAgents.agents[0].model).toBe(payload.sessionInput.model);
+    expect(payload.reviewAgents.agents[0].thinkingEffort).toBe(payload.sessionInput.variant);
   });
 
   it('throws when a provider GitLab review is missing its integration', async () => {
@@ -616,7 +616,7 @@ describe('prepareReviewPayload', () => {
       reviewType: 'standard',
       agents: [{ role: 'standard', model: 'test-model', thinkingEffort: null }],
     });
-    expect(payload.reviewAgents?.agents[0].model).toBe(payload.sessionInput.model);
+    expect(payload.reviewAgents.agents[0].model).toBe(payload.sessionInput.model);
     expect(payload.sessionInput).not.toHaveProperty('githubToken');
     expect(payload.sessionInput).not.toHaveProperty('gitToken');
     expect(payload.sessionInput).not.toHaveProperty('gateThreshold');

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
@@ -610,6 +610,13 @@ describe('prepareReviewPayload', () => {
       },
     });
     expect(payload.previousCloudAgentSessionId).toBeUndefined();
+    // Bitbucket must carry the same forward-shaped reviewAgents contract as
+    // GitHub/GitLab, mirroring the session's model (no drift).
+    expect(payload.reviewAgents).toEqual({
+      reviewType: 'standard',
+      agents: [{ role: 'standard', model: 'test-model', thinkingEffort: null }],
+    });
+    expect(payload.reviewAgents?.agents[0].model).toBe(payload.sessionInput.model);
     expect(payload.sessionInput).not.toHaveProperty('githubToken');
     expect(payload.sessionInput).not.toHaveProperty('gitToken');
     expect(payload.sessionInput).not.toHaveProperty('gateThreshold');

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
@@ -506,6 +506,35 @@ describe('prepareReviewPayload', () => {
     });
   });
 
+  it('builds forward-shaped reviewAgents for a standard review (single agent mirroring the session model)', async () => {
+    const [review] = await db
+      .insert(cloud_agent_code_reviews)
+      .values(
+        defineReview(testUser.id, gitlabIntegration.id, {
+          platform: 'gitlab',
+          platform_project_id: 456,
+          pr_url: `https://gitlab.example.com/${REPO}/-/merge_requests/123`,
+        })
+      )
+      .returning();
+
+    const payload = await prepareReviewPayload({
+      reviewId: review.id,
+      owner: { type: 'user', id: testUser.id, userId: testUser.id },
+      agentConfig: { config: { ...baseAgentConfig, thinking_effort: 'high' } },
+      platform: 'gitlab',
+    });
+
+    // Standard review => exactly one 'standard' agent, and agents[0] mirrors what the
+    // session actually runs on (no drift between the two).
+    expect(payload.reviewAgents).toEqual({
+      reviewType: 'standard',
+      agents: [{ role: 'standard', model: 'test-model', thinkingEffort: 'high' }],
+    });
+    expect(payload.reviewAgents?.agents[0].model).toBe(payload.sessionInput.model);
+    expect(payload.reviewAgents?.agents[0].thinkingEffort).toBe(payload.sessionInput.variant);
+  });
+
   it('throws when a provider GitLab review is missing its integration', async () => {
     const [review] = await db
       .insert(cloud_agent_code_reviews)

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
@@ -306,12 +306,15 @@ export async function prepareReviewPayload(
           }
         );
         const authToken = generateApiToken(user, { botId: 'reviewer' });
+        // Single source for the standard reviewer's model so the session input and the
+        // forward-shaped `reviewAgents[0]` can never drift apart.
+        const standardModel = config.model_slug || DEFAULT_CODE_REVIEW_MODEL;
         const sessionInput: SessionInput = {
           gitUrl: `https://bitbucket.org/${workspaceSlug.data}/${repositorySlug.data}.git`,
           kilocodeOrganizationId: owner.id,
           prompt,
           mode: DEFAULT_CODE_REVIEW_MODE as 'code',
-          model: config.model_slug || DEFAULT_CODE_REVIEW_MODEL,
+          model: standardModel,
           variant: config.thinking_effort ?? undefined,
           upstreamBranch: review.head_ref,
           platform: PLATFORM.BITBUCKET,
@@ -322,6 +325,20 @@ export async function prepareReviewPayload(
           bitbucketIntegrationId: integration.id,
           bitbucketPullRequestId: review.pr_number,
           bitbucketExpectedHeadSha: expectedHeadSha.data,
+        };
+
+        // Forward-shaped agent selections, built for every review (see GitHub/GitLab
+        // path below). Today this is always a single 'standard' agent mirroring the
+        // session's model/effort; council mode will populate one entry per specialist.
+        const reviewAgents: ReviewAgentsConfig = {
+          reviewType: 'standard',
+          agents: [
+            {
+              role: 'standard',
+              model: standardModel,
+              thinkingEffort: config.thinking_effort ?? null,
+            },
+          ],
         };
 
         logExceptInTest('[prepareReviewPayload] Prepared Bitbucket payload', {
@@ -340,6 +357,7 @@ export async function prepareReviewPayload(
           sessionInput,
           owner,
           repositorySize: null,
+          reviewAgents,
         };
       }
       case PLATFORM.GITHUB:

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
@@ -22,6 +22,10 @@ import {
   fetchGitHubRepositorySize,
 } from '@/lib/integrations/platforms/github/adapter';
 import type { GitHubAppType } from '@/lib/integrations/platforms/github/app-selector';
+import type {
+  ReviewAgentSelection,
+  ReviewAgentsConfig,
+} from '@kilocode/worker-utils/review-agents';
 import {
   findKiloReviewNote,
   fetchMRInlineComments,
@@ -123,33 +127,11 @@ export type SessionInput = {
 };
 
 /**
- * One reviewing agent's selection. FORWARD-SHAPED for the upcoming council (multi-agent)
- * mode: today only a single `role: 'standard'` agent is produced/consumed. A council
- * review will populate one entry per specialist, each with its own requested model.
+ * Review agent selection wire contract shared with the code-review Worker. Defined once
+ * in `@kilocode/worker-utils/review-agents` so producer and consumer cannot drift as
+ * council mode adds fields. See that module for the forward-plumbing notes.
  */
-export type ReviewAgentSelection = {
-  /** `'standard'` for the standard reviewer; a specialist role/id for council members. */
-  role: string;
-  /** Requested model slug; falls back to the review default when null. */
-  model: string | null;
-  /** Requested thinking-effort variant; null = model default. */
-  thinkingEffort: string | null;
-};
-
-/**
- * Review agent configuration sent along the code-reviewer -> cloud-agent path.
- *
- * NOTE (forward plumbing): today the pipeline only builds and consumes a single
- * `'standard'` agent (`agents[0]`). `reviewType`, `aggregationStrategy`, and additional
- * `agents[]` entries are carried end-to-end for the imminent council mode but are not yet
- * consumed by execution. See the standard/council fork in prepare-review-payload.
- */
-export type ReviewAgentsConfig = {
-  reviewType: 'standard' | 'council';
-  /** Council-only: how specialist votes combine. Unused for standard. */
-  aggregationStrategy?: 'any_blocking_member' | 'majority' | 'unanimous_required';
-  agents: ReviewAgentSelection[];
-};
+export type { ReviewAgentSelection, ReviewAgentsConfig };
 
 export type CodeReviewPayload = {
   reviewId: string;
@@ -165,9 +147,11 @@ export type CodeReviewPayload = {
   /**
    * Forward-shaped review agent selections. Built for every review (standard = a single
    * `'standard'` agent). Only `agents[0]` is consumed today; the rest is plumbing for
-   * council mode.
+   * council mode. Required on the producer output so no return path can silently omit
+   * it; it stays optional on the Worker request and persisted state for rolling-deploy
+   * and in-flight compatibility.
    */
-  reviewAgents?: ReviewAgentsConfig;
+  reviewAgents: ReviewAgentsConfig;
 };
 
 /**

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
@@ -122,6 +122,35 @@ export type SessionInput = {
   gateThreshold?: 'off' | 'all' | 'warning' | 'critical';
 };
 
+/**
+ * One reviewing agent's selection. FORWARD-SHAPED for the upcoming council (multi-agent)
+ * mode: today only a single `role: 'standard'` agent is produced/consumed. A council
+ * review will populate one entry per specialist, each with its own requested model.
+ */
+export type ReviewAgentSelection = {
+  /** `'standard'` for the standard reviewer; a specialist role/id for council members. */
+  role: string;
+  /** Requested model slug; falls back to the review default when null. */
+  model: string | null;
+  /** Requested thinking-effort variant; null = model default. */
+  thinkingEffort: string | null;
+};
+
+/**
+ * Review agent configuration sent along the code-reviewer -> cloud-agent path.
+ *
+ * NOTE (forward plumbing): today the pipeline only builds and consumes a single
+ * `'standard'` agent (`agents[0]`). `reviewType`, `aggregationStrategy`, and additional
+ * `agents[]` entries are carried end-to-end for the imminent council mode but are not yet
+ * consumed by execution. See the standard/council fork in prepare-review-payload.
+ */
+export type ReviewAgentsConfig = {
+  reviewType: 'standard' | 'council';
+  /** Council-only: how specialist votes combine. Unused for standard. */
+  aggregationStrategy?: 'any_blocking_member' | 'majority' | 'unanimous_required';
+  agents: ReviewAgentSelection[];
+};
+
 export type CodeReviewPayload = {
   reviewId: string;
   attemptId?: string;
@@ -133,6 +162,12 @@ export type CodeReviewPayload = {
   previousCloudAgentSessionId?: string;
   /** Provider-reported repository storage size, formatted for log correlation. */
   repositorySize?: string | null;
+  /**
+   * Forward-shaped review agent selections. Built for every review (standard = a single
+   * `'standard'` agent). Only `agents[0]` is consumed today; the rest is plumbing for
+   * council mode.
+   */
+  reviewAgents?: ReviewAgentsConfig;
 };
 
 /**
@@ -697,6 +732,9 @@ export async function prepareReviewPayload(
     // GitHub: uses githubRepo (owner/repo format) + githubToken
     // GitLab: uses gitUrl (full HTTPS URL) + gitToken
     const variant = config.thinking_effort ?? undefined;
+    // Single source for the standard reviewer's model so the session input and the
+    // forward-shaped `reviewAgents[0]` can never drift apart.
+    const standardModel = config.model_slug || DEFAULT_CODE_REVIEW_MODEL;
     const gateThreshold = config.gate_threshold ?? 'off';
     const githubCheckoutRef = getGitHubPullRequestCheckoutRef(review.pr_number);
     const sessionInput: SessionInput =
@@ -709,7 +747,7 @@ export async function prepareReviewPayload(
             kilocodeOrganizationId: owner.type === 'org' ? owner.id : undefined,
             prompt,
             mode: DEFAULT_CODE_REVIEW_MODE as 'code',
-            model: config.model_slug || DEFAULT_CODE_REVIEW_MODEL,
+            model: standardModel,
             variant,
             upstreamBranch: review.head_ref,
           }
@@ -722,7 +760,7 @@ export async function prepareReviewPayload(
               kilocodeOrganizationId: owner.type === 'org' ? owner.id : undefined,
               prompt,
               mode: DEFAULT_CODE_REVIEW_MODE as 'code',
-              model: config.model_slug || DEFAULT_CODE_REVIEW_MODEL,
+              model: standardModel,
               variant,
               upstreamBranch: review.head_ref,
               ...(gateThreshold !== 'off' ? { gateThreshold } : {}),
@@ -735,11 +773,25 @@ export async function prepareReviewPayload(
               kilocodeOrganizationId: owner.type === 'org' ? owner.id : undefined,
               prompt,
               mode: DEFAULT_CODE_REVIEW_MODE as 'code',
-              model: config.model_slug || DEFAULT_CODE_REVIEW_MODEL,
+              model: standardModel,
               variant,
               upstreamBranch: githubCheckoutRef,
               ...(gateThreshold !== 'off' ? { gateThreshold } : {}),
             };
+
+    // Forward-shaped agent selections. Today this is always a single 'standard' agent
+    // mirroring the session's model/effort; council mode will populate one entry per
+    // specialist. agents[0].model is kept identical to sessionInput.model above.
+    const reviewAgents: ReviewAgentsConfig = {
+      reviewType: 'standard',
+      agents: [
+        {
+          role: 'standard',
+          model: standardModel,
+          thinkingEffort: config.thinking_effort ?? null,
+        },
+      ],
+    };
 
     // Log the session input for GitLab
     if (platform === 'gitlab') {
@@ -769,6 +821,7 @@ export async function prepareReviewPayload(
       owner,
       previousCloudAgentSessionId,
       repositorySize,
+      reviewAgents,
     };
 
     logExceptInTest('[prepareReviewPayload] Prepared payload', {

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -28,7 +28,8 @@
     "./security-notification-policy": "./src/security-notification-policy.ts",
     "./security-finding-audit": "./src/security-finding-audit.ts",
     "./dependabot-dismissal-target": "./src/dependabot-dismissal-target.ts",
-    "./client-error": "./src/client-error.ts"
+    "./client-error": "./src/client-error.ts",
+    "./review-agents": "./src/review-agents.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/worker-utils/src/review-agents.ts
+++ b/packages/worker-utils/src/review-agents.ts
@@ -1,0 +1,40 @@
+import * as z from 'zod';
+
+/**
+ * Cross-service wire contract for code-reviewer -> cloud-agent review agent selections.
+ *
+ * FORWARD-SHAPED for the upcoming council (multi-agent) mode: today only a single
+ * `role: 'standard'` agent is produced/consumed. A council review will populate one
+ * entry per specialist, each with its own requested model.
+ *
+ * This is the single source of truth for the shape. Both the producer
+ * (`apps/web` prepare-review-payload) and the consumer (`services/code-review-infra`)
+ * import the inferred types from here so council-mode additions cannot drift.
+ */
+
+/** One reviewing agent's selection. */
+export const ReviewAgentSelectionSchema = z.object({
+  /** `'standard'` for the standard reviewer; a specialist role/id for council members. */
+  role: z.string(),
+  /** Requested model slug; falls back to the review default when null. */
+  model: z.string().nullable(),
+  /** Requested thinking-effort variant; null = model default. */
+  thinkingEffort: z.string().nullable(),
+});
+
+/**
+ * Review agent configuration carried along the code-reviewer -> cloud-agent path.
+ *
+ * NOTE (forward plumbing): only `agents[0]` (the standard agent) is consumed today;
+ * `reviewType`, `aggregationStrategy`, and additional `agents[]` entries are carried
+ * end-to-end for council mode but are not yet consumed by execution.
+ */
+export const ReviewAgentsConfigSchema = z.object({
+  reviewType: z.enum(['standard', 'council']),
+  /** Council-only: how specialist votes combine. Unused for standard. */
+  aggregationStrategy: z.enum(['any_blocking_member', 'majority', 'unanimous_required']).optional(),
+  agents: z.array(ReviewAgentSelectionSchema),
+});
+
+export type ReviewAgentSelection = z.infer<typeof ReviewAgentSelectionSchema>;
+export type ReviewAgentsConfig = z.infer<typeof ReviewAgentsConfigSchema>;

--- a/services/code-review-infra/src/code-review-orchestrator.ts
+++ b/services/code-review-infra/src/code-review-orchestrator.ts
@@ -22,6 +22,7 @@ import type {
   CodeReviewStatusResponse,
   CodeReviewStatusResult,
   SessionInput,
+  ReviewAgentsConfig,
 } from './types';
 import { InternalStatusResponseSchema } from './types';
 import { doNameForAttempt } from './do-name';
@@ -892,6 +893,7 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
     previousCloudAgentSessionId?: string;
     repositorySize?: string | null;
     runReviewDelayMs?: number;
+    reviewAgents?: ReviewAgentsConfig;
   }): Promise<{ status: CodeReviewStatus }> {
     if (!this.state) {
       await this.loadState();
@@ -920,8 +922,21 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
           ? undefined
           : params.previousCloudAgentSessionId,
       repositorySize: params.repositorySize,
+      reviewAgents: params.reviewAgents,
     };
     await this.saveState();
+
+    // Forward plumbing: today execution consumes only the standard reviewer settings
+    // (agents[0] / sessionInput). Log the full selection for observability ahead of
+    // council (multi-agent) mode, which will consume the rest.
+    if (params.reviewAgents) {
+      console.log('[CodeReviewOrchestrator] Review agent selections', {
+        reviewId: params.reviewId,
+        reviewType: params.reviewAgents.reviewType,
+        agentCount: params.reviewAgents.agents.length,
+        agentRoles: params.reviewAgents.agents.map(agent => agent.role),
+      });
+    }
     const runReviewDelayMs =
       params.runReviewDelayMs ?? CodeReviewOrchestrator.RUN_REVIEW_FALLBACK_DELAY_MS;
     await this.ctx.storage.setAlarm(Date.now() + runReviewDelayMs);

--- a/services/code-review-infra/src/code-review-orchestrator.ts
+++ b/services/code-review-infra/src/code-review-orchestrator.ts
@@ -928,15 +928,17 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
 
     // Forward plumbing: today execution consumes only the standard reviewer settings
     // (agents[0] / sessionInput). Log the full selection for observability ahead of
-    // council (multi-agent) mode, which will consume the rest. Guard the shape
-    // defensively so a malformed payload can never throw here, between saveState()
-    // and setAlarm(), which would leave the review queued but never scheduled.
-    if (params.reviewAgents && Array.isArray(params.reviewAgents.agents)) {
+    // council (multi-agent) mode, which will consume the rest. This is a pure
+    // observability log sitting between saveState() and setAlarm(): a malformed
+    // payload (non-array agents, null entries, etc.) must never throw here, or the
+    // review would be persisted as queued but never scheduled. Keep it total.
+    if (params.reviewAgents) {
+      const agents = params.reviewAgents.agents;
       console.log('[CodeReviewOrchestrator] Review agent selections', {
         reviewId: params.reviewId,
         reviewType: params.reviewAgents.reviewType,
-        agentCount: params.reviewAgents.agents.length,
-        agentRoles: params.reviewAgents.agents.map(agent => agent.role),
+        agentCount: Array.isArray(agents) ? agents.length : 0,
+        agentRoles: Array.isArray(agents) ? agents.map(agent => agent?.role) : [],
       });
     }
     const runReviewDelayMs =

--- a/services/code-review-infra/src/code-review-orchestrator.ts
+++ b/services/code-review-infra/src/code-review-orchestrator.ts
@@ -928,8 +928,10 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
 
     // Forward plumbing: today execution consumes only the standard reviewer settings
     // (agents[0] / sessionInput). Log the full selection for observability ahead of
-    // council (multi-agent) mode, which will consume the rest.
-    if (params.reviewAgents) {
+    // council (multi-agent) mode, which will consume the rest. Guard the shape
+    // defensively so a malformed payload can never throw here, between saveState()
+    // and setAlarm(), which would leave the review queued but never scheduled.
+    if (params.reviewAgents && Array.isArray(params.reviewAgents.agents)) {
       console.log('[CodeReviewOrchestrator] Review agent selections', {
         reviewId: params.reviewId,
         reviewType: params.reviewAgents.reviewType,
@@ -1040,6 +1042,7 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
       skipBalanceCheck: this.state.skipBalanceCheck,
       previousCloudAgentSessionId: undefined,
       repositorySize: this.state.repositorySize,
+      reviewAgents: this.state.reviewAgents,
       runReviewDelayMs: retryDelayMs,
     });
 

--- a/services/code-review-infra/src/index.ts
+++ b/services/code-review-infra/src/index.ts
@@ -103,6 +103,7 @@ app.post('/review', async (c: Context<HonoEnv>) => {
         skipBalanceCheck: body.skipBalanceCheck,
         previousCloudAgentSessionId: body.previousCloudAgentSessionId,
         repositorySize: body.repositorySize,
+        reviewAgents: body.reviewAgents,
       }),
     'start'
   );

--- a/services/code-review-infra/src/types.ts
+++ b/services/code-review-infra/src/types.ts
@@ -4,9 +4,14 @@
 
 import type { CodeReviewOrchestrator } from './code-review-orchestrator';
 import type { Owner, MCPServerConfig, CloudAgentTerminalReason } from '@kilocode/worker-utils';
+import type {
+  ReviewAgentSelection,
+  ReviewAgentsConfig,
+} from '@kilocode/worker-utils/review-agents';
 import * as z from 'zod';
 
 export type { Owner, MCPServerConfig };
+export type { ReviewAgentSelection, ReviewAgentsConfig };
 
 export type CodeReviewStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
 
@@ -46,31 +51,6 @@ export interface SessionInput {
   mcpServers?: Record<string, MCPServerConfig>;
   /** Gate threshold — when not 'off', the agent should report gateResult in its callback */
   gateThreshold?: 'off' | 'all' | 'warning' | 'critical';
-}
-
-/**
- * One reviewing agent's selection. FORWARD-SHAPED for the upcoming council (multi-agent)
- * mode: today only a single `role: 'standard'` agent is produced/consumed. A council
- * review will populate one entry per specialist, each with its own requested model.
- */
-export interface ReviewAgentSelection {
-  /** `'standard'` for the standard reviewer; a specialist role/id for council members. */
-  role: string;
-  /** Requested model slug; falls back to the review default when null. */
-  model: string | null;
-  /** Requested thinking-effort variant; null = model default. */
-  thinkingEffort: string | null;
-}
-
-/**
- * Review agent configuration carried along the code-reviewer -> cloud-agent path.
- * NOTE (forward plumbing): only `agents[0]` (the standard agent) is consumed today;
- * `reviewType`/`aggregationStrategy`/extra `agents[]` are carried for council mode.
- */
-export interface ReviewAgentsConfig {
-  reviewType: 'standard' | 'council';
-  aggregationStrategy?: 'any_blocking_member' | 'majority' | 'unanimous_required';
-  agents: ReviewAgentSelection[];
 }
 
 export interface CodeReview {

--- a/services/code-review-infra/src/types.ts
+++ b/services/code-review-infra/src/types.ts
@@ -48,6 +48,31 @@ export interface SessionInput {
   gateThreshold?: 'off' | 'all' | 'warning' | 'critical';
 }
 
+/**
+ * One reviewing agent's selection. FORWARD-SHAPED for the upcoming council (multi-agent)
+ * mode: today only a single `role: 'standard'` agent is produced/consumed. A council
+ * review will populate one entry per specialist, each with its own requested model.
+ */
+export interface ReviewAgentSelection {
+  /** `'standard'` for the standard reviewer; a specialist role/id for council members. */
+  role: string;
+  /** Requested model slug; falls back to the review default when null. */
+  model: string | null;
+  /** Requested thinking-effort variant; null = model default. */
+  thinkingEffort: string | null;
+}
+
+/**
+ * Review agent configuration carried along the code-reviewer -> cloud-agent path.
+ * NOTE (forward plumbing): only `agents[0]` (the standard agent) is consumed today;
+ * `reviewType`/`aggregationStrategy`/extra `agents[]` are carried for council mode.
+ */
+export interface ReviewAgentsConfig {
+  reviewType: 'standard' | 'council';
+  aggregationStrategy?: 'any_blocking_member' | 'majority' | 'unanimous_required';
+  agents: ReviewAgentSelection[];
+}
+
 export interface CodeReview {
   reviewId: string;
   attemptId?: string;
@@ -77,6 +102,8 @@ export interface CodeReview {
   sandboxRetryAttempted?: boolean;
   /** Provider-reported repository storage size, formatted for log correlation. */
   repositorySize?: string | null;
+  /** Forward-shaped review agent selections (only agents[0] consumed today). */
+  reviewAgents?: ReviewAgentsConfig;
 }
 
 export interface CodeReviewStatusResponse {
@@ -144,6 +171,8 @@ export interface CodeReviewRequest {
   previousCloudAgentSessionId?: string;
   /** Provider-reported repository storage size, formatted for log correlation. */
   repositorySize?: string | null;
+  /** Forward-shaped review agent selections (only agents[0] consumed today). */
+  reviewAgents?: ReviewAgentsConfig;
 }
 
 export interface CodeReviewResponse {

--- a/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
+++ b/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
@@ -807,6 +807,10 @@ describe('CodeReviewOrchestrator recovery', () => {
           errorMessage: 'Container shutdown: SIGTERM',
           terminalReason: 'sandbox_error',
           repositorySize: '100 MB',
+          reviewAgents: {
+            reviewType: 'standard',
+            agents: [{ role: 'standard', model: 'test-model', thinkingEffort: null }],
+          },
         })
       );
     });
@@ -838,6 +842,10 @@ describe('CodeReviewOrchestrator recovery', () => {
     });
     await expect(storedReview(retryStub)).resolves.toMatchObject({
       repositorySize: '100 MB',
+      reviewAgents: {
+        reviewType: 'standard',
+        agents: [{ role: 'standard', model: 'test-model', thinkingEffort: null }],
+      },
     });
     const retryAlarm = await storedAlarm(retryStub);
     expectAutoRetryAlarmInRange(retryAlarm, retrySchedulingStartedAt);


### PR DESCRIPTION
## Summary

Plumbs a forward-shaped `reviewAgents` object end-to-end along the code-reviewer -> cloud-agent path so the pipeline can carry per-agent model selections. Today every review produces a single `standard` agent that mirrors the session's model and thinking effort; the extra shape (`reviewType`, `aggregationStrategy`, and additional `agents[]` entries) is carried but not yet consumed by execution, in preparation for an upcoming council (multi-agent) review mode.

## Changes

- Added `ReviewAgentSelection` and `ReviewAgentsConfig` types in `apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts` and mirrored them in `services/code-review-infra/src/types.ts` (on `CodeReview` and `CodeReviewRequest`).
- In `prepareReviewPayload`, introduced a single `standardModel` source (`config.model_slug || DEFAULT_CODE_REVIEW_MODEL`) used for both `sessionInput.model` and `reviewAgents.agents[0].model` so the two cannot drift, and attached `reviewAgents` to the returned payload.
- Threaded `reviewAgents` through the `POST /review` handler in `services/code-review-infra/src/index.ts` into the orchestrator's `start` params.
- Persisted `reviewAgents` in `CodeReviewOrchestrator` state and added a log line recording `reviewType`, agent count, and agent roles for observability ahead of council mode.
- Added a test asserting a standard review builds exactly one `standard` agent whose `model` and `thinkingEffort` match the session input.

## Verification

- [ ] No manual testing performed. The change is forward plumbing that is not yet consumed by execution (only `agents[0]`, which mirrors existing session behavior, is used today); covered by the added unit test.

## Visual Changes

N/A

## Reviewer Notes

- All new fields are optional, so the change is backward-compatible with in-flight reviews and older payloads.
- `reviewType`, `aggregationStrategy`, and any `agents[]` beyond `agents[0]` are intentionally unused for now and exist only to carry council-mode data.
