### PR TITLE
docs(mobile): fix kilo run launch command and switch orchestrator to sonnet-5 high

### DIFF
--- a/apps/mobile/.kilo/MOBILE_WORKFLOW.md
+++ b/apps/mobile/.kilo/MOBILE_WORKFLOW.md
@@ -81,10 +81,10 @@ Launch the orchestrator in the current tmux session with a unique, descriptive w
 tmux new-window -t <planner-tmux-session> \
   -n <feature>-orchestrator \
   -c <dedicated-worktree>/apps/mobile \
-  'kilo run "Execute the approved mobile plan in the attached handoff. Own implementation through the completion gate." --interactive --model kilo/kilo-auto/frontier --title "<feature> orchestrator" --file <sanitized-handoff-file>'
+  'kilo run "Execute the approved mobile plan in the attached handoff. Own implementation through the completion gate." --interactive --model kilo/anthropic/claude-sonnet-5 --variant high --title "<feature> orchestrator" --file <sanitized-handoff-file>'
 ```
 
-Use `kilo run --interactive` exactly as shown, with the message positional before the flags: `--file` accepts multiple values and consumes a trailing message as a file path, which fails with `File not found`. Do not add `--continue`, `--session`, or `--variant`, because the orchestrator must be a fresh session on Kilo Auto Frontier with its default reasoning setting. Verify the tmux window started, then report the window name, worktree paths, model, and handoff path to the user. The orchestrator deletes the handoff file after ingesting it.
+Use `kilo run --interactive` exactly as shown, with the message positional before the flags: `--file` accepts multiple values and consumes a trailing message as a file path, which fails with `File not found`. Do not add `--continue` or `--session`, because the orchestrator must be a fresh session on Claude Sonnet 5 at high reasoning effort. Verify the tmux window started, then report the window name, worktree paths, model, and handoff path to the user. The orchestrator deletes the handoff file after ingesting it.
 
 ## Roles
 

--- a/apps/mobile/.kilo/MOBILE_WORKFLOW.md
+++ b/apps/mobile/.kilo/MOBILE_WORKFLOW.md
@@ -81,10 +81,10 @@ Launch the orchestrator in the current tmux session with a unique, descriptive w
 tmux new-window -t <planner-tmux-session> \
   -n <feature>-orchestrator \
   -c <dedicated-worktree>/apps/mobile \
-  'kilo run --interactive --model kilo/kilo-auto/frontier --title "<feature> orchestrator" --file <sanitized-handoff-file> "Execute the approved mobile plan in the attached handoff. Own implementation through the completion gate."'
+  'kilo run "Execute the approved mobile plan in the attached handoff. Own implementation through the completion gate." --interactive --model kilo/kilo-auto/frontier --title "<feature> orchestrator" --file <sanitized-handoff-file>'
 ```
 
-Use `kilo run --interactive` exactly as shown: no `--continue`, `--session`, or `--variant`, because the orchestrator must be a fresh session on Kilo Auto Frontier with its default reasoning setting. Verify the tmux window started, then report the window name, worktree paths, model, and handoff path to the user. The orchestrator deletes the handoff file after ingesting it.
+Use `kilo run --interactive` exactly as shown, with the message positional before the flags: `--file` accepts multiple values and consumes a trailing message as a file path, which fails with `File not found`. Do not add `--continue`, `--session`, or `--variant`, because the orchestrator must be a fresh session on Kilo Auto Frontier with its default reasoning setting. Verify the tmux window started, then report the window name, worktree paths, model, and handoff path to the user. The orchestrator deletes the handoff file after ingesting it.
 
 ## Roles
 


### PR DESCRIPTION
Two fixes to the orchestrator launch command in `MOBILE_WORKFLOW.md`:

1. **Argument order**: `kilo run --file <handoff> "<message>"` fails with `File not found: <message>` because `--file` is an array option that consumes the trailing positional (reproduced on kilo 7.4.9). The message now comes before the flags, with a note explaining why.

2. **Orchestrator model**: `kilo/kilo-auto/frontier` currently gets zero prompt caching through the gateway (verified: 2-turn probe, both turns billed full input, ~$5.2/M blended; 351M input tokens across last night's orchestrator sessions billed uncached at ~$1,800). `kilo/anthropic/claude-sonnet-5 --variant high` caches correctly (verified: turn 1 cache-write 40k, turn 2 cache-read 39.9k, 12x cheaper), so the workflow now launches orchestrators on it until frontier caching is fixed.