### PR TITLE
docs(agents): scope remaining baseline rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,16 +66,6 @@ package manifests before running repository JavaScript or package scripts. Load
 | UI and product design | `DESIGN.md`, relevant app `AGENTS.md`, and `kilo-design` skill |
 | Contribution and PR workflow | `CONTRIBUTING.md` and relevant Git or PR skill |
 
-## Domain Context
-
-`CONTEXT.md` defines domain language and ownership for Code Reviewer, Security
-Agent, and Cost Insights contexts. Before changing covered domains, consult its
-`Scope` and `Contexts` sections. It does not govern the rest of the monorepo.
-
-## Mandatory Baseline
+## Security Baseline
 
 - Never log tokens, credentials, API keys, authentication headers, cookies, or webhook secrets. Use `redactSensitiveHeaders` when headers must be retained or logged. Do not enable `sendDefaultPii` or `attachRpcInput` in Sentry.
-- Validate genuinely unknown, external, user-controlled, or persisted data at runtime. Do not hide uncertainty with `as any`, double casts through `unknown`, or non-null assertions.
-- When adding persisted PII such as email, name, or IP address to any database, update `softDeleteUser` in `apps/web/src/lib/user/index.ts` to delete or anonymize it and add corresponding test in `apps/web/src/lib/user/index.test.ts`.
-- Do not use Git `--force`, `--no-verify`, or any flag that bypasses hooks or safety checks without explicit user approval. Diagnose failed hooks rather than skipping them.
-- Run `pnpm format` before committing.

--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -30,8 +30,9 @@ Prefer one generated migration per unshipped feature branch.
 Load `database-migrations` for shared PostgreSQL migration work. Load
 `git-rebase` for migration conflicts during a rebase.
 
-For shared-schema PII additions, follow root `AGENTS.md`'s `softDeleteUser` and
-corresponding test invariant; do not duplicate that rule here.
+When adding user or account PII to shared PostgreSQL, update `softDeleteUser` in
+`apps/web/src/lib/user/index.ts` to delete or anonymize it and add corresponding
+coverage in `apps/web/src/lib/user/index.test.ts`.
 
 ## Timestamp boundaries
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -376,8 +376,8 @@ export type NewCreditCampaign = typeof credit_campaigns.$inferInsert;
 
 /**
  * When adding or removing PII/account-linked columns, update
- * softDeleteUser() in src/lib/user.ts (and src/lib/user.test.ts) to
- * null or reset the field.
+ * softDeleteUser() in apps/web/src/lib/user/index.ts (and its index.test.ts) to
+ * delete, anonymize, or reset the field.
  */
 export const kilocode_users = pgTable(
   'kilocode_users',


### PR DESCRIPTION
## Summary
Moves remaining repository guidance to scopes that match where each rule applies.

### Why this change is needed
Root guidance mixed repository-wide security policy with TypeScript-specific advice and a shared PostgreSQL cleanup requirement. This made ownership less clear and described the `softDeleteUser` requirement as applying to databases it does not manage.

### How this is addressed
- Keep secret-handling and Sentry PII safeguards as the repository-wide security baseline.
- Leave runtime validation and unsafe-cast guidance to the existing code-quality skill.
- Place the `softDeleteUser` requirement with shared PostgreSQL guidance and narrow its scope to user or account PII.
- Correct stale cleanup-path references in the shared schema comment.

## Human Verification
- Reviewed each remaining baseline rule against scoped repository guides, skills, and its actual consumers.

## Reviewer Notes

### Human Reviewer Flags
- Guidance placement now distinguishes repository-wide security policy from TypeScript task guidance and shared PostgreSQL lifecycle requirements.
