### PR TITLE
Default Kimi K3 to max reasoning effort

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -34,6 +34,12 @@ export const REASONING_VARIANTS_LOW_MEDIUM_HIGH = {
   high: { reasoning: { enabled: true, effort: 'high' } },
 } as const;
 
+export const REASONING_VARIANTS_MAX_HIGH_LOW = {
+  max: { reasoning: { enabled: true, effort: 'max' } },
+  high: { reasoning: { enabled: true, effort: 'high' } },
+  low: { reasoning: { enabled: true, effort: 'low' } },
+} as const;
+
 export const REASONING_VARIANTS_MINIMAL_LOW_MEDIUM_HIGH = {
   minimal: { reasoning: { enabled: true, effort: 'minimal' } },
   ...REASONING_VARIANTS_LOW_MEDIUM_HIGH,
@@ -95,7 +101,10 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
   if (model.includes('mistral-medium-3-5')) {
     return REASONING_VARIANTS_BINARY;
   }
-  if (model.includes('kimi-k2.7-code') || model.includes('kimi-k3')) {
+  if (model.includes('kimi-k3')) {
+    return REASONING_VARIANTS_MAX_HIGH_LOW;
+  }
+  if (model.includes('kimi-k2.7-code')) {
     return REASONING_VARIANTS_THINKING_ONLY;
   }
   if (


### PR DESCRIPTION
## Summary
- add `max`, `high`, and `low` reasoning variants in that order
- map `kimi-k3` to the new variant set so `max` is the first/default option
- keep `kimi-k2.7-code` on the existing thinking-only setting

## Verification
- `pnpm --filter web test -- --runInBand apps/web/src/lib/ai-gateway/custom-llm/order-opencode-variants.test.ts apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `git diff --check`