### PR TITLE
fix(ai-gateway): enforce exclusive provider filters

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -791,6 +791,15 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     });
     if (modelRestrictionError) return modelRestrictionError;
 
+    // Experiment traffic captures prompts to R2 for partner evaluation, which
+    // is a form of data collection that the gateway-pinned `data_collection`
+    // setting cannot enforce on a direct partner upstream. If the org has
+    // explicitly disabled data collection, refuse the experimented public id
+    // here rather than routing through and silently capturing prompts.
+    if (effectiveProviderContext.experiment && settings?.data_collection === 'deny') {
+      return dataCollectionRequiredResponse();
+    }
+
     // Enterprise `provider_allow_list` is enforced via OpenRouter's
     // `body.provider.only` field, which doesn't reach a direct partner
     // upstream. Refuse the experimented public id rather than routing

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -56,6 +56,7 @@ import {
   forbiddenFreeModelResponse,
   storeAndPreviousResponseIdIsNotSupported,
   apiKindNotSupportedResponse,
+  checkExclusiveModelProviderAllowed,
 } from '@/lib/ai-gateway/llm-proxy-helpers';
 import { ProxyErrorType } from '@/lib/proxy-error-types';
 import { getBalanceAndOrgSettings } from '@/lib/organizations/organization-usage';
@@ -591,21 +592,6 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     }
   }
 
-  // Request-level data-collection opt-out: a caller can set
-  // `provider.data_collection: 'deny'` or `provider.zdr: true` on any
-  // request to opt that single request out of training/data-retention.
-  // Direct experiment upstreams ignore those OpenRouter/Vercel flags
-  // (we never reach OpenRouter), but we still capture the prompt to R2
-  // for partner evaluation — which violates the caller's stated
-  // intent. Refuse here regardless of org settings, anon/BYOK status,
-  // or the org-level check below.
-  if (
-    (await hasBestEffortGuessDataCollectionRequirement(effectiveModelIdLowerCased)) &&
-    isDataCollectionExplicitlyDisallowed(requestBodyParsed.body.provider)
-  ) {
-    return dataCollectionRequiredResponse();
-  }
-
   if (!effectiveProviderContext.provider.supportedChatApis.includes(requestBodyParsed.kind)) {
     return apiKindNotSupportedResponse(
       requestBodyParsed.kind,
@@ -805,15 +791,6 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     });
     if (modelRestrictionError) return modelRestrictionError;
 
-    // Experiment traffic captures prompts to R2 for partner evaluation, which
-    // is a form of data collection that the gateway-pinned `data_collection`
-    // setting cannot enforce on a direct partner upstream. If the org has
-    // explicitly disabled data collection, refuse the experimented public id
-    // here rather than routing through and silently capturing prompts.
-    if (effectiveProviderContext.experiment && settings?.data_collection === 'deny') {
-      return dataCollectionRequiredResponse();
-    }
-
     // Enterprise `provider_allow_list` is enforced via OpenRouter's
     // `body.provider.only` field, which doesn't reach a direct partner
     // upstream. Refuse the experimented public id rather than routing
@@ -829,6 +806,19 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       requestBodyParsed.body.provider = providerConfig;
     }
   }
+
+  if (
+    (await hasBestEffortGuessDataCollectionRequirement(effectiveModelIdLowerCased)) &&
+    isDataCollectionExplicitlyDisallowed(requestBodyParsed.body.provider)
+  ) {
+    return dataCollectionRequiredResponse();
+  }
+
+  const providerNotAllowedError = checkExclusiveModelProviderAllowed(
+    effectiveModelIdLowerCased,
+    requestBodyParsed.body.provider
+  );
+  if (providerNotAllowedError) return providerNotAllowedError;
 
   if (effectiveProviderContext.experiment) {
     usageContext.modelExperimentVariantVersionId =

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -47,6 +47,7 @@ import { computeOpenRouterCostFields } from '@/lib/ai-gateway/processUsage.share
 import { persistExperimentAttribution } from '@/lib/ai-gateway/experiments/persist';
 export { proxyErrorTypeSchema, ProxyErrorType } from '@/lib/proxy-error-types';
 import { ProxyErrorType } from '@/lib/proxy-error-types';
+import { getInferenceProvider } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 
 // FIM suffix markers for tracking purposes - used to wrap suffix in a fake system prompt format
 // This allows FIM requests to be tracked consistently with chat requests
@@ -143,6 +144,31 @@ export function dataCollectionRequiredResponse() {
       message: error,
     },
     { status: 400 }
+  );
+}
+
+export function checkExclusiveModelProviderAllowed(
+  model: string,
+  provider: OpenRouterProviderConfig | undefined
+) {
+  if (!provider) return null;
+  const exclusiveModel = findKiloExclusiveModel(model);
+  if (!exclusiveModel) return null;
+  const inferenceProvider = getInferenceProvider(exclusiveModel)?.slug;
+  if (!inferenceProvider) return null;
+  if (
+    (!provider.only || provider.only.includes(inferenceProvider)) &&
+    (!provider.ignore || !provider.ignore.includes(inferenceProvider))
+  )
+    return null;
+  const error = `No eligible provider can serve the selected model. Please enable provider: ${inferenceProvider}`;
+  return NextResponse.json(
+    {
+      error: error,
+      error_type: ProxyErrorType.provider_not_allowed,
+      message: error,
+    },
+    { status: 403 }
   );
 }
 


### PR DESCRIPTION
## Summary
- enforce `provider.only` and `provider.ignore` for Kilo-exclusive model inference providers
- apply request-level data collection restrictions after model routing is resolved
- return a provider-not-allowed response when filtering excludes the exclusive provider

## Validation
- `pnpm exec oxfmt --list-different apps/web/src/app/api/openrouter/[...path]/route.ts apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts`
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- `git diff --cached --check`