### PR TITLE
feat(mobile): sort agent sessions by last updated or created time

### DIFF
--- a/apps/mobile/src/components/agents/platform-filter-modal.tsx
+++ b/apps/mobile/src/components/agents/platform-filter-modal.tsx
@@ -3,7 +3,9 @@ import { useState } from 'react';
 import { Modal, Pressable, ScrollView, View } from 'react-native';
 
 import { Button } from '@/components/ui/button';
+import { ChoiceRow } from '@/components/ui/choice-row';
 import { Text } from '@/components/ui/text';
+import { type AgentSessionSortBy } from '@/lib/agent-session-sort';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { cn } from '@/lib/utils';
 
@@ -18,6 +20,11 @@ const PLATFORM_FILTERS = [
 ] as const;
 const chipScrollContentStyle = { paddingHorizontal: 22, paddingVertical: 8, gap: 8 };
 
+const SORT_OPTIONS: readonly { value: AgentSessionSortBy; label: string }[] = [
+  { value: 'updated_at', label: 'Last updated' },
+  { value: 'created_at', label: 'Created' },
+];
+
 export type ProjectFilterOption = {
   gitUrl: string;
   displayName: string;
@@ -26,9 +33,10 @@ export type ProjectFilterOption = {
 type SessionFilters = {
   platformFilter: string[];
   projectFilter: string[];
+  sortBy: AgentSessionSortBy;
 };
 
-type SessionFilterChipsProps = SessionFilters & {
+type SessionFilterChipsProps = Omit<SessionFilters, 'sortBy'> & {
   projectOptions: ProjectFilterOption[];
   onRemovePlatform: (platform: string) => void;
   onRemoveProject: (gitUrl: string) => void;
@@ -37,6 +45,7 @@ type SessionFilterChipsProps = SessionFilters & {
 type SessionFilterModalProps = {
   selectedPlatforms: string[];
   selectedProjects: string[];
+  selectedSortBy: AgentSessionSortBy;
   projectOptions: ProjectFilterOption[];
   onClose: () => void;
   onApply: (filters: SessionFilters) => void;
@@ -170,12 +179,14 @@ export function SessionFilterChips({
 export function SessionFilterModal({
   selectedPlatforms,
   selectedProjects,
+  selectedSortBy,
   projectOptions,
   onClose,
   onApply,
 }: Readonly<SessionFilterModalProps>) {
   const [draftPlatforms, setDraftPlatforms] = useState<string[]>(selectedPlatforms);
   const [draftProjects, setDraftProjects] = useState<string[]>(selectedProjects);
+  const [draftSortBy, setDraftSortBy] = useState<AgentSessionSortBy>(selectedSortBy);
 
   const togglePlatform = (platform: string) => {
     setDraftPlatforms(prev =>
@@ -213,6 +224,22 @@ export function SessionFilterModal({
           <Text className="text-base font-semibold">Filter sessions</Text>
           <ScrollView showsVerticalScrollIndicator={false}>
             <View className="gap-4">
+              <View className="gap-1">
+                <Text variant="eyebrow" className="px-3">
+                  Sort by
+                </Text>
+                {SORT_OPTIONS.map(option => (
+                  <ChoiceRow
+                    key={option.value}
+                    label={option.label}
+                    selected={draftSortBy === option.value}
+                    onPress={() => {
+                      setDraftSortBy(option.value);
+                    }}
+                    className="rounded-lg px-3"
+                  />
+                ))}
+              </View>
               <View className="gap-1">
                 <Text variant="eyebrow" className="px-3">
                   Platform
@@ -253,7 +280,11 @@ export function SessionFilterModal({
             </Button>
             <Button
               onPress={() => {
-                onApply({ platformFilter: draftPlatforms, projectFilter: draftProjects });
+                onApply({
+                  platformFilter: draftPlatforms,
+                  projectFilter: draftProjects,
+                  sortBy: draftSortBy,
+                });
                 onClose();
               }}
             >

--- a/apps/mobile/src/components/agents/session-list-content.tsx
+++ b/apps/mobile/src/components/agents/session-list-content.tsx
@@ -20,6 +20,7 @@ import { Button } from '@/components/ui/button';
 import { Eyebrow } from '@/components/ui/eyebrow';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
+import { type AgentSessionSortBy } from '@/lib/agent-session-sort';
 import { type StoredSession } from '@/lib/hooks/use-agent-sessions';
 import { useSessionMutations } from '@/lib/hooks/use-session-mutations';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
@@ -45,6 +46,7 @@ type AgentSessionListContentProps = {
   isSearching: boolean;
   onClearQuery: () => void;
   onCreateSession: () => void;
+  sortBy: AgentSessionSortBy;
 };
 
 export function AgentSessionListContent({
@@ -64,6 +66,7 @@ export function AgentSessionListContent({
   isSearching,
   onClearQuery,
   onCreateSession,
+  sortBy,
 }: Readonly<AgentSessionListContentProps>) {
   const colors = useThemeColors();
   const { bottom } = useSafeAreaInsets();
@@ -204,6 +207,7 @@ export function AgentSessionListContent({
           <StoredSessionRow
             session={item.session}
             isLive={item.isLive}
+            sortBy={sortBy}
             onPress={() => {
               onSessionPress(item.session.session_id, item.session.organization_id);
             }}
@@ -225,7 +229,7 @@ export function AgentSessionListContent({
         />
       );
     },
-    [onSessionPress, deleteSession, renameSession, organizationIdBySessionId]
+    [onSessionPress, deleteSession, renameSession, organizationIdBySessionId, sortBy]
   );
 
   const renderSectionHeader = useCallback(

--- a/apps/mobile/src/components/agents/session-list-screen.tsx
+++ b/apps/mobile/src/components/agents/session-list-screen.tsx
@@ -19,6 +19,7 @@ import {
   type StoredSessionItem,
 } from '@/components/agents/session-list-helpers';
 import { ScreenHeader } from '@/components/screen-header';
+import { clearAgentSessionNarrowingFilters } from '@/lib/agent-session-filters';
 import {
   useAgentSessions,
   useAgentSessionSearch,
@@ -36,6 +37,7 @@ export function AgentSessionListScreen() {
   const {
     platformFilter,
     projectFilter,
+    sortBy,
     hasLoaded: filtersLoaded,
     setFilters,
     setPlatformFilter,
@@ -97,6 +99,7 @@ export function AgentSessionListScreen() {
     gitUrl,
     organizationId,
     enabled: ready,
+    sortBy,
   });
   const isSearching = searchQuery.length > 0;
   const search = useAgentSessionSearch({
@@ -105,6 +108,7 @@ export function AgentSessionListScreen() {
     gitUrl,
     organizationId,
     enabled: ready && isSearching,
+    sortBy,
   });
   const { data: recentRepositories } = useRecentAgentRepositories({
     organizationId,
@@ -261,7 +265,9 @@ export function AgentSessionListScreen() {
 
   const handleClearQuery = useCallback(() => {
     handleClearSearch();
-    setFilters({ platformFilter: [], projectFilter: [] });
+    // Functional update so the persisted sort preference is preserved
+    // across "Clear search" / "Clear filters".
+    setFilters(prev => clearAgentSessionNarrowingFilters(prev));
   }, [handleClearSearch, setFilters]);
 
   return (
@@ -317,12 +323,14 @@ export function AgentSessionListScreen() {
           onCreateSession={() => {
             router.push(getNewAgentSessionPath(organizationId) as Href);
           }}
+          sortBy={sortBy}
         />
       </Animated.View>
       {showFilterModal && (
         <SessionFilterModal
           selectedPlatforms={platformFilter}
           selectedProjects={projectFilter}
+          selectedSortBy={sortBy}
           projectOptions={projectOptions}
           onClose={() => {
             setShowFilterModal(false);

--- a/apps/mobile/src/components/agents/session-row.tsx
+++ b/apps/mobile/src/components/agents/session-row.tsx
@@ -4,6 +4,7 @@ import { ActionSheetIOS, Alert, Modal, Platform, Pressable, TextInput, View } fr
 
 import { SessionRow } from '@/components/ui/session-row';
 import { Text } from '@/components/ui/text';
+import { type AgentSessionSortBy, getAgentSessionTimestamp } from '@/lib/agent-session-sort';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { parseTimestamp, timeAgo } from '@/lib/utils';
 
@@ -14,11 +15,18 @@ type StoredSessionRowProps = {
     git_url: string | null;
     cloud_agent_session_id: string | null;
     created_on_platform: string;
+    created_at: string;
     updated_at: string;
     git_branch: string | null;
     status: string | null;
   };
   isLive: boolean;
+  /**
+   * Which timestamp drives the row's relative meta label. The list
+   * section the session lands in and the timestamp shown here are
+   * both computed from this same field, so the two never contradict.
+   */
+  sortBy: AgentSessionSortBy;
   onPress: () => void;
   onDelete: () => void;
   onRename: (newTitle: string) => void;
@@ -96,6 +104,7 @@ function showRenamePrompt(currentTitle: string, onRename: (newTitle: string) => 
 export function StoredSessionRow({
   session,
   isLive,
+  sortBy,
   onPress,
   onDelete,
   onRename,
@@ -165,7 +174,7 @@ export function StoredSessionRow({
           agentLabel={agentLabel}
           title={title}
           subtitle={session.git_branch}
-          meta={formatMeta(session.updated_at)}
+          meta={formatMeta(getAgentSessionTimestamp(session, sortBy))}
           live={isLive}
           stripMode="inline"
           className="pl-[22px] pr-[22px]"

--- a/apps/mobile/src/components/agents/session-row.tsx
+++ b/apps/mobile/src/components/agents/session-row.tsx
@@ -68,8 +68,8 @@ function platformLabel(platform: string): string {
   }
 }
 
-function formatMeta(updatedAt: string): string {
-  return timeAgo(parseTimestamp(updatedAt)).toUpperCase();
+function formatMeta(timestamp: string): string {
+  return timeAgo(parseTimestamp(timestamp)).toUpperCase();
 }
 
 function showDeleteConfirm(onDelete: () => void) {

--- a/apps/mobile/src/lib/agent-session-filters.test.ts
+++ b/apps/mobile/src/lib/agent-session-filters.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type AgentSessionFilters,
+  clearAgentSessionNarrowingFilters,
+  createDefaultAgentSessionFilters,
+  parseStoredAgentSessionFilters,
+} from './agent-session-filters';
+
+describe('createDefaultAgentSessionFilters', () => {
+  it('returns empty narrowing filters and the default sort', () => {
+    expect(createDefaultAgentSessionFilters()).toEqual({
+      platformFilter: [],
+      projectFilter: [],
+      sortBy: 'updated_at',
+    });
+  });
+});
+
+describe('parseStoredAgentSessionFilters', () => {
+  it('returns null for invalid JSON', () => {
+    expect(parseStoredAgentSessionFilters('not json')).toBeNull();
+  });
+
+  it('returns null for non-object JSON', () => {
+    expect(parseStoredAgentSessionFilters('null')).toBeNull();
+    expect(parseStoredAgentSessionFilters('42')).toBeNull();
+    expect(parseStoredAgentSessionFilters('"hi"')).toBeNull();
+    expect(parseStoredAgentSessionFilters('[1,2,3]')).toBeNull();
+  });
+
+  it('tolerantly parses platform and project arrays', () => {
+    const raw = JSON.stringify({
+      platformFilter: ['cli', 'cloud-agent'],
+      projectFilter: ['https://github.com/foo/bar'],
+    });
+    expect(parseStoredAgentSessionFilters(raw)).toEqual({
+      platformFilter: ['cli', 'cloud-agent'],
+      projectFilter: ['https://github.com/foo/bar'],
+      sortBy: 'updated_at',
+    });
+  });
+
+  it('drops non-string entries from array filters', () => {
+    const raw = JSON.stringify({
+      platformFilter: ['cli', 42, null, 'extension'],
+      projectFilter: [{}, 'https://x', 'y'],
+    });
+    expect(parseStoredAgentSessionFilters(raw)).toEqual({
+      platformFilter: ['cli', 'extension'],
+      projectFilter: ['https://x', 'y'],
+      sortBy: 'updated_at',
+    });
+  });
+
+  it('accepts a stored sortBy value', () => {
+    const raw = JSON.stringify({
+      platformFilter: [],
+      projectFilter: [],
+      sortBy: 'created_at',
+    });
+    expect(parseStoredAgentSessionFilters(raw)?.sortBy).toBe('created_at');
+  });
+
+  it('defaults sortBy to updated_at for missing, malformed, or unknown values', () => {
+    expect(
+      parseStoredAgentSessionFilters(JSON.stringify({ platformFilter: [], projectFilter: [] }))
+        ?.sortBy
+    ).toBe('updated_at');
+    expect(
+      parseStoredAgentSessionFilters(
+        JSON.stringify({ platformFilter: [], projectFilter: [], sortBy: 'title' })
+      )?.sortBy
+    ).toBe('updated_at');
+    expect(
+      parseStoredAgentSessionFilters(
+        JSON.stringify({ platformFilter: [], projectFilter: [], sortBy: 42 })
+      )?.sortBy
+    ).toBe('updated_at');
+  });
+});
+
+describe('clearAgentSessionNarrowingFilters', () => {
+  const current: AgentSessionFilters = {
+    platformFilter: ['cli'],
+    projectFilter: ['https://github.com/foo/bar'],
+    sortBy: 'created_at',
+  };
+
+  it('resets platform and project filters but preserves sortBy', () => {
+    expect(clearAgentSessionNarrowingFilters(current)).toEqual({
+      platformFilter: [],
+      projectFilter: [],
+      sortBy: 'created_at',
+    });
+  });
+
+  it('does not mutate the input', () => {
+    const snapshot: AgentSessionFilters = {
+      ...current,
+      platformFilter: [...current.platformFilter],
+    };
+    clearAgentSessionNarrowingFilters(current);
+    expect(current).toEqual(snapshot);
+  });
+});

--- a/apps/mobile/src/lib/agent-session-filters.ts
+++ b/apps/mobile/src/lib/agent-session-filters.ts
@@ -1,0 +1,77 @@
+import { type AgentSessionSortBy, parseAgentSessionSortBy } from './agent-session-sort';
+
+/**
+ * Pure contract for the persisted agent-session filter set. Intentionally
+ * free of any Expo / SecureStore imports so it can be unit-tested in node
+ * and re-used by tests/mocks without touching the native bridge.
+ */
+export type AgentSessionFilters = {
+  platformFilter: string[];
+  projectFilter: string[];
+  sortBy: AgentSessionSortBy;
+};
+
+export function createDefaultAgentSessionFilters(): AgentSessionFilters {
+  return {
+    platformFilter: [],
+    projectFilter: [],
+    sortBy: parseAgentSessionSortBy(undefined),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+/**
+ * Parse the raw SecureStore JSON for the agent-session filter record. Returns
+ * `null` only when the JSON itself is malformed or not an object — in every
+ * other case the function tolerantly recovers so a partially bad record
+ * (e.g. an unknown sortBy or a non-array platformFilter) still produces a
+ * usable filter object with the default where applicable.
+ */
+export function parseStoredAgentSessionFilters(raw: string | null): AgentSessionFilters | null {
+  if (!raw) {
+    return null;
+  }
+
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed)) {
+    return null;
+  }
+
+  return {
+    platformFilter: readStringArray(parsed.platformFilter),
+    projectFilter: readStringArray(parsed.projectFilter),
+    sortBy: parseAgentSessionSortBy(parsed.sortBy),
+  };
+}
+
+/**
+ * Reset the narrowing parts of the filter record (platform + project) while
+ * leaving `sortBy` untouched — sort is a persistent preference, not a
+ * transient filter, and "Clear filters" / "Clear search" must never
+ * silently revert it to the default.
+ */
+export function clearAgentSessionNarrowingFilters(
+  filters: AgentSessionFilters
+): AgentSessionFilters {
+  return {
+    platformFilter: [],
+    projectFilter: [],
+    sortBy: filters.sortBy,
+  };
+}

--- a/apps/mobile/src/lib/agent-session-groups.test.ts
+++ b/apps/mobile/src/lib/agent-session-groups.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { groupAgentSessionsByDate } from './agent-session-groups';
+
+type FakeSession = {
+  session_id: string;
+  created_at: string;
+  updated_at: string;
+};
+
+const NOW = new Date('2024-06-10T12:00:00.000Z');
+
+function iso(daysAgo: number, hour = 12): string {
+  const d = new Date(NOW);
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  d.setUTCHours(hour, 0, 0, 0);
+  return d.toISOString();
+}
+
+describe('groupAgentSessionsByDate', () => {
+  it('does not mutate the input array', () => {
+    const input: FakeSession[] = [
+      { session_id: 'b', created_at: iso(5), updated_at: iso(0) },
+      { session_id: 'a', created_at: iso(0), updated_at: iso(5) },
+    ];
+    const original = [...input];
+    groupAgentSessionsByDate(input, 'updated_at', NOW);
+    expect(input).toEqual(original);
+  });
+
+  it('sorts by updated_at descending by default (matches legacy behavior)', () => {
+    const input: FakeSession[] = [
+      { session_id: 'old', created_at: iso(20), updated_at: iso(20) },
+      { session_id: 'fresh', created_at: iso(2), updated_at: iso(0) },
+      { session_id: 'mid', created_at: iso(10), updated_at: iso(5) },
+    ];
+    const groups = groupAgentSessionsByDate(input, 'updated_at', NOW);
+    const flat = groups.flatMap(g => g.sessions);
+    expect(flat.map(s => s.session_id)).toEqual(['fresh', 'mid', 'old']);
+  });
+
+  it('sorts by created_at descending when requested', () => {
+    const input: FakeSession[] = [
+      { session_id: 'old', created_at: iso(20), updated_at: iso(0) },
+      { session_id: 'fresh', created_at: iso(2), updated_at: iso(20) },
+      { session_id: 'mid', created_at: iso(10), updated_at: iso(5) },
+    ];
+    const groups = groupAgentSessionsByDate(input, 'created_at', NOW);
+    const flat = groups.flatMap(g => g.sessions);
+    expect(flat.map(s => s.session_id)).toEqual(['fresh', 'mid', 'old']);
+  });
+
+  it('buckets sessions into Today / Yesterday / weekday / Older', () => {
+    const input: FakeSession[] = [
+      { session_id: 'today', created_at: iso(0, 8), updated_at: iso(0, 8) },
+      { session_id: 'yesterday', created_at: iso(1, 8), updated_at: iso(1, 8) },
+      { session_id: 'this-week', created_at: iso(3, 8), updated_at: iso(3, 8) },
+      { session_id: 'ancient', created_at: iso(30, 8), updated_at: iso(30, 8) },
+    ];
+    const groups = groupAgentSessionsByDate(input, 'updated_at', NOW);
+    const labels = groups.map(g => g.label);
+    expect(labels).toContain('Today');
+    expect(labels).toContain('Yesterday');
+    expect(labels).toContain('Older');
+    // The 3-days-ago bucket label is the weekday of that date in en-US.
+    const weekday = new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(
+      new Date(iso(3, 8))
+    );
+    expect(labels).toContain(weekday);
+  });
+
+  it('places Today before Yesterday before weekday before Older', () => {
+    const input: FakeSession[] = [
+      { session_id: 'ancient', created_at: iso(30), updated_at: iso(30) },
+      { session_id: 'this-week', created_at: iso(3), updated_at: iso(3) },
+      { session_id: 'yesterday', created_at: iso(1), updated_at: iso(1) },
+      { session_id: 'today', created_at: iso(0), updated_at: iso(0) },
+    ];
+    const groups = groupAgentSessionsByDate(input, 'updated_at', NOW);
+    expect(groups.map(g => g.label)).toEqual(['Today', 'Yesterday', expect.any(String), 'Older']);
+  });
+
+  it('places weekend-stale created_at in the correct weekday bucket under created_at sort', () => {
+    // updated_at is "today" but created_at is ancient — by created_at sort it
+    // belongs in Older, not Today.
+    const input: FakeSession[] = [
+      { session_id: 'ancient-created', created_at: iso(60), updated_at: iso(0) },
+    ];
+    const groups = groupAgentSessionsByDate(input, 'created_at', NOW);
+    expect(groups.map(g => g.label)).toEqual(['Older']);
+  });
+
+  it('keeps a weekday bucket in selected-timestamp descending order when multiple sessions land on the same day', () => {
+    // 4 days ago = the only day-of-week in this test that lands in the weekday
+    // bucket (not Today, not Yesterday, not Older). All three sessions share
+    // that day but with different hours.
+    const input: FakeSession[] = [
+      { session_id: 'late', created_at: iso(4, 20), updated_at: iso(4, 20) },
+      { session_id: 'early', created_at: iso(4, 8), updated_at: iso(4, 8) },
+      { session_id: 'mid', created_at: iso(4, 14), updated_at: iso(4, 14) },
+    ];
+    const groups = groupAgentSessionsByDate(input, 'updated_at', NOW);
+    const weekday = new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(new Date(iso(4)));
+    const weekdayGroup = groups.find(g => g.label === weekday);
+    expect(weekdayGroup?.sessions.map(s => s.session_id)).toEqual(['late', 'mid', 'early']);
+  });
+
+  it('keeps Older bucket in selected-timestamp descending order', () => {
+    const input: FakeSession[] = [
+      { session_id: '60d', created_at: iso(60), updated_at: iso(60) },
+      { session_id: '20d', created_at: iso(20), updated_at: iso(20) },
+      { session_id: '90d', created_at: iso(90), updated_at: iso(90) },
+    ];
+    const groups = groupAgentSessionsByDate(input, 'updated_at', NOW);
+    const older = groups.find(g => g.label === 'Older');
+    expect(older?.sessions.map(s => s.session_id)).toEqual(['20d', '60d', '90d']);
+  });
+});

--- a/apps/mobile/src/lib/agent-session-groups.ts
+++ b/apps/mobile/src/lib/agent-session-groups.ts
@@ -1,0 +1,104 @@
+import {
+  type AgentSessionSortBy,
+  getAgentSessionTimestamp,
+  parseAgentSessionSortBy,
+} from './agent-session-sort';
+import { parseTimestamp } from '@/lib/utils';
+
+type SessionTimestamps = { created_at: string; updated_at: string };
+
+type AgentSessionDateGroup<T extends SessionTimestamps> = {
+  label: string;
+  sessions: T[];
+};
+
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+function getWeekdayName(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(date);
+}
+
+function timestampMs(session: SessionTimestamps, sortBy: AgentSessionSortBy): number {
+  return parseTimestamp(getAgentSessionTimestamp(session, sortBy)).getTime();
+}
+
+/**
+ * Bucket sessions into the existing Today / Yesterday / weekday / Older
+ * sections, sorted newest-first by the selected timestamp. The input array
+ * is never mutated — callers can hand in the tRPC query result directly.
+ *
+ * Server-side ordering is authoritative for cross-page consistency, but
+ * every section boundary check uses the same timestamp the row's relative
+ * meta label will display, so a session can never end up in a section that
+ * contradicts the timestamp it shows.
+ */
+export function groupAgentSessionsByDate<T extends SessionTimestamps>(
+  sessions: T[],
+  sortBy: AgentSessionSortBy,
+  now: Date = new Date()
+): AgentSessionDateGroup<T>[] {
+  // Defensive: tolerate callers (e.g. older call sites) that pass an unknown
+  // string here, the same way parseAgentSessionSortBy would have.
+  const resolvedSort = parseAgentSessionSortBy(sortBy);
+  const sorted = [...sessions].toSorted(
+    (a, b) => timestampMs(b, resolvedSort) - timestampMs(a, resolvedSort)
+  );
+
+  const yesterday = addDays(now, -1);
+
+  const buckets = new Map<string, T[]>();
+  const bucketOrder: string[] = [];
+
+  function addToBucket(label: string, session: T) {
+    const existing = buckets.get(label);
+    if (existing) {
+      existing.push(session);
+    } else {
+      buckets.set(label, [session]);
+      bucketOrder.push(label);
+    }
+  }
+
+  for (const session of sorted) {
+    const date = parseTimestamp(getAgentSessionTimestamp(session, resolvedSort));
+
+    if (isSameDay(date, now)) {
+      addToBucket('Today', session);
+    } else if (isSameDay(date, yesterday)) {
+      addToBucket('Yesterday', session);
+    } else {
+      const diffMs = now.getTime() - date.getTime();
+      const diffDays = diffMs / (1000 * 60 * 60 * 24);
+      if (diffDays <= 7) {
+        addToBucket(getWeekdayName(date), session);
+      } else {
+        addToBucket('Older', session);
+      }
+    }
+  }
+
+  // The weekday bucket holds sessions in their sorted (newest-first) order
+  // already; Older needs a second pass because it's keyed by label, not by
+  // insertion order of distinct days.
+  const olderBucket = buckets.get('Older');
+  if (olderBucket) {
+    olderBucket.sort((a, b) => timestampMs(b, resolvedSort) - timestampMs(a, resolvedSort));
+  }
+
+  return bucketOrder.map(label => ({
+    label,
+    sessions: buckets.get(label) ?? [],
+  }));
+}

--- a/apps/mobile/src/lib/agent-session-groups.ts
+++ b/apps/mobile/src/lib/agent-session-groups.ts
@@ -52,7 +52,8 @@ export function groupAgentSessionsByDate<T extends SessionTimestamps>(
   // Defensive: tolerate callers (e.g. older call sites) that pass an unknown
   // string here, the same way parseAgentSessionSortBy would have.
   const resolvedSort = parseAgentSessionSortBy(sortBy);
-  const sorted = [...sessions].toSorted(
+  // eslint-disable-next-line unicorn/no-array-sort -- Hermes does not implement Array.prototype.toSorted; spread already prevents mutation of the source
+  const sorted = [...sessions].sort(
     (a, b) => timestampMs(b, resolvedSort) - timestampMs(a, resolvedSort)
   );
 

--- a/apps/mobile/src/lib/agent-session-input.ts
+++ b/apps/mobile/src/lib/agent-session-input.ts
@@ -1,0 +1,81 @@
+import {
+  type AgentSessionSortBy,
+  DEFAULT_AGENT_SESSION_SORT,
+  parseAgentSessionSortBy,
+} from './agent-session-sort';
+
+/**
+ * Pure input-builder for the `cliSessionsV2.list` tRPC query. Lives in its
+ * own module (no React, no react-query) so the test suite can exercise
+ * sorting/filtering without pulling in the native bridge.
+ *
+ * Defaults `orderBy` to `updated_at` so callers that don't care about
+ * sort (e.g. Home's session surface) keep the legacy behavior bit-for-bit.
+ */
+type AgentSessionListInput = {
+  limit: number;
+  orderBy: AgentSessionSortBy;
+  includeChildren: boolean;
+  createdOnPlatform?: string | string[];
+  gitUrl?: string | string[];
+  organizationId?: string | null;
+};
+
+const SESSIONS_PAGE_SIZE = 30;
+
+function resolveSortBy(sortBy: AgentSessionSortBy | undefined): AgentSessionSortBy {
+  return parseAgentSessionSortBy(sortBy ?? DEFAULT_AGENT_SESSION_SORT);
+}
+
+export function buildAgentSessionListInput(options: {
+  createdOnPlatform?: string | string[];
+  gitUrl?: string | string[];
+  organizationId?: string | null;
+  sortBy?: AgentSessionSortBy;
+}): AgentSessionListInput {
+  const sortBy = resolveSortBy(options.sortBy);
+  return {
+    limit: SESSIONS_PAGE_SIZE,
+    orderBy: sortBy,
+    includeChildren: false,
+    createdOnPlatform: options.createdOnPlatform,
+    gitUrl: options.gitUrl,
+    organizationId: options.organizationId,
+  };
+}
+
+/**
+ * Pure input-builder for the `cliSessionsV2.search` tRPC query. Same
+ * rationale as `buildAgentSessionListInput` — kept in this module so the
+ * test suite can cover sort fallback + passthrough without the native
+ * stack.
+ */
+type AgentSessionSearchInput = {
+  search_string: string;
+  limit: number;
+  orderBy: AgentSessionSortBy;
+  includeChildren: boolean;
+  createdOnPlatform?: string | string[];
+  gitUrl?: string | string[];
+  organizationId?: string | null;
+};
+
+export function buildAgentSessionSearchInput(options: {
+  searchQuery: string;
+  createdOnPlatform?: string | string[];
+  gitUrl?: string | string[];
+  organizationId?: string | null;
+  sortBy?: AgentSessionSortBy;
+}): AgentSessionSearchInput {
+  const sortBy = resolveSortBy(options.sortBy);
+  return {
+    search_string: options.searchQuery,
+    // Endpoint max; no offset paging — past 50 matches, refining the query is the answer.
+    limit: 50,
+    orderBy: sortBy,
+    includeChildren: false,
+    createdOnPlatform: options.createdOnPlatform,
+    gitUrl: options.gitUrl,
+    organizationId: options.organizationId,
+  };
+}

--- a/apps/mobile/src/lib/agent-session-sort.test.ts
+++ b/apps/mobile/src/lib/agent-session-sort.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AGENT_SESSION_SORT_OPTIONS,
+  type AgentSessionSortBy,
+  DEFAULT_AGENT_SESSION_SORT,
+  getAgentSessionTimestamp,
+  parseAgentSessionSortBy,
+} from './agent-session-sort';
+
+describe('AGENT_SESSION_SORT_OPTIONS', () => {
+  it('lists every supported sort field exactly once', () => {
+    expect(AGENT_SESSION_SORT_OPTIONS).toEqual(['updated_at', 'created_at']);
+  });
+});
+
+describe('DEFAULT_AGENT_SESSION_SORT', () => {
+  it('defaults to updated_at so existing behavior is preserved', () => {
+    expect(DEFAULT_AGENT_SESSION_SORT).toBe('updated_at');
+  });
+});
+
+describe('parseAgentSessionSortBy', () => {
+  it('accepts every option', () => {
+    expect(parseAgentSessionSortBy('updated_at')).toBe<AgentSessionSortBy>('updated_at');
+    expect(parseAgentSessionSortBy('created_at')).toBe<AgentSessionSortBy>('created_at');
+  });
+
+  it('defaults to updated_at for missing, empty, or non-string values', () => {
+    expect(parseAgentSessionSortBy(undefined)).toBe('updated_at');
+    expect(parseAgentSessionSortBy(null)).toBe('updated_at');
+    expect(parseAgentSessionSortBy('')).toBe('updated_at');
+    expect(parseAgentSessionSortBy(42)).toBe('updated_at');
+    expect(parseAgentSessionSortBy({})).toBe('updated_at');
+  });
+
+  it('defaults to updated_at for unknown or legacy sort values', () => {
+    expect(parseAgentSessionSortBy('title')).toBe('updated_at');
+    expect(parseAgentSessionSortBy('updatedAt')).toBe('updated_at');
+    expect(parseAgentSessionSortBy('createdAt')).toBe('updated_at');
+  });
+});
+
+describe('getAgentSessionTimestamp', () => {
+  it('returns updated_at verbatim when sort is updated_at', () => {
+    expect(
+      getAgentSessionTimestamp(
+        { created_at: '2024-01-02T00:00:00.000Z', updated_at: '2024-06-01T00:00:00.000Z' },
+        'updated_at'
+      )
+    ).toBe('2024-06-01T00:00:00.000Z');
+  });
+
+  it('returns created_at verbatim when sort is created_at', () => {
+    expect(
+      getAgentSessionTimestamp(
+        { created_at: '2024-01-02T00:00:00.000Z', updated_at: '2024-06-01T00:00:00.000Z' },
+        'created_at'
+      )
+    ).toBe('2024-01-02T00:00:00.000Z');
+  });
+
+  it('falls back to updated_at when sort is anything else', () => {
+    expect(
+      getAgentSessionTimestamp(
+        { created_at: '2024-01-02T00:00:00.000Z', updated_at: '2024-06-01T00:00:00.000Z' },
+        'title' as unknown as AgentSessionSortBy
+      )
+    ).toBe('2024-06-01T00:00:00.000Z');
+  });
+});

--- a/apps/mobile/src/lib/agent-session-sort.ts
+++ b/apps/mobile/src/lib/agent-session-sort.ts
@@ -1,0 +1,43 @@
+/**
+ * The set of fields the agent-sessions list/search endpoints accept as the
+ * `orderBy` argument. Today they both default to `updated_at` server-side;
+ * the value here MUST stay in sync with the zod enum in the web router
+ * (`ListSessionsInputSchema.orderBy` / `SearchInputSchema.orderBy`).
+ */
+export const AGENT_SESSION_SORT_OPTIONS = ['updated_at', 'created_at'] as const;
+
+export type AgentSessionSortBy = (typeof AGENT_SESSION_SORT_OPTIONS)[number];
+
+export const DEFAULT_AGENT_SESSION_SORT: AgentSessionSortBy = 'updated_at';
+
+const SORT_BY_SET = new Set<string>(AGENT_SESSION_SORT_OPTIONS);
+
+/**
+ * Coerce arbitrary persisted/legacy/unknown input into a known sort value.
+ * Anything that isn't a recognized field falls back to the default so a bad
+ * SecureStore record can never crash the list.
+ */
+export function parseAgentSessionSortBy(value: unknown): AgentSessionSortBy {
+  if (typeof value === 'string' && SORT_BY_SET.has(value)) {
+    return value as AgentSessionSortBy;
+  }
+  return DEFAULT_AGENT_SESSION_SORT;
+}
+
+type AgentSessionTimestamps = { created_at: string; updated_at: string };
+
+/**
+ * Pick which timestamp string drives ordering and relative-time display
+ * for the given sort. Defensive fallback to `updated_at` for a non-`SortBy`
+ * input so callers that interpolate from a wider value type can't break the
+ * row's meta label.
+ */
+export function getAgentSessionTimestamp(
+  session: AgentSessionTimestamps,
+  sortBy: AgentSessionSortBy
+): string {
+  if (sortBy === 'created_at') {
+    return session.created_at;
+  }
+  return session.updated_at;
+}

--- a/apps/mobile/src/lib/hooks/use-agent-sessions.test.ts
+++ b/apps/mobile/src/lib/hooks/use-agent-sessions.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAgentSessionListInput,
+  buildAgentSessionSearchInput,
+} from '@/lib/agent-session-input';
+
+describe('buildAgentSessionListInput', () => {
+  it('defaults to updated_at when sortBy is omitted (matches pre-feature behavior)', () => {
+    expect(
+      buildAgentSessionListInput({
+        createdOnPlatform: 'cli',
+        organizationId: null,
+      })
+    ).toMatchObject({
+      orderBy: 'updated_at',
+      limit: 30,
+      includeChildren: false,
+      createdOnPlatform: 'cli',
+      organizationId: null,
+    });
+  });
+
+  it('passes updated_at through when explicitly requested', () => {
+    expect(
+      buildAgentSessionListInput({
+        sortBy: 'updated_at',
+      }).orderBy
+    ).toBe('updated_at');
+  });
+
+  it('passes created_at through when explicitly requested', () => {
+    expect(
+      buildAgentSessionListInput({
+        sortBy: 'created_at',
+      }).orderBy
+    ).toBe('created_at');
+  });
+
+  it('falls back to updated_at for an unknown sort value (defensive default)', () => {
+    expect(
+      buildAgentSessionListInput({
+        sortBy: 'title' as unknown as 'updated_at',
+      }).orderBy
+    ).toBe('updated_at');
+  });
+
+  it('forwards filter fields alongside the sort', () => {
+    expect(
+      buildAgentSessionListInput({
+        sortBy: 'created_at',
+        createdOnPlatform: ['cli', 'extension'],
+        gitUrl: ['https://github.com/foo/bar'],
+        organizationId: 'org-1',
+      })
+    ).toEqual({
+      limit: 30,
+      orderBy: 'created_at',
+      includeChildren: false,
+      createdOnPlatform: ['cli', 'extension'],
+      gitUrl: ['https://github.com/foo/bar'],
+      organizationId: 'org-1',
+    });
+  });
+});
+
+describe('buildAgentSessionSearchInput', () => {
+  it('defaults to updated_at when sortBy is omitted', () => {
+    expect(buildAgentSessionSearchInput({ searchQuery: 'hello' })).toMatchObject({
+      search_string: 'hello',
+      orderBy: 'updated_at',
+      limit: 50,
+      includeChildren: false,
+    });
+  });
+
+  it('uses created_at when explicitly requested', () => {
+    expect(
+      buildAgentSessionSearchInput({ searchQuery: 'hello', sortBy: 'created_at' })
+    ).toMatchObject({
+      search_string: 'hello',
+      orderBy: 'created_at',
+      limit: 50,
+    });
+  });
+
+  it('falls back to updated_at for an unknown sort value', () => {
+    expect(
+      buildAgentSessionSearchInput({
+        searchQuery: 'hello',
+        sortBy: 'name' as unknown as 'updated_at',
+      }).orderBy
+    ).toBe('updated_at');
+  });
+
+  it('forwards filter fields alongside the sort', () => {
+    expect(
+      buildAgentSessionSearchInput({
+        searchQuery: 'hello',
+        sortBy: 'created_at',
+        createdOnPlatform: 'cli',
+        gitUrl: 'https://github.com/foo/bar',
+        organizationId: 'org-1',
+      })
+    ).toEqual({
+      search_string: 'hello',
+      limit: 50,
+      orderBy: 'created_at',
+      includeChildren: false,
+      createdOnPlatform: 'cli',
+      gitUrl: 'https://github.com/foo/bar',
+      organizationId: 'org-1',
+    });
+  });
+});

--- a/apps/mobile/src/lib/hooks/use-agent-sessions.ts
+++ b/apps/mobile/src/lib/hooks/use-agent-sessions.ts
@@ -2,8 +2,17 @@ import { type inferRouterOutputs, type RootRouter } from '@kilocode/trpc';
 import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
+import {
+  buildAgentSessionListInput,
+  buildAgentSessionSearchInput,
+} from '@/lib/agent-session-input';
+import { groupAgentSessionsByDate } from '@/lib/agent-session-groups';
+import {
+  type AgentSessionSortBy,
+  DEFAULT_AGENT_SESSION_SORT,
+  parseAgentSessionSortBy,
+} from '@/lib/agent-session-sort';
 import { useTRPC } from '@/lib/trpc';
-import { parseTimestamp } from '@/lib/utils';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -13,22 +22,33 @@ export type StoredSession = RouterOutputs['cliSessionsV2']['list']['cliSessions'
 
 export type ActiveSession = RouterOutputs['activeSessions']['list']['sessions'][number];
 
-type DateGroup = {
-  label: string;
-  sessions: StoredSession[];
-};
-
 type UseAgentSessionsOptions = {
   createdOnPlatform?: string | string[];
   gitUrl?: string | string[];
   organizationId?: string | null;
   enabled?: boolean;
+  /**
+   * Field to order by. Defaults to `updated_at` so callers that don't
+   * care (e.g. Home's session surface) keep the legacy behavior bit-for-bit.
+   */
+  sortBy?: AgentSessionSortBy;
 };
 
 type UseRecentAgentRepositoriesOptions = {
   organizationId?: string | null;
   enabled?: boolean;
 };
+
+// ── Query-input builders ─────────────────────────────────────────────
+
+/**
+ * Resolve the effective sort once and use it for both the server `orderBy`
+ * field and the client-side date grouping, so the section a row lands in
+ * always agrees with the timestamp it shows.
+ */
+function resolveSortBy(sortBy: AgentSessionSortBy | undefined): AgentSessionSortBy {
+  return parseAgentSessionSortBy(sortBy ?? DEFAULT_AGENT_SESSION_SORT);
+}
 
 // ── Date helpers ─────────────────────────────────────────────────────
 
@@ -50,27 +70,15 @@ function getUpdatedSince(days: number): string {
 
 // ── Queries ──────────────────────────────────────────────────────────
 
-const SESSIONS_PAGE_SIZE = 30;
-
 function useStoredSessions(options?: UseAgentSessionsOptions) {
   const trpc = useTRPC();
 
   return useInfiniteQuery(
-    trpc.cliSessionsV2.list.infiniteQueryOptions(
-      {
-        limit: SESSIONS_PAGE_SIZE,
-        orderBy: 'updated_at',
-        includeChildren: false,
-        createdOnPlatform: options?.createdOnPlatform,
-        gitUrl: options?.gitUrl,
-        organizationId: options?.organizationId,
-      },
-      {
-        staleTime: 30_000,
-        enabled: options?.enabled,
-        getNextPageParam: lastPage => lastPage.nextCursor,
-      }
-    )
+    trpc.cliSessionsV2.list.infiniteQueryOptions(buildAgentSessionListInput(options ?? {}), {
+      staleTime: 30_000,
+      enabled: options?.enabled,
+      getNextPageParam: lastPage => lastPage.nextCursor,
+    })
   );
 }
 
@@ -100,75 +108,6 @@ export function useRecentAgentRepositories(options?: UseRecentAgentRepositoriesO
   );
 }
 
-// ── Date grouping ────────────────────────────────────────────────────
-
-function isSameDay(a: Date, b: Date): boolean {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
-  );
-}
-
-function addDays(date: Date, days: number): Date {
-  const result = new Date(date);
-  result.setDate(result.getDate() + days);
-  return result;
-}
-
-function getWeekdayName(date: Date): string {
-  return new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(date);
-}
-
-function groupSessionsByDate(sessions: StoredSession[]): DateGroup[] {
-  const now = new Date();
-  const yesterday = addDays(now, -1);
-
-  const buckets = new Map<string, StoredSession[]>();
-  const bucketOrder: string[] = [];
-
-  function addToBucket(label: string, session: StoredSession) {
-    const existing = buckets.get(label);
-    if (existing) {
-      existing.push(session);
-    } else {
-      buckets.set(label, [session]);
-      bucketOrder.push(label);
-    }
-  }
-
-  for (const session of sessions) {
-    const date = parseTimestamp(session.updated_at);
-
-    if (isSameDay(date, now)) {
-      addToBucket('Today', session);
-    } else if (isSameDay(date, yesterday)) {
-      addToBucket('Yesterday', session);
-    } else {
-      const diffMs = now.getTime() - date.getTime();
-      const diffDays = diffMs / (1000 * 60 * 60 * 24);
-      if (diffDays <= 7) {
-        addToBucket(getWeekdayName(date), session);
-      } else {
-        addToBucket('Older', session);
-      }
-    }
-  }
-
-  // Sort "Older" bucket by updated_at descending
-  const olderBucket = buckets.get('Older');
-  if (olderBucket) {
-    olderBucket.sort(
-      (a, b) => parseTimestamp(b.updated_at).getTime() - parseTimestamp(a.updated_at).getTime()
-    );
-  }
-
-  return bucketOrder.map(label => ({
-    label,
-    sessions: buckets.get(label) ?? [],
-  }));
-}
-
 // ── Search ───────────────────────────────────────────────────────────
 
 type UseAgentSessionSearchOptions = UseAgentSessionsOptions & {
@@ -182,28 +121,18 @@ type UseAgentSessionSearchOptions = UseAgentSessionsOptions & {
  */
 export function useAgentSessionSearch(options: UseAgentSessionSearchOptions) {
   const trpc = useTRPC();
+  const sortBy = resolveSortBy(options.sortBy);
 
   const query = useQuery(
-    trpc.cliSessionsV2.search.queryOptions(
-      {
-        search_string: options.searchQuery,
-        // Endpoint max; no offset paging — past 50 matches, refining the query is the answer.
-        limit: 50,
-        includeChildren: false,
-        createdOnPlatform: options.createdOnPlatform,
-        gitUrl: options.gitUrl,
-        organizationId: options.organizationId,
-      },
-      {
-        staleTime: 30_000,
-        enabled: (options.enabled ?? true) && options.searchQuery.length > 0,
-        placeholderData: keepPreviousData,
-      }
-    )
+    trpc.cliSessionsV2.search.queryOptions(buildAgentSessionSearchInput(options), {
+      staleTime: 30_000,
+      enabled: (options.enabled ?? true) && options.searchQuery.length > 0,
+      placeholderData: keepPreviousData,
+    })
   );
 
   const sessions = useMemo(() => query.data?.results ?? [], [query.data]);
-  const dateGroups = useMemo(() => groupSessionsByDate(sessions), [sessions]);
+  const dateGroups = useMemo(() => groupAgentSessionsByDate(sessions, sortBy), [sessions, sortBy]);
 
   return {
     dateGroups,
@@ -216,11 +145,13 @@ export function useAgentSessionSearch(options: UseAgentSessionSearchOptions) {
 // ── Main hook ────────────────────────────────────────────────────────
 
 export function useAgentSessions(options?: UseAgentSessionsOptions) {
+  const sortBy = resolveSortBy(options?.sortBy);
   const stored = useStoredSessions(options);
   const active = useActiveSessions(options);
 
   // A session can repeat across pages when it is updated while older pages
-  // load (the cursor is its updated_at), so dedupe by session_id.
+  // load (the cursor follows the selected sort field), so dedupe by
+  // session_id.
   const storedSessions = useMemo(() => {
     const seen = new Set<string>();
     const sessions: StoredSession[] = [];
@@ -239,7 +170,10 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
 
   const activeSessionIds = useMemo(() => new Set(activeSessions.map(s => s.id)), [activeSessions]);
 
-  const dateGroups = useMemo(() => groupSessionsByDate(storedSessions), [storedSessions]);
+  const dateGroups = useMemo(
+    () => groupAgentSessionsByDate(storedSessions, sortBy),
+    [storedSessions, sortBy]
+  );
 
   return {
     storedSessions,

--- a/apps/mobile/src/lib/hooks/use-persisted-agent-session-filters.ts
+++ b/apps/mobile/src/lib/hooks/use-persisted-agent-session-filters.ts
@@ -2,62 +2,26 @@ import * as SecureStore from 'expo-secure-store';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner-native';
 
+import {
+  type AgentSessionFilters,
+  createDefaultAgentSessionFilters,
+  parseStoredAgentSessionFilters,
+} from '@/lib/agent-session-filters';
+import { type AgentSessionSortBy } from '@/lib/agent-session-sort';
 import { SESSION_FILTERS_KEY } from '@/lib/storage-keys';
-
-type AgentSessionFilters = {
-  platformFilter: string[];
-  projectFilter: string[];
-};
 
 type FiltersUpdater = AgentSessionFilters | ((prev: AgentSessionFilters) => AgentSessionFilters);
 type StringArrayUpdater = string[] | ((prev: string[]) => string[]);
 
-function createDefaultFilters(): AgentSessionFilters {
-  return {
-    platformFilter: [],
-    projectFilter: [],
-  };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function readStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.filter(item => typeof item === 'string');
-}
-
-function parseStoredFilters(raw: string | null): AgentSessionFilters | null {
-  if (!raw) {
-    return null;
-  }
-
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!isRecord(parsed)) {
-      return null;
-    }
-
-    return {
-      platformFilter: readStringArray(parsed.platformFilter),
-      projectFilter: readStringArray(parsed.projectFilter),
-    };
-  } catch {
-    return null;
-  }
-}
-
 async function loadStoredFilters(): Promise<AgentSessionFilters> {
   const raw = await SecureStore.getItemAsync(SESSION_FILTERS_KEY);
-  return parseStoredFilters(raw) ?? createDefaultFilters();
+  return parseStoredAgentSessionFilters(raw) ?? createDefaultAgentSessionFilters();
 }
 
 export function usePersistedAgentSessionFilters() {
-  const [filters, setFiltersState] = useState<AgentSessionFilters>(() => createDefaultFilters());
+  const [filters, setFiltersState] = useState<AgentSessionFilters>(() =>
+    createDefaultAgentSessionFilters()
+  );
   const [hasLoaded, setHasLoaded] = useState(false);
 
   useEffect(() => {
@@ -71,7 +35,7 @@ export function usePersistedAgentSessionFilters() {
         }
       } catch {
         if (isActive) {
-          setFiltersState(createDefaultFilters());
+          setFiltersState(createDefaultAgentSessionFilters());
         }
       } finally {
         if (isActive) {
@@ -130,12 +94,21 @@ export function usePersistedAgentSessionFilters() {
     [setFilters]
   );
 
+  const setSortBy = useCallback(
+    (sortBy: AgentSessionSortBy) => {
+      setFilters(prev => ({ ...prev, sortBy }));
+    },
+    [setFilters]
+  );
+
   return {
     platformFilter: filters.platformFilter,
     projectFilter: filters.projectFilter,
+    sortBy: filters.sortBy,
     hasLoaded,
     setFilters,
     setPlatformFilter,
     setProjectFilter,
+    setSortBy,
   };
 }

--- a/apps/web/src/routers/cli-sessions-v2-router.test.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.test.ts
@@ -10,7 +10,7 @@ import {
   organization_memberships,
   platform_integrations,
 } from '@kilocode/db/schema';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import type { User, Organization } from '@kilocode/db/schema';
 import * as githubAdapter from '@/lib/integrations/platforms/github/adapter';
 import { parseGitHubOwnerRepo } from '@/routers/cli-sessions-v2-router';
@@ -1332,6 +1332,64 @@ describe('cli-sessions-v2-router', () => {
           .where(eq(cli_sessions_v2.session_id, sessionId));
         await db.delete(organizations).where(eq(organizations.id, otherOrg.id));
       }
+    });
+  });
+
+  describe('search ordering', () => {
+    const olderCreatedNewerUpdated = 'ses_search_sort_old_created';
+    const newerCreatedOlderUpdated = 'ses_search_sort_new_created';
+    const searchableTitle = 'mobile-search-sort-fixture';
+
+    beforeEach(async () => {
+      await db.insert(cli_sessions_v2).values([
+        {
+          session_id: olderCreatedNewerUpdated,
+          kilo_user_id: regularUser.id,
+          created_on_platform: 'cloud-agent',
+          title: searchableTitle,
+          created_at: '2026-01-01T10:00:00.000Z',
+          updated_at: '2026-01-04T10:00:00.000Z',
+        },
+        {
+          session_id: newerCreatedOlderUpdated,
+          kilo_user_id: regularUser.id,
+          created_on_platform: 'cloud-agent',
+          title: searchableTitle,
+          created_at: '2026-01-03T10:00:00.000Z',
+          updated_at: '2026-01-02T10:00:00.000Z',
+        },
+      ]);
+    });
+
+    afterEach(async () => {
+      await db
+        .delete(cli_sessions_v2)
+        .where(
+          inArray(cli_sessions_v2.session_id, [olderCreatedNewerUpdated, newerCreatedOlderUpdated])
+        );
+    });
+
+    it('defaults search to updated_at descending', async () => {
+      const caller = await createCallerForUser(regularUser.id);
+      const result = await caller.cliSessionsV2.search({ search_string: searchableTitle });
+
+      expect(result.results.map(session => session.session_id)).toEqual([
+        olderCreatedNewerUpdated,
+        newerCreatedOlderUpdated,
+      ]);
+    });
+
+    it('orders search by created_at descending when requested', async () => {
+      const caller = await createCallerForUser(regularUser.id);
+      const result = await caller.cliSessionsV2.search({
+        search_string: searchableTitle,
+        orderBy: 'created_at',
+      });
+
+      expect(result.results.map(session => session.session_id)).toEqual([
+        newerCreatedOlderUpdated,
+        olderCreatedNewerUpdated,
+      ]);
     });
   });
 });

--- a/apps/web/src/routers/cli-sessions-v2-router.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.ts
@@ -318,6 +318,7 @@ const SearchInputSchema = z.object({
   search_string: z.string().min(1),
   limit: z.number().min(1).max(50).optional().default(PAGE_SIZE),
   offset: z.number().min(0).optional().default(0),
+  orderBy: z.enum(['created_at', 'updated_at']).optional().default('updated_at'),
   createdOnPlatform: z
     .union([createdOnPlatformField, z.array(createdOnPlatformField).min(1)])
     .optional(),
@@ -534,11 +535,15 @@ export const cliSessionsV2Router = createTRPCRouter({
       search_string,
       limit,
       offset,
+      orderBy,
       createdOnPlatform,
       organizationId,
       includeChildren,
       gitUrl,
     } = input;
+
+    const orderColumn =
+      orderBy === 'updated_at' ? cli_sessions_v2.updated_at : cli_sessions_v2.created_at;
 
     const whereConditions: SQL[] = [eq(cli_sessions_v2.kilo_user_id, ctx.user.id)];
 
@@ -569,7 +574,7 @@ export const cliSessionsV2Router = createTRPCRouter({
         .from(cli_sessions_v2)
         .leftJoin(github_branch_pull_requests, sessionPrJoinPredicate)
         .where(baseWhere)
-        .orderBy(desc(cli_sessions_v2.updated_at))
+        .orderBy(desc(orderColumn))
         .limit(limit)
         .offset(offset),
       db


### PR DESCRIPTION
## Summary

Adds a `Sort by` choice (`Last updated` default / `Created`) to the mobile Agents `Filter sessions` modal. The selected field consistently drives server list ordering, server search ordering, date-section grouping, and stored-row relative timestamps, and persists across relaunch.

## Changes

- **Server**: `cliSessionsV2.search` gains a backward-compatible, optional, defaulted `orderBy: 'created_at' | 'updated_at'` input (default `updated_at`), matching the existing `cliSessionsV2.list.orderBy` contract.
- **Mobile**:
  - New pure contract modules: `agent-session-sort.ts` (sort type/default/parser/timestamp selection), `agent-session-groups.ts` (date-section grouping by selected field), `agent-session-filters.ts` (persisted-filter shape, defaulting/parsing, narrowing-filter reset that preserves `sortBy`), `agent-session-input.ts` (tRPC input builders for list/search).
  - `use-agent-sessions.ts` threads `sortBy` into both list and search queries and delegates date grouping to the pure helper.
  - `use-persisted-agent-session-filters.ts` persists `sortBy` in the existing `agent-session-filters` SecureStore record; missing/legacy/malformed/unknown values default to `updated_at`.
  - `platform-filter-modal.tsx` adds an accessible `Sort by` radio section (`ChoiceRow`) above `Platform`.
  - `session-list-screen.tsx` / `session-list-content.tsx` / `session-row.tsx` thread the selection through to stored rows only; remote-only sessions stay pinned in `Remote` with unchanged metadata. `Clear search` / `Clear filters` preserve `sortBy` and never affect the filter icon or produce a chip.

## Testing

- `apps/web`: router Jest suite 52/52 passing (50 baseline + 2 new ordering tests), `pnpm typecheck`, `pnpm lint` clean.
- `apps/mobile`: full Vitest suite 122 files / 803 tests passing (118/769 baseline + 4 new files/34 new tests), `pnpm typecheck`, `pnpm lint`, `pnpm check:unused`, `pnpm format:check` all clean.
- Two independent fresh code reviews (including one after a Hermes-compatibility repair) reported no actionable findings.
- On-device E2E (Maestro, iOS simulator) independently confirmed: no runtime crash on the Agents tab, `Last updated` default ordering, an accessible `Sort by` radio section in the filter modal with correct checked state and ≥44pt targets, and that selecting `Created` persists across reopening the filter modal within a session.
  - A Hermes runtime crash (`Array.prototype.toSorted` is not implemented in Hermes) was caught by this on-device pass, fixed, and reconfirmed crash-free.
  - Full state-matrix on-device proof (timestamp-divergence reordering, cold-relaunch persistence, search-under-`Created` ordering, clear-preserves-sort, no-match empty state) could not be completed: repeated attempts across four different simulators (including a freshly claimed, never-before-used device) hit an identical `Failed to connect to /127.0.0.1:22087` Maestro-driver connection failure, consistent with host-level driver/port contention from heavy concurrent multi-worktree E2E usage rather than a device- or code-specific issue. These behaviors are covered by the automated suite above (grouping/order consistency, persisted-filter defaulting/parsing, clear-preserves-sort, and list/search input-builder propagation for both sort values).

## Non-goals

No ascending/oldest-first option, no additional sort fields, no changes to Home's session surface, the active-session contract, or web session-list behavior.
