### PR TITLE
fix(kilo-pass): grandfather pre-fingerprint welcome bonuses

### DIFF
--- a/apps/web/src/lib/kilo-pass/bonus-decision.ts
+++ b/apps/web/src/lib/kilo-pass/bonus-decision.ts
@@ -1,9 +1,9 @@
 import {
   KiloPassCadence,
-  KiloPassPaymentProvider,
   type KiloPassTier,
   KiloPassWelcomePromoEligibilityReason,
 } from '@/lib/kilo-pass/enums';
+import type { KiloPassWelcomePromoPolicy } from '@/lib/kilo-pass/welcome-promo-context';
 import {
   computeMonthlyCadenceBonusPercent,
   computeYearlyCadenceMonthlyBonusUsd,
@@ -45,16 +45,16 @@ export function computeMonthlyKiloPassBonusDecision(params: {
   startedAtIso: string | null;
   streakMonths: number;
   isFirstTimeSubscriberEver: boolean;
+  welcomePromoPolicy: KiloPassWelcomePromoPolicy;
   welcomePromoEligibilityReason?: KiloPassWelcomePromoEligibilityReason | null;
-  requiresSettledPaymentDecision?: boolean;
   issueMonth?: string;
 }): KiloPassMonthlyBonusDecision {
   const streakMonths = Math.max(1, params.streakMonths);
+  const hasRequiredPaymentEligibility =
+    params.welcomePromoPolicy === 'account-history-only' ||
+    isAllowedStripeWelcomePromoReason(params.welcomePromoEligibilityReason);
   const isEligibleForWelcomePromo =
-    params.isFirstTimeSubscriberEver &&
-    (params.requiresSettledPaymentDecision
-      ? isAllowedStripeWelcomePromoReason(params.welcomePromoEligibilityReason)
-      : true);
+    params.isFirstTimeSubscriberEver && hasRequiredPaymentEligibility;
   const bonusPercentApplied = computeMonthlyCadenceBonusPercent({
     tier: params.tier,
     streakMonths,
@@ -83,6 +83,7 @@ export function computeMonthlyKiloPassBonusDecision(params: {
         startedAt: params.startedAtIso,
         issueMonth: params.issueMonth ?? null,
         bonusPercentApplied,
+        welcomePromoPolicy: params.welcomePromoPolicy,
         welcomePromoEligibilityReason: params.welcomePromoEligibilityReason ?? null,
       },
       bonusKind,
@@ -96,7 +97,7 @@ export function computeKiloPassBonusCreditsUsd(params: {
   startedAtIso: string | null;
   streakMonths: number;
   isFirstTimeSubscriberEver: boolean;
-  paymentProvider: KiloPassPaymentProvider;
+  welcomePromoPolicy: KiloPassWelcomePromoPolicy;
   welcomePromoEligibilityReason?: KiloPassWelcomePromoEligibilityReason | null;
 }): number {
   if (params.cadence === KiloPassCadence.Yearly) {
@@ -112,9 +113,7 @@ export function computeKiloPassBonusCreditsUsd(params: {
     startedAtIso: params.startedAtIso,
     streakMonths: params.streakMonths,
     isFirstTimeSubscriberEver: params.isFirstTimeSubscriberEver,
-    requiresSettledPaymentDecision:
-      params.paymentProvider === KiloPassPaymentProvider.Stripe &&
-      params.welcomePromoEligibilityReason != null,
+    welcomePromoPolicy: params.welcomePromoPolicy,
     welcomePromoEligibilityReason: params.welcomePromoEligibilityReason,
   }).bonusUsd;
 }

--- a/apps/web/src/lib/kilo-pass/constants.ts
+++ b/apps/web/src/lib/kilo-pass/constants.ts
@@ -9,6 +9,12 @@ export {
 
 export const KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT = 0.5;
 
+// Fixed historical boundary when the settled-payment fingerprint policy reached production.
+// Changing this would retroactively change welcome-promo eligibility for existing issuances.
+export const KILO_PASS_WELCOME_PROMO_FINGERPRINT_POLICY_ROLLOUT = dayjs(
+  '2026-05-28T12:06:20.000Z'
+).utc();
+
 // First-time subscribers receive a 50% bonus for month 2 only if they started
 // strictly before this grandfather cutoff. Month 1 remains 50% for new subscribers.
 export const KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF = dayjs('2026-05-07T00:00:00Z').utc();

--- a/apps/web/src/lib/kilo-pass/usage-triggered-bonus.test.ts
+++ b/apps/web/src/lib/kilo-pass/usage-triggered-bonus.test.ts
@@ -15,6 +15,7 @@ import {
   KiloPassCadence,
   KiloPassIssuanceItemKind,
   KiloPassIssuanceSource,
+  KiloPassPaymentProvider,
   KiloPassTier,
   KiloPassWelcomePromoEligibilityReason,
 } from '@/lib/kilo-pass/enums';
@@ -36,8 +37,10 @@ async function seedBaseIssuance(params: {
   currentStreakMonths: number;
   nextYearlyIssueAt: string | null;
   startedAtIso?: string | null;
-  welcomePromoEligibilityReason?: KiloPassWelcomePromoEligibilityReason;
+  paymentProvider?: KiloPassPaymentProvider;
+  welcomePromoEligibilityReason?: KiloPassWelcomePromoEligibilityReason | null;
   initialWelcomePromoEligibilityReason?: KiloPassWelcomePromoEligibilityReason;
+  issuanceCreatedAt?: string;
 }) {
   const {
     kiloUserId,
@@ -48,17 +51,21 @@ async function seedBaseIssuance(params: {
     currentStreakMonths,
     nextYearlyIssueAt,
     startedAtIso,
+    paymentProvider = KiloPassPaymentProvider.Stripe,
     welcomePromoEligibilityReason,
     initialWelcomePromoEligibilityReason,
+    issuanceCreatedAt,
   } = params;
 
-  const stripeSubscriptionId = `sub_${Math.random()}`;
+  const providerSubscriptionId = `sub_${Math.random()}`;
   const subscriptionRow = await db
     .insert(kilo_pass_subscriptions)
     .values({
       kilo_user_id: kiloUserId,
-      provider_subscription_id: stripeSubscriptionId,
-      stripe_subscription_id: stripeSubscriptionId,
+      payment_provider: paymentProvider,
+      provider_subscription_id: providerSubscriptionId,
+      stripe_subscription_id:
+        paymentProvider === KiloPassPaymentProvider.Stripe ? providerSubscriptionId : null,
       tier,
       cadence,
       status: 'active',
@@ -91,10 +98,12 @@ async function seedBaseIssuance(params: {
       source: KiloPassIssuanceSource.StripeInvoice,
       stripe_invoice_id: stripeInvoiceId,
       initial_welcome_promo_eligibility_reason:
-        welcomePromoEligibilityReason ??
-        (cadence === KiloPassCadence.Monthly
-          ? KiloPassWelcomePromoEligibilityReason.FirstPaymentFingerprintClaim
-          : undefined),
+        welcomePromoEligibilityReason !== undefined
+          ? welcomePromoEligibilityReason
+          : cadence === KiloPassCadence.Monthly
+            ? KiloPassWelcomePromoEligibilityReason.FirstPaymentFingerprintClaim
+            : undefined,
+      ...(issuanceCreatedAt ? { created_at: issuanceCreatedAt } : {}),
     })
     .returning({ id: kilo_pass_issuances.id });
 
@@ -188,6 +197,8 @@ describe('maybeIssueKiloPassBonusFromUsageThreshold', () => {
       stripeInvoiceId: 'inv_test_monthly_referral_bonus_blocks_usage_bonus',
       currentStreakMonths: 1,
       nextYearlyIssueAt: null,
+      welcomePromoEligibilityReason: null,
+      issuanceCreatedAt: '2026-05-28T12:06:19.999Z',
     });
 
     const [referralCredit] = await db
@@ -515,6 +526,89 @@ describe('maybeIssueKiloPassBonusFromUsageThreshold', () => {
     expect(userRow?.kilo_pass_threshold).toBeNull();
   });
 
+  test('monthly: pre-gate Stripe issuance with no decision receives first-month promo', async () => {
+    const user = await insertTestUser({
+      microdollars_used: 20_000_000,
+      kilo_pass_threshold: 19_000_000,
+    });
+    const { issuanceId } = await seedBaseIssuance({
+      kiloUserId: user.id,
+      cadence: KiloPassCadence.Monthly,
+      tier: KiloPassTier.Tier19,
+      issueMonth: '2026-05-01',
+      stripeInvoiceId: 'inv_test_pre_gate_null_reason',
+      currentStreakMonths: 1,
+      nextYearlyIssueAt: null,
+      welcomePromoEligibilityReason: null,
+      issuanceCreatedAt: '2026-05-28T12:06:19.999Z',
+    });
+
+    await maybeIssueKiloPassBonusFromUsageThreshold({
+      kiloUserId: user.id,
+      nowIso: '2026-06-01T00:00:00.000Z',
+      db,
+    });
+
+    const bonusItem = await db.query.kilo_pass_issuance_items.findFirst({
+      where: and(
+        eq(kilo_pass_issuance_items.kilo_pass_issuance_id, issuanceId),
+        eq(kilo_pass_issuance_items.kind, KiloPassIssuanceItemKind.Bonus)
+      ),
+    });
+    const bonusTx = await db.query.credit_transactions.findFirst({
+      where: eq(credit_transactions.id, bonusItem?.credit_transaction_id ?? ''),
+    });
+    expect(bonusTx?.amount_microdollars).toBe(9_500_000);
+
+    const audit = await db.query.kilo_pass_audit_log.findFirst({
+      where: and(
+        eq(kilo_pass_audit_log.action, KiloPassAuditLogAction.BonusCreditsIssued),
+        eq(kilo_pass_audit_log.related_monthly_issuance_id, issuanceId)
+      ),
+    });
+    const monthlyDecision = isRecord(audit?.payload_json)
+      ? audit.payload_json.monthlyBonusDecision
+      : null;
+    expect(monthlyDecision).toEqual(
+      expect.objectContaining({ welcomePromoPolicy: 'account-history-only' })
+    );
+  });
+
+  test('monthly: Stripe issuance at gate boundary with no decision receives ramp bonus', async () => {
+    const user = await insertTestUser({
+      microdollars_used: 20_000_000,
+      kilo_pass_threshold: 19_000_000,
+    });
+    const { issuanceId } = await seedBaseIssuance({
+      kiloUserId: user.id,
+      cadence: KiloPassCadence.Monthly,
+      tier: KiloPassTier.Tier19,
+      issueMonth: '2026-05-01',
+      stripeInvoiceId: 'inv_test_at_gate_null_reason',
+      currentStreakMonths: 1,
+      nextYearlyIssueAt: null,
+      welcomePromoEligibilityReason: null,
+      issuanceCreatedAt: '2026-05-28T12:06:20.000Z',
+    });
+
+    await maybeIssueKiloPassBonusFromUsageThreshold({
+      kiloUserId: user.id,
+      nowIso: '2026-06-01T00:00:00.000Z',
+      db,
+    });
+
+    const bonusItem = await db.query.kilo_pass_issuance_items.findFirst({
+      where: and(
+        eq(kilo_pass_issuance_items.kilo_pass_issuance_id, issuanceId),
+        eq(kilo_pass_issuance_items.kind, KiloPassIssuanceItemKind.Bonus)
+      ),
+    });
+    const bonusTx = await db.query.credit_transactions.findFirst({
+      where: eq(credit_transactions.id, bonusItem?.credit_transaction_id ?? ''),
+    });
+    expect(bonusTx?.amount_microdollars).toBe(950_000);
+  });
+
   test('monthly: reused card eligibility issues regular ramp bonus instead of first-month promo', async () => {
     const user = await insertTestUser({
       microdollars_used: 20_000_000,
@@ -594,6 +688,8 @@ describe('maybeIssueKiloPassBonusFromUsageThreshold', () => {
       stripeInvoiceId: 'inv_test_monthly_zero',
       currentStreakMonths: 1,
       nextYearlyIssueAt: null,
+      welcomePromoEligibilityReason: null,
+      issuanceCreatedAt: '2026-05-28T12:06:19.999Z',
     });
 
     await maybeIssueKiloPassBonusFromUsageThreshold({

--- a/apps/web/src/lib/kilo-pass/usage-triggered-bonus.ts
+++ b/apps/web/src/lib/kilo-pass/usage-triggered-bonus.ts
@@ -28,7 +28,11 @@ import { computeMonthlyKiloPassBonusDecision } from '@/lib/kilo-pass/bonus-decis
 import { dayjs } from '@/lib/kilo-pass/dayjs';
 import { getKiloPassStateForUser, type KiloPassSubscriptionState } from '@/lib/kilo-pass/state';
 import { getEffectiveKiloPassThreshold } from '@/lib/kilo-pass/threshold';
-import { getInitialWelcomePromoEligibilityReasonForSubscription } from '@/lib/kilo-pass/welcome-promo-context';
+import {
+  getInitialWelcomePromoContextForSubscription,
+  getKiloPassWelcomePromoPolicy,
+  type KiloPassWelcomePromoPolicy,
+} from '@/lib/kilo-pass/welcome-promo-context';
 import { and, desc, eq, inArray, ne } from 'drizzle-orm';
 
 type Db = typeof defaultDb;
@@ -46,7 +50,7 @@ export function computeUsageTriggeredMonthlyBonusDecision(params: {
   startedAtIso: string | null;
   currentStreakMonths: number;
   isFirstTimeSubscriberEver: boolean;
-  requiresSettledPaymentDecision?: boolean;
+  welcomePromoPolicy: KiloPassWelcomePromoPolicy;
   welcomePromoEligibilityReason?: KiloPassWelcomePromoEligibilityReason | null;
   issueMonth: string;
 }): UsageTriggeredMonthlyBonusDecision {
@@ -55,7 +59,7 @@ export function computeUsageTriggeredMonthlyBonusDecision(params: {
     startedAtIso: params.startedAtIso,
     streakMonths: params.currentStreakMonths,
     isFirstTimeSubscriberEver: params.isFirstTimeSubscriberEver,
-    requiresSettledPaymentDecision: params.requiresSettledPaymentDecision,
+    welcomePromoPolicy: params.welcomePromoPolicy,
     welcomePromoEligibilityReason: params.welcomePromoEligibilityReason,
     issueMonth: params.issueMonth,
   });
@@ -253,21 +257,23 @@ async function maybeIssueBonusFromUsageThreshold(
       .limit(1);
 
     const isFirstTimeSubscriberEver = otherSubscription.length === 0;
-    const welcomePromoEligibilityReason =
+    const initialWelcomePromoContext =
       subscription.paymentProvider === KiloPassPaymentProvider.Stripe
-        ? await getInitialWelcomePromoEligibilityReasonForSubscription(tx, {
+        ? await getInitialWelcomePromoContextForSubscription(tx, {
             subscriptionId: subscription.subscriptionId,
           })
         : null;
+    const welcomePromoPolicy = getKiloPassWelcomePromoPolicy({
+      paymentProvider: subscription.paymentProvider,
+      initialIssuanceCreatedAt: initialWelcomePromoContext?.createdAt ?? null,
+    });
     const monthlyDecision = computeUsageTriggeredMonthlyBonusDecision({
       tier: subscription.tier,
       startedAtIso: subscription.startedAt,
       currentStreakMonths: subscription.currentStreakMonths,
       isFirstTimeSubscriberEver,
-      requiresSettledPaymentDecision:
-        subscription.paymentProvider === KiloPassPaymentProvider.Stripe &&
-        welcomePromoEligibilityReason != null,
-      welcomePromoEligibilityReason,
+      welcomePromoPolicy,
+      welcomePromoEligibilityReason: initialWelcomePromoContext?.eligibilityReason ?? null,
       issueMonth: issuance.issueMonth,
     });
 

--- a/apps/web/src/lib/kilo-pass/usage-triggered-bonus.unit.test.ts
+++ b/apps/web/src/lib/kilo-pass/usage-triggered-bonus.unit.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, test } from '@jest/globals';
 
 import { KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF } from '@/lib/kilo-pass/constants';
-import { KiloPassTier, KiloPassWelcomePromoEligibilityReason } from '@/lib/kilo-pass/enums';
+import {
+  KiloPassPaymentProvider,
+  KiloPassTier,
+  KiloPassWelcomePromoEligibilityReason,
+} from '@/lib/kilo-pass/enums';
 import {
   computeUsageTriggeredMonthlyBonusDecision,
   computeUsageTriggeredYearlyIssueMonth,
 } from '@/lib/kilo-pass/usage-triggered-bonus';
+import { getKiloPassWelcomePromoPolicy } from '@/lib/kilo-pass/welcome-promo-context';
 
 describe('usage-triggered-bonus (unit)', () => {
   describe('computeUsageTriggeredMonthlyBonusDecision', () => {
@@ -15,6 +20,7 @@ describe('usage-triggered-bonus (unit)', () => {
         startedAtIso: null,
         currentStreakMonths: 0,
         isFirstTimeSubscriberEver: false,
+        welcomePromoPolicy: 'account-history-only',
         issueMonth: '2026-01-01',
       });
 
@@ -34,6 +40,7 @@ describe('usage-triggered-bonus (unit)', () => {
         startedAtIso: '2026-01-01T00:00:00.000Z',
         currentStreakMonths: 1,
         isFirstTimeSubscriberEver: true,
+        welcomePromoPolicy: 'account-history-only',
         issueMonth: '2026-01-01',
       });
 
@@ -59,7 +66,7 @@ describe('usage-triggered-bonus (unit)', () => {
         startedAtIso: '2026-05-20T00:00:00.000Z',
         currentStreakMonths: 1,
         isFirstTimeSubscriberEver: true,
-        requiresSettledPaymentDecision: true,
+        welcomePromoPolicy: 'settled-payment-required',
         welcomePromoEligibilityReason:
           KiloPassWelcomePromoEligibilityReason.FingerprintPreviouslyClaimed,
         issueMonth: '2026-05-01',
@@ -82,7 +89,7 @@ describe('usage-triggered-bonus (unit)', () => {
           startedAtIso: '2026-05-20T00:00:00.000Z',
           currentStreakMonths: 1,
           isFirstTimeSubscriberEver: true,
-          requiresSettledPaymentDecision: true,
+          welcomePromoPolicy: 'settled-payment-required',
           welcomePromoEligibilityReason,
           issueMonth: '2026-05-01',
         });
@@ -104,7 +111,7 @@ describe('usage-triggered-bonus (unit)', () => {
           startedAtIso: '2026-05-20T00:00:00.000Z',
           currentStreakMonths: 1,
           isFirstTimeSubscriberEver: true,
-          requiresSettledPaymentDecision: true,
+          welcomePromoPolicy: 'settled-payment-required',
           welcomePromoEligibilityReason,
           issueMonth: '2026-05-01',
         });
@@ -120,6 +127,7 @@ describe('usage-triggered-bonus (unit)', () => {
         startedAtIso: '2026-01-01T00:00:00.000Z',
         currentStreakMonths: 2,
         isFirstTimeSubscriberEver: true,
+        welcomePromoPolicy: 'account-history-only',
         issueMonth: '2026-02-01',
       });
 
@@ -135,6 +143,7 @@ describe('usage-triggered-bonus (unit)', () => {
         startedAtIso: KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF.toISOString(),
         currentStreakMonths: 2,
         isFirstTimeSubscriberEver: true,
+        welcomePromoPolicy: 'account-history-only',
         issueMonth: '2026-06-01',
       });
 
@@ -142,6 +151,32 @@ describe('usage-triggered-bonus (unit)', () => {
       expect(d.bonusPercentApplied).toBe(0.1);
       expect(d.description).toBe('Kilo Pass monthly bonus (tier_49, streak=2)');
       expect(d.auditPayload).toEqual(expect.objectContaining({ bonusKind: 'monthly-ramp' }));
+    });
+  });
+
+  describe('getKiloPassWelcomePromoPolicy', () => {
+    test.each([
+      ['2026-05-28T12:06:19.999Z', 'account-history-only'],
+      ['2026-05-28T12:06:20.000Z', 'settled-payment-required'],
+      ['2026-05-28T12:06:20.001Z', 'settled-payment-required'],
+      [null, 'settled-payment-required'],
+      ['not-a-timestamp', 'settled-payment-required'],
+    ] as const)('classifies Stripe issuance created at %s as %s', (createdAt, expectedPolicy) => {
+      expect(
+        getKiloPassWelcomePromoPolicy({
+          paymentProvider: KiloPassPaymentProvider.Stripe,
+          initialIssuanceCreatedAt: createdAt,
+        })
+      ).toBe(expectedPolicy);
+    });
+
+    test('keeps App Store eligibility on account history when issuance context is missing', () => {
+      expect(
+        getKiloPassWelcomePromoPolicy({
+          paymentProvider: KiloPassPaymentProvider.AppStore,
+          initialIssuanceCreatedAt: null,
+        })
+      ).toBe('account-history-only');
     });
   });
 

--- a/apps/web/src/lib/kilo-pass/welcome-promo-context.ts
+++ b/apps/web/src/lib/kilo-pass/welcome-promo-context.ts
@@ -4,23 +4,53 @@ import { kilo_pass_issuances } from '@kilocode/db/schema';
 import { asc, eq } from 'drizzle-orm';
 
 import type { DrizzleTransaction, db as defaultDb } from '@/lib/drizzle';
-import type { KiloPassWelcomePromoEligibilityReason } from '@/lib/kilo-pass/enums';
+import {
+  KiloPassPaymentProvider,
+  type KiloPassWelcomePromoEligibilityReason,
+} from '@/lib/kilo-pass/enums';
+import { KILO_PASS_WELCOME_PROMO_FINGERPRINT_POLICY_ROLLOUT } from '@/lib/kilo-pass/constants';
+import { dayjs } from '@/lib/kilo-pass/dayjs';
 
 type Db = typeof defaultDb;
 type DbOrTx = Db | DrizzleTransaction;
 
-export async function getInitialWelcomePromoEligibilityReasonForSubscription(
+export type KiloPassWelcomePromoPolicy = 'account-history-only' | 'settled-payment-required';
+
+export type InitialWelcomePromoContext = {
+  createdAt: string;
+  eligibilityReason: KiloPassWelcomePromoEligibilityReason | null;
+};
+
+export function getKiloPassWelcomePromoPolicy(params: {
+  paymentProvider: KiloPassPaymentProvider;
+  initialIssuanceCreatedAt: string | null;
+}): KiloPassWelcomePromoPolicy {
+  if (params.paymentProvider !== KiloPassPaymentProvider.Stripe) {
+    return 'account-history-only';
+  }
+
+  if (params.initialIssuanceCreatedAt == null) return 'settled-payment-required';
+
+  const initialIssuanceCreatedAt = dayjs(params.initialIssuanceCreatedAt).utc();
+  return initialIssuanceCreatedAt.isValid() &&
+    initialIssuanceCreatedAt.isBefore(KILO_PASS_WELCOME_PROMO_FINGERPRINT_POLICY_ROLLOUT)
+    ? 'account-history-only'
+    : 'settled-payment-required';
+}
+
+export async function getInitialWelcomePromoContextForSubscription(
   db: DbOrTx,
   params: { subscriptionId: string }
-): Promise<KiloPassWelcomePromoEligibilityReason | null> {
+): Promise<InitialWelcomePromoContext | null> {
   const initialIssuance = await db
     .select({
-      welcomePromoEligibilityReason: kilo_pass_issuances.initial_welcome_promo_eligibility_reason,
+      createdAt: kilo_pass_issuances.created_at,
+      eligibilityReason: kilo_pass_issuances.initial_welcome_promo_eligibility_reason,
     })
     .from(kilo_pass_issuances)
     .where(eq(kilo_pass_issuances.kilo_pass_subscription_id, params.subscriptionId))
     .orderBy(asc(kilo_pass_issuances.issue_month))
     .limit(1);
 
-  return initialIssuance[0]?.welcomePromoEligibilityReason ?? null;
+  return initialIssuance[0] ?? null;
 }

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -853,13 +853,20 @@ describe('kiloPassRouter', () => {
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-get-state-monthly@example.com',
       });
-      await insertSubscription({
+      const { id: subscriptionId } = await insertSubscription({
         kiloUserId: user.id,
         stripeSubscriptionId: 'sub_test_monthly',
         tier: KiloPassTier.Tier19,
         cadence: KiloPassCadence.Monthly,
         status: 'active',
         currentStreakMonths: 0,
+      });
+      await insertBaseCreditsIssuance({
+        subscriptionId,
+        kiloUserId: user.id,
+        stripeInvoiceId: 'in_test_monthly_initial',
+        welcomePromoEligibilityReason:
+          KiloPassWelcomePromoEligibilityReason.FirstPaymentFingerprintClaim,
       });
 
       const caller = await createCallerForUser(user.id);
@@ -1452,7 +1459,7 @@ describe('kiloPassRouter', () => {
         google_user_email: 'kilo-pass-get-state-monthly-grandfathered-month2-next@example.com',
       });
 
-      await insertSubscription({
+      const { id: subscriptionId } = await insertSubscription({
         kiloUserId: user.id,
         stripeSubscriptionId: 'sub_test_monthly_grandfathered_month2_next',
         tier: KiloPassTier.Tier19,
@@ -1460,6 +1467,14 @@ describe('kiloPassRouter', () => {
         status: 'active',
         currentStreakMonths: 1,
         startedAt: '2026-01-01T00:00:00.000Z',
+      });
+      await insertBaseCreditsIssuance({
+        subscriptionId,
+        kiloUserId: user.id,
+        issueMonth: '2026-01-01',
+        stripeInvoiceId: 'in_test_monthly_grandfathered_month2_next_initial',
+        welcomePromoEligibilityReason:
+          KiloPassWelcomePromoEligibilityReason.FirstPaymentFingerprintClaim,
       });
 
       const caller = await createCallerForUser(user.id);

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -48,6 +48,7 @@ import {
 import {
   KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_BONUS_PERCENT,
   KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF,
+  KILO_PASS_WELCOME_PROMO_FINGERPRINT_POLICY_ROLLOUT,
 } from '@/lib/kilo-pass/constants';
 
 import { insertTestUser } from '@/tests/helpers/user.helper';
@@ -1471,6 +1472,76 @@ describe('kiloPassRouter', () => {
 
       expect(result.subscription?.nextBonusCreditsUsd).toBe(expectedNextBonusUsd);
     });
+
+    it.each([
+      {
+        label: 'before the fingerprint-policy rollout',
+        issuanceCreatedAt: new Date(
+          KILO_PASS_WELCOME_PROMO_FINGERPRINT_POLICY_ROLLOUT.valueOf() - 1
+        ).toISOString(),
+        expectedCurrentPercent: 0.5,
+        expectedNextPercent: 0.5,
+      },
+      {
+        label: 'at the fingerprint-policy rollout',
+        issuanceCreatedAt: KILO_PASS_WELCOME_PROMO_FINGERPRINT_POLICY_ROLLOUT.toISOString(),
+        expectedCurrentPercent: 0.05,
+        expectedNextPercent: 0.1,
+      },
+    ])(
+      'projects Stripe bonuses from initial issuance policy $label',
+      async ({ issuanceCreatedAt, expectedCurrentPercent, expectedNextPercent }) => {
+        const stripeMock = getStripeMock();
+        const currentPeriodEndSeconds = 1_700_123_456;
+        const currentPeriodStartSeconds = currentPeriodEndSeconds - 2_592_000;
+        const suffix = issuanceCreatedAt.replaceAll(/[^0-9]/g, '');
+        const stripeSubscriptionId = `sub_test_welcome_policy_${suffix}`;
+        stripeMock.subscriptions.retrieve.mockResolvedValue({
+          id: stripeSubscriptionId,
+          status: 'active',
+          items: {
+            data: [
+              {
+                current_period_end: currentPeriodEndSeconds,
+                current_period_start: currentPeriodStartSeconds,
+              },
+            ],
+          },
+        });
+
+        const user = await insertTestUser({
+          google_user_email: `kilo-pass-welcome-policy-${suffix}@example.com`,
+        });
+        const { id: subscriptionId } = await insertSubscription({
+          kiloUserId: user.id,
+          stripeSubscriptionId,
+          tier: KiloPassTier.Tier19,
+          cadence: KiloPassCadence.Monthly,
+          status: 'active',
+          currentStreakMonths: 1,
+          startedAt: '2026-01-01T00:00:00.000Z',
+        });
+        await insertBaseCreditsIssuance({
+          subscriptionId,
+          kiloUserId: user.id,
+          issueMonth: '2026-01-01',
+          stripeInvoiceId: `in_test_welcome_policy_${suffix}`,
+          createdAt: issuanceCreatedAt,
+        });
+
+        const caller = await createCallerForUser(user.id);
+        const result = await caller.kiloPass.getState();
+        const baseAmountUsd = getMonthlyPriceUsd(KiloPassTier.Tier19);
+
+        expect(result.subscription).toEqual(
+          expect.objectContaining({
+            currentPeriodBonusCreditsUsd:
+              Math.round(baseAmountUsd * expectedCurrentPercent * 100) / 100,
+            nextBonusCreditsUsd: Math.round(baseAmountUsd * expectedNextPercent * 100) / 100,
+          })
+        );
+      }
+    );
 
     it('predicts monthly nextBonusCreditsUsd with ramp for reused-card month 2', async () => {
       const stripeMock = getStripeMock();

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -80,7 +80,11 @@ import { closePauseEvent } from '@/lib/kilo-pass/pause-events';
 import { getAllMobileStoreKiloPassProducts } from '@/lib/kilo-pass/mobile-store-products';
 import { verifyAppleKiloPassTransactionJws } from '@/lib/kilo-pass/apple-store-verifier';
 import { completeStoreKiloPassPurchase } from '@/lib/kilo-pass/store-subscription-completion';
-import { getInitialWelcomePromoEligibilityReasonForSubscription } from '@/lib/kilo-pass/welcome-promo-context';
+import {
+  getInitialWelcomePromoContextForSubscription,
+  getKiloPassWelcomePromoPolicy,
+  type KiloPassWelcomePromoPolicy,
+} from '@/lib/kilo-pass/welcome-promo-context';
 import { sentryLogger } from '@/lib/utils.server';
 
 const logHostingActivationInfo = sentryLogger('kilo-pass-hosting-activation', 'info');
@@ -333,6 +337,7 @@ function getNextBillingAtFromSubscriptionStart(subscription: {
 function getNextKiloPassBonusCreditsUsd(params: {
   subscription: KiloPassSubscriptionState;
   isFirstTimeSubscriberEver: boolean;
+  welcomePromoPolicy: KiloPassWelcomePromoPolicy;
   welcomePromoEligibilityReason: KiloPassWelcomePromoEligibilityReason | null;
 }): number {
   return computeKiloPassBonusCreditsUsd({
@@ -341,7 +346,7 @@ function getNextKiloPassBonusCreditsUsd(params: {
     startedAtIso: params.subscription.startedAt,
     streakMonths: Math.max(1, params.subscription.currentStreakMonths + 1),
     isFirstTimeSubscriberEver: params.isFirstTimeSubscriberEver,
-    paymentProvider: params.subscription.paymentProvider,
+    welcomePromoPolicy: params.welcomePromoPolicy,
     welcomePromoEligibilityReason: params.welcomePromoEligibilityReason,
   });
 }
@@ -349,6 +354,7 @@ function getNextKiloPassBonusCreditsUsd(params: {
 function getCurrentKiloPassBonusCreditsUsd(params: {
   subscription: KiloPassSubscriptionState;
   isFirstTimeSubscriberEver: boolean;
+  welcomePromoPolicy: KiloPassWelcomePromoPolicy;
   welcomePromoEligibilityReason: KiloPassWelcomePromoEligibilityReason | null;
 }): number {
   return computeKiloPassBonusCreditsUsd({
@@ -357,7 +363,7 @@ function getCurrentKiloPassBonusCreditsUsd(params: {
     startedAtIso: params.subscription.startedAt,
     streakMonths: Math.max(1, params.subscription.currentStreakMonths),
     isFirstTimeSubscriberEver: params.isFirstTimeSubscriberEver,
-    paymentProvider: params.subscription.paymentProvider,
+    welcomePromoPolicy: params.welcomePromoPolicy,
     welcomePromoEligibilityReason: params.welcomePromoEligibilityReason,
   });
 }
@@ -707,14 +713,18 @@ async function buildActiveKiloPassSubscriptionState(params: {
     kiloUserId: params.kiloUserId,
     subscriptionId: params.subscription.subscriptionId,
   });
-  const [isBonusUnlocked, baseCreditsIssuedAtIso, welcomePromoEligibilityReason] =
-    await Promise.all([
-      getIsBonusUnlockedForSubscriptionId(params.subscription.subscriptionId),
-      getBaseCreditsIssuedAtForSubscription(params.subscription.subscriptionId),
-      getInitialWelcomePromoEligibilityReasonForSubscription(db, {
-        subscriptionId: params.subscription.subscriptionId,
-      }),
-    ]);
+  const [isBonusUnlocked, baseCreditsIssuedAtIso, initialWelcomePromoContext] = await Promise.all([
+    getIsBonusUnlockedForSubscriptionId(params.subscription.subscriptionId),
+    getBaseCreditsIssuedAtForSubscription(params.subscription.subscriptionId),
+    getInitialWelcomePromoContextForSubscription(db, {
+      subscriptionId: params.subscription.subscriptionId,
+    }),
+  ]);
+  const welcomePromoPolicy = getKiloPassWelcomePromoPolicy({
+    paymentProvider: params.subscription.paymentProvider,
+    initialIssuanceCreatedAt: initialWelcomePromoContext?.createdAt ?? null,
+  });
+  const welcomePromoEligibilityReason = initialWelcomePromoContext?.eligibilityReason ?? null;
   const usageStartInclusiveIso = getUsageStartInclusiveIso({
     subscription: params.subscription,
     baseCreditsIssuedAtIso,
@@ -732,6 +742,7 @@ async function buildActiveKiloPassSubscriptionState(params: {
     nextBonusCreditsUsd: getNextKiloPassBonusCreditsUsd({
       subscription: params.subscription,
       isFirstTimeSubscriberEver,
+      welcomePromoPolicy,
       welcomePromoEligibilityReason,
     }),
     nextBillingAt: params.nextBillingAt,
@@ -742,6 +753,7 @@ async function buildActiveKiloPassSubscriptionState(params: {
     currentPeriodBonusCreditsUsd: getCurrentKiloPassBonusCreditsUsd({
       subscription: params.subscription,
       isFirstTimeSubscriberEver,
+      welcomePromoPolicy,
       welcomePromoEligibilityReason,
     }),
     isBonusUnlocked,


### PR DESCRIPTION
## Summary
Restore the 50% Kilo Pass welcome bonus for eligible first-time Stripe subscriptions whose initial issuance predates the payment-fingerprint rollout.

### Why this change is needed
The settled-payment fingerprint gate was intended to apply only to new subscriptions after its production rollout. Existing subscriptions could have a null eligibility reason because that value was not recorded previously. Treating those subscriptions under the new policy caused some eligible customers to receive the normal ramp bonus instead of the welcome bonus.

### How this is addressed
- Classify welcome-promo policy from the initial issuance creation time using the fixed production rollout boundary.
- Preserve account-history-only eligibility for pre-rollout Stripe issuances and non-Stripe subscriptions.
- Require an affirmative settled-payment decision for Stripe issuances created at or after rollout, including missing or invalid context.
- Use the same explicit policy for issued bonuses and current/next API projections.
- Record the selected policy in bonus audit data.
- Cover rollout boundaries, prior-subscription and referral exclusions, Apple behavior, and projected bonus amounts.

## Human Verification
- Local code review completed across security, types, data, resources, React, style, and test-quality lenses.
- Focused Jest suites were attempted but could not run because the local PostgreSQL service was unavailable and Docker was not running.

## Reviewer Notes
### Human Reviewer Flags
- The compatibility boundary is the initial issuance `created_at`, strictly before `2026-05-28T12:06:20.000Z`. This timestamp is fixed historical production data and must not move.
- Missing or invalid initial issuance context fails closed for Stripe.
- An unrelated existing sequential database lookup reported by React Doctor was left unchanged to keep this fix scoped.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `welcomePromoPolicy` is required at the shared decision boundary, preventing null eligibility reasons from implicitly selecting policy.
- The initial issuance context loader returns both `created_at` and the persisted settled-payment reason.
- Referral precedence, first-ever-subscriber checks, duplicate-card protection, cadence handling, and idempotency remain unchanged.
- Typecheck and lint passed. Database-backed Jest assertions did not execute because test setup could not connect to PostgreSQL.

</details>
