### PR TITLE
fix(deps): resolve Dependabot alerts 99, 200, and 201

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,9 @@ overrides:
   drizzle-orm: 0.45.2
   lodash-es: '>=4.18.1'
   '@xmldom/xmldom': 0.8.13
-  qs: '>=6.14.1'
+  qs: 6.15.2
+  smol-toml: 1.6.1
+  uuid@<11.1.1: 11.1.1
   serialize-javascript: '>=7.0.3'
   hono: 4.12.25
   '@hono/node-server': 1.19.14
@@ -15541,8 +15543,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -16397,8 +16399,8 @@ packages:
     resolution: {integrity: sha512-HVk9X1E0gz3mSpoi60h/saazLKXKaZThMLU3u/aNwoYn8/xQyX2MGxL0ui2eaokkD7tF+Zo+cKTHUbe1mmmGzA==}
     engines: {node: '>=8.0.0'}
 
-  smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
   sonic-boom@4.2.1:
@@ -17362,21 +17364,6 @@ packages:
 
   uuid@13.0.2:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
-    hasBin: true
-
-  uuid@7.0.3:
-    resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.6:
@@ -24400,7 +24387,7 @@ snapshots:
   '@sentry/webpack-plugin@5.1.1(webpack@5.105.4(@swc/core@1.15.18))':
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1
-      uuid: 9.0.1
+      uuid: 11.1.1
       webpack: 5.105.4(@swc/core@1.15.18)
     transitivePeerDependencies:
       - supports-color
@@ -24408,7 +24395,7 @@ snapshots:
   '@sentry/webpack-plugin@5.1.1(webpack@5.105.4)':
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1
-      uuid: 9.0.1
+      uuid: 11.1.1
       webpack: 5.105.4
     transitivePeerDependencies:
       - supports-color
@@ -24895,7 +24882,7 @@ snapshots:
       dequal: 2.0.3
       polished: 4.3.1
       storybook: 10.4.6(@types/react@19.2.14)(bufferutil@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6)
-      uuid: 9.0.1
+      uuid: 11.1.1
 
   '@storybook/addon-backgrounds@8.5.8(storybook@10.4.6(@types/react@19.2.14)(bufferutil@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))':
     dependencies:
@@ -25356,7 +25343,7 @@ snapshots:
       playwright-core: 1.60.0
       rimraf: 3.0.2
       storybook: 10.4.6(@types/react@19.2.14)(bufferutil@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6)
-      uuid: 8.3.2
+      uuid: 11.1.1
     transitivePeerDependencies:
       - '@swc/helpers'
       - '@types/node'
@@ -26983,7 +26970,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -29012,7 +28999,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -30137,7 +30124,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       p-map: 3.0.0
       rimraf: 3.0.2
-      uuid: 8.3.2
+      uuid: 11.1.1
 
   istanbul-lib-report@3.0.1:
     dependencies:
@@ -30483,7 +30470,7 @@ snapshots:
     dependencies:
       mkdirp: 1.0.4
       strip-ansi: 6.0.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       xml: 1.0.1
 
   jest-leak-detector@29.7.0:
@@ -31071,7 +31058,7 @@ snapshots:
       oxc-resolver: 11.19.1
       picocolors: 1.1.1
       picomatch: 4.0.4
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
       strip-json-comments: 5.0.3
       typescript: 5.9.3
       unbash: 2.2.0
@@ -31090,7 +31077,7 @@ snapshots:
       oxc-resolver: 11.19.1
       picocolors: 1.1.1
       picomatch: 4.0.4
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
       strip-json-comments: 5.0.3
       unbash: 2.2.0
       yaml: 2.8.4
@@ -32271,7 +32258,7 @@ snapshots:
       preact-render-to-string: 5.2.6(preact@10.28.4)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      uuid: 8.3.2
+      uuid: 11.1.1
 
   next-tick@1.1.0: {}
 
@@ -32372,7 +32359,7 @@ snapshots:
       is-wsl: 2.2.0
       semver: 7.8.2
       shellwords: 0.1.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       which: 2.0.2
 
   node-polyfill-webpack-plugin@2.0.1(webpack@5.105.4(esbuild@0.27.4)):
@@ -33420,7 +33407,7 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -34571,7 +34558,7 @@ snapshots:
 
   slugify@1.6.8: {}
 
-  smol-toml@1.6.0: {}
+  smol-toml@1.6.1: {}
 
   sonic-boom@4.2.1:
     dependencies:
@@ -34852,13 +34839,13 @@ snapshots:
 
   stripe@19.3.1(@types/node@24.12.4):
     dependencies:
-      qs: 6.15.0
+      qs: 6.15.2
     optionalDependencies:
       '@types/node': 24.12.4
 
   stripe@19.3.1(@types/node@25.5.2):
     dependencies:
-      qs: 6.15.0
+      qs: 6.15.2
     optionalDependencies:
       '@types/node': 25.5.2
 
@@ -35500,7 +35487,7 @@ snapshots:
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
-      qs: 6.15.0
+      qs: 6.15.2
 
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.0):
     dependencies:
@@ -35565,12 +35552,6 @@ snapshots:
   uuid@11.1.1: {}
 
   uuid@13.0.2: {}
-
-  uuid@7.0.3: {}
-
-  uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
 
   uvu@0.5.6:
     dependencies:
@@ -36333,7 +36314,7 @@ snapshots:
   xcode@3.0.1:
     dependencies:
       simple-plist: 1.3.1
-      uuid: 7.0.3
+      uuid: 11.1.1
 
   xdg-basedir@5.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -96,7 +96,9 @@ overrides:
   drizzle-orm: 0.45.2
   lodash-es: '>=4.18.1'
   '@xmldom/xmldom': 0.8.13
-  qs: '>=6.14.1'
+  qs: 6.15.2
+  smol-toml: 1.6.1
+  uuid@<11.1.1: 11.1.1
   serialize-javascript: '>=7.0.3'
   hono: 4.12.25
   '@hono/node-server': 1.19.14


### PR DESCRIPTION
## Summary

- upgrade `smol-toml` from 1.6.0 to 1.6.1 to address GHSA-v3rj-xjv7-4jmq ([Dependabot #99](https://github.com/Kilo-Org/cloud/security/dependabot/99))
- upgrade `qs` from 6.15.0 to 6.15.2 to address CVE-2026-8723 / GHSA-q8mj-m7cp-5q26 ([Dependabot #201](https://github.com/Kilo-Org/cloud/security/dependabot/201))
- override only `uuid` versions below 11.1.1 to 11.1.1 to address CVE-2026-41907 / GHSA-w5hq-g745-h8pq while retaining the already-safe `uuid@13.0.2` consumer ([Dependabot #200](https://github.com/Kilo-Org/cloud/security/dependabot/200))

## Potential Breaking Changes

Overall risk is **low to moderate**.

- `smol-toml` is a patch update with unchanged Node.js >=18 support. Its functional change replaces recursive comment skipping to prevent stack overflow. Parsing valid TOML should remain compatible; the main observable difference is that malicious documents containing thousands of consecutive comments no longer crash through uncontrolled recursion. Risk: low.
- `qs` is a patch update with unchanged runtime support. It fixes several edge cases between 6.15.0 and 6.15.2. The security-relevant observable change is that comma-format arrays containing null/undefined values under `encodeValuesOnly` now serialize instead of throwing. Other fixes affect unusual combinations such as `parameterLimit: Infinity` with `throwOnLimitExceeded`, nested bracket parsing, strict-null RFC1738 formatting, and custom charset-sentinel delimiters. Applications relying on the previous erroneous output or thrown errors could observe changed query strings, but these are corrective edge-case changes. Risk: low.
- `uuid` is the only cross-major update: legacy transitive versions 7.x, 8.x, and 9.x resolve to 11.1.1. Across those majors, uuid removed deep imports, changed package/module exports, dropped old Node/browser support, added native TypeScript types, and tightened some option/buffer behavior. This can break consumers that use `uuid/v4`, default imports, obsolete runtimes, or deprecated signatures. Repository-owned code uses supported named exports (`v4`, `v5`, and `validate`), and the repository requires Node 24. The affected packages installed successfully and the full web suite passed. The override is range-scoped so `uuid@13.0.2` remains untouched. Risk: moderate but mitigated.

## Verification

No manual product flow testing was performed because this changes transitive dependency resolution only. Automated checks performed locally:

- `pnpm install --frozen-lockfile`
- Gastown container `pnpm install --prod --frozen-lockfile`
- `pnpm test`: 634 suites passed, 8,512 tests passed, 3 skipped; all 6 web environment tests passed
- `pnpx expo-doctor`: 19/19 checks passed
- `pnpm why --recursive smol-toml`: resolves 1.6.1
- `pnpm why --recursive qs`: resolves 6.15.2
- `pnpm why --recursive uuid`: resolves 11.1.1 for previously vulnerable consumers and preserves 13.0.2
- `git diff --check`

## Visual Changes

N/A

## Reviewer Notes

The primary review focus is the scoped `uuid@<11.1.1` override because it intentionally crosses major versions for transitive consumers. GitHub should close all three alerts after this reaches the default branch and Dependabot rescans the lockfile.