### PR TITLE
ci(deploy): annotate production deploys in Axiom

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  VERCEL_VERSION: '53.3.1'
+  VERCEL_VERSION: "53.3.1"
   VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
 
 jobs:
@@ -38,8 +38,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -68,8 +68,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -96,6 +96,7 @@ jobs:
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-app.outputs.deployment_url }}
+      axiom_annotation_dataset: kilocode-app
     secrets: inherit
 
   promote-global-app:
@@ -267,8 +268,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  VERCEL_VERSION: "53.3.1"
+  VERCEL_VERSION: '53.3.1'
   VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
 
 jobs:
@@ -38,8 +38,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -68,8 +68,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -268,8 +268,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/promote-vercel-deployment.yml
+++ b/.github/workflows/promote-vercel-deployment.yml
@@ -4,19 +4,19 @@ on:
   workflow_call:
     inputs:
       deployment_url:
-        description: "Vercel deployment URL to promote"
+        description: 'Vercel deployment URL to promote'
         required: true
         type: string
       axiom_annotation_dataset:
-        description: "Optional Axiom dataset used to scope deployment annotations"
+        description: 'Optional Axiom dataset used to scope deployment annotations'
         required: false
         type: string
-        default: ""
+        default: ''
       axiom_expected_project:
-        description: "Vercel project name the promoted deployment must match before annotating"
+        description: 'Vercel project name the promoted deployment must match before annotating'
         required: false
         type: string
-        default: "kilocode-app"
+        default: 'kilocode-app'
 
 permissions:
   contents: read
@@ -28,7 +28,7 @@ jobs:
     environment: production
 
     env:
-      VERCEL_VERSION: "53.3.1"
+      VERCEL_VERSION: '53.3.1'
 
     steps:
       - name: Install Vercel CLI
@@ -63,7 +63,9 @@ jobs:
             deployment_id=$(jq -r '.id // empty' <<<"$inspection" 2>/dev/null)
             if [ -z "$deployment_id" ]; then
               echo "::warning::vercel inspect did not return a deployment id (attempt $attempt): $inspection"
-              sleep 5
+              if [ "$attempt" != "5" ]; then
+                sleep 5
+              fi
               continue
             fi
 
@@ -74,7 +76,9 @@ jobs:
             fi
 
             echo "::warning::Deployment not READY yet (attempt $attempt, state=$ready_state)"
-            sleep 5
+            if [ "$attempt" != "5" ]; then
+              sleep 5
+            fi
           done
 
           project=$(jq -r '.name // empty' <<<"$deployment" 2>/dev/null)
@@ -92,15 +96,16 @@ jobs:
           commit_message=$(jq -r '(.meta.githubCommitMessage // "Commit message unavailable" | split("\n")[0])[0:360]' <<<"$deployment")
           commit_ref=$(jq -r '.meta.githubCommitRef // "unknown"' <<<"$deployment")
           commit_author=$(jq -r '.meta.githubCommitAuthorName // .creator.username // "unknown"' <<<"$deployment")
-          deployment_link="https://vercel.com/kilocode/kilocode-app/${deployment_id#dpl_}"
+          deployment_link="https://vercel.com/kilocode/$project/${deployment_id#dpl_}"
 
           payload=$(jq -n \
             --arg dataset "$AXIOM_DATASET" \
             --arg time "$deployment_time" \
-            --arg title "kilocode-app · $short_sha" \
+            --arg title "$project · $short_sha" \
             --arg description "$commit_message · $commit_ref · $commit_author" \
             --arg url "$deployment_link" \
-            '{datasets:[$dataset], type:"kilocode-app-production-deployment", time:$time, title:$title, description:$description, url:$url}')
+            --arg type "$project-production-deployment" \
+            '{datasets:[$dataset], type:$type, time:$time, title:$title, description:$description, url:$url}')
 
           curl --fail-with-body --silent --show-error \
             --request POST \

--- a/.github/workflows/promote-vercel-deployment.yml
+++ b/.github/workflows/promote-vercel-deployment.yml
@@ -4,9 +4,19 @@ on:
   workflow_call:
     inputs:
       deployment_url:
-        description: 'Vercel deployment URL to promote'
+        description: "Vercel deployment URL to promote"
         required: true
         type: string
+      axiom_annotation_dataset:
+        description: "Optional Axiom dataset used to scope deployment annotations"
+        required: false
+        type: string
+        default: ""
+      axiom_expected_project:
+        description: "Vercel project name the promoted deployment must match before annotating"
+        required: false
+        type: string
+        default: "kilocode-app"
 
 permissions:
   contents: read
@@ -18,7 +28,7 @@ jobs:
     environment: production
 
     env:
-      VERCEL_VERSION: '53.3.1'
+      VERCEL_VERSION: "53.3.1"
 
     steps:
       - name: Install Vercel CLI
@@ -26,3 +36,76 @@ jobs:
 
       - name: Promote Vercel deployment
         run: vercel promote "${{ inputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Annotate production deployment in Axiom
+        if: inputs.axiom_annotation_dataset != ''
+        # Annotation is best-effort observability, not a deploy gate: never fail
+        # a successful promotion because Axiom/Vercel is flaky or slow to update.
+        continue-on-error: true
+        env:
+          AXIOM_ANNOTATION_TOKEN: ${{ secrets.AXIOM_ANNOTATION_TOKEN }}
+          AXIOM_DATASET: ${{ inputs.axiom_annotation_dataset }}
+          AXIOM_ORG_ID: kilo-code-nvjh
+          DEPLOYMENT_URL: ${{ inputs.deployment_url }}
+          EXPECTED_PROJECT: ${{ inputs.axiom_expected_project }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$AXIOM_ANNOTATION_TOKEN" ]; then
+            echo "::warning::Skipping deployment annotation because AXIOM_ANNOTATION_TOKEN is not configured"
+            exit 0
+          fi
+
+          # Vercel's API can briefly lag behind a promotion, so retry until the
+          # deployment reports READY instead of failing on the first check.
+          deployment=""
+          for attempt in 1 2 3 4 5; do
+            inspection=$(vercel inspect "$DEPLOYMENT_URL" --json --scope=kilocode --token="$VERCEL_TOKEN" 2>&1)
+            deployment_id=$(jq -r '.id // empty' <<<"$inspection" 2>/dev/null)
+            if [ -z "$deployment_id" ]; then
+              echo "::warning::vercel inspect did not return a deployment id (attempt $attempt): $inspection"
+              sleep 5
+              continue
+            fi
+
+            deployment=$(vercel api "/v13/deployments/$deployment_id" --raw --scope=kilocode --token="$VERCEL_TOKEN" 2>&1)
+            ready_state=$(jq -r '.readyState // empty' <<<"$deployment" 2>/dev/null)
+            if [ "$ready_state" = "READY" ]; then
+              break
+            fi
+
+            echo "::warning::Deployment not READY yet (attempt $attempt, state=$ready_state)"
+            sleep 5
+          done
+
+          project=$(jq -r '.name // empty' <<<"$deployment" 2>/dev/null)
+          target=$(jq -r '.target // empty' <<<"$deployment" 2>/dev/null)
+          ready_state=$(jq -r '.readyState // empty' <<<"$deployment" 2>/dev/null)
+
+          if [ "$project" != "$EXPECTED_PROJECT" ] || [ "$target" != "production" ] || [ "$ready_state" != "READY" ]; then
+            echo "::warning::Skipping annotation for unexpected deployment: project=$project target=$target state=$ready_state"
+            exit 0
+          fi
+
+          deployment_time=$(jq -r '((.ready // .createdAt) / 1000) | todateiso8601' <<<"$deployment")
+          commit_sha=$(jq -r '.meta.githubCommitSha // "unknown"' <<<"$deployment")
+          short_sha=${commit_sha:0:8}
+          commit_message=$(jq -r '(.meta.githubCommitMessage // "Commit message unavailable" | split("\n")[0])[0:360]' <<<"$deployment")
+          commit_ref=$(jq -r '.meta.githubCommitRef // "unknown"' <<<"$deployment")
+          commit_author=$(jq -r '.meta.githubCommitAuthorName // .creator.username // "unknown"' <<<"$deployment")
+          deployment_link="https://vercel.com/kilocode/kilocode-app/${deployment_id#dpl_}"
+
+          payload=$(jq -n \
+            --arg dataset "$AXIOM_DATASET" \
+            --arg time "$deployment_time" \
+            --arg title "kilocode-app · $short_sha" \
+            --arg description "$commit_message · $commit_ref · $commit_author" \
+            --arg url "$deployment_link" \
+            '{datasets:[$dataset], type:"kilocode-app-production-deployment", time:$time, title:$title, description:$description, url:$url}')
+
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $AXIOM_ANNOTATION_TOKEN" \
+            --header "X-Axiom-Org-Id: $AXIOM_ORG_ID" \
+            --header "Content-Type: application/json" \
+            --data "$payload" \
+            https://api.axiom.co/v2/annotations >/dev/null

--- a/.github/workflows/redeploy-web.yml
+++ b/.github/workflows/redeploy-web.yml
@@ -44,6 +44,7 @@ jobs:
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-app.outputs.deployment_url }}
+      axiom_annotation_dataset: kilocode-app
     secrets: inherit
 
   promote-global-app:


### PR DESCRIPTION
## Summary
Adds a best-effort Axiom annotation step to the shared Vercel promote workflow so production deploys of `kilocode-app` show up alongside metrics and traces.

### Why this change is needed
Production incidents and metric anomalies are hard to correlate with deploys without a shared timeline marker in Axiom. There was previously no automated link between a Vercel production promotion and Axiom's observability data.

### How this is addressed
- Adds an opt-in `axiom_annotation_dataset` input to the reusable `promote-vercel-deployment.yml` workflow; only wired up for `deploy-production.yml` and `redeploy-web.yml`'s app promotion job (not `global-app`).
- Before annotating, verifies the promoted deployment matches the expected project, `production` target, and `READY` state, retrying briefly to absorb Vercel API propagation lag after `vercel promote`.
- Posts an annotation to Axiom with the deploy time, commit SHA/message/branch/author, and a link back to the Vercel deployment.
- The step is `continue-on-error: true` and treats missing tokens or an unexpected deployment as warnings, not failures — so a flaky Axiom/Vercel call or eventual-consistency lag never fails a promotion that already succeeded.
- Added `axiom_expected_project` input (default `kilocode-app`) instead of hardcoding the project name, so the reusable workflow stays generic for future callers.

## Human Verification
- Reviewed the workflow YAML by hand for correct GitHub Actions expression syntax and step wiring; no CI run has exercised this yet since it only executes during a real production promotion.

## Reviewer Notes

### Human Reviewer Flags
- This step runs with `secrets: inherit` and reads `AXIOM_ANNOTATION_TOKEN`/`VERCEL_TOKEN` from the `production` environment; confirm `AXIOM_ANNOTATION_TOKEN` is configured there (or annotation is skipped with a warning).
- `promote-global-app` intentionally does not pass `axiom_annotation_dataset`, so no annotation happens for that promotion path — confirm that scoping is correct.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Retry loop (5 attempts, 5s apart) polls `vercel inspect`/`vercel api` until `readyState == READY` before validating project/target.
- Failure paths log `::warning::` with the raw API response instead of silently swallowing stderr, to keep debugging tractable.
- Axiom payload is built with `jq -n --arg` (not string interpolation) to avoid injection via commit metadata.

</details>
