### PR TITLE
fix(cloud-agent): settle chat after interrupted message

### DIFF
--- a/apps/web/src/components/cloud-agent-next/ChatInput.tsx
+++ b/apps/web/src/components/cloud-agent-next/ChatInput.tsx
@@ -618,7 +618,7 @@ export function ChatInput({
               variant="destructive"
               size="icon"
               onClick={handleStop}
-              disabled={!onStop}
+              disabled={disabled || !onStop}
               className="relative h-8 w-8 rounded-lg before:absolute before:-inset-1.5"
               aria-label="Stop response"
             >

--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -110,6 +110,7 @@ StaticMessages.displayName = 'StaticMessages';
 // ---------------------------------------------------------------------------
 type DynamicMessagesProps = {
   active: boolean;
+  isStreaming: boolean;
   messages: StoredMessage[];
   pendingMessages: ReadonlyMap<string, MessageDeliveryState>;
   preparationByMessageId: ReadonlyMap<string, readonly PreparationAttempt[]>;
@@ -120,6 +121,7 @@ type DynamicMessagesProps = {
 
 const DynamicMessages = memo(
   function DynamicMessages({
+    isStreaming,
     messages,
     pendingMessages,
     preparationByMessageId,
@@ -130,7 +132,7 @@ const DynamicMessages = memo(
     return (
       <>
         {messages.map(msg => {
-          const streaming = isMessageStreaming(msg);
+          const streaming = isStreaming && isMessageStreaming(msg);
           return (
             <MessageErrorBoundary key={msg.info.id}>
               <MessageBubble
@@ -158,6 +160,7 @@ const DynamicMessages = memo(
 
     return (
       previous.active === next.active &&
+      previous.isStreaming === next.isStreaming &&
       previous.messages === next.messages &&
       previous.pendingMessages === next.pendingMessages &&
       previous.preparationByMessageId === next.preparationByMessageId &&
@@ -877,6 +880,7 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                             />
                             <DynamicMessages
                               active={chatTabActive}
+                              isStreaming={isStreaming}
                               messages={dynamicMessages}
                               pendingMessages={pendingMessages}
                               preparationByMessageId={preparationByMessageId}

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
@@ -1666,10 +1666,11 @@ describe('createServiceState', () => {
       expect(state.getPendingMessages().has('m1')).toBe(false);
     });
 
-    it('cloud.message.failed with reason=interrupted clears pending entry', () => {
+    it('cloud.message.failed with reason=interrupted settles the session', () => {
       const state = createServiceState(makeConfig());
 
       state.process({ type: 'cloud.message.queued', messageId: 'm1' });
+      state.process({ type: 'session.status', sessionId: 'root-1', status: { type: 'busy' } });
       state.process({
         type: 'cloud.message.failed',
         messageId: 'm1',
@@ -1678,6 +1679,8 @@ describe('createServiceState', () => {
       });
 
       expect(state.getPendingMessages().has('m1')).toBe(false);
+      expect(state.getActivity()).toEqual({ type: 'idle' });
+      expect(state.getStatus()).toEqual({ type: 'interrupted' });
     });
 
     it('cloud.message.failed with reason=execution clears pending entry', () => {

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.ts
@@ -554,6 +554,13 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
       attempts: event.attempts,
     };
     pendingMessages.delete(event.messageId);
+    if (event.reason === 'interrupted') {
+      activity = { type: 'idle' };
+      status = { type: 'interrupted' };
+      terminated = true;
+      disconnectedSource = null;
+      completed = false;
+    }
     config.onMessageFailed?.(event.messageId, deliveryState);
     notify();
   }

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -3332,7 +3332,7 @@ describe('createSessionManager', () => {
   // -------------------------------------------------------------------------
 
   describe('delivery failure status indicator', () => {
-    it('exhausted-retry failure sets an error indicator and leaves failedPrompt null', async () => {
+    it('interrupted message leaves terminal status to service state', async () => {
       const config = createMockConfig();
       const mgr = createSessionManager(config);
 
@@ -3348,9 +3348,7 @@ describe('createSessionManager', () => {
         config.store,
         mgr.atoms.statusIndicator
       );
-      expect(indicator).toEqual(
-        expect.objectContaining({ type: 'error', message: 'Queued message interrupted' })
-      );
+      expect(indicator).toBeNull();
     });
 
     it('execution failure does not overwrite the indicator', async () => {

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
@@ -1185,12 +1185,12 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       },
       onError: message => store.set(errorAtom, message),
       onMessageFailed: (_messageId, deliveryState) => {
-        if (deliveryState.reason === 'execution') return;
-        const message =
-          deliveryState.reason === 'interrupted'
-            ? 'Queued message interrupted'
-            : 'Message failed to deliver';
-        setIndicator({ type: 'error', message, timestamp: Date.now() });
+        if (deliveryState.reason !== 'exhausted') return;
+        setIndicator({
+          type: 'error',
+          message: 'Message failed to deliver',
+          timestamp: Date.now(),
+        });
       },
       onEvent: event => {
         if (expectedGeneration !== switchGeneration) return;


### PR DESCRIPTION
## Summary

Set the Cloud Agent client state to terminal interrupted when it receives an interrupted message failure, preventing the chat UI from remaining in a streaming state after the durable WebSocket ends.

The service-state layer now owns this terminal transition; the session manager only displays a delivery error for exhausted retries. The chat view stops streaming message bubbles and disables the stop control once the session is settled.

## Verification

- [x] Verified manually 

## Reviewer Notes

Focus on the `cloud.message.failed` path for `reason: interrupted`: it now terminates service state directly, based on the Durable Object terminal event. Exhausted-delivery failures retain the existing error indicator behavior.