### PR TITLE
fix(deploy): retry Axiom annotations

### DIFF
--- a/.github/workflows/promote-vercel-deployment.yml
+++ b/.github/workflows/promote-vercel-deployment.yml
@@ -107,10 +107,28 @@ jobs:
             --arg type "$project-production-deployment" \
             '{datasets:[$dataset], type:$type, time:$time, title:$title, description:$description, url:$url}')
 
-          curl --fail-with-body --silent --show-error \
-            --request POST \
-            --header "Authorization: Bearer $AXIOM_ANNOTATION_TOKEN" \
-            --header "X-Axiom-Org-Id: $AXIOM_ORG_ID" \
-            --header "Content-Type: application/json" \
-            --data "$payload" \
-            https://api.axiom.co/v2/annotations >/dev/null
+          for attempt in 1 2 3; do
+            if axiom_response=$(curl --fail-with-body --silent --show-error \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --request POST \
+              --header "Authorization: Bearer $AXIOM_ANNOTATION_TOKEN" \
+              --header "X-Axiom-Org-Id: $AXIOM_ORG_ID" \
+              --header "Content-Type: application/json" \
+              --data "$payload" \
+              https://api.axiom.co/v2/annotations 2>&1); then
+              echo "Created Axiom annotation for Vercel deployment $deployment_id"
+              exit 0
+            else
+              curl_exit=$?
+            fi
+
+            axiom_error=${axiom_response//$'\n'/ }
+            echo "Axiom annotation attempt $attempt/3 failed (curl exit $curl_exit): ${axiom_error:0:1000}"
+            if [ "$attempt" != "3" ]; then
+              sleep 2
+            fi
+          done
+
+          echo "::warning::Failed to create Axiom annotation after 3 attempts (last curl exit $curl_exit)"
+          exit "$curl_exit"


### PR DESCRIPTION
## Summary
Make production deployment annotations resilient to transient Axiom connectivity failures.

### Why this change is needed
A successful production promotion produced no Axiom annotation when the runner's proxy could not be resolved. The annotation is intentionally best-effort, but the single request gave transient network failures no chance to recover and exposed only a generic curl exit code.

### How this is addressed
- Retry failed Axiom annotation requests up to three times.
- Bound each request with connection and total timeouts.
- Report the curl exit code and a bounded error response for diagnosis.
- Log successful annotation creation while keeping failures non-blocking.

## Human Verification
- Simulated three consecutive curl failures and confirmed exit code 5 is preserved through the retry loop.
- Validated the workflow shell block with ShellCheck and the workflow with actionlint.

## Reviewer Notes
### Human Reviewer Flags
- Annotation failures remain non-blocking so observability outages cannot fail a successful production deployment.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Each attempt has a 10-second connection timeout and a 30-second total timeout.
- Error output is flattened and capped at 1,000 characters before logging.
- The final non-zero curl status is preserved for GitHub's `continue-on-error` handling.

</details>
