### PR TITLE
Allow DeepSeek routing through Vercel

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -231,7 +231,7 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
 
   if (
     eligibleForVercelRouting &&
-    (await shouldRouteToVercel(requestedModel, kiloExclusiveModel, request, taskId || user.id))
+    (await shouldRouteToVercel(requestedModel, request, taskId || user.id))
   ) {
     return {
       kind: 'provider',

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
@@ -66,7 +66,7 @@ export default {
     apiKey: getEnvVariable('VERCEL_AI_GATEWAY_API_KEY'),
     supportedChatApis: ['chat_completions', 'messages', 'responses'],
     async transformRequest(context) {
-      applyVercelSettings(context.model, context.request, context.userByok);
+      await applyVercelSettings(context.model, context.request, context.userByok);
     },
   },
 } as const satisfies Record<string, Provider>;

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -38,12 +38,12 @@ describe('applyVercelSettings', () => {
     expect(mockedGetCachedVercelInferenceProviderIdsForModel).not.toHaveBeenCalled();
   });
 
-  it('allows DeepSeek when the explicit provider list only contains Novita', async () => {
+  it('keeps Novita when it is the only explicit DeepSeek provider', async () => {
     const request = createDeepseekRequest(['novita']);
 
     await applyVercelSettings('deepseek/deepseek-v3.2', request, null);
 
-    expect(request.body.providerOptions?.gateway?.only).toBe(undefined);
+    expect(request.body.providerOptions?.gateway?.only).toEqual(['novita']);
     expect(mockedGetCachedVercelInferenceProviderIdsForModel).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -7,13 +7,8 @@ import {
 } from '@/lib/ai-gateway/providers/vercel';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
-import { getCachedVercelInferenceProviderIdsForModel } from '@/lib/ai-gateway/providers/gateway-models-cache';
 
-jest.mock('@/lib/ai-gateway/providers/gateway-models-cache');
-
-const mockedGetCachedVercelInferenceProviderIdsForModel = jest.mocked(
-  getCachedVercelInferenceProviderIdsForModel
-);
+const getVercelInferenceProviders = jest.fn<() => Promise<string[] | null>>();
 
 function createDeepseekRequest(only?: string[]): GatewayRequest {
   return {
@@ -30,39 +25,55 @@ describe('applyVercelSettings', () => {
   it('removes Novita from an explicit DeepSeek provider list', async () => {
     const request = createDeepseekRequest(['Novita/fp8', 'deepseek']);
 
-    await applyVercelSettings('deepseek/deepseek-v3.2', request, null);
+    await applyVercelSettings(
+      'deepseek/deepseek-v3.2',
+      request,
+      null,
+      getVercelInferenceProviders
+    );
 
     expect(request.body.providerOptions?.gateway?.only).toEqual(['deepseek']);
-    expect(mockedGetCachedVercelInferenceProviderIdsForModel).not.toHaveBeenCalled();
+    expect(getVercelInferenceProviders).not.toHaveBeenCalled();
   });
 
   it('keeps Novita when it is the only explicit DeepSeek provider', async () => {
     const request = createDeepseekRequest(['novita']);
 
-    await applyVercelSettings('deepseek/deepseek-v3.2', request, null);
+    await applyVercelSettings(
+      'deepseek/deepseek-v3.2',
+      request,
+      null,
+      getVercelInferenceProviders
+    );
 
     expect(request.body.providerOptions?.gateway?.only).toEqual(['novita']);
-    expect(mockedGetCachedVercelInferenceProviderIdsForModel).not.toHaveBeenCalled();
+    expect(getVercelInferenceProviders).not.toHaveBeenCalled();
   });
 
   it('uses the cached Vercel providers without Novita for DeepSeek', async () => {
-    mockedGetCachedVercelInferenceProviderIdsForModel.mockResolvedValueOnce([
-      'novita',
-      'deepseek',
-      'bedrock',
-    ]);
+    getVercelInferenceProviders.mockResolvedValueOnce(['novita', 'deepseek', 'bedrock']);
     const request = createDeepseekRequest();
 
-    await applyVercelSettings('deepseek/deepseek-v3.2', request, null);
+    await applyVercelSettings(
+      'deepseek/deepseek-v3.2',
+      request,
+      null,
+      getVercelInferenceProviders
+    );
 
     expect(request.body.providerOptions?.gateway?.only).toEqual(['deepseek', 'bedrock']);
   });
 
   it('leaves only undefined when DeepSeek has no cached provider list', async () => {
-    mockedGetCachedVercelInferenceProviderIdsForModel.mockResolvedValueOnce(null);
+    getVercelInferenceProviders.mockResolvedValueOnce(null);
     const request = createDeepseekRequest();
 
-    await applyVercelSettings('deepseek/deepseek-v3.2', request, null);
+    await applyVercelSettings(
+      'deepseek/deepseek-v3.2',
+      request,
+      null,
+      getVercelInferenceProviders
+    );
 
     expect(request.body.providerOptions?.gateway?.only).toBe(undefined);
   });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -1,11 +1,65 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import {
+  applyVercelSettings,
   getAnthropicProviderOptionsForVercel,
   hasCompatibleVercelInferenceProvider,
   passesVercelRoutingPercentage,
 } from '@/lib/ai-gateway/providers/vercel';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import { getCachedVercelInferenceProviderIdsForModel } from '@/lib/ai-gateway/providers/gateway-models-cache';
+
+jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
+  getCachedVercelInferenceProviderIdsForModel: jest.fn(),
+}));
+
+const mockedGetCachedVercelInferenceProviderIdsForModel = jest.mocked(
+  getCachedVercelInferenceProviderIdsForModel
+);
+
+function createDeepseekRequest(only?: string[]): GatewayRequest {
+  return {
+    kind: 'chat_completions',
+    body: {
+      model: 'deepseek/deepseek-v3.2',
+      messages: [{ role: 'user', content: 'hello' }],
+      provider: only ? { only } : undefined,
+    },
+  };
+}
+
+describe('applyVercelSettings', () => {
+  it('removes Novita from an explicit DeepSeek provider list', async () => {
+    const request = createDeepseekRequest(['Novita/fp8', 'deepseek']);
+
+    await applyVercelSettings('deepseek/deepseek-v3.2', request, null);
+
+    expect(request.body.providerOptions?.gateway?.only).toEqual(['deepseek']);
+    expect(mockedGetCachedVercelInferenceProviderIdsForModel).not.toHaveBeenCalled();
+  });
+
+  it('uses the cached Vercel providers without Novita for DeepSeek', async () => {
+    mockedGetCachedVercelInferenceProviderIdsForModel.mockResolvedValueOnce([
+      'novita',
+      'deepseek',
+      'bedrock',
+    ]);
+    const request = createDeepseekRequest();
+
+    await applyVercelSettings('deepseek/deepseek-v3.2', request, null);
+
+    expect(request.body.providerOptions?.gateway?.only).toEqual(['deepseek', 'bedrock']);
+  });
+
+  it('leaves only undefined when DeepSeek has no cached provider list', async () => {
+    mockedGetCachedVercelInferenceProviderIdsForModel.mockResolvedValueOnce(null);
+    const request = createDeepseekRequest();
+
+    await applyVercelSettings('deepseek/deepseek-v3.2', request, null);
+
+    expect(request.body.providerOptions?.gateway?.only).toBe(undefined);
+  });
+});
 
 describe('getAnthropicProviderOptionsForVercel', () => {
   it('maps chat completion verbosity to Anthropic effort', () => {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -9,9 +9,7 @@ import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import { getCachedVercelInferenceProviderIdsForModel } from '@/lib/ai-gateway/providers/gateway-models-cache';
 
-jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
-  getCachedVercelInferenceProviderIdsForModel: jest.fn(),
-}));
+jest.mock('@/lib/ai-gateway/providers/gateway-models-cache');
 
 const mockedGetCachedVercelInferenceProviderIdsForModel = jest.mocked(
   getCachedVercelInferenceProviderIdsForModel

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -25,12 +25,7 @@ describe('applyVercelSettings', () => {
   it('removes Novita from an explicit DeepSeek provider list', async () => {
     const request = createDeepseekRequest(['Novita/fp8', 'deepseek']);
 
-    await applyVercelSettings(
-      'deepseek/deepseek-v3.2',
-      request,
-      null,
-      getVercelInferenceProviders
-    );
+    await applyVercelSettings('deepseek/deepseek-v3.2', request, null, getVercelInferenceProviders);
 
     expect(request.body.providerOptions?.gateway?.only).toEqual(['deepseek']);
     expect(getVercelInferenceProviders).not.toHaveBeenCalled();
@@ -39,12 +34,7 @@ describe('applyVercelSettings', () => {
   it('keeps Novita when it is the only explicit DeepSeek provider', async () => {
     const request = createDeepseekRequest(['novita']);
 
-    await applyVercelSettings(
-      'deepseek/deepseek-v3.2',
-      request,
-      null,
-      getVercelInferenceProviders
-    );
+    await applyVercelSettings('deepseek/deepseek-v3.2', request, null, getVercelInferenceProviders);
 
     expect(request.body.providerOptions?.gateway?.only).toEqual(['novita']);
     expect(getVercelInferenceProviders).not.toHaveBeenCalled();
@@ -54,12 +44,7 @@ describe('applyVercelSettings', () => {
     getVercelInferenceProviders.mockResolvedValueOnce(['novita', 'deepseek', 'bedrock']);
     const request = createDeepseekRequest();
 
-    await applyVercelSettings(
-      'deepseek/deepseek-v3.2',
-      request,
-      null,
-      getVercelInferenceProviders
-    );
+    await applyVercelSettings('deepseek/deepseek-v3.2', request, null, getVercelInferenceProviders);
 
     expect(request.body.providerOptions?.gateway?.only).toEqual(['deepseek', 'bedrock']);
   });
@@ -68,12 +53,7 @@ describe('applyVercelSettings', () => {
     getVercelInferenceProviders.mockResolvedValueOnce(null);
     const request = createDeepseekRequest();
 
-    await applyVercelSettings(
-      'deepseek/deepseek-v3.2',
-      request,
-      null,
-      getVercelInferenceProviders
-    );
+    await applyVercelSettings('deepseek/deepseek-v3.2', request, null, getVercelInferenceProviders);
 
     expect(request.body.providerOptions?.gateway?.only).toBe(undefined);
   });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -38,6 +38,15 @@ describe('applyVercelSettings', () => {
     expect(mockedGetCachedVercelInferenceProviderIdsForModel).not.toHaveBeenCalled();
   });
 
+  it('allows DeepSeek when the explicit provider list only contains Novita', async () => {
+    const request = createDeepseekRequest(['novita']);
+
+    await applyVercelSettings('deepseek/deepseek-v3.2', request, null);
+
+    expect(request.body.providerOptions?.gateway?.only).toBe(undefined);
+    expect(mockedGetCachedVercelInferenceProviderIdsForModel).not.toHaveBeenCalled();
+  });
+
   it('uses the cached Vercel providers without Novita for DeepSeek', async () => {
     mockedGetCachedVercelInferenceProviderIdsForModel.mockResolvedValueOnce([
       'novita',

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -142,6 +142,9 @@ async function convertProviderOptions(
         ) ?? undefined;
     } else {
       only = only.filter(providerId => providerId !== 'novita');
+      if (only.length === 0) {
+        only = undefined;
+      }
     }
   }
 

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -141,9 +141,9 @@ async function convertProviderOptions(
           providerId => providerId !== 'novita'
         ) ?? undefined;
     } else {
-      only = only.filter(providerId => providerId !== 'novita');
-      if (only.length === 0) {
-        only = undefined;
+      const onlyWithoutNovita = only.filter(providerId => providerId !== 'novita');
+      if (onlyWithoutNovita.length > 0) {
+        only = onlyWithoutNovita;
       }
     }
   }

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -125,7 +125,8 @@ export async function shouldRouteToVercel(
 
 async function convertProviderOptions(
   requestedModel: string,
-  requestToMutate: GatewayRequest
+  requestToMutate: GatewayRequest,
+  getVercelInferenceProviders: typeof getCachedVercelInferenceProviderIdsForModel
 ): Promise<VercelProviderConfig> {
   const provider = requestToMutate.body.provider;
   let only = provider?.only?.map(p => openRouterToVercelInferenceProviderId(p));
@@ -137,7 +138,7 @@ async function convertProviderOptions(
         isReasoningExplicitlyDisabled(requestToMutate)
       );
       only =
-        (await getCachedVercelInferenceProviderIdsForModel(vercelModelId))?.filter(
+        (await getVercelInferenceProviders(vercelModelId))?.filter(
           providerId => providerId !== 'novita'
         ) ?? undefined;
     } else {
@@ -217,7 +218,8 @@ export function getVercelInferenceProviderConfigForUserByok(
 export async function applyVercelSettings(
   requestedModel: string,
   requestToMutate: GatewayRequest,
-  userByok: BYOKResult[] | null
+  userByok: BYOKResult[] | null,
+  getVercelInferenceProviders = getCachedVercelInferenceProviderIdsForModel
 ) {
   requestToMutate.body.model = mapModelIdToVercel(
     requestedModel,
@@ -246,7 +248,8 @@ export async function applyVercelSettings(
   } else {
     requestToMutate.body.providerOptions = await convertProviderOptions(
       requestedModel,
-      requestToMutate
+      requestToMutate,
+      getVercelInferenceProviders
     );
   }
 

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -27,7 +27,6 @@ import {
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { isDeepseekModel } from '@/lib/ai-gateway/providers/deepseek';
-import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 
 const getVercelRoutingPercentage = createCachedFetch(
   async () => {
@@ -83,21 +82,12 @@ export function passesVercelRoutingPercentage(randomSeed: string, routingPercent
 
 export async function shouldRouteToVercel(
   requestedModel: string,
-  kiloExclusiveModel: KiloExclusiveModel | null,
   request: GatewayRequest,
   randomSeed: string
 ) {
   if (hasOpenRouterExclusiveProviderOptions(request)) {
     console.debug(
       '[shouldRouteToVercel] not routing to Vercel because of unsupported provider options'
-    );
-    return false;
-  }
-
-  if (!kiloExclusiveModel?.flags.includes('vercel-routing') && isDeepseekModel(requestedModel)) {
-    // https://kilo-code.slack.com/archives/C0A4SA041DE/p1781743079721409
-    console.debug(
-      '[shouldRouteToVercel] not routing to Vercel because some of its DeepSeek providers have tool call issues'
     );
     return false;
   }
@@ -133,11 +123,31 @@ export async function shouldRouteToVercel(
   return true;
 }
 
-function convertProviderOptions(requestToMutate: GatewayRequest): VercelProviderConfig {
+async function convertProviderOptions(
+  requestedModel: string,
+  requestToMutate: GatewayRequest
+): Promise<VercelProviderConfig> {
   const provider = requestToMutate.body.provider;
+  let only = provider?.only?.map(p => openRouterToVercelInferenceProviderId(p));
+
+  if (isDeepseekModel(requestedModel)) {
+    if (!only) {
+      const vercelModelId = mapModelIdToVercel(
+        requestedModel,
+        isReasoningExplicitlyDisabled(requestToMutate)
+      );
+      only =
+        (await getCachedVercelInferenceProviderIdsForModel(vercelModelId))?.filter(
+          providerId => providerId !== 'novita'
+        ) ?? undefined;
+    } else {
+      only = only.filter(providerId => providerId !== 'novita');
+    }
+  }
+
   return {
     gateway: {
-      only: provider?.only?.map(p => openRouterToVercelInferenceProviderId(p)),
+      only,
       order: provider?.order?.map(p => openRouterToVercelInferenceProviderId(p)),
       zeroDataRetention: provider?.zdr,
       disallowPromptTraining: provider?.data_collection === 'deny',
@@ -201,7 +211,7 @@ export function getVercelInferenceProviderConfigForUserByok(
   return [key, list];
 }
 
-export function applyVercelSettings(
+export async function applyVercelSettings(
   requestedModel: string,
   requestToMutate: GatewayRequest,
   userByok: BYOKResult[] | null
@@ -231,7 +241,10 @@ export function applyVercelSettings(
       },
     };
   } else {
-    requestToMutate.body.providerOptions = convertProviderOptions(requestToMutate);
+    requestToMutate.body.providerOptions = await convertProviderOptions(
+      requestedModel,
+      requestToMutate
+    );
   }
 
   if (requestToMutate.body.providerOptions) {


### PR DESCRIPTION
## Summary
- allow DeepSeek models to participate in Vercel routing
- exclude Novita from explicit DeepSeek provider constraints
- derive a Novita-free provider constraint from Redis when the request has no `only` list
- preserve an undefined `only` constraint when Redis has no provider list

## Verification
- not run per request