### PR TITLE
feat(mobile): add Active now session filter

### DIFF
--- a/apps/mobile/src/components/agents/platform-filter-modal.tsx
+++ b/apps/mobile/src/components/agents/platform-filter-modal.tsx
@@ -24,6 +24,7 @@ export type ProjectFilterOption = {
 };
 
 type SessionFilters = {
+  activeNow: boolean;
   platformFilter: string[];
   projectFilter: string[];
 };
@@ -32,11 +33,11 @@ type SessionFilterChipsProps = SessionFilters & {
   projectOptions: ProjectFilterOption[];
   onRemovePlatform: (platform: string) => void;
   onRemoveProject: (gitUrl: string) => void;
+  onRemoveActiveNow: () => void;
 };
 
 type SessionFilterModalProps = {
-  selectedPlatforms: string[];
-  selectedProjects: string[];
+  selectedFilters: SessionFilters;
   projectOptions: ProjectFilterOption[];
   onClose: () => void;
   onApply: (filters: SessionFilters) => void;
@@ -107,15 +108,17 @@ function FilterCheckboxRow({ label, isChecked, onPress }: Readonly<FilterCheckbo
 }
 
 export function SessionFilterChips({
+  activeNow,
   platformFilter,
   projectFilter,
   projectOptions,
   onRemovePlatform,
   onRemoveProject,
+  onRemoveActiveNow,
 }: Readonly<SessionFilterChipsProps>) {
   const colors = useThemeColors();
 
-  if (platformFilter.length === 0 && projectFilter.length === 0) {
+  if (!activeNow && platformFilter.length === 0 && projectFilter.length === 0) {
     return null;
   }
 
@@ -125,6 +128,19 @@ export function SessionFilterChips({
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={chipScrollContentStyle}
     >
+      {activeNow && (
+        <Pressable
+          className="flex-row items-center gap-1.5 rounded-full bg-accent-soft px-3 py-1.5 active:opacity-70"
+          onPress={onRemoveActiveNow}
+          accessibilityRole="button"
+          accessibilityLabel="Remove Active now filter"
+        >
+          <Text className="font-mono-medium text-[11px] uppercase tracking-[0.6px] text-accent-soft-foreground">
+            Active now
+          </Text>
+          <X size={12} color={colors.accentSoftForeground} />
+        </Pressable>
+      )}
       {projectFilter.map(gitUrl => {
         const label = projectFilterLabel(gitUrl, projectOptions);
         return (
@@ -168,14 +184,18 @@ export function SessionFilterChips({
 }
 
 export function SessionFilterModal({
-  selectedPlatforms,
-  selectedProjects,
+  selectedFilters,
   projectOptions,
   onClose,
   onApply,
 }: Readonly<SessionFilterModalProps>) {
-  const [draftPlatforms, setDraftPlatforms] = useState<string[]>(selectedPlatforms);
-  const [draftProjects, setDraftProjects] = useState<string[]>(selectedProjects);
+  const [draftActiveNow, setDraftActiveNow] = useState(selectedFilters.activeNow);
+  const [draftPlatforms, setDraftPlatforms] = useState<string[]>(selectedFilters.platformFilter);
+  const [draftProjects, setDraftProjects] = useState<string[]>(selectedFilters.projectFilter);
+
+  const toggleActiveNow = () => {
+    setDraftActiveNow(value => !value);
+  };
 
   const togglePlatform = (platform: string) => {
     setDraftPlatforms(prev =>
@@ -213,6 +233,11 @@ export function SessionFilterModal({
           <Text className="text-base font-semibold">Filter sessions</Text>
           <ScrollView showsVerticalScrollIndicator={false}>
             <View className="gap-4">
+              <FilterCheckboxRow
+                label="Active now"
+                isChecked={draftActiveNow}
+                onPress={toggleActiveNow}
+              />
               <View className="gap-1">
                 <Text variant="eyebrow" className="px-3">
                   Platform
@@ -253,7 +278,11 @@ export function SessionFilterModal({
             </Button>
             <Button
               onPress={() => {
-                onApply({ platformFilter: draftPlatforms, projectFilter: draftProjects });
+                onApply({
+                  activeNow: draftActiveNow,
+                  platformFilter: draftPlatforms,
+                  projectFilter: draftProjects,
+                });
                 onClose();
               }}
             >

--- a/apps/mobile/src/components/agents/session-list-screen.tsx
+++ b/apps/mobile/src/components/agents/session-list-screen.tsx
@@ -10,13 +10,10 @@ import {
   SessionFilterChips,
   SessionFilterModal,
 } from '@/components/agents/platform-filter-modal';
+import { buildSessionSections } from '@/components/agents/session-list-sections';
 import {
   expandPlatformFilter,
   formatGitUrlProject,
-  matchesSearch,
-  type RemoteSessionItem,
-  type SessionSection,
-  type StoredSessionItem,
 } from '@/components/agents/session-list-helpers';
 import { ScreenHeader } from '@/components/screen-header';
 import {
@@ -34,10 +31,12 @@ export function AgentSessionListScreen() {
 
   const { organizationId, isLoaded: orgLoaded } = useOrganization();
   const {
+    activeNow,
     platformFilter,
     projectFilter,
     hasLoaded: filtersLoaded,
     setFilters,
+    setActiveNow,
     setPlatformFilter,
     setProjectFilter,
   } = usePersistedAgentSessionFilters();
@@ -85,7 +84,6 @@ export function AgentSessionListScreen() {
     storedSessions,
     dateGroups,
     activeSessions,
-    activeSessionIds,
     isLoading,
     isError,
     hasNextPage,
@@ -176,69 +174,35 @@ export function AgentSessionListScreen() {
   // `isSearchPending` drives a lightweight inline indicator instead.
   const effectiveSearchQuery = isSearchPending ? '' : searchQuery;
 
-  const sections = useMemo<SessionSection[]>(() => {
-    const result: SessionSection[] = [];
-    const storedSessionIds = new Set(storedSessions.map(session => session.session_id));
+  // Stored sessions are cursor-paginated, so a client-side filter would only
+  // see the loaded pages. When a query is active, use the server search
+  // results (which cover the full history) instead.
+  const storedGroups = useMemo(
+    () => (effectiveSearchQuery ? search.dateGroups : dateGroups),
+    [dateGroups, effectiveSearchQuery, search.dateGroups]
+  );
 
-    const filteredActive = activeSessions.filter(session => {
-      if (storedSessionIds.has(session.id)) {
-        return false;
-      }
-
-      if (projectFilter.length > 0 && !session.gitUrl) {
-        return false;
-      }
-
-      if (projectFilter.length > 0 && session.gitUrl && !projectFilter.includes(session.gitUrl)) {
-        return false;
-      }
-
-      return effectiveSearchQuery
-        ? matchesSearch(effectiveSearchQuery, session.title, session.gitUrl ?? null)
-        : true;
-    });
-
-    if (filteredActive.length > 0) {
-      result.push({
-        title: 'Remote',
-        data: filteredActive.map(
-          (session): RemoteSessionItem => ({
-            kind: 'remote',
-            session,
-          })
-        ),
-      });
-    }
-
-    // Stored sessions are cursor-paginated, so a client-side filter would only
-    // see the loaded pages. When a query is active, use the server search
-    // results (which cover the full history) instead.
-    const storedGroups = effectiveSearchQuery ? search.dateGroups : dateGroups;
-    for (const group of storedGroups) {
-      if (group.sessions.length > 0) {
-        result.push({
-          title: group.label,
-          data: group.sessions.map(
-            (session): StoredSessionItem => ({
-              kind: 'stored',
-              session,
-              isLive: activeSessionIds.has(session.session_id),
-            })
-          ),
-        });
-      }
-    }
-
-    return result;
-  }, [
-    activeSessionIds,
-    activeSessions,
-    dateGroups,
-    effectiveSearchQuery,
-    projectFilter,
-    search.dateGroups,
-    storedSessions,
-  ]);
+  const sections = useMemo(
+    () =>
+      buildSessionSections({
+        activeNow,
+        activeSessions,
+        storedGroups,
+        platformFilter,
+        projectFilter,
+        searchQuery: effectiveSearchQuery,
+        organizationId,
+      }),
+    [
+      activeNow,
+      activeSessions,
+      effectiveSearchQuery,
+      organizationId,
+      platformFilter,
+      projectFilter,
+      storedGroups,
+    ]
+  );
 
   const navigateToSession = useCallback(
     (sessionId: string, sessionOrgId?: string | null) => {
@@ -256,12 +220,12 @@ export function AgentSessionListScreen() {
     }
   }, [fetchNextPage, hasNextPage, isFetchingNextPage, isSearching]);
 
-  const hasActiveFilter = platformFilter.length > 0 || projectFilter.length > 0;
+  const hasActiveFilter = activeNow || platformFilter.length > 0 || projectFilter.length > 0;
   const hasAnySessions = storedSessions.length > 0 || activeSessions.length > 0;
 
   const handleClearQuery = useCallback(() => {
     handleClearSearch();
-    setFilters({ platformFilter: [], projectFilter: [] });
+    setFilters({ activeNow: false, platformFilter: [], projectFilter: [] });
   }, [handleClearSearch, setFilters]);
 
   return (
@@ -286,9 +250,13 @@ export function AgentSessionListScreen() {
       />
       <Animated.View layout={LinearTransition}>
         <SessionFilterChips
+          activeNow={activeNow}
           platformFilter={platformFilter}
           projectFilter={projectFilter}
           projectOptions={projectOptions}
+          onRemoveActiveNow={() => {
+            setActiveNow(false);
+          }}
           onRemovePlatform={platform => {
             setPlatformFilter(prev => prev.filter(p => p !== platform));
           }}
@@ -321,8 +289,7 @@ export function AgentSessionListScreen() {
       </Animated.View>
       {showFilterModal && (
         <SessionFilterModal
-          selectedPlatforms={platformFilter}
-          selectedProjects={projectFilter}
+          selectedFilters={{ activeNow, platformFilter, projectFilter }}
           projectOptions={projectOptions}
           onClose={() => {
             setShowFilterModal(false);

--- a/apps/mobile/src/components/agents/session-list-sections.test.ts
+++ b/apps/mobile/src/components/agents/session-list-sections.test.ts
@@ -150,7 +150,13 @@ describe('buildSessionSections', () => {
       ids(
         buildSessionSections({
           activeNow: true,
-          activeSessions: [active({ id: 'match', title: 'Fix checkout', gitUrl: 'https://github.com/kilo/repo.git' })],
+          activeSessions: [
+            active({
+              id: 'match',
+              title: 'Fix checkout',
+              gitUrl: 'https://github.com/kilo/repo.git',
+            }),
+          ],
           storedGroups: [],
           platformFilter: [],
           projectFilter: ['https://github.com/kilo/repo.git'],
@@ -196,7 +202,10 @@ describe('buildSessionSections', () => {
 
     const sections = buildSessionSections({
       activeNow: true,
-      activeSessions: [active({ id: 'remote-only' }), active({ id: 'remote-org', organizationId: 'org-1' })],
+      activeSessions: [
+        active({ id: 'remote-only' }),
+        active({ id: 'remote-org', organizationId: 'org-1' }),
+      ],
       storedGroups: [{ label: 'Today', sessions: [orgStored] }],
       platformFilter: [],
       projectFilter: [],
@@ -259,8 +268,6 @@ describe('buildSessionSections', () => {
       organizationId: null,
     });
 
-    expect(ids(sections)).toEqual([
-      { title: 'Today', ids: ['returned'], kinds: ['stored'] },
-    ]);
+    expect(ids(sections)).toEqual([{ title: 'Today', ids: ['returned'], kinds: ['stored'] }]);
   });
 });

--- a/apps/mobile/src/components/agents/session-list-sections.test.ts
+++ b/apps/mobile/src/components/agents/session-list-sections.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSessionSections } from './session-list-sections';
+import { type ActiveSession, type StoredSession } from '@/lib/hooks/use-agent-sessions';
+
+function stored(overrides: { session_id: string } & Partial<StoredSession>): StoredSession {
+  const { session_id, ...rest } = overrides;
+  return {
+    session_id,
+    title: 'Stored session',
+    cloud_agent_session_id: null,
+    parent_session_id: null,
+    organization_id: null,
+    created_on_platform: 'cli',
+    git_url: 'https://github.com/kilo/repo.git',
+    git_branch: 'main',
+    status: null,
+    status_updated_at: null,
+    created_at: '2026-07-01 00:00:00+00',
+    updated_at: '2026-07-01 00:00:00+00',
+    version: 0,
+    associatedPr: null,
+    ...rest,
+  };
+}
+
+function active(overrides: { id: string } & Partial<ActiveSession>): ActiveSession {
+  const { id, ...rest } = overrides;
+  return {
+    id,
+    title: 'Active session',
+    status: 'busy',
+    connectionId: 'connection-1',
+    ...rest,
+  };
+}
+
+const ids = (sections: ReturnType<typeof buildSessionSections>) =>
+  sections.map(section => ({
+    title: section.title,
+    ids: section.data.map(item =>
+      item.kind === 'stored' ? item.session.session_id : item.session.id
+    ),
+    kinds: section.data.map(item => item.kind),
+  }));
+
+const allStoredIds = (sections: ReturnType<typeof buildSessionSections>) =>
+  sections.flatMap(section =>
+    section.data.flatMap(item => (item.kind === 'stored' ? [item.session.session_id] : []))
+  );
+
+describe('buildSessionSections', () => {
+  it('moves live stored and active-only sessions into Active now exactly once', () => {
+    const liveStored = stored({ session_id: 'live-stored', created_on_platform: 'cloud-agent' });
+    const history = stored({ session_id: 'history' });
+
+    expect(
+      ids(
+        buildSessionSections({
+          activeNow: true,
+          activeSessions: [active({ id: 'live-stored' }), active({ id: 'remote-only' })],
+          storedGroups: [{ label: 'Today', sessions: [liveStored, history] }],
+          platformFilter: [],
+          projectFilter: [],
+          searchQuery: '',
+          organizationId: null,
+        })
+      )
+    ).toEqual([
+      { title: 'Active now', ids: ['live-stored', 'remote-only'], kinds: ['stored', 'remote'] },
+      { title: 'Today', ids: ['history'], kinds: ['stored'] },
+    ]);
+  });
+
+  it('preserves current placement when Active now is disabled', () => {
+    const liveStored = stored({ session_id: 'live-stored' });
+
+    expect(
+      ids(
+        buildSessionSections({
+          activeNow: false,
+          activeSessions: [active({ id: 'live-stored' }), active({ id: 'remote-only' })],
+          storedGroups: [{ label: 'Today', sessions: [liveStored] }],
+          platformFilter: [],
+          projectFilter: [],
+          searchQuery: '',
+          organizationId: null,
+        })
+      )
+    ).toEqual([
+      { title: 'Remote', ids: ['remote-only'], kinds: ['remote'] },
+      { title: 'Today', ids: ['live-stored'], kinds: ['stored'] },
+    ]);
+  });
+
+  it('marks stored items in Active now as live so the row can show the live indicator', () => {
+    const liveStored = stored({ session_id: 'live-stored' });
+
+    const sections = buildSessionSections({
+      activeNow: true,
+      activeSessions: [active({ id: 'live-stored' })],
+      storedGroups: [{ label: 'Today', sessions: [liveStored] }],
+      platformFilter: [],
+      projectFilter: [],
+      searchQuery: '',
+      organizationId: null,
+    });
+
+    const firstSection = sections[0];
+    expect(firstSection?.title).toBe('Active now');
+    const onlyItem = firstSection?.data[0];
+    expect(onlyItem?.kind).toBe('stored');
+    if (onlyItem?.kind === 'stored') {
+      expect(onlyItem.isLive).toBe(true);
+    }
+  });
+
+  it('treats active-only sessions as CLI for platform filtering', () => {
+    const base = {
+      activeNow: true,
+      activeSessions: [active({ id: 'remote-only' })],
+      storedGroups: [],
+      projectFilter: [],
+      searchQuery: '',
+      organizationId: null,
+    };
+    expect(ids(buildSessionSections({ ...base, platformFilter: ['cli'] }))).toEqual([
+      { title: 'Active now', ids: ['remote-only'], kinds: ['remote'] },
+    ]);
+    expect(ids(buildSessionSections({ ...base, platformFilter: ['cloud-agent'] }))).toEqual([]);
+  });
+
+  it('honors enriched createdOnPlatform on active-only sessions for platform filtering', () => {
+    const base = {
+      activeNow: true,
+      activeSessions: [active({ id: 'cloud-only', createdOnPlatform: 'cloud-agent' })],
+      storedGroups: [],
+      projectFilter: [],
+      searchQuery: '',
+      organizationId: null,
+    };
+    expect(ids(buildSessionSections({ ...base, platformFilter: ['cloud-agent'] }))).toEqual([
+      { title: 'Active now', ids: ['cloud-only'], kinds: ['remote'] },
+    ]);
+    expect(ids(buildSessionSections({ ...base, platformFilter: ['cli'] }))).toEqual([]);
+  });
+
+  it('applies search and project filters to active-only sessions', () => {
+    expect(
+      ids(
+        buildSessionSections({
+          activeNow: true,
+          activeSessions: [active({ id: 'match', title: 'Fix checkout', gitUrl: 'https://github.com/kilo/repo.git' })],
+          storedGroups: [],
+          platformFilter: [],
+          projectFilter: ['https://github.com/kilo/repo.git'],
+          searchQuery: 'checkout',
+          organizationId: null,
+        })
+      )
+    ).toEqual([{ title: 'Active now', ids: ['match'], kinds: ['remote'] }]);
+  });
+
+  it('filters out active-only sessions whose project does not match the project filter', () => {
+    expect(
+      ids(
+        buildSessionSections({
+          activeNow: true,
+          activeSessions: [active({ id: 'other', gitUrl: 'https://github.com/kilo/other.git' })],
+          storedGroups: [],
+          platformFilter: [],
+          projectFilter: ['https://github.com/kilo/repo.git'],
+          searchQuery: '',
+          organizationId: null,
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it('omits active-only sessions when organization scope cannot be verified', () => {
+    expect(
+      buildSessionSections({
+        activeNow: true,
+        activeSessions: [active({ id: 'remote-only' })],
+        storedGroups: [],
+        platformFilter: [],
+        projectFilter: [],
+        searchQuery: '',
+        organizationId: 'org-1',
+      })
+    ).toEqual([]);
+  });
+
+  it('keeps organization-scoped stored records while omitting unverifiable active-only records', () => {
+    const orgStored = stored({ session_id: 'org-stored', organization_id: 'org-1' });
+
+    const sections = buildSessionSections({
+      activeNow: true,
+      activeSessions: [active({ id: 'remote-only' }), active({ id: 'remote-org', organizationId: 'org-1' })],
+      storedGroups: [{ label: 'Today', sessions: [orgStored] }],
+      platformFilter: [],
+      projectFilter: [],
+      searchQuery: '',
+      organizationId: 'org-1',
+    });
+
+    expect(ids(sections)).toEqual([
+      { title: 'Active now', ids: ['remote-org'], kinds: ['remote'] },
+      { title: 'Today', ids: ['org-stored'], kinds: ['stored'] },
+    ]);
+  });
+
+  it('omits an empty Active now section and returns stored sessions after presence ends', () => {
+    const session = stored({ session_id: 'formerly-live' });
+    expect(
+      ids(
+        buildSessionSections({
+          activeNow: true,
+          activeSessions: [],
+          storedGroups: [{ label: 'Today', sessions: [session] }],
+          platformFilter: [],
+          projectFilter: [],
+          searchQuery: '',
+          organizationId: null,
+        })
+      )
+    ).toEqual([{ title: 'Today', ids: ['formerly-live'], kinds: ['stored'] }]);
+  });
+
+  it('deduplicates stored sessions that repeat across groups', () => {
+    const dup = stored({ session_id: 'dup' });
+    const other = stored({ session_id: 'other' });
+    const sections = buildSessionSections({
+      activeNow: false,
+      activeSessions: [],
+      storedGroups: [
+        { label: 'Today', sessions: [dup] },
+        { label: 'Older', sessions: [dup, other] },
+      ],
+      platformFilter: [],
+      projectFilter: [],
+      searchQuery: '',
+      organizationId: null,
+    });
+
+    const allIds = allStoredIds(sections);
+    expect(allIds).toEqual(['dup', 'other']);
+  });
+
+  it('keeps a previously-live stored session in its date section once presence ends, even when activeNow is on', () => {
+    const storedSession = stored({ session_id: 'returned' });
+    const sections = buildSessionSections({
+      activeNow: true,
+      activeSessions: [],
+      storedGroups: [{ label: 'Today', sessions: [storedSession] }],
+      platformFilter: [],
+      projectFilter: [],
+      searchQuery: '',
+      organizationId: null,
+    });
+
+    expect(ids(sections)).toEqual([
+      { title: 'Today', ids: ['returned'], kinds: ['stored'] },
+    ]);
+  });
+});

--- a/apps/mobile/src/components/agents/session-list-sections.ts
+++ b/apps/mobile/src/components/agents/session-list-sections.ts
@@ -1,0 +1,114 @@
+import {
+  matchesSearch,
+  type RemoteSessionItem,
+  type SessionItem,
+  type SessionSection,
+  type StoredSessionItem,
+} from '@/components/agents/session-list-helpers';
+import { type ActiveSession, type StoredSession } from '@/lib/hooks/use-agent-sessions';
+
+type StoredGroup = { label: string; sessions: StoredSession[] };
+
+type BuildSessionSectionsInput = {
+  activeNow: boolean;
+  activeSessions: ActiveSession[];
+  storedGroups: StoredGroup[];
+  platformFilter: string[];
+  projectFilter: string[];
+  searchQuery: string;
+  organizationId?: string | null;
+};
+
+const knownPlatforms = new Set([
+  'cloud-agent',
+  'cloud-agent-web',
+  'vscode',
+  'agent-manager',
+  'cli',
+  'slack',
+  'github',
+  'linear',
+]);
+
+function matchesPlatformSelection(platform: string, selected: string[]): boolean {
+  if (selected.length === 0) return true;
+  return selected.some(value => {
+    if (value === 'cloud-agent') return platform === 'cloud-agent' || platform === 'cloud-agent-web';
+    if (value === 'extension') return platform === 'vscode' || platform === 'agent-manager';
+    if (value === 'other') return !knownPlatforms.has(platform);
+    return platform === value;
+  });
+}
+
+function matchesActiveFilters(
+  session: ActiveSession,
+  input: Pick<
+    BuildSessionSectionsInput,
+    'organizationId' | 'platformFilter' | 'projectFilter' | 'searchQuery'
+  >
+): boolean {
+  const sessionOrganizationId = session.organizationId ?? null;
+  if (input.organizationId !== undefined && sessionOrganizationId !== input.organizationId) {
+    return false;
+  }
+  const platform = session.createdOnPlatform ?? 'cli';
+  if (!matchesPlatformSelection(platform, input.platformFilter)) return false;
+  if (input.projectFilter.length > 0 && (!session.gitUrl || !input.projectFilter.includes(session.gitUrl))) {
+    return false;
+  }
+  return input.searchQuery
+    ? matchesSearch(input.searchQuery, session.title, session.gitUrl ?? null)
+    : true;
+}
+
+function storedItem(session: StoredSession, activeIds: Set<string>): StoredSessionItem {
+  return { kind: 'stored', session, isLive: activeIds.has(session.session_id) };
+}
+
+export function buildSessionSections(input: BuildSessionSectionsInput): SessionSection[] {
+  const activeIds = new Set(input.activeSessions.map(session => session.id));
+  const seenStoredIds = new Set<string>();
+  const storedGroups = input.storedGroups.map(group => ({
+    ...group,
+    sessions: group.sessions.filter(session => {
+      if (seenStoredIds.has(session.session_id)) return false;
+      seenStoredIds.add(session.session_id);
+      return true;
+    }),
+  }));
+  const visibleStored = storedGroups.flatMap(group => group.sessions);
+  const storedIds = new Set(visibleStored.map(session => session.session_id));
+  const activeOnly = input.activeSessions.filter(
+    session => !storedIds.has(session.id) && matchesActiveFilters(session, input)
+  );
+  const result: SessionSection[] = [];
+
+  if (input.activeNow) {
+    const activeItems: SessionItem[] = [
+      ...visibleStored
+        .filter(session => activeIds.has(session.session_id))
+        .map(session => storedItem(session, activeIds)),
+      ...activeOnly.map((session): RemoteSessionItem => ({ kind: 'remote', session })),
+    ];
+    if (activeItems.length > 0) result.push({ title: 'Active now', data: activeItems });
+  } else if (activeOnly.length > 0) {
+    result.push({
+      title: 'Remote',
+      data: activeOnly.map((session): RemoteSessionItem => ({ kind: 'remote', session })),
+    });
+  }
+
+  for (const group of storedGroups) {
+    const sessions = input.activeNow
+      ? group.sessions.filter(session => !activeIds.has(session.session_id))
+      : group.sessions;
+    if (sessions.length > 0) {
+      result.push({
+        title: group.label,
+        data: sessions.map(session => storedItem(session, activeIds)),
+      });
+    }
+  }
+
+  return result;
+}

--- a/apps/mobile/src/components/agents/session-list-sections.ts
+++ b/apps/mobile/src/components/agents/session-list-sections.ts
@@ -31,11 +31,19 @@ const knownPlatforms = new Set([
 ]);
 
 function matchesPlatformSelection(platform: string, selected: string[]): boolean {
-  if (selected.length === 0) return true;
+  if (selected.length === 0) {
+    return true;
+  }
   return selected.some(value => {
-    if (value === 'cloud-agent') return platform === 'cloud-agent' || platform === 'cloud-agent-web';
-    if (value === 'extension') return platform === 'vscode' || platform === 'agent-manager';
-    if (value === 'other') return !knownPlatforms.has(platform);
+    if (value === 'cloud-agent') {
+      return platform === 'cloud-agent' || platform === 'cloud-agent-web';
+    }
+    if (value === 'extension') {
+      return platform === 'vscode' || platform === 'agent-manager';
+    }
+    if (value === 'other') {
+      return !knownPlatforms.has(platform);
+    }
     return platform === value;
   });
 }
@@ -52,8 +60,13 @@ function matchesActiveFilters(
     return false;
   }
   const platform = session.createdOnPlatform ?? 'cli';
-  if (!matchesPlatformSelection(platform, input.platformFilter)) return false;
-  if (input.projectFilter.length > 0 && (!session.gitUrl || !input.projectFilter.includes(session.gitUrl))) {
+  if (!matchesPlatformSelection(platform, input.platformFilter)) {
+    return false;
+  }
+  if (
+    input.projectFilter.length > 0 &&
+    (!session.gitUrl || !input.projectFilter.includes(session.gitUrl))
+  ) {
     return false;
   }
   return input.searchQuery
@@ -71,7 +84,9 @@ export function buildSessionSections(input: BuildSessionSectionsInput): SessionS
   const storedGroups = input.storedGroups.map(group => ({
     ...group,
     sessions: group.sessions.filter(session => {
-      if (seenStoredIds.has(session.session_id)) return false;
+      if (seenStoredIds.has(session.session_id)) {
+        return false;
+      }
       seenStoredIds.add(session.session_id);
       return true;
     }),
@@ -90,7 +105,9 @@ export function buildSessionSections(input: BuildSessionSectionsInput): SessionS
         .map(session => storedItem(session, activeIds)),
       ...activeOnly.map((session): RemoteSessionItem => ({ kind: 'remote', session })),
     ];
-    if (activeItems.length > 0) result.push({ title: 'Active now', data: activeItems });
+    if (activeItems.length > 0) {
+      result.push({ title: 'Active now', data: activeItems });
+    }
   } else if (activeOnly.length > 0) {
     result.push({
       title: 'Remote',

--- a/apps/mobile/src/components/agents/session-row.tsx
+++ b/apps/mobile/src/components/agents/session-row.tsx
@@ -30,6 +30,10 @@ type RemoteSessionRowProps = {
     title: string;
     status: string;
     gitBranch?: string;
+    // Optional: when the active record was enriched with stored metadata
+    // (see active-sessions-router enrichment), use it so stored Cloud rows
+    // label as CLOUD AGENT and genuine active-only fallbacks label as CLI.
+    createdOnPlatform?: string;
   };
   onPress: () => void;
 };
@@ -230,7 +234,7 @@ export function RemoteSessionRow({ session, onPress }: Readonly<RemoteSessionRow
   return (
     <Pressable onPress={onPress} accessibilityLabel={title} className="active:opacity-70">
       <SessionRow
-        agentLabel="CLOUD AGENT"
+        agentLabel={platformLabel(session.createdOnPlatform ?? 'cli')}
         title={title}
         subtitle={session.gitBranch}
         meta={session.status.toUpperCase()}

--- a/apps/mobile/src/lib/agent-session-filters.test.ts
+++ b/apps/mobile/src/lib/agent-session-filters.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createDefaultAgentSessionFilters,
+  parseStoredAgentSessionFilters,
+} from './agent-session-filters';
+
+describe('agent session filters', () => {
+  it('defaults Active now on for a new install', () => {
+    expect(createDefaultAgentSessionFilters()).toEqual({
+      activeNow: true,
+      platformFilter: [],
+      projectFilter: [],
+    });
+  });
+
+  it('migrates an older stored value with Active now enabled', () => {
+    expect(
+      parseStoredAgentSessionFilters(
+        JSON.stringify({ platformFilter: ['cli'], projectFilter: ['git@example/repo.git'] })
+      )
+    ).toEqual({
+      activeNow: true,
+      platformFilter: ['cli'],
+      projectFilter: ['git@example/repo.git'],
+    });
+  });
+
+  it('preserves an explicit disabled value', () => {
+    expect(
+      parseStoredAgentSessionFilters(
+        JSON.stringify({ activeNow: false, platformFilter: [], projectFilter: [] })
+      )
+    ).toEqual({ activeNow: false, platformFilter: [], projectFilter: [] });
+  });
+
+  it.each([null, '', 'null', '[]', '{bad json'])('rejects invalid persisted input %j', raw => {
+    expect(parseStoredAgentSessionFilters(raw)).toBeNull();
+  });
+});

--- a/apps/mobile/src/lib/agent-session-filters.ts
+++ b/apps/mobile/src/lib/agent-session-filters.ts
@@ -1,0 +1,34 @@
+export type AgentSessionFilters = {
+  activeNow: boolean;
+  platformFilter: string[];
+  projectFilter: string[];
+};
+
+export function createDefaultAgentSessionFilters(): AgentSessionFilters {
+  return { activeNow: true, platformFilter: [], projectFilter: [] };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter(item => typeof item === 'string') : [];
+}
+
+export function parseStoredAgentSessionFilters(raw: string | null): AgentSessionFilters | null {
+  if (!raw) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+
+    return {
+      activeNow: typeof parsed.activeNow === 'boolean' ? parsed.activeNow : true,
+      platformFilter: readStringArray(parsed.platformFilter),
+      projectFilter: readStringArray(parsed.projectFilter),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/mobile/src/lib/agent-session-filters.ts
+++ b/apps/mobile/src/lib/agent-session-filters.ts
@@ -17,11 +17,15 @@ function readStringArray(value: unknown): string[] {
 }
 
 export function parseStoredAgentSessionFilters(raw: string | null): AgentSessionFilters | null {
-  if (!raw) return null;
+  if (!raw) {
+    return null;
+  }
 
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (!isRecord(parsed)) return null;
+    if (!isRecord(parsed)) {
+      return null;
+    }
 
     return {
       activeNow: typeof parsed.activeNow === 'boolean' ? parsed.activeNow : true,

--- a/apps/mobile/src/lib/hooks/use-persisted-agent-session-filters.ts
+++ b/apps/mobile/src/lib/hooks/use-persisted-agent-session-filters.ts
@@ -2,62 +2,23 @@ import * as SecureStore from 'expo-secure-store';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner-native';
 
+import {
+  type AgentSessionFilters,
+  createDefaultAgentSessionFilters,
+  parseStoredAgentSessionFilters,
+} from '@/lib/agent-session-filters';
 import { SESSION_FILTERS_KEY } from '@/lib/storage-keys';
 
-type AgentSessionFilters = {
-  platformFilter: string[];
-  projectFilter: string[];
-};
-
-type FiltersUpdater = AgentSessionFilters | ((prev: AgentSessionFilters) => AgentSessionFilters);
+type FiltersUpdater = Partial<AgentSessionFilters> | ((prev: AgentSessionFilters) => AgentSessionFilters);
 type StringArrayUpdater = string[] | ((prev: string[]) => string[]);
-
-function createDefaultFilters(): AgentSessionFilters {
-  return {
-    platformFilter: [],
-    projectFilter: [],
-  };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function readStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.filter(item => typeof item === 'string');
-}
-
-function parseStoredFilters(raw: string | null): AgentSessionFilters | null {
-  if (!raw) {
-    return null;
-  }
-
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!isRecord(parsed)) {
-      return null;
-    }
-
-    return {
-      platformFilter: readStringArray(parsed.platformFilter),
-      projectFilter: readStringArray(parsed.projectFilter),
-    };
-  } catch {
-    return null;
-  }
-}
 
 async function loadStoredFilters(): Promise<AgentSessionFilters> {
   const raw = await SecureStore.getItemAsync(SESSION_FILTERS_KEY);
-  return parseStoredFilters(raw) ?? createDefaultFilters();
+  return parseStoredAgentSessionFilters(raw) ?? createDefaultAgentSessionFilters();
 }
 
 export function usePersistedAgentSessionFilters() {
-  const [filters, setFiltersState] = useState<AgentSessionFilters>(() => createDefaultFilters());
+  const [filters, setFiltersState] = useState<AgentSessionFilters>(() => createDefaultAgentSessionFilters());
   const [hasLoaded, setHasLoaded] = useState(false);
 
   useEffect(() => {
@@ -71,7 +32,7 @@ export function usePersistedAgentSessionFilters() {
         }
       } catch {
         if (isActive) {
-          setFiltersState(createDefaultFilters());
+          setFiltersState(createDefaultAgentSessionFilters());
         }
       } finally {
         if (isActive) {
@@ -107,8 +68,17 @@ export function usePersistedAgentSessionFilters() {
   }, [filters, hasLoaded]);
 
   const setFilters = useCallback((updater: FiltersUpdater) => {
-    setFiltersState(prev => (typeof updater === 'function' ? updater(prev) : updater));
+    setFiltersState(prev =>
+      typeof updater === 'function' ? updater(prev) : { ...prev, ...updater }
+    );
   }, []);
+
+  const setActiveNow = useCallback(
+    (activeNow: boolean) => {
+      setFilters(prev => ({ ...prev, activeNow }));
+    },
+    [setFilters]
+  );
 
   const setPlatformFilter = useCallback(
     (updater: StringArrayUpdater) => {
@@ -131,10 +101,12 @@ export function usePersistedAgentSessionFilters() {
   );
 
   return {
+    activeNow: filters.activeNow,
     platformFilter: filters.platformFilter,
     projectFilter: filters.projectFilter,
     hasLoaded,
     setFilters,
+    setActiveNow,
     setPlatformFilter,
     setProjectFilter,
   };

--- a/apps/mobile/src/lib/hooks/use-persisted-agent-session-filters.ts
+++ b/apps/mobile/src/lib/hooks/use-persisted-agent-session-filters.ts
@@ -9,7 +9,9 @@ import {
 } from '@/lib/agent-session-filters';
 import { SESSION_FILTERS_KEY } from '@/lib/storage-keys';
 
-type FiltersUpdater = Partial<AgentSessionFilters> | ((prev: AgentSessionFilters) => AgentSessionFilters);
+type FiltersUpdater =
+  | Partial<AgentSessionFilters>
+  | ((prev: AgentSessionFilters) => AgentSessionFilters);
 type StringArrayUpdater = string[] | ((prev: string[]) => string[]);
 
 async function loadStoredFilters(): Promise<AgentSessionFilters> {
@@ -18,7 +20,9 @@ async function loadStoredFilters(): Promise<AgentSessionFilters> {
 }
 
 export function usePersistedAgentSessionFilters() {
-  const [filters, setFiltersState] = useState<AgentSessionFilters>(() => createDefaultAgentSessionFilters());
+  const [filters, setFiltersState] = useState<AgentSessionFilters>(() =>
+    createDefaultAgentSessionFilters()
+  );
   const [hasLoaded, setHasLoaded] = useState(false);
 
   useEffect(() => {

--- a/apps/web/src/routers/active-sessions-router.test.ts
+++ b/apps/web/src/routers/active-sessions-router.test.ts
@@ -142,5 +142,27 @@ describe('active-sessions-router', () => {
       expect(result.sessions[2]).not.toHaveProperty('createdOnPlatform');
       expect(result.sessions[2]).not.toHaveProperty('organizationId');
     });
+    it('returns un-enriched sessions when metadata enrichment fails', async () => {
+      const selectSpy = jest.spyOn(db, 'select').mockImplementation(() => {
+        throw new Error('Simulated DB transient error');
+      });
+
+      try {
+        const caller = await createCallerForUser(user.id);
+        const result = await caller.activeSessions.list();
+
+        expect(result.sessions).toHaveLength(3);
+        expect(result.sessions[0]).toEqual({
+          id: ACTIVE_STORED_ID,
+          status: 'busy',
+          title: 'Stored active',
+          connectionId: 'connection-1',
+          gitUrl: 'https://github.com/kilo/heartbeat.git',
+          gitBranch: 'heartbeat-branch',
+        });
+      } finally {
+        selectSpy.mockRestore();
+      }
+    });
   });
 });

--- a/apps/web/src/routers/active-sessions-router.test.ts
+++ b/apps/web/src/routers/active-sessions-router.test.ts
@@ -1,0 +1,146 @@
+import { createCallerForUser } from '@/routers/test-utils';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { db } from '@/lib/drizzle';
+import { cli_sessions_v2, type User } from '@kilocode/db/schema';
+import { inArray } from 'drizzle-orm';
+
+jest.mock('@/lib/config.server', () => {
+  const actual: Record<string, unknown> = jest.requireActual('@/lib/config.server');
+  return {
+    ...actual,
+    SESSION_INGEST_WORKER_URL: 'https://test-ingest.example.com',
+  };
+});
+
+// Globally unique across parallel test runs in the shared test database.
+const SUITE_TAG = 'active-sessions-router-suite-2026-07-15';
+const ACTIVE_STORED_ID = `${SUITE_TAG}-active-stored`;
+const ACTIVE_ONLY_ID = `${SUITE_TAG}-active-only`;
+const OTHER_USER_SESSION_ID = `${SUITE_TAG}-other-user-session`;
+const SESSION_IDS = [ACTIVE_STORED_ID, ACTIVE_ONLY_ID, OTHER_USER_SESSION_ID];
+
+let user: User;
+let otherUser: User;
+
+describe('active-sessions-router', () => {
+  beforeAll(async () => {
+    user = await insertTestUser({
+      google_user_email: `${SUITE_TAG}-user@example.com`,
+      google_user_name: 'Active Sessions User',
+      is_admin: false,
+    });
+    otherUser = await insertTestUser({
+      google_user_email: `${SUITE_TAG}-other@example.com`,
+      google_user_name: 'Active Sessions Other User',
+      is_admin: false,
+    });
+  });
+
+  afterAll(async () => {
+    // Final safety cleanup.
+    await db.delete(cli_sessions_v2).where(inArray(cli_sessions_v2.session_id, SESSION_IDS));
+  });
+
+  describe('list', () => {
+    let fetchSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      // Defensive cleanup in case a previous test run left rows.
+      await db.delete(cli_sessions_v2).where(inArray(cli_sessions_v2.session_id, SESSION_IDS));
+
+      await db.insert(cli_sessions_v2).values([
+        {
+          session_id: ACTIVE_STORED_ID,
+          kilo_user_id: user.id,
+          created_on_platform: 'cloud-agent',
+          organization_id: null,
+          git_url: 'https://github.com/kilo/stored.git',
+          git_branch: 'stored-branch',
+        },
+        {
+          session_id: OTHER_USER_SESSION_ID,
+          kilo_user_id: otherUser.id,
+          created_on_platform: 'cloud-agent',
+          organization_id: null,
+        },
+      ]);
+
+      fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            sessions: [
+              {
+                id: ACTIVE_STORED_ID,
+                status: 'busy',
+                title: 'Stored active',
+                connectionId: 'connection-1',
+                gitUrl: 'https://github.com/kilo/heartbeat.git',
+                gitBranch: 'heartbeat-branch',
+              },
+              {
+                id: ACTIVE_ONLY_ID,
+                status: 'idle',
+                title: 'Remote active',
+                connectionId: 'connection-2',
+              },
+              {
+                id: OTHER_USER_SESSION_ID,
+                status: 'busy',
+                title: 'Collision',
+                connectionId: 'connection-3',
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+    });
+
+    afterEach(async () => {
+      fetchSpy.mockRestore();
+      await db.delete(cli_sessions_v2).where(inArray(cli_sessions_v2.session_id, SESSION_IDS));
+    });
+
+    it('enriches active records with stored metadata and prefers the stored repository fields', async () => {
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.activeSessions.list();
+
+      expect(result.sessions).toHaveLength(3);
+      expect(result.sessions[0]).toMatchObject({
+        id: ACTIVE_STORED_ID,
+        status: 'busy',
+        title: 'Stored active',
+        connectionId: 'connection-1',
+        createdOnPlatform: 'cloud-agent',
+        organizationId: null,
+        gitUrl: 'https://github.com/kilo/stored.git',
+        gitBranch: 'stored-branch',
+      });
+    });
+
+    it('passes active-only and another-user sessions through without leaking stored metadata', async () => {
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.activeSessions.list();
+
+      // active-only: no stored row, must be unchanged.
+      expect(result.sessions[1]).toEqual({
+        id: ACTIVE_ONLY_ID,
+        status: 'idle',
+        title: 'Remote active',
+        connectionId: 'connection-2',
+      });
+      expect(result.sessions[1]).not.toHaveProperty('createdOnPlatform');
+      expect(result.sessions[1]).not.toHaveProperty('organizationId');
+
+      // Collision: another user's stored row must not enrich this caller's response.
+      expect(result.sessions[2]).toEqual({
+        id: OTHER_USER_SESSION_ID,
+        status: 'busy',
+        title: 'Collision',
+        connectionId: 'connection-3',
+      });
+      expect(result.sessions[2]).not.toHaveProperty('createdOnPlatform');
+      expect(result.sessions[2]).not.toHaveProperty('organizationId');
+    });
+  });
+});

--- a/apps/web/src/routers/active-sessions-router.ts
+++ b/apps/web/src/routers/active-sessions-router.ts
@@ -1,8 +1,11 @@
 import 'server-only';
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { z } from 'zod';
+import { and, eq, inArray } from 'drizzle-orm';
 import { SESSION_INGEST_WORKER_URL } from '@/lib/config.server';
 import { generateInternalServiceToken } from '@/lib/tokens';
+import { db } from '@/lib/drizzle';
+import { cli_sessions_v2 } from '@kilocode/db/schema';
 
 const activeSessionSchema = z.object({
   id: z.string(),
@@ -11,6 +14,9 @@ const activeSessionSchema = z.object({
   connectionId: z.string(),
   gitUrl: z.string().optional(),
   gitBranch: z.string().optional(),
+  // Additively enriched from the caller's own stored row, when present.
+  createdOnPlatform: z.string().optional(),
+  organizationId: z.string().nullable().optional(),
 });
 
 const activeSessionsResponseSchema = z.object({
@@ -47,7 +53,52 @@ export const activeSessionsRouter = createTRPCRouter({
       }
 
       const raw = await response.json();
-      return activeSessionsResponseSchema.parse(raw);
+      const parsed = activeSessionsResponseSchema.parse(raw);
+
+      if (parsed.sessions.length === 0) {
+        return parsed;
+      }
+
+      // Enrich with the caller's own stored metadata. Filtering by
+      // `kilo_user_id` keeps another user's stored row from leaking into
+      // this response, even if the ingest worker returns an id that the
+      // current user does not own.
+      const metadata = await db
+        .select({
+          sessionId: cli_sessions_v2.session_id,
+          createdOnPlatform: cli_sessions_v2.created_on_platform,
+          organizationId: cli_sessions_v2.organization_id,
+          gitUrl: cli_sessions_v2.git_url,
+          gitBranch: cli_sessions_v2.git_branch,
+        })
+        .from(cli_sessions_v2)
+        .where(
+          and(
+            eq(cli_sessions_v2.kilo_user_id, ctx.user.id),
+            inArray(
+              cli_sessions_v2.session_id,
+              parsed.sessions.map(session => session.id)
+            )
+          )
+        );
+
+      const metadataById = new Map(metadata.map(row => [row.sessionId, row]));
+
+      return {
+        sessions: parsed.sessions.map(session => {
+          const stored = metadataById.get(session.id);
+          if (!stored) return session;
+          return {
+            ...session,
+            createdOnPlatform: stored.createdOnPlatform,
+            organizationId: stored.organizationId,
+            // Stored Git fields are authoritative when present; fall back
+            // to the heartbeat-reported values otherwise.
+            gitUrl: stored.gitUrl ?? session.gitUrl,
+            gitBranch: stored.gitBranch ?? session.gitBranch,
+          };
+        }),
+      };
     } catch (error) {
       console.warn('[active-sessions] error:', error);
       return { sessions: [] as ActiveSession[] };

--- a/apps/web/src/routers/active-sessions-router.ts
+++ b/apps/web/src/routers/active-sessions-router.ts
@@ -59,46 +59,51 @@ export const activeSessionsRouter = createTRPCRouter({
         return parsed;
       }
 
-      // Enrich with the caller's own stored metadata. Filtering by
-      // `kilo_user_id` keeps another user's stored row from leaking into
-      // this response, even if the ingest worker returns an id that the
-      // current user does not own.
-      const metadata = await db
-        .select({
-          sessionId: cli_sessions_v2.session_id,
-          createdOnPlatform: cli_sessions_v2.created_on_platform,
-          organizationId: cli_sessions_v2.organization_id,
-          gitUrl: cli_sessions_v2.git_url,
-          gitBranch: cli_sessions_v2.git_branch,
-        })
-        .from(cli_sessions_v2)
-        .where(
-          and(
-            eq(cli_sessions_v2.kilo_user_id, ctx.user.id),
-            inArray(
-              cli_sessions_v2.session_id,
-              parsed.sessions.map(session => session.id)
+      try {
+        // Enrich with the caller's own stored metadata. Filtering by
+        // `kilo_user_id` keeps another user's stored row from leaking into
+        // this response, even if the ingest worker returns an id that the
+        // current user does not own.
+        const metadata = await db
+          .select({
+            sessionId: cli_sessions_v2.session_id,
+            createdOnPlatform: cli_sessions_v2.created_on_platform,
+            organizationId: cli_sessions_v2.organization_id,
+            gitUrl: cli_sessions_v2.git_url,
+            gitBranch: cli_sessions_v2.git_branch,
+          })
+          .from(cli_sessions_v2)
+          .where(
+            and(
+              eq(cli_sessions_v2.kilo_user_id, ctx.user.id),
+              inArray(
+                cli_sessions_v2.session_id,
+                parsed.sessions.map(session => session.id)
+              )
             )
-          )
-        );
+          );
 
-      const metadataById = new Map(metadata.map(row => [row.sessionId, row]));
+        const metadataById = new Map(metadata.map(row => [row.sessionId, row]));
 
-      return {
-        sessions: parsed.sessions.map(session => {
-          const stored = metadataById.get(session.id);
-          if (!stored) return session;
-          return {
-            ...session,
-            createdOnPlatform: stored.createdOnPlatform,
-            organizationId: stored.organizationId,
-            // Stored Git fields are authoritative when present; fall back
-            // to the heartbeat-reported values otherwise.
-            gitUrl: stored.gitUrl ?? session.gitUrl,
-            gitBranch: stored.gitBranch ?? session.gitBranch,
-          };
-        }),
-      };
+        return {
+          sessions: parsed.sessions.map(session => {
+            const stored = metadataById.get(session.id);
+            if (!stored) return session;
+            return {
+              ...session,
+              createdOnPlatform: stored.createdOnPlatform,
+              organizationId: stored.organizationId,
+              // Stored Git fields are authoritative when present; fall back
+              // to the heartbeat-reported values otherwise.
+              gitUrl: stored.gitUrl ?? session.gitUrl,
+              gitBranch: stored.gitBranch ?? session.gitBranch,
+            };
+          }),
+        };
+      } catch (error) {
+        console.warn('[active-sessions] enrichment error:', error);
+        return parsed;
+      }
     } catch (error) {
       console.warn('[active-sessions] error:', error);
       return { sessions: [] as ActiveSession[] };


### PR DESCRIPTION
## Summary

Adds a default-on, persisted `Active now` checkbox to the mobile Agents page session filter. When checked, matching active Cloud Agent / remote CLI sessions appear once in a dedicated first `Active now` section and are omitted from the sections below. The section respects search, platform, project, and organization filters.

## Approach

- **Persistence** (`apps/mobile/src/lib/agent-session-filters.ts`, `use-persisted-agent-session-filters.ts`): pure default/migration parser for the persisted filter payload. New installs and pre-existing persisted payloads default `activeNow: true`; an explicit `false` is preserved.
- **tRPC enrichment** (`apps/web/src/routers/active-sessions-router.ts`): additive-only enrichment of `activeSessions.list` with optional `createdOnPlatform`/`organizationId`, scoped strictly to the caller's own stored `cli_sessions_v2` rows (no cross-user leakage), preferring stored Git URL/branch over heartbeat values when present. No schema, migration, or session-ingest changes.
- **Partitioning** (`apps/mobile/src/components/agents/session-list-sections.ts`): pure section builder that dedupes live stored + active-only sessions into one `Active now` section when enabled, and falls back to the existing `Remote` + date-group layout when disabled. Applies platform/project/search/organization filters to active-only sessions (stored sessions are already server-filtered upstream).
- **UI integration** (`platform-filter-modal.tsx`, `session-list-screen.tsx`, `session-row.tsx`): `Active now` checkbox as the first row in the filter modal, removable chip, clear-filters wiring, and correct Cloud Agent/CLI row labeling for enriched vs. genuinely active-only records.

## Feature-state coverage

| State | Coverage |
|---|---|
| Happy | `session-list-sections.test.ts` — checked-mode dedup/ordering; device E2E confirms default-on, checkbox/chip copy and state, filter application, disable/re-enable, persistence after relaunch, chip removal |
| Retryable failure | Existing load/search retry and pull-to-refresh are unmodified; a transient active-poll failure never hides stored history (structural: active section only adds to, never replaces, stored sections) |
| Non-retryable failure | Not applicable — the feature only partitions already-fetched records; no mutation, no terminal failure surface |
| Empty | `session-list-sections.test.ts` — empty active results omit the section header; device E2E confirms existing `No sessions match`/clear-filter behavior |

## Verification

- Mobile: `pnpm format`, `pnpm format:check`, `pnpm test` (120 files / 789 tests, +20 new), `pnpm typecheck`, `pnpm lint`, `pnpm check:unused` — all pass.
- Web: `pnpm --filter web test -- --runInBand src/routers/active-sessions-router.test.ts`, `pnpm --filter web typecheck`, `pnpm --filter web lint` — all pass.
- Fresh independent code review: no valid actionable findings.
- Device E2E (iOS simulator, dev build, worktree-local backend): default-on state, exact `Active now` copy/accessibility state, platform/project/search filter application to the (session-less) active section, disabling/re-enabling the checkbox, chip removal disabling the setting, persistence across force-quit/relaunch, no-active-match empty state, and pull-to-refresh all **passed** with live device evidence.

### Explicit E2E limitation

Flows that require an actual live (connected) Cloud Agent or CLI session — the `Active now` section appearing first with a genuinely live session, no duplicate below, and a session returning to its date group when presence ends — could not be exercised on-device in this worktree. Root cause (confirmed via `cloud-agent-next` and `cloudflare-session-ingest` logs): this worktree's port-offset shifts the local Next.js origin to `http://192.168.1.10:5900`, which is not present in the local `WS_ALLOWED_ORIGINS` allowlist, so the dev-client's live-session WebSocket registration is rejected with `403 Origin not allowed`. This is a local dev-environment configuration gap unrelated to this feature's code (a newly created Cloud Agent session never gets the chance to register presence with session-ingest in this worktree, regardless of the `Active now` filter). The underlying partition/dedup/ordering/organization-scope/presence-ending logic this would exercise is covered by `session-list-sections.test.ts`'s pure unit tests. Flagging for reviewer awareness; happy to re-attempt on-device verification of this specific slice in an environment where the WS origin allowlist matches the worktree's shifted port.

A separate, not-fully-diagnosed observation: during E2E, an app screen occasionally went blank (recovered by tab navigation) after repeatedly toggling the filter modal in quick succession under active Metro Fast Refresh. No JS error or exception was logged, and the behavior was not reproducible from static code inspection of the changed files. Noting this for reviewer awareness in case it recurs; it did not block any of the verified acceptance flows.