### PR TITLE
fix(cost-insights): show captured spend evidence

### DIFF
--- a/apps/web/src/lib/cost-insights/presenter.test.ts
+++ b/apps/web/src/lib/cost-insights/presenter.test.ts
@@ -465,6 +465,77 @@ describe('Cost Insights presenter', () => {
     ]);
   });
 
+  it('uses exact current-hour evidence when rollup coverage has not been initialized', () => {
+    expect(
+      formatSpendEvidence(
+        [
+          {
+            hourStart: '2026-06-25T22:00:00.000Z',
+            variableMicrodollars: null,
+            scheduledMicrodollars: null,
+            totalMicrodollars: null,
+            variableRecordCount: null,
+            scheduledRecordCount: null,
+            isCovered: false,
+          },
+          {
+            hourStart: '2026-06-25T23:00:00.000Z',
+            variableMicrodollars: null,
+            scheduledMicrodollars: null,
+            totalMicrodollars: null,
+            variableRecordCount: null,
+            scheduledRecordCount: null,
+            isCovered: false,
+          },
+        ],
+        '24h',
+        {
+          hourStart: '2026-06-25T23:00:00.000Z',
+          variableMicrodollars: 3_320_000,
+          scheduledMicrodollars: 0,
+          totalMicrodollars: 3_320_000,
+          variableRecordCount: null,
+          scheduledRecordCount: null,
+          isCovered: true,
+        }
+      )
+    ).toEqual([
+      expect.objectContaining({
+        periodStart: '2026-06-25T22:00:00.000Z',
+        coverage: 'unavailable',
+        variableUsd: null,
+      }),
+      expect.objectContaining({
+        periodStart: '2026-06-25T23:00:00.000Z',
+        coverage: 'complete',
+        variableUsd: 3.32,
+        scheduledUsd: 0,
+      }),
+    ]);
+  });
+
+  it('includes exact current-hour spend in a complete daily chart bucket', () => {
+    const points = Array.from({ length: 24 }, (_, hour) => ({
+      hourStart: `2026-06-25T${String(hour).padStart(2, '0')}:00:00.000Z`,
+      variableMicrodollars: hour === 23 ? 3_320_000 : 0,
+      scheduledMicrodollars: 0,
+      totalMicrodollars: hour === 23 ? 3_320_000 : 0,
+      variableRecordCount: hour === 23 ? 1 : 0,
+      scheduledRecordCount: 0,
+      isCovered: true,
+    }));
+
+    expect(formatSpendEvidence(points, '7d')).toEqual([
+      expect.objectContaining({
+        periodStart: '2026-06-25T00:00:00.000Z',
+        periodEndExclusive: '2026-06-26T00:00:00.000Z',
+        coverage: 'complete',
+        variableUsd: 3.32,
+        scheduledUsd: 0,
+      }),
+    ]);
+  });
+
   it('rejects covered evidence with missing category totals instead of coercing it to zero', () => {
     expect(() =>
       formatSpendEvidence(

--- a/apps/web/src/lib/cost-insights/presenter.ts
+++ b/apps/web/src/lib/cost-insights/presenter.ts
@@ -22,6 +22,7 @@ import {
   microdollarsToUsd,
   MICRODOLLARS_PER_USD,
 } from './policy';
+import { loadCanonicalCostInsightAggregationsByHour } from './canonical-sources';
 import { getCostInsightAnomalyPolicy } from './evaluation';
 import {
   countCostInsightEvents,
@@ -33,7 +34,7 @@ import {
   type CostInsightDatabase,
 } from './repository';
 import {
-  getOwnerCurrentHourSpend,
+  getOwnerHourDriverEvidence,
   getOwnerHourlySpend,
   getOwnerRolling24HourSpendExact,
   getOwnerTopSpendDrivers,
@@ -257,10 +258,14 @@ function groupByUtcDay(points: OwnerHourlySpend[]): OwnerHourlySpend[][] {
 
 export function formatSpendEvidence(
   points: OwnerHourlySpend[],
-  range: SpendRange
+  range: SpendRange,
+  currentHour?: OwnerHourlySpend
 ): SpendEvidencePoint[] {
+  const evidencePoints = currentHour
+    ? points.map(point => (point.hourStart === currentHour.hourStart ? currentHour : point))
+    : points;
   if (range === '1h' || range === '24h') {
-    return points.map(point => {
+    return evidencePoints.map(point => {
       const common = {
         label: formatHourLabel(point.hourStart),
         periodStart: normalizeCostInsightTimestamp(point.hourStart),
@@ -286,7 +291,7 @@ export function formatSpendEvidence(
     });
   }
 
-  const days = groupByUtcDay(points);
+  const days = groupByUtcDay(evidencePoints);
   if (range === '7d' || range === '30d') {
     return days.map(presentEvidenceBucket);
   }
@@ -298,15 +303,80 @@ export function formatSpendEvidence(
   return weeks;
 }
 
-async function loadRangeEvidence(
-  database: CostInsightDatabase,
-  owner: CostInsightSpendOwner,
+function hourlyEvidenceRange(
+  points: OwnerHourlySpend[],
   range: SpendRange,
   endHourExclusive: string
-): Promise<SpendEvidencePoint[]> {
+): OwnerHourlySpend[] {
   const startHour = spendRangeStartHour(range, endHourExclusive);
-  const points = await getOwnerHourlySpend(database, { owner, startHour, endHourExclusive });
-  return formatSpendEvidence(points, range);
+  return points.filter(point => point.hourStart >= startHour);
+}
+
+function canonicalHourlySpend(
+  hourly: Awaited<ReturnType<typeof loadCanonicalCostInsightAggregationsByHour>>,
+  startHour: string,
+  endHourExclusive: string
+): OwnerHourlySpend[] {
+  const byHour = new Map(hourly.map(hour => [hour.hourStart, hour]));
+  const points: OwnerHourlySpend[] = [];
+  for (
+    let hourStart = startHour;
+    hourStart < endHourExclusive;
+    hourStart = addHours(hourStart, 1)
+  ) {
+    const aggregation = byHour.get(hourStart);
+    const variable = aggregation?.totals.find(total => total.category === 'variable');
+    const scheduled = aggregation?.totals.find(total => total.category === 'scheduled');
+    const variableMicrodollars = variable?.totalMicrodollars ?? 0;
+    const scheduledMicrodollars = scheduled?.totalMicrodollars ?? 0;
+    const totalMicrodollars = variableMicrodollars + scheduledMicrodollars;
+    if (!Number.isSafeInteger(totalMicrodollars)) {
+      throw new Error('Canonical Cost Insights hourly total exceeds the safe-integer range.');
+    }
+    points.push({
+      hourStart,
+      variableMicrodollars,
+      scheduledMicrodollars,
+      totalMicrodollars,
+      variableRecordCount: variable?.spendRecordCount ?? 0,
+      scheduledRecordCount: scheduled?.spendRecordCount ?? 0,
+      isCovered: true,
+    });
+  }
+  return points;
+}
+
+async function loadEvidenceByRange(
+  database: CostInsightDatabase,
+  owner: CostInsightSpendOwner,
+  endHourExclusive: string,
+  asOf: string,
+  currentHour: OwnerHourlySpend
+): Promise<Record<SpendRange, SpendEvidencePoint[]>> {
+  const startHour = spendRangeStartHour('90d', endHourExclusive);
+  const rollupPoints = await getOwnerHourlySpend(database, {
+    owner,
+    startHour,
+    endHourExclusive,
+  });
+  const points = rollupPoints.some(point => !point.isCovered)
+    ? canonicalHourlySpend(
+        await loadCanonicalCostInsightAggregationsByHour(database, {
+          owner,
+          startInclusive: startHour,
+          endExclusive: asOf,
+        }),
+        startHour,
+        endHourExclusive
+      )
+    : rollupPoints;
+
+  return Object.fromEntries(
+    (Object.keys(rangeHours) as SpendRange[]).map(range => [
+      range,
+      formatSpendEvidence(hourlyEvidenceRange(points, range, endHourExclusive), range, currentHour),
+    ])
+  ) as Record<SpendRange, SpendEvidencePoint[]>;
 }
 
 async function loadTopDriversByRange(
@@ -760,57 +830,71 @@ export async function buildCostInsightsDashboardData(params: {
   const asOf = new Date().toISOString();
   const currentHourStart = floorUtcHour(new Date(asOf));
   const endHourExclusive = addHours(currentHourStart, 1);
+  const isExactHourBoundary = asOf === currentHourStart;
   const config = await getCostInsightOwnerConfig(params.database, params.owner);
   const [
-    currentHourSpend,
+    currentHourEvidence,
     rolling24HourSpend,
     anomalyPolicy,
     dashboardState,
     topDriversByRange,
     events,
   ] = await Promise.all([
-    getOwnerCurrentHourSpend(params.database, params.owner),
-    getOwnerRolling24HourSpendExact(params.database, { owner: params.owner, asOf }),
+    isExactHourBoundary
+      ? Promise.resolve({
+          startInclusive: currentHourStart,
+          endExclusive: asOf,
+          variableMicrodollars: 0,
+          scheduledMicrodollars: 0,
+          totalMicrodollars: 0,
+          topDrivers: [],
+          usedCanonicalFallback: false,
+          degradedIntervalCount: 0,
+        })
+      : getOwnerHourDriverEvidence(params.database, {
+          owner: params.owner,
+          hourStart: currentHourStart,
+          intervalEnd: asOf,
+        }),
+    getOwnerRolling24HourSpendExact(params.database, {
+      owner: params.owner,
+      asOf,
+      fallbackToCanonical: true,
+    }),
     getCostInsightAnomalyPolicy(params.database, params.owner, currentHourStart),
     getCostInsightDashboardState(params.database, params.owner),
     loadTopDriversByRange(params.database, params.owner, endHourExclusive),
     listCostInsightEvents(params.database, params.owner, { limit: 5 }),
   ]);
-  const [
-    evidenceThisHour,
-    evidence24h,
-    evidence7d,
-    evidence30d,
-    evidence90d,
-    actorLabels,
-    activeSuggestions,
-    eventPreview,
-    memberLimitsHref,
-  ] = await Promise.all([
-    loadRangeEvidence(params.database, params.owner, '1h', endHourExclusive),
-    loadRangeEvidence(params.database, params.owner, '24h', endHourExclusive),
-    loadRangeEvidence(params.database, params.owner, '7d', endHourExclusive),
-    loadRangeEvidence(params.database, params.owner, '30d', endHourExclusive),
-    loadRangeEvidence(params.database, params.owner, '90d', endHourExclusive),
-    loadActorLabels(params.database, [
-      ...Object.values(topDriversByRange).flatMap(drivers =>
-        drivers.map(driver => driver.actorUserId)
-      ),
-      ...dashboardState.events.flatMap(event =>
-        (event.snapshot.topDrivers ?? [])
-          .map(driver => driver.actorUserId)
-          .filter((actorUserId): actorUserId is string => Boolean(actorUserId))
-      ),
-    ]),
-    (config?.cost_suggestions_enabled ?? true)
-      ? listActiveCostInsightSuggestions(params.database, params.owner)
-      : [],
-    mapEvents(params.database, params.owner, events),
-    loadOrganizationMemberLimitsHref(params.database, params.owner, params.uiOwner),
-  ]);
+  const currentHourSpend: OwnerHourlySpend = {
+    hourStart: currentHourStart,
+    variableMicrodollars: currentHourEvidence.variableMicrodollars,
+    scheduledMicrodollars: currentHourEvidence.scheduledMicrodollars,
+    totalMicrodollars: currentHourEvidence.totalMicrodollars,
+    variableRecordCount: null,
+    scheduledRecordCount: null,
+    isCovered: true,
+  };
+  const [evidenceByRange, actorLabels, activeSuggestions, eventPreview, memberLimitsHref] =
+    await Promise.all([
+      loadEvidenceByRange(params.database, params.owner, endHourExclusive, asOf, currentHourSpend),
+      loadActorLabels(params.database, [
+        ...Object.values(topDriversByRange).flatMap(drivers =>
+          drivers.map(driver => driver.actorUserId)
+        ),
+        ...dashboardState.events.flatMap(event =>
+          (event.snapshot.topDrivers ?? [])
+            .map(driver => driver.actorUserId)
+            .filter((actorUserId): actorUserId is string => Boolean(actorUserId))
+        ),
+      ]),
+      (config?.cost_suggestions_enabled ?? true)
+        ? listActiveCostInsightSuggestions(params.database, params.owner)
+        : [],
+      mapEvents(params.database, params.owner, events),
+      loadOrganizationMemberLimitsHref(params.database, params.owner, params.uiOwner),
+    ]);
 
-  const currentHourVariableMicrodollars =
-    evidenceThisHour[0]?.coverage === 'complete' ? currentHourSpend.variableMicrodollars : null;
   const alerts = formatActiveCostInsightAlerts(dashboardState, params.owner, actorLabels);
   return {
     enabled: config?.spend_alerts_enabled ?? false,
@@ -818,21 +902,15 @@ export async function buildCostInsightsDashboardData(params: {
     range: '7d',
     metrics: buildMetrics({
       rolling24HourMicrodollars: rolling24HourSpend.totalMicrodollars,
-      currentHourVariableMicrodollars,
+      currentHourVariableMicrodollars: currentHourEvidence.variableMicrodollars,
       anomalyBaselineMicrodollars: anomalyPolicy.baselineMicrodollars,
       anomalyThresholdMicrodollars: anomalyPolicy.thresholdMicrodollars,
       thresholdMicrodollars: config?.spend_threshold_microdollars ?? null,
       alerts,
       enabled: config?.spend_alerts_enabled ?? false,
     }),
-    evidence: evidence7d,
-    evidenceByRange: {
-      '1h': evidenceThisHour,
-      '24h': evidence24h,
-      '7d': evidence7d,
-      '30d': evidence30d,
-      '90d': evidence90d,
-    },
+    evidence: evidenceByRange['7d'],
+    evidenceByRange,
     driversByRange: {
       '1h': mapDrivers(params.owner, topDriversByRange['1h'], actorLabels),
       '24h': mapDrivers(params.owner, topDriversByRange['24h'], actorLabels),

--- a/apps/web/src/lib/cost-insights/spend-repository.ts
+++ b/apps/web/src/lib/cost-insights/spend-repository.ts
@@ -1279,7 +1279,7 @@ export async function getOwnerRollingSpendExact(
 
 export async function getOwnerRolling24HourSpendExact(
   primaryDatabase: ExactRollingDatabase,
-  params: { owner: CostInsightSpendOwner; asOf?: string }
+  params: { owner: CostInsightSpendOwner; asOf?: string; fallbackToCanonical?: boolean }
 ): Promise<OwnerRolling24HourSpendExact> {
   return await getOwnerRollingSpendExact(primaryDatabase, {
     ...params,


### PR DESCRIPTION
## Summary

Show captured Cost Insights spend consistently in summary metrics, charts, and contributor data when rollup coverage is incomplete.

### Why this change is needed

Cost Insights could display a captured AI usage contributor, such as $3.32, while the rolling summary and current-hour metric remained unavailable and the chart showed no spend. Contributors read captured rollups directly, but summary and chart evidence were gated by a separate coverage marker that may lag or be unavailable.

The dashboard must still avoid presenting incomplete historical rollups as authoritative totals.

### How this is addressed

- Use exact source-of-truth evidence for the current partial UTC hour.
- Fall back to canonical hourly spend when chart rollup coverage is incomplete, preserving complete daily aggregation across all supported ranges.
- Use canonical fallback for the exact rolling 24-hour summary.
- Keep uncovered historical evidence from being displayed as understated partial totals.
- Handle exact UTC-hour boundaries as a valid zero-spend current-hour bucket.
- Add regression coverage for current-hour and daily chart presentation.

## Human Verification

- Confirmed the implementation matches the Cost Insights requirements for current partial-hour evidence and exact rolling windows.
- Focused Jest tests could not execute because the configured PostgreSQL test database was unavailable and Docker was not running; Jest stopped during global database setup before running test cases.

## Reviewer Notes

### Human Reviewer Flags

- Incomplete chart rollups now trigger a canonical source-of-truth fallback for the 90-day evidence window. This favors consistent, complete evidence over cheaper but potentially misleading partial rollup output.

### Code Reviewer Agent

<details>
<summary>Code Reviewer Notes</summary>

- Canonical hourly data is zero-filled into a dense series before deriving the 1h, 24h, 7d, 30d, and 90d chart ranges.
- The exact current partial hour replaces the corresponding dense hourly point so future portions of the hour are not represented as spend.
- Rolling 24-hour totals use the repository’s existing canonical fallback and retain exact `[asOf - 24h, asOf)` semantics.
- Web typecheck, lint, formatting, and diff whitespace checks passed. An independent code review found no remaining issues.

</details>
