### PR TITLE
CloudAgentNext - redistribute container capacity to containment classes

### DIFF
--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -163,7 +163,7 @@
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.54",
       },
-      "max_instances": 400,
+      "max_instances": 200,
       "rollout_active_grace_period": 1800,
     },
     {
@@ -177,7 +177,7 @@
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.54",
       },
-      "max_instances": 300,
+      "max_instances": 150,
       "rollout_active_grace_period": 1800,
     },
     {
@@ -205,7 +205,7 @@
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.54",
       },
-      "max_instances": 1000,
+      "max_instances": 500,
       "rollout_active_grace_period": 1800,
     },
     {
@@ -219,7 +219,7 @@
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.54",
       },
-      "max_instances": 400,
+      "max_instances": 750,
       "rollout_active_grace_period": 1800,
     },
     {
@@ -247,7 +247,7 @@
       "image_vars": {
         "KILOCODE_CLI_VERSION": "7.3.54",
       },
-      "max_instances": 1000,
+      "max_instances": 1500,
       "rollout_active_grace_period": 1800,
     },
   ],


### PR DESCRIPTION
## Summary

Redistribute production container capacity for `cloud-agent-next` from non-containment sandbox classes toward the containment classes, which were approaching their limits (e.g. `SandboxCodeReviewContainment` mid-rollout at 256/1000). Total production capacity is unchanged (3420).

## Changes (`services/cloud-agent-next/wrangler.jsonc`)

| Class | Old | New | Δ |
|---|---|---|---|
| Sandbox | 400 | 200 | -200 |
| SandboxSmall | 300 | 150 | -150 |
| SandboxCodeReview | 1000 | 500 | -500 |
| SandboxContainment | 400 | 750 | +350 |
| SandboxCodeReviewContainment | 1000 | 1500 | +500 |

Net: 0 (net-neutral redistribution).
