### PR TITLE
Fix exclusive model provider restriction mutation

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/anthropic.constants';
-import { applyGatewayModelsFallback } from '@/lib/ai-gateway/providers/apply-provider-specific-logic';
+import {
+  applyGatewayModelsFallback,
+  applyPreferredProvider,
+} from '@/lib/ai-gateway/providers/apply-provider-specific-logic';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 
@@ -44,5 +47,28 @@ describe('applyGatewayModelsFallback', () => {
     applyGatewayModelsFallback('openrouter', 'openai/gpt-4o', request);
 
     expect(request.body.models).toBeUndefined();
+  });
+});
+
+describe('applyPreferredProvider', () => {
+  it('preserves valid provider options when adding order', () => {
+    const request = makeRequest('anthropic/claude-sonnet-4.5');
+    request.body.provider = { zdr: true };
+
+    applyPreferredProvider('anthropic/claude-sonnet-4.5', request.body);
+
+    expect(request.body.provider).toEqual({
+      zdr: true,
+      order: ['amazon-bedrock', 'anthropic'],
+    });
+  });
+
+  it('overwrites a malformed provider value', () => {
+    const request = makeRequest('anthropic/claude-sonnet-4.5');
+    Object.assign(request.body, { provider: 'lmstudio' });
+
+    applyPreferredProvider('anthropic/claude-sonnet-4.5', request.body);
+
+    expect(request.body.provider).toEqual({ order: ['amazon-bedrock', 'anthropic'] });
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -1,8 +1,9 @@
-import type {
-  GatewayResponsesRequest,
-  OpenRouterChatCompletionRequest,
-  GatewayRequest,
-  GatewayMessagesRequest,
+import {
+  isOpenRouterProviderConfig,
+  type GatewayResponsesRequest,
+  type OpenRouterChatCompletionRequest,
+  type GatewayRequest,
+  type GatewayMessagesRequest,
 } from '@/lib/ai-gateway/providers/openrouter/types';
 import { applyMistralModelSettings, isMistralModel } from '@/lib/ai-gateway/providers/mistral';
 import { findKiloExclusiveModel } from '@/lib/ai-gateway/models';
@@ -75,7 +76,7 @@ export function getPreferredProviderOrder(requestedModel: string): string[] {
   return [];
 }
 
-function applyPreferredProvider(
+export function applyPreferredProvider(
   requestedModel: string,
   requestToMutate:
     | OpenRouterChatCompletionRequest
@@ -89,7 +90,7 @@ function applyPreferredProvider(
   console.debug(
     `[applyPreferredProvider] Preferentially routing ${requestedModel} to ${preferredProviderOrder.join()}`
   );
-  if (!requestToMutate.provider) {
+  if (!isOpenRouterProviderConfig(requestToMutate.provider)) {
     requestToMutate.provider = { order: preferredProviderOrder };
   } else if (!requestToMutate.provider.order) {
     requestToMutate.provider.order = preferredProviderOrder;

--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.test.ts
@@ -141,7 +141,20 @@ describe('applyKiloExclusiveModelSettings', () => {
         inference_provider_restriction: ['anthropic'] as OpenRouterInferenceProviderId[],
       })
     );
-    expect(req.body.provider).toEqual({ zdr: true, only: ['anthropic'] });
+    expect(req.body.provider).toEqual({ only: ['anthropic'] });
+  });
+
+  it('overwrites a malformed provider value', () => {
+    const req = makeRequest();
+    Object.assign(req.body, { provider: 'lmstudio' });
+    applyKiloExclusiveModelSettings(
+      req,
+      makeModel({
+        internal_id: 'vendor/x',
+        inference_provider_restriction: ['anthropic'] as OpenRouterInferenceProviderId[],
+      })
+    );
+    expect(req.body.provider).toEqual({ only: ['anthropic'] });
   });
 
   it('intersects caller-supplied only with the restriction', () => {

--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.test.ts
@@ -141,7 +141,7 @@ describe('applyKiloExclusiveModelSettings', () => {
         inference_provider_restriction: ['anthropic'] as OpenRouterInferenceProviderId[],
       })
     );
-    expect(req.body.provider).toEqual({ only: ['anthropic'] });
+    expect(req.body.provider).toEqual({ zdr: true, only: ['anthropic'] });
   });
 
   it('overwrites a malformed provider value', () => {

--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
@@ -4,7 +4,10 @@ import {
   type OpenRouterInferenceProviderId,
 } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
-import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import {
+  isOpenRouterProviderConfig,
+  type GatewayRequest,
+} from '@/lib/ai-gateway/providers/openrouter/types';
 
 export type KiloExclusiveModelFlag =
   | 'reasoning'
@@ -167,8 +170,10 @@ export function applyKiloExclusiveModelSettings(
     return;
   }
   const provider = requestToMutate.body.provider;
-  if (provider?.only) {
+  if (isOpenRouterProviderConfig(provider) && provider.only) {
     provider.only = [...new Set(provider.only).intersection(new Set<string>(restriction))];
+  } else if (isOpenRouterProviderConfig(provider)) {
+    provider.only = [...restriction];
   } else {
     requestToMutate.body.provider = { only: [...restriction] };
   }

--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
@@ -169,8 +169,6 @@ export function applyKiloExclusiveModelSettings(
   const provider = requestToMutate.body.provider;
   if (provider?.only) {
     provider.only = [...new Set(provider.only).intersection(new Set<string>(restriction))];
-  } else if (provider) {
-    provider.only = [...restriction];
   } else {
     requestToMutate.body.provider = { only: [...restriction] };
   }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
@@ -17,6 +17,10 @@ export type OpenRouterProviderConfig = {
   require_parameters?: boolean;
 };
 
+export function isOpenRouterProviderConfig(value: unknown): value is OpenRouterProviderConfig {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export type VercelInferenceProviderConfig = { apiKey: string; baseURL?: string } | AwsCredentials;
 
 export type VercelProviderConfig = {


### PR DESCRIPTION
## Summary
- validate that provider routing configuration is a non-null, non-array object before mutating it
- preserve valid provider options while adding exclusive-model `only` or preferred-provider `order` routing
- overwrite malformed primitive provider values such as `lmstudio`
- add regression coverage for both mutation paths

## Trigger analysis
- the exact `Cannot create property 'only' on string 'lmstudio'` error originated from `kilo-exclusive-model.ts`
- the preferred-provider mutation had the analogous risk of producing `Cannot create property 'order' on string 'lmstudio'` and is fixed in this PR

## Verification
- changed-file `oxlint`: passed with zero warnings/errors
- `pnpm format`: passed
- `git diff --check`: passed
- focused Jest suites attempted, but global setup could not connect to the test PostgreSQL database