### PR TITLE
Move Kat Coder 3.5 Pro (free) into recommended models

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -41,9 +41,6 @@ export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 
 export const autoFreeModels = [
   'tencent/hy3:free',
-  kat_coder_pro_v2_5_free_model.status === 'public'
-    ? kat_coder_pro_v2_5_free_model.public_id
-    : null,
   stepfun_37_flash_free_model.status === 'public' ? stepfun_37_flash_free_model.public_id : null,
 ].filter(m => m !== null);
 
@@ -53,7 +50,11 @@ export const preferredModels = [
   KILO_AUTO_EFFICIENT_MODEL.id,
   KILO_AUTO_FREE_MODEL.id,
 
-  ...autoFreeModels,
+  'tencent/hy3:free',
+  kat_coder_pro_v2_5_free_model.status === 'public'
+    ? kat_coder_pro_v2_5_free_model.public_id
+    : null,
+  ...autoFreeModels.filter(m => m !== 'tencent/hy3:free'),
 
   CLAUDE_SONNET_CURRENT_MODEL_ID,
   CLAUDE_OPUS_CURRENT_MODEL_ID,
@@ -66,7 +67,7 @@ export const preferredModels = [
   KIMI_CURRENT_MODEL_ID,
   MINIMAX_CURRENT_MODEL_ID,
   QWEN37_PLUS_MODEL_ID,
-];
+].filter((m): m is string => m !== null);
 
 export function isPdfSupportingModel(model: string): boolean {
   return isClaudeModel(model) || isOpenAiModel(model) || isGrokModel(model) || isGeminiModel(model);

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -41,6 +41,9 @@ export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 
 export const autoFreeModels = [
   'tencent/hy3:free',
+  kat_coder_pro_v2_5_free_model.status === 'public'
+    ? kat_coder_pro_v2_5_free_model.public_id
+    : null,
   stepfun_37_flash_free_model.status === 'public' ? stepfun_37_flash_free_model.public_id : null,
 ].filter(m => m !== null);
 


### PR DESCRIPTION
## What changed

Adds the free `kwaipilot/kat-coder-pro-v2.5` model to the `preferredModels` array in `apps/web/src/lib/ai-gateway/models.ts`, positioned directly below `'tencent/hy3:free'`.

`preferredModels` is the global ordered "recommended models" list that drives model ordering in the model picker (`model-combobox-options.ts`), the organization providers/models page, the Slack bot model allow-list, monitored models, and the models router. Adding the entry here surfaces the free Kat Coder 3.5 Pro model in the recommended models list, immediately below "Tencent: Hy3".

**Update:** the model is no longer added to `autoFreeModels`. That array also controls auto-routing free-tier behavior (`KILO_AUTO_FREE_MODEL`), which is a broader change than intended for this PR. `autoFreeModels` has been reverted to its original state, and the model is instead added directly in `preferredModels` (right below the `tencent/hy3:free` entry that's already spread in from `autoFreeModels`), so only the recommended-models ordering is affected.

## Why

The free version of Kat Coder 3.5 Pro was previously only registered in `kiloExclusiveModels` (a general free/exclusive model registry) but was not part of the curated recommended list, so it wasn't surfaced to users in the "Recommended" section of the model picker.

## Testing

- Verified the change follows the existing conditional-entry pattern already used in `preferredModels`/`autoFreeModels`.
- Ran `pnpm -w exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/models.ts` — 0 warnings/errors.
- Ran `oxfmt` on the file — no formatting changes needed.
- Ran `tsgo --noEmit` against `apps/web` — no errors reported for this file.
- Could not run the full `models.test.ts` suite: the test suite requires a reachable Postgres instance (`docker` is unavailable in this sandbox).

---

Built for [Christiaan Arnoldus](https://kilo-code.slack.com/archives/C09MVPCD90B/p1784215660035979?thread_ts=1784209647.822439&cid=C09MVPCD90B) by [Kilo for Slack](https://kilo.ai/slack)
