### PR TITLE
feat(billing): add usage records admin views

### DIFF
--- a/apps/web/src/app/admin/cloud-billing-skus/BillingHealthContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/BillingHealthContent.tsx
@@ -27,11 +27,13 @@ function Metric({
   value,
   detail,
   href,
+  linkLabel,
 }: {
   label: string;
   value: string;
   detail: string;
   href?: string;
+  linkLabel?: string;
 }) {
   return (
     <div className="bg-surface-inset rounded-lg border border-border p-4">
@@ -39,7 +41,8 @@ function Metric({
       {href ? (
         <Link
           href={href}
-          className="mt-1 block text-xl font-semibold tabular-nums underline-offset-4 hover:underline"
+          className="mt-1 block rounded-sm text-xl font-semibold tabular-nums text-link underline decoration-current/40 underline-offset-4 outline-none hover:text-link-hover focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={linkLabel}
         >
           {value}
         </Link>
@@ -66,7 +69,12 @@ export default function BillingHealthContent() {
     return (
       <Alert variant="destructive">
         <AlertTitle>Billing health could not be loaded</AlertTitle>
-        <AlertDescription>{health.error.message}</AlertDescription>
+        <AlertDescription className="space-y-3">
+          <p>{health.error.message}</p>
+          <Button variant="outline" size="sm" onClick={() => void health.refetch()}>
+            Retry
+          </Button>
+        </AlertDescription>
       </Alert>
     );
   }
@@ -75,7 +83,7 @@ export default function BillingHealthContent() {
     <div className="space-y-6">
       <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-start">
         <div>
-          <h2 className="type-section">Accounting health</h2>
+          <h2 className="type-heading">Accounting health</h2>
           <p className="text-muted-foreground mt-1 type-body">
             Metering-path indicators for the last 24 hours and current open intervals.
           </p>
@@ -86,21 +94,25 @@ export default function BillingHealthContent() {
           disabled={health.isFetching}
           onClick={() => void health.refetch()}
         >
-          <RefreshCw className={health.isFetching ? 'size-4 animate-spin' : 'size-4'} />
+          <RefreshCw
+            className={
+              health.isFetching ? 'size-4 animate-spin motion-reduce:animate-none' : 'size-4'
+            }
+          />
           {health.isFetching ? 'Refreshing...' : 'Refresh'}
         </Button>
       </div>
 
-      {data && (data.staleOpenIntervals > 0 || data.unconfirmedIntervals > 0) && (
+      {data && (data.staleOpenIntervals > 0 || data.unconfirmedIntervalsWithRecentActivity > 0) && (
         <Alert variant="destructive">
           <AlertTriangle className="size-4" />
           <AlertTitle>Metering anomalies need attention</AlertTitle>
           <AlertDescription>
             {data.staleOpenIntervals} open interval
             {data.staleOpenIntervals === 1 ? '' : 's'} have not reported for more than 15 minutes;{' '}
-            {data.unconfirmedIntervals} interval
-            {data.unconfirmedIntervals === 1 ? '' : 's'} closed without a confirmed stop in the last
-            24 hours.
+            {data.unconfirmedIntervalsWithRecentActivity} unconfirmed interval
+            {data.unconfirmedIntervalsWithRecentActivity === 1 ? '' : 's'} had final activity in the
+            last 24 hours.
           </AlertDescription>
         </Alert>
       )}
@@ -129,15 +141,16 @@ export default function BillingHealthContent() {
           detail={data ? `${data.staleOpenIntervals} stale beyond 15 minutes` : 'Loading…'}
         />
         <Metric
-          label="Closed"
-          value={data ? data.closedIntervals.toLocaleString() : '—'}
-          detail="Closed during the last 24 hours"
+          label="Closed after recent activity"
+          value={data ? data.closedIntervalsWithRecentActivity.toLocaleString() : '—'}
+          detail="Final activity occurred in the last 24 hours"
         />
         <Metric
           label="Unconfirmed"
-          value={data ? data.unconfirmedIntervals.toLocaleString() : '—'}
-          detail="Closed by stale reconciliation"
+          value={data ? data.unconfirmedIntervalsWithRecentActivity.toLocaleString() : '—'}
+          detail="Final activity occurred in the last 24 hours"
           href="/admin/cloud-billing-skus?tab=usage-records&closeReason=unconfirmed"
+          linkLabel={`View ${data?.unconfirmedIntervalsWithRecentActivity ?? 0} unconfirmed usage intervals`}
         />
         <Metric
           label="Clipped segments"
@@ -155,12 +168,16 @@ export default function BillingHealthContent() {
         <CardHeader>
           <CardTitle>Closure outcomes</CardTitle>
           <CardDescription>
-            Closed intervals grouped by reason over the last 24 hours.
+            Closed intervals grouped by reason when final activity occurred in the last 24 hours.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {data && data.closeReasons.length === 0 ? (
-            <p className="text-muted-foreground type-body">No intervals closed in this period.</p>
+          {!data ? (
+            <p className="text-muted-foreground type-body">Loading closure outcomes…</p>
+          ) : data.closeReasonsByLastActivity.length === 0 ? (
+            <p className="text-muted-foreground type-body">
+              No closed intervals had final activity in this period.
+            </p>
           ) : (
             <div className="overflow-x-auto rounded-lg border border-border">
               <Table>
@@ -171,7 +188,7 @@ export default function BillingHealthContent() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {(data?.closeReasons ?? []).map(row => (
+                  {data.closeReasonsByLastActivity.map(row => (
                     <TableRow key={row.reason}>
                       <TableCell className="type-code">{row.reason}</TableCell>
                       <TableCell className="text-right tabular-nums type-code">

--- a/apps/web/src/app/admin/cloud-billing-skus/BillingHealthContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/BillingHealthContent.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import Link from 'next/link';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useTRPC } from '@/lib/trpc/utils';
+
+function seconds(value: number): string {
+  if (value < 60) return `${value.toLocaleString()}s`;
+  const hours = value / 3_600;
+  return hours < 1 ? `${(value / 60).toFixed(1)}m` : `${hours.toFixed(1)}h`;
+}
+
+function Metric({
+  label,
+  value,
+  detail,
+  href,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  href?: string;
+}) {
+  return (
+    <div className="bg-surface-inset rounded-lg border border-border p-4">
+      <p className="text-muted-foreground type-label">{label}</p>
+      {href ? (
+        <Link
+          href={href}
+          className="mt-1 block text-xl font-semibold tabular-nums underline-offset-4 hover:underline"
+        >
+          {value}
+        </Link>
+      ) : (
+        <p className="mt-1 text-xl font-semibold tabular-nums">{value}</p>
+      )}
+      <p className="text-muted-foreground mt-1 type-label">{detail}</p>
+    </div>
+  );
+}
+
+export default function BillingHealthContent() {
+  const trpc = useTRPC();
+  const health = useQuery(
+    trpc.admin.cloudBillingSkus.usageHealth.queryOptions(undefined, {
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    })
+  );
+  const data = health.data;
+
+  if (health.isError) {
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Billing health could not be loaded</AlertTitle>
+        <AlertDescription>{health.error.message}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-start">
+        <div>
+          <h2 className="type-section">Accounting health</h2>
+          <p className="text-muted-foreground mt-1 type-body">
+            Metering-path indicators for the last 24 hours and current open intervals.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={health.isFetching}
+          onClick={() => void health.refetch()}
+        >
+          <RefreshCw className={health.isFetching ? 'size-4 animate-spin' : 'size-4'} />
+          {health.isFetching ? 'Refreshing...' : 'Refresh'}
+        </Button>
+      </div>
+
+      {data && (data.staleOpenIntervals > 0 || data.unconfirmedIntervals > 0) && (
+        <Alert variant="destructive">
+          <AlertTriangle className="size-4" />
+          <AlertTitle>Metering anomalies need attention</AlertTitle>
+          <AlertDescription>
+            {data.staleOpenIntervals} open interval
+            {data.staleOpenIntervals === 1 ? '' : 's'} have not reported for more than 15 minutes;{' '}
+            {data.unconfirmedIntervals} interval
+            {data.unconfirmedIntervals === 1 ? '' : 's'} closed without a confirmed stop in the last
+            24 hours.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4" aria-busy={health.isLoading}>
+        <Metric
+          label="Accepted usage"
+          value={data ? seconds(data.acceptedSeconds) : '—'}
+          detail={data ? `${data.segments.toLocaleString()} segments received` : 'Loading…'}
+        />
+        <Metric
+          label="Reported usage"
+          value={data ? seconds(data.reportedSeconds) : '—'}
+          detail={
+            data ? `${seconds(data.clippedSeconds)} clipped by receive-time caps` : 'Loading…'
+          }
+        />
+        <Metric
+          label="Intervals reported"
+          value={data ? data.intervalsReported.toLocaleString() : '—'}
+          detail="Distinct intervals with segments in the last 24 hours"
+        />
+        <Metric
+          label="Open now"
+          value={data ? data.openIntervals.toLocaleString() : '—'}
+          detail={data ? `${data.staleOpenIntervals} stale beyond 15 minutes` : 'Loading…'}
+        />
+        <Metric
+          label="Closed"
+          value={data ? data.closedIntervals.toLocaleString() : '—'}
+          detail="Closed during the last 24 hours"
+        />
+        <Metric
+          label="Unconfirmed"
+          value={data ? data.unconfirmedIntervals.toLocaleString() : '—'}
+          detail="Closed by stale reconciliation"
+          href="/admin/cloud-billing-skus?tab=usage-records&closeReason=unconfirmed"
+        />
+        <Metric
+          label="Clipped segments"
+          value={data ? data.clippedSegments.toLocaleString() : '—'}
+          detail="Reported seconds exceeded meter-observed time"
+        />
+        <Metric
+          label="Generated"
+          value={data ? new Date(data.generatedAt).toLocaleTimeString() : '—'}
+          detail="Snapshot refresh time"
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Closure outcomes</CardTitle>
+          <CardDescription>
+            Closed intervals grouped by reason over the last 24 hours.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data && data.closeReasons.length === 0 ? (
+            <p className="text-muted-foreground type-body">No intervals closed in this period.</p>
+          ) : (
+            <div className="overflow-x-auto rounded-lg border border-border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Reason</TableHead>
+                    <TableHead className="text-right">Intervals</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {(data?.closeReasons ?? []).map(row => (
+                    <TableRow key={row.reason}>
+                      <TableCell className="type-code">{row.reason}</TableCell>
+                      <TableCell className="text-right tabular-nums type-code">
+                        {row.count.toLocaleString()}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      {data && (
+        <p className="text-muted-foreground type-label">
+          Window: {new Date(data.periodStart).toLocaleString()} to{' '}
+          {new Date(data.generatedAt).toLocaleString()}. Segment metrics use meter receive time.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronDown, ChevronRight, Search } from 'lucide-react';
 import Link from 'next/link';
@@ -62,6 +62,17 @@ function adminSubjectHref(type: 'user' | 'org', id: string): string {
     : `/admin/organizations/${encodeURIComponent(id)}`;
 }
 
+function parseCloseReason(value: string | null): CloseReason | undefined {
+  return value === 'exit' ||
+    value === 'runtime_signal' ||
+    value === 'activity_expired' ||
+    value === 'reconciled' ||
+    value === 'unconfirmed' ||
+    value === 'superseded'
+    ? value
+    : undefined;
+}
+
 function SegmentDetails({ intervalId }: { intervalId: string }) {
   const trpc = useTRPC();
   const [afterSeq, setAfterSeq] = useState<number | undefined>();
@@ -72,7 +83,17 @@ function SegmentDetails({ intervalId }: { intervalId: string }) {
   if (query.isLoading)
     return <p className="text-muted-foreground type-label">Loading segments...</p>;
   if (query.isError) {
-    return <p className="text-destructive type-label">{query.error.message}</p>;
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Segments could not be loaded</AlertTitle>
+        <AlertDescription className="space-y-3">
+          <p>{query.error.message}</p>
+          <Button variant="outline" size="sm" onClick={() => void query.refetch()}>
+            Retry
+          </Button>
+        </AlertDescription>
+      </Alert>
+    );
   }
   const segments = query.data?.items ?? [];
   const metadata = Object.entries(query.data?.metadata ?? {}).sort(([left], [right]) =>
@@ -169,17 +190,8 @@ export default function UsageRecordsContent() {
   const [kind, setKind] = useState<SearchKind>('user');
   const [value, setValue] = useState('');
   const [status, setStatus] = useState<'all' | 'open' | 'closed'>('all');
-  const initialCloseReason = searchParams.get('closeReason');
-  const [closeReason, setCloseReason] = useState<'all' | CloseReason>(
-    initialCloseReason === 'exit' ||
-      initialCloseReason === 'runtime_signal' ||
-      initialCloseReason === 'activity_expired' ||
-      initialCloseReason === 'reconciled' ||
-      initialCloseReason === 'unconfirmed' ||
-      initialCloseReason === 'superseded'
-      ? initialCloseReason
-      : 'all'
-  );
+  const urlCloseReason = parseCloseReason(searchParams.get('closeReason'));
+  const [closeReason, setCloseReason] = useState<'all' | CloseReason>(urlCloseReason ?? 'all');
   const [skuId, setSkuId] = useState('all');
   const [submitted, setSubmitted] = useState<SearchRequest>({
     kind: 'recent',
@@ -208,6 +220,32 @@ export default function UsageRecordsContent() {
   };
   const results = useQuery(trpc.admin.cloudBillingSkus.searchUsageIntervals.queryOptions(input));
   const rows = results.data?.items ?? [];
+
+  const resetResultNavigation = () => {
+    setCursor(undefined);
+    setPreviousCursors([]);
+    setExpandedId(null);
+  };
+
+  const replaceCloseReasonParam = (reason: CloseReason | undefined) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (reason) params.set('closeReason', reason);
+    else params.delete('closeReason');
+    const query = params.toString();
+    router.replace(`${pathname}${query ? `?${query}` : ''}`, { scroll: false });
+  };
+
+  useEffect(() => {
+    const next = urlCloseReason ?? 'all';
+    setCloseReason(next);
+    if (urlCloseReason) setStatus('closed');
+    setSubmitted(current => {
+      const nextStatus = urlCloseReason && current.status === 'open' ? 'closed' : current.status;
+      if (current.closeReason === urlCloseReason && current.status === nextStatus) return current;
+      return { ...current, status: nextStatus, closeReason: urlCloseReason };
+    });
+    resetResultNavigation();
+  }, [urlCloseReason]);
 
   return (
     <div className="space-y-6">
@@ -240,9 +278,7 @@ export default function UsageRecordsContent() {
                 submitted.closeReason === next.closeReason &&
                 submitted.skuId === next.skuId;
               setSubmitted(next);
-              setCursor(undefined);
-              setPreviousCursors([]);
-              setExpandedId(null);
+              resetResultNavigation();
               if (unchanged) void results.refetch();
             }}
           >
@@ -272,7 +308,26 @@ export default function UsageRecordsContent() {
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="usage-search-status">Status</Label>
-              <Select value={status} onValueChange={next => setStatus(next as typeof status)}>
+              <Select
+                value={status}
+                onValueChange={next => {
+                  const selected = next as typeof status;
+                  const selectedStatus = selected === 'all' ? undefined : selected;
+                  const selectedCloseReason =
+                    selected === 'open' ? undefined : submitted.closeReason;
+                  setStatus(selected);
+                  if (selected === 'open' && closeReason !== 'all') {
+                    setCloseReason('all');
+                    replaceCloseReasonParam(undefined);
+                  }
+                  setSubmitted(current => ({
+                    ...current,
+                    status: selectedStatus,
+                    closeReason: selectedCloseReason,
+                  }));
+                  resetResultNavigation();
+                }}
+              >
                 <SelectTrigger id="usage-search-status" className="w-full">
                   <SelectValue />
                 </SelectTrigger>
@@ -290,18 +345,15 @@ export default function UsageRecordsContent() {
                 onValueChange={next => {
                   const selected = next as typeof closeReason;
                   const selectedReason = selected === 'all' ? undefined : selected;
+                  if (selectedReason && status === 'open') setStatus('closed');
                   setCloseReason(selected);
-                  const params = new URLSearchParams(searchParams.toString());
-                  if (selectedReason) params.set('closeReason', selectedReason);
-                  else params.delete('closeReason');
-                  const query = params.toString();
-                  router.replace(`${pathname}${query ? `?${query}` : ''}`, { scroll: false });
-                  if (submitted.kind === 'recent') {
-                    setSubmitted({ ...submitted, closeReason: selectedReason });
-                    setCursor(undefined);
-                    setPreviousCursors([]);
-                    setExpandedId(null);
-                  }
+                  replaceCloseReasonParam(selectedReason);
+                  setSubmitted(current => ({
+                    ...current,
+                    status: selectedReason && current.status === 'open' ? 'closed' : current.status,
+                    closeReason: selectedReason,
+                  }));
+                  resetResultNavigation();
                 }}
               >
                 <SelectTrigger id="usage-search-close-reason" className="w-full">
@@ -320,7 +372,17 @@ export default function UsageRecordsContent() {
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="usage-search-sku">SKU</Label>
-              <Select value={skuId} onValueChange={setSkuId}>
+              <Select
+                value={skuId}
+                onValueChange={selected => {
+                  setSkuId(selected);
+                  setSubmitted(current => ({
+                    ...current,
+                    skuId: selected === 'all' ? undefined : selected,
+                  }));
+                  resetResultNavigation();
+                }}
+              >
                 <SelectTrigger id="usage-search-sku" className="w-full">
                   <SelectValue />
                 </SelectTrigger>
@@ -353,7 +415,12 @@ export default function UsageRecordsContent() {
       {results.isError && (
         <Alert variant="destructive">
           <AlertTitle>Usage records could not be loaded</AlertTitle>
-          <AlertDescription>{results.error.message}</AlertDescription>
+          <AlertDescription className="space-y-3">
+            <p>{results.error.message}</p>
+            <Button variant="outline" size="sm" onClick={() => void results.refetch()}>
+              Retry
+            </Button>
+          </AlertDescription>
         </Alert>
       )}
 
@@ -422,7 +489,8 @@ export default function UsageRecordsContent() {
                               <Badge variant="secondary">{interval.subject_type}</Badge>
                               <Link
                                 href={adminSubjectHref(interval.subject_type, interval.subject_id)}
-                                className="block break-all font-medium underline-offset-4 type-code hover:underline"
+                                className="block break-all rounded-sm font-medium text-link underline decoration-current/40 underline-offset-4 type-code outline-none hover:text-link-hover focus-visible:ring-2 focus-visible:ring-ring"
+                                aria-label={`View ${interval.subject_type === 'user' ? 'user' : 'organization'} ${interval.subject_id}`}
                               >
                                 {interval.subject_id}
                               </Link>
@@ -431,7 +499,8 @@ export default function UsageRecordsContent() {
                                 {interval.actor_type === 'user' ? (
                                   <Link
                                     href={`/admin/users/${encodeURIComponent(interval.actor_id)}`}
-                                    className="underline-offset-4 hover:text-foreground hover:underline"
+                                    className="rounded-sm text-link underline decoration-current/40 underline-offset-4 outline-none hover:text-link-hover focus-visible:ring-2 focus-visible:ring-ring"
+                                    aria-label={`View user ${interval.actor_id}`}
                                   >
                                     {interval.actor_id}
                                   </Link>

--- a/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
@@ -1,0 +1,523 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { ChevronDown, ChevronRight, Search } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useTRPC } from '@/lib/trpc/utils';
+
+type SearchKind = 'interval' | 'user' | 'org';
+type CloseReason =
+  | 'exit'
+  | 'runtime_signal'
+  | 'activity_expired'
+  | 'reconciled'
+  | 'unconfirmed'
+  | 'superseded';
+type SearchRequest =
+  | {
+      kind: 'recent';
+      status?: 'open' | 'closed';
+      closeReason?: CloseReason;
+      skuId?: string;
+    }
+  | {
+      kind: SearchKind;
+      value: string;
+      status?: 'open' | 'closed';
+      closeReason?: CloseReason;
+      skuId?: string;
+    };
+type Cursor = { startedAt: string; id: string };
+
+function formatTimestamp(value: string | null): string {
+  return value ? new Date(value).toLocaleString() : '—';
+}
+
+function adminSubjectHref(type: 'user' | 'org', id: string): string {
+  return type === 'user'
+    ? `/admin/users/${encodeURIComponent(id)}`
+    : `/admin/organizations/${encodeURIComponent(id)}`;
+}
+
+function SegmentDetails({ intervalId }: { intervalId: string }) {
+  const trpc = useTRPC();
+  const [afterSeq, setAfterSeq] = useState<number | undefined>();
+  const [previousCursors, setPreviousCursors] = useState<Array<number | undefined>>([]);
+  const query = useQuery(
+    trpc.admin.cloudBillingSkus.listUsageSegments.queryOptions({ intervalId, afterSeq, limit: 100 })
+  );
+  if (query.isLoading)
+    return <p className="text-muted-foreground type-label">Loading segments...</p>;
+  if (query.isError) {
+    return <p className="text-destructive type-label">{query.error.message}</p>;
+  }
+  const segments = query.data?.items ?? [];
+  const metadata = Object.entries(query.data?.metadata ?? {}).sort(([left], [right]) =>
+    left.localeCompare(right)
+  );
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="mb-2 font-medium type-body">Metadata</h3>
+        {metadata.length === 0 ? (
+          <p className="text-muted-foreground type-label">No metadata recorded.</p>
+        ) : (
+          <dl className="grid gap-x-4 gap-y-2 rounded-md border border-border p-3 sm:grid-cols-[minmax(8rem,auto)_1fr]">
+            {metadata.map(([key, value]) => (
+              <div key={key} className="contents">
+                <dt className="text-muted-foreground break-all type-code">{key}</dt>
+                <dd className="break-all type-code">{value}</dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </div>
+      <div>
+        <h3 className="mb-2 font-medium type-body">Segments</h3>
+        {segments.length === 0 ? (
+          <p className="text-muted-foreground type-label">No segments recorded.</p>
+        ) : (
+          <div className="overflow-x-auto rounded-md border border-border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Sequence</TableHead>
+                  <TableHead>Reported</TableHead>
+                  <TableHead>Accepted</TableHead>
+                  <TableHead>Received</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {segments.map(segment => (
+                  <TableRow key={segment.seq}>
+                    <TableCell className="tabular-nums type-code">{segment.seq}</TableCell>
+                    <TableCell className="tabular-nums type-code">
+                      {segment.reported_seconds}s
+                    </TableCell>
+                    <TableCell className="tabular-nums type-code">
+                      {segment.usage_seconds}s
+                    </TableCell>
+                    <TableCell className="text-muted-foreground tabular-nums type-label">
+                      {formatTimestamp(segment.received_at)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={previousCursors.length === 0 || query.isFetching}
+          onClick={() => {
+            const previous = [...previousCursors];
+            setAfterSeq(previous.pop());
+            setPreviousCursors(previous);
+          }}
+        >
+          Previous segments
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={!query.data?.nextCursor || query.isFetching}
+          onClick={() => {
+            if (!query.data?.nextCursor) return;
+            setPreviousCursors(current => [...current, afterSeq]);
+            setAfterSeq(query.data.nextCursor ?? undefined);
+          }}
+        >
+          Next segments
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default function UsageRecordsContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const trpc = useTRPC();
+  const catalog = useQuery(trpc.admin.cloudBillingSkus.list.queryOptions());
+  const [kind, setKind] = useState<SearchKind>('user');
+  const [value, setValue] = useState('');
+  const [status, setStatus] = useState<'all' | 'open' | 'closed'>('all');
+  const initialCloseReason = searchParams.get('closeReason');
+  const [closeReason, setCloseReason] = useState<'all' | CloseReason>(
+    initialCloseReason === 'exit' ||
+      initialCloseReason === 'runtime_signal' ||
+      initialCloseReason === 'activity_expired' ||
+      initialCloseReason === 'reconciled' ||
+      initialCloseReason === 'unconfirmed' ||
+      initialCloseReason === 'superseded'
+      ? initialCloseReason
+      : 'all'
+  );
+  const [skuId, setSkuId] = useState('all');
+  const [submitted, setSubmitted] = useState<SearchRequest>({
+    kind: 'recent',
+    closeReason: closeReason === 'all' ? undefined : closeReason,
+  });
+  const [cursor, setCursor] = useState<Cursor | undefined>();
+  const [previousCursors, setPreviousCursors] = useState<Array<Cursor | undefined>>([]);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const input = {
+    search:
+      submitted.kind === 'recent'
+        ? ({ kind: 'recent' } as const)
+        : submitted.kind === 'interval'
+          ? ({ kind: 'interval', id: submitted.value } as const)
+          : ({
+              kind: 'subject',
+              subjectType: submitted.kind,
+              subjectId: submitted.value,
+            } as const),
+    status: submitted.status,
+    closeReason: submitted.closeReason,
+    skuId: submitted.skuId,
+    cursor,
+    limit: submitted.kind === 'recent' ? 10 : 25,
+  };
+  const results = useQuery(trpc.admin.cloudBillingSkus.searchUsageIntervals.queryOptions(input));
+  const rows = results.data?.items ?? [];
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Search usage records</CardTitle>
+          <CardDescription>
+            Search an exact interval ID or the usage history for an exact user or organization ID.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="grid gap-4 lg:grid-cols-3 lg:items-start xl:grid-cols-[9rem_minmax(12.5rem,1fr)_7rem_10rem_10rem_auto] xl:gap-3"
+            onSubmit={event => {
+              event.preventDefault();
+              const trimmed = value.trim();
+              if (!trimmed) return;
+              const next: SearchRequest = {
+                kind,
+                value: trimmed,
+                status: status === 'all' ? undefined : status,
+                closeReason: closeReason === 'all' ? undefined : closeReason,
+                skuId: skuId === 'all' ? undefined : skuId,
+              };
+              const unchanged =
+                cursor === undefined &&
+                submitted.kind === next.kind &&
+                submitted.value === next.value &&
+                submitted.status === next.status &&
+                submitted.closeReason === next.closeReason &&
+                submitted.skuId === next.skuId;
+              setSubmitted(next);
+              setCursor(undefined);
+              setPreviousCursors([]);
+              setExpandedId(null);
+              if (unchanged) void results.refetch();
+            }}
+          >
+            <div className="space-y-1.5">
+              <Label htmlFor="usage-search-kind">Search by</Label>
+              <Select value={kind} onValueChange={next => setKind(next as SearchKind)}>
+                <SelectTrigger id="usage-search-kind" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="interval">Interval ID</SelectItem>
+                  <SelectItem value="user">User ID</SelectItem>
+                  <SelectItem value="org">Organization ID</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="usage-search-value">Exact value</Label>
+              <Input
+                id="usage-search-value"
+                value={value}
+                required
+                maxLength={kind === 'interval' ? 512 : 256}
+                placeholder={kind === 'interval' ? 'service:instance:startEpochMs' : 'Exact ID'}
+                onChange={event => setValue(event.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="usage-search-status">Status</Label>
+              <Select value={status} onValueChange={next => setStatus(next as typeof status)}>
+                <SelectTrigger id="usage-search-status" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Any status</SelectItem>
+                  <SelectItem value="open">Open</SelectItem>
+                  <SelectItem value="closed">Closed</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="usage-search-close-reason">Close reason</Label>
+              <Select
+                value={closeReason}
+                onValueChange={next => {
+                  const selected = next as typeof closeReason;
+                  const selectedReason = selected === 'all' ? undefined : selected;
+                  setCloseReason(selected);
+                  const params = new URLSearchParams(searchParams.toString());
+                  if (selectedReason) params.set('closeReason', selectedReason);
+                  else params.delete('closeReason');
+                  const query = params.toString();
+                  router.replace(`${pathname}${query ? `?${query}` : ''}`, { scroll: false });
+                  if (submitted.kind === 'recent') {
+                    setSubmitted({ ...submitted, closeReason: selectedReason });
+                    setCursor(undefined);
+                    setPreviousCursors([]);
+                    setExpandedId(null);
+                  }
+                }}
+              >
+                <SelectTrigger id="usage-search-close-reason" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Any reason</SelectItem>
+                  <SelectItem value="exit">Exit</SelectItem>
+                  <SelectItem value="runtime_signal">Runtime signal</SelectItem>
+                  <SelectItem value="activity_expired">Activity expired</SelectItem>
+                  <SelectItem value="unconfirmed">Unconfirmed (15m timeout)</SelectItem>
+                  <SelectItem value="superseded">Superseded</SelectItem>
+                  <SelectItem value="reconciled">Reconciled</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="usage-search-sku">SKU</Label>
+              <Select value={skuId} onValueChange={setSkuId}>
+                <SelectTrigger id="usage-search-sku" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Any SKU</SelectItem>
+                  {(catalog.data ?? []).map(sku => (
+                    <SelectItem key={sku.id} value={sku.id}>
+                      {sku.id}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label className="invisible" aria-hidden="true">
+                Action
+              </Label>
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={results.isFetching || !value.trim()}
+              >
+                <Search className="size-4" /> {results.isFetching ? 'Searching...' : 'Search'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {results.isError && (
+        <Alert variant="destructive">
+          <AlertTitle>Usage records could not be loaded</AlertTitle>
+          <AlertDescription>{results.error.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {results.isSuccess && (
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              {submitted.kind === 'recent' ? 'Recent usage activity' : 'Usage intervals'}
+            </CardTitle>
+            <CardDescription>
+              {rows.length === 0
+                ? submitted.kind === 'recent'
+                  ? 'No usage intervals have been recorded yet.'
+                  : 'No intervals matched this exact search.'
+                : `${rows.length} interval${rows.length === 1 ? '' : 's'} on this page`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {rows.length > 0 && (
+              <div className="overflow-x-auto rounded-lg border border-border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-10">
+                        <span className="sr-only">Details</span>
+                      </TableHead>
+                      <TableHead>Interval</TableHead>
+                      <TableHead>Subject</TableHead>
+                      <TableHead>SKU / status</TableHead>
+                      <TableHead>Usage</TableHead>
+                      <TableHead>Lifecycle</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {rows.map(interval => {
+                      const expanded = expandedId === interval.id;
+                      const detailId = `usage-segments-${encodeURIComponent(interval.id)}`;
+                      return [
+                        <TableRow key={interval.id}>
+                          <TableCell>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              aria-expanded={expanded}
+                              aria-controls={detailId}
+                              aria-label={`${expanded ? 'Hide' : 'Show'} segments for ${interval.id}`}
+                              onClick={() => setExpandedId(expanded ? null : interval.id)}
+                            >
+                              {expanded ? (
+                                <ChevronDown className="size-4" />
+                              ) : (
+                                <ChevronRight className="size-4" />
+                              )}
+                            </Button>
+                          </TableCell>
+                          <TableCell>
+                            <div className="max-w-md space-y-1">
+                              <code className="break-all type-code">{interval.id}</code>
+                              <p className="text-muted-foreground type-label">
+                                {interval.service} · {interval.instance_id}
+                              </p>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <div className="space-y-1">
+                              <Badge variant="secondary">{interval.subject_type}</Badge>
+                              <Link
+                                href={adminSubjectHref(interval.subject_type, interval.subject_id)}
+                                className="block break-all font-medium underline-offset-4 type-code hover:underline"
+                              >
+                                {interval.subject_id}
+                              </Link>
+                              <p className="text-muted-foreground type-label">
+                                Actor: {interval.actor_type}{' '}
+                                {interval.actor_type === 'user' ? (
+                                  <Link
+                                    href={`/admin/users/${encodeURIComponent(interval.actor_id)}`}
+                                    className="underline-offset-4 hover:text-foreground hover:underline"
+                                  >
+                                    {interval.actor_id}
+                                  </Link>
+                                ) : (
+                                  interval.actor_id
+                                )}
+                              </p>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <div className="space-y-1">
+                              <code className="type-code">{interval.cloud_billing_sku_id}</code>
+                              <div>
+                                <Badge variant={interval.status === 'open' ? 'new' : 'secondary'}>
+                                  {interval.status}
+                                </Badge>
+                              </div>
+                              {interval.close_reason && (
+                                <p className="text-muted-foreground type-label">
+                                  {interval.close_reason}
+                                </p>
+                              )}
+                            </div>
+                          </TableCell>
+                          <TableCell className="tabular-nums">
+                            <p className="type-code">{interval.confirmed_seconds}s</p>
+                            <p className="text-muted-foreground type-label">
+                              Seq {interval.last_heartbeat_seq}
+                            </p>
+                          </TableCell>
+                          <TableCell className="min-w-52">
+                            <p className="type-label">
+                              Started {formatTimestamp(interval.started_at)}
+                            </p>
+                            <p className="text-muted-foreground type-label">
+                              Last seen {formatTimestamp(interval.last_seen_at)}
+                            </p>
+                            {interval.stopped_at && (
+                              <p className="text-muted-foreground type-label">
+                                Stopped {formatTimestamp(interval.stopped_at)}
+                              </p>
+                            )}
+                          </TableCell>
+                        </TableRow>,
+                        expanded ? (
+                          <TableRow key={`${interval.id}-details`}>
+                            <TableCell id={detailId} colSpan={6} className="bg-surface-inset p-4">
+                              <SegmentDetails intervalId={interval.id} />
+                            </TableCell>
+                          </TableRow>
+                        ) : null,
+                      ];
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                disabled={previousCursors.length === 0 || results.isFetching}
+                onClick={() => {
+                  const previous = [...previousCursors];
+                  setCursor(previous.pop());
+                  setPreviousCursors(previous);
+                  setExpandedId(null);
+                }}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                disabled={!results.data.nextCursor || results.isFetching}
+                onClick={() => {
+                  if (!results.data.nextCursor) return;
+                  setPreviousCursors(current => [...current, cursor]);
+                  setCursor(results.data.nextCursor);
+                  setExpandedId(null);
+                }}
+              >
+                Older
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/cloud-billing-skus/page.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Plus, Tags, X } from 'lucide-react';
 import { toast } from 'sonner';
@@ -31,15 +32,24 @@ import {
 } from '@/components/ui/table';
 import { useTRPC } from '@/lib/trpc/utils';
 import type { CreateCloudBillingSkuInput } from '@/lib/cloud-billing-sku';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import CloudBillingSkuForm from './CloudBillingSkuForm';
+import UsageRecordsContent from './UsageRecordsContent';
+import BillingHealthContent from './BillingHealthContent';
 
 const breadcrumbs = (
   <BreadcrumbItem>
-    <BreadcrumbPage>Cloud Billing SKUs</BreadcrumbPage>
+    <BreadcrumbPage>Cloud Billing</BreadcrumbPage>
   </BreadcrumbItem>
 );
 
+const tabTriggerClass =
+  'text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none';
+
 export default function CloudBillingSkusPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const [creating, setCreating] = useState(false);
@@ -52,6 +62,18 @@ export default function CloudBillingSkusPage() {
   const catalog = useQuery(listOptions);
   const { data: skus, isLoading } = catalog;
   const loadedSkus = skus ?? [];
+  const tabParam = searchParams.get('tab');
+  const activeTab = tabParam === 'usage-records' || tabParam === 'health' ? tabParam : 'catalog';
+  const onTabChange = useCallback(
+    (value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value === 'catalog') params.delete('tab');
+      else params.set('tab', value);
+      const query = params.toString();
+      router.replace(`${pathname}${query ? `?${query}` : ''}`, { scroll: false });
+    },
+    [pathname, router, searchParams]
+  );
 
   const invalidateList = () => queryClient.invalidateQueries({ queryKey: listOptions.queryKey });
   const createMutation = useMutation(
@@ -89,13 +111,13 @@ export default function CloudBillingSkusPage() {
       <div className="flex w-full flex-col gap-6">
         <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
           <div className="max-w-2xl">
-            <h1 className="type-title">Cloud Billing SKUs</h1>
+            <h1 className="type-title">Cloud Billing</h1>
             <p className="text-muted-foreground mt-2 type-body">
               Immutable usage products reported by cloud services. A price change requires a new SKU
               and a producer deployment.
             </p>
           </div>
-          {!creating ? (
+          {activeTab === 'catalog' && !creating ? (
             <Button
               ref={createButtonRef}
               onClick={() => {
@@ -105,7 +127,7 @@ export default function CloudBillingSkusPage() {
             >
               <Plus className="size-4" /> Create SKU
             </Button>
-          ) : (
+          ) : activeTab === 'catalog' ? (
             <Button
               variant="outline"
               disabled={createMutation.isPending}
@@ -116,159 +138,181 @@ export default function CloudBillingSkusPage() {
             >
               <X className="size-4" /> Cancel
             </Button>
-          )}
+          ) : null}
         </div>
 
-        {creating && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Create billing SKU</CardTitle>
-              <CardDescription>
-                Identity, unit, and rate cannot be edited after creation. Verify the previews before
-                creating the SKU.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <CloudBillingSkuForm
-                pending={createMutation.isPending}
-                serverErrors={createErrors}
-                onSubmit={values => {
-                  setCreateErrors({});
-                  createMutation.mutate(values);
-                }}
-              />
-            </CardContent>
-          </Card>
-        )}
+        <Tabs value={activeTab} onValueChange={onTabChange}>
+          <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent p-0">
+            <TabsTrigger value="catalog" className={tabTriggerClass}>
+              SKU catalog
+            </TabsTrigger>
+            <TabsTrigger value="usage-records" className={tabTriggerClass}>
+              Usage records
+            </TabsTrigger>
+            <TabsTrigger value="health" className={tabTriggerClass}>
+              Health
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="catalog" className="mt-6 space-y-6">
+            {creating && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Create billing SKU</CardTitle>
+                  <CardDescription>
+                    Identity, unit, and rate cannot be edited after creation. Verify the previews
+                    before creating the SKU.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <CloudBillingSkuForm
+                    pending={createMutation.isPending}
+                    serverErrors={createErrors}
+                    onSubmit={values => {
+                      setCreateErrors({});
+                      createMutation.mutate(values);
+                    }}
+                  />
+                </CardContent>
+              </Card>
+            )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Tags className="size-4" /> Catalog
-            </CardTitle>
-            <CardDescription>
-              {catalog.isSuccess
-                ? `${loadedSkus.length} SKU${loadedSkus.length === 1 ? '' : 's'} configured`
-                : 'Named usage products and per-second rates'}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {isLoading && <p className="text-muted-foreground type-body">Loading SKUs...</p>}
-            {catalog.isError && (
-              <Alert variant="destructive">
-                <AlertTitle>Billing SKUs could not be loaded</AlertTitle>
-                <AlertDescription>
-                  <p>
-                    {catalog.error.message || 'The billing SKU catalog is temporarily unavailable.'}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Tags className="size-4" /> Catalog
+                </CardTitle>
+                <CardDescription>
+                  {catalog.isSuccess
+                    ? `${loadedSkus.length} SKU${loadedSkus.length === 1 ? '' : 's'} configured`
+                    : 'Named usage products and per-second rates'}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {isLoading && <p className="text-muted-foreground type-body">Loading SKUs...</p>}
+                {catalog.isError && (
+                  <Alert variant="destructive">
+                    <AlertTitle>Billing SKUs could not be loaded</AlertTitle>
+                    <AlertDescription>
+                      <p>
+                        {catalog.error.message ||
+                          'The billing SKU catalog is temporarily unavailable.'}
+                      </p>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={catalog.isFetching}
+                        onClick={() => void catalog.refetch()}
+                      >
+                        {catalog.isFetching ? 'Retrying...' : 'Retry'}
+                      </Button>
+                    </AlertDescription>
+                  </Alert>
+                )}
+                {catalog.isSuccess && loadedSkus.length === 0 && (
+                  <p className="text-muted-foreground type-body">
+                    No billing SKUs exist yet. An admin can create the first SKU.
                   </p>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={catalog.isFetching}
-                    onClick={() => void catalog.refetch()}
-                  >
-                    {catalog.isFetching ? 'Retrying...' : 'Retry'}
-                  </Button>
-                </AlertDescription>
-              </Alert>
-            )}
-            {catalog.isSuccess && loadedSkus.length === 0 && (
-              <p className="text-muted-foreground type-body">
-                No billing SKUs exist yet. An admin can create the first SKU.
-              </p>
-            )}
-            {catalog.isSuccess && loadedSkus.length > 0 && (
-              <div className="overflow-x-auto rounded-lg border border-border">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>SKU</TableHead>
-                      <TableHead>Rate</TableHead>
-                      <TableHead>Status</TableHead>
-                      <TableHead>Created</TableHead>
-                      <TableHead className="text-right">Action</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {loadedSkus.map(sku => (
-                      <TableRow key={sku.id}>
-                        <TableCell>
-                          <div className="space-y-1">
-                            <code className="type-code">{sku.id}</code>
-                            <p className="font-medium type-body">{sku.name}</p>
-                            {sku.description && (
-                              <p className="text-muted-foreground max-w-lg type-label">
-                                {sku.description}
-                              </p>
-                            )}
-                          </div>
-                        </TableCell>
-                        <TableCell className="tabular-nums type-code">
-                          {sku.rate_cents_per_unit} cents/{sku.unit}
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant={sku.accepts_new_usage ? 'new' : 'secondary'}>
-                            {sku.accepts_new_usage ? 'Accepting usage' : 'Disabled'}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="text-muted-foreground tabular-nums type-label">
-                          {new Date(sku.created_at).toLocaleDateString()}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          {sku.accepts_new_usage && (
-                            <AlertDialog>
-                              <AlertDialogTrigger asChild>
-                                <Button
-                                  variant="outline"
-                                  size="sm"
-                                  disabled={disablingId === sku.id}
-                                >
-                                  Disable
-                                </Button>
-                              </AlertDialogTrigger>
-                              <AlertDialogContent
-                                aria-busy={disablingId === sku.id}
-                                onEscapeKeyDown={event => {
-                                  if (disablingId === sku.id) event.preventDefault();
-                                }}
-                                onPointerDownOutside={event => {
-                                  if (disablingId === sku.id) event.preventDefault();
-                                }}
-                              >
-                                <AlertDialogHeader>
-                                  <AlertDialogTitle>Disable {sku.id}?</AlertDialogTitle>
-                                  <AlertDialogDescription>
-                                    New starts will be rejected. Existing usage can continue and the
-                                    SKU cannot be re-enabled.
-                                  </AlertDialogDescription>
-                                </AlertDialogHeader>
-                                <AlertDialogFooter>
-                                  <AlertDialogCancel disabled={disablingId === sku.id}>
-                                    Cancel
-                                  </AlertDialogCancel>
-                                  <AlertDialogAction
-                                    variant="destructive"
-                                    disabled={disablingId === sku.id}
-                                    onClick={() => {
-                                      setDisablingId(sku.id);
-                                      disableMutation.mutate({ id: sku.id });
+                )}
+                {catalog.isSuccess && loadedSkus.length > 0 && (
+                  <div className="overflow-x-auto rounded-lg border border-border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>SKU</TableHead>
+                          <TableHead>Rate</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead>Created</TableHead>
+                          <TableHead className="text-right">Action</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {loadedSkus.map(sku => (
+                          <TableRow key={sku.id}>
+                            <TableCell>
+                              <div className="space-y-1">
+                                <code className="type-code">{sku.id}</code>
+                                <p className="font-medium type-body">{sku.name}</p>
+                                {sku.description && (
+                                  <p className="text-muted-foreground max-w-lg type-label">
+                                    {sku.description}
+                                  </p>
+                                )}
+                              </div>
+                            </TableCell>
+                            <TableCell className="tabular-nums type-code">
+                              {sku.rate_cents_per_unit} cents/{sku.unit}
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant={sku.accepts_new_usage ? 'new' : 'secondary'}>
+                                {sku.accepts_new_usage ? 'Accepting usage' : 'Disabled'}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="text-muted-foreground tabular-nums type-label">
+                              {new Date(sku.created_at).toLocaleDateString()}
+                            </TableCell>
+                            <TableCell className="text-right">
+                              {sku.accepts_new_usage && (
+                                <AlertDialog>
+                                  <AlertDialogTrigger asChild>
+                                    <Button
+                                      variant="outline"
+                                      size="sm"
+                                      disabled={disablingId === sku.id}
+                                    >
+                                      Disable
+                                    </Button>
+                                  </AlertDialogTrigger>
+                                  <AlertDialogContent
+                                    aria-busy={disablingId === sku.id}
+                                    onEscapeKeyDown={event => {
+                                      if (disablingId === sku.id) event.preventDefault();
+                                    }}
+                                    onPointerDownOutside={event => {
+                                      if (disablingId === sku.id) event.preventDefault();
                                     }}
                                   >
-                                    {disablingId === sku.id ? 'Disabling...' : 'Disable SKU'}
-                                  </AlertDialogAction>
-                                </AlertDialogFooter>
-                              </AlertDialogContent>
-                            </AlertDialog>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+                                    <AlertDialogHeader>
+                                      <AlertDialogTitle>Disable {sku.id}?</AlertDialogTitle>
+                                      <AlertDialogDescription>
+                                        New starts will be rejected. Existing usage can continue and
+                                        the SKU cannot be re-enabled.
+                                      </AlertDialogDescription>
+                                    </AlertDialogHeader>
+                                    <AlertDialogFooter>
+                                      <AlertDialogCancel disabled={disablingId === sku.id}>
+                                        Cancel
+                                      </AlertDialogCancel>
+                                      <AlertDialogAction
+                                        variant="destructive"
+                                        disabled={disablingId === sku.id}
+                                        onClick={() => {
+                                          setDisablingId(sku.id);
+                                          disableMutation.mutate({ id: sku.id });
+                                        }}
+                                      >
+                                        {disablingId === sku.id ? 'Disabling...' : 'Disable SKU'}
+                                      </AlertDialogAction>
+                                    </AlertDialogFooter>
+                                  </AlertDialogContent>
+                                </AlertDialog>
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+          <TabsContent value="usage-records" className="mt-6">
+            <UsageRecordsContent />
+          </TabsContent>
+          <TabsContent value="health" className="mt-6">
+            <BillingHealthContent />
+          </TabsContent>
+        </Tabs>
       </div>
     </AdminPage>
   );

--- a/apps/web/src/app/admin/cloud-billing-skus/page.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/page.tsx
@@ -59,11 +59,11 @@ export default function CloudBillingSkusPage() {
   const [disablingId, setDisablingId] = useState<string | null>(null);
   const createButtonRef = useRef<HTMLButtonElement>(null);
   const listOptions = trpc.admin.cloudBillingSkus.list.queryOptions();
-  const catalog = useQuery(listOptions);
-  const { data: skus, isLoading } = catalog;
-  const loadedSkus = skus ?? [];
   const tabParam = searchParams.get('tab');
   const activeTab = tabParam === 'usage-records' || tabParam === 'health' ? tabParam : 'catalog';
+  const catalog = useQuery({ ...listOptions, enabled: activeTab === 'catalog' });
+  const { data: skus, isLoading } = catalog;
+  const loadedSkus = skus ?? [];
   const onTabChange = useCallback(
     (value: string) => {
       const params = new URLSearchParams(searchParams.toString());

--- a/apps/web/src/routers/admin/cloud-billing-skus-router.test.ts
+++ b/apps/web/src/routers/admin/cloud-billing-skus-router.test.ts
@@ -9,7 +9,11 @@ import {
   type User,
 } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
-import { serializeCloudBillingSku } from './cloud-billing-skus-router';
+import {
+  serializeCloudBillingSku,
+  serializeUsageInterval,
+  serializeUsageSegment,
+} from './cloud-billing-skus-router';
 
 let admin: User;
 let nonAdmin: User;
@@ -99,15 +103,20 @@ describe('admin.cloudBillingSkus usage records', () => {
   });
 
   it('merges the most recently active open and closed intervals', async () => {
-    await insertUsageInterval({ id: 'recent-open', startedAt: '2026-07-22T09:00:00.000Z' });
-    await insertUsageInterval({ id: 'recent-closed', startedAt: '2026-07-22T10:00:00.000Z' });
+    const now = Date.now();
+    const openAt = new Date(now - 2 * 60_000).toISOString();
+    const closedAt = new Date(now - 60_000).toISOString();
+    const oldAt = new Date(now - 25 * 60 * 60_000).toISOString();
+    await insertUsageInterval({ id: 'recent-open', startedAt: openAt });
+    await insertUsageInterval({ id: 'recent-closed', startedAt: closedAt });
+    await insertUsageInterval({ id: 'recent-old', startedAt: oldAt });
     await db
       .update(container_usage_interval)
       .set({
         status: 'closed',
         close_reason: 'exit',
-        stopped_at: '2026-07-22T11:00:00.000Z',
-        last_seen_at: '2026-07-22T11:00:00.000Z',
+        stopped_at: closedAt,
+        last_seen_at: closedAt,
       })
       .where(eq(container_usage_interval.id, 'recent-closed'));
     const caller = await createCallerForUser(admin.id);
@@ -116,6 +125,46 @@ describe('admin.cloudBillingSkus usage records', () => {
       limit: 10,
     });
     expect(result.items.map(item => item.id)).toEqual(['recent-closed', 'recent-open']);
+  });
+
+  it('normalizes production-shaped interval and segment timestamps', () => {
+    const interval = serializeUsageInterval({
+      id: 'timestamp-interval',
+      service: 'cloud-agent-next',
+      instance_id: 'instance-1',
+      start_epoch_ms: 123,
+      cloud_billing_sku_id: 'usage-search-sku',
+      context_fingerprint: 'a'.repeat(64),
+      subject_type: 'user',
+      subject_id: 'user-1',
+      actor_type: 'user',
+      actor_id: 'user-1',
+      session_id: null,
+      started_at: '2026-04-29 01:16:12.945+00',
+      last_seen_at: '2026-04-29 01:17:12.945+00',
+      last_heartbeat_seq: 1,
+      confirmed_seconds: 60,
+      stopped_at: '2026-04-29 01:17:12.945+00',
+      close_reason: 'exit',
+      exit_code: 0,
+      final_stop_seq: 1,
+      status: 'closed',
+      metadata: null,
+    });
+    const segment = serializeUsageSegment({
+      interval_id: interval.id,
+      seq: 1,
+      idempotency_key: 'hidden',
+      reported_seconds: 60,
+      usage_seconds: 60,
+      received_at: '2026-04-29 01:17:12.945+00',
+    });
+    expect(interval).toMatchObject({
+      started_at: '2026-04-29T01:16:12.945Z',
+      last_seen_at: '2026-04-29T01:17:12.945Z',
+      stopped_at: '2026-04-29T01:17:12.945Z',
+    });
+    expect(segment.received_at).toBe('2026-04-29T01:17:12.945Z');
   });
 
   it('requires admin access and searches exact interval IDs', async () => {
@@ -153,10 +202,11 @@ describe('admin.cloudBillingSkus usage records', () => {
     });
     expect(first.items.map(item => item.id)).toEqual(['interval-b']);
     expect(first.nextCursor).not.toBeNull();
+    if (!first.nextCursor) throw new Error('Expected an interval cursor');
     const second = await caller.admin.cloudBillingSkus.searchUsageIntervals({
       search: { kind: 'subject', subjectType: 'user', subjectId: 'subject-1' },
       limit: 1,
-      cursor: first.nextCursor!,
+      cursor: first.nextCursor,
     });
     expect(second.items.map(item => item.id)).toEqual(['interval-a']);
   });
@@ -208,6 +258,16 @@ describe('admin.cloudBillingSkus usage records', () => {
     });
     expect(result.items[0]).not.toHaveProperty('idempotency_key');
     expect(result).not.toHaveProperty('context_fingerprint');
+    await db
+      .update(container_usage_interval)
+      .set({ metadata: { invalid: { nested: true } } as never })
+      .where(eq(container_usage_interval.id, 'interval-segments'));
+    await expect(
+      caller.admin.cloudBillingSkus.listUsageSegments({ intervalId: 'interval-segments' })
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Stored usage metadata is invalid',
+    });
     const nonAdminCaller = await createCallerForUser(nonAdmin.id);
     await expect(
       nonAdminCaller.admin.cloudBillingSkus.listUsageSegments({
@@ -244,14 +304,14 @@ describe('admin.cloudBillingSkus usage records', () => {
       intervalsReported: 1,
       openIntervals: 1,
       staleOpenIntervals: 1,
-      closedIntervals: 1,
-      unconfirmedIntervals: 1,
+      closedIntervalsWithRecentActivity: 1,
+      unconfirmedIntervalsWithRecentActivity: 1,
       segments: 1,
       reportedSeconds: 10,
       acceptedSeconds: 8,
       clippedSeconds: 2,
       clippedSegments: 1,
-      closeReasons: [{ reason: 'unconfirmed', count: 1 }],
+      closeReasonsByLastActivity: [{ reason: 'unconfirmed', count: 1 }],
     });
     expect(health.generatedAt).toMatch(/Z$/);
     const unconfirmed = await caller.admin.cloudBillingSkus.searchUsageIntervals({

--- a/apps/web/src/routers/admin/cloud-billing-skus-router.test.ts
+++ b/apps/web/src/routers/admin/cloud-billing-skus-router.test.ts
@@ -119,12 +119,26 @@ describe('admin.cloudBillingSkus usage records', () => {
         last_seen_at: closedAt,
       })
       .where(eq(container_usage_interval.id, 'recent-closed'));
+    await db
+      .update(container_usage_interval)
+      .set({ status: 'closed', close_reason: 'unconfirmed', stopped_at: oldAt })
+      .where(eq(container_usage_interval.id, 'recent-old'));
     const caller = await createCallerForUser(admin.id);
     const result = await caller.admin.cloudBillingSkus.searchUsageIntervals({
       search: { kind: 'recent' },
       limit: 10,
     });
-    expect(result.items.map(item => item.id)).toEqual(['recent-closed', 'recent-open']);
+    expect(result.items.map(item => item.id)).toEqual([
+      'recent-closed',
+      'recent-open',
+      'recent-old',
+    ]);
+    const bounded = await caller.admin.cloudBillingSkus.searchUsageIntervals({
+      search: { kind: 'recent' },
+      closeReason: 'unconfirmed',
+      limit: 10,
+    });
+    expect(bounded.items).toEqual([]);
   });
 
   it('normalizes production-shaped interval and segment timestamps', () => {

--- a/apps/web/src/routers/admin/cloud-billing-skus-router.test.ts
+++ b/apps/web/src/routers/admin/cloud-billing-skus-router.test.ts
@@ -2,7 +2,12 @@ import { beforeEach, describe, expect, it } from '@jest/globals';
 import { cleanupDbForTest, db } from '@/lib/drizzle';
 import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import { cloud_billing_sku, type User } from '@kilocode/db/schema';
+import {
+  cloud_billing_sku,
+  container_usage_interval,
+  container_usage_segment,
+  type User,
+} from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import { serializeCloudBillingSku } from './cloud-billing-skus-router';
 
@@ -22,6 +27,30 @@ function validInput(id: string) {
     unit: 'second' as const,
     rate_cents_per_unit: '0.123456789012',
   };
+}
+
+async function insertUsageInterval(params: {
+  id: string;
+  subjectType?: 'user' | 'org';
+  subjectId?: string;
+  startedAt?: string;
+}) {
+  const subjectType = params.subjectType ?? 'user';
+  const subjectId = params.subjectId ?? admin.id;
+  await db.insert(container_usage_interval).values({
+    id: params.id,
+    service: 'cloud-agent-next',
+    instance_id: params.id,
+    start_epoch_ms: 123,
+    cloud_billing_sku_id: 'usage-search-sku',
+    context_fingerprint: 'a'.repeat(64),
+    subject_type: subjectType,
+    subject_id: subjectId,
+    actor_type: 'user',
+    actor_id: subjectType === 'user' ? subjectId : admin.id,
+    started_at: params.startedAt ?? '2026-07-22T10:00:00.000Z',
+    last_seen_at: params.startedAt ?? '2026-07-22T10:00:00.000Z',
+  });
 }
 
 describe('admin.cloudBillingSkus.list', () => {
@@ -58,6 +87,183 @@ describe('admin.cloudBillingSkus.list', () => {
     });
 
     expect(serialized.created_at).toBe('2026-04-29T01:16:12.945Z');
+  });
+});
+
+describe('admin.cloudBillingSkus usage records', () => {
+  beforeEach(async () => {
+    await db.insert(cloud_billing_sku).values({
+      ...validInput('usage-search-sku'),
+      created_by_user_id: admin.id,
+    });
+  });
+
+  it('merges the most recently active open and closed intervals', async () => {
+    await insertUsageInterval({ id: 'recent-open', startedAt: '2026-07-22T09:00:00.000Z' });
+    await insertUsageInterval({ id: 'recent-closed', startedAt: '2026-07-22T10:00:00.000Z' });
+    await db
+      .update(container_usage_interval)
+      .set({
+        status: 'closed',
+        close_reason: 'exit',
+        stopped_at: '2026-07-22T11:00:00.000Z',
+        last_seen_at: '2026-07-22T11:00:00.000Z',
+      })
+      .where(eq(container_usage_interval.id, 'recent-closed'));
+    const caller = await createCallerForUser(admin.id);
+    const result = await caller.admin.cloudBillingSkus.searchUsageIntervals({
+      search: { kind: 'recent' },
+      limit: 10,
+    });
+    expect(result.items.map(item => item.id)).toEqual(['recent-closed', 'recent-open']);
+  });
+
+  it('requires admin access and searches exact interval IDs', async () => {
+    await insertUsageInterval({ id: 'interval-exact' });
+    const nonAdminCaller = await createCallerForUser(nonAdmin.id);
+    await expect(
+      nonAdminCaller.admin.cloudBillingSkus.searchUsageIntervals({
+        search: { kind: 'interval', id: 'interval-exact' },
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    const caller = await createCallerForUser(admin.id);
+    const result = await caller.admin.cloudBillingSkus.searchUsageIntervals({
+      search: { kind: 'interval', id: 'interval-exact' },
+    });
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        id: 'interval-exact',
+        started_at: '2026-07-22T10:00:00.000Z',
+      }),
+    ]);
+    expect(result.items[0]).not.toHaveProperty('context_fingerprint');
+    expect(result.items[0]).not.toHaveProperty('metadata');
+    expect(result.items[0]).not.toHaveProperty('session_id');
+  });
+
+  it('pages exact subject history deterministically', async () => {
+    await insertUsageInterval({ id: 'interval-b', subjectId: 'subject-1' });
+    await insertUsageInterval({ id: 'interval-a', subjectId: 'subject-1' });
+    await insertUsageInterval({ id: 'interval-other', subjectId: 'subject-2' });
+    const caller = await createCallerForUser(admin.id);
+    const first = await caller.admin.cloudBillingSkus.searchUsageIntervals({
+      search: { kind: 'subject', subjectType: 'user', subjectId: 'subject-1' },
+      limit: 1,
+    });
+    expect(first.items.map(item => item.id)).toEqual(['interval-b']);
+    expect(first.nextCursor).not.toBeNull();
+    const second = await caller.admin.cloudBillingSkus.searchUsageIntervals({
+      search: { kind: 'subject', subjectType: 'user', subjectId: 'subject-1' },
+      limit: 1,
+      cursor: first.nextCursor!,
+    });
+    expect(second.items.map(item => item.id)).toEqual(['interval-a']);
+  });
+
+  it('returns ordered, safe segment details and rejects unknown intervals', async () => {
+    await insertUsageInterval({ id: 'interval-segments' });
+    await db
+      .update(container_usage_interval)
+      .set({ metadata: { repository: 'Kilo-Org/cloud', runtime: 'container' } })
+      .where(eq(container_usage_interval.id, 'interval-segments'));
+    await db.insert(container_usage_segment).values([
+      {
+        interval_id: 'interval-segments',
+        seq: 2,
+        idempotency_key: 'segment-2',
+        reported_seconds: 10,
+        usage_seconds: 8,
+        received_at: '2026-07-22T10:02:00.000Z',
+      },
+      {
+        interval_id: 'interval-segments',
+        seq: 1,
+        idempotency_key: 'segment-1',
+        reported_seconds: 5,
+        usage_seconds: 5,
+        received_at: '2026-07-22T10:01:00.000Z',
+      },
+    ]);
+    const caller = await createCallerForUser(admin.id);
+    const first = await caller.admin.cloudBillingSkus.listUsageSegments({
+      intervalId: 'interval-segments',
+      limit: 1,
+    });
+    expect(first.items.map(item => item.seq)).toEqual([1]);
+    expect(first.nextCursor).toBe(1);
+    expect(first.metadata).toEqual({ repository: 'Kilo-Org/cloud', runtime: 'container' });
+    if (!first.nextCursor) throw new Error('Expected a segment cursor');
+    const result = await caller.admin.cloudBillingSkus.listUsageSegments({
+      intervalId: 'interval-segments',
+      afterSeq: first.nextCursor,
+      limit: 1,
+    });
+    expect(result.items.map(item => item.seq)).toEqual([2]);
+    expect(result.nextCursor).toBeNull();
+    expect(result.items[0]).toMatchObject({
+      reported_seconds: 10,
+      usage_seconds: 8,
+      received_at: '2026-07-22T10:02:00.000Z',
+    });
+    expect(result.items[0]).not.toHaveProperty('idempotency_key');
+    expect(result).not.toHaveProperty('context_fingerprint');
+    const nonAdminCaller = await createCallerForUser(nonAdmin.id);
+    await expect(
+      nonAdminCaller.admin.cloudBillingSkus.listUsageSegments({
+        intervalId: 'interval-segments',
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    await expect(
+      caller.admin.cloudBillingSkus.listUsageSegments({ intervalId: 'missing' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('reports bounded accounting health metrics and requires admin access', async () => {
+    const now = Date.now();
+    const recent = new Date(now - 60_000).toISOString();
+    const stale = new Date(now - 20 * 60_000).toISOString();
+    await insertUsageInterval({ id: 'health-open', startedAt: stale });
+    await insertUsageInterval({ id: 'health-closed', startedAt: recent });
+    await db
+      .update(container_usage_interval)
+      .set({ status: 'closed', close_reason: 'unconfirmed', stopped_at: recent })
+      .where(eq(container_usage_interval.id, 'health-closed'));
+    await db.insert(container_usage_segment).values({
+      interval_id: 'health-closed',
+      seq: 1,
+      idempotency_key: 'health-segment',
+      reported_seconds: 10,
+      usage_seconds: 8,
+      received_at: recent,
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    const health = await caller.admin.cloudBillingSkus.usageHealth();
+    expect(health).toMatchObject({
+      intervalsReported: 1,
+      openIntervals: 1,
+      staleOpenIntervals: 1,
+      closedIntervals: 1,
+      unconfirmedIntervals: 1,
+      segments: 1,
+      reportedSeconds: 10,
+      acceptedSeconds: 8,
+      clippedSeconds: 2,
+      clippedSegments: 1,
+      closeReasons: [{ reason: 'unconfirmed', count: 1 }],
+    });
+    expect(health.generatedAt).toMatch(/Z$/);
+    const unconfirmed = await caller.admin.cloudBillingSkus.searchUsageIntervals({
+      search: { kind: 'recent' },
+      closeReason: 'unconfirmed',
+      limit: 10,
+    });
+    expect(unconfirmed.items.map(item => item.id)).toEqual(['health-closed']);
+    const nonAdminCaller = await createCallerForUser(nonAdmin.id);
+    await expect(nonAdminCaller.admin.cloudBillingSkus.usageHealth()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
   });
 });
 

--- a/apps/web/src/routers/admin/cloud-billing-skus-router.ts
+++ b/apps/web/src/routers/admin/cloud-billing-skus-router.ts
@@ -5,9 +5,16 @@ import {
   createCloudBillingSkuInputSchema,
   normalizeCloudBillingSkuRate,
 } from '@/lib/cloud-billing-sku';
-import { cloud_billing_sku, type CloudBillingSku } from '@kilocode/db/schema';
+import {
+  cloud_billing_sku,
+  container_usage_interval,
+  container_usage_segment,
+  type CloudBillingSku,
+  type ContainerUsageInterval,
+  type ContainerUsageSegment,
+} from '@kilocode/db/schema';
 import { TRPCError } from '@trpc/server';
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq, gt, lt, or, sql, type SQL } from 'drizzle-orm';
 import * as z from 'zod';
 
 export type SerializedCloudBillingSku = Omit<CloudBillingSku, 'created_at'> & {
@@ -20,6 +27,106 @@ export function serializeCloudBillingSku(sku: CloudBillingSku): SerializedCloudB
     rate_cents_per_unit: normalizeCloudBillingSkuRate(sku.rate_cents_per_unit),
     created_at: new Date(sku.created_at).toISOString(),
   };
+}
+
+const usageSearchSchema = z
+  .object({
+    search: z.discriminatedUnion('kind', [
+      z.object({ kind: z.literal('recent') }),
+      z.object({ kind: z.literal('interval'), id: z.string().trim().min(1).max(512) }),
+      z.object({
+        kind: z.literal('subject'),
+        subjectType: z.enum(['user', 'org']),
+        subjectId: z.string().trim().min(1).max(256),
+      }),
+    ]),
+    status: z.enum(['open', 'closed']).optional(),
+    closeReason: z
+      .enum([
+        'exit',
+        'runtime_signal',
+        'activity_expired',
+        'reconciled',
+        'unconfirmed',
+        'superseded',
+      ])
+      .optional(),
+    skuId: cloudBillingSkuIdSchema.optional(),
+    cursor: z
+      .object({ startedAt: z.iso.datetime(), id: z.string().min(1).max(512) })
+      .strict()
+      .optional(),
+    limit: z.number().int().min(1).max(100).default(25),
+  })
+  .strict();
+
+const segmentSearchSchema = z
+  .object({
+    intervalId: z.string().trim().min(1).max(512),
+    afterSeq: z.number().int().positive().optional(),
+    limit: z.number().int().min(1).max(500).default(200),
+  })
+  .strict();
+
+const BILLING_HEALTH_WINDOW_MS = 24 * 60 * 60 * 1_000;
+const STALE_OPEN_INTERVAL_MS = 15 * 60 * 1_000;
+
+export type SerializedUsageInterval = Pick<
+  ContainerUsageInterval,
+  | 'id'
+  | 'service'
+  | 'instance_id'
+  | 'start_epoch_ms'
+  | 'cloud_billing_sku_id'
+  | 'subject_type'
+  | 'subject_id'
+  | 'actor_type'
+  | 'actor_id'
+  | 'last_heartbeat_seq'
+  | 'confirmed_seconds'
+  | 'close_reason'
+  | 'exit_code'
+  | 'final_stop_seq'
+  | 'status'
+> & {
+  started_at: string;
+  last_seen_at: string;
+  stopped_at: string | null;
+};
+
+function serializeUsageInterval(interval: ContainerUsageInterval): SerializedUsageInterval {
+  return {
+    id: interval.id,
+    service: interval.service,
+    instance_id: interval.instance_id,
+    start_epoch_ms: interval.start_epoch_ms,
+    cloud_billing_sku_id: interval.cloud_billing_sku_id,
+    subject_type: interval.subject_type,
+    subject_id: interval.subject_id,
+    actor_type: interval.actor_type,
+    actor_id: interval.actor_id,
+    last_heartbeat_seq: interval.last_heartbeat_seq,
+    confirmed_seconds: interval.confirmed_seconds,
+    close_reason: interval.close_reason,
+    exit_code: interval.exit_code,
+    final_stop_seq: interval.final_stop_seq,
+    status: interval.status,
+    started_at: new Date(interval.started_at).toISOString(),
+    last_seen_at: new Date(interval.last_seen_at).toISOString(),
+    stopped_at: interval.stopped_at ? new Date(interval.stopped_at).toISOString() : null,
+  };
+}
+
+export type SerializedUsageSegment = Omit<
+  ContainerUsageSegment,
+  'idempotency_key' | 'received_at'
+> & {
+  received_at: string;
+};
+
+function serializeUsageSegment(segment: ContainerUsageSegment): SerializedUsageSegment {
+  const { idempotency_key: _idempotencyKey, ...safe } = segment;
+  return { ...safe, received_at: new Date(segment.received_at).toISOString() };
 }
 
 function postgresErrorCode(error: unknown): string | undefined {
@@ -36,6 +143,192 @@ export const cloudBillingSkusRouter = createTRPCRouter({
       .from(cloud_billing_sku)
       .orderBy(desc(cloud_billing_sku.created_at));
     return rows.map(serializeCloudBillingSku);
+  }),
+
+  searchUsageIntervals: adminProcedure.input(usageSearchSchema).query(async ({ input }) => {
+    const predicates: SQL[] = [];
+    if (input.search.kind === 'recent') {
+      const sharedPredicates: SQL[] = [];
+      if (input.closeReason) {
+        sharedPredicates.push(eq(container_usage_interval.close_reason, input.closeReason));
+      }
+      if (input.skuId) {
+        sharedPredicates.push(eq(container_usage_interval.cloud_billing_sku_id, input.skuId));
+      }
+      const statuses = input.status
+        ? [input.status]
+        : input.closeReason
+          ? ['closed' as const]
+          : (['open', 'closed'] as const);
+      const pages = await Promise.all(
+        statuses.map(status =>
+          db
+            .select()
+            .from(container_usage_interval)
+            .where(and(eq(container_usage_interval.status, status), ...sharedPredicates))
+            .orderBy(desc(container_usage_interval.last_seen_at), desc(container_usage_interval.id))
+            .limit(input.limit)
+        )
+      );
+      const items = pages
+        .flat()
+        .sort((left, right) => {
+          const byLastSeen =
+            new Date(right.last_seen_at).getTime() - new Date(left.last_seen_at).getTime();
+          return byLastSeen || right.id.localeCompare(left.id);
+        })
+        .slice(0, input.limit)
+        .map(serializeUsageInterval);
+      return { items, nextCursor: null };
+    }
+    if (input.search.kind === 'interval') {
+      predicates.push(eq(container_usage_interval.id, input.search.id));
+    } else {
+      predicates.push(
+        eq(container_usage_interval.subject_type, input.search.subjectType),
+        eq(container_usage_interval.subject_id, input.search.subjectId)
+      );
+    }
+    if (input.status) predicates.push(eq(container_usage_interval.status, input.status));
+    if (input.closeReason) {
+      predicates.push(eq(container_usage_interval.close_reason, input.closeReason));
+    }
+    if (input.skuId) {
+      predicates.push(eq(container_usage_interval.cloud_billing_sku_id, input.skuId));
+    }
+    if (input.cursor) {
+      const startedAt = input.cursor.startedAt;
+      const sameTimestamp = and(
+        eq(container_usage_interval.started_at, startedAt),
+        lt(container_usage_interval.id, input.cursor.id)
+      );
+      const cursorPredicate = sameTimestamp
+        ? or(lt(container_usage_interval.started_at, startedAt), sameTimestamp)
+        : lt(container_usage_interval.started_at, startedAt);
+      if (cursorPredicate) predicates.push(cursorPredicate);
+    }
+
+    const rows = await db
+      .select()
+      .from(container_usage_interval)
+      .where(and(...predicates))
+      .orderBy(desc(container_usage_interval.started_at), desc(container_usage_interval.id))
+      .limit(input.limit + 1);
+    const hasMore = rows.length > input.limit;
+    const page = rows.slice(0, input.limit);
+    const last = page.at(-1);
+    return {
+      items: page.map(serializeUsageInterval),
+      nextCursor:
+        hasMore && last
+          ? { startedAt: new Date(last.started_at).toISOString(), id: last.id }
+          : null,
+    };
+  }),
+
+  listUsageSegments: adminProcedure.input(segmentSearchSchema).query(async ({ input }) => {
+    const [interval] = await db
+      .select({ id: container_usage_interval.id, metadata: container_usage_interval.metadata })
+      .from(container_usage_interval)
+      .where(eq(container_usage_interval.id, input.intervalId))
+      .limit(1);
+    if (!interval) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Usage interval not found' });
+    }
+    const predicates = [eq(container_usage_segment.interval_id, input.intervalId)];
+    if (input.afterSeq) predicates.push(gt(container_usage_segment.seq, input.afterSeq));
+    const rows = await db
+      .select()
+      .from(container_usage_segment)
+      .where(and(...predicates))
+      .orderBy(container_usage_segment.seq)
+      .limit(input.limit + 1);
+    const hasMore = rows.length > input.limit;
+    const page = rows.slice(0, input.limit);
+    return {
+      metadata: interval.metadata ?? {},
+      items: page.map(serializeUsageSegment),
+      nextCursor: hasMore ? (page.at(-1)?.seq ?? null) : null,
+    };
+  }),
+
+  usageHealth: adminProcedure.query(async () => {
+    const end = new Date();
+    const start = new Date(end.getTime() - BILLING_HEALTH_WINDOW_MS);
+    const staleBefore = new Date(end.getTime() - STALE_OPEN_INTERVAL_MS);
+    const [openRows, segmentRows, closeReasonRows] = await Promise.all([
+      db
+        .select({
+          open: sql<number>`count(*)`.mapWith(Number),
+          stale:
+            sql<number>`count(*) FILTER (WHERE ${container_usage_interval.last_seen_at} < ${staleBefore.toISOString()})`.mapWith(
+              Number
+            ),
+        })
+        .from(container_usage_interval)
+        .where(eq(container_usage_interval.status, 'open')),
+      db
+        .select({
+          segments: sql<number>`count(*)`.mapWith(Number),
+          intervalsReported:
+            sql<number>`count(distinct ${container_usage_segment.interval_id})`.mapWith(Number),
+          reportedSeconds:
+            sql<number>`coalesce(sum(${container_usage_segment.reported_seconds}), 0)`.mapWith(
+              Number
+            ),
+          acceptedSeconds:
+            sql<number>`coalesce(sum(${container_usage_segment.usage_seconds}), 0)`.mapWith(Number),
+          clippedSeconds:
+            sql<number>`coalesce(sum(${container_usage_segment.reported_seconds} - ${container_usage_segment.usage_seconds}), 0)`.mapWith(
+              Number
+            ),
+          clippedSegments:
+            sql<number>`count(*) FILTER (WHERE ${container_usage_segment.usage_seconds} < ${container_usage_segment.reported_seconds})`.mapWith(
+              Number
+            ),
+        })
+        .from(container_usage_segment)
+        .where(
+          and(
+            gt(container_usage_segment.received_at, start.toISOString()),
+            lt(container_usage_segment.received_at, end.toISOString())
+          )
+        ),
+      db
+        .select({
+          reason: container_usage_interval.close_reason,
+          count: sql<number>`count(*)`.mapWith(Number),
+        })
+        .from(container_usage_interval)
+        .where(
+          and(
+            eq(container_usage_interval.status, 'closed'),
+            gt(container_usage_interval.last_seen_at, start.toISOString()),
+            lt(container_usage_interval.last_seen_at, end.toISOString())
+          )
+        )
+        .groupBy(container_usage_interval.close_reason)
+        .orderBy(desc(sql`count(*)`)),
+    ]);
+    const closeReasons = closeReasonRows.map(row => ({
+      reason: row.reason ?? 'unknown',
+      count: row.count,
+    }));
+    return {
+      generatedAt: end.toISOString(),
+      periodStart: start.toISOString(),
+      intervalsReported: segmentRows[0]?.intervalsReported ?? 0,
+      openIntervals: openRows[0]?.open ?? 0,
+      staleOpenIntervals: openRows[0]?.stale ?? 0,
+      closedIntervals: closeReasons.reduce((total, row) => total + row.count, 0),
+      unconfirmedIntervals: closeReasons.find(row => row.reason === 'unconfirmed')?.count ?? 0,
+      segments: segmentRows[0]?.segments ?? 0,
+      reportedSeconds: segmentRows[0]?.reportedSeconds ?? 0,
+      acceptedSeconds: segmentRows[0]?.acceptedSeconds ?? 0,
+      clippedSeconds: segmentRows[0]?.clippedSeconds ?? 0,
+      clippedSegments: segmentRows[0]?.clippedSegments ?? 0,
+      closeReasons,
+    };
   }),
 
   create: adminProcedure

--- a/apps/web/src/routers/admin/cloud-billing-skus-router.ts
+++ b/apps/web/src/routers/admin/cloud-billing-skus-router.ts
@@ -1,5 +1,5 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
-import { db } from '@/lib/drizzle';
+import { db, readDb } from '@/lib/drizzle';
 import {
   cloudBillingSkuIdSchema,
   createCloudBillingSkuInputSchema,
@@ -70,6 +70,12 @@ const segmentSearchSchema = z
 
 const BILLING_HEALTH_WINDOW_MS = 24 * 60 * 60 * 1_000;
 const STALE_OPEN_INTERVAL_MS = 15 * 60 * 1_000;
+const usageMetadataSchema = z
+  .record(z.string().min(1).max(64), z.string().max(512))
+  .refine(
+    metadata => Object.keys(metadata).length <= 16,
+    'Metadata may contain at most 16 entries'
+  );
 
 export type SerializedUsageInterval = Pick<
   ContainerUsageInterval,
@@ -94,7 +100,7 @@ export type SerializedUsageInterval = Pick<
   stopped_at: string | null;
 };
 
-function serializeUsageInterval(interval: ContainerUsageInterval): SerializedUsageInterval {
+export function serializeUsageInterval(interval: ContainerUsageInterval): SerializedUsageInterval {
   return {
     id: interval.id,
     service: interval.service,
@@ -117,16 +123,32 @@ function serializeUsageInterval(interval: ContainerUsageInterval): SerializedUsa
   };
 }
 
-export type SerializedUsageSegment = Omit<
+export type SerializedUsageSegment = Pick<
   ContainerUsageSegment,
-  'idempotency_key' | 'received_at'
+  'interval_id' | 'seq' | 'reported_seconds' | 'usage_seconds'
 > & {
   received_at: string;
 };
 
-function serializeUsageSegment(segment: ContainerUsageSegment): SerializedUsageSegment {
-  const { idempotency_key: _idempotencyKey, ...safe } = segment;
-  return { ...safe, received_at: new Date(segment.received_at).toISOString() };
+export function serializeUsageSegment(segment: ContainerUsageSegment): SerializedUsageSegment {
+  return {
+    interval_id: segment.interval_id,
+    seq: segment.seq,
+    reported_seconds: segment.reported_seconds,
+    usage_seconds: segment.usage_seconds,
+    received_at: new Date(segment.received_at).toISOString(),
+  };
+}
+
+function parseUsageMetadata(metadata: unknown): Record<string, string> {
+  const parsed = usageMetadataSchema.safeParse(metadata ?? {});
+  if (!parsed.success) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Stored usage metadata is invalid',
+    });
+  }
+  return parsed.data;
 }
 
 function postgresErrorCode(error: unknown): string | undefined {
@@ -148,7 +170,8 @@ export const cloudBillingSkusRouter = createTRPCRouter({
   searchUsageIntervals: adminProcedure.input(usageSearchSchema).query(async ({ input }) => {
     const predicates: SQL[] = [];
     if (input.search.kind === 'recent') {
-      const sharedPredicates: SQL[] = [];
+      const recentCutoff = new Date(Date.now() - BILLING_HEALTH_WINDOW_MS).toISOString();
+      const sharedPredicates: SQL[] = [gt(container_usage_interval.last_seen_at, recentCutoff)];
       if (input.closeReason) {
         sharedPredicates.push(eq(container_usage_interval.close_reason, input.closeReason));
       }
@@ -162,7 +185,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
           : (['open', 'closed'] as const);
       const pages = await Promise.all(
         statuses.map(status =>
-          db
+          readDb
             .select()
             .from(container_usage_interval)
             .where(and(eq(container_usage_interval.status, status), ...sharedPredicates))
@@ -208,7 +231,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
       if (cursorPredicate) predicates.push(cursorPredicate);
     }
 
-    const rows = await db
+    const rows = await readDb
       .select()
       .from(container_usage_interval)
       .where(and(...predicates))
@@ -227,7 +250,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
   }),
 
   listUsageSegments: adminProcedure.input(segmentSearchSchema).query(async ({ input }) => {
-    const [interval] = await db
+    const [interval] = await readDb
       .select({ id: container_usage_interval.id, metadata: container_usage_interval.metadata })
       .from(container_usage_interval)
       .where(eq(container_usage_interval.id, input.intervalId))
@@ -237,7 +260,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
     }
     const predicates = [eq(container_usage_segment.interval_id, input.intervalId)];
     if (input.afterSeq) predicates.push(gt(container_usage_segment.seq, input.afterSeq));
-    const rows = await db
+    const rows = await readDb
       .select()
       .from(container_usage_segment)
       .where(and(...predicates))
@@ -246,7 +269,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
     const hasMore = rows.length > input.limit;
     const page = rows.slice(0, input.limit);
     return {
-      metadata: interval.metadata ?? {},
+      metadata: parseUsageMetadata(interval.metadata),
       items: page.map(serializeUsageSegment),
       nextCursor: hasMore ? (page.at(-1)?.seq ?? null) : null,
     };
@@ -257,7 +280,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
     const start = new Date(end.getTime() - BILLING_HEALTH_WINDOW_MS);
     const staleBefore = new Date(end.getTime() - STALE_OPEN_INTERVAL_MS);
     const [openRows, segmentRows, closeReasonRows] = await Promise.all([
-      db
+      readDb
         .select({
           open: sql<number>`count(*)`.mapWith(Number),
           stale:
@@ -267,7 +290,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
         })
         .from(container_usage_interval)
         .where(eq(container_usage_interval.status, 'open')),
-      db
+      readDb
         .select({
           segments: sql<number>`count(*)`.mapWith(Number),
           intervalsReported:
@@ -294,7 +317,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
             lt(container_usage_segment.received_at, end.toISOString())
           )
         ),
-      db
+      readDb
         .select({
           reason: container_usage_interval.close_reason,
           count: sql<number>`count(*)`.mapWith(Number),
@@ -320,14 +343,15 @@ export const cloudBillingSkusRouter = createTRPCRouter({
       intervalsReported: segmentRows[0]?.intervalsReported ?? 0,
       openIntervals: openRows[0]?.open ?? 0,
       staleOpenIntervals: openRows[0]?.stale ?? 0,
-      closedIntervals: closeReasons.reduce((total, row) => total + row.count, 0),
-      unconfirmedIntervals: closeReasons.find(row => row.reason === 'unconfirmed')?.count ?? 0,
+      closedIntervalsWithRecentActivity: closeReasons.reduce((total, row) => total + row.count, 0),
+      unconfirmedIntervalsWithRecentActivity:
+        closeReasons.find(row => row.reason === 'unconfirmed')?.count ?? 0,
       segments: segmentRows[0]?.segments ?? 0,
       reportedSeconds: segmentRows[0]?.reportedSeconds ?? 0,
       acceptedSeconds: segmentRows[0]?.acceptedSeconds ?? 0,
       clippedSeconds: segmentRows[0]?.clippedSeconds ?? 0,
       clippedSegments: segmentRows[0]?.clippedSegments ?? 0,
-      closeReasons,
+      closeReasonsByLastActivity: closeReasons,
     };
   }),
 

--- a/apps/web/src/routers/admin/cloud-billing-skus-router.ts
+++ b/apps/web/src/routers/admin/cloud-billing-skus-router.ts
@@ -1,5 +1,5 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
-import { db, readDb } from '@/lib/drizzle';
+import { db } from '@/lib/drizzle';
 import {
   cloudBillingSkuIdSchema,
   createCloudBillingSkuInputSchema,
@@ -170,8 +170,11 @@ export const cloudBillingSkusRouter = createTRPCRouter({
   searchUsageIntervals: adminProcedure.input(usageSearchSchema).query(async ({ input }) => {
     const predicates: SQL[] = [];
     if (input.search.kind === 'recent') {
-      const recentCutoff = new Date(Date.now() - BILLING_HEALTH_WINDOW_MS).toISOString();
-      const sharedPredicates: SQL[] = [gt(container_usage_interval.last_seen_at, recentCutoff)];
+      const sharedPredicates: SQL[] = [];
+      if (input.closeReason || input.skuId) {
+        const recentCutoff = new Date(Date.now() - BILLING_HEALTH_WINDOW_MS).toISOString();
+        sharedPredicates.push(gt(container_usage_interval.last_seen_at, recentCutoff));
+      }
       if (input.closeReason) {
         sharedPredicates.push(eq(container_usage_interval.close_reason, input.closeReason));
       }
@@ -185,7 +188,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
           : (['open', 'closed'] as const);
       const pages = await Promise.all(
         statuses.map(status =>
-          readDb
+          db
             .select()
             .from(container_usage_interval)
             .where(and(eq(container_usage_interval.status, status), ...sharedPredicates))
@@ -231,7 +234,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
       if (cursorPredicate) predicates.push(cursorPredicate);
     }
 
-    const rows = await readDb
+    const rows = await db
       .select()
       .from(container_usage_interval)
       .where(and(...predicates))
@@ -250,7 +253,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
   }),
 
   listUsageSegments: adminProcedure.input(segmentSearchSchema).query(async ({ input }) => {
-    const [interval] = await readDb
+    const [interval] = await db
       .select({ id: container_usage_interval.id, metadata: container_usage_interval.metadata })
       .from(container_usage_interval)
       .where(eq(container_usage_interval.id, input.intervalId))
@@ -260,7 +263,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
     }
     const predicates = [eq(container_usage_segment.interval_id, input.intervalId)];
     if (input.afterSeq) predicates.push(gt(container_usage_segment.seq, input.afterSeq));
-    const rows = await readDb
+    const rows = await db
       .select()
       .from(container_usage_segment)
       .where(and(...predicates))
@@ -280,7 +283,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
     const start = new Date(end.getTime() - BILLING_HEALTH_WINDOW_MS);
     const staleBefore = new Date(end.getTime() - STALE_OPEN_INTERVAL_MS);
     const [openRows, segmentRows, closeReasonRows] = await Promise.all([
-      readDb
+      db
         .select({
           open: sql<number>`count(*)`.mapWith(Number),
           stale:
@@ -290,7 +293,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
         })
         .from(container_usage_interval)
         .where(eq(container_usage_interval.status, 'open')),
-      readDb
+      db
         .select({
           segments: sql<number>`count(*)`.mapWith(Number),
           intervalsReported:
@@ -317,7 +320,7 @@ export const cloudBillingSkusRouter = createTRPCRouter({
             lt(container_usage_segment.received_at, end.toISOString())
           )
         ),
-      readDb
+      db
         .select({
           reason: container_usage_interval.close_reason,
           count: sql<number>`count(*)`.mapWith(Number),


### PR DESCRIPTION
## Summary

- Add URL-backed SKU catalog, Usage records, and Health tabs to the Cloud Billing admin page.
- Show the 10 most recently active open/closed intervals by merging two queries backed by the existing `(status, last_seen_at)` reconciliation index; keep exact interval/user/org searches paginated.
- Add safe lazy detail views for interval metadata and paginated heartbeat/final-stop segments, plus canonical admin links for user/org subjects and human actors.
- Add a 24-hour accounting-health snapshot for accepted/reported/clipped usage, reporting intervals, open/stale state, unconfirmed closes, and closure outcomes.
- Link Unconfirmed health results to a close-reason-filtered records view and keep that filter synchronized with the URL.
- Validate persisted metadata at the API boundary and use explicit response allowlists.

## Verification

- [x] Local fake-admin: opened `/admin/cloud-billing-skus?tab=usage-records`; recent activity loaded the two existing local sample intervals.
- [x] Local fake-admin: searched an exact interval, expanded it, and viewed ordered segments and lazy metadata.
- [x] Local fake-admin: verified user/org subjects and human actors link to their canonical admin detail pages.
- [x] Local fake-admin: opened `/admin/cloud-billing-skus?tab=health`; 24-hour metrics and closure outcomes matched local sample rows at desktop and 375px widths.
- [x] Local fake-admin: followed the Unconfirmed drill-down, then selected Any reason; the `closeReason` URL parameter was removed and recent results refreshed immediately.

## Visual Changes


![Uploading Screenshot 2026-07-22 at 2.42.29 PM.png…]()


## Reviewer Notes

- No schema or migration changes. Unfiltered recent activity uses two bounded top-10 queries against the existing `(status, last_seen_at)` index and merges at most 20 rows in the API; sparse SKU/close-reason filters are additionally limited to 24 hours.
- Search responses use explicit field allowlists. Metadata is runtime-validated and fetched only on admin expansion; context fingerprints and idempotency keys remain hidden.
- Health segment metrics use `received_at`; closure outcomes are explicitly labelled by final activity (`last_seen_at`) rather than closure transition time.

