### PR TITLE
Consolidate OpenCode reasoning mutation logs

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/fixOpenCodeDuplicateReasoning.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/fixOpenCodeDuplicateReasoning.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { fixOpenCodeDuplicateReasoning } from '@/lib/ai-gateway/providers/fixOpenCodeDuplicateReasoning';
 import { ReasoningDetailType } from '@/lib/ai-gateway/custom-llm/reasoning-details';
 import type { OpenRouterChatCompletionRequest } from '@/lib/ai-gateway/providers/openrouter/types';
@@ -22,6 +22,10 @@ function getReasoningDetails(request: OpenRouterChatCompletionRequest) {
 }
 
 describe('fixOpenCodeDuplicateReasoning', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('deduplicates reasoning items with empty text but identical signatures', () => {
     const signature = 'Eu8BClkIDRgCKkBlUUZG1kCXFO+sample+signature==';
     const request = makeRequest([
@@ -114,5 +118,48 @@ describe('fixOpenCodeDuplicateReasoning', () => {
     fixOpenCodeDuplicateReasoning('anthropic/claude-opus-4.7', request, 'test-session');
 
     expect(getReasoningDetails(request)).toHaveLength(0);
+  });
+
+  it('logs once after mutating a request', () => {
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => undefined);
+    const request = makeRequest([
+      { type: ReasoningDetailType.Encrypted, data: 'encrypted-blob' },
+      { type: ReasoningDetailType.Encrypted, data: 'encrypted-blob' },
+      {
+        text: 'hello',
+        type: ReasoningDetailType.Text,
+        format: 'anthropic-claude-v1',
+        signature: 'sig-a',
+      },
+      {
+        text: 'hello',
+        type: ReasoningDetailType.Text,
+        format: 'anthropic-claude-v1',
+        signature: 'sig-b',
+      },
+    ]);
+
+    fixOpenCodeDuplicateReasoning('anthropic/claude-opus-4.7', request, 'test-session');
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[fixOpenCodeDuplicateReasoning] removed duplicate or invalid reasoning, model: anthropic/claude-opus-4.7, session: test-session'
+    );
+  });
+
+  it('does not log when the request is unchanged', () => {
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => undefined);
+    const request = makeRequest([
+      {
+        text: 'hello',
+        type: ReasoningDetailType.Text,
+        format: 'anthropic-claude-v1',
+        signature: 'sig-a',
+      },
+    ]);
+
+    fixOpenCodeDuplicateReasoning('anthropic/claude-opus-4.7', request, 'test-session');
+
+    expect(debugSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/fixOpenCodeDuplicateReasoning.ts
+++ b/apps/web/src/lib/ai-gateway/providers/fixOpenCodeDuplicateReasoning.ts
@@ -12,9 +12,7 @@ export function fixOpenCodeDuplicateReasoning(
 ) {
   // workaround for @openrouter/ai-sdk-provider v1 duplicating reasoning
   // possibly fixed in https://github.com/OpenRouterTeam/ai-sdk-provider/pull/344/
-  console.debug(
-    `[fixOpenCodeDuplicateReasoning] start, model: ${requestedModel}, session: ${sessionId || 'unknown'}`
-  );
+  let requestMutated = false;
   for (const msg of request.messages) {
     const msgWithReasoning = msg as MessageWithReasoning;
     if (!msgWithReasoning.reasoning_details) {
@@ -29,32 +27,24 @@ export function fixOpenCodeDuplicateReasoning(
           encryptedDataSet.add(rd.data);
           return true;
         }
-        console.debug(
-          `[fixOpenCodeDuplicateReasoning] removing duplicated encrypted reasoning, model: ${requestedModel}, session: ${sessionId || 'unknown'}`
-        );
+        requestMutated = true;
         return false;
       }
       if (rd.type === ReasoningDetailType.Text) {
         if (isClaudeModel(requestedModel) && !rd.signature) {
-          console.debug(
-            `[fixOpenCodeDuplicateReasoning] removing reasoning text without signature, model: ${requestedModel}, session: ${sessionId || 'unknown'}`
-          );
+          requestMutated = true;
           return false;
         }
         if (rd.signature) {
           if (signatureSet.has(rd.signature)) {
-            console.debug(
-              `[fixOpenCodeDuplicateReasoning] removing duplicated reasoning signature, model: ${requestedModel}, session: ${sessionId || 'unknown'}`
-            );
+            requestMutated = true;
             return false;
           }
           signatureSet.add(rd.signature);
         }
         if (rd.text) {
           if (textSet.has(rd.text)) {
-            console.debug(
-              `[fixOpenCodeDuplicateReasoning] removing duplicated reasoning text, model: ${requestedModel}, session: ${sessionId || 'unknown'}`
-            );
+            requestMutated = true;
             return false;
           }
           textSet.add(rd.text);
@@ -63,5 +53,10 @@ export function fixOpenCodeDuplicateReasoning(
       }
       return true;
     });
+  }
+  if (requestMutated) {
+    console.debug(
+      `[fixOpenCodeDuplicateReasoning] removed duplicate or invalid reasoning, model: ${requestedModel}, session: ${sessionId || 'unknown'}`
+    );
   }
 }


### PR DESCRIPTION
## Summary
- remove per-item and unconditional logging from fixOpenCodeDuplicateReasoning
- emit one debug log after processing only when the request was mutated
- cover mutated and unchanged logging behavior

## Verification
- `pnpm exec oxfmt --check apps/web/src/lib/ai-gateway/providers/fixOpenCodeDuplicateReasoning.ts apps/web/src/lib/ai-gateway/providers/fixOpenCodeDuplicateReasoning.test.ts`
- `git diff --check`
- focused Jest suite attempted but blocked by unavailable PostgreSQL in shared test setup