### PR TITLE
feat(ai-gateway): add upstream request logging

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -193,9 +193,10 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     mockedRedisGet.mockResolvedValue(null);
     mockedRedisSet.mockResolvedValue('OK');
     mockedGetOpenRouterModels.mockResolvedValue(new Set(['stepfun/step-3.7-flash:free']));
-    mockedUpstreamRequest.mockResolvedValue(
-      upstreamJsonResponse({ id: 'chatcmpl-1', model: 'openai/gpt-4o', choices: [] })
-    );
+    mockedUpstreamRequest.mockResolvedValue({
+      type: 'success',
+      response: upstreamJsonResponse({ id: 'chatcmpl-1', model: 'openai/gpt-4o', choices: [] }),
+    });
     mockedEmitApiMetricsForResponse.mockReturnValue(undefined);
     mockedAccountForMicrodollarUsage.mockReturnValue(undefined);
   });
@@ -447,9 +448,14 @@ describe('kilo-auto/efficient classifier billing', () => {
     mockedRedisGet.mockResolvedValue(null);
     mockedRedisSet.mockResolvedValue('OK');
     mockedGetOpenRouterModels.mockResolvedValue(new Set());
-    mockedUpstreamRequest.mockResolvedValue(
-      upstreamJsonResponse({ id: 'chatcmpl-1', model: 'anthropic/claude-haiku-4', choices: [] })
-    );
+    mockedUpstreamRequest.mockResolvedValue({
+      type: 'success',
+      response: upstreamJsonResponse({
+        id: 'chatcmpl-1',
+        model: 'anthropic/claude-haiku-4',
+        choices: [],
+      }),
+    });
     mockedEmitApiMetricsForResponse.mockReturnValue(undefined);
     mockedAccountForMicrodollarUsage.mockReturnValue(undefined);
     mockedLogMicrodollarUsage.mockResolvedValue(null);
@@ -724,9 +730,10 @@ describe('auto-routing shadow classifier', () => {
     mockedRedisGet.mockResolvedValue(null);
     mockedRedisSet.mockResolvedValue('OK');
     mockedGetOpenRouterModels.mockResolvedValue(new Set());
-    mockedUpstreamRequest.mockResolvedValue(
-      upstreamJsonResponse({ id: 'chatcmpl-1', model: 'openai/gpt-4o', choices: [] })
-    );
+    mockedUpstreamRequest.mockResolvedValue({
+      type: 'success',
+      response: upstreamJsonResponse({ id: 'chatcmpl-1', model: 'openai/gpt-4o', choices: [] }),
+    });
     mockedEmitApiMetricsForResponse.mockReturnValue(undefined);
     mockedAccountForMicrodollarUsage.mockReturnValue(undefined);
     mockedApplyResolvedAutoModel.mockImplementation(async (_opts, request) => {

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -107,6 +107,7 @@ import {
   hasMiddleOutTransform,
 } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
 import { redactProviderHints } from '@kilocode/auto-routing-contracts';
+import { logExceptInTest } from '@/lib/utils.server';
 
 export const maxDuration = 1800;
 
@@ -865,7 +866,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     await sleepForRulesEngineAction(rulesEngineDecision.delayMs);
   }
 
-  const response = await upstreamRequest({
+  const upstreamResult = await upstreamRequest({
     path,
     search: url.search,
     method: request.method,
@@ -874,6 +875,12 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     provider: effectiveProviderContext.provider,
     signal: request.signal,
   });
+  if (upstreamResult.type === 'error') {
+    return upstreamResult.response;
+  }
+  const response = upstreamResult.response;
+  logExceptInTest('upstream response status %s', response.status);
+
   const ttfbMs = Math.max(0, Math.round(performance.now() - requestStartedAt));
   usageContext.ttfb_ms = ttfbMs;
 

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -879,7 +879,11 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     return upstreamResult.response;
   }
   const response = upstreamResult.response;
-  logExceptInTest('upstream response status %s', response.status);
+  logExceptInTest(
+    'upstream response status: %s, x-vercel-id: %s',
+    response.status,
+    response.headers.get('x-vercel-id') || '<none>'
+  );
 
   const ttfbMs = Math.max(0, Math.round(performance.now() - requestStartedAt));
   usageContext.ttfb_ms = ttfbMs;

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -45,7 +45,6 @@ import { KILO_AUTO_BALANCED_MODEL, KILO_AUTO_FREE_MODEL } from '@/lib/ai-gateway
 import type { GatewayChatApiKind, ProviderId } from '@/lib/ai-gateway/providers/types';
 import { computeOpenRouterCostFields } from '@/lib/ai-gateway/processUsage.shared';
 import { persistExperimentAttribution } from '@/lib/ai-gateway/experiments/persist';
-export { proxyErrorTypeSchema, ProxyErrorType } from '@/lib/proxy-error-types';
 import { ProxyErrorType } from '@/lib/proxy-error-types';
 import { getInferenceProvider } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 
@@ -93,6 +92,18 @@ export function temporarilyUnavailableResponse() {
       error: 'Service Unavailable',
       error_type: ProxyErrorType.temporarily_unavailable,
       message: 'The service is temporarily unavailable. Please try again later.',
+    },
+    { status: 503 }
+  );
+}
+
+export function upstreamDisconnectResponse() {
+  const error = 'The upstream provider disconnected before sending a response.';
+  return NextResponse.json(
+    {
+      error,
+      error_type: ProxyErrorType.upstream_disconnect,
+      message: error,
     },
     { status: 503 }
   );

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -97,18 +97,6 @@ export function temporarilyUnavailableResponse() {
   );
 }
 
-export function upstreamDisconnectResponse() {
-  const error = 'The upstream provider disconnected before sending a response.';
-  return NextResponse.json(
-    {
-      error,
-      error_type: ProxyErrorType.upstream_disconnect,
-      message: error,
-    },
-    { status: 503 }
-  );
-}
-
 export function upgradeRequiredResponse() {
   return NextResponse.json(
     {

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -10,8 +10,8 @@ import type {
 } from '@/lib/ai-gateway/providers/openrouter/types';
 import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attribution-headers';
 import type { Provider } from '@/lib/ai-gateway/providers/types';
-import { upstreamDisconnectResponse } from '@/lib/ai-gateway/llm-proxy-helpers';
-import type { NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import { ProxyErrorType } from '@/lib/proxy-error-types';
 
 type UpstreamFetchFailureFamily =
   | 'request_timeout'
@@ -134,6 +134,18 @@ function classifyUpstreamFetchFailure({
     default:
       return 'unknown';
   }
+}
+
+function upstreamDisconnectResponse() {
+  const error = 'The upstream provider disconnected before sending a response.';
+  return NextResponse.json(
+    {
+      error,
+      error_type: ProxyErrorType.upstream_disconnect,
+      message: error,
+    },
+    { status: 503 }
+  );
 }
 
 export async function upstreamRequest({

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -10,6 +10,8 @@ import type {
 } from '@/lib/ai-gateway/providers/openrouter/types';
 import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attribution-headers';
 import type { Provider } from '@/lib/ai-gateway/providers/types';
+import { upstreamDisconnectResponse } from '@/lib/ai-gateway/llm-proxy-helpers';
+import type { NextResponse } from 'next/server';
 
 type UpstreamFetchFailureFamily =
   | 'request_timeout'
@@ -150,7 +152,7 @@ export async function upstreamRequest({
   extraHeaders: Record<string, string>;
   provider: Provider;
   signal?: AbortSignal;
-}) {
+}): Promise<{ type: 'success'; response: Response } | { type: 'error'; response: NextResponse }> {
   const headers = new Headers();
   for (const [key, value] of Object.entries(ATTRIBUTION_HEADERS)) {
     headers.set(key, value);
@@ -166,17 +168,23 @@ export async function upstreamRequest({
 
   const TEN_MINUTES_MS = 10 * 60 * 1000;
   const timeoutSignal = AbortSignal.timeout(TEN_MINUTES_MS);
+  timeoutSignal.addEventListener('abort', () => {
+    errorExceptInTest('[upstreamRequest] timeout');
+  });
   const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 
   try {
-    return await fetch(targetUrl, {
-      method,
-      headers,
-      body: JSON.stringify(body),
-      // @ts-expect-error see https://github.com/node-fetch/node-fetch/issues/1769
-      duplex: 'half',
-      signal: combinedSignal,
-    });
+    return {
+      type: 'success',
+      response: await fetch(targetUrl, {
+        method,
+        headers,
+        body: JSON.stringify(body),
+        // @ts-expect-error see https://github.com/node-fetch/node-fetch/issues/1769
+        duplex: 'half',
+        signal: combinedSignal,
+      }),
+    };
   } catch (error) {
     try {
       const cause = error instanceof Error ? error.cause : undefined;
@@ -214,7 +222,7 @@ export async function upstreamRequest({
       // Fetch failure must remain caller-visible even when diagnostic enrichment fails.
     }
 
-    throw error;
+    return { type: 'error', response: upstreamDisconnectResponse() };
   }
 }
 

--- a/apps/web/src/lib/proxy-error-types.ts
+++ b/apps/web/src/lib/proxy-error-types.ts
@@ -28,6 +28,7 @@ export const proxyErrorTypeSchema = z.enum([
   'no_free_models_available',
   'abuse_blocked',
   'organization_auto_configuration',
+  'upstream_disconnect',
 ]);
 
 export type ProxyErrorType = z.infer<typeof proxyErrorTypeSchema>;

--- a/apps/web/src/tests/openrouterApi.timeout.test.ts
+++ b/apps/web/src/tests/openrouterApi.timeout.test.ts
@@ -24,21 +24,20 @@ describe('upstreamRequest timeout', () => {
     const controller = new AbortController();
     controller.abort();
 
-    await expect(
-      upstreamRequest({
-        path: '/chat/completions',
-        search: '',
-        method: 'POST',
-        body: {
-          model: 'test-model',
-          messages: [{ role: 'user', content: 'test' }],
-        },
-        extraHeaders: {},
-        provider: PROVIDERS.OPENROUTER,
-        signal: controller.signal,
-      })
-    ).rejects.toThrow();
+    const result = await upstreamRequest({
+      path: '/chat/completions',
+      search: '',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'test' }],
+      },
+      extraHeaders: {},
+      provider: PROVIDERS.OPENROUTER,
+      signal: controller.signal,
+    });
 
+    expect(result.type).toBe('error');
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
@@ -50,19 +49,19 @@ describe('upstreamRequest timeout', () => {
     const mockFetch = jest.fn().mockRejectedValue(timeoutError);
     global.fetch = mockFetch;
 
-    await expect(
-      upstreamRequest({
-        path: '/chat/completions',
-        search: '',
-        method: 'POST',
-        body: {
-          model: 'test-model',
-          messages: [{ role: 'user', content: 'test' }],
-        },
-        extraHeaders: {},
-        provider: PROVIDERS.OPENROUTER,
-      })
-    ).rejects.toBe(timeoutError);
+    const result = await upstreamRequest({
+      path: '/chat/completions',
+      search: '',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'test' }],
+      },
+      extraHeaders: {},
+      provider: PROVIDERS.OPENROUTER,
+    });
+
+    expect(result.type).toBe('error');
 
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -86,20 +85,19 @@ describe('upstreamRequest timeout', () => {
     const mockFetch = jest.fn().mockRejectedValue(fetchError);
     global.fetch = mockFetch;
 
-    await expect(
-      upstreamRequest({
-        path: '/chat/completions',
-        search: '',
-        method: 'POST',
-        body: {
-          model: 'test-model',
-          messages: [{ role: 'user', content: 'test' }],
-        },
-        extraHeaders: {},
-        provider: PROVIDERS.OPENROUTER,
-      })
-    ).rejects.toBe(fetchError);
+    const result = await upstreamRequest({
+      path: '/chat/completions',
+      search: '',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'test' }],
+      },
+      extraHeaders: {},
+      provider: PROVIDERS.OPENROUTER,
+    });
 
+    expect(result.type).toBe('error');
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
@@ -118,22 +116,22 @@ describe('upstreamRequest timeout', () => {
     const mockFetch = jest.fn().mockRejectedValue(fetchError);
     global.fetch = mockFetch;
 
-    await expect(
-      upstreamRequest({
-        path: '/chat/completions',
-        search: '?trace=search-secret',
-        method: 'POST',
-        body: {
-          model: 'test-model',
-          messages: [{ role: 'user', content: 'body-secret-content' }],
-        },
-        extraHeaders: {},
-        provider: {
-          ...PROVIDERS.OPENROUTER,
-          apiUrl: 'https://gateway.example.test/v1?token=url-secret',
-        },
-      })
-    ).rejects.toBe(fetchError);
+    const result = await upstreamRequest({
+      path: '/chat/completions',
+      search: '?trace=search-secret',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'body-secret-content' }],
+      },
+      extraHeaders: {},
+      provider: {
+        ...PROVIDERS.OPENROUTER,
+        apiUrl: 'https://gateway.example.test/v1?token=url-secret',
+      },
+    });
+
+    expect(result.type).toBe('error');
 
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -167,19 +165,19 @@ describe('upstreamRequest timeout', () => {
     const mockFetch = jest.fn().mockRejectedValue(fetchError);
     global.fetch = mockFetch;
 
-    await expect(
-      upstreamRequest({
-        path: '/chat/completions',
-        search: '',
-        method: 'POST',
-        body: {
-          model: 'test-model',
-          messages: [{ role: 'user', content: 'test' }],
-        },
-        extraHeaders: {},
-        provider: PROVIDERS.OPENROUTER,
-      })
-    ).rejects.toBe(fetchError);
+    const result = await upstreamRequest({
+      path: '/chat/completions',
+      search: '',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'test' }],
+      },
+      extraHeaders: {},
+      provider: PROVIDERS.OPENROUTER,
+    });
+
+    expect(result.type).toBe('error');
 
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'TypeError', message: 'fetch failed' }),
@@ -195,7 +193,7 @@ describe('upstreamRequest timeout', () => {
     );
   });
 
-  it('rethrows provider fetch failures and captures safe timeout metadata', async () => {
+  it('captures safe timeout metadata on provider fetch failures', async () => {
     const timeoutCause = Object.assign(new Error('Headers Timeout Error'), {
       code: 'UND_ERR_HEADERS_TIMEOUT',
       name: 'HeadersTimeoutError',
@@ -204,23 +202,23 @@ describe('upstreamRequest timeout', () => {
     const mockFetch = jest.fn().mockRejectedValue(fetchError);
     global.fetch = mockFetch;
 
-    await expect(
-      upstreamRequest({
-        path: '/chat/completions',
-        search: '?trace=search-secret',
-        method: 'POST',
-        body: {
-          model: 'test-model',
-          messages: [{ role: 'user', content: 'body-secret-content' }],
-        },
-        extraHeaders: { 'x-safe-extra-header': 'extra-header-secret' },
-        provider: {
-          ...PROVIDERS.OPENROUTER,
-          apiUrl: 'https://gateway.example.test/v1?token=url-secret',
-          apiKey: 'provider-api-key-secret',
-        },
-      })
-    ).rejects.toBe(fetchError);
+    const result = await upstreamRequest({
+      path: '/chat/completions',
+      search: '?trace=search-secret',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'body-secret-content' }],
+      },
+      extraHeaders: { 'x-safe-extra-header': 'extra-header-secret' },
+      provider: {
+        ...PROVIDERS.OPENROUTER,
+        apiUrl: 'https://gateway.example.test/v1?token=url-secret',
+        apiKey: 'provider-api-key-secret',
+      },
+    });
+
+    expect(result.type).toBe('error');
 
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'TypeError', message: 'fetch failed' }),


### PR DESCRIPTION
## Summary
- Add extra logging for upstream requests in the AI gateway
- Log `x-vercel-id` header from upstream responses for better traceability
- Update `upstreamRequest` tests to match the discriminated union return type (`{ type: 'success' | 'error', response }`)

## Test plan
- [x] All 84 test suites (662 tests) pass