### PR TITLE
fix(ai-gateway): stop treating OpenRouter alpha/beta as free

### DIFF
--- a/apps/web/src/lib/ai-gateway/is-free-model.ts
+++ b/apps/web/src/lib/ai-gateway/is-free-model.ts
@@ -1,9 +1,5 @@
 import { KILO_AUTO_FREE_MODEL } from '@/lib/ai-gateway/auto-model';
-import {
-  isKiloExclusiveFreeModel,
-  isOpenRouterStealthModel,
-  kiloExclusiveModels,
-} from '@/lib/ai-gateway/models';
+import { isKiloExclusiveFreeModel, kiloExclusiveModels } from '@/lib/ai-gateway/models';
 import { isPublicIdExperimented } from '@/lib/ai-gateway/experiments/membership';
 
 /**
@@ -22,7 +18,6 @@ export async function isFreeModel(model: string): Promise<boolean> {
     model === KILO_AUTO_FREE_MODEL.id ||
     (model ?? '').endsWith(':free') ||
     model === 'openrouter/free' ||
-    isOpenRouterStealthModel(model ?? '') ||
     (await isPublicIdExperimented(model ?? ''))
   );
 }

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -22,13 +22,6 @@ describe('isFreeModel', () => {
       expect(await isFreeModel('openrouter/free')).toBe(true);
     });
 
-    test('should return true for OpenRouter stealth models (alpha/beta)', async () => {
-      expect(await isFreeModel('openrouter/model-alpha')).toBe(true);
-      expect(await isFreeModel('openrouter/model-beta')).toBe(true);
-      expect(await isFreeModel('openrouter/sonoma-dusk-alpha')).toBe(true);
-      expect(await isFreeModel('openrouter/sonoma-sky-beta')).toBe(true);
-    });
-
     test('should return true for enabled Kilo exclusive models with no pricing', async () => {
       // Test with known Kilo exclusive models that are enabled and have no pricing (free)
       const enabledFreeModels = kiloExclusiveModels.filter(
@@ -158,10 +151,15 @@ describe('isFreeModel', () => {
       expect(await isFreeModel('freemium')).toBe(false);
     });
 
-    test('should return false for OpenRouter models that do not end with -alpha or -beta', async () => {
+    test('should return false for OpenRouter models including alpha/beta', async () => {
       expect(await isFreeModel('openrouter/model')).toBe(false);
       expect(await isFreeModel('openrouter/model-gamma')).toBe(false);
       expect(await isFreeModel('openrouter/model-stable')).toBe(false);
+      expect(await isFreeModel('openrouter/model-alpha')).toBe(false);
+      expect(await isFreeModel('openrouter/model-beta')).toBe(false);
+      expect(await isFreeModel('openrouter/sonoma-dusk-alpha')).toBe(false);
+      expect(await isFreeModel('openrouter/sonoma-sky-beta')).toBe(false);
+      expect(await isFreeModel('openrouter/auto-beta')).toBe(false);
     });
 
     test('should return false for non-OpenRouter models ending with -alpha or -beta', async () => {
@@ -185,7 +183,6 @@ describe('isFreeModel', () => {
       expect(await isFreeModel('model:FREE')).toBe(false);
       expect(await isFreeModel('model:Free')).toBe(false);
       expect(await isFreeModel('OPENROUTER/FREE')).toBe(false);
-      expect(await isFreeModel('openrouter/model-ALPHA')).toBe(false);
     });
 
     test('should handle whitespace correctly', async () => {
@@ -193,7 +190,6 @@ describe('isFreeModel', () => {
       expect(await isFreeModel(' model:free')).toBe(true);
       expect(await isFreeModel(' openrouter/free')).toBe(false);
       expect(await isFreeModel('openrouter/free ')).toBe(false);
-      expect(await isFreeModel('openrouter/model-alpha ')).toBe(false);
     });
   });
 });

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -116,10 +116,6 @@ export function shouldRedactModelNameInResponse(provider: ProviderId, model: str
   );
 }
 
-export function isOpenRouterStealthModel(model: string): boolean {
-  return model.startsWith('openrouter/') && (model.endsWith('-alpha') || model.endsWith('-beta'));
-}
-
 export function isDeadFreeModel(model: string): boolean {
   return !!kiloExclusiveModels.find(
     m => m.public_id === model && m.status === 'disabled' && !m.pricing


### PR DESCRIPTION
## Summary
- OpenRouter models with IDs starting with `openrouter/` and ending in `-alpha` or `-beta` are no longer treated as free.
- Removes `isOpenRouterStealthModel` from the free-model check (covers cases like `openrouter/auto-beta`).
- Updates unit tests to expect these models to be paid.

## Test plan
- [ ] CI unit tests for `isFreeModel` / `models.test.ts`
- [ ] Confirm `openrouter/auto-beta` and other `openrouter/*-alpha|*-beta` IDs require balance / are not free
- [ ] Confirm `openrouter/free` and `*:free` models remain free