### PR TITLE
feat(ai-gateway): inject extra models for all Vercel providers

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -194,9 +194,7 @@ function injectExtraProviderModels(
       vercelModel.endpoints
         .map(
           endpoint =>
-            VercelInferenceProviderIdSchema.safeParse(
-              endpoint.provider_name ?? endpoint.tag
-            ).data
+            VercelInferenceProviderIdSchema.safeParse(endpoint.provider_name ?? endpoint.tag).data
         )
         .filter(p => p !== undefined)
     );

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -39,7 +39,7 @@ import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attri
 import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelIdToVercel';
 import {
   openRouterToVercelInferenceProviderId,
-  VercelUserByokInferenceProviderIdSchema,
+  VercelInferenceProviderIdSchema,
 } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 
 /**
@@ -176,7 +176,7 @@ async function fetchModelsForProvider(provider: OpenRouterProvider): Promise<Ope
   return data.data.models;
 }
 
-function injectExtraUserByokModels(
+function injectExtraProviderModels(
   vercelModels: Record<string, StoredModel>,
   providerModelData: Array<{ provider: OpenRouterProvider; models: OpenRouterModel[] }>
 ) {
@@ -194,7 +194,7 @@ function injectExtraUserByokModels(
       vercelModel.endpoints
         .map(
           endpoint =>
-            VercelUserByokInferenceProviderIdSchema.safeParse(
+            VercelInferenceProviderIdSchema.safeParse(
               endpoint.provider_name ?? endpoint.tag
             ).data
         )
@@ -202,7 +202,7 @@ function injectExtraUserByokModels(
     );
 
     for (const providerData of providerModelData) {
-      const vercelProviderId = VercelUserByokInferenceProviderIdSchema.safeParse(
+      const vercelProviderId = VercelInferenceProviderIdSchema.safeParse(
         openRouterToVercelInferenceProviderId(providerData.provider.slug)
       ).data;
       const endpoint = vercelModel.endpoints.find(e => e.provider_name === vercelProviderId);
@@ -225,7 +225,7 @@ function injectExtraUserByokModels(
           },
         };
         console.warn(
-          '[injectExtraUserByokModels] Adding missing model to user byok provider %s: %s',
+          '[injectExtraProviderModels] Adding missing model to provider %s: %s',
           providerData.provider.name,
           m.name
         );
@@ -268,7 +268,7 @@ async function syncProviders(
     )
   );
 
-  injectExtraUserByokModels(vercelModels, providerModelData);
+  injectExtraProviderModels(vercelModels, providerModelData);
 
   const mappedExtraModels = kiloExclusiveModels
     .flatMap(kfm => {


### PR DESCRIPTION
## Summary

Renames `injectExtraUserByokModels` to `injectExtraProviderModels` in the OpenRouter provider sync and broadens its matching from `VercelUserByokInferenceProviderIdSchema` to `VercelInferenceProviderIdSchema`, so all code-defined Vercel inference providers (not just the user BYOK subset) qualify for injecting missing models into the per-provider model lists.

## Verification

- [ ] Not manually tested — behavior change is a schema-swap in the sync path; relying on CI (typecheck/lint/tests) and automated review.

## Visual Changes

N/A

## Reviewer Notes

`VercelInferenceProviderIdSchema` is the union of `VercelUserByokInferenceProviderIdSchema` and `VercelNonUserByokInferenceProviderIdSchema` (see `inference-provider-id.ts`), so previously-excluded providers like `vertex`, `azure`, `cerebras`, etc. now also get missing models injected.