### PR TITLE
fix(cost-insights): show pre-coverage spend evidence

### DIFF
--- a/apps/web/src/lib/cost-insights/presenter.test.ts
+++ b/apps/web/src/lib/cost-insights/presenter.test.ts
@@ -628,7 +628,7 @@ describe('Cost Insights presenter', () => {
       )
     ).toEqual([
       {
-        label: '11 PM',
+        label: '23',
         periodStart: '2026-06-25T23:00:00.000Z',
         periodEndExclusive: '2026-06-26T00:00:00.000Z',
         coverage: 'partial',

--- a/apps/web/src/lib/cost-insights/presenter.test.ts
+++ b/apps/web/src/lib/cost-insights/presenter.test.ts
@@ -610,6 +610,36 @@ describe('Cost Insights presenter', () => {
     ]);
   });
 
+  it('shows driver-backed spend from an uncovered hour as partial evidence', () => {
+    expect(
+      formatSpendEvidence(
+        [
+          {
+            hourStart: '2026-06-25T23:00:00.000Z',
+            variableMicrodollars: 4_000_000,
+            scheduledMicrodollars: 1_000_000,
+            totalMicrodollars: 5_000_000,
+            variableRecordCount: 2,
+            scheduledRecordCount: 1,
+            isCovered: false,
+          },
+        ],
+        '24h'
+      )
+    ).toEqual([
+      {
+        label: '11 PM',
+        periodStart: '2026-06-25T23:00:00.000Z',
+        periodEndExclusive: '2026-06-26T00:00:00.000Z',
+        coverage: 'partial',
+        coveredHours: 0,
+        totalHours: 1,
+        variableUsd: 4,
+        scheduledUsd: 1,
+      },
+    ]);
+  });
+
   it('retains period boundaries and sums only fully covered 90-day buckets', () => {
     const points = Array.from({ length: 2 }, (_, index) => ({
       hourStart: `2026-06-25T${String(22 + index).padStart(2, '0')}:00:00.000Z`,

--- a/apps/web/src/lib/cost-insights/presenter.ts
+++ b/apps/web/src/lib/cost-insights/presenter.ts
@@ -194,12 +194,15 @@ export function normalizeCostInsightTimestamp(value: string | Date): string {
   return new Date(value).toISOString();
 }
 
-function requireCoveredAmounts(point: OwnerHourlySpend): {
+function knownAmounts(point: OwnerHourlySpend): {
   variableMicrodollars: number;
   scheduledMicrodollars: number;
-} {
+} | null {
   if (point.variableMicrodollars === null || point.scheduledMicrodollars === null) {
-    throw new Error('Covered Cost Insights evidence must include both spend categories.');
+    if (point.isCovered) {
+      throw new Error('Covered Cost Insights evidence must include both spend categories.');
+    }
+    return null;
   }
   return {
     variableMicrodollars: point.variableMicrodollars,
@@ -215,6 +218,10 @@ function presentEvidenceBucket(points: OwnerHourlySpend[]): SpendEvidencePoint {
   }
 
   const covered = points.filter(point => point.isCovered);
+  const known = points.flatMap(point => {
+    const amounts = knownAmounts(point);
+    return amounts ? [{ point, amounts }] : [];
+  });
   const common = {
     label: formatDayLabel(first.hourStart),
     periodStart: normalizeCostInsightTimestamp(first.hourStart),
@@ -222,13 +229,12 @@ function presentEvidenceBucket(points: OwnerHourlySpend[]): SpendEvidencePoint {
     coveredHours: covered.length,
     totalHours: points.length,
   };
-  if (covered.length === 0) {
+  if (known.length === 0) {
     return { ...common, coverage: 'unavailable', variableUsd: null, scheduledUsd: null };
   }
   let variableMicrodollars = 0;
   let scheduledMicrodollars = 0;
-  for (const point of covered) {
-    const amounts = requireCoveredAmounts(point);
+  for (const { amounts } of known) {
     variableMicrodollars += amounts.variableMicrodollars;
     scheduledMicrodollars += amounts.scheduledMicrodollars;
   }
@@ -268,7 +274,8 @@ export function formatSpendEvidence(
         coveredHours: point.isCovered ? 1 : 0,
         totalHours: 1,
       };
-      if (!point.isCovered) {
+      const amounts = knownAmounts(point);
+      if (!amounts) {
         return {
           ...common,
           coverage: 'unavailable' as const,
@@ -276,10 +283,9 @@ export function formatSpendEvidence(
           scheduledUsd: null,
         };
       }
-      const amounts = requireCoveredAmounts(point);
       return {
         ...common,
-        coverage: 'complete' as const,
+        coverage: point.isCovered ? ('complete' as const) : ('partial' as const),
         variableUsd: microdollarsToUsd(amounts.variableMicrodollars),
         scheduledUsd: microdollarsToUsd(amounts.scheduledMicrodollars),
       };

--- a/apps/web/src/lib/cost-insights/spend-repository.integration.test.ts
+++ b/apps/web/src/lib/cost-insights/spend-repository.integration.test.ts
@@ -77,6 +77,63 @@ afterEach(async () => {
 });
 
 describe('Cost Insights spend repository integration', () => {
+  test('shows driver-bucket spend before total-rollup coverage as incomplete evidence', async () => {
+    const userId = await createUser();
+    const driver = await aiGatewayDriver('historical-model', userId);
+    await db.insert(cost_insight_rollup_coverage).values({
+      rollup_version: 1,
+      live_capture_start_hour: '2026-06-01T02:00:00.000Z',
+      coverage_start_hour: '2026-06-01T02:00:00.000Z',
+    });
+    await db.insert(cost_insight_owner_hour_driver_buckets).values({
+      owned_by_user_id: userId,
+      hour_start: '2026-06-01T00:00:00.000Z',
+      spend_category: 'variable',
+      driver_key: driver.driverKey,
+      source: driver.source,
+      product_key: driver.productKey,
+      feature_key: driver.featureKey,
+      model_or_plan_key: driver.modelOrPlanKey,
+      provider_key: driver.providerKey,
+      actor_user_id: driver.actorUserId,
+      total_microdollars: 25,
+      spend_record_count: 2,
+    });
+    await db.insert(cost_insight_owner_hour_totals).values({
+      owned_by_user_id: userId,
+      hour_start: '2026-06-01T02:00:00.000Z',
+      spend_category: 'variable',
+      total_microdollars: 10,
+      spend_record_count: 1,
+    });
+
+    await expect(
+      loadOwnerDashboardHourlySpend(db, {
+        owner: { type: 'user', id: userId },
+        startHour: '2026-06-01T00:00:00.000Z',
+        endHourExclusive: '2026-06-01T03:00:00.000Z',
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({
+        hourStart: '2026-06-01T00:00:00.000Z',
+        variableMicrodollars: 25,
+        totalMicrodollars: 25,
+        isCovered: false,
+      }),
+      expect.objectContaining({
+        hourStart: '2026-06-01T01:00:00.000Z',
+        totalMicrodollars: null,
+        isCovered: false,
+      }),
+      expect.objectContaining({
+        hourStart: '2026-06-01T02:00:00.000Z',
+        variableMicrodollars: 10,
+        totalMicrodollars: 10,
+        isCovered: true,
+      }),
+    ]);
+  });
+
   test('replaces separated degraded dashboard hours with canonical spend', async () => {
     const userId = await createUser();
     await initializeCoverage();

--- a/apps/web/src/lib/cost-insights/spend-repository.test.ts
+++ b/apps/web/src/lib/cost-insights/spend-repository.test.ts
@@ -211,7 +211,18 @@ describe('Cost Insights spend repository', () => {
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            hour_start: '2026-06-01 00:00:00+00',
+            variable_microdollars: '5',
+            scheduled_microdollars: '3',
+            variable_record_count: '1',
+            scheduled_record_count: '1',
+          },
+        ],
+      });
     const database = {
       transaction: async (callback: (transaction: CostInsightQueryExecutor) => Promise<unknown>) =>
         await callback({ execute } as unknown as CostInsightQueryExecutor),
@@ -226,7 +237,9 @@ describe('Cost Insights spend repository', () => {
     ).resolves.toEqual([
       expect.objectContaining({
         hourStart: '2026-06-01T00:00:00.000Z',
-        totalMicrodollars: null,
+        variableMicrodollars: 5,
+        scheduledMicrodollars: 3,
+        totalMicrodollars: 8,
         isCovered: false,
       }),
       expect.objectContaining({
@@ -241,9 +254,9 @@ describe('Cost Insights spend repository', () => {
       }),
     ]);
 
-    expect(execute).toHaveBeenCalledTimes(7);
+    expect(execute).toHaveBeenCalledTimes(8);
     const canonicalQueries = execute.mock.calls
-      .slice(3)
+      .slice(3, 7)
       .map(([query]) => new PgDialect().sqlToQuery(query).params);
     expect(canonicalQueries).toEqual(
       expect.arrayContaining([
@@ -253,6 +266,10 @@ describe('Cost Insights spend repository', () => {
     for (const queryParameters of canonicalQueries) {
       expect(queryParameters).not.toContain('2026-06-01T00:00:00.000Z');
     }
+    const driverQueryParameters = new PgDialect().sqlToQuery(execute.mock.calls[7]?.[0]).params;
+    expect(driverQueryParameters).toEqual(
+      expect.arrayContaining(['2026-06-01T00:00:00.000Z', '2026-06-01T01:00:00.000Z'])
+    );
   });
 
   test('adds current-hour categories using safe integer conversion', async () => {

--- a/apps/web/src/lib/cost-insights/spend-repository.ts
+++ b/apps/web/src/lib/cost-insights/spend-repository.ts
@@ -128,6 +128,14 @@ type DenseHourlySpendRow = {
   is_covered: boolean;
 };
 
+type HourlyDriverSpendRow = {
+  hour_start: string | Date;
+  variable_microdollars: string | number | bigint;
+  scheduled_microdollars: string | number | bigint;
+  variable_record_count: string | number | bigint;
+  scheduled_record_count: string | number | bigint;
+};
+
 type TopDriverRow = {
   spend_category: CostInsightSpendCategory;
   source: CostInsightSpendSource;
@@ -552,6 +560,77 @@ function canonicalHourlySpend(
   return points;
 }
 
+async function getOwnerHourlyDriverSpend(
+  executor: CostInsightQueryExecutor,
+  params: {
+    owner: CostInsightSpendOwner;
+    startHour: string;
+    endHourExclusive: string;
+  }
+): Promise<Map<string, Omit<OwnerHourlySpend, 'hourStart' | 'isCovered'>>> {
+  const range = requireHourlyRange(params);
+  const owner = params.owner;
+  const result = await executor.execute<HourlyDriverSpendRow>(sql`
+    SELECT
+      ${cost_insight_owner_hour_driver_buckets.hour_start} AS hour_start,
+      COALESCE(SUM(${cost_insight_owner_hour_driver_buckets.total_microdollars})
+        FILTER (WHERE ${cost_insight_owner_hour_driver_buckets.spend_category} = 'variable'), 0)::text
+        AS variable_microdollars,
+      COALESCE(SUM(${cost_insight_owner_hour_driver_buckets.total_microdollars})
+        FILTER (WHERE ${cost_insight_owner_hour_driver_buckets.spend_category} = 'scheduled'), 0)::text
+        AS scheduled_microdollars,
+      COALESCE(SUM(${cost_insight_owner_hour_driver_buckets.spend_record_count})
+        FILTER (WHERE ${cost_insight_owner_hour_driver_buckets.spend_category} = 'variable'), 0)::text
+        AS variable_record_count,
+      COALESCE(SUM(${cost_insight_owner_hour_driver_buckets.spend_record_count})
+        FILTER (WHERE ${cost_insight_owner_hour_driver_buckets.spend_category} = 'scheduled'), 0)::text
+        AS scheduled_record_count
+    FROM ${cost_insight_owner_hour_driver_buckets}
+    WHERE ${cost_insight_owner_hour_driver_buckets.hour_start} >= ${range.startHour}
+      AND ${cost_insight_owner_hour_driver_buckets.hour_start} < ${range.endHourExclusive}
+      AND ${ownerPredicate(
+        owner,
+        sql`${cost_insight_owner_hour_driver_buckets.owned_by_user_id}`,
+        sql`${cost_insight_owner_hour_driver_buckets.owned_by_organization_id}`
+      )}
+    GROUP BY 1
+    ORDER BY 1 ASC
+  `);
+
+  return new Map(
+    result.rows.map(row => {
+      const variableMicrodollars = parseSafeDatabaseInteger(
+        row.variable_microdollars,
+        'driver variable_microdollars'
+      );
+      const scheduledMicrodollars = parseSafeDatabaseInteger(
+        row.scheduled_microdollars,
+        'driver scheduled_microdollars'
+      );
+      return [
+        normalizeDatabaseTimestamp(row.hour_start, 'driver hour_start'),
+        {
+          variableMicrodollars,
+          scheduledMicrodollars,
+          totalMicrodollars: sumSafe(
+            variableMicrodollars,
+            scheduledMicrodollars,
+            'driver hourly total microdollars'
+          ),
+          variableRecordCount: parseSafeDatabaseInteger(
+            row.variable_record_count,
+            'driver variable_record_count'
+          ),
+          scheduledRecordCount: parseSafeDatabaseInteger(
+            row.scheduled_record_count,
+            'driver scheduled_record_count'
+          ),
+        },
+      ];
+    })
+  );
+}
+
 export async function loadOwnerDashboardHourlySpend(
   primaryDatabase: ExactRollingDatabase,
   params: {
@@ -579,24 +658,45 @@ export async function loadOwnerDashboardHourlySpend(
         ),
         false
       );
-      if (!hasIntervals(uncoveredIntervals)) return rollupPoints;
-
-      const canonicalPoints = await withCanonicalFallbackTelemetry(
-        'dashboard_evidence_90d',
-        uncoveredIntervals,
-        async () =>
-          canonicalHourlySpend(
-            await loadCanonicalCostInsightAggregationsByIntervals(transaction, {
-              owner: params.owner,
-              intervals: toCanonicalIntervals(uncoveredIntervals),
-            }),
-            uncoveredIntervals
+      const canonicalByHour = hasIntervals(uncoveredIntervals)
+        ? new Map(
+            (
+              await withCanonicalFallbackTelemetry(
+                'dashboard_evidence_90d',
+                uncoveredIntervals,
+                async () =>
+                  canonicalHourlySpend(
+                    await loadCanonicalCostInsightAggregationsByIntervals(transaction, {
+                      owner: params.owner,
+                      intervals: toCanonicalIntervals(uncoveredIntervals),
+                    }),
+                    uncoveredIntervals
+                  )
+              )
+            ).map(point => [point.hourStart, point])
           )
-      );
-      const canonicalByHour = new Map(canonicalPoints.map(point => [point.hourStart, point]));
-      return rollupPoints.map(point =>
+        : new Map<string, OwnerHourlySpend>();
+      const pointsWithCanonicalFallback = rollupPoints.map(point =>
         point.isCovered ? point : (canonicalByHour.get(point.hourStart) ?? point)
       );
+
+      const preCoverageEnd = effectiveCoverageStart
+        ? new Date(
+            Math.min(Date.parse(effectiveCoverageStart), Date.parse(range.endHourExclusive))
+          ).toISOString()
+        : range.endHourExclusive;
+      if (preCoverageEnd <= range.startHour) return pointsWithCanonicalFallback;
+
+      const driverSpendByHour = await getOwnerHourlyDriverSpend(transaction, {
+        owner: params.owner,
+        startHour: range.startHour,
+        endHourExclusive: preCoverageEnd,
+      });
+      return pointsWithCanonicalFallback.map(point => {
+        if (point.isCovered || point.hourStart >= preCoverageEnd) return point;
+        const driverSpend = driverSpendByHour.get(point.hourStart);
+        return driverSpend ? { ...point, ...driverSpend } : point;
+      });
     },
     { isolationLevel: 'repeatable read', accessMode: 'read only' }
   );


### PR DESCRIPTION
## Summary

Show known historical spend in Cost Insights when contributor rollups exist before total-rollup coverage begins.

### Why this change is needed

The spend chart could show little or no historical spend while the largest-contributors list showed thousands of dollars for the same period. The previous fix only retained spend from covered total buckets, so it could not recover historical evidence stored only in driver buckets.

### How this is addressed

- Aggregate owner-scoped driver buckets for hours before total-rollup coverage.
- Surface those amounts as known lower-bound spend without marking the hours fully covered.
- Keep hours without driver evidence unavailable and preserve canonical fallback behavior for degraded covered hours.
- Add repository, database-integration, and presenter regression coverage.

## Local Verification

- The local eight-focus code review passed with no findings.
- React Doctor completed with a 92/100 score; reported warnings were outside the changed hunks.

## Reviewer Notes

### Human Reviewer Flags

- Pre-coverage driver totals are intentionally presented as partial lower-bound evidence. They improve consistency with the contributor list without claiming complete historical coverage.

### Code Reviewer Agent

<details>
<summary>Code Reviewer Notes</summary>

- The fallback query is owner-scoped and bounded to the pre-coverage portion of the existing 90-day dashboard range.
- Canonical fallback remains authoritative for degraded hours at or after the declared coverage boundary.
- Driver-backed hours retain `isCovered: false`, and the presenter maps known amounts in those hours to partial evidence.

</details>
