### PR TITLE
fix(admin): destroy KiloClaw instances during GDPR deletion

### DIFF
--- a/apps/web/src/app/admin/api/users/gdpr-removal/route.test.ts
+++ b/apps/web/src/app/admin/api/users/gdpr-removal/route.test.ts
@@ -158,6 +158,26 @@ describe('POST /admin/api/users/gdpr-removal', () => {
     expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error), expect.any(Object));
   });
 
+  test('reports a rollback failure without masking the worker destruction error', async () => {
+    const destroyError = new Error('worker unavailable');
+    const rollbackError = new Error('instance batch changed concurrently');
+    destroy.mockRejectedValueOnce(destroyError);
+    mockedRestoreGdprDestroyedInstanceBatch.mockRejectedValueOnce(rollbackError);
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(500);
+    expect(mockedCaptureException).toHaveBeenNthCalledWith(1, rollbackError, {
+      tags: { source: 'gdpr-removal', operation: 'restore-instance-batch' },
+      extra: { userId: USER_ID, instanceIds: ['instance-one'] },
+    });
+    expect(mockedCaptureException).toHaveBeenNthCalledWith(2, destroyError, {
+      tags: { source: 'gdpr-removal' },
+      extra: { userId: USER_ID },
+    });
+    expect(mockedSoftDeleteUser).not.toHaveBeenCalled();
+  });
+
   test('returns subscription precondition failures before destructive calls', async () => {
     mockedAssertUserCanBeSoftDeleted.mockRejectedValue(
       new SoftDeletePreconditionError('active subscription')

--- a/apps/web/src/app/admin/api/users/gdpr-removal/route.test.ts
+++ b/apps/web/src/app/admin/api/users/gdpr-removal/route.test.ts
@@ -1,0 +1,186 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getUserFromAuth } from '@/lib/user/server';
+import {
+  assertUserCanBeSoftDeleted,
+  softDeleteUser,
+  SoftDeletePreconditionError,
+  findUserById,
+} from '@/lib/user';
+import { softDeleteUserExternalServices } from '@/lib/external-services';
+import {
+  listAllActiveInstanceRows,
+  markActiveInstanceBatchDestroyedForGdpr,
+  restoreGdprDestroyedInstanceBatch,
+  workerInstanceId,
+} from '@/lib/kiloclaw/instance-registry';
+import { captureException } from '@sentry/nextjs';
+import { POST } from './route';
+
+jest.mock('@/lib/user/server');
+jest.mock('@/lib/user');
+jest.mock('@/lib/external-services');
+jest.mock('@/lib/kiloclaw/instance-registry');
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
+
+const destroy = jest.fn();
+jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
+  KiloClawInternalClient: jest.fn().mockImplementation(() => ({ destroy })),
+}));
+
+const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
+const mockedFindUserById = jest.mocked(findUserById);
+const mockedAssertUserCanBeSoftDeleted = jest.mocked(assertUserCanBeSoftDeleted);
+const mockedSoftDeleteUser = jest.mocked(softDeleteUser);
+const mockedSoftDeleteUserExternalServices = jest.mocked(softDeleteUserExternalServices);
+const mockedListAllActiveInstanceRows = jest.mocked(listAllActiveInstanceRows);
+const mockedMarkActiveInstanceBatchDestroyedForGdpr = jest.mocked(
+  markActiveInstanceBatchDestroyedForGdpr
+);
+const mockedRestoreGdprDestroyedInstanceBatch = jest.mocked(restoreGdprDestroyedInstanceBatch);
+const mockedWorkerInstanceId = jest.mocked(workerInstanceId);
+const mockedCaptureException = jest.mocked(captureException);
+
+const USER_ID = 'user-id';
+const activeInstances = [
+  {
+    id: 'instance-one',
+    userId: USER_ID,
+    sandboxId: 'ki_one',
+    organizationId: null,
+    name: null,
+    inboundEmailEnabled: false,
+  },
+  {
+    id: 'instance-two',
+    userId: USER_ID,
+    sandboxId: 'legacy-user-derived-sandbox',
+    organizationId: null,
+    name: null,
+    inboundEmailEnabled: false,
+  },
+] as const;
+
+function request() {
+  return new NextRequest('http://localhost:3000/admin/api/users/gdpr-removal', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId: USER_ID }),
+  });
+}
+
+describe('POST /admin/api/users/gdpr-removal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: { id: 'admin-id' },
+      authFailedResponse: null,
+    } as never);
+    mockedFindUserById.mockResolvedValue({ id: USER_ID } as never);
+    mockedAssertUserCanBeSoftDeleted.mockResolvedValue();
+    mockedSoftDeleteUser.mockResolvedValue();
+    mockedSoftDeleteUserExternalServices.mockResolvedValue([]);
+    mockedListAllActiveInstanceRows.mockResolvedValue([...activeInstances]);
+    mockedMarkActiveInstanceBatchDestroyedForGdpr.mockImplementation(
+      async (_userId, instanceIds) => ({
+        userId: USER_ID,
+        instanceIds,
+        destroyedAt: '2026-07-21T12:00:00.000Z',
+      })
+    );
+    mockedWorkerInstanceId.mockImplementation(instance =>
+      instance?.sandboxId?.startsWith('ki_') ? instance.id : undefined
+    );
+    destroy.mockResolvedValue({});
+  });
+
+  test('groups duplicate legacy rows into one worker destroy and processes instance-keyed rows separately', async () => {
+    mockedListAllActiveInstanceRows.mockResolvedValue([
+      activeInstances[1],
+      { ...activeInstances[1], id: 'legacy-duplicate' },
+      activeInstances[0],
+      { ...activeInstances[0], id: 'instance-three', sandboxId: 'ki_three' },
+    ]);
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mockedMarkActiveInstanceBatchDestroyedForGdpr).toHaveBeenNthCalledWith(1, USER_ID, [
+      'instance-two',
+      'legacy-duplicate',
+    ]);
+    expect(destroy).toHaveBeenNthCalledWith(1, USER_ID, undefined, {
+      reason: 'admin_request',
+    });
+    expect(mockedMarkActiveInstanceBatchDestroyedForGdpr).toHaveBeenNthCalledWith(2, USER_ID, [
+      'instance-one',
+    ]);
+    expect(destroy).toHaveBeenNthCalledWith(2, USER_ID, 'instance-one', {
+      reason: 'admin_request',
+    });
+    expect(mockedMarkActiveInstanceBatchDestroyedForGdpr).toHaveBeenNthCalledWith(3, USER_ID, [
+      'instance-three',
+    ]);
+    expect(destroy).toHaveBeenNthCalledWith(3, USER_ID, 'instance-three', {
+      reason: 'admin_request',
+    });
+    expect(
+      mockedMarkActiveInstanceBatchDestroyedForGdpr.mock.invocationCallOrder[1]
+    ).toBeGreaterThan(destroy.mock.invocationCallOrder[0] ?? 0);
+    expect(mockedSoftDeleteUser).toHaveBeenCalledWith(USER_ID);
+    expect(mockedSoftDeleteUser.mock.invocationCallOrder[0]).toBeGreaterThan(
+      destroy.mock.invocationCallOrder[2] ?? 0
+    );
+  });
+
+  test('soft-deletes users with no active instances', async () => {
+    mockedListAllActiveInstanceRows.mockResolvedValue([]);
+
+    const noInstancesResponse = await POST(request());
+
+    expect(noInstancesResponse.status).toBe(200);
+    expect(mockedMarkActiveInstanceBatchDestroyedForGdpr).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+    expect(mockedSoftDeleteUser).toHaveBeenCalledWith(USER_ID);
+  });
+
+  test('restores the failed batch and does not soft-delete when worker destruction fails', async () => {
+    destroy.mockRejectedValueOnce(new Error('worker unavailable'));
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(500);
+    expect(mockedRestoreGdprDestroyedInstanceBatch).toHaveBeenCalledWith({
+      userId: USER_ID,
+      instanceIds: ['instance-one'],
+      destroyedAt: '2026-07-21T12:00:00.000Z',
+    });
+    expect(mockedSoftDeleteUser).not.toHaveBeenCalled();
+    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error), expect.any(Object));
+  });
+
+  test('returns subscription precondition failures before destructive calls', async () => {
+    mockedAssertUserCanBeSoftDeleted.mockRejectedValue(
+      new SoftDeletePreconditionError('active subscription')
+    );
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(400);
+    expect(mockedListAllActiveInstanceRows).not.toHaveBeenCalled();
+    expect(mockedMarkActiveInstanceBatchDestroyedForGdpr).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+    expect(mockedSoftDeleteUser).not.toHaveBeenCalled();
+  });
+
+  test('returns the authentication failure without looking up the target user', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: null,
+      authFailedResponse: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    } as never);
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(401);
+    expect(mockedFindUserById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/admin/api/users/gdpr-removal/route.ts
+++ b/apps/web/src/app/admin/api/users/gdpr-removal/route.ts
@@ -2,7 +2,19 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user/server';
 import { softDeleteUserExternalServices } from '@/lib/external-services';
-import { softDeleteUser, SoftDeletePreconditionError, findUserById } from '@/lib/user';
+import {
+  assertUserCanBeSoftDeleted,
+  softDeleteUser,
+  SoftDeletePreconditionError,
+  findUserById,
+} from '@/lib/user';
+import {
+  listAllActiveInstanceRows,
+  markActiveInstanceBatchDestroyedForGdpr,
+  restoreGdprDestroyedInstanceBatch,
+  workerInstanceId,
+} from '@/lib/kiloclaw/instance-registry';
+import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { captureException } from '@sentry/nextjs';
 
 type GdprRemovalResponse =
@@ -36,6 +48,31 @@ export async function POST(request: NextRequest): Promise<NextResponse<GdprRemov
   }
 
   try {
+    await assertUserCanBeSoftDeleted(userId);
+
+    const groups = new Map<string, { instanceIds: string[]; workerInstanceId?: string }>();
+    for (const instance of await listAllActiveInstanceRows(userId)) {
+      const instanceId = workerInstanceId(instance);
+      const key = instanceId ?? 'legacy';
+      const group = groups.get(key) ?? { instanceIds: [], workerInstanceId: instanceId };
+      group.instanceIds.push(instance.id);
+      groups.set(key, group);
+    }
+
+    // Process rows serially. Legacy instances share one user-routed worker;
+    // instance-keyed rows each route to their own worker.
+    for (const group of groups.values()) {
+      const batch = await markActiveInstanceBatchDestroyedForGdpr(userId, group.instanceIds);
+      try {
+        await new KiloClawInternalClient().destroy(userId, group.workerInstanceId, {
+          reason: 'admin_request',
+        });
+      } catch (error) {
+        await restoreGdprDestroyedInstanceBatch(batch);
+        throw error;
+      }
+    }
+
     await softDeleteUser(userId);
   } catch (error) {
     if (error instanceof SoftDeletePreconditionError) {

--- a/apps/web/src/app/admin/api/users/gdpr-removal/route.ts
+++ b/apps/web/src/app/admin/api/users/gdpr-removal/route.ts
@@ -68,7 +68,14 @@ export async function POST(request: NextRequest): Promise<NextResponse<GdprRemov
           reason: 'admin_request',
         });
       } catch (error) {
-        await restoreGdprDestroyedInstanceBatch(batch);
+        try {
+          await restoreGdprDestroyedInstanceBatch(batch);
+        } catch (rollbackError) {
+          captureException(rollbackError, {
+            tags: { source: 'gdpr-removal', operation: 'restore-instance-batch' },
+            extra: { userId, instanceIds: batch.instanceIds },
+          });
+        }
         throw error;
       }
     }

--- a/apps/web/src/lib/kiloclaw/instance-registry.test.ts
+++ b/apps/web/src/lib/kiloclaw/instance-registry.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { CURRENT_KILOCLAW_PRICE_VERSION } from '@kilocode/db';
+import {
+  kiloclaw_instances,
+  kiloclaw_subscription_change_log,
+  kiloclaw_subscriptions,
+} from '@kilocode/db/schema';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { cleanupDbForTest, db } from '@/lib/drizzle';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import {
+  markActiveInstanceBatchDestroyedForGdpr,
+  restoreGdprDestroyedInstanceBatch,
+} from './instance-registry';
+
+async function insertInstance(userId: string, sandboxId: string): Promise<string> {
+  const [instance] = await db
+    .insert(kiloclaw_instances)
+    .values({ sandbox_id: sandboxId, user_id: userId })
+    .returning({ id: kiloclaw_instances.id });
+  return instance.id;
+}
+
+describe('GDPR instance registry batches', () => {
+  afterEach(async () => {
+    await cleanupDbForTest();
+  });
+
+  it('changes only destroyed_at without changing subscription lineage or logs', async () => {
+    const user = await insertTestUser();
+    const instanceId = await insertInstance(user.id, 'legacy-gdpr-instance');
+    const [subscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        instance_id: instanceId,
+        kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+        plan: 'standard',
+        status: 'canceled',
+        user_id: user.id,
+      })
+      .returning({
+        id: kiloclaw_subscriptions.id,
+        status: kiloclaw_subscriptions.status,
+        transferredToSubscriptionId: kiloclaw_subscriptions.transferred_to_subscription_id,
+        updatedAt: kiloclaw_subscriptions.updated_at,
+      });
+
+    const batch = await markActiveInstanceBatchDestroyedForGdpr(user.id, [instanceId]);
+
+    const [instance] = await db
+      .select({
+        destroyedAt: kiloclaw_instances.destroyed_at,
+        sandboxId: kiloclaw_instances.sandbox_id,
+      })
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.id, instanceId));
+    const [subscriptionAfter] = await db
+      .select({
+        id: kiloclaw_subscriptions.id,
+        status: kiloclaw_subscriptions.status,
+        transferredToSubscriptionId: kiloclaw_subscriptions.transferred_to_subscription_id,
+        updatedAt: kiloclaw_subscriptions.updated_at,
+      })
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+    const changeLogs = await db
+      .select({ id: kiloclaw_subscription_change_log.id })
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
+
+    expect(batch.instanceIds).toEqual([instanceId]);
+    expect(instance).toEqual({ destroyedAt: batch.destroyedAt, sandboxId: 'legacy-gdpr-instance' });
+    expect(subscriptionAfter).toEqual(subscription);
+    expect(changeLogs).toHaveLength(0);
+  });
+
+  it('rejects an exact-set mismatch without marking any matching rows', async () => {
+    const user = await insertTestUser();
+    const ownedInstanceId = await insertInstance(user.id, 'owned-gdpr-instance');
+    const otherUser = await insertTestUser();
+    const otherInstanceId = await insertInstance(otherUser.id, 'other-gdpr-instance');
+
+    await expect(
+      markActiveInstanceBatchDestroyedForGdpr(user.id, [ownedInstanceId, otherInstanceId])
+    ).rejects.toThrow('exact active user-owned ID set');
+
+    const activeRows = await db
+      .select({ id: kiloclaw_instances.id })
+      .from(kiloclaw_instances)
+      .where(
+        and(
+          inArray(kiloclaw_instances.id, [ownedInstanceId, otherInstanceId]),
+          isNull(kiloclaw_instances.destroyed_at)
+        )
+      );
+    expect(activeRows.map(row => row.id).sort()).toEqual([ownedInstanceId, otherInstanceId].sort());
+  });
+
+  it('timestamp-guards rollback and leaves the batch untouched on a mismatch', async () => {
+    const user = await insertTestUser();
+    const firstInstanceId = await insertInstance(user.id, 'first-gdpr-instance');
+    const secondInstanceId = await insertInstance(user.id, 'second-gdpr-instance');
+    const batch = await markActiveInstanceBatchDestroyedForGdpr(user.id, [
+      firstInstanceId,
+      secondInstanceId,
+    ]);
+    const laterTimestamp = '2026-07-21T12:01:00.000Z';
+    await db
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: laterTimestamp })
+      .where(eq(kiloclaw_instances.id, secondInstanceId));
+
+    await expect(restoreGdprDestroyedInstanceBatch(batch)).rejects.toThrow(
+      'exact destroyed ID set'
+    );
+
+    const rows = await db
+      .select({ id: kiloclaw_instances.id, destroyedAt: kiloclaw_instances.destroyed_at })
+      .from(kiloclaw_instances)
+      .where(inArray(kiloclaw_instances.id, [firstInstanceId, secondInstanceId]));
+    expect(Object.fromEntries(rows.map(row => [row.id, row.destroyedAt]))).toEqual({
+      [firstInstanceId]: batch.destroyedAt,
+      [secondInstanceId]: expect.any(String),
+    });
+    expect(rows.find(row => row.id === secondInstanceId)?.destroyedAt).not.toBe(batch.destroyedAt);
+  });
+});

--- a/apps/web/src/lib/kiloclaw/instance-registry.ts
+++ b/apps/web/src/lib/kiloclaw/instance-registry.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import {
   markInstanceDestroyedWithPersonalSubscriptionCollapse,
   type KiloClawSubscriptionChangeActor,
@@ -20,6 +20,12 @@ export type ActiveKiloClawInstance = {
 export type EnsureActiveInstanceResult = {
   instance: ActiveKiloClawInstance;
   created: boolean;
+};
+
+export type GdprDestroyedInstanceBatch = {
+  destroyedAt: string;
+  instanceIds: string[];
+  userId: string;
 };
 
 type InstanceRegistryExecutor = typeof db | DrizzleTransaction;
@@ -197,6 +203,73 @@ export async function restoreDestroyedInstance(instanceId: string): Promise<void
 }
 
 /**
+ * Marks an exact active, user-owned batch destroyed for GDPR worker cleanup.
+ * This intentionally changes only kiloclaw_instances.destroyed_at and never
+ * collapses personal subscription lineage or writes subscription change logs.
+ */
+export async function markActiveInstanceBatchDestroyedForGdpr(
+  userId: string,
+  instanceIds: string[]
+): Promise<GdprDestroyedInstanceBatch> {
+  const uniqueInstanceIds = [...new Set(instanceIds)];
+  if (uniqueInstanceIds.length === 0) {
+    throw new Error('GDPR instance batch must include at least one instance ID');
+  }
+
+  const destroyedAt = new Date().toISOString();
+  return await db.transaction(async tx => {
+    const rows = await tx
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: destroyedAt })
+      .where(
+        and(
+          eq(kiloclaw_instances.user_id, userId),
+          inArray(kiloclaw_instances.id, uniqueInstanceIds),
+          isNull(kiloclaw_instances.destroyed_at)
+        )
+      )
+      .returning({ id: kiloclaw_instances.id, destroyedAt: kiloclaw_instances.destroyed_at });
+
+    if (rows.length !== uniqueInstanceIds.length) {
+      throw new Error('GDPR instance batch did not match the exact active user-owned ID set');
+    }
+
+    const batchDestroyedAt = rows[0]?.destroyedAt;
+    if (!batchDestroyedAt) {
+      throw new Error('GDPR instance batch did not receive a destruction timestamp');
+    }
+
+    return { destroyedAt: batchDestroyedAt, instanceIds: uniqueInstanceIds, userId };
+  });
+}
+
+/**
+ * Restores precisely a GDPR batch after its worker teardown fails. The
+ * timestamp guard prevents undoing a later lifecycle transition.
+ */
+export async function restoreGdprDestroyedInstanceBatch(
+  batch: GdprDestroyedInstanceBatch
+): Promise<void> {
+  await db.transaction(async tx => {
+    const rows = await tx
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: null })
+      .where(
+        and(
+          eq(kiloclaw_instances.user_id, batch.userId),
+          inArray(kiloclaw_instances.id, batch.instanceIds),
+          eq(kiloclaw_instances.destroyed_at, batch.destroyedAt)
+        )
+      )
+      .returning({ id: kiloclaw_instances.id });
+
+    if (rows.length !== batch.instanceIds.length) {
+      throw new Error('GDPR instance batch restore did not match the exact destroyed ID set');
+    }
+  });
+}
+
+/**
  * Fetch the user's active personal KiloClaw instance (read-only, no upsert).
  *
  * Finds the active row for this user without filtering by sandboxId format.
@@ -295,18 +368,7 @@ export async function getActiveOrgInstance(
  * getActiveOrgInstance which use LIMIT 1 + ORDER BY created_at.
  */
 export async function listAllActiveInstances(userId: string): Promise<ActiveKiloClawInstance[]> {
-  const rows = await db
-    .select({
-      id: kiloclaw_instances.id,
-      userId: kiloclaw_instances.user_id,
-      sandboxId: kiloclaw_instances.sandbox_id,
-      organizationId: kiloclaw_instances.organization_id,
-      name: kiloclaw_instances.name,
-      inboundEmailEnabled: kiloclaw_instances.inbound_email_enabled,
-    })
-    .from(kiloclaw_instances)
-    .where(and(eq(kiloclaw_instances.user_id, userId), isNull(kiloclaw_instances.destroyed_at)))
-    .orderBy(kiloclaw_instances.created_at);
+  const rows = await listAllActiveInstanceRows(userId);
 
   // Deduplicate: keep only the oldest row per context (personal = null orgId,
   // org = specific orgId). Historical legacy races left duplicate active rows;
@@ -318,6 +380,25 @@ export async function listAllActiveInstances(userId: string): Promise<ActiveKilo
     seen.add(key);
     return true;
   });
+}
+
+/**
+ * List every active instance row for a user without resolving duplicate
+ * contexts. Destructive maintenance paths use this to clean up legacy rows.
+ */
+export async function listAllActiveInstanceRows(userId: string): Promise<ActiveKiloClawInstance[]> {
+  return db
+    .select({
+      id: kiloclaw_instances.id,
+      userId: kiloclaw_instances.user_id,
+      sandboxId: kiloclaw_instances.sandbox_id,
+      organizationId: kiloclaw_instances.organization_id,
+      name: kiloclaw_instances.name,
+      inboundEmailEnabled: kiloclaw_instances.inbound_email_enabled,
+    })
+    .from(kiloclaw_instances)
+    .where(and(eq(kiloclaw_instances.user_id, userId), isNull(kiloclaw_instances.destroyed_at)))
+    .orderBy(kiloclaw_instances.created_at);
 }
 
 /**

--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -109,6 +109,7 @@ import {
 import { eq, count, sql } from 'drizzle-orm';
 import {
   softDeleteUser,
+  assertUserCanBeSoftDeleted,
   SoftDeletePreconditionError,
   findUserById,
   findUsersByIds,
@@ -3422,6 +3423,9 @@ describe('User', () => {
         cancel_at_period_end: false,
       });
 
+      await expect(assertUserCanBeSoftDeleted(user.id)).rejects.toThrow(
+        SoftDeletePreconditionError
+      );
       await expect(softDeleteUser(user.id)).rejects.toThrow(SoftDeletePreconditionError);
       // User should not be modified
       const userAfter = await findUserById(user.id);
@@ -3858,6 +3862,9 @@ describe('User', () => {
         cancel_at_period_end: false,
       });
 
+      await expect(assertUserCanBeSoftDeleted(user.id)).rejects.toThrow(
+        SoftDeletePreconditionError
+      );
       await expect(softDeleteUser(user.id)).rejects.toThrow(SoftDeletePreconditionError);
       // User should not be modified
       const userAfter = await findUserById(user.id);

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -812,6 +812,61 @@ export class SoftDeletePreconditionError extends Error {
   }
 }
 
+type SoftDeleteExecutor = typeof db | DrizzleTransaction;
+
+async function assertNoLiveSubscriptionsForSoftDelete(
+  userId: string,
+  executor: SoftDeleteExecutor
+): Promise<void> {
+  const activeSubscriptions = await executor
+    .select({ id: kilo_pass_subscriptions.id })
+    .from(kilo_pass_subscriptions)
+    .where(
+      and(
+        eq(kilo_pass_subscriptions.kilo_user_id, userId),
+        eq(kilo_pass_subscriptions.status, 'active'),
+        eq(kilo_pass_subscriptions.cancel_at_period_end, false)
+      )
+    );
+
+  if (activeSubscriptions.length > 0) {
+    throw new SoftDeletePreconditionError(
+      `User ${userId} has an active Kilo Pass subscription. Cancel the subscription before deleting the account.`
+    );
+  }
+
+  // Block soft-delete for any live KiloClaw subscription. This includes
+  // trialing — the user may have a running Fly instance, and deleting the
+  // row without destroying the instance would orphan it.
+  const liveClawSubscriptions = await executor
+    .select({
+      id: kiloclaw_subscriptions.id,
+      status: kiloclaw_subscriptions.status,
+    })
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        inArray(kiloclaw_subscriptions.status, ['active', 'past_due', 'unpaid', 'trialing'])
+      )
+    );
+
+  if (liveClawSubscriptions.length > 0) {
+    throw new SoftDeletePreconditionError(
+      `User ${userId} has a live KiloClaw subscription (${liveClawSubscriptions[0].status}). Cancel the subscription before deleting the account.`
+    );
+  }
+}
+
+/**
+ * Reject account deletion before external cleanup when the user has a
+ * subscription that must be cancelled first. softDeleteUser repeats this
+ * assertion in its transaction as the authoritative race-safe check.
+ */
+export async function assertUserCanBeSoftDeleted(userId: string): Promise<void> {
+  await assertNoLiveSubscriptionsForSoftDelete(userId, db);
+}
+
 /**
  * Soft-delete a user: anonymize PII, scrub related data, but keep the
  * user row and financial/billing records intact.
@@ -896,44 +951,7 @@ export async function softDeleteUser(userId: string) {
 
   await db.transaction(async tx => {
     // ── Precondition checks (inside tx to avoid TOCTOU races) ──────────
-    const activeSubscriptions = await tx
-      .select({ id: kilo_pass_subscriptions.id })
-      .from(kilo_pass_subscriptions)
-      .where(
-        and(
-          eq(kilo_pass_subscriptions.kilo_user_id, userId),
-          eq(kilo_pass_subscriptions.status, 'active'),
-          eq(kilo_pass_subscriptions.cancel_at_period_end, false)
-        )
-      );
-
-    if (activeSubscriptions.length > 0) {
-      throw new SoftDeletePreconditionError(
-        `User ${userId} has an active Kilo Pass subscription. Cancel the subscription before deleting the account.`
-      );
-    }
-
-    // Block soft-delete for any live KiloClaw subscription. This includes
-    // trialing — the user may have a running Fly instance, and deleting the
-    // row without destroying the instance would orphan it.
-    const liveClawSubscriptions = await tx
-      .select({
-        id: kiloclaw_subscriptions.id,
-        status: kiloclaw_subscriptions.status,
-      })
-      .from(kiloclaw_subscriptions)
-      .where(
-        and(
-          eq(kiloclaw_subscriptions.user_id, userId),
-          inArray(kiloclaw_subscriptions.status, ['active', 'past_due', 'unpaid', 'trialing'])
-        )
-      );
-
-    if (liveClawSubscriptions.length > 0) {
-      throw new SoftDeletePreconditionError(
-        `User ${userId} has a live KiloClaw subscription (${liveClawSubscriptions[0].status}). Cancel the subscription before deleting the account.`
-      );
-    }
+    await assertNoLiveSubscriptionsForSoftDelete(userId, tx);
 
     const activeClawInstances = await tx
       .select({ id: kiloclaw_instances.id })


### PR DESCRIPTION
## Summary
Automatically destroy a user's active KiloClaw instances before completing an admin-initiated GDPR deletion.

### Why this change is needed
GDPR deletion currently fails when the target user still has a KiloClaw instance. The admin has already confirmed a destructive account-removal action, so requiring separate manual instance cleanup makes deletion unreliable and can leave personal infrastructure running.

### How this is addressed
- Reject deletion before teardown when an existing Kilo Pass or KiloClaw subscription must be cancelled.
- Group legacy instance records by their shared user-routed Worker and destroy that Worker once.
- Destroy instance-keyed Workers separately through the existing KiloClaw lifecycle API.
- Mark exact instance batches destroyed without changing retained subscription lineage or change logs.
- Restore only the failed batch using a user-, ID-, and timestamp-scoped rollback.
- Keep the final transactional soft-delete checks as defense in depth.

## Human Verification
- 100 tests passed across the GDPR route, KiloClaw instance registry, and user soft-delete suites.
- Local code-quality review confirmed the data-integrity and duplicate-resource findings are resolved.

## Reviewer Notes
### Human Reviewer Flags
- A rare TOCTOU race remains possible if an independent billing process activates a subscription after the preliminary check but before final soft deletion. Closing it requires a durable deletion claim honored by Stripe, App Store, KiloClaw billing bootstrap, and lifecycle reactivation paths. That broader billing-admission protocol is intentionally outside this PR.
- GDPR teardown bypasses the normal personal-subscription collapse path because subscription records are retained and must not be rewritten by failed infrastructure cleanup.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Legacy rows are grouped because they share a user-keyed Durable Object; instance-keyed rows continue to route by instance ID.
- GDPR registry transitions update only `destroyed_at`.
- Exact-set cardinality checks make batch marking and rollback transactional.
- Rollback requires the original destruction timestamp so it cannot clear a later lifecycle transition.

</details>
