### PR TITLE
fix(cloud-agent): hide no-op preparation rows so 'Environment prepared' shows only on cold starts

### DIFF
--- a/apps/mobile/src/components/agents/session-transcript.test.ts
+++ b/apps/mobile/src/components/agents/session-transcript.test.ts
@@ -27,7 +27,51 @@ function attempt(id: string, triggerMessageId: string) {
     startedAt: 1,
     completedAt: 2,
     revision: 1,
-    steps: [],
+    // A real cold-start attempt always records at least one substantive step;
+    // without one a completed attempt is treated as a warm-reuse no-op and hidden.
+    steps: [
+      {
+        id: `${id}:step`,
+        key: 'cloning',
+        kind: 'phase' as const,
+        label: 'cloning',
+        status: 'completed' as const,
+        startedAt: 1,
+        revision: 1,
+      },
+    ],
+  };
+}
+
+function warmReuseAttempt(id: string, triggerMessageId: string) {
+  return {
+    id,
+    triggerMessageId,
+    status: 'completed' as const,
+    startedAt: 1,
+    completedAt: 2,
+    revision: 1,
+    // Only the always-on sandbox markers `ensureWrapper` emits for every delivery.
+    steps: [
+      {
+        id: `${id}:provision`,
+        key: 'sandbox_provision',
+        kind: 'phase' as const,
+        label: 'sandbox_provision',
+        status: 'completed' as const,
+        startedAt: 1,
+        revision: 1,
+      },
+      {
+        id: `${id}:boot`,
+        key: 'sandbox_boot',
+        kind: 'phase' as const,
+        label: 'sandbox_boot',
+        status: 'completed' as const,
+        startedAt: 1,
+        revision: 1,
+      },
+    ],
   };
 }
 
@@ -54,6 +98,29 @@ describe('session transcript', () => {
     expect(transcript.map(item => getSessionTranscriptItemKey(item))).toEqual([
       'msg_011',
       'preparation:attempt_older',
+    ]);
+  });
+
+  it('hides warm-reuse completed attempts that only ran synthetic sandbox markers', () => {
+    const transcript = mergeSessionTranscript(
+      [message('msg_001')],
+      [warmReuseAttempt('attempt_warm', 'msg_001')]
+    );
+
+    expect(transcript.map(item => getSessionTranscriptItemKey(item))).toEqual(['msg_001']);
+  });
+
+  it('keeps a running attempt even if it only has synthetic markers so far', () => {
+    const running = {
+      ...warmReuseAttempt('attempt_running', 'msg_001'),
+      status: 'running' as const,
+      completedAt: undefined,
+    };
+    const transcript = mergeSessionTranscript([message('msg_001')], [running]);
+
+    expect(transcript.map(item => getSessionTranscriptItemKey(item))).toEqual([
+      'msg_001',
+      'preparation:attempt_running',
     ]);
   });
 });

--- a/apps/mobile/src/components/agents/session-transcript.ts
+++ b/apps/mobile/src/components/agents/session-transcript.ts
@@ -1,3 +1,4 @@
+import { isNoOpCompletedPreparationAttempt } from 'cloud-agent-sdk/preparation-attempts';
 import { type PreparationAttempt, type StoredMessage } from 'cloud-agent-sdk';
 
 export type SessionTranscriptItem =
@@ -12,8 +13,16 @@ export function mergeSessionTranscript(
   messages: readonly StoredMessage[],
   preparationAttempts: readonly PreparationAttempt[]
 ): SessionTranscriptItem[] {
+  // `ensureWrapper` records a completed attempt for every message delivery,
+  // even warm reuse. Drop no-op completed attempts so "Environment prepared"
+  // surfaces only for genuine cold starts. Running and failed attempts are
+  // always kept: live progress may still arrive, and failures must stay visible.
+  const visibleAttempts = preparationAttempts.filter(
+    attempt => !isNoOpCompletedPreparationAttempt(attempt)
+  );
+
   const byMessageId = new Map<string, PreparationAttempt[]>();
-  for (const attempt of preparationAttempts) {
+  for (const attempt of visibleAttempts) {
     const attempts = byMessageId.get(attempt.triggerMessageId) ?? [];
     byMessageId.set(attempt.triggerMessageId, [...attempts, attempt]);
   }
@@ -27,7 +36,7 @@ export function mergeSessionTranscript(
       items.push({ type: 'preparation', attempt });
     }
   }
-  for (const attempt of preparationAttempts) {
+  for (const attempt of visibleAttempts) {
     if (!messageIds.has(attempt.triggerMessageId)) {
       items.push({ type: 'preparation', attempt });
     }

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
       'cloud-agent-sdk/remote-command-catalog': fileURLToPath(
         new URL('../../apps/web/src/lib/cloud-agent-sdk/remote-command-catalog.ts', import.meta.url)
       ),
+      'cloud-agent-sdk/preparation-attempts': fileURLToPath(
+        new URL('../../apps/web/src/lib/cloud-agent-sdk/preparation-attempts.ts', import.meta.url)
+      ),
       'cloud-agent-sdk': fileURLToPath(
         new URL('../../apps/web/src/lib/cloud-agent-sdk/index.ts', import.meta.url)
       ),

--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -20,6 +20,7 @@ import { ChildSessionDrawer } from './ChildSessionDrawer';
 import type { ChildSessionDrawerEntry, OpenChildSession } from './ChildSessionSection';
 import { SessionStatusIndicator } from './SessionStatusIndicator';
 import { PreparationRow } from './PreparationRow';
+import { isNoOpCompletedPreparationAttempt } from './preparation-summary';
 import { PreparationDrawer } from './PreparationDrawer';
 import { WorkingIndicator } from './WorkingIndicator';
 import { QuestionToolCard } from './QuestionToolCard';
@@ -761,6 +762,7 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const preparationByMessageId = useMemo(() => {
     const byMessageId = new Map<string, readonly PreparationAttempt[]>();
     for (const attempt of preparationAttempts) {
+      if (isNoOpCompletedPreparationAttempt(attempt)) continue;
       const attempts = byMessageId.get(attempt.triggerMessageId) ?? [];
       byMessageId.set(attempt.triggerMessageId, [...attempts, attempt]);
     }

--- a/apps/web/src/components/cloud-agent-next/preparation-summary.ts
+++ b/apps/web/src/components/cloud-agent-next/preparation-summary.ts
@@ -1,6 +1,8 @@
 import type { PreparationAttempt, PreparationStepSnapshot } from '@/lib/cloud-agent-sdk';
 import { formatAttemptDuration, humanizePhaseLabel } from './preparation-phases';
 
+export { isNoOpCompletedPreparationAttempt } from '@/lib/cloud-agent-sdk';
+
 /** The single line the chat row shows for a preparation attempt. */
 export type PreparationRowSummary =
   | { kind: 'starting' }

--- a/apps/web/src/lib/cloud-agent-sdk/index.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/index.ts
@@ -126,6 +126,8 @@ export { splitByContiguousPrefix } from './array-utils';
 export { calculateContextUsagePercentage } from './context-usage';
 export type { ContextUsage } from './context-usage';
 
+export { isNoOpCompletedPreparationAttempt } from './preparation-attempts';
+
 export type {
   KiloSdkMessageHistory,
   KiloSdkMessageHistoryPage,

--- a/apps/web/src/lib/cloud-agent-sdk/preparation-attempts.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/preparation-attempts.test.ts
@@ -1,0 +1,78 @@
+import type { PreparationAttempt, PreparationStepSnapshot } from './types';
+import { isNoOpCompletedPreparationAttempt } from './preparation-attempts';
+
+function step(overrides: Partial<PreparationStepSnapshot>): PreparationStepSnapshot {
+  return {
+    id: 'step-1',
+    key: 'workspace_setup',
+    kind: 'phase',
+    label: 'workspace setup',
+    status: 'running',
+    startedAt: 1000,
+    revision: 1,
+    ...overrides,
+  };
+}
+
+function attempt(overrides: Partial<PreparationAttempt>): PreparationAttempt {
+  return {
+    id: 'attempt-1',
+    triggerMessageId: 'message-1',
+    status: 'running',
+    startedAt: 1000,
+    revision: 1,
+    steps: [],
+    ...overrides,
+  };
+}
+
+describe('isNoOpCompletedPreparationAttempt', () => {
+  it('treats a completed attempt with no steps as a no-op', () => {
+    expect(isNoOpCompletedPreparationAttempt(attempt({ status: 'completed' }))).toBe(true);
+  });
+
+  it('treats a completed attempt with only synthetic sandbox markers as a no-op', () => {
+    const warmReuse = attempt({
+      status: 'completed',
+      steps: [
+        step({
+          id: 'a',
+          key: 'sandbox_provision',
+          label: 'sandbox_provision',
+          status: 'completed',
+        }),
+        step({ id: 'b', key: 'sandbox_boot', label: 'sandbox_boot', status: 'completed' }),
+      ],
+    });
+    expect(isNoOpCompletedPreparationAttempt(warmReuse)).toBe(true);
+  });
+
+  it('does not treat a completed attempt with a substantive step as a no-op', () => {
+    const coldStart = attempt({
+      status: 'completed',
+      steps: [
+        step({
+          id: 'a',
+          key: 'sandbox_provision',
+          label: 'sandbox_provision',
+          status: 'completed',
+        }),
+        step({ id: 'b', key: 'cloning', label: 'cloning', status: 'completed' }),
+      ],
+    });
+    expect(isNoOpCompletedPreparationAttempt(coldStart)).toBe(false);
+  });
+
+  it('never treats a running attempt as a no-op', () => {
+    const running = attempt({
+      status: 'running',
+      steps: [step({ key: 'sandbox_provision', label: 'sandbox_provision' })],
+    });
+    expect(isNoOpCompletedPreparationAttempt(running)).toBe(false);
+  });
+
+  it('never treats a failed attempt as a no-op', () => {
+    const failed = attempt({ status: 'failed' });
+    expect(isNoOpCompletedPreparationAttempt(failed)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/cloud-agent-sdk/preparation-attempts.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/preparation-attempts.ts
@@ -1,0 +1,23 @@
+import type { PreparationAttempt, PreparationStepSnapshot } from './types';
+
+/**
+ * Steps `ensureWrapper` emits unconditionally on every message delivery, even
+ * when reusing a warm sandbox/wrapper. Their presence alone does not prove a
+ * cold start happened.
+ */
+const SYNTHETIC_PREPARATION_STEPS = new Set<PreparationStepSnapshot['key']>([
+  'sandbox_provision',
+  'sandbox_boot',
+]);
+
+/**
+ * A completed attempt that only ever ran the always-on sandbox acquisition/boot
+ * markers performed no real environment provisioning (warm reuse). Hide its
+ * "Environment prepared" indicator so it surfaces only true cold starts.
+ * Running attempts are never treated as no-ops: their substantive steps may
+ * still arrive, and hiding them would risk suppressing live cold-start progress.
+ */
+export function isNoOpCompletedPreparationAttempt(attempt: PreparationAttempt): boolean {
+  if (attempt.status !== 'completed') return false;
+  return attempt.steps.every(step => SYNTHETIC_PREPARATION_STEPS.has(step.key));
+}


### PR DESCRIPTION
## Problem

"Environment prepared" appeared beneath every message in both the web and mobile cloud-agent chat UIs, not just on cold starts.

## Root cause

`ensureWrapper` runs on every message delivery and unconditionally emits the preparation progress markers `sandbox_provision` (`cloudflare-agent-sandbox.ts:529`) and `sandbox_boot` (`:639`), even when reusing a warm sandbox/wrapper. The first `onProgress` call creates an `attempt_started` snapshot (`preparation-progress.ts:77`), and `executeDirectly` always finalizes the recorder as `completed` on success (`CloudAgentSession.ts:3229`). So every message produced a completed attempt, which the UI rendered as "Environment prepared" (`PreparationRow.tsx` / `PreparationDrawer.tsx` on web; `PreparationGroup` on mobile).

## Fix

Surface the indicator only for genuine cold starts by hiding no-op completed attempts at the UI layer (the option chosen for this change):

- A **completed** attempt whose steps are only the always-on synthetic markers (`sandbox_provision`, `sandbox_boot`) is treated as a warm-reuse no-op and hidden.
- A real cold start always records at least one substantive step (`cloning`, `workspace_setup`, `kilo_session`, `kilo_server`, …), so it stays visible.
- **Running** and **failed** attempts are never hidden, so live cold-start progress and failures remain visible.

### Shared SDK
- `apps/web/src/lib/cloud-agent-sdk/preparation-attempts.ts` — new `isNoOpCompletedPreparationAttempt()` + `SYNTHETIC_PREPARATION_STEPS` (single source of truth for both apps).
- `apps/web/src/lib/cloud-agent-sdk/preparation-attempts.test.ts` — canonical tests.
- `apps/web/src/lib/cloud-agent-sdk/index.ts` — exports the predicate.
- `apps/web/src/components/cloud-agent-next/preparation-summary.ts` — replaced the local copy with a re-export so existing web import sites are unchanged.

### Web
- `apps/web/src/components/cloud-agent-next/CloudChatPage.tsx` — `preparationByMessageId` skips no-op completed attempts, so neither `StaticMessages` nor `DynamicMessages` render the row.

### Mobile
- `apps/mobile/src/components/agents/session-transcript.ts` — `mergeSessionTranscript` filters no-op completed attempts before grouping; this is the single chokepoint for both inline and orphaned attempts.
- `apps/mobile/vitest.config.ts` — added the `cloud-agent-sdk/preparation-attempts` alias, matching the existing `context-usage`/`cli-model`/`message-id`/`remote-model-order` pattern (vitest does not honor the `cloud-agent-sdk/*` tsconfig path; Metro does, so runtime is unaffected).
- `apps/mobile/src/components/agents/session-transcript.test.ts` — existing fixtures upgraded to realistic cold-start shapes (a `cloning` step so they remain visible); added a warm-reuse no-op test and a running-attempt-stays-visible test.

## Verification

- Mobile: `pnpm test` — 137 files / 927 tests pass. `pnpm lint` and `pnpm typecheck` clean for changed files (pre-existing unrelated errors elsewhere).
- Web: `pnpm run lint` clean (0 errors). Web Jest (`pnpm test`) could not run in this environment — its global setup requires PostgreSQL. `tsgo --noEmit` exceeded the sandbox time budget (large app, no errors emitted before timeout). The web change is a behavior-preserving refactor (predicate moved to the SDK and re-exported), so please run `pnpm test`/`pnpm typecheck` locally to confirm.
- `pnpm format:changed` and `git diff --check` clean.

## Known limitation

A warm-reuse attempt briefly shows "Preparing environment" while `running` before it completes and gets hidden. If that flicker is noticeable, the durable fix is to gate `onProgress` to genuine cold work in `ensureWrapper` (backend option).