### PR TITLE
fix(ai-gateway): remove DeepSeek V4 Novita ignore routing workaround

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -37,7 +37,6 @@ import {
 } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
 import { isQwenExplicitCacheModel, isQwenModel } from '@/lib/ai-gateway/providers/qwen';
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
-import { isRecognizedDeepseekV4Model } from '@/lib/ai-gateway/providers/deepseek';
 
 export function getPreferredProviderOrder(requestedModel: string): string[] {
   if (isClaudeModel(requestedModel) && !isFableModel(requestedModel)) {
@@ -110,19 +109,6 @@ export async function applyGatewayModelsFallback(
   delete requestToMutate.body.models;
 }
 
-export function applyDeepSeekV4Routing(requestedModel: string, requestToMutate: GatewayRequest) {
-  if (!isRecognizedDeepseekV4Model(requestedModel)) {
-    return;
-  }
-  requestToMutate.body.provider = {
-    ...requestToMutate.body.provider,
-    ignore: [
-      ...(requestToMutate.body.provider?.ignore ?? []),
-      OpenRouterInferenceProviderIdSchema.enum.novita, // https://kilo-code.slack.com/archives/C0A4SA041DE/p1781743079721409
-    ],
-  };
-}
-
 export async function applyProviderSpecificLogic(
   provider: Provider,
   requestedModel: string,
@@ -173,7 +159,6 @@ export async function applyProviderSpecificLogic(
 
   if (provider.id === 'openrouter' || provider.id === 'vercel') {
     applyPreferredProvider(requestedModel, requestToMutate.body);
-    applyDeepSeekV4Routing(requestedModel, requestToMutate);
   }
 
   if (isKimiModel(requestedModel)) {

--- a/apps/web/src/lib/ai-gateway/providers/deepseek.ts
+++ b/apps/web/src/lib/ai-gateway/providers/deepseek.ts
@@ -4,10 +4,6 @@ export function isDeepseekModel(model: string) {
   return model.includes('deepseek');
 }
 
-export function isRecognizedDeepseekV4Model(model: string) {
-  return ['deepseek/deepseek-v4-pro', 'deepseek/deepseek-v4-flash'].includes(model);
-}
-
 export const deepseek_v4_pro_discounted_model: KiloExclusiveModel = {
   public_id: 'deepseek/deepseek-v4-pro:discounted',
   internal_id: 'deepseek/deepseek-v4-pro',


### PR DESCRIPTION
The Novita provider issue for DeepSeek V4 models has been resolved. Remove the temporary `applyDeepSeekV4Routing` workaround and the `isRecognizedDeepseekV4Model` helper.