### PR TITLE
fix(byok): make coding plan keys read-only

### DIFF
--- a/.specs/coding-plans.md
+++ b/.specs/coding-plans.md
@@ -6,7 +6,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Definitions
 
-**Coding Plan** - A recurring subscription product that grants a user access through Kilo to an upstream provider plan by installing its issued credential in the user's existing personal BYOK provider slot. A user's later BYOK changes do not alter Coding Plan billing.
+**Coding Plan** - A recurring subscription product that grants a user access through Kilo to an upstream provider plan by installing its issued credential in the user's existing personal BYOK provider slot.
 
 **Plan Catalog** - The set of Coding Plan offerings enabled by Kilo. The catalog is controlled by trusted application configuration and may contain one or more offerings.
 
@@ -16,7 +16,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 **Managed Plan Credential** - An upstream API key acquired or provisioned by Kilo for a Coding Plan. Kilo manages its assignment and revocation. It is paired with an Upstream Plan ID and is not exposed to the subscriber after it is installed in BYOK.
 
-**Installed BYOK Configuration** - A normal personal BYOK entry that Kilo initially populates with a Managed Plan Credential. While unchanged, it identifies the subscriber's MiniMax token plan as its origin and Kilo deletes it at Effective Cancellation. A subscriber may test, enable, disable, or update it using normal BYOK operations, but **MUST NOT** delete it directly while it remains Kilo-managed; it is removed by cancelling the plan in the Subscription Center. Replacing its credential transfers cleanup ownership to the subscriber and makes the resulting user-managed key deletable through normal BYOK operations.
+**Installed BYOK Configuration** - A read-only personal BYOK entry that Kilo populates with a Managed Plan Credential. It identifies the subscriber's MiniMax token plan as its origin, may be tested without changing its configuration, and is deleted by Kilo at Effective Cancellation. A subscriber **MUST NOT** update, enable, disable, or delete it through ordinary BYOK operations.
 
 **Availability Notification Intent** - A user's plan-scoped request to be notified when a sold-out Coding Plan has capacity again. It is not a reservation, purchase, subscription, or entitlement.
 
@@ -72,7 +72,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 3.4. On activation, Kilo **MUST** configure an Installed BYOK Configuration in the ordinary personal provider slot so eligible traffic can use the plan through the Kilo Gateway. Activation **MUST** fail without charge or assignment if that provider slot is occupied, including by a disabled key.
 
-3.5. While an Installed BYOK Configuration still contains Kilo's issued credential, user-facing BYOK surfaces **MUST** identify its Coding Plan origin. Ordinary BYOK test, enable/disable, and update operations **MUST** remain available. A direct delete of a Kilo-managed Installed BYOK Configuration **MUST** be rejected so a removed routing key cannot strand a still-billed subscription; the surface **MUST** direct the user to cancel the plan in the Subscription Center, which removes the configuration at Effective Cancellation. Before updating or disabling that configuration, Kilo **MUST** warn that the operation changes routing but does not cancel subscription billing and **MUST** direct cancellation to the Subscription Center. Updating the credential **MUST** mark the entry as user-managed, detach it from later Coding Plan cleanup, and restore ordinary delete for the resulting user-managed key. Testing or re-enabling the key does not require this warning.
+3.5. An Installed BYOK Configuration **MUST** remain read-only while it contains Kilo's issued credential. User-facing BYOK surfaces **MUST** identify its Coding Plan origin and **MUST NOT** offer update, enable/disable, or delete controls. The corresponding API operations **MUST** reject attempts to mutate it. Non-mutating credential testing **MAY** remain available. The surface **MUST** direct users who want the configuration removed to cancel the plan in the Subscription Center, which removes it at Effective Cancellation.
 
 ## 4. Credential provisioning and inventory
 
@@ -98,9 +98,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## 5. Subscription lifecycle
 
-5.1. A Coding Plan with successful activation enters `active` state and remains billable until its paid period ends or it is terminated immediately under this section. A subscriber's BYOK updates or disablement, or deletion of a user-managed replacement key, **MUST NOT** change that billing lifecycle.
+5.1. A Coding Plan with successful activation enters `active` state and remains billable until its paid period ends or it is terminated immediately under this section.
 
-5.2. When a user requests cancellation, the subscription **MUST** stop renewing and **MUST** remain paid through the end of its current period. On the first billing lifecycle sweep processing the subscription at or after Effective Cancellation, Kilo **MUST** delete its Installed BYOK Configuration only if that configuration is still linked and Kilo-installed, and **MUST** create a Manual Revocation Work Item for the originally issued credential. Kilo **MUST NOT** delete a replacement or later user-created provider key.
+5.2. When a user requests cancellation, the subscription **MUST** stop renewing and **MUST** remain paid through the end of its current period. On the first billing lifecycle sweep processing the subscription at or after Effective Cancellation, Kilo **MUST** delete its Installed BYOK Configuration only if that configuration is still linked and Kilo-installed, and **MUST** create a Manual Revocation Work Item for the originally issued credential. Kilo **MUST NOT** delete a separate user-created provider key.
 
 5.3. An uninterrupted successful renewal **MUST** extend paid access using the existing assigned credential. The system **MUST** debit the snapshotted renewal price atomically with recording the new charged term.
 
@@ -110,7 +110,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 5.6. During the `past_due` recovery period, arrival of sufficient credits before the stored grace deadline **MUST** allow one atomic renewal debit and restore `active` status. If renewal cannot be funded by that deadline, the next billing lifecycle sweep **MUST** terminate the subscription, delete only a still-linked Installed BYOK Configuration, and create a Manual Revocation Work Item for the issued credential.
 
-5.7. A user-requested cancellation **MUST NOT** trigger auto-top-up. Updating or disabling an Installed BYOK Configuration, or deleting a user-managed replacement key, **MUST NOT** trigger cancellation or affect renewal billing.
+5.7. A user-requested cancellation **MUST NOT** trigger auto-top-up.
 
 5.8. When a user account is deleted, Kilo **MUST** immediately terminate any Coding Plan subscription, delete the user's BYOK configurations and Availability Notification Intents under the general deletion policy, create a Manual Revocation Work Item for each issued credential, and anonymize subscriber linkage in retained credential disposition records. Account deletion **MUST NOT** wait until the end of a prepaid period. Subscription and charged-term history **MAY** remain associated with the platform's anonymized user record when required for financial or compliance retention.
 
@@ -122,9 +122,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 6.1. Initial MiniMax Coding Plan setup **MUST** route through the Kilo Gateway using the existing ordinary personal MiniMax BYOK provider identity. The initial release **MUST NOT** expose saved raw credential values through Kilo UI or API responses.
 
-6.2. The system **MUST NOT** add a MiniMax Coding Plan-specific provider or model-routing namespace. The Kilo-installed MiniMax key and any later subscriber replacement **MUST** use ordinary MiniMax BYOK routing and model availability.
+6.2. The system **MUST NOT** add a MiniMax Coding Plan-specific provider or model-routing namespace. The Kilo-installed MiniMax key **MUST** use ordinary MiniMax BYOK routing and model availability.
 
-6.3. Purchase **MUST** reject an occupied personal MiniMax BYOK slot before a charge or issued credential assignment commits. Once subscribed, a user's ordinary MiniMax BYOK actions affect routing configuration only; Coding Plan billing and revocation of Kilo's originally issued credential remain independent.
+6.3. Purchase **MUST** reject an occupied personal MiniMax BYOK slot before a charge or issued credential assignment commits. Once subscribed, the Installed BYOK Configuration **MUST** remain read-only until Kilo removes it at Effective Cancellation.
 
 ## 7. User-facing behavior
 
@@ -132,11 +132,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 7.2. Coding Plan surfaces **MUST** display recurring prices and charged-term amounts in USD regardless of payment source. Kilo Credits are valued one-to-one with USD for display. Surfaces **MUST** identify `Credits` as the payment source for credit-funded subscriptions and **MUST NOT** expose internal microdollars.
 
-7.3. While an Installed BYOK Configuration is unchanged, the BYOK surface **MUST** identify it as configured by the subscriber's MiniMax token plan. Before updating or disabling it, the surface **MUST** warn that routing changes do not cancel subscription billing and direct the user to Subscription Center to cancel. A delete attempt on the Kilo-managed configuration **MUST** be blocked with a message that directs the user to cancel the plan in the Subscription Center. Saved raw-key view or copy controls **MUST NOT** be added for customer BYOK surfaces.
+7.3. The BYOK surface **MUST** identify an Installed BYOK Configuration as managed by the subscriber's MiniMax token plan and read-only. It **MUST NOT** offer update, enable/disable, delete, saved raw-key view, or copy controls. Non-mutating credential testing **MAY** remain available. The surface **MUST** direct users to the Subscription Center to cancel the plan and remove the configuration at Effective Cancellation.
 
 7.4. Purchase messaging **MUST** state that Kilo configures MiniMax in BYOK and **MUST** tell users with an existing user-managed MiniMax key to delete it before subscribing. Cancellation messaging **MUST** state when billing ends, that Kilo deletes only its unchanged installed configuration, and that Kilo revokes its issued credential when plan access ends.
 
-7.5. A `past_due` subscription **MUST** communicate its grace deadline with date and local time, the consequence of unsuccessful payment recovery, and that a replacement or user-created MiniMax BYOK key is not deleted by Coding Plan termination.
+7.5. A `past_due` subscription **MUST** communicate its grace deadline with date and local time, the consequence of unsuccessful payment recovery, and that a separate user-created MiniMax BYOK key is not deleted by Coding Plan termination.
 
 7.6. A sold-out offering **MUST** display its unavailable state and **MUST** offer an authenticated user a way to record an Availability Notification Intent. Recording the same intent again **MUST** be idempotent, **MUST NOT** reserve capacity or initiate billing, and **MUST** show the saved intent state. A successful activation **MUST** clear the activated user's intent for that Plan ID.
 

--- a/.specs/subscription-center.md
+++ b/.specs/subscription-center.md
@@ -299,12 +299,11 @@ historical Commit names, prices, invoices, and credit deductions.
     - Inline billing history showing credit transactions with amounts in USD
       (see Billing History rules)
 
-    Before update or disable, `/byok` MUST warn that routing changes do not
-    cancel or pause MiniMax token plan billing and cancellation is managed in
-    Subscription Center. `/byok` MUST block a direct delete of the Kilo-managed
-    installed key and direct the user to cancel the plan in Subscription Center,
-    which removes it at Effective Cancellation; customer surfaces MUST NOT
-    include saved raw-key view or copy controls.
+    `/byok` MUST identify the Kilo-managed installed key as read-only and MUST
+    NOT offer update, enable/disable, delete, saved raw-key view, or copy
+    controls. Non-mutating credential testing MAY remain available. `/byok` MUST
+    direct users to cancel the plan in Subscription Center to remove the key at
+    Effective Cancellation.
 
 31. Coding Plan cancellation, installed MiniMax configuration cleanup,
     and issued-credential revocation MUST follow `.specs/coding-plans.md`.
@@ -471,6 +470,11 @@ not yet enforced in the current codebase:
    the current plan and seat count without management actions.
 
 ## Changelog
+
+### 2026-07-14 -- Coding Plans installed keys made read-only
+
+- Made Kilo-managed installed MiniMax keys read-only in BYOK surfaces and APIs; users can still run a non-mutating credential test.
+- Kept cancellation as the user path for removing the managed configuration at Effective Cancellation.
 
 ### 2026-07-01 -- Coding Plans installed-key deletion blocked
 

--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useReducer, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { useTRPC } from '@/lib/trpc/utils';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/Button';
@@ -12,16 +11,6 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { useConfirm } from '@/components/ui/confirm';
 import {
   Select,
@@ -104,9 +93,8 @@ function BYOKDescription({ showsCodingPlanKey = false }: { showsCodingPlanKey?: 
       <p>Keys you create here use provider billing instead of your Kilo balance.</p>
       {showsCodingPlanKey ? (
         <p>
-          The MiniMax Coding Plan configured your MiniMax key using Kilo Credits. Updating,
-          disabling, or deleting that key changes routing only; subscription billing continues until
-          canceled in Subscriptions.
+          The MiniMax Coding Plan configured your MiniMax key using Kilo Credits. This managed key
+          is read-only. Cancel the plan in Subscriptions to remove it when the plan ends.
         </p>
       ) : null}
     </div>
@@ -156,11 +144,6 @@ type BYOKKeysManagerProps = {
   organizationId?: string;
 };
 
-type InstalledKeyWarningAction =
-  | { type: 'disable'; keyId: string }
-  | { type: 'update'; keyId: string }
-  | { type: 'delete'; keyId: string };
-
 type BYOKDialogState = {
   isDialogOpen: boolean;
   editingKeyId: string | null;
@@ -168,7 +151,6 @@ type BYOKDialogState = {
   apiKey: string;
   showApiKey: boolean;
   awsCredentialError: string | null;
-  installedKeyWarningAction: InstalledKeyWarningAction | null;
 };
 
 const INITIAL_BYOK_DIALOG_STATE: BYOKDialogState = {
@@ -178,7 +160,6 @@ const INITIAL_BYOK_DIALOG_STATE: BYOKDialogState = {
   apiKey: '',
   showApiKey: false,
   awsCredentialError: null,
-  installedKeyWarningAction: null,
 };
 
 function updateBYOKDialogState(state: BYOKDialogState, update: Partial<BYOKDialogState>) {
@@ -190,15 +171,8 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
     updateBYOKDialogState,
     INITIAL_BYOK_DIALOG_STATE
   );
-  const {
-    isDialogOpen,
-    editingKeyId,
-    selectedProvider,
-    apiKey,
-    showApiKey,
-    awsCredentialError,
-    installedKeyWarningAction,
-  } = dialogState;
+  const { isDialogOpen, editingKeyId, selectedProvider, apiKey, showApiKey, awsCredentialError } =
+    dialogState;
   const setIsDialogOpen = (isDialogOpen: boolean) => updateDialogState({ isDialogOpen });
   const setEditingKeyId = (editingKeyId: string | null) => updateDialogState({ editingKeyId });
   const setSelectedProvider = (selectedProvider: string) => updateDialogState({ selectedProvider });
@@ -206,13 +180,8 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
   const setShowApiKey = (showApiKey: boolean) => updateDialogState({ showApiKey });
   const setAwsCredentialError = (awsCredentialError: string | null) =>
     updateDialogState({ awsCredentialError });
-  const setInstalledKeyWarningAction = (
-    installedKeyWarningAction: InstalledKeyWarningAction | null
-  ) => updateDialogState({ installedKeyWarningAction });
-
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const router = useRouter();
   const confirm = useConfirm();
 
   // Build query options - only include organizationId if provided
@@ -306,10 +275,6 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
     return keys?.some(k => k.provider_id === providerSlug) ?? false;
   };
 
-  const isInstalledCodingPlanKey = (keyId: string) =>
-    !organizationId &&
-    (keys?.some(key => key.id === keyId && key.management_source === 'coding_plan') ?? false);
-
   const validateAwsCredentials = (value: string): string | null => {
     if (!value) return null;
     let parsed: unknown;
@@ -341,10 +306,6 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
       if (error) return;
     }
     if (editingKeyId) {
-      if (isInstalledCodingPlanKey(editingKeyId)) {
-        setInstalledKeyWarningAction({ type: 'update', keyId: editingKeyId });
-        return;
-      }
       updateMutation.mutate({
         ...(organizationId && { organizationId }),
         id: editingKeyId,
@@ -374,10 +335,6 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
   };
 
   const handleDelete = async (keyId: string, providerName: string) => {
-    if (isInstalledCodingPlanKey(keyId)) {
-      setInstalledKeyWarningAction({ type: 'delete', keyId });
-      return;
-    }
     if (
       await confirm({
         title: `Delete the ${providerName} API key?`,
@@ -391,33 +348,11 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
   };
 
   const handleToggleEnabled = (keyId: string, is_enabled: boolean) => {
-    if (!is_enabled && isInstalledCodingPlanKey(keyId)) {
-      setInstalledKeyWarningAction({ type: 'disable', keyId });
-      return;
-    }
     setEnabledMutation.mutate({
       ...(organizationId && { organizationId }),
       id: keyId,
       is_enabled,
     });
-  };
-
-  const confirmInstalledKeyChange = () => {
-    if (!installedKeyWarningAction) return;
-
-    if (installedKeyWarningAction.type === 'update') {
-      updateMutation.mutate({
-        id: installedKeyWarningAction.keyId,
-        api_key: apiKey,
-      });
-    } else if (installedKeyWarningAction.type === 'delete') {
-      // A coding-plan-managed key can't be deleted directly; it is removed by
-      // cancelling the plan in the Subscription Center.
-      router.push('/subscriptions');
-    } else {
-      setEnabledMutation.mutate({ id: installedKeyWarningAction.keyId, is_enabled: false });
-    }
-    setInstalledKeyWarningAction(null);
   };
 
   if (keysLoading) {
@@ -441,39 +376,6 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
     );
   }
 
-  function getInstalledKeyWarning(action: InstalledKeyWarningAction | null): {
-    title: string;
-    description: string;
-    actionLabel: string;
-    cancelLabel: string;
-  } {
-    if (action?.type === 'update') {
-      return {
-        title: 'Replace MiniMax Coding Plan key?',
-        description:
-          'Replacing this key changes MiniMax routing and makes it user-managed. MiniMax Coding Plan billing continues until you cancel it in Subscription Center.',
-        actionLabel: 'Replace key',
-        cancelLabel: 'Keep configuration',
-      };
-    }
-    if (action?.type === 'delete') {
-      return {
-        title: 'This key is managed by your coding plan',
-        description:
-          'This MiniMax key routes your MiniMax token plan, so it can\u2019t be deleted here. To remove it, cancel the plan in Subscription Center. Your plan stays active and billed until you cancel.',
-        actionLabel: 'Go to Subscription Center',
-        cancelLabel: 'Close',
-      };
-    }
-    return {
-      title: 'Disable MiniMax Coding Plan key?',
-      description:
-        'Disabling this key stops MiniMax routing while it is disabled. MiniMax Coding Plan billing continues until you cancel it in Subscription Center.',
-      actionLabel: 'Disable key',
-      cancelLabel: 'Keep configuration',
-    };
-  }
-
   // Map provider IDs to display names
   const getProviderDisplayName = (providerId: string) => {
     const provider = BYOK_PROVIDERS.find(p => p.id === providerId);
@@ -483,8 +385,6 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
   const getProviderModels = (providerId: string): string[] => {
     return supportedModels?.[providerId] ?? [];
   };
-  const installedKeyWarning = getInstalledKeyWarning(installedKeyWarningAction);
-
   return (
     <div className="space-y-4">
       <BYOKDescription showsCodingPlanKey={showsCodingPlanKey} />
@@ -518,82 +418,92 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
                       created_at: string;
                       management_source: 'user' | 'coding_plan';
                       is_enabled: boolean;
-                    }) => (
-                      <tr
-                        key={key.id}
-                        className={
-                          !key.is_enabled
-                            ? 'bg-muted/20 border-b last:border-0'
-                            : 'border-b last:border-0'
-                        }
-                      >
-                        <td className={!key.is_enabled ? 'text-muted-foreground p-4' : 'p-4'}>
-                          <div>{getProviderDisplayName(key.provider_id)}</div>
-                          {!organizationId &&
-                          key.provider_id === 'minimax' &&
-                          key.management_source === 'coding_plan' ? (
-                            <p className="text-muted-foreground mt-1 text-xs">
-                              Configured by MiniMax Coding Plan. BYOK changes do not cancel
-                              subscription billing.
-                            </p>
-                          ) : null}
-                          <SupportedModelsList models={getProviderModels(key.provider_id)} />
-                        </td>
-                        <td className="text-muted-foreground p-4">
-                          {new Date(key.created_at).toLocaleDateString()}
-                        </td>
-                        <td className="p-4">
-                          <div className="flex items-center gap-3">
-                            <Switch
-                              checked={key.is_enabled}
-                              onCheckedChange={isEnabled => handleToggleEnabled(key.id, isEnabled)}
-                              disabled={setEnabledMutation.isPending}
-                              aria-label={`Toggle ${getProviderDisplayName(key.provider_id)} BYOK key`}
-                            />
-                            <span className="text-sm">
-                              {key.is_enabled ? 'Enabled' : 'Disabled'}
-                            </span>
-                          </div>
-                        </td>
-                        <td className="space-x-2 p-4 text-right">
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            onClick={() =>
-                              testMutation.mutate({
-                                ...(organizationId && { organizationId }),
-                                id: key.id,
-                              })
-                            }
-                            disabled={testMutation.isPending}
-                            title="Test API key"
-                            aria-label={`Test ${getProviderDisplayName(key.provider_id)} API key`}
-                          >
-                            <FlaskConical className="size-4" />
-                          </Button>
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            onClick={() => handleEdit(key.id)}
-                            disabled={updateMutation.isPending}
-                            aria-label={`Update ${getProviderDisplayName(key.provider_id)} API key`}
-                          >
-                            <Edit className="size-4" />
-                          </Button>
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            onClick={() =>
-                              handleDelete(key.id, getProviderDisplayName(key.provider_id))
-                            }
-                            disabled={deleteMutation.isPending}
-                            aria-label={`Delete ${getProviderDisplayName(key.provider_id)} API key`}
-                          >
-                            <Trash2 className="size-4" />
-                          </Button>
-                        </td>
-                      </tr>
-                    )
+                    }) => {
+                      const isManaged = !organizationId && key.management_source === 'coding_plan';
+                      return (
+                        <tr
+                          key={key.id}
+                          className={
+                            !key.is_enabled
+                              ? 'bg-muted/20 border-b last:border-0'
+                              : 'border-b last:border-0'
+                          }
+                        >
+                          <td className={!key.is_enabled ? 'text-muted-foreground p-4' : 'p-4'}>
+                            <div>{getProviderDisplayName(key.provider_id)}</div>
+                            {!organizationId &&
+                            key.provider_id === 'minimax' &&
+                            key.management_source === 'coding_plan' ? (
+                              <p className="text-muted-foreground mt-1 text-xs">
+                                Managed by MiniMax Coding Plan. This key is read-only.
+                              </p>
+                            ) : null}
+                            <SupportedModelsList models={getProviderModels(key.provider_id)} />
+                          </td>
+                          <td className="text-muted-foreground p-4">
+                            {new Date(key.created_at).toLocaleDateString()}
+                          </td>
+                          <td className="p-4">
+                            <div className="flex items-center gap-3">
+                              {!isManaged ? (
+                                <Switch
+                                  checked={key.is_enabled}
+                                  onCheckedChange={isEnabled =>
+                                    handleToggleEnabled(key.id, isEnabled)
+                                  }
+                                  disabled={setEnabledMutation.isPending}
+                                  aria-label={`Toggle ${getProviderDisplayName(key.provider_id)} BYOK key`}
+                                />
+                              ) : null}
+                              <span className="text-sm">
+                                {key.is_enabled ? 'Enabled' : 'Disabled'}
+                              </span>
+                            </div>
+                          </td>
+                          <td className="space-x-2 p-4 text-right">
+                            <Button
+                              variant="secondary"
+                              size="sm"
+                              onClick={() =>
+                                testMutation.mutate({
+                                  ...(organizationId && { organizationId }),
+                                  id: key.id,
+                                })
+                              }
+                              disabled={testMutation.isPending}
+                              title="Test API key"
+                              aria-label={`Test ${getProviderDisplayName(key.provider_id)} API key`}
+                            >
+                              <FlaskConical className="size-4" />
+                            </Button>
+                            {!isManaged ? (
+                              <>
+                                <Button
+                                  variant="secondary"
+                                  size="sm"
+                                  onClick={() => handleEdit(key.id)}
+                                  disabled={updateMutation.isPending}
+                                  aria-label={`Update ${getProviderDisplayName(key.provider_id)} API key`}
+                                >
+                                  <Edit className="size-4" />
+                                </Button>
+                                <Button
+                                  variant="secondary"
+                                  size="sm"
+                                  onClick={() =>
+                                    handleDelete(key.id, getProviderDisplayName(key.provider_id))
+                                  }
+                                  disabled={deleteMutation.isPending}
+                                  aria-label={`Delete ${getProviderDisplayName(key.provider_id)} API key`}
+                                >
+                                  <Trash2 className="size-4" />
+                                </Button>
+                              </>
+                            ) : null}
+                          </td>
+                        </tr>
+                      );
+                    }
                   )}
                 </tbody>
               </table>
@@ -824,23 +734,6 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
             </DialogFooter>
           </DialogContent>
         </Dialog>
-        <AlertDialog
-          open={installedKeyWarningAction !== null}
-          onOpenChange={open => !open && setInstalledKeyWarningAction(null)}
-        >
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>{installedKeyWarning.title}</AlertDialogTitle>
-              <AlertDialogDescription>{installedKeyWarning.description}</AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>{installedKeyWarning.cancelLabel}</AlertDialogCancel>
-              <AlertDialogAction variant="default" onClick={confirmInstalledKeyChange}>
-                {installedKeyWarning.actionLabel}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
         <CardFooter>
           <BYOKSetupGuideLink />
         </CardFooter>

--- a/apps/web/src/routers/byok-router.test.ts
+++ b/apps/web/src/routers/byok-router.test.ts
@@ -554,38 +554,53 @@ describe('BYOK Router', () => {
       return { key, subscription };
     }
 
-    test('identifies installed origin and allows disable without affecting ownership', async () => {
+    test('identifies installed origin and blocks changing enabled state', async () => {
       const { key } = await createInstalledMiniMaxKey();
       const caller = await createCallerForUser(ownerUser.id);
       const listed = await caller.byok.list({});
 
       expect(listed[0].provider_id).toBe('minimax');
       expect(listed[0].management_source).toBe('coding_plan');
-      const disabled = await caller.byok.setEnabled({ id: key.id, is_enabled: false });
-      expect(disabled.is_enabled).toBe(false);
-      expect(disabled.management_source).toBe('coding_plan');
+      await expect(caller.byok.setEnabled({ id: key.id, is_enabled: false })).rejects.toThrow(
+        /read-only/i
+      );
+
+      const [unchangedKey] = await db
+        .select()
+        .from(byok_api_keys)
+        .where(eq(byok_api_keys.id, key.id));
+      expect(unchangedKey.is_enabled).toBe(true);
+      expect(unchangedKey.management_source).toBe('coding_plan');
     });
 
-    test('transfers cleanup ownership when installed MiniMax credential is updated', async () => {
+    test('blocks replacing an installed MiniMax credential', async () => {
       const { key, subscription } = await createInstalledMiniMaxKey();
       const caller = await createCallerForUser(ownerUser.id);
 
-      const updated = await caller.byok.update({ id: key.id, api_key: 'replacement-key' });
+      await expect(caller.byok.update({ id: key.id, api_key: 'replacement-key' })).rejects.toThrow(
+        /read-only/i
+      );
+
+      const [unchangedKey] = await db
+        .select()
+        .from(byok_api_keys)
+        .where(eq(byok_api_keys.id, key.id));
       const [updatedSubscription] = await db
         .select()
         .from(coding_plan_subscriptions)
         .where(eq(coding_plan_subscriptions.id, subscription.id));
 
-      expect(updated.management_source).toBe('user');
+      expect(unchangedKey.encrypted_api_key).toBe(key.encrypted_api_key);
+      expect(unchangedKey.management_source).toBe('coding_plan');
       expect(updatedSubscription.status).toBe('active');
-      expect(updatedSubscription.installed_byok_key_id).toBeNull();
+      expect(updatedSubscription.installed_byok_key_id).toBe(key.id);
     });
 
     test('blocks deleting an installed coding-plan MiniMax key', async () => {
       const { key, subscription } = await createInstalledMiniMaxKey();
       const caller = await createCallerForUser(ownerUser.id);
 
-      await expect(caller.byok.delete({ id: key.id })).rejects.toThrow(/coding plan/i);
+      await expect(caller.byok.delete({ id: key.id })).rejects.toThrow(/read-only/i);
 
       const remainingKeys = await db
         .select()

--- a/apps/web/src/routers/byok-router.test.ts
+++ b/apps/web/src/routers/byok-router.test.ts
@@ -590,7 +590,7 @@ describe('BYOK Router', () => {
         .from(coding_plan_subscriptions)
         .where(eq(coding_plan_subscriptions.id, subscription.id));
 
-      expect(unchangedKey.encrypted_api_key).toBe(key.encrypted_api_key);
+      expect(unchangedKey.encrypted_api_key).toStrictEqual(key.encrypted_api_key);
       expect(unchangedKey.management_source).toBe('coding_plan');
       expect(updatedSubscription.status).toBe('active');
       expect(updatedSubscription.installed_byok_key_id).toBe(key.id);

--- a/apps/web/src/routers/byok-router.ts
+++ b/apps/web/src/routers/byok-router.ts
@@ -4,11 +4,7 @@ import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
 import { db } from '@/lib/drizzle';
 import { sentryLogger } from '@/lib/utils.server';
-import {
-  byok_api_keys,
-  coding_plan_subscriptions,
-  MODELS_BY_PROVIDER_ADMIN_URL,
-} from '@kilocode/db/schema';
+import { byok_api_keys, MODELS_BY_PROVIDER_ADMIN_URL } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import { encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
 import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
@@ -49,7 +45,18 @@ const CODESTRAL_FIM_URL = 'https://codestral.mistral.ai/v1/fim/completions';
 const CODESTRAL_TEST_MODEL = 'codestral-2508';
 const GENERIC_TEST_FAILURE_MESSAGE =
   'API key test failed. Check the credential and supported models, then try again.';
+const MANAGED_KEY_READ_ONLY_MESSAGE =
+  'This key is managed by your coding plan and is read-only. Cancel the coding plan to remove it.';
 const logByokWarning = sentryLogger('byok-key-test', 'warning');
+
+function rejectManagedKeyMutation(managementSource: 'user' | 'coding_plan') {
+  if (managementSource === 'coding_plan') {
+    throw new TRPCError({
+      code: 'CONFLICT',
+      message: MANAGED_KEY_READ_ONLY_MESSAGE,
+    });
+  }
+}
 
 async function testCodestralApiKey(apiKey: string): Promise<{ success: boolean; message: string }> {
   try {
@@ -278,40 +285,26 @@ export const byokRouter = createTRPCRouter({
         }
       }
 
+      rejectManagedKeyMutation(existingKey.management_source);
+
       const encrypted = encryptApiKey(api_key, BYOK_ENCRYPTION_KEY);
-      const transfersCodingPlanOwnership =
-        !organizationId && existingKey.management_source === 'coding_plan';
+      const [updatedKey] = await db
+        .update(byok_api_keys)
+        .set({ encrypted_api_key: encrypted })
+        .where(eq(byok_api_keys.id, id))
+        .returning({
+          id: byok_api_keys.id,
+          provider_id: byok_api_keys.provider_id,
+          created_at: byok_api_keys.created_at,
+          updated_at: byok_api_keys.updated_at,
+          created_by: byok_api_keys.created_by,
+          management_source: byok_api_keys.management_source,
+          is_enabled: byok_api_keys.is_enabled,
+        });
 
-      const updatedKey = await db.transaction(async tx => {
-        const [updated] = await tx
-          .update(byok_api_keys)
-          .set(
-            transfersCodingPlanOwnership
-              ? { encrypted_api_key: encrypted, management_source: 'user' }
-              : { encrypted_api_key: encrypted }
-          )
-          .where(eq(byok_api_keys.id, id))
-          .returning({
-            id: byok_api_keys.id,
-            provider_id: byok_api_keys.provider_id,
-            created_at: byok_api_keys.created_at,
-            updated_at: byok_api_keys.updated_at,
-            created_by: byok_api_keys.created_by,
-            management_source: byok_api_keys.management_source,
-            is_enabled: byok_api_keys.is_enabled,
-          });
-
-        if (!updated) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: 'BYOK key not found' });
-        }
-        if (transfersCodingPlanOwnership) {
-          await tx
-            .update(coding_plan_subscriptions)
-            .set({ installed_byok_key_id: null })
-            .where(eq(coding_plan_subscriptions.installed_byok_key_id, id));
-        }
-        return updated;
-      });
+      if (!updatedKey) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'BYOK key not found' });
+      }
 
       // Create audit log only for organization keys
       if (existingKey.organization_id) {
@@ -373,6 +366,8 @@ export const byokRouter = createTRPCRouter({
           });
         }
       }
+
+      rejectManagedKeyMutation(existingKey.management_source);
 
       const [updatedKey] = await db
         .update(byok_api_keys)
@@ -554,16 +549,7 @@ export const byokRouter = createTRPCRouter({
         }
       }
 
-      // Coding-plan-managed keys are user-scoped and back a billed subscription.
-      // Deleting one here would orphan the subscription (FK is set-null) while it
-      // keeps billing. Require cancelling the coding plan instead.
-      if (!organizationId && existingKey.management_source === 'coding_plan') {
-        throw new TRPCError({
-          code: 'CONFLICT',
-          message:
-            "This key is managed by your coding plan and can't be deleted directly. Cancel the coding plan to remove it.",
-        });
-      }
+      rejectManagedKeyMutation(existingKey.management_source);
 
       // Delete from database
       await db.delete(byok_api_keys).where(eq(byok_api_keys.id, id));

--- a/apps/web/src/routers/coding-plans-router.test.ts
+++ b/apps/web/src/routers/coding-plans-router.test.ts
@@ -278,10 +278,9 @@ describe('coding plans router', () => {
     if (!installedKey) {
       throw new Error('Expected Coding Plan activation to install a BYOK key');
     }
-    await ownerCaller.byok.update({ id: installedKey.id, api_key: 'owner-replacement-key' });
     await expect(
       ownerCaller.codingPlans.getSubscriptionDetail({ subscriptionId: activation.subscriptionId })
-    ).resolves.toMatchObject({ hasInstalledByokKey: false });
+    ).resolves.toMatchObject({ hasInstalledByokKey: true });
 
     await expect(
       otherCaller.codingPlans.getSubscriptionDetail({ subscriptionId: activation.subscriptionId })


### PR DESCRIPTION
## Summary

Make Kilo-managed Coding Plan BYOK keys read-only while preserving non-mutating credential testing.

### Why this change is needed

Coding Plan credentials are issued and managed by Kilo, but users could previously replace or disable the installed key. That could break managed routing or transfer cleanup ownership while the subscription remained active.

### How this is addressed

- Reject update, enable/disable, and delete requests for Coding Plan-managed keys at the API boundary.
- Present managed keys as read-only and remove their mutation controls from the BYOK UI.
- Keep credential testing available because it does not change the stored configuration.
- Align the Coding Plans and Subscription Center specifications with the read-only contract.
- Update router coverage to verify rejected mutations preserve the key and subscription link.

## Human Verification

- Completed an eight-focus local code review against a validated Review Packet.
- Re-reviewed the corrected Subscription Center rule and confirmed it matches the Coding Plans contract, UI behavior, and API guards.

## Reviewer Notes

### Human Reviewer Flags

- This changes the Coding Plan contract: managed keys can no longer be replaced, enabled, disabled, or deleted through ordinary BYOK operations.
- Credential testing intentionally remains available because it is non-mutating.
- Existing managed keys that were disabled under the previous behavior need rollout consideration: after this change, users cannot re-enable them through BYOK.
- Focused database-backed tests could not initialize locally because PostgreSQL was unavailable.

### Code Reviewer Agent

<details>
<summary>Code Reviewer Notes</summary>

- The mutation guard runs after ownership checks and before writes.
- Cancellation and trusted lifecycle cleanup remain responsible for deleting managed keys.
- Security, logic, types, resources, style, and React review focuses passed after the approved spec correction.
- A focused component test for managed-row controls remains a deferred Minor test finding.

</details>
