### PR TITLE
chore(mobile): speed up agent workflow

### DIFF
--- a/apps/mobile/.kilo/MOBILE_WORKFLOW.md
+++ b/apps/mobile/.kilo/MOBILE_WORKFLOW.md
@@ -30,10 +30,10 @@ Use the current tmux session and a unique, descriptive window name. The canonica
 tmux new-window -t <planner-tmux-session> \
   -n <feature>-orchestrator \
   -c <dedicated-worktree>/apps/mobile \
-  'kilo run --interactive --model kilo/openai/gpt-5.6-sol --variant medium --title "<feature> orchestrator" --file <sanitized-handoff-file> "Execute the approved mobile plan in the attached handoff. Own implementation through the completion gate."'
+  'kilo run --interactive --model kilo/kilo-auto/frontier --title "<feature> orchestrator" --file <sanitized-handoff-file> "Execute the approved mobile plan in the attached handoff. Own implementation through the completion gate."'
 ```
 
-Use `kilo run --interactive` without `--continue` or `--session`; session freshness is required. The planner verifies that the tmux window started and then returns its window name, worktree paths, model, variant, and handoff-file path to the user. The fresh orchestrator must delete the temporary handoff file after ingesting it and before completion.
+Use `kilo run --interactive` without `--continue`, `--session`, or `--variant`; session freshness and Kilo Auto Frontier's default reasoning setting are required. The planner verifies that the tmux window started and then returns its window name, worktree paths, model, and handoff-file path to the user. The fresh orchestrator must delete the temporary handoff file after ingesting it and before completion.
 
 ## Feature State Matrix
 

--- a/apps/mobile/.kilo/MOBILE_WORKFLOW.md
+++ b/apps/mobile/.kilo/MOBILE_WORKFLOW.md
@@ -1,10 +1,39 @@
 # Mobile Agent Workflow
 
-Use this workflow when the main session is planning or implementing work whose product surface is the mobile app. Start Kilo from `apps/mobile/` so the role agents in `.kilo/agent/` are discovered. The implementation itself is not restricted to `apps/mobile`: an accepted plan may require cloud services, tRPC routers, shared packages, infrastructure, or a sibling checkout such as `~/Projects/kilocode`.
+Use this workflow when planning or implementing work whose product surface is the mobile app. Start Kilo from `apps/mobile/` so the role agents in `.kilo/agent/` are discovered. The implementation itself is not restricted to `apps/mobile`: an accepted plan may require cloud services, tRPC routers, shared packages, infrastructure, or a sibling checkout such as `~/Projects/kilocode`.
 
 Work must always be done in a dedicated worktree, regardless of the repository. This applies to the cloud repository and all sibling repositories touched by the plan. The orchestrator and role agents must not edit the primary checkout or the main checkout of any repository.
 
-The main session is the orchestrator and should use a strong model. Role agents use `kilo/kilo-auto/efficient`. The orchestrator retains product judgment, architecture decisions, loop control, final verification, Git integration, and pull-request ownership. Prefer small, logically scoped commits throughout the flow instead of one final catch-all commit.
+The initial main session is the planner. After plan approval, a fresh session becomes the orchestrator. Role agents use `kilo/kilo-auto/efficient`. The orchestrator retains product judgment, architecture decisions, loop control, final verification, Git integration, and pull-request ownership. Prefer small, logically scoped commits throughout the flow instead of one final catch-all commit.
+
+Role step limits are hard ceilings: `mobile-implementer` has 80 steps, `mobile-reviewer` has 50, and `mobile-e2e-verifier` has 100. Size every handoff below 75% of its role limit; an implementation slice should normally fit in roughly 60 planned steps. Do not raise a global limit to compensate for an oversized task.
+
+## Planner Handoff
+
+The planning session explores requirements, defines acceptance criteria, creates dedicated worktrees, and writes the approved plan. After the user approves the plan, the planning session must not implement it. It prepares a sanitized handoff and launches a fresh orchestrator in a named tmux window.
+
+The handoff must contain:
+
+- The accepted plan's absolute path and any approved design path
+- The dedicated worktree path for every repository in scope
+- Current branch, commit, and working-tree state in each worktree
+- Acceptance criteria, feature-state matrix, execution ledger, non-goals, and unresolved risks
+- Existing changes and resources that must be preserved
+- Required review, E2E, Git, PR, Kilobot, mergeability, and CI completion gates
+- A direct instruction to continue through a mergeable, conflict-free PR with all expected CI checks green on the latest head
+
+The handoff must not contain secrets or raw environment-file contents. Write only sanitized explicit values to a temporary file outside every repository. Never attach `.env`, `.env.*`, `.dev.vars`, or an equivalent environment-file.
+
+Use the current tmux session and a unique, descriptive window name. The canonical launch shape is:
+
+```bash
+tmux new-window -t <planner-tmux-session> \
+  -n <feature>-orchestrator \
+  -c <dedicated-worktree>/apps/mobile \
+  'kilo run --interactive --model kilo/openai/gpt-5.6-sol --variant medium --title "<feature> orchestrator" --file <sanitized-handoff-file> "Execute the approved mobile plan in the attached handoff. Own implementation through the completion gate."'
+```
+
+Use `kilo run --interactive` without `--continue` or `--session`; session freshness is required. The planner verifies that the tmux window started and then returns its window name, worktree paths, model, variant, and handoff-file path to the user. The fresh orchestrator must delete the temporary handoff file after ingesting it and before completion.
 
 ## Feature State Matrix
 
@@ -29,21 +58,35 @@ Do not collapse retryable and non-retryable failures into one generic error stat
 
 Reviewer and verifier invocations must be fresh sessions so earlier conclusions do not anchor later passes. Role agents do not dispatch other agents or perform commits, pushes, or PR operations.
 
+## Execution Ledger
+
+After accepting the plan, split it into the smallest behaviorally meaningful and independently testable slices. Record each slice in an execution ledger before dispatch:
+
+- Slice ID, dependencies, priority, and estimated step cost
+- Exact writable path set and forbidden path set in every repository
+- Shared generated outputs and mutable runtime resources
+- Producer-consumer dependency on contracts, schemas, generated code, or runtime state
+- Ownership-safe narrow checks and checks deferred until the synchronization barrier
+- Intended commit boundary
+
+Two slices are parallel-safe only when their write sets do not overlap, neither consumes an unstable output from the other, they share no mutable runtime resource, and neither runs a repository-wide mutating command. File separation alone is not sufficient when one slice changes a contract consumed by another. Lockfiles, dependency installation, migrations, generated clients, repository-wide formatters, and broad autofix commands are always serialized.
+
 ## Orchestration
 
-1. Discuss the request with the user. Inspect affected repositories, agree on acceptance criteria for every feature state in the matrix, and produce an implementation plan before dispatching work.
-2. Split the plan into the smallest slices that remain behaviorally meaningful and independently testable. Give `mobile-implementer` one slice, relevant repository paths, acceptance criteria, and required checks. A slice may span repositories when one contract change requires coordinated producers and consumers.
-3. Inspect the implementer's result and diff. Resolve ambiguity with the user or make architecture decisions in the main session; do not delegate judgment to the efficient model. After the slice passes its required review and checks, the orchestrator creates a concise logical commit before dispatching the next slice.
-4. Dispatch a fresh `mobile-reviewer` with the accepted plan, acceptance criteria, changed repositories, and exact diff range or working-tree scope.
-5. Triage every review finding in the main session. Send valid findings to `mobile-implementer`, then repeat review with a fresh reviewer. Record rejected findings with a short rationale to prevent churn.
-6. Stop after three repair rounds if findings remain. The main session takes over or asks the user to resolve the underlying ambiguity; never loop indefinitely.
-7. Once review has no valid findings, dispatch `mobile-e2e-verifier` with observable acceptance criteria and the intended worktree/service context.
-8. Route product failures through implementer and reviewer again. Let the verifier attempt one recovery for environment failures. The main session classifies inconclusive results before deciding whether code should change.
+1. Discuss the request with the user. Inspect affected repositories, agree on acceptance criteria for every feature state in the matrix, produce an implementation plan, and create the execution ledger.
+2. Dispatch every ready independent slice in a bounded wave, capped at two or three concurrent implementers. Include all other active slices and ownership boundaries in each handoff. Run only ownership-safe narrow checks while the wave is active.
+3. Treat completion of every active implementer as a synchronization barrier. Inspect each result, ownership adherence, and the combined diff. Resolve integration and architecture decisions in the main session, then run shared mutating commands and shared checks once. Preserve successful independent slices when another slice fails.
+4. Dispatch one fresh `mobile-reviewer` over the coherent wave. Triage findings in the main session and route valid fixes through a bounded repair wave followed by a fresh reviewer. Record rejected findings with a short rationale.
+5. After checks and review pass, create concise logical commits at the ledger's intended per-slice boundaries. Never let a role agent commit. If a slice reaches two budget-exhausted invocations, the orchestrator takes over rather than raising role limits.
+6. Stop after three repair rounds for the same issue. The orchestrator takes over or asks the user to resolve the underlying ambiguity; never loop indefinitely.
+7. When device E2E is likely, dispatch a separate prewarm-only `mobile-e2e-verifier` concurrently with implementation. It may prepare stable services, claim and label a device, install a baseline native build only when unaffected by active slices, connect the exact Metro URL, and establish login state. It must not judge acceptance behavior while implementation is changing. Retain its resource manifest.
+8. After the coherent implementation passes review, dispatch a fresh final `mobile-e2e-verifier` with the prewarm resource manifest. It independently revalidates ownership and provenance, relabels the simulator to `verify`, runs acceptance flows, and owns cleanup. Route product failures through a bounded repair wave and fresh reviewer before another fresh final verifier.
 9. The main session performs the final full-diff review and repository-appropriate verification, commits any final narrowly scoped repair, then pushes and creates or updates the PR. Assign the PR to the requesting human. Do not squash the work into a catch-all commit unless the user explicitly requests it.
 10. Wait until Kilobot has reviewed the latest head. Fetch every Kilobot review thread, including comments that arrive after earlier repairs, and triage each finding in the main session using the repository-root `AGENTS.md` review-remark workflow.
 11. For each valid finding, plan the smallest coherent repair and send that bounded task to `mobile-implementer`. Run the required narrow checks, dispatch a fresh `mobile-reviewer`, and create the smallest coherent commit before pushing. Reply in the original review thread with the concrete fix, then resolve the thread. Reject invalid findings with technical evidence in the same thread instead of changing correct code.
 12. Repeat the Kilobot triage, implementer, fresh reviewer, commit, push, reply, and resolution cycle until Kilobot has reviewed the latest head and there are no unresolved actionable Kilobot comments. Preserve the three-repair-round limit for any one finding; the main session takes over or asks the user if that limit is reached.
 13. Run local mobile E2E again after Kilobot repairs that affect behavior, build/runtime configuration, or the E2E workflow. Documentation-only or test-only repairs may skip repeated device E2E when the orchestrator records why the previously verified behavior is unaffected.
+14. Inspect the exact latest PR head SHA, mergeability, merge-state status, expected CI checks, and latest-head Kilobot review. If the base branch advances, integrate the current base in the dedicated worktree, resolve conflicts, rerun affected checks and local E2E, obtain fresh review, and push the new head. Wait again for CI and Kilobot on that exact head.
 
 ## Handoff Requirements
 
@@ -58,10 +101,27 @@ Every dispatch should include:
 - Exact checks or user flows expected for that stage
 - Prior findings being addressed, including rejected findings that must not be reopened without new evidence
 - The intended commit boundary for the assigned slice
+- Priority order, minimum complete outcome, optional work to drop, and a clean stopping rule before budget exhaustion
+- Required continuation state: completed work, remaining work, failures, files touched, checks run or deferred, and safest next action
 - A prohibition on reading secret-bearing environment files: role agents must not read `.env`, `.env.*`, `.dev.vars`, or equivalent files. Use documented setup commands, sanitized status or manifest output, and sanitized explicit values supplied by the orchestrator instead.
 - A prohibition on committing generated E2E fixtures: E2E fixtures must never be committed. Role agents may create them only in a temporary directory for the current run and must clean them up before returning control.
 
 Do not ask a role agent to infer context from the conversation it cannot see. Keep cross-repository changes on coordinated branches or working trees, and give the reviewer and verifier the location of every related diff. Never place secrets or raw environment-file contents in a handoff; provide only the minimum sanitized explicit values required for the task.
+
+## Workflow Metrics
+
+The final report records lightweight in-session measurements when applicable:
+
+- Number and width of implementation waves
+- Budget exhaustion and collision counts
+- Unmanaged listener detections
+- Prewarm reuse or invalidation
+- Simulator relabel or original-name restoration failures
+- Accepted-plan-to-final-E2E-start time
+- Accepted-plan-to-merged-PR time
+- Review, E2E repair, and latest-head CI wait/repair rounds
+
+Do not add persistent telemetry or a new data store for these metrics.
 
 ## Completion Gate
 
@@ -77,4 +137,6 @@ The orchestrator may call the work complete only when:
 - The main session has reviewed the complete diff and owns the Git/PR actions
 - The PR is assigned to the requesting human
 - Kilobot has reviewed the latest head and there are no unresolved actionable Kilobot comments
+- GitHub reports the exact latest head as mergeable with no conflicts
+- All expected CI checks on the latest head have reached a successful terminal state; failed, cancelled, timed-out, action-required, or pending checks block completion
 - Generated E2E fixtures have been cleaned up, and final `git status` confirms none are tracked or untracked in the repository

--- a/apps/mobile/.kilo/agent/mobile-e2e-verifier.md
+++ b/apps/mobile/.kilo/agent/mobile-e2e-verifier.md
@@ -9,6 +9,8 @@ permission:
   task: deny
   bash:
     "*": allow
+    "socat": deny
+    "socat *": deny
     "git commit*": deny
     "git push*": deny
     "gh pr*": deny
@@ -17,18 +19,28 @@ permission:
 
 You are a read-only E2E verifier for an approved mobile-app change. Repository files are immutable during verification, but you may operate worktree-local services, simulators, emulators, Maestro, disposable CLI installs, temporary files, and test data.
 
+The orchestrator must assign exactly one mode:
+
+- `prewarm`: prepare stable infrastructure concurrently with implementation, claim iOS with `pnpm dev:mobile:simulator claim [udid] --phase prewarm`, and return a resource manifest. Do not judge acceptance behavior while implementation is changing.
+- `verify`: independently revalidate all resource and bundle provenance, claim or relabel iOS with `pnpm dev:mobile:simulator claim [udid] --phase verify`, exercise acceptance criteria, and own cleanup. This must be a fresh verifier invocation.
+
+The 100-step limit is a hard ceiling. The handoff must define a priority order, minimum complete outcome, optional work to drop, and clean stopping rule before exhaustion.
+
 Before testing:
 
 1. Read `apps/mobile/e2e/AGENTS.md` and all instructions it references.
 2. Translate the orchestrator's acceptance criteria into observable happy, retryable unhappy, non-retryable unhappy, and empty flows for every new user-facing feature.
-3. Record pre-existing services, simulators, and tmux sessions so cleanup only removes resources you create. Claim a simulator with `pnpm dev:mobile:simulator claim`; never use one claimed by another worktree.
+3. Record pre-existing services, listeners, simulators, and tmux sessions so cleanup only removes resources you create. Never use a device claimed by another worktree.
 
 During verification:
 
 - Run the login/logout helper preflight rather than manually inferring bundle provenance, ports, or simulator ownership.
 - Run `pnpm dev:mobile:android doctor` before declaring Android tooling unavailable; do not rely on the inherited `PATH`.
+- Install only validated cached native builds with `pnpm dev:mobile:ios build <udid>` or `pnpm dev:mobile:android build <serial>`. Do not run an independent Xcode or Gradle producer.
 - Use Maestro as the primary driver on iOS and Android. Fall back to `xcrun simctl` on iOS or repository-wrapped ADB on Android only when Maestro cannot inspect or operate the state, or when low-level device control is required.
 - Inspect the current screen before selecting Maestro elements and re-inspect after UI changes. Copy exact hierarchy text; never infer selectors from screenshots or visible tab captions.
+- Prefer `xcrun simctl openurl` for iOS scheme reconnection. If a Safari/WebView flow shows the exact `Open this page in "Kilo"?` dialog, tap the exact `Open` accessibility action within the shared five-second optional-prompt budget; do not add a separate fixed wait.
+- You must not create ad hoc proxies, redirects, tunnels, NAT rules, or listeners to compensate for stale Expo state. This includes equivalent tools not covered by the explicit `socat` permission denial.
 - Exercise every applicable feature state that can be produced safely and deterministically. A skipped state requires an explicit rationale; do not silently omit it.
 - Confirm retryable and empty states show a meaningful message and actionable CTA, and that the CTA performs the expected recovery or next step.
 - Confirm non-retryable states show a meaningful message with no CTA at all.
@@ -42,11 +54,21 @@ Classify failures as one of:
 - Test-environment failure: services, build provenance, simulator, data, or tooling prevented a valid test
 - Inconclusive: evidence is insufficient to distinguish the two
 
-Attempt one reasonable recovery for a test-environment failure. Return product failures and unresolved environment failures to the orchestrator; never compensate by changing product code.
+Attempt one reasonable recovery for a test-environment failure. If exact-URL recovery still points at stale Metro state, return the failure and process/listener evidence to the orchestrator. Never compensate by changing product code or routing around provenance checks. An unmanaged listener invalidates a `prewarm` handoff.
 
-Return:
+Return a resource manifest containing:
+
+- Worktree path and assigned mode
+- Service status and reported ports
+- Device ID, current label, original name, owner, and phase
+- Native-build and Metro-provenance evidence
+- Every intentionally retained process and listener
+- Explicit cleanup owner for each retained resource
+
+Also return:
 
 - Flows exercised and device/platform
-- Pass/fail/skipped result for every feature state and acceptance criterion, with rationale for each skip
+- In `verify` mode only, pass/fail/skipped result for every feature state and acceptance criterion, with rationale for each skip
 - Failure classification, exact reproduction steps, and evidence
 - Cleanup performed and any resources intentionally left running
+- If stopping early: completed work, remaining work, failures, files or resources touched, checks run or deferred, and safest next action

--- a/apps/mobile/.kilo/agent/mobile-implementer.md
+++ b/apps/mobile/.kilo/agent/mobile-implementer.md
@@ -22,6 +22,7 @@ Before editing:
 2. Inspect the existing implementation and tests. Do not infer APIs or conventions from the task alone.
 3. Restate the acceptance criteria and flag ambiguity instead of making product or architecture decisions.
 4. For a new user-facing feature, restate the happy, retryable unhappy, non-retryable unhappy, and empty states. Include each state's trigger/classification, message intent, CTA label and outcome or required absence, and planned coverage. Do not proceed if a state is underdefined or omitted without an orchestrator-accepted rationale that it is structurally impossible.
+5. Restate your priority order, minimum complete outcome, optional work to drop, clean stopping rule before the 80-step hard limit, owned paths, forbidden paths, and all other active slices.
 
 While implementing:
 
@@ -29,6 +30,8 @@ While implementing:
 - Add or update focused behavioral tests for every applicable feature state. Verify meaningful messages and CTA behavior: retryable and empty states have an actionable CTA; non-retryable states have no CTA at all.
 - Do not merge retryable and non-retryable failures into a generic error presentation.
 - Preserve unrelated working-tree changes and never revert work you did not create.
+- Edit only the paths assigned to this slice and do not reformat another active slice's changes. If unexpected changes appear inside owned paths, stop and report the collision. If they appear outside owned paths, continue while preserving them.
+- Defer checks that require another active slice's unstable output until the orchestrator's synchronization barrier.
 - Run narrow formatting, type, lint, and test checks appropriate to the files changed.
 - Keep changes in small, logically scoped, independently reviewable slices. Finish and report one slice before starting the next when the orchestrator assigns multiple slices.
 - Do not expand scope, dispatch subagents, commit, push, or create/update a pull request.
@@ -42,3 +45,4 @@ Return:
 - Feature-state matrix coverage, including triggers, message semantics, CTA assertions, and any accepted structurally impossible states
 - Suggested commit boundary and concise commit message for the completed slice
 - Remaining risks, ambiguity, or work not completed
+- Continuation state when stopping early: completed work, remaining work, failures, files touched, checks run or deferred, and safest next action

--- a/apps/mobile/.kilo/agent/mobile-reviewer.md
+++ b/apps/mobile/.kilo/agent/mobile-reviewer.md
@@ -27,6 +27,8 @@ permission:
 
 You are an independent, read-only reviewer for an approved mobile-app plan. Review every relevant change, including cloud backend, shared-package, and sibling-repository changes when present. Do not edit files or fix findings yourself.
 
+The 50-step limit is a hard ceiling. The handoff must define a priority order, minimum complete outcome, optional work to drop, and clean stopping rule before exhaustion. Review one coherent wave diff rather than partial output from active implementers.
+
 Review against:
 
 - The orchestrator's accepted plan and acceptance criteria
@@ -49,3 +51,5 @@ Return findings first, ordered by severity. Every finding must include:
 - Required outcome, without prescribing unnecessary implementation details
 
 If there are no actionable findings, return exactly `No findings.` followed by any residual testing risks. Do not praise the implementation or provide a general summary before findings.
+
+If you must stop early, return continuation state containing completed review scope, remaining scope, failures, files inspected, checks run or deferred, and the safest next action.

--- a/apps/mobile/e2e/AGENTS.md
+++ b/apps/mobile/e2e/AGENTS.md
@@ -21,7 +21,7 @@ xcrun simctl list devices booted
 
 Reuse a complete stack already running for this worktree. Do not start a competing stack or stop an unrelated `kilo-dev-*` session.
 
-`kiloclaw-docker-tcp` on port 23750 is the sole intentional host-wide exception: it is a stateless loopback proxy to the same Docker socket. The runner reuses an occupied proxy. Never kill a `socat` process owned by another worktree to free this port.
+The sole intentional host-wide proxy exception is port `23750`. The repository-managed `kiloclaw-docker-tcp` service on that port is the sole intentional host-wide exception: it is a stateless loopback proxy to the same Docker socket. The runner reuses an occupied proxy. Never kill a `socat` process owned by another worktree to free this port.
 
 When this worktree has no stack, start the complete mobile flow. Secondary worktrees automatically receive an isolated port offset, and mobile startup generates and explicitly injects this worktree's LAN URLs before Metro starts. Do not export `KILO_PORT_OFFSET` or source `apps/mobile/.env`; stale parent-shell values must not select the bundle endpoints:
 
@@ -37,6 +37,14 @@ The session-ingest env step creates the JWT Secrets Store binding; without it th
 Secrets Store state is local to each Worker directory. `dev:start` runs env sync for its selected service graph and refreshes every source-backed secret before launching Workers; secret creation failures are fatal. Do not run bare `wrangler secrets-store` commands: use `pnpm dev:env -y <group>` from the repository root so values come from the canonical local source and Wrangler receives a complete non-interactive prompt.
 
 Confirm `mobile`, `nextjs`, `cloudflare-session-ingest`, `cloud-agent-next`, `kiloclaw`, and `event-service` are `up`. Restarts are asynchronous; if `mobile` is still starting, inspect its log and rerun status instead of restarting the stack. Use reported ports; never assume defaults in a secondary worktree.
+
+### Host Networking Safety
+
+You must never map port `8081` or another shared host port to a worktree Metro port. Except for the repository-managed `23750` proxy above, do not create ad hoc proxies, redirects, tunnels, NAT rules, or listeners to repair stale Expo state.
+
+After an exact development-client URL reconnect fails, perform at most one supported recovery through the existing preflight and launch flow. If the client still targets stale Metro state, return a test-environment failure with the Metro manifest, worktree root, expected URL, process evidence, and listener evidence. Do not route around bundle-provenance validation.
+
+When an unexpected listener exists, report its PID, parent PID, command, bind address, and port. Stop it only when the current invocation can prove it created the process. Otherwise return the ownership evidence to the orchestrator.
 
 ## Logs and tmux
 
@@ -61,31 +69,29 @@ E2E fixtures must never be committed. When a flow needs generated fixture files,
 
 ## iOS Simulator
 
-Never share a simulator with another worktree. Claim one before any build, install, login, Maestro, or MCP action; the command prefers an unclaimed shutdown device and boots it. Pass a UDID only when intentionally claiming that device:
+Never share a simulator with another worktree. Claim one before any build, install, login, Maestro, or MCP action; the command prefers an unclaimed shutdown device and boots it. A prewarm verifier uses `--phase prewarm`; the fresh acceptance verifier reclaims the same worktree-owned device with `--phase verify`:
 
 ```bash
-pnpm dev:mobile:simulator claim [udid]
+pnpm dev:mobile:simulator claim [udid] --phase prewarm
+pnpm dev:mobile:simulator claim [udid] --phase verify
 ```
 
-Uninstall Kilo, then build from this worktree in a dedicated tmux session. A fresh checkout generates the gitignored `ios/` directory and installs pods, so the first build takes a few minutes and is noisy:
+The wrapper visibly renames a claimed device to `Kilo E2E - <sanitized-worktree-basename> - <phase>`. Verifiers must not call `xcrun simctl rename` directly. Releasing an owned claim restores the original simulator name before removing the claim.
+
+Install a validated cached native build. A compatible fingerprint avoids rebuilding; a cache miss is serialized through the host-wide native compiler semaphore:
 
 ```bash
-xcrun simctl uninstall <udid> com.kilocode.kiloapp 2>/dev/null || true
-IOS_BUILD_SESSION="kilo-e2e-ios-$(basename "$PWD")"
-tmux new-session -d -s "$IOS_BUILD_SESSION" -c "$PWD/apps/mobile"
-tmux set-option -t "$IOS_BUILD_SESSION" remain-on-exit on
-tmux respawn-pane -k -t "$IOS_BUILD_SESSION":0.0 \
-  "npx expo run:ios --device <udid> --no-bundler"
-tmux capture-pane -p -t "$IOS_BUILD_SESSION" -S -80
-tmux display-message -p -t "$IOS_BUILD_SESSION" '#{pane_dead} #{pane_dead_status}'
+pnpm dev:mobile:ios build <udid>
 ```
 
-Poll the bounded pane tail until `pane_dead` is `1` and `pane_dead_status` is `0`; do not stream the full native build into agent context. Then connect to the Metro URL shown by this worktree's `mobile` pane. `expo run:ios --no-bundler` may still open port 8081 instead of the worktree-safe port:
+Do not consume an arbitrary DerivedData app or run a separate Expo native build. Connect the validated app to the Metro URL shown by this worktree's `mobile` pane:
 
 ```bash
 xcrun simctl openurl <udid> \
   "exp+kilo-app://expo-development-client/?url=http%3A%2F%2F<lan-ip>%3A<metro-port>"
 ```
+
+Prefer `xcrun simctl openurl` for low-level scheme reconnection to avoid Safari's external-app confirmation. If an acceptance flow intentionally follows the scheme through Safari or a WebView, inspect the hierarchy for the exact message `Open this page in "Kilo"?`, then tap the exact `Open` accessibility action. This is one bounded optional prompt within the existing five-second optional-prompt budget, not permission to add another fixed wait.
 
 Before testing, capture the `mobile` pane and verify `Starting project at <this-worktree>/apps/mobile` plus a fresh `iOS Bundled` line. Seeing the Kilo login screen alone does not prove bundle provenance. The login preflight also reads Metro's development manifest and verifies `expoConfig.extra.apiBaseUrl` and `_internal.projectRoot` against this worktree. These endpoint extras come from the Metro manifest in a dev client; after env changes, regenerate env, restart Metro, reconnect the dev client to the exact Metro URL, and reload. Rebuild only when native config/plugins changed. The shared launch flows dismiss the clean-install tracking alert, accept the Expo dev-menu introduction with `Continue`, and then close the full Expo/React Native developer menu containing Fast Refresh and Element Inspector with its `Close` accessibility action.
 
@@ -179,9 +185,10 @@ pnpm dev:mobile:android adb wait-for-device
 pnpm dev:mobile:android claim <serial>
 pnpm dev:mobile:android adb reverse tcp:<nextjs-port> tcp:<nextjs-port>
 pnpm dev:mobile:android adb reverse tcp:<metro-port> tcp:<metro-port>
-cd apps/mobile
-pnpm -w dev:mobile:android build
+pnpm dev:mobile:android build <serial>
 ```
+
+The build command installs a validated cached APK when the Android native fingerprint and toolchain match. Do not install an APK from another output path or invoke Gradle directly.
 
 Use Maestro as the primary Android automation driver, matching iOS. Fall back to repository-wrapped ADB when Maestro cannot inspect or operate a native prompt, when direct intent/process control is required, or when diagnosing the emulator itself. Android setup still uses ADB for readiness and port reversal. Use the repository wrapper rather than bare `adb`:
 
@@ -204,7 +211,6 @@ The existing login/logout helpers accept either an iOS simulator UDID or an Andr
 Clean up only resources you started. The remote CLI session and its disposable install are owned by the orchestrator; do not kill `kilo-e2e-cli-*` sessions or remove CLI scratch directories you did not create:
 
 ```bash
-tmux kill-session -t "$IOS_BUILD_SESSION" # if created
 tmux kill-session -t "$ANDROID_SESSION"   # if created
 rm -f "$LOGIN_LOG"                        # if created
 pnpm dev:stop                              # only if you started this worktree's stack

--- a/dev/local/mobile-android-build.test.ts
+++ b/dev/local/mobile-android-build.test.ts
@@ -1,0 +1,268 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  buildAndroidCompatibilityKey,
+  buildAndroidFingerprintOptions,
+  buildAndroidInstallCommand,
+  pruneAndroidCache,
+  runAndroidBuild,
+  validateAndroidBuildClaim,
+  type AndroidBuildDeps,
+} from './mobile-android-build';
+
+const PACKAGE_ID = 'com.kilocode.kiloapp';
+
+function temp(name: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `kilo-${name}-`));
+}
+
+function writeClaim(root: string, serial: string, worktreeRoot: string, status = 'ready'): void {
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(
+    path.join(root, `${serial}.json`),
+    JSON.stringify({
+      serial,
+      worktreeRoot,
+      status,
+      claimId: 'claim-1',
+      claimedAt: new Date().toISOString(),
+    })
+  );
+}
+
+function compatibility() {
+  return {
+    nativeHash: 'native',
+    gradleVersion: '8.14.3',
+    javaVersion: '17.0.12',
+    androidSdkIdentity: 'android-36/build-tools-36.0.0',
+    hostArch: 'arm64',
+    buildMode: 'debug-dev-client' as const,
+  };
+}
+
+function deps(overrides: Partial<AndroidBuildDeps> = {}): AndroidBuildDeps {
+  return {
+    cacheRoot: temp('android-cache'),
+    claimRoot: temp('android-claims'),
+    worktreeRoot: temp('android-worktree'),
+    mobileRoot: '/mobile',
+    fingerprint: async () => 'native',
+    compatibility: () => {
+      const { nativeHash: _nativeHash, buildMode: _buildMode, ...toolchain } = compatibility();
+      return toolchain;
+    },
+    withNativeBuildSlot: run => run(),
+    build: async staging => {
+      const apk = path.join(staging, 'app-debug.apk');
+      fs.writeFileSync(apk, 'apk');
+      return apk;
+    },
+    readPackageId: () => PACKAGE_ID,
+    install: () => undefined,
+    now: () => new Date('2026-07-15T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+test('Android fingerprint skips only Expo extra beyond defaults', () => {
+  const options = buildAndroidFingerprintOptions();
+  assert.deepEqual(options.platforms, ['android']);
+  assert.equal(options.silent, true);
+  assert.notEqual(options.sourceSkips, 0);
+});
+
+test('Android compatibility key changes for every native toolchain dimension', () => {
+  const base = compatibility();
+  const key = buildAndroidCompatibilityKey(base);
+  for (const changed of [
+    { ...base, nativeHash: 'other' },
+    { ...base, gradleVersion: '8.15' },
+    { ...base, javaVersion: '17.0.13' },
+    { ...base, androidSdkIdentity: 'android-36/build-tools-36.0.1' },
+    { ...base, hostArch: 'x64' },
+  ]) {
+    assert.notEqual(buildAndroidCompatibilityKey(changed), key);
+  }
+});
+
+test('validates only a ready Android claim owned by the current worktree', () => {
+  const root = temp('android-claims');
+  const worktree = temp('android-worktree');
+  writeClaim(root, 'emulator-1', worktree);
+  validateAndroidBuildClaim('emulator-1', worktree, root);
+
+  writeClaim(root, 'emulator-2', worktree, 'preparing');
+  assert.throws(() => validateAndroidBuildClaim('emulator-2', worktree, root), /not ready/);
+  assert.throws(() => validateAndroidBuildClaim('emulator-1', '/other', root), /claimed by/);
+});
+
+test('uses adb install -r for the claimed Android device', () => {
+  assert.deepEqual(buildAndroidInstallCommand('/sdk/adb', 'emulator-1', '/cache/Kilo.apk'), {
+    command: '/sdk/adb',
+    args: ['-s', 'emulator-1', 'install', '-r', '/cache/Kilo.apk'],
+  });
+});
+
+test('Android cache hit installs without entering the native build slot', async () => {
+  const d = deps();
+  const serial = 'emulator-hit';
+  writeClaim(d.claimRoot, serial, d.worktreeRoot);
+  const key = buildAndroidCompatibilityKey(compatibility());
+  const entry = path.join(d.cacheRoot, 'entries', key);
+  fs.mkdirSync(entry, { recursive: true });
+  const apk = path.join(entry, 'Kilo.apk');
+  fs.writeFileSync(apk, 'cached-apk');
+  const checksum = createHash('sha256').update('cached-apk').digest('hex');
+  fs.writeFileSync(
+    path.join(entry, 'manifest.json'),
+    JSON.stringify({
+      key,
+      ...compatibility(),
+      packageId: PACKAGE_ID,
+      artifactChecksum: checksum,
+      producerWorktree: '/main',
+      createdAt: '2026-07-15T12:00:00.000Z',
+    })
+  );
+  let slots = 0;
+  let builds = 0;
+  const installed: string[] = [];
+  d.withNativeBuildSlot = async run => {
+    slots += 1;
+    return run();
+  };
+  d.build = async staging => {
+    builds += 1;
+    return path.join(staging, 'app-debug.apk');
+  };
+  d.install = (_serial, value) => installed.push(value);
+
+  await runAndroidBuild(serial, d);
+
+  assert.equal(slots, 0);
+  assert.equal(builds, 0);
+  assert.deepEqual(installed, [apk]);
+});
+
+test('Android cache miss builds once, publishes, then reuses the APK', async () => {
+  const d = deps();
+  const serial = 'emulator-miss';
+  writeClaim(d.claimRoot, serial, d.worktreeRoot);
+  let slots = 0;
+  let builds = 0;
+  const installed: string[] = [];
+  d.withNativeBuildSlot = async run => {
+    slots += 1;
+    return run();
+  };
+  d.build = async staging => {
+    builds += 1;
+    const apk = path.join(staging, 'app-debug.apk');
+    fs.writeFileSync(apk, 'built-apk');
+    return apk;
+  };
+  d.install = (_serial, apk) => installed.push(apk);
+
+  await runAndroidBuild(serial, d);
+  await runAndroidBuild(serial, d);
+
+  assert.equal(slots, 1);
+  assert.equal(builds, 1);
+  assert.equal(installed.length, 2);
+  assert.equal(installed[0], installed[1]);
+});
+
+test('Android cache hit with the wrong actual package id rebuilds before install', async () => {
+  const d = deps();
+  const serial = 'emulator-package';
+  writeClaim(d.claimRoot, serial, d.worktreeRoot);
+  const key = buildAndroidCompatibilityKey(compatibility());
+  const entry = path.join(d.cacheRoot, 'entries', key);
+  fs.mkdirSync(entry, { recursive: true });
+  const apk = path.join(entry, 'Kilo.apk');
+  fs.writeFileSync(apk, 'wrong-package');
+  fs.writeFileSync(
+    path.join(entry, 'manifest.json'),
+    JSON.stringify({
+      key,
+      ...compatibility(),
+      packageId: PACKAGE_ID,
+      artifactChecksum: createHash('sha256').update('wrong-package').digest('hex'),
+      producerWorktree: '/main',
+      createdAt: '2026-07-15T12:00:00.000Z',
+    })
+  );
+  let builds = 0;
+  d.readPackageId = candidate =>
+    candidate === apk && builds === 0 ? 'com.example.wrong' : PACKAGE_ID;
+  d.build = async staging => {
+    builds += 1;
+    const output = path.join(staging, 'app-debug.apk');
+    fs.writeFileSync(output, 'correct-package');
+    return output;
+  };
+
+  await runAndroidBuild(serial, d);
+
+  assert.equal(builds, 1);
+});
+
+test('Android build validates claim before fingerprinting or entering build slot', async () => {
+  const d = deps();
+  let fingerprinted = false;
+  let slotted = false;
+  d.fingerprint = async () => {
+    fingerprinted = true;
+    return 'native';
+  };
+  d.withNativeBuildSlot = async run => {
+    slotted = true;
+    return run();
+  };
+
+  await assert.rejects(runAndroidBuild('missing', d), /not claimed/);
+  assert.equal(fingerprinted, false);
+  assert.equal(slotted, false);
+});
+
+test('Android build rejects an APK symlink that escapes cache-local staging', async () => {
+  const d = deps();
+  const serial = 'emulator-symlink';
+  writeClaim(d.claimRoot, serial, d.worktreeRoot);
+  const outside = path.join(temp('outside-apk'), 'outside.apk');
+  fs.writeFileSync(outside, 'outside');
+  d.build = async staging => {
+    const link = path.join(staging, 'app-debug.apk');
+    fs.symlinkSync(outside, link);
+    return link;
+  };
+
+  await assert.rejects(runAndroidBuild(serial, d), /invalid APK path/);
+});
+
+test('prunes expired Android cache entries but keeps recent entries', () => {
+  const root = temp('android-prune');
+  const entries = path.join(root, 'entries');
+  fs.mkdirSync(path.join(entries, 'old'), { recursive: true });
+  fs.mkdirSync(path.join(entries, 'recent'), { recursive: true });
+  fs.writeFileSync(
+    path.join(entries, 'old', 'manifest.json'),
+    JSON.stringify({ createdAt: '2026-06-01T00:00:00.000Z' })
+  );
+  fs.writeFileSync(
+    path.join(entries, 'recent', 'manifest.json'),
+    JSON.stringify({ createdAt: '2026-07-14T00:00:00.000Z' })
+  );
+
+  const result = pruneAndroidCache(root, new Date('2026-07-15T12:00:00.000Z'));
+
+  assert.deepEqual(result.removed, ['old']);
+  assert.deepEqual(result.kept, ['recent']);
+  assert.equal(fs.existsSync(path.join(entries, 'old')), false);
+});

--- a/dev/local/mobile-android-build.test.ts
+++ b/dev/local/mobile-android-build.test.ts
@@ -132,6 +132,7 @@ test('Android cache hit installs without entering the native build slot', async 
   );
   let slots = 0;
   let builds = 0;
+  let packageReads = 0;
   const installed: string[] = [];
   d.withNativeBuildSlot = async run => {
     slots += 1;
@@ -141,12 +142,17 @@ test('Android cache hit installs without entering the native build slot', async 
     builds += 1;
     return path.join(staging, 'app-debug.apk');
   };
+  d.readPackageId = () => {
+    packageReads += 1;
+    return PACKAGE_ID;
+  };
   d.install = (_serial, value) => installed.push(value);
 
   await runAndroidBuild(serial, d);
 
   assert.equal(slots, 0);
   assert.equal(builds, 0);
+  assert.equal(packageReads, 1);
   assert.deepEqual(installed, [apk]);
 });
 

--- a/dev/local/mobile-android-build.ts
+++ b/dev/local/mobile-android-build.ts
@@ -1,0 +1,296 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { DEFAULT_SOURCE_SKIPS, SourceSkips } from '@expo/fingerprint';
+
+const PACKAGE_ID = 'com.kilocode.kiloapp';
+const BUILD_MODE = 'debug-dev-client';
+
+export type AndroidCompatibility = {
+  nativeHash: string;
+  gradleVersion: string;
+  javaVersion: string;
+  androidSdkIdentity: string;
+  hostArch: string;
+  buildMode: 'debug-dev-client';
+};
+
+type AndroidManifest = AndroidCompatibility & {
+  key: string;
+  packageId: string;
+  artifactChecksum: string;
+  producerWorktree: string;
+  createdAt: string;
+};
+
+export type AndroidBuildDeps = {
+  cacheRoot: string;
+  claimRoot: string;
+  worktreeRoot: string;
+  mobileRoot: string;
+  fingerprint: (
+    mobileRoot: string,
+    options: ReturnType<typeof buildAndroidFingerprintOptions>
+  ) => Promise<string>;
+  compatibility: () => Omit<AndroidCompatibility, 'nativeHash' | 'buildMode'>;
+  withNativeBuildSlot: <T>(run: () => Promise<T>) => Promise<T>;
+  build: (stagingDir: string) => Promise<string>;
+  readPackageId: (apkPath: string) => string | undefined;
+  install: (serial: string, apkPath: string) => void;
+  now: () => Date;
+};
+
+export function buildAndroidFingerprintOptions(): {
+  platforms: ['android'];
+  sourceSkips: number;
+  silent: boolean;
+} {
+  return {
+    platforms: ['android'],
+    sourceSkips: DEFAULT_SOURCE_SKIPS | SourceSkips.ExpoConfigExtraSection,
+    silent: true,
+  };
+}
+
+export function buildAndroidCompatibilityKey(value: AndroidCompatibility): string {
+  const normalized = {
+    androidSdkIdentity: value.androidSdkIdentity,
+    buildMode: value.buildMode,
+    gradleVersion: value.gradleVersion,
+    hostArch: value.hostArch,
+    javaVersion: value.javaVersion,
+    nativeHash: value.nativeHash,
+  };
+  return createHash('sha256').update(JSON.stringify(normalized)).digest('hex');
+}
+
+export function validateAndroidBuildClaim(
+  serial: string,
+  worktreeRoot: string,
+  claimRoot: string
+): void {
+  const claimPath = path.join(claimRoot, `${serial.replaceAll('/', '_')}.json`);
+  let value: unknown;
+  try {
+    value = JSON.parse(fs.readFileSync(claimPath, 'utf8'));
+  } catch (error) {
+    if (hasCode(error, 'ENOENT')) throw new Error(`${serial} is not claimed by this worktree`);
+    throw new Error(`${serial} claim is corrupt`, { cause: error });
+  }
+  if (typeof value !== 'object' || value === null) throw new Error(`${serial} claim is corrupt`);
+  const claim = value as Record<string, unknown>;
+  if (typeof claim.worktreeRoot !== 'string') throw new Error(`${serial} claim is corrupt`);
+  if (claim.worktreeRoot !== worktreeRoot)
+    throw new Error(`${serial} is claimed by ${claim.worktreeRoot}`);
+  if (claim.status !== 'ready') throw new Error(`${serial} claim is not ready`);
+  if (typeof claim.claimId !== 'string' || claim.claimId.length === 0) {
+    throw new Error(`${serial} claim is corrupt`);
+  }
+  if (
+    typeof claim.claimedAt !== 'string' ||
+    Number.isNaN(Date.parse(claim.claimedAt)) ||
+    new Date(claim.claimedAt).toISOString() !== claim.claimedAt
+  ) {
+    throw new Error(`${serial} claim is corrupt`);
+  }
+}
+
+export function buildAndroidInstallCommand(
+  adb: string,
+  serial: string,
+  apkPath: string
+): { command: string; args: string[] } {
+  return { command: adb, args: ['-s', serial, 'install', '-r', apkPath] };
+}
+
+export async function runAndroidBuild(serial: string, deps: AndroidBuildDeps): Promise<void> {
+  validateAndroidBuildClaim(serial, deps.worktreeRoot, deps.claimRoot);
+  const nativeHash = await deps.fingerprint(deps.mobileRoot, buildAndroidFingerprintOptions());
+  const compatibility: AndroidCompatibility = {
+    ...deps.compatibility(),
+    nativeHash,
+    buildMode: BUILD_MODE,
+  };
+  const key = buildAndroidCompatibilityKey(compatibility);
+  let entry = await lookup(deps.cacheRoot, key, compatibility, deps.readPackageId);
+  if (!entry) {
+    entry = await deps.withNativeBuildSlot(async () => {
+      const queuedHit = await lookup(deps.cacheRoot, key, compatibility, deps.readPackageId);
+      if (queuedHit) return queuedHit;
+      return publish(serial, key, compatibility, deps);
+    });
+  }
+  const verified = await lookup(deps.cacheRoot, key, compatibility, deps.readPackageId);
+  if (!verified || verified.apkPath !== entry.apkPath) {
+    throw new Error(`Android cache entry failed validation for key ${key}`);
+  }
+  deps.install(serial, verified.apkPath);
+}
+
+async function lookup(
+  cacheRoot: string,
+  key: string,
+  compatibility: AndroidCompatibility,
+  readPackageId: (apkPath: string) => string | undefined
+): Promise<{ apkPath: string; manifest: AndroidManifest } | undefined> {
+  const entry = path.join(cacheRoot, 'entries', key);
+  const apkPath = path.join(entry, 'Kilo.apk');
+  const manifestPath = path.join(entry, 'manifest.json');
+  if (!fs.existsSync(apkPath) || !fs.existsSync(manifestPath)) return undefined;
+  let value: unknown;
+  try {
+    value = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+  if (!isManifest(value, key, compatibility)) return undefined;
+  if ((await hashFile(apkPath)) !== value.artifactChecksum) return undefined;
+  if (readPackageId(apkPath) !== PACKAGE_ID) return undefined;
+  return { apkPath, manifest: value };
+}
+
+async function publish(
+  serial: string,
+  key: string,
+  compatibility: AndroidCompatibility,
+  deps: AndroidBuildDeps
+): Promise<{ apkPath: string; manifest: AndroidManifest }> {
+  const stagingRoot = path.join(deps.cacheRoot, 'staging');
+  fs.mkdirSync(stagingRoot, { recursive: true });
+  const staging = fs.mkdtempSync(path.join(stagingRoot, `${key}-`));
+  try {
+    const producedApk = await deps.build(staging);
+    if (!isWithinRealPath(producedApk, staging) || !fs.statSync(producedApk).isFile()) {
+      throw new Error(`Android build returned an invalid APK path for ${serial}`);
+    }
+    if (deps.readPackageId(producedApk) !== PACKAGE_ID) {
+      throw new Error(`Produced APK has unexpected package id (expected ${PACKAGE_ID})`);
+    }
+    const stagedApk = path.join(staging, 'Kilo.apk');
+    if (path.resolve(producedApk) !== path.resolve(stagedApk))
+      fs.copyFileSync(producedApk, stagedApk);
+    const manifest: AndroidManifest = {
+      key,
+      ...compatibility,
+      packageId: PACKAGE_ID,
+      artifactChecksum: await hashFile(stagedApk),
+      producerWorktree: deps.worktreeRoot,
+      createdAt: deps.now().toISOString(),
+    };
+    fs.writeFileSync(path.join(staging, 'manifest.json'), JSON.stringify(manifest));
+    const finalDir = path.join(deps.cacheRoot, 'entries', key);
+    fs.mkdirSync(path.dirname(finalDir), { recursive: true });
+    let concurrentPublish = false;
+    try {
+      fs.renameSync(staging, finalDir);
+    } catch (error) {
+      if (!hasCode(error, 'EEXIST') && !hasCode(error, 'ENOTEMPTY')) throw error;
+      concurrentPublish = true;
+    }
+    const verified = await lookup(deps.cacheRoot, key, compatibility, deps.readPackageId);
+    if (!verified) {
+      throw new Error(
+        concurrentPublish
+          ? `Concurrent Android cache entry is invalid for ${key}`
+          : `Android cache entry failed post-publish validation for ${key}`
+      );
+    }
+    return verified;
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+function isManifest(
+  value: unknown,
+  key: string,
+  compatibility: AndroidCompatibility
+): value is AndroidManifest {
+  if (typeof value !== 'object' || value === null) return false;
+  const manifest = value as Record<string, unknown>;
+  return (
+    manifest.key === key &&
+    manifest.nativeHash === compatibility.nativeHash &&
+    manifest.gradleVersion === compatibility.gradleVersion &&
+    manifest.javaVersion === compatibility.javaVersion &&
+    manifest.androidSdkIdentity === compatibility.androidSdkIdentity &&
+    manifest.hostArch === compatibility.hostArch &&
+    manifest.buildMode === BUILD_MODE &&
+    manifest.packageId === PACKAGE_ID &&
+    typeof manifest.artifactChecksum === 'string' &&
+    /^[0-9a-f]{64}$/.test(manifest.artifactChecksum) &&
+    typeof manifest.producerWorktree === 'string' &&
+    typeof manifest.createdAt === 'string' &&
+    !Number.isNaN(Date.parse(manifest.createdAt)) &&
+    new Date(manifest.createdAt).toISOString() === manifest.createdAt
+  );
+}
+
+async function hashFile(filePath: string): Promise<string> {
+  const hash = createHash('sha256');
+  const handle = await fs.promises.open(filePath, 'r');
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  try {
+    while (true) {
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    await handle.close();
+  }
+  return hash.digest('hex');
+}
+
+function isWithinRealPath(candidate: string, parent: string): boolean {
+  let realCandidate: string;
+  let realParent: string;
+  try {
+    realCandidate = fs.realpathSync(candidate);
+    realParent = fs.realpathSync(parent);
+  } catch {
+    return false;
+  }
+  const relative = path.relative(realParent, realCandidate);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+export function pruneAndroidCache(
+  cacheRoot: string,
+  now = new Date(),
+  retentionMs = 14 * 24 * 60 * 60 * 1000
+): { removed: string[]; kept: string[] } {
+  const entriesRoot = path.join(cacheRoot, 'entries');
+  const removed: string[] = [];
+  const kept: string[] = [];
+  if (!fs.existsSync(entriesRoot)) return { removed, kept };
+  for (const key of fs.readdirSync(entriesRoot).sort()) {
+    const entry = path.join(entriesRoot, key);
+    let createdAt: unknown;
+    try {
+      createdAt = JSON.parse(fs.readFileSync(path.join(entry, 'manifest.json'), 'utf8')).createdAt;
+    } catch {
+      const age = now.getTime() - fs.statSync(entry).mtimeMs;
+      if (age < retentionMs) {
+        kept.push(key);
+        continue;
+      }
+      fs.rmSync(entry, { recursive: true, force: true });
+      removed.push(key);
+      continue;
+    }
+    const timestamp = typeof createdAt === 'string' ? Date.parse(createdAt) : Number.NaN;
+    if (Number.isNaN(timestamp) || now.getTime() - timestamp >= retentionMs) {
+      fs.rmSync(entry, { recursive: true, force: true });
+      removed.push(key);
+    } else {
+      kept.push(key);
+    }
+  }
+  return { removed, kept };
+}
+
+function hasCode(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && error.code === code;
+}

--- a/dev/local/mobile-android-build.ts
+++ b/dev/local/mobile-android-build.ts
@@ -121,11 +121,7 @@ export async function runAndroidBuild(serial: string, deps: AndroidBuildDeps): P
       return publish(serial, key, compatibility, deps);
     });
   }
-  const verified = await lookup(deps.cacheRoot, key, compatibility, deps.readPackageId);
-  if (!verified || verified.apkPath !== entry.apkPath) {
-    throw new Error(`Android cache entry failed validation for key ${key}`);
-  }
-  deps.install(serial, verified.apkPath);
+  deps.install(serial, entry.apkPath);
 }
 
 async function lookup(

--- a/dev/local/mobile-android.test.ts
+++ b/dev/local/mobile-android.test.ts
@@ -6,6 +6,7 @@ import test from 'node:test';
 
 import {
   claimAndroidDevice,
+  readGradleWrapperVersion,
   releaseAndroidDevice,
   resolveAndroidEnvironment,
 } from './mobile-android';
@@ -116,4 +117,55 @@ test('recovers an orphaned Android claim mutation lock', () => {
     fs.rmSync(mutationLockPath, { recursive: true, force: true });
     fs.rmSync(worktreeRoot, { recursive: true, force: true });
   }
+});
+
+test('creates an explicit ready Android claim', () => {
+  const serial = `test-ready-${process.pid}-${Date.now()}`;
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const filePath = path.join(os.tmpdir(), 'kilo-mobile-android-claims', `${serial}.json`);
+
+  try {
+    const claim = claimAndroidDevice(serial, worktreeRoot);
+    assert.equal(claim.status, 'ready');
+    assert.equal(typeof claim.claimId, 'string');
+    assert.ok(claim.claimId.length > 0);
+    assert.equal(JSON.parse(fs.readFileSync(filePath, 'utf8')).status, 'ready');
+  } finally {
+    fs.rmSync(filePath, { force: true });
+    fs.rmSync(`${filePath}.lock`, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('upgrades a same-worktree legacy Android claim to ready', () => {
+  const serial = `test-upgrade-${process.pid}-${Date.now()}`;
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const filePath = path.join(os.tmpdir(), 'kilo-mobile-android-claims', `${serial}.json`);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({ serial, worktreeRoot, claimedAt: new Date().toISOString() })
+  );
+
+  try {
+    const claim = claimAndroidDevice(serial, worktreeRoot);
+    assert.equal(claim.status, 'ready');
+    assert.equal(JSON.parse(fs.readFileSync(filePath, 'utf8')).status, 'ready');
+  } finally {
+    fs.rmSync(filePath, { force: true });
+    fs.rmSync(`${filePath}.lock`, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('reads the Gradle version from the worktree wrapper properties without launching Gradle', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-android-project-'));
+  const wrapper = path.join(root, 'gradle/wrapper');
+  fs.mkdirSync(wrapper, { recursive: true });
+  fs.writeFileSync(
+    path.join(wrapper, 'gradle-wrapper.properties'),
+    'distributionUrl=https\\://services.gradle.org/distributions/gradle-8.14.3-bin.zip\n'
+  );
+
+  assert.equal(readGradleWrapperVersion(root), '8.14.3');
 });

--- a/dev/local/mobile-android.ts
+++ b/dev/local/mobile-android.ts
@@ -3,6 +3,16 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import { createProjectHashAsync } from '@expo/fingerprint';
+
+import {
+  buildAndroidCompatibilityKey,
+  buildAndroidFingerprintOptions,
+  buildAndroidInstallCommand,
+  pruneAndroidCache,
+  runAndroidBuild,
+} from './mobile-android-build';
+import { withNativeBuildSemaphore } from './mobile-native-build';
 import { withProcessLock } from './process-lock';
 
 type AndroidEnvironment = {
@@ -21,7 +31,13 @@ type ResolveArgs = {
   javaMajor?: (javaHome: string) => number | undefined;
 };
 
-type DeviceClaim = { serial: string; worktreeRoot: string; claimedAt: string };
+type DeviceClaim = {
+  serial: string;
+  worktreeRoot: string;
+  claimedAt: string;
+  claimId: string;
+  status: 'ready';
+};
 type ClaimOptions = {
   fileOperations?: {
     readFileSync?: (filePath: string, encoding: 'utf8') => string;
@@ -157,8 +173,14 @@ function claimAndroidDevice(
   return withClaimMutationLock(filePath, () => {
     try {
       const readFileSync = options?.fileOperations?.readFileSync ?? fs.readFileSync;
-      const claim = JSON.parse(readFileSync(filePath, 'utf8')) as DeviceClaim;
-      if (claim.worktreeRoot === worktreeRoot) return claim;
+      const claim = JSON.parse(readFileSync(filePath, 'utf8')) as Partial<DeviceClaim>;
+      if (claim.worktreeRoot === worktreeRoot) {
+        if (claim.status === 'ready' && typeof claim.claimId === 'string')
+          return claim as DeviceClaim;
+        const upgraded = buildReadyClaim(serial, worktreeRoot);
+        fs.writeFileSync(filePath, JSON.stringify(upgraded));
+        return upgraded;
+      }
       if (fs.existsSync(claim.worktreeRoot))
         throw new Error(`${serial} is claimed by ${claim.worktreeRoot}`);
       fs.rmSync(filePath, { force: true });
@@ -171,10 +193,20 @@ function claimAndroidDevice(
         throw error;
       }
     }
-    const claim = { serial, worktreeRoot, claimedAt: new Date().toISOString() };
+    const claim = buildReadyClaim(serial, worktreeRoot);
     fs.writeFileSync(filePath, JSON.stringify(claim), { flag: 'wx' });
     return claim;
   });
+}
+
+function buildReadyClaim(serial: string, worktreeRoot: string): DeviceClaim {
+  return {
+    serial,
+    worktreeRoot,
+    claimedAt: new Date().toISOString(),
+    claimId: `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    status: 'ready',
+  };
 }
 
 function releaseAndroidDevice(serial: string, worktreeRoot: string): void {
@@ -187,7 +219,7 @@ function releaseAndroidDevice(serial: string, worktreeRoot: string): void {
   });
 }
 
-function main(): void {
+async function main(): Promise<void> {
   const [command, ...args] = process.argv.slice(2);
   const env = environment();
   const worktreeRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
@@ -204,13 +236,56 @@ function main(): void {
     console.log(JSON.stringify({ ...env, avds, worktree: path.basename(process.cwd()) }, null, 2));
     return;
   }
-  if (command === 'build') {
-    return run(
-      'npx',
-      ['expo', 'run:android', '--no-install', '--no-bundler', ...args],
-      env,
-      path.join(worktreeRoot, 'apps/mobile')
+  const mobileRoot = path.join(worktreeRoot, 'apps/mobile');
+  const cacheRoot = path.join(os.homedir(), 'Library/Caches/Kilo/mobile-android-builds');
+  if (command === 'fingerprint') {
+    if (args.length !== 0) throw new Error('Usage: pnpm dev:mobile:android fingerprint');
+    const nativeHash = await createProjectHashAsync(mobileRoot, buildAndroidFingerprintOptions());
+    const compatibility = {
+      ...androidCompatibility(env, mobileRoot),
+      nativeHash,
+      buildMode: 'debug-dev-client' as const,
+    };
+    console.log(
+      JSON.stringify(
+        { key: buildAndroidCompatibilityKey(compatibility), ...compatibility },
+        null,
+        2
+      )
     );
+    return;
+  }
+  if (command === 'prune') {
+    if (args.length !== 0) throw new Error('Usage: pnpm dev:mobile:android prune');
+    console.log(JSON.stringify(pruneAndroidCache(cacheRoot), null, 2));
+    return;
+  }
+  if (command === 'build') {
+    const serial = args[0];
+    if (!serial) throw new Error('Usage: pnpm dev:mobile:android build <serial>');
+    const claimRoot = path.join(os.tmpdir(), 'kilo-mobile-android-claims');
+    await runAndroidBuild(serial, {
+      cacheRoot,
+      claimRoot,
+      worktreeRoot,
+      mobileRoot,
+      fingerprint: (root, options) => createProjectHashAsync(root, options),
+      compatibility: () => androidCompatibility(env, mobileRoot),
+      withNativeBuildSlot: runBuild =>
+        withNativeBuildSemaphore({
+          root: path.join(os.homedir(), 'Library/Caches/Kilo'),
+          run: runBuild,
+        }),
+      build: staging => buildAndroidApk(env, mobileRoot, staging),
+      readPackageId: apkPath => readAndroidPackageId(env, apkPath),
+      install: (deviceSerial, apkPath) => {
+        const command = buildAndroidInstallCommand(env.adb, deviceSerial, apkPath);
+        run(command.command, command.args, env);
+      },
+      now: () => new Date(),
+    });
+    console.log(`Installed ${serial}`);
+    return;
   }
   if (command === 'claim') {
     const requested = args[0];
@@ -234,20 +309,118 @@ function main(): void {
     return run(env.sdkmanager, args, env);
   }
   throw new Error(
-    'Usage: pnpm dev:mobile:android [doctor|build|claim|release|adb|emulator|sdkmanager] [args...]'
+    'Usage: pnpm dev:mobile:android [doctor|fingerprint|build|prune|claim|release|adb|emulator|sdkmanager] [args...]'
   );
 }
 
 const isMain =
   process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
 if (isMain) {
-  try {
-    main();
-  } catch (error) {
+  main().catch(error => {
     console.error(error instanceof Error ? error.message : error);
     process.exit(1);
-  }
+  });
 }
 
-export { claimAndroidDevice, releaseAndroidDevice, resolveAndroidEnvironment };
+function androidCompatibility(env: AndroidEnvironment, mobileRoot: string) {
+  const gradleProject = path.join(mobileRoot, 'android');
+  const gradlew = path.join(gradleProject, 'gradlew');
+  if (!fs.existsSync(gradlew)) {
+    throw new Error(
+      `Generated Android project is missing at ${gradleProject}. Run \`npx expo prebuild --platform android\` in apps/mobile first.`
+    );
+  }
+  const gradleVersion = readGradleWrapperVersion(gradleProject);
+  const javaResult = spawnSync(path.join(env.javaHome, 'bin/java'), ['-version'], {
+    encoding: 'utf8',
+  });
+  const javaVersion = `${javaResult.stdout}${javaResult.stderr}`.match(/version "([^"]+)"/)?.[1];
+  if (!gradleVersion || !javaVersion)
+    throw new Error('Unable to determine Android build toolchain');
+  const platforms = listVersions(path.join(env.sdkRoot, 'platforms'));
+  const buildTools = listVersions(path.join(env.sdkRoot, 'build-tools'));
+  return {
+    gradleVersion,
+    javaVersion,
+    androidSdkIdentity: `${platforms.at(-1) ?? 'none'}/${buildTools.at(-1) ?? 'none'}`,
+    hostArch: process.arch,
+  };
+}
+
+function readGradleWrapperVersion(androidRoot: string): string {
+  const properties = fs.readFileSync(
+    path.join(androidRoot, 'gradle/wrapper/gradle-wrapper.properties'),
+    'utf8'
+  );
+  const version = properties.match(/gradle-([0-9][0-9.]*)-(?:all|bin)\.zip/)?.[1];
+  if (!version) throw new Error('Unable to determine Gradle wrapper version');
+  return version;
+}
+
+async function buildAndroidApk(
+  env: AndroidEnvironment,
+  mobileRoot: string,
+  staging: string
+): Promise<string> {
+  const androidRoot = path.join(mobileRoot, 'android');
+  const gradlew = path.join(androidRoot, 'gradlew');
+  if (!fs.existsSync(gradlew)) {
+    throw new Error(
+      `Generated Android project is missing at ${androidRoot}. Run \`npx expo prebuild --platform android\` in apps/mobile first.`
+    );
+  }
+  const sourceApk = path.join(androidRoot, 'app/build/outputs/apk/debug/app-debug.apk');
+  fs.rmSync(sourceApk, { force: true });
+  run(
+    gradlew,
+    [
+      'app:assembleDebug',
+      '--no-daemon',
+      '--project-cache-dir',
+      path.join(staging, 'project-cache'),
+    ],
+    env,
+    androidRoot
+  );
+  if (!fs.existsSync(sourceApk)) {
+    throw new Error(`Gradle did not produce the expected APK at ${sourceApk}`);
+  }
+  const stagedApk = path.join(staging, 'app-debug.apk');
+  fs.copyFileSync(sourceApk, stagedApk);
+  return stagedApk;
+}
+
+function readAndroidPackageId(env: AndroidEnvironment, apkPath: string): string | undefined {
+  const buildTools = listVersions(path.join(env.sdkRoot, 'build-tools'));
+  const version = buildTools.at(-1);
+  if (!version) throw new Error('Android build-tools are not installed');
+  const aapt = path.join(env.sdkRoot, 'build-tools', version, 'aapt');
+  const output = execFileSync(aapt, ['dump', 'badging', apkPath], {
+    encoding: 'utf8',
+    env: androidProcessEnv(env),
+  });
+  return output.match(/^package: name='([^']+)'/m)?.[1];
+}
+
+function listVersions(root: string): string[] {
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+}
+
+function androidProcessEnv(env: AndroidEnvironment): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ANDROID_HOME: env.sdkRoot,
+    ANDROID_SDK_ROOT: env.sdkRoot,
+    JAVA_HOME: env.javaHome,
+    PATH: env.path,
+  };
+}
+
+export {
+  claimAndroidDevice,
+  readGradleWrapperVersion,
+  releaseAndroidDevice,
+  resolveAndroidEnvironment,
+};
 export type { AndroidEnvironment };

--- a/dev/local/mobile-ios-build.test.ts
+++ b/dev/local/mobile-ios-build.test.ts
@@ -1,0 +1,2150 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  buildCompatibilityKey,
+  buildFingerprintOptions,
+  buildInstallCommand,
+  buildXcodeBuildCommand,
+  computeArtifactChecksum,
+  defaultIsLockActive,
+  isValidManifest,
+  locateProducedApp,
+  lookupCache,
+  mobileRoot,
+  parseCliArgs,
+  pruneCache,
+  publishCacheEntry,
+  resolveCacheRoot,
+  resolveMobileRoot,
+  runBuild,
+  runFingerprint,
+  runPrune,
+  validateSimulatorClaim,
+  validateXcodeWorkspace,
+  withFingerprintLock,
+  type BuildDeps,
+  type CacheEnvironment,
+  type CacheLockDeps,
+  type CompatibilityDimensions,
+  type LockRecord,
+  type Manifest,
+  type PruneResult,
+} from './mobile-ios-build';
+
+function makeTempDir(label: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `kilo-ios-build-${label}-`));
+}
+
+function fakeManifest(overrides: Partial<Manifest> = {}): Manifest {
+  return {
+    key: 'k1',
+    nativeHash: 'native-hash',
+    xcodeBuildVersion: '16A0000',
+    simulatorSdkVersion: '17.5',
+    hostArch: 'arm64',
+    buildMode: 'debug-dev-client',
+    bundleId: 'com.kilocode.kiloapp',
+    artifactChecksum: 'a'.repeat(64),
+    producerWorktree: '/worktree',
+    createdAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+function fixedEnv(overrides: Partial<CacheEnvironment> = {}): CacheEnvironment {
+  return {
+    home: '/Users/test',
+    cacheRoot: '/cache/Kilo/mobile-ios-builds',
+    platform: 'darwin',
+    arch: 'arm64',
+    xcodeBuildVersion: '16A0000',
+    simulatorSdkVersion: '17.5',
+    now: () => new Date('2026-07-15T12:00:00Z'),
+    ...overrides,
+  };
+}
+
+function fixedDimensions(
+  overrides: Partial<CompatibilityDimensions> = {}
+): CompatibilityDimensions {
+  return {
+    nativeHash: 'h1',
+    xcodeBuildVersion: '16A0000',
+    simulatorSdkVersion: '17.5',
+    hostArch: 'arm64',
+    buildMode: 'debug-dev-client',
+    ...overrides,
+  };
+}
+
+function sharedResult<T>(initialValue: T): { set: (value: T) => void; read: () => Promise<T> } {
+  let value = initialValue;
+  return {
+    set: (v: T) => {
+      value = v;
+    },
+    read: async () => value,
+  };
+}
+
+// ── Fingerprint options ──────────────────────────────────────────────
+
+test('fingerprint options include iOS platform and only skip the Expo extra section beyond defaults', () => {
+  const options = buildFingerprintOptions();
+  assert.deepEqual(options.platforms, ['ios']);
+  assert.equal(options.silent, true);
+  // SourceSkips.ExpoConfigExtraSection === 4096
+  assert.equal(options.sourceSkips & 4096, 4096);
+});
+
+// ── Compatibility key ────────────────────────────────────────────────
+
+test('buildCompatibilityKey is stable for identical dimensions and changes on each dimension', () => {
+  const dimensions = fixedDimensions();
+  const keyA = buildCompatibilityKey(dimensions);
+  const keyB = buildCompatibilityKey({ ...dimensions });
+  assert.equal(keyA, keyB);
+  assert.equal(keyA.length, 64);
+
+  for (const variant of [
+    { ...dimensions, nativeHash: 'h2' },
+    { ...dimensions, xcodeBuildVersion: '16A0001' },
+    { ...dimensions, simulatorSdkVersion: '18.0' },
+    { ...dimensions, hostArch: 'x64' },
+  ]) {
+    assert.notEqual(buildCompatibilityKey(variant), keyA);
+  }
+});
+
+// ── Cache root resolution ────────────────────────────────────────────
+
+test('resolveCacheRoot prefers macOS Library/Caches/Kilo with XDG fallback chain', () => {
+  assert.equal(
+    resolveCacheRoot({ home: '/Users/test', platform: 'darwin', env: {} }),
+    '/Users/test/Library/Caches/Kilo/mobile-ios-builds'
+  );
+  assert.equal(
+    resolveCacheRoot({ home: '/home/test', platform: 'linux', env: { XDG_CACHE_HOME: '/xdg' } }),
+    '/xdg/Kilo/mobile-ios-builds'
+  );
+  assert.equal(
+    resolveCacheRoot({ home: '/home/test', platform: 'linux', env: {} }),
+    '/home/test/.cache/Kilo/mobile-ios-builds'
+  );
+});
+
+// ── Artifact checksum ────────────────────────────────────────────────
+
+test('computeArtifactChecksum is deterministic and content-sensitive', async () => {
+  const dir = makeTempDir('checksum');
+  try {
+    fs.writeFileSync(path.join(dir, 'a'), 'hello');
+    fs.writeFileSync(path.join(dir, 'b'), 'world');
+    const a = await computeArtifactChecksum(dir);
+    const b = await computeArtifactChecksum(dir);
+    assert.equal(a, b);
+    assert.equal(a.length, 64);
+    fs.writeFileSync(path.join(dir, 'a'), 'HELLO');
+    assert.notEqual(await computeArtifactChecksum(dir), a);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Concurrency: withFingerprintLock ─────────────────────────────────
+
+test('withFingerprintLock runs producer once for matching concurrent callers', async () => {
+  const cacheRoot = makeTempDir('lock-once');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  let producerInvocations = 0;
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
+  };
+  const result = sharedResult({ value: '' });
+  const producer = async () => {
+    producerInvocations += 1;
+    await new Promise(resolve => setTimeout(resolve, 50));
+    result.set({ value: 'shared' });
+  };
+  try {
+    const [a, b] = await Promise.all([
+      withFingerprintLock({
+        key: 'concurrent',
+        lockRoot,
+        deps: lockDeps,
+        producer,
+        readResult: result.read,
+      }),
+      withFingerprintLock({
+        key: 'concurrent',
+        lockRoot,
+        deps: lockDeps,
+        producer,
+        readResult: result.read,
+      }),
+    ]);
+    assert.equal(producerInvocations, 1);
+    assert.equal(a.value, 'shared');
+    assert.equal(b.value, 'shared');
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+test('withFingerprintLock recovers an abandoned lock', async () => {
+  const cacheRoot = makeTempDir('lock-abandoned');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  const lockPath = path.join(lockRoot, 'abandoned.lock');
+  fs.mkdirSync(lockPath, { recursive: true });
+  fs.writeFileSync(
+    path.join(lockPath, 'lock.json'),
+    JSON.stringify({
+      key: 'abandoned',
+      pid: 99999,
+      identity: 'old-identity',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+    })
+  );
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
+    pidAlive: () => true,
+    processIdentity: pid => (pid === 99999 ? 'old-identity' : 'new-identity'),
+    isLockActive: record => record.identity !== 'old-identity',
+  };
+  const result = sharedResult({ hello: '' });
+  let produced = 0;
+  try {
+    const value = await withFingerprintLock({
+      key: 'abandoned',
+      lockRoot,
+      deps: lockDeps,
+      producer: async () => {
+        produced += 1;
+        result.set({ hello: 'world' });
+      },
+      readResult: result.read,
+    });
+    assert.equal(value.hello, 'world');
+    assert.equal(produced, 1);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+test('withFingerprintLock bounds wait when an active lock holds the producer', async () => {
+  const cacheRoot = makeTempDir('lock-bounded');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  const lockPath = path.join(lockRoot, 'active.lock');
+  fs.mkdirSync(lockPath, { recursive: true });
+  fs.writeFileSync(
+    path.join(lockPath, 'lock.json'),
+    JSON.stringify({
+      key: 'active',
+      pid: 4242,
+      identity: 'active',
+      startedAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+    })
+  );
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
+    pidAlive: () => true,
+    processIdentity: () => 'active',
+    isLockActive: () => true,
+    waitForResultMs: 100,
+    pollIntervalMs: 25,
+  };
+  let produced = 0;
+  try {
+    await assert.rejects(
+      () =>
+        withFingerprintLock({
+          key: 'active',
+          lockRoot,
+          deps: lockDeps,
+          producer: async () => {
+            produced += 1;
+          },
+          readResult: async () => ({ skipped: true }),
+        }),
+      /active producer/i
+    );
+    assert.equal(produced, 0);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+// ── Cache lookup ─────────────────────────────────────────────────────
+
+test('cache hit returns the published manifest and avoids the producer', async () => {
+  const cacheRoot = makeTempDir('hit');
+  const key = 'k-hit';
+  const keyDir = path.join(cacheRoot, 'entries', key);
+  fs.mkdirSync(keyDir, { recursive: true });
+  const bundle = path.join(keyDir, 'Kilo.app');
+  fs.mkdirSync(bundle, { recursive: true });
+  fs.writeFileSync(path.join(bundle, 'Info.plist'), '<plist></plist>');
+  const checksum = await computeArtifactChecksum(bundle);
+  const manifest = fakeManifest({ key, artifactChecksum: checksum });
+  fs.writeFileSync(path.join(keyDir, 'manifest.json'), JSON.stringify(manifest));
+  let producerInvocations = 0;
+  const result = await lookupCache({
+    env: fixedEnv({ cacheRoot }),
+    key,
+    onMiss: async () => {
+      producerInvocations += 1;
+      throw new Error('producer should not run on hit');
+    },
+  });
+  assert.equal(producerInvocations, 0);
+  assert.ok(result);
+  assert.equal(result!.manifest.bundleId, 'com.kilocode.kiloapp');
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});
+
+test('cache miss when the manifest key does not match', async () => {
+  const cacheRoot = makeTempDir('miss-key');
+  const key = 'k-miss';
+  const keyDir = path.join(cacheRoot, 'entries', key);
+  fs.mkdirSync(keyDir, { recursive: true });
+  fs.mkdirSync(path.join(keyDir, 'Kilo.app'), { recursive: true });
+  fs.writeFileSync(
+    path.join(keyDir, 'manifest.json'),
+    JSON.stringify(fakeManifest({ key: 'other-key' }))
+  );
+  const result = await lookupCache({
+    env: fixedEnv({ cacheRoot }),
+    key,
+    onMiss: async () => ({ installed: true }),
+  });
+  assert.equal(result, undefined);
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});
+
+test('cache miss when the manifest bundle id does not match', async () => {
+  const cacheRoot = makeTempDir('miss-bundle');
+  const key = 'k-miss-bundle';
+  const keyDir = path.join(cacheRoot, 'entries', key);
+  fs.mkdirSync(keyDir, { recursive: true });
+  fs.mkdirSync(path.join(keyDir, 'Kilo.app'), { recursive: true });
+  fs.writeFileSync(
+    path.join(keyDir, 'manifest.json'),
+    JSON.stringify(fakeManifest({ key, bundleId: 'com.example.other' }))
+  );
+  const result = await lookupCache({
+    env: fixedEnv({ cacheRoot }),
+    key,
+    onMiss: async () => ({ installed: true }),
+  });
+  assert.equal(result, undefined);
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});
+
+test('cache miss when the artifact checksum does not match the manifest', async () => {
+  const cacheRoot = makeTempDir('miss-checksum');
+  const key = 'k-miss-checksum';
+  const keyDir = path.join(cacheRoot, 'entries', key);
+  fs.mkdirSync(keyDir, { recursive: true });
+  const bundle = path.join(keyDir, 'Kilo.app');
+  fs.mkdirSync(bundle, { recursive: true });
+  fs.writeFileSync(path.join(bundle, 'Info.plist'), '<plist></plist>');
+  fs.writeFileSync(
+    path.join(keyDir, 'manifest.json'),
+    JSON.stringify(fakeManifest({ key, artifactChecksum: 'b'.repeat(64) }))
+  );
+  const result = await lookupCache({
+    env: fixedEnv({ cacheRoot }),
+    key,
+    onMiss: async () => ({ installed: true }),
+  });
+  assert.equal(result, undefined);
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});
+
+test('cache miss when the manifest is corrupt JSON', async () => {
+  const cacheRoot = makeTempDir('miss-corrupt');
+  const key = 'k-miss-corrupt';
+  const keyDir = path.join(cacheRoot, 'entries', key);
+  fs.mkdirSync(keyDir, { recursive: true });
+  fs.mkdirSync(path.join(keyDir, 'Kilo.app'), { recursive: true });
+  fs.writeFileSync(path.join(keyDir, 'manifest.json'), '{ not json');
+  const result = await lookupCache({
+    env: fixedEnv({ cacheRoot }),
+    key,
+    onMiss: async () => ({ installed: true }),
+  });
+  assert.equal(result, undefined);
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});
+
+test('cache miss when the entry is missing the app bundle directory', async () => {
+  const cacheRoot = makeTempDir('miss-incomplete');
+  const key = 'k-miss-incomplete';
+  const keyDir = path.join(cacheRoot, 'entries', key);
+  fs.mkdirSync(keyDir, { recursive: true });
+  fs.writeFileSync(path.join(keyDir, 'manifest.json'), JSON.stringify(fakeManifest({ key })));
+  const result = await lookupCache({
+    env: fixedEnv({ cacheRoot }),
+    key,
+    onMiss: async () => ({ installed: true }),
+  });
+  assert.equal(result, undefined);
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});
+
+// ── Simulator claim validation ───────────────────────────────────────
+
+test('validateSimulatorClaim accepts the current worktree and rejects foreign worktrees', () => {
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const otherWorktree = makeTempDir('wt-other');
+  try {
+    fs.writeFileSync(
+      path.join(claimRoot, 'UDID.json'),
+      JSON.stringify({
+        deviceId: 'UDID',
+        worktreeRoot: worktree,
+        claimId: 'c1',
+        status: 'ready',
+        claimedAt: new Date().toISOString(),
+      })
+    );
+    assert.doesNotThrow(() => validateSimulatorClaim('UDID', worktree, claimRoot));
+    assert.throws(() => validateSimulatorClaim('UDID', otherWorktree, claimRoot), /claimed by/);
+    assert.throws(() => validateSimulatorClaim('MISSING', worktree, claimRoot), /not claimed/);
+  } finally {
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+    fs.rmSync(otherWorktree, { recursive: true, force: true });
+  }
+});
+
+// ── Install command ──────────────────────────────────────────────────
+
+test('buildInstallCommand uses xcrun simctl install with the cached bundle', () => {
+  const command = buildInstallCommand('UDID-1234', '/cache/key/Kilo.app');
+  assert.deepEqual(command, {
+    command: 'xcrun',
+    args: ['simctl', 'install', 'UDID-1234', '/cache/key/Kilo.app'],
+  });
+});
+
+// ── Pruning ──────────────────────────────────────────────────────────
+
+test('pruneCache removes entries older than the threshold and protects active locks', async () => {
+  const cacheRoot = makeTempDir('prune');
+  const entriesRoot = path.join(cacheRoot, 'entries');
+  fs.mkdirSync(entriesRoot, { recursive: true });
+  const oldKey = 'old';
+  const oldDir = path.join(entriesRoot, oldKey);
+  fs.mkdirSync(oldDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(oldDir, 'manifest.json'),
+    JSON.stringify(fakeManifest({ key: oldKey, createdAt: '2026-06-01T00:00:00.000Z' }))
+  );
+  const recentKey = 'recent';
+  const recentDir = path.join(entriesRoot, recentKey);
+  fs.mkdirSync(recentDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(recentDir, 'manifest.json'),
+    JSON.stringify(fakeManifest({ key: recentKey, createdAt: '2026-07-15T11:00:00.000Z' }))
+  );
+  fs.mkdirSync(path.join(cacheRoot, 'locks', `${recentKey}.lock`), { recursive: true });
+  fs.writeFileSync(
+    path.join(cacheRoot, 'locks', `${recentKey}.lock`, 'lock.json'),
+    JSON.stringify({ key: recentKey, pid: 1, identity: 'r', startedAt: new Date().toISOString() })
+  );
+  fs.mkdirSync(path.join(cacheRoot, 'locks', `${oldKey}.lock`), { recursive: true });
+  fs.writeFileSync(
+    path.join(cacheRoot, 'locks', `${oldKey}.lock`, 'lock.json'),
+    JSON.stringify({ key: oldKey, pid: 2, identity: 'o', startedAt: new Date().toISOString() })
+  );
+
+  const result = await pruneCache({
+    env: fixedEnv({ cacheRoot }),
+    retentionMs: 14 * 24 * 60 * 60 * 1000,
+    isLockActive: () => true,
+  });
+  assert.equal(result.removed.length, 0, 'active locks are protected from pruning');
+  assert.equal(fs.existsSync(oldDir), true);
+  assert.equal(fs.existsSync(recentDir), true);
+
+  const result2 = await pruneCache({
+    env: fixedEnv({ cacheRoot }),
+    retentionMs: 14 * 24 * 60 * 60 * 1000,
+    isLockActive: record => record.key !== oldKey,
+  });
+  assert.deepEqual(result2.removed, [oldKey]);
+  assert.equal(fs.existsSync(oldDir), false);
+  assert.equal(fs.existsSync(recentDir), true);
+
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});
+
+// ── CLI parsing ──────────────────────────────────────────────────────
+
+test('parseCliArgs supports fingerprint, build, and prune subcommands', () => {
+  assert.deepEqual(parseCliArgs(['fingerprint']), { command: 'fingerprint' });
+  assert.deepEqual(parseCliArgs(['build', 'UDID-1']), { command: 'build', udid: 'UDID-1' });
+  assert.deepEqual(parseCliArgs(['prune']), { command: 'prune' });
+  assert.throws(() => parseCliArgs([]), /Usage/);
+  assert.throws(() => parseCliArgs(['build']), /Usage/);
+  assert.throws(() => parseCliArgs(['unknown']), /Usage/);
+});
+
+// ── Publication boundary ─────────────────────────────────────────────
+
+test('withFingerprintLock does not publish a usable entry when the producer throws', async () => {
+  const cacheRoot = makeTempDir('lock-publish-fail');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
+  };
+  // Pre-create an entry that would otherwise satisfy lookup — it must
+  // not survive a failed producer run.
+  const entryDir = path.join(cacheRoot, 'entries', 'k');
+  fs.mkdirSync(entryDir, { recursive: true });
+  fs.mkdirSync(path.join(entryDir, 'Kilo.app'), { recursive: true });
+  fs.writeFileSync(path.join(entryDir, 'manifest.json'), JSON.stringify({ key: 'k' }));
+  try {
+    await assert.rejects(
+      () =>
+        withFingerprintLock({
+          key: 'k',
+          lockRoot,
+          deps: lockDeps,
+          producer: async () => {
+            throw new Error('producer boom');
+          },
+          readResult: async () => {
+            throw new Error('readResult should not be called on error');
+          },
+        }),
+      /producer boom/
+    );
+    // The on-disk entry must not be installable: either the entry is
+    // removed or the manifest is missing/corrupt. We assert that
+    // lookupCache reports a miss.
+    const result = await lookupCache({
+      env: fixedEnv({ cacheRoot }),
+      key: 'k',
+      onMiss: async () => undefined,
+    });
+    assert.equal(result, undefined);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+test('withFingerprintLock publishes atomically via a temp directory rename', async () => {
+  const cacheRoot = makeTempDir('lock-atomic');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
+  };
+  let producerInvocations = 0;
+  // The producer must build into a temp staging area; publication
+  // (rename into place) happens outside the producer. We observe the
+  // entry dir before the rename to verify the staging boundary.
+  const stagedDirs: string[] = [];
+  const entriesDir = path.join(cacheRoot, 'entries', 'k');
+  const result = sharedResult({ ok: false });
+  const consumer = withFingerprintLock({
+    key: 'k',
+    lockRoot,
+    deps: lockDeps,
+    producer: async () => {
+      producerInvocations += 1;
+      const stage = path.join(cacheRoot, 'staging', `k-${producerInvocations}`);
+      fs.mkdirSync(stage, { recursive: true });
+      fs.mkdirSync(path.join(stage, 'Kilo.app'), { recursive: true });
+      fs.writeFileSync(path.join(stage, 'Kilo.app', 'Info.plist'), '<plist/>');
+      stagedDirs.push(stage);
+      // Simulate atomic publish: rename stage → final.
+      fs.mkdirSync(path.dirname(entriesDir), { recursive: true });
+      fs.renameSync(stage, entriesDir);
+      fs.writeFileSync(
+        path.join(entriesDir, 'manifest.json'),
+        JSON.stringify({
+          key: 'k',
+          nativeHash: 'h',
+          xcodeBuildVersion: 'x',
+          simulatorSdkVersion: 's',
+          hostArch: 'arm64',
+          buildMode: 'debug-dev-client',
+          bundleId: 'com.kilocode.kiloapp',
+          artifactChecksum: await computeArtifactChecksum(path.join(entriesDir, 'Kilo.app')),
+          producerWorktree: '/wt',
+          createdAt: new Date().toISOString(),
+        })
+      );
+      result.set({ ok: true });
+    },
+    readResult: result.read,
+  });
+  // Run twice with a small delay so we can observe the staging/rename
+  // boundary between runs.
+  const value = await consumer;
+  assert.equal(value.ok, true);
+  assert.equal(producerInvocations, 1);
+  assert.equal(stagedDirs.length, 1);
+  assert.equal(fs.existsSync(entriesDir), true);
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});
+
+// ── xcodebuild command ──────────────────────────────────────────────
+
+test('validateXcodeWorkspace accepts the generated workspace and rejects missing', () => {
+  const mobileRoot = makeTempDir('ws-ok');
+  try {
+    fs.mkdirSync(path.join(mobileRoot, 'ios'), { recursive: true });
+    fs.writeFileSync(path.join(mobileRoot, 'ios', 'Kilo.xcworkspace'), 'contents');
+    assert.doesNotThrow(() => validateXcodeWorkspace(mobileRoot));
+  } finally {
+    fs.rmSync(mobileRoot, { recursive: true, force: true });
+  }
+});
+
+test('validateXcodeWorkspace throws with a clear instruction when ios/ is missing', () => {
+  const mobileRoot = makeTempDir('ws-missing');
+  try {
+    assert.throws(
+      () => validateXcodeWorkspace(mobileRoot),
+      /Kilo\.xcworkspace|run.*expo.*prebuild|prebuild/
+    );
+  } finally {
+    fs.rmSync(mobileRoot, { recursive: true, force: true });
+  }
+});
+
+test('buildXcodeBuildCommand uses a dedicated derivedDataPath and targets iphonesimulator', () => {
+  const staging = '/staging';
+  const cmd = buildXcodeBuildCommand({
+    mobileRoot: '/mobile',
+    udid: 'UDID-1234',
+    derivedDataPath: path.join(staging, 'DerivedData'),
+  });
+  assert.equal(cmd.command, 'xcodebuild');
+  assert.deepEqual(cmd.args, [
+    '-workspace',
+    '/mobile/ios/Kilo.xcworkspace',
+    '-scheme',
+    'Kilo',
+    '-configuration',
+    'Debug',
+    '-sdk',
+    'iphonesimulator',
+    '-destination',
+    'id=UDID-1234',
+    '-derivedDataPath',
+    path.join(staging, 'DerivedData'),
+    'build',
+  ]);
+});
+
+test('locateProducedApp returns the canonical Debug-iphonesimulator/Kilo.app path', () => {
+  const derived = makeTempDir('derived');
+  try {
+    const app = path.join(derived, 'Build', 'Products', 'Debug-iphonesimulator', 'Kilo.app');
+    fs.mkdirSync(app, { recursive: true });
+    fs.writeFileSync(path.join(app, 'Info.plist'), '<plist/>');
+    const located = locateProducedApp(derived);
+    assert.equal(located, app);
+  } finally {
+    fs.rmSync(derived, { recursive: true, force: true });
+  }
+});
+
+test('locateProducedApp throws when the canonical .app is missing', () => {
+  const derived = makeTempDir('derived-empty');
+  try {
+    assert.throws(() => locateProducedApp(derived), /Kilo\.app|Debug-iphonesimulator/);
+  } finally {
+    fs.rmSync(derived, { recursive: true, force: true });
+  }
+});
+
+// ── runBuild orchestration ──────────────────────────────────────────
+
+function makeBuildDeps(overrides: Partial<BuildDeps> = {}): BuildDeps {
+  return {
+    env: fixedEnv(),
+    worktreeRoot: '/wt',
+    claimRoot: '/claims',
+    mobileRoot: '/mobile',
+    fingerprint: async () => 'native-hash',
+    build: async () => undefined,
+    readInfoPlist: () => 'com.kilocode.kiloapp',
+    install: () => undefined,
+    copyDir: (src, dest) => {
+      fs.cpSync(src, dest, { recursive: true });
+    },
+    mkdtemp: () => fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-stage-')),
+    validateClaim: (udid: string, worktreeRoot: string, claimRoot: string) =>
+      validateSimulatorClaim(udid, worktreeRoot, claimRoot),
+    sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
+    ...overrides,
+  };
+}
+
+test('runBuild installs a cached entry on hit and does not invoke the builder', async () => {
+  const cacheRoot = makeTempDir('build-hit');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const udid = 'UDID-hit';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: worktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  const key = buildCompatibilityKey({
+    nativeHash: 'native-hash',
+    xcodeBuildVersion: '16A0000',
+    simulatorSdkVersion: '17.5',
+    hostArch: 'arm64',
+    buildMode: 'debug-dev-client',
+  });
+  const keyDir = path.join(cacheRoot, 'entries', key);
+  fs.mkdirSync(keyDir, { recursive: true });
+  const bundle = path.join(keyDir, 'Kilo.app');
+  fs.mkdirSync(bundle, { recursive: true });
+  fs.writeFileSync(path.join(bundle, 'Info.plist'), '<plist/>');
+  const checksum = await computeArtifactChecksum(bundle);
+  fs.writeFileSync(
+    path.join(keyDir, 'manifest.json'),
+    JSON.stringify(
+      fakeManifest({
+        key,
+        nativeHash: 'native-hash',
+        artifactChecksum: checksum,
+        xcodeBuildVersion: '16A0000',
+        simulatorSdkVersion: '17.5',
+      })
+    )
+  );
+  let builderCalls = 0;
+  const installs: Array<{ udid: string; app: string }> = [];
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    fingerprint: async () => 'native-hash',
+    build: async () => {
+      builderCalls += 1;
+    },
+    install: (udid, app) => {
+      installs.push({ udid, app });
+    },
+  });
+  try {
+    await runBuild(udid, deps);
+    assert.equal(builderCalls, 0);
+    assert.equal(installs.length, 1);
+    assert.equal(installs[0].udid, udid);
+    assert.equal(installs[0].app, bundle);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+  }
+});
+
+test('runBuild on miss invokes the builder once, publishes, and installs', async () => {
+  const cacheRoot = makeTempDir('build-miss');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const udid = 'UDID-miss';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: worktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  let builderCalls = 0;
+  const installs: Array<{ udid: string; app: string }> = [];
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    build: async ({ derivedDataPath, udid: buildUdid }) => {
+      builderCalls += 1;
+      // Simulate xcodebuild output: create Kilo.app at canonical path.
+      const app = path.join(
+        derivedDataPath,
+        'Build',
+        'Products',
+        'Debug-iphonesimulator',
+        'Kilo.app'
+      );
+      fs.mkdirSync(app, { recursive: true });
+      fs.writeFileSync(path.join(app, 'Info.plist'), '<plist/>');
+      assert.equal(buildUdid, udid);
+    },
+    install: (installUdid, app) => {
+      installs.push({ udid: installUdid, app });
+    },
+  });
+  try {
+    await runBuild(udid, deps);
+    assert.equal(builderCalls, 1);
+    assert.equal(installs.length, 1);
+    assert.equal(installs[0].udid, udid);
+    // The installed path must be the on-disk cache entry, not a staging path.
+    const key = buildCompatibilityKey({
+      nativeHash: 'native-hash',
+      xcodeBuildVersion: '16A0000',
+      simulatorSdkVersion: '17.5',
+      hostArch: 'arm64',
+      buildMode: 'debug-dev-client',
+    });
+    assert.equal(installs[0].app, path.join(cacheRoot, 'entries', key, 'Kilo.app'));
+    // Cache entry must be valid.
+    const hit = await lookupCache({
+      env: fixedEnv({ cacheRoot }),
+      key,
+      onMiss: async () => undefined,
+    });
+    assert.ok(hit);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+  }
+});
+
+test('runBuild waiter: two concurrent callers invoke the builder once and both install the same entry', async () => {
+  const cacheRoot = makeTempDir('build-waiter');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const udid = 'UDID-waiter';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: worktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  let builderCalls = 0;
+  const installs: string[] = [];
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    build: async ({ derivedDataPath }) => {
+      builderCalls += 1;
+      // Slow build so the second caller arrives before completion.
+      await new Promise(resolve => setTimeout(resolve, 50));
+      const app = path.join(
+        derivedDataPath,
+        'Build',
+        'Products',
+        'Debug-iphonesimulator',
+        'Kilo.app'
+      );
+      fs.mkdirSync(app, { recursive: true });
+      fs.writeFileSync(path.join(app, 'Info.plist'), '<plist/>');
+    },
+    install: (_udid, app) => {
+      installs.push(app);
+    },
+  });
+  try {
+    await Promise.all([runBuild(udid, deps), runBuild(udid, deps)]);
+    assert.equal(builderCalls, 1);
+    assert.equal(installs.length, 2);
+    // Both installs must target the same on-disk entry.
+    assert.equal(installs[0], installs[1]);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+  }
+});
+
+test('runBuild builder failure does not publish a cache entry or install', async () => {
+  const cacheRoot = makeTempDir('build-fail');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const udid = 'UDID-fail';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: worktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  let installCount = 0;
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    build: async () => {
+      throw new Error('xcodebuild failed');
+    },
+    install: () => {
+      installCount += 1;
+    },
+  });
+  try {
+    await assert.rejects(() => runBuild(udid, deps), /xcodebuild failed/);
+    assert.equal(installCount, 0);
+    // No cache entry should exist.
+    const entries = path.join(cacheRoot, 'entries');
+    if (fs.existsSync(entries)) {
+      assert.equal(fs.readdirSync(entries).length, 0);
+    }
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+  }
+});
+
+test('runBuild rejects when the produced app has the wrong bundle id', async () => {
+  const cacheRoot = makeTempDir('build-bundle');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const udid = 'UDID-bundle';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: worktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  let installCount = 0;
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    build: async ({ derivedDataPath }) => {
+      const app = path.join(
+        derivedDataPath,
+        'Build',
+        'Products',
+        'Debug-iphonesimulator',
+        'Kilo.app'
+      );
+      fs.mkdirSync(app, { recursive: true });
+      fs.writeFileSync(path.join(app, 'Info.plist'), '<plist/>');
+    },
+    readInfoPlist: () => 'com.example.wrong',
+    install: () => {
+      installCount += 1;
+    },
+  });
+  try {
+    await assert.rejects(
+      () => runBuild(udid, deps),
+      /bundle id|BundleIdentifier|CFBundleIdentifier/i
+    );
+    assert.equal(installCount, 0);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+  }
+});
+
+test('runBuild rejects when the simulator is not claimed by the current worktree', async () => {
+  const cacheRoot = makeTempDir('build-claim');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const otherWorktree = makeTempDir('wt-other');
+  const udid = 'UDID-claim';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: otherWorktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  let installCount = 0;
+  let buildCount = 0;
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    build: async () => {
+      buildCount += 1;
+    },
+    install: () => {
+      installCount += 1;
+    },
+  });
+  try {
+    await assert.rejects(() => runBuild(udid, deps), /claimed by/);
+    assert.equal(buildCount, 0);
+    assert.equal(installCount, 0);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+    fs.rmSync(otherWorktree, { recursive: true, force: true });
+  }
+});
+
+test('runBuild installs via the exact xcrun simctl install command shape', async () => {
+  const cacheRoot = makeTempDir('build-cmd');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const udid = 'UDID-cmd';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: worktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  const key = buildCompatibilityKey({
+    nativeHash: 'native-hash',
+    xcodeBuildVersion: '16A0000',
+    simulatorSdkVersion: '17.5',
+    hostArch: 'arm64',
+    buildMode: 'debug-dev-client',
+  });
+  const keyDir = path.join(cacheRoot, 'entries', key);
+  fs.mkdirSync(keyDir, { recursive: true });
+  const bundle = path.join(keyDir, 'Kilo.app');
+  fs.mkdirSync(bundle, { recursive: true });
+  fs.writeFileSync(path.join(bundle, 'Info.plist'), '<plist/>');
+  const checksum = await computeArtifactChecksum(bundle);
+  fs.writeFileSync(
+    path.join(keyDir, 'manifest.json'),
+    JSON.stringify(fakeManifest({ key, artifactChecksum: checksum }))
+  );
+  const captured: Array<{ command: string; args: string[] }> = [];
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    fingerprint: async () => 'native-hash',
+    install: (udidArg, app) => {
+      captured.push(buildInstallCommand(udidArg, app));
+    },
+  });
+  try {
+    await runBuild(udid, deps);
+    assert.equal(captured.length, 1);
+    assert.deepEqual(captured[0], {
+      command: 'xcrun',
+      args: ['simctl', 'install', udid, bundle],
+    });
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+  }
+});
+
+// ── runFingerprint orchestration ────────────────────────────────────
+
+test('runFingerprint prints sanitized compatibility dimensions and key only', async () => {
+  const outputs: string[] = [];
+  const write = (chunk: string): void => {
+    outputs.push(chunk);
+  };
+  const deps = {
+    env: fixedEnv({
+      xcodeBuildVersion: '16A0000',
+      simulatorSdkVersion: '17.5',
+      arch: 'arm64',
+    }),
+    mobileRoot: '/mobile',
+    fingerprint: async () => 'native-hash-123',
+    write,
+  };
+  await runFingerprint(deps);
+  assert.equal(outputs.length, 1);
+  const json = JSON.parse(outputs[0]);
+  assert.deepEqual(Object.keys(json).sort(), [
+    'buildMode',
+    'bundleId',
+    'hostArch',
+    'key',
+    'nativeHash',
+    'simulatorSdkVersion',
+    'xcodeBuildVersion',
+  ]);
+  assert.equal(json.bundleId, 'com.kilocode.kiloapp');
+  assert.equal(json.buildMode, 'debug-dev-client');
+  assert.equal(
+    json.key,
+    buildCompatibilityKey({
+      nativeHash: 'native-hash-123',
+      xcodeBuildVersion: '16A0000',
+      simulatorSdkVersion: '17.5',
+      hostArch: 'arm64',
+      buildMode: 'debug-dev-client',
+    })
+  );
+});
+
+// ── runPrune orchestration ──────────────────────────────────────────
+
+test('runPrune reports the removed count and keeps the rest', async () => {
+  const cacheRoot = makeTempDir('prune-run');
+  const entriesRoot = path.join(cacheRoot, 'entries');
+  fs.mkdirSync(entriesRoot, { recursive: true });
+  const oldKey = 'old';
+  const oldDir = path.join(entriesRoot, oldKey);
+  fs.mkdirSync(oldDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(oldDir, 'manifest.json'),
+    JSON.stringify(fakeManifest({ key: oldKey, createdAt: '2026-06-01T00:00:00.000Z' }))
+  );
+  const recentKey = 'recent';
+  const recentDir = path.join(entriesRoot, recentKey);
+  fs.mkdirSync(recentDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(recentDir, 'manifest.json'),
+    JSON.stringify(fakeManifest({ key: recentKey, createdAt: '2026-07-15T11:00:00.000Z' }))
+  );
+  const outputs: string[] = [];
+  const deps = {
+    env: fixedEnv({ cacheRoot }),
+    isLockActive: () => false,
+    write: (chunk: string) => outputs.push(chunk),
+  };
+  try {
+    await runPrune(deps);
+    assert.equal(outputs.length, 1);
+    const json = JSON.parse(outputs[0]);
+    assert.deepEqual(json.removed, [oldKey]);
+    assert.deepEqual(json.kept, [recentKey]);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+// ── Spec-review findings ────────────────────────────────────────────
+
+test('atomic lock takeover: two simultaneous adopters produce exactly once', async () => {
+  const cacheRoot = makeTempDir('lock-atomic-takeover');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  const lockDir = path.join(lockRoot, 'test.lock');
+  fs.mkdirSync(lockDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(lockDir, 'lock.json'),
+    JSON.stringify({
+      key: 'test',
+      pid: 99999,
+      identity: 'dead-identity',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+    })
+  );
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
+    // The stale lock has pid 99999; the winner will have process.pid.
+    pidAlive: (pid: number) => pid === process.pid,
+    processIdentity: (pid: number) =>
+      pid === process.pid ? `live-identity-${process.pid}` : 'dead-identity',
+    isLockActive: record =>
+      record.pid === process.pid && record.identity.startsWith('live-identity'),
+  };
+  const result = sharedResult({ value: '' });
+  let producerInvocations = 0;
+  const producer = async () => {
+    producerInvocations += 1;
+    await new Promise(resolve => setTimeout(resolve, 50));
+    result.set({ value: 'produced' });
+  };
+  try {
+    const [a, b] = await Promise.all([
+      withFingerprintLock({
+        key: 'test',
+        lockRoot,
+        deps: lockDeps,
+        producer,
+        readResult: result.read,
+      }),
+      withFingerprintLock({
+        key: 'test',
+        lockRoot,
+        deps: lockDeps,
+        producer,
+        readResult: result.read,
+      }),
+    ]);
+    assert.equal(producerInvocations, 1, 'exactly one producer should run');
+    assert.equal(a.value, 'produced');
+    assert.equal(b.value, 'produced');
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+test('waiter TOCTOU: re-read result before attempting takeover', async () => {
+  const cacheRoot = makeTempDir('lock-toctou');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  const lockDir = path.join(lockRoot, 'test.lock');
+  const resultFile = path.join(lockDir, 'result.json');
+  fs.mkdirSync(lockDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(lockDir, 'lock.json'),
+    JSON.stringify({
+      key: 'test',
+      pid: 99999,
+      identity: 'dead-identity',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+    })
+  );
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: async (ms: number) => {
+      await new Promise(resolve => setTimeout(resolve, Math.max(ms, 1)));
+      // Simulate producer publishing completion between waiter's result read and lock read
+      if (!fs.existsSync(resultFile)) {
+        fs.writeFileSync(resultFile, JSON.stringify({ done: true }));
+        fs.rmSync(path.join(lockDir, 'lock.json'), { force: true });
+      }
+    },
+    pidAlive: () => false,
+    processIdentity: () => 'dead-identity',
+    isLockActive: () => false,
+  };
+  let producerInvocations = 0;
+  const result = sharedResult('published');
+  const producer = async () => {
+    producerInvocations += 1;
+  };
+  try {
+    const value = await withFingerprintLock({
+      key: 'test',
+      lockRoot,
+      deps: lockDeps,
+      producer,
+      readResult: result.read,
+    });
+    assert.equal(producerInvocations, 0, 'producer should not run if result was published');
+    assert.equal(value, 'published');
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+test('lookupCache misses when app present but manifest absent', async () => {
+  const cacheRoot = makeTempDir('lookup-no-manifest');
+  const key = 'test-key';
+  const keyDir = path.join(cacheRoot, 'entries', key);
+  fs.mkdirSync(keyDir, { recursive: true });
+  fs.mkdirSync(path.join(keyDir, 'Kilo.app'), { recursive: true });
+  // No manifest.json
+  let onMissCalled = false;
+  const result = await lookupCache({
+    env: fixedEnv({ cacheRoot }),
+    key,
+    onMiss: async () => {
+      onMissCalled = true;
+      return undefined;
+    },
+  });
+  assert.equal(result, undefined);
+  assert.equal(onMissCalled, true);
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});
+
+test('pruneCache removes entries with invalid manifest JSON', async () => {
+  const cacheRoot = makeTempDir('prune-invalid-manifest');
+  const entriesRoot = path.join(cacheRoot, 'entries');
+  fs.mkdirSync(entriesRoot, { recursive: true });
+  const invalidKey = 'invalid';
+  const invalidDir = path.join(entriesRoot, invalidKey);
+  fs.mkdirSync(invalidDir, { recursive: true });
+  fs.writeFileSync(path.join(invalidDir, 'manifest.json'), '{ invalid json');
+  const validKey = 'valid';
+  const validDir = path.join(entriesRoot, validKey);
+  fs.mkdirSync(validDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(validDir, 'manifest.json'),
+    JSON.stringify(fakeManifest({ key: validKey, createdAt: '2026-07-15T11:00:00.000Z' }))
+  );
+  const result = await pruneCache({
+    env: fixedEnv({ cacheRoot }),
+    retentionMs: 14 * 24 * 60 * 60 * 1000,
+    isLockActive: () => false,
+  });
+  assert.deepEqual(result.removed, [invalidKey]);
+  assert.deepEqual(result.kept, [validKey]);
+  assert.equal(fs.existsSync(invalidDir), false);
+  assert.equal(fs.existsSync(validDir), true);
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});
+
+test('publishCacheEntry rechecks cache and avoids build when valid entry appears', async () => {
+  const cacheRoot = makeTempDir('publish-recheck');
+  const key = 'a'.repeat(64);
+  const keyDir = path.join(cacheRoot, 'entries', key);
+  fs.mkdirSync(keyDir, { recursive: true });
+  const bundle = path.join(keyDir, 'Kilo.app');
+  fs.mkdirSync(bundle, { recursive: true });
+  fs.writeFileSync(path.join(bundle, 'Info.plist'), '<plist/>');
+  const checksum = await computeArtifactChecksum(bundle);
+  fs.writeFileSync(
+    path.join(keyDir, 'manifest.json'),
+    JSON.stringify(
+      fakeManifest({
+        key,
+        nativeHash: 'native-hash',
+        artifactChecksum: checksum,
+        xcodeBuildVersion: '16A0000',
+        simulatorSdkVersion: '17.5',
+      })
+    )
+  );
+  let buildInvocations = 0;
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    build: async () => {
+      buildInvocations += 1;
+    },
+  });
+  try {
+    const result = await publishCacheEntry({
+      env: fixedEnv({ cacheRoot }),
+      key,
+      compatibility: {
+        nativeHash: 'native-hash',
+        xcodeBuildVersion: '16A0000',
+        simulatorSdkVersion: '17.5',
+        hostArch: 'arm64',
+        buildMode: 'debug-dev-client',
+      },
+      worktreeRoot: '/wt',
+      udid: 'UDID-test',
+      deps,
+    });
+    assert.equal(buildInvocations, 0, 'build should not be called when cache is valid');
+    assert.ok(result);
+    assert.equal(result.manifest.key, key);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+test('runBuild revalidates on-disk entry after lock result', async () => {
+  const cacheRoot = makeTempDir('runbuild-revalidate');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const udid = 'UDID-revalidate';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: worktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  let buildInvocations = 0;
+  const installs: string[] = [];
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    build: async ({ derivedDataPath }) => {
+      buildInvocations += 1;
+      const app = path.join(
+        derivedDataPath,
+        'Build',
+        'Products',
+        'Debug-iphonesimulator',
+        'Kilo.app'
+      );
+      fs.mkdirSync(app, { recursive: true });
+      fs.writeFileSync(path.join(app, 'Info.plist'), '<plist/>');
+    },
+    install: (_udid, app) => {
+      installs.push(app);
+    },
+  });
+  try {
+    await runBuild(udid, deps);
+    assert.equal(buildInvocations, 1);
+    assert.equal(installs.length, 1);
+    // Verify the installed path is the on-disk cache entry, not a staging path
+    const key = buildCompatibilityKey({
+      nativeHash: 'native-hash',
+      xcodeBuildVersion: '16A0000',
+      simulatorSdkVersion: '17.5',
+      hostArch: 'arm64',
+      buildMode: 'debug-dev-client',
+    });
+    const expectedPath = path.join(cacheRoot, 'entries', key, 'Kilo.app');
+    assert.equal(installs[0], expectedPath);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+  }
+});
+
+test('computeArtifactChecksum distinguishes nested paths (a/file vs b/file)', async () => {
+  const dir = makeTempDir('checksum-nested');
+  try {
+    // Create a/file with content1 and b/file with content2 in the SAME directory
+    fs.mkdirSync(path.join(dir, 'a'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'a', 'file'), 'content1');
+    fs.mkdirSync(path.join(dir, 'b'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'b', 'file'), 'content2');
+
+    const checksum = await computeArtifactChecksum(dir);
+
+    // Create a different structure with same filenames but different content
+    const dir2 = makeTempDir('checksum-nested-2');
+    fs.mkdirSync(path.join(dir2, 'a'), { recursive: true });
+    fs.writeFileSync(path.join(dir2, 'a', 'file'), 'content2');
+    fs.mkdirSync(path.join(dir2, 'b'), { recursive: true });
+    fs.writeFileSync(path.join(dir2, 'b', 'file'), 'content1');
+
+    const checksum2 = await computeArtifactChecksum(dir2);
+
+    // These should be different because the content is swapped between a/ and b/
+    assert.notEqual(checksum, checksum2, 'swapped content should produce different checksums');
+
+    fs.rmSync(dir2, { recursive: true, force: true });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('computeArtifactChecksum rejects symlinks outside root', async () => {
+  const dir = makeTempDir('checksum-symlink');
+  const outsideDir = makeTempDir('checksum-outside');
+  try {
+    // Create a file outside the root
+    fs.writeFileSync(path.join(outsideDir, 'secret'), 'secret-content');
+
+    // Create a symlink inside the root pointing outside
+    fs.symlinkSync(path.join(outsideDir, 'secret'), path.join(dir, 'link'));
+
+    // The checksum should reject the symlink
+    await assert.rejects(
+      () => computeArtifactChecksum(dir),
+      /symlink|link/i,
+      'should reject symlinks'
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  }
+});
+
+// ── Review findings ────────────────────────────────────────────────
+
+test('tryAdoptLock does not steal a lock that has been replaced by a fresh active record', async () => {
+  const cacheRoot = makeTempDir('lock-steal-toctou');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  const lockDir = path.join(lockRoot, 'test.lock');
+  const lockFile = path.join(lockDir, 'lock.json');
+  const resultFile = path.join(lockDir, 'result.json');
+  fs.mkdirSync(lockDir, { recursive: true });
+  const staleRecord: LockRecord = {
+    key: 'test',
+    pid: 99999,
+    identity: 'dead',
+    startedAt: new Date(Date.now() - 60_000).toISOString(),
+  };
+  fs.writeFileSync(lockFile, JSON.stringify(staleRecord));
+
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: async ms => {
+      await new Promise(resolve => setTimeout(resolve, Math.max(ms, 1)));
+      // Between observing the stale record and attempting takeover, a
+      // fresh active lock is installed by another caller.
+      if (fs.readFileSync(lockFile, 'utf8').includes('"pid":99999')) {
+        fs.writeFileSync(
+          lockFile,
+          JSON.stringify({
+            key: 'test',
+            pid: 4242,
+            identity: 'fresh-active',
+            startedAt: new Date().toISOString(),
+          })
+        );
+      }
+    },
+    pidAlive: pid => pid === 4242,
+    processIdentity: pid => (pid === 4242 ? 'fresh-active' : 'dead'),
+    isLockActive: record => record.pid === 4242 && record.identity === 'fresh-active',
+    waitForResultMs: 100,
+    pollIntervalMs: 25,
+  };
+  let producerInvocations = 0;
+  try {
+    await assert.rejects(
+      () =>
+        withFingerprintLock({
+          key: 'test',
+          lockRoot,
+          deps: lockDeps,
+          producer: async () => {
+            producerInvocations += 1;
+          },
+          readResult: async () => {
+            throw new Error('readResult should not be called when lock is active');
+          },
+        }),
+      /Timed out|active producer/i
+    );
+    assert.equal(producerInvocations, 0, 'must not steal an active lock');
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+test('staging directory is created under cacheRoot so publication rename is same filesystem', async () => {
+  const cacheRoot = makeTempDir('exdev-safe');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const udid = 'UDID-exdev';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: worktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  let requestedMkdtempPrefix: string | undefined;
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    mkdtemp: prefix => {
+      requestedMkdtempPrefix = prefix;
+      return fs.mkdtempSync(prefix);
+    },
+    build: async ({ stagingDir, derivedDataPath }) => {
+      // Ensure the staging dir is inside the cache root.
+      assert.ok(
+        stagingDir.startsWith(cacheRoot),
+        `stagingDir ${stagingDir} must be under cacheRoot ${cacheRoot}`
+      );
+      fs.mkdirSync(
+        path.join(derivedDataPath, 'Build', 'Products', 'Debug-iphonesimulator', 'Kilo.app'),
+        {
+          recursive: true,
+        }
+      );
+      fs.writeFileSync(
+        path.join(
+          derivedDataPath,
+          'Build',
+          'Products',
+          'Debug-iphonesimulator',
+          'Kilo.app',
+          'Info.plist'
+        ),
+        '<plist/>'
+      );
+    },
+  });
+  try {
+    await runBuild(udid, deps);
+    assert.ok(
+      requestedMkdtempPrefix?.startsWith(path.join(cacheRoot, 'staging')),
+      `mkdtemp prefix should be under cacheRoot/staging, got ${requestedMkdtempPrefix}`
+    );
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+  }
+});
+
+test('pruneCache removes stale lock artifacts and orphan quarantines', async () => {
+  const cacheRoot = makeTempDir('prune-artifacts');
+  const entriesRoot = path.join(cacheRoot, 'entries');
+  const locksRoot = path.join(cacheRoot, 'locks');
+  fs.mkdirSync(entriesRoot, { recursive: true });
+  fs.mkdirSync(locksRoot, { recursive: true });
+
+  const oldKey = 'old';
+  const oldDir = path.join(entriesRoot, oldKey);
+  fs.mkdirSync(oldDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(oldDir, 'manifest.json'),
+    JSON.stringify(fakeManifest({ key: oldKey, createdAt: '2026-06-01T00:00:00.000Z' }))
+  );
+  // Inactive lock artifacts for the old entry
+  const oldLockDir = path.join(locksRoot, `${oldKey}.lock`);
+  fs.mkdirSync(oldLockDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(oldLockDir, 'lock.json'),
+    JSON.stringify({ key: oldKey, pid: 1, identity: 'x', startedAt: new Date().toISOString() })
+  );
+  fs.writeFileSync(path.join(oldLockDir, 'result.json'), '{}');
+
+  // Active lock artifacts must be protected
+  const activeKey = 'active';
+  const activeDir = path.join(entriesRoot, activeKey);
+  fs.mkdirSync(activeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(activeDir, 'manifest.json'),
+    JSON.stringify(fakeManifest({ key: activeKey, createdAt: '2026-07-15T11:00:00.000Z' }))
+  );
+  const activeLockDir = path.join(locksRoot, `${activeKey}.lock`);
+  fs.mkdirSync(activeLockDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(activeLockDir, 'lock.json'),
+    JSON.stringify({
+      key: activeKey,
+      pid: process.pid,
+      identity: 'active',
+      startedAt: new Date().toISOString(),
+    })
+  );
+
+  // Orphan quarantine directory with no entry
+  const orphanQuarantine = path.join(locksRoot, 'orphan.quarantine.123-456-abc');
+  fs.mkdirSync(orphanQuarantine, { recursive: true });
+  fs.writeFileSync(path.join(orphanQuarantine, 'stale.json'), '{}');
+
+  const result = await pruneCache({
+    env: fixedEnv({ cacheRoot }),
+    retentionMs: 14 * 24 * 60 * 60 * 1000,
+    isLockActive: record => record.pid === process.pid && record.identity === 'active',
+  });
+  assert.deepEqual(result.removed, [oldKey]);
+  assert.deepEqual(result.kept, [activeKey]);
+  assert.equal(fs.existsSync(oldDir), false);
+  assert.equal(fs.existsSync(oldLockDir), false);
+  assert.equal(fs.existsSync(orphanQuarantine), false);
+  assert.equal(fs.existsSync(activeDir), true);
+  assert.equal(fs.existsSync(activeLockDir), true);
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});
+
+test('computeArtifactChecksum is async and streams files without loading entire .app into memory', async () => {
+  const dir = makeTempDir('checksum-stream');
+  try {
+    fs.mkdirSync(path.join(dir, 'a'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'a', 'file'), 'chunk-1');
+    fs.mkdirSync(path.join(dir, 'b'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'b', 'file'), 'chunk-2');
+    const checksum = await computeArtifactChecksum(dir);
+    assert.equal(checksum.length, 64);
+    // Same content produces same checksum
+    const checksum2 = await computeArtifactChecksum(dir);
+    assert.equal(checksum, checksum2);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('computeArtifactChecksum rejects symlinks when streaming', async () => {
+  const dir = makeTempDir('checksum-stream-link');
+  const outsideDir = makeTempDir('checksum-outside-2');
+  try {
+    fs.writeFileSync(path.join(outsideDir, 'secret'), 'secret');
+    fs.symlinkSync(path.join(outsideDir, 'secret'), path.join(dir, 'link'));
+    await assert.rejects(() => computeArtifactChecksum(dir), /symlink|link/i);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test('mobileRoot is resolved from import.meta.dirname, not process.cwd', () => {
+  const actual = mobileRoot();
+  // The module is at dev/local/mobile-ios-build.ts; two levels up is repo root.
+  const expected = path.resolve(import.meta.dirname, '..', '..', 'apps', 'mobile');
+  assert.equal(actual, expected);
+  // The current working directory must not influence the result.
+  assert.doesNotMatch(actual, /apps\/mobile\/apps\/mobile/);
+});
+
+test('validateSimulatorClaim requires status ready and rejects preparing, invalid, legacy, and foreign', () => {
+  const claimRoot = makeTempDir('claim-ready');
+  const worktree = makeTempDir('wt');
+  const other = makeTempDir('wt-other');
+  const udid = 'UDID-ready';
+  try {
+    // Ready claim owned by this worktree
+    fs.writeFileSync(
+      path.join(claimRoot, `${udid}.json`),
+      JSON.stringify({
+        deviceId: udid,
+        worktreeRoot: worktree,
+        claimId: 'c',
+        status: 'ready',
+        claimedAt: new Date().toISOString(),
+      })
+    );
+    assert.doesNotThrow(() => validateSimulatorClaim(udid, worktree, claimRoot));
+
+    // Same worktree but preparing
+    fs.writeFileSync(
+      path.join(claimRoot, `${udid}.json`),
+      JSON.stringify({
+        deviceId: udid,
+        worktreeRoot: worktree,
+        claimId: 'c',
+        status: 'preparing',
+        claimedAt: new Date().toISOString(),
+      })
+    );
+    assert.throws(
+      () => validateSimulatorClaim(udid, worktree, claimRoot),
+      /not ready|preparing|status/i
+    );
+
+    // Invalid status
+    fs.writeFileSync(
+      path.join(claimRoot, `${udid}.json`),
+      JSON.stringify({
+        deviceId: udid,
+        worktreeRoot: worktree,
+        claimId: 'c',
+        status: 'invalid',
+        claimedAt: new Date().toISOString(),
+      })
+    );
+    assert.throws(
+      () => validateSimulatorClaim(udid, worktree, claimRoot),
+      /not ready|invalid|status/i
+    );
+
+    // Corrupt current record (missing claimId)
+    fs.writeFileSync(
+      path.join(claimRoot, `${udid}.json`),
+      JSON.stringify({
+        deviceId: udid,
+        worktreeRoot: worktree,
+        status: 'ready',
+        claimedAt: new Date().toISOString(),
+      })
+    );
+    assert.throws(() => validateSimulatorClaim(udid, worktree, claimRoot), /corrupt|claimId/i);
+
+    // Legacy claim (no status) is rejected for build cache
+    fs.writeFileSync(
+      path.join(claimRoot, `${udid}.json`),
+      JSON.stringify({ deviceId: udid, worktreeRoot: worktree })
+    );
+    assert.throws(
+      () => validateSimulatorClaim(udid, worktree, claimRoot),
+      /not ready|legacy|status/i
+    );
+
+    // Foreign ready claim
+    fs.writeFileSync(
+      path.join(claimRoot, `${udid}.json`),
+      JSON.stringify({
+        deviceId: udid,
+        worktreeRoot: other,
+        claimId: 'c',
+        status: 'ready',
+        claimedAt: new Date().toISOString(),
+      })
+    );
+    assert.throws(() => validateSimulatorClaim(udid, worktree, claimRoot), /claimed by/);
+  } finally {
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+    fs.rmSync(other, { recursive: true, force: true });
+  }
+});
+
+test('defaultIsLockActive requires both pidAlive and processIdentity match', () => {
+  const aliveRecord: LockRecord = { key: 'k', pid: 1, identity: 'a', startedAt: '' };
+  const deadRecord: LockRecord = { key: 'k', pid: 2, identity: 'b', startedAt: '' };
+
+  // Both probes agree: active
+  let active = defaultIsLockActive({
+    env: fixedEnv(),
+    pidAlive: () => true,
+    processIdentity: () => 'a',
+  });
+  assert.equal(active(aliveRecord), true);
+
+  // PID alive but identity mismatch: inactive
+  active = defaultIsLockActive({
+    env: fixedEnv(),
+    pidAlive: () => true,
+    processIdentity: () => 'wrong',
+  });
+  assert.equal(active(aliveRecord), false);
+
+  // Identity matches but PID dead: inactive
+  active = defaultIsLockActive({
+    env: fixedEnv(),
+    pidAlive: () => false,
+    processIdentity: () => 'b',
+  });
+  assert.equal(active(deadRecord), false);
+
+  // Only processIdentity provided: must still be alive via default probe
+  active = defaultIsLockActive({
+    env: fixedEnv(),
+    processIdentity: () => 'a',
+  });
+  // Use our own PID for the default probe; it is alive.
+  const ownRecord: LockRecord = { key: 'k', pid: process.pid, identity: 'a', startedAt: '' };
+  assert.equal(active(ownRecord), true);
+  // A dead record with only identity provided should be inactive because
+  // the default pidAlive probe returns false for non-existent PIDs.
+  active = defaultIsLockActive({
+    env: fixedEnv(),
+    processIdentity: () => 'b',
+  });
+  assert.equal(active(deadRecord), false);
+});
+
+test('isValidManifest rejects createdAt that is not a strict ISO-8601 roundtrip', () => {
+  const base = fakeManifest();
+  assert.equal(
+    isValidManifest(
+      { ...base, createdAt: new Date().toISOString() },
+      { key: 'k1', bundleId: 'com.kilocode.kiloapp' }
+    ),
+    true
+  );
+  assert.equal(
+    isValidManifest(
+      { ...base, createdAt: '2026-07-15' },
+      { key: 'k1', bundleId: 'com.kilocode.kiloapp' }
+    ),
+    false
+  );
+  assert.equal(
+    isValidManifest(
+      { ...base, createdAt: '2026-07-15 12:00:00' },
+      { key: 'k1', bundleId: 'com.kilocode.kiloapp' }
+    ),
+    false
+  );
+  assert.equal(
+    isValidManifest(
+      { ...base, createdAt: 'not a date' },
+      { key: 'k1', bundleId: 'com.kilocode.kiloapp' }
+    ),
+    false
+  );
+  assert.equal(
+    isValidManifest({ ...base, createdAt: '' }, { key: 'k1', bundleId: 'com.kilocode.kiloapp' }),
+    false
+  );
+});
+
+test('computeArtifactChecksum streams large files in chunks without loading full file', async () => {
+  const dir = makeTempDir('checksum-large');
+  try {
+    // Create a file larger than the 64KB chunk size
+    const large = Buffer.alloc(70 * 1024, 'x');
+    fs.writeFileSync(path.join(dir, 'large.bin'), large);
+    const checksum = await computeArtifactChecksum(dir);
+    assert.equal(checksum.length, 64);
+    // Same content produces same checksum
+    const checksum2 = await computeArtifactChecksum(dir);
+    assert.equal(checksum, checksum2);
+    // Different content produces different checksum
+    large[0] = 'y'.charCodeAt(0);
+    fs.writeFileSync(path.join(dir, 'large.bin'), large);
+    assert.notEqual(await computeArtifactChecksum(dir), checksum);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('defaultIsLockActive rejects when only pidAlive or only processIdentity matches', () => {
+  const record: LockRecord = { key: 'k', pid: 42, identity: 'expected', startedAt: '' };
+
+  // Only pidAlive provided: identity must still match via default probe
+  let active = defaultIsLockActive({
+    env: fixedEnv(),
+    pidAlive: () => true,
+  });
+  assert.equal(active(record), false, 'alive but identity mismatch');
+
+  // Only processIdentity provided: pid must still be alive via default probe
+  active = defaultIsLockActive({
+    env: fixedEnv(),
+    processIdentity: () => 'expected',
+  });
+  // PID 42 is unlikely to exist in this test process, so it should be inactive
+  assert.equal(active(record), false, 'identity matches but pid dead');
+
+  // Both provided and match
+  active = defaultIsLockActive({
+    env: fixedEnv(),
+    pidAlive: () => true,
+    processIdentity: () => 'expected',
+  });
+  assert.equal(active(record), true);
+});
+
+test('withFingerprintLock treats result file only as completion signal and does not trust serialized values', async () => {
+  const cacheRoot = makeTempDir('lock-completion-signal');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  const lockDir = path.join(lockRoot, 'test.lock');
+  const resultFile = path.join(lockDir, 'result.json');
+  fs.mkdirSync(lockDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(lockDir, 'lock.json'),
+    JSON.stringify({
+      key: 'test',
+      pid: 99999,
+      identity: 'dead-identity',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+    })
+  );
+  // A previous producer left a valid completion signal. The waiter must
+  // not deserialize any value from this file; it must call readResult to
+  // get the canonical result from disk.
+  fs.writeFileSync(resultFile, JSON.stringify({ done: true }));
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
+    pidAlive: () => false,
+    processIdentity: () => 'dead-identity',
+    isLockActive: () => false,
+  };
+  let producerInvocations = 0;
+  let readResultCalls = 0;
+  try {
+    const result = await withFingerprintLock({
+      key: 'test',
+      lockRoot,
+      deps: lockDeps,
+      producer: async () => {
+        producerInvocations += 1;
+      },
+      readResult: async () => {
+        readResultCalls += 1;
+        return { validated: true };
+      },
+    });
+    assert.equal(producerInvocations, 0, 'producer must not run when a completion signal exists');
+    assert.equal(readResultCalls, 1);
+    assert.equal(result.validated, true);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+test('withFingerprintLock propagates producer error marker to active waiters without trusting serialized values', async () => {
+  const cacheRoot = makeTempDir('lock-error-marker');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  const lockDir = path.join(lockRoot, 'test.lock');
+  const resultFile = path.join(lockDir, 'result.json');
+  fs.mkdirSync(lockDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(lockDir, 'lock.json'),
+    JSON.stringify({
+      key: 'test',
+      pid: 99999,
+      identity: 'active-identity',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+    })
+  );
+  // A currently failing producer left an error marker. An active waiter must
+  // propagate the message-only generic Error and never run its own producer
+  // or call readResult. Once the lock is no longer active, the marker is
+  // stale and a later caller will rebuild instead.
+  fs.writeFileSync(resultFile, JSON.stringify({ error: { message: 'previous producer failed' } }));
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
+    pidAlive: () => true,
+    processIdentity: () => 'active-identity',
+    isLockActive: () => true,
+  };
+  let producerInvocations = 0;
+  let readResultCalls = 0;
+  try {
+    await assert.rejects(
+      () =>
+        withFingerprintLock({
+          key: 'test',
+          lockRoot,
+          deps: lockDeps,
+          producer: async () => {
+            producerInvocations += 1;
+          },
+          readResult: async () => {
+            readResultCalls += 1;
+            return { validated: true };
+          },
+        }),
+      /previous producer failed/
+    );
+    assert.equal(producerInvocations, 0);
+    assert.equal(readResultCalls, 0);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+test('withFingerprintLock rebuilds when a stale done marker has no canonical result', async () => {
+  // A stale `{done:true}` marker with no active lock and no usable canonical
+  // result must not fail; the next caller should adopt and rebuild.
+  const cacheRoot = makeTempDir('lock-stale-done-rebuild');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  const lockDir = path.join(lockRoot, 'test.lock');
+  const resultFile = path.join(lockDir, 'result.json');
+  const canonicalResultFile = path.join(cacheRoot, 'canonical-result.txt');
+  fs.mkdirSync(lockDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(lockDir, 'lock.json'),
+    JSON.stringify({
+      key: 'test',
+      pid: 99999,
+      identity: 'dead-identity',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+    })
+  );
+  fs.writeFileSync(resultFile, JSON.stringify({ done: true }));
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
+    pidAlive: () => false,
+    processIdentity: () => 'dead-identity',
+    isLockActive: () => false,
+  };
+  let producerInvocations = 0;
+  try {
+    const value = await withFingerprintLock({
+      key: 'test',
+      lockRoot,
+      deps: lockDeps,
+      producer: async () => {
+        producerInvocations += 1;
+        fs.writeFileSync(canonicalResultFile, 'rebuilt');
+      },
+      readResult: async () => {
+        if (!fs.existsSync(canonicalResultFile)) {
+          throw new Error('no canonical result yet');
+        }
+        return { value: fs.readFileSync(canonicalResultFile, 'utf8') };
+      },
+    });
+    assert.equal(producerInvocations, 1, 'producer must run once to rebuild');
+    assert.equal(value.value, 'rebuilt');
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  }
+});
+
+test('withFingerprintLock retries after producer failure when lock is inactive', async () => {
+  // Regression test: producer failure should not permanently poison the key.
+  // First call fails and leaves an error marker. Second call detects the
+  // inactive stale marker, clears it, runs a succeeding producer once, and
+  // returns the canonical readResult. Third call is governed by the actual
+  // cache/result protocol, not the stale error marker.
+  const cacheRoot = makeTempDir('lock-retry-after-failure');
+  const lockRoot = path.join(cacheRoot, 'locks');
+  const lockDir = path.join(lockRoot, 'test.lock');
+  const resultFile = path.join(lockDir, 'result.json');
+  const lockDeps: CacheLockDeps = {
+    env: fixedEnv({ cacheRoot }),
+    sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
+    pidAlive: () => false,
+    processIdentity: () => 'dead-identity',
+    isLockActive: () => false,
+  };
+
+  // First call: producer fails; error reaches caller.
+  let firstProducerInvocations = 0;
+  await assert.rejects(
+    () =>
+      withFingerprintLock({
+        key: 'test',
+        lockRoot,
+        deps: lockDeps,
+        producer: async () => {
+          firstProducerInvocations += 1;
+          throw new Error('first producer failed');
+        },
+        readResult: async () => {
+          throw new Error('readResult should not be called on error');
+        },
+      }),
+    /first producer failed/
+  );
+  assert.equal(firstProducerInvocations, 1);
+  assert.equal(fs.existsSync(resultFile), true);
+  const firstMarker = JSON.parse(fs.readFileSync(resultFile, 'utf8'));
+  assert.equal(firstMarker.error?.message, 'first producer failed');
+  assert.equal(
+    fs.existsSync(path.join(lockDir, 'lock.json')),
+    false,
+    'lock.json removed after failure'
+  );
+
+  // Second call: detects stale error marker, adopts, clears marker, runs
+  // succeeding producer once, and returns canonical readResult.
+  const result = sharedResult({ value: '' });
+  let secondProducerInvocations = 0;
+  const value = await withFingerprintLock({
+    key: 'test',
+    lockRoot,
+    deps: lockDeps,
+    producer: async () => {
+      secondProducerInvocations += 1;
+      result.set({ value: 'success' });
+    },
+    readResult: result.read,
+  });
+  assert.equal(secondProducerInvocations, 1);
+  assert.equal(value.value, 'success');
+  const secondMarker = JSON.parse(fs.readFileSync(resultFile, 'utf8'));
+  assert.equal(secondMarker.done, true, 'stale error marker must be replaced with done');
+  assert.equal(secondMarker.error, undefined, 'stale error marker must be cleared');
+
+  // Third call: governed by actual cache/result protocol; the stale error is
+  // gone and the done marker is honored, so the producer does not run again.
+  let thirdProducerInvocations = 0;
+  const thirdValue = await withFingerprintLock({
+    key: 'test',
+    lockRoot,
+    deps: lockDeps,
+    producer: async () => {
+      thirdProducerInvocations += 1;
+    },
+    readResult: result.read,
+  });
+  assert.equal(thirdProducerInvocations, 0, 'third call must not re-run producer');
+  assert.equal(thirdValue.value, 'success');
+
+  fs.rmSync(cacheRoot, { recursive: true, force: true });
+});

--- a/dev/local/mobile-ios-build.test.ts
+++ b/dev/local/mobile-ios-build.test.ts
@@ -689,12 +689,61 @@ function makeBuildDeps(overrides: Partial<BuildDeps> = {}): BuildDeps {
       fs.cpSync(src, dest, { recursive: true });
     },
     mkdtemp: () => fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-stage-')),
+    withNativeBuildSlot: run => run(),
     validateClaim: (udid: string, worktreeRoot: string, claimRoot: string) =>
       validateSimulatorClaim(udid, worktreeRoot, claimRoot),
     sleep: (ms: number) => new Promise(resolve => setTimeout(resolve, Math.max(ms, 1))),
     ...overrides,
   };
 }
+
+test('runBuild enters the host native-build slot only on cache miss', async () => {
+  const cacheRoot = makeTempDir('build-slot');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const udid = 'UDID-slot';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: worktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  let slots = 0;
+  const deps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    withNativeBuildSlot: async run => {
+      slots += 1;
+      return run();
+    },
+    build: async ({ derivedDataPath }) => {
+      const app = path.join(
+        derivedDataPath,
+        'Build',
+        'Products',
+        'Debug-iphonesimulator',
+        'Kilo.app'
+      );
+      fs.mkdirSync(app, { recursive: true });
+      fs.writeFileSync(path.join(app, 'Info.plist'), '<plist/>');
+    },
+  });
+
+  try {
+    await runBuild(udid, deps);
+    await runBuild(udid, deps);
+    assert.equal(slots, 1);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+  }
+});
 
 test('runBuild installs a cached entry on hit and does not invoke the builder', async () => {
   const cacheRoot = makeTempDir('build-hit');

--- a/dev/local/mobile-ios-build.test.ts
+++ b/dev/local/mobile-ios-build.test.ts
@@ -1683,10 +1683,9 @@ test('pruneCache removes stale lock artifacts and orphan quarantines', async () 
     })
   );
 
-  // Orphan quarantine directory with no entry
+  // tryAdoptLock quarantines lock.json as a file, not a directory.
   const orphanQuarantine = path.join(locksRoot, 'orphan.quarantine.123-456-abc');
-  fs.mkdirSync(orphanQuarantine, { recursive: true });
-  fs.writeFileSync(path.join(orphanQuarantine, 'stale.json'), '{}');
+  fs.writeFileSync(orphanQuarantine, '{}');
 
   const result = await pruneCache({
     env: fixedEnv({ cacheRoot }),
@@ -1936,7 +1935,12 @@ test('computeArtifactChecksum streams large files in chunks without loading full
 });
 
 test('defaultIsLockActive rejects when only pidAlive or only processIdentity matches', () => {
-  const record: LockRecord = { key: 'k', pid: 42, identity: 'expected', startedAt: '' };
+  const record: LockRecord = {
+    key: 'k',
+    pid: 0,
+    identity: 'expected',
+    startedAt: '',
+  };
 
   // Only pidAlive provided: identity must still match via default probe
   let active = defaultIsLockActive({
@@ -1950,7 +1954,7 @@ test('defaultIsLockActive rejects when only pidAlive or only processIdentity mat
     env: fixedEnv(),
     processIdentity: () => 'expected',
   });
-  // PID 42 is unlikely to exist in this test process, so it should be inactive
+  // PID 0 is rejected before the default probe reaches the host process table.
   assert.equal(active(record), false, 'identity matches but pid dead');
 
   // Both provided and match

--- a/dev/local/mobile-ios-build.ts
+++ b/dev/local/mobile-ios-build.ts
@@ -1,0 +1,1287 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createProjectHashAsync, DEFAULT_SOURCE_SKIPS, SourceSkips } from '@expo/fingerprint';
+
+// Compatibility dimensions hashed into the cache key. Any change must
+// invalidate the key so cached artifacts are not reused for an
+// incompatible environment.
+export type CompatibilityDimensions = {
+  nativeHash: string;
+  xcodeBuildVersion: string;
+  simulatorSdkVersion: string;
+  hostArch: string;
+  buildMode: 'debug-dev-client';
+};
+
+// Manifest persisted next to the cached `.app`. The schema is strict:
+// every field is required, types are exact, and `createdAt` must parse
+// as an ISO-8601 date. A manifest that fails any check is a miss.
+export type Manifest = {
+  key: string;
+  nativeHash: string;
+  xcodeBuildVersion: string;
+  simulatorSdkVersion: string;
+  hostArch: string;
+  buildMode: 'debug-dev-client';
+  bundleId: string;
+  artifactChecksum: string;
+  producerWorktree: string;
+  createdAt: string;
+};
+
+// Host environment captured at runtime. All fields are injectable for
+// tests; production reads them once per process.
+export type CacheEnvironment = {
+  home: string;
+  cacheRoot: string;
+  platform: NodeJS.Platform;
+  arch: string;
+  xcodeBuildVersion: string;
+  simulatorSdkVersion: string;
+  now: () => Date;
+};
+
+const BUNDLE_ID = 'com.kilocode.kiloapp';
+const BUILD_MODE = 'debug-dev-client';
+const ENTRY_BUNDLE_NAME = 'Kilo.app';
+const MANIFEST_NAME = 'manifest.json';
+// Producer wait budget: if a concurrent producer has not published
+// within this window, the wait is abandoned and the wait caller
+// throws. Multi-minute builds need a generous ceiling; abandoned-lock
+// recovery handles the producer-died case faster.
+const DEFAULT_WAIT_FOR_RESULT_MS = 10 * 60 * 1000;
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+const DEFAULT_RETENTION_MS = 14 * 24 * 60 * 60 * 1000;
+
+// Lock record persisted under each key's lock directory. Identity is
+// process-start identity (ps lstart) so PID reuse is detected. A
+// matching (pid, identity) is the source of truth for "still alive".
+export type LockRecord = {
+  key: string;
+  pid: number;
+  identity: string;
+  startedAt: string;
+};
+
+export type CacheLockDeps = {
+  env: CacheEnvironment;
+  sleep?: (ms: number) => Promise<void>;
+  // Override the liveness probe. Default: process.kill(pid, 0) truthy
+  // and ESRCH → false.
+  pidAlive?: (pid: number) => boolean;
+  // Override the process identity probe. Default: `ps -o lstart= -p <pid>`.
+  processIdentity?: (pid: number) => string | undefined;
+  // Override the active-lock decision. Default: pidAlive(pid) AND
+  // processIdentity(pid) === record.identity.
+  isLockActive?: (record: LockRecord) => boolean;
+  // Overrides for tests; production uses DEFAULT_WAIT_FOR_RESULT_MS.
+  waitForResultMs?: number;
+  pollIntervalMs?: number;
+};
+
+export type WithFingerprintLockArgs<T> = {
+  key: string;
+  lockRoot: string;
+  deps: CacheLockDeps;
+  producer: () => Promise<T>;
+  // Called after the lock completes (for both producer and waiter) to
+  // read the canonical published result from disk. The result file in
+  // the lock directory is only a completion signal; it never carries
+  // the serialized result value, so arbitrary in-memory values are
+  // not trusted across processes.
+  readResult: () => Promise<T>;
+};
+
+export type LookupCacheArgs = {
+  env: CacheEnvironment;
+  key: string;
+  onMiss: () => Promise<unknown>;
+};
+
+export type LookupCacheResult = {
+  manifest: Manifest;
+  appPath: string;
+};
+
+export type BuildInstallCommand = {
+  command: string;
+  args: string[];
+};
+
+export type PruneCacheArgs = {
+  env: CacheEnvironment;
+  retentionMs?: number;
+  // Used to determine whether a lock is still active. When the lock
+  // is active, the entry is protected from pruning. Default probes
+  // process identity.
+  isLockActive?: (record: LockRecord) => boolean;
+};
+
+export type PruneResult = {
+  removed: string[];
+  kept: string[];
+};
+
+export type CliArgs =
+  | { command: 'fingerprint' }
+  | { command: 'build'; udid: string }
+  | { command: 'prune' };
+
+// ── Fingerprint ──────────────────────────────────────────────────────
+
+// Build the option bag used to compute the native project hash. Only
+// the Expo `extra` section is skipped beyond the library defaults —
+// versions, schemes, bundle ID, plugins, assets, permissions, and
+// optional native config all remain in the hash.
+export function buildFingerprintOptions(): {
+  platforms: ['ios'];
+  sourceSkips: number;
+  silent: boolean;
+} {
+  return {
+    platforms: ['ios'],
+    sourceSkips: DEFAULT_SOURCE_SKIPS | SourceSkips.ExpoConfigExtraSection,
+    silent: true,
+  };
+}
+
+// Hash the normalized JSON form of the compatibility dimensions with
+// SHA-256. JSON key order is sorted so the key is stable across
+// implementations.
+export function buildCompatibilityKey(dimensions: CompatibilityDimensions): string {
+  const ordered = {
+    buildMode: dimensions.buildMode,
+    hostArch: dimensions.hostArch,
+    nativeHash: dimensions.nativeHash,
+    simulatorSdkVersion: dimensions.simulatorSdkVersion,
+    xcodeBuildVersion: dimensions.xcodeBuildVersion,
+  };
+  return createHash('sha256').update(JSON.stringify(ordered)).digest('hex');
+}
+
+// ── Cache root ───────────────────────────────────────────────────────
+
+export type ResolveCacheRootArgs = {
+  home: string;
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+};
+
+export function resolveCacheRoot(args: ResolveCacheRootArgs): string {
+  if (args.platform === 'darwin') {
+    return path.join(args.home, 'Library/Caches/Kilo/mobile-ios-builds');
+  }
+  const xdg = args.env.XDG_CACHE_HOME;
+  if (typeof xdg === 'string' && xdg.length > 0) {
+    return path.join(xdg, 'Kilo/mobile-ios-builds');
+  }
+  return path.join(args.home, '.cache/Kilo/mobile-ios-builds');
+}
+
+// ── Artifact checksum ───────────────────────────────────────────────
+
+// Deterministic directory hash. Walks the directory recursively,
+// reading each file in order, and feeds its relative path + contents
+// into SHA-256. Symlinks are rejected so the checksum cannot traverse
+// arbitrary host paths. Empty directories contribute their relative
+// path only.
+export async function computeArtifactChecksum(root: string): Promise<string> {
+  const hash = createHash('sha256');
+  const entries: WalkEntry[] = [];
+  walk(root, '', entries);
+  for (const entry of entries) {
+    hash.update(entry.relativePath);
+    hash.update('\0');
+    if (entry.isFile) {
+      await hashFileChunks(entry.absolutePath, hash);
+      hash.update('\0');
+    }
+  }
+  return hash.digest('hex');
+}
+
+type WalkEntry = {
+  relativePath: string;
+  absolutePath: string;
+  isFile: boolean;
+};
+
+function walk(root: string, prefix: string, out: WalkEntry[]): void {
+  const names = fs.readdirSync(root).sort();
+  for (const name of names) {
+    const abs = path.join(root, name);
+    const rel = prefix === '' ? name : `${prefix}/${name}`;
+    const lstat = fs.lstatSync(abs);
+    if (lstat.isSymbolicLink()) {
+      throw new Error(
+        `Symlink found at ${rel}; refusing to follow for deterministic artifact checksum`
+      );
+    }
+    if (lstat.isDirectory()) {
+      out.push({ relativePath: rel, absolutePath: abs, isFile: false });
+      walk(abs, rel, out);
+    } else if (lstat.isFile()) {
+      out.push({ relativePath: rel, absolutePath: abs, isFile: true });
+    }
+  }
+}
+
+const CHECKSUM_CHUNK_SIZE = 64 * 1024; // 64KB
+
+function hashFileChunks(filePath: string, hash: ReturnType<typeof createHash>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const fd = fs.openSync(filePath, 'r');
+    const buffer = Buffer.alloc(CHECKSUM_CHUNK_SIZE);
+    try {
+      let bytesRead: number;
+      do {
+        bytesRead = fs.readSync(fd, buffer, 0, CHECKSUM_CHUNK_SIZE, null);
+        if (bytesRead > 0) {
+          hash.update(bytesRead === CHECKSUM_CHUNK_SIZE ? buffer : buffer.slice(0, bytesRead));
+        }
+      } while (bytesRead > 0);
+      resolve();
+    } catch (error) {
+      reject(error);
+    } finally {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // ignore
+      }
+    }
+  });
+}
+
+// ── Manifest validation ──────────────────────────────────────────────
+
+// Strict manifest check. Returns true iff every field is present and
+// well-typed. Bundle ID, key, and build mode must match the
+// requested values. The producer worktree is recorded for audit but
+// not validated here — a successful rebuild from a different
+// worktree is a valid cache hit.
+export function isValidManifest(
+  obj: unknown,
+  expected: { key: string; bundleId: string }
+): obj is Manifest {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  if (typeof o.key !== 'string' || o.key !== expected.key) return false;
+  if (typeof o.nativeHash !== 'string' || o.nativeHash.length === 0) return false;
+  if (typeof o.xcodeBuildVersion !== 'string' || o.xcodeBuildVersion.length === 0) return false;
+  if (typeof o.simulatorSdkVersion !== 'string' || o.simulatorSdkVersion.length === 0) return false;
+  if (typeof o.hostArch !== 'string' || o.hostArch.length === 0) return false;
+  if (o.buildMode !== 'debug-dev-client') return false;
+  if (typeof o.bundleId !== 'string' || o.bundleId !== expected.bundleId) return false;
+  if (typeof o.artifactChecksum !== 'string' || !/^[0-9a-f]{64}$/.test(o.artifactChecksum))
+    return false;
+  if (typeof o.producerWorktree !== 'string' || o.producerWorktree.length === 0) return false;
+  if (typeof o.createdAt !== 'string') return false;
+  // Strict ISO-8601 validation: the value must parse and roundtrip.
+  const parsedDate = new Date(o.createdAt);
+  if (Number.isNaN(parsedDate.getTime()) || parsedDate.toISOString() !== o.createdAt) return false;
+  return true;
+}
+
+// ── Cache lookup ─────────────────────────────────────────────────────
+
+// Returns the cached entry iff the manifest is well-formed, the
+// bundle id matches, and the artifact checksum is current. On any
+// miss, calls `onMiss` for side-effects and returns `undefined`.
+// The onMiss return value is intentionally discarded — a miss is
+// always `undefined`.
+export async function lookupCache(args: LookupCacheArgs): Promise<LookupCacheResult | undefined> {
+  const entryDir = path.join(args.env.cacheRoot, 'entries', args.key);
+  const appPath = path.join(entryDir, ENTRY_BUNDLE_NAME);
+  const manifestPath = path.join(entryDir, MANIFEST_NAME);
+  if (!fs.existsSync(manifestPath) || !fs.existsSync(appPath)) {
+    await args.onMiss();
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    await args.onMiss();
+    return undefined;
+  }
+  if (!isValidManifest(parsed, { key: args.key, bundleId: BUNDLE_ID })) {
+    await args.onMiss();
+    return undefined;
+  }
+  const manifest = parsed as Manifest;
+  const actualChecksum = await computeArtifactChecksum(appPath);
+  if (actualChecksum !== manifest.artifactChecksum) {
+    await args.onMiss();
+    return undefined;
+  }
+  return { manifest, appPath };
+}
+
+// ── Producer lock ────────────────────────────────────────────────────
+
+// Run `producer` under a fingerprint-specific host lock. Exactly one
+// concurrent caller becomes the producer; the rest wait for the
+// published result. An abandoned lock (dead PID or identity mismatch)
+// is recovered and a new producer is started. Active locks bound the
+// wait; on timeout we fail closed and let the caller decide.
+export async function withFingerprintLock<T>(args: WithFingerprintLockArgs<T>): Promise<T> {
+  fs.mkdirSync(args.lockRoot, { recursive: true });
+  const lockDir = path.join(args.lockRoot, `${args.key}.lock`);
+  const lockFile = path.join(lockDir, 'lock.json');
+  const resultFile = path.join(lockDir, 'result.json');
+  const sleep = args.deps.sleep ?? defaultSleep;
+  const waitForResultMs = args.deps.waitForResultMs ?? DEFAULT_WAIT_FOR_RESULT_MS;
+  const pollIntervalMs = args.deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const isActive = args.deps.isLockActive ?? defaultIsLockActive(args.deps);
+  const identity =
+    args.deps.processIdentity?.(process.pid) ??
+    defaultProcessIdentity(process.pid) ??
+    `pid-${process.pid}`;
+
+  // Fast path: if a previous producer left a valid completion signal and the
+  // lock is not active, we may be able to return the canonical result without
+  // running a producer. If the marker is stale (no canonical result), fall
+  // through and acquire/rebuild so the key is not poisoned.
+  const prePublished = readLockResult(resultFile);
+  if (prePublished.kind === 'done') {
+    try {
+      return await args.readResult();
+    } catch {
+      // Stale done marker with no canonical result: fall through and rebuild.
+    }
+  }
+  if (tryAcquireLock(lockDir, lockFile, args.key, identity)) {
+    return runProducer(args, lockFile, resultFile);
+  }
+
+  // Phase 2: another caller might be producing. Check the lock first.
+  // Only a currently active lock's result markers are trustworthy; an
+  // inactive lock means the previous producer died, and any leftover
+  // done/error marker in result.json is stale and must be ignored.
+  const deadline = Date.now() + waitForResultMs;
+  while (Date.now() < deadline) {
+    await sleep(pollIntervalMs);
+    const record = readLockRecord(lockFile);
+    if (record && isActive(record)) {
+      // Active producer: wait for its completion/error signal.
+      const published = readLockResult(resultFile);
+      if (published.kind === 'done') return args.readResult();
+      if (published.kind === 'error') throw published.error;
+      continue;
+    }
+    // Lock inactive or missing. A stale `{done:true}` marker may still
+    // correspond to a valid canonical result; try to use it before
+    // rebuilding. If the result is missing or invalid, adopt/acquire and
+    // rebuild so the key is not poisoned by a stale marker.
+    const published = readLockResult(resultFile);
+    if (published.kind === 'done') {
+      try {
+        return await args.readResult();
+      } catch {
+        // Stale done marker with no canonical result: fall through and rebuild.
+      }
+    }
+    // Lock inactive but a record exists. Try to take over atomically. Passing
+    // the exact stale record we observed prevents stealing a freshly
+    // acquired active lock in the race window.
+    if (record && tryAdoptLock(args.lockRoot, lockDir, lockFile, args.key, record, identity)) {
+      return runProducer(args, lockFile, resultFile);
+    }
+    // No lock record: the previous producer already released the lock. A
+    // stale error marker is ignored, so acquire directly and rebuild.
+    if (!record && tryAcquireLock(lockDir, lockFile, args.key, identity)) {
+      return runProducer(args, lockFile, resultFile);
+    }
+  }
+  throw new Error(`Timed out waiting for active producer to publish result for key ${args.key}`);
+}
+
+async function runProducer<T>(
+  args: WithFingerprintLockArgs<T>,
+  lockFile: string,
+  resultFile: string
+): Promise<T> {
+  try {
+    // Clear any stale result marker before the producer starts so waiters
+    // cannot see an abandoned error/done marker from a previous run.
+    try {
+      fs.rmSync(resultFile, { force: true });
+    } catch {
+      // ignore
+    }
+    await args.producer();
+    // Publish only a completion signal; the actual result is read
+    // from the canonical on-disk source via readResult.
+    writeLockResult(resultFile, { done: true });
+  } catch (error) {
+    // Errors are serialized as message-only objects. Cross-process waiters
+    // receive only a generic `Error` with that message and must not depend
+    // on subclass, name, stack, or cause, which could carry secrets or
+    // implementation details across process boundaries.
+    writeLockResult(resultFile, {
+      error: { message: error instanceof Error ? error.message : String(error) },
+    });
+    throw error;
+  } finally {
+    // Remove only the lock record. The result file lives in the
+    // same directory and must survive release so waiters can read
+    // the published value. The next producer (or prune) cleans it
+    // up before publishing a new value.
+    try {
+      fs.rmSync(lockFile, { force: true });
+    } catch {
+      // ignore
+    }
+  }
+  return args.readResult();
+}
+
+export function defaultIsLockActive(deps: CacheLockDeps): (record: LockRecord) => boolean {
+  const pidAlive = deps.pidAlive ?? defaultPidAlive;
+  const processIdentity = deps.processIdentity ?? defaultProcessIdentity;
+  return record => {
+    const alive = pidAlive(record.pid);
+    const identity = processIdentity(record.pid);
+    return alive && identity !== undefined && record.identity === identity;
+  };
+}
+
+function tryAcquireLock(
+  lockDir: string,
+  lockFile: string,
+  key: string,
+  identity?: string
+): boolean {
+  // Ensure the lock directory exists. A leftover directory from a
+  // crashed producer (with no active lock.json) must not block a new
+  // producer from claiming the key.
+  try {
+    fs.mkdirSync(lockDir, { recursive: false });
+  } catch (error) {
+    if (!(error instanceof Error && 'code' in error && error.code === 'EEXIST')) {
+      throw error;
+    }
+  }
+  // Atomically claim the lock file. `wx` succeeds only if no other
+  // process currently holds the lock. On EEXIST we back off without
+  // destroying the directory, because another caller may have just
+  // created an active lock. The directory will be cleaned up by prune
+  // or the next successful acquisition.
+  try {
+    const record: LockRecord = createLockRecord(key, identity);
+    fs.writeFileSync(lockFile, JSON.stringify(record), { flag: 'wx' });
+    return true;
+  } catch (error) {
+    // Do NOT remove the lock directory here. Another caller may have just
+    // created an active lock, and destroying it would break waiters. The
+    // directory will be cleaned up by prune or the next successful acquisition.
+    if (error instanceof Error && 'code' in error && error.code === 'EEXIST') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function tryAdoptLock(
+  lockRoot: string,
+  lockDir: string,
+  lockFile: string,
+  key: string,
+  staleRecord: LockRecord,
+  identity?: string
+): boolean {
+  // Verify the canonical lock file still matches the exact stale record
+  // we observed before attempting to steal. If another caller has
+  // already replaced it with a fresh active lock, we must back off.
+  const current = readLockRecord(lockFile);
+  if (!current || !lockRecordsEqual(current, staleRecord)) {
+    return false;
+  }
+  // Atomic single-winner takeover: rename the stale lock file to a unique
+  // quarantine path. Only one caller wins the rename; losers see ENOENT and
+  // back off. The winner then writes a fresh lock record with `wx`.
+  const quarantine = path.join(
+    lockRoot,
+    `${key}.quarantine.${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  try {
+    fs.renameSync(lockFile, quarantine);
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+  // Winner: write fresh lock record
+  try {
+    const record: LockRecord = createLockRecord(key, identity);
+    fs.writeFileSync(lockFile, JSON.stringify(record), { flag: 'wx' });
+  } catch (error) {
+    // Another winner already wrote the lockFile; restore quarantine
+    try {
+      fs.renameSync(quarantine, lockFile);
+    } catch {
+      // ignore
+    }
+    if (error instanceof Error && 'code' in error && error.code === 'EEXIST') {
+      return false;
+    }
+    throw error;
+  }
+  // Clean up quarantine
+  try {
+    fs.rmSync(quarantine, { force: true });
+  } catch {
+    // ignore
+  }
+  return true;
+}
+
+function lockRecordsEqual(a: LockRecord, b: LockRecord): boolean {
+  return (
+    a.key === b.key && a.pid === b.pid && a.identity === b.identity && a.startedAt === b.startedAt
+  );
+}
+
+function createLockRecord(key: string, identity?: string): LockRecord {
+  return {
+    key,
+    pid: process.pid,
+    identity: identity ?? defaultProcessIdentity(process.pid) ?? `pid-${process.pid}`,
+    startedAt: new Date().toISOString(),
+  };
+}
+
+function readLockRecord(lockFile: string): LockRecord | undefined {
+  try {
+    const raw = fs.readFileSync(lockFile, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    const o = parsed as Record<string, unknown>;
+    if (
+      typeof o.key !== 'string' ||
+      typeof o.pid !== 'number' ||
+      typeof o.identity !== 'string' ||
+      typeof o.startedAt !== 'string'
+    ) {
+      return undefined;
+    }
+    return { key: o.key, pid: o.pid, identity: o.identity, startedAt: o.startedAt };
+  } catch {
+    return undefined;
+  }
+}
+
+type LockResult = { kind: 'pending' } | { kind: 'done' } | { kind: 'error'; error: Error };
+
+// Read the lock completion signal. Errors are deliberately
+// message-only generic `Error` instances: waiters MUST NOT depend on
+// error subclass, name, stack, or any other fields that could carry
+// secrets or implementation details across process boundaries.
+function readLockResult(resultFile: string): LockResult {
+  try {
+    const raw = fs.readFileSync(resultFile, 'utf8');
+    const parsed = JSON.parse(raw) as { done?: unknown; error?: { message: string } };
+    if (parsed.error && typeof parsed.error.message === 'string') {
+      return { kind: 'error', error: new Error(parsed.error.message) };
+    }
+    if (parsed.done === true) {
+      return { kind: 'done' };
+    }
+    return { kind: 'pending' };
+  } catch {
+    return { kind: 'pending' };
+  }
+}
+
+function writeLockResult(
+  resultFile: string,
+  result: { done: true } | { error: { message: string } }
+): void {
+  fs.writeFileSync(resultFile, JSON.stringify(result), { flag: 'w' });
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function defaultPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error) {
+      if (error.code === 'EPERM') return true;
+      if (error.code === 'ESRCH') return false;
+    }
+    return false;
+  }
+}
+
+function defaultProcessIdentity(pid: number): string | undefined {
+  if (!Number.isInteger(pid) || pid <= 0) return undefined;
+  try {
+    const result = execFileSync('ps', ['-o', 'lstart=', '-p', String(pid)], {
+      encoding: 'utf8',
+    });
+    const identity = result.replace(/\s+/g, ' ').trim();
+    return identity || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ── Simulator claim validation ───────────────────────────────────────
+
+// Read-only validation of a claim recorded by the simulator
+// wrapper. Accepts the caller's current worktree as the exclusive
+// owner; any other recorded worktree (including legacy claims without
+// `status`) is rejected.
+export function validateSimulatorClaim(
+  udid: string,
+  worktreeRoot: string,
+  claimRoot: string
+): void {
+  const claimPath = path.join(claimRoot, `${udid}.json`);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(claimPath, 'utf8');
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      throw new Error(`Simulator ${udid} is not claimed by this worktree`, { cause: error });
+    }
+    throw error;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Simulator ${udid} claim is corrupt`, { cause: error });
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error(`Simulator ${udid} claim is corrupt`);
+  }
+  const o = parsed as Record<string, unknown>;
+  if (typeof o.worktreeRoot !== 'string' || o.worktreeRoot.length === 0) {
+    throw new Error(`Simulator ${udid} claim is corrupt`);
+  }
+  if (o.worktreeRoot !== worktreeRoot) {
+    throw new Error(`Simulator ${udid} is claimed by ${o.worktreeRoot}`);
+  }
+  // For the build cache we require a current-format ready claim. A
+  // preparing claim (same worktree or not) cannot be used to install
+  // an app; legacy claims (no status) are also rejected — the E2E
+  // simulator wrapper must reclaim/upgrade them first.
+  if (typeof o.status !== 'string' || o.status !== 'ready') {
+    throw new Error(`Simulator ${udid} is not ready for build (status=${String(o.status)})`);
+  }
+  if (typeof o.claimId !== 'string' || o.claimId.length === 0) {
+    throw new Error(`Simulator ${udid} claim is corrupt`);
+  }
+  if (typeof o.claimedAt !== 'string' || Number.isNaN(Date.parse(o.claimedAt))) {
+    throw new Error(`Simulator ${udid} claim is corrupt`);
+  }
+}
+
+// ── Install command ──────────────────────────────────────────────────
+
+export function buildInstallCommand(udid: string, appPath: string): BuildInstallCommand {
+  return {
+    command: 'xcrun',
+    args: ['simctl', 'install', udid, appPath],
+  };
+}
+
+// ── Pruning ──────────────────────────────────────────────────────────
+
+export async function pruneCache(args: PruneCacheArgs): Promise<PruneResult> {
+  const entriesRoot = path.join(args.env.cacheRoot, 'entries');
+  const locksRoot = path.join(args.env.cacheRoot, 'locks');
+  const retentionMs = args.retentionMs ?? DEFAULT_RETENTION_MS;
+  const isActive = args.isLockActive ?? defaultIsLockActive({ env: args.env });
+  const removed: string[] = [];
+  const kept: string[] = [];
+  if (!fs.existsSync(entriesRoot)) return { removed, kept };
+  const now = args.env.now().getTime();
+  for (const key of fs.readdirSync(entriesRoot)) {
+    const manifestPath = path.join(entriesRoot, key, MANIFEST_NAME);
+    if (!fs.existsSync(manifestPath)) {
+      kept.push(key);
+      continue;
+    }
+    // Active locks (those with a real lock record) protect entries
+    // from pruning. A missing lock record means the entry is not
+    // currently being produced and is eligible for age-based pruning.
+    const lockDir = path.join(locksRoot, `${key}.lock`);
+    const lockFile = path.join(lockDir, 'lock.json');
+    const lockRecord = readLockRecord(lockFile);
+    if (lockRecord && isActive(lockRecord)) {
+      kept.push(key);
+      continue;
+    }
+    let manifest: unknown;
+    try {
+      manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    } catch {
+      removeEntry(entriesRoot, key);
+      removeLockArtifacts(lockDir);
+      removed.push(key);
+      continue;
+    }
+    const createdAt = (manifest as { createdAt?: unknown }).createdAt;
+    if (typeof createdAt !== 'string' || Number.isNaN(Date.parse(createdAt))) {
+      removeEntry(entriesRoot, key);
+      removeLockArtifacts(lockDir);
+      removed.push(key);
+      continue;
+    }
+    const age = now - Date.parse(createdAt);
+    if (age >= retentionMs) {
+      removeEntry(entriesRoot, key);
+      removeLockArtifacts(lockDir);
+      removed.push(key);
+    } else {
+      kept.push(key);
+    }
+  }
+  // Cleanup orphan lock/quarantine directories that have no corresponding
+  // entry and are not active. Active locks are always protected.
+  if (fs.existsSync(locksRoot)) {
+    for (const name of fs.readdirSync(locksRoot)) {
+      const full = path.join(locksRoot, name);
+      const stat = fs.statSync(full);
+      if (!stat.isDirectory()) continue;
+      // Only remove directories that look like our lock or quarantine artifacts.
+      if (!/\.(lock|quarantine\..*)$/.test(name)) continue;
+      const key = name.replace(/\.(lock|quarantine\..*)$/, '');
+      if (fs.existsSync(path.join(entriesRoot, key))) continue;
+      const lockFile = path.join(full, 'lock.json');
+      const lockRecord = readLockRecord(lockFile);
+      if (lockRecord && isActive(lockRecord)) continue;
+      removeLockArtifacts(full);
+    }
+  }
+  return { removed, kept };
+}
+
+function removeEntry(entriesRoot: string, key: string): void {
+  fs.rmSync(path.join(entriesRoot, key), { recursive: true, force: true });
+}
+
+function removeLockArtifacts(lockDir: string): void {
+  try {
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────
+
+export function parseCliArgs(argv: readonly string[]): CliArgs {
+  const [command, ...rest] = argv;
+  if (command === 'fingerprint') {
+    if (rest.length !== 0) throw new Error('Usage: pnpm dev:mobile:ios fingerprint');
+    return { command: 'fingerprint' };
+  }
+  if (command === 'build') {
+    if (rest.length !== 1) throw new Error('Usage: pnpm dev:mobile:ios build <udid>');
+    return { command: 'build', udid: rest[0] };
+  }
+  if (command === 'prune') {
+    if (rest.length !== 0) throw new Error('Usage: pnpm dev:mobile:ios prune');
+    return { command: 'prune' };
+  }
+  throw new Error('Usage: pnpm dev:mobile:ios [fingerprint|build <udid>|prune]');
+}
+
+// ── Xcode workspace and build command ───────────────────────────────
+
+// Check that the generated native project exists. Expo generates
+// `apps/mobile/ios/Kilo.xcworkspace` via `npx expo prebuild --platform
+// ios` (or as a side effect of `expo run:ios`). We do NOT run prebuild
+// ourselves — the caller is expected to have done so. A missing
+// workspace is a clear, actionable error.
+export function validateXcodeWorkspace(mobileRoot: string): void {
+  const workspace = path.join(mobileRoot, 'ios', 'Kilo.xcworkspace');
+  if (!fs.existsSync(workspace)) {
+    throw new Error(
+      `Native iOS project is missing at ${workspace}. Run \`npx expo prebuild --platform ios\` in apps/mobile before invoking this command.`
+    );
+  }
+}
+
+// Build the exact xcodebuild invocation. A dedicated derivedDataPath
+// under our staging directory is the ONLY source of the produced
+// `.app` — we never scan global DerivedData. The command targets
+// Debug / iphonesimulator and pins the destination to the requested
+// UDID.
+export function buildXcodeBuildCommand(args: {
+  mobileRoot: string;
+  udid: string;
+  derivedDataPath: string;
+}): BuildInstallCommand {
+  return {
+    command: 'xcodebuild',
+    args: [
+      '-workspace',
+      path.join(args.mobileRoot, 'ios', 'Kilo.xcworkspace'),
+      '-scheme',
+      'Kilo',
+      '-configuration',
+      'Debug',
+      '-sdk',
+      'iphonesimulator',
+      '-destination',
+      `id=${args.udid}`,
+      '-derivedDataPath',
+      args.derivedDataPath,
+      'build',
+    ],
+  };
+}
+
+// Locate the produced `.app` at the canonical xcodebuild path. Throws
+// if missing — the producer must not silently fall back to a
+// different artifact.
+export function locateProducedApp(derivedDataPath: string): string {
+  const app = path.join(derivedDataPath, 'Build', 'Products', 'Debug-iphonesimulator', 'Kilo.app');
+  if (!fs.existsSync(app)) {
+    throw new Error(
+      `Produced app not found at ${app}. xcodebuild did not produce the expected artifact.`
+    );
+  }
+  return app;
+}
+
+// ── Build flow types ────────────────────────────────────────────────
+
+// All side-effecting boundaries the build flow needs. Tests inject
+// stubs; production wires real implementations.
+export type BuildDeps = {
+  env: CacheEnvironment;
+  worktreeRoot: string;
+  claimRoot: string;
+  mobileRoot: string;
+  fingerprint: (
+    root: string,
+    options: ReturnType<typeof buildFingerprintOptions>
+  ) => Promise<string>;
+  build: (args: {
+    stagingDir: string;
+    derivedDataPath: string;
+    udid: string;
+    mobileRoot: string;
+  }) => Promise<void>;
+  readInfoPlist: (appPath: string, key: string) => string | undefined;
+  install: (udid: string, appPath: string) => void;
+  copyDir: (src: string, dest: string) => void;
+  mkdtemp: (prefix: string) => string;
+  validateClaim: (udid: string, worktreeRoot: string, claimRoot: string) => void;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+export type RunFingerprintDeps = {
+  env: CacheEnvironment;
+  mobileRoot: string;
+  fingerprint: (
+    root: string,
+    options: ReturnType<typeof buildFingerprintOptions>
+  ) => Promise<string>;
+  write: (chunk: string) => void;
+};
+
+export type RunPruneDeps = {
+  env: CacheEnvironment;
+  isLockActive?: (record: LockRecord) => boolean;
+  write: (chunk: string) => void;
+};
+
+// ── Publish flow ────────────────────────────────────────────────────
+
+// Build, verify, and atomically publish a cache entry. Called as the
+// sole producer inside the fingerprint lock. On entry, the cache is
+// re-checked — if a concurrent caller already published a valid
+// entry, we return it without rebuilding (this also covers the
+// "abandoned lock recovery must not overwrite a valid entry"
+// requirement).
+export async function publishCacheEntry(args: {
+  env: CacheEnvironment;
+  key: string;
+  compatibility: CompatibilityDimensions;
+  worktreeRoot: string;
+  udid: string;
+  deps: BuildDeps;
+}): Promise<LookupCacheResult> {
+  validateKey(args.key);
+  // Re-check: another caller may have published between our
+  // pre-lock lookup and acquiring the lock.
+  const existing = await lookupCache({
+    env: args.env,
+    key: args.key,
+    onMiss: async () => undefined,
+  });
+  if (existing) return existing;
+
+  const stagingRoot = path.join(args.env.cacheRoot, 'staging');
+  fs.mkdirSync(stagingRoot, { recursive: true });
+  const staging = args.deps.mkdtemp(path.join(stagingRoot, `kilo-mobile-ios-build-${args.key}-`));
+  const derivedDataPath = path.join(staging, 'DerivedData');
+  fs.mkdirSync(derivedDataPath, { recursive: true });
+  try {
+    await args.deps.build({
+      stagingDir: staging,
+      derivedDataPath,
+      udid: args.udid,
+      mobileRoot: args.deps.mobileRoot,
+    });
+    const builtApp = locateProducedApp(derivedDataPath);
+    const stagingApp = path.join(staging, ENTRY_BUNDLE_NAME);
+    args.deps.copyDir(builtApp, stagingApp);
+    const bundleId = args.deps.readInfoPlist(stagingApp, 'CFBundleIdentifier');
+    if (bundleId !== BUNDLE_ID) {
+      throw new Error(
+        `Produced app has unexpected bundle id "${bundleId}" (expected ${BUNDLE_ID})`
+      );
+    }
+    const artifactChecksum = await computeArtifactChecksum(stagingApp);
+    const manifest: Manifest = {
+      key: args.key,
+      nativeHash: args.compatibility.nativeHash,
+      xcodeBuildVersion: args.compatibility.xcodeBuildVersion,
+      simulatorSdkVersion: args.compatibility.simulatorSdkVersion,
+      hostArch: args.compatibility.hostArch,
+      buildMode: BUILD_MODE,
+      bundleId: BUNDLE_ID,
+      artifactChecksum,
+      producerWorktree: args.worktreeRoot,
+      createdAt: args.env.now().toISOString(),
+    };
+    fs.writeFileSync(path.join(staging, MANIFEST_NAME), JSON.stringify(manifest), {
+      flag: 'w',
+    });
+    const finalDir = path.join(args.env.cacheRoot, 'entries', args.key);
+    fs.mkdirSync(path.dirname(finalDir), { recursive: true });
+    try {
+      fs.renameSync(staging, finalDir);
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        throw new Error(`Failed to publish cache entry: staging directory vanished`);
+      }
+      // Defensive fallback: if another producer won the race, verify the
+      // existing entry rather than overwriting. This only applies to
+      // expected rename-over-directory races; other failures propagate.
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        (error.code === 'EEXIST' || error.code === 'ENOTEMPTY')
+      ) {
+        const concurrent = await lookupCache({
+          env: args.env,
+          key: args.key,
+          onMiss: async () => undefined,
+        });
+        if (concurrent) return concurrent;
+      }
+      throw error;
+    }
+    // Re-validate the on-disk entry. This is the canonical source of
+    // truth for both the producer and any waiters.
+    const verified = await lookupCache({
+      env: args.env,
+      key: args.key,
+      onMiss: async () => undefined,
+    });
+    if (!verified) {
+      throw new Error(`Cache entry failed post-publish validation for key ${args.key}`);
+    }
+    return verified;
+  } finally {
+    // If staging still exists (publish failed), clean it up. Use
+    // rmSync with force to swallow EBUSY etc.
+    try {
+      fs.rmSync(staging, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+}
+
+// ── Build orchestration ─────────────────────────────────────────────
+
+// Run the full `build <udid>` flow. On a cache hit, install without
+// building. On a miss, enter the fingerprint lock; the sole producer
+// publishes a validated entry, and all callers (including waiters)
+// re-validate the on-disk entry before installing. This guarantees
+// the installed `.app` is always checksum-verified and manifest-
+// signed, never an unvalidated in-memory producer value.
+// Defense-in-depth: the cache key is the SHA-256 output of
+// buildCompatibilityKey, so it is always 64 hex characters. Reject any
+// other shape before deriving filesystem paths, guarding against accidental
+// caller mistakes just as much as malicious input.
+function validateKey(key: string): void {
+  if (!/^[0-9a-f]{64}$/.test(key)) {
+    throw new Error(`Invalid cache key: expected 64 hex characters, got ${key}`);
+  }
+}
+
+export async function runBuild(udid: string, deps: BuildDeps): Promise<void> {
+  // 1. Validate exclusive claim for the current worktree.
+  deps.validateClaim(udid, deps.worktreeRoot, deps.claimRoot);
+
+  // 2. Compute compatibility dimensions and key.
+  const nativeHash = await deps.fingerprint(deps.mobileRoot, buildFingerprintOptions());
+  const compatibility: CompatibilityDimensions = {
+    nativeHash,
+    xcodeBuildVersion: deps.env.xcodeBuildVersion,
+    simulatorSdkVersion: deps.env.simulatorSdkVersion,
+    hostArch: deps.env.arch,
+    buildMode: BUILD_MODE,
+  };
+  const key = buildCompatibilityKey(compatibility);
+  validateKey(key);
+
+  // 3. Pre-lock lookup. A hit here avoids the lock entirely.
+  const preHit = await lookupCache({
+    env: deps.env,
+    key,
+    onMiss: async () => undefined,
+  });
+  if (preHit) {
+    deps.install(udid, preHit.appPath);
+    return;
+  }
+
+  // 4. Miss: enter the fingerprint lock. publishCacheEntry
+  // re-checks the cache (covers abandoned-lock + valid-entry) and
+  // publishes a validated entry for the sole producer.
+  const lockRoot = path.join(deps.env.cacheRoot, 'locks');
+  const lockDeps: CacheLockDeps = {
+    env: deps.env,
+    sleep: deps.sleep,
+  };
+  await withFingerprintLock<LookupCacheResult>({
+    key,
+    lockRoot,
+    deps: lockDeps,
+    producer: () =>
+      publishCacheEntry({
+        env: deps.env,
+        key,
+        compatibility,
+        worktreeRoot: deps.worktreeRoot,
+        udid,
+        deps,
+      }),
+    readResult: async () =>
+      lookupCache({
+        env: deps.env,
+        key,
+        onMiss: async () => undefined,
+      }).then(r => {
+        if (!r) {
+          throw new Error(
+            `Cache entry missing after publish for key ${key}; refusing to install unvalidated artifact`
+          );
+        }
+        return r;
+      }),
+  });
+
+  // 5. Re-validate from disk (requirement 7). Both the producer
+  // (who built and published) and the waiter (who observed the
+  // result file) must observe the same validated on-disk entry.
+  // readResult already performs this, and we repeat it here so
+  // runBuild owns the final install decision.
+  const revalidated = await lookupCache({
+    env: deps.env,
+    key,
+    onMiss: async () => undefined,
+  });
+  if (!revalidated) {
+    throw new Error(
+      `Cache entry missing after publish for key ${key}; refusing to install unvalidated artifact`
+    );
+  }
+  deps.install(udid, revalidated.appPath);
+}
+
+// ── Fingerprint orchestration ───────────────────────────────────────
+
+// Print sanitized compatibility dimensions and the cache key. No
+// environment values, no source lists, no secrets. Uses the injected
+// `fingerprint` function (which in production calls
+// `@expo/fingerprint.createProjectHashAsync` directly — no child
+// process indirection).
+export async function runFingerprint(deps: RunFingerprintDeps): Promise<void> {
+  const nativeHash = await deps.fingerprint(deps.mobileRoot, buildFingerprintOptions());
+  const compatibility: CompatibilityDimensions = {
+    nativeHash,
+    xcodeBuildVersion: deps.env.xcodeBuildVersion,
+    simulatorSdkVersion: deps.env.simulatorSdkVersion,
+    hostArch: deps.env.arch,
+    buildMode: BUILD_MODE,
+  };
+  const sanitized = {
+    key: buildCompatibilityKey(compatibility),
+    nativeHash,
+    xcodeBuildVersion: deps.env.xcodeBuildVersion,
+    simulatorSdkVersion: deps.env.simulatorSdkVersion,
+    hostArch: deps.env.arch,
+    buildMode: BUILD_MODE,
+    bundleId: BUNDLE_ID,
+  };
+  deps.write(`${JSON.stringify(sanitized, null, 2)}\n`);
+}
+
+// ── Prune orchestration ─────────────────────────────────────────────
+
+export async function runPrune(deps: RunPruneDeps): Promise<void> {
+  const result = await pruneCache({ env: deps.env, isLockActive: deps.isLockActive });
+  deps.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+// ── Main entry point ─────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const parsed = parseCliArgs(process.argv.slice(2));
+  const env = productionEnvironment();
+  if (parsed.command === 'fingerprint') {
+    await runFingerprint({
+      env,
+      mobileRoot: mobileRoot(),
+      fingerprint: async (root, options) =>
+        createProjectHashAsync(root, options as Parameters<typeof createProjectHashAsync>[1]),
+      write: (chunk: string) => process.stdout.write(chunk),
+    });
+    return;
+  }
+  if (parsed.command === 'prune') {
+    await runPrune({
+      env,
+      write: (chunk: string) => process.stdout.write(chunk),
+    });
+    return;
+  }
+  if (parsed.command === 'build') {
+    const worktreeRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+    }).trim();
+    const claimRoot = path.join(os.tmpdir(), 'kilo-mobile-simulator-claims');
+    await runBuild(parsed.udid, {
+      env,
+      worktreeRoot,
+      claimRoot,
+      mobileRoot: mobileRoot(),
+      fingerprint: async (root, options) =>
+        createProjectHashAsync(root, options as Parameters<typeof createProjectHashAsync>[1]),
+      build: productionBuilder,
+      readInfoPlist: productionReadInfoPlist,
+      install: productionInstall,
+      copyDir: productionCopyDir,
+      mkdtemp: (prefix: string) => {
+        fs.mkdirSync(path.dirname(prefix), { recursive: true });
+        return fs.mkdtempSync(prefix);
+      },
+      validateClaim: (udid: string, worktreeRoot: string, claimRoot: string) =>
+        validateSimulatorClaim(udid, worktreeRoot, claimRoot),
+    });
+    process.stdout.write(`Installed ${parsed.udid}\n`);
+    return;
+  }
+  throw new Error('Usage: pnpm dev:mobile:ios [fingerprint|build <udid>|prune]');
+}
+
+// Production builder: validates the Xcode workspace, then invokes
+// xcodebuild with a dedicated derivedDataPath under the staging
+// directory. The staging directory is created by `runBuild` and
+// passed in; we do not prebuild or mutate the global workspace.
+async function productionBuilder(args: {
+  stagingDir: string;
+  derivedDataPath: string;
+  udid: string;
+  mobileRoot: string;
+}): Promise<void> {
+  validateXcodeWorkspace(args.mobileRoot);
+  const cmd = buildXcodeBuildCommand({
+    mobileRoot: args.mobileRoot,
+    udid: args.udid,
+    derivedDataPath: args.derivedDataPath,
+  });
+  execFileSync(cmd.command, cmd.args, { stdio: 'inherit' });
+  locateProducedApp(args.derivedDataPath);
+}
+
+function productionReadInfoPlist(appPath: string, key: string): string | undefined {
+  const result = execFileSync(
+    'plutil',
+    ['-extract', key, 'raw', '-o', '-', path.join(appPath, 'Info.plist')],
+    {
+      encoding: 'utf8',
+    }
+  );
+  const value = result.trim();
+  return value.length === 0 ? undefined : value;
+}
+
+function productionInstall(udid: string, appPath: string): void {
+  const cmd = buildInstallCommand(udid, appPath);
+  execFileSync(cmd.command, cmd.args, { stdio: 'inherit' });
+}
+
+function productionCopyDir(src: string, dest: string): void {
+  fs.cpSync(src, dest, { recursive: true });
+}
+
+function productionEnvironment(): CacheEnvironment {
+  const home = os.homedir();
+  return {
+    home,
+    cacheRoot: resolveCacheRoot({ home, platform: process.platform, env: process.env }),
+    platform: process.platform,
+    arch: process.arch,
+    xcodeBuildVersion: queryXcodeBuildVersion(),
+    simulatorSdkVersion: querySimulatorSdkVersion(),
+    now: () => new Date(),
+  };
+}
+
+function queryXcodeBuildVersion(): string {
+  const raw = execFileSync('xcodebuild', ['-version'], { encoding: 'utf8' });
+  const match = raw.match(/Build version (\S+)/);
+  if (!match) throw new Error('Unable to determine Xcode build version');
+  return match[1];
+}
+
+function querySimulatorSdkVersion(): string {
+  const raw = execFileSync('xcrun', ['--sdk', 'iphonesimulator', '--show-sdk-version'], {
+    encoding: 'utf8',
+  });
+  return raw.trim();
+}
+
+// Resolve the mobile project root from this module's location, never from
+// process.cwd(). The module lives at dev/local/mobile-ios-build.ts, so two
+// directories up is the repo root, then apps/mobile.
+export function mobileRoot(): string {
+  return path.resolve(import.meta.dirname, '..', '..', 'apps', 'mobile');
+}
+
+export function resolveMobileRoot(repoRoot: string): string {
+  return path.resolve(repoRoot, 'apps', 'mobile');
+}
+
+const isMain =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
+if (isMain) {
+  main().catch(error => {
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+    process.exit(1);
+  });
+}

--- a/dev/local/mobile-ios-build.ts
+++ b/dev/local/mobile-ios-build.ts
@@ -758,11 +758,14 @@ export async function pruneCache(args: PruneCacheArgs): Promise<PruneResult> {
     for (const name of fs.readdirSync(locksRoot)) {
       const full = path.join(locksRoot, name);
       const stat = fs.statSync(full);
-      if (!stat.isDirectory()) continue;
-      // Only remove directories that look like our lock or quarantine artifacts.
+      // Locks are directories; tryAdoptLock quarantines lock.json as a file.
       if (!/\.(lock|quarantine\..*)$/.test(name)) continue;
       const key = name.replace(/\.(lock|quarantine\..*)$/, '');
       if (fs.existsSync(path.join(entriesRoot, key))) continue;
+      if (!stat.isDirectory()) {
+        removeLockArtifacts(full);
+        continue;
+      }
       const lockFile = path.join(full, 'lock.json');
       const lockRecord = readLockRecord(lockFile);
       if (lockRecord && isActive(lockRecord)) continue;

--- a/dev/local/mobile-ios-build.ts
+++ b/dev/local/mobile-ios-build.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 
 import { createProjectHashAsync, DEFAULT_SOURCE_SKIPS, SourceSkips } from '@expo/fingerprint';
 
+import { withNativeBuildSemaphore } from './mobile-native-build';
+
 // Compatibility dimensions hashed into the cache key. Any change must
 // invalidate the key so cached artifacts are not reused for an
 // incompatible environment.
@@ -883,6 +885,7 @@ export type BuildDeps = {
   install: (udid: string, appPath: string) => void;
   copyDir: (src: string, dest: string) => void;
   mkdtemp: (prefix: string) => string;
+  withNativeBuildSlot: <T>(run: () => Promise<T>) => Promise<T>;
   validateClaim: (udid: string, worktreeRoot: string, claimRoot: string) => void;
   sleep?: (ms: number) => Promise<void>;
 };
@@ -1071,14 +1074,16 @@ export async function runBuild(udid: string, deps: BuildDeps): Promise<void> {
     lockRoot,
     deps: lockDeps,
     producer: () =>
-      publishCacheEntry({
-        env: deps.env,
-        key,
-        compatibility,
-        worktreeRoot: deps.worktreeRoot,
-        udid,
-        deps,
-      }),
+      deps.withNativeBuildSlot(() =>
+        publishCacheEntry({
+          env: deps.env,
+          key,
+          compatibility,
+          worktreeRoot: deps.worktreeRoot,
+          udid,
+          deps,
+        })
+      ),
     readResult: async () =>
       lookupCache({
         env: deps.env,
@@ -1189,6 +1194,11 @@ async function main(): Promise<void> {
         fs.mkdirSync(path.dirname(prefix), { recursive: true });
         return fs.mkdtempSync(prefix);
       },
+      withNativeBuildSlot: run =>
+        withNativeBuildSemaphore({
+          root: path.join(env.cacheRoot, '..'),
+          run,
+        }),
       validateClaim: (udid: string, worktreeRoot: string, claimRoot: string) =>
         validateSimulatorClaim(udid, worktreeRoot, claimRoot),
     });

--- a/dev/local/mobile-native-build.test.ts
+++ b/dev/local/mobile-native-build.test.ts
@@ -49,10 +49,9 @@ test('serializes native producers across different platform builds', async () =>
 
 test('recovers an abandoned native producer lock', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-native-build-'));
-  const lockDir = path.join(root, 'native-build.lock');
-  fs.mkdirSync(lockDir, { recursive: true });
+  const lockPath = path.join(root, 'native-build.lock');
   fs.writeFileSync(
-    path.join(lockDir, 'owner.json'),
+    lockPath,
     JSON.stringify({
       pid: 99_999,
       identity: 'dead',
@@ -73,21 +72,49 @@ test('recovers an abandoned native producer lock', async () => {
   });
 
   assert.equal(ran, true);
-  assert.equal(fs.existsSync(lockDir), false);
+  assert.equal(fs.existsSync(lockPath), false);
+});
+
+test('recovers an abandoned legacy directory-shaped native producer lock', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-native-build-'));
+  const lockPath = path.join(root, 'native-build.lock');
+  fs.mkdirSync(lockPath);
+  fs.writeFileSync(
+    path.join(lockPath, 'owner.json'),
+    JSON.stringify({
+      pid: 99_999,
+      identity: 'dead',
+      token: 'legacy-stale',
+      startedAt: new Date().toISOString(),
+    })
+  );
+
+  let ran = false;
+  await withNativeBuildSemaphore({
+    root,
+    pidAlive: () => false,
+    processIdentity: () => undefined,
+    pollIntervalMs: 1,
+    run: async () => {
+      ran = true;
+    },
+  });
+
+  assert.equal(ran, true);
+  assert.equal(fs.existsSync(lockPath), false);
 });
 
 test('does not release a native lock replaced by another owner', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-native-build-'));
-  const lockDir = path.join(root, 'native-build.lock');
+  const lockPath = path.join(root, 'native-build.lock');
 
   await assert.rejects(
     withNativeBuildSemaphore({
       root,
       run: async () => {
-        fs.rmSync(lockDir, { recursive: true, force: true });
-        fs.mkdirSync(lockDir, { recursive: true });
+        fs.rmSync(lockPath, { force: true });
         fs.writeFileSync(
-          path.join(lockDir, 'owner.json'),
+          lockPath,
           JSON.stringify({
             pid: process.pid,
             identity: 'replacement',
@@ -101,8 +128,69 @@ test('does not release a native lock replaced by another owner', async () => {
     /producer failed/
   );
 
-  assert.equal(
-    JSON.parse(fs.readFileSync(path.join(lockDir, 'owner.json'), 'utf8')).token,
-    'replacement'
+  assert.equal(JSON.parse(fs.readFileSync(lockPath, 'utf8')).token, 'replacement');
+});
+
+test('publishes owner metadata before exposing the canonical native lock', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-native-build-'));
+  const originalLinkSync = fs.linkSync;
+  let second: Promise<void> | undefined;
+  let active = 0;
+  let maxActive = 0;
+  let intercepted = false;
+
+  fs.linkSync = ((existingPath, newPath) => {
+    if (!intercepted && path.basename(String(newPath)) === 'native-build.lock') {
+      intercepted = true;
+      second = withNativeBuildSemaphore({
+        root,
+        pollIntervalMs: 1,
+        run: async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise(resolve => setTimeout(resolve, 10));
+          active -= 1;
+        },
+      });
+    }
+    return originalLinkSync(existingPath, newPath);
+  }) as typeof fs.linkSync;
+
+  try {
+    await withNativeBuildSemaphore({
+      root,
+      pollIntervalMs: 1,
+      run: async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise(resolve => setTimeout(resolve, 10));
+        active -= 1;
+      },
+    });
+    await second;
+    assert.equal(maxActive, 1);
+  } finally {
+    fs.linkSync = originalLinkSync;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('enforces the wait timeout before reclaiming an incomplete lock', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-native-build-'));
+  fs.writeFileSync(path.join(root, 'native-build.lock'), '{');
+  let ran = false;
+
+  await assert.rejects(
+    withNativeBuildSemaphore({
+      root,
+      waitTimeoutMs: 0,
+      run: async () => {
+        ran = true;
+      },
+    }),
+    /Timed out waiting for native build producer/
   );
+  assert.equal(ran, false);
+  assert.equal(fs.existsSync(path.join(root, 'native-build.lock')), true);
+  fs.rmSync(root, { recursive: true, force: true });
 });

--- a/dev/local/mobile-native-build.test.ts
+++ b/dev/local/mobile-native-build.test.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { withNativeBuildSemaphore } from './mobile-native-build';
+
+test('serializes native producers across different platform builds', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-native-build-'));
+  let active = 0;
+  let maxActive = 0;
+  let releaseFirst: (() => void) | undefined;
+  const firstMayFinish = new Promise<void>(resolve => {
+    releaseFirst = resolve;
+  });
+  let firstStarted: (() => void) | undefined;
+  const firstDidStart = new Promise<void>(resolve => {
+    firstStarted = resolve;
+  });
+
+  const run = async (wait: Promise<void>) => {
+    active += 1;
+    maxActive = Math.max(maxActive, active);
+    firstStarted?.();
+    firstStarted = undefined;
+    await wait;
+    active -= 1;
+  };
+
+  const first = withNativeBuildSemaphore({
+    root,
+    pollIntervalMs: 5,
+    run: () => run(firstMayFinish),
+  });
+  await firstDidStart;
+  const second = withNativeBuildSemaphore({
+    root,
+    pollIntervalMs: 5,
+    run: () => run(Promise.resolve()),
+  });
+
+  await new Promise(resolve => setTimeout(resolve, 20));
+  assert.equal(active, 1);
+  releaseFirst?.();
+  await Promise.all([first, second]);
+  assert.equal(maxActive, 1);
+});
+
+test('recovers an abandoned native producer lock', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-native-build-'));
+  const lockDir = path.join(root, 'native-build.lock');
+  fs.mkdirSync(lockDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(lockDir, 'owner.json'),
+    JSON.stringify({
+      pid: 99_999,
+      identity: 'dead',
+      token: 'stale',
+      startedAt: new Date().toISOString(),
+    })
+  );
+
+  let ran = false;
+  await withNativeBuildSemaphore({
+    root,
+    pidAlive: () => false,
+    processIdentity: () => undefined,
+    pollIntervalMs: 1,
+    run: async () => {
+      ran = true;
+    },
+  });
+
+  assert.equal(ran, true);
+  assert.equal(fs.existsSync(lockDir), false);
+});
+
+test('does not release a native lock replaced by another owner', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-native-build-'));
+  const lockDir = path.join(root, 'native-build.lock');
+
+  await assert.rejects(
+    withNativeBuildSemaphore({
+      root,
+      run: async () => {
+        fs.rmSync(lockDir, { recursive: true, force: true });
+        fs.mkdirSync(lockDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(lockDir, 'owner.json'),
+          JSON.stringify({
+            pid: process.pid,
+            identity: 'replacement',
+            token: 'replacement',
+            startedAt: new Date().toISOString(),
+          })
+        );
+        throw new Error('producer failed');
+      },
+    }),
+    /producer failed/
+  );
+
+  assert.equal(
+    JSON.parse(fs.readFileSync(path.join(lockDir, 'owner.json'), 'utf8')).token,
+    'replacement'
+  );
+});

--- a/dev/local/mobile-native-build.ts
+++ b/dev/local/mobile-native-build.ts
@@ -1,0 +1,153 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+type NativeBuildOwner = {
+  pid: number;
+  identity: string;
+  token: string;
+  startedAt: string;
+};
+
+type NativeBuildSemaphoreArgs<T> = {
+  root: string;
+  run: () => Promise<T>;
+  pidAlive?: (pid: number) => boolean;
+  processIdentity?: (pid: number) => string | undefined;
+  pollIntervalMs?: number;
+  waitTimeoutMs?: number;
+};
+
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+const DEFAULT_WAIT_TIMEOUT_MS = 20 * 60 * 1000;
+
+export async function withNativeBuildSemaphore<T>(args: NativeBuildSemaphoreArgs<T>): Promise<T> {
+  fs.mkdirSync(args.root, { recursive: true });
+  const lockDir = path.join(args.root, 'native-build.lock');
+  const ownerPath = path.join(lockDir, 'owner.json');
+  const pidAlive = args.pidAlive ?? defaultPidAlive;
+  const processIdentity = args.processIdentity ?? defaultProcessIdentity;
+  const deadline = Date.now() + (args.waitTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS);
+
+  while (true) {
+    const owner = acquire(lockDir, ownerPath, processIdentity);
+    if (owner) {
+      try {
+        return await args.run();
+      } finally {
+        releaseOwned(lockDir, ownerPath, owner.token);
+      }
+    }
+
+    const current = readOwner(ownerPath);
+    if (!current || !pidAlive(current.pid) || processIdentity(current.pid) !== current.identity) {
+      reclaim(lockDir, ownerPath, current);
+      continue;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for native build producer ${current.pid}`);
+    }
+    await sleep(args.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+  }
+}
+
+function acquire(
+  lockDir: string,
+  ownerPath: string,
+  processIdentity: (pid: number) => string | undefined
+): NativeBuildOwner | undefined {
+  try {
+    fs.mkdirSync(lockDir);
+  } catch (error) {
+    if (hasCode(error, 'EEXIST')) return undefined;
+    throw error;
+  }
+  const owner: NativeBuildOwner = {
+    pid: process.pid,
+    identity: processIdentity(process.pid) ?? `pid-${process.pid}`,
+    token: `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    startedAt: new Date().toISOString(),
+  };
+  try {
+    fs.writeFileSync(ownerPath, JSON.stringify(owner), { flag: 'wx' });
+    return owner;
+  } catch (error) {
+    fs.rmSync(lockDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function reclaim(lockDir: string, ownerPath: string, expected: NativeBuildOwner | undefined): void {
+  const current = readOwner(ownerPath);
+  if (!sameOwner(current, expected)) return;
+  const quarantine = `${lockDir}.stale-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  try {
+    fs.renameSync(lockDir, quarantine);
+    fs.rmSync(quarantine, { recursive: true, force: true });
+  } catch (error) {
+    if (!hasCode(error, 'ENOENT')) throw error;
+  }
+}
+
+function releaseOwned(lockDir: string, ownerPath: string, token: string): void {
+  if (readOwner(ownerPath)?.token !== token) return;
+  fs.rmSync(lockDir, { recursive: true, force: true });
+}
+
+function readOwner(ownerPath: string): NativeBuildOwner | undefined {
+  try {
+    const value: unknown = JSON.parse(fs.readFileSync(ownerPath, 'utf8'));
+    if (typeof value !== 'object' || value === null) return undefined;
+    const owner = value as Record<string, unknown>;
+    if (
+      !Number.isInteger(owner.pid) ||
+      typeof owner.identity !== 'string' ||
+      typeof owner.token !== 'string' ||
+      typeof owner.startedAt !== 'string'
+    ) {
+      return undefined;
+    }
+    return {
+      pid: owner.pid as number,
+      identity: owner.identity,
+      token: owner.token,
+      startedAt: owner.startedAt,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function sameOwner(
+  left: NativeBuildOwner | undefined,
+  right: NativeBuildOwner | undefined
+): boolean {
+  if (!left || !right) return left === right;
+  return left.pid === right.pid && left.identity === right.identity && left.token === right.token;
+}
+
+function defaultPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return hasCode(error, 'EPERM');
+  }
+}
+
+function defaultProcessIdentity(pid: number): string | undefined {
+  try {
+    const value = execFileSync('ps', ['-o', 'lstart=', '-p', String(pid)], { encoding: 'utf8' });
+    return value.replace(/\s+/g, ' ').trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasCode(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && error.code === code;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/dev/local/mobile-native-build.ts
+++ b/dev/local/mobile-native-build.ts
@@ -23,45 +23,46 @@ const DEFAULT_WAIT_TIMEOUT_MS = 20 * 60 * 1000;
 
 export async function withNativeBuildSemaphore<T>(args: NativeBuildSemaphoreArgs<T>): Promise<T> {
   fs.mkdirSync(args.root, { recursive: true });
-  const lockDir = path.join(args.root, 'native-build.lock');
-  const ownerPath = path.join(lockDir, 'owner.json');
+  const lockPath = path.join(args.root, 'native-build.lock');
   const pidAlive = args.pidAlive ?? defaultPidAlive;
   const processIdentity = args.processIdentity ?? defaultProcessIdentity;
   const deadline = Date.now() + (args.waitTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS);
 
   while (true) {
-    const owner = acquire(lockDir, ownerPath, processIdentity);
+    const owner = acquire(lockPath, processIdentity);
     if (owner) {
       try {
         return await args.run();
       } finally {
-        releaseOwned(lockDir, ownerPath, owner.token);
+        releaseOwned(lockPath, owner.token);
       }
     }
 
-    const current = readOwner(ownerPath);
-    if (!current || !pidAlive(current.pid) || processIdentity(current.pid) !== current.identity) {
-      reclaim(lockDir, ownerPath, current);
+    if (Date.now() >= deadline) {
+      throw new Error('Timed out waiting for native build producer');
+    }
+
+    const current = readOwner(lockPath);
+    if (!current) {
+      await sleep(args.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
       continue;
     }
-    if (Date.now() >= deadline) {
-      throw new Error(`Timed out waiting for native build producer ${current.pid}`);
+    if (!pidAlive(current.pid) || processIdentity(current.pid) !== current.identity) {
+      reclaim(lockPath, current);
+      await sleep(args.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+      continue;
     }
     await sleep(args.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
   }
 }
 
 function acquire(
-  lockDir: string,
-  ownerPath: string,
+  lockPath: string,
   processIdentity: (pid: number) => string | undefined
 ): NativeBuildOwner | undefined {
-  try {
-    fs.mkdirSync(lockDir);
-  } catch (error) {
-    if (hasCode(error, 'EEXIST')) return undefined;
-    throw error;
-  }
+  const stagingPath = `${lockPath}.acquire-${process.pid}-${Date.now()}-${Math.random()
+    .toString(16)
+    .slice(2)}`;
   const owner: NativeBuildOwner = {
     pid: process.pid,
     identity: processIdentity(process.pid) ?? `pid-${process.pid}`,
@@ -69,33 +70,48 @@ function acquire(
     startedAt: new Date().toISOString(),
   };
   try {
-    fs.writeFileSync(ownerPath, JSON.stringify(owner), { flag: 'wx' });
+    fs.writeFileSync(stagingPath, JSON.stringify(owner), { flag: 'wx' });
+    fs.linkSync(stagingPath, lockPath);
     return owner;
   } catch (error) {
-    fs.rmSync(lockDir, { recursive: true, force: true });
+    if (hasCode(error, 'EEXIST')) return undefined;
     throw error;
+  } finally {
+    try {
+      fs.rmSync(stagingPath, { force: true });
+    } catch {
+      // Unique staging files are inert; cleanup must not mask lock acquisition.
+    }
   }
 }
 
-function reclaim(lockDir: string, ownerPath: string, expected: NativeBuildOwner | undefined): void {
-  const current = readOwner(ownerPath);
+function reclaim(lockPath: string, expected: NativeBuildOwner): void {
+  const current = readOwner(lockPath);
   if (!sameOwner(current, expected)) return;
-  const quarantine = `${lockDir}.stale-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const quarantine = `${lockPath}.stale-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   try {
-    fs.renameSync(lockDir, quarantine);
-    fs.rmSync(quarantine, { recursive: true, force: true });
+    fs.renameSync(lockPath, quarantine);
   } catch (error) {
     if (!hasCode(error, 'ENOENT')) throw error;
+    return;
+  }
+  try {
+    fs.rmSync(quarantine, { recursive: true, force: true });
+  } catch {
+    // A uniquely named quarantine is inert and must not block the next producer.
   }
 }
 
-function releaseOwned(lockDir: string, ownerPath: string, token: string): void {
-  if (readOwner(ownerPath)?.token !== token) return;
-  fs.rmSync(lockDir, { recursive: true, force: true });
+function releaseOwned(lockPath: string, token: string): void {
+  if (readOwner(lockPath)?.token !== token) return;
+  fs.rmSync(lockPath, { force: true });
 }
 
-function readOwner(ownerPath: string): NativeBuildOwner | undefined {
+function readOwner(lockPath: string): NativeBuildOwner | undefined {
   try {
+    const ownerPath = fs.statSync(lockPath).isDirectory()
+      ? path.join(lockPath, 'owner.json')
+      : lockPath;
     const value: unknown = JSON.parse(fs.readFileSync(ownerPath, 'utf8'));
     if (typeof value !== 'object' || value === null) return undefined;
     const owner = value as Record<string, unknown>;
@@ -118,15 +134,13 @@ function readOwner(ownerPath: string): NativeBuildOwner | undefined {
   }
 }
 
-function sameOwner(
-  left: NativeBuildOwner | undefined,
-  right: NativeBuildOwner | undefined
-): boolean {
-  if (!left || !right) return left === right;
+function sameOwner(left: NativeBuildOwner | undefined, right: NativeBuildOwner): boolean {
+  if (!left) return false;
   return left.pid === right.pid && left.identity === right.identity && left.token === right.token;
 }
 
 function defaultPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
     process.kill(pid, 0);
     return true;

--- a/dev/local/mobile-simulator.test.ts
+++ b/dev/local/mobile-simulator.test.ts
@@ -6,7 +6,9 @@ import test from 'node:test';
 
 import {
   bootSimulator,
+  buildSimulatorLabel,
   claimSimulator,
+  parseClaimArgs,
   releaseSimulator,
   type SimulatorDevice,
 } from './mobile-simulator';
@@ -1738,6 +1740,975 @@ test('attaches a rollback cleanup failure to the original prepare error', () => 
     );
     const cleanupError = caught.cleanupError as Error;
     assert.match(String(cleanupError), /injected cleanup deletion failure/);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+// --- Task 1: ownership-aware simulator labels ---
+
+test('buildSimulatorLabel: deterministic sanitization and 64-char bound', () => {
+  const base = '/Users/igor/Projects/cloud/.worktrees/speed-mobile-agent-workflow';
+  const label = buildSimulatorLabel(base, 'prewarm');
+  assert.equal(label.startsWith('Kilo E2E - '), true);
+  assert.equal(label.endsWith(' - prewarm'), true);
+  // Worktree basename is "speed-mobile-agent-workflow" — no special chars.
+  assert.equal(label, 'Kilo E2E - speed-mobile-agent-workflow - prewarm');
+});
+
+test('buildSimulatorLabel: trims leading/trailing separators and falls back to "worktree"', () => {
+  const base = '/tmp/---name---/';
+  const label = buildSimulatorLabel(base, 'prewarm');
+  assert.equal(label, 'Kilo E2E - name - prewarm');
+});
+
+test('buildSimulatorLabel: falls back to "worktree" when the basename has no allowed characters', () => {
+  const base = '/tmp/!!!/';
+  const label = buildSimulatorLabel(base, 'prewarm');
+  assert.equal(label, 'Kilo E2E - worktree - prewarm');
+});
+
+test('buildSimulatorLabel: bounds the visible label to 64 characters', () => {
+  const base = `/tmp/${'a'.repeat(120)}_some-more-name-padding/`;
+  const label = buildSimulatorLabel(base, 'verify');
+  assert.ok(label.length <= 64, `label length ${label.length} exceeds 64`);
+  assert.equal(label.startsWith('Kilo E2E - '), true);
+  assert.equal(label.endsWith(' - verify'), true);
+});
+
+test('parseClaimArgs: bare claim', () => {
+  assert.deepEqual(parseClaimArgs(['claim']), {
+    command: 'claim',
+    udid: undefined,
+    phase: undefined,
+  });
+});
+
+test('parseClaimArgs: claim with udid', () => {
+  assert.deepEqual(parseClaimArgs(['claim', 'UDID-X']), {
+    command: 'claim',
+    udid: 'UDID-X',
+    phase: undefined,
+  });
+});
+
+test('parseClaimArgs: claim with --phase flag', () => {
+  assert.deepEqual(parseClaimArgs(['claim', '--phase', 'prewarm']), {
+    command: 'claim',
+    udid: undefined,
+    phase: 'prewarm',
+  });
+});
+
+test('parseClaimArgs: claim with udid and --phase flag', () => {
+  assert.deepEqual(parseClaimArgs(['claim', 'UDID-Y', '--phase', 'verify']), {
+    command: 'claim',
+    udid: 'UDID-Y',
+    phase: 'verify',
+  });
+});
+
+test('parseClaimArgs: claim with --phase before udid', () => {
+  assert.deepEqual(parseClaimArgs(['claim', '--phase', 'verify', 'UDID-Z']), {
+    command: 'claim',
+    udid: 'UDID-Z',
+    phase: 'verify',
+  });
+});
+
+test('parseClaimArgs: release with udid', () => {
+  assert.deepEqual(parseClaimArgs(['release', 'UDID-R']), { command: 'release', udid: 'UDID-R' });
+});
+
+test('parseClaimArgs: rejects missing udid for release', () => {
+  assert.throws(() => parseClaimArgs(['release']), /usage/i);
+});
+
+test('parseClaimArgs: rejects missing/invalid phase values', () => {
+  assert.throws(() => parseClaimArgs(['claim', '--phase']), /usage/i);
+  assert.throws(() => parseClaimArgs(['claim', '--phase', 'other']), /usage/i);
+  assert.throws(
+    () => parseClaimArgs(['claim', '--phase', 'prewarm', '--phase', 'verify']),
+    /usage/i
+  );
+});
+
+test('parseClaimArgs: rejects unknown command', () => {
+  assert.throws(() => parseClaimArgs(['bogus']), /usage/i);
+});
+
+test('parseClaimArgs: rejects --phase with release', () => {
+  assert.throws(() => parseClaimArgs(['release', 'UDID-R', '--phase', 'prewarm']), /usage/i);
+});
+
+test('new phase claim: renames the device, persists original/current name and phase, returns label', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const renameCalls: Array<{ id: string; name: string }> = [];
+  const expectedLabel = buildSimulatorLabel(worktreeRoot, 'prewarm');
+
+  try {
+    const result = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: (id, name) => {
+        renameCalls.push({ id, name });
+      },
+    });
+
+    assert.equal(result.alreadyOwned, false);
+    assert.equal(result.device.id, 'B');
+    assert.deepEqual(renameCalls, [{ id: 'B', name: expectedLabel }]);
+
+    const persisted = JSON.parse(fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8')) as {
+      phase?: string;
+      originalDeviceName?: string;
+      currentDeviceName?: string;
+      status: string;
+    };
+    assert.equal(persisted.status, 'ready');
+    assert.equal(persisted.phase, 'prewarm');
+    assert.equal(persisted.originalDeviceName, 'Kilo E2E-B');
+    assert.equal(persisted.currentDeviceName, expectedLabel);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('phase-less claim: does not rename and does not persist name fields', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  let renameCalls = 0;
+
+  try {
+    const result = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      rename: () => {
+        renameCalls += 1;
+      },
+    });
+
+    assert.equal(result.alreadyOwned, false);
+    assert.equal(renameCalls, 0);
+    const persisted = JSON.parse(fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8')) as {
+      phase?: string;
+      originalDeviceName?: string;
+      currentDeviceName?: string;
+    };
+    assert.equal(persisted.phase, undefined);
+    assert.equal(persisted.originalDeviceName, undefined);
+    assert.equal(persisted.currentDeviceName, undefined);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('same-worktree relabel: prewarm -> verify renames and updates stored phase/name', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const renameCalls: Array<{ id: string; name: string }> = [];
+
+  try {
+    const first = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: (id, name) => {
+        renameCalls.push({ id, name });
+      },
+    });
+    assert.equal(first.alreadyOwned, false);
+    const firstLabel = buildSimulatorLabel(worktreeRoot, 'prewarm');
+    const secondLabel = buildSimulatorLabel(worktreeRoot, 'verify');
+
+    const second = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'verify',
+      rename: (id, name) => {
+        renameCalls.push({ id, name });
+      },
+    });
+
+    assert.equal(second.alreadyOwned, true);
+    // The original rename (during the first claim) plus the relabel rename.
+    assert.deepEqual(renameCalls, [
+      { id: 'B', name: firstLabel },
+      { id: 'B', name: secondLabel },
+    ]);
+
+    const persisted = JSON.parse(fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8')) as {
+      phase: string;
+      originalDeviceName: string;
+      currentDeviceName: string;
+    };
+    assert.equal(persisted.phase, 'verify');
+    assert.equal(persisted.originalDeviceName, 'Kilo E2E-B');
+    assert.equal(persisted.currentDeviceName, secondLabel);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('cross-worktree relabel is rejected (does not rename, claim still belongs to original worktree)', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const firstWorktree = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-one-'));
+  const secondWorktree = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-two-'));
+  const renameCalls: Array<{ id: string; name: string }> = [];
+
+  try {
+    claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot: firstWorktree,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: (id, name) => {
+        renameCalls.push({ id, name });
+      },
+    });
+
+    assert.throws(
+      () =>
+        claimSimulator({
+          devices,
+          lockRoot,
+          worktreeRoot: secondWorktree,
+          requestedId: 'B',
+          phase: 'verify',
+          rename: (id, name) => {
+            renameCalls.push({ id, name });
+          },
+        }),
+      new RegExp(`claimed by ${firstWorktree}`)
+    );
+    // Only the original-worktree rename should have happened.
+    assert.equal(renameCalls.length, 1);
+
+    const persisted = JSON.parse(fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8')) as {
+      worktreeRoot: string;
+      phase: string;
+    };
+    assert.equal(persisted.worktreeRoot, firstWorktree);
+    assert.equal(persisted.phase, 'prewarm');
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(firstWorktree, { recursive: true, force: true });
+    fs.rmSync(secondWorktree, { recursive: true, force: true });
+  }
+});
+
+test('same-owner phase-less reclaim preserves the existing labeled claim', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const renameCalls: Array<{ id: string; name: string }> = [];
+
+  try {
+    claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: (id, name) => {
+        renameCalls.push({ id, name });
+      },
+    });
+    const before = fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8');
+
+    const second = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      // No phase — must preserve the existing label.
+      rename: (id, name) => {
+        renameCalls.push({ id, name });
+      },
+    });
+
+    assert.equal(second.alreadyOwned, true);
+    assert.equal(renameCalls.length, 1);
+    const after = fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8');
+    assert.equal(after, before);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('initial phase rename rollback success: restores original name and removes the preparing claim', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const renameCalls: string[] = [];
+  let caught: Error | undefined;
+
+  try {
+    try {
+      claimSimulator({
+        devices,
+        lockRoot,
+        worktreeRoot,
+        requestedId: 'B',
+        phase: 'prewarm',
+        rename: (id, name) => {
+          renameCalls.push(`${id}:${name}`);
+          if (name !== 'Kilo E2E-B') {
+            // The first rename (to the visible label) fails; the
+            // restoration (back to the original name) succeeds.
+            throw new Error('rename failed');
+          }
+        },
+      });
+    } catch (error) {
+      caught = error as Error;
+    }
+
+    assert.ok(caught, 'claimSimulator must throw when initial rename fails');
+    assert.match(String(caught), /rename failed/);
+    // The exact-own rollback must have removed the preparing claim.
+    assert.equal(fs.existsSync(path.join(lockRoot, 'B.json')), false);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('initial phase rename + restoration failure: preserves the preparing claim and exposes both failures', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  let caught: Error | undefined;
+
+  try {
+    try {
+      claimSimulator({
+        devices,
+        lockRoot,
+        worktreeRoot,
+        requestedId: 'B',
+        phase: 'prewarm',
+        rename: () => {
+          // Both the initial label rename and the restoration rename fail.
+          throw new Error('rename failed');
+        },
+      });
+    } catch (error) {
+      caught = error as Error;
+    }
+
+    assert.ok(caught, 'claimSimulator must throw when rename + restoration both fail');
+    // The preparing claim must be preserved so a peer cannot adopt
+    // unknown state.
+    const persisted = JSON.parse(fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8')) as {
+      status: string;
+      phase: string;
+    };
+    assert.equal(persisted.status, 'preparing');
+    assert.equal(persisted.phase, 'prewarm');
+    // The error message must surface both failures.
+    assert.match(String(caught), /rename failed/);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('releaseSimulator restores the original device name before deleting an owned ready claim', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const renameCalls: Array<{ id: string; name: string }> = [];
+
+  try {
+    claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: (id, name) => {
+        renameCalls.push({ id, name });
+      },
+    });
+    const labelRename = renameCalls[0];
+
+    releaseSimulator({
+      deviceId: 'B',
+      lockRoot,
+      worktreeRoot,
+      rename: (id, name) => {
+        renameCalls.push({ id, name });
+      },
+    });
+
+    // The first rename was the initial claim; the second must be the
+    // restoration back to the original name (which is the device name
+    // at the time of claim, not the list-time name).
+    assert.equal(renameCalls.length, 2);
+    assert.equal(renameCalls[1].id, 'B');
+    assert.equal(renameCalls[1].name, 'Kilo E2E-B');
+    assert.notEqual(renameCalls[1].name, labelRename.name);
+    assert.equal(fs.existsSync(path.join(lockRoot, 'B.json')), false);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('releaseSimulator: restoration failure preserves the claim and throws', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  let caught: Error | undefined;
+
+  try {
+    claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      // Initial rename succeeds; release-time restoration will be
+      // forced to fail.
+      rename: () => undefined,
+    });
+
+    try {
+      releaseSimulator({
+        deviceId: 'B',
+        lockRoot,
+        worktreeRoot,
+        rename: () => {
+          throw new Error('restoration failed');
+        },
+      });
+    } catch (error) {
+      caught = error as Error;
+    }
+
+    assert.ok(caught, 'releaseSimulator must throw when restoration fails');
+    assert.match(String(caught), /restoration failed/);
+    // The claim must be preserved so a peer can investigate.
+    assert.equal(fs.existsSync(path.join(lockRoot, 'B.json')), true);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('releaseSimulator: old claim without original/current name retains existing behavior (no rename)', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  let renameCalled = false;
+
+  try {
+    // A current-format claim written by an older release of this code
+    // (status, claimId, but no phase/originalDeviceName/currentDeviceName).
+    fs.writeFileSync(
+      path.join(lockRoot, 'B.json'),
+      JSON.stringify({
+        deviceId: 'B',
+        worktreeRoot,
+        claimId: 'legacy-claim-id',
+        preparerPid: process.pid,
+        preparerIdentity: 'legacy-identity',
+        status: 'ready',
+        claimedAt: new Date().toISOString(),
+      })
+    );
+
+    releaseSimulator({
+      deviceId: 'B',
+      lockRoot,
+      worktreeRoot,
+      rename: () => {
+        renameCalled = true;
+      },
+    });
+
+    assert.equal(renameCalled, false);
+    assert.equal(fs.existsSync(path.join(lockRoot, 'B.json')), false);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('production rename command: xcrun simctl rename <device> <name>', () => {
+  // The production CLI is `xcrun simctl rename <device> <name>`. The
+  // ts file must use that exact command shape; we pin it via a source
+  // assertion so an accidental rewrite is caught by tests.
+  const source = fs.readFileSync(new URL('./mobile-simulator.ts', import.meta.url), 'utf8');
+  assert.match(source, /xcrun['"]?\s*,\s*\[['"]simctl['"]\s*,\s*['"]rename['"]/);
+});
+
+// --- Spec-review follow-up: disallowed runs in the basename ---
+
+test('buildSimulatorLabel: collapses disallowed runs in the basename to a single dash', () => {
+  // The reviewer's example: `/tmp/foo bar!!!baz` has a space and three
+  // exclamation marks. After sanitization the basename must read
+  // `foo-bar-baz` and the full label must be deterministic.
+  assert.equal(
+    buildSimulatorLabel('/tmp/foo bar!!!baz', 'verify'),
+    'Kilo E2E - foo-bar-baz - verify'
+  );
+});
+
+// --- Spec-review follow-up: phase-less -> phase upgrade records originalDeviceName ---
+
+test('phase-less -> phase upgrade: records originalDeviceName from list-time device.name and restores it on release', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const renameCalls: string[] = [];
+
+  try {
+    // Pre-existing phase-less ready claim owned by the same worktree.
+    // This is what a pre-protocol or earlier-release claim looks like:
+    // current-format (status, claimId, preparerPid) but no phase /
+    // originalDeviceName / currentDeviceName.
+    fs.writeFileSync(
+      path.join(lockRoot, 'B.json'),
+      JSON.stringify({
+        deviceId: 'B',
+        worktreeRoot,
+        claimId: 'pre-existing-claim-id',
+        preparerPid: process.pid,
+        preparerIdentity: 'pre-existing-identity',
+        status: 'ready',
+        claimedAt: new Date().toISOString(),
+      })
+    );
+
+    // Reclaim with a phase. The list-time device name is the source of
+    // truth for the new originalDeviceName.
+    const result = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: (id, name) => {
+        renameCalls.push(`${id}:${name}`);
+      },
+    });
+
+    const expectedLabel = buildSimulatorLabel(worktreeRoot, 'prewarm');
+    assert.equal(result.alreadyOwned, true);
+    // The returned device must report the new visible label.
+    assert.equal(result.device.name, expectedLabel);
+
+    // First rename is the upgrade to the visible label.
+    assert.deepEqual(renameCalls, [`B:${expectedLabel}`]);
+
+    const persisted = JSON.parse(fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8')) as {
+      phase: string;
+      originalDeviceName: string;
+      currentDeviceName: string;
+      claimId: string;
+    };
+    assert.equal(persisted.phase, 'prewarm');
+    assert.equal(persisted.originalDeviceName, 'Kilo E2E-B');
+    assert.equal(persisted.currentDeviceName, expectedLabel);
+    // The claim identity must be preserved (we're upgrading an
+    // existing claim, not replacing it).
+    assert.equal(persisted.claimId, 'pre-existing-claim-id');
+
+    // Release must restore the original name before deletion.
+    releaseSimulator({
+      deviceId: 'B',
+      lockRoot,
+      worktreeRoot,
+      rename: (id, name) => {
+        renameCalls.push(`${id}:${name}`);
+      },
+    });
+
+    assert.deepEqual(renameCalls, [`B:${expectedLabel}`, `B:Kilo E2E-B`]);
+    assert.equal(fs.existsSync(path.join(lockRoot, 'B.json')), false);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+// --- Spec-review follow-up: returned device.name reflects the visible label ---
+
+test('new phase claim: returned device.name is the new visible label', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const expectedLabel = buildSimulatorLabel(worktreeRoot, 'prewarm');
+
+  try {
+    const result = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: () => undefined,
+    });
+
+    assert.equal(result.alreadyOwned, false);
+    assert.equal(result.device.id, 'B');
+    assert.equal(result.device.name, expectedLabel);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('relabel: returned device.name is the new visible label', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const expectedLabel = buildSimulatorLabel(worktreeRoot, 'verify');
+
+  try {
+    claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: () => undefined,
+    });
+
+    const result = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'verify',
+      rename: () => undefined,
+    });
+
+    assert.equal(result.alreadyOwned, true);
+    assert.equal(result.device.name, expectedLabel);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('phase-less claim: returned device.name is the list-time device name (unchanged)', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+
+  try {
+    const result = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+    });
+
+    assert.equal(result.alreadyOwned, false);
+    assert.equal(result.device.name, 'Kilo E2E-B');
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('same-owner phase-less reclaim: returned device.name is the existing currentDeviceName (preserved)', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const expectedLabel = buildSimulatorLabel(worktreeRoot, 'prewarm');
+
+  try {
+    claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: () => undefined,
+    });
+
+    const result = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+    });
+
+    assert.equal(result.alreadyOwned, true);
+    // The existing label must be preserved (not the list-time name).
+    assert.equal(result.device.name, expectedLabel);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+// --- Code-quality follow-up: corrupt optional label fields are sanitized ---
+
+test('readClaim sanitizes non-string originalDeviceName/currentDeviceName/phase so they cannot poison relabel', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+
+  try {
+    // On-disk claim with corrupted label fields: non-string
+    // originalDeviceName, non-string currentDeviceName, and an invalid
+    // phase. The reader must drop the corrupt fields (matching
+    // readClaimRaw) so a reclaim cannot persist a bogus original
+    // name — the list-time device.name must be the fallback.
+    fs.writeFileSync(
+      path.join(lockRoot, 'B.json'),
+      JSON.stringify({
+        deviceId: 'B',
+        worktreeRoot,
+        claimId: 'corrupt-fields-claim-id',
+        preparerPid: process.pid,
+        preparerIdentity: 'corrupt-fields-identity',
+        status: 'ready',
+        claimedAt: new Date().toISOString(),
+        phase: 12345,
+        originalDeviceName: { not: 'a string' },
+        currentDeviceName: ['not', 'a', 'string'],
+      })
+    );
+
+    const renameCalls: string[] = [];
+    const result = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: (id, name) => {
+        renameCalls.push(`${id}:${name}`);
+      },
+    });
+
+    const expectedLabel = buildSimulatorLabel(worktreeRoot, 'prewarm');
+    assert.equal(result.alreadyOwned, true);
+    // The relabel must have actually renamed (not just returned the
+    // stored corrupt name).
+    assert.deepEqual(renameCalls, [`B:${expectedLabel}`]);
+
+    const persisted = JSON.parse(fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8')) as {
+      phase: string;
+      originalDeviceName: string;
+      currentDeviceName: string;
+    };
+    assert.equal(persisted.phase, 'prewarm');
+    // The corrupt originalDeviceName must be replaced by the list-time
+    // device name (sanitized readClaim treated it as undefined).
+    assert.equal(persisted.originalDeviceName, 'Kilo E2E-B');
+    assert.equal(persisted.currentDeviceName, expectedLabel);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+// --- Code-quality follow-up: same phase but different stored label must rename ---
+
+test('relabel: same phase but different stored currentDeviceName renames and persists the target label', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const renameCalls: string[] = [];
+
+  try {
+    // Pre-existing claim with phase='prewarm' but a stored
+    // currentDeviceName that does not match the canonical label (e.g.,
+    // written by a buggy or older build). The relabel must notice the
+    // mismatch and actually rename, not just return the stored name.
+    const expectedLabel = buildSimulatorLabel(worktreeRoot, 'prewarm');
+    const staleLabel = 'Kilo E2E - stale-basename - prewarm';
+    fs.writeFileSync(
+      path.join(lockRoot, 'B.json'),
+      JSON.stringify({
+        deviceId: 'B',
+        worktreeRoot,
+        claimId: 'stale-label-claim-id',
+        preparerPid: process.pid,
+        preparerIdentity: 'stale-label-identity',
+        status: 'ready',
+        claimedAt: new Date().toISOString(),
+        phase: 'prewarm',
+        originalDeviceName: 'Kilo E2E-B',
+        currentDeviceName: staleLabel,
+      })
+    );
+
+    const result = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: (id, name) => {
+        renameCalls.push(`${id}:${name}`);
+      },
+    });
+
+    assert.equal(result.alreadyOwned, true);
+    // The rename must have fired (stale label != canonical label).
+    assert.deepEqual(renameCalls, [`B:${expectedLabel}`]);
+    assert.equal(result.device.name, expectedLabel);
+
+    const persisted = JSON.parse(fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8')) as {
+      currentDeviceName: string;
+      phase: string;
+    };
+    assert.equal(persisted.phase, 'prewarm');
+    assert.equal(persisted.currentDeviceName, expectedLabel);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+// --- Code-quality follow-up: initial rename error is the primary cause, restorationError is separate ---
+
+test('initial phase rename + restoration failure: cause is the initial rename error and restorationError exposes the restoration failure', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  let caught: (Error & { cause?: unknown; restorationError?: unknown }) | undefined;
+
+  try {
+    try {
+      claimSimulator({
+        devices,
+        lockRoot,
+        worktreeRoot,
+        requestedId: 'B',
+        phase: 'prewarm',
+        rename: () => {
+          // Both the initial label rename and the restoration rename
+          // fail with distinct messages so the test can distinguish
+          // them.
+          throw new Error('initial-rename-failed');
+        },
+      });
+    } catch (error) {
+      caught = error as Error & { cause?: unknown; restorationError?: unknown };
+    }
+
+    assert.ok(caught, 'claimSimulator must throw when rename + restoration both fail');
+    // The preparing claim must be preserved so a peer cannot adopt
+    // unknown state.
+    const persisted = JSON.parse(fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8')) as {
+      status: string;
+      phase: string;
+    };
+    assert.equal(persisted.status, 'preparing');
+    assert.equal(persisted.phase, 'prewarm');
+
+    // The primary cause must be the initial rename error, not the
+    // restoration error. The restoration failure is exposed
+    // separately as `restorationError`.
+    assert.ok(caught.cause instanceof Error, 'cause must be the initial rename error');
+    assert.match((caught.cause as Error).message, /initial-rename-failed/);
+    assert.ok(caught.restorationError instanceof Error, 'restorationError must be set');
+    assert.match((caught.restorationError as Error).message, /initial-rename-failed/);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+test('initial phase rename rollback success: cause is the initial rename error and restorationError is undefined', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  let caught: (Error & { cause?: unknown; restorationError?: unknown }) | undefined;
+
+  try {
+    try {
+      claimSimulator({
+        devices,
+        lockRoot,
+        worktreeRoot,
+        requestedId: 'B',
+        phase: 'prewarm',
+        rename: (id, name) => {
+          if (name !== 'Kilo E2E-B') {
+            // The first rename (to the visible label) fails; the
+            // restoration (back to the original name) succeeds.
+            throw new Error('initial-rename-failed');
+          }
+        },
+      });
+    } catch (error) {
+      caught = error as Error & { cause?: unknown; restorationError?: unknown };
+    }
+
+    assert.ok(caught, 'claimSimulator must throw when initial rename fails');
+    // The primary cause must be the initial rename error.
+    assert.ok(caught.cause instanceof Error, 'cause must be the initial rename error');
+    assert.match((caught.cause as Error).message, /initial-rename-failed/);
+    // Restoration succeeded, so restorationError must be undefined.
+    assert.equal(caught.restorationError, undefined);
+    // The exact-own rollback must have removed the preparing claim.
+    assert.equal(fs.existsSync(path.join(lockRoot, 'B.json')), false);
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
+// --- Code-quality follow-up: same-worktree, same-phase, same-label reclaim is idempotent ---
+
+test('same-worktree, same-phase, same-label reclaim is idempotent (no rename, record unchanged)', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const renameCalls: string[] = [];
+
+  try {
+    // First claim establishes the label.
+    const first = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: (id, name) => {
+        renameCalls.push(`${id}:${name}`);
+      },
+    });
+    const expectedLabel = buildSimulatorLabel(worktreeRoot, 'prewarm');
+    assert.equal(first.alreadyOwned, false);
+    assert.deepEqual(renameCalls, [`B:${expectedLabel}`]);
+
+    // Snapshot the on-disk claim before the second (idempotent) claim.
+    const before = fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8');
+
+    // Second claim with the same phase and the same label must be a
+    // no-op: rename must NOT fire again and the record must be
+    // byte-for-byte unchanged. The returned device.name must still
+    // report the current label.
+    const second = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'prewarm',
+      rename: (id, name) => {
+        renameCalls.push(`${id}:${name}`);
+      },
+    });
+
+    assert.equal(second.alreadyOwned, true);
+    // No additional rename was issued.
+    assert.deepEqual(renameCalls, [`B:${expectedLabel}`]);
+    // The returned device name is the current label.
+    assert.equal(second.device.name, expectedLabel);
+    // The on-disk claim is byte-for-byte unchanged.
+    const after = fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8');
+    assert.equal(after, before);
   } finally {
     fs.rmSync(lockRoot, { recursive: true, force: true });
     fs.rmSync(worktreeRoot, { recursive: true, force: true });

--- a/dev/local/mobile-simulator.test.ts
+++ b/dev/local/mobile-simulator.test.ts
@@ -929,6 +929,44 @@ test('treats a legacy claim (no status/claimId) as ready for the same worktree',
   }
 });
 
+test('upgrades and relabels a same-worktree legacy claim without desynchronizing its name', () => {
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-'));
+  const renames: string[] = [];
+
+  try {
+    fs.writeFileSync(path.join(lockRoot, 'B.json'), JSON.stringify({ worktreeRoot }));
+
+    const claim = claimSimulator({
+      devices,
+      lockRoot,
+      worktreeRoot,
+      requestedId: 'B',
+      phase: 'verify',
+      rename: (_deviceId, name) => renames.push(name),
+    });
+
+    assert.equal(claim.alreadyOwned, true);
+    assert.equal(claim.device.name, buildSimulatorLabel(worktreeRoot, 'verify'));
+    assert.deepEqual(renames, [buildSimulatorLabel(worktreeRoot, 'verify')]);
+    const persisted = JSON.parse(fs.readFileSync(path.join(lockRoot, 'B.json'), 'utf8')) as {
+      status: string;
+      claimId: string;
+      originalDeviceName: string;
+      currentDeviceName: string;
+      phase: string;
+    };
+    assert.equal(persisted.status, 'ready');
+    assert.ok(persisted.claimId);
+    assert.equal(persisted.originalDeviceName, devices.find(device => device.id === 'B')?.name);
+    assert.equal(persisted.currentDeviceName, buildSimulatorLabel(worktreeRoot, 'verify'));
+    assert.equal(persisted.phase, 'verify');
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  }
+});
+
 test('rejects a different worktree against a legacy claim (no status/claimId)', () => {
   const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-simulator-locks-'));
   const firstWorktree = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-worktree-one-'));

--- a/dev/local/mobile-simulator.ts
+++ b/dev/local/mobile-simulator.ts
@@ -633,6 +633,23 @@ function claimSimulator(args: ClaimArgs): { device: SimulatorDevice; alreadyOwne
                   `Simulator ${device.id} relabel to ${args.phase} requires a rename hook`
                 );
               }
+              if (existing.claimId === undefined) {
+                const upgraded: ClaimRecord = {
+                  deviceId: device.id,
+                  worktreeRoot,
+                  claimId: randomUUID(),
+                  status: 'ready',
+                  claimedAt: new Date().toISOString(),
+                  originalDeviceName: device.name,
+                  currentDeviceName: device.name,
+                };
+                fs.writeFileSync(lockPath(lockRoot, device.id), JSON.stringify(upgraded), {
+                  flag: 'w',
+                });
+                existing.claimId = upgraded.claimId;
+                existing.originalDeviceName = upgraded.originalDeviceName;
+                existing.currentDeviceName = upgraded.currentDeviceName;
+              }
               args.rename(device.id, targetLabel);
               // Persist the new label/phase under the mutation lock. We
               // only touch the record when the exact claimId is still

--- a/dev/local/mobile-simulator.ts
+++ b/dev/local/mobile-simulator.ts
@@ -19,6 +19,15 @@ type CommandResult = {
 };
 type ExecWithOutputFn = (command: string, args: readonly string[]) => CommandResult;
 type ClaimStatus = 'preparing' | 'ready';
+// Phase is recorded alongside the visible simulator name so an operator
+// inspecting the device list can tell at a glance which agent role
+// (prewarm or verify) currently owns the simulator. Phase-less claims
+// keep the legacy pre-protocol behavior and do not rename the device.
+export type SimulatorPhase = 'prewarm' | 'verify';
+// Rename hook used to set and restore the visible simulator name.
+// Production wires this to `xcrun simctl rename <device> <name>`.
+// Injectable for deterministic tests.
+export type RenameFn = (deviceId: string, name: string) => void;
 // All fields are optional in the exported type. Current-format claims
 // require deviceId, worktreeRoot, claimId, status, and claimedAt;
 // legacy claims (no `status`) require only worktreeRoot. The
@@ -37,12 +46,29 @@ type ClaimRecord = {
   preparerIdentity?: string;
   status?: ClaimStatus;
   claimedAt?: string;
+  // Ownership-aware label fields. Populated only when a phase is
+  // supplied at claim time. `originalDeviceName` is the simulator's
+  // name at the moment of claim and is restored on release;
+  // `currentDeviceName` is the visible label. Both are absent on
+  // phase-less and pre-protocol claims for backward compatibility.
+  phase?: SimulatorPhase;
+  originalDeviceName?: string;
+  currentDeviceName?: string;
 };
 type ClaimArgs = {
   devices: SimulatorDevice[];
   lockRoot: string;
   worktreeRoot: string;
   requestedId?: string;
+  // Optional phase for ownership-aware labeling. When set, the device
+  // is renamed to a deterministic label and the original/current names
+  // are persisted on the claim record. When undefined, the claim
+  // behaves like a pre-protocol claim (no rename, no label fields).
+  phase?: SimulatorPhase;
+  // Rename hook. Required for phase claims. Defaults to
+  // `xcrun simctl rename <device> <name>` in production via `main`.
+  // Tests inject a recording stub.
+  rename?: RenameFn;
   prepare?: (device: SimulatorDevice) => void;
   // Recovery reset contract: REQUIRED for abandoned-preparation
   // recovery. The callback receives a deviceId and must return a
@@ -69,6 +95,81 @@ type ClaimArgs = {
     rmSync?: (filePath: string, options: { force?: boolean }) => void;
   };
 };
+
+// Build the deterministic visible label for a phase-claimed simulator:
+// `Kilo E2E - <sanitized-worktree-basename> - <phase>`, bounded to 64
+// characters. The worktree basename is sanitized by collapsing runs of
+// characters outside `[A-Za-z0-9._-]` to a single dash, trimming
+// leading/trailing separators, and falling back to `worktree` when the
+// result is empty. If the sanitized label still exceeds 64 characters,
+// the worktree segment is truncated to fit. Pure helper exported for
+// tests.
+function buildSimulatorLabel(worktreeRoot: string, phase: SimulatorPhase): string {
+  const suffix = ` - ${phase}`;
+  const prefix = 'Kilo E2E - ';
+  const maxWorktreeSegment = 64 - prefix.length - suffix.length;
+  const basename = path.basename(worktreeRoot);
+  const sanitized =
+    basename
+      .replace(/[^A-Za-z0-9._-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, Math.max(0, maxWorktreeSegment))
+      .replace(/^-+|-+$/g, '') || 'worktree';
+  const label = `${prefix}${sanitized}${suffix}`;
+  return label.length <= 64 ? label : label.slice(0, 64).replace(/-+$/, '');
+}
+
+// Parse the CLI arguments for the `claim` and `release` commands.
+// Supports:
+//   - `claim`
+//   - `claim <udid>`
+//   - `claim --phase <prewarm|verify>`
+//   - `claim <udid> --phase <prewarm|verify>`
+//   - `claim --phase <prewarm|verify> <udid>`
+//   - `release <udid>`
+// Throws a clear usage error on missing, duplicate, or invalid
+// `--phase` values, missing `release` udid, or unknown commands. Pure
+// helper exported for tests.
+function parseClaimArgs(
+  argv: readonly string[]
+):
+  | { command: 'claim'; udid: string | undefined; phase: SimulatorPhase | undefined }
+  | { command: 'release'; udid: string } {
+  const [command, ...rest] = argv;
+  if (command === 'release') {
+    if (rest.length !== 1) {
+      throw new Error('Usage: release <udid>');
+    }
+    return { command: 'release', udid: rest[0] };
+  }
+  if (command !== 'claim') {
+    throw new Error('Usage: claim [--phase <prewarm|verify>] [<udid>] | release <udid>');
+  }
+  let phase: SimulatorPhase | undefined;
+  let phaseSeen = false;
+  const positional: string[] = [];
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i];
+    if (arg === '--phase') {
+      if (phaseSeen) {
+        throw new Error('Usage: --phase may only be specified once');
+      }
+      phaseSeen = true;
+      const value = rest[i + 1];
+      if (value !== 'prewarm' && value !== 'verify') {
+        throw new Error('Usage: --phase must be one of: prewarm, verify');
+      }
+      phase = value;
+      i += 1;
+      continue;
+    }
+    positional.push(arg);
+  }
+  if (positional.length > 1) {
+    throw new Error('Usage: claim [--phase <prewarm|verify>] [<udid>]');
+  }
+  return { command: 'claim', udid: positional[0], phase };
+}
 
 // Typed error thrown by `bootSimulator` so the caller can distinguish a
 // prepare failure (safe to roll back the claim) from a prepare failure whose
@@ -231,6 +332,17 @@ function readClaim(
     return undefined;
   }
   const claim = obj as unknown as ClaimRecord;
+  // Sanitize optional label fields to the same shape as readClaimRaw:
+  // phase must be exactly 'prewarm' or 'verify'; the two name fields
+  // must be strings. Corrupt values (wrong type, invalid phase string)
+  // are dropped to undefined so a subsequent relabel cannot persist a
+  // bogus original name or label. The claim stays valid; only the
+  // optional fields are coerced.
+  claim.phase = obj.phase === 'prewarm' || obj.phase === 'verify' ? obj.phase : undefined;
+  claim.originalDeviceName =
+    typeof obj.originalDeviceName === 'string' ? obj.originalDeviceName : undefined;
+  claim.currentDeviceName =
+    typeof obj.currentDeviceName === 'string' ? obj.currentDeviceName : undefined;
   if (claim.status === 'preparing') return claim;
   // Ready: check worktreeRoot liveness.
   if (claim.worktreeRoot && fs.existsSync(claim.worktreeRoot)) return claim;
@@ -290,6 +402,11 @@ function readClaimRaw(
       preparerIdentity: typeof obj.preparerIdentity === 'string' ? obj.preparerIdentity : undefined,
       status: obj.status as ClaimStatus,
       claimedAt: obj.claimedAt as string,
+      phase: obj.phase === 'prewarm' || obj.phase === 'verify' ? obj.phase : undefined,
+      originalDeviceName:
+        typeof obj.originalDeviceName === 'string' ? obj.originalDeviceName : undefined,
+      currentDeviceName:
+        typeof obj.currentDeviceName === 'string' ? obj.currentDeviceName : undefined,
     },
   };
 }
@@ -415,7 +532,8 @@ function buildPreparingClaim(
   deviceId: string,
   worktreeRoot: string,
   claimId: string,
-  processIdentity: (pid: number) => string | undefined
+  processIdentity: (pid: number) => string | undefined,
+  phase?: SimulatorPhase
 ): Record<string, unknown> {
   const record: Record<string, unknown> = {
     deviceId,
@@ -428,6 +546,9 @@ function buildPreparingClaim(
   const identity = processIdentity(process.pid);
   if (identity !== undefined) {
     record.preparerIdentity = identity;
+  }
+  if (phase !== undefined) {
+    record.phase = phase;
   }
   return record;
 }
@@ -475,14 +596,65 @@ function claimSimulator(args: ClaimArgs): { device: SimulatorDevice; alreadyOwne
             fs.writeFileSync(
               lockPath(lockRoot, device.id),
               JSON.stringify(
-                buildPreparingClaim(device.id, worktreeRoot, claimId, processIdentity)
+                buildPreparingClaim(device.id, worktreeRoot, claimId, processIdentity, args.phase)
               ),
               { flag: 'w' }
             );
             return { device, alreadyOwned: false, claimId, recovering: true };
           }
           if (existing.worktreeRoot === worktreeRoot) {
-            return { device, alreadyOwned: true };
+            // Same-worktree ready reclaim. A phase set on the call may
+            // relabel an existing labeled claim to a new phase
+            // (`Kilo E2E - <basename> - <phase>`). A phase-less reclaim
+            // must preserve the existing label — the original
+            // originalDeviceName and currentDeviceName (when present)
+            // are left intact.
+            if (args.phase === undefined) {
+              return {
+                device: existing.currentDeviceName
+                  ? { ...device, name: existing.currentDeviceName }
+                  : device,
+                alreadyOwned: true,
+              };
+            }
+            const targetLabel = buildSimulatorLabel(worktreeRoot, args.phase);
+            if (existing.currentDeviceName === targetLabel && existing.phase === args.phase) {
+              return { device: { ...device, name: targetLabel }, alreadyOwned: true };
+            }
+            // Relabel fires when EITHER the stored phase differs from
+            // the requested phase OR the stored currentDeviceName does
+            // not match the canonical target label. The phase-only
+            // check would miss a claim whose stored label is stale
+            // (e.g., written by an older build, or by a peer with a
+            // different worktree basename that later relinked).
+            if (existing.phase !== args.phase || existing.currentDeviceName !== targetLabel) {
+              if (!args.rename) {
+                throw new Error(
+                  `Simulator ${device.id} relabel to ${args.phase} requires a rename hook`
+                );
+              }
+              args.rename(device.id, targetLabel);
+              // Persist the new label/phase under the mutation lock. We
+              // only touch the record when the exact claimId is still
+              // current (which it is — we hold the lock). When no
+              // originalDeviceName is stored (legacy or phase-less
+              // claim being upgraded), the list-time device name is the
+              // source of truth — it must be persisted so release can
+              // restore it.
+              const fresh = readClaimRaw(lockRoot, device.id);
+              if (fresh.kind !== 'current' || fresh.record.claimId !== existing.claimId) {
+                throw new Error(`Simulator ${device.id} relabel failed: claim record changed`);
+              }
+              const next: Record<string, unknown> = {
+                ...fresh.record,
+                phase: args.phase,
+                currentDeviceName: targetLabel,
+                originalDeviceName:
+                  existing.originalDeviceName ?? fresh.record.originalDeviceName ?? device.name,
+              };
+              fs.writeFileSync(lockPath(lockRoot, device.id), JSON.stringify(next), { flag: 'w' });
+            }
+            return { device: { ...device, name: targetLabel }, alreadyOwned: true };
           }
           throw new Error(`Simulator ${device.id} is claimed by ${existing.worktreeRoot}`);
         }
@@ -493,7 +665,9 @@ function claimSimulator(args: ClaimArgs): { device: SimulatorDevice; alreadyOwne
         const claimId = randomUUID();
         fs.writeFileSync(
           lockPath(lockRoot, device.id),
-          JSON.stringify(buildPreparingClaim(device.id, worktreeRoot, claimId, processIdentity)),
+          JSON.stringify(
+            buildPreparingClaim(device.id, worktreeRoot, claimId, processIdentity, args.phase)
+          ),
           { flag: 'wx' }
         );
         return { device, alreadyOwned: false, claimId, recovering: false };
@@ -561,6 +735,57 @@ function claimSimulator(args: ClaimArgs): { device: SimulatorDevice; alreadyOwne
               });
       }
 
+      // Phase rename happens after prepare and before finalization. We
+      // capture the original device name (the list-time `device.name`)
+      // so it can be restored on release. If the rename fails we try to
+      // restore the original name; if the restore also fails the
+      // preparing claim is preserved (a peer must not be able to adopt
+      // a device whose visible name is unknown).
+      let labelInfo: { label: string; originalName: string } | undefined;
+      let renameError: unknown;
+      if (!prepareError && args.phase !== undefined) {
+        if (!args.rename) {
+          prepareError = new PrepareError(
+            `Simulator ${device.id} phase claim requires a rename hook`,
+            { shutdownFailed: false }
+          );
+        } else {
+          const label = buildSimulatorLabel(worktreeRoot, args.phase);
+          const originalName = device.name;
+          try {
+            args.rename(device.id, label);
+            labelInfo = { label, originalName };
+          } catch (initialRenameError) {
+            renameError = initialRenameError;
+            let restorationError: unknown;
+            try {
+              args.rename(device.id, originalName);
+            } catch (restoreError) {
+              restorationError = restoreError;
+            }
+            const restoreSucceeded = restorationError === undefined;
+            const message = `Simulator ${device.id} rename to ${label} failed${
+              restoreSucceeded ? ' (restored original name)' : ' (restoration also failed)'
+            }: ${initialRenameError instanceof Error ? initialRenameError.message : String(initialRenameError)}`;
+            // The initial rename error is the primary cause; the
+            // restoration failure (if any) is exposed separately as
+            // `restorationError` so operators can see both without the
+            // restoration error masking the original failure.
+            prepareError = new PrepareError(message, {
+              shutdownFailed: !restoreSucceeded,
+              cause: initialRenameError,
+            });
+            (prepareError as PrepareError & { renameError?: unknown }).renameError =
+              initialRenameError;
+            (prepareError as PrepareError & { restorationError?: unknown }).restorationError =
+              restorationError;
+            (
+              prepareError as PrepareError & { restorationSucceeded?: boolean }
+            ).restorationSucceeded = restoreSucceeded;
+          }
+        }
+      }
+
       // Reacquire the mutation lock to finalize (mark ready) or roll back
       // (remove the preparing claim). The on-disk record is the source of
       // truth; we only touch it when our exact claimId is still current.
@@ -576,19 +801,16 @@ function claimSimulator(args: ClaimArgs): { device: SimulatorDevice; alreadyOwne
         const result = readClaimRaw(lockRoot, device.id);
         const rmSync = args.fileOperations?.rmSync ?? fs.rmSync;
         if (prepareError) {
+          // When a rename failure's restoration also failed, the device
+          // is in an unknown visible-name state — preserve the
+          // preparing claim so a peer cannot adopt it.
           if (prepareError.shutdownFailed) {
-            // Preserve the preparing claim so a peer cannot adopt a
-            // device that may still be running. The original prepare
-            // error still surfaces to the caller via the throw below.
             return;
           }
           if (result.kind === 'current' && result.record.claimId === claimId) {
             try {
               rmSync(lockPath(lockRoot, device.id), { force: true });
             } catch (cleanupError) {
-              // Attach the cleanup failure to the original prepare error
-              // so the operator sees both; the original prepare failure
-              // remains the primary reason the claim did not succeed.
               prepareError = new PrepareError(prepareError.message, {
                 shutdownFailed: false,
                 cause: prepareError.cause ?? prepareError,
@@ -597,8 +819,6 @@ function claimSimulator(args: ClaimArgs): { device: SimulatorDevice; alreadyOwne
                 cleanupError;
             }
           }
-          // For missing/corrupt/replaced records during rollback, do
-          // nothing — the original prepare error will be thrown.
           return;
         }
         if (result.kind === 'missing') {
@@ -612,27 +832,33 @@ function claimSimulator(args: ClaimArgs): { device: SimulatorDevice; alreadyOwne
           );
         }
         if (result.kind === 'legacy') {
-          // A legacy claim appeared mid-prepare (e.g., a peer on an
-          // older worktree wrote it). We do not own it; fail closed.
           throw new Error(
             `Simulator ${device.id} finalization failed: claim record was replaced by a legacy entry`
           );
         }
-        // result.kind === 'current'
         if (result.record.claimId !== claimId) {
           throw new Error(
             `Simulator ${device.id} finalization failed: claim record was replaced by another owner`
           );
         }
-        fs.writeFileSync(
-          lockPath(lockRoot, device.id),
-          JSON.stringify({ ...result.record, status: 'ready' }),
-          { flag: 'w' }
-        );
+        const nextRecord: Record<string, unknown> = { ...result.record, status: 'ready' };
+        if (labelInfo) {
+          nextRecord.phase = args.phase;
+          nextRecord.originalDeviceName = labelInfo.originalName;
+          nextRecord.currentDeviceName = labelInfo.label;
+        }
+        fs.writeFileSync(lockPath(lockRoot, device.id), JSON.stringify(nextRecord), { flag: 'w' });
       });
 
       if (prepareError) throw prepareError;
-      return { device: outcome.device, alreadyOwned: false };
+      // For phase claims the visible simulator name is the label we
+      // just applied; for phase-less claims the list-time device name
+      // is unchanged. Returning the correct name lets callers and the
+      // CLI print the visible label.
+      return {
+        device: labelInfo ? { ...outcome.device, name: labelInfo.label } : outcome.device,
+        alreadyOwned: false,
+      };
     } catch (error) {
       if (error instanceof Error && 'code' in error && error.code === 'EEXIST') {
         if (requestedId) {
@@ -665,6 +891,12 @@ function releaseSimulator(args: {
   deviceId: string;
   lockRoot: string;
   worktreeRoot: string;
+  // Optional rename hook used to restore the original simulator name
+  // before deleting an owned ready claim. When a current-format claim
+  // carries `originalDeviceName`, the hook is invoked to restore it
+  // before removal. Old/legacy claims without `originalDeviceName`
+  // skip the restore (no name was set by this protocol).
+  rename?: RenameFn;
 }): void {
   withClaimMutationLock(args.lockRoot, args.deviceId, () => {
     const result = readClaimRaw(args.lockRoot, args.deviceId);
@@ -688,6 +920,16 @@ function releaseSimulator(args: {
       if (result.record.worktreeRoot !== args.worktreeRoot) {
         throw new Error(`Simulator ${args.deviceId} is claimed by ${result.record.worktreeRoot}`);
       }
+      // Restore the original simulator name before deleting the claim.
+      // A restoration failure preserves the claim and surfaces the
+      // error so a peer (or operator) can investigate.
+      if (
+        args.rename !== undefined &&
+        typeof result.record.originalDeviceName === 'string' &&
+        result.record.originalDeviceName.length > 0
+      ) {
+        args.rename(args.deviceId, result.record.originalDeviceName);
+      }
     } else if (result.worktreeRoot !== args.worktreeRoot) {
       // Legacy claim — treat as ready, but enforce worktree ownership.
       throw new Error(`Simulator ${args.deviceId} is claimed by ${result.worktreeRoot}`);
@@ -708,18 +950,27 @@ function listIosDevices(): SimulatorDevice[] {
     .map(device => ({ id: device.udid, name: device.name, state: device.state }));
 }
 
+// Production rename: `xcrun simctl rename <device> <name>`. Throws on
+// non-zero exit so callers can handle failures (e.g., restore the
+// original name on a relabel or claim rollback).
+function defaultRename(deviceId: string, name: string): void {
+  execFileSync('xcrun', ['simctl', 'rename', deviceId, name], { stdio: 'ignore' });
+}
+
 function main(): void {
-  const [command, requestedId] = process.argv.slice(2);
+  const parsed = parseClaimArgs(process.argv.slice(2));
   const worktreeRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
     encoding: 'utf8',
   }).trim();
   const lockRoot = path.join(os.tmpdir(), 'kilo-mobile-simulator-claims');
-  if (command === 'claim') {
+  if (parsed.command === 'claim') {
     const claim = claimSimulator({
       devices: listIosDevices(),
       lockRoot,
       worktreeRoot,
-      requestedId,
+      requestedId: parsed.udid,
+      phase: parsed.phase,
+      rename: defaultRename,
       prepare: device => bootSimulator(device),
       // Production recovery reset: re-read the actual simulator state
       // at decision time (not the list-time snapshot). If the device
@@ -749,15 +1000,19 @@ function main(): void {
         return { id: deviceId, name: deviceId, state: 'Shutdown' as const };
       },
     });
-    console.log(JSON.stringify({ ...claim, worktreeRoot }));
+    const label =
+      parsed.phase !== undefined ? buildSimulatorLabel(worktreeRoot, parsed.phase) : undefined;
+    console.log(JSON.stringify({ ...claim, worktreeRoot, ...(label ? { label } : {}) }));
     return;
   }
-  if (command === 'release' && requestedId) {
-    releaseSimulator({ deviceId: requestedId, lockRoot, worktreeRoot });
-    console.log(`Released ${requestedId}`);
-    return;
-  }
-  throw new Error('Usage: pnpm dev:mobile:simulator <claim [udid]|release <udid>>');
+  // parsed.command === 'release'
+  releaseSimulator({
+    deviceId: parsed.udid,
+    lockRoot,
+    worktreeRoot,
+    rename: defaultRename,
+  });
+  console.log(`Released ${parsed.udid}`);
 }
 
 const isMain =
@@ -771,5 +1026,5 @@ if (isMain) {
   }
 }
 
-export { bootSimulator, claimSimulator, releaseSimulator };
-export type { SimulatorDevice, ClaimRecord, ClaimStatus };
+export { bootSimulator, buildSimulatorLabel, claimSimulator, parseClaimArgs, releaseSimulator };
+export type { ClaimRecord, ClaimStatus, RenameFn, SimulatorDevice, SimulatorPhase };

--- a/dev/local/mobile-workflow.test.ts
+++ b/dev/local/mobile-workflow.test.ts
@@ -252,6 +252,157 @@ test('workflow documents the shared Docker proxy exception without weakening bac
   assert.match(cli, /Refusing to share occupied worktree service ports/);
 });
 
+test('mobile verifier cannot create host-global Metro proxies', () => {
+  const verifier = fs.readFileSync('apps/mobile/.kilo/agent/mobile-e2e-verifier.md', 'utf8');
+  const runbook = fs.readFileSync('apps/mobile/e2e/AGENTS.md', 'utf8');
+
+  assert.match(verifier, /"socat": deny/);
+  assert.match(verifier, /"socat \*": deny/);
+  assert.match(verifier, /must not create.*proxies.*listeners/is);
+  assert.match(runbook, /must never map.*8081.*worktree.*Metro/is);
+  assert.match(runbook, /sole intentional host-wide proxy exception.*23750/is);
+  assert.match(runbook, /test-environment failure/i);
+  assert.match(runbook, /PID.*parent PID.*bind address.*port/is);
+});
+
+test('mobile verifier uses ownership-aware simulator phase labels', () => {
+  const verifier = fs.readFileSync('apps/mobile/.kilo/agent/mobile-e2e-verifier.md', 'utf8');
+  const runbook = fs.readFileSync('apps/mobile/e2e/AGENTS.md', 'utf8');
+
+  assert.match(verifier, /--phase (?:prewarm|verify)/);
+  assert.match(runbook, /Kilo E2E - <sanitized-worktree-basename> - <phase>/);
+  assert.match(runbook, /must not call.*simctl rename/i);
+  assert.match(runbook, /restores the original simulator name/i);
+});
+
+test('mobile verifier installs validated cached native builds', () => {
+  const verifier = fs.readFileSync('apps/mobile/.kilo/agent/mobile-e2e-verifier.md', 'utf8');
+  const runbook = fs.readFileSync('apps/mobile/e2e/AGENTS.md', 'utf8');
+
+  for (const document of [verifier, runbook]) {
+    assert.match(document, /dev:mobile:ios build <udid>/);
+    assert.match(document, /dev:mobile:android build <serial>/);
+    assert.match(document, /validated cached/i);
+  }
+  assert.doesNotMatch(runbook, /npx expo run:ios --device/);
+});
+
+test('mobile verifier handles the exact Safari external-app prompt within the shared budget', () => {
+  const verifier = fs.readFileSync('apps/mobile/.kilo/agent/mobile-e2e-verifier.md', 'utf8');
+  const runbook = fs.readFileSync('apps/mobile/e2e/AGENTS.md', 'utf8');
+
+  for (const document of [verifier, runbook]) {
+    assert.match(document, /Open this page in [“"]Kilo[”"]\?/);
+    assert.match(document, /exact.*Open.*accessibility/is);
+    assert.match(document, /five-second optional-prompt/i);
+  }
+  assert.match(runbook, /prefer.*simctl openurl.*avoid.*confirmation/is);
+});
+
+test('mobile workflow schedules bounded dependency-aware implementation waves', () => {
+  const workflow = fs.readFileSync('apps/mobile/.kilo/MOBILE_WORKFLOW.md', 'utf8');
+  const implementer = fs.readFileSync('apps/mobile/.kilo/agent/mobile-implementer.md', 'utf8');
+
+  assert.match(workflow, /two or three concurrent implementers/i);
+  assert.match(workflow, /write set/i);
+  assert.match(workflow, /producer-consumer dependency/i);
+  assert.match(workflow, /synchronization barrier/i);
+  assert.match(workflow, /repository-wide formatters.*serialized/is);
+  assert.match(implementer, /other active slices/i);
+  assert.match(implementer, /unexpected changes.*owned paths.*stop/is);
+  assert.match(implementer, /outside.*owned paths.*continue/is);
+});
+
+test('mobile workflow sizes handoffs below hard role step limits', () => {
+  const workflow = fs.readFileSync('apps/mobile/.kilo/MOBILE_WORKFLOW.md', 'utf8');
+  const implementer = fs.readFileSync('apps/mobile/.kilo/agent/mobile-implementer.md', 'utf8');
+  const reviewer = fs.readFileSync('apps/mobile/.kilo/agent/mobile-reviewer.md', 'utf8');
+  const verifier = fs.readFileSync('apps/mobile/.kilo/agent/mobile-e2e-verifier.md', 'utf8');
+
+  assert.match(workflow, /80.*50.*100/s);
+  assert.match(workflow, /75%/);
+  assert.match(workflow, /roughly 60 planned steps/i);
+  for (const role of [implementer, reviewer, verifier]) {
+    assert.match(role, /minimum complete outcome/i);
+    assert.match(role, /clean stopping rule/i);
+    assert.match(role, /safest next action/i);
+  }
+});
+
+test('mobile workflow overlaps verifier prewarming with implementation', () => {
+  const workflow = fs.readFileSync('apps/mobile/.kilo/MOBILE_WORKFLOW.md', 'utf8');
+
+  assert.match(workflow, /prewarm-only.*concurrent.*implementation/is);
+  assert.match(workflow, /fresh.*final.*mobile-e2e-verifier/is);
+  assert.match(workflow, /resource manifest/i);
+  assert.match(workflow, /must not.*acceptance.*implementation.*changing/is);
+});
+
+test('mobile workflow preserves successful slices and bounds repairs', () => {
+  const workflow = fs.readFileSync('apps/mobile/.kilo/MOBILE_WORKFLOW.md', 'utf8');
+
+  assert.match(workflow, /preserve successful independent slices/i);
+  assert.match(workflow, /two budget-exhausted invocations.*orchestrator takes over/is);
+  assert.match(workflow, /bounded repair wave/i);
+  assert.match(workflow, /fresh reviewer/i);
+});
+
+test('mobile workflow reports lightweight elapsed-time and contention metrics', () => {
+  const workflow = fs.readFileSync('apps/mobile/.kilo/MOBILE_WORKFLOW.md', 'utf8');
+
+  assert.match(workflow, /number and width of implementation waves/i);
+  assert.match(workflow, /budget exhaustion.*collision counts/is);
+  assert.match(workflow, /unmanaged listener detections/i);
+  assert.match(workflow, /prewarm reuse.*invalidation/is);
+  assert.match(workflow, /accepted-plan-to-final-E2E-start time/i);
+  assert.match(workflow, /accepted-plan-to-merged-PR time/i);
+  assert.match(workflow, /do not add persistent telemetry/i);
+});
+
+test('mobile workflow requires a conflict-free CI-green latest PR head', () => {
+  const workflow = fs.readFileSync('apps/mobile/.kilo/MOBILE_WORKFLOW.md', 'utf8');
+
+  assert.match(workflow, /mergeable.*no conflicts/i);
+  assert.match(workflow, /latest head/i);
+  assert.match(workflow, /CI checks.*successful terminal state/i);
+  assert.match(workflow, /failed.*cancelled.*timed-out.*pending/is);
+  assert.match(workflow, /base branch advances/i);
+  assert.match(workflow, /wait again.*CI.*Kilobot/is);
+});
+
+test('mobile planner hands implementation to a fresh tmux orchestrator', () => {
+  const workflow = fs.readFileSync('apps/mobile/.kilo/MOBILE_WORKFLOW.md', 'utf8');
+  const launchShape = workflow.slice(
+    workflow.indexOf('```bash\ntmux new-window'),
+    workflow.indexOf('```', workflow.indexOf('```bash\ntmux new-window') + 7)
+  );
+
+  assert.match(workflow, /planning session.*must not implement/is);
+  assert.match(workflow, /fresh orchestrator/i);
+  assert.match(workflow, /tmux new-window/);
+  assert.match(workflow, /named.*tmux window/is);
+  assert.match(workflow, /-c <dedicated-worktree>\/apps\/mobile/);
+  assert.match(workflow, /kilo run --interactive/);
+  assert.match(workflow, /--model kilo\/openai\/gpt-5\.6-sol/);
+  assert.match(workflow, /--variant medium/);
+  assert.doesNotMatch(launchShape, /(?:--continue|--session)/);
+});
+
+test('mobile planner handoff is complete and secret-free', () => {
+  const workflow = fs.readFileSync('apps/mobile/.kilo/MOBILE_WORKFLOW.md', 'utf8');
+  const handoffSection = workflow.slice(
+    workflow.indexOf('## Planner Handoff'),
+    workflow.indexOf('## Feature State Matrix')
+  );
+
+  assert.match(handoffSection, /accepted plan.*absolute path/is);
+  assert.match(handoffSection, /dedicated worktree path.*every repository/is);
+  assert.match(handoffSection, /current branch.*working-tree state/is);
+  assert.match(handoffSection, /acceptance criteria.*execution ledger/is);
+  assert.match(handoffSection, /continue through.*mergeable.*CI/is);
+  assert.match(handoffSection, /must not contain.*secrets.*environment-file/is);
+});
+
 test('mobile workflow owns PR assignment and the post-PR Kilobot repair loop', () => {
   const workflow = fs.readFileSync('apps/mobile/.kilo/MOBILE_WORKFLOW.md', 'utf8');
 

--- a/dev/local/mobile-workflow.test.ts
+++ b/dev/local/mobile-workflow.test.ts
@@ -186,12 +186,14 @@ test('Android tooling is resolved independently of the agent PATH', async () => 
   assert.match(env.path, /android-commandlinetools\/platform-tools/);
 });
 
-test('Android workflow uses Maestro first and applies resolved tooling to Expo builds', () => {
+test('Android workflow uses Maestro first and applies resolved tooling to cached native builds', () => {
   const android = fs.readFileSync('dev/local/mobile-android.ts', 'utf8');
   const runbook = fs.readFileSync('apps/mobile/e2e/AGENTS.md', 'utf8');
 
   assert.match(android, /'build'/);
-  assert.match(android, /'run:android'/);
+  assert.match(android, /runAndroidBuild/);
+  assert.match(android, /withNativeBuildSemaphore/);
+  assert.match(android, /app:assembleDebug/);
   assert.match(android, /path\.join\(worktreeRoot, 'apps\/mobile'\)/);
   assert.match(runbook, /Use Maestro as the primary Android automation driver/);
   assert.match(runbook, /Fall back to repository-wrapped ADB/);

--- a/dev/local/mobile-workflow.test.ts
+++ b/dev/local/mobile-workflow.test.ts
@@ -383,8 +383,8 @@ test('mobile planner hands implementation to a fresh tmux orchestrator', () => {
   assert.match(workflow, /named.*tmux window/is);
   assert.match(workflow, /-c <dedicated-worktree>\/apps\/mobile/);
   assert.match(workflow, /kilo run --interactive/);
-  assert.match(workflow, /--model kilo\/openai\/gpt-5\.6-sol/);
-  assert.match(workflow, /--variant medium/);
+  assert.match(workflow, /--model kilo\/kilo-auto\/frontier/);
+  assert.doesNotMatch(launchShape, /--variant/);
   assert.doesNotMatch(launchShape, /(?:--continue|--session)/);
 });
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "dev:env:mobile": "tsx dev/local/mobile-env.ts",
     "dev:mobile:simulator": "tsx dev/local/mobile-simulator.ts",
     "dev:mobile:android": "tsx dev/local/mobile-android.ts",
+    "dev:mobile:ios": "tsx dev/local/mobile-ios-build.ts",
+    "test:mobile-workflow": "tsx --test dev/local/mobile-simulator.test.ts dev/local/mobile-ios-build.test.ts dev/local/mobile-workflow.test.ts",
     "dev:setup-env": "tsx dev/local/setup-env.ts",
     "dev:seed": "tsx dev/seed/index.ts",
     "dev:discord-gateway-cron": "tsx dev/discord-gateway-cron.ts",
@@ -42,6 +44,7 @@
   },
   "packageManager": "pnpm@11.1.2",
   "devDependencies": {
+    "@expo/fingerprint": "0.16.7",
     "@types/node": "catalog:",
     "@types/proper-lockfile": "4.1.4",
     "@typescript/native-preview": "catalog:",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dev:mobile:simulator": "tsx dev/local/mobile-simulator.ts",
     "dev:mobile:android": "tsx dev/local/mobile-android.ts",
     "dev:mobile:ios": "tsx dev/local/mobile-ios-build.ts",
-    "test:mobile-workflow": "tsx --test dev/local/mobile-simulator.test.ts dev/local/mobile-ios-build.test.ts dev/local/mobile-workflow.test.ts",
+    "test:mobile-workflow": "tsx --test dev/local/mobile-simulator.test.ts dev/local/mobile-native-build.test.ts dev/local/mobile-ios-build.test.ts dev/local/mobile-android-build.test.ts dev/local/mobile-android.test.ts dev/local/mobile-workflow.test.ts",
     "dev:setup-env": "tsx dev/local/setup-env.ts",
     "dev:seed": "tsx dev/seed/index.ts",
     "dev:discord-gateway-cron": "tsx dev/discord-gateway-cron.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
 
   .:
     devDependencies:
+      '@expo/fingerprint':
+        specifier: 0.16.7
+        version: 0.16.7
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4


### PR DESCRIPTION
## Summary
- add ownership-aware simulator labels and validated native build reuse for iOS and Android
- serialize native compiler producers and harden E2E host-network isolation
- add bounded implementation waves, verifier prewarming, explicit role budgets, and a fresh gpt-5.6-sol medium-effort orchestrator handoff

## Verification
- pnpm test:mobile-workflow (209 passed)
- pnpm format:check
- pnpm lint
- scripts/typecheck-all.sh --changes-only
- git diff --check
- kilo agent list