### PR TITLE
feat(mobile): agent interaction prerequisites (presence, inline suggestions, blocking interaction)

### DIFF
--- a/apps/mobile/src/components/agents/agent-interaction-policy.test.ts
+++ b/apps/mobile/src/components/agents/agent-interaction-policy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBlockingInteraction } from './agent-interaction-policy';
+
+describe('getBlockingInteraction', () => {
+  it('returns none without a question or permission', () => {
+    expect(getBlockingInteraction({ activeQuestion: null, activePermission: null })).toBe('none');
+  });
+
+  it('returns permission when only permission is active', () => {
+    expect(
+      getBlockingInteraction({ activeQuestion: null, activePermission: { requestId: 'perm-1' } })
+    ).toBe('permission');
+  });
+
+  it('gives question priority when both are active', () => {
+    expect(
+      getBlockingInteraction({
+        activeQuestion: { requestId: 'question-1' },
+        activePermission: { requestId: 'perm-1' },
+      })
+    ).toBe('question');
+  });
+});

--- a/apps/mobile/src/components/agents/agent-interaction-policy.ts
+++ b/apps/mobile/src/components/agents/agent-interaction-policy.ts
@@ -1,0 +1,16 @@
+type ActiveRequest = { requestId: string } | null | undefined;
+
+type BlockingInteraction = 'question' | 'permission' | 'none';
+
+export function getBlockingInteraction(input: {
+  activeQuestion: ActiveRequest;
+  activePermission: ActiveRequest;
+}): BlockingInteraction {
+  if (input.activeQuestion) {
+    return 'question';
+  }
+  if (input.activePermission) {
+    return 'permission';
+  }
+  return 'none';
+}

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -8,6 +8,7 @@ import { FlatList, KeyboardAvoidingView, Platform, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { toast } from 'sonner-native';
 
+import { getBlockingInteraction } from '@/components/agents/agent-interaction-policy';
 import { ChatComposer } from '@/components/agents/chat-composer';
 import { ConnectivityBanner } from '@/components/agents/connectivity-banner';
 import { MessageBubble } from '@/components/agents/message-bubble';
@@ -66,6 +67,7 @@ import {
   type ModelPickerSelection,
   type ModelPickerSelectionScope,
 } from '@/lib/picker-bridge';
+import { cn } from '@/lib/utils';
 
 type SessionDetailContentProps = {
   sessionId: KiloSessionId;
@@ -402,14 +404,15 @@ export function SessionDetailContent({
   const title =
     fetchedData?.kiloSessionId === sessionId ? (fetchedData.title ?? 'Session') : 'Session';
   const requiresModel = Boolean(fetchedData?.cloudAgentSessionId);
+  const blockingInteraction = getBlockingInteraction({ activeQuestion, activePermission });
+  const hasBlockingInteraction = blockingInteraction !== 'none';
   const isComposerDisabled =
     isReadOnly ||
     !canSend ||
     shouldShowLoading ||
     Boolean(error) ||
-    Boolean(activeQuestion) ||
+    hasBlockingInteraction ||
     (requiresModel && !currentModel);
-  const showInteractionCards = activeQuestion ?? activePermission;
   const composerPlaceholder =
     (cloudStatus && COMPOSER_PLACEHOLDERS[cloudStatus.type]) ?? 'Message...';
   const keyboardContainerKind = getSessionKeyboardContainerKind(Platform.OS);
@@ -506,7 +509,7 @@ export function SessionDetailContent({
       <>
         <View className="flex-1">{renderContent()}</View>
 
-        {activeQuestion ? (
+        {blockingInteraction === 'question' && activeQuestion ? (
           <QuestionCard
             questions={activeQuestion.questions}
             onAnswer={answers => {
@@ -519,7 +522,7 @@ export function SessionDetailContent({
           />
         ) : null}
 
-        {activePermission ? (
+        {blockingInteraction === 'permission' && activePermission ? (
           <PermissionCard
             permission={activePermission.permission}
             patterns={activePermission.patterns}
@@ -531,37 +534,42 @@ export function SessionDetailContent({
           />
         ) : null}
 
-        {!showInteractionCards &&
-          (isReadOnly && messages.length > 0 ? (
-            <View className="border-t border-border bg-secondary px-4 py-3">
-              <Text className="text-center text-sm text-muted-foreground">
-                This is a read-only session
-              </Text>
-            </View>
-          ) : (
-            <>
-              <ModelPickerSelectionScopeProvider
-                selectionScope={modelPickerSelectionScope}
-                isSelectionCurrent={isModelPickerSelectionCurrent}
-              >
-                <ChatComposer
-                  onSend={handleSend}
-                  onStop={handleStop}
-                  disabled={isComposerDisabled}
-                  isStreaming={isStreaming}
-                  placeholder={composerPlaceholder}
-                  mode={currentMode}
-                  onModeChange={setCurrentMode}
-                  model={currentModel}
-                  variant={currentVariant}
-                  modelOptions={modelOptions}
-                  onModelSelect={handleModelSelect}
-                  organizationId={organizationId}
-                  attachmentsEnabled={supportsAttachments}
-                />
-              </ModelPickerSelectionScopeProvider>
-            </>
-          ))}
+        {isReadOnly && messages.length > 0 && !hasBlockingInteraction ? (
+          <View className="border-t border-border bg-secondary px-4 py-3">
+            <Text className="text-center text-sm text-muted-foreground">
+              This is a read-only session
+            </Text>
+          </View>
+        ) : null}
+
+        {!isReadOnly || messages.length === 0 ? (
+          <View
+            className={cn(hasBlockingInteraction && 'hidden')}
+            accessibilityElementsHidden={hasBlockingInteraction}
+            importantForAccessibility={hasBlockingInteraction ? 'no-hide-descendants' : 'auto'}
+          >
+            <ModelPickerSelectionScopeProvider
+              selectionScope={modelPickerSelectionScope}
+              isSelectionCurrent={isModelPickerSelectionCurrent}
+            >
+              <ChatComposer
+                onSend={handleSend}
+                onStop={handleStop}
+                disabled={isComposerDisabled}
+                isStreaming={isStreaming}
+                placeholder={composerPlaceholder}
+                mode={currentMode}
+                onModeChange={setCurrentMode}
+                model={currentModel}
+                variant={currentVariant}
+                modelOptions={modelOptions}
+                onModelSelect={handleModelSelect}
+                organizationId={organizationId}
+                attachmentsEnabled={supportsAttachments}
+              />
+            </ModelPickerSelectionScopeProvider>
+          </View>
+        ) : null}
       </>
     );
   }

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -33,6 +33,10 @@ import {
 } from '@/components/agents/session-working-state';
 import { EmptyState } from '@/components/empty-state';
 import { AppAwareKeyboardPaddingView } from '@/components/kilo-chat/app-aware-keyboard-padding';
+import {
+  resolveLoadedCliSessionPresenceId,
+  useCliSessionPresence,
+} from '@/components/kilo-chat/hooks/use-cli-session-presence';
 import { useInteractionHandlers } from '@/components/agents/use-interaction-handlers';
 import { useSessionAutoScroll } from '@/components/agents/use-session-auto-scroll';
 import { useSessionConfigSync } from '@/components/agents/use-session-config-sync';
@@ -136,6 +140,12 @@ export function SessionDetailContent({
   });
 
   const organizationId = fetchedData?.organizationId ?? undefined;
+
+  const presenceSessionId = resolveLoadedCliSessionPresenceId(
+    sessionId,
+    fetchedData?.kiloSessionId
+  );
+  useCliSessionPresence(presenceSessionId);
 
   const { saveModel: savePersistedModel } = usePersistedAgentModel();
   const { setLastSelected: persistServerLastSelected } = useModelPreferences(organizationId);

--- a/apps/mobile/src/components/agents/suggest-tool-card.tsx
+++ b/apps/mobile/src/components/agents/suggest-tool-card.tsx
@@ -1,0 +1,44 @@
+import { useAtomValue } from 'jotai';
+import { Sparkles } from 'lucide-react-native';
+import { type ToolPart } from 'cloud-agent-sdk';
+
+import { useSessionManager } from '@/components/agents/session-provider';
+
+import { resolveSuggestionPresentation } from './suggestion-card-state';
+import { SuggestionCard } from './suggestion-card';
+import { ToolCardShell } from './tool-card-shell';
+
+export function SuggestToolCard({ part }: Readonly<{ part: ToolPart }>) {
+  const manager = useSessionManager();
+  const activeSuggestion = useAtomValue(manager.atoms.activeSuggestion);
+  const presentation = resolveSuggestionPresentation(
+    part.state.status,
+    part.callID,
+    activeSuggestion
+  );
+
+  if (presentation === 'interactive' && activeSuggestion) {
+    return (
+      <SuggestionCard
+        key={activeSuggestion.requestId}
+        text={activeSuggestion.text}
+        actions={activeSuggestion.actions}
+        onAccept={async index => {
+          await manager.acceptSuggestion(activeSuggestion.requestId, index);
+        }}
+        onDismiss={async () => {
+          await manager.dismissSuggestion(activeSuggestion.requestId);
+        }}
+      />
+    );
+  }
+
+  return (
+    <ToolCardShell
+      icon={Sparkles}
+      title="Suggestion"
+      subtitle={part.state.status === 'error' ? 'Suggestion dismissed' : 'Suggestion'}
+      status={part.state.status}
+    />
+  );
+}

--- a/apps/mobile/src/components/agents/suggestion-card-state.test.ts
+++ b/apps/mobile/src/components/agents/suggestion-card-state.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createSuggestionActionLock,
+  resolveSuggestionPresentation,
+  suggestionActionError,
+} from './suggestion-card-state';
+
+describe('resolveSuggestionPresentation', () => {
+  const suggestion = { requestId: 'sug-1', callId: 'call-1' };
+
+  it('is interactive only for a pending matching call', () => {
+    expect(resolveSuggestionPresentation('pending', 'call-1', suggestion)).toBe('interactive');
+    expect(resolveSuggestionPresentation('running', 'call-1', suggestion)).toBe('interactive');
+  });
+
+  it.each([
+    ['completed', 'call-1'],
+    ['error', 'call-1'],
+    ['pending', 'other-call'],
+    ['pending', undefined],
+  ] as const)('is compact for %s / %s', (status, callId) => {
+    expect(resolveSuggestionPresentation(status, callId, suggestion)).toBe('compact');
+  });
+});
+
+describe('createSuggestionActionLock', () => {
+  it('rejects duplicate acquisition until released', () => {
+    const lock = createSuggestionActionLock();
+    expect(lock.tryAcquire()).toBe(true);
+    expect(lock.tryAcquire()).toBe(false);
+    lock.release();
+    expect(lock.tryAcquire()).toBe(true);
+  });
+});
+
+it('uses fixed safe error copy', () => {
+  expect(suggestionActionError('accept')).toBe("Couldn't apply this suggestion. Try again.");
+  expect(suggestionActionError('dismiss')).toBe("Couldn't dismiss this suggestion. Try again.");
+});

--- a/apps/mobile/src/components/agents/suggestion-card-state.ts
+++ b/apps/mobile/src/components/agents/suggestion-card-state.ts
@@ -1,0 +1,38 @@
+type ToolStatus = 'pending' | 'running' | 'completed' | 'error';
+type ActiveSuggestionIdentity = { requestId: string; callId?: string } | null;
+
+export function resolveSuggestionPresentation(
+  status: ToolStatus,
+  callId: string | undefined,
+  suggestion: ActiveSuggestionIdentity
+): 'interactive' | 'compact' {
+  const pending = status === 'pending' || status === 'running';
+  return pending && suggestion?.callId !== undefined && suggestion.callId === callId
+    ? 'interactive'
+    : 'compact';
+}
+
+export function createSuggestionActionLock(): {
+  tryAcquire: () => boolean;
+  release: () => void;
+} {
+  let held = false;
+  return {
+    tryAcquire: () => {
+      if (held) {
+        return false;
+      }
+      held = true;
+      return true;
+    },
+    release: () => {
+      held = false;
+    },
+  };
+}
+
+export function suggestionActionError(kind: 'accept' | 'dismiss'): string {
+  return kind === 'accept'
+    ? "Couldn't apply this suggestion. Try again."
+    : "Couldn't dismiss this suggestion. Try again.";
+}

--- a/apps/mobile/src/components/agents/suggestion-card.tsx
+++ b/apps/mobile/src/components/agents/suggestion-card.tsx
@@ -1,0 +1,131 @@
+import { useRef, useState } from 'react';
+import { View } from 'react-native';
+import * as Haptics from 'expo-haptics';
+import { Sparkles } from 'lucide-react-native';
+import { type StandaloneSuggestion, type SuggestionAction } from 'cloud-agent-sdk';
+
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { cn } from '@/lib/utils';
+
+import { createSuggestionActionLock, suggestionActionError } from './suggestion-card-state';
+
+type SuggestionCardProps = {
+  text: string;
+  actions: StandaloneSuggestion['actions'];
+  onAccept: (index: number) => Promise<void>;
+  onDismiss: () => Promise<void>;
+};
+
+type PendingState = { kind: 'accept'; index: number } | { kind: 'dismiss' };
+
+export function SuggestionCard({
+  text,
+  actions,
+  onAccept,
+  onDismiss,
+}: Readonly<SuggestionCardProps>) {
+  const colors = useThemeColors();
+  const lockRef = useRef(createSuggestionActionLock());
+  const [pending, setPending] = useState<PendingState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleAccept(index: number) {
+    if (!lockRef.current.tryAcquire()) {
+      return;
+    }
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setPending({ kind: 'accept', index });
+    setError(null);
+    try {
+      await onAccept(index);
+    } catch {
+      lockRef.current.release();
+      setPending(null);
+      setError(suggestionActionError('accept'));
+    }
+  }
+
+  async function handleDismiss() {
+    if (!lockRef.current.tryAcquire()) {
+      return;
+    }
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setPending({ kind: 'dismiss' });
+    setError(null);
+    try {
+      await onDismiss();
+    } catch {
+      lockRef.current.release();
+      setPending(null);
+      setError(suggestionActionError('dismiss'));
+    }
+  }
+
+  const isPending = pending !== null;
+
+  return (
+    <View className="mx-4 my-2 shrink overflow-hidden rounded-xl border border-border bg-card">
+      <View className="flex-row items-center gap-2 border-b border-border bg-secondary px-4 py-3">
+        <Sparkles size={16} color={colors.mutedForeground} />
+        <Text className="text-sm font-medium">Suggestion</Text>
+      </View>
+
+      <View className="gap-3 p-4">
+        <Text className="text-sm leading-5 text-foreground">{text}</Text>
+
+        {error ? (
+          <Text accessibilityLiveRegion="polite" className="text-xs text-destructive">
+            {error}
+          </Text>
+        ) : null}
+
+        {actions.length > 0 ? (
+          <View className="gap-2">
+            {actions.map((action: SuggestionAction, index: number) => {
+              const isLoading = pending?.kind === 'accept' && pending.index === index;
+              return (
+                <View key={`${action.label}-${index}`} className="gap-1">
+                  <Button
+                    variant={index === 0 ? 'default' : 'outline'}
+                    onPress={() => {
+                      void handleAccept(index);
+                    }}
+                    disabled={isPending}
+                    loading={isLoading}
+                    accessibilityRole="button"
+                    accessibilityLabel={action.label}
+                    accessibilityHint={action.description}
+                  >
+                    <Text className="text-sm">{action.label}</Text>
+                  </Button>
+                  {action.description ? (
+                    <Text className="text-xs leading-5 text-muted-foreground">
+                      {action.description}
+                    </Text>
+                  ) : null}
+                </View>
+              );
+            })}
+          </View>
+        ) : null}
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onPress={() => {
+            void handleDismiss();
+          }}
+          disabled={isPending}
+          loading={pending?.kind === 'dismiss'}
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss suggestion"
+          className={cn(actions.length > 0 && 'self-start')}
+        >
+          <Text className="text-sm">Dismiss suggestion</Text>
+        </Button>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/agents/tool-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/tool-part-renderer.tsx
@@ -19,6 +19,7 @@ import {
   WebSearchToolCard,
   WriteToolCard,
 } from './tool-cards';
+import { SuggestToolCard } from './suggest-tool-card';
 
 type ToolPartRendererProps = {
   part: ToolPart;
@@ -83,6 +84,9 @@ export function ToolPartRenderer({
     }
     case 'task': {
       return <TaskToolCard part={part} />;
+    }
+    case 'suggest': {
+      return <SuggestToolCard part={part} />;
     }
     default: {
       return <GenericToolCard part={part} />;

--- a/apps/mobile/src/components/kilo-chat/hooks/use-cli-session-presence.test.ts
+++ b/apps/mobile/src/components/kilo-chat/hooks/use-cli-session-presence.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { resolveLoadedCliSessionPresenceId } from './use-cli-session-presence';
+
+// Mock the transitive react-native import (Flow source trips rolldown's
+// SSR transform) and the bare minimum of useAppActiveAndFocused's other
+// dependency. We only exercise resolveLoadedCliSessionPresenceId here.
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
+}));
+
+vi.mock('expo-router', () => ({
+  useFocusEffect: vi.fn(),
+}));
+
+describe('resolveLoadedCliSessionPresenceId', () => {
+  it('returns the route ID only after matching session data loads', () => {
+    expect(resolveLoadedCliSessionPresenceId('route-1', 'route-1')).toBe('route-1');
+  });
+
+  it.each([undefined, null, 'other-session'])(
+    'does not claim presence for loaded ID %s',
+    loadedSessionId => {
+      expect(resolveLoadedCliSessionPresenceId('route-1', loadedSessionId)).toBeUndefined();
+    }
+  );
+});

--- a/apps/mobile/src/components/kilo-chat/hooks/use-cli-session-presence.ts
+++ b/apps/mobile/src/components/kilo-chat/hooks/use-cli-session-presence.ts
@@ -1,0 +1,19 @@
+import { presenceContextForCliSession } from '@kilocode/event-service';
+import { usePresenceSubscription } from '@kilocode/kilo-chat-hooks';
+
+import { useAppActiveAndFocused } from './use-app-active-and-focused';
+
+export function resolveLoadedCliSessionPresenceId(
+  routeSessionId: string,
+  loadedSessionId: string | null | undefined
+): string | undefined {
+  return loadedSessionId === routeSessionId ? routeSessionId : undefined;
+}
+
+export function useCliSessionPresence(sessionId: string | undefined): void {
+  const activeAndFocused = useAppActiveAndFocused();
+  usePresenceSubscription(
+    sessionId ? presenceContextForCliSession(sessionId) : null,
+    Boolean(sessionId) && activeAndFocused
+  );
+}


### PR DESCRIPTION
## Summary

Prerequisite mobile release reimplementing in-spirit useful parts of closed PR #4545 on latest `main`, on top of already-merged PR #4445 (which shipped remote CLI slash commands but left `REMOTE_SESSION_ATTENTION_PUSH_ENABLED` disabled).

- **Exact-session presence**: `useCliSessionPresence` holds `/presence/cli-session/{kiloSessionId}` only after the route's session data has verifiably loaded and matches, and only while the route is focused and the app is foregrounded.
- **Inline remote-CLI suggestions**: a dedicated `SuggestToolCard` renders interactive accept/dismiss controls only at the exact matching pending/running `suggest` tool call (`callId` === `callID`), with a synchronous same-frame action lock, per-action loading state, fixed safe retry copy, and automatic reset on request replacement (via `key={requestId}`).
- **Deterministic blocking-interaction precedence**: `getBlockingInteraction` gives a pending question priority over a pending permission.
- **Composer-state preservation**: the composer stays mounted (hidden via accessibility-safe `View` wrapper + `disabled`) during a blocking interaction, so draft text, attachments, and voice-input abort semantics are preserved instead of being unmounted.

No push notifications are enabled by this change; `REMOTE_SESSION_ATTENTION_PUSH_ENABLED` is untouched.

## Changes

- `apps/mobile/src/components/agents/agent-interaction-policy.ts` (+test) — pure question/permission precedence.
- `apps/mobile/src/components/kilo-chat/hooks/use-cli-session-presence.ts` (+test) — canonical CLI-session presence subscription and loaded-session resolver.
- `apps/mobile/src/components/agents/suggestion-card-state.ts` (+test), `suggestion-card.tsx`, `suggest-tool-card.tsx` — inline suggestion presentation, matching, and action-lock state.
- `apps/mobile/src/components/agents/tool-part-renderer.tsx` — routes `suggest` tool parts to `SuggestToolCard`.
- `apps/mobile/src/components/agents/session-detail-content.tsx` — integrates blocking-interaction policy, presence, and the hidden-not-unmounted composer wrapper.

## Verification

- `pnpm test` (apps/mobile): 121 files / 783 tests passed (14 new tests across 3 new test files; baseline was 118/769).
- `pnpm typecheck`, `pnpm lint`, `pnpm check:unused`, `pnpm format:check`: all clean.
- Fresh independent code review: 11/11 explicit review points PASS with file:line evidence (presence gating/teardown, composer never unmounted, voice-input abort wiring, suggestion/tool-call matching, action-lock semantics, no raw error leakage, no Cloud Agent suggestion capability added, accessibility, no push enablement, question-before-permission, no backend/lockfile/dependency changes).
- Device E2E (iOS simulator, local dev stack, real authenticated remote `kilo` CLI session against this worktree's local backend):
  - Confirmed via live `event-service` logs that opening the CLI session's detail screen subscribes to the exact `/presence/cli-session/{kiloSessionId}` context, and navigating away unsubscribes.
  - Confirmed no regressions: session list, session detail rendering, and the existing read-only banner all continue to work correctly with the integrated diff.
  - Live triggering of the `suggest` tool card and `question`/`permission` blocking states was not deterministically reproducible in this run (requires CLI-side scenario/config outside this project's scope — the local CLI auto-approves permissions and does not emit `suggest` tool calls from ordinary prompts). These states are covered by the 14 new automated unit/state tests plus the reviewer's explicit sign-off on lock/matching/error-copy semantics.

## Non-goals confirmed unchanged

- `REMOTE_SESSION_ATTENTION_PUSH_ENABLED` and push enablement
- Notification contracts, outboxes, retries, migrations
- `/presence/cli-session/*` naming
- Cloud Agent suggestion filtering/transport capability
- Dependencies / `pnpm-lock.yaml`