### PR TITLE
fix(organizations): save pending balance alert email

### DIFF
--- a/apps/web/src/components/organizations/SpendingAlertsModal.test.ts
+++ b/apps/web/src/components/organizations/SpendingAlertsModal.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from '@jest/globals';
+import { resolveNotificationEmails } from './spending-alerts-form';
+
+describe('resolveNotificationEmails', () => {
+  test('uses a valid pending email as the first recipient', () => {
+    expect(resolveNotificationEmails([], ' billing@example.com ')).toEqual(['billing@example.com']);
+  });
+
+  test('adds a valid pending email to existing recipients', () => {
+    expect(resolveNotificationEmails(['owner@example.com'], 'billing@example.com')).toEqual([
+      'owner@example.com',
+      'billing@example.com',
+    ]);
+  });
+
+  test('does not add a duplicate pending email', () => {
+    expect(resolveNotificationEmails(['billing@example.com'], ' billing@example.com ')).toEqual([
+      'billing@example.com',
+    ]);
+  });
+
+  test('rejects a non-empty invalid pending email', () => {
+    expect(resolveNotificationEmails(['owner@example.com'], 'not-an-email')).toBeNull();
+  });
+
+  test('keeps existing recipients when the input is empty', () => {
+    expect(resolveNotificationEmails(['owner@example.com'], '  ')).toEqual(['owner@example.com']);
+  });
+});

--- a/apps/web/src/components/organizations/SpendingAlertsModal.tsx
+++ b/apps/web/src/components/organizations/SpendingAlertsModal.tsx
@@ -17,17 +17,13 @@ import type { OrganizationSettings } from '@/lib/organizations/organization-type
 import { Loader2, Plus, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { useUpdateMinimumBalanceAlert } from '@/app/api/organizations/hooks';
+import { isValidEmail, resolveNotificationEmails } from './spending-alerts-form';
 
 type SpendingAlertsModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   organizationId: string;
   settings: OrganizationSettings | undefined;
-};
-
-const isValidEmail = (email: string): boolean => {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return emailRegex.test(email.trim());
 };
 
 export function SpendingAlertsModal({
@@ -102,26 +98,34 @@ export function SpendingAlertsModal({
   };
 
   const parsedBalance = parseFloat(minimumBalance);
+  const notificationEmails = resolveNotificationEmails(emails, newEmail);
   const isBalanceValid = !enabled || (!isNaN(parsedBalance) && parsedBalance > 0);
-  const hasEmails = !enabled || emails.length > 0;
-  const canSave = isBalanceValid && hasEmails;
+  const areEmailsValid = !enabled || (notificationEmails !== null && notificationEmails.length > 0);
+  const canSave = isBalanceValid && areEmailsValid;
 
   const handleSave = () => {
     if (!canSave) {
       if (!isBalanceValid) {
         toast.error('Please enter a valid minimum balance greater than $0');
-      } else if (!hasEmails) {
-        toast.error('Please add at least one email address');
+      } else if (!areEmailsValid) {
+        toast.error(
+          newEmail.trim()
+            ? 'Please enter a valid email address'
+            : 'Please enter at least one email address'
+        );
       }
       return;
     }
+
+    const emailsToSave = enabled ? notificationEmails : undefined;
+    if (emailsToSave === null) return;
 
     updateMinimumBalanceAlertMutation.mutate(
       {
         organizationId,
         enabled,
         minimum_balance: enabled ? parsedBalance : undefined,
-        minimum_balance_alert_email: enabled ? emails : undefined,
+        minimum_balance_alert_email: emailsToSave,
       },
       {
         onSuccess: () => {
@@ -205,14 +209,39 @@ export function SpendingAlertsModal({
                       setNewEmail(e.target.value);
                       setEmailError(null);
                     }}
+                    onBlur={() => {
+                      if (newEmail.trim() && !isValidEmail(newEmail)) {
+                        setEmailError('Please enter a valid email address');
+                      }
+                    }}
                     onKeyDown={handleKeyDown}
+                    aria-describedby={
+                      emailError
+                        ? 'notification-email-help notification-email-error'
+                        : 'notification-email-help'
+                    }
+                    aria-invalid={emailError !== null}
                     className={emailError ? 'border-red-500 focus:border-red-500' : ''}
                   />
-                  <Button type="button" variant="outline" size="icon" onClick={handleAddEmail}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={handleAddEmail}
+                    aria-label="Add another notification email"
+                  >
                     <Plus className="h-4 w-4" />
                   </Button>
                 </div>
-                {emailError && <p className="text-sm text-red-600">{emailError}</p>}
+                {emailError && (
+                  <p id="notification-email-error" className="text-sm text-red-600">
+                    {emailError}
+                  </p>
+                )}
+
+                <p id="notification-email-help" className="text-muted-foreground text-xs">
+                  Save adds this address automatically. Use the add button for another.
+                </p>
 
                 {/* Email list display */}
                 {emails.length > 0 && (
@@ -227,18 +256,13 @@ export function SpendingAlertsModal({
                           type="button"
                           onClick={() => handleRemoveEmail(email)}
                           className="text-muted-foreground hover:text-foreground"
+                          aria-label={`Remove ${email}`}
                         >
                           <X className="h-4 w-4" />
                         </button>
                       </div>
                     ))}
                   </div>
-                )}
-
-                {emails.length === 0 && (
-                  <p className="text-muted-foreground text-xs">
-                    Add at least one email address to receive alerts.
-                  </p>
                 )}
               </div>
             </>

--- a/apps/web/src/components/organizations/spending-alerts-form.ts
+++ b/apps/web/src/components/organizations/spending-alerts-form.ts
@@ -1,0 +1,14 @@
+export function isValidEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email.trim());
+}
+
+export function resolveNotificationEmails(emails: string[], pendingEmail: string): string[] | null {
+  const trimmedEmail = pendingEmail.trim();
+
+  if (!trimmedEmail) return emails;
+  if (!isValidEmail(trimmedEmail)) return null;
+  if (emails.includes(trimmedEmail)) return emails;
+
+  return [...emails, trimmedEmail];
+}


### PR DESCRIPTION
## Summary
Allow organization owners to save a minimum balance alert with a valid email still in the notification input.

### Why this change is needed
The modal previously required users to press the add button before Save became available. For the common single-recipient case, the populated email field looked complete even though the address had not been added to the internal recipient list.

### How this is addressed
- Treat a valid pending email as a recipient when determining whether Save is available.
- Add the pending address automatically when saving while preserving multi-recipient support.
- Reject invalid pending input instead of silently omitting it.
- Trim and deduplicate pending addresses.
- Improve email-field guidance and accessible labels.
- Add focused coverage for first, additional, duplicate, invalid, and empty pending-address cases.

## Human Verification
- Evaluated recipient resolution directly for single-recipient, multi-recipient, duplicate, invalid, and empty-input behavior.

## Reviewer Notes

### Human Reviewer Flags
- The add button remains available for multiple recipients, but it is no longer required for the single-recipient path.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Client-side email syntax validation remains consistent with the modal's existing behavior.
- The server continues to enforce a positive threshold and at least one valid notification email.
- The focused Jest suite could not run locally because PostgreSQL and Docker were unavailable; web typecheck and lint passed.

</details>
