### PR TITLE
fix(ai-gateway): support PDFs for Gemini models

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -23,7 +23,7 @@ import { seed_20_code_free_model } from '@/lib/ai-gateway/providers/seed';
 import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 import { MINIMAX_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/minimax';
 import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
-import { gemma_4_26b_a4b_it_free_model } from '@/lib/ai-gateway/providers/google';
+import { gemma_4_26b_a4b_it_free_model, isGeminiModel } from '@/lib/ai-gateway/providers/google';
 import { QWEN37_PLUS_MODEL_ID, qwen36_plus_stealth_model } from '@/lib/ai-gateway/providers/qwen';
 import { stepfun_37_flash_free_model } from '@/lib/ai-gateway/providers/stepfun';
 import { isGrokModel } from '@/lib/ai-gateway/providers/xai';
@@ -73,7 +73,7 @@ export const preferredModels = [
 ];
 
 export function isPdfSupportingModel(model: string): boolean {
-  return isClaudeModel(model) || isOpenAiModel(model) || isGrokModel(model);
+  return isClaudeModel(model) || isOpenAiModel(model) || isGrokModel(model) || isGeminiModel(model);
 }
 
 export function isKiloExclusiveFreeModel(model: string): boolean {

--- a/apps/web/src/lib/ai-gateway/providers/google.ts
+++ b/apps/web/src/lib/ai-gateway/providers/google.ts
@@ -22,6 +22,10 @@ export const gemma_4_26b_a4b_it_free_model: KiloExclusiveModel = {
   inference_provider_restriction: [],
 };
 
+export function isGeminiModel(model: string) {
+  return model.includes('gemini');
+}
+
 export function isGemini3Model(model: string) {
   return model.includes('gemini-3');
 }


### PR DESCRIPTION
## Summary
- detect Gemini models with a shared provider predicate
- mark Gemini models as supporting PDF inputs

## Verification
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/providers/model-prefix.test.ts src/lib/ai-gateway/models.test.ts`
- `scripts/typecheck-all.sh --changes-only`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/models.ts apps/web/src/lib/ai-gateway/providers/google.ts`
- `git diff --check`