### PR TITLE
fix(ai-gateway): return proper HTTP errors when upstream fetch fails

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -1,7 +1,9 @@
+import { NextResponse } from 'next/server';
 import { debugSaveProxyResponseStream } from '../../debugUtils';
 import { fetchWithBackoff } from '../../fetchWithBackoff';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import { errorExceptInTest } from '@/lib/utils.server';
+import { ProxyErrorType } from '@/lib/proxy-error-types';
 import type {
   GatewayResponsesRequest,
   OpenRouterChatCompletionRequest,
@@ -134,6 +136,27 @@ function classifyUpstreamFetchFailure({
   }
 }
 
+const UPSTREAM_TIMEOUT_MS = 10 * 60 * 1000;
+
+const TIMEOUT_FAILURE_FAMILIES: ReadonlySet<UpstreamFetchFailureFamily> = new Set([
+  'request_timeout',
+  'headers_timeout',
+  'connect_timeout',
+  'read_timeout',
+]);
+
+function upstreamFailureResponse(failureFamily: UpstreamFetchFailureFamily): Response {
+  const isTimeout = TIMEOUT_FAILURE_FAMILIES.has(failureFamily);
+  const error = isTimeout ? 'Gateway Timeout' : 'Bad Gateway';
+  const message = isTimeout
+    ? 'The upstream provider did not respond in time. Please try again.'
+    : 'The request to the upstream provider failed. Please try again.';
+  return NextResponse.json(
+    { error, error_type: ProxyErrorType.upstream_error, message },
+    { status: isTimeout ? 504 : 502 }
+  );
+}
+
 export async function upstreamRequest({
   path,
   search,
@@ -142,6 +165,7 @@ export async function upstreamRequest({
   extraHeaders,
   provider,
   signal,
+  timeoutMs = UPSTREAM_TIMEOUT_MS,
 }: {
   path: string;
   search: string;
@@ -150,7 +174,8 @@ export async function upstreamRequest({
   extraHeaders: Record<string, string>;
   provider: Provider;
   signal?: AbortSignal;
-}) {
+  timeoutMs?: number;
+}): Promise<Response> {
   const headers = new Headers();
   for (const [key, value] of Object.entries(ATTRIBUTION_HEADERS)) {
     headers.set(key, value);
@@ -164,9 +189,28 @@ export async function upstreamRequest({
 
   const targetUrl = `${provider.apiUrl}${path}${search}`;
 
-  const TEN_MINUTES_MS = 10 * 60 * 1000;
-  const timeoutSignal = AbortSignal.timeout(TEN_MINUTES_MS);
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
   const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+
+  const onTimeoutAbort = () => {
+    const timeoutMetadata = {
+      providerId: provider.id,
+      targetHost: getProviderTargetHost(provider.apiUrl),
+      path,
+      timeoutMs,
+    };
+    errorExceptInTest('AI gateway upstream request timed out', timeoutMetadata);
+    captureMessage('AI gateway upstream request timed out', {
+      level: 'error',
+      tags: {
+        source: 'ai-gateway-upstream-fetch',
+        provider: provider.id,
+        failure_family: 'request_timeout',
+      },
+      extra: timeoutMetadata,
+    });
+  };
+  timeoutSignal.addEventListener('abort', onTimeoutAbort, { once: true });
 
   try {
     return await fetch(targetUrl, {
@@ -178,6 +222,8 @@ export async function upstreamRequest({
       signal: combinedSignal,
     });
   } catch (error) {
+    let failureFamily: UpstreamFetchFailureFamily = 'unknown';
+    let clientAborted = false;
     try {
       const cause = error instanceof Error ? error.cause : undefined;
       const errorName = getErrorName(error);
@@ -185,7 +231,8 @@ export async function upstreamRequest({
       const causeCode = getCauseCode(cause);
       const causeName = getCauseName(cause);
       const causeMessage = getCauseMessage(cause);
-      const failureFamily = classifyUpstreamFetchFailure({ errorName, causeCode, causeName });
+      failureFamily = classifyUpstreamFetchFailure({ errorName, causeCode, causeName });
+      clientAborted = failureFamily === 'abort' && !!signal?.aborted;
       const failureMetadata = {
         providerId: provider.id,
         targetHost: getProviderTargetHost(provider.apiUrl),
@@ -198,7 +245,7 @@ export async function upstreamRequest({
         ...(causeMessage && { causeMessage }),
       };
 
-      if (!(failureFamily === 'abort' && signal?.aborted)) {
+      if (!clientAborted) {
         errorExceptInTest('AI gateway upstream fetch failed', failureMetadata);
         captureException(createLoggedFetchFailure(errorName, errorMessage), {
           level: 'error',
@@ -211,10 +258,16 @@ export async function upstreamRequest({
         });
       }
     } catch {
-      // Fetch failure must remain caller-visible even when diagnostic enrichment fails.
+      // The caller must still receive an HTTP error response even when diagnostic enrichment fails.
     }
 
-    throw error;
+    if (clientAborted) {
+      // The client disconnected; there is no one left to receive an HTTP error response.
+      throw error;
+    }
+    return upstreamFailureResponse(failureFamily);
+  } finally {
+    timeoutSignal.removeEventListener('abort', onTimeoutAbort);
   }
 }
 

--- a/apps/web/src/tests/openrouterApi.timeout.test.ts
+++ b/apps/web/src/tests/openrouterApi.timeout.test.ts
@@ -1,4 +1,4 @@
-import { captureException } from '@sentry/nextjs';
+import { captureException, captureMessage } from '@sentry/nextjs';
 import { upstreamRequest } from '../lib/ai-gateway/providers/upstream-request';
 import PROVIDERS from '../lib/ai-gateway/providers/provider-definitions';
 
@@ -8,11 +8,13 @@ jest.mock('@sentry/nextjs', () => ({
 }));
 
 const mockCaptureException = jest.mocked(captureException);
+const mockCaptureMessage = jest.mocked(captureMessage);
 const originalFetch = global.fetch;
 
 describe('upstreamRequest timeout', () => {
   beforeEach(() => {
     mockCaptureException.mockReset();
+    mockCaptureMessage.mockReset();
     global.fetch = originalFetch;
   });
 
@@ -42,7 +44,7 @@ describe('upstreamRequest timeout', () => {
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
-  it('classifies request timeout aborts separately', async () => {
+  it('returns a gateway timeout response for request timeout aborts', async () => {
     const timeoutError = new DOMException(
       'The operation was aborted due to timeout',
       'TimeoutError'
@@ -50,19 +52,22 @@ describe('upstreamRequest timeout', () => {
     const mockFetch = jest.fn().mockRejectedValue(timeoutError);
     global.fetch = mockFetch;
 
-    await expect(
-      upstreamRequest({
-        path: '/chat/completions',
-        search: '',
-        method: 'POST',
-        body: {
-          model: 'test-model',
-          messages: [{ role: 'user', content: 'test' }],
-        },
-        extraHeaders: {},
-        provider: PROVIDERS.OPENROUTER,
-      })
-    ).rejects.toBe(timeoutError);
+    const response = await upstreamRequest({
+      path: '/chat/completions',
+      search: '',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'test' }],
+      },
+      extraHeaders: {},
+      provider: PROVIDERS.OPENROUTER,
+    });
+
+    expect(response.status).toBe(504);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({ error: 'Gateway Timeout', error_type: 'upstream_error' })
+    );
 
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -76,7 +81,7 @@ describe('upstreamRequest timeout', () => {
     );
   });
 
-  it('preserves fetch failures when diagnostic enrichment throws', async () => {
+  it('returns a bad gateway response when diagnostic enrichment throws', async () => {
     const fetchError = new TypeError('fetch failed');
     Object.defineProperty(fetchError, 'cause', {
       get() {
@@ -86,19 +91,22 @@ describe('upstreamRequest timeout', () => {
     const mockFetch = jest.fn().mockRejectedValue(fetchError);
     global.fetch = mockFetch;
 
-    await expect(
-      upstreamRequest({
-        path: '/chat/completions',
-        search: '',
-        method: 'POST',
-        body: {
-          model: 'test-model',
-          messages: [{ role: 'user', content: 'test' }],
-        },
-        extraHeaders: {},
-        provider: PROVIDERS.OPENROUTER,
-      })
-    ).rejects.toBe(fetchError);
+    const response = await upstreamRequest({
+      path: '/chat/completions',
+      search: '',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'test' }],
+      },
+      extraHeaders: {},
+      provider: PROVIDERS.OPENROUTER,
+    });
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({ error: 'Bad Gateway', error_type: 'upstream_error' })
+    );
 
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
@@ -118,22 +126,22 @@ describe('upstreamRequest timeout', () => {
     const mockFetch = jest.fn().mockRejectedValue(fetchError);
     global.fetch = mockFetch;
 
-    await expect(
-      upstreamRequest({
-        path: '/chat/completions',
-        search: '?trace=search-secret',
-        method: 'POST',
-        body: {
-          model: 'test-model',
-          messages: [{ role: 'user', content: 'body-secret-content' }],
-        },
-        extraHeaders: {},
-        provider: {
-          ...PROVIDERS.OPENROUTER,
-          apiUrl: 'https://gateway.example.test/v1?token=url-secret',
-        },
-      })
-    ).rejects.toBe(fetchError);
+    const response = await upstreamRequest({
+      path: '/chat/completions',
+      search: '?trace=search-secret',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'body-secret-content' }],
+      },
+      extraHeaders: {},
+      provider: {
+        ...PROVIDERS.OPENROUTER,
+        apiUrl: 'https://gateway.example.test/v1?token=url-secret',
+      },
+    });
+
+    expect(response.status).toBe(502);
 
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -158,7 +166,7 @@ describe('upstreamRequest timeout', () => {
     expect(capturedOptions).not.toContain('body-secret-content');
   });
 
-  it('classifies ETIMEDOUT transport failures as read timeouts', async () => {
+  it('returns a gateway timeout response for ETIMEDOUT transport failures', async () => {
     const timeoutCause = Object.assign(new Error('socket read timed out'), {
       code: 'ETIMEDOUT',
       name: 'SocketTimeoutError',
@@ -167,19 +175,19 @@ describe('upstreamRequest timeout', () => {
     const mockFetch = jest.fn().mockRejectedValue(fetchError);
     global.fetch = mockFetch;
 
-    await expect(
-      upstreamRequest({
-        path: '/chat/completions',
-        search: '',
-        method: 'POST',
-        body: {
-          model: 'test-model',
-          messages: [{ role: 'user', content: 'test' }],
-        },
-        extraHeaders: {},
-        provider: PROVIDERS.OPENROUTER,
-      })
-    ).rejects.toBe(fetchError);
+    const response = await upstreamRequest({
+      path: '/chat/completions',
+      search: '',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'test' }],
+      },
+      extraHeaders: {},
+      provider: PROVIDERS.OPENROUTER,
+    });
+
+    expect(response.status).toBe(504);
 
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'TypeError', message: 'fetch failed' }),
@@ -195,7 +203,7 @@ describe('upstreamRequest timeout', () => {
     );
   });
 
-  it('rethrows provider fetch failures and captures safe timeout metadata', async () => {
+  it('returns a gateway timeout response and captures safe timeout metadata', async () => {
     const timeoutCause = Object.assign(new Error('Headers Timeout Error'), {
       code: 'UND_ERR_HEADERS_TIMEOUT',
       name: 'HeadersTimeoutError',
@@ -204,23 +212,23 @@ describe('upstreamRequest timeout', () => {
     const mockFetch = jest.fn().mockRejectedValue(fetchError);
     global.fetch = mockFetch;
 
-    await expect(
-      upstreamRequest({
-        path: '/chat/completions',
-        search: '?trace=search-secret',
-        method: 'POST',
-        body: {
-          model: 'test-model',
-          messages: [{ role: 'user', content: 'body-secret-content' }],
-        },
-        extraHeaders: { 'x-safe-extra-header': 'extra-header-secret' },
-        provider: {
-          ...PROVIDERS.OPENROUTER,
-          apiUrl: 'https://gateway.example.test/v1?token=url-secret',
-          apiKey: 'provider-api-key-secret',
-        },
-      })
-    ).rejects.toBe(fetchError);
+    const response = await upstreamRequest({
+      path: '/chat/completions',
+      search: '?trace=search-secret',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'body-secret-content' }],
+      },
+      extraHeaders: { 'x-safe-extra-header': 'extra-header-secret' },
+      provider: {
+        ...PROVIDERS.OPENROUTER,
+        apiUrl: 'https://gateway.example.test/v1?token=url-secret',
+        apiKey: 'provider-api-key-secret',
+      },
+    });
+
+    expect(response.status).toBe(504);
 
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'TypeError', message: 'fetch failed' }),
@@ -251,5 +259,56 @@ describe('upstreamRequest timeout', () => {
     expect(capturedOptions).not.toContain('search-secret');
     expect(capturedOptions).not.toContain('body-secret-content');
     expect(capturedOptions).not.toContain('extra-header-secret');
+  });
+
+  it('logs when the timeout signal fires and returns a gateway timeout response', async () => {
+    const mockFetch = jest.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const fetchSignal = init?.signal;
+        if (!fetchSignal) return;
+        const onAbort = () => reject(fetchSignal.reason);
+        if (fetchSignal.aborted) {
+          onAbort();
+          return;
+        }
+        fetchSignal.addEventListener('abort', onAbort, { once: true });
+      });
+    });
+    global.fetch = mockFetch;
+
+    const response = await upstreamRequest({
+      path: '/chat/completions',
+      search: '',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'test' }],
+      },
+      extraHeaders: {},
+      provider: PROVIDERS.OPENROUTER,
+      timeoutMs: 25,
+    });
+
+    expect(response.status).toBe(504);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({ error: 'Gateway Timeout', error_type: 'upstream_error' })
+    );
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'AI gateway upstream request timed out',
+      expect.objectContaining({
+        level: 'error',
+        tags: expect.objectContaining({
+          source: 'ai-gateway-upstream-fetch',
+          provider: 'openrouter',
+          failure_family: 'request_timeout',
+        }),
+        extra: expect.objectContaining({
+          providerId: 'openrouter',
+          path: '/chat/completions',
+          timeoutMs: 25,
+        }),
+      })
+    );
   });
 });


### PR DESCRIPTION
## Problem

`upstreamRequest` rethrew raw fetch exceptions. The call site in `apps/web/src/app/api/openrouter/[...path]/route.ts` does not wrap it in try/catch, so any upstream connection failure or timeout escaped the route handler as a generic, non-JSON 500.

Also, when the 10 minute `AbortSignal.timeout` fired there was no log tied to the signal itself — only the later fetch rejection classification.

## Changes

- `upstreamRequest` now returns a proper JSON error response (`error_type: upstream_error`) when the fetch throws:
  - **504 Gateway Timeout** for timeout failures (`request_timeout`, `headers_timeout`, `connect_timeout`, `read_timeout`)
  - **502 Bad Gateway** for other upstream failures (`conn_reset`, `unknown`)
- Client-disconnect aborts (caller `signal` aborted) are still rethrown — there is no client left to receive an HTTP error response.
- Added an `abort` listener on the timeout signal that logs to console and Sentry (`captureMessage`, `failure_family: request_timeout`) when the 10 minute timeout fires. The listener is removed once the fetch settles so completed requests cannot log spuriously.
- Added an optional `timeoutMs` parameter (defaults to 10 minutes) so the timeout path is testable.
- Updated `openrouterApi.timeout.test.ts` for the new return-instead-of-throw behavior and added a test covering the timeout-signal logging.

## Verification

- Attempted to run `src/tests/openrouterApi.timeout.test.ts` locally; the sandbox has no PostgreSQL/Docker for the jest global setup, so relying on CI.
- `pnpm typecheck` for `apps/web` exceeded the sandbox command timeout; relying on CI.