### PR TITLE
fix(mobile): unique per-worktree e2e login email

### DIFF
--- a/apps/mobile/e2e/AGENTS.md
+++ b/apps/mobile/e2e/AGENTS.md
@@ -98,9 +98,11 @@ The shared launch flows dismiss the clean-install tracking alert, accept the Exp
 Backend and Metro must be running. These idempotent wrappers verify simulator ownership, required services, the generated API port, and Metro project provenance, then reconnect the dev client to this worktree's exact Metro URL before Maestro runs. Never bypass their preflight or call the YAML login steps directly:
 
 ```bash
-apps/mobile/e2e/login.sh <udid> [email]  # default: e2e-mobile@example.com
+apps/mobile/e2e/login.sh <udid> [email]  # default: e2e-mobile+<worktree-basename>@example.com
 apps/mobile/e2e/logout.sh <udid>
 ```
+
+The default email is unique per worktree (`e2e-mobile+<worktree-basename>@example.com`), so concurrent worktrees sign into distinct backend users and never cross-pollute each other's sessions. Pass an explicit email only when a test needs a specific account.
 
 Login requests an email OTP, waits up to 30 seconds for the worktree-local outbox, verifies the code, accepts first-account consent, and asserts Home. It retries only the known dev-client launch/request boundary once. The wrappers open the exact dev-client URL via preflight, then `flows/settle-app.yaml` handles late tracking and Expo developer-menu prompts without restarting the app. `flows/open-app.yaml` is the standalone cold-launch flow.
 
@@ -156,7 +158,7 @@ Attach a screenshot of the changed flow to the PR when it helps review. For tran
 
 ## Remote CLI Session Flows
 
-Use this only when testing session discovery, mirroring, or mobile-to-CLI messaging. The orchestrator mints the user's local auth token, installs the CLI in a disposable directory, and starts it in a `kilo-e2e-cli-$(basename "$PWD")` tmux session with the required API URLs and bearer token already set. Role agents must not read environment files, accept a bearer token, install the CLI, or run `wrangler` commands.
+Use this only when testing session discovery, mirroring, or mobile-to-CLI messaging. The orchestrator mints the auth token for the same per-worktree user the app is signed in as (the `e2e-mobile+<worktree-basename>@example.com` account by default), installs the CLI in a disposable directory, and starts it in a `kilo-e2e-cli-$(basename "$PWD")` tmux session with the required API URLs and bearer token already set. Role agents must not read environment files, accept a bearer token, install the CLI, or run `wrangler` commands.
 
 Reuse the orchestrator-prepared session and verify discovery and mirroring by inspecting its pane and the mobile list:
 

--- a/apps/mobile/e2e/login.sh
+++ b/apps/mobile/e2e/login.sh
@@ -8,6 +8,11 @@
 # Usage:
 #   e2e/login.sh <device-udid> [email]
 #
+# When no email is given, defaults to a per-worktree-unique address
+# (e2e-mobile+<worktree-basename>@example.com) so concurrent worktrees never
+# share a backend user. It is stable within a worktree, so repeat logins reuse
+# the same seeded account.
+#
 # Env overrides:
 #   OUTBOX   outbox dir (default: <repo-root>/dev/logs/emails)
 #
@@ -15,11 +20,13 @@
 set -euo pipefail
 
 DEVICE="${1:?usage: login.sh <device-udid> [email]}"
-EMAIL="${2:-e2e-mobile@example.com}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 OUTBOX="${OUTBOX:-$REPO_ROOT/dev/logs/emails}"
+
+WORKTREE_SLUG="$(basename "$REPO_ROOT" | tr -cs 'a-zA-Z0-9' '-' | sed 's/^-*//;s/-*$//')"
+EMAIL="${2:-e2e-mobile+${WORKTREE_SLUG}@example.com}"
 
 "$SCRIPT_DIR/preflight.sh" "$DEVICE"
 


### PR DESCRIPTION
## Why

The e2e login helper (`apps/mobile/e2e/login.sh`) defaulted to a single shared account, `e2e-mobile@example.com`. When several worktrees run mobile E2E concurrently against the same local backend (as the orchestrated mobile-workflow runs do), they all signed into the **same backend user**. CLI and cloud-agent sessions started by one worktree then showed up in another worktree's app, cross-polluting session lists and corrupting verification.

## What

Default the login email to `e2e-mobile+<worktree-basename>@example.com`:

- **Stable within a worktree** — repeat logins (e.g. prewarm then verify phases) reuse the same seeded account.
- **Distinct across worktrees** — concurrent runs get isolated users, no cross-pollination.
- Explicit `[email]` argument still overrides for tests that need a specific account.

Docs in `e2e/AGENTS.md` updated (login default + Remote CLI token note that the minted token targets the same per-worktree user).

## Scope

Shell + docs only. No app/runtime code touched.