### PR TITLE
Add cloud-agent-web to feature-detection

### DIFF
--- a/apps/web/src/lib/feature-detection.ts
+++ b/apps/web/src/lib/feature-detection.ts
@@ -18,6 +18,7 @@ export const FEATURE_VALUES = [
   'managed-indexing',
   'cli',
   'cloud-agent',
+  'cloud-agent-web',
   'code-review',
   'auto-triage',
   'autofix',


### PR DESCRIPTION
fixes cloud agents session logged with feature null in microdollar usage