### PR TITLE
fix(mobile): restore GitHub setup and Android attachments

### DIFF
--- a/apps/mobile/src/app/(app)/agent-chat/new.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/new.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from 'react-native';
 import { type Href, useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
+import { useActionSheet } from '@expo/react-native-action-sheet';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { generateMessageId } from 'cloud-agent-sdk/message-id';
 import * as Haptics from 'expo-haptics';
@@ -70,6 +71,7 @@ export default function NewSessionScreen() {
   const navigation = useNavigation();
   const colors = useThemeColors();
   const queryClient = useQueryClient();
+  const { showActionSheetWithOptions } = useActionSheet();
   const { organizationId } = useLocalSearchParams<{ organizationId?: string }>();
 
   // ── Selectors state ──────────────────────────────────────────────
@@ -257,8 +259,8 @@ export default function NewSessionScreen() {
 
   const { addCandidates } = attachments;
   const handleAddAttachment = useCallback(async () => {
-    addCandidates(await pickAgentAttachments());
-  }, [addCandidates]);
+    addCandidates(await pickAgentAttachments(showActionSheetWithOptions));
+  }, [addCandidates, showActionSheetWithOptions]);
 
   function handlePromptInputLayout(event: LayoutChangeEvent) {
     const nextWidth = Math.max(Math.round(event.nativeEvent.layout.width), 0);

--- a/apps/mobile/src/components/agents/attachment-picker.test.ts
+++ b/apps/mobile/src/components/agents/attachment-picker.test.ts
@@ -1,0 +1,43 @@
+import { type ActionSheetProps } from '@expo/react-native-action-sheet';
+import { describe, expect, it, vi } from 'vitest';
+
+import { pickAgentAttachments } from './attachment-picker';
+
+const reactNativeMock = vi.hoisted(() => ({
+  alert: vi.fn(),
+  openSettings: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({
+  Alert: { alert: reactNativeMock.alert },
+  Linking: { openSettings: reactNativeMock.openSettings },
+}));
+
+vi.mock('expo-document-picker', () => ({
+  getDocumentAsync: vi.fn(),
+}));
+
+vi.mock('expo-image-picker', () => ({
+  launchCameraAsync: vi.fn(),
+  launchImageLibraryAsync: vi.fn(),
+  requestCameraPermissionsAsync: vi.fn(),
+}));
+
+describe('agent attachment picker', () => {
+  it('opens a native action sheet that keeps all sources and the cancel action', () => {
+    const showActionSheet: ActionSheetProps['showActionSheetWithOptions'] = vi.fn(
+      (_options, _callback) => undefined
+    );
+
+    void pickAgentAttachments(showActionSheet);
+
+    expect(showActionSheet).toHaveBeenCalledWith(
+      {
+        options: ['Camera', 'Photo Library', 'Files', 'Cancel'],
+        cancelButtonIndex: 3,
+      },
+      expect.any(Function)
+    );
+    expect(reactNativeMock.alert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/components/agents/attachment-picker.ts
+++ b/apps/mobile/src/components/agents/attachment-picker.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/promise-function-async, require-await -- This module wraps Alert.alert and select-style pickers in Promise-returning helpers, so require-await and promise-function-async apply; prefer-await-to-then still applies inside the body. */
 import * as DocumentPicker from 'expo-document-picker';
 import * as ImagePicker from 'expo-image-picker';
+import { type ActionSheetProps } from '@expo/react-native-action-sheet';
 import { Alert, Linking } from 'react-native';
 
 import {
@@ -109,6 +110,9 @@ async function pickAgentDocuments(): Promise<AgentAttachmentCandidate[]> {
 
 type AttachmentSource = 'camera' | 'library' | 'files';
 
+const ATTACHMENT_SOURCE_OPTIONS = ['Camera', 'Photo Library', 'Files', 'Cancel'];
+const ATTACHMENT_SOURCE_CANCEL_INDEX = ATTACHMENT_SOURCE_OPTIONS.length - 1;
+
 async function pickFromSource(source: AttachmentSource): Promise<AgentAttachmentCandidate[]> {
   if (source === 'camera') {
     return pickAgentCameraImage();
@@ -119,7 +123,9 @@ async function pickFromSource(source: AttachmentSource): Promise<AgentAttachment
   return pickAgentDocuments();
 }
 
-export function pickAgentAttachments(): Promise<AgentAttachmentCandidate[]> {
+export function pickAgentAttachments(
+  showActionSheetWithOptions: ActionSheetProps['showActionSheetWithOptions']
+): Promise<AgentAttachmentCandidate[]> {
   return new Promise(resolve => {
     let settled = false;
     const settle = (value: AgentAttachmentCandidate[]) => {
@@ -132,41 +138,21 @@ export function pickAgentAttachments(): Promise<AgentAttachmentCandidate[]> {
       const result = await pickFromSource(source);
       settle(result);
     };
-    Alert.alert(
-      'Add attachment',
-      'Choose a source',
-      [
-        {
-          text: 'Camera',
-          onPress: () => {
-            void handle('camera');
-          },
-        },
-        {
-          text: 'Photo Library',
-          onPress: () => {
-            void handle('library');
-          },
-        },
-        {
-          text: 'Files',
-          onPress: () => {
-            void handle('files');
-          },
-        },
-        {
-          text: 'Cancel',
-          style: 'cancel',
-          onPress: () => {
-            settle([]);
-          },
-        },
-      ],
+    showActionSheetWithOptions(
       {
-        cancelable: true,
-        onDismiss: () => {
+        options: ATTACHMENT_SOURCE_OPTIONS,
+        cancelButtonIndex: ATTACHMENT_SOURCE_CANCEL_INDEX,
+      },
+      index => {
+        if (index === 0) {
+          void handle('camera');
+        } else if (index === 1) {
+          void handle('library');
+        } else if (index === 2) {
+          void handle('files');
+        } else {
           settle([]);
-        },
+        }
       }
     );
   });

--- a/apps/mobile/src/components/agents/chat-composer.tsx
+++ b/apps/mobile/src/components/agents/chat-composer.tsx
@@ -1,4 +1,5 @@
 import * as Haptics from 'expo-haptics';
+import { useActionSheet } from '@expo/react-native-action-sheet';
 import { ArrowUp, Paperclip, Square } from 'lucide-react-native';
 import { useCallback, useRef, useState } from 'react';
 import {
@@ -69,6 +70,7 @@ export function ChatComposer({
   attachmentsEnabled = true,
 }: Readonly<ChatComposerProps>) {
   const colors = useThemeColors();
+  const { showActionSheetWithOptions } = useActionSheet();
   const textRef = useRef('');
   const inputRef = useRef<TextInput>(null);
   const [hasText, setHasText] = useState(false);
@@ -134,8 +136,8 @@ export function ChatComposer({
   const { addCandidates, removeAttachment } = upload;
 
   const handleAddAttachment = useCallback(async () => {
-    addCandidates(await pickAgentAttachments());
-  }, [addCandidates]);
+    addCandidates(await pickAgentAttachments(showActionSheetWithOptions));
+  }, [addCandidates, showActionSheetWithOptions]);
 
   const textInputStyle: TextStyle = {
     color: colors.foreground,

--- a/apps/web/src/app/api/integrations/github/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, test } from '@jest/globals';
+import { createAppAuth } from '@octokit/auth-app';
+import { Octokit } from '@octokit/rest';
 import { NextRequest, NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user/server';
 import { verifyGitHubBotLinkState } from '@/lib/bot/github-link-state';
@@ -6,7 +8,10 @@ import { exchangeGitHubOAuthCode } from '@/lib/integrations/platforms/github/ada
 import { linkKiloUser } from '@/lib/bot-identity';
 import { bot } from '@/lib/bot';
 import { failureResult } from '@/lib/maybe-result';
-import { findIntegrationByInstallationId } from '@/lib/integrations/db/platform-integrations';
+import {
+  findIntegrationByInstallationId,
+  upsertPlatformIntegrationForOwner,
+} from '@/lib/integrations/db/platform-integrations';
 import { isOrganizationMember } from '@/lib/organizations/organizations';
 import type { StateAdapter } from 'chat';
 
@@ -67,6 +72,9 @@ const mockedExchangeGitHubOAuthCode = jest.mocked(exchangeGitHubOAuthCode);
 const mockedLinkKiloUser = jest.mocked(linkKiloUser);
 const mockedBot = jest.mocked(bot);
 const mockedFindIntegrationByInstallationId = jest.mocked(findIntegrationByInstallationId);
+const mockedCreateAppAuth = jest.mocked(createAppAuth);
+const mockedOctokit = jest.mocked(Octokit);
+const mockedUpsertPlatformIntegrationForOwner = jest.mocked(upsertPlatformIntegrationForOwner);
 const mockedIsOrganizationMember = jest.mocked(isOrganizationMember);
 
 const USER_ID = '034489e8-19e0-4479-9d69-2edad719e847';
@@ -204,5 +212,61 @@ describe('GET /api/integrations/github/callback bot link flow', () => {
     await GET(makeRequest('/api/integrations/github/callback?code=abc&state=signed') as never);
 
     expect(mockedExchangeGitHubOAuthCode).toHaveBeenCalledWith('abc', 'lite');
+  });
+});
+
+describe('GET /api/integrations/github/callback installation flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: {
+        id: USER_ID,
+        google_user_email: 'mobile-e2e@example.com',
+        google_user_name: 'Mobile E2E',
+      },
+      authFailedResponse: null,
+    } as never);
+    mockedCreateAppAuth.mockReturnValue(
+      jest.fn(async () => ({ token: 'github-app-token' })) as never
+    );
+    mockedOctokit.mockImplementation(
+      () =>
+        ({
+          apps: {
+            getInstallation: jest.fn(async () => ({
+              data: {
+                account: { id: 12_345, login: 'securexg' },
+                created_at: '2026-07-09T19:00:00.000Z',
+                events: ['issues'],
+                permissions: { contents: 'write' },
+                repository_selection: 'all',
+              },
+            })),
+            listReposAccessibleToInstallation: jest.fn(),
+          },
+        }) as never
+    );
+  });
+
+  test('associates an existing installation after GitHub updates its configuration', async () => {
+    const { GET } = await import('./route');
+    const response = await GET(
+      makeRequest(
+        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=update&state=user_${USER_ID}%7Creturn%3D%252Fgithub-app`
+      ) as never
+    );
+
+    expect(response.status).toBe(307);
+    expectRedirectLocation(response, '/github-app?github_install=success');
+    expect(mockedUpsertPlatformIntegrationForOwner).toHaveBeenCalledWith(
+      { type: 'user', id: USER_ID },
+      expect.objectContaining({
+        platform: 'github',
+        integrationType: 'app',
+        platformInstallationId: INSTALLATION_ID,
+        platformAccountLogin: 'securexg',
+      })
+    );
   });
 });

--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -359,7 +359,7 @@ export async function GET(request: NextRequest) {
     }
 
     // 8. Store installation in database using new platform_integrations table
-    if (setupAction === 'install') {
+    if (setupAction === 'install' || setupAction === 'update') {
       // Handle null account and union type (User | Organization)
       if (!installation.account) {
         throw new Error('Installation account is missing');

--- a/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
+++ b/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
@@ -171,8 +171,11 @@ describe('processAppStoreKiloPassNotification', () => {
       notificationType: NotificationTypeV2.CONSUMPTION_REQUEST,
     });
     const decodedTransaction = transaction();
+    const consumptionInformationStarted = Promise.withResolvers<void>();
+    const releaseConsumptionInformation = Promise.withResolvers<void>();
     const sendConsumptionInformation = jest.fn(async () => {
-      await new Promise(resolve => setTimeout(resolve, 25));
+      consumptionInformationStarted.resolve();
+      await releaseConsumptionInformation.promise;
     });
     const params = {
       signedPayload: 'concurrent-consumption-request',
@@ -181,10 +184,14 @@ describe('processAppStoreKiloPassNotification', () => {
       sendConsumptionInformation,
     };
 
-    const results = await Promise.all([
-      processAppStoreKiloPassNotification(params),
-      processAppStoreKiloPassNotification(params),
-    ]);
+    const firstDelivery = processAppStoreKiloPassNotification(params);
+    await consumptionInformationStarted.promise;
+
+    const duplicateResult = await processAppStoreKiloPassNotification(params);
+
+    releaseConsumptionInformation.resolve();
+    const firstResult = await firstDelivery;
+    const results = [firstResult, duplicateResult];
 
     expect(results.filter(result => result.processed)).toHaveLength(1);
     expect(results).toContainEqual({ processed: false, status: 'in_flight' });


### PR DESCRIPTION
## Summary

- persist GitHub App installations when an already-installed app returns `setup_action=update`, allowing the mobile repository refetch to discover the installation
- replace the Cloud Agent attachment source alert with the native action sheet so Android renders Camera, Photo Library, Files, and Cancel
- cover both regressions with focused callback and mobile picker tests

Production evidence showed a connected personal GitHub OAuth identity but no applicable `platform_integrations` row. The callback previously fetched existing installation details and returned success for `update`, but skipped the upsert reserved for `install`.

## Verification

- [x] Reproduced the Android source chooser without a Cancel action on a Pixel 7 Android 15 emulator
- [x] Verified the fixed chooser renders Camera, Photo Library, Files, and Cancel through Maestro
- [x] Selected a gallery image and observed the Cloud Agent attachment reach `uploaded`
- [x] Reproduced the no-installation repository gate locally with the same account-state shape as production

## Visual Changes

N/A. This changes the attachment source control from a truncated Android alert to the app-standard native action sheet.

## Reviewer Notes

The owner authorization checks still run before installation fetch and persistence. Automated verification: all 587 mobile tests, mobile typecheck/lint/knip, web typecheck/lint, focused callback tests, formatting, and `git diff --check`. An independent review found no issues.