### PR TITLE
Fix(kiloclaw) hooks invariant self heal

### DIFF
--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -2000,6 +2000,27 @@ describe('hookConfigBootViolation', () => {
     expect(hookConfigBootViolation(config)).toBeNull();
   });
 
+  // The mapping sessionKey is attacker-influenced and re-checked on every gateway
+  // spawn, so template detection must stay linear. OpenClaw's own regex spends
+  // ~6s on this input; ours must not, or one crafted mapping stalls every restart.
+  it('detects templates in linear time on an unterminated expression', () => {
+    const config = healthyHookConfig();
+    config.hooks.mappings = [{ id: 'x', sessionKey: `{{${' '.repeat(5000)}a` }];
+
+    const startedAt = Date.now();
+    expect(hookConfigBootViolation(config)).toBeNull();
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+  });
+
+  // Parity guard: OpenClaw's regex accepts a whitespace-only interior, so a
+  // "tighten the pattern" change that rejects these would stop us repairing a
+  // config the gateway does treat as templated.
+  it.each(['{{ }}', '{{  }}'])('treats %j as templated, as OpenClaw does', sessionKey => {
+    const config = healthyHookConfig();
+    config.hooks.mappings = [{ id: 'x', sessionKey }];
+    expect(hookConfigBootViolation(config)).toMatch(/allowedSessionKeyPrefixes is required/);
+  });
+
   it('treats a mapping with no explicit action as an agent mapping', () => {
     const config = healthyHookConfig();
     // action defaults to 'agent' in OpenClaw, so this one does require prefixes.

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -1983,6 +1983,72 @@ describe('hookConfigBootViolation', () => {
   it('ignores configs with no hooks block', () => {
     expect(hookConfigBootViolation({ gateway: { port: 3001 } })).toBeNull();
   });
+
+  // Parity with hasEffectiveTemplatedHookSessionKeyMapping. Each of these is a
+  // mapping OpenClaw does NOT treat as templated, so requiring prefixes for
+  // them would reject configs the gateway starts from.
+  it.each([
+    {
+      name: 'a non-agent action',
+      mapping: { id: 'x', action: 'wake', sessionKey: '{{payload.sessionKey}}' },
+    },
+    { name: 'an unclosed template', mapping: { id: 'x', sessionKey: 'literal{{' } },
+    { name: 'an empty template', mapping: { id: 'x', sessionKey: '{{}}' } },
+  ])('does not treat $name as templated', ({ mapping }) => {
+    const config = healthyHookConfig();
+    config.hooks.mappings = [mapping];
+    expect(hookConfigBootViolation(config)).toBeNull();
+  });
+
+  it('treats a mapping with no explicit action as an agent mapping', () => {
+    const config = healthyHookConfig();
+    // action defaults to 'agent' in OpenClaw, so this one does require prefixes.
+    config.hooks.mappings = [{ id: 'x', sessionKey: '{{payload.sessionKey}}' }];
+    expect(hookConfigBootViolation(config)).toMatch(/allowedSessionKeyPrefixes is required/);
+  });
+
+  it('skips a templated mapping shadowed by an earlier catch-all', () => {
+    const config = healthyHookConfig();
+    config.hooks.mappings = [
+      // No matchPath/matchSource — shadows everything after it.
+      { id: 'catch-all', sessionKey: 'hook:fixed' },
+      { id: 'shadowed', sessionKey: '{{payload.sessionKey}}' },
+    ];
+    expect(hookConfigBootViolation(config)).toBeNull();
+  });
+
+  it('still flags a templated mapping that an earlier narrower mapping cannot shadow', () => {
+    const config = healthyHookConfig();
+    config.hooks.mappings = [
+      { id: 'narrow', match: { path: 'other' }, sessionKey: 'hook:fixed' },
+      { id: 'templated', match: { path: 'email' }, sessionKey: '{{payload.sessionKey}}' },
+    ];
+    expect(hookConfigBootViolation(config)).toMatch(/allowedSessionKeyPrefixes is required/);
+  });
+
+  // Parity with openclaw 2026.6.11's resolveHooksConfig, which rejects only a
+  // literal '/'. Its trailing-slash strip is greedy, so '//' reduces to '' and
+  // is accepted; blanks fall back to the default. Flagging these would reject
+  // configs the gateway starts from, so the accepted cases are pinned here to
+  // stop a well-meaning "all-slash paths are invalid" change.
+  it.each([
+    { path: '/', rejected: true },
+    { path: '//', rejected: false },
+    { path: '///', rejected: false },
+    { path: '   ', rejected: false },
+    { path: '/hooks', rejected: false },
+    { path: 'hooks', rejected: false },
+  ])('treats hooks.path $path as rejected=$rejected, matching OpenClaw', ({ path, rejected }) => {
+    const config = healthyHookConfig();
+    config.hooks.path = path;
+
+    const violation = hookConfigBootViolation(config);
+    if (rejected) {
+      expect(violation).toMatch(/hooks\.path may not be/);
+    } else {
+      expect(violation).toBeNull();
+    }
+  });
 });
 
 describe('ensureBootableHookConfig', () => {
@@ -2032,6 +2098,19 @@ describe('ensureBootableHookConfig', () => {
     ensureBootableHookConfig(config, {});
     expect(config.hooks.path).toBe('/hooks');
   });
+
+  // The repair must not touch paths OpenClaw accepts, or it would rewrite a
+  // working config on every gateway spawn.
+  it.each(['//', '///', '   ', '/hooks', 'hooks'])(
+    'leaves the OpenClaw-accepted path %j alone',
+    path => {
+      const config = healthyHookConfig();
+      config.hooks.path = path;
+
+      expect(ensureBootableHookConfig(config, {})).toEqual([]);
+      expect(config.hooks.path).toBe(path);
+    }
+  );
 
   it('keeps the operator defaultSessionKey by allowing it as its own prefix', () => {
     const config = healthyHookConfig();

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   backupConfigFile,
-  ensureHookSessionKeyPrefixes,
+  ensureBootableHookConfig,
   ensureInboundEmailHookFlags,
   generateBaseConfig,
-  hookSessionKeyPrefixViolation,
+  hookConfigBootViolation,
   repairPersistedHookInvariants,
   setNestedValue,
   writeBaseConfig,
@@ -1875,16 +1875,12 @@ describe('writeMcporterConfig', () => {
 
 /** Config shaped like the one that bricked a live instance: templated hook
  * sessionKey, `allowRequestSessionKey` set, but no prefix allow-list. */
-function bootBlockingConfig(): {
-  hooks: {
-    enabled: boolean;
-    token: string;
-    path: string;
-    allowRequestSessionKey: boolean;
-    allowedSessionKeyPrefixes?: unknown;
-    mappings: { id: string; action: string; sessionKey: string }[];
-  };
-} {
+// Mirrors the untyped shape of openclaw.json so cases can break one field at a
+// time without fighting inferred literal types.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ConfigLike = { hooks: Record<string, any> };
+
+function bootBlockingConfig(): ConfigLike {
   return {
     hooks: {
       enabled: true,
@@ -1902,67 +1898,179 @@ function bootBlockingConfig(): {
   };
 }
 
-describe('ensureHookSessionKeyPrefixes', () => {
-  it('adds the required prefixes when a mapping sessionKey is templated', () => {
-    const config = bootBlockingConfig();
-    expect(ensureHookSessionKeyPrefixes(config)).toBe(true);
-    expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['hook:', 'inbound-email:']);
+/** Builds a hooks block that is startable, so each case can break one thing. */
+function healthyHookConfig(): ConfigLike {
+  return {
+    hooks: {
+      enabled: true,
+      token: 'local-token',
+      path: '/hooks',
+      mappings: [{ id: 'static', action: 'agent', sessionKey: 'hook:fixed' }],
+    },
+  };
+}
+
+/**
+ * Every way OpenClaw's resolveHooksConfig refuses to start, keyed to the throw
+ * it mirrors. Used to drive both the detector and the repair.
+ */
+const BOOT_BLOCKING_CASES: { name: string; expect: RegExp; build: () => ConfigLike }[] = [
+  {
+    name: 'hooks.enabled with no token',
+    expect: /hooks\.enabled requires hooks\.token/,
+    build: () => {
+      const config = healthyHookConfig();
+      delete config.hooks.token;
+      return config;
+    },
+  },
+  {
+    name: "hooks.path of '/'",
+    expect: /hooks\.path may not be/,
+    build: () => {
+      const config = healthyHookConfig();
+      config.hooks.path = '/';
+      return config;
+    },
+  },
+  {
+    name: 'defaultSessionKey matching no configured prefix',
+    expect: /hooks\.defaultSessionKey must match/,
+    build: () => {
+      const config = healthyHookConfig();
+      config.hooks.defaultSessionKey = 'custom:abc';
+      config.hooks.allowedSessionKeyPrefixes = ['hook:'];
+      return config;
+    },
+  },
+  {
+    name: "prefixes without 'hook:' and no defaultSessionKey",
+    expect: /must include 'hook:'/,
+    build: () => {
+      const config = healthyHookConfig();
+      config.hooks.allowedSessionKeyPrefixes = ['inbound-email:'];
+      return config;
+    },
+  },
+  {
+    name: 'templated sessionKey with no prefixes',
+    expect: /hooks\.allowedSessionKeyPrefixes is required/,
+    build: bootBlockingConfig,
+  },
+];
+
+describe('hookConfigBootViolation', () => {
+  it.each(BOOT_BLOCKING_CASES)('reports $name', ({ build, expect: pattern }) => {
+    expect(hookConfigBootViolation(build())).toMatch(pattern);
   });
 
-  it('is idempotent', () => {
+  it('accepts a startable hook config', () => {
+    expect(hookConfigBootViolation(healthyHookConfig())).toBeNull();
+  });
+
+  it('treats a blank-only allow-list as absent, matching OpenClaw', () => {
     const config = bootBlockingConfig();
-    ensureHookSessionKeyPrefixes(config);
-    expect(ensureHookSessionKeyPrefixes(config)).toBe(false);
+    config.hooks.allowedSessionKeyPrefixes = ['   '];
+    expect(hookConfigBootViolation(config)).not.toBeNull();
+  });
+
+  it.each(BOOT_BLOCKING_CASES)('ignores $name when hooks are disabled', ({ build }) => {
+    const config = build();
+    config.hooks.enabled = false;
+    expect(hookConfigBootViolation(config)).toBeNull();
+  });
+
+  it('ignores configs with no hooks block', () => {
+    expect(hookConfigBootViolation({ gateway: { port: 3001 } })).toBeNull();
+  });
+});
+
+describe('ensureBootableHookConfig', () => {
+  // The property that matters: whatever the repair does, the result must be
+  // something OpenClaw will actually start from.
+  it.each(BOOT_BLOCKING_CASES)('repairs $name into a startable config', ({ build }) => {
+    const config = build();
+    const applied = ensureBootableHookConfig(config, { KILOCLAW_HOOKS_TOKEN: 'env-token' });
+
+    expect(applied.length).toBeGreaterThan(0);
+    expect(hookConfigBootViolation(config)).toBeNull();
+  });
+
+  it.each(BOOT_BLOCKING_CASES)('is idempotent for $name', ({ build }) => {
+    const config = build();
+    ensureBootableHookConfig(config, { KILOCLAW_HOOKS_TOKEN: 'env-token' });
+    expect(ensureBootableHookConfig(config, { KILOCLAW_HOOKS_TOKEN: 'env-token' })).toEqual([]);
+  });
+
+  it('restores a missing token from the environment', () => {
+    const config = healthyHookConfig();
+    delete config.hooks.token;
+
+    const applied = ensureBootableHookConfig(config, { KILOCLAW_HOOKS_TOKEN: 'env-token' });
+
+    expect(config.hooks.token).toBe('env-token');
+    expect(config.hooks.enabled).toBe(true);
+    expect(applied.join()).toMatch(/restored hooks\.token/);
+  });
+
+  it('disables hooks when no token exists anywhere, rather than leaving it unbootable', () => {
+    const config = healthyHookConfig();
+    delete config.hooks.token;
+
+    const applied = ensureBootableHookConfig(config, {});
+
+    // A disabled hook surface still boots; bootstrap re-enables it next start.
+    expect(config.hooks.enabled).toBe(false);
+    expect(applied.join()).toMatch(/disabled hooks/);
+    expect(hookConfigBootViolation(config)).toBeNull();
+  });
+
+  it("resets a '/' path to the default rather than guessing", () => {
+    const config = healthyHookConfig();
+    config.hooks.path = '/';
+
+    ensureBootableHookConfig(config, {});
+    expect(config.hooks.path).toBe('/hooks');
+  });
+
+  it('keeps the operator defaultSessionKey by allowing it as its own prefix', () => {
+    const config = healthyHookConfig();
+    config.hooks.defaultSessionKey = 'custom:abc';
+    config.hooks.allowedSessionKeyPrefixes = ['hook:'];
+
+    ensureBootableHookConfig(config, {});
+
+    expect(config.hooks.defaultSessionKey).toBe('custom:abc');
+    expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['hook:', 'custom:abc']);
+  });
+
+  it('adds the required prefixes when a mapping sessionKey is templated', () => {
+    const config = bootBlockingConfig();
+    expect(ensureBootableHookConfig(config, {})).not.toEqual([]);
     expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['hook:', 'inbound-email:']);
   });
 
   it('preserves operator-added prefixes while appending the required ones', () => {
     const config = bootBlockingConfig();
-    (config.hooks as Record<string, unknown>).allowedSessionKeyPrefixes = ['custom:'];
-    expect(ensureHookSessionKeyPrefixes(config)).toBe(true);
+    config.hooks.allowedSessionKeyPrefixes = ['custom:'];
+    expect(ensureBootableHookConfig(config, {})).not.toEqual([]);
     expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['custom:', 'hook:', 'inbound-email:']);
   });
 
-  it('leaves configs without a templated sessionKey untouched', () => {
-    const config = {
-      hooks: {
-        enabled: true,
-        mappings: [{ id: 'static', action: 'agent', sessionKey: 'hook:fixed' }],
-      },
-    };
-    expect(ensureHookSessionKeyPrefixes(config)).toBe(false);
+  it('leaves a startable config untouched', () => {
+    const config = healthyHookConfig();
+    expect(ensureBootableHookConfig(config, {})).toEqual([]);
     expect(config.hooks).not.toHaveProperty('allowedSessionKeyPrefixes');
   });
 
   it('ignores configs with no hooks block', () => {
-    const config: Record<string, unknown> = { gateway: { port: 3001 } };
-    expect(ensureHookSessionKeyPrefixes(config)).toBe(false);
-  });
-});
-
-describe('hookSessionKeyPrefixViolation', () => {
-  it('reports a config that would stop the gateway from starting', () => {
-    expect(hookSessionKeyPrefixViolation(bootBlockingConfig())).toMatch(
-      /hooks\.allowedSessionKeyPrefixes is required/
-    );
+    expect(ensureBootableHookConfig({ gateway: { port: 3001 } }, {})).toEqual([]);
   });
 
-  it('returns null once the prefixes are present', () => {
-    const config = bootBlockingConfig();
-    ensureHookSessionKeyPrefixes(config);
-    expect(hookSessionKeyPrefixViolation(config)).toBeNull();
-  });
-
-  it('treats a blank-only allow-list as missing', () => {
-    const config = bootBlockingConfig();
-    (config.hooks as Record<string, unknown>).allowedSessionKeyPrefixes = ['   '];
-    expect(hookSessionKeyPrefixViolation(config)).not.toBeNull();
-  });
-
-  it('returns null when hooks are disabled', () => {
+  it('leaves a disabled hook surface alone', () => {
     const config = bootBlockingConfig();
     config.hooks.enabled = false;
-    expect(hookSessionKeyPrefixViolation(config)).toBeNull();
+    expect(ensureBootableHookConfig(config, {})).toEqual([]);
   });
 });
 
@@ -1985,7 +2093,7 @@ describe('repairPersistedHookInvariants', () => {
 
   it('does not rewrite a config that is already valid', () => {
     const config = bootBlockingConfig();
-    ensureHookSessionKeyPrefixes(config);
+    ensureBootableHookConfig(config);
     const { deps, written } = fakeDeps(JSON.stringify(config));
 
     expect(repairPersistedHookInvariants('/root/.openclaw/openclaw.json', deps)).toBe(false);

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   backupConfigFile,
+  ensureHookSessionKeyPrefixes,
   ensureInboundEmailHookFlags,
   generateBaseConfig,
+  hookSessionKeyPrefixViolation,
+  repairPersistedHookInvariants,
   setNestedValue,
   writeBaseConfig,
   writeMcporterConfig,
@@ -1867,5 +1870,148 @@ describe('writeMcporterConfig', () => {
     const config = JSON.parse(written[0].data);
     // The header should contain the literal string ${LINEAR_API_KEY}, not the actual value
     expect(config.mcpServers.linear.headers.Authorization).toBe('Bearer ${LINEAR_API_KEY}');
+  });
+});
+
+/** Config shaped like the one that bricked a live instance: templated hook
+ * sessionKey, `allowRequestSessionKey` set, but no prefix allow-list. */
+function bootBlockingConfig(): {
+  hooks: {
+    enabled: boolean;
+    token: string;
+    path: string;
+    allowRequestSessionKey: boolean;
+    allowedSessionKeyPrefixes?: unknown;
+    mappings: { id: string; action: string; sessionKey: string }[];
+  };
+} {
+  return {
+    hooks: {
+      enabled: true,
+      token: 'local-token',
+      path: '/hooks',
+      allowRequestSessionKey: true,
+      mappings: [
+        {
+          id: 'cloudflare-email-inbound',
+          action: 'agent',
+          sessionKey: '{{payload.sessionKey}}',
+        },
+      ],
+    },
+  };
+}
+
+describe('ensureHookSessionKeyPrefixes', () => {
+  it('adds the required prefixes when a mapping sessionKey is templated', () => {
+    const config = bootBlockingConfig();
+    expect(ensureHookSessionKeyPrefixes(config)).toBe(true);
+    expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['hook:', 'inbound-email:']);
+  });
+
+  it('is idempotent', () => {
+    const config = bootBlockingConfig();
+    ensureHookSessionKeyPrefixes(config);
+    expect(ensureHookSessionKeyPrefixes(config)).toBe(false);
+    expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['hook:', 'inbound-email:']);
+  });
+
+  it('preserves operator-added prefixes while appending the required ones', () => {
+    const config = bootBlockingConfig();
+    (config.hooks as Record<string, unknown>).allowedSessionKeyPrefixes = ['custom:'];
+    expect(ensureHookSessionKeyPrefixes(config)).toBe(true);
+    expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['custom:', 'hook:', 'inbound-email:']);
+  });
+
+  it('leaves configs without a templated sessionKey untouched', () => {
+    const config = {
+      hooks: {
+        enabled: true,
+        mappings: [{ id: 'static', action: 'agent', sessionKey: 'hook:fixed' }],
+      },
+    };
+    expect(ensureHookSessionKeyPrefixes(config)).toBe(false);
+    expect(config.hooks).not.toHaveProperty('allowedSessionKeyPrefixes');
+  });
+
+  it('ignores configs with no hooks block', () => {
+    const config: Record<string, unknown> = { gateway: { port: 3001 } };
+    expect(ensureHookSessionKeyPrefixes(config)).toBe(false);
+  });
+});
+
+describe('hookSessionKeyPrefixViolation', () => {
+  it('reports a config that would stop the gateway from starting', () => {
+    expect(hookSessionKeyPrefixViolation(bootBlockingConfig())).toMatch(
+      /hooks\.allowedSessionKeyPrefixes is required/
+    );
+  });
+
+  it('returns null once the prefixes are present', () => {
+    const config = bootBlockingConfig();
+    ensureHookSessionKeyPrefixes(config);
+    expect(hookSessionKeyPrefixViolation(config)).toBeNull();
+  });
+
+  it('treats a blank-only allow-list as missing', () => {
+    const config = bootBlockingConfig();
+    (config.hooks as Record<string, unknown>).allowedSessionKeyPrefixes = ['   '];
+    expect(hookSessionKeyPrefixViolation(config)).not.toBeNull();
+  });
+
+  it('returns null when hooks are disabled', () => {
+    const config = bootBlockingConfig();
+    config.hooks.enabled = false;
+    expect(hookSessionKeyPrefixViolation(config)).toBeNull();
+  });
+});
+
+describe('repairPersistedHookInvariants', () => {
+  it('rewrites a bricking config and reports the repair', () => {
+    const { deps, written, renamed, chmodded } = fakeDeps(JSON.stringify(bootBlockingConfig()));
+
+    expect(repairPersistedHookInvariants('/root/.openclaw/openclaw.json', deps)).toBe(true);
+
+    expect(written).toHaveLength(1);
+    expect(JSON.parse(written[0].data).hooks.allowedSessionKeyPrefixes).toEqual([
+      'hook:',
+      'inbound-email:',
+    ]);
+    // Written to a temp path, tightened, then renamed over the live config.
+    expect(written[0].path).not.toBe('/root/.openclaw/openclaw.json');
+    expect(chmodded[0].mode).toBe(0o600);
+    expect(renamed[0].to).toBe('/root/.openclaw/openclaw.json');
+  });
+
+  it('does not rewrite a config that is already valid', () => {
+    const config = bootBlockingConfig();
+    ensureHookSessionKeyPrefixes(config);
+    const { deps, written } = fakeDeps(JSON.stringify(config));
+
+    expect(repairPersistedHookInvariants('/root/.openclaw/openclaw.json', deps)).toBe(false);
+    expect(written).toHaveLength(0);
+  });
+
+  it('returns false instead of throwing when the config is unreadable', () => {
+    const { deps, written } = fakeDeps('{ not json');
+
+    expect(repairPersistedHookInvariants('/root/.openclaw/openclaw.json', deps)).toBe(false);
+    expect(written).toHaveLength(0);
+  });
+
+  it('returns false when there is no config yet', () => {
+    const { deps } = fakeDeps();
+    expect(repairPersistedHookInvariants('/root/.openclaw/openclaw.json', deps)).toBe(false);
+  });
+
+  it('cleans up the temp file when the rename fails', () => {
+    const { deps, unlinked } = fakeDeps(JSON.stringify(bootBlockingConfig()));
+    deps.renameSync = vi.fn(() => {
+      throw new Error('EXDEV');
+    });
+
+    expect(repairPersistedHookInvariants('/root/.openclaw/openclaw.json', deps)).toBe(false);
+    expect(unlinked).toHaveLength(1);
+    expect(unlinked[0]).toContain('.kilorepair.');
   });
 });

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -2015,3 +2015,32 @@ describe('repairPersistedHookInvariants', () => {
     expect(unlinked[0]).toContain('.kilorepair.');
   });
 });
+
+describe('repairPersistedHookInvariants concurrency', () => {
+  it('abandons the repair when the config changed under it', () => {
+    const { deps, written, renamed, unlinked } = fakeDeps(JSON.stringify(bootBlockingConfig()));
+    let reads = 0;
+    deps.readFileSync = vi.fn(() => {
+      reads += 1;
+      // First read returns the bricking config; the re-read before rename
+      // simulates an admin write landing mid-repair.
+      return reads === 1
+        ? JSON.stringify(bootBlockingConfig())
+        : JSON.stringify({ hooks: { enabled: true, mappings: [], adminEdit: true } });
+    });
+
+    expect(repairPersistedHookInvariants('/root/.openclaw/openclaw.json', deps)).toBe(false);
+
+    // Staged, then discarded — the admin's write is left intact.
+    expect(written).toHaveLength(1);
+    expect(renamed).toHaveLength(0);
+    expect(unlinked).toHaveLength(1);
+  });
+
+  it('completes the repair when the config is untouched', () => {
+    const { deps, renamed } = fakeDeps(JSON.stringify(bootBlockingConfig()));
+
+    expect(repairPersistedHookInvariants('/root/.openclaw/openclaw.json', deps)).toBe(true);
+    expect(renamed).toHaveLength(1);
+  });
+});

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -234,6 +234,57 @@ const INBOUND_EMAIL_HOOK_MAPPING = {
   deliver: false,
 };
 
+const DEFAULT_HOOKS_PATH = '/hooks';
+
+const BOOT_BLOCKER_SUFFIX =
+  ' The OpenClaw gateway refuses to start in this state, and because restarts do not ' +
+  're-derive config, the instance cannot recover on its own.';
+
+/** Mirrors OpenClaw's `normalizeOptionalString`. */
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Mirrors OpenClaw's `hooks.path` normalization. Several inputs collapse to a
+ * bare '/', which OpenClaw rejects: '/', '//', and '   ' among them.
+ */
+function normalizeHookPath(value: unknown): string {
+  const raw = normalizeOptionalString(value) ?? DEFAULT_HOOKS_PATH;
+  const withSlash = raw.startsWith('/') ? raw : `/${raw}`;
+  return withSlash.length > 1 ? withSlash.replace(/\/+$/, '') : withSlash;
+}
+
+/**
+ * Mirrors OpenClaw's `resolveAllowedSessionKeyPrefixes`: entries are lowercased,
+ * blanks dropped, and an list with nothing usable resolves to undefined rather
+ * than an empty array. That undefined-vs-empty distinction is load-bearing —
+ * OpenClaw skips two of its checks entirely when prefixes are absent.
+ */
+function resolveAllowedPrefixes(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const resolved = new Set<string>();
+  for (const entry of value) {
+    const normalized = normalizeOptionalString(entry)?.toLowerCase();
+    if (normalized) {
+      resolved.add(normalized);
+    }
+  }
+  return resolved.size > 0 ? [...resolved] : undefined;
+}
+
+/** Mirrors OpenClaw's `isSessionKeyAllowedByPrefix`. */
+function isAllowedByPrefix(sessionKey: string, prefixes: string[]): boolean {
+  const normalized = sessionKey.trim().toLowerCase();
+  return normalized.length > 0 && prefixes.some(prefix => normalized.startsWith(prefix));
+}
+
 /** A hook mapping `sessionKey` that interpolates request data, e.g. `{{payload.sessionKey}}`. */
 function hasTemplatedSessionKey(mapping: unknown): boolean {
   if (typeof mapping !== 'object' || mapping === null) {
@@ -244,82 +295,152 @@ function hasTemplatedSessionKey(mapping: unknown): boolean {
 }
 
 /**
- * Guarantee `hooks.allowedSessionKeyPrefixes` whenever a hook mapping derives
- * its `sessionKey` from a template.
- *
- * OpenClaw's gateway (2026.6.11+) refuses to start when a templated mapping is
- * present without this allow-list — `hooks.allowRequestSessionKey: true` is NOT
- * sufficient. A config in that state fails at the `config.normalize` phase on
- * every start, and because the gateway supervisor only restarts the process (it
- * does not re-derive config), the instance crash-loops indefinitely.
- *
- * Deliberately keyed off the *persisted config* rather than the environment:
- * the mapping that trips the check lives in the config and outlives any single
- * boot, so the repair must not be gated on `KILOCLAW_HOOKS_TOKEN` (or any other
- * env var) being set on the boot that happens to observe it.
- *
- * Idempotent. Returns true when the config was modified.
- */
-export function ensureHookSessionKeyPrefixes(config: ConfigObject): boolean {
-  const hooks = config.hooks;
-  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) {
-    return false;
-  }
-  if (!Array.isArray(hooks.mappings) || !hooks.mappings.some(hasTemplatedSessionKey)) {
-    return false;
-  }
-
-  const existing: unknown = hooks.allowedSessionKeyPrefixes;
-  const prefixes: string[] = Array.isArray(existing)
-    ? existing.filter((value): value is string => typeof value === 'string')
-    : [];
-  const missing = [DEFAULT_HOOK_SESSION_KEY_PREFIX, INBOUND_EMAIL_SESSION_KEY_PREFIX].filter(
-    prefix => !prefixes.includes(prefix)
-  );
-
-  // Preserve any operator-added prefixes; only append what OpenClaw requires.
-  if (missing.length === 0 && Array.isArray(existing)) {
-    return false;
-  }
-  hooks.allowedSessionKeyPrefixes = [...prefixes, ...missing];
-  return true;
-}
-
-/**
  * Report why OpenClaw's gateway would refuse to start with this config, or null
  * when the hook config is startable.
  *
- * Pure counterpart to {@link ensureHookSessionKeyPrefixes}, for write paths that
- * must reject a bricking config rather than silently rewriting the caller's
- * content. Intentionally a local structural check rather than a shell out to
- * `openclaw config validate`: it runs on every write, and this specific failure
- * is unrecoverable without a manual reboot, so it is enforced even when the
+ * Mirrors every throw in OpenClaw's `resolveHooksConfig`, in the same order, so
+ * the message a caller gets matches the one that would otherwise only surface as
+ * a crash-loop. Kept as a local structural check rather than a shell out to
+ * `openclaw config validate`: it runs on every write, and these failures are
+ * unrecoverable without a manual reboot, so they are enforced even when the
  * caller opts out of advisory validation.
+ *
+ * Pure counterpart to {@link ensureBootableHookConfig}, for write paths that
+ * must reject a bricking config rather than silently rewriting the caller's
+ * content.
  */
-export function hookSessionKeyPrefixViolation(config: ConfigObject): string | null {
+export function hookConfigBootViolation(config: ConfigObject): string | null {
   const hooks = config.hooks;
   if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) {
     return null;
   }
-  if (hooks.enabled !== true || !Array.isArray(hooks.mappings)) {
+  // OpenClaw skips hook validation entirely when the surface is disabled.
+  if (hooks.enabled !== true) {
     return null;
   }
-  if (!hooks.mappings.some(hasTemplatedSessionKey)) {
-    return null;
+
+  if (!normalizeOptionalString(hooks.token)) {
+    return `hooks.enabled requires hooks.token.${BOOT_BLOCKER_SUFFIX}`;
   }
-  const prefixes: unknown = hooks.allowedSessionKeyPrefixes;
-  const hasPrefixes =
-    Array.isArray(prefixes) &&
-    prefixes.some(value => typeof value === 'string' && value.trim().length > 0);
-  if (hasPrefixes) {
-    return null;
+  if (normalizeHookPath(hooks.path) === '/') {
+    return `hooks.path may not be '/'.${BOOT_BLOCKER_SUFFIX}`;
   }
-  return (
-    'hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses ' +
-    'templates (for example "{{payload.sessionKey}}"). Without it the OpenClaw gateway ' +
-    'refuses to start and the instance cannot recover on its own. Add the prefixes your ' +
-    'mappings use, for example ["hook:", "inbound-email:"].'
-  );
+
+  const prefixes = resolveAllowedPrefixes(hooks.allowedSessionKeyPrefixes);
+  const defaultSessionKey = normalizeOptionalString(hooks.defaultSessionKey);
+
+  if (defaultSessionKey && prefixes && !isAllowedByPrefix(defaultSessionKey, prefixes)) {
+    return (
+      'hooks.defaultSessionKey must match hooks.allowedSessionKeyPrefixes ' +
+      `(defaultSessionKey "${defaultSessionKey}" matches none of them).${BOOT_BLOCKER_SUFFIX}`
+    );
+  }
+  if (!defaultSessionKey && prefixes && !isAllowedByPrefix('hook:example', prefixes)) {
+    return (
+      "hooks.allowedSessionKeyPrefixes must include 'hook:' when hooks.defaultSessionKey " +
+      `is unset.${BOOT_BLOCKER_SUFFIX}`
+    );
+  }
+  if (Array.isArray(hooks.mappings) && hooks.mappings.some(hasTemplatedSessionKey) && !prefixes) {
+    return (
+      'hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses ' +
+      'templates (for example "{{payload.sessionKey}}"), even with ' +
+      `hooks.allowRequestSessionKey enabled.${BOOT_BLOCKER_SUFFIX}`
+    );
+  }
+  return null;
+}
+
+/**
+ * Repair a hook config into a shape OpenClaw's gateway will start from.
+ *
+ * Deliberately keyed off the *persisted config* rather than the environment: the
+ * state that trips these checks lives in the config and outlives any single
+ * boot, so the repair must not be gated on `KILOCLAW_HOOKS_TOKEN` (or any other
+ * env var) being set on the boot that happens to observe it. The env is consulted
+ * only as a source for a token that is missing outright.
+ *
+ * Idempotent. Returns a description of each repair applied; empty when the
+ * config was already startable.
+ */
+export function ensureBootableHookConfig(
+  config: ConfigObject,
+  env: EnvLike = process.env
+): string[] {
+  const hooks = config.hooks;
+  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) {
+    return [];
+  }
+  if (hooks.enabled !== true) {
+    return [];
+  }
+
+  const applied: string[] = [];
+
+  if (!normalizeOptionalString(hooks.token)) {
+    const envToken = normalizeOptionalString(env.KILOCLAW_HOOKS_TOKEN);
+    if (envToken) {
+      hooks.token = envToken;
+      applied.push('restored hooks.token from the environment');
+    } else {
+      // Nothing can serve hooks without a token, and a disabled hook surface
+      // still boots. Bootstrap re-enables it with a fresh token on the next
+      // controller start, so this degrades inbound email rather than the agent.
+      hooks.enabled = false;
+      applied.push('disabled hooks (enabled with no token, and none in the environment)');
+      return applied;
+    }
+  }
+
+  if (normalizeHookPath(hooks.path) === '/') {
+    hooks.path = DEFAULT_HOOKS_PATH;
+    applied.push(`reset hooks.path to '${DEFAULT_HOOKS_PATH}'`);
+  }
+
+  const original: unknown = hooks.allowedSessionKeyPrefixes;
+  const prefixes: string[] = Array.isArray(original)
+    ? original.filter((value): value is string => typeof value === 'string')
+    : [];
+  const before = JSON.stringify(prefixes);
+  const defaultSessionKey = normalizeOptionalString(hooks.defaultSessionKey);
+  const hasTemplated = Array.isArray(hooks.mappings) && hooks.mappings.some(hasTemplatedSessionKey);
+
+  // Preserve any operator-added prefixes; only append what is missing.
+  //
+  // Both defaults go in whenever a templated mapping exists, not just when the
+  // allow-list is empty: booting is necessary but not sufficient. Hook dispatch
+  // checks the incoming session key against this same list, so omitting
+  // 'inbound-email:' because some unrelated operator prefix happened to satisfy
+  // the boot check would start the gateway and then reject every inbound email.
+  if (hasTemplated) {
+    for (const required of [DEFAULT_HOOK_SESSION_KEY_PREFIX, INBOUND_EMAIL_SESSION_KEY_PREFIX]) {
+      if (!prefixes.some(prefix => prefix.trim().toLowerCase() === required)) {
+        prefixes.push(required);
+      }
+    }
+  }
+
+  // Only meaningful once prefixes exist: OpenClaw skips both of these checks
+  // when the allow-list resolves to undefined.
+  const effective = resolveAllowedPrefixes(prefixes);
+  if (effective) {
+    if (defaultSessionKey) {
+      if (!isAllowedByPrefix(defaultSessionKey, effective)) {
+        // A key always satisfies itself as a prefix — the least invasive repair
+        // that keeps the operator's chosen defaultSessionKey intact.
+        prefixes.push(defaultSessionKey);
+      }
+    } else if (!isAllowedByPrefix('hook:example', effective)) {
+      prefixes.push(DEFAULT_HOOK_SESSION_KEY_PREFIX);
+    }
+  }
+
+  if (JSON.stringify(prefixes) !== before) {
+    hooks.allowedSessionKeyPrefixes = prefixes;
+    applied.push('added the session-key prefixes OpenClaw requires');
+  }
+
+  return applied;
 }
 
 type ExecFileOptions = { env?: NodeJS.ProcessEnv; stdio?: 'inherit' | 'pipe' };
@@ -752,10 +873,10 @@ export function generateBaseConfig(
   }
 
   // Runs outside the KILOCLAW_HOOKS_TOKEN branch on purpose: a config that
-  // already carries a templated hook mapping (from an earlier boot, a restored
-  // backup, or a hand-edit) must get the prefixes that OpenClaw requires even
-  // on a boot where the branch above is skipped. See the function's comment.
-  ensureHookSessionKeyPrefixes(config);
+  // already carries hook state (from an earlier boot, a restored backup, or a
+  // hand-edit) must be brought into a bootable shape even on a boot where the
+  // branch above is skipped. See the function's comment.
+  ensureBootableHookConfig(config, env);
 
   // Vector memory configuration — configures OpenClaw's builtin memory search
   // to use the Kilo Gateway embeddings endpoint via the OpenAI-compatible adapter.
@@ -977,16 +1098,17 @@ export function backupConfigFile(
  *
  * Called before every gateway spawn so a config that would refuse to boot is
  * repaired instead of crash-looping. `generateBaseConfig` only runs during
- * bootstrap, so without this any writer that drops the prefixes — a restored
- * backup, a hand-edit, a whole-file API write — bricks the instance until
- * someone reboots it by hand.
+ * bootstrap, so without this any writer that leaves the hook config unbootable —
+ * a restored backup, a hand-edit, a whole-file API write — bricks the instance
+ * until someone reboots it by hand.
  *
  * Best-effort by contract: returns false and never throws, because a repair
  * failure must not be the reason the gateway does not start.
  */
 export function repairPersistedHookInvariants(
   configPath = DEFAULT_CONFIG_PATH,
-  deps: ConfigWriterDeps = defaultDeps
+  deps: ConfigWriterDeps = defaultDeps,
+  env: EnvLike = process.env
 ): boolean {
   try {
     if (!deps.existsSync(configPath)) {
@@ -999,7 +1121,8 @@ export function repairPersistedHookInvariants(
     }
 
     const config = parsed as ConfigObject;
-    if (!ensureHookSessionKeyPrefixes(config)) {
+    const applied = ensureBootableHookConfig(config, env);
+    if (applied.length === 0) {
       return false;
     }
 
@@ -1033,8 +1156,7 @@ export function repairPersistedHookInvariants(
     }
 
     console.warn(
-      '[controller] Repaired hooks.allowedSessionKeyPrefixes before gateway start ' +
-        '(config had a templated hook sessionKey without the required prefix allow-list)'
+      `[controller] Repaired unbootable hook config before gateway start: ${applied.join('; ')}`
     );
     return true;
   } catch (error) {

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -234,6 +234,94 @@ const INBOUND_EMAIL_HOOK_MAPPING = {
   deliver: false,
 };
 
+/** A hook mapping `sessionKey` that interpolates request data, e.g. `{{payload.sessionKey}}`. */
+function hasTemplatedSessionKey(mapping: unknown): boolean {
+  if (typeof mapping !== 'object' || mapping === null) {
+    return false;
+  }
+  const sessionKey = (mapping as ConfigObject).sessionKey;
+  return typeof sessionKey === 'string' && sessionKey.includes('{{');
+}
+
+/**
+ * Guarantee `hooks.allowedSessionKeyPrefixes` whenever a hook mapping derives
+ * its `sessionKey` from a template.
+ *
+ * OpenClaw's gateway (2026.6.11+) refuses to start when a templated mapping is
+ * present without this allow-list — `hooks.allowRequestSessionKey: true` is NOT
+ * sufficient. A config in that state fails at the `config.normalize` phase on
+ * every start, and because the gateway supervisor only restarts the process (it
+ * does not re-derive config), the instance crash-loops indefinitely.
+ *
+ * Deliberately keyed off the *persisted config* rather than the environment:
+ * the mapping that trips the check lives in the config and outlives any single
+ * boot, so the repair must not be gated on `KILOCLAW_HOOKS_TOKEN` (or any other
+ * env var) being set on the boot that happens to observe it.
+ *
+ * Idempotent. Returns true when the config was modified.
+ */
+export function ensureHookSessionKeyPrefixes(config: ConfigObject): boolean {
+  const hooks = config.hooks;
+  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) {
+    return false;
+  }
+  if (!Array.isArray(hooks.mappings) || !hooks.mappings.some(hasTemplatedSessionKey)) {
+    return false;
+  }
+
+  const existing: unknown = hooks.allowedSessionKeyPrefixes;
+  const prefixes: string[] = Array.isArray(existing)
+    ? existing.filter((value): value is string => typeof value === 'string')
+    : [];
+  const missing = [DEFAULT_HOOK_SESSION_KEY_PREFIX, INBOUND_EMAIL_SESSION_KEY_PREFIX].filter(
+    prefix => !prefixes.includes(prefix)
+  );
+
+  // Preserve any operator-added prefixes; only append what OpenClaw requires.
+  if (missing.length === 0 && Array.isArray(existing)) {
+    return false;
+  }
+  hooks.allowedSessionKeyPrefixes = [...prefixes, ...missing];
+  return true;
+}
+
+/**
+ * Report why OpenClaw's gateway would refuse to start with this config, or null
+ * when the hook config is startable.
+ *
+ * Pure counterpart to {@link ensureHookSessionKeyPrefixes}, for write paths that
+ * must reject a bricking config rather than silently rewriting the caller's
+ * content. Intentionally a local structural check rather than a shell out to
+ * `openclaw config validate`: it runs on every write, and this specific failure
+ * is unrecoverable without a manual reboot, so it is enforced even when the
+ * caller opts out of advisory validation.
+ */
+export function hookSessionKeyPrefixViolation(config: ConfigObject): string | null {
+  const hooks = config.hooks;
+  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) {
+    return null;
+  }
+  if (hooks.enabled !== true || !Array.isArray(hooks.mappings)) {
+    return null;
+  }
+  if (!hooks.mappings.some(hasTemplatedSessionKey)) {
+    return null;
+  }
+  const prefixes: unknown = hooks.allowedSessionKeyPrefixes;
+  const hasPrefixes =
+    Array.isArray(prefixes) &&
+    prefixes.some(value => typeof value === 'string' && value.trim().length > 0);
+  if (hasPrefixes) {
+    return null;
+  }
+  return (
+    'hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses ' +
+    'templates (for example "{{payload.sessionKey}}"). Without it the OpenClaw gateway ' +
+    'refuses to start and the instance cannot recover on its own. Add the prefixes your ' +
+    'mappings use, for example ["hook:", "inbound-email:"].'
+  );
+}
+
 type ExecFileOptions = { env?: NodeJS.ProcessEnv; stdio?: 'inherit' | 'pipe' };
 
 export type ConfigWriterDeps = {
@@ -638,23 +726,6 @@ export function generateBaseConfig(
     config.hooks.token = env.KILOCLAW_HOOKS_TOKEN;
     config.hooks.path = '/hooks';
     ensureInboundEmailHookFlags(config);
-    config.hooks.allowedSessionKeyPrefixes = Array.isArray(config.hooks.allowedSessionKeyPrefixes)
-      ? config.hooks.allowedSessionKeyPrefixes
-      : [];
-    if (
-      !(config.hooks.allowedSessionKeyPrefixes as string[]).includes(
-        DEFAULT_HOOK_SESSION_KEY_PREFIX
-      )
-    ) {
-      (config.hooks.allowedSessionKeyPrefixes as string[]).push(DEFAULT_HOOK_SESSION_KEY_PREFIX);
-    }
-    if (
-      !(config.hooks.allowedSessionKeyPrefixes as string[]).includes(
-        INBOUND_EMAIL_SESSION_KEY_PREFIX
-      )
-    ) {
-      (config.hooks.allowedSessionKeyPrefixes as string[]).push(INBOUND_EMAIL_SESSION_KEY_PREFIX);
-    }
 
     config.hooks.mappings = Array.isArray(config.hooks.mappings)
       ? config.hooks.mappings.map((mapping: ConfigObject) => migrateHookMapping(mapping))
@@ -679,6 +750,12 @@ export function generateBaseConfig(
     }
     console.log('Hooks enabled with inbound email mapping (dedicated token)');
   }
+
+  // Runs outside the KILOCLAW_HOOKS_TOKEN branch on purpose: a config that
+  // already carries a templated hook mapping (from an earlier boot, a restored
+  // backup, or a hand-edit) must get the prefixes that OpenClaw requires even
+  // on a boot where the branch above is skipped. See the function's comment.
+  ensureHookSessionKeyPrefixes(config);
 
   // Vector memory configuration — configures OpenClaw's builtin memory search
   // to use the Kilo Gateway embeddings endpoint via the OpenAI-compatible adapter.
@@ -893,6 +970,69 @@ export function backupConfigFile(
   }
 
   pruneOldConfigBackups(dir, base, deps);
+}
+
+/**
+ * Re-apply controller-managed hook invariants to the persisted config.
+ *
+ * Called before every gateway spawn so a config that would refuse to boot is
+ * repaired instead of crash-looping. `generateBaseConfig` only runs during
+ * bootstrap, so without this any writer that drops the prefixes — a restored
+ * backup, a hand-edit, a whole-file API write — bricks the instance until
+ * someone reboots it by hand.
+ *
+ * Best-effort by contract: returns false and never throws, because a repair
+ * failure must not be the reason the gateway does not start.
+ */
+export function repairPersistedHookInvariants(
+  configPath = DEFAULT_CONFIG_PATH,
+  deps: ConfigWriterDeps = defaultDeps
+): boolean {
+  try {
+    if (!deps.existsSync(configPath)) {
+      return false;
+    }
+    const raw = deps.readFileSync(configPath, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return false;
+    }
+
+    const config = parsed as ConfigObject;
+    if (!ensureHookSessionKeyPrefixes(config)) {
+      return false;
+    }
+
+    // Reuse the onboard temp-file convention so a crash mid-write leaves the
+    // live config untouched rather than truncated.
+    const dir = path.dirname(configPath);
+    const base = path.basename(configPath);
+    const tmpPath = path.join(dir, `.${base}.kilorepair.${crypto.randomBytes(6).toString('hex')}`);
+    try {
+      deps.writeFileSync(tmpPath, JSON.stringify(config, null, 2));
+      deps.chmodSync(tmpPath, 0o600);
+      deps.renameSync(tmpPath, configPath);
+    } catch (error) {
+      try {
+        deps.unlinkSync(tmpPath);
+      } catch {
+        // Temp file may not exist; nothing to clean up.
+      }
+      throw error;
+    }
+
+    console.warn(
+      '[controller] Repaired hooks.allowedSessionKeyPrefixes before gateway start ' +
+        '(config had a templated hook sessionKey without the required prefix allow-list)'
+    );
+    return true;
+  } catch (error) {
+    console.error(
+      '[controller] Failed to repair hook invariants, starting gateway anyway:',
+      error instanceof Error ? error.message : String(error)
+    );
+    return false;
+  }
 }
 
 /**

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -250,8 +250,21 @@ function normalizeOptionalString(value: unknown): string | undefined {
 }
 
 /**
- * Mirrors OpenClaw's `hooks.path` normalization. Several inputs collapse to a
- * bare '/', which OpenClaw rejects: '/', '//', and '   ' among them.
+ * Mirrors OpenClaw's `hooks.path` normalization, including its quirks.
+ *
+ * Only a literal '/' is rejected by OpenClaw. It is tempting to assume every
+ * all-slash path is, but the trailing-slash strip is greedy, so '//' and '///'
+ * reduce to '' rather than '/' and pass the check; blank strings fall back to
+ * the default. Verified against openclaw 2026.6.11:
+ *
+ *   '/'   -> '/'       (rejected)
+ *   '//'  -> ''        (accepted)
+ *   '///' -> ''        (accepted)
+ *   '   ' -> '/hooks'  (accepted)
+ *
+ * Do not "fix" the empty-string result into '/': that would reject configs
+ * OpenClaw accepts, and make the repair rewrite a working path on every spawn.
+ * Parity with the gateway is the point — see the normalizeHookPath tests.
  */
 function normalizeHookPath(value: unknown): string {
   const raw = normalizeOptionalString(value) ?? DEFAULT_HOOKS_PATH;
@@ -285,13 +298,62 @@ function isAllowedByPrefix(sessionKey: string, prefixes: string[]): boolean {
   return normalized.length > 0 && prefixes.some(prefix => normalized.startsWith(prefix));
 }
 
-/** A hook mapping `sessionKey` that interpolates request data, e.g. `{{payload.sessionKey}}`. */
-function hasTemplatedSessionKey(mapping: unknown): boolean {
-  if (typeof mapping !== 'object' || mapping === null) {
+/** Mirrors OpenClaw's `hasHookTemplateExpressions`: a complete, non-empty `{{ … }}`. */
+const HOOK_TEMPLATE_EXPRESSION = /\{\{\s*[^}]+\s*\}\}/;
+
+/** Mirrors OpenClaw's `normalizeMatchPath`. */
+function normalizeMatchPath(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed ? trimmed.replace(/^\/+/, '').replace(/\/+$/, '') : undefined;
+}
+
+/**
+ * Mirrors OpenClaw's `hasEffectiveTemplatedHookSessionKeyMapping`.
+ *
+ * Three details are load-bearing, and getting any of them wrong makes this
+ * broader than the gateway — which would reject configs OpenClaw starts from:
+ *  - only `action: 'agent'` mappings count, and `action` defaults to 'agent'
+ *  - the template must be a complete `{{ … }}`; a bare '{{' or '{{}}' is literal
+ *  - mappings shadowed by an earlier, broader mapping are skipped entirely
+ */
+function hasEffectiveTemplatedSessionKey(mappings: unknown): boolean {
+  if (!Array.isArray(mappings)) {
     return false;
   }
-  const sessionKey = (mapping as ConfigObject).sessionKey;
-  return typeof sessionKey === 'string' && sessionKey.includes('{{');
+  const effective: { matchPath?: string; matchSource?: string }[] = [];
+  for (const entry of mappings) {
+    if (typeof entry !== 'object' || entry === null) {
+      continue;
+    }
+    const mapping = entry as ConfigObject;
+    const matchPath = normalizeMatchPath(mapping.match?.path);
+    const matchSource =
+      typeof mapping.match?.source === 'string' ? mapping.match.source.trim() : undefined;
+
+    const shadowed = effective.some(earlier => {
+      if (earlier.matchPath && earlier.matchPath !== matchPath) {
+        return false;
+      }
+      return !earlier.matchSource || earlier.matchSource === matchSource;
+    });
+    if (shadowed) {
+      continue;
+    }
+    effective.push({ matchPath, matchSource });
+
+    const action = mapping.action ?? 'agent';
+    if (
+      action === 'agent' &&
+      typeof mapping.sessionKey === 'string' &&
+      HOOK_TEMPLATE_EXPRESSION.test(mapping.sessionKey)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -341,7 +403,7 @@ export function hookConfigBootViolation(config: ConfigObject): string | null {
       `is unset.${BOOT_BLOCKER_SUFFIX}`
     );
   }
-  if (Array.isArray(hooks.mappings) && hooks.mappings.some(hasTemplatedSessionKey) && !prefixes) {
+  if (hasEffectiveTemplatedSessionKey(hooks.mappings) && !prefixes) {
     return (
       'hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses ' +
       'templates (for example "{{payload.sessionKey}}"), even with ' +
@@ -403,7 +465,7 @@ export function ensureBootableHookConfig(
     : [];
   const before = JSON.stringify(prefixes);
   const defaultSessionKey = normalizeOptionalString(hooks.defaultSessionKey);
-  const hasTemplated = Array.isArray(hooks.mappings) && hooks.mappings.some(hasTemplatedSessionKey);
+  const hasTemplated = hasEffectiveTemplatedSessionKey(hooks.mappings);
 
   // Preserve any operator-added prefixes; only append what is missing.
   //

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -1011,6 +1011,17 @@ export function repairPersistedHookInvariants(
     try {
       deps.writeFileSync(tmpPath, JSON.stringify(config, null, 2));
       deps.chmodSync(tmpPath, 0o600);
+
+      // Optimistic concurrency: this writer runs unattended on every gateway
+      // spawn, so unlike the human-initiated edit routes it must not be the one
+      // that silently reverts a concurrent admin write. If the file moved since
+      // the read above, drop the repair — the next spawn re-reads and retries.
+      if (deps.readFileSync(configPath, 'utf8') !== raw) {
+        deps.unlinkSync(tmpPath);
+        console.warn('[controller] Config changed during hook invariant repair, skipping write');
+        return false;
+      }
+
       deps.renameSync(tmpPath, configPath);
     } catch (error) {
       try {

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -298,8 +298,22 @@ function isAllowedByPrefix(sessionKey: string, prefixes: string[]): boolean {
   return normalized.length > 0 && prefixes.some(prefix => normalized.startsWith(prefix));
 }
 
-/** Mirrors OpenClaw's `hasHookTemplateExpressions`: a complete, non-empty `{{ … }}`. */
-const HOOK_TEMPLATE_EXPRESSION = /\{\{\s*[^}]+\s*\}\}/;
+/**
+ * Mirrors OpenClaw's `hasHookTemplateExpressions`: a complete, non-empty `{{ … }}`.
+ *
+ * Upstream writes this as `/\{\{\s*[^}]+\s*\}\}/`, which accepts exactly the same
+ * strings — `\s` is a subset of `[^}]`, so the `\s*` groups are redundant — but
+ * that redundancy makes them ambiguous with `[^}]+`, and the engine explores
+ * exponentially many splits before failing on a `{{` that never closes.
+ * `{{` + 3000 spaces takes ~6s upstream and ~0.1ms here.
+ *
+ * That matters more for us than for the gateway: this runs on the controller's
+ * event loop on every gateway spawn, against whatever is already on disk, so one
+ * crafted sessionKey would stall every restart. Simplified rather than bounded
+ * so parity is exact — verified identical over templated, empty, whitespace-only,
+ * and unterminated inputs.
+ */
+const HOOK_TEMPLATE_EXPRESSION = /\{\{[^}]+\}\}/;
 
 /** Mirrors OpenClaw's `normalizeMatchPath`. */
 function normalizeMatchPath(raw: unknown): string | undefined {

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from './proxy';
 import { createSupervisor } from './supervisor';
 import type { Supervisor } from './supervisor';
+import { repairPersistedHookInvariants } from './config-writer';
 import { registerHealthRoute, startKiloChatHealthProbe } from './routes/health';
 import type { KiloChatHealthProbe } from './routes/health';
 import { registerGatewayRoutes } from './routes/gateway';
@@ -375,6 +376,12 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
   supervisor = createSupervisor({
     args: ['gateway', ...config.gatewayArgs],
     onStdoutLine: line => pc.onPairingLogLine(line),
+    // Self-heal on every attempt, not just the first: a config that OpenClaw
+    // refuses to boot would otherwise crash-loop forever, since restarts do
+    // not re-run bootstrap's config generation.
+    beforeSpawn: () => {
+      repairPersistedHookInvariants();
+    },
   });
 
   let googleAccountEmail: string | null = null;

--- a/services/kiloclaw/controller/src/routes/config.test.ts
+++ b/services/kiloclaw/controller/src/routes/config.test.ts
@@ -227,6 +227,55 @@ describe('/_kilo/config/patch routes', () => {
     expect(written.gateway.port).toBe(3001);
   });
 
+  it('rejects a patch that would stop the gateway from starting', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, createMockSupervisor(), 'test-token');
+
+    // Healthy config: hooks enabled, no templated sessionKey.
+    readMock.mockReturnValue(JSON.stringify({ hooks: { enabled: true, mappings: [] } }));
+
+    const resp = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify({
+        hooks: { mappings: [{ id: 'x', sessionKey: '{{payload.sessionKey}}' }] },
+      }),
+      headers: authHeaders(),
+    });
+
+    expect(resp.status).toBe(422);
+    expect((await resp.json()) as { code: string }).toMatchObject({
+      code: 'openclaw_config_would_not_boot',
+    });
+    expect(atomicWriteMock).not.toHaveBeenCalled();
+  });
+
+  it('allows an unrelated patch on an already-broken config and heals it', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, createMockSupervisor(), 'test-token');
+
+    // Already in the bricking state before this patch touches anything.
+    readMock.mockReturnValue(
+      JSON.stringify({
+        hooks: {
+          enabled: true,
+          mappings: [{ id: 'cloudflare-email-inbound', sessionKey: '{{payload.sessionKey}}' }],
+        },
+      })
+    );
+
+    const resp = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify({ gateway: { port: 3001 } }),
+      headers: authHeaders(),
+    });
+
+    // Must not lock the caller out of repairing an instance that is already down.
+    expect(resp.status).toBe(200);
+    const written = JSON.parse(atomicWriteMock.mock.calls[0][1] as string);
+    expect(written.gateway.port).toBe(3001);
+    expect(written.hooks.allowedSessionKeyPrefixes).toEqual(['hook:', 'inbound-email:']);
+  });
+
   it('rejects non-object body', async () => {
     const app = new Hono();
     registerConfigRoutes(app, createMockSupervisor(), 'test-token');

--- a/services/kiloclaw/controller/src/routes/config.test.ts
+++ b/services/kiloclaw/controller/src/routes/config.test.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono';
 import { registerConfigRoutes } from './config';
 import type { Supervisor } from '../supervisor';
 
-// Keep the real hookSessionKeyPrefixViolation: it is pure, and the replace
+// Keep the real hookConfigBootViolation: it is pure, and the replace
 // route depends on it to reject configs the gateway could not boot.
 vi.mock('../config-writer', async importOriginal => {
   const actual = await importOriginal<typeof import('../config-writer')>();
@@ -232,7 +232,9 @@ describe('/_kilo/config/patch routes', () => {
     registerConfigRoutes(app, createMockSupervisor(), 'test-token');
 
     // Healthy config: hooks enabled, no templated sessionKey.
-    readMock.mockReturnValue(JSON.stringify({ hooks: { enabled: true, mappings: [] } }));
+    readMock.mockReturnValue(
+      JSON.stringify({ hooks: { enabled: true, token: 'local-token', mappings: [] } })
+    );
 
     const resp = await app.request('/_kilo/config/patch', {
       method: 'POST',
@@ -258,6 +260,7 @@ describe('/_kilo/config/patch routes', () => {
       JSON.stringify({
         hooks: {
           enabled: true,
+          token: 'local-token',
           mappings: [{ id: 'cloudflare-email-inbound', sessionKey: '{{payload.sessionKey}}' }],
         },
       })

--- a/services/kiloclaw/controller/src/routes/config.test.ts
+++ b/services/kiloclaw/controller/src/routes/config.test.ts
@@ -3,10 +3,16 @@ import { Hono } from 'hono';
 import { registerConfigRoutes } from './config';
 import type { Supervisor } from '../supervisor';
 
-vi.mock('../config-writer', () => ({
-  backupConfigFile: vi.fn(),
-  writeBaseConfig: vi.fn(),
-}));
+// Keep the real hookSessionKeyPrefixViolation: it is pure, and the replace
+// route depends on it to reject configs the gateway could not boot.
+vi.mock('../config-writer', async importOriginal => {
+  const actual = await importOriginal<typeof import('../config-writer')>();
+  return {
+    ...actual,
+    backupConfigFile: vi.fn(),
+    writeBaseConfig: vi.fn(),
+  };
+});
 
 vi.mock('../bootstrap', async importOriginal => {
   const actual = await importOriginal<typeof import('../bootstrap')>();
@@ -609,6 +615,34 @@ describe('/_kilo/config/replace routes', () => {
             expect(mock).toHaveBeenCalledOnce();
             const written = JSON.parse(mock.mock.calls[0][1] as string);
             expect(written).toEqual(newConfig);
+          },
+        },
+      },
+    });
+  });
+
+  it('refuses a config the gateway could not boot, without writing or backing up', async () => {
+    const bricking = {
+      hooks: {
+        enabled: true,
+        mappings: [{ id: 'cloudflare-email-inbound', sessionKey: '{{payload.sessionKey}}' }],
+      },
+    };
+
+    await test({
+      route: '/_kilo/config/replace',
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({ config: bricking }),
+      expect: {
+        status: 422,
+        mocks: {
+          // The live config must be left exactly as it was.
+          backup: mock => {
+            expect(mock).not.toHaveBeenCalled();
+          },
+          write: mock => {
+            expect(mock).not.toHaveBeenCalled();
           },
         },
       },

--- a/services/kiloclaw/controller/src/routes/config.ts
+++ b/services/kiloclaw/controller/src/routes/config.ts
@@ -7,8 +7,8 @@ import { timingSafeTokenEqual } from '../auth';
 import type { Supervisor } from '../supervisor';
 import {
   backupConfigFile,
-  ensureHookSessionKeyPrefixes,
-  hookSessionKeyPrefixViolation,
+  ensureBootableHookConfig,
+  hookConfigBootViolation,
   writeBaseConfig,
 } from '../config-writer';
 import { GOG_SECTION_CONFIG, seedExecApprovalsDefaults, updateToolsMdSection } from '../bootstrap';
@@ -170,7 +170,7 @@ export function registerConfigRoutes(
 
       // Same guard as the raw-file editor: never persist a config that stops
       // the gateway from starting, since the instance cannot recover on its own.
-      const bootBlocker = hookSessionKeyPrefixViolation(config);
+      const bootBlocker = hookConfigBootViolation(config);
       if (bootBlocker) {
         return c.json({ code: 'openclaw_config_would_not_boot', error: bootBlocker }, 422);
       }
@@ -213,9 +213,9 @@ export function registerConfigRoutes(
       // Compared before and after the merge on purpose. Rejecting on the
       // post-merge state alone would lock an already-broken instance out of
       // every unrelated patch — including the patch used to repair it.
-      const violationBefore = hookSessionKeyPrefixViolation(config);
+      const violationBefore = hookConfigBootViolation(config);
       deepMerge(config, patch as Record<string, unknown>);
-      const violationAfter = hookSessionKeyPrefixViolation(config);
+      const violationAfter = hookConfigBootViolation(config);
 
       if (violationAfter && !violationBefore) {
         return c.json({ code: 'openclaw_config_would_not_boot', error: violationAfter }, 422);
@@ -223,7 +223,7 @@ export function registerConfigRoutes(
       if (violationAfter) {
         // Already broken before this patch: heal it rather than persisting a
         // config we know the gateway cannot start from.
-        ensureHookSessionKeyPrefixes(config);
+        ensureBootableHookConfig(config);
       }
 
       // Sync exec-approvals.json BEFORE writing openclaw.json so the host

--- a/services/kiloclaw/controller/src/routes/config.ts
+++ b/services/kiloclaw/controller/src/routes/config.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { atomicWrite } from '../atomic-write';
 import { timingSafeTokenEqual } from '../auth';
 import type { Supervisor } from '../supervisor';
-import { backupConfigFile, writeBaseConfig } from '../config-writer';
+import { backupConfigFile, hookSessionKeyPrefixViolation, writeBaseConfig } from '../config-writer';
 import { GOG_SECTION_CONFIG, seedExecApprovalsDefaults, updateToolsMdSection } from '../bootstrap';
 import { getBearerToken } from './gateway';
 import { registerAgentConfigRoutes } from './config-agents';
@@ -161,6 +161,13 @@ export function registerConfigRoutes(
             409
           );
         }
+      }
+
+      // Same guard as the raw-file editor: never persist a config that stops
+      // the gateway from starting, since the instance cannot recover on its own.
+      const bootBlocker = hookSessionKeyPrefixViolation(config);
+      if (bootBlocker) {
+        return c.json({ code: 'openclaw_config_would_not_boot', error: bootBlocker }, 422);
       }
 
       backupConfigFile(CONFIG_PATH);

--- a/services/kiloclaw/controller/src/routes/config.ts
+++ b/services/kiloclaw/controller/src/routes/config.ts
@@ -5,7 +5,12 @@ import { z } from 'zod';
 import { atomicWrite } from '../atomic-write';
 import { timingSafeTokenEqual } from '../auth';
 import type { Supervisor } from '../supervisor';
-import { backupConfigFile, hookSessionKeyPrefixViolation, writeBaseConfig } from '../config-writer';
+import {
+  backupConfigFile,
+  ensureHookSessionKeyPrefixes,
+  hookSessionKeyPrefixViolation,
+  writeBaseConfig,
+} from '../config-writer';
 import { GOG_SECTION_CONFIG, seedExecApprovalsDefaults, updateToolsMdSection } from '../bootstrap';
 import { getBearerToken } from './gateway';
 import { registerAgentConfigRoutes } from './config-agents';
@@ -205,7 +210,21 @@ export function registerConfigRoutes(
     try {
       const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
       const config = JSON.parse(raw);
+      // Compared before and after the merge on purpose. Rejecting on the
+      // post-merge state alone would lock an already-broken instance out of
+      // every unrelated patch — including the patch used to repair it.
+      const violationBefore = hookSessionKeyPrefixViolation(config);
       deepMerge(config, patch as Record<string, unknown>);
+      const violationAfter = hookSessionKeyPrefixViolation(config);
+
+      if (violationAfter && !violationBefore) {
+        return c.json({ code: 'openclaw_config_would_not_boot', error: violationAfter }, 422);
+      }
+      if (violationAfter) {
+        // Already broken before this patch: heal it rather than persisting a
+        // config we know the gateway cannot start from.
+        ensureHookSessionKeyPrefixes(config);
+      }
 
       // Sync exec-approvals.json BEFORE writing openclaw.json so the host
       // layer is already correct when the gateway's file watcher triggers a

--- a/services/kiloclaw/controller/src/routes/files.test.ts
+++ b/services/kiloclaw/controller/src/routes/files.test.ts
@@ -437,6 +437,7 @@ describe('file routes', () => {
     const BRICKING_CONFIG = JSON.stringify({
       hooks: {
         enabled: true,
+        token: 'local-token',
         mappings: [{ id: 'cloudflare-email-inbound', sessionKey: '{{payload.sessionKey}}' }],
       },
     });
@@ -477,6 +478,7 @@ describe('file routes', () => {
       const repaired = JSON.stringify({
         hooks: {
           enabled: true,
+          token: 'local-token',
           allowedSessionKeyPrefixes: ['hook:', 'inbound-email:'],
           mappings: [{ id: 'cloudflare-email-inbound', sessionKey: '{{payload.sessionKey}}' }],
         },

--- a/services/kiloclaw/controller/src/routes/files.test.ts
+++ b/services/kiloclaw/controller/src/routes/files.test.ts
@@ -431,6 +431,67 @@ describe('file routes', () => {
       );
     });
 
+    // A templated hook sessionKey without hooks.allowedSessionKeyPrefixes stops
+    // the OpenClaw gateway from starting, and the instance cannot recover on its
+    // own — so this is rejected even when the caller opts out of validation.
+    const BRICKING_CONFIG = JSON.stringify({
+      hooks: {
+        enabled: true,
+        mappings: [{ id: 'cloudflare-email-inbound', sessionKey: '{{payload.sessionKey}}' }],
+      },
+    });
+
+    it.each(['warn-before-write', 'allow-invalid'] as const)(
+      'refuses a config that would not boot in %s mode',
+      async mode => {
+        vi.mocked(fs.existsSync).mockReturnValue(true);
+        vi.mocked(fs.lstatSync).mockReturnValue({
+          isSymbolicLink: () => false,
+          isFile: () => true,
+        } as any);
+        vi.mocked(fs.readFileSync).mockReturnValue('old config');
+
+        const res = await app.request('/_kilo/files/write-openclaw-config', {
+          method: 'POST',
+          headers: authHeaders(),
+          body: JSON.stringify({ content: BRICKING_CONFIG, mode }),
+        });
+
+        expect(res.status).toBe(422);
+        const body = (await res.json()) as { code: string; error: string };
+        expect(body.code).toBe('openclaw_config_would_not_boot');
+        expect(body.error).toMatch(/allowedSessionKeyPrefixes/);
+        expect(atomicWrite).not.toHaveBeenCalled();
+      }
+    );
+
+    it('accepts the same config once the required prefixes are present', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        isSymbolicLink: () => false,
+        isFile: () => true,
+      } as any);
+      vi.mocked(fs.readFileSync).mockReturnValue('old config');
+      vi.mocked(validateOpenclawConfigCandidate).mockResolvedValue({ valid: true });
+
+      const repaired = JSON.stringify({
+        hooks: {
+          enabled: true,
+          allowedSessionKeyPrefixes: ['hook:', 'inbound-email:'],
+          mappings: [{ id: 'cloudflare-email-inbound', sessionKey: '{{payload.sessionKey}}' }],
+        },
+      });
+
+      const res = await app.request('/_kilo/files/write-openclaw-config', {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({ content: repaired, mode: 'warn-before-write' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(atomicWrite).toHaveBeenCalled();
+    });
+
     it('serializes legacy openclaw writes through in-root aliases behind validation-aware writes', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.lstatSync).mockReturnValue({

--- a/services/kiloclaw/controller/src/routes/files.ts
+++ b/services/kiloclaw/controller/src/routes/files.ts
@@ -23,7 +23,24 @@ import {
 } from '../openclaw-export';
 import { getBearerToken } from './gateway';
 import { timingSafeTokenEqual } from '../auth';
-import { hookSessionKeyPrefixViolation } from '../config-writer';
+import { hookConfigBootViolation } from '../config-writer';
+import { resolveSafePath, verifyCanonicalized, SafePathError } from '../safe-path';
+import { atomicWrite } from '../atomic-write';
+import { backupFile } from '../backup-file';
+import { serializeAgentConfigMutation } from '../openclaw-agent-config';
+import {
+  isOpenclawValidationArtifactPath,
+  validateOpenclawConfigCandidate,
+} from '../openclaw-config-validation';
+import {
+  ensureWeatherSkillInstalled,
+  formatBotIdentityMarkdown,
+  formatUserProfileMarkdown,
+  removeUserMdLocation,
+  removeUserMdTimezone,
+  setUserMdLocation,
+  setUserMdTimezone,
+} from '../bootstrap';
 
 /**
  * Returns a human-readable reason when persisting `content` would leave the
@@ -42,25 +59,8 @@ function describeBootBlockingConfig(content: string): string | null {
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
     return null;
   }
-  return hookSessionKeyPrefixViolation(parsed as Record<string, unknown>);
+  return hookConfigBootViolation(parsed as Record<string, unknown>);
 }
-import { resolveSafePath, verifyCanonicalized, SafePathError } from '../safe-path';
-import { atomicWrite } from '../atomic-write';
-import { backupFile } from '../backup-file';
-import { serializeAgentConfigMutation } from '../openclaw-agent-config';
-import {
-  isOpenclawValidationArtifactPath,
-  validateOpenclawConfigCandidate,
-} from '../openclaw-config-validation';
-import {
-  ensureWeatherSkillInstalled,
-  formatBotIdentityMarkdown,
-  formatUserProfileMarkdown,
-  removeUserMdLocation,
-  removeUserMdTimezone,
-  setUserMdLocation,
-  setUserMdTimezone,
-} from '../bootstrap';
 
 const OpenclawWorkspaceImportFileSchema = z.object({
   path: z.string().min(1),

--- a/services/kiloclaw/controller/src/routes/files.ts
+++ b/services/kiloclaw/controller/src/routes/files.ts
@@ -23,6 +23,27 @@ import {
 } from '../openclaw-export';
 import { getBearerToken } from './gateway';
 import { timingSafeTokenEqual } from '../auth';
+import { hookSessionKeyPrefixViolation } from '../config-writer';
+
+/**
+ * Returns a human-readable reason when persisting `content` would leave the
+ * OpenClaw gateway unable to start, or null when it is safe to write.
+ *
+ * Unparseable or non-object content is deferred to the existing validation
+ * flow, which reports malformed JSON with better context than this check.
+ */
+function describeBootBlockingConfig(content: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  return hookSessionKeyPrefixViolation(parsed as Record<string, unknown>);
+}
 import { resolveSafePath, verifyCanonicalized, SafePathError } from '../safe-path';
 import { atomicWrite } from '../atomic-write';
 import { backupFile } from '../backup-file';
@@ -1038,6 +1059,21 @@ export function registerFileRoutes(app: Hono, expectedToken: string, rootDir: st
             409
           );
         }
+        // Enforced for every mode, including 'allow-invalid': the override
+        // exists so operators can persist configs OpenClaw merely dislikes, but
+        // this particular shape prevents the gateway from starting at all and
+        // leaves no way back in short of a manual reboot.
+        const bootBlocker = describeBootBlockingConfig(body.content);
+        if (bootBlocker) {
+          return c.json(
+            {
+              code: 'openclaw_config_would_not_boot',
+              error: bootBlocker,
+            },
+            422
+          );
+        }
+
         if (body.mode === 'warn-before-write') {
           const validation = await validateOpenclawConfigCandidate(body.content, result);
           if (!validation.valid) {

--- a/services/kiloclaw/controller/src/supervisor.test.ts
+++ b/services/kiloclaw/controller/src/supervisor.test.ts
@@ -436,3 +436,77 @@ describe('onStdoutLine callback', () => {
     expect(supervisor.getState()).toBe('running');
   });
 });
+
+describe('createSupervisor beforeSpawn', () => {
+  /** beforeSpawn is awaited, so a restart needs an extra turn to reach spawn. */
+  async function settle(): Promise<void> {
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve();
+    }
+  }
+
+  it('runs before every spawn, including crash restarts', async () => {
+    const { spawnImpl, children } = createSpawnHarness();
+    const beforeSpawn = vi.fn();
+    const supervisor = createSupervisor({
+      args: ['gateway'],
+      spawnImpl: spawnImpl as never,
+      backoffInitialMs: 1_000,
+      beforeSpawn,
+    });
+
+    await supervisor.start();
+    await settle();
+    expect(beforeSpawn).toHaveBeenCalledTimes(1);
+
+    // A crash-looping gateway must re-run the hook each attempt, otherwise a
+    // config it refuses to boot can never be repaired without a manual reboot.
+    children[0].emit('exit', 1, null);
+    vi.advanceTimersByTime(1_000);
+    await settle();
+
+    expect(beforeSpawn).toHaveBeenCalledTimes(2);
+    expect(spawnImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs the hook before spawning, not after', async () => {
+    const order: string[] = [];
+    const { children } = createSpawnHarness();
+    const spawnImpl = vi.fn(() => {
+      order.push('spawn');
+      const child = new FakeChildProcess(1);
+      children.push(child);
+      queueMicrotask(() => child.emit('spawn'));
+      return child as never;
+    });
+    const supervisor = createSupervisor({
+      args: ['gateway'],
+      spawnImpl: spawnImpl as never,
+      beforeSpawn: () => {
+        order.push('repair');
+      },
+    });
+
+    await supervisor.start();
+    await settle();
+
+    expect(order).toEqual(['repair', 'spawn']);
+  });
+
+  it('still spawns when the hook throws', async () => {
+    const { spawnImpl } = createSpawnHarness();
+    const supervisor = createSupervisor({
+      args: ['gateway'],
+      spawnImpl: spawnImpl as never,
+      beforeSpawn: () => {
+        throw new Error('repair exploded');
+      },
+    });
+
+    await supervisor.start();
+    await settle();
+
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+    expect(supervisor.getStats().state).not.toBe('stopped');
+  });
+});

--- a/services/kiloclaw/controller/src/supervisor.ts
+++ b/services/kiloclaw/controller/src/supervisor.ts
@@ -56,6 +56,12 @@ type SupervisorOptions = {
   setTimeoutImpl?: typeof setTimeout;
   clearTimeoutImpl?: typeof clearTimeout;
   onStdoutLine?: (line: string) => void;
+  /**
+   * Runs immediately before every spawn, including restarts. Use for
+   * self-healing work that must happen on each attempt rather than once at
+   * bootstrap. Failures are logged and ignored so the spawn still proceeds.
+   */
+  beforeSpawn?: () => void | Promise<void>;
 };
 
 export function createSupervisor(options: SupervisorOptions): Supervisor {
@@ -72,6 +78,7 @@ export function createSupervisor(options: SupervisorOptions): Supervisor {
     setTimeoutImpl = setTimeout,
     clearTimeoutImpl = clearTimeout,
     onStdoutLine,
+    beforeSpawn,
   } = options;
 
   let state: SupervisorState = 'stopped';
@@ -182,6 +189,22 @@ export function createSupervisor(options: SupervisorOptions): Supervisor {
 
     state = 'starting';
     stopRequested = false;
+
+    if (beforeSpawn) {
+      try {
+        await beforeSpawn();
+      } catch (error) {
+        console.error(
+          '[supervisor] beforeSpawn hook failed, spawning anyway:',
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+      // The hook yields to the event loop, so re-check the flags it may have
+      // raced with; shutdown/stop must win over a spawn that is now stale.
+      if (child || shuttingDown || manualStop) {
+        return;
+      }
+    }
 
     const spawned = spawnImpl(command, args, {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/services/kiloclaw/scripts/tests/README.md
+++ b/services/kiloclaw/scripts/tests/README.md
@@ -20,8 +20,26 @@ It runs a preflight (Docker, bump branch, clean tree, grype, credential) then:
 | Script | What it checks | Key? |
 |---|---|---|
 | `openclaw-upgrade-validate.sh` | **entry point** — orchestrates the two below | — |
-| `openclaw-upgrade-image-checks.sh` | the built image: version, bundle patches, plugin pins, config schema, grype CVE scan | no |
-| `openclaw-upgrade-smoke.sh` | the live upgrade: baseline → candidate on the same `/root`, plus a real gateway turn | yes |
+| `openclaw-upgrade-image-checks.sh` | the built image: version, bundle patches, plugin pins, config schema, hook boot-validation parity, grype CVE scan | no |
+| `openclaw-upgrade-smoke.sh` | the live upgrade: baseline → candidate on the same `/root`, plus a real gateway turn and hook config self-heal | yes |
+
+### Hook boot-validation parity
+
+`openclaw-upgrade-image-checks.sh` asserts that the set of conditions OpenClaw
+refuses to start the gateway on — the `throw`s in its `resolveHooksConfig` — is
+exactly the set the controller mirrors in `hookConfigBootViolation` /
+`ensureBootableHookConfig` (`controller/src/config-writer.ts`).
+
+This exists because nothing else catches drift here. Those failures are raised
+at **gateway startup**, so neither `openclaw config validate` (schema-only) nor
+`openclaw doctor` sees them, and a config that trips one crash-loops the
+instance with no self-recovery. If OpenClaw adds or rewords a condition, this
+check fails on the bump PR with a diff; update the mirror **and its tests**,
+then update the expected list in the script.
+
+The live smoke covers the other half: `assert_hook_config_self_heal` plants an
+unbootable config in the persisted root, restarts the gateway, and asserts the
+controller repaired it and came back up rather than crash-looping.
 
 Notes: run from a **clean committed bump branch** (the validator refuses a dirty
 tree; `ALLOW_DIRTY_TREE=true` runs but can't report a clean result). `grype` is

--- a/services/kiloclaw/scripts/tests/openclaw-upgrade-image-checks.sh
+++ b/services/kiloclaw/scripts/tests/openclaw-upgrade-image-checks.sh
@@ -288,6 +288,49 @@ validate_fixture "validator still rejects a malformed config (self-check)" \
   '{"agents":{"defaults":{"model":{"primary":123}}}}' \
   "invalid"
 
+# ── Hook boot-validation parity (drift guard) ────────────────────────────────
+# The controller mirrors OpenClaw's resolveHooksConfig so it can (a) refuse
+# writes that would leave the gateway unable to start and (b) repair a persisted
+# config before each spawn — see hookConfigBootViolation / ensureBootableHookConfig
+# in controller/src/config-writer.ts.
+#
+# That mirror is duplicated logic against a fast-moving upstream, and nothing
+# else catches drift: these failures are thrown at gateway startup, NOT by
+# `config validate` (schema-only) or `doctor`. A config that trips one of them
+# crash-loops the instance with no self-recovery, which is how this class of bug
+# reached production in the first place.
+#
+# So assert the packaged conditions are exactly the set the controller mirrors.
+# A new or reworded condition fails here, on the bump PR, rather than silently
+# leaving the mirror incomplete. Verified identical on 2026.6.11 and 2026.7.2.
+#
+# If this fails: update the mirror in config-writer.ts (detector AND repair) and
+# its tests, then update the expected list below.
+HOOK_CONDITION_PATTERN="hooks\.[A-Za-z]+ (is required|requires|must match|must include|may not be)[^\"]*"
+EXPECTED_HOOK_CONDITIONS="hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates, even if hooks.allowRequestSessionKey=true
+hooks.allowedSessionKeyPrefixes must include 'hook:' when hooks.defaultSessionKey is unset
+hooks.defaultSessionKey must match hooks.allowedSessionKeyPrefixes
+hooks.enabled requires hooks.token
+hooks.path may not be '/'"
+
+actual_hook_conditions=$(docker run --rm "$IMAGE" sh -c \
+  "grep -rhoE \"$HOOK_CONDITION_PATTERN\" /usr/local/lib/node_modules/openclaw/dist/ | sort -u" 2>/dev/null || echo "")
+
+expected_hook_count=$(printf '%s\n' "$EXPECTED_HOOK_CONDITIONS" | wc -l | tr -d ' ')
+actual_hook_count=$(printf '%s\n' "$actual_hook_conditions" | grep -c . || echo 0)
+check "hook boot-validation condition count" "$expected_hook_count" "$actual_hook_count"
+
+if [ "$actual_hook_conditions" = "$EXPECTED_HOOK_CONDITIONS" ]; then
+  echo "PASS: hook boot-validation conditions match the controller mirror"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: hook boot-validation conditions drifted from the controller mirror"
+  echo "      controller/src/config-writer.ts must be updated to match. Diff:"
+  diff <(printf '%s\n' "$EXPECTED_HOOK_CONDITIONS") <(printf '%s\n' "$actual_hook_conditions") \
+    | sed 's/^/      /' || true
+  FAIL=$((FAIL + 1))
+fi
+
 # ── Keyless plugin-load resolution (doctor, no gateway) ──────────────────────
 # Regression guard for the class of bug where the controller writes a
 # plugins.load.paths entry that the bundled openclaw does not ship — e.g. the

--- a/services/kiloclaw/scripts/tests/openclaw-upgrade-image-checks.sh
+++ b/services/kiloclaw/scripts/tests/openclaw-upgrade-image-checks.sh
@@ -304,23 +304,49 @@ validate_fixture "validator still rejects a malformed config (self-check)" \
 # A new or reworded condition fails here, on the bump PR, rather than silently
 # leaving the mirror incomplete. Verified identical on 2026.6.11 and 2026.7.2.
 #
+# Matches on the throw SITES (`throw new Error("hooks.…"`) rather than on the
+# wording of each message. Matching wording would silently pass when upstream
+# adds a condition phrased in a way the pattern does not recognise — the pattern
+# extracts nothing for it, so nothing differs from the expected list, so the
+# guard reports PASS while the mirror is already behind. Anchoring on the throw
+# site means any new hooks.* condition changes the extracted set no matter how it
+# is worded. Extraction returning nothing fails loudly for the same reason.
+#
+# Single-quoted, and passed into the container by environment rather than
+# interpolated into a nested `sh -c` string: the pattern contains a double quote,
+# which would otherwise unbalance the inner command and make it a syntax error
+# that `|| echo ""` silently turns into "no conditions found".
+#
 # If this fails: update the mirror in config-writer.ts (detector AND repair) and
 # its tests, then update the expected list below.
-HOOK_CONDITION_PATTERN="hooks\.[A-Za-z]+ (is required|requires|must match|must include|may not be)[^\"]*"
+HOOK_THROW_PATTERN='throw new Error\("hooks\.[^"]*"'
 EXPECTED_HOOK_CONDITIONS="hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates, even if hooks.allowRequestSessionKey=true
 hooks.allowedSessionKeyPrefixes must include 'hook:' when hooks.defaultSessionKey is unset
 hooks.defaultSessionKey must match hooks.allowedSessionKeyPrefixes
 hooks.enabled requires hooks.token
 hooks.path may not be '/'"
 
-actual_hook_conditions=$(docker run --rm "$IMAGE" sh -c \
-  "grep -rhoE \"$HOOK_CONDITION_PATTERN\" /usr/local/lib/node_modules/openclaw/dist/ | sort -u" 2>/dev/null || echo "")
+actual_hook_conditions=$(docker run --rm \
+  -e HOOK_THROW_PATTERN="$HOOK_THROW_PATTERN" \
+  "$IMAGE" sh -c \
+  'grep -rhoE "$HOOK_THROW_PATTERN" /usr/local/lib/node_modules/openclaw/dist/ | sed "s/^throw new Error(\"//; s/\"$//" | sort -u' \
+  2>/dev/null || echo "")
 
 expected_hook_count=$(printf '%s\n' "$EXPECTED_HOOK_CONDITIONS" | wc -l | tr -d ' ')
-actual_hook_count=$(printf '%s\n' "$actual_hook_conditions" | grep -c . || echo 0)
+# `|| true`, not `|| echo 0`: grep -c already prints 0 when nothing matches, and
+# exits 1 while doing so, so the echo would append a second line and make the
+# count "0\n0" — which compares unequal to "0" and defeats the guard below.
+actual_hook_count=$(printf '%s\n' "$actual_hook_conditions" | grep -c . || true)
 check "hook boot-validation condition count" "$expected_hook_count" "$actual_hook_count"
 
-if [ "$actual_hook_conditions" = "$EXPECTED_HOOK_CONDITIONS" ]; then
+# Distinguish "extraction broke" from "upstream changed a condition": a zero
+# count means the grep found no throw sites at all, which is a bug in this check
+# (or a minifier change), not evidence that OpenClaw dropped hook validation.
+if [ "$actual_hook_count" = "0" ]; then
+  echo "FAIL: extracted no hook conditions from the image — this check is broken, not upstream"
+  echo "      verify: docker run --rm $IMAGE sh -c 'ls /usr/local/lib/node_modules/openclaw/dist/ | head'"
+  FAIL=$((FAIL + 1))
+elif [ "$actual_hook_conditions" = "$EXPECTED_HOOK_CONDITIONS" ]; then
   echo "PASS: hook boot-validation conditions match the controller mirror"
   PASS=$((PASS + 1))
 else

--- a/services/kiloclaw/scripts/tests/smoke-helpers.sh
+++ b/services/kiloclaw/scripts/tests/smoke-helpers.sh
@@ -425,3 +425,76 @@ PY
     echo "  details: $details"
   fi
 }
+
+# Prove the controller repairs a config the gateway cannot start from, in a real
+# container, before every spawn.
+#
+# This is the end-to-end counterpart to the unit tests for
+# ensureBootableHookConfig and the supervisor beforeSpawn hook: those cover the
+# pieces, only this covers the wiring. It is the regression guard for the
+# incident where a persisted config lost hooks.allowedSessionKeyPrefixes and the
+# instance crash-looped indefinitely, since gateway restarts do not re-run
+# bootstrap's config generation.
+#
+# Deliberately writes the broken config with `docker exec` rather than through a
+# config route: the routes now reject this shape, and the point is to simulate a
+# config that reached disk some other way (restored backup, hand-edit, or an
+# older controller) — which is exactly how the original incident happened.
+assert_hook_config_self_heal() {
+  local cid="$1"
+  local port="$2"
+  local token="$3"
+  local broken
+  local repaired
+  local code
+
+  echo
+  echo "--- hook config self-heal (gateway restart repairs an unbootable config) ---"
+
+  # Strip the prefixes while leaving the templated inbound-email mapping: the
+  # exact shape that bricked a production instance.
+  broken=$(docker exec -i "$cid" python3 - <<'PY' 2>&1
+import json, pathlib
+path = pathlib.Path('/root/.openclaw/openclaw.json')
+doc = json.loads(path.read_text())
+hooks = doc.setdefault('hooks', {})
+hooks['enabled'] = True
+hooks.setdefault('token', 'smoke-hooks-token')
+hooks.pop('allowedSessionKeyPrefixes', None)
+hooks['mappings'] = [{
+    'id': 'cloudflare-email-inbound',
+    'match': {'path': 'email'},
+    'action': 'agent',
+    'sessionKey': '{{payload.sessionKey}}',
+}]
+path.write_text(json.dumps(doc, indent=2))
+print('broken')
+PY
+  )
+  if [ "$broken" != "broken" ]; then
+    check "planted unbootable hook config" "broken" "$broken"
+    return
+  fi
+  check "planted unbootable hook config" "broken" "$broken"
+
+  # supervisor.restart() runs the beforeSpawn repair on the way back up.
+  code=$(curl -sS -o /dev/null -w "%{http_code}" \
+    -X POST \
+    -H "Authorization: Bearer $token" \
+    "http://127.0.0.1:${port}/_kilo/gateway/restart" 2>/dev/null || true)
+  check "gateway restart accepted -> 200" "200" "$code"
+
+  # The repair must have landed on disk...
+  repaired=$(docker exec -i "$cid" python3 - <<'PY' 2>&1
+import json, pathlib
+doc = json.loads(pathlib.Path('/root/.openclaw/openclaw.json').read_text())
+prefixes = (doc.get('hooks') or {}).get('allowedSessionKeyPrefixes')
+print('repaired' if isinstance(prefixes, list) and 'inbound-email:' in prefixes else f'not-repaired: {prefixes!r}')
+PY
+  )
+  check "controller restored allowedSessionKeyPrefixes" "repaired" "$repaired"
+
+  # ...and the gateway must actually be serving, not crash-looping.
+  wait_for_ready "self-heal restart"
+  assert_gateway_status
+}

--- a/services/kiloclaw/scripts/tests/smoke-live-provider.sh
+++ b/services/kiloclaw/scripts/tests/smoke-live-provider.sh
@@ -474,6 +474,11 @@ run_phase() {
     # Candidate only: prove the removed #4054 catalog-refresh workaround is no
     # longer needed — native discovery must supply kilocode image capability.
     assert_kilocode_vision_capability
+    # Candidate only, and last of the config mutations: plants a config the
+    # gateway cannot start from and proves the restart repairs it instead of
+    # crash-looping. Leaves the config valid, so the live turn below still runs
+    # against a working gateway — which doubles as proof the repair is sound.
+    assert_hook_config_self_heal "$CID" "$PORT" "$TOKEN"
   fi
   assert_exec_approvals_seeded "$CID"
   assert_github_gh_auth


### PR DESCRIPTION
## Summary

OpenClaw 2026.6.11 will not start the gateway when a hook mapping's `sessionKey`
uses a template and `hooks.allowedSessionKeyPrefixes` is absent. KiloClaw writes
those prefixes in one place, `generateBaseConfig`, which runs during bootstrap.
Gateway restarts do not re-derive config, so if a persisted config did not carry
them, a restart on its own would not put them back. The check runs at gateway
startup, so `openclaw config validate` (schema only) and `openclaw doctor` do not
surface it.

Two layers of fix, plus drift protection for future OpenClaw bumps.

**Self-heal.** `supervisor.ts` gains a `beforeSpawn` hook that runs inside
`spawnProcess()`, the single path every start and restart goes through. The
gateway supervisor uses it to call `repairPersistedHookInvariants`, so the
prefixes are restored on the next start rather than only at bootstrap. The repair
keys off the persisted config rather than the environment, since the config state
it checks outlives any single boot.

**Write guards.** `/_kilo/files/write-openclaw-config`, `/_kilo/config/replace`
and `/_kilo/config/patch` now reject a config the gateway would not start from,
returning 422 `openclaw_config_would_not_boot`. The raw config editor refuses the
save rather than silently rewriting what the user typed. `config/patch` rejects
only when the patch introduces the problem, so a config that already has it is not
locked out of unrelated patches, or of the patch used to correct it.

Both sides mirror all five conditions in OpenClaw's `resolveHooksConfig`, not just
the missing-prefix one: a missing token, a `/` path, a `defaultSessionKey` that
matches no prefix, an allow-list without `hook:`, and a templated `sessionKey`
with no prefixes.

**Drift protection.** `openclaw-upgrade-image-checks.sh` asserts that the set of
conditions in the candidate image's packaged OpenClaw is exactly the set the
controller mirrors, so a new or reworded condition shows up on the bump PR instead
of leaving the mirror quietly behind. The live smoke gains
`assert_hook_config_self_heal`, which plants a config the gateway will not start
from, restarts the gateway, and asserts the controller restored the prefixes and
the gateway came back up. That covers the wiring between the repair and the
supervisor, which unit tests cannot reach.

## Verification

- [x] Reproduced against a running instance where the gateway was not starting,
      confirmed from its stability bundles
- [x] Added the missing prefixes there and confirmed the gateway started and
      stayed up
- [x] Confirmed `openclaw doctor --fix` leaves the config byte identical (md5
      unchanged), ruling it out as the writer and confirming it does not catch
      this
- [x] Ran the drift guard's extraction against the real packaged OpenClaw dist
      (2026.6.11) and got exactly the five expected conditions
- [x] Drove the drift guard block verbatim with a stubbed `docker` across three
      cases: current version passes, an added condition fails with a diff, and an
      empty extraction reports the check itself as broken rather than as drift
- [x] Measured the template regex on `{{` plus 3000 spaces: 6146 ms before,
      0.1 ms after, with identical match results across 12 inputs
- [x] Checked OpenClaw 2026.7.2 source: `resolveHooksConfig` has the same five
      conditions, so the mirror is already correct for that upgrade
- [ ] Not run: `openclaw-upgrade-image-checks.sh` and the live smoke end to end
      against a built image. Both need Docker and a Kilo API key, and OpenClaw is
      never built in CI. Worth one real run on the 2026.7.x bump branch

## Visual Changes

N/A

## Reviewer Notes

- The repair disables hooks when `hooks.enabled` is true but no token exists
  anywhere, since hooks cannot serve without one. Bootstrap re-enables it with a
  fresh token on the next controller start.
- `repairPersistedHookInvariants` runs unattended on every spawn, so it re-reads
  the config immediately before renaming over it and abandons the repair if it
  changed. It should never be the thing that reverts a concurrent admin write.
- Template detection mirrors OpenClaw's regex semantics exactly rather than
  tightening them. OpenClaw treats a whitespace-only interior (`{{ }}`) as
  templated, so rejecting it would mean skipping configs the gateway will not
  start from. The pattern is simplified to an equivalent unambiguous form because
  the original backtracks exponentially, and it runs on the controller event loop
  on every spawn against on-disk config.
- The drift guard anchors on throw sites rather than message wording. A condition
  phrased unexpectedly would otherwise extract nothing, differ from nothing, and
  report a pass while the mirror was already behind.
- The controller changes take effect when a machine picks up a new controller
  image.
