### PR TITLE
fix(mobile): correct session labels and empty-session rendering

### DIFF
--- a/apps/mobile/src/components/agents/mobile-session-page-adapter.test.ts
+++ b/apps/mobile/src/components/agents/mobile-session-page-adapter.test.ts
@@ -72,7 +72,7 @@ async function importAdapter(): Promise<{
   fetchMobileSessionSnapshotPage: (
     kiloSessionId: KiloSessionId,
     options: { cursor?: string }
-  ) => Promise<SessionSnapshotPageOutcome | null>;
+  ) => Promise<SessionSnapshotPageOutcome>;
 }> {
   const adapter = await import('@/components/agents/mobile-session-page-adapter');
   return adapter;
@@ -140,14 +140,38 @@ describe('fetchMobileSessionSnapshotPage', () => {
     expect(mocks.getSessionMessagesPageQuery).toHaveBeenCalledWith({ session_id: 'ses_123' });
   });
 
-  it('preserves a null history result so the manager can mark it terminal', async () => {
+  it('maps a freshly-created cloud-agent session with no messages (BUG 3, history:null) to an empty success page', async () => {
     mocks.getSessionMessagesPageQuery.mockResolvedValueOnce({
-      kiloSessionId: 'ses_123',
+      kiloSessionId: 'ses_new',
       history: null,
     });
 
     const { fetchMobileSessionSnapshotPage } = await importAdapter();
-    await expect(fetchMobileSessionSnapshotPage(kiloSessionId('ses_123'), {})).resolves.toBeNull();
+    await expect(fetchMobileSessionSnapshotPage(kiloSessionId('ses_new'), {})).resolves.toEqual({
+      kind: 'success',
+      info: { id: 'ses_new' },
+      messages: [],
+      nextCursor: null,
+      omittedItemCount: 0,
+    });
+  });
+
+  it('maps an existing empty read-only session (BUG 4, history:null) to an empty success page', async () => {
+    mocks.getSessionMessagesPageQuery.mockResolvedValueOnce({
+      kiloSessionId: 'ses_readonly_empty',
+      history: null,
+    });
+
+    const { fetchMobileSessionSnapshotPage } = await importAdapter();
+    await expect(
+      fetchMobileSessionSnapshotPage(kiloSessionId('ses_readonly_empty'), {})
+    ).resolves.toEqual({
+      kind: 'success',
+      info: { id: 'ses_readonly_empty' },
+      messages: [],
+      nextCursor: null,
+      omittedItemCount: 0,
+    });
   });
 
   it('passes typed retryable_failure through verbatim so the UI can offer Retry', async () => {

--- a/apps/mobile/src/components/agents/mobile-session-page-adapter.ts
+++ b/apps/mobile/src/components/agents/mobile-session-page-adapter.ts
@@ -22,7 +22,8 @@ function isHistoryPage(history: KiloSdkMessageHistory): history is KiloSdkMessag
  * `SessionSnapshotPageOutcome`:
  * - Page variant → success outcome with messages, cursor, and omitted count
  * - Failure variants → passed through verbatim (retryable, too_large, invalid_data)
- * - Null history → null (access not found)
+ * - Null history → empty success page (existing session with zero messages). A genuine
+ *   NOT_FOUND is returned as a thrown/rejected TRPCError, never as `history === null`.
  *
  * The adapter does not re-validate the tRPC response; it trusts the shared
  * contract and uses structural narrowing to distinguish page from failure.
@@ -30,7 +31,7 @@ function isHistoryPage(history: KiloSdkMessageHistory): history is KiloSdkMessag
 export async function fetchMobileSessionSnapshotPage(
   kiloSessionId: KiloSessionId,
   options: { cursor?: string }
-): Promise<SessionSnapshotPageOutcome | null> {
+): Promise<SessionSnapshotPageOutcome> {
   const result = await trpcClient.cliSessionsV2.getSessionMessagesPage.query({
     session_id: kiloSessionId,
     ...(options.cursor ? { cursor: options.cursor } : {}),
@@ -38,7 +39,13 @@ export async function fetchMobileSessionSnapshotPage(
 
   const history = result.history as KiloSdkMessageHistory | null;
   if (history === null) {
-    return null;
+    return {
+      kind: 'success',
+      info: { id: result.kiloSessionId },
+      messages: [],
+      nextCursor: null,
+      omittedItemCount: 0,
+    };
   }
 
   if (isHistoryPage(history)) {

--- a/apps/mobile/src/components/agents/session-list-helpers.test.ts
+++ b/apps/mobile/src/components/agents/session-list-helpers.test.ts
@@ -214,6 +214,14 @@ describe('remoteAgentLabel', () => {
   it("returns 'LIVE' for undefined", () => {
     expect(remoteAgentLabel(undefined)).toBe('LIVE');
   });
+
+  it("returns 'LIVE' for empty origin", () => {
+    expect(remoteAgentLabel('')).toBe('LIVE');
+  });
+
+  it("returns 'LIVE' for unknown origin", () => {
+    expect(remoteAgentLabel('unknown')).toBe('LIVE');
+  });
 });
 
 describe('remoteMeta', () => {

--- a/apps/mobile/src/components/agents/session-list-helpers.ts
+++ b/apps/mobile/src/components/agents/session-list-helpers.ts
@@ -2,7 +2,13 @@ import { KNOWN_PLATFORMS } from '@kilocode/app-shared/platforms';
 
 import { type AgentSessionDateGroup } from '@/lib/agent-session-groups';
 import { type ActiveSession, type StoredSession } from '@/lib/hooks/use-agent-sessions';
+import { platformLabel } from '@/lib/platform-label';
 import { parseTimestamp, timeAgo } from '@/lib/utils';
+
+// Re-exported so existing importers of `platformLabel` from this module keep
+// working while `@/lib/platform-label` stays the single source of truth for
+// the platform→label mapping (no duplicate definition to drift).
+export { platformLabel };
 
 /**
  * One stored-history section. Exclusivity against the "Active now" tray is
@@ -56,42 +62,21 @@ export function formatGitUrlProject(gitUrl: string): string {
   return gitUrl;
 }
 
-/**
- * Map backend `created_on_platform` strings to a pretty uppercase label
- * for the row eyebrow. The row's hue is hashed from this label.
- */
-export function platformLabel(platform: string): string {
-  switch (platform) {
-    case 'cloud-agent':
-    case 'cloud-agent-web': {
-      return 'CLOUD AGENT';
-    }
-    case 'vscode':
-    case 'agent-manager': {
-      return 'VSCODE';
-    }
-    case 'slack': {
-      return 'SLACK';
-    }
-    case 'cli': {
-      return 'CLI';
-    }
-    default: {
-      return platform.toUpperCase();
-    }
-  }
-}
-
 export function formatMeta(timestamp: string): string {
   return timeAgo(parseTimestamp(timestamp)).toUpperCase();
 }
 
 /**
  * Pinned-tray label for an active session. Reuses `platformLabel` when the
- * platform is known, otherwise falls back to 'LIVE'.
+ * origin is known, otherwise falls back to 'LIVE'. An undefined, empty, or
+ * 'unknown' origin is treated as unknown and returns 'LIVE' rather than a
+ * definitive (and potentially wrong) label.
  */
 export function remoteAgentLabel(createdOnPlatform: string | undefined): string {
-  return createdOnPlatform ? platformLabel(createdOnPlatform) : 'LIVE';
+  if (!createdOnPlatform || createdOnPlatform === 'unknown') {
+    return 'LIVE';
+  }
+  return platformLabel(createdOnPlatform);
 }
 
 /**

--- a/apps/mobile/src/components/agents/session-row.tsx
+++ b/apps/mobile/src/components/agents/session-row.tsx
@@ -320,7 +320,7 @@ export function RemoteSessionRow({ session, onPress }: Readonly<RemoteSessionRow
       className="active:opacity-70"
     >
       <SessionRow
-        agentLabel={remoteAgentLabel(session.platform ?? session.createdOnPlatform)}
+        agentLabel={remoteAgentLabel(session.createdOnPlatform)}
         title={title}
         subtitle={session.gitBranch ?? null}
         meta={remoteMeta(session)}

--- a/apps/mobile/src/components/home/agent-sessions-section.test.ts
+++ b/apps/mobile/src/components/home/agent-sessions-section.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { activeSessionLabel } from '@/components/home/agent-sessions-section';
+import { type ActiveSession } from '@/lib/hooks/use-agent-sessions';
+
+vi.mock('expo-router', () => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({
+  View: 'View',
+}));
+
+vi.mock('@/components/home/section-header', () => ({
+  SectionHeader: () => null,
+}));
+
+vi.mock('@/components/ui/session-row', () => ({
+  SessionRow: () => null,
+}));
+
+vi.mock('@/components/ui/text', () => ({
+  Text: () => null,
+}));
+
+vi.mock('@/lib/hooks/use-agent-sessions', () => ({
+  useAgentSessions: () => ({
+    activeSessions: [],
+    storedSessions: [],
+    activeSessionIds: new Set(),
+    activeIsError: false,
+  }),
+}));
+
+function makeActiveSession(over: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    id: 'test-id',
+    status: 'running',
+    title: 'Test Session',
+    connectionId: 'conn-1',
+    ...over,
+  };
+}
+
+describe('activeSessionLabel', () => {
+  it('returns repo name uppercased when gitUrl is present', () => {
+    const session = makeActiveSession({
+      gitUrl: 'git@github.com:org/my-repo.git',
+      createdOnPlatform: 'cli',
+    });
+    expect(activeSessionLabel(session)).toBe('MY-REPO');
+  });
+
+  it('returns "LIVE" when createdOnPlatform is undefined and no repo', () => {
+    const session = makeActiveSession({
+      createdOnPlatform: undefined,
+      gitUrl: undefined,
+    });
+    expect(activeSessionLabel(session)).toBe('LIVE');
+  });
+
+  it('returns "LIVE" when createdOnPlatform is empty string and no repo', () => {
+    const session = makeActiveSession({
+      createdOnPlatform: '',
+      gitUrl: undefined,
+    });
+    expect(activeSessionLabel(session)).toBe('LIVE');
+  });
+
+  it('returns "LIVE" when createdOnPlatform is "unknown" and no repo', () => {
+    const session = makeActiveSession({
+      createdOnPlatform: 'unknown',
+      gitUrl: undefined,
+    });
+    expect(activeSessionLabel(session)).toBe('LIVE');
+  });
+
+  it('returns "CLI" when createdOnPlatform is "cli" and no repo', () => {
+    const session = makeActiveSession({
+      createdOnPlatform: 'cli',
+      gitUrl: undefined,
+    });
+    expect(activeSessionLabel(session)).toBe('CLI');
+  });
+
+  it('returns "CLOUD AGENT" when createdOnPlatform is "cloud-agent-web" and no repo', () => {
+    const session = makeActiveSession({
+      createdOnPlatform: 'cloud-agent-web',
+      gitUrl: undefined,
+    });
+    expect(activeSessionLabel(session)).toBe('CLOUD AGENT');
+  });
+});

--- a/apps/mobile/src/components/home/agent-sessions-section.tsx
+++ b/apps/mobile/src/components/home/agent-sessions-section.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native';
 import {
   expandPlatformFilter,
   formatGitUrlProject,
+  remoteAgentLabel,
 } from '@/components/agents/session-list-helpers';
 import { SectionHeader } from '@/components/home/section-header';
 import { SessionRow } from '@/components/ui/session-row';
@@ -125,14 +126,15 @@ function storedSessionMeta(session: StoredSession): string {
   return timeAgo(parseTimestamp(tsSource)).toUpperCase();
 }
 
-function activeSessionLabel(session: ActiveSession): string {
+export function activeSessionLabel(session: ActiveSession): string {
   const repo = repoNameFromGitUrl(session.gitUrl);
-  // kilocode_change - K1/C3a: derive the fallback label from the live
-  // per-session `platform` heartbeat field instead of a hardcoded
-  // 'cloud-agent' guess, so a `kilo remote`-spawned session shows "CLI"
-  // (via platformLabel) instead of being mislabeled "CLOUD AGENT". Entries
-  // without `platform` (legacy senders) keep today's exact fallback.
-  return repo ? repo.toUpperCase() : platformLabel(session.platform ?? 'cloud-agent');
+  // kilocode_change - K1/C3a: derive the fallback label from the session's
+  // backend origin (`createdOnPlatform`) via the shared `remoteAgentLabel`,
+  // not from the host-OS `platform` heartbeat field. Live CLI sessions start
+  // with origin 'unknown' and get no repo, so they now show the neutral 'LIVE'
+  // label until the first `kilo_meta` sets origin to 'cli'; they never show
+  // 'CLOUD AGENT' (BUG1). Once origin is 'cli' the label becomes 'CLI'.
+  return repo ? repo.toUpperCase() : remoteAgentLabel(session.createdOnPlatform);
 }
 
 function storedSessionLabel(session: StoredSession): string {


### PR DESCRIPTION
## Summary

Fixes four mobile session-list/session-detail defects, split into two logically independent slices.

**Slice A — active session labels derive from origin, not host platform** (`f9d66931`)
- **BUG 1 (Home CLI mislabel):** A `kilo remote`-spawned live session on the Home screen was mislabeled **CLOUD AGENT**. The label now derives from the session's backend origin (`createdOnPlatform`) via the shared `remoteAgentLabel`, not from the host-OS `platform` heartbeat. Live CLI sessions begin with origin `unknown` (neutral **LIVE**) and become **CLI** once `kilo_meta` sets the origin; they never show **CLOUD AGENT**.
- **BUG 2 (Agents "UNKNOWN"):** `remoteAgentLabel` now treats `undefined`, empty-string, and `'unknown'` origins as unknown and returns **LIVE** instead of a definitive-but-wrong label. `platformLabel` is consolidated to a single source of truth in `@/lib/platform-label` (re-exported from `session-list-helpers` for existing importers) so the mapping cannot drift.

**Slice B — empty and freshly-created sessions render an empty state, not an error** (`3fa715a8`)
- **BUG 4 (existing empty read-only session):** `fetchMobileSessionSnapshotPage` mapped a `history === null` response to `null`, which the manager treated as terminal/not-found and surfaced as an error. It now maps `history === null` to an empty success page (zero messages), so an existing session with no messages renders the empty state.
- **BUG 3 (`/new` cloud-agent happy-path first load):** shares BUG 4's identical adapter path — a freshly-created cloud-agent session returns `history === null` on first load and now renders the empty state instead of an error. A genuine NOT_FOUND remains a thrown/rejected `TRPCError`, never `history === null`.

## Feature-state coverage

| State | Behavior | Covered by |
|---|---|---|
| Happy (page of messages) | success outcome with messages/cursor/omitted count | `mobile-session-page-adapter.test.ts` (page variant) |
| Retryable failure | typed `retryable_failure` passed through verbatim so UI offers Retry | `mobile-session-page-adapter.test.ts` |
| Non-retryable failure | `too_large` / `invalid_data` passed through verbatim | `mobile-session-page-adapter.test.ts` |
| Empty (`history === null`) | empty success page → empty state (BUG 3 & BUG 4) | `mobile-session-page-adapter.test.ts` (both new cases) |
| Label unknown origin | `undefined` / `''` / `'unknown'` → **LIVE** | `session-list-helpers.test.ts`, `agent-sessions-section.test.ts` |
| Label known origin | `cli` → **CLI**, `cloud-agent-web` → **CLOUD AGENT**, repo name when gitUrl present | `agent-sessions-section.test.ts` |

## Verification & known limitation

- **BUG 1 / BUG 2 / BUG 4 were verified on-device** on the local stack against a live remote-CLI session (Home CLI label corrected; Agents no longer show **UNKNOWN**; an empty read-only session renders the empty state rather than an error).
- **BUG 3's `/new` cloud-agent happy-path E2E could NOT be reproduced on the local stack** due to a local-only cloud-agent constraint (CORS/403 origin allowlist plus repo-selection gating on the local cloud-agent path). This is an environment limitation, not a defect in the fix.
- The underlying fix — the shared `history === null` → empty success page mapping in `mobile-session-page-adapter.ts` — **is verified on-device via BUG 4** and by unit tests, since BUG 3 and BUG 4 route through the identical adapter path.
- **BUG 3's `/new` happy-path therefore still needs verification in prod / by a human.** This is surfaced explicitly rather than self-accepted.
