### PR TITLE
Remove GitHub star giveaway notification

### DIFF
--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -67,16 +67,6 @@ const normalUnconditionalNotifications: KiloNotification[] = [
     showOnlyOnLegacyExtension: true,
   },
   {
-    id: 'star-giveaway-june-2026',
-    title: 'GitHub Star Giveaway',
-    message:
-      "We're giving away $500 of AI Credits when we reach 25,000 stars on GitHub. Support us:",
-    action: {
-      actionText: 'github.com/Kilo-Org/kilocode',
-      actionURL: 'https://github.com/Kilo-Org/kilocode/',
-    },
-  },
-  {
     id: 'stealth-opus-discount-may-25',
     title: 'Claude Opus 4.7 at 20% Off — Only in Kilo Code!',
     message:


### PR DESCRIPTION
## Summary

Removes the extension notification promoting a "star our GitHub repo for a chance to win $500 of AI Credits" giveaway.

The entry (`id: 'star-giveaway-june-2026'`) lived in the static `normalUnconditionalNotifications` array in `apps/web/src/lib/notifications.ts`, which feeds the `/api/users/notifications` route consumed by the VS Code extension. It has been deleted entirely, along with its title, message copy, and action link.

## Verification

- Confirmed no other file references the notification id, title, or message text (repo-wide grep).
- No tests specifically covered this notification entry; existing generic tests in `notifications.test.ts` are unaffected by the removal.
- Confirmed `pnpm format:changed` produces no formatting diffs for the change.
- Could not run the full Jest suite for this file in this sandbox because it requires a running Postgres test database (Docker is unavailable here); the change itself is a self-contained array-entry deletion with no other code depending on it.

---
Built for [Brian Turcotte](https://kilo-code.slack.com/archives/D0A8Q82JX41/p1784215299606419?thread_ts=1784215233.423569&cid=D0A8Q82JX41) by [Kilo for Slack](https://kilo.ai/slack)