### PR TITLE
Update preferred AI model variants

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -27,7 +27,7 @@ import { QWEN37_PLUS_MODEL_ID, qwen36_plus_stealth_model } from '@/lib/ai-gatewa
 import { stepfun_37_flash_free_model } from '@/lib/ai-gateway/providers/stepfun';
 import { isGrokModel } from '@/lib/ai-gateway/providers/xai';
 import { isClaudeModel } from '@/lib/ai-gateway/providers/anthropic.constants';
-import { isOpenAiModel } from '@/lib/ai-gateway/providers/openai';
+import { GPT_CURRENT_MODEL_ID, isOpenAiModel } from '@/lib/ai-gateway/providers/openai';
 import { gpt_5_6_sol_stealth_model } from '@/lib/ai-gateway/providers/openai-exclusive';
 import { muse_spark_1_1_model } from '@/lib/ai-gateway/providers/meta';
 import { kat_coder_pro_v2_5_free_model } from '@/lib/ai-gateway/providers/streamlake';
@@ -55,7 +55,9 @@ export const preferredModels = [
 
   CLAUDE_SONNET_CURRENT_MODEL_ID,
   CLAUDE_OPUS_CURRENT_MODEL_ID,
-  gpt_5_6_sol_stealth_model.public_id,
+  gpt_5_6_sol_stealth_model.status === 'public'
+    ? gpt_5_6_sol_stealth_model.public_id
+    : GPT_CURRENT_MODEL_ID,
   deepseek_v4_pro_discounted_model.public_id,
   GLM_CURRENT_MODEL_ID,
   KIMI_CURRENT_MODEL_ID,

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -55,9 +55,10 @@ export const preferredModels = [
 
   CLAUDE_SONNET_CURRENT_MODEL_ID,
   CLAUDE_OPUS_CURRENT_MODEL_ID,
-  gpt_5_6_sol_stealth_model.status === 'public'
-    ? gpt_5_6_sol_stealth_model.public_id
-    : GPT_CURRENT_MODEL_ID,
+  GPT_CURRENT_MODEL_ID,
+  ...(gpt_5_6_sol_stealth_model.status === 'public'
+    ? [gpt_5_6_sol_stealth_model.public_id]
+    : []),
   deepseek_v4_pro_discounted_model.public_id,
   GLM_CURRENT_MODEL_ID,
   KIMI_CURRENT_MODEL_ID,

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -32,7 +32,10 @@ import { gpt_5_6_sol_stealth_model } from '@/lib/ai-gateway/providers/openai-exc
 import { muse_spark_1_1_model } from '@/lib/ai-gateway/providers/meta';
 import { kat_coder_pro_v2_5_free_model } from '@/lib/ai-gateway/providers/streamlake';
 import { GLM_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/zai';
-import { deepseekDiscountedModels } from '@/lib/ai-gateway/providers/deepseek';
+import {
+  deepseek_v4_pro_discounted_model,
+  deepseekDiscountedModels,
+} from '@/lib/ai-gateway/providers/deepseek';
 import { type ProviderId } from '@/lib/ai-gateway/providers/types';
 
 export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
@@ -53,7 +56,7 @@ export const preferredModels = [
   CLAUDE_SONNET_CURRENT_MODEL_ID,
   CLAUDE_OPUS_CURRENT_MODEL_ID,
   gpt_5_6_sol_stealth_model.public_id,
-  'deepseek/deepseek-v4-pro',
+  deepseek_v4_pro_discounted_model.public_id,
   GLM_CURRENT_MODEL_ID,
   KIMI_CURRENT_MODEL_ID,
   MINIMAX_CURRENT_MODEL_ID,

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -56,9 +56,7 @@ export const preferredModels = [
   CLAUDE_SONNET_CURRENT_MODEL_ID,
   CLAUDE_OPUS_CURRENT_MODEL_ID,
   GPT_CURRENT_MODEL_ID,
-  ...(gpt_5_6_sol_stealth_model.status === 'public'
-    ? [gpt_5_6_sol_stealth_model.public_id]
-    : []),
+  ...(gpt_5_6_sol_stealth_model.status === 'public' ? [gpt_5_6_sol_stealth_model.public_id] : []),
   deepseek_v4_pro_discounted_model.public_id,
   GLM_CURRENT_MODEL_ID,
   KIMI_CURRENT_MODEL_ID,

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -10,7 +10,6 @@ import {
   KILO_AUTO_FRONTIER_MODEL,
 } from '@/lib/ai-gateway/auto-model';
 import {
-  CLAUDE_OPUS_4_8_STEALTH_MODEL_ID,
   claude_opus_4_8_stealth_model,
   claude_opus_4_7_stealth_model,
   claude_sonnet_4_6_stealth_model,
@@ -28,15 +27,12 @@ import { QWEN37_PLUS_MODEL_ID, qwen36_plus_stealth_model } from '@/lib/ai-gatewa
 import { stepfun_37_flash_free_model } from '@/lib/ai-gateway/providers/stepfun';
 import { isGrokModel } from '@/lib/ai-gateway/providers/xai';
 import { isClaudeModel } from '@/lib/ai-gateway/providers/anthropic.constants';
-import { GPT_CURRENT_MODEL_ID, isOpenAiModel } from '@/lib/ai-gateway/providers/openai';
+import { isOpenAiModel } from '@/lib/ai-gateway/providers/openai';
 import { gpt_5_6_sol_stealth_model } from '@/lib/ai-gateway/providers/openai-exclusive';
 import { muse_spark_1_1_model } from '@/lib/ai-gateway/providers/meta';
 import { kat_coder_pro_v2_5_free_model } from '@/lib/ai-gateway/providers/streamlake';
 import { GLM_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/zai';
-import {
-  deepseek_v4_pro_discounted_model,
-  deepseekDiscountedModels,
-} from '@/lib/ai-gateway/providers/deepseek';
+import { deepseekDiscountedModels } from '@/lib/ai-gateway/providers/deepseek';
 import { type ProviderId } from '@/lib/ai-gateway/providers/types';
 
 export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
@@ -55,21 +51,13 @@ export const preferredModels = [
   ...autoFreeModels,
 
   CLAUDE_SONNET_CURRENT_MODEL_ID,
-  claude_opus_4_8_stealth_model.status === 'public'
-    ? CLAUDE_OPUS_4_8_STEALTH_MODEL_ID
-    : CLAUDE_OPUS_CURRENT_MODEL_ID,
-  GPT_CURRENT_MODEL_ID,
-  'openai/gpt-5.6-terra',
-
-  deepseek_v4_pro_discounted_model.status === 'public'
-    ? deepseek_v4_pro_discounted_model.public_id
-    : 'deepseek/deepseek-v4-pro',
+  CLAUDE_OPUS_CURRENT_MODEL_ID,
+  gpt_5_6_sol_stealth_model.public_id,
+  'deepseek/deepseek-v4-pro',
   GLM_CURRENT_MODEL_ID,
   KIMI_CURRENT_MODEL_ID,
   MINIMAX_CURRENT_MODEL_ID,
-  qwen36_plus_stealth_model.status === 'public'
-    ? qwen36_plus_stealth_model.public_id
-    : QWEN37_PLUS_MODEL_ID,
+  QWEN37_PLUS_MODEL_ID,
 ];
 
 export function isPdfSupportingModel(model: string): boolean {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -57,7 +57,9 @@ export const preferredModels = [
   CLAUDE_OPUS_CURRENT_MODEL_ID,
   GPT_CURRENT_MODEL_ID,
   ...(gpt_5_6_sol_stealth_model.status === 'public' ? [gpt_5_6_sol_stealth_model.public_id] : []),
-  deepseek_v4_pro_discounted_model.public_id,
+  deepseek_v4_pro_discounted_model.status === 'public'
+    ? deepseek_v4_pro_discounted_model.public_id
+    : 'deepseek/deepseek-v4-pro',
   GLM_CURRENT_MODEL_ID,
   KIMI_CURRENT_MODEL_ID,
   MINIMAX_CURRENT_MODEL_ID,

--- a/apps/web/src/tests/openrouter-models-config.test.ts
+++ b/apps/web/src/tests/openrouter-models-config.test.ts
@@ -13,7 +13,9 @@ describe('OpenRouter Models Config', () => {
     const expectedModels = [
       CLAUDE_SONNET_CURRENT_MODEL_ID,
       CLAUDE_OPUS_CURRENT_MODEL_ID,
-      gpt_5_6_sol_stealth_model.public_id,
+      gpt_5_6_sol_stealth_model.status === 'public'
+        ? gpt_5_6_sol_stealth_model.public_id
+        : GPT_CURRENT_MODEL_ID,
       'deepseek/deepseek-v4-pro:discounted',
       QWEN37_PLUS_MODEL_ID,
       'z-ai/glm-5.2',
@@ -24,7 +26,6 @@ describe('OpenRouter Models Config', () => {
     });
 
     const supersededModels = [
-      GPT_CURRENT_MODEL_ID,
       'openai/gpt-5.6-terra',
       'stealth/claude-opus-4.8',
       'deepseek/deepseek-v4-pro',
@@ -34,5 +35,11 @@ describe('OpenRouter Models Config', () => {
     supersededModels.forEach(model => {
       expect(preferredModels).not.toContain(model);
     });
+
+    const inactiveSolVariant =
+      gpt_5_6_sol_stealth_model.status === 'public'
+        ? GPT_CURRENT_MODEL_ID
+        : gpt_5_6_sol_stealth_model.public_id;
+    expect(preferredModels).not.toContain(inactiveSolVariant);
   });
 });

--- a/apps/web/src/tests/openrouter-models-config.test.ts
+++ b/apps/web/src/tests/openrouter-models-config.test.ts
@@ -1,14 +1,38 @@
 import { test, expect, describe } from '@jest/globals';
 import { preferredModels } from '@/lib/ai-gateway/models';
-import { CLAUDE_SONNET_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/anthropic.constants';
+import {
+  CLAUDE_OPUS_CURRENT_MODEL_ID,
+  CLAUDE_SONNET_CURRENT_MODEL_ID,
+} from '@/lib/ai-gateway/providers/anthropic.constants';
 import { GPT_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/openai';
+import { gpt_5_6_sol_stealth_model } from '@/lib/ai-gateway/providers/openai-exclusive';
+import { QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/providers/qwen';
 
 describe('OpenRouter Models Config', () => {
   test('preferred models should contain expected models', () => {
-    const expectedModels = [CLAUDE_SONNET_CURRENT_MODEL_ID, GPT_CURRENT_MODEL_ID, 'z-ai/glm-5.2'];
+    const expectedModels = [
+      CLAUDE_SONNET_CURRENT_MODEL_ID,
+      CLAUDE_OPUS_CURRENT_MODEL_ID,
+      gpt_5_6_sol_stealth_model.public_id,
+      'deepseek/deepseek-v4-pro',
+      QWEN37_PLUS_MODEL_ID,
+      'z-ai/glm-5.2',
+    ];
 
     expectedModels.forEach(model => {
       expect(preferredModels).toContain(model);
+    });
+
+    const supersededModels = [
+      GPT_CURRENT_MODEL_ID,
+      'openai/gpt-5.6-terra',
+      'stealth/claude-opus-4.8',
+      'deepseek/deepseek-v4-pro:discounted',
+      'stealth/qwen3.6-plus',
+    ];
+
+    supersededModels.forEach(model => {
+      expect(preferredModels).not.toContain(model);
     });
   });
 });

--- a/apps/web/src/tests/openrouter-models-config.test.ts
+++ b/apps/web/src/tests/openrouter-models-config.test.ts
@@ -13,9 +13,7 @@ describe('OpenRouter Models Config', () => {
     const expectedModels = [
       CLAUDE_SONNET_CURRENT_MODEL_ID,
       CLAUDE_OPUS_CURRENT_MODEL_ID,
-      gpt_5_6_sol_stealth_model.status === 'public'
-        ? gpt_5_6_sol_stealth_model.public_id
-        : GPT_CURRENT_MODEL_ID,
+      GPT_CURRENT_MODEL_ID,
       'deepseek/deepseek-v4-pro:discounted',
       QWEN37_PLUS_MODEL_ID,
       'z-ai/glm-5.2',
@@ -36,10 +34,13 @@ describe('OpenRouter Models Config', () => {
       expect(preferredModels).not.toContain(model);
     });
 
-    const inactiveSolVariant =
-      gpt_5_6_sol_stealth_model.status === 'public'
-        ? GPT_CURRENT_MODEL_ID
-        : gpt_5_6_sol_stealth_model.public_id;
-    expect(preferredModels).not.toContain(inactiveSolVariant);
+    if (gpt_5_6_sol_stealth_model.status === 'public') {
+      expect(preferredModels).toContain(gpt_5_6_sol_stealth_model.public_id);
+      expect(preferredModels.indexOf(GPT_CURRENT_MODEL_ID)).toBeLessThan(
+        preferredModels.indexOf(gpt_5_6_sol_stealth_model.public_id)
+      );
+    } else {
+      expect(preferredModels).not.toContain(gpt_5_6_sol_stealth_model.public_id);
+    }
   });
 });

--- a/apps/web/src/tests/openrouter-models-config.test.ts
+++ b/apps/web/src/tests/openrouter-models-config.test.ts
@@ -14,7 +14,7 @@ describe('OpenRouter Models Config', () => {
       CLAUDE_SONNET_CURRENT_MODEL_ID,
       CLAUDE_OPUS_CURRENT_MODEL_ID,
       gpt_5_6_sol_stealth_model.public_id,
-      'deepseek/deepseek-v4-pro',
+      'deepseek/deepseek-v4-pro:discounted',
       QWEN37_PLUS_MODEL_ID,
       'z-ai/glm-5.2',
     ];
@@ -27,7 +27,7 @@ describe('OpenRouter Models Config', () => {
       GPT_CURRENT_MODEL_ID,
       'openai/gpt-5.6-terra',
       'stealth/claude-opus-4.8',
-      'deepseek/deepseek-v4-pro:discounted',
+      'deepseek/deepseek-v4-pro',
       'stealth/qwen3.6-plus',
     ];
 

--- a/apps/web/src/tests/openrouter-models-config.test.ts
+++ b/apps/web/src/tests/openrouter-models-config.test.ts
@@ -4,6 +4,7 @@ import {
   CLAUDE_OPUS_CURRENT_MODEL_ID,
   CLAUDE_SONNET_CURRENT_MODEL_ID,
 } from '@/lib/ai-gateway/providers/anthropic.constants';
+import { deepseek_v4_pro_discounted_model } from '@/lib/ai-gateway/providers/deepseek';
 import { GPT_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/openai';
 import { gpt_5_6_sol_stealth_model } from '@/lib/ai-gateway/providers/openai-exclusive';
 import { QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/providers/qwen';
@@ -14,7 +15,9 @@ describe('OpenRouter Models Config', () => {
       CLAUDE_SONNET_CURRENT_MODEL_ID,
       CLAUDE_OPUS_CURRENT_MODEL_ID,
       GPT_CURRENT_MODEL_ID,
-      'deepseek/deepseek-v4-pro:discounted',
+      deepseek_v4_pro_discounted_model.status === 'public'
+        ? deepseek_v4_pro_discounted_model.public_id
+        : 'deepseek/deepseek-v4-pro',
       QWEN37_PLUS_MODEL_ID,
       'z-ai/glm-5.2',
     ];
@@ -26,7 +29,6 @@ describe('OpenRouter Models Config', () => {
     const supersededModels = [
       'openai/gpt-5.6-terra',
       'stealth/claude-opus-4.8',
-      'deepseek/deepseek-v4-pro',
       'stealth/qwen3.6-plus',
     ];
 
@@ -42,5 +44,11 @@ describe('OpenRouter Models Config', () => {
     } else {
       expect(preferredModels).not.toContain(gpt_5_6_sol_stealth_model.public_id);
     }
+
+    const inactiveDeepSeekVariant =
+      deepseek_v4_pro_discounted_model.status === 'public'
+        ? 'deepseek/deepseek-v4-pro'
+        : deepseek_v4_pro_discounted_model.public_id;
+    expect(preferredModels).not.toContain(inactiveDeepSeekVariant);
   });
 });


### PR DESCRIPTION
## Summary
- keep regular GPT-5.6 Sol preferred ahead of the discounted Martian variant
- include discounted Martian Sol only while its model status is public
- remove GPT-5.6 Terra from preferred models
- use regular Claude Opus 4.8 and Qwen 3.7 Plus variants
- prefer discounted DeepSeek V4 Pro while its model status is public, otherwise use regular V4 Pro
- update the focused preferred-model test for conditional inclusion, exclusion, and Sol ordering

## Validation
- git diff --check
- targeted oxfmt check for both changed files
- automated Kilo review: no issues found on prior revisions
- remaining validation runs in CI