### PR TITLE
Enable free KAT Coder model

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/streamlake.ts
+++ b/apps/web/src/lib/ai-gateway/providers/streamlake.ts
@@ -7,7 +7,7 @@ export const kat_coder_pro_v2_5_free_model: KiloExclusiveModel = {
     'KAT-Coder-Pro V2.5 is a flagship-level Agentic Coding model that can directly hand over an entire issue or an entire business workflow to it, allowing it to autonomously locate and make modifications, and complete the entire process in the actual repository. At the same time, it seamlessly integrates multiple experts to fully retain the front-end aesthetic generation capability of V2.',
   context_length: 256_000,
   max_completion_tokens: 80_000,
-  status: 'disabled',
+  status: 'public',
   flags: ['reasoning'],
   gateway: 'streamlake',
   internal_id: 'ep-fsp5wc-1783487206835267047',


### PR DESCRIPTION
## Summary
- enable the predefined KAT-Coder-Pro V2.5 free model
- publish it in the model catalog

## Testing
- not run (declarative one-line status change)