### PR TITLE
fix(kilo-pass): align displayed usage with bonus eligibility

### DIFF
--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -427,6 +427,7 @@ async function insertBaseCreditsIssuance(params: {
   issueMonth?: string;
   stripeInvoiceId?: string;
   createdAt?: string;
+  usageBaselineMicrodollars?: number | null;
 }): Promise<void> {
   const issuedMonth = new Date().toISOString().slice(0, 7);
   const issueMonth = params.issueMonth ?? `${issuedMonth}-01`;
@@ -455,6 +456,7 @@ async function insertBaseCreditsIssuance(params: {
       amount_microdollars: 1_000_000,
       is_free: false,
       description: `kilo-pass-base-test-${Date.now()}`,
+      original_baseline_microdollars_used: params.usageBaselineMicrodollars,
       created_at: params.createdAt,
     })
     .returning({ id: credit_transactions.id });
@@ -1001,7 +1003,7 @@ describe('kiloPassRouter', () => {
       );
     });
 
-    it('uses the latest App Store purchase period and reports current usage, hosting, and bonus', async () => {
+    it('reports qualifying credit spend from the base-credit usage baseline', async () => {
       freezeKiloPassClock('2026-02-15T12:00:00.000Z');
 
       const user = await insertTestUser({
@@ -1061,6 +1063,7 @@ describe('kiloPassRouter', () => {
           is_free: false,
           description: 'Kilo Pass base credits (tier_19, monthly)',
           credit_category: 'kilo-pass-store-test-base',
+          original_baseline_microdollars_used: 10_000_000,
           created_at: baseCreditsIssuedAt,
         })
         .returning({ id: credit_transactions.id });
@@ -1111,6 +1114,34 @@ describe('kiloPassRouter', () => {
         created_at: '2026-02-10T00:00:00.000Z',
       });
 
+      await db.insert(credit_transactions).values([
+        {
+          id: crypto.randomUUID(),
+          kilo_user_id: user.id,
+          amount_microdollars: -2_500_000,
+          is_free: false,
+          description: 'Coding plan test deduction',
+          credit_category: 'coding-plan:test-get-state',
+          original_baseline_microdollars_used: 16_750_000,
+          created_at: '2026-02-11T00:00:00.000Z',
+        },
+        {
+          id: crypto.randomUUID(),
+          kilo_user_id: user.id,
+          amount_microdollars: -4_000_000,
+          is_free: false,
+          description: 'Balance-neutral test deduction',
+          credit_category: 'balance-neutral:test-get-state',
+          original_baseline_microdollars_used: 19_250_000,
+          created_at: '2026-02-12T00:00:00.000Z',
+        },
+      ]);
+
+      await db
+        .update(kilocode_users)
+        .set({ microdollars_used: 19_250_000 })
+        .where(eq(kilocode_users.id, user.id));
+
       const caller = await createCallerForUser(user.id);
       const result = await caller.kiloPass.getState();
 
@@ -1131,7 +1162,7 @@ describe('kiloPassRouter', () => {
           nextBillingAt: expiresAt,
           refillAt: expiresAt,
           currentPeriodBaseCreditsUsd: baseAmountUsd,
-          currentPeriodUsageUsd: 6.75,
+          currentPeriodUsageUsd: 9.25,
           currentPeriodHostingCostUsd: 1.5,
           currentPeriodBonusCreditsUsd: currentBonusUsd,
         })
@@ -1212,6 +1243,7 @@ describe('kiloPassRouter', () => {
           description: 'Kilo Pass upgrade base credits (tier_49, monthly)',
           credit_category:
             'kilo-pass-upgrade-base:app_store:tx_get_state_app_store_upgrade_usage_replacement',
+          original_baseline_microdollars_used: 7_000_000,
           created_at: '2026-05-16T00:00:00.000Z',
         })
         .returning({ id: credit_transactions.id });
@@ -1251,6 +1283,11 @@ describe('kiloPassRouter', () => {
           created_at: '2026-05-17T00:00:00.000Z',
         },
       ]);
+
+      await db
+        .update(kilocode_users)
+        .set({ microdollars_used: 10_000_000 })
+        .where(eq(kilocode_users.id, user.id));
 
       const caller = await createCallerForUser(user.id);
       const result = await caller.kiloPass.getState();
@@ -1840,7 +1877,7 @@ describe('kiloPassRouter', () => {
       const nowIso = new Date().toISOString();
       const nextYearlyIssueAtIso = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
 
-      await insertSubscription({
+      const { id: subscriptionId } = await insertSubscription({
         kiloUserId: user.id,
         stripeSubscriptionId: 'sub_test_yearly_usage_window',
         tier: KiloPassTier.Tier49,
@@ -1849,6 +1886,15 @@ describe('kiloPassRouter', () => {
         currentStreakMonths: 0,
         nextYearlyIssueAt: nextYearlyIssueAtIso,
         startedAt: nowIso,
+      });
+
+      await insertBaseCreditsIssuance({
+        subscriptionId,
+        kiloUserId: user.id,
+        issueMonth: nowIso.slice(0, 7) + '-01',
+        stripeInvoiceId: 'in_test_yearly_usage_window',
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 10).toISOString(),
+        usageBaselineMicrodollars: 10_000_000,
       });
 
       // Outside monthly bonus window
@@ -1875,10 +1921,15 @@ describe('kiloPassRouter', () => {
         created_at: new Date(Date.now() - 1000 * 60 * 60 * 24 * 10).toISOString(),
       });
 
+      await db
+        .update(kilocode_users)
+        .set({ microdollars_used: 15_000_000 })
+        .where(eq(kilocode_users.id, user.id));
+
       const caller = await createCallerForUser(user.id);
       const result = await caller.kiloPass.getState();
 
-      // Only the in-window $5.00 should be counted.
+      // The current monthly base baseline excludes the earlier $10 and includes the later $5.
       expect(result.subscription?.currentPeriodUsageUsd).toBe(5);
     });
   });

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -28,6 +28,7 @@ import {
   kilo_pass_scheduled_changes,
   kilo_pass_store_purchases,
   kilo_pass_subscriptions,
+  kilocode_users,
   kiloclaw_instances,
   kiloclaw_subscriptions,
   microdollar_usage,
@@ -460,17 +461,22 @@ async function getIsBonusUnlockedForSubscriptionId(subscriptionId: string): Prom
 }
 
 /**
- * Get the timestamp when base credits were issued for the most recent issuance of a subscription.
+ * Get the credit transaction for the most recent base issuance of a subscription.
  *
  * The Kilo Pass usage window should start from when base credits were actually issued (via the
  * invoice.paid webhook), not from Stripe's `current_period_start`. There is often a gap between
  * these two timestamps during which usage is served from pre-existing credits, not pass credits.
+ * Its cumulative-usage baseline is the canonical start for bonus-qualifying usage.
  */
-async function getBaseCreditsIssuedAtForSubscription(
-  subscriptionId: string
-): Promise<string | null> {
+async function getLatestBaseCreditsForSubscription(subscriptionId: string): Promise<{
+  issuedAtIso: string;
+  usageBaselineMicrodollars: number | null;
+} | null> {
   const rows = await db
-    .select({ createdAt: credit_transactions.created_at })
+    .select({
+      createdAt: credit_transactions.created_at,
+      usageBaselineMicrodollars: credit_transactions.original_baseline_microdollars_used,
+    })
     .from(kilo_pass_issuance_items)
     .innerJoin(
       kilo_pass_issuances,
@@ -493,7 +499,12 @@ async function getBaseCreditsIssuedAtForSubscription(
   if (!row?.createdAt) return null;
 
   const parsed = dayjs(row.createdAt).utc();
-  return parsed.isValid() ? parsed.toISOString() : null;
+  if (!parsed.isValid()) return null;
+
+  return {
+    issuedAtIso: parsed.toISOString(),
+    usageBaselineMicrodollars: row.usageBaselineMicrodollars,
+  };
 }
 
 async function getKiloPassIssuanceCreditHistoryRows(
@@ -675,16 +686,19 @@ async function getCurrentPeriodSpendUsd(params: {
   kiloUserId: string;
   startInclusiveIso: string;
   endExclusiveIso: string;
+  usageBaselineMicrodollars: number | null;
 }): Promise<{
   currentPeriodUsageUsd: number;
   currentPeriodHostingCostUsd: number;
 }> {
-  const [currentPeriodInferenceUsageUsd, currentPeriodHostingCostUsdValue] = await Promise.all([
-    getCurrentPeriodUsageUsd({
-      kiloUserId: params.kiloUserId,
-      startInclusiveIso: params.startInclusiveIso,
-      endExclusiveIso: params.endExclusiveIso,
-    }),
+  const [userRows, currentPeriodHostingCostUsdValue] = await Promise.all([
+    params.usageBaselineMicrodollars === null
+      ? Promise.resolve([])
+      : db
+          .select({ microdollarsUsed: kilocode_users.microdollars_used })
+          .from(kilocode_users)
+          .where(eq(kilocode_users.id, params.kiloUserId))
+          .limit(1),
     getCurrentPeriodHostingCostUsd({
       kiloUserId: params.kiloUserId,
       startInclusiveIso: params.startInclusiveIso,
@@ -692,10 +706,24 @@ async function getCurrentPeriodSpendUsd(params: {
     }),
   ]);
 
+  const currentMicrodollarsUsed = userRows[0]?.microdollarsUsed;
+  // Bonus issuance is driven by this same cumulative usage counter. Its delta from the
+  // base-credit transaction baseline includes every qualifying credit-funded product.
+  const currentPeriodUsageUsd =
+    params.usageBaselineMicrodollars !== null && currentMicrodollarsUsed !== undefined
+      ? roundToCents(
+          fromMicrodollars(Math.max(0, currentMicrodollarsUsed - params.usageBaselineMicrodollars))
+        )
+      : await getCurrentPeriodUsageUsd({
+          kiloUserId: params.kiloUserId,
+          startInclusiveIso: params.startInclusiveIso,
+          endExclusiveIso: params.endExclusiveIso,
+        }).then(inferenceUsageUsd =>
+          roundToCents(inferenceUsageUsd + currentPeriodHostingCostUsdValue)
+        );
+
   return {
-    currentPeriodUsageUsd: roundToCents(
-      currentPeriodInferenceUsageUsd + currentPeriodHostingCostUsdValue
-    ),
+    currentPeriodUsageUsd,
     currentPeriodHostingCostUsd: currentPeriodHostingCostUsdValue,
   };
 }
@@ -713,9 +741,9 @@ async function buildActiveKiloPassSubscriptionState(params: {
     kiloUserId: params.kiloUserId,
     subscriptionId: params.subscription.subscriptionId,
   });
-  const [isBonusUnlocked, baseCreditsIssuedAtIso, initialWelcomePromoContext] = await Promise.all([
+  const [isBonusUnlocked, latestBaseCredits, initialWelcomePromoContext] = await Promise.all([
     getIsBonusUnlockedForSubscriptionId(params.subscription.subscriptionId),
-    getBaseCreditsIssuedAtForSubscription(params.subscription.subscriptionId),
+    getLatestBaseCreditsForSubscription(params.subscription.subscriptionId),
     getInitialWelcomePromoContextForSubscription(db, {
       subscriptionId: params.subscription.subscriptionId,
     }),
@@ -727,7 +755,7 @@ async function buildActiveKiloPassSubscriptionState(params: {
   const welcomePromoEligibilityReason = initialWelcomePromoContext?.eligibilityReason ?? null;
   const usageStartInclusiveIso = getUsageStartInclusiveIso({
     subscription: params.subscription,
-    baseCreditsIssuedAtIso,
+    baseCreditsIssuedAtIso: latestBaseCredits?.issuedAtIso ?? null,
     periodStartIso: params.periodStartIso,
     nowUtc: params.nowUtc,
   });
@@ -735,6 +763,7 @@ async function buildActiveKiloPassSubscriptionState(params: {
     kiloUserId: params.kiloUserId,
     startInclusiveIso: usageStartInclusiveIso,
     endExclusiveIso: params.spendEndExclusiveIso,
+    usageBaselineMicrodollars: latestBaseCredits?.usageBaselineMicrodollars ?? null,
   });
 
   return {


### PR DESCRIPTION
## Summary
Align Kilo Pass usage progress with the cumulative usage that determines bonus eligibility.

### Why this change is needed
The Kilo Pass display reconstructed usage from inference records and selected KiloClaw transactions, while bonus issuance uses the user's cumulative usage counter. Credit-funded purchases such as Coding Plans could therefore unlock a bonus without advancing the displayed progress.

### How this is addressed
- Calculate current-period qualifying usage from the cumulative usage counter and the baseline captured when base credits were issued.
- Preserve the existing timestamp-based calculation for legacy base-credit records without a usage baseline.
- Continue reporting KiloClaw hosting separately without double-counting it in total usage.
- Cover Coding Plan-style spend, balance-neutral deductions, App Store upgrades, and yearly monthly issuance baselines.

## Human Verification
- Reviewed the behavior against the Kilo Pass cumulative threshold and issuance rules.
- Ran the local code-quality review workflow; accepted Security and Data reviews found no issues, while the remaining focuses were blocked by reviewer response-format errors rather than code findings.

## Reviewer Notes
### Human Reviewer Flags
- The display now treats the cumulative usage counter as authoritative, matching bonus issuance and avoiding a product-category allowlist.
- Legacy records without an issuance baseline retain the existing query path.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- The normal path replaces the inference usage aggregation with a user-counter lookup.
- KiloClaw hosting remains a separate breakdown and is not added twice.
- Typecheck, lint, formatting, and diff checks passed.
- The targeted database-backed router suite could not run because PostgreSQL was unavailable locally.

</details>
