### PR TITLE
fix(ai-gateway): detach upstream timeout listener after response settles

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -180,9 +180,10 @@ export async function upstreamRequest({
 
   const TEN_MINUTES_MS = 10 * 60 * 1000;
   const timeoutSignal = AbortSignal.timeout(TEN_MINUTES_MS);
-  timeoutSignal.addEventListener('abort', () => {
+  const onTimeoutAbort = () => {
     errorExceptInTest('[upstreamRequest] timeout');
-  });
+  };
+  timeoutSignal.addEventListener('abort', onTimeoutAbort);
   const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 
   try {
@@ -235,6 +236,11 @@ export async function upstreamRequest({
     }
 
     return { type: 'error', response: upstreamDisconnectResponse() };
+  } finally {
+    // The timeout signal fires unconditionally after TEN_MINUTES_MS. Detach the
+    // listener once the fetch has settled so a late timeout cannot log a spurious
+    // error after the response has already completed.
+    timeoutSignal.removeEventListener('abort', onTimeoutAbort);
   }
 }
 


### PR DESCRIPTION
## Problem

`AbortSignal.timeout(TEN_MINUTES_MS)` fires its `abort` event unconditionally 10 minutes after creation — even when the upstream fetch has already completed successfully. The `abort` listener at `upstream-request.ts:184` therefore logged a spurious `[upstreamRequest] timeout` error long after a successful response had finished.

## Fix

Extract the listener into a named handler and detach it in a `finally` block once the fetch settles. A genuine in-flight timeout still logs, because the `abort` event is dispatched (and the listener runs) before the fetch rejects; the listener is only removed after settling, so a late timeout can no longer produce a false error.