### PR TITLE
perf(cost-insights): reduce dashboard driver query scans

### DIFF
--- a/apps/web/src/lib/cost-insights/canonical-sources.test.ts
+++ b/apps/web/src/lib/cost-insights/canonical-sources.test.ts
@@ -2,6 +2,7 @@ import {
   aggregateCanonicalCostInsightDrivers,
   aggregateNormalizedCanonicalCostInsightDrivers,
   loadCanonicalCostInsightAggregationsByHour,
+  loadCanonicalCostInsightAggregationsByIntervals,
   mapAiGatewayCanonicalDriver,
   mapCodingPlanCanonicalDriver,
   mapExaCanonicalDriver,
@@ -264,6 +265,105 @@ describe('Cost Insights canonical source mapping', () => {
         totals: [expect.objectContaining({ totalMicrodollars: 6, spendRecordCount: 2 })],
       }),
     ]);
+  });
+
+  test('loads separated intervals with four source queries and excludes envelope-only rows', async () => {
+    const row = (hour_start: string, total_microdollars: string) => ({
+      hour_start,
+      owned_by_user_id: 'user-1',
+      owned_by_organization_id: null,
+      actor_user_id: 'user-1',
+      raw_product_key: null,
+      raw_feature_key: null,
+      requested_model: 'model',
+      resolved_model: null,
+      inference_provider: 'provider',
+      gateway_provider: null,
+      total_microdollars,
+      spend_record_count: '1',
+    });
+    const execute = jest
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [
+          row('2026-06-01 00:00:00+00', '4'),
+          row('2026-06-01 01:00:00+00', '99'),
+          row('2026-06-01 02:00:00+00', '6'),
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const hourly = await loadCanonicalCostInsightAggregationsByIntervals(
+      { execute } as unknown as CostInsightQueryExecutor,
+      {
+        owner: userOwner,
+        intervals: [
+          {
+            startInclusive: '2026-06-01T00:00:00.000Z',
+            endExclusive: '2026-06-01T01:00:00.000Z',
+          },
+          {
+            startInclusive: '2026-06-01T02:00:00.000Z',
+            endExclusive: '2026-06-01T03:00:00.000Z',
+          },
+        ],
+      }
+    );
+
+    expect(execute).toHaveBeenCalledTimes(4);
+    expect(hourly).toEqual([
+      expect.objectContaining({
+        hourStart: '2026-06-01T00:00:00.000Z',
+        totals: [expect.objectContaining({ totalMicrodollars: 4 })],
+      }),
+      expect.objectContaining({
+        hourStart: '2026-06-01T02:00:00.000Z',
+        totals: [expect.objectContaining({ totalMicrodollars: 6 })],
+      }),
+    ]);
+  });
+
+  test('normalizes touching intervals and rejects invalid interval timestamps', async () => {
+    const execute = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    await loadCanonicalCostInsightAggregationsByIntervals(
+      { execute } as unknown as CostInsightQueryExecutor,
+      {
+        owner: userOwner,
+        intervals: [
+          {
+            startInclusive: '2026-06-01T01:00:00.000Z',
+            endExclusive: '2026-06-01T02:00:00.000Z',
+          },
+          {
+            startInclusive: '2026-06-01T00:00:00.000Z',
+            endExclusive: '2026-06-01T01:00:00.000Z',
+          },
+        ],
+      }
+    );
+    expect(execute).toHaveBeenCalledTimes(4);
+
+    await expect(
+      loadCanonicalCostInsightAggregationsByIntervals(
+        { execute } as unknown as CostInsightQueryExecutor,
+        {
+          owner: userOwner,
+          intervals: [
+            {
+              startInclusive: 'invalid',
+              endExclusive: '2026-06-01T01:00:00.000Z',
+            },
+          ],
+        }
+      )
+    ).rejects.toThrow('startInclusive must be a valid timestamp');
   });
 
   test('rejects unsafe database integers instead of rounding them', () => {

--- a/apps/web/src/lib/cost-insights/canonical-sources.ts
+++ b/apps/web/src/lib/cost-insights/canonical-sources.ts
@@ -86,6 +86,8 @@ type CanonicalRange = {
   endExclusive: string;
 };
 
+export type CanonicalCostInsightInterval = CanonicalRange;
+
 type RawAiAggregate = {
   hour_start: string | Date;
   owned_by_user_id: string | null;
@@ -146,6 +148,63 @@ function requireCanonicalRange(range: CanonicalRange): void {
   if (start >= end) {
     throw new Error('Cost Insights canonical source range must be a non-empty half-open range.');
   }
+}
+
+function normalizeCanonicalIntervals(
+  intervals: readonly [CanonicalCostInsightInterval, ...CanonicalCostInsightInterval[]]
+): CanonicalCostInsightInterval[] {
+  const normalized = intervals
+    .map(interval => {
+      requireCanonicalRange(interval);
+      return {
+        startInclusive: requireUtcTimestamp(interval.startInclusive, 'startInclusive'),
+        endExclusive: requireUtcTimestamp(interval.endExclusive, 'endExclusive'),
+      };
+    })
+    .sort((left, right) => Date.parse(left.startInclusive) - Date.parse(right.startInclusive));
+  const merged: CanonicalCostInsightInterval[] = [];
+  for (const interval of normalized) {
+    const previous = merged.at(-1);
+    if (!previous || Date.parse(previous.endExclusive) < Date.parse(interval.startInclusive)) {
+      merged.push(interval);
+      continue;
+    }
+    if (Date.parse(interval.endExclusive) > Date.parse(previous.endExclusive)) {
+      merged[merged.length - 1] = { ...previous, endExclusive: interval.endExclusive };
+    }
+  }
+  return merged;
+}
+
+function intervalMembershipPredicate(
+  timestampColumn: SQL,
+  intervals: readonly CanonicalCostInsightInterval[]
+): SQL {
+  const values = sql.join(
+    intervals.map(
+      interval =>
+        sql`(${interval.startInclusive}::timestamptz, ${interval.endExclusive}::timestamptz)`
+    ),
+    sql`, `
+  );
+  return sql`EXISTS (
+    SELECT 1
+    FROM (VALUES ${values}) AS canonical_intervals(start_inclusive, end_exclusive)
+    WHERE ${timestampColumn} >= canonical_intervals.start_inclusive
+      AND ${timestampColumn} < canonical_intervals.end_exclusive
+  )`;
+}
+
+function canonicalHourIntersectsIntervals(
+  rawHourStart: string | Date,
+  intervals: readonly CanonicalCostInsightInterval[]
+): boolean {
+  const hourStart = Date.parse(normalizeCanonicalHour(rawHourStart));
+  const hourEnd = hourStart + HOUR_MS;
+  return intervals.some(
+    interval =>
+      Date.parse(interval.startInclusive) < hourEnd && Date.parse(interval.endExclusive) > hourStart
+  );
 }
 
 export function requireUtcTimestamp(value: string, fieldName: string): string {
@@ -545,7 +604,8 @@ function compareCanonicalDrivers(
 async function loadAiAggregates(
   executor: CostInsightQueryExecutor,
   range: CanonicalRange,
-  owner: CostInsightSpendOwner | undefined
+  owner: CostInsightSpendOwner | undefined,
+  intervalPredicate: SQL = sql`TRUE`
 ): Promise<RawAiAggregate[]> {
   const result = await executor.execute<RawAiAggregate>(sql`
     SELECT
@@ -571,6 +631,7 @@ async function loadAiAggregates(
       ON ${api_kind.api_kind_id} = ${microdollar_usage_metadata.api_kind_id}
     WHERE ${microdollar_usage.created_at} >= ${range.startInclusive}
       AND ${microdollar_usage.created_at} < ${range.endExclusive}
+      AND ${intervalPredicate}
       AND ${microdollar_usage.cost} > 0
       AND ${ownerPredicate({
         owner,
@@ -585,7 +646,8 @@ async function loadAiAggregates(
 async function loadExaAggregates(
   executor: CostInsightQueryExecutor,
   range: CanonicalRange,
-  owner: CostInsightSpendOwner | undefined
+  owner: CostInsightSpendOwner | undefined,
+  intervalPredicate: SQL = sql`TRUE`
 ): Promise<RawExaAggregate[]> {
   const result = await executor.execute<RawExaAggregate>(sql`
     SELECT
@@ -600,6 +662,7 @@ async function loadExaAggregates(
     FROM ${exa_usage_log}
     WHERE ${exa_usage_log.created_at} >= ${range.startInclusive}
       AND ${exa_usage_log.created_at} < ${range.endExclusive}
+      AND ${intervalPredicate}
       AND ${exa_usage_log.charged_to_balance} = TRUE
       AND ${exa_usage_log.cost_microdollars} > 0
       AND ${ownerPredicate({
@@ -615,7 +678,8 @@ async function loadExaAggregates(
 async function loadCodingPlanAggregates(
   executor: CostInsightQueryExecutor,
   range: CanonicalRange,
-  owner: CostInsightSpendOwner | undefined
+  owner: CostInsightSpendOwner | undefined,
+  intervalPredicate: SQL = sql`TRUE`
 ): Promise<RawCodingPlanAggregate[]> {
   const result = await executor.execute<RawCodingPlanAggregate>(sql`
     SELECT
@@ -636,6 +700,7 @@ async function loadCodingPlanAggregates(
       ON ${coding_plan_subscriptions.id} = ${coding_plan_terms.subscription_id}
     WHERE ${credit_transactions.created_at} >= ${range.startInclusive}
       AND ${credit_transactions.created_at} < ${range.endExclusive}
+      AND ${intervalPredicate}
       AND ${credit_transactions.amount_microdollars} < 0
       AND ${ownerPredicate({
         owner,
@@ -650,7 +715,8 @@ async function loadCodingPlanAggregates(
 async function loadKiloClawAggregates(
   executor: CostInsightQueryExecutor,
   range: CanonicalRange,
-  owner: CostInsightSpendOwner | undefined
+  owner: CostInsightSpendOwner | undefined,
+  intervalPredicate: SQL = sql`TRUE`
 ): Promise<RawKiloClawAggregate[]> {
   const transactionAlias = sql.raw('ct');
   const result = await executor.execute<RawKiloClawAggregate>(sql`
@@ -678,6 +744,7 @@ async function loadKiloClawAggregates(
       FROM ${credit_transactions} ct
       WHERE ct.created_at >= ${range.startInclusive}
         AND ct.created_at < ${range.endExclusive}
+        AND ${intervalPredicate}
         AND ct.amount_microdollars < 0
         AND ${pureCreditKiloClawPredicate(transactionAlias)}
         AND ${ownerPredicate({
@@ -733,13 +800,25 @@ function appendMappedCanonicalDriver(
 
 export async function loadCanonicalCostInsightAggregationsByHour(
   executor: CostInsightQueryExecutor,
-  params: CanonicalRange & { owner?: CostInsightSpendOwner }
+  params: CanonicalRange & {
+    owner?: CostInsightSpendOwner;
+    intervals?: readonly CanonicalCostInsightInterval[];
+  }
 ): Promise<CanonicalCostInsightHourAggregation[]> {
   requireCanonicalRange(params);
+  const intervals = params.intervals;
   const accumulators = new Map<string, CanonicalHourAccumulator>();
 
-  const aiRows = await loadAiAggregates(executor, params, params.owner);
+  const aiRows = await loadAiAggregates(
+    executor,
+    params,
+    params.owner,
+    intervals
+      ? intervalMembershipPredicate(sql`${microdollar_usage.created_at}`, intervals)
+      : undefined
+  );
   for (const row of aiRows) {
+    if (intervals && !canonicalHourIntersectsIntervals(row.hour_start, intervals)) continue;
     appendMappedCanonicalDriver(
       getCanonicalHourAccumulator(accumulators, row.hour_start),
       mapAiGatewayCanonicalDriver({
@@ -763,8 +842,14 @@ export async function loadCanonicalCostInsightAggregationsByHour(
     );
   }
 
-  const exaRows = await loadExaAggregates(executor, params, params.owner);
+  const exaRows = await loadExaAggregates(
+    executor,
+    params,
+    params.owner,
+    intervals ? intervalMembershipPredicate(sql`${exa_usage_log.created_at}`, intervals) : undefined
+  );
   for (const row of exaRows) {
+    if (intervals && !canonicalHourIntersectsIntervals(row.hour_start, intervals)) continue;
     appendMappedCanonicalDriver(
       getCanonicalHourAccumulator(accumulators, row.hour_start),
       mapExaCanonicalDriver({
@@ -783,8 +868,16 @@ export async function loadCanonicalCostInsightAggregationsByHour(
     );
   }
 
-  const codingPlanRows = await loadCodingPlanAggregates(executor, params, params.owner);
+  const codingPlanRows = await loadCodingPlanAggregates(
+    executor,
+    params,
+    params.owner,
+    intervals
+      ? intervalMembershipPredicate(sql`${credit_transactions.created_at}`, intervals)
+      : undefined
+  );
   for (const row of codingPlanRows) {
+    if (intervals && !canonicalHourIntersectsIntervals(row.hour_start, intervals)) continue;
     appendMappedCanonicalDriver(
       getCanonicalHourAccumulator(accumulators, row.hour_start),
       mapCodingPlanCanonicalDriver({
@@ -805,8 +898,14 @@ export async function loadCanonicalCostInsightAggregationsByHour(
     );
   }
 
-  const kiloClawRows = await loadKiloClawAggregates(executor, params, params.owner);
+  const kiloClawRows = await loadKiloClawAggregates(
+    executor,
+    params,
+    params.owner,
+    intervals ? intervalMembershipPredicate(sql.raw('ct.created_at'), intervals) : undefined
+  );
   for (const row of kiloClawRows) {
+    if (intervals && !canonicalHourIntersectsIntervals(row.hour_start, intervals)) continue;
     getCanonicalHourAccumulator(accumulators, row.hour_start).inputs.push(
       mapKiloClawCanonicalDriver({
         owner: ownerFromColumns(row.owned_by_user_id, row.owned_by_organization_id),
@@ -836,6 +935,27 @@ export async function loadCanonicalCostInsightAggregationsByHour(
     });
   }
   return hourly;
+}
+
+export async function loadCanonicalCostInsightAggregationsByIntervals(
+  executor: CostInsightQueryExecutor,
+  params: {
+    owner: CostInsightSpendOwner;
+    intervals: readonly [CanonicalCostInsightInterval, ...CanonicalCostInsightInterval[]];
+  }
+): Promise<CanonicalCostInsightHourAggregation[]> {
+  const intervals = normalizeCanonicalIntervals(params.intervals);
+  const first = intervals[0];
+  const last = intervals.at(-1);
+  if (!first || !last) {
+    throw new Error('Cost Insights canonical source intervals must not be empty.');
+  }
+  return await loadCanonicalCostInsightAggregationsByHour(executor, {
+    owner: params.owner,
+    startInclusive: first.startInclusive,
+    endExclusive: last.endExclusive,
+    intervals,
+  });
 }
 
 export async function loadCanonicalCostInsightAggregation(

--- a/apps/web/src/lib/cost-insights/presenter.ts
+++ b/apps/web/src/lib/cost-insights/presenter.ts
@@ -22,7 +22,6 @@ import {
   microdollarsToUsd,
   MICRODOLLARS_PER_USD,
 } from './policy';
-import { loadCanonicalCostInsightAggregationsByHour } from './canonical-sources';
 import { getCostInsightAnomalyPolicy } from './evaluation';
 import {
   countCostInsightEvents,
@@ -36,6 +35,7 @@ import {
 import {
   getOwnerHourDriverEvidence,
   getOwnerHourlySpend,
+  loadOwnerDashboardHourlySpend,
   getOwnerRolling24HourSpendExact,
   getOwnerTopSpendDriversByRange,
   type OwnerHourlySpend,
@@ -312,64 +312,18 @@ function hourlyEvidenceRange(
   return points.filter(point => point.hourStart >= startHour);
 }
 
-function canonicalHourlySpend(
-  hourly: Awaited<ReturnType<typeof loadCanonicalCostInsightAggregationsByHour>>,
-  startHour: string,
-  endHourExclusive: string
-): OwnerHourlySpend[] {
-  const byHour = new Map(hourly.map(hour => [hour.hourStart, hour]));
-  const points: OwnerHourlySpend[] = [];
-  for (
-    let hourStart = startHour;
-    hourStart < endHourExclusive;
-    hourStart = addHours(hourStart, 1)
-  ) {
-    const aggregation = byHour.get(hourStart);
-    const variable = aggregation?.totals.find(total => total.category === 'variable');
-    const scheduled = aggregation?.totals.find(total => total.category === 'scheduled');
-    const variableMicrodollars = variable?.totalMicrodollars ?? 0;
-    const scheduledMicrodollars = scheduled?.totalMicrodollars ?? 0;
-    const totalMicrodollars = variableMicrodollars + scheduledMicrodollars;
-    if (!Number.isSafeInteger(totalMicrodollars)) {
-      throw new Error('Canonical Cost Insights hourly total exceeds the safe-integer range.');
-    }
-    points.push({
-      hourStart,
-      variableMicrodollars,
-      scheduledMicrodollars,
-      totalMicrodollars,
-      variableRecordCount: variable?.spendRecordCount ?? 0,
-      scheduledRecordCount: scheduled?.spendRecordCount ?? 0,
-      isCovered: true,
-    });
-  }
-  return points;
-}
-
 async function loadEvidenceByRange(
   database: CostInsightDatabase,
   owner: CostInsightSpendOwner,
   endHourExclusive: string,
-  asOf: string,
   currentHour: OwnerHourlySpend
 ): Promise<Record<SpendRange, SpendEvidencePoint[]>> {
   const startHour = spendRangeStartHour('90d', endHourExclusive);
-  const rollupPoints = await getOwnerHourlySpend(database, {
+  const points = await loadOwnerDashboardHourlySpend(database, {
     owner,
     startHour,
     endHourExclusive,
   });
-  const points = rollupPoints.some(point => !point.isCovered)
-    ? canonicalHourlySpend(
-        await loadCanonicalCostInsightAggregationsByHour(database, {
-          owner,
-          startInclusive: startHour,
-          endExclusive: asOf,
-        }),
-        startHour,
-        endHourExclusive
-      )
-    : rollupPoints;
 
   return Object.fromEntries(
     (Object.keys(rangeHours) as SpendRange[]).map(range => [
@@ -872,7 +826,7 @@ export async function buildCostInsightsDashboardData(params: {
   };
   const [evidenceByRange, actorLabels, activeSuggestions, eventPreview, memberLimitsHref] =
     await Promise.all([
-      loadEvidenceByRange(params.database, params.owner, endHourExclusive, asOf, currentHourSpend),
+      loadEvidenceByRange(params.database, params.owner, endHourExclusive, currentHourSpend),
       loadActorLabels(params.database, [
         ...Object.values(topDriversByRange).flatMap(drivers =>
           drivers.map(driver => driver.actorUserId)

--- a/apps/web/src/lib/cost-insights/presenter.ts
+++ b/apps/web/src/lib/cost-insights/presenter.ts
@@ -34,7 +34,6 @@ import {
 } from './repository';
 import {
   getOwnerHourDriverEvidence,
-  getOwnerHourlySpend,
   loadOwnerDashboardHourlySpend,
   getOwnerRolling24HourSpendExact,
   getOwnerTopSpendDriversByRange,

--- a/apps/web/src/lib/cost-insights/presenter.ts
+++ b/apps/web/src/lib/cost-insights/presenter.ts
@@ -37,7 +37,7 @@ import {
   getOwnerHourDriverEvidence,
   getOwnerHourlySpend,
   getOwnerRolling24HourSpendExact,
-  getOwnerTopSpendDrivers,
+  getOwnerTopSpendDriversByRange,
   type OwnerHourlySpend,
   type OwnerTopSpendDriver,
 } from './spend-repository';
@@ -384,26 +384,21 @@ async function loadTopDriversByRange(
   owner: CostInsightSpendOwner,
   endHourExclusive: string
 ): Promise<Record<SpendRange, OwnerTopSpendDriver[]>> {
-  const loadRange = (range: SpendRange) =>
-    getOwnerTopSpendDrivers(database, {
-      owner,
+  const driversByRange = await getOwnerTopSpendDriversByRange(database, {
+    owner,
+    ranges: (Object.keys(rangeHours) as SpendRange[]).map(range => ({
+      key: range,
       startHour: spendRangeStartHour(range, endHourExclusive),
-      endHourExclusive,
-      limit: 5,
-    });
-  const [thisHour, last24Hours, last7Days, last30Days, last90Days] = await Promise.all([
-    loadRange('1h'),
-    loadRange('24h'),
-    loadRange('7d'),
-    loadRange('30d'),
-    loadRange('90d'),
-  ]);
+    })),
+    endHourExclusive,
+    limit: 5,
+  });
   return {
-    '1h': thisHour,
-    '24h': last24Hours,
-    '7d': last7Days,
-    '30d': last30Days,
-    '90d': last90Days,
+    '1h': driversByRange.get('1h') ?? [],
+    '24h': driversByRange.get('24h') ?? [],
+    '7d': driversByRange.get('7d') ?? [],
+    '30d': driversByRange.get('30d') ?? [],
+    '90d': driversByRange.get('90d') ?? [],
   };
 }
 

--- a/apps/web/src/lib/cost-insights/spend-repository.integration.test.ts
+++ b/apps/web/src/lib/cost-insights/spend-repository.integration.test.ts
@@ -19,6 +19,7 @@ import {
   getOwnerRolling24HourSpendExact,
   getOwnerTopSpendDrivers,
   getOwnerTopSpendDriversByRange,
+  loadOwnerDashboardHourlySpend,
 } from './spend-repository';
 
 const testUserIds = new Set<string>();
@@ -76,6 +77,102 @@ afterEach(async () => {
 });
 
 describe('Cost Insights spend repository integration', () => {
+  test('replaces separated degraded dashboard hours with canonical spend', async () => {
+    const userId = await createUser();
+    await initializeCoverage();
+    await db.insert(cost_insight_owner_hour_totals).values([
+      {
+        owned_by_user_id: userId,
+        hour_start: '2026-06-01T13:00:00.000Z',
+        spend_category: 'variable',
+        total_microdollars: 999,
+        spend_record_count: 1,
+      },
+      {
+        owned_by_user_id: userId,
+        hour_start: '2026-06-01T14:00:00.000Z',
+        spend_category: 'variable',
+        total_microdollars: 100,
+        spend_record_count: 1,
+      },
+      {
+        owned_by_user_id: userId,
+        hour_start: '2026-06-01T15:00:00.000Z',
+        spend_category: 'variable',
+        total_microdollars: 999,
+        spend_record_count: 1,
+      },
+    ]);
+    await db.insert(cost_insight_rollup_degraded_intervals).values([
+      {
+        start_hour: '2026-06-01T13:00:00.000Z',
+        end_hour_exclusive: '2026-06-01T14:00:00.000Z',
+        reason: 'capture_bypass',
+      },
+      {
+        start_hour: '2026-06-01T15:00:00.000Z',
+        end_hour_exclusive: '2026-06-01T16:00:00.000Z',
+        reason: 'capture_bypass',
+      },
+    ]);
+    await db.insert(microdollar_usage).values([
+      {
+        kilo_user_id: userId,
+        cost: 11,
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_write_tokens: 0,
+        cache_hit_tokens: 0,
+        created_at: '2026-06-01T13:15:00.000Z',
+      },
+      {
+        kilo_user_id: userId,
+        cost: 50,
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_write_tokens: 0,
+        cache_hit_tokens: 0,
+        created_at: '2026-06-01T14:15:00.000Z',
+      },
+      {
+        kilo_user_id: userId,
+        cost: 13,
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_write_tokens: 0,
+        cache_hit_tokens: 0,
+        created_at: '2026-06-01T15:15:00.000Z',
+      },
+    ]);
+
+    await expect(
+      loadOwnerDashboardHourlySpend(db, {
+        owner: { type: 'user', id: userId },
+        startHour: '2026-06-01T13:00:00.000Z',
+        endHourExclusive: '2026-06-01T16:00:00.000Z',
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({
+        hourStart: '2026-06-01T13:00:00.000Z',
+        variableMicrodollars: 11,
+        totalMicrodollars: 11,
+        isCovered: true,
+      }),
+      expect.objectContaining({
+        hourStart: '2026-06-01T14:00:00.000Z',
+        variableMicrodollars: 100,
+        totalMicrodollars: 100,
+        isCovered: true,
+      }),
+      expect.objectContaining({
+        hourStart: '2026-06-01T15:00:00.000Z',
+        variableMicrodollars: 13,
+        totalMicrodollars: 13,
+        isCovered: true,
+      }),
+    ]);
+  });
+
   test('ranks each nested dashboard range independently from one 90-day bucket scan', async () => {
     const userId = await createUser();
     const recentDriver = await aiGatewayDriver('recent-winner', userId);
@@ -631,24 +728,41 @@ describe('Cost Insights spend repository integration', () => {
     });
   });
 
-  test('uses full canonical exact evidence when interior rollup coverage is incomplete', async () => {
+  test('combines covered rollup drivers with canonical degraded-hour and boundary drivers', async () => {
     const userId = await createUser();
     await initializeCoverage();
     const driver = await aiGatewayDriver('fallback-model', userId);
-    await db.insert(cost_insight_owner_hour_driver_buckets).values({
-      owned_by_user_id: userId,
-      hour_start: '2026-06-01T13:00:00.000Z',
-      spend_category: 'variable',
-      driver_key: driver.driverKey,
-      source: 'ai_gateway',
-      product_key: 'other',
-      feature_key: 'other',
-      model_or_plan_key: 'fallback-model',
-      provider_key: 'provider',
-      actor_user_id: userId,
-      total_microdollars: 999,
-      spend_record_count: 1,
-    });
+    const coveredDriver = await aiGatewayDriver('covered-model', userId);
+    await db.insert(cost_insight_owner_hour_driver_buckets).values([
+      {
+        owned_by_user_id: userId,
+        hour_start: '2026-06-01T13:00:00.000Z',
+        spend_category: 'variable',
+        driver_key: driver.driverKey,
+        source: driver.source,
+        product_key: driver.productKey,
+        feature_key: driver.featureKey,
+        model_or_plan_key: driver.modelOrPlanKey,
+        provider_key: driver.providerKey,
+        actor_user_id: driver.actorUserId,
+        total_microdollars: 999,
+        spend_record_count: 1,
+      },
+      {
+        owned_by_user_id: userId,
+        hour_start: '2026-06-01T14:00:00.000Z',
+        spend_category: 'variable',
+        driver_key: coveredDriver.driverKey,
+        source: coveredDriver.source,
+        product_key: coveredDriver.productKey,
+        feature_key: coveredDriver.featureKey,
+        model_or_plan_key: coveredDriver.modelOrPlanKey,
+        provider_key: coveredDriver.providerKey,
+        actor_user_id: coveredDriver.actorUserId,
+        total_microdollars: 100,
+        spend_record_count: 1,
+      },
+    ]);
     await db.insert(cost_insight_rollup_degraded_intervals).values({
       start_hour: '2026-06-01T13:00:00.000Z',
       end_hour_exclusive: '2026-06-01T14:00:00.000Z',
@@ -658,6 +772,7 @@ describe('Cost Insights spend repository integration', () => {
       [
         { createdAt: '2026-06-01T12:45:00.000Z', cost: 3 },
         { createdAt: '2026-06-01T13:15:00.000Z', cost: 11 },
+        { createdAt: '2026-06-01T14:15:00.000Z', cost: 50 },
         { createdAt: '2026-06-02T12:15:00.000Z', cost: 4 },
       ].map(({ createdAt, cost }) => ({
         id: crypto.randomUUID(),
@@ -684,16 +799,78 @@ describe('Cost Insights spend repository integration', () => {
     ).resolves.toEqual({
       asOf: '2026-06-02T12:30:00.000Z',
       windowStart: '2026-06-01T12:30:00.000Z',
-      variableMicrodollars: 18,
+      variableMicrodollars: 118,
       scheduledMicrodollars: 0,
-      totalMicrodollars: 18,
+      totalMicrodollars: 118,
       topDrivers: [
+        expect.objectContaining({
+          modelOrPlanKey: 'covered-model',
+          totalMicrodollars: 100,
+          spendRecordCount: 1,
+        }),
         expect.objectContaining({
           modelOrPlanKey: 'fallback-model',
           totalMicrodollars: 18,
           spendRecordCount: 3,
         }),
       ],
+    });
+  });
+
+  test('combines covered rollup totals with canonical degraded-hour and boundary totals', async () => {
+    const userId = await createUser();
+    await initializeCoverage();
+    await db.insert(cost_insight_owner_hour_totals).values([
+      {
+        owned_by_user_id: userId,
+        hour_start: '2026-06-01T13:00:00.000Z',
+        spend_category: 'variable',
+        total_microdollars: 999,
+        spend_record_count: 1,
+      },
+      {
+        owned_by_user_id: userId,
+        hour_start: '2026-06-01T14:00:00.000Z',
+        spend_category: 'variable',
+        total_microdollars: 100,
+        spend_record_count: 1,
+      },
+    ]);
+    await db.insert(cost_insight_rollup_degraded_intervals).values({
+      start_hour: '2026-06-01T13:00:00.000Z',
+      end_hour_exclusive: '2026-06-01T14:00:00.000Z',
+      reason: 'capture_bypass',
+    });
+    await db.insert(microdollar_usage).values(
+      [
+        { createdAt: '2026-06-01T12:45:00.000Z', cost: 3 },
+        { createdAt: '2026-06-01T13:15:00.000Z', cost: 11 },
+        { createdAt: '2026-06-01T14:15:00.000Z', cost: 50 },
+        { createdAt: '2026-06-02T12:15:00.000Z', cost: 4 },
+      ].map(({ createdAt, cost }) => ({
+        kilo_user_id: userId,
+        cost,
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_write_tokens: 0,
+        cache_hit_tokens: 0,
+        created_at: createdAt,
+      }))
+    );
+
+    await expect(
+      getOwnerRolling24HourSpendExact(db, {
+        owner: { type: 'user', id: userId },
+        asOf: '2026-06-02T12:30:00.000Z',
+        fallbackToCanonical: true,
+      })
+    ).resolves.toEqual({
+      asOf: '2026-06-02T12:30:00.000Z',
+      windowStart: '2026-06-01T12:30:00.000Z',
+      variableMicrodollars: 118,
+      scheduledMicrodollars: 0,
+      totalMicrodollars: 118,
+      isComplete: true,
     });
   });
 

--- a/apps/web/src/lib/cost-insights/spend-repository.integration.test.ts
+++ b/apps/web/src/lib/cost-insights/spend-repository.integration.test.ts
@@ -18,6 +18,7 @@ import {
   getOwnerRolling24HourDriverEvidenceExact,
   getOwnerRolling24HourSpendExact,
   getOwnerTopSpendDrivers,
+  getOwnerTopSpendDriversByRange,
 } from './spend-repository';
 
 const testUserIds = new Set<string>();
@@ -75,6 +76,59 @@ afterEach(async () => {
 });
 
 describe('Cost Insights spend repository integration', () => {
+  test('ranks each nested dashboard range independently from one 90-day bucket scan', async () => {
+    const userId = await createUser();
+    const recentDriver = await aiGatewayDriver('recent-winner', userId);
+    const dayDriver = await aiGatewayDriver('day-winner', userId);
+    await db.insert(cost_insight_owner_hour_driver_buckets).values([
+      {
+        owned_by_user_id: userId,
+        hour_start: '2026-06-01T01:00:00.000Z',
+        spend_category: 'variable',
+        driver_key: recentDriver.driverKey,
+        source: recentDriver.source,
+        product_key: recentDriver.productKey,
+        feature_key: recentDriver.featureKey,
+        model_or_plan_key: recentDriver.modelOrPlanKey,
+        provider_key: recentDriver.providerKey,
+        actor_user_id: recentDriver.actorUserId,
+        total_microdollars: 30,
+        spend_record_count: 3,
+      },
+      {
+        owned_by_user_id: userId,
+        hour_start: '2026-05-31T02:00:00.000Z',
+        spend_category: 'variable',
+        driver_key: dayDriver.driverKey,
+        source: dayDriver.source,
+        product_key: dayDriver.productKey,
+        feature_key: dayDriver.featureKey,
+        model_or_plan_key: dayDriver.modelOrPlanKey,
+        provider_key: dayDriver.providerKey,
+        actor_user_id: dayDriver.actorUserId,
+        total_microdollars: 100,
+        spend_record_count: 1,
+      },
+    ]);
+
+    const driversByRange = await getOwnerTopSpendDriversByRange(db, {
+      owner: { type: 'user', id: userId },
+      ranges: [
+        { key: '1h', startHour: '2026-06-01T01:00:00.000Z' },
+        { key: '24h', startHour: '2026-05-31T02:00:00.000Z' },
+      ],
+      endHourExclusive: '2026-06-01T02:00:00.000Z',
+      limit: 1,
+    });
+
+    expect(driversByRange.get('1h')).toEqual([
+      expect.objectContaining({ modelOrPlanKey: 'recent-winner', totalMicrodollars: 30 }),
+    ]);
+    expect(driversByRange.get('24h')).toEqual([
+      expect.objectContaining({ modelOrPlanKey: 'day-winner', totalMicrodollars: 100 }),
+    ]);
+  });
+
   test('zero-fills covered sparse hours, isolates owners, and suppresses degraded hours', async () => {
     const userId = await createUser();
     const otherUserId = await createUser();

--- a/apps/web/src/lib/cost-insights/spend-repository.test.ts
+++ b/apps/web/src/lib/cost-insights/spend-repository.test.ts
@@ -3,6 +3,7 @@ import {
   getCostInsightRollupCoverage,
   getOwnerCurrentHourSpend,
   getOwnerHourlySpend,
+  getOwnerTopSpendDriversByRange,
   getRolling24HourFragments,
   getRollingWindowFragments,
 } from './spend-repository';
@@ -124,6 +125,52 @@ describe('Cost Insights spend repository', () => {
       variableRecordCount: 2,
       scheduledRecordCount: 1,
     });
+  });
+
+  test('returns independently ranked drivers for all ranges in one query', async () => {
+    const executor = executorReturning([
+      {
+        range_key: '1h',
+        spend_category: 'variable',
+        source: 'ai_gateway',
+        product_key: 'recent-winner',
+        feature_key: 'other',
+        model_or_plan_key: 'other',
+        provider_key: 'other',
+        actor_user_id: 'user-1',
+        total_microdollars: '30',
+        spend_record_count: '3',
+      },
+      {
+        range_key: '24h',
+        spend_category: 'scheduled',
+        source: 'kiloclaw',
+        product_key: 'day-winner',
+        feature_key: 'other',
+        model_or_plan_key: 'other',
+        provider_key: 'other',
+        actor_user_id: 'user-1',
+        total_microdollars: '100',
+        spend_record_count: '1',
+      },
+    ]);
+
+    const driversByRange = await getOwnerTopSpendDriversByRange(executor, {
+      owner,
+      ranges: [
+        { key: '1h', startHour: '2026-06-01T01:00:00.000Z' },
+        { key: '24h', startHour: '2026-05-31T02:00:00.000Z' },
+      ],
+      endHourExclusive: '2026-06-01T02:00:00.000Z',
+    });
+
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+    expect(driversByRange.get('1h')).toEqual([
+      expect.objectContaining({ productKey: 'recent-winner', totalMicrodollars: 30 }),
+    ]);
+    expect(driversByRange.get('24h')).toEqual([
+      expect.objectContaining({ productKey: 'day-winner', totalMicrodollars: 100 }),
+    ]);
   });
 
   test('marks range incomplete when unresolved degraded interval overlaps it', async () => {

--- a/apps/web/src/lib/cost-insights/spend-repository.test.ts
+++ b/apps/web/src/lib/cost-insights/spend-repository.test.ts
@@ -6,6 +6,7 @@ import {
   getOwnerTopSpendDriversByRange,
   getRolling24HourFragments,
   getRollingWindowFragments,
+  groupContiguousHourlyIntervals,
 } from './spend-repository';
 
 const owner = { type: 'user', id: 'user-1' } as const;
@@ -58,6 +59,32 @@ describe('Cost Insights spend repository', () => {
     expect(fragments.currentBoundaryStart).toBe(fragments.asOf);
     expect(fragments.interiorStart).toBe('2026-06-01T12:00:00.000Z');
     expect(fragments.interiorEnd).toBe('2026-06-02T12:00:00.000Z');
+  });
+
+  test('groups adjacent hours with the same coverage state into intervals', () => {
+    const points = [
+      { hourStart: '2026-06-01T00:00:00.000Z', isCovered: false },
+      { hourStart: '2026-06-01T01:00:00.000Z', isCovered: false },
+      { hourStart: '2026-06-01T02:00:00.000Z', isCovered: true },
+      { hourStart: '2026-06-01T03:00:00.000Z', isCovered: false },
+    ];
+
+    expect(groupContiguousHourlyIntervals(points, false)).toEqual([
+      {
+        startHour: '2026-06-01T00:00:00.000Z',
+        endHourExclusive: '2026-06-01T02:00:00.000Z',
+      },
+      {
+        startHour: '2026-06-01T03:00:00.000Z',
+        endHourExclusive: '2026-06-01T04:00:00.000Z',
+      },
+    ]);
+    expect(groupContiguousHourlyIntervals(points, true)).toEqual([
+      {
+        startHour: '2026-06-01T02:00:00.000Z',
+        endHourExclusive: '2026-06-01T03:00:00.000Z',
+      },
+    ]);
   });
 
   test('returns covered sparse hours as zero and uncovered hours as null', async () => {

--- a/apps/web/src/lib/cost-insights/spend-repository.ts
+++ b/apps/web/src/lib/cost-insights/spend-repository.ts
@@ -5,6 +5,7 @@ import {
   cost_insight_rollup_coverage,
   cost_insight_rollup_degraded_intervals,
 } from '@kilocode/db/schema';
+import { startSpan } from '@sentry/nextjs';
 import { sql, type SQL } from 'drizzle-orm';
 
 import type { db } from '@/lib/drizzle';
@@ -13,6 +14,8 @@ import {
   COST_INSIGHT_ROLLUP_VERSION,
   getCanonicalOwnerSpendTotals,
   loadCanonicalCostInsightAggregation,
+  loadCanonicalCostInsightAggregationsByHour,
+  loadCanonicalCostInsightAggregationsByIntervals,
   parseSafeDatabaseInteger,
   requireUtcHour,
   requireUtcTimestamp,
@@ -111,6 +114,11 @@ export type RollingWindowFragments = {
 export type OwnerRolling24HourSpendExact = OwnerRollingSpendExact;
 export type OwnerRolling24HourDriverEvidenceExact = OwnerRollingDriverEvidenceExact;
 export type Rolling24HourFragments = RollingWindowFragments;
+
+export type HourInterval = {
+  startHour: string;
+  endHourExclusive: string;
+};
 
 type DenseHourlySpendRow = {
   hour_start: string | Date;
@@ -226,6 +234,134 @@ function sumSafe(left: number, right: number, fieldName: string): number {
     throw new Error(`${fieldName} is outside the JavaScript safe-integer range.`);
   }
   return total;
+}
+
+export function groupContiguousHourlyIntervals(
+  points: readonly Pick<OwnerHourlySpend, 'hourStart' | 'isCovered'>[],
+  isCovered: boolean
+): HourInterval[] {
+  const intervals: HourInterval[] = [];
+  for (const point of points) {
+    if (point.isCovered !== isCovered) continue;
+    const previous = intervals.at(-1);
+    if (previous && previous.endHourExclusive === point.hourStart) {
+      previous.endHourExclusive = addHours(point.hourStart, 1);
+    } else {
+      intervals.push({
+        startHour: point.hourStart,
+        endHourExclusive: addHours(point.hourStart, 1),
+      });
+    }
+  }
+  return intervals;
+}
+
+function addHours(hourStart: string, hours: number): string {
+  return new Date(Date.parse(hourStart) + hours * HOUR_MS).toISOString();
+}
+
+function hasIntervals<T>(intervals: readonly T[]): intervals is readonly [T, ...T[]] {
+  return intervals.length > 0;
+}
+
+function toCanonicalIntervals(
+  intervals: readonly [HourInterval, ...HourInterval[]]
+): readonly [
+  { startInclusive: string; endExclusive: string },
+  ...{ startInclusive: string; endExclusive: string }[],
+] {
+  return intervals.map(interval => ({
+    startInclusive: interval.startHour,
+    endExclusive: interval.endHourExclusive,
+  })) as [
+    { startInclusive: string; endExclusive: string },
+    ...{ startInclusive: string; endExclusive: string }[],
+  ];
+}
+
+function summarizeCanonicalHourlySpend(
+  hourly: Awaited<ReturnType<typeof loadCanonicalCostInsightAggregationsByHour>>
+): { variableMicrodollars: number; scheduledMicrodollars: number } {
+  let variableMicrodollars = 0;
+  let scheduledMicrodollars = 0;
+  for (const aggregation of hourly) {
+    for (const total of aggregation.totals) {
+      if (total.category === 'variable') {
+        variableMicrodollars = sumSafe(
+          variableMicrodollars,
+          total.totalMicrodollars,
+          'canonical hourly variable microdollars'
+        );
+      } else {
+        scheduledMicrodollars = sumSafe(
+          scheduledMicrodollars,
+          total.totalMicrodollars,
+          'canonical hourly scheduled microdollars'
+        );
+      }
+    }
+  }
+  return { variableMicrodollars, scheduledMicrodollars };
+}
+
+function canonicalHourlyDrivers(
+  hourly: Awaited<ReturnType<typeof loadCanonicalCostInsightAggregationsByHour>>,
+  owner: CostInsightSpendOwner
+): MergeableSpendDriver[] {
+  return hourly.flatMap(aggregation =>
+    aggregation.drivers.map(driver => {
+      if (driver.owner.type !== owner.type || driver.owner.id !== owner.id) {
+        throw new Error('Canonical Cost Insights driver resolved to the wrong Spend owner.');
+      }
+      return {
+        category: driver.category,
+        driverKey: driver.driverKey,
+        source: driver.source,
+        productKey: driver.productKey,
+        featureKey: driver.featureKey,
+        modelOrPlanKey: driver.modelOrPlanKey,
+        providerKey: driver.providerKey,
+        actorUserId: driver.actorUserId,
+        totalMicrodollars: driver.totalMicrodollars,
+        spendRecordCount: driver.spendRecordCount,
+      };
+    })
+  );
+}
+
+async function withCanonicalFallbackTelemetry<T>(
+  operation: 'dashboard_evidence_90d' | 'rolling_spend' | 'rolling_driver_evidence',
+  intervals: readonly HourInterval[],
+  callback: () => Promise<T>
+): Promise<T> {
+  if (intervals.length === 0) return await callback();
+  const intervalHours = intervals.reduce(
+    (total, interval) =>
+      sumSafe(
+        total,
+        (Date.parse(interval.endHourExclusive) - Date.parse(interval.startHour)) / HOUR_MS,
+        'canonical fallback interval hours'
+      ),
+    0
+  );
+  return await startSpan(
+    { name: `cost_insights.${operation}`, op: 'cost_insights.canonical_fallback' },
+    async span => {
+      const startedAt = performance.now();
+      span.setAttribute('cost_insights.operation', operation);
+      span.setAttribute('cost_insights.occurrence', 1);
+      span.setAttribute('cost_insights.interval_count', intervals.length);
+      span.setAttribute('cost_insights.interval_hours', intervalHours);
+      try {
+        return await callback();
+      } finally {
+        span.setAttribute(
+          'cost_insights.fallback_duration_ms',
+          Math.round(performance.now() - startedAt)
+        );
+      }
+    }
+  );
 }
 
 function floorUtcHour(timestamp: number): number {
@@ -385,6 +521,81 @@ export async function getOwnerHourlySpend(
       isCovered: true,
     };
   });
+}
+
+function canonicalHourlySpend(
+  hourly: Awaited<ReturnType<typeof loadCanonicalCostInsightAggregationsByHour>>,
+  intervals: readonly HourInterval[]
+): OwnerHourlySpend[] {
+  const byHour = new Map(hourly.map(hour => [hour.hourStart, hour]));
+  const points: OwnerHourlySpend[] = [];
+  for (const interval of intervals) {
+    for (
+      let hourStart = interval.startHour;
+      hourStart < interval.endHourExclusive;
+      hourStart = addHours(hourStart, 1)
+    ) {
+      const aggregation = byHour.get(hourStart);
+      const variable = aggregation?.totals.find(total => total.category === 'variable');
+      const scheduled = aggregation?.totals.find(total => total.category === 'scheduled');
+      const variableMicrodollars = variable?.totalMicrodollars ?? 0;
+      const scheduledMicrodollars = scheduled?.totalMicrodollars ?? 0;
+      points.push({
+        hourStart,
+        variableMicrodollars,
+        scheduledMicrodollars,
+        totalMicrodollars: sumSafe(
+          variableMicrodollars,
+          scheduledMicrodollars,
+          'canonical hourly total microdollars'
+        ),
+        variableRecordCount: variable?.spendRecordCount ?? 0,
+        scheduledRecordCount: scheduled?.spendRecordCount ?? 0,
+        isCovered: true,
+      });
+    }
+  }
+  return points;
+}
+
+export async function loadOwnerDashboardHourlySpend(
+  primaryDatabase: ExactRollingDatabase,
+  params: {
+    owner: CostInsightSpendOwner;
+    startHour: string;
+    endHourExclusive: string;
+  }
+): Promise<OwnerHourlySpend[]> {
+  const range = requireHourlyRange(params);
+  return await primaryDatabase.transaction(
+    async transaction => {
+      const rollupPoints = await getOwnerHourlySpend(transaction, {
+        owner: params.owner,
+        startHour: range.startHour,
+        endHourExclusive: range.endHourExclusive,
+      });
+      const uncoveredIntervals = groupContiguousHourlyIntervals(rollupPoints, false);
+      if (!hasIntervals(uncoveredIntervals)) return rollupPoints;
+
+      const canonicalPoints = await withCanonicalFallbackTelemetry(
+        'dashboard_evidence_90d',
+        uncoveredIntervals,
+        async () =>
+          canonicalHourlySpend(
+            await loadCanonicalCostInsightAggregationsByIntervals(transaction, {
+              owner: params.owner,
+              intervals: toCanonicalIntervals(uncoveredIntervals),
+            }),
+            uncoveredIntervals
+          )
+      );
+      const canonicalByHour = new Map(canonicalPoints.map(point => [point.hourStart, point]));
+      return rollupPoints.map(point =>
+        point.isCovered ? point : (canonicalByHour.get(point.hourStart) ?? point)
+      );
+    },
+    { isolationLevel: 'repeatable read', accessMode: 'read only' }
+  );
 }
 
 export async function getOwnerTopSpendDrivers(
@@ -985,6 +1196,73 @@ async function getInteriorRollupDrivers(
   }));
 }
 
+async function getInteriorRollupDriversByIntervals(
+  executor: CostInsightQueryExecutor,
+  owner: CostInsightSpendOwner,
+  intervals: readonly HourInterval[]
+): Promise<MergeableSpendDriver[]> {
+  if (!hasIntervals(intervals)) return [];
+  const first = intervals[0];
+  const last = intervals.at(-1);
+  if (!last) return [];
+  const intervalValues = sql.join(
+    intervals.map(
+      interval =>
+        sql`(${interval.startHour}::timestamptz, ${interval.endHourExclusive}::timestamptz)`
+    ),
+    sql`, `
+  );
+  const result = await executor.execute<InteriorDriverRow>(sql`
+    SELECT
+      ${cost_insight_owner_hour_driver_buckets.spend_category} AS spend_category,
+      ${cost_insight_owner_hour_driver_buckets.driver_key} AS driver_key,
+      ${cost_insight_owner_hour_driver_buckets.source} AS source,
+      ${cost_insight_owner_hour_driver_buckets.product_key} AS product_key,
+      ${cost_insight_owner_hour_driver_buckets.feature_key} AS feature_key,
+      ${cost_insight_owner_hour_driver_buckets.model_or_plan_key} AS model_or_plan_key,
+      ${cost_insight_owner_hour_driver_buckets.provider_key} AS provider_key,
+      ${cost_insight_owner_hour_driver_buckets.actor_user_id} AS actor_user_id,
+      SUM(${cost_insight_owner_hour_driver_buckets.total_microdollars})::text
+        AS total_microdollars,
+      SUM(${cost_insight_owner_hour_driver_buckets.spend_record_count})::text
+        AS spend_record_count
+    FROM ${cost_insight_owner_hour_driver_buckets}
+    WHERE ${cost_insight_owner_hour_driver_buckets.hour_start} >= ${first.startHour}
+      AND ${cost_insight_owner_hour_driver_buckets.hour_start} < ${last.endHourExclusive}
+      AND EXISTS (
+        SELECT 1
+        FROM (VALUES ${intervalValues}) AS covered_intervals(start_inclusive, end_exclusive)
+        WHERE ${cost_insight_owner_hour_driver_buckets.hour_start} >= covered_intervals.start_inclusive
+          AND ${cost_insight_owner_hour_driver_buckets.hour_start} < covered_intervals.end_exclusive
+      )
+      AND ${ownerPredicate(
+        owner,
+        sql`${cost_insight_owner_hour_driver_buckets.owned_by_user_id}`,
+        sql`${cost_insight_owner_hour_driver_buckets.owned_by_organization_id}`
+      )}
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8
+    ORDER BY 1, 2, 3, 4, 5, 6, 7, 8
+  `);
+  return result.rows.map(row => ({
+    category: row.spend_category,
+    driverKey: row.driver_key,
+    source: row.source,
+    productKey: row.product_key,
+    featureKey: row.feature_key,
+    modelOrPlanKey: row.model_or_plan_key,
+    providerKey: row.provider_key,
+    actorUserId: row.actor_user_id,
+    totalMicrodollars: parseSafeDatabaseInteger(
+      row.total_microdollars,
+      'interior driver total_microdollars'
+    ),
+    spendRecordCount: parseSafeDatabaseInteger(
+      row.spend_record_count,
+      'interior driver spend_record_count'
+    ),
+  }));
+}
+
 async function getCanonicalDrivers(
   executor: CostInsightQueryExecutor,
   params: {
@@ -1236,41 +1514,53 @@ export async function getOwnerRollingDriverEvidenceExact(
         normalizeDatabaseTimestamp(asOfRow.value, 'as_of'),
         params.windowHours
       );
-      const coverage =
+      const interiorPoints =
         fragments.interiorStart === fragments.interiorEnd
-          ? null
-          : await getCostInsightRollupCoverage(transaction, {
+          ? []
+          : await getOwnerHourlySpend(transaction, {
+              owner: params.owner,
               startHour: fragments.interiorStart,
               endHourExclusive: fragments.interiorEnd,
             });
-
-      const mergedDrivers =
-        coverage?.isFullyCovered === false
-          ? mergeSpendDrivers([
-              await getCanonicalDrivers(transaction, {
-                owner: params.owner,
-                startInclusive: fragments.windowStart,
-                endExclusive: fragments.asOf,
-              }),
-            ])
-          : mergeSpendDrivers([
-              await getInteriorRollupDrivers(
-                transaction,
-                params.owner,
-                fragments.interiorStart,
-                fragments.interiorEnd
-              ),
-              await getCanonicalDrivers(transaction, {
-                owner: params.owner,
-                startInclusive: fragments.windowStart,
-                endExclusive: fragments.oldestBoundaryEnd,
-              }),
-              await getCanonicalDrivers(transaction, {
-                owner: params.owner,
-                startInclusive: fragments.currentBoundaryStart,
-                endExclusive: fragments.asOf,
-              }),
-            ]);
+      const coveredIntervals = groupContiguousHourlyIntervals(interiorPoints, true);
+      const uncoveredIntervals = groupContiguousHourlyIntervals(interiorPoints, false);
+      const canonicalIntervals: HourInterval[] = [
+        ...(fragments.windowStart === fragments.oldestBoundaryEnd
+          ? []
+          : [
+              {
+                startHour: fragments.windowStart,
+                endHourExclusive: fragments.oldestBoundaryEnd,
+              },
+            ]),
+        ...uncoveredIntervals,
+        ...(fragments.currentBoundaryStart === fragments.asOf
+          ? []
+          : [
+              {
+                startHour: fragments.currentBoundaryStart,
+                endHourExclusive: fragments.asOf,
+              },
+            ]),
+      ];
+      const canonicalDrivers = await withCanonicalFallbackTelemetry(
+        'rolling_driver_evidence',
+        uncoveredIntervals,
+        async () =>
+          hasIntervals(canonicalIntervals)
+            ? canonicalHourlyDrivers(
+                await loadCanonicalCostInsightAggregationsByIntervals(transaction, {
+                  owner: params.owner,
+                  intervals: toCanonicalIntervals(canonicalIntervals),
+                }),
+                params.owner
+              )
+            : []
+      );
+      const mergedDrivers = mergeSpendDrivers([
+        await getInteriorRollupDriversByIntervals(transaction, params.owner, coveredIntervals),
+        canonicalDrivers,
+      ]);
       const evidence = summarizeSpendDrivers(mergedDrivers);
       return {
         asOf: fragments.asOf,
@@ -1326,33 +1616,16 @@ export async function getOwnerRollingSpendExact(
         currentBoundaryStart,
       } = fragments;
 
-      const coverage =
+      const interiorPoints =
         interiorStart === interiorEnd
-          ? null
-          : await getCostInsightRollupCoverage(transaction, {
+          ? []
+          : await getOwnerHourlySpend(transaction, {
+              owner: params.owner,
               startHour: interiorStart,
               endHourExclusive: interiorEnd,
             });
-      if (coverage && !coverage.isFullyCovered) {
-        if (params.fallbackToCanonical) {
-          const canonical = await getCanonicalOwnerSpendTotals(transaction, {
-            owner: params.owner,
-            startInclusive: windowStart,
-            endExclusive: asOf,
-          });
-          return {
-            asOf,
-            windowStart,
-            variableMicrodollars: canonical.variableMicrodollars,
-            scheduledMicrodollars: canonical.scheduledMicrodollars,
-            totalMicrodollars: sumSafe(
-              canonical.variableMicrodollars,
-              canonical.scheduledMicrodollars,
-              'canonical rolling total microdollars'
-            ),
-            isComplete: true,
-          };
-        }
+      const uncoveredIntervals = groupContiguousHourlyIntervals(interiorPoints, false);
+      if (uncoveredIntervals.length > 0 && !params.fallbackToCanonical) {
         return {
           asOf,
           windowStart,
@@ -1363,52 +1636,58 @@ export async function getOwnerRollingSpendExact(
         };
       }
 
-      const interior = await getInteriorRollupTotals(
-        transaction,
-        params.owner,
-        interiorStart,
-        interiorEnd
+      let interior = { variableMicrodollars: 0, scheduledMicrodollars: 0 };
+      for (const point of interiorPoints) {
+        if (!point.isCovered) continue;
+        interior = {
+          variableMicrodollars: sumSafe(
+            interior.variableMicrodollars,
+            point.variableMicrodollars ?? 0,
+            'rolling interior variable microdollars'
+          ),
+          scheduledMicrodollars: sumSafe(
+            interior.scheduledMicrodollars,
+            point.scheduledMicrodollars ?? 0,
+            'rolling interior scheduled microdollars'
+          ),
+        };
+      }
+      const canonicalIntervals: HourInterval[] = [
+        ...(windowStart === oldestBoundaryEnd
+          ? []
+          : [{ startHour: windowStart, endHourExclusive: oldestBoundaryEnd }]),
+        ...uncoveredIntervals,
+        ...(currentBoundaryStart === asOf
+          ? []
+          : [{ startHour: currentBoundaryStart, endHourExclusive: asOf }]),
+      ];
+      const canonical = await withCanonicalFallbackTelemetry(
+        'rolling_spend',
+        uncoveredIntervals,
+        async () =>
+          hasIntervals(canonicalIntervals)
+            ? summarizeCanonicalHourlySpend(
+                await loadCanonicalCostInsightAggregationsByIntervals(transaction, {
+                  owner: params.owner,
+                  intervals: toCanonicalIntervals(canonicalIntervals),
+                })
+              )
+            : { variableMicrodollars: 0, scheduledMicrodollars: 0 }
       );
-      const oldestBoundary =
-        windowStart === oldestBoundaryEnd
-          ? {
-              variableMicrodollars: 0,
-              scheduledMicrodollars: 0,
-            }
-          : await getCanonicalOwnerSpendTotals(transaction, {
-              owner: params.owner,
-              startInclusive: windowStart,
-              endExclusive: interiorStart,
-            });
-      const currentBoundary =
-        currentBoundaryStart === asOf
-          ? {
-              variableMicrodollars: 0,
-              scheduledMicrodollars: 0,
-            }
-          : await getCanonicalOwnerSpendTotals(transaction, {
-              owner: params.owner,
-              startInclusive: interiorEnd,
-              endExclusive: asOf,
-            });
-      const variableMicrodollars = sumSafe(
-        sumSafe(
+      interior = {
+        variableMicrodollars: sumSafe(
           interior.variableMicrodollars,
-          oldestBoundary.variableMicrodollars,
-          'rolling variable microdollars'
+          canonical.variableMicrodollars,
+          'rolling interior variable microdollars'
         ),
-        currentBoundary.variableMicrodollars,
-        'rolling variable microdollars'
-      );
-      const scheduledMicrodollars = sumSafe(
-        sumSafe(
+        scheduledMicrodollars: sumSafe(
           interior.scheduledMicrodollars,
-          oldestBoundary.scheduledMicrodollars,
-          'rolling scheduled microdollars'
+          canonical.scheduledMicrodollars,
+          'rolling interior scheduled microdollars'
         ),
-        currentBoundary.scheduledMicrodollars,
-        'rolling scheduled microdollars'
-      );
+      };
+      const variableMicrodollars = interior.variableMicrodollars;
+      const scheduledMicrodollars = interior.scheduledMicrodollars;
       return {
         asOf,
         windowStart,

--- a/apps/web/src/lib/cost-insights/spend-repository.ts
+++ b/apps/web/src/lib/cost-insights/spend-repository.ts
@@ -133,6 +133,10 @@ type TopDriverRow = {
   spend_record_count: string | number | bigint;
 };
 
+type TopDriverByRangeRow = TopDriverRow & {
+  range_key: string;
+};
+
 type CurrentHourRow = {
   variable_microdollars: string | number | bigint;
   scheduled_microdollars: string | number | bigint;
@@ -454,6 +458,151 @@ export async function getOwnerTopSpendDrivers(
       'top-driver spend_record_count'
     ),
   }));
+}
+
+export async function getOwnerTopSpendDriversByRange(
+  executor: CostInsightQueryExecutor,
+  params: {
+    owner: CostInsightSpendOwner;
+    ranges: readonly { key: string; startHour: string }[];
+    endHourExclusive: string;
+    limit?: number;
+  }
+): Promise<Map<string, OwnerTopSpendDriver[]>> {
+  const endHourExclusive = requireUtcHour(params.endHourExclusive, 'endHourExclusive');
+  if (params.ranges.length === 0) {
+    throw new Error('Cost Insights top-driver ranges must not be empty.');
+  }
+
+  const rangeKeys = new Set<string>();
+  const ranges = params.ranges.map(range => {
+    if (!range.key) {
+      throw new Error('Cost Insights top-driver range keys must not be empty.');
+    }
+    if (rangeKeys.has(range.key)) {
+      throw new Error(`Cost Insights top-driver range key ${range.key} is duplicated.`);
+    }
+    rangeKeys.add(range.key);
+    return {
+      key: range.key,
+      ...requireHourlyRange({ startHour: range.startHour, endHourExclusive }),
+    };
+  });
+
+  const requestedLimit = params.limit ?? COST_INSIGHT_MAX_TOP_DRIVERS;
+  if (!Number.isSafeInteger(requestedLimit) || requestedLimit <= 0) {
+    throw new Error('Cost Insights top-driver limit must be a positive safe integer.');
+  }
+  const limit = Math.min(requestedLimit, COST_INSIGHT_MAX_TOP_DRIVERS);
+  const owner = params.owner;
+  const rangeValues = sql.join(
+    ranges.map(range => sql`(${range.key}, ${range.startHour}::timestamptz)`),
+    sql`, `
+  );
+  const result = await executor.execute<TopDriverByRangeRow>(sql`
+    WITH ranges(range_key, start_hour) AS (
+      VALUES ${rangeValues}
+    ), owner_buckets AS MATERIALIZED (
+      SELECT
+        ${cost_insight_owner_hour_driver_buckets.hour_start} AS hour_start,
+        ${cost_insight_owner_hour_driver_buckets.spend_category} AS spend_category,
+        ${cost_insight_owner_hour_driver_buckets.source} AS source,
+        ${cost_insight_owner_hour_driver_buckets.product_key} AS product_key,
+        ${cost_insight_owner_hour_driver_buckets.feature_key} AS feature_key,
+        ${cost_insight_owner_hour_driver_buckets.model_or_plan_key} AS model_or_plan_key,
+        ${cost_insight_owner_hour_driver_buckets.provider_key} AS provider_key,
+        ${cost_insight_owner_hour_driver_buckets.actor_user_id} AS actor_user_id,
+        ${cost_insight_owner_hour_driver_buckets.total_microdollars} AS total_microdollars,
+        ${cost_insight_owner_hour_driver_buckets.spend_record_count} AS spend_record_count
+      FROM ${cost_insight_owner_hour_driver_buckets}
+      WHERE ${cost_insight_owner_hour_driver_buckets.hour_start} >= (
+        SELECT MIN(start_hour) FROM ranges
+      )
+        AND ${cost_insight_owner_hour_driver_buckets.hour_start} < ${endHourExclusive}
+        AND ${ownerPredicate(
+          owner,
+          sql`${cost_insight_owner_hour_driver_buckets.owned_by_user_id}`,
+          sql`${cost_insight_owner_hour_driver_buckets.owned_by_organization_id}`
+        )}
+    ), driver_totals AS (
+      SELECT
+        ranges.range_key,
+        owner_buckets.spend_category AS spend_category,
+        owner_buckets.source AS source,
+        owner_buckets.product_key AS product_key,
+        owner_buckets.feature_key AS feature_key,
+        owner_buckets.model_or_plan_key AS model_or_plan_key,
+        owner_buckets.provider_key AS provider_key,
+        owner_buckets.actor_user_id AS actor_user_id,
+        SUM(owner_buckets.total_microdollars)::text
+          AS total_microdollars,
+        SUM(owner_buckets.spend_record_count)::text
+          AS spend_record_count
+      FROM owner_buckets
+      CROSS JOIN ranges
+      WHERE owner_buckets.hour_start >= ranges.start_hour
+      GROUP BY 1, 2, 3, 4, 5, 6, 7, 8
+    ), ranked_drivers AS (
+      SELECT
+        *,
+        ROW_NUMBER() OVER (
+          PARTITION BY range_key
+          ORDER BY
+            total_microdollars::numeric DESC,
+            spend_category ASC,
+            source ASC,
+            product_key ASC,
+            feature_key ASC,
+            model_or_plan_key ASC,
+            provider_key ASC,
+            actor_user_id ASC
+        ) AS rank
+      FROM driver_totals
+    )
+    SELECT
+      range_key,
+      spend_category,
+      source,
+      product_key,
+      feature_key,
+      model_or_plan_key,
+      provider_key,
+      actor_user_id,
+      total_microdollars,
+      spend_record_count
+    FROM ranked_drivers
+    WHERE rank <= ${limit}
+    ORDER BY range_key ASC, rank ASC
+  `);
+
+  const driversByRange = new Map<string, OwnerTopSpendDriver[]>();
+  for (const range of ranges) {
+    driversByRange.set(range.key, []);
+  }
+  for (const row of result.rows) {
+    const drivers = driversByRange.get(row.range_key);
+    if (!drivers) {
+      throw new Error(`Cost Insights top-driver query returned unknown range ${row.range_key}.`);
+    }
+    drivers.push({
+      category: row.spend_category,
+      source: row.source,
+      productKey: row.product_key,
+      featureKey: row.feature_key,
+      modelOrPlanKey: row.model_or_plan_key,
+      providerKey: row.provider_key,
+      actorUserId: row.actor_user_id,
+      totalMicrodollars: parseSafeDatabaseInteger(
+        row.total_microdollars,
+        'top-driver total_microdollars'
+      ),
+      spendRecordCount: parseSafeDatabaseInteger(
+        row.spend_record_count,
+        'top-driver spend_record_count'
+      ),
+    });
+  }
+  return driversByRange;
 }
 
 export async function getOwnerCurrentHourSpend(

--- a/apps/web/src/lib/cost-insights/spend-repository.ts
+++ b/apps/web/src/lib/cost-insights/spend-repository.ts
@@ -12,9 +12,7 @@ import type { db } from '@/lib/drizzle';
 
 import {
   COST_INSIGHT_ROLLUP_VERSION,
-  getCanonicalOwnerSpendTotals,
   loadCanonicalCostInsightAggregation,
-  loadCanonicalCostInsightAggregationsByHour,
   loadCanonicalCostInsightAggregationsByIntervals,
   parseSafeDatabaseInteger,
   requireUtcHour,
@@ -22,6 +20,7 @@ import {
   type CostInsightQueryExecutor,
   type CostInsightSpendCategory,
   type CostInsightSpendSource,
+  type loadCanonicalCostInsightAggregationsByHour,
 } from './canonical-sources';
 
 const HOUR_MS = 60 * 60 * 1_000;
@@ -167,11 +166,6 @@ type DegradedIntervalRow = {
   source: CostInsightSpendSource | null;
   reason: string;
   detected_at: string | Date;
-};
-
-type InteriorTotalRow = {
-  spend_category: CostInsightSpendCategory;
-  total_microdollars: string | number | bigint;
 };
 
 type InteriorDriverRow = TopDriverRow & {
@@ -955,45 +949,6 @@ export async function getCostInsightRollupCoverage(
   };
 }
 
-async function getInteriorRollupTotals(
-  executor: CostInsightQueryExecutor,
-  owner: CostInsightSpendOwner,
-  startInclusive: string,
-  endExclusive: string
-): Promise<{ variableMicrodollars: number; scheduledMicrodollars: number }> {
-  if (startInclusive === endExclusive) {
-    return { variableMicrodollars: 0, scheduledMicrodollars: 0 };
-  }
-  const result = await executor.execute<InteriorTotalRow>(sql`
-    SELECT
-      ${cost_insight_owner_hour_totals.spend_category} AS spend_category,
-      SUM(${cost_insight_owner_hour_totals.total_microdollars})::text AS total_microdollars
-    FROM ${cost_insight_owner_hour_totals}
-    WHERE ${cost_insight_owner_hour_totals.hour_start} >= ${startInclusive}
-      AND ${cost_insight_owner_hour_totals.hour_start} < ${endExclusive}
-      AND ${ownerPredicate(
-        owner,
-        sql`${cost_insight_owner_hour_totals.owned_by_user_id}`,
-        sql`${cost_insight_owner_hour_totals.owned_by_organization_id}`
-      )}
-    GROUP BY ${cost_insight_owner_hour_totals.spend_category}
-  `);
-  let variableMicrodollars = 0;
-  let scheduledMicrodollars = 0;
-  for (const row of result.rows) {
-    const amount = parseSafeDatabaseInteger(
-      row.total_microdollars,
-      'rolling interior total_microdollars'
-    );
-    if (row.spend_category === 'variable') {
-      variableMicrodollars = amount;
-    } else if (row.spend_category === 'scheduled') {
-      scheduledMicrodollars = amount;
-    }
-  }
-  return { variableMicrodollars, scheduledMicrodollars };
-}
-
 function compareTopSpendDrivers(left: OwnerTopSpendDriver, right: OwnerTopSpendDriver): number {
   if (left.totalMicrodollars !== right.totalMicrodollars) {
     return left.totalMicrodollars > right.totalMicrodollars ? -1 : 1;
@@ -1141,58 +1096,6 @@ function toMergeableSpendDrivers(drivers: OwnerTopSpendDriver[]): MergeableSpend
       driver.providerKey,
       driver.actorUserId,
     ]),
-  }));
-}
-
-async function getInteriorRollupDrivers(
-  executor: CostInsightQueryExecutor,
-  owner: CostInsightSpendOwner,
-  startInclusive: string,
-  endExclusive: string
-): Promise<MergeableSpendDriver[]> {
-  if (startInclusive === endExclusive) return [];
-  const result = await executor.execute<InteriorDriverRow>(sql`
-    SELECT
-      ${cost_insight_owner_hour_driver_buckets.spend_category} AS spend_category,
-      ${cost_insight_owner_hour_driver_buckets.driver_key} AS driver_key,
-      ${cost_insight_owner_hour_driver_buckets.source} AS source,
-      ${cost_insight_owner_hour_driver_buckets.product_key} AS product_key,
-      ${cost_insight_owner_hour_driver_buckets.feature_key} AS feature_key,
-      ${cost_insight_owner_hour_driver_buckets.model_or_plan_key} AS model_or_plan_key,
-      ${cost_insight_owner_hour_driver_buckets.provider_key} AS provider_key,
-      ${cost_insight_owner_hour_driver_buckets.actor_user_id} AS actor_user_id,
-      SUM(${cost_insight_owner_hour_driver_buckets.total_microdollars})::text
-        AS total_microdollars,
-      SUM(${cost_insight_owner_hour_driver_buckets.spend_record_count})::text
-        AS spend_record_count
-    FROM ${cost_insight_owner_hour_driver_buckets}
-    WHERE ${cost_insight_owner_hour_driver_buckets.hour_start} >= ${startInclusive}
-      AND ${cost_insight_owner_hour_driver_buckets.hour_start} < ${endExclusive}
-      AND ${ownerPredicate(
-        owner,
-        sql`${cost_insight_owner_hour_driver_buckets.owned_by_user_id}`,
-        sql`${cost_insight_owner_hour_driver_buckets.owned_by_organization_id}`
-      )}
-    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8
-    ORDER BY 1, 2, 3, 4, 5, 6, 7, 8
-  `);
-  return result.rows.map(row => ({
-    category: row.spend_category,
-    driverKey: row.driver_key,
-    source: row.source,
-    productKey: row.product_key,
-    featureKey: row.feature_key,
-    modelOrPlanKey: row.model_or_plan_key,
-    providerKey: row.provider_key,
-    actorUserId: row.actor_user_id,
-    totalMicrodollars: parseSafeDatabaseInteger(
-      row.total_microdollars,
-      'interior driver total_microdollars'
-    ),
-    spendRecordCount: parseSafeDatabaseInteger(
-      row.spend_record_count,
-      'interior driver spend_record_count'
-    ),
   }));
 }
 


### PR DESCRIPTION
## Summary
Reduce Cost Insights dashboard loading time by consolidating overlapping rollup queries and limiting canonical fallback work to uncovered intervals.

### Why this change is needed
The organization Cost Insights dashboard repeatedly scanned overlapping rollup data for its five ranges. More importantly, one uncovered rollup hour caused the dashboard to rebuild the full 90-day evidence window from raw usage. For high-volume organizations such as Kilo, either path could exceed the request timeout and prevent the dashboard from loading.

### How this is addressed
- Scan the owner’s driver buckets once and calculate independent top-five rankings for every dashboard range.
- Preserve covered hourly rollups and query canonical sources only for uncovered intervals.
- Batch fragmented uncovered intervals into four canonical source queries, independent of interval count.
- Apply the same mixed rollup/canonical composition to exact rolling spend and driver evidence, including partial-hour boundaries.
- Record fallback operation, interval count, interval hours, and duration through Sentry spans without owner identifiers.
- Preserve the existing dashboard response, ranking semantics, exact-window behavior, and safe-integer validation.

## Human Verification
- Cost Insights canonical source, spend repository, PostgreSQL integration, and presenter suites passed: 51 tests.
- The previously failing PR check was isolated to an unrelated Stripe concurrency test and passed when rerun locally.
- Independent code reviews verified aggregate overflow handling, bounded canonical query count, interval SQL predicates, transaction consistency, and boundary accounting.

## Reviewer Notes

### Human Reviewer Flags
- The fallback strategy now mixes rollup and canonical data within one response: covered hours remain rollup-backed while uncovered hours use canonical sources.
- Fragmentation increases the number of interval values passed to SQL but no longer increases canonical or rollup query count.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Canonical interval batches retain an index-usable min/max envelope and add half-open interval membership predicates to AI Gateway, Exa, Coding Plan, and KiloClaw queries.
- Rolling totals and drivers batch uncovered interior intervals and normal partial-hour boundaries into one four-source canonical load.
- Covered rolling driver fragments are aggregated with one interval-filtered rollup query.
- Exact rolling reads remain inside repeatable-read, read-only transactions.

</details>
