### PR TITLE
feat(code-reviwer) Select models per repo

### DIFF
--- a/apps/mobile/src/lib/code-reviewer-config.ts
+++ b/apps/mobile/src/lib/code-reviewer-config.ts
@@ -1,4 +1,7 @@
-import { type CodeReviewPlatform } from '@kilocode/app-shared/code-review';
+import {
+  type CodeReviewPlatform,
+  type RepositoryModelOverrideInput,
+} from '@kilocode/app-shared/code-review';
 
 import { parseParam } from '@/lib/route-params';
 
@@ -93,6 +96,7 @@ export type ReviewConfigData = {
   gateThreshold: 'off' | 'all' | 'warning' | 'critical';
   repositorySelectionMode: 'all' | 'selected';
   selectedRepositoryIds: (number | string)[];
+  repositoryModelOverrides: RepositoryModelOverrideInput[];
   disableReviewMd: boolean;
 };
 
@@ -105,5 +109,6 @@ export type ConfigPatch = Partial<{
   gateThreshold: ReviewConfigData['gateThreshold'];
   repositorySelectionMode: ReviewConfigData['repositorySelectionMode'];
   selectedRepositoryIds: (number | string)[];
+  repositoryModelOverrides: RepositoryModelOverrideInput[];
   disableReviewMd: boolean;
 }>;

--- a/apps/mobile/src/lib/hooks/use-code-reviewer.ts
+++ b/apps/mobile/src/lib/hooks/use-code-reviewer.ts
@@ -242,6 +242,11 @@ export function useSaveReviewConfig(scope: string, platform: ReviewerPlatform) {
               selectedRepositoryIds: input.selectedRepositoryIds.filter(
                 (id): id is number => typeof id === 'number'
               ),
+              // Same numeric-only narrowing as selectedRepositoryIds above.
+              repositoryModelOverrides: input.repositoryModelOverrides.filter(
+                (override): override is typeof override & { repositoryId: number } =>
+                  typeof override.repositoryId === 'number'
+              ),
             })
           : await trpcClient.organizations.reviewAgent.saveReviewConfig.mutate({
               ...input,

--- a/apps/web/src/components/code-reviews/RepositoryModelOverrides.tsx
+++ b/apps/web/src/components/code-reviews/RepositoryModelOverrides.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Plus, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
+import {
+  getAvailableThinkingEfforts,
+  thinkingEffortLabel,
+} from '@/lib/code-reviews/core/model-variants';
+
+export type RepositoryModelOverrideValue = {
+  repoFullName: string;
+  modelSlug: string;
+  thinkingEffort: string | null;
+};
+
+export type RepositoryOverrideOption = {
+  id: number;
+  full_name: string;
+};
+
+export type RepositoryModelOverridesProps = {
+  /** All repositories available from the integration (independent of trigger selection). */
+  availableRepositories: RepositoryOverrideOption[];
+  models: ModelOption[];
+  isLoadingModels: boolean;
+  /** Current overrides keyed by repository id. */
+  overrides: Map<number, RepositoryModelOverrideValue>;
+  /** Model a newly-added repository override starts on. */
+  defaultModelSlug: string;
+  /** Add or update the override for a repository. */
+  onSet: (repositoryId: number, value: RepositoryModelOverrideValue) => void;
+  /** Remove the override for a repository (repo reverts to the default model). */
+  onRemove: (repositoryId: number) => void;
+  disabled?: boolean;
+};
+
+/**
+ * Per-repository model overrides, add-on-demand. Only repositories with an override
+ * are shown as rows; the "Add repository" picker offers the remaining repositories.
+ * Overrides are independent of the trigger selection mode (they apply in both "all"
+ * and "selected" modes) — removing a row reverts that repo to the default model.
+ */
+export function RepositoryModelOverrides({
+  availableRepositories,
+  models,
+  isLoadingModels,
+  overrides,
+  defaultModelSlug,
+  onSet,
+  onRemove,
+  disabled,
+}: RepositoryModelOverridesProps) {
+  const overrideRows = useMemo(
+    () =>
+      Array.from(overrides.entries()).map(([id, value]) => ({
+        id,
+        ...value,
+      })),
+    [overrides]
+  );
+
+  const repositoriesToAdd = useMemo(
+    () => availableRepositories.filter(repository => !overrides.has(repository.id)),
+    [availableRepositories, overrides]
+  );
+
+  return (
+    <div className="space-y-3">
+      {overrideRows.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          No per-repository overrides yet. Add a repository to run its reviews on a different model
+          than the default.
+        </p>
+      ) : (
+        <div className="border-border divide-border divide-y rounded-md border">
+          {overrideRows.map(row => (
+            <RepositoryOverrideRowItem
+              key={row.id}
+              repoFullName={row.repoFullName}
+              models={models}
+              isLoadingModels={isLoadingModels}
+              value={{
+                repoFullName: row.repoFullName,
+                modelSlug: row.modelSlug,
+                thinkingEffort: row.thinkingEffort,
+              }}
+              onChange={value => onSet(row.id, value)}
+              onRemove={() => onRemove(row.id)}
+              disabled={disabled}
+            />
+          ))}
+        </div>
+      )}
+
+      <AddRepositoryButton
+        repositories={repositoriesToAdd}
+        disabled={disabled}
+        onSelect={repository =>
+          onSet(repository.id, {
+            repoFullName: repository.full_name,
+            modelSlug: defaultModelSlug,
+            thinkingEffort: null,
+          })
+        }
+      />
+    </div>
+  );
+}
+
+function RepositoryOverrideRowItem({
+  repoFullName,
+  models,
+  isLoadingModels,
+  value,
+  onChange,
+  onRemove,
+  disabled,
+}: {
+  repoFullName: string;
+  models: ModelOption[];
+  isLoadingModels: boolean;
+  value: RepositoryModelOverrideValue;
+  onChange: (value: RepositoryModelOverrideValue) => void;
+  onRemove: () => void;
+  disabled?: boolean;
+}) {
+  const availableVariants = useMemo(
+    () => getAvailableThinkingEfforts(value.modelSlug),
+    [value.modelSlug]
+  );
+
+  return (
+    <div className="flex flex-col gap-2 p-3 sm:flex-row sm:items-center sm:justify-between">
+      <span className="min-w-0 truncate font-mono text-sm" title={repoFullName}>
+        {repoFullName}
+      </span>
+      <div className="flex items-center gap-2">
+        <ModelCombobox
+          variant="compact"
+          models={models}
+          isLoading={isLoadingModels}
+          value={value.modelSlug}
+          disabled={disabled}
+          // Selecting a model resets thinking effort — the prior effort may not exist
+          // on the newly chosen model.
+          onValueChange={modelSlug => onChange({ ...value, modelSlug, thinkingEffort: null })}
+        />
+        {availableVariants.length > 0 && (
+          <Select
+            value={value.thinkingEffort ?? '__default__'}
+            onValueChange={variant =>
+              onChange({
+                ...value,
+                thinkingEffort: variant === '__default__' ? null : variant,
+              })
+            }
+            disabled={disabled}
+          >
+            <SelectTrigger className="h-9 w-36">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__default__">Default effort</SelectItem>
+              {availableVariants.map(variant => (
+                <SelectItem key={variant} value={variant}>
+                  {thinkingEffortLabel(variant)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground h-9 px-2"
+          onClick={onRemove}
+          disabled={disabled}
+          aria-label={`Remove model override for ${repoFullName}`}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function AddRepositoryButton({
+  repositories,
+  onSelect,
+  disabled,
+}: {
+  repositories: RepositoryOverrideOption[];
+  onSelect: (repository: RepositoryOverrideOption) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const noneLeft = repositories.length === 0;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled || noneLeft}
+          className="gap-1.5"
+        >
+          <Plus className="h-4 w-4" />
+          {noneLeft ? 'All repositories have overrides' : 'Add repository'}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[min(24rem,calc(100vw-2rem))] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search repositories..." />
+          <CommandEmpty>No repositories match your search</CommandEmpty>
+          <CommandList className="max-h-64 overflow-auto">
+            <CommandGroup>
+              {repositories.map(repository => (
+                <CommandItem
+                  key={repository.id}
+                  value={repository.full_name}
+                  onSelect={() => {
+                    onSelect(repository);
+                    setOpen(false);
+                  }}
+                  className="font-mono"
+                >
+                  {repository.full_name}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
@@ -36,6 +36,10 @@ import { useOrganizationModels } from '@/components/cloud-agent/hooks/useOrganiz
 import { ModelCombobox } from '@/components/shared/ModelCombobox';
 import { cn } from '@/lib/utils';
 import { RepositoryMultiSelect } from './RepositoryMultiSelect';
+import {
+  RepositoryModelOverrides,
+  type RepositoryModelOverrideValue,
+} from './RepositoryModelOverrides';
 import { CodeReviewActionRequiredAlert } from './CodeReviewActionRequiredAlert';
 import { PRIMARY_DEFAULT_MODEL } from '@/lib/ai-gateway/models';
 import {
@@ -226,6 +230,12 @@ export function ReviewConfigForm({
   const [gateThreshold, setGateThreshold] = useState<'off' | 'all' | 'warning' | 'critical'>('off');
   const [repositorySelectionMode, setRepositorySelectionMode] = useState<'all' | 'selected'>('all');
   const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
+  // Per-repository model overrides keyed by repository id.
+  const [repositoryModelOverrides, setRepositoryModelOverrides] = useState<
+    Map<number, RepositoryModelOverrideValue>
+  >(new Map());
+  // Opt-in toggle for the per-repository model section.
+  const [overridesEnabled, setOverridesEnabled] = useState(false);
   const [useReviewMd, setUseReviewMd] = useState(true);
   // GitLab-specific: auto-configure webhooks
   const [autoConfigureWebhooks, setAutoConfigureWebhooks] = useState(true);
@@ -344,9 +354,36 @@ export function ReviewConfigForm({
           (repositoryId): repositoryId is number => typeof repositoryId === 'number'
         )
       );
+      const overridesMap = new Map<number, RepositoryModelOverrideValue>();
+      for (const override of configData.repositoryModelOverrides ?? []) {
+        if (typeof override.repositoryId === 'number') {
+          overridesMap.set(override.repositoryId, {
+            repoFullName: override.repoFullName,
+            modelSlug: override.modelSlug,
+            thinkingEffort: override.thinkingEffort ?? null,
+          });
+        }
+      }
+      setRepositoryModelOverrides(overridesMap);
+      setOverridesEnabled(overridesMap.size > 0);
       setUseReviewMd(!(configData.disableReviewMd ?? false));
     }
   }, [configData, isGitLab]);
+
+  const handleRepositoryModelOverrideSet = useCallback(
+    (repositoryId: number, value: RepositoryModelOverrideValue) => {
+      setRepositoryModelOverrides(prev => new Map(prev).set(repositoryId, value));
+    },
+    []
+  );
+
+  const handleRepositoryModelOverrideRemove = useCallback((repositoryId: number) => {
+    setRepositoryModelOverrides(prev => {
+      const next = new Map(prev);
+      next.delete(repositoryId);
+      return next;
+    });
+  }, []);
 
   // Organization mutations
   const orgToggleMutation = useMutation(
@@ -467,6 +504,18 @@ export function ReviewConfigForm({
       selectedRepositoryIdSet.has(repo.id)
     );
 
+    // Overrides are independent of the trigger selection mode — they apply whether
+    // reviews run on all or selected repositories. Sent only when the per-repository
+    // section is toggled on; toggling it off clears the overrides on save.
+    const repositoryModelOverridesPayload = overridesEnabled
+      ? Array.from(repositoryModelOverrides.entries()).map(([repositoryId, value]) => ({
+          repositoryId,
+          repoFullName: value.repoFullName,
+          modelSlug: value.modelSlug,
+          thinkingEffort: value.thinkingEffort,
+        }))
+      : [];
+
     if (organizationId) {
       orgSaveMutation.mutate({
         organizationId,
@@ -480,6 +529,7 @@ export function ReviewConfigForm({
         repositorySelectionMode,
         selectedRepositoryIds,
         manuallyAddedRepositories,
+        repositoryModelOverrides: repositoryModelOverridesPayload,
         disableReviewMd: !useReviewMd,
         // GitLab-specific: auto-configure webhooks
         autoConfigureWebhooks: isGitLab ? autoConfigureWebhooks : undefined,
@@ -496,6 +546,7 @@ export function ReviewConfigForm({
         repositorySelectionMode,
         selectedRepositoryIds,
         manuallyAddedRepositories,
+        repositoryModelOverrides: repositoryModelOverridesPayload,
         disableReviewMd: !useReviewMd,
         // GitLab-specific: auto-configure webhooks
         autoConfigureWebhooks: isGitLab ? autoConfigureWebhooks : undefined,
@@ -570,14 +621,14 @@ export function ReviewConfigForm({
 
           {/* Configuration Fields */}
           <div className={cn('space-y-8', !isEnabled && 'pointer-events-none opacity-50')}>
-            {/* AI Model Selection */}
+            {/* Default AI Model Selection */}
             <ModelCombobox
-              label="AI Model"
+              label="Default AI Model"
               models={modelOptions}
               value={selectedModel}
               onValueChange={setSelectedModel}
               isLoading={isLoadingModels}
-              helperText="Choose the AI model to use for code reviews"
+              helperText="Applies to all repositories unless overridden below"
             />
 
             {/* Thinking Effort — only shown when the model supports variants */}
@@ -768,6 +819,41 @@ export function ReviewConfigForm({
                 </>
               )}
             </div>
+
+            {/* Per-repository model overrides — independent of the trigger selection
+                mode above; applies whether reviews run on all or selected repos. */}
+            {repositoriesData?.integrationInstalled && selectableRepositories.length > 0 && (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between rounded-lg border p-4">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="per-repo-models" className="text-base font-semibold">
+                      Per-repository models
+                    </Label>
+                    <p className="text-muted-foreground text-sm">
+                      Run specific repositories&apos; reviews on a different model than the default.
+                    </p>
+                  </div>
+                  <Switch
+                    id="per-repo-models"
+                    checked={overridesEnabled}
+                    onCheckedChange={setOverridesEnabled}
+                    disabled={!isEnabled}
+                  />
+                </div>
+                {overridesEnabled && (
+                  <RepositoryModelOverrides
+                    availableRepositories={selectableRepositories}
+                    models={modelOptions}
+                    isLoadingModels={isLoadingModels}
+                    overrides={repositoryModelOverrides}
+                    defaultModelSlug={selectedModel}
+                    onSet={handleRepositoryModelOverrideSet}
+                    onRemove={handleRepositoryModelOverrideRemove}
+                    disabled={!isEnabled}
+                  />
+                )}
+              </div>
+            )}
 
             {/* GitLab Webhook Configuration */}
             {isGitLab &&

--- a/apps/web/src/lib/agent-config/core/types.ts
+++ b/apps/web/src/lib/agent-config/core/types.ts
@@ -4,7 +4,11 @@ export {
   ManuallyAddedRepositorySchema,
   CodeReviewAgentConfigSchema,
 } from '@kilocode/db/schema-types';
-export type { ManuallyAddedRepository, CodeReviewAgentConfig } from '@kilocode/db/schema-types';
+export type {
+  ManuallyAddedRepository,
+  CodeReviewAgentConfig,
+  RepositoryModelOverride,
+} from '@kilocode/db/schema-types';
 
 /**
  * Zod schema for ReviewConfig validation

--- a/apps/web/src/lib/code-reviews/core/model-selection.test.ts
+++ b/apps/web/src/lib/code-reviews/core/model-selection.test.ts
@@ -1,0 +1,121 @@
+import { resolveEffectiveModel } from './model-selection';
+import type { CodeReviewAgentConfig } from '@kilocode/db/schema-types';
+
+const FALLBACK = 'anthropic/claude-sonnet-4.6';
+
+function baseConfig(
+  overrides?: CodeReviewAgentConfig['repository_model_overrides'],
+  partial?: Partial<CodeReviewAgentConfig>
+): Pick<CodeReviewAgentConfig, 'model_slug' | 'thinking_effort' | 'repository_model_overrides'> {
+  return {
+    model_slug: 'anthropic/claude-opus-4.8',
+    thinking_effort: null,
+    repository_model_overrides: overrides,
+    ...partial,
+  };
+}
+
+describe('resolveEffectiveModel', () => {
+  it('uses the global model when there are no overrides', () => {
+    const result = resolveEffectiveModel(baseConfig(), 'acme/api', FALLBACK);
+    expect(result).toEqual({
+      modelSlug: 'anthropic/claude-opus-4.8',
+      thinkingEffort: null,
+      source: 'global',
+    });
+  });
+
+  it('falls back to the provided fallback when the global model_slug is empty', () => {
+    const result = resolveEffectiveModel(
+      baseConfig(undefined, { model_slug: '' }),
+      'acme/api',
+      FALLBACK
+    );
+    expect(result).toEqual({ modelSlug: FALLBACK, thinkingEffort: null, source: 'global' });
+  });
+
+  it('applies a matching override by repo_full_name', () => {
+    const result = resolveEffectiveModel(
+      baseConfig([
+        {
+          repository_id: 123,
+          repo_full_name: 'acme/api',
+          model_slug: 'openai/gpt-5',
+          thinking_effort: 'high',
+        },
+      ]),
+      'acme/api',
+      FALLBACK
+    );
+    expect(result).toEqual({
+      modelSlug: 'openai/gpt-5',
+      thinkingEffort: 'high',
+      source: 'repository_override',
+    });
+  });
+
+  it('matches on repo_full_name regardless of the override id type (Bitbucket UUID)', () => {
+    const result = resolveEffectiveModel(
+      baseConfig([
+        {
+          repository_id: '9b3c1d2e-0000-4000-8000-000000000000',
+          repo_full_name: 'workspace/repo',
+          model_slug: 'openai/gpt-5',
+        },
+      ]),
+      'workspace/repo',
+      FALLBACK
+    );
+    expect(result.modelSlug).toBe('openai/gpt-5');
+    expect(result.source).toBe('repository_override');
+  });
+
+  it('falls back to global when no override matches the repo', () => {
+    const result = resolveEffectiveModel(
+      baseConfig([
+        { repository_id: 123, repo_full_name: 'acme/other', model_slug: 'openai/gpt-5' },
+      ]),
+      'acme/api',
+      FALLBACK
+    );
+    expect(result.source).toBe('global');
+    expect(result.modelSlug).toBe('anthropic/claude-opus-4.8');
+  });
+
+  it('does not match a different repo name (no coercion / substring matching)', () => {
+    const result = resolveEffectiveModel(
+      baseConfig([{ repository_id: 1, repo_full_name: 'acme/api', model_slug: 'openai/gpt-5' }]),
+      'acme/api-internal',
+      FALLBACK
+    );
+    expect(result.source).toBe('global');
+  });
+
+  it('treats a blank override model_slug as no override', () => {
+    const result = resolveEffectiveModel(
+      baseConfig([{ repository_id: 1, repo_full_name: 'acme/api', model_slug: '' }]),
+      'acme/api',
+      FALLBACK
+    );
+    expect(result.source).toBe('global');
+    expect(result.modelSlug).toBe('anthropic/claude-opus-4.8');
+  });
+
+  it('defaults a matching override thinking effort to null when omitted', () => {
+    const result = resolveEffectiveModel(
+      baseConfig([{ repository_id: 1, repo_full_name: 'acme/api', model_slug: 'openai/gpt-5' }]),
+      'acme/api',
+      FALLBACK
+    );
+    expect(result.thinkingEffort).toBeNull();
+  });
+
+  it('uses the global model when the review has no repo name', () => {
+    const result = resolveEffectiveModel(
+      baseConfig([{ repository_id: 1, repo_full_name: 'acme/api', model_slug: 'openai/gpt-5' }]),
+      null,
+      FALLBACK
+    );
+    expect(result.source).toBe('global');
+  });
+});

--- a/apps/web/src/lib/code-reviews/core/model-selection.ts
+++ b/apps/web/src/lib/code-reviews/core/model-selection.ts
@@ -1,0 +1,61 @@
+/**
+ * Per-repository model selection.
+ *
+ * A Code Reviewer config carries a global `model_slug` / `thinking_effort` plus an
+ * optional list of per-repository overrides (`repository_model_overrides`). This
+ * helper resolves the *effective* model for a single review: an override applies
+ * only when its `repo_full_name` exactly matches the review's repository; otherwise
+ * the global model is used.
+ *
+ * Matching is on `repo_full_name` because that is the only repo identifier persisted
+ * on the review row across every platform (numeric IDs are not on the row for GitHub
+ * or Bitbucket). See `RepositoryModelOverrideSchema`.
+ */
+
+import type { CodeReviewAgentConfig } from '@kilocode/db/schema-types';
+
+export type EffectiveModelSelection = {
+  modelSlug: string;
+  thinkingEffort: string | null;
+  source: 'repository_override' | 'global';
+};
+
+/**
+ * Resolve the effective model for a review's repository.
+ *
+ * @param config       The Code Reviewer agent config (global model + overrides).
+ * @param repoFullName The review row's `repo_full_name` (e.g. "owner/repo"). Null/
+ *                     empty falls back to the global model.
+ * @param fallbackModel Model to use when the config has no global `model_slug`
+ *                     (mirrors the existing `config.model_slug || DEFAULT_...` guard).
+ */
+export function resolveEffectiveModel(
+  config: Pick<
+    CodeReviewAgentConfig,
+    'model_slug' | 'thinking_effort' | 'repository_model_overrides'
+  >,
+  repoFullName: string | null | undefined,
+  fallbackModel: string
+): EffectiveModelSelection {
+  const globalSelection: EffectiveModelSelection = {
+    modelSlug: config.model_slug || fallbackModel,
+    thinkingEffort: config.thinking_effort ?? null,
+    source: 'global',
+  };
+
+  if (!repoFullName) return globalSelection;
+
+  const override = config.repository_model_overrides?.find(
+    entry => entry.repo_full_name === repoFullName
+  );
+
+  // An override with a blank model_slug is treated as "no override" so a malformed
+  // entry can never blank out the model — fall back to the global selection.
+  if (!override || !override.model_slug) return globalSelection;
+
+  return {
+    modelSlug: override.model_slug,
+    thinkingEffort: override.thinking_effort ?? null,
+    source: 'repository_override',
+  };
+}

--- a/apps/web/src/lib/code-reviews/core/repository-model-override.test.ts
+++ b/apps/web/src/lib/code-reviews/core/repository-model-override.test.ts
@@ -1,0 +1,69 @@
+import { CodeReviewAgentConfigSchema } from '@kilocode/db/schema-types';
+
+// Schema validation for repository_model_overrides. Lives in the web tree (not
+// packages/db) because the web jest suite is what actually runs in CI.
+describe('CodeReviewAgentConfigSchema repository_model_overrides', () => {
+  const base = {
+    review_style: 'balanced' as const,
+    focus_areas: [],
+    model_slug: 'anthropic/claude-sonnet-4.6',
+  };
+
+  it('accepts a config without repository_model_overrides (backward compatible)', () => {
+    expect(CodeReviewAgentConfigSchema.safeParse(base).success).toBe(true);
+  });
+
+  it('accepts numeric and UUID override repository ids', () => {
+    const result = CodeReviewAgentConfigSchema.safeParse({
+      ...base,
+      repository_model_overrides: [
+        { repository_id: 123, repo_full_name: 'acme/api', model_slug: 'openai/gpt-5' },
+        {
+          repository_id: '9b3c1d2e-0000-4000-8000-000000000000',
+          repo_full_name: 'workspace/repo',
+          model_slug: 'openai/gpt-5',
+          thinking_effort: 'high',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a null thinking_effort on an override', () => {
+    const result = CodeReviewAgentConfigSchema.safeParse({
+      ...base,
+      repository_model_overrides: [
+        {
+          repository_id: 1,
+          repo_full_name: 'acme/api',
+          model_slug: 'openai/gpt-5',
+          thinking_effort: null,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an override missing repo_full_name', () => {
+    const result = CodeReviewAgentConfigSchema.safeParse({
+      ...base,
+      repository_model_overrides: [{ repository_id: 1, model_slug: 'openai/gpt-5' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid thinking_effort on an override', () => {
+    const result = CodeReviewAgentConfigSchema.safeParse({
+      ...base,
+      repository_model_overrides: [
+        {
+          repository_id: 1,
+          repo_full_name: 'acme/api',
+          model_slug: 'openai/gpt-5',
+          thinking_effort: 'high-3', // digits/hyphen not allowed by the regex
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
@@ -301,6 +301,89 @@ describe('tryDispatchPendingReviews', () => {
     );
   });
 
+  it('applies a per-repository model override to the dispatched config', async () => {
+    const timestamp = minutesAgo(1);
+    const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
+    mockGetAgentConfigForOwner.mockResolvedValue({
+      id: 'test-agent-config',
+      config: {
+        model_slug: 'anthropic/claude-sonnet-4.6',
+        thinking_effort: null,
+        repository_model_overrides: [
+          {
+            repository_id: 123,
+            repo_full_name: REPO,
+            model_slug: 'openai/gpt-5',
+            thinking_effort: 'high',
+          },
+        ],
+      },
+      is_enabled: true,
+      runtime_state: {},
+    });
+
+    const [review] = await db
+      .insert(cloud_agent_code_reviews)
+      .values(
+        reviewValues({ owner, status: 'pending', createdAt: timestamp, updatedAt: timestamp })
+      )
+      .returning({ id: cloud_agent_code_reviews.id });
+
+    await tryDispatchPendingReviews({ type: 'user', id: testUser.id, userId: testUser.id });
+
+    expect(mockPrepareReviewPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reviewId: review.id,
+        agentConfig: expect.objectContaining({
+          config: expect.objectContaining({
+            model_slug: 'openai/gpt-5',
+            thinking_effort: 'high',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('uses the global model when no repository override matches', async () => {
+    const timestamp = minutesAgo(1);
+    const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
+    mockGetAgentConfigForOwner.mockResolvedValue({
+      id: 'test-agent-config',
+      config: {
+        model_slug: 'anthropic/claude-sonnet-4.6',
+        thinking_effort: null,
+        repository_model_overrides: [
+          {
+            repository_id: 999,
+            repo_full_name: 'some-other-org/some-other-repo',
+            model_slug: 'openai/gpt-5',
+            thinking_effort: 'high',
+          },
+        ],
+      },
+      is_enabled: true,
+      runtime_state: {},
+    });
+
+    const [review] = await db
+      .insert(cloud_agent_code_reviews)
+      .values(
+        reviewValues({ owner, status: 'pending', createdAt: timestamp, updatedAt: timestamp })
+      )
+      .returning({ id: cloud_agent_code_reviews.id });
+
+    await tryDispatchPendingReviews({ type: 'user', id: testUser.id, userId: testUser.id });
+
+    expect(mockPrepareReviewPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reviewId: review.id,
+        agentConfig: expect.objectContaining({
+          config: expect.objectContaining({ model_slug: 'anthropic/claude-sonnet-4.6' }),
+        }),
+      })
+    );
+  });
+
   it('keeps organization concurrency at 20 reviews', async () => {
     const recentTimestamp = minutesAgo(1);
     const owner = { type: 'org', id: testOrganizationId } satisfies ReviewOwner;

--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
@@ -34,6 +34,9 @@ import { captureException } from '@sentry/nextjs';
 import { errorExceptInTest, logExceptInTest } from '@/lib/utils.server';
 import { codeReviewWorkerClient } from '../client/code-review-worker-client';
 import { CodeReviewPlatformSchema, type CodeReviewPlatform } from '../core/schemas';
+import { DEFAULT_CODE_REVIEW_MODEL } from '../core/constants';
+import { resolveEffectiveModel } from '../core/model-selection';
+import type { CodeReviewAgentConfig } from '@kilocode/db/schema-types';
 import { appendCodeReviewAnalyticsPromptAppendix } from '../analytics/contracts';
 import { getReviewAnalyticsEnabledFromConfig } from '../analytics/settings';
 import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
@@ -497,7 +500,34 @@ async function dispatchReservedReview(reservation: ReservedReview, owner: Owner)
       );
     }
 
-    agentConfig = persistedAgentConfig;
+    // Resolve the per-repository model override (if any) against the live config.
+    // Manual reviews are intentionally excluded — they keep the model the user
+    // picked in the manual dialog (handled by the `manualConfig` branch above).
+    // Only rewrite the config when an override actually applies, so the no-override
+    // path passes the live config through untouched.
+    const persistedConfig = persistedAgentConfig.config as CodeReviewAgentConfig;
+    const effectiveModel = resolveEffectiveModel(
+      persistedConfig,
+      review.repo_full_name,
+      DEFAULT_CODE_REVIEW_MODEL
+    );
+    if (effectiveModel.source === 'repository_override') {
+      logExceptInTest('[dispatchReview] Applying per-repository model override', {
+        reviewId: review.id,
+        repo: review.repo_full_name,
+        model: effectiveModel.modelSlug,
+      });
+      agentConfig = {
+        ...persistedAgentConfig,
+        config: {
+          ...persistedConfig,
+          model_slug: effectiveModel.modelSlug,
+          thinking_effort: effectiveModel.thinkingEffort,
+        },
+      };
+    } else {
+      agentConfig = persistedAgentConfig;
+    }
   }
 
   const payload = await prepareReviewPayload({

--- a/apps/web/src/routers/code-reviews-router.test.ts
+++ b/apps/web/src/routers/code-reviews-router.test.ts
@@ -2227,4 +2227,33 @@ describe('review agent config repository model overrides', () => {
       },
     ]);
   });
+
+  it('rejects duplicate repository overrides for the same repo', async () => {
+    const caller = await createCallerForUser(testUser.id);
+    await expect(
+      caller.personalReviewAgent.saveReviewConfig({
+        platform: 'github',
+        reviewStyle: 'balanced',
+        focusAreas: [],
+        modelSlug: 'test-model',
+        repositorySelectionMode: 'all',
+        selectedRepositoryIds: [],
+        repositoryModelOverrides: [
+          {
+            repositoryId: 101,
+            repoFullName: 'acme/api',
+            modelSlug: 'openai/gpt-5',
+            thinkingEffort: null,
+          },
+          {
+            repositoryId: 101,
+            repoFullName: 'acme/api',
+            modelSlug: 'anthropic/claude-sonnet-5',
+            thinkingEffort: null,
+          },
+        ],
+        autoConfigureWebhooks: false,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
 });

--- a/apps/web/src/routers/code-reviews-router.test.ts
+++ b/apps/web/src/routers/code-reviews-router.test.ts
@@ -2047,3 +2047,184 @@ describe('codeReviewRouter attempts', () => {
     }
   });
 });
+
+describe('review agent config repository model overrides', () => {
+  let testUser: User;
+  let organization: Organization;
+
+  beforeAll(async () => {
+    testUser = await insertTestUser();
+    organization = await createTestOrganization('Override Config Org', testUser.id, 0, {}, false);
+  });
+
+  afterEach(async () => {
+    await db
+      .delete(agent_configs)
+      .where(
+        or(
+          eq(agent_configs.owned_by_user_id, testUser.id),
+          eq(agent_configs.owned_by_organization_id, organization.id)
+        )
+      );
+  });
+
+  it('round-trips personal overrides independent of the selected repositories', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    await caller.personalReviewAgent.saveReviewConfig({
+      platform: 'github',
+      reviewStyle: 'balanced',
+      focusAreas: [],
+      modelSlug: 'test-model',
+      repositorySelectionMode: 'selected',
+      selectedRepositoryIds: [101],
+      repositoryModelOverrides: [
+        {
+          repositoryId: 101,
+          repoFullName: 'acme/api',
+          modelSlug: 'openai/gpt-5',
+          thinkingEffort: 'high',
+        },
+        // 202 is not in the trigger selection but overrides are independent of it.
+        {
+          repositoryId: 202,
+          repoFullName: 'acme/other',
+          modelSlug: 'openai/gpt-5',
+          thinkingEffort: null,
+        },
+      ],
+      autoConfigureWebhooks: false,
+    });
+
+    const returned = await caller.personalReviewAgent.getReviewConfig({ platform: 'github' });
+    expect(returned.repositoryModelOverrides).toEqual([
+      {
+        repositoryId: 101,
+        repoFullName: 'acme/api',
+        modelSlug: 'openai/gpt-5',
+        thinkingEffort: 'high',
+      },
+      {
+        repositoryId: 202,
+        repoFullName: 'acme/other',
+        modelSlug: 'openai/gpt-5',
+        thinkingEffort: null,
+      },
+    ]);
+  });
+
+  it('keeps personal overrides in all-repositories mode', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    await caller.personalReviewAgent.saveReviewConfig({
+      platform: 'github',
+      reviewStyle: 'balanced',
+      focusAreas: [],
+      modelSlug: 'test-model',
+      repositorySelectionMode: 'all',
+      selectedRepositoryIds: [],
+      repositoryModelOverrides: [
+        {
+          repositoryId: 101,
+          repoFullName: 'acme/api',
+          modelSlug: 'openai/gpt-5',
+          thinkingEffort: null,
+        },
+      ],
+      autoConfigureWebhooks: false,
+    });
+
+    const returned = await caller.personalReviewAgent.getReviewConfig({ platform: 'github' });
+    expect(returned.repositoryModelOverrides).toEqual([
+      {
+        repositoryId: 101,
+        repoFullName: 'acme/api',
+        modelSlug: 'openai/gpt-5',
+        thinkingEffort: null,
+      },
+    ]);
+  });
+
+  it('clears personal overrides when an empty list is saved', async () => {
+    const caller = await createCallerForUser(testUser.id);
+    const saveWith = (
+      repositoryModelOverrides: Array<{
+        repositoryId: number;
+        repoFullName: string;
+        modelSlug: string;
+        thinkingEffort: string | null;
+      }>
+    ) =>
+      caller.personalReviewAgent.saveReviewConfig({
+        platform: 'github',
+        reviewStyle: 'balanced',
+        focusAreas: [],
+        modelSlug: 'test-model',
+        repositorySelectionMode: 'all',
+        selectedRepositoryIds: [],
+        repositoryModelOverrides,
+        autoConfigureWebhooks: false,
+      });
+
+    await saveWith([
+      {
+        repositoryId: 101,
+        repoFullName: 'acme/api',
+        modelSlug: 'openai/gpt-5',
+        thinkingEffort: null,
+      },
+    ]);
+    await saveWith([]);
+
+    const returned = await caller.personalReviewAgent.getReviewConfig({ platform: 'github' });
+    expect(returned.repositoryModelOverrides).toEqual([]);
+  });
+
+  it('round-trips organization github overrides independent of the selection', async () => {
+    const caller = await createCallerForUser(testUser.id);
+
+    await caller.organizations.reviewAgent.saveReviewConfig({
+      organizationId: organization.id,
+      platform: 'github',
+      reviewStyle: 'balanced',
+      focusAreas: [],
+      modelSlug: 'test-model',
+      repositorySelectionMode: 'selected',
+      selectedRepositoryIds: [101],
+      repositoryModelOverrides: [
+        {
+          repositoryId: 101,
+          repoFullName: 'acme/api',
+          modelSlug: 'openai/gpt-5',
+          thinkingEffort: null,
+        },
+        {
+          repositoryId: 202,
+          repoFullName: 'acme/other',
+          modelSlug: 'openai/gpt-5',
+          thinkingEffort: null,
+        },
+      ],
+      autoConfigureWebhooks: false,
+    });
+
+    const returned = await caller.organizations.reviewAgent.getReviewConfig({
+      organizationId: organization.id,
+      platform: 'github',
+    });
+    expect(returned.repositoryModelOverrides).toEqual([
+      {
+        repositoryId: 101,
+        repoFullName: 'acme/api',
+        modelSlug: 'openai/gpt-5',
+        thinkingEffort: null,
+      },
+      {
+        repositoryId: 202,
+        repoFullName: 'acme/other',
+        modelSlug: 'openai/gpt-5',
+        thinkingEffort: null,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/routers/code-reviews-router.ts
+++ b/apps/web/src/routers/code-reviews-router.ts
@@ -40,6 +40,19 @@ const ManuallyAddedRepositoryInputSchema = z.object({
   private: z.boolean(),
 });
 
+// Personal integrations are GitHub/GitLab only, so override repo IDs are numeric.
+const RepositoryModelOverrideInputSchema = z.object({
+  repositoryId: z.number(),
+  repoFullName: z.string().max(511),
+  modelSlug: z.string(),
+  thinkingEffort: z
+    .string()
+    .max(50)
+    .regex(/^[a-zA-Z]+$/)
+    .nullable()
+    .optional(),
+});
+
 const SaveReviewConfigInputSchema = z.object({
   platform: PlatformSchema,
   reviewStyle: z.enum(['strict', 'balanced', 'lenient', 'roast']),
@@ -55,6 +68,7 @@ const SaveReviewConfigInputSchema = z.object({
   repositorySelectionMode: z.enum(['all', 'selected']).optional(),
   selectedRepositoryIds: z.array(z.number()).optional(),
   manuallyAddedRepositories: z.array(ManuallyAddedRepositoryInputSchema).optional(),
+  repositoryModelOverrides: z.array(RepositoryModelOverrideInputSchema).optional(),
   disableReviewMd: z.boolean().optional(),
   gateThreshold: z.enum(['off', 'all', 'warning', 'critical']).optional(),
   // GitLab-specific: auto-configure webhooks
@@ -166,6 +180,7 @@ export const personalReviewAgentRouter = createTRPCRouter({
           repositorySelectionMode: 'all' as const,
           selectedRepositoryIds: [],
           manuallyAddedRepositories: [],
+          repositoryModelOverrides: [],
           disableReviewMd: true,
           reviewMemoryEnabled: false,
           actionRequired: null,
@@ -186,6 +201,17 @@ export const personalReviewAgentRouter = createTRPCRouter({
           (repositoryId): repositoryId is number => typeof repositoryId === 'number'
         ),
         manuallyAddedRepositories: cfg.manually_added_repositories || [],
+        repositoryModelOverrides: (cfg.repository_model_overrides ?? [])
+          .filter(
+            (override): override is typeof override & { repository_id: number } =>
+              typeof override.repository_id === 'number'
+          )
+          .map(override => ({
+            repositoryId: override.repository_id,
+            repoFullName: override.repo_full_name,
+            modelSlug: override.model_slug,
+            thinkingEffort: override.thinking_effort ?? null,
+          })),
         disableReviewMd: cfg.disable_review_md ?? true,
         reviewMemoryEnabled: getReviewMemoryEnabledFromConfig(config.config),
         actionRequired: getCodeReviewActionRequiredState(config),
@@ -209,6 +235,16 @@ export const personalReviewAgentRouter = createTRPCRouter({
           (previousConfig?.config as CodeReviewAgentConfig | undefined)?.selected_repository_ids ||
           [];
 
+        // Per-repository model overrides are independent of the trigger selection —
+        // they apply in both 'all' and 'selected' modes. IDs are numeric for personal
+        // (GitHub/GitLab) integrations, enforced by the input schema.
+        const repositoryModelOverrides = (input.repositoryModelOverrides ?? []).map(override => ({
+          repository_id: override.repositoryId,
+          repo_full_name: override.repoFullName,
+          model_slug: override.modelSlug,
+          thinking_effort: override.thinkingEffort ?? null,
+        }));
+
         // Save the agent config
         await upsertAgentConfigForOwner({
           owner,
@@ -224,6 +260,7 @@ export const personalReviewAgentRouter = createTRPCRouter({
             repository_selection_mode: input.repositorySelectionMode || 'all',
             selected_repository_ids: input.selectedRepositoryIds || [],
             manually_added_repositories: input.manuallyAddedRepositories || [],
+            repository_model_overrides: repositoryModelOverrides,
             disable_review_md: input.disableReviewMd ?? true,
             review_memory_enabled: false,
             review_analytics_enabled: false,

--- a/apps/web/src/routers/code-reviews-router.ts
+++ b/apps/web/src/routers/code-reviews-router.ts
@@ -10,7 +10,7 @@ import {
   upsertAgentConfigForOwner,
   setAgentEnabledForOwner,
 } from '@/lib/agent-config/db/agent-configs';
-import type { CodeReviewAgentConfig } from '@/lib/agent-config/core/types';
+import type { CodeReviewAgentConfig, RepositoryModelOverride } from '@/lib/agent-config/core/types';
 import { fetchGitHubRepositoriesForUser } from '@/lib/cloud-agent/github-integration-helpers';
 import { fetchGitLabRepositoriesForUser } from '@/lib/cloud-agent/gitlab-integration-helpers';
 import { PRIMARY_DEFAULT_MODEL } from '@/lib/ai-gateway/models';
@@ -44,7 +44,10 @@ const ManuallyAddedRepositoryInputSchema = z.object({
 const RepositoryModelOverrideInputSchema = z.object({
   repositoryId: z.number(),
   repoFullName: z.string().max(511),
-  modelSlug: z.string(),
+  // Keep in sync with RepositoryModelOverrideSchema.model_slug (canonical storage),
+  // so an over-long slug is rejected at save time rather than failing the config's
+  // canonical parse on read.
+  modelSlug: z.string().max(512),
   thinkingEffort: z
     .string()
     .max(50)
@@ -238,7 +241,9 @@ export const personalReviewAgentRouter = createTRPCRouter({
         // Per-repository model overrides are independent of the trigger selection —
         // they apply in both 'all' and 'selected' modes. IDs are numeric for personal
         // (GitHub/GitLab) integrations, enforced by the input schema.
-        const repositoryModelOverrides = (input.repositoryModelOverrides ?? []).map(override => ({
+        const repositoryModelOverrides: RepositoryModelOverride[] = (
+          input.repositoryModelOverrides ?? []
+        ).map(override => ({
           repository_id: override.repositoryId,
           repo_full_name: override.repoFullName,
           model_slug: override.modelSlug,

--- a/apps/web/src/routers/code-reviews-router.ts
+++ b/apps/web/src/routers/code-reviews-router.ts
@@ -56,6 +56,31 @@ const RepositoryModelOverrideInputSchema = z.object({
     .optional(),
 });
 
+// Bound the overrides array so a caller cannot grow the JSONB config unbounded, and
+// reject duplicate entries for the same repo (by id or full name) — dispatch resolves
+// via first-match, so duplicates would silently pick one. Mirrors the duplicate
+// rejection already applied to Bitbucket selectedRepositoryIds.
+const MAX_REPOSITORY_MODEL_OVERRIDES = 1000;
+
+function rejectDuplicateRepositoryModelOverrides(
+  overrides: Array<{ repositoryId: number | string; repoFullName: string }>,
+  ctx: z.RefinementCtx
+) {
+  const seenIds = new Set<number | string>();
+  const seenNames = new Set<string>();
+  for (const override of overrides) {
+    if (seenIds.has(override.repositoryId) || seenNames.has(override.repoFullName)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Duplicate repository model override for the same repository',
+      });
+      return;
+    }
+    seenIds.add(override.repositoryId);
+    seenNames.add(override.repoFullName);
+  }
+}
+
 const SaveReviewConfigInputSchema = z.object({
   platform: PlatformSchema,
   reviewStyle: z.enum(['strict', 'balanced', 'lenient', 'roast']),
@@ -71,7 +96,11 @@ const SaveReviewConfigInputSchema = z.object({
   repositorySelectionMode: z.enum(['all', 'selected']).optional(),
   selectedRepositoryIds: z.array(z.number()).optional(),
   manuallyAddedRepositories: z.array(ManuallyAddedRepositoryInputSchema).optional(),
-  repositoryModelOverrides: z.array(RepositoryModelOverrideInputSchema).optional(),
+  repositoryModelOverrides: z
+    .array(RepositoryModelOverrideInputSchema)
+    .max(MAX_REPOSITORY_MODEL_OVERRIDES)
+    .superRefine(rejectDuplicateRepositoryModelOverrides)
+    .optional(),
   disableReviewMd: z.boolean().optional(),
   gateThreshold: z.enum(['off', 'all', 'warning', 'critical']).optional(),
   // GitLab-specific: auto-configure webhooks

--- a/apps/web/src/routers/organizations/organization-code-reviews-router.ts
+++ b/apps/web/src/routers/organizations/organization-code-reviews-router.ts
@@ -22,6 +22,7 @@ import {
 import {
   CodeReviewAgentConfigSchema,
   type CodeReviewAgentConfig,
+  type RepositoryModelOverride,
 } from '@/lib/agent-config/core/types';
 import { fetchGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
 import { fetchGitLabRepositoriesForOrganization } from '@/lib/cloud-agent/gitlab-integration-helpers';
@@ -71,7 +72,10 @@ const ManuallyAddedRepositoryInputSchema = z.object({
 const RepositoryModelOverrideInputSchema = z.object({
   repositoryId: z.union([z.number(), z.string()]),
   repoFullName: z.string().max(511),
-  modelSlug: z.string(),
+  // Keep in sync with RepositoryModelOverrideSchema.model_slug (canonical storage),
+  // so an over-long slug is rejected at save time rather than failing the config's
+  // canonical parse on read.
+  modelSlug: z.string().max(512),
   thinkingEffort: z
     .string()
     .max(50)
@@ -526,7 +530,9 @@ export const organizationReviewAgentRouter = createTRPCRouter({
         // they apply in both 'all' and 'selected' modes. Keep only overrides whose id
         // type matches the platform (numeric for GitHub/GitLab, UUID string for
         // Bitbucket), mirroring how selected repository ids are validated.
-        const repositoryModelOverrides = (input.repositoryModelOverrides ?? [])
+        const repositoryModelOverrides: RepositoryModelOverride[] = (
+          input.repositoryModelOverrides ?? []
+        )
           .filter(override =>
             isBitbucket
               ? typeof override.repositoryId === 'string'

--- a/apps/web/src/routers/organizations/organization-code-reviews-router.ts
+++ b/apps/web/src/routers/organizations/organization-code-reviews-router.ts
@@ -65,6 +65,21 @@ const ManuallyAddedRepositoryInputSchema = z.object({
   private: z.boolean(),
 });
 
+// Repository IDs are numeric for GitHub/GitLab and UUID strings for Bitbucket, so
+// the override ID is a union here; per-platform validation happens against the
+// validated `selectedRepositoryIds` at save time.
+const RepositoryModelOverrideInputSchema = z.object({
+  repositoryId: z.union([z.number(), z.string()]),
+  repoFullName: z.string().max(511),
+  modelSlug: z.string(),
+  thinkingEffort: z
+    .string()
+    .max(50)
+    .regex(/^[a-zA-Z]+$/)
+    .nullable()
+    .optional(),
+});
+
 const SaveReviewConfigInputSchema = OrganizationIdInputSchema.extend({
   platform: PlatformSchema,
   reviewStyle: z.enum(['strict', 'balanced', 'lenient', 'roast']),
@@ -80,6 +95,7 @@ const SaveReviewConfigInputSchema = OrganizationIdInputSchema.extend({
   repositorySelectionMode: z.enum(['all', 'selected']).optional(),
   selectedRepositoryIds: z.array(z.union([z.number(), z.string()])).optional(),
   manuallyAddedRepositories: z.array(ManuallyAddedRepositoryInputSchema).optional(),
+  repositoryModelOverrides: z.array(RepositoryModelOverrideInputSchema).optional(),
   disableReviewMd: z.boolean().optional(),
   gateThreshold: z.enum(['off', 'all', 'warning', 'critical']).optional(),
   // GitLab-specific: auto-configure webhooks
@@ -426,6 +442,7 @@ export const organizationReviewAgentRouter = createTRPCRouter({
             platform === 'bitbucket' ? ('selected' as const) : ('all' as const),
           selectedRepositoryIds: [],
           manuallyAddedRepositories: [],
+          repositoryModelOverrides: [],
           disableReviewMd: true,
           reviewMemoryEnabled: false,
           actionRequired: null,
@@ -454,6 +471,18 @@ export const organizationReviewAgentRouter = createTRPCRouter({
           : cfg.repository_selection_mode || 'all',
         selectedRepositoryIds,
         manuallyAddedRepositories: isBitbucket ? [] : cfg.manually_added_repositories || [],
+        repositoryModelOverrides: (cfg.repository_model_overrides ?? [])
+          .filter(override =>
+            isBitbucket
+              ? typeof override.repository_id === 'string'
+              : typeof override.repository_id === 'number'
+          )
+          .map(override => ({
+            repositoryId: override.repository_id,
+            repoFullName: override.repo_full_name,
+            modelSlug: override.model_slug,
+            thinkingEffort: override.thinking_effort ?? null,
+          })),
         disableReviewMd: isBitbucket ? true : (cfg.disable_review_md ?? true),
         reviewMemoryEnabled: isBitbucket ? false : getReviewMemoryEnabledFromConfig(config.config),
         actionRequired: getCodeReviewActionRequiredState(config),
@@ -493,6 +522,23 @@ export const organizationReviewAgentRouter = createTRPCRouter({
           }
         }
 
+        // Per-repository model overrides are independent of the trigger selection —
+        // they apply in both 'all' and 'selected' modes. Keep only overrides whose id
+        // type matches the platform (numeric for GitHub/GitLab, UUID string for
+        // Bitbucket), mirroring how selected repository ids are validated.
+        const repositoryModelOverrides = (input.repositoryModelOverrides ?? [])
+          .filter(override =>
+            isBitbucket
+              ? typeof override.repositoryId === 'string'
+              : typeof override.repositoryId === 'number'
+          )
+          .map(override => ({
+            repository_id: override.repositoryId,
+            repo_full_name: override.repoFullName,
+            model_slug: override.modelSlug,
+            thinking_effort: override.thinkingEffort ?? null,
+          }));
+
         await upsertAgentConfig({
           organizationId: input.organizationId,
           agentType: 'code_review',
@@ -509,6 +555,7 @@ export const organizationReviewAgentRouter = createTRPCRouter({
               : input.repositorySelectionMode || 'all',
             selected_repository_ids: selectedRepositoryIds,
             manually_added_repositories: isBitbucket ? [] : input.manuallyAddedRepositories || [],
+            repository_model_overrides: repositoryModelOverrides,
             disable_review_md: isBitbucket ? true : (input.disableReviewMd ?? true),
             review_memory_enabled: false,
             review_analytics_enabled: false,

--- a/apps/web/src/routers/organizations/organization-code-reviews-router.ts
+++ b/apps/web/src/routers/organizations/organization-code-reviews-router.ts
@@ -84,6 +84,31 @@ const RepositoryModelOverrideInputSchema = z.object({
     .optional(),
 });
 
+// Bound the overrides array so a caller cannot grow the JSONB config unbounded, and
+// reject duplicate entries for the same repo (by id or full name) — dispatch resolves
+// via first-match, so duplicates would silently pick one. Mirrors the duplicate
+// rejection already applied to Bitbucket selectedRepositoryIds.
+const MAX_REPOSITORY_MODEL_OVERRIDES = 1000;
+
+function rejectDuplicateRepositoryModelOverrides(
+  overrides: Array<{ repositoryId: number | string; repoFullName: string }>,
+  ctx: z.RefinementCtx
+) {
+  const seenIds = new Set<number | string>();
+  const seenNames = new Set<string>();
+  for (const override of overrides) {
+    if (seenIds.has(override.repositoryId) || seenNames.has(override.repoFullName)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Duplicate repository model override for the same repository',
+      });
+      return;
+    }
+    seenIds.add(override.repositoryId);
+    seenNames.add(override.repoFullName);
+  }
+}
+
 const SaveReviewConfigInputSchema = OrganizationIdInputSchema.extend({
   platform: PlatformSchema,
   reviewStyle: z.enum(['strict', 'balanced', 'lenient', 'roast']),
@@ -99,7 +124,11 @@ const SaveReviewConfigInputSchema = OrganizationIdInputSchema.extend({
   repositorySelectionMode: z.enum(['all', 'selected']).optional(),
   selectedRepositoryIds: z.array(z.union([z.number(), z.string()])).optional(),
   manuallyAddedRepositories: z.array(ManuallyAddedRepositoryInputSchema).optional(),
-  repositoryModelOverrides: z.array(RepositoryModelOverrideInputSchema).optional(),
+  repositoryModelOverrides: z
+    .array(RepositoryModelOverrideInputSchema)
+    .max(MAX_REPOSITORY_MODEL_OVERRIDES)
+    .superRefine(rejectDuplicateRepositoryModelOverrides)
+    .optional(),
   disableReviewMd: z.boolean().optional(),
   gateThreshold: z.enum(['off', 'all', 'warning', 'critical']).optional(),
   // GitLab-specific: auto-configure webhooks

--- a/packages/app-shared/src/code-review/config.test.ts
+++ b/packages/app-shared/src/code-review/config.test.ts
@@ -14,6 +14,7 @@ const config: CodeReviewConfigInput = {
   gateThreshold: 'off',
   repositorySelectionMode: 'all',
   selectedRepositoryIds: [],
+  repositoryModelOverrides: [],
   disableReviewMd: true,
 };
 
@@ -30,8 +31,26 @@ describe('buildSaveConfigInput', () => {
       gateThreshold: 'off',
       repositorySelectionMode: 'all',
       selectedRepositoryIds: [],
+      repositoryModelOverrides: [],
       disableReviewMd: true,
     });
+  });
+
+  it('preserves repository model overrides across an unrelated patch', () => {
+    const overrides = [
+      {
+        repositoryId: 123,
+        repoFullName: 'acme/api',
+        modelSlug: 'anthropic/claude-opus-4.8',
+        thinkingEffort: null,
+      },
+    ];
+    const input = buildSaveConfigInput(
+      'github',
+      { ...config, repositoryModelOverrides: overrides },
+      { reviewStyle: 'strict' }
+    );
+    expect(input.repositoryModelOverrides).toEqual(overrides);
   });
 
   it('applies patches over current values', () => {

--- a/packages/app-shared/src/code-review/config.ts
+++ b/packages/app-shared/src/code-review/config.ts
@@ -1,5 +1,15 @@
 import type { CodeReviewPlatform, GateThreshold, ReviewStyle } from './enums';
 
+// Wire shape of a per-repository model override. Mirrors the tRPC input/output
+// contract (camelCase); the persisted snake_case shape lives in
+// RepositoryModelOverrideSchema in @kilocode/db/schema-types.
+export type RepositoryModelOverrideInput = {
+  repositoryId: number | string;
+  repoFullName: string;
+  modelSlug: string;
+  thinkingEffort: string | null;
+};
+
 // Structural shape of the review config a save request is built from —
 // matches apps/mobile/src/lib/code-reviewer-config.ts's ReviewConfigData
 // (mobile keeps that name/type locally, derived from its tRPC query output;
@@ -13,6 +23,7 @@ export type CodeReviewConfigInput = {
   gateThreshold: GateThreshold;
   repositorySelectionMode: 'all' | 'selected';
   selectedRepositoryIds: (number | string)[];
+  repositoryModelOverrides: RepositoryModelOverrideInput[];
   disableReviewMd: boolean;
 };
 
@@ -25,6 +36,7 @@ export type CodeReviewConfigPatch = Partial<{
   gateThreshold: GateThreshold;
   repositorySelectionMode: 'all' | 'selected';
   selectedRepositoryIds: (number | string)[];
+  repositoryModelOverrides: RepositoryModelOverrideInput[];
   disableReviewMd: boolean;
 }>;
 
@@ -59,6 +71,9 @@ export function buildSaveConfigInput(
         ? ('selected' as const)
         : config.repositorySelectionMode,
     selectedRepositoryIds: config.selectedRepositoryIds,
+    // Preserve web-created overrides across mobile settings edits (mobile has no
+    // override editing UI in v1). The server prunes these to the current selection.
+    repositoryModelOverrides: config.repositoryModelOverrides,
     disableReviewMd: config.disableReviewMd,
     ...(platform === 'gitlab' ? { autoConfigureWebhooks: true as const } : {}),
     ...patch,

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1324,6 +1324,33 @@ export const CodeReviewCouncilConfigSchema = z.object({
 });
 export type CodeReviewCouncilConfig = z.infer<typeof CodeReviewCouncilConfigSchema>;
 
+// Per-repository model override. Ties a repository to a specific model so a repo
+// can run its standard review on a different model than the global default. A repo
+// without an entry here uses the config's global `model_slug`.
+//
+// Two identifiers are stored intentionally, each serving a lookup the other can't:
+//   - `repository_id` matches `selected_repository_ids` (GitHub/GitLab numeric,
+//     Bitbucket UUID). Used at save time for selection/pruning parity.
+//   - `repo_full_name` is the platform's canonical full name and the ONLY repo
+//     identifier persisted on the review row, so it is what the dispatch-time model
+//     lookup matches against (numeric IDs are not on the row for GitHub/Bitbucket).
+export const RepositoryModelOverrideSchema = z.object({
+  // Matched by exact value and type against the platform repository ID — never coerced.
+  repository_id: z.union([z.number(), z.string()]),
+  // "owner/repo" (GitHub), path_with_namespace (GitLab), "workspace/slug" (Bitbucket).
+  repo_full_name: z.string().max(511),
+  model_slug: z.string().max(512),
+  // Thinking effort variant name (e.g. "high", "max") — null means model default,
+  // matching the global `thinking_effort` field below.
+  thinking_effort: z
+    .string()
+    .max(50)
+    .regex(/^[a-zA-Z]+$/)
+    .nullable()
+    .optional(),
+});
+export type RepositoryModelOverride = z.infer<typeof RepositoryModelOverrideSchema>;
+
 export const CodeReviewAgentConfigSchema = z.object({
   review_style: z.enum(REVIEW_STYLES),
   focus_areas: z.array(z.string()),
@@ -1343,6 +1370,8 @@ export const CodeReviewAgentConfigSchema = z.object({
   selected_repository_ids: z.array(z.union([z.number(), z.string()])).optional(),
   // Manually added repositories (for GitLab where pagination limits results)
   manually_added_repositories: z.array(ManuallyAddedRepositorySchema).optional(),
+  // Per-repository model overrides. Absent/empty = every repo uses the global model_slug.
+  repository_model_overrides: z.array(RepositoryModelOverrideSchema).optional(),
   disable_review_md: z.boolean().optional(),
   // Controls when the PR gate check (GitHub Check Run / GitLab commit status)
   // reports a failure based on review findings.


### PR DESCRIPTION
## Summary

Adds per-repository model selection to Code Reviewer. Each repository uses the global default model unless it has an override, in which case automatic reviews for that repository run on the chosen model and thinking effort. Overrides are stored in a new field on the existing `agent_configs` JSONB config, so there is no database migration. The override is resolved at dispatch by matching the review's `repo_full_name`, which is the only repository identifier present on the review row across GitHub, GitLab, and Bitbucket.

Main changes:

- Config schema (`packages/db/src/schema-types.ts`): add `RepositoryModelOverrideSchema` and a `repository_model_overrides` field on `CodeReviewAgentConfigSchema`. Each override holds `repository_id`, `repo_full_name`, `model_slug`, and optional `thinking_effort`. Configs without the field keep working unchanged.
- Dispatch (`dispatch-pending-reviews.ts` + new `core/model-selection.ts`): a `resolveEffectiveModel` helper resolves the effective model for a webhook review and swaps `model_slug`/`thinking_effort` before the payload is built. When no override matches, the live config passes through untouched.
- Routers (`code-reviews-router.ts`, `organizations/organization-code-reviews-router.ts`): accept and return `repositoryModelOverrides`, with per-platform id validation (numeric for GitHub/GitLab, UUID for Bitbucket). Overrides apply in both "all" and "selected" repository modes.
- Web UI (`ReviewConfigForm.tsx`, new `RepositoryModelOverrides.tsx`): rename "AI Model" to "Default AI Model" with helper text, and add an opt-in "Per-repository models" section that lists repositories on demand via an "Add repository" picker, each with its own model and thinking-effort control.
- Mobile and shared contract (`app-shared/src/code-review/config.ts`, mobile config and hook): thread `repositoryModelOverrides` through `buildSaveConfigInput` so mobile preserves overrides created on web. No mobile editing UI in this change.
- Tests: resolution helper and config schema unit tests, router save/get round trips (including pruning and per-platform validation), and dispatch tests asserting the override model is applied and the default is used when no override matches.

## Verification

Manually tested against local dev by posting signed `pull_request` webhooks to `/api/webhooks/github` for a connected repository:

- [x] Saved and reloaded per-repo overrides through the config UI and confirmed they persist in `agent_configs`.
- [x] Fired a webhook for a repository with an override and one without; the overridden repository dispatched on its model, the other fell back to the default.
- [x] Pushed a commit to an open PR and let the review run to completion on the overridden model; it posted findings on the PR and the review detail page recorded the model that ran.

## Visual Changes

The Code Reviewer config screen renames "AI Model" to "Default AI Model" (with helper text) and adds an opt-in "Per-repository models" section. Screenshots to add.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- Overrides live in the existing `agent_configs` JSONB (no migration). Reads still validate the whole config with `CodeReviewAgentConfigSchema`, so the router input schemas cap `modelSlug` at 512 to match the canonical schema and avoid a save-then-fail-on-read gap.
- Resolution matches on `repo_full_name` because numeric repository ids are not stored on the review row for GitHub or Bitbucket. A repository rename means the override stops matching and the repository falls back to the default (a safe default rather than an error).
- Manual reviews are intentionally not affected; they keep the model selected in the manual dialog.
- Mobile is preserve-only: it keeps overrides created on web but does not add editing UI.
