### PR TITLE
fix(mobile): match navigation gesture background to theme

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -31,6 +31,7 @@
     "@kilocode/trpc": "workspace:*",
     "@react-native-community/netinfo": "11.5.2",
     "@react-native-google-signin/google-signin": "^16.1.2",
+    "@react-navigation/native": "7.1.33",
     "@rn-primitives/portal": "1.3.0",
     "@rn-primitives/slot": "1.2.0",
     "@sentry/react-native": "~7.11.0",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -5,6 +5,7 @@ import {
   JetBrainsMono_500Medium,
   JetBrainsMono_600SemiBold,
 } from '@expo-google-fonts/jetbrains-mono';
+import { ThemeProvider } from '@react-navigation/native';
 import * as Sentry from '@sentry/react-native';
 import { isRunningInExpoGo } from 'expo';
 import { useFonts } from 'expo-font';
@@ -32,6 +33,7 @@ import { useAnalyticsConsentGate } from '@/lib/hooks/use-analytics-consent-gate'
 import { useForceUpdate } from '@/lib/hooks/use-force-update';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
 import { useScreenTracking } from '@/lib/hooks/use-screen-tracking';
+import { useNavigationTheme } from '@/lib/hooks/use-theme-colors';
 import { useTrackingPermissionPrompt } from '@/lib/hooks/use-tracking-permission-prompt';
 import {
   checkInitialNotification,
@@ -325,6 +327,7 @@ function RootLayoutNav() {
 
 function RootLayout() {
   const ref = useNavigationContainerRef();
+  const navigationTheme = useNavigationTheme();
 
   useEffect(() => {
     if (ref.current) {
@@ -340,10 +343,12 @@ function RootLayout() {
   }, []);
 
   return (
-    <AppRootProviders>
-      <StatusBar style="auto" />
-      <RootLayoutNav />
-    </AppRootProviders>
+    <ThemeProvider value={navigationTheme}>
+      <AppRootProviders>
+        <StatusBar style="auto" />
+        <RootLayoutNav />
+      </AppRootProviders>
+    </ThemeProvider>
   );
 }
 

--- a/apps/mobile/src/lib/hooks/use-theme-colors.ts
+++ b/apps/mobile/src/lib/hooks/use-theme-colors.ts
@@ -1,3 +1,4 @@
+import { DarkTheme, DefaultTheme } from '@react-navigation/native';
 import { useColorScheme } from 'react-native';
 
 // These values must stay in sync with src/global.css design tokens.
@@ -74,4 +75,23 @@ export type ThemeColors = { readonly [K in keyof typeof lightColors]: string };
 export function useThemeColors(): ThemeColors {
   const colorScheme = useColorScheme();
   return colorScheme === 'dark' ? darkColors : lightColors;
+}
+
+export function useNavigationTheme() {
+  const colorScheme = useColorScheme();
+  const colors = colorScheme === 'dark' ? darkColors : lightColors;
+  const baseTheme = colorScheme === 'dark' ? DarkTheme : DefaultTheme;
+
+  return {
+    ...baseTheme,
+    colors: {
+      ...baseTheme.colors,
+      primary: colors.primary,
+      background: colors.background,
+      card: colors.card,
+      text: colors.foreground,
+      border: colors.border,
+      notification: colors.destructive,
+    },
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,9 @@ importers:
       '@react-native-google-signin/google-signin':
         specifier: ^16.1.2
         version: 16.1.2(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)
+      '@react-navigation/native':
+        specifier: 7.1.33
+        version: 7.1.33(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)
       '@rn-primitives/portal':
         specifier: 1.3.0
         version: 1.3.0(@types/react@19.2.14)(immer@11.1.4)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@6.0.6))(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))


### PR DESCRIPTION
## Summary

- provide the Kilo light/dark palette through React Navigation at the app root
- make every nested native stack inherit the correct interactive-transition background
- declare the already-resolved `@react-navigation/native` version as a direct mobile dependency

## Test plan

- `pnpm format`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:unused`
- `pnpm test` — 118 files, 769 tests
- fresh iOS 26.5 E2E from a new OTP login and real Profile → Code Reviewer stack
  - dark partial swipe: 0/252 sampled frames exposed a bright background
  - light partial swipe: exposed corner matched the warm Kilo background
  - cancelled swipe returned byte-identically to Personal
  - completed swipe returned to Profile

## Verification note

`pnpx expo-doctor` passed 18/19 checks. Its only failure is the existing `origin/main` Expo patch-version drift across 24 Expo packages; this PR does not change those packages.