### PR TITLE
feat(code-reviewer) better council decision logic

### DIFF
--- a/apps/web/src/components/code-reviews/CodeReviewJobsCard.tsx
+++ b/apps/web/src/components/code-reviews/CodeReviewJobsCard.tsx
@@ -202,7 +202,7 @@ export function CodeReviewJobsCard({
   const [manualJobInstructions, setManualJobInstructions] = useState('');
   const [manualJobCouncilEnabled, setManualJobCouncilEnabled] = useState(false);
   const [manualJobCouncilAggregation, setManualJobCouncilAggregation] =
-    useState<CouncilAggregationStrategy>('any_blocking_member');
+    useState<CouncilAggregationStrategy>('advisory');
   const [manualJobCouncilSelections, setManualJobCouncilSelections] = useState<
     Record<string, CouncilSpecialistSelection>
   >(() => defaultCouncilSelections());
@@ -351,7 +351,7 @@ export function CodeReviewJobsCard({
     );
     setManualJobInstructions('');
     setManualJobCouncilEnabled(false);
-    setManualJobCouncilAggregation('any_blocking_member');
+    setManualJobCouncilAggregation('advisory');
     setManualJobCouncilSelections(defaultCouncilSelections());
     setManualJobSubmitted(false);
     setManualJobSubmitError(null);

--- a/apps/web/src/components/code-reviews/CodeReviewJobsCard.tsx
+++ b/apps/web/src/components/code-reviews/CodeReviewJobsCard.tsx
@@ -51,6 +51,7 @@ import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { Switch } from '@/components/ui/switch';
 import {
   COUNCIL_AGGREGATION_STRATEGIES,
+  DEFAULT_COUNCIL_AGGREGATION_STRATEGY,
   type CouncilAggregationStrategy,
 } from '@kilocode/db/schema-types';
 import {
@@ -202,7 +203,7 @@ export function CodeReviewJobsCard({
   const [manualJobInstructions, setManualJobInstructions] = useState('');
   const [manualJobCouncilEnabled, setManualJobCouncilEnabled] = useState(false);
   const [manualJobCouncilAggregation, setManualJobCouncilAggregation] =
-    useState<CouncilAggregationStrategy>('advisory');
+    useState<CouncilAggregationStrategy>(DEFAULT_COUNCIL_AGGREGATION_STRATEGY);
   const [manualJobCouncilSelections, setManualJobCouncilSelections] = useState<
     Record<string, CouncilSpecialistSelection>
   >(() => defaultCouncilSelections());
@@ -351,7 +352,7 @@ export function CodeReviewJobsCard({
     );
     setManualJobInstructions('');
     setManualJobCouncilEnabled(false);
-    setManualJobCouncilAggregation('advisory');
+    setManualJobCouncilAggregation(DEFAULT_COUNCIL_AGGREGATION_STRATEGY);
     setManualJobCouncilSelections(defaultCouncilSelections());
     setManualJobSubmitted(false);
     setManualJobSubmitError(null);

--- a/apps/web/src/components/code-reviews/CouncilGovernancePanel.tsx
+++ b/apps/web/src/components/code-reviews/CouncilGovernancePanel.tsx
@@ -6,19 +6,16 @@ import { Loader2, Users } from 'lucide-react';
 import type { CodeReviewCouncilResult, CouncilVote } from '@kilocode/db/schema-types';
 import { formatAggregationStrategy } from '@kilocode/worker-utils/code-review-council';
 
+// v2: votes are binary. `pass` = approve, `block` = reject (any critical finding).
 const VOTE_LABELS: Record<CouncilVote, string> = {
   pass: 'Pass',
-  warn: 'Warn',
   block: 'Block',
-  abstain: 'Abstain',
 };
 
 // Map council votes onto the app's status-domain surface/border/foreground tokens.
 const VOTE_CLASSES: Record<CouncilVote, string> = {
   pass: 'bg-status-success-surface text-status-success border-status-success-border',
-  warn: 'bg-status-warning-surface text-status-warning border-status-warning-border',
   block: 'bg-status-destructive-surface text-status-destructive border-status-destructive-border',
-  abstain: 'bg-status-neutral-surface text-status-neutral border-status-neutral-border',
 };
 
 function VoteBadge({ vote }: { vote: CouncilVote }) {
@@ -55,7 +52,13 @@ export function CouncilGovernancePanel({
           <Users className="h-5 w-5" />
           Council review
         </CardTitle>
-        {councilResult ? <VoteBadge vote={councilResult.decision} /> : null}
+        {councilResult?.decision ? (
+          <VoteBadge vote={councilResult.decision} />
+        ) : councilResult ? (
+          <Badge className="bg-status-neutral-surface text-status-neutral border-status-neutral-border">
+            Advisory
+          </Badge>
+        ) : null}
       </CardHeader>
       <CardContent className="space-y-4">
         {!councilResult ? (
@@ -76,12 +79,14 @@ export function CouncilGovernancePanel({
             </div>
 
             {/*
-              PR4: the decision above is an advisory pass/fail score only — it is surfaced
-              here but does not (yet) block the pull request merge. Keep in sync with the
-              TODO(council) note in finalize-council-result.ts.
+              v2: votes are code-derived (any critical finding → block). In `advisory` mode
+              there is no aggregate decision; in unanimous/majority the decision is code-owned.
+              Neither blocks the merge yet — the gate wiring is follow-up #10.
             */}
             <p className="text-muted-foreground text-xs">
-              This is an advisory pass/fail score and does not block the pull request yet.
+              {councilResult.decision === null
+                ? 'Advisory mode — specialist votes are shown, but no overall decision is computed and the merge is not gated.'
+                : 'Decision is computed by Kilo from the specialist votes; it does not block the pull request yet.'}
             </p>
 
             <ul className="divide-border divide-y">

--- a/apps/web/src/components/code-reviews/CouncilGovernancePanel.tsx
+++ b/apps/web/src/components/code-reviews/CouncilGovernancePanel.tsx
@@ -96,7 +96,13 @@ export function CouncilGovernancePanel({
                     <div className="min-w-0 space-y-0.5">
                       <div className="flex items-center gap-2">
                         <span className="font-medium">{specialist.name}</span>
-                        <VoteBadge vote={specialist.vote} />
+                        {specialist.vote ? (
+                          <VoteBadge vote={specialist.vote} />
+                        ) : (
+                          <Badge className="bg-status-neutral-surface text-status-neutral border-status-neutral-border">
+                            No result
+                          </Badge>
+                        )}
                       </div>
                       <p className="text-muted-foreground text-xs">
                         {specialist.model ?? 'Default model'}

--- a/apps/web/src/lib/code-reviews/council/finalize-council-result.test.ts
+++ b/apps/web/src/lib/code-reviews/council/finalize-council-result.test.ts
@@ -5,7 +5,7 @@ import { buildCouncilResult } from './finalize-council-result';
 
 const council: CodeReviewCouncilConfig = {
   enabled: true,
-  aggregation_strategy: 'any_blocking_member',
+  aggregation_strategy: 'unanimous',
   specialists: [
     {
       id: 'security',
@@ -27,28 +27,26 @@ const council: CodeReviewCouncilConfig = {
   ],
 };
 
+// v2: specialists report findings only (no vote). The vote is derived: a critical finding → block.
+const crit = [{ path: 'a.ts', line: 3, severity: 'critical', rationale: 'sqli' }];
+
 const manifestText = (specialists: unknown[]): string =>
   `done\n<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify({ specialists })} -->`;
 
 describe('buildCouncilResult', () => {
-  it('joins each specialist with its reported vote/findings and per-specialist model', () => {
+  it('derives each specialist vote + highest severity from findings; decision from votes', () => {
     const result = buildCouncilResult({
       council,
       baseModel: 'base/model',
       baseThinkingEffort: null,
       lastAssistantMessageText: manifestText([
-        {
-          specialistId: 'security',
-          vote: 'block',
-          highestSeverity: 'critical',
-          findings: [{ path: 'a.ts', line: 3, severity: 'critical', rationale: 'sqli' }],
-        },
-        { specialistId: 'performance', vote: 'pass', findings: [] },
+        { specialistId: 'security', findings: crit },
+        { specialistId: 'performance', findings: [] },
       ]),
     });
 
-    expect(result.decision).toBe('block'); // any_blocking_member + a block vote
-    expect(result.aggregationStrategy).toBe('any_blocking_member');
+    expect(result.decision).toBe('block'); // unanimous + one critical (derived block)
+    expect(result.aggregationStrategy).toBe('unanimous');
     expect(result.specialists[0]).toMatchObject({
       id: 'security',
       model: 'anthropic/x',
@@ -56,12 +54,46 @@ describe('buildCouncilResult', () => {
       highestSeverity: 'critical',
     });
     expect(result.specialists[0].findings).toHaveLength(1);
-    // Falls back to the review base model when the specialist has no model of its own.
+    // performance: no findings → derived pass; model falls back to the review base model.
     expect(result.specialists[1]).toMatchObject({
       id: 'performance',
       model: 'base/model',
       vote: 'pass',
+      highestSeverity: null,
     });
+  });
+
+  it('passes under unanimous when every specialist has no critical finding', () => {
+    const result = buildCouncilResult({
+      council,
+      baseModel: 'base/model',
+      baseThinkingEffort: null,
+      lastAssistantMessageText: manifestText([
+        {
+          specialistId: 'security',
+          findings: [{ path: 'a', severity: 'warning', rationale: 'x' }],
+        },
+        { specialistId: 'performance', findings: [] },
+      ]),
+    });
+    expect(result.decision).toBe('pass');
+    expect(result.specialists.every(s => s.vote === 'pass')).toBe(true);
+  });
+
+  it('advisory: computes NO decision (null) but still derives per-specialist votes', () => {
+    const result = buildCouncilResult({
+      council: { ...council, aggregation_strategy: 'advisory' },
+      baseModel: 'base/model',
+      baseThinkingEffort: null,
+      lastAssistantMessageText: manifestText([
+        { specialistId: 'security', findings: crit },
+        { specialistId: 'performance', findings: [] },
+      ]),
+    });
+    expect(result.decision).toBeNull();
+    expect(result.aggregationStrategy).toBe('advisory');
+    expect(result.specialists.find(s => s.id === 'security')?.vote).toBe('block');
+    expect(result.specialists.find(s => s.id === 'performance')?.vote).toBe('pass');
   });
 
   it('prefers the model the specialist REPORTED (auto slug resolved) over the configured model', () => {
@@ -70,23 +102,10 @@ describe('buildCouncilResult', () => {
       baseModel: 'base/model',
       baseThinkingEffort: null,
       lastAssistantMessageText: manifestText([
-        // security configured as anthropic/x but reports the concrete resolved model.
-        {
-          specialistId: 'security',
-          model: 'anthropic/claude-sonnet-5',
-          vote: 'pass',
-          findings: [],
-        },
-        // performance left on default (base/model) and reports what it resolved to.
-        {
-          specialistId: 'performance',
-          model: 'openai/gpt-5',
-          vote: 'pass',
-          findings: [],
-        },
+        { specialistId: 'security', model: 'anthropic/claude-sonnet-5', findings: [] },
+        { specialistId: 'performance', model: 'openai/gpt-5', findings: [] },
       ]),
     });
-
     expect(result.specialists.find(s => s.id === 'security')?.model).toBe(
       'anthropic/claude-sonnet-5'
     );
@@ -99,69 +118,58 @@ describe('buildCouncilResult', () => {
       baseModel: 'base/model',
       baseThinkingEffort: null,
       lastAssistantMessageText: manifestText([
-        // No `model` field → fall back to the configured per-specialist model.
-        { specialistId: 'security', vote: 'pass', findings: [] },
-        // No `model` field, no per-specialist override → fall back to the review base model.
-        { specialistId: 'performance', vote: 'pass', findings: [] },
+        { specialistId: 'security', findings: [] },
+        { specialistId: 'performance', findings: [] },
       ]),
     });
-
     expect(result.specialists.find(s => s.id === 'security')?.model).toBe('anthropic/x');
     expect(result.specialists.find(s => s.id === 'performance')?.model).toBe('base/model');
   });
 
-  it('falls back to the review base model AND base thinking effort for specialists without overrides', () => {
+  it('only inherits base thinking effort when the specialist also inherits the base model', () => {
     const result = buildCouncilResult({
       council,
       baseModel: 'base/model',
       baseThinkingEffort: 'high',
       lastAssistantMessageText: manifestText([
-        { specialistId: 'security', vote: 'pass', findings: [] },
-        { specialistId: 'performance', vote: 'pass', findings: [] },
+        { specialistId: 'security', findings: [] },
+        { specialistId: 'performance', findings: [] },
       ]),
     });
-    // security has its OWN model (anthropic/x) and no effort override → it does NOT inherit
-    // the base model's effort (variants are model-specific), so thinkingEffort is null.
+    // security has its OWN model (anthropic/x) → does NOT inherit the base effort.
     expect(result.specialists.find(s => s.id === 'security')).toMatchObject({
       model: 'anthropic/x',
       thinkingEffort: null,
     });
-    // performance inherits the default model, so it also inherits the base effort.
+    // performance inherits the default model → inherits the base effort.
     expect(result.specialists.find(s => s.id === 'performance')).toMatchObject({
       model: 'base/model',
       thinkingEffort: 'high',
     });
   });
 
-  it('fails closed when a configured specialist is missing from the manifest', () => {
+  it('fails closed (block) when a configured specialist is missing from the manifest', () => {
     const result = buildCouncilResult({
       council,
       baseModel: 'base/model',
       baseThinkingEffort: null,
-      lastAssistantMessageText: manifestText([
-        { specialistId: 'security', vote: 'pass', findings: [] },
-      ]),
+      lastAssistantMessageText: manifestText([{ specialistId: 'security', findings: [] }]),
     });
-
     expect(result.decision).toBe('block'); // missing performance → no coverage → block
     const performance = result.specialists.find(s => s.id === 'performance');
-    expect(performance).toMatchObject({
-      vote: 'abstain',
-      highestSeverity: null,
-    });
+    expect(performance).toMatchObject({ vote: 'block', highestSeverity: null });
     expect(performance?.findings).toEqual([]);
   });
 
-  it('fails closed (block, all abstain) when no manifest is present', () => {
+  it('fails closed (block, all specialists block) when no manifest is present', () => {
     const result = buildCouncilResult({
       council,
       baseModel: 'base/model',
       baseThinkingEffort: null,
       lastAssistantMessageText: 'no marker here',
     });
-
     expect(result.decision).toBe('block');
-    expect(result.specialists.every(s => s.vote === 'abstain')).toBe(true);
+    expect(result.specialists.every(s => s.vote === 'block')).toBe(true);
   });
 
   it('fails closed on an invalid manifest payload', () => {
@@ -172,6 +180,6 @@ describe('buildCouncilResult', () => {
       lastAssistantMessageText: `<!-- ${COUNCIL_RESULT_MARKER_TAG} {not json} -->`,
     });
     expect(result.decision).toBe('block');
-    expect(result.specialists.every(s => s.vote === 'abstain')).toBe(true);
+    expect(result.specialists.every(s => s.vote === 'block')).toBe(true);
   });
 });

--- a/apps/web/src/lib/code-reviews/council/finalize-council-result.test.ts
+++ b/apps/web/src/lib/code-reviews/council/finalize-council-result.test.ts
@@ -156,12 +156,13 @@ describe('buildCouncilResult', () => {
       lastAssistantMessageText: manifestText([{ specialistId: 'security', findings: [] }]),
     });
     expect(result.decision).toBe('block'); // missing performance → no coverage → block
+    // The missing specialist shows "no result" (vote null), NOT a block vote.
     const performance = result.specialists.find(s => s.id === 'performance');
-    expect(performance).toMatchObject({ vote: 'block', highestSeverity: null });
+    expect(performance).toMatchObject({ vote: null, highestSeverity: null });
     expect(performance?.findings).toEqual([]);
   });
 
-  it('fails closed (block, all specialists block) when no manifest is present', () => {
+  it('fails closed (block) when no manifest is present; specialists show "no result"', () => {
     const result = buildCouncilResult({
       council,
       baseModel: 'base/model',
@@ -169,10 +170,11 @@ describe('buildCouncilResult', () => {
       lastAssistantMessageText: 'no marker here',
     });
     expect(result.decision).toBe('block');
-    expect(result.specialists.every(s => s.vote === 'block')).toBe(true);
+    // No specialist reported → all "no result" (vote null), none shown as a block vote.
+    expect(result.specialists.every(s => s.vote === null)).toBe(true);
   });
 
-  it('fails closed on an invalid manifest payload', () => {
+  it('fails closed on an invalid manifest payload; specialists show "no result"', () => {
     const result = buildCouncilResult({
       council,
       baseModel: null,
@@ -180,6 +182,6 @@ describe('buildCouncilResult', () => {
       lastAssistantMessageText: `<!-- ${COUNCIL_RESULT_MARKER_TAG} {not json} -->`,
     });
     expect(result.decision).toBe('block');
-    expect(result.specialists.every(s => s.vote === 'block')).toBe(true);
+    expect(result.specialists.every(s => s.vote === null)).toBe(true);
   });
 });

--- a/apps/web/src/lib/code-reviews/council/finalize-council-result.ts
+++ b/apps/web/src/lib/code-reviews/council/finalize-council-result.ts
@@ -8,7 +8,9 @@ import type {
 } from '@kilocode/db/schema-types';
 import {
   decideCouncilFromManifest,
+  deriveSpecialistVote,
   enabledSpecialists,
+  highestSeverityOf,
   parseCouncilResultManifest,
 } from '@kilocode/worker-utils/code-review-council';
 import { getManualCodeReviewConfig } from '../manual-config';
@@ -65,16 +67,23 @@ export function buildCouncilResult(params: {
       // also inherited the base model (variants are model-specific). A specialist on its own
       // model shows no effort unless it set one.
       thinkingEffort: member.thinking_effort ?? (member.model_slug ? null : baseThinkingEffort),
-      vote: reported?.vote ?? 'abstain',
-      highestSeverity: reported?.highestSeverity ?? null,
+      // v2: vote + highest severity are DERIVED from the reported findings, never model-authored.
+      // A specialist that did NOT report is treated as `block` (fail closed) with no findings.
+      vote: reported ? deriveSpecialistVote(reported.findings) : 'block',
+      highestSeverity: reported ? highestSeverityOf(reported.findings) : null,
       findings: reported?.findings ?? [],
     };
   });
 
+  // Advisory → no aggregate verdict (null). Otherwise: a captured manifest decides via
+  // `decideCouncilFromManifest` (coverage-checked, fail-closed); a missing/invalid manifest
+  // (no coverage) fails closed to `block`.
   const decision =
-    capture.status === 'captured'
-      ? decideCouncilFromManifest(configuredIds, capture.manifest, strategy).decision
-      : 'block';
+    strategy === 'advisory'
+      ? null
+      : capture.status === 'captured'
+        ? decideCouncilFromManifest(configuredIds, capture.manifest, strategy).decision
+        : 'block';
 
   return { decision, aggregationStrategy: strategy, specialists };
 }

--- a/apps/web/src/lib/code-reviews/council/finalize-council-result.ts
+++ b/apps/web/src/lib/code-reviews/council/finalize-council-result.ts
@@ -68,8 +68,10 @@ export function buildCouncilResult(params: {
       // model shows no effort unless it set one.
       thinkingEffort: member.thinking_effort ?? (member.model_slug ? null : baseThinkingEffort),
       // v2: vote + highest severity are DERIVED from the reported findings, never model-authored.
-      // A specialist that did NOT report is treated as `block` (fail closed) with no findings.
-      vote: reported ? deriveSpecialistVote(reported.findings) : 'block',
+      // A specialist that did NOT report shows `vote: null` ("no result") — distinct from a
+      // `block` vote (which means it reported a critical). The aggregate decision below still
+      // fails closed on this missing coverage for enforcing modes.
+      vote: reported ? deriveSpecialistVote(reported.findings) : null,
       highestSeverity: reported ? highestSeverityOf(reported.findings) : null,
       findings: reported?.findings ?? [],
     };

--- a/apps/web/src/lib/code-reviews/council/finalize-council-result.ts
+++ b/apps/web/src/lib/code-reviews/council/finalize-council-result.ts
@@ -18,19 +18,22 @@ import { setCodeReviewCouncilResult } from '../db/code-reviews';
 import { logExceptInTest } from '@/lib/utils.server';
 
 /**
- * Pure mapping: captures the council manifest from the final assistant message, computes
- * the code-owned decision, and joins each configured specialist with its reported
- * vote/findings into the persisted `CodeReviewCouncilResult`.
+ * Pure mapping: captures the council manifest from the final assistant message and joins each
+ * configured specialist with its reported findings into the persisted `CodeReviewCouncilResult`.
+ * The model reports findings only; this DERIVES each specialist's binary vote
+ * (`deriveSpecialistVote`) and computes the aggregate decision.
  *
- * Fails CLOSED: a missing/invalid manifest → `decision: 'block'`; a configured specialist
- * absent from the manifest → `abstain` (and, via `decideCouncilFromManifest`, blocks).
+ * Decision semantics (v2):
+ * - `advisory` governance always returns `decision: null` (no aggregate verdict, no gate),
+ *   independent of whether the manifest was captured.
+ * - `unanimous`/`majority` defer to `decideCouncilFromManifest`, which FAILS CLOSED to `block`
+ *   on a missing/invalid manifest or on any missing specialist coverage.
  *
- * TODO(council): the `decision` here is ADVISORY for PR4 — a pass/fail score surfaced in the
- * cloud UI only. It is NOT yet wired into the PR merge gate (`gateResult`), so a council
- * `block` does not hard-block the PR. Threading the code-owned decision into `gateResult`
- * (so `block` actually fails the merge check) is deferred to a later PR — see the council
- * plan's beta-readiness gate ("Validate the council PR output in a deployed run"). Keep the
- * UI copy in `CouncilGovernancePanel` in sync with this advisory-only status.
+ * A specialist that did not return a reliable result is shown as `vote: null` ("no result"),
+ * which is distinct from a `block` vote (a `block` vote means the specialist reported a critical).
+ *
+ * NOTE: the decision is not yet wired into the PR merge gate (`gateResult`), so a `block` does
+ * not hard-block the PR today. Injecting the decision into the gate + PR summary is a follow-up.
  */
 export function buildCouncilResult(params: {
   council: CodeReviewCouncilConfig;

--- a/apps/web/src/lib/code-reviews/prompts/council-prompt.test.ts
+++ b/apps/web/src/lib/code-reviews/prompts/council-prompt.test.ts
@@ -95,12 +95,12 @@ describe('buildCouncilOrchestratorPrompt', () => {
     expect(prompt).toContain('subagent_type "security"');
     expect(prompt).toContain('subagent_type "performance"');
     expect(prompt).toContain('BASE REVIEW CONTEXT');
-    // Coordinator must not author an overall decision anywhere — code owns it (avoids the
-    // model-derived PR decision diverging from the fail-closed, coverage-checked one).
-    expect(prompt).toContain('Do NOT compute or render an overall');
+    // Coordinator must not author a vote, decision, or verdict anywhere — code owns them
+    // (v2: votes derived from severities, decision from votes with coverage checks).
+    expect(prompt).toContain('any vote, decision, or verdict');
   });
 
-  it('instructs the coordinator to publish the aggregated review + a council voting table', () => {
+  it('instructs the coordinator to publish a facts-only council table (no vote/decision)', () => {
     const prompt = buildCouncilOrchestratorPrompt({
       basePrompt: 'BASE',
       specialists: [
@@ -113,19 +113,14 @@ describe('buildCouncilOrchestratorPrompt', () => {
     // Owns publishing (specialists are read-only), following the base publication instructions.
     expect(prompt).toContain('YOU publish the review');
     expect(prompt.toLowerCase()).toContain('publication instructions');
-    // Council voting table in the summary, with vote icons.
+    // v2 council table is FACTS only — severity + counts, no vote/decision column.
     expect(prompt).toContain('## Council review');
-    expect(prompt).toContain('Specialist | Model | Vote | Findings');
-    expect(prompt).toContain('✅ Pass');
-    expect(prompt).toContain('⚠️ Warn');
-    expect(prompt).toContain('⛔ Block');
-    expect(prompt).toContain('➖ Abstain');
-    // Must NOT displace the required marker/standard heading (they come first); council
-    // section goes right after — so the summary-identification contract stays intact.
+    expect(prompt).toContain('Specialist | Model | Highest severity | Findings');
+    expect(prompt).toContain('Do NOT include a vote or decision column');
+    // Must NOT displace the required marker/standard heading (they come first).
     expect(prompt).toContain('the standard summary heading come FIRST');
     expect(prompt).toContain('Immediately AFTER that standard heading');
-    // Must neutralize the base "Recommendation" field so the model can't publish a merge
-    // verdict (Merge / Address before merge) that contradicts the code-owned decision.
+    // Must neutralize the base "Recommendation" so the model publishes no merge verdict.
     expect(prompt).toContain('must NOT assert a merge verdict');
     expect(prompt).toContain('determined by council governance');
   });
@@ -140,8 +135,7 @@ describe('buildCouncilOrchestratorPrompt', () => {
       aggregationStrategy: 'majority',
     });
 
-    // 1. Startup line names the specialists AND the formatted governance label — assert the
-    // full fragment so it isn't satisfied by the separate `describeAggregationStrategy` text.
+    // 1. Startup line names the specialists AND the formatted governance label.
     expect(prompt).toContain(
       'Starting council review with 2 specialists (Security, Performance) using Majority governance.'
     );
@@ -153,11 +147,14 @@ describe('buildCouncilOrchestratorPrompt', () => {
 });
 
 describe('buildSpecialistAgentPrompt', () => {
-  it('scopes the specialist to its lens and asks for a structured vote + findings', () => {
+  it('scopes the specialist to its lens and asks for findings + fixed severity, NO vote (v2)', () => {
     const prompt = buildSpecialistAgentPrompt(specialist({ id: 'security', name: 'Security' }));
     expect(prompt).toContain('security concerns');
-    expect(prompt).toContain('"vote"');
-    expect(prompt).toContain('findings');
+    expect(prompt).toContain('"findings"');
+    expect(prompt).toContain('critical|warning|suggestion|nitpick');
+    // The specialist must NOT vote — the vote is code-derived from severities.
+    expect(prompt).toContain('Do NOT cast a vote');
+    expect(prompt).not.toContain('"vote"');
   });
 
   it('bounds the specialist: read-only, diff-scoped, and convergent (no runaway loop)', () => {

--- a/apps/web/src/lib/code-reviews/prompts/council-prompt.ts
+++ b/apps/web/src/lib/code-reviews/prompts/council-prompt.ts
@@ -4,7 +4,6 @@ import type { CouncilAggregationStrategy, CouncilSpecialist } from '@kilocode/db
 import type { RuntimeAgentInput } from '@kilocode/worker-utils/cloud-agent-next-client';
 import {
   COUNCIL_RESULT_MARKER_TAG,
-  describeAggregationStrategy,
   formatAggregationStrategy,
 } from '@kilocode/worker-utils/code-review-council';
 
@@ -12,9 +11,9 @@ import {
  * Council execution prompts (single-session, multi-model).
  *
  * The primary agent acts as the COORDINATOR: it delegates to one sub-agent per specialist
- * (each pinned to its own model via `runtimeAgents`), collects their structured results,
- * and emits ONE combined `kilo-code-review-council:v1` manifest. Our code — never the
- * model — computes the governance decision from that manifest.
+ * (each pinned to its own model via `runtimeAgents`), collects their findings, and emits ONE
+ * combined `kilo-code-review-council:v2` manifest. Our code — never the model — derives each
+ * specialist's binary vote from its findings and computes the governance decision.
  *
  * NOTE: these prompts are a first cut and are expected to be tuned against real inference
  * in local development. The machine-readable manifest contract below is the load-bearing
@@ -39,14 +38,22 @@ export function buildSpecialistAgentPrompt(specialist: CouncilSpecialist): strin
     '  re-analyze — once you have reviewed the changes through your lens, report and STOP.',
     '',
     'Report back to the coordinator with a single JSON object (no prose) of the form:',
-    '{"model":"<the exact model slug you are running as>","vote":"pass|warn|block|abstain","highestSeverity":"<label or null>","findings":[{"path":"...","line":<number|null>,"severity":"<label>","rationale":"..."}]}',
+    '{"model":"<the exact model slug you are running as>","findings":[{"path":"...","line":<number|null>,"severity":"critical|warning|suggestion|nitpick","rationale":"..."}]}',
     '',
-    'Set "model" to the concrete model you are actually running as (not an "auto" alias).',
-    'If you cannot determine it, omit the "model" field entirely.',
+    'Set "model" to the concrete model you are actually running as (not an "auto" alias);',
+    'omit the field if you cannot determine it.',
     '',
-    'Voting guidance: "block" for issues that should stop merge, "warn" for non-blocking',
-    'concerns, "pass" if nothing in your lens is wrong, "abstain" only if your lens does',
-    'not apply to these changes. Report findings only within your lens.',
+    'Severity — assign EXACTLY one per finding from this fixed scale:',
+    '- critical — a genuinely blocking problem in your lens. This is the ONLY severity that',
+    '  blocks a merge, so use it only for issues that should truly stop the change.',
+    '- warning — a real but non-blocking concern.',
+    '- suggestion — an optional improvement.',
+    '- nitpick — trivial or stylistic.',
+    '',
+    'Report ONLY issues within your lens. Do NOT cast a vote or state any overall verdict —',
+    'our system computes the vote and decision from your findings. Returning NO findings',
+    'means you reviewed and found nothing blocking (good to go). There is no "abstain": if',
+    'you were asked to run, you review and report findings-or-none.',
   ]
     .filter(Boolean)
     .join('\n');
@@ -78,8 +85,6 @@ export function buildCouncilOrchestratorPrompt(params: {
     'Specialists:',
     roster,
     '',
-    `Governance (for context only — our system computes the final decision): ${describeAggregationStrategy(aggregationStrategy)}`,
-    '',
     // A council coordinator is mostly quiet (it delegates and waits), so the live session log
     // looks empty and the run appears stuck. Narrate progress so the operator sees it working.
     'Progress updates — print each of the following as a plain-text status line on its own',
@@ -101,28 +106,26 @@ export function buildCouncilOrchestratorPrompt(params: {
     '  marker (e.g. `<!-- kilo-review -->`) and the standard summary heading come FIRST,',
     '  unchanged — do not put anything before them. Immediately AFTER that standard heading,',
     '  insert a "## Council review" section: a markdown table with one row per specialist,',
-    '  columns `Specialist | Model | Vote | Findings`. Render each vote with these icons:',
-    '  ✅ Pass, ⚠️ Warn, ⛔ Block, ➖ Abstain.',
-    '- The summary must NOT assert a merge verdict of its own — this includes any',
-    '  "Recommendation" field the base format asks for (e.g. "Merge" / "Address before merge").',
-    '  Wherever the base format wants a recommendation or merge/no-merge statement, write the',
-    '  neutral placeholder `Recommendation: determined by council governance (computed by Kilo)`',
-    '  instead. The council pass/warn/block decision is code-owned and can differ from what the',
-    '  votes alone suggest (our coverage checks fail closed), so you must not recommend',
-    '  merging or blocking anywhere.',
+    "  columns `Specialist | Model | Highest severity | Findings`, reporting each specialist's",
+    '  worst finding severity and its finding count. Do NOT include a vote or decision column —',
+    '  votes and the overall decision are computed by our system from the severities, not you.',
+    '- The summary must NOT assert a merge verdict of ANY kind — no vote, no decision, and no',
+    '  "Recommendation" (the base format\'s "Merge" / "Address before merge"). Wherever the base',
+    '  format wants a recommendation or merge/no-merge statement, write the neutral placeholder',
+    '  `Recommendation: determined by council governance (computed by Kilo)` instead. The',
+    '  council decision is code-owned; a model-authored verdict could contradict it.',
     '',
     'When every specialist has reported, emit EXACTLY ONE machine-readable manifest on its',
     'own line in your final message, verbatim on a line by itself. It does NOT need to be',
     'the very last line — if any other trailing markers are required, they may follow it:',
     '',
-    `<!-- ${COUNCIL_RESULT_MARKER_TAG} {"specialists":[{"specialistId":"<id>","model":"<model the specialist reported, or omit>","vote":"pass|warn|block|abstain","highestSeverity":"<label or null>","findings":[{"path":"<path>","line":<number|null>,"severity":"<label>","rationale":"<text>"}]}]} -->`,
+    `<!-- ${COUNCIL_RESULT_MARKER_TAG} {"specialists":[{"specialistId":"<id>","model":"<model the specialist reported, or omit>","findings":[{"path":"<path>","line":<number|null>,"severity":"critical|warning|suggestion|nitpick","rationale":"<text>"}]}]} -->`,
     '',
     'Include one entry per specialist, using the subagent_type as its specialistId, and',
-    "pass through each specialist's findings AND reported model verbatim. Omit the model",
-    'field for a specialist that did not report one. Do NOT compute or render an overall',
-    'pass/warn/block DECISION anywhere — not in the manifest and not in the PR summary. Our',
-    'system computes the authoritative decision from these votes (with coverage checks) and',
-    'surfaces it; a model-authored decision could contradict it.',
+    "pass through each specialist's findings (with their severity) AND reported model",
+    'verbatim. Omit the model field for a specialist that did not report one. Do NOT include',
+    'any vote, decision, or verdict — our system derives the votes from the severities and',
+    'computes the decision (with coverage checks); a model-authored verdict could contradict it.',
     '',
     '---',
     '',

--- a/apps/web/src/lib/code-reviews/prompts/council-prompt.ts
+++ b/apps/web/src/lib/code-reviews/prompts/council-prompt.ts
@@ -51,9 +51,9 @@ export function buildSpecialistAgentPrompt(specialist: CouncilSpecialist): strin
     '- nitpick — trivial or stylistic.',
     '',
     'Report ONLY issues within your lens. Do NOT cast a vote or state any overall verdict —',
-    'our system computes the vote and decision from your findings. Returning NO findings',
-    'means you reviewed and found nothing blocking (good to go). There is no "abstain": if',
-    'you were asked to run, you review and report findings-or-none.',
+    'our system computes the vote and decision from your findings. ALWAYS include the',
+    '"findings" array — use [] when you found nothing (that means "reviewed, good to go").',
+    'There is no "abstain": if you were asked to run, you review and report findings-or-none.',
   ]
     .filter(Boolean)
     .join('\n');
@@ -123,7 +123,9 @@ export function buildCouncilOrchestratorPrompt(params: {
     '',
     'Include one entry per specialist, using the subagent_type as its specialistId, and',
     "pass through each specialist's findings (with their severity) AND reported model",
-    'verbatim. Omit the model field for a specialist that did not report one. Do NOT include',
+    'verbatim. EVERY entry MUST include a "findings" array (use [] for a specialist that',
+    'found nothing), and each severity MUST be one of critical|warning|suggestion|nitpick.',
+    'Omit the model field for a specialist that did not report one. Do NOT include',
     'any vote, decision, or verdict — our system derives the votes from the severities and',
     'computes the decision (with coverage checks); a model-authored verdict could contradict it.',
     '',

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
@@ -28,6 +28,7 @@ import type {
 } from '@kilocode/worker-utils/review-agents';
 import type { RuntimeAgentInput } from '@kilocode/worker-utils/cloud-agent-next-client';
 import { enabledSpecialists, isCouncilActive } from '@kilocode/worker-utils/code-review-council';
+import { DEFAULT_COUNCIL_AGGREGATION_STRATEGY } from '@kilocode/db/schema-types';
 import {
   buildCouncilOrchestratorPrompt,
   buildCouncilRuntimeAgents,
@@ -807,7 +808,8 @@ export async function prepareReviewPayload(
     // prompt. `councilActive` (computed above, gating `omitSubAgentGuidance`) guarantees the
     // config is enabled with >= the minimum specialists.
     const councilMembers = councilActive && councilConfig ? enabledSpecialists(councilConfig) : [];
-    const aggregationStrategy = councilConfig?.aggregation_strategy ?? 'advisory';
+    const aggregationStrategy =
+      councilConfig?.aggregation_strategy ?? DEFAULT_COUNCIL_AGGREGATION_STRATEGY;
 
     // Forward-shaped agent selections. Standard = a single 'standard' agent mirroring the
     // session's model/effort; council = one entry per enabled specialist.

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
@@ -807,7 +807,7 @@ export async function prepareReviewPayload(
     // prompt. `councilActive` (computed above, gating `omitSubAgentGuidance`) guarantees the
     // config is enabled with >= the minimum specialists.
     const councilMembers = councilActive && councilConfig ? enabledSpecialists(councilConfig) : [];
-    const aggregationStrategy = councilConfig?.aggregation_strategy ?? 'any_blocking_member';
+    const aggregationStrategy = councilConfig?.aggregation_strategy ?? 'advisory';
 
     // Forward-shaped agent selections. Standard = a single 'standard' agent mirroring the
     // session's model/effort; council = one entry per enabled specialist.

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1245,8 +1245,19 @@ export const COUNCIL_SPECIALIST_ROLES = [
 ] as const;
 export type CouncilSpecialistRole = (typeof COUNCIL_SPECIALIST_ROLES)[number];
 
-export const CouncilVoteSchema = z.enum(['pass', 'warn', 'block', 'abstain']);
+// Council decision model v2: a vote is BINARY (yes/no). "warn"/"abstain" are NOT votes —
+// a warning is a finding severity (see COUNCIL_FINDING_SEVERITIES), and a specialist that
+// ran always votes (no-findings = pass). Votes are code-DERIVED from findings, never
+// authored by the model. Same binary type is reused for the aggregate decision.
+export const CouncilVoteSchema = z.enum(['pass', 'block']);
 export type CouncilVote = z.infer<typeof CouncilVoteSchema>;
+
+// Finding severity scale (v2). The LLM assigns one per finding — this is where its
+// judgment lives. `critical` is the only BLOCKING severity: any critical finding makes the
+// specialist's derived vote `block`; warning/suggestion/nitpick are informational.
+export const COUNCIL_FINDING_SEVERITIES = ['critical', 'warning', 'suggestion', 'nitpick'] as const;
+export const CouncilFindingSeveritySchema = z.enum(COUNCIL_FINDING_SEVERITIES);
+export type CouncilFindingSeverity = (typeof COUNCIL_FINDING_SEVERITIES)[number];
 
 /**
  * Review type for a run. 'standard' is the existing single-reviewer scan; 'council'
@@ -1261,13 +1272,14 @@ export const CODE_REVIEW_TRIGGER_SOURCES = ['manual', 'webhook'] as const;
 export const CodeReviewTriggerSourceSchema = z.enum(CODE_REVIEW_TRIGGER_SOURCES);
 export type CodeReviewTriggerSource = z.infer<typeof CodeReviewTriggerSourceSchema>;
 
-// 'weighted' is intentionally omitted until per-specialist vote weights exist in the
-// config — offering it now would be an aggregation option we cannot actually honor.
-export const COUNCIL_AGGREGATION_STRATEGIES = [
-  'any_blocking_member',
-  'majority',
-  'unanimous_required',
-] as const;
+// Governance mode (v2). Field is still named `aggregation_strategy` for continuity, but the
+// values are the three DISTINCT modes under binary votes:
+// - 'advisory'  — report votes/findings only; compute NO aggregate decision and NO merge gate.
+// - 'unanimous' — block unless EVERY specialist votes pass (i.e. any block → block). Strict.
+// - 'majority'  — block only when block votes outnumber pass votes. Lenient.
+// (v1's 'any_blocking_member' is dropped: with no abstain, it is mathematically identical to
+// 'unanimous'. 'advisory' is the safe default so a new council never blocks a merge unasked.)
+export const COUNCIL_AGGREGATION_STRATEGIES = ['advisory', 'unanimous', 'majority'] as const;
 export const CouncilAggregationStrategySchema = z.enum(COUNCIL_AGGREGATION_STRATEGIES);
 export type CouncilAggregationStrategy = z.infer<typeof CouncilAggregationStrategySchema>;
 
@@ -1338,7 +1350,9 @@ export const CodeReviewCouncilConfigSchema = z.object({
   // and retained while council is toggled off. Defaults true so an existing council
   // object (e.g. from a manual job) is treated as enabled.
   enabled: z.boolean().default(true),
-  aggregation_strategy: CouncilAggregationStrategySchema.default('any_blocking_member'),
+  // Default 'advisory' — the safety net: a council runs and reports, but never blocks a merge
+  // until an org explicitly picks unanimous/majority.
+  aggregation_strategy: CouncilAggregationStrategySchema.default('advisory'),
   // Specialist ids must be unique: a specialist must not appear (and therefore vote)
   // more than once, or vote aggregation could be skewed by a duplicate.
   specialists: z
@@ -1363,6 +1377,9 @@ export type CodeReviewCouncilConfig = z.infer<typeof CodeReviewCouncilConfigSche
 export const CouncilFindingSchema = z.object({
   path: z.string().max(1024),
   line: z.number().int().nonnegative().nullable().optional(),
+  // Canonical scale is COUNCIL_FINDING_SEVERITIES; kept a bounded string (not a strict enum)
+  // so an off-scale label from the model never rejects the whole manifest. Vote derivation
+  // normalizes and only treats `critical` as blocking (see `deriveSpecialistVote`).
   severity: z.string().max(64),
   rationale: z.string().max(4000),
 });
@@ -1375,6 +1392,7 @@ export const CouncilResultSpecialistSchema = z.object({
   // The model/effort that actually ran this specialist (we assign these), for display.
   model: z.string().max(512).nullable(),
   thinkingEffort: z.string().max(50).nullable(),
+  // Binary, CODE-DERIVED from this specialist's findings (any critical → block).
   vote: CouncilVoteSchema,
   highestSeverity: z.string().max(64).nullable(),
   findings: z.array(CouncilFindingSchema).max(200),
@@ -1385,8 +1403,9 @@ export type CouncilResultSpecialist = z.infer<typeof CouncilResultSpecialistSche
 // council runs are not posted to a PR). The capture code maps the parsed
 // `kilo-code-review-council:v1` manifest + the code-owned decision into this storage contract.
 export const CodeReviewCouncilResultSchema = z.object({
-  // The code-owned governance decision (never model-authored).
-  decision: CouncilVoteSchema,
+  // The code-owned governance decision (never model-authored). NULL in `advisory` mode —
+  // there is no aggregate verdict, only the per-specialist votes/findings.
+  decision: CouncilVoteSchema.nullable(),
   aggregationStrategy: CouncilAggregationStrategySchema,
   specialists: z.array(CouncilResultSpecialistSchema).max(8),
 });

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1352,7 +1352,19 @@ export const CodeReviewCouncilConfigSchema = z.object({
   enabled: z.boolean().default(true),
   // Default 'advisory' — the safety net: a council runs and reports, but never blocks a merge
   // until an org explicitly picks unanimous/majority.
-  aggregation_strategy: CouncilAggregationStrategySchema.default('advisory'),
+  //
+  // Backward-compat (read boundary): `aggregation_strategy` is a PERSISTED field, so configs
+  // written before the v2 rollout can hold the legacy v1 values `any_blocking_member` /
+  // `unanimous_required`. Both meant "block on any block", which is exactly v2 `unanimous`, so
+  // we normalize them here rather than throwing when a queued/completed pre-v2 council config
+  // is re-parsed (`getManualCodeReviewConfig`). New values pass through unchanged.
+  aggregation_strategy: z
+    .preprocess(
+      value =>
+        value === 'any_blocking_member' || value === 'unanimous_required' ? 'unanimous' : value,
+      CouncilAggregationStrategySchema
+    )
+    .default('advisory'),
   // Specialist ids must be unique: a specialist must not appear (and therefore vote)
   // more than once, or vote aggregation could be skewed by a duplicate.
   specialists: z
@@ -1377,10 +1389,19 @@ export type CodeReviewCouncilConfig = z.infer<typeof CodeReviewCouncilConfigSche
 export const CouncilFindingSchema = z.object({
   path: z.string().max(1024),
   line: z.number().int().nonnegative().nullable().optional(),
-  // Canonical scale is COUNCIL_FINDING_SEVERITIES; kept a bounded string (not a strict enum)
-  // so an off-scale label from the model never rejects the whole manifest. Vote derivation
-  // normalizes and only treats `critical` as blocking (see `deriveSpecialistVote`).
-  severity: z.string().max(64),
+  // Severity MUST be one of the canonical scale (case/space-insensitive). Because the vote is
+  // DERIVED from severity, a loose label would be unsafe: a real critical issue mislabeled
+  // `high`/`sev1` would otherwise derive to `pass`. An off-scale label instead fails the
+  // finding → the manifest is invalid → the decision fails closed (block). Casing/whitespace
+  // is tolerated (normalized on read via `isBlockingSeverity`), but off-scale words are not.
+  severity: z
+    .string()
+    .max(64)
+    .refine(
+      value =>
+        (COUNCIL_FINDING_SEVERITIES as readonly string[]).includes(value.trim().toLowerCase()),
+      'severity must be one of: critical, warning, suggestion, nitpick'
+    ),
   rationale: z.string().max(4000),
 });
 export type CouncilFinding = z.infer<typeof CouncilFindingSchema>;
@@ -1392,8 +1413,11 @@ export const CouncilResultSpecialistSchema = z.object({
   // The model/effort that actually ran this specialist (we assign these), for display.
   model: z.string().max(512).nullable(),
   thinkingEffort: z.string().max(50).nullable(),
-  // Binary, CODE-DERIVED from this specialist's findings (any critical → block).
-  vote: CouncilVoteSchema,
+  // Binary, CODE-DERIVED from this specialist's findings (any critical → block). NULL when the
+  // specialist returned no reliable result (absent from / not captured in the manifest) — this
+  // is "no result", NOT a `block` vote. The fail-closed AGGREGATE decision (enforcing modes)
+  // is computed separately and still blocks on missing coverage.
+  vote: CouncilVoteSchema.nullable(),
   highestSeverity: z.string().max(64).nullable(),
   findings: z.array(CouncilFindingSchema).max(200),
 });

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1259,6 +1259,10 @@ export const COUNCIL_FINDING_SEVERITIES = ['critical', 'warning', 'suggestion', 
 export const CouncilFindingSeveritySchema = z.enum(COUNCIL_FINDING_SEVERITIES);
 export type CouncilFindingSeverity = (typeof COUNCIL_FINDING_SEVERITIES)[number];
 
+// The single blocking severity: a finding at this level makes the specialist's derived vote
+// `block`. Referenced by `isBlockingSeverity` so the blocking rule lives in exactly one place.
+export const COUNCIL_BLOCKING_SEVERITY: CouncilFindingSeverity = 'critical';
+
 /**
  * Review type for a run. 'standard' is the existing single-reviewer scan; 'council'
  * is a multi-specialist run. Extensible to future types.
@@ -1282,6 +1286,11 @@ export type CodeReviewTriggerSource = z.infer<typeof CodeReviewTriggerSourceSche
 export const COUNCIL_AGGREGATION_STRATEGIES = ['advisory', 'unanimous', 'majority'] as const;
 export const CouncilAggregationStrategySchema = z.enum(COUNCIL_AGGREGATION_STRATEGIES);
 export type CouncilAggregationStrategy = z.infer<typeof CouncilAggregationStrategySchema>;
+
+// The safe default governance mode: report only, never gate a merge unasked. Single source of
+// truth — referenced by the schema default, the manual-job UI state, dispatch, and the label
+// fallback, so the default can't drift between the backend and what the UI initializes to.
+export const DEFAULT_COUNCIL_AGGREGATION_STRATEGY: CouncilAggregationStrategy = 'advisory';
 
 // A specialist id doubles as the cloud-agent-next `runtimeAgents[].slug` (single-session
 // execution) AND the manifest correlation key, so it must satisfy the runtime-agent slug
@@ -1364,7 +1373,7 @@ export const CodeReviewCouncilConfigSchema = z.object({
         value === 'any_blocking_member' || value === 'unanimous_required' ? 'unanimous' : value,
       CouncilAggregationStrategySchema
     )
-    .default('advisory'),
+    .default(DEFAULT_COUNCIL_AGGREGATION_STRATEGY),
   // Specialist ids must be unique: a specialist must not appear (and therefore vote)
   // more than once, or vote aggregation could be skewed by a duplicate.
   specialists: z

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -20,6 +20,7 @@ import {
   type SpecialistVote,
 } from './code-review-council.js';
 import type { CouncilResultManifest } from './code-review-council.js';
+import { CodeReviewCouncilConfigSchema } from '@kilocode/db/schema-types';
 import type { CodeReviewCouncilConfig } from '@kilocode/db/schema-types';
 
 const votes = (...vs: Array<[string, SpecialistVote['vote']]>): SpecialistVote[] =>
@@ -113,7 +114,7 @@ describe('parseCouncilResultManifest', () => {
     if (capture.status !== 'captured') throw new Error('unreachable');
     expect(capture.manifest.specialists).toHaveLength(2);
     expect(capture.manifest.specialists[0].findings).toHaveLength(1);
-    // findings defaults to [] when omitted.
+    // An explicit empty findings array is valid (= "reviewed, nothing blocking").
     expect(capture.manifest.specialists[1].findings).toEqual([]);
   });
 
@@ -127,6 +128,41 @@ describe('parseCouncilResultManifest', () => {
     const bad = { specialists: [{ findings: [] }] };
     const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(bad)} -->`;
     expect(parseCouncilResultManifest(text).status).toBe('invalid');
+  });
+
+  it('fails closed: a specialist entry with NO findings key is invalid (not a silent pass)', () => {
+    const bad = { specialists: [{ specialistId: 'security' }] };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(bad)} -->`;
+    expect(parseCouncilResultManifest(text).status).toBe('invalid');
+  });
+
+  it('fails closed: an off-scale severity is invalid (a mislabeled critical cannot derive to pass)', () => {
+    const bad = {
+      specialists: [
+        {
+          specialistId: 'security',
+          findings: [{ path: 'a.ts', severity: 'high', rationale: 'x' }],
+        },
+      ],
+    };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(bad)} -->`;
+    expect(parseCouncilResultManifest(text).status).toBe('invalid');
+  });
+
+  it('tolerates casing/whitespace on canonical severities', () => {
+    const ok = {
+      specialists: [
+        {
+          specialistId: 'security',
+          findings: [{ path: 'a.ts', severity: ' Critical ', rationale: 'x' }],
+        },
+      ],
+    };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(ok)} -->`;
+    const capture = parseCouncilResultManifest(text);
+    expect(capture.status).toBe('captured');
+    if (capture.status !== 'captured') throw new Error('unreachable');
+    expect(deriveSpecialistVote(capture.manifest.specialists[0].findings)).toBe('block');
   });
 
   it('returns invalid on non-JSON payload', () => {
@@ -472,6 +508,28 @@ describe('council config helpers', () => {
     expect(formatAggregationStrategy('unanimous')).toBe('Unanimous');
     expect(formatAggregationStrategy(null)).toBe('Advisory (report only)');
     expect(formatAggregationStrategy('weird')).toBe('weird');
+  });
+
+  it('normalizes legacy v1 aggregation_strategy values when parsing a persisted config', () => {
+    const base = {
+      enabled: true,
+      specialists: [presetToSpecialist(COUNCIL_SPECIALIST_PRESETS[0])],
+    };
+    // Pre-v2 configs used any_blocking_member / unanimous_required — both → v2 unanimous.
+    expect(
+      CodeReviewCouncilConfigSchema.parse({ ...base, aggregation_strategy: 'any_blocking_member' })
+        .aggregation_strategy
+    ).toBe('unanimous');
+    expect(
+      CodeReviewCouncilConfigSchema.parse({ ...base, aggregation_strategy: 'unanimous_required' })
+        .aggregation_strategy
+    ).toBe('unanimous');
+    // New values + omitted (→ default advisory) pass through.
+    expect(
+      CodeReviewCouncilConfigSchema.parse({ ...base, aggregation_strategy: 'majority' })
+        .aggregation_strategy
+    ).toBe('majority');
+    expect(CodeReviewCouncilConfigSchema.parse(base).aggregation_strategy).toBe('advisory');
   });
 });
 

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -6,137 +6,103 @@ import {
   computeCouncilDecision,
   councilDecisionBlocksMerge,
   decideCouncilFromManifest,
-  describeAggregationStrategy,
+  deriveSpecialistVote,
   determineAutomatedReviewType,
   enabledSpecialists,
   formatAggregationStrategy,
+  highestSeverityOf,
+  isBlockingSeverity,
   isCouncilActive,
   parseCouncilResultManifest,
-  parseGovernanceMarker,
   presetToSpecialist,
   reconcileCouncilVotes,
   summarizeCouncilManifest,
   type SpecialistVote,
 } from './code-review-council.js';
 import type { CouncilResultManifest } from './code-review-council.js';
-import type {
-  CodeReviewCouncilConfig,
-  CouncilAggregationStrategy,
-} from '@kilocode/db/schema-types';
+import type { CodeReviewCouncilConfig } from '@kilocode/db/schema-types';
 
 const votes = (...vs: Array<[string, SpecialistVote['vote']]>): SpecialistVote[] =>
   vs.map(([specialistId, vote]) => ({ specialistId, vote }));
 
-describe('computeCouncilDecision', () => {
-  it('blocks on empty coverage for every strategy (never pass)', () => {
-    const strategies: CouncilAggregationStrategy[] = [
-      'any_blocking_member',
-      'majority',
-      'unanimous_required',
-    ];
-    for (const strategy of strategies) {
-      expect(computeCouncilDecision([], strategy)).toBe('block');
-      // All-abstain is also "no usable coverage".
-      expect(computeCouncilDecision(votes(['a', 'abstain'], ['b', 'abstain']), strategy)).toBe(
-        'block'
-      );
-    }
+// v2: a specialist's vote is DERIVED from its findings — a critical finding → block, else pass.
+const crit = (path = 'a.ts') => [{ path, line: 1, severity: 'critical', rationale: 'x' }];
+const nit = (path = 'a.ts') => [{ path, line: 1, severity: 'nitpick', rationale: 'x' }];
+
+describe('severity → vote derivation (v2)', () => {
+  it('isBlockingSeverity is true only for critical (case/space-insensitive)', () => {
+    expect(isBlockingSeverity('critical')).toBe(true);
+    expect(isBlockingSeverity(' Critical ')).toBe(true);
+    expect(isBlockingSeverity('warning')).toBe(false);
+    expect(isBlockingSeverity('')).toBe(false);
+    expect(isBlockingSeverity(null)).toBe(false);
   });
 
-  describe('any_blocking_member', () => {
+  it('deriveSpecialistVote: block iff any finding is critical (no findings = pass)', () => {
+    expect(deriveSpecialistVote([])).toBe('pass');
+    expect(deriveSpecialistVote(nit())).toBe('pass');
+    expect(deriveSpecialistVote([...nit(), ...crit()])).toBe('block');
+  });
+
+  it('highestSeverityOf returns the worst label present (original casing), or null', () => {
+    expect(highestSeverityOf([])).toBeNull();
+    expect(
+      highestSeverityOf([
+        { path: 'a', severity: 'warning', rationale: 'x' },
+        { path: 'b', severity: 'critical', rationale: 'y' },
+      ])
+    ).toBe('critical');
+    expect(highestSeverityOf([{ path: 'a', severity: 'nitpick', rationale: 'x' }])).toBe('nitpick');
+    // Off-scale labels rank lowest but are still surfaced when nothing else is present.
+    expect(highestSeverityOf([{ path: 'a', severity: 'weird', rationale: 'x' }])).toBe('weird');
+  });
+});
+
+describe('computeCouncilDecision (binary)', () => {
+  it('blocks on empty coverage for every enforcing strategy (never pass)', () => {
+    expect(computeCouncilDecision([], 'unanimous')).toBe('block');
+    expect(computeCouncilDecision([], 'majority')).toBe('block');
+  });
+
+  describe('unanimous', () => {
     it('blocks if any specialist blocks', () => {
-      expect(
-        computeCouncilDecision(votes(['a', 'pass'], ['b', 'block']), 'any_blocking_member')
-      ).toBe('block');
+      expect(computeCouncilDecision(votes(['a', 'pass'], ['b', 'block']), 'unanimous')).toBe(
+        'block'
+      );
     });
-    it('warns if any warn and none block', () => {
-      expect(
-        computeCouncilDecision(votes(['a', 'pass'], ['b', 'warn']), 'any_blocking_member')
-      ).toBe('warn');
-    });
-    it('passes when all pass', () => {
-      expect(
-        computeCouncilDecision(votes(['a', 'pass'], ['b', 'pass']), 'any_blocking_member')
-      ).toBe('pass');
+    it('passes only when every specialist passes', () => {
+      expect(computeCouncilDecision(votes(['a', 'pass'], ['b', 'pass']), 'unanimous')).toBe('pass');
     });
   });
 
   describe('majority', () => {
-    it('blocks only when block votes outnumber pass votes', () => {
+    it('blocks only when block votes outnumber pass votes; ties pass', () => {
       expect(
         computeCouncilDecision(votes(['a', 'block'], ['b', 'block'], ['c', 'pass']), 'majority')
       ).toBe('block');
-      // Tie (1 block, 1 pass) is not a block majority → warn/pass by remaining votes.
+      // 1 block, 1 pass → tie → pass.
       expect(computeCouncilDecision(votes(['a', 'block'], ['b', 'pass']), 'majority')).toBe('pass');
-    });
-    it('warns when not out-blocked but a warn exists', () => {
-      expect(
-        computeCouncilDecision(votes(['a', 'pass'], ['b', 'pass'], ['c', 'warn']), 'majority')
-      ).toBe('warn');
-    });
-  });
-
-  describe('unanimous_required', () => {
-    it('blocks if any block or abstain', () => {
-      expect(
-        computeCouncilDecision(votes(['a', 'pass'], ['b', 'abstain']), 'unanimous_required')
-      ).toBe('block');
-      expect(
-        computeCouncilDecision(votes(['a', 'pass'], ['b', 'block']), 'unanimous_required')
-      ).toBe('block');
-    });
-    it('warns if all non-block/non-abstain but a warn exists', () => {
-      expect(
-        computeCouncilDecision(votes(['a', 'pass'], ['b', 'warn']), 'unanimous_required')
-      ).toBe('warn');
-    });
-    it('passes only when every specialist passes', () => {
-      expect(
-        computeCouncilDecision(votes(['a', 'pass'], ['b', 'pass']), 'unanimous_required')
-      ).toBe('pass');
     });
   });
 });
 
 describe('councilDecisionBlocksMerge', () => {
-  it('blocks only on block', () => {
+  it('blocks only on block; pass and null (advisory) do not', () => {
     expect(councilDecisionBlocksMerge('block')).toBe(true);
-    expect(councilDecisionBlocksMerge('warn')).toBe(false);
     expect(councilDecisionBlocksMerge('pass')).toBe(false);
-    expect(councilDecisionBlocksMerge('abstain')).toBe(false);
-  });
-});
-
-describe('describeAggregationStrategy', () => {
-  it('returns distinct wording per strategy', () => {
-    const a = describeAggregationStrategy('any_blocking_member');
-    const m = describeAggregationStrategy('majority');
-    const u = describeAggregationStrategy('unanimous_required');
-    expect(new Set([a, m, u]).size).toBe(3);
-    expect(m.toLowerCase()).toContain('majority');
-    expect(u.toLowerCase()).toContain('unanimous');
-  });
-
-  it('documents the no-usable-coverage → block rule for every strategy (lockstep with computeCouncilDecision)', () => {
-    const strategies = ['any_blocking_member', 'majority', 'unanimous_required'] as const;
-    for (const strategy of strategies) {
-      const text = describeAggregationStrategy(strategy).toLowerCase();
-      expect(text).toContain('all abstained');
-      expect(text).toContain('block');
-    }
+    expect(councilDecisionBlocksMerge(null)).toBe(false);
   });
 });
 
 describe('parseCouncilResultManifest', () => {
+  // v2 manifest: specialists report findings only (no vote/highestSeverity — code derives them).
   const manifest = {
     specialists: [
       {
         specialistId: 'security',
-        vote: 'block',
-        highestSeverity: 'critical',
         findings: [{ path: 'a.ts', line: 3, severity: 'critical', rationale: 'sqli' }],
       },
-      { specialistId: 'performance', vote: 'pass', findings: [] },
+      { specialistId: 'performance', findings: [] },
     ],
   };
 
@@ -157,8 +123,8 @@ describe('parseCouncilResultManifest', () => {
     expect(parseCouncilResultManifest(null).status).toBe('missing');
   });
 
-  it('returns invalid when a specialist vote is missing/invalid', () => {
-    const bad = { specialists: [{ specialistId: 'security', findings: [] }] };
+  it('returns invalid when a specialist entry is missing its id', () => {
+    const bad = { specialists: [{ findings: [] }] };
     const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(bad)} -->`;
     expect(parseCouncilResultManifest(text).status).toBe('invalid');
   });
@@ -170,13 +136,14 @@ describe('parseCouncilResultManifest', () => {
   });
 
   it('uses the last marker when several are present (trailing prose safe)', () => {
-    const first = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
-    const last = { specialists: [{ specialistId: 'security', vote: 'block', findings: [] }] };
+    const first = { specialists: [{ specialistId: 'security', findings: [] }] };
+    const last = { specialists: [{ specialistId: 'security', findings: crit() }] };
     const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(first)} -->\nthen\n<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(last)} -->\ntrailing note`;
     const capture = parseCouncilResultManifest(text);
     expect(capture.status).toBe('captured');
     if (capture.status !== 'captured') throw new Error('unreachable');
-    expect(capture.manifest.specialists[0].vote).toBe('block');
+    // The LAST marker wins — its security finding is critical (→ derived block).
+    expect(deriveSpecialistVote(capture.manifest.specialists[0].findings)).toBe('block');
   });
 
   it('captures a manifest whose finding text contains --> and braces (no false invalid)', () => {
@@ -184,13 +151,11 @@ describe('parseCouncilResultManifest', () => {
       specialists: [
         {
           specialistId: 'correctness',
-          vote: 'warn',
-          highestSeverity: 'medium',
           findings: [
             {
               path: 'src/loop.ts',
               line: 12,
-              severity: 'medium',
+              severity: 'warning',
               rationale: 'Confusing "goes to" operator: while (i --> 0) {} reads like an arrow.',
             },
           ],
@@ -209,26 +174,23 @@ describe('parseCouncilResultManifest', () => {
       specialists: [
         {
           specialistId: 'security',
-          vote: 'pass',
-          findings: [{ path: 'a.ts', line: 1, severity: 'low', rationale: 'note --> here' }],
+          findings: [{ path: 'a.ts', line: 1, severity: 'nitpick', rationale: 'note --> here' }],
         },
       ],
     };
-    const last = {
-      specialists: [{ specialistId: 'security', vote: 'block', findings: [] }],
-    };
+    const last = { specialists: [{ specialistId: 'security', findings: crit() }] };
     const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(first)} -->\n<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(last)} -->`;
     const capture = parseCouncilResultManifest(text);
     expect(capture.status).toBe('captured');
     if (capture.status !== 'captured') throw new Error('unreachable');
-    expect(capture.manifest.specialists[0].vote).toBe('block');
+    expect(deriveSpecialistVote(capture.manifest.specialists[0].findings)).toBe('block');
   });
 
-  it('treats a duplicate specialistId as invalid (a later entry cannot override an earlier vote)', () => {
+  it('treats a duplicate specialistId as invalid (a later entry cannot override an earlier one)', () => {
     const dup = {
       specialists: [
-        { specialistId: 'security', vote: 'block', findings: [] },
-        { specialistId: 'security', vote: 'pass', findings: [] },
+        { specialistId: 'security', findings: crit() },
+        { specialistId: 'security', findings: [] },
       ],
     };
     const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(dup)} -->`;
@@ -237,39 +199,34 @@ describe('parseCouncilResultManifest', () => {
     const decision = decideCouncilFromManifest(
       ['security'],
       dup as unknown as CouncilResultManifest,
-      'any_blocking_member'
+      'unanimous'
     );
     expect(decision.decision).toBe('block');
     expect(decision.missingSpecialistIds).toEqual(['security']);
   });
 
-  it('does not treat a longer version tag (v10 / v1junk) as a v1 marker', () => {
-    const manifest = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
+  it('does not treat a longer version tag (v20 / v2junk) as the marker', () => {
+    const m = { specialists: [{ specialistId: 'security', findings: [] }] };
     expect(
-      parseCouncilResultManifest(
-        `<!-- ${COUNCIL_RESULT_MARKER_TAG}0 ${JSON.stringify(manifest)} -->`
-      ).status
+      parseCouncilResultManifest(`<!-- ${COUNCIL_RESULT_MARKER_TAG}0 ${JSON.stringify(m)} -->`)
+        .status
     ).toBe('missing');
     expect(
-      parseCouncilResultManifest(
-        `<!-- ${COUNCIL_RESULT_MARKER_TAG}junk ${JSON.stringify(manifest)} -->`
-      ).status
+      parseCouncilResultManifest(`<!-- ${COUNCIL_RESULT_MARKER_TAG}junk ${JSON.stringify(m)} -->`)
+        .status
     ).toBe('missing');
   });
 
   it('ignores marker text embedded inside a finding and captures the real manifest', () => {
-    // A specialist quotes the marker in its rationale. JSON.stringify does not escape it,
-    // so the serialized message contains a second, embedded marker occurrence.
     const real = {
       specialists: [
         {
           specialistId: 'security',
-          vote: 'block',
           findings: [
             {
               path: 'a.ts',
               line: 1,
-              severity: 'high',
+              severity: 'critical',
               rationale: `Do not emit <!-- ${COUNCIL_RESULT_MARKER_TAG} {"specialists":[]} --> in code.`,
             },
           ],
@@ -281,13 +238,13 @@ describe('parseCouncilResultManifest', () => {
     expect(capture.status).toBe('captured');
     if (capture.status !== 'captured') throw new Error('unreachable');
     expect(capture.manifest.specialists).toHaveLength(1);
-    expect(capture.manifest.specialists[0].vote).toBe('block');
+    expect(deriveSpecialistVote(capture.manifest.specialists[0].findings)).toBe('block');
   });
 
   it('a malformed LATEST top-level marker stays invalid and does not fall back to an earlier valid one', () => {
-    const earlierPass = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
-    // Later top-level marker is malformed (missing vote) — must fail closed, not reuse the earlier pass.
-    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(earlierPass)} -->\n<!-- ${COUNCIL_RESULT_MARKER_TAG} {"specialists":[{"specialistId":"security"}]} -->`;
+    const earlier = { specialists: [{ specialistId: 'security', findings: [] }] };
+    // Later top-level marker is malformed (entry missing specialistId) — must fail closed.
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(earlier)} -->\n<!-- ${COUNCIL_RESULT_MARKER_TAG} {"specialists":[{"findings":[]}]} -->`;
     expect(parseCouncilResultManifest(text).status).toBe('invalid');
   });
 
@@ -297,8 +254,7 @@ describe('parseCouncilResultManifest', () => {
       specialists: [
         {
           specialistId: 'security',
-          vote: 'block',
-          findings: [{ path: 'a.ts', line: 1, severity: 'high', rationale: noise }],
+          findings: [{ path: 'a.ts', line: 1, severity: 'critical', rationale: noise }],
         },
       ],
     };
@@ -306,71 +262,57 @@ describe('parseCouncilResultManifest', () => {
     const capture = parseCouncilResultManifest(text);
     expect(capture.status).toBe('captured');
     if (capture.status !== 'captured') throw new Error('unreachable');
-    expect(capture.manifest.specialists[0].vote).toBe('block');
+    expect(deriveSpecialistVote(capture.manifest.specialists[0].findings)).toBe('block');
   });
 
   it('does not swallow unrelated JSON when the marker has no immediate payload', () => {
-    // Marker with no `{` on its line, followed later by manifest-shaped JSON that is NOT
-    // framed by this marker. Must not be captured.
-    const stray = JSON.stringify({
-      specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }],
-    });
+    const stray = JSON.stringify({ specialists: [{ specialistId: 'security', findings: [] }] });
     const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} -->\nHere is some JSON: ${stray}`;
     expect(parseCouncilResultManifest(text).status).toBe('invalid');
   });
 
   it('requires the closing --> frame after the JSON object', () => {
-    const manifest = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
-    // Object present after the tag but not framed by a closing `-->`.
-    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(manifest)} and then prose`;
+    const m = { specialists: [{ specialistId: 'security', findings: [] }] };
+    const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(m)} and then prose`;
     expect(parseCouncilResultManifest(text).status).toBe('invalid');
   });
 
   it('ignores an embedded marker preceded by a Unicode line separator (U+2028/U+2029)', () => {
-    // JS `^m` treats U+2028/U+2029 as line starts, and JSON.stringify leaves them
-    // unescaped — so a finding containing one before the marker must NOT be treated as a
-    // top-level marker.
     const real = {
       specialists: [
         {
           specialistId: 'security',
-          vote: 'block',
           findings: [
             {
               path: 'a.ts',
               line: 1,
-              severity: 'high',
-              rationale: `line1\u2028<!-- ${COUNCIL_RESULT_MARKER_TAG} {"specialists":[]} -->\u2029end`,
+              severity: 'critical',
+              rationale: `line1 <!-- ${COUNCIL_RESULT_MARKER_TAG} {"specialists":[]} --> end`,
             },
           ],
         },
       ],
     };
     const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(real)} -->`;
-    // Sanity: the serialized text really contains a raw U+2028 (unescaped by JSON.stringify).
-    expect(text).toContain('\u2028');
+    expect(text).toContain(' ');
     const capture = parseCouncilResultManifest(text);
     expect(capture.status).toBe('captured');
     if (capture.status !== 'captured') throw new Error('unreachable');
-    expect(capture.manifest.specialists[0].vote).toBe('block');
+    expect(deriveSpecialistVote(capture.manifest.specialists[0].findings)).toBe('block');
   });
 
   it('enforces the byte cap for unpaired surrogates (cannot undercount past 128 KiB)', () => {
-    // `\uD800\u0800` = an unpaired high surrogate + a BMP char = 6 UTF-8 bytes (3-byte
-    // replacement char + 3-byte char), NOT 4. 25k of them is ~150 KiB, over the cap.
-    // Character count (~50k) stays under the scan bound, so the byte cap must catch it.
-    const seq = '\uD800\u0800'.repeat(25_000);
+    const seq = '\uD800ࠀ'.repeat(25_000);
     const payload = `{"specialists":[],"x":"${seq}"}`;
     const text = `<!-- ${COUNCIL_RESULT_MARKER_TAG} ${payload} -->`;
     expect(parseCouncilResultManifest(text).status).toBe('invalid');
   });
 
   it('does not treat a mid-line (non-line-anchored) marker as top-level', () => {
-    const manifest = { specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }] };
-    // Marker preceded by non-whitespace on the same line is not a top-level marker.
+    const m = { specialists: [{ specialistId: 'security', findings: [] }] };
     expect(
       parseCouncilResultManifest(
-        `prefix <!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(manifest)} -->`
+        `prefix <!-- ${COUNCIL_RESULT_MARKER_TAG} ${JSON.stringify(m)} -->`
       ).status
     ).toBe('missing');
   });
@@ -380,8 +322,9 @@ describe('parseCouncilResultManifest', () => {
       specialists: [
         {
           specialistId: 'security',
-          vote: 'pass',
-          findings: [{ path: 'a.ts', line: 1, severity: 'x', rationale: 'y'.repeat(200_000) }],
+          findings: [
+            { path: 'a.ts', line: 1, severity: 'warning', rationale: 'y'.repeat(200_000) },
+          ],
         },
       ],
     };
@@ -391,19 +334,17 @@ describe('parseCouncilResultManifest', () => {
 });
 
 describe('summarizeCouncilManifest', () => {
-  it('rolls up vote, highest severity, and findings count per specialist', () => {
+  it('derives vote + highest severity from findings (model reports neither)', () => {
     const summary = summarizeCouncilManifest({
       specialists: [
         {
           specialistId: 'security',
-          vote: 'block',
-          highestSeverity: 'critical',
           findings: [
             { path: 'a.ts', line: 1, severity: 'critical', rationale: 'x' },
-            { path: 'b.ts', line: 2, severity: 'high', rationale: 'y' },
+            { path: 'b.ts', line: 2, severity: 'warning', rationale: 'y' },
           ],
         },
-        { specialistId: 'performance', vote: 'pass', findings: [] },
+        { specialistId: 'performance', findings: [] },
       ],
     });
     expect(summary).toEqual([
@@ -416,12 +357,12 @@ describe('summarizeCouncilManifest', () => {
 describe('reconcileCouncilVotes', () => {
   const manifest: CouncilResultManifest = {
     specialists: [
-      { specialistId: 'security', vote: 'block', findings: [] },
-      { specialistId: 'unknown', vote: 'pass', findings: [] },
+      { specialistId: 'security', findings: crit() },
+      { specialistId: 'unknown', findings: [] },
     ],
   };
 
-  it('surfaces a configured specialist absent from the manifest as missing (not abstain)', () => {
+  it('surfaces a configured specialist absent from the manifest as missing', () => {
     const coverage = reconcileCouncilVotes(['security', 'performance'], manifest);
     expect(coverage.votes).toEqual([{ specialistId: 'security', vote: 'block' }]);
     expect(coverage.missingSpecialistIds).toEqual(['performance']);
@@ -433,66 +374,62 @@ describe('reconcileCouncilVotes', () => {
     expect(coverage.missingSpecialistIds).toEqual([]);
   });
 
-  it('keeps a legitimately returned abstain vote as abstain', () => {
+  it('derives pass for a reported specialist with no critical findings', () => {
     const coverage = reconcileCouncilVotes(['security'], {
-      specialists: [{ specialistId: 'security', vote: 'abstain', findings: [] }],
+      specialists: [{ specialistId: 'security', findings: nit() }],
     });
-    expect(coverage.votes).toEqual([{ specialistId: 'security', vote: 'abstain' }]);
-    expect(coverage.missingSpecialistIds).toEqual([]);
+    expect(coverage.votes).toEqual([{ specialistId: 'security', vote: 'pass' }]);
   });
 });
 
 describe('decideCouncilFromManifest (coverage-aware)', () => {
-  const strategies = ['any_blocking_member', 'majority', 'unanimous_required'] as const;
-
-  it('blocks under EVERY strategy when a configured specialist is missing (fail closed)', () => {
+  it('advisory: computes NO aggregate decision (null), regardless of votes', () => {
     const manifest: CouncilResultManifest = {
-      specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }],
+      specialists: [{ specialistId: 'security', findings: crit() }],
     };
-    for (const strategy of strategies) {
+    const result = decideCouncilFromManifest(['security'], manifest, 'advisory');
+    expect(result.decision).toBeNull();
+    expect(result.votes).toEqual([{ specialistId: 'security', vote: 'block' }]);
+  });
+
+  it('blocks under enforcing strategies when a configured specialist is missing (fail closed)', () => {
+    const manifest: CouncilResultManifest = {
+      specialists: [{ specialistId: 'security', findings: [] }],
+    };
+    for (const strategy of ['unanimous', 'majority'] as const) {
       const result = decideCouncilFromManifest(['security', 'performance'], manifest, strategy);
       expect(result.decision).toBe('block');
       expect(result.missingSpecialistIds).toEqual(['performance']);
     }
   });
 
-  it('passes when every configured specialist reported and all pass', () => {
+  it('passes when every configured specialist reported and none is critical', () => {
     const manifest: CouncilResultManifest = {
       specialists: [
-        { specialistId: 'security', vote: 'pass', findings: [] },
-        { specialistId: 'performance', vote: 'pass', findings: [] },
+        { specialistId: 'security', findings: [] },
+        { specialistId: 'performance', findings: nit() },
       ],
     };
-    const result = decideCouncilFromManifest(
-      ['security', 'performance'],
-      manifest,
-      'any_blocking_member'
-    );
+    const result = decideCouncilFromManifest(['security', 'performance'], manifest, 'unanimous');
     expect(result.decision).toBe('pass');
     expect(result.missingSpecialistIds).toEqual([]);
   });
 
-  it('does not block on a legitimately returned abstain under any_blocking_member (strategy A)', () => {
+  it('blocks under unanimous when one specialist has a critical finding', () => {
     const manifest: CouncilResultManifest = {
       specialists: [
-        { specialistId: 'security', vote: 'abstain', findings: [] },
-        { specialistId: 'performance', vote: 'pass', findings: [] },
+        { specialistId: 'security', findings: crit() },
+        { specialistId: 'performance', findings: [] },
       ],
     };
-    const result = decideCouncilFromManifest(
-      ['security', 'performance'],
-      manifest,
-      'any_blocking_member'
-    );
-    expect(result.decision).toBe('pass');
+    const result = decideCouncilFromManifest(['security', 'performance'], manifest, 'unanimous');
+    expect(result.decision).toBe('block');
   });
 
   it('fails closed on a duplicate configured id (a specialist cannot be counted twice)', () => {
     const manifest: CouncilResultManifest = {
-      specialists: [{ specialistId: 'security', vote: 'pass', findings: [] }],
+      specialists: [{ specialistId: 'security', findings: [] }],
     };
-    // Without the guard, ['security','security'] would append security's pass vote twice
-    // and could flip a majority. It is counted once and treated as unreliable coverage.
     const result = decideCouncilFromManifest(['security', 'security'], manifest, 'majority');
     expect(result.decision).toBe('block');
     expect(result.missingSpecialistIds).toEqual(['security']);
@@ -500,59 +437,18 @@ describe('decideCouncilFromManifest (coverage-aware)', () => {
   });
 });
 
-describe('parseGovernanceMarker', () => {
-  it('parses member votes and strips any model-authored overall decision', () => {
-    // The model emits `decision`, but it is code-owned — the parsed result must not carry
-    // it (it could contradict computeCouncilDecision in the UI).
-    const gov = { members: [{ id: 'security', vote: 'pass' }], decision: 'pass' };
-    const parsed = parseGovernanceMarker(
-      `<!-- kilo-review-governance:v1 ${JSON.stringify(gov)} -->`
-    );
-    expect(parsed).toEqual({ members: [{ id: 'security', vote: 'pass', highestSeverity: null }] });
-    expect(parsed as unknown as Record<string, unknown>).not.toHaveProperty('decision');
-  });
-
-  it('returns null when absent or malformed', () => {
-    expect(parseGovernanceMarker('nothing')).toBeNull();
-    expect(parseGovernanceMarker(null)).toBeNull();
-    expect(parseGovernanceMarker('<!-- kilo-review-governance:v1 {bad} -->')).toBeNull();
-  });
-
-  it('normalizes a "none" severity label to null', () => {
-    const gov = { members: [{ id: 'a', vote: 'pass', highestSeverity: 'none' }], decision: 'pass' };
-    const parsed = parseGovernanceMarker(
-      `<!-- kilo-review-governance:v1 ${JSON.stringify(gov)} -->`
-    );
-    expect(parsed?.members[0].highestSeverity).toBeNull();
-  });
-
-  it('parses when a member reason contains --> and braces', () => {
-    const gov = {
-      members: [{ id: 'security', vote: 'warn', reason: 'template `${x}` and --> in code' }],
-      decision: 'warn',
-    };
-    const parsed = parseGovernanceMarker(
-      `<!-- kilo-review-governance:v1 ${JSON.stringify(gov)} -->`
-    );
-    expect(parsed?.members[0].vote).toBe('warn');
-    expect(parsed?.members[0].reason).toContain('-->');
-  });
-});
-
 describe('council config helpers', () => {
-  // One enabled (security) + one disabled (performance).
   const council: CodeReviewCouncilConfig = {
     enabled: true,
-    aggregation_strategy: 'any_blocking_member',
+    aggregation_strategy: 'unanimous',
     specialists: [
       presetToSpecialist(COUNCIL_SPECIALIST_PRESETS[0]),
       { ...presetToSpecialist(COUNCIL_SPECIALIST_PRESETS[1]), enabled: false },
     ],
   };
-  // Two enabled specialists (meets COUNCIL_MIN_SPECIALISTS).
   const activeCouncil: CodeReviewCouncilConfig = {
     enabled: true,
-    aggregation_strategy: 'any_blocking_member',
+    aggregation_strategy: 'advisory',
     specialists: [
       presetToSpecialist(COUNCIL_SPECIALIST_PRESETS[0]),
       presetToSpecialist(COUNCIL_SPECIALIST_PRESETS[1]),
@@ -565,16 +461,16 @@ describe('council config helpers', () => {
 
   it('isCouncilActive requires enabled + at least COUNCIL_MIN_SPECIALISTS enabled specialists', () => {
     expect(isCouncilActive(activeCouncil)).toBe(true);
-    // Below the minimum (only one enabled) must NOT be active.
     expect(isCouncilActive(council)).toBe(false);
     expect(isCouncilActive({ ...activeCouncil, enabled: false })).toBe(false);
     expect(isCouncilActive({ ...activeCouncil, specialists: [] })).toBe(false);
     expect(isCouncilActive(null)).toBe(false);
   });
 
-  it('formatAggregationStrategy labels known strategies and falls back', () => {
+  it('formatAggregationStrategy labels the governance modes and falls back', () => {
     expect(formatAggregationStrategy('majority')).toBe('Majority');
-    expect(formatAggregationStrategy(null)).toBe('Any blocking member');
+    expect(formatAggregationStrategy('unanimous')).toBe('Unanimous');
+    expect(formatAggregationStrategy(null)).toBe('Advisory (report only)');
     expect(formatAggregationStrategy('weird')).toBe('weird');
   });
 });

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -18,6 +18,9 @@
 
 import * as z from 'zod';
 import {
+  COUNCIL_BLOCKING_SEVERITY,
+  COUNCIL_FINDING_SEVERITIES,
+  DEFAULT_COUNCIL_AGGREGATION_STRATEGY,
   CouncilFindingSchema,
   type CodeReviewCouncilConfig,
   type CodeReviewType,
@@ -35,21 +38,24 @@ import {
 /** A specialist's BINARY vote as seen by aggregation (code-derived, never model-authored). */
 export type SpecialistVote = { specialistId: string; vote: CouncilVote };
 
-/** Ranking of the canonical severity scale; higher = more severe. Off-scale labels rank 0. */
-const SEVERITY_RANK: Record<string, number> = {
-  critical: 4,
-  warning: 3,
-  suggestion: 2,
-  nitpick: 1,
-};
+// Ranking derived from the canonical scale (index 0 = most severe) so it can never drift from
+// COUNCIL_FINDING_SEVERITIES: extend/reorder the scale and the ranking follows automatically.
+// Off-scale labels rank 0 (below the whole scale).
+const SEVERITY_RANK: Record<string, number> = Object.fromEntries(
+  COUNCIL_FINDING_SEVERITIES.map((severity, index) => [
+    severity,
+    COUNCIL_FINDING_SEVERITIES.length - index,
+  ])
+);
 
 function severityRank(severity: string): number {
   return SEVERITY_RANK[severity.trim().toLowerCase()] ?? 0;
 }
 
-/** Whether a finding severity counts as BLOCKING (v2: only `critical`). Case/space-insensitive. */
+/** Whether a finding severity counts as BLOCKING (the canonical `COUNCIL_BLOCKING_SEVERITY`).
+ * Case/space-insensitive. */
 export function isBlockingSeverity(severity: string | null | undefined): boolean {
-  return (severity ?? '').trim().toLowerCase() === 'critical';
+  return (severity ?? '').trim().toLowerCase() === COUNCIL_BLOCKING_SEVERITY;
 }
 
 /**
@@ -129,8 +135,9 @@ export type CouncilSpecialistFinding = CouncilFinding;
 /**
  * One specialist's structured result (v2). The model reports ONLY facts: `findings` (each
  * with a severity from the canonical scale). It does NOT report a vote — the vote is
- * code-derived from the findings (`deriveSpecialistVote`). `highestSeverity` is likewise
- * derived, not reported. Lenient throughout so an off-scale label never rejects the manifest.
+ * code-derived from the findings (`deriveSpecialistVote`), as is `highestSeverity`. `findings`
+ * is required and severities must be on-scale (both fail closed if not); only `model` is
+ * lenient (a missing model does not invalidate the manifest).
  */
 export const CouncilSpecialistResultSchema = z.object({
   specialistId: z.string().min(1).max(64),
@@ -506,9 +513,9 @@ const AGGREGATION_STRATEGY_LABELS: Record<CouncilAggregationStrategy, string> = 
   majority: 'Majority',
 };
 
-/** Display label for a governance mode (falls back to the safe-default advisory label). */
+/** Display label for a governance mode (falls back to the safe-default label). */
 export function formatAggregationStrategy(strategy: string | null | undefined): string {
-  if (!strategy) return AGGREGATION_STRATEGY_LABELS.advisory;
+  if (!strategy) return AGGREGATION_STRATEGY_LABELS[DEFAULT_COUNCIL_AGGREGATION_STRATEGY];
   return AGGREGATION_STRATEGY_LABELS[strategy as CouncilAggregationStrategy] ?? strategy;
 }
 

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -134,7 +134,11 @@ export type CouncilSpecialistFinding = CouncilFinding;
  */
 export const CouncilSpecialistResultSchema = z.object({
   specialistId: z.string().min(1).max(64),
-  findings: z.array(CouncilFindingSchema).max(200).default([]),
+  // REQUIRED (no default): an entry must explicitly carry its findings array — `[]` means
+  // "reviewed, nothing blocking" (→ pass). A missing `findings` key is ambiguous (truncated
+  // report vs. clean) and must NOT silently derive to pass, so it invalidates the manifest →
+  // the decision fails closed. The coordinator prompt requires `findings` on every entry.
+  findings: z.array(CouncilFindingSchema).max(200),
   // Best-effort: the concrete model this specialist actually ran on, as reported back by
   // the specialist itself. We assign a model per specialist, but an "auto" slug (e.g.
   // `kilo-auto/...`) resolves to a concrete model at runtime inside cloud-agent-next, which

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -5,21 +5,20 @@
  * web app and the `code-review-infra` worker can import it without duplicating logic.
  *
  * Scope: the settled, capture-agnostic pieces — the code-owned governance DECISION,
- * the per-specialist result contract (vote + findings), the single-session combined
- * result manifest + parser, the display-only governance marker, specialist presets,
- * and the automated review-type stub. Prompt builders (web) and execution wiring
- * (worker/DO, runtimeAgents) live with their callers, not here.
+ * the per-specialist result contract (findings only; votes are DERIVED), the single-session
+ * combined result manifest + parser, specialist presets, and the automated review-type stub.
+ * Prompt builders (web) and execution wiring (worker/DO, runtimeAgents) live with their
+ * callers, not here.
  *
- * The council runs as ONE cloud-agent session: an orchestrator delegates to one
- * sub-agent per specialist (each pinned to its own model via `runtimeAgents[]`), then
- * relays every specialist's structured result in its final message. Our code — never
- * the model — computes the decision from the collected votes.
+ * v2: the model reports FACTS only (findings + a fixed severity per finding). Code derives
+ * each specialist's BINARY vote (any critical finding → block), then computes the aggregate
+ * decision per the governance mode (advisory → no decision; unanimous/majority → block/pass).
+ * The model never authors a vote, decision, or verdict.
  */
 
 import * as z from 'zod';
 import {
   CouncilFindingSchema,
-  CouncilVoteSchema,
   type CodeReviewCouncilConfig,
   type CodeReviewType,
   type CouncilAggregationStrategy,
@@ -30,85 +29,89 @@ import {
 } from '@kilocode/db/schema-types';
 
 // ============================================================================
-// Governance decision (code-owned, deterministic)
+// Governance decision (code-owned, deterministic) — v2
 // ============================================================================
 
-/** A specialist's vote as seen by aggregation. */
+/** A specialist's BINARY vote as seen by aggregation (code-derived, never model-authored). */
 export type SpecialistVote = { specialistId: string; vote: CouncilVote };
 
+/** Ranking of the canonical severity scale; higher = more severe. Off-scale labels rank 0. */
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 4,
+  warning: 3,
+  suggestion: 2,
+  nitpick: 1,
+};
+
+function severityRank(severity: string): number {
+  return SEVERITY_RANK[severity.trim().toLowerCase()] ?? 0;
+}
+
+/** Whether a finding severity counts as BLOCKING (v2: only `critical`). Case/space-insensitive. */
+export function isBlockingSeverity(severity: string | null | undefined): boolean {
+  return (severity ?? '').trim().toLowerCase() === 'critical';
+}
+
 /**
- * Computes the council governance decision from the collected specialist votes using
- * the selected strategy. This is the deterministic, code-owned replacement for asking
- * the model to compute the decision. The semantics MUST stay in lockstep with
- * `describeAggregationStrategy` (the prompt text the specialists/orchestrator see).
+ * The highest-severity label present in a specialist's findings (original casing preserved),
+ * or null if there are none. Ranks off the canonical scale; unknown labels rank lowest.
+ */
+export function highestSeverityOf(findings: readonly CouncilFinding[]): string | null {
+  let top: string | null = null;
+  let topRank = 0;
+  for (const finding of findings) {
+    const rank = severityRank(finding.severity);
+    if (rank > topRank || (rank === 0 && top === null)) {
+      topRank = rank;
+      top = finding.severity;
+    }
+  }
+  return top;
+}
+
+/**
+ * Derives a specialist's BINARY vote from its findings — code-owned, never model-authored.
+ * Any finding at the blocking severity (`critical`) → `block`; otherwise (including zero
+ * findings — "I ran and found nothing") → `pass`. This is the "a member votes yes/no, not
+ * 'warning'" rule: severity is the model's judgment, the vote follows deterministically.
+ */
+export function deriveSpecialistVote(findings: readonly CouncilFinding[]): CouncilVote {
+  return findings.some(finding => isBlockingSeverity(finding.severity)) ? 'block' : 'pass';
+}
+
+/**
+ * Computes the aggregate council decision from the collected BINARY specialist votes.
+ * Only the enforcing modes are valid here ('unanimous' | 'majority'); 'advisory' produces
+ * NO decision and is handled by `decideCouncilFromManifest`.
  *
- * Abstain semantics (deliberate): a returned `abstain` vote is treated leniently — it
- * is NOT counted under `any_blocking_member` or `majority` (so a specialist that ran
- * but had nothing to flag does not force a block), and only `unanimous_required`
- * blocks on it. The one universal guard is total no-coverage: if there is no usable
- * vote at all (empty, or every specialist abstained), the decision is `block` for
- * every strategy (never pass on absent coverage).
+ * - `unanimous` — block unless every specialist voted pass (any block → block). Strict.
+ * - `majority`  — block only when block votes outnumber pass votes. Lenient (ties → pass).
  *
- * IMPORTANT: this operates only on the votes it is GIVEN. It does NOT know which
- * specialists were configured, so it cannot detect a missing/dropped specialist. That
- * coverage-integrity guard (missing configured specialist → block regardless of
- * strategy) lives in `decideCouncilFromManifest`, which callers should use when
- * deciding from a captured manifest.
+ * Empty votes → `block` (never pass on absent coverage). Missing-configured-specialist
+ * coverage is enforced separately in `decideCouncilFromManifest`.
  */
 export function computeCouncilDecision(
   votes: readonly SpecialistVote[],
-  strategy: CouncilAggregationStrategy
+  strategy: Exclude<CouncilAggregationStrategy, 'advisory'>
 ): CouncilVote {
-  const counts = { pass: 0, warn: 0, block: 0, abstain: 0 } satisfies Record<CouncilVote, number>;
-  for (const { vote } of votes) counts[vote]++;
-
-  // No usable signal (empty, or every specialist abstained) => never pass.
-  if (counts.pass + counts.warn + counts.block === 0) return 'block';
-
-  const anyWarn = counts.warn > 0;
-
+  if (votes.length === 0) return 'block'; // no usable coverage → never pass
+  const blockCount = votes.filter(vote => vote.vote === 'block').length;
+  const passCount = votes.length - blockCount;
   switch (strategy) {
-    case 'majority': {
-      if (counts.block > counts.pass) return 'block';
-      return anyWarn ? 'warn' : 'pass';
-    }
-    case 'unanimous_required': {
-      if (counts.block > 0 || counts.abstain > 0) return 'block';
-      return anyWarn ? 'warn' : 'pass';
-    }
-    case 'any_blocking_member':
-    default: {
-      if (counts.block > 0) return 'block';
-      return anyWarn ? 'warn' : 'pass';
-    }
+    case 'majority':
+      return blockCount > passCount ? 'block' : 'pass';
+    case 'unanimous':
+    default:
+      return blockCount > 0 ? 'block' : 'pass';
   }
 }
 
 /**
- * Whether a governance decision should block merge. `block` always blocks; `warn` is
- * non-blocking here (warning-as-blocking is a separate gate-threshold policy).
+ * Whether a governance decision should block merge. `block` blocks; `pass` and `null`
+ * (advisory — no verdict) do not.
  */
-export function councilDecisionBlocksMerge(decision: CouncilVote): boolean {
+export function councilDecisionBlocksMerge(decision: CouncilVote | null): boolean {
   return decision === 'block';
-}
-
-/** Human-readable governance rule text so the orchestrator applies the SELECTED strategy.
- * Every configured specialist is a voting member; all votes count equally. Keep the
- * wording in lockstep with `computeCouncilDecision`. */
-export function describeAggregationStrategy(strategy: CouncilAggregationStrategy): string {
-  // Every strategy blocks when there is no usable coverage (no votes at all, or every
-  // specialist abstained) — this MUST match the guard in `computeCouncilDecision`.
-  const noCoverageRule =
-    ' If no specialist produced a usable vote (all abstained, or no votes at all), the decision is block.';
-  switch (strategy) {
-    case 'majority':
-      return `Majority: count votes across all specialists. If block votes outnumber pass votes, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.${noCoverageRule}`;
-    case 'unanimous_required':
-      return `Unanimous: every specialist must vote pass. If any specialist voted block or abstain, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.${noCoverageRule}`;
-    case 'any_blocking_member':
-    default:
-      return `Any blocking member: if any specialist voted block, the decision is block. Otherwise, if any specialist voted warn, the decision is warn. Otherwise pass.${noCoverageRule}`;
-  }
 }
 
 // ============================================================================
@@ -124,14 +127,13 @@ export { CouncilFindingSchema as CouncilSpecialistFindingSchema } from '@kilocod
 export type CouncilSpecialistFinding = CouncilFinding;
 
 /**
- * One specialist's structured result. STRICT only on `vote` (the load-bearing value
- * the code-side decision depends on); findings + severity are lenient. `findings` is
- * the full list surfaced in the Kilo UI and published to the PR.
+ * One specialist's structured result (v2). The model reports ONLY facts: `findings` (each
+ * with a severity from the canonical scale). It does NOT report a vote — the vote is
+ * code-derived from the findings (`deriveSpecialistVote`). `highestSeverity` is likewise
+ * derived, not reported. Lenient throughout so an off-scale label never rejects the manifest.
  */
 export const CouncilSpecialistResultSchema = z.object({
   specialistId: z.string().min(1).max(64),
-  vote: CouncilVoteSchema,
-  highestSeverity: z.string().max(64).nullable().optional(),
   findings: z.array(CouncilFindingSchema).max(200).default([]),
   // Best-effort: the concrete model this specialist actually ran on, as reported back by
   // the specialist itself. We assign a model per specialist, but an "auto" slug (e.g.
@@ -144,10 +146,10 @@ export type CouncilSpecialistResult = z.infer<typeof CouncilSpecialistResultSche
 
 /**
  * Marker tag for the single-session combined council manifest. The orchestrator emits
- * ONE of these in its final message, carrying every specialist's result. (One marker
- * + strict schema is more deterministic than N scattered per-specialist markers.)
+ * ONE of these in its final message, carrying every specialist's findings. v2 dropped the
+ * model-authored `vote` (code derives it), so the shape changed → the tag version bumped.
  */
-export const COUNCIL_RESULT_MARKER_TAG = 'kilo-code-review-council:v1';
+export const COUNCIL_RESULT_MARKER_TAG = 'kilo-code-review-council:v2';
 
 /** Hard cap on the manifest JSON payload (UTF-8 bytes) to bound parsing cost. */
 export const COUNCIL_RESULT_MAX_BYTES = 128 * 1024;
@@ -350,14 +352,15 @@ export type CouncilSpecialistSummary = {
   findingsCount: number;
 };
 
-/** Summarizes each specialist's result (findings count included) for UI display. */
+/** Summarizes each specialist's result (findings count included) for UI display. Vote and
+ * highest severity are DERIVED from the findings (the model reports neither). */
 export function summarizeCouncilManifest(
   manifest: CouncilResultManifest
 ): CouncilSpecialistSummary[] {
   return manifest.specialists.map(specialist => ({
     specialistId: specialist.specialistId,
-    vote: specialist.vote,
-    highestSeverity: specialist.highestSeverity ?? null,
+    vote: deriveSpecialistVote(specialist.findings),
+    highestSeverity: highestSeverityOf(specialist.findings),
     findingsCount: specialist.findings.length,
   }));
 }
@@ -404,20 +407,21 @@ export function reconcileCouncilVotes(
   for (const specialist of manifest.specialists) {
     counts.set(specialist.specialistId, (counts.get(specialist.specialistId) ?? 0) + 1);
   }
-  const reported = new Map(manifest.specialists.map(s => [s.specialistId, s.vote]));
+  const reported = new Map(manifest.specialists.map(s => [s.specialistId, s]));
 
   const votes: SpecialistVote[] = [];
   const missingSpecialistIds: string[] = [];
   // Iterate the DEDUPED configured ids so a specialist is never counted more than once.
   for (const specialistId of configuredSeen) {
-    const vote = reported.get(specialistId);
+    const specialist = reported.get(specialistId);
     // Reliable coverage requires exactly one configured entry AND exactly one report.
     if (
       !duplicateConfigured.has(specialistId) &&
       counts.get(specialistId) === 1 &&
-      vote !== undefined
+      specialist !== undefined
     ) {
-      votes.push({ specialistId, vote });
+      // The vote is DERIVED from the reported findings, never model-authored.
+      votes.push({ specialistId, vote: deriveSpecialistVote(specialist.findings) });
     } else {
       missingSpecialistIds.push(specialistId);
     }
@@ -425,9 +429,9 @@ export function reconcileCouncilVotes(
   return { votes, missingSpecialistIds };
 }
 
-/** A council decision plus the coverage that produced it. */
+/** A council decision plus the coverage that produced it. `decision` is null in advisory mode. */
 export type CouncilDecision = {
-  decision: CouncilVote;
+  decision: CouncilVote | null;
   votes: SpecialistVote[];
   missingSpecialistIds: string[];
 };
@@ -452,6 +456,10 @@ export function decideCouncilFromManifest(
   strategy: CouncilAggregationStrategy
 ): CouncilDecision {
   const { votes, missingSpecialistIds } = reconcileCouncilVotes(configuredSpecialistIds, manifest);
+  // Advisory: report the derived votes but compute NO aggregate verdict and no gate.
+  if (strategy === 'advisory') {
+    return { decision: null, votes, missingSpecialistIds };
+  }
   if (missingSpecialistIds.length > 0) {
     return { decision: 'block', votes, missingSpecialistIds };
   }
@@ -462,57 +470,9 @@ export function decideCouncilFromManifest(
   };
 }
 
-// ============================================================================
-// Governance marker (display-only human-readable summary)
-// ============================================================================
-
-/** Marker tag for the human-readable governance summary. Display-only: it is NOT the
- * source of the decision (our code computes that via `computeCouncilDecision`). */
-export const GOVERNANCE_MARKER_TAG = 'kilo-review-governance:v1';
-
-const GovernanceMemberSchema = z.object({
-  id: z.string(),
-  vote: CouncilVoteSchema,
-  // Display-only label; accept any wording the model emits (e.g. "low", "info",
-  // "none") so a severity vocabulary mismatch never rejects the whole marker.
-  highestSeverity: z
-    .string()
-    .max(50)
-    .nullable()
-    .optional()
-    .transform(value => (value && value.toLowerCase() !== 'none' ? value : null)),
-  reason: z.string().max(1000).optional(),
-});
-
-// The overall `decision` is deliberately NOT part of this schema: it is code-owned
-// (`computeCouncilDecision`), and a model-authored decision here could contradict it in
-// the UI. Consumers render the per-member votes from this marker and inject the computed
-// decision. Any `decision` key the model emits is ignored (non-strict object strips it).
-export const GovernanceSchema = z.object({
-  members: z.array(GovernanceMemberSchema).max(8),
-});
-export type Governance = z.infer<typeof GovernanceSchema>;
-export type GovernanceMember = z.infer<typeof GovernanceMemberSchema>;
-
-/**
- * Extracts and validates the display-only governance marker (per-member votes/reasons)
- * from an assistant message. Returns null when absent or malformed. This drives display
- * only; the overall merge decision comes from `computeCouncilDecision`, never from here.
- */
-export function parseGovernanceMarker(text: string | null | undefined): Governance | null {
-  if (!text) return null;
-  // Same line-anchored, brace-aware, size-capped extraction as the manifest parser.
-  const { json } = extractLastMarkerJson(text, GOVERNANCE_MARKER_TAG);
-  if (json === null) return null;
-  if (utf8ByteLengthExceeds(json, COUNCIL_RESULT_MAX_BYTES)) return null;
-  try {
-    const parsed: unknown = JSON.parse(json);
-    const result = GovernanceSchema.safeParse(parsed);
-    return result.success ? result.data : null;
-  } catch {
-    return null;
-  }
-}
+// (v1's display-only "kilo-review-governance:v1" marker was removed in v2: the model no
+// longer authors votes/decisions, so there is nothing model-reported to render from a
+// separate marker. Per-specialist votes are DERIVED from the manifest findings.)
 
 // ============================================================================
 // Council config helpers
@@ -537,14 +497,14 @@ export function isCouncilActive(council: CodeReviewCouncilConfig | undefined | n
 }
 
 const AGGREGATION_STRATEGY_LABELS: Record<CouncilAggregationStrategy, string> = {
-  any_blocking_member: 'Any blocking member',
+  advisory: 'Advisory (report only)',
+  unanimous: 'Unanimous',
   majority: 'Majority',
-  unanimous_required: 'Unanimous required',
 };
 
-/** Display label for an aggregation strategy (falls back to the default label). */
+/** Display label for a governance mode (falls back to the safe-default advisory label). */
 export function formatAggregationStrategy(strategy: string | null | undefined): string {
-  if (!strategy) return AGGREGATION_STRATEGY_LABELS.any_blocking_member;
+  if (!strategy) return AGGREGATION_STRATEGY_LABELS.advisory;
   return AGGREGATION_STRATEGY_LABELS[strategy as CouncilAggregationStrategy] ?? strategy;
 }
 


### PR DESCRIPTION
## Summary

Reworks how the code review council reaches a decision. Before, the coordinator and specialists (LLMs) authored votes and an overall verdict, which could disagree with the votes the code computed and with each other. Now specialists report only findings with a severity, and code owns everything above that: it derives each specialist's vote from the findings, tallies the decision, and controls what the PR shows. The goal is predictable results and keeping voting/gating logic out of the model.

## Changes

- Votes are binary and computed in code. A specialist votes `block` when any of its findings is `critical`, otherwise `pass`. The model no longer emits a vote.
- Findings use a fixed severity scale (`critical`, `warning`, `suggestion`, `nitpick`), and `critical` is the only blocking severity. Severity is validated on parse (casing and whitespace tolerated). An off-scale label, or a specialist entry with no `findings` array, is treated as invalid so the decision fails closed instead of silently passing.
- Governance modes are `advisory`, `unanimous`, and `majority` (the New Job selector). `advisory` reports votes with no aggregate decision and no gate, and is the default so a council never blocks a merge unasked. `unanimous` blocks unless every specialist passes. `majority` blocks when block votes outnumber pass votes. The old `any_blocking_member` was dropped because, with abstain removed, it behaves identically to `unanimous`.
- The aggregate decision is nullable: `null` in advisory mode. Enforcing modes fail closed to `block` on missing or invalid coverage.
- A specialist with no reliable result (absent from the manifest, or no/invalid manifest) is shown as "No result" (`vote: null`), not a `block` vote. The aggregate decision still fails closed separately, so display and enforcement are decoupled.
- The coordinator publishes a council table on the PR with facts only (specialist, model, highest severity, finding count) and no longer writes a vote, decision, or merge recommendation. Those are computed in code.
- The result manifest format changed (marker bumped to `kilo-code-review-council:v2`): specialists report `findings` only, no `vote`.
- Council configs written before this change (`any_blocking_member` / `unanimous_required`) are normalized to `unanimous` when read, so older reviews still parse.
- Removed the unused display-only governance marker parser.

## Verification

- [ ] No manual end-to-end council run on this branch yet. Logic is covered by unit tests (worker-utils council logic, finalize mapping, prompt contracts) plus typecheck. The provider publish path and multi-model routing were exercised on the prior publish change, not re-run here.

## Visual Changes

UI changed; screenshots not attached:
- New Job council governance select now lists Advisory / Unanimous / Majority (default Advisory).
- Council review panel shows binary Pass/Block votes, a "No result" badge for specialists with no result, and an "Advisory" chip when there is no aggregate decision.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- Fail-closed strictness: an off-scale severity or a missing `findings` array invalidates the whole manifest (block under enforcing modes). This is deliberate, so the specialist and coordinator prompts require a `findings` array on every entry (use `[]` for none) and the fixed severity words.
- Decision vs display are intentionally separate: the aggregate decision fails closed on missing coverage, while the per-specialist display shows "No result" rather than a block vote.
- The council decision is computed but not yet enforced as a merge gate, and the PR summary shows a neutral recommendation placeholder. Wiring the decision into the check run and into the PR summary is a planned follow-up.
