### PR TITLE
O11y - Monitor containment containers and add 60% info capacity alert

### DIFF
--- a/services/o11y/src/alerting/container-capacity.ts
+++ b/services/o11y/src/alerting/container-capacity.ts
@@ -42,6 +42,7 @@ export type ContainerCapacityAlert = {
 export const CONTAINER_CAPACITY_THRESHOLDS = {
   page: 0.95,
   ticket: 0.8,
+  ticketEarly: 0.6,
 } as const;
 
 /** Application names to monitor (lowercase, as returned by the Cloudflare API). */
@@ -49,6 +50,9 @@ export const MONITORED_CONTAINER_APPS: readonly string[] = [
   'cloud-agent-next-sandbox',
   'cloud-agent-next-sandboxsmall',
   'cloud-agent-next-sandboxcodereview',
+  'cloud-agent-next-sandboxcontainment',
+  'cloud-agent-next-sandboxsmallcontainment',
+  'cloud-agent-next-sandboxcodereviewcontainment',
 ];
 
 // ── Zod schemas for the Cloudflare Containers API ───────────────────────────
@@ -136,6 +140,9 @@ export function evaluateCapacityThresholds(apps: ContainerApplication[]): Contai
     } else if (utilization >= CONTAINER_CAPACITY_THRESHOLDS.ticket) {
       severity = 'ticket';
       thresholdFraction = CONTAINER_CAPACITY_THRESHOLDS.ticket;
+    } else if (utilization >= CONTAINER_CAPACITY_THRESHOLDS.ticketEarly) {
+      severity = 'info';
+      thresholdFraction = CONTAINER_CAPACITY_THRESHOLDS.ticketEarly;
     }
 
     if (severity === null) continue;

--- a/services/o11y/src/alerting/dedup.ts
+++ b/services/o11y/src/alerting/dedup.ts
@@ -7,7 +7,11 @@
  */
 
 import type { AlertSeverity } from './slo-config';
-import { PAGE_COOLDOWN_SECONDS, TICKET_COOLDOWN_SECONDS } from './slo-config';
+import {
+  PAGE_COOLDOWN_SECONDS,
+  TICKET_COOLDOWN_SECONDS,
+  INFO_COOLDOWN_SECONDS,
+} from './slo-config';
 
 function alertKey(
   severity: AlertSeverity,
@@ -19,9 +23,24 @@ function alertKey(
   return `o11y:alert:${severity}:${alertType}:${provider}:${model}:${clientName}`;
 }
 
+const COOLDOWN_SECONDS: Record<AlertSeverity, number> = {
+  page: PAGE_COOLDOWN_SECONDS,
+  ticket: TICKET_COOLDOWN_SECONDS,
+  info: INFO_COOLDOWN_SECONDS,
+};
+
 function cooldownForSeverity(severity: AlertSeverity): number {
-  return severity === 'page' ? PAGE_COOLDOWN_SECONDS : TICKET_COOLDOWN_SECONDS;
+  return COOLDOWN_SECONDS[severity];
 }
+
+// Higher severities that suppress a given severity for the same dimension.
+// Lower severities never suppress higher ones, so an early warning does not
+// block escalation (e.g. an info alert at 60% does not suppress a ticket at 80%).
+const HIGHER_SEVERITIES: Record<AlertSeverity, AlertSeverity[]> = {
+  page: [],
+  ticket: ['page'],
+  info: ['page', 'ticket'],
+};
 
 /**
  * Check whether an alert should be suppressed.
@@ -41,12 +60,10 @@ export async function shouldSuppress(
   const existing = await kv.get(key);
   if (existing) return true;
 
-  // If this is a ticket, also check if a page-level alert is active
-  // (page suppresses ticket for the same dimension).
-  if (severity === 'ticket') {
-    const pageKey = alertKey('page', alertType, provider, model, clientName);
-    const pageExisting = await kv.get(pageKey);
-    if (pageExisting) return true;
+  // A higher-severity marker for the same dimension suppresses this alert.
+  for (const higher of HIGHER_SEVERITIES[severity]) {
+    const higherExisting = await kv.get(alertKey(higher, alertType, provider, model, clientName));
+    if (higherExisting) return true;
   }
 
   return false;

--- a/services/o11y/src/alerting/notify.ts
+++ b/services/o11y/src/alerting/notify.ts
@@ -84,6 +84,17 @@ function formatPercent(value: number): string {
   return `${(value * 100).toFixed(2)}%`;
 }
 
+function formatSeverityLabel(severity: AlertSeverity): string {
+  switch (severity) {
+    case 'page':
+      return ':rotating_light: PAGE';
+    case 'ticket':
+      return ':ticket: TICKET';
+    case 'info':
+      return ':information_source: INFO';
+  }
+}
+
 function formatAlertTypeLabel(alertType: AlertPayload['alertType']): string {
   switch (alertType) {
     case 'error_rate':
@@ -109,7 +120,7 @@ function buildSloMetricLine(alert: SloAlertPayload): string {
 }
 
 function buildSloSlackBlocks(alert: SloAlertPayload): object[] {
-  const severityLabel = alert.severity === 'page' ? ':rotating_light: PAGE' : ':ticket: TICKET';
+  const severityLabel = formatSeverityLabel(alert.severity);
   const typeLabel = formatAlertTypeLabel(alert.alertType);
 
   return [
@@ -143,7 +154,7 @@ function buildSloSlackBlocks(alert: SloAlertPayload): object[] {
 }
 
 function buildCapacitySlackBlocks(alert: ContainerCapacityAlertPayload): object[] {
-  const severityLabel = alert.severity === 'page' ? ':rotating_light: PAGE' : ':ticket: TICKET';
+  const severityLabel = formatSeverityLabel(alert.severity);
   const utilizationPct = (alert.utilizationFraction * 100).toFixed(1);
   const thresholdPct = (alert.thresholdFraction * 100).toFixed(1);
 
@@ -183,7 +194,7 @@ function buildCapacitySlackBlocks(alert: ContainerCapacityAlertPayload): object[
 }
 
 function buildQueueBacklogSlackBlocks(alert: QueueBacklogAlertPayload): object[] {
-  const severityLabel = alert.severity === 'page' ? ':rotating_light: PAGE' : ':ticket: TICKET';
+  const severityLabel = formatSeverityLabel(alert.severity);
   const oldestMessageTimestamp = alert.oldestMessageTimestamp?.toISOString() ?? 'Unknown';
 
   return [

--- a/services/o11y/src/alerting/slo-config.ts
+++ b/services/o11y/src/alerting/slo-config.ts
@@ -8,7 +8,7 @@
  * exceed the burn rate threshold for a given provider:model.
  */
 
-export type AlertSeverity = 'page' | 'ticket';
+export type AlertSeverity = 'page' | 'ticket' | 'info';
 
 export type BurnRateWindow = {
   severity: AlertSeverity;
@@ -27,3 +27,4 @@ export const BURN_RATE_WINDOWS: BurnRateWindow[] = [
 // Alert dedup cooldowns
 export const PAGE_COOLDOWN_SECONDS = 15 * 60; // 15 minutes
 export const TICKET_COOLDOWN_SECONDS = 4 * 60 * 60; // 4 hours
+export const INFO_COOLDOWN_SECONDS = 4 * 60 * 60; // 4 hours

--- a/services/o11y/test/alerting.spec.ts
+++ b/services/o11y/test/alerting.spec.ts
@@ -135,6 +135,58 @@ describe('dedup', () => {
     expect(result).toBe(false);
   });
 
+  it('page suppresses info for the same dimension', async () => {
+    await recordAlertFired(kv, 'page', 'error_rate', 'openai', 'gpt-4', 'kilo-gateway');
+    const result = await shouldSuppress(
+      kv,
+      'info',
+      'error_rate',
+      'openai',
+      'gpt-4',
+      'kilo-gateway'
+    );
+    expect(result).toBe(true);
+  });
+
+  it('ticket suppresses info for the same dimension', async () => {
+    await recordAlertFired(kv, 'ticket', 'error_rate', 'openai', 'gpt-4', 'kilo-gateway');
+    const result = await shouldSuppress(
+      kv,
+      'info',
+      'error_rate',
+      'openai',
+      'gpt-4',
+      'kilo-gateway'
+    );
+    expect(result).toBe(true);
+  });
+
+  it('info does not suppress ticket (escalation is independent)', async () => {
+    await recordAlertFired(kv, 'info', 'error_rate', 'openai', 'gpt-4', 'kilo-gateway');
+    const result = await shouldSuppress(
+      kv,
+      'ticket',
+      'error_rate',
+      'openai',
+      'gpt-4',
+      'kilo-gateway'
+    );
+    expect(result).toBe(false);
+  });
+
+  it('info does not suppress page', async () => {
+    await recordAlertFired(kv, 'info', 'error_rate', 'openai', 'gpt-4', 'kilo-gateway');
+    const result = await shouldSuppress(
+      kv,
+      'page',
+      'error_rate',
+      'openai',
+      'gpt-4',
+      'kilo-gateway'
+    );
+    expect(result).toBe(false);
+  });
+
   it('records alert with TTL', async () => {
     await recordAlertFired(kv, 'page', 'error_rate', 'openai', 'gpt-4', 'kilo-gateway');
     expect(putSpy).toHaveBeenCalledWith(
@@ -150,6 +202,17 @@ describe('dedup', () => {
     await recordAlertFired(kv, 'ticket', 'error_rate', 'openai', 'gpt-4', 'kilo-gateway');
     expect(putSpy).toHaveBeenCalledWith(
       'o11y:alert:ticket:error_rate:openai:gpt-4:kilo-gateway',
+      expect.any(String),
+      {
+        expirationTtl: 4 * 60 * 60,
+      }
+    );
+  });
+
+  it('info cooldown is 4 hours', async () => {
+    await recordAlertFired(kv, 'info', 'error_rate', 'openai', 'gpt-4', 'kilo-gateway');
+    expect(putSpy).toHaveBeenCalledWith(
+      'o11y:alert:info:error_rate:openai:gpt-4:kilo-gateway',
       expect.any(String),
       {
         expirationTtl: 4 * 60 * 60,

--- a/services/o11y/test/container-capacity-evaluate.spec.ts
+++ b/services/o11y/test/container-capacity-evaluate.spec.ts
@@ -129,6 +129,51 @@ describe('evaluateContainerCapacity', () => {
     expect(kv.store.has(pageKey)).toBe(true);
   });
 
+  it('fires an info alert at 60% utilization', async () => {
+    const queryFn = vi.fn(
+      async (): Promise<ContainerApplication[]> => [
+        { id: 'id1', name: 'cloud-agent-next-sandbox', instances: 60, maxInstances: 100 },
+      ]
+    );
+    await evaluateContainerCapacity(makeEnv(kv), queryFn, notifyFn);
+    expect(sentAlerts).toHaveLength(1);
+    expect(sentAlerts[0].severity).toBe('info');
+    expect(sentAlerts[0].thresholdFraction).toBe(0.6);
+    const [key] = [...kv.store.keys()];
+    expect(key).toContain('info');
+    expect(key).toContain('container_capacity');
+    expect(key).toContain('cloud-agent-next-sandbox');
+  });
+
+  it('does not suppress a ticket alert when only an info marker exists (escalation is independent)', async () => {
+    kv.store.set(
+      'o11y:alert:info:container_capacity:cloudflare:cloud-agent-next-sandbox:containers',
+      new Date().toISOString()
+    );
+    const queryFn = vi.fn(
+      async (): Promise<ContainerApplication[]> => [
+        { id: 'id1', name: 'cloud-agent-next-sandbox', instances: 81, maxInstances: 100 },
+      ]
+    );
+    await evaluateContainerCapacity(makeEnv(kv), queryFn, notifyFn);
+    expect(sentAlerts).toHaveLength(1);
+    expect(sentAlerts[0].severity).toBe('ticket');
+  });
+
+  it('suppresses an info alert when a ticket marker exists for the same dimension', async () => {
+    kv.store.set(
+      'o11y:alert:ticket:container_capacity:cloudflare:cloud-agent-next-sandbox:containers',
+      new Date().toISOString()
+    );
+    const queryFn = vi.fn(
+      async (): Promise<ContainerApplication[]> => [
+        { id: 'id1', name: 'cloud-agent-next-sandbox', instances: 60, maxInstances: 100 },
+      ]
+    );
+    await evaluateContainerCapacity(makeEnv(kv), queryFn, notifyFn);
+    expect(sentAlerts).toHaveLength(0);
+  });
+
   it('propagates API query failure as thrown error', async () => {
     const failingQuery = vi.fn(async (): Promise<ContainerApplication[]> => {
       throw new Error('API unreachable');

--- a/services/o11y/test/container-capacity.spec.ts
+++ b/services/o11y/test/container-capacity.spec.ts
@@ -29,6 +29,10 @@ describe('CONTAINER_CAPACITY_THRESHOLDS', () => {
   it('ticket threshold is 0.80', () => {
     expect(CONTAINER_CAPACITY_THRESHOLDS.ticket).toBe(0.8);
   });
+
+  it('ticketEarly threshold is 0.60', () => {
+    expect(CONTAINER_CAPACITY_THRESHOLDS.ticketEarly).toBe(0.6);
+  });
 });
 
 describe('evaluateCapacityThresholds', () => {
@@ -81,8 +85,24 @@ describe('evaluateCapacityThresholds', () => {
     expect(alerts[0].severity).toBe('page');
   });
 
-  it('returns no alert at 79% utilization (just below ticket threshold)', () => {
+  it('returns info alert at 79% utilization (crosses 60% early tier)', () => {
     const apps = [makeApp({ name: MONITORED, instances: 79, maxInstances: 100 })];
+    const alerts = evaluateCapacityThresholds(apps);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe('info');
+    expect(alerts[0].thresholdFraction).toBe(CONTAINER_CAPACITY_THRESHOLDS.ticketEarly);
+  });
+
+  it('returns info alert at exactly 60% utilization (early tier boundary inclusive)', () => {
+    const apps = [makeApp({ name: MONITORED, instances: 60, maxInstances: 100 })];
+    const alerts = evaluateCapacityThresholds(apps);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe('info');
+    expect(alerts[0].thresholdFraction).toBe(CONTAINER_CAPACITY_THRESHOLDS.ticketEarly);
+  });
+
+  it('returns no alert at 59% utilization (just below early tier)', () => {
+    const apps = [makeApp({ name: MONITORED, instances: 59, maxInstances: 100 })];
     expect(evaluateCapacityThresholds(apps)).toEqual([]);
   });
 

--- a/services/o11y/test/notify.spec.ts
+++ b/services/o11y/test/notify.spec.ts
@@ -229,4 +229,17 @@ describe('buildSlackMessage — container_capacity alert', () => {
     ]);
     expect(allText.some(t => t.includes('230'))).toBe(true);
   });
+
+  it('includes INFO severity label for an info-tier alert', () => {
+    const infoAlert: ContainerCapacityAlertPayload = {
+      ...alert,
+      severity: 'info',
+      usedInstances: 60,
+      maxInstances: 100,
+      utilizationFraction: 0.6,
+      thresholdFraction: 0.6,
+    };
+    const msg = buildSlackMessage(infoAlert) as { blocks: Array<{ text?: { text: string } }> };
+    expect(msg.blocks[0].text?.text).toContain('INFO');
+  });
 });


### PR DESCRIPTION
## Summary

Extends o11y container-capacity alerting to cover the credential-containment sandbox applications and adds a new early-warning alert tier at 60% utilization.

## Changes

**Containment container monitoring**
- Adds three containment container apps to `MONITORED_CONTAINER_APPS` (`cloud-agent-next-sandboxcontainment`, `cloud-agent-next-sandboxsmallcontainment`, `cloud-agent-next-sandboxcodereviewcontainment`), matching the `SandboxContainment` / `SandboxSmallContainment` / `SandboxCodeReviewContainment` container classes in `services/cloud-agent-next/wrangler.jsonc`.

**60% early-warning tier**
- Introduces an `info` severity distinct from `page`/`ticket`, with its own dedup key and a 4h cooldown (same as ticket).
- Adds a `ticketEarly` threshold at 0.6; capacity between 60–79% now emits an `info` alert.
- Generalizes the dedup suppression hierarchy (`page` > `ticket` > `info`): higher severities suppress lower, but lower never suppresses higher, so the 60% alert does not block escalation to the 80% `ticket` or 95% `page` alerts.
- `info` alerts route to the existing ticket Slack webhook (no new secret required).

## Behavior
- `<60%` → no alert
- `60–79%` → `info` (4h cooldown, ticket channel)
- `80–94%` → `ticket` (independent of `info` marker)
- `≥95%` → `page`

## Verification
- All 168 o11y tests pass; `tsgo` typecheck and `oxlint` clean.
- Added dedup-hierarchy unit tests (info doesn't suppress ticket/page; ticket & page suppress info; info cooldown), evaluate-level split tests (info marker doesn't block 81% ticket; ticket marker suppresses 60% info), and an INFO-label notify test.

## Note
Containment app names assume Cloudflare names container applications as `<worker>-<class-lowercased>`, as it does for the existing three. Worth confirming against an actual `GET .../containers/dash/applications` listing after deploy.