### PR TITLE
Add stealth GPT-5.6 Sol and Muse Spark 1.1 models

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -7,6 +7,8 @@ import {
   claude_sonnet_4_6_stealth_model,
   claude_opus_4_6_stealth_model,
 } from './providers/anthropic.constants';
+import { gpt_5_6_sol_stealth_model } from './providers/openai';
+import { muse_spark_1_1_model } from './providers/meta';
 
 describe('isFreeModel', () => {
   describe('free models', () => {
@@ -68,6 +70,46 @@ describe('isFreeModel', () => {
       expect(claude_sonnet_4_6_stealth_model.public_id).toBe('stealth/claude-sonnet-4.6');
       expect(getInferenceProvider(claude_opus_4_6_stealth_model)).toBe('stealth');
       expect(claude_opus_4_6_stealth_model.public_id).toBe('stealth/claude-opus-4.6');
+    });
+
+    test('registers GPT-5.6 Sol as a Martian stealth model', () => {
+      expect(findKiloExclusiveModel('stealth/gpt-5.6-sol')).toBe(gpt_5_6_sol_stealth_model);
+      expect(gpt_5_6_sol_stealth_model.internal_id).toBe('openai/gpt-5.6-sol:optimized');
+      expect(gpt_5_6_sol_stealth_model.gateway).toBe('martian');
+      expect(getInferenceProvider(gpt_5_6_sol_stealth_model)).toBe('stealth');
+      expect(gpt_5_6_sol_stealth_model.pricing).toEqual([
+        {
+          start_context_length: 0,
+          pricing: {
+            prompt_per_million: 4,
+            completion_per_million: 24,
+            input_cache_read_per_million: 0.4,
+            input_cache_write_per_million: 5,
+          },
+        },
+        {
+          start_context_length: 272_000,
+          pricing: {
+            prompt_per_million: 8,
+            completion_per_million: 36,
+            input_cache_read_per_million: 0.8,
+            input_cache_write_per_million: 10,
+          },
+        },
+      ]);
+    });
+
+    test('registers Muse Spark 1.1 through Vercel', () => {
+      expect(findKiloExclusiveModel('meta/muse-spark-1.1')).toBe(muse_spark_1_1_model);
+      expect(muse_spark_1_1_model.gateway).toBe('vercel');
+      expect(getInferenceProvider(muse_spark_1_1_model)).toBeUndefined();
+      expect(muse_spark_1_1_model.context_length).toBe(1_048_576);
+      expect(muse_spark_1_1_model.pricing?.[0].pricing).toEqual({
+        prompt_per_million: 1.25,
+        completion_per_million: 4.25,
+        input_cache_read_per_million: 0.15,
+        input_cache_write_per_million: null,
+      });
     });
 
     test('all Kilo exclusive models should have either no pricing or valid ordered pricing tiers', () => {

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -102,7 +102,7 @@ describe('isFreeModel', () => {
     test('registers Muse Spark 1.1 through Vercel', () => {
       expect(findKiloExclusiveModel('meta/muse-spark-1.1')).toBe(muse_spark_1_1_model);
       expect(muse_spark_1_1_model.gateway).toBe('vercel');
-      expect(getInferenceProvider(muse_spark_1_1_model)).toBeUndefined();
+      expect(getInferenceProvider(muse_spark_1_1_model)).toBeNull();
       expect(muse_spark_1_1_model.context_length).toBe(1_048_576);
       expect(muse_spark_1_1_model.pricing?.[0].pricing).toEqual({
         prompt_per_million: 1.25,

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -7,7 +7,7 @@ import {
   claude_sonnet_4_6_stealth_model,
   claude_opus_4_6_stealth_model,
 } from './providers/anthropic.constants';
-import { gpt_5_6_sol_stealth_model } from './providers/openai';
+import { gpt_5_6_sol_stealth_model } from './providers/openai-exclusive';
 import { muse_spark_1_1_model } from './providers/meta';
 
 describe('isFreeModel', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -28,7 +28,12 @@ import { QWEN37_PLUS_MODEL_ID, qwen36_plus_stealth_model } from '@/lib/ai-gatewa
 import { stepfun_37_flash_free_model } from '@/lib/ai-gateway/providers/stepfun';
 import { isGrokModel } from '@/lib/ai-gateway/providers/xai';
 import { isClaudeModel } from '@/lib/ai-gateway/providers/anthropic.constants';
-import { GPT_CURRENT_MODEL_ID, isOpenAiModel } from '@/lib/ai-gateway/providers/openai';
+import {
+  GPT_CURRENT_MODEL_ID,
+  gpt_5_6_sol_stealth_model,
+  isOpenAiModel,
+} from '@/lib/ai-gateway/providers/openai';
+import { muse_spark_1_1_model } from '@/lib/ai-gateway/providers/meta';
 import { GLM_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/zai';
 import {
   deepseek_v4_pro_discounted_model,
@@ -88,6 +93,8 @@ export const kiloExclusiveModels = [
   seed_20_code_free_model,
   ...deepseekDiscountedModels,
   qwen36_plus_stealth_model,
+  gpt_5_6_sol_stealth_model,
+  muse_spark_1_1_model,
   claude_sonnet_clawsetup_model,
   claude_opus_4_8_stealth_model,
   claude_opus_4_7_stealth_model,

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -28,11 +28,8 @@ import { QWEN37_PLUS_MODEL_ID, qwen36_plus_stealth_model } from '@/lib/ai-gatewa
 import { stepfun_37_flash_free_model } from '@/lib/ai-gateway/providers/stepfun';
 import { isGrokModel } from '@/lib/ai-gateway/providers/xai';
 import { isClaudeModel } from '@/lib/ai-gateway/providers/anthropic.constants';
-import {
-  GPT_CURRENT_MODEL_ID,
-  gpt_5_6_sol_stealth_model,
-  isOpenAiModel,
-} from '@/lib/ai-gateway/providers/openai';
+import { GPT_CURRENT_MODEL_ID, isOpenAiModel } from '@/lib/ai-gateway/providers/openai';
+import { gpt_5_6_sol_stealth_model } from '@/lib/ai-gateway/providers/openai-exclusive';
 import { muse_spark_1_1_model } from '@/lib/ai-gateway/providers/meta';
 import { GLM_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/zai';
 import {

--- a/apps/web/src/lib/ai-gateway/providers/meta.ts
+++ b/apps/web/src/lib/ai-gateway/providers/meta.ts
@@ -1,0 +1,27 @@
+import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
+
+export const muse_spark_1_1_model: KiloExclusiveModel = {
+  public_id: 'meta/muse-spark-1.1',
+  internal_id: 'meta/muse-spark-1.1',
+  display_name: 'Meta: Muse Spark 1.1',
+  description:
+    'Muse Spark 1.1 is strongest at agentic performance, tool use, and computer use. It does well on long-running tasks with a 1M-token context window and can delegate execution to sub-agents running in parallel.',
+  status: 'public',
+  context_length: 1_048_576,
+  max_completion_tokens: 1_048_576,
+  gateway: 'vercel',
+  flags: ['reasoning', 'vision'],
+  pricing: [
+    {
+      start_context_length: 0,
+      pricing: {
+        prompt_per_million: 1.25,
+        completion_per_million: 4.25,
+        input_cache_read_per_million: 0.15,
+        input_cache_write_per_million: null,
+      },
+    },
+  ],
+  exclusive_to: [],
+  inference_provider_restriction: [],
+};

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -16,6 +16,7 @@ import { ReasoningEffortSchema } from '@kilocode/db/schema-types';
 import { isDeepseekModel } from '@/lib/ai-gateway/providers/deepseek';
 import { isMinimaxModel } from '@/lib/ai-gateway/providers/minimax';
 import type { DirectUserByokInferenceProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
+import { muse_spark_1_1_model } from '@/lib/ai-gateway/providers/meta';
 
 const REASONING_VARIANTS_THINKING_ONLY = {
   thinking: { reasoning: { enabled: true, effort: 'high' } },
@@ -35,6 +36,11 @@ export const REASONING_VARIANTS_LOW_MEDIUM_HIGH = {
 export const REASONING_VARIANTS_MINIMAL_LOW_MEDIUM_HIGH = {
   minimal: { reasoning: { enabled: true, effort: 'minimal' } },
   ...REASONING_VARIANTS_LOW_MEDIUM_HIGH,
+} as const;
+
+export const REASONING_VARIANTS_NONE_MINIMAL_LOW_MEDIUM_HIGH = {
+  none: { reasoning: { enabled: false, effort: 'none' } },
+  ...REASONING_VARIANTS_MINIMAL_LOW_MEDIUM_HIGH,
 } as const;
 
 export const REASONING_VARIANTS_NONE_LOW_MEDIUM_HIGH = {
@@ -113,6 +119,9 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
   if (isDeepseekModel(model) || isGlmModel(model)) {
     return REASONING_VARIANTS_NONE_HIGH_XHIGH;
   }
+  if (model === muse_spark_1_1_model.public_id) {
+    return REASONING_VARIANTS_NONE_MINIMAL_LOW_MEDIUM_HIGH;
+  }
   return undefined;
 }
 
@@ -136,7 +145,7 @@ export function getAiSdkProvider(
   ) {
     return 'anthropic';
   }
-  if (isOpenAiModel(model) || isGrokModel(model)) {
+  if (isOpenAiModel(model) || isGrokModel(model) || model === muse_spark_1_1_model.public_id) {
     // OpenAI: "While Chat Completions remains supported, Responses is recommended for all new projects.""
     // xAI: "The Responses API is the recommended way to interact with xAI models."
     return 'openai';

--- a/apps/web/src/lib/ai-gateway/providers/openai-exclusive.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openai-exclusive.ts
@@ -1,0 +1,36 @@
+import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
+
+export const gpt_5_6_sol_stealth_model: KiloExclusiveModel = {
+  public_id: 'stealth/gpt-5.6-sol',
+  internal_id: 'openai/gpt-5.6-sol:optimized',
+  display_name: 'Stealth: GPT-5.6 Sol (20% off)',
+  description:
+    "Your prompts and completions may be retained and used to train or improve the provider's services. This third-party-served variant of GPT-5.6 Sol is offered at 20% lower cost than standard GPT-5.6 Sol pricing and is not served by OpenAI or Kilo Code.",
+  status: 'public',
+  context_length: 1_050_000,
+  max_completion_tokens: 128_000,
+  gateway: 'martian',
+  flags: ['reasoning', 'vision', 'stealth', 'requires-data-collection'],
+  pricing: [
+    {
+      start_context_length: 0,
+      pricing: {
+        prompt_per_million: 4,
+        completion_per_million: 24,
+        input_cache_read_per_million: 0.4,
+        input_cache_write_per_million: 5,
+      },
+    },
+    {
+      start_context_length: 272_000,
+      pricing: {
+        prompt_per_million: 8,
+        completion_per_million: 36,
+        input_cache_read_per_million: 0.8,
+        input_cache_write_per_million: 10,
+      },
+    },
+  ],
+  exclusive_to: [],
+  inference_provider_restriction: [],
+};

--- a/apps/web/src/lib/ai-gateway/providers/openai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openai.ts
@@ -1,5 +1,3 @@
-import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
-
 export function isOpenAiModel(requestedModel: string) {
   return (
     (requestedModel.includes('openai') || requestedModel.includes('gpt')) &&
@@ -18,38 +16,3 @@ export const GPT_CURRENT_VERCEL_MODEL_ID = GPT_CURRENT_MODEL_ID;
 export const GPT_MINI_CURRENT_MODEL_ID = 'openai/gpt-5.4-mini';
 
 export const GPT_MINI_CURRENT_VERCEL_MODEL_ID = GPT_MINI_CURRENT_MODEL_ID;
-
-export const gpt_5_6_sol_stealth_model: KiloExclusiveModel = {
-  public_id: 'stealth/gpt-5.6-sol',
-  internal_id: 'openai/gpt-5.6-sol:optimized',
-  display_name: 'Stealth: GPT-5.6 Sol (20% off)',
-  description:
-    "Your prompts and completions may be retained and used to train or improve the provider's services. This third-party-served variant of GPT-5.6 Sol is offered at 20% lower cost than standard GPT-5.6 Sol pricing and is not served by OpenAI or Kilo Code.",
-  status: 'public',
-  context_length: 1_050_000,
-  max_completion_tokens: 128_000,
-  gateway: 'martian',
-  flags: ['reasoning', 'vision', 'stealth', 'requires-data-collection'],
-  pricing: [
-    {
-      start_context_length: 0,
-      pricing: {
-        prompt_per_million: 4,
-        completion_per_million: 24,
-        input_cache_read_per_million: 0.4,
-        input_cache_write_per_million: 5,
-      },
-    },
-    {
-      start_context_length: 272_000,
-      pricing: {
-        prompt_per_million: 8,
-        completion_per_million: 36,
-        input_cache_read_per_million: 0.8,
-        input_cache_write_per_million: 10,
-      },
-    },
-  ],
-  exclusive_to: [],
-  inference_provider_restriction: [],
-};

--- a/apps/web/src/lib/ai-gateway/providers/openai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openai.ts
@@ -1,3 +1,5 @@
+import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
+
 export function isOpenAiModel(requestedModel: string) {
   return (
     (requestedModel.includes('openai') || requestedModel.includes('gpt')) &&
@@ -16,3 +18,38 @@ export const GPT_CURRENT_VERCEL_MODEL_ID = GPT_CURRENT_MODEL_ID;
 export const GPT_MINI_CURRENT_MODEL_ID = 'openai/gpt-5.4-mini';
 
 export const GPT_MINI_CURRENT_VERCEL_MODEL_ID = GPT_MINI_CURRENT_MODEL_ID;
+
+export const gpt_5_6_sol_stealth_model: KiloExclusiveModel = {
+  public_id: 'stealth/gpt-5.6-sol',
+  internal_id: 'openai/gpt-5.6-sol:optimized',
+  display_name: 'Stealth: GPT-5.6 Sol (20% off)',
+  description:
+    "Your prompts and completions may be retained and used to train or improve the provider's services. This third-party-served variant of GPT-5.6 Sol is offered at 20% lower cost than standard GPT-5.6 Sol pricing and is not served by OpenAI or Kilo Code.",
+  status: 'public',
+  context_length: 1_050_000,
+  max_completion_tokens: 128_000,
+  gateway: 'martian',
+  flags: ['reasoning', 'vision', 'stealth', 'requires-data-collection'],
+  pricing: [
+    {
+      start_context_length: 0,
+      pricing: {
+        prompt_per_million: 4,
+        completion_per_million: 24,
+        input_cache_read_per_million: 0.4,
+        input_cache_write_per_million: 5,
+      },
+    },
+    {
+      start_context_length: 272_000,
+      pricing: {
+        prompt_per_million: 8,
+        completion_per_million: 36,
+        input_cache_read_per_million: 0.8,
+        input_cache_write_per_million: 10,
+      },
+    },
+  ],
+  exclusive_to: [],
+  inference_provider_restriction: [],
+};

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -128,6 +128,10 @@ describe('mapModelIdToVercel', () => {
   });
 
   describe('kilo-exclusive models', () => {
+    it('maps a Vercel-exclusive model to its internal id', () => {
+      expect(mapModelIdToVercel('meta/muse-spark-1.1', false)).toBe('meta/muse-spark-1.1');
+    });
+
     it('maps an exclusive flagged with vercel-routing to its internal id', () => {
       // google/gemma-4-26b-a4b-it:free is registered in kiloExclusiveModels
       // with the 'vercel-routing' flag and internal_id 'google/gemma-4-26b-a4b-it'.


### PR DESCRIPTION
## Summary
- add a Martian-routed stealth GPT-5.6 Sol model backed by `openai/gpt-5.6-sol:optimized`
- apply a 20% discount to OpenRouter pricing, including the long-context tier
- add the Kilo-exclusive `meta/muse-spark-1.1` model through Vercel AI Gateway
- cover registry, pricing, provider identity, and Vercel mapping behavior

## Validation
- `pnpm exec oxfmt <changed files>`
- `pnpm exec oxlint --config .oxlintrc.json <changed files>`
- `git diff --check`
- focused Jest files attempted but blocked by unavailable PostgreSQL/Redis test infrastructure before assertions ran