### PR TITLE
feat(code-reviewer) Add council per repo webhook

### DIFF
--- a/apps/web/src/app/(app)/organizations/[id]/code-reviews/ReviewAgentPageClient.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/code-reviews/ReviewAgentPageClient.tsx
@@ -74,6 +74,9 @@ export function ReviewAgentPageClient({
     )
   );
   const councilEntitled = councilEntitlement?.entitled ?? false;
+  // Same gate as the manual council UI: local dev, or an entitled org behind the rollout flag.
+  const councilUiEnabled =
+    localCodeReviewDevelopmentEnabled || (councilEntitled && !!councilFlagEnabled);
 
   const handlePlatformChange = (platform: Platform) => {
     const params = new URLSearchParams();
@@ -297,7 +300,11 @@ export function ReviewAgentPageClient({
             </TabsList>
 
             <TabsContent value="config" className="mt-6 space-y-4">
-              <ReviewConfigForm organizationId={organizationId} platform="github" />
+              <ReviewConfigForm
+                organizationId={organizationId}
+                platform="github"
+                councilUiEnabled={councilUiEnabled}
+              />
             </TabsContent>
 
             <TabsContent value="jobs" className="mt-6 space-y-4">
@@ -397,6 +404,7 @@ export function ReviewAgentPageClient({
               <ReviewConfigForm
                 organizationId={organizationId}
                 platform="gitlab"
+                councilUiEnabled={councilUiEnabled}
                 gitlabStatusData={
                   gitlabStatusData
                     ? {

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -107,6 +107,8 @@ import {
   getManualCodeReviewConfig,
   shouldPublishCodeReviewToProvider,
 } from '@/lib/code-reviews/manual-config';
+import { getAgentConfigForOwner } from '@/lib/agent-config/db/agent-configs';
+import type { CodeReviewAgentConfig } from '@kilocode/db/schema-types';
 
 const CallbackTextTruncationSchema = z
   .object({
@@ -533,6 +535,25 @@ async function shouldSkipAutoRetryForFailedSessionUsage(params: {
 
 function isSupersededReview(review: CloudAgentCodeReview): boolean {
   return review.terminal_reason === 'superseded';
+}
+
+/**
+ * Resolves the org/user Code Reviewer config for a review, used as the council-config source for
+ * AUTOMATED (webhook) council reviews, which carry no `manual_config`. Manual reviews resolve
+ * their council from `manual_config` and never need this. Returns null on any gap (no owner, no
+ * config) so council finalization fails safe rather than throwing.
+ */
+async function resolveOrgCodeReviewAgentConfig(
+  review: CloudAgentCodeReview
+): Promise<CodeReviewAgentConfig | null> {
+  const owner = review.owned_by_organization_id
+    ? ({ type: 'org', id: review.owned_by_organization_id } as const)
+    : review.owned_by_user_id
+      ? ({ type: 'user', id: review.owned_by_user_id } as const)
+      : null;
+  if (!owner) return null;
+  const agentConfig = await getAgentConfigForOwner(owner, 'code_review', review.platform);
+  return agentConfig ? (agentConfig.config as CodeReviewAgentConfig) : null;
 }
 
 async function resolveTerminalOwner(
@@ -1060,6 +1081,15 @@ export async function POST(
     // Code-owned council outcome for a completed council run. Set on whichever completion path
     // runs below, then used to drive the merge gate (the council LLM never sets `gateResult`).
     let councilResult: CodeReviewCouncilResult | null = null;
+    // Council-config source for AUTOMATED (webhook) council reviews, which carry no `manual_config`.
+    // Fetched once (only for completed council reviews without a manual config) and reused on
+    // whichever completion path runs. Manual/standard reviews skip the lookup.
+    const councilOrgAgentConfig: CodeReviewAgentConfig | null =
+      status === 'completed' &&
+      review.review_type === 'council' &&
+      getManualCodeReviewConfig(review) === null
+        ? await resolveOrgCodeReviewAgentConfig(review)
+        : null;
 
     if (
       status === 'completed' &&
@@ -1076,6 +1106,7 @@ export async function POST(
       councilResult = computeCouncilResultForReview({
         review,
         lastAssistantMessageText: rawPayload.lastAssistantMessageText,
+        orgAgentConfig: councilOrgAgentConfig,
       });
       const completionResult = await finalizeCompletedCodeReviewWithAnalytics({
         codeReviewId: reviewId,
@@ -1370,6 +1401,7 @@ export async function POST(
       councilResult = await finalizeCouncilResultForReview({
         review,
         lastAssistantMessageText: rawPayload.lastAssistantMessageText,
+        orgAgentConfig: councilOrgAgentConfig,
       });
     }
 

--- a/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
@@ -543,8 +543,17 @@ export function ReviewConfigForm({
     setRepositorySelectionMode(enabled ? 'selected' : 'all');
   };
 
-  // Council is on when 1+ repos opt in; the shared specialist picker then applies to all of them.
-  const councilEnabled = councilEnabledRepositoryIds.size > 0;
+  // Council is on when 1+ *currently selected* repos opt in; the shared specialist picker then
+  // applies to all of them. A council opt-in only counts while its repository is still selected:
+  // removing a repo from the Repositories list stops rendering its council toggle, so without this
+  // intersection a stale id would keep the picker open, block save on the minimum-specialist check,
+  // and persist to council_enabled_repository_ids (silently re-activating council if the repo were
+  // re-added). Deriving from the live selection instead of mutating the set means re-selecting the
+  // repo within the same edit restores its prior opt-in.
+  const councilEnabledSelectedRepositoryIds = selectedRepositoryIds.filter(id =>
+    councilEnabledRepositoryIds.has(id)
+  );
+  const councilEnabled = councilEnabledSelectedRepositoryIds.length > 0;
   const councilEnabledCount = countEnabledSelections(councilSelections);
   const councilBelowMin = councilEnabled && councilEnabledCount < COUNCIL_MIN_SPECIALISTS;
   // Only repositories the user actually selected can be configured per-repo (model + council),
@@ -601,8 +610,10 @@ export function ReviewConfigForm({
           specialists: buildCouncilSpecialists(councilSelections),
         }
       : null;
+    // Persist only opt-ins for still-selected repos, so a repo deselected after enabling council
+    // never leaves a stale id in council_enabled_repository_ids.
     const councilEnabledRepositoryIdsPayload = perRepoOverridesEnabled
-      ? Array.from(councilEnabledRepositoryIds)
+      ? councilEnabledSelectedRepositoryIds
       : [];
 
     if (organizationId) {

--- a/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
@@ -610,9 +610,13 @@ export function ReviewConfigForm({
           specialists: buildCouncilSpecialists(councilSelections),
         }
       : null;
-    // Persist only opt-ins for still-selected repos, so a repo deselected after enabling council
-    // never leaves a stale id in council_enabled_repository_ids.
-    const councilEnabledRepositoryIdsPayload = perRepoOverridesEnabled
+    // Gate on `councilActiveForSave` (not just `perRepoOverridesEnabled`) so `council` and its
+    // per-repo opt-ins are always written or cleared as a unit. Otherwise, if council becomes
+    // UI-unavailable (entitlement lapses or the flag is turned off) while Advanced stays on, an
+    // unrelated save would persist `council: null` alongside a non-empty opt-in list, leaving
+    // orphaned ids that would silently re-activate council if it were later re-enabled. When
+    // active, still persist only opt-ins for repos that are currently selected.
+    const councilEnabledRepositoryIdsPayload = councilActiveForSave
       ? councilEnabledSelectedRepositoryIds
       : [];
 

--- a/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
@@ -584,22 +584,26 @@ export function ReviewConfigForm({
         }))
       : [];
 
-    // Council is org-only (requires an enterprise org). Persist the built config when the section
-    // is visible + enabled; otherwise clear it. Block the save if council is on but under-staffed.
-    if (councilUiEnabled && councilBelowMin) {
+    // Council lives entirely inside Advanced Settings, so turning Advanced off clears it on save
+    // (same as per-repo model overrides), matching the "every repository uses the global settings"
+    // copy. Only guard/persist council when the section is actually shown (Advanced + entitled).
+    const councilActiveForSave = perRepoOverridesEnabled && councilUiEnabled && councilEnabled;
+    if (councilActiveForSave && councilBelowMin) {
       toast.error('Council needs more specialists', {
         description: `Select at least ${COUNCIL_MIN_SPECIALISTS} council specialists.`,
       });
       return;
     }
-    const councilPayload =
-      councilUiEnabled && councilEnabled
-        ? {
-            enabled: true,
-            aggregation_strategy: councilAggregation,
-            specialists: buildCouncilSpecialists(councilSelections),
-          }
-        : null;
+    const councilPayload = councilActiveForSave
+      ? {
+          enabled: true,
+          aggregation_strategy: councilAggregation,
+          specialists: buildCouncilSpecialists(councilSelections),
+        }
+      : null;
+    const councilEnabledRepositoryIdsPayload = perRepoOverridesEnabled
+      ? Array.from(councilEnabledRepositoryIds)
+      : [];
 
     if (organizationId) {
       orgSaveMutation.mutate({
@@ -616,7 +620,7 @@ export function ReviewConfigForm({
         manuallyAddedRepositories,
         repositoryModelOverrides: repositoryModelOverridesPayload,
         council: councilPayload,
-        councilEnabledRepositoryIds: Array.from(councilEnabledRepositoryIds),
+        councilEnabledRepositoryIds: councilEnabledRepositoryIdsPayload,
         disableReviewMd: !useReviewMd,
         // GitLab-specific: auto-configure webhooks
         autoConfigureWebhooks: isGitLab ? autoConfigureWebhooks : undefined,

--- a/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
@@ -33,6 +33,23 @@ import {
 
 import { useRefreshRepositories } from '@/hooks/useRefreshRepositories';
 import { useOrganizationModels } from '@/components/cloud-agent/hooks/useOrganizationModels';
+import { CouncilSpecialistPicker } from './CouncilSpecialistPicker';
+import {
+  buildCouncilSpecialists,
+  councilSelectionsFromConfig,
+  countEnabledSelections,
+  defaultCouncilSelections,
+  type CouncilSpecialistSelection,
+} from '@/lib/code-reviews/core/council-selection';
+import {
+  COUNCIL_AGGREGATION_STRATEGIES,
+  DEFAULT_COUNCIL_AGGREGATION_STRATEGY,
+  type CouncilAggregationStrategy,
+} from '@kilocode/db/schema-types';
+import {
+  COUNCIL_MIN_SPECIALISTS,
+  formatAggregationStrategy,
+} from '@kilocode/worker-utils/code-review-council';
 import { ModelCombobox } from '@/components/shared/ModelCombobox';
 import { cn } from '@/lib/utils';
 import { RepositoryMultiSelect } from './RepositoryMultiSelect';
@@ -70,6 +87,8 @@ export type ReviewConfigFormProps = {
   organizationId?: string;
   platform?: Platform;
   gitlabStatusData?: GitLabStatusData;
+  /** Same gate as the manual council UI: local dev, or an entitled org behind the rollout flag. */
+  councilUiEnabled?: boolean;
 };
 
 // Labels/descriptions stay web-local; the ids/values themselves are derived
@@ -116,6 +135,7 @@ export function ReviewConfigForm({
   organizationId,
   platform = 'github',
   gitlabStatusData,
+  councilUiEnabled = false,
 }: ReviewConfigFormProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -234,8 +254,17 @@ export function ReviewConfigForm({
   const [repositoryModelOverrides, setRepositoryModelOverrides] = useState<
     Map<number, RepositoryModelOverrideValue>
   >(new Map());
-  // Opt-in toggle for the per-repository model section.
-  const [overridesEnabled, setOverridesEnabled] = useState(false);
+  // Org-level council config (shared by every council-enabled repo) + per-repo opt-in set.
+  // Council is "on" when at least one repo opts in — there is no separate global toggle.
+  const [councilAggregation, setCouncilAggregation] = useState<CouncilAggregationStrategy>(
+    DEFAULT_COUNCIL_AGGREGATION_STRATEGY
+  );
+  const [councilSelections, setCouncilSelections] = useState<
+    Record<string, CouncilSpecialistSelection>
+  >(() => defaultCouncilSelections());
+  const [councilEnabledRepositoryIds, setCouncilEnabledRepositoryIds] = useState<Set<number>>(
+    new Set()
+  );
   const [useReviewMd, setUseReviewMd] = useState(true);
   // GitLab-specific: auto-configure webhooks
   const [autoConfigureWebhooks, setAutoConfigureWebhooks] = useState(true);
@@ -365,7 +394,20 @@ export function ReviewConfigForm({
         }
       }
       setRepositoryModelOverrides(overridesMap);
-      setOverridesEnabled(overridesMap.size > 0);
+      const loadedCouncil = configData.council ?? null;
+      setCouncilAggregation(
+        loadedCouncil?.aggregation_strategy ?? DEFAULT_COUNCIL_AGGREGATION_STRATEGY
+      );
+      setCouncilSelections(
+        loadedCouncil ? councilSelectionsFromConfig(loadedCouncil) : defaultCouncilSelections()
+      );
+      setCouncilEnabledRepositoryIds(
+        new Set(
+          (configData.councilEnabledRepositoryIds ?? []).filter(
+            (repositoryId): repositoryId is number => typeof repositoryId === 'number'
+          )
+        )
+      );
       setUseReviewMd(!(configData.disableReviewMd ?? false));
     }
   }, [configData, isGitLab]);
@@ -494,6 +536,32 @@ export function ReviewConfigForm({
     }
   };
 
+  // Master "Simple vs Advanced" switch: Advanced reveals per-repository overrides (repo selection,
+  // per-repo model/effort, per-repo council). GitLab has no "all" mode, so it is always Advanced.
+  const perRepoOverridesEnabled = isGitLab || repositorySelectionMode === 'selected';
+  const handlePerRepoOverridesToggle = (enabled: boolean) => {
+    setRepositorySelectionMode(enabled ? 'selected' : 'all');
+  };
+
+  // Council is on when 1+ repos opt in; the shared specialist picker then applies to all of them.
+  const councilEnabled = councilEnabledRepositoryIds.size > 0;
+  const councilEnabledCount = countEnabledSelections(councilSelections);
+  const councilBelowMin = councilEnabled && councilEnabledCount < COUNCIL_MIN_SPECIALISTS;
+  // Only repositories the user actually selected can be configured per-repo (model + council),
+  // so the per-repo pickers never offer a repo that isn't being reviewed.
+  const selectedRepositories = selectableRepositories.filter(repo =>
+    selectedRepositoryIds.includes(repo.id)
+  );
+
+  const handleCouncilRepoToggle = (repositoryId: number, enabled: boolean) => {
+    setCouncilEnabledRepositoryIds(prev => {
+      const next = new Set(prev);
+      if (enabled) next.add(repositoryId);
+      else next.delete(repositoryId);
+      return next;
+    });
+  };
+
   const handleSave = () => {
     // Clear previous webhook sync result
     setWebhookSyncResult(null);
@@ -507,7 +575,7 @@ export function ReviewConfigForm({
     // Overrides are independent of the trigger selection mode — they apply whether
     // reviews run on all or selected repositories. Sent only when the per-repository
     // section is toggled on; toggling it off clears the overrides on save.
-    const repositoryModelOverridesPayload = overridesEnabled
+    const repositoryModelOverridesPayload = perRepoOverridesEnabled
       ? Array.from(repositoryModelOverrides.entries()).map(([repositoryId, value]) => ({
           repositoryId,
           repoFullName: value.repoFullName,
@@ -515,6 +583,23 @@ export function ReviewConfigForm({
           thinkingEffort: value.thinkingEffort,
         }))
       : [];
+
+    // Council is org-only (requires an enterprise org). Persist the built config when the section
+    // is visible + enabled; otherwise clear it. Block the save if council is on but under-staffed.
+    if (councilUiEnabled && councilBelowMin) {
+      toast.error('Council needs more specialists', {
+        description: `Select at least ${COUNCIL_MIN_SPECIALISTS} council specialists.`,
+      });
+      return;
+    }
+    const councilPayload =
+      councilUiEnabled && councilEnabled
+        ? {
+            enabled: true,
+            aggregation_strategy: councilAggregation,
+            specialists: buildCouncilSpecialists(councilSelections),
+          }
+        : null;
 
     if (organizationId) {
       orgSaveMutation.mutate({
@@ -530,6 +615,8 @@ export function ReviewConfigForm({
         selectedRepositoryIds,
         manuallyAddedRepositories,
         repositoryModelOverrides: repositoryModelOverridesPayload,
+        council: councilPayload,
+        councilEnabledRepositoryIds: Array.from(councilEnabledRepositoryIds),
         disableReviewMd: !useReviewMd,
         // GitLab-specific: auto-configure webhooks
         autoConfigureWebhooks: isGitLab ? autoConfigureWebhooks : undefined,
@@ -621,6 +708,14 @@ export function ReviewConfigForm({
 
           {/* Configuration Fields */}
           <div className={cn('space-y-8', !isEnabled && 'pointer-events-none opacity-50')}>
+            {/* Global Settings — defaults inherited by every repository unless overridden below. */}
+            <div className="space-y-1">
+              <h3 className="text-base font-semibold">Global Settings</h3>
+              <p className="text-muted-foreground text-sm">
+                Defaults applied to every repository unless overridden per repository below.
+              </p>
+            </div>
+
             {/* Default AI Model Selection */}
             <ModelCombobox
               label="Default AI Model"
@@ -725,135 +820,253 @@ export function ReviewConfigForm({
               />
             </div>
 
-            {/* Repository Selection */}
+            {/* Focus Areas (global) */}
             <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label>Repository Selection</Label>
-                  <p className="text-muted-foreground text-sm">
-                    Choose which repositories should trigger automatic code reviews
-                  </p>
-                </div>
-                {repositoriesData?.integrationInstalled && (
-                  <div className="flex items-center gap-2">
-                    <span className="text-muted-foreground text-xs">
-                      Last synced:{' '}
-                      {repositoriesData.syncedAt
-                        ? formatDistanceToNow(new Date(repositoriesData.syncedAt), {
-                            addSuffix: true,
-                          })
-                        : 'Never'}
-                    </span>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={refreshRepositories}
-                      disabled={isRefreshingRepos || isLoadingRepositories}
-                    >
-                      <RefreshCw className={cn('h-4 w-4', isRefreshingRepos && 'animate-spin')} />
-                    </Button>
-                  </div>
-                )}
-              </div>
-
-              {isLoadingRepositories ? (
-                <div className="rounded-md border border-gray-600 bg-gray-800/50 p-3">
-                  <p className="text-sm text-gray-400">Loading repositories...</p>
-                </div>
-              ) : repositoriesError ? (
-                <div className="rounded-md border border-red-500/50 bg-red-500/10 p-3">
-                  <p className="text-sm text-red-200">
-                    Failed to load repositories. Please try refreshing the page.
-                  </p>
-                </div>
-              ) : !repositoriesData?.integrationInstalled ? (
-                <div className="rounded-md border border-yellow-500/50 bg-yellow-500/10 p-3">
-                  <p className="text-sm text-yellow-200">
-                    {repositoriesData?.errorMessage ||
-                      `${platformLabel} integration is not connected. Please connect ${platformLabel} in the Integrations page to configure repository selection.`}
-                  </p>
-                </div>
-              ) : selectableRepositories.length === 0 ? (
-                <div className="rounded-md border border-yellow-500/50 bg-yellow-500/10 p-3">
-                  <p className="text-sm text-yellow-200">
-                    No repositories found. Please ensure the {platformLabel}{' '}
-                    {isGitLab ? 'integration' : 'App'} has access to your repositories.
-                  </p>
-                </div>
-              ) : (
-                <>
-                  {/* For GitLab, only show "Selected repositories" since "All" is not supported */}
-                  {!isGitLab && (
-                    <RadioGroup
-                      value={repositorySelectionMode}
-                      onValueChange={value =>
-                        setRepositorySelectionMode(value as 'all' | 'selected')
-                      }
-                      className="space-y-3"
-                    >
-                      <div className="flex items-center space-x-3">
-                        <RadioGroupItem value="all" id="all-repos" />
-                        <Label htmlFor="all-repos" className="cursor-pointer font-normal">
-                          All repositories ({repositoriesData.repositories.length})
-                        </Label>
-                      </div>
-                      <div className="flex items-start space-x-3">
-                        <RadioGroupItem value="selected" id="selected-repos" className="mt-1" />
-                        <Label htmlFor="selected-repos" className="cursor-pointer font-normal">
-                          Selected repositories
-                        </Label>
-                      </div>
-                    </RadioGroup>
-                  )}
-
-                  {/* For GitLab, always show the multi-select; for GitHub, only when 'selected' mode */}
-                  {(isGitLab || repositorySelectionMode === 'selected') && (
-                    <div className="mt-4">
-                      <RepositoryMultiSelect
-                        repositories={selectableRepositories}
-                        selectedIds={selectedRepositoryIds}
-                        onSelectionChange={setSelectedRepositoryIds}
-                      />
+              <Label>Focus Areas</Label>
+              <p className="text-muted-foreground mb-3 text-sm">
+                Select specific areas for the agent to pay special attention to
+              </p>
+              <div className="space-y-3">
+                {FOCUS_AREAS.map(area => (
+                  <div key={area.id} className="flex items-start space-x-3">
+                    <Checkbox
+                      id={area.id}
+                      checked={focusAreas.includes(area.id)}
+                      onCheckedChange={() => handleFocusAreaToggle(area.id)}
+                    />
+                    <div className="grid gap-1.5 leading-none">
+                      <Label
+                        htmlFor={area.id}
+                        className="cursor-pointer leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                      >
+                        {area.label}
+                      </Label>
+                      <p className="text-muted-foreground text-sm">{area.description}</p>
                     </div>
-                  )}
-                </>
-              )}
+                  </div>
+                ))}
+              </div>
             </div>
 
-            {/* Per-repository model overrides — independent of the trigger selection
-                mode above; applies whether reviews run on all or selected repos. */}
-            {repositoriesData?.integrationInstalled && selectableRepositories.length > 0 && (
-              <div className="space-y-4">
-                <div className="flex items-center justify-between rounded-lg border p-4">
-                  <div className="space-y-0.5">
-                    <Label htmlFor="per-repo-models" className="text-base font-semibold">
-                      Per-repository models
-                    </Label>
-                    <p className="text-muted-foreground text-sm">
-                      Run specific repositories&apos; reviews on a different model than the default.
-                    </p>
-                  </div>
-                  <Switch
-                    id="per-repo-models"
-                    checked={overridesEnabled}
-                    onCheckedChange={setOverridesEnabled}
-                    disabled={!isEnabled}
-                  />
+            {/* Custom Instructions (global) */}
+            <div className="space-y-3">
+              <Label htmlFor="custom-instructions">Custom Instructions (Optional)</Label>
+              <Textarea
+                id="custom-instructions"
+                placeholder="e.g., 'Always check for TypeScript strict mode compliance' or 'Focus on React best practices'"
+                value={customInstructions}
+                onChange={e => setCustomInstructions(e.target.value)}
+                rows={4}
+                className="resize-none"
+              />
+              <p className="text-muted-foreground text-sm">
+                Add specific guidelines for your team's code review standards
+              </p>
+            </div>
+
+            {/* Advanced Settings — one card holding the switch and, when on, the per-repository
+                settings. GitLab has no "all" mode, so it is always Advanced (switch hidden). */}
+            <div className="space-y-6 rounded-lg border p-4">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="advanced-settings" className="text-base font-semibold">
+                    Advanced Settings
+                  </Label>
+                  <p className="text-muted-foreground text-sm">
+                    Choose specific repositories and override the global defaults for each (model,
+                    thinking effort, and council review). Off means every repository uses the global
+                    settings above.
+                  </p>
                 </div>
-                {overridesEnabled && (
-                  <RepositoryModelOverrides
-                    availableRepositories={selectableRepositories}
-                    models={modelOptions}
-                    isLoadingModels={isLoadingModels}
-                    overrides={repositoryModelOverrides}
-                    defaultModelSlug={selectedModel}
-                    onSet={handleRepositoryModelOverrideSet}
-                    onRemove={handleRepositoryModelOverrideRemove}
+                {!isGitLab && (
+                  <Switch
+                    id="advanced-settings"
+                    checked={perRepoOverridesEnabled}
+                    onCheckedChange={handlePerRepoOverridesToggle}
                     disabled={!isEnabled}
                   />
                 )}
               </div>
-            )}
+
+              {/* Repository Selection (Advanced) — which repositories to review + configure. */}
+              {perRepoOverridesEnabled && (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <Label>Repositories</Label>
+                      <p className="text-muted-foreground text-sm">
+                        Choose which repositories to review and configure below. Others are not
+                        reviewed.
+                      </p>
+                    </div>
+                    {repositoriesData?.integrationInstalled && (
+                      <div className="flex items-center gap-2">
+                        <span className="text-muted-foreground text-xs">
+                          Last synced:{' '}
+                          {repositoriesData.syncedAt
+                            ? formatDistanceToNow(new Date(repositoriesData.syncedAt), {
+                                addSuffix: true,
+                              })
+                            : 'Never'}
+                        </span>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={refreshRepositories}
+                          disabled={isRefreshingRepos || isLoadingRepositories}
+                        >
+                          <RefreshCw
+                            className={cn('h-4 w-4', isRefreshingRepos && 'animate-spin')}
+                          />
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+
+                  {isLoadingRepositories ? (
+                    <div className="rounded-md border border-gray-600 bg-gray-800/50 p-3">
+                      <p className="text-sm text-gray-400">Loading repositories...</p>
+                    </div>
+                  ) : repositoriesError ? (
+                    <div className="rounded-md border border-red-500/50 bg-red-500/10 p-3">
+                      <p className="text-sm text-red-200">
+                        Failed to load repositories. Please try refreshing the page.
+                      </p>
+                    </div>
+                  ) : !repositoriesData?.integrationInstalled ? (
+                    <div className="rounded-md border border-yellow-500/50 bg-yellow-500/10 p-3">
+                      <p className="text-sm text-yellow-200">
+                        {repositoriesData?.errorMessage ||
+                          `${platformLabel} integration is not connected. Please connect ${platformLabel} in the Integrations page to configure repository selection.`}
+                      </p>
+                    </div>
+                  ) : selectableRepositories.length === 0 ? (
+                    <div className="rounded-md border border-yellow-500/50 bg-yellow-500/10 p-3">
+                      <p className="text-sm text-yellow-200">
+                        No repositories found. Please ensure the {platformLabel}{' '}
+                        {isGitLab ? 'integration' : 'App'} has access to your repositories.
+                      </p>
+                    </div>
+                  ) : (
+                    <RepositoryMultiSelect
+                      repositories={selectableRepositories}
+                      selectedIds={selectedRepositoryIds}
+                      onSelectionChange={setSelectedRepositoryIds}
+                    />
+                  )}
+                </div>
+              )}
+
+              {/* Per-repository model overrides — independent of the trigger selection
+                mode above; applies whether reviews run on all or selected repos. */}
+              {perRepoOverridesEnabled &&
+                repositoriesData?.integrationInstalled &&
+                selectedRepositories.length > 0 && (
+                  <div className="space-y-4">
+                    <div className="space-y-0.5">
+                      <Label className="text-base font-semibold">Per-repository model</Label>
+                      <p className="text-muted-foreground text-sm">
+                        Optionally run specific repositories&apos; reviews on a different model or
+                        effort than the global default.
+                      </p>
+                    </div>
+                    <RepositoryModelOverrides
+                      availableRepositories={selectedRepositories}
+                      models={modelOptions}
+                      isLoadingModels={isLoadingModels}
+                      overrides={repositoryModelOverrides}
+                      defaultModelSlug={selectedModel}
+                      onSet={handleRepositoryModelOverrideSet}
+                      onRemove={handleRepositoryModelOverrideRemove}
+                      disabled={!isEnabled}
+                    />
+
+                    {/* Per-repository council opt-in + the shared specialist config it applies. */}
+                    {councilUiEnabled &&
+                      perRepoOverridesEnabled &&
+                      selectedRepositories.length > 0 && (
+                        <div className="space-y-4 rounded-lg border p-4">
+                          <div className="space-y-0.5">
+                            <Label className="text-base font-semibold">Council review</Label>
+                            <p className="text-muted-foreground text-sm">
+                              Choose which repositories run the council review (multiple
+                              specialists, combined into one decision) on every pull request. Others
+                              use the standard single reviewer.
+                            </p>
+                          </div>
+                          <div className="divide-y rounded-md border">
+                            {selectedRepositories.map(repo => (
+                              <div
+                                key={repo.id}
+                                className="flex items-center justify-between gap-3 p-3"
+                              >
+                                <span className="truncate text-sm" title={repo.full_name}>
+                                  {repo.full_name}
+                                </span>
+                                <Switch
+                                  checked={councilEnabledRepositoryIds.has(repo.id)}
+                                  onCheckedChange={checked =>
+                                    handleCouncilRepoToggle(repo.id, checked)
+                                  }
+                                  disabled={!isEnabled || orgSaveMutation.isPending}
+                                  aria-label={`Enable council review for ${repo.full_name}`}
+                                />
+                              </div>
+                            ))}
+                          </div>
+
+                          {/* Shared specialists + governance — applied to every council-enabled repo. */}
+                          {councilEnabled && (
+                            <div className="space-y-4 border-t pt-4">
+                              <p className="text-sm font-medium">
+                                Specialists (applied to all council-enabled repositories)
+                              </p>
+                              <CouncilSpecialistPicker
+                                selections={councilSelections}
+                                onChange={setCouncilSelections}
+                                modelOptions={modelOptions}
+                                isLoadingModels={isLoadingModels}
+                                disabled={orgSaveMutation.isPending}
+                                defaultModelSlug={selectedModel}
+                              />
+                              <div className="space-y-2">
+                                <Label htmlFor="council-aggregation">Governance decision</Label>
+                                <Select
+                                  value={councilAggregation}
+                                  onValueChange={value =>
+                                    setCouncilAggregation(value as CouncilAggregationStrategy)
+                                  }
+                                  disabled={orgSaveMutation.isPending}
+                                >
+                                  <SelectTrigger id="council-aggregation" className="w-full">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {COUNCIL_AGGREGATION_STRATEGIES.map(strategy => (
+                                      <SelectItem key={strategy} value={strategy}>
+                                        {formatAggregationStrategy(strategy)}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                                <p
+                                  className={
+                                    councilBelowMin
+                                      ? 'text-destructive text-sm'
+                                      : 'text-muted-foreground text-sm'
+                                  }
+                                >
+                                  Select {COUNCIL_MIN_SPECIALISTS}–4 specialists.{' '}
+                                  {councilEnabledCount} selected.
+                                </p>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                  </div>
+                )}
+            </div>
 
             {/* GitLab Webhook Configuration */}
             {isGitLab &&
@@ -1071,50 +1284,6 @@ export function ReviewConfigForm({
                   </div>
                 </div>
               )}
-
-            {/* Focus Areas */}
-            <div className="space-y-3">
-              <Label>Focus Areas</Label>
-              <p className="text-muted-foreground mb-3 text-sm">
-                Select specific areas for the agent to pay special attention to
-              </p>
-              <div className="space-y-3">
-                {FOCUS_AREAS.map(area => (
-                  <div key={area.id} className="flex items-start space-x-3">
-                    <Checkbox
-                      id={area.id}
-                      checked={focusAreas.includes(area.id)}
-                      onCheckedChange={() => handleFocusAreaToggle(area.id)}
-                    />
-                    <div className="grid gap-1.5 leading-none">
-                      <Label
-                        htmlFor={area.id}
-                        className="cursor-pointer leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                      >
-                        {area.label}
-                      </Label>
-                      <p className="text-muted-foreground text-sm">{area.description}</p>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            {/* Custom Instructions */}
-            <div className="space-y-3">
-              <Label htmlFor="custom-instructions">Custom Instructions (Optional)</Label>
-              <Textarea
-                id="custom-instructions"
-                placeholder="e.g., 'Always check for TypeScript strict mode compliance' or 'Focus on React best practices'"
-                value={customInstructions}
-                onChange={e => setCustomInstructions(e.target.value)}
-                rows={4}
-                className="resize-none"
-              />
-              <p className="text-muted-foreground text-sm">
-                Add specific guidelines for your team's code review standards
-              </p>
-            </div>
 
             {/* Save Button */}
             <div className="flex justify-end pt-2">

--- a/apps/web/src/lib/code-reviews/core/council-selection.test.ts
+++ b/apps/web/src/lib/code-reviews/core/council-selection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import { COUNCIL_SPECIALIST_PRESETS } from '@kilocode/worker-utils/code-review-council';
 import {
   buildCouncilSpecialists,
+  councilSelectionsFromConfig,
   countEnabledSelections,
   defaultCouncilSelections,
 } from './council-selection';
@@ -41,5 +42,37 @@ describe('council-selection', () => {
     // Default model/effort are omitted, not persisted as null-model.
     expect(specialists[1].model_slug).toBeUndefined();
     expect(specialists[1].thinking_effort).toBeUndefined();
+  });
+
+  it('councilSelectionsFromConfig round-trips a saved config back into picker state', () => {
+    const selections = defaultCouncilSelections();
+    for (const id of Object.keys(selections)) selections[id].enabled = false;
+    selections.security = { enabled: true, modelSlug: 'anthropic/x', thinkingEffort: 'high' };
+    selections.testing = { enabled: true, modelSlug: null, thinkingEffort: null };
+
+    const council = {
+      enabled: true,
+      aggregation_strategy: 'unanimous' as const,
+      specialists: buildCouncilSpecialists(selections),
+    };
+    const hydrated = councilSelectionsFromConfig(council);
+
+    // Enabled presets come back with their saved model/effort; absent ones are disabled.
+    expect(hydrated.security).toEqual({
+      enabled: true,
+      modelSlug: 'anthropic/x',
+      thinkingEffort: 'high',
+    });
+    expect(hydrated.testing).toEqual({ enabled: true, modelSlug: null, thinkingEffort: null });
+    expect(hydrated.performance.enabled).toBe(false);
+    expect(hydrated.correctness.enabled).toBe(false);
+    // Re-building from the hydrated selections reproduces the same specialist ids.
+    expect(buildCouncilSpecialists(hydrated).map(s => s.id)).toEqual(['security', 'testing']);
+  });
+
+  it('councilSelectionsFromConfig disables everything for a null/empty config', () => {
+    const hydrated = councilSelectionsFromConfig(null);
+    expect(countEnabledSelections(hydrated)).toBe(0);
+    expect(Object.keys(hydrated).sort()).toEqual(COUNCIL_SPECIALIST_PRESETS.map(p => p.id).sort());
   });
 });

--- a/apps/web/src/lib/code-reviews/core/council-selection.ts
+++ b/apps/web/src/lib/code-reviews/core/council-selection.ts
@@ -1,4 +1,4 @@
-import type { CouncilSpecialist } from '@kilocode/db/schema-types';
+import type { CodeReviewCouncilConfig, CouncilSpecialist } from '@kilocode/db/schema-types';
 import {
   COUNCIL_SPECIALIST_PRESETS,
   presetToSpecialist,
@@ -34,6 +34,30 @@ export function defaultCouncilSelections(): Record<string, CouncilSpecialistSele
       preset.id,
       { enabled: true, modelSlug: null, thinkingEffort: null },
     ])
+  );
+}
+
+/**
+ * Reverse of `buildCouncilSpecialists`: hydrates picker selections from a persisted council
+ * config so an existing org config round-trips into the UI. Presets absent from the config are
+ * disabled; present ones carry their saved per-specialist model/effort.
+ */
+export function councilSelectionsFromConfig(
+  council: CodeReviewCouncilConfig | null | undefined
+): Record<string, CouncilSpecialistSelection> {
+  const byId = new Map((council?.specialists ?? []).map(specialist => [specialist.id, specialist]));
+  return Object.fromEntries(
+    COUNCIL_SPECIALIST_PRESETS.map(preset => {
+      const saved = byId.get(preset.id);
+      return [
+        preset.id,
+        {
+          enabled: saved?.enabled ?? false,
+          modelSlug: saved?.model_slug ?? null,
+          thinkingEffort: saved?.thinking_effort ?? null,
+        },
+      ];
+    })
   );
 }
 

--- a/apps/web/src/lib/code-reviews/council/finalize-council-result.test.ts
+++ b/apps/web/src/lib/code-reviews/council/finalize-council-result.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
 import { COUNCIL_RESULT_MARKER_TAG } from '@kilocode/worker-utils/code-review-council';
-import type { CodeReviewCouncilConfig } from '@kilocode/db/schema-types';
-import { buildCouncilResult } from './finalize-council-result';
+import type { CloudAgentCodeReview } from '@kilocode/db/schema';
+import type { CodeReviewAgentConfig, CodeReviewCouncilConfig } from '@kilocode/db/schema-types';
+import { buildCouncilResult, computeCouncilResultForReview } from './finalize-council-result';
 
 const council: CodeReviewCouncilConfig = {
   enabled: true,
@@ -183,5 +184,50 @@ describe('buildCouncilResult', () => {
     });
     expect(result.decision).toBe('block');
     expect(result.specialists.every(s => s.vote === null)).toBe(true);
+  });
+});
+
+describe('computeCouncilResultForReview — automated (webhook) council config source', () => {
+  // Webhook council reviews carry no manual_config; the council config comes from the org config.
+  const webhookReview = {
+    review_type: 'council',
+    manual_config: null,
+  } as unknown as CloudAgentCodeReview;
+  const orgAgentConfig = { model_slug: 'base/model', council } as unknown as CodeReviewAgentConfig;
+  const manifest = manifestText([
+    { specialistId: 'security', findings: crit },
+    { specialistId: 'performance', findings: [] },
+  ]);
+
+  it('falls back to the org agent config when there is no manual_config', () => {
+    const result = computeCouncilResultForReview({
+      review: webhookReview,
+      lastAssistantMessageText: manifest,
+      orgAgentConfig,
+    });
+    expect(result?.decision).toBe('block'); // unanimous + one critical
+    expect(result?.specialists).toHaveLength(2);
+    expect(result?.specialists[0].model).toBe('anthropic/x'); // configured per-specialist model
+    expect(result?.specialists[1].model).toBe('base/model'); // inherits the org base model
+  });
+
+  it('returns null for a webhook council review when no org config is available (fail-safe)', () => {
+    expect(
+      computeCouncilResultForReview({
+        review: webhookReview,
+        lastAssistantMessageText: manifest,
+        orgAgentConfig: null,
+      })
+    ).toBeNull();
+  });
+
+  it('returns null for a non-council review even with an org council config', () => {
+    expect(
+      computeCouncilResultForReview({
+        review: { review_type: 'standard', manual_config: null } as unknown as CloudAgentCodeReview,
+        lastAssistantMessageText: manifest,
+        orgAgentConfig,
+      })
+    ).toBeNull();
   });
 });

--- a/apps/web/src/lib/code-reviews/council/finalize-council-result.ts
+++ b/apps/web/src/lib/code-reviews/council/finalize-council-result.ts
@@ -110,7 +110,8 @@ export function computeCouncilResultForReview(params: {
 }): CodeReviewCouncilResult | null {
   const { review, lastAssistantMessageText } = params;
   if (review.review_type !== 'council') return null;
-  const agentConfig = getManualCodeReviewConfig(review)?.agentConfig ?? params.orgAgentConfig ?? null;
+  const agentConfig =
+    getManualCodeReviewConfig(review)?.agentConfig ?? params.orgAgentConfig ?? null;
   const council = agentConfig?.council;
   if (!council) return null;
 

--- a/apps/web/src/lib/code-reviews/council/finalize-council-result.ts
+++ b/apps/web/src/lib/code-reviews/council/finalize-council-result.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import type { CloudAgentCodeReview } from '@kilocode/db/schema';
 import type {
+  CodeReviewAgentConfig,
   CodeReviewCouncilConfig,
   CodeReviewCouncilResult,
   CouncilResultSpecialist,
@@ -101,10 +102,15 @@ export function buildCouncilResult(params: {
 export function computeCouncilResultForReview(params: {
   review: CloudAgentCodeReview;
   lastAssistantMessageText: string | null | undefined;
+  // Council-config source for AUTOMATED (webhook) reviews, which carry no `manual_config`.
+  // Manual reviews resolve their council from `manual_config` and ignore this. Resolved + passed
+  // by the caller (the status callback) because this function is pure/DB-free and also runs inside
+  // the analytics completion transaction. Absent → automated council reviews persist no result.
+  orgAgentConfig?: CodeReviewAgentConfig | null;
 }): CodeReviewCouncilResult | null {
   const { review, lastAssistantMessageText } = params;
   if (review.review_type !== 'council') return null;
-  const agentConfig = getManualCodeReviewConfig(review)?.agentConfig;
+  const agentConfig = getManualCodeReviewConfig(review)?.agentConfig ?? params.orgAgentConfig ?? null;
   const council = agentConfig?.council;
   if (!council) return null;
 
@@ -134,6 +140,7 @@ export function computeCouncilResultForReview(params: {
 export async function finalizeCouncilResultForReview(params: {
   review: CloudAgentCodeReview;
   lastAssistantMessageText: string | null | undefined;
+  orgAgentConfig?: CodeReviewAgentConfig | null;
 }): Promise<CodeReviewCouncilResult | null> {
   const councilResult = computeCouncilResultForReview(params);
   if (!councilResult) return null;

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
@@ -12,6 +12,7 @@ const mockTryDispatchPendingReviews = jest.fn();
 const mockCancelReview = jest.fn();
 const mockAddReactionToPR = jest.fn();
 const mockIsMergeCommit = jest.fn();
+const mockIsCouncilEntitledForOwner = jest.fn();
 
 jest.mock('@/lib/bot-users/bot-user-service', () => ({
   getBotUserId: (organizationId: string, botType: string) =>
@@ -21,6 +22,10 @@ jest.mock('@/lib/bot-users/bot-user-service', () => ({
 jest.mock('@/lib/agent-config/db/agent-configs', () => ({
   getAgentConfigForOwner: (owner: unknown, agentType: string, platform: string) =>
     mockGetAgentConfigForOwner(owner, agentType, platform),
+}));
+
+jest.mock('@/lib/code-reviews/core/council-entitlement', () => ({
+  isCouncilEntitledForOwner: (...args: unknown[]) => mockIsCouncilEntitledForOwner(...args),
 }));
 
 jest.mock('@/lib/code-reviews/db/code-reviews', () => ({
@@ -117,6 +122,7 @@ beforeEach(() => {
   mockCancelReview.mockResolvedValue({ success: true, reviewId: 'old-review' });
   mockAddReactionToPR.mockResolvedValue(undefined);
   mockIsMergeCommit.mockResolvedValue(false);
+  mockIsCouncilEntitledForOwner.mockResolvedValue(false);
 });
 
 describe('resolvePullRequestCheckoutRef', () => {
@@ -283,6 +289,80 @@ describe('handlePullRequest', () => {
       { status: 'completed', conclusion: 'cancelled' },
       'standard'
     );
+  });
+
+  describe('automated council review type', () => {
+    const councilConfig = {
+      is_enabled: true,
+      config: {
+        council: {
+          enabled: true,
+          aggregation_strategy: 'unanimous',
+          specialists: [
+            {
+              id: 'security',
+              role: 'security',
+              name: 'Security',
+              enabled: true,
+              required: false,
+              lens: 'x',
+            },
+            {
+              id: 'performance',
+              role: 'performance',
+              name: 'Performance',
+              enabled: true,
+              required: false,
+              lens: 'y',
+            },
+          ],
+        },
+        // Repo 123 (acme/widgets, from pullRequestPayload) opted into council.
+        council_enabled_repository_ids: [123],
+      },
+    };
+
+    it('creates a council review when entitled + council active + repo opted in', async () => {
+      mockGetBotUserId.mockResolvedValue('bot-user-1');
+      mockGetAgentConfigForOwner.mockResolvedValue(councilConfig);
+      mockIsCouncilEntitledForOwner.mockResolvedValue(true);
+
+      await handlePullRequest(pullRequestPayload(), platformIntegration());
+
+      expect(mockCreateCodeReview).toHaveBeenCalledWith(
+        expect.objectContaining({ reviewType: 'council', repoFullName: 'acme/widgets' })
+      );
+    });
+
+    it('falls back to standard when the repo has not opted into council (entitlement not queried)', async () => {
+      mockGetBotUserId.mockResolvedValue('bot-user-1');
+      mockGetAgentConfigForOwner.mockResolvedValue({
+        ...councilConfig,
+        config: { ...councilConfig.config, council_enabled_repository_ids: [999] },
+      });
+      mockIsCouncilEntitledForOwner.mockResolvedValue(true);
+
+      await handlePullRequest(pullRequestPayload(), platformIntegration());
+
+      expect(mockCreateCodeReview).toHaveBeenCalledWith(
+        expect.objectContaining({ reviewType: 'standard' })
+      );
+      // Entitlement is only looked up when the repo opted in + council is active.
+      expect(mockIsCouncilEntitledForOwner).not.toHaveBeenCalled();
+    });
+
+    it('falls back to standard when the org is not council-entitled', async () => {
+      mockGetBotUserId.mockResolvedValue('bot-user-1');
+      mockGetAgentConfigForOwner.mockResolvedValue(councilConfig);
+      mockIsCouncilEntitledForOwner.mockResolvedValue(false);
+
+      await handlePullRequest(pullRequestPayload(), platformIntegration());
+
+      expect(mockCreateCodeReview).toHaveBeenCalledWith(
+        expect.objectContaining({ reviewType: 'standard' })
+      );
+      expect(mockIsCouncilEntitledForOwner).toHaveBeenCalled();
+    });
   });
 
   it('cancels superseded DB rows, interrupts queued/running only, and creates the new review', async () => {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.ts
@@ -13,6 +13,11 @@ import {
 } from '@/lib/code-reviews/db/code-reviews';
 import { tryDispatchPendingReviews } from '@/lib/code-reviews/dispatch/dispatch-pending-reviews';
 import { getAgentConfigForOwner } from '@/lib/agent-config/db/agent-configs';
+import {
+  determineAutomatedReviewType,
+  isCouncilActive,
+} from '@kilocode/worker-utils/code-review-council';
+import { isCouncilEntitledForOwner } from '@/lib/code-reviews/core/council-entitlement';
 import type { PlatformIntegration } from '@kilocode/db/schema';
 import type { Owner } from '@/lib/code-reviews/core';
 import { getBotUserId } from '@/lib/bot-users/bot-user-service';
@@ -297,9 +302,25 @@ export async function handlePullRequestCodeReview(
       );
     }
 
+    // 6b. Decide standard vs council for this automated review. Council is a per-repo opt-in and
+    // requires an active council config + entitlement. The entitlement lookup is a DB call, so it
+    // is gated behind the two cheap local checks (most webhooks are standard and skip it). Falls
+    // back to 'standard' if any condition is missing, so a bad/absent council config never blocks.
+    const councilConfigActive = isCouncilActive(config.council);
+    const councilEnabledForRepo =
+      Array.isArray(config.council_enabled_repository_ids) &&
+      config.council_enabled_repository_ids.includes(repository.id);
+    const councilEntitled =
+      councilConfigActive && councilEnabledForRepo ? await isCouncilEntitledForOwner(owner) : false;
+    const reviewType = determineAutomatedReviewType(
+      { isDraft: pull_request.draft ?? false, author: pull_request.user.login },
+      { councilEntitled, councilConfigActive, councilEnabledForRepo }
+    );
+
     // 7. Create review record (session_id will be updated async)
     const reviewId = await createCodeReview({
       owner,
+      reviewType,
       platformIntegrationId: integration.id,
       repoFullName: repository.full_name,
       prNumber: pull_request.number,

--- a/apps/web/src/routers/code-reviews-router.ts
+++ b/apps/web/src/routers/code-reviews-router.ts
@@ -213,6 +213,8 @@ export const personalReviewAgentRouter = createTRPCRouter({
           selectedRepositoryIds: [],
           manuallyAddedRepositories: [],
           repositoryModelOverrides: [],
+          council: null,
+          councilEnabledRepositoryIds: [],
           disableReviewMd: true,
           reviewMemoryEnabled: false,
           actionRequired: null,
@@ -245,6 +247,10 @@ export const personalReviewAgentRouter = createTRPCRouter({
             thinkingEffort: override.thinking_effort ?? null,
           })),
         disableReviewMd: cfg.disable_review_md ?? true,
+        // Council is org-only; personal configs never set it, but expose it so the query shape
+        // matches the org query (the form's `configData` is a union of the two).
+        council: cfg.council ?? null,
+        councilEnabledRepositoryIds: cfg.council_enabled_repository_ids ?? [],
         reviewMemoryEnabled: getReviewMemoryEnabledFromConfig(config.config),
         actionRequired: getCodeReviewActionRequiredState(config),
       };

--- a/apps/web/src/routers/organizations/organization-code-reviews-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-code-reviews-router.test.ts
@@ -103,3 +103,78 @@ describe('organization review agent router: toggleReviewAgent', () => {
     expect(logs).toEqual([{ message: 'Enabled AI Code Review Agent for github' }]);
   });
 });
+
+describe('organization review agent router: council config', () => {
+  afterAll(async () => {
+    for (const organizationId of createdOrganizationIds) {
+      await db
+        .delete(organization_audit_logs)
+        .where(eq(organization_audit_logs.organization_id, organizationId));
+      await db
+        .delete(agent_configs)
+        .where(eq(agent_configs.owned_by_organization_id, organizationId));
+      await db.delete(organizations).where(eq(organizations.id, organizationId));
+    }
+  });
+
+  const activeCouncil = {
+    enabled: true as const,
+    aggregation_strategy: 'unanimous' as const,
+    specialists: [
+      {
+        id: 'security',
+        role: 'security' as const,
+        name: 'Security',
+        enabled: true,
+        required: false,
+        lens: 'x',
+      },
+      {
+        id: 'performance',
+        role: 'performance' as const,
+        name: 'Performance',
+        enabled: true,
+        required: false,
+        lens: 'y',
+      },
+    ],
+  };
+
+  it('getReviewConfig exposes council fields (null/empty by default)', async () => {
+    const { owner, organization } = await createFixtureOrganization();
+    const caller = await createCallerForUser(owner.id);
+
+    const cfg = await caller.organizations.reviewAgent.getReviewConfig({
+      organizationId: organization.id,
+      platform: 'github',
+    });
+
+    expect(cfg.council).toBeNull();
+    expect(cfg.councilEnabledRepositoryIds).toEqual([]);
+  });
+
+  it('saves and reloads the council config + per-repo opt-ins for an entitled org', async () => {
+    // The fixture org has the trial bypass, which grants council entitlement (require_seats=false).
+    const { owner, organization } = await createFixtureOrganization();
+    const caller = await createCallerForUser(owner.id);
+
+    await caller.organizations.reviewAgent.saveReviewConfig({
+      organizationId: organization.id,
+      platform: 'github',
+      reviewStyle: 'balanced',
+      focusAreas: [],
+      modelSlug: 'anthropic/claude-sonnet-5',
+      council: activeCouncil,
+      councilEnabledRepositoryIds: [123, 456],
+    });
+
+    const cfg = await caller.organizations.reviewAgent.getReviewConfig({
+      organizationId: organization.id,
+      platform: 'github',
+    });
+    expect(cfg.council?.enabled).toBe(true);
+    expect(cfg.council?.aggregation_strategy).toBe('unanimous');
+    expect(cfg.council?.specialists).toHaveLength(2);
+    expect(cfg.councilEnabledRepositoryIds).toEqual([123, 456]);
+  });
+});

--- a/apps/web/src/routers/organizations/organization-code-reviews-router.ts
+++ b/apps/web/src/routers/organizations/organization-code-reviews-router.ts
@@ -29,6 +29,8 @@ import { fetchGitLabRepositoriesForOrganization } from '@/lib/cloud-agent/gitlab
 import { PRIMARY_DEFAULT_MODEL } from '@/lib/ai-gateway/models';
 import { createDefaultCodeReviewConfig } from '@/lib/code-reviews/core/default-config';
 import { isCouncilEntitledForOrganization } from '@/lib/code-reviews/core/council-entitlement';
+import { CodeReviewCouncilConfigSchema } from '@kilocode/db/schema-types';
+import { isCouncilActive } from '@kilocode/worker-utils/code-review-council';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { isPlatformIntegrationHealthy } from '@/lib/integrations/core/health';
 import {
@@ -132,6 +134,11 @@ const SaveReviewConfigInputSchema = OrganizationIdInputSchema.extend({
     .optional(),
   disableReviewMd: z.boolean().optional(),
   gateThreshold: z.enum(['off', 'all', 'warning', 'critical']).optional(),
+  // Org-level council config (specialists + governance), shared by every council-enabled repo.
+  // `null`/absent leaves council unset. Persisted only for entitled orgs (checked in the handler).
+  council: CodeReviewCouncilConfigSchema.nullable().optional(),
+  // Per-repository council opt-in: repos (by platform id) that run council on automated reviews.
+  councilEnabledRepositoryIds: z.array(z.union([z.number(), z.string()])).optional(),
   // GitLab-specific: auto-configure webhooks
   autoConfigureWebhooks: z.boolean().optional().default(true),
 });
@@ -489,6 +496,8 @@ export const organizationReviewAgentRouter = createTRPCRouter({
           selectedRepositoryIds: [],
           manuallyAddedRepositories: [],
           repositoryModelOverrides: [],
+          council: null,
+          councilEnabledRepositoryIds: [],
           disableReviewMd: true,
           reviewMemoryEnabled: false,
           actionRequired: null,
@@ -530,6 +539,8 @@ export const organizationReviewAgentRouter = createTRPCRouter({
             thinkingEffort: override.thinking_effort ?? null,
           })),
         disableReviewMd: isBitbucket ? true : (cfg.disable_review_md ?? true),
+        council: cfg.council ?? null,
+        councilEnabledRepositoryIds: cfg.council_enabled_repository_ids ?? [],
         reviewMemoryEnabled: isBitbucket ? false : getReviewMemoryEnabledFromConfig(config.config),
         actionRequired: getCodeReviewActionRequiredState(config),
       };
@@ -587,6 +598,20 @@ export const organizationReviewAgentRouter = createTRPCRouter({
             thinking_effort: override.thinkingEffort ?? null,
           }));
 
+        // Council config may only be SAVED by council-entitled orgs. This is the authoritative
+        // save-time gate (the UI also hides the section); without it a non-entitled org could
+        // persist an active council that the automated trigger would then honor.
+        const council = input.council ?? undefined;
+        if (council && isCouncilActive(council)) {
+          const entitled = await isCouncilEntitledForOrganization(input.organizationId);
+          if (!entitled) {
+            throw new TRPCError({
+              code: 'FORBIDDEN',
+              message: 'Council review requires an enterprise plan with an active subscription.',
+            });
+          }
+        }
+
         await upsertAgentConfig({
           organizationId: input.organizationId,
           agentType: 'code_review',
@@ -604,6 +629,8 @@ export const organizationReviewAgentRouter = createTRPCRouter({
             selected_repository_ids: selectedRepositoryIds,
             manually_added_repositories: isBitbucket ? [] : input.manuallyAddedRepositories || [],
             repository_model_overrides: repositoryModelOverrides,
+            council,
+            council_enabled_repository_ids: input.councilEnabledRepositoryIds ?? [],
             disable_review_md: isBitbucket ? true : (input.disableReviewMd ?? true),
             review_memory_enabled: false,
             review_analytics_enabled: false,

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1492,6 +1492,12 @@ export const CodeReviewAgentConfigSchema = z.object({
   manually_added_repositories: z.array(ManuallyAddedRepositorySchema).optional(),
   // Per-repository model overrides. Absent/empty = every repo uses the global model_slug.
   repository_model_overrides: z.array(RepositoryModelOverrideSchema).optional(),
+  // Per-repository council opt-in. A repository whose ID is listed here runs the COUNCIL review
+  // type on automated (webhook) reviews, using the single org-level `council` config above.
+  // Absent/empty = no repo runs council automatically. Only meaningful when the org is
+  // council-entitled and `council` is configured + active; the automated trigger re-checks both.
+  // Matched against the platform repository ID the same way as `selected_repository_ids`.
+  council_enabled_repository_ids: z.array(z.union([z.number(), z.string()])).optional(),
   disable_review_md: z.boolean().optional(),
   // Controls when the PR gate check (GitHub Check Run / GitLab commit status)
   // reports a failure based on review findings.

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -562,7 +562,9 @@ describe('determineAutomatedReviewType', () => {
   });
 
   it('falls back to standard when any condition is missing (fail-safe)', () => {
-    expect(determineAutomatedReviewType({}, { ...ALL_ON, councilEntitled: false })).toBe('standard');
+    expect(determineAutomatedReviewType({}, { ...ALL_ON, councilEntitled: false })).toBe(
+      'standard'
+    );
     expect(determineAutomatedReviewType({}, { ...ALL_ON, councilConfigActive: false })).toBe(
       'standard'
     );

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -644,6 +644,20 @@ describe('buildCouncilReviewSection', () => {
     expect(section).toContain('No specialist raised a blocking finding');
   });
 
+  it('states the outvoted block count on a majority pass that still had blocking votes', () => {
+    const section = buildCouncilReviewSection(
+      councilResult('pass', ['block', 'pass', 'pass', 'pass'], 'majority'),
+      { gates: true }
+    );
+    expect(section).toContain('**Decision: Approved** (Majority governance)');
+    expect(section).toContain('1 block, 3 pass');
+    // The contradictory "No specialist raised a blocking finding" must not appear here.
+    expect(section).not.toContain('No specialist raised a blocking finding');
+    expect(section).toContain(
+      '1 specialist raised a blocking finding, but the passing votes carried the Majority decision.'
+    );
+  });
+
   it('renders an advisory section with governance info but no merge decision', () => {
     const section = buildCouncilReviewSection(councilResult(null, ['pass', 'block'], 'advisory'), {
       gates: false,

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -551,12 +551,32 @@ describe('presets', () => {
 });
 
 describe('determineAutomatedReviewType', () => {
-  it('is a safe stub that always returns standard', () => {
-    expect(determineAutomatedReviewType({}, { councilAvailable: true })).toBe('standard');
+  const ALL_ON = {
+    councilEntitled: true,
+    councilConfigActive: true,
+    councilEnabledForRepo: true,
+  };
+
+  it('returns council only when entitled AND config active AND repo opted in', () => {
+    expect(determineAutomatedReviewType({}, ALL_ON)).toBe('council');
+  });
+
+  it('falls back to standard when any condition is missing (fail-safe)', () => {
+    expect(determineAutomatedReviewType({}, { ...ALL_ON, councilEntitled: false })).toBe('standard');
+    expect(determineAutomatedReviewType({}, { ...ALL_ON, councilConfigActive: false })).toBe(
+      'standard'
+    );
+    expect(determineAutomatedReviewType({}, { ...ALL_ON, councilEnabledForRepo: false })).toBe(
+      'standard'
+    );
+  });
+
+  it('does not use SCM-controlled PR facts (a "council" label cannot force council)', () => {
+    // Entitlement/config/opt-in are Kilo-side; a dev-controlled label must not upgrade the type.
     expect(
       determineAutomatedReviewType(
         { isDraft: false, labels: ['council'], changedFileCount: 40 },
-        { councilAvailable: true }
+        { councilEntitled: false, councilConfigActive: false, councilEnabledForRepo: false }
       )
     ).toBe('standard');
   });

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -716,20 +716,30 @@ export type AutomatedReviewPrFacts = {
 };
 
 /**
- * Determines the review type for an AUTOMATED (webhook) run from PR facts.
+ * Determines the review type for an AUTOMATED (webhook) run.
  *
- * STUB (intentional, phased plan): the real standard-vs-council determination is later
- * work — it must be configured/evaluated Kilo-side and resistant to SCM-side abuse (a
- * dev must not be able to force paid council reviews via a PR label). For now this is a
- * safe stub that always returns `'standard'`, so automated reviews behave exactly as
- * they do today. The plumbing (passing full PR facts + `councilAvailable`) is defined
- * here so the logic can be filled in at the webhook step without further wiring.
+ * Plan A: an automated review runs the COUNCIL type only when ALL of these hold, otherwise it
+ * falls back to `'standard'` (fail-safe — a bad or missing council config never blocks reviews):
+ * - `councilEntitled` — the org is council-entitled (enterprise + active entitlement). This is
+ *   the abuse-resistant gate: it is decided Kilo-side, never from an SCM-controlled signal.
+ * - `councilConfigActive` — the org has a configured, active council (>= min specialists).
+ * - `councilEnabledForRepo` — the target repo explicitly opted in
+ *   (`config.council_enabled_repository_ids`). Council is per-repo opt-in, not org-wide.
  *
- * Manual runs never call this — they carry an explicit user-selected review type.
+ * PR-facts based gating (draft/size/labels) is intentionally NOT applied yet: every PR on an
+ * opted-in repo gets a council review. `prFacts` is threaded through so that policy can be added
+ * here later without re-wiring the webhook handlers. Manual runs never call this — they carry an
+ * explicit user-selected review type.
  */
 export function determineAutomatedReviewType(
   _prFacts: AutomatedReviewPrFacts,
-  _options: { councilAvailable: boolean }
+  options: {
+    councilEntitled: boolean;
+    councilConfigActive: boolean;
+    councilEnabledForRepo: boolean;
+  }
 ): CodeReviewType {
-  return 'standard';
+  const useCouncil =
+    options.councilEntitled && options.councilConfigActive && options.councilEnabledForRepo;
+  return useCouncil ? 'council' : 'standard';
 }

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -583,7 +583,12 @@ export function buildCouncilReviewSection(
       : 'This manual review reports the decision but does not block merge. An automated review with this decision would block merge until the blocking findings are addressed.';
   } else if (result.decision === 'pass') {
     decisionLine = `**Decision: Approved** (${governanceLabel} governance)`;
-    detailLine = 'No specialist raised a blocking finding.';
+    // Under majority governance a pass can still carry blocking votes (they were outvoted); only
+    // claim "no blocking finding" when that is actually true, otherwise state the outvoted count.
+    detailLine =
+      blockVotes > 0
+        ? `${blockVotes} specialist${blockVotes === 1 ? '' : 's'} raised a blocking finding, but the passing votes carried the ${governanceLabel} decision.`
+        : 'No specialist raised a blocking finding.';
   } else {
     // Advisory: the governance label already reads "Advisory (report only)", so don't repeat it
     // in the decision line — the governance-mode line below states it once.


### PR DESCRIPTION
## Summary

Adds per-repository opt-in for Council reviews on automated (webhook) pull
requests. A repository listed in the new `council_enabled_repository_ids` config
field runs the Council review type when its PRs are reviewed via webhook, using
the single org-level `council` config. Repositories not listed continue to get a
standard review. This is the path that lets a Council review run automatically on
a PR (trigger, execute, post the verdict, and drive the merge gate) rather than
only from a manual run.

## Changes

- **Config schema**: add `council_enabled_repository_ids` to
  `CodeReviewAgentConfigSchema` (`packages/db/src/schema-types.ts`). Absent/empty
  means no repo runs Council automatically. Matched against the platform
  repository ID the same way as `selected_repository_ids`.
- **Webhook trigger** (`pull-request-handler.ts`): choose standard vs council per
  PR with `determineAutomatedReviewType`, gated on an active council config, the
  per-repo opt-in, and entitlement. The entitlement lookup is a DB call, so it
  only runs after the two cheap local checks pass; any missing condition falls
  back to `standard` so a bad or absent council config never blocks a review.
- **Review type selection** (`worker-utils/code-review-council.ts`): add
  `determineAutomatedReviewType`, returning `council` only when entitled, config
  active, and the repo opted in.
- **Config UI** (`ReviewConfigForm.tsx`, `ReviewAgentPageClient.tsx`): restructure
  the form into a Global Settings section (defaults every repo inherits) and a
  master "Advanced Settings" toggle that reveals per-repo overrides: repository
  selection, per-repo model, and per-repo Council toggles with a shared specialist
  picker. Add `councilSelectionsFromConfig` to hydrate the picker from a saved
  config.
- **Routers** (`organization-code-reviews-router.ts`, `code-reviews-router.ts`):
  expose and persist `council` and `councilEnabledRepositoryIds` in
  `getReviewConfig`/`saveReviewConfig`, with an entitlement guard that rejects
  saving an active council config for a non-entitled org.
- **Finalize / status callback** (`finalize-council-result.ts`,
  `code-review-status/[reviewId]/route.ts`): let the council result fall back to
  the org-level agent config for webhook reviews (which have no per-run manual
  config) via `resolveOrgCodeReviewAgentConfig` and an `orgAgentConfig` param.
  Automated council reviews drive the merge gate and post the council verdict
  section into the PR summary.
- **Fix**: the council review section no longer prints "No specialist raised a
  blocking finding" on a majority pass that actually had outvoted blocking votes;
  it now states the outvoted block count.
- **Fix**: Council opt-ins for repositories the user later deselects are dropped
  (intersected with the live selection) instead of persisting a stale ID that
  could keep the specialist picker open, block save on the minimum-specialist
  check, or silently re-activate Council if the repo is re-added.
- Tests added/updated for the review-type decision, the config round-trip, the
  picker hydration, the org-config fallback, and the verdict-section copy.

## Verification

- [x] Locally fired a signed GitHub `pull_request` webhook at a council-enabled,
  council-entitled org repo: confirmed it created a `council` review, executed,
  posted the verdict section plus inline comments, and set the merge gate check to
  `failure` (blocked). Pushed a fix and fired a `synchronize` webhook: confirmed a
  fresh council review ran, returned a pass decision, and flipped the gate check to
  `success` (unblocked).

## Visual Changes

The code review config screen was restructured (Global Settings section + a master
Advanced Settings toggle exposing per-repo model and Council controls). Screenshots
to be added.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- `determineAutomatedReviewType` intentionally fails closed to `standard`, so any
  missing entitlement/config condition yields a normal review rather than an error.
- The entitlement DB lookup is deliberately behind the two local checks to keep the
  common (standard) webhook path from adding a query.
- Council remains a single org-level config; `council_enabled_repository_ids` only
  controls which repos opt that shared config into automated reviews. There is no
  per-repo specialist config in this PR.
