### PR TITLE
fix(ai-gateway): add Meta provider

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -62,11 +62,13 @@ describe('isFreeModel', () => {
     });
 
     test('routes the discounted Claude Opus offering through the stealth provider identity', () => {
-      expect(getInferenceProvider(claude_opus_4_7_stealth_model)).toBe('stealth');
+      expect(getInferenceProvider(claude_opus_4_7_stealth_model)).toMatchObject({ slug: 'stealth' });
       expect(claude_opus_4_7_stealth_model.public_id).toBe('stealth/claude-opus-4.7');
-      expect(getInferenceProvider(claude_sonnet_4_6_stealth_model)).toBe('stealth');
+      expect(getInferenceProvider(claude_sonnet_4_6_stealth_model)).toMatchObject({
+        slug: 'stealth',
+      });
       expect(claude_sonnet_4_6_stealth_model.public_id).toBe('stealth/claude-sonnet-4.6');
-      expect(getInferenceProvider(claude_opus_4_6_stealth_model)).toBe('stealth');
+      expect(getInferenceProvider(claude_opus_4_6_stealth_model)).toMatchObject({ slug: 'stealth' });
       expect(claude_opus_4_6_stealth_model.public_id).toBe('stealth/claude-opus-4.6');
     });
 

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -62,13 +62,11 @@ describe('isFreeModel', () => {
     });
 
     test('routes the discounted Claude Opus offering through the stealth provider identity', () => {
-      expect(getInferenceProvider(claude_opus_4_7_stealth_model)).toMatchObject({ slug: 'stealth' });
+      expect(getInferenceProvider(claude_opus_4_7_stealth_model)?.slug).toBe('stealth');
       expect(claude_opus_4_7_stealth_model.public_id).toBe('stealth/claude-opus-4.7');
-      expect(getInferenceProvider(claude_sonnet_4_6_stealth_model)).toMatchObject({
-        slug: 'stealth',
-      });
+      expect(getInferenceProvider(claude_sonnet_4_6_stealth_model)?.slug).toBe('stealth');
       expect(claude_sonnet_4_6_stealth_model.public_id).toBe('stealth/claude-sonnet-4.6');
-      expect(getInferenceProvider(claude_opus_4_6_stealth_model)).toMatchObject({ slug: 'stealth' });
+      expect(getInferenceProvider(claude_opus_4_6_stealth_model)?.slug).toBe('stealth');
       expect(claude_opus_4_6_stealth_model.public_id).toBe('stealth/claude-opus-4.6');
     });
 

--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
@@ -8,6 +8,7 @@ import {
   isOpenRouterProviderConfig,
   type GatewayRequest,
 } from '@/lib/ai-gateway/providers/openrouter/types';
+import { isMuseModel } from '@/lib/ai-gateway/providers/meta';
 
 export type KiloExclusiveModelFlag =
   | 'reasoning'
@@ -179,12 +180,30 @@ export function applyKiloExclusiveModelSettings(
   }
 }
 
-export function getInferenceProvider(
-  model: KiloExclusiveModel
-): OpenRouterInferenceProviderId | null {
-  if (model.flags.includes('stealth')) return 'stealth';
-  if (model.gateway === 'openrouter' || model.gateway === 'vercel') return null;
-  return OpenRouterInferenceProviderIdSchema.parse(model.gateway);
+type InferenceProvider = {
+  slug: OpenRouterInferenceProviderId;
+  name: string;
+  training: boolean;
+  retainsPrompts: boolean;
+};
+
+export function getInferenceProvider(model: KiloExclusiveModel): InferenceProvider | null {
+  if (model.flags.includes('stealth')) {
+    return { slug: 'stealth', name: 'Stealth', training: true, retainsPrompts: true };
+  }
+  if (isMuseModel(model.public_id)) {
+    return { slug: 'meta', name: 'Meta', training: false, retainsPrompts: true };
+  }
+  if (model.gateway === 'openrouter' || model.gateway === 'vercel') {
+    return null;
+  }
+  const slug = OpenRouterInferenceProviderIdSchema.parse(model.gateway);
+  return {
+    slug,
+    name: slug.toUpperCase(),
+    training: false,
+    retainsPrompts: true,
+  };
 }
 
 function formatPricePerMillionAsPerToken(price: number): string;

--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
@@ -8,7 +8,6 @@ import {
   isOpenRouterProviderConfig,
   type GatewayRequest,
 } from '@/lib/ai-gateway/providers/openrouter/types';
-import { isMuseModel } from '@/lib/ai-gateway/providers/meta';
 
 export type KiloExclusiveModelFlag =
   | 'reasoning'
@@ -191,7 +190,7 @@ export function getInferenceProvider(model: KiloExclusiveModel): InferenceProvid
   if (model.flags.includes('stealth')) {
     return { slug: 'stealth', name: 'Stealth', training: true, retainsPrompts: true };
   }
-  if (isMuseModel(model.public_id)) {
+  if (model.public_id.includes('muse-')) {
     return { slug: 'meta', name: 'Meta', training: false, retainsPrompts: true };
   }
   if (model.gateway === 'openrouter' || model.gateway === 'vercel') {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.ts
@@ -40,6 +40,7 @@ export const OpenRouterInferenceProviderIdSchema = z.enum([
   'liquid',
   'mancer',
   'mara',
+  'meta', // not yet on OpenRouter
   'minimax',
   'mistral',
   'modelrun',
@@ -180,6 +181,7 @@ export const VercelNonUserByokInferenceProviderIdSchema = z.enum([
   'interfaze',
   'klingai',
   'meituan',
+  'meta',
   'morph',
   'nebius',
   'parasail',

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -304,7 +304,9 @@ async function syncProviders(
     });
 
   for (const extraModel of mappedExtraModels) {
-    const providerData = providerModelData.find(data => data.provider.slug === extraModel.provider);
+    const providerData = providerModelData.find(
+      data => data.provider.slug === extraModel.provider.slug
+    );
     if (providerData) {
       console.log(
         `Found existing ${extraModel.provider} provider from OpenRouter, adding extra model ${extraModel.model.slug}`
@@ -347,25 +349,21 @@ async function syncProviders(
   const allProviders = [...normalizedProviders];
 
   // Auto-detect providers referenced by extra models that aren't already present
-  const missingProviderSlugs = new Set(
+  const missingProviders = new Set(
     mappedExtraModels
       .map(m => m.provider)
-      .filter(
-        (slug): slug is NonNullable<typeof slug> =>
-          slug !== null && !allProviders.some(p => p.slug === slug)
-      )
+      .filter(provider => !allProviders.some(p => p.slug === provider.slug))
   );
 
-  for (const providerSlug of missingProviderSlugs) {
-    const displayName = providerSlug.toUpperCase();
-    const iconInitials = providerSlug.slice(0, 2).toUpperCase();
+  for (const provider of missingProviders) {
+    const iconInitials = provider.slug.slice(0, 2).toUpperCase();
     allProviders.push({
-      name: displayName,
-      displayName,
-      slug: providerSlug,
+      name: provider.name,
+      displayName: provider.name,
+      slug: provider.slug,
       dataPolicy: {
-        training: true,
-        retainsPrompts: true,
+        training: provider.training,
+        retainsPrompts: provider.retainsPrompts,
         canPublish: false,
       },
       headquarters: 'Unknown',
@@ -374,7 +372,7 @@ async function syncProviders(
         url: `https://placehold.co/100?text=${iconInitials}&font=roboto`,
         className: 'rounded-sm',
       },
-      models: mappedExtraModels.filter(m => m.provider === providerSlug).map(m => m.model),
+      models: mappedExtraModels.filter(m => m.provider.slug === provider.slug).map(m => m.model),
     });
   }
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -349,13 +349,14 @@ async function syncProviders(
   const allProviders = [...normalizedProviders];
 
   // Auto-detect providers referenced by extra models that aren't already present
-  const missingProviders = new Set(
+  const missingProviders = new Map(
     mappedExtraModels
       .map(m => m.provider)
       .filter(provider => !allProviders.some(p => p.slug === provider.slug))
+      .map(provider => [provider.slug, provider])
   );
 
-  for (const provider of missingProviders) {
+  for (const provider of missingProviders.values()) {
     const iconInitials = provider.slug.slice(0, 2).toUpperCase();
     allProviders.push({
       name: provider.name,


### PR DESCRIPTION
## Summary
- preserve provider names and data policies when synthesizing Kilo-exclusive inference providers
- classify Muse models under Meta without introducing a provider module dependency cycle
- deduplicate synthetic providers by slug while retaining one metadata object per provider

## Validation
- `pnpm --filter web run typecheck`
- `pnpm --filter web run dependency-cycle-check`
- targeted oxlint and oxfmt checks
- `git diff --check`