### PR TITLE
fix(ai-gateway): ignore Novita for DeepSeek V4 instead of blocking Vercel routing

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -20,7 +20,6 @@ import { isGlmModel } from '@/lib/ai-gateway/providers/zai';
 import { isMinimaxModel } from '@/lib/ai-gateway/providers/minimax';
 import type { BYOKResult, Provider, ProviderId } from '@/lib/ai-gateway/providers/types';
 import { isStepModel } from '@/lib/ai-gateway/providers/stepfun';
-import { isDeepseekModel } from '@/lib/ai-gateway/providers/deepseek';
 import type { FraudDetectionHeaders } from '@/lib/utils';
 import { applyTrackingIds } from '@/lib/ai-gateway/providerHash';
 import {
@@ -38,6 +37,7 @@ import {
 } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
 import { isQwenExplicitCacheModel, isQwenModel } from '@/lib/ai-gateway/providers/qwen';
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
+import { isRecognizedDeepseekV4Model } from '@/lib/ai-gateway/providers/deepseek';
 
 export function getPreferredProviderOrder(requestedModel: string): string[] {
   if (isClaudeModel(requestedModel) && !isFableModel(requestedModel)) {
@@ -59,9 +59,6 @@ export function getPreferredProviderOrder(requestedModel: string): string[] {
   }
   if (isStepModel(requestedModel)) {
     return [OpenRouterInferenceProviderIdSchema.enum.stepfun];
-  }
-  if (isDeepseekModel(requestedModel)) {
-    return [OpenRouterInferenceProviderIdSchema.enum.alibaba];
   }
   if (isGlmModel(requestedModel)) {
     return [
@@ -111,6 +108,19 @@ export async function applyGatewayModelsFallback(
   }
 
   delete requestToMutate.body.models;
+}
+
+export function applyDeepSeekV4Routing(requestedModel: string, requestToMutate: GatewayRequest) {
+  if (!isRecognizedDeepseekV4Model(requestedModel)) {
+    return;
+  }
+  requestToMutate.body.provider = {
+    ...requestToMutate.body.provider,
+    ignore: [
+      ...(requestToMutate.body.provider?.ignore ?? []),
+      OpenRouterInferenceProviderIdSchema.enum.novita, // https://kilo-code.slack.com/archives/C0A4SA041DE/p1781743079721409
+    ],
+  };
 }
 
 export async function applyProviderSpecificLogic(
@@ -163,6 +173,7 @@ export async function applyProviderSpecificLogic(
 
   if (provider.id === 'openrouter' || provider.id === 'vercel') {
     applyPreferredProvider(requestedModel, requestToMutate.body);
+    applyDeepSeekV4Routing(requestedModel, requestToMutate);
   }
 
   if (isKimiModel(requestedModel)) {

--- a/apps/web/src/lib/ai-gateway/providers/deepseek.ts
+++ b/apps/web/src/lib/ai-gateway/providers/deepseek.ts
@@ -4,10 +4,14 @@ export function isDeepseekModel(model: string) {
   return model.includes('deepseek');
 }
 
+export function isRecognizedDeepseekV4Model(model: string) {
+  return ['deepseek/deepseek-v4-pro', 'deepseek/deepseek-v4-flash'].includes(model);
+}
+
 export const deepseek_v4_pro_discounted_model: KiloExclusiveModel = {
   public_id: 'deepseek/deepseek-v4-pro:discounted',
   internal_id: 'deepseek/deepseek-v4-pro',
-  display_name: 'DeepSeek: DeepSeek V4 Pro (>80% off)',
+  display_name: 'DeepSeek: DeepSeek V4 Pro (lowest price)',
   description:
     "DeepSeek V4 Pro is a large-scale Mixture-of-Experts model from DeepSeek with 1.6T total parameters and 49B activated parameters, supporting a 1M-token context window. For this discounted endpoint, your prompts and completions may be retained and used to train or improve the provider's services.",
   status: 'public',
@@ -32,7 +36,7 @@ export const deepseek_v4_pro_discounted_model: KiloExclusiveModel = {
 const deepseek_v4_flash_discounted_model: KiloExclusiveModel = {
   public_id: 'deepseek/deepseek-v4-flash:discounted',
   internal_id: 'deepseek/deepseek-v4-flash',
-  display_name: 'DeepSeek: DeepSeek V4 Flash (>40% off)',
+  display_name: 'DeepSeek: DeepSeek V4 Flash (lowest price)',
   description:
     "DeepSeek V4 Flash is an efficiency-optimized Mixture-of-Experts model from DeepSeek with 284B total parameters and 13B activated parameters, supporting a 1M-token context window. For this discounted endpoint, your prompts and completions may be retained and used to train or improve the provider's services.",
   status: 'public',

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -231,7 +231,7 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
 
   if (
     eligibleForVercelRouting &&
-    (await shouldRouteToVercel(requestedModel, kiloExclusiveModel, request, taskId || user.id))
+    (await shouldRouteToVercel(requestedModel, request, taskId || user.id))
   ) {
     return {
       kind: 'provider',

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -25,8 +25,6 @@ import {
   getVercelModelsFromRedis,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
-import { isDeepseekModel } from '@/lib/ai-gateway/providers/deepseek';
-import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 
 const getVercelRoutingPercentage = createCachedFetch(
   async () => {
@@ -77,18 +75,9 @@ export function passesVercelRoutingPercentage(randomSeed: string, routingPercent
 
 export async function shouldRouteToVercel(
   requestedModel: string,
-  kiloExclusiveModel: KiloExclusiveModel | null,
   request: GatewayRequest,
   randomSeed: string
 ) {
-  if (!kiloExclusiveModel?.flags.includes('vercel-routing') && isDeepseekModel(requestedModel)) {
-    // https://kilo-code.slack.com/archives/C0A4SA041DE/p1781743079721409
-    console.debug(
-      '[shouldRouteToVercel] not routing to Vercel because some of its DeepSeek providers have tool call issues'
-    );
-    return false;
-  }
-
   console.debug('[shouldRouteToVercel] randomizing user to either OpenRouter or Vercel');
   const routingPercentage = await getVercelRoutingPercentage();
 


### PR DESCRIPTION
Replace the blanket Vercel routing block for DeepSeek models with a targeted Novita ignore rule for recognized DeepSeek V4 models. This allows Vercel routing while avoiding the provider with tool call issues.

Also update discounted model display names to use 'lowest price' instead of percentage-based discount labels.