### PR TITLE
fix(review-memory): stop validating output against caps stripped from wire schema

### DIFF
--- a/apps/web/src/lib/code-reviews/review-memory/change-request.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/change-request.ts
@@ -169,11 +169,19 @@ export async function approveAndOpenReviewMemoryChangeRequest(input: {
     if (!opened) throw new Error('Failed to mark proposal change request opened.');
     return opened;
   } catch (error) {
-    await markProposalChangeRequestFailed({ proposalId: proposal.id });
-    throw new ReviewMemoryChangeRequestError(
-      'BAD_REQUEST',
-      redactSensitiveErrorMessage(error instanceof Error ? error.message : String(error))
+    const message = redactSensitiveErrorMessage(
+      error instanceof Error ? error.message : String(error)
     );
+    // Log before collapsing into BAD_REQUEST so failures are diagnosable from the log
+    // drain instead of requiring a DB dive (the error is otherwise never surfaced).
+    console.error('[review-memory] approveAndOpenChangeRequest failed', {
+      proposalId: proposal.id,
+      ownerType: input.owner.type,
+      repoFullName: proposal.repo_full_name,
+      message,
+    });
+    await markProposalChangeRequestFailed({ proposalId: proposal.id });
+    throw new ReviewMemoryChangeRequestError('BAD_REQUEST', message);
   }
 }
 

--- a/apps/web/src/lib/code-reviews/review-memory/llm.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/llm.ts
@@ -13,7 +13,12 @@ import type { User } from '@kilocode/db/schema';
 import type { ReviewMemoryPlatform } from '@kilocode/db/schema-types';
 import type { ReviewMemoryOwner } from './db';
 
-// Claude rejects these constraints at the provider boundary; the source Zod schema still validates output locally.
+// These JSON Schema keywords are stripped from the wire schema because Claude rejects
+// them at the provider boundary. IMPORTANT: the model therefore never receives these
+// constraints, so callers must NOT enforce them in the schema used to validate output
+// (e.g. Zod .min()/.max()). Doing so rejects complete, valid responses with
+// "No object generated: response did not match schema". Apply length limits in the
+// caller's `validate` callback instead (see review-md-integration.ts).
 const UNSUPPORTED_WIRE_SCHEMA_KEYWORDS = new Set([
   'minimum',
   'maximum',
@@ -87,7 +92,9 @@ export function createReviewMemoryGatewayProvider(input: {
 }) {
   const headers: Record<string, string> = {
     'User-Agent': input.userAgent,
-    [FEATURE_HEADER]: 'code-review-memory',
+    // Must be a value in FEATURE_VALUES or the gateway stores NULL (unattributed usage).
+    // 'code-review-memory' is not in the allow-list; reuse the 'code-review' feature.
+    [FEATURE_HEADER]: 'code-review',
   };
   if (input.owner.type === 'org') {
     headers['X-KiloCode-OrganizationId'] = input.owner.id;

--- a/apps/web/src/lib/code-reviews/review-memory/review-md-integration.test.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/review-md-integration.test.ts
@@ -1,0 +1,117 @@
+import type { User } from '@kilocode/db/schema';
+
+import { createReviewMemoryGatewayProvider, generateReviewMemoryStructuredOutput } from './llm';
+import {
+  MAX_INTEGRATION_SUMMARY_CHARS,
+  ReviewMdIntegrationOutputSchema,
+  validateReviewMdIntegrationOutput,
+} from './review-md-integration';
+
+describe('validateReviewMdIntegrationOutput', () => {
+  it('clamps an over-length integrationSummary instead of throwing', () => {
+    const result = validateReviewMdIntegrationOutput({
+      status: 'updated',
+      updatedReviewMd: '# Guide\n- always lint',
+      integrationSummary: 'x'.repeat(MAX_INTEGRATION_SUMMARY_CHARS + 500),
+    });
+
+    expect(result.integrationSummary).toHaveLength(MAX_INTEGRATION_SUMMARY_CHARS);
+    expect(result.updatedReviewMd).toBe('# Guide\n- always lint');
+  });
+
+  it('falls back to a default summary when the model returns an empty one', () => {
+    const result = validateReviewMdIntegrationOutput({
+      status: 'already_present',
+      updatedReviewMd: null,
+      integrationSummary: '   ',
+    });
+
+    expect(result.integrationSummary).toBe('Updated REVIEW.md guidance.');
+    expect(result.status).toBe('already_present');
+  });
+
+  it('throws when status is updated but updatedReviewMd is missing', () => {
+    expect(() =>
+      validateReviewMdIntegrationOutput({
+        status: 'updated',
+        updatedReviewMd: null,
+        integrationSummary: 'ok',
+      })
+    ).toThrow(/without updatedReviewMd/);
+  });
+
+  it('throws when updatedReviewMd exceeds the size ceiling', () => {
+    expect(() =>
+      validateReviewMdIntegrationOutput({
+        status: 'updated',
+        updatedReviewMd: 'a'.repeat(30_001),
+        integrationSummary: 'ok',
+      })
+    ).toThrow(/exceeds 30000 characters/);
+  });
+
+  it('throws when the integrated file mentions Review Memory', () => {
+    expect(() =>
+      validateReviewMdIntegrationOutput({
+        status: 'updated',
+        updatedReviewMd: '# Review Memory\n- do things',
+        integrationSummary: 'ok',
+      })
+    ).toThrow(/must not mention Review Memory/);
+  });
+});
+
+describe('Review Memory integration structured output', () => {
+  // Regression for the plug-and-pay failure: the wire schema strips maxLength, so a
+  // complete response whose integrationSummary runs past the source cap used to throw
+  // "No object generated: response did not match schema". It must now succeed (clamped).
+  it('accepts a complete response with an over-length summary', async () => {
+    const longSummary = 'y'.repeat(MAX_INTEGRATION_SUMMARY_CHARS + 400);
+    const gatewayFetch: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({
+          id: 'gateway-response-id',
+          object: 'chat.completion',
+          created: 1_750_204_800,
+          model: 'test/model',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: JSON.stringify({
+                  status: 'updated',
+                  updatedReviewMd: '# Guide\n- fail CI on lint errors',
+                  integrationSummary: longSummary,
+                }),
+              },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 20, completion_tokens: 10, total_tokens: 30 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+
+    const actor = { id: 'test-user-id', api_token_pepper: null } as User;
+    const provider = createReviewMemoryGatewayProvider({
+      owner: { type: 'user', id: actor.id },
+      actor,
+      userAgent: 'Review Memory integration test',
+      fetch: gatewayFetch,
+    });
+
+    const result = await generateReviewMemoryStructuredOutput({
+      model: provider.chatModel('test/model'),
+      prompt: 'Integrate the proposal.',
+      maxOutputTokens: 8_000,
+      schemaName: 'review_md_integration',
+      schema: ReviewMdIntegrationOutputSchema,
+      validate: validateReviewMdIntegrationOutput,
+    });
+
+    expect(result.output.status).toBe('updated');
+    expect(result.output.updatedReviewMd).toBe('# Guide\n- fail CI on lint errors');
+    expect(result.output.integrationSummary).toHaveLength(MAX_INTEGRATION_SUMMARY_CHARS);
+  });
+});

--- a/apps/web/src/lib/code-reviews/review-memory/review-md-integration.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/review-md-integration.ts
@@ -11,13 +11,19 @@ import {
 } from './llm';
 
 const MAX_REVIEW_MD_CHARS = 30_000;
+export const MAX_INTEGRATION_SUMMARY_CHARS = 1_000;
 const REVIEW_MEMORY_BRANDING_PATTERN = /\b(?:kilo\s+)?review\s+memory\b/i;
 const REVIEW_MEMORY_HEADING_PATTERN = /^#{1,6}\s+(?:kilo\s+)?review\s+memory\b/im;
 
-const ReviewMdIntegrationOutputSchema = z.object({
+// Structural constraints only. transformReviewMemoryWireSchema (llm.ts) strips
+// minLength/maxLength from the wire schema the model receives, so the model is never
+// told about length limits. Enforcing .min()/.max() here would reject complete, usable
+// responses with "No object generated: response did not match schema" (the plug-and-pay
+// failure). Length limits are applied in validateReviewMdIntegrationOutput below.
+export const ReviewMdIntegrationOutputSchema = z.object({
   status: z.enum(['updated', 'already_present']),
-  updatedReviewMd: z.string().min(1).max(MAX_REVIEW_MD_CHARS).nullable(),
-  integrationSummary: z.string().min(1).max(1_000),
+  updatedReviewMd: z.string().nullable(),
+  integrationSummary: z.string(),
 });
 
 export type ReviewMdIntegrationResult = {
@@ -68,19 +74,27 @@ export async function generateIntegratedReviewGuidanceWithGateway(input: {
   };
 }
 
-function validateReviewMdIntegrationOutput(
+export function validateReviewMdIntegrationOutput(
   output: z.infer<typeof ReviewMdIntegrationOutputSchema>
 ): ReviewMdIntegrationResult {
+  // integrationSummary is advisory and has no downstream consumer, so clamp it to the
+  // limit rather than failing the whole change request over a summary that ran long.
+  const integrationSummary =
+    output.integrationSummary.trim().slice(0, MAX_INTEGRATION_SUMMARY_CHARS) ||
+    'Updated REVIEW.md guidance.';
+
   if (output.status === 'already_present') {
-    return output;
+    return { status: output.status, updatedReviewMd: output.updatedReviewMd, integrationSummary };
   }
 
-  if (!output.updatedReviewMd) {
+  if (!output.updatedReviewMd || !output.updatedReviewMd.trim()) {
     throw new Error('Integration model returned updated status without updatedReviewMd.');
   }
 
-  if (!output.updatedReviewMd.trim()) {
-    throw new Error('Integration model returned empty REVIEW.md content.');
+  if (output.updatedReviewMd.length > MAX_REVIEW_MD_CHARS) {
+    throw new Error(
+      `Integrated REVIEW.md exceeds ${MAX_REVIEW_MD_CHARS} characters (${output.updatedReviewMd.length}).`
+    );
   }
 
   if (
@@ -90,7 +104,7 @@ function validateReviewMdIntegrationOutput(
     throw new Error('Integrated REVIEW.md must not mention Review Memory.');
   }
 
-  return output;
+  return { status: output.status, updatedReviewMd: output.updatedReviewMd, integrationSummary };
 }
 
 function buildReviewMdIntegrationPrompt(input: {


### PR DESCRIPTION
## Summary

The Review Memory "Open REVIEW.md PR" action failed for some orgs with the toast "No object generated: response did not match schema", leaving the proposal stuck in `change_request_failed`.

Root cause: the JSON schema sent to the model has `minLength` and `maxLength` stripped, because the provider rejects those keywords at its boundary (`transformReviewMemoryWireSchema` in `llm.ts`). Output was still validated against the source Zod schema that kept `.min()`/`.max()`. When a model returned a complete response that stayed within the token budget but whose `integrationSummary` ran past 1,000 characters, the source validation rejected it and the AI SDK threw the error above. The model was graded on a limit it was never given.

- `review-md-integration.ts`: the output schema now carries only the constraints the model actually receives (structure, enum, nullable). Length limits move into `validateReviewMdIntegrationOutput`. The advisory `integrationSummary` (no downstream consumer) is trimmed and clamped to 1,000 characters instead of failing the request. `updatedReviewMd` keeps its 30,000 character ceiling as an explicit error.
- `llm.ts`: replaced the comment at the strip site with a warning so a future caller does not reintroduce a stripped bound into its validation schema.
- `llm.ts`: fixed the feature header value. `code-review-memory` is not in `FEATURE_VALUES`, so the gateway stored NULL and Review Memory usage was unattributed in billing. Changed to the existing `code-review` value.
- `change-request.ts`: the catch now logs the redacted failure with proposal, owner, and repo context before returning `BAD_REQUEST`, so future failures are visible in logs instead of requiring a database query.
- `review-md-integration.test.ts`: new tests, including a regression that drives the real validation path with a summary longer than the cap and asserts it now succeeds clamped.

## Verification

- [x] Reproduced the failure against the model gateway by lowering the source summary cap while keeping the wire strip in place. All three tested models (sonnet, qwen, glm) returned the exact production error on complete, within-budget responses, then passed once the schema change was applied.
- [x] Ran the new and existing Review Memory Jest tests locally (regression plus adjacent suites pass). Lint, format, and typecheck pass.
- No UI paths to test manually; the change is server side.

## Visual Changes

N/A

## Reviewer Notes

- The `updatedReviewMd` 30,000 character ceiling still throws on overflow. This is pre-guarded (an existing REVIEW.md over 30,000 characters is rejected before the call) and would hit the token budget first, so it is a rare, clearly messaged error rather than the opaque failure this PR fixes.
- A separate fragility is out of scope: the model re-emits the entire REVIEW.md inside one JSON string under an 8,000 token cap, which truncates on large files and on reasoning models. That produces a different error (`No output generated`) and is left for a follow-up.
- The feature header change affects billing attribution going forward. Past Review Memory usage stays NULL.
