### PR TITLE
CloudAgentNext - broadcast cloud.status ready after terminalization and broaden wrapper terminal error detection

### DIFF
--- a/apps/web/src/lib/code-reviews/terminal-reason-from-failure.ts
+++ b/apps/web/src/lib/code-reviews/terminal-reason-from-failure.ts
@@ -65,6 +65,7 @@ const FAILURE_CODE_REASONS = {
   wrapper_error_before_activity: 'wrapper_failed',
   wrapper_error_after_activity: 'wrapper_failed',
   assistant_error: 'assistant_failed',
+  provider_error: 'assistant_failed',
   missing_assistant_reply: 'assistant_no_reply',
   payment_required: 'billing',
   user_interrupt: 'user_cancelled',

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -5760,6 +5760,7 @@ export type CloudAgentSessionRunFailureCode =
   | 'wrapper_error_after_activity'
   | 'missing_assistant_reply'
   | 'payment_required'
+  | 'provider_error'
   | 'user_interrupt'
   | 'container_shutdown'
   | 'system_interrupt'

--- a/packages/worker-utils/src/cloud-agent-failure.ts
+++ b/packages/worker-utils/src/cloud-agent-failure.ts
@@ -28,6 +28,7 @@ export const CLOUD_AGENT_FAILURE_CODES = [
   'wrapper_error_after_activity',
   'missing_assistant_reply',
   'payment_required',
+  'provider_error',
   'user_interrupt',
   'container_shutdown',
   'system_interrupt',
@@ -241,6 +242,7 @@ export function classifyCloudAgentFailure(
     case 'assistant_error':
     case 'payment_required':
     case 'model_missing':
+    case 'provider_error':
       return classifyAssistantFailure(input);
     case 'unclassified':
       return classified('unknown', 'unclassified');

--- a/packages/worker-utils/src/cloud-agent-queue-report.ts
+++ b/packages/worker-utils/src/cloud-agent-queue-report.ts
@@ -34,6 +34,7 @@ export const CloudAgentRunFailureClassifications = [
   { failureStage: 'agent_activity', failureCode: 'assistant_error' },
   { failureStage: 'agent_activity', failureCode: 'payment_required' },
   { failureStage: 'agent_activity', failureCode: 'model_missing' },
+  { failureStage: 'agent_activity', failureCode: 'provider_error' },
   { failureStage: 'agent_activity', failureCode: 'wrapper_error_after_activity' },
   { failureStage: 'interruption', failureCode: 'user_interrupt' },
   { failureStage: 'interruption', failureCode: 'container_shutdown' },

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -829,6 +829,15 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
         requestAlarmAtOrBefore: deadline => this.scheduleAlarmAtOrBefore(deadline),
         isSessionDeletionInProgress: () => this.hasDeletionIntent(),
         getSessionIdForLogs: () => this.sessionId,
+        onSessionTerminalized: async () => {
+          this.broadcastVolatileEvent({
+            executionId: '' as EventSourceId,
+            sessionId: this.sessionId ?? '',
+            streamEventType: 'cloud.status',
+            payload: JSON.stringify({ cloudStatus: { type: 'ready' } }),
+            timestamp: Date.now(),
+          });
+        },
       });
     }
 
@@ -3580,8 +3589,19 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
   }
 
   async handleWrapperTerminalEvent(params: WrapperTerminalEvent): Promise<void> {
-    await this.resolveSessionId();
-    await this.getWrapperSupervisor().onTerminalEvent(params);
+    const sessionId = await this.resolveSessionId();
+    const accepted = await this.getWrapperSupervisor().onTerminalEvent(params);
+
+    if (accepted && (params.status === 'failed' || params.status === 'interrupted')) {
+      this.broadcastVolatileEvent({
+        executionId: '' as EventSourceId,
+        sessionId: sessionId ?? '',
+        streamEventType: 'cloud.status',
+        payload: JSON.stringify({ cloudStatus: { type: 'ready' } }),
+        timestamp: Date.now(),
+      });
+    }
+
     const metadata = await this.getMetadata();
     if (!metadata) return;
     if (!isCodeReviewEphemeralSandboxId(metadata.workspace?.sandboxId)) return;

--- a/services/cloud-agent-next/src/session/safe-failure-projection.ts
+++ b/services/cloud-agent-next/src/session/safe-failure-projection.ts
@@ -50,6 +50,7 @@ const GENERIC_FAILURE_MESSAGES = {
   wrapper_error_after_activity: 'Agent wrapper failed while processing the message',
   missing_assistant_reply: 'No assistant reply was produced',
   payment_required: 'Assistant request failed: insufficient credits',
+  provider_error: 'Assistant provider returned an invalid response',
   user_interrupt: 'The message was interrupted by the user',
   container_shutdown: 'The agent container shut down',
   system_interrupt: 'The message was interrupted',

--- a/services/cloud-agent-next/src/session/terminal-error-projector.ts
+++ b/services/cloud-agent-next/src/session/terminal-error-projector.ts
@@ -9,6 +9,7 @@ const NON_RETRYABLE_FAILURE_CODES = new Set<SessionMessageFailureCode>([
   'session_metadata_missing',
   'model_missing',
   'payment_required',
+  'provider_error',
   'user_interrupt',
 ]);
 

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
@@ -127,6 +127,7 @@ function createHarness(
     ) => Promise<void>;
     recordSharedSandboxFailover?: (routeKey: SandboxId) => Promise<void>;
     isSessionDeletionInProgress?: () => Promise<boolean>;
+    onSessionTerminalized?: () => Promise<void>;
   }
 ) {
   const getAssistantMessageForUserMessage =
@@ -168,6 +169,7 @@ function createHarness(
   const recordSharedSandboxFailover = vi.fn(
     options?.recordSharedSandboxFailover ?? (async () => {})
   );
+  const onSessionTerminalized = vi.fn(options?.onSessionTerminalized ?? (async () => {}));
   const supervisor = createWrapperSupervisor({
     storage,
     agentRuntime: {
@@ -191,6 +193,7 @@ function createHarness(
     },
     isSessionDeletionInProgress: options?.isSessionDeletionInProgress,
     getSessionIdForLogs: () => currentMetadata.identity.sessionId,
+    onSessionTerminalized,
   });
 
   return {
@@ -205,6 +208,7 @@ function createHarness(
     requestedAlarms,
     requestPendingDrainIfNeeded,
     recordSharedSandboxFailover,
+    onSessionTerminalized,
     settlementOutbox,
     supervisor,
   };
@@ -1309,6 +1313,266 @@ describe('WrapperSupervisor', () => {
       state: 'stop_needed',
       reason: 'unhealthy-wrapper',
     });
+  });
+
+  it('calls onSessionTerminalized after disconnect grace terminalizes accepted work', async () => {
+    const harness = createHarness([
+      liveRuntimeState({ pingDeadlineAt: 92_000, noOutputDeadlineAt: 332_000 }),
+      OWNED_WRAPPER_LEASE,
+      disconnectGraceForCurrentConnection(90_000),
+    ]);
+    await putSessionMessageState(harness.storage, acceptedMessage());
+
+    await harness.supervisor.runMaintenance(100_001);
+
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      status: 'failed',
+      failureCode: 'wrapper_disconnected',
+    });
+    expect(harness.onSessionTerminalized).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSessionTerminalized after liveness expiry terminalizes accepted work', async () => {
+    const acceptedAt = 2_000;
+    const noOutputDeadlineAt = acceptedAt + WRAPPER_NO_OUTPUT_TIMEOUT_MS;
+    const harness = createHarness([
+      liveRuntimeState({ noOutputDeadlineAt, nextPingAt: noOutputDeadlineAt + 1 }),
+      OWNED_WRAPPER_LEASE,
+    ]);
+    await putSessionMessageState(harness.storage, acceptedMessage());
+
+    await harness.supervisor.runMaintenance(noOutputDeadlineAt);
+
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      status: 'failed',
+      failureCode: 'wrapper_no_output',
+    });
+    expect(harness.onSessionTerminalized).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves supervision when terminalization persistence fails', async () => {
+    const acceptedAt = 2_000;
+    const noOutputDeadlineAt = acceptedAt + WRAPPER_NO_OUTPUT_TIMEOUT_MS;
+    const harness = createHarness([
+      liveRuntimeState({ noOutputDeadlineAt, nextPingAt: noOutputDeadlineAt + 1 }),
+      OWNED_WRAPPER_LEASE,
+    ]);
+    await putSessionMessageState(harness.storage, acceptedMessage());
+
+    const originalPut = harness.storage.put.bind(harness.storage);
+    harness.storage.put = (async (key: string, value: unknown) => {
+      if (key.startsWith('session_message')) {
+        throw new Error('terminalize storage failure');
+      }
+      await originalPut(key, value);
+    }) as typeof harness.storage.put;
+
+    await expect(harness.supervisor.runMaintenance(noOutputDeadlineAt)).rejects.toThrow(
+      'terminalize storage failure'
+    );
+
+    // Readiness is not published because the durable transition failed
+    expect(harness.onSessionTerminalized).not.toHaveBeenCalled();
+    // Supervision is preserved — the wrapper runtime identity is not cleared
+    const runtimeState = await getWrapperRuntimeState(harness.storage);
+    expect(runtimeState.wrapperConnectionId).toBeDefined();
+    // The message remains accepted so maintenance can retry terminalization
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      status: 'accepted',
+    });
+  });
+
+  it('publishes readiness when terminal effects fail after the durable transition', async () => {
+    const acceptedAt = 2_000;
+    const noOutputDeadlineAt = acceptedAt + WRAPPER_NO_OUTPUT_TIMEOUT_MS;
+    const harness = createHarness([
+      liveRuntimeState({ noOutputDeadlineAt, nextPingAt: noOutputDeadlineAt + 1 }),
+      OWNED_WRAPPER_LEASE,
+    ]);
+    await putSessionMessageState(harness.storage, acceptedMessage());
+
+    // Let the durable terminal transition succeed (first session_message:
+    // state write), then fail on the subsequent terminal-effects write so the
+    // effect path throws while the message is already terminal.
+    let sessionMessageStatePutCount = 0;
+    const originalPut = harness.storage.put.bind(harness.storage);
+    harness.storage.put = (async (key: string, value: unknown) => {
+      if (key.startsWith('session_message:')) {
+        sessionMessageStatePutCount++;
+        if (sessionMessageStatePutCount > 1) {
+          throw new Error('terminal effects storage failure');
+        }
+      }
+      await originalPut(key, value);
+    }) as typeof harness.storage.put;
+
+    await harness.supervisor.runMaintenance(noOutputDeadlineAt);
+
+    // Readiness is published because the durable transition succeeded
+    expect(harness.onSessionTerminalized).toHaveBeenCalledTimes(1);
+    // The message is terminal despite the effect failure
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      status: 'failed',
+    });
+  });
+
+  it('publishes readiness when the terminal-state re-read fails after an ambiguous terminalization failure', async () => {
+    const acceptedAt = 2_000;
+    const noOutputDeadlineAt = acceptedAt + WRAPPER_NO_OUTPUT_TIMEOUT_MS;
+    const harness = createHarness([
+      liveRuntimeState({ noOutputDeadlineAt, nextPingAt: noOutputDeadlineAt + 1 }),
+      OWNED_WRAPPER_LEASE,
+    ]);
+    await putSessionMessageState(harness.storage, acceptedMessage());
+
+    // Let the durable terminal transition succeed (first state write), fail
+    // the subsequent terminal-effects write, and also fail the supervisor's
+    // verification re-read so the durable outcome is ambiguous.
+    const stateKey = `session_message:${MESSAGE_ID}`;
+    let sessionMessageStatePutCount = 0;
+    let effectsWriteFailed = false;
+    let verificationReadFailed = false;
+    const originalPut = harness.storage.put.bind(harness.storage);
+    const originalGet = harness.storage.get.bind(harness.storage);
+    harness.storage.put = (async (key: string, value: unknown) => {
+      if (key === stateKey) {
+        sessionMessageStatePutCount++;
+        if (sessionMessageStatePutCount > 1) {
+          effectsWriteFailed = true;
+          throw new Error('terminal effects storage failure');
+        }
+      }
+      await originalPut(key, value);
+    }) as typeof harness.storage.put;
+    harness.storage.get = (async (key: string) => {
+      if (effectsWriteFailed && !verificationReadFailed && key === stateKey) {
+        verificationReadFailed = true;
+        throw new Error('transient re-read failure');
+      }
+      return originalGet(key);
+    }) as typeof harness.storage.get;
+
+    await expect(harness.supervisor.runMaintenance(noOutputDeadlineAt)).rejects.toThrow(
+      'terminal effects storage failure'
+    );
+
+    // Readiness is published because the transition may have committed; the
+    // message is indeed terminal, so later maintenance would never re-enter
+    // the terminalization path to publish it.
+    expect(harness.onSessionTerminalized).toHaveBeenCalledTimes(1);
+    // Supervision is still preserved — the wrapper runtime identity is not cleared
+    const runtimeState = await getWrapperRuntimeState(harness.storage);
+    expect(runtimeState.wrapperConnectionId).toBeDefined();
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      status: 'failed',
+    });
+  });
+
+  it('retries a failed gate-wait release instead of abandoning supervision', async () => {
+    const acceptedAt = 2_000;
+    const noOutputDeadlineAt = acceptedAt + WRAPPER_NO_OUTPUT_TIMEOUT_MS;
+    const harness = createHarness(
+      [
+        liveRuntimeState({ noOutputDeadlineAt, nextPingAt: noOutputDeadlineAt + 1 }),
+        OWNED_WRAPPER_LEASE,
+      ],
+      {
+        metadata: {
+          ...createMetadata(),
+          finalization: { gateThreshold: 'warning' },
+        },
+      }
+    );
+    await putSessionMessageState(harness.storage, {
+      ...acceptedMessage(),
+      callbackRequired: true,
+      callbackTarget: { url: 'https://example.com/gate-release-retry' },
+    });
+    // Settle the message as completed so its idle batch waits for a wrapper
+    // gate result that never arrives — the wrapper is about to go silent.
+    await harness.settlementOutbox.terminalizeSessionMessageOnce(MESSAGE_ID, {
+      kind: 'completed',
+      completionSource: 'assistant_message_event',
+    });
+    await expect(harness.settlementOutbox.isWaitingForWrapperTerminalGateResult()).resolves.toBe(
+      true
+    );
+
+    // Fail the gate-release write once; the first unhealthy-wrapper pass must
+    // propagate the failure without clearing supervision.
+    let releaseFailed = false;
+    const originalPut = harness.storage.put.bind(harness.storage);
+    harness.storage.put = (async (key: string, value: unknown) => {
+      if (!releaseFailed && key.startsWith('idle_batch_callback:')) {
+        releaseFailed = true;
+        throw new Error('gate release storage failure');
+      }
+      await originalPut(key, value);
+    }) as typeof harness.storage.put;
+
+    await expect(harness.supervisor.runMaintenance(noOutputDeadlineAt)).rejects.toThrow(
+      'gate release storage failure'
+    );
+    expect(harness.callbackJobs).toHaveLength(0);
+
+    // The next maintenance pass must retry the release even though every
+    // accepted message is already terminal.
+    await harness.supervisor.runMaintenance(noOutputDeadlineAt + 1_000);
+
+    expect(harness.callbackJobs).toHaveLength(1);
+    expect(harness.callbackJobs[0].payload).toMatchObject({
+      messageId: MESSAGE_ID,
+      status: 'completed',
+    });
+    await expect(harness.settlementOutbox.isWaitingForWrapperTerminalGateResult()).resolves.toBe(
+      false
+    );
+  });
+
+  it('does not call onSessionTerminalized when disconnect grace expires for a stale wrapper run', async () => {
+    const harness = createHarness([
+      liveRuntimeState({
+        wrapperRunId: 'wr_newer_current',
+        wrapperGeneration: 5,
+        wrapperConnectionId: 'conn_newer',
+      }),
+      OWNED_WRAPPER_LEASE,
+      disconnectGraceForCurrentConnection(90_000, {
+        wrapperRunId: 'wr_stale_run',
+        wrapperGeneration: 4,
+        wrapperConnectionId: WRAPPER_CONNECTION_ID,
+      }),
+    ]);
+    await putSessionMessageState(harness.storage, {
+      ...acceptedMessage(),
+      wrapperRunId: 'wr_newer_current',
+    });
+
+    await harness.supervisor.runMaintenance(100_001);
+
+    await expect(harness.storage.get('disconnect_grace')).resolves.toBeUndefined();
+    expect(harness.onSessionTerminalized).not.toHaveBeenCalled();
+  });
+
+  it('calls onSessionTerminalized when liveness expiry abandons a finalizing run with no accepted messages', async () => {
+    const harness = createHarness([
+      liveRuntimeState({
+        finalizingWrapperRunId: WRAPPER_RUN_ID,
+        noOutputDeadlineAt: 9_000,
+        nextPingAt: 30_000,
+      }),
+      OWNED_WRAPPER_LEASE,
+    ]);
+    await putSessionMessageState(harness.storage, {
+      ...acceptedMessage(),
+      status: 'completed',
+      terminalAt: 3_000,
+      completionSource: 'assistant_message_event',
+    });
+
+    await harness.supervisor.runMaintenance(10_000);
+
+    expect(harness.onSessionTerminalized).toHaveBeenCalledTimes(1);
   });
 
   it('includes the disconnect grace expiry deadline even when the ping deadline is earlier', async () => {

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.ts
@@ -18,6 +18,8 @@ import {
 import { countPendingSessionMessages, type SessionQueueStorage } from './pending-messages.js';
 import type { SessionMessageQueue } from './session-message-queue.js';
 import {
+  getSessionMessageState,
+  isTerminalMessageState,
   listMessagesForWrapperRun,
   listNonTerminalAcceptedMessages,
   type SessionMessageState,
@@ -148,7 +150,7 @@ export type WrapperSupervisor = {
   ): Promise<void>;
   observeFinalizing(wrapperRunId: string): Promise<void>;
   onDisconnected(input: WrapperDisconnectedInput): Promise<void>;
-  onTerminalEvent(params: WrapperTerminalEvent): Promise<void>;
+  onTerminalEvent(params: WrapperTerminalEvent): Promise<boolean>;
   requestPhysicalWrapperStop(reason: WrapperStopReason, target?: WrapperStopTarget): Promise<void>;
   recheckExhaustedCleanup(): Promise<void>;
   clearDisconnectGrace(): Promise<void>;
@@ -198,6 +200,13 @@ export type WrapperSupervisorDependencies = {
   requestAlarmAtOrBefore?: (deadline: number) => Promise<void>;
   isSessionDeletionInProgress?: () => Promise<boolean>;
   getSessionIdForLogs: () => string | undefined;
+  /**
+   * Invoked after a disconnect-grace or liveness path terminalizes accepted
+   * work, so the DO can broadcast a `cloud.status: ready` event and re-enable
+   * client input. Not invoked for the normal terminal-event path, which
+   * broadcasts readiness from {@link handleWrapperTerminalEvent} directly.
+   */
+  onSessionTerminalized?: () => Promise<void>;
 };
 
 function matchesDisconnectGraceFence(
@@ -437,6 +446,7 @@ export function createWrapperSupervisor(
     requestAlarmAtOrBefore,
     isSessionDeletionInProgress,
     getSessionIdForLogs,
+    onSessionTerminalized,
   } = dependencies;
 
   async function readDisconnectGrace(): Promise<DisconnectGraceState | undefined> {
@@ -725,7 +735,8 @@ export function createWrapperSupervisor(
    */
   async function terminalizeAcceptedMessagesForDeadWrapper(
     acceptedMessages: SessionMessageState[],
-    fallbackParams: (message: SessionMessageState) => TerminalizeParams
+    fallbackParams: (message: SessionMessageState) => TerminalizeParams,
+    options?: { wrapperRunId?: string | null }
   ): Promise<void> {
     const metadata = await getMetadata();
     const kiloSessionId = metadata?.auth.kiloSessionId;
@@ -742,10 +753,51 @@ export function createWrapperSupervisor(
             )
           : null;
       if (reconciled) reconciledCount += 1;
-      await messageSettlementOutbox.terminalizeSessionMessageOnce(
-        message.messageId,
-        reconciled ?? fallbackParams(message)
-      );
+      try {
+        await messageSettlementOutbox.terminalizeSessionMessageOnce(
+          message.messageId,
+          reconciled ?? fallbackParams(message)
+        );
+      } catch (terminalizeError) {
+        // terminalizeSessionMessageOnly only becomes fallible after the
+        // durable transition commits (event/callback effects). A throw while
+        // the message is still non-terminal means the durable write itself
+        // failed; re-throw so the wrapper runtime identity is preserved and
+        // maintenance can retry instead of orphaning still-accepted work.
+        let durableTransitionSucceeded = false;
+        let reReadFailed = false;
+        try {
+          const persistedState = await getSessionMessageState(storage, message.messageId);
+          durableTransitionSucceeded =
+            persistedState !== undefined && isTerminalMessageState(persistedState);
+        } catch {
+          // The re-read itself failed, so the durable outcome is unknown.
+          reReadFailed = true;
+        }
+        if (!durableTransitionSucceeded) {
+          if (reReadFailed) {
+            // The transition may actually have committed. If it did, the next
+            // maintenance pass sees an already-terminal message and never
+            // re-enters this path, so readiness would never be published.
+            // Publish it now: a duplicate `cloud.status: ready` is harmless,
+            // while a genuinely failed transition keeps the message accepted
+            // and supervised via the rethrow below.
+            await onSessionTerminalized?.();
+          }
+          throw terminalizeError;
+        }
+        logger
+          .withFields({
+            sessionId: getSessionIdForLogs(),
+            wrapperRunId: options?.wrapperRunId,
+            messageId: message.messageId,
+            error:
+              terminalizeError instanceof Error
+                ? terminalizeError.message
+                : String(terminalizeError),
+          })
+          .warn('Failed to apply terminal effects during unhealthy wrapper handling');
+      }
     }
     if (reconciledCount > 0) {
       logger
@@ -775,17 +827,22 @@ export function createWrapperSupervisor(
     await requestPhysicalWrapperStop('unhealthy-wrapper');
 
     const acceptedMessages = await listNonTerminalAcceptedMessages(storage, state.wrapperRunId);
-    await terminalizeAcceptedMessagesForDeadWrapper(acceptedMessages, message => {
-      const activityObserved = message.agentActivityObservedAt !== undefined;
-      return {
-        kind: 'failed',
-        reason: 'wrapper_failure',
-        error,
-        completionSource: 'wrapper_failure',
-        failureStage: activityObserved ? 'agent_activity' : 'post_dispatch_no_activity',
-        failureCode: activityObserved ? 'wrapper_error_after_activity' : failureCode,
-      };
-    });
+    await terminalizeAcceptedMessagesForDeadWrapper(
+      acceptedMessages,
+      message => {
+        const activityObserved = message.agentActivityObservedAt !== undefined;
+        return {
+          kind: 'failed',
+          reason: 'wrapper_failure',
+          error,
+          completionSource: 'wrapper_failure',
+          failureStage: activityObserved ? 'agent_activity' : 'post_dispatch_no_activity',
+          failureCode: activityObserved ? 'wrapper_error_after_activity' : failureCode,
+        };
+      },
+      { wrapperRunId: state.wrapperRunId }
+    );
+    await onSessionTerminalized?.();
     await messageSettlementOutbox.releaseWrapperTerminalWaitForIdleBatch();
     if (isWrapperRunFinalizing(state) && state.wrapperRunId) {
       await messageSettlementOutbox.finalizeTerminalWrapperRunCallbackIfReady(state.wrapperRunId);
@@ -854,17 +911,22 @@ export function createWrapperSupervisor(
       .warn('Grace period expired - failing supervised wrapper work');
     await requestPhysicalWrapperStop('unhealthy-wrapper');
     await storage.delete(DISCONNECT_GRACE_KEY);
-    await terminalizeAcceptedMessagesForDeadWrapper(acceptedMessages, message => {
-      const activityObserved = message.agentActivityObservedAt !== undefined;
-      return {
-        kind: 'failed',
-        reason: 'wrapper_disconnected',
-        error: 'Wrapper disconnected',
-        completionSource: 'wrapper_failure',
-        failureStage: activityObserved ? 'agent_activity' : 'post_dispatch_no_activity',
-        failureCode: activityObserved ? 'wrapper_error_after_activity' : 'wrapper_disconnected',
-      };
-    });
+    await terminalizeAcceptedMessagesForDeadWrapper(
+      acceptedMessages,
+      message => {
+        const activityObserved = message.agentActivityObservedAt !== undefined;
+        return {
+          kind: 'failed',
+          reason: 'wrapper_disconnected',
+          error: 'Wrapper disconnected',
+          completionSource: 'wrapper_failure',
+          failureStage: activityObserved ? 'agent_activity' : 'post_dispatch_no_activity',
+          failureCode: activityObserved ? 'wrapper_error_after_activity' : 'wrapper_disconnected',
+        };
+      },
+      { wrapperRunId }
+    );
+    await onSessionTerminalized?.();
     await clearWrapperRuntimeIdentity(
       storage,
       {
@@ -878,7 +940,14 @@ export function createWrapperSupervisor(
 
   async function hasActiveWrapperWork(state: WrapperRuntimeState): Promise<boolean> {
     if (isWrapperRunFinalizing(state)) return true;
-    return (await listNonTerminalAcceptedMessages(storage, state.wrapperRunId)).length > 0;
+    if ((await listNonTerminalAcceptedMessages(storage, state.wrapperRunId)).length > 0) {
+      return true;
+    }
+    // A gate-waiting idle batch is only released by this supervisor (or by a
+    // live wrapper terminal event). Keep supervision alive while it is
+    // pending so a failed release is retried instead of stranding the
+    // gate-waiting callback once all accepted messages are terminal.
+    return messageSettlementOutbox.isWaitingForWrapperTerminalGateResult();
   }
 
   /**
@@ -1610,7 +1679,7 @@ export function createWrapperSupervisor(
     );
   }
 
-  async function onTerminalEvent(params: WrapperTerminalEvent): Promise<void> {
+  async function onTerminalEvent(params: WrapperTerminalEvent): Promise<boolean> {
     const {
       wrapperRunId,
       status,
@@ -1633,7 +1702,7 @@ export function createWrapperSupervisor(
       logger
         .withFields({ sessionId, wrapperRunId, status })
         .warn('Ignoring non-current wrapper terminal event');
-      return;
+      return false;
     }
 
     logger
@@ -1785,6 +1854,7 @@ export function createWrapperSupervisor(
     ) {
       await sessionMessageQueue.requestPendingDrainIfNeeded();
     }
+    return true;
   }
 
   async function runMaintenance(now: number): Promise<void> {

--- a/services/cloud-agent-next/src/shared/protocol.ts
+++ b/services/cloud-agent-next/src/shared/protocol.ts
@@ -53,7 +53,11 @@ export type IngestEvent = {
   data: unknown;
 };
 
-export const WrapperTerminalFailureCodes = ['payment_required', 'model_missing'] as const;
+export const WrapperTerminalFailureCodes = [
+  'payment_required',
+  'model_missing',
+  'provider_error',
+] as const;
 export type WrapperTerminalFailureCode = (typeof WrapperTerminalFailureCodes)[number];
 
 /**

--- a/services/cloud-agent-next/src/telemetry/queue-reports.test.ts
+++ b/services/cloud-agent-next/src/telemetry/queue-reports.test.ts
@@ -83,13 +83,14 @@ describe('Cloud Agent report emitter', () => {
   });
 
   it.each([
-    ['agent_activity', 'payment_required', 'insufficient_credits'],
-    ['agent_activity', 'model_missing', 'model_unavailable'],
-    ['post_dispatch_no_activity', 'payment_required', 'insufficient_credits'],
-    ['post_dispatch_no_activity', 'model_missing', 'model_unavailable'],
+    ['agent_activity', 'payment_required', 'user', 'insufficient_credits'],
+    ['agent_activity', 'model_missing', 'user', 'model_unavailable'],
+    ['agent_activity', 'provider_error', 'unknown', 'assistant_unknown'],
+    ['post_dispatch_no_activity', 'payment_required', 'user', 'insufficient_credits'],
+    ['post_dispatch_no_activity', 'model_missing', 'user', 'model_unavailable'],
   ] as const)(
-    'preserves %s/%s with user reason %s',
-    async (failureStage, failureCode, expectedFailureReason) => {
+    'preserves %s/%s with %s reason %s',
+    async (failureStage, failureCode, expectedResponsibility, expectedFailureReason) => {
       const reports: CloudAgentQueueReport[] = [];
       await emitRunStateReport({
         queue: { send: async report => void reports.push(report) },
@@ -100,7 +101,7 @@ describe('Cloud Agent report emitter', () => {
       expect(reports[0]?.run).toMatchObject({
         failureStage,
         failureCode,
-        failureResponsibility: 'user',
+        failureResponsibility: expectedResponsibility,
         failureReason: expectedFailureReason,
       });
     }

--- a/services/cloud-agent-next/src/telemetry/queue-reports.ts
+++ b/services/cloud-agent-next/src/telemetry/queue-reports.ts
@@ -47,6 +47,7 @@ const FAILED_RUN_DIAGNOSTIC_MESSAGES: Partial<
   wrapper_error_after_activity: 'Wrapper failed after agent activity',
   missing_assistant_reply: 'No assistant reply was produced',
   payment_required: 'Model request failed: insufficient credits',
+  provider_error: 'Assistant provider returned an invalid response',
   unclassified: 'Run failed without a classified cause',
 };
 

--- a/services/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/services/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -9,6 +9,7 @@ import {
   getWrapperRuntimeState,
 } from '../../../src/session/wrapper-runtime-state.js';
 import type { ExecutionId } from '../../../src/types/ids.js';
+import { registerReadySession } from '../../helpers/session-setup.js';
 
 describe('Disconnect handling and compatibility execution RPCs', () => {
   it('alarm schedules the idle cadence when no current message deadlines exist', async () => {
@@ -250,5 +251,177 @@ describe('Disconnect handling and compatibility execution RPCs', () => {
     expect(result.events.some(event => event.stream_event_type === 'wrapper_disconnected')).toBe(
       true
     );
+  });
+
+  it('broadcasts cloud.status: ready after a wrapper disconnect and grace expiry', async () => {
+    const userId = 'user_disconnect_ready';
+    const sessionId = 'agent_disconnect_ready';
+    const stub = env.CLOUD_AGENT_SESSION.get(
+      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+    );
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      await registerReadySession(instance, {
+        sessionId,
+        userId,
+        kiloSessionId: 'ses_disconnect_ready',
+        prompt: 'disconnect ready test',
+        mode: 'code',
+        model: 'test-model',
+      });
+
+      const now = Date.now();
+      await state.storage.put('wrapper_runtime_state', {
+        wrapperRunId: 'wr_disconnect_ready',
+        wrapperGeneration: 1,
+        wrapperConnectionId: 'conn_disconnect_ready',
+      });
+      await putSessionMessageState(state.storage, {
+        messageId: 'msg_018f1e2d3c4bDiscReadyABCDE',
+        status: 'accepted',
+        prompt: 'disconnect ready test',
+        createdAt: now,
+        acceptedAt: now,
+        wrapperRunId: 'wr_disconnect_ready',
+      });
+      await state.storage.put('disconnect_grace', {
+        wrapperRunId: 'wr_disconnect_ready',
+        disconnectedAt: now - 20_000,
+        wsCloseCode: 1006,
+        wsCloseReason: 'socket closed',
+        wrapperGeneration: 1,
+        wrapperConnectionId: 'conn_disconnect_ready',
+      });
+
+      const broadcasted: Array<{ stream_event_type: string; payload: string }> = [];
+      instance.broadcastEvent = event => {
+        broadcasted.push({
+          stream_event_type: event.stream_event_type,
+          payload: event.payload,
+        });
+      };
+
+      await instance.alarm();
+      return { broadcasted };
+    });
+
+    const cloudStatusReady = result.broadcasted.filter(event => {
+      if (event.stream_event_type !== 'cloud.status') return false;
+      const payload = JSON.parse(event.payload) as { cloudStatus?: { type?: string } };
+      return payload.cloudStatus?.type === 'ready';
+    });
+    expect(cloudStatusReady).toHaveLength(1);
+  });
+
+  it('broadcasts cloud.status: ready after a failed wrapper terminal event', async () => {
+    const userId = 'user_terminal_ready';
+    const sessionId = 'agent_terminal_ready';
+    const stub = env.CLOUD_AGENT_SESSION.get(
+      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+    );
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      await registerReadySession(instance, {
+        sessionId,
+        userId,
+        kiloSessionId: 'ses_terminal_ready',
+        prompt: 'terminal ready test',
+        mode: 'code',
+        model: 'test-model',
+      });
+
+      const now = Date.now();
+      await state.storage.put('wrapper_runtime_state', {
+        wrapperRunId: 'wr_terminal_ready',
+        wrapperGeneration: 1,
+        wrapperConnectionId: 'conn_terminal_ready',
+      });
+      await putSessionMessageState(state.storage, {
+        messageId: 'msg_018f1e2d3c4bTermReadyABCDE',
+        status: 'accepted',
+        prompt: 'terminal ready test',
+        createdAt: now,
+        acceptedAt: now,
+        wrapperRunId: 'wr_terminal_ready',
+      });
+
+      const broadcasted: Array<{ stream_event_type: string; payload: string }> = [];
+      instance.broadcastEvent = event => {
+        broadcasted.push({
+          stream_event_type: event.stream_event_type,
+          payload: event.payload,
+        });
+      };
+
+      await instance.handleWrapperTerminalEvent({
+        wrapperRunId: 'wr_terminal_ready',
+        status: 'failed',
+        error: 'Assistant request failed',
+      });
+      return { broadcasted };
+    });
+
+    const cloudStatusReady = result.broadcasted.filter(event => {
+      if (event.stream_event_type !== 'cloud.status') return false;
+      const payload = JSON.parse(event.payload) as { cloudStatus?: { type?: string } };
+      return payload.cloudStatus?.type === 'ready';
+    });
+    expect(cloudStatusReady).toHaveLength(1);
+  });
+
+  it('does not broadcast cloud.status: ready for a stale wrapper terminal event', async () => {
+    const userId = 'user_stale_terminal';
+    const sessionId = 'agent_stale_terminal';
+    const stub = env.CLOUD_AGENT_SESSION.get(
+      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+    );
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      await registerReadySession(instance, {
+        sessionId,
+        userId,
+        kiloSessionId: 'ses_stale_terminal',
+        prompt: 'stale terminal test',
+        mode: 'code',
+        model: 'test-model',
+      });
+
+      const now = Date.now();
+      await state.storage.put('wrapper_runtime_state', {
+        wrapperRunId: 'wr_current',
+        wrapperGeneration: 1,
+        wrapperConnectionId: 'conn_current',
+      });
+      await putSessionMessageState(state.storage, {
+        messageId: 'msg_018f1e2d3c4bStaleTermABCDE',
+        status: 'accepted',
+        prompt: 'stale terminal test',
+        createdAt: now,
+        acceptedAt: now,
+        wrapperRunId: 'wr_current',
+      });
+
+      const broadcasted: Array<{ stream_event_type: string; payload: string }> = [];
+      instance.broadcastEvent = event => {
+        broadcasted.push({
+          stream_event_type: event.stream_event_type,
+          payload: event.payload,
+        });
+      };
+
+      await instance.handleWrapperTerminalEvent({
+        wrapperRunId: 'wr_stale',
+        status: 'failed',
+        error: 'Assistant request failed',
+      });
+      return { broadcasted };
+    });
+
+    const cloudStatusReady = result.broadcasted.filter(event => {
+      if (event.stream_event_type !== 'cloud.status') return false;
+      const payload = JSON.parse(event.payload) as { cloudStatus?: { type?: string } };
+      return payload.cloudStatus?.type === 'ready';
+    });
+    expect(cloudStatusReady).toHaveLength(0);
   });
 });

--- a/services/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
@@ -1406,6 +1406,117 @@ describe('ingest WS reconnection', () => {
     expect(callbacks.onTerminalError).not.toHaveBeenCalled();
   });
 
+  it('classifies AI_InvalidResponseDataError as a terminal provider error', async () => {
+    const kiloClient = createMockKiloClient({
+      subscribeEvents: vi.fn().mockResolvedValue({
+        stream: createEventStream([
+          {
+            type: 'session.error',
+            properties: {
+              sessionID: 'kilo_sess_456',
+              error: {
+                name: 'AI_InvalidResponseDataError',
+                message: "Expected 'id' to be a string",
+              },
+            },
+          },
+        ]),
+      }),
+    });
+
+    const manager = createManagerWithClient(kiloClient);
+    await openConnection(manager);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onTerminalError).toHaveBeenCalledWith({
+      code: 'provider_error',
+      message: "Expected 'id' to be a string",
+      errorSource: 'assistant',
+    });
+  });
+
+  it('classifies an AI_JSONParseError as a terminal provider error', async () => {
+    const kiloClient = createMockKiloClient({
+      subscribeEvents: vi.fn().mockResolvedValue({
+        stream: createEventStream([
+          {
+            type: 'session.error',
+            properties: {
+              sessionID: 'kilo_sess_456',
+              error: {
+                name: 'AI_JSONParseError',
+                message: 'Unexpected end of JSON input',
+              },
+            },
+          },
+        ]),
+      }),
+    });
+
+    const manager = createManagerWithClient(kiloClient);
+    await openConnection(manager);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onTerminalError).toHaveBeenCalledWith({
+      code: 'provider_error',
+      message: 'Unexpected end of JSON input',
+      errorSource: 'assistant',
+    });
+  });
+
+  it('classifies an expected-field pattern error as a terminal provider error', async () => {
+    const kiloClient = createMockKiloClient({
+      subscribeEvents: vi.fn().mockResolvedValue({
+        stream: createEventStream([
+          {
+            type: 'session.error',
+            properties: {
+              sessionID: 'kilo_sess_456',
+              error: {
+                data: { message: "Expected 'choices' to be an array" },
+              },
+            },
+          },
+        ]),
+      }),
+    });
+
+    const manager = createManagerWithClient(kiloClient);
+    await openConnection(manager);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onTerminalError).toHaveBeenCalledWith({
+      code: 'provider_error',
+      message: "Expected 'choices' to be an array",
+      errorSource: 'assistant',
+    });
+  });
+
+  it('does not treat a transient provider error as terminal', async () => {
+    const kiloClient = createMockKiloClient({
+      subscribeEvents: vi.fn().mockResolvedValue({
+        stream: createEventStream([
+          {
+            type: 'session.error',
+            properties: {
+              sessionID: 'kilo_sess_456',
+              error: {
+                name: 'ProviderError',
+                data: { message: 'Rate limit exceeded for provider request' },
+              },
+            },
+          },
+        ]),
+      }),
+    });
+
+    const manager = createManagerWithClient(kiloClient);
+    await openConnection(manager);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onTerminalError).not.toHaveBeenCalled();
+  });
+
   it('records explicit Kilo gate results from event properties', async () => {
     const kiloClient = createMockKiloClient({
       subscribeEvents: vi.fn().mockResolvedValue({

--- a/services/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
@@ -1464,6 +1464,64 @@ describe('ingest WS reconnection', () => {
     });
   });
 
+  it('classifies UnknownError Invalid response data as a terminal provider error', async () => {
+    const kiloClient = createMockKiloClient({
+      subscribeEvents: vi.fn().mockResolvedValue({
+        stream: createEventStream([
+          {
+            type: 'session.error',
+            properties: {
+              sessionID: 'kilo_sess_456',
+              error: {
+                name: 'UnknownError',
+                data: { message: "Invalid response data: Expected 'id' to be a string." },
+              },
+            },
+          },
+        ]),
+      }),
+    });
+
+    const manager = createManagerWithClient(kiloClient);
+    await openConnection(manager);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onTerminalError).toHaveBeenCalledWith({
+      code: 'provider_error',
+      message: "Invalid response data: Expected 'id' to be a string.",
+      errorSource: 'assistant',
+    });
+  });
+
+  it('classifies UnknownError JSON parsing failed as a terminal provider error', async () => {
+    const kiloClient = createMockKiloClient({
+      subscribeEvents: vi.fn().mockResolvedValue({
+        stream: createEventStream([
+          {
+            type: 'session.error',
+            properties: {
+              sessionID: 'kilo_sess_456',
+              error: {
+                name: 'UnknownError',
+                data: { message: 'JSON parsing failed: Unexpected end of JSON input' },
+              },
+            },
+          },
+        ]),
+      }),
+    });
+
+    const manager = createManagerWithClient(kiloClient);
+    await openConnection(manager);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onTerminalError).toHaveBeenCalledWith({
+      code: 'provider_error',
+      message: 'JSON parsing failed: Unexpected end of JSON input',
+      errorSource: 'assistant',
+    });
+  });
+
   it('classifies an expected-field pattern error as a terminal provider error', async () => {
     const kiloClient = createMockKiloClient({
       subscribeEvents: vi.fn().mockResolvedValue({

--- a/services/cloud-agent-next/wrapper/src/connection.ts
+++ b/services/cloud-agent-next/wrapper/src/connection.ts
@@ -935,13 +935,12 @@ export function createConnectionManager(
   }
 
   function isAIProviderResponseError(errorText: string, error: unknown): boolean {
-    const normalized = errorText.toLowerCase();
+    const serializedError = error === undefined ? '' : JSON.stringify(error);
+    const normalized = `${errorText}\n${serializedError}`.toLowerCase();
     if (normalized.includes('ai_invalidresponsedataerror')) return true;
     if (normalized.includes('ai_jsonparseerror')) return true;
-    if (isRecord(error) && typeof error.name === 'string') {
-      const name = error.name.toLowerCase();
-      if (name === 'ai_invalidresponsedataerror' || name === 'ai_jsonparseerror') return true;
-    }
+    if (normalized.includes('invalid response data:')) return true;
+    if (normalized.includes('json parsing failed:')) return true;
     if (/^expected\s+['"].+['"]\s+to be\s+/i.test(errorText.trim())) return true;
     return false;
   }

--- a/services/cloud-agent-next/wrapper/src/connection.ts
+++ b/services/cloud-agent-next/wrapper/src/connection.ts
@@ -892,7 +892,14 @@ export function createConnectionManager(
             normalizedError.includes('too many requests')
           );
         })());
-    if (!code && !isExplicitAssistantFailure) return undefined;
+    const isProviderResponseError =
+      eventType === 'session.error' &&
+      isAIProviderResponseError(terminalErrorText, properties.error);
+    if (!code && !isExplicitAssistantFailure && !isProviderResponseError) return undefined;
+
+    if (isProviderResponseError && !code) {
+      code = 'provider_error';
+    }
 
     return {
       ...(code ? { code } : {}),
@@ -925,6 +932,18 @@ export function createConnectionManager(
 
   function isModelNotFoundMessage(message: string): boolean {
     return /\b(model\s+(?:was\s+)?not\s+found|unknown\s+model|invalid\s+model)\b/i.test(message);
+  }
+
+  function isAIProviderResponseError(errorText: string, error: unknown): boolean {
+    const normalized = errorText.toLowerCase();
+    if (normalized.includes('ai_invalidresponsedataerror')) return true;
+    if (normalized.includes('ai_jsonparseerror')) return true;
+    if (isRecord(error) && typeof error.name === 'string') {
+      const name = error.name.toLowerCase();
+      if (name === 'ai_invalidresponsedataerror' || name === 'ai_jsonparseerror') return true;
+    }
+    if (/^expected\s+['"].+['"]\s+to be\s+/i.test(errorText.trim())) return true;
+    return false;
   }
 
   function shouldFetchModelNotFoundDiagnostics(

--- a/services/cloud-agent-next/wrapper/src/lifecycle.test.ts
+++ b/services/cloud-agent-next/wrapper/src/lifecycle.test.ts
@@ -119,4 +119,117 @@ describe('wrapper lifecycle drain races', () => {
     await wait(500);
     expect(events.filter(event => event.streamEventType === 'complete')).toHaveLength(1);
   }, 10_000);
+
+  it('delays close longer when aborted while disconnected to allow reconnect delivery', async () => {
+    const state = new WrapperState();
+    state.bindSession(sessionContext);
+    state.setSendToIngestFn(() => {});
+
+    let closed = false;
+    const lifecycle = createLifecycleManager(
+      { workspacePath: '/tmp' },
+      {
+        state,
+        kiloClient: {} as WrapperKiloClient,
+        closeConnections: async () => {
+          closed = true;
+        },
+        isConnected: () => false,
+        reconnectEventSubscription: () => {},
+      }
+    );
+
+    state.acceptMessage('message-1', {
+      autoCommit: false,
+      condenseOnComplete: false,
+    });
+    state.clearAllMessages();
+    lifecycle.setAborted();
+    lifecycle.triggerDrainAndClose();
+
+    await wait(500);
+    expect(closed).toBe(false);
+
+    await wait(2_000);
+    expect(closed).toBe(true);
+  }, 10_000);
+
+  it('closes immediately when reconnect restores during aborted drain', async () => {
+    const state = new WrapperState();
+    state.bindSession(sessionContext);
+    state.setSendToIngestFn(() => {});
+
+    let closeCount = 0;
+    const lifecycle = createLifecycleManager(
+      { workspacePath: '/tmp' },
+      {
+        state,
+        kiloClient: {} as WrapperKiloClient,
+        closeConnections: async () => {
+          closeCount++;
+        },
+        isConnected: () => false,
+        reconnectEventSubscription: () => {},
+      }
+    );
+
+    state.acceptMessage('message-1', {
+      autoCommit: false,
+      condenseOnComplete: false,
+    });
+    state.clearAllMessages();
+    lifecycle.setAborted();
+    lifecycle.triggerDrainAndClose();
+
+    await wait(300);
+    expect(closeCount).toBe(0);
+
+    lifecycle.onConnectionRestored();
+
+    await wait(100);
+    expect(closeCount).toBe(1);
+
+    await wait(2_000);
+    expect(closeCount).toBe(1);
+  }, 10_000);
+
+  it('defers close while reconnecting during aborted drain until reconnect gives up', async () => {
+    const state = new WrapperState();
+    state.bindSession(sessionContext);
+    state.setSendToIngestFn(() => {});
+
+    let closed = false;
+    let reconnecting = true;
+    const lifecycle = createLifecycleManager(
+      { workspacePath: '/tmp' },
+      {
+        state,
+        kiloClient: {} as WrapperKiloClient,
+        closeConnections: async () => {
+          closed = true;
+        },
+        isConnected: () => false,
+        isReconnecting: () => reconnecting,
+        reconnectEventSubscription: () => {},
+      }
+    );
+
+    state.acceptMessage('message-1', {
+      autoCommit: false,
+      condenseOnComplete: false,
+    });
+    state.clearAllMessages();
+    lifecycle.setAborted();
+    lifecycle.triggerDrainAndClose();
+
+    // Past the 2-second fallback ceiling the close is still deferred because a
+    // reconnect is in progress with a buffered terminal frame.
+    await wait(2_500);
+    expect(closed).toBe(false);
+
+    // Once the reconnect gives up the next poll closes.
+    reconnecting = false;
+    await wait(500);
+    expect(closed).toBe(true);
+  }, 10_000);
 });

--- a/services/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/services/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -5,6 +5,15 @@ import { runCondenseOnComplete } from './condense-on-complete.js';
 import { getCurrentBranch, logToFile } from './utils.js';
 
 const DRAIN_DELAY_MS = 250;
+/**
+ * When a terminal error is detected while the ingest WS is disconnected, the
+ * fatal error frame is buffered and only delivered after the WS reconnects
+ * (first attempt after ~1 s). Extend the drain window so the reconnect can
+ * flush the buffered terminal frame before close() clears the buffer. If the
+ * reconnect completes within this window, the drain closes immediately rather
+ * than waiting for the full delay; this value is the fallback ceiling.
+ */
+const TERMINAL_ERROR_DISCONNECTED_DRAIN_DELAY_MS = 2_000;
 const STABLE_ROOT_IDLE_MS = 3_000;
 const SSE_TRANSPORT_TIMEOUT_MS = 15_000;
 const AUTO_COMMIT_TIMEOUT_MS = 120_000;
@@ -18,6 +27,14 @@ export type LifecycleDependencies = {
   kiloClient: WrapperKiloClient;
   closeConnections: () => Promise<void>;
   isConnected: () => boolean;
+  /**
+   * Whether the ingest WebSocket is currently attempting to reconnect. When a
+   * terminal error is detected while disconnected, the fatal frame is buffered
+   * and only flushed once a reconnect completes; the drain close defers while a
+   * reconnect is in progress so that frame can be delivered instead of being
+   * discarded by close().
+   */
+  isReconnecting?: () => boolean;
   reconnectEventSubscription: () => void;
 };
 
@@ -153,6 +170,28 @@ export function createLifecycleManager(
     }
   }
 
+  function performDrainClose(): void {
+    // When closing on an aborted drain while disconnected, a reconnect may
+    // still be in progress with a buffered fatal terminal frame. Closing now
+    // would abort that reconnect and discard the frame before it can be
+    // flushed. Defer until the reconnect completes (onConnectionRestored
+    // closes immediately once the frame is flushed) or gives up.
+    if (isAborted && !deps.isConnected() && deps.isReconnecting?.()) {
+      drainTimeout = setTimeout(performDrainClose, DRAIN_DELAY_MS);
+      return;
+    }
+    void deps
+      .closeConnections()
+      .catch(error =>
+        logToFile(`close failed: ${error instanceof Error ? error.message : String(error)}`)
+      )
+      .finally(() => {
+        isDraining = false;
+        drainTimeout = null;
+        state.clearSession();
+      });
+  }
+
   function triggerDrainAndClose(): void {
     state.blockAdmissions();
     if (isDraining) return;
@@ -208,18 +247,12 @@ export function createLifecycleManager(
         }
 
         if (isDraining) {
-          drainTimeout = setTimeout(() => {
-            void deps
-              .closeConnections()
-              .catch(error =>
-                logToFile(`close failed: ${error instanceof Error ? error.message : String(error)}`)
-              )
-              .finally(() => {
-                isDraining = false;
-                drainTimeout = null;
-                state.clearSession();
-              });
-          }, DRAIN_DELAY_MS);
+          drainTimeout = setTimeout(
+            performDrainClose,
+            isAborted && !deps.isConnected()
+              ? TERMINAL_ERROR_DISCONNECTED_DRAIN_DELAY_MS
+              : DRAIN_DELAY_MS
+          );
         }
       }
     })();
@@ -282,7 +315,18 @@ export function createLifecycleManager(
       }
       armStableIdleCandidate();
     },
-    onConnectionRestored: armStableIdleCandidate,
+    onConnectionRestored: () => {
+      if (isDraining && isAborted && drainTimeout) {
+        logToFile(
+          'reconnect restored during aborted drain — closing now that buffered terminal frame flushed'
+        );
+        clearTimeout(drainTimeout);
+        drainTimeout = null;
+        performDrainClose();
+        return;
+      }
+      armStableIdleCandidate();
+    },
     triggerDrainAndClose,
     signalCompletion,
     setAborted: () => {

--- a/services/cloud-agent-next/wrapper/src/main.ts
+++ b/services/cloud-agent-next/wrapper/src/main.ts
@@ -558,6 +558,7 @@ async function main() {
         kiloClient: nextKiloClient,
         closeConnections: () => connectionManager?.close() ?? Promise.resolve(),
         isConnected: () => connectionManager?.isConnected() ?? false,
+        isReconnecting: () => connectionManager?.isReconnecting() ?? false,
         reconnectEventSubscription: () => connectionManager?.reconnectEventSubscription(),
       }
     );


### PR DESCRIPTION
## Problem

When a Cloud Agent execution ends abnormally, the web UI's chat input stays disabled (`canSend = false`) because the DO never broadcasts a `cloud.status: ready` event to re-enable it. Users are forced to create a new session for every prompt instead of sending follow-ups.

Two independent gaps cause this:

1. **DO gap**: When the wrapper disconnects without sending a `complete`/`error`/`interrupted` event, the DO terminalizes messages as failed but never broadcasts any `cloud.status` event. Even when the wrapper sends a fatal `error` event, the ingest handler broadcasts `cloud.status: error` but never follows with `cloud.status: ready`.

2. **Wrapper gap**: `getTerminalFailure()` only classifies payment/credit/quota/model-not-found errors as terminal. AI SDK errors like `AI_InvalidResponseDataError` (e.g., when a BYOK model returns a malformed response) are NOT classified as terminal, so the wrapper never sends a fatal `error` event — it disconnects without any terminal event, triggering gap 1.

## Fix 1: DO broadcasts `cloud.status: ready` after terminalization

- `handleWrapperTerminalEvent` broadcasts `cloud.status: ready` after `onTerminalEvent` for `failed`/`interrupted` status (skips `completed` since the ingest handler already broadcasts it).
- Added `onSessionTerminalized` callback to `WrapperSupervisorDependencies`, called after `checkDisconnectGrace` and `handleUnhealthyWrapper` terminalize accepted work, so the DO broadcasts `cloud.status: ready` on the disconnect-grace and liveness-expiry paths that don't go through the normal terminal-event flow.

## Fix 2: Wrapper detects AI SDK response errors as terminal

- Added `provider_error` to `WrapperTerminalFailureCodes`.
- Added `isAIProviderResponseError` helper detecting `AI_InvalidResponseDataError`, `AI_JSONParseError`, and the `Expected '...' to be a ...` message pattern.
- Wired into `getTerminalFailure` so these permanent failures send a fatal `error` event to the DO, which then broadcasts the error and transitions to ready.

## Supporting changes

Added `provider_error` to the shared failure-code contract (`CLOUD_AGENT_FAILURE_CODES`, DB schema type, safe-failure-projection message map, and non-retryable set) for consistency across run-state reports, client error projection, and telemetry.

## Verification

- `pnpm run typecheck` — passes
- `pnpm run lint` — passes
- `pnpm run test` — 2184 unit tests pass
- `pnpm run test:integration` — 210 integration tests pass