### PR TITLE
chore(mobile): add Android changelog for build 98

### DIFF
--- a/apps/mobile/metadata/README.md
+++ b/apps/mobile/metadata/README.md
@@ -1,0 +1,24 @@
+# Store metadata
+
+Play Store listing metadata for the Android build of Kilo App, using the
+[fastlane `supply` layout](https://docs.fastlane.tools/actions/supply/#metadata-structure)
+so it can be consumed directly by `fastlane supply` or copied into the Play
+Console if we're not running fastlane in CI yet.
+
+## Changelogs
+
+`android/en-US/changelogs/<versionCode>.txt` holds the Play Store "What's new"
+text for a given Android `versionCode` (the build number shown in EAS/Play
+Console). Each file should be plain, user-facing release notes (no internal
+jargon, no PR/issue links) and stay within Google's 500-character limit per
+locale.
+
+Android build numbers are tracked via the `kilo-app-release/<date>-<sha>` tags
+pushed by `.github/workflows/kilo-app-release.yml`. To find the commit range
+for a given build, diff the tag for that build against the tag for the
+previous build, filtered to the paths the release workflow watches
+(`apps/mobile/`, `packages/trpc/`, `pnpm-lock.yaml`):
+
+```bash
+git log --oneline <previous-tag>..<this-tag> -- apps/mobile packages/trpc pnpm-lock.yaml
+```

--- a/apps/mobile/metadata/android/en-US/changelogs/98.txt
+++ b/apps/mobile/metadata/android/en-US/changelogs/98.txt
@@ -1,0 +1,8 @@
+What's new:
+• Manage your organization directly from the app
+• Security Agent: review and fix vulnerabilities on the go
+• Sign in with Apple, Google, or a one-time email code
+• Code reviewer support for GitHub, GitLab, and Bitbucket
+• Feedback flow replaces the old Support tile
+• Push notification when a session becomes controllable
+• Various bug fixes and polish


### PR DESCRIPTION
## Summary

Adds the Android (Play Store) changelog entry for **build 98**, covering user-facing changes since **build 95**.

### Important note on repo conventions

I searched the repo (`apps/mobile`, root, and full-text search for `changelog`/`whatsnew`/`fastlane`/`store.config`) and found **no existing changelog/release-notes directory for the Android app** — this is the first one. Since there was no prior convention to follow, I used the industry-standard [fastlane `supply` metadata layout](https://docs.fastlane.tools/actions/supply/#metadata-structure) (`metadata/android/<locale>/changelogs/<versionCode>.txt`), which is the de facto format for Play Store release notes and can be consumed directly by `fastlane supply` or copied into the Play Console.

### How the build 95 → 98 range was determined

`apps/mobile` doesn't track a local `versionCode`/build number (EAS manages it remotely via `autoIncrement: true`), and there's no local record mapping build numbers to commits. The closest signal is the `kilo-app-release/<date>-<sha>` tags pushed by `.github/workflows/kilo-app-release.yml`, which only builds/tags when there are changes under `apps/mobile/`, `packages/trpc/`, or `pnpm-lock.yaml`. Assuming a 1:1 mapping between those tags and incrementing build numbers (consistent with the daily release cadence), build 98 = `kilo-app-release/2026-07-11-56df628` and build 95 = `kilo-app-release/2026-07-08-f43c2af`, three release cycles apart.

Commits in that range touching the mobile app:

- `56df62822` Dedupe web/mobile app logic into `@kilocode/app-shared` (#4499)
- `b5fa7658d` fix(mobile): restore GitHub setup and Android attachments (#4496)
- `bf77dd558` feat(mobile): expand PostHog analytics coverage (#4495)
- `293c0c587` feat(mobile): organization management screens (#4491)
- `6e42ef854` feat(mobile): replace Support tile with Feedback flow (#4487)
- `9d60a85d4` feat(mobile): Security Agent (#4479)
- `bdeb2fc62` fix(mobile): bump app version to 1.0.2 (#4478)
- `88b835aa7` feat(mobile): native login & account creation (Apple, Google, email OTP) (#4470)
- `f28ddef25` fix(session-ingest,mobile): session-ready push only for remote-controllable sessions + back button (#4456)
- `e7d813ad2` fix(mobile): code reviewer UX follow-ups (#4454)
- `54195f0c1` fix(mobile): model picker sheet header overlapping list content (#4449)
- `5b1cba507` feat(mobile): profile tab + code reviewer (GitHub, GitLab, Bitbucket) (#4441)
- `ec95f5fc6` feat(session-ingest): push notification when a CLI session becomes controllable (#4436)

These were condensed into user-facing, Play-Store-appropriate release notes (no internal jargon, under Google's 500-character limit).

## Files

- `apps/mobile/metadata/android/en-US/changelogs/98.txt` — the build 98 release notes
- `apps/mobile/metadata/README.md` — explains the layout and how to find the commit range for future build changelogs

## Follow-up for reviewers

If build numbers/tags are actually tracked elsewhere (e.g. in the EAS/Play Console dashboard) and 95→98 maps to a different commit range, let me know and I'll adjust the copy — the tag-based mapping here is an assumption made from what's available in the repo.

---

Built for [Arkadiy Kondrashov](https://kilo-code.slack.com/archives/C0A3LKC18CW/p1783946468726619?thread_ts=1783707521.652559&cid=C0A3LKC18CW) by [Kilo for Slack](https://kilo.ai/slack)