### PR TITLE
feat(mobile): gate PR Review behind a PostHog feature flag

### DIFF
--- a/apps/mobile/src/components/agents/chat-markdown-text.tsx
+++ b/apps/mobile/src/components/agents/chat-markdown-text.tsx
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { type GestureResponderEvent } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { FEATURE_FLAG_PR_REVIEW, useFeatureFlag } from '@/lib/analytics/posthog';
 import { openExternalUrl } from '@/lib/external-link';
 import { parseGitHubPrUrl } from '@/lib/github-pr-url';
 
@@ -36,10 +37,13 @@ export function ChatMarkdownText(props: Readonly<ChatMarkdownTextProps>) {
   const { showActionSheetWithOptions } = useActionSheet();
   const { bottom } = useSafeAreaInsets();
   const router = useRouter();
+  const prReviewEnabled = useFeatureFlag(FEATURE_FLAG_PR_REVIEW, true);
 
   const handlePressLink = useCallback(
     (href: string) => {
-      if (!parseGitHubPrUrl(href)) {
+      // When PR Review is off, PR links behave like any other link (default
+      // open-in-browser) instead of showing the Review-PR tap sheet.
+      if (!prReviewEnabled || !parseGitHubPrUrl(href)) {
         return false;
       }
       // Tap on a PR link shows exactly three options: Review PR / Open in
@@ -69,13 +73,13 @@ export function ChatMarkdownText(props: Readonly<ChatMarkdownTextProps>) {
       );
       return true;
     },
-    [bottom, router, showActionSheetWithOptions]
+    [bottom, prReviewEnabled, router, showActionSheetWithOptions]
   );
 
   const handleLongPressLink = useCallback(
     (href: string, event?: GestureResponderEvent) => {
       event?.stopPropagation();
-      const isPrLink = parseGitHubPrUrl(href) !== null;
+      const isPrLink = prReviewEnabled && parseGitHubPrUrl(href) !== null;
       const sheet = buildChatLinkActionSheet({ isPrLink });
       showActionSheetWithOptions(
         {
@@ -100,7 +104,7 @@ export function ChatMarkdownText(props: Readonly<ChatMarkdownTextProps>) {
         }
       );
     },
-    [bottom, router, showActionSheetWithOptions]
+    [bottom, prReviewEnabled, router, showActionSheetWithOptions]
   );
 
   return (

--- a/apps/mobile/src/components/profile-screen.tsx
+++ b/apps/mobile/src/components/profile-screen.tsx
@@ -26,6 +26,7 @@ import { TabScreenScrollView } from '@/components/tab-screen';
 import { ConfigureRow } from '@/components/ui/configure-row';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
+import { FEATURE_FLAG_PR_REVIEW, useFeatureFlag } from '@/lib/analytics/posthog';
 import { useAuth } from '@/lib/auth/auth-context';
 import { showFeedbackPrompt } from '@/lib/feedback';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
@@ -50,6 +51,7 @@ export function ProfileScreen() {
   const colors = useThemeColors();
   const { organizationId, isLoaded: organizationContextLoaded } = useOrganization();
   const isAuthenticated = token != null;
+  const prReviewEnabled = useFeatureFlag(FEATURE_FLAG_PR_REVIEW, true);
   const {
     data,
     isLoading,
@@ -167,21 +169,23 @@ export function ProfileScreen() {
         </View>
 
         {/* PR Review */}
-        <View className="mt-6 gap-3">
-          <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
-            Reviews
-          </Text>
-          <ConfigureRow
-            icon={GitMerge}
-            title="PR Review"
-            subtitle="Review pull requests on mobile"
-            className="rounded-lg bg-secondary px-3"
-            last
-            onPress={() => {
-              router.push(getPrReviewEntryPath());
-            }}
-          />
-        </View>
+        {prReviewEnabled && (
+          <View className="mt-6 gap-3">
+            <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
+              Reviews
+            </Text>
+            <ConfigureRow
+              icon={GitMerge}
+              title="PR Review"
+              subtitle="Review pull requests on mobile"
+              className="rounded-lg bg-secondary px-3"
+              last
+              onPress={() => {
+                router.push(getPrReviewEntryPath());
+              }}
+            />
+          </View>
+        )}
 
         {/* Organization */}
         {organizationId != null && (

--- a/apps/mobile/src/lib/analytics/posthog.ts
+++ b/apps/mobile/src/lib/analytics/posthog.ts
@@ -1,4 +1,5 @@
 import PostHog from 'posthog-react-native';
+import { useCallback, useSyncExternalStore } from 'react';
 
 import { POSTHOG_API_KEY } from '@/lib/config';
 
@@ -27,7 +28,17 @@ export const KILO_PASS_PURCHASE_FAILED_EVENT = 'kilo_pass_purchase_failed';
 
 export type AnalyticsSurface = 'claw' | 'cloud-agent' | 'remote-session';
 
+// PostHog feature flags. The project is shared with web, so mobile-only flags
+// are prefixed to avoid colliding with web flag keys.
+export const FEATURE_FLAG_PR_REVIEW = 'mobile-pr-review';
+
 let client: PostHog | null = null;
+
+// `useFeatureFlag` subscribers register here rather than on `client`, because
+// the client is created lazily (after consent) — a component that mounts before
+// init would otherwise subscribe to a null client and never re-render when
+// flags later load. init wires the client's single update into this registry.
+const flagListeners = new Set<() => void>();
 
 export function initPostHog(): void {
   if (client) {
@@ -41,6 +52,11 @@ export function initPostHog(): void {
   // Super property on every event so dashboards can filter mobile vs web
   // without relying on $lib.
   void client.register({ platform: 'mobile' });
+  client.onFeatureFlags(() => {
+    for (const listener of flagListeners) {
+      listener();
+    }
+  });
 }
 
 export function captureEvent(
@@ -56,8 +72,31 @@ export function captureScreen(name: string): void {
 
 export function identifyUser(email: string): void {
   client?.identify(email, { email });
+  // Pull the freshly-identified user's flags so gated UI resolves promptly.
+  void client?.reloadFeatureFlags();
 }
 
 export function resetAnalyticsUser(): void {
   client?.reset();
+}
+
+function isFeatureEnabled(key: string, defaultValue: boolean): boolean {
+  const value = client?.getFeatureFlag(key);
+  return value === undefined ? defaultValue : value === true;
+}
+
+/**
+ * Reactively read a boolean feature flag. Fails open: while the client is
+ * disabled (dev builds), uninitialized, or flags have not loaded yet, returns
+ * `defaultValue`. Flags only ever flip UI off on an explicit `false`.
+ */
+export function useFeatureFlag(key: string, defaultValue = false): boolean {
+  const subscribe = useCallback((onChange: () => void) => {
+    flagListeners.add(onChange);
+    return () => {
+      flagListeners.delete(onChange);
+    };
+  }, []);
+  const getSnapshot = useCallback(() => isFeatureEnabled(key, defaultValue), [key, defaultValue]);
+  return useSyncExternalStore(subscribe, getSnapshot);
 }


### PR DESCRIPTION
## What

Wires up PostHog feature flags in the mobile app (previously `posthog-react-native` was used only for analytics events) and uses one to gate the **PR Review** feature.

New `useFeatureFlag(key, defaultValue)` hook in `src/lib/analytics/posthog.ts`, backed by `useSyncExternalStore`. Subscribers register in a module-level listener set that's decoupled from the lazily-created (post-consent, `disabled: __DEV__`) client, so screens that mount before init still re-render once flags load. `identifyUser` now reloads flags after identify.

## Flag: `mobile-pr-review`

When **off**, PR Review is hidden in both places it surfaces:
- The **"Reviews"** section (PR Review row) in the profile screen.
- The **"Review PR"** action on GitHub PR links in chat — tapping a PR link falls through to normal open-in-browser, and the long-press sheet omits "Review PR".

**Fails open:** while the client is disabled (dev), uninitialized, or flags haven't loaded, the hook returns the default (`true` at both call sites), so the already-shipped feature stays visible. It only hides on an explicit `false` from PostHog.

> Note: the `mobile-pr-review` flag needs to be created in PostHog (shared web+mobile project). Until it exists / is set to `false`, behavior is unchanged.

## Test

- `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` — clean.
- `pnpm test` — 1591 passing.
- Manual on-device: verify the profile section and PR-link actions disappear when the flag is toggled off in PostHog on a release build.