### PR TITLE
feat(session-ingest): enable remote session attention pushes for all users

### DIFF
--- a/services/session-ingest/.dev.vars.example
+++ b/services/session-ingest/.dev.vars.example
@@ -1,7 +1,3 @@
 DIRECT_INGEST_PERCENT="0"
 DIRECT_INGEST_USER_IDS=""
 DIRECT_INGEST_MAX_BYTES="4194304"
-
-# Exact user ID allowed to receive remote session attention pushes during rollout.
-# Leave empty to keep remote session pushes disabled.
-REMOTE_SESSION_ATTENTION_PUSH_USER_ID=""

--- a/services/session-ingest/src/env.ts
+++ b/services/session-ingest/src/env.ts
@@ -8,13 +8,10 @@ export type Env = Omit<
   | 'DIRECT_INGEST_PERCENT'
   | 'DIRECT_INGEST_USER_IDS'
   | 'DIRECT_INGEST_MAX_BYTES'
-  | 'REMOTE_SESSION_ATTENTION_PUSH_USER_ID'
 > & {
   O11Y: O11YBinding;
   NOTIFICATIONS: NotificationsBinding;
   DIRECT_INGEST_PERCENT: string;
   DIRECT_INGEST_USER_IDS: string;
   DIRECT_INGEST_MAX_BYTES: string;
-  /** User ID permitted to receive remote session attention pushes during the rollout. */
-  REMOTE_SESSION_ATTENTION_PUSH_USER_ID?: string;
 };

--- a/services/session-ingest/src/ingest/direct-ingest.test.ts
+++ b/services/session-ingest/src/ingest/direct-ingest.test.ts
@@ -116,10 +116,6 @@ function makeRequest(params: {
     DIRECT_INGEST_PERCENT: '100',
     DIRECT_INGEST_MAX_BYTES: '4194304',
     DIRECT_INGEST_USER_IDS: 'usr_agent',
-    // Enable legacy (completed / needs_input) attention pushes for this user so the
-    // per-user rollout gate does not suppress them. agent_notification pushes bypass
-    // this gate regardless.
-    REMOTE_SESSION_ATTENTION_PUSH_USER_ID: 'usr_agent',
     HYPERDRIVE: { connectionString: 'postgres://unused' },
     SESSION_INGEST_R2: { put: vi.fn(), delete: vi.fn() },
     NOTIFICATIONS: { sendAgentSessionNotification, sendCloudAgentSessionNotification },

--- a/services/session-ingest/src/ingest/direct-ingest.ts
+++ b/services/session-ingest/src/ingest/direct-ingest.ts
@@ -439,7 +439,6 @@ async function runDirectPostCommitTasks(
             await dispatchRemoteSessionAttentionSignal(
               { kiloUserId: request.kiloUserId, sessionId: request.sessionId, signal },
               {
-                remoteSessionAttentionPushUserId: request.env.REMOTE_SESSION_ATTENTION_PUSH_USER_ID,
                 hasActiveCliSession: () => userConnection.hasActiveCliSession(request.sessionId),
                 sendPush: pushParams =>
                   request.env.NOTIFICATIONS.sendCloudAgentSessionNotification(pushParams),

--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -1347,10 +1347,6 @@ describe('agent_notification attention signals', () => {
     const body = JSON.stringify({ data: params.stagedItems ?? [] });
     const env = {
       HYPERDRIVE: { connectionString: 'postgres://unused' },
-      // Enable legacy (completed / needs_input) attention pushes for this user so the
-      // per-user rollout gate does not suppress them. agent_notification pushes bypass
-      // this gate regardless.
-      REMOTE_SESSION_ATTENTION_PUSH_USER_ID: 'usr_agent',
       SESSION_INGEST_R2: {
         get: vi.fn(async () => new Response(body)),
         put: vi.fn(async () => undefined),

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -430,7 +430,6 @@ async function dispatchRemoteSessionAttentionSignals(
       await dispatchRemoteSessionAttentionSignal(
         { kiloUserId, sessionId, signal },
         {
-          remoteSessionAttentionPushUserId: env.REMOTE_SESSION_ATTENTION_PUSH_USER_ID,
           hasActiveCliSession: async () => {
             const stub = getUserConnectionDO(env, { kiloUserId });
             return stub.hasActiveCliSession(sessionId);

--- a/services/session-ingest/src/remote-session-notifications.test.ts
+++ b/services/session-ingest/src/remote-session-notifications.test.ts
@@ -47,46 +47,13 @@ describe('buildRemoteSessionAttentionPushBody', () => {
 });
 
 describe('dispatchRemoteSessionAttentionSignal', () => {
-  it('suppresses pushes when no user is enabled', async () => {
-    const hasActiveCliSession = vi.fn(async () => true);
-    const sendPush = vi.fn(async () => ({ dispatched: true }));
-    const sendAgentSessionNotification = vi.fn(async () => ({ dispatched: true }));
-    const outcome = await dispatchRemoteSessionAttentionSignal(
-      { kiloUserId: 'usr_1', sessionId: 'ses_1', signal: completedSignal('Done') },
-      { hasActiveCliSession, sendPush, sendAgentSessionNotification }
-    );
-
-    expect(outcome).toBe('suppressed');
-    expect(hasActiveCliSession).not.toHaveBeenCalled();
-    expect(sendPush).not.toHaveBeenCalled();
-  });
-
-  it('suppresses pushes for users other than the rollout user', async () => {
-    const hasActiveCliSession = vi.fn(async () => true);
-    const sendPush = vi.fn(async () => ({ dispatched: true }));
-    const outcome = await dispatchRemoteSessionAttentionSignal(
-      { kiloUserId: 'usr_1', sessionId: 'ses_1', signal: completedSignal('Done') },
-      {
-        remoteSessionAttentionPushUserId: 'usr_2',
-        hasActiveCliSession,
-        sendPush,
-        sendAgentSessionNotification: vi.fn(async () => ({ dispatched: true })),
-      }
-    );
-
-    expect(outcome).toBe('suppressed');
-    expect(hasActiveCliSession).not.toHaveBeenCalled();
-    expect(sendPush).not.toHaveBeenCalled();
-  });
-
-  it('sends a push for the rollout user with an active remote CLI session', async () => {
+  it('sends a push when the remote CLI session is active', async () => {
     const hasActiveCliSession = vi.fn(async () => true);
     const sendPush = vi.fn(async () => ({ dispatched: true }));
     const signal = completedSignal('Done');
     const outcome = await dispatchRemoteSessionAttentionSignal(
       { kiloUserId: 'usr_1', sessionId: 'ses_1', signal },
       {
-        remoteSessionAttentionPushUserId: ' usr_1 ',
         hasActiveCliSession,
         sendPush,
         sendAgentSessionNotification: vi.fn(async () => ({ dispatched: true })),
@@ -103,6 +70,22 @@ describe('dispatchRemoteSessionAttentionSignal', () => {
       body: 'Done',
       suppressIfViewingSession: true,
     });
+  });
+
+  it('suppresses pushes when no remote CLI session is active', async () => {
+    const hasActiveCliSession = vi.fn(async () => false);
+    const sendPush = vi.fn(async () => ({ dispatched: true }));
+    const outcome = await dispatchRemoteSessionAttentionSignal(
+      { kiloUserId: 'usr_1', sessionId: 'ses_1', signal: completedSignal('Done') },
+      {
+        hasActiveCliSession,
+        sendPush,
+        sendAgentSessionNotification: vi.fn(async () => ({ dispatched: true })),
+      }
+    );
+
+    expect(outcome).toBe('suppressed');
+    expect(sendPush).not.toHaveBeenCalled();
   });
 
   // §4.3: agent_notification signals intentionally bypass the live-CLI gate so a

--- a/services/session-ingest/src/remote-session-notifications.ts
+++ b/services/session-ingest/src/remote-session-notifications.ts
@@ -30,7 +30,6 @@ export function buildRemoteSessionAttentionPushBody(signal: ExcerptAttentionSign
 }
 
 export type DispatchRemoteSessionAttentionDeps = {
-  remoteSessionAttentionPushUserId?: string;
   hasActiveCliSession: () => Promise<boolean>;
   sendPush: (
     params: SendCloudAgentSessionNotificationParams
@@ -79,12 +78,8 @@ export async function dispatchRemoteSessionAttentionSignal(
     return result.dispatched ? 'sent' : 'suppressed';
   }
 
-  // Legacy attention pushes (completed / needs_input) remain gated behind the staged
-  // per-user rollout and the live-CLI presence check.
-  if (deps.remoteSessionAttentionPushUserId?.trim() !== params.kiloUserId) {
-    return 'suppressed';
-  }
-
+  // Legacy attention pushes (completed / needs_input) remain gated behind the live-CLI
+  // presence check.
   if (!(await deps.hasActiveCliSession())) {
     return 'suppressed';
   }

--- a/services/session-ingest/worker-configuration.d.ts
+++ b/services/session-ingest/worker-configuration.d.ts
@@ -10,7 +10,6 @@ interface __BaseEnv_CloudflareBindings {
 	DIRECT_INGEST_PERCENT: "100";
 	DIRECT_INGEST_USER_IDS: "f1a848ca-bade-48d8-a5ad-1042d08651e6";
 	DIRECT_INGEST_MAX_BYTES: "4194304";
-	REMOTE_SESSION_ATTENTION_PUSH_USER_ID: "";
 	SESSION_INGEST_DO: DurableObjectNamespace<import("./src/index").SessionIngestDO>;
 	SESSION_ACCESS_CACHE_DO: DurableObjectNamespace<import("./src/index").SessionAccessCacheDO>;
 	USER_CONNECTION_DO: DurableObjectNamespace<import("./src/index").UserConnectionDO>;
@@ -29,7 +28,7 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
 	[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 };
 declare namespace NodeJS {
-	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "DIRECT_INGEST_PERCENT" | "DIRECT_INGEST_USER_IDS" | "DIRECT_INGEST_MAX_BYTES" | "REMOTE_SESSION_ATTENTION_PUSH_USER_ID">> {}
+	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "DIRECT_INGEST_PERCENT" | "DIRECT_INGEST_USER_IDS" | "DIRECT_INGEST_MAX_BYTES">> {}
 }
 declare module "*.sql" {
 	const value: string;

--- a/services/session-ingest/wrangler.jsonc
+++ b/services/session-ingest/wrangler.jsonc
@@ -24,7 +24,6 @@
     "DIRECT_INGEST_PERCENT": "100",
     "DIRECT_INGEST_USER_IDS": "f1a848ca-bade-48d8-a5ad-1042d08651e6",
     "DIRECT_INGEST_MAX_BYTES": "4194304",
-    "REMOTE_SESSION_ATTENTION_PUSH_USER_ID": "",
   },
   "observability": {
     "enabled": true,


### PR DESCRIPTION
Removes the `REMOTE_SESSION_ATTENTION_PUSH_USER_ID` per-user rollout gate.

Completed and `needs_input` attention pushes are now dispatched for every user with an active remote CLI session; the live-CLI presence check is preserved. `agent_notification` pushes were already gated only by presence and are unchanged.