### PR TITLE
Remove Muse Spark exclusive model

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -8,7 +8,6 @@ import {
   claude_opus_4_6_stealth_model,
 } from './providers/anthropic.constants';
 import { gpt_5_6_sol_stealth_model } from './providers/openai-exclusive';
-import { muse_spark_1_1_model } from './providers/meta';
 
 describe('isFreeModel', () => {
   describe('free models', () => {
@@ -97,19 +96,6 @@ describe('isFreeModel', () => {
           },
         },
       ]);
-    });
-
-    test('registers Muse Spark 1.1 through Vercel', () => {
-      expect(findKiloExclusiveModel('meta/muse-spark-1.1')).toBe(muse_spark_1_1_model);
-      expect(muse_spark_1_1_model.gateway).toBe('vercel');
-      expect(getInferenceProvider(muse_spark_1_1_model)?.slug).toBe('meta');
-      expect(muse_spark_1_1_model.context_length).toBe(1_048_576);
-      expect(muse_spark_1_1_model.pricing?.[0].pricing).toEqual({
-        prompt_per_million: 1.25,
-        completion_per_million: 4.25,
-        input_cache_read_per_million: 0.15,
-        input_cache_write_per_million: null,
-      });
     });
 
     test('all Kilo exclusive models should have either no pricing or valid ordered pricing tiers', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -28,7 +28,6 @@ import { isGrokModel } from '@/lib/ai-gateway/providers/xai';
 import { isClaudeModel } from '@/lib/ai-gateway/providers/anthropic.constants';
 import { GPT_CURRENT_MODEL_ID, isOpenAiModel } from '@/lib/ai-gateway/providers/openai';
 import { gpt_5_6_sol_stealth_model } from '@/lib/ai-gateway/providers/openai-exclusive';
-import { muse_spark_1_1_model } from '@/lib/ai-gateway/providers/meta';
 import { kat_coder_pro_v2_5_free_model } from '@/lib/ai-gateway/providers/streamlake';
 import { GLM_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/zai';
 import {
@@ -86,7 +85,6 @@ export const kiloExclusiveModels = [
   ...deepseekDiscountedModels,
   qwen36_plus_stealth_model,
   gpt_5_6_sol_stealth_model,
-  muse_spark_1_1_model,
   claude_sonnet_clawsetup_model,
   claude_opus_4_8_stealth_model,
   claude_opus_4_7_stealth_model,

--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
@@ -187,9 +187,6 @@ export function getInferenceProvider(model: KiloExclusiveModel): InferenceProvid
   if (model.flags.includes('stealth')) {
     return { slug: 'stealth', name: 'Stealth', training: true, retainsPrompts: true };
   }
-  if (model.public_id.includes('muse-')) {
-    return { slug: 'meta', name: 'Meta', training: false, retainsPrompts: true };
-  }
   if (model.gateway === 'openrouter' || model.gateway === 'vercel') {
     return null;
   }

--- a/apps/web/src/lib/ai-gateway/providers/meta.ts
+++ b/apps/web/src/lib/ai-gateway/providers/meta.ts
@@ -1,26 +1,3 @@
-import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
-
-export const muse_spark_1_1_model: KiloExclusiveModel = {
-  public_id: 'meta/muse-spark-1.1',
-  internal_id: 'meta/muse-spark-1.1',
-  display_name: 'Meta: Muse Spark 1.1',
-  description:
-    'Muse Spark 1.1 is strongest at agentic performance, tool use, and computer use. It does well on long-running tasks with a 1M-token context window and can delegate execution to sub-agents running in parallel.',
-  status: 'public',
-  context_length: 1_048_576,
-  max_completion_tokens: 1_048_576,
-  gateway: 'vercel',
-  flags: ['reasoning', 'vision'],
-  pricing: [
-    {
-      start_context_length: 0,
-      pricing: {
-        prompt_per_million: 1.25,
-        completion_per_million: 4.25,
-        input_cache_read_per_million: 0.15,
-        input_cache_write_per_million: null,
-      },
-    },
-  ],
-  inference_provider_restriction: [],
-};
+export function isMuseModel(model: string) {
+  return model.startsWith('meta/muse-');
+}

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -16,7 +16,7 @@ import { ReasoningEffortSchema } from '@kilocode/db/schema-types';
 import { isDeepseekModel } from '@/lib/ai-gateway/providers/deepseek';
 import { isMinimaxModel } from '@/lib/ai-gateway/providers/minimax';
 import type { DirectUserByokInferenceProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
-import { muse_spark_1_1_model } from '@/lib/ai-gateway/providers/meta';
+import { isMuseModel } from '@/lib/ai-gateway/providers/meta';
 import { kat_coder_pro_v2_5_free_model } from '@/lib/ai-gateway/providers/streamlake';
 
 const REASONING_VARIANTS_THINKING_ONLY = {
@@ -120,7 +120,7 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
   if (isDeepseekModel(model) || isGlmModel(model)) {
     return REASONING_VARIANTS_NONE_HIGH_XHIGH;
   }
-  if (model === muse_spark_1_1_model.public_id) {
+  if (isMuseModel(model)) {
     return REASONING_VARIANTS_NONE_MINIMAL_LOW_MEDIUM_HIGH;
   }
   return undefined;
@@ -148,7 +148,7 @@ export function getAiSdkProvider(
   ) {
     return 'anthropic';
   }
-  if (isOpenAiModel(model) || isGrokModel(model) || model === muse_spark_1_1_model.public_id) {
+  if (isOpenAiModel(model) || isGrokModel(model) || isMuseModel(model)) {
     // OpenAI: "While Chat Completions remains supported, Responses is recommended for all new projects.""
     // xAI: "The Responses API is the recommended way to interact with xAI models."
     return 'openai';

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.ts
@@ -40,7 +40,7 @@ export const OpenRouterInferenceProviderIdSchema = z.enum([
   'liquid',
   'mancer',
   'mara',
-  'meta', // not yet on OpenRouter
+  'meta',
   'minimax',
   'mistral',
   'modelrun',

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -99,10 +99,6 @@ describe('mapModelIdToVercel', () => {
   });
 
   describe('kilo-exclusive models', () => {
-    it('maps a Vercel-exclusive model to its internal id', () => {
-      expect(mapModelIdToVercel('meta/muse-spark-1.1')).toBe('meta/muse-spark-1.1');
-    });
-
     it('maps an exclusive flagged with vercel-routing to its internal id', () => {
       // google/gemma-4-26b-a4b-it:free is registered in kiloExclusiveModels
       // with the 'vercel-routing' flag and internal_id 'google/gemma-4-26b-a4b-it'.


### PR DESCRIPTION
## Summary
- remove Muse Spark 1.1 from Kilo-exclusive model registration now that it is on OpenRouter
- remove the exclusive inference-provider exception and Vercel routing coverage
- preserve Muse reasoning variants and AI SDK settings through an `isMuseModel` check

## Testing
- Not run per request; awaiting CI.