### PR TITLE
feat(code reviewer) Begin deprecation of code review custom instructions

### DIFF
--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/code-reviewer/[scope]/[platform]/(edit)/instructions.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/code-reviewer/[scope]/[platform]/(edit)/instructions.tsx
@@ -26,6 +26,10 @@ function InstructionsEditor({
 
   return (
     <Animated.View entering={FadeIn.duration(200)} className="gap-4">
+      <Text className="text-sm text-muted-foreground">
+        Custom instructions is planned for deprecation. Move these guidelines into a REVIEW.md file
+        in your repository instead.
+      </Text>
       <TextInput
         className="h-32 rounded-lg bg-secondary p-3 text-sm leading-5 text-foreground"
         multiline

--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/code-reviewer/[scope]/[platform]/(edit)/instructions.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/code-reviewer/[scope]/[platform]/(edit)/instructions.tsx
@@ -27,7 +27,7 @@ function InstructionsEditor({
   return (
     <Animated.View entering={FadeIn.duration(200)} className="gap-4">
       <Text className="text-sm text-muted-foreground">
-        Custom instructions is planned for deprecation. Move these guidelines into a REVIEW.md file
+        Custom Instructions is planned for deprecation. Move these guidelines into a REVIEW.md file
         in your repository instead.
       </Text>
       <TextInput

--- a/apps/mobile/src/components/code-reviewer/platform-overview-rows.ts
+++ b/apps/mobile/src/components/code-reviewer/platform-overview-rows.ts
@@ -52,12 +52,18 @@ export function buildOverviewRows({
       subtitle:
         data.focusAreas.length > 0 ? data.focusAreas.map(capitalize).join(', ') : 'All areas',
     },
-    {
-      field: 'instructions',
-      icon: ScrollText,
-      title: 'Custom Instructions',
-      subtitle: data.customInstructions ? 'Set' : 'None',
-    },
+    // Custom Instructions is deprecated in favour of REVIEW.md, so the row is
+    // only offered to configs that already have something stored in it.
+    ...(data.customInstructions?.trim()
+      ? [
+          {
+            field: 'instructions',
+            icon: ScrollText,
+            title: 'Custom Instructions',
+            subtitle: 'Set',
+          },
+        ]
+      : []),
     {
       field: 'model',
       icon: FileSliders,

--- a/apps/web/src/components/code-reviews/BitbucketReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/BitbucketReviewConfigForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
 import { AlertCircle, Play, RefreshCw, Save, Settings2, ShieldCheck } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -84,9 +85,16 @@ export function BitbucketReviewConfigForm({ organizationId }: BitbucketReviewCon
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [manualReviewUrl, setManualReviewUrl] = useState('');
   const [manualReviewError, setManualReviewError] = useState<string | null>(null);
+  // Custom instructions is deprecated in favour of REVIEW.md. The field is only
+  // surfaced to configs that already have something stored in it, and stays
+  // visible for the rest of the session even if the user clears it.
+  const [showCustomInstructions, setShowCustomInstructions] = useState(false);
 
   useEffect(() => {
     if (!configQuery.data) return;
+    if (configQuery.data.customInstructions?.trim()) {
+      setShowCustomInstructions(true);
+    }
     const nextConfig: BitbucketReviewConfig = {
       reviewStyle: configQuery.data.reviewStyle,
       focusAreas: configQuery.data.focusAreas,
@@ -530,19 +538,34 @@ export function BitbucketReviewConfigForm({ organizationId }: BitbucketReviewCon
               </div>
             </div>
 
-            <div className="space-y-2 border-t border-border pt-6">
-              <Label htmlFor="bitbucket-custom-instructions">Custom instructions (optional)</Label>
-              <Textarea
-                id="bitbucket-custom-instructions"
-                value={draft.customInstructions}
-                onChange={event =>
-                  setDraft(current => ({ ...current, customInstructions: event.target.value }))
-                }
-                placeholder="Add repository-specific review guidance for your team."
-                rows={4}
-                className="resize-none"
-              />
-            </div>
+            {/* Deprecated — only shown to configs that already have custom instructions stored. */}
+            {showCustomInstructions && (
+              <div className="space-y-2 border-t border-border pt-6">
+                <Label htmlFor="bitbucket-custom-instructions">
+                  Custom instructions (optional)
+                </Label>
+                <Textarea
+                  id="bitbucket-custom-instructions"
+                  value={draft.customInstructions}
+                  onChange={event =>
+                    setDraft(current => ({ ...current, customInstructions: event.target.value }))
+                  }
+                  placeholder="Add repository-specific review guidance for your team."
+                  rows={4}
+                  className="resize-none"
+                />
+                <p className="text-muted-foreground text-sm">
+                  Custom instructions is planned for deprecation. Move this guidance into a
+                  REVIEW.md file in your repository instead.{' '}
+                  <Link
+                    href={`/organizations/${organizationId}/code-reviews/review-md`}
+                    className="text-blue-400 underline-offset-2 hover:text-blue-300 hover:underline"
+                  >
+                    Learn about REVIEW.md
+                  </Link>
+                </p>
+              </div>
+            )}
           </div>
 
           <div className="flex flex-col gap-3 border-t border-border pt-6 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/src/components/code-reviews/BitbucketReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/BitbucketReviewConfigForm.tsx
@@ -555,7 +555,7 @@ export function BitbucketReviewConfigForm({ organizationId }: BitbucketReviewCon
                   className="resize-none"
                 />
                 <p className="text-muted-foreground text-sm">
-                  Custom instructions is planned for deprecation. Move this guidance into a
+                  Custom Instructions is planned for deprecation. Move these guidelines into a
                   REVIEW.md file in your repository instead.{' '}
                   <Link
                     href={`/organizations/${organizationId}/code-reviews/review-md`}

--- a/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
@@ -245,6 +245,10 @@ export function ReviewConfigForm({
   );
   const [focusAreas, setFocusAreas] = useState<string[]>([]);
   const [customInstructions, setCustomInstructions] = useState('');
+  // Custom Instructions is deprecated in favour of REVIEW.md. The field is only
+  // surfaced to configs that already have something stored in it, and stays
+  // visible for the rest of the session even if the user clears it.
+  const [showCustomInstructions, setShowCustomInstructions] = useState(false);
   const [selectedModel, setSelectedModel] = useState(PRIMARY_DEFAULT_MODEL);
   const [thinkingEffort, setThinkingEffort] = useState<string | null>(null);
   const [gateThreshold, setGateThreshold] = useState<'off' | 'all' | 'warning' | 'critical'>('off');
@@ -372,6 +376,9 @@ export function ReviewConfigForm({
       setReviewStyle(configData.reviewStyle);
       setFocusAreas(configData.focusAreas);
       setCustomInstructions(configData.customInstructions || '');
+      if (configData.customInstructions?.trim()) {
+        setShowCustomInstructions(true);
+      }
       setSelectedModel(configData.modelSlug);
       setThinkingEffort(configData.thinkingEffort ?? null);
       setGateThreshold(configData.gateThreshold ?? 'off');
@@ -867,21 +874,30 @@ export function ReviewConfigForm({
               </div>
             </div>
 
-            {/* Custom Instructions (global) */}
-            <div className="space-y-3">
-              <Label htmlFor="custom-instructions">Custom Instructions (Optional)</Label>
-              <Textarea
-                id="custom-instructions"
-                placeholder="e.g., 'Always check for TypeScript strict mode compliance' or 'Focus on React best practices'"
-                value={customInstructions}
-                onChange={e => setCustomInstructions(e.target.value)}
-                rows={4}
-                className="resize-none"
-              />
-              <p className="text-muted-foreground text-sm">
-                Add specific guidelines for your team's code review standards
-              </p>
-            </div>
+            {/* Custom Instructions (global) — deprecated, only shown to configs that already use it */}
+            {showCustomInstructions && (
+              <div className="space-y-3">
+                <Label htmlFor="custom-instructions">Custom Instructions (Optional)</Label>
+                <Textarea
+                  id="custom-instructions"
+                  placeholder="e.g., 'Always check for TypeScript strict mode compliance' or 'Focus on React best practices'"
+                  value={customInstructions}
+                  onChange={e => setCustomInstructions(e.target.value)}
+                  rows={4}
+                  className="resize-none"
+                />
+                <p className="text-muted-foreground text-sm">
+                  Custom Instructions is planned for deprecation. Move these guidelines into a
+                  REVIEW.md file in your repository instead.{' '}
+                  <Link
+                    href={reviewMdGuideHref}
+                    className="text-blue-400 underline-offset-2 hover:text-blue-300 hover:underline"
+                  >
+                    Learn about REVIEW.md
+                  </Link>
+                </p>
+              </div>
+            )}
 
             {/* Advanced Settings — one card holding the switch and, when on, the per-repository
                 settings. GitLab has no "all" mode, so it is always Advanced (switch hidden). */}


### PR DESCRIPTION
## Summary

Starts deprecating the code reviewer's Custom Instructions field in favor of REVIEW.md. The field no longer renders for configs that have never used it. Configs that already have a value keep the field, with a note pointing them to REVIEW.md.

UI only. The schema, tRPC routers, and prompt generation are untouched, so stored custom instructions are still saved and still applied to reviews.

## Changes

- `ReviewConfigForm.tsx` (GitHub and GitLab, org and personal scopes): gate the Custom Instructions block behind new `showCustomInstructions` state, set on config load when the stored value is non-empty. The old helper text ("Add specific guidelines for your team's code review standards") is replaced by the deprecation note plus a link to the existing REVIEW.md guide page.
- `BitbucketReviewConfigForm.tsx`: same gating and note for Bitbucket's separate custom instructions field, which had no helper text before.
- `platform-overview-rows.ts` (mobile): drop the Custom Instructions row from the provider overview when nothing is stored, which also removes the only route to the edit screen. The subtitle is now always "Set", since the row only renders when a value exists.
- `instructions.tsx` (mobile edit screen): same note above the input.

Wording is identical on all three surfaces:

> Custom Instructions is planned for deprecation. Move these guidelines into a REVIEW.md file in your repository instead.

## Verification

- [ ] No manual testing yet. Checked with `pnpm --filter web typecheck`, `pnpm lint` in `apps/mobile`, and `oxfmt`. The conditional rendering still needs a pass against one config with a stored value and one without.

## Visual Changes

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- Visibility is sticky per page load. If someone clears the box and saves, the section stays visible until reload so it does not vanish mid-edit. A fresh load then hides it.
- The Bitbucket note links to the org-scoped guide path directly, since Bitbucket config is org only. The shared form reuses its existing `reviewMdGuideHref`, which already covers both scopes.
- Mobile has no REVIEW.md guide route, so the note there carries no link.
- Not in this PR, but worth knowing: the REVIEW.md guide page these notes link to still lists "Custom instructions and focus areas are still applied around repository guidance" as a limitation (`ReviewMdGuideContent.tsx:30`). That reads oddly as the destination of a deprecation notice.
- "planned for deprecation" is deliberately vague on timing because there is no target date set.
