### PR TITLE
fix(deploy): keep Vercel inspect JSON clean

### DIFF
--- a/.github/workflows/promote-vercel-deployment.yml
+++ b/.github/workflows/promote-vercel-deployment.yml
@@ -59,8 +59,18 @@ jobs:
           # deployment reports READY instead of failing on the first check.
           deployment=""
           for attempt in 1 2 3 4 5; do
-            inspection=$(vercel inspect "$DEPLOYMENT_URL" --json --scope=kilocode --token="$VERCEL_TOKEN" 2>&1)
-            deployment_id=$(jq -r '.id // empty' <<<"$inspection" 2>/dev/null)
+            inspection_error=$(mktemp)
+            if ! inspection=$(vercel inspect "$DEPLOYMENT_URL" --json --scope=kilocode --token="$VERCEL_TOKEN" 2>"$inspection_error"); then
+              echo "::warning::vercel inspect failed (attempt $attempt): $(<"$inspection_error")"
+              rm "$inspection_error"
+              if [ "$attempt" != "5" ]; then
+                sleep 5
+              fi
+              continue
+            fi
+            rm "$inspection_error"
+
+            deployment_id=$(jq -r '.id // empty' <<<"$inspection" 2>/dev/null || true)
             if [ -z "$deployment_id" ]; then
               echo "::warning::vercel inspect did not return a deployment id (attempt $attempt): $inspection"
               if [ "$attempt" != "5" ]; then


### PR DESCRIPTION
## Summary
Prevent Vercel CLI progress output from corrupting deployment JSON used for Axiom annotations.

### Why this change is needed
Production annotation still exited with code 5 before making the Axiom request. `vercel inspect --json` writes progress output to stderr, and the workflow merged stderr into stdout. That made the captured value invalid JSON, causing `jq` to exit 5 under `bash -e`.

### How this is addressed
- Capture Vercel inspection JSON from stdout only.
- Capture stderr separately and report it when the CLI fails.
- Treat malformed or missing deployment IDs as retryable inspection failures.

## Human Verification
- Reproduced the failure with Vercel CLI 53.3.1 against deployment `dpl_Eg5FxKQBAjSkLXPGoyx4htRSxDgN`.
- Confirmed separated streams extract the deployment ID while Vercel progress output remains on stderr.
- Validated the workflow shell block with ShellCheck and the workflow with actionlint.

## Reviewer Notes
### Human Reviewer Flags
No notable items for human review beyond what the summary covers.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- The previous Axiom retry loop remains unchanged.
- Temporary stderr files are removed on both successful and failed inspection paths.
- JSON parsing is guarded so malformed output follows the existing retry path instead of terminating the shell.

</details>
