### PR TITLE
CloudAgentNext - Add GitLab outbound diagnostic logging

### DIFF
--- a/services/cloud-agent-next/src/sandbox-outbound.ts
+++ b/services/cloud-agent-next/src/sandbox-outbound.ts
@@ -522,24 +522,76 @@ async function handleManagedGitLabOutbound(
   capability: { capability: string },
   outboundContainerId: string
 ): Promise<Response> {
+  const logFields = {
+    ...getSafeRequestLogFields(request),
+    provider: 'gitlab',
+    capabilityVersion: getCapabilityVersion(capability.capability),
+    outboundContainerId,
+  };
+  logDiagnostic('debug', logFields, 'Redeeming managed GitLab outbound request');
+
   const tokenService = env.GIT_TOKEN_SERVICE;
   if (!supportsGitLabSessionCapabilityRedemption(tokenService)) {
+    logDiagnostic(
+      'warn',
+      { ...logFields, failureStage: 'redemption-binding' },
+      'Managed GitLab outbound redemption unavailable'
+    );
     return new Response('GitLab authorization unavailable', { status: 502 });
   }
+
+  let result: Awaited<ReturnType<GitLabTokenRedemptionBinding['redeemGitLabSessionCapability']>>;
   try {
-    const result = await tokenService.redeemGitLabSessionCapability({
+    result = await tokenService.redeemGitLabSessionCapability({
       capability: capability.capability,
       outboundContainerId,
       requestMethod: request.method,
       requestUrl: request.url,
     });
-    if (!result.success) {
-      return new Response('GitLab authorization unavailable', { status: 502 });
-    }
-    return await forwardRedeemedRequest(request, result.headers, true);
-  } catch {
+  } catch (error) {
+    logDiagnostic(
+      'warn',
+      {
+        ...logFields,
+        failureStage: 'redemption-rpc',
+        errorClass: classifyDiagnosticError(error),
+      },
+      'Managed GitLab outbound redemption failed'
+    );
     return new Response('GitLab authorization unavailable', { status: 502 });
   }
+
+  if (!result.success) {
+    logDiagnostic(
+      'warn',
+      { ...logFields, failureStage: 'redemption-policy', reason: result.reason },
+      'Managed GitLab outbound redemption rejected'
+    );
+    return new Response('GitLab authorization unavailable', { status: 502 });
+  }
+
+  let response: Response;
+  try {
+    response = await forwardRedeemedRequest(request, result.headers, true);
+  } catch (error) {
+    logDiagnostic(
+      'warn',
+      {
+        ...logFields,
+        failureStage: 'upstream-forward',
+        errorClass: classifyDiagnosticError(error),
+      },
+      'Managed GitLab outbound forwarding failed'
+    );
+    return new Response('GitLab authorization unavailable', { status: 502 });
+  }
+
+  logDiagnostic(
+    'info',
+    { ...logFields, upstreamStatus: response.status },
+    'Managed GitLab outbound request forwarded'
+  );
+  return response;
 }
 
 export function handleManagedScmOutbound(


### PR DESCRIPTION
## Summary

`handleManagedGitLabOutbound` was the only managed-SCM outbound handler
without diagnostic logging, making self-hosted GitLab containment failures
undistinguishable (all surfaced as opaque 502s).

Add the same structured `logDiagnostic` calls already present in the
GitHub and Kilo handlers:

- debug on redemption start
- warn with `failureStage` (`redemption-binding`, `redemption-rpc`,
  `redemption-policy`, `upstream-forward`) plus `reason`/`errorClass`
  at each failure point
- info with `upstreamStatus` on successful forward

No behavioral change; enforcement and fail-closed semantics are
unchanged. Existing 63 outbound tests pass.

## Test plan

- [x] `pnpm exec vitest run src/sandbox-outbound.test.ts` (63 passed)
- [x] `pnpm run lint` (clean)
- [x] `pnpm run typecheck` (clean)