### PR TITLE
fix(kilo-pass): reconcile stale scheduled changes

### DIFF
--- a/apps/web/src/lib/kilo-pass/scheduled-change-release.ts
+++ b/apps/web/src/lib/kilo-pass/scheduled-change-release.ts
@@ -3,7 +3,7 @@ import 'server-only';
 import { kilo_pass_scheduled_changes } from '@kilocode/db/schema';
 import { auto_deleted_at } from '@/lib/drizzle';
 import type { DrizzleTransaction, db as defaultDb } from '@/lib/drizzle';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, inArray, isNull, not } from 'drizzle-orm';
 
 import {
   KiloPassAuditLogAction,
@@ -18,8 +18,43 @@ type DbOrTx = Db | DrizzleTransaction;
 export type StripeSubscriptionSchedulesClient = {
   subscriptionSchedules: {
     release: (scheduleId: string) => Promise<unknown>;
+    retrieve?: (scheduleId: string) => Promise<{ status: string }>;
   };
 };
+
+export const KILO_PASS_TERMINAL_SCHEDULE_STATUSES = [
+  KiloPassScheduledChangeStatus.Released,
+  KiloPassScheduledChangeStatus.Canceled,
+  KiloPassScheduledChangeStatus.Completed,
+] as const;
+
+export function isTerminalKiloPassScheduleStatus(status: KiloPassScheduledChangeStatus): boolean {
+  return KILO_PASS_TERMINAL_SCHEDULE_STATUSES.includes(
+    status as (typeof KILO_PASS_TERMINAL_SCHEDULE_STATUSES)[number]
+  );
+}
+
+export async function reconcileKiloPassScheduledChangeTerminalStatus(params: {
+  dbOrTx: DbOrTx;
+  scheduledChangeId: string;
+  status: KiloPassScheduledChangeStatus;
+}): Promise<boolean> {
+  if (!isTerminalKiloPassScheduleStatus(params.status)) return false;
+
+  const updatedRows = await params.dbOrTx
+    .update(kilo_pass_scheduled_changes)
+    .set({ status: params.status, ...auto_deleted_at })
+    .where(
+      and(
+        eq(kilo_pass_scheduled_changes.id, params.scheduledChangeId),
+        isNull(kilo_pass_scheduled_changes.deleted_at),
+        not(inArray(kilo_pass_scheduled_changes.status, KILO_PASS_TERMINAL_SCHEDULE_STATUSES))
+      )
+    )
+    .returning({ id: kilo_pass_scheduled_changes.id });
+
+  return updatedRows.length > 0;
+}
 
 export function maybeMapStripeScheduleStatusToDb(
   status: string
@@ -136,40 +171,85 @@ export async function releaseScheduledChangeForSubscription(params: {
   // Soft-delete first so that if Stripe release fails, callers can safely retry.
   // Also update status to `released` to reflect intent (even if Stripe later fails,
   // we revert this along with the soft-delete).
-  await dbOrTx
+  const claimedRows = await dbOrTx
     .update(kilo_pass_scheduled_changes)
     .set({ ...auto_deleted_at, status: KiloPassScheduledChangeStatus.Released })
     .where(
       and(
         eq(kilo_pass_scheduled_changes.id, row.id),
-        isNull(kilo_pass_scheduled_changes.deleted_at)
+        isNull(kilo_pass_scheduled_changes.deleted_at),
+        not(inArray(kilo_pass_scheduled_changes.status, KILO_PASS_TERMINAL_SCHEDULE_STATUSES))
       )
-    );
+    )
+    .returning({ id: kilo_pass_scheduled_changes.id });
+
+  // Another caller or webhook won the state transition after our initial read.
+  // Confirm a durable provider outcome before reporting idempotent success.
+  if (claimedRows.length === 0) {
+    const retrieve = stripe.subscriptionSchedules.retrieve;
+    if (retrieve) {
+      const schedule = await retrieve(row.stripe_schedule_id);
+      const providerStatus = maybeMapStripeScheduleStatusToDb(schedule.status);
+      if (providerStatus && isTerminalKiloPassScheduleStatus(providerStatus)) return;
+    }
+    throw new Error(`Kilo Pass scheduled change release already in progress: ${row.id}`);
+  }
 
   try {
     await stripe.subscriptionSchedules.release(row.stripe_schedule_id);
-
-    await appendKiloPassAuditLog(dbOrTx, {
-      action: KiloPassAuditLogAction.StripeWebhookReceived,
-      result: KiloPassAuditLogResult.Success,
-      kiloUserId: row.kilo_user_id,
-      stripeEventId: stripeEventId ?? null,
-      stripeSubscriptionId: row.stripe_subscription_id,
-      payload: {
-        scope: 'kilo_pass_scheduled_change',
-        type: 'subscription_schedule.release',
-        scheduledChangeId: row.id,
-        scheduleId: row.stripe_schedule_id,
-        scheduleStatus: row.status,
-        reason,
-      },
-    });
   } catch (error) {
+    let providerStatus: KiloPassScheduledChangeStatus | null = null;
+    let providerStateError: unknown = null;
+    try {
+      const retrieve = stripe.subscriptionSchedules.retrieve;
+      if (retrieve) {
+        const schedule = await retrieve(row.stripe_schedule_id);
+        providerStatus = maybeMapStripeScheduleStatusToDb(schedule.status);
+      }
+    } catch (retrieveError) {
+      providerStateError = retrieveError;
+    }
+
+    if (providerStatus && isTerminalKiloPassScheduleStatus(providerStatus)) {
+      await dbOrTx
+        .update(kilo_pass_scheduled_changes)
+        .set({ status: providerStatus })
+        .where(
+          and(
+            eq(kilo_pass_scheduled_changes.id, row.id),
+            eq(kilo_pass_scheduled_changes.status, KiloPassScheduledChangeStatus.Released)
+          )
+        );
+
+      await appendKiloPassAuditLog(dbOrTx, {
+        action: KiloPassAuditLogAction.StripeWebhookReceived,
+        result: KiloPassAuditLogResult.Success,
+        kiloUserId: row.kilo_user_id,
+        stripeEventId: stripeEventId ?? null,
+        stripeSubscriptionId: row.stripe_subscription_id,
+        payload: {
+          scope: 'kilo_pass_scheduled_change',
+          type: 'subscription_schedule.release',
+          scheduledChangeId: row.id,
+          scheduleId: row.stripe_schedule_id,
+          scheduleStatus: providerStatus,
+          reason,
+          note: 'release_failed_but_provider_terminal',
+        },
+      });
+      return;
+    }
+
     // Revert the soft delete so the row remains visible and can be retried.
     await dbOrTx
       .update(kilo_pass_scheduled_changes)
       .set({ deleted_at: null, status: row.status })
-      .where(eq(kilo_pass_scheduled_changes.id, row.id));
+      .where(
+        and(
+          eq(kilo_pass_scheduled_changes.id, row.id),
+          eq(kilo_pass_scheduled_changes.status, KiloPassScheduledChangeStatus.Released)
+        )
+      );
 
     await appendKiloPassAuditLog(dbOrTx, {
       action: KiloPassAuditLogAction.StripeWebhookReceived,
@@ -185,9 +265,32 @@ export async function releaseScheduledChangeForSubscription(params: {
         scheduleStatus: row.status,
         reason,
         error: error instanceof Error ? error.message : String(error),
+        providerStatus,
+        providerStateError:
+          providerStateError instanceof Error
+            ? providerStateError.message
+            : providerStateError
+              ? String(providerStateError)
+              : null,
       },
     });
 
     throw error;
   }
+
+  await appendKiloPassAuditLog(dbOrTx, {
+    action: KiloPassAuditLogAction.StripeWebhookReceived,
+    result: KiloPassAuditLogResult.Success,
+    kiloUserId: row.kilo_user_id,
+    stripeEventId: stripeEventId ?? null,
+    stripeSubscriptionId: row.stripe_subscription_id,
+    payload: {
+      scope: 'kilo_pass_scheduled_change',
+      type: 'subscription_schedule.release',
+      scheduledChangeId: row.id,
+      scheduleId: row.stripe_schedule_id,
+      scheduleStatus: row.status,
+      reason,
+    },
+  });
 }

--- a/apps/web/src/lib/stripe/index.test.ts
+++ b/apps/web/src/lib/stripe/index.test.ts
@@ -2456,7 +2456,7 @@ describe('processStripePaymentEventHook', () => {
         to_tier: KiloPassTier.Tier49,
         to_cadence: KiloPassCadence.Yearly,
         stripe_schedule_id: scheduleId,
-        effective_at: '2026-02-01T00:00:00.000Z',
+        effective_at: '2099-02-01T00:00:00.000Z',
         status: KiloPassScheduledChangeStatus.NotStarted,
       });
 
@@ -2481,6 +2481,20 @@ describe('processStripePaymentEventHook', () => {
       expect(updatedRow).toBeTruthy();
       expect(updatedRow?.status).toBe(KiloPassScheduledChangeStatus.Released);
       expect(updatedRow?.deleted_at).not.toBeNull();
+
+      const auditLog = await db.query.kilo_pass_audit_log.findFirst({
+        where: eq(kilo_pass_audit_log.stripe_event_id, event.id),
+      });
+      expect(auditLog?.stripe_subscription_id).toBe(stripeSubscriptionId);
+      expect(auditLog?.payload_json).toEqual(
+        expect.objectContaining({
+          scheduleId,
+          scheduledChangeId,
+          scheduleStatus: KiloPassScheduledChangeStatus.Released,
+          effectiveAt: '2099-02-01T00:00:00.000Z',
+          unexpectedPreEffectiveRelease: true,
+        })
+      );
     });
 
     test('subscription_schedule.updated (status=canceled) soft-deletes the scheduled change row', async () => {
@@ -2620,6 +2634,168 @@ describe('processStripePaymentEventHook', () => {
 });
 
 describe('releaseScheduledChangeForSubscription', () => {
+  test('only the caller that claims the row releases Stripe under concurrent reads', async () => {
+    const scheduledChangeId = crypto.randomUUID();
+    const stripeSubId = `sub_release_helper_concurrent_${Math.random()}`;
+    const scheduleId = `sched_release_helper_concurrent_${Math.random()}`;
+    const user = await insertTestUser({
+      google_user_email: 'kilo-pass-release-helper-concurrent@example.com',
+    });
+    await db.insert(kilo_pass_subscriptions).values({
+      kilo_user_id: user.id,
+      provider_subscription_id: stripeSubId,
+      stripe_subscription_id: stripeSubId,
+      tier: KiloPassTier.Tier19,
+      cadence: KiloPassCadence.Monthly,
+      status: 'active',
+      cancel_at_period_end: false,
+      current_streak_months: 1,
+      started_at: '2026-01-01T00:00:00.000Z',
+    });
+    await db.insert(kilo_pass_scheduled_changes).values({
+      id: scheduledChangeId,
+      kilo_user_id: user.id,
+      stripe_subscription_id: stripeSubId,
+      from_tier: KiloPassTier.Tier19,
+      from_cadence: KiloPassCadence.Monthly,
+      to_tier: KiloPassTier.Tier49,
+      to_cadence: KiloPassCadence.Yearly,
+      stripe_schedule_id: scheduleId,
+      effective_at: '2026-02-01T00:00:00.000Z',
+      status: KiloPassScheduledChangeStatus.NotStarted,
+    });
+
+    const realFindFirst = db.query.kilo_pass_scheduled_changes.findFirst.bind(
+      db.query.kilo_pass_scheduled_changes
+    );
+    let readers = 0;
+    let releaseReaders: (() => void) | null = null;
+    const bothRead = new Promise<void>(resolve => {
+      releaseReaders = resolve;
+    });
+    const concurrentDb = new Proxy(db, {
+      get(target, property, receiver) {
+        if (property !== 'query') return Reflect.get(target, property, receiver);
+        return {
+          ...target.query,
+          kilo_pass_scheduled_changes: {
+            ...target.query.kilo_pass_scheduled_changes,
+            findFirst: async (...args: Parameters<typeof realFindFirst>) => {
+              const row = await realFindFirst(...args);
+              readers += 1;
+              if (readers === 2) releaseReaders?.();
+              await bothRead;
+              return row;
+            },
+          },
+        };
+      },
+    });
+    const release = jest.fn(async (_scheduleId: string) => ({}));
+    const retrieve = jest.fn(async (_scheduleId: string) => ({ status: 'released' }));
+    const params = {
+      dbOrTx: concurrentDb,
+      stripe: { subscriptionSchedules: { release, retrieve } },
+      stripeSubscriptionId: stripeSubId,
+      reason: 'cancel_scheduled_change' as const,
+    };
+
+    await Promise.all([
+      releaseScheduledChangeForSubscription(params),
+      releaseScheduledChangeForSubscription(params),
+    ]);
+
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledWith(scheduleId);
+    const row = await db.query.kilo_pass_scheduled_changes.findFirst({
+      where: eq(kilo_pass_scheduled_changes.id, scheduledChangeId),
+    });
+    expect(row?.status).toBe(KiloPassScheduledChangeStatus.Released);
+    expect(row?.deleted_at).not.toBeNull();
+  });
+
+  test('a concurrent caller does not report success while the claimed release fails', async () => {
+    const scheduledChangeId = crypto.randomUUID();
+    const stripeSubId = `sub_release_helper_concurrent_failure_${Math.random()}`;
+    const scheduleId = `sched_release_helper_concurrent_failure_${Math.random()}`;
+    const user = await insertTestUser({
+      google_user_email: 'kilo-pass-release-helper-concurrent-failure@example.com',
+    });
+    await db.insert(kilo_pass_subscriptions).values({
+      kilo_user_id: user.id,
+      provider_subscription_id: stripeSubId,
+      stripe_subscription_id: stripeSubId,
+      tier: KiloPassTier.Tier19,
+      cadence: KiloPassCadence.Monthly,
+      status: 'active',
+      cancel_at_period_end: false,
+      current_streak_months: 1,
+      started_at: '2026-01-01T00:00:00.000Z',
+    });
+    await db.insert(kilo_pass_scheduled_changes).values({
+      id: scheduledChangeId,
+      kilo_user_id: user.id,
+      stripe_subscription_id: stripeSubId,
+      from_tier: KiloPassTier.Tier19,
+      from_cadence: KiloPassCadence.Monthly,
+      to_tier: KiloPassTier.Tier49,
+      to_cadence: KiloPassCadence.Yearly,
+      stripe_schedule_id: scheduleId,
+      effective_at: '2026-02-01T00:00:00.000Z',
+      status: KiloPassScheduledChangeStatus.NotStarted,
+    });
+
+    const realFindFirst = db.query.kilo_pass_scheduled_changes.findFirst.bind(
+      db.query.kilo_pass_scheduled_changes
+    );
+    let readers = 0;
+    let releaseReaders: (() => void) | null = null;
+    const bothRead = new Promise<void>(resolve => {
+      releaseReaders = resolve;
+    });
+    const concurrentDb = new Proxy(db, {
+      get(target, property, receiver) {
+        if (property !== 'query') return Reflect.get(target, property, receiver);
+        return {
+          ...target.query,
+          kilo_pass_scheduled_changes: {
+            ...target.query.kilo_pass_scheduled_changes,
+            findFirst: async (...args: Parameters<typeof realFindFirst>) => {
+              const row = await realFindFirst(...args);
+              readers += 1;
+              if (readers === 2) releaseReaders?.();
+              await bothRead;
+              return row;
+            },
+          },
+        };
+      },
+    });
+    const release = jest.fn(async (_scheduleId: string) => {
+      throw new Error('stripe release failed');
+    });
+    const retrieve = jest.fn(async (_scheduleId: string) => ({ status: 'active' }));
+    const params = {
+      dbOrTx: concurrentDb,
+      stripe: { subscriptionSchedules: { release, retrieve } },
+      stripeSubscriptionId: stripeSubId,
+      reason: 'cancel_scheduled_change' as const,
+    };
+
+    const results = await Promise.allSettled([
+      releaseScheduledChangeForSubscription(params),
+      releaseScheduledChangeForSubscription(params),
+    ]);
+
+    expect(results.every(result => result.status === 'rejected')).toBe(true);
+    expect(release).toHaveBeenCalledTimes(1);
+    const row = await db.query.kilo_pass_scheduled_changes.findFirst({
+      where: eq(kilo_pass_scheduled_changes.id, scheduledChangeId),
+    });
+    expect(row?.status).toBe(KiloPassScheduledChangeStatus.NotStarted);
+    expect(row?.deleted_at).toBeNull();
+  });
+
   test('soft-deletes first and reverts the delete if Stripe release fails', async () => {
     const scheduledChangeId = crypto.randomUUID();
     const stripeSubId = `sub_release_helper_${Math.random()}`;

--- a/apps/web/src/lib/stripe/index.ts
+++ b/apps/web/src/lib/stripe/index.ts
@@ -1280,7 +1280,7 @@ export async function processStripePaymentEventHook(event: Stripe.Event) {
             previousScheduleStatus: typeof previousStatus === 'string' ? previousStatus : null,
             scheduleStatusForDb,
             softDeleted: shouldDeleteFromStatus,
-            effectiveAt: row.effective_at,
+            effectiveAt: new Date(row.effective_at).toISOString(),
             unexpectedPreEffectiveRelease:
               scheduleStatus === KiloPassScheduledChangeStatus.Released &&
               new Date(row.effective_at).getTime() > Date.now(),

--- a/apps/web/src/lib/stripe/index.ts
+++ b/apps/web/src/lib/stripe/index.ts
@@ -45,7 +45,10 @@ import {
   KiloPassScheduledChangeStatus,
 } from '@/lib/kilo-pass/enums';
 import { appendKiloPassAuditLog } from '@/lib/kilo-pass/issuance';
-import { maybeMapStripeScheduleStatusToDb } from '@/lib/kilo-pass/scheduled-change-release';
+import {
+  KILO_PASS_TERMINAL_SCHEDULE_STATUSES,
+  maybeMapStripeScheduleStatusToDb,
+} from '@/lib/kilo-pass/scheduled-change-release';
 import { invoiceLooksLikeKiloPassByPriceId } from '@/lib/kilo-pass/stripe-invoice-classifier.server';
 import { getKiloPassMetadataFromStripeMetadata } from '@/lib/kilo-pass/stripe-handlers-metadata';
 import {
@@ -1219,12 +1222,6 @@ export async function processStripePaymentEventHook(event: Stripe.Event) {
 
       await db.transaction(async tx => {
         const previousStatus = event.data.previous_attributes?.['status'];
-        const terminalStatuses = [
-          KiloPassScheduledChangeStatus.Released,
-          KiloPassScheduledChangeStatus.Canceled,
-          KiloPassScheduledChangeStatus.Completed,
-        ] as const;
-
         const softDeleteUpdate = shouldDeleteFromStatus ? auto_deleted_at : {};
         const updatedRows = await tx
           .update(kilo_pass_scheduled_changes)
@@ -1237,7 +1234,9 @@ export async function processStripePaymentEventHook(event: Stripe.Event) {
               // Prevent status regressions once we hit a terminal status.
               // (Still allows idempotent replays of the same terminal status.)
               or(
-                not(inArray(kilo_pass_scheduled_changes.status, terminalStatuses)),
+                not(
+                  inArray(kilo_pass_scheduled_changes.status, KILO_PASS_TERMINAL_SCHEDULE_STATUSES)
+                ),
                 eq(kilo_pass_scheduled_changes.status, scheduleStatusForDb)
               )
             )
@@ -1246,6 +1245,7 @@ export async function processStripePaymentEventHook(event: Stripe.Event) {
             id: kilo_pass_scheduled_changes.id,
             kilo_user_id: kilo_pass_scheduled_changes.kilo_user_id,
             stripe_subscription_id: kilo_pass_scheduled_changes.stripe_subscription_id,
+            effective_at: kilo_pass_scheduled_changes.effective_at,
           });
 
         const row = updatedRows[0];
@@ -1280,6 +1280,10 @@ export async function processStripePaymentEventHook(event: Stripe.Event) {
             previousScheduleStatus: typeof previousStatus === 'string' ? previousStatus : null,
             scheduleStatusForDb,
             softDeleted: shouldDeleteFromStatus,
+            effectiveAt: row.effective_at,
+            unexpectedPreEffectiveRelease:
+              scheduleStatus === KiloPassScheduledChangeStatus.Released &&
+              new Date(row.effective_at).getTime() > Date.now(),
           },
         });
       });

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -73,6 +73,7 @@ type StripeMock = {
     create: ReturnType<typeof jest.fn>;
     update: ReturnType<typeof jest.fn>;
     release: ReturnType<typeof jest.fn>;
+    retrieve: ReturnType<typeof jest.fn>;
   };
   checkout: {
     sessions: {
@@ -201,6 +202,12 @@ type KiloPassCaller = {
     targetTier: KiloPassTier;
     targetCadence: KiloPassCadence;
   }) => Promise<{ scheduledChangeId: string; effectiveAt: string }>;
+  getScheduledChange: () => Promise<{
+    scheduledChange: {
+      id: string;
+      status: KiloPassScheduledChangeStatus;
+    } | null;
+  }>;
   cancelScheduledChange: () => Promise<{ success: boolean }>;
   createCheckoutSession: (input: {
     tier: KiloPassTier;
@@ -285,6 +292,7 @@ jest.mock('@/lib/stripe-client', () => {
       create: jest.fn(),
       update: jest.fn(),
       release: jest.fn(),
+      retrieve: jest.fn(),
     },
     checkout: {
       sessions: {
@@ -554,6 +562,7 @@ describe('kiloPassRouter', () => {
     stripeMock.subscriptionSchedules.create.mockReset();
     stripeMock.subscriptionSchedules.update.mockReset();
     stripeMock.subscriptionSchedules.release.mockReset();
+    stripeMock.subscriptionSchedules.retrieve.mockReset();
     stripeMock.checkout.sessions.create.mockReset();
     stripeMock.checkout.sessions.retrieve.mockReset();
     stripeMock.billingPortal.sessions.create.mockReset();
@@ -3078,6 +3087,95 @@ describe('kiloPassRouter', () => {
     });
   });
 
+  describe('getScheduledChange', () => {
+    async function insertPendingScheduledChange(params: {
+      email: string;
+      effectiveAt: string;
+      status?: KiloPassScheduledChangeStatus;
+    }) {
+      const user = await insertTestUser({ google_user_email: params.email });
+      const stripeSubscriptionId = `sub_read_${crypto.randomUUID()}`;
+      const scheduleId = `sched_read_${crypto.randomUUID()}`;
+      await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+      const scheduledChangeId = crypto.randomUUID();
+      await db.insert(kilo_pass_scheduled_changes).values({
+        id: scheduledChangeId,
+        kilo_user_id: user.id,
+        stripe_subscription_id: stripeSubscriptionId,
+        from_tier: KiloPassTier.Tier19,
+        from_cadence: KiloPassCadence.Monthly,
+        to_tier: KiloPassTier.Tier49,
+        to_cadence: KiloPassCadence.Monthly,
+        stripe_schedule_id: scheduleId,
+        effective_at: params.effectiveAt,
+        status: params.status ?? KiloPassScheduledChangeStatus.Active,
+      });
+      return { user, scheduleId, scheduledChangeId };
+    }
+
+    it('does not retrieve Stripe state for a non-overdue pending change', async () => {
+      freezeKiloPassClock('2026-07-14T12:00:00.000Z');
+      const stripeMock = getStripeMock();
+      const { user, scheduledChangeId } = await insertPendingScheduledChange({
+        email: 'kilo-pass-scheduled-read-future@example.com',
+        effectiveAt: '2026-07-15T12:00:00.000Z',
+      });
+
+      const result = await (await createCallerForUser(user.id)).kiloPass.getScheduledChange();
+
+      expect(result.scheduledChange?.id).toBe(scheduledChangeId);
+      expect(stripeMock.subscriptionSchedules.retrieve).not.toHaveBeenCalled();
+    });
+
+    it('keeps an overdue change pending while the Stripe schedule remains active', async () => {
+      freezeKiloPassClock('2026-07-14T12:00:00.000Z');
+      const stripeMock = getStripeMock();
+      stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({ status: 'active' });
+      const { user, scheduleId, scheduledChangeId } = await insertPendingScheduledChange({
+        email: 'kilo-pass-scheduled-read-active@example.com',
+        effectiveAt: '2026-07-14T11:00:00.000Z',
+      });
+
+      const result = await (await createCallerForUser(user.id)).kiloPass.getScheduledChange();
+
+      expect(result.scheduledChange?.id).toBe(scheduledChangeId);
+      expect(stripeMock.subscriptionSchedules.retrieve).toHaveBeenCalledWith(scheduleId);
+      const row = await db.query.kilo_pass_scheduled_changes.findFirst({
+        where: eq(kilo_pass_scheduled_changes.id, scheduledChangeId),
+      });
+      expect(row?.deleted_at).toBeNull();
+      expect(row?.status).toBe(KiloPassScheduledChangeStatus.Active);
+    });
+
+    it.each([
+      KiloPassScheduledChangeStatus.Released,
+      KiloPassScheduledChangeStatus.Canceled,
+      KiloPassScheduledChangeStatus.Completed,
+    ])('reconciles an overdue change when Stripe reports %s', async providerStatus => {
+      freezeKiloPassClock('2026-07-14T12:00:00.000Z');
+      getStripeMock().subscriptionSchedules.retrieve.mockResolvedValue({ status: providerStatus });
+      const { user, scheduledChangeId } = await insertPendingScheduledChange({
+        email: `kilo-pass-scheduled-read-${providerStatus}@example.com`,
+        effectiveAt: '2026-07-14T11:00:00.000Z',
+      });
+
+      const result = await (await createCallerForUser(user.id)).kiloPass.getScheduledChange();
+
+      expect(result).toEqual({ scheduledChange: null });
+      const row = await db.query.kilo_pass_scheduled_changes.findFirst({
+        where: eq(kilo_pass_scheduled_changes.id, scheduledChangeId),
+      });
+      expect(row?.status).toBe(providerStatus);
+      expect(row?.deleted_at).not.toBeNull();
+    });
+  });
+
   describe('scheduleChange', () => {
     it('monthly cadence: creates a Stripe subscription schedule and inserts a pending scheduled change row', async () => {
       const stripeMock = getStripeMock();
@@ -3560,6 +3658,88 @@ describe('kiloPassRouter', () => {
       // The API releases the schedule; the DB row is deleted asynchronously by the Stripe
       // `subscription_schedule.updated` webhook when it transitions to released/canceled/completed.
       expect(updated).toBeTruthy();
+    });
+
+    it('reconciles and succeeds when Stripe reports the schedule was already released', async () => {
+      const stripeMock = getStripeMock();
+      stripeMock.subscriptionSchedules.release.mockRejectedValue(
+        new Error('The subscription schedule is already released')
+      );
+      stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({ status: 'released' });
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-cancel-already-released@example.com',
+      });
+      const stripeSubId = `sub_cancel_released_${crypto.randomUUID()}`;
+      const scheduleId = `sched_cancel_released_${crypto.randomUUID()}`;
+      await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: stripeSubId,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+      const scheduledChangeId = crypto.randomUUID();
+      await db.insert(kilo_pass_scheduled_changes).values({
+        id: scheduledChangeId,
+        kilo_user_id: user.id,
+        stripe_subscription_id: stripeSubId,
+        from_tier: KiloPassTier.Tier19,
+        from_cadence: KiloPassCadence.Monthly,
+        to_tier: KiloPassTier.Tier49,
+        to_cadence: KiloPassCadence.Monthly,
+        stripe_schedule_id: scheduleId,
+        effective_at: '2026-08-01T00:00:00.000Z',
+        status: KiloPassScheduledChangeStatus.Active,
+      });
+
+      const result = await (await createCallerForUser(user.id)).kiloPass.cancelScheduledChange();
+
+      expect(result).toEqual({ success: true });
+      expect(stripeMock.subscriptionSchedules.retrieve).toHaveBeenCalledWith(scheduleId);
+      const row = await db.query.kilo_pass_scheduled_changes.findFirst({
+        where: eq(kilo_pass_scheduled_changes.id, scheduledChangeId),
+      });
+      expect(row?.status).toBe(KiloPassScheduledChangeStatus.Released);
+      expect(row?.deleted_at).not.toBeNull();
+    });
+
+    it('restores the pending row when release fails and Stripe remains active', async () => {
+      const stripeMock = getStripeMock();
+      stripeMock.subscriptionSchedules.release.mockRejectedValue(new Error('Stripe unavailable'));
+      stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({ status: 'active' });
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-cancel-still-active@example.com',
+      });
+      const stripeSubId = `sub_cancel_active_${crypto.randomUUID()}`;
+      await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: stripeSubId,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+      const scheduledChangeId = crypto.randomUUID();
+      await db.insert(kilo_pass_scheduled_changes).values({
+        id: scheduledChangeId,
+        kilo_user_id: user.id,
+        stripe_subscription_id: stripeSubId,
+        from_tier: KiloPassTier.Tier19,
+        from_cadence: KiloPassCadence.Monthly,
+        to_tier: KiloPassTier.Tier49,
+        to_cadence: KiloPassCadence.Monthly,
+        stripe_schedule_id: `sched_cancel_active_${crypto.randomUUID()}`,
+        effective_at: '2026-08-01T00:00:00.000Z',
+        status: KiloPassScheduledChangeStatus.Active,
+      });
+
+      await expect(
+        (await createCallerForUser(user.id)).kiloPass.cancelScheduledChange()
+      ).rejects.toThrow('Stripe unavailable');
+      const row = await db.query.kilo_pass_scheduled_changes.findFirst({
+        where: eq(kilo_pass_scheduled_changes.id, scheduledChangeId),
+      });
+      expect(row?.status).toBe(KiloPassScheduledChangeStatus.Active);
+      expect(row?.deleted_at).toBeNull();
     });
 
     it('rejects active Google Play subscriptions without releasing a Stripe schedule', async () => {

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -56,7 +56,12 @@ import { getMonthlyPriceUsd } from '@/lib/kilo-pass/bonus';
 import { computeKiloPassBonusCreditsUsd } from '@/lib/kilo-pass/bonus-decision';
 import { KiloPassError } from '@/lib/kilo-pass/errors';
 import { isStripeSubscriptionEnded } from '@/lib/kilo-pass/stripe-subscription-status';
-import { releaseScheduledChangeForSubscription } from '@/lib/kilo-pass/scheduled-change-release';
+import {
+  isTerminalKiloPassScheduleStatus,
+  maybeMapStripeScheduleStatusToDb,
+  reconcileKiloPassScheduledChangeTerminalStatus,
+  releaseScheduledChangeForSubscription,
+} from '@/lib/kilo-pass/scheduled-change-release';
 import { KILO_PASS_BONUS_LIKE_ITEM_KINDS, appendKiloPassAuditLog } from '@/lib/kilo-pass/issuance';
 import {
   KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF,
@@ -80,6 +85,7 @@ import { sentryLogger } from '@/lib/utils.server';
 
 const logHostingActivationInfo = sentryLogger('kilo-pass-hosting-activation', 'info');
 const logHostingActivationWarning = sentryLogger('kilo-pass-hosting-activation', 'warning');
+const logScheduledChangeWarning = sentryLogger('kilo-pass-scheduled-change', 'warning');
 
 const CursorInputSchema = z.object({
   cursor: z.string().nullable().optional(),
@@ -1837,13 +1843,14 @@ export const kiloPassRouter = createTRPCRouter({
       }
       assertStripeManagedSubscription(subscription);
 
-      const scheduledChange = await db.query.kilo_pass_scheduled_changes.findFirst({
+      let scheduledChange = await db.query.kilo_pass_scheduled_changes.findFirst({
         columns: {
           id: true,
           from_tier: true,
           from_cadence: true,
           to_tier: true,
           to_cadence: true,
+          stripe_schedule_id: true,
           effective_at: true,
           status: true,
         },
@@ -1855,6 +1862,69 @@ export const kiloPassRouter = createTRPCRouter({
 
       if (!scheduledChange) {
         return { scheduledChange: null };
+      }
+
+      const isPending =
+        scheduledChange.status === KiloPassScheduledChangeStatus.NotStarted ||
+        scheduledChange.status === KiloPassScheduledChangeStatus.Active;
+      if (isPending && !dayjs(scheduledChange.effective_at).isAfter(dayjs())) {
+        try {
+          const stripeSchedule = await stripe.subscriptionSchedules.retrieve(
+            scheduledChange.stripe_schedule_id
+          );
+          const providerStatus = maybeMapStripeScheduleStatusToDb(stripeSchedule.status);
+
+          if (providerStatus && isTerminalKiloPassScheduleStatus(providerStatus)) {
+            const reconciled = await reconcileKiloPassScheduledChangeTerminalStatus({
+              dbOrTx: db,
+              scheduledChangeId: scheduledChange.id,
+              status: providerStatus,
+            });
+            if (reconciled) return { scheduledChange: null };
+
+            const currentScheduledChange = await db.query.kilo_pass_scheduled_changes.findFirst({
+              columns: {
+                id: true,
+                from_tier: true,
+                from_cadence: true,
+                to_tier: true,
+                to_cadence: true,
+                stripe_schedule_id: true,
+                effective_at: true,
+                status: true,
+              },
+              where: and(
+                eq(
+                  kilo_pass_scheduled_changes.stripe_subscription_id,
+                  subscription.stripeSubscriptionId
+                ),
+                isNull(kilo_pass_scheduled_changes.deleted_at)
+              ),
+            });
+            if (!currentScheduledChange) return { scheduledChange: null };
+            scheduledChange = currentScheduledChange;
+          }
+
+          logScheduledChangeWarning('Overdue Kilo Pass provider schedule remains pending', {
+            scheduledChangeId: scheduledChange.id,
+            scheduleId: scheduledChange.stripe_schedule_id,
+            stripeSubscriptionId: subscription.stripeSubscriptionId,
+            effectiveAt: scheduledChange.effective_at,
+            localStatus: scheduledChange.status,
+            providerStatus: stripeSchedule.status,
+          });
+        } catch (error) {
+          captureException(error, {
+            tags: { source: 'kilo_pass_scheduled_change', stage: 'overdue_read_reconciliation' },
+            extra: {
+              scheduledChangeId: scheduledChange.id,
+              scheduleId: scheduledChange.stripe_schedule_id,
+              stripeSubscriptionId: subscription.stripeSubscriptionId,
+              effectiveAt: scheduledChange.effective_at,
+              localStatus: scheduledChange.status,
+            },
+          });
+        }
       }
 
       return {


### PR DESCRIPTION
## Summary

Self-heal stale Kilo Pass scheduled changes when Stripe has already reached a terminal schedule state.

### Why this change is needed

Stripe subscription schedules can be released outside Kilo’s normal flow before their effective time. When the corresponding webhook is missed or delayed, Kilo keeps showing a pending tier or cadence change that can no longer occur. Cancellation then fails because Stripe already considers the schedule terminal.

Historical overdue rows can remain active for the same reason even when the intended subscription transition completed.

### How this is addressed

- Reconcile overdue pending changes against Stripe when they are read, while avoiding provider calls for ordinary non-overdue reads.
- Persist `released`, `canceled`, and `completed` provider states using the existing terminal soft-delete semantics.
- Recover cancellation when Stripe rejects release but a follow-up retrieval confirms a terminal schedule.
- Preserve the pending row and existing failure behavior when provider state remains active or cannot be established.
- Use an atomic local claim so concurrent release attempts cannot roll back each other or report success before a durable provider outcome is known.
- Record structured context for unexpected pre-effective releases through the existing Kilo Pass audit path.

## Human Verification

- Completed the packet-based local code review workflow across security, logic, types, data, resources, style, React, and tests.
- React Doctor completed without diagnostics.
- Focused database-backed tests were prepared but could not run because the local PostgreSQL service and Docker were unavailable.

## Reviewer Notes

### Human Reviewer Flags

- Overdue reads intentionally retrieve Stripe every time while the schedule remains pending. This keeps reconciliation stateless but can repeat provider calls and warning events for anomalously overdue schedules.
- Cancellation recovery treats `released`, `canceled`, and `completed` as terminal success, matching the requested self-healing contract even when completion means the transition may already have occurred.
- This change does not include a worker, migration, Portal restriction, or cleanup of existing stale rows.

### Code Reviewer Agent

<details>
<summary>Code Reviewer Notes</summary>

- Terminal transitions use conditional updates so webhook replay and concurrent reconciliation cannot regress an already-terminal row.
- Release recovery separates the Stripe call from success-audit persistence so an audit failure cannot roll back a confirmed provider release.
- Concurrency tests force two callers through the same pre-claim read and cover both provider success and rollback after provider failure.
- Static typecheck, lint, formatting, and diff checks pass. Database-backed Jest execution remains pending on local PostgreSQL availability.

</details>
