### PR TITLE
fix: preserve Fable fallback on Vercel

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -51,6 +51,14 @@ describe('applyGatewayModelsFallback', () => {
 });
 
 describe('applyPreferredProvider', () => {
+  it('does not set a provider order for Fable', () => {
+    const request = makeRequest('anthropic/claude-fable-5');
+
+    applyPreferredProvider('anthropic/claude-fable-5', request.body);
+
+    expect(request.body.provider).toBeUndefined();
+  });
+
   it('preserves valid provider options when adding order', () => {
     const request = makeRequest('anthropic/claude-sonnet-4.5');
     request.body.provider = { zdr: true };

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -44,7 +44,9 @@ import {
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
 
 export function getPreferredProviderOrder(requestedModel: string): string[] {
-  if (isClaudeModel(requestedModel)) {
+  if (isClaudeModel(requestedModel) && !isFableModel(requestedModel)) {
+    // fable is not available on bedrock on vercel
+    // and specifying bedrock breaks the opus fallback
     return [
       OpenRouterInferenceProviderIdSchema.enum['amazon-bedrock'],
       OpenRouterInferenceProviderIdSchema.enum.anthropic,


### PR DESCRIPTION
## Summary
- avoid forcing Fable requests through Amazon Bedrock on Vercel
- preserve the configured Claude Opus fallback
- add regression coverage for Fable provider ordering

## Testing
- `pnpm --filter web test -- --runInBand apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts`
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- `git diff --check`