### PR TITLE
Support decimal Vercel routing percentages

### DIFF
--- a/apps/web/src/app/admin/gateway/RoutingContent.tsx
+++ b/apps/web/src/app/admin/gateway/RoutingContent.tsx
@@ -9,7 +9,11 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { DEFAULT_VERCEL_PERCENTAGE, NOTE_MAX_LENGTH } from '@/lib/ai-gateway/gateway-config';
+import {
+  DEFAULT_VERCEL_PERCENTAGE,
+  NOTE_MAX_LENGTH,
+  VercelRoutingPercentageSchema,
+} from '@/lib/ai-gateway/gateway-config';
 
 export function RoutingContent() {
   const trpc = useTRPC();
@@ -55,8 +59,10 @@ export function RoutingContent() {
       mutation.mutate({ vercel_routing_percentage: null, note });
     } else {
       const num = Number(trimmed);
-      if (!Number.isInteger(num) || num < 0 || num > 100) {
-        toast.error('Please enter a whole number between 0 and 100, or leave empty for default');
+      if (!VercelRoutingPercentageSchema.safeParse(num).success) {
+        toast.error(
+          'Enter a percentage between 0 and 100 with up to 3 decimal places, or leave it empty for the default.'
+        );
         return;
       }
       mutation.mutate({ vercel_routing_percentage: num, note });
@@ -92,6 +98,7 @@ export function RoutingContent() {
               type="number"
               min={0}
               max={100}
+              step={0.001}
               placeholder={`Default: ${DEFAULT_VERCEL_PERCENTAGE}%`}
               value={inputValue}
               onChange={e => {

--- a/apps/web/src/lib/ai-gateway/gateway-config.test.ts
+++ b/apps/web/src/lib/ai-gateway/gateway-config.test.ts
@@ -4,7 +4,18 @@ import {
   GatewayConfigSchema,
   GatewayConfigInputSchema,
   NOTE_MAX_LENGTH,
+  VercelRoutingPercentageSchema,
 } from './gateway-config';
+
+describe('VercelRoutingPercentageSchema', () => {
+  test.each([0, 0.001, 12.345, 99.9, 99.999, 100])('accepts %s', percentage => {
+    expect(VercelRoutingPercentageSchema.parse(percentage)).toBe(percentage);
+  });
+
+  test.each([-0.001, 12.3456, 100.001])('rejects %s', percentage => {
+    expect(() => VercelRoutingPercentageSchema.parse(percentage)).toThrow();
+  });
+});
 
 describe('GatewayPercentageSchema', () => {
   test('accepts a numeric percentage', () => {

--- a/apps/web/src/lib/ai-gateway/gateway-config.ts
+++ b/apps/web/src/lib/ai-gateway/gateway-config.ts
@@ -2,14 +2,14 @@ import * as z from 'zod';
 
 export const DEFAULT_VERCEL_PERCENTAGE = 50;
 
-const vercelRoutingPercentage = z.number().int().min(0).max(100);
+export const VercelRoutingPercentageSchema = z.number().min(0).max(100).multipleOf(0.001);
 
 export const NOTE_MAX_LENGTH = 500;
 
 const note = z.string().max(NOTE_MAX_LENGTH);
 
 export const GatewayConfigSchema = z.object({
-  vercel_routing_percentage: vercelRoutingPercentage.nullable(),
+  vercel_routing_percentage: VercelRoutingPercentageSchema.nullable(),
   updated_at: z.string().nullable(),
   updated_by: z.string().nullable(),
   updated_by_email: z.string().nullable(),
@@ -34,11 +34,11 @@ export const DEFAULT_GATEWAY_CONFIG: GatewayConfig = {
  * "no override, use DEFAULT_VERCEL_PERCENTAGE".
  */
 export const GatewayPercentageSchema = z.object({
-  vercel_routing_percentage: vercelRoutingPercentage.nullable(),
+  vercel_routing_percentage: VercelRoutingPercentageSchema.nullable(),
 });
 
 /** Schema for the admin set-mutation input. */
 export const GatewayConfigInputSchema = z.object({
-  vercel_routing_percentage: vercelRoutingPercentage.nullable(),
+  vercel_routing_percentage: VercelRoutingPercentageSchema.nullable(),
   note: note.nullable(),
 });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from '@jest/globals';
 import {
   getAnthropicProviderOptionsForVercel,
   hasCompatibleVercelInferenceProvider,
+  passesVercelRoutingPercentage,
 } from '@/lib/ai-gateway/providers/vercel';
+import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 
 describe('getAnthropicProviderOptionsForVercel', () => {
@@ -68,5 +70,32 @@ describe('hasCompatibleVercelInferenceProvider', () => {
 
   it('accepts when the model has no cached provider entry', () => {
     expect(hasCompatibleVercelInferenceProvider(['google-vertex'], null)).toBe(true);
+  });
+});
+
+describe('passesVercelRoutingPercentage', () => {
+  it('never passes at 0% and always passes at 100%', () => {
+    for (let seed = 0; seed < 1_000; seed++) {
+      expect(passesVercelRoutingPercentage(String(seed), 0)).toBe(false);
+      expect(passesVercelRoutingPercentage(String(seed), 100)).toBe(true);
+    }
+  });
+
+  it('preserves whole-percentage routing cohorts', () => {
+    for (let seed = 0; seed < 1_000; seed++) {
+      const randomSeed = String(seed);
+      const previousDecision = getRandomNumber('vercel_routing_' + randomSeed, 100) < 63;
+
+      expect(passesVercelRoutingPercentage(randomSeed, 63)).toBe(previousDecision);
+    }
+  });
+
+  it('routes a fractional portion of the next percentage bucket', () => {
+    const seedsInFinalBucket = Array.from({ length: 10_000 }, (_, seed) => String(seed)).filter(
+      seed => getRandomNumber('vercel_routing_' + seed, 100) === 99
+    );
+
+    expect(seedsInFinalBucket.some(seed => passesVercelRoutingPercentage(seed, 99.9))).toBe(true);
+    expect(seedsInFinalBucket.some(seed => !passesVercelRoutingPercentage(seed, 99.9))).toBe(true);
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -73,6 +73,14 @@ export function hasCompatibleVercelInferenceProvider(
   );
 }
 
+export function passesVercelRoutingPercentage(randomSeed: string, routingPercentage: number) {
+  const routingSeed = 'vercel_routing_' + randomSeed;
+  const wholePercentageBucket = getRandomNumber(routingSeed, 100);
+  const fractionalPercentageBucket = getRandomNumber(routingSeed + '_fractional', 1_000);
+
+  return wholePercentageBucket + fractionalPercentageBucket / 1_000 < routingPercentage;
+}
+
 export async function shouldRouteToVercel(
   requestedModel: string,
   kiloExclusiveModel: KiloExclusiveModel | null,
@@ -97,8 +105,7 @@ export async function shouldRouteToVercel(
   console.debug('[shouldRouteToVercel] randomizing user to either OpenRouter or Vercel');
   const routingPercentage = await getVercelRoutingPercentage();
 
-  const passedRandomization =
-    getRandomNumber('vercel_routing_' + randomSeed, 100) < routingPercentage;
+  const passedRandomization = passesVercelRoutingPercentage(randomSeed, routingPercentage);
 
   if (!passedRandomization) {
     return false;


### PR DESCRIPTION
## Summary
- accept Vercel routing percentages with up to three decimal places
- update the admin input and validation for decimal values
- add deterministic fractional routing while preserving whole-percentage cohorts
- cover decimal validation and routing behavior with unit tests

## Verification
- `pnpm -w exec oxfmt --check ...` passed for all changed files
- `git diff --check` passed
- focused Jest tests could not run because the global test setup requires PostgreSQL and Docker is unavailable in this environment
- changes-only typecheck exceeded the 120-second environment limit