### PR TITLE
feat(observability): add scheduled job completion events

### DIFF
--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
@@ -4,9 +4,22 @@ jest.mock('@/lib/config.server', () => ({
   CRON_SECRET: 'cron-secret',
 }));
 
+jest.mock('@kilocode/worker-utils/scheduled-job-observability', () => ({
+  createScheduledJobRun: jest.fn(() => ({ runId: 'run-id' })),
+  buildScheduledJobSuccessEvent: jest.fn((_run, fields) => ({ outcome: 'succeeded', ...fields })),
+  buildScheduledJobFailureEvent: jest.fn((_run, error) => ({
+    outcome: 'failed',
+    exception_name: error instanceof Error ? error.name : 'UnknownError',
+  })),
+  emitScheduledJobEvent: jest.fn(),
+}));
+
 import { api_request_compress_log, api_request_log } from '@kilocode/db/schema';
 import { db, sql } from '@/lib/drizzle';
+import { emitScheduledJobEvent } from '@kilocode/worker-utils/scheduled-job-observability';
 import { GET } from './route';
+
+const mockEmitScheduledJobEvent = jest.mocked(emitScheduledJobEvent);
 
 const BATCH_SIZE = 1_000;
 
@@ -54,6 +67,7 @@ async function insertApiRequestCompressLogRecord(created_at: string) {
 
 describe('GET /api/cron/cleanup-api-request-log', () => {
   beforeEach(async () => {
+    jest.clearAllMocks();
     await db.delete(api_request_log).where(sql`true`);
     await db.delete(api_request_compress_log).where(sql`true`);
   });
@@ -63,6 +77,7 @@ describe('GET /api/cron/cleanup-api-request-log', () => {
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(mockEmitScheduledJobEvent).not.toHaveBeenCalled();
   });
 
   it('returns zero deleted when table is empty', async () => {
@@ -75,6 +90,14 @@ describe('GET /api/cron/cleanup-api-request-log', () => {
     expect(body.hasMore).toBe(false);
     expect(body.cutoffDate).toEqual(expect.any(String));
     expect(body.timestamp).toEqual(expect.any(String));
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith({
+      outcome: 'succeeded',
+      deleted_api_request_log_count: 0,
+      deleted_api_request_compress_log_count: 0,
+      deleted_count: 0,
+      batch_size: BATCH_SIZE,
+      has_more: false,
+    });
   });
 
   it('deletes expired records and preserves recent records', async () => {
@@ -88,6 +111,14 @@ describe('GET /api/cron/cleanup-api-request-log', () => {
     const body = await response.json();
     expect(body.deletedCount).toBe(2);
     expect(body.hasMore).toBe(false);
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: 'succeeded',
+        deleted_api_request_log_count: 2,
+        deleted_api_request_compress_log_count: 0,
+        deleted_count: 2,
+      })
+    );
 
     const remaining = await db.select().from(api_request_log);
     expect(remaining).toHaveLength(1);
@@ -131,5 +162,22 @@ describe('GET /api/cron/cleanup-api-request-log', () => {
     expect(remainingIds).toEqual(
       expect.arrayContaining([recent1.id.toString(), recent2.id.toString()])
     );
+  });
+
+  it('emits one failure event and preserves rejected database failure semantics', async () => {
+    const select = jest.spyOn(db, 'select').mockImplementationOnce(() => {
+      throw new Error('database unavailable');
+    });
+
+    await expect(GET(makeRequest({ authorization: 'Bearer cron-secret' }))).rejects.toThrow(
+      'database unavailable'
+    );
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledTimes(1);
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith({
+      outcome: 'failed',
+      exception_name: 'Error',
+    });
+
+    select.mockRestore();
   });
 });

--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
@@ -1,4 +1,10 @@
 import { NextResponse } from 'next/server';
+import {
+  buildScheduledJobFailureEvent,
+  buildScheduledJobSuccessEvent,
+  createScheduledJobRun,
+  emitScheduledJobEvent,
+} from '@kilocode/worker-utils/scheduled-job-observability';
 import { db } from '@/lib/drizzle';
 import { api_request_compress_log, api_request_log } from '@kilocode/db/schema';
 import { asc, inArray, lt } from 'drizzle-orm';
@@ -18,40 +24,63 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const cutoffDate = getDaysAgo(RETENTION_DAYS).toISOString();
-  const expiredRows = await db
-    .select({ id: api_request_log.id })
-    .from(api_request_log)
-    .where(lt(api_request_log.created_at, cutoffDate))
-    .orderBy(asc(api_request_log.created_at))
-    .limit(BATCH_SIZE + 1);
-
-  const batchIds = expiredRows.slice(0, BATCH_SIZE).map(row => row.id);
-  const result =
-    batchIds.length > 0
-      ? await db.delete(api_request_log).where(inArray(api_request_log.id, batchIds))
-      : null;
-
-  const expiredCompressRows = await db
-    .select({ id: api_request_compress_log.id })
-    .from(api_request_compress_log)
-    .where(lt(api_request_compress_log.created_at, cutoffDate))
-    .orderBy(asc(api_request_compress_log.created_at))
-    .limit(BATCH_SIZE + 1);
-
-  const compressBatchIds = expiredCompressRows.slice(0, BATCH_SIZE).map(row => row.id);
-  const compressResult =
-    compressBatchIds.length > 0
-      ? await db
-          .delete(api_request_compress_log)
-          .where(inArray(api_request_compress_log.id, compressBatchIds))
-      : null;
-
-  return NextResponse.json({
-    deletedCount: (result?.rowCount ?? 0) + (compressResult?.rowCount ?? 0),
-    batchSize: BATCH_SIZE,
-    hasMore: expiredRows.length > BATCH_SIZE || expiredCompressRows.length > BATCH_SIZE,
-    cutoffDate,
-    timestamp: new Date().toISOString(),
+  const run = createScheduledJobRun({
+    jobName: 'web.cleanup_api_request_log',
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
   });
+
+  try {
+    const cutoffDate = getDaysAgo(RETENTION_DAYS).toISOString();
+    const expiredRows = await db
+      .select({ id: api_request_log.id })
+      .from(api_request_log)
+      .where(lt(api_request_log.created_at, cutoffDate))
+      .orderBy(asc(api_request_log.created_at))
+      .limit(BATCH_SIZE + 1);
+
+    const batchIds = expiredRows.slice(0, BATCH_SIZE).map(row => row.id);
+    const result =
+      batchIds.length > 0
+        ? await db.delete(api_request_log).where(inArray(api_request_log.id, batchIds))
+        : null;
+
+    const expiredCompressRows = await db
+      .select({ id: api_request_compress_log.id })
+      .from(api_request_compress_log)
+      .where(lt(api_request_compress_log.created_at, cutoffDate))
+      .orderBy(asc(api_request_compress_log.created_at))
+      .limit(BATCH_SIZE + 1);
+
+    const compressBatchIds = expiredCompressRows.slice(0, BATCH_SIZE).map(row => row.id);
+    const compressResult =
+      compressBatchIds.length > 0
+        ? await db
+            .delete(api_request_compress_log)
+            .where(inArray(api_request_compress_log.id, compressBatchIds))
+        : null;
+    const deletedApiRequestLogCount = result?.rowCount ?? 0;
+    const deletedApiRequestCompressLogCount = compressResult?.rowCount ?? 0;
+    const deletedCount = deletedApiRequestLogCount + deletedApiRequestCompressLogCount;
+    const hasMore = expiredRows.length > BATCH_SIZE || expiredCompressRows.length > BATCH_SIZE;
+    emitScheduledJobEvent(
+      buildScheduledJobSuccessEvent(run, {
+        deleted_api_request_log_count: deletedApiRequestLogCount,
+        deleted_api_request_compress_log_count: deletedApiRequestCompressLogCount,
+        deleted_count: deletedCount,
+        batch_size: BATCH_SIZE,
+        has_more: hasMore,
+      })
+    );
+
+    return NextResponse.json({
+      deletedCount,
+      batchSize: BATCH_SIZE,
+      hasMore,
+      cutoffDate,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    emitScheduledJobEvent(buildScheduledJobFailureEvent(run, error));
+    throw error;
+  }
 }

--- a/apps/web/src/app/api/cron/cleanup-device-auth/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-device-auth/route.test.ts
@@ -1,0 +1,57 @@
+jest.mock('@/lib/config.server', () => ({ CRON_SECRET: 'cron-secret' }));
+
+jest.mock('@kilocode/worker-utils/scheduled-job-observability', () => ({
+  createScheduledJobRun: jest.fn(() => ({ runId: 'run-id' })),
+  buildScheduledJobSuccessEvent: jest.fn((_run, fields) => ({ outcome: 'succeeded', ...fields })),
+  buildScheduledJobFailureEvent: jest.fn(() => ({ outcome: 'failed', exception_name: 'Error' })),
+  emitScheduledJobEvent: jest.fn(),
+}));
+
+jest.mock('@/lib/device-auth/device-auth', () => ({ cleanupExpiredDeviceAuthRequests: jest.fn() }));
+jest.mock('@/lib/kiloclaw/access-codes', () => ({ cleanupExpiredAccessCodes: jest.fn() }));
+jest.mock('@/lib/utils.server', () => ({ sentryLogger: jest.fn(() => jest.fn()) }));
+
+import { cleanupExpiredDeviceAuthRequests } from '@/lib/device-auth/device-auth';
+import { cleanupExpiredAccessCodes } from '@/lib/kiloclaw/access-codes';
+import { emitScheduledJobEvent } from '@kilocode/worker-utils/scheduled-job-observability';
+import { GET } from './route';
+
+const mockEmitScheduledJobEvent = jest.mocked(emitScheduledJobEvent);
+
+describe('GET /api/cron/cleanup-device-auth', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('emits one success event with both cleanup counts', async () => {
+    jest.mocked(cleanupExpiredDeviceAuthRequests).mockResolvedValue(2);
+    jest.mocked(cleanupExpiredAccessCodes).mockResolvedValue(3);
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/cleanup-device-auth', {
+        headers: { authorization: 'Bearer cron-secret' },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith({
+      outcome: 'succeeded',
+      deleted_device_auth_request_count: 2,
+      deleted_access_code_count: 3,
+    });
+  });
+
+  it('emits one failure event then rethrows a cleanup error', async () => {
+    jest.mocked(cleanupExpiredDeviceAuthRequests).mockRejectedValue(new Error('cleanup failed'));
+
+    await expect(
+      GET(
+        new Request('http://localhost/api/cron/cleanup-device-auth', {
+          headers: { authorization: 'Bearer cron-secret' },
+        })
+      )
+    ).rejects.toThrow('cleanup failed');
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith({
+      outcome: 'failed',
+      exception_name: 'Error',
+    });
+  });
+});

--- a/apps/web/src/app/api/cron/cleanup-device-auth/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-device-auth/route.ts
@@ -1,4 +1,10 @@
 import { NextResponse } from 'next/server';
+import {
+  buildScheduledJobFailureEvent,
+  buildScheduledJobSuccessEvent,
+  createScheduledJobRun,
+  emitScheduledJobEvent,
+} from '@kilocode/worker-utils/scheduled-job-observability';
 import { cleanupExpiredDeviceAuthRequests } from '@/lib/device-auth/device-auth';
 import { cleanupExpiredAccessCodes } from '@/lib/kiloclaw/access-codes';
 import { sentryLogger } from '@/lib/utils.server';
@@ -7,9 +13,6 @@ const CRON_SECRET = process.env['CRON_SECRET'];
 if (!CRON_SECRET) {
   throw new Error('CRON_SECRET is not configured in environment variables');
 }
-
-const BETTERSTACK_HEARTBEAT_URL =
-  'https://uptime.betterstack.com/api/v1/heartbeat/Az5GGCNPJddhpKofgVYVpRnR';
 
 /**
  * Cron job endpoint to cleanup expired device authorization requests
@@ -25,27 +28,36 @@ export async function GET(request: Request) {
     sentryLogger(
       'cron',
       'warning'
-    )(
-      'SECURITY: Invalid CRON job authorization attempt: ' +
-        (authHeader ? authHeader : 'Missing authorization header')
-    );
+    )(`SECURITY: ${authHeader ? 'Invalid' : 'Missing'} CRON job authorization`);
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  // Execute cleanup
-  const deletedCount = await cleanupExpiredDeviceAuthRequests();
-  sentryLogger('cron', 'info')(`Cleaned up ${deletedCount} expired device auth requests`);
-
-  const accessCodesDeleted = await cleanupExpiredAccessCodes();
-  sentryLogger('cron', 'info')(`Cleaned up ${accessCodesDeleted} expired access codes`);
-
-  // Send heartbeat to BetterStack on success
-  await fetch(BETTERSTACK_HEARTBEAT_URL);
-
-  return NextResponse.json({
-    success: true,
-    deletedCount,
-    accessCodesDeleted,
-    timestamp: new Date().toISOString(),
+  const run = createScheduledJobRun({
+    jobName: 'web.cleanup_device_auth',
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
   });
+
+  try {
+    const deletedCount = await cleanupExpiredDeviceAuthRequests();
+    sentryLogger('cron', 'info')(`Cleaned up ${deletedCount} expired device auth requests`);
+
+    const accessCodesDeleted = await cleanupExpiredAccessCodes();
+    sentryLogger('cron', 'info')(`Cleaned up ${accessCodesDeleted} expired access codes`);
+    emitScheduledJobEvent(
+      buildScheduledJobSuccessEvent(run, {
+        deleted_device_auth_request_count: deletedCount,
+        deleted_access_code_count: accessCodesDeleted,
+      })
+    );
+
+    return NextResponse.json({
+      success: true,
+      deletedCount,
+      accessCodesDeleted,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    emitScheduledJobEvent(buildScheduledJobFailureEvent(run, error));
+    throw error;
+  }
 }

--- a/apps/web/src/app/api/cron/cleanup-stale-analyses/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-stale-analyses/route.test.ts
@@ -1,0 +1,56 @@
+jest.mock('@/lib/config.server', () => ({ CRON_SECRET: 'cron-secret' }));
+
+jest.mock('@kilocode/worker-utils/scheduled-job-observability', () => ({
+  createScheduledJobRun: jest.fn(() => ({ runId: 'run-id' })),
+  buildScheduledJobSuccessEvent: jest.fn((_run, fields) => ({ outcome: 'succeeded', ...fields })),
+  buildScheduledJobFailureEvent: jest.fn(() => ({ outcome: 'failed', exception_name: 'Error' })),
+  emitScheduledJobEvent: jest.fn(),
+}));
+
+jest.mock('@/lib/security-agent/db/security-analysis', () => ({ cleanupStaleAnalyses: jest.fn() }));
+jest.mock('@/lib/utils.server', () => ({ sentryLogger: jest.fn(() => jest.fn()) }));
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
+
+import { cleanupStaleAnalyses } from '@/lib/security-agent/db/security-analysis';
+import { emitScheduledJobEvent } from '@kilocode/worker-utils/scheduled-job-observability';
+import { GET } from './route';
+
+const mockEmitScheduledJobEvent = jest.mocked(emitScheduledJobEvent);
+
+describe('GET /api/cron/cleanup-stale-analyses', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('emits a success event for a no-work cleanup', async () => {
+    jest.mocked(cleanupStaleAnalyses).mockResolvedValue(0);
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/cleanup-stale-analyses', {
+        headers: { authorization: 'Bearer cron-secret' },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith({
+      outcome: 'succeeded',
+      cleaned_count: 0,
+      anomaly_threshold: 10,
+      anomaly_detected: false,
+    });
+  });
+
+  it('emits a failure event before returning its existing error response', async () => {
+    jest.mocked(cleanupStaleAnalyses).mockRejectedValue(new Error('cleanup failed'));
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/cleanup-stale-analyses', {
+        headers: { authorization: 'Bearer cron-secret' },
+      })
+    );
+
+    expect(response.status).toBe(500);
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith({
+      outcome: 'failed',
+      exception_name: 'Error',
+    });
+  });
+});

--- a/apps/web/src/app/api/cron/cleanup-stale-analyses/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-stale-analyses/route.ts
@@ -1,8 +1,14 @@
 import { NextResponse } from 'next/server';
 import { captureException } from '@sentry/nextjs';
+import {
+  buildScheduledJobFailureEvent,
+  buildScheduledJobSuccessEvent,
+  createScheduledJobRun,
+  emitScheduledJobEvent,
+} from '@kilocode/worker-utils/scheduled-job-observability';
 import { cleanupStaleAnalyses } from '@/lib/security-agent/db/security-analysis';
 import { sentryLogger } from '@/lib/utils.server';
-import { CRON_SECRET, SECURITY_CLEANUP_BETTERSTACK_HEARTBEAT_URL } from '@/lib/config.server';
+import { CRON_SECRET } from '@/lib/config.server';
 
 if (!CRON_SECRET) {
   throw new Error('CRON_SECRET is not configured in environment variables');
@@ -41,6 +47,11 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  const run = createScheduledJobRun({
+    jobName: 'web.cleanup_stale_analyses',
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+  });
+
   try {
     // Execute cleanup - mark analyses running for more than 30 minutes as failed
     const cleanedCount = await cleanupStaleAnalyses(30);
@@ -57,12 +68,13 @@ export async function GET(request: Request) {
       );
     }
 
-    // Send heartbeat to BetterStack on success
-    if (SECURITY_CLEANUP_BETTERSTACK_HEARTBEAT_URL) {
-      await fetch(SECURITY_CLEANUP_BETTERSTACK_HEARTBEAT_URL, {
-        signal: AbortSignal.timeout(5000),
-      }).catch(() => {});
-    }
+    emitScheduledJobEvent(
+      buildScheduledJobSuccessEvent(run, {
+        cleaned_count: cleanedCount,
+        anomaly_threshold: STALE_ANOMALY_THRESHOLD,
+        anomaly_detected: cleanedCount > STALE_ANOMALY_THRESHOLD,
+      })
+    );
 
     return NextResponse.json({
       success: true,
@@ -74,12 +86,7 @@ export async function GET(request: Request) {
       tags: { endpoint: 'cron/cleanup-stale-analyses' },
     });
 
-    // Send failure heartbeat to BetterStack
-    if (SECURITY_CLEANUP_BETTERSTACK_HEARTBEAT_URL) {
-      await fetch(`${SECURITY_CLEANUP_BETTERSTACK_HEARTBEAT_URL}/fail`, {
-        signal: AbortSignal.timeout(5000),
-      }).catch(() => {});
-    }
+    emitScheduledJobEvent(buildScheduledJobFailureEvent(run, error));
 
     return NextResponse.json(
       {

--- a/apps/web/src/app/api/cron/sync-model-stats/route.test.ts
+++ b/apps/web/src/app/api/cron/sync-model-stats/route.test.ts
@@ -1,0 +1,91 @@
+jest.mock('@/lib/config.server', () => ({ CRON_SECRET: 'cron-secret' }));
+
+jest.mock('@kilocode/worker-utils/scheduled-job-observability', () => ({
+  createScheduledJobRun: jest.fn(() => ({ runId: 'run-id' })),
+  buildScheduledJobSuccessEvent: jest.fn((_run, fields) => ({ outcome: 'succeeded', ...fields })),
+  buildScheduledJobFailureEvent: jest.fn(() => ({ outcome: 'failed', exception_name: 'Error' })),
+  emitScheduledJobEvent: jest.fn(),
+}));
+
+jest.mock('@/lib/ai-gateway/providers/openrouter', () => ({
+  getRawOpenRouterModels: jest.fn(),
+  getEnhancedOpenRouterModels: jest.fn(),
+}));
+jest.mock('@/lib/model-stats/sync-artificial-analysis', () => ({
+  syncArtificialAnalysisBenchmarks: jest.fn(),
+}));
+jest.mock('@/lib/model-stats/sync-openrouter', () => ({ syncOpenRouterModels: jest.fn() }));
+jest.mock('@/lib/model-stats/sync-internal-data', () => ({ syncInternalUsageStats: jest.fn() }));
+jest.mock('@/lib/ai-gateway/monitored-models', () => ({ getMonitoredModels: jest.fn() }));
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
+
+import {
+  getEnhancedOpenRouterModels,
+  getRawOpenRouterModels,
+} from '@/lib/ai-gateway/providers/openrouter';
+import { getMonitoredModels } from '@/lib/ai-gateway/monitored-models';
+import { syncArtificialAnalysisBenchmarks } from '@/lib/model-stats/sync-artificial-analysis';
+import { syncInternalUsageStats } from '@/lib/model-stats/sync-internal-data';
+import { syncOpenRouterModels } from '@/lib/model-stats/sync-openrouter';
+import { emitScheduledJobEvent } from '@kilocode/worker-utils/scheduled-job-observability';
+import { GET } from './route';
+
+const mockEmitScheduledJobEvent = jest.mocked(emitScheduledJobEvent);
+
+describe('GET /api/cron/sync-model-stats', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('emits a success event with aggregate model counters', async () => {
+    const model = {
+      id: 'openai/gpt',
+      name: 'GPT',
+      created: 0,
+      description: '',
+      architecture: { input_modalities: [], output_modalities: [], tokenizer: '' },
+      top_provider: { is_moderated: false },
+      pricing: { prompt: '0', completion: '0' },
+      context_length: 0,
+    };
+    jest.mocked(getRawOpenRouterModels).mockResolvedValue({ data: [model] });
+    jest.mocked(getEnhancedOpenRouterModels).mockResolvedValue({ data: [model] });
+    jest.mocked(getMonitoredModels).mockResolvedValue(['openai/gpt']);
+    jest.mocked(syncOpenRouterModels).mockResolvedValue({
+      newModels: ['openai/gpt'],
+      updatedModels: [],
+      totalProcessed: 1,
+    });
+    jest.mocked(syncArtificialAnalysisBenchmarks).mockResolvedValue(undefined as never);
+    jest.mocked(syncInternalUsageStats).mockResolvedValue();
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/sync-model-stats', {
+        headers: { authorization: 'Bearer cron-secret' },
+      }) as never
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith({
+      outcome: 'succeeded',
+      preferred_model_count: 1,
+      total_processed: 1,
+      new_model_count: 1,
+      updated_model_count: 0,
+    });
+  });
+
+  it('emits a failure event before returning its existing error response', async () => {
+    jest.mocked(getRawOpenRouterModels).mockRejectedValue(new Error('upstream failed'));
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/sync-model-stats', {
+        headers: { authorization: 'Bearer cron-secret' },
+      }) as never
+    );
+
+    expect(response.status).toBe(500);
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith({
+      outcome: 'failed',
+      exception_name: 'Error',
+    });
+  });
+});

--- a/apps/web/src/app/api/cron/sync-model-stats/route.ts
+++ b/apps/web/src/app/api/cron/sync-model-stats/route.ts
@@ -2,6 +2,12 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { captureException } from '@sentry/nextjs';
 import {
+  buildScheduledJobFailureEvent,
+  buildScheduledJobSuccessEvent,
+  createScheduledJobRun,
+  emitScheduledJobEvent,
+} from '@kilocode/worker-utils/scheduled-job-observability';
+import {
   getRawOpenRouterModels,
   getEnhancedOpenRouterModels,
 } from '@/lib/ai-gateway/providers/openrouter';
@@ -11,9 +17,6 @@ import { syncInternalUsageStats } from '@/lib/model-stats/sync-internal-data';
 import { CRON_SECRET } from '@/lib/config.server';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
 import { getMonitoredModels } from '@/lib/ai-gateway/monitored-models';
-
-const BETTERSTACK_HEARTBEAT_URL =
-  'https://uptime.betterstack.com/api/v1/heartbeat/1zuL4cAH8Ui6JF9j8M3L8oAD';
 
 /**
  * Vercel Cron Job: Sync Model Stats
@@ -28,12 +31,17 @@ const BETTERSTACK_HEARTBEAT_URL =
  * Note: Models are never automatically deactivated - only users can deactivate models.
  */
 export async function GET(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get('authorization');
-    if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+  const authHeader = request.headers.get('authorization');
+  if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
 
+  const run = createScheduledJobRun({
+    jobName: 'web.sync_model_stats',
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+  });
+
+  try {
     console.log('[sync-model-stats] Starting model stats sync...');
     const startTime = Date.now();
 
@@ -92,14 +100,24 @@ export async function GET(request: NextRequest) {
       timestamp: new Date().toISOString(),
     };
 
-    console.log('[sync-model-stats] Sync completed:', summary);
-
-    // Send heartbeat to BetterStack on success
-    await fetch(BETTERSTACK_HEARTBEAT_URL);
+    console.log('[sync-model-stats] Sync completed', {
+      duration,
+      newModelCount: newModels.length,
+      totalProcessed,
+      updatedModelCount: updatedModels.length,
+    });
+    emitScheduledJobEvent(
+      buildScheduledJobSuccessEvent(run, {
+        preferred_model_count: preferredModelData.length,
+        total_processed: totalProcessed,
+        new_model_count: newModels.length,
+        updated_model_count: updatedModels.length,
+      })
+    );
 
     return NextResponse.json(summary);
   } catch (error) {
-    console.error('[sync-model-stats] Error syncing model stats:', error);
+    console.error('[sync-model-stats] Error syncing model stats');
     captureException(error, {
       tags: { endpoint: 'cron/sync-model-stats' },
       extra: {
@@ -107,8 +125,7 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Send failure heartbeat to BetterStack
-    await fetch(`${BETTERSTACK_HEARTBEAT_URL}/fail`);
+    emitScheduledJobEvent(buildScheduledJobFailureEvent(run, error));
 
     return NextResponse.json(
       {

--- a/apps/web/src/app/api/cron/sync-providers/route.test.ts
+++ b/apps/web/src/app/api/cron/sync-providers/route.test.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/config.server', () => ({ CRON_SECRET: 'cron-secret' }));
+
+jest.mock('@kilocode/worker-utils/scheduled-job-observability', () => ({
+  createScheduledJobRun: jest.fn(() => ({ runId: 'run-id' })),
+  buildScheduledJobSuccessEvent: jest.fn((_run, fields) => ({ outcome: 'succeeded', ...fields })),
+  buildScheduledJobFailureEvent: jest.fn(() => ({ outcome: 'failed', exception_name: 'Error' })),
+  emitScheduledJobEvent: jest.fn(),
+}));
+
+jest.mock('@/lib/ai-gateway/providers/openrouter/sync-providers', () => ({
+  syncAndStoreProviders: jest.fn(),
+}));
+
+import { syncAndStoreProviders } from '@/lib/ai-gateway/providers/openrouter/sync-providers';
+import { emitScheduledJobEvent } from '@kilocode/worker-utils/scheduled-job-observability';
+import { GET } from './route';
+
+const mockEmitScheduledJobEvent = jest.mocked(emitScheduledJobEvent);
+
+describe('GET /api/cron/sync-providers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('emits one event at the cron boundary with aggregate provider counts', async () => {
+    jest.mocked(syncAndStoreProviders).mockResolvedValue({
+      id: 1,
+      generated_at: '2026-07-20T00:00:00.000Z',
+      total_models: 42,
+      total_providers: 12,
+      direct_byok_model_counts: {},
+      time: 5,
+    });
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/cron/sync-providers', {
+        headers: { authorization: 'Bearer cron-secret' },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith({
+      outcome: 'succeeded',
+      total_provider_count: 12,
+      total_model_count: 42,
+    });
+  });
+
+  it('emits one failure event then preserves rejected helper failure semantics', async () => {
+    jest.mocked(syncAndStoreProviders).mockRejectedValue(new Error('sync failed'));
+
+    await expect(
+      GET(
+        new NextRequest('http://localhost/api/cron/sync-providers', {
+          headers: { authorization: 'Bearer cron-secret' },
+        })
+      )
+    ).rejects.toThrow('sync failed');
+    expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith({
+      outcome: 'failed',
+      exception_name: 'Error',
+    });
+  });
+});

--- a/apps/web/src/app/api/cron/sync-providers/route.ts
+++ b/apps/web/src/app/api/cron/sync-providers/route.ts
@@ -1,5 +1,11 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import {
+  buildScheduledJobFailureEvent,
+  buildScheduledJobSuccessEvent,
+  createScheduledJobRun,
+  emitScheduledJobEvent,
+} from '@kilocode/worker-utils/scheduled-job-observability';
 import { CRON_SECRET } from '@/lib/config.server';
 import { syncAndStoreProviders } from '@/lib/ai-gateway/providers/openrouter/sync-providers';
 
@@ -8,7 +14,24 @@ export async function GET(request: NextRequest) {
   if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const summary = await syncAndStoreProviders();
 
-  return NextResponse.json(summary);
+  const run = createScheduledJobRun({
+    jobName: 'web.sync_providers',
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+  });
+
+  try {
+    const summary = await syncAndStoreProviders();
+    emitScheduledJobEvent(
+      buildScheduledJobSuccessEvent(run, {
+        total_provider_count: summary.total_providers,
+        total_model_count: summary.total_models,
+      })
+    );
+
+    return NextResponse.json(summary);
+  } catch (error) {
+    emitScheduledJobEvent(buildScheduledJobFailureEvent(run, error));
+    throw error;
+  }
 }

--- a/apps/web/src/lib/config.server.ts
+++ b/apps/web/src/lib/config.server.ts
@@ -413,11 +413,6 @@ export const CREDIT_CATEGORIES_ENCRYPTION_KEY = getEnvVariable('CREDIT_CATEGORIE
 export const O11Y_SERVICE_URL = getEnvVariable('O11Y_SERVICE_URL') || '';
 export const O11Y_KILO_GATEWAY_CLIENT_SECRET = getEnvVariable('O11Y_KILO_GATEWAY_CLIENT_SECRET');
 
-// Security agent BetterStack heartbeat URLs
-export const SECURITY_CLEANUP_BETTERSTACK_HEARTBEAT_URL = getEnvVariable(
-  'SECURITY_CLEANUP_BETTERSTACK_HEARTBEAT_URL'
-);
-
 // Pylon chat widget (support chat on Code Reviewer pages).
 // PYLON_IDENTITY_SECRET is the shared secret from the Pylon dashboard used to HMAC-sign
 // the user's email so the widget can verify the end user's identity.

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -31,7 +31,8 @@
     "./dependabot-dismissal-target": "./src/dependabot-dismissal-target.ts",
     "./client-error": "./src/client-error.ts",
     "./review-agents": "./src/review-agents.ts",
-    "./code-review-council": "./src/code-review-council.ts"
+    "./code-review-council": "./src/code-review-council.ts",
+    "./scheduled-job-observability": "./src/scheduled-job-observability.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/worker-utils/src/scheduled-job-observability.test.ts
+++ b/packages/worker-utils/src/scheduled-job-observability.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildScheduledJobFailureEvent,
+  buildScheduledJobSuccessEvent,
+  createScheduledJobRun,
+  createScheduledJobRunContext,
+  emitScheduledJobEvent,
+  type ScheduledJobLogger,
+} from './scheduled-job-observability.js';
+
+describe('scheduled job observability', () => {
+  it('builds a successful terminal event with deterministic duration and scalar metadata', () => {
+    const event = buildScheduledJobSuccessEvent({
+      context: createScheduledJobRunContext({ runId: 'run-123', startedAt: 1_000 }),
+      jobName: 'web.cleanup_api_request_log',
+      environment: 'production',
+      metadata: {
+        deleted_count: 0,
+        has_more: false,
+        ignored: undefined,
+      },
+      now: 1_421,
+    });
+
+    expect(event).toEqual({
+      event_name: 'scheduled_job.completed',
+      event_version: 1,
+      job_name: 'web.cleanup_api_request_log',
+      run_id: 'run-123',
+      outcome: 'succeeded',
+      duration_ms: 421,
+      environment: 'production',
+      deleted_count: 0,
+      has_more: false,
+    });
+  });
+
+  it('uses a supplied run ID and generates a UUID when one is not supplied', () => {
+    expect(createScheduledJobRunContext({ runId: 'security-sync-run', startedAt: 100 })).toEqual({
+      runId: 'security-sync-run',
+      startedAt: 100,
+    });
+
+    expect(createScheduledJobRunContext({ startedAt: 100 }).runId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+  });
+
+  it('builds events from a scheduled boundary run', () => {
+    const run = createScheduledJobRun({
+      jobName: 'web.cleanup_device_auth',
+      environment: 'production',
+      runId: 'boundary-run',
+      startedAt: 100,
+    });
+
+    expect(buildScheduledJobSuccessEvent(run, { deleted_count: 0, has_more: false })).toMatchObject(
+      {
+        job_name: 'web.cleanup_device_auth',
+        run_id: 'boundary-run',
+        environment: 'production',
+        deleted_count: 0,
+        has_more: false,
+      }
+    );
+    expect(buildScheduledJobFailureEvent(run, new Error('raw exception content'))).toMatchObject({
+      job_name: 'web.cleanup_device_auth',
+      run_id: 'boundary-run',
+      exception_name: 'Error',
+    });
+  });
+
+  it('sanitizes bounded exception names without including raw exception content', () => {
+    const error = new Error('database password: secret-value');
+    error.name = 'Database Error: secret-value';
+
+    expect(
+      buildScheduledJobFailureEvent({
+        context: { runId: 'run-456', startedAt: 100 },
+        jobName: 'security_sync.dispatch',
+        error,
+        now: 303,
+      })
+    ).toEqual({
+      event_name: 'scheduled_job.completed',
+      event_version: 1,
+      job_name: 'security_sync.dispatch',
+      run_id: 'run-456',
+      outcome: 'failed',
+      duration_ms: 203,
+      exception_name: 'Error',
+    });
+  });
+
+  it('emits one JSON object at info or error severity without exception messages', () => {
+    const info = vi.fn();
+    const error = vi.fn();
+    const logger: ScheduledJobLogger = {
+      info,
+      error,
+    };
+    const success = buildScheduledJobSuccessEvent({
+      context: { runId: 'success-run', startedAt: 0 },
+      jobName: 'web.sync_model_stats',
+      now: 1,
+    });
+    const failure = buildScheduledJobFailureEvent({
+      context: { runId: 'failure-run', startedAt: 0 },
+      jobName: 'web.sync_model_stats',
+      error: new Error('raw exception content'),
+      now: 1,
+    });
+
+    emitScheduledJobEvent(success, logger);
+    emitScheduledJobEvent(failure, logger);
+
+    expect(info).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledOnce();
+    expect(JSON.parse(info.mock.calls[0][0])).toEqual(success);
+    expect(JSON.parse(error.mock.calls[0][0])).toEqual(failure);
+    expect(error.mock.calls[0][0]).not.toContain('raw exception content');
+  });
+
+  it('swallows logger failures', () => {
+    const logger: ScheduledJobLogger = {
+      info: () => {
+        throw new Error('logging unavailable');
+      },
+      error: vi.fn(),
+    };
+
+    expect(() =>
+      emitScheduledJobEvent(
+        buildScheduledJobSuccessEvent({
+          context: { runId: 'run-789', startedAt: 0 },
+          jobName: 'web.cleanup_device_auth',
+          now: 1,
+        }),
+        logger
+      )
+    ).not.toThrow();
+  });
+});

--- a/packages/worker-utils/src/scheduled-job-observability.ts
+++ b/packages/worker-utils/src/scheduled-job-observability.ts
@@ -1,0 +1,202 @@
+export const SCHEDULED_JOB_COMPLETED_EVENT = 'scheduled_job.completed' as const;
+export const SCHEDULED_JOB_EVENT_VERSION = 1 as const;
+
+export type ScheduledJobMetadataValue = boolean | number | string;
+
+export type ScheduledJobMetadata = Record<string, ScheduledJobMetadataValue | undefined>;
+
+export type ScheduledJobRunContext = {
+  runId: string;
+  startedAt: number;
+};
+
+export type CreateScheduledJobRunContextOptions = {
+  runId?: string;
+  startedAt?: number;
+};
+
+export type CreateScheduledJobRunOptions = CreateScheduledJobRunContextOptions & {
+  environment?: string;
+  jobName: string;
+};
+
+export type ScheduledJobRun = ScheduledJobRunContext & {
+  environment?: string;
+  jobName: string;
+};
+
+type ScheduledJobEventFields = {
+  event_name: typeof SCHEDULED_JOB_COMPLETED_EVENT;
+  event_version: typeof SCHEDULED_JOB_EVENT_VERSION;
+  job_name: string;
+  run_id: string;
+  duration_ms: number;
+  environment?: string;
+};
+
+export type ScheduledJobSuccessEvent = ScheduledJobEventFields &
+  ScheduledJobMetadata & {
+    outcome: 'succeeded';
+  };
+
+export type ScheduledJobFailureEvent = ScheduledJobEventFields &
+  ScheduledJobMetadata & {
+    outcome: 'failed';
+    exception_name: string;
+  };
+
+export type BuildScheduledJobEventOptions = {
+  context: ScheduledJobRunContext;
+  jobName: string;
+  environment?: string;
+  metadata?: ScheduledJobMetadata;
+  now?: number;
+};
+
+export type BuildScheduledJobFailureEventOptions = BuildScheduledJobEventOptions & {
+  error: unknown;
+};
+
+export type ScheduledJobLogger = {
+  error(message: string): void;
+  info(message: string): void;
+};
+
+export function createScheduledJobRunContext(
+  options: CreateScheduledJobRunContextOptions = {}
+): ScheduledJobRunContext {
+  return {
+    runId: options.runId ?? crypto.randomUUID(),
+    startedAt: options.startedAt ?? Date.now(),
+  };
+}
+
+export function createScheduledJobRun(options: CreateScheduledJobRunOptions): ScheduledJobRun {
+  return {
+    ...createScheduledJobRunContext(options),
+    jobName: options.jobName,
+    ...(options.environment === undefined ? {} : { environment: options.environment }),
+  };
+}
+
+export function buildScheduledJobSuccessEvent(
+  run: ScheduledJobRun,
+  metadata?: ScheduledJobMetadata
+): ScheduledJobSuccessEvent;
+export function buildScheduledJobSuccessEvent(
+  options: BuildScheduledJobEventOptions
+): ScheduledJobSuccessEvent;
+export function buildScheduledJobSuccessEvent(
+  options: BuildScheduledJobEventOptions | ScheduledJobRun,
+  metadata?: ScheduledJobMetadata
+): ScheduledJobSuccessEvent {
+  const normalizedOptions = normalizeSuccessEventOptions(options, metadata);
+  return {
+    ...scalarMetadata(normalizedOptions.metadata),
+    ...eventFields(normalizedOptions),
+    outcome: 'succeeded',
+  };
+}
+
+export function buildScheduledJobFailureEvent(
+  run: ScheduledJobRun,
+  error: unknown
+): ScheduledJobFailureEvent;
+export function buildScheduledJobFailureEvent(
+  options: BuildScheduledJobFailureEventOptions
+): ScheduledJobFailureEvent;
+export function buildScheduledJobFailureEvent(
+  options: BuildScheduledJobFailureEventOptions | ScheduledJobRun,
+  error?: unknown
+): ScheduledJobFailureEvent {
+  const normalizedOptions = normalizeFailureEventOptions(options, error);
+  return {
+    ...scalarMetadata(normalizedOptions.metadata),
+    ...eventFields(normalizedOptions),
+    outcome: 'failed',
+    exception_name: sanitizedExceptionName(normalizedOptions.error),
+  };
+}
+
+export function emitScheduledJobEvent(
+  event: ScheduledJobSuccessEvent | ScheduledJobFailureEvent,
+  logger: ScheduledJobLogger = console
+): void {
+  try {
+    const serializedEvent = JSON.stringify(event);
+    if (event.outcome === 'succeeded') {
+      logger.info(serializedEvent);
+    } else {
+      logger.error(serializedEvent);
+    }
+  } catch {
+    // Scheduled job logging must not affect the job result.
+  }
+}
+
+export function sanitizedExceptionName(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return 'UnknownError';
+  }
+
+  return /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/.test(error.name) ? error.name : 'Error';
+}
+
+function eventFields(options: BuildScheduledJobEventOptions): ScheduledJobEventFields {
+  return {
+    event_name: SCHEDULED_JOB_COMPLETED_EVENT,
+    event_version: SCHEDULED_JOB_EVENT_VERSION,
+    job_name: options.jobName,
+    run_id: options.context.runId,
+    duration_ms: Math.max(0, (options.now ?? Date.now()) - options.context.startedAt),
+    ...(options.environment === undefined ? {} : { environment: options.environment }),
+  };
+}
+
+function normalizeSuccessEventOptions(
+  options: BuildScheduledJobEventOptions | ScheduledJobRun,
+  metadata: ScheduledJobMetadata | undefined
+): BuildScheduledJobEventOptions {
+  if ('context' in options) {
+    return options;
+  }
+
+  return {
+    context: options,
+    jobName: options.jobName,
+    ...(options.environment === undefined ? {} : { environment: options.environment }),
+    ...(metadata === undefined ? {} : { metadata }),
+  };
+}
+
+function normalizeFailureEventOptions(
+  options: BuildScheduledJobFailureEventOptions | ScheduledJobRun,
+  error: unknown
+): BuildScheduledJobFailureEventOptions {
+  if ('context' in options) {
+    return options;
+  }
+
+  return {
+    context: options,
+    jobName: options.jobName,
+    ...(options.environment === undefined ? {} : { environment: options.environment }),
+    error,
+  };
+}
+
+function scalarMetadata(metadata: ScheduledJobMetadata | undefined): ScheduledJobMetadata {
+  if (!metadata) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).filter(
+      ([, value]) =>
+        value !== undefined &&
+        (typeof value === 'string' ||
+          typeof value === 'boolean' ||
+          (typeof value === 'number' && Number.isFinite(value)))
+    )
+  );
+}

--- a/services/model-eval-ingest/src/index.test.ts
+++ b/services/model-eval-ingest/src/index.test.ts
@@ -1,0 +1,95 @@
+import { getWorkerDb } from '@kilocode/db/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { syncPromotionsFromBench } from './sync.js';
+import worker from './index.js';
+
+vi.mock('@kilocode/db/client', () => ({ getWorkerDb: vi.fn() }));
+vi.mock('./sync.js', () => ({
+  createPromotionStore: vi.fn(),
+  syncPromotionsFromBench: vi.fn(),
+}));
+
+const syncResult = {
+  fetched: 3,
+  inserted: 1,
+  alreadyHad: 2,
+  cacheRecomputes: 1,
+};
+
+function env(): CloudflareEnv {
+  return {
+    ENVIRONMENT: 'test',
+    HYPERDRIVE: { connectionString: 'postgres://test' },
+    BENCH_DASHBOARD: {},
+    INTERNAL_API_SECRET: { get: async () => 'internal-secret' },
+  } as unknown as CloudflareEnv;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  vi.mocked(getWorkerDb).mockReturnValue({} as never);
+  vi.mocked(syncPromotionsFromBench).mockResolvedValue(syncResult);
+});
+
+describe('scheduled sync', () => {
+  it('emits a canonical success event with sync counters and schedule metadata', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const controller = {
+      cron: '*/15 * * * *',
+      scheduledTime: 1_700_000_000_000,
+    } as ScheduledController;
+
+    await expect(worker.scheduled(controller, env())).resolves.toBeUndefined();
+
+    expect(JSON.parse(String(info.mock.calls[0]?.[0]))).toMatchObject({
+      event_name: 'scheduled_job.completed',
+      event_version: 1,
+      job_name: 'model_eval_ingest.sync',
+      outcome: 'succeeded',
+      environment: 'test',
+      schedule: '*/15 * * * *',
+      scheduled_time: 1_700_000_000_000,
+      fetched_count: 3,
+      inserted_count: 1,
+      already_had_count: 2,
+      cache_recompute_count: 1,
+      no_op: false,
+    });
+  });
+
+  it('emits a failure event and rethrows the sync error', async () => {
+    const error = new Error('sync failed');
+    vi.mocked(syncPromotionsFromBench).mockRejectedValueOnce(error);
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(
+      worker.scheduled({ cron: '* * * * *' } as ScheduledController, env())
+    ).rejects.toBe(error);
+
+    expect(JSON.parse(String(errorLog.mock.calls[0]?.[0]))).toMatchObject({
+      event_name: 'scheduled_job.completed',
+      job_name: 'model_eval_ingest.sync',
+      outcome: 'failed',
+      exception_name: 'Error',
+      schedule: '* * * * *',
+    });
+  });
+});
+
+it('does not emit a scheduled-job event for manual sync requests', async () => {
+  const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+  const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+  const response = await worker.fetch(
+    new Request('https://model-eval-ingest/internal/sync', {
+      method: 'POST',
+      headers: { 'x-internal-api-key': 'internal-secret' },
+    }),
+    env()
+  );
+
+  expect(response.status).toBe(200);
+  expect(info).not.toHaveBeenCalled();
+  expect(error).not.toHaveBeenCalled();
+});

--- a/services/model-eval-ingest/src/index.ts
+++ b/services/model-eval-ingest/src/index.ts
@@ -1,22 +1,15 @@
 import { timingSafeEqual as nodeTimingSafeEqual } from 'crypto';
 import { getWorkerDb } from '@kilocode/db/client';
+import {
+  buildScheduledJobFailureEvent,
+  buildScheduledJobSuccessEvent,
+  createScheduledJobRunContext,
+  emitScheduledJobEvent,
+} from '@kilocode/worker-utils/scheduled-job-observability';
 import * as z from 'zod';
 import { createPromotionStore, syncPromotionsFromBench } from './sync.js';
 
 const SyncRequestSchema = z.object({ promotionName: z.string().min(1).optional() }).optional();
-
-async function sendBetterStackHeartbeat(
-  heartbeatUrl: string | undefined,
-  failed: boolean
-): Promise<void> {
-  if (!heartbeatUrl) return;
-  const url = failed ? `${heartbeatUrl}/fail` : heartbeatUrl;
-  try {
-    await fetch(url, { signal: AbortSignal.timeout(5000) });
-  } catch {
-    // best-effort heartbeat
-  }
-}
 
 async function timingSafeEqual(left: string, right: string): Promise<boolean> {
   const encoder = new TextEncoder();
@@ -34,6 +27,10 @@ async function runSync(env: CloudflareEnv, promotionName?: string) {
 
 async function getInternalApiSecret(secret: SecretBinding | string): Promise<string> {
   return typeof secret === 'string' ? secret : secret.get();
+}
+
+function scheduledEnvironment(env: CloudflareEnv): string | undefined {
+  return 'ENVIRONMENT' in env && typeof env.ENVIRONMENT === 'string' ? env.ENVIRONMENT : undefined;
 }
 
 async function handleFetch(request: Request, env: CloudflareEnv): Promise<Response> {
@@ -82,19 +79,46 @@ export default {
     return handleFetch(request, env);
   },
 
-  async scheduled(
-    _controller: ScheduledController,
-    env: CloudflareEnv,
-    ctx: ExecutionContext
-  ): Promise<void> {
-    let failed = false;
+  async scheduled(controller: ScheduledController, env: CloudflareEnv): Promise<void> {
+    const context = createScheduledJobRunContext();
+    const environment = scheduledEnvironment(env);
+    const metadata = {
+      scheduled_time: controller.scheduledTime,
+      schedule: controller.cron,
+    };
+
     try {
-      await runSync(env);
+      const result = await runSync(env);
+      emitScheduledJobEvent(
+        buildScheduledJobSuccessEvent({
+          context,
+          jobName: 'model_eval_ingest.sync',
+          environment,
+          metadata: {
+            ...metadata,
+            fetched_count: result.fetched,
+            inserted_count: result.inserted,
+            already_had_count: result.alreadyHad,
+            cache_recompute_count: result.cacheRecomputes,
+            no_op:
+              result.fetched === 0 &&
+              result.inserted === 0 &&
+              result.alreadyHad === 0 &&
+              result.cacheRecomputes === 0,
+          },
+        })
+      );
     } catch (error) {
-      failed = true;
+      emitScheduledJobEvent(
+        buildScheduledJobFailureEvent({
+          context,
+          jobName: 'model_eval_ingest.sync',
+          environment,
+          metadata,
+          error,
+        })
+      );
       throw error;
-    } finally {
-      ctx.waitUntil(sendBetterStackHeartbeat(env.BETTERSTACK_HEARTBEAT_URL, failed));
     }
   },
 };

--- a/services/model-eval-ingest/worker-configuration.d.ts
+++ b/services/model-eval-ingest/worker-configuration.d.ts
@@ -28,5 +28,5 @@ declare type CloudflareEnv = {
   HYPERDRIVE: Hyperdrive;
   BENCH_DASHBOARD: BenchDashboardService;
   INTERNAL_API_SECRET: SecretBinding | string;
-  BETTERSTACK_HEARTBEAT_URL: string | undefined;
+  ENVIRONMENT: string;
 };

--- a/services/model-eval-ingest/wrangler.jsonc
+++ b/services/model-eval-ingest/wrangler.jsonc
@@ -14,6 +14,17 @@
   },
   "observability": {
     "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": false,
+    },
+  },
+  "logpush": true,
+  "vars": {
+    "ENVIRONMENT": "production",
   },
   "triggers": {
     "crons": ["*/15 * * * *"],
@@ -43,6 +54,9 @@
     "dev": {
       "name": "model-eval-ingest-dev",
       "workers_dev": true,
+      "vars": {
+        "ENVIRONMENT": "development",
+      },
       "hyperdrive": [
         {
           "binding": "HYPERDRIVE",

--- a/services/security-auto-analysis/src/index.test.ts
+++ b/services/security-auto-analysis/src/index.test.ts
@@ -10,27 +10,12 @@ import { startManualRemediation } from './remediation.js';
 import { dispatchDueOwners } from './dispatcher.js';
 import worker from './index.js';
 
-const loggerMock = vi.hoisted(() => {
-  const logger = {
-    withTags: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  };
-  logger.withTags.mockReturnValue(logger);
-  return logger;
-});
-
 vi.mock('@kilocode/db', () => ({
   createSecurityAgentCommand: vi.fn(),
   markSecurityAgentCommandQueueAdmissionFailed: vi.fn(),
 }));
 vi.mock('@kilocode/db/client', () => ({ getWorkerDb: vi.fn() }));
 vi.mock('./dispatcher.js', () => ({ dispatchDueOwners: vi.fn() }));
-vi.mock('./logger.js', () => ({
-  logger: loggerMock,
-  sanitizedExceptionName: (error: unknown) =>
-    error instanceof Error ? error.name : 'UnknownError',
-}));
 vi.mock('./remediation.js', async importOriginal => ({
   ...(await importOriginal<typeof RemediationModule>()),
   startManualRemediation: vi.fn(),
@@ -39,7 +24,6 @@ vi.mock('./remediation.js', async importOriginal => ({
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.clearAllMocks();
-  loggerMock.withTags.mockReturnValue(loggerMock);
   vi.mocked(getWorkerDb).mockReturnValue({} as never);
   vi.mocked(dispatchDueOwners).mockResolvedValue({
     dispatchId: 'dispatch-123',
@@ -98,29 +82,6 @@ async function remediationCallbackTokenFor(
   });
 }
 
-function scheduledEnv(heartbeatUrl: string | undefined): CloudflareEnv {
-  return {
-    BETTERSTACK_HEARTBEAT_URL: heartbeatUrl,
-    ENVIRONMENT: 'test',
-    CF_VERSION_METADATA: { id: 'version-123', tag: '', timestamp: '' },
-  } as CloudflareEnv;
-}
-
-async function runScheduled(env: CloudflareEnv): Promise<{
-  scheduledResult: Promise<void>;
-  heartbeatPromise: Promise<unknown>;
-}> {
-  let heartbeatPromise: Promise<unknown> | undefined;
-  const scheduledResult = worker.scheduled({} as ScheduledController, env, {
-    waitUntil(promise) {
-      heartbeatPromise = promise;
-    },
-  } as ExecutionContext);
-  await scheduledResult.catch(() => undefined);
-  if (!heartbeatPromise) throw new Error('Expected heartbeat waitUntil promise');
-  return { scheduledResult, heartbeatPromise };
-}
-
 function manualRemediationRequest(): Request {
   return new Request('https://security-auto-analysis/internal/remediation/start', {
     method: 'POST',
@@ -137,119 +98,23 @@ function manualRemediationRequest(): Request {
   });
 }
 
-describe('scheduled dispatcher heartbeat', () => {
-  it('delivers successful dispatch heartbeats and logs attempted and successful outcomes', async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response(null, { status: 204 }));
-
-    const { scheduledResult, heartbeatPromise } = await runScheduled(
-      scheduledEnv('https://heartbeat.example/secret')
-    );
-    await expect(scheduledResult).resolves.toBeUndefined();
-    await heartbeatPromise;
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://heartbeat.example/secret',
-      expect.objectContaining({ signal: expect.any(AbortSignal) })
-    );
-    const dispatchId = vi.mocked(dispatchDueOwners).mock.calls[0]?.[1];
-    expect(dispatchId).toEqual(expect.any(String));
-    expect(heartbeatTags()).toEqual(
-      expect.arrayContaining([expect.objectContaining({ dispatch_id: dispatchId })])
-    );
-    expect(heartbeatOutcomes()).toEqual(['attempted', 'succeeded']);
-    expect(JSON.stringify(loggerMock.withTags.mock.calls)).not.toContain('heartbeat.example');
+describe('scheduled dispatcher', () => {
+  it('resolves after a successful dispatch', async () => {
+    await expect(
+      worker.scheduled({} as ScheduledController, {} as CloudflareEnv)
+    ).resolves.toBeUndefined();
+    expect(dispatchDueOwners).toHaveBeenCalledWith({}, expect.any(String));
   });
 
-  it('selects /fail, rethrows dispatcher errors, and preserves them across heartbeat failure', async () => {
-    const dispatcherError = new Error('original dispatcher failure');
+  it('rejects when dispatch fails', async () => {
+    const dispatcherError = new Error('dispatcher failed');
     vi.mocked(dispatchDueOwners).mockRejectedValueOnce(dispatcherError);
-    const fetchMock = vi
-      .spyOn(globalThis, 'fetch')
-      .mockRejectedValueOnce(new Error('heartbeat-url credential network failure'));
 
-    const { scheduledResult, heartbeatPromise } = await runScheduled(
-      scheduledEnv('https://heartbeat.example/secret')
+    await expect(worker.scheduled({} as ScheduledController, {} as CloudflareEnv)).rejects.toBe(
+      dispatcherError
     );
-    await expect(scheduledResult).rejects.toBe(dispatcherError);
-    await expect(heartbeatPromise).resolves.toBeUndefined();
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://heartbeat.example/secret/fail',
-      expect.objectContaining({ signal: expect.any(AbortSignal) })
-    );
-    const dispatchId = vi.mocked(dispatchDueOwners).mock.calls[0]?.[1];
-    expect(dispatchId).toEqual(expect.any(String));
-    expect(heartbeatTags()).toEqual(
-      expect.arrayContaining([expect.objectContaining({ dispatch_id: dispatchId })])
-    );
-    expect(heartbeatOutcomes()).toEqual(['attempted', 'failed']);
-    const failureTags = heartbeatTags().at(-1);
-    expect(failureTags).toMatchObject({
-      exception_name: 'Error',
-      error_message: 'Heartbeat network failure',
-      heartbeat_kind: 'failure',
-    });
-    expect(JSON.stringify(loggerMock.withTags.mock.calls)).not.toContain('credential');
-  });
-
-  it('logs skipped delivery when heartbeat binding is absent', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch');
-
-    const { scheduledResult, heartbeatPromise } = await runScheduled(scheduledEnv(undefined));
-    await expect(scheduledResult).resolves.toBeUndefined();
-    await heartbeatPromise;
-
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(heartbeatOutcomes()).toEqual(['skipped']);
-  });
-
-  it('treats non-2xx responses as delivery failures without failing dispatch', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 503 }));
-
-    const { scheduledResult, heartbeatPromise } = await runScheduled(
-      scheduledEnv('https://heartbeat.example/secret')
-    );
-    await expect(scheduledResult).resolves.toBeUndefined();
-    await heartbeatPromise;
-
-    expect(heartbeatOutcomes()).toEqual(['attempted', 'failed']);
-    expect(heartbeatTags().at(-1)).toMatchObject({
-      response_status: 503,
-      response_status_class: '5xx',
-    });
-  });
-
-  it('logs heartbeat timeouts without failing dispatch', async () => {
-    const timeout = new Error('heartbeat URL timed out');
-    timeout.name = 'TimeoutError';
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(timeout);
-
-    const { scheduledResult, heartbeatPromise } = await runScheduled(
-      scheduledEnv('https://heartbeat.example/secret')
-    );
-    await expect(scheduledResult).resolves.toBeUndefined();
-    await heartbeatPromise;
-
-    expect(heartbeatOutcomes()).toEqual(['attempted', 'timeout']);
-    expect(heartbeatTags().at(-1)).toMatchObject({
-      exception_name: 'TimeoutError',
-      error_message: 'Heartbeat delivery timed out',
-    });
-    expect(JSON.stringify(loggerMock.withTags.mock.calls)).not.toContain('heartbeat URL');
   });
 });
-
-function heartbeatTags(): Array<Record<string, unknown>> {
-  return loggerMock.withTags.mock.calls
-    .map(([tags]) => tags)
-    .filter(tags => tags.event_name === 'security_auto_analysis.heartbeat_delivery');
-}
-
-function heartbeatOutcomes(): unknown[] {
-  return heartbeatTags().map(tags => tags.outcome);
-}
 
 describe('manual remediation ingress', () => {
   it('returns HTTP 409 with analysis_required for a policy rejection', async () => {

--- a/services/security-auto-analysis/src/index.test.ts
+++ b/services/security-auto-analysis/src/index.test.ts
@@ -99,20 +99,78 @@ function manualRemediationRequest(): Request {
 }
 
 describe('scheduled dispatcher', () => {
-  it('resolves after a successful dispatch', async () => {
+  it('emits a canonical success event with dispatch counters and schedule metadata', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    vi.mocked(dispatchDueOwners).mockResolvedValueOnce({
+      dispatchId: 'dispatch-123',
+      discoveredOwners: 2,
+      enqueuedMessages: 2,
+      discoveredRemediationAttempts: 3,
+      enqueuedRemediationMessages: 3,
+    });
+
     await expect(
-      worker.scheduled({} as ScheduledController, {} as CloudflareEnv)
+      worker.scheduled(
+        { cron: '* * * * *', scheduledTime: 1_700_000_000_000 } as ScheduledController,
+        { ENVIRONMENT: 'development' } as CloudflareEnv
+      )
     ).resolves.toBeUndefined();
-    expect(dispatchDueOwners).toHaveBeenCalledWith({}, expect.any(String));
+    const dispatchId = vi.mocked(dispatchDueOwners).mock.calls[0]?.[1];
+    expect(dispatchDueOwners).toHaveBeenCalledWith(
+      expect.objectContaining({ ENVIRONMENT: 'development' }),
+      dispatchId
+    );
+    expect(
+      JSON.parse(
+        info.mock.calls.find(
+          ([message]) => typeof message === 'string' && message.includes('scheduled_job.completed')
+        )?.[0] ?? '{}'
+      )
+    ).toMatchObject({
+      event_name: 'scheduled_job.completed',
+      job_name: 'security_auto_analysis.dispatch',
+      run_id: dispatchId,
+      dispatch_id: dispatchId,
+      outcome: 'succeeded',
+      environment: 'development',
+      schedule: '* * * * *',
+      scheduled_time: 1_700_000_000_000,
+      discovered_owner_count: 2,
+      enqueued_owner_message_count: 2,
+      discovered_remediation_attempt_count: 3,
+      enqueued_remediation_message_count: 3,
+    });
   });
 
-  it('rejects when dispatch fails', async () => {
+  it('emits a canonical failure event before rethrowing', async () => {
     const dispatcherError = new Error('dispatcher failed');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     vi.mocked(dispatchDueOwners).mockRejectedValueOnce(dispatcherError);
 
-    await expect(worker.scheduled({} as ScheduledController, {} as CloudflareEnv)).rejects.toBe(
-      dispatcherError
-    );
+    await expect(
+      worker.scheduled(
+        { cron: '* * * * *', scheduledTime: 1_700_000_000_000 } as ScheduledController,
+        { ENVIRONMENT: 'production' } as CloudflareEnv
+      )
+    ).rejects.toBe(dispatcherError);
+    const dispatchId = vi.mocked(dispatchDueOwners).mock.calls[0]?.[1];
+    expect(
+      JSON.parse(
+        error.mock.calls.find(
+          ([message]) => typeof message === 'string' && message.includes('scheduled_job.completed')
+        )?.[0] ?? '{}'
+      )
+    ).toMatchObject({
+      event_name: 'scheduled_job.completed',
+      job_name: 'security_auto_analysis.dispatch',
+      run_id: dispatchId,
+      dispatch_id: dispatchId,
+      outcome: 'failed',
+      environment: 'production',
+      schedule: '* * * * *',
+      scheduled_time: 1_700_000_000_000,
+      exception_name: 'Error',
+    });
   });
 });
 

--- a/services/security-auto-analysis/src/index.ts
+++ b/services/security-auto-analysis/src/index.ts
@@ -6,6 +6,12 @@ import {
 } from '@kilocode/db';
 import { getWorkerDb } from '@kilocode/db/client';
 import { verifyCallbackToken } from '@kilocode/worker-utils';
+import {
+  buildScheduledJobFailureEvent,
+  buildScheduledJobSuccessEvent,
+  createScheduledJobRun,
+  emitScheduledJobEvent,
+} from '@kilocode/worker-utils/scheduled-job-observability';
 import { consumeOwnerBatch } from './consumer.js';
 import { dispatchDueOwners } from './dispatcher.js';
 import {
@@ -337,9 +343,37 @@ export default {
     return handleFetch(request, env);
   },
 
-  async scheduled(_controller: ScheduledController, env: CloudflareEnv): Promise<void> {
+  async scheduled(controller: ScheduledController, env: CloudflareEnv): Promise<void> {
     const dispatchId = randomUUID();
-    await dispatchDueOwners(env, dispatchId);
+    const run = createScheduledJobRun({
+      jobName: 'security_auto_analysis.dispatch',
+      runId: dispatchId,
+      environment: env.ENVIRONMENT,
+    });
+    const scheduleMetadata = {
+      schedule: controller.cron,
+      scheduled_time: controller.scheduledTime,
+      dispatch_id: dispatchId,
+    };
+
+    try {
+      const result = await dispatchDueOwners(env, dispatchId);
+      emitScheduledJobEvent(
+        buildScheduledJobSuccessEvent(run, {
+          ...scheduleMetadata,
+          discovered_owner_count: result.discoveredOwners,
+          enqueued_owner_message_count: result.enqueuedMessages,
+          discovered_remediation_attempt_count: result.discoveredRemediationAttempts,
+          enqueued_remediation_message_count: result.enqueuedRemediationMessages,
+        })
+      );
+    } catch (error) {
+      emitScheduledJobEvent({
+        ...buildScheduledJobFailureEvent(run, error),
+        ...scheduleMetadata,
+      });
+      throw error;
+    }
   },
 
   async queue(batch: MessageBatch<unknown>, env: CloudflareEnv): Promise<void> {

--- a/services/security-auto-analysis/src/index.ts
+++ b/services/security-auto-analysis/src/index.ts
@@ -8,7 +8,6 @@ import { getWorkerDb } from '@kilocode/db/client';
 import { verifyCallbackToken } from '@kilocode/worker-utils';
 import { consumeOwnerBatch } from './consumer.js';
 import { dispatchDueOwners } from './dispatcher.js';
-import { logger, sanitizedExceptionName } from './logger.js';
 import {
   consumeAnalysisCallbackBatch,
   SecurityAnalysisCallbackPayloadSchema,
@@ -25,60 +24,6 @@ import {
   cancelRemediation,
   startManualRemediation,
 } from './remediation.js';
-
-const HEARTBEAT_EVENT = 'security_auto_analysis.heartbeat_delivery';
-
-async function sendBetterStackHeartbeat(options: {
-  heartbeatUrl: string | undefined;
-  dispatcherFailed: boolean;
-  dispatchId: string | undefined;
-  env: CloudflareEnv;
-}): Promise<void> {
-  const heartbeatKind = options.dispatcherFailed ? 'failure' : 'success';
-  const commonTags = {
-    event_name: HEARTBEAT_EVENT,
-    heartbeat_kind: heartbeatKind,
-    dispatch_id: options.dispatchId,
-    worker_environment: options.env.ENVIRONMENT,
-    worker_version: options.env.CF_VERSION_METADATA?.id,
-  } as const;
-
-  if (!options.heartbeatUrl) {
-    logger.withTags({ ...commonTags, outcome: 'skipped' }).warn(HEARTBEAT_EVENT);
-    return;
-  }
-
-  const startedAt = Date.now();
-  logger.withTags({ ...commonTags, outcome: 'attempted' }).info(HEARTBEAT_EVENT);
-
-  try {
-    const url = options.dispatcherFailed ? `${options.heartbeatUrl}/fail` : options.heartbeatUrl;
-    const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
-    const responseTags = {
-      ...commonTags,
-      elapsed_ms: Date.now() - startedAt,
-      response_status: response.status,
-      response_status_class: `${Math.floor(response.status / 100)}xx`,
-    };
-    if (response.ok) {
-      logger.withTags({ ...responseTags, outcome: 'succeeded' }).info(HEARTBEAT_EVENT);
-      return;
-    }
-
-    logger.withTags({ ...responseTags, outcome: 'failed' }).warn(HEARTBEAT_EVENT);
-  } catch (error) {
-    const timedOut = error instanceof Error && error.name === 'TimeoutError';
-    logger
-      .withTags({
-        ...commonTags,
-        outcome: timedOut ? 'timeout' : 'failed',
-        exception_name: sanitizedExceptionName(error),
-        error_message: timedOut ? 'Heartbeat delivery timed out' : 'Heartbeat network failure',
-        elapsed_ms: Date.now() - startedAt,
-      })
-      .warn(HEARTBEAT_EVENT);
-  }
-}
 
 /**
  * Constant-time string equality that does not leak either string's length.
@@ -392,28 +337,9 @@ export default {
     return handleFetch(request, env);
   },
 
-  async scheduled(
-    _controller: ScheduledController,
-    env: CloudflareEnv,
-    ctx: ExecutionContext
-  ): Promise<void> {
-    let failed = false;
+  async scheduled(_controller: ScheduledController, env: CloudflareEnv): Promise<void> {
     const dispatchId = randomUUID();
-    try {
-      await dispatchDueOwners(env, dispatchId);
-    } catch (error) {
-      failed = true;
-      throw error;
-    } finally {
-      ctx.waitUntil(
-        sendBetterStackHeartbeat({
-          heartbeatUrl: env.BETTERSTACK_HEARTBEAT_URL,
-          dispatcherFailed: failed,
-          dispatchId,
-          env,
-        })
-      );
-    }
+    await dispatchDueOwners(env, dispatchId);
   },
 
   async queue(batch: MessageBatch<unknown>, env: CloudflareEnv): Promise<void> {

--- a/services/security-auto-analysis/worker-configuration.d.ts
+++ b/services/security-auto-analysis/worker-configuration.d.ts
@@ -87,7 +87,6 @@ declare type CloudflareEnv = {
   SECURITY_ANALYSIS_CALLBACK_WORKER_INGRESS_ENABLED: string | undefined;
   MANUAL_ANALYSIS_COMMAND_ROUTING_ENABLED: string | undefined;
   NEXT_PUBLIC_POSTHOG_KEY: string | undefined;
-  BETTERSTACK_HEARTBEAT_URL: string | undefined;
 };
 
 declare type GitTokenLookupFailureReason = Extract<

--- a/services/security-sync/src/index.test.ts
+++ b/services/security-sync/src/index.test.ts
@@ -83,6 +83,7 @@ describe('collectScheduledSyncOwners', () => {
 
 describe('scheduled sync dispatch', () => {
   it('enqueues enabled owners and processes the scheduled queue message', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const queuedBatches: MessageSendRequest<SecuritySyncQueueMessage>[][] = [];
     vi.mocked(getWorkerDb)
       .mockReturnValueOnce({
@@ -107,7 +108,7 @@ describe('scheduled sync dispatch', () => {
     vi.mocked(syncOwner).mockResolvedValue({ synced: 1, errors: 0, staleRepos: 0 } as never);
 
     await worker.scheduled(
-      { cron: '0 */6 * * *' } as ScheduledController,
+      { cron: '0 */6 * * *', scheduledTime: 1_700_000_000_000 } as ScheduledController,
       {
         HYPERDRIVE: { connectionString: 'postgres://worker' },
         SYNC_QUEUE: {
@@ -115,8 +116,7 @@ describe('scheduled sync dispatch', () => {
             queuedBatches.push(batch);
           },
         },
-      } as CloudflareEnv,
-      { waitUntil: vi.fn() } as unknown as ExecutionContext
+      } as CloudflareEnv
     );
 
     const queuedMessage = queuedBatches[0]?.[0]?.body;
@@ -125,6 +125,21 @@ describe('scheduled sync dispatch', () => {
       trigger: 'scheduled',
       owner: { organizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' },
     });
+    const terminalEvent = JSON.parse(
+      info.mock.calls.find(
+        ([message]) => typeof message === 'string' && message.includes('scheduled_job.completed')
+      )?.[0] ?? '{}'
+    );
+    expect(terminalEvent).toMatchObject({
+      schedule: '0 */6 * * *',
+      scheduled_time: 1_700_000_000_000,
+      event_name: 'scheduled_job.completed',
+      job_name: 'security_sync.dispatch',
+      outcome: 'succeeded',
+      owner_count: 1,
+      enqueued_message_count: 1,
+    });
+    info.mockRestore();
 
     const ack = vi.fn();
     const retry = vi.fn();
@@ -147,19 +162,124 @@ describe('scheduled sync dispatch', () => {
   });
 
   it('runs notification sweep on hourly notification cron without sync dispatch', async () => {
-    const waitUntil = vi.fn();
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const env = {
       HYPERDRIVE: { connectionString: 'postgres://worker' },
       SYNC_QUEUE: { sendBatch: vi.fn() },
+      ENVIRONMENT: 'development',
     } as unknown as CloudflareEnv;
+    vi.mocked(runSecurityNotificationSweep).mockResolvedValue({
+      recovered: 1,
+      stagedRecovered: 2,
+      cancelled: 3,
+      materialized: 4,
+      reactivated: 5,
+      processed: 6,
+      sent: 7,
+      retried: 8,
+      failed: 9,
+      deferred: 10,
+      dispatchCapReached: true,
+      materializationCapReached: false,
+    } as never);
 
-    await worker.scheduled({ cron: '15 * * * *' } as ScheduledController, env, {
-      waitUntil,
-    } as unknown as ExecutionContext);
+    await worker.scheduled(
+      { cron: '15 * * * *', scheduledTime: 1_700_000_000_000 } as ScheduledController,
+      env
+    );
 
     expect(runSecurityNotificationSweep).toHaveBeenCalledWith(env);
     expect(getWorkerDb).not.toHaveBeenCalled();
-    expect(waitUntil).not.toHaveBeenCalled();
+    expect(
+      JSON.parse(
+        info.mock.calls.find(
+          ([message]) => typeof message === 'string' && message.includes('scheduled_job.completed')
+        )?.[0] ?? '{}'
+      )
+    ).toMatchObject({
+      job_name: 'security_sync.notification_sweep',
+      outcome: 'succeeded',
+      environment: 'development',
+      scheduled_time: 1_700_000_000_000,
+      schedule: '15 * * * *',
+      staged_recovered: 2,
+      dispatch_cap_reached: true,
+      materialization_cap_reached: false,
+    });
+    info.mockRestore();
+  });
+
+  it('emits a dispatch failure event before rethrowing', async () => {
+    const error = new Error('database unavailable');
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(getWorkerDb).mockReturnValueOnce({
+      select: () => ({
+        from: () => ({
+          where: async () => {
+            throw error;
+          },
+        }),
+      }),
+    } as never);
+
+    await expect(
+      worker.scheduled(
+        { cron: '0 */6 * * *', scheduledTime: 1_700_000_000_000 } as ScheduledController,
+        { HYPERDRIVE: { connectionString: 'postgres://worker' } } as CloudflareEnv
+      )
+    ).rejects.toThrow(error);
+    expect(
+      JSON.parse(
+        errorLog.mock.calls.find(
+          ([message]) => typeof message === 'string' && message.includes('scheduled_job.completed')
+        )?.[0] ?? '{}'
+      )
+    ).toMatchObject({
+      job_name: 'security_sync.dispatch',
+      outcome: 'failed',
+      exception_name: 'Error',
+    });
+    errorLog.mockRestore();
+  });
+
+  it('emits a notification sweep failure event before rethrowing', async () => {
+    const error = new Error('notification database unavailable');
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(runSecurityNotificationSweep).mockRejectedValue(error);
+
+    await expect(
+      worker.scheduled(
+        { cron: '15 * * * *', scheduledTime: 1_700_000_000_000 } as ScheduledController,
+        { ENVIRONMENT: 'development' } as unknown as CloudflareEnv
+      )
+    ).rejects.toThrow(error);
+    expect(
+      JSON.parse(
+        errorLog.mock.calls.find(
+          ([message]) => typeof message === 'string' && message.includes('scheduled_job.completed')
+        )?.[0] ?? '{}'
+      )
+    ).toMatchObject({
+      job_name: 'security_sync.notification_sweep',
+      outcome: 'failed',
+      exception_name: 'Error',
+    });
+    errorLog.mockRestore();
+  });
+
+  it('does not emit a terminal event for an unknown cron expression', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    await worker.scheduled(
+      { cron: '30 * * * *', scheduledTime: 1_700_000_000_000 } as ScheduledController,
+      {} as CloudflareEnv
+    );
+
+    expect(info).toHaveBeenCalledWith('Ignoring unknown Security Sync cron expression', {
+      cron: '30 * * * *',
+    });
+    expect(info).not.toHaveBeenCalledWith(expect.stringContaining('scheduled_job.completed'));
+    info.mockRestore();
   });
 });
 

--- a/services/security-sync/src/index.ts
+++ b/services/security-sync/src/index.ts
@@ -12,6 +12,12 @@ import {
 } from '@kilocode/db';
 import { getWorkerDb, type WorkerDb } from '@kilocode/db/client';
 import { agent_configs } from '@kilocode/db/schema';
+import {
+  buildScheduledJobFailureEvent,
+  buildScheduledJobSuccessEvent,
+  createScheduledJobRun,
+  emitScheduledJobEvent,
+} from '@kilocode/worker-utils/scheduled-job-observability';
 import { eq, and, isNotNull, or } from 'drizzle-orm';
 import { syncOwner } from './sync';
 import { processSecurityFindingDismissal } from './dismiss';
@@ -165,6 +171,13 @@ function isStrictTrueRolloutFlag(value: string | undefined, name: string): boole
   return false;
 }
 
+function getEnvironment(env: CloudflareEnv): string | undefined {
+  if ('ENVIRONMENT' in env && typeof env.ENVIRONMENT === 'string') {
+    return env.ENVIRONMENT;
+  }
+  return undefined;
+}
+
 const QUEUE_SEND_BATCH_LIMIT = 100;
 const SECURITY_SYNC_COMMAND_MAX_ATTEMPTS = 4;
 
@@ -306,19 +319,6 @@ async function enqueueOwners(
   }
 
   return messages.length;
-}
-
-async function sendBetterStackHeartbeat(
-  heartbeatUrl: string | undefined,
-  failed: boolean
-): Promise<void> {
-  if (!heartbeatUrl) return;
-  const url = failed ? `${heartbeatUrl}/fail` : heartbeatUrl;
-  try {
-    await fetch(url, { signal: AbortSignal.timeout(5000) });
-  } catch {
-    // best-effort
-  }
 }
 
 function resolveOwner(
@@ -596,9 +596,41 @@ export default {
     return jsonResponse({ success: false, error: 'Not found' }, 404);
   },
 
-  async scheduled(controller: ScheduledController, env: CloudflareEnv, ctx: ExecutionContext) {
+  async scheduled(controller: ScheduledController, env: CloudflareEnv) {
+    const environment = getEnvironment(env);
     if (controller.cron === '15 * * * *') {
-      await runSecurityNotificationSweep(env);
+      const run = createScheduledJobRun({
+        jobName: 'security_sync.notification_sweep',
+        environment,
+      });
+      try {
+        const result = await runSecurityNotificationSweep(env);
+        emitScheduledJobEvent(
+          buildScheduledJobSuccessEvent(run, {
+            scheduled_time: controller.scheduledTime,
+            schedule: controller.cron,
+            recovered: result.recovered,
+            staged_recovered: result.stagedRecovered,
+            cancelled: result.cancelled,
+            materialized: result.materialized,
+            reactivated: result.reactivated,
+            processed: result.processed,
+            sent: result.sent,
+            retried: result.retried,
+            failed: result.failed,
+            deferred: result.deferred,
+            dispatch_cap_reached: result.dispatchCapReached,
+            materialization_cap_reached: result.materializationCapReached,
+          })
+        );
+      } catch (error) {
+        emitScheduledJobEvent({
+          ...buildScheduledJobFailureEvent(run, error),
+          scheduled_time: controller.scheduledTime,
+          schedule: controller.cron,
+        });
+        throw error;
+      }
       return;
     }
     if (controller.cron !== '0 */6 * * *') {
@@ -607,7 +639,11 @@ export default {
     }
 
     const runId = crypto.randomUUID();
-    let failed = false;
+    const run = createScheduledJobRun({
+      jobName: 'security_sync.dispatch',
+      runId,
+      environment,
+    });
 
     try {
       const db = getWorkerDb(env.HYPERDRIVE.connectionString, { statement_timeout: 30_000 });
@@ -643,15 +679,25 @@ export default {
         ownerCount: owners.length,
         enqueuedMessages,
       });
+      emitScheduledJobEvent(
+        buildScheduledJobSuccessEvent(run, {
+          scheduled_time: controller.scheduledTime,
+          schedule: controller.cron,
+          owner_count: owners.length,
+          enqueued_message_count: enqueuedMessages,
+        })
+      );
     } catch (error) {
-      failed = true;
       console.error('Security sync scheduled dispatch failed', {
         runId,
-        error: error instanceof Error ? error.message : String(error),
+        error_type: error instanceof Error ? error.name : 'UnknownError',
+      });
+      emitScheduledJobEvent({
+        ...buildScheduledJobFailureEvent(run, error),
+        scheduled_time: controller.scheduledTime,
+        schedule: controller.cron,
       });
       throw error;
-    } finally {
-      ctx.waitUntil(sendBetterStackHeartbeat(env.SECURITY_SYNC_BETTERSTACK_HEARTBEAT_URL, failed));
     }
   },
 

--- a/services/security-sync/worker-configuration.d.ts
+++ b/services/security-sync/worker-configuration.d.ts
@@ -42,11 +42,11 @@ declare type ExecutionContext = {
 };
 
 declare type CloudflareEnv = {
-  SECURITY_SYNC_BETTERSTACK_HEARTBEAT_URL: string | undefined;
   INTERNAL_API_SECRET: SecretBinding;
   SYNC_QUEUE: Queue<import('./src/index').SecuritySyncQueueMessage>;
   HYPERDRIVE: Hyperdrive;
   GIT_TOKEN_SERVICE: GitTokenService;
+  ENVIRONMENT: string;
   MANUAL_SYNC_COMMAND_ROUTING_ENABLED: string | undefined;
   DISMISS_FINDING_COMMAND_ROUTING_ENABLED: string | undefined;
   BACKEND_API_URL: string | undefined;

--- a/services/security-sync/wrangler.jsonc
+++ b/services/security-sync/wrangler.jsonc
@@ -8,7 +8,15 @@
   "workers_dev": false,
   "observability": {
     "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": false,
+    },
   },
+  "logpush": true,
   "routes": [
     {
       "pattern": "security-sync.kilosessions.ai",
@@ -22,6 +30,7 @@
     "ip": "0.0.0.0",
   },
   "vars": {
+    "ENVIRONMENT": "production",
     "MANUAL_SYNC_COMMAND_ROUTING_ENABLED": "true",
     "DISMISS_FINDING_COMMAND_ROUTING_ENABLED": "true",
     "BACKEND_API_URL": "https://app.kilo.ai",
@@ -73,6 +82,7 @@
     "dev": {
       "name": "cloudflare-security-sync-dev",
       "vars": {
+        "ENVIRONMENT": "development",
         "MANUAL_SYNC_COMMAND_ROUTING_ENABLED": "true",
         "DISMISS_FINDING_COMMAND_ROUTING_ENABLED": "true",
         "BACKEND_API_URL": "http://localhost:3000",


### PR DESCRIPTION
## Summary
Replace scoped Better Stack heartbeats with structured scheduled-job completion events for Axiom monitoring.

### Why this change is needed
The affected scheduled jobs rely on isolated heartbeat URLs that do not expose consistent outcomes, durations, environment data, or job-specific counters. Moving these signals into structured application and Worker logs lets Axiom monitor missing runs, explicit failures, and degraded results from one stable contract.

This is a direct cutover. The old Better Stack calls and bindings are removed in the same change rather than retained for a parallel reporting period.

### How this is addressed
- Add a runtime-neutral helper that emits one best-effort JSON completion event with a run ID, duration, outcome, environment, scalar result metadata, and sanitized exception name.
- Instrument the scoped web cron routes, Security Sync dispatch and notification sweep, and Model Eval Ingest scheduled handler at their execution boundaries.
- Keep Security Auto Analysis on its existing structured dispatcher events while removing its redundant heartbeat.
- Enable persisted Worker logs, full head sampling, Logpush, and production/development environment separation where required.
- Remove scoped heartbeat URLs, helpers, bindings, and heartbeat-specific tests.

## Human Verification
- Worker Utils test suite: 306 tests passed.
- Security Sync test suite: 46 tests passed.
- Model Eval Ingest test suite: 13 tests passed.
- Security Auto Analysis test suite: 122 tests passed.
- Local code-quality review completed across security, logic, types, data, resources, style, React applicability, and tests with no remaining findings.

## Reviewer Notes
### Human Reviewer Flags
- This is an intentional direct monitoring cutover without dual reporting.
- The shared event helper remains in `@kilocode/worker-utils` because that package already serves runtime-neutral web and Worker consumers. A dedicated observability package can be considered if more cross-runtime telemetry contracts emerge.
- Deployment still requires confirming Axiom field extraction and creating missing-run, failure, and degraded-counter monitors before deleting deployed Better Stack secrets.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Unauthorized web cron requests create no monitored run and emit no terminal event.
- Successful no-work runs preserve zero and false counters.
- Failure events contain bounded exception names without messages or stacks.
- Security Sync dispatch reports owner discovery and queue admission, not downstream queue completion.
- Notification sweep item failures, retries, deferrals, and cap flags remain successful boundary outcomes with separate counters.
- Manual Model Eval Ingest requests do not emit scheduled-job events.

</details>
