### PR TITLE
feat(mobile): expand PostHog analytics coverage

### DIFF
--- a/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/chat/[sandbox-id]/[conversation-id].tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/chat/[sandbox-id]/[conversation-id].tsx
@@ -16,9 +16,14 @@ import { useKiloChatClient } from '@/components/kilo-chat/hooks/use-kilo-chat-cl
 import { chatSandboxPath } from '@/lib/kilo-chat-routes';
 
 export default function ChatConversationRoute() {
-  const params = useLocalSearchParams<{ 'sandbox-id': string; 'conversation-id': string }>();
+  const params = useLocalSearchParams<{
+    'sandbox-id': string;
+    'conversation-id': string;
+    via?: string;
+  }>();
   const sandboxId = params['sandbox-id'];
   const conversationId = params['conversation-id'];
+  const openedVia = params.via === 'push' ? 'push' : 'app';
   const router = useRouter();
   const client = useKiloChatClient();
   const conversationDetail = useConversationDetail(client, conversationId);
@@ -34,8 +39,8 @@ export default function ChatConversationRoute() {
       return;
     }
     viewTrackedRef.current = conversationId;
-    captureEvent(SESSION_VIEWED_EVENT, { surface: 'claw' });
-  }, [conversationDetail.data, conversationId]);
+    captureEvent(SESSION_VIEWED_EVENT, { surface: 'claw', via: openedVia });
+  }, [conversationDetail.data, conversationId, openedVia]);
 
   useEffect(() => {
     if (conversationDetail.isError) {

--- a/apps/mobile/src/app/(app)/agent-chat/[session-id].tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/[session-id].tsx
@@ -10,9 +10,14 @@ import { Text } from '@/components/ui/text';
 import { useTRPC } from '@/lib/trpc';
 
 export default function SessionDetailScreen() {
-  const { 'session-id': sessionId, organizationId: routeOrganizationId } = useLocalSearchParams<{
+  const {
+    'session-id': sessionId,
+    organizationId: routeOrganizationId,
+    via,
+  } = useLocalSearchParams<{
     'session-id': string;
     organizationId?: string;
+    via?: string;
   }>();
   const trpc = useTRPC();
   const sessionQuery = useQuery({
@@ -59,7 +64,10 @@ export default function SessionDetailScreen() {
       key={`${sessionId}:${organizationId ?? 'personal'}`}
       organizationId={organizationId}
     >
-      <SessionDetailContent sessionId={sessionId as KiloSessionId} />
+      <SessionDetailContent
+        sessionId={sessionId as KiloSessionId}
+        openedVia={via === 'push' ? 'push' : 'app'}
+      />
     </AgentSessionProvider>
   );
 }

--- a/apps/mobile/src/app/(app)/agent-chat/new.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/new.tsx
@@ -33,6 +33,7 @@ import {
   shouldShowGitHubIntegrationPrompt,
 } from '@/lib/agent-github-integration';
 import { AGENT_ATTACHMENT_MAX_FILES } from '@/lib/agent-attachments/constants';
+import { captureEvent, SESSION_CREATED_EVENT } from '@/lib/analytics/posthog';
 import {
   type AgentAttachmentWire,
   useAgentAttachmentUpload,
@@ -219,6 +220,7 @@ export default function NewSessionScreen() {
           })
         : await trpcClient.cloudAgentNext.prepareSession.mutate(baseInput);
 
+      captureEvent(SESSION_CREATED_EVENT, { surface: 'cloud-agent' });
       await invalidateAgentSessionQueries(queryClient, trpc);
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       const path = organizationId

--- a/apps/mobile/src/app/(app)/kiloclaw/[instance-id]/dashboard.tsx
+++ b/apps/mobile/src/app/(app)/kiloclaw/[instance-id]/dashboard.tsx
@@ -25,6 +25,7 @@ import { SettingsList } from '@/components/kiloclaw/settings-list';
 import { StatusCard } from '@/components/kiloclaw/status-card';
 import { QueryError } from '@/components/query-error';
 import { ScreenHeader } from '@/components/screen-header';
+import { captureEvent, INSTANCE_ACTION_EVENT } from '@/lib/analytics/posthog';
 import { ConfigureRow } from '@/components/ui/configure-row';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useInstanceContext } from '@/lib/hooks/use-instance-context';
@@ -143,6 +144,7 @@ export default function DashboardScreen() {
           text: 'Destroy',
           style: 'destructive',
           onPress: () => {
+            captureEvent(INSTANCE_ACTION_EVENT, { surface: 'claw', action: 'destroy' });
             mutations.destroy.mutate(undefined);
             router.dismissAll();
             router.replace('/(app)/(tabs)/(0_home)' as Href);

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -31,6 +31,7 @@ import { subscribeToConsentChanges } from '@/lib/consent';
 import { useAnalyticsConsentGate } from '@/lib/hooks/use-analytics-consent-gate';
 import { useForceUpdate } from '@/lib/hooks/use-force-update';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
+import { useScreenTracking } from '@/lib/hooks/use-screen-tracking';
 import { useTrackingPermissionPrompt } from '@/lib/hooks/use-tracking-permission-prompt';
 import {
   checkInitialNotification,
@@ -159,6 +160,7 @@ function RootLayoutNav() {
 
   useTrackingPermissionPrompt(!isLoading);
   useAnalyticsConsentGate({ hasToken: token != null, consentChecked, needsConsent, email });
+  useScreenTracking();
 
   useEffect(() => {
     if (isLoading) {

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -51,6 +51,7 @@ import {
 
 type SessionDetailContentProps = {
   sessionId: KiloSessionId;
+  openedVia?: 'push' | 'app';
 };
 
 const COMPOSER_PLACEHOLDERS: Partial<Record<CloudStatus['type'], string>> = {
@@ -58,7 +59,10 @@ const COMPOSER_PLACEHOLDERS: Partial<Record<CloudStatus['type'], string>> = {
   finalizing: 'Wrapping up...',
 };
 
-export function SessionDetailContent({ sessionId }: Readonly<SessionDetailContentProps>) {
+export function SessionDetailContent({
+  sessionId,
+  openedVia = 'app',
+}: Readonly<SessionDetailContentProps>) {
   const manager = useSessionManager();
 
   const messages = useAtomValue(manager.atoms.messagesList);
@@ -85,13 +89,22 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
   const { isConnected } = useAppLifecycle();
   const { bottom } = useSafeAreaInsets();
 
+  const analyticsSurface: AnalyticsSurface = fetchedData?.cloudAgentSessionId
+    ? 'cloud-agent'
+    : 'remote-session';
+
   const {
     isAnswering,
     isRespondingToPermission,
     handleAnswerQuestion,
     handleRejectQuestion,
     handleRespondToPermission,
-  } = useInteractionHandlers({ manager, activeQuestion, activePermission });
+  } = useInteractionHandlers({
+    manager,
+    activeQuestion,
+    activePermission,
+    surface: analyticsSurface,
+  });
 
   const organizationId = fetchedData?.organizationId ?? undefined;
 
@@ -161,18 +174,14 @@ export function SessionDetailContent({ sessionId }: Readonly<SessionDetailConten
     handleMomentumScrollEnd,
   } = useSessionAutoScroll<StoredMessage>({ itemCount: messages.length, resetKey: sessionId });
 
-  const analyticsSurface: AnalyticsSurface = fetchedData?.cloudAgentSessionId
-    ? 'cloud-agent'
-    : 'remote-session';
-
   const viewTrackedRef = useRef<string | null>(null);
   useEffect(() => {
     if (fetchedData?.kiloSessionId !== sessionId || viewTrackedRef.current === sessionId) {
       return;
     }
     viewTrackedRef.current = sessionId;
-    captureEvent(SESSION_VIEWED_EVENT, { surface: analyticsSurface });
-  }, [fetchedData, sessionId, analyticsSurface]);
+    captureEvent(SESSION_VIEWED_EVENT, { surface: analyticsSurface, via: openedVia });
+  }, [fetchedData, sessionId, analyticsSurface, openedVia]);
 
   useEffect(() => {
     void manager.switchSession(sessionId);

--- a/apps/mobile/src/components/agents/use-interaction-handlers.ts
+++ b/apps/mobile/src/components/agents/use-interaction-handlers.ts
@@ -1,18 +1,27 @@
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner-native';
 
+import {
+  type AnalyticsSurface,
+  captureEvent,
+  PERMISSION_RESPONDED_EVENT,
+  QUESTION_ANSWERED_EVENT,
+} from '@/lib/analytics/posthog';
+
 import { type useSessionManager } from './session-provider';
 
 type InteractionHandlersArgs = {
   manager: ReturnType<typeof useSessionManager>;
   activeQuestion: { requestId: string; questions?: unknown[] } | null;
   activePermission: { requestId: string } | null;
+  surface: AnalyticsSurface;
 };
 
 export function useInteractionHandlers({
   manager,
   activeQuestion,
   activePermission,
+  surface,
 }: InteractionHandlersArgs) {
   const [isAnswering, setIsAnswering] = useState(false);
   const [isRespondingToPermission, setIsRespondingToPermission] = useState(false);
@@ -25,13 +34,14 @@ export function useInteractionHandlers({
       setIsAnswering(true);
       try {
         await manager.answerQuestion(activeQuestion.requestId, answers);
+        captureEvent(QUESTION_ANSWERED_EVENT, { surface, skipped: false });
       } catch {
         toast.error('Failed to submit answer');
       } finally {
         setIsAnswering(false);
       }
     },
-    [manager, activeQuestion]
+    [manager, activeQuestion, surface]
   );
 
   const handleRejectQuestion = useCallback(async () => {
@@ -41,12 +51,13 @@ export function useInteractionHandlers({
     setIsAnswering(true);
     try {
       await manager.rejectQuestion(activeQuestion.requestId);
+      captureEvent(QUESTION_ANSWERED_EVENT, { surface, skipped: true });
     } catch {
       toast.error('Failed to skip question');
     } finally {
       setIsAnswering(false);
     }
-  }, [manager, activeQuestion]);
+  }, [manager, activeQuestion, surface]);
 
   const handleRespondToPermission = useCallback(
     async (response: 'once' | 'always' | 'reject') => {
@@ -56,13 +67,14 @@ export function useInteractionHandlers({
       setIsRespondingToPermission(true);
       try {
         await manager.respondToPermission(activePermission.requestId, response);
+        captureEvent(PERMISSION_RESPONDED_EVENT, { surface, response });
       } catch {
         toast.error('Failed to respond to permission request');
       } finally {
         setIsRespondingToPermission(false);
       }
     },
-    [manager, activePermission]
+    [manager, activePermission, surface]
   );
 
   return {

--- a/apps/mobile/src/components/kilo-chat/conversation-list-screen.tsx
+++ b/apps/mobile/src/components/kilo-chat/conversation-list-screen.tsx
@@ -9,6 +9,7 @@ import Animated, { FadeIn } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { QueryError } from '@/components/query-error';
+import { captureEvent, CONVERSATION_CREATED_EVENT } from '@/lib/analytics/posthog';
 import { ScreenHeader } from '@/components/screen-header';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
@@ -132,6 +133,7 @@ export function ConversationListScreen({ sandboxId, sandboxLabel }: Props) {
       { sandboxId },
       {
         onSuccess: result => {
+          captureEvent(CONVERSATION_CREATED_EVENT, { surface: 'claw' });
           router.push(chatConversationPath(sandboxId, result.conversationId));
         },
       }

--- a/apps/mobile/src/components/kiloclaw/instance-controls.tsx
+++ b/apps/mobile/src/components/kiloclaw/instance-controls.tsx
@@ -2,6 +2,7 @@ import { Play, Power, RefreshCw, RotateCcw } from 'lucide-react-native';
 import { Alert, View } from 'react-native';
 
 import { ActionButton } from '@/components/ui/action-button';
+import { captureEvent, INSTANCE_ACTION_EVENT } from '@/lib/analytics/posthog';
 import { type InstanceStatus, type useKiloClawMutations } from '@/lib/hooks/use-kiloclaw-queries';
 
 type InstanceControlsProps = {
@@ -21,6 +22,7 @@ export function InstanceControls({ status, mutations }: Readonly<InstanceControl
       {
         text: 'Start',
         onPress: () => {
+          captureEvent(INSTANCE_ACTION_EVENT, { surface: 'claw', action: 'start' });
           mutations.start.mutate(undefined);
         },
       },
@@ -34,6 +36,7 @@ export function InstanceControls({ status, mutations }: Readonly<InstanceControl
         text: 'Stop',
         style: 'destructive',
         onPress: () => {
+          captureEvent(INSTANCE_ACTION_EVENT, { surface: 'claw', action: 'stop' });
           mutations.stop.mutate(undefined);
         },
       },
@@ -46,6 +49,7 @@ export function InstanceControls({ status, mutations }: Readonly<InstanceControl
       {
         text: 'Restart',
         onPress: () => {
+          captureEvent(INSTANCE_ACTION_EVENT, { surface: 'claw', action: 'restart_openclaw' });
           mutations.restartOpenClaw.mutate(undefined);
         },
       },
@@ -58,6 +62,7 @@ export function InstanceControls({ status, mutations }: Readonly<InstanceControl
       {
         text: 'Redeploy',
         onPress: () => {
+          captureEvent(INSTANCE_ACTION_EVENT, { surface: 'claw', action: 'redeploy' });
           mutations.restartMachine.mutate(undefined);
         },
       },

--- a/apps/mobile/src/components/organization/invite-member-sheet.tsx
+++ b/apps/mobile/src/components/organization/invite-member-sheet.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from 'react';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
 import { ROLE_LABEL } from '@/components/organization/member-row';
+import { captureEvent, ORGANIZATION_MEMBER_INVITED_EVENT } from '@/lib/analytics/posthog';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { useOrganizationMutations } from '@/lib/hooks/use-organization-mutations';
@@ -33,6 +34,9 @@ export function InviteMemberSheet() {
       { email, role: isBillingManager ? 'member' : role },
       {
         onSuccess: () => {
+          captureEvent(ORGANIZATION_MEMBER_INVITED_EVENT, {
+            role: isBillingManager ? 'member' : role,
+          });
           void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
           router.back();
         },

--- a/apps/mobile/src/lib/analytics/posthog.ts
+++ b/apps/mobile/src/lib/analytics/posthog.ts
@@ -13,6 +13,17 @@ import { POSTHOG_API_KEY } from '@/lib/config';
 
 export const SESSION_VIEWED_EVENT = 'session_viewed';
 export const MESSAGE_SENT_EVENT = 'message_sent';
+export const SESSION_CREATED_EVENT = 'session_created';
+export const PERMISSION_RESPONDED_EVENT = 'permission_responded';
+export const QUESTION_ANSWERED_EVENT = 'question_answered';
+export const CONVERSATION_CREATED_EVENT = 'conversation_created';
+export const INSTANCE_ACTION_EVENT = 'instance_action';
+export const FEEDBACK_SUBMITTED_EVENT = 'feedback_submitted';
+// Matches the event name web already captures — keep in sync for shared funnels.
+export const ORGANIZATION_MEMBER_INVITED_EVENT = 'organization_member_invited';
+export const KILO_PASS_PURCHASE_STARTED_EVENT = 'kilo_pass_purchase_started';
+export const KILO_PASS_PURCHASE_COMPLETED_EVENT = 'kilo_pass_purchase_completed';
+export const KILO_PASS_PURCHASE_FAILED_EVENT = 'kilo_pass_purchase_failed';
 
 export type AnalyticsSurface = 'claw' | 'cloud-agent' | 'remote-session';
 
@@ -27,10 +38,20 @@ export function initPostHog(): void {
     // No events are sent from dev builds.
     disabled: __DEV__,
   });
+  // Super property on every event so dashboards can filter mobile vs web
+  // without relying on $lib.
+  void client.register({ platform: 'mobile' });
 }
 
-export function captureEvent(name: string, properties: { surface: AnalyticsSurface }): void {
+export function captureEvent(
+  name: string,
+  properties?: Record<string, string | number | boolean>
+): void {
   client?.capture(name, properties);
+}
+
+export function captureScreen(name: string): void {
+  void client?.screen(name);
 }
 
 export function identifyUser(email: string): void {

--- a/apps/mobile/src/lib/appsflyer.ts
+++ b/apps/mobile/src/lib/appsflyer.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react-native';
 import appsFlyer from 'react-native-appsflyer';
 
+import { captureEvent } from '@/lib/analytics/posthog';
 import { APPSFLYER_APP_ID, APPSFLYER_DEV_KEY } from '@/lib/config';
 
 let initialized = false;
@@ -50,6 +51,11 @@ export function initAppsFlyer(): void {
 
 export function trackEvent(name: string, values?: Record<string, string>): void {
   const eventValues = values ?? {};
+
+  // Mirror attribution events into PostHog so the onboarding funnel is
+  // visible in product analytics too. Both SDKs sit behind the same consent
+  // gate; captureEvent no-ops until PostHog is initialized.
+  captureEvent(name, eventValues);
 
   if (!initialized) {
     pendingEvents.push({ name, values: eventValues });

--- a/apps/mobile/src/lib/feedback.ts
+++ b/apps/mobile/src/lib/feedback.ts
@@ -4,6 +4,7 @@ import * as StoreReview from 'expo-store-review';
 import { Alert, Linking, Platform } from 'react-native';
 import { toast } from 'sonner-native';
 
+import { captureEvent, FEEDBACK_SUBMITTED_EVENT } from '@/lib/analytics/posthog';
 import { REVIEW_REQUESTED_AT_KEY } from '@/lib/storage-keys';
 
 const SUPPORT_EMAIL = 'hi@kilo.ai';
@@ -54,6 +55,7 @@ export function showFeedbackPrompt(userId: string | undefined) {
     {
       text: 'I like it',
       onPress: () => {
+        captureEvent(FEEDBACK_SUBMITTED_EVENT, { sentiment: 'positive' });
         Alert.alert(
           "We're glad to hear that!",
           'A store review would help us out immensely. Thanks for using Kilo!',
@@ -72,6 +74,7 @@ export function showFeedbackPrompt(userId: string | undefined) {
     {
       text: 'Needs work',
       onPress: () => {
+        captureEvent(FEEDBACK_SUBMITTED_EVENT, { sentiment: 'negative' });
         Alert.alert(
           "We're sorry to hear that!",
           'Please let us know what needs to be better. The engineer in charge of the app reads every single report!',

--- a/apps/mobile/src/lib/hooks/use-screen-tracking.ts
+++ b/apps/mobile/src/lib/hooks/use-screen-tracking.ts
@@ -1,0 +1,20 @@
+import { useSegments } from 'expo-router';
+import { useEffect } from 'react';
+
+import { captureScreen } from '@/lib/analytics/posthog';
+
+/**
+ * Captures a PostHog $screen event on every route change. Route segments keep
+ * their bracket placeholders (e.g. `chat/[sandbox-id]`), so no IDs or other
+ * dynamic values ever leave the device.
+ */
+export function useScreenTracking(): void {
+  const segments = useSegments();
+  const screenName = segments.join('/');
+
+  useEffect(() => {
+    if (screenName) {
+      captureScreen(screenName);
+    }
+  }, [screenName]);
+}

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
@@ -75,6 +75,13 @@ vi.mock('sonner-native', () => ({
   toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
 }));
 
+vi.mock('@/lib/analytics/posthog', () => ({
+  captureEvent: vi.fn(),
+  KILO_PASS_PURCHASE_COMPLETED_EVENT: 'kilo_pass_purchase_completed',
+  KILO_PASS_PURCHASE_FAILED_EVENT: 'kilo_pass_purchase_failed',
+  KILO_PASS_PURCHASE_STARTED_EVENT: 'kilo_pass_purchase_started',
+}));
+
 vi.mock('@/lib/trpc', () => ({
   useTRPC: () => ({
     kiloPass: {

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
@@ -22,6 +22,12 @@ import { Platform } from 'react-native';
 import { toast } from 'sonner-native';
 import { z } from 'zod';
 
+import {
+  captureEvent,
+  KILO_PASS_PURCHASE_COMPLETED_EVENT,
+  KILO_PASS_PURCHASE_FAILED_EVENT,
+  KILO_PASS_PURCHASE_STARTED_EVENT,
+} from '@/lib/analytics/posthog';
 import { useTRPC } from '@/lib/trpc';
 import { type AppStoreKiloPassProduct } from './store-products';
 import {
@@ -373,8 +379,10 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
     onPurchaseError: error => {
       pendingPurchaseCompletedCallbackRef.current = null;
       releasePurchaseRequest();
+      // A null message means the user cancelled — not a failure.
       const message = getKiloPassPurchaseErrorMessage(error, error.message);
       if (message) {
+        captureEvent(KILO_PASS_PURCHASE_FAILED_EVENT);
         showDedupedPurchaseError(message);
       }
     },
@@ -431,6 +439,9 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
         finishTransaction,
         invalidateAfterCompletion,
         onPurchaseCompleted: () => {
+          // Only user-initiated purchases reach here — recovery and restore
+          // flows pass notifyCompletion: false.
+          captureEvent(KILO_PASS_PURCHASE_COMPLETED_EVENT);
           const onCompleted = pendingPurchaseCompletedCallbackRef.current;
           pendingPurchaseCompletedCallbackRef.current = null;
           onCompleted?.();
@@ -461,6 +472,7 @@ export function StoreKiloPassPurchaseProvider({ children }: { children: ReactNod
 
       activePurchaseRequestRef.current = { sku: product.appleProductId };
       setIsRequestingPurchase(true);
+      captureEvent(KILO_PASS_PURCHASE_STARTED_EVENT);
       try {
         const requestStarted = await actions.purchase(product, options);
         if (!requestStarted) {

--- a/apps/mobile/src/lib/notification-path.test.ts
+++ b/apps/mobile/src/lib/notification-path.test.ts
@@ -12,7 +12,7 @@ describe('notificationPathForData', () => {
         conversationId: 'conversation-1',
         messageId: 'message-1',
       })
-    ).toBe('/(app)/(tabs)/(1_kiloclaw)/chat/sandbox-1/conversation-1');
+    ).toBe('/(app)/(tabs)/(1_kiloclaw)/chat/sandbox-1/conversation-1?via=push');
   });
 
   it('keeps notifications on the tab-owned KiloClaw chat route', () => {
@@ -52,7 +52,7 @@ describe('notificationPathForData', () => {
         type: 'cloud_agent_session',
         cliSessionId: 'ses_1',
       })
-    ).toBe('/(app)/agent-chat/ses_1');
+    ).toBe('/(app)/agent-chat/ses_1?via=push');
   });
 });
 

--- a/apps/mobile/src/lib/notification-path.ts
+++ b/apps/mobile/src/lib/notification-path.ts
@@ -3,11 +3,13 @@ import { type PushData } from '@kilocode/notifications';
 import { chatConversationRoute, chatSandboxRoute } from './kilo-chat-routes';
 
 export function notificationPathForData(data: PushData): string {
+  // `via=push` marks the resulting session_viewed analytics event as
+  // push-originated.
   if (data.type === 'cloud_agent_session') {
-    return `/(app)/agent-chat/${data.cliSessionId}`;
+    return `/(app)/agent-chat/${data.cliSessionId}?via=push`;
   }
   if (data.type === 'chat.message') {
-    return chatConversationRoute(data.sandboxId, data.conversationId);
+    return `${chatConversationRoute(data.sandboxId, data.conversationId)}?via=push`;
   }
   return chatSandboxRoute(data.sandboxId);
 }


### PR DESCRIPTION
## What

Expands mobile PostHog instrumentation from 2 events to full coverage of meaningful activity per feature surface.

### Plumbing
- `captureEvent` now accepts arbitrary stable-enum properties (was hardcoded to `{ surface }`)
- `platform: mobile` registered as a super property on every event, so dashboards don't need to rely on `$lib`
- AppsFlyer events (onboarding funnel, login) are mirrored into PostHog via `trackEvent` — the activation funnel is now visible in product analytics
- `useScreenTracking` captures a `$screen` event on every route change; expo-router segments keep bracket placeholders (`agent-chat/[session-id]`) so no IDs leave the device

### New events
| Event | Props | Where |
|---|---|---|
| `session_created` | `surface` | agent-chat new session |
| `permission_responded` | `surface`, `response: once\|always\|reject` | tool-call approval |
| `question_answered` | `surface`, `skipped` | agent question card |
| `conversation_created` | `surface: claw` | KiloClaw chat |
| `instance_action` | `surface: claw`, `action: start\|stop\|restart_openclaw\|redeploy\|destroy` | instance controls + dashboard |
| `feedback_submitted` | `sentiment: positive\|negative` | feedback prompt |
| `organization_member_invited` | `role` | matches web's existing event name |
| `kilo_pass_purchase_started/completed/failed` | — | IAP flow (mobile-only, nothing else can capture this) |

`session_viewed` additionally carries `via: push\|app` — push-opened sessions are tagged at the single choke point in `notification-path.ts`.

## Verification

Ran the flows e2e against the local stack (fake-login, remote CLI session, Maestro-driven simulator) with a temporary log in `captureEvent`/`captureScreen`; observed in Metro:

- `captureScreen` for every tab + `(auth)/login` + sanitized `agent-chat/[session-id]`
- `login {}` via the AppsFlyer mirror after device-auth sign-in
- `feedback_submitted {"sentiment":"negative"}` via the profile feedback prompt
- `session_viewed {"surface":"remote-session","via":"app"}` opening a live CLI session
- `message_sent {"surface":"remote-session"}` sending from the app (message arrived in the CLI TUI)

Also: `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` green, vitest 586/586 (added a posthog module mock to the kilo-pass purchase suite; updated notification-path tests for the `via=push` param).