### PR TITLE
chore(session-ingest): bump direct ingest percent to 100

### DIFF
--- a/services/session-ingest/wrangler.jsonc
+++ b/services/session-ingest/wrangler.jsonc
@@ -21,7 +21,7 @@
     "mode": "smart",
   },
   "vars": {
-    "DIRECT_INGEST_PERCENT": "75",
+    "DIRECT_INGEST_PERCENT": "100",
     "DIRECT_INGEST_USER_IDS": "f1a848ca-bade-48d8-a5ad-1042d08651e6",
     "DIRECT_INGEST_MAX_BYTES": "4194304",
   },


### PR DESCRIPTION
## Summary

Bump the session-ingest `DIRECT_INGEST_PERCENT` var from 75 to 100 in `services/session-ingest/wrangler.jsonc`, completing the rollout of the direct-ingest path to all non-allowlisted users.

## Verification

- [ ] Confirm production traffic mix after deploy via the `direct_ingest_legacy` / `direct_ingest_ok` log events — `direct_ingest_legacy` should drop to ~0 except for oversize / error fallbacks.
- [ ] Confirm no spike in `direct_ingest_error`, `direct_ingest_fallback`, or `direct_ingest_attention_error` events.

## Visual Changes

N/A — runtime config change only.

## Reviewer Notes

- Single-line var change in `services/session-ingest/wrangler.jsonc`; no code, schema, or test changes.
- Follow-up to #4560 (20% → 50%) and #4567 (50% → 75%). The allowlist in `DIRECT_INGEST_USER_IDS` remains in effect but is now redundant with 100% rollout — consider removing it in a follow-up cleanup.