### PR TITLE
feat(ai-gateway): prefix openrouter/ model display names with OpenRouter

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -127,6 +127,29 @@ describe('formatName', () => {
     const model = buildModel({ created: 0 });
     expect(formatName(model, NOT_PREFERRED)).toBe('Test Model');
   });
+
+  it('prefixes the name with OpenRouter for openrouter/ models without it', () => {
+    const model = buildModel({ id: 'openrouter/auto', created: 0 });
+    expect(formatName(model, NOT_PREFERRED)).toBe('OpenRouter Test Model');
+  });
+
+  it('does not prefix the name when it already contains OpenRouter', () => {
+    const model = buildModel({ id: 'openrouter/auto', name: 'OpenRouter Test Model', created: 0 });
+    expect(formatName(model, NOT_PREFERRED)).toBe('OpenRouter Test Model');
+  });
+
+  it('does not prefix the name for non-openrouter/ models', () => {
+    const model = buildModel({ id: 'vendor/model', created: 0 });
+    expect(formatName(model, NOT_PREFERRED)).toBe('Test Model');
+  });
+
+  it('prefixes the name before appending markers', () => {
+    const model = buildModel({
+      id: 'openrouter/auto',
+      pricing: { prompt: '0.00001', completion: '0' },
+    });
+    expect(formatName(model, NOT_PREFERRED)).toBe('OpenRouter Test Model ($$$$)');
+  });
 });
 
 describe('undoPricingDiscount', () => {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -76,13 +76,17 @@ function buildAutoModels(): OpenRouterModel[] {
 }
 
 export function formatName(model: OpenRouterModel, preferredIndex: number) {
+  const name =
+    model.id.startsWith('openrouter/') && !model.name.includes('OpenRouter')
+      ? 'OpenRouter ' + model.name
+      : model.name;
   const promptPrice = Number.parseFloat(model.pricing.prompt);
   const isExpensive = Number.isFinite(promptPrice) && promptPrice >= 0.00001; // Opus 4.8 Fast price
-  if (isExpensive) return model.name + ' ($$$$)';
-  if (model.name.endsWith(')')) return model.name;
+  if (isExpensive) return name + ' ($$$$)';
+  if (name.endsWith(')')) return name;
   const ageDays = (Date.now() / 1_000 - model.created) / (24 * 3600);
   const isNew = preferredIndex >= 0 && ageDays >= 0 && ageDays < 7;
-  if (isNew) return model.name + ' (new)';
+  if (isNew) return name + ' (new)';
   if (model.expiration_date) {
     const expirationDate = new Date(model.expiration_date);
     if (expirationDate <= addMonths(new Date(), 1)) {
@@ -91,10 +95,10 @@ export function formatName(model: OpenRouterModel, preferredIndex: number) {
         day: 'numeric',
         timeZone: 'UTC',
       });
-      return model.name + ' (retires ' + suffix + ')';
+      return name + ' (retires ' + suffix + ')';
     }
   }
-  return model.name;
+  return name;
 }
 
 type EndpointPricing = NonNullable<StoredModel['endpoints'][number]['pricing']>;


### PR DESCRIPTION
When a model id starts with `openrouter/` but its display name does not contain 'OpenRouter', prefix the display name with `OpenRouter ` in `formatName` (apps/web/src/lib/ai-gateway/providers/openrouter/index.ts).

The prefix is applied before any markers (`($$$$)`, `(new)`, `(retires ...)`) are appended, and skipped when the name already contains 'OpenRouter'. Added test coverage for the new behavior.