### PR TITLE
Fix mobile subagent card activity label and conversation sheet autoscroll

### DIFF
--- a/apps/mobile/src/components/agents/child-session-card-state.test.ts
+++ b/apps/mobile/src/components/agents/child-session-card-state.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   getChildSessionActivityLabel,
   getChildSessionCardState,
+  getChildSessionStreaming,
   getTaskToolSessionId,
 } from './child-session-card-state';
 
@@ -385,5 +386,49 @@ describe('getTaskToolSessionId', () => {
       time: { start: 1, end: 2 },
     });
     expect(getTaskToolSessionId(readPart)).toBeUndefined();
+  });
+});
+
+describe('getChildSessionStreaming', () => {
+  it('returns true when an assistant message has a running task with a matching sessionId', () => {
+    const runningTask = makeTaskPart('running');
+    const messages = [makeAssistantMessage([runningTask])];
+    expect(getChildSessionStreaming(messages, subagentSessionId)).toBe(true);
+  });
+
+  it('returns false for a completed task with a matching sessionId', () => {
+    const completedTask = makeTaskPart('completed');
+    const messages = [makeAssistantMessage([completedTask])];
+    expect(getChildSessionStreaming(messages, subagentSessionId)).toBe(false);
+  });
+
+  it('returns false for an errored task with a matching sessionId', () => {
+    const erroredTask = makeTaskPart('error');
+    const messages = [makeAssistantMessage([erroredTask])];
+    expect(getChildSessionStreaming(messages, subagentSessionId)).toBe(false);
+  });
+
+  it('returns false when no task part matches the child sessionId', () => {
+    const otherTask = makeTaskPart('running', {});
+    const otherSessionId = 'ses-other' as KiloSessionId;
+    const messages = [makeAssistantMessage([otherTask])];
+    expect(getChildSessionStreaming(messages, otherSessionId)).toBe(false);
+  });
+
+  it('returns false when the only tool is a non-task tool', () => {
+    const readPart = makeToolPart('read', {
+      status: 'completed',
+      input: { filePath: 'x' },
+      output: 'y',
+      title: 'read',
+      metadata: {},
+      time: { start: 1, end: 2 },
+    });
+    const messages = [makeAssistantMessage([readPart])];
+    expect(getChildSessionStreaming(messages, subagentSessionId)).toBe(false);
+  });
+
+  it('returns false for an empty messages list', () => {
+    expect(getChildSessionStreaming([], subagentSessionId)).toBe(false);
   });
 });

--- a/apps/mobile/src/components/agents/child-session-card-state.test.ts
+++ b/apps/mobile/src/components/agents/child-session-card-state.test.ts
@@ -1,4 +1,5 @@
-import { type KiloSessionId, type StoredMessage, type ToolPart } from 'cloud-agent-sdk';
+/* eslint-disable max-lines -- test file with many fixtures */
+import { type KiloSessionId, type Part, type StoredMessage, type ToolPart } from 'cloud-agent-sdk';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -55,7 +56,29 @@ function makeTaskPart(
   });
 }
 
-function makeAssistantMessage(parts: ToolPart[], id = 'msg-1'): StoredMessage {
+function makeTextPart(text: string): Part {
+  return {
+    id: 'p-text',
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'text',
+    text,
+    time: { start: 1, end: 2 },
+  };
+}
+
+function makeReasoningPart(text: string): Part {
+  return {
+    id: 'p-reasoning',
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'reasoning',
+    text,
+    time: { start: 1, end: 2 },
+  };
+}
+
+function makeAssistantMessage(parts: Part[], id = 'msg-1'): StoredMessage {
   return {
     info: {
       id,
@@ -239,6 +262,60 @@ describe('getChildSessionCardState', () => {
     expect(state.latestActivity).toEqual({
       tool: 'task',
       context: 'This is a very long nested tas\u2026',
+    });
+  });
+
+  it('shows live text activity when the latest assistant part is a text part', () => {
+    const part = makeTaskPart('running', { subagent_type: 'Writer', description: 'Draft reply' });
+    const messages = [makeAssistantMessage([makeTextPart('Here is the answer.')])];
+    expect(getChildSessionCardState(part, messages)).toEqual({
+      agentName: 'Writer',
+      taskName: 'Draft reply',
+      latestActivity: 'Writing response',
+    });
+  });
+
+  it('shows live reasoning activity when the latest assistant part is a reasoning part', () => {
+    const part = makeTaskPart('running', { subagent_type: 'Thinker', description: 'Reason' });
+    const messages = [makeAssistantMessage([makeReasoningPart('stepping through the problem')])];
+    expect(getChildSessionCardState(part, messages)).toEqual({
+      agentName: 'Thinker',
+      taskName: 'Reason',
+      latestActivity: 'Thinking',
+    });
+  });
+
+  it('prefers a newer text part over an older completed tool part', () => {
+    const part = makeTaskPart('running', { subagent_type: 'Agent', description: 'Work' });
+    const olderTool = makeToolPart('read', {
+      status: 'completed',
+      input: { filePath: '/project/docs/spec.md' },
+      output: 'content',
+      title: 'read',
+      metadata: {},
+      time: { start: 1, end: 2 },
+    });
+    const newerText = makeTextPart('Based on the spec...');
+    const messages = [makeAssistantMessage([olderTool, newerText])];
+    expect(getChildSessionCardState(part, messages)).toEqual({
+      agentName: 'Agent',
+      taskName: 'Work',
+      latestActivity: 'Writing response',
+    });
+  });
+
+  it('ignores a transient empty-parts assistant message and finds the prior text part', () => {
+    const part = makeTaskPart('running', { subagent_type: 'Agent', description: 'Stream' });
+    const earlierText = makeTextPart('Streaming in progress...');
+    const emptyAssistant: StoredMessage = {
+      ...makeAssistantMessage([], 'msg-latest'),
+      info: { ...makeAssistantMessage([], 'msg-latest').info, id: 'msg-latest' },
+    };
+    const messages = [makeAssistantMessage([earlierText], 'msg-1'), emptyAssistant];
+    expect(getChildSessionCardState(part, messages)).toEqual({
+      agentName: 'Agent',
+      taskName: 'Stream',
+      latestActivity: 'Writing response',
     });
   });
 

--- a/apps/mobile/src/components/agents/child-session-card-state.ts
+++ b/apps/mobile/src/components/agents/child-session-card-state.ts
@@ -111,3 +111,24 @@ export function getTaskToolSessionId(part: ToolPart): KiloSessionId | undefined 
   }
   return undefined;
 }
+
+export function getChildSessionStreaming(
+  messages: StoredMessage[],
+  childSessionId: KiloSessionId
+): boolean {
+  for (const message of messages) {
+    if (message.info.role === 'assistant') {
+      for (const part of message.parts) {
+        if (
+          isToolPart(part) &&
+          part.tool === 'task' &&
+          part.state.status === 'running' &&
+          getTaskToolSessionId(part) === childSessionId
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}

--- a/apps/mobile/src/components/agents/child-session-card-state.ts
+++ b/apps/mobile/src/components/agents/child-session-card-state.ts
@@ -1,5 +1,6 @@
-import { type KiloSessionId, type StoredMessage, type ToolPart } from 'cloud-agent-sdk';
+import { type KiloSessionId, type Part, type StoredMessage, type ToolPart } from 'cloud-agent-sdk';
 
+import { computeStatus } from './compute-status';
 import { isToolPart } from './part-types';
 import { getFilename, truncateText } from './tool-card-utils';
 
@@ -8,7 +9,7 @@ export type ChildSessionActivity = { tool: string; context?: string };
 export type ChildSessionCardState = {
   agentName: string;
   taskName: string;
-  latestActivity: ChildSessionActivity | 'Waiting for activity';
+  latestActivity: ChildSessionActivity | string;
 };
 
 function getStringProperty(obj: unknown, key: string): string | undefined {
@@ -54,13 +55,13 @@ function getToolContext(p: ToolPart): string | undefined {
   return undefined;
 }
 
-function findLatestToolPart(messages: StoredMessage[]): ToolPart | undefined {
+function findLatestAssistantPart(messages: StoredMessage[]): Part | undefined {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const msg = messages[i];
     if (msg?.info.role === 'assistant') {
       for (let j = msg.parts.length - 1; j >= 0; j -= 1) {
         const part = msg.parts[j];
-        if (part && isToolPart(part)) {
+        if (part) {
           return part;
         }
       }
@@ -79,10 +80,16 @@ export function getChildSessionCardState(
   const prompt = getStringProperty(input, 'prompt');
   const taskName = description ?? (prompt ? truncateText(prompt, 60) : 'Task');
 
-  const latestToolPart = findLatestToolPart(childMessages);
-  const latestActivity: ChildSessionActivity | 'Waiting for activity' = latestToolPart
-    ? { tool: latestToolPart.tool, context: getToolContext(latestToolPart) }
-    : 'Waiting for activity';
+  const latestPart = findLatestAssistantPart(childMessages);
+  const latestActivity: ChildSessionActivity | string = (() => {
+    if (!latestPart) {
+      return 'Waiting for activity';
+    }
+    if (isToolPart(latestPart)) {
+      return { tool: latestPart.tool, context: getToolContext(latestPart) };
+    }
+    return computeStatus(latestPart);
+  })();
 
   return { agentName, taskName, latestActivity };
 }

--- a/apps/mobile/src/components/agents/child-session-section.tsx
+++ b/apps/mobile/src/components/agents/child-session-section.tsx
@@ -90,7 +90,7 @@ export function ChildSessionSection({
             {taskName}
           </Text>
           <Text className="text-xs leading-4 text-muted-foreground" numberOfLines={1}>
-            {latestActivity === 'Waiting for activity' ? (
+            {typeof latestActivity === 'string' ? (
               latestActivity
             ) : (
               <>

--- a/apps/mobile/src/components/agents/child-session-sheet.tsx
+++ b/apps/mobile/src/components/agents/child-session-sheet.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { FlatList, Modal, View } from 'react-native';
+import { Modal, View } from 'react-native';
 import { type ChildSessionHydrationState, type StoredMessage } from 'cloud-agent-sdk';
 
 import { EmptyState } from '@/components/empty-state';
@@ -14,23 +14,30 @@ import {
 } from './child-session-section';
 import { MessageErrorBoundary } from './message-error-boundary';
 import { getChildSessionSheetState } from './child-session-sheet-state';
+import { SessionMessageList } from './session-message-list';
+import { WorkingIndicator } from './working-indicator';
 
 type ChildSessionSheetProps = {
   sessionId: string;
   title: string;
   getChildMessages: (sessionId: string) => StoredMessage[];
   hydrationState: ChildSessionHydrationState;
+  isStreaming: boolean;
   renderPart: RenderPartFn;
   onOpenChildSession: OpenChildSession;
   onRetry: () => void;
   onClose: () => void;
 };
 
+// eslint-disable-next-line no-empty-function -- child sessions are hydrated one-shot, no pagination
+function noopLoadOlder(): void {}
+
 export function ChildSessionSheet({
   sessionId,
   title,
   getChildMessages,
   hydrationState,
+  isStreaming,
   renderPart,
   onOpenChildSession,
   onRetry,
@@ -42,9 +49,15 @@ export function ChildSessionSheet({
 
   if (state === 'content') {
     content = (
-      <FlatList
-        data={messages}
+      <SessionMessageList
+        sessionId={sessionId}
+        items={messages}
         keyExtractor={message => message.info.id}
+        hasOlderMessages={false}
+        isLoadingOlderMessages={false}
+        olderMessagesError={null}
+        olderMessagesOmittedItemCount={0}
+        onLoadOlderMessages={noopLoadOlder}
         renderItem={({ item }) => (
           <MessageErrorBoundary>
             <View className="px-4 py-1">
@@ -58,7 +71,7 @@ export function ChildSessionSheet({
             </View>
           </MessageErrorBoundary>
         )}
-        contentContainerClassName="py-2"
+        ListFooterComponent={<WorkingIndicator messages={messages} isStreaming={isStreaming} />}
       />
     );
   } else if (state === 'error') {

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -55,6 +55,7 @@ import {
 } from '@/components/agents/session-transcript';
 import { useSessionDetailRename } from '@/components/agents/use-session-detail-rename';
 import { WorkingIndicator } from '@/components/agents/working-indicator';
+import { getChildSessionStreaming } from '@/components/agents/child-session-card-state';
 import { ChildSessionSheet } from '@/components/agents/child-session-sheet';
 import { PartRenderer } from '@/components/agents/part-renderer';
 import { QueryError } from '@/components/query-error';
@@ -638,6 +639,7 @@ export function SessionDetailContent({
           title={childSession.title}
           getChildMessages={getChildMessages}
           hydrationState={getChildSessionHydrationState(childSession.sessionId)}
+          isStreaming={getChildSessionStreaming(messages, childSession.sessionId)}
           renderPart={props => <PartRenderer {...props} />}
           onOpenChildSession={handleOpenChildSession}
           onRetry={() => {


### PR DESCRIPTION
## Summary

Fixes two UX defects in the mobile subagent (Task tool) experience: the inline subagent **card** and the full-screen subagent conversation **sheet**.

### Fix A — card activity label reflects real activity
The inline subagent card derived its activity label only from tool parts (`findLatestToolPart`). A subagent that streams only text/reasoning (or whose whole job is text) never produces a tool part, so the card showed a static **"Waiting for activity"** during active generation and permanently after a text-only subagent finished.

The label is now derived from the newest assistant part of any type via a new `findLatestAssistantPart` (a newest→oldest cross-message scan that skips transient empty-`parts` messages) and `computeStatus` for text/reasoning phrases ("Thinking", "Writing response"), keeping the rich `{tool} {context}` display for tool activity. "Waiting for activity" now appears only when the subagent has produced nothing yet.

### Fix B — sheet autoscroll parity and liveliness
The subagent conversation sheet used a bare `FlatList` with none of the main conversation's follow-new-content / stick-to-bottom / release-on-manual-scroll behavior, and showed no live activity — so it stayed pinned to the top while the subagent streamed.

The sheet's content branch now reuses `SessionMessageList` (which wires `useSessionListAutoScroll` and the floating scroll-to-bottom affordance) with one-shot no-op pagination props, plus a `WorkingIndicator` footer. A new `isStreaming` prop is derived by the caller via a small pure helper `getChildSessionStreaming(messages, childSessionId)`, which reports `true` when a top-level `running` task part matches the open child session.

Both fixes reuse existing components and contracts; no new abstractions, no data-layer changes.

## Testing

- `pnpm format`, `pnpm typecheck`, `pnpm lint`, `pnpm check:unused` — all clean
- `pnpm test` — 1601 tests pass, including new coverage for the card label selection (text/reasoning/tool/idle + transient empty-`parts` window) and `getChildSessionStreaming` (running/completed/error/no-match/empty)
- On-device iOS E2E: both reported defects verified fixed on the streaming repro flow — the card shows "Writing response" (not "Waiting for activity") while streaming, and the sheet autoscrolls with a live WorkingIndicator; the completed sheet is pinned to bottom with no indicator. The sheet's manual-scroll-release behavior comes from the unchanged, unit-tested `useSessionListAutoScroll` hook. The sheet's `empty`/`error`/`loading` branches are unchanged by this PR and covered by `child-session-sheet-state` tests.

## Files
- `child-session-card-state.ts` — `findLatestAssistantPart`, reworked `getChildSessionCardState`, `getChildSessionStreaming`
- `child-session-section.tsx` — card render gate for the widened activity type
- `child-session-sheet.tsx` — `SessionMessageList` + `WorkingIndicator`, `isStreaming` prop
- `session-detail-content.tsx` — derives and passes `isStreaming`
- `child-session-card-state.test.ts` — expanded coverage
