### PR TITLE
chore(session-ingest): bump direct ingest percent to 75

### DIFF
--- a/services/session-ingest/wrangler.jsonc
+++ b/services/session-ingest/wrangler.jsonc
@@ -21,7 +21,7 @@
     "mode": "smart",
   },
   "vars": {
-    "DIRECT_INGEST_PERCENT": "50",
+    "DIRECT_INGEST_PERCENT": "75",
     "DIRECT_INGEST_USER_IDS": "f1a848ca-bade-48d8-a5ad-1042d08651e6",
     "DIRECT_INGEST_MAX_BYTES": "4194304",
   },


### PR DESCRIPTION
## Summary

Bump the session-ingest `DIRECT_INGEST_PERCENT` var from 50 to 75 in `services/session-ingest/wrangler.jsonc`, continuing the gradual rollout of the direct-ingest path for non-allowlisted users.

## Verification

- [ ] Confirm production traffic mix after deploy via the `direct_ingest_legacy` / `direct_ingest_ok` log events settles near the new percentage.

## Visual Changes

N/A — runtime config change only.

## Reviewer Notes

- Single-line var change in `services/session-ingest/wrangler.jsonc`; no code, schema, or test changes.
- Follow-up to #4560 (20% → 50%). The allowlist in `DIRECT_INGEST_USER_IDS` is unchanged, so previously eligible users remain on the direct path.