### PR TITLE
fix(gitlab): accept project lookup metadata

### DIFF
--- a/services/git-token-service/src/gitlab-runtime-token-resolver.ts
+++ b/services/git-token-service/src/gitlab-runtime-token-resolver.ts
@@ -77,7 +77,7 @@ type GitLabCandidateEvaluation =
   | { status: 'lookup_failed' }
   | { status: 'token_failed'; failure: GetGitLabTokenFailure };
 
-const GitLabProjectIdentitySchema = z.object({ id: z.number().int().positive() }).strict();
+const GitLabProjectIdentitySchema = z.object({ id: z.number().int().positive() });
 const MAX_PROJECT_LOOKUP_RESPONSE_BYTES = 16_000;
 
 function mapCredentialFailure(status: string, project = false): GetGitLabTokenFailure {

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -1765,8 +1765,18 @@ describe('GitTokenRPCEntrypoint GitLab session capability RPCs', () => {
     }
   );
 
-  it('issues an opaque project-source capability for a code-review repository without exposing its token', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ id: 42 })));
+  it('issues an opaque project-source capability from a GitLab project response without exposing its token', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        Response.json({
+          id: 42,
+          name: 'widgets',
+          path_with_namespace: 'acme/widgets',
+          web_url: 'https://gitlab.com/acme/widgets',
+        })
+      )
+    );
     serviceMocks.findAuthorizedGitLabIntegrations.mockResolvedValueOnce({
       success: true,
       integrations: [


### PR DESCRIPTION
## Summary

Allow GitLab project lookup responses to include standard metadata while continuing to require a valid positive project ID.

Add regression coverage for a representative GitLab project response.

## Verification

- [ ] Manual testing not run; this is a non-UI resolver change covered by focused automated checks.

## Visual Changes

N/A

## Reviewer Notes

The identity parser now ignores non-identity response fields rather than rejecting the entire GitLab API response.