### PR TITLE
feat(code-reviewer) council type code review core components

### DIFF
--- a/packages/db/src/schema-types.test.ts
+++ b/packages/db/src/schema-types.test.ts
@@ -1,5 +1,30 @@
 import { describe, expect, it } from '@jest/globals';
-import { OrganizationSettingsSchema } from './schema-types';
+import { CodeReviewCouncilConfigSchema, OrganizationSettingsSchema } from './schema-types';
+
+describe('CodeReviewCouncilConfigSchema', () => {
+  const specialist = (id: string) => ({
+    id,
+    role: 'security' as const,
+    name: 'Security',
+    enabled: true,
+    required: false,
+    lens: 'security concerns',
+  });
+
+  it('accepts a council with unique specialist ids', () => {
+    const result = CodeReviewCouncilConfigSchema.safeParse({
+      specialists: [specialist('security'), specialist('performance')],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects duplicate specialist ids (a specialist must not vote twice)', () => {
+    const result = CodeReviewCouncilConfigSchema.safeParse({
+      specialists: [specialist('security'), specialist('security')],
+    });
+    expect(result.success).toBe(false);
+  });
+});
 
 describe('OrganizationSettingsSchema org_auto_model', () => {
   it('accepts bounded route maps and a fallback model', () => {

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1306,7 +1306,21 @@ export const CodeReviewCouncilConfigSchema = z.object({
   // object (e.g. from a manual job) is treated as enabled.
   enabled: z.boolean().default(true),
   aggregation_strategy: CouncilAggregationStrategySchema.default('any_blocking_member'),
-  specialists: z.array(CouncilSpecialistSchema).max(8),
+  // Specialist ids must be unique: a specialist must not appear (and therefore vote)
+  // more than once, or vote aggregation could be skewed by a duplicate.
+  specialists: z
+    .array(CouncilSpecialistSchema)
+    .max(8)
+    .superRefine((specialists, ctx) => {
+      const seen = new Set<string>();
+      for (const specialist of specialists) {
+        if (seen.has(specialist.id)) {
+          ctx.addIssue({ code: 'custom', message: `Duplicate specialist id: ${specialist.id}` });
+          return;
+        }
+        seen.add(specialist.id);
+      }
+    }),
 });
 export type CodeReviewCouncilConfig = z.infer<typeof CodeReviewCouncilConfigSchema>;
 

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -29,7 +29,8 @@
     "./security-finding-audit": "./src/security-finding-audit.ts",
     "./dependabot-dismissal-target": "./src/dependabot-dismissal-target.ts",
     "./client-error": "./src/client-error.ts",
-    "./review-agents": "./src/review-agents.ts"
+    "./review-agents": "./src/review-agents.ts",
+    "./code-review-council": "./src/code-review-council.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -170,6 +170,51 @@ describe('parseCouncilResultManifest', () => {
     expect(capture.manifest.specialists[0].vote).toBe('block');
   });
 
+  it('captures a manifest whose finding text contains --> and braces (no false invalid)', () => {
+    const tricky = {
+      specialists: [
+        {
+          specialistId: 'correctness',
+          vote: 'warn',
+          highestSeverity: 'medium',
+          findings: [
+            {
+              path: 'src/loop.ts',
+              line: 12,
+              severity: 'medium',
+              rationale: 'Confusing "goes to" operator: while (i --> 0) {} reads like an arrow.',
+            },
+          ],
+        },
+      ],
+    };
+    const text = `Summary here.\n<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(tricky)} -->\nthanks!`;
+    const capture = parseCouncilResultManifest(text);
+    expect(capture.status).toBe('captured');
+    if (capture.status !== 'captured') throw new Error('unreachable');
+    expect(capture.manifest.specialists[0].findings[0].rationale).toContain('i --> 0');
+  });
+
+  it('captures the last marker even when an earlier finding contains -->', () => {
+    const first = {
+      specialists: [
+        {
+          specialistId: 'security',
+          vote: 'pass',
+          findings: [{ path: 'a.ts', line: 1, severity: 'low', rationale: 'note --> here' }],
+        },
+      ],
+    };
+    const last = {
+      specialists: [{ specialistId: 'security', vote: 'block', findings: [] }],
+    };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(first)} -->\n<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(last)} -->`;
+    const capture = parseCouncilResultManifest(text);
+    expect(capture.status).toBe('captured');
+    if (capture.status !== 'captured') throw new Error('unreachable');
+    expect(capture.manifest.specialists[0].vote).toBe('block');
+  });
+
   it('returns invalid when the payload exceeds the size cap', () => {
     const huge = {
       specialists: [
@@ -306,6 +351,18 @@ describe('parseGovernanceMarker', () => {
       `<!-- kilo-review-governance:v1 ${JSON.stringify(gov)} -->`
     );
     expect(parsed?.members[0].highestSeverity).toBeNull();
+  });
+
+  it('parses when a member reason contains --> and braces', () => {
+    const gov = {
+      members: [{ id: 'security', vote: 'warn', reason: 'template `${x}` and --> in code' }],
+      decision: 'warn',
+    };
+    const parsed = parseGovernanceMarker(
+      `<!-- kilo-review-governance:v1 ${JSON.stringify(gov)} -->`
+    );
+    expect(parsed?.decision).toBe('warn');
+    expect(parsed?.members[0].reason).toContain('-->');
   });
 });
 

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -5,6 +5,7 @@ import {
   COUNCIL_SPECIALIST_PRESETS,
   computeCouncilDecision,
   councilDecisionBlocksMerge,
+  decideCouncilFromManifest,
   describeAggregationStrategy,
   determineAutomatedReviewType,
   enabledSpecialists,
@@ -17,6 +18,7 @@ import {
   summarizeCouncilManifest,
   type SpecialistVote,
 } from './code-review-council.js';
+import type { CouncilResultManifest } from './code-review-council.js';
 import type {
   CodeReviewCouncilConfig,
   CouncilAggregationStrategy,
@@ -207,31 +209,77 @@ describe('summarizeCouncilManifest', () => {
 });
 
 describe('reconcileCouncilVotes', () => {
-  const manifest = {
+  const manifest: CouncilResultManifest = {
     specialists: [
-      { specialistId: 'security', vote: 'block' as const, findings: [] },
-      { specialistId: 'unknown', vote: 'pass' as const, findings: [] },
+      { specialistId: 'security', vote: 'block', findings: [] },
+      { specialistId: 'unknown', vote: 'pass', findings: [] },
     ],
   };
 
-  it('maps a configured specialist absent from the manifest to abstain', () => {
-    const reconciled = reconcileCouncilVotes(['security', 'performance'], manifest);
-    expect(reconciled).toEqual([
-      { specialistId: 'security', vote: 'block' },
-      { specialistId: 'performance', vote: 'abstain' },
-    ]);
+  it('surfaces a configured specialist absent from the manifest as missing (not abstain)', () => {
+    const coverage = reconcileCouncilVotes(['security', 'performance'], manifest);
+    expect(coverage.votes).toEqual([{ specialistId: 'security', vote: 'block' }]);
+    expect(coverage.missingSpecialistIds).toEqual(['performance']);
   });
 
   it('ignores manifest entries for specialists we did not configure', () => {
-    const reconciled = reconcileCouncilVotes(['security'], manifest);
-    expect(reconciled).toEqual([{ specialistId: 'security', vote: 'block' }]);
+    const coverage = reconcileCouncilVotes(['security'], manifest);
+    expect(coverage.votes).toEqual([{ specialistId: 'security', vote: 'block' }]);
+    expect(coverage.missingSpecialistIds).toEqual([]);
   });
 
-  it('a dropped specialist cannot let the council pass', () => {
-    const reconciled = reconcileCouncilVotes(['security', 'performance'], {
-      specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }],
+  it('keeps a legitimately returned abstain vote as abstain', () => {
+    const coverage = reconcileCouncilVotes(['security'], {
+      specialists: [{ specialistId: 'security', vote: 'abstain', findings: [] }],
     });
-    expect(computeCouncilDecision(reconciled, 'unanimous_required')).toBe('block');
+    expect(coverage.votes).toEqual([{ specialistId: 'security', vote: 'abstain' }]);
+    expect(coverage.missingSpecialistIds).toEqual([]);
+  });
+});
+
+describe('decideCouncilFromManifest (coverage-aware)', () => {
+  const strategies = ['any_blocking_member', 'majority', 'unanimous_required'] as const;
+
+  it('blocks under EVERY strategy when a configured specialist is missing (fail closed)', () => {
+    const manifest: CouncilResultManifest = {
+      specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }],
+    };
+    for (const strategy of strategies) {
+      const result = decideCouncilFromManifest(['security', 'performance'], manifest, strategy);
+      expect(result.decision).toBe('block');
+      expect(result.missingSpecialistIds).toEqual(['performance']);
+    }
+  });
+
+  it('passes when every configured specialist reported and all pass', () => {
+    const manifest: CouncilResultManifest = {
+      specialists: [
+        { specialistId: 'security', vote: 'pass', findings: [] },
+        { specialistId: 'performance', vote: 'pass', findings: [] },
+      ],
+    };
+    const result = decideCouncilFromManifest(
+      ['security', 'performance'],
+      manifest,
+      'any_blocking_member'
+    );
+    expect(result.decision).toBe('pass');
+    expect(result.missingSpecialistIds).toEqual([]);
+  });
+
+  it('does not block on a legitimately returned abstain under any_blocking_member (strategy A)', () => {
+    const manifest: CouncilResultManifest = {
+      specialists: [
+        { specialistId: 'security', vote: 'abstain', findings: [] },
+        { specialistId: 'performance', vote: 'pass', findings: [] },
+      ],
+    };
+    const result = decideCouncilFromManifest(
+      ['security', 'performance'],
+      manifest,
+      'any_blocking_member'
+    );
+    expect(result.decision).toBe('pass');
   });
 });
 

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -116,6 +116,15 @@ describe('describeAggregationStrategy', () => {
     expect(m.toLowerCase()).toContain('majority');
     expect(u.toLowerCase()).toContain('unanimous');
   });
+
+  it('documents the no-usable-coverage → block rule for every strategy (lockstep with computeCouncilDecision)', () => {
+    const strategies = ['any_blocking_member', 'majority', 'unanimous_required'] as const;
+    for (const strategy of strategies) {
+      const text = describeAggregationStrategy(strategy).toLowerCase();
+      expect(text).toContain('all abstained');
+      expect(text).toContain('block');
+    }
+  });
 });
 
 describe('parseCouncilResultManifest', () => {
@@ -234,6 +243,47 @@ describe('parseCouncilResultManifest', () => {
     expect(decision.missingSpecialistIds).toEqual(['security']);
   });
 
+  it('does not treat a longer version tag (v10 / v1junk) as a v1 marker', () => {
+    const manifest = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
+    expect(
+      parseCouncilResultManifest(
+        `<!-- ${COUNCIL_RESULT_MARKER_TAG}0 ${JSON.stringify(manifest)} -->`
+      ).status
+    ).toBe('missing');
+    expect(
+      parseCouncilResultManifest(
+        `<!-- ${COUNCIL_RESULT_MARKER_TAG}junk ${JSON.stringify(manifest)} -->`
+      ).status
+    ).toBe('missing');
+  });
+
+  it('ignores marker text embedded inside a finding and captures the real manifest', () => {
+    // A specialist quotes the marker in its rationale. JSON.stringify does not escape it,
+    // so the serialized message contains a second, embedded marker occurrence.
+    const real = {
+      specialists: [
+        {
+          specialistId: 'security',
+          vote: 'block',
+          findings: [
+            {
+              path: 'a.ts',
+              line: 1,
+              severity: 'high',
+              rationale: `Do not emit <!-- ${COUNCIL_RESULT_MARKER_TAG} {"specialists":[]} --> in code.`,
+            },
+          ],
+        },
+      ],
+    };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(real)} -->`;
+    const capture = parseCouncilResultManifest(text);
+    expect(capture.status).toBe('captured');
+    if (capture.status !== 'captured') throw new Error('unreachable');
+    expect(capture.manifest.specialists).toHaveLength(1);
+    expect(capture.manifest.specialists[0].vote).toBe('block');
+  });
+
   it('returns invalid when the payload exceeds the size cap', () => {
     const huge = {
       specialists: [
@@ -344,6 +394,18 @@ describe('decideCouncilFromManifest (coverage-aware)', () => {
       'any_blocking_member'
     );
     expect(result.decision).toBe('pass');
+  });
+
+  it('fails closed on a duplicate configured id (a specialist cannot be counted twice)', () => {
+    const manifest: CouncilResultManifest = {
+      specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }],
+    };
+    // Without the guard, ['security','security'] would append security's pass vote twice
+    // and could flip a majority. It is counted once and treated as unreliable coverage.
+    const result = decideCouncilFromManifest(['security', 'security'], manifest, 'majority');
+    expect(result.decision).toBe('block');
+    expect(result.missingSpecialistIds).toEqual(['security']);
+    expect(result.votes).toEqual([]);
   });
 });
 

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -215,6 +215,25 @@ describe('parseCouncilResultManifest', () => {
     expect(capture.manifest.specialists[0].vote).toBe('block');
   });
 
+  it('treats a duplicate specialistId as invalid (a later entry cannot override an earlier vote)', () => {
+    const dup = {
+      specialists: [
+        { specialistId: 'security', vote: 'block', findings: [] },
+        { specialistId: 'security', vote: 'pass', findings: [] },
+      ],
+    };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(dup)} -->`;
+    expect(parseCouncilResultManifest(text).status).toBe('invalid');
+    // And a duplicate manifest must fail closed at the decision layer.
+    const decision = decideCouncilFromManifest(
+      ['security'],
+      dup as unknown as CouncilResultManifest,
+      'any_blocking_member'
+    );
+    expect(decision.decision).toBe('block');
+    expect(decision.missingSpecialistIds).toEqual(['security']);
+  });
+
   it('returns invalid when the payload exceeds the size cap', () => {
     const huge = {
       specialists: [

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -326,6 +326,35 @@ describe('parseCouncilResultManifest', () => {
     expect(parseCouncilResultManifest(text).status).toBe('invalid');
   });
 
+  it('ignores an embedded marker preceded by a Unicode line separator (U+2028/U+2029)', () => {
+    // JS `^m` treats U+2028/U+2029 as line starts, and JSON.stringify leaves them
+    // unescaped — so a finding containing one before the marker must NOT be treated as a
+    // top-level marker.
+    const real = {
+      specialists: [
+        {
+          specialistId: 'security',
+          vote: 'block',
+          findings: [
+            {
+              path: 'a.ts',
+              line: 1,
+              severity: 'high',
+              rationale: `line1\u2028<!-- ${COUNCIL_RESULT_MARKER_TAG} {"specialists":[]} -->\u2029end`,
+            },
+          ],
+        },
+      ],
+    };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(real)} -->`;
+    // Sanity: the serialized text really contains a raw U+2028 (unescaped by JSON.stringify).
+    expect(text).toContain('\u2028');
+    const capture = parseCouncilResultManifest(text);
+    expect(capture.status).toBe('captured');
+    if (capture.status !== 'captured') throw new Error('unreachable');
+    expect(capture.manifest.specialists[0].vote).toBe('block');
+  });
+
   it('does not treat a mid-line (non-line-anchored) marker as top-level', () => {
     const manifest = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
     // Marker preceded by non-whitespace on the same line is not a top-level marker.

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COUNCIL_MIN_SPECIALISTS,
+  COUNCIL_RESULT_MARKER_TAG,
+  COUNCIL_SPECIALIST_PRESETS,
+  computeCouncilDecision,
+  councilDecisionBlocksMerge,
+  describeAggregationStrategy,
+  determineAutomatedReviewType,
+  enabledSpecialists,
+  formatAggregationStrategy,
+  isCouncilActive,
+  parseCouncilResultManifest,
+  parseGovernanceMarker,
+  presetToSpecialist,
+  reconcileCouncilVotes,
+  summarizeCouncilManifest,
+  type SpecialistVote,
+} from './code-review-council.js';
+import type {
+  CodeReviewCouncilConfig,
+  CouncilAggregationStrategy,
+} from '@kilocode/db/schema-types';
+
+const votes = (...vs: Array<[string, SpecialistVote['vote']]>): SpecialistVote[] =>
+  vs.map(([specialistId, vote]) => ({ specialistId, vote }));
+
+describe('computeCouncilDecision', () => {
+  it('blocks on empty coverage for every strategy (never pass)', () => {
+    const strategies: CouncilAggregationStrategy[] = [
+      'any_blocking_member',
+      'majority',
+      'unanimous_required',
+    ];
+    for (const strategy of strategies) {
+      expect(computeCouncilDecision([], strategy)).toBe('block');
+      // All-abstain is also "no usable coverage".
+      expect(computeCouncilDecision(votes(['a', 'abstain'], ['b', 'abstain']), strategy)).toBe(
+        'block'
+      );
+    }
+  });
+
+  describe('any_blocking_member', () => {
+    it('blocks if any specialist blocks', () => {
+      expect(
+        computeCouncilDecision(votes(['a', 'pass'], ['b', 'block']), 'any_blocking_member')
+      ).toBe('block');
+    });
+    it('warns if any warn and none block', () => {
+      expect(
+        computeCouncilDecision(votes(['a', 'pass'], ['b', 'warn']), 'any_blocking_member')
+      ).toBe('warn');
+    });
+    it('passes when all pass', () => {
+      expect(
+        computeCouncilDecision(votes(['a', 'pass'], ['b', 'pass']), 'any_blocking_member')
+      ).toBe('pass');
+    });
+  });
+
+  describe('majority', () => {
+    it('blocks only when block votes outnumber pass votes', () => {
+      expect(
+        computeCouncilDecision(votes(['a', 'block'], ['b', 'block'], ['c', 'pass']), 'majority')
+      ).toBe('block');
+      // Tie (1 block, 1 pass) is not a block majority → warn/pass by remaining votes.
+      expect(computeCouncilDecision(votes(['a', 'block'], ['b', 'pass']), 'majority')).toBe('pass');
+    });
+    it('warns when not out-blocked but a warn exists', () => {
+      expect(
+        computeCouncilDecision(votes(['a', 'pass'], ['b', 'pass'], ['c', 'warn']), 'majority')
+      ).toBe('warn');
+    });
+  });
+
+  describe('unanimous_required', () => {
+    it('blocks if any block or abstain', () => {
+      expect(
+        computeCouncilDecision(votes(['a', 'pass'], ['b', 'abstain']), 'unanimous_required')
+      ).toBe('block');
+      expect(
+        computeCouncilDecision(votes(['a', 'pass'], ['b', 'block']), 'unanimous_required')
+      ).toBe('block');
+    });
+    it('warns if all non-block/non-abstain but a warn exists', () => {
+      expect(
+        computeCouncilDecision(votes(['a', 'pass'], ['b', 'warn']), 'unanimous_required')
+      ).toBe('warn');
+    });
+    it('passes only when every specialist passes', () => {
+      expect(
+        computeCouncilDecision(votes(['a', 'pass'], ['b', 'pass']), 'unanimous_required')
+      ).toBe('pass');
+    });
+  });
+});
+
+describe('councilDecisionBlocksMerge', () => {
+  it('blocks only on block', () => {
+    expect(councilDecisionBlocksMerge('block')).toBe(true);
+    expect(councilDecisionBlocksMerge('warn')).toBe(false);
+    expect(councilDecisionBlocksMerge('pass')).toBe(false);
+    expect(councilDecisionBlocksMerge('abstain')).toBe(false);
+  });
+});
+
+describe('describeAggregationStrategy', () => {
+  it('returns distinct wording per strategy', () => {
+    const a = describeAggregationStrategy('any_blocking_member');
+    const m = describeAggregationStrategy('majority');
+    const u = describeAggregationStrategy('unanimous_required');
+    expect(new Set([a, m, u]).size).toBe(3);
+    expect(m.toLowerCase()).toContain('majority');
+    expect(u.toLowerCase()).toContain('unanimous');
+  });
+});
+
+describe('parseCouncilResultManifest', () => {
+  const manifest = {
+    specialists: [
+      {
+        specialistId: 'security',
+        vote: 'block',
+        highestSeverity: 'critical',
+        findings: [{ path: 'a.ts', line: 3, severity: 'critical', rationale: 'sqli' }],
+      },
+      { specialistId: 'performance', vote: 'pass', findings: [] },
+    ],
+  };
+
+  it('captures a well-formed combined manifest', () => {
+    const text = `review done\n<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(manifest)} -->`;
+    const capture = parseCouncilResultManifest(text);
+    expect(capture.status).toBe('captured');
+    if (capture.status !== 'captured') throw new Error('unreachable');
+    expect(capture.manifest.specialists).toHaveLength(2);
+    expect(capture.manifest.specialists[0].findings).toHaveLength(1);
+    // findings defaults to [] when omitted.
+    expect(capture.manifest.specialists[1].findings).toEqual([]);
+  });
+
+  it('returns missing when no marker present', () => {
+    expect(parseCouncilResultManifest('no marker here').status).toBe('missing');
+    expect(parseCouncilResultManifest('').status).toBe('missing');
+    expect(parseCouncilResultManifest(null).status).toBe('missing');
+  });
+
+  it('returns invalid when a specialist vote is missing/invalid', () => {
+    const bad = { specialists: [{ specialistId: 'security', findings: [] }] };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(bad)} -->`;
+    expect(parseCouncilResultManifest(text).status).toBe('invalid');
+  });
+
+  it('returns invalid on non-JSON payload', () => {
+    expect(parseCouncilResultManifest(`<!-- ${COUNCIL_RESULT_MARKER_TAG} {nope} -->`).status).toBe(
+      'invalid'
+    );
+  });
+
+  it('uses the last marker when several are present (trailing prose safe)', () => {
+    const first = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
+    const last = { specialists: [{ specialistId: 'security', vote: 'block', findings: [] }] };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(first)} -->\nthen\n<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(last)} -->\ntrailing note`;
+    const capture = parseCouncilResultManifest(text);
+    expect(capture.status).toBe('captured');
+    if (capture.status !== 'captured') throw new Error('unreachable');
+    expect(capture.manifest.specialists[0].vote).toBe('block');
+  });
+
+  it('returns invalid when the payload exceeds the size cap', () => {
+    const huge = {
+      specialists: [
+        {
+          specialistId: 'security',
+          vote: 'pass',
+          findings: [{ path: 'a.ts', line: 1, severity: 'x', rationale: 'y'.repeat(200_000) }],
+        },
+      ],
+    };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(huge)} -->`;
+    expect(parseCouncilResultManifest(text).status).toBe('invalid');
+  });
+});
+
+describe('summarizeCouncilManifest', () => {
+  it('rolls up vote, highest severity, and findings count per specialist', () => {
+    const summary = summarizeCouncilManifest({
+      specialists: [
+        {
+          specialistId: 'security',
+          vote: 'block',
+          highestSeverity: 'critical',
+          findings: [
+            { path: 'a.ts', line: 1, severity: 'critical', rationale: 'x' },
+            { path: 'b.ts', line: 2, severity: 'high', rationale: 'y' },
+          ],
+        },
+        { specialistId: 'performance', vote: 'pass', findings: [] },
+      ],
+    });
+    expect(summary).toEqual([
+      { specialistId: 'security', vote: 'block', highestSeverity: 'critical', findingsCount: 2 },
+      { specialistId: 'performance', vote: 'pass', highestSeverity: null, findingsCount: 0 },
+    ]);
+  });
+});
+
+describe('reconcileCouncilVotes', () => {
+  const manifest = {
+    specialists: [
+      { specialistId: 'security', vote: 'block' as const, findings: [] },
+      { specialistId: 'unknown', vote: 'pass' as const, findings: [] },
+    ],
+  };
+
+  it('maps a configured specialist absent from the manifest to abstain', () => {
+    const reconciled = reconcileCouncilVotes(['security', 'performance'], manifest);
+    expect(reconciled).toEqual([
+      { specialistId: 'security', vote: 'block' },
+      { specialistId: 'performance', vote: 'abstain' },
+    ]);
+  });
+
+  it('ignores manifest entries for specialists we did not configure', () => {
+    const reconciled = reconcileCouncilVotes(['security'], manifest);
+    expect(reconciled).toEqual([{ specialistId: 'security', vote: 'block' }]);
+  });
+
+  it('a dropped specialist cannot let the council pass', () => {
+    const reconciled = reconcileCouncilVotes(['security', 'performance'], {
+      specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }],
+    });
+    expect(computeCouncilDecision(reconciled, 'unanimous_required')).toBe('block');
+  });
+});
+
+describe('parseGovernanceMarker', () => {
+  it('parses a valid governance marker', () => {
+    const gov = { members: [{ id: 'security', vote: 'pass' }], decision: 'pass' };
+    expect(
+      parseGovernanceMarker(`<!-- kilo-review-governance:v1 ${JSON.stringify(gov)} -->`)
+    ).toEqual({
+      members: [{ id: 'security', vote: 'pass', highestSeverity: null }],
+      decision: 'pass',
+    });
+  });
+
+  it('returns null when absent or malformed', () => {
+    expect(parseGovernanceMarker('nothing')).toBeNull();
+    expect(parseGovernanceMarker(null)).toBeNull();
+    expect(parseGovernanceMarker('<!-- kilo-review-governance:v1 {bad} -->')).toBeNull();
+  });
+
+  it('normalizes a "none" severity label to null', () => {
+    const gov = { members: [{ id: 'a', vote: 'pass', highestSeverity: 'none' }], decision: 'pass' };
+    const parsed = parseGovernanceMarker(
+      `<!-- kilo-review-governance:v1 ${JSON.stringify(gov)} -->`
+    );
+    expect(parsed?.members[0].highestSeverity).toBeNull();
+  });
+});
+
+describe('council config helpers', () => {
+  const council: CodeReviewCouncilConfig = {
+    enabled: true,
+    aggregation_strategy: 'any_blocking_member',
+    specialists: [
+      presetToSpecialist(COUNCIL_SPECIALIST_PRESETS[0]),
+      { ...presetToSpecialist(COUNCIL_SPECIALIST_PRESETS[1]), enabled: false },
+    ],
+  };
+
+  it('enabledSpecialists filters to enabled', () => {
+    expect(enabledSpecialists(council).map(s => s.id)).toEqual(['security']);
+  });
+
+  it('isCouncilActive requires enabled + at least one enabled specialist', () => {
+    expect(isCouncilActive(council)).toBe(true);
+    expect(isCouncilActive({ ...council, enabled: false })).toBe(false);
+    expect(isCouncilActive({ ...council, specialists: [] })).toBe(false);
+    expect(isCouncilActive(null)).toBe(false);
+  });
+
+  it('formatAggregationStrategy labels known strategies and falls back', () => {
+    expect(formatAggregationStrategy('majority')).toBe('Majority');
+    expect(formatAggregationStrategy(null)).toBe('Any blocking member');
+    expect(formatAggregationStrategy('weird')).toBe('weird');
+  });
+});
+
+describe('presets', () => {
+  it('exposes at least the minimum selectable specialists with unique ids', () => {
+    expect(COUNCIL_SPECIALIST_PRESETS.length).toBeGreaterThanOrEqual(COUNCIL_MIN_SPECIALISTS);
+    const ids = COUNCIL_SPECIALIST_PRESETS.map(p => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('presetToSpecialist yields an enabled, non-required voting member', () => {
+    const specialist = presetToSpecialist(COUNCIL_SPECIALIST_PRESETS[0]);
+    expect(specialist).toMatchObject({ id: 'security', enabled: true, required: false });
+  });
+});
+
+describe('determineAutomatedReviewType', () => {
+  it('is a safe stub that always returns standard', () => {
+    expect(determineAutomatedReviewType({}, { councilAvailable: true })).toBe('standard');
+    expect(
+      determineAutomatedReviewType(
+        { isDraft: false, labels: ['council'], changedFileCount: 40 },
+        { councilAvailable: true }
+      )
+    ).toBe('standard');
+  });
+});

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -355,6 +355,16 @@ describe('parseCouncilResultManifest', () => {
     expect(capture.manifest.specialists[0].vote).toBe('block');
   });
 
+  it('enforces the byte cap for unpaired surrogates (cannot undercount past 128 KiB)', () => {
+    // `\uD800\u0800` = an unpaired high surrogate + a BMP char = 6 UTF-8 bytes (3-byte
+    // replacement char + 3-byte char), NOT 4. 25k of them is ~150 KiB, over the cap.
+    // Character count (~50k) stays under the scan bound, so the byte cap must catch it.
+    const seq = '\uD800\u0800'.repeat(25_000);
+    const payload = `{"specialists":[],"x":"${seq}"}`;
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${payload} -->`;
+    expect(parseCouncilResultManifest(text).status).toBe('invalid');
+  });
+
   it('does not treat a mid-line (non-line-anchored) marker as top-level', () => {
     const manifest = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
     // Marker preceded by non-whitespace on the same line is not a top-level marker.

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -309,6 +309,23 @@ describe('parseCouncilResultManifest', () => {
     expect(capture.manifest.specialists[0].vote).toBe('block');
   });
 
+  it('does not swallow unrelated JSON when the marker has no immediate payload', () => {
+    // Marker with no `{` on its line, followed later by manifest-shaped JSON that is NOT
+    // framed by this marker. Must not be captured.
+    const stray = JSON.stringify({
+      specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }],
+    });
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} -->\nHere is some JSON: ${stray}`;
+    expect(parseCouncilResultManifest(text).status).toBe('invalid');
+  });
+
+  it('requires the closing --> frame after the JSON object', () => {
+    const manifest = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
+    // Object present after the tag but not framed by a closing `-->`.
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(manifest)} and then prose`;
+    expect(parseCouncilResultManifest(text).status).toBe('invalid');
+  });
+
   it('does not treat a mid-line (non-line-anchored) marker as top-level', () => {
     const manifest = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
     // Marker preceded by non-whitespace on the same line is not a top-level marker.
@@ -445,14 +462,15 @@ describe('decideCouncilFromManifest (coverage-aware)', () => {
 });
 
 describe('parseGovernanceMarker', () => {
-  it('parses a valid governance marker', () => {
+  it('parses member votes and strips any model-authored overall decision', () => {
+    // The model emits `decision`, but it is code-owned — the parsed result must not carry
+    // it (it could contradict computeCouncilDecision in the UI).
     const gov = { members: [{ id: 'security', vote: 'pass' }], decision: 'pass' };
-    expect(
-      parseGovernanceMarker(`<!-- kilo-review-governance:v1 ${JSON.stringify(gov)} -->`)
-    ).toEqual({
-      members: [{ id: 'security', vote: 'pass', highestSeverity: null }],
-      decision: 'pass',
-    });
+    const parsed = parseGovernanceMarker(
+      `<!-- kilo-review-governance:v1 ${JSON.stringify(gov)} -->`
+    );
+    expect(parsed).toEqual({ members: [{ id: 'security', vote: 'pass', highestSeverity: null }] });
+    expect(parsed as unknown as Record<string, unknown>).not.toHaveProperty('decision');
   });
 
   it('returns null when absent or malformed', () => {
@@ -477,12 +495,13 @@ describe('parseGovernanceMarker', () => {
     const parsed = parseGovernanceMarker(
       `<!-- kilo-review-governance:v1 ${JSON.stringify(gov)} -->`
     );
-    expect(parsed?.decision).toBe('warn');
+    expect(parsed?.members[0].vote).toBe('warn');
     expect(parsed?.members[0].reason).toContain('-->');
   });
 });
 
 describe('council config helpers', () => {
+  // One enabled (security) + one disabled (performance).
   const council: CodeReviewCouncilConfig = {
     enabled: true,
     aggregation_strategy: 'any_blocking_member',
@@ -491,15 +510,26 @@ describe('council config helpers', () => {
       { ...presetToSpecialist(COUNCIL_SPECIALIST_PRESETS[1]), enabled: false },
     ],
   };
+  // Two enabled specialists (meets COUNCIL_MIN_SPECIALISTS).
+  const activeCouncil: CodeReviewCouncilConfig = {
+    enabled: true,
+    aggregation_strategy: 'any_blocking_member',
+    specialists: [
+      presetToSpecialist(COUNCIL_SPECIALIST_PRESETS[0]),
+      presetToSpecialist(COUNCIL_SPECIALIST_PRESETS[1]),
+    ],
+  };
 
   it('enabledSpecialists filters to enabled', () => {
     expect(enabledSpecialists(council).map(s => s.id)).toEqual(['security']);
   });
 
-  it('isCouncilActive requires enabled + at least one enabled specialist', () => {
-    expect(isCouncilActive(council)).toBe(true);
-    expect(isCouncilActive({ ...council, enabled: false })).toBe(false);
-    expect(isCouncilActive({ ...council, specialists: [] })).toBe(false);
+  it('isCouncilActive requires enabled + at least COUNCIL_MIN_SPECIALISTS enabled specialists', () => {
+    expect(isCouncilActive(activeCouncil)).toBe(true);
+    // Below the minimum (only one enabled) must NOT be active.
+    expect(isCouncilActive(council)).toBe(false);
+    expect(isCouncilActive({ ...activeCouncil, enabled: false })).toBe(false);
+    expect(isCouncilActive({ ...activeCouncil, specialists: [] })).toBe(false);
     expect(isCouncilActive(null)).toBe(false);
   });
 

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -284,6 +284,41 @@ describe('parseCouncilResultManifest', () => {
     expect(capture.manifest.specialists[0].vote).toBe('block');
   });
 
+  it('a malformed LATEST top-level marker stays invalid and does not fall back to an earlier valid one', () => {
+    const earlierPass = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
+    // Later top-level marker is malformed (missing vote) — must fail closed, not reuse the earlier pass.
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(earlierPass)} -->\n<!-- ${COUNCIL_RESULT_MARKER_TAG} {"specialists":[{"specialistId":"security"}]} -->`;
+    expect(parseCouncilResultManifest(text).status).toBe('invalid');
+  });
+
+  it('ignores many embedded marker prefixes inside a finding and captures the real manifest', () => {
+    const noise = `prefix <!-- ${COUNCIL_RESULT_MARKER_TAG} `.repeat(20);
+    const real = {
+      specialists: [
+        {
+          specialistId: 'security',
+          vote: 'block',
+          findings: [{ path: 'a.ts', line: 1, severity: 'high', rationale: noise }],
+        },
+      ],
+    };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(real)} -->`;
+    const capture = parseCouncilResultManifest(text);
+    expect(capture.status).toBe('captured');
+    if (capture.status !== 'captured') throw new Error('unreachable');
+    expect(capture.manifest.specialists[0].vote).toBe('block');
+  });
+
+  it('does not treat a mid-line (non-line-anchored) marker as top-level', () => {
+    const manifest = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
+    // Marker preceded by non-whitespace on the same line is not a top-level marker.
+    expect(
+      parseCouncilResultManifest(
+        `prefix <!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(manifest)} -->`
+      ).status
+    ).toBe('missing');
+  });
+
   it('returns invalid when the payload exceeds the size cap', () => {
     const huge = {
       specialists: [

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -1,0 +1,401 @@
+/**
+ * Code Reviewer Council — core, pure logic (single-session model).
+ *
+ * Dependency-light on purpose (`zod` + `@kilocode/db/schema-types` only) so both the
+ * web app and the `code-review-infra` worker can import it without duplicating logic.
+ *
+ * Scope: the settled, capture-agnostic pieces — the code-owned governance DECISION,
+ * the per-specialist result contract (vote + findings), the single-session combined
+ * result manifest + parser, the display-only governance marker, specialist presets,
+ * and the automated review-type stub. Prompt builders (web) and execution wiring
+ * (worker/DO, runtimeAgents) live with their callers, not here.
+ *
+ * The council runs as ONE cloud-agent session: an orchestrator delegates to one
+ * sub-agent per specialist (each pinned to its own model via `runtimeAgents[]`), then
+ * relays every specialist's structured result in its final message. Our code — never
+ * the model — computes the decision from the collected votes.
+ */
+
+import * as z from 'zod';
+import {
+  CouncilVoteSchema,
+  type CodeReviewCouncilConfig,
+  type CodeReviewType,
+  type CouncilAggregationStrategy,
+  type CouncilSpecialist,
+  type CouncilSpecialistRole,
+  type CouncilVote,
+} from '@kilocode/db/schema-types';
+
+// ============================================================================
+// Governance decision (code-owned, deterministic)
+// ============================================================================
+
+/**
+ * A specialist's vote as seen by aggregation. A specialist whose result could not be
+ * captured contributes `abstain` (abstain-never-pass), so a lost/garbled result can
+ * never silently produce a passing council decision.
+ */
+export type SpecialistVote = { specialistId: string; vote: CouncilVote };
+
+/**
+ * Computes the council governance decision from the collected specialist votes using
+ * the selected strategy. This is the deterministic, code-owned replacement for asking
+ * the model to compute the decision. The semantics MUST stay in lockstep with
+ * `describeAggregationStrategy` (the prompt text the specialists/orchestrator see).
+ *
+ * When there is no usable coverage — no votes at all, OR every specialist abstained —
+ * the decision is `block` for every strategy (never pass on absent coverage). This
+ * subsumes abstain-never-pass: a lost/garbled result contributes `abstain`, and if
+ * that is all we have, the council blocks.
+ */
+export function computeCouncilDecision(
+  votes: readonly SpecialistVote[],
+  strategy: CouncilAggregationStrategy
+): CouncilVote {
+  const counts = { pass: 0, warn: 0, block: 0, abstain: 0 } satisfies Record<CouncilVote, number>;
+  for (const { vote } of votes) counts[vote]++;
+
+  // No usable signal (empty, or every specialist abstained) => never pass.
+  if (counts.pass + counts.warn + counts.block === 0) return 'block';
+
+  const anyWarn = counts.warn > 0;
+
+  switch (strategy) {
+    case 'majority': {
+      if (counts.block > counts.pass) return 'block';
+      return anyWarn ? 'warn' : 'pass';
+    }
+    case 'unanimous_required': {
+      if (counts.block > 0 || counts.abstain > 0) return 'block';
+      return anyWarn ? 'warn' : 'pass';
+    }
+    case 'any_blocking_member':
+    default: {
+      if (counts.block > 0) return 'block';
+      return anyWarn ? 'warn' : 'pass';
+    }
+  }
+}
+
+/**
+ * Whether a governance decision should block merge. `block` always blocks; `warn` is
+ * non-blocking here (warning-as-blocking is a separate gate-threshold policy).
+ */
+export function councilDecisionBlocksMerge(decision: CouncilVote): boolean {
+  return decision === 'block';
+}
+
+/** Human-readable governance rule text so the orchestrator applies the SELECTED strategy.
+ * Every configured specialist is a voting member; all votes count equally. Keep the
+ * wording in lockstep with `computeCouncilDecision`. */
+export function describeAggregationStrategy(strategy: CouncilAggregationStrategy): string {
+  switch (strategy) {
+    case 'majority':
+      return 'Majority: count votes across all specialists. If block votes outnumber pass votes, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.';
+    case 'unanimous_required':
+      return 'Unanimous: every specialist must vote pass. If any specialist voted block or abstain, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.';
+    case 'any_blocking_member':
+    default:
+      return 'Any blocking member: if any specialist voted block, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.';
+  }
+}
+
+// ============================================================================
+// Per-specialist result contract + single-session combined manifest
+// ============================================================================
+
+/**
+ * One finding reported by a specialist. Lenient by design: `severity` is a free-form
+ * display label (severity vocabularies vary), `line` is optional/nullable, and
+ * `rationale`/`path` are length-bounded but not otherwise constrained.
+ */
+export const CouncilSpecialistFindingSchema = z.object({
+  path: z.string().max(1024),
+  line: z.number().int().nonnegative().nullable().optional(),
+  severity: z.string().max(64),
+  rationale: z.string().max(4000),
+});
+export type CouncilSpecialistFinding = z.infer<typeof CouncilSpecialistFindingSchema>;
+
+/**
+ * One specialist's structured result. STRICT only on `vote` (the load-bearing value
+ * the code-side decision depends on); findings + severity are lenient. `findings` is
+ * the full list surfaced in the Kilo UI and published to the PR.
+ */
+export const CouncilSpecialistResultSchema = z.object({
+  specialistId: z.string().min(1).max(64),
+  vote: CouncilVoteSchema,
+  highestSeverity: z.string().max(64).nullable().optional(),
+  findings: z.array(CouncilSpecialistFindingSchema).max(200).default([]),
+});
+export type CouncilSpecialistResult = z.infer<typeof CouncilSpecialistResultSchema>;
+
+/**
+ * Marker tag for the single-session combined council manifest. The orchestrator emits
+ * ONE of these in its final message, carrying every specialist's result. (One marker
+ * + strict schema is more deterministic than N scattered per-specialist markers.)
+ */
+export const COUNCIL_RESULT_MARKER_TAG = 'kilo-code-review-council:v1';
+
+/** Hard cap on the manifest JSON payload (UTF-8 bytes) to bound parsing cost. */
+export const COUNCIL_RESULT_MAX_BYTES = 128 * 1024;
+
+/**
+ * The combined council manifest: one array of per-specialist results. This is the
+ * single-session capture shape; our code parses it and computes the decision.
+ */
+export const CouncilResultManifestSchema = z.object({
+  specialists: z.array(CouncilSpecialistResultSchema).max(8),
+});
+export type CouncilResultManifest = z.infer<typeof CouncilResultManifestSchema>;
+
+/**
+ * Result of attempting to capture the combined council manifest from the orchestrator's
+ * final message. `missing` = no marker present; `invalid` = marker present but
+ * unparseable / failed schema. Both non-captured states must be treated as NO coverage
+ * downstream (→ `computeCouncilDecision` blocks), never as an implicit pass.
+ */
+export type CouncilManifestCapture =
+  | { status: 'captured'; manifest: CouncilResultManifest }
+  | { status: 'missing' }
+  | { status: 'invalid' };
+
+/**
+ * Extracts and validates the combined council manifest from the orchestrator's final
+ * message.
+ *
+ * The marker may appear ANYWHERE in the message and the LAST occurrence wins — real
+ * models often add a trailing sentence after the marker, and that must not cause a
+ * false miss. The payload is captured up to the closing `-->` (which valid JSON never
+ * contains), so nested JSON in `findings` is tolerated. Size-capped; schema is strict
+ * only where it must be (each specialist's `vote`).
+ */
+export function parseCouncilResultManifest(
+  text: string | null | undefined
+): CouncilManifestCapture {
+  if (!text) return { status: 'missing' };
+
+  const marker = new RegExp(`<!--\\s*${COUNCIL_RESULT_MARKER_TAG}\\s*([\\s\\S]*?)\\s*-->`, 'g');
+  const matches = [...text.matchAll(marker)];
+  if (matches.length === 0) return { status: 'missing' };
+
+  const payload = matches[matches.length - 1][1].trim();
+  if (new TextEncoder().encode(payload).length > COUNCIL_RESULT_MAX_BYTES) {
+    return { status: 'invalid' };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(payload);
+    const result = CouncilResultManifestSchema.safeParse(parsed);
+    return result.success ? { status: 'captured', manifest: result.data } : { status: 'invalid' };
+  } catch {
+    return { status: 'invalid' };
+  }
+}
+
+/** Per-specialist rollup for the Kilo UI: vote, highest severity, and findings count. */
+export type CouncilSpecialistSummary = {
+  specialistId: string;
+  vote: CouncilVote;
+  highestSeverity: string | null;
+  findingsCount: number;
+};
+
+/** Summarizes each specialist's result (findings count included) for UI display. */
+export function summarizeCouncilManifest(
+  manifest: CouncilResultManifest
+): CouncilSpecialistSummary[] {
+  return manifest.specialists.map(specialist => ({
+    specialistId: specialist.specialistId,
+    vote: specialist.vote,
+    highestSeverity: specialist.highestSeverity ?? null,
+    findingsCount: specialist.findings.length,
+  }));
+}
+
+/**
+ * The votes to feed `computeCouncilDecision`, reconciled against the specialists we
+ * ASKED to run. Any configured specialist absent from the manifest (the orchestrator
+ * dropped it) contributes `abstain` — so a dropped specialist can never silently let
+ * the council pass. Manifest entries for unknown specialists are ignored.
+ */
+export function reconcileCouncilVotes(
+  configuredSpecialistIds: readonly string[],
+  manifest: CouncilResultManifest
+): SpecialistVote[] {
+  const reported = new Map(manifest.specialists.map(s => [s.specialistId, s.vote]));
+  return configuredSpecialistIds.map(specialistId => ({
+    specialistId,
+    vote: reported.get(specialistId) ?? 'abstain',
+  }));
+}
+
+// ============================================================================
+// Governance marker (display-only human-readable summary)
+// ============================================================================
+
+/** Marker tag for the human-readable governance summary. Display-only: it is NOT the
+ * source of the decision (our code computes that via `computeCouncilDecision`). */
+export const GOVERNANCE_MARKER_TAG = 'kilo-review-governance:v1';
+
+const GovernanceMemberSchema = z.object({
+  id: z.string(),
+  vote: CouncilVoteSchema,
+  // Display-only label; accept any wording the model emits (e.g. "low", "info",
+  // "none") so a severity vocabulary mismatch never rejects the whole marker.
+  highestSeverity: z
+    .string()
+    .max(50)
+    .nullable()
+    .optional()
+    .transform(value => (value && value.toLowerCase() !== 'none' ? value : null)),
+  reason: z.string().max(1000).optional(),
+});
+
+export const GovernanceSchema = z.object({
+  members: z.array(GovernanceMemberSchema).max(8),
+  decision: CouncilVoteSchema,
+});
+export type Governance = z.infer<typeof GovernanceSchema>;
+export type GovernanceMember = z.infer<typeof GovernanceMemberSchema>;
+
+/**
+ * Extracts and validates the display-only governance marker from an assistant message.
+ * Returns null when absent or malformed. This drives display only; never derive the
+ * merge decision from it.
+ */
+export function parseGovernanceMarker(text: string | null | undefined): Governance | null {
+  if (!text) return null;
+  const marker = new RegExp(`<!--\\s*${GOVERNANCE_MARKER_TAG}\\s*(\\{[\\s\\S]*?\\})\\s*-->`);
+  const match = text.match(marker);
+  if (!match) return null;
+  try {
+    const parsed: unknown = JSON.parse(match[1]);
+    const result = GovernanceSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Council config helpers
+// ============================================================================
+
+/** Enabled specialists in a council config. */
+export function enabledSpecialists(council: CodeReviewCouncilConfig): CouncilSpecialist[] {
+  return council.specialists.filter(specialist => specialist.enabled);
+}
+
+/**
+ * Whether there is a renderable council definition (enabled with at least one enabled
+ * specialist). This only guards prompt rendering — whether a run IS a council run is
+ * recorded per-run via `review_type`, not inferred here.
+ */
+export function isCouncilActive(council: CodeReviewCouncilConfig | undefined | null): boolean {
+  return !!council && council.enabled && enabledSpecialists(council).length > 0;
+}
+
+const AGGREGATION_STRATEGY_LABELS: Record<CouncilAggregationStrategy, string> = {
+  any_blocking_member: 'Any blocking member',
+  majority: 'Majority',
+  unanimous_required: 'Unanimous required',
+};
+
+/** Display label for an aggregation strategy (falls back to the default label). */
+export function formatAggregationStrategy(strategy: string | null | undefined): string {
+  if (!strategy) return AGGREGATION_STRATEGY_LABELS.any_blocking_member;
+  return AGGREGATION_STRATEGY_LABELS[strategy as CouncilAggregationStrategy] ?? strategy;
+}
+
+// ============================================================================
+// Specialist presets
+// ============================================================================
+
+export type CouncilSpecialistPreset = {
+  id: string;
+  role: CouncilSpecialistRole;
+  name: string;
+  lens: string;
+};
+
+export const COUNCIL_SPECIALIST_PRESETS: CouncilSpecialistPreset[] = [
+  {
+    id: 'security',
+    role: 'security',
+    name: 'Security',
+    lens: 'Injection, auth/authorization bypass, secret handling, unsafe deserialization, SSRF, and data exposure.',
+  },
+  {
+    id: 'performance',
+    role: 'performance',
+    name: 'Performance',
+    lens: 'Hot paths, N+1 queries, unnecessary allocations, blocking I/O, and algorithmic complexity regressions.',
+  },
+  {
+    id: 'testing',
+    role: 'testing',
+    name: 'Test coverage',
+    lens: 'Missing or weak tests for new behavior, untested edge cases, and regressions lacking coverage.',
+  },
+  {
+    id: 'correctness',
+    role: 'correctness',
+    name: 'Correctness',
+    lens: 'Logic errors, incorrect edge-case handling, race conditions, and broken invariants.',
+  },
+];
+
+/** Council must have at least this many specialists selected when enabled. */
+export const COUNCIL_MIN_SPECIALISTS = 2;
+
+/** Converts a preset into a persistable specialist (enabled, default model/effort). */
+export function presetToSpecialist(preset: CouncilSpecialistPreset): CouncilSpecialist {
+  return {
+    id: preset.id,
+    role: preset.role,
+    name: preset.name,
+    enabled: true,
+    // No required/optional distinction: every configured specialist is a voting member.
+    required: false,
+    lens: preset.lens,
+  };
+}
+
+// ============================================================================
+// Automated (webhook) review-type determination
+// ============================================================================
+
+/**
+ * Full PR fact set piped into Code Reviewer for automated (webhook) reviews. The
+ * automated review-type determination must be made Kilo-side from these facts, not by
+ * trusting a dev-controlled SCM label. Kept intentionally open/extensible.
+ */
+export type AutomatedReviewPrFacts = {
+  isDraft?: boolean;
+  labels?: string[];
+  baseRef?: string;
+  changedFileCount?: number;
+  changedLineCount?: number;
+  author?: string;
+};
+
+/**
+ * Determines the review type for an AUTOMATED (webhook) run from PR facts.
+ *
+ * STUB (intentional, phased plan): the real standard-vs-council determination is later
+ * work — it must be configured/evaluated Kilo-side and resistant to SCM-side abuse (a
+ * dev must not be able to force paid council reviews via a PR label). For now this is a
+ * safe stub that always returns `'standard'`, so automated reviews behave exactly as
+ * they do today. The plumbing (passing full PR facts + `councilAvailable`) is defined
+ * here so the logic can be filled in at the webhook step without further wiring.
+ *
+ * Manual runs never call this — they carry an explicit user-selected review type.
+ */
+export function determineAutomatedReviewType(
+  _prFacts: AutomatedReviewPrFacts,
+  _options: { councilAvailable: boolean }
+): CodeReviewType {
+  return 'standard';
+}

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -203,9 +203,17 @@ function utf8ByteLengthExceeds(str: string, limit: number): boolean {
     if (code < 0x80) bytes += 1;
     else if (code < 0x800) bytes += 2;
     else if (code >= 0xd800 && code <= 0xdbff) {
-      bytes += 4; // surrogate pair (one code point across two code units)
-      i++;
-    } else bytes += 3;
+      // High surrogate: only a valid pair (followed by a low surrogate) is one 4-byte
+      // code point. An unpaired high surrogate is encoded as the 3-byte replacement
+      // character (U+FFFD) and does NOT consume the next unit — matching TextEncoder.
+      const next = str.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        i++;
+      } else {
+        bytes += 3;
+      }
+    } else bytes += 3; // BMP char, or an unpaired low surrogate (3-byte replacement char)
     if (bytes > limit) return true;
   }
   return false;

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -94,14 +94,18 @@ export function councilDecisionBlocksMerge(decision: CouncilVote): boolean {
  * Every configured specialist is a voting member; all votes count equally. Keep the
  * wording in lockstep with `computeCouncilDecision`. */
 export function describeAggregationStrategy(strategy: CouncilAggregationStrategy): string {
+  // Every strategy blocks when there is no usable coverage (no votes at all, or every
+  // specialist abstained) — this MUST match the guard in `computeCouncilDecision`.
+  const noCoverageRule =
+    ' If no specialist produced a usable vote (all abstained, or no votes at all), the decision is block.';
   switch (strategy) {
     case 'majority':
-      return 'Majority: count votes across all specialists. If block votes outnumber pass votes, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.';
+      return `Majority: count votes across all specialists. If block votes outnumber pass votes, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.${noCoverageRule}`;
     case 'unanimous_required':
-      return 'Unanimous: every specialist must vote pass. If any specialist voted block or abstain, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.';
+      return `Unanimous: every specialist must vote pass. If any specialist voted block or abstain, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.${noCoverageRule}`;
     case 'any_blocking_member':
     default:
-      return 'Any blocking member: if any specialist voted block, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.';
+      return `Any blocking member: if any specialist voted block, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.${noCoverageRule}`;
   }
 }
 
@@ -188,32 +192,11 @@ export type CouncilManifestCapture =
   | { status: 'invalid' };
 
 /**
- * Extracts the JSON object payload of the LAST occurrence of an HTML-comment marker
- * (`<!-- TAG {json} -->`) from free text.
- *
- * Does NOT rely on the payload being `-->`-free: a finding's `rationale`/`path` can
- * legitimately contain `-->` or `}` (e.g. reviewing HTML, or `while (i --> 0)`). So we
- * locate the last marker tag, then do a brace-depth scan from the first `{` — honoring
- * JSON string literals and escapes — to its matching `}`. The trailing `-->` is not
- * required for extraction (real models add prose after it).
- *
- * Returns `tagPresent` so callers can distinguish "no marker at all" (missing) from
- * "marker present but no balanced JSON object" (invalid).
+ * Balanced-brace scan from `open`, honoring JSON string literals and escapes, returning
+ * the JSON object substring (inclusive of its braces) or null if never balanced. Because
+ * it tracks string state, a `-->` or `}` inside a string value does not truncate it.
  */
-function extractLastMarkerJson(
-  text: string,
-  tag: string
-): { tagPresent: boolean; json: string | null } {
-  const starter = new RegExp(`<!--\\s*${tag}\\s*`, 'g');
-  let searchFrom = -1;
-  for (const match of text.matchAll(starter)) {
-    searchFrom = match.index + match[0].length;
-  }
-  if (searchFrom < 0) return { tagPresent: false, json: null };
-
-  const open = text.indexOf('{', searchFrom);
-  if (open < 0) return { tagPresent: true, json: null };
-
+function scanBalancedJson(text: string, open: number): string | null {
   let depth = 0;
   let inString = false;
   let escaped = false;
@@ -227,43 +210,80 @@ function extractLastMarkerJson(
     }
     if (ch === '"') inString = true;
     else if (ch === '{') depth++;
-    else if (ch === '}' && --depth === 0) {
-      return { tagPresent: true, json: text.slice(open, i + 1) };
-    }
+    else if (ch === '}' && --depth === 0) return text.slice(open, i + 1);
   }
-  return { tagPresent: true, json: null }; // unbalanced
+  return null; // unbalanced
+}
+
+/**
+ * Enumerates the balanced JSON payloads of every HTML-comment marker (`<!-- TAG {json} -->`)
+ * in free text, in document order.
+ *
+ * Two robustness properties:
+ * - **Version isolation:** the tag must be followed by whitespace (`\\s+`), so a longer
+ *   version like `${tag}0` or `${tag}junk` is NOT matched as `tag`.
+ * - **Embedded-marker safety:** a finding's `rationale`/`path` can legitimately contain
+ *   the marker text (JSON does not escape `<!-- ... {}`), which would appear as its own
+ *   occurrence. Rather than trusting the last textual occurrence, we return ALL candidates
+ *   so the caller can pick the last one that actually validates — an embedded fragment
+ *   fails the schema and is skipped, so PR content quoting the marker cannot displace the
+ *   real manifest. Payloads with `-->`/`}` inside strings are preserved (string-aware scan).
+ *
+ * `tagPresent` lets callers distinguish "no marker at all" (missing) from "marker present
+ * but no valid payload" (invalid).
+ */
+function markerJsonCandidates(
+  text: string,
+  tag: string
+): { tagPresent: boolean; candidates: string[] } {
+  const starter = new RegExp(`<!--\\s*${tag}\\s+`, 'g');
+  const candidates: string[] = [];
+  let tagPresent = false;
+  for (const match of text.matchAll(starter)) {
+    tagPresent = true;
+    const open = text.indexOf('{', match.index + match[0].length);
+    if (open < 0) continue;
+    const json = scanBalancedJson(text, open);
+    if (json !== null) candidates.push(json);
+  }
+  return { tagPresent, candidates };
 }
 
 /**
  * Extracts and validates the combined council manifest from the orchestrator's final
  * message.
  *
- * The marker may appear ANYWHERE in the message and the LAST occurrence wins — real
- * models often add a trailing sentence after the marker, and that must not cause a
- * false miss. The JSON object is extracted by a brace-aware scan (see
- * `extractLastMarkerJson`), so a `-->` or `}` inside a finding's free-form text does not
- * truncate a legitimate manifest. Size-capped; schema is strict only where it must be
- * (each specialist's `vote`).
+ * The marker may appear ANYWHERE in the message and the LAST schema-valid occurrence
+ * wins — real models often add a trailing sentence after the marker, and that must not
+ * cause a false miss. Each candidate JSON object is extracted by a brace-aware scan (see
+ * `markerJsonCandidates`), so a `-->`/`}` inside a finding's free-form text does not
+ * truncate it, and marker text quoted inside a finding fails the schema and is skipped
+ * rather than displacing the real manifest. Size-capped; schema is strict only where it
+ * must be (each specialist's `vote`).
  */
 export function parseCouncilResultManifest(
   text: string | null | undefined
 ): CouncilManifestCapture {
   if (!text) return { status: 'missing' };
 
-  const { tagPresent, json } = extractLastMarkerJson(text, COUNCIL_RESULT_MARKER_TAG);
+  const { tagPresent, candidates } = markerJsonCandidates(text, COUNCIL_RESULT_MARKER_TAG);
   if (!tagPresent) return { status: 'missing' };
-  if (json === null) return { status: 'invalid' };
-  if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES) {
-    return { status: 'invalid' };
-  }
 
-  try {
-    const parsed: unknown = JSON.parse(json);
-    const result = CouncilResultManifestSchema.safeParse(parsed);
-    return result.success ? { status: 'captured', manifest: result.data } : { status: 'invalid' };
-  } catch {
-    return { status: 'invalid' };
+  // Prefer the last candidate that is a valid manifest; skip oversized or malformed
+  // candidates (including marker-like text embedded in a finding) rather than failing on
+  // them, so embedded content cannot force a false no-coverage block.
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    const json = candidates[i];
+    if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES) continue;
+    try {
+      const parsed: unknown = JSON.parse(json);
+      const result = CouncilResultManifestSchema.safeParse(parsed);
+      if (result.success) return { status: 'captured', manifest: result.data };
+    } catch {
+      // try an earlier candidate
+    }
   }
+  return { status: 'invalid' };
 }
 
 /** Per-specialist rollup for the Kilo UI: vote, highest severity, and findings count. */
@@ -305,28 +325,42 @@ export type CouncilCoverage = {
  * rather than being laundered into an `abstain` vote. Manifest entries for specialists
  * we did not configure are ignored. Callers enforce coverage via `decideCouncilFromManifest`.
  *
- * Defense in depth: `CouncilResultManifestSchema` already rejects duplicate ids at parse
- * time, so a captured manifest is unique. But if a manifest is constructed without going
- * through the parser, a configured specialist reported MORE THAN ONCE is treated as
- * missing (unreliable coverage) rather than letting a `Map` silently keep the last vote
- * (which could override an earlier, more severe one).
+ * Defense in depth (fail closed on ambiguity):
+ * - `CouncilResultManifestSchema` already rejects duplicate REPORTED ids at parse time,
+ *   but if a manifest is constructed without the parser, a specialist reported MORE THAN
+ *   ONCE is treated as missing rather than letting a `Map` silently keep the last vote.
+ * - A duplicate CONFIGURED id is a config-integrity violation (a specialist must not vote
+ *   twice — otherwise duplicating a passing specialist could flip a majority). Each
+ *   duplicated configured id is counted once and treated as missing coverage.
  */
 export function reconcileCouncilVotes(
   configuredSpecialistIds: readonly string[],
   manifest: CouncilResultManifest
 ): CouncilCoverage {
+  const configuredSeen = new Set<string>();
+  const duplicateConfigured = new Set<string>();
+  for (const specialistId of configuredSpecialistIds) {
+    if (configuredSeen.has(specialistId)) duplicateConfigured.add(specialistId);
+    configuredSeen.add(specialistId);
+  }
+
   const counts = new Map<string, number>();
   for (const specialist of manifest.specialists) {
     counts.set(specialist.specialistId, (counts.get(specialist.specialistId) ?? 0) + 1);
   }
   const reported = new Map(manifest.specialists.map(s => [s.specialistId, s.vote]));
+
   const votes: SpecialistVote[] = [];
   const missingSpecialistIds: string[] = [];
-  for (const specialistId of configuredSpecialistIds) {
-    // Exactly one reported result is reliable coverage; 0 = absent (dropped), >1 =
-    // duplicate/ambiguous — neither counts.
+  // Iterate the DEDUPED configured ids so a specialist is never counted more than once.
+  for (const specialistId of configuredSeen) {
     const vote = reported.get(specialistId);
-    if (counts.get(specialistId) === 1 && vote !== undefined) {
+    // Reliable coverage requires exactly one configured entry AND exactly one report.
+    if (
+      !duplicateConfigured.has(specialistId) &&
+      counts.get(specialistId) === 1 &&
+      vote !== undefined
+    ) {
       votes.push({ specialistId, vote });
     } else {
       missingSpecialistIds.push(specialistId);
@@ -404,19 +438,21 @@ export type GovernanceMember = z.infer<typeof GovernanceMemberSchema>;
  */
 export function parseGovernanceMarker(text: string | null | undefined): Governance | null {
   if (!text) return null;
-  // Brace-aware extraction (see `extractLastMarkerJson`): a `-->` or `}` inside a
-  // member `reason` must not truncate the payload.
-  const { json } = extractLastMarkerJson(text, GOVERNANCE_MARKER_TAG);
-  if (json === null) return null;
-  // Bound parse cost on untrusted model output, symmetric with the manifest parser.
-  if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES) return null;
-  try {
-    const parsed: unknown = JSON.parse(json);
-    const result = GovernanceSchema.safeParse(parsed);
-    return result.success ? result.data : null;
-  } catch {
-    return null;
+  // Same brace-aware, embedded-marker-safe, size-capped extraction as the manifest parser:
+  // return the last candidate that validates; skip oversized/malformed ones.
+  const { candidates } = markerJsonCandidates(text, GOVERNANCE_MARKER_TAG);
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    const json = candidates[i];
+    if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES) continue;
+    try {
+      const parsed: unknown = JSON.parse(json);
+      const result = GovernanceSchema.safeParse(parsed);
+      if (result.success) return result.data;
+    } catch {
+      // try an earlier candidate
+    }
   }
+  return null;
 }
 
 // ============================================================================

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -166,31 +166,77 @@ export type CouncilManifestCapture =
   | { status: 'invalid' };
 
 /**
+ * Extracts the JSON object payload of the LAST occurrence of an HTML-comment marker
+ * (`<!-- TAG {json} -->`) from free text.
+ *
+ * Does NOT rely on the payload being `-->`-free: a finding's `rationale`/`path` can
+ * legitimately contain `-->` or `}` (e.g. reviewing HTML, or `while (i --> 0)`). So we
+ * locate the last marker tag, then do a brace-depth scan from the first `{` — honoring
+ * JSON string literals and escapes — to its matching `}`. The trailing `-->` is not
+ * required for extraction (real models add prose after it).
+ *
+ * Returns `tagPresent` so callers can distinguish "no marker at all" (missing) from
+ * "marker present but no balanced JSON object" (invalid).
+ */
+function extractLastMarkerJson(
+  text: string,
+  tag: string
+): { tagPresent: boolean; json: string | null } {
+  const starter = new RegExp(`<!--\\s*${tag}\\s*`, 'g');
+  let searchFrom = -1;
+  for (const match of text.matchAll(starter)) {
+    searchFrom = match.index + match[0].length;
+  }
+  if (searchFrom < 0) return { tagPresent: false, json: null };
+
+  const open = text.indexOf('{', searchFrom);
+  if (open < 0) return { tagPresent: true, json: null };
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = open; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{') depth++;
+    else if (ch === '}' && --depth === 0) {
+      return { tagPresent: true, json: text.slice(open, i + 1) };
+    }
+  }
+  return { tagPresent: true, json: null }; // unbalanced
+}
+
+/**
  * Extracts and validates the combined council manifest from the orchestrator's final
  * message.
  *
  * The marker may appear ANYWHERE in the message and the LAST occurrence wins — real
  * models often add a trailing sentence after the marker, and that must not cause a
- * false miss. The payload is captured up to the closing `-->` (which valid JSON never
- * contains), so nested JSON in `findings` is tolerated. Size-capped; schema is strict
- * only where it must be (each specialist's `vote`).
+ * false miss. The JSON object is extracted by a brace-aware scan (see
+ * `extractLastMarkerJson`), so a `-->` or `}` inside a finding's free-form text does not
+ * truncate a legitimate manifest. Size-capped; schema is strict only where it must be
+ * (each specialist's `vote`).
  */
 export function parseCouncilResultManifest(
   text: string | null | undefined
 ): CouncilManifestCapture {
   if (!text) return { status: 'missing' };
 
-  const marker = new RegExp(`<!--\\s*${COUNCIL_RESULT_MARKER_TAG}\\s*([\\s\\S]*?)\\s*-->`, 'g');
-  const matches = [...text.matchAll(marker)];
-  if (matches.length === 0) return { status: 'missing' };
-
-  const payload = matches[matches.length - 1][1].trim();
-  if (new TextEncoder().encode(payload).length > COUNCIL_RESULT_MAX_BYTES) {
+  const { tagPresent, json } = extractLastMarkerJson(text, COUNCIL_RESULT_MARKER_TAG);
+  if (!tagPresent) return { status: 'missing' };
+  if (json === null) return { status: 'invalid' };
+  if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES) {
     return { status: 'invalid' };
   }
 
   try {
-    const parsed: unknown = JSON.parse(payload);
+    const parsed: unknown = JSON.parse(json);
     const result = CouncilResultManifestSchema.safeParse(parsed);
     return result.success ? { status: 'captured', manifest: result.data } : { status: 'invalid' };
   } catch {
@@ -317,11 +363,12 @@ export type GovernanceMember = z.infer<typeof GovernanceMemberSchema>;
  */
 export function parseGovernanceMarker(text: string | null | undefined): Governance | null {
   if (!text) return null;
-  const marker = new RegExp(`<!--\\s*${GOVERNANCE_MARKER_TAG}\\s*(\\{[\\s\\S]*?\\})\\s*-->`);
-  const match = text.match(marker);
-  if (!match) return null;
+  // Brace-aware extraction (see `extractLastMarkerJson`): a `-->` or `}` inside a
+  // member `reason` must not truncate the payload.
+  const { json } = extractLastMarkerJson(text, GOVERNANCE_MARKER_TAG);
+  if (json === null) return null;
   try {
-    const parsed: unknown = JSON.parse(match[1]);
+    const parsed: unknown = JSON.parse(json);
     const result = GovernanceSchema.safeParse(parsed);
     return result.success ? result.data : null;
   } catch {

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -192,15 +192,43 @@ export type CouncilManifestCapture =
   | { status: 'invalid' };
 
 /**
+ * Whether the UTF-8 byte length of `str` exceeds `limit`, computed incrementally with an
+ * early exit so we never allocate a full byte array just to measure (important for a
+ * Worker handling untrusted model output).
+ */
+function utf8ByteLengthExceeds(str: string, limit: number): boolean {
+  let bytes = 0;
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (code < 0x80) bytes += 1;
+    else if (code < 0x800) bytes += 2;
+    else if (code >= 0xd800 && code <= 0xdbff) {
+      bytes += 4; // surrogate pair (one code point across two code units)
+      i++;
+    } else bytes += 3;
+    if (bytes > limit) return true;
+  }
+  return false;
+}
+
+/**
  * Balanced-brace scan from `open`, honoring JSON string literals and escapes, returning
  * the JSON object substring (inclusive of its braces) or null if never balanced. Because
  * it tracks string state, a `-->` or `}` inside a string value does not truncate it.
+ *
+ * The scan is bounded: it aborts (returns null) once it has traversed more than `maxChars`
+ * characters, so an oversized untrusted payload cannot cause unbounded scanning or
+ * materialize an oversized slice. `maxChars` is a byte budget used as a character bound;
+ * since a string's byte length is >= its character length, a payload within the byte cap
+ * is never aborted, and one that would exceed the cap in characters certainly exceeds it
+ * in bytes (fail closed either way — both null results are treated as invalid upstream).
  */
-function scanBalancedJson(text: string, open: number): string | null {
+function scanBalancedJson(text: string, open: number, maxChars: number): string | null {
   let depth = 0;
   let inString = false;
   let escaped = false;
   for (let i = open; i < text.length; i++) {
+    if (i - open > maxChars) return null; // oversized — abort before allocating a slice
     const ch = text[i];
     if (inString) {
       if (escaped) escaped = false;
@@ -222,9 +250,13 @@ function scanBalancedJson(text: string, open: number): string | null {
  *
  * Robustness properties:
  * - **Embedded-marker safety (structural):** the orchestrator emits the marker on its own
- *   final line, and `JSON.stringify` escapes newlines, so marker text quoted inside a
- *   finding's JSON string is NEVER at line start. Anchoring to line start therefore
- *   excludes embedded occurrences structurally — no need to try-and-validate candidates.
+ *   final line, and `JSON.stringify` escapes `\n`/`\r`, so marker text quoted inside a
+ *   finding's JSON string is NEVER at the start of a real line. Anchoring to a real line
+ *   break therefore excludes embedded occurrences structurally. NOTE: we deliberately do
+ *   NOT use `^` with the `m` flag — JS also treats U+2028/U+2029 as line terminators for
+ *   `^m`, but those can appear UNESCAPED inside JSON strings, so an `^m` anchor would let
+ *   a finding containing `\u2028<!-- tag` masquerade as a top-level marker. We anchor only
+ *   to `\n`/`\r` (or start-of-text).
  * - **Version isolation:** the tag must be followed by horizontal whitespace, so a longer
  *   version like `${tag}0` / `${tag}junk` is NOT matched as `tag`.
  * - **`-->`/`}` tolerance:** the JSON is read by a string-aware brace scan, so those chars
@@ -239,11 +271,14 @@ function extractLastMarkerJson(
   text: string,
   tag: string
 ): { tagPresent: boolean; json: string | null } {
-  // `^` (multiline) + horizontal-whitespace classes so a match cannot span lines and an
-  // embedded, mid-line marker is never selected.
-  const starter = new RegExp(`^[ \\t]*<!--[ \\t]*${tag}[ \\t]+`, 'gm');
+  const starter = new RegExp(`<!--[ \\t]*${tag}[ \\t]+`, 'g');
   let searchFrom = -1;
   for (const match of text.matchAll(starter)) {
+    // Top-level = only horizontal whitespace between this `<!--` and a real line break
+    // (`\n`/`\r`) or start-of-text. Skip mid-line occurrences (embedded in a finding).
+    let p = match.index - 1;
+    while (p >= 0 && (text[p] === ' ' || text[p] === '\t')) p--;
+    if (p >= 0 && text[p] !== '\n' && text[p] !== '\r') continue;
     searchFrom = match.index + match[0].length;
   }
   if (searchFrom < 0) return { tagPresent: false, json: null };
@@ -252,7 +287,7 @@ function extractLastMarkerJson(
   // separating whitespace). Do NOT scan ahead for a `{` — otherwise a malformed marker
   // with no payload could swallow unrelated JSON later in the message.
   if (text[searchFrom] !== '{') return { tagPresent: true, json: null };
-  const json = scanBalancedJson(text, searchFrom);
+  const json = scanBalancedJson(text, searchFrom, COUNCIL_RESULT_MAX_BYTES);
   if (json === null) return { tagPresent: true, json: null };
 
   // Require the marker to be framed: optional horizontal whitespace then its closing
@@ -285,8 +320,7 @@ export function parseCouncilResultManifest(
   const { tagPresent, json } = extractLastMarkerJson(text, COUNCIL_RESULT_MARKER_TAG);
   if (!tagPresent) return { status: 'missing' };
   if (json === null) return { status: 'invalid' };
-  if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES)
-    return { status: 'invalid' };
+  if (utf8ByteLengthExceeds(json, COUNCIL_RESULT_MAX_BYTES)) return { status: 'invalid' };
 
   try {
     const parsed: unknown = JSON.parse(json);
@@ -455,7 +489,7 @@ export function parseGovernanceMarker(text: string | null | undefined): Governan
   // Same line-anchored, brace-aware, size-capped extraction as the manifest parser.
   const { json } = extractLastMarkerJson(text, GOVERNANCE_MARKER_TAG);
   if (json === null) return null;
-  if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES) return null;
+  if (utf8ByteLengthExceeds(json, COUNCIL_RESULT_MAX_BYTES)) return null;
   try {
     const parsed: unknown = JSON.parse(json);
     const result = GovernanceSchema.safeParse(parsed);

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -248,9 +248,21 @@ function extractLastMarkerJson(
   }
   if (searchFrom < 0) return { tagPresent: false, json: null };
 
-  const open = text.indexOf('{', searchFrom);
-  if (open < 0) return { tagPresent: true, json: null };
-  return { tagPresent: true, json: scanBalancedJson(text, open) };
+  // The JSON object must begin immediately after the tag (the `[ \t]+` above consumed the
+  // separating whitespace). Do NOT scan ahead for a `{` — otherwise a malformed marker
+  // with no payload could swallow unrelated JSON later in the message.
+  if (text[searchFrom] !== '{') return { tagPresent: true, json: null };
+  const json = scanBalancedJson(text, searchFrom);
+  if (json === null) return { tagPresent: true, json: null };
+
+  // Require the marker to be framed: optional horizontal whitespace then its closing
+  // `-->` immediately after the balanced object. This confirms the object belongs to this
+  // marker rather than being loose JSON that merely follows the tag.
+  let after = searchFrom + json.length;
+  while (text[after] === ' ' || text[after] === '\t') after++;
+  if (text.slice(after, after + 3) !== '-->') return { tagPresent: true, json: null };
+
+  return { tagPresent: true, json };
 }
 
 /**
@@ -423,17 +435,20 @@ const GovernanceMemberSchema = z.object({
   reason: z.string().max(1000).optional(),
 });
 
+// The overall `decision` is deliberately NOT part of this schema: it is code-owned
+// (`computeCouncilDecision`), and a model-authored decision here could contradict it in
+// the UI. Consumers render the per-member votes from this marker and inject the computed
+// decision. Any `decision` key the model emits is ignored (non-strict object strips it).
 export const GovernanceSchema = z.object({
   members: z.array(GovernanceMemberSchema).max(8),
-  decision: CouncilVoteSchema,
 });
 export type Governance = z.infer<typeof GovernanceSchema>;
 export type GovernanceMember = z.infer<typeof GovernanceMemberSchema>;
 
 /**
- * Extracts and validates the display-only governance marker from an assistant message.
- * Returns null when absent or malformed. This drives display only; never derive the
- * merge decision from it.
+ * Extracts and validates the display-only governance marker (per-member votes/reasons)
+ * from an assistant message. Returns null when absent or malformed. This drives display
+ * only; the overall merge decision comes from `computeCouncilDecision`, never from here.
  */
 export function parseGovernanceMarker(text: string | null | undefined): Governance | null {
   if (!text) return null;
@@ -460,12 +475,16 @@ export function enabledSpecialists(council: CodeReviewCouncilConfig): CouncilSpe
 }
 
 /**
- * Whether there is a renderable council definition (enabled with at least one enabled
- * specialist). This only guards prompt rendering — whether a run IS a council run is
- * recorded per-run via `review_type`, not inferred here.
+ * Whether there is a runnable council definition: enabled, with at least
+ * `COUNCIL_MIN_SPECIALISTS` enabled specialists. A council below the minimum must not
+ * render or execute as a council (it falls back to a standard review). This only guards
+ * whether the council is renderable — whether a run IS a council run is recorded per-run
+ * via `review_type`, not inferred here.
  */
 export function isCouncilActive(council: CodeReviewCouncilConfig | undefined | null): boolean {
-  return !!council && council.enabled && enabledSpecialists(council).length > 0;
+  return (
+    !!council && council.enabled && enabledSpecialists(council).length >= COUNCIL_MIN_SPECIALISTS
+  );
 }
 
 const AGGREGATION_STRATEGY_LABELS: Record<CouncilAggregationStrategy, string> = {

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -31,11 +31,7 @@ import {
 // Governance decision (code-owned, deterministic)
 // ============================================================================
 
-/**
- * A specialist's vote as seen by aggregation. A specialist whose result could not be
- * captured contributes `abstain` (abstain-never-pass), so a lost/garbled result can
- * never silently produce a passing council decision.
- */
+/** A specialist's vote as seen by aggregation. */
 export type SpecialistVote = { specialistId: string; vote: CouncilVote };
 
 /**
@@ -44,10 +40,18 @@ export type SpecialistVote = { specialistId: string; vote: CouncilVote };
  * the model to compute the decision. The semantics MUST stay in lockstep with
  * `describeAggregationStrategy` (the prompt text the specialists/orchestrator see).
  *
- * When there is no usable coverage — no votes at all, OR every specialist abstained —
- * the decision is `block` for every strategy (never pass on absent coverage). This
- * subsumes abstain-never-pass: a lost/garbled result contributes `abstain`, and if
- * that is all we have, the council blocks.
+ * Abstain semantics (deliberate): a returned `abstain` vote is treated leniently — it
+ * is NOT counted under `any_blocking_member` or `majority` (so a specialist that ran
+ * but had nothing to flag does not force a block), and only `unanimous_required`
+ * blocks on it. The one universal guard is total no-coverage: if there is no usable
+ * vote at all (empty, or every specialist abstained), the decision is `block` for
+ * every strategy (never pass on absent coverage).
+ *
+ * IMPORTANT: this operates only on the votes it is GIVEN. It does NOT know which
+ * specialists were configured, so it cannot detect a missing/dropped specialist. That
+ * coverage-integrity guard (missing configured specialist → block regardless of
+ * strategy) lives in `decideCouncilFromManifest`, which callers should use when
+ * deciding from a captured manifest.
  */
 export function computeCouncilDecision(
   votes: readonly SpecialistVote[],
@@ -214,21 +218,67 @@ export function summarizeCouncilManifest(
   }));
 }
 
+/** Coverage of a captured manifest against the specialists we asked to run. */
+export type CouncilCoverage = {
+  /** One entry per configured specialist that actually reported a result. */
+  votes: SpecialistVote[];
+  /** Configured specialists with NO captured result (the orchestrator dropped them). */
+  missingSpecialistIds: string[];
+};
+
 /**
- * The votes to feed `computeCouncilDecision`, reconciled against the specialists we
- * ASKED to run. Any configured specialist absent from the manifest (the orchestrator
- * dropped it) contributes `abstain` — so a dropped specialist can never silently let
- * the council pass. Manifest entries for unknown specialists are ignored.
+ * Reconciles a captured manifest against the specialists we ASKED to run. Reported
+ * votes are returned as-is (a real returned `abstain` stays `abstain`); configured
+ * specialists absent from the manifest are surfaced separately in `missingSpecialistIds`
+ * rather than being laundered into an `abstain` vote. Manifest entries for specialists
+ * we did not configure are ignored. Callers enforce coverage via `decideCouncilFromManifest`.
  */
 export function reconcileCouncilVotes(
   configuredSpecialistIds: readonly string[],
   manifest: CouncilResultManifest
-): SpecialistVote[] {
+): CouncilCoverage {
   const reported = new Map(manifest.specialists.map(s => [s.specialistId, s.vote]));
-  return configuredSpecialistIds.map(specialistId => ({
-    specialistId,
-    vote: reported.get(specialistId) ?? 'abstain',
-  }));
+  const votes: SpecialistVote[] = [];
+  const missingSpecialistIds: string[] = [];
+  for (const specialistId of configuredSpecialistIds) {
+    const vote = reported.get(specialistId);
+    if (vote === undefined) missingSpecialistIds.push(specialistId);
+    else votes.push({ specialistId, vote });
+  }
+  return { votes, missingSpecialistIds };
+}
+
+/** A council decision plus the coverage that produced it. */
+export type CouncilDecision = {
+  decision: CouncilVote;
+  votes: SpecialistVote[];
+  missingSpecialistIds: string[];
+};
+
+/**
+ * The deterministic, coverage-aware council decision — the entry point callers should
+ * use to decide from a captured manifest.
+ *
+ * COVERAGE INTEGRITY (fail closed): if ANY configured specialist has no captured result
+ * (`missingSpecialistIds` is non-empty), the decision is `block` regardless of strategy.
+ * We cannot vouch for a dimension we never got a result for, so a dropped/lost specialist
+ * can never silently let the council pass. Only when every configured specialist reported
+ * does the decision defer to `computeCouncilDecision` over the reported votes.
+ *
+ * Note: a failed capture (`parseCouncilResultManifest` returned `missing`/`invalid`)
+ * means NO coverage at all — callers must treat that as `block` (e.g. pass an empty
+ * manifest, which yields all-missing → block).
+ */
+export function decideCouncilFromManifest(
+  configuredSpecialistIds: readonly string[],
+  manifest: CouncilResultManifest,
+  strategy: CouncilAggregationStrategy
+): CouncilDecision {
+  const { votes, missingSpecialistIds } = reconcileCouncilVotes(configuredSpecialistIds, manifest);
+  if (missingSpecialistIds.length > 0) {
+    return { decision: 'block', votes, missingSpecialistIds };
+  }
+  return { decision: computeCouncilDecision(votes, strategy), votes, missingSpecialistIds };
 }
 
 // ============================================================================

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -216,74 +216,73 @@ function scanBalancedJson(text: string, open: number): string | null {
 }
 
 /**
- * Enumerates the balanced JSON payloads of every HTML-comment marker (`<!-- TAG {json} -->`)
- * in free text, in document order.
+ * Extracts the balanced JSON payload of the LAST top-level marker (`<!-- TAG {json} -->`)
+ * in free text. "Top-level" = the marker starts its own line (only leading horizontal
+ * whitespace before `<!--`).
  *
- * Two robustness properties:
- * - **Version isolation:** the tag must be followed by whitespace (`\\s+`), so a longer
- *   version like `${tag}0` or `${tag}junk` is NOT matched as `tag`.
- * - **Embedded-marker safety:** a finding's `rationale`/`path` can legitimately contain
- *   the marker text (JSON does not escape `<!-- ... {}`), which would appear as its own
- *   occurrence. Rather than trusting the last textual occurrence, we return ALL candidates
- *   so the caller can pick the last one that actually validates — an embedded fragment
- *   fails the schema and is skipped, so PR content quoting the marker cannot displace the
- *   real manifest. Payloads with `-->`/`}` inside strings are preserved (string-aware scan).
+ * Robustness properties:
+ * - **Embedded-marker safety (structural):** the orchestrator emits the marker on its own
+ *   final line, and `JSON.stringify` escapes newlines, so marker text quoted inside a
+ *   finding's JSON string is NEVER at line start. Anchoring to line start therefore
+ *   excludes embedded occurrences structurally — no need to try-and-validate candidates.
+ * - **Version isolation:** the tag must be followed by horizontal whitespace, so a longer
+ *   version like `${tag}0` / `${tag}junk` is NOT matched as `tag`.
+ * - **`-->`/`}` tolerance:** the JSON is read by a string-aware brace scan, so those chars
+ *   inside a finding's text do not truncate it.
  *
- * `tagPresent` lets callers distinguish "no marker at all" (missing) from "marker present
- * but no valid payload" (invalid).
+ * Only the LAST such marker is scanned (single pass), and callers validate it
+ * authoritatively — a malformed/oversized latest marker stays invalid rather than falling
+ * back to an earlier one (fail closed, last-marker-wins). `tagPresent` distinguishes "no
+ * marker" (missing) from "marker present but no balanced JSON" (invalid).
  */
-function markerJsonCandidates(
+function extractLastMarkerJson(
   text: string,
   tag: string
-): { tagPresent: boolean; candidates: string[] } {
-  const starter = new RegExp(`<!--\\s*${tag}\\s+`, 'g');
-  const candidates: string[] = [];
-  let tagPresent = false;
+): { tagPresent: boolean; json: string | null } {
+  // `^` (multiline) + horizontal-whitespace classes so a match cannot span lines and an
+  // embedded, mid-line marker is never selected.
+  const starter = new RegExp(`^[ \\t]*<!--[ \\t]*${tag}[ \\t]+`, 'gm');
+  let searchFrom = -1;
   for (const match of text.matchAll(starter)) {
-    tagPresent = true;
-    const open = text.indexOf('{', match.index + match[0].length);
-    if (open < 0) continue;
-    const json = scanBalancedJson(text, open);
-    if (json !== null) candidates.push(json);
+    searchFrom = match.index + match[0].length;
   }
-  return { tagPresent, candidates };
+  if (searchFrom < 0) return { tagPresent: false, json: null };
+
+  const open = text.indexOf('{', searchFrom);
+  if (open < 0) return { tagPresent: true, json: null };
+  return { tagPresent: true, json: scanBalancedJson(text, open) };
 }
 
 /**
  * Extracts and validates the combined council manifest from the orchestrator's final
  * message.
  *
- * The marker may appear ANYWHERE in the message and the LAST schema-valid occurrence
- * wins — real models often add a trailing sentence after the marker, and that must not
- * cause a false miss. Each candidate JSON object is extracted by a brace-aware scan (see
- * `markerJsonCandidates`), so a `-->`/`}` inside a finding's free-form text does not
- * truncate it, and marker text quoted inside a finding fails the schema and is skipped
- * rather than displacing the real manifest. Size-capped; schema is strict only where it
- * must be (each specialist's `vote`).
+ * The LAST top-level marker (see `extractLastMarkerJson`) is authoritative — real models
+ * add a trailing sentence after the marker, but a later marker supersedes an earlier one.
+ * The JSON is read by a brace-aware scan, so `-->`/`}` inside a finding's text does not
+ * truncate it, and marker text quoted inside a finding is excluded structurally (it is not
+ * at line start). A malformed or oversized latest marker stays `invalid` (fail closed) —
+ * it never falls back to an earlier result. Schema is strict only where it must be
+ * (each specialist's `vote`).
  */
 export function parseCouncilResultManifest(
   text: string | null | undefined
 ): CouncilManifestCapture {
   if (!text) return { status: 'missing' };
 
-  const { tagPresent, candidates } = markerJsonCandidates(text, COUNCIL_RESULT_MARKER_TAG);
+  const { tagPresent, json } = extractLastMarkerJson(text, COUNCIL_RESULT_MARKER_TAG);
   if (!tagPresent) return { status: 'missing' };
+  if (json === null) return { status: 'invalid' };
+  if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES)
+    return { status: 'invalid' };
 
-  // Prefer the last candidate that is a valid manifest; skip oversized or malformed
-  // candidates (including marker-like text embedded in a finding) rather than failing on
-  // them, so embedded content cannot force a false no-coverage block.
-  for (let i = candidates.length - 1; i >= 0; i--) {
-    const json = candidates[i];
-    if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES) continue;
-    try {
-      const parsed: unknown = JSON.parse(json);
-      const result = CouncilResultManifestSchema.safeParse(parsed);
-      if (result.success) return { status: 'captured', manifest: result.data };
-    } catch {
-      // try an earlier candidate
-    }
+  try {
+    const parsed: unknown = JSON.parse(json);
+    const result = CouncilResultManifestSchema.safeParse(parsed);
+    return result.success ? { status: 'captured', manifest: result.data } : { status: 'invalid' };
+  } catch {
+    return { status: 'invalid' };
   }
-  return { status: 'invalid' };
 }
 
 /** Per-specialist rollup for the Kilo UI: vote, highest severity, and findings count. */
@@ -438,21 +437,17 @@ export type GovernanceMember = z.infer<typeof GovernanceMemberSchema>;
  */
 export function parseGovernanceMarker(text: string | null | undefined): Governance | null {
   if (!text) return null;
-  // Same brace-aware, embedded-marker-safe, size-capped extraction as the manifest parser:
-  // return the last candidate that validates; skip oversized/malformed ones.
-  const { candidates } = markerJsonCandidates(text, GOVERNANCE_MARKER_TAG);
-  for (let i = candidates.length - 1; i >= 0; i--) {
-    const json = candidates[i];
-    if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES) continue;
-    try {
-      const parsed: unknown = JSON.parse(json);
-      const result = GovernanceSchema.safeParse(parsed);
-      if (result.success) return result.data;
-    } catch {
-      // try an earlier candidate
-    }
+  // Same line-anchored, brace-aware, size-capped extraction as the manifest parser.
+  const { json } = extractLastMarkerJson(text, GOVERNANCE_MARKER_TAG);
+  if (json === null) return null;
+  if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES) return null;
+  try {
+    const parsed: unknown = JSON.parse(json);
+    const result = GovernanceSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
   }
-  return null;
 }
 
 // ============================================================================

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -148,9 +148,31 @@ export const COUNCIL_RESULT_MAX_BYTES = 128 * 1024;
 /**
  * The combined council manifest: one array of per-specialist results. This is the
  * single-session capture shape; our code parses it and computes the decision.
+ *
+ * `specialistId` must be unique across the array. A duplicate is a coverage-integrity
+ * violation: without this, a `Map`-based reconcile would silently keep the last entry,
+ * letting a later `{id: pass}` override an earlier `{id: block}`. Rejecting duplicates
+ * here makes such a manifest INVALID (→ no coverage → the decision fails closed), and
+ * keeps the computed decision in agreement with `summarizeCouncilManifest` (which
+ * iterates the raw array).
  */
 export const CouncilResultManifestSchema = z.object({
-  specialists: z.array(CouncilSpecialistResultSchema).max(8),
+  specialists: z
+    .array(CouncilSpecialistResultSchema)
+    .max(8)
+    .superRefine((specialists, ctx) => {
+      const seen = new Set<string>();
+      for (const specialist of specialists) {
+        if (seen.has(specialist.specialistId)) {
+          ctx.addIssue({
+            code: 'custom',
+            message: `Duplicate specialistId: ${specialist.specialistId}`,
+          });
+          return;
+        }
+        seen.add(specialist.specialistId);
+      }
+    }),
 });
 export type CouncilResultManifest = z.infer<typeof CouncilResultManifestSchema>;
 
@@ -268,7 +290,11 @@ export function summarizeCouncilManifest(
 export type CouncilCoverage = {
   /** One entry per configured specialist that actually reported a result. */
   votes: SpecialistVote[];
-  /** Configured specialists with NO captured result (the orchestrator dropped them). */
+  /**
+   * Configured specialists without a single reliable result — either absent from the
+   * manifest (dropped), or reported more than once (duplicate/ambiguous). Both are
+   * treated as no coverage so the decision fails closed.
+   */
   missingSpecialistIds: string[];
 };
 
@@ -278,18 +304,33 @@ export type CouncilCoverage = {
  * specialists absent from the manifest are surfaced separately in `missingSpecialistIds`
  * rather than being laundered into an `abstain` vote. Manifest entries for specialists
  * we did not configure are ignored. Callers enforce coverage via `decideCouncilFromManifest`.
+ *
+ * Defense in depth: `CouncilResultManifestSchema` already rejects duplicate ids at parse
+ * time, so a captured manifest is unique. But if a manifest is constructed without going
+ * through the parser, a configured specialist reported MORE THAN ONCE is treated as
+ * missing (unreliable coverage) rather than letting a `Map` silently keep the last vote
+ * (which could override an earlier, more severe one).
  */
 export function reconcileCouncilVotes(
   configuredSpecialistIds: readonly string[],
   manifest: CouncilResultManifest
 ): CouncilCoverage {
+  const counts = new Map<string, number>();
+  for (const specialist of manifest.specialists) {
+    counts.set(specialist.specialistId, (counts.get(specialist.specialistId) ?? 0) + 1);
+  }
   const reported = new Map(manifest.specialists.map(s => [s.specialistId, s.vote]));
   const votes: SpecialistVote[] = [];
   const missingSpecialistIds: string[] = [];
   for (const specialistId of configuredSpecialistIds) {
+    // Exactly one reported result is reliable coverage; 0 = absent (dropped), >1 =
+    // duplicate/ambiguous — neither counts.
     const vote = reported.get(specialistId);
-    if (vote === undefined) missingSpecialistIds.push(specialistId);
-    else votes.push({ specialistId, vote });
+    if (counts.get(specialistId) === 1 && vote !== undefined) {
+      votes.push({ specialistId, vote });
+    } else {
+      missingSpecialistIds.push(specialistId);
+    }
   }
   return { votes, missingSpecialistIds };
 }
@@ -367,6 +408,8 @@ export function parseGovernanceMarker(text: string | null | undefined): Governan
   // member `reason` must not truncate the payload.
   const { json } = extractLastMarkerJson(text, GOVERNANCE_MARKER_TAG);
   if (json === null) return null;
+  // Bound parse cost on untrusted model output, symmetric with the manifest parser.
+  if (new TextEncoder().encode(json).length > COUNCIL_RESULT_MAX_BYTES) return null;
   try {
     const parsed: unknown = JSON.parse(json);
     const result = GovernanceSchema.safeParse(parsed);


### PR DESCRIPTION
## Summary

Adds the shared core logic for the Code Reviewer Council to `packages/worker-utils`,
exposed as a new `./code-review-council` package export so both the web app and the
`code-review-infra` worker can import it without duplicating logic. The module is
dependency-light on purpose (only `zod` and `@kilocode/db/schema-types`).

This is the pure, capture-agnostic layer: the code-owned governance decision, the
per-specialist result contract, the single-session combined result manifest and its
parser, a display-only governance marker, specialist presets, and a review-type stub.
Prompt building and execution wiring are intentionally left to their callers and are
not part of this PR. The council itself computes the merge decision in code from the
collected specialist votes rather than trusting the model to compute it.

## Changes

- Add `packages/worker-utils/src/code-review-council.ts`:
  - `computeCouncilDecision` / `councilDecisionBlocksMerge`: deterministic decision
    across the `any_blocking_member`, `majority`, and `unanimous_required` strategies.
    No usable coverage (empty or all-abstain) blocks under every strategy, and a
    returned `abstain` is treated leniently except under `unanimous_required`.
  - `describeAggregationStrategy`: human-readable rule text kept in lockstep with the
    decision logic for use in prompts.
  - Zod schemas for a specialist finding, a specialist result (strict only on `vote`),
    and the combined `CouncilResultManifest`, which rejects duplicate `specialistId`
    entries so a later vote cannot silently override an earlier one.
  - `parseCouncilResultManifest`: extracts the last `kilo-code-review-council:v1`
    marker with a brace-aware, string-literal-aware scan so `-->` or `}` inside a
    finding's text does not truncate the payload. Size-capped at 128 KiB; `missing`
    and `invalid` are distinct states and both mean no coverage downstream.
  - `reconcileCouncilVotes` / `decideCouncilFromManifest`: coverage-aware decision
    that fails closed. Any configured specialist that is absent or reported more than
    once is surfaced as missing and forces a `block` regardless of strategy.
  - `summarizeCouncilManifest`: per-specialist rollup (vote, highest severity,
    findings count) for UI display.
  - `parseGovernanceMarker` and its schemas: display-only `kilo-review-governance:v1`
    summary, explicitly not the source of the merge decision.
  - Config helpers (`enabledSpecialists`, `isCouncilActive`, `formatAggregationStrategy`),
    four specialist presets (security, performance, testing, correctness) with
    `presetToSpecialist` and a `COUNCIL_MIN_SPECIALISTS` of 2.
  - `determineAutomatedReviewType`: intentional stub that always returns `'standard'`
    for automated webhook runs, with the PR-facts plumbing in place for later work.
- Add `packages/worker-utils/src/code-review-council.test.ts`: unit tests covering the
  decision strategies, no-coverage and fail-closed behavior, manifest parsing edge
  cases (last-marker-wins, `-->` in findings, duplicate ids, size cap), governance
  marker parsing, config helpers, presets, and the review-type stub.
- Register the `./code-review-council` export in `packages/worker-utils/package.json`.

## Verification

- [ ] No manual testing. This PR is pure, side-effect-free logic with no UI or runtime
  wiring, so behavior is exercised by the added unit tests rather than a manual path.

## Visual Changes

N/A

## Reviewer Notes

- The decision is code-owned and fails closed on missing coverage: worth confirming
  the abstain semantics and the duplicate-specialist handling match the intended
  policy, since those are the load-bearing rules.
- `determineAutomatedReviewType` is deliberately a stub returning `'standard'`; the
  real standard-vs-council determination is planned follow-up work.
- The schema types (`CodeReviewCouncilConfig`, `CouncilVoteSchema`, etc.) are imported
  from `@kilocode/db/schema-types` and are not defined in this PR.
