### PR TITLE
fix(cost-insights): show spend in partial chart periods

### DIFF
--- a/apps/web/src/components/cost-insights/overview/SpendEvidenceCard.tsx
+++ b/apps/web/src/components/cost-insights/overview/SpendEvidenceCard.tsx
@@ -46,7 +46,7 @@ export function SpendEvidenceCard({
     '90d': 'Last 90 days',
   }[range];
   const highest = evidence
-    .filter(point => point.coverage === 'complete')
+    .filter(point => point.coverage !== 'unavailable')
     .reduce<(typeof evidence)[number] | undefined>((currentHighest, point) => {
       if (!currentHighest) return point;
       const currentTotal = currentHighest.variableUsd + currentHighest.scheduledUsd;
@@ -105,7 +105,7 @@ export function SpendEvidenceCard({
               ? `${rangeLabel}: spend total unavailable because one or more periods have incomplete coverage.`
               : `${rangeLabel}: ${money(completeTotal)} total.`}{' '}
             {highest
-              ? `Highest complete period was ${highest.label} at ${money(highest.variableUsd + highest.scheduledUsd)}.`
+              ? `Highest period with spend evidence was ${highest.label} at ${money(highest.variableUsd + highest.scheduledUsd)}.`
               : ''}
           </p>
           <p id={chartInstructionsId} className="sr-only">
@@ -135,9 +135,9 @@ export function SpendEvidenceCard({
                   const isPeak = highest !== undefined && point.periodStart === highest.periodStart;
                   const showTick = index % tickStride === 0 || index === evidence.length - 1;
                   const accessibilityLabel =
-                    point.coverage === 'complete'
-                      ? `${point.label}: ${money(pointTotal)} total, ${money(point.variableUsd)} usage-based, ${money(point.scheduledUsd)} scheduled`
-                      : `${point.label}: spend data unavailable, ${point.coveredHours} of ${point.totalHours} hours covered`;
+                    point.coverage === 'unavailable'
+                      ? `${point.label}: spend data unavailable, ${point.coveredHours} of ${point.totalHours} hours covered`
+                      : `${point.label}: ${point.coverage === 'partial' ? 'at least ' : ''}${money(pointTotal)} total, ${money(point.variableUsd)} usage-based, ${money(point.scheduledUsd)} scheduled${point.coverage === 'partial' ? `, ${point.coveredHours} of ${point.totalHours} hours covered` : ''}`;
                   return (
                     <Tooltip key={point.periodStart}>
                       <TooltipTrigger asChild>
@@ -153,7 +153,7 @@ export function SpendEvidenceCard({
                           onKeyDown={event => handleBarKeyDown(event, index)}
                         >
                           <span className="flex h-5 w-full items-end justify-center">
-                            {isPeak && point.coverage === 'complete' && (
+                            {isPeak && point.coverage !== 'unavailable' && (
                               <span className="type-label font-mono tabular-nums whitespace-nowrap">
                                 {money(pointTotal)}
                               </span>
@@ -163,16 +163,18 @@ export function SpendEvidenceCard({
                             <span
                               className={cn(
                                 'group-hover:ring-foreground/50 mx-auto flex w-full max-w-10 flex-col-reverse overflow-hidden rounded-t-sm transition-[filter,box-shadow] duration-150 group-hover:brightness-110 group-focus-visible:brightness-110',
-                                point.coverage !== 'complete' &&
+                                point.coverage === 'partial' &&
+                                  'border-border-strong border border-dashed',
+                                point.coverage === 'unavailable' &&
                                   'border-border-strong bg-surface-overlay h-2 border border-dashed'
                               )}
                               style={
-                                point.coverage === 'complete'
+                                point.coverage !== 'unavailable'
                                   ? { height: `${totalHeight}%` }
                                   : undefined
                               }
                             >
-                              {point.coverage === 'complete' && (
+                              {point.coverage !== 'unavailable' && (
                                 <>
                                   <span
                                     className="bg-chart-1"
@@ -198,9 +200,11 @@ export function SpendEvidenceCard({
                       </TooltipTrigger>
                       <TooltipContent side="top" sideOffset={8} className="min-w-44 p-3">
                         <div className="type-label font-medium">{point.label}</div>
-                        {point.coverage === 'complete' ? (
+                        {point.coverage !== 'unavailable' ? (
                           <dl className="mt-2 grid grid-cols-[1fr_auto] gap-x-4 gap-y-1 type-label">
-                            <dt className="text-muted-foreground">Total</dt>
+                            <dt className="text-muted-foreground">
+                              {point.coverage === 'partial' ? 'Known spend' : 'Total'}
+                            </dt>
                             <dd className="text-right font-mono font-semibold tabular-nums">
                               {money(pointTotal)}
                             </dd>
@@ -218,6 +222,11 @@ export function SpendEvidenceCard({
                             <dd className="text-right font-mono tabular-nums">
                               {money(point.scheduledUsd)}
                             </dd>
+                            {point.coverage === 'partial' && (
+                              <dt className="text-muted-foreground col-span-2 mt-1">
+                                Partial coverage: {point.coveredHours} of {point.totalHours} hours.
+                              </dt>
+                            )}
                           </dl>
                         ) : (
                           <p className="type-label text-muted-foreground mt-2">

--- a/apps/web/src/components/cost-insights/types.ts
+++ b/apps/web/src/components/cost-insights/types.ts
@@ -30,12 +30,12 @@ type SpendEvidencePointBase = {
 
 export type SpendEvidencePoint =
   | (SpendEvidencePointBase & {
-      coverage: 'complete';
+      coverage: 'complete' | 'partial';
       variableUsd: number;
       scheduledUsd: number;
     })
   | (SpendEvidencePointBase & {
-      coverage: 'partial' | 'unavailable';
+      coverage: 'unavailable';
       variableUsd: null;
       scheduledUsd: null;
     });

--- a/apps/web/src/components/cost-insights/types.ts
+++ b/apps/web/src/components/cost-insights/types.ts
@@ -30,7 +30,12 @@ type SpendEvidencePointBase = {
 
 export type SpendEvidencePoint =
   | (SpendEvidencePointBase & {
-      coverage: 'complete' | 'partial';
+      coverage: 'complete';
+      variableUsd: number;
+      scheduledUsd: number;
+    })
+  | (SpendEvidencePointBase & {
+      coverage: 'partial';
       variableUsd: number;
       scheduledUsd: number;
     })

--- a/apps/web/src/lib/cost-insights/presenter.test.ts
+++ b/apps/web/src/lib/cost-insights/presenter.test.ts
@@ -555,7 +555,7 @@ describe('Cost Insights presenter', () => {
     ).toThrow('Covered Cost Insights evidence must include both spend categories.');
   });
 
-  it('marks aggregate evidence partial without exposing an understated covered subtotal', () => {
+  it('shows known spend in partial aggregate evidence without presenting it as a complete total', () => {
     const points = [
       {
         hourStart: '2026-06-25T22:00:00.000Z',
@@ -594,8 +594,8 @@ describe('Cost Insights presenter', () => {
         coverage: 'partial',
         coveredHours: 1,
         totalHours: 2,
-        variableUsd: null,
-        scheduledUsd: null,
+        variableUsd: 2,
+        scheduledUsd: 1,
       },
       {
         label: 'Jun 26',

--- a/apps/web/src/lib/cost-insights/presenter.ts
+++ b/apps/web/src/lib/cost-insights/presenter.ts
@@ -468,7 +468,7 @@ function buildMetrics(params: {
         params.currentHourVariableMicrodollars === null
           ? 'Current-hour spend evidence is unavailable'
           : params.currentHourVariableMicrodollars >= params.anomalyThresholdMicrodollars
-            ? 'Above current alert level'
+            ? 'Unusually high for this account'
             : `Typical hour: ${money(params.anomalyBaselineMicrodollars)}`,
       tone:
         params.currentHourVariableMicrodollars !== null &&

--- a/apps/web/src/lib/cost-insights/presenter.ts
+++ b/apps/web/src/lib/cost-insights/presenter.ts
@@ -225,10 +225,6 @@ function presentEvidenceBucket(points: OwnerHourlySpend[]): SpendEvidencePoint {
   if (covered.length === 0) {
     return { ...common, coverage: 'unavailable', variableUsd: null, scheduledUsd: null };
   }
-  if (covered.length !== points.length) {
-    return { ...common, coverage: 'partial', variableUsd: null, scheduledUsd: null };
-  }
-
   let variableMicrodollars = 0;
   let scheduledMicrodollars = 0;
   for (const point of covered) {
@@ -238,7 +234,7 @@ function presentEvidenceBucket(points: OwnerHourlySpend[]): SpendEvidencePoint {
   }
   return {
     ...common,
-    coverage: 'complete',
+    coverage: covered.length === points.length ? 'complete' : 'partial',
     variableUsd: microdollarsToUsd(variableMicrodollars),
     scheduledUsd: microdollarsToUsd(scheduledMicrodollars),
   };


### PR DESCRIPTION
## Summary

Show known Cost Insights spend when a chart period has incomplete rollup coverage.

### Why this change is needed

Recent query optimizations stopped loading canonical data for hours before rollup coverage. Daily and weekly chart buckets can therefore contain both covered and unavailable hours.

The presenter treated those partial buckets as having no spend, so the chart rendered dashed zero-value bars even when captured spend appeared in the contributor list.

### How this is addressed

- Preserve spend totals from covered hours in partial chart buckets.
- Render partial spend as a visible bar with a dashed outline.
- Label partial values as known minimum spend instead of complete totals.
- Keep fully unavailable periods empty.
- Describe anomaly detection as unusually high spend without implying a configured alert fired.
- Update the evidence contract and presenter regression coverage.

## Human Verification

- The local code-review workflow passed all eight quality focuses with no findings.
- React Doctor scanned the changed React code and reported no issues.

## Reviewer Notes

### Human Reviewer Flags

- Partial-period values intentionally represent a lower bound. The chart shows captured spend while retaining incomplete-coverage warnings.

### Code Reviewer Agent

<details>
<summary>Code Reviewer Notes</summary>

- Partial evidence carries numeric category values; only unavailable evidence retains null values.
- Tooltips and screen-reader labels distinguish known partial spend from complete totals.
- The focused Jest suite could not run because the local PostgreSQL service and Docker daemon were unavailable. Type checking, linting, formatting, and static React analysis passed.

</details>
