### PR TITLE
config schema: add privacy_mode to kiloExtras top bucket

### DIFF
--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -80,6 +80,11 @@ export const kiloExtras = {
       type: 'boolean',
       default: false,
     },
+    privacy_mode: {
+      description:
+        'Blur personally identifiable information (account email, balance, team name, etc.) in the TUI and require confirmation before showing profile details',
+      type: 'boolean',
+    },
     commit_message: {
       description: 'Configuration for AI-generated commit messages',
       type: 'object',

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -52,6 +52,11 @@ describe('kilo config.json schema merge', () => {
     expect(props.code_edit_display).toBeDefined();
     expect(props.hide_prompt_training_models).toBeDefined();
     expect(props.web_search).toEqual(expect.objectContaining({ type: 'boolean', default: false }));
+    expect(props.privacy_mode).toBeDefined();
+  });
+
+  test('privacy_mode is a boolean', () => {
+    expect(props.privacy_mode).toEqual(expect.objectContaining({ type: 'boolean' }));
   });
 
   test('auto_collapse_reasoning is a boolean', () => {


### PR DESCRIPTION
Add `privacy_mode` to the `top` bucket of `apps/web/src/app/config.json/extras.ts` so editors using `https://app.kilo.ai/config.json` don't flag it as an unknown property. Also adds the matching assertion in `cli-config-schema.test.ts` to keep schema-sync enforcement green.

Related: Kilo-Org/kilocode#12442