### PR TITLE
fix(session-ingest): preserve attachment capability in live heartbeats

### DIFF
--- a/apps/mobile/src/components/agents/mobile-session-manager-helpers.ts
+++ b/apps/mobile/src/components/agents/mobile-session-manager-helpers.ts
@@ -29,7 +29,7 @@ export async function buildRemoteAttachmentParts(
   const parts = await Promise.all(
     submission.files.map(async file => {
       const result = await trpcClient.cloudAgentNext.getAttachmentDownloadUrl.mutate({
-        messageUuid: submission.messageUuid,
+        messageUuid: submission.wire.path,
         filename: file.remoteName,
       });
       const mime = mimeForExtension(normalizeAttachmentExtension(file.remoteName));

--- a/apps/mobile/src/components/agents/mobile-session-manager.test.ts
+++ b/apps/mobile/src/components/agents/mobile-session-manager.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/lib/trpc', () => {
 });
 
 describe('buildRemoteAttachmentParts', () => {
-  it('mints a presigned URL per file using remoteName and derives MIME from extension', async () => {
+  it('mints each download URL from the upload path and remoteName', async () => {
     const mutate = vi.mocked(trpcClient.cloudAgentNext.getAttachmentDownloadUrl.mutate);
     mutate.mockResolvedValue({
       signedUrl: 'https://r2.example.com/signed',
@@ -27,7 +27,7 @@ describe('buildRemoteAttachmentParts', () => {
     const submission: AgentAttachmentSubmissionPayload = {
       messageUuid: 'msg-uuid',
       wire: {
-        path: 'msg-uuid',
+        path: 'upload-path',
         files: ['msg-uuid.zip', 'msg-uuid.txt', 'msg-uuid.png'],
       },
       files: [
@@ -40,9 +40,9 @@ describe('buildRemoteAttachmentParts', () => {
     const parts = await buildRemoteAttachmentParts(submission);
 
     expect(mutate).toHaveBeenCalledTimes(3);
-    expect(mutate).toHaveBeenCalledWith({ messageUuid: 'msg-uuid', filename: 'msg-uuid.zip' });
-    expect(mutate).toHaveBeenCalledWith({ messageUuid: 'msg-uuid', filename: 'msg-uuid.txt' });
-    expect(mutate).toHaveBeenCalledWith({ messageUuid: 'msg-uuid', filename: 'msg-uuid.png' });
+    expect(mutate).toHaveBeenCalledWith({ messageUuid: 'upload-path', filename: 'msg-uuid.zip' });
+    expect(mutate).toHaveBeenCalledWith({ messageUuid: 'upload-path', filename: 'msg-uuid.txt' });
+    expect(mutate).toHaveBeenCalledWith({ messageUuid: 'upload-path', filename: 'msg-uuid.png' });
 
     expect(parts).toEqual([
       {

--- a/services/session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.test.ts
@@ -691,7 +691,7 @@ describe('UserConnectionDO', () => {
       }
     });
 
-    it('projects capabilities.attachments=true on every session row of the sessions.heartbeat event', () => {
+    it('projects the latest connection capabilities onto every sessions.heartbeat row', () => {
       const { doInstance, mockCtx } = setup();
       const cliWs = addCliSocket(mockCtx, 'cli-1');
       const webWs = addWebSocket(mockCtx, 'web-1');
@@ -702,25 +702,40 @@ describe('UserConnectionDO', () => {
       sendSubscribe(doInstance, webWs, 's1');
       webWs.send.mockClear();
 
-      // Now advertise capabilities: the broadcast heartbeat must carry the
-      // capabilities on the message envelope, but each session row only
-      // carries its own owning-connection identity (capabilities is read from
-      // the connection, not the per-session row of the broadcast). The S3b
-      // SDK consumer re-attaches capabilities per-row in the consumer layer.
       sendHeartbeat(doInstance, cliWs, [makeSession('s1'), makeSession('s2')], {
         capabilities: { attachments: true },
       });
 
-      const sent = parseSent(webWs) as { data: { capabilities?: unknown; sessions: unknown[] } };
-      expect(sent.data.capabilities).toEqual({ attachments: true });
-      expect(sent.data.sessions).toHaveLength(2);
+      expect(parseSent(webWs)).toMatchObject({
+        data: {
+          sessions: [
+            { id: 's1', capabilities: { attachments: true } },
+            { id: 's2', capabilities: { attachments: true } },
+          ],
+        },
+      });
 
-      // aggregateSessions() must still surface the latest capabilities, which
-      // is the S3b consumer's source of truth for the per-row projection.
-      const rows = doInstance.getActiveSessions();
-      for (const row of rows) {
-        expect(row.capabilities).toEqual({ attachments: true });
-      }
+      webWs.send.mockClear();
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1'), makeSession('s2')]);
+      expect(parseSent(webWs)).toMatchObject({
+        data: { sessions: [{ id: 's1' }, { id: 's2' }] },
+      });
+      const legacyRows = (parseSent(webWs) as { data: { sessions: Record<string, unknown>[] } })
+        .data.sessions;
+      expect(legacyRows.every(row => !Object.hasOwn(row, 'capabilities'))).toBe(true);
+
+      webWs.send.mockClear();
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1'), makeSession('s2')], {
+        capabilities: { attachments: false },
+      });
+      expect(parseSent(webWs)).toMatchObject({
+        data: {
+          sessions: [
+            { id: 's1', capabilities: { attachments: false } },
+            { id: 's2', capabilities: { attachments: false } },
+          ],
+        },
+      });
     });
 
     it('omits capabilities from aggregateSessions rows when the latest heartbeat omits the field (legacy CLI)', () => {

--- a/services/session-ingest/src/dos/UserConnectionDO.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.ts
@@ -493,7 +493,15 @@ export class UserConnectionDO extends DurableObject<Env> {
     this.broadcastToWeb({
       type: 'system',
       event: 'sessions.heartbeat',
-      data: { connectionId, protocolVersion, capabilities, sessions },
+      data: {
+        connectionId,
+        protocolVersion,
+        capabilities,
+        sessions: sessions.map(session => ({
+          ...session,
+          ...(capabilities ? { capabilities } : {}),
+        })),
+      },
     });
 
     this.sendToCli(ws, { type: 'heartbeat_ack' });


### PR DESCRIPTION
## Summary

- project each CLI connection capability onto every live `sessions.heartbeat` session row
- preserve `true`, `false`, and absent capability semantics
- keep live heartbeat behavior aligned with `activeSessions.list`

## Why

The merged remote-attachment flow initially enables the mobile paperclip from the active-session snapshot, then the next live heartbeat disables it because the SDK reads capability from each session row while session-ingest only sent it at the envelope level.

Companion CLI PR: Kilo-Org/kilocode#12394

## Verification

- 573 session-ingest tests
- session-ingest typecheck
- session-ingest lint
- `git diff --check`
- independent review: no findings